### PR TITLE
test(win): gate the nested-wait arms on the registration, not on a flag raised before it

### DIFF
--- a/prosper/tests/test_win_exception_delivery.cpp
+++ b/prosper/tests/test_win_exception_delivery.cpp
@@ -935,8 +935,23 @@ int main() {
     for (int i = 0; i < 2000 && !nested_wait_ready; ++i) Sleep(1);
     CHECK(nested_wait_ready != 0, "guest handler entered its nested semaphore-style wait");
     GuestWaitSnapshot nested_waits[4]{};
-    const size_t nested_wait_count =
-        snapshot_guest_waits(worker_tid, nested_waits, sizeof(nested_waits) / sizeof(nested_waits[0]));
+    size_t nested_wait_count = 0;
+    // Gate on the REGISTRATION, not on the flag. The handler raises nested_wait_ready two statements
+    // before the interruptible_cond_wait that registers the inner wait, so the flag being set does
+    // not mean there are two waits yet -- and sampling in that window sees only the outer one, which
+    // fails the count arm below AND makes the singular snapshot succeed where it must refuse. On a
+    // loaded runner that window is wide enough to hit: the arms passed on two runs of a branch and
+    // failed on a third whose only diff was two Python files (#2237).
+    //
+    // This does not weaken the arms. snapshot_guest_waits is the instrument under test, so a genuine
+    // failure to register never reaches 2, the loop times out, and the count arm reddens exactly as
+    // it does today -- the loop removes a window, it cannot manufacture a pass.
+    for (int i = 0; i < 2000; ++i) {
+        nested_wait_count = snapshot_guest_waits(worker_tid, nested_waits,
+                                                 sizeof(nested_waits) / sizeof(nested_waits[0]));
+        if (nested_wait_count >= 2) break;
+        Sleep(1);
+    }
     bool nested_has_outer = false;
     bool nested_has_distinct_inner = false;
     for (size_t i = 0; i < nested_wait_count && i < 4; ++i) {


### PR DESCRIPTION
test(win): gate the nested-wait arms on the registration, not on a flag raised before it

`test_win_exception_delivery`'s nested-wait arms sampled the guest wait registry
after spinning on `nested_wait_ready` -- a flag the guest handler raises TWO
statements before the `interruptible_cond_wait` that registers the inner wait
(`test_win_exception_delivery.cpp:91` vs `:93`). Between them the handler still
has to test its loop condition, enter the call, and get through
`consume_cond_wait_failure` and `cond_slot_for`, which scans up to 4096 slots and
may CAS. A preemption anywhere in there and the sampler sees one wait, not two:

  :947  requires nested_wait_count == 2 and a distinct inner object  -> fails
  :950  requires the singular snapshot to REFUSE on ambiguity, but with
        one wait it succeeds                                         -> fails
  :936  still passes, because the flag genuinely is set

which is exactly the signature CI reported.

Observed
--------
Windows MinGW, run 31169473385, job 92837774824:

    100/164 Test #100: win_exception_delivery ...............***Failed  3.70 sec
      [FAIL] nested snapshot reports both active waits without choosing an
             arbitrary current slot
      [FAIL] singular wait snapshot rejects nested ambiguity

Passed on the two immediately preceding runs of the SAME branch (92814027401,
92834898004), whose only diff was two Python files under tools/revision/ -- so
not a code regression, and intermittent, as a race should be.

Reproduced locally rather than inferred
---------------------------------------
This host wins the race every time, so the window was widened deliberately
(a temporary `Sleep(200)` between the flag and the wait) and both gates measured
against it:

    widened window, registration gate   exit=0  == PASS ==
    widened window, flag-only gate      exit=1  [FAIL] nested snapshot reports
                                                       both active waits ...
                                                [FAIL] singular wait snapshot
                                                       rejects nested ambiguity

Same two arms, same order. The perturbation is not committed; it exists to make
the mechanism falsifiable on a host that otherwise cannot show it.

The fix
-------
Spin until `snapshot_guest_waits` reports the second registration, then assert.
This does not weaken the arms: `snapshot_guest_waits` IS the instrument under
test, so a genuine failure to register never reaches 2, the loop times out, and
the count arm reddens exactly as it does today. The loop removes a window; it
cannot manufacture a pass.

Deliberately NOT changed: the later `nested_wait_returned` gate at :954. It looks
like the same shape and is not -- `unregister_wait` runs at `sync_futex.cpp:336`,
before `interruptible_cond_wait` returns, so by the time the handler sets that
flag the inner wait is already gone and there is no window to lose.

Verification
------------
  Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo:
    ./test_win_exception_delivery.exe -> == PASS ==, exit 0

Fixes #2237

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
