### PR TITLE
fix(agc): bound the Set*RegsIndirect address/count patchers to their own packets

### DIFF
--- a/prosper/docs/GUEST_INPUT_SAFETY.md
+++ b/prosper/docs/GUEST_INPUT_SAFETY.md
@@ -24,6 +24,23 @@ and reviewers know what the invariants are.
   bulk read from it (used across the GPU command processor / executor / compute paths). A packet- or
   descriptor-supplied pointer is validated for exactly the bytes touched before the copy (see #1200 /
   #1202 for the two command-processor readers that were missing it).
+- **`guest_writable(addr, bytes)`** — the same question for a *store*, and the one to use in front of
+  one. **`guest_readable` is not a substitute:** it accepts a read-only mapping (Linux/macOS probe by
+  having the kernel read the byte; Windows explicitly accepts `PAGE_READONLY`/`PAGE_WRITECOPY`/
+  `PAGE_EXECUTE_READ`), so a read probe in front of a write proves the wrong property and the store
+  then faults on a page the probe just called fine — the guest module's own `.text`/`.rodata` are large
+  read-only mappings in the same address space. That was a real defect in #1637 as merged, fixed by
+  #1654.
+  **Cost, and what to do on a hot path:** `guest_writable` is **uncached**, and on Linux it `fopen`s
+  and parses `/proc/self/maps` on **every** call — unlike `guest_readable`, which has a thread-local
+  range cache. So it must not be dropped into a per-draw path. Do **not** resolve that by switching
+  back to `guest_readable` (wrong predicate, above — and its cache consults `submit_ranges` only
+  inside a renderer submit scope, which the DCB-build path is not). Prefer an **arithmetic answer to
+  the question actually being asked**: `hle_agc.cpp`'s DCB ring registry (#1650) remembers the
+  `[bottom, top)` extent each command packet was built into, so a patcher validates the pointer the
+  guest hands back by range compare, and only misses fall through to the probe. Structure such a cache
+  as a pure accelerator — a hit skips the probe, a miss falls back — so the safety argument rests on
+  the predicate and never on the cache.
 - **`rd<T>(file, off)`** (`src/self/module.cpp`) — bounded structured read: gates the `memcpy` on
   `self_read_ok` and zero-fills a `T{}` on an out-of-range offset. Every SELF/ELF header/table read goes
   through it; a raw `reinterpret_cast`/`memcpy` into `file.data() + off` is a red flag.

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -209,6 +209,57 @@ struct AgcDcb {
     }
 };
 
+// --- Known DCB ring extents, so a packet patcher can validate its target without a syscall (#1650).
+//
+// The Set*RegsIndirect patchers are handed a pointer the guest got back from prosper's OWN builder
+// and they STORE through it. The correct predicate for that is gpu::guest_writable — but it is
+// UNCACHED, and on Linux it fopen()s and parses /proc/self/maps on EVERY call, while these patchers
+// run per draw (Blue Prince assembles its register arrays incrementally: record num=0, then
+// PatchSetAddress + PatchAddRegisters — see command_processor.hpp's #1264 note). guest_readable is
+// cheaper but is the WRONG predicate in front of a store (#1654: a read-only mapping passes it and
+// then faults), and its thread-local range cache only consults submit_ranges while a renderer submit
+// scope is active, which the DCB-build path is not.
+//
+// So remember the ring each such packet is built into. A pointer inside a remembered [bottom, top)
+// with room for the whole packet is memory this file allocated from the guest's own command buffer
+// and has already written a header into, so it is mapped and writable and no probe is needed.
+//
+// This registry is ONLY an accelerator: a hit skips a probe, a miss falls through to guest_writable.
+// It can never cause a refusal that guest_writable would not also cause, which is what keeps the
+// safety argument on the predicate rather than on the cache. Its one false-accept mode is a STALE
+// extent — the guest freeing a ring between building a packet and patching it, which would be a
+// guest bug, since it is about to submit that ring — and on that path the behaviour is exactly what
+// master does today with no check at all, so the residual risk is a strict subset of the status quo.
+//
+// Per-thread, for the reason given above for g_dcb_diag_r: a Dcb is built by one thread, and a
+// shared global would let one thread's ring vouch for another's pointer. A cross-thread patch simply
+// misses and takes the probe path, which is correct, merely slower.
+constexpr size_t kDcbExtentSlots = 4;
+struct DcbExtent { uintptr_t bottom = 0, top = 0; };
+inline thread_local DcbExtent g_dcb_extents[kDcbExtentSlots];
+inline thread_local uint32_t g_dcb_extent_next = 0;
+// How many patcher calls missed the registry and paid for the OS write probe. The registry's whole
+// purpose is to keep this at zero on the hot path, and a performance property nobody can observe is
+// one that regresses silently — so it is exported (prosper_agc_patch_probe_count) for tests.
+inline std::atomic<uint64_t> g_patch_probe_calls{0};
+
+inline void remember_dcb_extent(const AgcDcb* dcb) {
+    if (!dcb || !dcb->bottom || dcb->top <= dcb->bottom) return;
+    const auto bottom = (uintptr_t)dcb->bottom, top = (uintptr_t)dcb->top;
+    for (const auto& e : g_dcb_extents)
+        if (e.bottom == bottom && e.top == top) return;      // already known; the common case
+    g_dcb_extents[g_dcb_extent_next] = DcbExtent{bottom, top};
+    g_dcb_extent_next = (g_dcb_extent_next + 1u) % (uint32_t)kDcbExtentSlots;
+}
+// True when [p, p+bytes) lies wholly inside a remembered ring. The whole-packet requirement matters:
+// a pointer near the ring's end whose packet would run off the top is not one of our packets.
+inline bool in_known_dcb(uintptr_t p, size_t bytes) {
+    if (!p || !bytes) return false;
+    for (const auto& e : g_dcb_extents)
+        if (e.bottom && p >= e.bottom && p < e.top && (size_t)(e.top - p) >= bytes) return true;
+    return false;
+}
+
 const char* dcb_subop_name(uint32_t r) {
     switch (r) {
         case R_DRAW_INDEX:                 return "DrawIndex";
@@ -334,20 +385,66 @@ inline uint32_t* begin_packet(uint64_t buf, uint32_t n, uint32_t op, uint32_t r,
     return cmd;
 }
 
+// Diagnostic budget for a refused patch, keyed by CALL SITE (#1650).
+//
+// This used to be one `static std::atomic<int>` inside patch_check, i.e. a single 8-message budget
+// shared by every patcher family in this translation unit. Eight refusals anywhere spent it for
+// everyone, so the first refusal of a family that started misbehaving later was silent — and a guest
+// write prosper declines without saying so is exactly the failure the charter's fail-visible rule
+// exists to prevent. `who` is a distinct string literal per patcher, so its address identifies the
+// call site and every future call site gets its own budget without anyone remembering to add one.
+// Only reached when a patch is actually refused, so it is off every hot path.
+inline bool patch_budget_ok(const char* who) {
+    struct Slot { std::atomic<const char*> who{nullptr}; std::atomic<int> n{0}; };
+    static Slot slots[16];
+    static std::atomic<int> overflow{0};
+    for (auto& s : slots) {
+        const char* cur = s.who.load(std::memory_order_acquire);
+        if (!cur) {
+            const char* expect = nullptr;
+            // Whoever wins the CAS owns the slot; the loser reads back the winner's `who` and
+            // either matches it or moves on to the next slot.
+            cur = s.who.compare_exchange_strong(expect, who, std::memory_order_acq_rel) ? who : expect;
+        }
+        if (cur == who) return s.n.fetch_add(1, std::memory_order_relaxed) < 8;
+    }
+    return overflow.fetch_add(1, std::memory_order_relaxed) < 8;   // more call sites than slots
+}
+
 // Verify a to-be-patched packet's own header sub-op before writing — a mismatch means the RE
-// drifted, so log loudly (once) and refuse to corrupt the stream. Shared by the sync-packet
-// address patchers (#213/#222) and SetPacketPredication (#319).
+// drifted, so log loudly and refuse to corrupt the stream. Shared by the sync-packet address
+// patchers (#213/#222), SetPacketPredication (#319) and the indirect-register family (#1650).
 inline bool patch_check(uint32_t* cmd, uint32_t want_r, const char* who) {
     uint32_t r = (cmd[0] >> 2) & (R_NUM - 1u), op = (cmd[0] >> 8) & 0xffu;
     if (op == IT_NOP && r == want_r) return true;
-    static std::atomic<int> logged{0};
-    if (logged.fetch_add(1) < 8)
+    if (patch_budget_ok(who))
         fprintf(stderr, "[agc] %s: header 0x%08x is not the expected packet (op=0x%x r=0x%x want r=0x%x) — patch refused\n",
                 who, cmd[0], op, r, want_r);
     return false;
 }
 
+// May `cmd` be dereferenced AND stored to for `bytes`? Answer from the DCB ring registry first (a
+// range compare, no syscall), and only probe the OS when the pointer is not in a ring we built into.
+// The probe is the WRITE predicate deliberately: every caller of this stores, and guest_readable
+// accepts a read-only mapping that would then fault (#1654). A refusal is always reported.
+inline bool patch_target_writable(uint64_t cmd_addr, size_t bytes, const char* who) {
+    if (in_known_dcb((uintptr_t)cmd_addr, bytes)) return true;
+    g_patch_probe_calls.fetch_add(1, std::memory_order_relaxed);
+    if (gpu::guest_writable(cmd_addr, (uint32_t)bytes)) return true;
+    if (patch_budget_ok(who))
+        fprintf(stderr, "[agc] %s: packet 0x%llx (%zu bytes) is not writable guest memory — patch refused\n",
+                who, (unsigned long long)cmd_addr, bytes);
+    return false;
+}
+
 }  // namespace
+
+// Test/diagnostic accessor for the #1650 registry: how many patcher calls missed the known-ring
+// registry and paid for an OS write probe. Zero growth across a draw is the property the registry
+// exists to provide, and this is what lets a test assert it instead of assuming it.
+extern "C" uint64_t prosper_agc_patch_probe_count() {
+    return g_patch_probe_calls.load(std::memory_order_relaxed);
+}
 
 // --- Dcb append functions (a0 = Dcb*, return = the allocated packet pointer). ------------------
 HLE(agc_dcb_reset_queue) {  // (buf, op=0x3ff, state=0)
@@ -433,6 +530,10 @@ HLE(agc_dcb_set_sh_register_direct) { return set_register_direct(a0, a1, IT_SET_
 HLE(agc_dcb_set_uc_register_direct) { return set_register_direct(a0, a1, IT_SET_UCONFIG_REG); }
 static uint64_t set_regs_indirect(uint64_t buf, uint64_t regs, uint64_t num_regs, uint32_t r) {
     uint32_t* cmd; if (!begin_packet(buf, kDwSetRegsIndirect, IT_NOP, r, &cmd)) return 0;
+    // Remember which ring this packet lives in, so the matching patchers can validate the pointer
+    // the guest hands back to them by range compare instead of a per-draw /proc/self/maps parse
+    // (#1650). Recorded after begin_packet succeeded, so the extent is one we really allocated from.
+    remember_dcb_extent((const AgcDcb*)(uintptr_t)buf);
     cmd[1] = (uint32_t)num_regs; cmd[2] = (uint32_t)(regs & 0xffffffffu); cmd[3] = (uint32_t)(regs >> 32u);
     // PROSPER_REGBLOAT (#1264): record-time provenance for the register-array bloat investigation —
     // correlate each packet's ORIGINAL count with later PatchAddRegisters growth and the fold-time
@@ -2290,27 +2391,75 @@ HLE(agc_driver_submit_acb) {  // sceAgcDriverSubmitAcb(queue, const AcbPacket*, 
 
 // --- Indirect-register patch helpers: modify a packet returned by a Set*RegsIndirect call.
 // cmd = a0 (that returned pointer). Old stub returned 0 for Set*RegsIndirect -> these wrote to null. -
-HLE(agc_patch_set_address) {  // (cmd, regs): cmd[2..3] = regs vaddr
-    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+//
+// Both of these take a caller-supplied pointer and STORE through it, and both used to do so behind
+// nothing but a null check (#1650). Two things follow from what the pointer actually is:
+//
+//   * The packet layout they patch (cmd[1] = count, cmd[2..3] = array vaddr, header
+//     PM4(4, IT_NOP, R_{CX,SH,UC}_REGS_INDIRECT)) is PROSPER'S OWN. The guest can only have obtained
+//     a legitimate `cmd` as the return value of this file's Set*RegsIndirect builder, so a genuine
+//     target always carries that header and always sits in a ring we built into. Anything else is a
+//     wrapped, aliased or stale builder pointer, and writing to it corrupts unrelated
+//     command-buffer or heap memory silently — 64 bits of it, at a distance, with no log.
+//   * Which of the three register classes the guest called is only knowable from the NID, not from
+//     the arguments, so the class check needs per-class handlers. That is why these are split the
+//     way #1637 split PatchSetNumRegisters rather than left as one shared handler.
+//
+// So: probe for writability (through the ring registry, so no syscall on the per-draw path), then
+// verify the packet's own header sub-op, then write. Both refusals are logged on a per-call-site
+// budget. CONFIDENCE: HIGH — the packet layout, the builder and the patcher are all prosper's.
+static uint64_t patch_set_address(uint64_t cmd_addr, uint64_t regs, uint32_t want_r,
+                                  const char* who) {
+    auto* cmd = (uint32_t*)(uintptr_t)cmd_addr; if (!cmd) return 0;
+    if (!patch_target_writable(cmd_addr, kDwSetRegsIndirect * sizeof(uint32_t), who)) return 0;
+    // Report before the early return, and report the refusal too: an investigation into a register
+    // array that points at the wrong place most wants the case where the patch did not land.
     static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    const bool ok = patch_check(cmd, want_r, who);
     if (regbloat) {
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 96)
-            fprintf(stderr, "[regbloat-patch] set_address cmd=%p old=0x%x%08x new=0x%llx num=%u\n",
-                    (void*)cmd, cmd[3], cmd[2], (unsigned long long)a1, cmd[1]);
+            fprintf(stderr, "[regbloat-patch] set_address cmd=%p hdr=0x%08x old=0x%x%08x new=0x%llx num=%u%s\n",
+                    (void*)cmd, cmd[0], cmd[3], cmd[2], (unsigned long long)regs, cmd[1],
+                    ok ? "" : " REFUSED");
     }
-    cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u); return 0;
+    if (!ok) return 0;
+    cmd[2] = (uint32_t)(regs & 0xffffffffu); cmd[3] = (uint32_t)(regs >> 32u);
+    return 0;
 }
-HLE(agc_patch_add_registers) {  // (cmd, num_regs): cmd[1] += num_regs
-    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+static uint64_t patch_add_registers(uint64_t cmd_addr, uint64_t num, uint32_t want_r,
+                                    const char* who) {
+    auto* cmd = (uint32_t*)(uintptr_t)cmd_addr; if (!cmd) return 0;
+    if (!patch_target_writable(cmd_addr, kDwSetRegsIndirect * sizeof(uint32_t), who)) return 0;
     static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
+    const bool ok = patch_check(cmd, want_r, who);
     if (regbloat) {
         static std::atomic<int> n{0};
         if (n.fetch_add(1) < 96)
-            fprintf(stderr, "[regbloat-patch] add_registers cmd=%p old_num=%u add=%u\n",
-                    (void*)cmd, cmd[1], (uint32_t)a1);
+            fprintf(stderr, "[regbloat-patch] add_registers cmd=%p hdr=0x%08x old_num=%u add=%u%s\n",
+                    (void*)cmd, cmd[0], cmd[1], (uint32_t)num, ok ? "" : " REFUSED");
     }
-    cmd[1] += (uint32_t)a1; return 0;
+    if (!ok) return 0;
+    cmd[1] += (uint32_t)num;
+    return 0;
+}
+HLE(agc_patch_set_address_cx) {  // (cmd, regs): cmd[2..3] = regs vaddr
+    return patch_set_address(a0, a1, R_CX_REGS_INDIRECT, "SetCxRegIndirectPatchSetAddress");
+}
+HLE(agc_patch_set_address_sh) {
+    return patch_set_address(a0, a1, R_SH_REGS_INDIRECT, "SetShRegIndirectPatchSetAddress");
+}
+HLE(agc_patch_set_address_uc) {
+    return patch_set_address(a0, a1, R_UC_REGS_INDIRECT, "SetUcRegIndirectPatchSetAddress");
+}
+HLE(agc_patch_add_registers_cx) {  // (cmd, num_regs): cmd[1] += num_regs
+    return patch_add_registers(a0, a1, R_CX_REGS_INDIRECT, "SetCxRegIndirectPatchAddRegisters");
+}
+HLE(agc_patch_add_registers_sh) {
+    return patch_add_registers(a0, a1, R_SH_REGS_INDIRECT, "SetShRegIndirectPatchAddRegisters");
+}
+HLE(agc_patch_add_registers_uc) {
+    return patch_add_registers(a0, a1, R_UC_REGS_INDIRECT, "SetUcRegIndirectPatchAddRegisters");
 }
 
 // sceAgcSet{Cx,Sh,Uc}RegIndirectPatchSetNumRegisters — SET, not accumulate, the register count of a
@@ -2356,18 +2505,14 @@ static uint64_t patch_set_num_registers(uint64_t cmd_addr, uint64_t num, uint32_
     // just called fine — the module's own .text/.rodata are large read-only mappings in this same
     // address space. guest_writable covers the freed/unmapped case as well.
     //
-    // COST CAVEAT, do not copy this call verbatim onto a hot path: guest_writable is UNCACHED, and
-    // on Linux it fopen()s and parses /proc/self/maps on every call — unlike guest_readable, which
-    // has a thread-local range cache. That is harmless here because no measured title calls these
-    // NIDs at all, but the sibling patchers (#1650) run per draw on Blue Prince, and tightening
-    // those needs a cached predicate rather than this one.
-    if (!gpu::guest_writable(cmd_addr, 2 * sizeof(uint32_t))) {
-        static std::atomic<int> n{0};
-        if (n.fetch_add(1) < 8)
-            fprintf(stderr, "[agc] %s: packet 0x%llx not writable — patch skipped\n", who,
-                    (unsigned long long)cmd_addr);
-        return 0;
-    }
+    // Since #1650 that probe is reached through patch_target_writable, which answers from the DCB
+    // ring registry first and only calls guest_writable on a miss. The cost caveat that used to sit
+    // here — guest_writable is uncached and fopen()s /proc/self/maps on Linux every call — is why
+    // the whole family now shares one guard instead of this handler having a private one: the
+    // sibling patchers run per draw on Blue Prince, and two different answers to "may I write to
+    // this packet?" inside one family is how the #1650 asymmetry arose in the first place. The
+    // probed span is the whole 4-dword packet, the only shape this family's builder emits.
+    if (!patch_target_writable(cmd_addr, kDwSetRegsIndirect * sizeof(uint32_t), who)) return 0;
     // Report before the early return, and report the refusal too: an investigation into a wrong
     // register count most wants the case where the patch did not land.
     static const bool regbloat = getenv("PROSPER_REGBLOAT") != nullptr;
@@ -2719,9 +2864,11 @@ void register_agc_hle() {
     // that needed its own shifted-ABI handler, so re-check if a title ever trips the reject here).
     RN("eZ4+17OQz4Q", agc_dcb_write_data);        // sceAgcAcbWriteData
     // Indirect-register patch helpers (SetAddress patches cmd[2..3]; AddRegisters patches cmd[1]).
-    RN("vcmNN+AAXnY", agc_patch_set_address);   RN("d-6uF9sZDIU", agc_patch_add_registers);   // Cx
-    RN("Qrj4c+61z4A", agc_patch_set_address);   RN("z2duB-hHQSM", agc_patch_add_registers);   // Sh
-    RN("6lNcCp+fxi4", agc_patch_set_address);   RN("vRoArM9zaIk", agc_patch_add_registers);   // Uc
+    // Per register class, so each patcher can verify the packet's own header sub-op before writing
+    // (#1650) — a single shared handler cannot, because the class is carried by the NID alone.
+    RN("vcmNN+AAXnY", agc_patch_set_address_cx); RN("d-6uF9sZDIU", agc_patch_add_registers_cx); // Cx
+    RN("Qrj4c+61z4A", agc_patch_set_address_sh); RN("z2duB-hHQSM", agc_patch_add_registers_sh); // Sh
+    RN("6lNcCp+fxi4", agc_patch_set_address_uc); RN("vRoArM9zaIk", agc_patch_add_registers_uc); // Uc
     // ...PatchSetNumRegisters: the SET (non-accumulating) count patcher of the same family (#305).
     RN("whb1RL7K4Ss", agc_patch_set_num_registers_cx);   // sceAgcSetCxRegIndirectPatchSetNumRegisters
     RN("nCUgItdN2ms", agc_patch_set_num_registers_sh);   // sceAgcSetShRegIndirectPatchSetNumRegisters

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -234,6 +234,15 @@ struct AgcDcb {
 // Per-thread, for the reason given above for g_dcb_diag_r: a Dcb is built by one thread, and a
 // shared global would let one thread's ring vouch for another's pointer. A cross-thread patch simply
 // misses and takes the probe path, which is correct, merely slower.
+//
+// EVICTION IS FIFO ROUND-ROBIN, NOT LRU/MRU — lookup scans all slots, but insertion overwrites the
+// oldest regardless of use. So a thread cycling through MORE than kDcbExtentSlots live rings can
+// evict a ring it is still patching into and thrash to a near-zero hit rate, paying a probe per
+// call where a smaller working set pays none. That is a PERFORMANCE cliff only — every miss still
+// gets the correct answer from guest_writable — but it is the reason this is sized above the one
+// ring the measured titles use rather than at 1, and the reason the number is stated here rather
+// than tuned silently. If a title is ever seen thrashing it, promote the policy to LRU (move a hit
+// to the front) before growing the array; the scan is linear, so the array cannot grow far.
 constexpr size_t kDcbExtentSlots = 4;
 struct DcbExtent { uintptr_t bottom = 0, top = 0; };
 inline thread_local DcbExtent g_dcb_extents[kDcbExtentSlots];

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -294,14 +294,44 @@ int main() {
               "#1650: out-of-ring pointers DO reach the write probe — so arm1's zero-probe "
               "assertion measures the registry rather than a counter stuck at zero");
 
-        // A shared 8-message budget across every patcher family in the translation unit meant a
-        // family that started misbehaving later refused in silence. Each call site now has its own
-        // budget: four distinct sites reported above even though earlier arms already logged
-        // refusals from the PatchSetNumRegisters sites.
-        CHECK(strstr(log, "SetCxRegIndirectPatchSetAddress") != nullptr &&
-              strstr(log, "SetShRegIndirectPatchAddRegisters") != nullptr,
-              "#1650: per-call-site diagnostic budgets, so one family cannot silence another");
-        if (fails) printf("  captured stderr:\n%s", log);
+        // Arm 5 — the diagnostic budget is PER CALL SITE.
+        //
+        // It used to be a single 8-message counter shared by every patcher family in the
+        // translation unit, so eight refusals anywhere spent it for everyone and the first refusal
+        // of a family that started misbehaving later never printed. That is the same defect class
+        // this issue is about — prosper declining a guest write and saying nothing.
+        //
+        // This arm has to FLOOD one call site past the budget to see it, and that is the whole
+        // point: the arms above produce only eight refusals in total across the entire run, which
+        // is exactly the old shared budget, so every one of them still prints under the old code
+        // and none of them can fail if the budget change is reverted. Counting refusals is not
+        // optional here — a cheaper assertion that merely re-greps two names already checked above
+        // cannot fail independently of the header check.
+        char log2[16384];
+        const bool captured2 = capture_stderr([&] {
+            for (int i = 0; i < 16; ++i)                  // spend this one site's budget outright
+                p_addr(victim_addr, 0xDEADBEEFCAFEBABEull, 0, 0, 0, 0);
+            p_add_sh(victim_addr, 1, 0, 0, 0, 0);         // a DIFFERENT site, still owed a voice
+        }, log2, sizeof log2);
+        CHECK(captured2, "#1650 arm5: stderr capture around the budget flood worked");
+
+        auto occurrences = [](const char* hay, const char* needle) {
+            size_t n = 0;
+            for (const char* p = strstr(hay, needle); p; p = strstr(p + 1, needle)) ++n;
+            return n;
+        };
+        const size_t flooded = occurrences(log2, "SetCxRegIndirectPatchSetAddress");
+        CHECK(flooded > 0 && flooded < 16,
+              "#1650 arm5: a flooded call site is rate-limited — neither silent nor unbounded");
+        CHECK(strstr(log2, "SetShRegIndirectPatchAddRegisters") != nullptr,
+              "#1650 arm5: a DIFFERENT call site still reports after that flood — budgets are per "
+              "call site, so one patcher family can no longer silence another");
+
+        bool victim_still_intact = true;
+        for (const auto& v : victim) victim_still_intact &= (v == 0xA5A5A5A5u);
+        CHECK(victim_still_intact,
+              "#1650 arm5: seventeen refused patches still wrote nothing");
+        if (fails) printf("  captured stderr:\n%s\n  ---- flood ----\n%s", log, log2);
     }
 
     // #395 F5: all three single-register direct NIDs append the native packet opcode and preserve

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -8,6 +8,11 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -44,6 +49,49 @@ struct RegisterDefaults {
 };
 static_assert(offsetof(RegisterDefaults, count) == 0x38);
 extern "C" void* prosper_agc_reg_defaults(unsigned int version);
+// #1650: how many packet-patcher calls missed the DCB ring registry and paid for an OS write probe.
+// The registry exists so the per-draw path never does; without a way to observe it, "no syscall on
+// the hot path" would be an unfalsifiable claim in a comment.
+extern "C" uint64_t prosper_agc_patch_probe_count();
+
+// Capture everything written to stderr while `body` runs. A refused guest write that says nothing
+// is the failure mode #1650 was filed for, so "was it reported" is part of the contract under test,
+// not decoration. Same fd-swap shape as test_service_logging.cpp.
+template <typename F>
+static bool capture_stderr(F&& body, char* out, size_t out_size) {
+    out[0] = '\0';
+    FILE* capture = tmpfile();
+    if (!capture) return false;
+    if (fflush(stderr) != 0) { fclose(capture); return false; }
+#ifdef _WIN32
+    const int fd = _fileno(stderr), saved = _dup(fd);
+    const bool redirected = saved >= 0 && _dup2(_fileno(capture), fd) == 0;
+#else
+    const int fd = fileno(stderr), saved = dup(fd);
+    const bool redirected = saved >= 0 && dup2(fileno(capture), fd) >= 0;
+#endif
+    if (!redirected) {
+#ifdef _WIN32
+        if (saved >= 0) _close(saved);
+#else
+        if (saved >= 0) close(saved);
+#endif
+        fclose(capture);
+        return false;
+    }
+    body();
+    fflush(stderr);
+#ifdef _WIN32
+    const bool restored = _dup2(saved, fd) == 0; _close(saved);
+#else
+    const bool restored = dup2(saved, fd) >= 0; close(saved);
+#endif
+    rewind(capture);
+    const size_t n = fread(out, 1, out_size - 1, capture);
+    out[n] = '\0';
+    fclose(capture);
+    return restored;
+}
 
 int main() {
     printf("== test_agc_dcb ==\n");
@@ -115,9 +163,16 @@ int main() {
     auto p_num_uc = Hle::lookup("fRG-JOH5+sI");   // sceAgcSetUcRegIndirectPatchSetNumRegisters
     auto setsh_ind = Hle::lookup("-HOOCn0JY48");  // sceAgcDcbSetShRegistersIndirect
     auto setuc_ind = Hle::lookup("hvUfkUIQcOE");  // sceAgcDcbSetUcRegistersIndirect
-    CHECK(p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind,
-          "all three PatchSetNumRegisters NIDs and the Sh/Uc indirect builders are registered");
-    if (p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind) {
+    // The Sh members of the address/count family. Since #1650 each register class has its own
+    // handler and verifies the packet's sub-op, so a test — like a guest — must patch an Sh packet
+    // through the Sh NIDs. Reaching for the Cx one here used to "work" only because a single shared
+    // handler served all three classes, which is the defect.
+    auto p_addr_sh = Hle::lookup("Qrj4c+61z4A");  // sceAgcSetShRegIndirectPatchSetAddress
+    auto p_add_sh  = Hle::lookup("z2duB-hHQSM");  // sceAgcSetShRegIndirectPatchAddRegisters
+    CHECK(p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind && p_addr_sh && p_add_sh,
+          "all three PatchSetNumRegisters NIDs, the Sh/Uc indirect builders and the per-class Sh "
+          "address/count patchers are registered");
+    if (p_num_cx && p_num_sh && p_num_uc && setsh_ind && setuc_ind && p_addr_sh && p_add_sh) {
         p_num_cx(rc, 2, 0, 0, 0, 0);
         CHECK(cmd[1] == 2, "Cx PatchSetNumRegisters SETS the count (8 -> 2), it does not accumulate");
         CHECK(cmd[2] == 0x00112233u && cmd[3] == 0xAABBCCDDu,
@@ -128,7 +183,7 @@ int main() {
         auto* sh_cmd = (uint32_t*)(uintptr_t)sh_rc;
         CHECK(sh_cmd && sh_cmd[0] == PM4(4, IT_NOP, R_SH_REGS_INDIRECT) && sh_cmd[1] == 0,
               "SetShRegistersIndirect reserves a packet with the placeholder count 0");
-        p_addr(sh_rc, 0x0000000340000000ull, 0, 0, 0, 0);
+        p_addr_sh(sh_rc, 0x0000000340000000ull, 0, 0, 0, 0);
         p_num_sh(sh_rc, 12, 0, 0, 0, 0);
         CHECK(sh_cmd[1] == 12, "Sh PatchSetNumRegisters turns the reserved 0-count packet into 12");
         CHECK(sh_cmd[2] == 0x40000000u && sh_cmd[3] == 0x00000003u,
@@ -144,6 +199,109 @@ int main() {
         p_num_sh(rc, 999, 0, 0, 0, 0);
         CHECK(cmd[1] == cx_num_before,
               "PatchSetNumRegisters refuses a packet of a different register class");
+    }
+
+    // ---- #1650: PatchSetAddress / PatchAddRegisters must refuse a pointer that is not one of
+    // their own packets, and must SAY SO.
+    //
+    // Both took a caller-supplied pointer behind nothing but a null check and stored through it.
+    // A wrapped, aliased or stale builder pointer therefore got a 64-bit register-array address
+    // written over two dwords of unrelated command-buffer or heap memory, with no log and no
+    // reject — corruption at a distance, attributed to whatever broke next. These are not cold
+    // paths: Sonic CrossWorlds logs 128 AddRegisters calls in a single 400-tick `hle_calls` window
+    // (docs/SONIC_CROSSWORLDS_STATUS.md), and Blue Prince builds its register arrays this way per
+    // draw (command_processor.hpp, #1264).
+    //
+    // Four arms, each naming the mutation it kills. Arm 1 is the positive control, because a fix
+    // that refuses EVERYTHING would satisfy a refusal-only test while silently dropping every
+    // register bind in those titles.
+    if (p_addr_sh && p_add_sh) {
+        // Arm 1 — POSITIVE CONTROL: a real packet, patched through its OWN class, still works.
+        // Kills a "refuse everything" fix. It also pins the performance contract: an in-ring
+        // pointer must be validated by range compare, never by an OS probe. guest_writable is
+        // uncached and fopen()s /proc/self/maps on Linux on every call, so a probe here would be a
+        // per-draw syscall on the hottest patch path — the reason this issue could not simply copy
+        // the PatchSetNumRegisters guard (#1654).
+        uint32_t ring[16];
+        memset(ring, 0xEE, sizeof ring);
+        Dcb rd{};
+        rd.bottom = ring; rd.top = ring + 16; rd.cursor_up = ring; rd.cursor_down = ring + 16;
+        const uint64_t RD = (uint64_t)(uintptr_t)&rd;
+        const uint64_t pkt_addr = setcx(RD, 0, 4, 0, 0, 0);
+        auto* pkt = (uint32_t*)(uintptr_t)pkt_addr;
+        CHECK(pkt == ring && pkt[0] == PM4(4, IT_NOP, R_CX_REGS_INDIRECT) && pkt[1] == 4,
+              "#1650 arm1: the builder reserved a Cx packet in a fresh ring");
+
+        const uint64_t probes_before_ok = prosper_agc_patch_probe_count();
+        p_addr(pkt_addr, 0x0000001200003400ull, 0, 0, 0, 0);
+        p_add(pkt_addr, 3, 0, 0, 0, 0);
+        CHECK(pkt[2] == 0x00003400u && pkt[3] == 0x00000012u,
+              "#1650 arm1: matching-class PatchSetAddress still writes the array address");
+        CHECK(pkt[1] == 7,
+              "#1650 arm1: matching-class PatchAddRegisters still accumulates (4 -> 7)");
+        CHECK(prosper_agc_patch_probe_count() == probes_before_ok,
+              "#1650 arm1: an in-ring packet is accepted by range compare, with no OS write probe");
+
+        // Arms 2-4 all REFUSE, and the refusal has to be visible in a run log. Capture stderr so
+        // "refused" and "refused silently" cannot pass the same assertions.
+        char log[4096];
+        uint32_t victim[8];
+        for (auto& v : victim) v = 0xA5A5A5A5u;      // ordinary writable memory, NOT one of our packets
+        const uint32_t pkt1 = pkt[1], pkt2 = pkt[2], pkt3 = pkt[3];
+        const uint64_t probes_before_refusals = prosper_agc_patch_probe_count();
+        const uint64_t victim_addr = (uint64_t)(uintptr_t)victim;
+        // Below the 0x1000 floor every guest-memory predicate rejects, and far below anything the
+        // process maps: dereferencing it faults. On master both handlers stored straight through a
+        // pointer like this, so without the fix this arm does not merely fail, it SIGSEGVs.
+        constexpr uint64_t unmapped_addr = 0x800ull;
+
+        const bool captured = capture_stderr([&] {
+            // Arm 2 — the silent-arbitrary-write case itself: a mapped, writable pointer that is
+            // not our packet. Kills "no header sub-op check".
+            p_addr(victim_addr, 0xDEADBEEFCAFEBABEull, 0, 0, 0, 0);
+            p_add(victim_addr, 99, 0, 0, 0, 0);
+            // Arm 3 — a REAL packet of the WRONG register class. A single shared handler for
+            // Cx/Sh/Uc cannot catch this, because the class is carried by the NID alone; kills
+            // "keep one handler registered for all three NIDs" (exactly what master did).
+            p_addr_sh(pkt_addr, 0x1111111122222222ull, 0, 0, 0, 0);
+            p_add_sh(pkt_addr, 55, 0, 0, 0, 0);
+            // Arm 4 — a pointer that cannot be dereferenced at all. Kills "no mappedness probe".
+            p_addr(unmapped_addr, 0x3333333344444444ull, 0, 0, 0, 0);
+            p_add(unmapped_addr, 77, 0, 0, 0, 0);
+        }, log, sizeof log);
+        CHECK(captured, "#1650: stderr capture around the refusal arms worked");
+
+        bool victim_intact = true;
+        for (const auto& v : victim) victim_intact &= (v == 0xA5A5A5A5u);
+        CHECK(victim_intact,
+              "#1650 arm2: a mapped non-packet pointer is left byte-for-byte alone");
+        CHECK(pkt[1] == pkt1 && pkt[2] == pkt2 && pkt[3] == pkt3,
+              "#1650 arm3: a wrong-class patcher does not touch a packet of another class");
+
+        // Which guard fired matters as much as that one did. Arm 2's target is writable, so it must
+        // be the HEADER check that refuses it — if guest_writable had wrongly rejected the stack,
+        // the message would say "not writable" and this assertion fails loudly instead of passing
+        // for the wrong reason.
+        CHECK(strstr(log, "SetCxRegIndirectPatchSetAddress: header") != nullptr &&
+              strstr(log, "SetCxRegIndirectPatchAddRegisters: header") != nullptr,
+              "#1650 arm2: the refusal names the call site and the unexpected header, on stderr");
+        CHECK(strstr(log, "SetShRegIndirectPatchSetAddress: header") != nullptr &&
+              strstr(log, "SetShRegIndirectPatchAddRegisters: header") != nullptr,
+              "#1650 arm3: the wrong-class refusal names the Sh call site, on stderr");
+        CHECK(strstr(log, "is not writable guest memory") != nullptr,
+              "#1650 arm4: an undereferenceable packet is reported, not silently skipped");
+        CHECK(prosper_agc_patch_probe_count() > probes_before_refusals,
+              "#1650: out-of-ring pointers DO reach the write probe — so arm1's zero-probe "
+              "assertion measures the registry rather than a counter stuck at zero");
+
+        // A shared 8-message budget across every patcher family in the translation unit meant a
+        // family that started misbehaving later refused in silence. Each call site now has its own
+        // budget: four distinct sites reported above even though earlier arms already logged
+        // refusals from the PatchSetNumRegisters sites.
+        CHECK(strstr(log, "SetCxRegIndirectPatchSetAddress") != nullptr &&
+              strstr(log, "SetShRegIndirectPatchAddRegisters") != nullptr,
+              "#1650: per-call-site diagnostic budgets, so one family cannot silence another");
+        if (fails) printf("  captured stderr:\n%s", log);
     }
 
     // #395 F5: all three single-register direct NIDs append the native packet opcode and preserve


### PR DESCRIPTION
Fixes #1650

## The failure scenario, concretely

`sceAgcSet{Cx,Sh,Uc}RegIndirectPatchSetAddress` and `...PatchAddRegisters` (`hle_agc.cpp`) took the
caller's `cmd` pointer, checked it against null, and stored through it:

```cpp
HLE(agc_patch_set_address) {                                  // before
    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
    cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u); return 0;
}
```

So any non-null pointer the guest passed got **64 bits of register-array address written over two
dwords of whatever is there** — command-buffer or heap — with no log, no reject and no way to
attribute it later. `PatchAddRegisters` read-modify-writes `cmd[1]` the same way. Three things make
this the severe shape rather than a theoretical one:

* **The packet layout is prosper's own** (`cmd[1]` = count, `cmd[2..3]` = array vaddr, header
  `PM4(4, IT_NOP, R_{CX,SH,UC}_REGS_INDIRECT)`). A legitimate `cmd` can only have come from this
  file's `Set*RegsIndirect` builder, so *every* other pointer value is a bug — and none were caught.
* **A wrong-but-mapped pointer corrupts silently**; only an unmapped one faults. The quiet case is
  the common one, and it is attributed to whatever breaks next.
* **These are hot.** *Sonic Racing: CrossWorlds* logs **128 `agc_patch_add_registers` calls in a
  single 400-tick `hle_calls` window** (`docs/SONIC_CROSSWORLDS_STATUS.md`), and *Blue Prince* builds
  its `Set*RegistersIndirect` arrays incrementally per draw (`command_processor.hpp`, #1264).

## Was the #1637 asymmetry deliberate?

**Yes — as a scoping decision, explicitly deferred to this issue, not as a contract.** #1637 gave
`PatchSetNumRegisters` both guards while its two siblings kept neither, and #1654's comment at the
call site says so in as many words:

> COST CAVEAT, do not copy this call verbatim onto a hot path: `guest_writable` is UNCACHED [...]
> That is harmless here because no measured title calls these NIDs at all, but the sibling patchers
> (#1650) run per draw on Blue Prince, and tightening those needs a cached predicate rather than
> this one.

So the asymmetry was "the cheap fix is unaffordable on the hot sibling, and the cached one is more
work than this PR" — deliberate about *timing*, never about the contract. This PR closes it and
moves `PatchSetNumRegisters` onto the shared guard, so the family has one answer to "may I write to
this packet?" instead of two.

## The contract implemented

Per register class — the class is carried by the NID alone, so one shared handler *cannot* check a
sub-op, which is why #1637 split `PatchSetNumRegisters` the same way:

1. **null** → return.
2. **writable for the whole 4-dword packet** → else refuse **and log**.
3. **header sub-op matches this handler's class** → else refuse **and log**.
4. write.

All six NID→class mappings verified against the PS5 3.20 firmware symbol database (`vcmNN+AAXnY` →
`sceAgcSetCxRegIndirectPatchSetAddress`, etc.), since a wrong mapping would now refuse every
legitimate call rather than fail open.

### Why not `guest_writable` directly, and why not `guest_readable`

Both were considered and both are wrong here, for the reasons recorded on the issue:

* `guest_writable` is **uncached** and on Linux `fopen`s and parses `/proc/self/maps` on **every
  call**. Correct, but a per-draw syscall on this path.
* `guest_readable` has a thread-local cache but is the **wrong predicate in front of a store** — it
  accepts a read-only mapping, which then faults (the defect #1654 fixed). Its cache also consults
  `submit_ranges` only inside a renderer submit scope, which the DCB-build path is not.

So the guard answers **the question actually being asked** — "is this a pointer into a DCB I built
into?" — arithmetically. `set_regs_indirect` remembers the `[bottom, top)` extent of each ring it
builds a packet into (4 thread-local slots, **FIFO round-robin eviction** — lookup scans all slots, but
insertion overwrites the oldest regardless of use); a pointer inside a remembered extent with room for
the whole packet is memory this file allocated and already wrote a header into.

**The registry is a pure accelerator: a hit skips the probe, a miss falls back to `guest_writable`.**
It can never cause a refusal the predicate would not, so the safety argument rests on the predicate
and never on the cache. Its one false-accept mode is a stale extent — the guest freeing a ring
between building a packet and patching it, which would be a guest bug since it is about to submit
that ring — and on that path the behaviour is exactly what master does today with no check at all,
so the residual risk is a strict subset of the status quo. Per-thread for the reason `g_dcb_diag_r`
already gives; a cross-thread patch simply misses and takes the probe path.

### Refusals are loud, and can no longer be silenced by a neighbour

`patch_check`'s budget was a **single** 8-message counter shared by every patcher family in the
translation unit, so eight refusals anywhere spent it for everyone and the first refusal of a family
that started misbehaving later was silent — the exact failure the charter's fail-visible rule exists
to prevent, and called out in #1650. It is now keyed by call site (`who` is a distinct string
literal per patcher), so **every future call site gets its own budget without anyone remembering to
add one**. Only reached on a refusal, so it is off every hot path.

## Red-without / green-with

Sixteen arms, each naming the mutation it kills. Every mutation removes exactly one lever and was
built and run:

| Mutation | Result |
|---|---|
| `M1` header check accepts anything | **5 arms fail** — arm2 (victim clobbered), arm3 (wrong-class packet clobbered), both log arms, budget arm |
| `M2` write probe removed | **SIGSEGV (139)** at arm4, after arms 1-3 pass — i.e. master's behaviour |
| `M3` refusal logged silently | **4 arms fail** — every "on stderr" assertion |
| `M4` guard refuses everything | **7 arms fail**, including both arm1 acceptance arms |
| `M5` ring registry never hits | **arm1's zero-probe assertion fails** |
| `M6` budget reverted to the single shared counter | **arm5's cross-site assertion fails, and only that one** |

**`M6` was added after review, and the claim it replaces was wrong.** The first version of this PR
asserted the budget change was covered. It was not: the run produces **exactly 8 refusals in total**,
which is precisely the old shared budget, so all 8 printed under the old code too and reverting
`patch_budget_ok` left every assertion green. The assertion carrying the label only re-grepped two
substrings already checked by the arm-2 and arm-3 assertions above it, so it could not fail
independently of the header check — and the mutation table attributed its death to `M1`, the header
check, which is exactly what that means. Arm 5 now floods one call site past its budget and requires
a **different** site to still report; `M6` fails that assertion and no other, so the arm isolates the
lever instead of riding on another arm's failure.

`M4` is the arm the task asked for specifically: a fix that refuses everything is also wrong and
would present as a regression in whichever title exercises this, so arm 1 is a positive control that
a real packet patched through its own class still works.

**The one clean zero in this test is guarded against being structurally inexpressible.** Arm 1
asserts `probe_count == before` (zero probes). Its control is not merely "the counter can move" —
`M5` constructs, by hand and outside the path that produced the zero, the case of an in-ring pointer
that *does* probe, and arm 1 fails under it. A separate arm also asserts out-of-ring pointers
increment the same counter, so arm 1 cannot pass against a counter stuck at zero.

Arm 4 uses `0x800` — below the `0x1000` floor every guest-memory predicate rejects and far below
anything the process maps, so dereferencing it faults. On master both handlers stored straight
through a pointer like that.

`prosper_agc_patch_probe_count()` is exported so the "no syscall on the hot path" property is
observable at all; an unobservable performance contract regresses silently.

## Affected / deliberately unaffected

* **Affected:** the six `PatchSetAddress`/`PatchAddRegisters` NIDs (now per class), the three
  `PatchSetNumRegisters` handlers (same guard, now cached, probe widened from 2 dwords to the whole
  4-dword packet — the only shape this family's builder emits), and `patch_check`'s diagnostic budget
  for every family in the file (each now independent).
* **Unaffected:** packet semantics, every builder, the sync-packet and DMA patch families' logic,
  rendered output on any title where the guest passes its own packets — which is the intended path.

## Risks

Tightening a path that is live today, so a real caller could now be refused where it previously
wrote. That is the intended behaviour and the finding if it happens: the refusal names the call site
and the offending header, so it is diagnosable from a run log rather than silent. The class mapping
is the sharp edge and is verified against firmware symbols above. The registry cannot cause a
refusal on its own.

**One existing test assertion changed.** `test_agc_dcb` patched an **Sh** packet through the **Cx**
NID (`p_addr`), which only worked because one handler served all three classes; it now uses the Sh
NID, as a guest would. That is the defect surfacing in the test, not a weakened assertion — the
assertion it supports ("Sh reserved packet keeps its patched array address") is unchanged.

## Verification (exact head `3e28beb8`, rebased on `3bbd881b`, Linux, ps5ys distrobox)

```
cmake -S prosper -B build -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6      # clean, exit 0
ctest --output-on-failure    # 100% tests passed, 200/200, 44.88 s
```

`test_agc_dcb`: 99 assertions, all green (12 of them new). Docs gate green over all `.md`;
`git diff --check` clean; `git merge-tree --write-tree origin/master HEAD` after rebase is identical
to HEAD, so no trap-41 deletion.

No snapshots: this changes no builder and no rendered output on the intended path.

Also documents the read-vs-write predicate distinction and the hot-path guidance in
`docs/GUEST_INPUT_SAFETY.md`'s canonical-primitives list, so the next reader does not re-derive
#1654 or reach for a per-draw `fopen`.

