### PR TITLE
docs(charter): a same-source positive control tests the discriminator, never the domain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,21 @@ The standing warnings that are **not** title-specific:
   can fail silently. Check a diagnostic's rate limit before quoting its volume as a frequency, and
   check whether it clears `live_gpu_targets` before comparing it against a default run.
 
+- **A positive control drawn from the same source as the null it validates tests the DISCRIMINATOR,
+  never the DOMAIN.** This qualifies the rule above, and it is the harder half. "A discriminator that
+  cannot show its lever moved is void" is true — but a lever that *does* move proves only that the
+  machinery runs, not that the space it searches can express the case you are testing for. Worked
+  example (2026-08-06, instrument trap 122): a reviewer's fuzz reported zero instances of a widening
+  class. Suspecting the zero, they ran a positive control — **and it passed**: 41,206 constructions,
+  17,659 narrowings, 0 widenings. It could not have done otherwise, because it drew from the same
+  generator and so inherited the same broken geometry, in which the case was *structurally
+  inexpressible*. Interior geometry surfaced 1,277 instances immediately.
+  **So: before believing a clean zero, construct one positive instance of the class BY HAND, outside
+  whatever produced the null.** A same-source control confirms the machinery fires on cases the source
+  can build — which is exactly the assumption in question. This is the sharpest form of the family the
+  instrument-trap list records, because unlike the silent instruments in traps 64, 116 and 121, this
+  one is *loud*, and the noise is what launders the null.
+
 ### Superseded documents
 
 `docs/NEXT_STEP_VERTEX_FETCH.md` (bindless-dynamic vertex fetch, superseded 2026-07-11) and


### PR DESCRIPTION
Qualifies the charter's existing **"prefer experiments that detect their own invalidity"** rule with the harder half.

## Why this needs saying

*"A discriminator that cannot show its lever moved is void"* is true, and it is the rule this project quotes most — I have quoted it to lanes a dozen times today alone.

But it is only half the test. **A lever that *does* move proves the machinery runs. It proves nothing about whether the space being searched can express the case under test.**

## The worked example (instrument trap 122, merged as #2152)

A reviewer's fuzz reported **zero** instances of a widening class in `hle_kernel_mem.cpp`'s validation walk. Suspecting the zero, they did the right thing and ran a positive control.

**It passed.** 41,206 constructions, 17,659 narrowings, 0 widenings.

It could not have done otherwise. The control drew from the **same generator** as the null it was validating, and so inherited the same broken geometry — the model's apertures sat flush against the top of the address space, making a case that must *straddle* that edge structurally inexpressible. Interior geometry surfaced **1,277** instances immediately.

So the control confirmed the discriminator fires on cases the generator can build, which is precisely the assumption in question.

## Why it is the sharpest member of its family

The instrument-trap list already records unarmed, half-armed and wrongly-scoped instruments (64, 116, 121). In all of those the discriminator is **silent**, and silence is at least suspicious.

Here it was **loud** — and the noise is what laundered the null. `17,659 narrowings` is exactly the evidence anyone would cite to prove their discriminator works.

## The rule

**Before believing a clean zero, construct one positive instance of the class by hand, outside whatever produced the null.**

That is mechanical rather than a discipline, which is the point trap 121 exists to make: a remedy that depends on remembering decays, and the agent who hit 121 had read 116.

## Affected / unaffected

`CLAUDE.md` only — **15 insertions, 0 deletions**, appended to the existing paragraph rather than rewriting it. No other file, no code, no test.

## Verification

Documentation-only, so per the charter's own exception this does not wait on CI; the docs gate ran locally instead.

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   -> exit 0
git diff --name-only origin/master...HEAD | grep -v '\.md$'                            -> empty
git diff --check                                                                        -> clean
merge-tree --write-tree origin/master HEAD, diffed vs master                            -> +15/-0
```

Authored from a worktree branched at `origin/master` and verified equal before editing.

Refs #2152
