### PR TITLE
fix(win): the AGC buffer-full callback is a HOST->GUEST call and needs the trampoline

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1108,6 +1108,10 @@ if(TARGET prosper_core)
 
   # End-to-end AGC submit plus fixed args 7-9 in ReleaseMem/WaitRegMem. This is cross-platform so
   # Windows validates the real fence builders behind the generated import-ABI conformance test.
+  add_executable(test_agc_dcb_callback_abi tests/test_agc_dcb_callback_abi.cpp)
+  target_link_libraries(test_agc_dcb_callback_abi PRIVATE prosper_core)
+  add_test(NAME agc_dcb_callback_abi COMMAND test_agc_dcb_callback_abi)
+
   add_executable(test_agc_submit tests/test_agc_submit.cpp)
   target_link_libraries(test_agc_submit PRIVATE prosper_core)
   add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -48,6 +48,13 @@ extern "C" void prosper_label_hist_wait_built(uint64_t addr, uint64_t cb);
 
 namespace prosper {
 
+#ifdef _WIN32
+// Host -> guest call trampoline (MS-x64 -> SysV). Declared exactly as hle_service.cpp does for the
+// AvPlayer guest callbacks; see AgcDcb::invoke_full_callback for why the AGC one needs it (#2194).
+extern "C" uint64_t prosper_call_guest_sysv4(uint64_t fn, uint64_t a0, uint64_t a1,
+                                             uint64_t a2, uint64_t a3);
+#endif
+
 #define HLE(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
                                        uint64_t a3, uint64_t a4, uint64_t a5)
 #define HLE9(name) static PROSPER_SYSV_ABI uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, \
@@ -188,7 +195,7 @@ struct AgcDcb {
     uint32_t* top;          // +0x08 buffer end
     uint32_t* cursor_up;    // +0x10 current write ptr
     uint32_t* cursor_down;  // +0x18 reserve limit
-    bool (*callback)(AgcDcb*, uint32_t, void*);  // +0x20 buffer-full callback (guest fn)
+    bool (PROSPER_SYSV_ABI *callback)(AgcDcb*, uint32_t, void*);  // +0x20 buffer-full callback (guest fn)
     void*     user_data;    // +0x28
     uint32_t  reserved_dw;  // +0x30
 
@@ -196,11 +203,39 @@ struct AgcDcb {
         auto avail = (uint32_t)(cursor_down - cursor_up);
         return avail > reserved_dw ? avail - reserved_dw : 0;
     }
+    // Invoke the guest's buffer-full callback. This is a HOST -> GUEST call, and the two directions
+    // are not symmetric: guest -> host conversion happens in the emitted import stub, but nothing
+    // converts a call the other way. PROSPER_SYSV_ABI is empty on every platform today (see
+    // dispatch.hpp), so on Windows a direct call through this pointer uses MS-x64 registers
+    // (rcx/rdx/r8) while the guest reads SysV (rdi/rsi/rdx) -- the arguments arrive shifted by one
+    // position and the guest dereferences a count as a pointer.
+    //
+    // #2194: measured in Blue Prince. prosper read a perfectly valid user_data
+    // (`[dcbfull] need=7 cb=0x4113d8f80 user=0x20108ddf50`) and the guest callback received
+    // `rdi=0x7 rsi=0x40000000 rdx=0x7` -- its third SysV argument picking up our second MS-x64 one,
+    // `n + reserved_dw`. It faults on `[rdi+8]` and takes the title's primary thread down with it.
+    // Linux is unaffected because SysV is native there, which is why this only ever bit on Windows.
+    //
+    // Same treatment the AvPlayer guest callbacks already get (`avp_fire`, hle_service.cpp).
+    bool invoke_full_callback(uint32_t need) {
+#ifdef _WIN32
+        // bool is returned in AL with the upper bits of RAX unspecified -- the guest's own epilogue
+        // is `setbe al`, which leaves them as whatever was there. Read one byte, not eight.
+        const uint64_t r = prosper_call_guest_sysv4((uint64_t)(uintptr_t)callback,
+                                                    (uint64_t)(uintptr_t)this,
+                                                    (uint64_t)need,
+                                                    (uint64_t)(uintptr_t)user_data, 0);
+        return (uint8_t)r != 0;
+#else
+        return callback(this, need, user_data);
+#endif
+    }
+
     uint32_t* allocate_dw(uint32_t n) {
         if (n == 0) return nullptr;
         if (n > available_dw()) {
             dcb_report_full(this, n);          // #1756 probe; no-op unless PROSPER_DCBFULL
-            if (!callback || !callback(this, n + reserved_dw, user_data)) return nullptr;
+            if (!callback || !invoke_full_callback(n + reserved_dw)) return nullptr;
             if (available_dw() < n) return nullptr;
         }
         uint32_t* r = cursor_up;
@@ -352,10 +387,10 @@ void dcb_report_full(const AgcDcb* dcb, uint32_t need) {
     static std::atomic<uint32_t> n{0};
     const uint32_t i = n.fetch_add(1, std::memory_order_relaxed);
     if (i >= 512 && (i & 8191u) != 0) return;
-    fprintf(stderr, "[dcbfull] #%u %s op=0x%x need=%u avail=%u reserved=%u window=%u dw at +%u cb=%p\n",
+    fprintf(stderr, "[dcbfull] #%u %s op=0x%x need=%u avail=%u reserved=%u window=%u dw at +%u cb=%p user=%p dcb=%p\n",
             i, dcb_subop_name(g_dcb_diag_r), g_dcb_diag_op, need, dcb->available_dw(), dcb->reserved_dw, window,
             dcb->bottom && dcb->cursor_up ? (unsigned)(dcb->cursor_up - dcb->bottom) : 0,
-            (void*)(uintptr_t)dcb->callback);
+            (void*)(uintptr_t)dcb->callback, (void*)(uintptr_t)dcb->user_data, (const void*)dcb);
 }
 void dcb_report_window(const AgcDcb* dcb, uint32_t n, uint32_t op, uint32_t r) {
     // begin_packet is the hottest path in the HLE (millions of packets per minute), so do nothing at

--- a/prosper/tests/test_agc_dcb_callback_abi.cpp
+++ b/prosper/tests/test_agc_dcb_callback_abi.cpp
@@ -1,0 +1,113 @@
+// test_agc_dcb_callback_abi — the AGC "command buffer full" callback is a HOST -> GUEST call, and
+// its arguments must arrive in the guest's registers, not the host's (#2194).
+//
+// The guest registers this callback in its DCB and prosper invokes it from allocate_dw when a packet
+// does not fit. guest -> host conversion happens in the emitted import stub; nothing converts a call
+// going the OTHER way, so on Windows a direct call through the pointer passes arguments in MS-x64
+// registers (rcx/rdx/r8) into guest code that reads SysV (rdi/rsi/rdx). They arrive shifted by one
+// position, and the guest dereferences a dword count as a pointer.
+//
+// The callback below is declared __attribute__((sysv_abi)) precisely so it reads its arguments the
+// way real guest code does. A plain host callback would be given the host convention on both sides
+// and would pass whether or not the trampoline is used -- i.e. it could not fail, which is the trap
+// this test exists to avoid.
+#include "../src/hle/dispatch.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else std::printf("  [ok]   %s\n", m); } while (0)
+
+#ifdef _WIN32
+
+// The DCB layout prosper models (hle_agc.cpp AgcDcb). Built as raw storage rather than reusing the
+// struct, so the test also pins the OFFSETS the guest writes to -- if a field moves, this fails.
+struct alignas(16) TestDcb {
+    uint32_t* bottom;       // +0x00
+    uint32_t* top;          // +0x08
+    uint32_t* cursor_up;    // +0x10
+    uint32_t* cursor_down;  // +0x18
+    void*     callback;     // +0x20
+    void*     user_data;    // +0x28
+    uint32_t  reserved_dw;  // +0x30
+    uint32_t  pad;
+};
+static_assert(offsetof(TestDcb, callback) == 0x20, "callback must sit at +0x20");
+static_assert(offsetof(TestDcb, user_data) == 0x28, "user_data must sit at +0x28");
+static_assert(offsetof(TestDcb, reserved_dw) == 0x30, "reserved_dw must sit at +0x30");
+
+static volatile uint64_t g_seen_dcb;
+static volatile uint64_t g_seen_need;
+static volatile uint64_t g_seen_user;
+static volatile int      g_calls;
+
+// A stand-in for the guest's buffer-full handler, reading its arguments as guest code does.
+// Returns false: "I could not grow the buffer", which makes allocate_dw give up rather than retry.
+extern "C" __attribute__((sysv_abi)) bool test_dcb_full(void* dcb, uint32_t need, void* user) {
+    g_seen_dcb = (uint64_t)(uintptr_t)dcb;
+    g_seen_need = need;
+    g_seen_user = (uint64_t)(uintptr_t)user;
+    ++g_calls;
+    return false;
+}
+
+#endif  // _WIN32
+
+int main() {
+#ifndef _WIN32
+    std::printf("  [skip] host->guest ABI conversion is a Windows-only concern\n");
+    std::printf("== PASS ==\n");
+    return 0;
+#else
+    register_builtin_hle();   // populates the NID table, as every other AGC test does
+    HleFn set_sh_range = Hle::lookup("n2fD4A+pb+g");   // sceAgcCbSetShRegisterRangeDirect
+    CHECK(set_sh_range != nullptr, "sceAgcCbSetShRegisterRangeDirect is registered");
+    if (!set_sh_range) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+
+    static uint32_t ring[64];
+    TestDcb dcb{};
+    dcb.bottom = ring;
+    dcb.top = ring + 64;
+    dcb.cursor_up = ring;
+    // Deliberately tiny window: 2 dwords available, so the very first packet overflows and the
+    // buffer-full callback is the path under test rather than an incidental one.
+    dcb.cursor_down = ring + 2;
+    dcb.callback = (void*)&test_dcb_full;
+    dcb.user_data = (void*)(uintptr_t)0xD00DFEEDCAFEB00Dull;   // must arrive intact, not truncated
+    dcb.reserved_dw = 0;
+
+    g_seen_dcb = g_seen_need = g_seen_user = 0;
+    g_calls = 0;
+
+    static const uint32_t values[4] = {1, 2, 3, 4};
+    // num=4 -> the packet needs 4+2 dwords against a 2-dword window, so allocate_dw must consult the
+    // callback. It answers false, so the HLE returns 0 -- the point is the arguments, not the result.
+    set_sh_range((uint64_t)(uintptr_t)&dcb, 0x100, (uint64_t)(uintptr_t)values, 4, 0, 0);
+
+    CHECK(g_calls == 1, "the buffer-full callback was invoked exactly once");
+    CHECK(g_seen_dcb == (uint64_t)(uintptr_t)&dcb,
+          "argument 1 is the DCB, in the guest's first register");
+    CHECK(g_seen_need == 6,
+          "argument 2 is the dword count needed (4 values + 2 header), not something else");
+    // The one that actually failed in #2194: the guest received `need` here instead of user_data,
+    // dereferenced it, and took the title's primary thread down.
+    CHECK(g_seen_user == 0xD00DFEEDCAFEB00Dull,
+          "argument 3 is user_data, delivered whole and in the guest's THIRD register");
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+#endif
+}


### PR DESCRIPTION
fix(win): the AGC buffer-full callback is a HOST->GUEST call and needs the trampoline

Blue Prince's primary guest thread died on a null dereference (#2194), taking the
65 threads waiting on it with it, so the title presented as a total deadlock.

The guest registers a "command buffer full" callback in its AGC DCB, and
prosper's own allocate_dw invokes it when a packet does not fit:

    bool (*callback)(AgcDcb*, uint32_t, void*);       // +0x20
    ...
    if (!callback || !callback(this, n + reserved_dw, user_data)) return nullptr;

That is a HOST -> GUEST call, and the two directions are NOT symmetric.
guest -> host conversion happens in the emitted import-stub trampoline;
nothing converts a call going the other way. PROSPER_SYSV_ABI is empty on every
platform today (dispatch.hpp explains why: the attribute conflicts with MinGW's
SEH unwinding), so on Windows this compiled as a plain MS-x64 call -- arguments
in rcx/rdx/r8 -- into guest code that reads SysV -- rdi/rsi/rdx.

The arguments arrive shifted by one position. The guest's third SysV argument
picks up our second MS-x64 one, so it dereferences a dword count as a pointer.

Measured, both sides of the same call
-------------------------------------
PROSPER_DCBFULL=1 prints what prosper passed; the fault report prints what the
guest received:

  [dcbfull] #0 DrawIndex op=0x10 need=7 avail=2 reserved=0
                cb=0x4113d8f80 user=0x20108ddf50
  [app] guest thread ended: ACCESS-VIOLATION at addr=0xf rip=eboot+0x13d8fbf
                rdi=0x7 rsi=0x40000000 rdx=0x7

user_data was a perfectly valid guest pointer. The guest got rdx = 7 = need --
our second argument in its third register -- and faulted on [rdi+8] with rdi=7.
Every observed value fits that shift, across three captures with different
counts (7, 0x1a, 0x20).

Linux is unaffected because SysV is native there, which is why this only ever
bit on Windows and why the title reaches gameplay on the AMD lane.

The fix routes it through prosper_call_guest_sysv4 on Windows, exactly as the
AvPlayer guest callbacks already are (avp_fire, hle_service.cpp). The bool
return is read as ONE BYTE: SysV returns bool in AL with the upper bits of RAX
unspecified, and this guest's epilogue is `setbe al`, which leaves them dirty.

A sweep of the HLE for the same shape found no other instance -- every other
guest function pointer is either already routed through the trampoline or is a
host callback. hle_agc.cpp:203 was the only direct host->guest call left.

Result
------
Blue Prince reaches GAMEPLAY on native Windows (rung 3). 56 buffer-full
callbacks now complete in a run where the first one used to be fatal; 0 guest
thread deaths. Frames advance through the intro cinematic into the Day One
manor. Frame rate is poor and lighting flickers -- both tracked separately and
neither is this defect.

Also extends the existing PROSPER_DCBFULL probe with user_data and the DCB
address. It printed the callback pointer but not the argument that was wrong,
which is what made this take a second run to see.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
