### PR TITLE
fix(test): reallocalign's over-copy guard skips an empty window instead of failing on it

### DIFF
--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -118,12 +118,22 @@ int main() {
                 // while still printing [ok]. It is genuinely empty on macOS (malloc_size(64) == 64),
                 // on musl, and under ASan (which intercepts and returns the REQUESTED size) — so on
                 // those configurations this arm reports nothing and must say so rather than pass.
-                CHECK(usable > kNew,
-                      "the over-copy guard has a non-empty window (else the arm below is vacuous)");
-                bool slack_clean = true;
-                for (size_t i = kNew; i < usable && slack_clean; ++i) slack_clean = small[i] != 0xC3;
-                CHECK(slack_clean,
-                      "the copy is capped by the NEW size — no source bytes past it (over-copy guard)");
+                // An empty window is a property of the host allocator, NOT a defect in
+                // reallocalign, so it is reported and skipped rather than failed — macOS, musl and
+                // ASan are all legitimate configurations where no slack is inspectable, and failing
+                // there makes the suite red on a correct implementation. It must still be LOUD:
+                // running the loop anyway would print [ok] for an arm whose body never executed,
+                // which is precisely the vacuous pass this guard exists to prevent.
+                if (usable > kNew) {
+                    bool slack_clean = true;
+                    for (size_t i = kNew; i < usable && slack_clean; ++i) slack_clean = small[i] != 0xC3;
+                    CHECK(slack_clean,
+                          "the copy is capped by the NEW size — no source bytes past it (over-copy guard)");
+                } else {
+                    printf("  [skip] over-copy guard did NOT run: this allocator reports usable=%zu "
+                           "for a %zu-byte request, so there is no readable slack to inspect\n",
+                           usable, kNew);
+                }
 #endif
                 free_fn(U(small), 0, 0, 0, 0, 0);
             }


### PR DESCRIPTION
Fixes #2226. **`master` is currently red on macOS**, and this is the cause.

## Failure

```
39/175 Test #39: reallocalign ...***Failed
  [FAIL] the over-copy guard has a non-empty window (else the arm below is vacuous)
  [ok]   the copy is capped by the NEW size — no source bytes past it (over-copy guard)
```

`test_reallocalign.cpp:121` asserts `usable > kNew`. On macOS `malloc_size(64) == 64`, so the window is empty and the assertion fails **on a correct implementation**.

## Why the original construct was wrong, not the intent

The guard exists so a vacuous arm cannot pass silently — that is worth keeping, and the test already documented this exact case at `:118`:

> *"It is genuinely empty on macOS (`malloc_size(64) == 64`), on musl, and under ASan (which intercepts and returns the REQUESTED size) — so on those configurations this arm reports nothing and must say so rather than pass."*

The author anticipated it precisely and then implemented "must say so" as a `CHECK`, which is a **failure**. An empty window is a property of the host allocator, not a defect in `reallocalign`, so the correct report is a skip.

## The second half, which is the part worth reviewing

When the window was empty the slack loop **still ran**:

```c
for (size_t i = kNew; i < usable && slack_clean; ++i) slack_clean = small[i] != 0xC3;
CHECK(slack_clean, "the copy is capped by the NEW size — …");
```

With `usable == kNew` the body never executes, `slack_clean` stays `true`, and it prints `[ok]` for an arm that inspected nothing. That is visible in the CI log above as the `[ok]` directly after the `[FAIL]` — the exact vacuous pass this guard was written to prevent, sitting one line below the guard.

Moving the check inside the non-empty branch means it can no longer report on a window it did not read. Had only the `CHECK` been relaxed to a skip, macOS would have gone green while still printing a meaningless `[ok]`.

## Verification — both branches, since Linux alone exercises one

glibc's size ladder is 24, 40, 56, 72, … so on Linux `usable(64) = 72` and the window is always non-empty. I mutated the constant to reach the other branch:

| `kNew` | `usable` | window | result |
| --- | --- | --- | --- |
| 64 (committed) | 72 | 8 bytes | guard **runs** → `[ok]`, exit 0 |
| 72 (temporary) | 72 | none | `[skip] over-copy guard did NOT run: this allocator reports usable=72 for a 72-byte request` — exit 0 |

The second reproduces macOS's allocator behaviour on Linux, so the skip path is executed and observed rather than assumed. **Mutation reverted** — the committed constant is 64, which keeps the arm live on glibc.

```
cmake --build build -j6                  # rc=0
ctest --no-tests=error -j4               # 217/217 passed, exit 0
```

## Affected / unaffected

- **Affected:** the shrink arm's over-copy guard on allocators where usable == requested (macOS, musl, ASan) — previously a failure, now a reported skip.
- **Unaffected:** glibc, where the window is non-empty and the guard runs exactly as before. No change to `reallocalign` itself; this is a test-only diff.

Windows is untouched — the whole block is already inside `#if !defined(_WIN32)`.

## Not fixed here

`master` is also red on **Windows MinGW** (`check_build_revision`, three arms, timestamp comparison). That is a separate defect with a separate cause and is filed as #2225. This PR does not address it, so CI here will still show MinGW red — that failure is pre-existing on master and is not introduced by this change.
