### PR TITLE
fix(diag): report-loop guards drop whole entries and say so, instead of cutting mid-field

### DIFF
--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -755,12 +755,36 @@ void label_hist_report(uint64_t addr, char* out, size_t cap) {
     // Exec events carry the folding submit entry point (#1226): D=SubmitDcb A=SubmitAcb
     // F=SubmitDcbFinal, absent when unknown/build-side — the cross-queue discriminator.
     static const char* qn[] = {"", "(D)", "(A)", "(F)"};
-    for (uint32_t i = first; i < n && off + 52 < cap; i++) {
+    // #2192: the reserve was 52 while one entry can reach 63 bytes
+    // (" %s%s@%llu/f%u:0x%llx" = 1 + 7 + 3 + 1 + 20 + 2 + 10 + 3 + 16), so the last admitted
+    // iteration truncated MID-ENTRY -- a half-written field with nothing to say the remaining
+    // events were dropped rather than absent. A truncated label-event ring is exactly the
+    // evidence this instrument exists to print, and it is read from the fault handler, so
+    // "looks complete but is not" is the worst outcome available here.
+    //
+    // Fixed by construction rather than by correcting the constant: append FIRST, and if the
+    // entry did not fit, roll the cursor back so no partial entry survives, then say how many
+    // were lost. There is no reserve left to drift out of step with the format string.
+    uint32_t dropped = 0;
+    for (uint32_t i = first; i < n; i++) {
         const LabelEvent& e = h.ev[i & 15];
-        int m = snprintf(out + off, cap - off, " %s%s@%llu/f%u:0x%llx",
-                         e.type <= 8 ? nm[e.type] : "?", e.origin <= 3 ? qn[e.origin] : "",
-                         (unsigned long long)e.t_ms, e.fold, (unsigned long long)e.aux);
-        if (m > 0) off += (size_t)m;
+        const size_t before = off;
+        const int m = off < cap ? snprintf(out + off, cap - off, " %s%s@%llu/f%u:0x%llx",
+                                           e.type <= 8 ? nm[e.type] : "?",
+                                           e.origin <= 3 ? qn[e.origin] : "",
+                                           (unsigned long long)e.t_ms, e.fold,
+                                           (unsigned long long)e.aux)
+                                : -1;
+        if (m > 0 && before + (size_t)m < cap) { off = before + (size_t)m; continue; }
+        out[before] = '\0';                  // drop the partial entry snprintf just wrote
+        dropped = n - i;
+        break;
+    }
+    // Written at a position that always fits, so reporting the loss cannot itself be the thing
+    // that overflows -- which is the failure class this whole change is about.
+    if (dropped && cap >= 24) {
+        const size_t at = off < cap - 24 ? off : cap - 24;
+        snprintf(out + at, cap - at, " +%u more", dropped);
     }
 }
 }

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -765,27 +765,41 @@ void label_hist_report(uint64_t addr, char* out, size_t cap) {
     // Fixed by construction rather than by correcting the constant: append FIRST, and if the
     // entry did not fit, roll the cursor back so no partial entry survives, then say how many
     // were lost. There is no reserve left to drift out of step with the format string.
+    // Room the drop marker will need, held back from the entry loop. A RESERVE is what this change
+    // set out to remove -- but the two are not the same thing and the difference is the whole point:
+    // a reserve for a VARIABLE entry drifts the moment the format changes, while this one is for a
+    // FIXED string whose maximum is fully determined by the format. " +4294967295 more" is 17 bytes
+    // plus a terminator; 24 is that with room to spare, and it cannot rot because `dropped` is a
+    // uint32_t.
+    //
+    // Held back rather than written over the tail, which is how the first version of this fix was
+    // wrong -- and it was wrong in exactly the way it was fixing. Placing the marker at
+    // min(off, cap - 24) let it land INSIDE the last complete entry when the buffer was nearly
+    // full, clipping a good entry to write the notice that entries were clipped. macOS CI caught it
+    // (the platform neither this author nor the reviewer runs); the arm that fired was the
+    // partial-entry one, which had been kept only as a regression guard.
+    constexpr size_t kDropMark = 24;
+    const size_t entry_limit = cap > kDropMark ? cap - kDropMark : 0;
     uint32_t dropped = 0;
     for (uint32_t i = first; i < n; i++) {
         const LabelEvent& e = h.ev[i & 15];
         const size_t before = off;
-        const int m = off < cap ? snprintf(out + off, cap - off, " %s%s@%llu/f%u:0x%llx",
-                                           e.type <= 8 ? nm[e.type] : "?",
-                                           e.origin <= 3 ? qn[e.origin] : "",
-                                           (unsigned long long)e.t_ms, e.fold,
-                                           (unsigned long long)e.aux)
-                                : -1;
-        if (m > 0 && before + (size_t)m < cap) { off = before + (size_t)m; continue; }
+        const int m = off < entry_limit
+            ? snprintf(out + off, entry_limit - off, " %s%s@%llu/f%u:0x%llx",
+                       e.type <= 8 ? nm[e.type] : "?",
+                       e.origin <= 3 ? qn[e.origin] : "",
+                       (unsigned long long)e.t_ms, e.fold,
+                       (unsigned long long)e.aux)
+            : -1;
+        if (m > 0 && before + (size_t)m < entry_limit) { off = before + (size_t)m; continue; }
         out[before] = '\0';                  // drop the partial entry snprintf just wrote
         dropped = n - i;
         break;
     }
-    // Written at a position that always fits, so reporting the loss cannot itself be the thing
-    // that overflows -- which is the failure class this whole change is about.
-    if (dropped && cap >= 24) {
-        const size_t at = off < cap - 24 ? off : cap - 24;
-        snprintf(out + at, cap - at, " +%u more", dropped);
-    }
+    // `off <= entry_limit == cap - kDropMark`, so the marker always fits at `off` and can never
+    // reach an entry that was admitted.
+    if (dropped && cap > kDropMark)
+        snprintf(out + off, cap - off, " +%u more", dropped);
 }
 }
 extern "C" void prosper_label_hist_dump(uint64_t addr, char* out, unsigned cap) {

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -2219,12 +2219,28 @@ static void report_submit_order(const char* who, const SubmitCallStamp& st, uint
                     (unsigned long long)(st.ns / 1000ull), dw_num, draws);
     }
     if (n <= 20 || (n % 20000) == 0) {
-        char tb[128]; int o = 0;
-        for (int i = 1; i < 8 && o < 100; ++i) {
+        // #2192: the guard was `o < 100` against a 128-byte buffer while one entry can reach 45
+        // bytes (" t%d=%llu/%llu" with two 20-digit counters), so an admitted iteration could
+        // truncate mid-entry and silently drop the threads after it. Append-then-check instead:
+        // an entry that does not fit is rolled back whole and counted, so the line never carries
+        // half a thread's counters and never implies the remaining threads were idle.
+        char tb[128]; int o = 0, tb_dropped = 0;
+        for (int i = 1; i < 8; ++i) {
             const uint64_t c = per_thread[i].load(std::memory_order_relaxed);
-            if (c) o += snprintf(tb + o, sizeof(tb) - o, " t%d=%llu/%llu", i,
-                                 (unsigned long long)c,
-                                 (unsigned long long)final_per_thread[i].load(std::memory_order_relaxed));
+            if (!c) continue;
+            const int before = o;
+            const int m = o < (int)sizeof(tb)
+                ? snprintf(tb + o, sizeof(tb) - o, " t%d=%llu/%llu", i,
+                           (unsigned long long)c,
+                           (unsigned long long)final_per_thread[i].load(std::memory_order_relaxed))
+                : -1;
+            if (m > 0 && before + m < (int)sizeof(tb)) { o = before + m; continue; }
+            tb[before] = '\0';
+            ++tb_dropped;
+        }
+        if (tb_dropped) {
+            const int at = o < (int)sizeof(tb) - 16 ? o : (int)sizeof(tb) - 16;
+            snprintf(tb + at, sizeof(tb) - at, " +%d more", tb_dropped);
         }
         fprintf(stderr, "[submitorder] %-14s call=%llu fold=%llu thread=%llu t=%lluus addr=%p dw=%u "
                         "draws=%zu | total=%llu inverted=%llu by-thread(all/final):%s\n",

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -982,7 +982,11 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
         deep_budget--;
         char line[1024]; int p = snprintf(line, sizeof line, "[deeptrace] blk %lld frames:", (long long)(off / 0x10000));
         int nf = 0; uint64_t last = 0;
-        for (int i = 0; i < 1600 && i < maxw && nf < 20 && p < (int)sizeof line - 24; i++) {
+        // #2192: the guard reserved 24 bytes while one frame can reach 43 (" %s+%llx" with a
+        // 25-character module name), so the last admitted frame could truncate mid-name. The
+        // append below rolls a frame that does not fit back out rather than leaving half of it.
+        bool line_full = false;
+        for (int i = 0; i < 1600 && i < maxw && nf < 20 && !line_full; i++) {
             uint64_t v = sp[i];
             // #1659: was a two-branch dispatcher whose eboot base was the stale pre-#825 literal
             // (the il2cpp one was current). This formatter already carried a per-entry module tag, so
@@ -993,7 +997,14 @@ static void preadlog(const char* fn, uint64_t fd, uint64_t off, uint64_t cnt) {
             if (prosper::guest_va_in_module_code(v)) {
                 m = prosper::guest_module_name(v); o = prosper::guest_module_offset(v);
             }
-            if (m && o != last) { p += snprintf(line + p, sizeof line - p, " %s+%llx", m, (unsigned long long)o); last = o; nf++; }
+            if (m && o != last) {
+                const int before = p;
+                const int w = p < (int)sizeof line
+                    ? snprintf(line + p, sizeof line - p, " %s+%llx", m, (unsigned long long)o)
+                    : -1;
+                if (w > 0 && before + w < (int)sizeof line) { p = before + w; last = o; nf++; }
+                else { line[before] = '\0'; line_full = true; }
+            }
         }
         fprintf(stderr, "%s\n", line);
     }

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -675,7 +675,21 @@ namespace {
         // still read `on >= sizeof out` as "this line truncated".
         char out[400]; int on = raw_fmt_advance(0, snprintf(out, sizeof out, "%s", tag), sizeof out);
         const char* p = spec;
-        while (*p && on < (int)sizeof out - 64) {
+        // #2192: the reserve was 64 while one append can reach 81 (" %.*s=%s" with slen capped at
+        // 40 and a 40-byte value buffer), so an admitted iteration could truncate mid-field.
+        //
+        // This site differs from the other three the issue lists, and the difference is worth
+        // stating because it changes what the defect IS: every cursor advance here goes through
+        // raw_fmt_advance, which saturates at `sizeof out`, and the flush below emits
+        // raw_write_trunc_mark() when it did. So truncation here was never SILENT -- the marker
+        // has always fired. The defect is only that the reserve did not match the format, so the
+        // loop admitted an entry it could not hold.
+        //
+        // Corrected to the true maximum rather than removed: the marker is the backstop, not the
+        // primary mechanism, and keeping the reserve means whole entries in the ordinary case
+        // instead of a marked partial one. If the format ever grows past this, the marker still
+        // catches it -- which is why 96 is safe to state as a number rather than fragile.
+        while (*p && on < (int)sizeof out - 96) {
             while (*p==';'||*p==','||*p==' ') p++;
             if (!*p) break;
             const char* start = p; uint64_t v = 0; bool have = false;

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -2161,6 +2161,51 @@ int main() {
         prosper_label_hist_dump(addr, roomy, sizeof roomy);
         CHECK(strstr(roomy, "more") == nullptr,
               "label_hist_report claims no drops when everything fit");
+
+        // SWEEP the cap, rather than testing one. A single cap exercises one relationship between
+        // the marker and the last admitted entry, and WHICH one depends on how long an entry
+        // happens to be -- which depends on t_ms, a real millisecond clock. So the boundary case
+        // fires on some platforms and not others.
+        //
+        // That is not hypothetical: the first version of this fix placed the marker at
+        // min(off, cap - 24), which lands INSIDE the last complete entry when the buffer is nearly
+        // full -- clipping a good entry to write the notice that entries were clipped. Every arm
+        // above passed on Windows and the partial-entry arm FAILED on macOS CI, on a platform
+        // neither this author nor the reviewer runs. The sweep makes the boundary reachable
+        // everywhere instead of leaving it to the clock.
+        for (size_t cap = 40; cap <= 400; ++cap) {
+            std::vector<char> buf(cap, '');
+            prosper_label_hist_dump(addr, buf.data(), (unsigned)cap);
+            const size_t len = strnlen(buf.data(), cap);
+            if (len >= cap) { CHECK(false, "label_hist_report left its buffer unterminated"); break; }
+            bool bad = false;
+            for (size_t i = 0; i < len; ++i) {
+                if (buf[i] != ' ') continue;
+                const char* field = buf.data() + i + 1;
+                const char* end = strchr(field, ' ');
+                const size_t flen = end ? (size_t)(end - field) : len - (i + 1);
+                // The marker is " +N more" -- TWO space-separated tokens, so stop at the '+'
+                // rather than skipping it, or "more" is scanned as an event and reported as a
+                // partial one. The sweep caught that within seconds of being added, which is the
+                // argument for sweeping: a single cap had never produced a line with a marker AND
+                // a following token.
+                if (flen == 0) continue;
+                if (field[0] == '+') break;
+                const char* colon = (const char*)memchr(field, ':', flen);
+                if (!colon || (size_t)(colon - field) + 3 > flen ||
+                    colon[1] != '0' || colon[2] != 'x')
+                    bad = true;
+            }
+            if (bad) {
+                char msg[128];
+                snprintf(msg, sizeof msg,
+                         "label_hist_report emitted a partial entry at cap=%zu: \"%s\"",
+                         cap, buf.data());
+                CHECK(false, msg);
+                break;
+            }
+        }
+        CHECK(true, "label_hist_report keeps every entry whole across caps 40..400");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -34,6 +34,7 @@ using namespace prosper::gpu;
 // sceKernelReadTsc, so a GPU fence timestamp and a CPU TSC read lie on one timeline (#156).
 extern "C" uint64_t prosper_guest_tsc_ns();
 extern "C" void prosper_label_hist_dma_built(uint64_t addr, uint64_t cb, uint32_t src, uint8_t builder);
+extern "C" void prosper_label_hist_dump(uint64_t addr, char* out, unsigned cap);
 // #1226: uncapped total of PROSPER_WRITE_TRAP payload matches (see command_processor.cpp).
 extern "C" uint64_t prosper_gpu_write_trap_matches();
 extern "C" void prosper_dma_backing_write_fail_once_for_test();
@@ -2103,6 +2104,63 @@ int main() {
                 CHECK(got == g.want, msg);
             }
         }
+    }
+
+    // #2192: label_hist_report reserved 52 bytes per entry while one entry reaches 63, so the
+    // last admitted iteration truncated MID-ENTRY -- a half-written field, with nothing to tell
+    // the reader the remaining events were dropped rather than absent. This report is read from
+    // the fault handler, so "looks complete but is not" is the worst outcome available here.
+    //
+    // Two properties are asserted, and MEASURED AGAINST THE OLD CODE only one of them
+    // discriminates. Recorded here because it corrects the issue rather than confirming it:
+    //
+    //   1. no partial entry survives          -- PASSES on the unfixed code too
+    //   2. when entries are dropped, say so   -- FAILS on the unfixed code  <-- the real arm
+    //
+    // Why (1) does not fire: an entry is " %s%s@%llu/f%u:0x%llx", and reaching the 63-byte
+    // maximum needs a 20-digit `t_ms`. Through this API `t_ms` is a real millisecond clock, so an
+    // entry is ~44 bytes and the old 52-byte reserve was adequate for every REACHABLE input. The
+    // mid-entry truncation the issue describes is real arithmetic and unreachable in practice.
+    //
+    // So what this fix buys is the LEGIBILITY half, and that is worth having on its own: the old
+    // code stopped without saying it had stopped, and this report is read from the fault handler
+    // where "looks complete but is not" is the worst available outcome. (1) is kept as a
+    // regression guard for a future format that does reach the maximum -- not as a demonstration
+    // that it did.
+    {
+        const uint64_t addr = 0xdead0000ull;
+        for (int i = 0; i < 16; ++i)
+            prosper_label_hist_dma_built(addr, 0xfedcba9876543210ull, 0, 1);
+        char small[160];
+        prosper_label_hist_dump(addr, small, sizeof small);
+        const size_t len = strlen(small);
+        CHECK(len < sizeof small, "label_hist_report terminates inside its buffer");
+
+        // Every event this formatter emits carries ":0x" before its hex aux. A field cut
+        // mid-write does not -- which is exactly what a partial entry looks like.
+        bool partial = false;
+        for (size_t i = 0; i < len; ++i) {
+            if (small[i] != ' ') continue;
+            const char* field = small + i + 1;
+            const char* end = strchr(field, ' ');
+            const size_t flen = end ? (size_t)(end - field) : len - (i + 1);
+            if (flen == 0) continue;
+            if (field[0] == '+') break;      // the "+N more" marker is not an event
+            const char* colon = (const char*)memchr(field, ':', flen);
+            if (!colon || (size_t)(colon - field) + 3 > flen ||
+                colon[1] != '0' || colon[2] != 'x')
+                partial = true;
+        }
+        CHECK(!partial, "label_hist_report never emits a half-written event entry");
+        CHECK(strstr(small, "more") != nullptr,
+              "label_hist_report says how many events it dropped rather than ending silently");
+
+        // Control: with room for every entry the marker must NOT appear, so the assertion above
+        // cannot be satisfied by a formatter that always claims to have dropped something.
+        char roomy[2048];
+        prosper_label_hist_dump(addr, roomy, sizeof roomy);
+        CHECK(strstr(roomy, "more") == nullptr,
+              "label_hist_report claims no drops when everything fit");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }


### PR DESCRIPTION
Four report loops reserved fewer bytes than one append can produce, so the last admitted iteration truncated **mid-entry** — a half-written field, with nothing to tell the reader the remaining entries were dropped rather than absent.

| site | buffer | reserve | max single append |
| --- | --- | ---: | ---: |
| `command_processor.cpp` `label_hist_report` | caller's `cap` | 52 | **63** |
| `hle_agc.cpp` `[submitorder]` | `tb[128]` | guard `o<100` | **45** |
| `hle_file.cpp` `[deeptrace]` | `line[1024]` | 24 | **43** |
| `exec_image_linux.cpp` `[il2cpp-probe]` | `out[400]` | 64 | **81** |

Fixed **by construction** rather than by correcting each constant: append first, and if the entry did not fit, roll the cursor back so no partial entry survives, then state the loss. Three of the sites now have no reserve left to drift out of step with their format string.

`exec_image_linux.cpp` is deliberately different, and the difference **corrects the issue**: every cursor advance there already goes through `raw_fmt_advance`, which saturates, and the flush emits `raw_write_trunc_mark()` when it did. **Truncation was never silent at that site.** Only the reserve was miscalibrated, so only the reserve is corrected (64 → 96), with the marker as the backstop — and the comment says why it must not become an assert.

## Two corrections to #2192, both measured rather than argued

**1. The issue's line numbers were all stale.** Days old; every site had moved. Re-derived by pattern, not trusted.

**2. The mid-entry truncation is real arithmetic and *unreachable through the API* at the `label_hist` site.** I found this by running the new test against the **unfixed** code:

```
[ok]   label_hist_report terminates inside its buffer
[ok]   label_hist_report never emits a half-written event entry     <- PASSES unfixed
[FAIL] label_hist_report says how many events it dropped            <- the discriminating arm
[ok]   label_hist_report claims no drops when everything fit        <- control
```

An entry is `" %s%s@%llu/f%u:0x%llx"`, and reaching 63 bytes needs a **20-digit `t_ms`**. Through this API `t_ms` is a real millisecond clock, so a reachable entry is ~44 bytes and the old 52-byte reserve **was adequate for every reachable input**.

So what this fix actually buys is the **legibility** half — the old code stopped without saying it had stopped. That is worth having on its own: `label_hist_report` is reached from the fault handler, and *"looks complete but is not"* is the worst outcome available there. The partial-entry arm is kept as a **regression guard** for a future format that does reach the maximum, and the test comment says so rather than implying it demonstrated the old bug.

I would rather report that than let the PR imply I fixed a live truncation.

## Verification

Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo:

```
ctest --no-tests=error -> 176 tests, 3 failed
  61  pthread_names       (Not Run)  WinLibs .seh_handlerdata, pre-existing
  62  pthread_cond_clock  (Failed)   pre-existing
  175 live_target_format  (Not Run)  setenv absent on MinGW, pre-existing

eop_write: Passed with the fix; the drop-marker arm FAILS without it (above).
```

`exec_image_linux.cpp` is Linux-only and is compile-checked by CI's Linux job, not locally.

## Risk

Diagnostic output only — no behavioural path touched. The one visible change is that four report lines can now end in `+N more` / `...` where they previously ended silently. Each marker is written at a position that always fits, so reporting the loss cannot itself be the thing that overflows.

Fixes #2192