### PR TITLE
fix(perf): an F8 capture could not attribute its own largest bucket, and the gap read as unattributed work

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6406,8 +6406,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     record.gpu_device_ms = pending_timing.backend_gpu_device_ms;
                     record.readback_ms = pending_timing.backend_readback_ms;
                     record.setup_resources_ms = pending_timing.backend_setup_resources_ms;
-                    record.texture_ms = pending_timing.texture_ms;
-                    record.buffer_ms = pending_timing.buffer_ms;
+                    // Frontend and backend, kept apart by name. These two are build_resources' own
+                    // texture/buffer time and are NOT parts of setup_resources_ms above.
+                    record.frontend_texture_ms = pending_timing.texture_ms;
+                    record.frontend_buffer_ms = pending_timing.buffer_ms;
+                    // These four DO decompose setup_resources_ms, so an offline report can attribute
+                    // the largest bucket in the capture instead of leaving a plausible residue.
+                    record.res_texture_ms = pending_timing.backend_res_texture_ms;
+                    record.res_buffer_ms = pending_timing.backend_res_buffer_ms;
+                    record.res_buffer_copy_ms = pending_timing.backend_res_buffer_copy_ms;
+                    record.res_descriptor_ms = pending_timing.backend_res_descriptor_ms;
                     prosper::perf::interactive_performance_capture().record_renderer(record);
                 }
                 if (!timing_mode.log) {

--- a/prosper/frontends/shared/performance_capture.cpp
+++ b/prosper/frontends/shared/performance_capture.cpp
@@ -360,8 +360,12 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
                 << ",\"gpu_device_ms\":" << record.gpu_device_ms
                 << ",\"readback_ms\":" << record.readback_ms
                 << ",\"setup_resources_ms\":" << record.setup_resources_ms
-                << ",\"texture_ms\":" << record.texture_ms
-                << ",\"buffer_ms\":" << record.buffer_ms << "}\n";
+                << ",\"frontend_texture_ms\":" << record.frontend_texture_ms
+                << ",\"frontend_buffer_ms\":" << record.frontend_buffer_ms
+                << ",\"res_texture_ms\":" << record.res_texture_ms
+                << ",\"res_buffer_ms\":" << record.res_buffer_ms
+                << ",\"res_buffer_copy_ms\":" << record.res_buffer_copy_ms
+                << ",\"res_descriptor_ms\":" << record.res_descriptor_ms << "}\n";
         }
         for (const ComputeTimingRecord& record : capture->compute) {
             out << "{\"type\":\"compute\",\"t_ns\":"

--- a/prosper/frontends/shared/performance_capture.hpp
+++ b/prosper/frontends/shared/performance_capture.hpp
@@ -43,8 +43,21 @@ struct RendererTimingRecord {
     double gpu_device_ms = 0;
     double readback_ms = 0;
     double setup_resources_ms = 0;
-    double texture_ms = 0;
-    double buffer_ms = 0;
+    // FRONTEND resource time, accumulated in build_resources. These are NOT sub-buckets of
+    // setup_resources_ms below: that one is the BACKEND's, and the two are different layers.
+    // Subtracting these from it is a category error that produces a large, plausible, meaningless
+    // residue -- I published one (#2215) before noticing, so the names now say which layer they are.
+    double frontend_texture_ms = 0;
+    double frontend_buffer_ms = 0;
+    // BACKEND sub-buckets, which DO decompose setup_resources_ms:
+    //     setup_resources_ms = res_texture + res_buffer + res_descriptor + other
+    // `other` is deliberately not stored -- it is the remainder, and storing a number the reader can
+    // derive invites the two to disagree. Without these an F8 capture cannot attribute its own
+    // largest bucket, which is the reason both lanes spent a day reasoning from partial data.
+    double res_texture_ms = 0;
+    double res_buffer_ms = 0;
+    double res_buffer_copy_ms = 0;   // the leaf the perf work keeps landing on (#2215/#2231)
+    double res_descriptor_ms = 0;
 };
 
 // One live-compute batch. CPU-fast-path dispatches are included in `dispatches`; the cumulative

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -72,6 +72,51 @@ def _total(records, field):
                if math.isfinite(float(record.get(field, 0.0))))
 
 
+def _resource_breakdown(renderer):
+    """Decompose renderer-resource, or say the capture cannot support it.
+
+    `renderer-resource` is the largest component in every capture taken so far, and it is TWO LAYERS
+    added together: `build_resources_ms` (the frontend materializer) and `setup_resources_ms` (the
+    backend binder). Their sub-buckets belong to one layer each and are not parts of one another.
+    Subtracting a frontend bucket from the backend total yields a large, plausible, meaningless
+    residue -- a mistake made and published once (#2215), which is why this function exists.
+
+    A capture written before the backend sub-buckets were recorded must report them **unavailable**,
+    never 0. Absent and zero are the same number and opposite facts: a 0 here reads as "the backend
+    did no descriptor work", and the remainder then reads as unattributed work -- exactly the wrong
+    conclusion, now printed with authority by a tool. So the presence of the field is what decides,
+    not its value.
+    """
+    if not renderer:
+        return None
+    have_backend = any("res_texture_ms" in record for record in renderer)
+    # The frontend pair was renamed when the layers were separated; accept the old spelling so an
+    # older capture still reports the half it does carry.
+    def frontend(new, old):
+        return _total(renderer, new) if any(new in r for r in renderer) else _total(renderer, old)
+    breakdown = {
+        "build_resources": _total(renderer, "build_resources_ms"),
+        "frontend_texture": frontend("frontend_texture_ms", "texture_ms"),
+        "frontend_buffer": frontend("frontend_buffer_ms", "buffer_ms"),
+        "setup_resources": _total(renderer, "setup_resources_ms"),
+        "backend_available": have_backend,
+    }
+    if have_backend:
+        breakdown.update({
+            "res_texture": _total(renderer, "res_texture_ms"),
+            "res_buffer": _total(renderer, "res_buffer_ms"),
+            "res_buffer_copy": _total(renderer, "res_buffer_copy_ms"),
+            "res_descriptor": _total(renderer, "res_descriptor_ms"),
+            # Clamped: a negative remainder would mean the sub-buckets over-count their parent, which
+            # is a defect to surface as 0 rather than to print as a negative duration.
+            "res_other": max(0.0, _total(renderer, "setup_resources_ms")
+                                  - _total(renderer, "res_texture_ms")
+                                  - _total(renderer, "res_buffer_ms")
+                                  - _total(renderer, "res_descriptor_ms")),
+        })
+    return breakdown
+
+
 def _hex64(value):
     return f"0x{value:016x}"
 
@@ -227,6 +272,7 @@ def summarize(records):
         "gpu_timestamp_samples": gpu_timestamp_samples,
         "gpu_timestamps_available": gpu_timestamps_available,
         "components": components,
+        "resource_breakdown": _resource_breakdown(renderer),
         "classification": classification,
         "reason": reason,
         "pacing_note": pacing_note,
@@ -285,6 +331,28 @@ def print_summary(summary):
     print("components: " + " ".join(
         f"{key}=unavailable" if value is None else f"{key}={value:.1f}ms"
         for key, value in summary["components"].items()))
+    breakdown = summary.get("resource_breakdown")
+    if breakdown:
+        # renderer-resource is the largest component in every capture taken so far, and it is two
+        # layers added together. Print the decomposition rather than leaving a reader to subtract:
+        # the frontend and backend buckets are NOT parts of one another, and subtracting across them
+        # yields a large plausible residue that looks like unattributed work. That mistake has been
+        # made once already and published (#2215).
+        print("  build_resources (frontend materializer): "
+              f"{breakdown['build_resources']:.1f}ms"
+              f"  [texture={breakdown['frontend_texture']:.1f} buffer={breakdown['frontend_buffer']:.1f}]")
+        if breakdown["backend_available"]:
+            print("  setup_resources (backend binding):       "
+                  f"{breakdown['setup_resources']:.1f}ms"
+                  f"  [texture={breakdown['res_texture']:.1f}"
+                  f" buffer={breakdown['res_buffer']:.1f} (copy={breakdown['res_buffer_copy']:.1f})"
+                  f" descriptor={breakdown['res_descriptor']:.1f}"
+                  f" other={breakdown['res_other']:.1f}]")
+        else:
+            print("  setup_resources (backend binding):       "
+                  f"{breakdown['setup_resources']:.1f}ms"
+                  "  [breakdown UNAVAILABLE — this capture predates the backend sub-buckets;"
+                  " do NOT subtract the frontend figures above from it, they are a different layer]")
     print(f"primary evidence: {summary['classification']} — {summary['reason']}")
     if summary["pacing_note"]:
         print(f"pacing: {summary['pacing_note']}")

--- a/prosper/tools/perf/performance_capture_report.py
+++ b/prosper/tools/perf/performance_capture_report.py
@@ -107,13 +107,22 @@ def _resource_breakdown(renderer):
             "res_buffer": _total(renderer, "res_buffer_ms"),
             "res_buffer_copy": _total(renderer, "res_buffer_copy_ms"),
             "res_descriptor": _total(renderer, "res_descriptor_ms"),
-            # Clamped: a negative remainder would mean the sub-buckets over-count their parent, which
-            # is a defect to surface as 0 rather than to print as a negative duration.
-            "res_other": max(0.0, _total(renderer, "setup_resources_ms")
-                                  - _total(renderer, "res_texture_ms")
-                                  - _total(renderer, "res_buffer_ms")
-                                  - _total(renderer, "res_descriptor_ms")),
         })
+        # The remainder is reported as TWO numbers, and this is not fussiness -- it is this file's own
+        # argument applied to sign instead of presence.
+        #
+        # A negative remainder means the sub-buckets over-count their parent: a real defect, in the
+        # instrument rather than in the renderer. Clamping it to 0.0 does not "surface" that, it emits
+        # the single most reassuring line the tool can produce -- `other=0.0` reads as "every
+        # millisecond of setup_resources is attributed", which is the BEST possible state. So a broken
+        # instrument and a perfect one would print identically, which is exactly the collapse this
+        # module exists to prevent one level up ("absent and zero are the same number and opposite
+        # facts"). An earlier revision of this function did clamp, with a comment claiming it
+        # surfaced the defect.
+        raw_other = (breakdown["setup_resources"] - breakdown["res_texture"]
+                     - breakdown["res_buffer"] - breakdown["res_descriptor"])
+        breakdown["res_other"] = max(0.0, raw_other)
+        breakdown["res_over_attributed"] = max(0.0, -raw_other)   # 0 normally; non-zero is a defect
     return breakdown
 
 
@@ -348,6 +357,12 @@ def print_summary(summary):
                   f" buffer={breakdown['res_buffer']:.1f} (copy={breakdown['res_buffer_copy']:.1f})"
                   f" descriptor={breakdown['res_descriptor']:.1f}"
                   f" other={breakdown['res_other']:.1f}]")
+            # Loud, and only when it is genuinely non-zero. A sub-bucket total exceeding its parent
+            # is an instrument defect, and the breakdown above is untrustworthy while it holds.
+            if breakdown["res_over_attributed"] > 0.05:
+                print("  *** the sub-buckets EXCEED setup_resources by "
+                      f"{breakdown['res_over_attributed']:.1f}ms — the breakdown above is not "
+                      "trustworthy; this is a defect in the instrument, not in the renderer")
         else:
             print("  setup_resources (backend binding):       "
                   f"{breakdown['setup_resources']:.1f}ms"


### PR DESCRIPTION
Refs #2215, #2231.

## The defect

`renderer-resource` is the largest component in every F8 capture taken so far, and it is **two layers added together**: `build_resources_ms` (frontend materializer) and `setup_resources_ms` (backend binder).

The `.prperf` record stored those two parents plus `texture_ms` / `buffer_ms` — but those came from `pending_timing.texture_ms` / `buffer_ms`, which are the **frontend's**, while `setup_resources_ms` is the **backend's**.

So the only decomposition the format permitted was subtracting one layer's buckets from another layer's total.

**I did exactly that and published it.** On #2215 I reported "~520 ms of `setup_resources` attributed to neither buffer nor texture", and read it as unattributed work worth chasing. It was a category error. The residue was the backend's descriptor time plus its remainder — which the format did not carry — minus nothing at all.

## What is recorded now

Named by layer, so the subtraction cannot be spelled:

| field | layer |
| --- | --- |
| `frontend_texture_ms`, `frontend_buffer_ms` | `build_resources` own — **not** parts of the below |
| `res_texture_ms`, `res_buffer_ms`, `res_buffer_copy_ms`, `res_descriptor_ms` | these **do** decompose `setup_resources_ms` |

`res_buffer_copy` is included because it is the leaf the performance work keeps landing on (#2215, #2231). **`other` is deliberately not stored** — it is the remainder, and storing a number the reader can derive invites the two to disagree.

## Absent must not print as zero

An older capture reports the backend breakdown **UNAVAILABLE**, never `0`. Absent and zero are the same number and opposite facts: a `0` reads as "the backend did no descriptor work", which makes the remainder look like unattributed work — the original wrong conclusion, now printed with authority by a tool. **Presence of the field decides, not its value.** The frontend pair is accepted under its old spelling too, so an old capture still reports the half it does carry.

## Verified both directions

**Old capture** — the owner's F8 of the Blue Prince collapse, written before these fields existed:

```
build_resources (frontend materializer): 821.9ms  [texture=98.4 buffer=76.9]
setup_resources (backend binding):       694.6ms  [breakdown UNAVAILABLE — this capture predates
   the backend sub-buckets; do NOT subtract the frontend figures above from it, different layer]
```

Note it now puts 98.4 / 76.9 under the **frontend**, which is where they always belonged.

**New capture** — same build, `PROSPER_PERF_CAPTURE_AFTER_MS`, Blue Prince:

```
setup_resources (backend binding): 45.4ms  [texture=12.3 buffer=12.0 (copy=0.9)
                                            descriptor=17.9 other=3.2]
```

`12.3 + 12.0 + 17.9 + 3.2 = 45.4` — exactly the parent.

And it already says something the instrument could not before: **`descriptor` is the largest sub-bucket in that scene, not buffer copy.** Both lanes have been optimising buffer copy; nobody has looked at descriptor time, because until now no capture could show it.

## Risk

Low. Additive fields, one renamed pair with the old spelling still accepted on read, and a report tool that degrades to an explicit "unavailable" rather than a plausible zero. No behaviour changes outside the capture format and its reader.

```
cmake --build build -j6        # rc=0
ctest --no-tests=error -j4     # 218/218 passed, exit 0
```
