### PR TITLE
fix(test): the documented Windows toolchain can build 'all' again

### DIFF
--- a/prosper/tests/test_live_target_format.cpp
+++ b/prosper/tests/test_live_target_format.cpp
@@ -87,12 +87,26 @@ bool notifier_republishes(const FormatCase& c, uint64_t base, uint32_t width, ui
     return republished;
 }
 
+// setenv() does not exist in the MinGW UCRT headers, so this file failed to COMPILE on the
+// toolchain docs/WINDOWS_PORT_HANDOFF.md prescribes -- aborting `cmake --build all` and skipping
+// every target after it (#2142's second instance; CI's MSYS2 gcc has the same gap and the job
+// never reached this file because the SEH abort came first). Same shape as the helper
+// test_apr_registry.cpp:38 already uses; kept local rather than shared because a two-line
+// platform shim in a test is cheaper to read where it is used than to chase to a header.
+static bool set_test_env(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
+
 } // namespace
 
 int main() {
     // The renderer's replay seed writer is the only public way to publish an RTT identity, and it is
     // registered only when this is set at registration time.
-    setenv("PROSPER_GPU_REPLAY_RTT_SEEDS", "1", 1);
+    set_test_env("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
     prosper::frontend::register_live_renderer(std::string(), false);
 
     // The mapping itself. VK_FORMAT_UNDEFINED would mean "unnamed", which the notifier treats as a

--- a/prosper/tests/test_pthread_names.cpp
+++ b/prosper/tests/test_pthread_names.cpp
@@ -19,14 +19,46 @@ static int fails = 0;
 
 static std::atomic<bool> worker_started{false};
 static std::atomic<bool> worker_release{false};
+// The body lives OUTSIDE the ABI shim, and on Windows that is load-bearing rather than tidy (#2142).
+//
+// WinLibs MinGW-w64 UCRT gcc 16.1.0 fails to ASSEMBLE a `sysv_abi` function that contains a call
+// needing unwind info:
+//
+//     ccXXXX.s: Error: .seh_handlerdata used outside of .seh_proc block
+//
+// gcc emits `.seh_handlerdata` for the EH region while the non-native-ABI prologue opens no
+// `.seh_proc`. That aborted `cmake --build all`, so every target after this one was skipped and a
+// full local ctest needed `-k 0` -- while CI stayed green, because its Windows job uses MSYS2's gcc.
+//
+// Reduced to two lines by hand, outside this file, so the trigger is named rather than guessed:
+//
+//     #include <thread>
+//     extern "C" __attribute__((sysv_abi)) void* f(void*) {
+//         std::this_thread::yield(); return nullptr; }
+//
+// Fails at -O2, compiles at -O0. `sysv_abi` alone is NOT enough -- an empty one assembles fine --
+// so the attribute is not the thing to remove.
+//
+// Two workarounds were tried and rejected before this one:
+//   * -fno-asynchronous-unwind-tables on the target: assembles, then fails to LINK with
+//     `undefined reference to __gxx_personality_v0`. It trades one toolchain error for another.
+//   * -O0 on the target: works, but silently un-optimises a test to dodge a codegen bug.
+// Moving the work out of the shim needs no flags at all and leaves the ABI boundary trivially
+// correct: a shim that only forwards has nothing to unwind, which is what the ABI already requires.
+//
+// `noinline` is the part that must not be removed -- without it -O2 merges the body back in and the
+// assembler error returns.
+static __attribute__((noinline)) void* named_worker_body() {
+    worker_started.store(true, std::memory_order_release);
+    while (!worker_release.load(std::memory_order_acquire)) std::this_thread::yield();
+    return (void*)0x386;
+}
 #ifdef _WIN32
 extern "C" __attribute__((sysv_abi)) void* named_worker(void*) {
 #else
 static void* named_worker(void*) {
 #endif
-    worker_started.store(true, std::memory_order_release);
-    while (!worker_release.load(std::memory_order_acquire)) std::this_thread::yield();
-    return (void*)0x386;
+    return named_worker_body();
 }
 
 int main() {


### PR DESCRIPTION
**`cmake --build` succeeds on the documented Windows toolchain for the first time** — rc=0, no `-k 0`.

Two separate compile aborts stopped it on the WinLibs MinGW-w64 UCRT gcc 16.1.0 that `docs/WINDOWS_PORT_HANDOFF.md` prescribes and `scripts/run-windows.ps1` auto-detects. Each skipped every target after it, so a full local `ctest` needed `-k 0` and could not be quoted honestly.

CI saw neither: the `Windows MinGW` job uses MSYS2's gcc. That is exactly #2142's point — **"green CI" did not imply "builds with the setup the docs tell you to install."**

## 1. `test_pthread_names.cpp` — assembler error

```
ccXXXX.s: Error: .seh_handlerdata used outside of .seh_proc block
```

Reduced **by hand, outside the file**, so the trigger is named rather than guessed:

```cpp
#include <thread>
extern "C" __attribute__((sysv_abi)) void* f(void*) { std::this_thread::yield(); return nullptr; }
```

Fails at `-O2`, **compiles at `-O0`**. gcc emits `.seh_handlerdata` for the EH region while the non-native-ABI prologue opens no `.seh_proc`. **`sysv_abi` alone is not enough** — an empty one assembles fine — so the attribute is not the thing to remove, and I checked that before touching anything.

**Fixed in the source**, by moving the body out of the ABI shim. No toolchain flags, and it leaves the boundary trivially correct: a shim that only forwards has nothing to unwind, which is what the ABI already requires. `noinline` is load-bearing — without it `-O2` merges the body back in and the error returns.

**Two workarounds were tried and rejected**, both recorded in the comment so nobody re-tries them:

| attempt | result |
| --- | --- |
| `-fno-asynchronous-unwind-tables` | assembles, then **fails to link**: `undefined reference to __gxx_personality_v0`. One toolchain error for another. |
| `-O0` on the target | works, but silently un-optimises a test to dodge a codegen bug. |

## 2. `test_live_target_format.cpp` — `setenv()` is not in MinGW's headers

The same two-line platform shim `test_apr_registry.cpp:38` already uses. CI's gcc has the same gap and never reached this file, because the abort above came first.

## Verification

Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo:

```
cmake --build prosper/build-mingw -j12   -> rc=0, no -k 0        (was: aborted)
ctest --no-tests=error -j8               -> 176 tests, 2 failed
    62 pthread_cond_clock         pre-existing, unrelated
    15 build_revision_refresh     stale scratch git object; passes 1/1 alone

ctest -R '^(build_revision_refresh|pthread_names|live_target_format)$'  -> 3/3 passed
```

**Both tests previously reported `(Not Run)` on every local run in this repo.** They now run and pass, which is the falsifiable part of this change: the local failure count drops from 4 to 1 real failure.

## Risk

Test sources only; no production code. The `named_worker` split changes no observable behaviour — the shim forwards and returns the same value — and the non-Windows branch is unchanged apart from calling through the same helper.

Fixes #2142
