### PR TITLE
diag(render): partition setup_fixed_ms — 55% of it is a vkCreateBuffer+vkAllocateMemory per indexed draw

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1188,6 +1188,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 double backend_gpu_device_ms = 0;
                 double backend_readback_ms = 0, backend_cleanup_ms = 0;
                 double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
+                double backend_res_fixed_index_upload_ms = 0;
+                double backend_res_fixed_blend_ms = 0;
+                double backend_res_fixed_depth_stencil_ms = 0;
+                double backend_res_fixed_viewport_ms = 0;
+                double backend_res_fixed_stages_ms = 0;
+                double backend_res_fixed_prologue_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                 // #1284: sub-attribution of backend_setup_resources_ms. res_texture/res_buffer
                 // cover the whole per-resource branch; the upload/bind pair is nested inside
@@ -1279,6 +1285,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 pending_timing.backend_cleanup_ms += backend.cleanup_ms;
                 pending_timing.backend_setup_shader_ms += backend.setup_shader_ms;
                 pending_timing.backend_setup_fixed_ms += backend.setup_fixed_ms;
+                pending_timing.backend_res_fixed_index_upload_ms += backend.res_fixed_index_upload_ms;
+                pending_timing.backend_res_fixed_blend_ms += backend.res_fixed_blend_ms;
+                pending_timing.backend_res_fixed_depth_stencil_ms += backend.res_fixed_depth_stencil_ms;
+                pending_timing.backend_res_fixed_viewport_ms += backend.res_fixed_viewport_ms;
+                pending_timing.backend_res_fixed_stages_ms += backend.res_fixed_stages_ms;
+                pending_timing.backend_res_fixed_prologue_ms += backend.res_fixed_prologue_ms;
                 pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
                 pending_timing.backend_res_texture_ms += backend.res_texture_ms;
                 pending_timing.backend_res_texture_upload_ms += backend.res_texture_upload_ms;
@@ -6545,6 +6557,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     double backend_gpu_device_ms = 0;
                     double backend_readback_ms = 0, backend_cleanup_ms = 0;
                     double backend_setup_shader_ms = 0, backend_setup_fixed_ms = 0;
+                    double backend_res_fixed_index_upload_ms = 0;
+                    double backend_res_fixed_blend_ms = 0;
+                    double backend_res_fixed_depth_stencil_ms = 0;
+                    double backend_res_fixed_viewport_ms = 0;
+                    double backend_res_fixed_stages_ms = 0;
+                    double backend_res_fixed_prologue_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                     double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
                     double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
@@ -6598,6 +6616,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.backend_cleanup_ms += pending_timing.backend_cleanup_ms;
                     timing.backend_setup_shader_ms += pending_timing.backend_setup_shader_ms;
                     timing.backend_setup_fixed_ms += pending_timing.backend_setup_fixed_ms;
+                    timing.backend_res_fixed_index_upload_ms += pending_timing.backend_res_fixed_index_upload_ms;
+                    timing.backend_res_fixed_blend_ms += pending_timing.backend_res_fixed_blend_ms;
+                    timing.backend_res_fixed_depth_stencil_ms += pending_timing.backend_res_fixed_depth_stencil_ms;
+                    timing.backend_res_fixed_viewport_ms += pending_timing.backend_res_fixed_viewport_ms;
+                    timing.backend_res_fixed_stages_ms += pending_timing.backend_res_fixed_stages_ms;
+                    timing.backend_res_fixed_prologue_ms += pending_timing.backend_res_fixed_prologue_ms;
                     timing.backend_setup_resources_ms += pending_timing.backend_setup_resources_ms;
                     timing.backend_res_texture_ms += pending_timing.backend_res_texture_ms;
                     timing.backend_res_texture_upload_ms += pending_timing.backend_res_texture_upload_ms;
@@ -6688,11 +6712,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             totals.backend_gpu_timestamp_samples / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
-                            "resources=%.2f pipeline=%.2f\n",
+                            "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
+                            "depth_stencil=%.2f viewport=%.2f stages=%.2f prologue=%.2f "
+                            "other=%+.2f}\n",
                             totals.backend_setup_shader_ms / nsub,
                             totals.backend_setup_fixed_ms / nsub,
                             totals.backend_setup_resources_ms / nsub,
-                            totals.backend_setup_pipeline_ms / nsub);
+                            totals.backend_setup_pipeline_ms / nsub,
+                            totals.backend_res_fixed_index_upload_ms / nsub,
+                            totals.backend_res_fixed_blend_ms / nsub,
+                            totals.backend_res_fixed_depth_stencil_ms / nsub,
+                            totals.backend_res_fixed_viewport_ms / nsub,
+                            totals.backend_res_fixed_stages_ms / nsub,
+                            totals.backend_res_fixed_prologue_ms / nsub,
+                            (totals.backend_setup_fixed_ms - totals.backend_res_fixed_index_upload_ms -
+                             totals.backend_res_fixed_blend_ms - totals.backend_res_fixed_depth_stencil_ms -
+                             totals.backend_res_fixed_viewport_ms - totals.backend_res_fixed_stages_ms -
+                             totals.backend_res_fixed_prologue_ms) / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit resources avg_ms: texture=%.2f "
                             "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "
@@ -6898,11 +6934,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             window.backend_gpu_timestamp_samples / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
-                            "resources=%.2f pipeline=%.2f\n",
+                            "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
+                            "depth_stencil=%.2f viewport=%.2f stages=%.2f prologue=%.2f "
+                            "other=%+.2f}\n",
                             window.backend_setup_shader_ms / wn,
                             window.backend_setup_fixed_ms / wn,
                             window.backend_setup_resources_ms / wn,
-                            window.backend_setup_pipeline_ms / wn);
+                            window.backend_setup_pipeline_ms / wn,
+                            window.backend_res_fixed_index_upload_ms / wn,
+                            window.backend_res_fixed_blend_ms / wn,
+                            window.backend_res_fixed_depth_stencil_ms / wn,
+                            window.backend_res_fixed_viewport_ms / wn,
+                            window.backend_res_fixed_stages_ms / wn,
+                            window.backend_res_fixed_prologue_ms / wn,
+                            (window.backend_setup_fixed_ms - window.backend_res_fixed_index_upload_ms -
+                             window.backend_res_fixed_blend_ms - window.backend_res_fixed_depth_stencil_ms -
+                             window.backend_res_fixed_viewport_ms - window.backend_res_fixed_stages_ms -
+                             window.backend_res_fixed_prologue_ms) / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit resources avg_ms: texture=%.2f "
                             "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6713,7 +6713,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     fprintf(stderr,
                             "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
-                            "depth_stencil=%.2f viewport=%.2f stages=%.2f prologue=%.2f "
+                            "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
                             "other=%+.2f}\n",
                             totals.backend_setup_shader_ms / nsub,
                             totals.backend_setup_fixed_ms / nsub,
@@ -6935,7 +6935,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     fprintf(stderr,
                             "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
-                            "depth_stencil=%.2f viewport=%.2f stages=%.2f prologue=%.2f "
+                            "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
                             "other=%+.2f}\n",
                             window.backend_setup_shader_ms / wn,
                             window.backend_setup_fixed_ms / wn,

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -604,6 +604,25 @@ struct BackendRenderTimingStats {
     double cleanup_ms = 0;
     double setup_shader_ms = 0;
     double setup_fixed_ms = 0;
+    // Leaves of setup_fixed_ms, which had none. `fixed` is 15.9% of a Blue Prince gameplay frame
+    // (29.11 ms/submit, 13.85 us/draw) and until now was a single number, so anything inside it was
+    // indistinguishable from anything else inside it -- the condition that let a diagnostic bill
+    // 305 ms/submit to the renderer inside res_buffer_ms (instrument trap 130). index_upload is the
+    // per-indexed-draw vkCreateBuffer + vkAllocateMemory + bind + map + copy at render_runner.h's
+    // index block; the rest name the fixed-function state translation. setup_fixed_other_ms() is
+    // printed SIGNED so the partition reports its own completeness (#2246).
+    double res_fixed_index_upload_ms = 0;
+    double res_fixed_blend_ms = 0;
+    double res_fixed_depth_stencil_ms = 0;
+    double res_fixed_viewport_ms = 0;
+    double res_fixed_stages_ms = 0;
+    double res_fixed_prologue_ms = 0;
+
+    double setup_fixed_other_ms() const {
+        return setup_fixed_ms - res_fixed_index_upload_ms - res_fixed_blend_ms -
+               res_fixed_depth_stencil_ms - res_fixed_viewport_ms - res_fixed_stages_ms -
+               res_fixed_prologue_ms;
+    }
     double setup_resources_ms = 0;
     double setup_pipeline_ms = 0;
     // Sub-attribution of setup_resources_ms (#1284). `resources` is not descriptor bookkeeping alone:
@@ -3877,6 +3896,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     size_t persistent_texture_misses = 0;
     double setup_shader_ms = 0.0;
     double setup_fixed_ms = 0.0;
+    double res_fixed_index_upload_ms = 0.0;
+    double res_fixed_blend_ms = 0.0;
+    double res_fixed_depth_stencil_ms = 0.0;
+    double res_fixed_viewport_ms = 0.0;
+    double res_fixed_stages_ms = 0.0;
+    double res_fixed_prologue_ms = 0.0;
     double setup_resources_ms = 0.0;
     double setup_pipeline_ms = 0.0;
     // #1284 sub-attribution of setup_resources_ms; see BackendRenderTimingStats for what each covers.
@@ -4081,9 +4106,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             v.scissor.extent = {static_cast<uint32_t>(right - left),
                                 static_cast<uint32_t>(bottom - top)};
         }
+        if (timing_enabled) res_fixed_prologue_ms += setup_elapsed_ms(setup_begin, TimingClock::now());
         // Indexed draw: upload the 32-bit index data to a host-visible VkIndexBuffer now; the record
         // pass binds it and issues vkCmdDrawIndexed instead of vkCmdDraw.
         if (!bd.indices.empty()) {
+            // Per INDEXED DRAW: create a buffer, allocate memory, bind, map, copy, unmap. Six
+            // Vulkan entry points and one allocation on every draw that carries indices, and until
+            // this timer none of it was separable from fixed-function state translation.
+            const ResourcePhaseTimer phase_index_upload(timing_enabled, &res_fixed_index_upload_ms);
             VkDeviceSize isz = (VkDeviceSize)bd.indices.size() * 4;
             VkBufferCreateInfo ibci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
             ibci.size = isz; ibci.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
@@ -4098,6 +4128,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             std::memcpy(ip, bd.indices.data(), (size_t)isz); vkUnmapMemory(dev, v.ibmem);
             v.icount = (uint32_t)bd.indices.size();
         }
+        const auto fixed_stages_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         VkPipelineShaderStageCreateInfo st[3]{};
         VkPipelineShaderStageRequiredSubgroupSizeCreateInfo required_fragment_subgroup{
             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO};
@@ -4127,6 +4158,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // Default: full-target viewport. When the resolved state carries the guest's PA_CL_VPORT transform,
         // honor it — a guest yscale < 0 arrives as a negative viewport_h (Vulkan core-1.1 flipped viewport),
         // reproducing the hardware's Y orientation (#38; each draw item keeps its own resolved viewport).
+        if (timing_enabled) res_fixed_stages_ms += setup_elapsed_ms(fixed_stages_begin, TimingClock::now());
+        // viewport/scissor/raster begins here; the index upload above is timed separately.
+        const auto fixed_viewport_begin = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         VkViewport vp{0, 0, (float)W, (float)H, 0, 1}; VkRect2D sc{{0, 0}, {W, H}};
         if (ps && ps->has_viewport)
             vp = {ps->viewport_x, ps->viewport_y, ps->viewport_w, ps->viewport_h, ps->min_depth, ps->max_depth};
@@ -4160,6 +4194,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
         VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
         ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+        const auto fixed_viewport_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) res_fixed_viewport_ms += setup_elapsed_ms(fixed_viewport_begin, fixed_viewport_ready);
         std::array<VkPipelineColorBlendAttachmentState,
                    prosper::gpu::kColorTargetCount> cba{};
         for (uint32_t slot = 0; slot < color_count; ++slot) cba[slot].colorWriteMask = 0xF;
@@ -4215,6 +4251,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             }
         }
         cb.attachmentCount = color_count; cb.pAttachments = cba.data();
+        const auto fixed_blend_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) res_fixed_blend_ms += setup_elapsed_ms(fixed_viewport_ready, fixed_blend_ready);
         VkPipelineDepthStencilStateCreateInfo dss{VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO};
         if (ps && ps->depth_test_enable) {
             dss.depthTestEnable  = VK_TRUE;
@@ -4287,6 +4325,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         dss.front.reference, dss.back.reference, (unsigned)ps->cull_mode, (int)ps->depth_test_enable);
         }
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
+        const auto fixed_dss_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        if (timing_enabled) res_fixed_depth_stencil_ms += setup_elapsed_ms(fixed_blend_ready, fixed_dss_ready);
         const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_fixed_ms += setup_elapsed_ms(setup_shaders_ready, setup_fixed_ready);
         const auto& R = effective_resources[di];
@@ -6533,6 +6573,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.cleanup_ms = ms(timing_readback_done, timing_done);
         call_timing.setup_shader_ms = setup_shader_ms;
         call_timing.setup_fixed_ms = setup_fixed_ms;
+        call_timing.res_fixed_index_upload_ms = res_fixed_index_upload_ms;
+        call_timing.res_fixed_blend_ms = res_fixed_blend_ms;
+        call_timing.res_fixed_depth_stencil_ms = res_fixed_depth_stencil_ms;
+        call_timing.res_fixed_viewport_ms = res_fixed_viewport_ms;
+        call_timing.res_fixed_stages_ms = res_fixed_stages_ms;
+        call_timing.res_fixed_prologue_ms = res_fixed_prologue_ms;
         call_timing.setup_resources_ms = setup_resources_ms;
         call_timing.res_texture_ms = res_texture_ms;
         call_timing.res_texture_upload_ms = res_texture_upload_ms;
@@ -6867,6 +6913,12 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(cleanup_ms);
             PROSPER_SUM_TIMING_STAT(setup_shader_ms);
             PROSPER_SUM_TIMING_STAT(setup_fixed_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_index_upload_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_blend_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_depth_stencil_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_viewport_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_stages_ms);
+            PROSPER_SUM_TIMING_STAT(res_fixed_prologue_ms);
             PROSPER_SUM_TIMING_STAT(setup_resources_ms);
             PROSPER_SUM_TIMING_STAT(res_texture_ms);
             PROSPER_SUM_TIMING_STAT(res_texture_upload_ms);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -616,6 +616,14 @@ struct BackendRenderTimingStats {
     double res_fixed_depth_stencil_ms = 0;
     double res_fixed_viewport_ms = 0;
     double res_fixed_stages_ms = 0;
+    // Printed as `pre_index_unsplit`, NOT `prologue`, and the name is the point. This leaf is
+    // defined by where the timing region STARTS rather than by what it contains, so it is a residual
+    // with a location rather than a component. `other=+0.27` reads as unattributed and invites
+    // investigation; a component name reads as attributed and closes it, which would make the
+    // partition look complete while the blind spot had only been renamed. Keeping the position in
+    // the printed token turns "what is the prologue doing" into "what is IN that span", which is the
+    // question #2254 exists to answer. Do not rename it to something that sounds like a phase until
+    // it has been split into ones.
     double res_fixed_prologue_ms = 0;
 
     double setup_fixed_other_ms() const {


### PR DESCRIPTION
## What this partitions and why

`fixed` was the **second-largest leaf in the Blue Prince gameplay frame** — 29–34 ms/submit, ~16% —
and had no sub-attribution at all. Anything inside it was indistinguishable from anything else inside
it, which is exactly the condition instrument trap 130 records: *an unmeasured region does not read
as unmeasured, it reads as somebody else's cost.*

Six leaves plus a signed remainder, same shape as #2246. One window, default Linux gameplay run,
2,251 draws/submit:

```
fixed=32.07  index_upload=17.62  prologue=12.60  viewport=0.57  blend=0.41
             stages=0.32  depth_stencil=0.28  other=+0.27
```

Parts sum to **32.07 exactly**; the remainder is **0.8%**.

## Two findings, neither of which was my hypothesis

**1. `index_upload` — 55% of `fixed`, ~9% of the whole frame.** Every indexed draw runs

```c
vkCreateBuffer → vkGetBufferMemoryRequirements → allocate_transient_render_memory
              → vkBindBufferMemory → vkMapMemory → memcpy → vkUnmapMemory
```

Six Vulkan entry points and **one memory allocation, per draw**. The storage-buffer path immediately
next door already pools and arenas precisely this work (`acquire_buffer_arena_slice`); index buffers
get none of it. Filed separately as the fix — this PR only measures.

**2. `prologue` — 39% of `fixed`, ~6% of the frame.** The span from `setup_begin` to the index block:
shader-key computation, subgroup checks, the deferred persistent-pipeline lookup preamble. **Nobody
had suspected this**, and that is the argument for partitioning over nominating.

The fixed-function state translation anyone would have guessed at — blend, depth/stencil,
viewport/raster, shader-stage structs — is **1.58 ms combined, under 5% of `fixed`**.

## A hypothesis this closes, with its own A/B

Those blocks hold ~14 **raw per-draw `getenv()` calls** (`PROSPER_NO_CULL`, `PROSPER_NO_BLEND` ×3,
`PROSPER_STENCILLOG`, …). At 2,106 draws that is ~25,000 linear scans of `environ` per submit, and it
fit 29 ms almost too well.

Tested on the **unmodified binary**, by running it twice with different environment sizes — an
experiment that falsifies itself if the mechanism is absent:

| | `fixed` per draw |
| --- | ---: |
| default env (98 entries) | 13.85 µs (13.71–16.22) |
| +300 entries | 17.30 µs (17.19–18.41) |

Non-overlapping, so the mechanism is real — only `getenv` can make per-draw cost depend on
environment size. And confirming it bounds it: **≤8.1% of `fixed`, ≤1.3% of frame**. That bound is
conservative because my padding variables shared the `PROSPER_` prefix and so cost more per entry
than a real environment of `PATH`/`HOME`. The partition now measures those blocks directly at
**1.58 ms — under half the bound**. Real, free to fix, and not the answer.

## Behavior

- **Unaffected by default.** Every stamp is `timing_enabled ? TimingClock::now() : {}`, identical in
  kind and cost to the `setup_fixed_ready` stamp already there.
- `index_upload` uses a `ResourcePhaseTimer` scope guard so it stays correct across the block's exits;
  the other five are boundary stamps, which suit a straight-line region better than guards because the
  state objects must outlive their own construction.
- All six are in the `PROSPER_SUM_TIMING_STAT` list — a field added to the struct and not to that
  macro under-reports on every multi-pass submit (@Wren's check on #2245).

## Risks

The boundary stamps read the clock six more times per draw when `PROSPER_RENDER_TIMING` is set, which
inflates the enclosing bucket **while armed** — the same self-measurement caveat @Wren flagged at
`live_renderer.cpp:4523`. It does not affect a default run, and the `index_upload`/`prologue` split is
far too large to be clock overhead (17.62 ms over 2,251 draws is 7.8 µs/draw against a `TimingClock`
read of tens of nanoseconds).

## Verification

```
cmake --build build -j6                # rc=0
ctest --no-tests=error -j6             # 219/219 passed
git diff --check                       # clean
```

219 is master's count in a `-DGAME_DUMP=…` build (trap 126); this PR adds no tests, so it is unchanged.

Requesting review, @Wren — particularly on whether `prologue` is the right cut, since it is defined by
*where the timing region starts* rather than by a semantic boundary, and that is the kind of leaf that
can be honest and still unhelpful.

Refs #2215.
