### PR TITLE
docs(orchestration): one guard re-run is not enough — bracket the bisect at both ends

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -750,6 +750,24 @@ copy path, so a binding-miss run with the same environment is the control for a 
     converge confidently on an innocent commit — an answer-shaped non-answer, worse than no signal. One extra
     run protects the ~4 the bisect will spend. Guards that sample a route window are phase-sensitive, so this is
     not a hypothetical (see the `blue-prince-hall` / `terminator-boot` note above).
+  - **One re-run is NOT sufficient, and the first batch run proved it.** `messenger-scene` failed **twice
+    consecutively with a byte-identical signature** (`pixel_crc32=d21ae76a`, all 29 window frames identical),
+    which passes the re-run safeguard above and looks exactly like a real, deterministic regression. The bisect
+    then named #2003 — with an *attractive* mechanism, since Messenger's `param.json` declares
+    `userDefinedParam4 = 1` and #2003 changed that answer from 0 to 1. It was wrong: #2003 passes, and it
+    differs from the failing head only by a comment block, a docs file and a PNG. Re-running the named head
+    settled it — **FAIL, FAIL, PASS, PASS, PASS**. A flake can repeat, and a repeated flake plus a plausible
+    mechanism is the most convincing wrong answer this process can produce.
+    **So bracket the bisect at both ends:** (1) establish the **good endpoint** first — run the guard on the
+    pre-batch base and confirm it passes, or the whole bisect is measuring noise against noise; and (2)
+    **re-test the commit the bisect names**, several times, before believing it. Both cost one run each and
+    they are what separates a bisect result from a coincidence. Treat "the mechanism is plausible" as a reason
+    for *more* scepticism, not less — it is what stops you re-testing.
+  - **A bisect that skips environmentally loses resolution silently.** Two steps of the first batch recorded
+    `build FAILED -> skip` purely because podman's DB lock fails spuriously under many concurrent lanes, not
+    because the commit was unbuildable. `git bisect skip` widens the surviving range without saying that the
+    evidence is missing rather than negative. Wrap the build in a retry, and if a step still skips, say so in
+    the report rather than letting the narrowed range imply coverage it does not have.
   - Automate with `git bisect run` over the guard's exit code; every candidate builds standalone because each fix
     is its own merged commit. A batch can hold two independent regressions — bisect finds the earliest, so re-run
     after fixing. Expect to attribute a regression to a lane that has already finished: the orchestrator owns the


### PR DESCRIPTION
## What the first batched-guard run taught

The batched-guard policy (#1989) shipped with one safeguard: **re-run a failed guard on the same commit before spending a bisect**, because a flaky guard makes `git bisect` converge confidently on an innocent commit. The first exercise of that policy showed the safeguard is **necessary and not sufficient.**

`messenger-scene` failed **twice consecutively with a byte-identical signature** — `pixel_crc32=d21ae76a`, all 29 window frames identical, stall at the same point. That passes the re-run check and reads exactly like a deterministic regression.

The bisect then named **#2003**, and the mechanism was *attractive*: Messenger's `param.json` declares `userDefinedParam4 = 1`, and #2003 changed that answer from 0 to 1. A real behavioural change, in the right window, on the right title.

**It was wrong.** #2003 passes, and differs from the failing head only by a comment block, a docs file and a PNG — no functional code difference at all. Re-running the named head settled it: **FAIL, FAIL, PASS, PASS, PASS.**

## The rule this adds

A flake can repeat. And **a repeated flake plus a plausible mechanism is the most convincing wrong answer this process can produce** — precisely because the mechanism is what stops you re-testing.

So bracket the bisect at **both** ends:

1. **Establish the good endpoint first.** Run the guard on the pre-batch base and confirm it passes. Without that, the bisect is measuring noise against noise.
2. **Re-test the commit the bisect names**, several times, before believing it.

One run each. Together they are what separates a bisect *result* from a coincidence. The doc also says plainly: treat "the mechanism is plausible" as a reason for **more** scepticism, not less.

## A second failure mode from the same run

Two bisect steps recorded `build FAILED -> skip` purely because podman's DB lock fails spuriously under many concurrent lanes — not because the commit was unbuildable. **`git bisect skip` widens the surviving range without saying that the evidence is missing rather than negative**, so a skipped step quietly implies coverage the bisect does not have. Wrap the build in a retry; report any step that still skips.

## For the record: the batch itself was clean

All four reviewed guards pass on `c3614f51` over the ten-commit batch `278c9b1f..c3614f51`. **#1990** — the present-path rewrite, the highest-risk change in the batch — was exonerated **two independent ways**: the bisect put #1992 GOOD (clearing #1987/#1989/#1990/#1991), and inside the messenger failures themselves #1990's own instruments were **completely silent** (0 `PRESENT SOURCE EXTENT MISMATCH`, 0 `PUBLISH DROPPED`, 0 `PRESENT SOURCE DEMOTED`) while `frame_seq` climbed ~250 *fresh* publishes/sec.

The messenger flake is a **route** defect, not a renderer one — the failures show a correct, fully-composited name-entry screen whose field holds exactly ten `A`s, because the route's late recovery block has no confirm control. Filed as #2036, and explicitly **not** a rebaseline: the baseline is correct and the reached state is wrong. Dead Cells' single failure was capture throughput (281/290 shots) with content perfectly healthy — #2038.

## Affected / unaffected

- **Affected:** the documented bisect procedure inside the batched-guard policy.
- **Unaffected:** no code, no guard, no route, no baseline, no CI.

## Verification

Documentation only, one file, +18/−1. No table rows and no numbered instrument-trap entries, so the `Docs` gate's structural and gapless-numbering checks are untouched.

```
git diff --check origin/master..HEAD  -> rc=0
session trailers                      -> 0
```

Refs #1943, #2036, #2038