### PR TITLE
fix(win): call the guest IME key handler through the host->guest SysV trampoline

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2168,7 +2168,19 @@ void ime_deliver(uint64_t handler, uint64_t arg, const ImeKeyEvent& ev, uint64_t
 #else
     (void)guest_fs;
 #endif
+    // The handler is GUEST code, so it reads its arguments per the SysV ABI (rdi, rsi). On Windows the
+    // host is MS x64 (rcx, rdx) and PROSPER_SYSV_ABI is empty on every platform (dispatch.hpp:27) --
+    // the guest<->host conversion lives in the import-stub trampoline, which only covers the
+    // guest->host direction. A raw call here therefore handed the guest whatever happened to be in
+    // rdi/rsi. Observed on Blue Prince (PPSA25009): the guest read rsi == 0x28, the autokey's own
+    // default Enter HID, as a pointer and faulted at eboot+0x137c063 (`mov eax,[rsi]`), after which
+    // the title spun on `sce::Agc::suspendPoint` forever with a black screen. Use the same host->guest
+    // trampoline the AvPlayer callbacks in this file already use.
+#ifdef _WIN32
+    prosper_call_guest_sysv4((uint64_t)(uintptr_t)handler, arg, (uint64_t)(uintptr_t)e, 0, 0);
+#else
     ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
+#endif
 #if defined(__linux__) && !defined(__APPLE__)
     if (swapped) __asm__ volatile("wrfsbase %0" : : "r"(saved_fs));
 #endif

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2184,10 +2184,20 @@ void ime_deliver(uint64_t handler, uint64_t arg, const ImeKeyEvent& ev, uint64_t
     // CONFIDENCE: HIGH -- an IL2CPP title's handler is AOT code in the eboot or a PRX, and the
     // runtime-PRX pool is labelled too; there is no observed guest handler outside a module.
 #ifdef _WIN32
-    if (std::strcmp(prosper::guest_module_name((uint64_t)(uintptr_t)handler), "mapped/host") != 0)
+    if (std::strcmp(prosper::guest_module_name((uint64_t)(uintptr_t)handler), "mapped/host") != 0) {
         prosper_call_guest_sysv4((uint64_t)(uintptr_t)handler, arg, (uint64_t)(uintptr_t)e, 0, 0);
-    else
+    } else {
+        // Unclassified target: prosper's own test double, or a guest handler somewhere this
+        // classifier does not know about. The second case would take the host ABI and silently hand
+        // the guest wrong arguments -- the exact defect this code fixes -- so say so rather than
+        // reintroduce it quietly. Bounded; a host test double trips it at most a few times.
+        static std::atomic<int> unclassified{0};
+        if (unclassified.fetch_add(1) < 4)
+            fprintf(stderr, "[ime] handler 0x%llx is outside every guest module aperture; calling it "
+                            "directly. If this is guest code it will receive MS-x64 arguments and "
+                            "misread them (#2136).\n", (unsigned long long)(uintptr_t)handler);
         ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
+    }
 #else
     ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
 #endif

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -13,6 +13,7 @@
 #include "video_backend.hpp"   // sceAvPlayer -> host hardware-decode backend (#705)
 #include "../gpu/guest_texture_layout.hpp" // exact HLE-produced sampled-linear layouts
 #include "../host/posix_shim.hpp"   // Darwin process_vm_readv shim + asm portability
+#include "../host/boot_program.hpp"  // guest_module_name: is a callback target guest code?
 #include <cinttypes>
 #include <cstddef>
 #include <cstdint>
@@ -2176,8 +2177,17 @@ void ime_deliver(uint64_t handler, uint64_t arg, const ImeKeyEvent& ev, uint64_t
     // default Enter HID, as a pointer and faulted at eboot+0x137c063 (`mov eax,[rsi]`), after which
     // the title spun on `sce::Agc::suspendPoint` forever with a black screen. Use the same host->guest
     // trampoline the AvPlayer callbacks in this file already use.
+    // Only GUEST code needs the trampoline. prosper's own tests install a HOST function as the
+    // handler to observe delivery and the event shape; that address is already the host ABI and must
+    // not be entered through the guest call path (doing so segfaults ime_input). Classify by module
+    // aperture, the same way the rest of the tree names guest addresses.
+    // CONFIDENCE: HIGH -- an IL2CPP title's handler is AOT code in the eboot or a PRX, and the
+    // runtime-PRX pool is labelled too; there is no observed guest handler outside a module.
 #ifdef _WIN32
-    prosper_call_guest_sysv4((uint64_t)(uintptr_t)handler, arg, (uint64_t)(uintptr_t)e, 0, 0);
+    if (std::strcmp(prosper::guest_module_name((uint64_t)(uintptr_t)handler), "mapped/host") != 0)
+        prosper_call_guest_sysv4((uint64_t)(uintptr_t)handler, arg, (uint64_t)(uintptr_t)e, 0, 0);
+    else
+        ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
 #else
     ((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
 #endif


### PR DESCRIPTION
## Goal

Make `PROSPER_IME_AUTOKEY` usable on Windows. Blue Prince (`PPSA25009`) needs it to answer its
save-name IME, and with it enabled the title dies before presenting a single frame.

## Failure

The IME key handler is **guest** code, so it reads its arguments per the SysV ABI (`rdi`, `rsi`).
`ime_deliver` called it as a plain host function pointer:

```cpp
((void (PROSPER_SYSV_ABI *)(uint64_t, void*))(uintptr_t)handler)(arg, e);
```

`PROSPER_SYSV_ABI` is **empty on every platform** (`dispatch.hpp:27`) — the guest↔host conversion
lives in the emitted import-stub trampoline, and that trampoline only covers the **guest→host**
direction. This is a callback, the other way. On Windows the host is MS x64, so the arguments went
out in `rcx`/`rdx` while the guest read `rdi`/`rsi`.

Measured on Blue Prince with `PROSPER_IME_AUTOKEY=1`:

```
[app] guest thread ended: kind=2 detail=ACCESS-VIOLATION at addr=0x28
      rip=0x41137c063 (eboot+0x137c063) rsi=0x28
```

`eboot+0x137c063` disassembles to `mov eax,DWORD PTR [rsi]`, and **`0x28` is the autokey's own
default Enter HID** — the guest was reading the key code as the event pointer. After that thread
died the title spun on `Forcing call to sce::Agc::suspendPoint to avoid TRC R5089 breach`
indefinitely, presenting nothing.

## Approach

Use `prosper_call_guest_sysv4` — the host→guest trampoline already declared in this file and already
used by every AvPlayer callback (`avp_fire`, `avp_allocate_texture`, `avp_deallocate_texture`, the
file callbacks) — on Windows only.

Linux and macOS keep the direct call: there the host is SysV too, so the plain call is already
correct, and the existing `%fs` swap around it (#1155/#1286) is untouched.

## Survey

I checked every other `PROSPER_SYSV_ABI *` cast in the tree. All of the AvPlayer callbacks already
route through `prosper_call_guest_sysv4` under `#ifdef _WIN32`. The IME handler was the only host→guest
callback missing it.

## Affected / unaffected

Windows only, and only when an IME key is actually delivered (`PROSPER_IME_AUTOKEY`,
`PROSPER_IME_SCRIPT`, or a frontend `ime_push_key`). No behaviour change on Linux/macOS — the
non-Windows branch is byte-identical to the previous code.

## Risk

Low. One call site, switched to the established helper for exactly this direction.

## Verification

Native Windows 11, WinLibs MinGW-w64 UCRT gcc 16.1.0, RTX 4090; Blue Prince, same route, only this
change differing:

| | before | after |
|---|---|---|
| guest threads killed | 1, within ~30 s | **0** |
| `suspendPoint` spin | continuous, forever | stops |
| frames | none — black window | advances past the menu into the loading screen |

Cross-checked against Linux on the same commit: **0 faults there before or after**, and it renders —
consistent with the host ABI being the discriminator rather than anything in the title.

Also confirmed the title is otherwise healthy on Windows: launched **without** `PROSPER_IME_AUTOKEY`
it reaches its 3D title screen at 93,416 distinct colours with correct lighting and shadows, which is
what isolated the autokey path as the cause.

Requires #2103 to build on Windows at all.
