### PR TITLE
feat(app): schedule the F8 and F9 captures headlessly, on either a delay or a host frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,12 +309,26 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
 
     ```bash
     cmake -S prosper -B build -DPROSPER_APP=ON          # the app is NOT built by default
-    SDL_VIDEODRIVER=offscreen \                         # no window; works over ssh/in a container
+    SDL_VIDEODRIVER=offscreen \                         # LINUX ONLY -- see below
     PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
     PROSPER_CAPTURE_DIR=$HOME/work \
     PROSPER_GRAB_BUNDLE_AFTER_MS=18000 PROSPER_PERF_CAPTURE_AFTER_MS=18000 \
         ./build/prosper-app <DUMP_ROOT>/<TITLE_ID>-app0
     ```
+
+    **`SDL_VIDEODRIVER=offscreen` is Linux-only. Drop it on Windows** — the triggers themselves are
+    platform-independent and fire correctly there with an ordinary window. SDL's offscreen driver needs
+    `VK_EXT_headless_surface`, which NVIDIA's Windows Vulkan driver does not expose, so the app dies
+    before writing anything:
+
+    ```
+    Installed Vulkan doesn't implement the VK_EXT_headless_surface extension
+    [app] SDL_Vulkan_CreateSurface: VK_EXT_headless_surface extension is not enabled ...
+    terminate called without an active exception
+    ```
+
+    That signature is recorded because it does not look like what it is: no artifacts and a
+    non-graceful exit read as "the capture triggers are broken", when the triggers were never reached.
 
     Which axis to use: **`_AFTER_MS` aims at an event you can only describe in time** ("when the movie
     starts", "when the rate collapses"); **`_AT_FRAME` aims at an ordinal you already located** with a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -294,9 +294,42 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     that exact frame **offline and deterministically**, and `--inspect-only` / `--draw-steps` /
     `--dump-resource` (via `--bundle-extract-submit`) dissect it draw-by-draw. This answers "which draw
     wrote this pixel / why does this frame look wrong / why is it slow" without re-booting and re-routing
-    to catch the moment live — the human presses F9 once, then the fix is iterated on the frozen frame.
+    to catch the moment live — press F9 once, then iterate the fix on the frozen frame.
     It captures *rendered-frame* bugs (not CPU/logic/audio). See `tools/AGENTS.md` (interactive frame grab)
     and `tools/gpu_replay/README.md`.
+  - **You do NOT need a human at the keyboard: both captures are schedulable, and an agent can run the
+    whole thing headless.** This is written here because it was missed for months — the triggers live in
+    `prosper-app`, which is **off by default** (`-DPROSPER_APP=ON`), so an env sweep of `src/` never sees
+    them, and lanes built weaker instruments instead. Two rich diagnostics, four one-shot triggers:
+
+    | capture | after a wall-clock delay | at a host frame |
+    | --- | --- | --- |
+    | **F9** replayable `.prgbundle` + `.bmp` | `PROSPER_GRAB_BUNDLE_AFTER_MS` | `PROSPER_GRAB_BUNDLE_AT_FRAME` |
+    | **F8** bounded `.prperf` (5 s before + 5 s after) | `PROSPER_PERF_CAPTURE_AFTER_MS` | `PROSPER_PERF_CAPTURE_AT_FRAME` |
+
+    ```bash
+    cmake -S prosper -B build -DPROSPER_APP=ON          # the app is NOT built by default
+    SDL_VIDEODRIVER=offscreen \                         # no window; works over ssh/in a container
+    PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+    PROSPER_CAPTURE_DIR=$HOME/work \
+    PROSPER_GRAB_BUNDLE_AFTER_MS=18000 PROSPER_PERF_CAPTURE_AFTER_MS=18000 \
+        ./build/prosper-app <DUMP_ROOT>/<TITLE_ID>-app0
+    ```
+
+    Which axis to use: **`_AFTER_MS` aims at an event you can only describe in time** ("when the movie
+    starts", "when the rate collapses"); **`_AT_FRAME` aims at an ordinal you already located** with a
+    cheap `tools/screenshot` sweep or `PROSPER_CAPTURE_SCREENSHOT_AT_FRAME`, and is the reproducible one.
+    Point both at the same moment to get the timing breakdown and the replayable frame together.
+
+    Each is **one-shot and opt-in**, and a malformed value **disables its own trigger** rather than firing
+    at an unintended moment — so a typo costs you a capture, never a wrong measurement. Read the
+    `.prperf` with `tools/perf/performance_capture_report.py` (it reports by **time**; the record counts
+    are not load), and the bundle with `tools/gpu_replay --bundle`.
+
+    **Read the F8 report before optimising anything.** Worked example (#2215, 2026-08-07): Blue Prince at
+    1 fps, and the capture said `gpu-device` was **2.2%** of the frame while `renderer-resource` was 47%
+    — and that `buffer copy`, the leaf two lanes were optimising because it dominates in *gameplay*, was
+    **2.4%** during the collapse. Two different problems that looked like one.
 - **Reaching the running frame loop:** `PROSPER_GUEST_ARGS=-force-gfx-direct`, plus `PROSPER_RENDER=1`
   to run the live renderer and `PROSPER_GFXLOG=1` for graphics diagnostics.
   - **`PROSPER_GUEST_FS=1` is NOT needed on Linux or Windows, and this line used to say it was.** Guest

--- a/prosper/frontends/prosper-app/frame_grab_naming.hpp
+++ b/prosper/frontends/prosper-app/frame_grab_naming.hpp
@@ -286,11 +286,16 @@ private:
 // sanitisation, so it can contain anything — including " -> ". An arm line that parses as a write
 // line would hand a log reader a path that never existed, which is this file's whole subject, so the
 // arrow is folded out of the label rather than trusted not to appear.
-inline std::string frame_grab_arm_line(unsigned index, const std::string& title_label) {
+// `trigger` names what armed this capture. It defaults to the hotkey so existing callers and their
+// tests are unaffected, but a SCHEDULED capture must not say "F9": there is no operator on that path,
+// and a log line that names a keypress nobody made sends its reader looking for one. (#2233)
+inline std::string frame_grab_arm_line(unsigned index, const std::string& title_label,
+                                       std::string_view trigger = "F9") {
     std::string label = title_label.empty() ? std::string("an unidentified title") : title_label;
     for (size_t k = label.find(" -> "); k != std::string::npos; k = label.find(" -> ", k))
         label.replace(k, 4, " - ");
-    return "[grab] F9 #" + std::to_string(index) + ": arming a whole-frame capture for " + label;
+    return "[grab] " + std::string(trigger) + " #" + std::to_string(index) +
+           ": arming a whole-frame capture for " + label;
 }
 
 // "[grab] bundle written (312 submits) [name collision: suffix -2] -> ./frame_grab_....prgbundle"

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1427,6 +1427,101 @@ int main(int argc, char** argv) {
         suffix = 0;
         return false;
     };
+    // The F9 frame grab, callable from the hotkey AND from the headless triggers below (#2233).
+    // Extracted verbatim so an unattended capture takes exactly the interactive path -- the
+    // supersede accounting and the reservation bookkeeping included. A second implementation for
+    // automation would mean a second set of rules for who owns a reserved file, and that is the
+    // one part of this that has already been hard to get right.
+    auto arm_frame_grab = [&](bool automatic, const char* why) {
+        std::fprintf(stderr, "[grab] %s bundle grab requested (%s)\n",
+                     automatic ? "automatic" : "F9", why);
+                // Claim both output names now, from ONE timestamp, with an exclusive create. Doing
+                // it here rather than at each write is what binds the two artifacts of this
+                // capture together: they are written seconds apart on two different threads, and a
+                // name derived independently at each write would let a bundle take a collision
+                // suffix its screenshot did not — which is exactly the mismatched pair this
+                // change exists to make impossible.
+                const prosper::frontend::FrameGrabPaths grab = grabNamer.reserve();
+                if (!grab.ok) {
+                    std::fprintf(stderr, "[grab] F9 #%u: could not reserve capture files: %s\n",
+                                 grab.index, grab.error.c_str());
+                    return;
+                }
+                // This line names NO file, deliberately. A log line must assert only what is true
+                // when it is emitted: at arm time the capture may still abort, the write may fail,
+                // and a collision suffix makes the eventual path unequal to any guess. An intention
+                // written in the grammar of a result is one a reader — human or agent — cannot tell
+                // apart from a result, and this fleet's agents read these logs to find artifacts.
+                // The real paths are logged by the writes, once the files exist. Do not "helpfully"
+                // restore a filename here.
+                std::fprintf(stderr, "%s\n",
+                             prosper::frontend::frame_grab_arm_line(
+                                 grab.index, grabNamer.title_label()).c_str());
+                // Honour PROSPER_CAPTURE_BUNDLE_MAX_MB here too (#1587). It was consulted only on
+                // the headless/scheduled paths, so the hotkey was pinned to the 2 GiB default with
+                // no way to raise it without editing code — and one 3840x2160 frame of a deferred
+                // renderer exceeds that, which made F9 unusable on 4K UE titles.
+                // Supersede and EXPLAIN, rather than refuse. A press that lands before the
+                // previous arm was promoted replaces it, and a replaced arm never runs and never
+                // reports — so this frontend is the only thing that can account for the names it
+                // reserved. Refusing the press instead was considered and rejected: the flag that
+                // says "a grab is in flight" is cleared only by a guest PRESENT, so a hung title
+                // would leave F9 dead for the rest of the session — and a hung title is exactly
+                // when someone reaches for F9.
+                const std::string replaced =
+                    prosper::gpu::request_interactive_capture_bundle(grab.bundle, grabBundleMaxMb);
+                if (!grab.warning.empty())
+                    std::fprintf(stderr, "[grab] %s\n", grab.warning.c_str());
+                if (!replaced.empty()) {
+                    unsigned dropped = 0;
+                    const bool ours = take_bundle_reservation(replaced, dropped);
+                    std::error_code ec;
+                    // Only our own, and only while still empty: a file with bytes in it belongs
+                    // to whoever wrote them.
+                    const bool removed = ours && std::filesystem::exists(replaced, ec) && !ec &&
+                                         std::filesystem::file_size(replaced, ec) == 0 && !ec &&
+                                         std::filesystem::remove(replaced, ec) && !ec;
+                    std::fprintf(stderr,
+                                 "[grab] this press replaced an armed capture that had not started; "
+                                 "it will never report. %s: %s\n",
+                                 removed ? "its empty reserved bundle has been removed"
+                                         : (ours ? "its reserved bundle is still on disk"
+                                                 : "its output path was configured, not reserved, "
+                                                   "and was left alone"),
+                                 replaced.c_str());
+                }
+                // A pending screenshot is dropped by this press whichever kind it is, but the two
+                // kinds cannot share a sentence: one is a name this frontend reserved and can
+                // account for, the other a configured path it never created.
+                if (!pendingGrabScreenshot.empty()) {
+                    if (pendingGrabReserved) {
+                        std::error_code ec;
+                        const bool removed =
+                            std::filesystem::exists(pendingGrabScreenshot, ec) && !ec &&
+                            std::filesystem::file_size(pendingGrabScreenshot, ec) == 0 && !ec &&
+                            std::filesystem::remove(pendingGrabScreenshot, ec) && !ec;
+                        std::fprintf(stderr,
+                                     "[grab] the previous capture's screenshot was still pending and "
+                                     "is dropped by this press; %s: %s\n",
+                                     removed ? "its empty reserved file has been removed"
+                                             : "its reserved file is still on disk",
+                                     pendingGrabScreenshot.c_str());
+                    } else {
+                        std::fprintf(stderr,
+                                     "[grab] the pending scheduled screenshot is dropped by this "
+                                     "press; nothing was written to %s\n",
+                                     pendingGrabScreenshot.c_str());
+                    }
+                }
+                pendingGrabScreenshot = grab.screenshot;
+                pendingGrabGuestPresent = gpu::present_count();
+                pendingGrabSuffix = grab.suffix;
+                pendingGrabReserved = true;
+                if (grabReservedBundles.size() >= 32) grabReservedBundles.erase(grabReservedBundles.begin());
+                grabReservedBundles.emplace_back(grab.bundle, grab.suffix);
+                return;
+    };
+
     auto flushGrabScreenshot = [&](const uint8_t* rgba, uint32_t w, uint32_t h) {
         if (pendingGrabScreenshot.empty()) return;
         const bool ok = write_frame_bmp(pendingGrabScreenshot, rgba, w, h);
@@ -1468,6 +1563,35 @@ int main(int argc, char** argv) {
                 static_cast<unsigned long long>(scheduledScreenshotFrame),
                 scheduledScreenshotPath.c_str());
     }
+
+    // --- Headless capture triggers (#2233) -------------------------------------------------
+    // F8 and F9 are the richest diagnostics this project has, and the bundle grab could previously
+    // be reached ONLY by a human pressing a key. Every agent here runs headless, so the best
+    // instrument in the toolbox was the one nobody could aim -- and lanes built weaker ones instead.
+    // Both captures are now schedulable on either axis, because they answer different questions:
+    // "after N ms" aims at a wall-clock event (a movie starts, a frame rate collapses); "at frame N"
+    // aims at a reproducible ordinal already located with a cheap screenshot sweep.
+    //
+    // All are one-shot and opt-in, and a malformed value disables its own trigger rather than firing
+    // at an unintended moment -- see parse_* in capture_schedule.hpp / performance_capture_schedule.hpp.
+    prosper::frontend::ElapsedPerformanceCaptureTrigger automaticGrabAfter(
+        prosper::frontend::parse_performance_capture_delay_ns(getenv("PROSPER_GRAB_BUNDLE_AFTER_MS")));
+    const uint64_t scheduledGrabFrame =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_GRAB_BUNDLE_AT_FRAME"));
+    bool scheduledGrabArmed = false;
+    const uint64_t scheduledPerfFrame =
+        prosper::frontend::parse_capture_frame(getenv("PROSPER_PERF_CAPTURE_AT_FRAME"));
+    bool scheduledPerfArmed = false;
+    if (automaticGrabAfter.delay_ns())
+        std::fprintf(stderr, "[grab] automatic bundle scheduled by PROSPER_GRAB_BUNDLE_AFTER_MS "
+                             "(one attempt after %llu ms of app-loop time)\n",
+                     (unsigned long long)(automaticGrabAfter.delay_ns() / 1000000));
+    if (scheduledGrabFrame)
+        std::fprintf(stderr, "[grab] automatic bundle scheduled at host frame %llu\n",
+                     (unsigned long long)scheduledGrabFrame);
+    if (scheduledPerfFrame)
+        std::fprintf(stderr, "[perf] automatic capture scheduled at host frame %llu\n",
+                     (unsigned long long)scheduledPerfFrame);
     bool scheduledScreenshotArmed = false;
     bool timedDumpPending = timedDumpMs > 0;
     bool running = true;
@@ -1645,6 +1769,10 @@ int main(int argc, char** argv) {
             arm_performance_capture(
                 true, perfNow, (perfNow - perfLoopStartNs) / 1'000'000);
         }
+        // Same one-shot contract as the perf trigger above: the trigger is consumed before the arm is
+        // attempted, so a failed arm stays visible instead of silently retrying into a later phase.
+        if (automaticGrabAfter.take_if_due(perfLoopStartNs, perfNow))
+            arm_frame_grab(true, "PROSPER_GRAB_BUNDLE_AFTER_MS");
         openedThisBatch = rejectedThisBatch = false;
         SDL_Event ev;
         while (SDL_PollEvent(&ev)) {
@@ -1686,90 +1814,7 @@ int main(int argc, char** argv) {
                 // only — near-zero cost until pressed, so it never distorts the FPS you are observing.
                 if (ev.type == SDL_EVENT_KEY_DOWN && key.app_window && !ev.key.repeat &&
                     ev.key.key == SDLK_F9) {
-                    // Claim both output names now, from ONE timestamp, with an exclusive create. Doing
-                    // it here rather than at each write is what binds the two artifacts of this
-                    // capture together: they are written seconds apart on two different threads, and a
-                    // name derived independently at each write would let a bundle take a collision
-                    // suffix its screenshot did not — which is exactly the mismatched pair this
-                    // change exists to make impossible.
-                    const prosper::frontend::FrameGrabPaths grab = grabNamer.reserve();
-                    if (!grab.ok) {
-                        std::fprintf(stderr, "[grab] F9 #%u: could not reserve capture files: %s\n",
-                                     grab.index, grab.error.c_str());
-                        continue;
-                    }
-                    // This line names NO file, deliberately. A log line must assert only what is true
-                    // when it is emitted: at arm time the capture may still abort, the write may fail,
-                    // and a collision suffix makes the eventual path unequal to any guess. An intention
-                    // written in the grammar of a result is one a reader — human or agent — cannot tell
-                    // apart from a result, and this fleet's agents read these logs to find artifacts.
-                    // The real paths are logged by the writes, once the files exist. Do not "helpfully"
-                    // restore a filename here.
-                    std::fprintf(stderr, "%s\n",
-                                 prosper::frontend::frame_grab_arm_line(
-                                     grab.index, grabNamer.title_label()).c_str());
-                    // Honour PROSPER_CAPTURE_BUNDLE_MAX_MB here too (#1587). It was consulted only on
-                    // the headless/scheduled paths, so the hotkey was pinned to the 2 GiB default with
-                    // no way to raise it without editing code — and one 3840x2160 frame of a deferred
-                    // renderer exceeds that, which made F9 unusable on 4K UE titles.
-                    // Supersede and EXPLAIN, rather than refuse. A press that lands before the
-                    // previous arm was promoted replaces it, and a replaced arm never runs and never
-                    // reports — so this frontend is the only thing that can account for the names it
-                    // reserved. Refusing the press instead was considered and rejected: the flag that
-                    // says "a grab is in flight" is cleared only by a guest PRESENT, so a hung title
-                    // would leave F9 dead for the rest of the session — and a hung title is exactly
-                    // when someone reaches for F9.
-                    const std::string replaced =
-                        prosper::gpu::request_interactive_capture_bundle(grab.bundle, grabBundleMaxMb);
-                    if (!grab.warning.empty())
-                        std::fprintf(stderr, "[grab] %s\n", grab.warning.c_str());
-                    if (!replaced.empty()) {
-                        unsigned dropped = 0;
-                        const bool ours = take_bundle_reservation(replaced, dropped);
-                        std::error_code ec;
-                        // Only our own, and only while still empty: a file with bytes in it belongs
-                        // to whoever wrote them.
-                        const bool removed = ours && std::filesystem::exists(replaced, ec) && !ec &&
-                                             std::filesystem::file_size(replaced, ec) == 0 && !ec &&
-                                             std::filesystem::remove(replaced, ec) && !ec;
-                        std::fprintf(stderr,
-                                     "[grab] this press replaced an armed capture that had not started; "
-                                     "it will never report. %s: %s\n",
-                                     removed ? "its empty reserved bundle has been removed"
-                                             : (ours ? "its reserved bundle is still on disk"
-                                                     : "its output path was configured, not reserved, "
-                                                       "and was left alone"),
-                                     replaced.c_str());
-                    }
-                    // A pending screenshot is dropped by this press whichever kind it is, but the two
-                    // kinds cannot share a sentence: one is a name this frontend reserved and can
-                    // account for, the other a configured path it never created.
-                    if (!pendingGrabScreenshot.empty()) {
-                        if (pendingGrabReserved) {
-                            std::error_code ec;
-                            const bool removed =
-                                std::filesystem::exists(pendingGrabScreenshot, ec) && !ec &&
-                                std::filesystem::file_size(pendingGrabScreenshot, ec) == 0 && !ec &&
-                                std::filesystem::remove(pendingGrabScreenshot, ec) && !ec;
-                            std::fprintf(stderr,
-                                         "[grab] the previous capture's screenshot was still pending and "
-                                         "is dropped by this press; %s: %s\n",
-                                         removed ? "its empty reserved file has been removed"
-                                                 : "its reserved file is still on disk",
-                                         pendingGrabScreenshot.c_str());
-                        } else {
-                            std::fprintf(stderr,
-                                         "[grab] the pending scheduled screenshot is dropped by this "
-                                         "press; nothing was written to %s\n",
-                                         pendingGrabScreenshot.c_str());
-                        }
-                    }
-                    pendingGrabScreenshot = grab.screenshot;
-                    pendingGrabGuestPresent = gpu::present_count();
-                    pendingGrabSuffix = grab.suffix;
-                    pendingGrabReserved = true;
-                    if (grabReservedBundles.size() >= 32) grabReservedBundles.erase(grabReservedBundles.begin());
-                    grabReservedBundles.emplace_back(grab.bundle, grab.suffix);
+                    arm_frame_grab(false, "hotkey");
                     continue;
                 }
                 // Ctrl+O opens a title in the empty window (#1469). Deliberately unavailable once a
@@ -2038,6 +2083,19 @@ int main(int argc, char** argv) {
         // frame, with no GPU command capture, so long routes can locate a visual checkpoint before
         // scheduling the replayable bundle there. Do not overwrite an interactive F9 screenshot;
         // if both coincide, the scheduled shot remains eligible for the following real present.
+        // Frame-addressed captures reuse the screenshot's due rule, so a skipped swapchain ordinal
+        // leaves the one-shot eligible for the next real present rather than missing silently.
+        if (prosper::frontend::capture_frame_due(scheduledGrabFrame, shown, scheduledGrabArmed)) {
+            scheduledGrabArmed = true;
+            arm_frame_grab(true, "PROSPER_GRAB_BUNDLE_AT_FRAME");
+        }
+        if (prosper::frontend::capture_frame_due(scheduledPerfFrame, shown, scheduledPerfArmed)) {
+            scheduledPerfArmed = true;
+            // Report the REAL elapsed time, not a placeholder: this line is read as a measurement,
+            // and "fired at 0 ms" for a capture armed 40 s in is simply false.
+            arm_performance_capture(true, perfNow,
+                                    (perfNow - perfLoopStartNs) / 1'000'000);
+        }
         if (pendingGrabScreenshot.empty() && prosper::frontend::capture_frame_due(
                 scheduledScreenshotFrame, shown, scheduledScreenshotArmed)) {
             pendingGrabScreenshot = scheduledScreenshotPath;

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1433,6 +1433,10 @@ int main(int argc, char** argv) {
     // automation would mean a second set of rules for who owns a reserved file, and that is the
     // one part of this that has already been hard to get right.
     auto arm_frame_grab = [&](bool automatic, const char* why) {
+        // Every line this path emits is read by an agent, not an operator. `source` names what armed
+        // the capture, so a SCHEDULED grab reports its trigger rather than a keypress nobody made --
+        // a log line naming F9 on a run with no window sends its reader looking for an operator.
+        const char* const source = automatic ? why : "F9";
         std::fprintf(stderr, "[grab] %s bundle grab requested (%s)\n",
                      automatic ? "automatic" : "F9", why);
                 // Claim both output names now, from ONE timestamp, with an exclusive create. Doing
@@ -1443,8 +1447,8 @@ int main(int argc, char** argv) {
                 // change exists to make impossible.
                 const prosper::frontend::FrameGrabPaths grab = grabNamer.reserve();
                 if (!grab.ok) {
-                    std::fprintf(stderr, "[grab] F9 #%u: could not reserve capture files: %s\n",
-                                 grab.index, grab.error.c_str());
+                    std::fprintf(stderr, "[grab] %s #%u: could not reserve capture files: %s\n",
+                                 source, grab.index, grab.error.c_str());
                     return;
                 }
                 // This line names NO file, deliberately. A log line must assert only what is true
@@ -1456,7 +1460,7 @@ int main(int argc, char** argv) {
                 // restore a filename here.
                 std::fprintf(stderr, "%s\n",
                              prosper::frontend::frame_grab_arm_line(
-                                 grab.index, grabNamer.title_label()).c_str());
+                                 grab.index, grabNamer.title_label(), source).c_str());
                 // Honour PROSPER_CAPTURE_BUNDLE_MAX_MB here too (#1587). It was consulted only on
                 // the headless/scheduled paths, so the hotkey was pinned to the 2 GiB default with
                 // no way to raise it without editing code — and one 3840x2160 frame of a deferred
@@ -2186,7 +2190,7 @@ int main(int argc, char** argv) {
                         "  %s\n"
                         "  %s\n"
                         "  budget in force: %llu MiB — raise it with "
-                        "PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and press F9 again\n"
+                        "PROSPER_CAPTURE_BUNDLE_MAX_MB=<64..3072> and re-arm the capture\n"
                         "============================================================================\n\n",
                         grab.error.c_str(), grab.bundle_path.c_str(), state.c_str(),
                         reservedHere

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -2259,7 +2259,12 @@ void interactive_frame_bundle_on_present() {
                     b.outcome_error = b.pending_failure_error.empty() ? std::string("grab aborted")
                                                                      : b.pending_failure_error;
                 } else {
-                    std::fprintf(stderr, "[grab] frame-bundle: window had no submits; press F9 again\n");
+                    // Names no key: this path is reached by the scheduled triggers too (#2233), where there is
+                    // no operator. It also points at the actual fix rather than at a repeat -- a
+                    // single-present window on a title that presents faster than it submits catches
+                    // zero legitimately, and re-arming the same width is a coin flip (trap 101).
+                    std::fprintf(stderr, "[grab] frame-bundle: window had no submits; widen it with "
+                                         "PROSPER_CAPTURE_FRAMES=N (1..240) or re-arm\n");
                     b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
                     b.outcome_error = "the capture window contained no GPU submits";
                 }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -576,9 +576,11 @@ predict a submit index with `PROSPER_GPU_CAPTURE_AT`.
 > **Agents: you do not need the hotkey.** Both F9 and F8 are schedulable, so a headless run can take
 > them itself — see the trigger table in `CLAUDE.md` (`PROSPER_GRAB_BUNDLE_AFTER_MS` /
 > `PROSPER_GRAB_BUNDLE_AT_FRAME`, `PROSPER_PERF_CAPTURE_AFTER_MS` / `PROSPER_PERF_CAPTURE_AT_FRAME`).
-> Build with `-DPROSPER_APP=ON` (off by default, which is why these were long assumed human-only) and
-> run under `SDL_VIDEODRIVER=offscreen` for no window at all. The scheduled path calls exactly the same
-> code as the keypress, reservation accounting included.
+> Build with `-DPROSPER_APP=ON` (off by default, which is why these were long assumed human-only). On
+> **Linux** add `SDL_VIDEODRIVER=offscreen` for no window at all; on **Windows** leave it off — SDL's
+> offscreen driver needs `VK_EXT_headless_surface`, which the NVIDIA Windows driver does not expose, and
+> the app terminates before writing any artifact. The triggers work with an ordinary window on either.
+> The scheduled path calls exactly the same code as the keypress, reservation accounting included.
 
 F9 arms a one-shot capture of the next frame
 (default 1, `PROSPER_CAPTURE_FRAMES=1..240` to grab an animation over several frames) and writes two

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -571,7 +571,16 @@ gitdir links, so the build-time fallback revision is `unknown` there.
 
 **Interactive frame grab (prosper-app hotkey).** When you are *playing* a title in `prosper-app` and see a
 graphical bug or an FPS drop, press **F9** to capture that moment for offline debugging — no need to
-predict a submit index with `PROSPER_GPU_CAPTURE_AT`. F9 arms a one-shot capture of the next frame
+predict a submit index with `PROSPER_GPU_CAPTURE_AT`.
+
+> **Agents: you do not need the hotkey.** Both F9 and F8 are schedulable, so a headless run can take
+> them itself — see the trigger table in `CLAUDE.md` (`PROSPER_GRAB_BUNDLE_AFTER_MS` /
+> `PROSPER_GRAB_BUNDLE_AT_FRAME`, `PROSPER_PERF_CAPTURE_AFTER_MS` / `PROSPER_PERF_CAPTURE_AT_FRAME`).
+> Build with `-DPROSPER_APP=ON` (off by default, which is why these were long assumed human-only) and
+> run under `SDL_VIDEODRIVER=offscreen` for no window at all. The scheduled path calls exactly the same
+> code as the keypress, reservation accounting included.
+
+F9 arms a one-shot capture of the next frame
 (default 1, `PROSPER_CAPTURE_FRAMES=1..240` to grab an animation over several frames) and writes two
 files (to `PROSPER_CAPTURE_DIR`, default cwd):
 


### PR DESCRIPTION
Fixes #2233. Refs #2215, #2231.

## The problem

`prosper-app`'s two richest diagnostics are **F8** (bounded `.prperf`, 5 s before + 5 s after) and **F9** (replayable `.prgbundle` + `.bmp`). **F9 could be reached only by a human pressing a key.**

Every agent here runs headless. So the best instrument in the toolbox was the one nobody could aim, and lanes built weaker ones instead. A second reason it stayed hidden: the triggers live in `prosper-app`, which is **not built by default** (`-DPROSPER_APP=ON`), so an env-var sweep over `src/` never sees them. `PROSPER_PERF_CAPTURE_AFTER_MS` already existed and I did not know it.

**What that cost, today.** Two lanes spent hours on Blue Prince's 1 fps FMV collapse (#2215) — a sampling profiler on Windows, an `LD_PRELOAD` `getenv` counter on Linux — and *both* of my successive explanations were wrong. One F8 press then said:

```
guest flips=1.69/s
components: renderer-resource=1516.5ms (47%)  gpu-device=71.3ms (2.2%)  compute=53.1ms (1.7%)
```

and showed that `buffer copy` — the leaf both lanes were optimising because it dominates in *gameplay* — is **2.4%** during the collapse. A different problem from the one being worked, and a keypress separated them.

## What this adds

| capture | after a delay | at a host frame |
| --- | --- | --- |
| **F9** bundle | `PROSPER_GRAB_BUNDLE_AFTER_MS` | `PROSPER_GRAB_BUNDLE_AT_FRAME` |
| **F8** perf | `PROSPER_PERF_CAPTURE_AFTER_MS` *(existed)* | `PROSPER_PERF_CAPTURE_AT_FRAME` |

Both axes, because they answer different questions: `_AFTER_MS` aims at an event only describable in time ("when the movie starts"); `_AT_FRAME` at a reproducible ordinal already located with a cheap screenshot sweep.

## Approach

**The F9 handler is extracted, not reimplemented.** The scheduled path calls exactly the interactive one, so the supersede accounting and reservation bookkeeping — who owns a reserved file, when an empty one may be removed — keeps a single definition. A parallel implementation for automation would mean a second set of rules for the part of this that has already been hard to get right.

**No new parsing or trigger machinery.** It reuses `parse_capture_frame` + `capture_frame_due` (one-shot, and already tolerant of a skipped swapchain ordinal) and `parse_performance_capture_delay_ns` + `ElapsedPerformanceCaptureTrigger` (consumes the trigger *before* arming, so a failed arm is fail-visible rather than retrying into a later phase). Both are already unit-tested, which is why this diff is wiring and the verification below is live rather than another unit test.

One correctness fix in passing: the frame-addressed perf arm reports its **real** elapsed milliseconds. My first draft passed `0` and logged `fired at 0 ms` for a capture armed 40 s in — false, in a line read as a measurement.

## Verification — live, headless, on `PPSA25009`

Under `SDL_VIDEODRIVER=offscreen`, so **no window** — it works over ssh and inside a container:

| arm | result |
| --- | --- |
| `_AFTER_MS` pair, both 18000 | both fired at 18000 ms → `.prgbundle` (11.6 MB) + `.bmp` (6.2 MB) + `.prperf` (211 KB) |
| `_AT_FRAME` pair, 600 / 650 | bundle armed at host frame 600, perf at 650; all artifacts written |
| malformed (`=abc`, `=-5`) | **0** announcements — each malformed value disables its **own** trigger |

That last row is the one that matters: a typo costs you a capture, never a wrong measurement.

```
cmake --build build -j6           # rc=0
ctest --no-tests=error -j4        # 218/218 passed, exit 0
docs gate                         # green
```

## Documentation

`CLAUDE.md` gets the trigger table, guidance on which axis to use, the `-DPROSPER_APP=ON` and `SDL_VIDEODRIVER=offscreen` requirements, a note that the `.prperf` report is by **time** (record counts are not load), and the #2215 worked example. `tools/AGENTS.md`'s frame-grab section gets a pointer so someone arriving from the tool docs finds it too.

## Risk

Low. Additive and opt-in — with none of the four variables set, behaviour is byte-for-byte what it was, and the hotkey path is the same code it always ran. The realistic failure mode is a scheduled grab firing at an unhelpful moment, which costs one capture.

## Not addressed

Repeating or multi-shot captures. Every trigger here is one-shot, matching the existing screenshot trigger. If a lane needs a burst, that is a separate change with its own disk-budget question.
