### PR TITLE
fix(win): set _WIN32_WINNT before the first include in hle_kernel_mem.cpp — master does not compile on Windows

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -3,6 +3,15 @@
 // an opaque offset, then map it (or flexible memory) into VA. We back it with host
 // native VM primitives and TRACK every mapping so VirtualQuery is truthful and so we can
 // log/debug the guest's address-space construction.
+#ifdef _WIN32
+// Must precede EVERY header — including <thread>/<mutex>/<atomic>, which pull in MinGW's _mingw.h and
+// default _WIN32_WINNT to 0x0601 (Windows 7). A later `#ifndef _WIN32_WINNT` is then a silent no-op, and
+// GetCurrentThreadStackLimits / WaitOnAddress / WakeByAddress* (all >= 0x0602, Win8) go undeclared.
+// Same placement rule as hle_kernel.cpp and exec_image_win.cpp.
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
+#endif
 #include "dispatch.hpp"
 #include "dmem_caller_chain.hpp"
 #include "guest_memory_topology.hpp"
@@ -2483,9 +2492,8 @@ int dmem_caller_scan_slots_for_test(const volatile uint64_t* frame, int want) {
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x0A00   // Win10: WaitOnAddress/WakeByAddress* need >= 0x0602 (Win8)
-#endif
+// _WIN32_WINNT is set at the TOP of this file, not here: by this point the C++ standard headers
+// above have already fixed it at MinGW's 0x0601 default, so an `#ifndef` here would never fire.
 #include <windows.h>
 #include <winioctl.h>
 #include <algorithm>


### PR DESCRIPTION
## Goal

Make master compile on native Windows again. It currently does not, with the WinLibs MinGW-w64 UCRT
toolchain that `docs/WINDOWS_PORT_HANDOFF.md` prescribes and `prosper/scripts/run-windows.ps1`
auto-detects.

## Failure

```
src/hle/hle_kernel_mem.cpp:2567: error: 'GetCurrentThreadStackLimits' was not declared in this scope
```

`hle_kernel_mem.cpp` raises `_WIN32_WINNT` to `0x0A00` immediately before its own
`#include <windows.h>`, roughly 2,480 lines into the file. By then the C++ standard headers at the
top of the file (`<thread>`, `<mutex>`, `<atomic>`, …) have already pulled in MinGW's `_mingw.h`,
which fixes `_WIN32_WINNT` at its `0x0601` default — so the `#ifndef _WIN32_WINNT` guard never
fires. mingw-w64 declares `GetCurrentThreadStackLimits` only under `_WIN32_WINNT >= 0x0602`.

Confirmed directly: a TU containing only `#include <thread>` / `#include <mutex>` already has
`_WIN32_WINNT == 0x0601`.

The call arrived with #1778 (`e96cbd93`, 2026-08-02), which bounded `PROSPER_DMEM_CALLER`'s stack
walk to mapped memory. CI's MSYS2 gcc accepts it, which is why the break was not visible there.

## Approach

Move the define above every include, matching the placement `hle_kernel.cpp` and
`exec_image_win.cpp` already use — both of which carry a comment explaining why it has to go first.
The late guard is replaced by a comment recording that an `#ifndef` at that point is a no-op, so it
does not get reintroduced.

## Affected / unaffected

No behavioural change on any platform. The macro only gates Win32 header declarations, and the sole
Windows API it newly exposes is the one this file already calls. Linux and macOS do not compile the
`_WIN32` half at all.

## Risk

Low. One preprocessor define moved within one file.

## Verification

Native Windows 11, WinLibs MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 1.4.350.0, RTX 4090:

```powershell
cmake -S prosper -B prosper/build-mingw-app -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo `
  -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON
cmake --build prosper/build-mingw-app --target prosper-app screenshot --parallel 16
```

- Before: fails as above at `[70/353]`.
- After: builds clean; `prosper-app.exe` and `screenshot.exe` produced.
- The Messenger (`PPSA24651`) then boots and composites real 1920×1080 frames through the native
  SDL3/Vulkan frontend; a 36-sample fresh-save route run completed 36/36 with
  `--min-distinct-frames 25 --min-pixel-distinct-frames 10 --require-composited-frame`, exit 0.

Note the run above still shows the separate Windows presentation defect tracked in #2101; this PR is
strictly the compile fix and does not address it.
