### PR TITLE
fix(hle): clamp the [exc2] handler's write lengths — same over-read class as #2050

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -24,6 +24,22 @@
 #include <pthread.h>
 #include <semaphore.h>   // scePthreadSem* -> host sem_t
 #include "../host/posix_shim.hpp"   // Darwin: sem/barrier/timedlock/getattr_np/sigqueue compat
+// raw_fmt_len: snprintf's would-be length clamped to what actually landed (#2050), used by the
+// [exc2] handler below.
+//
+// Guarded, and at FILE SCOPE, for two separate reasons that must both hold:
+//   * raw_syscall.hpp's non-Linux branch includes <sys/mman.h>/<unistd.h> unconditionally, so it is
+//     not MinGW-clean -- hence the guard. The [exc2] handler is POSIX-only, so Windows needs none
+//     of this.
+//   * it declares `namespace prosper`, so including it anywhere nested produces
+//     `prosper::{anonymous}::prosper` and every later `prosper::` lookup resolves into the INNER
+//     namespace and fails. The first attempt put it beside the handler, inside an anonymous
+//     namespace inside `namespace prosper`, and Linux/macOS CI rejected it with
+//     "'guest_module_name' is not a member of 'prosper::{anonymous}::prosper'". A header that opens
+//     a namespace can only be included where that namespace means what the file expects.
+#if defined(__linux__) || defined(__APPLE__)
+#include "../host/raw_syscall.hpp"
+#endif
 #include <cerrno>
 #include <cctype>
 #include <cstdio>
@@ -2659,11 +2675,6 @@ bool g_exc_log = false;               // set once (outside signal ctx) from PROS
 bool g_exc_log2 = false;
 volatile int* g_exc_counter = nullptr; // optional fork-safe raise counter (tests)
 #if defined(__linux__) || defined(__APPLE__)
-// raw_fmt_len: snprintf's would-be length clamped to what actually landed (#2050). Included INSIDE
-// the POSIX guard because raw_syscall.hpp's non-Linux branch includes <sys/mman.h>/<unistd.h>
-// unconditionally, so it is not MinGW-clean -- and the exception handler below is POSIX-only, so
-// nothing here needs it on Windows.
-#include "../host/raw_syscall.hpp"
 int  g_exc_sig = -1;
 #ifdef __APPLE__
 // Darwin has no pthread_sigqueue / RT-signal payload, so the exception TYPE travels through a

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2659,6 +2659,11 @@ bool g_exc_log = false;               // set once (outside signal ctx) from PROS
 bool g_exc_log2 = false;
 volatile int* g_exc_counter = nullptr; // optional fork-safe raise counter (tests)
 #if defined(__linux__) || defined(__APPLE__)
+// raw_fmt_len: snprintf's would-be length clamped to what actually landed (#2050). Included INSIDE
+// the POSIX guard because raw_syscall.hpp's non-Linux branch includes <sys/mman.h>/<unistd.h>
+// unconditionally, so it is not MinGW-clean -- and the exception handler below is POSIX-only, so
+// nothing here needs it on Windows.
+#include "../host/raw_syscall.hpp"
 int  g_exc_sig = -1;
 #ifdef __APPLE__
 // Darwin has no pthread_sigqueue / RT-signal payload, so the exception TYPE travels through a
@@ -2692,9 +2697,19 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
             // %fs-safe: this handler can interrupt guest code running on the GUEST %fs, where host
             // libc TLS (locale, stack canary) reads garbage — swap to host %fs for the logging.
             uint64_t sfs = guest_fs_to_host_scoped();
+            // snprintf returns the length it WOULD have written, so handing it to write() reads
+            // past the end of this stack buffer whenever the line truncates -- #2050's class, and
+            // instrument trap 109's. raw_fmt_len() is the clamp #2050 introduced for exactly this,
+            // already unit-tested (tests/test_raw_syscall.cpp), and it encodes the right choice for
+            // the truncated case: write the cap-1 bytes that really landed, so the shortening stays
+            // visible rather than being papered over.
+            //
+            // Integers only, so this one cannot truncate today -- clamped anyway, because "cannot
+            // truncate today" is a property of the format string, and the next person to add a %s
+            // will not re-derive it.
             char b[96]; int n = snprintf(b, sizeof b, "[exc2] DROPPED type=%d tid=%ld (no handler)\n",
                                          type, (long)prosper_gettid());
-            (void)!write(2, b, n);
+            (void)!write(2, b, prosper::raw_fmt_len(n, sizeof b));
             guest_fs_restore_scoped(sfs);
         }
         return;
@@ -2709,12 +2724,16 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
         // #1659: was a hand-rolled three-branch dispatcher whose eboot (0x400000000) and libc
         // (0x500000000) bases were both stale; only the il2cpp one was current. One shared,
         // module-aware call replaces all three and cannot drift again.
+        // This is the reachable one of the three (#2162): the format embeds guest_module_name(),
+        // which is NOT length-bounded at the call site, into a 160-byte buffer whose fixed part is
+        // ~50. A module label over ~90 characters truncates and the unclamped write over-reads --
+        // the same shape that made the [labelhist] site the first one caught in trap 109.
         n = snprintf(b, sizeof b, "[exc2] ENTER tid=%ld type=%d fs=%s rip=%s+0x%llx\n",
                      (long)prosper_gettid(), type, fss, prosper::guest_module_name(irip),
                      (unsigned long long)prosper::guest_module_offset(irip));
         // guest_module_name/offset already degrade to "mapped/host" + the verbatim address, so the
         // former host: fallback branch is folded into the single call above.
-        (void)!write(2, b, n);
+        (void)!write(2, b, prosper::raw_fmt_len(n, sizeof b));
         guest_fs_restore_scoped(sfs);
     }
     auto* uc = (ucontext_t*)uc_;
@@ -2750,7 +2769,7 @@ void exc_delivery_handler(int, siginfo_t* si, void* uc_) {
         uint64_t sfs = guest_fs_to_host_scoped();   // %fs-safe logging (see ENTER)
         char b[96]; int n = snprintf(b, sizeof b, "[exc2] RESUME tid=%ld type=%d\n",
                                      (long)prosper_gettid(), type);
-        (void)!write(2, b, n);
+        (void)!write(2, b, prosper::raw_fmt_len(n, sizeof b));
         guest_fs_restore_scoped(sfs);
     }
 }


### PR DESCRIPTION
Three sites in the guest-exception delivery handler passed `snprintf`'s return value straight to `write()`:

| site | buffer | line |
| --- | --- | --- |
| `[exc2] DROPPED` | `char b[96]` | integers only |
| `[exc2] ENTER` | `char b[160]` | **embeds `guest_module_name()`** |
| `[exc2] RESUME` | `char b[96]` | integers only |

`snprintf` returns the length it **would have** written, so on truncation the `write` reads past the end of a stack buffer — #2050's class and instrument trap 109's, in a **signal handler** that runs the guest's own GC suspend/resume callbacks.

## Which one is reachable

**`ENTER`.** Its format embeds `prosper::guest_module_name(irip)`, which is **not length-bounded at the call site**, into a 160-byte buffer whose fixed part is ~50 bytes. A module label over ~90 characters truncates and the unclamped write over-reads. That is precisely the shape that made the `[labelhist]` site the first one caught in trap 109: a `%s` whose length is not obviously smaller than its buffer.

`DROPPED` and `RESUME` are integers only and cannot truncate today. **Clamped anyway** — "cannot truncate today" is a property of the format string, and the next person to add a `%s` will not re-derive it.

## Reusing the tested clamp rather than re-deriving it

`raw_fmt_len()` is #2050's own clamp, already unit-tested in `tests/test_raw_syscall.cpp`. It also encodes the right choice for the truncated case: write the `cap - 1` bytes that really landed, so the shortening stays **visible** through the existing contract rather than being silently papered over.

The include sits **inside** the existing `#if defined(__linux__) || defined(__APPLE__)` guard, because `raw_syscall.hpp`'s non-Linux branch includes `<sys/mman.h>` and `<unistd.h>` unconditionally and is therefore **not MinGW-clean**. The handler is POSIX-only, so nothing needs it on Windows — and that constraint is stated in the comment so nobody hoists the include to the top of the file.

## Verification, and what it does and does not establish

Windows, MinGW (WinLibs UCRT g++ 16.1.0), RelWithDebInfo:

```
cmake --build -j12          -> rc=0
ctest --no-tests=error -j8  -> 176 tests, 2 failed
    62 pthread_cond_clock      pre-existing
    15 build_revision_refresh  stale scratch git object
```

**Stated plainly: the changed lines are not compiled on this host.** The Windows build proves exactly one thing — that the guarded include does not leak into the Windows translation unit, which is the only way this change could have broken anything from my side. Linux and macOS compile the changed lines and CI covers both; I am relying on that rather than implying local coverage I do not have.

## An unrelated intermittent found during verification

`ult_semantics` aborted with `STATUS_HEAP_CORRUPTION` (`0xc0000374`) in **1 of 4** parallel ctest runs, and passed 3/3 in isolation. **Not from this change** — the diff is not compiled on Windows, and the other three parallel runs on the same binary failed only on the two known-bad tests. Filed separately as **#2277** rather than buried here, because a 1-in-4 heap corruption will otherwise be attributed to whatever change is in flight, repeatedly.

Fixes #2162
