### PR TITLE
docs(graphics): record that a 0x0 native pass extent does not occur in practice

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -676,6 +676,24 @@ re-deriving — and read it before forming a hypothesis about a frozen, black, o
   and its resources are unaffected — which is why a capture is still the right instrument for "what
   did the guest submit" — but do not compare a capture run's *renderer* behaviour, target residency
   or publish provenance against a default run. #1968.
+- **A `0x0` native pass extent does not occur in practice — do not reach for MRT-prefix truncation to
+  explain a missing colour attachment.** The renderer truncated the prefix whenever a bound slot's
+  extent differed from MRT0's, and `native_w`/`native_h` are `0` whenever the guest's
+  `CB_COLOR0_ATTRIB2` was never seen, so any real MRT1 compared unequal against `0` and was dropped
+  with nothing logged (#2114). A per-pass census over **17 titles and ~72,900 passes** found **zero**
+  passes at `native=0x0` and **zero** truncations of any kind — while five of those titles bind 464
+  real MRT1 attachments, so the path is genuinely exercised rather than merely absent. The defect is
+  **latent, not active**: it was closed as a guard, and no title's rendering changed.
+  **Those zeros are only readable because the detector was proved able to report non-zero.** Forcing
+  `native_w`/`native_h` to 0 at the MRT decision moved the counter `0 -> 2,030` and collapsed
+  *rendered* MRT1 attachments `206 -> 0` under the old predicate, against `206` under the fix.
+  Without that arm a census reporting zero is void, not negative.
+  **Bound on the instrument, and it is the part worth inheriting:** `PROSPER_RTTLOG` is itself in the
+  `live_gpu_targets` disable list — same family as the `PROSPER_GPU_CAPTURE` entry above — so this
+  census ran the CPU-render path, not the default persistent-GPU-target route. No input to the
+  truncation decision depends on that flag, so the `native=0x0` and truncation counts stand; but the
+  forced arm never exercised the GPU-side cost of *keeping* an attachment, which is argued from the
+  extent-keyed target cache rather than measured. #2114 / #2127.
 
 ## Recommended implementation order
 


### PR DESCRIPTION
Docs-only. Records, in `GRAPHICS.md` § Ruled out, the reachability measurement behind #2127 (which
fixed #2114).

## Why this is a Ruled-out entry rather than just a merged PR body

#2127 fixed a real defect: the MRT-prefix truncation compared a bound MRT1 binding for equality
against a pass extent of `0x0`, which is the "never measured" sentinel rather than a legal extent, so
any real second colour attachment was dropped with nothing logged. The falsifiable claim attached to
it — **"a `0x0` native extent occurs in practice"** — was measured and found false, and that is
exactly the hypothesis the next reader forms the first time they meet the sentinel and wonder whether
it fires. Left only in a merged PR body it gets re-derived at full cost.

## What the entry says — three things, deliberately no more

1. **The census.** 17 titles, ~72,900 passes, zero at `native=0x0`, zero truncations of any kind —
   with five of those titles binding 464 real MRT1 attachments, so the path is genuinely exercised
   rather than merely absent. Hence *latent, not active*.
2. **The positive control**, without which the zeros are void rather than negative. Forcing the
   extent to 0 at the MRT decision moved the detector `0 -> 2,030` and collapsed *rendered* MRT1
   attachments `206 -> 0` under the old predicate, against `206` under the fix.
3. **The bound on the instrument.** `PROSPER_RTTLOG` is itself in the `live_gpu_targets` disable
   list, so the census ran the CPU-render path rather than the default persistent-GPU-target route.
   No input to the truncation decision depends on that flag, so the counts stand — but the forced arm
   never exercised the GPU-side cost of *keeping* an attachment, which is argued from the
   extent-keyed target cache rather than measured.

The third item is the one a summary drops and the one most worth having: the first two are facts
about titles, while the third is a fact about what those facts can support. It was raised by the
independent reviewer on #2127, not by me — I had run the census without checking whether my own
diagnostic took the run off the default path, which is precisely the check
`GAME_COMPAT_ORCHESTRATION.md` tells you to make.

Placed directly after the `PROSPER_GPU_CAPTURE` entry, which records the same `live_gpu_targets`
family for captures.

## Verification

```
python3 prosper/tools/docs/check_numbered_table.py --sequential \
    --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md   # rc=0
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py  # rc=0
```

`GRAPHICS.md` § Ruled out is a bullet list, not a table, so the arity gate has nothing to check here
and no `\|` escaping is required; the gate reports `0 table(s)` for the file and passes.

- `git diff --name-only origin/master HEAD` is `prosper/docs/GRAPHICS.md` alone — `.md`-only.
- Trap-41 deletion audit: the diff contains **no** `-` lines; it is a pure addition. (The first run
  did show deletions in `CLAUDE.md` — master had gained #2133 while this was being written. Rebased
  onto `b448e581` and re-checked, which is what that gate is for.)
- `git diff --check` clean; no `Claude-Session:` trailer.

Merging without waiting for CI per the charter's documentation-only exception: the diff touches
nothing but `.md`, so there is no build, test or snapshot CI could report on. The content is the
measurement from #2127, which an independent reviewer already checked — including the instrument
bound in item 3, which was their finding.
