### PR TITLE
fix(recompiler): v_med3_f16 must take the ISA any-NaN MIN3 fallback (#2013)

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8256,18 +8256,35 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (in.opcode == 0x34B) {                            // v_fma_f16
                     result = b.fbin(Op_FAdd, b.fbin(Op_FMul, f16src(0), f16src(1)), f16src(2));
                 } else if (in.opcode == 0x351) {                     // v_min3_f16
+                    // ISA op 849 is a plain nested min — `V_MIN_F16(V_MIN_F16(S0,S1),S2)` — with
+                    // NO any-NaN clause of the kind op 855 v_med3_f16 carries. NMin already
+                    // matches V_MIN_F16's own one-NaN rule (return the other operand), so the
+                    // bare chain is the whole contract. CONFIDENCE: HIGH.
                     result = b.fext2(Glsl_NMin,
                                      b.fext2(Glsl_NMin, f16src(0), f16src(1)), f16src(2));
                 } else if (in.opcode == 0x354) {                     // v_max3_f16
+                    // ISA op 852, likewise: `V_MAX_F16(V_MAX_F16(S0,S1),S2)`, no NaN clause.
                     result = b.fext2(Glsl_NMax,
                                      b.fext2(Glsl_NMax, f16src(0), f16src(1)), f16src(2));
                 } else {                                             // v_med3_f16
-                    // Median of three, the same formula the f32 form uses: NaN-aware min/max so a
-                    // single NaN input yields the other operand rather than propagating.
+                    // ISA op 855 opens with a SEPARATE any-NaN clause, exactly as op 343
+                    // v_med3_f32 does (see 0x157 below — same structure, only the width differs):
+                    //   if (isNan(S0) || isNan(S1) || isNan(S2)) D.f16 = V_MIN3_F16(S0,S1,S2)
+                    // The plain max(min(...)) median formula does NOT reproduce that fallback on
+                    // its own, so the clause is emitted explicitly. It is not academic: Sonic
+                    // Racing: CrossWorlds' NaN-safe saturate idiom `v_med3_f16 v3, 1.0, v5, 0`
+                    // (#2013) with S1 = NaN must yield MIN3(1.0,NaN,0) = 0.0h, where the bare
+                    // formula yields 1.0h — black rendered as white. Kernel 32r10n pins it.
+                    // The min/max legs use NaN-aware NMin/NMax because V_MIN_F16/V_MAX_F16 return
+                    // the OTHER operand when exactly one input is NaN. CONFIDENCE: HIGH.
                     const uint32_t x = f16src(0), y = f16src(1), z = f16src(2);
-                    auto mn = [&](uint32_t p, uint32_t q) { return b.fext2(Glsl_NMin, p, q); };
-                    auto mx = [&](uint32_t p, uint32_t q) { return b.fext2(Glsl_NMax, p, q); };
-                    result = mx(mn(x, y), mx(mn(x, z), mn(y, z)));
+                    const uint32_t mn = b.fext2(Glsl_NMin, x, y), mx = b.fext2(Glsl_NMax, x, y);
+                    const uint32_t med = b.fext2(Glsl_NMax, mn, b.fext2(Glsl_NMin, mx, z));
+                    const uint32_t min3 = b.fext2(Glsl_NMin, mn, z);
+                    const uint32_t nan_any = b.lor(b.fcmp(Op_FUnordNotEqual, x, x),
+                                                   b.lor(b.fcmp(Op_FUnordNotEqual, y, y),
+                                                         b.fcmp(Op_FUnordNotEqual, z, z)));
+                    result = b.sel(nan_any, min3, med);
                 }
                 result = fresult(result);
                 uint32_t r16 = b.pack_half_lo(result);

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3023,6 +3023,38 @@ int main() {
     CHECK(got32r10.size()==1 && bits_of(got32r10[0])==0x33337c00u,
           "kernel 32r10 takes the median and the minimum of three f16 sources");
 
+    // Kernel 32r10n (#2013): the DISCRIMINATING NaN case for `v_med3_f16`, on the exact live
+    // encoding that motivated the opcode — Sonic Racing: CrossWorlds' NaN-safe saturate idiom
+    //   d7571003,02020af2 = v_med3_f16 v3, 1.0, v5, 0 op_sel:[0,1,0,0]
+    // with v5's HIGH half (the half OPSEL[1]=1 selects) set to the f16 quiet NaN 0x7e00.
+    // RDNA2 ISA op 855 opens with a SEPARATE any-NaN clause:
+    //   if (isNan(S0) || isNan(S1) || isNan(S2)) D.f16 = V_MIN3_F16(S0,S1,S2)
+    // so hardware returns MIN3(1.0h, NaN, 0.0h) = 0.0h. The bare max(min(...)) median formula
+    // returns 1.0h instead — a saturate that yields white where hardware yields black. Three
+    // outcomes are distinguishable, so the kernel cannot pass by not running:
+    //   0x11110000 = correct (0.0h)   0x11113c00 = the bare-formula bug (1.0h)
+    //   0x11112222 = the instruction never executed (seed untouched)
+    // OPSEL[3]=0 writes the LOW half, so the 0x1111 marker must survive in the high half.
+    // The kernel also discriminates HOW the NaN is detected, not merely that it is: 0x7e000000
+    // is a NaN only when its HIGH HALF is read as f16 — as a full dword it is a finite f32
+    // (exponent 0xfc). So a lowering that copies the f32 arm's whole-dword fv() compares instead
+    // of the unpacked f16src() halves sees no NaN, skips the clause and returns 0x11113c00.
+    // Verified by mutation: swapping the compares to the packed dword turns this kernel red.
+    const uint32_t code32r10n[] = {
+        0x7e0602ffu, 0x11112222u,            // v3 = seed {hi=0x1111 marker, lo=0x2222 sentinel}
+        0x7e0a02ffu, 0x7e000000u,            // v5 = {hi=NaNh (0x7e00), lo=0}
+        0xd7571003u, 0x02020af2u,            // v_med3_f16 v3, 1.0, v5.hi, 0  -> v3.lo (LIVE words)
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv32r10n = recompile_valu(code32r10n, std::size(code32r10n), 0, 3);
+    CHECK(!spv32r10n.empty(), "recompiled kernel 32r10n (live v_med3_f16 NaN saturate) -> SPIR-V");
+    std::vector<float> got32r10n = prosper::test::run_compute(spv32r10n, std::vector<float>(1), 1, 1);
+    printf("  kernel 32r10n out=0x%08x (want 0x11110000; 0x11113c00 = bare-formula bug, "
+           "0x11112222 = did not execute)\n",
+           got32r10n.size()==1 ? bits_of(got32r10n[0]) : 0u);
+    CHECK(got32r10n.size()==1 && bits_of(got32r10n[0])==0x11110000u,
+          "kernel 32r10n: v_med3_f16(1.0, NaN, 0) takes the ISA any-NaN MIN3 path -> 0.0h, not 1.0h");
+
     // Kernel 32r11: the packed f16 siblings of the add/mul pair the recompiler already had —
     // v_pk_fma_f16 (three sources), v_pk_min_f16 and v_pk_max_f16.
     const uint32_t code32r11[] = {


### PR DESCRIPTION
## The defect

`v_med3_f16` (VOP3 `0x357`) on current `master` lowers the median as the bare formula

```cpp
result = mx(mn(x, y), mx(mn(x, z), mn(y, z)));   // plain NMin/NMax
```

under a comment claiming this is *"the same formula the f32 form uses"*. That claim is false in
both directions: the `v_med3_f32` arm (`0x157`, same file) emits an explicit any-NaN → `MIN3`
select, and **its** comment says in as many words that the plain `max(min(...))` formula does not
reproduce the documented NaN fallback on its own.

The RDNA 2 ISA reference (document 70648) defines opcode 855 = `0x357` with the NaN clause first:

```
855   V_MED3_F16   Return median FP16 value of three inputs.

          if (isNan(S0.f16) || isNan(S1.f16) || isNan(S2.f16))
             D.f16 = V_MIN3_F16(S0.f16, S1.f16, S2.f16);
          else if (V_MAX3_F16(S0.f16, S1.f16, S2.f16) == S0.f16)
             D.f16 = V_MAX_F16(S1.f16, S2.f16);
          ...
```

which is structurally identical to opcode 343 = `0x157` `V_MED3_F32`.

## Failure scenario

The live encoding that motivated adding this opcode in #2115 is *Sonic Racing: CrossWorlds*'
NaN-safe saturate idiom (#2013), confirmed by `llvm-mc -mcpu=gfx1030` round trip:

```
d7571003,02020af2  =  v_med3_f16 v3, 1.0, v5, 0 op_sel:[0,1,0,0]
```

With the OPSEL-selected half of `v5` = NaN, operand triple `(1.0h, NaN, 0.0h)`:

| | result |
| --- | --- |
| **Hardware** — any-NaN clause → `MIN3(1.0, NaN, 0)` | **0.0h** |
| **`master` as merged** — `NMin(1.0,NaN)=1.0`, `NMin(1.0,0)=0`, `NMin(NaN,0)=0`, `NMax(0,0)=0`, `NMax(1.0,0)` | **1.0h** |

Black is emitted as white, on that exact instruction in that exact shader of the exact title the
opcode was added to support. This is also the only *previously rejected loudly → now silently
wrong* case in #2115: before that PR the instruction rejected and the draw was dropped visibly.

## The fix

Mirrors the `v_med3_f32` arm — same helpers, same structure, only the width differs. The f16
scalar path already computes in f32 internally (`f16src()` unpacks the OPSEL half to f32,
`pack_half_lo()` narrows the result), so the two arms are now literally the same lowering.

Two hazards were deliberately avoided rather than inherited from a verbatim copy, and both are
**mechanically checked**, not asserted:

1. **The NaN compares read `f16src(k)`, not `fv(k)`.** `fv()` reads the operand as a full dword
   f32; the f16 arm's operand is a packed half. `grep -o 'fv('` inside the arm returns 0.
2. **The three sources are bound once.** `f16src()` emits SPIR-V on every call, so `med`, `min3`
   and all three compares are built from the same three ids. `grep -o 'f16src('` inside the arm
   returns exactly 3, all on one binding line.

## Test — kernel `32r10n`

Replays the live word pair with `v5`'s high half set to the f16 quiet NaN `0x7e00`. Three
outcomes are distinguishable, so the kernel **cannot pass by not running**:

| output | meaning |
| --- | --- |
| `0x11110000` | correct — `0.0h` written to the low half, `0x1111` marker preserved in the high half |
| `0x11113c00` | the bare-formula bug — `1.0h` |
| `0x11112222` | the instruction never executed — untouched seed |

### Demonstrated red before green (not asserted — run)

With the test added and **the fix not applied**, on real Vulkan execution:

```
kernel 32r10n out=0x11113c00 (want 0x11110000; 0x11113c00 = bare-formula bug, 0x11112222 = did not execute)
[FAIL] kernel 32r10n: v_med3_f16(1.0, NaN, 0) takes the ISA any-NaN MIN3 path -> 0.0h, not 1.0h
== FAIL: 1 ==            (exit 1, the only failure in the binary)
```

The observed value is exactly the *predicted* wrong value, not the did-not-run sentinel. With the
fix:

```
kernel 32r10n out=0x11110000 (want 0x11110000; ...)
[ok]   kernel 32r10n: v_med3_f16(1.0, NaN, 0) takes the ISA any-NaN MIN3 path -> 0.0h, not 1.0h
== PASS ==
```

The pre-existing all-finite kernel `32r10` still passes, so the non-NaN median is unchanged.

### Second mutation arm — the test discriminates *how* the NaN is detected

`0x7e000000` is a NaN only when its **high half** is read as f16; as a full dword it is a *finite*
f32 (exponent `0xfc`). So a lowering that used whole-dword `fv()` compares would see no NaN, skip
the clause, and return the bare median. Verified by mutating the compares to the packed dword and
rebuilding: kernel `32r10n` goes red at `0x11113c00`. The mutation was then reverted and the source
file confirmed byte-identical to the committed version. This is why the test cannot pass while the
fix is subtly wrong.

## Siblings checked — correct as written, no change needed

Verified against the same ISA section, since they sit directly above and use bare `NMin`/`NMax`
chains:

- **`v_min3_f16`** (op 849 = `0x351`): `D.f16 = V_MIN_F16(V_MIN_F16(S0,S1),S2)`
- **`v_max3_f16`** (op 852 = `0x354`): `D.f16 = V_MAX_F16(V_MAX_F16(S0,S1),S2)`

Neither has a NaN clause of any kind — the fallback is unique to `med3`. And `V_MIN_F16`/
`V_MAX_F16` specify `else if (S0 == NaN) D = S1; else if (S1 == NaN) D = S0;` — return the other
operand — which is exactly GLSL `NMin`/`NMax`. So the bare chains already implement the full
contract. **Useful negative result: no defect here.** Both now carry a comment saying so, so the
next reader does not re-derive it.

## The durable lesson

There are two median implementations 13 lines apart: `v_med3_u32` is the plain `max(min(...))`
formula, `v_med3_f32` is that formula **plus** the any-NaN fallback. Generalising from the
*integer* one produces code that looks right and a comment that is confidently wrong.

> **When adding an f16 or packed variant of an existing f32 op, diff against the f32 arm and read
> its comments for rules the integer form cannot have.**

## Scope

Only this one arm. #2115 is **not** reverted — the rest of it was independently verified (every
opcode re-derived with `llvm-mc`, four mutation arms reproduced, NEG_LO/NEG_HI corroborated), and
`v_med3_f16` is the only op in that diff whose f32 counterpart carries an extra rule.

Out of scope, noted not filed: GLSL `NMin`/`NMax` do not specify signed-zero ordering, where
`V_MIN_F16`/`V_MAX_F16` do (`min(-0,+0) = -0`). That is a pre-existing, project-wide lowering
convention shared by every f32 and f16 min/max in the file, not something this diff or #2115
introduced.

## Verification

Built and tested in the `ps5ys` distrobox (a host build silently omits every Vulkan execution
test), at exact head.

```
cmake --build build -j6
ctest -j4        ->  100% tests passed, 198/198 (1 skipped: plugin_autolink)
```

`rdna2_to_spirv_exec` (test 179), which contains kernel `32r10n`, passes.

Gates: session-trailer count 0; `git diff --check` clean; trap 41 checked with
`git merge-tree --write-tree origin/master HEAD` after rebasing onto current master — the only 5
deleted lines are the old med3 comment and body.

Refs #2013
