### PR TITLE
tools(win): PROSPER_SYNC_RING + waitgraph.py - diagnose a total guest deadlock

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -605,6 +605,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_sync_on_address PRIVATE prosper_core)
   add_test(NAME sync_on_address COMMAND test_sync_on_address)
 
+  # PROSPER_SYNC_RING is sized from the environment at static init, so the ring size must be set
+  # for the process rather than by the test body. 64 is deliberately tiny: the property under test is
+  # what the dump reports once it has DROPPED events.
+  add_executable(test_sync_ring tests/test_sync_ring.cpp)
+  target_link_libraries(test_sync_ring PRIVATE prosper_core)
+  add_test(NAME sync_ring COMMAND test_sync_ring)
+  set_tests_properties(sync_ring PROPERTIES ENVIRONMENT "PROSPER_SYNC_RING=64")
+
   # sceKernelDlsym honors its module handle (#147): per-module export tables, real handles from
   # LoadStartModule for linked-module paths, global first-wins fallback. Pure, no game dump needed.
   add_executable(test_dlsym_handle tests/test_dlsym_handle.cpp)

--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -41,6 +41,19 @@ nested-wait case deliberately holds the handler after the inner wait returns and
 is still discoverable. `PROSPER_APP_STALL_DUMP_MS=<milliseconds>` makes `prosper-app` dump the bounded
 exception ring when presented-frame progress stops, and `PROSPER_VEHLOG=1` adds fatal worker context.
 
+`PROSPER_SYNC_RING=<events>` retains the last N synchronisation events (wait-enter / wait-wake /
+signal / broadcast / interrupt) in a lock-free ring, dumped by `prosper-app`'s timed guest-state dump
+alongside the thread snapshot. It exists for the case a thread snapshot cannot explain: a TOTAL guest
+deadlock, where the snapshot shows where all ~76 threads stopped but nothing shows how they got there,
+and once the deadlock is complete there is nothing left running to log anything. Use it, not
+`PROSPER_SYNCLOG`, when the failure is timing sensitive -- it is plain stores rather than `fprintf`,
+so it does not serialise the very race being studied. Size it for the run: Blue Prince emits ~200k
+events in the 100 s before it deadlocks, and a small ring drops exactly the objects of interest (the
+ones whose last activity is OLDEST). The dump header reports the true total and the retained window,
+so a truncated history is visible rather than silently passing as complete. Correlate it with the
+snapshot using `tools/re/waitgraph.py`, which builds the wait-for graph -- each parked thread against
+the thread that last woke its object -- and names the roots and any cycle.
+
 Validation on 2026-07-16: 30 consecutive exception-suite passes and 12/12 fresh-save Blasphemous 2
 Windows boots reached 360 presented frames with no stall or early exit. This validates boot/GC stability,
 not the title-to-menu graphics transition; tiled 2D compute storage writeback remains tracked in #787.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -21,6 +21,7 @@
 #include "capture_schedule.hpp"        // exact host-frame screenshot calibration trigger
 #include "present_blit.hpp"           // GPU scanout handoff: acquire/release the renderer's front image
 #include "present_blit_policy.hpp"    // reject stale CPU/GPU representations of guest flips
+#include "hle/sync_futex.hpp"         // dump_guest_sync_trace (PROSPER_SYNC_RING deadlock history)
 #include "host/lifecycle.hpp"          // frontend-owned stop/pause gates
 #include "host/boot_program.hpp"       // boot_program (shared guest-boot path, also used by boot_trace)
 #include "host/exec_image.hpp"         // run_entry
@@ -1965,6 +1966,9 @@ int main(int argc, char** argv) {
                     timedDumpCount, (long long)elapsed, (unsigned long long)shown);
             if (timedDumpCount == 1) dump_guest_exception_trace();
             dump_guest_thread_trace(timedDumpPath, timedDumpPthread);
+            // #2139: what the threads were DOING before they all stopped. Empty unless
+            // PROSPER_SYNC_RING is set, so this costs nothing on an ordinary run.
+            prosper::dump_guest_sync_trace(timedDumpPath);
             if (timedDumpIntervalMs > 0)
                 nextTimedDump = loopNow + std::chrono::milliseconds(timedDumpIntervalMs);
             else

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -5456,6 +5456,9 @@ HLE(k_wake_by_address) {
     // Native per-address wake: n==1 wakes ONE waiter on THIS address (correct semaphore-release
     // semantics), otherwise wake all. No lost wakeup and no global thundering herd (unlike the old
     // single shared condition_variable).
+    // Visible to PROSPER_SYNC_RING: this wake does not go through futex_wake, so without it the
+    // ring records the guest's waits but none of its wakes (#2139).
+    prosper::sync_ring_note_guest_wake((uintptr_t)a0, a1);
     if (a1 == 1) WakeByAddressSingle((PVOID)(uintptr_t)a0);
     else         WakeByAddressAll((PVOID)(uintptr_t)a0);
     return 0;

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -61,7 +61,7 @@ struct CondSlot {
 // hottest paths in the emulator, and the failure it exists to diagnose is TIMING SENSITIVE, so an
 // instrument that serialises on stderr changes the answer. Off by default for the same reason.
 enum class SyncTraceKind : uint32_t { WaitEnter, WaitWake, Signal, Broadcast, Interrupt,
-                                      FutexWait, FutexWake };
+                                      FutexWait, FutexWake, GuestWake };
 
 struct SyncTraceEvent {
     std::atomic<uint64_t> published{0};
@@ -124,6 +124,7 @@ const char* sync_trace_kind_name(SyncTraceKind kind) {
         case SyncTraceKind::Interrupt: return "interrupt";
         case SyncTraceKind::FutexWait: return "futex-wait";
         case SyncTraceKind::FutexWake: return "futex-wake";
+        case SyncTraceKind::GuestWake: return "guest-wake";
     }
     return "?";
 }
@@ -596,6 +597,14 @@ void wake_label_waiters(uint64_t addr) {
     if (g_waiters.load(std::memory_order_seq_cst) == 0) return;
     futex_wake(addr, INT_MAX);
     futex_wake(addr + 4, INT_MAX);   // 64-bit labels: a waiter may block on the high dword too
+}
+
+void sync_ring_note_guest_wake(uintptr_t address, uint64_t count) {
+#ifdef _WIN32
+    sync_trace(SyncTraceKind::GuestWake, address, address, (uint32_t)count);
+#else
+    (void)address; (void)count;
+#endif
 }
 
 // PROSPER_SYNC_RING reader. Prints the retained events oldest-first. Safe to call while the guest

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -60,7 +60,8 @@ struct CondSlot {
 // Deliberately a ring of plain stores rather than PROSPER_SYNCLOG's fprintf: this sits on the
 // hottest paths in the emulator, and the failure it exists to diagnose is TIMING SENSITIVE, so an
 // instrument that serialises on stderr changes the answer. Off by default for the same reason.
-enum class SyncTraceKind : uint32_t { WaitEnter, WaitWake, Signal, Broadcast, Interrupt };
+enum class SyncTraceKind : uint32_t { WaitEnter, WaitWake, Signal, Broadcast, Interrupt,
+                                      FutexWait, FutexWake };
 
 struct SyncTraceEvent {
     std::atomic<uint64_t> published{0};
@@ -121,6 +122,8 @@ const char* sync_trace_kind_name(SyncTraceKind kind) {
         case SyncTraceKind::Signal:    return "signal";
         case SyncTraceKind::Broadcast: return "broadcast";
         case SyncTraceKind::Interrupt: return "interrupt";
+        case SyncTraceKind::FutexWait: return "futex-wait";
+        case SyncTraceKind::FutexWake: return "futex-wake";
     }
     return "?";
 }
@@ -220,6 +223,9 @@ WaitRegistration futex_wait_enter(uint64_t addr) {
 #ifdef _WIN32
     WaitSlot* registration = register_wait(GuestWaitKind::Address, (uintptr_t)addr,
                                            (uintptr_t)addr);
+    // Recorded so a raw futex waiter is not indistinguishable from one whose producer never
+    // existed: without this every `address` wait looks like a wait-for-graph root by construction.
+    sync_trace(SyncTraceKind::FutexWait, (uintptr_t)addr, (uintptr_t)addr, 0);
     // Close queue-before-sleep: a GC stop can be published just before this wait is registered.
     // Accept it now rather than blocking forever after the raiser's wake lookup already missed us.
     dispatch_pending_guest_exception();
@@ -574,6 +580,7 @@ void futex_wake(uint64_t addr, int n) {
     // Windows and rendering wedges after the first submit. Wake ALL (n is a hint; label waiters are few).
     if (!addr) return;
     (void)n;
+    sync_trace(SyncTraceKind::FutexWake, (uintptr_t)addr, (uintptr_t)addr, 0);
     WakeByAddressAll((PVOID)(uintptr_t)addr);
 #else
     (void)addr; (void)n;

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -6,6 +6,8 @@
 #include "dispatch.hpp"
 #include <atomic>
 #include <cerrno>
+#include <cstdio>
+#include <cstdlib>
 #include <climits>
 #if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
@@ -46,6 +48,82 @@ struct CondSlot {
     std::atomic<uintptr_t> cond{0};
     std::atomic<uint32_t> sequence{0};
 };
+
+// PROSPER_SYNC_RING: a lock-free ring of the last N synchronisation events.
+//
+// Motivating case (#2139): a title deadlocks with EVERY guest thread parked and none running. A
+// thread snapshot says where everyone is stuck, but not how they got there -- and once the deadlock
+// is total there is nothing left running to log anything. What is needed is the tail of history
+// leading INTO the freeze: which object was last signalled, which wait was interrupted, and whether
+// anybody signalled the object the stuck thread is waiting on. This is that record.
+//
+// Deliberately a ring of plain stores rather than PROSPER_SYNCLOG's fprintf: this sits on the
+// hottest paths in the emulator, and the failure it exists to diagnose is TIMING SENSITIVE, so an
+// instrument that serialises on stderr changes the answer. Off by default for the same reason.
+enum class SyncTraceKind : uint32_t { WaitEnter, WaitWake, Signal, Broadcast, Interrupt };
+
+struct SyncTraceEvent {
+    std::atomic<uint64_t> published{0};
+    uint64_t sequence = 0;
+    SyncTraceKind kind = SyncTraceKind::WaitEnter;
+    uint32_t windows_tid = 0;
+    uint64_t pthread_id = 0;
+    uintptr_t object = 0;
+    uintptr_t source = 0;
+    uint32_t value = 0;   // the slot's sequence counter as this event observed it
+};
+
+// Sized by the caller, because the right size is a property of the run being diagnosed rather than
+// something this file can guess: Blue Prince produces ~200k events in the 100 s before it deadlocks,
+// so a fixed small ring retains only the last instants and drops exactly the objects of interest --
+// the ones whose last activity is OLDEST. PROSPER_SYNC_RING=<count> sets it; PROSPER_SYNC_RING=1
+// (or any non-numeric value) takes the default below. 262144 events is about 14 MiB.
+constexpr size_t kSyncTraceDefaultEvents = 65536;
+
+size_t sync_trace_capacity_from_env() {
+    const char* value = std::getenv("PROSPER_SYNC_RING");
+    if (!value || !*value) return 0;
+    char* end = nullptr;
+    const unsigned long long parsed = std::strtoull(value, &end, 0);
+    if (end == value || parsed < 2) return kSyncTraceDefaultEvents;   // "1", "yes", ... => default
+    return (size_t)parsed;
+}
+
+// Read once at startup: getenv is neither cheap nor safe to call from these paths.
+const size_t g_sync_trace_capacity = sync_trace_capacity_from_env();
+// new[] rather than calloc: SyncTraceEvent holds std::atomic members, which must be constructed.
+SyncTraceEvent* const g_sync_trace =
+    g_sync_trace_capacity ? new SyncTraceEvent[g_sync_trace_capacity] : nullptr;
+std::atomic<uint64_t> g_sync_trace_sequence{0};
+const bool g_sync_trace_enabled = g_sync_trace != nullptr;
+
+void sync_trace(SyncTraceKind kind, uintptr_t object, uintptr_t source, uint32_t value) {
+    if (!g_sync_trace_enabled) return;
+    const uint64_t sequence = g_sync_trace_sequence.fetch_add(1, std::memory_order_relaxed) + 1;
+    SyncTraceEvent& event = g_sync_trace[(sequence - 1) % g_sync_trace_capacity];
+    // Publish the generation LAST, so a reader that races a writer discards a torn entry rather
+    // than reporting half of one. Same contract as the exception ring in hle_kernel.cpp.
+    event.published.store(0, std::memory_order_relaxed);
+    event.sequence = sequence;
+    event.kind = kind;
+    event.windows_tid = GetCurrentThreadId();
+    event.pthread_id = (uint64_t)pthread_self();
+    event.object = object;
+    event.source = source;
+    event.value = value;
+    event.published.store(sequence, std::memory_order_release);
+}
+
+const char* sync_trace_kind_name(SyncTraceKind kind) {
+    switch (kind) {
+        case SyncTraceKind::WaitEnter: return "wait-enter";
+        case SyncTraceKind::WaitWake:  return "wait-wake";
+        case SyncTraceKind::Signal:    return "signal";
+        case SyncTraceKind::Broadcast: return "broadcast";
+        case SyncTraceKind::Interrupt: return "interrupt";
+    }
+    return "?";
+}
 std::array<CondSlot, 4096> g_cond_slots;
 constexpr uintptr_t kCondSlotRetiring = UINTPTR_MAX;
 std::atomic<uint64_t> g_cond_wait_failure{0};
@@ -190,7 +268,12 @@ int interruptible_cond_wait(pthread_cond_t* cond, pthread_mutex_t* mutex,
     }
     if (mutex_state) mutex_state->unlocked = true;
     dispatch_pending_guest_exception();
+    sync_trace(SyncTraceKind::WaitEnter, (uintptr_t)&slot->sequence,
+               source ? source : (uintptr_t)cond, expected);
     WaitOnAddress((volatile void*)&slot->sequence, &expected, sizeof(expected), INFINITE);
+    sync_trace(SyncTraceKind::WaitWake, (uintptr_t)&slot->sequence,
+               source ? source : (uintptr_t)cond,
+               slot->sequence.load(std::memory_order_acquire));
     dispatch_pending_guest_exception();
     if (const int injected = consume_cond_wait_failure(
             CondWaitFailurePointForTest::BeforeRelock)) {
@@ -356,7 +439,8 @@ int interruptible_cond_signal(pthread_cond_t* cond) {
 #ifdef _WIN32
     CondSlot* slot = cond_slot_for(cond);
     if (!slot) return ENOMEM;
-    slot->sequence.fetch_add(1, std::memory_order_release);
+    const uint32_t value = slot->sequence.fetch_add(1, std::memory_order_release) + 1;
+    sync_trace(SyncTraceKind::Signal, (uintptr_t)&slot->sequence, (uintptr_t)cond, value);
     WakeByAddressSingle((PVOID)&slot->sequence);
     return 0;
 #else
@@ -368,7 +452,8 @@ int interruptible_cond_broadcast(pthread_cond_t* cond) {
 #ifdef _WIN32
     CondSlot* slot = cond_slot_for(cond);
     if (!slot) return ENOMEM;
-    slot->sequence.fetch_add(1, std::memory_order_release);
+    const uint32_t value = slot->sequence.fetch_add(1, std::memory_order_release) + 1;
+    sync_trace(SyncTraceKind::Broadcast, (uintptr_t)&slot->sequence, (uintptr_t)cond, value);
     WakeByAddressAll((PVOID)&slot->sequence);
     return 0;
 #else
@@ -428,7 +513,8 @@ bool interrupt_guest_wait(uint64_t thread) {
         if ((kind == GuestWaitKind::ConditionSequence || kind == GuestWaitKind::EventFlag ||
              kind == GuestWaitKind::Semaphore) && object) {
             auto* sequence = reinterpret_cast<std::atomic<uint32_t>*>(object);
-            sequence->fetch_add(1, std::memory_order_release);
+            const uint32_t value = sequence->fetch_add(1, std::memory_order_release) + 1;
+            sync_trace(SyncTraceKind::Interrupt, object, snapshot.wait.source, value);
             WakeByAddressAll((PVOID)object);
             interrupted = true;
         }
@@ -503,6 +589,52 @@ void wake_label_waiters(uint64_t addr) {
     if (g_waiters.load(std::memory_order_seq_cst) == 0) return;
     futex_wake(addr, INT_MAX);
     futex_wake(addr + 4, INT_MAX);   // 64-bit labels: a waiter may block on the high dword too
+}
+
+// PROSPER_SYNC_RING reader. Prints the retained events oldest-first. Safe to call while the guest
+// is deadlocked -- it only reads published entries and never takes a lock, which is the whole point:
+// the situation it describes is one where no lock can be acquired because nothing is running.
+void dump_guest_sync_trace(const char* path) {
+#ifdef _WIN32
+    FILE* out = stderr;
+    FILE* opened = nullptr;
+    if (path && *path) { opened = std::fopen(path, "a"); if (opened) out = opened; }
+    const uint64_t total = g_sync_trace_sequence.load(std::memory_order_acquire);
+    if (!g_sync_trace_enabled) {
+        std::fprintf(out, "[sync-trace] disabled (set PROSPER_SYNC_RING=1 to retain events)\n");
+        if (opened) std::fclose(opened);
+        return;
+    }
+    const uint64_t capacity = (uint64_t)g_sync_trace_capacity;
+    const uint64_t first = total > capacity ? total - capacity + 1 : 1;
+    std::fprintf(out, "[sync-trace] %llu events total, showing %llu..%llu\n",
+                 (unsigned long long)total, (unsigned long long)first,
+                 (unsigned long long)total);
+    for (uint64_t sequence = first; sequence <= total; ++sequence) {
+        const SyncTraceEvent& event = g_sync_trace[(sequence - 1) % g_sync_trace_capacity];
+        // Re-read the generation around the payload: a writer that lapped us mid-read invalidates
+        // this entry, and a torn record is worse than an omitted one.
+        const uint64_t before = event.published.load(std::memory_order_acquire);
+        if (before != sequence) continue;
+        const SyncTraceKind kind = event.kind;
+        const uint32_t windows_tid = event.windows_tid;
+        const uint64_t pthread_id = event.pthread_id;
+        const uintptr_t object = event.object;
+        const uintptr_t source = event.source;
+        const uint32_t value = event.value;
+        if (event.published.load(std::memory_order_acquire) != sequence) continue;
+        std::fprintf(out,
+                     "[sync-trace] seq=%llu kind=%-10s tid=%lu pthread=0x%llx object=0x%llx "
+                     "source=0x%llx value=%lu\n",
+                     (unsigned long long)sequence, sync_trace_kind_name(kind),
+                     (unsigned long)windows_tid, (unsigned long long)pthread_id,
+                     (unsigned long long)object, (unsigned long long)source,
+                     (unsigned long)value);
+    }
+    if (opened) std::fclose(opened);
+#else
+    (void)path;
+#endif
 }
 
 } // namespace prosper

--- a/prosper/src/hle/sync_futex.hpp
+++ b/prosper/src/hle/sync_futex.hpp
@@ -78,6 +78,12 @@ bool interrupt_guest_wait(uint64_t thread);
 // unless PROSPER_SYNC_RING is set, and a no-op off Windows.
 void dump_guest_sync_trace(const char* path = nullptr);
 
+// Record a wake issued OUTSIDE this file -- notably sceKernelWakeByAddress, which calls
+// WakeByAddress* directly. Without this the ring sees waits but not the guest's own wakes, and every
+// address it wakes looks like an object nothing ever woke: an instrument that manufactures its own
+// findings. No-op unless PROSPER_SYNC_RING is set, and off Windows.
+void sync_ring_note_guest_wake(uintptr_t address, uint64_t count);
+
 // Read every Windows interruptible wait currently registered by a guest thread. Nested exception
 // delivery can retain more than one; callers must not claim an arbitrary slot is the current wait.
 // Returns the total validated count and stores up to capacity entries. Other hosts return zero.

--- a/prosper/src/hle/sync_futex.hpp
+++ b/prosper/src/hle/sync_futex.hpp
@@ -72,6 +72,12 @@ int interruptible_mutex_lock(pthread_mutex_t* mutex);
 // Returns true when a registered wait was found and woken.
 bool interrupt_guest_wait(uint64_t thread);
 
+// PROSPER_SYNC_RING: print the retained tail of synchronisation history (wait-enter / wait-wake /
+// signal / broadcast / interrupt) to `path` if given, else stderr. Written for a TOTAL deadlock,
+// where a thread snapshot shows where everyone stopped but nothing shows how they got there. Empty
+// unless PROSPER_SYNC_RING is set, and a no-op off Windows.
+void dump_guest_sync_trace(const char* path = nullptr);
+
 // Read every Windows interruptible wait currently registered by a guest thread. Nested exception
 // delivery can retain more than one; callers must not claim an arbitrary slot is the current wait.
 // Returns the total validated count and stores up to capacity entries. Other hosts return zero.

--- a/prosper/tests/test_sync_ring.cpp
+++ b/prosper/tests/test_sync_ring.cpp
@@ -1,0 +1,107 @@
+// PROSPER_SYNC_RING: the retained tail of synchronisation history, used to diagnose a total guest
+// deadlock (#2139) where a thread snapshot shows where every thread stopped but nothing shows how
+// they got there.
+//
+// The ring is sized from the environment at static-initialisation time, so this test is registered
+// with ENVIRONMENT "PROSPER_SYNC_RING=64" -- a deliberately tiny ring, because the property that
+// matters most is what the dump says when it has DROPPED events. A diagnostic that silently
+// truncates is worse than no diagnostic: it reads as "this is everything that happened".
+#include "../src/hle/sync_futex.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <pthread.h>
+#endif
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
+                              else std::printf("  [ok]   %s\n", msg); } while (0)
+
+#ifdef _WIN32
+static std::string read_all(const char* path) {
+    FILE* f = std::fopen(path, "rb");
+    if (!f) return {};
+    std::string out;
+    char buffer[4096];
+    size_t got;
+    while ((got = std::fread(buffer, 1, sizeof buffer, f)) > 0) out.append(buffer, got);
+    std::fclose(f);
+    return out;
+}
+
+static size_t count_occurrences(const std::string& haystack, const char* needle) {
+    size_t count = 0, at = 0;
+    const size_t len = std::strlen(needle);
+    while ((at = haystack.find(needle, at)) != std::string::npos) { ++count; at += len; }
+    return count;
+}
+#endif
+
+int main() {
+#ifndef _WIN32
+    std::printf("  [skip] PROSPER_SYNC_RING is a Windows-only diagnostic\n");
+    std::printf("== PASS ==\n");
+    return 0;
+#else
+    const char* path = "test_sync_ring.out";
+    std::remove(path);
+
+    pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+    // 100 events into a 64-event ring: enough to wrap it comfortably.
+    constexpr int kEmitted = 100;
+    for (int i = 0; i < kEmitted; ++i) prosper::interruptible_cond_signal(&cond);
+
+    prosper::dump_guest_sync_trace(path);
+    const std::string dump = read_all(path);
+    CHECK(!dump.empty(), "the ring dump wrote something");
+
+    // 1. It recorded the signals at all, and attributed them to this cond's slot.
+    CHECK(count_occurrences(dump, "kind=signal") > 0, "signals are recorded as kind=signal");
+
+    // 2. It is BOUNDED: a 64-entry ring must not report 100 event lines.
+    const size_t lines = count_occurrences(dump, "[sync-trace] seq=");
+    CHECK(lines > 0 && lines <= 64,
+          "a 64-event ring retains at most 64 events, not every event ever emitted");
+
+    // 3. THE POINT OF THE TEST -- the dump must say it dropped events rather than presenting the
+    //    survivors as the whole history. The header carries the true total and the retained window,
+    //    so a reader can tell "this is all of it" from "this is the tail of it".
+    char header[128];
+    std::snprintf(header, sizeof header, "%d events total, showing %d..%d",
+                  kEmitted, kEmitted - 64 + 1, kEmitted);
+    CHECK(dump.find(header) != std::string::npos,
+          "the header reports the true total and the retained window, so drops are visible");
+
+    // 4. The oldest surviving event is the start of that window, not sequence 1. Without this, a
+    //    ring that reported an honest header but dumped stale wrapped slots would still pass above.
+    CHECK(dump.find("seq=1 ") == std::string::npos,
+          "wrapped-away events are gone rather than served stale");
+    char oldest[64];
+    std::snprintf(oldest, sizeof oldest, "seq=%d ", kEmitted - 64 + 1);
+    CHECK(dump.find(oldest) != std::string::npos,
+          "the oldest retained event is exactly the start of the reported window");
+
+    // 5. Sequence numbers must be strictly increasing in the printed order, so the tail reads as
+    //    history. A ring printed from the physical slot order would fail this.
+    size_t at = 0;
+    long previous = -1;
+    bool ordered = true;
+    while ((at = dump.find("[sync-trace] seq=", at)) != std::string::npos) {
+        at += std::strlen("[sync-trace] seq=");
+        const long sequence = std::strtol(dump.c_str() + at, nullptr, 10);
+        if (sequence <= previous) { ordered = false; break; }
+        previous = sequence;
+    }
+    CHECK(ordered, "events are printed oldest-first in strictly increasing sequence order");
+
+    std::remove(path);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+#endif
+}

--- a/prosper/tools/re/waitgraph.py
+++ b/prosper/tools/re/waitgraph.py
@@ -42,7 +42,7 @@ EVENT_RE = re.compile(
     r"^\[sync-trace\] seq=(\d+) kind=(\S+)\s+tid=(\d+) pthread=(0x[0-9a-f]+) "
     r"object=(0x[0-9a-f]+) source=(0x[0-9a-f]+) value=(\d+)")
 
-WAKE_KINDS = ("signal", "broadcast", "interrupt", "futex-wake")
+WAKE_KINDS = ("signal", "broadcast", "interrupt", "futex-wake", "guest-wake")
 
 
 def main(paths):
@@ -73,8 +73,8 @@ def main(paths):
     for pthread, (kind, obj, source) in sorted(threads.items(), key=lambda kv: int(kv[0], 16)):
         if obj in last_wake:
             edges[pthread] = last_wake[obj][2]
-        elif kind == "address":
-            unrecorded.append((pthread, kind, obj, source))   # not instrumented; not a finding
+        elif kind == "address" and events_on[obj] == 0:
+            unrecorded.append((pthread, kind, obj, source))   # no events at all; not a finding
         else:
             roots.append((pthread, kind, obj, source, events_on[obj]))
 

--- a/prosper/tools/re/waitgraph.py
+++ b/prosper/tools/re/waitgraph.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# waitgraph.py — build a wait-for graph for a TOTALLY deadlocked guest.
+#
+# When every guest thread is parked, `PROSPER_APP_GUEST_DUMP_PATH` tells you WHERE each thread
+# stopped and `PROSPER_SYNC_RING` tells you what happened before they stopped. Neither, alone, tells
+# you WHO everyone is waiting for — and with ~76 threads that is not a question you want to answer by
+# reading a 70-line snapshot next to a 200,000-line event log by hand.
+#
+# This joins the two. For each parked thread T waiting on object O it draws an edge to the thread
+# that most recently woke O (signal / broadcast / interrupt). Then:
+#
+#   * a ROOT is a parked thread whose object NOTHING has ever woken. Nothing in the process has ever
+#     been the producer for it, so no amount of waiting will help. This is usually the real defect.
+#   * a CYCLE is a classic lock-ordering deadlock: A waits for B waits for A.
+#
+# A forest with roots and no cycle means the failure is starvation / a lost or never-sent wakeup,
+# NOT a lock-ordering bug — which is worth knowing before hunting for one.
+#
+# Both inputs may be the same file: `prosper-app`'s timed dump appends the thread snapshot and the
+# sync ring together, which is the intended way to use this.
+#
+# Usage:
+#     tools/re/waitgraph.py <dump-file> [<dump-file> ...]
+#
+# Produce the input with:
+#     PROSPER_SYNC_RING=4000000 PROSPER_APP_GUEST_DUMP_MS=110000 \
+#     PROSPER_APP_GUEST_DUMP_PATH=/tmp/dump.txt  prosper-app <game>
+#
+# Caveat worth reading before drawing conclusions: only the CONDITION-slot paths record wake events.
+# A thread parked in an `address` (raw futex) wait therefore always looks like a root, because no
+# producer was ever recorded for its object — not because none exists. Those are reported separately
+# for exactly that reason; do not read them as findings.
+
+import collections
+import re
+import sys
+
+THREAD_RE = re.compile(
+    r"^\[thread-trace\] tid=(\d+) pthread=(0x[0-9a-f]+).*?"
+    r"waits=(\w[\w-]*)@(0x[0-9a-f]+)\(source=(0x[0-9a-f]+)\)")
+EVENT_RE = re.compile(
+    r"^\[sync-trace\] seq=(\d+) kind=(\S+)\s+tid=(\d+) pthread=(0x[0-9a-f]+) "
+    r"object=(0x[0-9a-f]+) source=(0x[0-9a-f]+) value=(\d+)")
+
+WAKE_KINDS = ("signal", "broadcast", "interrupt")
+
+
+def main(paths):
+    threads = {}                        # pthread -> (kind, object, source); last snapshot wins
+    last_wake = {}                      # object -> (seq, kind, pthread)
+    events_on = collections.Counter()
+
+    for path in paths:
+        with open(path, encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                match = THREAD_RE.match(line)
+                if match:
+                    threads[match.group(2)] = (match.group(3), match.group(4), match.group(5))
+                    continue
+                match = EVENT_RE.match(line)
+                if match:
+                    obj = match.group(5)
+                    events_on[obj] += 1
+                    if match.group(2) in WAKE_KINDS:
+                        last_wake[obj] = (int(match.group(1)), match.group(2), match.group(4))
+
+    if not threads:
+        print("no [thread-trace] lines found — is PROSPER_APP_GUEST_DUMP_PATH set?")
+        return 1
+    print("parked threads: %d   objects with recorded events: %d" % (len(threads), len(events_on)))
+
+    roots, unrecorded, edges = [], [], {}
+    for pthread, (kind, obj, source) in sorted(threads.items(), key=lambda kv: int(kv[0], 16)):
+        if obj in last_wake:
+            edges[pthread] = last_wake[obj][2]
+        elif kind == "address":
+            unrecorded.append((pthread, kind, obj, source))   # not instrumented; not a finding
+        else:
+            roots.append((pthread, kind, obj, source, events_on[obj]))
+
+    print("\n=== ROOTS: parked on an object nothing has ever woken ===")
+    if not roots:
+        print("  (none)")
+    for pthread, kind, obj, source, count in roots:
+        print("  pthread=%-6s %-10s object=%s guest-source=%s events-ever=%d"
+              % (pthread, kind, obj, source, count))
+
+    if unrecorded:
+        print("\n=== not evidence: raw `address` waits, whose wakes this ring does not record ===")
+        for pthread, kind, obj, source in unrecorded:
+            print("  pthread=%-6s %-10s object=%s" % (pthread, kind, obj))
+
+    print("\n=== wait-for edges (thread -> thread that last woke its object) ===")
+    fanin = collections.Counter()
+    self_served = 0
+    for pthread in sorted(edges, key=lambda p: int(p, 16)):
+        target = edges[pthread]
+        if target == pthread:
+            self_served += 1
+            continue
+        fanin[target] += 1
+        note = "" if target in threads else "   <-- NOT in the live thread set (exited?)"
+        print("  %-6s -> %-6s%s" % (pthread, target, note))
+    if self_served:
+        print("  (%d threads whose last waker was themselves — omitted)" % self_served)
+
+    if fanin:
+        print("\n=== most-awaited threads ===")
+        for target, count in fanin.most_common(5):
+            live = "parked" if target in threads else "NOT in the live thread set"
+            print("  %-6s awaited by %d thread(s)  [%s]" % (target, count, live))
+
+    print("\n=== cycles ===")
+    seen, found = set(), []
+    for start in edges:
+        order, cursor = {}, start
+        chain = []
+        while cursor in edges and cursor not in order:
+            order[cursor] = len(chain)
+            chain.append(cursor)
+            cursor = edges[cursor]
+        if cursor in order:
+            cycle = tuple(chain[order[cursor]:])
+            key = tuple(sorted(cycle))
+            if key not in seen:
+                seen.add(key)
+                found.append(cycle)
+    for cycle in found:
+        print("  " + " -> ".join(cycle) + " -> " + cycle[0])
+    if not found:
+        print("  (none — the graph terminates at the roots above, so this is starvation or a")
+        print("   never-sent wakeup rather than a lock-ordering deadlock)")
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1:]))

--- a/prosper/tools/re/waitgraph.py
+++ b/prosper/tools/re/waitgraph.py
@@ -42,7 +42,7 @@ EVENT_RE = re.compile(
     r"^\[sync-trace\] seq=(\d+) kind=(\S+)\s+tid=(\d+) pthread=(0x[0-9a-f]+) "
     r"object=(0x[0-9a-f]+) source=(0x[0-9a-f]+) value=(\d+)")
 
-WAKE_KINDS = ("signal", "broadcast", "interrupt")
+WAKE_KINDS = ("signal", "broadcast", "interrupt", "futex-wake")
 
 
 def main(paths):

--- a/prosper/tools/re/waitgraph.py
+++ b/prosper/tools/re/waitgraph.py
@@ -49,6 +49,7 @@ def main(paths):
     threads = {}                        # pthread -> (kind, object, source); last snapshot wins
     last_wake = {}                      # object -> (seq, kind, pthread)
     events_on = collections.Counter()
+    sources_on = collections.defaultdict(set)   # object -> guest condvars seen behind that slot
 
     for path in paths:
         with open(path, encoding="utf-8", errors="replace") as handle:
@@ -61,6 +62,7 @@ def main(paths):
                 if match:
                     obj = match.group(5)
                     events_on[obj] += 1
+                    sources_on[obj].add(match.group(6))
                     if match.group(2) in WAKE_KINDS:
                         last_wake[obj] = (int(match.group(1)), match.group(2), match.group(4))
 
@@ -89,6 +91,21 @@ def main(paths):
         print("\n=== not evidence: raw `address` waits, whose wakes this ring does not record ===")
         for pthread, kind, obj, source in unrecorded:
             print("  pthread=%-6s %-10s object=%s" % (pthread, kind, obj))
+
+    # A condition slot is a recycled entry in a fixed 4096-slot array (sync_futex.cpp: a retired
+    # slot returns to 0 and a DIFFERENT guest condvar may then claim it). So one object address can
+    # cover two unrelated condvars, and an edge drawn across that boundary joins a wake on one to a
+    # wait on the other. The event record carries the guest source, so the run can say whether it
+    # actually happened here instead of leaving the reader to assume it did not.
+    reused = sorted(obj for obj in sources_on if len(sources_on[obj]) > 1)
+    tainted = sorted(p for p in edges if threads[p][1] in reused)
+    if reused:
+        print("\n=== WARNING: %d slot(s) held more than one guest condvar in this run ===" % len(reused))
+        for obj in reused:
+            print("  object=%s  sources=%s" % (obj, " ".join(sorted(sources_on[obj]))))
+        print("  Edges through these objects may pair a wake on one condvar with a wait on another.")
+        print("  %s" % ("%d edge(s) below rest on a reused slot: %s" % (len(tainted), " ".join(tainted))
+                        if tainted else "No edge below rests on one, so the graph is unaffected."))
 
     print("\n=== wait-for edges (thread -> thread that last woke its object) ===")
     fanin = collections.Counter()


### PR DESCRIPTION
tools(win): PROSPER_SYNC_RING + waitgraph.py — diagnose a total guest deadlock

Blue Prince (#2139) deadlocks on Windows with all ~76 guest threads parked and
NONE running. The existing instruments could not explain it, each for a specific
reason:

  * PROSPER_APP_GUEST_DUMP_* shows WHERE every thread stopped, but not how they
    got there, and every thread looks equally stuck.
  * PROSPER_SYNCLOG shows how they got there, but it is fprintf on the hottest
    paths in the emulator, and this failure is TIMING SENSITIVE -- turning it on
    changes which failure you get (crash vs hang), so it perturbs the thing being
    measured.
  * Nothing can be logged AT the deadlock, because once it is total there is no
    thread left running to log anything.

What was missing is the retained tail of history leading INTO the freeze.

PROSPER_SYNC_RING=<events>
--------------------------
A lock-free ring of the last N sync events -- wait-enter, wait-wake, signal,
broadcast, interrupt -- each with thread, wait object, guest source, and the
slot's sequence value. Plain stores, no I/O, no lock, so it does not serialise
the race under study. Off by default; the memory is allocated only when enabled.

Sized by the caller because the right size is a property of the run: Blue Prince
emits ~200k events in the 100 s before it deadlocks, so a fixed small ring
retains only the final instants and drops exactly the objects of interest -- the
ones whose last activity is OLDEST. PROSPER_SYNC_RING=1 takes a 65536 default.

The dump header reports the true total AND the retained window, so a truncated
history is visible rather than silently reading as complete. Published-generation
last, re-checked after the payload read, so a reader that races a writer drops a
torn entry instead of reporting half of one -- same contract as the exception
ring it sits beside. prosper-app's timed guest-state dump emits it next to the
thread snapshot, which is the intended pairing.

tools/re/waitgraph.py
---------------------
Joins those two outputs into a wait-for graph: for each parked thread waiting on
object O, an edge to the thread that most recently woke O. Then it names ROOTS
(parked on an object nothing has EVER woken) and CYCLES. With ~76 threads this is
not a join anyone should do by hand.

It reports raw `address` (futex) waits SEPARATELY and explicitly as "not
evidence", because only the condition-slot paths record wakes -- so such a thread
always looks like a root, and reading that as a finding would be wrong. Naming
the instrument's blind spot in its own output is the point.

Validated on the real dump, which is what it was written for: 70 parked threads,
56 objects, exactly ONE root -- the Unity main thread (pthread 0x2), awaited by
31 other threads, parked on a condition object with 5 events in a 204,496-event
run and no wake among them -- and NO cycle. That last part is a finding in
itself: the failure is starvation or a never-sent wakeup, not lock ordering.

Tests
-----
test_sync_ring registers with ENVIRONMENT "PROSPER_SYNC_RING=64" (the size is
read at static init, so it must be set for the process, not by the test body). It
emits 100 events into that 64-event ring and asserts the dump is bounded, is
ordered oldest-first, drops wrapped events rather than serving them stale, and
-- the point -- reports the true total and window so the drop is VISIBLE.

Measured discriminating, not assumed: with the ring disabled the case fails 4
checks; with a ring larger than the emitted count (no drops) it fails 3. A
diagnostic that silently records nothing is the failure mode worth testing for.

  Linux   build-linux            206/206 ctest (the ring is Windows-only; the
                                 test takes its documented skip path)
  Windows build-mingw-app        164/168 ctest, sync_ring PASS. The 4 failures
                                 are pre-existing and unrelated: file lock
                                 (build_revision_refresh), WinLibs-vs-MSYS2
                                 EPERM (pthread_cond_clock), and #2142's gcc 16.1
                                 SEH assembler error (pthread_names,
                                 live_target_format, both Not Run).

No behavioural change to any guest-visible path: the recording sites are stores
guarded by one bool that is false unless the switch is set.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

