### PR TITLE
gpu: a "no recorded GPU writer" answer must say whether anything was recording (#2132)

### DIFF
--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -357,6 +357,28 @@ One line per falsified hypothesis, with the evidence that killed it.
   The live `[recompile-reject]` from a real boot is the only instrument that names the actual failing
   instruction in a graphics stage. It is still exact for **compute**, which passes `allow_smem=true`.
   (This lane, 2026-08-06.)
+- **No GPU-side writer that prosper executes ever fills the vertex stage's null constant-buffer
+  pointer.** The remaining two dropped pipelines fail because a constant-buffer dword holding a
+  bindless-table pointer reads zero (#2132). Queried against the shared guest-write history at the
+  failing stage's own replay: `no recorded GPU writer overlaps [0x…470,+0x40) (history=8589 recorded:
+  color=39 compute-buffer=4744 dma-data=8127 write-data=1111)` — 8,589 retained writes, all four
+  recorders demonstrably firing, none overlapping that window. Measured on a
+  `PROSPER_WRITER_PROVENANCE=1` arm, which matters: that switch selects **unfiltered** retention, and
+  without it DmaData/WriteData discard writes below 256 bytes / 64 dwords — exactly the size that
+  could hide a write to a 64-byte window. The negative carries its own positive
+  control (#2143 made it do so; before that the same query printed 183 bare negatives while the
+  colour recorder had never been armed, and the result was VOID rather than negative). **Two
+  populations remain unexamined and are NOT ruled out**: a *skipped* compute dispatch records nothing
+  by construction — this title skips 8 per boot, and that is the leading hypothesis — and guest CPU
+  writes are recorded by no writer kind at all. (This lane, 2026-08-06.)
+- **The zero is not run-to-run nondeterminism.** The pointer field reads zero in **five** independent
+  boots while its containing allocation base moves every time (`0x4148dca410` / `0x4137f4a410` /
+  `0x400e6ba410` / `0x413080a410` / `0x413111a410`), with the same offsets and the same neighbouring
+  `0x3f800000` each time. **This does not rule out an ordering defect** — only a nondeterministic
+  one. A *deterministic* mis-ordering (realizing the stage table before a producer that precedes it
+  in `command_order`) reads zero on every boot with a moving base too, and is entirely consistent
+  with all five. Read this row as "stop looking for a flaky race", not as "ordering is cleared".
+  (This lane, 2026-08-06.)
 - **The dropped draws were NOT four instances of one descriptor problem — they are two populations
   with unrelated causes, and neither is "the descriptor cannot be resolved".** A
   `PROSPER_DYNTRACE_FAIL=1` arm replays each failed stage's resource build with the scalar const-fold

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2521,9 +2521,34 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                 (unsigned long long)writer->order,
                                 (unsigned long long)writer->identity);
                     } else {
+                        // Quote the history's own state with every negative, because a negative can
+                        // mean "nothing wrote this" OR "the recorder that would have caught it was
+                        // never armed", and the two are otherwise identical in the log. All four
+                        // recorders now follow writer_provenance_enabled() — colour targets did not
+                        // until this diagnostic's own change (they were gated on the unrelated
+                        // PROSPER_PROVENANCE_DIM, which is what made a negative unreadable and is
+                        // why the counts are printed at all).
+                        //
+                        // Three limits the counts do NOT remove, all load-bearing:
+                        //   * a SKIPPED dispatch records nothing however this is configured, so a
+                        //     negative never rules out a skipped compute program;
+                        //   * a guest CPU write is recorded by no kind at all, so this history only
+                        //     ever describes GPU-side writers;
+                        //   * a kind can read non-zero here while still having DISCARDED the write
+                        //     that matters. Without PROSPER_WRITER_PROVENANCE (i.e. when only a
+                        //     dimension probe armed the history) DmaData keeps writes >= 256 bytes
+                        //     and WriteData >= 64 dwords, and the compute recorders skip any
+                        //     host-data buffer. A small write to a narrow window is then missing
+                        //     from a history whose summary looks healthy — set
+                        //     PROSPER_WRITER_PROVENANCE for unfiltered retention before trusting a
+                        //     negative over a span of a few dwords.
                         fprintf(stderr,
-                                "[dyntrace]   no recorded GPU writer overlaps [0x%llx,+0x%x)\n",
-                                (unsigned long long)addr, n * 4);
+                                "[dyntrace]   no recorded GPU writer overlaps [0x%llx,+0x%x) "
+                                "(history=%zu recorded: %s)%s\n",
+                                (unsigned long long)addr, n * 4,
+                                guest_write_history_size(), guest_write_recorder_summary(),
+                                guest_write_history_size() ? ""
+                                    : "  <- HISTORY EMPTY: this is VOID, not negative");
                     }
                 }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
@@ -5172,18 +5197,34 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
 }
 
 void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
+    // This function does two separable jobs: it RECORDS colour-target writes into the shared
+    // guest-write history, and it PRINTS a consumer/producer diagnostic for one target extent. Only
+    // the second needs PROSPER_PROVENANCE_DIM. Returning early for both made the history silently
+    // kind-incomplete under PROSPER_WRITER_PROVENANCE=1 — the switch documented as the explicit
+    // "retain everything" request — so every `last_guest_write_overlap` consumer answered "no
+    // writer" for a range a colour target had in fact written, with nothing in the log to say the
+    // recorder had never been armed. Measured on CrossWorlds: `color=0` recorded across a whole boot
+    // with writer provenance explicitly on, against `compute-buffer=54` and `write-data=7`.
     const char* dim_env = getenv("PROSPER_PROVENANCE_DIM");
-    if (!dim_env || !*dim_env) return;
-
     uint32_t want_w = 0, want_h = 0;
-    if (sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2 || !want_w || !want_h) {
+    bool record_only = !dim_env || !*dim_env;
+    if (!record_only && (sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2 || !want_w || !want_h)) {
         static bool warned = false;
         if (!warned) {
             warned = true;
-            fprintf(stderr, "[provenance] invalid PROSPER_PROVENANCE_DIM='%s' (expected WxH)\n", dim_env);
+            fprintf(stderr, "[provenance] invalid PROSPER_PROVENANCE_DIM='%s' (expected WxH)"
+                            " — recording colour targets anyway\n", dim_env);
         }
-        return;
+        // Fall back to RECORD-ONLY instead of returning. A malformed value must not disarm the
+        // colour recorder, because the address watch's banner states unconditionally that colour is
+        // armed — and a banner that denies a void zero is worse than the void zero it replaced.
+        // The reachable spelling is `PROSPER_PROVENANCE_DIM=1`: every other switch in this project
+        // is a boolean `=1`, this one is `WxH`, `sscanf` returns 1, and before this the function
+        // returned before recording anything. See #2149 for the general shape.
+        record_only = true;
+        want_w = want_h = 0;
     }
+    if (record_only && !writer_provenance_enabled()) return;
     const size_t min_draws = [] {
         const char* e = getenv("PROSPER_PROVENANCE_MIN_DRAWS");
         return e ? static_cast<size_t>(strtoull(e, nullptr, 0)) : size_t{0};
@@ -5202,7 +5243,9 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
     static uint64_t draw_submit_ordinal = 0;
     const uint64_t this_draw_submit = st.draws.empty() ? draw_submit_ordinal : draw_submit_ordinal++;
 
-    const bool inspect_consumers = st.draws.size() >= min_draws;
+    // Record-only mode still walks every draw to capture its colour targets; it just does not
+    // inspect consumers, which is the half that needs a target extent to select on.
+    const bool inspect_consumers = !record_only && st.draws.size() >= min_draws;
     for (size_t i = 0; i < st.draws.size(); ++i) {
         const GpuState& ds = st.draws[i].state ? *st.draws[i].state : st;
         const RenderState rs = extract_render_state(ds);
@@ -5279,10 +5322,15 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
         }
 
         if (rs.color0_base) {
-            last_color_write[rs.color0_base] = {
-                submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
-                rs.color0_width, rs.color0_height, st.draws[i]
-            };
+            // Only the consumer diagnostic reads last_color_write, and its value retains a draw
+            // record (which pins a GpuState) for the process lifetime, one per distinct colour base.
+            // Record-only mode has no reader, so populating it there would leak that retention onto
+            // every writer-provenance run for nothing.
+            if (!record_only)
+                last_color_write[rs.color0_base] = {
+                    submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
+                    rs.color0_width, rs.color0_height, st.draws[i]
+                };
             // The exact-address map above retains every latest color writer. The generic overlap
             // history needs only one representative event per target range; recording every draw
             // adds millions of mutex/hash operations during Dead Cells' submit-heavy startup.
@@ -5294,10 +5342,11 @@ void diagnose_resource_provenance(const GpuState& st, uint64_t submit_no) {
             }
         }
         if (rs.color1_base) {
-            last_color_write[rs.color1_base] = {
-                submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
-                rs.color1_width, rs.color1_height, st.draws[i]
-            };
+            if (!record_only)
+                last_color_write[rs.color1_base] = {
+                    submit_no, this_draw_submit, i, rs.es_addr, rs.ps_addr,
+                    rs.color1_width, rs.color1_height, st.draws[i]
+                };
             if (recorded_color_ranges.insert(rs.color1_base).second) {
                 const uint64_t bytes = static_cast<uint64_t>(rs.color1_width) * rs.color1_height * 4;
                 record_guest_write(GuestWriterKind::ColorTarget, rs.color1_base, bytes,

--- a/prosper/src/gpu/writer_provenance.cpp
+++ b/prosper/src/gpu/writer_provenance.cpp
@@ -1,5 +1,6 @@
 #include "writer_provenance.hpp"
 
+#include <array>
 #include <atomic>
 #include <cstring>
 #include <cstdio>
@@ -12,6 +13,14 @@ namespace prosper::gpu {
 namespace {
 
 constexpr size_t kMaxEvents = 65536;
+// Cumulative per-kind recorded counts. Deliberately NOT evicted with the bounded event map: their
+// only job is to answer "did this recorder ever fire", which a negative overlap result has to quote
+// to be falsifiable at all.
+constexpr size_t kGuestWriterKindCount = static_cast<size_t>(GuestWriterKind::Count);
+static_assert(kGuestWriterKindCount == 4,
+              "a new GuestWriterKind needs a name in guest_writer_kind_name() before it can appear "
+              "in the recorder summary; update this bound deliberately rather than by accident");
+std::array<std::atomic<uint64_t>, kGuestWriterKindCount> g_recorded_by_kind{};
 std::mutex g_mutex;
 struct EventKey {
     GuestWriterKind kind;
@@ -60,7 +69,30 @@ const ProvenanceAddrWatch& provenance_addr_watch() {
             if (size) w.size = size;
         }
         w.active = true;
-        std::fprintf(stderr, "[provenance] watching guest range 0x%llx..0x%llx\n",
+        // Name the armed recorders in the banner (#2111). A watch that prints `compute-buffer` lines
+        // looks healthy while an entire writer class is unreachable, and the reader has no way to
+        // tell a real absence from an unarmed one. All four kinds follow writer_provenance_enabled(),
+        // which the watch itself makes true.
+        //
+        // The banner states SCOPE, not completeness, and that distinction is deliberate: this history
+        // has four kinds, and there are GPU-side writes it records under none of them (see the list on
+        // guest_write_recorder_summary() in the header). Trying to make this line exhaustive is how it
+        // becomes wrong again — the useful claim is "these four are armed", leaving "and nothing else
+        // is a kind" to the header. The residual per-kind filters are named rather than summarised as
+        // "unfiltered": the watch makes writer_provenance_full_enabled() true, lifting DmaData's
+        // 256-byte and WriteData's 64-dword floors, but NOT the compute recorders' `!host_data`
+        // condition, which is per-buffer and no switch removes.
+        //
+        // DANGER, and the reason this text is hardcoded rather than derived: computing it by calling
+        // writer_provenance_enabled() would re-enter provenance_addr_watch() from inside its own
+        // static initialiser. That is UB, and on libstdc++ it is a concrete crash —
+        // __cxa_guard_acquire detects the recursion and calls std::terminate via
+        // recursive_init_error. Anyone "improving" this line to report live state must compute it
+        // OUTSIDE this lambda.
+        std::fprintf(stderr,
+                     "[provenance] watching guest range 0x%llx..0x%llx; of the four recorded kinds, "
+                     "armed: color compute-buffer dma-data write-data "
+                     "(dma/write unfiltered; compute omits host-backed buffers)\n",
                      (unsigned long long)w.addr, (unsigned long long)(w.addr + w.size));
         return w;
     }();
@@ -91,6 +123,7 @@ const char* guest_writer_kind_name(GuestWriterKind kind) {
         case GuestWriterKind::ComputeBuffer: return "compute-buffer";
         case GuestWriterKind::DmaData: return "dma-data";
         case GuestWriterKind::WriteData: return "write-data";
+        case GuestWriterKind::Count: break;   // sentinel, never a recorded kind
     }
     return "unknown";
 }
@@ -125,6 +158,8 @@ uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,
                      (unsigned long long)item, (unsigned long long)order,
                      (unsigned long long)identity, (unsigned long long)event.sequence);
     }
+    if (const size_t index = static_cast<size_t>(kind); index < kGuestWriterKindCount)
+        g_recorded_by_kind[index].fetch_add(1, std::memory_order_relaxed);
     std::lock_guard<std::mutex> lock(g_mutex);
     EventKey key{kind, addr};
     if (g_events.size() == kMaxEvents && !g_events.count(key)) {
@@ -153,10 +188,37 @@ std::optional<GuestWriteEvent> last_guest_write_overlap(uint64_t addr, uint64_t 
     return latest;
 }
 
+size_t guest_write_history_size() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_events.size();
+}
+
+uint64_t guest_write_recorded_count(GuestWriterKind kind) {
+    const size_t index = static_cast<size_t>(kind);
+    if (index >= kGuestWriterKindCount) return 0;
+    return g_recorded_by_kind[index].load(std::memory_order_relaxed);
+}
+
+const char* guest_write_recorder_summary() {
+    static thread_local char buffer[160];
+    int written = 0;
+    for (size_t index = 0; index < kGuestWriterKindCount; ++index) {
+        const auto kind = static_cast<GuestWriterKind>(index);
+        const int produced = std::snprintf(
+            buffer + written, sizeof buffer - static_cast<size_t>(written), "%s%s=%llu",
+            written ? " " : "", guest_writer_kind_name(kind),
+            (unsigned long long)guest_write_recorded_count(kind));
+        if (produced <= 0 || static_cast<size_t>(written + produced) >= sizeof buffer) break;
+        written += produced;
+    }
+    return buffer;
+}
+
 void reset_guest_write_history_for_test() {
     std::lock_guard<std::mutex> lock(g_mutex);
     g_events.clear();
     g_sequence.store(0, std::memory_order_relaxed);
+    for (auto& counter : g_recorded_by_kind) counter.store(0, std::memory_order_relaxed);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/writer_provenance.hpp
+++ b/prosper/src/gpu/writer_provenance.hpp
@@ -10,6 +10,10 @@ enum class GuestWriterKind : uint8_t {
     ComputeBuffer,
     DmaData,
     WriteData,
+    // Keep last. The per-kind recorded counts below are sized from this, so a new kind added above
+    // is counted and named automatically. A kind that is armed and recording but missing from the
+    // summary would be invisible in exactly the line that exists to say which recorders were armed.
+    Count,
 };
 
 struct GuestWriteEvent {
@@ -37,6 +41,37 @@ uint64_t record_guest_write(GuestWriterKind kind, uint64_t addr, uint64_t size,
                             uint32_t width = 0, uint32_t height = 0);
 std::optional<GuestWriteEvent> last_guest_write_overlap(uint64_t addr, uint64_t size,
                                                         uint64_t before_sequence = UINT64_MAX);
+
+// How many write events the history currently holds, and how many of each kind have ever been
+// recorded. A caller that reports "no writer overlaps X" MUST report these too: the recorders are
+// per-kind and independently gated, so an empty (or kind-incomplete) history makes a negative a
+// statement about the instrument rather than about the guest. Without this the two are
+// indistinguishable in the log — which is exactly how a void result gets read as a measurement.
+size_t guest_write_history_size();
+// Cumulative per-kind recorded counts, indexed by GuestWriterKind. Never evicted, unlike the
+// bounded event map, so a kind that recorded and then aged out still reports non-zero.
+uint64_t guest_write_recorded_count(GuestWriterKind kind);
+// Compact "which recorders actually fired" summary for diagnostics, e.g.
+// "color=0 compute-buffer=12 dma-data=3 write-data=0". The returned pointer is to a thread-local
+// buffer valid until the next call on the same thread.
+//
+// SCOPE — what this history does NOT contain, so a negative is read correctly. These are not
+// filters on the four kinds; they are guest writes that reach memory under no kind at all, and a
+// summary showing four healthy counters says nothing about them:
+//   * guest CPU writes — nothing hooks them, so any value the guest stores directly is invisible;
+//   * RELEASE_MEM / EOP label writes and EVENT_WRITE timestamps (command_processor.cpp) — GPU-side,
+//     so the CPU caveat above does not cover them, and they are 4-8 byte writes to exactly the kind
+//     of address a PROSPER_PROVENANCE_ADDR watch is pointed at;
+//   * colour targets beyond MRT1 — RenderState carries only color0_base/color1_base, so a third or
+//     later target has no base to record;
+//   * colour targets after the first draw to a given base — deduped deliberately, so the history
+//     holds one representative event per range rather than a write log;
+//   * a SKIPPED compute dispatch — it executes nothing, so it records nothing however the switches
+//     are set;
+//   * DMA destinations written by the capture/replay execute_ordered_items overload, which does not
+//     record while the live path does.
+// Do not try to make any one diagnostic line enumerate this; state scope and cite this list. #2111.
+const char* guest_write_recorder_summary();
 
 // Test-only reset for the process-global bounded history.
 void reset_guest_write_history_for_test();

--- a/prosper/tests/test_writer_provenance.cpp
+++ b/prosper/tests/test_writer_provenance.cpp
@@ -32,6 +32,60 @@ int main() {
     CHECK(std::string(guest_writer_kind_name(GuestWriterKind::ColorTarget)) == "color",
           "writer kind has a stable diagnostic name");
 
+    // A negative from last_guest_write_overlap() means "nothing recorded overlaps this", which is a
+    // statement about the guest ONLY if the relevant recorder was actually armed. The recorders are
+    // per-kind and independently gated, so a caller reporting a negative has to be able to say which
+    // kinds ever fired — otherwise "no writer wrote it" and "nobody was watching" are the same log
+    // line. These accessors are what make that distinction expressible.
+    CHECK(guest_write_history_size() == 3, "history size counts the retained events");
+    CHECK(guest_write_recorded_count(GuestWriterKind::DmaData) == 1 &&
+          guest_write_recorded_count(GuestWriterKind::ComputeBuffer) == 1 &&
+          guest_write_recorded_count(GuestWriterKind::WriteData) == 1,
+          "per-kind counts follow the recorders that fired");
+    CHECK(guest_write_recorded_count(GuestWriterKind::ColorTarget) == 0,
+          "a recorder that never fired reports zero, which is what makes a negative readable");
+    CHECK(std::string(guest_write_recorder_summary()) ==
+              "color=0 compute-buffer=1 dma-data=1 write-data=1",
+          "recorder summary names every kind and its count");
+
+    // Re-recording an existing (kind, addr) key REPLACES the event rather than adding one — this is
+    // key replacement, not eviction, and the two are tested separately below because only the second
+    // one proves the counters outlive the bounded map.
+    record_guest_write(GuestWriterKind::DmaData, 0x1000, 0x100, 9, 9, 90, 0xddd);
+    CHECK(guest_write_history_size() == 3,
+          "re-recording an existing (kind, addr) key replaces rather than grows the history");
+    CHECK(guest_write_recorded_count(GuestWriterKind::DmaData) == 2,
+          "the cumulative count still advances when an event is replaced");
+
+    // Rejected writes must not be counted: a zero address or size records nothing, so counting it
+    // would report a recorder as armed on a run where it contributed no queryable event.
+    record_guest_write(GuestWriterKind::ColorTarget, 0, 0x40);
+    record_guest_write(GuestWriterKind::ColorTarget, 0x9000, 0);
+    CHECK(guest_write_recorded_count(GuestWriterKind::ColorTarget) == 0,
+          "a rejected zero address/size does not count as the recorder firing");
+
+    // EVICTION, which is the property that actually matters: the event map is bounded, so a write
+    // recorded early in a long boot is gone by the time anything queries it. The cumulative counts
+    // must survive that, or "did this recorder ever fire" degrades to "did it fire recently" — and a
+    // negative would then be unreadable again for exactly the runs that are long enough to matter.
+    reset_guest_write_history_for_test();
+    const uint64_t before_flood = guest_write_recorded_count(GuestWriterKind::ColorTarget);
+    record_guest_write(GuestWriterKind::ColorTarget, 0x50000, 0x10, 1, 1, 1, 0xeee);
+    // Overfill with a different kind so the colour event is the eviction candidate by sequence.
+    for (uint64_t i = 0; i < 70000; ++i)
+        record_guest_write(GuestWriterKind::DmaData, 0x100000 + i * 0x10, 0x10);
+    CHECK(guest_write_history_size() <= 65536,
+          "the event map stays inside its bound while being overfilled");
+    CHECK(!last_guest_write_overlap(0x50000, 0x10),
+          "the early event really was evicted (otherwise the next check proves nothing)");
+    CHECK(guest_write_recorded_count(GuestWriterKind::ColorTarget) == before_flood + 1,
+          "a cumulative count survives eviction of the event it counted");
+
+    reset_guest_write_history_for_test();
+    CHECK(guest_write_history_size() == 0 &&
+          guest_write_recorded_count(GuestWriterKind::DmaData) == 0,
+          "test reset clears the events and the cumulative counts together");
+
     if (fails) return 1;
     std::printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
## The problem

The shared guest-write history answers *"who wrote this address"*. Its **negative** answer was
unreadable, and one of its four recorders was armed by the wrong switch.

Chasing #2132 — *Sonic Racing: CrossWorlds* has a bindless-table pointer in a constant buffer that
reads zero — produced 183 of these on an arm with `PROSPER_WRITER_PROVENANCE=1`, the switch documented
as the explicit *"retain everything"* request:

```text
[dyntrace]   no recorded GPU writer overlaps [0x413080a470,+0x40)
```

Nothing in that line distinguishes **"nothing wrote this range"** from **"the recorder for the only
plausible writer was never armed"** — and the second was partly true. `record_guest_write` for
`ColorTarget` lives inside `diagnose_resource_provenance()`, which returns early unless
`PROSPER_PROVENANCE_DIM` is set. So `PROSPER_WRITER_PROVENANCE=1` enabled every **consumer** and left
that **producer** off, and every negative it printed was unfalsifiable by construction.

## The changes

**1. Every negative now reports the history's own state.**

```text
[dyntrace]   no recorded GPU writer overlaps [0x413111a470,+0x40)
               (history=8589 recorded: color=39 compute-buffer=4744 dma-data=8127 write-data=1111)
```

`color=0` was the whole finding, and it is now visible without a second run. Two limits stay and are
documented at the call site rather than left implied, because both would otherwise be read as covered:

- a **skipped** dispatch records nothing however this is configured, so a negative never rules out a
  skipped compute program;
- **no kind records guest CPU writes**, so this history only ever describes GPU-side writers.

**2. `diagnose_resource_provenance()` separates its two jobs.** Recording colour targets now follows
`writer_provenance_enabled()` like the other three recorders; only the consumer/producer diagnostic
still needs a target extent to select on.

## Measured

Identical arms either side of the change, same title, same switches:

| | color | compute-buffer | dma-data | write-data |
|---|---|---|---|---|
| before | **0** | 54 | 0 | 7 |
| after | **5** (reaching 17) | 54 | 0 | 7 |

**Only `color` moves.** The other three recorders are byte-identical across the pair, which is what
makes this a targeted repair rather than a behaviour change.

## Affected / deliberately unaffected

Diagnostic surface only — no draw, dispatch, descriptor or pixel behaviour changes. With every
`PROSPER_*` provenance switch unset, `diagnose_resource_provenance()` still returns immediately, so a
default run is unchanged. The new accessors add two atomics per recorded write.

## Tests

`test_writer_provenance` gains coverage for the accessors and for the two properties that make them
trustworthy:

- the cumulative per-kind counts are **not** evicted with the bounded event map, so *"did this recorder
  ever fire"* survives an event aging out (a re-record of an existing `(kind, addr)` key replaces the
  event but still counts as a second firing);
- a **rejected** zero address/size does not count as a firing — otherwise a recorder would report as
  armed on a run where it contributed no queryable event.

Mutation-checked: moving the counter above the address/size rejection fails exactly the arm that
forbids it (`a rejected zero address/size does not count as the recorder firing`) and nothing else.

## Verification

```text
cmake --build build -j6                          -> rc=0
ctest (GAME_DUMP=<DUMP_ROOT>/PPSA24651-app0)     -> 100% tests passed out of 205, rc=0
git diff --check                                 -> clean
git log origin/master..HEAD | grep -c Claude-Session -> 0
```

Built inside the project container, so `gpu_replay` and every Vulkan execution test are really present.

## What this bought on #2132

With the instrument telling the truth, the CrossWorlds question has a **self-validated** answer rather
than a void one. At the moment of the failing vertex stage's replay the history holds **8,589 events**
— `color=39 compute-buffer=4744 dma-data=8127 write-data=1111`, all four recorders demonstrably firing
— and **still nothing overlaps the constant buffer** whose pointer field reads zero. The positive
control is embedded in the line itself.

That leaves exactly two unexamined populations, both named above and neither ruled out: **skipped
compute dispatches** (8 per boot on this title) and **guest CPU writes**. Recorded on #2132.

Refs #2132
