### PR TITLE
fix(render): stop two off-by-default diagnostics from switching themselves on (~10x frame rate)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3842,7 +3842,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // Focused per-consumer version probe (#586). Hash both the raw guest backing
                         // and the final decoded/RTT-injected pixels so a live draw identifies whether
                         // divergence precedes format conversion or enters through renderer-owned state.
-                        if (resource_hash_w == tw && resource_hash_h == th) {
+                        // Unset parses to 0x0; require the probe to have been requested (see the
+                        // matching guard on the pass hash below).
+                        if (resource_hash_w && resource_hash_h &&
+                            resource_hash_w == tw && resource_hash_h == th) {
                             const size_t raw_size = std::min<size_t>(
                                 r.size ? r.size : volume_texels * 4, 64u << 20);
                             std::vector<uint8_t> raw(raw_size, 0);
@@ -5586,7 +5589,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             surface.rgba.reset();
                     }
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
-                    if (native_w == resource_hash_w && native_h == resource_hash_h &&
+                    // Both dims parse to 0 when PROSPER_RESOURCE_HASH_DIM is UNSET, so an extent
+                    // comparison alone made every 0x0 pass satisfy the filter and switch the
+                    // diagnostic on by itself. Require it to have actually been requested.
+                    if (resource_hash_w && resource_hash_h &&
+                        native_w == resource_hash_w && native_h == resource_hash_h &&
                         !rendered_pixels.empty()) {
                         uint64_t hash = 1469598103934665603ull;
                         for (uint8_t byte : rendered_pixels) {
@@ -5612,7 +5619,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 first ? first->ps.clear_color[3] : 0.0f,
                                 (unsigned long long)hash);
                     }
-                    if (native_w == target_step_w && native_h == target_step_h &&
+                    // Same unset-is-0 trap as the resource hash above, and far more expensive here:
+                    // the loop below re-renders every growing draw prefix, so a 0x0 pass silently
+                    // turned one pass into O(draws^2) rendering plus a readback and pixel census per
+                    // step. Require PROSPER_TARGET_STEP_HASH_DIM to have actually been requested.
+                    if (target_step_w && target_step_h &&
+                        native_w == target_step_w && native_h == target_step_h &&
                         render_pass.size() >= target_step_min_draws) {
                         for (size_t k = 1; k <= render_pass.size(); ++k) {
                             std::vector<const prosper::gpu::DrawItem*> prefix(


### PR DESCRIPTION
## Goal

Stop two off-by-default graphics diagnostics from switching themselves on, which costs roughly a
10x frame rate on live boots and starves the audio mixer.

## Failure

`PROSPER_RESOURCE_HASH_DIM` and `PROSPER_TARGET_STEP_HASH_DIM` parse their `WxH` into locals that
start at `0` and stay `0` when the variable is unset. The filters then tested extent equality alone:

```cpp
if (native_w == resource_hash_w && native_h == resource_hash_h && ...)
if (native_w == target_step_w  && native_h == target_step_h  && ...)
```

Any render pass whose extent is `0x0` satisfies `0 == 0 && 0 == 0`, so the diagnostic arms itself
with nothing requested. That shape is not rare: a pass with no color0 extent and no
viewport-derived extent reaches this code on live boots of both The Messenger (`PPSA24651`) and
Blasphemous 2 (`PPSA13579`).

The cheap one FNV-hashes the whole pass. The expensive one **re-renders every growing draw prefix**
through `build_bds()`, so one pass becomes O(draws^2) rendering plus a CPU readback and a pixel
census per step, and prints a line for each.

## Approach

Require each diagnostic to have actually been requested before its extent filter can match. The same
unset-is-0 trap sits on the per-consumer texture probe (`resource_hash_w == tw`), where a 0x0 texture
would arm it; closed identically so all three read the same way.

## Behavioural contract

- Variables **set**: unchanged. A real `WxH` is non-zero, so the added conjunct is true and the
  filter is exactly the old extent test.
- Variables **unset**: silent, which is what "off by default" already claimed.

## Measured effect

Native Windows, RTX 4090, same route, no other change:

| | before | after |
|---|---|---|
| Blasphemous 2 | 205 render submits in 111 s (~1.85/s), 725 KiB of `[target-step]` spam in 2 min | frame_seq 1280 in 75 s (~17/s) |
| The Messenger | frame 333 at 40 s (~8/s) | frame 3246 at 40 s (~81/s) |

The starvation is also what the audio was hearing: Blasphemous 2's FMOD update is driven per frame,
and #1080 records its streaming voices dropping out when the frame rate collapses. The distorted
output on a Windows run is audibly gone after this change.

## Affected / unaffected

Affects only the two diagnostic paths and the texture probe. No renderer output changes: none of the
three sites writes to a target, a descriptor, or the present source -- they hash, count, and print.
Platform-independent code; the measurements above are Windows only because that is where it was
found.

## Risk

Low. Three filters gain a conjunct that is true whenever the feature is in use.

## Verification

Built and run on native Windows (WinLibs MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 1.4.350.0). Both
titles above re-run with the identical route and capture settings; rates as tabulated, and
`[target-step]`/`[target-version]` no longer appear with the variables unset. Setting
`PROSPER_TARGET_STEP_HASH_DIM` to a real extent still produces the diagnostic.

This PR does not depend on, and does not address, the separate Windows presentation defect in #2101:
both titles still present incorrectly, only much faster.

Requires #2103 to build on Windows at all.
