### PR TITLE
tools: name the host frames in a guest fault backtrace

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -966,8 +966,9 @@ static bool start_guest(const std::string& app0_root, std::string* err) {
         if (result.kind != 0)
             dump_guest_exception_trace();
         for (uint64_t address : result.backtrace)
-            fprintf(stderr, "[app] guest backtrace: 0x%llx\n",
-                    static_cast<unsigned long long>(address));
+            fprintf(stderr, "[app] guest backtrace: 0x%llx (%s)\n",
+                    static_cast<unsigned long long>(address),
+                    describe_code_address(address).c_str());
     });   // runs the guest frame loop
     fprintf(stderr, "[app] guest booted; presenting its frames.\n");
     return true;

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -74,6 +74,18 @@ struct BootResult {
     uint64_t     rbp = 0, rsp = 0, rax = 0, rdi = 0, rsi = 0, rdx = 0, rbx = 0; // regs at fault
     std::vector<uint64_t> backtrace;   // return addresses (rbp chain) at the fault
 };
+// Describe a code address for a fault report or backtrace.
+//
+// A guest address becomes "<module>+0x<offset>" via boot_program.hpp's fixed map. A HOST address
+// becomes "prosper+0x<rva>" (or "<dll>+0x<rva>"), which is the part that matters: prosper is ASLR'd,
+// so a raw host frame is a different number every run and cannot be symbolised or even compared
+// across runs. With an RVA it can be fed straight to addr2line/nm.
+//
+// #2194 is why this exists: a guest thread faulted, and the frame that told us WHO called it was a
+// bare host address. The report named the guest side precisely and the caller not at all -- which is
+// the half that decides whether a fault is the title's bug or ours.
+std::string describe_code_address(uint64_t address);
+
 // Register the stack a guest thread runs on (main thread + workers we spawn), keyed by
 // its pthread id, so GC/thread code gets accurate bounds without pthread_getattr_np.
 void register_thread_stack(uint64_t tid, void* base, uint64_t size);

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -27,6 +27,7 @@
 #endif
 #include <cstdio>
 #include <cstring>
+#include <dlfcn.h>   // dladdr: name the host object behind a backtrace frame (#2194)
 #include <cstdlib>
 #include <cstdint>
 #include <cerrno>
@@ -3388,6 +3389,32 @@ uint64_t hle_guest_return_address(uint64_t entry_rsp) {
 uint64_t invoke_stub(uint64_t idx) {
     auto fn = (uint64_t(*)())(stub_addr(idx));
     return fn();
+}
+
+std::string describe_code_address(uint64_t address) {
+    char text[160];
+    const char* module = prosper::guest_module_name(address);
+    if (std::strcmp(module, "mapped/host") != 0) {
+        std::snprintf(text, sizeof text, "%s+0x%llx", module,
+                      (unsigned long long)prosper::guest_module_offset(address));
+        return text;
+    }
+    // Host frame. dladdr resolves the containing object and, when the symbol is exported, its name.
+    Dl_info info{};
+    if (dladdr((void*)(uintptr_t)address, &info) && info.dli_fname) {
+        const char* leaf = std::strrchr(info.dli_fname, '/');
+        leaf = leaf ? leaf + 1 : info.dli_fname;
+        const auto base = (uint64_t)(uintptr_t)info.dli_fbase;
+        if (info.dli_sname)
+            std::snprintf(text, sizeof text, "%s!%s+0x%llx", leaf, info.dli_sname,
+                          (unsigned long long)(address - (uint64_t)(uintptr_t)info.dli_saddr));
+        else
+            std::snprintf(text, sizeof text, "%s+0x%llx", leaf,
+                          (unsigned long long)(address - base));
+        return text;
+    }
+    std::snprintf(text, sizeof text, "host:0x%llx", (unsigned long long)address);
+    return text;
 }
 
 void register_thread_stack(uint64_t tid, void* base, uint64_t size) {

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -23,6 +23,7 @@
 #include "x86_read_decode.hpp"
 #include "../hle/nid.hpp"
 #include "../hle/dispatch.hpp"
+#include "boot_program.hpp"   // #1659: shared guest-module labelling (BOOT_* bases)
 
 #include <windows.h>
 #include <bcrypt.h>
@@ -1284,6 +1285,46 @@ uint64_t hle_guest_return_address(uint64_t entry_rsp) {
 uint64_t invoke_stub(uint64_t idx) {
     if (idx >= g_nstubs) return 0;
     return ((HleFn)(uintptr_t)stub_addr(idx))(0, 0, 0, 0, 0, 0);
+}
+
+// MinGW/MSVC both provide the linker-synthesised image base, so this needs no psapi dependency.
+extern "C" IMAGE_DOS_HEADER __ImageBase;
+
+std::string describe_code_address(uint64_t address) {
+    char text[160];
+    const char* module = prosper::guest_module_name(address);
+    if (std::strcmp(module, "mapped/host") != 0) {
+        std::snprintf(text, sizeof text, "%s+0x%llx", module,
+                      (unsigned long long)prosper::guest_module_offset(address));
+        return text;
+    }
+    const auto* dos = &__ImageBase;
+    const auto base = (uint64_t)(uintptr_t)dos;
+    const auto* nt = (const IMAGE_NT_HEADERS*)((const uint8_t*)dos + dos->e_lfanew);
+    if (nt->Signature == IMAGE_NT_SIGNATURE && address >= base &&
+        address < base + nt->OptionalHeader.SizeOfImage) {
+        std::snprintf(text, sizeof text, "prosper+0x%llx", (unsigned long long)(address - base));
+        return text;
+    }
+    // Some other loaded module (a system DLL, a driver shim). Name it rather than printing a bare
+    // pointer -- "which DLL" is usually the whole answer for a frame that is not ours.
+    HMODULE owner = nullptr;
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+                               GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           (LPCWSTR)(uintptr_t)address, &owner) && owner) {
+        wchar_t wide[MAX_PATH]{};
+        if (GetModuleFileNameW(owner, wide, MAX_PATH)) {
+            const wchar_t* leaf = wcsrchr(wide, L'\\');
+            leaf = leaf ? leaf + 1 : wide;
+            char narrow[96]{};
+            WideCharToMultiByte(CP_UTF8, 0, leaf, -1, narrow, sizeof narrow - 1, nullptr, nullptr);
+            std::snprintf(text, sizeof text, "%s+0x%llx", narrow,
+                          (unsigned long long)(address - (uint64_t)(uintptr_t)owner));
+            return text;
+        }
+    }
+    std::snprintf(text, sizeof text, "host:0x%llx", (unsigned long long)address);
+    return text;
 }
 
 void register_thread_stack(uint64_t tid, void* base, uint64_t size) {

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -515,8 +515,9 @@ int main(int argc, char** argv) {
                 static_cast<unsigned long long>(result.rbp),
                 static_cast<unsigned long long>(result.rsp));
         for (uint64_t address : result.backtrace)
-            fprintf(stderr, "[shot] guest backtrace: 0x%llx\n",
-                    static_cast<unsigned long long>(address));
+            fprintf(stderr, "[shot] guest backtrace: 0x%llx (%s)\n",
+                    static_cast<unsigned long long>(address),
+                    describe_code_address(address).c_str());
     });
     guest.detach();
 


### PR DESCRIPTION
tools: name the host frames in a guest fault backtrace

A guest fault report named the guest side precisely and the caller not at all:

  [app] guest thread ended: ... rip=0x4113d8fbf (eboot+0x13d8fbf)
  [app] guest backtrace: 0x4113d8fa0
  [app] guest backtrace: 0x7ff690c3e935

The second frame is a HOST address. prosper is ASLR'd, so it is a different
number every run: it cannot be symbolised, and it cannot even be compared across
two runs of the same failure. That is the half of the report that decides whether
a fault is the title's bug or ours, and it was unreadable.

describe_code_address() classifies an address for reporting:

  guest   -> "<module>+0x<offset>"   via boot_program.hpp's fixed map, so an
             IL2CPP return address is not mislabelled as an eboot RVA (#1659)
  prosper -> "prosper+0x<rva>"       relative to the linker-synthesised image
             base, which feeds straight into addr2line/nm
  other   -> "<dll>+0x<rva>"         a system DLL or driver shim, named rather
             than printed as a bare pointer
  unknown -> "host:0x<address>"      verbatim, never silently dropped

Windows takes the image base from __ImageBase, so this needs no psapi
dependency, and falls back to GetModuleHandleEx for a foreign module. POSIX uses
dladdr, which additionally yields the symbol name when one is exported.

Both frontends that print a fault backtrace now use it -- prosper-app and
screenshot. The raw address is kept alongside the label rather than replaced: the
label is an interpretation, and a reader comparing two runs may want the number.

Measured on the #2194 fault it was written for. Before, the caller frame was
0x7ff690c3e935 and nothing more. After:

  [app] guest backtrace: 0x4113d8fa0 (eboot+0x13d8fa0)
  [app] guest backtrace: 0x7ff7d8541711 (prosper+0x121711)

and 0x121711 resolves, via addr2line against the image base, to an exact inlined
chain in prosper's own AGC code:

  allocate_dw                          hle_agc.cpp:203
  begin_packet                         hle_agc.cpp:391
  agc_cb_set_sh_register_range_direct  hle_agc.cpp:1539

which is what put #2194's investigation in the right subsystem.

A caution recorded because it applies to every reader of this output: the
backtrace is an rbp-chain walk, so a frame may be a stale link rather than a real
caller. Naming the frame makes it legible; it does not make it load-bearing. In
the case above the named function is an HLE the guest CALLS, not one that calls
guest code, so it is context rather than a caller.

Verification
------------
  Windows build-mingw-app  165/169 ctest
      the 4 failures are pre-existing and unrelated, all present on master:
      build_revision_refresh (file lock), pthread_cond_clock (WinLibs-vs-MSYS2
      EPERM), and pthread_names + live_target_format (Not Run) -- both #2142,
      the gcc 16.1 SEH assembler error, in files this change does not touch.
  Linux   build-linux      208/208 ctest --no-tests=error, 0 failures.

Diagnostic-only: no guest-visible behaviour changes on any path.

Refs #2194.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

