### PR TITLE
fix(hle): two FALSE SUCCESS NIDs — sceRandomGetRandomNumber and the NpTrophy2 info queries

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -330,6 +330,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_service_getters PRIVATE prosper_core)
   add_test(NAME service_getters COMMAND test_service_getters)
 
+  # #2081 FALSE SUCCESS: an unregistered NID answers the dispatcher's 0, which for an SCE_OK
+  # contract is a success report over an out-parameter nothing wrote. Pure, no game dump.
+  add_executable(test_false_success_nids tests/test_false_success_nids.cpp)
+  target_link_libraries(test_false_success_nids PRIVATE prosper_core)
+  add_test(NAME false_success_nids COMMAND test_false_success_nids)
+
   # libSceSysmodule state query (#2002): IsLoaded answers from prosper's own load history, so a
   # title that gates its initialization on UNLOADED stops skipping that initialization.
   add_executable(test_sysmodule_state tests/test_sysmodule_state.cpp)

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -4216,8 +4216,18 @@ namespace {
 // The published single-request cap. A guest asking for more than this gets an error on hardware, so
 // prosper must not quietly serve it: a partial fill reported as success would recreate the exact
 // bug this handler exists to remove, and an over-long fill would paper over a guest bug that real
-// hardware rejects. CONFIDENCE: MED — the cap is from the API documentation, not from a live
-// capture; no local title was observed requesting more than 64 bytes.
+// hardware rejects.
+//
+// CONFIDENCE: MED — the cap is from the API documentation, not from a live capture. This is also
+// the ONLY arm of this handler that can newly FAIL a call the previous stub "succeeded", so it is
+// the one place a wrong constant costs something rather than merely being imprecise.
+//
+// What is NOT established: the request sizes local titles actually pass. `nid_gate_scan` classifies
+// what the guest does with `eax` and cannot recover an argument, so no instrument here has measured
+// the `size` operand at any call site — deliberately stated rather than left as an implied "we
+// checked". Settling it needs the argument registers read at the call, e.g. PROSPER_SVCLOG-style
+// logging on this NID or a hardware breakpoint at the import. If a title is ever found requesting
+// more, this constant is where to look first.
 constexpr uint64_t kRandomMaxBytes = 64;
 
 // Fill `bytes` from the host CSPRNG. Returns false if the host cannot supply entropy — which the

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -7,6 +7,7 @@
 #include "hle_addcontent.hpp"
 #include "hle_json2.hpp"
 #include "nid.hpp"
+#include "sce_errno.hpp"   // libkernel error encoding (libSceRandom reject arms)
 #include "callback_fs.hpp"
 #include "ime_input.hpp"
 #include "platform_ui.hpp"
@@ -44,7 +45,11 @@
 #else
 #include <sys/stat.h>   // mkdir
 #include <sys/uio.h>    // process_vm_readv: fault-contained diagnostic snapshots
+#include <sys/random.h> // getentropy: the host CSPRNG behind sceRandomGetRandomNumber
 #include <unistd.h>
+#endif
+#ifdef _WIN32
+#include <bcrypt.h>     // BCryptGenRandom (prosper_core already links bcrypt on Windows)
 #endif
 
 namespace prosper {
@@ -4175,6 +4180,85 @@ HLE(s_syss_noticeskip) {
     return 0;
 }
 
+// ===== libSceRandom ============================================================================
+//
+// `sceRandomGetRandomNumber(void* buf, size_t size)` is the library's ONLY export (PS5 3.20
+// `libSceRandom.c` lists exactly one `sprx_dlsym` line), and 27 of the 44 local dumps import it.
+//
+// Unregistered, it reached the dispatcher's `return 0` — and for this contract 0 is SCE_OK. The
+// guest was told its buffer had been filled while nothing wrote to it, so it read back whatever
+// its own stack or heap already held and used that as entropy. The worst property of that failure
+// is that it is STABLE: a fresh stack allocation at the same call site tends to hold the same
+// residue on every call, so a "random" session id or nonce can be identical all run. Nothing
+// crashes and no diagnostic fires; only code that inspected the buffer could notice. (#2065, swept
+// under #2081.)
+//
+// The fix is a real implementation rather than a fail-visible stub, because the honest answer here
+// is cheap: the host has a CSPRNG. Returning an error instead would be strictly worse — this is a
+// *value-producing* contract, and guests do gate on it.
+//
+// How the guests actually consume it, measured with `tools/re/nid_gate_scan.py --nid PI7jIZj4pcE`
+// over the local dumps (call sites classified by what happens to eax):
+//
+//     PPSA08804  nonzero=2 ignored=1        PPSA04263  nonzero=2
+//     PPSA24651  nonzero=1                  PPSA13579  nonzero=1
+//     PPSA17942  ignored=1                  PPSA19244  forward=1 ignored=1
+//
+// So most call sites branch on "did this fail", and — the load-bearing part — NOT ONE compares the
+// result against a specific constant (no `const` / `other-cmp` site anywhere). That is what makes
+// the reject arms safe to add: the guest reads only the SIGN of the answer, never its value.
+// CONFIDENCE: HIGH that success must fill the buffer and that failure must be non-zero;
+// LOW on the exact error constant — the SCE_RANDOM error space is not in the 3.20 dump (which
+// carries names and NIDs only) and no call site discriminates it, so the libkernel encoding is
+// used per the project's default rather than an invented SCE_RANDOM_* value.
+namespace {
+
+// The published single-request cap. A guest asking for more than this gets an error on hardware, so
+// prosper must not quietly serve it: a partial fill reported as success would recreate the exact
+// bug this handler exists to remove, and an over-long fill would paper over a guest bug that real
+// hardware rejects. CONFIDENCE: MED — the cap is from the API documentation, not from a live
+// capture; no local title was observed requesting more than 64 bytes.
+constexpr uint64_t kRandomMaxBytes = 64;
+
+// Fill `bytes` from the host CSPRNG. Returns false if the host cannot supply entropy — which the
+// caller MUST surface as an error, never as a zero-filled success. Deterministic zeros presented as
+// random are the same lie in a different costume.
+bool svc_host_entropy(void* dst, size_t bytes) {
+#ifdef _WIN32
+    return BCryptGenRandom(nullptr, (PUCHAR)dst, (ULONG)bytes,
+                           BCRYPT_USE_SYSTEM_PREFERRED_RNG) == 0;
+#else
+    auto* p = static_cast<unsigned char*>(dst);
+    while (bytes) {
+        const size_t chunk = bytes < 256 ? bytes : 256;   // getentropy's published maximum
+        if (getentropy(p, chunk) != 0) return false;
+        p += chunk;
+        bytes -= chunk;
+    }
+    return true;
+#endif
+}
+
+} // namespace
+
+HLE(s_random_get_random_number) {
+    (void)a2; (void)a3; (void)a4; (void)a5;
+    const uint64_t buf = a0, size = a1;
+    // A zero-length request asks for nothing and trivially gets it; there is no buffer to leave
+    // stale, so this is a real success rather than the empty kind.
+    if (size == 0) return 0;
+    if (size > kRandomMaxBytes) return prosper::hle::kSceKernelErrorEINVAL;
+    if (!svc_ptrish(buf)) return prosper::hle::kSceKernelErrorEFAULT;
+
+    unsigned char tmp[kRandomMaxBytes];
+    if (!svc_host_entropy(tmp, (size_t)size))
+        return prosper::hle::sce_kernel_error(prosper::hle::FreeBsdErrno::EIo);
+    // Fault-contained: an unmapped or unwritable guest buffer must return an error, not take down
+    // the emulator, and must not report success for a write that did not land.
+    if (!svc_write_bytes(buf, tmp, (size_t)size)) return prosper::hle::kSceKernelErrorEFAULT;
+    return 0;
+}
+
 void register_service_hle() {
     register_json2_hle();
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
@@ -4199,8 +4283,19 @@ void register_service_hle() {
     Hle::register_fn("sk54bi6FtYM", (HleFn)s_npweb_create_user_context,
                      "sceNpWebApi2CreateUserContext");
     // NpTrophy2: the config/info queries whose success-with-garbage-out crashed DOLL (see above).
+    // ALL FIVE of the library's info queries must answer here, not just the two that a title
+    // happened to crash on. Each writes its result through a caller-supplied out-struct, so any one
+    // of them left unregistered returns the dispatcher's 0 — SCE_OK — over memory nothing wrote,
+    // which is the failure #213 diagnosed (a heap-garbage trophy count sized a 34 GB array). The
+    // singular/plural pairs are the trap: registering `…TrophyInfoArray` and not `…TrophyInfo`
+    // leaves the identical shape live behind a name that looks covered. #1956, swept under #2081.
     Hle::register_fn("4IzqhhUQ3nk", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGameInfo");
     Hle::register_fn("y3zHpdZO6ME", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetTrophyInfoArray");
+    Hle::register_fn("EwNylPdWUTM", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetTrophyInfo");
+    Hle::register_fn("DoZWauG8mu0", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGroupInfo");
+    Hle::register_fn("+PDSI6WgPRc", (HleFn)s_nptrophy2_unavailable, "sceNpTrophy2GetGroupInfoArray");
+    // libSceRandom's only export — see the block comment above s_random_get_random_number.
+    Hle::register_fn("PI7jIZj4pcE", (HleFn)s_random_get_random_number, "sceRandomGetRandomNumber");
     // user service
     R("sceUserServiceGetInitialUser", s_user_initial);
     Hle::register_fn("eNb53LQJmIM", (HleFn)s_user_initial, "sceUserServiceGetForegroundUser");  // was MISSING -> garbage userId

--- a/prosper/tests/test_false_success_nids.cpp
+++ b/prosper/tests/test_false_success_nids.cpp
@@ -1,0 +1,148 @@
+// test_false_success_nids — the FALSE SUCCESS class from #2081.
+//
+// An import prosper does not register returns the dispatcher's default 0. Where that 0 is also the
+// contract's SCE_OK, the guest is told an operation succeeded that never ran, and any out-parameter
+// it was supposed to fill keeps whatever was already there. Nothing crashes and no diagnostic
+// fires, so these regress silently — which is exactly why they need a test rather than a boot.
+//
+// Every assertion below is written to die to a SPECIFIC wrong implementation, not merely to be true
+// of the right one. The mutation each arm kills is named on the arm, because an assertion that
+// passes for the wrong reason is the recurring failure in this project: a `CHECK(ret == 0)` on a
+// fill contract passes against the very stub the change exists to remove.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+// The guest-visible NIDs, from the PS5 3.20 export tables (verified by nid_hash round-trip in
+// tools/nid_census --self-check, which re-derives all 39,158 published pairs with 0 mismatches).
+constexpr const char* kRandomGetRandomNumber      = "PI7jIZj4pcE";
+constexpr const char* kNpTrophy2GetTrophyInfo     = "EwNylPdWUTM";
+constexpr const char* kNpTrophy2GetGroupInfo      = "DoZWauG8mu0";
+constexpr const char* kNpTrophy2GetGroupInfoArray = "+PDSI6WgPRc";
+constexpr const char* kNpTrophy2GetGameInfo       = "4IzqhhUQ3nk";  // already registered
+constexpr const char* kNpTrophy2GetTrophyInfoArray = "y3zHpdZO6ME"; // already registered
+
+bool all_bytes_equal(const unsigned char* p, size_t n, unsigned char v) {
+    for (size_t i = 0; i < n; ++i) if (p[i] != v) return false;
+    return true;
+}
+
+void test_random() {
+    printf("-- libSceRandom::sceRandomGetRandomNumber --\n");
+    HleFn fn = Hle::lookup(kRandomGetRandomNumber);
+    // Kills: leaving the NID unregistered, which is the whole bug — the dispatcher would answer 0.
+    CHECK(fn != nullptr, "sceRandomGetRandomNumber is registered");
+    if (!fn) return;
+
+    // A buffer pre-filled with a recognisable sentinel. Every "did it write?" question below is
+    // asked against this pattern, so a handler that returns success without touching memory is
+    // distinguishable from one that fills it — which the dispatcher default is NOT.
+    constexpr unsigned char kSentinel = 0xA5;
+    constexpr size_t kReq = 32, kBufSize = 64;
+
+    unsigned char buf[kBufSize];
+    memset(buf, kSentinel, sizeof(buf));
+    uint64_t ret = fn((uint64_t)(uintptr_t)buf, kReq, 0, 0, 0, 0);
+
+    // Kills: returning an error for an ordinary in-contract request.
+    CHECK(ret == 0, "a 32-byte request returns SCE_OK");
+    // Kills: THE BUG — success with the buffer untouched (the dispatcher's `return 0`).
+    CHECK(!all_bytes_equal(buf, kReq, kSentinel), "the requested bytes were actually written");
+    // Kills: a memset(buf, 0, size) "implementation" — zeros are a write, but they are not entropy,
+    // and they would satisfy the previous assertion while re-creating the same predictability bug.
+    CHECK(!all_bytes_equal(buf, kReq, 0), "the written bytes are not all zero");
+    // Kills: writing past the requested length (a cap/length confusion in the handler).
+    CHECK(all_bytes_equal(buf + kReq, kBufSize - kReq, kSentinel),
+          "bytes past the requested length are untouched");
+
+    // Kills: any deterministic filler — a constant, a counter, a fixed seed, or a buffer that is
+    // filled once and cached. This is the arm that separates "wrote something" from "wrote random".
+    unsigned char again[kReq];
+    memset(again, kSentinel, sizeof(again));
+    uint64_t ret2 = fn((uint64_t)(uintptr_t)again, kReq, 0, 0, 0, 0);
+    CHECK(ret2 == 0, "a second request also returns SCE_OK");
+    CHECK(memcmp(buf, again, kReq) != 0, "two successive draws differ");
+
+    // Zero-length: nothing was asked for, so nothing may be written and the call still succeeds.
+    // Kills: a handler that treats size==0 as an error, or that writes a byte anyway.
+    unsigned char zbuf[8];
+    memset(zbuf, kSentinel, sizeof(zbuf));
+    CHECK(fn((uint64_t)(uintptr_t)zbuf, 0, 0, 0, 0, 0) == 0, "a zero-length request returns SCE_OK");
+    CHECK(all_bytes_equal(zbuf, sizeof(zbuf), kSentinel), "a zero-length request writes nothing");
+
+    // Over the published 64-byte single-request cap: must FAIL, and must not partially fill. A
+    // partial fill reported as success would be the same lie this handler exists to remove.
+    // Kills: silently serving an over-length request, and "reject but scribble anyway".
+    unsigned char big[128];
+    memset(big, kSentinel, sizeof(big));
+    uint64_t over = fn((uint64_t)(uintptr_t)big, sizeof(big), 0, 0, 0, 0);
+    CHECK(over != 0, "an over-cap request returns an error");
+    CHECK(all_bytes_equal(big, sizeof(big), kSentinel), "an over-cap request writes nothing");
+
+    // A null / non-pointer buffer with a real length must be refused rather than faulting or
+    // succeeding. Kills: a handler that dereferences a0 without validating it.
+    CHECK(fn(0, 16, 0, 0, 0, 0) != 0, "a null buffer returns an error");
+
+    // Every failure answer must be non-zero, since the measured call sites branch on exactly that
+    // (nid_gate_scan: nonzero=2 on PPSA08804 and PPSA04263, nonzero=1 on PPSA24651/PPSA13579, and
+    // no call site anywhere compares against a specific constant).
+    // Kills: returning a "negative" that is zero in the low 32 bits the guest actually tests.
+    CHECK((uint32_t)over != 0, "the error answer is non-zero in its low 32 bits");
+}
+
+void test_nptrophy2_info_queries() {
+    printf("-- libSceNpTrophy2 info queries --\n");
+    // Each of these fills a caller-supplied out-struct. Unregistered, they return SCE_OK over
+    // memory nothing wrote — the #213 shape, where a heap-garbage trophy count sized a 34 GB array.
+    // All five must answer, not just the two a title happened to crash on.
+    const struct { const char* nid; const char* name; } queries[] = {
+        { kNpTrophy2GetGameInfo,        "sceNpTrophy2GetGameInfo" },
+        { kNpTrophy2GetTrophyInfoArray, "sceNpTrophy2GetTrophyInfoArray" },
+        { kNpTrophy2GetTrophyInfo,      "sceNpTrophy2GetTrophyInfo" },
+        { kNpTrophy2GetGroupInfo,       "sceNpTrophy2GetGroupInfo" },
+        { kNpTrophy2GetGroupInfoArray,  "sceNpTrophy2GetGroupInfoArray" },
+    };
+    for (const auto& q : queries) {
+        HleFn fn = Hle::lookup(q.nid);
+        char msg[160];
+        snprintf(msg, sizeof(msg), "%s is registered", q.name);
+        // Kills: leaving any one of the five on the unregistered path. The singular/plural pairs are
+        // the trap this arm exists for — registering `…InfoArray` and not `…Info` leaves the
+        // identical failure live behind a name that reads as covered.
+        CHECK(fn != nullptr, msg);
+        if (!fn) continue;
+
+        // The out-struct is not written on this path, so the ONLY thing keeping the caller off
+        // uninitialised memory is a non-zero return. Kills: registering these to a `return 0`
+        // no-op, which would be indistinguishable from the unregistered state it replaced.
+        uint64_t out[8];
+        memset(out, 0x5A, sizeof(out));
+        uint64_t r = fn(1, 1, (uint64_t)(uintptr_t)out, 0, 0, 0);
+        snprintf(msg, sizeof(msg), "%s reports unavailable rather than success", q.name);
+        CHECK(r != 0, msg);
+        snprintf(msg, sizeof(msg), "%s error is non-zero in its low 32 bits", q.name);
+        CHECK((uint32_t)r != 0, msg);
+    }
+}
+
+} // namespace
+
+int main() {
+    printf("== test_false_success_nids ==\n");
+    register_builtin_hle();
+    test_random();
+    test_nptrophy2_info_queries();
+    if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## The failure this fixes

An import prosper does not register never reaches a handler: `prosper_on_unimpl`
(`src/hle/dispatch.cpp:176`) logs it once and returns **0**. Where 0 is also the contract's
`SCE_OK`, the guest is told an operation succeeded that never ran, and any out-parameter the call
was supposed to fill keeps whatever was already in it.

That is strictly worse than an unimplemented stub returning an error. A caller that checks the
return value sees success; only a caller that inspects the buffer could notice; and the consequence
lands arbitrarily far from the call. Nothing crashes, no diagnostic fires, no frame goes black.

This PR fixes two instances found by the #2081 census, both confirmed unregistered on
`origin/master`. They are grouped because they are one defect class with one test, not because they
share code.

## 1. `sceRandomGetRandomNumber` — implemented, not stubbed

`PI7jIZj4pcE` is `libSceRandom`'s **only** export (PS5 3.20 `libSceRandom.c` has exactly one
`sprx_dlsym` line), and **27 of the 44 local dumps import it**.

Unregistered, the guest was told its buffer had been filled while nothing wrote to it, so it read
back its own stack or heap residue and used that as entropy. The worst property is that the lie is
**stable**: a fresh stack allocation at a given call site tends to hold the same bytes every call,
so a "random" session id or nonce can be identical for a whole run — the worst possible case for
anything used as a key or a de-duplication token.

The fix is a real implementation rather than a fail-visible stub, because the honest answer is
cheap — the host has a CSPRNG (`getentropy`, `BCryptGenRandom` on Windows; `prosper_core` already
links `bcrypt`). Returning an error instead would be **strictly worse here**: this is a
*value-producing* contract, and guests do gate on it.

### How the guests actually consume it

Measured with `tools/re/nid_gate_scan.py --nid PI7jIZj4pcE` over the local dumps — call sites
classified by what happens to `eax`:

| title | buckets |
|---|---|
| `PPSA08804` | `nonzero=2 ignored=1` |
| `PPSA04263` | `nonzero=2` |
| `PPSA24651` | `nonzero=1` |
| `PPSA13579` | `nonzero=1` |
| `PPSA17942` | `ignored=1` |
| `PPSA19244` | `forward=1 ignored=1` |

Most call sites branch on "did this fail", and — the load-bearing part — **not one compares the
result against a specific constant** (no `const` / `other-cmp` site anywhere). That is what makes
the reject arms safe to add: the guest reads only the **sign** of the answer, never its value.

Behaviour: fills exactly `size` bytes and returns `SCE_OK`; `size == 0` succeeds writing nothing;
`size > 64` (the published single-request cap) is **rejected rather than truncated**, since a
partial fill reported as success would recreate the very bug being removed; a non-pointer buffer and
a failed host draw are refused. The guest write goes through the fault-contained `svc_write_bytes`,
so an unmapped buffer returns an error instead of faulting or reporting a write that did not land.

`CONFIDENCE: HIGH` that success must fill the buffer and that failure must be non-zero.
`CONFIDENCE: LOW` on the exact error constant — the SCE_RANDOM error space is not in the 3.20 dump
(names and NIDs only) and no call site discriminates it, so the libkernel encoding is used per the
project default rather than an invented `SCE_RANDOM_*` value. `CONFIDENCE: MED` on the 64-byte cap:
it is from the API documentation, not a live capture, and no local title was seen asking for more.

## 2. `sceNpTrophy2` — the three unregistered info queries

`sceNpTrophy2GetTrophyInfo` (`EwNylPdWUTM`), `sceNpTrophy2GetGroupInfo` (`DoZWauG8mu0`) and
`sceNpTrophy2GetGroupInfoArray` (`+PDSI6WgPRc`) now answer "unavailable" through the existing
`s_nptrophy2_unavailable`, exactly like the two info queries already registered beside them.

All five write their result through a caller-supplied out-struct. #213 recorded what the unwritten
case costs: the guest consumed heap garbage as a trophy count and grew a 34,644,492,288-byte array.

**The singular/plural pair is the trap this fixes.** `…GetTrophyInfoArray` was registered and
`…GetTrophyInfo` was not, so the identical failure stayed live behind a name that reads as covered.
Registering all five removes the class from the library rather than the one member a title happened
to crash on. *Bendy and the Dark Revival* (`PPSA27624`) calls `EwNylPdWUTM` 36 times per boot.

## Deliberately NOT changed

- **No entitlement or ownership query is touched.** Nothing here answers "is this owned".
- `sceAgcDcbDrawIndirect` (#1977) — correct to fix, but it spans four files and needs GPU execution
  evidence; that is a graphics lane's work, not a sweep's.
- `sceAppContentAddcontUnmount` (#2004) — gets its own PR so the entitlement-adjacent reasoning is
  reviewed on its own.
- The other 900 census rows: a name alone is not a determination.

## Tests

`tests/test_false_success_nids.cpp` (new, pure, no game dump). **Every arm names the mutation it
kills**, because a `CHECK(ret == 0)` on a fill contract passes against the very stub this removes.

**Red arm, unmodified `origin/master` source:** 4 failures, exit 1 — and the two already-registered
Trophy2 siblings **still pass**, so the test discriminates registered from unregistered rather than
failing everything.

**Mutation arms — each mutation applied to the handler, built, and run:**

| mutation | killed by | other arms |
|---|---|---|
| A: return `SCE_OK` without writing (*the bug itself*) | `the requested bytes were actually written` | + distinctness |
| B: `memset(0)` instead of entropy | `the written bytes are not all zero` | + distinctness |
| C: over-cap request silently succeeds | `an over-cap request returns an error` | + low-32 non-zero |
| D: deterministic non-zero filler | `two successive draws differ` | **only** this one |

Mutation D matters most: it is killed *only* by the distinctness arm, which proves that arm is
load-bearing rather than redundant with "did it write anything".

## Verification (exact head)

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6          # clean
cd build && ctest                # 206/207
```

**`libc_alloc` fails, and it is NOT this change.** It asserts that `realloc` preserves a `memalign`
block's 256-byte alignment, which `h_realloc` — a plain forwarding `realloc` — cannot provide; it
has been passing on a heap-layout coincidence that **any** PR adding HLE registry entries disturbs.
Reproduced on unmodified `origin/master` by adding four registrations of fabricated NIDs pointing at
an existing handler: same failure. Two controls run: ~140 statements of never-called padding leaves
it green (so it is not code size), and the same binary passes standalone while failing under `ctest`
with the identical command and working directory (so it is not the assertion's own logic). Filed as
**#2165** with the reproduction.

Refs #2081. Fixes #2065. Fixes #1956.
