### PR TITLE
fix(libkernel): quarantine a destroyed guest sync object instead of freeing it under a live handler

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1181,6 +1181,12 @@ if(TARGET prosper_core)
     target_link_libraries(test_rwlock_once PRIVATE prosper_core)
     add_test(NAME rwlock_once_semantics COMMAND test_rwlock_once)
 
+    # #2042: a destroyed guest sync object's storage is retired, never returned to the allocator,
+    # so a Destroy racing a handler cannot corrupt prosper's own heap.
+    add_executable(test_sync_destroy_lifetime tests/test_sync_destroy_lifetime.cpp)
+    target_link_libraries(test_sync_destroy_lifetime PRIVATE prosper_core)
+    add_test(NAME sync_destroy_lifetime COMMAND test_sync_destroy_lifetime)
+
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).
     add_executable(test_tls_dtv_purge tests/test_tls_dtv_purge.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1182,17 +1182,38 @@ if(TARGET prosper_core)
     add_test(NAME rwlock_once_semantics COMMAND test_rwlock_once)
 
     # #2042: a destroyed guest sync object's storage is quarantined, not returned to the allocator,
-    # so a Destroy racing a handler cannot corrupt prosper's own heap. The counter-arm runs the SAME
-    # binary with the quarantine switched off (PROSPER_SYNC_RETIRE_SECONDS=0 is the pre-#2042
-    # immediate free) and requires it to FAIL — so CI keeps proving the assertions can move, without
-    # anyone having to rebuild against an older master.
+    # so a Destroy racing a handler cannot corrupt prosper's own heap. The assertions hold on every
+    # allocator, so the test itself runs everywhere.
     add_executable(test_sync_destroy_lifetime tests/test_sync_destroy_lifetime.cpp)
     target_link_libraries(test_sync_destroy_lifetime PRIVATE prosper_core)
     add_test(NAME sync_destroy_lifetime COMMAND test_sync_destroy_lifetime)
     set_tests_properties(sync_destroy_lifetime PROPERTIES TIMEOUT 120)
-    add_test(NAME sync_destroy_lifetime_counter_arm COMMAND test_sync_destroy_lifetime)
-    set_tests_properties(sync_destroy_lifetime_counter_arm PROPERTIES
-        ENVIRONMENT "PROSPER_SYNC_RETIRE_SECONDS=0" WILL_FAIL TRUE TIMEOUT 120)
+
+    # The window switch must FAIL SAFE. `atof` returns 0.0 on no conversion, so an early version of
+    # retire_window_seconds() turned the guard off for `=on`, `=true` or any typo — the exact
+    # use-after-free this exists to prevent, reached by misspelling a tuning knob. This arm passes an
+    # unparseable value and requires the suite to still PASS, i.e. the default window is in force.
+    # It asserts the green outcome, so unlike the counter-arm it is allocator-independent.
+    add_test(NAME sync_destroy_lifetime_bad_window COMMAND test_sync_destroy_lifetime)
+    set_tests_properties(sync_destroy_lifetime_bad_window PROPERTIES
+        ENVIRONMENT "PROSPER_SYNC_RETIRE_SECONDS=on" TIMEOUT 120)
+
+    # The counter-arm runs the SAME binary with the quarantine switched off
+    # (PROSPER_SYNC_RETIRE_SECONDS=0 is the pre-#2042 immediate free) and requires it to FAIL, so CI
+    # keeps proving the assertions can move without anyone rebuilding against an older master.
+    #
+    # LINUX ONLY, and the restriction is the honest one rather than a convenience: the arm is red
+    # because glibc's tcache hands a just-freed block of the same size back to the very next
+    # allocation, deterministically and LIFO. That reuse is the mechanism being demonstrated, not an
+    # incidental detail — on an allocator that does not reuse promptly the assertions would pass and
+    # WILL_FAIL would turn a correct result into a red build. Asserting an allocator's internals as
+    # a merge gate on hosts where they were never measured is how a guard starts failing for reasons
+    # unrelated to what it guards.
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+      add_test(NAME sync_destroy_lifetime_counter_arm COMMAND test_sync_destroy_lifetime)
+      set_tests_properties(sync_destroy_lifetime_counter_arm PROPERTIES
+          ENVIRONMENT "PROSPER_SYNC_RETIRE_SECONDS=0" WILL_FAIL TRUE TIMEOUT 120)
+    endif()
 
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1181,11 +1181,18 @@ if(TARGET prosper_core)
     target_link_libraries(test_rwlock_once PRIVATE prosper_core)
     add_test(NAME rwlock_once_semantics COMMAND test_rwlock_once)
 
-    # #2042: a destroyed guest sync object's storage is retired, never returned to the allocator,
-    # so a Destroy racing a handler cannot corrupt prosper's own heap.
+    # #2042: a destroyed guest sync object's storage is quarantined, not returned to the allocator,
+    # so a Destroy racing a handler cannot corrupt prosper's own heap. The counter-arm runs the SAME
+    # binary with the quarantine switched off (PROSPER_SYNC_RETIRE_SECONDS=0 is the pre-#2042
+    # immediate free) and requires it to FAIL — so CI keeps proving the assertions can move, without
+    # anyone having to rebuild against an older master.
     add_executable(test_sync_destroy_lifetime tests/test_sync_destroy_lifetime.cpp)
     target_link_libraries(test_sync_destroy_lifetime PRIVATE prosper_core)
     add_test(NAME sync_destroy_lifetime COMMAND test_sync_destroy_lifetime)
+    set_tests_properties(sync_destroy_lifetime PROPERTIES TIMEOUT 120)
+    add_test(NAME sync_destroy_lifetime_counter_arm COMMAND test_sync_destroy_lifetime)
+    set_tests_properties(sync_destroy_lifetime_counter_arm PROPERTIES
+        ENVIRONMENT "PROSPER_SYNC_RETIRE_SECONDS=0" WILL_FAIL TRUE TIMEOUT 120)
 
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -528,10 +528,11 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // Every one of these handlers used to `free()` the object outright. That is a use-after-free waiting
 // for a guest that destroys an object another thread is still using: the handlers resolve the
 // pointer from a guest slot and then dereference it, sometimes while PARKED INSIDE it
-// (`pthread_rwlock_rdlock`, `interruptible_cond_wait`), so the freed block is handed to the next
-// `calloc` and prosper's own heap is corrupted. The storage is now RETIRED instead — kept forever,
-// never reused — which keeps the guest's bug the guest's bug. `sync_retire.hpp` carries the full
-// argument, the cost and how the retained count reports itself; `sceKernelDeleteEventFlag` and
+// (`interruptible_mutex_lock`, `pthread_rwlock_rdlock`), so the freed block is handed to the next
+// `calloc` and prosper's own heap is corrupted. The storage now goes into a time-bounded QUARANTINE
+// instead, and the host `pthread_*_destroy` runs at reclaim rather than here — which keeps the
+// guest's bug the guest's bug. `sync_retire.hpp` carries the full argument, the measurement that
+// sized the window, and what the window does not close. `sceKernelDeleteEventFlag` and
 // `sceKernelDeleteSema` below already solved the same hazard their own way (defer the free to the
 // last waiter) and are left alone.
 //
@@ -557,7 +558,8 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // CONFIDENCE: HIGH on the table above (read out of libthr and libc, the guest's own platform);
 // CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
 // corpus can currently settle either way — a title observed testing a Destroy result would.
-HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); retire_sync_object(m); } if (a0) *(void**)a0 = nullptr; return 0; }
+HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); retire_sync_object(m, SyncObjectKind::Mutex,
+                                    [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } if (a0) *(void**)a0 = nullptr; return 0; }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -825,12 +827,13 @@ HLE(k_cond_init) {
 HLE(k_cond_destroy) {
     if (a0 && !pt_static_sentinel(*(void**)a0)) {
         auto* cond = (pthread_cond_t*)*(void**)a0;
-        // Retired, not freed, and the host `pthread_cond_destroy` is deliberately not called — see
-        // the contract block above k_mutex_destroy and sync_retire.hpp (#2042). A thread parked in
-        // interruptible_cond_wait is inside this very object.
+        // Quarantined, not freed, and the host `pthread_cond_destroy` runs at reclaim rather than
+        // here — see the contract block above k_mutex_destroy and sync_retire.hpp (#2042). A thread
+        // parked in interruptible_cond_wait is inside this very object.
         interruptible_cond_forget(cond);
         guest_cond_unregister(cond);
-        retire_sync_object(cond);
+        retire_sync_object(cond, SyncObjectKind::Cond,
+                           [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); });
     }
     if (a0) *(void**)a0 = nullptr;
     return 0;
@@ -884,15 +887,16 @@ HLE(k_rwlock_init) {
 // #2042. Destroying a rwlock while another thread is inside one of the handlers below used to free
 // the object under it — and the rwlock is the worst of the family, because `k_rwlock_rdlock` parks
 // the caller INSIDE `pthread_rwlock_rdlock(&g->rw)` with the raw pointer live for as long as the
-// lock stays write-held. The storage is retired instead (`sync_retire.hpp`), and the host
-// `pthread_rwlock_destroy` is deliberately not called, since a parked thread is sitting in it.
+// lock stays write-held. The storage is quarantined instead (`sync_retire.hpp`), and the host
+// `pthread_rwlock_destroy` runs at reclaim, since a parked thread may be sitting in it right now.
 //
 // The hold accounting from #2012 is NOT consulted here, and that is the interesting part: FreeBSD's
 // own `pthread_rwlock_destroy` performs no busy check at all and returns 0 whatever is held, so an
 // EBUSY refusal would be a divergence rather than a fix. See the contract table above
 // k_mutex_destroy. The return value, and the cleared slot, are exactly what they were before.
 HLE(k_rwlock_destroy) {
-    if (a0 && !pt_static_sentinel(*(void**)a0)) retire_sync_object(*(void**)a0);
+    if (a0 && !pt_static_sentinel(*(void**)a0)) retire_sync_object(*(void**)a0, SyncObjectKind::Rwlock,
+            [](void* p) { auto* g = (GuestRwlock*)p; pthread_rwlock_destroy(&g->rw); g->~GuestRwlock(); });
     if (a0) *(void**)a0 = nullptr;
     return 0;
 }
@@ -2280,18 +2284,18 @@ HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem
 HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
-// Retired, not freed, and `sem_destroy` deliberately not called — a thread parked in `sem_wait` is
+// Quarantined, not freed, and `sem_destroy` deferred to reclaim — a thread parked in `sem_wait` is
 // inside this object. See the contract block above k_mutex_destroy and sync_retire.hpp (#2042).
-HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot); *slot = nullptr; } } return 0; }
+HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Sem, [](void* p) { sem_destroy((sem_t*)p); }); *slot = nullptr; } } return 0; }
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
 // past a rendezvous before its peers arrived: the barrier's downstream invariant (all-arrived) is false ->
 // reads of not-yet-produced data (the async-load race class). Back with host pthread_barrier_t; the serial
 // thread gets -1 (PTHREAD_BARRIER_SERIAL_THREAD, FreeBSD's value), the rest 0. Barrierattr are no-ops.
 HLE(k_barrier_init)    { if (!a0 || a2 == 0) return 0x16; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
 HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return 0x16; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : fbsd_errno(rc); }
-// Retired, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the object,
-// which is the widest window in the family. See the contract block above k_mutex_destroy.
-HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot); *slot = nullptr; } } return 0; }
+// Quarantined, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the
+// object, the widest window in the family. See the contract block above k_mutex_destroy.
+HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); }); *slot = nullptr; } } return 0; }
 HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
     // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
     // same class of silent hang root-caused for wait_on_address, hle_kernel_mem.cpp). Sony

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -554,7 +554,9 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // memory-safety problem — the wrong trade in both directions. The three EBUSY results FreeBSD DOES
 // specify are a separate defect (a contract divergence, not a lifetime bug): prosper has no owner
 // tracking on POSIX hosts and no waiter counts for cond/barrier, so each needs new accounting and
-// is guest-visible on every title. Filed rather than folded in here — see #2042's follow-up.
+// is guest-visible on every title. Filed as #2168 rather than folded in here. The slot prosper
+// clears to NULL is a third divergence — FreeBSD writes a DESTROYED poison and fails EINVAL, where
+// prosper's sentinel test self-initializes a fresh unheld object instead — filed as #2170.
 // CONFIDENCE: HIGH on the table above (read out of libthr and libc, the guest's own platform);
 // CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
 // corpus can currently settle either way — a title observed testing a Destroy result would.

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -17,6 +17,7 @@
 #include "sce_errno.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "sync_futex.hpp"
+#include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "../gpu/mb3_freelist.hpp"
 #include "../host/exec_image.hpp"
 #include <pthread.h>
@@ -439,7 +440,12 @@ namespace {
         if (pthread_rwlock_init(&g->rw, nullptr) != 0) { g->~GuestRwlock(); free(mem); return nullptr; }
         return g;
     }
-    void guest_rwlock_destroy(GuestRwlock* g) {
+    // ONLY for an object that was never published through a guest slot: the init-failure path above
+    // and the lost-init-race path below. No other thread can hold this pointer, so the storage
+    // really can go back to the allocator — which matters, because the lost-race path is the
+    // CONTENDED one and must stay allocation-neutral. A published object is retired instead
+    // (`retire_sync_object`, #2042); do not reuse this for one.
+    void guest_rwlock_free_unpublished(GuestRwlock* g) {
         if (!g) return;
         pthread_rwlock_destroy(&g->rw);
         g->~GuestRwlock();
@@ -455,7 +461,7 @@ namespace {
         if (__atomic_compare_exchange_n(slot, &cur, (void*)g, false,
                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE))
             return g;
-        guest_rwlock_destroy(g);          // lost the init race: use the winner's object
+        guest_rwlock_free_unpublished(g);   // lost the init race: use the winner's object
         return (GuestRwlock*)cur;
     }
     // scePthreadSem*: read the sem_t created by scePthreadSemInit (no static SEM_INITIALIZER, so no lazy
@@ -517,7 +523,41 @@ namespace { inline uint64_t fbsd_errno(int host) {
     if (host == 0) return 0;
     return (uint64_t)static_cast<uint32_t>(prosper::hle::freebsd_errno_from_host(host));
 } }
-HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); pthread_mutex_destroy(m); free(m); } if (a0) *(void**)a0 = nullptr; return 0; }
+// --- DESTROYING A GUEST SYNC OBJECT (#2042) — read this before editing any *Destroy handler ------
+//
+// Every one of these handlers used to `free()` the object outright. That is a use-after-free waiting
+// for a guest that destroys an object another thread is still using: the handlers resolve the
+// pointer from a guest slot and then dereference it, sometimes while PARKED INSIDE it
+// (`pthread_rwlock_rdlock`, `interruptible_cond_wait`), so the freed block is handed to the next
+// `calloc` and prosper's own heap is corrupted. The storage is now RETIRED instead — kept forever,
+// never reused — which keeps the guest's bug the guest's bug. `sync_retire.hpp` carries the full
+// argument, the cost and how the retained count reports itself; `sceKernelDeleteEventFlag` and
+// `sceKernelDeleteSema` below already solved the same hazard their own way (defer the free to the
+// last waiter) and are left alone.
+//
+// WHAT THESE HANDLERS DELIBERATELY STILL DO NOT DO: refuse a busy destroy. FreeBSD libthr — the
+// platform the guest was built against — is NOT uniform here, and the differences are not
+// guessable, so each spelling follows its own source rather than a house rule:
+//
+//   pthread_mutex_destroy   EBUSY when an owner is recorded (`PMUTEX_OWNER_ID(m) != 0`); frees only
+//                           when unowned. EINVAL on an already-destroyed object.
+//   pthread_cond_destroy    EBUSY when `__has_user_waiters || kcond.c_has_waiters`. EINVAL likewise.
+//   pthread_barrier_destroy EBUSY when `b_waiters > 0`, or when another destroy is in progress; it
+//                           also waits out `b_refcount` on the barrier's own condition.
+//   pthread_rwlock_destroy  NO busy check of any kind — it frees unconditionally and returns 0,
+//                           whatever is held or blocked. EINVAL only for a double destroy.
+//   sem_destroy             no busy check; it does not free at all (the sem_t is caller storage).
+//
+// So the EBUSY that is obvious for a *rwlock* is exactly the one the platform does not have, and
+// inventing it here would be a guest-visible divergence introduced to paper over an emulator-side
+// memory-safety problem — the wrong trade in both directions. The three EBUSY results FreeBSD DOES
+// specify are a separate defect (a contract divergence, not a lifetime bug): prosper has no owner
+// tracking on POSIX hosts and no waiter counts for cond/barrier, so each needs new accounting and
+// is guest-visible on every title. Filed rather than folded in here — see #2042's follow-up.
+// CONFIDENCE: HIGH on the table above (read out of libthr and libc, the guest's own platform);
+// CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
+// corpus can currently settle either way — a title observed testing a Destroy result would.
+HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); retire_sync_object(m); } if (a0) *(void**)a0 = nullptr; return 0; }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -785,10 +825,12 @@ HLE(k_cond_init) {
 HLE(k_cond_destroy) {
     if (a0 && !pt_static_sentinel(*(void**)a0)) {
         auto* cond = (pthread_cond_t*)*(void**)a0;
-        pthread_cond_destroy(cond);
+        // Retired, not freed, and the host `pthread_cond_destroy` is deliberately not called — see
+        // the contract block above k_mutex_destroy and sync_retire.hpp (#2042). A thread parked in
+        // interruptible_cond_wait is inside this very object.
         interruptible_cond_forget(cond);
         guest_cond_unregister(cond);
-        free(cond);
+        retire_sync_object(cond);
     }
     if (a0) *(void**)a0 = nullptr;
     return 0;
@@ -839,14 +881,18 @@ HLE(k_rwlock_init) {
     *(void**)a0 = g;    // store handle through caller's slot (a1=attr, a2=name ignored)
     return 0;
 }
-// PRE-EXISTING HAZARD, recorded rather than fixed (#2042): destroying a rwlock while another thread
-// is inside one of the handlers below frees the object under it. That was already true when the
-// object was a bare pthread_rwlock_t — the concurrent thread dereferenced it once — and the hold
-// accounting widens the window to a few atomics. Destroying a lock another thread may still be
-// using is a guest bug on any platform, and no title in the corpus is known to do it; closing it
-// properly needs a lifetime scheme (epoch or refcount) that is out of scope here.
+// #2042. Destroying a rwlock while another thread is inside one of the handlers below used to free
+// the object under it — and the rwlock is the worst of the family, because `k_rwlock_rdlock` parks
+// the caller INSIDE `pthread_rwlock_rdlock(&g->rw)` with the raw pointer live for as long as the
+// lock stays write-held. The storage is retired instead (`sync_retire.hpp`), and the host
+// `pthread_rwlock_destroy` is deliberately not called, since a parked thread is sitting in it.
+//
+// The hold accounting from #2012 is NOT consulted here, and that is the interesting part: FreeBSD's
+// own `pthread_rwlock_destroy` performs no busy check at all and returns 0 whatever is held, so an
+// EBUSY refusal would be a divergence rather than a fix. See the contract table above
+// k_mutex_destroy. The return value, and the cleared slot, are exactly what they were before.
 HLE(k_rwlock_destroy) {
-    if (a0 && !pt_static_sentinel(*(void**)a0)) guest_rwlock_destroy((GuestRwlock*)*(void**)a0);
+    if (a0 && !pt_static_sentinel(*(void**)a0)) retire_sync_object(*(void**)a0);
     if (a0) *(void**)a0 = nullptr;
     return 0;
 }
@@ -2234,14 +2280,18 @@ HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem
 HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
-HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { sem_destroy((sem_t*)*slot); free(*slot); *slot = nullptr; } } return 0; }
+// Retired, not freed, and `sem_destroy` deliberately not called — a thread parked in `sem_wait` is
+// inside this object. See the contract block above k_mutex_destroy and sync_retire.hpp (#2042).
+HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot); *slot = nullptr; } } return 0; }
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
 // past a rendezvous before its peers arrived: the barrier's downstream invariant (all-arrived) is false ->
 // reads of not-yet-produced data (the async-load race class). Back with host pthread_barrier_t; the serial
 // thread gets -1 (PTHREAD_BARRIER_SERIAL_THREAD, FreeBSD's value), the rest 0. Barrierattr are no-ops.
 HLE(k_barrier_init)    { if (!a0 || a2 == 0) return 0x16; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
 HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return 0x16; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : fbsd_errno(rc); }
-HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { pthread_barrier_destroy((pthread_barrier_t*)*slot); free(*slot); *slot = nullptr; } } return 0; }
+// Retired, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the object,
+// which is the widest window in the family. See the contract block above k_mutex_destroy.
+HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot); *slot = nullptr; } } return 0; }
 HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
     // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
     // same class of silent hang root-caused for wait_on_address, hle_kernel_mem.cpp). Sony

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -11,6 +11,7 @@
 #include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
 #include "sync_futex.hpp"
+#include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include <pthread.h>
 #include <chrono>
 #if defined(__linux__)
@@ -714,12 +715,16 @@ HLE(k_uuid_create) {                                       // fill 16 non-zero b
 HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t)); pthread_mutexattr_t at; pthread_mutexattr_init(&at); pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE); pthread_mutex_init(m, &at); pthread_mutexattr_destroy(&at); *(void**)P(a0) = m; } return 0; }
 HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) interruptible_mutex_lock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
 HLE(m_mtx_unlock) { if (a0 && *(void**)P(a0)) pthread_mutex_unlock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
-HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { pthread_mutex_destroy((pthread_mutex_t*)*(void**)P(a0)); free(*(void**)P(a0)); } return 0; }
+// _Mtx_destroy / _Cnd_destroy are the guest STL's own spelling of the same objects, so they carry
+// the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: retire the storage,
+// never free it, and do not call the host destroy on an object a thread may be parked in. See the
+// contract block above k_mutex_destroy in hle_kernel.cpp and sync_retire.hpp (#2042).
+HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { retire_sync_object(*(void**)P(a0)); } return 0; }
 HLE(m_cnd_init)   { if (a0) { auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)P(a0) = c; } return 0; }
 HLE(m_cnd_signal) { if (a0 && *(void**)P(a0)) interruptible_cond_signal((pthread_cond_t*)*(void**)P(a0)); return 0; }
 HLE(m_cnd_broadcast){ if (a0 && *(void**)P(a0)) interruptible_cond_broadcast((pthread_cond_t*)*(void**)P(a0)); return 0; }
 HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) interruptible_cond_wait((pthread_cond_t*)*(void**)P(a0), (pthread_mutex_t*)*(void**)P(a1)); return 0; }
-HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); pthread_cond_destroy(c); interruptible_cond_forget(c); free(c); } return 0; }
+HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); interruptible_cond_forget(c); retire_sync_object(c); } return 0; }
 
 // --- event queue (sceKernelEqueue): kqueue-like event mechanism the engine uses for vsync/flip
 // and async I/O completion. Headless: give a valid queue object; WaitEqueue yields briefly and

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -716,15 +716,18 @@ HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthre
 HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) interruptible_mutex_lock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
 HLE(m_mtx_unlock) { if (a0 && *(void**)P(a0)) pthread_mutex_unlock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
 // _Mtx_destroy / _Cnd_destroy are the guest STL's own spelling of the same objects, so they carry
-// the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: retire the storage,
-// never free it, and do not call the host destroy on an object a thread may be parked in. See the
-// contract block above k_mutex_destroy in hle_kernel.cpp and sync_retire.hpp (#2042).
-HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { retire_sync_object(*(void**)P(a0)); } return 0; }
+// the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: quarantine the storage
+// instead of freeing it here, and defer the host destroy to reclaim, because a thread may be parked
+// inside the object. See the contract block above k_mutex_destroy in hle_kernel.cpp, and
+// sync_retire.hpp (#2042).
+HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { retire_sync_object(*(void**)P(a0), SyncObjectKind::StlMutex,
+                                                          [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } return 0; }
 HLE(m_cnd_init)   { if (a0) { auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)P(a0) = c; } return 0; }
 HLE(m_cnd_signal) { if (a0 && *(void**)P(a0)) interruptible_cond_signal((pthread_cond_t*)*(void**)P(a0)); return 0; }
 HLE(m_cnd_broadcast){ if (a0 && *(void**)P(a0)) interruptible_cond_broadcast((pthread_cond_t*)*(void**)P(a0)); return 0; }
 HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) interruptible_cond_wait((pthread_cond_t*)*(void**)P(a0), (pthread_mutex_t*)*(void**)P(a1)); return 0; }
-HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); interruptible_cond_forget(c); retire_sync_object(c); } return 0; }
+HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); interruptible_cond_forget(c); retire_sync_object(c, SyncObjectKind::StlCond,
+                                                                       [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); }); } return 0; }
 
 // --- event queue (sceKernelEqueue): kqueue-like event mechanism the engine uses for vsync/flip
 // and async I/O completion. Headless: give a valid queue object; WaitEqueue yields briefly and

--- a/prosper/src/hle/sync_retire.cpp
+++ b/prosper/src/hle/sync_retire.cpp
@@ -1,0 +1,42 @@
+// sync_retire.cpp — see sync_retire.hpp for why a destroyed guest sync object is retained.
+#include "sync_retire.hpp"
+#include <cstdio>
+#include <cstdlib>
+#include <mutex>
+#include <vector>
+
+namespace prosper {
+namespace {
+    std::mutex g_retired_mutex;
+    // Owns every retired object for the life of the process. Reachable ON PURPOSE — see the header.
+    std::vector<void*> g_retired;
+
+    bool retire_log() {
+        static const bool on = getenv("PROSPER_SYNC_RETIRELOG") != nullptr;
+        return on;
+    }
+    // Ungated reporting starts here so an ordinary boot stays silent while a title that churns sync
+    // objects cannot. 65,536 retained rwlocks is roughly 5 MB — small enough to be uninteresting,
+    // large enough that reaching it means the guest is doing something worth measuring.
+    constexpr size_t kUngatedReportFloor = 1u << 16;
+}
+
+void retire_sync_object(void* storage) {
+    if (!storage) return;
+    size_t n;
+    {
+        std::lock_guard<std::mutex> lock(g_retired_mutex);
+        g_retired.push_back(storage);
+        n = g_retired.size();
+    }
+    if ((n & (n - 1)) != 0) return;                              // powers of two only
+    if (!retire_log() && n < kUngatedReportFloor) return;
+    fprintf(stderr, "[sync] %zu destroyed guest sync objects retained, never freed (#2042)\n", n);
+}
+
+uint64_t retired_sync_object_count() {
+    std::lock_guard<std::mutex> lock(g_retired_mutex);
+    return (uint64_t)g_retired.size();
+}
+
+}  // namespace prosper

--- a/prosper/src/hle/sync_retire.cpp
+++ b/prosper/src/hle/sync_retire.cpp
@@ -45,13 +45,19 @@ namespace {
     }
     // How long a destroyed object stays unreachable-but-alive. 0 restores the pre-#2042 immediate
     // free (the counter-arm). Negative and unparseable values fall back to the default rather than
-    // silently disabling the guard.
+    // silently disabling the guard — and that has to be enforced by `strtod` + an endptr check, not
+    // by `atof`, which returns 0.0 on no conversion. Under `atof`, `PROSPER_SYNC_RETIRE_SECONDS=on`
+    // or any typo would pass `>= 0.0` and switch the guard OFF, which is the exact use-after-free
+    // this file exists to prevent — with the comment above promising the opposite, so a reader
+    // checking "does this switch fail safe?" would find the reassurance and stop looking.
     double retire_window_seconds() {
         static const double seconds = [] {
             const char* e = getenv("PROSPER_SYNC_RETIRE_SECONDS");
             if (!e || !*e) return 30.0;
-            const double v = atof(e);
-            return v >= 0.0 ? v : 30.0;
+            char* end = nullptr;
+            const double v = strtod(e, &end);
+            if (end == e || *end != '\0' || !(v >= 0.0)) return 30.0;   // !(v>=0) also rejects NaN
+            return v;
         }();
         return seconds;
     }

--- a/prosper/src/hle/sync_retire.cpp
+++ b/prosper/src/hle/sync_retire.cpp
@@ -1,42 +1,114 @@
-// sync_retire.cpp — see sync_retire.hpp for why a destroyed guest sync object is retained.
+// sync_retire.cpp — see sync_retire.hpp for why a destroyed guest sync object is quarantined.
 #include "sync_retire.hpp"
+#include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <deque>
 #include <mutex>
 #include <vector>
 
 namespace prosper {
 namespace {
-    std::mutex g_retired_mutex;
-    // Owns every retired object for the life of the process. Reachable ON PURPOSE — see the header.
-    std::vector<void*> g_retired;
+    const char* const kSyncObjectKindNames[(size_t)SyncObjectKind::Count_] = {
+        "mutex", "cond", "rwlock", "sem", "barrier", "_Mtx", "_Cnd"
+    };
+
+    using Clock = std::chrono::steady_clock;
+
+    struct Retired {
+        void* storage = nullptr;
+        SyncObjectHostDestroy host_destroy = nullptr;
+        Clock::time_point retired_at{};
+    };
+
+    std::mutex g_mutex;
+    std::deque<Retired> g_quarantine;          // FIFO: retirement time is monotonic, so is the order
+    uint64_t g_total = 0;
+    uint64_t g_by_kind[(size_t)SyncObjectKind::Count_] = {};
+    size_t g_high_water = 0;
+    size_t g_reported_high_water = 0;
 
     bool retire_log() {
         static const bool on = getenv("PROSPER_SYNC_RETIRELOG") != nullptr;
         return on;
     }
-    // Ungated reporting starts here so an ordinary boot stays silent while a title that churns sync
-    // objects cannot. 65,536 retained rwlocks is roughly 5 MB — small enough to be uninteresting,
-    // large enough that reaching it means the guest is doing something worth measuring.
+    // How long a destroyed object stays unreachable-but-alive. 0 restores the pre-#2042 immediate
+    // free (the counter-arm). Negative and unparseable values fall back to the default rather than
+    // silently disabling the guard.
+    double retire_window_seconds() {
+        static const double seconds = [] {
+            const char* e = getenv("PROSPER_SYNC_RETIRE_SECONDS");
+            if (!e || !*e) return 30.0;
+            const double v = atof(e);
+            return v >= 0.0 ? v : 30.0;
+        }();
+        return seconds;
+    }
+    // Ungated reporting starts here so an ordinary boot stays silent while a title whose churn is
+    // far above anything measured cannot. 65,536 objects held at once is a few megabytes.
     constexpr size_t kUngatedReportFloor = 1u << 16;
 }
 
-void retire_sync_object(void* storage) {
+void retire_sync_object(void* storage, SyncObjectKind kind, SyncObjectHostDestroy host_destroy) {
     if (!storage) return;
-    size_t n;
+
+    std::vector<Retired> reclaim;              // freed outside the lock
+    size_t held = 0;
+    bool report = false;
+    uint64_t by_kind[(size_t)SyncObjectKind::Count_];
     {
-        std::lock_guard<std::mutex> lock(g_retired_mutex);
-        g_retired.push_back(storage);
-        n = g_retired.size();
+        std::lock_guard<std::mutex> lock(g_mutex);
+        ++g_total;
+        if (kind < SyncObjectKind::Count_) ++g_by_kind[(size_t)kind];
+
+        const double window = retire_window_seconds();
+        const Clock::time_point now = Clock::now();
+        const Clock::time_point cutoff =
+            now - std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(window));
+        while (!g_quarantine.empty() && g_quarantine.front().retired_at <= cutoff) {
+            reclaim.push_back(g_quarantine.front());
+            g_quarantine.pop_front();
+        }
+
+        if (window > 0.0) g_quarantine.push_back(Retired{storage, host_destroy, now});
+        else              reclaim.push_back(Retired{storage, host_destroy, now});
+
+        held = g_quarantine.size();
+        g_high_water = std::max(g_high_water, held);
+        // Report on powers of two of the HIGH WATER, so a steady state reports once rather than
+        // oscillating across a boundary forever.
+        if (g_high_water > g_reported_high_water && (g_high_water & (g_high_water - 1)) == 0 &&
+            (retire_log() || g_high_water >= kUngatedReportFloor)) {
+            g_reported_high_water = g_high_water;
+            report = true;
+            for (size_t k = 0; k < (size_t)SyncObjectKind::Count_; ++k) by_kind[k] = g_by_kind[k];
+        }
     }
-    if ((n & (n - 1)) != 0) return;                              // powers of two only
-    if (!retire_log() && n < kUngatedReportFloor) return;
-    fprintf(stderr, "[sync] %zu destroyed guest sync objects retained, never freed (#2042)\n", n);
+
+    for (const Retired& r : reclaim) {
+        if (r.host_destroy) r.host_destroy(r.storage);
+        free(r.storage);
+    }
+
+    if (!report) return;
+    char census[224];
+    int off = 0;
+    for (size_t k = 0; k < (size_t)SyncObjectKind::Count_ && off > -1 && off < (int)sizeof census; ++k)
+        off += snprintf(census + off, sizeof census - (size_t)off, " %s=%llu",
+                        kSyncObjectKindNames[k], (unsigned long long)by_kind[k]);
+    fprintf(stderr, "[sync] %zu destroyed guest sync objects held in quarantine (#2042); "
+                    "destroyed so far:%s\n", held, census);
 }
 
 uint64_t retired_sync_object_count() {
-    std::lock_guard<std::mutex> lock(g_retired_mutex);
-    return (uint64_t)g_retired.size();
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_total;
+}
+
+uint64_t quarantined_sync_object_count() {
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return (uint64_t)g_quarantine.size();
 }
 
 }  // namespace prosper

--- a/prosper/src/hle/sync_retire.cpp
+++ b/prosper/src/hle/sync_retire.cpp
@@ -22,12 +22,22 @@ namespace {
         Clock::time_point retired_at{};
     };
 
-    std::mutex g_mutex;
-    std::deque<Retired> g_quarantine;          // FIFO: retirement time is monotonic, so is the order
-    uint64_t g_total = 0;
-    uint64_t g_by_kind[(size_t)SyncObjectKind::Count_] = {};
-    size_t g_high_water = 0;
-    size_t g_reported_high_water = 0;
+    struct Registry {
+        std::mutex mutex;
+        std::deque<Retired> quarantine;   // FIFO: retirement time is monotonic, so is the order
+        uint64_t total = 0;
+        uint64_t by_kind[(size_t)SyncObjectKind::Count_] = {};
+        size_t high_water = 0;
+        size_t reported_high_water = 0;
+    };
+    // DELIBERATELY LEAKED, and never destroyed. A guest thread can reach a *Destroy handler during
+    // static teardown (guest TSD destructors and atexit handlers both run there), and a namespace
+    // -scope registry would already have been destroyed by then — trading a use-after-free on the
+    // guest's object for a use-after-free on the machinery that exists to prevent it.
+    Registry& registry() {
+        static Registry* const r = new Registry();
+        return *r;
+    }
 
     bool retire_log() {
         static const bool on = getenv("PROSPER_SYNC_RETIRELOG") != nullptr;
@@ -57,32 +67,34 @@ void retire_sync_object(void* storage, SyncObjectKind kind, SyncObjectHostDestro
     size_t held = 0;
     bool report = false;
     uint64_t by_kind[(size_t)SyncObjectKind::Count_];
+    Registry& reg = registry();
     {
-        std::lock_guard<std::mutex> lock(g_mutex);
-        ++g_total;
-        if (kind < SyncObjectKind::Count_) ++g_by_kind[(size_t)kind];
+        std::lock_guard<std::mutex> lock(reg.mutex);
+        ++reg.total;
+        if (kind < SyncObjectKind::Count_) ++reg.by_kind[(size_t)kind];
 
         const double window = retire_window_seconds();
         const Clock::time_point now = Clock::now();
         const Clock::time_point cutoff =
             now - std::chrono::duration_cast<Clock::duration>(std::chrono::duration<double>(window));
-        while (!g_quarantine.empty() && g_quarantine.front().retired_at <= cutoff) {
-            reclaim.push_back(g_quarantine.front());
-            g_quarantine.pop_front();
+        while (!reg.quarantine.empty() && reg.quarantine.front().retired_at <= cutoff) {
+            reclaim.push_back(reg.quarantine.front());
+            reg.quarantine.pop_front();
         }
 
-        if (window > 0.0) g_quarantine.push_back(Retired{storage, host_destroy, now});
+        if (window > 0.0) reg.quarantine.push_back(Retired{storage, host_destroy, now});
         else              reclaim.push_back(Retired{storage, host_destroy, now});
 
-        held = g_quarantine.size();
-        g_high_water = std::max(g_high_water, held);
+        held = reg.quarantine.size();
+        reg.high_water = std::max(reg.high_water, held);
         // Report on powers of two of the HIGH WATER, so a steady state reports once rather than
         // oscillating across a boundary forever.
-        if (g_high_water > g_reported_high_water && (g_high_water & (g_high_water - 1)) == 0 &&
-            (retire_log() || g_high_water >= kUngatedReportFloor)) {
-            g_reported_high_water = g_high_water;
+        if (reg.high_water > reg.reported_high_water &&
+            (reg.high_water & (reg.high_water - 1)) == 0 &&
+            (retire_log() || reg.high_water >= kUngatedReportFloor)) {
+            reg.reported_high_water = reg.high_water;
             report = true;
-            for (size_t k = 0; k < (size_t)SyncObjectKind::Count_; ++k) by_kind[k] = g_by_kind[k];
+            for (size_t k = 0; k < (size_t)SyncObjectKind::Count_; ++k) by_kind[k] = reg.by_kind[k];
         }
     }
 
@@ -102,13 +114,15 @@ void retire_sync_object(void* storage, SyncObjectKind kind, SyncObjectHostDestro
 }
 
 uint64_t retired_sync_object_count() {
-    std::lock_guard<std::mutex> lock(g_mutex);
-    return g_total;
+    Registry& reg = registry();
+    std::lock_guard<std::mutex> lock(reg.mutex);
+    return reg.total;
 }
 
 uint64_t quarantined_sync_object_count() {
-    std::lock_guard<std::mutex> lock(g_mutex);
-    return (uint64_t)g_quarantine.size();
+    Registry& reg = registry();
+    std::lock_guard<std::mutex> lock(reg.mutex);
+    return (uint64_t)reg.quarantine.size();
 }
 
 }  // namespace prosper

--- a/prosper/src/hle/sync_retire.hpp
+++ b/prosper/src/hle/sync_retire.hpp
@@ -1,0 +1,48 @@
+// sync_retire.hpp — storage lifetime for destroyed guest synchronization objects (#2042).
+//
+// THE HAZARD. A guest sync object (mutex, condvar, rwlock, semaphore, barrier) is reached through a
+// POINTER SLOT in guest memory. Every handler re-reads that slot, resolves the host object, and then
+// dereferences it — including across a call that BLOCKS: `pthread_rwlock_rdlock(&g->rw)` parks the
+// calling thread *inside* the object, and so does `interruptible_cond_wait`. A concurrent `Destroy`
+// that returned the storage to the allocator would free it under a thread parked in prosper's own
+// handler, and the block would then be handed to the next `calloc`. So a guest bug — destroying an
+// object another thread is still using — becomes corruption of PROSPER's heap, in prosper's own
+// allocator, with no diagnosable link back to the guest call that caused it. That asymmetry is the
+// whole argument: the guest's bug stays the guest's bug on hardware, and must stay the guest's bug
+// here rather than being amplified into an emulator defect.
+//
+// THE FIX. A destroyed object's storage is RETIRED: kept alive, and never reused for anything. A
+// stale pointer then still names a live object of the right type, so the worst outcome is an
+// operation on a lock nothing can reach any more — which is the guest's own bug, contained.
+//
+// WHY THE POINTERS ARE KEPT IN A LIVE CONTAINER. Simply not calling `free` would be indistinguish-
+// able from a leak to LSan/valgrind and would bury real leaks under this one. A reachable owner
+// makes the retention a deliberate, auditable policy instead of an omission.
+//
+// WHY THE HOST PRIMITIVE IS NOT DESTROYED FIRST. `pthread_*_destroy` on an object another thread is
+// blocked in is undefined, and on some hosts (winpthreads) it frees an inner allocation the parked
+// thread still holds a handle to — reintroducing exactly the use-after-free this exists to remove.
+// Callers therefore retire the object WITHOUT calling the matching host destroy, and without running
+// its C++ destructor. On glibc and Apple libc these destroys own no kernel resource, so nothing is
+// lost; on winpthreads the inner allocation is retained along with the object.
+//
+// COST, AND HOW IT ANNOUNCES ITSELF. One object per guest `Destroy`, never reclaimed. Bounding that
+// needs epoch or hazard-pointer reclamation, which is a much larger change than this defect
+// justifies (#2042) — so instead the retained count is REPORTED at powers of two from 65,536 upward
+// (and from 1 under `PROSPER_SYNC_RETIRELOG=1`). A title that churns sync objects therefore
+// announces itself rather than growing silently, and the follow-up is then justified by measurement
+// rather than by argument.
+#pragma once
+#include <cstdint>
+
+namespace prosper {
+
+// Take ownership of a destroyed guest sync object's storage: never freed, never reused. Null is
+// ignored. Safe to call from any thread. The caller must NOT have called the matching host
+// `pthread_*_destroy` / `sem_destroy`, and must not run the object's C++ destructor — see above.
+void retire_sync_object(void* storage);
+
+// How many objects have been retired so far. For tests and diagnostics.
+uint64_t retired_sync_object_count();
+
+}  // namespace prosper

--- a/prosper/src/hle/sync_retire.hpp
+++ b/prosper/src/hle/sync_retire.hpp
@@ -30,7 +30,7 @@
 // unbounded case: a thread PARKED inside a destroyed object (blocked on a lock the guest then
 // destroyed) can outlive any window, and after it expires the object is reclaimed under that thread.
 // Closing that needs hazard-pointer or epoch reclamation bracketing every sync handler — real, and
-// far larger than this defect justifies; see #2042's follow-up. Note that FreeBSD frees a rwlock
+// far larger than this defect justifies; filed as #2169. Note that FreeBSD frees a rwlock
 // under a parked waiter too, so prosper is not worse than the platform there.
 //
 // WHY THE HOST PRIMITIVE IS DESTROYED ONLY AT RECLAIM. `pthread_*_destroy` on an object another

--- a/prosper/src/hle/sync_retire.hpp
+++ b/prosper/src/hle/sync_retire.hpp
@@ -2,47 +2,71 @@
 //
 // THE HAZARD. A guest sync object (mutex, condvar, rwlock, semaphore, barrier) is reached through a
 // POINTER SLOT in guest memory. Every handler re-reads that slot, resolves the host object, and then
-// dereferences it — including across a call that BLOCKS: `pthread_rwlock_rdlock(&g->rw)` parks the
-// calling thread *inside* the object, and so does `interruptible_cond_wait`. A concurrent `Destroy`
-// that returned the storage to the allocator would free it under a thread parked in prosper's own
-// handler, and the block would then be handed to the next `calloc`. So a guest bug — destroying an
-// object another thread is still using — becomes corruption of PROSPER's heap, in prosper's own
-// allocator, with no diagnosable link back to the guest call that caused it. That asymmetry is the
-// whole argument: the guest's bug stays the guest's bug on hardware, and must stay the guest's bug
-// here rather than being amplified into an emulator defect.
+// dereferences it — including across a call that BLOCKS: `interruptible_mutex_lock` and
+// `pthread_rwlock_rdlock` park the calling thread *inside* the object. A `Destroy` that returns the
+// storage to the allocator therefore frees it under a thread sitting in prosper's own handler, and
+// the block goes straight to the next `calloc`. So a guest bug — destroying an object another thread
+// is still using — stops corrupting the guest's own state and starts corrupting PROSPER's heap, in
+// prosper's own allocator, with no diagnosable link back to the guest call that caused it. That
+// asymmetry is the whole argument: the guest's bug stays the guest's bug on hardware and must stay
+// the guest's bug here rather than being amplified into an emulator defect.
 //
-// THE FIX. A destroyed object's storage is RETIRED: kept alive, and never reused for anything. A
-// stale pointer then still names a live object of the right type, so the worst outcome is an
-// operation on a lock nothing can reach any more — which is the guest's own bug, contained.
+// THE FIX. A destroyed object's storage goes into a QUARANTINE and is reclaimed only after it has
+// been unreachable for `PROSPER_SYNC_RETIRE_SECONDS` (default 30 s). A stale pointer inside an
+// in-flight handler therefore still names a live object of the right type.
 //
-// WHY THE POINTERS ARE KEPT IN A LIVE CONTAINER. Simply not calling `free` would be indistinguish-
-// able from a leak to LSan/valgrind and would bury real leaks under this one. A reachable owner
-// makes the retention a deliberate, auditable policy instead of an omission.
+// WHY A TIME WINDOW AND NOT PERMANENT RETENTION. #2042 proposed never freeing at all, on the premise
+// that guest sync objects are few. Measured on *The Messenger* (`PPSA24651`), 90 s of headless boot,
+// `PROSPER_SYNC_RETIRELOG=1`: **131,066 mutex destroys** against 6 cond, 0 rwlock, 0 sem, 0 barrier
+// and 0 of either C11 spelling. Permanent retention is ~5 MB per 90 s on a guarded title — hundreds
+// of megabytes in a play session — so the premise is false for the family as a whole, and true only
+// for the six low-volume kinds. A window bounds the retained set by RATE rather than by total, which
+// is the variable that actually varies: at the measured churn the default holds ~44,000 mutexes,
+// about 1.7 MB.
 //
-// WHY THE HOST PRIMITIVE IS NOT DESTROYED FIRST. `pthread_*_destroy` on an object another thread is
-// blocked in is undefined, and on some hosts (winpthreads) it frees an inner allocation the parked
+// WHAT THE WINDOW DOES AND DOES NOT CLOSE. It closes the window in the issue's own failure scenario
+// completely — "thread A is descheduled" between resolving the pointer and dereferencing it is
+// bounded by scheduler latency, four orders of magnitude inside the default. It does NOT close the
+// unbounded case: a thread PARKED inside a destroyed object (blocked on a lock the guest then
+// destroyed) can outlive any window, and after it expires the object is reclaimed under that thread.
+// Closing that needs hazard-pointer or epoch reclamation bracketing every sync handler — real, and
+// far larger than this defect justifies; see #2042's follow-up. Note that FreeBSD frees a rwlock
+// under a parked waiter too, so prosper is not worse than the platform there.
+//
+// WHY THE HOST PRIMITIVE IS DESTROYED ONLY AT RECLAIM. `pthread_*_destroy` on an object another
+// thread is blocked in is undefined, and on winpthreads it frees an inner allocation the parked
 // thread still holds a handle to — reintroducing exactly the use-after-free this exists to remove.
-// Callers therefore retire the object WITHOUT calling the matching host destroy, and without running
-// its C++ destructor. On glibc and Apple libc these destroys own no kernel resource, so nothing is
-// lost; on winpthreads the inner allocation is retained along with the object.
+// So the caller does NOT destroy the host primitive; it hands over a callback that runs once the
+// object leaves quarantine, which is also what keeps winpthreads' inner allocation from leaking.
 //
-// COST, AND HOW IT ANNOUNCES ITSELF. One object per guest `Destroy`, never reclaimed. Bounding that
-// needs epoch or hazard-pointer reclamation, which is a much larger change than this defect
-// justifies (#2042) — so instead the retained count is REPORTED at powers of two from 65,536 upward
-// (and from 1 under `PROSPER_SYNC_RETIRELOG=1`). A title that churns sync objects therefore
-// announces itself rather than growing silently, and the follow-up is then justified by measurement
-// rather than by argument.
+// DIAGNOSTICS AND THE COUNTER-ARM.
+//   PROSPER_SYNC_RETIRELOG=1        report the retained high-water and a per-kind census.
+//   PROSPER_SYNC_RETIRE_SECONDS=N   override the window. **N=0 restores the pre-#2042 immediate
+//                                   free**, so the A/B stays reproducible on a shipped binary — the
+//                                   `sync_destroy_lifetime_counter_arm` ctest entry is exactly that.
 #pragma once
 #include <cstdint>
 
 namespace prosper {
 
-// Take ownership of a destroyed guest sync object's storage: never freed, never reused. Null is
-// ignored. Safe to call from any thread. The caller must NOT have called the matching host
-// `pthread_*_destroy` / `sem_destroy`, and must not run the object's C++ destructor — see above.
-void retire_sync_object(void* storage);
+// Which spelling retired the object. Only the diagnostic census distinguishes them; the policy does
+// not. Keep in sync with kSyncObjectKindNames in sync_retire.cpp.
+enum class SyncObjectKind : uint32_t {
+    Mutex, Cond, Rwlock, Sem, Barrier, StlMutex, StlCond, Count_
+};
 
-// How many objects have been retired so far. For tests and diagnostics.
+// Runs once the object leaves quarantine and immediately before its storage is freed: the caller's
+// matching `pthread_*_destroy` / `sem_destroy`, plus any C++ destructor the type needs. Kept at the
+// call site so this file needs no knowledge of the object layouts.
+using SyncObjectHostDestroy = void (*)(void*);
+
+// Hand a destroyed guest sync object's storage over to the quarantine. Null is ignored. Safe to call
+// from any thread. The caller must NOT already have destroyed the host primitive — see above.
+void retire_sync_object(void* storage, SyncObjectKind kind, SyncObjectHostDestroy host_destroy);
+
+// Total objects ever retired, and how many are held in quarantine right now. For tests and
+// diagnostics.
 uint64_t retired_sync_object_count();
+uint64_t quarantined_sync_object_count();
 
 }  // namespace prosper

--- a/prosper/tests/test_sync_destroy_lifetime.cpp
+++ b/prosper/tests/test_sync_destroy_lifetime.cpp
@@ -20,7 +20,9 @@
 //
 // THE COUNTER-ARM IS PART OF THE SUITE. `PROSPER_SYNC_RETIRE_SECONDS=0` restores the pre-#2042
 // immediate free on this same binary, and CMake registers that as `sync_destroy_lifetime_counter_arm`
-// with WILL_FAIL, so CI keeps proving that these assertions CAN fail. Measured: 10 do — all seven
+// with WILL_FAIL (**Linux only** — the red depends on glibc's tcache reusing a just-freed block
+// immediately, which is the mechanism being demonstrated and not measured on other allocators; see
+// the CMake comment), so CI keeps proving that these assertions CAN fail. Measured: 10 do — all seven
 // spellings in arm 1 and three in arm 2, including `[rwlock] UNMATCHED unlock … holds=0` as the
 // freed object's accounting is reused by the next Init and the parked reader is never woken. The
 // retirement census below still passes under the counter-arm, and should: the objects really are

--- a/prosper/tests/test_sync_destroy_lifetime.cpp
+++ b/prosper/tests/test_sync_destroy_lifetime.cpp
@@ -1,0 +1,190 @@
+// test_sync_destroy_lifetime — #2042. Destroying a guest synchronization object must not hand its
+// storage back to the allocator, because prosper's handlers resolve the object from a guest slot and
+// then dereference it — sometimes while PARKED INSIDE it. A freed block is reused by the very next
+// `calloc`, so a guest that destroys an object another thread is still using stops corrupting its
+// own state and starts corrupting prosper's heap instead.
+//
+// The arms below call the handlers through the NID registry, exactly as the guest reaches them.
+//
+//   Arm 1  every *Destroy handler in the family: the destroyed object's address is never issued
+//          again. Deterministic under the fix on every allocator; RED on glibc because its tcache
+//          returns a just-freed block of the same size to the next allocation, which is precisely
+//          the reuse that turns the dangling pointer into corruption.
+//   Arm 2  the case the issue describes, constructed BY HAND: a thread parked inside
+//          `k_rwlock_rdlock` on a write-held lock, destroyed under it. Asserts the parked thread's
+//          object stays live and that the next Init does not alias it.
+//
+// Arm 2 asserts its own preconditions before it asserts anything else (the write hold really
+// excludes; the reader really did not acquire), because an arm that cannot construct the state it
+// claims to test passes for the wrong reason — the harness would be testing nothing at all.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/sync_retire.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+HleFn look(const char* name) { return Hle::lookup(nid_hash(name)); }
+
+uint64_t call(HleFn f, uint64_t a0, uint64_t a1 = 0, uint64_t a2 = 0) {
+    return f(a0, a1, a2, 0, 0, 0);
+}
+
+// One round of Init/Destroy through a guest slot, reporting the object the Init published.
+// `init_a2` carries the one argument that differs across the family (semaphore value, barrier count).
+void* init_destroy_round(HleFn init, HleFn destroy, uint64_t init_a2) {
+    void* slot = nullptr;
+    call(init, (uint64_t)(uintptr_t)&slot, 0, init_a2);
+    void* published = slot;
+    call(destroy, (uint64_t)(uintptr_t)&slot);
+    return published;
+}
+
+// Arm 1 for one spelling. Rounds of Init/Destroy must never publish the same address twice.
+void distinct_storage_arm(const char* label, const char* init_name, const char* destroy_name,
+                          uint64_t init_a2) {
+    HleFn init = look(init_name), destroy = look(destroy_name);
+    const std::string registered = std::string(label) + ": both handlers registered";
+    CHECK(init && destroy, registered.c_str());
+    if (!init || !destroy) return;
+
+    constexpr int kRounds = 8;
+    std::vector<void*> seen;
+    bool allocated_every_round = true;
+    for (int i = 0; i < kRounds; ++i) {
+        void* p = init_destroy_round(init, destroy, init_a2);
+        if (!p) { allocated_every_round = false; break; }
+        seen.push_back(p);
+    }
+    // Without this the arm would pass vacuously against an Init that published nothing.
+    const std::string allocated = std::string(label) + ": Init published an object every round";
+    CHECK(allocated_every_round && (int)seen.size() == kRounds, allocated.c_str());
+
+    int repeats = 0;
+    for (size_t i = 0; i < seen.size(); ++i)
+        for (size_t j = i + 1; j < seen.size(); ++j)
+            if (seen[i] == seen[j]) ++repeats;
+    char msg[192];
+    snprintf(msg, sizeof msg,
+             "%s: no destroyed object's storage is issued again (%d repeats over %d rounds)",
+             label, repeats, kRounds);
+    CHECK(repeats == 0, msg);
+}
+
+}  // namespace
+
+int main() {
+    printf("== test_sync_destroy_lifetime ==\n");
+    register_builtin_hle();
+
+    const uint64_t retired_at_start = retired_sync_object_count();
+
+    // ---- Arm 1: the whole family -------------------------------------------------------------
+    // Every guest-slot sync object with a *Destroy handler. The issue named four; barrier and the
+    // guest STL's own _Mtx_/_Cnd_ spellings have the identical shape and are included here.
+    printf("-- arm 1: a destroyed object's storage is never reissued --\n");
+    distinct_storage_arm("rwlock",  "scePthreadRwlockInit",  "scePthreadRwlockDestroy",  0);
+    distinct_storage_arm("mutex",   "scePthreadMutexInit",   "scePthreadMutexDestroy",   0);
+    distinct_storage_arm("cond",    "scePthreadCondInit",    "scePthreadCondDestroy",    0);
+    distinct_storage_arm("sem",     "scePthreadSemInit",     "scePthreadSemDestroy",     1);
+    distinct_storage_arm("barrier", "scePthreadBarrierInit", "scePthreadBarrierDestroy", 2);
+    distinct_storage_arm("_Mtx",    "_Mtx_init",             "_Mtx_destroy",             0);
+    distinct_storage_arm("_Cnd",    "_Cnd_init",             "_Cnd_destroy",             0);
+
+    // 7 spellings x 8 rounds. Counting them is what separates "retired" from "the allocator merely
+    // happened not to reuse the block", which is the only other way arm 1 could come out clean.
+    const uint64_t retired = retired_sync_object_count() - retired_at_start;
+    char count_msg[160];
+    snprintf(count_msg, sizeof count_msg,
+             "every Destroy retired its object (%llu retired, expected 56)",
+             (unsigned long long)retired);
+    CHECK(retired == 56, count_msg);
+
+    // ---- Arm 2: destroy under a thread parked inside the handler ------------------------------
+    printf("-- arm 2: an rwlock a thread is parked inside survives its Destroy --\n");
+    HleFn RWinit  = look("scePthreadRwlockInit");
+    HleFn RWwr    = look("scePthreadRwlockWrlock");
+    HleFn RWrd    = look("scePthreadRwlockRdlock");
+    HleFn RWun    = look("scePthreadRwlockUnlock");
+    HleFn RWtrywr = look("scePthreadRwlockTrywrlock");
+    HleFn RWdes   = look("scePthreadRwlockDestroy");
+    CHECK(RWinit && RWwr && RWrd && RWun && RWtrywr && RWdes, "rwlock handlers registered");
+    if (!(RWinit && RWwr && RWrd && RWun && RWtrywr && RWdes)) { printf("== FAIL ==\n"); return 1; }
+
+    void* slot_a = nullptr;
+    call(RWinit, (uint64_t)(uintptr_t)&slot_a);
+    void* parked_object = slot_a;
+    CHECK(parked_object != nullptr, "rwlock A initialised");
+
+    CHECK(call(RWwr, (uint64_t)(uintptr_t)&slot_a) == 0, "main takes the write lock on A");
+    // PRECONDITION, not a result: the hold must be real, or nothing below constructs the case.
+    CHECK(call(RWtrywr, (uint64_t)(uintptr_t)&slot_a) != 0,
+          "precondition: the write hold really excludes (trywrlock refused)");
+
+    std::atomic<bool> entered{false}, acquired{false};
+    std::thread reader([&] {
+        entered.store(true, std::memory_order_release);
+        call(RWrd, (uint64_t)(uintptr_t)&slot_a);          // parks inside pthread_rwlock_rdlock
+        acquired.store(true, std::memory_order_release);
+    });
+    while (!entered.load(std::memory_order_acquire)) std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    // PRECONDITION: it cannot have acquired — main holds the write lock — so after 200 ms past its
+    // own entry flag it is inside k_rwlock_rdlock, holding `parked_object` as a raw pointer.
+    CHECK(!acquired.load(std::memory_order_acquire),
+          "precondition: the reader is parked INSIDE k_rwlock_rdlock on this object");
+
+    call(RWdes, (uint64_t)(uintptr_t)&slot_a);             // the guest bug: destroy under the waiter
+    CHECK(slot_a == nullptr, "Destroy cleared the guest slot (unchanged behaviour)");
+
+    void* slot_b = nullptr;
+    call(RWinit, (uint64_t)(uintptr_t)&slot_b);
+    CHECK(slot_b != nullptr, "rwlock B initialised after the destroy");
+    // THE ASSERTION. On master the allocator hands B the block A was freed from, so B and the
+    // object the reader is parked in are the same memory: B's fresh pthread_rwlock_init resets the
+    // futex state under the parked thread, and B's hold accounting is whatever that thread does next.
+    CHECK(slot_b != parked_object,
+          "a new rwlock does not alias the object a thread is parked in");
+
+    // The destroy cleared slot A, so the guest can no longer reach the object it is holding — but
+    // the object itself must still be a live rwlock. Reach it through a slot holding the same
+    // pointer (which is exactly what an in-flight handler holds) and release the write hold: the
+    // parked reader must then wake. Under the fix this is an ordinary operation on a retired object;
+    // on master it is the use-after-free itself.
+    void* alias = parked_object;
+    CHECK(call(RWun, (uint64_t)(uintptr_t)&alias) == 0,
+          "the retired object is still a live rwlock: its write hold releases");
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!acquired.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    const bool woke = acquired.load(std::memory_order_acquire);
+    CHECK(woke, "the parked reader woke and completed its acquisition on the retired object");
+    if (woke) reader.join();
+    else      reader.detach();   // still parked: joining would hang the suite instead of failing it
+
+    if (woke)
+        CHECK(call(RWun, (uint64_t)(uintptr_t)&alias) == 0,
+              "the read hold the parked reader took releases normally afterwards");
+
+    // Lock B is untouched by any of it: nothing that happened to A reached it.
+    CHECK(call(RWtrywr, (uint64_t)(uintptr_t)&slot_b) == 0,
+          "rwlock B is uncontaminated: it write-acquires cleanly");
+    call(RWun, (uint64_t)(uintptr_t)&slot_b);
+
+    printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_sync_destroy_lifetime.cpp
+++ b/prosper/tests/test_sync_destroy_lifetime.cpp
@@ -6,10 +6,10 @@
 //
 // The arms below call the handlers through the NID registry, exactly as the guest reaches them.
 //
-//   Arm 1  every *Destroy handler in the family: the destroyed object's address is never issued
-//          again. Deterministic under the fix on every allocator; RED on glibc because its tcache
-//          returns a just-freed block of the same size to the next allocation, which is precisely
-//          the reuse that turns the dangling pointer into corruption.
+//   Arm 1  every *Destroy handler in the family: within the quarantine window, a destroyed object's
+//          address is never issued again. Deterministic under the fix on every allocator; RED on
+//          glibc because its tcache returns a just-freed block of the same size to the very next
+//          allocation, which is precisely the reuse that turns the dangling pointer into corruption.
 //   Arm 2  the case the issue describes, constructed BY HAND: a thread parked inside
 //          `k_rwlock_rdlock` on a write-held lock, destroyed under it. Asserts the parked thread's
 //          object stays live and that the next Init does not alias it.
@@ -17,6 +17,15 @@
 // Arm 2 asserts its own preconditions before it asserts anything else (the write hold really
 // excludes; the reader really did not acquire), because an arm that cannot construct the state it
 // claims to test passes for the wrong reason — the harness would be testing nothing at all.
+//
+// THE COUNTER-ARM IS PART OF THE SUITE. `PROSPER_SYNC_RETIRE_SECONDS=0` restores the pre-#2042
+// immediate free on this same binary, and CMake registers that as `sync_destroy_lifetime_counter_arm`
+// with WILL_FAIL, so CI keeps proving that these assertions CAN fail. Measured: 10 do — all seven
+// spellings in arm 1 and three in arm 2, including `[rwlock] UNMATCHED unlock … holds=0` as the
+// freed object's accounting is reused by the next Init and the parked reader is never woken. The
+// retirement census below still passes under the counter-arm, and should: the objects really are
+// handed over, the window is simply zero, so they are reclaimed on the spot. Rebuilding this file
+// against pre-#2042 handlers instead fails 11 — the census too, since nothing is handed over at all.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/sync_retire.hpp"
@@ -108,8 +117,8 @@ int main() {
     const uint64_t retired = retired_sync_object_count() - retired_at_start;
     char count_msg[160];
     snprintf(count_msg, sizeof count_msg,
-             "every Destroy retired its object (%llu retired, expected 56)",
-             (unsigned long long)retired);
+             "every Destroy retired its object (%llu retired, expected 56; %llu still quarantined)",
+             (unsigned long long)retired, (unsigned long long)quarantined_sync_object_count());
     CHECK(retired == 56, count_msg);
 
     // ---- Arm 2: destroy under a thread parked inside the handler ------------------------------


### PR DESCRIPTION
Fixes #2042. Refs #2015, #2024.

**A guest `Destroy` must not be able to corrupt prosper's own heap.**

## The failure

A guest sync object is reached through a **pointer slot in guest memory**. Every handler re-reads
that slot, resolves the host object, and then dereferences it — including across a call that
**blocks**: `interruptible_mutex_lock` and `pthread_rwlock_rdlock` park the calling thread *inside*
the object. Each `*Destroy` handler called `free()` on that storage outright, so a concurrent
`Destroy` freed the object under a thread parked in prosper's own handler, and glibc's tcache handed
the block to the very next `calloc`.

The asymmetry is the whole argument. Destroying an object another thread is still using is a guest
bug on any platform, and on hardware it stays the *guest's* bug. Under prosper it became corruption
of **prosper's heap, in prosper's allocator**, with no diagnosable link back to the guest call that
caused it.

## How many handlers actually share it

The issue names four. There are **seven**, and all seven change:

| handler | spellings | shares the defect |
|---|---|---|
| `k_mutex_destroy` | `scePthreadMutexDestroy`, `pthread_mutex_destroy` | yes |
| `k_cond_destroy` | `scePthreadCondDestroy`, `pthread_cond_destroy` | yes |
| `k_rwlock_destroy` | `scePthreadRwlockDestroy`, `pthread_rwlock_destroy` | yes — the issue's subject |
| `k_sem_destroy` | `scePthreadSemDestroy`, `sem_destroy` | yes |
| `k_barrier_destroy` | `scePthreadBarrierDestroy` | yes — **not named in the issue** |
| `m_mtx_destroy` | `_Mtx_destroy` (guest STL, `hle_kernel_time.cpp`) | yes — **not named in the issue** |
| `m_cnd_destroy` | `_Cnd_destroy` (guest STL, `hle_kernel_time.cpp`) | yes — **not named in the issue** |

Two more have the identical shape and **already solve it**, their own way, and are left alone:
`sceKernelDeleteEventFlag` and `sceKernelDeleteSema` free now if nobody is parked and otherwise hand
the free to the last waiter (`hle_kernel.cpp`, the comment above `sema_destroy` records exactly this
hazard). The four *attr* destroys (`scePthreadMutexattrDestroy`, `Condattr`, `Rwlockattr`,
`ScePthreadAttrDestroy`) free without a check too, but an attr has no blocking operation, so there is
no window in which a thread is parked holding the pointer; that is an ordinary guest data race with
the same shape on hardware. Not changed.

## The contract: what does the platform do on a *busy* destroy?

This is the part the issue guesses at, and the guess is wrong for the object it is about. Read out of
FreeBSD libthr / libc — the platform the guest was built against — the family is **not uniform**:

| | busy check | on busy |
|---|---|---|
| `pthread_mutex_destroy` | `PMUTEX_OWNER_ID(m) != 0` | **EBUSY**, does not free |
| `pthread_cond_destroy` | `__has_user_waiters \|\| kcond.c_has_waiters` | **EBUSY**, does not free |
| `pthread_barrier_destroy` | `b_waiters > 0`, or a concurrent destroy; also waits out `b_refcount` | **EBUSY** |
| `pthread_rwlock_destroy` | **none at all** | frees unconditionally, returns **0** |
| `sem_destroy` | none | clears `_magic`, returns 0 (never frees — the `sem_t` is caller storage) |

So **the `EBUSY` that looks obvious for a rwlock is exactly the one the platform does not have.**
Adding it would be a guest-visible divergence introduced to paper over an emulator-side memory-safety
problem — the wrong trade in both directions, and against the #1984 principle that `scePthread*`
results follow the platform rather than a house rule. `k_rwlock_destroy` therefore does **not**
consult the #2012 hold accounting, and every handler returns exactly what it returned before.

The three `EBUSY` results FreeBSD *does* specify are a real, separate defect — a contract divergence,
not a lifetime bug. prosper has no mutex ownership tracking on POSIX hosts and no waiter counts for
cond or barrier, so each needs new accounting and is guest-visible on every title. **Filed as #2168**
rather than folded in here.

`CONFIDENCE: HIGH` on the table (libthr/libc source, tier-2 evidence).
`CONFIDENCE: MED` that Sony's libkernel did not rewrite these bodies — no title in the corpus has
been observed testing a `Destroy` result, and one that did would settle it.

A **third** divergence turned up alongside: FreeBSD writes a `THR_*_DESTROYED` poison through the
handle slot and fails `EINVAL` on any later use, while prosper writes `NULL`, which
`pt_static_sentinel()` reads as *"statically initialized, self-init me"* — so a use-after-destroy
silently manufactures a fresh **unheld** lock and succeeds. Filed as **#2170**; not touched here,
since it is a contract change on every title and independent of the lifetime fix.

## Is the free the bug, or the missing check?

**The free.** Returning an error and not freeing is the usual answer, and here the platform says not
to return the error — so the fix is entirely on the lifetime side.

## What was implemented, and why it is not what #2042 proposed

#2042 proposed "never free — retire into a per-process list, since guest rwlocks are few". The first
commit on this branch did exactly that, with a self-reporting retained count. **The instrument
immediately falsified its own premise.** `PROSPER_SYNC_RETIRELOG=1`, 90 s of headless
*The Messenger* (`PPSA24651`), per-kind census:

```
[sync] 131072 destroyed guest sync objects retained, never freed (#2042):
       mutex=131066 cond=6 rwlock=0 sem=0 barrier=0 _Mtx=0 _Cnd=0
```

**131,066 mutex destroys in 90 s** — ~1,450/s, roughly 5 MB per 90 s, hundreds of megabytes in a play
session. The premise holds for six of the seven kinds and is false for the one that dominates. (The
issue's own subject, the rwlock, is destroyed **zero** times on this title.)

So retention is bounded by a **time window** instead — `PROSPER_SYNC_RETIRE_SECONDS`, default 30 s —
which bounds the retained set by destroy *rate*, the variable that actually varies. Same run,
after:

```
[sync] 32768 destroyed guest sync objects held in quarantine (#2042);
       destroyed so far: mutex=32762 cond=6 rwlock=0 ...
```

High-water 32,768–65,535 and steady, against unbounded growth before. Counting the `deque` entry
and malloc overhead as well as the object, that is roughly **2–4 MB** in steady state (~3 MB at the
measured rate).

Cross-title, *Little Nightmares III* (`PPSA05143`, UE5), same 90 s window: `mutex=7734 rwlock=453
cond=5`, high-water 8,192 — so the rwlock **is** exercised on UE titles, at a modest rate, and the
Messenger zero is not the general case.

The host `pthread_*_destroy` is **not** called at destroy time — doing that to an object a thread is
blocked in is undefined, and on winpthreads it frees an inner allocation the parked thread still
holds a handle to. It runs at *reclaim* instead, through a callback supplied at each call site (so
`sync_retire.cpp` needs no knowledge of the object layouts, including `GuestRwlock`'s destructor).
That also keeps winpthreads' inner allocation from leaking.

**What the window does not close, stated plainly:** a thread PARKED inside a destroyed object — the
guest blocked on a lock it then destroyed — can outlive any window, and after it expires the object
is reclaimed under that thread. It closes the issue's *own* failure scenario ("thread A is
descheduled") by four orders of magnitude, since that is bounded by scheduler latency. Closing the
parked case needs hazard-pointer or epoch reclamation bracketing every sync handler — filed as
**#2169**. Note FreeBSD frees a rwlock under a parked waiter too, so prosper is not worse than the
platform there.

## Deliberately unaffected

Every `Destroy` returns what it returned before and clears the guest slot as before — the change is
invisible to the guest. `k_rwlock_rdlock` / `k_rwlock_wrlock` are **untouched** (#2024's lane owns
them; the diff has no overlap). The lost-init-race and init-failure paths in `ensure_rwlock` /
`ensure_mutex` / `ensure_cond` still `free()` immediately and deliberately —
`guest_rwlock_free_unpublished` names that: those objects were never published through a guest slot,
so no other thread can hold the pointer, and the lost-race path is the *contended* one and must stay
allocation-neutral. No renderer, GPU or AGC code is touched.

## Risks

- Steady-state RSS rises by (destroy rate x 30 s x per-object cost): ~2–4 MB measured on the worst
  title in this sample. `PROSPER_SYNC_RETIRE_SECONDS` tunes it; `=0` disables the guard entirely,
  and an unparseable value now falls back to the default rather than disabling it (see below).
- Reclaim runs on the retiring thread, inside `retire_sync_object`'s lock for the dequeue and
  **outside** it for the `free()` calls (same pattern as the TLS block reclaim in this file). Destroy
  is not a hot path; the added work is a `deque` push plus a pop that is amortised *in aggregate* —
  the worst single call frees a whole window's backlog. Filed with four other sharp edges as **#2176**.
- The census printer allocates nothing and runs only on powers of two of the high-water, once each.

## Verification

- **`ctest` 207/207 inside the `ps5ys` distrobox** at the exact head, with `gpu_replay` present and
  the Vulkan **execution** tests running. (205 on master; this PR adds two.)
- **`sync_destroy_lifetime`** — 34 checks. Arm 1 walks all seven spellings, 8 Init/Destroy rounds
  each, and asserts no address is ever reissued, plus a retirement census (56 objects) that separates
  "quarantined" from "the allocator merely happened not to reuse the block". Arm 2 constructs the
  issue's exact scenario **by hand**: main takes the write lock, a second thread parks inside
  `k_rwlock_rdlock`, and the lock is destroyed under it.
- **The arm asserts its own preconditions before anything else** — `trywrlock` must refuse (the write
  hold is real) and the reader must not have acquired after 200 ms (it really is parked inside the
  handler). Without those, a clean pass would prove nothing about the held case.
- **The counter-arm is registered in ctest and runs on this same binary.**
  `PROSPER_SYNC_RETIRE_SECONDS=0` is the pre-#2042 immediate free;
  `sync_destroy_lifetime_counter_arm` runs with `WILL_FAIL TRUE`, and **10 assertions fail** — all
  seven spellings in arm 1 and three in arm 2, with the mechanism visible:

  ```
  [FAIL] cond: no destroyed object's storage is issued again (28 repeats over 8 rounds)
  [FAIL] a new rwlock does not alias the object a thread is parked in
  [rwlock] UNMATCHED unlock: the lock is unheld ... rc=1 holds=0
  [FAIL] the retired object is still a live rwlock: its write hold releases
  [FAIL] the parked reader woke and completed its acquisition on the retired object
  ```

  That last group **is** the use-after-free made guest-visible: the freed block is handed to the next
  `Init`, `calloc` zeroes the hold accounting the parked thread depended on, its unlock is refused
  with `EPERM`, and the parked reader is never woken.
- The retirement census still passes under the counter-arm, and should: the objects really are handed
  over, the window is simply zero. Rebuilding the test against pre-#2042 handlers instead fails
  **11** — the census too, since nothing is handed over at all. That arm was run and produced the
  identical repeat counts.
- **Live boots:** *The Messenger* (`PPSA24651`) and *Little Nightmares III* (`PPSA05143`), 90–120 s
  headless each, quantities above. LN3's `[seed-skip-verify]` lines are the positive control that the
  run reached real rendering rather than dying early.
- No snapshots run (batched policy). Windows and macOS are covered by CI only.

## Review

Requesting one: this is object-lifetime work on the shared sync path, the retirement policy is a
judgement call sized by measurement rather than by construction, and the residual exposure needs a
second reader to agree it is the right line.


## Review round

Independent review found two items; both are fixed at head `291894f8`.

- **Blocking — the window switch did not fail safe.** `retire_window_seconds()` used `atof`, which
  returns `0.0` on no conversion, and `0.0 >= 0.0` passed the guard — so
  `PROSPER_SYNC_RETIRE_SECONDS=on`, `=true` or any typo **silently restored the pre-#2042 immediate
  free**, reaching the exact use-after-free this file exists to prevent by misspelling a tuning knob.
  Worse, the comment three lines above promised the opposite, so a reader checking "does this switch
  fail safe?" would find the reassurance and stop. Now `strtod` + an endptr check, with
  `!(v >= 0.0)` also rejecting NaN.
  **New regression arm, and it discriminates:** `sync_destroy_lifetime_bad_window` runs the suite
  under `PROSPER_SYNC_RETIRE_SECONDS=on` and requires it to **pass**. Rebuilt against the `atof`
  version it fails 11 assertions; under `strtod` it passes. It asserts the *green* outcome, so unlike
  the counter-arm it is allocator-independent and runs on every UNIX host.
- **The counter-arm is now Linux-only.** It executes a deliberate use-after-free, and its expected-red
  outcome depends on glibc's tcache handing a just-freed block back to the next allocation — the
  mechanism being demonstrated, not an incidental detail. `WILL_FAIL` inverts a clean non-zero exit
  but **not** a crash or a timeout, so on macOS (unmeasured allocator, Rosetta) either mode would red
  CI for a correct result.

Five non-blocking findings are filed as **#2176** rather than folded in here — a racing double
`Destroy` becoming a *delayed* double free being the sharpest, with the suggested fix (claim the slot
with an atomic exchange instead of read-then-clear) also closing the "clock starts while the object
is still reachable" ordering.

`ctest` **209/209** in the distrobox at head `291894f8` (206 on master; this PR adds three).
