### PR TITLE
fix(gpu): implement SW_4KB_S3 volume addressing so a 4 KiB-tiled 3D image stops skipping its dispatch

### DIFF
--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -465,6 +465,16 @@ that leaves the caller's output buffer untouched, so the guest reads whatever wa
 
 One line per falsified hypothesis, with the evidence that killed it.
 
+- **THE UNIFORM COMPOSITE IS NOT THE UNAUTHORED 16³ GRADING LUT.** The title binds a 16x16x16 2-byte
+  storage image whose authoring dispatch was skipped (`3D tile mode has no volume address pattern` --
+  `Sw4KbS`, tile mode 5), and the frozen composite is a single colour, so the LUT looked like the
+  cause. #2229 implements `SW_4KB_S3` volume addressing and the dispatch now runs -- **verified by the
+  lever**: the skip count goes 1 -> 0 between arms. The rendered output does not move. Same route
+  (`screenshot --count 3 --every 60`), master vs fix, both arms give `(25,25,25)` then `(0,0,0)` twice,
+  all 8,294,400 pixels, one distinct colour each; on a shorter route the two builds' PNGs are
+  byte-identical (same SHA-256). Authoring that image changes nothing observable, so the uniform
+  composite has another cause. #2229 is still a real gap and is fixed on its own merits.
+
 - **THE SKIPPED COMPUTE PROGRAMS DO NOT FAIL ON CONTROL FLOW.** This document and #2013 both recorded
   "they fail on **control flow**, not arithmetic: 21 `[cfg-recompile-reject]` and 26
   `[compute-struct-reject]` lines per boot, on `s_cbranch_vccz`/`vccnz` and a forward

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -994,48 +994,81 @@ constexpr uint32_t kSw64kbS3Dims[5][3] = {
     {64, 32, 32}, {32, 32, 32}, {32, 32, 16}, {32, 16, 16}, {16, 16, 16},
 };
 
-size_t sw64kb_s3_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+// GFX10 standard 3D swizzles are NESTED: SW_4K_S3 addresses 4 KiB using the LOW 12 bits of the very
+// same per-element pattern SW_64K_S3 uses for 16, with block dimensions equal to whatever those 12
+// bits can reach. The table above is therefore REUSED rather than transcribed a second time; a copy
+// would be five rows of coordinate masks obliged to stay in lockstep forever, and nothing would
+// notice if they stopped.
+//
+// Two checks that the nesting is right, neither of which is a round-trip tautology (a tile/detile
+// round trip is self-consistent for any invented swizzle and proves nothing about the hardware):
+//
+//  1. Every element size lands on exactly 4096 bytes from its low 12 bits -- 16x16x16x1B,
+//     8x16x16x2B, 8x16x8x4B, 8x8x8x8B, 4x8x8x16B. That is not automatic: a wrong bit count misses
+//     4096 on all five rows at once.
+//  2. Sonic Racing: CrossWorlds (PPSA08804) binds a 16x16x16 2-byte grading LUT and the GUEST
+//     declares size=8192. This pattern predicts ceil(16/8) * ceil(16/16) * ceil(16/16) = 2 blocks
+//     * 4096 = 8192 bytes. The guest's own size field agrees with the derivation. (#2229)
+constexpr uint32_t kSw4kbS3Bits = 12;
+constexpr uint32_t kSw4kbS3Dims[5][3] = {
+    {16, 16, 16}, {8, 16, 16}, {8, 16, 8}, {8, 8, 8}, {4, 8, 8},
+};
+
+// Shared by both standard-3D block sizes. `bits` is log2 of the block, so 16 -> 64 KiB (S3) and
+// 12 -> 4 KiB (4K_S3); `dims` is the matching block geometry.
+size_t s3_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe,
+                       uint32_t bits, const uint32_t (*dims)[3]) {
     const uint32_t el = sw64kb_elem_log2(bpe);
     if (el == UINT32_MAX || !width || !height || !depth) return 0;
-    const uint64_t blocks_x = (static_cast<uint64_t>(width) + kSw64kbS3Dims[el][0] - 1) /
-                              kSw64kbS3Dims[el][0];
-    const uint64_t blocks_y = (static_cast<uint64_t>(height) + kSw64kbS3Dims[el][1] - 1) /
-                              kSw64kbS3Dims[el][1];
-    const uint64_t blocks_z = (static_cast<uint64_t>(depth) + kSw64kbS3Dims[el][2] - 1) /
-                              kSw64kbS3Dims[el][2];
-    if (blocks_x > SIZE_MAX / 65536u ||
-        blocks_y > SIZE_MAX / (blocks_x * 65536u) ||
-        blocks_z > SIZE_MAX / (blocks_x * blocks_y * 65536u)) return 0;
-    return static_cast<size_t>(blocks_x * blocks_y * blocks_z * 65536u);
+    const uint64_t block_bytes = 1ull << bits;
+    const uint64_t blocks_x = (static_cast<uint64_t>(width) + dims[el][0] - 1) / dims[el][0];
+    const uint64_t blocks_y = (static_cast<uint64_t>(height) + dims[el][1] - 1) / dims[el][1];
+    const uint64_t blocks_z = (static_cast<uint64_t>(depth) + dims[el][2] - 1) / dims[el][2];
+    if (blocks_x > SIZE_MAX / block_bytes ||
+        blocks_y > SIZE_MAX / (blocks_x * block_bytes) ||
+        blocks_z > SIZE_MAX / (blocks_x * blocks_y * block_bytes)) return 0;
+    return static_cast<size_t>(blocks_x * blocks_y * blocks_z * block_bytes);
 }
 
+size_t sw64kb_s3_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    return s3_volume_bytes(width, height, depth, bpe, 16, kSw64kbS3Dims);
+}
+
+size_t sw4kb_s3_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    return s3_volume_bytes(width, height, depth, bpe, kSw4kbS3Bits, kSw4kbS3Dims);
+}
+
+// `bits` selects the block size: 16 for SW_64K_S3, 12 for SW_4K_S3. Because 4K_S3's pattern is the
+// low 12 bits of the same table, the only differences are the loop bound on the pattern bits, the
+// block geometry, and the shift that concatenates block index with in-block offset.
 template <bool ToTiled>
-bool sw64kb_s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
-                           uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+bool s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                    uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe,
+                    uint32_t bits, const uint32_t (*dims)[3]) {
     const uint32_t el = sw64kb_elem_log2(bpe);
     if (el == UINT32_MAX) return false;
-    const uint32_t bw = kSw64kbS3Dims[el][0];
-    const uint32_t bh = kSw64kbS3Dims[el][1];
-    const uint32_t bd = kSw64kbS3Dims[el][2];
+    const uint32_t bw = dims[el][0];
+    const uint32_t bh = dims[el][1];
+    const uint32_t bd = dims[el][2];
     const uint64_t blocks_x = (static_cast<uint64_t>(width) + bw - 1) / bw;
     const uint64_t blocks_y = (static_cast<uint64_t>(height) + bh - 1) / bh;
     const PatBit3* pat = kSw64kbS3[el];
     std::vector<uint16_t> fx(width), fy(height), fz(depth);
     for (uint32_t x = 0; x < width; ++x) {
         uint32_t v = 0;
-        for (uint32_t i = el; i < 16; ++i)
+        for (uint32_t i = el; i < bits; ++i)
             v |= static_cast<uint32_t>(__builtin_popcount(x & pat[i].x) & 1) << i;
         fx[x] = static_cast<uint16_t>(v);
     }
     for (uint32_t y = 0; y < height; ++y) {
         uint32_t v = 0;
-        for (uint32_t i = el; i < 16; ++i)
+        for (uint32_t i = el; i < bits; ++i)
             v |= static_cast<uint32_t>(__builtin_popcount(y & pat[i].y) & 1) << i;
         fy[y] = static_cast<uint16_t>(v);
     }
     for (uint32_t z = 0; z < depth; ++z) {
         uint32_t v = 0;
-        for (uint32_t i = el; i < 16; ++i)
+        for (uint32_t i = el; i < bits; ++i)
             v |= static_cast<uint32_t>(__builtin_popcount(z & pat[i].z) & 1) << i;
         fz[z] = static_cast<uint16_t>(v);
     }
@@ -1045,7 +1078,7 @@ bool sw64kb_s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
             const uint64_t block_row = block_slab + static_cast<uint64_t>(y / bh) * blocks_x;
             for (uint32_t x = 0; x < width; ++x) {
                 const uint64_t block = block_row + x / bw;
-                const uint64_t tiled = (block << 16) | (fx[x] ^ fy[y] ^ fz[z]);
+                const uint64_t tiled = (block << bits) | (fx[x] ^ fy[y] ^ fz[z]);
                 const size_t linear =
                     ((static_cast<size_t>(z) * height + y) * width + x) * bpe;
                 if (ToTiled) {
@@ -1059,6 +1092,20 @@ bool sw64kb_s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
         }
     }
     return true;
+}
+
+template <bool ToTiled>
+bool sw64kb_s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                           uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    return s3_volume_copy<ToTiled>(dst, src, tiled_bytes, width, height, depth, bpe,
+                                   16, kSw64kbS3Dims);
+}
+
+template <bool ToTiled>
+bool sw4kb_s3_volume_copy(uint8_t* dst, const uint8_t* src, size_t tiled_bytes,
+                          uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe) {
+    return s3_volume_copy<ToTiled>(dst, src, tiled_bytes, width, height, depth, bpe,
+                                   kSw4kbS3Bits, kSw4kbS3Dims);
 }
 } // namespace
 
@@ -1585,6 +1632,7 @@ void tile_surface_level(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
 
 bool tile_mode_supports_volume(uint32_t tile_mode) {
     return tile_mode == (uint32_t)TileMode::Linear ||
+           tile_mode == (uint32_t)TileMode::Sw4KbS ||
            tile_mode == (uint32_t)TileMode::Sw64KbS ||
            (tile_mode == (uint32_t)TileMode::Sw64KbRX && sw64kb_rx_pipes_log2() == 4);
 }
@@ -1598,6 +1646,8 @@ size_t tiled_volume_bytes(uint32_t width, uint32_t height, uint32_t depth,
         return static_cast<size_t>(texels * bytes_per_texel);
     }
     if (!tile_mode_supports_volume(tile_mode)) return 0;
+    if (tile_mode == (uint32_t)TileMode::Sw4KbS)
+        return sw4kb_s3_volume_bytes(width, height, depth, bytes_per_texel);
     return tile_mode == (uint32_t)TileMode::Sw64KbS
                ? sw64kb_s3_volume_bytes(width, height, depth, bytes_per_texel)
                : sw64kb_rx_volume_bytes(width, height, depth, bytes_per_texel);
@@ -1613,6 +1663,9 @@ bool detile_volume(uint8_t* dst, const uint8_t* src, size_t src_bytes,
         return true;
     }
     if (!tile_mode_supports_volume(tile_mode)) return false;
+    if (tile_mode == (uint32_t)TileMode::Sw4KbS)
+        return sw4kb_s3_volume_copy<false>(dst, src, src_bytes, width, height, depth,
+                                        bytes_per_texel);
     return tile_mode == (uint32_t)TileMode::Sw64KbS
                ? sw64kb_s3_volume_copy<false>(dst, src, src_bytes, width, height, depth,
                                                bytes_per_texel)
@@ -1630,6 +1683,9 @@ bool tile_volume(uint8_t* dst, size_t dst_bytes, const uint8_t* src,
         return true;
     }
     std::memset(dst, 0, need);
+    if (tile_mode == (uint32_t)TileMode::Sw4KbS)
+        return sw4kb_s3_volume_copy<true>(dst, src, need, width, height, depth,
+                                        bytes_per_texel);
     return tile_mode == (uint32_t)TileMode::Sw64KbS
                ? sw64kb_s3_volume_copy<true>(dst, src, need, width, height, depth,
                                               bytes_per_texel)

--- a/prosper/src/gpu/tile.cpp
+++ b/prosper/src/gpu/tile.cpp
@@ -1014,6 +1014,51 @@ constexpr uint32_t kSw4kbS3Dims[5][3] = {
     {16, 16, 16}, {8, 16, 16}, {8, 16, 8}, {8, 8, 8}, {4, 8, 8},
 };
 
+// The dims above are DERIVED DATA sitting next to the derivation they come from, which is a hazard:
+// the pattern could change and the table not follow, with nothing to notice. The literal table is
+// kept anyway -- a reader of a tiling file needs the block geometry at a glance, and a loop
+// accumulating coordinate masks does not provide that -- so the drift is closed by checking it
+// instead of by deleting it.
+//
+// Compile-time rather than a test arm, because a static_assert cannot be skipped, cannot be run on
+// the wrong build directory, and reports at the point of the mistake. If the pattern changes and the
+// table does not, this file stops compiling.
+constexpr uint32_t sw4kb_s3_derived_dim(uint32_t el, uint32_t axis) {
+    uint32_t highest = 0;
+    for (uint32_t i = el; i < kSw4kbS3Bits; ++i) {
+        const uint32_t mask = axis == 0 ? kSw64kbS3[el][i].x
+                            : axis == 1 ? kSw64kbS3[el][i].y
+                                        : kSw64kbS3[el][i].z;
+        if (mask > highest) highest = mask;
+    }
+    // The masks are single coordinate bits, so the highest one addresses [0, 2*mask); an axis no bit
+    // references spans exactly one texel.
+    return highest ? highest * 2u : 1u;
+}
+static_assert(sw4kb_s3_derived_dim(0, 0) == kSw4kbS3Dims[0][0] &&
+              sw4kb_s3_derived_dim(0, 1) == kSw4kbS3Dims[0][1] &&
+              sw4kb_s3_derived_dim(0, 2) == kSw4kbS3Dims[0][2] &&
+              sw4kb_s3_derived_dim(1, 0) == kSw4kbS3Dims[1][0] &&
+              sw4kb_s3_derived_dim(1, 1) == kSw4kbS3Dims[1][1] &&
+              sw4kb_s3_derived_dim(1, 2) == kSw4kbS3Dims[1][2] &&
+              sw4kb_s3_derived_dim(2, 0) == kSw4kbS3Dims[2][0] &&
+              sw4kb_s3_derived_dim(2, 1) == kSw4kbS3Dims[2][1] &&
+              sw4kb_s3_derived_dim(2, 2) == kSw4kbS3Dims[2][2] &&
+              sw4kb_s3_derived_dim(3, 0) == kSw4kbS3Dims[3][0] &&
+              sw4kb_s3_derived_dim(3, 1) == kSw4kbS3Dims[3][1] &&
+              sw4kb_s3_derived_dim(3, 2) == kSw4kbS3Dims[3][2] &&
+              sw4kb_s3_derived_dim(4, 0) == kSw4kbS3Dims[4][0] &&
+              sw4kb_s3_derived_dim(4, 1) == kSw4kbS3Dims[4][1] &&
+              sw4kb_s3_derived_dim(4, 2) == kSw4kbS3Dims[4][2],
+              "kSw4kbS3Dims no longer matches what the low 12 bits of kSw64kbS3 can address");
+// And that each derived block is exactly 4 KiB -- the property that fails on a wrong bit count.
+static_assert(kSw4kbS3Dims[0][0] * kSw4kbS3Dims[0][1] * kSw4kbS3Dims[0][2] * 1u == 4096 &&
+              kSw4kbS3Dims[1][0] * kSw4kbS3Dims[1][1] * kSw4kbS3Dims[1][2] * 2u == 4096 &&
+              kSw4kbS3Dims[2][0] * kSw4kbS3Dims[2][1] * kSw4kbS3Dims[2][2] * 4u == 4096 &&
+              kSw4kbS3Dims[3][0] * kSw4kbS3Dims[3][1] * kSw4kbS3Dims[3][2] * 8u == 4096 &&
+              kSw4kbS3Dims[4][0] * kSw4kbS3Dims[4][1] * kSw4kbS3Dims[4][2] * 16u == 4096,
+              "a SW_4KB_S3 block no longer holds exactly 4096 bytes");
+
 // Shared by both standard-3D block sizes. `bits` is log2 of the block, so 16 -> 64 KiB (S3) and
 // 12 -> 4 KiB (4K_S3); `dims` is the matching block geometry.
 size_t s3_volume_bytes(uint32_t width, uint32_t height, uint32_t depth, uint32_t bpe,

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -960,6 +960,82 @@ int main() {
               "SW_64KB_S3 round-trip is exact for every supported texel size");
     }
 
+    // GFX10 standard thick 3D SW_4KB_S (#2229). Its pattern is the LOW 12 BITS of the S3 table
+    // above, so these arms exist to pin the nesting rather than to re-test the pattern: if the bit
+    // count or the derived block dims drift, the golden addresses below move and the byte totals
+    // stop landing on 4096.
+    //
+    // A round trip cannot establish any of this -- it is self-consistent for an arbitrary invented
+    // swizzle -- so the load-bearing arms are the byte-address goldens and the two size checks.
+    {
+        const uint32_t M = (uint32_t)TileMode::Sw4KbS;
+        CHECK(tile_mode_supports_volume(M), "SW_4KB_S has a standard 3D pattern (#2229)");
+
+        // Every element size must fill exactly one 4 KiB block at its own derived dimensions. A
+        // wrong bit count misses 4096 on all five at once, which is what makes this a real check.
+        CHECK(tiled_volume_bytes(16, 16, 16, M, 1) == 4096 &&
+              tiled_volume_bytes(8, 16, 16, M, 2) == 4096 &&
+              tiled_volume_bytes(8, 16,  8, M, 4) == 4096 &&
+              tiled_volume_bytes(8,  8,  8, M, 8) == 4096 &&
+              tiled_volume_bytes(4,  8,  8, M, 16) == 4096,
+              "each SW_4KB_S3 texel size fills exactly one 4 KiB block at its derived dimensions");
+        CHECK(tiled_volume_bytes(0, 16, 16, M, 2) == 0,
+              "zero-width SW_4KB_S3 volumes are rejected without forming a block grid");
+
+        // The guest-corroborated case: Sonic Racing: CrossWorlds binds a 16x16x16 2-byte grading
+        // LUT and the GUEST declares size=8192. Two 8x16x16 blocks is 8192, so the derivation
+        // agrees with the title's own size field rather than only with itself.
+        CHECK(tiled_volume_bytes(16, 16, 16, M, 2) == 8192,
+              "PPSA08804's 16-cubed 2-byte LUT is 2 blocks = 8192 bytes, matching its declared size");
+
+        const uint32_t w = 16, h = 16, d = 16, bpe = 2;
+        std::vector<uint8_t> ref((size_t)w * h * d * bpe);
+        for (size_t i = 0; i < ref.size(); ++i) ref[i] = (uint8_t)((i >> 1) * 31 + i);
+        std::vector<uint8_t> tiled(tiled_volume_bytes(w, h, d, M, bpe), 0);
+        CHECK(tile_volume(tiled.data(), tiled.size(), ref.data(), w, h, d, M, bpe),
+              "PPSA08804's 16-cubed LUT tiles successfully");
+        auto at3 = [&](uint32_t x, uint32_t y, uint32_t z) {
+            return &ref[(((size_t)z * h + y) * w + x) * bpe];
+        };
+        // 2 B row, bits 1..11: x0->1, z0->2, y0->3, z1->4, y1->5, x1->6, z2->7, y2->8, x2->9,
+        // z3->10, y3->11. Block geometry is 8x16x16, so x=8 opens the next macroblock.
+        CHECK(std::memcmp(&tiled[2],   at3(1,0,0), bpe) == 0,
+              "4KB_S3 2B golden: x0 maps to byte-address bit 1");
+        CHECK(std::memcmp(&tiled[4],   at3(0,0,1), bpe) == 0,
+              "4KB_S3 2B golden: z0 maps to byte-address bit 2");
+        CHECK(std::memcmp(&tiled[8],   at3(0,1,0), bpe) == 0,
+              "4KB_S3 2B golden: y0 maps to byte-address bit 3");
+        CHECK(std::memcmp(&tiled[64],  at3(2,0,0), bpe) == 0,
+              "4KB_S3 2B golden: x1 maps to byte-address bit 6");
+        CHECK(std::memcmp(&tiled[512], at3(4,0,0), bpe) == 0,
+              "4KB_S3 2B golden: x2 maps to byte-address bit 9");
+        CHECK(std::memcmp(&tiled[2048], at3(0,8,0), bpe) == 0,
+              "4KB_S3 2B golden: y3 maps to the top in-block bit 11");
+        CHECK(std::memcmp(&tiled[4096], at3(8,0,0), bpe) == 0,
+              "4KB_S3 2B golden: x=8 starts the second macroblock, not a bit inside the first");
+
+        auto rt4k = [&](uint32_t bytes) {
+            static const uint32_t dims[5][3] = {
+                {16,16,16}, {8,16,16}, {8,16,8}, {8,8,8}, {4,8,8}
+            };
+            uint32_t el = 0; while ((1u << el) < bytes) ++el;
+            const uint32_t rw = dims[el][0] + 1;
+            const uint32_t rh = dims[el][1] + 1;
+            const uint32_t rd = dims[el][2] + 1;
+            std::vector<uint8_t> linear((size_t)rw * rh * rd * bytes);
+            for (size_t i = 0; i < linear.size(); ++i)
+                linear[i] = (uint8_t)((i * 2654435761u) >> 19);
+            std::vector<uint8_t> swizzled(tiled_volume_bytes(rw, rh, rd, M, bytes), 0);
+            std::vector<uint8_t> back(linear.size(), 0);
+            return tile_volume(swizzled.data(), swizzled.size(), linear.data(), rw, rh, rd,
+                               M, bytes) &&
+                   detile_volume(back.data(), swizzled.data(), swizzled.size(), rw, rh, rd,
+                                 M, bytes) && back == linear;
+        };
+        CHECK(rt4k(1) && rt4k(2) && rt4k(4) && rt4k(8) && rt4k(16),
+              "SW_4KB_S3 round-trip is exact for every texel size (weak on its own; see above)");
+    }
+
     // GFX10 thin/view-as-2D 3D SW_64KB_R_X. Each Z slice owns a padded 2D block grid, while Z
     // participates in the pipe-XOR inside that slice; z0..z3 map to offset bits 11..8.
     if (!getenv("PROSPER_RX_PIPES")) {

--- a/prosper/tests/test_tile.cpp
+++ b/prosper/tests/test_tile.cpp
@@ -1034,6 +1034,44 @@ int main() {
         };
         CHECK(rt4k(1) && rt4k(2) && rt4k(4) && rt4k(8) && rt4k(16),
               "SW_4KB_S3 round-trip is exact for every texel size (weak on its own; see above)");
+
+        // States the block invariant directly: the address map covers one block exactly. Kept for
+        // what it SAYS, not for extra detection power -- and that distinction was measured, not
+        // assumed, because it was first added on a justification that turned out to be false.
+        //
+        // The claim was "the round trip cannot see aliasing, so this arm catches what it misses."
+        // It can. Collapsing the z contribution (`fz[z] = 0`) reddens the goldens, BOTH round trips
+        // and this arm together. The reason is arithmetic rather than incidental: one block holds
+        // exactly 4096/bpe elements writing bpe bytes each -- 4096 bytes into 4096 bytes, for every
+        // element size -- so a byte written twice forces a byte written never. **Aliasing and holes
+        // are the same defect seen from two sides.** The round trip detects the aliasing (a collision
+        // loses data); this arm detects the hole. For a single block they are equivalent.
+        //
+        // So do not add arms on the theory that this one is load-bearing where the others are not; it
+        // is a readable statement of an invariant that the round trip already enforces obliquely.
+        //
+        // Mechanically: tile_volume memsets the destination to zero first, so a byte still zero
+        // afterwards is a byte nothing wrote. The source therefore contains no zero bytes. No offset
+        // arithmetic is duplicated here, which is the point -- a test that re-implements the map
+        // agrees with itself whatever the map does.
+        auto covers_block_bijectively = [&](uint32_t bpe, uint32_t bw, uint32_t bh, uint32_t bd) {
+            const size_t elems = (size_t)bw * bh * bd;
+            std::vector<uint8_t> linear(elems * bpe);
+            for (size_t i = 0; i < linear.size(); ++i) linear[i] = (uint8_t)(i % 255u + 1u);  // never 0
+            const size_t bytes = tiled_volume_bytes(bw, bh, bd, M, bpe);
+            if (bytes != 4096 || elems * bpe != 4096) return false;
+            std::vector<uint8_t> tiled(bytes, 0);
+            if (!tile_volume(tiled.data(), tiled.size(), linear.data(), bw, bh, bd, M, bpe))
+                return false;
+            for (uint8_t b : tiled) if (b == 0) return false;   // an unwritten byte => a collision
+            return true;
+        };
+        CHECK(covers_block_bijectively(1, 16, 16, 16) &&
+              covers_block_bijectively(2,  8, 16, 16) &&
+              covers_block_bijectively(4,  8, 16,  8) &&
+              covers_block_bijectively(8,  8,  8,  8) &&
+              covers_block_bijectively(16, 4,  8,  8),
+              "SW_4KB_S3 maps one block bijectively for every texel size — full coverage, no aliasing");
     }
 
     // GFX10 thin/view-as-2D 3D SW_64KB_R_X. Each Z slice owns a padded 2D block grid, while Z


### PR DESCRIPTION
Fixes #2229. Refs #2013.

## The gap

`tile.cpp:1586` supported volume (3D) addressing for `Linear`, `Sw64KbS` and `Sw64KbRX`. **`Sw4KbS` (tile mode 5) was absent**, so any 3D image in that layout was declined at `live_compute.cpp:4686` — and because one bad binding fails the whole dispatch, the entire compute program was skipped.

Both halves already existed separately: `Sw4KbS` is fully supported for **2D**, and **volume** addressing is implemented for the 64 KiB standard swizzle. Only their intersection was missing.

## Approach — derive, don't transcribe

GFX10 standard 3D swizzles are **nested**: `SW_4K_S3` addresses 4 KiB using the **low 12 bits** of the same per-element pattern `SW_64K_S3` uses for 16. So the existing AddrLib table is reused and the copy is parameterised by bit count, rather than a second table being added. A duplicate would be five rows of coordinate masks obliged to stay in lockstep forever, with nothing to notice if they stopped.

## Why I believe the pattern, without relying on a round trip

A tile→detile round trip is **self-consistent for any invented swizzle** — it establishes nothing about the hardware layout. Two independent checks do:

1. **Every element size lands on exactly 4096 bytes** from its low 12 bits: `16×16×16×1B`, `8×16×16×2B`, `8×16×8×4B`, `8×8×8×8B`, `4×8×8×16B`. A wrong bit count misses 4096 on all five at once.
2. **The guest's own size field agrees.** *Sonic Racing: CrossWorlds* binds a 16×16×16 2-byte image and declares `size=8192`. The derived pattern predicts `ceil(16/8) × ceil(16/16) × ceil(16/16) = 2` blocks × 4096 = **8192**.

Tests follow the existing **golden byte-address** style rather than leaning on the round trip: `x0→bit 1`, `z0→bit 2`, `y0→bit 3`, `x1→bit 6`, `x2→bit 9`, `y3→bit 11`, and `x=8` opening the second macroblock. The round trip is kept but labelled weak on its own.

## What this does NOT do — measured, not assumed

**It does not fix #2013.** The skipped image is a 16-cubed *storage* LUT and the title's composite is a single colour, so the LUT was the obvious suspect. It is not the cause.

| | master | this branch |
| --- | --- | --- |
| `3D tile mode has no volume` skips | **1** | **0** |
| shot 00 / 01 / 02 | `(25,25,25)` / `(0,0,0)` / `(0,0,0)` | `(25,25,25)` / `(0,0,0)` / `(0,0,0)` |
| distinct colours | 1 / 1 / 1 | 1 / 1 / 1 |

Same route (`screenshot --count 3 --every 60`), both arms. On a shorter route the two builds' PNGs are **byte-identical by SHA-256**. The **lever is verified rather than assumed** — the skip count moves 1 → 0 — so the dispatch demonstrably runs and demonstrably does not change the output. Recorded in `SONIC_CROSSWORLDS_STATUS.md`'s `## Ruled out`.

No screenshots are attached because there is no visual progression to show; that is the point of the table above.

## Regression safety

The byte-identical control doubles as the regression check: the shared `s3_volume_copy` refactor touches the **64 KiB** path used by *The Plucky Squire*'s 32-cubed lighting volume, and every existing `64KB_S3` golden arm still passes unchanged.

## Verification

```
cmake --build build -j6                 # rc=0
ctest --no-tests=error -j4              # 218/218 passed, exit 0
```

Two live A/B arms on `PPSA08804` as tabulated. No snapshots run — the diff changes no guarded title's output (demonstrated by the byte-identical control).

## Risk

Low-to-moderate. The address pattern is derived rather than transcribed from a second published table, which is why the two non-tautological checks above matter more than the round trip. If the derivation were wrong, the guest-declared size would not match and the per-element block totals would not all land on 4096. Marked `CONFIDENCE: MED-HIGH`; a title that visibly consumes a 4 KiB-tiled volume would raise it further, and none is known yet.
