### PR TITLE
app: give the keyboard a right stick, and split the sticks from the D-pad

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -480,6 +480,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_prosper_app_pad_overlay PRIVATE prosper_core)
   add_test(NAME prosper_app_pad_overlay COMMAND test_prosper_app_pad_overlay)
 
+  # Which key is which pad control (#2234). No SDL here: the frontend keeps the Key -> scancode
+  # table and the mapping itself lives in a header, so this runs in the core suite on every host.
+  add_executable(test_prosper_app_keyboard_pad_map frontends/prosper-app/test_keyboard_pad_map.cpp)
+  target_include_directories(test_prosper_app_keyboard_pad_map PRIVATE src frontends/prosper-app)
+  target_link_libraries(test_prosper_app_keyboard_pad_map PRIVATE prosper_core)
+  add_test(NAME prosper_app_keyboard_pad_map COMMAND test_prosper_app_keyboard_pad_map)
+
   add_executable(test_prosper_app_window_controls frontends/prosper-app/test_window_controls.cpp)
   target_include_directories(test_prosper_app_window_controls PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_window_controls COMMAND test_prosper_app_window_controls)

--- a/prosper/docs/LINUX_RELEASE.md
+++ b/prosper/docs/LINUX_RELEASE.md
@@ -99,19 +99,27 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 
 | Host input | Guest control |
 |---|---|
-| WASD or arrows | D-pad and left stick |
-| J or Space | Cross |
-| K | Square |
-| L | Circle |
-| I | Triangle |
-| U / O | L1 / R1 |
-| Y / H | L2 / R2 |
+| WASD or arrows | D-pad |
+| T F G H | Left stick — up / left / down / right |
+| I J K L | Right stick — up / left / down / right |
+| N M , . | Square / Cross / Circle / Triangle |
+| Space | Cross |
+| Z X C V | L1 / L2 / R1 / R2 |
+| B / Slash | L3 / R3 (stick clicks) |
 | Enter | Options |
 | Pause or F10 | Pause/resume the guest and audio at a flip boundary |
 | F11 or Alt+Enter | Toggle host-window fullscreen |
 | F8 | Capture 5 seconds before and after a performance problem to `.prperf` |
 | F9 | Capture the current frame for offline replay |
 | Escape | Exit |
+
+Two clusters per hand, and a hand uses one at a time: left hand on WASD **or** TFGH, right hand on
+IJKL **or** N/M/,/. The right stick, L3 and R3 had no keyboard binding at all before this, so camera
+control needed a physical pad — in a first-person title you could walk but not look.
+
+**This changed WASD.** It used to drive the D-pad *and* the left stick together, so a stick-only
+title responded to it. The two are separate now: WASD is the D-pad, TFGH is the left stick.
+
 
 Pause/F10 is host-owned and is not forwarded to guest keyboard input. Alt+Enter is consumed by the
 host window and is not forwarded as the guest Options button. Closing the window also exits.

--- a/prosper/docs/WINDOWS_RELEASE.md
+++ b/prosper/docs/WINDOWS_RELEASE.md
@@ -58,19 +58,27 @@ SDL3 automatically uses a connected controller as pad 0. Keyboard input is compo
 
 | Host input | Guest control |
 |---|---|
-| WASD or arrows | D-pad and left stick |
-| J or Space | Cross |
-| K | Square |
-| L | Circle |
-| I | Triangle |
-| U / O | L1 / R1 |
-| Y / H | L2 / R2 |
+| WASD or arrows | D-pad |
+| T F G H | Left stick — up / left / down / right |
+| I J K L | Right stick — up / left / down / right |
+| N M , . | Square / Cross / Circle / Triangle |
+| Space | Cross |
+| Z X C V | L1 / L2 / R1 / R2 |
+| B / Slash | L3 / R3 (stick clicks) |
 | Enter | Options |
 | Pause or F10 | Pause/resume the guest and audio at a flip boundary |
 | F11 or Alt+Enter | Toggle host-window fullscreen |
 | F8 | Capture 5 seconds before and after a performance problem to `.prperf` |
 | F9 | Capture the current frame for offline replay |
 | Escape | Exit |
+
+Two clusters per hand, and a hand uses one at a time: left hand on WASD **or** TFGH, right hand on
+IJKL **or** N/M/,/. The right stick, L3 and R3 had no keyboard binding at all before this, so camera
+control needed a physical pad — in a first-person title you could walk but not look.
+
+**This changed WASD.** It used to drive the D-pad *and* the left stick together, so a stick-only
+title responded to it. The two are separate now: WASD is the D-pad, TFGH is the left stick.
+
 
 Pause/F10 is host-owned and is not forwarded to guest keyboard input. Alt+Enter is consumed by the
 host window and is not forwarded as the guest Options button. Closing

--- a/prosper/frontends/prosper-app/keyboard_pad_map.hpp
+++ b/prosper/frontends/prosper-app/keyboard_pad_map.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+// Keyboard -> virtual DualSense mapping (#2234).
+//
+// This lives apart from main.cpp, and takes a key-query callback instead of reading SDL directly,
+// so the mapping can be asserted key-by-key by a test that never links SDL. The frontend keeps only
+// the Key -> SDL_Scancode table, which is flat enough to audit by eye; every decision with judgment
+// in it -- which key deflects which stick, which face button sits under which finger, what a
+// diagonal does -- is here, and is covered.
+//
+// Layout. Two clusters per hand, and a hand uses one at a time; that is the point of the layout
+// rather than a side effect of it:
+//
+//     W A S D    D-pad up / left / down / right      (arrow keys do the same)
+//     T F G H    LEFT stick  up / left / down / right
+//     I J K L    RIGHT stick up / left / down / right
+//     N M , .    Square / Cross / Circle / Triangle
+//     Z X C V    L1 / L2 / R1 / R2
+//     B    /     L3 / R3
+//     Space      Cross      (under the thumb, and it costs nothing to keep)
+//     Enter      Options    (what Start is called on PlayStation)
+//
+// The right stick had NO keyboard binding at all before this. `HostPadState` carried right_x/right_y
+// and they reached `ScePadData` correctly, but nothing on the keyboard path ever wrote them, so they
+// stayed centred for the whole run -- camera control was reachable only from a physical pad, which
+// is most titles past rung 3. Blue Prince is first person: you could walk but you could not look.
+//
+// One change here is NOT additive. WASD used to drive the D-pad *and* the left stick together, so a
+// stick-only title responded to WASD. They are separate now: WASD is the D-pad, TFGH is the stick.
+// That is the intent of having a separate stick cluster, and it is also the one thing in this file
+// that can make a title stop responding to keys that worked yesterday.
+
+#include "input/pad.hpp"
+
+#include <cstdint>
+
+namespace prosper::frontend {
+
+// Named by the PHYSICAL key, not by what it does, so the mapping below is the thing under test
+// rather than a rename of its own answer.
+enum class PadKey {
+    W, A, S, D,
+    T, F, G, H,
+    I, J, K, L,
+    N, M, Comma, Period,
+    Z, X, C, V,
+    B, Slash,
+    Space, Enter,
+    ArrowUp, ArrowDown, ArrowLeft, ArrowRight,
+    Count,
+};
+
+namespace detail {
+
+// Sony's 8-bit stick convention: 0x80 centred, 0x00 up/left, 0xff down/right. A key is digital, so
+// it gives full deflection -- the same thing the left stick already did before this file existed.
+// Both directions held cancel, which is what a physical stick reports when it is not pushed.
+inline uint8_t stick_axis(bool negative, bool positive) {
+    if (negative == positive) return 0x80;
+    return negative ? 0x00 : 0xff;
+}
+
+}  // namespace detail
+
+// `down(k)` answers whether key `k` is currently held.
+//
+// `enter_maps_to_options` is false while the host owns Enter (Alt+Enter is the window's, and the
+// launcher UI uses it before a guest boots), matching the behaviour this replaces.
+template <typename KeyDown>
+input::HostPadState map_keyboard_to_pad(KeyDown down, bool enter_maps_to_options) {
+    using namespace input;
+    const auto k = [&](PadKey key) { return static_cast<bool>(down(key)); };
+
+    const bool dpad_up    = k(PadKey::W) || k(PadKey::ArrowUp);
+    const bool dpad_down  = k(PadKey::S) || k(PadKey::ArrowDown);
+    const bool dpad_left  = k(PadKey::A) || k(PadKey::ArrowLeft);
+    const bool dpad_right = k(PadKey::D) || k(PadKey::ArrowRight);
+
+    HostPadState st;
+    uint32_t b = 0;
+    if (dpad_up)    b |= SCE_PAD_BUTTON_UP;
+    if (dpad_down)  b |= SCE_PAD_BUTTON_DOWN;
+    if (dpad_left)  b |= SCE_PAD_BUTTON_LEFT;
+    if (dpad_right) b |= SCE_PAD_BUTTON_RIGHT;
+
+    // The face buttons are a diamond and N M , . is a row, so left-to-right is a convention either
+    // way. Read the diamond left -> bottom -> right -> top, which puts Cross -- the usual confirm --
+    // under the strongest finger.
+    if (k(PadKey::N))      b |= SCE_PAD_BUTTON_SQUARE;
+    if (k(PadKey::M) || k(PadKey::Space)) b |= SCE_PAD_BUTTON_CROSS;
+    if (k(PadKey::Comma))  b |= SCE_PAD_BUTTON_CIRCLE;
+    if (k(PadKey::Period)) b |= SCE_PAD_BUTTON_TRIANGLE;
+
+    // Shoulders sit on the left hand because the right hand owns IJKL and N/M/,/. at the same time.
+    // Not ideal, and not avoidable given that.
+    if (k(PadKey::Z)) b |= SCE_PAD_BUTTON_L1;
+    if (k(PadKey::X)) b |= SCE_PAD_BUTTON_L2;
+    if (k(PadKey::C)) b |= SCE_PAD_BUTTON_R1;
+    if (k(PadKey::V)) b |= SCE_PAD_BUTTON_R2;
+
+    // L3/R3 are commonly sprint and crouch in 3D titles, and were unreachable from the keyboard for
+    // the same reason the right stick was. B and / are free and sit at the outside of each cluster.
+    if (k(PadKey::B))     b |= SCE_PAD_BUTTON_L3;
+    if (k(PadKey::Slash)) b |= SCE_PAD_BUTTON_R3;
+
+    if (k(PadKey::Enter) && enter_maps_to_options) b |= SCE_PAD_BUTTON_OPTIONS;
+
+    st.buttons = b;
+    st.left_x  = detail::stick_axis(k(PadKey::F), k(PadKey::H));
+    st.left_y  = detail::stick_axis(k(PadKey::T), k(PadKey::G));
+    st.right_x = detail::stick_axis(k(PadKey::J), k(PadKey::L));
+    st.right_y = detail::stick_axis(k(PadKey::I), k(PadKey::K));
+
+    // The triggers are also analog. A key gives the full pull, and it must agree with the L2/R2
+    // button bits above -- a title may read either, and disagreeing between them is a bug the guest
+    // cannot see around.
+    st.l2 = k(PadKey::X) ? 255 : 0;
+    st.r2 = k(PadKey::V) ? 255 : 0;
+
+    st.connected = true;
+    return st;
+}
+
+}  // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -29,6 +29,7 @@
 #include "loader/linker.hpp"           // Program
 #include "input/pad.hpp"               // keyboard -> libScePad (HostPadState / PadBackend)
 #include "pad_overlay.hpp"              // keyboard pad 0 composed over the physical controller backend
+#include "keyboard_pad_map.hpp"         // which key is which pad control (#2234)
 #include "hle/ime_input.hpp"           // #1093: forward host keyboard keys to the guest IME path
 #include "present_mode.hpp"             // explicit swapchain latency/vsync policy, pure regression seam
 #include "present_policy.hpp"           // bounded-acquire present classification (#1182), pure seam
@@ -665,39 +666,58 @@ void feed_test_pattern(uint32_t w, uint32_t h, uint64_t frame) {
 // thread; the guest's scePadReadState reads the composed keyboard/physical state on a guest thread.
 prosper::frontend::KeyboardPadOverlay g_keyboard_pad;
 
+// The only SDL-aware part of the keyboard map: which physical key each PadKey names. The mapping
+// itself is in keyboard_pad_map.hpp, where a test can reach it without linking SDL.
+static SDL_Scancode scancode_for(prosper::frontend::PadKey k) {
+    using prosper::frontend::PadKey;
+    switch (k) {
+        case PadKey::W:          return SDL_SCANCODE_W;
+        case PadKey::A:          return SDL_SCANCODE_A;
+        case PadKey::S:          return SDL_SCANCODE_S;
+        case PadKey::D:          return SDL_SCANCODE_D;
+        case PadKey::T:          return SDL_SCANCODE_T;
+        case PadKey::F:          return SDL_SCANCODE_F;
+        case PadKey::G:          return SDL_SCANCODE_G;
+        case PadKey::H:          return SDL_SCANCODE_H;
+        case PadKey::I:          return SDL_SCANCODE_I;
+        case PadKey::J:          return SDL_SCANCODE_J;
+        case PadKey::K:          return SDL_SCANCODE_K;
+        case PadKey::L:          return SDL_SCANCODE_L;
+        case PadKey::N:          return SDL_SCANCODE_N;
+        case PadKey::M:          return SDL_SCANCODE_M;
+        case PadKey::Comma:      return SDL_SCANCODE_COMMA;
+        case PadKey::Period:     return SDL_SCANCODE_PERIOD;
+        case PadKey::Z:          return SDL_SCANCODE_Z;
+        case PadKey::X:          return SDL_SCANCODE_X;
+        case PadKey::C:          return SDL_SCANCODE_C;
+        case PadKey::V:          return SDL_SCANCODE_V;
+        case PadKey::B:          return SDL_SCANCODE_B;
+        case PadKey::Slash:      return SDL_SCANCODE_SLASH;
+        case PadKey::Space:      return SDL_SCANCODE_SPACE;
+        case PadKey::ArrowUp:    return SDL_SCANCODE_UP;
+        case PadKey::ArrowDown:  return SDL_SCANCODE_DOWN;
+        case PadKey::ArrowLeft:  return SDL_SCANCODE_LEFT;
+        case PadKey::ArrowRight: return SDL_SCANCODE_RIGHT;
+        // Enter has three scancodes and is handled by the caller; Count is not a key.
+        case PadKey::Enter:
+        case PadKey::Count:      break;
+    }
+    return SDL_SCANCODE_UNKNOWN;
+}
+
 // Snapshot the current keyboard into the overlay. Call from the thread that pumps SDL events.
 void poll_keyboard(const bool* keyboard, bool enter_maps_to_options) {
-    using namespace prosper::input;
-    auto d = [&](SDL_Scancode s){ return keyboard[s]; };
-    bool up    = d(SDL_SCANCODE_UP)   || d(SDL_SCANCODE_W);
-    bool down  = d(SDL_SCANCODE_DOWN) || d(SDL_SCANCODE_S);
-    bool left  = d(SDL_SCANCODE_LEFT) || d(SDL_SCANCODE_A);
-    bool right = d(SDL_SCANCODE_RIGHT)|| d(SDL_SCANCODE_D);
-    uint32_t b = 0;
-    if (up)    b |= SCE_PAD_BUTTON_UP;
-    if (down)  b |= SCE_PAD_BUTTON_DOWN;
-    if (left)  b |= SCE_PAD_BUTTON_LEFT;
-    if (right) b |= SCE_PAD_BUTTON_RIGHT;
-    if (d(SDL_SCANCODE_SPACE) || d(SDL_SCANCODE_J)) b |= SCE_PAD_BUTTON_CROSS;    // jump
-    if (d(SDL_SCANCODE_K))     b |= SCE_PAD_BUTTON_SQUARE;                        // attack
-    if (d(SDL_SCANCODE_L))     b |= SCE_PAD_BUTTON_CIRCLE;
-    if (d(SDL_SCANCODE_I))     b |= SCE_PAD_BUTTON_TRIANGLE;
-    if (d(SDL_SCANCODE_U))     b |= SCE_PAD_BUTTON_L1;
-    if (d(SDL_SCANCODE_O))     b |= SCE_PAD_BUTTON_R1;
-    if (d(SDL_SCANCODE_Y))     b |= SCE_PAD_BUTTON_L2;
-    if (d(SDL_SCANCODE_H))     b |= SCE_PAD_BUTTON_R2;
-    const bool enter_down = d(SDL_SCANCODE_RETURN) || d(SDL_SCANCODE_RETURN2) ||
-                            d(SDL_SCANCODE_KP_ENTER);
-    if (enter_down && enter_maps_to_options)
-        b |= SCE_PAD_BUTTON_OPTIONS;   // menu/start; Alt+Enter belongs to the host window
-    HostPadState st;
-    st.buttons = b;
-    st.left_x  = left ? 0x00 : (right ? 0xff : 0x80);   // also drive the left stick, for stick-only titles
-    st.left_y  = up   ? 0x00 : (down  ? 0xff : 0x80);
-    st.l2 = d(SDL_SCANCODE_Y) ? 255 : 0;
-    st.r2 = d(SDL_SCANCODE_H) ? 255 : 0;
-    st.connected = true;
-    g_keyboard_pad.set_keyboard_state(st);
+    using prosper::frontend::PadKey;
+    const auto down = [&](PadKey k) {
+        // Return, the numeric keypad's Enter, and the ISO Return2 are all "Enter" to a player.
+        if (k == PadKey::Enter)
+            return keyboard[SDL_SCANCODE_RETURN] || keyboard[SDL_SCANCODE_RETURN2] ||
+                   keyboard[SDL_SCANCODE_KP_ENTER];
+        const SDL_Scancode s = scancode_for(k);
+        return s != SDL_SCANCODE_UNKNOWN && keyboard[s];
+    };
+    g_keyboard_pad.set_keyboard_state(
+        prosper::frontend::map_keyboard_to_pad(down, enter_maps_to_options));
 }
 
 // ---- opening a game (#1469) --------------------------------------------------------------------

--- a/prosper/frontends/prosper-app/pad_overlay.hpp
+++ b/prosper/frontends/prosper-app/pad_overlay.hpp
@@ -27,8 +27,15 @@ public:
         }
         if (!physical) out = {};
         out.buttons |= keyboard.buttons;
-        if (keyboard.left_x != 0x80) out.left_x = keyboard.left_x;
-        if (keyboard.left_y != 0x80) out.left_y = keyboard.left_y;
+        // A centred axis is "the keyboard is not asking", so it must not overwrite a physical
+        // stick that IS deflected -- that is what makes this an overlay rather than a replacement.
+        // The right stick had no keyboard source at all until #2234, and consequently no merge
+        // here: adding it to the map alone would have left it centred, since this is where the
+        // composed state is decided.
+        if (keyboard.left_x  != 0x80) out.left_x  = keyboard.left_x;
+        if (keyboard.left_y  != 0x80) out.left_y  = keyboard.left_y;
+        if (keyboard.right_x != 0x80) out.right_x = keyboard.right_x;
+        if (keyboard.right_y != 0x80) out.right_y = keyboard.right_y;
         if (keyboard.l2 > out.l2) out.l2 = keyboard.l2;
         if (keyboard.r2 > out.r2) out.r2 = keyboard.r2;
         out.connected = true;

--- a/prosper/frontends/prosper-app/test_keyboard_pad_map.cpp
+++ b/prosper/frontends/prosper-app/test_keyboard_pad_map.cpp
@@ -1,0 +1,145 @@
+// Keyboard -> virtual DualSense mapping (#2234).
+//
+// The mapping is a contract with the player's fingers, so these arms name the KEY and the CONTROL,
+// not the internals. Two things here are worth more than the rest:
+//
+//   * the right stick is reachable at all -- it had no keyboard binding before #2234, so camera
+//     control was physical-pad-only and a first-person title could be walked but not looked around;
+//   * WASD no longer moves the left stick. That is the one non-additive change in the layout, so it
+//     is asserted in both directions rather than left to be discovered in a title that stops moving.
+
+#include "keyboard_pad_map.hpp"
+
+#include <cstdio>
+#include <initializer_list>
+
+using namespace prosper::input;
+using prosper::frontend::PadKey;
+using prosper::frontend::map_keyboard_to_pad;
+
+namespace {
+
+int failures = 0;
+#define CHECK(expr) do { if (!(expr)) { std::printf("FAIL line %d: %s\n", __LINE__, #expr); ++failures; } } while (0)
+
+// The state produced by holding exactly `held` and nothing else.
+HostPadState press(std::initializer_list<PadKey> held, bool enter_maps_to_options = true) {
+    return map_keyboard_to_pad(
+        [&](PadKey k) {
+            for (PadKey h : held) if (h == k) return true;
+            return false;
+        },
+        enter_maps_to_options);
+}
+
+bool centred(const HostPadState& s) {
+    return s.left_x == 0x80 && s.left_y == 0x80 && s.right_x == 0x80 && s.right_y == 0x80;
+}
+
+} // namespace
+
+int main() {
+    // --- nothing held ---------------------------------------------------------------------------
+    {
+        const HostPadState idle = press({});
+        CHECK(idle.buttons == 0);
+        CHECK(centred(idle));
+        CHECK(idle.l2 == 0 && idle.r2 == 0);
+        // The keyboard pad is always "present": the overlay composes it over a physical pad, and a
+        // title that polls for a connected controller must find one whether or not a key is down.
+        CHECK(idle.connected);
+    }
+
+    // --- the right stick, which is the gap this closes -------------------------------------------
+    CHECK(press({PadKey::I}).right_y == 0x00);   // up
+    CHECK(press({PadKey::K}).right_y == 0xff);   // down
+    CHECK(press({PadKey::J}).right_x == 0x00);   // left
+    CHECK(press({PadKey::L}).right_x == 0xff);   // right
+    // A diagonal deflects both axes; a camera that can only be moved on one axis at a time is not
+    // a camera.
+    {
+        const HostPadState diag = press({PadKey::I, PadKey::L});
+        CHECK(diag.right_y == 0x00 && diag.right_x == 0xff);
+    }
+    // Opposite keys cancel, the way a physical stick reports when it is not pushed.
+    CHECK(press({PadKey::I, PadKey::K}).right_y == 0x80);
+    CHECK(press({PadKey::J, PadKey::L}).right_x == 0x80);
+    // And the right stick must not disturb the left, or a title reading both gets a phantom walk.
+    {
+        const HostPadState right_only = press({PadKey::I, PadKey::J});
+        CHECK(right_only.left_x == 0x80 && right_only.left_y == 0x80);
+        CHECK(right_only.buttons == 0);
+    }
+
+    // --- the left stick moved to TFGH ------------------------------------------------------------
+    CHECK(press({PadKey::T}).left_y == 0x00);
+    CHECK(press({PadKey::G}).left_y == 0xff);
+    CHECK(press({PadKey::F}).left_x == 0x00);
+    CHECK(press({PadKey::H}).left_x == 0xff);
+    CHECK(press({PadKey::T, PadKey::G}).left_y == 0x80);
+    CHECK(press({PadKey::F, PadKey::H}).left_x == 0x80);
+    // H used to be R2. If it still were, walking right would fire a trigger.
+    CHECK(press({PadKey::H}).buttons == 0);
+    CHECK(press({PadKey::H}).r2 == 0);
+
+    // --- the D-pad, and the split that is not additive -------------------------------------------
+    CHECK(press({PadKey::W}).buttons == SCE_PAD_BUTTON_UP);
+    CHECK(press({PadKey::S}).buttons == SCE_PAD_BUTTON_DOWN);
+    CHECK(press({PadKey::A}).buttons == SCE_PAD_BUTTON_LEFT);
+    CHECK(press({PadKey::D}).buttons == SCE_PAD_BUTTON_RIGHT);
+    // Arrows are the same D-pad, so a player who reaches for them is not left without one.
+    CHECK(press({PadKey::ArrowUp}).buttons    == SCE_PAD_BUTTON_UP);
+    CHECK(press({PadKey::ArrowDown}).buttons  == SCE_PAD_BUTTON_DOWN);
+    CHECK(press({PadKey::ArrowLeft}).buttons  == SCE_PAD_BUTTON_LEFT);
+    CHECK(press({PadKey::ArrowRight}).buttons == SCE_PAD_BUTTON_RIGHT);
+    // THE behaviour change: WASD and the arrows drive the D-pad ONLY. Before #2234 they drove the
+    // left stick too, so a stick-only title responded to WASD and now will not.
+    CHECK(centred(press({PadKey::W})));
+    CHECK(centred(press({PadKey::A, PadKey::S, PadKey::D})));
+    CHECK(centred(press({PadKey::ArrowUp, PadKey::ArrowLeft})));
+    // ...and the converse, so the split cannot rot back together from the other side.
+    CHECK(press({PadKey::T, PadKey::F, PadKey::G, PadKey::H}).buttons == 0);
+
+    // --- face buttons: the diamond read left -> bottom -> right -> top ---------------------------
+    CHECK(press({PadKey::N}).buttons      == SCE_PAD_BUTTON_SQUARE);
+    CHECK(press({PadKey::M}).buttons      == SCE_PAD_BUTTON_CROSS);
+    CHECK(press({PadKey::Comma}).buttons  == SCE_PAD_BUTTON_CIRCLE);
+    CHECK(press({PadKey::Period}).buttons == SCE_PAD_BUTTON_TRIANGLE);
+    CHECK(press({PadKey::Space}).buttons  == SCE_PAD_BUTTON_CROSS);   // kept: it is under the thumb
+    CHECK(press({PadKey::M, PadKey::Space}).buttons == SCE_PAD_BUTTON_CROSS);  // not doubled
+
+    // --- shoulders, and the trigger analog that must agree with the button bit --------------------
+    CHECK(press({PadKey::Z}).buttons == SCE_PAD_BUTTON_L1);
+    CHECK(press({PadKey::C}).buttons == SCE_PAD_BUTTON_R1);
+    CHECK(press({PadKey::Z}).l2 == 0 && press({PadKey::C}).r2 == 0);
+    {
+        // A title may read the L2 button bit or the analog travel. Reporting a pressed trigger with
+        // zero travel -- or travel with no bit -- is a disagreement the guest cannot see around.
+        const HostPadState l2 = press({PadKey::X});
+        CHECK(l2.buttons == SCE_PAD_BUTTON_L2 && l2.l2 == 255 && l2.r2 == 0);
+        const HostPadState r2 = press({PadKey::V});
+        CHECK(r2.buttons == SCE_PAD_BUTTON_R2 && r2.r2 == 255 && r2.l2 == 0);
+    }
+
+    // --- stick clicks, unreachable from the keyboard for the same reason the right stick was ------
+    CHECK(press({PadKey::B}).buttons     == SCE_PAD_BUTTON_L3);
+    CHECK(press({PadKey::Slash}).buttons == SCE_PAD_BUTTON_R3);
+
+    // --- Enter is Options, except while the host owns Enter ---------------------------------------
+    CHECK(press({PadKey::Enter}).buttons == SCE_PAD_BUTTON_OPTIONS);
+    CHECK(press({PadKey::Enter}, /*enter_maps_to_options=*/false).buttons == 0);
+
+    // --- no key in the enum is dead ---------------------------------------------------------------
+    // A key added to PadKey but never wired reaches the frontend's scancode table and the README and
+    // still does nothing. Holding any one key alone must change SOMETHING about the pad.
+    for (int i = 0; i < static_cast<int>(PadKey::Count); ++i) {
+        const PadKey k = static_cast<PadKey>(i);
+        const HostPadState s = press({k});
+        const bool moved = s.buttons != 0 || !centred(s) || s.l2 != 0 || s.r2 != 0;
+        if (!moved) { std::printf("FAIL: PadKey %d is mapped to nothing\n", i); ++failures; }
+    }
+
+    if (failures) std::printf("FAIL: %d\n", failures);
+    else std::printf("PASS\n");
+    return failures ? 1 : 0;
+}

--- a/prosper/frontends/prosper-app/test_pad_overlay.cpp
+++ b/prosper/frontends/prosper-app/test_pad_overlay.cpp
@@ -50,6 +50,23 @@ int main() {
     CHECK(state.buttons == SCE_PAD_BUTTON_CIRCLE && state.left_x == 0x90);
     CHECK(!overlay.poll(2, state));
 
+    // The right stick composes on the same rule as the left (#2234). It was not merged here at all
+    // before, so a keyboard right-stick deflection was produced by the map and then dropped on the
+    // way to the guest -- the axis stayed centred for the whole run and only a physical pad could
+    // move the camera.
+    keyboard.right_x = 0x00;                 // deflected: the keyboard is asking, so it wins
+    keyboard.right_y = 0x80;                 // centred: not asking, so the physical pad keeps it
+    overlay.set_keyboard_state(keyboard);
+    CHECK(overlay.poll(0, state));
+    CHECK(state.right_x == 0x00);
+    CHECK(state.right_y == 0x80);            // PhysicalPads leaves right_y centred
+    CHECK(state.left_x == 0x00);             // and the left stick is unaffected by the addition
+
+    keyboard.right_x = 0x80;                 // back to centred: the physical deflection returns
+    overlay.set_keyboard_state(keyboard);
+    CHECK(overlay.poll(0, state));
+    CHECK(state.right_x == 0x22);
+
     if (failures) std::printf("FAIL: %d\n", failures);
     else std::printf("PASS\n");
     return failures ? 1 : 0;


### PR DESCRIPTION
feat(app): give the keyboard a right stick, and split the sticks from the D-pad

The keyboard pad had no binding for the right stick at all. `HostPadState`
carried right_x/right_y and they reached `ScePadData` correctly, but nothing on
the keyboard path ever wrote them -- so the axis sat centred for the entire run
and camera control needed a physical controller. That is most titles past rung 3.
Blue Prince is first person: on the keyboard you could walk but you could not
look. L3 and R3 were unreachable for the same reason.

The gap was in TWO places, which is why writing the axes alone would not have
fixed it: `KeyboardPadOverlay::poll` merged left_x/left_y from the keyboard and
never mentioned right_x/right_y, so a deflection produced by the map would have
been dropped on the way to the guest. Both are fixed here.

    W A S D    D-pad up / left / down / right   (arrows do the same)
    T F G H    LEFT stick  up / left / down / right
    I J K L    RIGHT stick up / left / down / right
    N M , .    Square / Cross / Circle / Triangle
    Z X C V    L1 / L2 / R1 / R2
    B    /     L3 / R3
    Space      Cross
    Enter      Options

Two clusters per hand, and a hand uses one at a time: left hand on WASD OR TFGH,
right hand on IJKL OR N/M/,/. -- that is the point of the layout rather than a
side effect of it. Layout per #2234.

One change is NOT additive
--------------------------
WASD used to drive the D-pad AND the left stick together, so a stick-only title
responded to WASD. They are separate now. That is the intent of having a distinct
stick cluster, and it is also the one thing here that can make a title stop
responding to keys that worked yesterday. Asserted in both directions so it
cannot quietly rot back together, and called out in both release docs.

Choices inside the layout, flagged rather than presented as obvious:

  * N M , . is a row and the face buttons are a diamond, so left-to-right is a
    convention either way. Read the diamond left -> bottom -> right -> top, which
    puts Cross -- the usual confirm -- under the strongest finger.
  * Shoulders land on the LEFT hand. I originally wrote that this was "not
    avoidable once the right hand owns IJKL and N/M/,/.". Review disproved that
    and it is corrected here rather than left standing: the layout being
    REPLACED already avoided it -- #2234's own "current mapping" table put U/O
    on L1/R1 and Y/H on L2/R2, so the right hand held its own shoulders while
    also holding I/J/K/L. Q E R Y U O P are all still free. So this is a
    deliberate tradeoff of what #2234 specifies, not a constraint the layout
    imposes, and moving R1/R2 back to the right hand would need the issue
    amended rather than a code change.
  * L3/R3 on B and / go slightly beyond the letter of #2234, which left them
    open. They are commonly sprint and crouch, both keys are free and inside the
    region the issue set aside for buttons, and they were otherwise unreachable
    from a keyboard at all. Trivially removable if unwanted.

Structure
---------
The mapping moved out of main.cpp into `keyboard_pad_map.hpp` and takes a
key-query callback rather than reading SDL. The frontend keeps only the
PadKey -> SDL_Scancode table, which is flat enough to audit by eye; everything
with judgment in it is in the header and covered by a test that never links SDL,
so it runs in the core suite on every host.

Tests
-----
`prosper_app_keyboard_pad_map` (new) and `prosper_app_pad_overlay` (extended).
Red/green measured by mutation, not asserted -- each mutation reddened exactly
its own arms and nothing else:

  overlay drops the right stick again      [FAIL] state.right_x == 0x00
  the map stops writing the right stick    [FAIL] 5 stick arms + 4 "PadKey is
                                                  mapped to nothing"
  WASD drives the left stick again         [FAIL] 3 centred() arms
  L2 bit without the analog travel         [FAIL] the agreement arm
  a PadKey wired to nothing (Slash)        [FAIL] the R3 arm + the dead-key scan

The dead-key scan holds every PadKey alone and requires the pad to change,
because a key added to the enum but never wired reaches the scancode table and
the README and still does nothing.

Verification
------------
  Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo:
    cmake --build prosper/build-mingw -j8 -- -k 0
    ctest --test-dir prosper/build-mingw --no-tests=error --output-on-failure
    -> 174 tests, 171 passed, 3 failed.

  All three failures are pre-existing and untouched by this diff, which reaches
  no threading or renderer code: pthread_names and live_target_format are #2142
  (both fail to ASSEMBLE on this toolchain -- ".seh_handlerdata used outside of
  .seh_proc block" -- so they report Not Run), and pthread_cond_clock is the
  known WinLibs-vs-MSYS2 EPERM difference.

Fixes #2234

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

