### PR TITLE
docs(charter): ctest exit code is truth ONLY with --no-tests=error

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,16 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   output capture fails, so redirect stdout **and** stderr to a file on the real disk, end with `exit 0`,
   read that file, and `rm -rf` scratch that is a day or more old. Leave `/tmp/claude-*` and anything
   touched in the last few hours alone — other agents are live.
-- **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth;
+- **Verification is agentic-first / programmatic** (`docs/VERIFICATION.md`): ctest exit code is truth
+  **only with `--no-tests=error`** — plain `ctest` on a build directory with nothing registered prints
+  `No tests were found!!!` and **exits 0**, so "no tests ran" and "everything passed" are the same
+  exit code (measured on ctest 4.4.0: plain → 0, `--no-tests=error` → 8). This is reachable without
+  any mishap — a copy-pasted `--test-dir` pointing at the wrong build directory yields a green run
+  that executed nothing, and an agent reporting "ctest green" has then reported a fact about an empty
+  directory. `prosper/tools/vkval/vk_validation_scan.py:206` already passes the flag and its comment
+  says why; nothing else in the repo does. **Pass `--no-tests=error` whenever you quote a ctest
+  result**, and quote the test *count* alongside the exit code — a count is falsifiable, an exit code
+  alone is not;
   every SPIR-V emitter is `spirv-val`-gated in CI (`tools/spv_validate`, §4c — one representative
   module per emitter path, not per game shader); rendered frames are asserted by pixels, hashes, or routed content
   metrics. Snapshots are a **release-time regression inventory**, not a day-to-day development or merge


### PR DESCRIPTION
Corrects a stated verification principle that is false in the case that matters most.

## The measurement

On ctest 4.4.0, in the project container, against a build directory with nothing registered:

```
ctest                    ->  "No tests were found!!!"   exit 0
ctest --no-tests=error   ->  "No tests were found!!!"   exit 8
```

So **"no tests ran" and "everything passed" are the same exit code** — and `CLAUDE.md` names that exit code as truth.

## Why this is reachable, not theoretical

A copy-pasted `--test-dir` pointing at the wrong build directory produces a green run that executed nothing. An agent then reports "ctest green" having stated a fact about an empty directory.

It surfaced tonight the hard way: a lane's worktree was removed mid-run, and its wrapper recorded `CTESTrc=0` for a build that no longer existed. Only a separately recorded `BUILDrc` stopped it being published as a 201-test pass. That lane filed #2187.

It matters more than usual right now, because GitHub Actions is in a `major_outage` and local ctest **is** the merge gate tonight rather than a supplement to CI.

## The part worth noticing

**The knowledge already existed in this repository and did not propagate.** `prosper/tools/vkval/vk_validation_scan.py:206` passes the flag, and its own comment says it closes *"the build directory with nothing registered variant of a silent pass"*. Nothing else in the tree uses it.

So this is not a discovery so much as a failure of a solved problem to travel — which is exactly what the charter and the instrument-trap table exist to prevent.

## What the rule now says

Pass `--no-tests=error` whenever you quote a ctest result, and **quote the test count alongside the exit code**. A count is falsifiable; an exit code alone is not. "201/201" cannot be produced by an empty directory, and "green" can.

## Affected / unaffected

`CLAUDE.md` only — 10 insertions, 1 deletion, amending the existing sentence rather than appending beside it, since leaving the false claim intact next to a correction is worse than either alone.

## Verification

Documentation-only, so per the charter's own exception this does not wait on CI — which is unavailable regardless. The docs gate ran locally.

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py  -> exit 0
git diff --name-only origin/master...HEAD | grep -v '\.md$'                           -> empty
git diff --check                                                                       -> clean
```

The exit codes above were measured in `$HOME` rather than `/var/tmp`, after a first attempt in `/var/tmp` produced meaningless results — distrobox does not share that path, so the `cd` failed silently and the exit codes were the shell's, not ctest's. That is the charter's own documented gotcha, and it invalidated my first measurement of a claim about invalid measurements.

Refs #2187
