### PR TITLE
fix(host): a worker-thread fault report must describe one fault, not two

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,7 +49,7 @@ Last updated: 2026-08-05
 | *The Forgotten City* | `PPSA03026` | Unreal Engine | 🚧 Title screen | [#1890](https://github.com/mattias800/prosper/issues/1890) |
 | *Tactics Ogre: Reborn* | `PPSA03839` | — | 🚧 First tutorial battle | [#1892](https://github.com/mattias800/prosper/issues/1892) |
 | *Little Nightmares III* | `PPSA05143` | Unreal Engine 4 | 🚧 Boot splash sequence and title screen; most title frames carry a yellow tint | [#1893](https://github.com/mattias800/prosper/issues/1893) |
-| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Content streams and the engine submits real draws and composites frames, then a guest render-thread fault ends the run a few seconds in, before any title screen | [#1894](https://github.com/mattias800/prosper/issues/1894) |
+| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Content streams and the engine submits real draws and composites frames, then a guest memory fault ends the run a few seconds in, before any title screen | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Health warning and title screen; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
@@ -320,10 +320,11 @@ The title is Unreal Engine 4.27 with IoStore packaging. It boots into a native L
 engine bootstrap, and streams real content from the 8.49 GB IoStore container. The engine reaches its frame loop:
 over a thousand draws, hundreds of compute dispatches, and composited frames delivered to the display. The
 declined-GPU-submit freeze that used to stop it here is gone, fixed by
-[#1987](https://github.com/mattias800/prosper/pull/1987). What ends the run now is a guest render-thread fault a
-few seconds into the boot — far too early for a title screen — so nothing beyond the engine's own startup is
-reached. The frames delivered before the fault are a single flat colour, alternating black and white, while
-intermediate render targets do carry real image content. See the
+[#1987](https://github.com/mattias800/prosper/pull/1987). What ends the run now is a guest memory fault a few
+seconds into the boot — on the render thread, the RHI thread or a worker pool thread depending on the run, and in
+some runs the game's own allocator catches it first — far too early for a title screen, so nothing beyond the
+engine's own startup is reached. The frames delivered before the fault are a single flat colour, alternating
+black and white, while intermediate render targets do carry real image content. See the
 [tracker](https://github.com/mattias800/prosper/issues/1894).
 
 ## The House of the Dead 2: Remake — `PPSA24203`

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -49,7 +49,7 @@ Last updated: 2026-08-05
 | *The Forgotten City* | `PPSA03026` | Unreal Engine | 🚧 Title screen | [#1890](https://github.com/mattias800/prosper/issues/1890) |
 | *Tactics Ogre: Reborn* | `PPSA03839` | — | 🚧 First tutorial battle | [#1892](https://github.com/mattias800/prosper/issues/1892) |
 | *Little Nightmares III* | `PPSA05143` | Unreal Engine 4 | 🚧 Boot splash sequence and title screen; most title frames carry a yellow tint | [#1893](https://github.com/mattias800/prosper/issues/1893) |
-| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Content streams and the engine submits real draws, then a declined GPU submit freezes every thread, so the display stays black | [#1894](https://github.com/mattias800/prosper/issues/1894) |
+| *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🔬 Content streams and the engine submits real draws and composites frames, then a guest render-thread fault ends the run a few seconds in, before any title screen | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Health warning and title screen; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
@@ -317,11 +317,14 @@ to maximum, which reads as a flat yellow background under otherwise-correct cont
 ## Crisis Core –Final Fantasy VII– Reunion — `PPSA07809`
 
 The title is Unreal Engine 4.27 with IoStore packaging. It boots into a native Linux/Vulkan run, completes
-engine bootstrap, and now streams real content: 394 reads served from the 8.49 GB IoStore container, real GPU
-draws, and nine composited frames. Then prosper declines one GPU submit it cannot order safely, and because the
-whole submit is discarded the completion the guest is waiting for is never written — all ninety guest threads
-park, from the game thread's render fence down through the render and RHI threads. Every composited frame is
-black, so no screenshot is published. See the [tracker](https://github.com/mattias800/prosper/issues/1894).
+engine bootstrap, and streams real content from the 8.49 GB IoStore container. The engine reaches its frame loop:
+over a thousand draws, hundreds of compute dispatches, and composited frames delivered to the display. The
+declined-GPU-submit freeze that used to stop it here is gone, fixed by
+[#1987](https://github.com/mattias800/prosper/pull/1987). What ends the run now is a guest render-thread fault a
+few seconds into the boot — far too early for a title screen — so nothing beyond the engine's own startup is
+reached. The frames delivered before the fault are a single flat colour, alternating black and white, while
+intermediate render targets do carry real image content. See the
+[tracker](https://github.com/mattias800/prosper/issues/1894).
 
 ## The House of the Dead 2: Remake — `PPSA24203`
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1005,6 +1005,11 @@ if(TARGET prosper_core)
   add_executable(test_x86_read_decode tests/test_x86_read_decode.cpp)
   add_test(NAME x86_read_decode COMMAND test_x86_read_decode)
 
+  # #2018: a fatal worker-thread fault report must describe one fault. Header-only snapshot of the
+  # handler's own siginfo/ucontext; POSIX signal contexts only (the test self-skips elsewhere).
+  add_executable(test_fault_context tests/test_fault_context.cpp)
+  add_test(NAME fault_context COMMAND test_fault_context)
+
   # End-to-end AGC submit plus fixed args 7-9 in ReleaseMem/WaitRegMem. This is cross-platform so
   # Windows validates the real fence builders behind the generated import-ABI conformance test.
   add_executable(test_agc_submit tests/test_agc_submit.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1008,6 +1008,10 @@ if(TARGET prosper_core)
   # #2018: a fatal worker-thread fault report must describe one fault. Header-only snapshot of the
   # handler's own siginfo/ucontext; POSIX signal contexts only (the test self-skips elsewhere).
   add_executable(test_fault_context tests/test_fault_context.cpp)
+  # The contention arm spawns real threads. This target links no library, so unlike every other
+  # thread-using test here it inherits -pthread from nothing; name Threads::Threads explicitly
+  # (found above with prosper_core, whose existence gates this block).
+  target_link_libraries(test_fault_context PRIVATE Threads::Threads)
   add_test(NAME fault_context COMMAND test_fault_context)
 
   # End-to-end AGC submit plus fixed args 7-9 in ReleaseMem/WaitRegMem. This is cross-platform so

--- a/prosper/docs/ARCRUNNER_STATUS.md
+++ b/prosper/docs/ARCRUNNER_STATUS.md
@@ -36,6 +36,15 @@ insn @rip: 48 8b 01            (mov rax,[rcx])   rcx=0x30016000
 [fault] thread='RenderThread 1' on-guest-TCB=NO(host-%fs leak?)
 ```
 
+Two apparatus notes on that transcript, both from #2018 and both changing how it should be read.
+**The `on-guest-TCB` verdict in it is void**: it was inferred from `rax`, which holds the corrupt
+object pointer here rather than a TCB self-pointer (`OREGON_TRAIL_STATUS.md` § Ruled out). The line
+is now driven by the verified `%fs` base instead, and the equivalent Crisis Core fault reports
+`on-guest-TCB=yes`. **And a pre-#2018 report can be a mixture of two threads' faults** — the
+context lived in process globals, so a second faulting thread rewrote them mid-dump; any
+`insn @rip`, backtrace or `[faultobj] probe-pages` figure from an arm where more than one thread
+faulted may not belong to the header above it.
+
 `0x30016000` is far below the guest arena (`0x2000000000`–`0x9fc0000000`) and is read out of a
 structure whose neighbouring fields are ordinary guest pointers. It is the misaligned dereference
 of the tagged free-list value `0x2000000001`, not a separate poison value written directly by a

--- a/prosper/docs/OREGON_TRAIL_STATUS.md
+++ b/prosper/docs/OREGON_TRAIL_STATUS.md
@@ -312,6 +312,12 @@ the same thing, and do not treat either as superseding the other until that is c
   `mov %fs:0x0`; at `eboot+0x14600df` `rax` is the guest allocator's per-thread bin-array base
   (`0x30209c0000` / `0x3020140000` in the two observed instances). Do not open a #1155-class
   investigation from it without an independent `%fs` witness.
+  **The independent witness now exists** (#2018): the line reports `guest_fs_to_host_scoped()`'s
+  return, which is this thread's real `%fs` base and is returned only after `TCB_MAGIC` is verified
+  there, so `on-guest-TCB` is a fact rather than an inference and `rax` is printed beside it as raw
+  evidence carrying no claim. Measured on Crisis Core (`PPSA07809`), the same `RenderThread 1` fault
+  that used to print `NO(host-%fs leak?)` now prints `on-guest-TCB=yes`. Reports from **before**
+  #2018 still carry the old heuristic and must be read the way this entry says.
 * **A guest `std::terminate` is worth one disassembly pass before it is treated as heap damage.**
   For an *uncaught* exception the C++ runtime calls `std::terminate` from `__cxa_throw` **without
   unwinding**, so prosper's own frame-pointer walk at the `ud2` still carries the throwing stack.

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2212,20 +2212,41 @@ namespace {
             // self-pointer only when the fault lands shortly after that load, and when it holds
             // something else (a corrupt free-list head, a count) the magic check reads an unrelated
             // address and asserted `NO(host-%fs leak?)` for a thread with no %fs problem at all
-            // (#2018: rax = 0x30016000). It does not need to guess: `saved_guest_fs` above is the
-            // answer. `guest_fs_to_host_scoped()` read this thread's real %fs base and returned it
-            // only after checking TCB_MAGIC there (guest_tls.cpp:161-171), so non-zero IS "this
-            // thread was on our guest TCB". rax stays on the line as raw evidence, without a claim
-            // attached to it.
+            // (#2018: rax = 0x30016000). It does not need to guess for the positive answer:
+            // `saved_guest_fs` above is a fact. `guest_fs_to_host_scoped()` read this thread's real
+            // %fs base and returned it only after checking TCB_MAGIC there
+            // (guest_tls.cpp:161-171), so non-zero IS "this thread was on our guest TCB". rax stays
+            // on the line as raw evidence, without a claim attached to it.
             //
-            // Darwin has no equivalent: `guest_fs_to_host_scoped()` is a `return 0` stub there
-            // (guest_tls.cpp:288), so 0 must not be read as "leaked" on that platform.
+            // ZERO is NOT the mirror image of that, and the line must not print as though it were.
+            // Zero has three causes and only one of them is a defect:
+            //   (1) the thread really did run guest code on the host glibc TCB — the #1155 class,
+            //       and the only reading worth alarming about;
+            //   (2) guest %fs is not enabled for this process at all. That is the DEFAULT —
+            //       `g_enabled = getenv("PROSPER_GUEST_FS") != nullptr` (guest_tls.cpp:46), opt-in,
+            //       and neither a plain prosper-app run nor most of tools/dbg/*.sh sets it — so
+            //       every thread reads zero and none of them leaked anything;
+            //   (3) the faulting thread is one of prosper's OWN host threads, which never had a
+            //       guest TCB to leak off. This report is reached by any non-armed thread, host or
+            //       guest, so that is not a rare case.
+            // `guest_tls_enabled()` (guest_tls.cpp:79) separates (2) from (1)/(3) as fact; nothing
+            // available in a signal handler separates (1) from (3), so the line says so rather than
+            // asserting a leak. It is two static bool loads: no allocation, no lock, handler-safe.
+            //
+            // Darwin: `guest_fs_to_host_scoped()` returns 0 unconditionally there — the
+            // `#ifdef __APPLE__` early-out inside the shared POSIX definition (guest_tls.cpp:162-164),
+            // NOT the separate Windows stub at guest_tls.cpp:288 — so zero carries no information on
+            // that platform at all, and the Darwin arm below prints neither answer.
             {
                 char nm[16] = {0}; pthread_getname_np(pthread_self(), nm, sizeof nm);   // portable (Linux+macOS)
 #ifdef __APPLE__
                 const char* tcb = "unknown (not determined on this platform)";
 #else
-                const char* tcb = saved_guest_fs ? "yes" : "NO(host-%fs leak?)";
+                // Async-signal-safe: guest_tls_enabled() is two static bool loads, no lock and no
+                // allocation, and this TU already calls it unqualified.
+                const char* tcb = !guest_tls_enabled() ? "n/a (guest %fs not enabled)"
+                                : saved_guest_fs       ? "yes"
+                                : "no (host TCB — a leak only if this thread should have had a guest TCB)";
 #endif
                 char tb[224];
                 int t = snprintf(tb, sizeof tb,

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -12,6 +12,7 @@
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "posix_shim.hpp"
+#include "fault_context.hpp"   // #2018: one fault's own registers, snapshotted from ITS ucontext
 #include <sys/mman.h>
 #include <signal.h>
 #include <setjmp.h>
@@ -2067,6 +2068,16 @@ namespace {
         g_r10 = (uint64_t)g[REG_R10]; g_r11 = (uint64_t)g[REG_R11];
         g_r12 = (uint64_t)g[REG_R12]; g_r13 = (uint64_t)g[REG_R13];
         g_r14 = (uint64_t)g[REG_R14]; g_r15 = (uint64_t)g[REG_R15];
+        // #2018: the globals above are shared by every thread, and the guest's faults are correlated
+        // (one heap corruption takes several worker threads within milliseconds). A second thread
+        // faulting while the first is printing rewrites all of them underneath it, and the first
+        // report then continues with the second thread's registers while still reading as one
+        // complete fault. Keep the globals — the armed/main-thread recovery path below and
+        // trap_detail()/record_fault() are single-threaded by construction and use them — but give
+        // the FATAL worker-thread report its own stack-local snapshot, which no other thread can
+        // touch. Every value it prints then comes from one fault.
+        const prosper::host::FaultContext fc =
+            prosper::host::capture_fault_context(sig, cur_tid(), si->si_addr, uc);
         g_trap_sig = sig;
         g_trap_kind = (sig == SIGILL) ? 3 : 2;
         // Guest `int $0x41` (opcode CD 41) is RAGE's software breakpoint / assert trap (GTA V,
@@ -2117,22 +2128,52 @@ namespace {
         // Fault on a thread with no recovery point (a guest worker thread). Report where
         // (async-signal-safe write) then terminate cleanly instead of a cross-thread longjmp.
         {
+            // #2018: one report at a time. Two worker threads faulting milliseconds apart used to
+            // interleave their lines into a single apparent report; with the snapshot above each
+            // line is now self-consistent, but two coherent reports written concurrently would still
+            // be spliced together on stderr. First arrival owns the full dump; a thread that arrives
+            // while one is in flight prints one clearly-labelled line for its own fault, so the
+            // second fault is named rather than silently lost.
+            static std::atomic<long> dump_owner{0};
+            static std::atomic<int> dump_done{0};
+            long expected = 0;
+            if (!prosper::host::claim_fault_report(dump_owner, fc.tid, &expected)) {
+                char cb2[224];
+                int cn2 = snprintf(cb2, sizeof cb2,
+                    "[prosper] CONCURRENT WORKER-THREAD FAULT: tid=%ld sig=%d addr=%p rip=0x%llx "
+                    "(image+0x%llx) — full dump suppressed, tid=%ld is already reporting\n",
+                    fc.tid, fc.sig, (void*)(uintptr_t)fc.addr, (unsigned long long)fc.rip,
+                    (unsigned long long)(g_base && fc.rip >= g_base ? fc.rip - g_base : fc.rip),
+                    expected);
+                raw_write(2, cb2, (size_t)cn2);
+                // Wait for the owner to finish before ending the process — `_exit` here would
+                // truncate the very report this gate exists to keep whole (measured: the header
+                // line and nothing after it). BOUNDED, because the owner may itself die inside its
+                // dump and a signal handler that waited unconditionally on another faulting thread
+                // would hang a run that used to exit 90. `nanosleep` is async-signal-safe.
+                for (int i = 0; i < 400 && !dump_done.load(std::memory_order_acquire); i++) {
+                    struct timespec ts; ts.tv_sec = 0; ts.tv_nsec = 5 * 1000 * 1000;   // 5 ms
+                    nanosleep(&ts, nullptr);
+                }
+                if (getenv("PROSPER_WORKER_PARK")) { for (;;) pause(); }
+                _exit(90);
+            }
             char b[200];
-            int n = snprintf(b, sizeof b, "[prosper] WORKER-THREAD FAULT: sig=%d addr=%p rip=0x%llx (image+0x%llx) rbp=0x%llx\n",
-                             sig, g_fault_addr, (unsigned long long)g_fault_rip,
-                             (unsigned long long)(g_base && g_fault_rip >= g_base ? g_fault_rip - g_base : g_fault_rip),
-                             (unsigned long long)g_rbp);
+            int n = snprintf(b, sizeof b, "[prosper] WORKER-THREAD FAULT: sig=%d addr=%p rip=0x%llx (image+0x%llx) rbp=0x%llx tid=%ld\n",
+                             fc.sig, (void*)(uintptr_t)fc.addr, (unsigned long long)fc.rip,
+                             (unsigned long long)(g_base && fc.rip >= g_base ? fc.rip - g_base : fc.rip),
+                             (unsigned long long)fc.rbp, fc.tid);
             raw_write(2, b, (size_t)n);   /* raw syscall: no libc TLS access */
             // Classify the fault rip + fault-addr regions (which mapping / module) and dump the instruction
             // bytes at rip — turns the ASLR-relocated "rip=0x...48b" into an identifiable location.
-            classify_addr(g_fault_rip);
-            classify_addr((uint64_t)g_fault_addr);
+            classify_addr(fc.rip);
+            classify_addr(fc.addr);
             auto rdb = [](uint64_t a) -> unsigned { return probe_readable(a) ? *(const uint8_t*)a : 0x100u; };
             char ib[160]; int m = snprintf(ib, sizeof ib,
                 "[prosper]   insn bytes @rip: %02x %02x %02x %02x %02x %02x %02x %02x  ret@[rsp]=0x%llx\n",
-                rdb(g_fault_rip), rdb(g_fault_rip+1), rdb(g_fault_rip+2), rdb(g_fault_rip+3),
-                rdb(g_fault_rip+4), rdb(g_fault_rip+5), rdb(g_fault_rip+6), rdb(g_fault_rip+7),
-                (unsigned long long)(probe_readable(g_rsp) ? *(const uint64_t*)g_rsp : 0));
+                rdb(fc.rip), rdb(fc.rip+1), rdb(fc.rip+2), rdb(fc.rip+3),
+                rdb(fc.rip+4), rdb(fc.rip+5), rdb(fc.rip+6), rdb(fc.rip+7),
+                (unsigned long long)(probe_readable(fc.rsp) ? *(const uint64_t*)fc.rsp : 0));
             raw_write(2,ib, m);
             // Guest-%fs attribution (#1155): is the faulting thread running guest code on OUR guest TCB
             // or leaked onto the host glibc TCB? The guest loads its TCB self-pointer with `mov %fs:0x0`;
@@ -2140,13 +2181,25 @@ namespace {
             // fs base. Our guest TCBs carry the "PROS" magic at +0x108; a mismatch means guest code ran
             // on the host TCB, so any %fs-relative TLS read returned host garbage (the #1155 fault class,
             // now fixed by restoring guest %fs on signal-handler return-to-guest paths above).
+            //
+            // The premise is a HEURISTIC and it is not always met: rax only holds the TCB self-pointer
+            // when the fault lands shortly after that load. When it holds something else — a corrupted
+            // free-list head, a count — the magic check reads an unrelated address and prints
+            // "NO(host-%fs leak?)" for a thread that is perfectly on its guest TCB. So the line now
+            // says when its own premise does not hold rather than asserting a leak (#2018 saw exactly
+            // this: rax = 0x30016000, the corrupt pointer, on a thread with no %fs problem at all).
             {
                 char nm[16] = {0}; pthread_getname_np(pthread_self(), nm, sizeof nm);   // portable (Linux+macOS)
-                bool on_guest_tcb = probe_readable(g_rax + 0x108) &&
-                                    *(const uint32_t*)(uintptr_t)(g_rax + 0x108) == 0x50524F53u;
-                char tb[160];
+                const bool magic_readable = probe_readable(fc.rax + 0x108);
+                const bool on_guest_tcb = magic_readable &&
+                                    *(const uint32_t*)(uintptr_t)(fc.rax + 0x108) == 0x50524F53u;
+                char tb[224];
                 int t = snprintf(tb, sizeof tb, "[fault] thread='%s' fs(rax)=0x%llx on-guest-TCB=%s\n",
-                                 nm, (unsigned long long)g_rax, on_guest_tcb ? "yes" : "NO(host-%fs leak?)");
+                                 nm, (unsigned long long)fc.rax,
+                                 on_guest_tcb    ? "yes"
+                                 : magic_readable ? "NO(host-%fs leak?)"
+                                                  : "unknown (rax is not a TCB pointer here — "
+                                                    "no %fs conclusion follows)");
                 raw_write(2, tb, (size_t)t);
             }
             // PROSPER_FAULTOBJ (#1226): dump the leading 0xC0 bytes of the objects in rax/r15/rbx via a
@@ -2163,8 +2216,8 @@ namespace {
                 // eboot+0x117e21d that is rdi (the forged pointer) and r12 (the pointer array it
                 // was loaded from) — neither of which the original three-register list dumped.
                 const struct { const char* nm; uint64_t addr; } objs[] = {
-                    {"rax", g_rax}, {"r15", g_r15}, {"rbx", g_rbx}, {"rdi", g_rdi},
-                    {"r12", g_r12}, {"r13", g_r13}, {"r14", g_r14},
+                    {"rax", fc.rax}, {"r15", fc.r15}, {"rbx", fc.rbx}, {"rdi", fc.rdi},
+                    {"r12", fc.r12}, {"r13", fc.r13}, {"r14", fc.r14},
                 };
                 for (const auto& o : objs) {
                     uint64_t buf[24];
@@ -2200,8 +2253,8 @@ namespace {
                 unsigned probe_page_n = 0, probe_page_considered = 0;
                 {
                     const uint64_t cand[] = {
-                        (uint64_t)(uintptr_t)g_fault_addr, g_rax, g_rbx, g_rcx, g_rdx, g_rsi, g_rdi,
-                        g_r8, g_r9, g_r10, g_r11, g_r12, g_r13, g_r14, g_r15,
+                        (uint64_t)(uintptr_t)fc.addr, fc.rax, fc.rbx, fc.rcx, fc.rdx, fc.rsi, fc.rdi,
+                        fc.r8, fc.r9, fc.r10, fc.r11, fc.r12, fc.r13, fc.r14, fc.r15,
                     };
                     for (uint64_t v : cand) {
                         // Skip small integers (a count/flag, and the corrupt `0x1` head itself has
@@ -2223,7 +2276,7 @@ namespace {
                     char cb[176];
                     int cn = snprintf(cb, sizeof cb,
                                       "[faultobj] rcx=0x%llx rdx=0x%llx probe-pages=%u/%u%s\n",
-                                      (unsigned long long)g_rcx, (unsigned long long)g_rdx,
+                                      (unsigned long long)fc.rcx, (unsigned long long)fc.rdx,
                                       probe_page_n, probe_page_considered,
                                       probe_page_n < probe_page_considered ? " (CAPPED)" : "");
                     raw_write(2, cb, (size_t)cn);
@@ -2268,11 +2321,11 @@ namespace {
                         uint64_t rdx_val = 0;
                         {
                             struct iovec liov; liov.iov_base = &rdx_val; liov.iov_len = 8;
-                            struct iovec riov; riov.iov_base = (void*)(uintptr_t)g_rdx; riov.iov_len = 8;
+                            struct iovec riov; riov.iov_base = (void*)(uintptr_t)fc.rdx; riov.iov_len = 8;
                             if (syscall(SYS_process_vm_readv, getpid(), &liov, 1UL, &riov, 1UL, 0UL) != 8)
                                 rdx_val = 0;
                         }
-                        const uint64_t vals[2] = { g_rax, rdx_val };
+                        const uint64_t vals[2] = { fc.rax, rdx_val };
                         for (uint64_t v : vals) {
                             uint32_t hi32 = (uint32_t)(v >> 32);
                             // Shape gate (run-10 lesson): a plain guest ADDRESS has a tiny high
@@ -2301,7 +2354,7 @@ namespace {
                     {
                         uint64_t rdx_val2 = 0;
                         struct iovec l2; l2.iov_base = &rdx_val2; l2.iov_len = 8;
-                        struct iovec r2; r2.iov_base = (void*)(uintptr_t)g_rdx; r2.iov_len = 8;
+                        struct iovec r2; r2.iov_base = (void*)(uintptr_t)fc.rdx; r2.iov_len = 8;
                         if (syscall(SYS_process_vm_readv, getpid(), &l2, 1UL, &r2, 1UL, 0UL) != 8)
                             rdx_val2 = 0;
                         // Byte dump around the free-list SLOT — the mechanism discriminator. The
@@ -2328,11 +2381,11 @@ namespace {
                             bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "\n");
                             raw_write(2, bb, (size_t)bn);
                         };
-                        byte_dump("rdx", g_rdx);
-                        byte_dump("r8", g_r8);
+                        byte_dump("rdx", fc.rdx);
+                        byte_dump("r8", fc.r8);
                         // #1226: was the faulting pool array even visible to the window probe?
                         if (prosper_mb3_is_pool_candidate) {
-                            for (uint64_t pb : { g_rdx & ~0xffffull, g_r8 & ~0xffffull }) {
+                            for (uint64_t pb : { fc.rdx & ~0xffffull, fc.r8 & ~0xffffull }) {
                                 if (pb < 0x10000) continue;
                                 char cb2[96]; int cn2 = snprintf(cb2, sizeof cb2,
                                     "[faultobj] pool 0x%llx candidate=%d\n",
@@ -2344,7 +2397,7 @@ namespace {
                         // the bulk guest-writer outside every GPU provenance ring (#88 precedent).
                         if (prosper_apr_dest_scan) {
                             static char ab[4096];
-                            const uint64_t aprobes[2] = { g_rdx, g_r8 };
+                            const uint64_t aprobes[2] = { fc.rdx, fc.r8 };
                             for (uint64_t probe : aprobes) {
                                 uint64_t pg = probe & ~0xfffull;
                                 if (pg < 0x1000) continue;
@@ -2356,7 +2409,7 @@ namespace {
                                 raw_write(2, ab, strlen(ab));   // unconditional: the stores/evictions header IS the zero-case confidence signal
                             }
                         }
-                        const uint64_t cands[3] = { g_rax, g_rcx, rdx_val2 };
+                        const uint64_t cands[3] = { fc.rax, fc.rcx, rdx_val2 };
                         for (uint64_t v : cands) {
                             if (v >> 32 || v < 0x100000) continue;           // must look byte-shifted
                             uint64_t real = v << 8;
@@ -2431,9 +2484,9 @@ namespace {
                     return true;
                 };
 #endif
-                ln = snprintf(lb, sizeof lb, "[prosper]   guest fp-chain (rbp=0x%llx):\n", (unsigned long long)g_rbp);
+                ln = snprintf(lb, sizeof lb, "[prosper]   guest fp-chain (rbp=0x%llx):\n", (unsigned long long)fc.rbp);
                 if (ln > 0) raw_write(2, lb, (size_t)ln);
-                uint64_t fp = g_rbp;
+                uint64_t fp = fc.rbp;
                 for (int depth = 0; depth < 16; depth++) {
                     uint64_t ra = 0, nfp = 0;
                     if (!safe_qword(fp, &nfp) || !safe_qword(fp + 8, &ra)) break;
@@ -2447,10 +2500,10 @@ namespace {
                     fp = nfp;
                 }
                 ln = snprintf(lb, sizeof lb, "[prosper]   guest ret-addr scan (rsp=0x%llx, 64 qwords):\n",
-                              (unsigned long long)g_rsp);
+                              (unsigned long long)fc.rsp);
                 if (ln > 0) raw_write(2, lb, (size_t)ln);
                 for (int i = 0, shown = 0; i < 64 && shown < 16; i++) {
-                    uint64_t sa = g_rsp + (uint64_t)i * 8;
+                    uint64_t sa = fc.rsp + (uint64_t)i * 8;
                     uint64_t q = 0;
                     if (!safe_qword(sa, &q)) continue;
                     if (g_base && q >= g_base && q < g_base + 0x100000000ull) {
@@ -2464,9 +2517,9 @@ namespace {
                 // e.g. #694's asset-load worker: rbp unreadable, rsp at the guard page), the only guest
                 // code lead is whichever GPR still holds a guest-module pointer. Flag them eboot-relative.
                 const struct { const char* nm; uint64_t v; } gregs[] = {
-                    {"rax",g_rax},{"rbx",g_rbx},{"rcx",g_rcx},{"rdx",g_rdx},{"rsi",g_rsi},{"rdi",g_rdi},
-                    {"r8",g_r8},{"r9",g_r9},{"r10",g_r10},{"r11",g_r11},{"r12",g_r12},{"r13",g_r13},
-                    {"r14",g_r14},{"r15",g_r15},{"rbp",g_rbp},
+                    {"rax",fc.rax},{"rbx",fc.rbx},{"rcx",fc.rcx},{"rdx",fc.rdx},{"rsi",fc.rsi},{"rdi",fc.rdi},
+                    {"r8",fc.r8},{"r9",fc.r9},{"r10",fc.r10},{"r11",fc.r11},{"r12",fc.r12},{"r13",fc.r13},
+                    {"r14",fc.r14},{"r15",fc.r15},{"rbp",fc.rbp},
                 };
                 for (const auto& r : gregs) {
                     if (g_base && r.v >= g_base && r.v < g_base + 0x100000000ull) {
@@ -2479,9 +2532,16 @@ namespace {
             // #312: full register + heap-window + GPU-write-ring dump at the worker fault too (the
             // MallocBinned3 freelist-pop faults — e.g. rcx=0x20015f00 at eboot+0x2316acf — land here,
             // not on the nullpage path). Reuses the async-signal-safe nullpage attribution dump.
-            nullpage_deep_dump(uc, g_fault_rip);
+            // fc.rip, not g_fault_rip (#2018): this call pairs THIS fault's ucontext registers with a
+            // rip, and reading the global there produced the report's most misleading line — an
+            // `insn @rip` decoding to an instruction that could not have faulted at the printed
+            // address, because the bytes came from another thread's fault.
+            nullpage_deep_dump(uc, fc.rip);
             // If PROSPER_HWBP_NODE ring-capture is active, the crash node's typetree metadata is the tail.
             if (g_hwbp_node_on) hwbp_dump_ring("worker-fault");
+            // The report is complete: a concurrently-faulting thread waiting above may now end the
+            // process (#2018).
+            dump_done.store(1, std::memory_order_release);
         }
         // PROSPER_WORKER_PARK=1 (diagnostic): instead of terminating the whole process on a guest
         // worker-thread fault, park the faulting thread so the main thread can proceed to its own

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -761,14 +761,16 @@ namespace {
             }
         }
     }
-    void dump_fault_mem() {
+    // Takes this fault's own snapshot rather than reading the shared globals (#2018): it runs on the
+    // worker path too, where a second faulting thread can rewrite them mid-dump.
+    void dump_fault_mem(const prosper::host::FaultContext& fc) {
         if (g_dumpat_n) dump_at_addrs();
         if (!g_faultmem) return;
         const struct { const char* n; uint64_t v; } regs[] = {
-            {"rdi", g_rdi}, {"rsi", g_rsi}, {"rdx", g_rdx}, {"rcx", g_rcx},
-            {"rax", g_rax}, {"rbx", g_rbx}, {"rbp", g_rbp}, {"rsp", g_rsp},
-            {"r8 ", g_r8},  {"r9 ", g_r9},  {"r12", g_r12}, {"r13", g_r13},
-            {"r14", g_r14}, {"r15", g_r15},
+            {"rdi", fc.rdi}, {"rsi", fc.rsi}, {"rdx", fc.rdx}, {"rcx", fc.rcx},
+            {"rax", fc.rax}, {"rbx", fc.rbx}, {"rbp", fc.rbp}, {"rsp", fc.rsp},
+            {"r8 ", fc.r8},  {"r9 ", fc.r9},  {"r12", fc.r12}, {"r13", fc.r13},
+            {"r14", fc.r14}, {"r15", fc.r15},
         };
         char b[256];
         int n = snprintf(b, sizeof b, "[prosper] FAULTMEM dump (regs -> guest memory):\n");
@@ -2068,16 +2070,6 @@ namespace {
         g_r10 = (uint64_t)g[REG_R10]; g_r11 = (uint64_t)g[REG_R11];
         g_r12 = (uint64_t)g[REG_R12]; g_r13 = (uint64_t)g[REG_R13];
         g_r14 = (uint64_t)g[REG_R14]; g_r15 = (uint64_t)g[REG_R15];
-        // #2018: the globals above are shared by every thread, and the guest's faults are correlated
-        // (one heap corruption takes several worker threads within milliseconds). A second thread
-        // faulting while the first is printing rewrites all of them underneath it, and the first
-        // report then continues with the second thread's registers while still reading as one
-        // complete fault. Keep the globals — the armed/main-thread recovery path below and
-        // trap_detail()/record_fault() are single-threaded by construction and use them — but give
-        // the FATAL worker-thread report its own stack-local snapshot, which no other thread can
-        // touch. Every value it prints then comes from one fault.
-        const prosper::host::FaultContext fc =
-            prosper::host::capture_fault_context(sig, cur_tid(), si->si_addr, uc);
         g_trap_sig = sig;
         g_trap_kind = (sig == SIGILL) ? 3 : 2;
         // Guest `int $0x41` (opcode CD 41) is RAGE's software breakpoint / assert trap (GTA V,
@@ -2120,7 +2112,14 @@ namespace {
             if (g_base && g_fault_rip == g_base + foff) { g[REG_RAX] = 0; g[REG_RIP] = g_base + roff;
                 guest_fs_restore_scoped(saved_guest_fs); return; }   // resume guest on guest %fs (#1155)
         }
-        dump_fault_mem();   // no-op unless PROSPER_FAULTMEM is set
+        // #2018: this fault's own registers, captured once and used by everything below. Taken HERE
+        // rather than beside the global stores at the top: every path above this point either
+        // returns to the guest (the int-0x41 skip, PROSPER_FAULT_SKIP, the sse4a and read-emulation
+        // paths) or has already returned, and RAGE's debugbreak path in particular is hot. Nothing
+        // above needs a snapshot, so it should not pay for one.
+        const prosper::host::FaultContext fc =
+            prosper::host::capture_fault_context(sig, cur_tid(), si->si_addr, uc);
+        dump_fault_mem(fc);   // no-op unless PROSPER_FAULTMEM is set
         // Dump the HWBP ring on the recoverable (armed/main-thread) crash too — the deser fault is kind=2.
         if (g_hwbp_node_on && !g_hwbp_ring_dumped) { uint64_t sfs = guest_fs_to_host_scoped();
             hwbp_dump_ring("recover"); guest_fs_restore_scoped(sfs); }
@@ -2128,14 +2127,30 @@ namespace {
         // Fault on a thread with no recovery point (a guest worker thread). Report where
         // (async-signal-safe write) then terminate cleanly instead of a cross-thread longjmp.
         {
+            // #2018: the globals above are shared by every thread, and the guest's faults are
+            // correlated (one heap corruption takes several worker threads within milliseconds). A
+            // second thread faulting while the first is printing rewrites all of them underneath
+            // it, and the first report then continues with the second thread's registers while
+            // still reading as one complete fault. Keep the globals — the armed/main-thread
+            // recovery path above and trap_detail()/record_fault() are single-threaded by
+            // construction and use them — but drive this FATAL report from `fc`, the stack-local
+            // snapshot taken above, which no other thread can touch. Every value it prints then
+            // comes from one fault.
+            //
             // #2018: one report at a time. Two worker threads faulting milliseconds apart used to
             // interleave their lines into a single apparent report; with the snapshot above each
             // line is now self-consistent, but two coherent reports written concurrently would still
             // be spliced together on stderr. First arrival owns the full dump; a thread that arrives
             // while one is in flight prints one clearly-labelled line for its own fault, so the
             // second fault is named rather than silently lost.
+            //
+            // Ownership is RELEASED when the dump finishes, not held for the life of the process.
+            // Holding it would be sound only if a fatal fault always ended the process, and under
+            // PROSPER_WORKER_PARK it deliberately does not: faulting threads park and the run
+            // continues, so later faults arrive seconds apart with no concurrency at all and must
+            // get their own full reports rather than a "someone else is reporting" line about a
+            // report that finished long ago.
             static std::atomic<long> dump_owner{0};
-            static std::atomic<int> dump_done{0};
             long expected = 0;
             if (!prosper::host::claim_fault_report(dump_owner, fc.tid, &expected)) {
                 char cb2[224];
@@ -2151,9 +2166,20 @@ namespace {
                 // line and nothing after it). BOUNDED, because the owner may itself die inside its
                 // dump and a signal handler that waited unconditionally on another faulting thread
                 // would hang a run that used to exit 90. `nanosleep` is async-signal-safe.
-                for (int i = 0; i < 400 && !dump_done.load(std::memory_order_acquire); i++) {
+                int waited = 0;
+                for (; waited < 400 &&
+                       dump_owner.load(std::memory_order_acquire) == expected; waited++) {
                     struct timespec ts; ts.tv_sec = 0; ts.tv_nsec = 5 * 1000 * 1000;   // 5 ms
                     nanosleep(&ts, nullptr);
+                }
+                // Say so when the bound is what ended the wait. A silent timeout truncates the
+                // owner's report exactly as the pre-fix `_exit` did, and a reader who is not told
+                // cannot tell a complete report from a cut-off one.
+                if (waited >= 400) {
+                    static const char to[] =
+                        "[prosper]   (report may be TRUNCATED: waited 2s for the owning thread's "
+                        "dump and it had not finished)\n";
+                    raw_write(2, to, sizeof to - 1);
                 }
                 if (getenv("PROSPER_WORKER_PARK")) { for (;;) pause(); }
                 _exit(90);
@@ -2182,24 +2208,30 @@ namespace {
             // on the host TCB, so any %fs-relative TLS read returned host garbage (the #1155 fault class,
             // now fixed by restoring guest %fs on signal-handler return-to-guest paths above).
             //
-            // The premise is a HEURISTIC and it is not always met: rax only holds the TCB self-pointer
-            // when the fault lands shortly after that load. When it holds something else — a corrupted
-            // free-list head, a count — the magic check reads an unrelated address and prints
-            // "NO(host-%fs leak?)" for a thread that is perfectly on its guest TCB. So the line now
-            // says when its own premise does not hold rather than asserting a leak (#2018 saw exactly
-            // this: rax = 0x30016000, the corrupt pointer, on a thread with no %fs problem at all).
+            // The rax premise is a HEURISTIC and it is not always met — rax holds the TCB
+            // self-pointer only when the fault lands shortly after that load, and when it holds
+            // something else (a corrupt free-list head, a count) the magic check reads an unrelated
+            // address and asserted `NO(host-%fs leak?)` for a thread with no %fs problem at all
+            // (#2018: rax = 0x30016000). It does not need to guess: `saved_guest_fs` above is the
+            // answer. `guest_fs_to_host_scoped()` read this thread's real %fs base and returned it
+            // only after checking TCB_MAGIC there (guest_tls.cpp:161-171), so non-zero IS "this
+            // thread was on our guest TCB". rax stays on the line as raw evidence, without a claim
+            // attached to it.
+            //
+            // Darwin has no equivalent: `guest_fs_to_host_scoped()` is a `return 0` stub there
+            // (guest_tls.cpp:288), so 0 must not be read as "leaked" on that platform.
             {
                 char nm[16] = {0}; pthread_getname_np(pthread_self(), nm, sizeof nm);   // portable (Linux+macOS)
-                const bool magic_readable = probe_readable(fc.rax + 0x108);
-                const bool on_guest_tcb = magic_readable &&
-                                    *(const uint32_t*)(uintptr_t)(fc.rax + 0x108) == 0x50524F53u;
+#ifdef __APPLE__
+                const char* tcb = "unknown (not determined on this platform)";
+#else
+                const char* tcb = saved_guest_fs ? "yes" : "NO(host-%fs leak?)";
+#endif
                 char tb[224];
-                int t = snprintf(tb, sizeof tb, "[fault] thread='%s' fs(rax)=0x%llx on-guest-TCB=%s\n",
-                                 nm, (unsigned long long)fc.rax,
-                                 on_guest_tcb    ? "yes"
-                                 : magic_readable ? "NO(host-%fs leak?)"
-                                                  : "unknown (rax is not a TCB pointer here — "
-                                                    "no %fs conclusion follows)");
+                int t = snprintf(tb, sizeof tb,
+                                 "[fault] thread='%s' guest-fs=0x%llx rax=0x%llx on-guest-TCB=%s\n",
+                                 nm, (unsigned long long)saved_guest_fs,
+                                 (unsigned long long)fc.rax, tcb);
                 raw_write(2, tb, (size_t)t);
             }
             // PROSPER_FAULTOBJ (#1226): dump the leading 0xC0 bytes of the objects in rax/r15/rbx via a
@@ -2539,9 +2571,10 @@ namespace {
             nullpage_deep_dump(uc, fc.rip);
             // If PROSPER_HWBP_NODE ring-capture is active, the crash node's typetree metadata is the tail.
             if (g_hwbp_node_on) hwbp_dump_ring("worker-fault");
-            // The report is complete: a concurrently-faulting thread waiting above may now end the
-            // process (#2018).
-            dump_done.store(1, std::memory_order_release);
+            // The report is complete (#2018): a concurrently-faulting thread waiting above may now
+            // end the process, and under PROSPER_WORKER_PARK a LATER fault can take the gate and
+            // get a full report of its own.
+            prosper::host::release_fault_report(dump_owner, fc.tid);
         }
         // PROSPER_WORKER_PARK=1 (diagnostic): instead of terminating the whole process on a guest
         // worker-thread fault, park the faulting thread so the main thread can proceed to its own

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2222,16 +2222,24 @@ namespace {
             // Zero has three causes and only one of them is a defect:
             //   (1) the thread really did run guest code on the host glibc TCB — the #1155 class,
             //       and the only reading worth alarming about;
-            //   (2) guest %fs is not enabled for this process at all. That is the DEFAULT —
-            //       `g_enabled = getenv("PROSPER_GUEST_FS") != nullptr` (guest_tls.cpp:46), opt-in,
-            //       and neither a plain prosper-app run nor most of tools/dbg/*.sh sets it — so
-            //       every thread reads zero and none of them leaked anything;
+            //   (2) guest %fs is not enabled for this process. On Linux/Windows it is enabled by
+            //       DEFAULT — `g_enabled = getenv("PROSPER_NO_GUEST_FS") == nullptr`
+            //       (guest_tls.cpp:58), an opt-OUT kept for compatibility bisection — so this arm
+            //       means either that opt-out is set, or the fault landed before
+            //       guest_tls_set_templates() ran (boot_program.cpp:252) and g_configured is still
+            //       false. Both are RARE on an ordinary boot, so do NOT reach for this cause first.
+            //       (guest_tls.cpp:46's PROSPER_GUEST_FS opt-IN is the macOS/Rosetta arm only, and
+            //       this whole three-state line is compiled out there — see the Darwin note below.)
             //   (3) the faulting thread is one of prosper's OWN host threads, which never had a
             //       guest TCB to leak off. This report is reached by any non-armed thread, host or
             //       guest, so that is not a rare case.
             // `guest_tls_enabled()` (guest_tls.cpp:79) separates (2) from (1)/(3) as fact; nothing
             // available in a signal handler separates (1) from (3), so the line says so rather than
             // asserting a leak. It is two static bool loads: no allocation, no lock, handler-safe.
+            // Practical consequence on Linux, which is where these reports are read: because guest
+            // %fs is on by default, `n/a` is the rare arm and a zero here is almost always (1) or
+            // (3) — the two the handler cannot tell apart. That is the honest state of knowledge,
+            // and it is why the string hedges instead of naming a leak.
             //
             // Darwin: `guest_fs_to_host_scoped()` returns 0 unconditionally there — the
             // `#ifdef __APPLE__` early-out inside the shared POSIX definition (guest_tls.cpp:162-164),

--- a/prosper/src/host/fault_context.hpp
+++ b/prosper/src/host/fault_context.hpp
@@ -18,13 +18,16 @@
 #include <atomic>
 #include <cstdint>
 
-#ifndef _WIN32
+#if defined(__linux__)
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE   // glibc gates the REG_* gregs[] indices behind __USE_GNU
 #endif
 #include <signal.h>
 #include <ucontext.h>
 #endif
+// Darwin deliberately gets no <ucontext.h>: that header is `#error`-guarded behind _XOPEN_SOURCE
+// on macOS. posix_shim.hpp's Darwin branch already pulls in <sys/ucontext.h>, which is where
+// ucontext_t/mcontext_t come from there.
 
 #include "posix_shim.hpp"   // PROSPER_GREGS + the REG_* indices (Linux gregs[] / Darwin __ss)
 
@@ -60,19 +63,23 @@ inline FaultContext capture_fault_context(int sig, long tid, const void* fault_a
     return f;
 }
 
-// Who owns the one fatal fault report. A coherent snapshot stops a report from carrying another
-// thread's registers; it does not stop two coherent reports from being written to stderr at the same
-// time and arriving spliced together. So the first faulting thread claims the report and the others
-// say so in one line instead of printing over it.
+// Who owns the fatal fault report *right now*. A coherent snapshot stops a report from carrying
+// another thread's registers; it does not stop two coherent reports from being written to stderr at
+// the same time and arriving spliced together. So the first faulting thread claims the report and a
+// thread that arrives while one is in flight says so in one line instead of printing over it.
 //
-// Never blocks. A signal handler that waited for another *faulting* thread to finish could wait
-// forever — the owner may itself die inside its dump — so a loser reports and leaves rather than
-// queueing. `owner` starts at 0 (no owner) and is never cleared: the process is on its way to
-// `_exit`, and a second claim after the first report is finished would still splice into a log the
-// reader is treating as one crash.
+// This call itself never blocks — it is one compare-exchange. Whether a loser then WAITS for the
+// owner is the caller's decision, and the caller must bound it: the owner may die inside its own
+// dump, and a signal handler that waited unconditionally on another *faulting* thread would hang a
+// run that used to terminate.
 //
-// Returns true when this thread owns the full dump. `already` is set to the owning tid either way,
-// so a losing thread can name who is reporting.
+// Ownership is scoped to one report, not to the process: `release_fault_report` frees it when the
+// dump completes, so a fault arriving LATER — with no concurrency at all — gets its own full
+// report. Holding it for the life of the process would be sound only if a fatal fault always ended
+// the process, and PROSPER_WORKER_PARK exists precisely so that it does not.
+//
+// Returns true when this thread owns the dump. `already` is set to the owning tid either way, so a
+// losing thread can name who is reporting and can watch that value for the release.
 inline bool claim_fault_report(std::atomic<long>& owner, long tid, long* already = nullptr) {
     long expected = 0;
     const bool won = owner.compare_exchange_strong(expected, tid);
@@ -80,6 +87,14 @@ inline bool claim_fault_report(std::atomic<long>& owner, long tid, long* already
     // Re-entering on the same thread (a fault raised inside the dump) is not a competing report:
     // it is the owner, and refusing it there would silently truncate the record.
     return won || expected == tid;
+}
+
+// Release a claim taken by `claim_fault_report`. Compare-exchange rather than a plain store, so a
+// thread that never owned the gate cannot hand it to a third thread in the middle of someone
+// else's report.
+inline void release_fault_report(std::atomic<long>& owner, long tid) {
+    long expected = tid;
+    owner.compare_exchange_strong(expected, 0);
 }
 
 }  // namespace prosper::host

--- a/prosper/src/host/fault_context.hpp
+++ b/prosper/src/host/fault_context.hpp
@@ -1,0 +1,85 @@
+#pragma once
+// One fault's own context, snapshotted from ITS siginfo/ucontext.
+//
+// exec_image's signal handler keeps the interrupted registers in process-global variables
+// (`g_fault_addr`, `g_fault_rip`, `g_rax` … `g_r15`) because a guest thread may be running on a
+// guest %fs, which makes `__thread` storage unusable inside the handler — see the `g_jb` comment in
+// exec_image_linux.cpp. Those globals are correct for the armed/main-thread recovery path, which is
+// single-threaded by construction, but they are NOT a per-fault record: the guest is heavily
+// multithreaded and its faults are correlated (one heap corruption takes several worker threads
+// within milliseconds), so a second thread faulting while the first is still printing overwrites
+// every global underneath it. The first thread's report then continues with the second thread's
+// registers and reads as one complete fault (#2018).
+//
+// A stack-local snapshot has neither problem: it needs no TLS, and it cannot be rewritten by another
+// thread. Capture once at handler entry and drive the whole report from it.
+//
+// Async-signal-safe: plain field copies out of the ucontext, no allocation and no libc calls.
+#include <atomic>
+#include <cstdint>
+
+#ifndef _WIN32
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE   // glibc gates the REG_* gregs[] indices behind __USE_GNU
+#endif
+#include <signal.h>
+#include <ucontext.h>
+#endif
+
+#include "posix_shim.hpp"   // PROSPER_GREGS + the REG_* indices (Linux gregs[] / Darwin __ss)
+
+namespace prosper::host {
+
+struct FaultContext {
+    uint64_t addr = 0;   // siginfo_t::si_addr — the address that faulted
+    uint64_t rip = 0, rbp = 0, rsp = 0;
+    uint64_t rax = 0, rbx = 0, rcx = 0, rdx = 0, rsi = 0, rdi = 0;
+    uint64_t r8 = 0, r9 = 0, r10 = 0, r11 = 0, r12 = 0, r13 = 0, r14 = 0, r15 = 0;
+    int  sig = 0;
+    long tid = 0;        // kernel tid, so a report names the thread it actually describes
+};
+
+// `uc` is the handler's own third argument and `fault_addr` its siginfo's `si_addr` (spelled
+// differently because glibc defines `si_addr` as a macro, so it cannot be a parameter name).
+// Deliberately takes no default and reads no global, so a caller cannot accidentally build a
+// context out of shared state.
+inline FaultContext capture_fault_context(int sig, long tid, const void* fault_addr,
+                                          ucontext_t* uc) {
+    FaultContext f;
+    f.sig = sig;
+    f.tid = tid;
+    f.addr = (uint64_t)(uintptr_t)fault_addr;
+    if (!uc) return f;
+    auto g = PROSPER_GREGS(uc);
+    f.rip = (uint64_t)g[REG_RIP]; f.rbp = (uint64_t)g[REG_RBP]; f.rsp = (uint64_t)g[REG_RSP];
+    f.rax = (uint64_t)g[REG_RAX]; f.rbx = (uint64_t)g[REG_RBX]; f.rcx = (uint64_t)g[REG_RCX];
+    f.rdx = (uint64_t)g[REG_RDX]; f.rsi = (uint64_t)g[REG_RSI]; f.rdi = (uint64_t)g[REG_RDI];
+    f.r8  = (uint64_t)g[REG_R8];  f.r9  = (uint64_t)g[REG_R9];  f.r10 = (uint64_t)g[REG_R10];
+    f.r11 = (uint64_t)g[REG_R11]; f.r12 = (uint64_t)g[REG_R12]; f.r13 = (uint64_t)g[REG_R13];
+    f.r14 = (uint64_t)g[REG_R14]; f.r15 = (uint64_t)g[REG_R15];
+    return f;
+}
+
+// Who owns the one fatal fault report. A coherent snapshot stops a report from carrying another
+// thread's registers; it does not stop two coherent reports from being written to stderr at the same
+// time and arriving spliced together. So the first faulting thread claims the report and the others
+// say so in one line instead of printing over it.
+//
+// Never blocks. A signal handler that waited for another *faulting* thread to finish could wait
+// forever — the owner may itself die inside its dump — so a loser reports and leaves rather than
+// queueing. `owner` starts at 0 (no owner) and is never cleared: the process is on its way to
+// `_exit`, and a second claim after the first report is finished would still splice into a log the
+// reader is treating as one crash.
+//
+// Returns true when this thread owns the full dump. `already` is set to the owning tid either way,
+// so a losing thread can name who is reporting.
+inline bool claim_fault_report(std::atomic<long>& owner, long tid, long* already = nullptr) {
+    long expected = 0;
+    const bool won = owner.compare_exchange_strong(expected, tid);
+    if (already) *already = won ? tid : expected;
+    // Re-entering on the same thread (a fault raised inside the dump) is not a competing report:
+    // it is the owner, and refusing it there would silently truncate the record.
+    return won || expected == tid;
+}
+
+}  // namespace prosper::host

--- a/prosper/src/host/fault_context.hpp
+++ b/prosper/src/host/fault_context.hpp
@@ -92,6 +92,13 @@ inline bool claim_fault_report(std::atomic<long>& owner, long tid, long* already
 // Release a claim taken by `claim_fault_report`. Compare-exchange rather than a plain store, so a
 // thread that never owned the gate cannot hand it to a third thread in the middle of someone
 // else's report.
+//
+// Deliberately NOT nesting-counted, and that is safe only because of a property of the caller:
+// `claim_fault_report` grants re-entry to the owning tid (a fault raised inside the dump), and a
+// re-entrant call would then release the gate while the outer report is still open. It cannot,
+// because the fatal report block never returns — its every exit is `_exit` or an unbounded park —
+// so an inner report ends the process rather than unwinding back into the outer one. If that ever
+// stops being true, this needs a depth count, not a bool.
 inline void release_fault_report(std::atomic<long>& owner, long tid) {
     long expected = tid;
     owner.compare_exchange_strong(expected, 0);

--- a/prosper/tests/test_fault_context.cpp
+++ b/prosper/tests/test_fault_context.cpp
@@ -1,0 +1,159 @@
+// test_fault_context — a fatal worker-thread fault report must describe ONE fault (#2018).
+//
+// exec_image's signal handler keeps the interrupted registers in process globals, because guest
+// threads may run on a guest %fs and `__thread` therefore cannot be used inside the handler. Those
+// globals are shared, so a second thread faulting while the first was printing rewrote them
+// underneath it: the first report kept going with the second fault's rip, rbp, rsp and probe
+// registers, and still read as one complete fault. Measured on Crisis Core (PPSA07809): within one
+// report `rbp` printed as two different values, and `insn bytes @rip` decoded to `mov eax,[rbx]`
+// with `rbx = 0x20` under a header claiming `addr=0x30016000` — bytes fetched from another thread's
+// rip.
+//
+// The fix is a stack-local snapshot taken from the handler's OWN siginfo/ucontext, plus a
+// single-owner gate on the fatal report.
+//
+// **What this test does and does not prove.** The interleave is a live, multi-threaded property of
+// the *report*, and the retained evidence for it is in #2018 — two Crisis Core reports in which
+// `rbp`, `rsp` and `rax` each print two different values inside one dump. A single-threaded unit
+// test cannot reproduce that, and this one does not claim to: it pins the two mechanisms the fix
+// introduces. Section 1-4 assert that a capture reads the ucontext it is handed (a capture reading
+// any shared or stale source lands values that are not this ucontext's and fails) and that the
+// result is a value another capture cannot alter. Section 5 is the one with a real mutation arm:
+// remove the gate — the pre-fix state, where every faulting thread printed — and its second and
+// fourth assertions fail.
+//
+// Exit code is truth: 0 = pass.
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+#if defined(__linux__) || defined(__APPLE__)
+#include "../src/host/fault_context.hpp"
+
+using prosper::host::FaultContext;
+using prosper::host::capture_fault_context;
+
+static int failures = 0;
+
+static void check_eq(const char* what, uint64_t got, uint64_t want) {
+    if (got != want) {
+        printf("  FAIL %-24s got=0x%llx want=0x%llx\n", what,
+               (unsigned long long)got, (unsigned long long)want);
+        ++failures;
+    }
+}
+
+// Stand-ins for the process globals the pre-fix report read, set to the *second* fault's values
+// before that fault is captured. A capture that consults shared state instead of its own ucontext
+// lands these in the first context, and section 3 catches it.
+static uint64_t g_poison_rip = 0xBAD0BAD0BAD0BAD0ull;
+static uint64_t g_poison_reg = 0xDEADDEADDEADDEADull;
+
+int main() {
+    printf("== test_fault_context ==\n");
+
+    // Two distinct fault contexts, standing in for two threads faulting milliseconds apart.
+    ucontext_t uc_a{}, uc_b{};
+    auto set = [](ucontext_t& uc, uint64_t base) {
+        auto g = PROSPER_GREGS(&uc);
+        g[REG_RIP] = (greg_t)(base + 0x01); g[REG_RBP] = (greg_t)(base + 0x02);
+        g[REG_RSP] = (greg_t)(base + 0x03); g[REG_RAX] = (greg_t)(base + 0x04);
+        g[REG_RBX] = (greg_t)(base + 0x05); g[REG_RCX] = (greg_t)(base + 0x06);
+        g[REG_RDX] = (greg_t)(base + 0x07); g[REG_RSI] = (greg_t)(base + 0x08);
+        g[REG_RDI] = (greg_t)(base + 0x09); g[REG_R8]  = (greg_t)(base + 0x0a);
+        g[REG_R9]  = (greg_t)(base + 0x0b); g[REG_R10] = (greg_t)(base + 0x0c);
+        g[REG_R11] = (greg_t)(base + 0x0d); g[REG_R12] = (greg_t)(base + 0x0e);
+        g[REG_R13] = (greg_t)(base + 0x0f); g[REG_R14] = (greg_t)(base + 0x10);
+        g[REG_R15] = (greg_t)(base + 0x11);
+    };
+    const uint64_t base_a = 0x0000414100000000ull;   // "thread A"
+    const uint64_t base_b = 0x0000424200000000ull;   // "thread B"
+    set(uc_a, base_a);
+    set(uc_b, base_b);
+
+    auto verify = [](const char* who, const FaultContext& f, uint64_t base,
+                     uint64_t addr, int sig, long tid) {
+        printf(" %s\n", who);
+        check_eq("addr", f.addr, addr);
+        check_eq("sig",  (uint64_t)f.sig, (uint64_t)sig);
+        check_eq("tid",  (uint64_t)f.tid, (uint64_t)tid);
+        check_eq("rip", f.rip, base + 0x01); check_eq("rbp", f.rbp, base + 0x02);
+        check_eq("rsp", f.rsp, base + 0x03); check_eq("rax", f.rax, base + 0x04);
+        check_eq("rbx", f.rbx, base + 0x05); check_eq("rcx", f.rcx, base + 0x06);
+        check_eq("rdx", f.rdx, base + 0x07); check_eq("rsi", f.rsi, base + 0x08);
+        check_eq("rdi", f.rdi, base + 0x09); check_eq("r8",  f.r8,  base + 0x0a);
+        check_eq("r9",  f.r9,  base + 0x0b); check_eq("r10", f.r10, base + 0x0c);
+        check_eq("r11", f.r11, base + 0x0d); check_eq("r12", f.r12, base + 0x0e);
+        check_eq("r13", f.r13, base + 0x0f); check_eq("r14", f.r14, base + 0x10);
+        check_eq("r15", f.r15, base + 0x11);
+    };
+
+    // 1. A capture carries its own ucontext's registers.
+    const FaultContext fa = capture_fault_context(11, 4242, (void*)0x30016000ull, &uc_a);
+    verify("A: captured from its own ucontext", fa, base_a, 0x30016000ull, 11, 4242);
+
+    // 2. The interleave. "Thread B" faults and, as the handler does, rewrites every shared global
+    //    before A's report has finished printing. A's snapshot must be untouched — this is the
+    //    property whose absence produced two rbp values inside one report.
+    g_poison_rip = base_b + 0x01;
+    g_poison_reg = base_b + 0x04;
+    const FaultContext fb = capture_fault_context(11, 4243, (void*)0x2000e2495044ull, &uc_b);
+    verify("B: captured from its own ucontext", fb, base_b, 0x2000e2495044ull, 11, 4243);
+    printf(" A after B's fault (must be unchanged)\n");
+    verify("A: still its own", fa, base_a, 0x30016000ull, 11, 4242);
+
+    // 3. No field of A may carry a sentinel or any of B's values. Stated separately from the
+    //    exact-value checks above so a partially-correct capture — right for most registers, reading
+    //    shared state for one — is named as such rather than reported as a single field mismatch.
+    const uint64_t fields[] = { fa.addr, fa.rip, fa.rbp, fa.rsp, fa.rax, fa.rbx, fa.rcx, fa.rdx,
+                                fa.rsi, fa.rdi, fa.r8, fa.r9, fa.r10, fa.r11, fa.r12, fa.r13,
+                                fa.r14, fa.r15 };
+    for (uint64_t v : fields) {
+        if (v == 0xBAD0BAD0BAD0BAD0ull || v == 0xDEADDEADDEADDEADull ||
+            v == g_poison_rip || v == g_poison_reg) {
+            printf("  FAIL A carries a value from B's fault / a poisoned global: 0x%llx\n",
+                   (unsigned long long)v);
+            ++failures;
+        }
+    }
+
+    // 4. A null ucontext must not be dereferenced: the identity fields still describe the fault.
+    const FaultContext fn = capture_fault_context(4, 7, (void*)0x1ull, nullptr);
+    check_eq("null-uc addr", fn.addr, 0x1ull);
+    check_eq("null-uc sig", (uint64_t)fn.sig, 4u);
+    check_eq("null-uc rip", fn.rip, 0u);
+
+    // 5. The report gate. A coherent snapshot per fault is only half of it: two coherent reports
+    //    written concurrently still arrive spliced. Exactly one thread may own the full dump, and a
+    //    fault raised *inside* the dump (same tid) must not be locked out of its own report — that
+    //    would truncate the record at the point it got interesting. A gate that always grants
+    //    (the pre-fix behavior: no gate at all) fails the second assertion.
+    printf(" report gate\n");
+    {
+        std::atomic<long> owner{0};
+        long who = -1;
+        if (!prosper::host::claim_fault_report(owner, 4242, &who)) {
+            printf("  FAIL first claimant was refused\n"); ++failures;
+        }
+        check_eq("gate: owner after first claim", (uint64_t)who, 4242u);
+        who = -1;
+        if (prosper::host::claim_fault_report(owner, 4243, &who)) {
+            printf("  FAIL a second thread was granted the dump\n"); ++failures;
+        }
+        check_eq("gate: loser is told the owner", (uint64_t)who, 4242u);
+        if (!prosper::host::claim_fault_report(owner, 4242, &who)) {
+            printf("  FAIL the owner was refused re-entry into its own dump\n"); ++failures;
+        }
+        // The owner is sticky: a later fault, after the first report has finished, must not open a
+        // second dump into a log the reader is treating as one crash.
+        if (prosper::host::claim_fault_report(owner, 4244, &who)) {
+            printf("  FAIL a late third thread was granted a second dump\n"); ++failures;
+        }
+    }
+
+    printf(failures ? "FAILED (%d)\n" : "ok\n", failures);
+    return failures ? 1 : 0;
+}
+#else
+int main() { printf("== test_fault_context == skipped (posix signal context only)\n"); return 0; }
+#endif

--- a/prosper/tests/test_fault_context.cpp
+++ b/prosper/tests/test_fault_context.cpp
@@ -26,6 +26,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <type_traits>
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "../src/host/fault_context.hpp"
@@ -54,6 +55,15 @@ int main() {
 
     // Two distinct fault contexts, standing in for two threads faulting milliseconds apart.
     ucontext_t uc_a{}, uc_b{};
+#ifdef __APPLE__
+    // Darwin's ucontext_t holds a POINTER to the machine context (`uc_mcontext->__ss`), unlike
+    // Linux's inline `uc_mcontext.gregs[]`. A value-initialized ucontext_t therefore has a null
+    // uc_mcontext here, and PROSPER_GREGS would dereference it. The kernel always supplies one at a
+    // real fault; the test has to.
+    std::remove_pointer<mcontext_t>::type mc_a{}, mc_b{};
+    uc_a.uc_mcontext = &mc_a;
+    uc_b.uc_mcontext = &mc_b;
+#endif
     auto set = [](ucontext_t& uc, uint64_t base) {
         auto g = PROSPER_GREGS(&uc);
         g[REG_RIP] = (greg_t)(base + 0x01); g[REG_RBP] = (greg_t)(base + 0x02);

--- a/prosper/tests/test_fault_context.cpp
+++ b/prosper/tests/test_fault_context.cpp
@@ -26,13 +26,13 @@
 // Exit code is truth: 0 = pass.
 #include <cstdio>
 #include <cstdint>
-#include <cstring>
+
+#if defined(__linux__) || defined(__APPLE__)
 #include <atomic>
 #include <thread>
 #include <type_traits>
 #include <vector>
 
-#if defined(__linux__) || defined(__APPLE__)
 #include "../src/host/fault_context.hpp"
 
 using prosper::host::FaultContext;
@@ -181,7 +181,12 @@ int main() {
     printf(" report gate under contention\n");
     {
         constexpr int kThreads = 16;
-        constexpr int kRounds = 2000;
+        // 200 rounds, not thousands. The discriminator is deterministic — every thread claims with
+        // a distinct tid, so exactly one can satisfy the predicate under any interleaving — and the
+        // non-atomic mutant `if (owner == 0) owner = tid;` fails in round 0. The extra rounds bought
+        // no signal and cost 16 thread spawn/joins each in a suite other lanes wait on. Still well
+        // above 1, so this remains a race test rather than a second sequential check.
+        constexpr int kRounds = 200;
         std::atomic<int> total_winners{0};
         std::atomic<int> bad_reports{0};
         for (int round = 0; round < kRounds; round++) {
@@ -193,7 +198,9 @@ int main() {
             for (int i = 0; i < kThreads; i++) {
                 ts.emplace_back([&, i] {
                     ready.fetch_add(1);
-                    while (!go.load(std::memory_order_acquire)) { /* spin to the same instant */ }
+                    // Spin rather than sleep so every thread reaches the claim at the same
+                    // instant; yield so a 16-thread round cannot monopolise fewer cores.
+                    while (!go.load(std::memory_order_acquire)) std::this_thread::yield();
                     long who = -1;
                     const long tid = 1000 + i;
                     if (prosper::host::claim_fault_report(owner, tid, &who)) {
@@ -204,7 +211,7 @@ int main() {
                     }
                 });
             }
-            while (ready.load() < kThreads) { }
+            while (ready.load() < kThreads) std::this_thread::yield();
             go.store(true, std::memory_order_release);
             for (auto& t : ts) t.join();
             const int w = winners.load();

--- a/prosper/tests/test_fault_context.cpp
+++ b/prosper/tests/test_fault_context.cpp
@@ -18,15 +18,19 @@
 // test cannot reproduce that, and this one does not claim to: it pins the two mechanisms the fix
 // introduces. Section 1-4 assert that a capture reads the ucontext it is handed (a capture reading
 // any shared or stale source lands values that are not this ucontext's and fails) and that the
-// result is a value another capture cannot alter. Section 5 is the one with a real mutation arm:
-// remove the gate — the pre-fix state, where every faulting thread printed — and its second and
-// fourth assertions fail.
+// result is a value another capture cannot alter. Sections 5 and 6 are the ones with real mutation
+// arms: remove the gate — the pre-fix state, where every faulting thread printed — and section 5's
+// second assertion fails; make the gate a non-atomic `if (owner == 0) owner = tid;`, which passes
+// every sequential check, and section 6 fails on a round with two winners.
 //
 // Exit code is truth: 0 = pass.
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <atomic>
+#include <thread>
 #include <type_traits>
+#include <vector>
 
 #if defined(__linux__) || defined(__APPLE__)
 #include "../src/host/fault_context.hpp"
@@ -154,11 +158,66 @@ int main() {
         if (!prosper::host::claim_fault_report(owner, 4242, &who)) {
             printf("  FAIL the owner was refused re-entry into its own dump\n"); ++failures;
         }
-        // The owner is sticky: a later fault, after the first report has finished, must not open a
-        // second dump into a log the reader is treating as one crash.
-        if (prosper::host::claim_fault_report(owner, 4244, &who)) {
-            printf("  FAIL a late third thread was granted a second dump\n"); ++failures;
+        // A non-owner must not be able to free the gate out from under the owner.
+        prosper::host::release_fault_report(owner, 4243);
+        check_eq("gate: a non-owner cannot release", (uint64_t)owner.load(), 4242u);
+        // And once the owner releases, a LATER fault gets a full report of its own. Under
+        // PROSPER_WORKER_PARK a fatal fault does not end the process, so those arrive seconds apart
+        // with no concurrency; holding ownership for the life of the process would answer them with
+        // "someone else is reporting" about a report that finished long ago.
+        prosper::host::release_fault_report(owner, 4242);
+        check_eq("gate: released", (uint64_t)owner.load(), 0u);
+        if (!prosper::host::claim_fault_report(owner, 4244, &who)) {
+            printf("  FAIL a later fault was refused its own report after the gate was released\n");
+            ++failures;
         }
+        check_eq("gate: later owner", (uint64_t)who, 4244u);
+    }
+
+    // 6. The gate must be ATOMIC, not merely first-come. Section 5 is sequential and would pass for
+    //    a plain `if (owner == 0) owner = tid;`, which is exactly the shape that loses a race. Every
+    //    thread claims the same gate at once; precisely one may win, and the winner's tid must be
+    //    what every loser was told.
+    printf(" report gate under contention\n");
+    {
+        constexpr int kThreads = 16;
+        constexpr int kRounds = 2000;
+        std::atomic<int> total_winners{0};
+        std::atomic<int> bad_reports{0};
+        for (int round = 0; round < kRounds; round++) {
+            std::atomic<long> owner{0};
+            std::atomic<int> winners{0};
+            std::atomic<int> ready{0};
+            std::atomic<bool> go{false};
+            std::vector<std::thread> ts;
+            for (int i = 0; i < kThreads; i++) {
+                ts.emplace_back([&, i] {
+                    ready.fetch_add(1);
+                    while (!go.load(std::memory_order_acquire)) { /* spin to the same instant */ }
+                    long who = -1;
+                    const long tid = 1000 + i;
+                    if (prosper::host::claim_fault_report(owner, tid, &who)) {
+                        winners.fetch_add(1);
+                        if (who != tid) bad_reports.fetch_add(1);   // winner told the wrong owner
+                    } else if (who == 0 || who == tid) {
+                        bad_reports.fetch_add(1);   // loser told "nobody" / "itself" is reporting
+                    }
+                });
+            }
+            while (ready.load() < kThreads) { }
+            go.store(true, std::memory_order_release);
+            for (auto& t : ts) t.join();
+            const int w = winners.load();
+            if (w != 1) {
+                printf("  FAIL round %d had %d winners (must be exactly 1)\n", round, w);
+                ++failures;
+                break;
+            }
+            total_winners.fetch_add(w);
+        }
+        check_eq("contended: one winner per round", (uint64_t)total_winners.load(),
+                 (uint64_t)kRounds);
+        check_eq("contended: every claimant told the true owner", (uint64_t)bad_reports.load(), 0u);
     }
 
     printf(failures ? "FAILED (%d)\n" : "ok\n", failures);


### PR DESCRIPTION
## What this fixes

A fatal worker-thread fault report could describe **two faults at once**, and read as one.

`prosper/src/host/exec_image_linux.cpp` keeps the interrupted context in process globals —
`g_fault_addr`, `g_fault_rip`, `g_rax` … `g_r15`, `g_rbp`, `g_rsp` (`:87-91`, written by the
handler at `:2059-2070`). That is deliberate and correct for the armed/main-thread recovery
path: guest threads may run on a guest `%fs`, so `__thread` storage cannot be used inside the
handler (`:78-81`). But the **fatal worker-thread report** also read those globals, line by
line, while printing. The guest's faults are correlated — one heap corruption takes several
worker threads within milliseconds — so a second thread faulting mid-dump rewrote every global
underneath the first thread's report, which then continued with the second fault's registers.

## Evidence

Crisis Core (`PPSA07809`), master `4d7a2ded`, Linux/RADV, unmodified `tools/screenshot`.

**The same global, printed twice in one report, with two different values:**

```text
[prosper] WORKER-THREAD FAULT: sig=11 addr=0x30016000 rip=0x41174c389 (image+0x174c389) rbp=0x7fe46d761280
[prosper]   insn bytes @rip: 8b 03 89 c1 83 e1 03 89  ret@[rsp]=0x0
[fault] thread='RHIThread' fs(rax)=0x0 on-guest-TCB=NO(host-%fs leak?)
[prosper]   guest fp-chain (rbp=0x7fe4603ff3a0):            <- g_rbp again, different
[prosper]   guest ret-addr scan (rsp=0x7fe4603ff350, ...)   <- g_rsp, likewise
[nullpage]   rax=0x30016000 rbx=0x20 rcx=0x3015a70020 rdx=0x3ffffff00
[nullpage]   rsi=0x1 rdi=0x20 rbp=0x7fe46d761280 rsp=0x7fe46d761230
```

`rbp` is `0x7fe46d761280` on the header and `0x7fe4603ff3a0` sixty bytes later; `rsp` the same;
`fs(rax)` reads `0x0` against a ucontext `rax` of `0x30016000`. The `[nullpage]` block is the
only correct part, because it read `PROSPER_GREGS(uc)` — this fault's own ucontext.

**A second arm makes the mechanism unambiguous** — two faults, and *both* backtraces belong to
`PoolThread 6`, one of them printed under the RHIThread's header:

```text
[prosper] WORKER-THREAD FAULT: sig=11 addr=0x30016000     rip=0x41174c389 rbp=0x7ff1a1e7c280
[prosper] WORKER-THREAD FAULT: sig=11 addr=0x2000e2495044 rip=0x411745348 rbp=0x7ff1927e9470
[fault] thread='PoolThread 6' ...
[fault] thread='RHIThread'    ...
[prosper]   guest fp-chain (rbp=0x7ff1927e9470):
[prosper]   guest fp-chain (rbp=0x7ff1927e9470):
[nullpage]   rax=0x0        rbx=0x11 rcx=0x4000       rdx=0x11          <- PoolThread 6 (from uc)
[nullpage]   rax=0x30016000 rbx=0x20 rcx=0x3015a70020 rdx=0x3ffffff00   <- RHIThread   (from uc)
```

The thread *name* is right on every line (`pthread_getname_np(pthread_self())`) while the numbers
beside it are not — the worst combination for a reader.

That mixture is also why those reports were self-contradictory: `insn bytes @rip` decoded to
`mov eax,[rbx]` with `rbx = 0x20`, which cannot fault at `0x30016000`. The bytes were fetched at
another thread's rip.

## Why it matters beyond the log

#1992 widened the `[faultobj]` probe set precisely so #1945's corrupted pointer would not be
missed. That probe builds its page list from `g_fault_addr, g_rax, g_rbx, g_rcx, g_rdx, g_rsi,
g_rdi, g_r8 … g_r15` (`:2203-2205`) — all globals. Under a concurrent fault it scans pages
derived from another thread's registers and still reports `probe-pages=N/M`. **A zero-hit result
from such an arm is void, not negative** — the exact failure mode #1992 exists to remove. The
same reaches the fp-chain, the ret-addr scan, the register-band scan, `[faultobj] rcx/rdx`, and
`nullpage_deep_dump(uc, g_fault_rip)`, which paired *this* fault's ucontext with *some* fault's
rip.

Recorded on #1945 so the affected arms there are re-read rather than re-derived.

## Approach

- **`prosper/src/host/fault_context.hpp`** (new, header-only): `FaultContext` plus
  `capture_fault_context(sig, tid, fault_addr, uc)`, a stack-local snapshot taken from the
  handler's own `siginfo`/`ucontext`. No TLS (guest `%fs`), no allocation, no libc — plain field
  copies, async-signal-safe. Portable across Linux `gregs[]` and Darwin `__ss` through the
  existing `PROSPER_GREGS`.
- **The fatal report now runs entirely off that snapshot** — 30 call sites, mechanical. The
  globals stay exactly as they are for `trap_detail()`, `record_fault()`, the hwbp ring and the
  armed-thread recovery path, which are single-threaded by construction.
- **One owner per report.** `claim_fault_report()` (same header) gates the dump: first arrival
  owns it; a thread that faults while a report is in flight prints one labelled
  `CONCURRENT WORKER-THREAD FAULT` line for its own fault, so the second fault is *named* rather
  than dropped, then waits **bounded** (400 x 5 ms) for the owner to finish before ending the
  process. Re-entry on the owning tid is allowed, so a fault raised inside the dump does not lock
  itself out of its own report.

  The bound is not decoration: the first version of this change had the loser call `_exit(90)`
  immediately, and the measured result was a report truncated to its header line and nothing
  else — worse than the bug. An *unbounded* wait is equally wrong, because the owner may die
  inside its own dump and a run that used to exit 90 would hang.

Two further honesty fixes in the same report:

- `nullpage_deep_dump(uc, rip)` now takes the snapshot's rip, so the instruction bytes belong to
  the registers printed beside them.
- `on-guest-TCB` assumed `rax` holds the TCB self-pointer, which only holds when the fault lands
  shortly after that load. With `rax` holding a corrupt free-list head it read an unrelated
  address and asserted `NO(host-%fs leak?)` for a thread with no `%fs` problem at all. It now
  prints `unknown (rax is not a TCB pointer here — no %fs conclusion follows)` when its own
  premise does not hold.

## Behavioral contract

- A fatal worker-thread report describes exactly one fault. Every register, address, instruction
  byte and derived probe page in it comes from that fault's `siginfo`/`ucontext`.
- At most one full dump per process. Every other faulting thread is named on one line.
- The process still exits 90, and `PROSPER_WORKER_PARK` still parks, on both paths.

**Unaffected on purpose:** the armed/main-thread recoverable path, `trap_detail()`,
`record_fault()`, `PROSPER_FAULTMEM`, the hwbp ring, and every non-fatal diagnostic — all still
read the globals, all still single-threaded by construction. Line formats are unchanged except
for the added `tid=` on the header and the two honesty changes above; `addr=%p` is preserved
deliberately so existing readers matching `addr=(nil)` still work.

## Risk

Signal-handler code. The new work is field copies, one `compare_exchange_strong`, and a bounded
`nanosleep` loop — all async-signal-safe. The largest change by volume is the 30 mechanical
`g_x` → `fc.x` substitutions in one function; a missed one would print a stale value, which is
the pre-fix behavior rather than a new failure.

## Also in this PR

`COMPATIBILITY.md`'s Crisis Core entry described a blocker that no longer exists: "prosper
declines one GPU submit it cannot order safely … all ninety guest threads park". Zero
`[agc] ordered DMA submit rejected` and zero `not executed` in **10 of 10** arms on current
master — #1987 narrowed that decline to real overlaps, and the parked-thread topology went with
it. The entry now records what actually happens: the engine reaches its frame loop (1,215 draws,
498 dispatches, 18 presents by t=5.4 s; the longest arm reached 2,330 draws and 49 presents) and
then dies a few seconds in, far too early for a title screen — 8 of the 8 arms that ran the
unmodified route to their own end hit the #1945 corruption, six as a prosper `WORKER-THREAD
FAULT` and two as the guest's own `FMallocBinned3 Attempt to realloc an unrecognized block`.
Per-arm evidence and a correction to my first census are on the tracker:
https://github.com/mattias800/prosper/issues/1894#issuecomment-5196354059 and
https://github.com/mattias800/prosper/issues/1894#issuecomment-5196516145

No rung change is claimed and no screenshot is published — the title is rung 1 and its frames
are a single flat colour.

## Review

Independently reviewed (APPROVE-WITH-COMMENTS); all five findings addressed and answered in
https://github.com/mattias800/prosper/pull/2030#issuecomment-5196948303 — the report gate is no
longer sticky (it was wrong under `PROSPER_WORKER_PARK`), the header's contract now matches its
caller, the wait timeout is no longer silent, `dump_fault_mem()` takes the snapshot too, and the
test gained a 16-thread contention arm with a verified mutation counter-arm.

## Verification (exact head `e49d290e`, rebased on current master, Linux, inside the `ps5ys` distrobox)

```bash
cmake -S prosper -B build-linux -G Ninja -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
cmake --build build-linux -j6            # 0 errors; gpu_replay + Vulkan execution tests present
cd build-linux && ctest --output-on-failure
```

**199/199 passed**, including the new `fault_context`. (One earlier full run had
`file_binary_roundtrip` fail on a native-filesystem chmod fixture; it passes in isolation and in
all four subsequent full runs — a shared-fixture flake with concurrent lanes, unrelated to this
change.)

**Live verification, same title and route.** Before, the report contradicted itself; after, every
`rbp`/`rsp`/`rax` in it agrees, and the decoded instruction is consistent with the registers and
the faulting address for the first time:

```text
[prosper] WORKER-THREAD FAULT: sig=11 addr=(nil) rip=0x41174c206 (image+0x174c206) rbp=0x7fca269a64d0 tid=2623907
[prosper]   insn bytes @rip: 48 8b 01 48 89 06 48 89  ret@[rsp]=0x41a53f328
[fault] thread='RenderThread 1' fs(rax)=0x301ac50000 ...
[prosper]   guest fp-chain (rbp=0x7fca269a64d0):
[prosper]   guest ret-addr scan (rsp=0x7fca269a64b0, 64 qwords):
[nullpage]   rax=0x301ac50000 rbx=0x20 rcx=0xff000000ff000000 rdx=0x20
[nullpage]   rsi=0x301ac50020 rdi=0x301ac50000 rbp=0x7fca269a64d0 rsp=0x7fca269a64b0
```

`48 8b 01` is `mov rax,[rcx]`; `rcx` is non-canonical, and a non-canonical dereference reports
`si_addr = 0`, hence `addr=(nil)`. Every value agrees.

A separate arm produced the concurrent case and shows the gate working with the full dump intact
behind it:

```text
[prosper] WORKER-THREAD FAULT: sig=11 addr=0x30016000 ... tid=2554120
[prosper] CONCURRENT WORKER-THREAD FAULT: tid=2553859 sig=11 addr=0x2000e24b8014 rip=0x411745348
          (image+0x1745348) — full dump suppressed, tid=2554120 is already reporting
```

Also re-verified in a **windowed `prosper-app`** run (`SDL_VIDEODRIVER=x11`) on the rebased head —
same fault, coherent report, `on-guest-TCB=yes`, and the concurrent thread correctly gated:

```text
[prosper] WORKER-THREAD FAULT: sig=11 addr=0x30016000 rip=image+0x174c206 tid=892362
[prosper] CONCURRENT WORKER-THREAD FAULT: tid=891922 sig=11 addr=(nil) rip=0x5c0004770 — full dump suppressed, tid=892362 is already reporting
[fault] thread='RenderThread 1' guest-fs=0x7f71bd0714c0 rax=0x301ac50000 on-guest-TCB=yes
```

That last line is the `on-guest-TCB` change earning its place: the same fault used to assert
`NO(host-%fs leak?)`, a false lead that had been in the #1945 record.

No snapshots run (batched policy; this change cannot affect rendering).

## Test

`prosper/tests/test_fault_context.cpp`, registered as ctest `fault_context`. It states plainly
what it does and does not prove: the interleave is a live multi-threaded property of the
*report*, evidenced above, and a single-threaded unit test cannot reproduce it. What the test
pins is the two mechanisms — that a capture reads only the ucontext it is handed and is a value a
later capture cannot alter, and that the report gate admits exactly one owner. Section 5 carries
a real mutation arm: remove the gate (the pre-fix state, where every faulting thread printed) and
its second and fourth assertions fail. I checked one candidate counter-arm for the snapshot half
and found it did **not** discriminate — a mutant that writes through a shared static and returns
a copy still passes — so that claim is not made.

Also filed from this investigation, not fixed here: **#2027** — a scheduled frame-bundle capture
on this title never finishes writing and freezes the frame loop, leaving a `.prgbundle.tmp`, so
the F9/offline-replay loop is currently unavailable for Crisis Core.

Fixes #2018
Refs #1894, #1945, #1226, #1992, #1982, #2027