### PR TITLE
diag(gpu): record WHY a fragment module requires its exact wave width — 35 of 35 skips are one reason

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -281,6 +281,12 @@ struct SpirvCompute {
     bool packed_r11_storage=true;
     uint32_t compute_min_subgroup_size=0;             // non-semantic backend contract (4/16/32/64)
     uint32_t fragment_required_subgroup_size=0;       // exact guest-wave contract (32 or 64)
+    // WHY that width was required, as a bitmask (#2147). The size alone is not actionable: a
+    // shader needing 64 for lane IDENTITY can never run at 32, while one needing it only for a
+    // width-agnostic branch vote might. The skip diagnostic reported neither, because its
+    // `required-ops` field scans for Vote/Arithmetic/Shuffle CAPABILITIES and the lane-id path
+    // declares none of them -- so the two cases printed identically.
+    uint32_t fragment_wave_reasons=0;
     uint32_t v_subgroupid=0, v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
@@ -527,7 +533,8 @@ struct SpirvCompute {
         }
         // Fragment lane ids model the guest RDNA wave, not the implementation's default subgroup.
         // Record that exact-width contract as non-semantic module metadata in finish().
-        if (is_fragment) fragment_required_subgroup_size = wave_size;
+        if (is_fragment) fragment_required_subgroup_size = wave_size,
+                         fragment_wave_reasons |= kFragmentWaveReasonLaneId;
         uint32_t lane = id();
         put(code, Op_Load, {t_u32, lane, v_subgroup_localid});
         return lane;
@@ -548,6 +555,7 @@ struct SpirvCompute {
             declared_subgroup_vote = true;
         }
         fragment_required_subgroup_size = wave_size;
+        fragment_wave_reasons |= kFragmentWaveReasonWaveAny;
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny,
             {t_bool, result, uconst(Scope_Subgroup), active_bit});
@@ -754,23 +762,27 @@ struct SpirvCompute {
         // DPP rows contain 16 contiguous lanes. Keep width metadata independent of SPIR-V
         // capabilities: declaring an unused operation merely as a marker over-requires the host and
         // confuses shaders that genuinely use that capability for unrelated work.
-        if (is_fragment) fragment_required_subgroup_size = wave_size;
+        if (is_fragment) fragment_required_subgroup_size = wave_size,
+                         fragment_wave_reasons |= kFragmentWaveReasonDppRow16;
         else compute_min_subgroup_size = std::max(compute_min_subgroup_size, 16u);
     }
     void mark_subgroup_min32() {
         // PERMLANEX16 crosses a pair of 16-lane rows.
-        if (is_fragment) fragment_required_subgroup_size = wave_size;
+        if (is_fragment) fragment_required_subgroup_size = wave_size,
+                         fragment_wave_reasons |= kFragmentWaveReasonPermLane32;
         else compute_min_subgroup_size = std::max(compute_min_subgroup_size, 32u);
     }
     void mark_subgroup_min64() {
         // V_READLANE_B32 may address every lane of a wave64.
-        if (is_fragment) fragment_required_subgroup_size = wave_size;
+        if (is_fragment) fragment_required_subgroup_size = wave_size,
+                         fragment_wave_reasons |= kFragmentWaveReasonReadLane64;
         else compute_min_subgroup_size = std::max(compute_min_subgroup_size, 64u);
     }
     uint32_t subgroup_shuffle(uint32_t value, uint32_t lane) {
         // Every supported native shuffle at least addresses an architectural quad. Wider row/wave
         // operations raise this contract before calling the common helper.
-        if (is_fragment) fragment_required_subgroup_size = wave_size;
+        if (is_fragment) fragment_required_subgroup_size = wave_size,
+                         fragment_wave_reasons |= kFragmentWaveReasonShuffle;
         else compute_min_subgroup_size = std::max(compute_min_subgroup_size, 4u);
         if (!declared_subgroup) {
             put(caps, Op_Capability, {Cap_GroupNonUniform});
@@ -2810,6 +2822,15 @@ struct SpirvCompute {
             std::snprintf(marker, sizeof marker, "Prosper.FragmentSubgroupSize=%u",
                           fragment_required_subgroup_size);
             std::vector<uint32_t> words;
+            pstr(words, marker);
+            putv(debug, Op_ModuleProcessed, words);
+            // A SEPARATE marker, not a wider one: a module cached or captured before #2147
+            // carries the size and not this, and a reader must be able to tell 'reasons
+            // unknown' from 'reasons none'. Absent and zero are the same number and opposite
+            // facts -- a zero would assert that nothing required a width this module demands.
+            std::snprintf(marker, sizeof marker, "Prosper.FragmentSubgroupWhy=%u",
+                          fragment_wave_reasons);
+            words.clear();
             pstr(words, marker);
             putv(debug, Op_ModuleProcessed, words);
         }
@@ -16270,6 +16291,36 @@ uint32_t compute_spirv_min_subgroup_size(const std::vector<uint32_t>& spirv) {
         offset += words;
     }
     return required;
+}
+
+uint32_t fragment_spirv_required_subgroup_reasons(const std::vector<uint32_t>& spirv) {
+    if (spirv.size() < 5 || spirv[0] != 0x07230203u) return UINT32_MAX;
+    constexpr char prefix[] = "Prosper.FragmentSubgroupWhy=";
+    for (size_t offset = 5; offset < spirv.size();) {
+        const uint32_t instruction = spirv[offset];
+        const uint32_t words = instruction >> 16;
+        const uint32_t opcode = instruction & 0xffffu;
+        if (!words || words > spirv.size() - offset) return UINT32_MAX;
+        if (opcode == Op_ModuleProcessed && words > 1) {
+            const char* text = reinterpret_cast<const char*>(&spirv[offset + 1]);
+            const size_t bytes = static_cast<size_t>(words - 1) * sizeof(uint32_t);
+            const void* terminator = std::memchr(text, '\0', bytes);
+            if (terminator) {
+                const size_t length = static_cast<const char*>(terminator) - text;
+                if (length > sizeof(prefix) - 1 &&
+                    std::memcmp(text, prefix, sizeof(prefix) - 1) == 0) {
+                    char* end = nullptr;
+                    const unsigned long value =
+                        std::strtoul(text + sizeof(prefix) - 1, &end, 10);
+                    if (end == text + length) return static_cast<uint32_t>(value);
+                }
+            }
+        }
+        offset += words;
+    }
+    // No marker: the module predates #2147. UINT32_MAX rather than 0, so a caller cannot read
+    // 'unknown' as 'nothing required it'.
+    return UINT32_MAX;
 }
 
 uint32_t fragment_spirv_required_subgroup_features(const std::vector<uint32_t>& spirv) {

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -285,6 +285,26 @@ uint32_t fragment_effective_wave_size_for_test(uint32_t requested_wave_size,
 // Recompiled fragment wave operations use native Vulkan subgroup instructions and therefore require
 // an exact guest-wave subgroup. Returns zero for ordinary modules and 32/64 for that contract.
 uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spirv);
+// WHY a fragment module requires its exact guest-wave width (#2147). The width alone is not
+// actionable: a shader needing 64 for lane IDENTITY can never run at 32, because
+// SubgroupLocalInvocationId IS the guest lane id and 32 lanes silently renumber it. One needing
+// 64 only for a branch-guard vote may be width-agnostic, since two 32-lane votes union to the
+// same executed-pixel set. Those have opposite prospects under a wave32 lowering, and the skip
+// diagnostic could not tell them apart: kFragmentSubgroup* below are CAPABILITY bits, and the
+// lane-id path declares only base GroupNonUniform, so it reported required-ops=0.
+//
+// These name the emitter path that raised the contract. A module may set several.
+inline constexpr uint32_t kFragmentWaveReasonLaneId     = 1u << 0;  // lane id from SubgroupLocalInvocationId
+inline constexpr uint32_t kFragmentWaveReasonWaveAny    = 1u << 1;  // OpGroupNonUniformAny (guard AND reduce)
+inline constexpr uint32_t kFragmentWaveReasonDppRow16   = 1u << 2;  // DPP row, needs >= 16
+inline constexpr uint32_t kFragmentWaveReasonPermLane32 = 1u << 3;  // PERMLANEX16, needs >= 32
+inline constexpr uint32_t kFragmentWaveReasonReadLane64 = 1u << 4;  // V_READLANE_B32 across a wave64
+inline constexpr uint32_t kFragmentWaveReasonShuffle    = 1u << 5;  // lane-addressed shuffle
+
+// Reasons recorded by the emitter, or UINT32_MAX when the module carries no reason marker at
+// all (built, cached or captured before #2147). Absent must not read as none.
+uint32_t fragment_spirv_required_subgroup_reasons(const std::vector<uint32_t>& spirv);
+
 inline constexpr uint32_t kFragmentSubgroupVote = 1u << 0;
 inline constexpr uint32_t kFragmentSubgroupArithmetic = 1u << 1;
 inline constexpr uint32_t kFragmentSubgroupShuffle = 1u << 2;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4060,18 +4060,53 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             static std::mutex log_mutex;
             static std::unordered_set<uint64_t> logged;
             std::lock_guard<std::mutex> lock(log_mutex);
-            if (logged.insert(shader_key).second)
+            if (logged.insert(shader_key).second) {
+                // WHY the width was required, decoded (#2147). `required-ops` cannot answer it:
+                // those are Vote/Arithmetic/Shuffle CAPABILITY bits, and the lane-id path declares
+                // none of them — so a shader needing 64 for lane IDENTITY (which can never run at
+                // 32, since SubgroupLocalInvocationId IS the guest lane id) printed identically to
+                // one needing it only for a branch-guard vote (which may be width-agnostic). Those
+                // have opposite prospects under a wave32 lowering, and without this field the
+                // census that decides whether such a lowering is worth writing cannot be taken.
+                //
+                // Inside the dedupe guard, so it costs once per distinct shader, not per draw.
+                const uint32_t why =
+                    prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs);
+                char why_text[160];
+                if (why == UINT32_MAX) {
+                    // Absent, not none. A module built before #2147 carries no marker, and printing
+                    // that as 0 would assert nothing required the width — impossible for a module
+                    // that requires one.
+                    std::snprintf(why_text, sizeof why_text, "unrecorded (pre-#2147 module)");
+                } else {
+                    int n = std::snprintf(why_text, sizeof why_text, "0x%x", why);
+                    const struct { uint32_t bit; const char* name; } kReasonNames[] = {
+                        {prosper::gpu::kFragmentWaveReasonLaneId,     " lane-id"},
+                        {prosper::gpu::kFragmentWaveReasonWaveAny,    " wave-any"},
+                        {prosper::gpu::kFragmentWaveReasonDppRow16,   " dpp16"},
+                        {prosper::gpu::kFragmentWaveReasonPermLane32, " permlane32"},
+                        {prosper::gpu::kFragmentWaveReasonReadLane64, " readlane64"},
+                        {prosper::gpu::kFragmentWaveReasonShuffle,    " shuffle"},
+                    };
+                    for (const auto& entry : kReasonNames)
+                        if ((why & entry.bit) && n > 0 && n < static_cast<int>(sizeof why_text))
+                            n += std::snprintf(why_text + n, sizeof why_text - n, "%s", entry.name);
+                    if (!why && n > 0 && n < static_cast<int>(sizeof why_text))
+                        std::snprintf(why_text + n, sizeof why_text - n, " none");
+                }
                 std::fprintf(stderr,
                              "[render] skip draw: fragment shader requires subgroup size %u "
                              "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
-                             "ops=0x%x required-ops=0x%x control=%d gds=%d fragment-atomics=%d)\n",
+                             "ops=0x%x required-ops=0x%x control=%d gds=%d fragment-atomics=%d "
+                             "why=%s)\n",
                              required_fragment_subgroup_size, ctx.min_subgroup_size,
                              ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
                              ctx.subgroup_stages, ctx.subgroup_operations,
                              required_fragment_subgroup_features,
                              static_cast<int>(ctx.subgroup_size_control),
                              static_cast<int>(uses_internal_gds),
-                             static_cast<int>(ctx.fragment_stores_atomics));
+                             static_cast<int>(ctx.fragment_stores_atomics), why_text);
+            }
             continue;
         }
         if (uses_internal_gds && !render_internal_gds_buffer().buffer) {


### PR DESCRIPTION
diag(gpu): record WHY a fragment module requires its exact wave width — 35 of 35 skips are one reason

On an NVIDIA host prosper skips every draw whose fragment shader requires
subgroup size 64 (#2147). The skip line could not say WHICH shaders might be
recoverable, and that is the number the issue is blocked on.

The gap
-------
`required-ops` in the diagnostic comes from `fragment_spirv_required_subgroup_
features`, which scans for three CAPABILITIES: Vote, Arithmetic, Shuffle. But the
exact-width contract is raised from six emitter paths, and the most important of
them declares none of those capabilities:

  rdna2_to_spirv.cpp:512   subgroup_local_id()  emits only base GroupNonUniform

So a shader requiring 64 for lane IDENTITY reported `required-ops=0x0`, and one
requiring it only for a branch-guard vote reported `required-ops=0x1`. Those two
have OPPOSITE prospects under a wave32 lowering — the first can never run at 32,
because SubgroupLocalInvocationId IS the guest lane id and 32 lanes silently
renumber it — and the log rendered them identical.

What is recorded now
--------------------
A `Prosper.FragmentSubgroupWhy=` module marker beside the existing size marker,
carrying one bit per emitter path: lane-id, wave-any, dpp16, permlane32,
readlane64, shuffle. Decoded into the skip line as `why=0x2 wave-any`.

A SEPARATE marker rather than a wider one, because an older cached or captured
module carries the size and not this, and `fragment_spirv_required_subgroup_
reasons` returns UINT32_MAX for it rather than 0 — absent and none are the same
number and opposite facts, and a 0 would assert that nothing required a width the
module demonstrably requires.

The census, which is the point
------------------------------
Live runs, Windows/MinGW, NVIDIA RTX 4090:

  PPSA25009 Blue Prince    23 distinct skipped fragment shaders   23 x why=0x2 wave-any
  PPSA13579 Blasphemous 2  12 distinct skipped fragment shaders   12 x why=0x2 wave-any

**35 of 35. Every one is wave-any alone.** Zero use lane-id, zero shuffle, zero
DPP, zero readlane — so not one of them is blocked by the reason that is
genuinely unfixable at 32 lanes.

That reframes #2147. The substantial wave64->wave32 lowering the issue
anticipated is not what these titles need. What they need is separating the two
uses of `fragment_wave_any()`, whose own comment claims both: a branch guard
(*"does any lane need this block"*, which is width-agnostic, since two 32-lane
votes union to the same executed-pixel set) and a mask reduction (which is not).
Filed separately; this PR deliberately changes no shader semantics.

What this does NOT establish
----------------------------
The `wave-any` bit says `fragment_wave_any()` was called, not what the result was
used for. Eight call sites exist and several read like waterfall-convergence
checks rather than mask reductions, but I have not established that, and the
emitter's own comment asserts both uses. **The census narrows the population to
one reason; it does not prove that reason is recoverable.**

One host, two titles. Astro Bot and Evergate are also affected per #2147 and are
not in this census.

Verification
------------
  Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo
  ctest --no-tests=error -> 175 tests, 172 passed
    60 pthread_names (Not Run) / 61 pthread_cond_clock / 174 live_target_format
    — the three pre-existing (#2142 x2, WinLibs EPERM)

The marker adds one OpModuleProcessed per fragment module that requires a width;
no recompiled shader changed behaviour and no SPIR-V test regressed.

Refs #2147

