### PR TITLE
tools(nid_gate_scan): --all-nids sweeps every import at once — and what it plus a current-master re-run measured on Sonic Origins

### DIFF
--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -152,6 +152,9 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 | The `dlc3`-prefixed CRI wave-bank APR misses leave the Atom banks without waveform data (the silent-audio candidate, #1993) | **Falsified as the silent-audio cause — the bank loads on the base-content-root retry.** On `c3614f51` the pattern is exact and repeats for every bank: `[apr] resolve MISS /app0/dlc3/sound/X.awb`, then immediately `[apr] content-root fallback /app0/sound/X.awb -> /app0/raw/sound/X.awb` and `[apr] resolve /app0/sound/X.awb -> id=12 size=28352512`. **Seven** banks do this, not the four #1993 recorded (`STH1_music`, `STH2_music`, `SCD_music`, `HITE_music`, `HITE_missions`, `Music03_S3K`, `Music09_Museum`). **Why the guest asks the DLC prefix first is NOT settled here**, and the difference matters for where a fix would belong: an add-content override search and #1993's own competing reading — a single engine-global content root that the DLC mount overwrote — both produce this log. The one detail that discriminates leans toward the latter: all three repeats target the same `dlc3` prefix while **four** DLC mount, whereas a genuine override search would probe each mount once. It does not matter for the audio path, because the bank resolves either way, so do not add a `/app0/dlc*/` -> `/app0/raw/` alias on this evidence. The silent AudioOut2 port has another cause. | #1905, #1993, this doc |
 | The absent `raw/ui/rpl_texture/ui_title_nocopy.dds` request says something about the dump | **Falsified — it was prosper's own wrong answer, and it is gone.** The title derives its **region** from the app's own declaration at `eboot+0x51230c`: it calls `sceAppContentAppParamGetInt(USER_DEFINED_PARAM_1)` into a pre-zeroed slot and branches `2 -> "EU"`, `1 -> "US"`, anything else -> `"JP"`, with JP additionally setting a flag the other two clear. That branch mapping is **read off the disassembly** at `eboot+0x51231c..0x512357` (the two-character codes are the immediates `0x5545`/`0x5355`/`0x504a`), not measured. This application declares `userDefinedParam1: 2` and `contentId EP0177-PPSA05325_00-…`, so the correct answer is **EU**, and that is what the handler now writes — measured directly rather than inferred, by breaking on `prosper::s_appcontent_int` and reading its out-slot after the return: `paramId=1 ret=0 value=2` (the neighbouring `sceSystemServiceParamGetInt(1)` reads `value=1`, en-US). Before #2003 `s_appcontent_int` was `*(int32_t*)PW(a1) = (a0 == 0) ? 3 : 0`, so this same call wrote `0`, which the branch above maps to **JP** — i.e. every earlier Sonic arm in this document is best read as having run the title as Japanese. That last step is an inference from the disassembly plus the disappearance of the JP-only request, not an A/B against the old binary. `ui_title_nocopy` / `ui_title_cero` / `ui_titile_healthy` are the JP legal-and-rating set (`ui_title_pegi` is the EU one). On current master the request is gone and `ui_startup.pac` is the only remaining UI miss. Nothing about the dump changed; prosper's answer did. | #1905, #2003, this doc |
 | The absent `raw/ui/ui_startup.pac` parks the resource loader (the "handled ENOENT is still a stalled state machine" reading) | **Falsified at the consumer, not just at the resolver.** The widened `apr_miss_callsite` annotation names the frame: `ra4=eboot+0x990235`. `eboot+0x98fa80` is a thin `exists()` predicate over the APR resolve (`call 0xf0600; test eax,eax; sete al`), reached as a virtual call `call QWORD PTR [rax+0x88]` at `eboot+0x99022f`. The **not-found** branch at `eboot+0x990239` releases its temporaries and jumps to `eboot+0x990120`, which is a loop head: `add r14,0x18; cmp r12,r14; je <exit>`. So a missing entry advances the cursor and the loop continues — the miss is skipped by construction, with no error path and no wait. Whether the *startup scene* later needs what that package would have contained is a separate question this does not answer. | #1905, this doc |
+| Sonic skipped initialization it still needed because `sceSysmoduleIsLoaded` used to claim every module was loaded (#2021/#2002), and the CRI Mana group is parked for that reason | **Falsified.** Sonic does import `fMP5NHUOaMk` and does query it — a `beeff2ab` boot logs `[sysmodule] IsLoaded -> UNLOADED` for ids `0x115`, `0x105` and `0x110` — but all **five** static call sites are the benign `if (not loaded) { LoadModule(id); mark-that-we-own-it; }` idiom, verified by disassembly (`eboot+0x8c4f0e`, `+0x9273e5`, `+0x92740f`, and the two finalize-side sites at `+0x927699`/`+0x9276c5`). The load then succeeds, so the only state #2021 changes is the ownership bit the object clears at finalize (`or BYTE [rbx+0x150],1` / `,2`; `or BYTE [r14+0x80],0x80`). The whole-boot result is unchanged: same 40-path resolved set, no `.usm`, no `.rsdk`, 10/10 black samples. | #1905, #2021, this doc |
+| An unsupported shader op, storage format or dispatch is silently skipped, and that is what collapses the composite | **Falsified on the live path, with a positive control.** Two 18 s live-renderer arms differing only in `PROSPER_DBG` match **zero** lines for `recompile-reject` (covering `[recompile-reject]`, `[cfg-…]` and `[exec-…]`) and zero for the literal pattern **`\[compute\] skip`** — the emitter writes `skip`, not `skipped` (`src/gpu/gpu_executor.cpp`: `skip unregistered/unreadable`, `skip unsupported`, `skip invalid descriptor contract`), so a grep for `skipped` would have returned zero by construction. The recompiler zero is a measurement rather than a void window because the `DBG=1` arm gains two prefixes the `DBG=0` arm does not have at all — `[compute-cfg]` ×6 and `[graphics-cfg]` ×6, emitted from the same translation unit under the same gate — and no line in either arm reports a non-zero `cf_rejected`. The three `[compute] skip` sites are **not** `DBG`-gated, so their zero needs no control. Note the twelve CFG lines are the count of *branching* shaders (they are also conditioned on `cfg_branches != 0`), so they are the channel control; the zero rejects carry the conclusion. | #1905, this doc |
+| The 22 draws per flip are what survives prosper dropping the rest of a larger frame at *translation* | **Falsified.** `state.draws` is filled by the PM4 decoder (`src/gpu/command_processor.cpp`) and printed by `progress_heartbeat` (`src/hle/hle_agc.cpp`), so the counter is pre-translation by construction; a `PROSPER_NO_COMPUTE=1` arm — where nothing is translated and therefore nothing can be rejected — reports the identical per-flip figures (66,988 draws and 42,734 dispatches over 3,044 flips at t=50 s: 22.01 and 14.04), which is the consistency check on that reading rather than its proof. **Scope it exactly:** this closes *translation* loss, not *decode* loss. A draw inside a PM4 packet prosper never decodes is invisible to this counter too, and the `walk=` field that would bound it is on the `[agc] <who> #N` form, not the `[agc] SubmitDcb #N: %u dwords -> %zu packets applied` form this title takes (266 of 266 lines in a 10 s `PROSPER_GFXLOG` arm). That bound is still open. | #1905, this doc |
 
 ## Sonic Origins dump audit
 
@@ -631,3 +634,84 @@ see whether it has a no-package path; (3) break on the writer of the movie index
 state ever selects one. **Do not fabricate the package, alias another `.pac` to it, or force the
 `exists()` predicate true** — that would model a producer the guest never had and could not be
 progression evidence even if it changed the screen.
+### Current-master re-run and the boot-gate bound (2026-08-06, master `beeff2ab`)
+
+**#2021** (`sceSysmoduleIsLoaded` answers from prosper's own load history) and **#2031** (the
+render-target-0 blend key on every SDK version) landed after the section above, and both touch
+surfaces this title uses, so the baseline was re-measured rather than assumed. **Neither moved
+anything.** A direct headless `screenshot` arm at native 3840x2160 with `PROSPER_RENDER_SCALE=1
+PROSPER_RENDER_EVERY=1` and `scripts/sonic/long-input-probe.pad`, 10 samples over 120 s, reports
+`source-distinct=10 pixel-distinct=1`, every sample `crc=666f7b3f`. A `PROSPER_NO_COMPUTE=1` arm over
+the same route resolves the same 40 unique paths, opens no `.usm` and no `.rsdk`, and settles into
+the same 22 draws / 14 dispatches per flip. Sonic Origins remains **rung 0**; nothing here is a
+visual claim.
+
+Scope that precisely, because the neighbouring section is easy to contradict: **#2003 is not part of
+this arm's claim.** `c3614f51` — the master the census above ran on — already contained it, and that
+section records what it *did* change here (the region flipped JP→EU and the
+`ui_title_nocopy.dds` request disappeared). "Neither moved anything" is about #2021 and #2031 only.
+
+`#1990`'s wall still fires on this title on current master — `[rtt] PRESENT SOURCE EXTENT MISMATCH …
+px_front=none px_vo=none px_last=none, offered 0 bytes; serving the retained frame instead (published
+so far: fresh=1 retained=465)` — which is the same reading as before: selection has nothing to offer,
+and every target it could offer is black anyway.
+
+**Bounding the "registered-but-mismodelled value" candidate statically.** That candidate is invisible
+to every absence check by construction (the call happens; the answer is wrong), and a runtime
+return-value histogram says what prosper returned, not whether the guest looked. `nid_gate_scan.py`
+gained an `--all-nids` mode for exactly this question — it classifies **every** import of a module in
+one pass, so the call sites that cannot be affected by any answer are struck off before a boot:
+
+```bash
+python3 tools/re/nid_gate_scan.py <DUMP_ROOT>/PPSA05325-app0/eboot.bin \
+    --all-nids --names ../PS5-3.20_Libs
+```
+
+Of 813 NID-shaped dynsym entries, 536 imports are actually called. The tool's own summary states the
+split, and it is deliberately a **three**-way one, not two:
+
+```text
+# eboot.bin: 536 imported NIDs are called; 247 shown at --min-gated=1
+#   247 gated, 157 ignored-only (cannot matter), 132 unresolved (>=1 forward/undecodable window
+#   — NOT cleared, read by hand)
+#   site buckets: alu-gate=125 const=1 forward=3445 ignored=14432 nonzero=3440 other-cmp=166
+#                 undecodable=2699
+```
+
+**Not-gated is not the same as cleared.** Only the **157** `ignored`-only rows are struck off; the
+**132** unresolved rows carry at least one `forward` window (the result left the window still live —
+returned, spilled or tail-jumped, so the gate is in a caller) or at least one `undecodable` one, and
+**2,699 of the 24,308 windows — 11.1% — are undecodable**, which is a void sample rather than a
+negative. Anyone narrowing the candidate list from this table must work through those 132 by hand
+rather than treat the 247 as the whole search space. Two further properties matter more than the
+numbers:
+
+- It is a **static upper bound on what can matter**, not a list of what runs. Cross it with the boot
+  census (`hle_calls --launch --values`) before treating any row as live: the
+  `PROSPER_PROGRESS_UNIMPL` table reads `(0 distinct unimplemented functions)` on this title, so every
+  row whose prosper handler is *unregistered* is called by code Sonic's boot never reaches.
+- The gated rows that prosper answers with a **shared** stub are the residue worth reading by hand,
+  because one prosper symbol can cover several Sony entry points and collapses into a single `0x0`
+  row in any runtime histogram. **This residue is open, and it is larger than the two rows checked
+  below.** Crossing the 247 gated rows against prosper's registration tables, **41** are answered by
+  a handler registered for more than one Sony name — `s_ok` covers 15 entry points and `k_attr_noop`
+  covers 20. Those 41 split **24 `libkernel` / 4 `libSceLibcInternal` / 13 across the eight service
+  libraries** (`libSceNpUniversalDataSystem` 3, `libSceErrorDialog` 3, `libSceNpManager` 2, and one
+  each from `libSceMsgDialog`, `libSceCommonDialog`, `libSceLoginDialog`, `libScePad`, `libSceRtc`).
+  Quote the split rather than a "non-libc" subtotal: whether `libkernel` counts as libc is a
+  definition, not a measurement, and it is the whole difference between the 37 and 13 that two
+  readings of the same 41 produce. Only the **`s_ok`** intersection was worked through
+  here, and it is exactly two: `sceCommonDialogIsUsed`, which the census above measured at zero
+  calls, and `sceLoginDialogInitialize` at `eboot+0x9b5d0e`, which is the same init-and-record idiom
+  as the sysmodule sites (`test eax,eax` → `or BYTE PTR [rbx+0x6a8],0x2`) and so cannot change what
+  the frontend renders whichever way it is answered. **The other 39 have not been read.** A
+  dispatcher-authoritative NID→handler→arity dump would make that cross cheap and drift-proof for
+  every future title; tracked as #2070.
+
+Verified against a known answer before use: in single-NID mode the sweep reproduces the
+`sceSysmoduleIsLoaded` result byte-for-byte after the refactor (`const=1 nonzero=4`, the same five
+sites), and directory-mode output over two other dumps `diff`s clean against the pre-refactor tool.
+The `--all-nids` figures above were first produced by a throwaway driver written against the same
+classifier and then reproduced by the committed mode; that is a re-derivation of the *enumeration*,
+not an independent implementation of the classifier, so it constrains the symbol walk and not the
+bucket rules — those are covered by `test_nid_gate_scan.py`.

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -125,6 +125,57 @@ Requires **GNU binutils** `objdump`: it disassembles a raw blob with `-b binary`
 disassembly rather than trusting the binary's presence, accepts Homebrew's `gobjdump`, and honours
 `$OBJDUMP`. The ctest skips cleanly when no capable objdump exists.
 
+### `--all-nids` — which Sony answers does this title depend on *at all*?
+
+`--nid` asks about one function. `--all-nids` inverts the question and classifies **every** import in
+one pass, which is the bound a *registered-but-mismodelled return value* investigation needs and
+cannot get any other way. An absence check (the `PROSPER_PROGRESS_UNIMPL` table) cannot see a handler
+that is registered and answers wrongly — the call happens, so nothing is missing. A runtime
+return-value histogram says what prosper returned, not whether the guest looked. This says which call
+sites *can* be affected by an answer, so the ones that cannot are struck off before any boot.
+
+```bash
+python3 tools/re/nid_gate_scan.py <DUMP_ROOT>/PPSA05325-app0/eboot.bin \
+    --all-nids --names ../PS5-3.20_Libs --min-gated 1
+```
+
+Rows sort by gated call sites descending, so the head of the table is libc, and the trailing `#`
+block is the part to read first:
+
+```text
+Ovb2dSJOAuE  strcmp                libSceLibcInternal  sites=981 gated=973 forward=7 nonzero=972 …
+…
+fMP5NHUOaMk  sceSysmoduleIsLoaded  libSceSysmodule     sites=5   gated=5   const=1 nonzero=4
+…
+# <path>: 536 imported NIDs are called; 247 shown at --min-gated=1
+#   247 gated, 157 ignored-only (cannot matter), 132 unresolved (>=1 forward/undecodable window
+#   — NOT cleared, read by hand)
+#   site buckets: alu-gate=125 const=1 forward=3445 ignored=14432 nonzero=3440 other-cmp=166
+#                 undecodable=2699
+```
+
+**Not-gated is not the same as cleared, and the summary says so on purpose.** `ignored` is the only
+bucket that means an answer cannot matter at that site; `forward` explicitly needs a look by hand and
+`undecodable` is a void sample. A two-way "called / gated" split invites the reading that everything
+below the cut is struck off — here that would wrongly retire 132 rows, and 11.1% of all windows are
+undecodable. The three-way split plus the site-bucket totals make it impossible to mistake the table
+for a clean partition.
+
+`--names` points at the gitignored PS5 firmware `genstub.py` library dump and is **symbolication
+only** — an unlabelled NID is still scanned and still reported, so a missing dump costs names, never
+coverage; a directory with no `sprx_dlsym` lines is rejected rather than silently producing an
+all-`?` table. `--min-gated N` hides imports with fewer than N gated sites; the summary always states
+the unfiltered total, so a filtered table cannot be mistaken for the whole one either.
+
+The enumerator accepts a dynsym name only when exactly 11 characters precede the first `#`, searching
+no further than the name's own NUL, because every relaxation of that rule fails silently — a C++
+mangled name pulled in as a phantom "import" reports zero call sites and reads as a clean negative, a
+dropped real import shrinks a census whose whole purpose is exhaustiveness, and an unclamped `#`
+search lets a name with no `#` borrow the next strtab string's. `test_nid_gate_scan.py` pins all
+three with a synthetic symbol table. Note the rule does **not** separate imports from exports (PS5
+exports carry the same shape) — what removes exports is the JMPREL/call-site filter, since an export
+has no jump slot bound to it.
+
 ## `pak_index.py` — turn a UE4 `.pak` byte offset into an asset name
 
 A UE4 title on PS5 streams content through the Ampr/APR async-read path, and `PROSPER_FILELOG=1`

--- a/prosper/tools/re/nid_gate_scan.py
+++ b/prosper/tools/re/nid_gate_scan.py
@@ -22,12 +22,28 @@ Buckets (see `classify_window`):
 
 Usage:
     nid_gate_scan.py <module|app0-dir> --nid <NID> [--const 0x805a1001] [--window 48] [-v]
+    nid_gate_scan.py <module|app0-dir> --all-nids [--names <PS5-libs-dir>] [--min-gated N] [-v]
 
 `<module>` is a SELF/PRX/eboot.bin (flattened in memory — no temp files) or an already-flat ELF.
 Given a directory, every `eboot.bin` and `*.prx`/`*.sprx` under it is scanned.
 
 Example — the sysmodule gate (#2002); `0x805A1001` is SCE_SYSMODULE_ERROR_UNLOADED:
     nid_gate_scan.py testdata/PPSA04263-app0 --nid fMP5NHUOaMk --const 0x805a1001
+
+`--all-nids` inverts the question: instead of "who branches on THIS value?", it answers **"which
+Sony answers does this title depend on at all?"** — every import, classified, in one pass. That is
+the bound a *registered-but-mismodelled return value* investigation needs and cannot get any other
+way. An absence check (the unimplemented-NID table) cannot see a handler that is registered and
+answers wrongly; a runtime return-value histogram says what prosper returned but not whether the
+guest looked. This says which call sites can be affected by an answer at all, so the ones that
+cannot are removed from the search before a single boot:
+
+    nid_gate_scan.py <DUMP_ROOT>/PPSA05325-app0/eboot.bin --all-nids --names ../PS5-3.20_Libs
+
+Read the buckets the same way as in single-NID mode, and read `ignored` as the load-bearing one:
+it is the only bucket that says an answer *cannot* matter at that site. `--names` is symbolication
+only — an unknown NID is still scanned and still reported, so a missing library dump costs labels,
+never coverage.
 """
 import argparse
 import os
@@ -118,8 +134,13 @@ class Image:
                 return self.tags[n]
         return None
 
-    def symbol_index(self, nid):
-        """Index of the dynsym entry whose NID is `nid` ("<NID>#<lib>#<mod>"), or None."""
+    def dynsym(self):
+        """(symtab file offset, strtab file offset, symbol count, entry size), or None.
+
+        Shared by the single-NID lookup and the whole-table sweep so both agree on how the table
+        is bounded — the bounding rule below is the one thing that can silently turn a present
+        import into a reported absence.
+        """
         symtab = self.tag(6, 0x61000039)
         strtab = self.tag(5, 0x61000035)
         if symtab is None or strtab is None:
@@ -138,6 +159,14 @@ class Image:
             # Falling through with n=0 would report "no-import" for a module that may well import
             # the NID — a false negative that reads exactly like a real absence. Fail loudly.
             raise ValueError("cannot bound symtab: no DT_SCE_SYMTABSZ and strtab precedes symtab")
+        return so, to, n, syment
+
+    def symbol_index(self, nid):
+        """Index of the dynsym entry whose NID is `nid` ("<NID>#<lib>#<mod>"), or None."""
+        d = self.dynsym()
+        if d is None:
+            return None
+        so, to, n, syment = d
         want = nid.encode() + b"#"
         for i in range(n):
             base = so + i * syment
@@ -147,6 +176,43 @@ class Image:
             if self.raw[to + st_name:to + st_name + len(want)] == want:
                 return i
         return None
+
+    def imported_nids(self):
+        """Every `<NID>#<lib>#<mod>` dynsym entry, as [(nid, symbol index)] in table order.
+
+        A PS5 dynsym name is the 11-character base64 NID, `#`, the import-library id, `#`, the
+        module id. Requiring exactly 11 characters before the first `#` is what keeps ordinary
+        C++ mangled names out — and the rule has to be *exactly* 11, not "contains a `#`", because
+        both looser and stricter versions fail silently: a mangled name admitted as a phantom
+        import reports zero call sites and reads as a clean negative, while a dropped real import
+        shrinks a census whose whole point is exhaustiveness.
+
+        The `#` search is clamped to the name's own NUL. Without that clamp a name with no `#` at
+        all can borrow the *next* strtab string's, and if that one happened to land at distance 11
+        the entry would be admitted — an over-report with nothing about it looking wrong.
+
+        This does NOT distinguish an import from an export: a module's own exports carry the same
+        shape. What removes them downstream is the JMPREL/call-site filter, since an export has no
+        jump slot bound to it. Duplicates are possible in principle — one NID can appear under two
+        library ids — so the caller gets every row rather than a dict that would silently keep one.
+        """
+        d = self.dynsym()
+        if d is None:
+            return []
+        so, to, n, syment = d
+        out = []
+        for i in range(n):
+            base = so + i * syment
+            if base + syment > len(self.raw):
+                break
+            st_name = struct.unpack_from("<I", self.raw, base)[0]
+            start = to + st_name
+            stop = self.raw.find(b"\0", start)
+            end = self.raw.find(b"#", start, stop if stop >= 0 else None)
+            if end < 0 or end - start != 11:
+                continue
+            out.append((self.raw[start:end].decode("latin1"), i))
+        return out
 
     def jump_slots(self, sym_index):
         """JMPREL jump-slot VAs bound to `sym_index` (usually exactly one)."""
@@ -404,6 +470,33 @@ def stub_entry_points(img, site):
     return entries
 
 
+def call_sites(img, xref, sym_index):
+    """Every (site VA, kind) that reaches the import bound to `sym_index`."""
+    sites = []
+    for slot in img.jump_slots(sym_index):
+        for site, kind in xref.get(slot, []):
+            if kind == "jmp*":
+                for e in stub_entry_points(img, site):
+                    sites += [(s, "call") for s, k in xref.get(e, []) if k == "call"]
+            elif kind == "call*":                            # direct indirect call through the slot
+                sites.append((site, "call*"))
+    return sorted(set(sites))
+
+
+def classify_sites(img, sites, const, window):
+    """(census, details) for a set of call sites. `details` rows are (site, bucket, ev, arg0)."""
+    census, details = {}, []
+    for site, kind in sites:
+        after = site + (6 if kind == "call*" else 5)
+        fo = img.foff(after)
+        if fo is None:
+            continue
+        bucket, ev = classify_window(disasm(img.raw[fo:fo + window], after), const)
+        census[bucket] = census.get(bucket, 0) + 1
+        details.append((site, bucket, ev, arg0_before(img.raw, img.foff(site))))
+    return census, details
+
+
 def scan_module(path, nid, const, window, verbose=False):
     """Returns (status, detail) where status is 'no-import', 'no-slot', or a bucket census dict."""
     try:
@@ -413,27 +506,9 @@ def scan_module(path, nid, const, window, verbose=False):
     idx = img.symbol_index(nid)
     if idx is None:
         return "no-import", {}
-    slots = img.jump_slots(idx)
-    if not slots:
+    if not img.jump_slots(idx):
         return "import-no-slot", {}
-    xref = scan_code(img)
-    sites = []
-    for slot in slots:
-        for site, kind in xref.get(slot, []):
-            if kind == "jmp*":
-                for e in stub_entry_points(img, site):
-                    sites += [(s, "call") for s, k in xref.get(e, []) if k == "call"]
-            elif kind == "call*":                            # direct indirect call through the slot
-                sites.append((site, "call*"))
-    census, details = {}, []
-    for site, kind in sorted(set(sites)):
-        after = site + (6 if kind == "call*" else 5)
-        fo = img.foff(after)
-        if fo is None:
-            continue
-        bucket, ev = classify_window(disasm(img.raw[fo:fo + window], after), const)
-        census[bucket] = census.get(bucket, 0) + 1
-        details.append((site, bucket, ev, arg0_before(img.raw, img.foff(site))))
+    census, details = classify_sites(img, call_sites(img, scan_code(img), idx), const, window)
     if verbose:
         for site, bucket, ev, arg in details:
             argtxt = ("id=%#x%s" % (arg[0], "" if arg[1] else "?")) if arg else "id=?"
@@ -441,14 +516,115 @@ def scan_module(path, nid, const, window, verbose=False):
     return "ok", census
 
 
+GATED = ("const", "nonzero", "other-cmp", "alu-gate")
+
+
+def load_nid_names(libs_dir):
+    """{NID: (function name, library)} from a PS5 firmware `genstub.py` library dump.
+
+    Each generated `libSceXxx.c` binds its imports with
+    `sprx_dlsym(__handle, "<NID>", &__ptr_<funcName>)`, so the file is a NID<->name table. This
+    is symbolication only: a NID that is absent stays a NID and is still scanned and reported, so
+    a missing or partial dump degrades the *labels* and never the census.
+    """
+    names = {}
+    pat = re.compile(r'sprx_dlsym\(__handle,\s*"([^"]+)",\s*&__ptr_([A-Za-z0-9_]+)\)')
+    try:
+        entries = sorted(os.listdir(libs_dir))
+    except OSError as e:
+        raise SystemExit("--names %s: %s" % (libs_dir, e))
+    for fn in entries:
+        if not fn.endswith(".c"):
+            continue
+        try:
+            with open(os.path.join(libs_dir, fn), errors="ignore") as f:
+                txt = f.read()
+        except OSError:
+            continue
+        for nid, name in pat.findall(txt):
+            names.setdefault(nid, (name, fn[:-2]))
+    if not names:
+        raise SystemExit("--names %s: no `sprx_dlsym(...)` lines — not a genstub library dump" % libs_dir)
+    return names
+
+
+def sweep_module(path, const, window, names, min_gated, verbose):
+    """Classify EVERY imported NID of one module. Prints a row per import that has call sites."""
+    img = Image(flatten(path))
+    if img.dynsym() is None:
+        # Returning an empty sweep here would print "0 imported NIDs are called", which reads as a
+        # module that imports nothing rather than as a table this tool could not locate. Same
+        # fail-loudly rule as the symtab bound in dynsym().
+        raise ValueError("no dynamic symbol/string table (DT_SYMTAB/DT_STRTAB): cannot enumerate imports")
+    xref = scan_code(img)                                    # once for the module, not once per NID
+    rows = []
+    for nid, idx in img.imported_nids():
+        sites = call_sites(img, xref, idx)
+        if not sites:
+            continue                                         # imported, never called: no gate here
+        census, details = classify_sites(img, sites, const, window)
+        gated = sum(census.get(b, 0) for b in GATED)
+        rows.append((gated, len(sites), nid, census, details))
+    rows.sort(key=lambda r: (-r[0], -r[1], r[2]))
+    shown = 0
+    for gated, nsites, nid, census, details in rows:
+        if gated < min_gated:
+            continue
+        shown += 1
+        name, lib = names.get(nid, ("", ""))
+        print("%-12s %-52s %-28s sites=%-5d gated=%-5d %s" % (
+            nid, name or "?", lib or "?", nsites, gated,
+            " ".join("%s=%d" % kv for kv in sorted(census.items()))))
+        if verbose:
+            for site, bucket, ev, arg in details:
+                if bucket not in GATED:
+                    continue
+                argtxt = ("id=%#x%s" % (arg[0], "" if arg[1] else "?")) if arg else "id=?"
+                print("    call at %#x %-10s -> %-9s %s %s" % (site, argtxt, bucket, ev[1], ev[2]))
+    return rows, shown
+
+
+def sweep_summary(label, rows, shown, min_gated):
+    """The trailing `#` block: what was hidden, and why the table is not a clean partition.
+
+    A row that is not gated is NOT automatically a row that cannot matter. `forward` means the
+    result left the window still live and needs a look by hand, and `undecodable` is a void sample.
+    Reporting only "N called, M shown" invites exactly the wrong reading — that everything below the
+    cut is cleared — which is the expensive direction in a document whose whole purpose is to stop
+    the next reader re-deriving a dead answer. So state the three-way split explicitly, and print
+    the site-level bucket totals so the undecodable share is impossible to miss.
+    """
+    gated_rows = sum(1 for g, _n, _i, _c, _d in rows if g)
+    ignored_only = sum(1 for g, _n, _i, c, _d in rows if not g and set(c) <= {"ignored"})
+    unresolved = len(rows) - gated_rows - ignored_only
+    totals = {}
+    for _g, _n, _i, c, _d in rows:
+        for k, v in c.items():
+            totals[k] = totals.get(k, 0) + v
+    print("# %s: %d imported NIDs are called; %d shown at --min-gated=%d"
+          % (label, len(rows), shown, min_gated))
+    print("#   %d gated, %d ignored-only (cannot matter), %d unresolved "
+          "(>=1 forward/undecodable window — NOT cleared, read by hand)"
+          % (gated_rows, ignored_only, unresolved))
+    print("#   site buckets: %s" % " ".join("%s=%d" % kv for kv in sorted(totals.items())))
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("target", help="SELF/PRX/ELF module, or an app0 directory")
-    ap.add_argument("--nid", required=True)
+    ap.add_argument("--nid", help="one NID to scan; omit and pass --all-nids to sweep every import")
+    ap.add_argument("--all-nids", action="store_true",
+                    help="classify EVERY imported NID of the module in one pass")
+    ap.add_argument("--names", metavar="DIR",
+                    help="PS5 firmware genstub library dump, to label NIDs with function names")
+    ap.add_argument("--min-gated", type=int, default=1,
+                    help="with --all-nids, hide imports with fewer than N gated call sites (default 1)")
     ap.add_argument("--const", default="0x805a1001")
     ap.add_argument("--window", type=lambda s: int(s, 0), default=48)
     ap.add_argument("-v", "--verbose", action="store_true")
     a = ap.parse_args()
+    if bool(a.nid) == bool(a.all_nids):
+        ap.error("pass exactly one of --nid <NID> or --all-nids")
     const = int(a.const, 0)
 
     targets = []
@@ -459,6 +635,21 @@ def main():
                     targets.append(os.path.join(root, f))
     else:
         targets = [a.target]
+
+    names = load_nid_names(a.names) if a.names else {}
+
+    if a.all_nids:
+        for t in sorted(targets):
+            label = os.path.relpath(t, a.target) if os.path.isdir(a.target) else t
+            try:
+                rows, shown = sweep_module(t, const, a.window, names, a.min_gated, a.verbose)
+            except Exception as e:                           # noqa: BLE001 — report, keep going
+                # Loud and per module: a directory sweep must not lose one module's failure in the
+                # noise of the others', and this is where dynsym()'s deliberate raises surface.
+                print("# %s: SCAN FAILED (no census for this module): %s" % (label, e))
+                continue
+            sweep_summary(label, rows, shown, a.min_gated)
+        return 0
 
     total = {}
     for t in sorted(targets):

--- a/prosper/tools/re/test_nid_gate_scan.py
+++ b/prosper/tools/re/test_nid_gate_scan.py
@@ -16,6 +16,7 @@ for bugs an independent review found after the first table had already been publ
 Run directly, or via ctest as `re_nid_gate_classifier`.
 """
 import os
+import struct
 import subprocess
 import sys
 
@@ -107,6 +108,45 @@ def objdump_free_checks():
     #  bf b4 00 00 00 90       mov edi,0xb4 ; nop  -> recovered but not exact
     check("arg0-not-exact", G.arg0_before(b"\xbf\xb4\x00\x00\x00\x90", 6), (0xB4, False))
     check("arg0-absent", G.arg0_before(b"\x90\x90\x90\x90", 4), None)
+
+    # --- imported_nids(): the --all-nids enumerator -----------------------------------------------
+    # This decides the whole sweep's coverage, and both ways it can be wrong are silent: too strict
+    # drops real imports from a census whose entire purpose is to be exhaustive, and too loose pulls
+    # ordinary defined symbols in as phantom "imports" that then report zero call sites and read as
+    # a clean negative. The `#` alone is not the discriminator — the 11-character NID before it is.
+    class FakeSyms(G.Image):
+        """A dynsym of `syment`-byte entries whose only field is the u32 st_name, then a strtab."""
+
+        def __init__(self, names):
+            syment = 4
+            strtab = syment * len(names)
+            blob, ents = bytearray(), bytearray()
+            for n in names:
+                ents += struct.pack("<I", len(blob))
+                blob += n.encode() + b"\0"
+            self.raw = bytes(ents + blob)
+            self._d = (0, strtab, len(names), syment)
+
+        def dynsym(self):
+            return self._d
+
+    syms = FakeSyms(["fMP5NHUOaMk#h#h",                      # a real import: 11-char NID then '#'
+                     "_ZNK3sce4Json6Object5emptyEv",         # C++ mangled, no '#' at all
+                     "short#h#h",                            # '#' present, NID too short
+                     "twelvecharss#h#h",                     # '#' present, NID too long
+                     "Oad3rvY-NJQ#libSceNpManager#libSceNpManager"])
+    check("imported-nids-picks-11-char-nids",
+          syms.imported_nids(), [("fMP5NHUOaMk", 0), ("Oad3rvY-NJQ", 4)])
+    #  The `#`-less name above is rejected in this fixture because the NEXT string's `#` is far
+    #  away, which does not pin the NUL clamp at all. Put a `#`-less name immediately before one
+    #  whose `#` lands at exactly distance 11 from it: an unclamped search finds that borrowed `#`
+    #  and admits a symbol that has no NID. Both entries must be rejected.
+    #  "nohash" is 6 bytes + NUL, so "abcd#efgh" starts at 7 and its '#' sits at absolute 11 —
+    #  exactly 11 from "nohash"'s first byte. An unclamped search therefore admits the phantom NID
+    #  "nohash\0abcd"; the clamped one rejects both entries. Verified to discriminate: with the
+    #  clamp removed this assertion returns [('nohash\0abcd', 0)].
+    borrow = FakeSyms(["nohash", "abcd#efgh"])
+    check("imported-nids-clamps-hash-search-to-nul", borrow.imported_nids(), [])
 
 
 def objdump_checks():


### PR DESCRIPTION
## Why

*Sonic Origins* (`PPSA05325`, #1905) has been at rung 0 through several lanes. The frontier they left
is a **registered-but-mismodelled Sony value returned during init** — a class no absence check can
see, because the call happens and the answer is wrong rather than missing. The two instruments that
exist attack it from the wrong side: the `PROSPER_PROGRESS_UNIMPL` table finds calls that *did not
happen*, and `hle_calls --values` reports what prosper *returned*. Neither says whether the guest
**looked**.

This PR builds the instrument that does, and lands what it plus a current-master re-run measured.

**No rung change. Sonic is still rung 0 and no screenshot is attached, because every frame in every
arm here is black.**

## What changes

### `tools/re/nid_gate_scan.py --all-nids`

`--nid` asks "who branches on **this** value?". `--all-nids` inverts it: classify **every** import of
a module in one pass, so the call sites that *cannot* be affected by any answer are struck off before
a boot. On Sonic's eboot — 813 NID-shaped dynsym entries, **536 imports actually called, 247 with at
least one gated call site**:

```bash
python3 tools/re/nid_gate_scan.py <DUMP_ROOT>/PPSA05325-app0/eboot.bin \
    --all-nids --names ../PS5-3.20_Libs
```
```text
Ovb2dSJOAuE  strcmp                 libSceLibcInternal  sites=981 gated=973 forward=7 nonzero=972 …
…
fMP5NHUOaMk  sceSysmoduleIsLoaded   libSceSysmodule     sites=5   gated=5   const=1 nonzero=4
…
# <path>: 536 imported NIDs are called; 247 shown at --min-gated=1
#   247 gated, 157 ignored-only (cannot matter), 132 unresolved (>=1 forward/undecodable window
#   — NOT cleared, read by hand)
#   site buckets: alu-gate=125 const=1 forward=3445 ignored=14432 nonzero=3440 other-cmp=166
#                 undecodable=2699
```

**The summary is a THREE-way split on purpose.** Not-gated is not the same as cleared: `ignored` is
the only bucket meaning an answer cannot matter, `forward` explicitly needs a look by hand, and
`undecodable` is a void sample. A two-way "called / gated" summary invites the reading that
everything below the cut is struck off — here that would wrongly retire **132** rows, and **11.1%**
of all 24,308 windows are undecodable.

- `--names DIR` labels NIDs from the gitignored PS5 firmware `genstub.py` dump. It is **symbolication
  only** — an unlabelled NID is still scanned and still reported, so a missing dump costs names,
  never coverage.
- `--min-gated N` hides thin rows; the summary always states the **unfiltered** total, so a filtered
  table cannot be mistaken for the whole one either.
- `--nid` and `--all-nids` are mutually exclusive and one is required (previously `--nid` was
  `required=True`).

The scan is refactored so a module's call-site index is built **once** instead of once per NID
(`call_sites` / `classify_sites` split out of `scan_module`) — with 536 imports the old shape would
re-scan 30 MB of text 536 times. Single-NID mode is otherwise untouched and reproduces its previous
output byte-for-byte on the sysmodule case the tool was written for.

**The enumerator's one judgement call, and why it is tested.** A dynsym name is accepted only when
**exactly 11 characters precede the first `#`**, searching no further than the name's own NUL. Every
relaxation fails *silently*: too loose pulls a C++ mangled name in as a phantom "import" that then
reports zero call sites and reads as a clean negative; too strict drops a real import from a census
whose entire purpose is exhaustiveness; and an unclamped `#` search lets a name with **no** `#` borrow
the next strtab string's. `test_nid_gate_scan.py` pins all three with a synthetic symbol table, and
the clamp fixture is built so the unclamped variant returns a phantom (`[('nohash\x00abcd', 0)]`)
rather than an empty list — i.e. it discriminates.

The rule does **not** separate imports from exports; PS5 exports carry the same shape. What removes
them is the JMPREL/call-site filter, since an export has no jump slot bound to it.

### `docs/GRIS_SONIC_COBRA_BRINGUP.md`

Three new `## Ruled out` rows and one new section (below). No existing row is edited.

## What it measured — master `beeff2ab`

### 1. The current-master re-run moved nothing

**#2021** (`sceSysmoduleIsLoaded` from prosper's own load history) and **#2031** (the RT0 blend key
on every SDK version) landed after #2035's arms and both touch surfaces this title uses. Re-measured
rather than assumed. **#2003 is deliberately NOT part of this claim** — `c3614f51`, the master #2035
measured on, already contained it, and #2035 records what it *did* change here (region JP→EU, the
`ui_title_nocopy.dds` request gone). The doc says so explicitly so the two adjacent sections cannot
be read as contradicting each other.

- Live renderer, native 3840x2160, `PROSPER_RENDER_SCALE=1 PROSPER_RENDER_EVERY=1`, route
  `scripts/sonic/long-input-probe.pad`, 10 samples over 120 s:
  `source-distinct=10 pixel-distinct=1`, every sample `crc=666f7b3f`.
- `PROSPER_NO_COMPUTE=1` over the same route: the same 40 unique resolved paths, no `.usm`, no
  `.rsdk`, the same steady state.

#1990's wall still fires here (`px_front=none px_vo=none px_last=none, offered 0 bytes … fresh=1
retained=465`) — same reading as before: selection has nothing to offer, and every target it could
offer is black anyway.

### 2. #2021 is falsified as a candidate for this title

Sonic **does** import `fMP5NHUOaMk` and **does** query it — a `beeff2ab` boot logs
`[sysmodule] IsLoaded -> UNLOADED` for ids `0x115`, `0x105`, `0x110`, immediately after the
`ui_startup.pac` miss. But all **five** static call sites are the benign
`if (not loaded) { LoadModule(id); mark-that-we-own-it; }` idiom:

```text
9273e5:  mov  edi,0x105
9273f1:  call <sceSysmoduleIsLoaded>
9273f6:  test eax,eax
9273f8:  je   0x92740f                  ; already loaded -> skip
9273ff:  call <sceSysmoduleLoadModule>
927406:  jne  0x92740f                  ; load failed -> skip
927408:  or   BYTE PTR [rbx+0x150],0x1  ; record that WE loaded it (finalize unloads it)
```

`eboot+0x8c4f0e` is the same shape against the exact errno (`cmp eax,0x805a1001`), and the two
`+0x927699`/`+0x9276c5` sites are the finalize half. The load then succeeds, so the only state #2021
changes on this title is an ownership bit read at teardown. Whole-boot result unchanged.

### 3. No shader op, format or dispatch is silently skipped — with a positive control

`[recompile-reject]` is `PROSPER_DBG`-gated, so a zero from a default run is **void, not negative**.
Two 18 s live-renderer arms differing *only* in `PROSPER_DBG` give the zero its control. Patterns are
literal, because the compute emitter writes `skip`, not `skipped` (`gpu_executor.cpp`:
`skip unregistered/unreadable`, `skip unsupported`, `skip invalid descriptor contract`) — a grep for
`skipped` would have returned zero **by construction**:

| pattern | `PROSPER_DBG=0` | `PROSPER_DBG=1` |
| --- | --- | --- |
| `[compute-cfg]` | 0 | 6 |
| `[graphics-cfg]` | 0 | 6 |
| `recompile-reject` (all three forms) | 0 | **0** |
| `\[compute\] skip` | 0 | **0** |
| `cf_rejected=[1-9]` | 0 | **0** |

The gated channel is demonstrably open (two prefixes appear that the `DBG=0` arm does not have at
all, emitted from the same TU under the same gate), and no line reports a non-zero `cf_rejected`. The
three `[compute] skip` sites are **not** `DBG`-gated, so their zero needs no control. The twelve CFG
lines are the count of *branching* shaders — they are the channel control; the zero rejects carry the
conclusion.

### 4. The 22 draws per flip are guest-issued, not prosper's residue

`state.draws` is filled by the PM4 decoder (`command_processor.cpp`) and printed by
`progress_heartbeat` (`hle_agc.cpp`), so the counter is pre-translation **by construction**; the
`PROSPER_NO_COMPUTE=1` arm — 66,988 draws and 42,734 dispatches over 3,044 flips at t=50 s, i.e.
**22.01 and 14.04 per flip** — is the consistency check on that reading rather than its proof.

**Scoped to *translation* loss, not *decode* loss.** A draw inside a PM4 packet prosper never decodes
is invisible to this counter too. I tried to bound that with the `walk=` field and could not: this
title takes the `[agc] SubmitDcb #N: %u dwords -> %zu packets applied` form, which has no `walk=`
(266 of 266 lines in a 10 s `PROSPER_GFXLOG` arm). The doc records that bound as **open** rather than
claiming it.

### 5. What the sweep does and does not bound

The 247 gated rows are a **static upper bound on what can matter**, not a list of what runs. Cross it
with the boot census before treating any row as live — `PROSPER_PROGRESS_UNIMPL` reads
`(0 distinct unimplemented functions)` on this title, so every row whose prosper handler is
*unregistered* belongs to code Sonic's boot never reaches. The residue worth reading by hand is the
non-libc gated rows prosper answers with a **shared** stub, because one prosper symbol can cover
several Sony entry points and collapses into a single `0x0` row in any runtime histogram.

## Affected / deliberately unaffected

Affected: `tools/re/nid_gate_scan.py` gains one mode and two options; its single-NID path is
behaviourally identical. `tools/re/README.md` and `docs/GRIS_SONIC_COBRA_BRINGUP.md` gain sections.

Deliberately unaffected: **no emulator code at all** — no HLE, no resolver, no renderer, no snapshot
baseline. No asset alias, no fabricated content, no title-address shim, no entitlement
blanket-approve.

## Risks

- `--nid` is no longer `required=True`. A script that invoked the tool with neither flag used to get
  argparse's "required" error and now gets "pass exactly one of…"; a script that passed `--nid` is
  unaffected.
- `--names` reads every `*.c` in the given directory. It raises rather than proceeding silently if
  the directory yields no `sprx_dlsym` lines, so a wrong path cannot degrade into an all-`?` table
  that looks like a firmware dump with poor coverage.
- The refactor changes *when* `scan_code` runs, not what it returns; the single-NID regression above
  is the check.

## Verification

```text
ctest -R re_nid_gate_classifier          1/1 Passed (re_nid_gate_classifier)
python3 tools/re/test_nid_gate_scan.py   == ALL CHECKS PASSED ==
git ls-files '*.md' -z | xargs -0 python3 tools/docs/check_numbered_table.py --github   exit 0
  GRIS_SONIC_COBRA_BRINGUP.md: 4 table(s), 36 rows, unbroken
git diff --check                         clean
```

Single-NID regression (identical to the pre-refactor output):

```text
    call at 0x8c4f13 id=0x115   -> const     cmp eax,0x805a1001
    call at 0x9273f1 id=0x105?  -> nonzero   test eax,eax
    call at 0x927414 id=0x110   -> nonzero   test eax,eax
    call at 0x927699 id=0x110   -> nonzero   test eax,eax
    call at 0x9276c5 id=0x105   -> nonzero   test eax,eax
eboot.bin  ok const=1 nonzero=4
```

The `--all-nids` figures were first produced by a throwaway driver written against the same
classifier and then reproduced by the committed mode. That is a re-derivation of the *enumeration*
only — it constrains the symbol walk, not the bucket rules, which are the unit test's job.

No C++ changed, so no full rebuild is claimed; no snapshots run (batched policy).

## Coordination

#2035 has **merged** (`560b7acc`) and this branch is rebased onto it. The `## Ruled out` table
conflicted and was resolved by hand, then read by hand rather than trusted: 25 rows, no duplicated
hypothesis, my three (23-25) distinct from #2035's (20-22), and `git diff origin/master -- <doc>`
shows **zero `-` lines**, so nothing of #2035's was reverted by the resolution. Nothing here touches
`tools/hle_calls` or `hle_file.cpp`, and nothing here re-opens the `ui_startup.pac` inventory
question, which is #2035's.

Refs #1905

