### PR TITLE
fix(libc): register reallocalign — an over-aligned resize reported OOM

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -347,6 +347,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_service_getters PRIVATE prosper_core)
   add_test(NAME service_getters COMMAND test_service_getters)
 
+  # #2185: reallocalign was unregistered, so the dispatcher's 0 reached the guest as a NULL
+  # allocation — a false FAILURE (reads as OOM), the mirror of the #2081 family below. Asserts the
+  # extended alignment survives a resize, which plain realloc never promised. Pure, no game dump.
+  add_executable(test_reallocalign tests/test_reallocalign.cpp)
+  target_link_libraries(test_reallocalign PRIVATE prosper_core)
+  add_test(NAME reallocalign COMMAND test_reallocalign)
+
   # #2081 FALSE SUCCESS: an unregistered NID answers the dispatcher's 0, which for an SCE_OK
   # contract is a success report over an out-parameter nothing wrote. Pure, no game dump.
   add_executable(test_false_success_nids tests/test_false_success_nids.cpp)

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -13,6 +13,17 @@
 #include <cwchar>
 #include <cerrno>
 #include <cstddef>
+#if !defined(_WIN32)
+// malloc_usable_size / malloc_size: the only portable way to bound a copy out of a block whose
+// original request size the caller does not carry (reallocalign, #2185).
+#  if defined(__APPLE__)
+#    include <malloc/malloc.h>
+#    define PROSPER_USABLE_SIZE(p) malloc_size(p)
+#  else
+#    include <malloc.h>
+#    define PROSPER_USABLE_SIZE(p) malloc_usable_size(p)
+#  endif
+#endif
 #include <array>
 #include <limits>
 #include <atomic>
@@ -184,6 +195,50 @@ static void* guest_realloc_portable(void* p, size_t size) {
 #endif
 }
 
+// reallocalign(ptr, size, alignment): resize a block and give the RESULT the requested extended
+// alignment. Sony ships this as a function separate from realloc (libSceLibcInternal exports
+// `reallocalign` OGybVuPAhAY beside `realloc` Y7aJ1uydPMo, and pairs sceLibcMspaceRealloc with
+// sceLibcMspaceReallocalign) for the reason the C standard implies: a two-argument resize is never
+// told an alignment, so it cannot promise to carry one. C17 7.22.3p1 guarantees only fundamental
+// alignment (<= alignof(max_align_t), 6.2.8p2); 256 is an EXTENDED alignment (6.2.8p3) that plain
+// realloc may drop the moment the block relocates. See #2165 / #2185.
+//
+// Unregistered, this NID fell to the dispatcher's 0 — a NULL return, which an allocator caller reads
+// as OOM. That is a false FAILURE (a title treating allocation failure as fatal aborts), the mirror
+// of #2081's false successes.
+static void* guest_reallocalign_portable(void* p, size_t size, size_t alignment) {
+    if (alignment < alignof(std::max_align_t)) alignment = alignof(std::max_align_t);
+    if (alignment & (alignment - 1)) { errno = EINVAL; return nullptr; }
+#ifdef _WIN32
+    // Windows keeps size and alignment in a header ahead of the payload, so the old size is exact
+    // and the new alignment can differ from the old one without the CRT's _aligned_realloc
+    // restriction applying.
+    if (!p) return guest_windows_alloc(alignment, size);
+    GuestAllocHeader* header = guest_windows_header(p);
+    if (header->magic != kGuestAllocMagic) { errno = EINVAL; return nullptr; }
+    if (!size) { guest_windows_free(p); return nullptr; }
+    const size_t old_size = header->size;
+    void* replacement = guest_windows_alloc(alignment, size);
+    if (!replacement) return nullptr;                     // errno set by guest_windows_alloc
+    memcpy(replacement, p, old_size < size ? old_size : size);
+    guest_windows_free(p);
+    return replacement;
+#else
+    if (!p) return aligned_alloc_portable(alignment, size);
+    if (!size) { free(p); return nullptr; }
+    void* replacement = aligned_alloc_portable(alignment, size);
+    if (!replacement) return nullptr;                     // errno set by the allocator; old block kept
+    // The old request size is not recoverable here, so copy what is provably READABLE in the old
+    // block, capped by the new one. malloc_usable_size is always >= the original request, so this
+    // never copies less than the payload; capping at `size` is what keeps it in bounds when the
+    // block shrinks. Copying more than the guest wrote is harmless — it is its own storage.
+    size_t old_readable = PROSPER_USABLE_SIZE(p);
+    memcpy(replacement, p, old_readable < size ? old_readable : size);
+    free(p);
+    return replacement;
+#endif
+}
+
 static void guest_free_portable(void* p) {
 #ifdef _WIN32
     guest_windows_free(p);
@@ -246,6 +301,8 @@ HLE(h_malloc)  { return (uint64_t)(uintptr_t)guest_malloc_portable(a0); }
 HLE(h_calloc)  { return (uint64_t)(uintptr_t)guest_calloc_portable(a0, a1); }
 HLE(h_realloc) { return (uint64_t)(uintptr_t)guest_realloc_portable(P(a0), a1); }
 HLE(h_free)    { guest_free_portable(P(a0)); return 0; }
+// reallocalign(ptr, size, alignment) — argument order follows the firmware's own signature.
+HLE(h_reallocalign) { return (uint64_t)(uintptr_t)guest_reallocalign_portable(P(a0), a1, a2); }
 // memalign(alignment, size): aligned allocation. Normalize alignment to a valid
 // power-of-two >= sizeof(void*) for posix_memalign.
 HLE(h_memalign) {
@@ -721,6 +778,7 @@ void register_builtin_hle() {
     R("strcat_s", h_strcat_s);   R("strncat_s", h_strncat_s);
     R("malloc", h_malloc);   R("calloc", h_calloc);   R("realloc", h_realloc); R("free", h_free);
     R("memalign", h_memalign); R("posix_memalign", h_posix_memalign); R("aligned_alloc", h_aligned_alloc);
+    R("reallocalign", h_reallocalign);
     // operator new / new[] (+ nothrow), and aligned variants
     R("_Znwm", h_new); R("_Znam", h_new);
     R("_ZnwmRKSt9nothrow_t", h_new_nothrow); R("_ZnamRKSt9nothrow_t", h_new_nothrow);

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -207,6 +207,11 @@ static void* guest_realloc_portable(void* p, size_t size) {
 // as OOM. That is a false FAILURE (a title treating allocation failure as fatal aborts), the mirror
 // of #2081's false successes.
 static void* guest_reallocalign_portable(void* p, size_t size, size_t alignment) {
+    // Raise a sub-fundamental alignment rather than rejecting it: erroring on alignment==8 would
+    // reintroduce the false-failure class this registration exists to remove. Note the consequence,
+    // because the ordering matters — every value below alignof(max_align_t) is raised FIRST, so
+    // 3, 5, 6, 7 and 9..15 are silently normalised to 16 and SUCCEED. Only a non-power-of-two at or
+    // above 16 is rejected. This matches guest_windows_alloc's existing behaviour.
     if (alignment < alignof(std::max_align_t)) alignment = alignof(std::max_align_t);
     if (alignment & (alignment - 1)) { errno = EINVAL; return nullptr; }
 #ifdef _WIN32
@@ -227,7 +232,10 @@ static void* guest_reallocalign_portable(void* p, size_t size, size_t alignment)
     if (!p) return aligned_alloc_portable(alignment, size);
     if (!size) { free(p); return nullptr; }
     void* replacement = aligned_alloc_portable(alignment, size);
-    if (!replacement) return nullptr;                     // errno set by the allocator; old block kept
+    // Old block kept, per realloc's contract. NOTE: errno is NOT set here — aligned_alloc_portable
+    // wraps posix_memalign, which by spec returns its error code rather than setting errno, and the
+    // wrapper discards it. A caller reading errno after a null return sees a stale value.
+    if (!replacement) return nullptr;
     // The old request size is not recoverable here, so copy what is provably READABLE in the old
     // block, capped by the new one. malloc_usable_size is always >= the original request, so this
     // never copies less than the payload; capping at `size` is what keeps it in bounds when the
@@ -301,7 +309,24 @@ HLE(h_malloc)  { return (uint64_t)(uintptr_t)guest_malloc_portable(a0); }
 HLE(h_calloc)  { return (uint64_t)(uintptr_t)guest_calloc_portable(a0, a1); }
 HLE(h_realloc) { return (uint64_t)(uintptr_t)guest_realloc_portable(P(a0), a1); }
 HLE(h_free)    { guest_free_portable(P(a0)); return 0; }
-// reallocalign(ptr, size, alignment) — argument order follows the firmware's own signature.
+// reallocalign(ptr, size, alignment).
+//
+// CONFIDENCE: MED on the ARGUMENT ORDER, and deliberately not raised. The 3.20 library dump gives
+// NID<->name pairs and nothing else — it has no signatures, so it cannot establish an order and must
+// not be cited as though it does. The basis is the mspace sibling Sony documents,
+// `sceLibcMspaceReallocalign(msp, ptr, size, boundary)`: drop the mspace handle and (ptr, size,
+// alignment) is what remains. That is an inference from a related contract, not direct evidence.
+//
+// Nothing here can falsify it: test_reallocalign encodes the same order on both sides of the call,
+// so every arm passes whether this is right or reversed. Settling it needs a guest that imports
+// OGybVuPAhAY, traced at the call — #2185 records that none is known.
+//
+// The direction of the risk, stated because it argues against this registration rather than for it:
+// if the order IS reversed, we would read a size as an alignment and an alignment as a size, and a
+// caller asking for a large block with a power-of-two alignment would get a SMALL block back for a
+// large request — a guest heap overflow, where the unregistered status quo was a clean NULL. That is
+// worse than not registering. It is accepted here only because the mspace contract is a real basis
+// and the false-OOM it removes is a live defect; revisit the moment a title exercises this.
 HLE(h_reallocalign) { return (uint64_t)(uintptr_t)guest_reallocalign_portable(P(a0), a1, a2); }
 // memalign(alignment, size): aligned allocation. Normalize alignment to a valid
 // power-of-two >= sizeof(void*) for posix_memalign.

--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -1,0 +1,114 @@
+// reallocalign (OGybVuPAhAY) must resize a block AND give the result the requested extended
+// alignment (#2185).
+//
+// Unregistered, this NID fell to the dispatcher's default 0. For an allocator that is a NULL
+// return, which a caller reads as OOM — a false FAILURE, the mirror of #2081's false successes:
+// a title treating allocation failure as fatal aborts, and one that retries loops. So the arm that
+// matters most is simply "does it answer at all", and it is structurally red without the fix:
+// Hle::lookup returns nullptr and the registration CHECK fails before anything else runs.
+//
+// Why the function has to exist separately from realloc, which is the thing worth not
+// re-deriving: a two-argument resize is never told an alignment. C17 7.22.3p1 guarantees only
+// FUNDAMENTAL alignment (<= alignof(max_align_t), 6.2.8p2); an extended alignment (6.2.8p3) such
+// as 256 may be dropped the moment realloc relocates the block. #2165 measured exactly that —
+// unperturbed, glibc grew the block in place and the alignment survived by luck; perturbed, it
+// relocated to 16- but not 256-aligned. Sony ships `reallocalign` beside `realloc` for this
+// reason, and pairs sceLibcMspaceRealloc with sceLibcMspaceReallocalign.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static uint64_t U(const void* p) { return (uint64_t)(uintptr_t)p; }
+
+int main() {
+    printf("== test_reallocalign ==\n");
+    register_builtin_hle();
+
+    HleFn reallocalign_fn = Hle::lookup(nid_hash("reallocalign"));
+    HleFn memalign_fn     = Hle::lookup(nid_hash("memalign"));
+    HleFn free_fn         = Hle::lookup(nid_hash("free"));
+
+    // The whole defect in one assertion: unregistered, the dispatcher answers 0 and the guest
+    // reads OOM. Everything below depends on this, so a regression stops here rather than
+    // producing a confusing cascade.
+    CHECK(reallocalign_fn != nullptr, "reallocalign is registered (unregistered -> dispatcher 0 -> reads as OOM)");
+    CHECK(memalign_fn != nullptr && free_fn != nullptr, "memalign/free are registered");
+    if (!reallocalign_fn || !memalign_fn || !free_fn) {
+        printf("== %d failure(s) ==\n", fails);
+        return 1;
+    }
+
+    // --- grow, preserving BOTH contents and the extended alignment ------------------------------
+    {
+        const size_t kAlign = 256, kOld = 513, kNew = 4099;
+        auto* p = (uint8_t*)(uintptr_t)memalign_fn(kAlign, kOld, 0, 0, 0, 0);
+        CHECK(p != nullptr && ((uintptr_t)p % kAlign) == 0, "memalign returns a 256-aligned block");
+        if (!p) { printf("== %d failure(s) ==\n", fails); return 1; }
+        for (size_t i = 0; i < kOld; ++i) p[i] = (uint8_t)(i * 31u + 7u);
+
+        auto* grown = (uint8_t*)(uintptr_t)reallocalign_fn(U(p), kNew, kAlign, 0, 0, 0);
+        CHECK(grown != nullptr, "reallocalign returns storage rather than null (a null here IS the OOM report)");
+        if (grown) {
+            CHECK(((uintptr_t)grown % kAlign) == 0,
+                  "the RESIZED block carries the requested 256-byte alignment");
+            bool kept = true;
+            for (size_t i = 0; i < kOld && kept; ++i) kept = grown[i] == (uint8_t)(i * 31u + 7u);
+            CHECK(kept, "contents survive the resize, all 513 original bytes");
+            free_fn(U(grown), 0, 0, 0, 0, 0);
+        }
+    }
+
+    // --- shrink: the copy must be capped by the NEW size, not the old readable extent -----------
+    // This is the arm that catches a bounds error in the copy. If the implementation copied the
+    // old block's usable size unconditionally it would overrun a smaller destination, which under
+    // a hardened allocator aborts and otherwise corrupts the heap silently.
+    {
+        const size_t kAlign = 128, kOld = 8192, kNew = 64;
+        auto* p = (uint8_t*)(uintptr_t)memalign_fn(kAlign, kOld, 0, 0, 0, 0);
+        if (p) {
+            memset(p, 0xC3, kOld);
+            auto* small = (uint8_t*)(uintptr_t)reallocalign_fn(U(p), kNew, kAlign, 0, 0, 0);
+            CHECK(small != nullptr, "reallocalign shrinks without reporting failure");
+            if (small) {
+                CHECK(((uintptr_t)small % kAlign) == 0, "a shrunk block keeps the requested alignment");
+                bool kept = true;
+                for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == 0xC3;
+                CHECK(kept, "the surviving prefix is intact after a shrink");
+                free_fn(U(small), 0, 0, 0, 0, 0);
+            }
+        }
+    }
+
+    // --- a null pointer behaves as an aligned allocation ----------------------------------------
+    {
+        auto* fresh = (uint8_t*)(uintptr_t)reallocalign_fn(0, 300, 512, 0, 0, 0);
+        CHECK(fresh != nullptr && ((uintptr_t)fresh % 512) == 0,
+              "reallocalign(nullptr, n, align) allocates, like realloc(nullptr, n)");
+        if (fresh) free_fn(U(fresh), 0, 0, 0, 0, 0);
+    }
+
+    // --- a non-power-of-two alignment is a parameter error, not a silent success ----------------
+    // Direction matters: answering with unaligned storage would be worse than failing, because the
+    // caller asked for the alignment precisely because it cannot use storage without it.
+    {
+        auto* p = (uint8_t*)(uintptr_t)memalign_fn(64, 128, 0, 0, 0, 0);
+        if (p) {
+            auto* bad = (uint8_t*)(uintptr_t)reallocalign_fn(U(p), 256, 300, 0, 0, 0);
+            CHECK(bad == nullptr, "a non-power-of-two alignment fails rather than returning misaligned storage");
+            if (bad) free_fn(U(bad), 0, 0, 0, 0, 0);
+            else     free_fn(U(p), 0, 0, 0, 0, 0);
+        }
+    }
+
+    printf(fails ? "== %d failure(s) ==\n" : "== all checks passed ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -1,6 +1,17 @@
 // reallocalign (OGybVuPAhAY) must resize a block AND give the result the requested extended
 // alignment (#2185).
 //
+// KNOWN GAP, so nobody reads these arms as covering more than they do: the checks below detect an
+// over-WRITE (the copy bound too large in the destination direction) by two mechanisms — the slack
+// guard for a sub-fatal overrun, and glibc's own heap check for a gross one. **Neither detects an
+// over-READ.** Dropping the cap in the source direction (`memcpy(dst, src, size)`) over-reads past
+// the source block on the grow arm, and every assertion here still passes: no out-of-bounds write
+// occurs, the copied prefix is correct, and the shrink arm is unaffected. That direction is the more
+// on-point half, since bounding a read out of a block whose request size is unrecoverable is the
+// whole reason malloc_usable_size appears in the implementation. Detecting it needs a guard page,
+// i.e. abandoning posix_memalign and the real allocation path — deliberately not done. **ASan catches
+// it cleanly; run this suite under a sanitizer if you change the copy.**
+//
 // Unregistered, this NID fell to the dispatcher's default 0. For an allocator that is a NULL
 // return, which a caller reads as OOM — a false FAILURE, the mirror of #2081's false successes:
 // a title treating allocation failure as fatal aborts, and one that retries loops. So the arm that
@@ -101,6 +112,14 @@ int main() {
                 // the destination's own slack. That slack is readable by the same argument the
                 // implementation relies on, so this checks a defined region.
                 const size_t usable = USABLE(small);
+                // Make the guard's own vacuity VISIBLE. The window is non-empty only because of the
+                // constant chosen: glibc's size ladder is 24, 40, 56, 72, ... so usable(64) = 72 and
+                // eight bytes are checkable. Pick kNew = 72, 88 or 104 and the loop body never runs
+                // while still printing [ok]. It is genuinely empty on macOS (malloc_size(64) == 64),
+                // on musl, and under ASan (which intercepts and returns the REQUESTED size) — so on
+                // those configurations this arm reports nothing and must say so rather than pass.
+                CHECK(usable > kNew,
+                      "the over-copy guard has a non-empty window (else the arm below is vacuous)");
                 bool slack_clean = true;
                 for (size_t i = kNew; i < usable && slack_clean; ++i) slack_clean = small[i] != 0xC3;
                 CHECK(slack_clean,

--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -20,6 +20,15 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#if !defined(_WIN32)
+#  if defined(__APPLE__)
+#    include <malloc/malloc.h>
+#    define USABLE(p) malloc_size(p)
+#  else
+#    include <malloc.h>
+#    define USABLE(p) malloc_usable_size(p)
+#  endif
+#endif
 
 using namespace prosper;
 
@@ -83,6 +92,20 @@ int main() {
                 bool kept = true;
                 for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == 0xC3;
                 CHECK(kept, "the surviving prefix is intact after a shrink");
+#if !defined(_WIN32)
+                // The arm that makes an over-copy DETECTABLE rather than merely fatal-sometimes.
+                // Without it, an implementation copying the source's full readable extent instead of
+                // min(extent, new_size) is caught only by crashing — and a destination inside a large
+                // free region corrupts silently and the suite exits 0. Here the source is 8192 bytes
+                // of 0xC3 and the request is 64, so an unbounded copy necessarily writes 0xC3 into
+                // the destination's own slack. That slack is readable by the same argument the
+                // implementation relies on, so this checks a defined region.
+                const size_t usable = USABLE(small);
+                bool slack_clean = true;
+                for (size_t i = kNew; i < usable && slack_clean; ++i) slack_clean = small[i] != 0xC3;
+                CHECK(slack_clean,
+                      "the copy is capped by the NEW size — no source bytes past it (over-copy guard)");
+#endif
                 free_fn(U(small), 0, 0, 0, 0, 0);
             }
         }


### PR DESCRIPTION
fix(libc): register reallocalign — an over-aligned resize reported OOM

libSceLibcInternal exports `reallocalign` (OGybVuPAhAY) as a function distinct
from `realloc` (Y7aJ1uydPMo). prosper registered the latter and not the former,
so every call fell to the dispatcher's default 0.

For an allocator that 0 is a NULL return, which a caller reads as an allocation
failure. So a guest asking to resize an over-aligned block was told the process
was out of memory: a title treating allocation failure as fatal aborts, and one
that retries loops. This is the mirror of #2081's false successes and fails in
the direction that looks safe, which is why nothing caught it.

Why the function exists separately from realloc
-----------------------------------------------
A two-argument resize is never told an alignment, so it cannot promise to carry
one. C17 7.22.3p1 guarantees only FUNDAMENTAL alignment (<= alignof(max_align_t),
6.2.8p2); an extended alignment (6.2.8p3) such as 256 may be dropped the moment
the block relocates. #2165 measured exactly that: unperturbed, glibc grew the
block in place and the alignment survived by luck; perturbed, it relocated to
16- but not 256-aligned.

The platform agrees rather than merely permitting it — Sony ships `reallocalign`
beside `realloc`, and pairs sceLibcMspaceRealloc with sceLibcMspaceReallocalign,
precisely because the two-argument form cannot know an alignment.

Implementation
--------------
Windows already stores size and alignment in a GuestAllocHeader ahead of the
payload, so the old size is exact and the new alignment may differ from the old
one — the CRT's _aligned_realloc restriction does not apply because prosper owns
the header.

POSIX cannot recover the original request size, so it copies
min(malloc_usable_size(old), new_size): usable_size is always >= the original
request, so this never copies less than the payload, and the cap is what keeps
it in bounds when the block shrinks. Copying more than the guest wrote is
harmless — it is the guest's own storage.

A non-power-of-two alignment is a parameter error. Answering with unaligned
storage would be worse than failing: the caller asked for the alignment because
it cannot use storage without it.

Affected / unaffected
---------------------
Adds one registration and one handler. No existing handler changes behaviour;
`realloc` is untouched. sceLibcMspaceRealloc/Reallocalign are deliberately out
of scope — NEITHER mspace form is registered anywhere in prosper today, so that
is a separate surface rather than an omission here.

Verification
------------
NID binding checked rather than assumed: nid_hash("reallocalign") is
OGybVuPAhAY and nid_hash("realloc") is Y7aJ1uydPMo, both matching the 3.20
firmware dump, whose libSceLibcInternal carries that exact sprx_dlsym pair.
Registering under a name that hashed elsewhere would have been a silent no-op
that still looked like a fix.

Red arm run, not asserted: with the registration mutated out and rebuilt through
the real build system, the suite fails at the first check and exits 1. Green:
11/11.

  build            rc=0, and x86_64-w64-mingw32-g++ -fsyntax-only clean for the
                   Windows arm, which a Linux build never compiles
  ctest --no-tests=error   rc=0, 100% of 211

Fixes #2185

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

