### PR TITLE
diag(render): report buffer-reuse economics — the leaf that dominates the FMV collapse explained nothing

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1258,7 +1258,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 ? RenderClock::now() : RenderClock::time_point{};
             auto record_backend_timing = [&]
                 (const prosper::test::BackendRenderTimingStats& backend,
-                 const prosper::test::BackendPipelineCacheStats& pipelines) {
+                 const prosper::test::BackendPipelineCacheStats& pipelines,
+                 const prosper::test::BackendResourceReuseStats& reuse) {
                 pending_timing.backend_calls += backend.calls;
                 pending_timing.backend_draws += backend.draws;
                 pending_timing.backend_command_buffers += backend.command_buffers;
@@ -1289,6 +1290,51 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 pending_timing.backend_pipeline_bypasses += pipelines.bypasses;
                 pending_timing.backend_pipeline_entries = pipelines.entries;
                 pending_timing.backend_pipeline_evictions += pipelines.evictions;
+                // Buffer-copy economics. This leaf dominates the Blue Prince FMV collapse -- 539 ms
+                // of 802 ms of backend resource setup, 67% (#2215) -- and nothing could say WHY: the
+                // counters are collected per call and aggregated into the thread-local storage, and
+                // the ONLY consumers in the tree were assertions in test_multidraw_render.cpp. The
+                // sibling resource kind has reported its cache economics for ages
+                // ("[render-timing] texture_cache hits=... misses=..."), while buffers -- an order of
+                // magnitude more expensive in that regime -- reported nothing at all.
+                //
+                // Per SUBMIT rather than as a window mean, deliberately. The question is which of
+                // three mutually exclusive stories produces the copy volume, and they need different
+                // fixes, so an average across them answers none of it:
+                //   skipped_unique dominates -> buffer_identity == 0, nothing can dedup, fix upstream
+                //   skipped_large dominates  -> the 4 KiB hash-dedup cap is working as designed and
+                //                               the payloads are genuinely distinct; the fix is not
+                //                               dedup at all but not staging through a mapped copy
+                //   refs >> memo_hits        -> repeat references within one call are being missed
+                if (timing_enabled) {
+                    // CUMULATIVE, not a per-call snapshot. The first draft printed one call's
+                    // numbers at diag_should_print's ordinals (first 64, then powers of two) --
+                    // which is a UNIFORM sample of a heavily skewed distribution, so it could not
+                    // see the expensive calls by construction. The sampled calls summed to ~290 KB
+                    // per submit against 30 ms of measured copy: 290 KB cannot take 30 ms, and that
+                    // contradiction is the only reason the sampling flaw was caught.
+                    //
+                    // Totals cannot miss a call. The rate limit now controls how often the running
+                    // total is PRINTED, never which calls it counts.
+                    static uint64_t refs = 0, uniq = 0, memo = 0, hashed = 0, dwords = 0;
+                    static uint64_t skipped_large = 0, skipped_unique = 0, fallbacks = 0, calls = 0;
+                    refs += reuse.buffer_references;      uniq += reuse.unique_buffers;
+                    memo += reuse.buffer_ref_memo_hits;   hashed += reuse.buffer_hash_calls;
+                    dwords += reuse.buffer_hash_dwords;   fallbacks += reuse.buffer_upload_fallbacks;
+                    skipped_large += reuse.buffer_hash_skipped_large;
+                    skipped_unique += reuse.buffer_hash_skipped_unique;
+                    if (prosper::diag_should_print(++calls))
+                        fprintf(stderr,
+                                "[render-timing] buffer_reuse (cumulative over %llu backend calls) "
+                                "refs=%llu unique=%llu memo_hits=%llu hashed=%llu (%.1f MiB) "
+                                "skipped_large=%llu skipped_unique=%llu upload_fallbacks=%llu\n",
+                                (unsigned long long)calls, (unsigned long long)refs,
+                                (unsigned long long)uniq, (unsigned long long)memo,
+                                (unsigned long long)hashed, (double)dwords * 4.0 / (1024.0 * 1024.0),
+                                (unsigned long long)skipped_large,
+                                (unsigned long long)skipped_unique,
+                                (unsigned long long)fallbacks);
+                }
             };
             auto append_rtt_timing = [](std::string& output, const RttTimingRecord& record) {
                 const prosper::test::BackendRenderTimingStats& timing = record.timing;
@@ -5569,12 +5615,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const prosper::test::BackendPipelineCacheStats backend_pipeline_stats = timing_enabled
                         ? prosper::test::backend_pipeline_cache_stats()
                         : prosper::test::BackendPipelineCacheStats{};
+                    // Captured HERE, beside the pipeline stats, and PASSED IN -- not read inside
+                    // record_backend_timing. These are thread_local and published by the backend call;
+                    // reading them from wherever the recorder happens to run returns a different,
+                    // nearly empty instance. The first draft did exactly that and reported refs=11 for
+                    // a 2,102-draw submit -- the kind of small plausible number that gets believed.
+                    const prosper::test::BackendResourceReuseStats backend_reuse_stats = timing_enabled
+                        ? prosper::test::backend_resource_reuse_stats()
+                        : prosper::test::BackendResourceReuseStats{};
                     if (timing_enabled) {
                         pending_timing.build_resources_ms +=
                             std::chrono::duration<double, std::milli>(build_done - build_start).count();
                         pending_timing.backend_ms +=
                             std::chrono::duration<double, std::milli>(backend_done - build_done).count();
-                        record_backend_timing(backend_call_timing, backend_pipeline_stats);
+                        record_backend_timing(backend_call_timing, backend_pipeline_stats,
+                                          backend_reuse_stats);
                         pending_timing.color_target_writes += color_target_call.writes;
                         pending_timing.color_target_write_hits += color_target_call.write_hits;
                         pending_timing.color_target_sample_hits += color_target_call.sampled_hits;
@@ -6099,12 +6154,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 const prosper::test::BackendPipelineCacheStats backend_pipeline_stats = timing_enabled
                     ? prosper::test::backend_pipeline_cache_stats()
                     : prosper::test::BackendPipelineCacheStats{};
+                // Captured HERE, beside the pipeline stats, and PASSED IN -- not read inside
+                // record_backend_timing. These are thread_local and published by the backend call;
+                // reading them from wherever the recorder happens to run returns a different,
+                // nearly empty instance. The first draft did exactly that and reported refs=11 for
+                // a 2,102-draw submit -- the kind of small plausible number that gets believed.
+                const prosper::test::BackendResourceReuseStats backend_reuse_stats = timing_enabled
+                    ? prosper::test::backend_resource_reuse_stats()
+                    : prosper::test::BackendResourceReuseStats{};
                 if (timing_enabled) {
                     pending_timing.build_resources_ms +=
                         std::chrono::duration<double, std::milli>(build_done - build_start).count();
                     pending_timing.backend_ms +=
                         std::chrono::duration<double, std::milli>(backend_done - build_done).count();
-                    record_backend_timing(backend_call_timing, backend_pipeline_stats);
+                    record_backend_timing(backend_call_timing, backend_pipeline_stats,
+                                          backend_reuse_stats);
                 }
                 // RTT (#167): cache these rendered pixels under this submit's render-target base, so a later
                 // composite pass that samples that address gets the scene we drew (not empty guest memory).

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1318,21 +1318,27 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // total is PRINTED, never which calls it counts.
                     static uint64_t refs = 0, uniq = 0, memo = 0, hashed = 0, dwords = 0;
                     static uint64_t skipped_large = 0, skipped_unique = 0, fallbacks = 0, calls = 0;
+                    static uint64_t large_dwords = 0, upload_bytes = 0;
                     refs += reuse.buffer_references;      uniq += reuse.unique_buffers;
                     memo += reuse.buffer_ref_memo_hits;   hashed += reuse.buffer_hash_calls;
                     dwords += reuse.buffer_hash_dwords;   fallbacks += reuse.buffer_upload_fallbacks;
                     skipped_large += reuse.buffer_hash_skipped_large;
                     skipped_unique += reuse.buffer_hash_skipped_unique;
+                    large_dwords += reuse.buffer_skipped_large_dwords;
+                    upload_bytes += reuse.buffer_upload_bytes;
                     if (prosper::diag_should_print(++calls))
                         fprintf(stderr,
                                 "[render-timing] buffer_reuse (cumulative over %llu backend calls) "
                                 "refs=%llu unique=%llu memo_hits=%llu hashed=%llu (%.1f MiB) "
-                                "skipped_large=%llu skipped_unique=%llu upload_fallbacks=%llu\n",
+                                "skipped_large=%llu (%.1f MiB) skipped_unique=%llu "
+                                "COPIED=%.1f MiB upload_fallbacks=%llu\n",
                                 (unsigned long long)calls, (unsigned long long)refs,
                                 (unsigned long long)uniq, (unsigned long long)memo,
                                 (unsigned long long)hashed, (double)dwords * 4.0 / (1024.0 * 1024.0),
                                 (unsigned long long)skipped_large,
+                                (double)large_dwords * 4.0 / (1024.0 * 1024.0),
                                 (unsigned long long)skipped_unique,
+                                (double)upload_bytes / (1024.0 * 1024.0),
                                 (unsigned long long)fallbacks);
                 }
             };

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -423,6 +423,12 @@ struct BackendResourceReuseStats {
     uint64_t buffer_hash_skipped_unique = 0;
     uint64_t buffer_hash_skipped_large = 0;
     uint64_t buffer_ref_memo_hits = 0;
+    // Reference share is not byte share, and the cost here is BYTES. skipped_large at 9.3% of
+    // references says nothing on its own about how much of the copy volume those buffers are --
+    // they are large by definition, so their byte share is necessarily higher, but "higher" is not
+    // a number. These two make the conclusion readable instead of derivable (#2245 review).
+    uint64_t buffer_skipped_large_dwords = 0;   // payload that bypasses content dedup by size
+    uint64_t buffer_upload_bytes = 0;           // bytes actually memcpy'd into mapped staging
 };
 
 inline BackendResourceReuseStats& backend_resource_reuse_stats_storage() {
@@ -4828,6 +4834,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         backend_hash_stats_totals().hash_dwords += word_count;
                     } else if (shareable) {
                         ++resource_reuse_stats.buffer_hash_skipped_large;
+                        resource_reuse_stats.buffer_skipped_large_dwords += word_count;
                         ++backend_hash_stats_totals().skipped_large;
                     } else {
                         ++resource_reuse_stats.buffer_hash_skipped_unique;
@@ -4895,6 +4902,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         } else {
                             const ResourcePhaseTimer phase_copy(timing_enabled,
                                                                 &res_buffer_copy_ms);
+                            resource_reuse_stats.buffer_upload_bytes += static_cast<uint64_t>(bytes);
                             std::memcpy(static_cast<uint8_t*>(upload.mapped) + upload.offset,
                                         words, static_cast<size_t>(bytes));
                             upload.range = bytes;
@@ -6768,6 +6776,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         PROSPER_SUM_RESOURCE_STAT(buffer_hash_skipped_unique);
         PROSPER_SUM_RESOURCE_STAT(buffer_hash_skipped_large);
         PROSPER_SUM_RESOURCE_STAT(buffer_ref_memo_hits);
+        PROSPER_SUM_RESOURCE_STAT(buffer_skipped_large_dwords);
+        PROSPER_SUM_RESOURCE_STAT(buffer_upload_bytes);
 #undef PROSPER_SUM_RESOURCE_STAT
         aggregate_resources.persistent_pipeline_layout_entries =
             resources.persistent_pipeline_layout_entries;


### PR DESCRIPTION
Refs #2215, #2231. Takes the narrow piece Wren released on #2241.

## The gap

`buffer copy` is **539 ms of 802 ms** of backend resource setup in Blue Prince's FMV collapse — 67%, and 15% of the whole frame. **Nothing could say why.** The counters exist and are aggregated on every backend call; the only consumers in the tree were assertions in `test_multidraw_render.cpp`.

The asymmetry is stark: the sibling resource kind has reported its cache economics for ages (`texture_cache hits=… misses=…` at 2 ms/submit), while buffers at 39 ms/submit reported nothing.

## What it says

Blue Prince, cumulative over 16,384 backend calls:

```
refs=7,267,454  unique=1,428,929  memo_hits=5,838,525  hashed=754,403 (307.8 MiB)
skipped_large=673,079  skipped_unique=1,447  upload_fallbacks=0
```

**It self-checks exactly**: `5,838,525 + 754,403 + 673,079 + 1,447 = 7,267,454` — every reference on exactly one path, which is the arm to watch if these counters ever drift.

That resolves the three-way question, and it is the third answer:

| | | |
|---|---:|---|
| memo hits | **80.3%** | the per-call memo is doing its job |
| `skipped_unique` | **0.02%** | `buffer_identity` is fine — *not* an upstream identity problem |
| `skipped_large` | **9.3%** | large buffers, content dedup skipped **by design** |

1.43M unique uploads, ~87 per backend call. **The copies are not a dedup failure.** They are large, genuinely distinct payloads that the 4 KiB hash-dedup cap deliberately excludes — and that cap is correct, on the measurement that put it there (zero dedup hits across 556K hashed references).

**So the fix is not better dedup. It is not staging a large payload through a mapped `memcpy` at all.** That is a different piece of work and this PR does not attempt it; it establishes which of three fixes is the right one.

## Two instrument errors made and caught while building this

Both left comments behind, because both are reproducible mistakes rather than typos.

1. **Read the thread-local inside `record_backend_timing`** rather than capturing it beside the pipeline stats at the call site. Fixed by passing it in, exactly as `pipelines` already was.

2. **Printed one call's numbers at `diag_should_print`'s ordinals** — a *uniform* sample of a heavily skewed distribution, so it could not see the expensive calls by construction. The sampled calls summed to ~290 KB/submit against 30 ms of measured copy, and **290 KB cannot take 30 ms**. That contradiction is the only reason the flaw was caught. It is cumulative now: the rate limit controls how often the total is *printed*, never which calls it counts.

I also had to correct my own reasoning twice — "refs=11 for a 2,102-draw submit is impossible" compared a per-**call** number against a per-**submit** one (27.5 calls/submit; 43 × 27.5 matches draws exactly).

## Risk

Low. Diagnostic-only, behind `PROSPER_RENDER_TIMING`, no behaviour change with it unset. The accumulators are function-static and only read on the printing path.

```
cmake --build build -j6        # rc=0
ctest --no-tests=error -j4     # 219/219 passed, exit 0
```