### PR TITLE
fix(libkernel): scePthreadRwlockRdlock/Wrlock must report a refused acquisition

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1010,29 +1010,48 @@ namespace {
                 (unsigned long long)rw_self_tid(),
                 (unsigned long long)(s & kRwCount), (s & kRwWrite) ? " WRITE" : "", n);
     }
-    // A lock call that FAILED records no hold, and it is worth saying so: the handlers below still
-    // report success to the guest, which is the other way an unmatched unlock can originate inside
-    // prosper rather than in the guest (#2024).
+    // A lock call that FAILED records no hold, and since #2024 it also reports that failure to the
+    // guest. Both halves matter and they are the same invariant seen from two sides: COUNT must
+    // equal the outstanding host holds, and the guest must not believe it holds what it does not.
+    // A handler that returned 0 on a refusal broke the second half, and the guest's own eventual
+    // unlock — correct from its point of view — then arrived unmatched at a lock with no hold to
+    // release, which is the #2012 corruption originating INSIDE prosper rather than in the guest.
     void rw_note_lock_result(const char* what, uint64_t slot, GuestRwlock* g, int rc) {
         if (rc == 0) { if (rwlocklog() >= 2) rw_report(RwReport::Trace, what, slot, g, 0); return; }
         rw_report(RwReport::Failed, what, slot, g, rc);
     }
 }
+// A REFUSED acquisition must be reported as one (#2024). These two returned 0 unconditionally, so a
+// guest told "the lock is yours" after a real EDEADLK/EAGAIN entered the critical section unguarded
+// and its later, entirely correct unlock arrived unmatched — the #2012 corruption manufactured by
+// prosper itself. `rc` fed only a diagnostic line.
+//
+// `fbsd_errno`, never the bare `rc`, and the reason is specific rather than stylistic: EDEADLK and
+// EAGAIN are the two values that SWAP between the host and the platform the guest was built against
+// (FreeBSD EDEADLK 11 / EAGAIN 35; Linux the mirror image). These handlers' interesting refusals are
+// exactly those two, so returning the host number would hand a guest "try again" where the host said
+// "deadlock" — the #1612 defect, on the paths that produce it most.
+//
+// The `!g` case (a null slot, or a lock object that could not be created) reports EINVAL, matching
+// `tryrdlock`, `trywrlock` and all four timed forms. It DELIBERATELY folds the out-of-memory
+// sub-case into EINVAL rather than reporting ENOMEM: `ensure_rwlock` does not distinguish them, and
+// answering one question two ways across the eight rwlock acquisition handlers would be its own
+// defect. Reachable only for a guest passing a null rwlock, where EINVAL is the platform answer.
 HLE(k_rwlock_rdlock)  {
     auto* g = ensure_rwlock(a0);
-    if (!g) return 0;
+    if (!g) return 0x16;   // EINVAL
     const int rc = pthread_rwlock_rdlock(&g->rw);
     if (rc == 0) rw_acquired(g, false);
     rw_note_lock_result("rdlock", a0, g, rc);
-    return 0;
+    return fbsd_errno(rc);
 }
 HLE(k_rwlock_wrlock)  {
     auto* g = ensure_rwlock(a0);
-    if (!g) return 0;
+    if (!g) return 0x16;   // EINVAL
     const int rc = pthread_rwlock_wrlock(&g->rw);
     if (rc == 0) rw_acquired(g, true);
     rw_note_lock_result("wrlock", a0, g, rc);
-    return 0;
+    return fbsd_errno(rc);
 }
 HLE(k_rwlock_unlock)  {
     auto* g = ensure_rwlock(a0);
@@ -1076,7 +1095,17 @@ HLE(k_rwlock_trywrlock){
 // way), and it makes the family self-consistent. CONFIDENCE: MED.
 // Init is aliased too: it can fail with ENOMEM (a failed allocation), so it is not a can't-fail
 // entry point.
+//
+// Rdlock and Wrlock are aliased as of #2024, and their previous ABSENCE from this list was not an
+// oversight — it was consistent with handlers that could not fail. Registering the Sony spelling
+// straight onto the POSIX body is only correct while that body returns nothing but 0; the moment it
+// can return a failure, the Sony spelling starts handing the guest a BARE FreeBSD errno where every
+// other libkernel entry point hands it the encoded form. Making a handler fallible and giving it its
+// alias are therefore one change, not two, and splitting them would produce exactly the #1984 defect
+// this alias exists to prevent.
 SCE_PTHREAD_ALIAS(k_sce_rwlock_init,      k_rwlock_init)
+SCE_PTHREAD_ALIAS(k_sce_rwlock_rdlock,    k_rwlock_rdlock)
+SCE_PTHREAD_ALIAS(k_sce_rwlock_wrlock,    k_rwlock_wrlock)
 SCE_PTHREAD_ALIAS(k_sce_rwlock_unlock,    k_rwlock_unlock)
 SCE_PTHREAD_ALIAS(k_sce_rwlock_tryrdlock, k_rwlock_tryrdlock)
 SCE_PTHREAD_ALIAS(k_sce_rwlock_trywrlock, k_rwlock_trywrlock)
@@ -3783,8 +3812,8 @@ void register_kernel_hle() {
     // read/write locks + once (Sony + POSIX names) — real host primitives (thread-safety fix).
     R("scePthreadRwlockInit", k_sce_rwlock_init);    R("pthread_rwlock_init", k_rwlock_init);
     R("scePthreadRwlockDestroy", k_rwlock_destroy);  R("pthread_rwlock_destroy", k_rwlock_destroy);
-    R("scePthreadRwlockRdlock", k_rwlock_rdlock);    R("pthread_rwlock_rdlock", k_rwlock_rdlock);
-    R("scePthreadRwlockWrlock", k_rwlock_wrlock);    R("pthread_rwlock_wrlock", k_rwlock_wrlock);
+    R("scePthreadRwlockRdlock", k_sce_rwlock_rdlock); R("pthread_rwlock_rdlock", k_rwlock_rdlock);
+    R("scePthreadRwlockWrlock", k_sce_rwlock_wrlock); R("pthread_rwlock_wrlock", k_rwlock_wrlock);
     R("scePthreadRwlockUnlock", k_sce_rwlock_unlock); R("pthread_rwlock_unlock", k_rwlock_unlock);
     R("scePthreadRwlockTryrdlock", k_sce_rwlock_tryrdlock);
     R("scePthreadRwlockTrywrlock", k_sce_rwlock_trywrlock);

--- a/prosper/tests/test_rwlock_once.cpp
+++ b/prosper/tests/test_rwlock_once.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <cstdint>
 #include <ctime>
+#include <cerrno>      // EDEADLK — the host's number, which is NOT the FreeBSD one the guest sees
+#include <pthread.h>   // the #2024 arm probes the host primitive directly before asserting on it
 #include <atomic>
 #include <chrono>
 #include <thread>
@@ -68,11 +70,113 @@ int main() {
     if (RWunPosix)
         CHECK(call1(RWunPosix, (uint64_t)(uintptr_t)&h) == 1,
               "unmatched pthread_rwlock_unlock returns bare EPERM");
-    // A read hold taken by THIS thread still releases normally afterwards. (The rdlock line is
-    // setup — the handler returns 0 unconditionally — the unlock is the assertion: it proves the
-    // acquisition was recorded, because an unrecorded one would be refused with EPERM.)
-    call1(RWrd, (uint64_t)(uintptr_t)&h);
+    // A read hold taken by THIS thread still releases normally afterwards. Since #2024 the rdlock
+    // line is an assertion in its own right rather than mere setup — the handler no longer returns 0
+    // unconditionally, so a 0 here means the host really granted the hold — and the unlock is the
+    // second half: it proves the acquisition was RECORDED, because an unrecorded one draws EPERM.
+    CHECK(call1(RWrd, (uint64_t)(uintptr_t)&h) == 0, "a granted rdlock reports success");
     CHECK(call1(RWun, (uint64_t)(uintptr_t)&h) == 0, "matched unlock still returns success");
+
+    // ===== #2024: an acquisition the host REFUSED must be reported as a failure ==================
+    //
+    // Rdlock and Wrlock used to `return 0` unconditionally — `rc` fed only a diagnostic line — so a
+    // guest handed a real EDEADLK was told "the lock is yours" and entered the critical section
+    // unguarded. Its later unlock, entirely correct from its own point of view, then arrived at a
+    // lock with no hold to release: #2012's corruption manufactured inside prosper rather than by
+    // the guest. Silent, non-deterministic, and attributable to whatever corrupts next.
+    //
+    // Two arms, because they need different things from the host.
+    //
+    //   (a) NULL SLOT — deterministic everywhere, no host cooperation needed. A null rwlock cannot
+    //       be acquired, so 0 is a lie the host was never even consulted about.
+    //   (b) HOST REFUSAL — the real lever: make the host lock refuse an acquisition the handler
+    //       forwards to it. A recursive write acquire does it; glibc, Darwin and FreeBSD all detect
+    //       it and answer EDEADLK instead of self-deadlocking.
+    //
+    // Arm (b) PROBES the host first, on a private pthread_rwlock_t of its own, and asserts nothing
+    // unless the probe proves this host really refuses. That is deliberate rather than defensive:
+    // an arm that cannot reach the failure path it exists for must SAY so instead of passing
+    // vacuously — the trap this repository keeps rediscovering is an assertion that held while the
+    // mechanism never ran. The probe is watchdog'd because a host WITHOUT deadlock detection would
+    // self-deadlock rather than answer, and a hung ctest is a worse signal than a loud skip.
+    //
+    // Both arms also assert the SONY and POSIX spellings separately, and that pairing is load-
+    // bearing: it is what distinguishes a correctly aliased handler from one wired straight to the
+    // POSIX body. Sony must report the libkernel-encoded form, POSIX the bare FreeBSD errno
+    // (#1984's split). A single-spelling arm passes under either wiring.
+    auto RWrdPosix = Hle::lookup(nid_hash("pthread_rwlock_rdlock"));
+    auto RWwrPosix = Hle::lookup(nid_hash("pthread_rwlock_wrlock"));
+    CHECK(RWrdPosix && RWwrPosix, "POSIX rdlock/wrlock spellings are registered");
+    if (RWrdPosix && RWwrPosix) {
+        // (a) A null slot: EINVAL, encoded for Sony and bare for POSIX.
+        CHECK(call1(RWrd, 0) == 0x80020016ull, "scePthreadRwlockRdlock(null) reports encoded EINVAL");
+        CHECK(call1(RWwr, 0) == 0x80020016ull, "scePthreadRwlockWrlock(null) reports encoded EINVAL");
+        CHECK(call1(RWrdPosix, 0) == 22, "pthread_rwlock_rdlock(null) reports bare EINVAL(22)");
+        CHECK(call1(RWwrPosix, 0) == 22, "pthread_rwlock_wrlock(null) reports bare EINVAL(22)");
+
+        // (b) Probe this host. Statics, not stack objects: on a host that self-deadlocks the probe
+        // thread is detached and never joined, so anything it can still touch must outlive main's
+        // frame. Each stage publishes its own result, and a stage that never returns leaves the
+        // stages after it at -1, which reads as "unknown" and skips the arm that depends on it.
+        static pthread_rwlock_t probe_rw;
+        static std::atomic<int> probe_rd{-1}, probe_wr{-1};
+        static std::atomic<bool> probe_done{false};
+        if (pthread_rwlock_init(&probe_rw, nullptr) == 0) {
+            std::thread p([]{
+                if (pthread_rwlock_wrlock(&probe_rw) != 0) { probe_done.store(true); return; }
+                probe_rd.store(pthread_rwlock_rdlock(&probe_rw));    // read while SELF write-holds
+                probe_wr.store(pthread_rwlock_wrlock(&probe_rw));    // recursive write acquire
+                probe_done.store(true);
+            });
+            for (int i = 0; i < 3000 && !probe_done.load(); i++)
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            if (probe_done.load()) p.join();
+            else                   p.detach();   // this host blocks instead of refusing
+        }
+        const int rd_rc = probe_rd.load(), wr_rc = probe_wr.load();
+        printf("  [info] host refusal probe: rdlock-while-self-write-held rc=%d, recursive wrlock"
+               " rc=%d (this host's EDEADLK=%d)\n", rd_rc, wr_rc, EDEADLK);
+
+        // FreeBSD EDEADLK is 11 and the encoded form is 0x8002000b. Neither is the host's number:
+        // EDEADLK is 35 on Linux and 36 on MinGW, and 35 is FreeBSD's EAGAIN — so a handler that
+        // returned the bare host `rc` would tell the guest "try again" where the host said
+        // "deadlock". These two literals are exactly what `fbsd_errno` exists to produce (#1612).
+        if (wr_rc == EDEADLK) {
+            CHECK(call1(RWwr, (uint64_t)(uintptr_t)&h) == 0, "wrlock granted (setup for the refusal)");
+            CHECK(call1(RWwr, (uint64_t)(uintptr_t)&h) == 0x8002000bull,
+                  "scePthreadRwlockWrlock reports encoded EDEADLK when the host REFUSED");
+            CHECK(call1(RWwrPosix, (uint64_t)(uintptr_t)&h) == 11,
+                  "pthread_rwlock_wrlock reports bare FreeBSD EDEADLK(11), not the host's number");
+            // No phantom hold: the two refusals recorded nothing, so exactly ONE hold is
+            // outstanding. The SECOND unlock being refused is the proof — had either refused
+            // acquire reached rw_acquired, COUNT would still be positive and this would return 0.
+            CHECK(call1(RWun, (uint64_t)(uintptr_t)&h) == 0, "the one real write hold releases");
+            CHECK(call1(RWun, (uint64_t)(uintptr_t)&h) == 0x80020001ull,
+                  "the refused wrlocks recorded NO hold (the next unlock is unmatched -> EPERM)");
+            CHECK(call1(RWtrywr, (uint64_t)(uintptr_t)&h) == 0,
+                  "the lock is undamaged after the refused wrlocks");
+            call1(RWun, (uint64_t)(uintptr_t)&h);
+        } else {
+            printf("  [SKIP] this host does not refuse a recursive write acquire (rc=%d) — the"
+                   " wrlock half of the #2024 arm cannot run here\n", wr_rc);
+        }
+        if (rd_rc == EDEADLK) {
+            CHECK(call1(RWwr, (uint64_t)(uintptr_t)&h) == 0, "wrlock granted (setup for the refusal)");
+            CHECK(call1(RWrd, (uint64_t)(uintptr_t)&h) == 0x8002000bull,
+                  "scePthreadRwlockRdlock reports encoded EDEADLK when the host REFUSED");
+            CHECK(call1(RWrdPosix, (uint64_t)(uintptr_t)&h) == 11,
+                  "pthread_rwlock_rdlock reports bare FreeBSD EDEADLK(11), not the host's number");
+            CHECK(call1(RWun, (uint64_t)(uintptr_t)&h) == 0, "the one real write hold releases");
+            CHECK(call1(RWun, (uint64_t)(uintptr_t)&h) == 0x80020001ull,
+                  "the refused rdlocks recorded NO hold (the next unlock is unmatched -> EPERM)");
+            CHECK(call1(RWtrywr, (uint64_t)(uintptr_t)&h) == 0,
+                  "the lock is undamaged after the refused rdlocks");
+            call1(RWun, (uint64_t)(uintptr_t)&h);
+        } else {
+            printf("  [SKIP] this host grants a read acquire while the caller write-holds (rc=%d) —"
+                   " the rdlock half of the #2024 arm cannot run here\n", rd_rc);
+        }
+    }
 
     // #2012: the accounting is PER LOCK, not per thread, and that distinction is load-bearing.
     // FreeBSD's umtx path refuses an unlock only when nothing is held (or when a non-owner tries to


### PR DESCRIPTION
Fixes #2024.

## Failure scenario

`scePthreadRwlockRdlock` / `scePthreadRwlockWrlock` (and their POSIX spellings) returned `0`
unconditionally. The host result fed a diagnostic line and nothing else:

```cpp
const int rc = pthread_rwlock_rdlock(&g->rw);
if (rc == 0) rw_acquired(g, false);
rw_note_lock_result("rdlock", a0, g, rc);
return 0;                                    // <- 0 regardless of rc
```

So a guest whose acquisition the host **refused** — `EDEADLK`, or `EAGAIN` on a lock whose reader
count is already saturated — was told "the lock is yours" and entered the critical section
unguarded. The hold was correctly *not* recorded (`rw_acquired` is gated on `rc == 0`), so the
guest's eventual `scePthreadRwlockUnlock`, entirely correct from its own point of view, arrived at a
lock with no hold to release. That is the #2012 corruption **manufactured inside prosper rather than
by the guest**: since #2015 the unmatched unlock is refused with `EPERM`, so the release silently
becomes a no-op; before it, that same unlock drove glibc's `__readers` negative and bricked the lock
permanently.

Silent, non-deterministic, and it surfaces as whatever corrupts next rather than as this.

## The encoding chosen for each failure mode

This is libkernel ABI, so the question is not "return non-zero" but *which* value. Two decisions.

**1. FreeBSD errno, never the bare host errno.** `fbsd_errno(rc)`, matching every other rwlock
handler. Not stylistic — it is the specific defect #1612 exists to prevent, and these two handlers
are where it bites hardest: `EDEADLK` and `EAGAIN` are precisely the two values that **swap** between
the host and the platform the guest was built against.

| condition | host (Linux / MinGW) | FreeBSD — what the guest must see |
| --- | --- | --- |
| `EDEADLK` | 35 / 36 | **11** |
| `EAGAIN` | 11 | **35** |

Returning the bare `rc` on Linux hands the guest `35` — FreeBSD's `EAGAIN`, a *retry* hint — where
the host said "deadlock". A guest that retries a deadlock loops forever.

**2. Sony spelling encoded, POSIX spelling bare** (#1984's split). `scePthreadRwlockRdlock` and
`Wrlock` were registered directly onto the POSIX body with no `SCE_PTHREAD_ALIAS`. That was *correct*
while the body could not fail — there was nothing to encode — and becomes wrong the instant it can.
Making a handler fallible and giving it its alias are one change, not two.

Resulting map, identical for `Rdlock` and `Wrlock`:

| host refusal | FreeBSD | `scePthreadRwlock*` | `pthread_rwlock_*` | reachable here? |
| --- | --- | --- | --- | --- |
| `EDEADLK` | 11 | `0x8002000b` | `11` | **yes** — recursive write acquire; read acquire while the caller write-holds. Forced live by the test. |
| `EAGAIN` | 35 | `0x80020023` | `35` | yes — `rdlock` past the max reader count, including a lock already driven negative. Same `fbsd_errno` path; not separately forced (see *Not forced* below). |
| `EINVAL` | 22 | `0x80020016` | `22` | yes — null rwlock slot. Forced by the test. |
| `ENOMEM` | 12 | `0x8002000c` | `12` | **deliberately folded into `EINVAL`** — see below. |
| `EBUSY` | 16 | `0x80020010` | `16` | **not reachable**: these are the *blocking* forms. `EBUSY` belongs to `tryrdlock`/`trywrlock`, which already return it through the same `fbsd_errno` path and are untouched here. |
| `ETIMEDOUT` | 60 | `0x8002003c` | `60` | **not reachable**: no timeout on the blocking forms. |

**Errno deliberately folded.** `ensure_rwlock()` returns null for *two* distinct causes — a null slot
address (`EINVAL`) and a failed allocation (`ENOMEM`) — and does not distinguish them. Both report
`EINVAL`. This matches `tryrdlock`, `trywrlock` and all four timed forms exactly; answering one
question two ways across the eight rwlock acquisition handlers would be its own defect, of the kind
`CLAUDE.md` records under #1873. The OOM sub-case is not observably reachable.

**Not forced: `EAGAIN`.** Reaching it legitimately needs ~2^30 concurrent readers. The issue notes it
also arises on an already-poisoned lock, but the only lever for that is the
`PROSPER_RWLOCK_UNSAFE_UNLOCK` escape hatch, whose env var is read through a function-local `static`
— so it cannot be toggled mid-process, and enabling it for the whole binary would disable the #2012
arms this same test file exists for. It travels the identical `fbsd_errno` path as `EDEADLK`, which
*is* forced, and the host→FreeBSD table itself is separately guarded by `test_sce_errno`.

## Confidence

- **`CONFIDENCE: HIGH`** that returning `0` on a refusal is wrong against the platform contract, and
  that `fbsd_errno` — not the bare host number — is the correct POSIX-side value.
- **`CONFIDENCE: MED`** on the *Sony* side specifically: extending #1984's encoded-error split from
  MUTEX/CONDVAR to RWLOCK. #1984's proof is direct — the shipped guest `libc.prx` compares
  `scePthreadMutex*`/`scePthreadCond*` results against the encoded constants (`0x8002000b`,
  `0x80020010`, `0x8002003c`). **No guest code has been observed testing an encoded RWLOCK result.**
  Applying it here is an extrapolation from a consistent libkernel-wide convention, not an
  observation.

  This is the *same* `CONFIDENCE: MED` already recorded above the rwlock alias block by #2015. **This
  PR does not raise it** — it extends the existing label to two more entry points and leaves the
  wording in place. It remains the safer of the two available errors: a guest that only tests `== 0`
  is unaffected either way, and the alternative — a bare errno from a Sony entry point — is the exact
  shape that killed *Oregon Trail* in #1984.

  The 3.20 firmware reference confirms both names are real `libkernel_sys` exports, which is what
  makes the libkernel convention applicable to them; it carries names and NIDs only, so it cannot
  settle the encoding itself.

## Guest-visible behavior

The success path is unchanged **byte for byte**: `fbsd_errno(0)` is `0`, and `sce_pthread_rc(0)`
passes `0` through. Every call that previously returned 0 *and had actually acquired the lock* still
returns exactly 0. The only divergence is on the paths that previously lied.

Risk accepted: a guest that never checked the return value now sees a non-zero one on a path that
previously could not fail. That path is a *refused* acquisition, where the previous answer was
actively harmful.

### Title arm — *Sonic Racing: CrossWorlds* (`PPSA08804`)

The title #2012/#2015 were measured on, and the heaviest rwlock user in the corpus. Default launch,
90 s, 9 samples, Linux `screenshot` frontend:

- **0** `rdlock`/`wrlock` refusals — so `fbsd_errno(rc)` returned 0 on every call, i.e. behaviour
  identical to master on this title.
- **0** unmatched unlocks (unchanged from #2015's post-fix measurement).
- The SEGA logo checkpoint reproduces with `crc=0d70a70a` on 5 of 9 samples — **bit-identical** to
  the `pixel_crc32` recorded in `docs/SONIC_CROSSWORLDS_STATUS.md`.

**Positive control for that zero**, per the charter rule added in #2153 — a clean zero is worthless
until you show the instrument can express the case, and that the domain is non-empty. Re-run with
`PROSPER_RWLOCKLOG=2` (same binary, same log channel): **80 `[rwlock]` lines, 42 of them `rdlock`/
`wrlock` operations, every one `rc=0`.** So the guest really does call these two handlers, the
diagnostic channel really is live in this frontend, and none of those calls was refused. (42 is a
floor, not a rate: `rw_report` prints the first 64 per report kind, then powers of two.)

Without that control the zero would have been ambiguous between "never refused" and "never called".

## Verification

Configure + full build + full `ctest`, in-container on Linux (Vulkan execution tests present):

```
cmake -S prosper -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
cmake --build build -j6
ctest --test-dir build --output-on-failure --timeout 600
```

**`100% tests passed out of 200`** (1 skipped: `plugin_autolink`), 70.77 s.

### The test forces the host lock to refuse — it does not merely call the function

`prosper/tests/test_rwlock_once.cpp` gains two arms.

- **(a) Null slot** — deterministic on every host, no host cooperation needed. Asserts the Sony
  spelling reports encoded `EINVAL` (`0x80020016`) and the POSIX spelling bare `22`. The *pairing* is
  what makes it a discriminator: it fails under either wrong wiring.
- **(b) Host refusal** — the real lever. A **recursive write acquire** makes the host lock genuinely
  refuse; glibc, Darwin and FreeBSD all detect it and answer `EDEADLK` rather than self-deadlocking.
  A real refusal from the same primitive the handler calls, not a simulated one.

**Arm (b) probes the host before asserting anything**, on a private `pthread_rwlock_t` of its own,
and reports a loud `[SKIP]` if this host does not produce the refusal. An arm that cannot reach the
failure path it exists for must *say so* rather than pass vacuously. The probe is watchdog'd on a
detached thread because a host *without* deadlock detection would self-deadlock instead of answering,
and a hung ctest is a worse signal than a loud skip.

The refusal was first constructed **by hand**, in a standalone C program outside the harness, before
any test code was written — recursive `wrlock` → `35`, `rdlock` while self-write-held → `35`,
`EDEADLK=35`. The test then reports the same probe in its own output, so the arm cannot silently
degrade:

```
[info] host refusal probe: rdlock-while-self-write-held rc=35, recursive wrlock rc=35 (this host's EDEADLK=35)
```

`rc=35 == EDEADLK`, so **both halves ran** — neither was skipped. The handler's own fail-visible
diagnostic confirms it from the production side, including `holds=1` (exactly one hold outstanding —
the refusals recorded none):

```
[rwlock] wrlock slot=0x… rw=0x… rc=35 tid=… holds=1 WRITE #0
[rwlock] rdlock slot=0x… rw=0x… rc=35 tid=… holds=1 WRITE #2
```

### Red-without / green-with, per arm — measured, not asserted

Each mutation was applied to the **fixed** tree, rebuilt, and run. These are observed results.

| mutation | what it changes | result |
| --- | --- | --- |
| **M1** `return fbsd_errno(rc)` → `return 0` (the original #2024 bug, restored verbatim) | both handlers | exit 1, **4 killed** — Sony `Rdlock`/`Wrlock` encoded `EDEADLK`, POSIX `rdlock`/`wrlock` bare `11` |
| **M2** `if (!g) return 0x16` → `return 0` | both handlers | exit 1, **4 killed** — all four null-slot assertions |
| **M3** drop both `SCE_PTHREAD_ALIAS`, register the Sony spelling onto the POSIX body | registration | exit 1, **4 killed** — the four **Sony** assertions only; the POSIX ones stay green |
| **M4** drop the `rc == 0` gate on `rw_acquired` | both handlers | **TIMEOUT / DEADLOCK** |
| **M5** `fbsd_errno(rc)` → bare host `rc` | both handlers | exit 1, **4 killed** — the `EDEADLK` assertions (host `35` ≠ FreeBSD `11`) |

**M3 is why both spellings are asserted.** Dropping the alias leaves every POSIX assertion green and
kills only the Sony ones. A single-spelling test would not have caught it.

**M4 is why the `rc == 0` gate matters.** Recording a hold for a refused acquisition inflates `COUNT`,
so `rw_release` accepts unlocks with no host hold behind them and forwards them — **reproducing
#2012 exactly**. Its kill is a deadlock rather than an assertion, and the stack is the tell:

```
TID …: __GI___futex_abstimed_wait64
       pthread_rwlock_wrlock@@GLIBC_2.34
       prosper::k_rwlock_wrlock
       prosper::k_sce_rwlock_wrlock
```

A thread parked forever in `pthread_rwlock_wrlock` — precisely what was measured on `PPSA08804` and
recorded in the comment above these handlers.

## Deliberately not changed

- `tryrdlock` / `trywrlock` / the four timed forms — already correct.
- The `EPERM` unmatched-unlock refusal from #2015.
- `PROSPER_RWLOCK_UNSAFE_UNLOCK` remains the #2012 A/B escape hatch, untouched and still off.
- The `CONFIDENCE: MED` label on the RWLOCK encoding extrapolation is left exactly as #2015 wrote it.

No `## Ruled out` entry: this PR falsifies no hypothesis, it fixes a defect.

## Review

Requesting independent review. This is reverse-engineered ABI semantics on a guest-visible interface
carrying a `CONFIDENCE: MED` encoding judgement — squarely in the review-required class.
