### PR TITLE
docs: the compute-skip log line says "skip", not "skipped"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   "handled" when they are not. Reject paths still exist as a *fail-visible* backstop for genuinely
   unknown encodings (mark `CONFIDENCE: LOW`, log loudly, file an issue with the exact opcode/format), but
   treat every one you hit on a live boot as the next thing to implement. Find the exact failing op with
-  `PROSPER_DBG=1` (`[recompile-reject] pc=… op=0x…` from the recompiler) or the `[compute] … skipped`
+  `PROSPER_DBG=1` (`[recompile-reject] pc=… op=0x…` from the recompiler) or the `[compute] skip …`
   lines from the live backend, then implement it with a round-trip/execution test — do not leave it skipped.
 - **Entitlement and add-content APIs answer from LOCAL INVENTORY — never blanket-approve.** When a
   title asks whether an add-on or entitlement is owned, prosper answers from the content actually


### PR DESCRIPTION
## The defect

`CLAUDE.md:303` tells readers to look for **`[compute] … skipped`** when hunting a silently dropped dispatch. The emitter writes **`[compute] skip …`** — three sites in `gpu_executor.cpp`:

| line | message |
| --- | --- |
| `:4405` | `[compute] skip unregistered/unreadable program 0x%llx` |
| `:4857` | `[compute] skip unsupported program 0x%llx` |
| `:4892` | `[compute] skip invalid descriptor contract for program 0x%llx` |

**None contains the string `skipped`.**

## Why this is more than a typo

The documented grep returns **zero by construction**, and a zero here reads as *"no dispatches are being skipped"* — on the exact check this file calls a **FATAL gap, not an acceptable skip**. It is a false negative that looks like a clean result, on the one search the charter most insists people run.

It has already cost a lane a review round: they ran the documented grep, got nothing, and had to be corrected to `\[compute\] skip` before the census meant anything. Their own words — *"the obvious grep returns zero by construction"*.

## Same family as #2052

This is the third charter claim corrected in a day where **being wrong makes a check silently vacuous rather than loudly broken**:

- **#2052** — `PROSPER_GUEST_FS` documented as a switch that is off by default; it is never read on Linux, and guest TLS is on by default with an opt-*out*. Propagated into five documents and ~fifteen agent briefings.
- **#2066** — a *cited* claim reads as a verified one, which is why the above travelled unchallenged.
- **this one** — a documented grep string that cannot match, on a FATAL-gap check.

A claim in this file is inherited without checking by every reader. That makes the ones that turn a check into a no-op the most expensive kind, because nothing fails — the search simply returns nothing and the reader moves on satisfied.

## Verification

Documentation only, one file, one line. No tables and no numbered instrument-trap entries, so the `Docs` gate's structural and gapless checks are untouched.

Confirmed against master:

```
$ git grep -n '\[compute\]' -- prosper/src | grep -i skip
prosper/src/gpu/gpu_executor.cpp:4405:  "[compute] skip unregistered/unreadable program 0x%llx\n"
prosper/src/gpu/gpu_executor.cpp:4857:  "[compute] skip unsupported program 0x%llx\n"
prosper/src/gpu/gpu_executor.cpp:4892:  "[compute] skip invalid descriptor contract for program 0x%llx\n"
```

Refs #2052, #2066
