### PR TITLE
tools(revision): refuse to quote a measurement from a build that is not the revision you think

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -137,6 +137,12 @@ if(Python3_Interpreter_FOUND)
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_phase_report.py")
   if(GIT_EXECUTABLE)
+    # The provenance GATE: refuses to quote a measurement from a build that is not the revision the
+    # author thinks it is. Pure argument/exit-status contract, no build required — but it resolves
+    # real refs and creates a scratch repository, so it needs git exactly as its sibling below does.
+    add_test(NAME check_build_revision
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tools/revision/test_check_build_revision.py")
     add_test(NAME build_revision_refresh
              COMMAND "${Python3_EXECUTABLE}"
                "${CMAKE_SOURCE_DIR}/tools/revision/test_build_revision.py"
@@ -190,7 +196,10 @@ if(TARGET prosper_core)
   # Screenshot evidence classification/JSON is pure and must remain testable without Vulkan or a dump.
   add_executable(test_capture_manifest tests/test_capture_manifest.cpp
                                        tools/screenshot/capture_manifest.cpp)
-  target_include_directories(test_capture_manifest PRIVATE tools/screenshot)
+  # `src` and the revision library are for `build_revision.hpp` only: the run header records the
+  # revision the binary was compiled from, so the manifest self-describes. Still no Vulkan, no dump.
+  target_include_directories(test_capture_manifest PRIVATE tools/screenshot src)
+  target_link_libraries(test_capture_manifest PRIVATE prosper_build_revision)
   add_test(NAME capture_manifest COMMAND test_capture_manifest)
 
   # va2foff resolution order (issue #113): DYNAMIC/PROCPARAM/TLS must never shadow

--- a/prosper/tests/test_capture_manifest.cpp
+++ b/prosper/tests/test_capture_manifest.cpp
@@ -160,6 +160,27 @@ int main() {
     CHECK(run.find("\"min_pixel_distinct_frames\":8") != std::string::npos &&
           run.find("\"max_pixel_stale_seconds\":3.500000") != std::string::npos,
           "run header records pixel-progress assertions");
+    // Provenance: the revision the BINARY was compiled from. A lane that checks out new work and
+    // measures without rebuilding produces a confident measurement of the wrong build, and nothing
+    // else in the artifact can tell -- the source tree looks current and the run succeeds.
+    // `tools/revision/check_build_revision.py` is what compares this against a ref.
+    // Assert the SHAPE, not merely non-emptiness: a 40-char hex sha or the literal "unknown" that
+    // the generator emits outside a git checkout. Non-emptiness alone was near-vacuous, since the
+    // field can only be empty if the generator itself is broken.
+    {
+        const std::string key = "\"build_revision\":\"";
+        const size_t at = run.find(key);
+        std::string value;
+        if (at != std::string::npos) {
+            const size_t start = at + key.size();
+            const size_t end = run.find('"', start);
+            if (end != std::string::npos) value = run.substr(start, end - start);
+        }
+        const bool sha = value.size() == 40 &&
+            value.find_first_not_of("0123456789abcdefABCDEF") == std::string::npos;
+        CHECK(sha || value == "unknown",
+              "run header records a 40-char revision (or \"unknown\" outside a git checkout)");
+    }
 
     const std::string summary = manifest_summary_json(3, 5, true, tracker, 1);
     CHECK(summary.find("\"timed_out\":true") != std::string::npos &&

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -226,6 +226,40 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     `PROSPER_DUMP_PERSISTENT` is deliberately **not** in the `live_gpu_targets` disable list, so it
     observes the normal persistent-GPU-target path;
     `PROSPER_GPU_CAPTURE` **is**, so an env-triggered capture run is on the CPU-readback path.
+- **`revision/check_build_revision.py`** — **is the binary you are about to quote a measurement from
+  actually built from the code you think it is?** The failure it exists for is silent and produces a
+  *confident* wrong answer: a lane checks out new work (or rebases onto a master that moved), runs
+  an existing build directory, and reports the result as a measurement of current master. The source
+  tree IS current, the run succeeds, and nothing says the executable predates the change under test.
+  On 2026-08-06 that nearly turned "#2121 does not move Sonic Frontiers" into a false negative on a
+  title that gates on the exact NID #2121 fixed.
+  ```bash
+  python3 tools/revision/check_build_revision.py build-linux          # vs origin/master
+  python3 tools/revision/check_build_revision.py build-linux --binary build-linux/screenshot
+  python3 tools/revision/check_build_revision.py --manifest ~/work/manifest.json
+  ```
+  **It certifies an executable, not a build directory, and that distinction is the whole tool.**
+  `prosper_build_revision_refresh` is an unconditional custom target consumers merely depend on, so
+  `generated/prosper_build_revision/build_revision.cpp` is rewritten at the **start** of a build — a
+  build that then fails leaves it recording the new revision while every executable still embeds the
+  old one. The first version of this tool read only that file and therefore **certified a stale
+  binary as current**, which is the failure it exists to prevent with a green tick on top; review
+  caught it with a two-sided scratch reproduction. It now also requires an executable whose mtime is
+  at least the generated source's, and **names which one it certified** so the claim is auditable.
+  `configure_file` preserves the mtime when the revision is unchanged, so a rebuild at the same
+  revision is not a false alarm. **Exit status is the contract: 0 only when a named executable is
+  certified**, 1 for a mismatch, a stale binary, and every case where provenance cannot be
+  established — no recorded revision, nothing linked to certify, not a build directory, an
+  unresolvable ref. An unestablished provenance is not a match. (Usage errors exit 2, argparse's
+  convention.) `--allow-stale` downgrades any refusal to 0 while still printing it, for deliberate
+  pre-fix A/B arms — which must then say in the write-up which revision the numbers describe.
+  Screenshot manifests carry `build_revision` in their run header, so an archived artifact nobody
+  can re-run still says which build produced it. Three things it cannot see, by construction: a
+  **dirty tree** (the embedded revision is HEAD — `--strict-dirty` fails when tracked files under
+  `prosper/` differ, and resolves git from the checkout that owns the target rather than the cwd,
+  which is a real distinction under the worktree rule); an **executable it was not asked about**
+  (name the one you will run); and a **binary copied in from elsewhere**, whose mtime says nothing
+  about this build directory.
 - **`screenshot/`** — writes normal composited PNG sequences plus a JSONL evidence manifest. Use
   `--seconds 1` for wall-clock sampling, warmup or `--render-every N --render-every-for-seconds S`
   for slow software rendering,

--- a/prosper/tools/revision/check_build_revision.py
+++ b/prosper/tools/revision/check_build_revision.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Is the binary you are about to quote a measurement from built from the code you think it is?
+
+THE FAILURE THIS EXISTS FOR, because it is silent and produces a *confident* wrong answer.
+
+A lane checks out new work (or rebases onto a master that moved), runs an existing build directory,
+and reports the result as a measurement of current master. The source tree IS current. The run
+succeeds. Nothing in the output, the manifest, or the log says the executable predates the change
+being tested. On 2026-08-06 that nearly turned "#2121 does not move Sonic Frontiers" into a false
+negative on a title that gates on the exact NID #2121 fixed -- caught only because the binary's
+provenance happened to be checked by hand before the number was quoted (instrument trap 81's shape).
+
+WHY THIS CHECKS A BINARY'S MTIME AND NOT JUST THE GENERATED REVISION
+
+`prosper_build_revision_refresh` is an **unconditional custom target that consumers depend on**
+(`cmake/ProsperBuildRevision.cmake`), so `generated/prosper_build_revision/build_revision.cpp` is
+rewritten at the **start** of a build. If that build then fails or is interrupted -- the single most
+common state a lane's build directory is actually in -- the generated file records the NEW revision
+while every executable still embeds the OLD one.
+
+The first version of this tool read only that file, and therefore **certified a stale binary as
+current**: exactly the failure it exists to prevent, with a green tick on top. It was caught in
+review by a two-sided reproduction in a scratch project. The fix is to derive the verdict from
+something that only exists once a **link succeeded**: an executable whose mtime is at least that of
+the generated source. `configure_file` preserves the mtime when the revision is unchanged, so a
+rebuild at the same revision does not raise a false alarm.
+
+    python3 tools/revision/check_build_revision.py build-linux
+    python3 tools/revision/check_build_revision.py build-linux --binary build-linux/screenshot
+    python3 tools/revision/check_build_revision.py build-linux --against HEAD
+    python3 tools/revision/check_build_revision.py --manifest ~/work/manifest.json
+
+Exit status is the contract: **0 only when a named executable is certified**, 1 for a mismatch AND
+for every case where the tool cannot establish provenance -- no recorded revision, no executable to
+certify, not a build directory, an unresolvable ref. An unestablished provenance is not a match, and
+a check that degrades to "pass" when it cannot answer is worse than no check: it converts "unknown"
+into a green tick. (Usage errors exit 2, argparse's convention.)
+
+`--allow-stale` downgrades any of those to exit 0 while still printing loudly, for deliberate pre-fix
+A/B arms and bisects -- which must then say in the write-up which revision the numbers describe.
+
+WHAT IT STILL CANNOT SEE, stated because a check that overstates its coverage is worse than none
+
+* **Uncommitted changes.** The embedded revision is `HEAD`, so a build from a dirty tree reports the
+  base commit. `--strict-dirty` additionally fails when tracked files under `prosper/` differ from
+  HEAD -- a binary built from edits that exist in no commit cannot be reproduced by anyone.
+* **Executables it was not asked about.** It certifies the ones named by `--binary`, or the known
+  frontends it finds. A sibling target left stale by an interrupted build is invisible unless named.
+  Name the executable you are about to run.
+* **A binary copied in from elsewhere**, whose mtime says nothing about this build directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+
+GENERATED = pathlib.Path("generated") / "prosper_build_revision" / "build_revision.cpp"
+_REV_IN_SOURCE = re.compile(r'return\s+"([0-9a-fA-F]{7,40}|unknown)"\s*;')
+# The frontends a lane actually measures with. Certifying one of these is the common case; --binary
+# overrides when the target of interest is something else.
+_KNOWN_STEMS = ("screenshot", "boot_trace", "gpu_replay", "prosper-app", "gpu_timeline")
+# `.exe` too: a Visual Studio / MinGW `build-windows` names every one of these with the
+# suffix, so a stem-only list makes every default invocation there refuse for the wrong
+# reason -- "nothing to certify" when the executables are sitting right there.
+KNOWN_BINARIES = _KNOWN_STEMS + tuple(f"{stem}.exe" for stem in _KNOWN_STEMS)
+
+
+def _git(*args: str, cwd: pathlib.Path | None = None) -> str | None:
+    """stdout of a SUCCESSFUL git invocation, else None.
+
+    Returning stdout regardless of the return code is the bug this signature exists to prevent: in a
+    shallow clone `git rev-parse HEAD~1` fails *and* prints a plausible sha, so a caller that trusts
+    stdout silently proceeds on a commit that is not in the repository.
+    """
+    try:
+        out = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+    except OSError:
+        return None
+    return out.stdout.strip() if out.returncode == 0 else None
+
+
+def repo_root_for(path: pathlib.Path) -> pathlib.Path | None:
+    """The checkout that OWNS `path` — not the one the tool happens to be invoked from.
+
+    Under this project's mandatory-worktree rule the invoking cwd is routinely a different checkout
+    from the one whose build directory is being certified, and resolving `--against` or a dirty-tree
+    query against the wrong one answers a question nobody asked.
+    """
+    probe = path if path.is_dir() else path.parent
+    root = _git("rev-parse", "--show-toplevel", cwd=probe)
+    return pathlib.Path(root) if root else None
+
+
+def revision_from_build_dir(build_dir: pathlib.Path) -> str | None:
+    source = build_dir / GENERATED
+    if not source.is_file():
+        return None
+    match = _REV_IN_SOURCE.search(source.read_text(encoding="utf-8", errors="replace"))
+    return match.group(1).lower() if match else None
+
+
+def revision_from_manifest(path: pathlib.Path) -> str | None:
+    with path.open(encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(record, dict) and record.get("type") == "run":
+                value = record.get("build_revision")
+                return value.lower() if isinstance(value, str) else None
+    return None
+
+
+def certify_binaries(build_dir: pathlib.Path, named: list[pathlib.Path]) -> tuple[
+        list[pathlib.Path], list[pathlib.Path], list[pathlib.Path]]:
+    """Split candidate executables into (certified, stale) by mtime against the generated source.
+
+    An executable older than the generated revision source cannot contain that revision: the source
+    is written at the start of a build, so anything not relinked afterwards predates it.
+    """
+    source = build_dir / GENERATED
+    if not source.is_file():
+        return ([], [], [])
+    cutoff = source.stat().st_mtime
+    candidates = named or [build_dir / name for name in KNOWN_BINARIES]
+    certified, stale, unexecutable = [], [], []
+    for candidate in candidates:
+        if not candidate.is_file():
+            continue
+        # "Certified" has to mean an executable, not any file that happens to sit at that path: a
+        # stray object file or log would otherwise satisfy the check. Reported separately rather
+        # than skipped, so a file present-but-not-executable is not described as absent.
+        if os.name == "posix" and not os.access(candidate, os.X_OK):
+            unexecutable.append(candidate)
+            continue
+        (certified if candidate.stat().st_mtime >= cutoff else stale).append(candidate)
+    return (certified, stale, unexecutable)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Refuse to quote a measurement from a build that is not the revision you think.")
+    parser.add_argument("build_dir", nargs="?", type=pathlib.Path,
+                        help="a CMake build directory (e.g. build-linux)")
+    parser.add_argument("--manifest", type=pathlib.Path,
+                        help="check a screenshot manifest's recorded revision instead")
+    parser.add_argument("--binary", type=pathlib.Path, action="append", default=[],
+                        help="executable to certify (repeatable); defaults to the known frontends")
+    parser.add_argument("--against", default="origin/master",
+                        help="git ref the build must match (default: origin/master)")
+    parser.add_argument("--allow-stale", action="store_true",
+                        help="report loudly but exit 0 (deliberate pre-fix A/B arms)")
+    parser.add_argument("--strict-dirty", action="store_true",
+                        help="also fail when tracked files under prosper/ differ from HEAD")
+    parser.add_argument("--repo", type=pathlib.Path,
+                        help="checkout to resolve --against in (default: the one owning the target)")
+    args = parser.parse_args()
+
+    if (args.build_dir is None) == (args.manifest is None):
+        parser.error("give exactly one of BUILD_DIR or --manifest")
+
+    def refuse(message: str) -> int:
+        print(message, file=sys.stderr)
+        return 0 if args.allow_stale else 1
+
+    target = args.manifest if args.manifest is not None else args.build_dir
+    if not target.exists():
+        return refuse(f"revision: UNKNOWN — {target} does not exist. Nothing was verified.")
+
+    repo = args.repo or repo_root_for(target) or repo_root_for(pathlib.Path.cwd())
+    if repo is None:
+        return refuse("revision: UNKNOWN — no git checkout owns the target and none was given with\n"
+                      "  --repo, so no ref can be resolved. Nothing was verified.")
+
+    stale_binaries: list[pathlib.Path] = []
+    if args.manifest is not None:
+        built = revision_from_manifest(args.manifest)
+        origin = f"manifest {args.manifest}"
+        if built is None:
+            return refuse(
+                f"revision: UNKNOWN — {args.manifest} has no build_revision in its run header.\n"
+                "  Manifests written before that field existed cannot be checked. Treat the\n"
+                "  measurement's provenance as unestablished rather than as matching.")
+    else:
+        built = revision_from_build_dir(args.build_dir)
+        origin = f"build dir {args.build_dir}"
+        if built is None:
+            return refuse(
+                f"revision: UNKNOWN — no {GENERATED} under {args.build_dir}.\n"
+                "  Either it is not a configured prosper build directory or it has never been\n"
+                "  built. Nothing is being verified; do not read this as a match.")
+        certified, stale_binaries, unexecutable = certify_binaries(args.build_dir, args.binary)
+        if not certified and not stale_binaries:
+            if unexecutable:
+                return refuse(
+                    f"revision: UNKNOWN — {args.build_dir} records revision {built[:12]}, and these\n"
+                    "  files exist but are not executable, so nothing can be certified:\n"
+                    + "".join(f"    {b} (mode {oct(b.stat().st_mode & 0o777)})\n"
+                              for b in unexecutable)
+                    + "  A file that cannot be executed cannot have produced a measurement. Fix the\n"
+                      "  mode, or name the real executable with --binary.")
+            wanted = [str(b) for b in args.binary] or list(KNOWN_BINARIES)
+            listed = "".join(f"    {name}\n" for name in wanted[:8])
+            more = f"    … and {len(wanted) - 8} more\n" if len(wanted) > 8 else ""
+            return refuse(
+                f"revision: UNKNOWN — {args.build_dir} records revision {built[:12]} but contains\n"
+                "  none of the executables it looked for:\n" + listed + more
+                + "  The generated revision source is written at the START of a build, so on its own\n"
+                  "  it proves only that a build was attempted at that revision — not that anything\n"
+                  "  was linked. Name the executable you are about to run with --binary.")
+
+    if built == "unknown":
+        return refuse("revision: UNKNOWN — this build recorded no revision (built outside a git\n"
+                      "  checkout, or git was unavailable at build time). Provenance unestablished.")
+
+    want = _git("rev-parse", "--verify", f"{args.against}^{{commit}}", cwd=repo)
+    if want is None:
+        return refuse(f"revision: UNKNOWN — cannot resolve --against {args.against!r} in {repo}.")
+    want = want.lower()
+
+    if stale_binaries:
+        return refuse(
+            "revision: STALE BINARY — " + origin + f" records revision {built[:12]}, but these\n"
+            "  executables are OLDER than the generated revision source, so they cannot contain it:\n"
+            + "".join(f"    {b}\n" for b in stale_binaries)
+            + "  The revision source is written at the START of a build; an executable not relinked\n"
+              "  afterwards predates it, which is what an interrupted or failed build leaves behind.\n"
+              "  Rebuild before quoting any measurement from them.")
+
+    matches = built == want or (len(built) >= 7 and want.startswith(built))
+    if not matches:
+        behind = _git("rev-list", "--count", f"{built}..{want}", cwd=repo)
+        ahead = _git("rev-list", "--count", f"{want}..{built}", cwd=repo)
+        relation = ""
+        if behind is not None and ahead is not None:
+            if ahead == "0" and behind != "0":
+                relation = f" — {behind} commit(s) BEHIND it"
+            elif behind == "0" and ahead != "0":
+                relation = f" — {ahead} commit(s) ahead of it"
+            elif ahead != "0" and behind != "0":
+                relation = f" — diverged ({ahead} ahead, {behind} behind)"
+        return refuse(
+            f"revision: MISMATCH — {origin} is built from {built[:12]}, "
+            f"but {args.against} is {want[:12]}{relation}.\n"
+            f"  A measurement from this build is NOT a measurement of {args.against}. Rebuild, or\n"
+            "  pass --allow-stale and say in the write-up which revision the numbers describe.")
+
+    if args.strict_dirty:
+        changed = _git("status", "--porcelain", "--untracked-files=no", "--", "prosper", cwd=repo)
+        if changed:
+            print("revision: DIRTY — tracked files under prosper/ differ from HEAD, so the binary\n"
+                  "  was built from edits that exist in no commit and nobody else can reproduce:",
+                  file=sys.stderr)
+            for line in changed.splitlines()[:20]:
+                print(f"    {line}", file=sys.stderr)
+            return 0 if args.allow_stale else 1
+
+    print(f"revision: OK — {origin} is built from {built[:12]} == {args.against}")
+    if args.manifest is None:
+        for binary in certified:
+            print(f"  certified: {binary}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/revision/test_check_build_revision.py
+++ b/prosper/tools/revision/test_check_build_revision.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Regression test for check_build_revision.py.
+
+What it guards: the tool's whole value is its EXIT STATUS, because that is what makes it usable as a
+gate ahead of a measurement run rather than a warning nobody reads. Every arm asserts the status --
+and each cannot-answer case asserts exit 1 specifically, because a check that degrades to "pass"
+when it cannot answer is worse than no check: it converts unestablished provenance into a green tick.
+
+Two arms exist because review found the tool doing exactly that, and they are the reason to keep this
+file honest:
+
+  * INTERRUPTED BUILD. The generated revision source is written at the START of a build, so a build
+    that then fails leaves it recording the new revision while every executable still embeds the old
+    one. The first version of the tool read only that file and certified the stale binary as current.
+  * --strict-dirty FROM ANOTHER DIRECTORY. It ran git with the process cwd and a `prosper` pathspec,
+    so from inside `prosper/` the pathspec became `prosper/prosper` and matched nothing -- a silent
+    no-op exactly when invoked as documented.
+
+Arms straddle the predicate in both directions on purpose: a test that only proved MISMATCH-fails
+would pass against a tool that always failed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+import tempfile
+
+TOOL = pathlib.Path(__file__).resolve().parent / "check_build_revision.py"
+CMAKE_DIR = pathlib.Path(__file__).resolve().parents[2] / "cmake"
+REPO = pathlib.Path(__file__).resolve().parents[3]
+
+fails = 0
+ran = 0
+skipped = 0
+
+
+def check(condition: bool, message: str) -> None:
+    global fails, ran
+    ran += 1
+    if condition:
+        print(f"  [ok]   {message}")
+    else:
+        print(f"  [FAIL] {message}")
+        fails += 1
+
+
+def skip(arms: int, reason: str) -> None:
+    """Record arms that did NOT run, and say how many.
+
+    Without this the summary is byte-identical whether every arm ran or only some did, and plain
+    ctest prints nothing at all for a passing test -- so a block silently vanishing looks exactly
+    like a clean pass. The block most likely to vanish here is the scratch-repo one, which guards
+    both defects review found. A suite that can drop the arms guarding its own bugs and still print
+    `all ok` is a confident zero: precisely what the tool under test exists to refuse, turned on its
+    own test suite. The count makes the suite's coverage falsifiable from a log.
+    """
+    global skipped
+    skipped += arms
+    print(f"  [skip] {reason} ({arms} arm{'s' if arms != 1 else ''})")
+
+
+def run(*args: str, cwd: pathlib.Path | None = None,
+        repo: pathlib.Path | None = REPO) -> subprocess.CompletedProcess:
+    """Invoke the tool, pinned by default to THIS checkout.
+
+    `--repo` is passed unless a caller explicitly asks for `repo=None`. Without it these arms depend
+    on where `TMPDIR` points: repo resolution follows the *target*, so a fixture created under a
+    tempdir that happens to live inside another checkout resolves `--against HEAD` to that
+    checkout's HEAD and the arm flakes. `CLAUDE.md` instructs every agent to set
+    `TMPDIR=<worktree>/build/tmpdir`, so that is the configuration a reader is most likely to have.
+    The arms that deliberately exercise repo discovery pass `repo=None`.
+    """
+    extra = ["--repo", str(repo)] if repo is not None else []
+    return subprocess.run([sys.executable, str(TOOL), *args, *extra], cwd=cwd or REPO,
+                          capture_output=True, text=True, check=False)
+
+
+def git(*args: str, cwd: pathlib.Path | None = None) -> str:
+    """stdout of a SUCCESSFUL git call, else "".
+
+    Not cosmetic: in a shallow clone (which is what CI checks out) `git rev-parse HEAD~1` fails and
+    still prints a plausible sha. An earlier version of this helper returned stdout unconditionally,
+    so the test proceeded on a commit not present in the repository and one arm failed in CI while
+    passing on every full checkout.
+    """
+    try:
+        out = subprocess.run(["git", *args], cwd=cwd or REPO, capture_output=True, text=True,
+                             check=False)
+    except OSError:
+        return ""
+    return out.stdout.strip() if out.returncode == 0 else ""
+
+
+def write_manifest(directory: pathlib.Path, name: str, revision: str | None) -> pathlib.Path:
+    record: dict[str, object] = {"type": "run", "schema": 1, "title": "TEST"}
+    if revision is not None:
+        record["build_revision"] = revision
+    path = directory / name
+    path.write_text(json.dumps(record) + "\n" + json.dumps({"type": "sample", "index": 0}) + "\n",
+                    encoding="utf-8")
+    return path
+
+
+def make_build_dir(root: pathlib.Path, revision: str, *, binary: bool = True,
+                   binary_older: bool = False) -> pathlib.Path:
+    """A build directory shaped like a real one: generated revision source plus an executable."""
+    build = root / "build"
+    generated = build / "generated" / "prosper_build_revision"
+    generated.mkdir(parents=True, exist_ok=True)
+    source = generated / "build_revision.cpp"
+    source.write_text(
+        '#include "build_revision.hpp"\n\nnamespace prosper {\n\n'
+        'const char* embedded_build_revision() noexcept {\n'
+        f'    return "{revision}";\n'
+        '}\n\n} // namespace prosper\n', encoding="utf-8")
+    if binary:
+        exe = build / "screenshot"
+        exe.write_bytes(b"\x7fELF fake")
+        exe.chmod(0o755)
+        stamp = source.stat().st_mtime
+        os.utime(exe, (stamp - 60, stamp - 60) if binary_older else (stamp + 60, stamp + 60))
+    return build
+
+
+def main() -> int:
+    head = git("rev-parse", "HEAD")
+    if not head:
+        print("test_check_build_revision: not a git checkout — skipping (0 arms, all skipped)")
+        return 0
+    parent = git("rev-parse", "HEAD~1")   # "" in a shallow clone; arms below are guarded
+
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = pathlib.Path(raw)
+
+        # --- the failure that reached review: an interrupted build ------------------------------
+        interrupted = make_build_dir(tmp / "interrupted", head, binary_older=True)
+        result = run(str(interrupted), "--against", "HEAD")
+        check(result.returncode == 1,
+              "an executable OLDER than the generated revision source FAILS (interrupted build)")
+        check("STALE BINARY" in result.stderr,
+              "the interrupted-build refusal names the stale binary rather than reporting a mismatch")
+        check(run(str(interrupted), "--against", "HEAD", "--allow-stale").returncode == 0,
+              "--allow-stale covers the stale-binary refusal too")
+
+        good = make_build_dir(tmp / "good", head)
+        result = run(str(good), "--against", "HEAD")
+        check(result.returncode == 0,
+              "an executable NEWER than the generated revision source is certified")
+        check("certified:" in result.stdout,
+              "a pass names which executable it certified, so the claim is auditable")
+
+        # A build dir with the right revision but nothing linked must NOT pass.
+        nolink = make_build_dir(tmp / "nolink", head, binary=False)
+        result = run(str(nolink), "--against", "HEAD")
+        check(result.returncode == 1,
+              "a build dir with no executable to certify FAILS rather than trusting the source file")
+        check("UNKNOWN" in result.stderr,
+              "and says it is unknown rather than reporting a match")
+        check(run(str(nolink), "--against", "HEAD",
+                  "--binary", str(nolink / "screenshot")).returncode == 1,
+              "naming a non-existent --binary does not manufacture a certification")
+
+        # A file that cannot be executed cannot have produced a measurement -- and must be reported
+        # as present-but-not-executable rather than as absent, which was the original misdirection.
+        if os.name == "posix":
+            notexec = make_build_dir(tmp / "notexec", head)
+            (notexec / "screenshot").chmod(0o644)
+            result = run(str(notexec), "--against", "HEAD")
+            check(result.returncode == 1, "a non-executable candidate is not certified")
+            check("not executable" in result.stderr and "screenshot" in result.stderr,
+                  "and is named as present-but-not-executable rather than reported as absent")
+            (notexec / "screenshot").chmod(0o755)
+            check(run(str(notexec), "--against", "HEAD").returncode == 0,
+                  "restoring the executable bit certifies it: the mode is the cause")
+        else:
+            skip(3, "not a POSIX host — the executable-bit arms")
+
+        if not parent:
+            skip(2, "shallow clone — the older-revision arms need HEAD~1")
+        else:
+            old = make_build_dir(tmp / "old", parent)
+            result = run(str(old), "--against", "HEAD")
+            check(result.returncode == 1, "a build dir built from an older revision FAILS")
+            check("BEHIND" in result.stderr, "the mismatch says which direction it is out of date")
+
+        # --- repo discovery: the tool must follow the TARGET, not the invoking checkout ----------
+        # NB1 from review: both fixed behaviours were only ever exercised through an explicit
+        # --repo, and every build-dir fixture sits in a non-repo tempdir where repo_root_for()
+        # falls back to cwd -- so nothing pinned the discovery itself. These two arms are a
+        # discriminator: the scratch repo's HEAD differs from this checkout's, so resolving against
+        # the wrong one gives the opposite verdict.
+        scratch = tmp / "scratchrepo"
+        (scratch / "prosper" / "tools").mkdir(parents=True)
+        (scratch / "prosper" / "tools" / "f.txt").write_text("one\n", encoding="utf-8")
+        for cmd in (["init", "-q"], ["config", "user.email", "t@t"], ["config", "user.name", "t"],
+                    ["add", "-A"], ["commit", "-qm", "seed"]):
+            subprocess.run(["git", *cmd], cwd=scratch, capture_output=True, check=False)
+        scratch_head = git("rev-parse", "HEAD", cwd=scratch)
+        if not scratch_head:
+            skip(6, "scratch git repo unavailable — discovery and --strict-dirty arms")
+        elif scratch_head == head:
+            skip(6, "scratch HEAD equals this checkout's — discovery cannot discriminate")
+        else:
+            sbuild = make_build_dir(scratch, scratch_head)
+            # No --repo, invoked from THIS checkout: only target-following resolution can pass.
+            check(run(str(sbuild), "--against", "HEAD", cwd=REPO, repo=None).returncode == 0,
+                  "repo resolution follows the target: a build dir inside another checkout is "
+                  "certified against THAT checkout's HEAD")
+            # The counter-arm proves the arm above is not vacuous: forced to this checkout, the
+            # identical invocation must disagree.
+            check(run(str(sbuild), "--against", "HEAD", cwd=REPO, repo=REPO).returncode == 1,
+                  "and --repo overrides discovery: the same build dir MISMATCHes this checkout")
+
+            # --- --strict-dirty must work from any cwd, which is how it is documented ------------
+            # In the SCRATCH repo, not this one: dirtying a tracked file in the real checkout would
+            # be visible to peer lanes, would survive a crash between write and restore, and would
+            # make the arms depend on the developer's own tree being clean.
+            check(run(str(sbuild), "--against", "HEAD", "--strict-dirty",
+                      cwd=REPO, repo=scratch).returncode == 0,
+                  "--strict-dirty passes on a clean tree")
+            (scratch / "prosper" / "tools" / "f.txt").write_text("two\n", encoding="utf-8")
+            check(run(str(sbuild), "--against", "HEAD", "--strict-dirty",
+                      cwd=REPO, repo=scratch).returncode == 1,
+                  "--strict-dirty fails on a dirty tree when run from the repo root")
+            check(run(str(sbuild), "--against", "HEAD", "--strict-dirty",
+                      cwd=scratch / "prosper", repo=scratch).returncode == 1,
+                  "--strict-dirty fails identically when run from prosper/ — the pathspec bug that "
+                  "made the flag a silent no-op exactly as documented")
+            check(run(str(sbuild), "--against", "HEAD",
+                      cwd=scratch / "prosper", repo=scratch).returncode == 0,
+                  "and without --strict-dirty the same dirty tree passes: the flag is the cause")
+
+
+        # --- the manifest reader ----------------------------------------------------------------
+        exact = write_manifest(tmp, "exact.jsonl", head)
+        check(run("--manifest", str(exact), "--against", "HEAD").returncode == 0,
+              "a manifest recording HEAD matches HEAD")
+        check(run("--manifest", str(write_manifest(tmp, "upper.jsonl", head.upper())),
+                  "--against", "HEAD").returncode == 0,
+              "an upper-case revision matches: comparison is case-insensitive")
+        check(run("--manifest", str(write_manifest(tmp, "short.jsonl", head[:12])),
+                  "--against", "HEAD").returncode == 0,
+              "an abbreviated revision is accepted as a prefix of the full ref")
+        wrong = head[:-1] + ("0" if head[-1] != "0" else "1")
+        check(run("--manifest", str(write_manifest(tmp, "wrong.jsonl", wrong)),
+                  "--against", "HEAD").returncode == 1,
+              "a revision differing in one character is a mismatch, not a prefix match")
+
+        # --- cannot-answer cases must FAIL, not pass ---------------------------------------------
+        check(run("--manifest", str(write_manifest(tmp, "none.jsonl", None)),
+                  "--against", "HEAD").returncode == 1,
+              "a manifest with no build_revision fails: unestablished is not matching")
+        check(run("--manifest", str(write_manifest(tmp, "unknown.jsonl", "unknown")),
+                  "--against", "HEAD").returncode == 1,
+              "a build that recorded no revision ('unknown') fails rather than passing")
+        check(run(str(tmp), "--against", "HEAD").returncode == 1,
+              "a directory that is not a configured build dir fails rather than passing")
+        check(run("--manifest", str(tmp / "no-such-file.jsonl")).returncode == 1,
+              "a missing manifest file fails cleanly rather than raising")
+        check("Traceback" not in run("--manifest", str(tmp / "no-such-file.jsonl")).stderr,
+              "and does so without a raw traceback")
+        check(run("--manifest", str(exact), "--against", "no/such/ref").returncode == 1,
+              "an unresolvable --against ref fails rather than passing")
+
+        # --- argument contract -------------------------------------------------------------------
+        check(run("--against", "HEAD").returncode == 2,
+              "neither BUILD_DIR nor --manifest is a usage error (argparse exit 2)")
+        check(run(str(tmp), "--manifest", str(exact)).returncode == 2,
+              "both BUILD_DIR and --manifest is a usage error")
+
+        # --- the fixture must match what CMake really generates ----------------------------------
+        template = CMAKE_DIR / "build_revision.cpp.in"
+        if not template.is_file():
+            skip(3, f"{template} absent — template-drift arms")
+        else:
+            rendered = template.read_text(encoding="utf-8").replace(
+                "@PROSPER_GENERATED_REVISION@", head)
+            pattern = re.compile(r'return\s+"([0-9a-fA-F]{7,40}|unknown)"\s*;')
+            check(bool(pattern.search(rendered)),
+                  "the tool's regex matches the real cmake/build_revision.cpp.in template")
+            # Both sides: the arm above would also pass against a regex that matched anything, so
+            # pin that the pattern is actually discriminating. If the template ever stops emitting a
+            # bare quoted literal, the arm above fails loudly instead of the tool silently reading
+            # every build dir as UNKNOWN.
+            check(not pattern.search(rendered.replace('return "', 'return get("')),
+                  "and the regex rejects a template that no longer emits a bare quoted literal")
+            drifted = make_build_dir(tmp / "drift", head)
+            (drifted / "generated" / "prosper_build_revision" / "build_revision.cpp").write_text(
+                'const char* embedded_build_revision() noexcept { return get("%s"); }\n' % head,
+                encoding="utf-8")
+            check(run(str(drifted), "--against", "HEAD").returncode == 1,
+                  "a drifted template makes the tool refuse, not silently certify")
+
+    coverage = f"{ran} arms" + (f", {skipped} skipped" if skipped else "")
+    print(f"test_check_build_revision: "
+          + (f"{fails} FAILURE(S) ({coverage})" if fails else f"all ok ({coverage})"))
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/screenshot/capture_manifest.cpp
+++ b/prosper/tools/screenshot/capture_manifest.cpp
@@ -1,5 +1,7 @@
 #include "capture_manifest.hpp"
 
+#include "build_revision.hpp"   // revision this binary was compiled from
+
 #include <algorithm>
 #include <cstdio>
 #include <iomanip>
@@ -176,6 +178,13 @@ std::string manifest_run_json(const CaptureRunConfig& c) {
     std::ostringstream line;
     line << "{\"type\":\"run\",\"schema\":1"
          << ",\"title\":\"" << json_escape(c.title) << "\""
+         // The revision this BINARY was compiled from, not the revision of the checkout it is run
+         // from. Those differ whenever a lane checks out new work and measures without rebuilding,
+         // and nothing else in the artifact can tell them apart: the source tree looks current, the
+         // run succeeds, and the result is a confident measurement of the wrong build (instrument
+         // trap 81). Recording it here makes every manifest self-describing, including archived ones
+         // nobody can re-run. `tools/revision/check_build_revision.py` is the active check.
+         << ",\"build_revision\":\"" << json_escape(prosper::embedded_build_revision()) << "\""
          << ",\"timestamp\":\"" << json_escape(c.timestamp) << "\""
          << ",\"output_dir\":\"" << json_escape(c.output_dir) << "\""
          << ",\"input_route\":\"" << json_escape(c.input_route) << "\""


### PR DESCRIPTION
## The failure this exists for

A lane checks out new work — or rebases onto a master that moved fifteen commits in an hour — runs an
existing build directory, and reports the result as a measurement of current master. **The source tree
IS current. The run succeeds. Nothing in the output, the log, or the manifest says the executable
predates the change under test.**

It is silent, and it produces a *confident* wrong answer rather than a visibly broken one.

**Measured, not hypothetical.** On 2026-08-06 this nearly turned *"#2121 does not move Sonic
Frontiers"* into a false negative — on a title that gates on `sceSaveDataCreateTransactionResource`,
the exact NID #2121 fixed, so it was a live candidate rather than a shrug. It was caught only because
the binary's provenance happened to be checked by hand before the number was quoted. That is
instrument trap 81's shape (a rebuilt artifact read as proof the measured executable changed), one
library over, and it should not depend on someone remembering.

## What this adds

Two halves, both reusing the revision infrastructure that already exists rather than inventing a
mechanism.

### Passive — the artifact self-describes

The screenshot run header now records `build_revision`: the revision CMake embedded into the binary
that produced the artifact.

```json
{"type":"run","schema":1,"title":"PPSA03831","build_revision":"b71d7557331fd428ce815bc73421d09697320d85",...}
```

Every manifest from now on carries its own provenance, **including archived ones nobody can re-run** —
which is the case a pre-run check can never cover.

### Active — the gate

```bash
python3 tools/revision/check_build_revision.py build-linux            # vs origin/master
python3 tools/revision/check_build_revision.py build-linux --against HEAD
python3 tools/revision/check_build_revision.py --manifest ~/work/manifest.json
```

It reads `generated/prosper_build_revision/build_revision.cpp` — the revision CMake embedded into
every binary in that build directory — so there is **no binary parsing and nothing to execute**.

**Exit status is the contract: 0 on match, 1 on anything else.** That is what makes it usable as a
gate ahead of a measurement run (`check && run`) rather than a warning in a log nobody reads.

Every case where it *cannot* answer also exits 1 — no recorded revision, not a build directory,
unresolvable ref, a build that recorded `"unknown"`. An unestablished provenance is not a match, and a
check that degrades to "pass" when it cannot answer is worse than no check at all: it converts
"unknown" into a green tick.

`--allow-stale` downgrades a real mismatch to exit 0 for deliberate pre-fix A/B arms and bisects —
while still printing it loudly, because a stale arm has to be *labelled* as one when its numbers are
written down.

## Limits, in the tool's own docstring rather than discovered later

- **Uncommitted changes.** The embedded revision is `HEAD`, so a build from a dirty tree reports the
  base commit. `--strict-dirty` additionally fails when tracked files under `prosper/` differ from
  HEAD — the case that matters, because a binary built from edits that exist in no commit cannot be
  reproduced by anyone, including its author.
- **Which target was rebuilt.** The revision is per build *directory*, not per target, so a build dir
  can hold a fresh `screenshot` and a stale sibling after an interrupted build. **Trap 81's original
  form is therefore not covered** — that one needs an mtime comparison between the executable and the
  library. Said plainly because a check that overstates its coverage is worse than none.
- **Ancestry.** A mismatch is a failure either way; the ancestor case is merely reported with the
  commit distance to make the message actionable.

## Verification — exact head `04d0632c`

```text
cmake --build build-linux -j8                       clean
ctest -j4                                           100% tests passed, 206/206
ctest -R 'capture_manifest|check_build_revision|build_revision_refresh'   3/3 passed
git diff --cached --check                           clean
trap-41 (merge-tree, three-dot)                     1 removed line, my own (adding `src` to the
                                                    manifest test's include dirs)
git log origin/master..HEAD | grep -c Claude-Session   0
```

**The regression test has 15 arms and straddles the predicate in both directions**, which matters here
because a test that only proved MISMATCH-fails would pass against a tool that always failed:

| arm | asserts |
| --- | --- |
| manifest recording HEAD, vs HEAD | exit 0 |
| abbreviated revision as a prefix | exit 0 |
| manifest from `HEAD~1`, vs HEAD | exit **1**, message says `BEHIND` |
| same with `--allow-stale` | exit 0, **and still prints `MISMATCH`** |
| revision differing in one character | exit **1** — not a prefix match |
| no `build_revision` / `"unknown"` / not a build dir / bad ref | exit **1** each |
| neither or both of BUILD_DIR and `--manifest` | non-zero |
| build dir at HEAD / at `HEAD~1` | exit 0 / exit **1** |

**End-to-end on the real path**, not only unit-tested: a 4K `tools/screenshot` run of `PPSA03831`
wrote `build_revision=b71d7557331fd428ce815bc73421d09697320d85`, and
`check_build_revision.py --manifest` accepted it. Before I rebuilt onto current master, the same gate
correctly reported the build directory **2 commits behind** — so the failing arm was demonstrated
against a real stale build, not a synthetic one.

## Affected and deliberately unaffected

Adds a JSON field and a tool; changes no runtime behaviour. `test_capture_manifest` gains `src` on its
include path and links `prosper_build_revision` so the header remains compilable standalone — still no
Vulkan and no dump. Nothing consumes `build_revision` automatically; wiring it into `verify-pr` or the
snapshot harness is a separate decision.

Refs #2023
