### PR TITLE
test(rwlock): the stress arm's comment described the ordering model that was falsified

### DIFF
--- a/prosper/tests/test_rwlock_once.cpp
+++ b/prosper/tests/test_rwlock_once.cpp
@@ -196,18 +196,31 @@ int main() {
     // readers, so a stray unlock that arrives while readers are present legitimately consumes one
     // reader's release — on hardware too. What must hold is sharper, and is exactly what the store
     // ordering buys:
-    //   * a WRITE hold can never be stolen: the owner is published before the count and cleared
-    //     after it, so a stray either sees the owner (EPERM) or sees no count (EPERM). With the
-    //     two stores in the obvious order, a stray robs the writer, the owner's own release then
-    //     drives the count negative, and the lock is bricked — #2012 reproduced by its own fix.
+    //   * a WRITE hold can never be stolen: the write flag and the hold count live in ONE atomic
+    //     word (bit 63 WRITE, bits 0..31 COUNT), so the unlock decision is a single CAS over the
+    //     whole value. A stray either sees WRITE set (owner check -> EPERM) or sees COUNT == 0
+    //     (-> EPERM). There is no pair of loads to straddle, by construction.
+    //     This is NOT the two-store ordering argument, which was tried and falsified. With
+    //     `writer` and `holds` as separate atomics, a stray could straddle the pre-check/post-check
+    //     pair across two stalls: the owner clears `writer` before decrementing `holds`, so the
+    //     stray reads writer == 0 with holds == 1, takes the reader path, and forwards an unlock
+    //     that glibc services as a WRITER release — freeing the real owner's lock. The owner then
+    //     decrements to -1 and its own unlock takes the reader path, driving __readers negative:
+    //     #2012 reproduced by its own fix. Publishing the owner before the count and clearing it
+    //     after is necessary and NOT sufficient; only the single-word CAS closes it.
     //   * a READ hold can only be stolen by a stray that was ACCEPTED, so the victims are bounded
     //     by the accepted strays.
     //   * and the lock is never corrupted: it still write-acquires afterwards.
-    // The workers take WRITE holds only, deliberately. A write-held lock has an owner published at
-    // every instant a stray could observe it, and an idle lock has a zero count, so under the
-    // correct ordering **no stray is ever accepted** — which makes the arm deterministic and gives
-    // it a crisp invariant. Under the wrong ordering the stray slips into the reader path, robs the
-    // owner, and the owner's own release then drives the count negative.
+    // The workers take WRITE holds only, deliberately. A write-held lock always has WRITE set in
+    // the same word the stray must CAS, and an idle lock has COUNT == 0, so **no stray is ever
+    // accepted** — which makes the arm deterministic and gives it a crisp invariant.
+    //
+    // Read this before acting on a failure: the invariant follows from the single-word CAS, NOT
+    // from this test. A two-stall interleaving is not observable by any amount of hammering here,
+    // so a clean run is not evidence of closure — the CAS's atomicity is the argument, and the arm
+    // exists to catch a future regression that reintroduces a straddle. If `strays_accepted != 0`
+    // ever fires, that is the signature of a residual ordering window in `rw_release`. Do not retry
+    // it; go read `rw_release`.
     //
     // Reader stealing is deliberately NOT in this loop. It is legal (the serialized cross-thread
     // read arm above covers it), but forwarding a non-owner read release into glibc under heavy


### PR DESCRIPTION
## The defect

`prosper/tests/test_rwlock_once.cpp` justified its `strays_accepted == 0` invariant with the **two-store ordering argument**:

> a WRITE hold can never be stolen: the owner is published before the count and cleared after it, so a stray either sees the owner (EPERM) or sees no count (EPERM)

and

> under the **correct ordering** no stray is ever accepted

**That argument was tried and falsified during #2015's review.** With `writer` and `holds` as separate atomics, a stray unlocker can straddle the pre-check/post-check pair across two stalls:

1. Owner clears `writer`, has not yet decremented `holds`
2. Stray reads `writer == 0` with `holds == 1`, takes the **reader** path
3. Stray forwards an unlock that glibc services as a **WRITER** release — freeing the real owner's lock
4. Owner decrements to `-1`; its own unlock takes the reader path; `__readers` goes negative

**#2012 reproduced by its own fix.** Publishing the owner before the count and clearing it after is **necessary and not sufficient**.

The shipped design abandoned two atomics for **one word** (bit 63 `WRITE`, bits 0..31 `COUNT`), so the unlock decision is a single CAS over the whole value and there is no pair of loads to straddle by construction. `hle_kernel.cpp` was corrected when that landed; **this file was missed.**

## Why a stale comment here is worse than usual

This comment is **the first thing someone opens when the assertion fires.** A stray acceptance is documented as the signature of a residual ordering window, so the reader arrives *already looking for an ordering bug* — and the comment then handed them the superseded model of why ordering was supposed to be sufficient. It routed them into a dead answer at exactly the moment they were most likely to trust it.

This is the same failure the whole #2015 review chain was about: the original comment asserted a race was impossible, the next reader built on it, and that produced windows 1 and 2.

## Also added: what the arm can and cannot show

> the invariant follows from the single-word CAS, **NOT** from this test. A two-stall interleaving is not observable by any amount of hammering here, so a clean run is not evidence of closure.

The stress arm exists to catch a **future regression** that reintroduces a straddle. Kept verbatim: `strays_accepted != 0` is the signature of a residual ordering window rather than flakiness, and "do not retry it; go read `rw_release`" — because retrying is exactly what someone does with a once-in-a-million failure.

## Verification

**Comment-only, verified mechanically** rather than by reading — filtering the diff to changed lines that are not `//` comments returns empty:

```
git diff origin/master..HEAD -U0 -- prosper/tests/test_rwlock_once.cpp \
  | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]\s*//'
  -> (empty)
```

No behaviour change, no assertion changed, so no re-run is load-bearing. One file, +22/−9.

```
git diff --check origin/master..HEAD  -> rc=0
session trailers                      -> 0
```

## Provenance

Non-blocking finding from the registered review that **APPROVED** #2015 at `3132eb14` (merged as `86fed89d`). Filed as #2047 at the time rather than folded in, so the approved head stayed the reviewed head.

Fixes #2047
