### PR TITLE
tools(regwatch): PROSPER_REGWATCH=Cx:* censuses a whole register class

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -62,6 +62,15 @@ std::vector<RegWatchEntry> parse_reg_watch(const char* setting) {
             item = item.substr(colon + 1);
             if (item.empty()) continue;
         }
+        if (item == "*") {
+            // Whole-class watch; only meaningful with an explicit class prefix (a bare "*" would
+            // not say which file to watch, so it is skipped like any other unparsable entry).
+            if (colon == std::string::npos) continue;
+            entry.all_offsets = true;
+            if (std::find(entries.begin(), entries.end(), entry) == entries.end())
+                entries.push_back(entry);
+            continue;
+        }
         char* end = nullptr;
         errno = 0;
         const unsigned long parsed = std::strtoul(item.c_str(), &end, 0);
@@ -88,16 +97,23 @@ void reg_watch_report(RegClass reg_class, uint32_t offset, uint32_t value, uint3
     if (entries.empty()) return;
     for (const auto& entry : entries) {
         if (entry.reg_class != reg_class) continue;
-        if (entry.offset < offset || entry.offset >= offset + (count ? count : 1u)) continue;
-        const uint32_t index = entry.offset - offset;
-        const uint32_t written = values && index < count ? values[index] : value;
-        static std::atomic<int> emitted{0};
-        if (emitted.fetch_add(1) >= 400000) return;
-        const char* cn = reg_class == RegClass::Cx ? "Cx"
-                       : reg_class == RegClass::Sh ? "Sh" : "Uc";
-        std::fprintf(stderr, "[regwatch] class=%s off=0x%x val=0x%08x path=%s span=0x%x+%u order=%llu\n",
-                     cn, entry.offset, written, path, offset, count,
-                     static_cast<unsigned long long>(command_order));
+        // A whole-class watch reports every offset of the reported span; a single-offset watch
+        // reports only its own dword within that span.
+        const uint32_t span = count ? count : 1u;
+        const uint32_t first = entry.all_offsets ? 0u : entry.offset - offset;
+        if (!entry.all_offsets &&
+            (entry.offset < offset || entry.offset >= offset + span)) continue;
+        for (uint32_t index = first; index < (entry.all_offsets ? span : first + 1u); ++index) {
+            const uint32_t written = values && index < count ? values[index] : value;
+            static std::atomic<int> emitted{0};
+            if (emitted.fetch_add(1) >= 400000) return;
+            const char* cn = reg_class == RegClass::Cx ? "Cx"
+                           : reg_class == RegClass::Sh ? "Sh" : "Uc";
+            std::fprintf(stderr,
+                         "[regwatch] class=%s off=0x%x val=0x%08x path=%s span=0x%x+%u order=%llu\n",
+                         cn, offset + index, written, path, offset, count,
+                         static_cast<unsigned long long>(command_order));
+        }
     }
 }
 }  // namespace

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -319,8 +319,12 @@ extern "C" void prosper_gpu_set_fold_origin(uint8_t origin);
 // from the submit paths, under the submit mutex.
 void submit_completion_pulse(bool submit_rejected = false);
 
-// PROSPER_REGWATCH=[Cx:|Sh:|Uc:]OFF[,...]: log every write to nominated registers from BOTH the
+// PROSPER_REGWATCH=[Cx:|Sh:|Uc:]OFF|*[,...]: log every write to nominated registers from BOTH the
 // direct (SET_*_REG) and indirect (Set*RegsIndirect) paths, with value and command order.
+// `Cx:*` (class + `*`) watches every offset of that class — use it to census which registers a title
+// programs at all, then narrow to specific offsets. High volume by construction; the emitter is
+// capped, so treat a whole-class census as a shape, not a rate (see the print-cap trap in
+// docs/GAME_COMPAT_ORCHESTRATION.md).
 //
 // Resolved state alone cannot answer "which packet wrote this register, and was it ever written at
 // all?" — a register the guest never programs and one it programs to a value that happens to look
@@ -330,8 +334,14 @@ void submit_completion_pulse(bool submit_rejected = false);
 struct RegWatchEntry {
     RegClass reg_class = RegClass::Cx;
     uint32_t offset = 0;
+    // `Cx:*` watches EVERY offset of one class. Asking "which registers does this title program at
+    // all?" otherwise requires guessing the offsets up front, and a register the guest never writes
+    // is indistinguishable from one whose offset you failed to list — the exact ambiguity this watch
+    // exists to remove.
+    bool all_offsets = false;
     bool operator==(const RegWatchEntry& o) const {
-        return reg_class == o.reg_class && offset == o.offset;
+        return reg_class == o.reg_class && offset == o.offset &&
+               all_offsets == o.all_offsets;
     }
 };
 

--- a/prosper/tests/test_command_processor.cpp
+++ b/prosper/tests/test_command_processor.cpp
@@ -595,6 +595,24 @@ int main() {
         const auto deduped = parse_reg_watch("0x202,0x202,Cx:0x202");
         CHECK(deduped.size() == 1,
               "a repeated register is watched once so one write reports one line");
+
+        // `Cx:*` censuses a whole class. Without it, "this title never writes register X" cannot be
+        // told apart from "X was not on the list I guessed", which is the question the watch exists
+        // to answer.
+        const auto whole = parse_reg_watch("Sh:*");
+        CHECK(whole.size() == 1 && whole[0].all_offsets &&
+                  whole[0].reg_class == RegClass::Sh,
+              "a class-qualified * watches every offset of that class");
+
+        CHECK(parse_reg_watch("*").empty(),
+              "a bare * names no register file and is skipped like any unparsable entry");
+
+        const auto mixed = parse_reg_watch("Cx:*,Cx:0x202");
+        CHECK(mixed.size() == 2 && mixed[0].all_offsets && !mixed[1].all_offsets,
+              "a whole-class watch and a single offset of the same class are distinct entries");
+
+        const auto both = parse_reg_watch("Cx:*,Cx:*");
+        CHECK(both.size() == 1, "a repeated whole-class watch is deduplicated");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
## Goal

Let `PROSPER_REGWATCH` answer "which registers does this title program at all?", not only "was this
specific offset written?".

## Why it matters

Those are different questions, and the second one is what identifies a defect. With only per-offset
watches, a register the guest never writes is indistinguishable from one whose offset you failed to
put on the list, so "no writes observed" quietly means both.

This is what localised #2101. Censusing the Cx class on Windows showed The Messenger programming 53
distinct context registers against Alex Kidd's 139 on the same binary, with `CB_COLOR0_BASE` and
both viewport-scale registers absent from the first and present in the second. That comparison
cannot be made by guessing offsets, because the interesting fact was precisely which offsets were
missing.

## Approach

`Cx:*` (a class prefix plus `*`) reports every offset of that class, from both the direct
(`SET_*_REG`) and indirect (`Set*RegsIndirect`) paths. It reuses the existing span reporting, so a
multi-register `SET_*_REG` range reports each dword that actually landed rather than one line for
the range.

A bare `*` names no register file and is skipped like any other unparsable entry, preserving the
existing "one bad entry never disables the rest of the list" contract.

## Behavioural contract

With no `*` in the setting, every entry parses and reports exactly as before -- the added branch is
not reached. Deduplication still applies, and a whole-class watch and a single offset of the same
class remain distinct entries.

## Caveat, stated in the header

The output is high volume by construction and the emitter keeps its existing 400,000-line cap, so a
whole-class census reports a **shape, not a rate**. The header says so and points at the print-cap
trap already recorded in `GAME_COMPAT_ORCHESTRATION.md`. Narrow to explicit offsets before quoting
counts: the census in #2101 hit the cap on Linux, and its per-offset numbers came from a targeted
re-run for exactly that reason.

## Affected / unaffected

Diagnostic-only. `reg_watch_report` returns immediately when no watch is configured, which is every
normal run; nothing in the emulated pipeline reads the entries.

## Risk

Low. One new parse branch and one loop bound in a diagnostic emitter.

## Verification

`test_command_processor` extends the existing pure selector test with four assertions: a
class-qualified `*` sets `all_offsets` for that class; a bare `*` is rejected; a whole-class watch
and a single offset of the same class stay distinct; a repeated whole-class watch deduplicates.

```
$ cmake --build prosper/build-linux --target test_command_processor -j 20
$ ./prosper/build-linux/test_command_processor
  [ok]   a class-qualified * watches every offset of that class
  [ok]   a bare * names no register file and is skipped like any unparsable entry
  [ok]   a whole-class watch and a single offset of the same class are distinct entries
  [ok]   a repeated whole-class watch is deduplicated
== PASS ==
```

Each new assertion fails without the change: `parse_reg_watch("Sh:*")` returns an empty vector on
master, so the first, third and fourth assertions fail on size, and `all_offsets` does not exist.

Also exercised live on both platforms (`PROSPER_REGWATCH='Cx:*'` against `PPSA24651` and
`PPSA02664`) while producing the #2101 census.
