### PR TITLE
tools: name the prosper frames on a guest thread's stack too

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -16,6 +16,7 @@
 #include "nid.hpp"
 #include "sce_errno.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
+#include "../host/exec_image.hpp"      // describe_code_address (host frame naming)
 #include "sync_futex.hpp"
 #include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "../gpu/mb3_freelist.hpp"
@@ -3519,6 +3520,29 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
             guest_returns_used += (size_t)appended;
             ++guest_return_count;
         }
+        // Host-side companion to the guest scan above: name the PROSPER frames on the same stack.
+        // A sampled rip inside a system DLL (getenv, memcpy, a wait) says WHAT the thread is doing
+        // and nothing about WHY; the prosper frame below it is the answer, and without this the
+        // reader is left inferring it from the guest frame, which is often several calls away.
+        char host_returns[288] = "-";
+        size_t host_returns_used = 0;
+        unsigned host_return_count = 0;
+        for (size_t i = 0; i < stack_bytes / sizeof(uint64_t) && host_return_count < 6; ++i) {
+            const uint64_t candidate = stack_words[i];
+            if (candidate < 0x10000) continue;
+            if (!guest_trace_page_executable((uintptr_t)candidate)) continue;
+            const std::string described = describe_code_address(candidate);
+            if (described.rfind("prosper+", 0) != 0) continue;   // ours only; DLLs are noise here
+            bool duplicate = false;
+            for (size_t j = 0; j < i; ++j) duplicate |= stack_words[j] == candidate;
+            if (duplicate) continue;
+            const int appended = std::snprintf(
+                host_returns + host_returns_used, sizeof(host_returns) - host_returns_used,
+                host_return_count ? ",%s" : "%s", described.c_str());
+            if (appended <= 0 || (size_t)appended >= sizeof(host_returns) - host_returns_used) break;
+            host_returns_used += (size_t)appended;
+            ++host_return_count;
+        }
         char wait_description[256] = "-";
         if (captured_wait_count) {
             wait_description[0] = 0;
@@ -3547,12 +3571,12 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
                 std::snprintf(wait_description + used, sizeof(wait_description) - used,
                               ";+%zu-more", captured_wait_count - captured_waits.size());
         }
-        trace("[thread-trace] tid=%lu pthread=0x%llx rip=%s+0x%llx "
-              "raw=0x%llx rsp=0x%llx suspend=%lu waits=%s guest-stack=%s\n",
-              (unsigned long)native_id, (unsigned long long)pthread_id, module_name,
-              (unsigned long long)offset, (unsigned long long)rip,
+        trace("[thread-trace] tid=%lu pthread=0x%llx rip=%s "
+              "raw=0x%llx rsp=0x%llx suspend=%lu waits=%s guest-stack=%s host-stack=%s\n",
+              (unsigned long)native_id, (unsigned long long)pthread_id,
+              describe_code_address(rip).c_str(), (unsigned long long)rip,
               (unsigned long long)context.Rsp, (unsigned long)prior_suspend,
-              wait_description, guest_returns);
+              wait_description, guest_returns, host_returns);
     }
     if (close_output) CloseHandle(output);
 #else


### PR DESCRIPTION
tools: name the prosper frames on a guest thread's stack too

Companion to describe_code_address in the same PR, and the change that made
#2215's frame-rate profile readable.

PROSPER_APP_GUEST_DUMP_* is usable as a sampling profiler: it captures each guest
thread's rip, wait object and guest stack. But a sampled rip inside a system DLL
says WHAT the thread is doing and nothing about WHY -- "47% of samples in
ucrtbase" is not actionable, and the guest frame is often several calls away from
the host code that actually made the call.

The trace now prints, alongside guest-stack, the PROSPER frames found on the same
stack:

  rip=ucrtbase.dll+0x315d7 ... guest-stack=0x4103b0f2c,...
    host-stack=prosper+0x4706ef,prosper+0x3fe00,prosper+0x46a644,...

which addr2line resolves against the image base to exact lines --
live_renderer.cpp:4484, gpu_executor.cpp:4269. That is what identified a getenv
being evaluated per resource per draw (#2214). Before it, five files were cached
on the strength of static reading, each measured no improvement, because the hot
caller was in none of them.

Scoped to prosper's own frames: system DLLs are noise for this question, and a
candidate must sit on a committed executable page, reusing the same
guest_trace_page_executable filter the guest scan already applies.

The rip itself is now described the same way, so a host rip reads as
"ucrtbase.dll+0x315d7" rather than "host+0x7ffe397a15d7" -- an ASLR-relative
number that cannot be compared between two runs of the same failure.

Same standing caveat as the fault backtrace: this is a stack SCAN, not an unwind,
so a frame may be a stale link rather than a real caller. It makes the stack
legible; it does not make any single frame load-bearing.

  Windows build-mingw-app  170/174 ctest
      the 4 failures are pre-existing and unrelated, all present on master:
      build_revision_refresh (file lock), pthread_cond_clock (WinLibs-vs-MSYS2
      EPERM), and pthread_names + live_target_format (Not Run) -- both #2142.
  Linux   build-linux      reported below.

Diagnostic-only; no guest-visible behaviour changes.
