### PR TITLE
ci: fail the six ctest gates that pass with zero tests, and keep them failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,12 @@ jobs:
       #   podman run --rm -v "$PWD:/work" ubuntu:25.10   # mesa-vulkan-drivers 25.2.8
       - name: Test
         run: |
-          ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
+          # --no-tests=error on every ctest in this file. Plain ctest EXITS 0 when it finds no
+          # tests at all, so "nothing ran" and "everything passed" are the same status and a job
+          # gating on it reports a confident green having verified nothing (#2187). This job also
+          # has the by-name registration guard above, which is the stronger check; the flag is
+          # here so the protection does not depend on remembering which job carries which guard.
+          ctest --test-dir prosper/build-ci --output-on-failure --timeout 600 --no-tests=error
 
       # #1704: until this step existed, no Vulkan validation layer ran anywhere in the project.
       # #1690 was an invalid descriptor binding — a VK_IMAGE_VIEW_TYPE_3D view on a descriptor whose
@@ -169,6 +174,22 @@ jobs:
       - name: Verify no Markdown table is split or mis-sized anywhere in docs
         run: |
           git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github
+
+      # Lives here, in the job that needs nothing built, for the same reason the checks above do:
+      # it is a repository-wide text scan that finishes in a second. It gates the flag that keeps
+      # the OTHER jobs' ctest steps honest -- plain ctest exits 0 on an empty suite, so a job
+      # reading only that status can report a green suite having run nothing (#2187). Four jobs in
+      # this file and both author-verification runs were exposed; they now pass --no-tests=error,
+      # and this step is what stops the next one from omitting it.
+      #
+      # --selftest first, deliberately: the scan's own failure mode is silence. A matcher that
+      # stops matching reports a clean tree forever, and this checker's first revision was 91%
+      # false positives, so its matching is the part that needs a guard. The two run as separate
+      # commands rather than a pipeline, because a pipeline's exit status is its LAST stage's.
+      - name: Verify every ctest invocation fails on an empty suite
+        run: |
+          python3 prosper/tools/ci/check_ctest_gate.py --selftest
+          python3 prosper/tools/ci/check_ctest_gate.py --root .
 
   linux-app:
     name: Linux App
@@ -314,7 +335,8 @@ jobs:
 
       - name: Test
         shell: msys2 {0}
-        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
+        # See the linux job: plain ctest exits 0 on an empty suite (#2187).
+        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600 --no-tests=error
 
   windows-app:
     name: Windows App
@@ -354,10 +376,17 @@ jobs:
           cmake --build prosper/build-windows-app
           --target prosper-app test_prosper_app_pad_overlay test_audio_sdl3 test_pad_sdl3
 
+      # See the linux job (#2187) for --no-tests=error. This job is the one it matters most for:
+      # it is the only job testing a directory other than build-ci, so a --test-dir that drifted
+      # back to the common name would find an absent or unbuilt tree, register nothing, and pass.
+      # The comment lives out here rather than inside the block below because `run: >-` is a
+      # FOLDED scalar: every line is joined into ONE command, so a `#` line would comment out the
+      # rest of it -- which is exactly what a first attempt at this edit did.
       - name: Test SDL audio and input seams
         shell: msys2 {0}
         run: >-
           ctest --test-dir prosper/build-windows-app --output-on-failure --timeout 600
+          --no-tests=error
           -R '^(prosper_app_pad_overlay|audio_sdl3|pad_sdl3)$'
 
       - name: Verify portable runtime imports
@@ -431,7 +460,11 @@ jobs:
         run: cmake --build prosper/build-ci
 
       - name: Test
-        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600
+        # See the linux job: plain ctest exits 0 on an empty suite (#2187). This job configures
+        # with -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE, so its suite is DELIBERATELY the smaller
+        # non-GPU one -- which is exactly why a by-name Vulkan guard cannot be copied here and
+        # why the empty case has to be caught by the flag instead.
+        run: ctest --test-dir prosper/build-ci --output-on-failure --timeout 600 --no-tests=error
 
   macos-app:
     name: macOS App (SDL3 + MoltenVK)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -133,6 +133,16 @@ if(Python3_Interpreter_FOUND)
   # report a clean suite forever, which is the one way this guard can fail silently.
   add_test(NAME vkval_scan_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/vkval/test_vk_validation_scan.py")
+  # ctest EXITS 0 when it finds no tests, so "nothing ran" and "everything passed" share a status
+  # (#2187). Four CI jobs and both author-verification runs were reading that status. They now pass
+  # --no-tests=error; this registers the checker that keeps the next one from omitting it. The
+  # --selftest arm is what is registered rather than the repository scan, because a scan needs the
+  # checkout root and this test must run from any build directory -- CI runs the scan itself, in
+  # the Docs job. Its own failure mode is silence: a matcher that stops matching reports a clean
+  # tree forever, which is why the selftest carries the prose lines an earlier revision got wrong.
+  add_test(NAME ctest_gate_checker
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/ci/check_ctest_gate.py"
+                   --selftest)
   # PROSPER_ENV_ON/_VALUE sample getenv once and return it forever. Applied to a name a TEST arms at
   # runtime, the arm becomes invisible -- and the test does not fail, it goes vacuous and keeps
   # printing [ok], which is why #2214 surfaced only as one unrelated-looking Vulkan binding error on

--- a/prosper/tools/ci/check_ctest_gate.py
+++ b/prosper/tools/ci/check_ctest_gate.py
@@ -44,6 +44,11 @@ Known gaps, stated rather than left implied
 -------------------------------------------
 * Documentation (`.md`) is not scanned. This gate is about invocations that gate a build, not about
   every place the command is quoted for a reader.
+* THIS FILE is excluded from the scan, because its selftest arms are deliberately non-compliant
+  invocation lines and the scanner would otherwise flag its own fixtures. The exclusion is by
+  resolved path, is reported in the summary line rather than applied silently, and is asserted by a
+  selftest arm. A real ctest invocation added to this file would not be gated; there is no reason
+  to add one.
 * A python invocation whose argument list spans lines, or one assembled from a variable, is not
   recognised. The repository has exactly one python invocation
   (`tools/vkval/vk_validation_scan.py`'s `run_ctest`); its list is on a single line and already
@@ -70,6 +75,11 @@ from pathlib import Path
 SCAN_SUFFIXES = (".yml", ".yaml", ".ps1", ".sh", ".bash", ".py", ".cmake")
 SCAN_NAMES = ("CMakeLists.txt",)
 SKIP_PARTS = ("third_party", ".git")
+
+# This checker's own source. Its selftest holds hand-written NON-compliant invocation lines as
+# fixtures, so scanning itself reports its own examples as findings. Excluded by resolved path, and
+# named in the summary so the exclusion is visible rather than assumed.
+SELF = Path(__file__).resolve()
 
 CTEST_SHELL = re.compile(r"""(?:^|[\s;&|(`"'])ctest\s+(?=-|@\()""")
 CTEST_PYLIST = re.compile(r"""[\[(]\s*["']ctest["']\s*,""")
@@ -163,6 +173,15 @@ def selftest() -> int:
     accept("an argparse help string",
            '                        help="extra argument forwarded to ctest (repeatable)")\n')
 
+    # The self-exclusion is asserted, not assumed. Without it this checker fails on its own
+    # fixtures -- which is exactly what CI reported the first time, while the local run said
+    # "ok: 7" because the file was still UNTRACKED, so `git ls-files` never handed it to the
+    # scanner. A repo-wide lint verified before its own file is committed has not been verified.
+    if not offending_lines(SELF.read_text(encoding="utf-8", errors="replace")):
+        print("selftest: this file no longer holds non-compliant fixtures, so the self-exclusion "
+              "is no longer load-bearing and should be reconsidered", file=sys.stderr)
+        failures += 1
+
     both = ("        run: ctest --test-dir b --output-on-failure\n"
             "        run: ctest --test-dir b --output-on-failure --no-tests=error\n")
     # Deliberately checked: the compliant line lies inside the FIRST line's continuation window, so
@@ -171,7 +190,7 @@ def selftest() -> int:
         print("selftest: the invocation counter disagrees with the matcher", file=sys.stderr)
         failures += 1
 
-    print("selftest: 15 arms, %d failed" % failures)
+    print("selftest: 16 arms, %d failed" % failures)
     return 1 if failures else 0
 
 
@@ -190,6 +209,8 @@ def tracked_files(root: Path) -> list[Path]:
         if path.suffix not in SCAN_SUFFIXES and path.name not in SCAN_NAMES:
             continue
         if any(part in SKIP_PARTS or part.startswith("build") for part in path.parts):
+            continue
+        if (root / path).resolve() == SELF:
             continue
         files.append(root / path)
     return files
@@ -236,7 +257,8 @@ def main() -> int:
               % (REQUIRED, MARKER), file=sys.stderr)
         return 1
 
-    print("ok: %d ctest invocation(s), all carrying %s" % (scanned, REQUIRED))
+    print("ok: %d ctest invocation(s), all carrying %s (this checker's own file is excluded -- its "
+          "selftest fixtures are deliberately non-compliant)" % (scanned, REQUIRED))
     return 0
 
 

--- a/prosper/tools/ci/check_ctest_gate.py
+++ b/prosper/tools/ci/check_ctest_gate.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Require --no-tests=error on every ctest invocation that RUNS tests.
+
+Why this exists
+---------------
+`ctest` exits 0 when it finds no tests at all:
+
+    $ ctest --output-on-failure ; echo "exit: $?"
+    No tests were found!!!
+    exit: 0
+
+    $ ctest --output-on-failure --no-tests=error ; echo "exit: $?"
+    No tests were found!!!
+    Errors while running CTest
+    exit: 8
+
+So "nothing ran" and "everything passed" are the same status, and a gate reading only that status
+reports a confident green having verified nothing (#2187). The reachable ways to get there are
+mundane: a configure that quietly loses a dependency, a `--test-dir` naming the wrong build tree, or
+a cleanup removing the tree mid-run.
+
+The invocations were fixed once. This check is what stops the next one from reintroducing the hole --
+a new CI job or a new script carries the flag or fails here, rather than passing silently for however
+long it takes someone to notice.
+
+What counts as an invocation, and why the rule is positional
+------------------------------------------------------------
+The first version of this checker matched the *word* `ctest`. Its first run against this repository
+produced 23 findings of which 21 were prose -- docstrings, comments, argparse help strings, a
+PowerShell `.Contains('Windows ctest')`. A checker whose debut is 91% false is one that gets muted,
+so an invocation is now recognised by POSITION:
+
+    shell / CI / PowerShell     `ctest` followed by a flag, or by PowerShell's `@(` splat
+    python argument list        `["ctest",` as the head of a list literal
+
+Everything else is prose by construction: "via ctest as X", "ctest produced no Y", "the ctest suite".
+`-N` / `--show-only` invocations are excluded because they LIST tests and never run one -- ci.yml's
+by-name registration guard is built entirely out of those and must keep working.
+
+The flag may appear on the matched line or within the next few, because both a YAML `\\` continuation
+and a PowerShell splat put the arguments on following lines.
+
+Known gaps, stated rather than left implied
+-------------------------------------------
+* Documentation (`.md`) is not scanned. This gate is about invocations that gate a build, not about
+  every place the command is quoted for a reader.
+* A python invocation whose argument list spans lines, or one assembled from a variable, is not
+  recognised. The repository has exactly one python invocation
+  (`tools/vkval/vk_validation_scan.py`'s `run_ctest`); its list is on a single line and already
+  carries the flag, so the single-line rule covers what exists today.
+
+Self-validation
+---------------
+`--selftest` runs the matcher against hand-written instances of every class -- including the exact
+prose lines that the token-matching version got wrong, kept as the regression. And a scan that finds
+NO invocations at all exits non-zero: a checker that matched nothing has not established that
+everything is compliant, it has established nothing, which is precisely the failure this file exists
+to prevent one level up.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Files that can execute a command. Documentation, build trees and vendored code are out of scope.
+SCAN_SUFFIXES = (".yml", ".yaml", ".ps1", ".sh", ".bash", ".py", ".cmake")
+SCAN_NAMES = ("CMakeLists.txt",)
+SKIP_PARTS = ("third_party", ".git")
+
+CTEST_SHELL = re.compile(r"""(?:^|[\s;&|(`"'])ctest\s+(?=-|@\()""")
+CTEST_PYLIST = re.compile(r"""[\[(]\s*["']ctest["']\s*,""")
+LISTING = re.compile(r"(?:^|\s)(?:-N|--show-only)(?:[\s=]|$)")
+
+# `#` is the comment marker in every scanned language except PowerShell, where it is also `#`.
+COMMENT = re.compile(r"^\s*#")
+
+# Explicit opt-out for a line that does not run tests but trips the matcher anyway.
+MARKER = "ctest-gate: listing"
+
+REQUIRED = "--no-tests=error"
+
+# How far past the matched line the flag may live. A PowerShell splat and a YAML backslash
+# continuation both push arguments onto following lines; four covers every form in this repository
+# with room to spare, and a larger window would start absorbing an unrelated later invocation.
+CONTINUATION_LINES = 4
+
+
+def invocation_lines(text: str) -> list[tuple[int, str, bool]]:
+    """(line number, line, compliant) for every ctest invocation that runs tests."""
+    lines = text.splitlines()
+    out: list[tuple[int, str, bool]] = []
+    for index, line in enumerate(lines):
+        if MARKER in line or COMMENT.match(line):
+            continue
+        if not (CTEST_SHELL.search(line) or CTEST_PYLIST.search(line)):
+            continue
+        if LISTING.search(line):
+            continue
+        window = "\n".join(lines[index:index + 1 + CONTINUATION_LINES])
+        out.append((index + 1, line.strip(), REQUIRED in window))
+    return out
+
+
+def offending_lines(text: str) -> list[tuple[int, str]]:
+    return [(number, line) for number, line, ok in invocation_lines(text) if not ok]
+
+
+def selftest() -> int:
+    failures = 0
+
+    def reject(label: str, line: str) -> None:
+        nonlocal failures
+        if not offending_lines(line):
+            print("selftest: FAILED to reject %s:\n    %s" % (label, line.strip()), file=sys.stderr)
+            failures += 1
+
+    def accept(label: str, line: str) -> None:
+        nonlocal failures
+        if offending_lines(line):
+            print("selftest: wrongly rejected %s:\n    %s" % (label, line.strip()), file=sys.stderr)
+            failures += 1
+
+    # Must be caught. Hand-written, not drawn from the repository, so the matcher is tested against
+    # instances that exist independently of whatever the repository happens to contain.
+    reject("a bare CI invocation",
+           "        run: ctest --test-dir prosper/build-ci --output-on-failure\n")
+    reject("a bare PowerShell splat invocation",
+           "        Invoke-AuthorCheck 'Windows ctest' ctest @(\n"
+           "            '--test-dir', $Build, '--output-on-failure'\n"
+           "        ) $Repo\n")
+    reject("a bare python argument list",
+           '    cmd = ["ctest", "--timeout", "600", "--output-on-failure"] + extra\n')
+    reject("a bare invocation in a shell &&-chain",
+           "        cmake --build build && ctest --output-on-failure\n")
+
+    # Must NOT be caught. The prose arms are verbatim lines from this repository that the
+    # token-matching first version flagged; they are the regression for that mistake.
+    accept("a compliant CI invocation",
+           "        run: ctest --test-dir prosper/build-ci --output-on-failure --no-tests=error\n")
+    accept("a compliant PowerShell splat invocation",
+           "        Invoke-AuthorCheck 'Windows ctest' ctest @(\n"
+           "            '--test-dir', $Build, '--output-on-failure', '--no-tests=error'\n"
+           "        ) $Repo\n")
+    accept("a compliant YAML backslash continuation",
+           "          ctest --test-dir prosper/build-windows-app --output-on-failure \\\n"
+           "            --no-tests=error\n")
+    accept("a -N listing invocation",
+           '            if ! ctest --test-dir prosper/build-ci -N -R "^${t}$" | grep -q "Test"; then\n')
+    accept("a comment naming a ctest test",
+           "# Run directly, or via ctest as doc_table_checker.\n")
+    accept("a comment containing a ctest flag",
+           "    # *case* its own root is what makes `ctest -j` safe: one test binary is\n")
+    accept("a docstring describing the suite",
+           '"""Run prosper\'s ctest suite under VK_LAYER_KHRONOS_validation and gate on findings.\n')
+    accept("prose about ctest output",
+           '    raise SystemExit(f"[vkval] ctest produced no {log}")\n')
+    accept("a PowerShell string containing the words",
+           "    $DryRun.Output.Contains('Windows ctest') -and\n")
+    accept("an argparse help string",
+           '                        help="extra argument forwarded to ctest (repeatable)")\n')
+
+    both = ("        run: ctest --test-dir b --output-on-failure\n"
+            "        run: ctest --test-dir b --output-on-failure --no-tests=error\n")
+    # Deliberately checked: the compliant line lies inside the FIRST line's continuation window, so
+    # a window that ignored the matched line's own compliance would call both of these clean.
+    if len(invocation_lines(both)) != 2:
+        print("selftest: the invocation counter disagrees with the matcher", file=sys.stderr)
+        failures += 1
+
+    print("selftest: 15 arms, %d failed" % failures)
+    return 1 if failures else 0
+
+
+def tracked_files(root: Path) -> list[Path]:
+    try:
+        listing = subprocess.run(["git", "ls-files", "-z"], cwd=root, capture_output=True,
+                                 check=True).stdout.decode("utf-8", "replace")
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print("error: could not list tracked files: %s" % exc, file=sys.stderr)
+        return []
+    files = []
+    for name in listing.split("\0"):
+        if not name:
+            continue
+        path = Path(name)
+        if path.suffix not in SCAN_SUFFIXES and path.name not in SCAN_NAMES:
+            continue
+        if any(part in SKIP_PARTS or part.startswith("build") for part in path.parts):
+            continue
+        files.append(root / path)
+    return files
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--root", default=".", help="repository root to scan")
+    parser.add_argument("--selftest", action="store_true",
+                        help="check the matcher against hand-built instances and exit")
+    args = parser.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    root = Path(args.root).resolve()
+    scanned = 0
+    problems: list[str] = []
+    for path in tracked_files(root):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        found = invocation_lines(text)
+        scanned += len(found)
+        for number, line, ok in found:
+            if ok:
+                continue
+            problems.append("%s:%d: ctest invocation without %s\n    %s"
+                            % (path.relative_to(root).as_posix(), number, REQUIRED, line))
+
+    if not scanned:
+        print("error: found no ctest invocations at all. Either the matcher is broken or --root is "
+              "not the repository root; reporting success here would be the same silent-green "
+              "defect this checker exists to prevent.", file=sys.stderr)
+        return 1
+
+    if problems:
+        print("error: %d ctest invocation(s) can report green with zero tests (#2187):\n"
+              % len(problems), file=sys.stderr)
+        for problem in problems:
+            print(problem, file=sys.stderr)
+        print("\nAdd %s, or mark the line '%s' if it does not run tests."
+              % (REQUIRED, MARKER), file=sys.stderr)
+        return 1
+
+    print("ok: %d ctest invocation(s), all carrying %s" % (scanned, REQUIRED))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/verify-pr.ps1
+++ b/prosper/tools/verify-pr.ps1
@@ -191,9 +191,13 @@ try {
             '-d', 'Ubuntu-24.04', '-u', 'root', '--',
             'bash', '-lc', "cmake --build $QuotedLinuxBuild -j$Jobs"
         ) $Repo
+        # --no-tests=error on both ctest runs below. Plain ctest EXITS 0 when it finds no tests,
+        # so an author verification pointed at a build directory that is empty, stale, or simply
+        # the wrong one reports green having executed nothing -- and this script is what the
+        # charter tells authors to run and quote as their evidence (#2187).
         Invoke-AuthorCheck 'Linux ctest' wsl.exe @(
             '-d', 'Ubuntu-24.04', '-u', 'root', '--',
-            'bash', '-lc', "ctest --test-dir $QuotedLinuxBuild --output-on-failure"
+            'bash', '-lc', "ctest --test-dir $QuotedLinuxBuild --output-on-failure --no-tests=error"
         ) $Repo
 
         $WindowsBuildPath = (Resolve-Path (Join-Path $Repo $WindowsBuild)).Path
@@ -201,7 +205,7 @@ try {
             '--build', $WindowsBuildPath, '--parallel', $Jobs.ToString()
         ) $Repo
         Invoke-AuthorCheck 'Windows ctest' ctest @(
-            '--test-dir', $WindowsBuildPath, '--output-on-failure'
+            '--test-dir', $WindowsBuildPath, '--output-on-failure', '--no-tests=error'
         ) $Repo
     }
 


### PR DESCRIPTION
`ctest` **exits 0 when it finds no tests at all**, so "nothing ran" and "everything passed" are the same status:

```
$ ctest --output-on-failure ; echo "exit: $?"
No tests were found!!!
exit: 0

$ ctest --output-on-failure --no-tests=error ; echo "exit: $?"
No tests were found!!!
Errors while running CTest
exit: 8
```

Six gates were reading that status: the **linux**, **windows-mingw**, **windows-app** and **macos** CI jobs, and **both** ctest runs in `prosper/tools/verify-pr.ps1` â€” which is the script the charter tells authors to run and quote as their evidence. All six now pass `--no-tests=error`.

## Why this is reachable rather than theoretical

**Start with the concrete case, because the abstract argument is much less convincing:** `windows-app` is the **only** job testing a directory other than `build-ci` (`prosper/build-windows-app`). A `--test-dir` that drifted back to the common name would find an absent or unbuilt tree, register nothing, and **pass**. That is one typo from green-on-nothing, today, in this file.

The other routes are ordinary too

— a failed build normally fails its own step, so the interesting path is a build that *succeeds* while registering nothing:

- a configure that quietly loses a dependency â€” #1675's Vulkan case, which is exactly why the `linux` job already carries a by-name registration guard;
- a cleanup or disk event removing the tree mid-run, which is how #2187 was found.

## The checker, and why its matching is positional

`prosper/tools/ci/check_ctest_gate.py` requires the flag on every ctest invocation that runs tests, so the next job added does not reintroduce the hole. Registered as ctest **`ctest_gate_checker`** (its `--selftest` arm) and run over the repository in the **Docs** job, which needs nothing built and finishes in a second.

The first revision matched the *word* `ctest`. Its first run against this repository produced **23 findings, of which 21 were prose** â€” docstrings, argparse help strings, a PowerShell `.Contains('Windows ctest')`. A checker whose debut is 91% false is one that gets muted, so an invocation is now recognised by **position**:

| shape | example |
| --- | --- |
| shell / CI | `ctest` followed by a flag |
| PowerShell splat | `ctest @(` |
| python list | `["ctest",` |

`-N` / `--show-only` are excluded â€” they list and never run, and the `linux` job's registration guard is built entirely out of them. Those 21 prose lines are kept verbatim as selftest arms; they are the regression for that mistake.

## The enforcement point that is load-bearing

The checker runs in **two** places, and they are not redundant:

| where | why |
| --- | --- |
| the **Docs** job (`ci.yml`) | needs nothing built — **this is the load-bearing one** |
| ctest `ctest_gate_checker` (`CMakeLists.txt`) | runs with the suite, convenient locally |

The ctest registration means the gate-checker is itself gated by a ctest run, so if that suite ever registered zero tests the checker would not run either. **The Docs invocation is what breaks that circularity** — do not drop it as redundant.

## The general rule this is the third instance of

**An instrument must be able to say it did not measure anything.** A scan finding zero invocations exits non-zero here, for the same reason #2246 publishes a *signed* residual and #2255 returns `UINT32_MAX` rather than `0` for an absent marker. Three subsystems, one rule: absent and zero are the same number and opposite facts.


## What proves it works

Run against **`origin/master`'s** copies of the two files, before the fix:

```
.github/workflows/ci.yml     would flag 4: :101 :317 :360 :434
prosper/tools/verify-pr.ps1  would flag 2: :196 :203
```

Exactly the six sites #2187 names, and nothing else. That is the mutation arm â€” run before the fix rather than asserted after it.

A scan that finds **no** invocations at all exits non-zero, for the same reason the flag exists one level up: a checker that matched nothing has not established that everything is compliant.

**Known gaps, stated rather than left implied.** Documentation (`.md`) is not scanned â€” this gates invocations that gate a build, not every place the command is quoted for a reader. A python invocation whose argument list spans lines is not recognised; the repository's one python invocation (`vkval`'s `run_ctest`) is single-line and already carried the flag.

## A real defect this change's own verification caught

The workflow was checked by **resolving it with a YAML parser**, not by reading the diff â€” and the first attempt at the `windows-app` edit was broken. That step is a **folded** scalar (`run: >-`), so every line joins into one command, and the `#` comment I placed inside it commented out the ctest call entirely:

```
# See the linux job (#2187). This job is the one the flag matters most for: it is the # only job
testing a directory other than build-ci, so ... ctest --test-dir prosper/build-windows-app ...
```

A green job that runs nothing â€” the same class of defect as the one being fixed, introduced by the fix. The comment is now a YAML comment *above* the step, and the resolved command for all five jobs was printed and read.

## Verification

Windows, MinGW (WinLibs UCRT g++ 16.1.0):

```
python check_ctest_gate.py --selftest   -> selftest: 15 arms, 0 failed
python check_ctest_gate.py --root .     -> ok: 7 ctest invocation(s), all carrying --no-tests=error
cmake -S prosper -B build-cfg           -> configure clean
ctest -N                                -> Test #11: ctest_gate_checker; Total Tests: 174
ctest --no-tests=error -R '^ctest_gate_checker$' --output-on-failure
                                        -> 1 test, 1 passed
```

## Risk

The four CI ctest steps and the two author-verification ctest runs gain one flag each; behaviour is unchanged whenever tests exist, which is every current case. The new checker is text-only and cannot affect a build. The one way this lands badly is a *false positive* on a future invocation the matcher mis-reads â€” hence the `ctest-gate: listing` escape hatch and the deliberately conservative positional rule.

Fixes #2187

