### PR TITLE
docs: say how a review verdict is expressed and detected

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -369,6 +369,24 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
   corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
   where required, and green required CI.
+  - **How a verdict is expressed and detected — this is mechanical, and getting it wrong has merged a rejected
+    PR.** The reviewer posts one or more **registered reviews** with `gh pr review <N> --comment --body '…'`,
+    each stating a verdict as a literal **`APPROVED`** or **`REJECTED`** in the body. The author reads the
+    comments, fixes what is raised, and merges only once a review says `APPROVED` **on the current head**.
+    Two mechanical facts make this the only workable scheme here, and both are invisible until they bite:
+    - **`gh pr comment` does NOT register as a review.** It creates an *issue* comment, fully visible on the PR
+      page and absent from `gh pr view --json reviews`. A verdict posted that way is invisible to anyone
+      checking programmatically. Several reviews were posted this way before it was noticed.
+    - **GitHub refuses `--approve` on a PR opened by the same account**, and every agent here operates as the
+      repository owner. So the review *state* is **always `COMMENTED`**, for approvals and rejections alike, and
+      `reviewDecision` stays empty. **The GitHub review state carries no verdict in this repository. Never gate
+      on it, and never treat "a review exists" as "a review approved".** A merge daemon that counted
+      `reviews > 0` merged #2026 with two blocking findings outstanding; the revert is #2044. The verdict lives
+      in the prose, so **a human or an agent must read it** — this specific check cannot be automated here.
+    - Corollary for the merge step: **a rebase or a new push detaches every review from head.** `reviews` still
+      reports rows, with a `commit_id` that is no longer on the branch. Compare each review's `commit_id`
+      against the current head; if it is stale, establish by **content** (`git diff <reviewed-sha> <head>`)
+      whether the approval still applies rather than assuming in either direction.
 - **Unpublished desktop-app parity is not a merge requirement.** A Linux-, Windows-, or macOS-specific app
   improvement may merge without matching work in every other frontend unless the issue explicitly promises
   parity or a shared public contract requires it. Unaffected platforms must still retain existing behavior and


### PR DESCRIPTION
## The gap

`CLAUDE.md` required *"reviewer approval where required"* but never said **how an approval is expressed, or how a merge agent detects one.** That gap merged a rejected PR today.

Two mechanical facts make the obvious readings wrong, and both are invisible until they bite:

- **`gh pr comment` does NOT register as a review.** It creates an *issue* comment — fully visible on the PR page, and absent from `gh pr view --json reviews`. Several verdicts were posted that way today before it was noticed.
- **GitHub refuses `--approve` on a PR opened by the same account**, and every agent here operates as the repository owner. So the review **state is always `COMMENTED`**, for approvals and rejections alike, and `reviewDecision` stays empty.

So an agent reading "reviewer approval where required" can quite reasonably implement it as **"a review exists"** — which is exactly what a background merge daemon did, merging **#2026 with two blocking findings outstanding** (it silently made `--require-composited-frame` vacuous on two guards, and its "not all bytes zero" guard could publish stale bytes over a good retained frame). Revert: **#2044**.

## The scheme this states

- The reviewer posts one or more **registered reviews** with `gh pr review <N> --comment --body '…'`, each carrying a literal **`APPROVED`** or **`REJECTED`** in the body text.
- The author reads the comments, fixes what is raised, and merges **only once a review says `APPROVED` on the current head.**
- **The verdict lives in prose and must be read.** This particular check *cannot* be automated in this repository, and pretending otherwise is precisely what went wrong. "A review exists" is not "a review approved".

## The corollary the merge step needs

**A rebase or a new push detaches every review from head** while `reviews` still reports rows — with a `commit_id` no longer on the branch. Compare each review's `commit_id` against the current head; if stale, establish by **content** (`git diff <reviewed-sha> <head>`) whether the approval still applies, rather than assuming in either direction.

## Affected / unaffected

- **Affected:** documentation of the review protocol only.
- **Unaffected:** no code, no test, no CI, and no change to *when* review is required — only to how its outcome is stated and read.

## Verification

Documentation only, one file, +19 lines. No tables and no numbered instrument-trap entries, so the `Docs` gate's structural and gapless-numbering checks are untouched.

```
git diff --check origin/master..HEAD  -> rc=0
session trailers                      -> 0
```

Refs #2026, #2044