### PR TITLE
fix(host): clamp the report CURSOR, not just the size — the fault handler's out-of-bounds write

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -667,7 +667,12 @@ namespace {
                 else if (c>='A'&&c<='F') d=c-'A'+10; else break; v = v*16 + d; }
             *pp = p; return v;
         };
-        char out[400]; int on = snprintf(out, sizeof out, "%s", tag);
+        // Every cursor advance in this function goes through raw_fmt_advance (#2161): snprintf
+        // returns the WOULD-BE length, so an unclamped `on` walks past `out` and the next
+        // `sizeof out - on` underflows to ~2^64. Saturated at `sizeof out`, so `out + on` stays
+        // in range, later appends see size 0 and write nothing, and the terminator/flush below
+        // still read `on >= sizeof out` as "this line truncated".
+        char out[400]; int on = raw_fmt_advance(0, snprintf(out, sizeof out, "%s", tag), sizeof out);
         const char* p = spec;
         while (*p && on < (int)sizeof out - 64) {
             while (*p==';'||*p==','||*p==' ') p++;
@@ -686,10 +691,10 @@ namespace {
                 else p++;
             }
             int slen = (int)(p - start); if (slen > 40) slen = 40;
-            if (bad) { on += snprintf(out+on, sizeof out-on, " %.*s=<unmapped>", slen, start); continue; }
+            if (bad) { on = raw_fmt_advance(on, snprintf(out+on, sizeof out-on, " %.*s=<unmapped>", slen, start), sizeof out); continue; }
             // probe_readable(v) verifies [v,v+8), covering any 1..8-byte read at v (guard the read's base).
             if (type=='s') {   // Il2CppString at v: length@0x10 (i32), UTF-16 chars@0x14 — print ASCII, capped.
-                on += snprintf(out+on, sizeof out-on, " %.*s=", slen, start);
+                on = raw_fmt_advance(on, snprintf(out+on, sizeof out-on, " %.*s=", slen, start), sizeof out);
                 if (probe_readable(v + 0x10)) {
                     int len = *(const int32_t*)(v + 0x10);
                     if (len < 0) len = 0; if (len > 48) len = 48;
@@ -709,12 +714,13 @@ namespace {
             else if (type=='d') snprintf(vb, sizeof vb, probe_readable(v) ? "0x%x"   : "?", probe_readable(v) ? *(const uint32_t*)v : 0);
             else if (type=='f') snprintf(vb, sizeof vb, probe_readable(v) ? "f:0x%x" : "?", probe_readable(v) ? *(const uint32_t*)v : 0);
             else                snprintf(vb, sizeof vb, probe_readable(v) ? "0x%llx" : "?", (unsigned long long)(probe_readable(v) ? *(const uint64_t*)v : 0));
-            on += snprintf(out+on, sizeof out-on, " %.*s=%s", slen, start, vb);
+            on = raw_fmt_advance(on, snprintf(out+on, sizeof out-on, " %.*s=%s", slen, start, vb), sizeof out);
         }
-        // `on` is a running total of snprintf returns, so a truncating chain leaves it ABOVE
-        // sizeof out — which would put the newline store out of bounds and hand raw_write a
-        // length past the end of the buffer. Clamp once, then both are provably in range: the
-        // store lands at index <= sizeof out - 1 and the write covers <= sizeof out bytes (#2050).
+        // Since #2161 every append above saturates `on` at sizeof out, so the only value the
+        // clamp still has to absorb here is that saturation itself — the newline store needs one
+        // byte more room than the appends do. `cut` is exactly `on == sizeof out`, which is how
+        // #2050's contract reads "this line truncated": the write covers the bytes that really
+        // landed and the marker tells the reader the tail is missing.
         const bool cut = on < 0 || (size_t)on >= sizeof out;
         on = (int)raw_fmt_len(on, sizeof out);
         out[on] = '\n';
@@ -909,12 +915,12 @@ namespace {
         };
         n = 0;
         for (int i = 0; i < 16; i++) {
-            n += snprintf(b + n, sizeof b - (size_t)n, "%s%s=0x%llx", (i % 4) ? " " : "[nullpage]   ",
-                          regs[i].nm, (unsigned long long)regs[i].v);
+            n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, "%s%s=0x%llx", (i % 4) ? " " : "[nullpage]   ",
+                          regs[i].nm, (unsigned long long)regs[i].v), sizeof b);
             if (i % 4 == 3) {
-                // Same shape as the [il2cpp-probe] line above: `n` is a running snprintf total, so
-                // a truncating chain leaves it past the end of `b`. Clamp before the newline store
-                // so the store and the write are both provably in range (#2050).
+                // Same shape as the [il2cpp-probe] line above: the append saturates `n` at
+                // sizeof b (#2161), and the newline store needs one byte more room than that,
+                // so `cut` is exactly the saturated case and the clamp lands it in range (#2050).
                 const bool cut = n < 0 || (size_t)n >= sizeof b;
                 n = (int)raw_fmt_len(n, sizeof b);
                 b[n++] = '\n';
@@ -959,17 +965,17 @@ namespace {
             uint64_t base = (v & ~0xfull) - (i == 6 /*rbp*/ ? 0x80 : 0x20);
             if (!probe_readable(base)) base = v & ~0xfull;
             int nw = (i == 6) ? 20 : 12;
-            n = snprintf(b, sizeof b, "[nullpage]   %s=0x%llx mem@0x%llx:", regs[i].nm,
-                         (unsigned long long)v, (unsigned long long)base);
+            n = raw_fmt_advance(0, snprintf(b, sizeof b, "[nullpage]   %s=0x%llx mem@0x%llx:", regs[i].nm,
+                         (unsigned long long)v, (unsigned long long)base), sizeof b);
             for (int w = 0; w < nw; w++) {
                 uint64_t addr = base + (uint64_t)w * 8;
                 if (probe_readable(addr))
-                    n += snprintf(b + n, sizeof b - (size_t)n, " %016llx",
-                                  (unsigned long long)*(const uint64_t*)addr);
+                    n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, " %016llx",
+                                  (unsigned long long)*(const uint64_t*)addr), sizeof b);
                 else
-                    n += snprintf(b + n, sizeof b - (size_t)n, " ????????????????");
+                    n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, " ????????????????"), sizeof b);
             }
-            n += snprintf(b + n, sizeof b - (size_t)n, "\n");
+            n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, "\n"), sizeof b);
             raw_write_fmt(2, b, sizeof b, n);
             // Corrupted-header hunt: the canary walk faulted following a NextFreeBlock == 0x1, so
             // the stomped FFreeBlock header is a qword equal to 0x1 somewhere in the current slab
@@ -1283,8 +1289,8 @@ namespace {
         if (sig == SIGILL) {
             uint64_t rip = (uint64_t)PROSPER_GREGS((ucontext_t*)uctx)[REG_RIP];
             const uint8_t* p = (const uint8_t*)rip;
-            char b[96]; int n = snprintf(b, sizeof b, "[sigill] rip=0x%llx bytes:", (unsigned long long)rip);
-            for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n += snprintf(b + n, sizeof b - n, " %02x", p[k]);
+            char b[96]; int n = raw_fmt_advance(0, snprintf(b, sizeof b, "[sigill] rip=0x%llx bytes:", (unsigned long long)rip), sizeof b);
+            for (int k = 0; k < 16 && n < (int)sizeof b - 4; k++) n = raw_fmt_advance(n, snprintf(b + n, sizeof b - n, " %02x", p[k]), sizeof b);
             if (n < (int)sizeof b - 1) b[n++] = '\n';
             ssize_t w = raw_write_fmt(2, b, sizeof b, n); (void)w;
         }
@@ -1356,18 +1362,24 @@ namespace {
                     raw_write_fmt(2, rb, sizeof rb, rn);
                     // Guest call stack: scan [rsp, rsp+0x200) for eboot-range return addresses.
                     uint64_t rsp = (uint64_t)gr2[REG_RSP];
-                    char sb[320]; int sn = snprintf(sb, sizeof sb, "[mb3watch]   guest-stack:");
+                    // The one chain in this file with NO cursor guard at all AND a variable-length
+                    // %s in its append (`gmod` returns module names up to 25 characters), so ten
+                    // captured frames can format to ~470 characters into 320 bytes. Before #2161
+                    // the append after the first truncating one computed `sizeof sb - sn` with
+                    // sn > 320 and wrote at `sb + sn` with a ~2^64 size: a real out-of-bounds
+                    // write, off the end of the signal stack, on realistic guest stacks.
+                    char sb[320]; int sn = raw_fmt_advance(0, snprintf(sb, sizeof sb, "[mb3watch]   guest-stack:"), sizeof sb);
                     int found = 0;
                     for (uint64_t p = rsp; p < rsp + 0x200 && found < 10; p += 8) {
                         if (!probe_readable(p)) break;
                         uint64_t ra = *(const uint64_t*)p;
                         if (gin(ra)) {
-                            sn += snprintf(sb + sn, sizeof sb - sn, " %s+0x%llx",
-                                           gmod(ra), (unsigned long long)goff(ra));
+                            sn = raw_fmt_advance(sn, snprintf(sb + sn, sizeof sb - sn, " %s+0x%llx",
+                                           gmod(ra), (unsigned long long)goff(ra)), sizeof sb);
                             found++;
                         }
                     }
-                    sn += snprintf(sb + sn, sizeof sb - sn, "\n");
+                    sn = raw_fmt_advance(sn, snprintf(sb + sn, sizeof sb - sn, "\n"), sizeof sb);
                     raw_write_fmt(2, sb, sizeof sb, sn);
                 }
                 return;
@@ -1527,12 +1539,12 @@ namespace {
                 if (g_hwbp_fields) {
                     uint64_t o = (uint64_t)gr[REG_RBX];
                     if (probe_readable(o + 0x60)) {
-                        char b[400]; int n = snprintf(b, sizeof b, "[hwbp-fields] rbx=0x%llx:", (unsigned long long)o);
+                        char b[400]; int n = raw_fmt_advance(0, snprintf(b, sizeof b, "[hwbp-fields] rbx=0x%llx:", (unsigned long long)o), sizeof b);
                         for (uint64_t off = 0x10; off <= 0x60; off += 8) {
                             uint64_t v = *(const uint64_t*)(o + off);
-                            n += snprintf(b+n, sizeof b-n, " +0x%llx=0x%llx", (unsigned long long)off, (unsigned long long)v);
+                            n = raw_fmt_advance(n, snprintf(b+n, sizeof b-n, " +0x%llx=0x%llx", (unsigned long long)off, (unsigned long long)v), sizeof b);
                         }
-                        n += snprintf(b+n, sizeof b-n, "\n"); raw_write_fmt(2, b, sizeof b, n);   /* raw syscall: no libc TLS access */
+                        n = raw_fmt_advance(n, snprintf(b+n, sizeof b-n, "\n"), sizeof b); raw_write_fmt(2, b, sizeof b, n);   /* raw syscall: no libc TLS access */
                         // Resolve the class name of each object-typed field (its [obj]->klass->[+0x10]=name).
                         for (uint64_t off = 0x10; off <= 0x88; off += 8) {
                             if (!probe_readable(o + off + 7)) continue;
@@ -1782,14 +1794,14 @@ namespace {
                     uint64_t r10 = (uint64_t)gr[REG_R10], rdx = (uint64_t)gr[REG_RDX];
                     uint64_t r8 = (uint64_t)gr[REG_R8];
                     char b[512];
-                    int n = snprintf(b, sizeof b,
+                    int n = raw_fmt_advance(0, snprintf(b, sizeof b,
                         "[bp] #%d rsi=0x%llx r10=0x%llx rdx=0x%llx rcx=0x%llx r8=0x%llx rax=0x%llx rdi=0x%llx r14=0x%llx r15=0x%llx [rdi]=0x%llx [rdi+0x1e4c]=0x%llx tid=%ld",
                         (int)g_bp_count, (unsigned long long)rsi, (unsigned long long)r10,
                         (unsigned long long)rdx, (unsigned long long)rcx, (unsigned long long)r8,
                         (unsigned long long)rax, (unsigned long long)rdi, (unsigned long long)r14,
                         (unsigned long long)r15, rd(rdi),
                         (unsigned long long)(probe_readable(rdi + 0x1e4c) ? *(const uint32_t*)(rdi + 0x1e4c) : 0xBADBAD),
-                        cur_tid());
+                        cur_tid()), sizeof b);
                     // Caller stack: first guest-text return addresses (who called free with this ptr).
                     uint64_t rsp = (uint64_t)gr[REG_RSP];
                     int found = 0;
@@ -1797,8 +1809,8 @@ namespace {
                         if (!probe_readable(rsp + o)) break;
                         uint64_t v = *(const uint64_t*)(rsp + o);
                         if (gin(v)) {
-                            n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                          (unsigned long long)goff(v));
+                            n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
+                                          (unsigned long long)goff(v)), sizeof b);
                             found++;
                         }
                     }
@@ -1849,15 +1861,15 @@ namespace {
                     g_lwatch_hits = g_lwatch_hits + 1;
                     char b[512];
                     bool guest = gin(g_lwatch_step_rip);
-                    int n = snprintf(b, sizeof b,
+                    int n = raw_fmt_advance(0, snprintf(b, sizeof b,
                         "[lwatch] SHIFT-STOMP fa=0x%llx val=0x%llx (<<8=0x%llx) rip=%s0x%llx tid=%ld",
                         (unsigned long long)g_lwatch_fa, (unsigned long long)v,
                         (unsigned long long)(v << 8), guest ? "eboot+" : "host:",
                         (unsigned long long)(guest ? goff(g_lwatch_step_rip) : g_lwatch_step_rip),
-                        cur_tid());
+                        cur_tid()), sizeof b);
                     for (int i = 0; i < g_lwatch_stkn && n < (int)sizeof b - 24; i++)
-                        n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                      (unsigned long long)goff(g_lwatch_stk[i]));
+                        n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
+                                      (unsigned long long)goff(g_lwatch_stk[i])), sizeof b);
                     if (n < (int)sizeof b - 1) b[n++] = '\n';
                     raw_write_fmt(2, b, sizeof b, n);
                     if (g_lwatch_hits >= g_lwatch_max) {   // caught enough — disarm, leave page RW
@@ -1913,13 +1925,13 @@ namespace {
                     g_lwatch_hits = g_lwatch_hits + 1;
                     char b[512];
                     bool guest = gin(rip);
-                    int n = snprintf(b, sizeof b,
+                    int n = raw_fmt_advance(0, snprintf(b, sizeof b,
                         "[lwatch] #%d write fa=0x%llx rip=%s0x%llx tid=%ld pre[0]=0x%llx pre[8]=0x%llx",
                         (int)g_lwatch_hits, (unsigned long long)fa,
                         guest ? "eboot+" : "host:",
                         (unsigned long long)(guest ? goff(rip) : rip), cur_tid(),
                         (unsigned long long)*(const uint64_t*)g_lwatch_slot,
-                        (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8));
+                        (unsigned long long)*(const uint64_t*)(g_lwatch_slot + 8)), sizeof b);
                     // #312: call-stack capture — scan the writer's stack for eboot-text return
                     // addresses (up to 8), so the guest free/alloc path above the raw write is
                     // identifiable (async-signal-safe: bounded reads of the faulting thread's
@@ -1930,8 +1942,8 @@ namespace {
                         if (!probe_readable(rsp + o)) break;
                         uint64_t v = *(const uint64_t*)(rsp + o);
                         if (gin(v)) {
-                            n += snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
-                                          (unsigned long long)goff(v));
+                            n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, " s:%llx",
+                                          (unsigned long long)goff(v)), sizeof b);
                             found++;
                         }
                     }
@@ -2425,12 +2437,12 @@ namespace {
                     struct iovec riov; riov.iov_base = (void*)(uintptr_t)o.addr; riov.iov_len = sizeof buf;
                     ssize_t got = syscall(SYS_process_vm_readv, getpid(), &liov, 1UL, &riov, 1UL, 0UL);
                     char ob[700];
-                    int on = snprintf(ob, sizeof ob, "[faultobj] %s=0x%llx got=%zd:",
-                                      o.nm, (unsigned long long)o.addr, (ssize_t)got);
+                    int on = raw_fmt_advance(0, snprintf(ob, sizeof ob, "[faultobj] %s=0x%llx got=%zd:",
+                                      o.nm, (unsigned long long)o.addr, (ssize_t)got), sizeof ob);
                     for (int w = 0; got > 0 && w < (int)((size_t)got / 8) && on < (int)sizeof ob - 24; w++)
-                        on += snprintf(ob + on, sizeof ob - (size_t)on, " +%02x=%016llx",
-                                       w * 8, (unsigned long long)buf[w]);
-                    on += snprintf(ob + on, sizeof ob - (size_t)on, "\n");
+                        on = raw_fmt_advance(on, snprintf(ob + on, sizeof ob - (size_t)on, " +%02x=%016llx",
+                                       w * 8, (unsigned long long)buf[w]), sizeof ob);
+                    on = raw_fmt_advance(on, snprintf(ob + on, sizeof ob - (size_t)on, "\n"), sizeof ob);
                     raw_write_fmt(2, ob, sizeof ob, on);
                 }
                 // Corruption-source probe: dump rcx/rdx and scan the GPU-write ring around every
@@ -2573,12 +2585,12 @@ namespace {
                             ssize_t got = syscall(SYS_process_vm_readv, getpid(), &lb, 1UL, &rb, 1UL, 0UL);
                             if (got <= 0) return;
                             char bb[640];
-                            int bn = snprintf(bb, sizeof bb, "[faultobj] bytes (%s) @0x%llx:", nm,
-                                              (unsigned long long)(center - 0x20));
+                            int bn = raw_fmt_advance(0, snprintf(bb, sizeof bb, "[faultobj] bytes (%s) @0x%llx:", nm,
+                                              (unsigned long long)(center - 0x20)), sizeof bb);
                             for (ssize_t k = 0; k < got && bn < (int)sizeof bb - 4; k++)
-                                bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "%s%02x",
-                                               (k % 8 == 0) ? " " : "", bytes[k]);
-                            bn += snprintf(bb + bn, sizeof bb - (size_t)bn, "\n");
+                                bn = raw_fmt_advance(bn, snprintf(bb + bn, sizeof bb - (size_t)bn, "%s%02x",
+                                               (k % 8 == 0) ? " " : "", bytes[k]), sizeof bb);
+                            bn = raw_fmt_advance(bn, snprintf(bb + bn, sizeof bb - (size_t)bn, "\n"), sizeof bb);
                             raw_write_fmt(2, bb, sizeof bb, bn);
                         };
                         byte_dump("rdx", fc.rdx);

--- a/prosper/src/host/raw_syscall.hpp
+++ b/prosper/src/host/raw_syscall.hpp
@@ -13,6 +13,57 @@
 // x86-64 asm branch; the POSIX fallback branch is plain libc (safe there, see its comment).
 #include <cerrno>
 #include <cstdint>
+#include <climits>
+
+namespace prosper {
+
+// --- accumulating a report line: clamp the CURSOR, not just the size ------------------------
+// Report sites build a diagnostic line by accumulating snprintf() returns into a running offset:
+//
+//     int n = snprintf(b, sizeof b, "...");
+//     n += snprintf(b + n, sizeof b - (size_t)n, "...");     // <-- both operands wrong on truncation
+//
+// snprintf() returns the length it WOULD have written. Once any call in the chain truncates,
+// `n > sizeof b`, and the next call in the same chain is handed `sizeof b - n` — size_t
+// arithmetic, so it underflows to roughly 2^64 — at `b + n`, which is already past the end of
+// the object. That is an out-of-bounds WRITE, and it is worse than the read-side sibling (#2050)
+// in exactly the situation these sites exist for: the fault handler corrupts its own signal
+// stack while reporting the fault it was called to describe. (#2161.)
+//
+// This is the whole contract: given the current cursor, the snprintf() return for the append
+// just made, and the destination array's `cap`, return the new cursor — SATURATED AT `cap`.
+//
+// Saturating at `cap` rather than `cap - 1` is deliberate, and it is what makes the fix compose
+// with the read side instead of fighting it:
+//   * `buf + n` stays inside [buf, buf + cap] — at worst one-past-the-end, a pointer C permits
+//     forming, and `cap - n` is >= 0 and never underflows.
+//   * At saturation `cap - n` is 0, and snprintf() with size 0 writes nothing at all (C11
+//     7.21.6.5), so every later append in the chain is a no-op rather than an overflow. The
+//     cursor is sticky: once cut, always cut.
+//   * `n == cap` is exactly the condition raw_fmt_len()/raw_write_fmt() already read as
+//     "this line truncated" (#2050), so the flush writes the `cap - 1` bytes that really landed
+//     and emits the existing truncation marker. Truncation stays visible through ONE contract;
+//     no second marker, no per-chain "did it truncate" flag to thread through nine call sites.
+// Clamping to `cap - 1` instead would be memory-safe and silent: the flush would see a
+// full-looking cursor, print no marker, and each post-saturation append would write its NUL over
+// the last content byte. A silently shortened fault report is its own trap — that is the whole
+// reason #2050 added a marker.
+//
+// A negative `written` (snprintf encoding error, which leaves the array contents indeterminate)
+// saturates too: fail-visible beats a line that silently drops an append it could not format.
+// Async-signal-safe: integer arithmetic only — no allocation, no lock, no errno, no TLS.
+// Defined above the platform guard because it is pure arithmetic: Windows/MinGW-clean, and
+// unit-testable on any host (see tests/test_raw_syscall.cpp).
+inline int raw_fmt_advance(int cursor, int written, uint64_t cap) {
+    const uint64_t lim = cap > (uint64_t)INT_MAX ? (uint64_t)INT_MAX : cap;
+    if (lim == 0) return 0;
+    const uint64_t at = cursor > 0 ? (uint64_t)cursor : 0;   // a bad cursor cannot make it worse
+    if (at >= lim || written < 0) return (int)lim;           // already cut, or nothing usable landed
+    const uint64_t next = at + (uint64_t)written;            // 64-bit: the int sum could overflow
+    return next < lim ? (int)next : (int)lim;
+}
+
+} // namespace prosper
 
 namespace prosper {
 

--- a/prosper/tests/test_raw_syscall.cpp
+++ b/prosper/tests/test_raw_syscall.cpp
@@ -10,13 +10,22 @@
 // out-of-bounds read in the one code path that only runs when the process is already broken.
 // The assertions below read what the PIPE received, never the helper's own return, so a helper
 // that computed the right number and wrote the wrong one would still fail.
+//
+// raw_fmt_advance (#2161): the WRITE half of the same class. The same report sites accumulate
+// those snprintf returns into a running cursor, so a truncating chain left the cursor past the
+// end of the buffer and handed the NEXT call `sizeof b - n` (size_t: underflows to ~2^64) at
+// `b + n` (already past the end) — an out-of-bounds write onto the signal stack. Those arms put
+// the buffer against a PROT_NONE page so an overflowing append faults the test.
 #include "../src/host/raw_syscall.hpp"
 
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <csignal>
 #include <sys/mman.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 static int failures = 0;
@@ -53,6 +62,79 @@ int main() {
     return 0;
 }
 #else
+
+// ---------------------------------------------------------------------------------------------
+// #2161: accumulated snprintf offsets underflow their remaining capacity — an OOB WRITE.
+//
+// A report site builds a line by accumulating snprintf() returns. snprintf returns the WOULD-BE
+// length, so once any call truncates the cursor exceeds the buffer; the next call in the chain
+// then gets `cap - cursor` (size_t: underflows to ~2^64) at `cap + cursor` (already past the
+// end). These arms put the buffer flush against the end of a mapped page with the next page
+// PROT_NONE, so "writes past the end" is a fault rather than an assertion about silent damage.
+// ---------------------------------------------------------------------------------------------
+
+static const size_t kPage = 4096;
+
+// A `cap`-byte buffer whose LAST byte is the last byte of a mapped page; the next page is
+// PROT_NONE. `buf[cap - 1]` is the last legal store, `buf + cap` is one-past-the-end (a pointer
+// C permits forming) and every byte from there on faults.
+static char* guard_backed(size_t cap, void** region) {
+    char* r = (char*)mmap(nullptr, 2 * kPage, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    if (r == MAP_FAILED) return nullptr;
+    if (mprotect(r + kPage, kPage, PROT_NONE) != 0) { munmap(r, 2 * kPage); return nullptr; }
+    *region = r;
+    return r + kPage - cap;
+}
+
+// The chain under test, lifted from the [mb3watch] guest-stack dump in
+// src/host/exec_image_linux.cpp: no cursor guard at all, and its append embeds a variable-length
+// %s (guest_module_name returns names up to 25 characters), so ten captured frames format to
+// ~470 characters into 320 bytes. `cap` stands in for the `sizeof sb` of the real array; the
+// arithmetic is otherwise identical, including `cap - (size_t)sn` — which is exactly what
+// `sizeof sb - sn` computes, an int promoted into size_t.
+static const char* kModName = "AkVorbisHwAccelerator.prx";   // 25 chars: the longest real one
+static const unsigned long long kOff = 0x1122334455667788ull;  // 16 hex digits
+static const int kFrames = 10;                                 // the site's `found < 10` cap
+
+// MASTER'S SHAPE, verbatim — the red arm. Not a mutation written for this test: this is the
+// accumulation as it stands in the fault handler today.
+__attribute__((noinline)) static int chain_unclamped(char* sb, size_t cap) {
+    int sn = snprintf(sb, cap, "[mb3watch]   guest-stack:");
+    for (int i = 0; i < kFrames; i++)
+        sn += snprintf(sb + sn, cap - (size_t)sn, " %s+0x%llx", kModName, kOff);
+    sn += snprintf(sb + sn, cap - (size_t)sn, "\n");
+    return sn;
+}
+
+// The same chain with the fix: every cursor advance goes through raw_fmt_advance.
+__attribute__((noinline)) static int chain_clamped(char* sb, size_t cap) {
+    int sn = prosper::raw_fmt_advance(0, snprintf(sb, cap, "[mb3watch]   guest-stack:"), cap);
+    for (int i = 0; i < kFrames; i++)
+        sn = prosper::raw_fmt_advance(
+            sn, snprintf(sb + sn, cap - (size_t)sn, " %s+0x%llx", kModName, kOff), cap);
+    sn = prosper::raw_fmt_advance(sn, snprintf(sb + sn, cap - (size_t)sn, "\n"), cap);
+    return sn;
+}
+
+// Run `fn` in a child and report how it died. Returns the terminating signal, 0 for a clean
+// exit, or -1 if the child could not be created/reaped.
+static int signal_from_child(int (*fn)(char*, size_t), size_t cap) {
+    fflush(nullptr);
+    pid_t pid = fork();
+    if (pid < 0) return -1;
+    if (pid == 0) {
+        void* region = nullptr;
+        char* buf = guard_backed(cap, &region);
+        if (!buf) _exit(70);
+        int r = fn(buf, cap);
+        _exit(r == 0 ? 71 : 0);       // survived: the OOB write did not happen
+    }
+    int st = 0;
+    if (waitpid(pid, &st, 0) != pid) return -1;
+    return WIFSIGNALED(st) ? WTERMSIG(st) : 0;
+}
+
 // Run `body` with fd 2 redirected into a pipe, and return what the pipe received. The assertions
 // that matter are on `out.n` — the byte count the kernel actually accepted — so a regression that
 // passes an over-long length is caught by the bytes that arrive, not by any value the helper
@@ -204,6 +286,114 @@ int main() {
 
         munmap(region, pg * 2);
     }
+
+    // === #2161: the accumulation clamp ========================================================
+    {
+        const size_t cap = 320;                    // the real `char sb[320]`
+
+        // --- ARM 1 (RED, master's shape): the unclamped chain writes past the end -----------
+        // Cursor walk: 25, then +45 per frame -> 295 after six. The seventh is handed size 25
+        // for a 45-character append, so it truncates and returns 45: the cursor becomes 340,
+        // twenty bytes into the guard page. The eighth iteration stores there. This arm is
+        // master's code, not a mutation of it (the charter's positive-control rule) — it is the
+        // reason the fix exists, and it must die.
+        int sig = signal_from_child(chain_unclamped, cap);
+        CHECK(sig == SIGSEGV,
+              "unclamped accumulation did not fault: child signal %d (expected SIGSEGV=%d). "
+              "If this stops faulting the guard page is not where the test thinks it is.",
+              sig, SIGSEGV);
+        // The control for arm 1, and it is deliberately NOT drawn from the same place as the
+        // null: the identical unclamped chain over a buffer big enough for the whole line must
+        // exit cleanly. Without it, "the child died" is also consistent with a broken harness —
+        // a mismapped guard page, or a chain that faults for some reason other than capacity.
+        CHECK(signal_from_child(chain_unclamped, 1024) == 0,
+              "unclamped chain faulted even with room to spare — arm 1's fault is not the overrun");
+
+        // --- ARM 2 (GREEN): the clamped chain survives the same input ------------------------
+        CHECK(signal_from_child(chain_clamped, cap) == 0,
+              "clamped accumulation faulted or exited non-zero");
+
+        // --- ARM 3: what actually LANDED in the buffer, not what the helper returned ---------
+        // Run it in-process against the same guard page and read the bytes back.
+        void* guard_region = nullptr;
+        char* buf = guard_backed(cap, &guard_region);
+        CHECK(buf != nullptr, "guard-backed mapping failed: %s", strerror(errno));
+        if (buf) {
+            memset(buf, 0, cap);
+            int sn = chain_clamped(buf, cap);
+
+            // The untruncated line, built independently, is the oracle for the content.
+            char ref[1024];
+            int rn = snprintf(ref, sizeof ref, "[mb3watch]   guest-stack:");
+            for (int i = 0; i < kFrames; i++)
+                rn += snprintf(ref + rn, sizeof ref - (size_t)rn, " %s+0x%llx", kModName, kOff);
+            CHECK((size_t)rn > cap, "oracle line (%d bytes) must exceed cap %zu or arm 3 is vacuous",
+                  rn, cap);
+
+            CHECK(strlen(buf) == cap - 1,
+                  "truncated buffer should hold exactly cap-1 = %zu characters, holds %zu",
+                  cap - 1, strlen(buf));
+            CHECK(memcmp(buf, ref, cap - 1) == 0,
+                  "truncated content is not the prefix of the full line");
+            // The cursor SATURATES at cap — it does not stop at cap-1. That is the signal the
+            // flush reads as "this line truncated" (raw_fmt_len/raw_write_fmt, #2050): clamping
+            // to cap-1 instead would be memory-safe and SILENT.
+            CHECK(sn == (int)cap, "cursor should saturate at cap=%zu, got %d", cap, sn);
+
+            // --- ARM 4: saturation is sticky AND does not eat the last content byte ----------
+            // This is what separates the fix from the obvious alternative. With a cap-1 clamp,
+            // each further append gets size 1 and writes its NUL over buf[cap-1] — memory-safe,
+            // but it destroys the last character of the report and still reports no truncation.
+            // With the cap clamp the size is 0, so snprintf writes nothing at all.
+            char before[cap];
+            memcpy(before, buf, cap);
+            for (int i = 0; i < 3; i++)
+                sn = prosper::raw_fmt_advance(
+                    sn, snprintf(buf + sn, cap - (size_t)sn, " %s+0x%llx", kModName, kOff), cap);
+            CHECK(sn == (int)cap, "cursor must stay saturated after further appends, got %d", sn);
+            CHECK(memcmp(before, buf, cap) == 0,
+                  "appends after saturation modified the buffer — the report lost its tail");
+            munmap(guard_region, 2 * kPage);
+        }
+    }
+    {
+        // --- ARM 5: a chain that FITS must not be clamped ------------------------------------
+        // Without this, "always return cap-1" passes every arm above. The cursor has to be the
+        // true byte count so a complete line is written complete and reports no truncation.
+        const size_t cap = 64;
+        void* guard_region = nullptr;
+        char* buf = guard_backed(cap, &guard_region);
+        CHECK(buf != nullptr, "guard-backed mapping failed: %s", strerror(errno));
+        if (buf) {
+            int n = prosper::raw_fmt_advance(0, snprintf(buf, cap, "[fits]"), cap);
+            n = prosper::raw_fmt_advance(n, snprintf(buf + n, cap - (size_t)n, " a=%d", 7), cap);
+            n = prosper::raw_fmt_advance(n, snprintf(buf + n, cap - (size_t)n, " b=%d\n", 9), cap);
+            CHECK(n == (int)strlen(buf), "fitting chain: cursor %d != bytes written %zu",
+                  n, strlen(buf));
+            CHECK((size_t)n < cap, "fitting chain must not report truncation (n=%d cap=%zu)",
+                  n, cap);
+            CHECK(strcmp(buf, "[fits] a=7 b=9\n") == 0, "fitting chain content wrong: '%s'", buf);
+
+            // --- ARM 6: the exact-fit boundary --------------------------------------------
+            // cap-1 content bytes is a COMPLETE line (no truncation); one more is not. An
+            // off-by-one in the saturation test (`>` for `>=`) fails exactly here.
+            char fill[cap];
+            memset(fill, 'x', sizeof fill); fill[cap - 1] = '\0';        // 63 characters
+            int e = prosper::raw_fmt_advance(0, snprintf(buf, cap, "%s", fill), cap);
+            CHECK(e == (int)cap - 1, "exact fit should give cap-1=%zu, got %d", cap - 1, e);
+            CHECK((size_t)e < cap, "an exactly-filling line must not report truncation");
+            e = prosper::raw_fmt_advance(e, snprintf(buf + e, cap - (size_t)e, "y"), cap);
+            CHECK(e == (int)cap, "one byte past an exact fit must saturate, got %d", e);
+            munmap(guard_region, 2 * kPage);
+        }
+    }
+    // --- ARM 7: degenerate inputs are absorbed, never propagated -----------------------------
+    // A negative snprintf return (encoding error, contents indeterminate) saturates: fail-visible
+    // beats a line that silently drops an append. A zero cap has nowhere to write.
+    CHECK(prosper::raw_fmt_advance(10, -1, 64) == 64, "negative snprintf return must saturate");
+    CHECK(prosper::raw_fmt_advance(0, 5, 0) == 0, "cap 0 must stay at 0");
+    CHECK(prosper::raw_fmt_advance(-5, 3, 64) == 3, "a negative cursor must be treated as 0");
+    CHECK(prosper::raw_fmt_advance(64, 5, 64) == 64, "an already-saturated cursor must not move");
 
     if (failures) { fprintf(stderr, "%d failure(s)\n", failures); return 1; }
     printf("raw_syscall: all checks passed\n");


### PR DESCRIPTION
Fixes #2161.

## The defect

Nineteen sites in `prosper/src/host/exec_image_linux.cpp` build a diagnostic line by accumulating
`snprintf` returns into a running cursor. `snprintf` returns the length it **would have** written,
so once any call in a chain truncates, `n > sizeof b`, and the next call in the same chain gets

* `sizeof b - n` — `size_t` arithmetic, so it **underflows to roughly 2^64**, and
* `b + n` — a pointer already past the end of the object.

snprintf then writes as far as the format needs, off the end of a stack buffer. This is the
**write** half of #2050: an out-of-bounds write corrupts adjacent memory rather than failing a
syscall, and every one of these sites runs inside the signal handler — so the corruption lands on
the signal stack while the handler is reporting the fault it exists to describe.

## The true site count, re-derived on `origin/master`

**19**, exactly as the issue says, and the list is the same. Two independent scans agree:
`grep -n '+= snprintf'` and `grep -nE 'snprintf\([^,]*,[^,]*-'` (every `snprintf` whose *size*
argument is a subtraction) both return the same 19 lines, and there are no multi-line or
`n = n + snprintf(...)` variants in the file. Ten more `snprintf`s open a chain
(`int n = snprintf(b, sizeof b, ...)`) and feed one of those 19, so the patch touches 29 call
sites in nine chains.

**The 19 are not equally live, and saying "19 out-of-bounds writes" would be wrong.** (Line numbers
below are `origin/master`'s; the issue quotes #2171's branch, which is the same 19 sites shifted by
its own additions.)

| chain | buffer | cursor guard | status on master |
| --- | --- | --- | --- |
| `[mb3watch]` guest-stack (L1343, L1348) | `sb[320]` | **none** | **reachable OOB write** |
| `[nullpage]` register dump (L903) | `b[512]` | **none** | latent — 4 entries ≈ 110 B |
| `[nullpage]` qword walk (L945–950) | `b[512]` | **none** | latent — 20 words ≈ 399 B |
| `[hwbp-fields]` (L1511, L1513) | `b[400]` | **none** | latent — 11 fields ≈ 313 B |
| `[il2cpp-probe]` (L687, L690, L710) | `out[400]` | `on < cap-64` | guard slack 64 < 81 max append |
| `[sigill]` bytes (L1265) | `b[96]` | `n < cap-4` | slack 4 ≥ 3 |
| `[bp]` / `[lwatch]` ×3 (L1778/1837/1911) | `b[512]` | `n < cap-24` | slack 24 ≥ 19 |
| `[faultobj]` qwords (L2410, L2412) | `ob[700]` | `on < cap-24` | slack 24 ≥ 21 |
| `[faultobj]` bytes (L2558, L2560) | `bb[640]` | `bn < cap-4` | slack 4 ≥ 3 |

The one that is live today is `[mb3watch]`: it has **no cursor guard at all** *and* its append
embeds a variable-length `%s` — `gmod` is `guest_module_name`, which returns names up to 25
characters (`AkVorbisHwAccelerator.prx`). Ten captured frames format to roughly 470 characters
into 320 bytes, so the cursor passes `sizeof sb` around the seventh frame and the eighth writes
into whatever follows. Four more chains carry **no guard at all** and are safe only by arithmetic
coincidence of their current buffer sizes and trip counts. The rest carry a loop guard whose slack
happens to exceed one append — which bounds the *loop*, not the *call*, so widening any format
arms them silently.

## The contract

`prosper::raw_fmt_advance(cursor, written, cap)` in `src/host/raw_syscall.hpp` returns the new
cursor, **saturated at `cap`**:

```c
n = raw_fmt_advance(n, snprintf(b + n, sizeof b - (size_t)n, ...), sizeof b);
```

* `b + n` stays inside `[b, b + cap]` — at worst one-past-the-end, a pointer C permits forming —
  and `cap - n` is `>= 0` and never underflows.
* At saturation `cap - n` is `0`, and `snprintf` with size 0 writes nothing at all
  (C11 7.21.6.5), so every later append in the chain is a no-op. The cursor is sticky: once cut,
  always cut. *This is not only argued from the standard — arms 2 and 3 below execute four such
  calls with the destination pointing at a `PROT_NONE` page and do not fault.*
* Every existing loop guard keeps working unchanged, because they all compare against `cap - k`
  and saturation sits at `cap`.

### Saturating at `cap`, not `cap - 1` — and why that is the whole point

The issue suggests `n = raw_fmt_len(n, cap)`, which saturates at `cap - 1`. That is memory-safe
and **silent**: the flush would see a full-looking cursor, print no truncation marker, and each
post-saturation append would write its NUL over `buf[cap-1]`, eating the last character of the
report. `n == cap` is *exactly* the condition `raw_fmt_len` / `raw_write_fmt` already read as
"this line truncated" (#2050), so with the `cap` clamp the flush writes the `cap - 1` bytes that
really landed **and emits the marker that already exists**. One contract, one marker, no per-chain
"did it truncate" flag threaded through nine call sites — the "same question answered two ways"
rule (#1873). Mutation arm M2 below is that alternative, and it fails five assertions.

## Relationship to #2171 (the read side) — merged and rebased onto

#2171 landed as `3134207f` while this branch was in review, and this branch is **rebased onto it**.
No parallel helper was added and nothing here re-fixes the read side:

* `raw_fmt_advance` answers a *different* question from `raw_fmt_len` — where is the cursor now,
  versus how many bytes landed — and the two are designed to compose. The cursor saturates at
  `cap`, which is precisely the input `raw_fmt_len` / `raw_write_fmt` already interpret as
  truncated, so the existing flush contract and the existing marker do the reporting unchanged.
* All 90 `raw_write_fmt` call sites, both `raw_write_trunc_mark` calls and both `raw_fmt_len`
  calls that #2171 placed in `exec_image_linux.cpp` are present verbatim on this head — counted,
  not assumed:

  ```
  raw_write_fmt:        master 90  head 90
  raw_write_trunc_mark: master  2  head  2
  raw_fmt_len:          master  2  head  2
  ```

  Likewise every #2171 arm in `tests/test_raw_syscall.cpp` survives (`check_fmt_len` 3/3,
  `capture_stderr` 7/7); the test diff is `+190 / -0`.

Seven hunks conflicted on the rebase, all of the form "the append clamp on line N (this PR) next to
the flush clamp on line N+2 (#2171)". Each was resolved by keeping **both**. At the two unguarded
newline stores — `out[on] = '\n'` in the il2cpp probe and `b[n++] = '\n'` in the nullpage register
dump — #2171's marker-emitting form was taken over this branch's minimal clamp, as flagged on
#2171 before it merged. With the cursor now saturating at `cap`, #2171's
`cut = n < 0 || (size_t)n >= sizeof b` evaluates to exactly "the cursor saturated", so its
truncation marker fires on precisely the cases that used to overflow.

## Verification

Local build + full `ctest` in the `ps5ys` distrobox, which is tonight's gate (GitHub Actions is in
a `major_outage` — jobs fail at `Set up job` before any code runs, so no green can be claimed from
CI).

```
cmake -S prosper -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6
ctest --output-on-failure --no-tests=error
```

`--no-tests=error` per the charter rule landed in #2188 — plain `ctest` exits 0 on a directory with
nothing registered, so the test *count* is quoted alongside the exit code. Exact-head results are
posted as a comment below.

### Red-without / green-with, per arm

The regression arms put the buffer flush against the end of a mapped page with the next page
`PROT_NONE`, so "writes past the end" is a fault rather than an assertion about silent damage.
Assertions are on **what landed in the buffer**, checked against an independently built oracle
line, not on the helper's return.

**Arm 1 is `master`'s chain verbatim** — the `[mb3watch]` accumulation copied out of the fault
handler, not a mutation written for this test (the charter rule landed in #2153). It dies with
`SIGSEGV` in a forked child. Its control is the *same function* over a 1024-byte buffer, which
exits cleanly: without that, "the child died" would also be consistent with a mismapped guard page
or a chain that faults for some unrelated reason.

Mutation matrix — each row is the shipped test file compiled against a mutated `raw_fmt_advance`:

| mutation | outcome |
| --- | --- |
| **M0 shipped implementation** | **exit 0, 0 failures** |
| M1 no clamp (master's arithmetic promoted into the helper) | test binary **killed by SIGSEGV**; arm 2 fails first |
| M2 saturate at `cap - 1` (the issue's own suggestion) | 5 failures — cursor never reports truncation |
| M3 always return `cap - 1` | 10 failures |
| M4 always return `cap` | 8 failures |
| M5 saturate one byte early | 2 failures — an exactly-filling line reported as truncated |
| M6 swallow a negative `snprintf` return | 1 failure |

M2 is the arm that matters: a truncation arm alone cannot tell a correct clamp from an
always-clamp, and an always-clamp arm alone cannot tell the `cap` contract from the `cap - 1` one.
M3/M4 are killed by the *fitting* chain (arm 5), M5 by the exact-fit boundary (arm 6).

## Deliberately unaffected

No change to what any diagnostic prints when nothing truncates — the cursor is the exact byte count
in that case (arm 5 asserts it). No new environment variable, no new marker, no change to
`raw_write`. `raw_fmt_advance` is pure integer arithmetic above the platform guard, so it stays
Windows/MinGW-clean and is async-signal-safe: no allocation, no lock, no `errno`, no TLS.

## Risks

The one behavioural change on a truncating line is that appends after the cut now write nothing
instead of overflowing, so a report that previously corrupted memory now ends early and is marked
(once #2171 lands) rather than ending early and being silent. Fault-handler-only; no game path
changes.
