### PR TITLE
fix(render): an unmeasured 0x0 extent must not truncate the MRT prefix

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -505,6 +505,12 @@ if(TARGET prosper_core)
   target_include_directories(test_rtt_scale PRIVATE frontends/shared)
   add_test(NAME rtt_scale COMMAND test_rtt_scale)
 
+  # MRT-prefix truncation: which bound colour slot may join a pass, and which extent comparisons are
+  # evidence of a real conflict rather than an unmeasured 0x0. Pure integer arithmetic, no deps.
+  add_executable(test_mrt_extent frontends/shared/test_mrt_extent.cpp)
+  target_include_directories(test_mrt_extent PRIVATE frontends/shared)
+  add_test(NAME mrt_extent COMMAND test_mrt_extent)
+
   add_executable(test_rtt_injection frontends/shared/test_rtt_injection.cpp)
   target_include_directories(test_rtt_injection PRIVATE frontends/shared)
   add_test(NAME rtt_injection COMMAND test_rtt_injection)

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4,6 +4,7 @@
 #include "rtt_authority.hpp"
 #include "rtt_injection.hpp"
 #include "rtt_scale.hpp"
+#include "mrt_extent.hpp"               // which MRT slot may join a pass (measured extents only)
 #include "readback_policy.hpp"
 #include "capture_renderer_policy.hpp"
 #include "write_watch_policy.hpp"
@@ -5273,9 +5274,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         for (uint32_t slot = 1; slot < mrt_count; ++slot) {
                             const auto binding = color_binding(*render_pass.front(), slot);
                             // Sparse exports retain their native Location through dummy attachments.
-                            // Only a real target whose extent differs from MRT0 truncates the prefix.
-                            if (pass_bases[slot] && (binding.width != native_w ||
-                                binding.height != native_h)) {
+                            // Only a real target whose extent is KNOWN to differ from the pass
+                            // extent truncates the prefix. A 0x0 on either side means the guest's
+                            // CB_COLORn_ATTRIB2 was never seen, not a 0-pixel surface, and an
+                            // unmeasured extent is no evidence of a conflict — comparing it for
+                            // equality dropped the whole attachment silently (#2114).
+                            if (pass_bases[slot] && prosper::frontend::mrt_extent_conflicts(
+                                    binding.width, binding.height, native_w, native_h)) {
                                 if (rtt_log)
                                     fprintf(stderr,
                                             "[rtt] truncate MRT prefix at c%u target=0x%llx "
@@ -5285,6 +5290,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 mrt_count = slot;
                                 break;
                             }
+                            // Fail-visible: name the attachment that was kept on missing extent
+                            // data, so an unmeasured extent is a reported state rather than a
+                            // silent one in either direction.
+                            if (rtt_log && pass_bases[slot] &&
+                                (!prosper::frontend::mrt_extent_known(binding.width, binding.height) ||
+                                 !prosper::frontend::mrt_extent_known(native_w, native_h)))
+                                fprintf(stderr,
+                                        "[rtt] keep MRT c%u target=0x%llx on unmeasured extent "
+                                        "%ux%u; MRT0 is %ux%u\n",
+                                        slot, (unsigned long long)pass_bases[slot],
+                                        binding.width, binding.height, native_w, native_h);
                         }
                     }
                     const bool use_color1 = mrt_count > 1;

--- a/prosper/frontends/shared/mrt_extent.hpp
+++ b/prosper/frontends/shared/mrt_extent.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include <cstdint>
+
+// Shared predicate for the live renderer's MRT-prefix truncation.
+//
+// A render pass binds one colour attachment per exported MRT slot, and the live renderer records
+// EVERY slot's surface at the single extent the pass renders at (live_renderer.cpp writes each
+// slot's RttSurf as gw x gh). A bound slot whose own surface is really a different size therefore
+// cannot join that pass, and the MRT prefix has to stop before it.
+//
+// That is a statement about two MEASURED extents, which is the whole point of the guard below.
+// A colour target's extent is only ever populated from CB_COLORn_ATTRIB2, whose MIP0_WIDTH and
+// MIP0_HEIGHT fields are biased by one: render_state.cpp decodes any register the guest actually
+// wrote to at least 1x1, and leaves the extent at 0x0 exclusively when prosper has never seen that
+// register. Zero is a "not measured" sentinel, never a real surface size -- and the two registers
+// are independent (0x3B0 and 0x3B1, a dense per-slot array), so either side can be absent on its
+// own.
+//
+// Comparing an unmeasured extent for equality manufactures a conflict out of missing data. It is
+// also silent in the worst way: mrt_count truncates, the second colour attachment is dropped, the
+// shader's second output goes nowhere, and nothing logs and nothing fails -- the frame simply
+// renders without whatever that target carried (a normal buffer, velocity, an ID target). #2114.
+namespace prosper::frontend {
+
+// Whether a colour target's extent was actually measured. Both axes come from one register write,
+// so a half-populated extent does not occur; requiring both mirrors live_renderer.cpp's existing
+// `if (native_w && native_h)` guards on the same values.
+constexpr bool mrt_extent_known(uint32_t w, uint32_t h) {
+    return w != 0u && h != 0u;
+}
+
+// True only when a bound slot's extent is KNOWN to disagree with the extent the pass renders at.
+// An unknown extent on either side yields false: absence of a measurement is not evidence of a
+// mismatch, and the fail-safe direction is to keep a real, actively-written attachment rather than
+// to drop its contents silently.
+constexpr bool mrt_extent_conflicts(uint32_t slot_w, uint32_t slot_h,
+                                    uint32_t pass_w, uint32_t pass_h) {
+    if (!mrt_extent_known(pass_w, pass_h)) return false;
+    if (!mrt_extent_known(slot_w, slot_h)) return false;
+    return slot_w != pass_w || slot_h != pass_h;
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/shared/test_mrt_extent.cpp
+++ b/prosper/frontends/shared/test_mrt_extent.cpp
@@ -1,0 +1,100 @@
+// Unit test for mrt_extent_conflicts (live-renderer MRT-prefix truncation).
+//
+// The predicate decides whether a bound colour slot may join the pass or whether the MRT prefix
+// truncates before it. Truncating drops the attachment with no log and no failure, so the boundary
+// between "measured extents that really disagree" (truncate) and "an extent nobody measured"
+// (keep) is pinned here.
+//
+// `legacy_extent_conflicts` below is the predicate this file replaced, kept as an explicit
+// counter-arm: several cases assert that the two DISAGREE, so the test cannot pass unless the guard
+// is actually present. A test that only asserted the new contract could stay green against an
+// implementation that never grew the guard at all.
+
+#include "mrt_extent.hpp"
+
+#include <cstdint>
+#include <cstdio>
+
+using prosper::frontend::mrt_extent_conflicts;
+using prosper::frontend::mrt_extent_known;
+
+// The pre-#2114 comparison, verbatim: a bare inequality against the pass extent.
+static constexpr bool legacy_extent_conflicts(uint32_t slot_w, uint32_t slot_h,
+                                              uint32_t pass_w, uint32_t pass_h) {
+    return slot_w != pass_w || slot_h != pass_h;
+}
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::fprintf(stderr, "FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+int main() {
+    // --- mrt_extent_known: 0 on either axis is the "never measured" sentinel. ---
+    CHECK(mrt_extent_known(1920, 1080));
+    CHECK(mrt_extent_known(1, 1));            // CB_COLORn_ATTRIB2 is biased by one: a written
+                                              // register decodes to at least 1x1, never 0.
+    CHECK(!mrt_extent_known(0, 0));
+    CHECK(!mrt_extent_known(1920, 0));
+    CHECK(!mrt_extent_known(0, 1080));
+
+    // --- Preserved behaviour: two MEASURED extents that really differ still truncate. ---
+    // This is the positive control. If the guard were written too broadly (e.g. returning false
+    // whenever any axis compares unequal) these would flip and the truncation would stop working.
+    CHECK(mrt_extent_conflicts(1024, 32, 1920, 1080));     // small LUT bound beside a scene target
+    CHECK(mrt_extent_conflicts(1920, 1080, 3840, 2160));
+    CHECK(mrt_extent_conflicts(1920, 540, 1920, 1080));     // height alone differs
+    CHECK(mrt_extent_conflicts(960, 1080, 1920, 1080));     // width alone differs
+    CHECK(legacy_extent_conflicts(1024, 32, 1920, 1080));   // old predicate agreed here
+    CHECK(legacy_extent_conflicts(1920, 540, 1920, 1080));
+
+    // --- Preserved behaviour: two measured extents that agree never truncate. ---
+    CHECK(!mrt_extent_conflicts(1920, 1080, 1920, 1080));
+    CHECK(!mrt_extent_conflicts(1, 1, 1, 1));
+    CHECK(!mrt_extent_conflicts(16384, 16384, 16384, 16384));  // MIP0_WIDTH is 14 bits + 1
+
+    // --- #2114: the pass extent was never measured. ---
+    // CB_COLOR0_ATTRIB2 unwritten leaves native_w/native_h at 0x0 while MRT1 carries a real
+    // extent. The old predicate reported a conflict against 0 and truncated mrt_count to 1,
+    // silently dropping the second colour attachment.
+    CHECK(!mrt_extent_conflicts(1920, 1080, 0, 0));
+    CHECK(!mrt_extent_conflicts(1024, 32, 0, 0));
+    CHECK(!mrt_extent_conflicts(1, 1, 0, 0));
+    // The lever, made visible: old and new disagree on exactly this input.
+    CHECK(legacy_extent_conflicts(1920, 1080, 0, 0));
+    CHECK(legacy_extent_conflicts(1920, 1080, 0, 0) != mrt_extent_conflicts(1920, 1080, 0, 0));
+    CHECK(legacy_extent_conflicts(1024, 32, 0, 0) != mrt_extent_conflicts(1024, 32, 0, 0));
+
+    // --- The same sentinel on the slot side. ---
+    // CB_COLORn_ATTRIB2 is a dense per-slot array (0x3B0, 0x3B1, ...), so a slot can carry a base,
+    // a format and a write mask -- everything that makes it a real, actively written target -- while
+    // its own extent register has not been seen. That is equally not evidence of a mismatch.
+    CHECK(!mrt_extent_conflicts(0, 0, 1920, 1080));
+    CHECK(!mrt_extent_conflicts(0, 0, 1024, 32));
+    CHECK(legacy_extent_conflicts(0, 0, 1920, 1080));
+    CHECK(legacy_extent_conflicts(0, 0, 1920, 1080) != mrt_extent_conflicts(0, 0, 1920, 1080));
+
+    // A half-populated extent cannot come from one register write, but must not be trusted if seen.
+    CHECK(!mrt_extent_conflicts(1920, 0, 1920, 1080));
+    CHECK(!mrt_extent_conflicts(0, 1080, 1920, 1080));
+    CHECK(!mrt_extent_conflicts(1920, 1080, 1920, 0));
+    CHECK(!mrt_extent_conflicts(1920, 1080, 0, 1080));
+
+    // --- Neither side measured: already benign before the fix (0 == 0), pinned so it stays so. ---
+    CHECK(!mrt_extent_conflicts(0, 0, 0, 0));
+    CHECK(!legacy_extent_conflicts(0, 0, 0, 0));
+
+    // --- Symmetry: the predicate is about disagreement, so measured pairs commute. ---
+    CHECK(mrt_extent_conflicts(1024, 32, 1920, 1080) ==
+          mrt_extent_conflicts(1920, 1080, 1024, 32));
+    CHECK(mrt_extent_conflicts(1920, 1080, 1920, 1080) ==
+          mrt_extent_conflicts(1920, 1080, 1920, 1080));
+
+    // --- Usable in constant expressions, like the rest of the frontend's extent predicates. ---
+    static_assert(!mrt_extent_conflicts(1920, 1080, 0, 0), "#2114: unknown pass extent never conflicts");
+    static_assert(!mrt_extent_conflicts(0, 0, 1920, 1080), "unknown slot extent never conflicts");
+    static_assert(mrt_extent_conflicts(1024, 32, 1920, 1080), "measured disagreement still truncates");
+    static_assert(!mrt_extent_known(0, 0), "0x0 is the not-measured sentinel");
+
+    if (failures == 0) std::printf("mrt_extent: OK\n");
+    return failures == 0 ? 0 : 1;
+}


### PR DESCRIPTION
Fixes #2114

## Goal

Stop a `0x0` "extent nobody measured" from being compared for equality against a real MRT binding,
where it silently truncates `mrt_count` to 1 and drops the second colour attachment.

## Failure scenario

`live_renderer.cpp` groups draws into a pass, then decides how many colour attachments that pass may
carry. The test was a bare inequality against MRT0's extent:

```c
if (pass_bases[slot] && (binding.width != native_w || binding.height != native_h)) {
    mrt_count = slot;   // truncate the MRT prefix
    break;
}
```

`native_w`/`native_h` come from `pass.front()->color0_width/height` and stay **0** unless the
VideoOut branch or the depth-only viewport recovery overwrites them. The same function already
treats `0x0` as a reachable state — it guards `if (native_w && native_h)` twice, immediately above.

`0` is not a legal extent here. Both sides are only ever populated from `CB_COLORn_ATTRIB2`, whose
`MIP0_WIDTH`/`MIP0_HEIGHT` fields are **biased by one** (`render_state.cpp`: `PM4_FIELD(...) + 1u`),
so a register the guest actually wrote decodes to at least `1x1`. `0x0` means only "prosper has
never seen that register" — the state `render_state.cpp` records separately as
`color0_has_extent == false` and describes as "a depth-only pass has no extent". The registers are a
dense per-slot array (`0x3B0`, `0x3B1`, …), so either side can be absent independently.

So when `native_w == 0`, **every** real MRT1 binding compares unequal and the prefix truncates to 1.
Whatever that attachment carried — a normal buffer, velocity, an ID target — is never written, the
shader's second output goes nowhere, and nothing logs by default and nothing fails.
(Under `PROSPER_RTTLOG` the old path did print `truncate MRT prefix`; the loss is silent on a
default run, which is where it matters.)

## Is it reachable? Not on any title measured — but the mechanism is real

This was the first question, and the answer changes what the PR should be, so it was measured rather
than argued.

**Instrument.** `live_renderer.cpp` already prints one line per render pass under `PROSPER_RTTLOG`
that carries the value in question verbatim: `[rtt] pass target=... extent=WxH native=WxH ...`,
where `native=` *is* `native_w x native_h`. It is inside a plain `if (rtt_log)` with no early
`continue` between the MRT decision and the print, so it is a complete per-pass census, not a
sample. `[rtt] pass c<N>=` counts colour attachments beyond MRT0 that actually rendered.

**Census — 17 titles, Linux, `PROSPER_RENDER_SCALE=1`, `PROSPER_RENDER_EVERY=1`, 45–90 s each:**

| title | passes | `native=0x0` | MRT1 rendered | truncations |
|---|---|---|---|---|
| PPSA24651 The Messenger | 15,719 | 0 | 0 | 0 |
| PPSA13579 Blasphemous 2 | 22,194 | 0 | 0 | 0 |
| PPSA25009 Blue Prince | 4,357 | 0 | 0 | 0 |
| PPSA05143 Little Nightmares III | 1,716 | 0 | 179 | 0 |
| PPSA03839 Tactics Ogre | 4,968 | 0 | 0 | 0 |
| PPSA15552 Dead Cells | 1,900 | 0 | 0 | 0 |
| PPSA02664 Alex Kidd DX | 3,627 | 0 | 0 | 0 |
| PPSA30140 Syberia | 3,323 | 0 | 0 | 0 |
| PPSA17942 Dragon Quest VII | 2,570 | 0 | 68 | 0 |
| PPSA19244 Oregon Trail | 1,052 | 0 | 0 | 0 |
| PPSA26414 R-Type Delta | 24 | 0 | 0 | 0 |
| PPSA08804 Sonic CrossWorlds | 2,056 | 0 | 0 | 0 |
| PPSA23760 Nikoderiko | 2,350 | 0 | 158 | 0 |
| PPSA21406 ArcRunner | 411 | 0 | 24 | 0 |
| PPSA27616 Bendy | 1,325 | 0 | 35 | 0 |
| PPSA03416 Summer Sports Games | 1,771 | 0 | 0 | 0 |
| PPSA30490 Asterix & Obelix | 3,546 | 0 | 0 | 0 |
| **total** | **~72,900** | **0** | **464** | **0** |

Five titles do bind a real second colour target, so the MRT path is genuinely exercised — it simply
never meets a `0x0` pass extent. **The precondition was not observed on any title measured.**

**What the instrument costs, stated because the charter tells the next reader to check it.**
`PROSPER_RTTLOG` is one of the diagnostics in the `live_gpu_targets` conjunction
(`live_renderer.cpp:1079-1086`), so this census ran the **CPU-render path, not the default
persistent-GPU-target route.** That does not touch the columns above: every input to the truncation
decision — `binding.width/height` from the register decode, `native_w/native_h`
(`pass.front()->color0_width/height`, the VideoOut override, the depth-only viewport recovery) and
`pass_bases[slot]` (write mask / format / base) — is independent of `live_gpu_targets`. What it does
bound is the **positive control**: the "206 attachments still rendered" row was measured with
persistent GPU targets off, so the fix's GPU-side consequence (an extra persistent colour target for
a kept slot) was not exercised under forcing. That path is analysed in Risk below rather than
measured. This is inherent to the instrument — there is no `native_w` census that does not clear
`live_gpu_targets` — not an oversight, but it belongs on the record.

**The negative is not a blind instrument.** A census that reports zero is worthless unless it can
report non-zero, so the detector was given a positive control: a temporary, uncommitted scaffold
forced `native_w/native_h` to 0 *at the MRT decision only* (leaving `gw`/`gh`, and therefore the
framebuffer, untouched), with a second switch selecting the pre-fix predicate. On Little Nightmares
III, which binds 206 real MRT1 attachments in this window:

| cell | passes | `native=0x0` | **MRT1 rendered** | truncations | of those, `MRT0 is 0x0` | kept on unmeasured |
|---|---|---|---|---|---|---|
| baseline (fixed predicate, no forcing) | 1,977 | 0 | **206** | 0 | 0 | 0 |
| forced `0x0` + **legacy** predicate | 2,030 | 2,030 | **0** | 210 | 210 | 0 |
| forced `0x0` + **fixed** predicate | 1,978 | 1,978 | **206** | 0 | 0 | 206 |

The middle row is the defect, reproduced end to end: every one of 210 MRT1 bindings truncated, and
the content metric — colour attachments beyond MRT0 that actually rendered — collapsed **206 → 0**.
The bottom row is the fix under the identical forced state: no truncation, all 206 attachments still
rendered, and 206 fail-visible "kept on unmeasured extent" lines. The `native=0x0` column moving
0 → 2,030 is what licenses reading the census's zeros as real.

**So: this is a latent defect, not an active one.** The honest outcome is the guard plus the comment
that the issue itself proposed, and that is what this PR is — with the mechanism pinned by a test so
it cannot come back, and with the census recorded so nobody re-derives it.

## Approach

Extract the decision into `frontends/shared/mrt_extent.hpp` as a `constexpr` predicate, next to the
existing `rtt_scale.hpp`, with the contract the call site actually wants: **truncate only on a KNOWN
disagreement.**

```c
constexpr bool mrt_extent_conflicts(uint32_t slot_w, uint32_t slot_h,
                                    uint32_t pass_w, uint32_t pass_h) {
    if (!mrt_extent_known(pass_w, pass_h)) return false;   // pass extent never measured
    if (!mrt_extent_known(slot_w, slot_h)) return false;   // this slot's extent never measured
    return slot_w != pass_w || slot_h != pass_h;
}
```

The guard is deliberately **symmetric**, and that half deserves a reviewer's attention because the
issue only asked for the pass side. It is the same sentinel collision rather than a different one:
`pass_bases[slot]` becomes non-zero from a base, a decodable format and a non-zero write mask —
none of which involves `ATTRIB2` — so a real, actively written target can reach this test with its
own extent unmeasured and be dropped for it. Absence of a measurement is not evidence of a mismatch
in either direction, and for a bound attachment the fail-safe direction is to keep it rather than
discard its contents silently. Fixing only one side would leave the predicate incoherent.

The declined-truncation case gains a `PROSPER_RTTLOG` line, so an unmeasured extent is a *reported*
state in both directions instead of a silent one.

## Behavioural contract

- Both extents measured and **equal** — unchanged, no truncation.
- Both extents measured and **different** — unchanged, still truncates. This is what the guard
  exists for; it is pinned by the test's positive control and by the baseline row above.
- Either extent **unmeasured** — no longer truncates. The attachment is kept and rendered at the
  pass extent, which is how MRT0 is already treated when its own extent is unknown (`gw`/`gh` fall
  back to the global framebuffer, and every slot's `RttSurf` is recorded at `gw x gh`).

Because `native=0x0` occurs on none of the 17 titles measured, this is a **no-op on every one of
them** — the baseline and fixed rows above are identical where the state is not forced.

## Test

`frontends/shared/test_mrt_extent.cpp`, ctest target `mrt_extent`, mirroring `test_rtt_scale`.

It carries `legacy_extent_conflicts` — the pre-fix expression, verbatim — as an explicit
counter-arm, and several cases assert the two predicates **disagree**. A test that only asserted the
new contract could stay green against an implementation that never grew the guard.

**Demonstrated to fail without the fix**, not asserted to. Rebuilding the *unmodified* test against
a mutant header carrying the old predicate:

```
$ g++ -std=c++20 -I. -o test_mutant test_mrt_extent.cpp        # mutant mrt_extent.hpp
test_mrt_extent.cpp:93: error: static assertion failed: #2114: unknown pass extent never conflicts
test_mrt_extent.cpp:94: error: static assertion failed: unknown slot extent never conflicts
rc=1

$ grep -v static_assert test_mrt_extent.cpp > test_runtime.cpp  # isolate the runtime checks
$ g++ -std=c++20 -I. -o test_runtime test_runtime.cpp && ./test_runtime
FAIL test_runtime.cpp:59: !mrt_extent_conflicts(1920, 1080, 0, 0)
FAIL test_runtime.cpp:60: !mrt_extent_conflicts(1024, 32, 0, 0)
... 12 failing checks total ...
rc=1
```

Every positive-control case (measured disagreement still truncates; measured agreement never does)
passed in **both** arms, so the 12 failures isolate the guard rather than the predicate as a whole.

## Affected / deliberately unaffected

- Affects only how many colour attachments a pass carries when an extent is unmeasured.
- Truncation on a genuine measured mismatch is unchanged, so the sparse-export dummy-attachment
  contract (`pass_bases[slot] == 0` → not a real target → never truncates) is untouched.
- No change to extents, formats, descriptors, the recompiler, or the present path.
- `PROSPER_NO_MRT1` / `PROSPER_NO_MRT` still force `mrt_count = 1` ahead of the loop.

## Risk

Low. The behavioural change is unreachable on all 17 titles measured — and since the only
behavioural change is *inside* the truncation branch, and the `truncations` column is 0 on every one
of them, the change is a bit-exact no-op there by construction. That includes all five rung-6
snapshot-guarded titles (Messenger, Blasphemous 2, Blue Prince, Dead Cells, Alex Kidd), which are
all in the census.

Where it does apply it replaces a guaranteed silent content loss with rendering the attachment at
the pass extent — the same treatment MRT0 already receives under an unknown extent. The cost of
keeping a slot whose real surface differs is bounded on both caches:

- **CPU seed paths reject a wrong-sized entry rather than misuse it** — both the MRT0 and MRT1 seed
  lookups require `sit->second.w == gw && sit->second.h == gh` before seeding, so a mismatched entry
  simply does not seed and the pass falls back.
- **The GPU side cannot clobber a correct entry.** `find_persistent_color_target` keys the persistent
  colour-target cache on the full `{id, width, height, format}` tuple (`tests/render_runner.h`), so a
  wrong-sized keep creates a *separate* evictable entry rather than resizing or aliasing an existing
  correct-sized one. It costs one slot against the `PROSPER_BACKEND_TARGET_CACHE_COUNT` budget.

So the trade is a bounded, self-correcting, extent-keyed cache entry against unbounded silent content
loss. The prior also favours keeping: a title that binds a differently-sized target is precisely the
title that would have programmed `ATTRIB2` for it, so an unmeasured slot extent is more likely
same-size than different-size.

The new diagnostic is behind `PROSPER_RTTLOG`, and is triple-gated (`rtt_log`, `pass_bases[slot]`,
unmeasured on either side) and bounded by `kColorTargetCount = 8` — at most 7 lines per pass in the
forced case, and zero on every title measured.

## Commands and results

```bash
# build (in the ps5ys distrobox — a host build silently omits gpu_replay and the Vulkan tests)
cmake -S prosper -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
TMPDIR=$PWD/build/tmpdir cmake --build build -j6          # 0 errors
ctest --test-dir build                                     # see below

# per-pass census, one title (repeated for the 17 in the table)
PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 PROSPER_RENDER_EVERY=1 \
PROSPER_RENDER_SCALE=1 PROSPER_RTTLOG=1 ./boot_trace <DUMP_ROOT>/PPSA13579-app0 2>&1 \
  | grep -E '\[rtt\] pass target|\[rtt\] pass c|truncate MRT prefix|keep MRT c'
```

```
$ ctest --output-on-failure -j4
 66/199 Test  #69: rtt_scale ......................................   Passed    0.00 sec
 67/199 Test  #70: mrt_extent .....................................   Passed    0.00 sec
...
100% tests passed out of 199
Total Test time (real) =  53.51 sec
The following tests did not run:
	 97 - plugin_autolink (Skipped)
```

199/199 green on Linux (`plugin_autolink` skips as it does on master), built in the `ps5ys`
distrobox so `gpu_replay` and the Vulkan execution tests are actually present. The new `mrt_extent`
target is #70.

## Not folded in

`native_w == resource_hash_w` and `native_w == target_step_w` (and the `resource_hash_w == tw`
texture probe) are the same zero-sentinel family and are already owned by the open #2104. This PR
leaves all three alone; the changes do not overlap textually. A sweep of the rest of
`live_renderer.cpp` for extent equality against a zero-initialised default found no instances beyond
those three and the one fixed here, so there is nothing further to file.

One measurement here bears on #2104 and has been posted there rather than acted on: that PR's
premise is that `0x0` passes occur on live boots of The Messenger and Blasphemous 2, and this
census saw none on either over 37,913 passes on Linux. #2104's numbers are from Windows and its
fix is correct regardless of frequency, so nothing about it is blocked by this — but the two
observations should be reconciled by whoever owns it.
