### PR TITLE
docs(sonic): recover the cross-title table's methodology, lost to a merge race

### DIFF
--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -1119,7 +1119,15 @@ none appeared.
 | *Little Nightmares III* `PPSA05143` | `0x280467f` | — | `mov [rip+0x60a3856],eax` (`0x88a7ee0`) | retained in a global |
 
 **All seven titles retain the value; not one discards it and not one uses `jne`/`je`**, so no title in
-the local inventory is regressed by returning an id instead of 0. `sceSaveDataMount3` still ignores
+the local inventory is regressed by returning an id instead of 0. Every row above was
+re-derived independently of the review that supplied the corrections: five at runtime by breaking on
+prosper's own handler and scanning between `rsp` and `rbp` for a return address whose preceding five
+bytes are an `e8` **whose target is an `ff 25` PLT thunk** (all three conditions must hold, so a
+merely-plausible return address is rejected), and the two with no runtime call statically by the same
+three checks. The thunk is then resolved to its import through `DT_JMPREL` -> symbol -> `DT_STRTAB`,
+which is what proves it is *this* NID's thunk rather than *a* thunk: Sonic's `0xc49710` resolves to
+`gjRZNnw0JPE` while the adjacent `0xc49730` resolves to `ZP4e7rlzOUk` (Mount3), so the resolver
+discriminates. `sceSaveDataMount3` still ignores
 the descriptor's `+0x28`, so no mount behaviour changes either.
 
 **A second title was silently failing on the old return, and it is not the one anyone was looking


### PR DESCRIPTION
Recovers eight lines that a merge race dropped.

## What happened

#2121 merged at `aea263a2` while its lane was force-pushing `f073c2f1`. I verified the damage rather than assuming it: the code, the tests, the `COMPATIBILITY.md` entry and both trap rows (113 and 114) are **byte-identical** between the merged head and the pushed one. Nothing functional was lost.

What did not survive is the paragraph describing **how** the corrected cross-title table was derived.

## Why those eight lines matter

The original table was wrong in four of five rows, because an rbp-chain backtrace resolves to the **caller's caller** whenever the call goes through a local wrapper. That error is what put *Tactics Ogre* down as "discards the return value" when it actually carries Sonic's exact `test eax,eax; jle` — a second title whose save path is silently failing (#2125).

The replacement table was produced by an instrument that validates its own answer: scan between `rsp` and `rbp` for a return address whose preceding five bytes are an `e8` **whose target is an `ff 25` PLT thunk** — all three conditions, so a merely-plausible return address is rejected — then resolve that thunk to its import through `DT_JMPREL` → symbol → `DT_STRTAB`.

And it carries the **positive control**, which is the half a summary always drops: Sonic's `0xc49710` resolves to `gjRZNnw0JPE` while the adjacent `0xc49730` resolves to `ZP4e7rlzOUk` (Mount3). So the resolver *discriminates* rather than answering the same thing everywhere. Without that arm the seven confirmed rows are an assertion; with it they are a measurement.

A future lane reusing the technique needs the three conditions and the control. A future lane doubting the table needs to know it can be re-derived. Neither is served by the conclusion alone.

## Approach

Recovered **verbatim** from `f073c2f1` rather than re-written, so the record says what the lane established rather than what I understood it to establish.

Checked for duplication: `gjRZNnw0JPE` appears twice in the result — once at line 1058 in a pre-existing disassembly listing, once in the recovered prose — matching the stranded head exactly. Master had one; this restores the second.

## Verification

Documentation-only, so per the charter it does not wait on CI; the docs gate ran locally instead.

```
check_numbered_table.py --github GRIS_SONIC_COBRA_BRINGUP.md
  -> 8 table(s), 73 rows, unbroken, every row matching its header
git ls-files '*.md' -z | xargs -0 check_numbered_table.py   -> exit 0
git diff --name-only origin/master...HEAD | grep -v '\.md$'  -> empty
git diff --check                                             -> clean
merge-tree vs master                                         -> 1 file, +9/-1
```

Refs #2121
Refs #1905
