### PR TITLE
fix(win): mprotect must see the WHOLE tracker snapshot, and must not admit prosper's own import stubs

### DIFF
--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -255,3 +255,31 @@ that thread waits on becomes the focus, so matching signals from other threads a
   is insufficient because it may never return to guest code (#678).
 - Dynamic-fetch constant folding must reject unreadable guest ranges on every host. The native
   renderer exercises this path; an unconditional Windows readability stub caused #688.
+- `sceKernelMprotect` on Windows accepts guest memory the VA tracker (`g_maps`) does not own, but
+  **only inside a fixed guest MODULE-CODE aperture** — the eboot, the PRXes, the plugin and
+  runtime-PRX pools (`guest_va_in_module_code`). Those images are mapped by the exec substrate's
+  `VirtualAlloc`, so they never enter `g_maps`, and a title mprotecting its own segment must succeed
+  the way POSIX `mprotect` does (#2101: The Messenger abandoned AGC device init over the refusal).
+  Everything else still fails: `MEM_FREE`, `MEM_RESERVE` with no tracker backing, a tracked mapping
+  the tracker calls uncommitted over committed host pages, and any committed page outside every
+  module aperture. **`guest_module_name(a) != "mapped/host"` is the wrong test for this** — it also
+  matches `[BOOT_STUB, BOOT_STUB_END)`, which is prosper's OWN emitted import trampolines, committed
+  by `install_stubs`' plain `VirtualAlloc` and therefore untracked exactly like a module image; using
+  it let a guest strip execute permission from every HLE entry point (#2144 F2).
+- The tracker snapshot that decides all of the above (`tracked_mapping_slices`) must be the *complete*
+  coverage of the span. Returning early on the first untracked hole silently reclassified every tracked
+  slice above it (#2144 F1), and **two** consumers read that vector for completeness, not one:
+  `tracked_slices_back_host_reservation` in the `MEM_RESERVE` arm, and — less obviously —
+  `next_slice_base` in the `MEM_COMMIT` arm, which is *derived from the vector* and collapses to
+  `region_end` when it is truncated, so the untracked gap handed to the aperture test is a different
+  range than it should be. Reason about both before changing that function; a safety argument covering
+  only the first one is the shape of mistake that produced #2144 in the first place.
+- Accepting a tracker-backed `MEM_RESERVE` region is **not** a relaxation. `win_protect`'s own
+  precondition comment (added 2026-07-18 in `9e8b22b5`, well before #2117) already states it: reserved
+  pages take a tracking-only protection change, matching the POSIX `PROT_NONE` reservation path. The
+  `MEM_RESERVE` arm pushes nothing into `committed`, so no `VirtualProtect` runs for it at all — the
+  entire effect is a success return plus `k_mprotect`'s `retrack_prot` on a range the tracker already
+  owns. Truncation never implemented a narrower *policy*; it just made that arm unreachable whenever
+  anything untracked preceded the reservation.
+- Note that #2117 narrowed the allowance during review: its PR body still describes the withdrawn first
+  cut, which accepted any committed page.

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4116,11 +4116,20 @@ namespace {
     // Snapshot the tracker coverage for a protection transaction. VirtualQuery describes every
     // committed host allocation in the process, including allocations that do not belong to the
     // guest. A host MEM_COMMIT result therefore cannot prove that sceKernelMprotect owns the span.
+    //
+    // `slices` is ALWAYS the complete set of tracked sub-ranges of [begin,end): an untracked hole is
+    // skipped, never fatal. It used to return on the first hole, which left every tracked slice
+    // ABOVE that hole out of the vector — harmless while the caller bailed on `false`, but win_protect
+    // now reads the vector as the coverage itself, so a truncated one silently reclassifies a tracked
+    // suffix as untracked and skips the refusals that only apply to tracked slices (#2144). The return
+    // value keeps its old meaning — true iff [begin,end) is fully covered — for any future caller that
+    // needs the whole-span question rather than the slices.
     bool tracked_mapping_slices(uint64_t begin, uint64_t end,
                                 std::vector<TrackedMappingSlice>& slices) {
         slices.clear();
         if (begin >= end) return false;
         std::lock_guard<std::mutex> lk(g_mx);
+        bool complete = true;
         uint64_t cursor = begin;
         while (cursor < end) {
             const Mapping* best = nullptr;
@@ -4128,12 +4137,21 @@ namespace {
                 if (cursor < mapping.base || cursor >= mapping.base + mapping.size) continue;
                 if (!best || mapping.base > best->base) best = &mapping;
             }
-            if (!best) return false;
+            if (!best) {
+                // Untracked hole. Resume at the next tracked mapping that starts above the cursor
+                // (or at `end`), which is strictly greater than the cursor, so this terminates.
+                complete = false;
+                uint64_t resume = end;
+                for (const auto& mapping : g_maps)
+                    if (mapping.base > cursor && mapping.base < resume) resume = mapping.base;
+                cursor = resume;
+                continue;
+            }
             const uint64_t slice_end = std::min<uint64_t>(end, best->base + best->size);
             slices.push_back({cursor, slice_end - cursor, best->prot, best->committed});
             cursor = slice_end;
         }
-        return true;
+        return complete;
     }
 
     bool tracked_slices_back_host_reservation(
@@ -4153,18 +4171,21 @@ namespace {
         return false;
     }
 
-    // True when [begin,end) lies inside the fixed guest MODULE apertures (eboot, the PRXes, the
-    // plugin/runtime pools). boot_program.hpp labels everything else "mapped/host"; the module
-    // images are mapped by the exec substrate rather than the memory HLE, so they are legitimate
-    // guest memory that g_maps never records. Both ends are checked, so a span that starts in a
-    // module and runs off its end is rejected; an interior hole would be MEM_FREE and is already
-    // refused by the region walk.
+    // True when [begin,end) lies inside the fixed guest MODULE CODE apertures (eboot, the PRXes, the
+    // plugin and runtime-PRX pools). Those images are mapped by the exec substrate rather than the
+    // memory HLE, so they are legitimate guest memory that g_maps never records. Both ends are
+    // checked, so a span that starts in a module and runs off its end is rejected; an interior hole
+    // would be MEM_FREE and is already refused by the region walk.
+    //
+    // guest_va_in_module_code, not "the boot_program.hpp label is not mapped/host": the import-stub
+    // aperture [BOOT_STUB, BOOT_STUB_END) is labelled "STUB" and would pass that test, but it holds
+    // PROSPER's OWN emitted trampolines, committed by install_stubs' plain VirtualAlloc and therefore
+    // untracked exactly like a module image. It is host memory wearing a guest address, and letting
+    // the guest reprotect it would strip execute permission from every HLE entry point (#2144).
     bool guest_module_image_span(uint64_t begin, uint64_t end) {
         if (begin >= end) return false;
-        auto is_module = [](uint64_t a) {
-            return std::strcmp(prosper::guest_module_name(a), "mapped/host") != 0;
-        };
-        return is_module(begin) && is_module(end - 1);
+        return prosper::guest_va_in_module_code(begin) &&
+               prosper::guest_va_in_module_code(end - 1);
     }
 
     bool win_protect(uint64_t addr, uint64_t len, int hp, DWORD* error_out = nullptr) {

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -9,11 +9,12 @@
 #include "../src/host/guest_write_watch.hpp"
 #ifdef _WIN32
 #include "../src/host/exec_image.hpp"
-#include "../src/host/boot_program.hpp"   // BOOT_EBOOT: the module aperture the mprotect case uses
+#include "../src/host/boot_program.hpp"   // BOOT_EBOOT / BOOT_STUB: the apertures the mprotect cases use
 #include "../src/host/guest_memory_map.hpp"
 #include "../src/gpu/gpu_execute.hpp"
 #include <windows.h>
 extern "C" int prosper_try_commit_dmem(uint64_t addr, uint64_t len, int write);
+extern "C" int prosper_try_commit_reserved_placeholder(uint64_t addr, uint64_t len);
 #endif
 #include <cstdio>
 #include <cstdint>
@@ -548,6 +549,116 @@ int main() {
             CHECK((unchanged.Protect & 0xff) == PAGE_READWRITE,
                   "the refused foreign page keeps its original protection");
             VirtualFree(foreign, 0, MEM_RELEASE);
+        }
+    }
+    // #2144 F1: the tracker snapshot win_protect works from must be the COMPLETE coverage of the
+    // span, not the prefix before the first untracked hole. #2117 made the caller read that vector
+    // as coverage, so a span BEGINNING in an untracked page produced an EMPTY vector and every
+    // tracked slice above it was misread as an untracked gap -- which silently voided the refusals
+    // that only apply to tracked slices, and made rollback restore the raw mbi.Protect (under an
+    // armed write-watch, the transient read-only value the tracker split exists to avoid).
+    // Both #2117 arms are wholly inside or wholly outside a module image; this one is MIXED, which
+    // is the only shape that reaches the truncation. Mutation killed: restoring the `return false`
+    // on the first hole makes the refusal below turn into an accept that reprotects both halves.
+    {
+        constexpr uint64_t kGranule = 0x10000;   // Windows allocation granularity
+        const uint64_t image_va = prosper::BOOT_EBOOT + 0x3000000ull;
+        const uint64_t reserved_va = image_va + kGranule;
+        // Prefix: a module image the memory HLE has never heard of, exactly as in the #2101 arm.
+        void* image = VirtualAlloc((void*)(uintptr_t)image_va, kGranule,
+                                   MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        CHECK(image != nullptr, "commit an untracked module-image prefix in the eboot aperture");
+        // Suffix: a range the tracker DOES own and calls uncommitted, over host pages that are in
+        // fact committed -- the bookkeeping disagreement the merged comment says must keep failing.
+        // The fixed reserve hands back a Windows PLACEHOLDER, which plain VirtualAlloc(MEM_COMMIT)
+        // cannot back (ERROR_INVALID_ADDRESS). prosper's own lazy-commit entry point -- the one its
+        // VEH uses when a guest first touches a reserved page -- replaces the placeholder with
+        // private pages under g_dview_mx and never touches g_maps, so the tracker keeps calling the
+        // range uncommitted. That is precisely the disagreement this arm needs.
+        uint64_t reserved = reserved_va;
+        const bool suffix_reserved =
+            image && reserve((uint64_t)(uintptr_t)&reserved, kGranule,
+                             0x10 /* SCE_KERNEL_MAP_FIXED */, kGranule, 0, 0) == 0 &&
+            reserved == reserved_va &&
+            prosper_try_commit_reserved_placeholder(reserved_va, kGranule) == 1;
+        CHECK(suffix_reserved, "track an uncommitted reservation directly above it");
+        uint8_t reserved_info[0x48]{};
+        MEMORY_BASIC_INFORMATION suffix_host{};
+        if (suffix_reserved)
+            VirtualQuery((void*)(uintptr_t)reserved_va, &suffix_host, sizeof(suffix_host));
+        // Self-invalidating precondition: without BOTH halves of the disagreement (tracker says
+        // uncommitted, host says committed) the refusal below would prove nothing.
+        const bool disagreement =
+            suffix_reserved && suffix_host.State == MEM_COMMIT &&
+            query(reserved_va, 0, (uint64_t)(uintptr_t)reserved_info, sizeof(reserved_info),
+                  0, 0) == 0 && reserved_info[0x20] == 0;
+        CHECK(disagreement, "the suffix is tracked-uncommitted over committed host pages");
+        if (disagreement) {
+            CHECK((uint32_t)protect(image_va, kGranule * 2, 0x1, 0, 0, 0) == 0x80020016u,
+                  "mprotect still refuses a tracked-uncommitted suffix behind an untracked prefix");
+            MEMORY_BASIC_INFORMATION prefix_after{}, suffix_after{};
+            VirtualQuery((void*)(uintptr_t)image_va, &prefix_after, sizeof(prefix_after));
+            VirtualQuery((void*)(uintptr_t)reserved_va, &suffix_after, sizeof(suffix_after));
+            CHECK((prefix_after.Protect & 0xff) == PAGE_READWRITE &&
+                      (suffix_after.Protect & 0xff) == PAGE_READWRITE,
+                  "the refused mixed span leaves both halves' host protection alone");
+            // Positive control for the arm itself: the untracked prefix ALONE is still accepted and
+            // still moves, so the refusal above came from the tracked suffix and not from a blanket
+            // refusal of the aperture or of this address.
+            CHECK(protect(image_va, kGranule, 0x1, 0, 0, 0) == 0,
+                  "the untracked module prefix alone is still accepted");
+            VirtualQuery((void*)(uintptr_t)image_va, &prefix_after, sizeof(prefix_after));
+            CHECK((prefix_after.Protect & 0xff) == PAGE_READONLY,
+                  "and the prefix's host protection actually changed");
+        }
+        if (suffix_reserved) unmap(reserved_va, kGranule, 0, 0, 0, 0);
+        if (image) VirtualFree(image, 0, MEM_RELEASE);
+    }
+    // #2144 F2: [BOOT_STUB, BOOT_STUB_END) is labelled "STUB" rather than "mapped/host", so the
+    // merged aperture test ("the label is not mapped/host") admitted it -- but install_stubs
+    // reserves and commits that window with a plain VirtualAlloc, so it is untracked exactly like a
+    // module image while holding PROSPER's OWN emitted trampolines. A guest could therefore
+    // reprotect every HLE entry point, which the pre-#2117 code refused. guest_va_in_module_code()
+    // already draws the line. Mutation killed: reverting to the strcmp("mapped/host") test makes
+    // both refusals below turn into accepts that strip execute from the stub table.
+    {
+        constexpr uint64_t kGranule = 0x10000;
+        // Mixed span: ONE committed host region whose low half is the real guest plugin pool and
+        // whose high half is the stub aperture, so the region walk sees a single gap spanning both.
+        const uint64_t straddle = prosper::BOOT_STUB - kGranule;
+        void* mixed = VirtualAlloc((void*)(uintptr_t)straddle, kGranule * 2,
+                                   MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        CHECK(mixed != nullptr, "commit one region straddling the plugin/import-stub boundary");
+        if (mixed) {
+            CHECK((uint32_t)protect(straddle, kGranule * 2, 0x1, 0, 0, 0) == 0x80020016u,
+                  "mprotect refuses a span running out of a guest module into the stub aperture");
+            MEMORY_BASIC_INFORMATION after{};
+            VirtualQuery((void*)(uintptr_t)prosper::BOOT_STUB, &after, sizeof(after));
+            CHECK((after.Protect & 0xff) == PAGE_READWRITE,
+                  "the refused straddling span leaves the stub half's protection alone");
+            // Positive control: the guest-module half of the same allocation is still accepted, so
+            // the refusal is about the stub aperture and not about this allocation.
+            CHECK(protect(straddle, kGranule, 0x1, 0, 0, 0) == 0,
+                  "the guest-module half of the same allocation is still accepted");
+            VirtualQuery((void*)(uintptr_t)straddle, &after, sizeof(after));
+            CHECK((after.Protect & 0xff) == PAGE_READONLY,
+                  "and the guest-module half's host protection actually changed");
+            VirtualFree(mixed, 0, MEM_RELEASE);
+        }
+        // And wholly inside the aperture, committed exactly as install_stubs commits the table.
+        void* stub_table = VirtualAlloc((void*)(uintptr_t)(prosper::BOOT_STUB + 0x100000ull),
+                                        kGranule, MEM_RESERVE | MEM_COMMIT,
+                                        PAGE_EXECUTE_READWRITE);
+        CHECK(stub_table != nullptr, "commit an import-stub table page as install_stubs does");
+        if (stub_table) {
+            CHECK((uint32_t)protect((uint64_t)(uintptr_t)stub_table, kGranule, 0x1, 0, 0, 0) ==
+                      0x80020016u,
+                  "mprotect refuses prosper's own import-stub aperture");
+            MEMORY_BASIC_INFORMATION after{};
+            VirtualQuery(stub_table, &after, sizeof(after));
+            CHECK((after.Protect & 0xff) == PAGE_EXECUTE_READWRITE,
+                  "the stub table keeps execute permission, so every HLE entry point still runs");
+            VirtualFree(stub_table, 0, MEM_RELEASE);
         }
     }
     CHECK(map((uint64_t)(uintptr_t)&sparse_va2, sparse_len, 0x1, 0,


### PR DESCRIPTION
Fixes #2144.

Two blocking findings from an independent review of #2117 that completed **after** it merged
(`87844547`). **#2117's direction is right** — the loosening is correct and its Windows-only scoping
is confirmed — so this is a targeted repair of two defects, not a revert. Both are inside the `#else`
Windows half of `hle_kernel_mem.cpp`; Linux and macOS are untouched.

Both were re-verified against `origin/master` at source before any change was made.

## F1 — `tracked` was silently truncated, voiding a stated refusal

`tracked_mapping_slices` returned on the first untracked hole:

```cpp
if (!best) return false;
```

leaving its output vector holding only the prefix. That was harmless while callers bailed on the
`false` return, but #2117 changed the call site to `(void)tracked_mapping_slices(addr, end, tracked);`
and then reads the vector **as complete coverage**.

**Failure scenario.** A span that *begins* in an untracked page. `best` is null on the first
iteration, the function returns immediately, and `tracked` is **empty** — so a tracked suffix is
misclassified as an untracked gap. Concretely, for
`[untracked module page][tracked range the tracker calls uncommitted over committed host pages]`,
`sceKernelMprotect` **returned 0 and reprotected both halves**. That voids

> a tracked mapping the tracker calls uncommitted over committed host pages still fails

which is one of the three bullets #2117's body offers as proof the change is bounded. Rollback then
restores `mbi.Protect`, which under an armed write-watch is exactly the transient read-only value the
retained comment says the tracker split exists to avoid.

**Fix.** Skip the hole and continue, so `slices` is always the complete set of tracked sub-ranges of
`[begin,end)`. The return value keeps its old meaning — true iff the span is fully covered.

**Did any other caller depend on the early return?** No. `tracked_mapping_slices` has exactly one
caller, the `(void)`-cast one #2117 introduced, so the return value currently has no consumer at all;
it is kept for its meaning rather than its use.

### Two consumers read the vector for *completeness*, and both change behaviour

An earlier revision of this description reasoned only about the first of these and concluded the
practical bound was exact. The conclusion holds; the argument did not cover the second consumer, and
**that is the same shape as the failure that produced #2144** — a true conclusion reached by a route
that does not establish it. Corrected here, and in the doc entry, on review.

**1. `tracked_slices_back_host_reservation` (the `MEM_RESERVE` arm).** It already detects a hole
itself (`if (slice.base > cursor) return false`), so a complete vector is strictly *more* information
to it, not different information. The behaviour change is that a `MEM_RESERVE` region the tracker
*does* back, sitting above an untracked hole in the same span, is now accepted rather than refused.

**This is the pre-existing contract, not a relaxation** — and the case is stronger than "restores the
intended contract", which is all the first revision of this description claimed:

- `win_protect`'s own precondition comment states it, and **predates #2117 by three weeks**
  (`9e8b22b5`, 2026-07-18): *"Reserved (uncommitted) pages accept a tracking-only protection change,
  matching the POSIX `PROT_NONE` reservation path."*
- The accepted case performs **no `VirtualProtect` at all**. The `MEM_RESERVE` arm pushes nothing into
  `committed`, and `committed` is the only thing the protection loop iterates. Its entire effect is a
  success return plus `k_mprotect`'s `retrack_prot()` on a range the tracker already owns — which is
  literally "a tracking-only protection change".
- So truncation never implemented a narrower *policy*. It made `tracked_slices_back_host_reservation`
  **unreachable** whenever anything untracked preceded the reservation.

**2. `next_slice_base` (the `MEM_COMMIT` arm) — the widening class the first revision did not
disclose.** `next_slice_base` is initialised to `region_end` and then lowered by tracked slice bases
found in the vector, so it is **itself derived from the vector** and collapses to `region_end` when
the vector is truncated. The aperture test is `guest_module_image_span(scan, next_slice_base)`.
Therefore an untracked gap that master evaluated as the larger `[scan, region_end)` and refused is now
evaluated as the smaller `[scan, next_slice_base)` and can be accepted.

The behaviour is correct — the gap really does end where the next tracked slice begins, and the old
range was over-wide only because the slice was missing. No reachable instance is known: it requires a
single `VirtualQuery` region holding **both** untracked module pages **and** tracked pages, *and*
ending outside every module aperture, which no real allocation produces. So the practical bound is
almost certainly still exact — but it is a second widening class, and it belongs in the record rather
than in nobody's head.

## F2 — the aperture classifier admitted prosper's own import stubs

`guest_module_image_span` asked "is the `boot_program.hpp` label something other than `mapped/host`?".
But `guest_module_name` returns `"STUB"` for `[BOOT_STUB, 0x610000000)`, and `install_stubs`
(`prosper/src/host/exec_image_win.cpp:1165-1171`) reserves and commits that aperture with a plain
`VirtualAlloc` — untracked, exactly like a module image.

**Failure scenario.** A guest calls `sceKernelMprotect` on an address in the import-stub aperture
(alone, or as the tail of a span starting in the plugin pool immediately below it). #2117's code
accepts it and reprotects **prosper's own emitted trampolines** — e.g. `CPU_READ` maps to
`PAGE_READONLY`, stripping execute from every HLE entry point. The pre-#2117 code refused this, and
the narrowing commit's stated property ("excludes foreign host memory") is not met.

**Fix.** Use `guest_va_in_module_code()`, which already expresses exactly this distinction (in a
fixed module aperture, and *not* in `[BOOT_STUB, BOOT_STUB_END)`). It is right for this site because
the question being asked is "is this guest module memory the exec substrate mapped?", and the stub
table is host memory wearing a guest address: it is emitted by prosper, not loaded from the title.

## Tests

#2117's six new assertions are good — each kills a real mutation, and *"the host protection actually
changed"* correctly separates *returned 0* from *did the thing*. But they cover **wholly inside** and
**wholly outside** a module image. Neither shape reaches either defect, which is why both merged.
`test_dmem` gains a **mixed-span** arm for each finding, each with its own positive control.

**F1 arm.** An untracked module-image prefix in the eboot aperture, followed by a range the tracker
owns and calls uncommitted over host pages that are in fact committed. That suffix state is built
through prosper's own lazy-commit entry point (`prosper_try_commit_reserved_placeholder`) — the one
its VEH uses on first touch of a reserved page — because the fixed reserve hands back a Windows
*placeholder*, which plain `VirtualAlloc(MEM_COMMIT)` cannot back (`ERROR_INVALID_ADDRESS`, which is
correct Win32 behaviour, not a harness artifact). That path replaces the placeholder under
`g_dview_mx` and never touches `g_maps`, so the tracker keeps calling the range uncommitted.
A **self-invalidating precondition check** asserts both halves of the disagreement actually exist
(`VirtualQuery` says `MEM_COMMIT`, `sceKernelVirtualQuery` says uncommitted) before the discriminator
runs, so the arm cannot pass vacuously.

*Known limitation of that check, raised on review and recorded rather than papered over:* its
`reserved_info[0x20] == 0` half is also satisfied by "untracked entirely", via `k_virtual_query`'s
not-found path — so that half does not verify quite what its name claims. It is harmless here, because
an untracked range would make the protect **succeed** and fail the discriminator loudly rather than
silently, and the `MEM_COMMIT` half of the check is unambiguous. Worth stating plainly all the same: a
self-invalidating check that only half-works is precisely the failure it was added to prevent.

*Mutation killed:* restoring `if (!best) return false;` turns the refusal into an accept that
reprotects both halves.

**F2 arm.** One committed host region straddling the plugin/import-stub boundary (so the region walk
sees a single gap spanning both apertures), plus the stub aperture on its own committed
`PAGE_EXECUTE_READWRITE` exactly as `install_stubs` commits the table.

*Mutation killed:* reverting to the `strcmp(..., "mapped/host")` test turns both refusals into
accepts that strip execute from the stub table.

**Positive controls.** In each arm the module-only half of the *same* allocation is still accepted
and its host protection is asserted to actually move — so a refusal cannot be coming from a blanket
rejection of the aperture or of that address.

## Red-without / green-with — measured, not asserted

These are Windows-only paths (`test_dmem.cpp`'s `#ifdef _WIN32`), and this is a Linux host. They were
exercised by cross-building the Windows unit tests with a MinGW toolchain and running them under
Wine. Stated plainly so the evidence can be weighted: this is **not** the native MSYS2/UCRT CI
configuration, and one link shim was needed for an unrelated UCRT-only CRT symbol in the file HLE
(`_set_thread_local_invalid_parameter_handler`), which nothing on these paths calls. Neither the shim
nor the toolchain is part of this diff.

**A — new arms applied on top of unmodified `origin/master` source:**

```
  [ok]   commit an untracked module-image prefix in the eboot aperture
  [ok]   track an uncommitted reservation directly above it
  [ok]   the suffix is tracked-uncommitted over committed host pages
  [FAIL] mprotect still refuses a tracked-uncommitted suffix behind an untracked prefix
  [FAIL] the refused mixed span leaves both halves' host protection alone
  [ok]   the untracked module prefix alone is still accepted
  [ok]   and the prefix's host protection actually changed
  [ok]   commit one region straddling the plugin/import-stub boundary
  [FAIL] mprotect refuses a span running out of a guest module into the stub aperture
  [FAIL] the refused straddling span leaves the stub half's protection alone
  [ok]   the guest-module half of the same allocation is still accepted
  [ok]   and the guest-module half's host protection actually changed
  [ok]   commit an import-stub table page as install_stubs does
  [FAIL] mprotect refuses prosper's own import-stub aperture
  [FAIL] the stub table keeps execute permission, so every HLE entry point still runs
== FAIL: 6 check(s) ==
```

Exactly the 6 discriminating checks fail — 2 for F1, 4 for F2 — while every setup check and every
positive control passes. The setup checks passing is what shows the state was really constructed; the
positive controls passing is what shows the arms are not blanket-refusing.

**B — same arms with the fix:** `143/143`, `== PASS ==`, and #2117's own refusal diagnostic fires on
each of the three refusals, which is independent confirmation that the rejection came from
`win_protect`'s validation walk and not from something upstream:

```
[memhle] sceKernelMprotect REFUSED addr=0x413000000 len=0x20000 prot=0x1 win_error=487
[memhle] sceKernelMprotect REFUSED addr=0x5ffff0000 len=0x20000 prot=0x1 win_error=487
[memhle] sceKernelMprotect REFUSED addr=0x600100000 len=0x10000 prot=0x1 win_error=487
```

**What could not be exercised here:** a live title on native Windows. #2117's own progression
evidence (The Messenger reaching AGC device init) is unaffected by this change — its eboot mprotect
is a wholly-in-module span with no tracked slice, which both arms of the existing #2117 test still
cover and which stays accepted.

## Verification (exact head `7225634`)

```
# Linux, distrobox ps5ys
cmake -S prosper -B build-linux -DCMAKE_BUILD_TYPE=Release && cmake --build build-linux -j6
cd build-linux && ctest
  -> 100% tests passed out of 200   (plugin_autolink skipped, as on master)

# Windows unit tests, MinGW cross-build run under Wine
cmake --build build-win --target test_dmem test_retrack_reservation -j6
wine build-win/test_dmem.exe                 -> 143 [ok], 0 [FAIL], == PASS ==
wine build-win/test_retrack_reservation.exe  ->  51 [ok], 0 [FAIL], == PASS ==
```

`test_retrack_reservation` is the test whose failure caught #2117's over-wide first cut on Windows
CI, so it is the direct guard for F2's half of this change.

**Whole Windows suite, A/B under the local cross+Wine harness:** `155` tests, `18` failures **before
and after** — the failing set is byte-identical on unmodified `origin/master` and on this branch
(`libc_alloc`, `sync_delete`, `pthread_names`, `pthread_cond_clock`, `file_binary_roundtrip`,
`service_logging_unmapped_args`, `apr_registry_resolution`, `dmem_caller_chain`, `eop_write`,
`wait_barrier`, `render_state_extract`, `shader_inspect_resource_table_honesty`, `spv_validate`,
`gpu_timeline_roundtrip`, `gpu_timeline_capture_exit`, `guest_log_capture`, `capture_trigger_file`,
`video_media_foundation`). These are artifacts of the cross-build/Wine harness — three of them have no
executable at all, because `test_pthread_names`, `test_video_mf` and `boot_trace` do not assemble or
link under this Fedora MinGW GCC 16 toolchain.

**But that A/B is weaker than the first revision of this description implied, and the framing is
corrected here.** A local A/B **cannot** detect a regression masked *inside* an already-failing test:
a test that fails before and after is opaque to it, so "identical failing set" bounds only the tests
that were passing. What actually closes the gap is the **native** pair — Windows MinGW green at head
*and* at master — where nothing is masked because nothing is failing. The reviewer verified Windows
MinGW green independently at head, at master, and at the merge base. Native CI reports **155/155**,
which is also what retires the 18 as harness artifacts rather than merely as "unchanged".

`git diff --check` clean. `merge-base == origin/master` was confirmed *before* the trap-41 deletion
screen; all 13 deleted lines are this change's own.

## Also fixes the record

#2117's PR body still describes its **withdrawn first cut** — the "Approach" bullets and the pasted
test output are the version that accepted any committed page, not the module-aperture narrowing that
actually merged. So the safety-relevant narrowing appeared nowhere in the project record. It is now
recorded, together with both corrections above, as a `## Gotchas learned` entry in
`docs/WINDOWS_PORT_HANDOFF.md`, including the explicit warning that
`guest_module_name(a) != "mapped/host"` is the wrong test for this question.

The headline claim is softened separately on #2101 (comment), where the "resolved for every affected
title" table landed. The evidence supports something narrower than "four of the six titles that boot
on native Windows": a full chain on **The Messenger**, symptom-only on **Dead Cells**,
intermediate-step-only in the PR body for **Blasphemous 2**, and contradicted for **Astro Bot**,
which is still black by #2117's own report.

## Risk

Medium — a memory-protection path. F2 is a strict narrowing (the new predicate admits nothing the old
one refused; verified mechanically over every aperture boundary +/-1, every midpoint, and a sweep of
`[0x400000000, 0xa00000000)` — the difference is exactly `[0x600000000, 0x60fffffff]`). F1 narrows in
the `MEM_COMMIT` arm's tracked-slice refusals and widens in the two classes enumerated above, both
correct, one of which performs no `VirtualProtect` at all.
