### PR TITLE
docs(charter): a finding you want to be true gets checked least — trace citations in proportion to hope

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,27 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     checked.** Opening the cited file and running one `grep -rn 'getenv("…")' prosper/src` is the whole
     defence, and it is two commands. This binds on reviewers most of all — when you cite a line, you are
     asserting you read it.
+    - **The asymmetry that makes this worse: a finding you WANT to be true gets checked least.** A
+      correction that *lowers* a claim is scrutinised, because it costs the author something. A
+      correction that *raises* one is waved through, because it agrees with what the author already
+      believed — and it lands in a `## Ruled out` row wearing a citation, where nobody is motivated to
+      re-derive it. Worked example (2026-08-06): an author marked a VOP3P `NEG` semantic
+      `CONFIDENCE: MED`, a reviewer volunteered "published support you hadn't cited", and the author
+      raised it to `HIGH`. A second reviewer traced the citation: the reference says the modifier is
+      *"valid for floating-point operands only"* — a **restriction**, cutting against the inference —
+      and the LLVM fold came from a PR merged and reverted the same day, covering a different
+      instruction family. The honest label was the original one; the author had been talked *up* from it.
+    - **The multiplier is the citation itself.** A bare "I think you're being too conservative" would
+      have drawn scrutiny. A published field description plus a compiler fold read as *already checked* —
+      the same authority-transfer described above, now pointed at the thing the author hoped was true.
+      **So trace a citation in proportion to how much you want it to be true, and treat "this supports
+      raising confidence" as a trigger for verification rather than a reason to skip it.**
+    - The general shape all of these share is worth naming, because it is not "someone was wrong": it is
+      **a true statement reached by a route that does not establish it.** The claim survives casual
+      checking precisely because it is defensible; what fails is the derivation, and nobody re-runs a
+      derivation whose conclusion they already accept. Three instances landed in one day — this citation,
+      a `v_med3_f16` lowering correct only for finite inputs, and a pair of test arms asserting a property
+      their inputs could not exercise (#2130).
   - **How a verdict is expressed and detected — this is mechanical, and getting it wrong has merged a rejected
     PR.** The reviewer posts one or more **registered reviews** with `gh pr review <N> --comment --body '…'`,
     each stating a verdict as a literal **`APPROVED`** or **`REJECTED`** in the body. The author reads the


### PR DESCRIPTION
Extends the charter's existing **"a cited claim reads as a verified one"** rule with the asymmetry that made it bite three times on 2026-08-06.

## The rule

A correction that **lowers** a claim is scrutinised, because it costs the author something. A correction that **raises** one is waved through, because it agrees with what the author already believed — and it lands in a `## Ruled out` row wearing a citation, where nobody is motivated to re-derive it.

**The multiplier is the citation itself.** A bare "I think you're being too conservative" draws scrutiny. A published field description plus a compiler fold reads as *already checked* — the same authority-transfer the existing rule describes, now pointed at the thing the author hoped was true.

So: **trace a citation in proportion to how much you want it to be true**, and treat "this supports raising confidence" as a trigger for verification rather than a reason to skip it.

## The worked example

An author marked a VOP3P `NEG` semantic `CONFIDENCE: MED`. A reviewer volunteered "published support you hadn't cited". The author raised it to `HIGH`. A second reviewer traced the citation:

- The reference says the modifier is *"valid for floating-point operands only"* — a **restriction**, which cuts *against* the inference it was offered to support.
- The compiler fold came from a PR **merged and reverted the same day**, covering a different instruction family.

The honest label was the original one. The author had been talked *up* from it, and said so themselves: *"I scrutinised the review finding that said I was wrong, and took on trust the one that said I was more right than I'd claimed."*

## Why this is worth charter space

The shape all three of the day's instances share is not "someone was wrong". It is **a true statement reached by a route that does not establish it**:

- this citation;
- a `v_med3_f16` lowering that was correct for every finite input and reached by generalising from the *integer* median arm, which has no NaN clause — it shipped, and turned black into white on the one encoding the PR existed to support;
- a pair of test arms asserting a property their inputs could not exercise (#2130).

Each survived casual checking *because* the conclusion was defensible. What failed was the derivation — and nobody re-runs a derivation whose conclusion they already accept.

## Affected / unaffected

`CLAUDE.md` only, 21 insertions, **0 deletions** — appended under the existing rule rather than rewriting it. No other file, no code, no test.

## Verification

Documentation-only, so per the charter's own merge exception this does not wait on CI; the docs gate was run locally instead:

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   -> exit 0
git diff --name-only origin/master...HEAD | grep -v '\.md$'                            -> empty
git diff --check                                                                        -> clean
git merge-tree --write-tree origin/master HEAD, diffed vs master                        -> +21/-0
```

Authored from a worktree branched at `origin/master`, verified equal before editing — the charter's own stale-checkout trap has caught three people today, including while checking a gate.

Refs #2130
Refs #2066
