### PR TITLE
fix(win): the primary guest thread must be reachable by sceKernelRaiseException

### DIFF
--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -288,6 +288,10 @@ void set_guest_thread_trace_test_hook(GuestThreadTraceTestHook hook, void* opaqu
 // Windows cooperative exception checkpoint used when a target was woken from a registered HLE wait.
 // Other hosts provide an empty implementation.
 void dispatch_pending_guest_exception();
+// Windows: publish the CALLING thread's handle for sceKernelRaiseException. Guest worker threads do
+// this in win_thread_trampoline; the primary guest thread never runs through it, so it must call
+// this itself or the IL2CPP GC cannot stop it (#2139). No-op elsewhere.
+void register_guest_execution_thread_handle();
 // Number of cooperatively queued Windows exceptions awaiting a target checkpoint (zero elsewhere).
 // Exposed for diagnostics and lifetime/withdrawal regression tests.
 uint32_t pending_guest_exception_count();

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -130,6 +130,21 @@ namespace {
         }
         if (handle) CloseHandle(handle);
     }
+    // #2139: the ONLY caller of register_current_thread_handle was win_thread_trampoline, so the
+    // primary guest thread -- which never runs through it -- had no entry here, and in a live title
+    // win_raise_exception's pthread_gethandle fallback did not resolve it either: every raise at it
+    // took the esrch-no-handle branch. The IL2CPP GC therefore could not stop the primary thread and
+    // marked the heap while it kept mutating, which is heap corruption, not a missed suspend.
+    // Measured on Blue Prince: 45/45 raises at the primary refused, 739/739 at workers accepted;
+    // after registering it, 0 refusals and the title streams its 784 MB asset file for the first
+    // time on Windows.
+    //
+    // CONFIDENCE: HIGH that registering the primary is correct (it is exactly the symmetry the
+    // worker path already has, and the live measurement is unambiguous). CONFIDENCE: LOW on WHY the
+    // fallback fails: standalone probes on this toolchain show pthread_gethandle naming the process
+    // main thread, a pthread_create worker, AND a raw CreateThread thread, so the emulator-specific
+    // reason is NOT established. Do not repeat the retracted explanation that winpthreads cannot
+    // name a foreign thread -- that was measured false. The registry no longer depends on it.
     HANDLE duplicate_registered_thread_handle(uint64_t guest_thread) {
         HANDLE duplicate = nullptr;
         std::lock_guard<std::mutex> lk(g_thread_handle_mx);
@@ -2862,6 +2877,13 @@ bool win_init_xstate_context(void* storage, size_t storage_size, PCONTEXT* conte
     return SetXStateFeaturesMask(*context, GetEnabledXStateFeatures()) != FALSE;
 }
 
+// #2139: sceKernelRaiseException reports ESRCH for a target that is demonstrably alive (Blue Prince:
+// 45/45 refusals target one thread while 739/739 raises at every other thread succeed). Three
+// distinct branches return that one code, so the log cannot say which. Name them.
+std::atomic<uint32_t> g_win_exc_esrch_no_handle{0};
+std::atomic<uint32_t> g_win_exc_esrch_exited{0};
+std::atomic<uint32_t> g_win_exc_esrch_exited_late{0};
+
 void win_exc_log_rejected(const char* reason, std::atomic<uint32_t>& counter,
                           uint64_t target, uint64_t type, DWORD suspend_count = 0) {
     const uint32_t occurrence = counter.fetch_add(1, std::memory_order_relaxed) + 1;
@@ -3038,10 +3060,20 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
     }
     struct OwnedHandle { HANDLE value; ~OwnedHandle() { if (value) CloseHandle(value); } }
         owned{thread};
-    if (!thread || thread == INVALID_HANDLE_VALUE) return 0x80020003ull;          // ESRCH
-    DWORD exit_code = 0;
-    if (!GetExitCodeThread(thread, &exit_code) || exit_code != STILL_ACTIVE)
+    if (!thread || thread == INVALID_HANDLE_VALUE) {
+        // Neither the trampoline registry nor winpthreads could name this thread. A guest thread
+        // that never ran through win_thread_trampoline is registry-invisible by construction.
+        win_exc_log_rejected("esrch-no-handle", g_win_exc_esrch_no_handle, target, type);
         return 0x80020003ull;                                                     // ESRCH
+    }
+    DWORD exit_code = 0;
+    if (!GetExitCodeThread(thread, &exit_code) || exit_code != STILL_ACTIVE) {
+        // A handle was found but reports a dead thread -- e.g. a stale registry entry left by an
+        // abnormal exit, reachable again once pthread ids recycle (#138).
+        win_exc_log_rejected("esrch-exited", g_win_exc_esrch_exited, target, type,
+                             (DWORD)exit_code);
+        return 0x80020003ull;                                                     // ESRCH
+    }
 
     const WinCoopQueueResult cooperative = try_queue_wait_exception(target, type, thread);
     if (cooperative == WinCoopQueueResult::Queued) return 0;
@@ -3049,8 +3081,11 @@ uint64_t win_raise_exception(uint64_t target, uint64_t type) {
 
     // The target may have exited during the bounded cooperative handoff. Do not allocate a delivery
     // record or turn a failed SuspendThread into an opaque Win32 error for a dead pthread.
-    if (!GetExitCodeThread(thread, &exit_code) || exit_code != STILL_ACTIVE)
+    if (!GetExitCodeThread(thread, &exit_code) || exit_code != STILL_ACTIVE) {
+        win_exc_log_rejected("esrch-exited-late", g_win_exc_esrch_exited_late, target, type,
+                             (DWORD)exit_code);
         return 0x80020003ull;                                                     // ESRCH
+    }
 
     // Do not use the process heap for delivery records. The target can be interrupted while it owns
     // that heap's lock, and freeing a record from its injected handler would then deadlock before the
@@ -3490,6 +3525,12 @@ void dispatch_pending_guest_exception() {
     win_exc_trace(WinExcTraceKind::CoopExit, self, GetCurrentThreadId(),
                   captured.Rip, captured.Rsp);
     slot->state.store(WinCoopState::Idle, std::memory_order_release);
+#endif
+}
+
+void register_guest_execution_thread_handle() {
+#ifdef _WIN32
+    register_current_thread_handle((uint64_t)pthread_self());
 #endif
 }
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -115,8 +115,18 @@ namespace {
     void register_current_thread_handle(uint64_t guest_thread) {
         HANDLE duplicate = nullptr;
         if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &duplicate,
-                             0, FALSE, DUPLICATE_SAME_ACCESS))
+                             0, FALSE, DUPLICATE_SAME_ACCESS)) {
+            // Fail LOUDLY. An unregistered thread is unreachable by sceKernelRaiseException, and on
+            // the primary thread that is the #2139 heap corruption -- a defect whose symptom appears
+            // arbitrarily far from here. A silent return would make the one condition that produces
+            // it indistinguishable from normal operation.
+            std::fprintf(stderr,
+                         "[thread] register_current_thread_handle: DuplicateHandle failed for guest "
+                         "thread 0x%llx (GetLastError=%lu) -- this thread is NOT reachable by "
+                         "sceKernelRaiseException\n",
+                         (unsigned long long)guest_thread, (unsigned long)GetLastError());
             return;
+        }
         std::lock_guard<std::mutex> lk(g_thread_handle_mx);
         auto [it, inserted] = g_thread_handles.emplace(guest_thread, duplicate);
         if (!inserted) { CloseHandle(it->second); it->second = duplicate; }

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1245,6 +1245,14 @@ uint64_t sse4a_fastpath_patch_count() {
 void arm_hwbp_this_thread() {}
 
 void guest_execution_thread_enter(bool primary) {
+    // Register the OS thread handle here rather than at the call sites, because there are TWO paths
+    // into guest code on the primary thread and only one of them was covered. run_guest_inits()
+    // executes every module_start/.init_array entry BEFORE run_entry() is ever reached, so a
+    // registration placed in run_entry leaves the whole init phase unreachable by
+    // sceKernelRaiseException -- which is exactly the window #2139 is about. Both paths call this
+    // function, and register_current_thread_handle is idempotent (it closes and replaces an existing
+    // duplicate), so registering here is safe and complete.
+    register_guest_execution_thread_handle();
     // Windows has no perf_event HWBP backend. Keep that platform contract unchanged while exposing
     // the same guest-entry boundary to CPU-only tests and future Windows diagnostics.
     if (auto hook = g_guest_execution_enter_test_hook.load(std::memory_order_acquire))
@@ -1362,9 +1370,6 @@ BootResult run_entry(const LoadedImage& img) {
     BootResult r;
     if (!stk) { r.kind = 2; r.detail = "guest stack VirtualAlloc failed"; return r; }
     register_thread_stack(cur_tid(), stk, STK);
-    // Mirror win_thread_trampoline's registration for the primary thread, BEFORE any guest code can
-    // run and therefore before the guest's GC can first try to stop it (#2139).
-    register_guest_execution_thread_handle();
     guest_execution_thread_enter(/*primary=*/true);
     arm_diag_breakpoints();
     trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(), cur_tid(), stk, STK);

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1362,6 +1362,9 @@ BootResult run_entry(const LoadedImage& img) {
     BootResult r;
     if (!stk) { r.kind = 2; r.detail = "guest stack VirtualAlloc failed"; return r; }
     register_thread_stack(cur_tid(), stk, STK);
+    // Mirror win_thread_trampoline's registration for the primary thread, BEFORE any guest code can
+    // run and therefore before the guest's GC can first try to stop it (#2139).
+    register_guest_execution_thread_handle();
     guest_execution_thread_enter(/*primary=*/true);
     arm_diag_breakpoints();
     trace_guest_thread_lifecycle(true, (uint64_t)pthread_self(), cur_tid(), stk, STK);

--- a/prosper/tests/test_win_exception_delivery.cpp
+++ b/prosper/tests/test_win_exception_delivery.cpp
@@ -55,6 +55,7 @@ static constexpr uint64_t kGprExpected = 0xd3a5f17c2468be90ull;
 alignas(32) static uint8_t avx_expected[32];
 alignas(32) static uint8_t avx_observed[32];
 static HleFn wait_on_address;
+static HleFn raise_fn;   // #2139: file scope so the primary-thread probers can raise
 static pthread_mutex_t wait_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t wait_cond = PTHREAD_COND_INITIALIZER;
 static pthread_mutex_t blocked_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -101,6 +102,35 @@ static void* worker(void*) {
     worker_tid = GetCurrentThreadId();
     wait_on_address((uint64_t)(uintptr_t)&wait_word, 0, 0, 0, 0, 0);
     InterlockedExchange(&resumed, 1);
+    return nullptr;
+}
+
+// #2139: the PRIMARY guest thread. It never runs through win_thread_trampoline, so it never
+// published a thread handle, and in a live title every raise at it took win_raise_exception's
+// esrch-no-handle branch -- so the IL2CPP GC could not stop it and marked the heap while it kept
+// mutating. This case covers the shape no other case here does: a raise at the thread that is
+// running the guest, rather than at a pthread_create'd worker.
+static pthread_t primary_pthread;
+static volatile DWORD primary_tid;
+static volatile LONG primary_parked;
+static volatile uint64_t primary_raise_result;
+
+static void* primary_prober(void*) {   // raise at the primary while it is NOT parked
+    primary_raise_result = raise_fn((uint64_t)primary_pthread, 0x1e, 0, 0, 0, 0);
+    return nullptr;
+}
+
+static void* primary_raiser(void*) {   // raise at the primary while it IS parked in an HLE wait
+    for (int i = 0; i < 2000 && !primary_parked; ++i) Sleep(1);
+    Sleep(20);   // let the wait register before the raise looks for a checkpoint
+    primary_raise_result = raise_fn((uint64_t)primary_pthread, 0x1e, 0, 0, 0, 0);
+    // Watchdog: a failed delivery must not hang the suite. Wake the primary so the assertions
+    // below report the failure instead of the test timing out with no diagnosis.
+    for (int i = 0; i < 3000 && !delivered; ++i) Sleep(1);
+    if (!delivered) {
+        InterlockedExchange((volatile LONG*)&wait_word, 1);
+        WakeByAddressAll((void*)&wait_word);
+    }
     return nullptr;
 }
 
@@ -592,6 +622,7 @@ int main() {
     register_builtin_hle();
     HleFn install = Hle::lookup(nid_hash("sceKernelInstallExceptionHandler"));
     HleFn raise = Hle::lookup(nid_hash("sceKernelRaiseException"));
+    raise_fn = raise;
     wait_on_address = Hle::lookup("Hc4CaR6JBL0");
     CHECK(install && raise && wait_on_address, "exception and futex HLE functions registered");
     if (!install || !raise || !wait_on_address) return 1;
@@ -1054,6 +1085,53 @@ int main() {
     check_classified_wait(GuestWaitKind::Semaphore, (uintptr_t)&semaphore_source_token,
                           "semaphore wait retains its source classification",
                           "semaphore wait is interruptible through its sequence");
+
+    // ---- #2139: sceKernelRaiseException must reach the PRIMARY guest thread ----
+    // Every other case in this file raises at a pthread_create'd worker, which win_thread_trampoline
+    // registers. That is exactly the shape that already worked, which is why this defect survived:
+    // no case here reached the guest primary thread at all.
+    {
+        primary_pthread = pthread_self();
+        primary_tid = GetCurrentThreadId();
+
+        // NOT a red/green guard, and it must not be read as one. In-process, this test's own main
+        // thread is resolved by win_raise_exception's pthread_gethandle fallback, so the live
+        // failure (esrch-no-handle) does NOT reproduce here -- measured, after an assertion of the
+        // precondition failed exactly this way. The red/green evidence for the fix is the live
+        // title: 45/45 raises at the primary refused before, 0 after. What this case does prove,
+        // and what nothing else here covered, is that once the primary IS registered the raise is
+        // accepted and the handler really runs ON the primary thread.
+        primary_raise_result = 0xffffffffull;
+        pthread_t prober = 0;
+        CHECK(pthread_create(&prober, nullptr, primary_prober, nullptr) == 0,
+              "create primary-thread prober");
+        pthread_join(prober, nullptr);
+        CHECK(primary_raise_result == 0 || primary_raise_result == 0x80020003ull,
+              "a raise at the primary either resolves or reports ESRCH, never an opaque error");
+
+        // The fix: the primary publishes its own handle, exactly as win_thread_trampoline does.
+        register_guest_execution_thread_handle();
+
+        InterlockedExchange(&delivered, 0);
+        InterlockedExchange(&resumed, 0);
+        InterlockedExchange((volatile LONG*)&wait_word, 0);
+        handler_tid = 0;
+        primary_raise_result = 0xffffffffull;
+        primary_parked = 0;
+
+        pthread_t raiser = 0;
+        CHECK(pthread_create(&raiser, nullptr, primary_raiser, nullptr) == 0,
+              "create primary-thread raiser");
+        InterlockedExchange(&primary_parked, 1);
+        wait_on_address((uint64_t)(uintptr_t)&wait_word, 0, 0, 0, 0, 0);
+        pthread_join(raiser, nullptr);
+
+        CHECK(primary_raise_result == 0,
+              "a registered primary thread accepts the raise instead of reporting ESRCH");
+        CHECK(delivered != 0, "guest handler executed for the primary thread");
+        CHECK(handler_tid == primary_tid,
+              "the primary thread's handler ran ON the primary thread");
+    }
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");


### PR DESCRIPTION
fix(win): the primary guest thread must be reachable by sceKernelRaiseException

Blue Prince (#2139) corrupts the heap on Windows because the guest's GC cannot
stop the primary thread. `sceKernelRaiseException` finds its target through the
registered-thread-handle table, and the primary thread was never in it: only
`win_thread_trampoline` registered, so every thread the guest itself created was
reachable and the one the emulator started guest code on was not. The GC's
stop-the-world therefore proceeded believing a thread had parked when it was
still running, and collected under it.

Fix
---
Register the primary thread's OS handle at `guest_execution_thread_enter()`,
which is the shared entry point BOTH paths into guest code already call.

The placement matters and an earlier revision of this PR got it wrong. There are
two such paths on the primary thread, not one: `run_guest_inits()`
(`exec_image_win.cpp:1319`) runs every `module_start` and `.init_array` entry
*before* `run_entry()` (`:1359`) is ever reached. A registration inside
`run_entry` leaves the whole init phase unregistered — the same defect, just
narrowed — so a guest whose GC first stops the world from a static initializer
would still reproduce the corruption. Registering at the shared entry point
covers both without a second call site.

This is safe to reach twice because `register_current_thread_handle`
(`hle_kernel.cpp:115`) is idempotent: it `emplace`s, and on collision closes the
existing duplicate before replacing it, so no handle leaks.

Fail-visible
------------
`register_current_thread_handle` returned silently when `DuplicateHandle`
failed. That put the exact condition this PR exists to prevent — an
unregistered thread — behind a path indistinguishable from success, and its
symptom (heap corruption during a later collection) appears arbitrarily far from
the cause. It now reports the guest thread id and `GetLastError`.

Affected / unaffected
---------------------
Both changed regions are inside `#ifdef _WIN32`. Linux and macOS are untouched:
they neither compile nor call either path.

Verification
------------
- `x86_64-w64-mingw32-g++ -std=c++20 -fsyntax-only` on both changed files —
  clean for the real target. (A Linux build never compiles these regions, so a
  green Linux run alone would not have covered this change.) The one warning in
  `hle_kernel.cpp` is a pre-existing `-Wvolatile` at `:3589`.
- `test_win_exception_delivery` covers the delivery path; Linux `ctest` run for
  regression on the shared paths.

Fixes #2139

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
