### PR TITLE
diag(#1968): name Sonic Frontiers' non-draw scanout writer, and aim a census by wall time

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -536,6 +536,12 @@ if(TARGET prosper_core)
   target_include_directories(test_guest_scanout_present PRIVATE frontends/shared)
   add_test(NAME guest_scanout_present COMMAND test_guest_scanout_present)
 
+  # The census window PROSPER_PASS_LOG / PROSPER_DUMP_PERSISTENT open: an ordinal (unchanged) or
+  # `ms:<millis>` (#1968). Pure predicate — no renderer, no device, and the clock is an argument.
+  add_executable(test_diagnostic_window frontends/shared/test_diagnostic_window.cpp)
+  target_include_directories(test_diagnostic_window PRIVATE frontends/shared)
+  add_test(NAME diagnostic_window COMMAND test_diagnostic_window)
+
   # boot_trace periodic BMPs are opt-in, with the legacy disable taking priority. This exercises the
   # exact environment-name lookup and registrar forwarding without constructing Vulkan or writing files.
   add_executable(test_frame_dump_policy frontends/shared/test_frame_dump_policy.cpp)

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -581,7 +581,12 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   only writer of either registered VideoOut buffer (`0x200a160000` / `0x200c140000`) is
   `compute-buffer … identity=0x20002fe800 size=33423360` — the storage-image writeback of **one**
   compute program, alternating between the two buffers, packing and tiling its result back into
-  guest memory across the padded SW_64KB_R_X footprint. **Zero** `dma-data` and **zero**
+  guest memory across the padded SW_64KB_R_X footprint. **Do not read that event count as a dispatch
+  rate**: `live_compute`'s "skipped identical storage writeback" fast path `continue`s *before* the
+  record, so the events count writes that **changed** something — 237 over 360 s against ~1,055
+  flips, collapsing to ~0 per sample once the frame is uniformly black and every writeback is
+  byte-identical to the last. The dispatch is still issued: a capture selected by
+  `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires in the black phase. **Zero** `dma-data` and **zero**
   `write-data` events touch either address, and the draw half is settled independently by the pass
   census below (`vo=1` on 0 of 8,443 records). So the guest composites with a compute dispatch,
   prosper executes it, prosper writes it back, and prosper publishes it. Reach for

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -573,6 +573,61 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   Cyber Space intro, Sonic Team logo and middleware credits from the same run are exact 4K frames. Do
   not look for a lost render target, a mis-selected pass or a dropped publish for this symptom: the
   remaining blocker is upstream guest progression. #1968 / #2023.
+- **A title's "non-draw" scanout writer is findable, and on Sonic Frontiers it is one compute
+  dispatch — so prosper is the writer, and there is no identity or aliasing failure to look for.**
+  The rows above establish that no pass ever targets the flipped buffer and that the frame is in
+  guest memory anyway; neither says *what puts it there*, and "a path that is not a draw" was as far
+  as it went. `PROSPER_PROVENANCE_ADDR=<scanout>:<span>` answers it exactly. Over a full boot the
+  only writer of either registered VideoOut buffer (`0x200a160000` / `0x200c140000`) is
+  `compute-buffer … identity=0x20002fe800 size=33423360` — the storage-image writeback of **one**
+  compute program, alternating between the two buffers, packing and tiling its result back into
+  guest memory across the padded SW_64KB_R_X footprint. **Zero** `color` (draw) and **zero**
+  `dma-data` events touch either address. So the guest composites with a compute dispatch, prosper
+  executes it, prosper writes it back, and prosper publishes it. Reach for `PROSPER_PROVENANCE_ADDR`
+  first on any title whose scanout no pass targets — it names the writer kind, the program's code
+  address and the submit, which no pass census can. #1968.
+- **Post-intro Frontiers runs a complete post-processing chain over an empty scene — the missing
+  thing is geometry, not a composite step.** A capture of the submit containing that composite
+  dispatch (selected with `PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x20002fe800`, 240 s into a default
+  launch) holds 15 draws and 2 dispatches, and **every draw is a `vcount=3 indices=0` fullscreen
+  triangle**: bloom into a 1920x1080 `R11G11B10F`, a 9-tap bloom composite into a 3840x2160
+  `RGBA16F`, a 960x540 -> 64x64 -> 16x16 -> 4x4 -> 2x1 luminance reduction, a tonemap into a
+  3840x2160 `RGBA8`, then the dispatch into the scanout. All 17 operations are `realized=yes`,
+  `failed=0`. There is no scene pass, no indexed draw and no depth geometry anywhere in it. #1968.
+- **Every renderer-owned target really is black in that phase, on the default path, measured.** A
+  `PROSPER_DUMP_PERSISTENT` census (not in the `live_gpu_targets` disable list, and taken with no
+  capture armed) enumerates **17** persistent colour targets over three consecutive black-phase
+  submits. Exactly one has content — `0x2059ea0000`, the CPU-materialised movie composite, still
+  holding the last credits frame at `rgb_nonblack=778215/8294400`, which is *stale* and not an input
+  to the post chain. Every 4K `RGBA16F` target reads `00 00 00 00 00 00 00 3c` per texel (RGB
+  bit-zero, alpha exactly 1.0) and every 4K `RGBA8` target reads `00 00 00 ff` (opaque black); the
+  bloom target and three others are entirely zero. Nothing is lost between any target and the
+  scanout because there is nothing anywhere to lose. Corroborated by a full `PROSPER_DBG=1` run:
+  **0** recompile-rejects of any kind and **0** `[compute] skip`, the only skipped dispatch in the
+  whole boot being #657's `64x64x6` layered image, twice, at boot. #1968 / #2023.
+- **`nz=0` on a `gpu_replay --inspect-only` resource marked `temporal-RTT-seed` is NOT evidence that
+  the target is empty.** That count is over the resource's *guest-memory* bytes, and a
+  renderer-owned target is legitimately all-zero there on the persistent-GPU-target path — prosper
+  renders into a Vulkan image, not into guest memory. The content is on the `rtt-seed` line for the
+  same address, and the two disagree: Frontiers' 4K `RGBA16F` post-chain buffer reports `nz=0` on
+  the `PS TEX` line while its seed hashes to `6c4969fdca4e4383`, which is **not** the all-zero hash
+  for 66,355,200 bytes — the persistent census then showed it is opaque black with alpha 1.0, a
+  different finding from empty. Read the seed, not the `nz`. A cheap decoder for the hashes: they
+  are FNV-1a 64, so the hash of *N* zero bytes (or of any repeating texel pattern) can be computed
+  offline and compared. Same family as the `px_nonblack` inversion. #1968.
+- **The census ordinal `PROSPER_DUMP_PERSISTENT` / `PROSPER_PASS_LOG` take is NOT the submit number
+  `[gpucap]` prints.** On one 360 s Frontiers route the renderer-callback ordinal reaches **6,560**
+  while the capture's submit counter reaches **26,209** — a 4x gap, in the direction that makes an
+  ordinal estimated from a capture overshoot. Overshooting produces **no census at all**, and that
+  silence is indistinguishable from "the census ran and every target was empty". Aim these windows
+  with the `ms:<millis>` form instead (`diagnostic_window.hpp`), which is the same origin
+  `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so a capture and a census can be aimed at one moment. #1968.
+- **Arming `PROSPER_GPU_CAPTURE` takes the run off the default rendering path.** It is in the
+  `live_gpu_targets` disable list (`live_renderer.cpp`), alongside `PROSPER_DUMP_RTGROUPS` and the
+  rest, so every env-triggered capture run is the CPU-readback path. The guest's own command stream
+  and its resources are unaffected — which is why a capture is still the right instrument for "what
+  did the guest submit" — but do not compare a capture run's *renderer* behaviour, target residency
+  or publish provenance against a default run. #1968.
 
 ## Recommended implementation order
 

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -616,7 +616,11 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   bloom target and three others are entirely zero. Nothing is lost between any target and the
   scanout because there is nothing anywhere to lose. Corroborated by a full `PROSPER_DBG=1` run:
   **0** recompile-rejects of any kind and **0** `[compute] skip`, the only skipped dispatch in the
-  whole boot being #657's `64x64x6` layered image, twice, at boot. #1968 / #2023.
+  whole boot being #657's `64x64x6` layered image, twice, at boot. **That zero has a positive
+  control, and it needs one**: all three reject emitters (`[recompile-reject]`,
+  `[exec-recompile-reject]`, `[cfg-recompile-reject]`) are `PROSPER_DBG`-gated, so an unset variable
+  is indistinguishable from a clean run. The same binary, the same variable and the same log filter
+  print **118** reject lines on *Nikoderiko* (`PPSA23760`) in 130 s. #1968 / #2023.
 - **`nz=0` on a `gpu_replay --inspect-only` resource marked `temporal-RTT-seed` is NOT evidence that
   the target is empty.** That count is over the resource's *guest-memory* bytes, and a
   renderer-owned target is legitimately all-zero there on the persistent-GPU-target path — prosper

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -588,7 +588,9 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   byte-identical to the last. The dispatch is still issued: a capture selected by
   `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires in the black phase. **Zero** `dma-data` and **zero**
   `write-data` events touch either address, and the draw half is settled independently by the pass
-  census below (`vo=1` on 0 of 8,443 records). So the guest composites with a compute dispatch,
+  census (`vo=1` on 0 of 8,443 records — a census of every *deferred* pass plus every pass with more
+  than 100 non-black pixels, which on the default live-target path is all of them). So the guest
+  composites with a compute dispatch,
   prosper executes it, prosper writes it back, and prosper publishes it. Reach for
   `PROSPER_PROVENANCE_ADDR` first on any title whose scanout no pass targets — it names the writer
   kind, the program's code address and the submit, which no pass census can. **Read its silence with
@@ -606,21 +608,26 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   `RGBA16F`, a 960x540 -> 64x64 -> 16x16 -> 4x4 -> 2x1 luminance reduction, a tonemap into a
   3840x2160 `RGBA8`, then the dispatch into the scanout. All 17 operations are `realized=yes`,
   `failed=0`. There is no scene pass, no indexed draw and no depth geometry anywhere in it. #1968.
-- **Every renderer-owned target really is black in that phase, on the default path, measured.** A
-  `PROSPER_DUMP_PERSISTENT` census (not in the `live_gpu_targets` disable list, and taken with no
-  capture armed) enumerates **17** persistent colour targets over three consecutive black-phase
-  submits. Exactly one has content — `0x2059ea0000`, the CPU-materialised movie composite, still
-  holding the last credits frame at `rgb_nonblack=778215/8294400`, which is *stale* and not an input
-  to the post chain. Every 4K `RGBA16F` target reads `00 00 00 00 00 00 00 3c` per texel (RGB
-  bit-zero, alpha exactly 1.0) and every 4K `RGBA8` target reads `00 00 00 ff` (opaque black); the
-  bloom target and three others are entirely zero. Nothing is lost between any target and the
-  scanout because there is nothing anywhere to lose. Corroborated by a full `PROSPER_DBG=1` run:
-  **0** recompile-rejects of any kind and **0** `[compute] skip`, the only skipped dispatch in the
-  whole boot being #657's `64x64x6` layered image, twice, at boot. **That zero has a positive
-  control, and it needs one**: all three reject emitters (`[recompile-reject]`,
-  `[exec-recompile-reject]`, `[cfg-recompile-reject]`) are `PROSPER_DBG`-gated, so an unset variable
-  is indistinguishable from a clean run. The same binary, the same variable and the same log filter
-  print **118** reject lines on *Nikoderiko* (`PPSA23760`) in 130 s. #1968 / #2023.
+- **Every renderer-owned target the census can see really is black in that phase, on the default
+  path, measured.** A `PROSPER_DUMP_PERSISTENT` census (not in the `live_gpu_targets` disable list,
+  and taken with no capture armed) enumerates **17** persistent colour targets over three
+  consecutive black-phase submits, in each of two independent runs. Read 17 as a **lower bound**:
+  the census skips anything smaller than 64x64 and silently `continue`s on a readback failure, so
+  the 16x16 / 4x4 / 2x1 tail of the luminance chain is outside it by construction. Exactly one
+  enumerated target has content — the CPU-materialised movie composite, still holding the last
+  credits frame at `rgb_nonblack=778215/8294400`, which is *stale* and not an input to the post
+  chain (`0x2059ea0000` in one run and `0x2059eb0000` in the next: **the address is run-local**,
+  re-derive it rather than grepping for either). Every 4K `RGBA16F` target reads
+  `00 00 00 00 00 00 00 3c` per texel (RGB bit-zero, alpha exactly 1.0) and every 4K `RGBA8` target
+  reads `00 00 00 ff` (opaque black); the bloom target and three others are entirely zero. Nothing
+  is lost between any target and the scanout because there is nothing anywhere to lose. Corroborated
+  by a full `PROSPER_DBG=1` run: **0** recompile-rejects of any kind and **0** `[compute] skip`, the
+  only skipped dispatch in the whole boot being #657's `64x64x6` layered image, twice, at boot.
+  **That zero has a positive control, and it needs one**: all four reject emitters
+  (`[recompile-reject]`, `[cfg-recompile-reject]`, `[vertex-recompile-reject]`,
+  `[exec-recompile-reject]`) are `PROSPER_DBG`-gated, so an unset variable is indistinguishable from
+  a clean run. The same binary, the same variable and the same log filter print **118** reject lines
+  on *Nikoderiko* (`PPSA23760`) in 130 s. #1968 / #2023.
 - **`nz=0` on a `gpu_replay --inspect-only` resource marked `temporal-RTT-seed` is NOT evidence that
   the target is empty.** That count is over the resource's *guest-memory* bytes, and a
   renderer-owned target is legitimately all-zero there on the persistent-GPU-target path — prosper
@@ -629,15 +636,21 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   the `PS TEX` line while its seed hashes to `6c4969fdca4e4383`, which is **not** the all-zero hash
   for 66,355,200 bytes — the persistent census then showed it is opaque black with alpha 1.0, a
   different finding from empty. Read the seed, not the `nz`. A cheap decoder for the hashes: they
-  are FNV-1a 64, so the hash of *N* zero bytes (or of any repeating texel pattern) can be computed
-  offline and compared. Same family as the `px_nonblack` inversion. #1968.
+  come from `gpu_capture_hash` (`gpu_capture.cpp`), so the hash of *N* zero bytes — or of any
+  repeating texel pattern, which is how "opaque black" and "alpha 1.0" were identified above — can
+  be computed offline and compared. **Do not reach for a stock FNV-1a 64 to do it.**
+  `gpu_capture_hash` uses the FNV prime with a **basis of `0x14650fb0739d0383`**, which is the FNV-1a
+  64 offset basis with a digit dropped; a standard implementation produces a value that can never
+  match a prosper hash, and that mismatch reads as "the buffer is not zero" — the exact false
+  conclusion this row exists to prevent. Same family as the `px_nonblack` inversion. #1968.
 - **The census ordinal `PROSPER_DUMP_PERSISTENT` / `PROSPER_PASS_LOG` take is NOT the submit number
   `[gpucap]` prints.** On one 360 s Frontiers route the renderer-callback ordinal reaches **6,560**
   while the capture's submit counter reaches **26,209** — a 4x gap, in the direction that makes an
   ordinal estimated from a capture overshoot. Overshooting produces **no census at all**, and that
   silence is indistinguishable from "the census ran and every target was empty". Aim these windows
-  with the `ms:<millis>` form instead (`diagnostic_window.hpp`), which is the same origin
-  `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so a capture and a census can be aimed at one moment. #1968.
+  with the `ms:<millis>` form instead (`diagnostic_window.hpp`), whose origin is the same *kind* as
+  `PROSPER_GPU_CAPTURE_AFTER_MS`'s — the first armed check on its own path — so the two can be aimed
+  at one moment to within the gap between those two lazily-started clocks, not exactly. #1968.
 - **Arming `PROSPER_GPU_CAPTURE` takes the run off the default rendering path.** It is in the
   `live_gpu_targets` disable list (`live_renderer.cpp`), alongside `PROSPER_DUMP_RTGROUPS` and the
   rest, so every env-triggered capture run is the CPU-readback path. The guest's own command stream

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -581,11 +581,18 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   only writer of either registered VideoOut buffer (`0x200a160000` / `0x200c140000`) is
   `compute-buffer … identity=0x20002fe800 size=33423360` — the storage-image writeback of **one**
   compute program, alternating between the two buffers, packing and tiling its result back into
-  guest memory across the padded SW_64KB_R_X footprint. **Zero** `color` (draw) and **zero**
-  `dma-data` events touch either address. So the guest composites with a compute dispatch, prosper
-  executes it, prosper writes it back, and prosper publishes it. Reach for `PROSPER_PROVENANCE_ADDR`
-  first on any title whose scanout no pass targets — it names the writer kind, the program's code
-  address and the submit, which no pass census can. #1968.
+  guest memory across the padded SW_64KB_R_X footprint. **Zero** `dma-data` and **zero**
+  `write-data` events touch either address, and the draw half is settled independently by the pass
+  census below (`vo=1` on 0 of 8,443 records). So the guest composites with a compute dispatch,
+  prosper executes it, prosper writes it back, and prosper publishes it. Reach for
+  `PROSPER_PROVENANCE_ADDR` first on any title whose scanout no pass targets — it names the writer
+  kind, the program's code address and the submit, which no pass census can. **Read its silence with
+  one limit in mind, because it is not stated anywhere else:** the address watch arms the
+  compute-writeback, `DMA_DATA` and `WRITE_DATA` recorders, but the **colour-target** recorder lives
+  inside `diagnose_resource_provenance`, which returns early unless the *separate*
+  `PROSPER_PROVENANCE_DIM` is also set (`gpu_executor.cpp`). An `ADDR`-only run therefore reports
+  **no `color` lines at all**, and that zero is void rather than negative — filed as #2111. Set both
+  variables, or settle the draw question with `PROSPER_PASS_LOG`. #1968.
 - **Post-intro Frontiers runs a complete post-processing chain over an empty scene — the missing
   thing is geometry, not a composite step.** A capture of the submit containing that composite
   dispatch (selected with `PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x20002fe800`, 240 s into a default

--- a/prosper/frontends/shared/diagnostic_window.hpp
+++ b/prosper/frontends/shared/diagnostic_window.hpp
@@ -15,11 +15,20 @@ namespace prosper::frontend {
 // when the ordinal was estimated from a capture's submit number. `PROSPER_GPU_CAPTURE_AFTER_MS`
 // already solves exactly this for captures; this gives the two census switches the same form.
 //
-//     PROSPER_DUMP_PERSISTENT=26000     ordinal — unchanged, byte-for-byte
+//     PROSPER_DUMP_PERSISTENT=26000     ordinal — unchanged for every reachable value
 //     PROSPER_DUMP_PERSISTENT=ms:240000 the first callback at or after 240 s, and the next two
 //
+// One deliberate difference in the ordinal form, stated because "unchanged" should not be taken on
+// trust: the old test was `at >= min && at < min + 3u`, whose addition wraps for the top three
+// `uint64` values, so those windows could never fire. `contains()` subtracts instead and they do.
+// Unreachable in practice — the counter is a per-callback ordinal — and the new answer is the
+// intended one, but it is a difference and the test pins it.
+//
 // Time is measured from the first call to `contains()`, i.e. from the first renderer callback of the
-// run — the same origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so the two can be aimed at one moment.
+// run. That is the same KIND of origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses — the first armed check on
+// its own path — but it is a separate lazily-started `steady_clock` static on a separate path, so a
+// capture and a census aimed at the same millisecond agree only to within the gap between the two
+// clocks' first calls. Close enough to aim both at one phase; not a shared timebase.
 struct DiagnosticWindowSpec {
     bool by_time = false;      // `value` is milliseconds rather than an ordinal
     uint64_t value = 0;        // ordinal, or milliseconds since the first callback

--- a/prosper/frontends/shared/diagnostic_window.hpp
+++ b/prosper/frontends/shared/diagnostic_window.hpp
@@ -1,0 +1,80 @@
+// diagnostic_window.hpp — selecting a short renderer-callback census window by ORDINAL or by TIME.
+#pragma once
+
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+
+namespace prosper::frontend {
+
+// `PROSPER_DUMP_PERSISTENT=<N>` and `PROSPER_PASS_LOG=<N>` open a three-callback census window at
+// renderer-callback ordinal N. That ordinal is a renderer-internal counter with no published rate,
+// and the states worth censusing are named in seconds ("after the intro", "once the frame goes
+// black"), so choosing N is guesswork: measured on Sonic Frontiers (#1968), the same 360 s route
+// reaches ordinal 6,560 while its *submit* counter reaches 26,209 — a 4x gap that cost one full run
+// when the ordinal was estimated from a capture's submit number. `PROSPER_GPU_CAPTURE_AFTER_MS`
+// already solves exactly this for captures; this gives the two census switches the same form.
+//
+//     PROSPER_DUMP_PERSISTENT=26000     ordinal — unchanged, byte-for-byte
+//     PROSPER_DUMP_PERSISTENT=ms:240000 the first callback at or after 240 s, and the next two
+//
+// Time is measured from the first call to `contains()`, i.e. from the first renderer callback of the
+// run — the same origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so the two can be aimed at one moment.
+struct DiagnosticWindowSpec {
+    bool by_time = false;      // `value` is milliseconds rather than an ordinal
+    uint64_t value = 0;        // ordinal, or milliseconds since the first callback
+    uint32_t span = 3;         // how many consecutive callbacks the window admits
+};
+
+// Parse one environment value. A bare number keeps `strtoull(text, nullptr, 0)`'s historical
+// behaviour EXACTLY, including its treatment of junk as 0 — this switch has been aimed at ordinal 0
+// by a typo before, and silently moving that to "never fires" would change what an existing recipe
+// does. Only the `ms:` prefix is new; junk after it is likewise 0, i.e. "immediately".
+inline DiagnosticWindowSpec parse_diagnostic_window(const char* text, uint32_t span = 3) {
+    DiagnosticWindowSpec spec;
+    spec.span = span ? span : 1u;
+    if (!text) return spec;
+    if (std::strncmp(text, "ms:", 3) == 0) {
+        spec.by_time = true;
+        spec.value = std::strtoull(text + 3, nullptr, 0);
+        return spec;
+    }
+    spec.value = std::strtoull(text, nullptr, 0);
+    return spec;
+}
+
+// The window itself. An ordinal spec is stateless. A time spec LATCHES: the first callback at or
+// after the deadline fixes the window's start ordinal, and every later call answers against that
+// fixed start. Without the latch the window would re-open on every subsequent callback and the
+// census would run for the rest of the process — a three-submit diagnostic that reads back every
+// persistent 4K colour target is not something to leave running.
+//
+// Not thread-safe, deliberately: both call sites live on the renderer's single present thread, next
+// to the `dp_submit` / `warned` / `last_scanout_present` statics that already carry that contract.
+class DiagnosticWindow {
+public:
+    DiagnosticWindow() = default;
+    explicit DiagnosticWindow(DiagnosticWindowSpec spec) : spec_(spec) {}
+
+    // `elapsed_ms` is ignored for an ordinal spec, so a caller with no clock may pass 0.
+    bool contains(uint64_t ordinal, uint64_t elapsed_ms) {
+        if (!spec_.by_time)
+            return ordinal >= spec_.value && ordinal - spec_.value < spec_.span;
+        if (!started_) {
+            if (elapsed_ms < spec_.value) return false;
+            started_ = true;
+            start_ordinal_ = ordinal;
+        }
+        return ordinal >= start_ordinal_ && ordinal - start_ordinal_ < spec_.span;
+    }
+
+    const DiagnosticWindowSpec& spec() const { return spec_; }
+    bool started() const { return started_ || !spec_.by_time; }
+
+private:
+    DiagnosticWindowSpec spec_{};
+    bool started_ = false;
+    uint64_t start_ordinal_ = 0;
+};
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -28,6 +28,7 @@
 #include "present_extent.hpp"           // the publish extent contract with the caller (#1986)
 #include "avplayer_plane_policy.hpp"    // which sampled resource is AvPlayer's NV12 chroma plane
 #include "guest_scanout_present.hpp"    // publishing the guest's own flipped buffer (#1968)
+#include "diagnostic_window.hpp"        // census window by callback ordinal or by elapsed time
 #include "gpu/diag_ratelimit.hpp"       // ordinal + sparse tail for capped diagnostics
 #include "host/guest_write_watch.hpp"
 #include "render_runner.h"              // offscreen Vulkan backend (render_draws_rgba) + dump_bmp
@@ -479,6 +480,16 @@ void log_avp_chroma_candidate(const prosper::gpu::ShaderResource& r,
     fflush(stderr);
 }
 
+// Milliseconds since the first ARMED census check of this run — the origin for the `ms:` form of
+// PROSPER_PASS_LOG / PROSPER_DUMP_PERSISTENT (diagnostic_window.hpp). Lazily started, so an
+// unarmed run never reads the clock and the origin is the same first-callback moment
+// PROSPER_GPU_CAPTURE_AFTER_MS uses, letting a capture and a census be aimed at one instant.
+static uint64_t diagnostic_elapsed_ms() {
+    static const auto start = std::chrono::steady_clock::now();
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start).count());
+}
+
 struct DecodedTexture {
     const uint8_t* pixels = nullptr;
     uint32_t output_height = 0;
@@ -654,6 +665,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     static RttCache g_rtt;   // render-to-texture cache (#167)
     // Shared final-callback ordinal for PROSPER_PASS_LOG (increments where dp_submit does).
     static std::atomic<uint64_t> g_pass_log_submit{0};
+    // The census windows those two switches open. Parsed once here rather than per callback so the
+    // `ms:` form's latch is one object: PROSPER_PASS_LOG is consulted from two places about the SAME
+    // ordinal, and a per-site window would latch them onto different callbacks. Same single-present-
+    // thread contract as `g_rtt` and the `dp_submit`/`warned` statics below.
+    static prosper::frontend::DiagnosticWindow g_pass_log_window{
+        prosper::frontend::parse_diagnostic_window(getenv("PROSPER_PASS_LOG"))};
+    static prosper::frontend::DiagnosticWindow g_persist_window{
+        prosper::frontend::parse_diagnostic_window(getenv("PROSPER_DUMP_PERSISTENT"))};
     // Match boot_trace's progression-diagnostic contract: callers may register the graphics
     // renderer while deliberately leaving compute unregistered. This keeps semantic dispatches
     // visible without letting screenshot/prosper-app registration silently undo the A/B.
@@ -5802,11 +5821,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         if (!converted.empty())
                             px_last = std::make_shared<const std::vector<uint8_t>>(std::move(converted));
                     }
-                    // PROSPER_PASS_LOG=<min-submit>: per-pass publish provenance for 3 submits —
-                    // which pass produced pixels, its target identity, and the defer decision.
-                    if (const char* pl = getenv("PROSPER_PASS_LOG")) {
+                    // PROSPER_PASS_LOG=<min-submit>|ms:<millis>: per-pass publish provenance for 3
+                    // submits — which pass produced pixels, its target identity, and the defer
+                    // decision. The `ms:` form aims the window by wall time (diagnostic_window.hpp).
+                    if (getenv("PROSPER_PASS_LOG")) {
                         const uint64_t at = g_pass_log_submit.load(std::memory_order_relaxed);
-                        const uint64_t pl_min = std::strtoull(pl, nullptr, 0);
+                        const bool in_window =
+                            g_pass_log_window.contains(at, diagnostic_elapsed_ms());
                         // px_nonblack must be counted in the PASS's OWN format. The original loop
                         // stepped 4 bytes and tested bytes `p`, `p+1`, `p+2` — never `p+3` — as if
                         // every target were 8-bit RGBA. Over an 8-byte FP16 texel that reads
@@ -5841,8 +5862,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // last case has to stay visible out of window: it is the one where this line
                         // cannot say whether the pass carries content, which is exactly when the
                         // reader needs to know the pass existed.
-                        if ((at >= pl_min && at < pl_min + 3u) || nz > 100 || nz < 0 ||
-                            defer_readback)
+                        if (in_window || nz > 100 || nz < 0 || defer_readback)
                             fprintf(stderr,
                                     "[pass] cb=%llu pass=%zu/%zu base=0x%llx %ux%u fmt=%d vo=%d "
                                     "seed=%d defer=%d writes=%llu px_nonblack=%lld\n",
@@ -5896,23 +5916,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 }
                 {
                     const uint64_t at = g_pass_log_submit.fetch_add(1);
-                    if (const char* pl = getenv("PROSPER_PASS_LOG")) {
-                        const uint64_t pl_min = std::strtoull(pl, nullptr, 0);
-                        if (at >= pl_min && at < pl_min + 3u)
+                    if (getenv("PROSPER_PASS_LOG")) {
+                        // The same window object and the same ordinal the per-pass report used, so
+                        // the two lines always describe one set of callbacks.
+                        if (g_pass_log_window.contains(at, diagnostic_elapsed_ms()))
                             fprintf(stderr, "[pass] cb=%llu selected=%s\n", (unsigned long long)at,
                                     prosper::frontend::present_source_name(present_choice));
                     }
                 }
-                // PROSPER_DUMP_PERSISTENT=<min-submit>: read back and dump EVERY persistent color
-                // target after this submit's passes render. Unlike PROSPER_RTT*/DUMP_*, this flag is
-                // NOT in the live_gpu_targets disable list (:480-487), so it observes the NORMAL
-                // persistent-render path (all other CPU-pixel diagnostics change that path -> #1103).
-                // readback_persistent_color_target restores the image layout, so rendering is unaffected.
-                if (const char* dp = getenv("PROSPER_DUMP_PERSISTENT")) {
+                // PROSPER_DUMP_PERSISTENT=<min-submit>|ms:<millis>: read back and dump EVERY
+                // persistent color target after this submit's passes render. Unlike
+                // PROSPER_RTT*/DUMP_*, this flag is NOT in the live_gpu_targets disable list
+                // (:480-487), so it observes the NORMAL persistent-render path (all other CPU-pixel
+                // diagnostics change that path -> #1103). readback_persistent_color_target restores
+                // the image layout, so rendering is unaffected. The `ms:` form aims the window by
+                // wall time, because the ordinal below is a renderer-internal counter with no
+                // published rate and the states worth censusing are named in seconds
+                // (diagnostic_window.hpp).
+                if (getenv("PROSPER_DUMP_PERSISTENT")) {
                     static std::atomic<uint64_t> dp_submit{0};
                     const uint64_t sub = dp_submit.fetch_add(1);
-                    const uint64_t dp_min = std::strtoull(dp, nullptr, 0);
-                    if (sub >= dp_min && sub < dp_min + 3u) {
+                    if (g_persist_window.contains(sub, diagnostic_elapsed_ms())) {
                         const char* dd = getenv("PROSPER_FRAME_DIR");
                         fprintf(stderr, "[persist] submit=%llu present: front=%d/%d front_va=0x%llx "
                                 "selected=%s vo:", (unsigned long long)sub, vo_front, vo_n,

--- a/prosper/frontends/shared/test_diagnostic_window.cpp
+++ b/prosper/frontends/shared/test_diagnostic_window.cpp
@@ -1,0 +1,95 @@
+// test_diagnostic_window — the census window `PROSPER_DUMP_PERSISTENT` / `PROSPER_PASS_LOG` open.
+//
+// What this guards: those two switches take a renderer-callback ORDINAL, and the states worth
+// censusing are named in seconds. On Sonic Frontiers (#1968) the ordinal a 360 s route reaches
+// (6,560) and the submit number a capture from the same route reports (26,209) differ by 4x, so an
+// ordinal estimated from a capture missed the window entirely and the run produced no census at all
+// — a silent zero, indistinguishable from "every target was empty". The `ms:` form removes the
+// guess; these arms pin both its behaviour and the exact preservation of the ordinal form.
+//
+// Pure predicate, so no renderer, no device and no clock: `contains()` takes the elapsed time as an
+// argument precisely so the latch can be driven backwards, forwards and out of order under test.
+#include "diagnostic_window.hpp"
+
+#include <cstdio>
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); ++fails; } \
+                              else         { std::printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    using prosper::frontend::DiagnosticWindow;
+    using prosper::frontend::parse_diagnostic_window;
+
+    // --- The ordinal form must be byte-for-byte what it was ------------------------------------
+    {
+        DiagnosticWindow w{parse_diagnostic_window("26000")};
+        CHECK(!w.contains(25999, 0), "an ordinal window is closed before its first ordinal");
+        CHECK(w.contains(26000, 0) && w.contains(26001, 0) && w.contains(26002, 0),
+              "an ordinal window admits exactly its ordinal and the next two");
+        CHECK(!w.contains(26003, 0), "an ordinal window closes after three callbacks");
+        CHECK(w.contains(26001, 0),
+              "an ordinal window is stateless: revisiting an in-window ordinal still answers yes");
+    }
+    {
+        DiagnosticWindow w{parse_diagnostic_window("0x10")};
+        CHECK(w.contains(16, 0) && !w.contains(15, 0),
+              "the ordinal form keeps strtoull base 0, so 0x10 means 16");
+    }
+    {
+        // Historical behaviour, deliberately preserved: junk parses as ordinal 0 and fires at once.
+        DiagnosticWindow w{parse_diagnostic_window("yes")};
+        CHECK(w.contains(0, 0) && w.contains(2, 0) && !w.contains(3, 0),
+              "unparseable text keeps its historical meaning of ordinal 0, not 'never'");
+    }
+    {
+        DiagnosticWindow w{parse_diagnostic_window(nullptr)};
+        CHECK(w.contains(0, 0), "a null value parses as ordinal 0 rather than crashing");
+    }
+
+    // --- The time form: latch on the first callback at or after the deadline --------------------
+    {
+        DiagnosticWindow w{parse_diagnostic_window("ms:240000")};
+        CHECK(w.spec().by_time, "the ms: prefix selects the time form");
+        CHECK(w.spec().value == 240000, "the ms: prefix parses the milliseconds after it");
+        CHECK(!w.contains(100, 0) && !w.contains(4000, 239999),
+              "a time window stays closed until the deadline, whatever the ordinal");
+        CHECK(w.contains(5000, 240000), "the first callback at or after the deadline opens it");
+        CHECK(w.contains(5001, 240016) && w.contains(5002, 240033),
+              "the two callbacks after the opening one are in the window");
+        CHECK(!w.contains(5003, 240050),
+              "the time window is three callbacks wide, not 'the rest of the run'");
+        CHECK(!w.contains(9000, 330000),
+              "the latch does not re-open later — this is the runaway-census guard");
+    }
+    {
+        // The two PROSPER_PASS_LOG call sites ask about the SAME ordinal (one loads the counter, the
+        // other fetch_adds it), so a repeated query must not consume or shift the window.
+        DiagnosticWindow w{parse_diagnostic_window("ms:1000")};
+        CHECK(w.contains(700, 1000) && w.contains(700, 1000) && w.contains(700, 1001),
+              "asking twice about the opening ordinal is idempotent");
+        CHECK(w.contains(702, 1002) && !w.contains(703, 1003),
+              "the span is counted from the latched ordinal, not from the number of queries");
+    }
+    {
+        DiagnosticWindow w{parse_diagnostic_window("ms:0")};
+        CHECK(w.contains(0, 0), "ms:0 opens on the first callback");
+    }
+    {
+        // Span is a parameter so a future call site can ask for a different width; the default is
+        // the three callbacks both existing censuses have always used.
+        DiagnosticWindow w{parse_diagnostic_window("ms:100", 1)};
+        CHECK(w.contains(10, 100) && !w.contains(11, 101), "an explicit span of 1 admits one callback");
+    }
+    {
+        // A very large ordinal must not wrap when the span is added — the reason `contains()`
+        // subtracts rather than adding.
+        DiagnosticWindow w{parse_diagnostic_window("18446744073709551615")};
+        CHECK(w.contains(UINT64_MAX, 0) && !w.contains(0, 0),
+              "an ordinal at the top of the range does not wrap the window open");
+    }
+
+    std::printf(fails ? "test_diagnostic_window: %d FAILURE(S)\n" : "test_diagnostic_window: all ok\n",
+                fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/frontends/shared/test_diagnostic_window.cpp
+++ b/prosper/frontends/shared/test_diagnostic_window.cpp
@@ -21,7 +21,7 @@ int main() {
     using prosper::frontend::DiagnosticWindow;
     using prosper::frontend::parse_diagnostic_window;
 
-    // --- The ordinal form must be byte-for-byte what it was ------------------------------------
+    // --- The ordinal form must be unchanged for every reachable value ---------------------------
     {
         DiagnosticWindow w{parse_diagnostic_window("26000")};
         CHECK(!w.contains(25999, 0), "an ordinal window is closed before its first ordinal");
@@ -83,7 +83,10 @@ int main() {
     }
     {
         // A very large ordinal must not wrap when the span is added — the reason `contains()`
-        // subtracts rather than adding.
+        // subtracts rather than adding. This is the ONE place the ordinal form's answer differs
+        // from the `at >= min && at < min + 3u` test it replaced: that addition wrapped, so the top
+        // three uint64 windows could never fire. Unreachable in practice; pinned so the difference
+        // is a decision rather than a surprise.
         DiagnosticWindow w{parse_diagnostic_window("18446744073709551615")};
         CHECK(w.contains(UINT64_MAX, 0) && !w.contains(0, 0),
               "an ordinal at the top of the range does not wrap the window open");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -206,6 +206,23 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     `low dword <= 1` form of this marker would have been inert on its own evidence. **A repeated page is not evidence of a
     lost mapping**: every `0x21000000xx` pointer lands in page `0x2100000000`, which is why two
     different guest sites appeared to "first-touch the same page".
+  - **Which target holds content right now, and which pass wrote it?** **`PROSPER_DUMP_PERSISTENT`**
+    reads back and reports *every* persistent colour target (`rgb_nonblack`, `raw_nonzero_bytes`, and
+    the first non-zero texel's own bytes, so "black" and "empty" stay distinguishable), and
+    **`PROSPER_PASS_LOG`** reports each pass's target identity, `vo=` flag and defer decision. Both
+    open a **three-callback** window, and both accept two forms:
+    ```text
+    PROSPER_DUMP_PERSISTENT=26000       renderer-callback ordinal (unchanged)
+    PROSPER_DUMP_PERSISTENT=ms:240000   the first callback at or after 240 s, and the next two
+    ```
+    Prefer `ms:` unless you have already measured the ordinal in the same configuration. **The
+    ordinal is NOT the submit number `[gpucap]` prints** — on one 360 s route it reaches 6,560 while
+    the capture's submit counter reaches 26,209 — and overshooting it yields *no census at all*, a
+    silence that reads exactly like "every target was empty" (#1968). The `ms:` origin is the first
+    armed census check, the same origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so a capture and a
+    census can be aimed at one moment. `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the
+    `live_gpu_targets` disable list, so it observes the normal persistent-GPU-target path;
+    `PROSPER_GPU_CAPTURE` **is**, so an env-triggered capture run is on the CPU-readback path.
 - **`screenshot/`** — writes normal composited PNG sequences plus a JSONL evidence manifest. Use
   `--seconds 1` for wall-clock sampling, warmup or `--render-every N --render-every-for-seconds S`
   for slow software rendering,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -207,8 +207,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     lost mapping**: every `0x21000000xx` pointer lands in page `0x2100000000`, which is why two
     different guest sites appeared to "first-touch the same page".
   - **Which target holds content right now, and which pass wrote it?** **`PROSPER_DUMP_PERSISTENT`**
-    reads back and reports *every* persistent colour target (`rgb_nonblack`, `raw_nonzero_bytes`, and
-    the first non-zero texel's own bytes, so "black" and "empty" stay distinguishable), and
+    reads back and reports every persistent colour target **of at least 64x64** (`rgb_nonblack`,
+    `raw_nonzero_bytes`, and the first non-zero texel's own bytes, so "black" and "empty" stay
+    distinguishable) — it also `continue`s silently past a readback failure, so treat its count as a
+    lower bound and do not read it as "every target" — and
     **`PROSPER_PASS_LOG`** reports each pass's target identity, `vo=` flag and defer decision. Both
     open a **three-callback** window, and both accept two forms:
     ```text
@@ -219,8 +221,8 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     ordinal is NOT the submit number `[gpucap]` prints** — on one 360 s route it reaches 6,560 while
     the capture's submit counter reaches 26,209 — and overshooting it yields *no census at all*, a
     silence that reads exactly like "every target was empty" (#1968). The `ms:` origin is the first
-    armed census check, the same origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, so a capture and a
-    census can be aimed at one moment. `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the
+    armed census check — the same *kind* of origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, on a separate
+    clock, so a capture and a census can be aimed at one phase but do not share a timebase. `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the
     `live_gpu_targets` disable list, so it observes the normal persistent-GPU-target path;
     `PROSPER_GPU_CAPTURE` **is**, so an env-triggered capture run is on the CPU-readback path.
 - **`screenshot/`** — writes normal composited PNG sequences plus a JSONL evidence manifest. Use


### PR DESCRIPTION
## What this answers

`#1968` §5 — *why does no post-intro pass target the flipped VideoOut buffer?* — with the half that
was still missing. `#2026` established that **no pass ever targets it, in any phase**, and that the
frame is in the guest buffer anyway; what it could not say is **what puts it there**. "A path that is
not a draw" was as far as the record went, and that gap is exactly what kept "is this an
identity/aliasing failure on our side?" open.

**It is one compute dispatch, and prosper is the writer.**

## The measurement

Exact master `f080fc23`, native Linux/Vulkan (RADV STRIX_HALO) in the `ps5ys` distrobox,
`tools/screenshot`, default launch with no input, `PROSPER_GUEST_ARGS=-force-gfx-direct
PROSPER_RENDER=1`, defaults for `RENDER_SCALE` and `RENDER_EVERY`. Shared GPU with peer lanes
throughout, so **nothing below is a timing claim** — every figure is an identity or an exact count.

### 1. The writer

`PROSPER_PROVENANCE_ADDR=<scanout>:0x4000000` over a full 360 s boot:

```text
[provenance] compute-buffer addr=0x200a160000 size=33423360 order=4403 identity=0x20002fe800
[provenance] compute-buffer addr=0x200c140000 size=33423360 order=5614 identity=0x20002fe800
```

Every write to either registered VideoOut buffer is a `compute-buffer` event from **one** program,
`0x20002fe800`, at the padded SW_64KB_R_X footprint of a 3840x2160 RGBA8 surface, alternating between
the two buffers. **Zero** `dma-data` and **zero** `write-data` events touch either address.

Do **not** read that event count as a dispatch rate: `live_compute`'s "skipped identical storage
writeback" fast path `continue`s *before* the record, so the events count writes that **changed**
something — 237 over 360 s against ~1,055 flips, collapsing to ~0 per sample once the frame is
uniformly black. The dispatch is still issued; the capture below, selected by
`PROSPER_GPU_CAPTURE_COMPUTE_ADDR`, fires in the black phase. (Commit `911760cd`.)

**Correction, made after the first push of this PR** (commit `fa6678dd`): the draw half was originally
claimed from the same watch, and that was an **unarmed instrument**. `PROSPER_PROVENANCE_ADDR` reaches
the compute-writeback, `DMA_DATA` and `WRITE_DATA` recorders, but the **colour-target** recorder sits
inside `diagnose_resource_provenance`, which returns early unless the *separate*
`PROSPER_PROVENANCE_DIM` is also set. An `ADDR`-only run therefore prints no `color` lines at all —
void, not negative, and on this run it happened to agree with the truth, which is the dangerous shape.
The gap is filed as **#2111**. The conclusion never rested on it: the draw half is settled
independently by the `PROSPER_PASS_LOG` census below — `vo=1` on **0 of 8,443** pass records on the
default live-target path.

### 2. What the post-intro passes write, and what is in them

A capture of the submit that runs that dispatch (`PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x20002fe800`,
`AFTER_MS=240000`) holds **15 draws and 2 dispatches, all `realized=yes`, `failed=0`** — and every
draw is a `vcount=3 indices=0` fullscreen triangle:

bloom -> `0x201e730000` 1920x1080 `R11G11B10F`; 9-tap bloom composite -> `0x200e230000` 3840x2160
`RGBA16F`; luminance reduction 960x540 -> 64x64 -> 16x16 -> 4x4 -> 2x1; tonemap -> `0x2033780000`
3840x2160 `RGBA8`; then `compute[1] code=0x20002fe800 groups=480x270 local=8x8` (= 3840x2160) into
the scanout. **There is no scene pass, no indexed draw and no depth geometry anywhere in it.**

A `PROSPER_DUMP_PERSISTENT` census in the same phase — *not* in the `live_gpu_targets` disable list,
and taken with no capture armed, so it observes the default path — enumerates **17** persistent
colour targets. Exactly one has content: `0x2059eb0000`, the CPU-materialised movie composite, still
holding the last credits frame at `rgb_nonblack=778215/8294400`, which the post chain does not read.
Every 4K `RGBA16F` target is `00 00 00 00 00 00 00 3c` per texel (RGB bit-zero, alpha exactly 1.0);
every 4K `RGBA8` target is `00 00 00 ff` (opaque black); the bloom target and three others are
entirely zero. Reproduced identically in two independent runs.

A full `PROSPER_DBG=1` run corroborates from the other side: **0** recompile-rejects of any kind and
**0** `[compute] skip`. The only skipped dispatch in the whole boot is #657's `64x64x6` layered
image, twice, before the movie.

**So there is nothing anywhere to lose between a target and the scanout**, and §5's second
sub-question resolves against a prosper-side identity/aliasing defect. The remaining blocker is
`#2023`, now stated more precisely: the guest's renderer is fully alive and runs its complete post
chain every frame; what is missing upstream of it is **geometry**.

## The change

Two diagnostics, one new header, no behavioural change to rendering.

`PROSPER_DUMP_PERSISTENT` and `PROSPER_PASS_LOG` open a three-callback census window at a
**renderer-callback ordinal**. That ordinal is **not** the submit number `[gpucap]` prints — 6,560
against 26,209 on one 360 s route here — and overshooting it produces **no census at all**, a
silence indistinguishable from "the census ran and every target was empty". That cost this
investigation a full run.

Both now also accept **`ms:<millis>`**, latching on the first callback at or after that wall time,
from the same origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses so a capture and a census can be aimed at
one moment. Both consult **one shared window object**: `PROSPER_PASS_LOG` is read from two places
about the same ordinal, and per-site windows would latch onto different callbacks.

- `frontends/shared/diagnostic_window.hpp` — the parser and the window. The `ms:` form latches, so a
  time-selected census cannot run for the rest of the process.
- The **ordinal form is unchanged**, byte for byte, including `strtoull`'s historical treatment of
  unparseable text as ordinal 0 — that switch has been aimed at 0 by a typo before, and quietly
  turning that into "never fires" would change what an existing recipe does.

## Invariants and deliberately unaffected behaviour

- Rendering is untouched: both call sites remain inside `if (getenv(...))`, and an unarmed run never
  even reads the clock (`diagnostic_elapsed_ms`'s `start` is a lazy function-local static).
- `DiagnosticWindow` is not thread-safe, deliberately — both call sites are on the renderer's single
  present thread, the same contract `g_rtt`, `dp_submit` and `last_scanout_present` already carry.
- The out-of-window escape hatches on the per-pass line (`nz > 100`, `nz < 0`, `defer_readback`) are
  unchanged, so a full-boot pass census still works exactly as before.

## Risks

The window objects are parsed once at renderer registration rather than per callback, so changing
these environment variables mid-process no longer takes effect. No caller does that.

## Verification

```text
cmake --build build-linux -j8                 # clean
ctest -j4                                     # 203/203 passed
python3 prosper/tools/docs/check_numbered_table.py --sequential \
    --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md   # 14 tables, 167 rows, contiguous
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   # all unbroken
git diff --cached --check                     # clean
```

Three mutation arms prove `test_diagnostic_window` is two-sided rather than merely true:

| mutation | arms that fail |
| --- | --- |
| drop the latch (time window re-opens every callback) | 4 |
| ordinal window never closes (`>= value`, no span) | 2 |
| `ms:` prefix ignored | 7 |

End-to-end on the subject: `PROSPER_DUMP_PERSISTENT=ms:240000 PROSPER_PASS_LOG=ms:240000` opened at
callback **4770** — both switches on the same ordinal, ~240 s in, in the black phase — and produced
the 17-target census quoted above.

## Screenshots

None. This PR claims **no** rung change: PPSA03831 stays at rung 1 and every post-140 s frame is
uniformly black, which is not progression evidence. The intro frames it does render (Sonic Team logo
at 60 s, middleware credits at 120 s, `tools/screenshot` on a default launch) are already in
`COMPATIBILITY.md`.

Refs #1968, #2023


