### PR TITLE
docs: a cited claim reads as a verified one — check the source, not the citation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,19 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   reviewer posts approval on the corrected exact head. Address every blocking finding and re-review authored
   corrections, then merge only after the merge agent separately confirms author verification, reviewer approval
   where required, and green required CI.
+  - **A cited claim reads as a verified one — and reviewers' findings propagate hardest.** A review
+    finding carries more authority than the same sentence anywhere else: it has been *checked* by
+    definition, and attaching a `file:line` makes it look checked twice. So a **wrong** finding with a
+    citation is the most contagious kind of error this project produces. Worked example (#2049 → #2052):
+    a reviewer stated an inverted default with a file:line, and that citation is what made it credible
+    enough to travel unchallenged into a briefing, then a shipped code comment, then an author's own
+    verification comment, then roughly fifteen agent briefings — with **nobody opening the cited file at
+    any step**. It was `guest_tls.cpp:46`, which is the Apple-only branch; Linux is `:58`, opt-**out**,
+    default **enabled**.
+    **So: check a claim against the source, never against anything downstream of the thing being
+    checked.** Opening the cited file and running one `grep -rn 'getenv("…")' prosper/src` is the whole
+    defence, and it is two commands. This binds on reviewers most of all — when you cite a line, you are
+    asserting you read it.
   - **How a verdict is expressed and detected — this is mechanical, and getting it wrong has merged a rejected
     PR.** The reviewer posts one or more **registered reviews** with `gh pr review <N> --comment --body '…'`,
     each stating a verdict as a literal **`APPROVED`** or **`REJECTED`** in the body. The author reads the


### PR DESCRIPTION
## The gap

#2046 added *how* a review verdict is expressed and detected. It says nothing about what happens when **a review finding is itself wrong** — and that turned out to be the more expensive gap.

A review finding carries more authority than the same sentence anywhere else: it has been *checked*, by definition, and attaching a `file:line` makes it look checked twice. **So a wrong finding with a citation is the most contagious error this project produces.**

## The worked example (#2049 → #2052)

A reviewer stated an inverted default with a `file:line` citation. That citation is what made it credible enough to travel unchallenged:

**review finding → a briefing → a shipped code comment → the author's own verification comment → roughly fifteen agent briefings**

with **nobody opening the cited file at any step.**

The citation pointed at `guest_tls.cpp:46` — the **Apple-only** branch. Linux is `:58`, opt-**out**, default **enabled**. The claim was not merely imprecise; it was backwards, and it was restated by an orchestrator into fifteen briefings in a single session precisely *because* it looked verified.

## The rule

**Check a claim against the source, never against anything downstream of the thing being checked.**

The defence is two commands — open the cited file, and `grep -rn 'getenv("…")' prosper/src`. That is the entire cost, against a wrong default that reached five documents.

This is the same shape as instrument trap 97, landed tonight: a completeness counter reported `captured 20/20` and could not detect that values had been **substituted** rather than lost, because a counter measures presence and never provenance. Only a source-derived positive control caught it. Nothing computed from the capture itself could have.

It binds on **reviewers most of all**: citing a line asserts you read it.

## Affected / unaffected

- **Affected:** guidance on how to treat a review finding, sitting alongside the verdict protocol it complements.
- **Unaffected:** no code, no test, no CI, and no change to when review is required or how a verdict is posted.

## Verification

Documentation only, one file, +13 lines. No tables and no numbered instrument-trap entries, so the `Docs` gate's structural and gapless-numbering checks are untouched.

```
git diff --check origin/master..HEAD  -> rc=0
session trailers                      -> 0
```

Refs #2046, #2049, #2052
