### PR TITLE
review(#2110 follow-up): apply the approving review's non-blocking findings

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -620,9 +620,14 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   the census skips anything smaller than 64x64 and silently `continue`s on a readback failure, so
   the 16x16 / 4x4 / 2x1 tail of the luminance chain is outside it by construction. **The headline
   survives that gap transitively rather than by enumeration**, and it is worth seeing why: those
-  unseen stages are exposure *scalars*, not image content, and their consumer is the tonemap — whose
-  3840x2160 `RGBA8` output IS in the census and reads opaque black. Whatever they hold, the pass
-  that reads them produced black. The silent readback-failure path is bounded separately and weakly:
+  unseen stages are exposure *scalars*, not image content — a 2x1 luminance value cannot be the
+  missing picture however it reads — and **in the captured frame** their consumer is the tonemap,
+  whose 3840x2160 `RGBA8` output IS in the census and reads opaque black. Read that consumer as
+  *that frame's*: a one-submit capture cannot see a cross-frame read by construction, and a
+  luminance reduction is exactly the quantity a renderer adapts temporally, so "the tonemap is the
+  only consumer" is a claim this instrument cannot make. **The scalar half is what carries the
+  headline**; the tonemap corroborates it. The silent readback-failure path is bounded separately
+  and weakly:
   the enumerated count is **identical (17) in both runs**, so it is not dropping a target
   nondeterministically. Exactly one
   enumerated target has content — the CPU-materialised movie composite, still holding the last

--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -583,23 +583,28 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   compute program, alternating between the two buffers, packing and tiling its result back into
   guest memory across the padded SW_64KB_R_X footprint. **Do not read that event count as a dispatch
   rate**: `live_compute`'s "skipped identical storage writeback" fast path `continue`s *before* the
-  record, so the events count writes that **changed** something — 237 over 360 s against ~1,055
-  flips, collapsing to ~0 per sample once the frame is uniformly black and every writeback is
-  byte-identical to the last. The dispatch is still issued: a capture selected by
-  `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires in the black phase. **Zero** `dma-data` and **zero**
-  `write-data` events touch either address, and the draw half is settled independently by the pass
-  census (`vo=1` on 0 of 8,443 records — a census of every *deferred* pass plus every pass with more
-  than 100 non-black pixels, which on the default live-target path is all of them). So the guest
-  composites with a compute dispatch,
+  record, so the events are an **upper bound on writebacks that changed something** — that fast
+  path also requires the binding to be a cache candidate, so a non-candidate records even with
+  identical bytes. 237 over 360 s against ~1,055 flips, collapsing to ~0 per sample once the frame
+  is uniformly black and every writeback is byte-identical to the last. The dispatch is still
+  issued: a capture selected by `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires in the black phase.
+  **Zero** `dma-data` and **zero** `write-data` events touch either address, and the draw half is
+  settled independently by the pass
+  census (`vo=1` on 0 of 8,443 records — every *deferred* pass plus every pass with more than 100
+  non-black pixels; 8,443 over ~1,055 flips is 8.0 records per frame, exactly the post chain the
+  capture enumerated, so coverage is complete **for that run** — which is the claim the arithmetic
+  supports and the code paths do not, since `PROSPER_READBACK_WHY` names six ways a pass on the
+  live-target path is not deferred). So the guest composites with a compute dispatch,
   prosper executes it, prosper writes it back, and prosper publishes it. Reach for
   `PROSPER_PROVENANCE_ADDR` first on any title whose scanout no pass targets — it names the writer
   kind, the program's code address and the submit, which no pass census can. **Read its silence with
   one limit in mind, because it is not stated anywhere else:** the address watch arms the
   compute-writeback, `DMA_DATA` and `WRITE_DATA` recorders, but the **colour-target** recorder lives
   inside `diagnose_resource_provenance`, which returns early unless the *separate*
-  `PROSPER_PROVENANCE_DIM` is also set (`gpu_executor.cpp`). An `ADDR`-only run therefore reports
-  **no `color` lines at all**, and that zero is void rather than negative — filed as #2111. Set both
-  variables, or settle the draw question with `PROSPER_PASS_LOG`. #1968.
+  `PROSPER_PROVENANCE_DIM` is also set — and set to something that *parses* as `WxH` with both
+  dimensions non-zero, so `=1` is not enough (`gpu_executor.cpp`). An `ADDR`-only run therefore
+  reports **no `color` lines at all**, and that zero is void rather than negative — filed as #2111.
+  Set both variables, or settle the draw question with `PROSPER_PASS_LOG`. #1968.
 - **Post-intro Frontiers runs a complete post-processing chain over an empty scene — the missing
   thing is geometry, not a composite step.** A capture of the submit containing that composite
   dispatch (selected with `PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x20002fe800`, 240 s into a default
@@ -613,7 +618,13 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   and taken with no capture armed) enumerates **17** persistent colour targets over three
   consecutive black-phase submits, in each of two independent runs. Read 17 as a **lower bound**:
   the census skips anything smaller than 64x64 and silently `continue`s on a readback failure, so
-  the 16x16 / 4x4 / 2x1 tail of the luminance chain is outside it by construction. Exactly one
+  the 16x16 / 4x4 / 2x1 tail of the luminance chain is outside it by construction. **The headline
+  survives that gap transitively rather than by enumeration**, and it is worth seeing why: those
+  unseen stages are exposure *scalars*, not image content, and their consumer is the tonemap — whose
+  3840x2160 `RGBA8` output IS in the census and reads opaque black. Whatever they hold, the pass
+  that reads them produced black. The silent readback-failure path is bounded separately and weakly:
+  the enumerated count is **identical (17) in both runs**, so it is not dropping a target
+  nondeterministically. Exactly one
   enumerated target has content — the CPU-materialised movie composite, still holding the last
   credits frame at `rgb_nonblack=778215/8294400`, which is *stale* and not an input to the post
   chain (`0x2059ea0000` in one run and `0x2059eb0000` in the next: **the address is run-local**,
@@ -621,8 +632,11 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   `00 00 00 00 00 00 00 3c` per texel (RGB bit-zero, alpha exactly 1.0) and every 4K `RGBA8` target
   reads `00 00 00 ff` (opaque black); the bloom target and three others are entirely zero. Nothing
   is lost between any target and the scanout because there is nothing anywhere to lose. Corroborated
-  by a full `PROSPER_DBG=1` run: **0** recompile-rejects of any kind and **0** `[compute] skip`, the
-  only skipped dispatch in the whole boot being #657's `64x64x6` layered image, twice, at boot.
+  by a full `PROSPER_DBG=1` run: **0** recompile-rejects of any kind and **0** `[compute] skip` —
+  not self-contradictory with what follows, because they are different tokens: `[compute] skip` is
+  the unsupported-program / descriptor-contract reject, while the only skipped dispatch in the whole
+  boot is #657's `64x64x6` layered image, twice, at boot, reported as `layered image deferred to
+  #657 -> dispatch skipped (#590)`.
   **That zero has a positive control, and it needs one**: all four reject emitters
   (`[recompile-reject]`, `[cfg-recompile-reject]`, `[vertex-recompile-reject]`,
   `[exec-recompile-reject]`) are `PROSPER_DBG`-gated, so an unset variable is indistinguishable from
@@ -639,8 +653,8 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   come from `gpu_capture_hash` (`gpu_capture.cpp`), so the hash of *N* zero bytes — or of any
   repeating texel pattern, which is how "opaque black" and "alpha 1.0" were identified above — can
   be computed offline and compared. **Do not reach for a stock FNV-1a 64 to do it.**
-  `gpu_capture_hash` uses the FNV prime with a **basis of `0x14650fb0739d0383`**, which is the FNV-1a
-  64 offset basis with a digit dropped; a standard implementation produces a value that can never
+  `gpu_capture_hash` uses the FNV prime with a **basis of `0x14650fb0739d0383`** — the FNV-1a 64
+  offset basis with a digit dropped; a standard implementation produces a value that can never
   match a prosper hash, and that mismatch reads as "the buffer is not zero" — the exact false
   conclusion this row exists to prevent. Same family as the `px_nonblack` inversion. #1968.
 - **The census ordinal `PROSPER_DUMP_PERSISTENT` / `PROSPER_PASS_LOG` take is NOT the submit number

--- a/prosper/frontends/shared/diagnostic_window.hpp
+++ b/prosper/frontends/shared/diagnostic_window.hpp
@@ -78,7 +78,6 @@ public:
     }
 
     const DiagnosticWindowSpec& spec() const { return spec_; }
-    bool started() const { return started_ || !spec_.by_time; }
 
 private:
     DiagnosticWindowSpec spec_{};

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -5918,7 +5918,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const uint64_t at = g_pass_log_submit.fetch_add(1);
                     if (getenv("PROSPER_PASS_LOG")) {
                         // The same window object and the same ordinal the per-pass report used, so
-                        // the two lines always describe one set of callbacks.
+                        // the two lines describe one set of callbacks — with one seam: if a `ms:`
+                        // deadline is crossed between the pass loop and this site, the latching
+                        // callback carries `selected=` with no per-pass lines beside it.
                         if (g_pass_log_window.contains(at, diagnostic_elapsed_ms()))
                             fprintf(stderr, "[pass] cb=%llu selected=%s\n", (unsigned long long)at,
                                     prosper::frontend::present_source_name(present_choice));
@@ -5927,7 +5929,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // PROSPER_DUMP_PERSISTENT=<min-submit>|ms:<millis>: read back and dump EVERY
                 // persistent color target after this submit's passes render. Unlike
                 // PROSPER_RTT*/DUMP_*, this flag is NOT in the live_gpu_targets disable list
-                // (:480-487), so it observes the NORMAL persistent-render path (all other CPU-pixel
+                // (:1078-1085), so it observes the NORMAL persistent-render path (all other CPU-pixel
                 // diagnostics change that path -> #1103). readback_persistent_color_target restores
                 // the image layout, so rendering is unaffected. The `ms:` form aims the window by
                 // wall time, because the ordinal below is a renderer-internal counter with no

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1543,6 +1543,14 @@ uint64_t gpu_capture_dcc_metadata_footprint(const ShaderResource& resource) {
     return dcc_metadata_footprint(resource);
 }
 
+// FNV-1a's prime with a basis of 1469598103934665603 (0x14650fb0739d0383) — the FNV-1a 64 offset
+// basis with a digit dropped. **Do not "correct" it.** It is a sound 64-bit hash (the multiplier is
+// odd, so the mixing is bijective) and nothing here claims FNV compliance, while the value is baked
+// into every recorded capture, bundle manifest and `--inspect-only` seed hash in the project's
+// evidence trail — changing it would invalidate all of them for a cosmetic gain. It is recorded
+// here because the dropped digit reads as a typo, and because anyone verifying one of these hashes
+// offline with a stock FNV-1a 64 gets a value that can never match and is liable to read the
+// mismatch as "this buffer is not zero" (#1968, `docs/GRAPHICS.md` § Ruled out).
 uint64_t gpu_capture_hash(const uint8_t* data, size_t size) {
     uint64_t h = 1469598103934665603ull;
     for (size_t i = 0; i < size; ++i) { h ^= data[i]; h *= 1099511628211ull; }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -221,9 +221,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     ordinal is NOT the submit number `[gpucap]` prints** — on one 360 s route it reaches 6,560 while
     the capture's submit counter reaches 26,209 — and overshooting it yields *no census at all*, a
     silence that reads exactly like "every target was empty" (#1968). The `ms:` origin is the first
-    armed census check — the same *kind* of origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, on a separate
-    clock, so a capture and a census can be aimed at one phase but do not share a timebase. `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the
-    `live_gpu_targets` disable list, so it observes the normal persistent-GPU-target path;
+    armed census check — the same *kind* of origin `PROSPER_GPU_CAPTURE_AFTER_MS` uses, on a
+    separate clock, so the two can be aimed at one phase but do not share a timebase.
+    `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the `live_gpu_targets` disable list, so it
+    observes the normal persistent-GPU-target path;
     `PROSPER_GPU_CAPTURE` **is**, so an env-triggered capture run is on the CPU-readback path.
 - **`screenshot/`** — writes normal composited PNG sequences plus a JSONL evidence manifest. Use
   `--seconds 1` for wall-clock sampling, warmup or `--render-every N --render-every-for-seconds S`


### PR DESCRIPTION
## Why this exists

**#2110 merged at head `16501212` while I was applying the non-blocking half of its approving
review.** Those corrections land here instead. Same author, same reviewer, same issue; nothing in
#2110 is reverted, and every removed line in this diff is my own prose from that PR being rewritten.

The review's central point was that #2110's last round of softenings bought honesty at the cost of
the headline, and that one clause buys it back. That is the first item below and the reason this is
worth a follow-up rather than a note on the issue.

## The changes

### 1. The census gap is covered transitively — the headline survives it

`GRAPHICS.md` said "17 persistent colour targets ... read 17 as a **lower bound**", which is true
(the census skips anything under 64x64 and `continue`s silently past a readback failure) and weaker
than the evidence. The unseen population is exactly the 16x16 / 4x4 / 2x1 tail of the luminance
reduction — **exposure scalars, not image content** — and *their consumer is the tonemap*, whose
3840x2160 `RGBA8` output IS in the census and reads opaque black. Whatever those stages hold, the
pass that reads them produced black. The chain closes downstream of the gap.

The silent readback-failure path is bounded separately and weakly, by tying a fact the row already
carried to the sentence that needs it: the enumerated count is **identical (17) in both independent
runs**, so it is not dropping a target nondeterministically.

### 2. A code-path inference replaced by the arithmetic that actually supports it

The row justified its pass census with "every deferred pass plus every pass with more than 100
non-black pixels, **which on the default live-target path is all of them**". That is an inference
from code paths, and the renderer contains a diagnostic that exists precisely because it is not
universally true: `PROSPER_READBACK_WHY`'s bucket enum names six ways a pass on the live-target path
is *not* deferred, one of them (`kVoFinal`) being the exact case the sentence claimed cannot happen.

Replaced with the run-scoped measurement: **8,443 records over ~1,055 flips is 8.0 per frame**,
exactly the post chain the capture enumerated — so coverage is complete *for that run*, which is the
claim the arithmetic supports.

### 3. Four smaller corrections to the same rows

| was | now |
| --- | --- |
| "**0** `[compute] skip`, the only skipped dispatch being #657's" — reads as self-contradictory | both tokens named: `[compute] skip` is the unsupported-program / descriptor-contract reject; #657's reports `layered image deferred to #657 -> dispatch skipped (#590)` |
| "the events count writes that **changed** something" | an **upper bound** on those: the identical-output fast path also requires a cache-candidate binding, so a non-candidate records even with identical bytes |
| `PROSPER_PROVENANCE_DIM` must be "also set" | must also **parse** as `WxH` with both dimensions non-zero (`gpu_executor.cpp`), so `=1` is not enough |
| ragged wrapping left by two rewrites | rewrapped; no added line exceeds 100 columns |

### 4. Code: three tidy-ups and one freeze

- `DiagnosticWindow::started()` was dead — no caller in the tree. Removed.
- `live_renderer.cpp` cited the `live_gpu_targets` disable list as `(:480-487)`; it is `:1078-1085`.
- "the two lines always describe one set of callbacks" is a touch strong: if a `ms:` deadline is
  crossed between the pass loop and the `fetch_add` site, the latching callback carries `selected=`
  with no per-pass lines beside it. The comment now says so.
- **`gpu_capture_hash`'s basis is frozen in a comment.** It uses the FNV prime with a basis of
  `0x14650fb0739d0383` — the FNV-1a 64 offset basis with a digit dropped. The reviewer and I agreed
  **not** to file that as an issue: it is a sound 64-bit hash (odd multiplier, so the mixing is
  bijective), nothing in the codebase claims FNV compliance, and changing the constant would
  silently invalidate every recorded capture hash, bundle manifest and `--inspect-only` seed hash in
  the project's evidence trail. But the next reader to notice the dropped digit will read it as a
  typo and "fix" it, so the definition now says why it must not be touched — and why a stock FNV-1a
  64 used to verify one of these hashes offline can never match.

## Affected and deliberately unaffected

No behavioural change. The only executable edit is deleting an uncalled accessor; everything else is
comments and documentation. `PROSPER_DUMP_PERSISTENT` / `PROSPER_PASS_LOG` behave exactly as they do
on master.

## Verification — exact head `f3f46233`

```text
cmake --build build-linux -j8                    clean
ctest -j4                                        100% tests passed, 203/203
docs gate, both invocations                      14 tables / 173 rows contiguous; all files unbroken
git diff --cached --check                        clean
trap-41 (merge-tree, three-dot)                  every removed line is this author's own #2110 prose;
                                                 gpu_capture.cpp is a pure addition
git log origin/master..HEAD | grep -c Claude-Session   0
```

Not docs-only (it touches `.hpp` and two `.cpp`), so the CI wait applies in full.

Refs #1968
