### PR TITLE
tools: add getenv_probe — count getenv() calls in a live run

### DIFF
--- a/prosper/tools/getenv_probe/README.md
+++ b/prosper/tools/getenv_probe/README.md
@@ -1,0 +1,55 @@
+# getenv_probe — count `getenv()` calls in a live prosper run
+
+An `LD_PRELOAD` shim that intercepts `getenv()`, counts every call, and reports the running total
+and rate every 10 seconds. Roughly 40 lines; no build-system integration, because it must be loaded
+into the process rather than linked into it.
+
+## Why this exists
+
+prosper gates diagnostics on environment variables, and several of those guards sit on per-draw and
+per-resource paths. That is invisible in an ordinary profile on Linux — glibc's `getenv()` is a
+lock-free scan of `environ`, so a high call rate costs some CPU and blocks nothing.
+
+On Windows it is not invisible. The UCRT's `getenv()` takes `__acrt_environment_lock` on **every
+call**, so the same code serialises every thread that touches the environment. A call rate that is
+merely wasteful on one platform is a global lock bottleneck on the other, and the two look nothing
+alike in a profile.
+
+The rate itself is platform-independent, which is the point of this tool: **measure the call count on
+Linux, reason about its cost on Windows.** First use (2026-08-07, #2215) measured **24.3 million
+calls in 90 seconds — a sustained ~295,000/s** on *Blue Prince* `PPSA25009`, which is the load that
+had to be explained before any Windows fix could be justified.
+
+## Build and use
+
+```bash
+gcc -shared -fPIC -O2 -o probe.so getenv_probe.c -ldl -lpthread
+
+LD_PRELOAD=$PWD/probe.so PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+    ./boot_trace <DUMP_ROOT>/<TITLE_ID>-app0 2> run.log
+
+grep getenv-probe run.log
+```
+
+```
+[getenv-probe] t=10s total=2002712  delta=2002712 rate=200271/s
+[getenv-probe] t=90s total=24324828 delta=2935805 rate=293580/s
+```
+
+## Reading the output
+
+- **Reports every 10 s from a background thread, not at exit.** A run ended by `timeout` dies on
+  SIGTERM and never runs a destructor, so an exit-time report yields nothing — the first revision of
+  this tool produced exactly that, an empty log after a 90-second run.
+- **`delta`/`rate` matter more than `total`.** The interesting question is usually whether the rate
+  *changes* — at a scene transition, when a movie starts, when a new thread appears. A steady rate
+  and a rate that doubles at an FMV are different findings.
+- **Expect one report stream per process.** `boot_trace` and the app may run helpers that inherit the
+  preload; a stream that stays at `total=0` is a process that makes no `getenv` calls, not an error.
+
+## What it does not tell you
+
+The **cost** of those calls, which is the platform-specific half. This counts; it does not time. It
+also cannot see calls made before the constructor runs, or calls inside statically-linked copies of
+libc. And it is Linux/macOS only — `LD_PRELOAD` has no Windows equivalent, which is precisely why
+the measurement is taken here and applied there.

--- a/prosper/tools/getenv_probe/getenv_probe.c
+++ b/prosper/tools/getenv_probe/getenv_probe.c
@@ -1,0 +1,41 @@
+// Counts getenv() calls in the host process and reports every 10 s, so a SIGTERM-terminated run
+// still yields data and the rate can be seen to EVOLVE (the #2215 collapse is a transition, not a
+// steady state). The call rate is platform-independent, so a Linux run substantiates or kills the
+// per-frame call-count arithmetic behind the Windows hypothesis.
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+#include <time.h>
+#include <pthread.h>
+#include <stdatomic.h>
+
+static atomic_ullong g_calls = 0;
+static char *(*real_getenv)(const char *) = NULL;
+
+char *getenv(const char *name) {
+    if (!real_getenv) real_getenv = (char *(*)(const char *))dlsym(RTLD_NEXT, "getenv");
+    atomic_fetch_add_explicit(&g_calls, 1, memory_order_relaxed);
+    return real_getenv(name);
+}
+
+static void *reporter(void *unused) {
+    (void)unused;
+    unsigned long long prev = 0;
+    for (int t = 10;; t += 10) {
+        struct timespec ts = {10, 0};
+        nanosleep(&ts, NULL);
+        unsigned long long n = atomic_load(&g_calls);
+        fprintf(stderr, "[getenv-probe] t=%ds total=%llu delta=%llu rate=%.0f/s\n",
+                t, n, n - prev, (double)(n - prev) / 10.0);
+        fflush(stderr);
+        prev = n;
+    }
+    return NULL;
+}
+
+__attribute__((constructor)) static void probe_init(void) {
+    pthread_t th;
+    pthread_create(&th, NULL, reporter, NULL);
+    pthread_detach(th);
+}


### PR DESCRIPTION
Adds `tools/getenv_probe`, the instrument that produced the load measurement on #2215.

## Why

prosper gates diagnostics on environment variables, and several of those guards sit on per-draw and per-resource paths. **On Linux that is invisible in a profile** — glibc's `getenv()` is a lock-free scan of `environ`, so a high call rate burns some CPU and blocks nothing. **On Windows it is not** — the UCRT takes `__acrt_environment_lock` on *every* call, so identical prosper code serialises every thread that touches the environment.

The consequence is a class of defect that cannot be found on the platform where it is cheap to investigate, and cannot be *quantified* on the platform where it hurts: a Windows profile shows time in `ucrtbase` and `ntdll` and tells you nothing about how many calls produced it.

The call **rate** is platform-independent. So: measure it on Linux, reason about its cost on Windows.

## First use

*Blue Prince* `PPSA25009`, `boot_trace`, default route, 90 s:

```
[getenv-probe] t=10s total=2002712  delta=2002712 rate=200271/s
[getenv-probe] t=50s total=12545217 delta=2926517 rate=292652/s
[getenv-probe] t=90s total=24324828 delta=2935805 rate=293580/s
```

**24.3 million calls in 90 seconds, steady at ~295 k/s.** That figure is what turned #2215 from "some `getenv` time in a profile" into a quantified load that can be compared against the UCRT lock's throughput ceiling — and it is not derivable from the Windows profile, which shows the symptom rather than the cause.

## Design notes worth the review

- **Reports every 10 s from a background thread, not at exit.** A run ended by `timeout` dies on SIGTERM and never runs a destructor. The first revision reported at exit and produced a completely empty log after a full 90-second run — the failure was silent, which is the worst property an instrument can have.
- **`delta`/`rate` are the useful columns**, not `total`. The interesting question is usually whether the rate *changes* — at a scene transition, when a movie starts, when a thread appears.
- **Multiple report streams are expected**, one per process inheriting the preload. A stream stuck at `total=0` is a process that makes no `getenv` calls, not a malfunction. Documented so it is not read as a bug.

## Scope

- **Not wired into CMake.** An `LD_PRELOAD` shim is loaded into a process, not linked into one; the build line is one `gcc` command in the README.
- **Counts, does not time.** The per-call *cost* is the platform-specific half and this tool deliberately does not estimate it.
- **Linux/macOS only** — `LD_PRELOAD` has no Windows equivalent, which is the whole reason the measurement is taken here and applied there.

## Verification

Compiled with the exact command documented in the README (`compile-rc=0`), and run end to end to produce the output quoted above. No prosper source is touched, nothing is added to the build, and no test behaviour changes — the diff is one new `.c` and one new `README.md` under `tools/`.
