### PR TITLE
tools(nid_census): say that an absence here is static, not runtime

### DIFF
--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -172,6 +172,15 @@ void print_scope(const char* prefix, size_t total, size_t modules_read, size_t m
         printf("%sWARNING: %zu module(s) did not parse — their imports are ABSENT from this "
                "census, so a NID missing below may be unmeasured rather than unimported\n",
                prefix, modules_failed);
+    // The distinction an absence in this report is most likely to be misread as. Recorded because it
+    // already produced a wrong lead: ArcRunner statically imports all three sceAgc*GetSize gaps from
+    // #1756 plus sceKernelWaitCommandBufferCompletion — a ready-made explanation for its fault — and
+    // calls NONE of them. The runtime unimplemented-call census over a full faulting run was 12 NIDs,
+    // none in libSceAgc/libSceAgcDriver/libkernel (#1226).
+    printf("%sNOTE: this is a STATIC import census — what a title MAY call, not what it did. A NID "
+           "listed here may never execute, and a fault is not explained by its presence. For what a "
+           "run actually called, use prosper_on_unimpl's first-seen census from a live boot, or "
+           "hle_calls (#1980), and bound it to the window the behaviour occurs in.\n", prefix);
     printf("%sNOTE: module set is a tree scan, not the loader's link set (boot_program.cpp): "
            "only Media/Plugins is auto-discovered, .sprx is never auto-linked, and sce_module "
            "contributes exactly two. Cross-module exclusions are computed over THIS set.\n",


### PR DESCRIPTION
tools(nid_census): say that an absence here is static, not runtime

Every line this tool prints is an assertion about what a title MAY call. Nothing
in the output said so, and the gap is not hypothetical — it produced a wrong lead
within hours of the tool landing.

ArcRunner (#1226) statically imports all three sceAgc*GetSize gaps left open by
#1756, plus sceKernelWaitCommandBufferCompletion. That is a ready-made
explanation for a fault at the first GPU submit, and it is wrong: the runtime
unimplemented-call census over a full faulting run is 12 NIDs, none of them in
libSceAgc, libSceAgcDriver or libkernel. The title calls none of the four.

An import census and a call census answer different questions, and the failure
is asymmetric: a NID PRESENT here invites an explanation it cannot support, while
a NID ABSENT from a runtime census is real evidence about that run. Reading the
first as the second is how a lane spends an afternoon on a candidate that never
executes.

The scope block now names the distinction in both modes and points at what does
answer the runtime question: prosper_on_unimpl's first-seen census from a live
boot, or hle_calls (#1980) — bounded to the window the behaviour occurs in,
since an unbounded run's census includes everything the title ever touched.

Sits with the two scope facts already there (unreadable modules, and the module
set being a tree scan rather than the loader's link set), all three being ways
this report can be read as more complete or more conclusive than it is.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

