### PR TITLE
fix(gpu): 2D_ARRAY image atomics, and a shader may use its own atomic image twice

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10160,7 +10160,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                      in.mimg_unorm || in.mimg_dmask != 1u ||
                      (!arrayed && (res->img_dim != 1u || res->depth != 1u)) ||
                      (arrayed && (res->img_dim != SQ_DIM_2D_ARRAY || !res->depth)) ||
-                     (arrayed && !res->depth) || res->depth_compare ||
+                     res->depth_compare ||
                      res->format != DataFormat::Uint32 || components != 1u ||
                      !res->width || !res->height || res->in_mip_tail ||
                      res->compression_enabled)) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1857,13 +1857,27 @@ struct SpirvCompute {
     // Compute lowers that exact 2D resource through a detiled storage-buffer view instead. The live
     // backend recognizes the reflected atomic buffer over a StorageImage resource, detiles before
     // dispatch, and tiles the result back afterwards. Graphics retains the native image-atomic path.
+    // Bindings this function itself declared, so a REPEAT use of one is a hit rather than a
+    // failure. A shader with two image atomics on the same image called here twice: the first
+    // declared cbuf_var[binding], and the second was refused by the `cbuf_var.count(binding)` guard
+    // -- which rejected the whole shader for the crime of using its own image twice. Measured on
+    // Sonic Racing: CrossWorlds, where the resource table has NO entry at the binding in question,
+    // so declare_cbufs cannot have been the declarer (#2265).
+    //
+    // Only OUR bindings are reusable. A binding declared by declare_cbufs from a
+    // ConstantBuffer/VertexBuffer resource is still refused: the types happen to match, which is
+    // exactly what would make aliasing onto someone else's buffer silent rather than loud.
+    std::set<uint32_t> atomic_img_buf_bindings;
     bool declare_compute_atomic_image_buffer(uint32_t binding) {
-        if (!is_compute || !t_ptr_sb_struct_u || cbuf_var.count(binding)) return false;
+        if (!is_compute || !t_ptr_sb_struct_u) return false;
+        if (atomic_img_buf_bindings.count(binding)) return true;   // ours already; reuse it
+        if (cbuf_var.count(binding)) return false;                 // someone else's; refuse
         const uint32_t variable = id();
         put(deco, Op_Decorate, {variable, Dec_DescriptorSet, desc_set});
         put(deco, Op_Decorate, {variable, Dec_Binding, binding});
         put(types, Op_Variable, {t_ptr_sb_struct_u, variable, SC_StorageBuffer});
         cbuf_var[binding] = variable;
+        atomic_img_buf_bindings.insert(binding);
         return true;
     }
     // LDS (Local Data Share) — a workgroup-shared u32 array for compute ds_read/ds_write. NGG shaders

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1713,8 +1713,10 @@ struct SpirvCompute {
     uint32_t image_atomic_u32(uint16_t opcode, uint32_t binding, uint32_t ncoord,
                               const uint32_t* coords, uint32_t value, bool predicated,
                               uint32_t pred, uint32_t fallback) {
-        // The decoder/resource gate currently accepts only non-arrayed 2D R32_UINT atomics.
-        if (ncoord != 2) return fallback;
+        // 2D and 2D_ARRAY R32_UINT atomics. `arrayed` is implied by ncoord==3 -- the gate below
+        // only reaches here for SQ_DIM_2D (ncoord 2) and SQ_DIM_2D_ARRAY (ncoord 3, x/y/layer).
+        const bool arrayed = ncoord == 3;
+        if (ncoord != 2 && ncoord != 3) return fallback;
         if (!t_ptr_img_u32) {
             t_ptr_img_u32 = id();
             put(types, Op_TypePointer, {t_ptr_img_u32, SC_Image, t_u32});
@@ -1726,12 +1728,25 @@ struct SpirvCompute {
         const uint32_t image = id();
         put(code, Op_Load, {stg_img_binding_type[binding], image, stg_img_var[binding]});
         const uint32_t size = id();
-        put(code, Op_ImageQuerySize, {t_v2i(), size, image});
+        // An arrayed image's OpImageQuerySize yields (width, height, layers); a plain 2D yields
+        // (width, height). Querying the wrong arity is a SPIR-V validity error rather than a silent
+        // miscompile, so spv_validate catches a mistake here.
+        put(code, Op_ImageQuerySize, {arrayed ? t_v3i() : t_v2i(), size, image});
         const uint32_t width_i = id(), height_i = id();
         put(code, Op_CompositeExtract, {t_i32, width_i, size, 0});
         put(code, Op_CompositeExtract, {t_i32, height_i, size, 1});
         uint32_t in_bounds = ucmp(Op_ULessThan, coords[0], i2u(width_i));
         in_bounds = land(in_bounds, ucmp(Op_ULessThan, coords[1], i2u(height_i)));
+        if (arrayed) {
+            // The layer bound is NOT optional. Vulkan leaves an out-of-bounds image atomic
+            // undefined -- robust image access does not cover atomics -- and the 2D case's own
+            // comment records that RADV can spend seconds in one before resetting the GPU. An
+            // unbounded layer index would be exactly that, so the layer is bounded from the image's
+            // own query rather than from a descriptor field the shader cannot see.
+            const uint32_t layers_i = id();
+            put(code, Op_CompositeExtract, {t_i32, layers_i, size, 2});
+            in_bounds = land(in_bounds, ucmp(Op_ULessThan, coords[2], i2u(layers_i)));
+        }
         const uint32_t active = predicated ? land(pred, in_bounds) : in_bounds;
         auto emit = [&]() {
             const uint32_t coord = stg_coord(ncoord, coords);
@@ -9847,6 +9862,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (!allow_smem || !rt) { ok = false; return true; }
             const uint32_t SQ_DIM_2D = 1u;
             const uint32_t SQ_DIM_3D = 2u;
+            const uint32_t SQ_DIM_2D_ARRAY = 5u;   // (x, y, layer) -- #2265
             auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
 
             // IMAGE_BVH_INTERSECT_RAY (GFX10 opcode 0xe6) has an image encoding but consumes a
@@ -10119,10 +10135,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // The live Astro Bot visibility image is an ordinary 2D R32_UINT surface. Keep the
                 // first atomic implementation exact and fail-visible for every other image shape;
                 // atomics require a typed integer image in Vulkan/SPIR-V rather than Format=Unknown.
+                // 2D and 2D_ARRAY. The array layer was added for #2265: Sonic Racing: CrossWorlds
+                // issues IMAGE_ATOMIC_ADD at dim=2D_ARRAY on a default launch, and the storage
+                // load/store siblings had already been generalised over the layer while the atomic
+                // had not. `res->depth` is the layer COUNT for an arrayed view, so it is required to
+                // be exactly 1 only in the non-arrayed case.
+                const bool atomic_2d_array = in.mimg_dim == SQ_DIM_2D_ARRAY && arrayed && !ms;
                 if (is_atomic &&
-                    (in.mimg_dim != SQ_DIM_2D || arrayed || ms || in.len_dwords != 2 ||
+                    ((in.mimg_dim != SQ_DIM_2D && !atomic_2d_array) || ms || in.len_dwords != 2 ||
                      in.mimg_unorm || in.mimg_dmask != 1u ||
-                     res->img_dim != 1u || res->depth != 1u || res->depth_compare ||
+                     (!arrayed && (res->img_dim != 1u || res->depth != 1u)) ||
+                     (arrayed && (res->img_dim != SQ_DIM_2D_ARRAY || !res->depth)) ||
+                     (arrayed && !res->depth) || res->depth_compare ||
                      res->format != DataFormat::Uint32 || components != 1u ||
                      !res->width || !res->height || res->in_mip_tail ||
                      res->compression_enabled)) {


### PR DESCRIPTION
Two defects behind #2265, found by instrumenting rather than inferring — and the second one is the
actual wall.

## 1. The atomic was 2D-shaped while its load/store siblings were not

`IMAGE_ATOMIC_ADD` at `dim=2D_ARRAY` was rejected. The storage path already handled 2D_ARRAY for
**load and store** (`rdna2_to_spirv.cpp` records *"Storage load/store handle 1D/2D/3D + 1D/2D_ARRAY"*);
only the atomic had never been generalised over the layer.

`image_atomic_u32` now accepts `ncoord==3`, queries `OpImageQuerySize` into a `v3i` for an arrayed
image, and **bounds the layer against the image's own third component**. That bound is not defensive:
Vulkan leaves an out-of-bounds image atomic undefined, robust image access does not cover atomics, and
the 2D path's own comment records that **RADV can spend seconds in one before resetting the GPU**.

The gate's descriptor conditions are split by arrayedness. Two things the issue had assumed wrong,
corrected by measurement:

```
[mimg-atomic-gate] pc=751 dim=5 arrayed=1 ms=0 len=2 unorm=0 dmask=0x1
   | res: img_dim=5 depth=2 fmt=2 comp=1 w=3840 h=2160
```

- `res->img_dim` is **5**, not 1 — the *descriptor* carries the array dim too
- `res->depth` is **2** — the layer count, so `depth == 1` is right only when non-arrayed

A 4K two-layer R32_UINT array image.

## 2. A shader could not use its own atomic image twice

With the above, the gate accepted the op — and it still rejected, one step later:

```
[atomic-buf-decl] binding=37 refused; resource-table entries at this binding:
(none)
```

`declare_compute_atomic_image_buffer` refused any binding already in `cbuf_var` — **including
bindings it declared itself**. A shader with two atomics on the same image compiled the first and was
rejected whole at the second.

**The resource table has no entry at binding 37**, so `declare_cbufs` — the only other writer of
`cbuf_var`, and only for ConstantBuffer/VertexBuffer resources — cannot have been the declarer. The
declaration was ours, so reuse is provably safe.

The fix tracks our own bindings and treats a repeat as a hit. **Bindings declared by `declare_cbufs`
are still refused**: their type happens to match (`t_ptr_sb_struct_u`), which is exactly what would
make aliasing onto another resource's buffer silent rather than loud. The distinction is by
**provenance**, not by type.

## Effect, stated at its real size

| | before | after |
| --- | ---: | ---: |
| `recompile-reject op=0x11` | 4 | **0** |
| `atomic-buf-decl` refusals | 4 | **0** |
| CrossWorlds frame at sample 06 | 1 colour | **1,092 colours** |

**It does not reach a title screen.** The composite still collapses to RGB(1,0,1); the title gets one
sample further. The same shader now stops on the next unimplemented op, MIMG `op=0x17`
(`words=f05c212a,00000910`), recorded on #2265.

**`0x17` is deliberately not implemented here.** The GCN/RDNA atomic block ordering makes it very
likely `IMAGE_ATOMIC_UMAX`, but `llvm-mc` will not decode this encoding, and a wrong choice between
`UMax`/`SMax`/`Sub` produces a subtly wrong image rather than a loud failure. `CONFIDENCE: MED` on the
mnemonic, and MED is not enough to ship a semantic.

## Verification

```
cmake --build build -j6            # rc=0
ctest --no-tests=error -j4         # 221/221 passed
git diff --check                   # clean
```

221 is master's count in a `-DGAME_DUMP=…` build. No test is added: the shapes this fixes need a
2-layer R32_UINT storage image and two atomics on it, which the unit harness cannot currently express
— worth saying plainly rather than implying coverage. The evidence is the reject counts going to zero
on a live title and the suite staying green.

Requesting review, @Wren — the provenance-vs-type distinction in (2) is the part I would attack: I
argue reuse is safe because *we* declared it, and the whole safety of that rests on the resource-table
dump being empty at that binding.

Refs #2265.
