### PR TITLE
fix(il2cpp): prx_to_elf wrote e_phnum into e_shnum, and left e_shstrndx stale

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -112,6 +112,12 @@ if(Python3_Interpreter_FOUND)
   # cases are regressions for classifier bugs found only after a table had been published (#2002).
   add_test(NAME re_nid_gate_classifier
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_nid_gate_scan.py")
+  # prx_to_elf.py writes an ELF header by hand, four bytes apart from a field that means something
+  # else entirely — #2016 put the program-header count in the section-header-count slot, and the
+  # result was a malformed image no consumer complained about until binutils refused the file. The
+  # test reads the produced bytes at their gABI offsets; nothing else can see this class of bug.
+  add_test(NAME il2cpp_prx_to_elf_header
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/il2cpp/test_prx_to_elf.py")
   add_test(NAME snapshot_guard_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
   add_test(NAME gpu_replay_regress_logic

--- a/prosper/tools/il2cpp/README.md
+++ b/prosper/tools/il2cpp/README.md
@@ -41,6 +41,25 @@ managed logic (scene load, boot state machines) during emulator debugging.
    (`0xFF` at v-2/-3/-6/-7), not just `0xE8` (call rel32) — IL2CPP dispatches
    managed methods indirectly, so an 0xE8-only filter drops every managed frame.
 
+## What binutils can and cannot do with the flattened ELF
+
+The image has program headers but **no section header table**, so `e_shoff`, `e_shnum` and
+`e_shstrndx` are all zero (`prx_to_elf.py`; regression: `test_prx_to_elf.py`, ctest
+`il2cpp_prx_to_elf_header`). That is enough for binutils to *accept* the file — `objdump -f`,
+`objdump -p` and `objdump -T` all work, and `-T` is genuinely useful: it lists the module's Sony
+NID dynamic symbols. It is **not** enough for `objdump -d`, which disassembles sections and finds
+none; disassembly still needs `objdump -D -b binary -m i386:x86-64 --start-address=…`, or
+`tools/re/xref.py`. Synthesizing section headers from the PT_LOADs would fix that and is #2154.
+
+### Ruled out
+- **"binutils also needs `e_ident[EI_OSABI]`/`[EI_ABIVERSION]` cleared" (#2016's own note) — false.**
+  binutils 2.46 accepts the flattened image with the module's `0x09 0x02` (FreeBSD, ABI 2) intact,
+  as long as `e_shnum` **and** `e_shstrndx` are both 0. A/B over all four combinations on the
+  `PPSA24651` IL2CPP module: `(shnum=14, shstrndx=43)` REJECT, `(0, 43)` REJECT, `(14, 0)` REJECT,
+  `(0, 0)` ACCEPT — and `(0, 0)` with OSABI cleared is also ACCEPT, i.e. OSABI changes nothing.
+  Zeroing only `e_shnum`, as #2016 suggested, would not have made binutils accept the file. No
+  `--gnu-compat` flag is needed (#2016 / PR #2155).
+
 ## gdb caveat (prosper)
 prosper installs a SIGSEGV handler for lazy memory commit. Under gdb, ALWAYS use
 

--- a/prosper/tools/il2cpp/prx_to_elf.py
+++ b/prosper/tools/il2cpp/prx_to_elf.py
@@ -30,7 +30,17 @@ def main(src, dst):
     struct.pack_into("<H", buf, 0x10, 3)       # e_type = ET_DYN
     struct.pack_into("<Q", buf, 0x20, 0x40)    # e_phoff
     struct.pack_into("<Q", buf, 0x28, 0)       # e_shoff = 0
-    struct.pack_into("<H", buf, 0x3c, e_phnum)
+    # The flattened image has no section header table, so all three fields describing one have to
+    # say so together. e_shoff is zeroed above; the values the source module carries describe a
+    # table that is not in this file (stripped PS5 modules keep stale ones — across 22 title
+    # modules e_shoff is always a past-EOF offset, e_shstrndx is always 41-46, and e_shnum is
+    # 0 or 43-48). Either survivor makes binutils reject the whole file with "file format not
+    # recognized"; both must be cleared, and clearing only one is not enough.
+    # e_phnum at 0x38 needs NO write: it survives the verbatim header copy above, and the loop
+    # below emits exactly that many program headers. Writing it to 0x3c — the e_shnum slot — was
+    # the bug in #2016.
+    struct.pack_into("<H", buf, 0x3c, 0)       # e_shnum = 0
+    struct.pack_into("<H", buf, 0x3e, 0)       # e_shstrndx = SHN_UNDEF
     for i, p in enumerate(phdrs):              # p_offset := p_vaddr for every phdr
         struct.pack_into("<IIQQQQQQ", buf, 0x40+i*56, p[0], p[1], p[3], p[3], p[4], p[5], p[6], p[7])
     open(dst, "wb").write(buf)

--- a/prosper/tools/il2cpp/test_prx_to_elf.py
+++ b/prosper/tools/il2cpp/test_prx_to_elf.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Header regression for prx_to_elf.py — the flattened ELF's own bytes, at their ELF64 offsets.
+
+Every assertion below reads the produced FILE at a fixed offset. Nothing here trusts a value the
+converter returns or prints, because the whole class of bug this guards (#2016: the program-header
+count written into the section-header-count slot) is invisible to anything that does not look at
+where the bytes landed.
+
+The synthetic SELF is built so each expected value is distinct from every wrong value a plausible
+mutation would leave behind. Each check names the mutation it kills.
+"""
+
+import os
+import struct
+import subprocess
+import sys
+import tempfile
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOOL = os.path.join(HERE, "prx_to_elf.py")
+
+# ELF64 header field offsets (System V gABI). The two that #2016 confused are 0x38 and 0x3c.
+E_IDENT, E_TYPE, E_PHOFF, E_SHOFF = 0x00, 0x10, 0x20, 0x28
+E_EHSIZE, E_PHENTSIZE, E_PHNUM = 0x34, 0x36, 0x38
+E_SHENTSIZE, E_SHNUM, E_SHSTRNDX = 0x3a, 0x3c, 0x3e
+
+PT_LOAD, PT_NOTE = 1, 4
+
+# Deliberately distinct so no two can be confused for one another in a failure message:
+SRC_PHNUM = 4          # program headers in the synthetic module
+SRC_SHNUM = 0x2a       # stale section count in the source header
+SRC_SHSTRNDX = 0x2b    # stale .shstrtab index (real modules carry 0x29-0x2e; 22 checked for #2016)
+SRC_SHOFF = 0x1232D528  # stale, past EOF — exactly what PPSA24651's IL2CPP PRX carries
+SRC_ETYPE = 0xFE18     # Sony's OS-specific module type
+
+SEG0_VADDR, SEG0_FILESZ = 0x0000, 0x100
+SEG2_VADDR, SEG2_FILESZ = 0x2000, 0x080
+EXPECT_SIZE = SEG2_VADDR + SEG2_FILESZ
+
+
+def build_selfish_module():
+    """A minimal PS5-shaped SELF: header, segment table, embedded ELF, then the segment payloads.
+
+    Only the parts prx_to_elf.py actually reads are modelled — nseg at 0x18, a 32-byte segment
+    table at 0x20, and an embedded ELF image located by its magic.
+    """
+    nseg = 2
+    seg_table_end = 0x20 + nseg * 32
+    elf_base = 0x200                      # after the segment table, magic-searchable
+    payload0_off = 0x1000
+    payload2_off = 0x2000
+
+    buf = bytearray(payload2_off + SEG2_FILESZ)
+    struct.pack_into("<H", buf, 0x18, nseg)
+    assert seg_table_end <= elf_base
+
+    # SELF segment entries: (flags, file_offset, file_size, mem_size). Bit 0x800 marks a data
+    # segment; the target program header index is flags >> 20. Map phdr 0 and phdr 2 — phdr 1 is
+    # not PT_LOAD and phdr 3 is bss-only; both must be carried through untouched.
+    struct.pack_into("<QQQQ", buf, 0x20 + 0 * 32,
+                     (0 << 20) | 0x800, payload0_off, SEG0_FILESZ, SEG0_FILESZ)
+    struct.pack_into("<QQQQ", buf, 0x20 + 1 * 32,
+                     (2 << 20) | 0x800, payload2_off, SEG2_FILESZ, SEG2_FILESZ)
+
+    # Embedded ELF header, with the stale section-table fields a stripped PS5 module really carries.
+    buf[elf_base:elf_base + 16] = bytes([0x7F, ord('E'), ord('L'), ord('F'), 2, 1, 1, 9, 2,
+                                         0, 0, 0, 0, 0, 0, 0])
+    struct.pack_into("<H", buf, elf_base + E_TYPE, SRC_ETYPE)
+    struct.pack_into("<H", buf, elf_base + 0x12, 62)          # e_machine = EM_X86_64
+    struct.pack_into("<I", buf, elf_base + 0x14, 1)           # e_version
+    struct.pack_into("<Q", buf, elf_base + E_PHOFF, 0x40)
+    struct.pack_into("<Q", buf, elf_base + E_SHOFF, SRC_SHOFF)
+    struct.pack_into("<H", buf, elf_base + E_EHSIZE, 64)
+    struct.pack_into("<H", buf, elf_base + E_PHENTSIZE, 56)
+    struct.pack_into("<H", buf, elf_base + E_PHNUM, SRC_PHNUM)
+    struct.pack_into("<H", buf, elf_base + E_SHENTSIZE, 64)
+    struct.pack_into("<H", buf, elf_base + E_SHNUM, SRC_SHNUM)
+    struct.pack_into("<H", buf, elf_base + E_SHSTRNDX, SRC_SHSTRNDX)
+
+    # Program headers: p_type, p_flags, p_offset, p_vaddr, p_paddr, p_filesz, p_memsz, p_align.
+    # p_offset is deliberately unequal to p_vaddr — making them equal is the converter's job.
+    # phdr 1 is a non-PT_LOAD header (PT_NOTE rather than PT_DYNAMIC only so binutils will parse
+    # the synthetic image at all — the converter treats every non-PT_LOAD type identically).
+    # phdr 3 is a bss-only PT_LOAD: carried through, but it must not extend the written image.
+    phdrs = [
+        (PT_LOAD, 5, 0x0400, SEG0_VADDR, 0x11, SEG0_FILESZ, SEG0_FILESZ, 0x1000),
+        (PT_NOTE, 6, 0x0500, 0x1500,     0x22, 0x40,        0x40,        8),
+        (PT_LOAD, 6, 0x0600, SEG2_VADDR, 0x33, SEG2_FILESZ, SEG2_FILESZ, 0x1000),
+        (PT_LOAD, 6, 0x0700, 0x3000,     0x44, 0,           0x100,       0x1000),
+    ]
+    assert len(phdrs) == SRC_PHNUM
+    for i, p in enumerate(phdrs):
+        struct.pack_into("<IIQQQQQQ", buf, elf_base + 0x40 + i * 56, *p)
+
+    # Payload bytes, distinguishable per segment.
+    buf[payload0_off:payload0_off + SEG0_FILESZ] = bytes([0xA5]) * SEG0_FILESZ
+    buf[payload2_off:payload2_off + SEG2_FILESZ] = bytes([0x5A]) * SEG2_FILESZ
+    return bytes(buf), phdrs
+
+
+def u16(b, off):
+    return struct.unpack_from("<H", b, off)[0]
+
+
+def u64(b, off):
+    return struct.unpack_from("<Q", b, off)[0]
+
+
+def check(ok, label, kills):
+    if not ok:
+        raise AssertionError("%s  [regression for: %s]" % (label, kills))
+
+
+def main():
+    src_bytes, phdrs = build_selfish_module()
+    # ctest hands every case a build-tree scratch root (#1613) precisely so tests stay off this
+    # machine's tmpfs; fall back to the system temp dir when run standalone.
+    scratch = os.environ.get("PROSPER_TEST_SCRATCH_DIR")
+    if scratch:
+        os.makedirs(scratch, exist_ok=True)
+    tmp = tempfile.mkdtemp(prefix="prx_to_elf_test_", dir=scratch or None)
+    src = os.path.join(tmp, "synthetic.prx")
+    dst = os.path.join(tmp, "synthetic.elf")
+    with open(src, "wb") as fh:
+        fh.write(src_bytes)
+
+    proc = subprocess.run([sys.executable, TOOL, src, dst],
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    if proc.returncode != 0:
+        raise AssertionError("prx_to_elf.py failed (%d): %s"
+                             % (proc.returncode, proc.stdout.decode("utf-8", "replace")))
+
+    with open(dst, "rb") as fh:
+        out = fh.read()
+
+    check(len(out) == EXPECT_SIZE,
+          "image size %#x, want %#x" % (len(out), EXPECT_SIZE),
+          "image sized from something other than max(p_vaddr + p_filesz) over PT_LOAD")
+
+    check(out[0:4] == b"\x7fELF", "no ELF magic at offset 0",
+          "the verbatim 64-byte header copy going missing")
+
+    # --- the #2016 pair. These two offsets are four bytes apart and mean unrelated things. ---
+    check(u16(out, E_PHNUM) == SRC_PHNUM,
+          "e_phnum@0x38 = %d, want %d" % (u16(out, E_PHNUM), SRC_PHNUM),
+          "e_phnum zeroed or clobbered — including a 'fix' that moves the zero write to 0x38")
+    check(u16(out, E_SHNUM) == 0,
+          "e_shnum@0x3c = %d, want 0" % u16(out, E_SHNUM),
+          "#2016: e_phnum written into e_shnum (would read %d), or the write dropped entirely "
+          "(would read %d)" % (SRC_PHNUM, SRC_SHNUM))
+    check(u16(out, E_SHSTRNDX) == 0,
+          "e_shstrndx@0x3e = %d, want 0" % u16(out, E_SHSTRNDX),
+          "the source module's stale .shstrtab index (%d) surviving the copy — binutils reports "
+          "'<corrupt: out of range>' and refuses the file" % SRC_SHSTRNDX)
+    check(u64(out, E_SHOFF) == 0,
+          "e_shoff@0x28 = %#x, want 0" % u64(out, E_SHOFF),
+          "the source module's stale section-table offset (%#x, past EOF) surviving" % SRC_SHOFF)
+
+    # --- fields the three above have to stay consistent with ---
+    check(u64(out, E_PHOFF) == 0x40,
+          "e_phoff@0x20 = %#x, want 0x40" % u64(out, E_PHOFF),
+          "phdr table relocated in the header but not in the file, or vice versa")
+    check(u16(out, E_TYPE) == 3,
+          "e_type@0x10 = %#x, want 3 (ET_DYN)" % u16(out, E_TYPE),
+          "Sony's OS-specific e_type (%#x) reaching a consumer that only knows ET_DYN" % SRC_ETYPE)
+    check(u16(out, E_EHSIZE) == 64 and u16(out, E_PHENTSIZE) == 56,
+          "e_ehsize/e_phentsize = %d/%d, want 64/56" % (u16(out, E_EHSIZE), u16(out, E_PHENTSIZE)),
+          "a header/phdr stride that disagrees with the 0x40 + i*56 layout actually written")
+    # e_shentsize is intentionally NOT rewritten: with e_shoff == 0 and e_shnum == 0 it describes
+    # nothing, and binutils accepts the file either way (checked with 0 and 64 on the real
+    # PPSA24651 module). Pinned so a future change to it is a deliberate one.
+    check(u16(out, E_SHENTSIZE) == 64,
+          "e_shentsize@0x3a = %d, want 64 (carried through)" % u16(out, E_SHENTSIZE),
+          "an undiscussed change to e_shentsize")
+
+    # --- program headers: p_offset must equal p_vaddr, everything else carried through ---
+    for i, p in enumerate(phdrs):
+        got = struct.unpack_from("<IIQQQQQQ", out, 0x40 + i * 56)
+        want = (p[0], p[1], p[3], p[3], p[4], p[5], p[6], p[7])
+        check(got == want,
+              "phdr[%d] = %r, want %r" % (i, got, want),
+              "p_offset not forced to p_vaddr, or a non-PT_LOAD phdr dropped/reordered")
+
+    # --- payload placement: each mapped SELF data segment must land at its p_vaddr ---
+    # The rewritten ELF header + phdr table deliberately overwrite the head of the first segment
+    # (they occupy the same addresses in the source module), so check from just past the table.
+    hdr_end = 0x40 + SRC_PHNUM * 56
+    check(out[hdr_end:SEG0_VADDR + SEG0_FILESZ] == bytes([0xA5]) * (SEG0_FILESZ - hdr_end),
+          "phdr-0 payload missing at its p_vaddr",
+          "the SELF flags>>20 -> phdr index mapping breaking")
+    check(out[SEG2_VADDR:SEG2_VADDR + SEG2_FILESZ] == bytes([0x5A]) * SEG2_FILESZ,
+          "phdr-2 payload missing at its p_vaddr",
+          "a non-zero phdr index in the SELF segment table being mis-decoded")
+
+    # --- differential arm: binutils is the consumer #2016 was actually reported against. ---
+    # This arm is only meaningful if the installed binutils can tell the two headers apart, so it
+    # carries its own control: the same image with the #2016 header written back in. A run where
+    # binutils accepts or rejects BOTH proves nothing about our fix and is reported VOID rather
+    # than passed or failed — an arm that cannot show its lever moved is not evidence.
+    control = bytearray(out)
+    struct.pack_into("<H", control, E_SHNUM, SRC_PHNUM)        # what master wrote here
+    struct.pack_into("<H", control, E_SHSTRNDX, SRC_SHSTRNDX)  # left over from the source module
+    ctl = os.path.join(tmp, "control-2016.elf")
+    with open(ctl, "wb") as fh:
+        fh.write(control)
+
+    def objdump_ok(path):
+        try:
+            r = subprocess.run(["objdump", "-f", path],
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        except OSError:
+            return None, ""
+        return (r.returncode == 0 and
+                b"file format elf64-x86-64" in r.stdout), r.stdout.decode("utf-8", "replace")
+
+    fixed_ok, fixed_text = objdump_ok(dst)
+    control_ok, _ = objdump_ok(ctl)
+    if fixed_ok is None:
+        print("objdump arm: VOID — binutils not on PATH; the byte checks above are the gate")
+    else:
+        check(fixed_ok,
+              "objdump rejected the flattened image: %s" % fixed_text.strip(),
+              "any header inconsistency binutils refuses outright")
+        if control_ok:
+            print("objdump arm: VOID — this binutils accepts the #2016 header too, so acceptance "
+                  "of ours discriminates nothing; the byte checks above are the gate")
+        else:
+            print("objdump arm: RAN and DISCRIMINATED — accepts the fixed header, "
+                  "rejects the #2016 header")
+
+    for f in (src, dst, ctl):
+        os.unlink(f)
+    os.rmdir(tmp)
+    print("prx_to_elf header regression: PASS")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #2016
Refs #2154

## What was wrong

`tools/il2cpp/prx_to_elf.py` flattens an unencrypted PS5 SELF into a plain ET_DYN ELF with program
headers and **no section header table**. It copied the source module's 64-byte ELF header verbatim,
zeroed `e_shoff`, and then wrote the program-header count to offset **`0x3c`**. In ELF64 `0x3c` is
`e_shnum`; `e_phnum` is `0x38`.

Field by field, on the `PPSA24651` IL2CPP module (binutils 2.46, `readelf -h`):

| offset | field | source module | master's output | correct | why |
| --- | --- | --- | --- | --- | --- |
| `0x28` | `e_shoff` | `0x1232d528` (past EOF) | `0` | `0` | already right — no section table |
| `0x38` | `e_phnum` | `14` | `14` | `14` | **already right, and needs no write** |
| `0x3a` | `e_shentsize` | `64` | `64` | `64` (unchanged) | describes nothing when `e_shoff == 0`; binutils accepts `0` or `64` |
| `0x3c` | `e_shnum` | `0` | **`14`** | `0` | N section headers claimed at offset 0 |
| `0x3e` | `e_shstrndx` | `43` | **`43`** | `0` | index into a table that does not exist |

**`e_phnum` was not missing — it was only misplaced.** It survives the verbatim header copy
(`buf[0:64] = f[eb:eb+64]`), and the loop below writes exactly `e_phnum` program headers, so the
write at `0x3c` was pure damage. That is established from the code path and pinned by a test arm:
mutating the fix to write the zero at `0x38` instead fails on `e_phnum@0x38 = 0, want 4`.

## What the fix is, and why it is two fields rather than one

#2016 suggested writing `0` to `e_shnum` and stopping. That alone does not make the file readable.
A/B over all four combinations, `objdump -f` on the real flattened `PPSA24651` module:

| `e_shnum` | `e_shstrndx` | objdump |
| --- | --- | --- |
| 14 | 43 | REJECT (what master produces) |
| 0 | 43 | REJECT (#2016's suggested fix) |
| 14 | 0 | REJECT |
| **0** | **0** | **ACCEPT** |

So both are cleared. `e_shentsize` is deliberately left alone: with `e_shoff == 0` and
`e_shnum == 0` it describes nothing, binutils accepts the file with either `0` or `64`, and leaving
it faithful to the source module keeps the diff to the fields that are actually wrong. The test
pins its current value so a future change to it is a deliberate one.

### Ruled out, and recorded in `tools/il2cpp/README.md`

#2016's closing note said binutils would *still* refuse the file until `e_ident[EI_OSABI]` /
`[EI_ABIVERSION]` (`0x09 0x02`, FreeBSD) were also cleared, and suggested an opt-in `--gnu-compat`
flag for it. **That is false.** binutils 2.46 accepts the flattened image with those bytes intact —
the fifth row of the A/B above, `(0, 0)` with OSABI cleared, is also ACCEPT, i.e. OSABI changes
nothing either way. The blocker was `e_shstrndx`. No flag is needed, and the falsification is in
the README's new `### Ruled out` section so nobody builds one.

## Scope: what this does NOT fix

binutils now **accepts** the file — `objdump -f`, `objdump -p` and `objdump -T` all work, and `-T`
is a real gain (594 lines of the module's Sony NID dynamic symbols). But `objdump -d` disassembles
*sections*, the image has none, so it prints nothing. #2016's motivating use case — disassembling a
stripped PS5 module without `-D -b binary` — needs synthesized section headers, which is a feature
rather than a malformed-header fix. Filed as #2154 and deliberately not attempted here. The README
now states plainly what binutils can and cannot do with the output.

## Verification

**End-to-end, actually run.** The full documented pipeline on `PPSA24651`: flatten with the fixed
converter, then `Il2CppDumper` (net7 build, `DOTNET_ROLL_FORWARD=LatestMajor`) against the title's
`global-metadata.dat`. It completed — `CodeRegistration : 219c7c0`, `MetadataRegistration :
21e65d0`, `Dumping... Done!` — and wrote `dump.cs` (17.2 MB), `script.json` (36.8 MB, 87,851
methods), `il2cpp.h`, `stringliteral.json` and `DummyDll/`. `resolve.py` symbolicates against the
result. Positive control that the symbols are real rather than merely present: 400 randomly sampled
method RVAs from `script.json`, **400/400 land inside the flattened image's executable `PT_LOAD`**
and 338/400 begin with a recognizable x86-64 prologue.

**Il2CppDumper is unaffected by the bug**, confirming why it went unnoticed: the same run against
the *pre-fix* ELF produces `dump.cs`, `script.json`, `il2cpp.h` and `stringliteral.json` that are
**byte-identical** (`cmp` clean on all four). It reads program headers and the dynamic segment,
never sections. This PR does not change what the IL2CPP pipeline recovers; it fixes the header for
every other consumer.

**Breadth.** 22 real modules from the local dumps — 20 `Il2CppUserAssemblies.prx` plus two
`eboot.bin` including `PPSA26414`, the title #2016 was found on. Every one: fixed output accepted by
objdump, #2016 header rejected. Source `e_shstrndx` is 41–46 on all 22; `e_shnum` is 0 on four and
43–48 on the rest, so on most titles the bug also overwrote a nonzero stale count.

**The whole-file diff is two fields.** `cmp -l` between master's output and the fixed output on the
`PPSA24651` module reports exactly two differing bytes, at file offsets `0x3c` and `0x3e`.

### The test

New: `tools/il2cpp/test_prx_to_elf.py`, registered as ctest `il2cpp_prx_to_elf_header`. It builds a
synthetic PS5-shaped SELF in memory (no game dump, so it runs in CI), invokes the converter as a
subprocess exactly as the README documents, and **reads the produced file's bytes at their gABI
offsets**. It never inspects a value the converter returns or prints — nothing else can see this
class of bug. Expected values are chosen pairwise-distinct (`e_phnum` 4, source `e_shnum` 42, source
`e_shstrndx` 43) so "0" separates the fix from the bug *and* from a dropped write.

Red-without / green-with, run — nine arms, each mutating the tool and re-running the test:

| arm | result | assertion that fired |
| --- | --- | --- |
| M0 fixed (control) | **PASS** | — |
| M1 master's `0x3c, e_phnum` (#2016) | FAIL | `e_shnum@0x3c = 4, want 0` |
| M2 write the zero to `0x38` instead | FAIL | `e_phnum@0x38 = 0, want 4` |
| M3 drop the `e_shstrndx` write | FAIL | `e_shstrndx@0x3e = 43, want 0` |
| M4 drop the `e_shnum` write | FAIL | `e_shnum@0x3c = 42, want 0` |
| M5 drop the `e_shoff` zeroing | FAIL | `e_shoff@0x28 = 0x1232d528, want 0` |
| M6 drop the `e_type` write | FAIL | `e_type@0x10 = 0xfe18, want 3` |
| M7 keep `p_offset` instead of forcing it to `p_vaddr` | FAIL | `phdr[0] = (…,1024,0,…), want (…,0,0,…)` |
| M8 emit one fewer program header | FAIL | `phdr[3] = (0xa5a5…), want (1,6,12288,…)` |

The binutils arm carries its own control: the same image with the #2016 header written back in. It
reports **RAN and DISCRIMINATED** only when objdump accepts the fixed header *and* rejects the
control; if the installed binutils accepts both, or is absent, the arm prints VOID and the byte
checks are the gate. The control is patched byte-by-byte rather than produced by the generator under
test, so it can express the case being tested for.

## Commands and results

```
python3 prosper/tools/il2cpp/test_prx_to_elf.py
  -> objdump arm: RAN and DISCRIMINATED — accepts the fixed header, rejects the #2016 header
  -> prx_to_elf header regression: PASS      (rc=0)

cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0     (rc=0)
ctest -R il2cpp_prx_to_elf_header -V
  -> 1/1 Test #6: il2cpp_prx_to_elf_header ......... Passed  0.04 sec   (rc=0)

python3 prosper/tools/docs/check_numbered_table.py prosper/tools/il2cpp/README.md   (rc=0)
git diff --check                                                                    (clean)
```

No compiled sources are touched, so no full build or snapshot run applies; the diff is a Python
tool, its new test, one `add_test()` and the tool's README. `PROSPER_TEST_SCRATCH_DIR` is honored so
the test stays off this machine's tmpfs (#1613), falling back to the system temp dir standalone.

## Risk

Low and bounded. The converter's output changes by exactly two header bytes; the IL2CPP pipeline's
output is proven byte-identical across the change on a real title. The one judgment call is leaving
`e_shentsize` at the source value — pinned by the test, and reversible without affecting anything
that reads the file today.
