### PR TITLE
fix(libkernel): sweep the "Sony spelling on a fallible body needs SCE_PTHREAD_ALIAS" rule across the sync families

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1231,6 +1231,12 @@ if(TARGET prosper_core)
       set_tests_properties(sync_destroy_lifetime_counter_arm PROPERTIES
           ENVIRONMENT "PROSPER_SYNC_RETIRE_SECONDS=0" WILL_FAIL TRUE TIMEOUT 120)
     endif()
+    # #2178: every fallible scePthread* spelling reports the libkernel-encoded error while the POSIX
+    # spelling on the same body keeps the bare FreeBSD errno. Asserts both halves per entry point —
+    # a single-spelling arm cannot see a missing (or a wrongly added) SCE_PTHREAD_ALIAS.
+    add_executable(test_pthread_error_encoding tests/test_pthread_error_encoding.cpp)
+    target_link_libraries(test_pthread_error_encoding PRIVATE prosper_core)
+    add_test(NAME pthread_error_encoding COMMAND test_pthread_error_encoding)
 
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -193,12 +193,17 @@ struct GuestCondAttr {
     int32_t pshared = 0;  // only process-private condition variables are supported
 };
 
+// Declared here, defined with its full rationale beside the mutex handlers below: the attribute
+// handlers in this section forward host pthread failures too, and a raw host errno reaching the
+// guest is the #1612 defect regardless of which spelling it arrives through.
+namespace { inline uint64_t fbsd_errno(int host); }
+
 HLE(k_mutexattr_init) {
     if (!a0) return 0x16; // EINVAL-ish
     auto* at = (GuestMutexAttr*)calloc(1, sizeof(GuestMutexAttr));
     if (!at) return 0x0c; // ENOMEM
     int result = pthread_mutexattr_init(&at->host);
-    if (result != 0) { free(at); return (uint64_t)(unsigned)result; }
+    if (result != 0) { free(at); return fbsd_errno(result); }
     // A FRESH attr's type must be the FreeBSD/Sony DEFAULT — ERRORCHECK — not the host default
     // (glibc: NORMAL). Kyty's PthreadMutexattrInit does exactly this (settype(1) on init). The
     // #183 change covered the no-attr init path but left attr-without-settype at glibc NORMAL,
@@ -209,7 +214,7 @@ HLE(k_mutexattr_init) {
     // single-thread wedge in k_mutex_lock, mutex __owner == self, ~10 s into the DOLL boot).
     // CONFIDENCE: HIGH (FreeBSD contract + Kyty + live wedge disassembly).
     result = pthread_mutexattr_settype(&at->host, PTHREAD_MUTEX_ERRORCHECK);
-    if (result != 0) { pthread_mutexattr_destroy(&at->host); free(at); return (uint64_t)(unsigned)result; }
+    if (result != 0) { pthread_mutexattr_destroy(&at->host); free(at); return fbsd_errno(result); }
     at->sony_type = 1;
     *(void**)a0 = at;                     // store handle through caller's slot
     return 0;
@@ -240,7 +245,7 @@ HLE(k_mutexattr_settype) {
     static const bool mtxlog = getenv("PROSPER_MUTEXLOG") != nullptr;
     if (mtxlog) fprintf(stderr, "[mtx] settype attr=%p type=%d\n", *(void**)a0, (int)a1);
     int result = pthread_mutexattr_settype(&at->host, host);
-    if (result != 0) return (uint64_t)(unsigned)result;
+    if (result != 0) return fbsd_errno(result);
     at->sony_type = (int)a1;
     return 0;
 }
@@ -248,8 +253,11 @@ HLE(k_mutexattr_settype) {
 // returned 0 while leaving the caller's `int* type` (a1) unwritten, so the guest read stack garbage as
 // the mutex type (the harmful-Get-stub class the affinity/sched paths already guard against). Preserve
 // the original Sony type because host ERRORCHECK represents both Sony ERRORCHECK(1) and ADAPTIVE_NP(4).
+// scePthreadMutexattrGettype has no POSIX spelling registered, so — like scePthreadMutexTimedlock —
+// it encodes in place rather than through SCE_PTHREAD_ALIAS. Registering `pthread_mutexattr_gettype`
+// onto this body later would need the alias split instead (#2178).
 HLE(k_mutexattr_gettype) {
-    if (!a0 || !*(void**)a0 || !a1) return 0x16;   // EINVAL
+    if (!a0 || !*(void**)a0 || !a1) return prosper::hle::kSceKernelErrorEINVAL;
     auto* at = (GuestMutexAttr*)*(void**)a0;
     *(int*)(uintptr_t)a1 = at->sony_type;
     return 0;
@@ -691,6 +699,15 @@ namespace {
     HLE(sce_name) { return sce_pthread_rc(posix_body(a0, a1, a2, a3, a4, a5)); }
 SCE_PTHREAD_ALIAS(k_sce_mutex_lock,    k_mutex_lock)
 SCE_PTHREAD_ALIAS(k_sce_mutex_trylock, k_mutex_trylock)
+// #2178: Unlock belongs here as much as Lock and Trylock do. It was the sharpest instance of the
+// gap — `scePthreadMutexUnlock` reports EPERM for a mutex this thread does not hold, and it was the
+// ONLY member of the lock/trylock/timedlock/unlock quartet handing that back bare, so the encoding
+// a guest saw depended on which of the four it called. Init and the two fallible attribute setters
+// travel with them for the same reason: each has a failure path, so each needs the split.
+SCE_PTHREAD_ALIAS(k_sce_mutex_unlock,      k_mutex_unlock)
+SCE_PTHREAD_ALIAS(k_sce_mutex_init,        k_mutex_init)
+SCE_PTHREAD_ALIAS(k_sce_mutexattr_init,    k_mutexattr_init)
+SCE_PTHREAD_ALIAS(k_sce_mutexattr_settype, k_mutexattr_settype)
 
 // --- condition variables ---
 namespace {
@@ -846,11 +863,24 @@ HLE(k_cond_init) {
     auto* cond = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t));
     if (!cond) return 0x0c;
     const int result = pthread_cond_init(cond, nullptr);
-    if (result != 0) { free(cond); return (uint64_t)(unsigned)result; }
+    // #1612, not #1984: this is the BARE value both spellings report, and a raw host number is
+    // wrong through either. pthread_cond_init's EAGAIN is host 11 on Linux, which is FreeBSD's
+    // EDEADLK — "out of resources, retry" delivered to the guest as "deadlock".
+    if (result != 0) { free(cond); return fbsd_errno(result); }
     guest_cond_register(cond, attr ? attr->clock_id : kSonyClockRealtime);
     *(void**)a0 = cond;
     return 0;
 }
+// The Sony spellings of the fallible condition-variable entry points (#2178). Destroy, Signal,
+// Broadcast and Wait are deliberately absent: each returns 0 unconditionally, so an alias would
+// change nothing today and misstate the contract tomorrow. scePthreadCondTimedwait encodes in
+// place instead — it has no POSIX spelling registered on its body.
+SCE_PTHREAD_ALIAS(k_sce_cond_init,             k_cond_init)
+SCE_PTHREAD_ALIAS(k_sce_condattr_init,         k_condattr_init)
+SCE_PTHREAD_ALIAS(k_sce_condattr_setclock,     k_condattr_setclock)
+SCE_PTHREAD_ALIAS(k_sce_condattr_getclock,     k_condattr_getclock)
+SCE_PTHREAD_ALIAS(k_sce_condattr_setpshared,   k_condattr_setpshared)
+SCE_PTHREAD_ALIAS(k_sce_condattr_getpshared,   k_condattr_getpshared)
 HLE(k_cond_destroy) {
     if (a0 && !pt_static_sentinel(*(void**)a0)) {
         auto* cond = (pthread_cond_t*)*(void**)a0;
@@ -1202,6 +1232,11 @@ HLE(k_rwlockattr_destroy) {
     *slot = nullptr;
     return 0;
 }
+// Both attribute entry points reject a null slot, and Init also forwards an allocation or host
+// failure, so both are fallible and both need the split (#2178). They were left raw when the rest
+// of the rwlock family was aliased.
+SCE_PTHREAD_ALIAS(k_sce_rwlockattr_init,    k_rwlockattr_init)
+SCE_PTHREAD_ALIAS(k_sce_rwlockattr_destroy, k_rwlockattr_destroy)
 
 // scePthreadOnce(once_control*, init_routine): run init exactly once, PER CONTROL. The old
 // implementation held ONE process-global recursive mutex across the guest init routine — if init
@@ -2227,13 +2262,18 @@ HLE(k_mutex_timedlock) {
 // Sony entry point returns the encoded SCE_KERNEL_ERROR_ETIMEDOUT (0x8002003c), not the positive
 // FreeBSD errno 60. Middleware commonly compares that exact value before returning from its bounded
 // wait; returning 60 makes it retry the timed wait forever instead of running its periodic work.
+// This one encoded only its TIMEOUT, and left EINVAL and every forwarded host failure bare — the
+// same question answered two ways inside a single function (#2178). It has no POSIX spelling
+// registered on its body (pthread_cond_timedwait takes the absolute form and has its own handler),
+// so it encodes in place, exactly as k_mutex_timedlock above does.
 HLE(k_cond_timedwait_sce) {
     auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
-    if (!c || !m) return 0x16;                          // EINVAL
+    if (!c || !m) return prosper::hle::kSceKernelErrorEINVAL;
     timespec dl = abs_deadline_us(a2);
     int rc = interruptible_cond_timedwait(c, m, &dl, GuestWaitKind::ConditionSequence, 0,
                                           nullptr, kGuestMutexCondWaitBookkeeping);
-    return rc == ETIMEDOUT ? prosper::hle::kSceKernelErrorETIMEDOUT : fbsd_errno(rc);
+    // sce_pthread_rc passes the already-encoded ETIMEDOUT through untouched, and encodes the rest.
+    return sce_pthread_rc(rc == ETIMEDOUT ? prosper::hle::kSceKernelErrorETIMEDOUT : fbsd_errno(rc));
 }
 // scePthreadRwlockTimedrd/wrlock(rwlock, SceKernelUseconds usec): acquire with a RELATIVE µs timeout.
 // Were MISSING -> the generic stub returned 0 (= "lock held") without taking the lock, so the guest ran
@@ -2337,18 +2377,35 @@ namespace { bool semlog() { static const bool on = getenv("PROSPER_SEMLOG") != n
 HLE(k_sem_init)      { if (!a0) return 0x16; auto* s = (sem_t*)calloc(1, sizeof(sem_t)); sem_init(s, 0, (unsigned)a2); *(void**)(uintptr_t)a0 = s; if (semlog()) fprintf(stderr, "[sem] init slot=%p value=%u\n", (void*)(uintptr_t)a0, (unsigned)a2); return 0; }
 HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog()) fprintf(stderr, "[sem] wait slot=%p enter\n", (void*)(uintptr_t)a0); int rc = sem_wait(s); if (semlog()) fprintf(stderr, "[sem] wait slot=%p exit rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : fbsd_errno(errno); }   // EAGAIN (would block) is 11 here, 35 on the PS5
-HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return 0x16; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : fbsd_errno(errno); }
+// scePthreadSemTimedwait is the one member of the family with no POSIX spelling registered on its
+// body, so it encodes in place; the other six go through SCE_PTHREAD_ALIAS below (#2178).
+HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return prosper::hle::kSceKernelErrorEINVAL; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : sce_pthread_rc(fbsd_errno(errno)); }
 HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 // Quarantined, not freed, and `sem_destroy` deferred to reclaim — a thread parked in `sem_wait` is
 // inside this object. See the contract block above k_mutex_destroy and sync_retire.hpp (#2042).
 HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Sem, [](void* p) { sem_destroy((sem_t*)p); }); *slot = nullptr; } } return 0; }
+// The Sony spellings of the fallible semaphore entry points (#2178). SemDestroy is absent because
+// it returns 0 unconditionally — #2042 made it quarantine its object rather than free it, which
+// changes what it does but not what it reports, so it still needs no alias. NOTE that the POSIX
+// names registered on these same bodies — sem_init/sem_wait/sem_trywait/sem_post/sem_getvalue —
+// have a separate, pre-existing problem: the C contract is "return -1, number in errno", and these
+// bodies return the number. That is not this rule and is not fixed here; the alias only stops the
+// SONY side from reporting a bare errno.
+SCE_PTHREAD_ALIAS(k_sce_sem_init,     k_sem_init)
+SCE_PTHREAD_ALIAS(k_sce_sem_wait,     k_sem_wait)
+SCE_PTHREAD_ALIAS(k_sce_sem_trywait,  k_sem_trywait)
+SCE_PTHREAD_ALIAS(k_sce_sem_post,     k_sem_post)
+SCE_PTHREAD_ALIAS(k_sce_sem_getvalue, k_sem_getvalue)
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
 // past a rendezvous before its peers arrived: the barrier's downstream invariant (all-arrived) is false ->
 // reads of not-yet-produced data (the async-load race class). Back with host pthread_barrier_t; the serial
 // thread gets -1 (PTHREAD_BARRIER_SERIAL_THREAD, FreeBSD's value), the rest 0. Barrierattr are no-ops.
-HLE(k_barrier_init)    { if (!a0 || a2 == 0) return 0x16; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
-HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return 0x16; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : fbsd_errno(rc); }
+// No POSIX spelling is registered on either body, so both encode in place (#2178). The serial
+// thread's -1 is NOT an errno and must survive untouched: sce_pthread_rc passes it through because
+// its high bits are set, which is exactly the case the pass-through guard exists for.
+HLE(k_barrier_init)    { if (!a0 || a2 == 0) return prosper::hle::kSceKernelErrorEINVAL; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
+HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return prosper::hle::kSceKernelErrorEINVAL; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : sce_pthread_rc(fbsd_errno(rc)); }
 // Quarantined, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the
 // object, the widest window in the family. See the contract block above k_mutex_destroy.
 HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); }); *slot = nullptr; } } return 0; }
@@ -3890,28 +3947,31 @@ void register_kernel_hle() {
     R("sceKernelRaiseException", k_raise_exception);
     R("sceKernelDlsym", k_dlsym);
     R("sceKernelIsStack", k_is_stack);
-    R("scePthreadMutexattrInit", k_mutexattr_init);
-    R("scePthreadMutexattrSettype", k_mutexattr_settype);
-    R("scePthreadMutexattrGettype", k_mutexattr_gettype);   // was MISSING -> left *type uninitialized
-    R("scePthreadMutexattrSetprotocol", k_mutexattr_setprotocol);
-    R("scePthreadMutexattrSetpshared", k_mutexattr_setpshared);
-    R("scePthreadMutexattrDestroy", k_mutexattr_destroy);
-    R("scePthreadMutexInit", k_mutex_init);
-    R("scePthreadMutexDestroy", k_mutex_destroy);
     // Sony spellings report failure in the libkernel-encoded form; the POSIX aliases further down
-    // keep the bare errno. See sce_pthread_rc() above for the guest-side evidence (#1945).
+    // keep the bare errno. See sce_pthread_rc() above for the guest-side evidence (#1945). The rule
+    // is "alias IFF the body can fail": a k_sce_* name below means the body has a failure path, and
+    // a raw k_* name means it returns 0 unconditionally and an alias would state a contract it does
+    // not have. #2178 swept the family for spellings on the wrong side of that.
+    R("scePthreadMutexattrInit", k_sce_mutexattr_init);
+    R("scePthreadMutexattrSettype", k_sce_mutexattr_settype);
+    R("scePthreadMutexattrGettype", k_mutexattr_gettype);   // encodes in place: no POSIX spelling
+    R("scePthreadMutexattrSetprotocol", k_mutexattr_setprotocol);   // always 0
+    R("scePthreadMutexattrSetpshared", k_mutexattr_setpshared);     // always 0
+    R("scePthreadMutexattrDestroy", k_mutexattr_destroy);           // always 0
+    R("scePthreadMutexInit", k_sce_mutex_init);
+    R("scePthreadMutexDestroy", k_mutex_destroy);                   // always 0
     R("scePthreadMutexLock", k_sce_mutex_lock);
     R("scePthreadMutexTrylock", k_sce_mutex_trylock);
     R("scePthreadMutexTimedlock", k_mutex_timedlock);   // was MISSING -> faked "locked" without locking
-    R("scePthreadMutexUnlock", k_mutex_unlock);
-    R("scePthreadCondattrInit", k_condattr_init);
-    R("scePthreadCondattrDestroy", k_condattr_destroy);
-    R("scePthreadCondattrSetclock", k_condattr_setclock);
-    R("scePthreadCondattrGetclock", k_condattr_getclock);
-    R("scePthreadCondattrSetpshared", k_condattr_setpshared);
-    R("scePthreadCondattrGetpshared", k_condattr_getpshared);
-    R("scePthreadCondInit", k_cond_init);
-    R("scePthreadCondDestroy", k_cond_destroy);
+    R("scePthreadMutexUnlock", k_sce_mutex_unlock);
+    R("scePthreadCondattrInit", k_sce_condattr_init);
+    R("scePthreadCondattrDestroy", k_condattr_destroy);             // always 0
+    R("scePthreadCondattrSetclock", k_sce_condattr_setclock);
+    R("scePthreadCondattrGetclock", k_sce_condattr_getclock);
+    R("scePthreadCondattrSetpshared", k_sce_condattr_setpshared);
+    R("scePthreadCondattrGetpshared", k_sce_condattr_getpshared);
+    R("scePthreadCondInit", k_sce_cond_init);
+    R("scePthreadCondDestroy", k_cond_destroy);                     // always 0
     R("scePthreadCondSignal", k_cond_signal);
     R("scePthreadCondBroadcast", k_cond_broadcast);
     R("scePthreadCondWait", k_cond_wait);
@@ -3934,15 +3994,15 @@ void register_kernel_hle() {
     R("pthread_rwlock_reltimedwrlock_np", k_posix_rwlock_reltimedwrlock);   // RELATIVE timespec*
     R("scePthreadRwlockTimedrdlock", k_sce_rwlock_timedrdlock);   // were MISSING -> faked "locked" without locking
     R("scePthreadRwlockTimedwrlock", k_sce_rwlock_timedwrlock);
-    R("scePthreadRwlockattrInit", k_rwlockattr_init);
-    R("scePthreadRwlockattrDestroy", k_rwlockattr_destroy);
+    R("scePthreadRwlockattrInit", k_sce_rwlockattr_init);
+    R("scePthreadRwlockattrDestroy", k_sce_rwlockattr_destroy);
     R("pthread_rwlockattr_init", k_rwlockattr_init);
     R("pthread_rwlockattr_destroy", k_rwlockattr_destroy);
     // scePthreadSem* counting semaphores (were MISSING -> SemWait never blocked)
-    R("scePthreadSemInit", k_sem_init);         R("scePthreadSemDestroy", k_sem_destroy);
-    R("scePthreadSemWait", k_sem_wait);         R("scePthreadSemTrywait", k_sem_trywait);
-    R("scePthreadSemTimedwait", k_sem_timedwait); R("scePthreadSemPost", k_sem_post);
-    R("scePthreadSemGetvalue", k_sem_getvalue);
+    R("scePthreadSemInit", k_sce_sem_init);       R("scePthreadSemDestroy", k_sem_destroy);   // Destroy: always 0
+    R("scePthreadSemWait", k_sce_sem_wait);       R("scePthreadSemTrywait", k_sce_sem_trywait);
+    R("scePthreadSemTimedwait", k_sem_timedwait); R("scePthreadSemPost", k_sce_sem_post);     // Timedwait: encodes in place
+    R("scePthreadSemGetvalue", k_sce_sem_getvalue);
     // scePthreadBarrier* (were MISSING -> BarrierWait let threads pass a false rendezvous)
     R("scePthreadBarrierInit", k_barrier_init);   R("scePthreadBarrierWait", k_barrier_wait);
     R("scePthreadBarrierDestroy", k_barrier_destroy);

--- a/prosper/tests/test_cond_clock.cpp
+++ b/prosper/tests/test_cond_clock.cpp
@@ -3,6 +3,7 @@
 // as CLOCK_REALTIME and normally appeared decades in the past.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "../src/hle/sce_errno.hpp"   // #2178: the Sony spellings report the libkernel encoding
 #include "../src/hle/sync_futex.hpp"
 
 #include <cerrno>
@@ -83,21 +84,24 @@ int main() {
                   attr_getclock(U(&attr), U(&value), 0, 0, 0, 0) == 0 && value == clock,
               "supported Sony condition clock round-trips");
     }
-    CHECK(attr_setclock(U(&attr), 3, 0, 0, 0, 0) == 22,
-          "unsupported condition clock is rejected with EINVAL(22)");
+    // #2178: these are the SONY spellings, so a rejection reports the libkernel-encoded form. The
+    // POSIX spellings registered on the same bodies keep the bare 22, and test_pthread_error_encoding
+    // asserts that half — a single-spelling assertion here cannot tell the two wirings apart.
+    CHECK(attr_setclock(U(&attr), 3, 0, 0, 0, 0) == 0x80020016ull,
+          "unsupported condition clock is rejected with encoded EINVAL (0x80020016)");
     value = -1;
     CHECK(attr_getclock(U(&attr), U(&value), 0, 0, 0, 0) == 0 && value == 4,
           "rejected setclock preserves the previous clock");
-    CHECK(attr_getclock(U(&attr), 0, 0, 0, 0, 0) == 22,
-          "getclock rejects a null output pointer");
+    CHECK(attr_getclock(U(&attr), 0, 0, 0, 0, 0) == 0x80020016ull,
+          "getclock rejects a null output pointer with encoded EINVAL");
 
     value = -1;
     CHECK(attr_getpshared(U(&attr), U(&value), 0, 0, 0, 0) == 0 && value == 0,
           "fresh attribute is process-private");
     CHECK(attr_setpshared(U(&attr), 0, 0, 0, 0, 0) == 0,
           "process-private condition attribute is accepted");
-    CHECK(attr_setpshared(U(&attr), 1, 0, 0, 0, 0) == 22,
-          "unsupported process-shared condition attribute is rejected");
+    CHECK(attr_setpshared(U(&attr), 1, 0, 0, 0, 0) == 0x80020016ull,
+          "unsupported process-shared condition attribute is rejected with encoded EINVAL");
 
     // CondInit must copy the attribute. Change the reusable attr back to realtime after init, then
     // use a deadline that is far in the future for every non-realtime clock but in the past for
@@ -206,8 +210,11 @@ int main() {
     // EPERM. The bookkeeping transaction must not publish this non-owner as the mutex owner.
     CHECK(!win_guest_mutex_owned_by_current_thread_for_test(sce_mutex),
           "unlocked mutex has no current-thread owner before invalid wait");
-    CHECK(sce_cond_timedwait(U(&sce_cond), U(&sce_mutex), 1'000, 0, 0, 0) == EPERM,
-          "condition wait by a mutex non-owner returns EPERM");
+    // #2178: this entry point encoded its TIMEOUT (0x8002003c, asserted above) and left every other
+    // failure bare — the same question answered two ways eleven lines apart. Both are encoded now.
+    CHECK(sce_cond_timedwait(U(&sce_cond), U(&sce_mutex), 1'000, 0, 0, 0)
+              == prosper::hle::sce_kernel_error(prosper::hle::FreeBsdErrno::EPerm),
+          "condition wait by a mutex non-owner returns encoded EPERM (0x80020001)");
     CHECK(!win_guest_mutex_owned_by_current_thread_for_test(sce_mutex),
           "failed non-owner unlock does not invent guest mutex ownership");
     CHECK(mutex_lock(U(&sce_mutex), 0, 0, 0, 0, 0) == 0,
@@ -220,8 +227,9 @@ int main() {
     CHECK(mutex_lock(U(&sce_mutex), 0, 0, 0, 0, 0) == 0,
           "mutex locks before injected relock failure");
     win_set_cond_wait_failure_for_test(CondWaitFailurePointForTest::BeforeRelock, EIO);
-    CHECK(sce_cond_timedwait(U(&sce_cond), U(&sce_mutex), 1'000, 0, 0, 0) == EIO,
-          "injected relock failure is returned");
+    CHECK(sce_cond_timedwait(U(&sce_cond), U(&sce_mutex), 1'000, 0, 0, 0)
+              == prosper::hle::sce_kernel_error(prosper::hle::FreeBsdErrno::EIo),
+          "injected relock failure is returned, encoded (0x80020005)");
     CHECK(!win_guest_mutex_owned_by_current_thread_for_test(sce_mutex),
           "relock failure leaves guest mutex ownership released");
     CHECK(mutex_lock(U(&sce_mutex), 0, 0, 0, 0, 0) == 0,

--- a/prosper/tests/test_mutex_types.cpp
+++ b/prosper/tests/test_mutex_types.cpp
@@ -102,10 +102,18 @@ int main() {
           "adaptive attr round-trips as type 4");
     attr_destroy(U(&aattr), 0, 0, 0, 0, 0);
 
-    // 5. Invalid type rejected.
+    // 5. Invalid type rejected. #2178: scePthreadMutexattrSettype is fallible, so the SONY spelling
+    //    reports the encoded form like every other fallible Sony entry point — it was handing back a
+    //    bare 22 while scePthreadMutexTrylock two lines up handed back 0x80020010. The POSIX
+    //    spelling registered on the same body still reports the bare 22, and asserting both is what
+    //    distinguishes a correct alias from either spelling drifting into the other's contract.
     void* battr = nullptr;
     attr_init(U(&battr), 0, 0, 0, 0, 0);
-    CHECK(attr_settype(U(&battr), 99, 0, 0, 0, 0) == 0x16, "settype(99) rejected EINVAL(22)");
+    CHECK(attr_settype(U(&battr), 99, 0, 0, 0, 0) == prosper::hle::kSceKernelErrorEINVAL,
+          "scePthreadMutexattrSettype(99) rejected with encoded EINVAL (0x80020016)");
+    auto p_attr_settype = Hle::lookup(nid_hash("pthread_mutexattr_settype"));
+    CHECK(p_attr_settype && p_attr_settype(U(&battr), 99, 0, 0, 0, 0) == 22,
+          "pthread_mutexattr_settype(99) keeps the bare EINVAL(22)");
     attr_destroy(U(&battr), 0, 0, 0, 0, 0);
 
     // 6. STATIC SENTINEL self-init remains non-recursive (native POSIX default; Windows ERRORCHECK):

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -92,7 +92,14 @@ const Row kRows[] = {
     {"scePthreadRwlockInit",         "pthread_rwlock_init",         "#1984"},
     {"scePthreadRwlockRdlock",       "pthread_rwlock_rdlock",       "#2158"},
     {"scePthreadRwlockWrlock",       "pthread_rwlock_wrlock",       "#2158"},
-    {"scePthreadRwlockUnlock",       "pthread_rwlock_unlock",       "#1984"},
+    // scePthreadRwlockUnlock is DELIBERATELY not probed with a null slot: it answers 0 there rather
+    // than EINVAL, which is the separate open defect #2159 (`k_rwlock_unlock` reaches
+    // `ensure_rwlock`'s null return and falls through to success) and NOT a gap in this rule. This
+    // sweep found that independently, on `a136bb93`, and must not paper over it — an arm asserting
+    // the current 0 would enshrine the bug, and an arm asserting EINVAL would fail for a reason this
+    // file is not about. Its Sony/POSIX encoding pairing is already guarded on a real failure, by
+    // test_rwlock_once.cpp's unmatched-unlock arms (encoded EPERM vs bare EPERM). Re-add the row
+    // here once #2159 lands.
     {"scePthreadRwlockTryrdlock",    "pthread_rwlock_tryrdlock",    "#1984"},
     {"scePthreadRwlockTrywrlock",    "pthread_rwlock_trywrlock",    "#1984"},
     {"scePthreadRwlockTimedrdlock",  "pthread_rwlock_timedrdlock",  "#1984, separate POSIX body"},

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -1,0 +1,291 @@
+// test_pthread_error_encoding — #2178's sweep, made executable.
+//
+// THE RULE. A `scePthread*` handler goes through `SCE_PTHREAD_ALIAS` (or encodes in place) **if and
+// only if** its body can fail. The alias wraps the body in `sce_pthread_rc`, which passes 0 and
+// already-encoded values through and otherwise returns `0x80020000 | errno`. A Sony-spelled entry
+// point registered straight onto a fallible body hands the guest a **bare FreeBSD errno** instead —
+// #1984's defect, the one that killed The Oregon Trail until 38619f29, and the one #2158 fixed for
+// `scePthreadRwlockRdlock`/`Wrlock` alone.
+//
+// WHY A SINGLE-SPELLING ASSERTION CANNOT SEE THIS, which is the whole reason this file exists.
+// The interesting failure is not "the handler returned zero when it should have failed" — every
+// row below returns *something* non-zero either way. It is that the VALUE is wrong. So an arm
+// written as `CHECK(sony(...) != 0)` passes identically under the bug and under the fix, and an arm
+// that checks only the Sony spelling cannot distinguish a correctly aliased handler from one wired
+// straight to the POSIX body when the two happen to agree. Every dual-registered row therefore
+// asserts BOTH spellings, and asserts them to *different* values: Sony encoded, POSIX bare. That
+// pairing is the discriminator. Nothing weaker is.
+//
+// WHAT EACH ARM KILLS. Three mutations, named here so a future reader can check they still bite:
+//   M1  drop the alias (register the Sony name onto the POSIX body)      -> Sony arm fails, POSIX passes
+//   M2  alias BOTH spellings (encode the POSIX one too)                  -> POSIX arm fails, Sony passes
+//   M3  return the host errno instead of the FreeBSD one (#1612)         -> the EAGAIN row fails on both
+//   M4  apply the encoding to a non-error return                         -> the barrier serial-thread arm fails
+//
+// The M3 and M4 arms matter most. M1/M2 are provoked with a null object, which yields EINVAL — and
+// EINVAL is 22 on FreeBSD, on Linux, on Darwin and on MinGW, so a null-slot arm alone cannot tell a
+// FreeBSD number from a host number. The EAGAIN row can: FreeBSD EAGAIN is 35 while the host's is
+// 11, and 11 is FreeBSD's EDEADLK, so "would block, retry" arrives as "deadlock" if the mapping is
+// skipped. The M4 arm guards the opposite error — `scePthreadBarrierWait` returns -1 for the serial
+// thread, which is not an errno at all, and over-applying the encoding would corrupt it.
+
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/sce_errno.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+// Written as literals on purpose. Deriving them from sce_errno.hpp would make the arms agree with
+// whatever the header says, including a mutated header — these are the numbers the guest's own
+// libc.prx compares against, so they are pinned here independently.
+constexpr uint64_t kEncodedEINVAL = 0x80020016ull;
+constexpr uint64_t kBareEINVAL    = 22;              // FreeBSD EINVAL == every host's EINVAL
+static_assert(kEncodedEINVAL ==
+                  prosper::hle::sce_kernel_error(prosper::hle::FreeBsdErrno::EInval),
+              "the literal and the encoder must agree; if this fires, one of them moved");
+static_assert(kBareEINVAL == static_cast<uint64_t>(prosper::hle::FreeBsdErrno::EInval),
+              "FreeBSD EINVAL is 22");
+
+uint64_t call0(HleFn f) { return f(0, 0, 0, 0, 0, 0); }
+
+// One row of the sweep: a Sony spelling, and the POSIX spelling registered on the same body (or
+// null when the body carries no POSIX name, in which case the Sony spelling encodes in place).
+struct Row {
+    const char* sony;
+    const char* posix;    // nullptr = Sony-only body
+    const char* note;
+};
+
+// Every fallible entry point in the synchronisation-object families, in registration order. A null
+// object provokes EINVAL in all of them (each body opens with a `!a0` / `ensure_*` guard), so one
+// zero-argument call exercises every row uniformly.
+const Row kRows[] = {
+    // --- mutex attributes ---
+    {"scePthreadMutexattrInit",      "pthread_mutexattr_init",      "#2178"},
+    {"scePthreadMutexattrSettype",   "pthread_mutexattr_settype",   "#2178"},
+    {"scePthreadMutexattrGettype",   nullptr,                       "#2178, in place"},
+    // --- mutex ---
+    {"scePthreadMutexInit",          "pthread_mutex_init",          "#2178"},
+    {"scePthreadMutexLock",          "pthread_mutex_lock",          "#1945, regression guard"},
+    {"scePthreadMutexTrylock",       "pthread_mutex_trylock",       "#1945, regression guard"},
+    {"scePthreadMutexTimedlock",     nullptr,                       "#1945, in place"},
+    {"scePthreadMutexUnlock",        "pthread_mutex_unlock",        "#2178, the sharpest row"},
+    // --- condition-variable attributes ---
+    {"scePthreadCondattrInit",       "pthread_condattr_init",       "#2178"},
+    {"scePthreadCondattrSetclock",   "pthread_condattr_setclock",   "#2178"},
+    {"scePthreadCondattrGetclock",   "pthread_condattr_getclock",   "#2178"},
+    {"scePthreadCondattrSetpshared", "pthread_condattr_setpshared", "#2178"},
+    {"scePthreadCondattrGetpshared", "pthread_condattr_getpshared", "#2178"},
+    // --- condition variables ---
+    {"scePthreadCondInit",           "pthread_cond_init",           "#2178"},
+    {"scePthreadCondTimedwait",      nullptr,                       "#2178, in place"},
+    // --- read/write locks (already correct: #1984 / #2158 — these are regression guards) ---
+    {"scePthreadRwlockInit",         "pthread_rwlock_init",         "#1984"},
+    {"scePthreadRwlockRdlock",       "pthread_rwlock_rdlock",       "#2158"},
+    {"scePthreadRwlockWrlock",       "pthread_rwlock_wrlock",       "#2158"},
+    {"scePthreadRwlockUnlock",       "pthread_rwlock_unlock",       "#1984"},
+    {"scePthreadRwlockTryrdlock",    "pthread_rwlock_tryrdlock",    "#1984"},
+    {"scePthreadRwlockTrywrlock",    "pthread_rwlock_trywrlock",    "#1984"},
+    {"scePthreadRwlockTimedrdlock",  "pthread_rwlock_timedrdlock",  "#1984, separate POSIX body"},
+    {"scePthreadRwlockTimedwrlock",  "pthread_rwlock_timedwrlock",  "#1984, separate POSIX body"},
+    // --- read/write lock attributes ---
+    {"scePthreadRwlockattrInit",     "pthread_rwlockattr_init",     "#2178"},
+    {"scePthreadRwlockattrDestroy",  "pthread_rwlockattr_destroy",  "#2178"},
+    // --- semaphores ---
+    {"scePthreadSemInit",            "sem_init",                    "#2178"},
+    {"scePthreadSemWait",            "sem_wait",                    "#2178"},
+    {"scePthreadSemTrywait",         "sem_trywait",                 "#2178"},
+    {"scePthreadSemTimedwait",       nullptr,                       "#2178, in place"},
+    {"scePthreadSemPost",            "sem_post",                    "#2178"},
+    {"scePthreadSemGetvalue",        "sem_getvalue",                "#2178"},
+    // --- barriers (no POSIX spelling registered on either body) ---
+    {"scePthreadBarrierInit",        nullptr,                       "#2178, in place"},
+    {"scePthreadBarrierWait",        nullptr,                       "#2178, in place"},
+};
+
+// Entry points whose body returns 0 on every path. They correctly have NO alias, and #2158
+// established that its absence is the right answer rather than an oversight.
+const char* const kInfallible[] = {
+    "scePthreadMutexattrSetprotocol", "scePthreadMutexattrSetpshared", "scePthreadMutexattrDestroy",
+    "scePthreadMutexDestroy", "scePthreadCondattrDestroy", "scePthreadCondDestroy",
+    "scePthreadCondSignal", "scePthreadCondBroadcast", "scePthreadCondWait",
+    "scePthreadRwlockDestroy", "scePthreadSemDestroy", "scePthreadBarrierDestroy",
+    "scePthreadBarrierattrInit", "scePthreadBarrierattrDestroy", "scePthreadBarrierattrSetpshared",
+};
+
+}  // namespace
+
+int main() {
+    printf("== test_pthread_error_encoding ==\n");
+    register_builtin_hle();
+
+    // ===== 1. the sweep: Sony encoded, POSIX bare, one row per fallible entry point ============
+    printf("-- the alias rule, per entry point (null object -> EINVAL) --\n");
+    for (const Row& r : kRows) {
+        char msg[256];
+        HleFn sony = Hle::lookup(nid_hash(r.sony));
+        if (!sony) {
+            snprintf(msg, sizeof msg, "%s is registered", r.sony);
+            CHECK(false, msg);
+            continue;
+        }
+        const uint64_t got = call0(sony);
+        snprintf(msg, sizeof msg, "%-30s -> encoded EINVAL 0x80020016 (got 0x%llx)  [%s]",
+                 r.sony, (unsigned long long)got, r.note);
+        CHECK(got == kEncodedEINVAL, msg);
+
+        if (!r.posix) continue;
+        HleFn posix = Hle::lookup(nid_hash(r.posix));
+        if (!posix) {
+            snprintf(msg, sizeof msg, "%s is registered", r.posix);
+            CHECK(false, msg);
+            continue;
+        }
+        // The half a single-spelling test cannot do: the POSIX name on the same body must NOT
+        // encode. Without this line, aliasing both spellings would look like a clean pass.
+        const uint64_t bare = call0(posix);
+        snprintf(msg, sizeof msg, "%-30s -> bare EINVAL 22 (got %llu)",
+                 r.posix, (unsigned long long)bare);
+        CHECK(bare == kBareEINVAL, msg);
+    }
+
+    // ===== 2. M3: a forwarded HOST errno, where host and FreeBSD numbering disagree ============
+    // scePthreadSemTrywait on an empty semaphore fails with EAGAIN. FreeBSD EAGAIN is 35; the host's
+    // is 11, which is FreeBSD's EDEADLK. This row is the only one that can tell a correct mapping
+    // from a passed-through host number, because every other row's errno is EINVAL(22), which every
+    // platform agrees on. It also carries the full contract at once: Sony gets 0x80020023, POSIX
+    // gets 35, and neither gets 11.
+    printf("-- a forwarded host errno (EAGAIN: FreeBSD 35, host 11) --\n");
+    {
+        HleFn sem_init    = Hle::lookup(nid_hash("scePthreadSemInit"));
+        HleFn sem_trywait = Hle::lookup(nid_hash("scePthreadSemTrywait"));
+        HleFn sem_destroy = Hle::lookup(nid_hash("scePthreadSemDestroy"));
+        HleFn posix_trywait = Hle::lookup(nid_hash("sem_trywait"));
+        CHECK(sem_init && sem_trywait && sem_destroy && posix_trywait,
+              "scePthreadSem* and sem_trywait are registered");
+        if (sem_init && sem_trywait && sem_destroy && posix_trywait) {
+            alignas(16) uint8_t slot[32]{};
+            CHECK(sem_init((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0) == 0,
+                  "a zero-count guest semaphore initializes");
+            CHECK(sem_trywait((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0) == 0x80020023ull,
+                  "scePthreadSemTrywait on an empty semaphore reports encoded FreeBSD EAGAIN "
+                  "(0x80020023) — not a bare 35, and not the host's 11");
+            CHECK(posix_trywait((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0) == 35,
+                  "sem_trywait on the same semaphore reports bare FreeBSD EAGAIN (35)");
+            sem_destroy((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ===== 3. the sharpest row, on a REAL failure rather than a null =========================
+    // scePthreadMutexLock/Trylock/Timedlock all encoded and Unlock did not, so the answer a guest
+    // got to "did this mutex operation fail, and how" depended on which of the four it called.
+    // A guest mutex initialized with no attribute is ERRORCHECK (Sony's default), so releasing one
+    // this thread does not hold is refused with EPERM instead of being undefined behaviour.
+    printf("-- scePthreadMutexUnlock on a mutex this thread does not hold (EPERM) --\n");
+    {
+        HleFn mtx_init   = Hle::lookup(nid_hash("scePthreadMutexInit"));
+        HleFn mtx_unlock = Hle::lookup(nid_hash("scePthreadMutexUnlock"));
+        HleFn mtx_lock   = Hle::lookup(nid_hash("scePthreadMutexLock"));
+        HleFn mtx_destroy = Hle::lookup(nid_hash("scePthreadMutexDestroy"));
+        HleFn posix_unlock = Hle::lookup(nid_hash("pthread_mutex_unlock"));
+        CHECK(mtx_init && mtx_unlock && mtx_lock && mtx_destroy && posix_unlock,
+              "scePthreadMutex* and pthread_mutex_unlock are registered");
+        if (mtx_init && mtx_unlock && mtx_lock && mtx_destroy && posix_unlock) {
+            alignas(16) void* slot = nullptr;
+            const uint64_t s = (uint64_t)(uintptr_t)&slot;
+            CHECK(mtx_init(s, 0, 0, 0, 0, 0) == 0, "guest mutex initializes (ERRORCHECK by default)");
+            const uint64_t sony_rc = mtx_unlock(s, 0, 0, 0, 0, 0);
+            if (sony_rc == 0) {
+                // A host whose ERRORCHECK unlock is permissive cannot run this arm. Say so rather
+                // than passing vacuously — an assertion that held while the mechanism never ran is
+                // the trap this repository keeps rediscovering.
+                printf("  [SKIP] this host permits unlocking an unheld ERRORCHECK mutex — the"
+                       " EPERM half of the #2178 mutex arm cannot run here\n");
+            } else {
+                CHECK(sony_rc == 0x80020001ull,
+                      "scePthreadMutexUnlock of an unheld mutex reports encoded EPERM (0x80020001)");
+                CHECK(posix_unlock(s, 0, 0, 0, 0, 0) == 1,
+                      "pthread_mutex_unlock of the same mutex reports bare EPERM (1)");
+                // The pair above is the #1873 shape closed: ask the same question through the two
+                // spellings of the SAME family and the answers now differ only in encoding.
+                CHECK(mtx_lock(s, 0, 0, 0, 0, 0) == 0, "the mutex still locks after the refusals");
+                CHECK(mtx_unlock(s, 0, 0, 0, 0, 0) == 0, "and the matched unlock still returns 0");
+            }
+            mtx_destroy(s, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ===== 4. M4: the encoding must NOT eat a non-error return ================================
+    // scePthreadBarrierWait answers -1 (PTHREAD_BARRIER_SERIAL_THREAD) to exactly one of the
+    // arriving threads. That is a sentinel, not an errno, and `sce_pthread_rc` passes it through
+    // only because its high bits are set. This arm is what stops the sweep from being applied by
+    // reflex to a handler whose return is a value: over-encode it and the guest's designated
+    // serial thread stops recognising itself.
+    printf("-- the barrier serial-thread sentinel survives the encoding --\n");
+    {
+        HleFn b_init = Hle::lookup(nid_hash("scePthreadBarrierInit"));
+        HleFn b_wait = Hle::lookup(nid_hash("scePthreadBarrierWait"));
+        HleFn b_destroy = Hle::lookup(nid_hash("scePthreadBarrierDestroy"));
+        CHECK(b_init && b_wait && b_destroy, "scePthreadBarrier* are registered");
+        if (b_init && b_wait && b_destroy) {
+            alignas(16) void* slot = nullptr;
+            const uint64_t s = (uint64_t)(uintptr_t)&slot;
+            // count 1: this thread is the whole rendezvous, so it is the serial thread.
+            CHECK(b_init(s, 0, 1, 0, 0, 0) == 0, "a one-participant barrier initializes");
+            const uint64_t rc = b_wait(s, 0, 0, 0, 0, 0);
+            CHECK(rc == (uint64_t)(int64_t)-1,
+                  "scePthreadBarrierWait still returns -1 to the serial thread, unencoded");
+            b_destroy(s, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ===== 5. the "iff" is two-sided: three handlers that must NEVER be encoded ===============
+    // These return a VALUE, not an error code. Aliasing scePthreadEqual would turn its `1` into
+    // 0x80020001 — "equal" delivered as EPERM — and aliasing Self or Getspecific would mangle any
+    // pointer-sized result whose top bits happen to be clear. The rule is "alias iff fallible"
+    // precisely so that a mechanical sweep cannot reach them.
+    printf("-- entry points that return a value, not an error code --\n");
+    {
+        HleFn eq   = Hle::lookup(nid_hash("scePthreadEqual"));
+        HleFn self = Hle::lookup(nid_hash("scePthreadSelf"));
+        CHECK(eq && self, "scePthreadEqual / scePthreadSelf are registered");
+        if (eq && self) {
+            CHECK(eq(0x1234, 0x1234, 0, 0, 0, 0) == 1,
+                  "scePthreadEqual answers 1 for equal ids (NOT 0x80020001)");
+            CHECK(eq(0x1234, 0x5678, 0, 0, 0, 0) == 0, "scePthreadEqual answers 0 for different ids");
+            const uint64_t me = call0(self);
+            CHECK(me != 0 && (me & ~0xffull) != 0x80020000ull,
+                  "scePthreadSelf returns a thread id, not an encoded error");
+        }
+    }
+
+    // ===== 6. the other side of "iff": handlers that correctly have no alias ==================
+    // HONEST LABEL: these arms document the contract, they do NOT discriminate. Each body returns 0
+    // on every path, and `sce_pthread_rc(0)` is 0, so a speculatively added alias would be
+    // invisible here. They are kept because they pin the *observable* half — that these entry
+    // points report success for a null object rather than inventing a failure — which is what a
+    // future author would break by "fixing" them to return EINVAL without also aliasing them.
+    printf("-- handlers with no failure path report success (contract, not a discriminator) --\n");
+    for (const char* name : kInfallible) {
+        char msg[192];
+        HleFn f = Hle::lookup(nid_hash(name));
+        if (!f) { snprintf(msg, sizeof msg, "%s is registered", name); CHECK(false, msg); continue; }
+        const uint64_t got = call0(f);
+        snprintf(msg, sizeof msg, "%-32s -> 0 (no failure path, so no alias)  got 0x%llx",
+                 name, (unsigned long long)got);
+        CHECK(got == 0, msg);
+    }
+
+    if (fails) printf("== FAIL (%d) ==\n", fails);
+    else       printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -143,9 +143,19 @@ int main() {
         if (sem_init && sem_trywait && sem_destroy) {
             alignas(16) uint8_t slot[32]{};
             CHECK(sem_init((uint64_t)slot, 0, 0, 0, 0, 0) == 0, "zero-count guest semaphore initializes");
+            // #2178: this is the SONY spelling, so the FreeBSD number arrives libkernel-encoded.
+            // The two halves of the claim are independent and both matter — 0x8002_0000 is the
+            // encoding, and 0x23 (35) is the FreeBSD numbering, where the host would have said 11.
             const uint64_t rc = sem_trywait((uint64_t)slot, 0, 0, 0, 0, 0);
-            CHECK(rc == static_cast<uint64_t>(FreeBsdErrno::EAgain),
-                  "scePthreadSemTrywait on an empty semaphore reports FreeBSD EAGAIN (35), not host 11");
+            CHECK(rc == sce_kernel_error(FreeBsdErrno::EAgain),
+                  "scePthreadSemTrywait on an empty semaphore reports encoded FreeBSD EAGAIN "
+                  "(0x80020023) — not a bare 35, and not host 11");
+            // The POSIX spelling shares the body and must NOT encode. Without this line the arm
+            // above cannot distinguish a correct alias from both spellings being encoded.
+            auto posix_trywait = Hle::lookup(nid_hash("sem_trywait"));
+            CHECK(posix_trywait && posix_trywait((uint64_t)slot, 0, 0, 0, 0, 0)
+                      == static_cast<uint64_t>(FreeBsdErrno::EAgain),
+                  "sem_trywait keeps the bare FreeBSD EAGAIN (35)");
             sem_destroy((uint64_t)slot, 0, 0, 0, 0, 0);
         } else {
             std::printf("  [skip] scePthreadSem* not registered on this platform\n");


### PR DESCRIPTION
## The rule, and why it needed sweeping

#2158 (issue #2024) established a rule that generalises well past the two handlers it fixed:

> A `scePthread*` handler must go through `SCE_PTHREAD_ALIAS` **if and only if** it is fallible. The
> alias expands to `sce_pthread_rc(body(...))`, which passes `0` and already-encoded values through
> and otherwise returns `0x80020000 | errno`. Without it, a Sony-spelled entry point returns a **bare
> FreeBSD errno** — #1984's defect, the one that held *The Oregon Trail* until `38619f29`.

The rule was applied once. This PR applies it to the synchronisation-object families after a full
census of all 87 `scePthread*` registrations, posted on #2178:
**34 fallible handlers, reached through 35 Sony spellings, did not encode.** This PR fixes the 22 of
them in the mutex, condition-variable, rwlock-attribute, semaphore and barrier families. The
remaining 12 (thread lifecycle, thread attributes, names, TLS keys) are listed on the issue and left
for a follow-up, because no guest has been observed testing an encoded result from any of them and
they belong to a different evidence class.

## The failure scenario

A guest calls `scePthreadMutexUnlock` on a mutex it does not hold. libkernel answers
`0x80020001`; prosper answered `1`. The shipped guest `libc.prx` compares against the **encoded**
constants — `_Mtx_trylock` tests `0x80020010`, `_Mtx_lock` tests `0x8002000b`, `_Cnd_timedwait`
tests `0x8002003c` and `0x80020001` — so a bare errno matches none of them, the wrapper maps the
result to Dinkumware's `_Thrd_error`, and `std::_Throw_C_error` raises an uncaught `std::system_error`
that terminates the process. An ordinary "the mutex was busy" kills the guest.

`scePthreadMutexUnlock` was the sharpest case and is `CLAUDE.md`'s **"same question answered two
ways"** shape (#1873) inside a single function family: `Lock`, `Trylock` and `Timedlock` all encoded,
by three different mechanisms, and `Unlock` encoded by none. The answer a guest got depended on which
of the four it happened to call.

`scePthreadCondTimedwait` was the same shape *inside one function*: it encoded its timeout
(`kSceKernelErrorETIMEDOUT`) and left `EINVAL` and every forwarded host failure bare. The old
`test_cond_clock.cpp` asserted the encoded `0x8002003c` at line 198 and a bare `EPERM` at line 209 —
same entry point, eleven lines apart, both green.

## The change

**Aliased** (dual-registered — the body also carries a POSIX spelling that must keep the bare errno):
`scePthreadMutexattrInit`, `MutexattrSettype`, `MutexInit`, `MutexUnlock`, `CondattrInit`,
`CondattrSetclock`, `CondattrGetclock`, `CondattrSetpshared`, `CondattrGetpshared`, `CondInit`,
`RwlockattrInit`, `RwlockattrDestroy`, `SemInit`, `SemWait`, `SemTrywait`, `SemPost`, `SemGetvalue`.

**Encoded in place** (no POSIX spelling registered on the body, so there is nothing to split — the
form `scePthreadMutexTimedlock` already used): `scePthreadMutexattrGettype`, `CondTimedwait`,
`SemTimedwait`, `BarrierInit`, `BarrierWait`.

**Deliberately NOT touched.** Every handler that returns `0` on all paths keeps its raw registration:
`MutexDestroy`, `MutexattrDestroy`, `MutexattrSetprotocol`, `MutexattrSetpshared`, `CondattrDestroy`,
`CondDestroy`, `CondSignal`, `CondBroadcast`, `CondWait`, `RwlockDestroy`, `SemDestroy`,
`BarrierDestroy`, `Barrierattr*`. #2158 established that the absence of the alias there is *correct*,
not an oversight — adding it would change nothing today and state a contract the body does not have.

**Prerequisite, in the same commits rather than a follow-up.** Three of the aliased bodies returned a
**raw host errno** on their host-failure paths (`(uint64_t)(unsigned)result` in `k_mutexattr_init`,
`k_mutexattr_settype`, `k_cond_init`). Encoding a host number would have been a new defect wearing
the fix's clothes: `pthread_cond_init`'s EAGAIN is host 11, which is FreeBSD's **EDEADLK** — "out of
resources, retry" delivered as "deadlock". These now go through `fbsd_errno` first (#1612's mapping),
which also corrects their POSIX spellings.

### Invariants

* `sce_pthread_rc` passes through `0` and anything with bits outside the low byte. That is what makes
  `scePthreadBarrierWait`'s serial-thread `-1` survive encoding, and what makes
  `scePthreadCondTimedwait`'s already-encoded `ETIMEDOUT` idempotent under the wrapper.
* The three entry points that return a **value** rather than an error code — `scePthreadSelf`,
  `scePthreadEqual`, `scePthreadGetspecific` — must never be aliased. `sce_pthread_rc` would turn
  `scePthreadEqual`'s `1` into `0x80020001`. The new test pins this explicitly, because the risk of a
  mechanical sweep is precisely that it reaches them.

## Evidence

The discriminating assertion for this defect is the **value** the Sony spelling returns, not that it
is non-zero: an arm asserting `!= 0` passes under both the bare errno and the encoded form, which is
the whole bug. And an arm that checks only the Sony spelling cannot tell a correct alias from both
spellings being encoded. So every dual-registered row asserts **both** spellings, to *different*
values.

New: `prosper/tests/test_pthread_error_encoding.cpp` — the sweep made executable. 32 rows covering
every fallible entry point in these families, plus four targeted arms. Registered as ctest
`pthread_error_encoding`.

Mutations each arm kills:

| | mutation | what fails |
| --- | --- | --- |
| M1 | drop the alias (Sony name registered onto the POSIX body) | the Sony half of every row; POSIX still passes |
| M2 | alias **both** spellings | the POSIX half of every row; Sony still passes |
| M3 | return the host errno instead of the FreeBSD one (#1612) | the EAGAIN row — and *only* that row |
| M4 | apply the encoding to a non-error return | the barrier serial-thread arm |

M3 and M4 carry the weight. Every null-object row provokes `EINVAL`, and EINVAL is 22 on FreeBSD,
Linux, Darwin and MinGW alike — so a null-slot arm cannot tell a FreeBSD number from a host number.
The `scePthreadSemTrywait`-on-an-empty-semaphore row can: FreeBSD EAGAIN is 35 while the host's is
11, and 11 is FreeBSD's EDEADLK. M4 guards the opposite error: over-applying the encoding to
`scePthreadBarrierWait`'s `-1` sentinel would stop the guest's designated serial thread recognising
itself.

Two arms deliberately refuse to assert when the host cannot reach the path they exist for (the
ERRORCHECK-unlock refusal) and say so loudly instead of passing vacuously.

Section 6 of the new test is labelled in the source as **contract documentation, not a
discriminator** — those bodies return 0, and `sce_pthread_rc(0)` is 0, so a speculatively added alias
would be invisible there. Saying so is the point.

Updated: `test_cond_clock.cpp` and `test_sce_errno.cpp` carried assertions pinning the **bare**
values — master's own written-down expectation. Flipping them to the encoded form is the red arm,
and `test_sce_errno.cpp` gains the paired `sem_trywait` POSIX assertion it was missing.

### Red-without / green-with, run

**Run — the full table is in [the evidence comment](https://github.com/mattias800/prosper/pull/2189#issuecomment-5208207995).**
Headline: 29 assertions fail against master's `hle_kernel.cpp` and 0 against this branch, with 248
passing on the green side.

The red arm is master's actual shape, not a mutation: `origin/master`'s `hle_kernel.cpp` compiled as
an object and linked ahead of `libprosper_core.a`, so the archive member is never extracted and the
*only* difference between the columns is that one file.

| suite | RED (master's `hle_kernel.cpp`) | GREEN (this branch) |
| --- | --- | --- |
| `test_pthread_error_encoding` (new) | 66 ok · **24 FAIL** | **90 ok** · 0 FAIL |
| `test_mutex_types` | 32 ok · **1 FAIL** | **33 ok** · 0 FAIL |
| `test_cond_clock` | 35 ok · **3 FAIL** | **38 ok** · 0 FAIL |
| `test_sce_errno` | 30 ok · **1 FAIL** | **31 ok** · 0 FAIL |
| `test_rwlock_once` | 56 ok · 0 FAIL | **56 ok** · 0 FAIL |

Three properties make it a discriminator rather than a blanket breakage, and the comment spells each
out: `test_rwlock_once` is **identical in both columns** (the negative control — #2158 already fixed
that family); **66 assertions of the new suite still pass in the red column** (every POSIX
counterpart, the sentinel, the never-encode rows), which is what separates M1 from M2; and each red
failure prints the *value* — `got 0x16` where `0x80020016` is required — rather than a truthiness.

**Full `ctest` has not completed** and this PR stays a **draft** until it does. The machine has been
saturated by concurrent lanes all session (load 34-40; one 50 MB test link took over an hour) and the
primary `cmake --build` is at 54%. The five suites above were linked directly against the
already-built `libprosper_core.a` — the same archive `ctest` uses — to get the evidence without
waiting on unrelated targets.

### Do the 248 green assertions mean anything? — the strongest answer is #2159

The obvious challenge to a suite this size is that it might be tautological: 248 assertions that
would pass against almost any implementation prove nothing. The best evidence they are *sensitive*
is that the suite **caught a live defect it was not aimed at, on its very first run**.

`scePthreadRwlockUnlock` and `pthread_rwlock_unlock` both answer **0** for a null slot instead of
EINVAL, while every sibling sharing `ensure_rwlock` — `Rdlock`, `Wrlock`, `Tryrdlock`, `Trywrlock`,
`Timedrdlock`, `Timedwrlock`, `Init` — answers EINVAL. That is **#2159**, open and separately owned,
and it is not this rule: a missing *check*, not a wrong *encoding*. It was found here by execution,
not by reading, and reported there with the mechanism.

The row is excluded from the null-slot table with a comment pointing at #2159 and a note to re-add it
when that lands. Deliberately not papered over in either direction: asserting the current `0` would
enshrine the bug, and asserting EINVAL would fail for a reason this file is not about.

A suite that finds something nobody pointed it at is not measuring its own assumptions.

## Risk

`CONFIDENCE: HIGH` that the inconsistency existed and that the enumeration is complete — the census
is mechanical and every body was read in full, both `#ifdef` arms.

`CONFIDENCE: MED` that the encoded form is right for each specific entry point, **unchanged from
#2178's own label and not raised by this PR**. #1984's direct evidence is the shipped `libc.prx`
comparing MUTEX and CONDVAR results against encoded constants; the RWLOCK/SEM/BARRIER extension is an
extrapolation from a consistent libkernel-wide convention, exactly as recorded above the rwlock alias
block since #2158. It is the safer of the two possible errors — a guest that only tests `== 0` is
unaffected either way — and it makes the family self-consistent. Do not raise that label without new
guest evidence.

Guest-visible by construction. A title that compared a Sony result against a bare errno would change
behaviour; no such comparison is known, and the guest disassembly evidence points the other way.

## Not fixed here (recorded on #2178 so they are not re-derived)

1. The POSIX `sem_*` spellings return an errno where the C contract is `-1` with the number in
   `errno`. Independent of this rule, and it must be fixed on the POSIX side only.
2. `k_key_delete`, `k_setspecific` and `k_pthread_create` return a raw host errno through *both*
   spellings — the same #1612 shape corrected here for the mutexattr/cond bodies. In the follow-up
   group.
3. `k_attr_setstacksize` silently accepts an invalid attribute and returns 0, while
   `k_attr_setstack` rejects the same conditions with EINVAL. Another "same question, two answers".

Refs #2178

## Verification

```bash
distrobox enter ps5ys -- bash -lc "cd <WORKTREE> && TMPDIR=\$PWD/build/tmpdir cmake --build build -j6"
distrobox enter ps5ys -- bash -lc "cd <WORKTREE> && TMPDIR=\$PWD/build/tmpdir ctest --test-dir build --output-on-failure -j4"
```

Results pending; posted as a comment on the exact head. No snapshots run — this is a libkernel ABI
change with no renderer surface.

**Coordination.** `hle_kernel.cpp` is busy. #2166 (`fix/issue-2042-rwlock-destroy`) has hunks in the
`k_cond_init`/`k_cond_destroy`, `k_rwlock_destroy` and `k_sem_*`/`k_barrier_*` blocks. The overlap is
**textual, not semantic**: #2166 changes the four *destroy* handlers to quarantine their objects, and
this PR changes the *error encoding* of the non-destroy handlers around them. No line is claimed by
both, but the hunks sit adjacent and will need a rebase whichever lands second. #2159 (`k_rwlock_unlock`'s
null slot) does not overlap — this PR touches nothing between `k_rwlock_init` and `k_rwlockattr_init`.


