### PR TITLE
fix(host): the three glibc write(2,…) sites in exec_image_linux.cpp join the #2050 clamp

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -851,7 +851,18 @@ namespace {
                 uint64_t obj = base;
                 if (ps.deref[k]) {   // chase one pointer level: obj = [base + pre]
                     uint64_t pa = base + ps.pre[k];
-                    if (!probe_readable(pa)) { n = snprintf(b, sizeof b, "    [+0x%llx]-><unmapped>\n", (unsigned long long)ps.pre[k]); write(2,b,n); continue; }
+                    // raw_write_fmt, like every other write in this dump -- including the one
+                    // eleven lines below. This site had NO guard at all: snprintf's would-be length
+                    // went straight to write(), so a truncating format over-read `b` (#2180, the
+                    // #2050 class). It also used glibc write() inside a fault handler, where the
+                    // rest of this function deliberately uses raw syscalls to avoid libc TLS on a
+                    // guest-%fs thread -- so it was two defects wearing one line.
+                    if (!probe_readable(pa)) {
+                        n = snprintf(b, sizeof b, "    [+0x%llx]-><unmapped>\n",
+                                     (unsigned long long)ps.pre[k]);
+                        raw_write_fmt(2, b, sizeof b, n);
+                        continue;
+                    }
                     obj = *(const uint64_t*)pa;
                 }
                 uint64_t addr = obj + ps.off[k];
@@ -1089,7 +1100,12 @@ namespace {
                 "[fs-emu] UNHANDLED fs insn rip=0x%llx off=%lld bytes: %02x %02x %02x %02x %02x %02x %02x %02x\n",
                 (unsigned long long)g[REG_RIP], (long long)off,
                 p[0],p[1],p[2],p[3],p[4],p[5],p[6],p[7]);
-            ssize_t wr = write(2, b, (size_t)(n>0?n:0)); (void)wr;
+            // `n > 0` rejects only the ENCODING error; a truncating format returns MORE than the
+            // buffer holds and the write over-reads it. #2171's own comment at the raw_write sites
+            // says exactly that, and these two glibc sites were missed because that sweep's
+            // enumeration was scoped to `raw_write` (#2180). raw_write_fmt applies the full clamp
+            // and keeps the truncation marker.
+            raw_write_fmt(2, b, sizeof b, n);
             return false;   // fall through to the normal (fatal) fault path so the form is visible
         }
         for (int k = 0; k < 16; k++) g[kX86ToReg[k]] = (greg_t)regs[k];
@@ -1097,7 +1113,7 @@ namespace {
         g_fs_emulated++;
         if (g_fslog && (g_fs_emulated & 0x3FFF) == 0) {
             char b[64]; int n = snprintf(b, sizeof b, "[fs-emu] %lu accesses\n", g_fs_emulated);
-            ssize_t wr = write(2, b, (size_t)(n>0?n:0)); (void)wr;
+            raw_write_fmt(2, b, sizeof b, n);
         }
         return true;
     }


### PR DESCRIPTION
#2171 swept the `snprintf` → write over-read class in this file — **88 sites** — but scoped its enumeration to `raw_write`. Three glibc `write(2, …)` sites in the same file carry the same shape and were neither converted nor enumerated.

| site | buffer | guard before |
| --- | --- | --- |
| PEEK dump (`:854`) | `char b[256]` | **none at all** |
| `fs-emu` UNHANDLED (`:1092`) | `char b[128]` | `n > 0` only |
| `fs-emu` counter (`:1100`) | `char b[64]` | `n > 0` only |

**`n > 0` rejects the encoding error and nothing else.** A truncating format returns *more* than the buffer holds and the write over-reads it — which #2171's own comment at the `raw_write` sites says in as many words. That is what makes these three an author miss rather than a reviewer nicety.

## The fix is a neighbour, not an invention

All three now call `raw_write_fmt(2, b, sizeof b, n)` — the helper the surrounding code already uses, **eleven lines below the first of them**. That is the strongest available form of this fix: there was nothing to design, only a call to make consistent with its own block.

**The PEEK site was two defects on one line.** Besides the missing clamp it used glibc `write()` inside a **fault handler**, where the rest of this function deliberately uses raw syscalls so a guest-`%fs` thread never touches libc TLS. Fixing the over-read fixes that too.

## The check #2171 could not quote

```
$ grep -n '[^_]write(2,' prosper/src/host/exec_image_linux.cpp | grep -v raw_write
(nothing)
```

The class is now **empty in this file**, not merely reduced. #2171's sweep could not state that, because its matcher was the thing that missed these — the issue records that a looser repo-wide matcher reported a higher count for this file, the discrepancy was noticed, and it was never reconciled.

## Verification, and what it does not establish

This file is POSIX-only and **is not compiled on Windows**, so my local build proves only that nothing leaked into the Windows translation unit. **Linux and macOS CI compile the changed lines**, and I am relying on that rather than implying coverage I do not have — the same division that caught a real namespace error in #2278 an hour ago.

## Risk

Diagnostic output only, in paths that run when a fault is already being reported. The visible change is that a truncated line now writes the bytes that really landed and carries the existing truncation marker, instead of writing past the end of a stack buffer.

Fixes #2180
