### PR TITLE
perf(render): memoize descriptor reflection on shader identity — 30.37 -> 0.00 ms/submit

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1714,8 +1714,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             //
             // Bounded at the same 4,096 entries the shader cache itself uses. On overflow the map is
             // cleared wholesale rather than evicted by age: there is no LRU bookkeeping to pay for on
-            // a path this hot, 523 distinct per submit leaves ample headroom, and `memo_clears` in
-            // the timing report makes a thrash visible instead of silent.
+            // a path this hot, and 523 distinct shaders per submit leaves ample headroom.
+            //
+            // The overflow behaviour does NOT degrade gracefully, and `memo_clears` should be read
+            // accordingly: a title exceeding the cap would clear and refill repeatedly, paying the
+            // full reflection cost again PLUS the map churn. So a non-zero `memo_clears` means this
+            // optimisation has STOPPED WORKING, not that a threshold was brushed -- do not read a
+            // small non-zero value as benign. Observed 0 across a 13-minute Blue Prince route.
+            //
+            // The entry copies the whole DescriptorValidationReport although this path reads only
+            // `descriptors`. Deliberate: storing the subset would bound the footprint to what is
+            // used, but it would also make the entry a lie about what it holds the moment a caller
+            // reads `issues`, and at 523 entries against a 4,096 cap the footprint is not the
+            // constraint. If that ever inverts, narrow the entry rather than raising the cap.
             struct ReflectMemoEntry {
                 prosper::gpu::DescriptorValidationReport report;
                 uint32_t set = 0;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1242,6 +1242,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 double build_reflect_ms = 0;
                 uint64_t build_reflect_calls = 0, build_reflect_words = 0;
                 uint64_t build_reflect_unidentified = 0;
+                uint64_t build_reflect_memo_hits = 0, build_reflect_memo_clears = 0;
+                uint64_t build_reflect_memo_mismatch = 0;
                 std::unordered_set<uint64_t> build_reflect_identities;
             };
             struct RttTimingRecord {
@@ -1691,6 +1693,36 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             // Build one draw's set-tagged resources from its VS (set 0) + PS (set 1) tables — read the
             // bytes from 1:1-mapped guest memory, detile textures. (Each constant/vertex buffer + texture
             // gets its own binding; the recompiler declared a storage buffer / image sampler at each.)
+            // #2256. `validate_spirv_descriptor_interface` is memoized inside shader_resources.cpp,
+            // but its HIT path is O(module size) twice -- an FNV-1a walk of every word to build the
+            // key, then a full vector equality compare to confirm it -- under a process-global lock,
+            // and build_R calls it twice per draw. Measured on a Blue Prince gameplay submit
+            // (PPSA25009, 2,103 draws): 30.37 ms/submit, 53% of build_R and 9.3% of the frame,
+            // traversing 27.2 million words. 3,231 calls served 523 distinct shaders, so 84% of that
+            // work was re-deriving a key for a module already reflected.
+            //
+            // The caller already holds a cheap stable key. DrawItem::vs_identity/fs_identity come
+            // from the exact shader-recompile cache as `cache.next_identity++`
+            // (src/gpu/gpu_executor.cpp:1255) -- a monotonic counter that is NEVER reused, so an
+            // identity denotes one module for the life of the process even across cache eviction
+            // (an evicted shader recompiles to a NEW identity, which misses here and is refilled).
+            //
+            // This changes no semantics. The upstream cache already returns its stored report for a
+            // matching module regardless of which runtime table was passed, so the report was
+            // already a pure function of the SPIR-V; and this call site reads only
+            // `report.descriptors` (via find_spirv_descriptor_binding), never `report.issues`.
+            //
+            // Bounded at the same 4,096 entries the shader cache itself uses. On overflow the map is
+            // cleared wholesale rather than evicted by age: there is no LRU bookkeeping to pay for on
+            // a path this hot, 523 distinct per submit leaves ample headroom, and `memo_clears` in
+            // the timing report makes a thrash visible instead of silent.
+            struct ReflectMemoEntry {
+                prosper::gpu::DescriptorValidationReport report;
+                uint32_t set = 0;
+                prosper::gpu::SpirvShaderStage stage = prosper::gpu::SpirvShaderStage::Unknown;
+            };
+            static thread_local std::unordered_map<uint64_t, ReflectMemoEntry> reflect_memo;
+            constexpr size_t kReflectMemoMaxEntries = 4096;
             auto build_R = [&](const prosper::gpu::DrawItem& draw,
                                const prosper::gpu::ShaderResourceTable* vrt,
                                const prosper::gpu::ShaderResourceTable* prt) {
@@ -1713,11 +1745,46 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // faith. `distinct` is the memo's CEILING and is deliberately UNCAPPED -- the last
                 // attempt on this path (#2239) died because its justifying probe hit a 4,096-entry
                 // cap on precisely this count, and a truncated ceiling reads as a small one.
-                const auto rt0 = timing_enabled ? RenderClock::now() : RenderClock::time_point{};
-                const prosper::gpu::DescriptorValidationReport reflected =
-                    prosper::gpu::validate_spirv_descriptor_interface(
+                const prosper::gpu::DescriptorValidationReport* memoized = nullptr;
+                if (shader_identity) {
+                    const auto found = reflect_memo.find(shader_identity);
+                    // set/stage are checked rather than assumed. They are fixed per module on this
+                    // path today (VS -> set 0, PS -> set 1), so a mismatch cannot occur -- but the
+                    // key is the identity alone, and a silent wrong answer here would be a wrong
+                    // descriptor contract rather than a slow one. A mismatch falls through to the
+                    // real call and is counted.
+                    if (found != reflect_memo.end() &&
+                        found->second.set == set && found->second.stage == stage)
+                        memoized = &found->second.report;
+                    else if (found != reflect_memo.end()) {
+                        ++pending_timing.build_reflect_memo_mismatch;
+                        // Loud and unconditional on first occurrence, NOT gated on timing: this
+                        // path is unreachable by the argument above, and if the argument is wrong
+                        // the consequence is a wrong descriptor contract rather than a slow frame.
+                        // A counter only a timing run prints would hide exactly the case that
+                        // matters. The fallback is correct either way -- it re-reflects -- so this
+                        // reports rather than fails.
+                        static thread_local bool warned = false;
+                        if (!warned) {
+                            warned = true;
+                            fprintf(stderr,
+                                    "[render] *** shader identity %llu was reflected for set=%u "
+                                    "stage=%u and is now asked for set=%u stage=%u -- identity is "
+                                    "not stage-unique after all (#2256). Re-reflecting; the "
+                                    "descriptor contract is unaffected%s",
+                                    (unsigned long long)shader_identity, found->second.set,
+                                    (unsigned)found->second.stage, set, (unsigned)stage, "\n");
+                        }
+                    }
+                }
+                if (memoized && timing_enabled) ++pending_timing.build_reflect_memo_hits;
+                const auto rt0 = (timing_enabled && !memoized)
+                    ? RenderClock::now() : RenderClock::time_point{};
+                prosper::gpu::DescriptorValidationReport computed;
+                if (!memoized)
+                    computed = prosper::gpu::validate_spirv_descriptor_interface(
                         spirv, t, set, stage, false);
-                if (timing_enabled) {
+                if (!memoized && timing_enabled) {
                     pending_timing.build_reflect_ms +=
                         std::chrono::duration<double, std::milli>(
                             RenderClock::now() - rt0).count();
@@ -1732,6 +1799,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     else
                         ++pending_timing.build_reflect_unidentified;
                 }
+                if (!memoized && shader_identity) {
+                    if (reflect_memo.size() >= kReflectMemoMaxEntries) {
+                        reflect_memo.clear();
+                        if (timing_enabled) ++pending_timing.build_reflect_memo_clears;
+                    }
+                    ReflectMemoEntry entry;
+                    entry.report = computed;
+                    entry.set = set;
+                    entry.stage = stage;
+                    memoized = &reflect_memo.emplace(shader_identity, std::move(entry))
+                                   .first->second.report;
+                }
+                // Bound to the memo entry when there is one and to the local otherwise. Both outlive
+                // the per-resource loop below, and the loop does not touch the map.
+                const prosper::gpu::DescriptorValidationReport& reflected =
+                    memoized ? *memoized : computed;
                 for (auto& r : t->resources) {
                     const prosper::gpu::SpirvDescriptorBinding* reflected_binding =
                         prosper::gpu::find_spirv_descriptor_binding(
@@ -6686,6 +6769,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     double build_reflect_ms = 0;
                     uint64_t build_reflect_calls = 0, build_reflect_words = 0;
                     uint64_t build_reflect_unidentified = 0, build_reflect_distinct = 0;
+                    uint64_t build_reflect_memo_hits = 0, build_reflect_memo_clears = 0;
+                    uint64_t build_reflect_memo_mismatch = 0;
                 };
                 static TimingTotals totals;
                 static TimingTotals window;
@@ -6776,6 +6861,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.build_reflect_words += pending_timing.build_reflect_words;
                     timing.build_reflect_unidentified += pending_timing.build_reflect_unidentified;
                     timing.build_reflect_distinct += pending_timing.build_reflect_identities.size();
+                    timing.build_reflect_memo_hits += pending_timing.build_reflect_memo_hits;
+                    timing.build_reflect_memo_clears += pending_timing.build_reflect_memo_clears;
+                    timing.build_reflect_memo_mismatch += pending_timing.build_reflect_memo_mismatch;
                     timing.buffer_ms += pending_timing.buffer_ms;
                 };
                 accumulate(totals);
@@ -6964,12 +7052,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // building however large the ms turns out to be.
                         fprintf(stderr,
                                 "[render-timing] build_R reflect %.3f ms/submit calls=%.1f "
-                                "distinct=%.1f unidentified=%.1f words=%.0f/submit\n",
+                                "distinct=%.1f unidentified=%.1f words=%.0f/submit "
+                                "memo_hits=%.1f clears=%.1f mismatch=%.1f\n",
                                 totals.build_reflect_ms / nsub,
                                 (double)totals.build_reflect_calls / nsub,
                                 (double)totals.build_reflect_distinct / nsub,
                                 (double)totals.build_reflect_unidentified / nsub,
-                                (double)totals.build_reflect_words / nsub);
+                                (double)totals.build_reflect_words / nsub,
+                                (double)totals.build_reflect_memo_hits / nsub,
+                                (double)totals.build_reflect_memo_clears / nsub,
+                                (double)totals.build_reflect_memo_mismatch / nsub);
                         if (br_other < -0.05 * nsub)
                             fprintf(stderr,
                                     "[render-timing] *** build_resources leaves EXCEED their parent "
@@ -7185,12 +7277,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 (double)window.build_rejected / wn);
                         fprintf(stderr,
                                 "[render-window] build_R reflect %.3f ms/submit calls=%.1f "
-                                "distinct=%.1f unidentified=%.1f words=%.0f/submit\n",
+                                "distinct=%.1f unidentified=%.1f words=%.0f/submit "
+                                "memo_hits=%.1f clears=%.1f mismatch=%.1f\n",
                                 window.build_reflect_ms / wn,
                                 (double)window.build_reflect_calls / wn,
                                 (double)window.build_reflect_distinct / wn,
                                 (double)window.build_reflect_unidentified / wn,
-                                (double)window.build_reflect_words / wn);
+                                (double)window.build_reflect_words / wn,
+                                (double)window.build_reflect_memo_hits / wn,
+                                (double)window.build_reflect_memo_clears / wn,
+                                (double)window.build_reflect_memo_mismatch / wn);
                         if (br_other_w < -0.05 * wn)
                             fprintf(stderr,
                                     "[render-window] *** build_resources leaves EXCEED their parent "

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -50,6 +50,7 @@
 #include <set>
 #include <map>
 #include <unordered_map>
+#include <unordered_set>
 
 #ifdef _WIN32
 #ifndef NOMINMAX
@@ -1234,6 +1235,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 double build_r_ms = 0, build_validate_ms = 0;
                 double build_poison_ms = 0, build_indices_ms = 0;
                 uint64_t build_draws = 0, build_rejected = 0;
+                // One level deeper, into build_R's own residual (#2256). `identities` is a SET and
+                // not a counter on purpose: its size is how many distinct shaders a submit-scoped
+                // memo would have to hold, which is the ceiling on what such a memo could save.
+                // It is cleared per submit with the rest of this struct.
+                double build_reflect_ms = 0;
+                uint64_t build_reflect_calls = 0, build_reflect_words = 0;
+                uint64_t build_reflect_unidentified = 0;
+                std::unordered_set<uint64_t> build_reflect_identities;
             };
             struct RttTimingRecord {
                 int submit = 0;
@@ -1688,11 +1697,41 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
               std::vector<prosper::test::FrameResource> R;
               auto add = [&](const prosper::gpu::ShaderResourceTable* t, uint32_t set,
                              const std::vector<uint32_t>& spirv,
-                             prosper::gpu::SpirvShaderStage stage){
+                             prosper::gpu::SpirvShaderStage stage,
+                             uint64_t shader_identity){
                 if (!t) return;
+                // #2256. This call is memoized inside shader_resources.cpp, but the memo's HIT path
+                // is O(module size) three times over -- an FNV-1a walk to build the key, a full
+                // vector equality compare to confirm it, and a copy of the report -- under a
+                // process-global lock, twice per draw. Time it as its own leaf of build_R rather
+                // than guessing: build_R's residual is the largest unexplained bucket in the
+                // renderer (+6.16 of 8.02 ms/submit on RADV, #2250) and this is the biggest fixed
+                // per-draw cost inside it.
+                //
+                // `words` is the falsifiable magnitude: it is exactly what the hash and the memcmp
+                // each traverse, so a reader can check the ms against it instead of taking it on
+                // faith. `distinct` is the memo's CEILING and is deliberately UNCAPPED -- the last
+                // attempt on this path (#2239) died because its justifying probe hit a 4,096-entry
+                // cap on precisely this count, and a truncated ceiling reads as a small one.
+                const auto rt0 = timing_enabled ? RenderClock::now() : RenderClock::time_point{};
                 const prosper::gpu::DescriptorValidationReport reflected =
                     prosper::gpu::validate_spirv_descriptor_interface(
                         spirv, t, set, stage, false);
+                if (timing_enabled) {
+                    pending_timing.build_reflect_ms +=
+                        std::chrono::duration<double, std::milli>(
+                            RenderClock::now() - rt0).count();
+                    ++pending_timing.build_reflect_calls;
+                    pending_timing.build_reflect_words += spirv.size();
+                    // Identity 0 means the module came from an external/replay path, so no memo
+                    // keyed on identity could serve it. Counted separately: folding those into
+                    // `distinct` would inflate the ceiling, folding them into the hit population
+                    // would inflate the saving. They are neither.
+                    if (shader_identity)
+                        pending_timing.build_reflect_identities.insert(shader_identity);
+                    else
+                        ++pending_timing.build_reflect_unidentified;
+                }
                 for (auto& r : t->resources) {
                     const prosper::gpu::SpirvDescriptorBinding* reflected_binding =
                         prosper::gpu::find_spirv_descriptor_binding(
@@ -4697,8 +4736,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     R.push_back(std::move(fr));
                 }
               };
-              add(vrt, 0, draw.vs_words(), prosper::gpu::SpirvShaderStage::Vertex);
-              add(prt, 1, draw.fs_words(), prosper::gpu::SpirvShaderStage::Fragment);
+              add(vrt, 0, draw.vs_words(), prosper::gpu::SpirvShaderStage::Vertex,
+                  draw.vs_identity);
+              add(prt, 1, draw.fs_words(), prosper::gpu::SpirvShaderStage::Fragment,
+                  draw.fs_identity);
               // VS resources -> descriptor set 0, PS -> set 1
               return R;
             };
@@ -6638,6 +6679,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     double build_r_ms = 0, build_validate_ms = 0;
                     double build_poison_ms = 0, build_indices_ms = 0;
                     uint64_t build_draws = 0, build_rejected = 0;
+                    // A COUNT here, not a set: the aggregate sums each submit's distinct count so
+                    // the report can divide by submits. A lifetime union would answer a different
+                    // question (how many shaders the title has) and would over-state the ceiling
+                    // for a memo whose scope is one submit.
+                    double build_reflect_ms = 0;
+                    uint64_t build_reflect_calls = 0, build_reflect_words = 0;
+                    uint64_t build_reflect_unidentified = 0, build_reflect_distinct = 0;
                 };
                 static TimingTotals totals;
                 static TimingTotals window;
@@ -6723,6 +6771,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.build_indices_ms += pending_timing.build_indices_ms;
                     timing.build_draws += pending_timing.build_draws;
                     timing.build_rejected += pending_timing.build_rejected;
+                    timing.build_reflect_ms += pending_timing.build_reflect_ms;
+                    timing.build_reflect_calls += pending_timing.build_reflect_calls;
+                    timing.build_reflect_words += pending_timing.build_reflect_words;
+                    timing.build_reflect_unidentified += pending_timing.build_reflect_unidentified;
+                    timing.build_reflect_distinct += pending_timing.build_reflect_identities.size();
                     timing.buffer_ms += pending_timing.buffer_ms;
                 };
                 accumulate(totals);
@@ -6869,22 +6922,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // here would double-count. That is the cross-layer subtraction #2243 fixed,
                     // and this comment exists so nobody re-derives it from the field names.
                     {
+                        // build_reflect_ms is INSIDE build_r_ms, so it is a sub-split of the
+                        // build_R leaf and must not be subtracted from build_resources here --
+                        // only from build_R's own residual above. Subtracting it at both levels
+                        // would drive the outer residual negative and trip the guard on a run
+                        // where nothing is wrong.
                         const double br_other = totals.build_resources_ms - totals.build_r_ms -
                                                 totals.build_validate_ms - totals.build_poison_ms -
                                                 totals.build_indices_ms;
                         fprintf(stderr,
                                 "[render-timing] build_resources %.2f ms/submit [build_R=%.2f "
-                                "(texture=%.2f buffer=%.2f other=%+.2f) validate=%.2f indices=%.2f "
+                                "(texture=%.2f buffer=%.2f reflect=%.2f other=%+.2f) "
+                                "validate=%.2f indices=%.2f "
                                 "poison=%.2f other=%+.2f] draws=%.1f (+%.1f rejected; build_R and validate cover both, poison and indices only the accepted)\n",
                                 totals.build_resources_ms / nsub, totals.build_r_ms / nsub,
                                 totals.texture_ms / nsub, totals.buffer_ms / nsub,
+                                totals.build_reflect_ms / nsub,
                                 // build_R's OWN residual, published for the same reason as its
                                 // parent's. texture+buffer covered 3.71 of 5.20 ms on the first run
                                 // of this instrument -- 29% of build_R with nothing naming it. A
                                 // nested partition that reports only the outer remainder just moves
                                 // the blind spot one level down, which is the mistake this whole
                                 // line exists to stop repeating.
-                                (totals.build_r_ms - totals.texture_ms - totals.buffer_ms) / nsub,
+                                (totals.build_r_ms - totals.texture_ms - totals.buffer_ms -
+                                 totals.build_reflect_ms) / nsub,
                                 totals.build_validate_ms / nsub, totals.build_indices_ms / nsub,
                                 totals.build_poison_ms / nsub, br_other / nsub,
                                 (double)totals.build_draws / nsub,
@@ -6894,6 +6955,21 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // build_bds() again at :5815, OUTSIDE the build_start/build_done span, so
                         // every prefix rebuild lands in the leaves without landing in the parent --
                         // and that loop is O(N^2) in draws. Zero occurrences on a default run.
+                        // The reflect leaf's own supporting numbers (#2256). `words` is what
+                        // the memo's key derivation and its equality check each traverse, so the
+                        // ms is checkable against it rather than merely assertable. `distinct` is
+                        // the per-submit ceiling on what an identity-keyed memo could remove:
+                        // calls - distinct - unidentified is the number of calls it could serve
+                        // from cache, and if that difference is small the memo is not worth
+                        // building however large the ms turns out to be.
+                        fprintf(stderr,
+                                "[render-timing] build_R reflect %.3f ms/submit calls=%.1f "
+                                "distinct=%.1f unidentified=%.1f words=%.0f/submit\n",
+                                totals.build_reflect_ms / nsub,
+                                (double)totals.build_reflect_calls / nsub,
+                                (double)totals.build_reflect_distinct / nsub,
+                                (double)totals.build_reflect_unidentified / nsub,
+                                (double)totals.build_reflect_words / nsub);
                         if (br_other < -0.05 * nsub)
                             fprintf(stderr,
                                     "[render-timing] *** build_resources leaves EXCEED their parent "
@@ -7095,15 +7171,26 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                   window.build_indices_ms;
                         fprintf(stderr,
                                 "[render-window] build_resources %.2f ms/submit [build_R=%.2f "
-                                "(texture=%.2f buffer=%.2f other=%+.2f) validate=%.2f indices=%.2f "
+                                "(texture=%.2f buffer=%.2f reflect=%.2f other=%+.2f) "
+                                "validate=%.2f indices=%.2f "
                                 "poison=%.2f other=%+.2f] draws=%.1f (+%.1f rejected)\n",
                                 window.build_resources_ms / wn, window.build_r_ms / wn,
                                 window.texture_ms / wn, window.buffer_ms / wn,
-                                (window.build_r_ms - window.texture_ms - window.buffer_ms) / wn,
+                                window.build_reflect_ms / wn,
+                                (window.build_r_ms - window.texture_ms - window.buffer_ms -
+                                 window.build_reflect_ms) / wn,
                                 window.build_validate_ms / wn, window.build_indices_ms / wn,
                                 window.build_poison_ms / wn, br_other_w / wn,
                                 (double)window.build_draws / wn,
                                 (double)window.build_rejected / wn);
+                        fprintf(stderr,
+                                "[render-window] build_R reflect %.3f ms/submit calls=%.1f "
+                                "distinct=%.1f unidentified=%.1f words=%.0f/submit\n",
+                                window.build_reflect_ms / wn,
+                                (double)window.build_reflect_calls / wn,
+                                (double)window.build_reflect_distinct / wn,
+                                (double)window.build_reflect_unidentified / wn,
+                                (double)window.build_reflect_words / wn);
                         if (br_other_w < -0.05 * wn)
                             fprintf(stderr,
                                     "[render-window] *** build_resources leaves EXCEED their parent "


### PR DESCRIPTION
`validate_spirv_descriptor_interface` was **30.37 ms/submit — 53% of `build_R`, 46% of `build_resources`, 9.3% of a 325.96 ms Blue Prince gameplay frame.** It is now **0.00**.

Two commits: the instrument that found it, then the fix. They are together because the instrument is the evidence and neither is worth reading alone.

## What was costing 30 ms

`build_R` calls it twice per draw. It is *already* memoized inside `shader_resources.cpp` — the cost is the memo's **hit** path:

```cpp
const uint64_t reflection_hash = spirv_reflection_hash(spirv);   // FNV-1a over EVERY word  :476
...
    std::lock_guard lock(cache.mutex);                           // process-global lock
    if (found != cache.entries.end() && found->second.spirv == spirv) {   // full module memcmp :611
        report = found->second.reflection;                       // whole report copied
```

At 2,103 draws/submit that is **3,231 calls traversing 27.2 million words — 108 MB — twice each**. 54 M word-operations in 30.4 ms is ~1.8 G/s, which is what a memory-bound FNV plus `memcmp` costs; the ms and the word count agree, which is why both are printed.

## The fix is at the caller. The cache is not touched.

The cache's strictness is **correct** and this change does not weaken it — equality is authoritative there precisely so a hash collision cannot hand back another module's descriptor contract. What is wrong is that the caller re-derives a key from raw bytes on every draw while already holding a cheap stable one.

`DrawItem::vs_identity`/`fs_identity` come from the exact shader-recompile cache as `cache.next_identity++` — **two mint sites, `src/gpu/gpu_executor.cpp:1255` (graphics) and `:1441` (compute), both on the same `shader_cache()` singleton and therefore the same counter declared at `:437`, which is its only assignment** — **a monotonic counter that is never reused**, so an identity denotes one module for the life of the process *even across cache eviction*: an evicted shader recompiles to a **new** identity, which misses here and refills. Identity `0` (external/replay module) falls through to the existing call unchanged.

### A second, independent reason the leaf goes to zero

The memo is `static thread_local`, so the hit path is **lock-free**. What it replaces took a
**process-global mutex** (`shader_resources.cpp:611`) on every one of 3,231 calls per submit. So this
removes lock traffic as well as the FNV walk and the `memcmp` — a reader reconstructing where 30 ms
went should not attribute all of it to hashing.

### Why this is not a semantic change

Two independent reasons, both checkable:

1. **The upstream cache already collapses table-dependence.** On a hit it returns its stored `reflection` wholesale regardless of which runtime table was passed, so the report was *already* a pure function of the SPIR-V before this change.
2. **This call site reads only `report.descriptors`** — via `find_spirv_descriptor_binding` — and never `report.issues`, which is the table-dependent half.

`set`/`stage` are stored per entry and **checked, not assumed**. A mismatch cannot occur on this path (VS → set 0, PS → set 1), but the key is the identity alone and a wrong answer here would be a wrong *descriptor contract* rather than a slow frame — so a mismatch falls through to the real call and warns **loudly and unconditionally, not gated on timing**. A counter only a timing run prints would hide exactly the case that matters. Observed **0** over ~3,240 lookups per submit across a 13-minute route.

Bounded at the same **4,096** entries the shader cache itself uses. On overflow the map is cleared wholesale rather than aged — there is no LRU bookkeeping to pay for on a path this hot, and 523 distinct shaders per submit leaves ample headroom. `clears` is reported so a thrash is visible instead of silent. Observed **0**.

## A/B — same route, same host, same binary but the memo

`PPSA25009`, fresh-save `PROSPER_IME_AUTOKEY` route to Day One gameplay, Windows / NVIDIA RTX 4090, `prosper-app`, `PROSPER_RENDER_SCALE=1` `RENDER_EVERY=1`.

| | control | treatment |
| --- | ---: | ---: |
| `build_resources` | 66.46 ms | **31.41 ms** |
| &nbsp;&nbsp;`build_R` | 57.16 | 22.43 |
| &nbsp;&nbsp;&nbsp;&nbsp;`texture` | 10.92 | 6.75 |
| &nbsp;&nbsp;&nbsp;&nbsp;`buffer` | 11.19 | 11.10 |
| &nbsp;&nbsp;&nbsp;&nbsp;`reflect` | **30.37** | **0.00** |
| &nbsp;&nbsp;`validate` | 5.84 | 5.71 |
| &nbsp;&nbsp;`indices` | 2.72 | 2.55 |
| draws/submit | 2103.4 | 2109.4 |
| reflect calls | 3231.5 | **0.0** |
| memo hits | — | 3240.9 |
| clears / mismatch | — | 0.0 / 0.0 |

**The leaf result is mechanistic, not statistical**: calls went to zero and every lookup was a hit. It does not rest on comparing two noisy totals.

### What this does NOT establish

The frame total moved 325.96 → 259.16 ms on the sampled window, but **that is not all attributable here**: `backend` moved −12.5 and `pass_control` −19.3, and this change touches neither. Two 13-minute routes are not identical runs. The defensible claim is the leaf and its parent — **reflect −30.37, `build_resources` −35.05 ms/submit** — and I am deliberately not quoting the frame delta as the result.

## The measurement trap in this PR, recorded because it nearly shipped

My **first** run of the instrument, same binary, said:

```
build_resources 4.69 [build_R=4.64 (texture=4.42 buffer=0.04 reflect=0.14 other=+0.03) ...]
```

`reflect` at **3%** of `build_R`, residual `+0.03` — a tidy, fully-explained bucket that would have closed #2256 as not worth fixing. That run reached only the **title screen, 10.2 draws/submit**. Same title, same instrument, **200× difference in the answer**, and the misleading one looks *more* trustworthy because its residual is near zero.

Anyone quoting a share of this bucket must say which phase it came from.

## Verification

Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo, on the rebased head:

```
ctest --no-tests=error -> 175 tests, 4 failed
  60  pthread_names       (Not Run)  WinLibs .seh_handlerdata, pre-existing
  61  pthread_cond_clock  (Failed)   pre-existing
  174 live_target_format  (Not Run)  setenv absent on MinGW, pre-existing
  14  build_revision_refresh — stale scratch git object (WinError 5); passes 1/1 alone
```

## Risk

The memo is `static thread_local`, bounded, and holds only reports keyed on never-reused identities. The failure mode it could have — serving a report for the wrong module — is blocked by the monotonic-counter argument above and *additionally* by the checked-and-loud `set`/`stage` guard. If that argument is wrong, the guard reports it on the first occurrence rather than rendering something wrong silently.

Fixes #2256
Refs #2215

