### PR TITLE
docs(arcrunner): record the intro cinematic in COMPATIBILITY.md, with its throttle caveat

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,7 +36,7 @@ Last updated: 2026-08-05
 | *Bendy and the Ink Machine* | `PPSA27616` | Unity / IL2CPP | 🚧 Chapter 1 gameplay | [#1881](https://github.com/mattias800/prosper/issues/1881) |
 | *The Plucky Squire* | `PPSA15319` | Unreal Engine 4 | 🚧 Title and save/play-style menus | [#1882](https://github.com/mattias800/prosper/issues/1882) |
 | *The Pathless* | `PPSA01826` | Unreal Engine 4 | 🚧 Title screen | [#1883](https://github.com/mattias800/prosper/issues/1883) |
-| *ArcRunner* | `PPSA21406` | Unreal Engine 4 | 🔬 Render bring-up, no composited frame | [#1817](https://github.com/mattias800/prosper/issues/1817) |
+| *ArcRunner* | `PPSA21406` | Unreal Engine 4 | 🚧 Intro cinematic, on a throttled route | [#1817](https://github.com/mattias800/prosper/issues/1817) |
 | *Asterix &amp; Obelix: Babylon Mission* | `PPSA30490` | Unity 6 / IL2CPP | 🚧 Logo movies, intro cutscene, and title menu | [#1884](https://github.com/mattias800/prosper/issues/1884) |
 | *R-Type Delta: HD Boosted* | `PPSA26414` | Custom | 🚧 Title screen and attract mode | [#1810](https://github.com/mattias800/prosper/issues/1810) |
 | *Nikoderiko: The Magical World* | `PPSA23760` | Unreal Engine 4 | 🚧 Title screen and EULA | [#1885](https://github.com/mattias800/prosper/issues/1885) |
@@ -217,7 +217,12 @@ The title screen renders at native 2560×1440. Gameplay has not yet been reached
 
 ## ArcRunner — `PPSA21406`
 
-The game reaches the UE4 render bring-up and submits real GPU work, but no composited frame is currently produced. See the [tracker](https://github.com/mattias800/prosper/issues/1817).
+<p align="center"><img src="assets/screenshots/arcrunner-intro-space-station.png" alt="ArcRunner — the intro cinematic's Titan-class space station"></p>
+<p align="center"><img src="assets/screenshots/arcrunner-intro-city.png" alt="ArcRunner — the intro cinematic's neon street"></p>
+
+The whole intro cinematic renders at 4K — the Titan-class station against its nebula, the rainy neon street, and the population card — with 1,901 of 1,908 video frames succeeding.
+
+**This needs `PROSPER_SUBMIT_STALL_US=1500`, and that is a diagnostic lever rather than a fix.** On the default route the title faults before the cinematic: 17 runs out of 17, against 0 out of 4 with the stall applied. Every graphics subsystem the cinematic exercises works; what remains is a submit-timing race, tracked as [#1226](https://github.com/mattias800/prosper/issues/1226) with a dose-response experiment in [#2084](https://github.com/mattias800/prosper/issues/2084). See the [tracker](https://github.com/mattias800/prosper/issues/1817).
 
 ## Asterix &amp; Obelix: Babylon Mission — `PPSA30490`
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -217,10 +217,12 @@ The title screen renders at native 2560×1440. Gameplay has not yet been reached
 
 ## ArcRunner — `PPSA21406`
 
-<p align="center"><img src="assets/screenshots/arcrunner-intro-space-station.png" alt="ArcRunner — the intro cinematic's Titan-class space station"></p>
-<p align="center"><img src="assets/screenshots/arcrunner-intro-city.png" alt="ArcRunner — the intro cinematic's neon street"></p>
+<p align="center"><img src="assets/screenshots/arcrunner-intro-space-station.png" alt="ArcRunner — the intro cinematic's Titan-class space station (colours are wrong: see #2094)"></p>
+<p align="center"><img src="assets/screenshots/arcrunner-intro-city.png" alt="ArcRunner — the intro cinematic's neon street (colours are wrong: see #2094)"></p>
 
 The whole intro cinematic renders at 4K — the Titan-class station against its nebula, the rainy neon street, and the population card — with 1,901 of 1,908 video frames succeeding.
+
+**The colours in these frames are wrong.** Decoding the same movie outside prosper gives an *orange* nebula with *cyan* thrusters; prosper produces green and magenta. Geometry, composition, timing and frame pacing are correct, so the images are valid evidence for those — but not for colour. Tracked in [#2094](https://github.com/mattias800/prosper/issues/2094).
 
 **This needs `PROSPER_SUBMIT_STALL_US=1500`, and that is a diagnostic lever rather than a fix.** On the default route the title faults before the cinematic: 17 runs out of 17, against 0 out of 4 with the stall applied. Every graphics subsystem the cinematic exercises works; what remains is a submit-timing race, tracked as [#1226](https://github.com/mattias800/prosper/issues/1226) with a dose-response experiment in [#2084](https://github.com/mattias800/prosper/issues/2084). See the [tracker](https://github.com/mattias800/prosper/issues/1817).
 


### PR DESCRIPTION
## Goal

Make the compatibility record match what ArcRunner actually does. Progress that lives only in `prosper/docs/ARCRUNNER_STATUS.md` is progress the compatibility table misreports, and this row misreported it: `COMPATIBILITY.md` said "Render bring-up, no composited frame" and the gallery section said "no composited frame is currently produced", while both screenshots have been sitting on master unreferenced.

## What changed

- Row 39: `🔬 Render bring-up, no composited frame` → `🚧 Intro cinematic, on a throttled route`
- Gallery section `## ArcRunner`: embeds `assets/screenshots/arcrunner-intro-space-station.png` and `arcrunner-intro-city.png` (both already committed), with the throttle caveat stated inline.

## Why the caveat is in the entry and not only in the tracker

These are **not default-route evidence**. They need `PROSPER_SUBMIT_STALL_US=1500`, which the project documents as a diagnostic lever and never a fix. On the default route the title faults before the cinematic — 17 runs out of 17, against 0 out of 4 with the stall applied.

So the entry deliberately does **not** claim rung 1. What the screenshots establish is narrower and still worth recording: every graphics subsystem the cinematic exercises works (1,901 of 1,908 video frames succeed at 4K), which leaves a submit-timing race rather than a renderer gap. That race is #1226, with the dose-response experiment in #2084.

A reader who sees only the screenshots would reasonably conclude the title runs. A reader who sees only the old row would conclude the renderer produces nothing. Both are wrong; the caveat is what makes the entry true.

## Affected / unaffected

Touches `COMPATIBILITY.md` only — two replacements, 7 insertions and 2 deletions. No other title's row, no code, no test. Verified with `git diff --cached` that the only deleted lines are the two being replaced (trap 41).

## Verification

Documentation-only; the `Docs` CI gate applies. No build or snapshot run is relevant to this diff.

Refs #1817
Refs #1226
