### PR TITLE
fix(win): one condvar, one slot - a freed EARLIER slot could steal a live condvar

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -613,6 +613,10 @@ if(TARGET prosper_core)
   add_test(NAME sync_ring COMMAND test_sync_ring)
   set_tests_properties(sync_ring PROPERTIES ENVIRONMENT "PROSPER_SYNC_RING=64")
 
+  add_executable(test_cond_slot_identity tests/test_cond_slot_identity.cpp)
+  target_link_libraries(test_cond_slot_identity PRIVATE prosper_core)
+  add_test(NAME cond_slot_identity COMMAND test_cond_slot_identity)
+
   # sceKernelDlsym honors its module handle (#147): per-module export tables, real handles from
   # LoadStartModule for linked-module paths, global first-wins fallback. Pure, no game dump needed.
   add_executable(test_dlsym_handle tests/test_dlsym_handle.cpp)

--- a/prosper/src/hle/sync_futex.cpp
+++ b/prosper/src/hle/sync_futex.cpp
@@ -140,15 +140,56 @@ int consume_cond_wait_failure(CondWaitFailurePointForTest point) {
     return (int)(uint32_t)armed;
 }
 
+// One condvar must resolve to ONE slot, for the life of that condvar.
+//
+// #2139: this used to search for an existing owner and claim a free slot in the SAME pass, so a free
+// slot encountered before this cond's own slot was taken instead of it. That splits a waiter and its
+// signaller across two slots, and the signal is then delivered to a sequence nobody is waiting on --
+// a permanent, silent lost wakeup. Blue Prince deadlocked exactly this way:
+//
+//   guest cond 0x…910 claims slot ...ad8 (…ac8 was busy); a thread parks on ...ad8;
+//   the cond that owned ...ac8 is destroyed, freeing an EARLIER slot;
+//   the next lookup for 0x…910 claims ...ac8 and signals it. The waiter on ...ad8 never wakes,
+//   the signaller then waits for that thread's reply, and all 70 guest threads pile up behind it.
+//
+// It needs slot churn plus a destroy in the window between a waiter's lookup and its signaller's, so
+// it only bites deep into a long run -- which is why it read as timing sensitivity.
+//
+// The fix is that an existing owner ANYWHERE in the table beats any free slot: prove the key absent
+// before claiming. Kept lock-free deliberately -- exception delivery can suspend a thread at any
+// instruction, so a mutex here can be held by a thread that is stopped (see g_wait_slots above).
 CondSlot* cond_slot_for(pthread_cond_t* cond) {
     const uintptr_t key = (uintptr_t)cond;
-    for (CondSlot& slot : g_cond_slots) {
-        uintptr_t owner = slot.cond.load(std::memory_order_acquire);
-        if (owner == key || (owner == 0 && slot.cond.compare_exchange_strong(
-                owner, key, std::memory_order_acq_rel)))
-            return &slot;
+    if (!key) return nullptr;
+    auto find_owner = [key]() -> CondSlot* {
+        for (CondSlot& slot : g_cond_slots)
+            if (slot.cond.load(std::memory_order_acquire) == key) return &slot;
+        return nullptr;
+    };
+    // Bounded: each iteration either returns or releases a slot that a lower-indexed claim won, and
+    // only a concurrent first-use of the SAME condvar can cause one. A spin cap keeps a pathological
+    // interleaving from becoming an unbounded loop inside a guest sync primitive.
+    for (int attempt = 0; attempt < 64; ++attempt) {
+        if (CondSlot* owner = find_owner()) return owner;
+
+        CondSlot* claimed = nullptr;
+        for (CondSlot& slot : g_cond_slots) {
+            uintptr_t expected = 0;
+            if (slot.cond.compare_exchange_strong(expected, key, std::memory_order_acq_rel)) {
+                claimed = &slot;
+                break;
+            }
+        }
+        if (!claimed) return nullptr;   // table full
+
+        // Two threads can reach the claim above for the same new condvar at once and take two
+        // different slots. Resolve it the same way on both sides -- lowest index wins -- so they
+        // converge on one slot instead of each keeping its own.
+        CondSlot* winner = find_owner();
+        if (winner == claimed) return claimed;
+        claimed->cond.store(0, std::memory_order_release);
     }
-    return nullptr;
+    return find_owner();
 }
 
 WaitSlot* register_wait(GuestWaitKind kind, uintptr_t object, uintptr_t source = 0) {

--- a/prosper/tests/test_cond_slot_identity.cpp
+++ b/prosper/tests/test_cond_slot_identity.cpp
@@ -1,0 +1,158 @@
+// One condition variable must resolve to ONE slot, for the life of that condvar (#2139).
+//
+// The Windows condition layer maps each guest `pthread_cond_t*` onto a fixed-size table of slots,
+// and the waiter and the signaller find their slot independently. If a lookup can ever return a
+// DIFFERENT slot for the same condvar, the signal is delivered to a sequence nobody is waiting on
+// and the waiter sleeps forever. There is no error and no log -- the only evidence afterwards is a
+// process in which every thread is parked, which is exactly how Blue Prince deadlocked.
+//
+// The trigger is slot reuse: `cond_slot_for` used to look for an existing owner and claim a free
+// slot in the SAME pass, so a slot freed EARLIER in the table was taken in preference to the slot
+// this condvar already owned.
+//
+// Two things about the shape of this test are load-bearing:
+//
+//  * It gates on `snapshot_guest_wait` rather than on a sleep. The defect only shows if the waiter
+//    is already REGISTERED on its slot when the signal is sent; a sleep-based gate let the waiter
+//    reach the predicate after it was set and pass without ever testing anything. Measured: with a
+//    30 ms sleep the case passed 3/3 against the unfixed code. Once the wait is registered the
+//    outcome is timing-independent, because the waiter captured its expected sequence beforehand.
+//  * It does not join a waiter it failed to wake. On the unfixed path the missed signal is
+//    unrecoverable from inside the test -- a rescue broadcast resolves to the same wrong slot -- so
+//    joining would hang the suite instead of reporting a failure.
+#include "../src/hle/sync_futex.hpp"
+
+#include <pthread.h>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { std::printf("  [FAIL] %s\n", msg); fails++; } \
+                              else std::printf("  [ok]   %s\n", msg); } while (0)
+
+namespace {
+
+constexpr int kWakeBudgetMs = 5000;   // reaching this IS the defect, not a tolerance
+
+pthread_mutex_t g_mutex = PTHREAD_MUTEX_INITIALIZER;
+volatile int g_predicate = 0;
+volatile unsigned long g_waiter_tid = 0;
+volatile int g_woke = 0;
+
+void sleep_ms(int ms) {
+#ifdef _WIN32
+    Sleep((DWORD)ms);
+#else
+    timespec ts{ms / 1000, (long)(ms % 1000) * 1000000L};
+    nanosleep(&ts, nullptr);
+#endif
+}
+
+void* wait_on(void* raw) {
+    auto* cond = (pthread_cond_t*)raw;
+#ifdef _WIN32
+    g_waiter_tid = (unsigned long)GetCurrentThreadId();
+#endif
+    pthread_mutex_lock(&g_mutex);
+    while (!g_predicate) interruptible_cond_wait(cond, &g_mutex);
+    g_woke = 1;
+    pthread_mutex_unlock(&g_mutex);
+    return nullptr;
+}
+
+// Block until the waiter's condition wait is REGISTERED, which is the state the defect needs. Any
+// weaker gate makes this test able to pass without exercising anything.
+bool await_registered_wait() {
+#ifdef _WIN32
+    for (int i = 0; i < 3000; ++i) {
+        GuestWaitSnapshot snapshot{};
+        if (g_waiter_tid &&
+            snapshot_guest_wait((uint64_t)g_waiter_tid, snapshot) &&
+            snapshot.kind == GuestWaitKind::ConditionSequence)
+            return true;
+        sleep_ms(1);
+    }
+    return false;
+#else
+    return true;
+#endif
+}
+
+// Park a thread on `target`, free `earlier` while it sleeps, then signal `target`. The signal must
+// still land on the slot the sleeper is parked on.
+bool signal_survives_slot_reuse(pthread_cond_t* earlier, pthread_cond_t* target,
+                                const char* gate_message) {
+    g_predicate = 0;
+    g_waiter_tid = 0;
+    g_woke = 0;
+
+    pthread_t thread{};
+    if (pthread_create(&thread, nullptr, wait_on, target) != 0) return false;
+    CHECK(await_registered_wait(), gate_message);
+
+    interruptible_cond_forget(earlier);   // frees a slot BEFORE the target's own
+
+    pthread_mutex_lock(&g_mutex);
+    g_predicate = 1;
+    interruptible_cond_signal(target);
+    pthread_mutex_unlock(&g_mutex);
+
+    for (int i = 0; i < kWakeBudgetMs && !g_woke; ++i) sleep_ms(1);
+    if (!g_woke) return false;            // do NOT join: unwakeable on the buggy path
+    pthread_join(thread, nullptr);
+    return true;
+}
+
+}  // namespace
+
+int main() {
+#ifndef _WIN32
+    std::printf("  [skip] the condition-slot table is Windows-only\n");
+    std::printf("== PASS ==\n");
+    return 0;
+#else
+    // `early` claims a slot before `target`, so it sits earlier in the table. Signalling with nobody
+    // waiting is the cheapest way to force the claim and is otherwise a no-op.
+    static pthread_cond_t early = PTHREAD_COND_INITIALIZER;
+    static pthread_cond_t target = PTHREAD_COND_INITIALIZER;
+    interruptible_cond_signal(&early);
+    interruptible_cond_signal(&target);
+    const bool first = signal_survives_slot_reuse(
+        &early, &target, "the waiter's condition wait is registered before the slot is freed");
+    CHECK(first, "a signal still reaches the waiter after an EARLIER slot is freed");
+
+    if (first) {
+        // Same property for a condvar that itself claimed a recycled slot. Only meaningful if the
+        // case above passed -- otherwise a thread is still parked on the wrong slot.
+        static pthread_cond_t filler = PTHREAD_COND_INITIALIZER;
+        static pthread_cond_t second_filler = PTHREAD_COND_INITIALIZER;
+        static pthread_cond_t recycled = PTHREAD_COND_INITIALIZER;
+        interruptible_cond_signal(&filler);
+        interruptible_cond_signal(&second_filler);
+        interruptible_cond_forget(&filler);       // free a slot...
+        interruptible_cond_signal(&recycled);     // ...which `recycled` now claims
+        CHECK(signal_survives_slot_reuse(&second_filler, &recycled,
+                                         "the second waiter's condition wait is registered"),
+              "a condvar holding a recycled slot keeps it when another slot is freed");
+    } else {
+        std::printf("  [skip] recycled-slot case: a thread is stuck on the wrong slot\n");
+    }
+
+    if (fails) {
+        std::printf("== FAIL: %d ==\n", fails);
+        std::fflush(stdout);
+        // A waiter may still be parked on a slot nothing will ever signal, so a normal return would
+        // block in thread teardown. Report first, then leave immediately.
+        std::_Exit(1);
+    }
+    std::printf("== PASS ==\n");
+    return 0;
+#endif
+}


### PR DESCRIPTION
Found with the tooling in #2184. Windows-only; the POSIX branches call `pthread_cond_*` directly and
have no slot table.

## The defect

The Windows condition layer maps each guest `pthread_cond_t*` onto a fixed table of slots, and the
waiter and the signaller resolve their slot **independently**. Slot identity is therefore the whole
contract: if a lookup can ever return a different slot for the same condvar, the signal goes to a
sequence nobody is waiting on and the waiter sleeps forever — no error, no log, nothing to observe
afterwards except a process in which every thread is parked.

`cond_slot_for` searched for an existing owner and claimed a free slot in the **same pass**:

```cpp
for (CondSlot& slot : g_cond_slots) {
    uintptr_t owner = slot.cond.load(acquire);
    if (owner == key || (owner == 0 && slot.cond.compare_exchange_strong(owner, key, acq_rel)))
        return &slot;
}
```

so a free slot encountered **before** this condvar's own slot was taken instead of it. Destroying any
condvar that happens to sit earlier in the table is enough to split a live waiter from its signaller.

## Observed in Blue Prince (#2139)

From a `PROSPER_SYNC_RING` capture — the same guest condvar resolving to two different slots:

```
seq=328135 wait-enter pthread=0x100 object=…ad8 source=0x19c883af910
seq=328805 signal     pthread=0x2   object=…ac8 source=0x19c883af910
```

Thread `0x100` parks on slot `…ad8`. The condvar owning `…ac8` is destroyed, freeing an *earlier*
slot. The primary thread's next lookup for the **same** condvar claims `…ac8` and signals it. `0x100`
never wakes; the primary then waits for `0x100`'s reply and never returns; all 70 guest threads pile
up behind it — one root, no cycle, exactly what the wait-for graph reported.

It needs slot churn plus a destroy in the window between a waiter's lookup and its signaller's, which
is why it only bit deep into a long run and read as timing sensitivity.

## The fix

An existing owner **anywhere** in the table beats any free slot: prove the key absent before claiming
one. Kept lock-free deliberately — exception delivery can suspend a thread at any instruction, so a
mutex here can be held by a thread that is stopped (the same reasoning the wait-slot table above
already records). A concurrent first-use of one condvar can still have two threads claim two slots;
both resolve it identically (lowest index wins) and the loser releases, so they converge.

## Verified on the live title, with a positive control

The same check run on both captures — identical command, identical parsing:

| capture | guest condvars mapped to >1 slot |
| --- | ---: |
| before the fix | **2** |
| after the fix | **0** |

The before-run is the positive control: it shows the check can detect the defect, so the zero is a
pass rather than an unexercised path.

**The failure moves forward.** Blue Prince previously deadlocked with the primary thread parked;
with this fix it gets past that point and the primary thread instead dies on a **null dereference in
guest code**:

```
[app] guest thread ended: kind=2 ACCESS-VIOLATION at addr=0xf
      rip=0x4113d8fbf (eboot+0x13d8fbf)  rbx=0x0 rdi=0x7 rsi=0x40000000 rdx=0x7
```

`mov rax,[rdi+0x8]` with `rdi=0x7` — the fault address `0xf` matches exactly. That is a **separate,
newly reachable defect** (`guest thread ended` appears in **1 of 6** captures — only this one), and it
is not claimed as fixed here. #2139 stays open.

## Test — and why it is shaped the way it is

`test_cond_slot_identity` parks a thread on a condvar, frees a condvar holding an earlier slot, then
signals. Two properties are load-bearing:

- **It gates on `snapshot_guest_wait`, not on a sleep.** The defect only shows if the waiter is
  already *registered* when the signal is sent. Measured: with a 30 ms sleep instead, the case passed
  **3/3 against the unfixed code** — it let the waiter reach the predicate after it was set and never
  tested anything. Once the wait is registered the outcome is timing-independent, because the waiter
  captured its expected sequence beforehand.
- **It does not join a waiter it failed to wake.** On the unfixed path the missed signal is
  unrecoverable from inside the test — a rescue broadcast resolves to the same wrong slot — so
  joining hangs the suite instead of reporting a failure. It reports, then `_Exit(1)`s.

**Red/green measured, not asserted:** unfixed master **3/3 FAIL**, with the fix **5/5 PASS**.

## Verification

```
Windows build-mingw-app   165/169 ctest, cond_slot_identity PASS
```

The 4 failures are pre-existing and unrelated, all present on master: `build_revision_refresh` (file
lock), `pthread_cond_clock` (WinLibs-vs-MSYS2 `EPERM`), and `pthread_names` + `live_target_format`
("Not Run", both **#2142** — the gcc 16.1 `.seh_handlerdata` assembler error, in files this change
does not touch).

Linux is unaffected by construction (`#ifdef _WIN32`); a full Linux run is attached below once it
completes.

## Risk

Medium — it is the resolution step for every guest condition wait, semaphore and event flag on
Windows. Worth a reviewer's attention on two points: the retry loop's termination argument, and
whether the lowest-index-wins tie-break is genuinely symmetric between the two racing claimants.
