### PR TITLE
fix(hle): sceAppContentAddcontUnmount must release the claim, not just report that it did

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -345,6 +345,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_false_success_nids PRIVATE prosper_core)
   add_test(NAME false_success_nids COMMAND test_false_success_nids)
 
+  # #2004: sceAppContentAddcontUnmount releases the claim the mount takes, so a mount/unmount/
+  # re-mount cycle works instead of being permanently BUSY. Pure, no game dump.
+  add_executable(test_addcontent_unmount tests/test_addcontent_unmount.cpp)
+  target_link_libraries(test_addcontent_unmount PRIVATE prosper_core)
+  add_test(NAME addcontent_unmount COMMAND test_addcontent_unmount)
+
   # libSceSysmodule state query (#2002): IsLoaded answers from prosper's own load history, so a
   # title that gates its initialization on UNLOADED stops skipping that initialization.
   add_executable(test_sysmodule_state tests/test_sysmodule_state.cpp)

--- a/prosper/src/hle/hle_addcontent.cpp
+++ b/prosper/src/hle/hle_addcontent.cpp
@@ -698,4 +698,26 @@ AddcontentMountResult addcontent_mount(uint32_t service_label, std::string_view 
     return AddcontentMountResult::Mounted;
 }
 
+// The inverse of the claim addcontent_mount takes. Without it, `mounted` was a one-way latch: a
+// title that mounted an add-content, finished with it, and mounted it again for a new chapter or a
+// language switch got SCE_APP_CONTENT_ERROR_BUSY forever, because the unmount that should have
+// cleared the flag was unregistered and answered the dispatcher's 0 — telling the guest the release
+// had succeeded while the claim stood. Content that IS present locally then becomes permanently
+// unreachable, which is the under-reporting half of the local-inventory rule (#2004).
+//
+// Matching is by the mount point the guest was given, so an unrecognised path frees nothing and is
+// reported as such. Deliberately no wildcard or "unmount everything" fallback: guessing which claim
+// to release would trade a stuck mount for a mount released behind the guest's back.
+AddcontentUnmountResult addcontent_unmount(std::string_view guest_mount_point) {
+    std::lock_guard<std::mutex> lock(g_inventory_mutex);
+    if (guest_mount_point.empty()) return AddcontentUnmountResult::NotMounted;
+    for (InstalledAddcontent& entry : g_inventory.entries) {
+        if (entry.mounted && entry.guest_mount_point == guest_mount_point) {
+            entry.mounted = false;
+            return AddcontentUnmountResult::Unmounted;
+        }
+    }
+    return AddcontentUnmountResult::NotMounted;
+}
+
 } // namespace prosper

--- a/prosper/src/hle/hle_addcontent.hpp
+++ b/prosper/src/hle/hle_addcontent.hpp
@@ -84,9 +84,23 @@ enum class AddcontentMountResult {
 using AddcontentMountWriter = bool (*)(uint64_t, const void*, std::size_t);
 
 // Atomically validate, write, and claim a configured mount. Successful output is the complete
-// zero-padded 16-byte SceAppContentMountPoint object; repeated mounts remain BUSY until unmount is
-// implemented. A failed guest write does not consume the mount.
+// zero-padded 16-byte SceAppContentMountPoint object. A failed guest write does not consume the
+// mount. The claim is released by addcontent_unmount below.
 AddcontentMountResult addcontent_mount(uint32_t service_label, std::string_view entitlement_label,
                                        uint64_t output_address, AddcontentMountWriter writer);
+
+enum class AddcontentUnmountResult {
+    Unmounted,
+    NotMounted,   // the path is not a currently-claimed mount point (or is not a mount point at all)
+};
+
+// Release a claim taken by addcontent_mount, identified by the mount point it handed back.
+//
+// This is the inverse of the claim and NOTHING else: it clears an entry's `mounted` flag. It grants
+// no entitlement, changes no ownership answer, and cannot make absent content present — an unknown
+// or already-free mount point is reported as NotMounted rather than quietly accepted. That
+// fail-visible direction is also what makes the handler safe under residual uncertainty about the
+// guest's argument: an argument we fail to recognise yields an error, never a false success.
+AddcontentUnmountResult addcontent_unmount(std::string_view guest_mount_point);
 
 } // namespace prosper

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -2874,6 +2874,41 @@ HLE(s_appcontent_addcont_mount) {
     return APP_CONTENT_ERROR_NOT_FOUND;
 }
 
+// sceAppContentAddcontUnmount(const SceAppContentMountPoint* mountPoint) — release a claim taken by
+// sceAppContentAddcontMount, identified by the 16-byte mount-point object that call handed back.
+//
+// Unregistered, this reached the dispatcher's `return 0`, which for this contract is SCE_OK: the
+// guest was told the unmount succeeded while `entry.mounted` stayed set, so the NEXT mount of the
+// same add-content returned BUSY and kept doing so forever. The title has no way to recover —
+// from its point of view it released the entry — and locally-present content becomes unreachable.
+// It presents as "the game refuses to load DLC it loaded a minute ago", arbitrarily far from here.
+//
+// This grants nothing. It clears a flag prosper itself set, and an unrecognised mount point frees
+// nothing and returns NOT_FOUND. No ownership or entitlement answer is reachable from this path.
+//
+// The argument is the mount point rather than the entitlement label, mirroring the Mount pair
+// (Mount takes serviceLabel + entitlementLabel and WRITES the mount point; Unmount takes the mount
+// point back). CONFIDENCE: MED on the argument — it is the inherited PS4 AppContent shape and no
+// local dump exercises a mount/unmount cycle, so it is not confirmed against a live guest. The
+// residual risk is bounded by direction: if a title passes something else, the lookup fails and the
+// guest gets NOT_FOUND, which is fail-visible and still strictly better than the silent success it
+// gets today. What would settle it: a boot of a title whose dump declares `dlc_emu.ini`, with the
+// argument registers traced at this NID.
+HLE(s_appcontent_addcont_unmount) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    if (!svc_ptrish(a0)) return APP_CONTENT_ERROR_PARAMETER;
+    // SceAppContentMountPoint is a 16-byte NUL-padded char array. Read it fault-contained: a bad
+    // pointer must be a parameter error, not a fault, and not a success.
+    char raw[16];
+    if (!svc_copy_bytes(a0, raw, sizeof(raw))) return APP_CONTENT_ERROR_PARAMETER;
+    const size_t len = strnlen(raw, sizeof(raw));
+    switch (addcontent_unmount(std::string_view(raw, len))) {
+    case AddcontentUnmountResult::Unmounted:  return 0;
+    case AddcontentUnmountResult::NotMounted: return APP_CONTENT_ERROR_NOT_FOUND;
+    }
+    return APP_CONTENT_ERROR_NOT_FOUND;
+}
+
 // sceSystemServiceParamGetString(paramId, char* buf, size_t bufSize): fetch a system string parameter
 // (e.g. the console/user nickname). The default unimplemented stub returned 0 (SUCCESS) but never wrote
 // the buffer, so the game read whatever uninitialized bytes were there as a "valid" string and derefed
@@ -4394,6 +4429,9 @@ void register_service_hle() {
     Hle::register_fn("m47juOmH0VE", (HleFn)s_appcontent_addcont_info,   "sceAppContentGetAddcontInfo");
     Hle::register_fn("XTWR0UXvcgs", (HleFn)s_appcontent_entitlement_key, "sceAppContentGetEntitlementKey");
     Hle::register_fn("VANhIWcqYak", (HleFn)s_appcontent_addcont_mount, "sceAppContentAddcontMount");
+    // The inverse. Unregistered it answered SCE_OK without releasing the claim, so a
+    // mount/unmount/re-mount cycle was permanently BUSY (#2004, swept under #2081).
+    Hle::register_fn("3rHWaV-1KC4", (HleFn)s_appcontent_addcont_unmount, "sceAppContentAddcontUnmount");
     R("sceCommonDialogInitialize", s_ok);
     R("sceCommonDialogIsUsed", s_ok);   // 0 = not in use (our dialogs auto-dismiss) - intentional, not an unimpl log
     R("sceSystemServiceParamGetInt", s_syss_param_int);   // language-aware (US English default), not blanket 0

--- a/prosper/tests/test_addcontent_unmount.cpp
+++ b/prosper/tests/test_addcontent_unmount.cpp
@@ -1,0 +1,118 @@
+// test_addcontent_unmount — sceAppContentAddcontUnmount releases the claim sceAppContentAddcontMount
+// takes, so a mount/unmount/re-mount cycle works (#2004).
+//
+// The bug this guards is a FALSE SUCCESS (#2081): the unmount NID was unregistered, so it reached
+// the dispatcher's `return 0` — SCE_OK — without clearing `InstalledAddcontent::mounted`. The guest
+// was told the release succeeded and every later mount of the same add-content returned BUSY,
+// forever, with no way for the title to recover. Content that IS present locally became permanently
+// unreachable, which is the under-reporting half of the local-inventory rule.
+//
+// The load-bearing arm is therefore the THIRD call in the cycle, not the second: an unmount that
+// returns 0 proves nothing on its own, because the unregistered stub returned 0 too. Only the
+// re-mount separates "released the claim" from "said it did".
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/hle_addcontent.hpp"
+#include "../src/hle/nid.hpp"
+#include "test_scratch.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+using namespace prosper;
+namespace fs = std::filesystem;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+constexpr const char* kAddcontMount   = "VANhIWcqYak";  // sceAppContentAddcontMount
+constexpr const char* kAddcontUnmount = "3rHWaV-1KC4";  // sceAppContentAddcontUnmount (PS5 3.20)
+constexpr uint64_t kErrBusy      = 0x80D90003ull;
+constexpr uint64_t kErrNotFound  = 0x80D90005ull;
+constexpr uint64_t kErrParameter = 0x80D90002ull;
+} // namespace
+
+int main() {
+    printf("== test_addcontent_unmount ==\n");
+    register_builtin_hle();
+
+    // A minimal local inventory: one installed, mountable PSAC entry at /app0/dlc1.
+    const fs::path scratch = prosper_test::test_scratch_dir() / "addcont-unmount";
+    const fs::path app0 = scratch / "app0";
+    std::error_code ec;
+    fs::remove_all(scratch, ec);
+    fs::create_directories(app0 / "sce_sys", ec);
+    fs::create_directories(app0 / "dlc1", ec);
+    { std::ofstream p(app0 / "sce_sys" / "param.json", std::ios::binary);
+      p << R"({"titleId":"PPSA00001"})"; }
+    { std::ofstream m(app0 / "dlc_emu.ini", std::ios::binary);
+      m << "[PSAC]\n"
+           "content_id=UP0000-PPSA00001_00-00000000000DLC01\n"
+           "download_status=INSTALLED\n"
+           "mount_point=/app0/dlc1\n"; }
+    set_app0_root(app0.string());
+
+    HleFn mount = Hle::lookup(kAddcontMount);
+    HleFn unmount = Hle::lookup(kAddcontUnmount);
+    CHECK(mount != nullptr, "sceAppContentAddcontMount is registered");
+    // Kills: leaving the NID unregistered — the bug itself. Unregistered, Hle::lookup is null and
+    // the guest would have reached the dispatcher's SCE_OK.
+    CHECK(unmount != nullptr, "sceAppContentAddcontUnmount is registered");
+    if (!mount || !unmount) { printf("== FAIL: %d ==\n", fails); return 1; }
+
+    // The entitlement label the manifest declares, as a 20-byte SceNpUnifiedEntitlementLabel.
+    char label[20]; memset(label, 0, sizeof(label));
+    memcpy(label, "00000000000DLC01", 16);
+
+    char mp[16]; memset(mp, 0xAB, sizeof(mp));
+    uint64_t r = mount(0, (uint64_t)(uintptr_t)label, (uint64_t)(uintptr_t)mp, 0, 0, 0);
+    CHECK(r == 0, "first mount succeeds");
+    CHECK(strncmp(mp, "/app0/dlc1", 10) == 0, "mount writes the declared mount point");
+
+    // Precondition for the whole test: the claim really is exclusive. Without this, the re-mount arm
+    // below could pass simply because mounting was never refused in the first place.
+    char mp2[16]; memset(mp2, 0xAB, sizeof(mp2));
+    CHECK(mount(0, (uint64_t)(uintptr_t)label, (uint64_t)(uintptr_t)mp2, 0, 0, 0) == kErrBusy,
+          "a second mount of a claimed entry is BUSY");
+
+    CHECK(unmount((uint64_t)(uintptr_t)mp, 0, 0, 0, 0, 0) == 0, "unmount reports success");
+
+    // THE load-bearing arm. An unmount returning 0 is exactly what the unregistered stub did, so
+    // only a successful re-mount shows the claim was actually released.
+    // Kills: registering the NID to a bare `return 0` no-op, which would satisfy every arm above.
+    char mp3[16]; memset(mp3, 0xAB, sizeof(mp3));
+    CHECK(mount(0, (uint64_t)(uintptr_t)label, (uint64_t)(uintptr_t)mp3, 0, 0, 0) == 0,
+          "re-mount after unmount succeeds (the claim was really released)");
+    CHECK(strncmp(mp3, "/app0/dlc1", 10) == 0, "re-mount writes the declared mount point again");
+
+    // Unmounting something that is not currently claimed must FAIL rather than be waved through.
+    // Kills: an implementation that clears state for any input, or ignores its argument entirely
+    // and frees whatever is mounted — which would pass the cycle above while releasing the wrong
+    // claim in a title with several add-contents.
+    char bogus[16]; memset(bogus, 0, sizeof(bogus));
+    memcpy(bogus, "/app0/nope", 10);
+    CHECK(unmount((uint64_t)(uintptr_t)bogus, 0, 0, 0, 0, 0) == kErrNotFound,
+          "unmounting an unknown mount point reports NOT_FOUND");
+    // The real entry must still be mounted after that failed call.
+    char mp4[16]; memset(mp4, 0xAB, sizeof(mp4));
+    CHECK(mount(0, (uint64_t)(uintptr_t)label, (uint64_t)(uintptr_t)mp4, 0, 0, 0) == kErrBusy,
+          "a failed unmount released nothing");
+
+    // Double unmount: the second one has nothing to release and must say so.
+    CHECK(unmount((uint64_t)(uintptr_t)mp, 0, 0, 0, 0, 0) == 0, "unmount of the live claim succeeds");
+    CHECK(unmount((uint64_t)(uintptr_t)mp, 0, 0, 0, 0, 0) == kErrNotFound,
+          "a second unmount of the same point reports NOT_FOUND");
+
+    // A non-pointer argument is a parameter error, not a fault and not a success.
+    CHECK(unmount(0, 0, 0, 0, 0, 0) == kErrParameter, "a null mount point reports PARAMETER");
+
+    fs::remove_all(scratch, ec);
+    if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
## The failure

`sceAppContentAddcontMount` sets `InstalledAddcontent::mounted` and returns
`SCE_APP_CONTENT_ERROR_BUSY` (`0x80D90003`) for any later mount of the same entry. The inverse call,
`sceAppContentAddcontUnmount` (`3rHWaV-1KC4`), was **registered nowhere**, so it reached the
dispatcher's default `return 0` — which for this contract is `SCE_OK`.

So the guest was told its unmount succeeded while the claim stood:

1. Title mounts `DLC01` → `Mounted`, `entry.mounted = true`, guest gets `/app0/dlc1`.
2. Title finishes with it, calls Unmount → **unregistered → 0 (success)**, flag still set.
3. Title re-mounts for a new chapter / a language switch → **`BUSY`**, and every time after.

The title cannot recover: from its point of view it released the entry. **Content that IS present
locally becomes permanently unreachable** — the under-reporting half of the local-inventory rule,
which is the direction that looks safe and therefore does not get filed. It presents as "the game
refuses to load DLC it loaded a minute ago", arbitrarily far from the call that caused it.

`hle_addcontent.hpp` already carried the caveat in a comment — "repeated mounts remain BUSY **until
unmount is implemented**" — so the asymmetry was known. What was not visible is that the call which
would resolve it *silently succeeded* instead of failing, which is the harmful half.

## What this does — and what it explicitly does not

`addcontent_unmount()` is the exact inverse of the claim **and nothing else**: it clears a flag
prosper itself set, matching on the mount point the mount handed back.

**It grants nothing.** It changes no ownership or entitlement answer, and it cannot make absent
content present — there is no path from this handler to any "is this owned" question. An unknown or
already-free mount point frees nothing and returns `NOT_FOUND` rather than being waved through, and
there is deliberately **no "unmount whatever is mounted" fallback**: guessing which claim to release
would trade a stuck mount for a mount released behind the guest's back, which is worse in a title
holding several add-contents at once.

## Confidence, and why the residual risk is bounded

`CONFIDENCE: MED` on the argument being the **mount point** rather than the entitlement label. It
mirrors the Mount pair — Mount takes `serviceLabel` + `entitlementLabel` and *writes* the mount
point; Unmount takes it back — and it is the inherited PS4 AppContent shape. But **no local dump
exercises a mount/unmount/re-mount cycle**, so it is not confirmed against a live guest.

The residual risk is bounded **by direction**, which is the reason this is safe to land without that
confirmation: if a title passes something else, the lookup fails and the guest gets `NOT_FOUND` —
fail-visible, and still strictly better than the silent success it gets today. The change cannot
produce a *new* false success under argument uncertainty.

**What would settle it:** a boot of a title whose dump declares `dlc_emu.ini`, with the argument
registers traced at this NID.

## Tests

`tests/test_addcontent_unmount.cpp` (new, pure, no game dump) drives the full cycle against a
scratch `dlc_emu.ini` inventory.

**The load-bearing arm is the third call, not the second.** An unmount returning 0 proves nothing on
its own — *the unregistered stub returned 0 too*. Only a successful **re-mount** separates "released
the claim" from "said it did". The test also pins the precondition that a second mount really is
`BUSY`, so the re-mount arm cannot pass merely because mounting was never refused.

**Red arm** (all three sources at `origin/master`): fails on `sceAppContentAddcontUnmount is
registered`.

**Mutation arms**, each applied, built and run:

| mutation | killed by |
|---|---|
| **M1: registered as a bare `return 0` no-op** — *the naive fix this guard exists to reject* | `re-mount after unmount succeeds (the claim was really released)`, + 4 more |
| M2: ignores its argument, frees whatever is mounted | `unmounting an unknown mount point reports NOT_FOUND` and `a failed unmount released nothing` |

M1 matters most: "just register the NID" passes every arm except the re-mount.

## Verification (exact head)

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6      # clean
cd build && ctest            # 207/207 passed
```

Incidentally, `libc_alloc` **passes** on this branch while it fails on the sibling PR #2167. That is
not luck being reported as a result — it is a prediction of **#2165** coming true: that test asserts
an alignment `realloc` does not guarantee, the outcome depends on how many entries are in the HLE
registry, and this branch adds one where #2167 adds four. Same mechanism, opposite side of the coin.

Refs #2081. Fixes #2004.
