### PR TITLE
docs: stop prescribing PROSPER_GUEST_FS=1 where it is never read

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ FUSE). Like the Windows archive, neither contains games, firmware, or keys.
 
 ```bash
 chmod +x prosper-linux-x86_64.AppImage
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
   ./prosper-linux-x86_64.AppImage --dump ~/ps5/PPSA24651-app0
 ```
 

--- a/prosper/docs/ARCRUNNER_STATUS.md
+++ b/prosper/docs/ARCRUNNER_STATUS.md
@@ -160,7 +160,7 @@ blanketing the target, not content and not a guest clear. See the `## Ruled out`
 ## Rung-1 pass: what the presented frames actually contain
 
 Three bounded runs on `9dcb6c4b`, ordinary and unsuppressed
-(`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), each with exact zero pre/post process
+(`PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), each with exact zero pre/post process
 censuses and no suppression, skip, or shim. Timing is deliberately not quoted: peer lanes shared the GPU.
 
 **prosper executes what the guest submits.** With `PROSPER_DRAWLOG=1`, one run realized **456 of 468
@@ -233,7 +233,7 @@ is wrong rather than missing.
 
 This section **supersedes the rung-1 framing above**. The three findings below were taken on
 `c3614f51` with `boot_trace`, ordinary and unsuppressed
-(`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), three runs, exact zero pre/post process
+(`PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), three runs, exact zero pre/post process
 censuses, no suppression, skip, or shim. See [#2011](https://github.com/mattias800/prosper/issues/2011).
 
 **1. ArcRunner plays its intro movie, and prosper's AvPlayer path works.** With `PROSPER_AVPLOG=1`
@@ -315,7 +315,7 @@ crop_right`. Under the pre-fix contract that published the visible 1920 alongsid
 `crop_right_offset=128`, that expression double-counted the padding and yielded **1792**.
 
 Ordinary unsuppressed `boot_trace`
-(`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_COLORSTATETRACE=all`), exact zero
+(`PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_COLORSTATETRACE=all`), exact zero
 pre/post process censuses, no suppression, skip or shim. Movie surfaces counted by their
 `raw-format=10 resolved-format=50` signature:
 
@@ -356,7 +356,7 @@ Build and run inside the `ps5ys` distrobox, with `TMPDIR` on disk rather than `/
 
 ```bash
 cd prosper
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS= PROSPER_RENDER=1 \
   ./build-linux/boot_trace <DUMP_ROOT>/PPSA21406-app0
 ```
 
@@ -366,7 +366,7 @@ census, and the rendered-target content readback. Write every artifact under `~/
 
 ```bash
 # 1. submitted-vs-realized draws, plus any recompile/skip lines
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DRAWLOG=1 \
+PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DRAWLOG=1 \
   ./build-linux/boot_trace <DUMP_ROOT>/PPSA21406-app0
 
 # 2. one raw-to-resolved colour/depth record per draw (runs BEFORE the no-effect fast path,
@@ -379,14 +379,14 @@ PROSPER_PRESENT_NZLOG=1 PROSPER_DUMP_RTGROUPS=1 PROSPER_FRAME_DIR=~/arc-work/rtt
 
 # 3. a BMP per rendered target group with >=1 nonzero byte; a DRAWN target with NO file is
 #    fully zero. ~1 GB per 14 s -- keep the run short and delete afterwards.
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DUMP_RTGROUPS=1 \
+PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DUMP_RTGROUPS=1 \
 PROSPER_FRAME_DIR=~/arc-work/rtt ./build-linux/boot_trace <DUMP_ROOT>/PPSA21406-app0
 ```
 
 The combined diagnostic arm used for the most recent narrow experiment is:
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS= PROSPER_RENDER=1 \
 PROSPER_INIT_SUPPRESS=ptr PROSPER_REL1_FORGE_SUPPRESS_ALL=1 \
 PROSPER_FORGE_TRIP=1 PROSPER_PRESENT_NZLOG=1 PROSPER_DUMP_RTGROUPS=1 \
   ./build-linux/boot_trace <DUMP_ROOT>/PPSA21406-app0   # NZLOG needs the readback companion
@@ -436,7 +436,7 @@ Durable run records are in the #1226 comments for the
 ## What the `addr=(nil)` fault actually dereferences
 
 Measured on current master (`c9e2588e`), ordinary and unsuppressed
-(`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), with the new `PROSPER_LAZY_COMMIT_STRICT`
+(`PROSPER_GUEST_ARGS= PROSPER_RENDER=1`), with the new `PROSPER_LAZY_COMMIT_STRICT`
 discriminator. **Three terminal paths compete for the same run**, so a single run per arm cannot A/B
 anything on this title — see the `## Ruled out` row.
 

--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -20,7 +20,8 @@ Current verified rung: **2 — title screen reached and rendered**
 
 The title screen is reached by a default `screenshot` route with no title-specific switches
 (`PROSPER_RENDER=1`, the tool's own `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`
-defaults). Two independent bounded runs reproduce it.
+defaults — `PROSPER_GUEST_FS` is inert here, read only on macOS/Rosetta, and is named only because
+`screenshot` sets it). Two independent bounded runs reproduce it.
 
 `sceAvPlayerJumpToTime` (`XC9wM+xULz8`) was unregistered, so the dispatcher's default `0` reached the
 guest as a completed seek. Three things had to be true together before the title could advance, and

--- a/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
+++ b/prosper/docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md
@@ -100,7 +100,6 @@ headless title render is correct.
 The strongest exact-head diagnostic for PR #1030 used:
 
 ```sh
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_NO_COMPUTE=1 \
 PROSPER_AVP_SYNTH_FRAMES=120 \
@@ -450,7 +449,6 @@ For rapid control-flow iteration, the documented synthetic/no-compute route is a
 
 ```sh
 cd prosper
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_NO_COMPUTE=1 \
 PROSPER_AVP_SYNTH_FRAMES=120 \
@@ -673,7 +671,6 @@ env -u PROSPER_RENDER_SCALE \
     -u PROSPER_NO_PERSISTENT_COMPUTE_IMAGE \
     -u PROSPER_NO_NATIVE_2D_COMPUTE_TRANSFER \
     -u PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION \
-  PROSPER_GUEST_FS=1 \
   PROSPER_GUEST_ARGS=-force-gfx-direct \
   PROSPER_RENDER=1 \
   PROSPER_COMPUTE_TIMING_HASH=0xa5e27ec0def1a807 \

--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -14,7 +14,7 @@ resolved 2026-07-26); rung 4 needs the live oracle side-by-side plus families 4-
 Reaching the frame loop uses the standard gated switches:
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_IME_AUTOKEY=1 PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_IME_AUTOKEY=1 PROSPER_RENDER=1 \
   ./build-linux/screenshot <root>/PPSA25009-app0 --seconds 3 --count 650 --timeout 2000 --no-manifest
 ```
 

--- a/prosper/docs/CRISIS_CORE_STATUS.md
+++ b/prosper/docs/CRISIS_CORE_STATUS.md
@@ -147,7 +147,8 @@ globally. It also does not transfer to another title without its own dose-respon
 
 ## Reproduction notes
 
-- No `PROSPER_GUEST_FS`, no `-force-gfx-direct`: `PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1`.
+- No `-force-gfx-direct`: `PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1`. (Guest `%fs` TLS is on by
+  default and is *not* disabled by omitting a switch; `PROSPER_NO_GUEST_FS=1` is the opt-out.)
 - `#1982` (the declined ordered-DMA submit) does **not** reproduce on this title on current
   master — 0 occurrences across every arm since #1987.
 - `#2027` (the frame-bundle writer never completing) still blocks the F9/`gpu_replay` loop here.

--- a/prosper/docs/CUTSCENE_GC_ABORT.md
+++ b/prosper/docs/CUTSCENE_GC_ABORT.md
@@ -18,7 +18,7 @@ logging/serialization perturbs the timing) and manifests on either the main thre
 ## How to reproduce
 
 ```
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PAD_PRESS=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PAD_PRESS=1 \
   ./boot_trace <dump>
 ```
 

--- a/prosper/docs/CUTSCENE_PROGRESSION.md
+++ b/prosper/docs/CUTSCENE_PROGRESSION.md
@@ -3,6 +3,13 @@
 **Goal:** advance the game past the loading screen (the "Werewolf" title art) into the first cutscene
 (mostly-black background + text, 8-bit graphics).
 
+> **Note on `PROSPER_GUEST_FS=1`.** Two dated records below quote it as part of the environment they
+> were run in, and are left as they were run: it was the Linux opt-in gate for guest `%fs` TLS in July
+> 2026. Guest TLS became **on by default** in #825 (`4fd585ac`, 2026-07-17), with
+> `PROSPER_NO_GUEST_FS=1` as the opt-out, so the reproduction recipe no longer carries it. On current
+> master the token is inert on Linux and Windows; `PROSPER_GUEST_FS` is read only on macOS/Rosetta
+> (`src/host/guest_tls.cpp:46`, inside `#ifdef __APPLE__`). See #2095.
+
 ## What was fixed — `sceSystemServiceParamGetString` (committed)
 
 The single biggest blocker was a one-line HLE gap. `sceSystemServiceParamGetString` (NID `SsC-m-S9JTA`)
@@ -129,7 +136,7 @@ addresses → uncaught SIGSEGV).
 ## Reproduce
 ```sh
 VK_ICD_FILENAMES=/usr/share/vulkan/icd.d/lvp_icd.json \
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PREADLOG=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_PREADLOG=1 \
   ./build/boot_trace /path/to/PPSA24651-app0
 # watch resources.assets block offsets climb, then a main-thread SIGSEGV in the Il2cpp+0x49d1 chain.
 ```

--- a/prosper/docs/CUTSCENE_RENDER.md
+++ b/prosper/docs/CUTSCENE_RENDER.md
@@ -41,7 +41,7 @@ So the game **reaches** the cutscene and submits its draws; they just don't prod
 
 Dump the composite VS and read its position math:
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   PROSPER_SHADER_DUMP=/tmp/sd PROSPER_RENDER_FIRST=140 PROSPER_DETILE=1 ./boot_trace <dump>
 spirv-dis /tmp/sd/frame_vs.spv          # frame_vs.spv = items[0].vs of the LAST render
 ```
@@ -71,7 +71,7 @@ letterbox appears even before the island/text draw correctly.
 
 ## Repro / tooling
 
-- Repro: `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_DETILE=1`
+- Repro: `PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_DETILE=1`
   (+ `PROSPER_RENDER_FIRST=140` to skip to the post-loading phase).
 - `PROSPER_DRAWLOG` (per-draw counts), `PROSPER_SHADER_DUMP=<dir>` (`frame_vs.spv`/`frame_fs.spv` +
   `exec_*_*.bin` for *failed* recompiles), `PROSPER_DUMP_TEX` (bound textures → BMP),

--- a/prosper/docs/DOLL_LOADING_PROGRESSION.md
+++ b/prosper/docs/DOLL_LOADING_PROGRESSION.md
@@ -34,7 +34,9 @@ flow target eboot+0x124beb0.
 
 Diagnosed 2026-07-10 on `diag/doll-loading-progression` (= master e116cd4) with the new
 `PROSPER_PROGRESS` heartbeat + `PROSPER_PROGRESS_UNIMPL` call-count dump (this branch). All runs:
-WSL2 ext4 fast path (`/root/PPSA17942-app0`), `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1`.
+WSL2 ext4 fast path (`/root/PPSA17942-app0`), `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1` — recorded as
+run, but `PROSPER_GUEST_FS` was the then-current Linux opt-in gate for guest `%fs` TLS and has been
+default-on since #825 (2026-07-17); today only `PROSPER_NULL_PAGE=1` is needed here (#2095).
 Tracked as **issue #306** (`bug`, `area:ue4`).
 
 ## 1. The steady state, measured (run 1: no renderer, 420 s)
@@ -261,7 +263,7 @@ pad → title menu → `PROSPER_PAD_SCRIPT` press Start → first level).
 
 ```
 # heartbeat + call-count boot (no renderer, full speed):
-timeout 420 env PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
+timeout 420 env PROSPER_NULL_PAGE=1 PROSPER_FILELOG=1 PROSPER_EVLOG=1 \
   PROSPER_PROGRESS=5 PROSPER_PROGRESS_UNIMPL=1 \
   ./build-linux/boot_trace /root/PPSA17942-app0 > /root/doll.log 2>&1
 # scripts: scripts/diag/run{1..5}*.sh on diag/doll-loading-progression

--- a/prosper/docs/DOLL_POSTPROCESS_HANDOFF.md
+++ b/prosper/docs/DOLL_POSTPROCESS_HANDOFF.md
@@ -158,7 +158,7 @@ normal Linux checkout.
 
 ```bash
 # from prosper/ , with a DOLL-dump build of boot_trace:
-PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DBG=1 \
+PROSPER_NULL_PAGE=1 PROSPER_GUEST_ARGS= PROSPER_RENDER=1 PROSPER_DBG=1 \
   PROSPER_SHADER_DUMP=/tmp/doll_dump \
   ./build-linux/boot_trace <path-to-PPSA17942-app0> 2> boot.log
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -44,7 +44,6 @@ directories created under `$HOME`; substitute their absolute paths before runnin
 screenshots and both save backends stay outside the worktree and `/tmp`.
 
 ```bash
-PROSPER_GUEST_FS=1 \
 PROSPER_NULL_PAGE=1 \
 PROSPER_GUEST_ARGS= \
 PROSPER_SAVE0=<FRESH_SAVE_ROOT>/save0 \

--- a/prosper/docs/EVERGATE_PERFORMANCE_HANDOFF_2026_07.md
+++ b/prosper/docs/EVERGATE_PERFORMANCE_HANDOFF_2026_07.md
@@ -155,7 +155,6 @@ ctest --test-dir prosper/build-linux --output-on-failure
 Run Evergate at native scale and full cadence from `prosper/`:
 
 ```sh
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_RENDER_EVERY=1 \
 PROSPER_RENDER_SCALE=1 \

--- a/prosper/docs/LINUX_RELEASE.md
+++ b/prosper/docs/LINUX_RELEASE.md
@@ -51,11 +51,11 @@ With the AppImage:
 
 ```bash
 chmod +x prosper-linux-x86_64.AppImage
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
   ./prosper-linux-x86_64.AppImage --dump ~/ps5/PPSA24651-app0
 ```
 
-The tarball ships `start-prosper.sh`, which sets those switches for you and creates a `savedata`
+The tarball ships `start-prosper.sh`, which sets that switch for you and creates a `savedata`
 directory beside itself:
 
 ```bash

--- a/prosper/docs/LITTLE_NIGHTMARES_3_STATUS.md
+++ b/prosper/docs/LITTLE_NIGHTMARES_3_STATUS.md
@@ -157,7 +157,7 @@ title" — that claim was made on this tracker from an unarmed `svc_log` and wit
 ## Reproduction
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_NULL_PAGE=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_NULL_PAGE=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA05143-app0 \
       --seconds 10 --count 36 --timeout 380 --out <OUT>
 ```

--- a/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
+++ b/prosper/docs/NEXT_STEP_VERTEX_FETCH.md
@@ -6,6 +6,12 @@
 > below as current status. Start from `MESSENGER_BLACK_RENDER.md` and GitHub issues #299, #300, #514,
 > and #515. The remainder is retained as implementation history.
 >
+> **`PROSPER_GUEST_FS=1` in the reproduction below is historical, and is left exactly as it was run.**
+> It was the Linux opt-in gate for guest `%fs` TLS at the time; guest TLS became **on by default** in
+> #825 (`4fd585ac`, 2026-07-17), with `PROSPER_NO_GUEST_FS=1` as the opt-out. On current master the
+> token is inert on Linux and Windows; `PROSPER_GUEST_FS` is read only on macOS/Rosetta
+> (`src/host/guest_tls.cpp:46`, inside `#ifdef __APPLE__`). Do not copy it into a new recipe (#2095).
+>
 > **Project context (read `../../CLAUDE.md` first).** prosper is a **PS5→PC compatibility layer** —
 > "Wine/Proton for PS5" — that runs a **legally-owned** game natively by reimplementing Sony's published
 > library ABI and translating the console's GPU commands + RDNA2 shaders to Vulkan/SPIR-V. This is

--- a/prosper/docs/NIKODERIKO_STATUS.md
+++ b/prosper/docs/NIKODERIKO_STATUS.md
@@ -79,7 +79,7 @@ re-derive these without contradictory new evidence.
 ## Reproduction
 
 ```bash
-PROSPER_NO_FRAME_DUMPS=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_NO_FRAME_DUMPS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 PROSPER_DBG=1 PROSPER_DYNTRACE_FAIL=1 PROSPER_UDPROV=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA23760-app0 --seconds 8 --count 55 --out <OUT> --timeout 460
 ```

--- a/prosper/docs/OREGON_TRAIL_STATUS.md
+++ b/prosper/docs/OREGON_TRAIL_STATUS.md
@@ -97,7 +97,7 @@ body originally called highest-value.
 ## Historical — where it stood after #1933 (2026-08-04)
 
 The black-frame era is over. On master `9dcb6c4b` the default environment
-(`PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, no diagnostics, no
+(`PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1`, no diagnostics, no
 route) produces real content within two seconds: a green legal panel titled *"Welcome to The Oregon
 Trail"*, three legal links, and a focused confirm button, at 3840x2160 with **4,009,938 non-black
 pixels** (48 % of the frame). `assets/screenshots/oregon-trail-legal-popup.png` is that frame.
@@ -430,7 +430,7 @@ at the documented search site `eboot+0x4ab2e00`.
 **Current — the popup, and the fault that follows it (2026-08-04, master `9dcb6c4b`):**
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA19244-app0 \
       --seconds 2 --count 8 --out <OUT> --timeout 60
 ```
@@ -444,7 +444,7 @@ been observed to act, because the crash lands before its first press.
 **Historical — the black-frame draw census (pre-#1933):**
 
 ```bash
-PROSPER_NO_FRAME_DUMPS=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_NO_FRAME_DUMPS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 PROSPER_RENDER_TIMING=1 PROSPER_RTT_TIMING=1 PROSPER_EXECLOG=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA19244-app0 --seconds 10 --count 2 --out <OUT> --timeout 250
 ```

--- a/prosper/docs/PORTING.md
+++ b/prosper/docs/PORTING.md
@@ -53,8 +53,8 @@ suggests:
   (EFLAGS.TF), `sigsetjmp` recovery, raw `SYS_write` inside handlers.
 - `perf_event_open` hardware break/watchpoints (`PROSPER_HWBP`/`PROSPER_HWWATCH`),
   `/proc/self/maps` classification.
-- Guest `%fs` TLS (`PROSPER_GUEST_FS`): per-thread guest TCB, base switched with
-  `rdfsbase`/`wrfsbase`; import stubs are hand-emitted x86 that swap `%fs` per HLE call.
+- Guest `%fs` TLS (on by default; opt out with `PROSPER_NO_GUEST_FS`): per-thread guest TCB, base
+  switched with `rdfsbase`/`wrfsbase`; import stubs are hand-emitted x86 that swap `%fs` per HLE call.
 - x86 machine-code emitters for import stubs; `int3` patching for `PROSPER_BP`.
 
 **HLE Linuxisms (small list):**
@@ -289,7 +289,8 @@ CPU a real guest fs base the way Linux (`wrfsbase`) and Windows (FSGSBASE + VEH 
 Solved by **trap-and-emulate**, settled by a spike: under Rosetta a guest `%fs:disp` access faults at
 linear address == the raw offset (fs base is 0), so the real target is simply `guest_TP + fault_addr`
 — no addressing-mode decode needed. Implementation:
-- `guest_tls.cpp` macOS "trap mode" (same `PROSPER_GUEST_FS` gate): build the per-thread Variant-II
+- `guest_tls.cpp` macOS "trap mode" (opt-in, and the one platform where `PROSPER_GUEST_FS` is read —
+  Linux/Windows are on by default): build the per-thread Variant-II
   guest TCB and store its thread pointer in host (`%gs`) TLS, but **do not** touch the CPU fs base.
 - `exec_image_linux.cpp` `try_emulate_fs_access`: in the SIGSEGV/SIGBUS handler, if the faulting
   instruction carries an `%fs` prefix and trap-mode TLS is active, redirect the access to

--- a/prosper/docs/REAL_FRAMES_FINDINGS.md
+++ b/prosper/docs/REAL_FRAMES_FINDINGS.md
@@ -66,8 +66,8 @@ block ~966). Crash RIP varies (downstream corruption). So the actual title/gamep
 Prime suspects (first-exercised on the load path, all currently returning 0): the libSceAgc trace-only stubs
 `H7uZqCoNuWk` (called with a GPU-VA-map shape `a2=0x2000000000 a3=… a4=0x10000`), `-KRzWekV120`,
 `tSBxhAPyytQ`; and the one-shot unimplemented `libSceAmpr` trio (`8aI7R7WaOlc`/`a8uLzYY--tM`/`N-FSPA4S3nI` —
-PS5 async memory/streaming, directly load-relevant). Repro under gdb: `PROSPER_GUEST_FS=1
-PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_FILELOG=1 PROSPER_PREADLOG=1 gdb ./boot_trace`; watch the
+PS5 async memory/streaming, directly load-relevant). Repro under gdb:
+`PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_FILELOG=1 PROSPER_PREADLOG=1 gdb ./boot_trace`; watch the
 `resources.assets` stream reach ~blk 966, then the WORKER-THREAD FAULT.
 
 ## What's in this branch
@@ -94,7 +94,7 @@ PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_FILELOG=1 PROSPER_PREADLOG=1 gdb ./
 
 ```
 # Prove the title renders (reference VS isolates the VS-UV bug):
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_RENDER_REFVS=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_RENDER_REFVS=1 \
   PROSPER_FRAME_DIR=/tmp/t ./boot_trace <dump>    # a late frame → ~1992 distinct colors (the title)
 # The game's own render (currently uniform — the VS-UV bug):
 … (drop PROSPER_RENDER_REFVS)

--- a/prosper/docs/RENDER_LOOP.md
+++ b/prosper/docs/RENDER_LOOP.md
@@ -7,6 +7,13 @@
 > [`../../COMPATIBILITY.md`](../../COMPATIBILITY.md) and the per-title docs named in `CLAUDE.md`; the
 > Messenger record specifically is [`MESSENGER_BLACK_RENDER.md`](MESSENGER_BLACK_RENDER.md). The
 > remainder is retained as implementation history.
+>
+> **`PROSPER_GUEST_FS=1` in the commands below is historical, and is left exactly as it was run.**
+> When these runs were made it really was the Linux opt-in gate for guest `%fs` TLS — this document
+> is where that gate was introduced. Guest TLS became **on by default** in #825 (`4fd585ac`,
+> 2026-07-17), with `PROSPER_NO_GUEST_FS=1` as the opt-out. On current master the token is inert on
+> Linux and Windows; `PROSPER_GUEST_FS` is read only on macOS/Rosetta (`src/host/guest_tls.cpp:46`,
+> inside `#ifdef __APPLE__`). Do not copy it into a new recipe (#2095).
 
 **Status:** open (the next big frontier). The GfxDevice boot wall is RESOLVED (see
 `GFXDEVICE_BRINGUP_PROBLEM.md`); the game now boots into asset loading + its frame loop but does not yet

--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -345,8 +345,8 @@ process on the host, and pointing it at a tree another lane is timing silently i
 Say what you are evicting first. It reports `mincore(2)` residency **before and after** so a cold arm
 can prove it was cold.
 
-Every arm below is `boot_trace`, default route (`PROSPER_GUEST_FS=1
-PROSPER_GUEST_ARGS=-force-gfx-direct`), low-volume timeline (`PROSPER_SYNCLOG=1` +
+Every arm below is `boot_trace`, default route (`PROSPER_GUEST_ARGS=-force-gfx-direct`),
+low-volume timeline (`PROSPER_SYNCLOG=1` +
 `PROSPER_SYNCLOG_SEMA_ONLY=1` + `PROSPER_SYNCLOG_COND_ONLY=1`), unmodified binary and unmodified
 guest, on `4d7a2ded` (master `278c9b1f`). The host was shared with 8–9 other agent lanes, so the
 1-minute load average is reported for every arm — the point of the table is that the two populations
@@ -411,7 +411,7 @@ It also has two immediate practical consequences:
 
   ```bash
   python3 tools/dropcache.py <DUMP_ROOT>/PPSA26414-app0     # prints resident MB before -> after
-  PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct ./build/boot_trace <DUMP_ROOT>/PPSA26414-app0
+  PROSPER_GUEST_ARGS=-force-gfx-direct ./build/boot_trace <DUMP_ROOT>/PPSA26414-app0
   ```
 
   It is a measurement aid, not a fix, and it is one-shot: the run it enables re-warms the cache, so
@@ -500,7 +500,7 @@ loops pinned to the same four logical CPUs as prosper:
 
 ```bash
 for i in $(seq 1 12); do taskset -c 0-3 bash -c 'while :; do :; done' & done
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   taskset -c 0-3 ./build/screenshot <DUMP_ROOT>/PPSA26414-app0 --seconds 3 --count 25 --out <dir>
 ```
 
@@ -621,7 +621,7 @@ that made the old workaround unreliable as an acceptance condition:
 
 ```bash
 python3 tools/dropcache.py <DUMP_ROOT>/PPSA26414-app0
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   ./build/screenshot <DUMP_ROOT>/PPSA26414-app0 --seconds 4 --count 45 --out <dir>
 ```
 

--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -17,7 +17,7 @@ Direct, unmodified `tools/screenshot` capture, Linux/RADV (`AMD Radeon 8060S (RA
 native 3840x2160, default switches, no route:
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA08804-app0 --seconds 20 --count 20 --out ~/shots
 ```
 

--- a/prosper/docs/SYBERIA_STATUS.md
+++ b/prosper/docs/SYBERIA_STATUS.md
@@ -51,7 +51,7 @@ already zero before guest packing/writeback.
 
 ## Route and timing (Linux, hardware Vulkan, RADV, 1920x1080)
 
-`screenshot` / `prosper-app` with `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct
+`screenshot` / `prosper-app` with `PROSPER_GUEST_ARGS=-force-gfx-direct
 PROSPER_RENDER=1`. No input is needed to reach the menu.
 
 | t | state |
@@ -523,7 +523,7 @@ that every consumed recompiler gap is the visible composite cause.
 
 ```bash
 # One settled-menu submit, ~680 MB capsule
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 PROSPER_NO_FRAME_DUMPS=1 \
 PROSPER_GPU_CAPTURE=~/menu.prgcap PROSPER_GPU_CAPTURE_AFTER_MS=190000 \
 PROSPER_GPU_CAPTURE_TARGET_DIM=1920x1080 PROSPER_GPU_CAPTURE_MIN_DRAWS=1 \

--- a/prosper/docs/TACTICS_OGRE_STATUS.md
+++ b/prosper/docs/TACTICS_OGRE_STATUS.md
@@ -47,7 +47,7 @@ placement.
 Use an FFmpeg installation with an HEVC decoder and the normal full-cadence renderer:
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_RENDER=1 \
   ./build-linux/screenshot <DUMP_ROOT>/PPSA03839-app0 \
   --seconds 1 --count 16 --timeout 25 --out ~/tactics-hevc

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -4,9 +4,10 @@ Status as of this doc: the title boots from garbage-byte execution all the way t
 bootstrap, platform-services init, and into UE's **IoStore asset layer**. The MallocBinned
 allocator is deterministically healthy (0 canary fatals) and the engine's own error handler runs.
 
-Boot recipe: `PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 ./boot_trace <PPSA17942-app0>`
-(GUEST_FS: UE MallocBinned TLS caches read `%fs`; NULL_PAGE: UE's FP-chain backtrace walker
-derefs the null chain terminator).
+Boot recipe: `PROSPER_NULL_PAGE=1 ./boot_trace <PPSA17942-app0>`
+(NULL_PAGE: UE's FP-chain backtrace walker derefs the null chain terminator). This title also
+depends on guest `%fs` TLS, because UE's MallocBinned TLS caches read `%fs` — that is on by
+default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for bisection.
 
 ## Ruled out
 
@@ -634,7 +635,7 @@ Two changes of fact, both measured:
   re-verify, then follow the boot toward VideoOut/RHI init and the first SubmitDcb.
 
 Boot recipe (fast): `cp -r` the dump to `/root/PPSA17942-app0` once, then
-`PROSPER_GUEST_FS=1 PROSPER_NULL_PAGE=1 [PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1
+`PROSPER_NULL_PAGE=1 [PROSPER_RENDER=1 PROSPER_GFXLOG=1 PROSPER_FILELOG=1
 PROSPER_EVLOG=1 PROSPER_AMPRLOG=1] ./build-linux/boot_trace /root/PPSA17942-app0` — reaches the
 stall (the current frontier) in ~15-80 s.
 

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -150,7 +150,6 @@ Smoke-test the actual SDL window and Vulkan swapchain without a game, then run t
 
 ```powershell
 prosper/build-mingw-app/prosper-app.exe --test-pattern --frames 120
-$env:PROSPER_GUEST_FS = '1'
 $env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
 prosper/build-mingw-app/prosper-app.exe --dump <DUMP_ROOT>/PPSA24651-app0
 ```

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -41,7 +41,6 @@ The direct executable form is also supported. The environment is currently requi
 is no settings UI:
 
 ```powershell
-$env:PROSPER_GUEST_FS = '1'
 $env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
 $env:PROSPER_SAVEDATA_DIR = "$PWD/savedata"
 ./prosper-app.exe --dump 'D:/PS5/PPSA24651-app0'

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -48,7 +48,7 @@ no-UI launch command, save-data selection, keyboard map, and runtime requirement
 
 ```bash
 # The game (reaching the frame loop needs these two env switches, same as boot_trace):
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
   ./build-app/prosper-app --dump /path/to/PPSA24651-app0
 
 # Window/swapchain smoke without a dump:

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -47,7 +47,7 @@ no-UI launch command, save-data selection, keyboard map, and runtime requirement
 ## Run
 
 ```bash
-# The game (reaching the frame loop needs these two env switches, same as boot_trace):
+# The game (reaching the frame loop needs this env switch, same as boot_trace):
 PROSPER_GUEST_ARGS=-force-gfx-direct \
   ./build-app/prosper-app --dump /path/to/PPSA24651-app0
 

--- a/prosper/scripts/astrobot/README.md
+++ b/prosper/scripts/astrobot/README.md
@@ -37,7 +37,7 @@ through `ps_logo` -> `title_controller_ship` -> `worldmap` and stops there:
 
 ```sh
 cd prosper
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_VULKAN_LIB=libvulkan.so.1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_VULKAN_LIB=libvulkan.so.1 \
   ../build-app/screenshot <DUMP_ROOT>/PPSA21564-app0 \
     --seconds 1 --count 300 --timeout 600 --out ~/astro-run
 ```
@@ -59,7 +59,7 @@ route had produced it. Sample sparsely and run long:
 
 ```sh
 cd prosper
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_VULKAN_LIB=libvulkan.so.1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_VULKAN_LIB=libvulkan.so.1 \
   ../build-app/screenshot <DUMP_ROOT>/PPSA21564-app0 \
     --seconds 20 --count 40 --timeout 1200 --out ~/astro-title
 ```
@@ -125,7 +125,6 @@ On a host without a usable VA-API device, explicitly enable the bounded syntheti
 video fallback for control-flow testing:
 
 ```sh
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_NO_COMPUTE=1 \
 PROSPER_AVP_SYNTH_FRAMES=120 \
@@ -155,7 +154,6 @@ guest pad polling to roughly 1-2 Hz. The route also retains the validated
 flip-anchored Linux sequence:
 
 ```powershell
-$env:PROSPER_GUEST_FS = '1'
 $env:PROSPER_GUEST_ARGS = '-force-gfx-direct'
 $env:PROSPER_NO_COMPUTE = '1'
 $env:PROSPER_PAD_SCRIPT = '@C:/path/to/prosper/scripts/astrobot/reach-first-level-windows.pad'

--- a/prosper/scripts/blasphemous2/README.md
+++ b/prosper/scripts/blasphemous2/README.md
@@ -56,7 +56,6 @@ future vertex-buffer-backed RectList still needs general post-VS corner synthesi
 Capture one full-resolution PNG per second with:
 
 ```bash
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_PAD_SCRIPT=@scripts/blasphemous2/reach-first-gameplay.pad \
 ./build-linux/screenshot /path/PPSA13579-app0 \
@@ -104,7 +103,7 @@ Audio is verifiable without a human listening: `PROSPER_AUDIO_DUMP=<path>` recor
 output, so a run can be asserted on level/coverage.
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 PROSPER_VULKAN_LIB=libvulkan.so.1 PROSPER_AUDIO_DUMP=/tmp/t.raw \
 PROSPER_PAD_SCRIPT=@scripts/blasphemous2/title-screen-idle.pad \
   ./build-linux/prosper-app --dump <PPSA13579-app0>

--- a/prosper/scripts/dragon-quest-vii/README.md
+++ b/prosper/scripts/dragon-quest-vii/README.md
@@ -20,7 +20,6 @@ directory created under `$HOME`; substitute its absolute path before running the
 screenshots do not land in the worktree or `/tmp`.
 
 ```bash
-PROSPER_GUEST_FS=1 \
 PROSPER_NULL_PAGE=1 \
 PROSPER_GUEST_ARGS= \
 PROSPER_SAVE0=<FRESH_SAVE_ROOT>/save0 \

--- a/prosper/scripts/earthion/README.md
+++ b/prosper/scripts/earthion/README.md
@@ -24,7 +24,7 @@ so it covers both rather than guessing an offset; surplus presses land in the me
 the route returns to it, which keeps both arms of an A/B on the same states.
 
 ```bash
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
 PROSPER_RENDER_SCALE=1 PROSPER_RENDER_EVERY=1 \
 PROSPER_PAD_SCRIPT=@scripts/earthion/reach-title-menu.pad PROSPER_PAD_SCRIPT_LOG=1 \
 PROSPER_VULKAN_LIB=libvulkan.so.1 \

--- a/prosper/scripts/evergate/README.md
+++ b/prosper/scripts/evergate/README.md
@@ -47,7 +47,6 @@ carrying them into `prosper-app` skips visible updates during the opening and re
 1920x1080 output at 480x270 before scaling it to the window.
 
 ```sh
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_RENDER_EVERY=1 \
 PROSPER_RENDER_SCALE=1 \

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -7,7 +7,6 @@ immutable replay capsule. Submit numbers are run-local. Vulkan warmup and render
 the selection.
 
 ```bash
-PROSPER_GUEST_FS=1 \
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_GPU_TIMELINE=/tmp/dead-cells.prgtl \
 PROSPER_CAPTURE_TITLE=PPSA15552 \

--- a/prosper/tools/guest_bt/README.md
+++ b/prosper/tools/guest_bt/README.md
@@ -45,7 +45,7 @@ unwinder derived from the swap-stub's fixed stack layout.
 1. Run the title once with the module map (and, for managed names, capture nothing extra — the map is
    all `guest_bt.py` needs):
 
-       PROSPER_INITLOG=1 PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+       PROSPER_INITLOG=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
          ./screenshot <dump>-app0 ... 2> run.log
 
 2. (IL2CPP titles, once) build a managed symbol map — see `tools/il2cpp/README.md` — and keep the

--- a/prosper/tools/hang_probe/README.md
+++ b/prosper/tools/hang_probe/README.md
@@ -11,8 +11,8 @@ so you need a **rate** and a **backtrace of a stuck run**, not one launch. This 
 
 ## What it does
 
-For each run it launches the title headless via `boot_trace` (with the gated `PROSPER_GUEST_FS` /
-`-force-gfx-direct` / `PROSPER_RENDER` switches and a fresh per-run savedata), waits, then attaches
+For each run it launches the title headless via `boot_trace` (with the `-force-gfx-direct` /
+`PROSPER_RENDER` switches and a fresh per-run savedata), waits, then attaches
 `guest_bt` to the main thread (Thread 1) and classifies it:
 
 - **BLOCKED** — the top HLE frame is a kernel wait (`k_sema_wait` / `k_eq_wait` / `k_cond_wait` /

--- a/prosper/tools/hle_calls/README.md
+++ b/prosper/tools/hle_calls/README.md
@@ -28,7 +28,7 @@ python3 tools/hle_calls/hle_calls.py --pid $(pgrep -x boot_trace) --ticks 400
 python3 tools/hle_calls/hle_calls.py --pid <pid> --filter '^s_'
 
 # cover INIT, and record what each handler answered rather than only that it ran
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_GUEST_ARGS=-force-gfx-direct \
 python3 tools/hle_calls/hle_calls.py --ticks 30 --values --filter '^s_' \
     --launch build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
 ```

--- a/prosper/tools/hostprof/README.md
+++ b/prosper/tools/hostprof/README.md
@@ -58,7 +58,7 @@ to isolate a single working thread.
 
 ```bash
 # Boot a title headless, let it reach steady state, then find the hot host function:
-PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
+PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
   ./build-linux/boot_trace /path/PPSA27616-app0 &
 sleep 45
 

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -125,9 +125,9 @@ PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1 screenshot /path/PPSA01885-app0
 ```
 
 `PROSPER_GUEST_FS=1` is named above because the tool really does set it, not because a run needs it:
-guest `%fs` TLS is **on by default** on Linux and Windows since #825 (opt out with
-`PROSPER_NO_GUEST_FS=1`), and `PROSPER_GUEST_FS` is read only on macOS/Rosetta. Do not carry it into a
-new recipe (#2095).
+guest `%fs` TLS is **on by default** on Linux (since #825) and Windows (since #624), and is opted out
+of with `PROSPER_NO_GUEST_FS=1`. `PROSPER_GUEST_FS` is read only on macOS/Rosetta. Do not carry it
+into a new recipe (#2095).
 
 ## Example
 

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -124,6 +124,11 @@ other titles set the appropriate env first, e.g. a UE4 title:
 PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1 screenshot /path/PPSA01885-app0
 ```
 
+`PROSPER_GUEST_FS=1` is named above because the tool really does set it, not because a run needs it:
+guest `%fs` TLS is **on by default** on Linux and Windows since #825 (opt out with
+`PROSPER_NO_GUEST_FS=1`), and `PROSPER_GUEST_FS` is read only on macOS/Rosetta. Do not carry it into a
+new recipe (#2095).
+
 ## Example
 
 ```bash


### PR DESCRIPTION
## The failure scenario

36 tracked Markdown files prescribed `PROSPER_GUEST_FS=1` inside a runnable command, on **65 lines**.

Exactly one place in the tree reads that variable:

```c
// prosper/src/host/guest_tls.cpp
#ifdef __APPLE__
    g_enabled = getenv("PROSPER_GUEST_FS")    != nullptr;   // :46  — macOS/Rosetta trap mode ONLY
#else
    g_enabled = getenv("PROSPER_NO_GUEST_FS") == nullptr;   // :58  — Linux: default ON, opt-OUT
#endif
...
#elif defined(_WIN32)
    g_enabled = getenv("PROSPER_NO_GUEST_FS") == nullptr;   // :240 — Windows: default ON, opt-OUT
```

Guest initial-exec TLS became **on by default** in #825 (`4fd585ac`, 2026-07-17) on Linux, and was
`PROSPER_NO_GUEST_FS`-gated on Windows from #624 (2026-07-13). On both platforms `PROSPER_GUEST_FS`
is never read and never validated, so a recipe carrying it runs **identically with and without it** —
the token reads as load-bearing while doing nothing, which is what makes a reproduction block
unfalsifiable ("I ran the documented route" and "I ran something else" produce the same result).

Verified by reading the file, not by citing it — `grep -n 'getenv("PROSPER_GUEST_FS' -- '*.cpp' '*.hpp'`
returns exactly one hit, `guest_tls.cpp:46`, and the enclosing `#ifdef __APPLE__` is at `:45`.

## What changed — 52 removals, 13 deliberate retentions

This is per-file judgement. A diff that removed all 65 would be wrong.

`PROSPER_GUEST_FS=1` across tracked Markdown: **65 → 17**, and 4 of the 17 are notes added by this
PR, leaving the **13** intended retentions.

| retained in | count | why |
| --- | --- | --- |
| `CLAUDE.md` | 1 | already the corrective mention (line 277) — untouched |
| `docs/RENDER_LOOP.md` | 5 | superseded log; runs **predate** the flip, so the switch really was load-bearing |
| `docs/NEXT_STEP_VERTEX_FETCH.md` | 2 | same — superseded, pre-flip |
| `docs/CUTSCENE_PROGRESSION.md` | 2 | dated pre-flip records of what a past run used |
| `docs/DOLL_LOADING_PROGRESSION.md` | 1 | dated pre-flip record (2026-07-10) |
| `docs/ASTERIX_BABYLON_STATUS.md` | 1 | describes what `tools/screenshot` **really sets** (`screenshot.cpp:391`) — true as written |
| `tools/screenshot/README.md` | 1 | same; the README now adds that the default is inert off macOS |

The historical point matters and is why the superseded docs are annotated rather than rewritten:
before 2026-07-17 `PROSPER_GUEST_FS=1` **was** the Linux opt-in gate. Deleting it from a record of a
July run would falsify that record. Those docs get one note near the top instead; the commands are
left exactly as they were run.

Everything else — 31 files — goes to zero. Per-file before/after:

| file | before | after |
| --- | --- | --- |
| `README.md` | 1 | 0 |
| `docs/ARCRUNNER_STATUS.md` | 8 | 0 |
| `docs/ASTROBOT_LINUX_HANDOFF_2026_07_19.md` | 3 | 0 |
| `docs/BLUE_PRINCE_STATUS.md` | 1 | 0 |
| `docs/CUTSCENE_GC_ABORT.md` | 1 | 0 |
| `docs/CUTSCENE_PROGRESSION.md` | 3 | 3 (1 removed, 1 note added) |
| `docs/CUTSCENE_RENDER.md` | 2 | 0 |
| `docs/DOLL_LOADING_PROGRESSION.md` | 2 | 1 |
| `docs/DOLL_POSTPROCESS_HANDOFF.md` | 1 | 0 |
| `docs/DRAGON_QUEST_STATUS.md` | 1 | 0 |
| `docs/EVERGATE_PERFORMANCE_HANDOFF_2026_07.md` | 1 | 0 |
| `docs/LINUX_RELEASE.md` | 1 | 0 |
| `docs/LITTLE_NIGHTMARES_3_STATUS.md` | 1 | 0 |
| `docs/NEXT_STEP_VERTEX_FETCH.md` | 2 | 3 (note added) |
| `docs/NIKODERIKO_STATUS.md` | 1 | 0 |
| `docs/OREGON_TRAIL_STATUS.md` | 3 | 0 |
| `docs/REAL_FRAMES_FINDINGS.md` | 2 | 0 |
| `docs/RENDER_LOOP.md` | 5 | 6 (note added) |
| `docs/R_TYPE_DELTA_STATUS.md` | 4 | 0 |
| `docs/SONIC_CROSSWORLDS_STATUS.md` | 1 | 0 |
| `docs/SYBERIA_STATUS.md` | 2 | 0 |
| `docs/TACTICS_OGRE_STATUS.md` | 1 | 0 |
| `docs/UE4_APR_IOSTORE_BRINGUP.md` | 2 | 0 |
| `frontends/prosper-app/README.md` | 1 | 0 |
| `scripts/astrobot/README.md` | 3 | 0 |
| `scripts/blasphemous2/README.md` | 2 | 0 |
| `scripts/dragon-quest-vii/README.md` | 1 | 0 |
| `scripts/earthion/README.md` | 1 | 0 |
| `scripts/evergate/README.md` | 1 | 0 |
| `tools/gpu_timeline/README.md` | 1 | 0 |
| `tools/guest_bt/README.md` | 1 | 0 |
| `tools/hle_calls/README.md` | 1 | 0 |
| `tools/hostprof/README.md` | 1 | 0 |
| `tools/screenshot/README.md` | 1 | 2 (note added) |
| `CLAUDE.md` | 1 | 1 (untouched) |
| `docs/ASTERIX_BABYLON_STATUS.md` | 1 | 1 (untouched) |

## One correction to the issue's own file list

**#2095 says `WINDOWS_PORT_HANDOFF.md`, `WINDOWS_RELEASE.md` and `PORTING.md` are macOS docs where
the variable is correct and must be kept. That is right only for `PORTING.md`.**

The two Windows docs set `$env:PROSPER_GUEST_FS = '1'` in PowerShell blocks. The `_WIN32` arm of
`guest_tls.cpp` begins at `:197` and never reads it — its own comment says *"guest-fs is enabled
whenever templates are configured (opt out with `PROSPER_NO_GUEST_FS` for bisection)"*, and the only
`getenv` in that arm is `PROSPER_NO_GUEST_FS` at `:240`. So those two are inert Windows uses, and are
corrected here rather than preserved. The same PowerShell form in `scripts/astrobot/README.md` (a
Windows acceptance block) is corrected too. These are outside the 65 because they use the `$env:`
form, which the issue's `PROSPER_GUEST_FS=1` grep does not match.

`PORTING.md` genuinely is the macOS doc: its occurrence at the macOS trap-mode section is **kept**,
and reworded to say explicitly that macOS is the one platform that reads the variable. Its other
mention was in the Linux port-surface list, where it named the wrong gate; that now reads
"on by default; opt out with `PROSPER_NO_GUEST_FS`".

## A false claim found along the way

`docs/CRISIS_CORE_STATUS.md` described its reproduction route as "**No `PROSPER_GUEST_FS`**, no
`-force-gfx-direct`". On Linux that is false: omitting the variable does not disable guest TLS,
which is on by default. Corrected in place.

## Deliberately NOT changed

- **`CLAUDE.md`** — already carries the correction at line 277.
- **Non-Markdown occurrences (68 files).** `tools/dbg/*.sh`, `scripts/diag/*.sh`,
  `scripts/start-prosper.sh`, `scripts/start-prosper.ps1`, `scripts/run-windows.ps1`,
  `tools/snapshot/snapshot.py`, `tools/hang_probe/hang_probe.py`, `tools/screenshot/screenshot.cpp:391`
  and the three tests that `setenv` it. These *set* an unread variable, which is harmless, but
  removing them is a code change with its own risk surface and belongs in its own PR. #2095 scopes
  itself to the 36 docs / 65 lines. Filed separately so it is not lost.
- **`docs/UNITY_SHADER_FORMAT.md:6`** and **`docs/BUG_HUNT_BACKLOG.md:31`** — both name the
  *feature/code path* by variable name in a historical sentence, not a runnable recipe. Rewriting
  them would add noise without removing a prescription.
- Source comments in `exec_image_linux.cpp`, `hle_kernel.cpp`, `hle_service.cpp` — they describe the
  mechanism correctly and `exec_image_linux.cpp:2344` already states the Linux default.

## Verification

No build or test covers documentation, so the burden is on showing the edit discriminates.

```bash
# 1. Exactly one reader of the variable, and it is Apple-only.
git grep -n 'getenv("PROSPER_GUEST_FS' -- '*.cpp' '*.hpp'
#   prosper/src/host/guest_tls.cpp:46      (enclosing #ifdef __APPLE__ at :45)

# 2. Prescriptive uses, before -> after
git grep -c 'PROSPER_GUEST_FS=1' -- '*.md' | awk -F: '{s+=$2} END {print s}'
#   origin/master: 65 across 36 files      this branch: 17 across 7 files
#   (4 of the 17 are notes added here => 13 deliberate retentions)

# 3. The macOS occurrence SURVIVED — the reviewer's first check.
git grep -n 'PROSPER_GUEST_FS' -- prosper/docs/PORTING.md
#   :292  macOS "trap mode" (opt-in, and the one platform where PROSPER_GUEST_FS is read ...)

# 4. Every deletion in the merged tree is either the token or an intended rewrap (trap 41).
TREE=$(git merge-tree --write-tree origin/master HEAD)
git diff origin/master "$TREE" -- | grep '^-' | grep -v '^---' | grep -v 'PROSPER_GUEST_FS'
#   7 lines, all rewraps of paragraphs the token was removed from (LINUX_RELEASE "those
#   switches"->"that switch", PORTING, REAL_FRAMES, R_TYPE, UE4 x2, hang_probe). No other lane's
#   work is reverted.

# 5. Docs CI, both steps, run locally exactly as ci.yml does.
python3 prosper/tools/docs/check_numbered_table.py --github --sequential \
  --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md
#   14 table(s), 167 rows, contiguous and unbroken   rc=0
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github
#   91 files, all unbroken                           rc=0

git diff --check     # rc=0
```

Code-fence balance was checked in all 39 edited files (every file has an even number of ``` lines),
since 10 of the removals deleted a whole line-continuation line inside a fenced block.

**Snapshots: not run, and not applicable** — documentation only, no code path touched.

## Risk

Low, and bounded to prose. The only way this changes a run is if some path read `PROSPER_GUEST_FS`
on Linux or Windows; check 1 above shows nothing does. The residual risk is editorial: a removed
token in a doc whose surrounding section was actually macOS. Every one of the 65 lines was read in
context first; none of the 52 removals sits in a macOS section (all are `build-linux`, AppImage,
distrobox, WSL or PowerShell/MinGW recipes), and the only macOS section in the tree is
`PORTING.md`'s, which is preserved.

Fixes #2095
