### PR TITLE
re(xref): find strings built from immediates — and name Sonic Origins's ui_startup insertion site

### DIFF
--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -155,6 +155,9 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 | Sonic skipped initialization it still needed because `sceSysmoduleIsLoaded` used to claim every module was loaded (#2021/#2002), and the CRI Mana group is parked for that reason | **Falsified.** Sonic does import `fMP5NHUOaMk` and does query it — a `beeff2ab` boot logs `[sysmodule] IsLoaded -> UNLOADED` for ids `0x115`, `0x105` and `0x110` — but all **five** static call sites are the benign `if (not loaded) { LoadModule(id); mark-that-we-own-it; }` idiom, verified by disassembly (`eboot+0x8c4f0e`, `+0x9273e5`, `+0x92740f`, and the two finalize-side sites at `+0x927699`/`+0x9276c5`). The load then succeeds, so the only state #2021 changes is the ownership bit the object clears at finalize (`or BYTE [rbx+0x150],1` / `,2`; `or BYTE [r14+0x80],0x80`). The whole-boot result is unchanged: same 40-path resolved set, no `.usm`, no `.rsdk`, 10/10 black samples. | #1905, #2021, this doc |
 | An unsupported shader op, storage format or dispatch is silently skipped, and that is what collapses the composite | **Falsified on the live path, with a positive control.** Two 18 s live-renderer arms differing only in `PROSPER_DBG` match **zero** lines for `recompile-reject` (covering `[recompile-reject]`, `[cfg-…]` and `[exec-…]`) and zero for the literal pattern **`\[compute\] skip`** — the emitter writes `skip`, not `skipped` (`src/gpu/gpu_executor.cpp`: `skip unregistered/unreadable`, `skip unsupported`, `skip invalid descriptor contract`), so a grep for `skipped` would have returned zero by construction. The recompiler zero is a measurement rather than a void window because the `DBG=1` arm gains two prefixes the `DBG=0` arm does not have at all — `[compute-cfg]` ×6 and `[graphics-cfg]` ×6, emitted from the same translation unit under the same gate — and no line in either arm reports a non-zero `cf_rejected`. The three `[compute] skip` sites are **not** `DBG`-gated, so their zero needs no control. Note the twelve CFG lines are the count of *branching* shaders (they are also conditioned on `cfg_branches != 0`), so they are the channel control; the zero rejects carry the conclusion. **Re-measured independently on master `36d3914e` against the specific *Sonic Racing: CrossWorlds* form of this hypothesis (#2013/#2067 — two whole graphics pipelines dropped because a 16-bit VALU family failed to recompile, `[exec-recompile-reject]` firing 256+ times per boot): a 60 s native-3840x2160 arm reproduces the same result — `[graphics-cfg]` ×6, `[compute-cfg]` ×6, `cf_rejected=0` on all twelve, zero lines matching `recompile-reject`/`cfg-`/`exec-`/`skip`/`unsupported`/`unregistered`/`invalid`/`no executable work`, and the run's only two `[compute]` lines are the backend's own registration. #2067 is not merged at that head, so the 16-bit VALU family is still rejected there and the arm would have caught it. Frames stayed `crc32=666f7b3f`, `nonblack=0`, across five samples. The `skipped`/`skip` trap above caught a second lane too, before the re-run corrected it — #2074 has since fixed the charter that stated it wrongly.** | #1905, #2067, #2074, this doc |
 | The 22 draws per flip are what survives prosper dropping the rest of a larger frame at *translation* | **Falsified.** `state.draws` is filled by the PM4 decoder (`src/gpu/command_processor.cpp`) and printed by `progress_heartbeat` (`src/hle/hle_agc.cpp`), so the counter is pre-translation by construction; a `PROSPER_NO_COMPUTE=1` arm — where nothing is translated and therefore nothing can be rejected — reports the identical per-flip figures (66,988 draws and 42,734 dispatches over 3,044 flips at t=50 s: 22.01 and 14.04), which is the consistency check on that reading rather than its proof. **Scope it exactly:** this closes *translation* loss, not *decode* loss. A draw inside a PM4 packet prosper never decodes is invisible to this counter too, and the `walk=` field that would bound it is on the `[agc] <who> #N` form, not the `[agc] SubmitDcb #N: %u dwords -> %zu packets applied` form this title takes (266 of 266 lines in a 10 s `PROSPER_GFXLOG` arm). That bound is still open. | #1905, this doc |
+| The `ui/ui_startup` insert at runtime index 3 is *conditional*, so the condition is a value prosper supplies (the "registered-but-mismodelled call" candidate, in the one place it would be visible) | **Falsified.** The insert is `eboot+0x5875b0`'s only unconditional action once that coroutine step is entered on resume index `-3`: the name is materialised from two `movabs` immediates at `eboot+0x587626`/`+0x587630` and handed to the add-resource call at `eboot+0x5876ba`, with no test of any kind between the step's entry and it. Measured — one hit per boot at both the build site and the add call, armed at `prosper::run_entry` so nothing in the chain can run unobserved. The only conditional part of that branch is the *region rating texture* that follows it. This closes the mismodelled-value reading for this insert and strengthens the dump-gap reading. | #1905, this doc, this PR |
+| The eboot's zero references to `ui/ui_startup` mean the request is not name-driven, or the cross-reference index is dead at that address | **Resolved, and it was an instrument gap, not a property of the title.** The literal at `eboot+0xdd593b` is genuinely unreferenced — 0 RIP-relative references by a byte-exhaustive disp32 scan over the whole executable segment (not merely over decoded instructions), 0 self-relative int32 offsets, 0 raw `u32` occurrences of the address anywhere in the image, 0 relocations. It is a **dead literal**: clang built the 13-byte string into the small-buffer from immediates instead, so the string has no address to reference. `xref.py` gained an `imm` mode for exactly this question and reports the one construction site; `bmpfont/segafont` (1 code ref, 0 constructions) and `ui/ui_modefade` (0 code refs, 1 relocation, 0 constructions) are its controls. Any `xref.py to <string VA>` zero for a string of 22 bytes or fewer is void until `imm` has been run. | #1905, this doc, this PR |
+| The boot resource load never completes because `ui/ui_startup.pac` is absent, so the frontend waits forever for a phase that can never finish | **Falsified at the completion site.** `eboot+0x55b400` is the manager's per-phase completion poll: for each in-flight phase it tests that phase's batch counter (`[mgr+0x58]`/`[mgr+0x60]` → `+0xa0`), and when it is zero it clears the in-flight bit and notifies every listener in `[mgr+0xf8]`. Both phase 0 (which contains the missing package) and phase 1 reach it: the mask goes `0 → 1` at `eboot+0x55aecf`, is cleared at `eboot+0x55b428`, then `0 → 1 → cleared`, then `0 → 2 → cleared` at `eboot+0x55b480`, on the same manager object, and its entry vectors are still intact at t≈2400 ticks. The read path is positive-controlled: the same byte is read immediately before and after the single `or` that sets it, 3/3 arms `before|bit == after`. So the absent package does not stall the loader, and it does not withhold the completion callback. | #1905, this doc, this PR |
 
 ## Sonic Origins dump audit
 
@@ -846,3 +849,93 @@ on this path are offline-consistent (`sceNetCtlGetState` -> DISCONNECTED, `sceNp
   off reports `calls=257 finish-failures=0`. So no value census can be taken here until #2075 is
   fixed, and any value figure quoted for this title comes from an earlier arm, not from current
   master.
+
+### The resource-phase model, the `ui_startup` insertion site, and what boot actually completes (2026-08-06, master `f080fc23`)
+
+The previous section left one concrete target: *what code inserts `ui/ui_startup` between array entries
+2 and 3, and is that insert conditional?* It is answered here, and answering it turned the 42-entry
+array into a phase model that makes the "has the frontend left boot?" question a one-line check.
+
+**Correct the array's base by 8 bytes first.** The pairs run from `eboot+0x1e05bb0`, not `+0x1e05bb8`,
+and the element is `{Type* type, const char* name}` — type first. The earlier base put the boundary in
+the middle of an element and so reported the roles swapped. With the right base the 42 entries are
+contiguous from `+0x1e05bb0` to `+0x1e05e40`, and `+0x1e05e50` (one past the end) is the only other
+address in the region any code takes.
+
+**The array is three phase lists, and the constructor splits it.** `eboot+0x55a52d..0x55a6f5` copies the
+static entries into three vectors on the AppResourceManager, at `mgr+0x78+32*phase` (data) /
+`+0x80+32*phase` (count):
+
+| phase | static entries | contents |
+| --- | --- | --- |
+| 0 | 0-1 | `decotext/parameter/param_tech`, `NeedleShader` |
+| 1 | 2-31 | the 30 common packages (`ui/ui_resident` … `text/text_common_zhs`) |
+| 2 | 32-41 | `text/text_menu` … `text/text_license`, `ui/ui_modefade` |
+| 3 | — | empty; filled from add-on content |
+
+`eboot+0x55ac00(mgr, phase)` is the request entry point, and its first act is `eax = 1 << phase;
+test [mgr+0x11c], al` — so `mgr+0x11c` is a four-bit per-phase state. Statically there are 15 call
+sites: one passes 0, two pass 1, seven pass 2, four pass 3, and `eboot+0x5b84b0` is a helper that walks
+a caller-supplied bitmask at `[obj+0x30]` and issues 0/1/2/3 in order.
+
+**Measured, whole boot: only phases 0 and 1 are ever requested.** Breaking on `eboot+0x55ac00` for a
+2000-tick CPU-only `boot_trace` yields exactly three calls — `phase=0` from `eboot+0x5b85bc`, `phase=0`
+from `eboot+0x587514`, `phase=1` from `eboot+0x58a7ba` — and none of the seven phase-2 sites is reached,
+nor is any of their containing functions entered. That is the mechanical form of the `ui/ui_modefade`
+marker: phase 2 is not merely unloaded, it is never asked for.
+
+**The `ui/ui_startup` insertion site is `eboot+0x587626`, and it is unconditional.** `eboot+0x587320`,
+`eboot+0x5875b0` and `eboot+0x587bc0` are three steps of one coroutine, each entered repeatedly with a
+resume index in `*(int*)arg3` (`0` = install the next step, `-3` = do the work, `-2`/`-4` = the
+remaining resume points). All three run to their `-4` finalize on every boot. Inside step 2's `-3`
+branch the name is built from two overlapping `movabs` immediates —
+`movabs rdx, 0x74735f69752f6975` ("ui/ui_st") and `movabs rsi, 0x707574726174735f` ("_startup"), a
+13-byte SSO string with its length word `0x8000007f0000000d` — and passed to the add-resource call at
+`eboot+0x5876ba` with the same package type pointer (`0x1e537a0`) the array's `.pac` entries use. There
+is no test between the branch's entry and that call. It executes once per boot; there is no
+prosper-supplied value in the path.
+
+**That step is the legal/rating screen's resource set, and on this title it is empty apart from the one
+absent package.** After `ui_startup` the same branch adds a region rating texture chosen from the app
+config at `eboot+0x350bf80`: `+0x12` is the two-character region code (`"EU"` here, from #2003), a
+`"CH"` value adds `ui/rpl_texture/ui_titile_healthy`, `+0x20 & 1` adds `ui_title_nocopy`, and `+0x1c` is
+a rating-organisation id switched 1→`ui_title_cero`, 2→`ui_title_esrb_e10`, 3→`ui_title_esrb_rp`,
+4→`ui_title_pegi`. **`+0x1c` is 0 at runtime, and nothing in the eboot ever writes it** — the field is
+absent from the init function at `eboot+0x5113f0` and from all 14 sites that load the config pointer, of
+which every one is a `48 8b` load. So the jump table is skipped and *no* rating texture is requested:
+measured, the switch site `eboot+0x587913` is never reached. Sonic's startup scene asks for exactly one
+asset, `ui/ui_startup.pac`, and this dump does not contain it.
+
+Checked and cleared while there, so it is not re-derived: `[cfg+0x10]` is 0, which is **correct**. It is
+not a language *string* but a one-byte internal id, looked up from the 23-entry table at
+`eboot+0x1e072a0` (whose entries are single-byte enums, not text) by
+`sceSystemServiceParamGetInt(1)`; prosper answers 1 (en-US) and `table[1] == 0`.
+
+**The load nevertheless completes.** `eboot+0x55b400` is the per-frame completion poll: for each
+in-flight phase it reads that phase's batch object (`[mgr+0x58]`, `[mgr+0x60]`) and, when `[obj+0xa0]`
+is zero, clears the bit and calls every listener in `[mgr+0xf8]`. Both phase 0 and phase 1 get there —
+the mask is set at `eboot+0x55aecf` and cleared at `eboot+0x55b428` / `+0x55b480` on the same manager,
+whose phase vectors are still intact at the last sample. The missing package therefore does not park the
+loader and does not withhold the completion notification, which removes the one mechanism by which a
+handled ENOENT could have stalled the state machine. What remains open is upstream of the loader
+entirely: nothing ever *asks* for phase 2.
+
+Reproduce any of the above with a gdb script that arms its guest breakpoints at `prosper::run_entry` —
+that anchor matters, because the whole chain runs before the first `prosper::k_usleep` tick, so a script
+that arms on the clock (as earlier arms in this document did) sees none of it:
+
+```bash
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_NO_COMPUTE=1 \
+  gdb -q -batch -x <script>.py --args ./build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
+```
+
+**Two instrument results worth keeping.**
+
+- **A gdb hardware watchpoint on a guest byte reported zero writes while that byte demonstrably
+  changed.** The same run's software breakpoints caught the writes at `eboot+0x55b428`/`+0x55b480`
+  immediately. There was no positive control that the watchpoint could fire at all, so its zero is
+  **void** rather than negative — do not use `watch` on guest memory here without first arming it on an
+  address you are about to write yourself.
+- **`xref.py to <string VA>` cannot see a string built from immediates**, and the zero it returns is
+  indistinguishable from "nothing uses this". `xref.py imm '<string>'` is the query for that, added with
+  this section; `tools/re/README.md` documents both numbers and why neither is sufficient alone.

--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -157,7 +157,7 @@ One line per dead hypothesis, the evidence that killed it, and where that eviden
 | The 22 draws per flip are what survives prosper dropping the rest of a larger frame at *translation* | **Falsified.** `state.draws` is filled by the PM4 decoder (`src/gpu/command_processor.cpp`) and printed by `progress_heartbeat` (`src/hle/hle_agc.cpp`), so the counter is pre-translation by construction; a `PROSPER_NO_COMPUTE=1` arm — where nothing is translated and therefore nothing can be rejected — reports the identical per-flip figures (66,988 draws and 42,734 dispatches over 3,044 flips at t=50 s: 22.01 and 14.04), which is the consistency check on that reading rather than its proof. **Scope it exactly:** this closes *translation* loss, not *decode* loss. A draw inside a PM4 packet prosper never decodes is invisible to this counter too, and the `walk=` field that would bound it is on the `[agc] <who> #N` form, not the `[agc] SubmitDcb #N: %u dwords -> %zu packets applied` form this title takes (266 of 266 lines in a 10 s `PROSPER_GFXLOG` arm). That bound is still open. | #1905, this doc |
 | The `ui/ui_startup` insert at runtime index 3 is *conditional*, so the condition is a value prosper supplies (the "registered-but-mismodelled call" candidate, in the one place it would be visible) | **Falsified.** The insert is `eboot+0x5875b0`'s only unconditional action once that coroutine step is entered on resume index `-3`: the name is materialised from two `movabs` immediates at `eboot+0x587626`/`+0x587630` and handed to the add-resource call at `eboot+0x5876ba`, with no test of any kind between the step's entry and it. Measured — one hit per boot at both the build site and the add call, armed at `prosper::run_entry` so nothing in the chain can run unobserved. The only conditional part of that branch is the *region rating texture* that follows it. This closes the mismodelled-value reading for this insert and strengthens the dump-gap reading. | #1905, this doc, this PR |
 | The eboot's zero references to `ui/ui_startup` mean the request is not name-driven, or the cross-reference index is dead at that address | **Resolved, and it was an instrument gap, not a property of the title.** The literal at `eboot+0xdd593b` is genuinely unreferenced — 0 RIP-relative references by a byte-exhaustive disp32 scan over the whole executable segment (not merely over decoded instructions), 0 self-relative int32 offsets, 0 raw `u32` occurrences of the address anywhere in the image, 0 relocations. It is a **dead literal**: clang built the 13-byte string into the small-buffer from immediates instead, so the string has no address to reference. `xref.py` gained an `imm` mode for exactly this question and reports the one construction site; `bmpfont/segafont` (1 code ref, 0 constructions) and `ui/ui_modefade` (0 code refs, 1 relocation, 0 constructions) are its controls. Any `xref.py to <string VA>` zero for a string of 22 bytes or fewer is void until `imm` has been run. | #1905, this doc, this PR |
-| The boot resource load never completes because `ui/ui_startup.pac` is absent, so the frontend waits forever for a phase that can never finish | **Falsified at the completion site.** `eboot+0x55b400` is the manager's per-phase completion poll: for each in-flight phase it tests that phase's batch counter (`[mgr+0x58]`/`[mgr+0x60]` → `+0xa0`), and when it is zero it clears the in-flight bit and notifies every listener in `[mgr+0xf8]`. Both phase 0 (which contains the missing package) and phase 1 reach it: the mask goes `0 → 1` at `eboot+0x55aecf`, is cleared at `eboot+0x55b428`, then `0 → 1 → cleared`, then `0 → 2 → cleared` at `eboot+0x55b480`, on the same manager object, and its entry vectors are still intact at t≈2400 ticks. The read path is positive-controlled: the same byte is read immediately before and after the single `or` that sets it, 3/3 arms `before|bit == after`. So the absent package does not stall the loader, and it does not withhold the completion callback. | #1905, this doc, this PR |
+| The boot resource load never completes because `ui/ui_startup.pac` is absent, so the frontend waits forever for a phase that can never finish | **Falsified at the completion site.** `eboot+0x55b400` is the manager's per-phase completion poll: for each in-flight phase it tests that phase's batch counter (`[mgr+0x58]`/`[mgr+0x60]` → `+0xa0`), and when it is zero it clears the in-flight bit and notifies every listener in `[mgr+0xf8]`. Both requested phases reach it: the mask goes `0 → 1` at `eboot+0x55aecf`, is cleared at `eboot+0x55b428`, then `0 → 1 → cleared`, then `0 → 2 → cleared` at `eboot+0x55b480`, on the same manager object, and its entry vectors are still intact at t≈2400 ticks. The read path is positive-controlled: the same byte is read immediately before and after the single `or` that sets it, 3/3 arms `before|bit == after`. Which phase the runtime `ui/ui_startup` insert lands in is **not** established here — phase 0's vector holds its two static entries and nothing else at every sample, so the package is tracked by another owner. The row's claim is the narrower measured one: every phase this boot requests completes and notifies, so a handled ENOENT does not leave the loader waiting. | #1905, this doc, this PR |
 
 ## Sonic Origins dump audit
 
@@ -878,7 +878,7 @@ test [mgr+0x11c], al` — so `mgr+0x11c` is a four-bit per-phase state. Statical
 sites: one passes 0, two pass 1, seven pass 2, four pass 3, and `eboot+0x5b84b0` is a helper that walks
 a caller-supplied bitmask at `[obj+0x30]` and issues 0/1/2/3 in order.
 
-**Measured, whole boot: only phases 0 and 1 are ever requested.** Breaking on `eboot+0x55ac00` for a
+**Measured over a 2000-tick CPU-only arm (`PROSPER_NO_COMPUTE=1`, no input route): only phases 0 and 1 are ever requested.** Breaking on `eboot+0x55ac00` for a
 2000-tick CPU-only `boot_trace` yields exactly three calls — `phase=0` from `eboot+0x5b85bc`, `phase=0`
 from `eboot+0x587514`, `phase=1` from `eboot+0x58a7ba` — and none of the seven phase-2 sites is reached,
 nor is any of their containing functions entered. That is the mechanical form of the `ui/ui_modefade`
@@ -900,11 +900,17 @@ absent package.** After `ui_startup` the same branch adds a region rating textur
 config at `eboot+0x350bf80`: `+0x12` is the two-character region code (`"EU"` here, from #2003), a
 `"CH"` value adds `ui/rpl_texture/ui_titile_healthy`, `+0x20 & 1` adds `ui_title_nocopy`, and `+0x1c` is
 a rating-organisation id switched 1→`ui_title_cero`, 2→`ui_title_esrb_e10`, 3→`ui_title_esrb_rp`,
-4→`ui_title_pegi`. **`+0x1c` is 0 at runtime, and nothing in the eboot ever writes it** — the field is
-absent from the init function at `eboot+0x5113f0` and from all 14 sites that load the config pointer, of
-which every one is a `48 8b` load. So the jump table is skipped and *no* rating texture is requested:
-measured, the switch site `eboot+0x587913` is never reached. Sonic's startup scene asks for exactly one
-asset, `ui/ui_startup.pac`, and this dump does not contain it.
+4→`ui_title_pegi`. **`+0x1c` reads 0 at runtime**, so the jump table is skipped and *no* rating texture
+is requested: measured, the switch site `eboot+0x587913` is never reached. Sonic's startup scene asks
+for exactly one asset, `ui/ui_startup.pac`, and this dump does not contain it.
+
+No writer of `+0x1c` was found — it is absent from the init function at `eboot+0x5113f0`, which writes
+`+0x12`, `+0x18` and `+0x20` only. **That is not an exhaustive negative and must not be read as one.**
+A store to `[cfg+0x1c]` is register-relative and no RIP-relative scan can see it, so the 14 sites that
+load the config pointer bound nothing by being loads — a writer would necessarily reach the field
+*through* one of them, and could equally arrive via an argument, a member, a deserialisation, or
+another module. A rating-organisation id sitting at zero is exactly the shape of a value a platform
+query might be expected to fill, so **whether prosper should be supplying it is open**, not closed.
 
 Checked and cleared while there, so it is not re-derived: `[cfg+0x10]` is 0, which is **correct**. It is
 not a language *string* but a one-byte internal id, looked up from the 23-entry table at
@@ -915,8 +921,10 @@ not a language *string* but a one-byte internal id, looked up from the 23-entry 
 in-flight phase it reads that phase's batch object (`[mgr+0x58]`, `[mgr+0x60]`) and, when `[obj+0xa0]`
 is zero, clears the bit and calls every listener in `[mgr+0xf8]`. Both phase 0 and phase 1 get there —
 the mask is set at `eboot+0x55aecf` and cleared at `eboot+0x55b428` / `+0x55b480` on the same manager,
-whose phase vectors are still intact at the last sample. The missing package therefore does not park the
-loader and does not withhold the completion notification, which removes the one mechanism by which a
+whose phase vectors are still intact at the last sample. Note the phase-0 vector holds only its two
+static entries at every sample, so which owner tracks the runtime `ui/ui_startup` insert is not
+settled here. The missing package therefore does not park the loader and does not withhold the
+completion notification of any phase this boot requests, which removes the one mechanism by which a
 handled ENOENT could have stalled the state machine. What remains open is upstream of the loader
 entirely: nothing ever *asks* for phase 2.
 

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -65,10 +65,18 @@ other query in this file reports nothing for it. Sonic Origins (`PPSA05325`, #19
 example — the package is requested on every boot from exactly this one site.
 
 The report is deliberately conservative. Only 8- and 4-byte windows form a candidate, at most a 3-byte
-tail may be completed by a smaller store, and the windows must cover the whole string within one ~96-byte
-code span; single-byte matches are constant in a dense instruction stream, so admitting them would let
-any stretch of code "build" any string. A string that exists only as a referenced literal correctly
-reports **0** constructions — check both numbers, not either alone.
+tail may be completed by a smaller store, and matches cluster only while consecutive hits are no more
+than ~96 bytes apart. Single-byte matches are constant in a dense instruction stream, so admitting them
+into the cover would let a stretch of code "build" any string — on this eboot that turns the one real
+answer above into **96**. A needle shorter than 4 bytes is **refused** rather than answered, because that
+floor cannot exist below the needle's own length. A string that exists only as a referenced literal
+correctly reports **0** constructions — check both numbers, not either alone.
+
+Two precision limits are visible in the output and are not designed away. Clustering is single-linkage
+over *consecutive* matches, so a cluster can span more than ~96 bytes overall — the printed
+`first..last` range is what bounds it. And a `<= 3`-byte tail window is accepted anywhere inside the
+cluster, with no positional relation to the strong stores, so a tail-completed hit is only as precise as
+its 4- and 8-byte windows; the `[lo:hi]` sizes in the output are how you tell the two cases apart.
 
 For The Messenger, the example above identifies both sides of Unity's runtime IL2CPP API table:
 

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -40,6 +40,36 @@ python3 tools/re/xref.py /tmp/eboot.elf to 0x20698a5
 `from ADDRESS` lists references made by the function window containing that address; `reloc ADDRESS`
 restricts output to relative data relocations.
 
+## Find who builds a SHORT string — `to` cannot, and its zero is misleading
+
+A short string may have **no address to reference**. Clang materialises a `std::string` built from a
+literal of 22 bytes or fewer directly into the small-buffer with `movabs`/`mov` **immediates**, and the
+`.rodata` copy of that literal is then left with zero references of every kind — no RIP-relative `lea`,
+no relocation, nothing. `to <literal VA>` answers **0** for a string the guest asks for on every boot,
+which reads as "the guest cannot be requesting this". Use `imm` for that question:
+
+```bash
+python3 tools/re/xref.py /tmp/eboot.elf imm 'ui/ui_startup'
+```
+
+```text
+inline-immediate constructions of 'ui/ui_startup' (13 bytes): 1
+   0x587628..0x587632  (in func 0x5875b0)  0x587628[0:8], 0x587632[5:13]
+literal copies in non-executable segments: 1
+   0xdd593b: 0 code refs, 0 data relocations
+```
+
+The two sites are the overlapping 8-byte immediates the compiler emits for a 13-byte string
+(`[0:8]` then `[5:13]`), and the second line is the trap itself: the literal is unreferenced, so every
+other query in this file reports nothing for it. Sonic Origins (`PPSA05325`, #1905) is the worked
+example — the package is requested on every boot from exactly this one site.
+
+The report is deliberately conservative. Only 8- and 4-byte windows form a candidate, at most a 3-byte
+tail may be completed by a smaller store, and the windows must cover the whole string within one ~96-byte
+code span; single-byte matches are constant in a dense instruction stream, so admitting them would let
+any stretch of code "build" any string. A string that exists only as a referenced literal correctly
+reports **0** constructions — check both numbers, not either alone.
+
 For The Messenger, the example above identifies both sides of Unity's runtime IL2CPP API table:
 
 ```text

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -83,5 +83,73 @@ def main():
     print("xref decoder: PASS")
 
 
+def imm():
+    """`imm` finds a string materialised from instruction immediates, and only that string.
+
+    Two executable segments' worth of arguments matter here. The positive arm is the exact shape
+    clang emits for a short std::string — two overlapping 8-byte `movabs` immediates — which leaves
+    the .rodata literal with no reference of any kind, so `to <literal VA>` answers 0 for a string
+    the program demonstrably uses. The negative arms are what keep the answer meaningful: a string
+    present only as a referenced literal must NOT be reported as immediate-built, and neither must a
+    stretch of unrelated code that happens to contain scattered single bytes of the query.
+    """
+    raw = bytearray(0x400)
+    raw[:4] = b"\x7fELF"
+    struct.pack_into("<Q", raw, 0x20, 0x40)
+    struct.pack_into("<HH", raw, 0x36, 56, 2)
+    struct.pack_into("<IIQQQQQQ", raw, 0x40,
+                     1, 5, 0x100, 0x1000, 0, 0x100, 0x100, 0x1000)     # exec  0x1000..0x1100
+    struct.pack_into("<IIQQQQQQ", raw, 0x40 + 56,
+                     1, 4, 0x200, 0x2000, 0, 0x100, 0x100, 0x1000)     # rodata 0x2000..0x2100
+
+    built = b"ui/ui_startup"                    # 13 bytes: movabs [0:8] then overlapping [5:13]
+    code = bytearray(b"\x90" * 0x100)
+    code[0x10:0x12] = b"\x48\xba"               # movabs rdx, imm64
+    code[0x12:0x1a] = built[0:8]
+    code[0x1a:0x1c] = b"\x48\xbe"               # movabs rsi, imm64
+    code[0x1c:0x24] = built[5:13]
+    # Decoy: every byte of this string is present in a 28-byte window, but never as a contiguous
+    # run of four, which is exactly the shape a loose cover rule would mistake for a construction.
+    scattered = b"cfg/boot_flags"
+    decoy = bytearray()
+    for ch in scattered:
+        decoy += bytes((ch, 0))
+    code[0x80:0x80 + len(decoy)] = decoy
+    raw[0x100:0x200] = code
+
+    referenced = b"bmpfont/segafont"
+    raw[0x200:0x200 + len(built) + 1] = built + b"\0"
+    raw[0x220:0x220 + len(referenced) + 1] = referenced + b"\0"
+
+    path = ""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False) as f:
+            path = f.name
+            f.write(raw)
+        module = XREF.Module(path)
+
+        hits = XREF.find_immediate_builds(module, built)
+        assert len(hits) == 1, hits
+        first, last, parts = hits[0]
+        assert (first, last) == (0x1012, 0x101c), hits
+        assert [(lo, hi) for _, lo, hi in parts] == [(0, 8), (5, 13)], parts
+
+        # The literal copy of the same string carries no reference at all — the trap `imm` exists
+        # for. Assert it, so a future change that starts reporting one is caught here.
+        assert module.code_xref.get(0x2000, []) == [], module.code_xref.get(0x2000)
+        assert module.data_xref.get(0x2000, []) == [], module.data_xref.get(0x2000)
+
+        # A string that only exists as a literal must not be reported as immediate-built.
+        assert XREF.find_immediate_builds(module, referenced) == []
+        # ...nor may the byte-scattered decoy satisfy the cover.
+        assert XREF.find_immediate_builds(module, scattered) == []
+    finally:
+        if path:
+            os.unlink(path)
+
+    print("xref imm: PASS")
+
+
 if __name__ == "__main__":
     main()
+    imm()

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -115,6 +115,20 @@ def imm():
     for ch in scattered:
         decoy += bytes((ch, 0))
     code[0x80:0x80 + len(decoy)] = decoy
+
+    # 8 + 4 + 1 — the other shape a 13-byte string arrives in, and the only arm that reaches the
+    # tail-completion branch.
+    tailed = b"rfl/param_hud"
+    code[0x30:0x38] = tailed[0:8]
+    code[0x3a:0x3e] = tailed[8:12]
+    code[0x40:0x41] = tailed[12:13]
+
+    # Two separate constructions of one string, 0xa0 apart, so they must not chain into one cluster.
+    repeated = b"text/text_menu"
+    code[0x50:0x58] = repeated[0:8]
+    code[0x58:0x60] = repeated[6:14]
+    code[0xf0:0xf8] = repeated[0:8]
+    code[0xf8:0x100] = repeated[6:14]
     raw[0x100:0x200] = code
 
     referenced = b"bmpfont/segafont"
@@ -134,15 +148,39 @@ def imm():
         assert (first, last) == (0x1012, 0x101c), hits
         assert [(lo, hi) for _, lo, hi in parts] == [(0, 8), (5, 13)], parts
 
-        # The literal copy of the same string carries no reference at all — the trap `imm` exists
-        # for. Assert it, so a future change that starts reporting one is caught here.
+        # The fixture emits no reference to the literal copy, which is the situation `imm` exists
+        # for; this only records that the fixture models it, and is not a test of the tool.
         assert module.code_xref.get(0x2000, []) == [], module.code_xref.get(0x2000)
         assert module.data_xref.get(0x2000, []) == [], module.data_xref.get(0x2000)
 
-        # A string that only exists as a literal must not be reported as immediate-built.
+        # A string that only exists as a literal must not be reported as immediate-built. This is a
+        # real negative: it fails if the search ever reaches non-executable segments.
         assert XREF.find_immediate_builds(module, referenced) == []
-        # ...nor may the byte-scattered decoy satisfy the cover.
+        # ...nor may the byte-scattered decoy satisfy the cover. This is the arm with the lever:
+        # relaxing the >= 4-byte window floor makes it fail.
         assert XREF.find_immediate_builds(module, scattered) == []
+
+        # The <= 3-byte tail path: 8-byte store, 4-byte store, then a single trailing byte. Nothing
+        # else in this function reaches that branch, because a decoy with no contiguous 4-byte run
+        # leaves `strong` empty and returns early.
+        tail_hits = XREF.find_immediate_builds(module, tailed)
+        assert len(tail_hits) == 1, tail_hits
+        sizes = sorted(hi - lo for _, lo, hi in tail_hits[0][2])
+        assert sizes == [1, 4, 8], tail_hits
+
+        # Two constructions of one string, further apart than the cluster span, must stay two.
+        twice = XREF.find_immediate_builds(module, repeated)
+        assert len(twice) == 2, twice
+        assert twice[1][0] - twice[0][0] > 0x60, twice
+
+        # Under 4 bytes the window floor cannot exist, so the query is refused rather than answered
+        # with every plain occurrence of those bytes in the instruction stream.
+        try:
+            XREF.find_immediate_builds(module, b"cfg")
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("a 3-byte needle must be refused, not answered")
     finally:
         if path:
             os.unlink(path)

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -22,10 +22,19 @@
 # Runtime address = module_load_base + VA (e.g. eboot base 0x410000000; it moved from
 # 0x400000000 in #825 — see prosper/src/host/boot_program.hpp for the authoritative set).
 #
+# A SHORT string has no address to reference at all. Clang materialises a std::string built from a
+# literal of <= 22 bytes into the small-buffer with `movabs`/`mov` IMMEDIATES, and then the .rodata
+# copy of that literal can end up with zero references of every kind -- no rip-relative lea, no
+# relocation, nothing. `to <string VA>` then answers 0 for a string the guest demonstrably uses, which
+# reads as "the guest cannot be asking for this" (it cost the Sonic Origins lane a whole hypothesis:
+# `ui/ui_startup` has zero references AND is requested on every boot -- #1905). `imm` closes that hole
+# by searching the executable segments for the string's own bytes appearing as instruction operands.
+#
 # Usage:
 #   xref.py <module.elf> to   <hexaddr>     # who references this address
 #   xref.py <module.elf> from <hexaddr>     # what this function references (rip-lea/call, ~2KB window)
 #   xref.py <module.elf> reloc <hexaddr>    # data-pointer relocations targeting this address only
+#   xref.py <module.elf> imm  <string>      # who BUILDS this string from inline immediates
 
 import struct, sys
 from collections import defaultdict
@@ -141,12 +150,124 @@ class Module:
                     self.code_xref[site + 7 + disp].append((site, 'cmpb'))
 
 
+def find_immediate_builds(m, needle, span=0x60):
+    """Locate code that materialises `needle` (bytes) from instruction immediates.
+
+    Returns [(first_site_va, last_site_va, [(va, lo, hi), ...])] — one entry per cluster of nearby
+    executable-segment occurrences whose covered byte ranges together span the whole string.
+
+    The chunk sizes are the ones a compiler can encode as an immediate: 8 (movabs) and 4 (mov
+    imm32) carry the string, and at most a 3-byte tail may arrive as a 2- or 1-byte store.
+
+    Only the >= 4-byte windows form clusters, and a cluster is reported only when they cover the
+    whole string apart from such a tail. That bound is what makes the answer trustworthy: 1-byte
+    windows match constantly in a dense instruction stream, so admitting them into the cover lets
+    any 96-byte stretch of code "build" any string. Requiring the 4- and 8-byte windows to do the
+    work leaves the tail as the only concession, which is the shape the compiler actually emits.
+    """
+    n = len(needle)
+    if n == 0:
+        return []
+
+    def scan(sizes):
+        windows = [(lo, lo + s) for s in sizes if s <= n for lo in range(0, n - s + 1)]
+        found = []
+        for v, o, fs, fl in m.segs:
+            if not (fl & 1):                    # executable segments only
+                continue
+            seg = m.raw[o:o + fs]
+            for lo, hi in windows:
+                chunk = needle[lo:hi]
+                start = 0
+                while True:
+                    i = seg.find(chunk, start)
+                    if i < 0:
+                        break
+                    found.append((v + i, lo, hi))
+                    start = i + 1
+        return sorted(found)
+
+    strong = scan((8, 4) if n >= 4 else (n,))
+    if not strong:
+        return []
+    weak = None                                 # scanned lazily; only a <= 3-byte tail may use it
+    clusters, cur = [], [strong[0]]
+    for h in strong[1:]:
+        if h[0] - cur[-1][0] <= span:
+            cur.append(h)
+        else:
+            clusters.append(cur)
+            cur = [h]
+    clusters.append(cur)
+
+    out = []
+    for c in clusters:
+        covered = set()
+        for _, lo, hi in c:
+            covered.update(range(lo, hi))
+        missing = set(range(n)) - covered
+        parts = list(c)
+        if missing:
+            if len(missing) > 3:
+                continue                        # partial match: not a construction of this string
+            if weak is None:
+                weak = scan((3, 2, 1))
+            lo_va, hi_va = c[0][0] - span, c[-1][0] + span
+            for va, lo, hi in weak:
+                if lo_va <= va <= hi_va and missing & set(range(lo, hi)):
+                    missing -= set(range(lo, hi))
+                    parts.append((va, lo, hi))
+            if missing:
+                continue
+        # Keep the largest window at each distinct site, then drop the windows that are merely
+        # sub-ranges of a larger one at the same origin — an 8-byte movabs also matches its own
+        # 4-byte prefixes at the next four addresses, and printing those hides the real stores.
+        best = {}
+        for va, lo, hi in parts:
+            if va not in best or (hi - lo) > (best[va][1] - best[va][0]):
+                best[va] = (lo, hi)
+        cand = sorted((va, lo, hi) for va, (lo, hi) in best.items())
+        merged = [w for w in cand
+                  if not any(o is not w and o[0] - o[1] == w[0] - w[1]
+                             and o[1] <= w[1] and w[2] <= o[2] and (o[2] - o[1]) > (w[2] - w[1])
+                             for o in cand)]
+        out.append((merged[0][0], merged[-1][0], merged))
+    return out
+
+
 def main():
     if len(sys.argv) < 4:
         print(__doc__)
         return 1
     m = Module(sys.argv[1])
     mode = sys.argv[2]
+    if mode == 'imm':
+        text = sys.argv[3]
+        needle = text.encode('utf-8')
+        builds = find_immediate_builds(m, needle)
+        print(f"inline-immediate constructions of {text!r} ({len(needle)} bytes): {len(builds)}")
+        for first, last, parts in builds:
+            where = ", ".join(f"0x{va:x}[{lo}:{hi}]" for va, lo, hi in parts)
+            print(f"   0x{first:x}..0x{last:x}  (in func 0x{m.func_start(first):x})  {where}")
+        # The .rodata copy and its (often zero) reference count — the other half of "who uses this
+        # string", and the number that misleads on its own.
+        lits = []
+        for v, o, fs, fl in m.segs:
+            if fl & 1:
+                continue
+            start = 0
+            while True:
+                i = m.raw[o:o + fs].find(needle + b'\0', start)
+                if i < 0:
+                    break
+                if i == 0 or m.raw[o + i - 1] == 0:
+                    lits.append(v + i)
+                start = i + 1
+        print(f"literal copies in non-executable segments: {len(lits)}")
+        for va in lits[:16]:
+            print(f"   0x{va:x}: {len(m.code_xref.get(va, []))} code refs, "
+                  f"{len(m.data_xref.get(va, []))} data relocations")
+        return 0
     addr = int(sys.argv[3], 0)
     if mode in ('to', 'reloc'):
         drefs = m.data_xref.get(addr, [])

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -162,12 +162,29 @@ def find_immediate_builds(m, needle, span=0x60):
     Only the >= 4-byte windows form clusters, and a cluster is reported only when they cover the
     whole string apart from such a tail. That bound is what makes the answer trustworthy: 1-byte
     windows match constantly in a dense instruction stream, so admitting them into the cover lets
-    any 96-byte stretch of code "build" any string. Requiring the 4- and 8-byte windows to do the
-    work leaves the tail as the only concession, which is the shape the compiler actually emits.
+    a stretch of code "build" any string. Requiring the 4- and 8-byte windows to do the work leaves
+    the tail as the only concession, which is the shape the compiler actually emits.
+
+    A needle shorter than 4 bytes is REFUSED (ValueError) rather than answered, because the floor
+    that makes the answer meaningful cannot exist below the needle's own length: every plain
+    occurrence of those bytes anywhere in the instruction stream would be reported as a
+    construction, in the same confident format as a real one.
+
+    Two precision limits the caller should read off the output rather than assume away:
+      * a cluster is single-linkage over CONSECUTIVE matches no more than `span` bytes apart, so it
+        can grow longer than `span` overall — the printed first..last range is what bounds it;
+      * a tail-completed hit's small window is accepted anywhere inside the cluster's span, with no
+        positional or origin relation to the strong stores, so its precision rests entirely on
+        those. The reported [lo:hi] sizes are how a reader tells the two cases apart.
     """
     n = len(needle)
     if n == 0:
         return []
+    if n < 4:
+        raise ValueError(
+            "needle %r is %d byte(s); `imm` needs at least 4. Below that the >=4-byte window floor "
+            "that makes a match meaningful cannot apply, and every plain occurrence of these bytes "
+            "in the instruction stream would be reported as a construction." % (needle, n))
 
     def scan(sizes):
         windows = [(lo, lo + s) for s in sizes if s <= n for lo in range(0, n - s + 1)]
@@ -187,7 +204,7 @@ def find_immediate_builds(m, needle, span=0x60):
                     start = i + 1
         return sorted(found)
 
-    strong = scan((8, 4) if n >= 4 else (n,))
+    strong = scan((8, 4))
     if not strong:
         return []
     weak = None                                 # scanned lazily; only a <= 3-byte tail may use it
@@ -244,7 +261,11 @@ def main():
     if mode == 'imm':
         text = sys.argv[3]
         needle = text.encode('utf-8')
-        builds = find_immediate_builds(m, needle)
+        try:
+            builds = find_immediate_builds(m, needle)
+        except ValueError as exc:
+            print(f"refused: {exc}")
+            return 1
         print(f"inline-immediate constructions of {text!r} ({len(needle)} bytes): {len(builds)}")
         for first, last, parts in builds:
             where = ", ".join(f"0x{va:x}[{lo}:{hi}]" for va, lo, hi in parts)


### PR DESCRIPTION
## Summary

Answers the one concrete question the previous Sonic Origins lane left: **what inserts
`ui/ui_startup` into the boot resident set, and is that insert conditional?**

It is `eboot+0x587626`, and it is **unconditional** — so the "a value prosper supplies gates it"
reading is closed, and with it the last place the registered-but-mismodelled-call candidate could
have hidden on this path. Answering it also produced a phase model that turns the lane's
`ui/ui_modefade` progress oracle into a one-breakpoint check, and falsified the reading that the
absent package parks the loader.

No behavioural change to prosper. One new RE query, its regression test, and the evidence.

## Why `xref.py to` said zero for a string the guest asks for on every boot

The previous lane found **zero** references to `ui/ui_startup` and correctly flagged it as
unexplained. It is explained: clang materialises the 13-byte string into the `std::string`
small-buffer from two overlapping `movabs` immediates, so the `.rodata` copy is a **dead literal**
with no address anyone takes. Confirmed exhaustively — 0 RIP-relative disp32 sites by a byte-wise
scan of the whole executable segment (not only decoded instructions), 0 self-relative int32 offsets,
0 raw `u32` occurrences of the address in the image, 0 relocations.

`xref.py` therefore gains **`imm '<string>'`**, which finds the code that *builds* a string:

```text
$ xref.py <eboot>.elf imm 'ui/ui_startup'
inline-immediate constructions of 'ui/ui_startup' (13 bytes): 1
   0x587628..0x587632  (in func 0x5875b0)  0x587628[0:8], 0x587632[5:13]
literal copies in non-executable segments: 1
   0xdd593b: 0 code refs, 0 data relocations
```

Verified against known answers on this title before use: `bmpfont/segafont` (a normal literal)
reports 1 code ref and 0 constructions, and `ui/ui_modefade` / `text/text_menu` (static array
members) report 0 code refs, 1 relocation, 0 constructions.

The rule is deliberately conservative: only 8- and 4-byte windows form a candidate, at most a 3-byte
tail may be completed by a smaller store, and coverage of the whole string must fall inside one
~96-byte code span. Single-byte matches are constant in a dense instruction stream — with them
admitted, the same query reports **96** "constructions" in this eboot instead of 1.

## What the answer is

- **The static array's base was off by 8.** The `{Type*, const char*}` pairs run from
  `eboot+0x1e05bb0`; the earlier base put the boundary mid-element and reported the fields swapped.
- **The 42 entries are three phase lists**, split by the constructor at `eboot+0x55a52d..0x55a6f5`
  into vectors at `mgr+0x78+32*phase`: phase 0 = `param_tech`, `NeedleShader`; phase 1 = the 30
  common packages (+ `bmpfont/segafont` appended); phase 2 = `text/text_menu` … `ui/ui_modefade`
  — the lane's "left boot" marker group; phase 3 = add-on content.
- **`eboot+0x55ac00(mgr, phase)` is the request entry point.** Census over a 2000-tick CPU-only arm
  (`PROSPER_NO_COMPUTE=1`, no input route): exactly three calls, `phase=0`, `phase=0`, `phase=1`.
  None of the seven phase-2 call sites is reached. Phase 2 is not merely unloaded — it is never asked
  for, and one breakpoint now says so. The breakpoint is on the entry rather than the static call
  sites, so the dynamic bitmask helper at `eboot+0x5b84b0` cannot smuggle a request past it.
- **The insert is unconditional.** `eboot+0x587320` / `+0x5875b0` / `+0x587bc0` are three steps of one
  coroutine; all three run to their finalize resume on every boot, and step 2's `-3` branch builds the
  name and calls the add-resource entry at `eboot+0x5876ba` with no test in between. One hit per boot,
  measured at both sites.
- **That step is the legal/rating screen, and it is otherwise empty here.** The region rating texture
  it would add is selected by `[eboot+0x350bf80]+0x1c`, which reads **0** at runtime, so the 1..4 jump
  table (`cero`/`esrb_e10`/`esrb_rp`/`pegi`) is skipped: its site `eboot+0x587913` is never reached.
  Sonic's startup scene requests exactly one asset, and this dump does not contain it.
  No writer of `+0x1c` was found — it is absent from the init function at `eboot+0x5113f0`, which
  writes `+0x12`/`+0x18`/`+0x20` only. **That is not an exhaustive negative and the doc says so:** a
  store to `[cfg+0x1c]` is register-relative and invisible to a RIP-relative scan, so the 14 sites
  that load the config pointer bound nothing by being loads — a writer would necessarily reach the
  field *through* one of them. Whether prosper should be supplying this value is **open**.
- **The load completes anyway.** `eboot+0x55b400` is the per-phase completion poll; both requested
  phases reach it — mask set at `eboot+0x55aecf`, cleared at `+0x55b428` / `+0x55b480` on the same
  live manager, with the read positive-controlled before and after the single `or`. The listener
  dispatch that follows the clear is read off the disassembly at `eboot+0x55b42f..0x55b463`, not
  observed. Which phase the runtime `ui/ui_startup` insert lands in is **not** established: phase 0's
  vector holds its two static entries and nothing else at every sample, so the package is tracked by
  another owner. The narrower measured claim is what the Ruled-out row makes — every phase this boot
  requests completes — so a handled ENOENT does not leave the loader waiting, and the remaining
  blocker is upstream of the loader entirely.

Also checked and cleared so it is not re-derived: `[cfg+0x10] == 0` is **correct**, not a wrong
answer from prosper — it is a one-byte internal language id from the enum table at
`eboot+0x1e072a0`, and `table[1] == 0` for the en-US value prosper returns.

## Instrument notes

- Every arm arms its guest breakpoints at **`prosper::run_entry`**. The whole coroutine chain runs
  before the first `prosper::k_usleep` tick, so scripts that arm on the clock — as earlier arms in
  this document did — see none of it.
- The mask read is positive-controlled: the same byte is read immediately before and after the single
  `or` that sets it, 3/3 arms `before|bit == after`. Only then is the later zero evidence of a clear.
- **A gdb hardware watchpoint on a guest byte reported zero writes while that byte demonstrably
  changed**, with software breakpoints catching the writers in the same run. There was no control
  that the watchpoint could fire, so its zero is **void**, not negative. Recorded in the doc; an
  instrument-trap number is requested separately.

## Affected / deliberately unaffected

- `tools/re/xref.py`: new `imm` mode and `find_immediate_builds()`. The `to` / `from` / `reloc` modes
  are untouched — `to 0x55ac00` on this eboot returns the same 15 call sites before and after.
- No `src/` change, no behavioural change to prosper, no snapshot-visible change. Sonic Origins
  remains **rung 0**; nothing here is a visual claim.

## Risks

Low. The new mode is read-only analysis in a developer tool. Its failure mode is a false *positive*
naming an innocent code span, which is why the window-size floor exists and is the thing the test
mutates.

## Verification

```text
python3 prosper/tools/re/test_xref.py            -> xref decoder: PASS / xref imm: PASS
  mutation arm: relaxing the window floor to (8,4,2,1) makes the decoy assertion FAIL, so the
  negative arm has a real lever rather than passing vacuously
cmake --build build-linux -j12 && ctest          -> (posted below, exact head)
python3 prosper/tools/docs/check_numbered_table.py --github --sequential \
    --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md   -> 14 tables, 167 rows, OK
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github -> 94/94 OK
```

Runtime arms: CPU-only `boot_trace` on `PPSA05325-app0` under gdb, `PROSPER_NO_COMPUTE=1`,
`PROSPER_GUEST_ARGS=-force-gfx-direct`; 4 arms at 1200-3000 `k_usleep` ticks each.

Refs #1905, #1871


---

## Review round 2 (head `63d45408`)

Three blocking findings from the independent review are addressed in `63d45408`, and this description
has been corrected along with them — the two claims the commit retracted in the tree
(`+0x1c` written by nothing; "whole boot") were still live in this body, which matters because all
three `## Ruled out` rows cite *this PR* as their evidence location.

- **B1** — the Ruled-out row asserted phase 0 "contains the missing package". Unestablished, and the
  measurement points the other way. Removed; the row's conclusion never depended on it.
- **B2** — "nothing in the eboot ever writes it" was a non-sequitur from "all 14 sites are loads".
  Rescoped to the measurement, with the reason the enumeration bounds nothing, and the question
  recorded as open.
- **B3** — `imm` silently dropped its own >= 4-byte window floor for needles under 4 bytes, reporting
  every plain occurrence as a construction. Now refused with `ValueError` and a message naming why.
  (The floor cannot simply be kept for short needles: with the guard deleted, `scan((8, 4))` yields no
  windows at all for a 3-byte needle and returns `[]` — a misleading zero, i.e. this PR's own subject
  matter reproduced inside the tool that closes it.)
- Non-blocking 1-5 also addressed: the "one ~96-byte span" claim corrected to what the code enforces;
  the tail window's lack of positional relation to the strong stores documented; three new test arms
  (the 8+4+1 tail path, two clusters 0xa0 apart, the short-needle refusal), each with a verified
  mutation lever; and the misleading comment on two fixture assertions replaced.
