### PR TITLE
docs(charter): a documentation-only PR may merge immediately, without waiting for CI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -352,7 +352,27 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   produced by forced guest-state diagnostics may illustrate an investigation but is not acceptance evidence.
   Run the strongest relevant local checks and wait for every applicable required CI check. Before
   merging, synchronize with the live target branch when needed, inspect the resulting diff, run `diff --check`,
-  and address every known correctness concern. An agent may merge only when the user or task explicitly
+  and address every known correctness concern.
+  - **Exception — a documentation-only PR may be merged immediately, without waiting for CI.** If the diff
+    touches nothing but `.md` files, there is no build, no test and no snapshot that CI can tell you
+    anything about, so waiting on it only slows the queue. Merge it.
+    **Run the docs gate locally first** — it is the one check that can actually fail on a docs diff, and
+    it takes a second:
+    ```bash
+    python3 prosper/tools/docs/check_numbered_table.py --sequential \
+        --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+    git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
+    ```
+    This matters most for `GAME_COMPAT_ORCHESTRATION.md`'s numbered tables, where the gate requires rows
+    to be unique, ascending **and gapless**: several lanes append to them concurrently, so a PR that was
+    contiguous when written can be gapped by the time it merges (#2087 sat conflicting for exactly this).
+    Confirm the diff really is `.md`-only — `git diff --name-only origin/master...HEAD | grep -v '\.md$'`
+    should be empty. The exception is about the *diff*, not the intent; one stray file makes it an
+    ordinary PR again.
+    **This waives the CI wait only.** It does not waive independent review where review is warranted — a
+    docs PR that rewrites a `## Ruled out` row, a reproduction route, or a numbered table's semantics can
+    be just as wrong as code, and no CI job has ever been able to see that. It also does not waive
+    `diff --check`, the trap-41 deletion check, or the session-trailer gate. An agent may merge only when the user or task explicitly
   authorizes it. Each agent owns its PR through merge and branch cleanup: before claiming or starting new work,
   merge the current PR after all gates pass, or explicitly close it with a clear rejected/superseded explanation.
   Do not accumulate floating PRs or silently hand merge ownership to another agent. The PR author owns


### PR DESCRIPTION
Project owner's decision, recorded in the charter so it applies to every lane rather than living in one conversation.

## The rule

**If a PR's diff touches nothing but `.md` files, merge it immediately — do not wait for CI.** There is no build, no test and no snapshot for CI to report on, so the wait only slows the queue behind changes that cannot break anything CI measures.

## What it does not waive

Scoped deliberately, because "docs" is not a synonym for "harmless":

- **Not independent review.** A docs PR that rewrites a `## Ruled out` row, a reproduction route, or a numbered table's semantics can be exactly as wrong as code, and no CI job has ever been able to see that. Today alone, #2091, #2093 and #2097 each had a real defect caught by a reader and by nothing else — a sample selected for the condition under test, a retracted claim left in a PR body, and an instruction of mine that was simply incorrect.
- **Not the local docs gate.** That is the one check that *can* fail on a docs diff, and it takes a second. The exception carries it as a requirement, run locally instead of waited on.
- **Not `diff --check`, the trap-41 deletion check, or the session-trailer gate.**

## Why the numbered-table gate is called out specifically

`GAME_COMPAT_ORCHESTRATION.md`'s tables must be unique, ascending **and gapless**, and several lanes append to them concurrently. A PR that was contiguous when written can be gapped by the time it merges — #2087 sat conflicting for exactly this reason. The exception also tells the reader to confirm the diff really is `.md`-only, since the rule is about the *diff*, not the intent, and one stray file makes it an ordinary PR again.

## Verification

```
python3 prosper/tools/docs/check_numbered_table.py --sequential \
    --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md
  -> 14 table(s), 171 rows, contiguous and unbroken

git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py  -> clean
git diff --check  -> clean
```

`git diff --word-diff` against master is empty on the `-` side: the one apparent deletion is a line rewrap, and no prose is removed. `git merge-tree --write-tree origin/master HEAD` confirms the change is confined to `CLAUDE.md`.
