### PR TITLE
perf(render): memoize the per-draw fragment subgroup scans — 6.65 -> 0.15 ms/submit

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1195,6 +1195,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 double backend_res_fixed_viewport_ms = 0;
                 double backend_res_fixed_stages_ms = 0;
                 double backend_res_fixed_prologue_ms = 0;
+                double backend_res_prologue_subgroup_scan_ms = 0;
                 double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                 // #1284: sub-attribution of backend_setup_resources_ms. res_texture/res_buffer
                 // cover the whole per-resource branch; the upload/bind pair is nested inside
@@ -1315,6 +1316,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 pending_timing.backend_res_fixed_viewport_ms += backend.res_fixed_viewport_ms;
                 pending_timing.backend_res_fixed_stages_ms += backend.res_fixed_stages_ms;
                 pending_timing.backend_res_fixed_prologue_ms += backend.res_fixed_prologue_ms;
+                pending_timing.backend_res_prologue_subgroup_scan_ms += backend.res_prologue_subgroup_scan_ms;
                 pending_timing.backend_setup_resources_ms += backend.setup_resources_ms;
                 pending_timing.backend_res_texture_ms += backend.res_texture_ms;
                 pending_timing.backend_res_texture_upload_ms += backend.res_texture_upload_ms;
@@ -6747,6 +6749,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     double backend_res_fixed_viewport_ms = 0;
                     double backend_res_fixed_stages_ms = 0;
                     double backend_res_fixed_prologue_ms = 0;
+                    double backend_res_prologue_subgroup_scan_ms = 0;
                     double backend_setup_resources_ms = 0, backend_setup_pipeline_ms = 0;
                     double backend_res_texture_ms = 0, backend_res_texture_upload_ms = 0;
                     double backend_res_texture_bind_ms = 0, backend_res_buffer_ms = 0;
@@ -6818,6 +6821,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.backend_res_fixed_viewport_ms += pending_timing.backend_res_fixed_viewport_ms;
                     timing.backend_res_fixed_stages_ms += pending_timing.backend_res_fixed_stages_ms;
                     timing.backend_res_fixed_prologue_ms += pending_timing.backend_res_fixed_prologue_ms;
+                    timing.backend_res_prologue_subgroup_scan_ms += pending_timing.backend_res_prologue_subgroup_scan_ms;
                     timing.backend_setup_resources_ms += pending_timing.backend_setup_resources_ms;
                     timing.backend_res_texture_ms += pending_timing.backend_res_texture_ms;
                     timing.backend_res_texture_upload_ms += pending_timing.backend_res_texture_upload_ms;
@@ -6924,7 +6928,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
                             "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
-                            "other=%+.2f}\n",
+                            "other=%+.2f} pre_index{subgroup_scan=%.2f other=%+.2f}\n",
                             totals.backend_setup_shader_ms / nsub,
                             totals.backend_setup_fixed_ms / nsub,
                             totals.backend_setup_resources_ms / nsub,
@@ -6938,7 +6942,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (totals.backend_setup_fixed_ms - totals.backend_res_fixed_index_upload_ms -
                              totals.backend_res_fixed_blend_ms - totals.backend_res_fixed_depth_stencil_ms -
                              totals.backend_res_fixed_viewport_ms - totals.backend_res_fixed_stages_ms -
-                             totals.backend_res_fixed_prologue_ms) / nsub);
+                             totals.backend_res_fixed_prologue_ms) / nsub,
+                            totals.backend_res_prologue_subgroup_scan_ms / nsub,
+                            (totals.backend_res_fixed_prologue_ms - totals.backend_res_prologue_subgroup_scan_ms) / nsub);
                     fprintf(stderr,
                             "[render-timing] backend-submit resources avg_ms: texture=%.2f "
                             "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "
@@ -7222,7 +7228,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
                             "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
                             "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
-                            "other=%+.2f}\n",
+                            "other=%+.2f} pre_index{subgroup_scan=%.2f other=%+.2f}\n",
                             window.backend_setup_shader_ms / wn,
                             window.backend_setup_fixed_ms / wn,
                             window.backend_setup_resources_ms / wn,
@@ -7236,7 +7242,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (window.backend_setup_fixed_ms - window.backend_res_fixed_index_upload_ms -
                              window.backend_res_fixed_blend_ms - window.backend_res_fixed_depth_stencil_ms -
                              window.backend_res_fixed_viewport_ms - window.backend_res_fixed_stages_ms -
-                             window.backend_res_fixed_prologue_ms) / wn);
+                             window.backend_res_fixed_prologue_ms) / wn,
+                            window.backend_res_prologue_subgroup_scan_ms / wn,
+                            (window.backend_res_fixed_prologue_ms - window.backend_res_prologue_subgroup_scan_ms) / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit resources avg_ms: texture=%.2f "
                             "(upload=%.2f bind=%.2f lookup=%.2f) buffer=%.2f "

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -625,6 +625,11 @@ struct BackendRenderTimingStats {
     // question #2254 exists to answer. Do not rename it to something that sounds like a phase until
     // it has been split into ones.
     double res_fixed_prologue_ms = 0;
+    // Leaves of res_fixed_prologue_ms (#2254). That span was 12.60 ms/submit -- 39% of `fixed`,
+    // ~6% of the frame -- and #2252 named it honestly as a positional residual with no identified
+    // cause. `subgroup_scan` is the pair of fragment_spirv_required_subgroup_{size,features} calls,
+    // each of which walks the ENTIRE SPIR-V module, per draw, unconditionally.
+    double res_prologue_subgroup_scan_ms = 0;
 
     double setup_fixed_other_ms() const {
         return setup_fixed_ms - res_fixed_index_upload_ms - res_fixed_blend_ms -
@@ -3927,6 +3932,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     double res_fixed_viewport_ms = 0.0;
     double res_fixed_stages_ms = 0.0;
     double res_fixed_prologue_ms = 0.0;
+    double res_prologue_subgroup_scan_ms = 0.0;
     double setup_resources_ms = 0.0;
     double setup_pipeline_ms = 0.0;
     // #1284 sub-attribution of setup_resources_ms; see BackendRenderTimingStats for what each covers.
@@ -4049,10 +4055,64 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         const std::vector<uint32_t>& bd_gs = bd.gs_words();
         const std::vector<uint32_t>& bd_fs = bd.fs_words();
         DV& v = dv[di];
-        const uint32_t required_fragment_subgroup_size =
-            prosper::gpu::fragment_spirv_required_subgroup_size(bd_fs);
-        const uint32_t required_fragment_subgroup_features =
-            prosper::gpu::fragment_spirv_required_subgroup_features(bd_fs);
+        const auto subgroup_scan_begin =
+            timing_enabled ? TimingClock::now() : TimingClock::time_point{};
+        // Both of these walk the ENTIRE SPIR-V module, and build_bds calls them once per draw on a
+        // module that changes only when the shader does. Measured at 7.14 ms/submit -- 58% of the
+        // pre-index span and ~4% of a Blue Prince gameplay frame (#2254, partitioned by #2252).
+        //
+        // Memoized on fs_identity, the same key and the same argument as #2259: DrawItem identities
+        // come from the shader-recompile cache as `cache.next_identity++`
+        // (src/gpu/gpu_executor.cpp:1255 graphics, :1441 compute; sole assignment at :437), a
+        // monotonic counter that is never reset, never decremented and untouched by eviction. So an
+        // identity denotes one module for the life of the process -- an evicted shader recompiles to
+        // a NEW identity, which misses here and refills, and the stale entry is simply never looked
+        // up again. The counter starts at 1, so identity 0 is never minted and the fallthrough below
+        // cannot collide with a real module.
+        //
+        // Both memoized values are pure functions of the module bytes alone -- neither reads device
+        // state -- so a hit is exactly what the call would have returned. The device-dependent half
+        // (available_fragment_subgroup_features, from ctx.subgroup_operations) is computed BELOW and
+        // is deliberately not memoized: it is cheap, and folding it in would key device state on a
+        // shader identity.
+        struct SubgroupScanEntry { uint32_t size; uint32_t features; };
+        static thread_local std::unordered_map<uint64_t, SubgroupScanEntry> subgroup_scan_memo;
+        constexpr size_t kSubgroupScanMemoMaxEntries = 4096;
+        uint32_t required_fragment_subgroup_size = 0;
+        uint32_t required_fragment_subgroup_features = 0;
+        // PROSPER_NO_SUBGROUP_SCAN_MEMO: opt out, so the A/B for this change is single-variable on
+        // ONE binary rather than a comparison of two builds. Kept as a permanent bisection lever for
+        // the same reason PROSPER_NO_INDEX_ARENA (#2258) and the PROSPER_NO_BACKEND_* family exist.
+        static const bool no_subgroup_scan_memo = getenv("PROSPER_NO_SUBGROUP_SCAN_MEMO") != nullptr;
+        bool subgroup_scan_memoized = false;
+        if (bd.fs_identity && !no_subgroup_scan_memo) {
+            const auto found = subgroup_scan_memo.find(bd.fs_identity);
+            if (found != subgroup_scan_memo.end()) {
+                required_fragment_subgroup_size = found->second.size;
+                required_fragment_subgroup_features = found->second.features;
+                subgroup_scan_memoized = true;
+            }
+        }
+        if (!subgroup_scan_memoized) {
+            required_fragment_subgroup_size =
+                prosper::gpu::fragment_spirv_required_subgroup_size(bd_fs);
+            required_fragment_subgroup_features =
+                prosper::gpu::fragment_spirv_required_subgroup_features(bd_fs);
+            if (bd.fs_identity && !no_subgroup_scan_memo) {
+                // Cleared wholesale rather than aged: there is no LRU bookkeeping worth paying for
+                // on a path this hot. A non-zero clear count means this memo has STOPPED WORKING --
+                // the scans are being paid again in full, plus the churn -- not that a threshold was
+                // brushed. 523 distinct shaders per submit leaves ample headroom against 4,096.
+                if (subgroup_scan_memo.size() >= kSubgroupScanMemoMaxEntries)
+                    subgroup_scan_memo.clear();
+                subgroup_scan_memo.emplace(bd.fs_identity,
+                                           SubgroupScanEntry{required_fragment_subgroup_size,
+                                                             required_fragment_subgroup_features});
+            }
+        }
+        if (timing_enabled)
+            res_prologue_subgroup_scan_ms +=
+                setup_elapsed_ms(subgroup_scan_begin, TimingClock::now());
         uint32_t available_fragment_subgroup_features = 0;
         if (ctx.subgroup_operations & VK_SUBGROUP_FEATURE_VOTE_BIT)
             available_fragment_subgroup_features |= prosper::gpu::kFragmentSubgroupVote;
@@ -6683,6 +6743,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         call_timing.res_fixed_viewport_ms = res_fixed_viewport_ms;
         call_timing.res_fixed_stages_ms = res_fixed_stages_ms;
         call_timing.res_fixed_prologue_ms = res_fixed_prologue_ms;
+        call_timing.res_prologue_subgroup_scan_ms = res_prologue_subgroup_scan_ms;
         call_timing.setup_resources_ms = setup_resources_ms;
         call_timing.res_texture_ms = res_texture_ms;
         call_timing.res_texture_upload_ms = res_texture_upload_ms;
@@ -7023,6 +7084,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             PROSPER_SUM_TIMING_STAT(res_fixed_viewport_ms);
             PROSPER_SUM_TIMING_STAT(res_fixed_stages_ms);
             PROSPER_SUM_TIMING_STAT(res_fixed_prologue_ms);
+            PROSPER_SUM_TIMING_STAT(res_prologue_subgroup_scan_ms);
             PROSPER_SUM_TIMING_STAT(setup_resources_ms);
             PROSPER_SUM_TIMING_STAT(res_texture_ms);
             PROSPER_SUM_TIMING_STAT(res_texture_upload_ms);


### PR DESCRIPTION
## What #2254 turned out to be

#2252 named `pre_index_unsplit` honestly as a **positional residual with no identified cause** —
12.60 ms/submit, 39% of `setup_fixed_ms`, ~6% of the frame — and #2254 filed it as a measurement
without a cause. Partitioned rather than nominated, and the cause is the same shape as #2259's:

**`fragment_spirv_required_subgroup_size` and `fragment_spirv_required_subgroup_features` each walk
the entire SPIR-V module, once per draw, unconditionally.** Both are pure functions of bytes that
change only when the shader does.

## Result — single-variable A/B, one binary, matched draw counts (2101.8 vs 2099.8)

| | memo ON | OFF | Δ |
| --- | ---: | ---: | ---: |
| `subgroup_scan` | **0.15** | 6.65 | **−98%** |
| `pre_index_unsplit` | 4.98 | 11.29 | −6.31 |
| `fixed` | 8.23 | 14.52 | −6.29 |
| `resources` | 43.77 | 43.76 | **unmoved** |
| `index_upload` | 1.70 | 1.70 | **unmoved** |
| frame total | 159.45 | 161.46 | −2.01 |

### The −98% is the most flattering statement available and it is not the claim

It is 98% of a term that was **~4% of the frame**, and the frame moved **2.01 ms against a leaf saving
of 6.50** — so 4–6 ms is unaccounted, either noise across two 160 s runs or absorbed by whatever else
bounds the submit. **The defensible claim is the leaf and its parents**, for the same reason #2259
declined to quote its own frame delta. I would rather state the smaller true thing.

The controls are what make the leaf claim solid: `resources` and `index_upload` are identical to two
decimal places across the arms.

## The key, and why I did not re-derive it

Keyed on `fs_identity`. The soundness argument was verified **while reviewing #2259**, not re-argued
here: `src/gpu/gpu_executor.cpp:437` is the sole assignment, `cache.next_identity++` at **`:1255`
(graphics) and `:1441` (compute)**, no reset, no decrement, and **no eviction path touches the
counter**. So an identity denotes one module for the life of the process; an evicted shader recompiles
to a *new* identity that misses and refills, and the stale entry is never looked up again. The counter
starts at **1**, so identity `0` is never minted and the fallthrough cannot collide with a real module.

**Both memoized values are pure functions of the module bytes — neither reads device state** — so a
hit returns exactly what the call would have. The device-dependent half,
`available_fragment_subgroup_features` from `ctx.subgroup_operations`, is computed below and is
**deliberately not memoized**: it is cheap, and folding it in would key device state on a shader
identity.

## Behavior and risks

- **`PROSPER_NO_SUBGROUP_SCAN_MEMO`** exists because the A/B otherwise compares two builds rather than
  one binary. Permanent bisection lever, alongside `PROSPER_NO_INDEX_ARENA` (#2258).
- Bounded at 4,096, cleared wholesale on overflow — no LRU bookkeeping on a path this hot. A non-zero
  clear count means the memo has **stopped working** (scans paid again in full, plus churn), not that
  a threshold was brushed.
- `static thread_local`, so no lock and no cross-thread sharing.
- **The failure mode if the key were wrong** is a wrong subgroup requirement, which would skip or
  un-skip fragment shaders — visible, not silent. `blue-prince-hall` covers it end to end.

## Verification

```
cmake --build build -j6                        # rc=0
ctest --no-tests=error -j4                     # 220/220 passed
python3 tools/env/check_cached_env.py          # all checks passed
snapshot.py check blue-prince-hall             # OK — 1920x1080, frames=96,
                                               #   richest=137602 colors,
                                               #   structural_matches=31, nonblack_matches=96
git diff --check                               # clean
```

Rebased onto `a54ad733`.

Requesting review, @Wren — particularly on the decision to leave `available_fragment_subgroup_features`
out of the memo, which is the one place device state and module state meet on this path.

Fixes #2254.
