### PR TITLE
fix(win): sceKernelMprotect must accept guest memory the VA tracker does not own — fixes the upside-down/world-less Windows frame

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4169,11 +4169,12 @@ namespace {
         // Reserved (uncommitted) pages accept a tracking-only protection change, matching the POSIX
         // PROT_NONE reservation path; MEM_FREE makes the whole operation fail (#387 F3).
         const uint64_t end = addr + len;
+        // Partial (or absent) tracker coverage is allowed; the per-region walk below decides. The
+        // authority on whether a page exists is the OS (MEM_FREE fails), not prosper's bookkeeping —
+        // g_maps records what the memory HLE allocated, and a guest may protect memory it did not
+        // get from the memory HLE at all. See the MEM_COMMIT arm.
         std::vector<TrackedMappingSlice> tracked;
-        if (!tracked_mapping_slices(addr, end, tracked)) {
-            if (error_out) *error_out = ERROR_INVALID_ADDRESS;
-            return false;
-        }
+        (void)tracked_mapping_slices(addr, end, tracked);
 
         struct CommittedRegion { uint64_t base, size; DWORD old_protection; };
         std::vector<CommittedRegion> committed;
@@ -4196,18 +4197,41 @@ namespace {
                     return false;
                 }
             } else if (mbi.State == MEM_COMMIT) {
-                if (!tracked_slices_have_commit_state(tracked, cursor, region_end, true)) {
-                    if (error_out) *error_out = ERROR_INVALID_ADDRESS;
-                    return false;
-                }
                 // Split at tracker boundaries so rollback restores the guest protection recorded
-                // before write-watch temporarily made any pages read-only.
-                for (const TrackedMappingSlice& slice : tracked) {
-                    const uint64_t overlap_begin = std::max(cursor, slice.base);
-                    const uint64_t overlap_end = std::min(region_end, slice.base + slice.size);
-                    if (overlap_begin < overlap_end)
-                        committed.push_back({overlap_begin, overlap_end - overlap_begin,
-                                             win_page_prot(slice.prot)});
+                // before write-watch temporarily made any pages read-only. A gap the tracker does
+                // not own is NOT an error: guest memory the memory HLE never allocated is still
+                // real, committed guest memory. A module image is mapped by the exec substrate
+                // (map_image's VirtualAlloc), so it is absent from g_maps, and the guest legitimately
+                // mprotects its OWN segments — POSIX mprotect accepts that, so this must too. #2101:
+                // The Messenger calls sceKernelMprotect(eboot+0x1d98000, 0x22240, CPU_WRITE|GPU_READ)
+                // during AGC device init; refusing it with EINVAL made the title abandon that init,
+                // which cost it its whole register-offset table. Rollback for an untracked gap uses
+                // the protection the pages actually had.
+                uint64_t scan = cursor;
+                while (scan < region_end) {
+                    const TrackedMappingSlice* covering = nullptr;
+                    uint64_t next_slice_base = region_end;
+                    for (const TrackedMappingSlice& slice : tracked) {
+                        const uint64_t slice_end = slice.base + slice.size;
+                        if (scan >= slice.base && scan < slice_end) { covering = &slice; break; }
+                        if (slice.base > scan && slice.base < next_slice_base)
+                            next_slice_base = slice.base;
+                    }
+                    if (covering) {
+                        // A tracked mapping that the tracker says is NOT committed, over host pages
+                        // that are, is a bookkeeping disagreement — keep refusing it as before.
+                        if (!covering->committed) {
+                            if (error_out) *error_out = ERROR_INVALID_ADDRESS;
+                            return false;
+                        }
+                        const uint64_t slice_end =
+                            std::min(region_end, covering->base + covering->size);
+                        committed.push_back({scan, slice_end - scan, win_page_prot(covering->prot)});
+                        scan = slice_end;
+                    } else {
+                        committed.push_back({scan, next_slice_base - scan, mbi.Protect});
+                        scan = next_slice_base;
+                    }
                 }
             }
             cursor = region_end;
@@ -4936,7 +4960,18 @@ HLE(k_mprotect) {
     if (!a0) return 0x80020016ull;
     const int prot = host_prot(a2);
     DWORD error = ERROR_SUCCESS;
-    if (!win_protect(a0, a1, prot, &error)) return sce_win_mprotect_error(error);
+    if (!win_protect(a0, a1, prot, &error)) {
+        // #2101: a refused mprotect is silent, and a guest that treats it as fatal then abandons a
+        // whole init path with no other symptom. Report the span, the requested Sony protection and
+        // the Win32 reason, bounded.
+        static std::atomic<int> n{0};
+        if (n.fetch_add(1) < 24)
+            fprintf(stderr, "[memhle] sceKernelMprotect REFUSED addr=0x%llx len=0x%llx prot=0x%llx "
+                            "win_error=%lu\n",
+                    (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
+                    (unsigned long)error);
+        return sce_win_mprotect_error(error);
+    }
     retrack_prot(a0, a1, prot, static_cast<uint32_t>(a2), "mprotect");
     return 0;
 }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4158,6 +4158,20 @@ namespace {
         return false;
     }
 
+    // True when [begin,end) lies inside the fixed guest MODULE apertures (eboot, the PRXes, the
+    // plugin/runtime pools). boot_program.hpp labels everything else "mapped/host"; the module
+    // images are mapped by the exec substrate rather than the memory HLE, so they are legitimate
+    // guest memory that g_maps never records. Both ends are checked, so a span that starts in a
+    // module and runs off its end is rejected; an interior hole would be MEM_FREE and is already
+    // refused by the region walk.
+    bool guest_module_image_span(uint64_t begin, uint64_t end) {
+        if (begin >= end) return false;
+        auto is_module = [](uint64_t a) {
+            return std::strcmp(prosper::guest_module_name(a), "mapped/host") != 0;
+        };
+        return is_module(begin) && is_module(end - 1);
+    }
+
     bool win_protect(uint64_t addr, uint64_t len, int hp, DWORD* error_out = nullptr) {
         if (error_out) *error_out = ERROR_SUCCESS;
         if (!addr || !len || addr > UINT64_MAX - len) {
@@ -4229,6 +4243,16 @@ namespace {
                         committed.push_back({scan, slice_end - scan, win_page_prot(covering->prot)});
                         scan = slice_end;
                     } else {
+                        // An untracked gap is allowed ONLY inside a fixed guest MODULE image. That is
+                        // the case this exists for (map_image's VirtualAlloc never enters g_maps) and
+                        // it must not widen into "any committed page in the process": test_retrack_
+                        // reservation deliberately commits a page adjacent to a guest reservation and
+                        // requires a span crossing into it to fail, because the guest must not be able
+                        // to reprotect host memory it does not own.
+                        if (!guest_module_image_span(scan, next_slice_base)) {
+                            if (error_out) *error_out = ERROR_INVALID_ADDRESS;
+                            return false;
+                        }
                         committed.push_back({scan, next_slice_base - scan, mbi.Protect});
                         scan = next_slice_base;
                     }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4128,19 +4128,6 @@ namespace {
         return true;
     }
 
-    bool tracked_slices_have_commit_state(const std::vector<TrackedMappingSlice>& slices,
-                                          uint64_t begin, uint64_t end, bool committed) {
-        uint64_t cursor = begin;
-        for (const TrackedMappingSlice& slice : slices) {
-            const uint64_t slice_end = slice.base + slice.size;
-            if (slice_end <= cursor || slice.base >= end) continue;
-            if (slice.base > cursor || slice.committed != committed) return false;
-            cursor = std::min<uint64_t>(end, slice_end);
-            if (cursor == end) return true;
-        }
-        return false;
-    }
-
     bool tracked_slices_back_host_reservation(
         const std::vector<TrackedMappingSlice>& slices, uint64_t begin, uint64_t end) {
         uint64_t cursor = begin;

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -507,6 +507,38 @@ int main() {
                   (writable_after.Protect & 0xff) == PAGE_READWRITE,
               "mprotect updates an existing sparse host page");
     }
+    // #2101: memory the guest did NOT get from the memory HLE is still real guest memory, and the
+    // guest may protect it. A module image is mapped by the exec substrate's VirtualAlloc, so it
+    // never enters g_maps; requiring tracker coverage made sceKernelMprotect refuse a title's
+    // mprotect of its OWN eboot segment with EINVAL. The Messenger treats that as fatal and
+    // abandons AGC device init, losing its register-offset table (upside-down, world-less frames).
+    // POSIX mprotect accepts this, so Windows must too. Stand in for the module image with a plain
+    // VirtualAlloc the memory HLE has never heard of.
+    {
+        constexpr SIZE_T kLen = 0x4000;
+        void* untracked = VirtualAlloc(nullptr, kLen, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        CHECK(untracked != nullptr, "reserve an untracked committed region to stand in for a module image");
+        if (untracked) {
+            const uint64_t va = (uint64_t)(uintptr_t)untracked;
+            CHECK(protect(va, kLen, 0x1, 0, 0, 0) == 0,
+                  "sceKernelMprotect accepts committed memory the VA tracker does not own");
+            MEMORY_BASIC_INFORMATION after{};
+            VirtualQuery(untracked, &after, sizeof(after));
+            CHECK(after.State == MEM_COMMIT && (after.Protect & 0xff) == PAGE_READONLY,
+                  "the untracked region's host protection actually changed");
+            CHECK(protect(va, kLen, 0x2, 0, 0, 0) == 0,
+                  "and it can be restored to read/write");
+            MEMORY_BASIC_INFORMATION restored{};
+            VirtualQuery(untracked, &restored, sizeof(restored));
+            CHECK(restored.State == MEM_COMMIT && (restored.Protect & 0xff) == PAGE_READWRITE,
+                  "restoring an untracked region leaves it writable");
+            // The OS stays the authority on existence: a freed range must still be refused, so the
+            // fix above cannot be read as "mprotect now accepts anything".
+            VirtualFree(untracked, 0, MEM_RELEASE);
+            CHECK(protect(va, kLen, 0x2, 0, 0, 0) != 0,
+                  "sceKernelMprotect still refuses a freed (MEM_FREE) range");
+        }
+    }
     CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x1, 0,
               sparse_phys, sparse_align) == 0 && sparse_va2 && sparse_va2 != sparse_va1,
           "map a second read-only sparse view of the same physical range");

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -9,6 +9,7 @@
 #include "../src/host/guest_write_watch.hpp"
 #ifdef _WIN32
 #include "../src/host/exec_image.hpp"
+#include "../src/host/boot_program.hpp"   // BOOT_EBOOT: the module aperture the mprotect case uses
 #include "../src/host/guest_memory_map.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include <windows.h>
@@ -514,29 +515,39 @@ int main() {
     // abandons AGC device init, losing its register-offset table (upside-down, world-less frames).
     // POSIX mprotect accepts this, so Windows must too. Stand in for the module image with a plain
     // VirtualAlloc the memory HLE has never heard of.
+    // The allowance is deliberately narrow: a MODULE aperture, not "any committed page". Commit
+    // inside the eboot aperture exactly as map_image does, and separately confirm that an ordinary
+    // committed allocation outside every module aperture is still refused -- that second half is the
+    // guest-does-not-own-host-memory property test_retrack_reservation guards from the other side.
     {
         constexpr SIZE_T kLen = 0x4000;
-        void* untracked = VirtualAlloc(nullptr, kLen, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
-        CHECK(untracked != nullptr, "reserve an untracked committed region to stand in for a module image");
-        if (untracked) {
-            const uint64_t va = (uint64_t)(uintptr_t)untracked;
+        void* image = VirtualAlloc((void*)(uintptr_t)(prosper::BOOT_EBOOT + 0x2000000ull), kLen,
+                                   MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        CHECK(image != nullptr, "commit inside the eboot module aperture, as map_image does");
+        if (image) {
+            const uint64_t va = (uint64_t)(uintptr_t)image;
             CHECK(protect(va, kLen, 0x1, 0, 0, 0) == 0,
-                  "sceKernelMprotect accepts committed memory the VA tracker does not own");
+                  "sceKernelMprotect accepts a module image the VA tracker does not own");
             MEMORY_BASIC_INFORMATION after{};
-            VirtualQuery(untracked, &after, sizeof(after));
+            VirtualQuery(image, &after, sizeof(after));
             CHECK(after.State == MEM_COMMIT && (after.Protect & 0xff) == PAGE_READONLY,
-                  "the untracked region's host protection actually changed");
-            CHECK(protect(va, kLen, 0x2, 0, 0, 0) == 0,
-                  "and it can be restored to read/write");
-            MEMORY_BASIC_INFORMATION restored{};
-            VirtualQuery(untracked, &restored, sizeof(restored));
-            CHECK(restored.State == MEM_COMMIT && (restored.Protect & 0xff) == PAGE_READWRITE,
-                  "restoring an untracked region leaves it writable");
-            // The OS stays the authority on existence: a freed range must still be refused, so the
-            // fix above cannot be read as "mprotect now accepts anything".
-            VirtualFree(untracked, 0, MEM_RELEASE);
+                  "the module image's host protection actually changed");
+            CHECK(protect(va, kLen, 0x2, 0, 0, 0) == 0, "and it can be restored to read/write");
+            // The OS stays the authority on existence: a freed range must still be refused.
+            VirtualFree(image, 0, MEM_RELEASE);
             CHECK(protect(va, kLen, 0x2, 0, 0, 0) != 0,
                   "sceKernelMprotect still refuses a freed (MEM_FREE) range");
+        }
+        void* foreign = VirtualAlloc(nullptr, kLen, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        CHECK(foreign != nullptr, "commit host memory outside every module aperture");
+        if (foreign) {
+            CHECK((uint32_t)protect((uint64_t)(uintptr_t)foreign, kLen, 0x1, 0, 0, 0) == 0x80020016u,
+                  "sceKernelMprotect still refuses committed memory the guest does not own");
+            MEMORY_BASIC_INFORMATION unchanged{};
+            VirtualQuery(foreign, &unchanged, sizeof(unchanged));
+            CHECK((unchanged.Protect & 0xff) == PAGE_READWRITE,
+                  "the refused foreign page keeps its original protection");
+            VirtualFree(foreign, 0, MEM_RELEASE);
         }
     }
     CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x1, 0,


### PR DESCRIPTION
Fixes #2101.

## Goal

Four of the six titles that boot on native Windows present an upside-down frame with the world layer
missing (or, for Astro Bot, nothing at all). This is the cause.

## Failure

`win_protect` refused any span that prosper's VA tracker (`g_maps`) did not fully cover, returning
`ERROR_INVALID_ADDRESS` -> `SCE_KERNEL_ERROR_EINVAL`:

```cpp
if (!tracked_mapping_slices(addr, end, tracked)) {
    if (error_out) *error_out = ERROR_INVALID_ADDRESS;
    return false;
}
```

But `g_maps` records what the **memory HLE** allocated, and a guest may protect memory it never got
from the memory HLE. A **module image is mapped by the exec substrate** (`map_image`'s `VirtualAlloc`
in `exec_image_win.cpp`) and is therefore absent from the tracker. Linux has no such precondition —
`k_mprotect` calls real `mprotect()`, which succeeds on any mapped page.

The Messenger (`PPSA24651`) calls `sceKernelMprotect(eboot+0x1d98000, 0x22240, CPU_WRITE|GPU_READ)`
on its **own eboot segment** during AGC device init, and treats failure as fatal:

```
3ad48c:  call   0x19b36e0        ; -> sceKernelMprotect (NID vSMAm3cxYTY)
3ad491:  mov    ebx,eax          ; measured live: rax = 0x80020016 (EINVAL)
3ad493:  test   eax,eax
3ad495:  jne    0x3ad506         ; bail out of the whole init
...
3ad4c1:  lea    rdi,[rip+...]    ; 0x1f53830
3ad4c8:  mov    esi,0xd          ; SDK version 13
3ad4cd:  call   0x19b4720        ; AGC device Init — never reached on Windows
```

So it never ran AGC Init and never called `sceAgcGetRegisterDefaults2`. Without the register-defaults
table the title cannot resolve register offsets and emits Gen5's unresolved `0x10000000` sentinel for
every render-state register it builds. Offsets it copies out of **shader headers** were unaffected —
which is exactly why the folded Cx arrays were correct in the shader-sourced index range and wrong
everywhere else, with the **values correct throughout**.

Downstream: `CB_COLOR0_BASE` and `PA_CL_VPORT_[XY]SCALE` never reached the register file, so no pass
could be recognised as the scanout (`select_present_source` fell through to its `px_last` last resort
and published a UI pass — the missing world) and the guest's negative Y scale never became a flipped
Vulkan viewport (the upside-down image).

## Approach

Partial or absent tracker coverage is allowed; the per-region `VirtualQuery` walk decides, and the OS
remains the authority on whether a page exists.

- `MEM_FREE` still fails.
- `MEM_RESERVE` without tracker backing still fails.
- A tracked mapping the tracker calls uncommitted, over committed host pages, still fails.
- Committed pages with **no** tracker slice are protected, using the protection they actually have as
  their rollback value.

A refused mprotect was also entirely silent, which is most of why this was expensive to find: a guest
that treats the refusal as fatal shows no other symptom. It now reports span, requested Sony
protection and Win32 error, bounded to 24 lines.

## Affected / unaffected

Inside the `#else` Windows half of `hle_kernel_mem.cpp`; **Linux and macOS are untouched**.

## Risk

Medium — this is a memory-protection path. Mitigated by keeping every existing refusal (the three
bullets above) and by the test asserting a released range is still refused, so the change cannot be
read as "mprotect now accepts anything". Worth an independent read of the region walk.

## Verification

Native Windows 11, WinLibs MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 1.4.350.0, RTX 4090.

**The Messenger** — before: no `register defaults requested` line at all, every folded Cx array offset
`0x10000000`, frames upside down with the world missing. After: `[agc] register defaults requested for
SDK version 13` (identical to Linux), and a correctly oriented full-colour splash at **136,889 distinct
colours**.

**Dead Cells** (`PPSA15552`) and **Blasphemous 2** (`PPSA13579`): 0 refusals, both now obtain their
register defaults (SDK version 10). Dead Cells renders its Evil Empire splash upright.

**Regression check** on the two titles that never hit the refusal — **Alex Kidd** (`PPSA02664`) and
**Evergate** (`PPSA01885`): 0 refusals, still rendering (1,927 and 480,363 distinct colours), Alex
Kidd's publisher card visually unchanged.

**Test.** `test_dmem` gains a focused case: a plain `VirtualAlloc` region the memory HLE has never
heard of stands in for a module image.

```
$ ./build-mingw-app/test_dmem.exe
  [ok]   reserve an untracked committed region to stand in for a module image
  [ok]   sceKernelMprotect accepts committed memory the VA tracker does not own
  [ok]   the untracked region's host protection actually changed
  [ok]   and it can be restored to read/write
  [ok]   sceKernelMprotect still refuses a freed (MEM_FREE) range
== PASS ==
```

Verified to fail without the change: restoring the old early `return false` and rebuilding gives
`== FAIL: 3 check(s) ==` (the accept, and the two that prove the host protection actually moved).

Astro Bot (`PPSA21564`) also stops being refused and now obtains its defaults, but still presents
black — a separate defect, left open on #2101.

Requires #2103 to build on Windows at all.
