### PR TITLE
test(rdna2): give the integer VOPC SDWA arms inputs that can observe the source select

### DIFF
--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5117,8 +5117,83 @@ int main() {
     uint32_t badT11 = 0; for (uint32_t i=0;i<N&&gotT11.size()==N;i++) if (gotT11[i]!=expT11[i]) badT11++;
     CHECK(gotT11.size()==N && badT11==0, "T11: v_cmp_gt_f32_sdwa applies |src0| before comparing");
 
+    // ---- T11b / T11c / T11b2 / T11b3: the 32-bit integer VOPC SDWA source select (#2130) ----
+    // These arms compare an inline `1` against ONE selected sub-dword field of v63. The shared `inX`
+    // they used to run on could not observe that: `inX[i] = (float)i` has a zero low byte in all 128
+    // patterns and a high word that is never 0x0001, and no pattern is the dword 1 — so BYTE_0 != 1,
+    // WORD_1 != 1 and the whole dword != 1 agreed on every single lane, and both arms stayed green
+    // with the source select deleted from the lowering outright.
+    //
+    // `inSdwa` is built from hand-written bit patterns instead, each present for a stated reason: for
+    // every candidate a wrong lowering could pick (the four bytes, the two words, the whole dword)
+    // there are lanes where that candidate's answer differs from the selected field's. Every pattern
+    // is a finite float so the value round-trips the f32 storage buffer unchanged.
+    const uint32_t sdwaPatterns[] = {
+        0x3F800001u,   // BYTE_0 = 01, dword != 1                     -> BYTE_0 vs DWORD
+        0x40000001u,   // same BYTE_0, differs ONLY outside it        -> the hand-built pair, see below
+        0x40000101u,   // BYTE_0 = 01 while WORD_0 = 0x0101           -> BYTE_0 vs WORD_0
+        0x40000102u,   // BYTE_1 = 01 while BYTE_0 = 02               -> BYTE_0 vs BYTE_1
+        0x40010002u,   // BYTE_2 = 01 while BYTE_0 = 02               -> BYTE_0 vs BYTE_2
+        0x01000002u,   // BYTE_3 = 01 while BYTE_0 = 02               -> BYTE_0 vs BYTE_3
+        0x00010002u,   // WORD_1 = 0001, dword != 1                   -> WORD_1 vs DWORD
+        0x00010000u,   // WORD_1 = 0001, differs ONLY outside it      -> the hand-built pair, see below
+        0x0001BEEFu,   // WORD_1 = 0001 while WORD_0 = 0xBEEF         -> WORD_1 vs WORD_0/BYTE_0/BYTE_1
+        0x02010000u,   // BYTE_2 = 01 while WORD_1 = 0x0201           -> WORD_1 vs BYTE_2
+        0x00000001u,   // the whole dword IS 1: the raw answer flips the OTHER way for both arms
+        0x3F800000u,   // 1.0f — no field equals 1 (the only class the old `inX` reached)
+        0x00000201u,   // BYTE_0 = 01, every other candidate != 1
+        0xC0000001u,   // BYTE_0 = 01 with the sign bit set
+        0x3F8000FFu,   // BYTE_0 = 0xFF — the sign-extension counterexample for T11b2
+        0x40000064u,   // BYTE_0 = 100 — T11b2's compare boundary
+    };
+    std::vector<float> inSdwa(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const uint32_t bits = sdwaPatterns[i % std::size(sdwaPatterns)];
+        std::memcpy(&inSdwa[i], &bits, 4);
+    }
+    // A fixture that cannot separate the selected field from the alternatives proves nothing about
+    // the select however green it goes, so establish the separation on the HOST first — and by hand,
+    // not from whatever produced the arms. `sdwa_field` mirrors the RDNA2 source-select encoding
+    // (0..3 = BYTE_0..BYTE_3, 4..5 = WORD_0/WORD_1, 6 = DWORD); it is used only to count how many
+    // lanes each wrong candidate would get wrong, never to compute an expected output.
+    auto sdwa_field = [](uint32_t x, uint32_t sel) -> uint32_t {
+        if (sel <= 3u) return (x >> (8u * sel)) & 0xFFu;
+        if (sel <= 5u) return (x >> (16u * (sel - 4u))) & 0xFFFFu;
+        return x;
+    };
+    auto sdwa_min_separation = [&](uint32_t truth) {
+        uint32_t worst = UINT32_MAX;
+        for (uint32_t alt = 0; alt <= 6u; ++alt) {
+            if (alt == truth) continue;
+            uint32_t differ = 0;
+            for (uint32_t i = 0; i < N; ++i) {
+                const uint32_t x = bits_of(inSdwa[i]);
+                if ((sdwa_field(x, truth) != 1u) != (sdwa_field(x, alt) != 1u)) ++differ;
+            }
+            worst = std::min(worst, differ);
+        }
+        return worst;
+    };
+    const uint32_t sepB = sdwa_min_separation(0), sepC = sdwa_min_separation(5),
+                   sepB3 = sdwa_min_separation(2);
+    printf("  SDWA fixture separation: BYTE_0 >= %u, WORD_1 >= %u, BYTE_2 >= %u lanes"
+           " (the old inX separated 0, 0, 0)\n", sepB, sepC, sepB3);
+    CHECK(sepB > 0, "T11b's inputs separate BYTE_0 from every other source select");
+    CHECK(sepC > 0, "T11c's inputs separate WORD_1 from every other source select");
+    CHECK(sepB3 > 0, "T11b3's inputs separate BYTE_2 from every other source select");
+    // The hand-built instances the separation counts above are checked against: 0x3F800001 and
+    // 0x40000001 differ only OUTSIDE BYTE_0, so the correct lowering answers `false` for both while
+    // any whole-dword lowering answers `true` for both. Same shape for WORD_1 with 0x00010000 /
+    // 0x0001BEEF, which differ only outside the selected high word.
+    CHECK(((0x3F800001u & 0xFFu) == 1u) && ((0x40000001u & 0xFFu) == 1u) &&
+          (0x3F800001u != 1u) && (0x40000001u != 1u) &&
+          (((0x00010000u >> 16) & 0xFFFFu) == 1u) && (((0x0001BEEFu >> 16) & 0xFFFFu) == 1u) &&
+          (0x00010000u != 1u) && (0x0001BEEFu != 1u),
+          "the hand-built SDWA pairs really do put 1 in the selected field and not in the dword");
+
     // Astro Bot's exact visibility-kernel compare: move the input bits to v63, compare integer 1
     // against its zero-extended low byte, then materialize the VCC result as float 0/1.
+    // (llvm-mc gfx1030: `v_cmp_ne_u32_sdwa vcc_lo, 1, v63 src0_sel:DWORD src1_sel:BYTE_0`.)
     const uint32_t codeT11b[] = {
         0x7e7e0300u,               // v_mov_b32 v63, v0
         0x7d8a7ef9u, 0x00860081u,  // v_cmp_ne_u32 vcc, 1, v63 src1_sel:BYTE_0
@@ -5127,15 +5202,20 @@ int main() {
     };
     std::vector<uint32_t> spvT11b = recompile_valu(codeT11b, sizeof(codeT11b)/4, 1, 0);
     CHECK(!spvT11b.empty(), "recompiled T11b (Astro integer VOPC SDWA BYTE_0) -> SPIR-V");
-    std::vector<float> gotT11b = prosper::test::run_compute(spvT11b, inX, N, N);
-    uint32_t badT11b = 0;
-    for (uint32_t i = 0; i < N && gotT11b.size() == N; ++i)
-        if (gotT11b[i] != (((bits_of(inX[i]) & 0xFFu) != 1u) ? 1.0f : 0.0f)) ++badT11b;
+    std::vector<float> gotT11b = prosper::test::run_compute(spvT11b, inSdwa, N, N);
+    uint32_t badT11b = 0, trueT11b = 0;
+    for (uint32_t i = 0; i < N && gotT11b.size() == N; ++i) {
+        const bool ne = (bits_of(inSdwa[i]) & 0xFFu) != 1u;
+        if (ne) ++trueT11b;
+        if (gotT11b[i] != (ne ? 1.0f : 0.0f)) ++badT11b;
+    }
+    CHECK(trueT11b > 0 && trueT11b < N, "T11b exercises both compare results");
     CHECK(gotT11b.size()==N && badT11b==0,
-          "T11b: unsigned SDWA compare zero-extends the selected source byte");
+          "T11b: the unsigned SDWA compare reads the selected source BYTE_0, not the whole dword");
 
     // Its later paired form selects WORD_1 and updates EXEC instead of VCC. Exact live words;
     // compilation proves the CMPX opcode family is normalized before the integer SDWA admission.
+    // Masked lanes never store, so they read back the zero-initialised output slot (as kernel 16).
     const uint32_t codeT11c[] = {
         0x7e7e0300u,               // v_mov_b32 v63, v0
         0x7daa7ef9u, 0x05860081u,  // v_cmpx_ne_u32 1, v63 src1_sel:WORD_1
@@ -5144,14 +5224,68 @@ int main() {
     };
     std::vector<uint32_t> spvT11c = recompile_valu(codeT11c, sizeof(codeT11c)/4, 1, 0);
     CHECK(!spvT11c.empty(), "recompiled T11c (Astro CMPX SDWA WORD_1) -> SPIR-V");
-    std::vector<float> gotT11c = prosper::test::run_compute(spvT11c, inX, N, N);
-    uint32_t badT11c = 0;
+    std::vector<float> gotT11c = prosper::test::run_compute(spvT11c, inSdwa, N, N);
+    uint32_t badT11c = 0, liveT11c = 0;
     for (uint32_t i = 0; i < N && gotT11c.size() == N; ++i) {
-        const bool active = ((bits_of(inX[i]) >> 16) & 0xFFFFu) != 1u;
-        if (gotT11c[i] != (active ? 1.0f : inX[i])) ++badT11c;
+        const bool active = ((bits_of(inSdwa[i]) >> 16) & 0xFFFFu) != 1u;
+        if (active) ++liveT11c;
+        if (gotT11c[i] != (active ? 1.0f : 0.0f)) ++badT11c;
     }
+    CHECK(liveT11c > 0 && liveT11c < N, "T11c exercises both active and EXEC-masked lanes");
     CHECK(gotT11c.size()==N && badT11c==0,
-          "T11c: CMPX compares the zero-extended high word and predicates the following write");
+          "T11c: CMPX compares the selected source WORD_1 and predicates the following write");
+
+    // T11b2 (synthesized, llvm-mc gfx1030 verified — the live Astro pair cannot reach this): the
+    // extension direction. SDWA zero-fills a selected field unless its SEXT bit is set, and the
+    // decoder refuses SEXT for integer VOPC, so the extracted byte must be 0..255 even under a
+    // SIGNED compare. `v_cmp_lt_i32_sdwa vcc_lo, v63, v62 src0_sel:BYTE_0` with v62 = 100 answers
+    // `byte < 100`; a sign-extending extract would call every byte >= 0x80 negative and answer
+    // `true` there instead. The NE-against-1 forms above cannot see this at all — sext(b) == 1 and
+    // zext(b) == 1 hold for exactly the same b — which is why this is a separate kernel.
+    const uint32_t codeT11b2[] = {
+        0x7e7e0300u,               // v_mov_b32 v63, v0
+        0x7e7c02ffu, 0x00000064u,  // v_mov_b32 v62, 100
+        0x7d027cf9u, 0x0600003fu,  // v_cmp_lt_i32_sdwa vcc_lo, v63, v62 src0_sel:BYTE_0
+        0xd5010000u, 0x01a9e480u,  // v_cndmask_b32_e64 v0, 0, 1.0, vcc_lo
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvT11b2 = recompile_valu(codeT11b2, std::size(codeT11b2), 1, 0);
+    CHECK(!spvT11b2.empty(), "recompiled T11b2 (signed integer VOPC SDWA BYTE_0) -> SPIR-V");
+    std::vector<float> gotT11b2 = prosper::test::run_compute(spvT11b2, inSdwa, N, N);
+    uint32_t badT11b2 = 0, ltT11b2 = 0, sextT11b2 = 0;
+    for (uint32_t i = 0; i < N && gotT11b2.size() == N; ++i) {
+        const uint32_t byte0 = bits_of(inSdwa[i]) & 0xFFu;
+        const bool lt = (int32_t)byte0 < 100;
+        if (lt) ++ltT11b2;
+        if (lt != ((int32_t)(int8_t)byte0 < 100)) ++sextT11b2;   // lanes a sign-extending extract breaks
+        if (gotT11b2[i] != (lt ? 1.0f : 0.0f)) ++badT11b2;
+    }
+    CHECK(ltT11b2 > 0 && ltT11b2 < N && sextT11b2 > 0,
+          "T11b2's inputs reach both compare results AND the sign-extension counterexample");
+    CHECK(gotT11b2.size()==N && badT11b2==0,
+          "T11b2: an integer SDWA source select ZERO-extends, so a selected byte is never negative");
+
+    // T11b3 (synthesized, llvm-mc gfx1030 verified): the byte OFFSET. T11b and T11b2 both select
+    // BYTE_0, whose offset is zero, so a lowering that hard-coded offset 0 for every byte select
+    // would satisfy them both. This is T11b's word with src1_sel:BYTE_2 and nothing else changed.
+    const uint32_t codeT11b3[] = {
+        0x7e7e0300u,               // v_mov_b32 v63, v0
+        0x7d8a7ef9u, 0x02860081u,  // v_cmp_ne_u32 vcc, 1, v63 src1_sel:BYTE_2
+        0xd5010000u, 0x01a9e480u,  // v_cndmask_b32_e64 v0, 0, 1.0, vcc
+        0xBF810000u,
+    };
+    std::vector<uint32_t> spvT11b3 = recompile_valu(codeT11b3, std::size(codeT11b3), 1, 0);
+    CHECK(!spvT11b3.empty(), "recompiled T11b3 (integer VOPC SDWA BYTE_2) -> SPIR-V");
+    std::vector<float> gotT11b3 = prosper::test::run_compute(spvT11b3, inSdwa, N, N);
+    uint32_t badT11b3 = 0, trueT11b3 = 0;
+    for (uint32_t i = 0; i < N && gotT11b3.size() == N; ++i) {
+        const bool ne = ((bits_of(inSdwa[i]) >> 16) & 0xFFu) != 1u;
+        if (ne) ++trueT11b3;
+        if (gotT11b3[i] != (ne ? 1.0f : 0.0f)) ++badT11b3;
+    }
+    CHECK(trueT11b3 > 0 && trueT11b3 < N, "T11b3 exercises both compare results");
+    CHECK(gotT11b3.size()==N && badT11b3==0,
+          "T11b3: a BYTE_2 select reads bits [23:16], not the byte at offset 0");
 
     // Exact Astro visibility-kernel word. Both unwritten sources are architectural undefined on
     // hardware but initialize to zero in the test shell, so XNOR(0,0) must produce all one bits.


### PR DESCRIPTION
Fixes #2130

## Failure scenario

`T11b` and `T11c` in `prosper/tests/test_rdna2_to_spirv.cpp` assert that an integer VOPC SDWA compare
reads the **selected sub-dword field** of its source. Their inputs made that unobservable, so both
arms stayed green with the source select deleted from the lowering entirely. They read as coverage of
`sdwa_integer` (`prosper/src/gpu/rdna2_to_spirv.cpp:7705`) and were not.

## Why the old inputs could not discriminate — re-measured on `origin/master`

Both arms ran on the shared `inX`, which is `inX[i] = (float)i` over `N = 128` lanes. Each arm's
predicate is `selected_field != 1`; the whole-dword alternative is `dword != 1`. Over those 128
patterns:

| | value |
| --- | --- |
| distinct low bytes across all 128 inputs | `{0x00}` — the set has exactly one element |
| inputs whose high word is `0x0001` | 0 |
| inputs whose whole dword is `1` | 0 |
| **lanes where BYTE_0-select and the whole dword would DIFFER** | **0** |
| **lanes where WORD_1-select and the whole dword would DIFFER** | **0** |

A small integer-valued float carries its mantissa in the high bits, so `(float)i` has a zero low byte
and a high word of `0x3f80`, `0x4000`, … — never `0x0001` — and is never the dword `1`. Both
predicates were therefore constant-`true` on every lane, and agreed with the whole-dword predicate on
every lane.

`T11c` carried a second dead branch for the same reason: its expectation was `active ? 1.0f : inX[i]`,
and `active` held on all 128 lanes, so the masked-lane arm never ran. It was also wrong —
`run_compute` zero-initialises the output buffer, so an EXEC-masked lane reads back `0.0f`, not the
input (see kernel 16's comment). Nothing caught that, because nothing reached it.

## The new inputs

A dedicated 16-entry `inSdwa` fixture of hand-written bit patterns replaces `inX` for these arms
(`inX` is shared by ~15 other arms and is left untouched). Each pattern is in the file with a stated
reason; 16 divides 128, so every pattern gets 8 lanes. Every pattern is a finite float, so the value
round-trips the `f32` storage buffer unchanged.

Separation against every candidate a wrong lowering could pick — the four bytes, the two words, the
whole dword — measured over the 128 lanes:

| arm | selected field | worst-case separation | vs. the whole dword |
| --- | --- | --- | --- |
| `T11b` | BYTE_0 | 16 lanes | 40 lanes |
| `T11c` | WORD_1 | 16 lanes | 32 lanes |
| `T11b3` | BYTE_2 | 16 lanes | 48 lanes |

The two hand-built instances the issue asks for are in the table and asserted literally:

- `0x3F800001` and `0x40000001` differ **only outside** BYTE_0. Correct: `false` for both.
  Whole-dword: `true` for both.
- `0x00010000` and `0x0001BEEF` differ **only outside** WORD_1. Correct: `false` for both.
  Whole-dword: `true` for both.

## Guards that make the fixture self-detecting

Per the charter rule added in #2153 — a positive control drawn from the same source as the null tests
the discriminator, not the domain — the fixture's discriminating power is established **on the host,
before any GPU result is believed**, and by hand rather than from whatever produced the arms:

- `CHECK(sepB > 0)` / `CHECK(sepC > 0)` / `CHECK(sepB3 > 0)` — the minimum, over all six wrong
  candidates, of the number of lanes that candidate would get wrong. Printed every run:
  `SDWA fixture separation: BYTE_0 >= 16, WORD_1 >= 16, BYTE_2 >= 16 lanes (the old inX separated 0, 0, 0)`.
- A literal assertion that the four hand-built patterns really do put `1` in the selected field and
  not in the dword.
- Per-arm "exercises both compare results" / "both active and EXEC-masked lanes" counts, so a later
  fixture edit that collapses an arm to a single answer fails loudly instead of silently.

## Arms affected, and two new ones

**Two arms were affected** — `T11b` and `T11c`. That is an empirical count, not a reading of the
issue: with `sdwa_integer` reduced to `return raw` on `origin/master`, exactly **one** of the file's
677 assertions failed — `kernel 32r20`, the 16-bit compare form. Every other SDWA arm in the file is
driven by in-shader literals with deliberately distinct bytes/words (`32r2`, `32r3`, `32r4`, `32p`,
`32r20`) or is a DWORD-select/modifier-only form with nothing to select (`kernel 39`, `59`, `60`). No
other test file executes an SDWA source-select arm at all: `test_recompile_coverage.cpp`,
`test_dynfetch_fold.cpp` and `test_rdna2_spirv_struct.cpp` never call `run_compute`, and every SDWA
control word in them is `0x0606…` — both selects DWORD.

Two arms are **added**, both `llvm-mc -mcpu=gfx1030` verified, because the live Astro encodings cannot
observe these properties whatever inputs they are given:

- `T11b2` — the extension direction. `v_cmp_lt_i32_sdwa … src0_sel:BYTE_0` against 100. The old
  messages claimed "zero-extends", but `NE` against inline `1` cannot see it: `sext(b) == 1` and
  `zext(b) == 1` hold for exactly the same `b`. A signed compare against 100 does — a sign-extending
  extract calls every byte `>= 0x80` negative.
- `T11b3` — the byte offset. `T11b` and `T11b2` both select BYTE_0, whose offset is zero, so a
  lowering that hard-coded offset 0 satisfies both. `T11b3` is `T11b`'s word with `src1_sel:BYTE_2`
  and nothing else changed.

## Mutation evidence

`sdwa_integer` was mutated five ways. Each variant was built and the **full** `test_rdna2_to_spirv`
run, twice: against `origin/master`'s test file (`pre`) and against this branch's (`post`).

| mutation | pre — `origin/master` | post — this PR |
| --- | --- | --- |
| **M1** `return raw` — delete the source select (the mutation named in the issue) | `32r20` only — 676 ok, FAIL 1 | `32r20`, **`T11b`**, **`T11c`**, **`T11b2`**, **`T11b3`** — 684 ok, FAIL 5 |
| **M2** always read byte offset 0 | **PASS, 677/677** | **`T11b3`** — 688 ok, FAIL 1 |
| **M3** swap `WORD_0`/`WORD_1` | **PASS, 677/677** | **`T11c`** — 688 ok, FAIL 1 |
| **M4** `bfe_s` instead of `bfe_u` — sign-extend the selected field | **PASS, 677/677** | **`T11b2`** — 688 ok, FAIL 1 |
| **M5** apply the select to `src0` only, drop `src1`'s | **PASS, 677/677** | **`T11b`**, **`T11c`**, **`T11b3`** — 686 ok, FAIL 3 |
| unmutated | PASS, 677/677 | PASS, 689/689 |

**Four of the five mutations passed the entire 677-assertion file before this change. All five fail
now.** The named one, M1, is the headline: `T11b` and `T11c` used to pass it and now fail it.

## Discriminating power, before and after

Nothing is removed. Before, the two arms proved: the two live Astro encodings **recompile**, and the
resulting shader returns `1.0f` on every lane. Both are still asserted. Added on top: which field the
compare reads, in which direction it extends, at which offset, for both operands, with both predicate
results and both EXEC states exercised, plus a host-side guard that the inputs can separate the
candidates at all.

Two message corrections, each narrowing a claim to what the arm can actually fail on:

- `T11b`: "unsigned SDWA compare zero-extends the selected source byte" → "reads the selected source
  BYTE_0, not the whole dword". The zero-extension claim now lives in `T11b2`, which can fail on it.
- `T11c`: "compares the zero-extended high word" → "compares the selected source WORD_1".

## Risk

Test-only. `prosper/src` is untouched — the diff is one file,
`prosper/tests/test_rdna2_to_spirv.cpp`, +144/−10, and every deleted line is one of the two arms'
own bodies.

## Verification

Built and run in the project container on Linux, at this branch's exact head:

```
cmake -S prosper -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6 --target test_rdna2_to_spirv
./build/test_rdna2_to_spirv
```

`== PASS ==`, **689 assertions ok, 0 failed** (`origin/master` baseline: 677 ok, 0 failed). Vulkan was
found at configure time (`Vulkan found (…libvulkan.so) — offscreen graphics harness enabled`), so the
execution arms really ran rather than being skipped. Every mutation row above is a separate full build
and run of the same target.
