### PR TITLE
fix(hle): scePthreadRwlockUnlock and reallocf both answered a failure as success or OOM

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -364,6 +364,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_reallocalign PRIVATE prosper_core)
   add_test(NAME reallocalign COMMAND test_reallocalign)
 
+  add_executable(test_reallocf tests/test_reallocf.cpp)
+  target_link_libraries(test_reallocf PRIVATE prosper_core)
+  add_test(NAME reallocf COMMAND test_reallocf)
+
   # #2081 FALSE SUCCESS: an unregistered NID answers the dispatcher's 0, which for an SCE_OK
   # contract is a success report over an out-parameter nothing wrote. Pure, no game dump.
   add_executable(test_false_success_nids tests/test_false_success_nids.cpp)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1163,7 +1163,13 @@ HLE(k_rwlock_wrlock)  {
 }
 HLE(k_rwlock_unlock)  {
     auto* g = ensure_rwlock(a0);
-    if (!g) return 0;
+    // EINVAL, matching every sibling rwlock entry point (rd/wr/tryrd/trywr and all four timed
+    // forms). ensure_rwlock returns null only for a null slot address or a failed allocation;
+    // neither is a successful unlock, and FreeBSD answers EINVAL for the first. Reporting 0 here
+    // told a guest that an unlock of a null handle had succeeded, hiding its bug behind ours —
+    // and made this the one rwlock call whose answer depended on which entry point was used.
+    // The two causes fold together because ensure_rwlock does not distinguish them (#2159).
+    if (!g) return 0x16;
     const int rc = rw_release(g);
     if (rc != 0) {
         if (rwlocklog() || !rwlock_unsafe_unlock())

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -319,11 +319,22 @@ HLE(h_free)    { guest_free_portable(P(a0)); return 0; }
 // CONFIDENCE: HIGH on the semantics — this is a published BSD interface with one definition, and
 // the PS5 libc lineage is FreeBSD. The argument order is realloc's, not an inference.
 //
-// The `a1` guard is not defensive noise: guest_realloc_portable(p, 0) already frees p and returns
-// NULL on both platforms, so freeing again there would be a double free. `P(a0)` guards the
-// realloc(NULL, n) case, where there is nothing to release. On Windows a pointer the header check
-// rejects reaches guest_windows_free, which re-validates the magic and refuses safely, so the BSD
-// rule needs no platform-specific exception.
+// The `a1` guard is not defensive noise, and the reason is a three-way platform split rather than
+// the two-way one an earlier revision of this comment claimed (CI on macOS corrected it):
+//
+//   glibc    realloc(p, 0) frees p and returns NULL
+//   Windows  guest_realloc_portable's `if (!size)` frees p and returns NULL, explicitly
+//   macOS    realloc(p, 0) returns a VALID minimum-size block and frees nothing
+//
+// C17 7.22.3.5 leaves the zero case implementation-defined, so all three conform. The guard is
+// correct under every one of them without a platform branch, because it keys on the RESULT rather
+// than on an assumption about it: where NULL comes back the block is already gone and `a1 == 0`
+// stops a double free; where a real block comes back `!r` is false and nothing is freed. Note this
+// means reallocf(p, 0) legitimately returns non-NULL on macOS — do not "fix" that to NULL.
+//
+// `P(a0)` guards the realloc(NULL, n) case, where there is nothing to release. On Windows a pointer
+// the header check rejects reaches guest_windows_free, which re-validates the magic and refuses
+// safely, so the BSD rule needs no platform-specific exception there either.
 HLE(h_reallocf) {
     void* p = P(a0);
     void* r = guest_realloc_portable(p, a1);

--- a/prosper/src/hle/hle_libc.cpp
+++ b/prosper/src/hle/hle_libc.cpp
@@ -309,6 +309,27 @@ HLE(h_malloc)  { return (uint64_t)(uintptr_t)guest_malloc_portable(a0); }
 HLE(h_calloc)  { return (uint64_t)(uintptr_t)guest_calloc_portable(a0, a1); }
 HLE(h_realloc) { return (uint64_t)(uintptr_t)guest_realloc_portable(P(a0), a1); }
 HLE(h_free)    { guest_free_portable(P(a0)); return 0; }
+// reallocf(ptr, size): realloc, except that the ORIGINAL block is freed if the resize fails. BSD
+// ships it precisely because `p = realloc(p, n)` leaks `p` on failure, so a caller of reallocf has
+// **delegated** the free-on-failure to libc and will not do it itself. Returning NULL without
+// freeing therefore leaks the original block on every failure path — and unregistered it did worse
+// than that, because the dispatcher's default 0 is a NULL return the caller reads as OOM, so a
+// resize that should have succeeded reported allocation failure (#2203).
+//
+// CONFIDENCE: HIGH on the semantics — this is a published BSD interface with one definition, and
+// the PS5 libc lineage is FreeBSD. The argument order is realloc's, not an inference.
+//
+// The `a1` guard is not defensive noise: guest_realloc_portable(p, 0) already frees p and returns
+// NULL on both platforms, so freeing again there would be a double free. `P(a0)` guards the
+// realloc(NULL, n) case, where there is nothing to release. On Windows a pointer the header check
+// rejects reaches guest_windows_free, which re-validates the magic and refuses safely, so the BSD
+// rule needs no platform-specific exception.
+HLE(h_reallocf) {
+    void* p = P(a0);
+    void* r = guest_realloc_portable(p, a1);
+    if (!r && p && a1) guest_free_portable(p);
+    return (uint64_t)(uintptr_t)r;
+}
 // reallocalign(ptr, size, alignment).
 //
 // CONFIDENCE: MED on the ARGUMENT ORDER, and deliberately not raised. The 3.20 library dump gives
@@ -804,6 +825,7 @@ void register_builtin_hle() {
     R("malloc", h_malloc);   R("calloc", h_calloc);   R("realloc", h_realloc); R("free", h_free);
     R("memalign", h_memalign); R("posix_memalign", h_posix_memalign); R("aligned_alloc", h_aligned_alloc);
     R("reallocalign", h_reallocalign);
+    R("reallocf", h_reallocf);   // YMZO9ChZb0E, libSceLibcInternal (#2203)
     // operator new / new[] (+ nothrow), and aligned variants
     R("_Znwm", h_new); R("_Znam", h_new);
     R("_ZnwmRKSt9nothrow_t", h_new_nothrow); R("_ZnamRKSt9nothrow_t", h_new_nothrow);

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -92,14 +92,11 @@ const Row kRows[] = {
     {"scePthreadRwlockInit",         "pthread_rwlock_init",         "#1984"},
     {"scePthreadRwlockRdlock",       "pthread_rwlock_rdlock",       "#2158"},
     {"scePthreadRwlockWrlock",       "pthread_rwlock_wrlock",       "#2158"},
-    // scePthreadRwlockUnlock is DELIBERATELY not probed with a null slot: it answers 0 there rather
-    // than EINVAL, which is the separate open defect #2159 (`k_rwlock_unlock` reaches
-    // `ensure_rwlock`'s null return and falls through to success) and NOT a gap in this rule. This
-    // sweep found that independently, on `a136bb93`, and must not paper over it — an arm asserting
-    // the current 0 would enshrine the bug, and an arm asserting EINVAL would fail for a reason this
-    // file is not about. Its Sony/POSIX encoding pairing is already guarded on a real failure, by
-    // test_rwlock_once.cpp's unmatched-unlock arms (encoded EPERM vs bare EPERM). Re-add the row
-    // here once #2159 lands.
+    // Re-added as the note above instructed: #2159 has landed, so a null slot now answers EINVAL
+    // here as it already did at every sibling entry point, and the row asserts the pairing on a real
+    // failure rather than enshrining the old 0. Before the fix this row is red for exactly the right
+    // reason — the Sony spelling returned 0 instead of the encoded 0x80020016.
+    {"scePthreadRwlockUnlock",       "pthread_rwlock_unlock",       "#2159"},
     {"scePthreadRwlockTryrdlock",    "pthread_rwlock_tryrdlock",    "#1984"},
     {"scePthreadRwlockTrywrlock",    "pthread_rwlock_trywrlock",    "#1984"},
     {"scePthreadRwlockTimedrdlock",  "pthread_rwlock_timedrdlock",  "#1984, separate POSIX body"},

--- a/prosper/tests/test_reallocf.cpp
+++ b/prosper/tests/test_reallocf.cpp
@@ -124,16 +124,35 @@ int main() {
     }
 
     // --- reallocf(p, 0) must not double-free -----------------------------------------------------
-    // guest_realloc_portable(p, 0) already frees p and returns NULL on both platforms, so the
-    // free-on-failure rule must not fire here. A double free aborts under glibc's own heap check,
-    // so reaching the assertion at all is most of the evidence; the follow-up allocation confirms
-    // the heap is still usable rather than merely un-aborted.
+    // The zero case is implementation-defined (C17 7.22.3.5) and the platforms genuinely differ, so
+    // this arm asserts the contract that holds everywhere rather than one platform's spelling of it.
+    // An earlier revision asserted `r == nullptr` and was red on macOS -- correctly, and the code was
+    // never wrong; the ASSERTION was:
+    //
+    //   glibc    realloc(p, 0) frees and returns NULL
+    //   Windows  guest_realloc_portable's `if (!size)` frees and returns NULL
+    //   macOS    realloc(p, 0) returns a VALID minimum-size block and frees nothing
+    //
+    // What must be true on all three is that the free-on-failure rule does NOT fire on top of a
+    // release that already happened. Both outcomes are checked for their own follow-through: a NULL
+    // means the block is gone and nothing more is owed, a non-NULL means the caller now owns a real
+    // block and must free it. The heap-intact probe afterwards is the double-free detector -- glibc
+    // aborts outright on a double free, so reaching the probe is most of the evidence and the
+    // successful allocation confirms the heap is usable rather than merely un-aborted.
     {
         auto* p = (void*)(uintptr_t)malloc_fn(64, 0, 0, 0, 0, 0);
         CHECK(p != nullptr, "malloc returns the block for the zero-size arm");
         if (p) {
             auto* r = (void*)(uintptr_t)reallocf_fn(U(p), 0, 0, 0, 0, 0);
-            CHECK(r == nullptr, "reallocf(p, 0) releases the block and returns NULL");
+            // Which branch runs is a platform fact, not a pass/fail condition, so it is REPORTED
+            // rather than asserted -- an assertion that cannot fail is not evidence.
+            if (r) {
+                printf("  [note] reallocf(p, 0) returned a block (macOS-style, C17-conforming)\n");
+                *(volatile unsigned char*)r = 0xA5;   // real storage, not a non-null sentinel
+                free_fn(U(r), 0, 0, 0, 0, 0);
+            } else {
+                printf("  [note] reallocf(p, 0) returned NULL, block released (glibc/Windows)\n");
+            }
             auto* after = (void*)(uintptr_t)malloc_fn(64, 0, 0, 0, 0, 0);
             CHECK(after != nullptr, "the heap is intact afterwards -- no double free on the 0 path");
             if (after) free_fn(U(after), 0, 0, 0, 0, 0);

--- a/prosper/tests/test_reallocf.cpp
+++ b/prosper/tests/test_reallocf.cpp
@@ -1,0 +1,145 @@
+// reallocf (YMZO9ChZb0E) is realloc except that the ORIGINAL block is freed when the resize fails
+// (#2203). BSD ships it because `p = realloc(p, n)` leaks `p` on failure, so a caller of reallocf
+// has delegated the free-on-failure to libc and will not do it itself.
+//
+// Unregistered, the NID fell to the dispatcher's default 0 — a NULL return the caller reads as OOM.
+// That is a false FAILURE on every call, not only on the failure path: a resize that should have
+// succeeded reported allocation failure. So the registration arm below is the whole defect, and it
+// is structurally red without the fix (Hle::lookup returns nullptr).
+//
+// THE DISCRIMINATOR, and it is the reason this file is longer than the change it covers.
+//
+// #2203 flagged the trap when it filed the bug: asserting the return is NULL on failure is
+// necessary and NOT sufficient, because a plain `realloc` alias returns NULL there too. Such an arm
+// passes whether or not the original was freed, so it cannot fail for the reason it claims — the
+// exact "true assertion, mechanism never ran" shape the charter warns about.
+//
+// What actually separates the two is observable without reading freed memory: **a live block's
+// address can never be handed out again.** So after a failed reallocf, allocate a batch of blocks
+// in the same size class and look for the original address among them.
+//
+//   - If the handler is reallocf (correct): the block was freed, and glibc's tcache returns it to
+//     the very next same-size request. The address reappears.
+//   - If the handler were realloc (the defect): the block is STILL LIVE, and no allocator may
+//     return its address for a new allocation. The address CANNOT reappear.
+//
+// The failing direction is therefore guaranteed by allocator correctness rather than by allocator
+// policy, which is what makes this a real discriminator: mutate `h_reallocf` into `h_realloc` and
+// this arm goes red deterministically. The passing direction relies on same-size-class reuse, so it
+// is given several attempts rather than one, and the block is small enough to be a tcache candidate.
+//
+// The mutation was run: replacing the body with plain `guest_realloc_portable` turns
+// "the failed resize RELEASED the original block" red while every other arm stays green.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static uint64_t U(const void* p) { return (uint64_t)(uintptr_t)p; }
+
+int main() {
+    printf("== test_reallocf ==\n");
+    register_builtin_hle();
+
+    HleFn reallocf_fn = Hle::lookup(nid_hash("reallocf"));
+    HleFn malloc_fn   = Hle::lookup(nid_hash("malloc"));
+    HleFn free_fn     = Hle::lookup(nid_hash("free"));
+
+    CHECK(reallocf_fn != nullptr,
+          "reallocf is registered (unregistered -> dispatcher 0 -> every call reads as OOM)");
+    CHECK(malloc_fn != nullptr && free_fn != nullptr, "malloc/free are registered");
+    if (!reallocf_fn || !malloc_fn || !free_fn) {
+        printf("== %d failure(s) ==\n", fails);
+        return 1;
+    }
+
+    // The name the guest imports must hash to the NID libSceLibcInternal actually exports. A
+    // registration under a mistyped name would satisfy every behavioural arm below while leaving
+    // the guest's call unresolved, so this is checked against the 3.20 dump's value directly.
+    CHECK(nid_hash("reallocf") == "YMZO9ChZb0E",
+          "nid_hash(\"reallocf\") == YMZO9ChZb0E, the NID libSceLibcInternal exports");
+
+    // --- the success path is ordinary realloc: resize, preserving contents ----------------------
+    {
+        const size_t kOld = 64, kNew = 4096;
+        auto* p = (uint8_t*)(uintptr_t)malloc_fn(kOld, 0, 0, 0, 0, 0);
+        CHECK(p != nullptr, "malloc returns a block");
+        if (p) {
+            for (size_t i = 0; i < kOld; ++i) p[i] = (uint8_t)(i * 17u + 3u);
+            auto* grown = (uint8_t*)(uintptr_t)reallocf_fn(U(p), kNew, 0, 0, 0, 0);
+            CHECK(grown != nullptr, "a resize that CAN succeed returns storage, not a false OOM");
+            if (grown) {
+                bool kept = true;
+                for (size_t i = 0; i < kOld && kept; ++i) kept = grown[i] == (uint8_t)(i * 17u + 3u);
+                CHECK(kept, "contents survive the resize, all 64 original bytes");
+                free_fn(U(grown), 0, 0, 0, 0, 0);
+            }
+        }
+    }
+
+    // --- reallocf(NULL, n) is malloc(n); there is nothing to release ----------------------------
+    {
+        auto* fresh = (void*)(uintptr_t)reallocf_fn(0, 128, 0, 0, 0, 0);
+        CHECK(fresh != nullptr, "reallocf(NULL, n) allocates, exactly as realloc(NULL, n) does");
+        if (fresh) free_fn(U(fresh), 0, 0, 0, 0, 0);
+    }
+
+    // --- THE ARM THAT DISTINGUISHES reallocf FROM realloc ---------------------------------------
+    // A resize the allocator must refuse, then look for the original address in a fresh batch.
+    {
+        const size_t kSize = 96;                 // small: a tcache size class
+        const size_t kImpossible = (size_t)-1;   // SIZE_MAX: no allocator can satisfy this
+        auto* victim = (uint8_t*)(uintptr_t)malloc_fn(kSize, 0, 0, 0, 0, 0);
+        CHECK(victim != nullptr, "malloc returns the block that the failed resize must release");
+        if (victim) {
+            const uintptr_t victim_addr = (uintptr_t)victim;
+
+            auto* r = (void*)(uintptr_t)reallocf_fn(U(victim), kImpossible, 0, 0, 0, 0);
+            // Necessary but NOT sufficient on its own -- a realloc alias also returns NULL here.
+            // Recorded as such so nobody later reads this line as the coverage.
+            CHECK(r == nullptr, "a resize to SIZE_MAX fails and returns NULL (true for realloc too)");
+
+            // Sufficient. A live block's address cannot be reissued, so seeing it again proves the
+            // failed resize released it.
+            const int kTries = 8;
+            void* probe[kTries] = {};
+            bool reissued = false;
+            for (int i = 0; i < kTries; ++i) {
+                probe[i] = (void*)(uintptr_t)malloc_fn(kSize, 0, 0, 0, 0, 0);
+                if ((uintptr_t)probe[i] == victim_addr) reissued = true;
+            }
+            CHECK(reissued,
+                  "the failed resize RELEASED the original block -- its address is reissued to a "
+                  "later same-size allocation, which a still-live block's address never could be");
+            for (int i = 0; i < kTries; ++i)
+                if (probe[i]) free_fn(U(probe[i]), 0, 0, 0, 0, 0);
+        }
+    }
+
+    // --- reallocf(p, 0) must not double-free -----------------------------------------------------
+    // guest_realloc_portable(p, 0) already frees p and returns NULL on both platforms, so the
+    // free-on-failure rule must not fire here. A double free aborts under glibc's own heap check,
+    // so reaching the assertion at all is most of the evidence; the follow-up allocation confirms
+    // the heap is still usable rather than merely un-aborted.
+    {
+        auto* p = (void*)(uintptr_t)malloc_fn(64, 0, 0, 0, 0, 0);
+        CHECK(p != nullptr, "malloc returns the block for the zero-size arm");
+        if (p) {
+            auto* r = (void*)(uintptr_t)reallocf_fn(U(p), 0, 0, 0, 0, 0);
+            CHECK(r == nullptr, "reallocf(p, 0) releases the block and returns NULL");
+            auto* after = (void*)(uintptr_t)malloc_fn(64, 0, 0, 0, 0, 0);
+            CHECK(after != nullptr, "the heap is intact afterwards -- no double free on the 0 path");
+            if (after) free_fn(U(after), 0, 0, 0, 0, 0);
+        }
+    }
+
+    printf("== %d failure(s) ==\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Two unrelated but same-shaped defects in the HLE return contract, each with a mutation-tested arm.
Kept in one PR as two clean commits because both are small, both are pure return-value corrections
with no shared code, and each closes independently — split on request.

---

## 1. `scePthreadRwlockUnlock` reported success for a null rwlock slot — `Fixes #2159`

`k_rwlock_unlock` answered `0` when `ensure_rwlock` returned null, which happens for a null slot
address or a failed allocation. Neither is a successful unlock, and FreeBSD answers `EINVAL` for the
first.

**Every sibling already did the right thing** — `rdlock`/`wrlock` since #2024/#2158, and
`tryrdlock`, `trywrlock` and all four timed forms before that. Unlock was the last rwlock entry point
answering a null handle with success, so the answer to "what happens if I unlock a null rwlock"
depended on nothing but which entry point the guest used. `CLAUDE.md` records that divergence as a
defect in its own right under #1873.

A guest passing an uninitialised handle was told the unlock succeeded, hiding its bug behind ours.
Strictly milder than #2024 — there is no lock to corrupt — and the same
report-success-for-an-operation-that-did-not-happen class.

**The test was pre-specified by the previous author.** `test_pthread_error_encoding.cpp:95-102`
carried a comment explaining why the row was deliberately absent, that an arm asserting the current
`0` would enshrine the bug, and ending *"Re-add the row here once #2159 lands."* This does exactly
that, and the row asserts both halves: Sony encodes to `0x80020016` through `SCE_PTHREAD_ALIAS`, the
POSIX spelling stays bare `22`.

## 2. `reallocf` (`YMZO9ChZb0E`) was unregistered — `Fixes #2203`

`libSceLibcInternal` exports it and prosper did not register it, so the NID fell to the dispatcher's
default `0`. For an allocator that is a NULL return the caller reads as OOM, so **every call reported
allocation failure**, including resizes that would have succeeded. Same false-failure class as
#2185's `reallocalign`, one line below it in the 3.20 dump.

`reallocf` is BSD's realloc variant that frees the original when the resize fails — it exists because
`p = realloc(p, n)` leaks `p` on failure, so a caller has *delegated* the free-on-failure to libc and
will not do it itself.

The `a1` guard is load-bearing, not defensive: `guest_realloc_portable(p, 0)` already frees and
returns NULL on both platforms, so freeing again there would be a double free. `P(a0)` covers
`realloc(NULL, n)`. On Windows a pointer the header check rejects reaches `guest_windows_free`, which
re-validates the magic and refuses safely (`hle_libc.cpp:132-143`), so BSD semantics need no platform
exception.

`CONFIDENCE: HIGH` on the semantics — a published BSD interface with one definition, and the argument
order is `realloc`'s rather than an inference. (Deliberately unlike #2185's `reallocalign`, which is
`MED` on argument order for good reasons that do not apply here.)

### The discriminator is the point of that test file

#2203 flagged the trap when it was filed: asserting a NULL return on failure is **necessary and not
sufficient**, because a plain `realloc` alias returns NULL there too — such an arm cannot fail for
the reason it claims.

What separates them is observable without reading freed memory: **a live block's address can never be
reissued.** After a failed `reallocf` the address reappears in a later same-size allocation; under
realloc semantics the block is still live and it provably cannot. The failing direction is guaranteed
by allocator correctness rather than by allocator policy.

---

## Mutation testing — run, not asserted

| mutation | result |
| --- | --- |
| `k_rwlock_unlock` → `return 0` | **both halves red**: `got 0x0` (Sony), `got 0` (POSIX) |
| `h_reallocf` → plain `guest_realloc_portable` | **only** `the failed resize RELEASED the original block` red |

The second row is the interesting one: **the NULL-return arm stayed green under the mutation**,
exactly as #2203 predicted. Had that been the only arm, the test would have passed on the broken
implementation.

Nothing else in the suite moved under either mutation.

## Verification

```
cmake -S prosper -B build -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6                       # rc=0
ctest --no-tests=error -j6                    # 100% tests passed out of 220
git diff --check                              # clean
```

220 = master's 219 in a dump-configured build, plus `test_reallocf`. The count is quoted per #2188 —
my first configure pointed `GAME_DUMP` inside the worktree, where the gitignored dump does not exist,
and reported a green **215**. That is instrument trap 126 landing on me in the course of this PR, and
it is the reason the count rather than the exit code is the evidence.

Also verified `nid_hash("reallocf") == "YMZO9ChZb0E"` directly against the 3.20 dump's value, so a
registration under a mistyped name cannot pass the behavioural arms while leaving the guest's import
unresolved.

Requesting review — the `reallocf` half is reverse-engineered libc semantics with a double-free edge,
which is the category `CLAUDE.md` says to review even when small.
