### PR TITLE
diag(compute): a declined image binding reports the SHADER's declared type, not only the guest resource

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4494,19 +4494,47 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (bits & (1u << i)) return i;
             return UINT32_MAX;
         };
+        // The SHADER-declared side of every image decision below, reported alongside the guest
+        // resource whenever a binding declines. Without it a decline prints only the resource --
+        // and most accept conditions here are a conjunction of the two, so the message names one
+        // half of a disagreement and hides the other. "layered image deferred to #657" is the
+        // worst case: it reports the guest's dim=5 while `dim_2d_array` additionally requires the
+        // reflected OpTypeImage to be 2D AND arrayed, so the printed line is identical whether the
+        // shader declared a plain 2D view, a cube, or a multisampled image. Set once per binding
+        // so all decline sites inherit it rather than each having to pass it.
+        const SpirvDescriptorBinding* skip_decl = nullptr;
         auto skip_image = [&](const prosper::gpu::ShaderResource* r, const char* why) {
             static std::vector<uint64_t> warned;
             const uint64_t key = r ? r->gpu_addr : 0;
             if (std::find(warned.begin(), warned.end(), key) == warned.end()) {
                 warned.push_back(key);
+                // image_dim defaults to UINT32_MAX for "no OpTypeImage reflected", which is a
+                // materially different state from any real Dim and must not print as 4294967295.
+                char decl[160];
+                if (!skip_decl) {
+                    std::snprintf(decl, sizeof decl, "shader{unreflected}");
+                } else {
+                    char dim[12];
+                    if (skip_decl->image_dim == UINT32_MAX)
+                        std::snprintf(dim, sizeof dim, "?");
+                    else
+                        std::snprintf(dim, sizeof dim, "%u", skip_decl->image_dim);
+                    std::snprintf(decl, sizeof decl,
+                                  "shader{dim=%s arrayed=%u ms=%u depth=%u storage=%u atomic=%u}",
+                                  dim, skip_decl->image_arrayed ? 1u : 0u,
+                                  skip_decl->image_multisampled ? 1u : 0u,
+                                  skip_decl->image_depth ? 1u : 0u,
+                                  skip_decl->kind == SpirvDescriptorKind::StorageImage ? 1u : 0u,
+                                  skip_decl->atomic_access ? 1u : 0u);
+                }
                 std::fprintf(stderr, "[compute] program 0x%llx image 0x%llx %ux%ux%u dim=%u "
-                                     "class=%u fmt=%u comps=%u tile=%u size=%u: %s -> "
+                                     "class=%u fmt=%u comps=%u tile=%u size=%u %s: %s -> "
                                      "dispatch skipped (#590)\n",
                              (unsigned long long)item.code_addr, (unsigned long long)key,
                              r ? r->width : 0, r ? r->height : 0, r ? r->depth : 0,
                              r ? r->img_dim : 0u, r ? static_cast<unsigned>(r->cls) : 0u,
                              r ? (unsigned)r->format : 0u, r ? r->num_components : 0u,
-                             r ? r->tile_mode : 0u, r ? r->size : 0u, why);
+                             r ? r->tile_mode : 0u, r ? r->size : 0u, decl, why);
             }
             images_ready = false;
         };
@@ -4514,6 +4542,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             image_timing_requested && timing_item_selected &&
             (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
+            // Every skip_image call below is inside this loop, so the cursor is always the binding
+            // being decided.
+            skip_decl = &image_descriptors[i];
             const auto image_start = ComputeClock::now();
             double import_ms = 0.0;
             double query_ms = 0.0;


### PR DESCRIPTION
## What was wrong

Every image accept condition in `live_compute.cpp`'s binding loop is a **conjunction of two things** — what the guest T# says the resource is (`r->img_dim`, extent, tiling) and what the shader's reflected `OpTypeImage` says it wants (`image_dim`, `image_arrayed`, …). `skip_image` printed only the first.

So a decline named one half of a disagreement and hid the other, and because `skip_image` is shared, **all 37 decline sites had the defect**.

`layered image deferred to #657` shows the cost. It prints the guest's `dim=5` and stops — which is byte-identical whether the shader declared a plain 2D view, a real 2D array, a cube, or a multisampled image. Those are four different situations requiring four different fixes, and the log could not tell them apart. Answering "which one is it?" previously meant attaching a debugger to a live title.

## What it prints now

```
[compute] program 0x2940000000 image 0x401c7f0000 3840x2160x2 dim=5 class=2 fmt=2 comps=1
  tile=27 size=66355200 shader{dim=1 arrayed=0 ms=0 depth=0 storage=0 atomic=0}:
  layered image deferred to #657 -> dispatch skipped (#590)
```

`image_dim` defaults to `UINT32_MAX` for "no `OpTypeImage` reflected" — a materially different state from any real `Dim`, so it prints as `?` rather than `4294967295`.

## It localised a live blocker on its first run

*Sonic Racing: CrossWorlds* (`PPSA08804`, rung 1, composite goes uniform — #2013). The declined dispatch **samples** a target that is black in all 1,325 passes touching it (`storage=0` below — it is an input, not an output), which is what made it worth chasing. It does not author that surface; see the correction on #2013. The new line says why it declines:

- guest resource — `dim=5`, `3840x2160x2`: a **two-layer 2D array**
- shader — `dim=1 arrayed=0 storage=0`: a **plain, non-arrayed, sampled 2D image**

That is the base-slice fallback `shader_resources.hpp`'s `image_dim` comment already describes ("a DIM=5 packet may deliberately compile either as the historical base-slice 2D fallback or as a real 2D-array image"). It is declined only because `dim_2d_single` additionally requires `depth == 1`.

So this is **not** arrayed-image work. It is a single-layer fallback that does not extend to a multi-layer resource — a much smaller gap than "layered images are unsupported", with an established precedent a few lines away in `cube_face_as_2d`, which binds face zero of a cube as a shader-declared 2D image. None of that was visible before this change. Details on #657 and #2013; **this PR does not attempt that fix.**

## Approach

`skip_image` is a `[&]` lambda declared before the loop, so the loop variable is not in scope and it cannot read `image_descriptors[i]` directly. Rather than change the signature and touch 37 call sites, a `const SpirvDescriptorBinding*` cursor is set once per iteration and read by the lambda.

I verified mechanically that **all 37 `skip_image` calls are inside that loop** (body spans one `for`), so the cursor is never stale — if any had been outside, it would have mislabelled a decline with the previous binding's type, which is worse than printing nothing.

## Affected / unaffected

- **Affected:** the text of `[compute] … dispatch skipped (#590)` lines.
- **Unaffected:** every binding decision. No accept condition, format choice, or view type is touched — the cursor is written and read, never branched on. Behaviour is identical with diagnostics off, and the line remains rate-limited to one per image address.

## Risk

Low. Diagnostic-only, one new stack buffer written with `snprintf` and a bounded size. The one judgement call is the `UINT32_MAX` sentinel, handled explicitly.

## Verification

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0    # configure rc=0
cmake --build build -j6                                            # rc=0, no warnings
ctest --no-tests=error -j4                                         # 217/217 passed, exit 0
```

Live check that the new field is correct rather than merely present: booted `PPSA08804` under `boot_trace` with `PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct` and read the emitted lines (quoted above). Two distinct declines fired, each reporting a shader type consistent with its stated reason — the 3D one reports `storage=1`, the layered one `storage=0`, matching their respective code paths.

No snapshots run: the diff cannot change a rendered frame.

