### PR TITLE
fix(recompiler): DS_WRITE2_B64 with equal offsets is ONE write of DATA0, not two

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10712,9 +10712,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 b.lds_store(idx0, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
                 b.lds_store(b.ibin(Op_IAdd, idx0, b.uconst(1)), vread(in.src[1].value + 1),
                             rs.exec_narrowed, rs.exec);
-                b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
-                b.lds_store(b.ibin(Op_IAdd, idx1, b.uconst(1)), vread(in.src[2].value + 1),
-                            rs.exec_narrowed, rs.exec);
+                // OFFSET0 == OFFSET1 selects ONE address: the hardware performs a single write and
+                // uses DATA0 only (RDNA2 ISA 70648 §10.4.3). Writing DATA1 as well leaves the later
+                // store winning, so a subsequent LDS read observes DATA1 where hardware preserves
+                // DATA0 -- silent wrong data rather than a fault. The ds_write2_b32 case above
+                // already guards this; the 64-bit variant did not (#1473).
+                if ((in.literal & 0xFFu) != ((in.literal >> 8) & 0xFFu)) {
+                    b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
+                    b.lds_store(b.ibin(Op_IAdd, idx1, b.uconst(1)), vread(in.src[2].value + 1),
+                                rs.exec_narrowed, rs.exec);
+                }
                 return true;
             }
             if (in.opcode == 0x0e) {                    // ds_write2_b32: two dwords at offset0/offset1

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10724,16 +10724,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            if (in.opcode == 0x0e) {                    // ds_write2_b32: two dwords at offset0/offset1
-                // AMD RDNA2 ISA 12.13: DATA0/1 go to ADDR + OFFSET0/1 * 4. The packed
-                // 8-bit offsets have the same layout as DS_READ2_B32 below.
-                const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
-                const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst(in.literal & 0xFFu));
-                const uint32_t idx1 = b.ibin(Op_IAdd, base, b.uconst((in.literal >> 8) & 0xFFu));
-                b.lds_store(idx0, vread(in.src[1].value), rs.exec_narrowed, rs.exec);
-                b.lds_store(idx1, vread(in.src[2].value), rs.exec_narrowed, rs.exec);
-                return true;
-            }
+            // NOTE: a SECOND ds_write2_b32 (0x0e) block used to sit here, unreachable because the
+            // handler above claims 0x0e first and returns. It was a duplicate carrying the
+            // PRE-FIX behaviour -- both stores, no equal-offset guard -- so the hazard was never
+            // that it ran. It was that adding any condition to the reachable block (a wave-size
+            // check, an encoding refinement) would have silently handed 0x0e to a copy with the
+            // #1473 defect still in it, and the tests would have kept passing. Deleted (#1473).
             if (in.opcode == 0x77) {                    // ds_read2_b64: two pairs at scaled offsets
                 const uint32_t base = b.ibin(Op_ShiftRightLogical, vread(in.src[0].value), b.uconst(2));
                 const uint32_t idx0 = b.ibin(Op_IAdd, base, b.uconst((in.literal & 0xFFu) * 2u));

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1888,6 +1888,37 @@ int main() {
     CHECK(got32b.size()==1 && std::fabs(got32b[0]-10.0f)<1e-3f,
           "kernel 32b wide LDS stores and loads preserve both dwords of both VGPR pairs");
 
+    // Kernel 32b64eq: DS_WRITE2_B64 with OFFSET0 == OFFSET1 selects ONE address, so the hardware
+    // performs a single write and uses DATA0 only (RDNA2 ISA 70648 §10.4.3). The lowering used to
+    // store both pairs unconditionally, leaving DATA1 as the later write and therefore the winner --
+    // a subsequent read observes DATA1 where hardware preserves DATA0. Silent wrong data, no fault.
+    // The DS_WRITE2_B32 sibling above already had this guard; the 64-bit variant did not (#1473).
+    //
+    // The two pairs are chosen so the defect and the fix cannot produce the same answer:
+    //   DATA0 = v[1:2] = (1.0,  2.0)  -> read back and summed = 3.0   (correct)
+    //   DATA1 = v[3:4] = (4.0, -4.0)  -> read back and summed = 0.0   (the defect)
+    // A pair summing to the same value either way would pass whatever the lowering did.
+    const uint32_t code32b64eq[] = {
+        0x7e000280u,                // v_mov_b32 v0, 0        LDS address
+        0x7e0202f2u,                // v_mov_b32 v1, 1.0      DATA0 lo
+        0x7e0402f4u,                // v_mov_b32 v2, 2.0      DATA0 hi
+        0x7e0602f6u,                // v_mov_b32 v3, 4.0      DATA1 lo
+        0x7e0802f7u,                // v_mov_b32 v4, -4.0     DATA1 hi
+        0xd9380000u, 0x00030100u,   // ds_write2_b64 v0, v[1:2], v[3:4] offset0:0 offset1:0
+        0xbf8a0000u,                // s_waitcnt lgkmcnt(0)
+        0xd9d80000u, 0x05000000u,   // ds_read_b64 v[5:6], v0
+        0x060a0d05u,                // v_add_f32 v5, v5, v6
+        0xbf810000u,                // s_endpgm
+    };
+    std::vector<uint32_t> spv32b64eq = recompile_valu(
+        code32b64eq, sizeof(code32b64eq)/sizeof(code32b64eq[0]), 0, 5);
+    CHECK(!spv32b64eq.empty(),
+          "recompiled kernel 32b64eq (DS_WRITE2_B64 equal offsets) -> SPIR-V");
+    std::vector<float> got32b64eq = prosper::test::run_compute(
+        spv32b64eq, std::vector<float>(1), 1, 1);
+    CHECK(got32b64eq.size()==1 && std::fabs(got32b64eq[0]-3.0f)<1e-3f,
+          "kernel 32b64eq DS_WRITE2_B64 equal offsets keep DATA0, not DATA1");
+
     // Kernel 32b2: Astro Bot's loading-surface producer uses DS_READ2_B32 twice, first with
     // offset0/1=(0,1) and then (16,17). Populate those exact LDS locations with integers 1..4,
     // execute the two live instruction words, and make both return pairs observable as sum=10.


### PR DESCRIPTION
Fixes #1473.

## The defect

`OFFSET0 == OFFSET1` selects a **single address**: the hardware performs one write and uses **DATA0 only** (RDNA2 ISA 70648 §10.4.3). The lowering at `rdna2_to_spirv.cpp:10708` stored both VGPR pairs unconditionally, so DATA1 was the later store and therefore the winner. A subsequent LDS read observes DATA1 where hardware preserves DATA0 — **wrong data, silently, with no fault and no diagnostic.**

## Why it survived a month

The `DS_WRITE2_B32` case **four lines above** already carried exactly this guard:

```c
if ((in.literal & 0xFFu) != ((in.literal >> 8) & 0xFFu))
    b.lds_store(idx1, ...);
```

One variant fixed, the sibling missed. The fix here is that condition applied to both dwords of the second pair.

That asymmetry is worth noting for triage: it is what a sweep **by opcode** finds and a sweep **by symptom** does not — nothing about the b64 path looks wrong until you read it beside the b32 path.

## The regression

Executable, not structural, and the constants are chosen so the defect and the fix **cannot produce the same answer**:

| | value | read back and summed |
| --- | --- | ---: |
| DATA0 `v[1:2]` | (1.0, 2.0) | **3.0** — correct |
| DATA1 `v[3:4]` | (4.0, −4.0) | **0.0** — the defect |

A pair summing to the same value either way would have passed whatever the lowering did. The encoding is adapted from the existing `kernel 32b` `ds_write2_b64` test with only the packed offsets changed to be equal, so the instruction stream is known-good.

**Counter-armed** rather than assumed — with the guard removed, the new arm fails and nothing else does:

```
[ok]   recompiled kernel 32b64eq (DS_WRITE2_B64 equal offsets) -> SPIR-V
[FAIL] kernel 32b64eq DS_WRITE2_B64 equal offsets keep DATA0, not DATA1
```

## Verification

```
cmake --build build -j6        # rc=0
ctest --no-tests=error -j4     # 219/219 passed, exit 0
```

## Risk

Low, and asymmetric in the safe direction: the change only *removes* stores, and only in the case where the ISA says no second store occurs. A shader relying on the old behaviour would have been relying on prosper contradicting hardware.