### PR TITLE
fix(win): report a dropped APR result slot instead of skipping it silently

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2561,17 +2561,33 @@ namespace prosper {
 // #2139: Windows sibling. Same contract, but fault-safe: this half never dereferences a guest
 // pointer it has not proven writable, because a fault here kills the emulator rather than the
 // guest (same rule as k_ampr_write_address below). A slot that is not committed and writable is
-// skipped -- the submit still posts its completion event, which is the part the guest waits on.
+// skipped -- but the skip is REPORTED, not silent. The guest asked for a result and did not get
+// one, so if a title ever stalls waiting on that value the log is what points at this line; a
+// silent skip would leave it looking like the write happened. Bounded so a pathological caller
+// cannot flood the log. POSIX cannot reach this state: its store faults instead of skipping.
 static void apr_write_result_slot(uint64_t addr, uint64_t value) {
     MEMORY_BASIC_INFORMATION mbi{};
     constexpr DWORD kWritable = PAGE_READWRITE | PAGE_WRITECOPY |
                                 PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
-    if (VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(addr)), &mbi, sizeof(mbi)) &&
+    const bool writable =
+        VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(addr)), &mbi, sizeof(mbi)) &&
         mbi.State == MEM_COMMIT && (mbi.Protect & kWritable) &&
         static_cast<uintptr_t>(addr) + sizeof(uint64_t) <=
-            reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize) {
-        *reinterpret_cast<uint64_t*>(static_cast<uintptr_t>(addr)) = value;
+            reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize;
+    if (!writable) {
+        static std::atomic<int> skipped{0};
+        const int n = skipped.fetch_add(1, std::memory_order_relaxed);
+        if (n < 8)
+            fprintf(stderr,
+                    "[ampr] APR result slot 0x%llx NOT WRITABLE (state=0x%lx prot=0x%lx) -- the "
+                    "guest's result value 0x%llx was dropped\n",
+                    (unsigned long long)addr, (unsigned long)mbi.State, (unsigned long)mbi.Protect,
+                    (unsigned long long)value);
+        else if (n == 8)
+            fprintf(stderr, "[ampr] further APR result-slot drops suppressed\n");
+        return;
     }
+    *reinterpret_cast<uint64_t*>(static_cast<uintptr_t>(addr)) = value;
 }
 
 // #2139 Windows sibling: prove the whole pair is committed and readable before touching it.


### PR DESCRIPTION
Follow-up to #2160, which I authored. Windows-only; POSIX cannot reach the changed path.

## What was wrong

`apr_write_result_slot` (Windows half of `hle_kernel_mem.cpp`, added in #2160) proves a guest
result slot committed and writable before storing to it, because a fault in host HLE code kills
the emulator rather than the guest. **That guard is correct and is unchanged.** What was wrong is
what it did when the check failed: it returned without storing and without saying anything.

The guest called `sceKernelAprSubmitCommandBufferAndGetResult` and asked for a result. If a slot
were ever unwritable, the guest would read whatever was already in that memory, and a title
stalling on that value would be indistinguishable from a title stalling on anything else -- with no
line in any log pointing here.

This is the same failure shape that #2150 had just corrected twice in my own #2117 (a truncated
helper result read as complete; a hazard I noticed and waved through). So it is the shape to remove
now rather than leave for a future investigation to trip over.

## What changed

The refusal path now reports the slot address, the `VirtualQuery` state/protect that caused it, and
the value that was dropped -- bounded at 8 lines plus a suppression notice, so a pathological
caller cannot flood the log.

The retained comment is also corrected. It claimed a dropped slot is harmless because *"the submit
still posts its completion event, which is the part the guest waits on"*. That is an unverified
assertion about guest behaviour, and nothing in this file establishes it. It is gone.

## Measured, not assumed

The point of the change is a signal, so the signal was exercised rather than asserted:

**Blue Prince (PPSA25009), native Windows, `prosper-app` to the title screen, `PROSPER_AMPRLOG=1`:**

| | |
| --- | ---: |
| APR result-slot drops (`NOT WRITABLE`) | **0** |
| APR submits allocating tokens | continuous (`0xae..0xb1` in the tail alone) |

So every result slot this title presents is committed and writable, and the guard refuses nothing
in practice.

That is a real result for #2139 rather than a no-op. *"The Windows result-slot guard is silently
dropping the guest's completion value"* was an open hypothesis; it is now closed, and closed by
instrumentation that **stays in the tree**, so it cannot quietly become true again under a later
change.

**Honest bound on that evidence:** the title screen is the state reached, so this exercises the
submits that occur up to and including the menu, not the post-New-Game asset-streaming burst. A
drop later in the route would still be caught -- that is the point of landing the log -- but it has
not been observed because that state has not been measured with this build.

## Verification

```
Windows, build-mingw-app (WinLibs UCRT gcc 16.1.0)
  build                     clean
  test_dmem                 143/143   == PASS ==
```

`test_dmem` is the relevant binary because it also carries #2150's new mixed-span arms, so this
confirms the tree is green on the corrected memory-protection paths as well.

`git diff --check` clean. CRLF preserved (21 insertions / 5 deletions, no whole-file EOL churn).

## Does not fix #2139

Blue Prince still stalls. This closes one hypothesis and makes a class of silent failure visible.

## Risk

Low. Diagnostic-only on a path that is not currently taken; no change to the store, the guard
predicate, or any POSIX code.
