### PR TITLE
perf(render): hoist the three per-draw getenv calls out of build_bds (2.6%, measured)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4521,8 +4521,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             pending_timing.texture_ms += elapsed;
                             const uint64_t detail_min_submit = PROSPER_ENV_VALUE("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT")
                                 ? strtoull(PROSPER_ENV_VALUE("PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT"), nullptr, 0) : 0;
-                            if (const char* mode = getenv("PROSPER_RENDER_TIMING");
-                                mode && strcmp(mode, "detail") == 0 &&
+                            // render_timing_detail is the SAME hoist #2214 introduced, already used
+                            // at the sibling site a few lines up; this one was missed. It is inside
+                            // `if (timing_enabled)`, so it costs a normal run nothing -- but it made
+                            // an F8 capture pay a getenv per resource, inflating the enclosing totals
+                            // the capture then reports. An instrument that charges for being read.
+                            if (render_timing_detail &&
                                 static_cast<uint64_t>(g_this_submit) >= detail_min_submit) {
                                 static uint64_t detail_lines = 0;
                                 if ((elapsed >= 0.5 || resource_persistent_invalidation ||
@@ -4616,11 +4620,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             // Poison mode keeps the draw running while making invalid bindings visually/numerically
             // unmistakable: magenta/cyan texels for images and NaN-like dwords for buffers. Missing,
             // duplicate, wrong-type, and undersized bindings are replaced from the reflected manifest.
-            auto poison_R = [](std::vector<prosper::test::FrameResource>& resources,
+            // Read once per submit, not once per call. poison_R is invoked TWICE per draw (VS and
+            // PS), so at 2,179 draws in a submit its getenv was 4,358 calls -- and on Windows
+            // getenv takes a process-wide lock and walks the environment block, which is why #2214
+            // measured +43% from removing exactly this shape from the per-resource path.
+            //
+            // Hoisted rather than wrapped in PROSPER_ENV_VALUE, and the difference is not stylistic:
+            // test_gpu_capture_render.cpp and test_shader_resources.cpp ARM this variable at runtime
+            // between phases, and a process-lifetime cache would not observe the second write. Those
+            // tests would not fail -- they would go VACUOUS and keep printing [ok] against a stale
+            // value, which is the #2214 defect that `cached_env_arming_logic` now gates. A per-submit
+            // hoist keeps every runtime write observable from the next submit on.
+            const char* const descriptor_validate_mode = getenv("PROSPER_DESCRIPTOR_VALIDATE");
+            auto poison_R = [descriptor_validate_mode](
+                               std::vector<prosper::test::FrameResource>& resources,
                                const std::vector<uint32_t>& spirv,
                                const prosper::gpu::ShaderResourceTable* table,
                                uint32_t set, prosper::gpu::SpirvShaderStage stage) {
-                const char* mode = getenv("PROSPER_DESCRIPTOR_VALIDATE");
+                const char* mode = descriptor_validate_mode;
                 if (!mode || strcmp(mode, "poison")) return;
                 auto report = prosper::gpu::validate_spirv_descriptor_interface(spirv, table, set, stage, false);
                 static const uint8_t poison_tex[16] = {
@@ -4784,6 +4801,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             };
             auto build_bds = [&](const std::vector<const prosper::gpu::DrawItem*>& group) {
                 std::vector<prosper::test::BackendDraw> bds;
+                // Once per call, not once per draw -- see the note on descriptor_validate_mode above
+                // for why this is a hoist and not a PROSPER_ENV_* cache (test_eop_write.cpp arms
+                // PROSPER_GFXLOG at runtime, and a cached read would make its arms vacuous).
+                const bool gfxlog = getenv("PROSPER_GFXLOG") != nullptr;
                 for (const auto* itp : group) {
                     const auto& it = *itp;
                     if (draw_is_skipped(it.draw_index)) continue;
@@ -4839,7 +4860,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // Indexed draw: hand the executor-fetched index data to the backend (vkCmdDrawIndexed).
                     // Skipped under REFVS — the reference VS is a 3-vertex non-indexed fullscreen triangle.
                     if (!refvs) bd.indices = it.indices;
-                    if (getenv("PROSPER_GFXLOG")) fprintf(stderr,
+                    if (gfxlog) fprintf(stderr,
                         "[render] item %zu: %zu resources vcount=%u instances=%u nidx=%zu topo=%u mask=0x%x blend=%d\n",
                         bds.size(), bd.R.size(), bd.vcount, bd.instance_count, bd.indices.size(), it.ps.topology,
                         it.ps.color_write_mask, (int)it.ps.blend_enable);


### PR DESCRIPTION
perf(render): hoist the three per-draw getenv calls out of build_bds

Worth 2.6% of a heavy submit. Saying that up front because the obvious
framing -- "#2214 got +43% from this exact shape" -- is wrong here, and I
believed it until I measured what a call costs.

The calls
---------
Three getenv survive #2214 on the normal per-draw path:

  live_renderer.cpp:4842  getenv("PROSPER_GFXLOG")             1 per draw
  poison_R :4623          getenv("PROSPER_DESCRIPTOR_VALIDATE") 2 per draw
                          (called once for VS, once for PS -- :4837, :4838)

poison_R is the larger of the two and is the one I missed first.

A fourth, :4523 (PROSPER_RENDER_TIMING), sits inside `if (timing_enabled)`
so it costs a normal run nothing -- but it made an F8 capture pay a getenv
per RESOURCE, inflating the totals the capture then reports. An instrument
that charges for being read. It now uses `render_timing_detail`, which is
the same hoist #2214 introduced and which is already used at the sibling
site four lines above; this one was simply missed.

Hoisted, NOT cached, and that is not a style choice
---------------------------------------------------
PROSPER_ENV_ON/PROSPER_ENV_VALUE sample getenv once per process. Both names
here are ARMED AT RUNTIME by tests -- test_eop_write.cpp writes
PROSPER_GFXLOG; test_gpu_capture_render.cpp and test_shader_resources.cpp
write PROSPER_DESCRIPTOR_VALIDATE. Caching them would not have failed those
tests. It would have made them VACUOUS: the assertion still holds against
the stale value and the arm keeps printing [ok]. That is the #2214 defect
`cached_env_arming_logic` exists to catch, and it is what the gate would
have said if I had reached for the macro.

A per-submit hoist keeps every runtime write observable from the next
submit onward, which is the granularity the tests actually arm at.

What it is worth, measured
--------------------------
getenv on this host, 300,000 calls, 80 variables / 4,618 bytes:

    miss (absent name)   331.65 ms / 300000 = 1.105 us per call
    hit  (PATH present)  221.57 ms / 300000 = 0.739 us per call

The miss arm applies -- nobody sets PROSPER_GFXLOG while playing, and an
absent name walks the whole block.

    3 calls/draw x 2179 draws/submit = 6,537 calls = 7.23 ms/submit
    against the 274 ms/submit measured on #2215  = 2.64%

Per draw: 3.3 us of the 35.7 us that build_resources costs.

The A/B I ran first was void, and its control says so
-----------------------------------------------------
Two 100 s `screenshot` runs on PPSA25009, same frontend both arms, compared
at matched submit counts, read naively as "-19% total":

    submits   total base->fix    build_resources    backend
       650   16.52 -> 13.39     2.80 -> 2.74       5.15 -> 3.75
      1150   15.41 -> 14.19     2.58 -> 2.46       4.82 -> 4.22
      1400   15.15 -> 14.58     2.51 -> 2.18       4.76 -> 4.51

`backend` is a control channel -- this diff cannot touch it, since both hot
sites are inside build_bds, which is timed as build_resources. It moved
5-32%, consistently MORE than the channel that changed. A control that moves
more than the treatment means the noise floor exceeds the effect, so the run
is void as evidence in either direction. The arms also reached different
submit counts (1425 vs 1575), i.e. different scenes.

The microbenchmark is quoted instead because it measures the thing itself
rather than inferring it through a shared, loaded box.

Where the frame rate actually is
--------------------------------
If getenv is 3.3 us of 35.7 us per draw, the other ~32 us is the target and
it is not environment lookups. Filed as #2239 with the three candidates
(the per-draw index-vector COPY at :4841, the per-draw build_R at :4831, and
validate_runtime_descriptor_contract twice per draw) and with the reason a
targeted timer beats another route A/B here.

Verification
------------
  Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo -- reported below.
  python prosper/tools/env/check_cached_env.py prosper -> all checks passed
    ("no cached variable is armed by a test"), which is the gate that would
    have rejected the caching version of this change.

Refs #2215, #2239

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
