### PR TITLE
diag(hle): capture what a title asks Videodec2 for — the output layout is YUV420 by arithmetic, not by guess

### DIFF
--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -878,6 +878,14 @@ namespace {
 struct AuDecoder {
     AVCodecContext* ctx = nullptr;
     AVFrame* frame = nullptr;
+    AVFrame* sw_frame = nullptr;      // hardware path: av_hwframe_transfer_data destination
+    AVBufferRef* hw_device = nullptr;
+    AVPixelFormat hw_pix_fmt = AV_PIX_FMT_NONE;
+    // get_format reads this through ctx->opaque, so it must outlive avcodec_open2 -- hence a
+    // shared_ptr rather than a stack local. Attaching hw_device_ctx ALONE is not enough: without
+    // this callback libavcodec silently negotiates a software format and the decoder reports
+    // hardware while decoding in software, which is exactly what the first version of this did.
+    std::shared_ptr<HardwareSelection> selection;
     AVPacket* packet = nullptr;
     std::vector<uint8_t> nv12;      // interleaved UV staging; owned so `out` stays valid to next call
     uint32_t width = 0, height = 0;
@@ -909,9 +917,9 @@ void yuv420p_to_nv12(const AVFrame* src, std::vector<uint8_t>& dst,
 }  // namespace
 
 int VaapiBackend::open_decoder(uint32_t codec) {
-    // codec==1 is AVC/H.264: Tales of Graces f creates its decoder with codec=1 profile=100, and
-    // profile_idc 100 is H.264 High Profile. 1920x1088 corroborates it -- 1088 is 1080 rounded up to
-    // an H.264 16-pixel macroblock row. Anything else is refused rather than guessed at.
+    // codec==1 is AVC/H.264: measured on two titles as codec=1 profile=100, and profile_idc 100 is
+    // H.264 High Profile. 1920x1088 / 3840x2160 corroborate it -- 1088 is 1080 rounded up to an
+    // H.264 16-pixel macroblock row. Anything else is refused rather than guessed at.
     if (codec != 1) {
         fprintf(stderr, "[vdec2] open_decoder: codec=%u is not AVC/H.264(1); refusing rather than "
                         "guessing a bitstream format (#2270)\n", codec);
@@ -919,22 +927,63 @@ int VaapiBackend::open_decoder(uint32_t codec) {
     }
     const AVCodec* av = avcodec_find_decoder(AV_CODEC_ID_H264);
     if (!av) { fprintf(stderr, "[vdec2] no H.264 decoder in this libavcodec build\n"); return -1; }
+
     AuDecoder d;
+    // VA-API FIRST, and not as an optimisation. A VA-API H.264 decoder produces NV12 surfaces
+    // NATIVELY, which is exactly what the guest allocates for (1.5 bytes/pixel, measured), so the
+    // hardware path has NO colour conversion at all -- the software path needs a per-frame
+    // YUV420P->NV12 chroma interleave, and at 3840x2160 that is 12.4 MB of CPU work every frame.
+    // Doing it on the CPU is the wrong answer; doing it on the GPU is a better wrong answer than
+    // that; not doing it is the right one. Same av_hwdevice_ctx_create the stream path above uses.
+    for (int i = 0;; ++i) {
+        const AVCodecHWConfig* cfg = avcodec_get_hw_config(av, i);
+        if (!cfg) break;
+        if ((cfg->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) &&
+            cfg->device_type == AV_HWDEVICE_TYPE_VAAPI) { d.hw_pix_fmt = cfg->pix_fmt; break; }
+    }
+    if (d.hw_pix_fmt != AV_PIX_FMT_NONE) {
+        const char* dev = std::getenv("PROSPER_AVP_VAAPI_DEVICE");
+        if (dev && !*dev) dev = nullptr;
+        if (av_hwdevice_ctx_create(&d.hw_device, AV_HWDEVICE_TYPE_VAAPI, dev, nullptr, 0) < 0) {
+            d.hw_pix_fmt = AV_PIX_FMT_NONE;
+            d.hw_device = nullptr;
+        }
+    }
+
     d.ctx = avcodec_alloc_context3(av);
-    if (!d.ctx) return -1;
-    if (avcodec_open2(d.ctx, av, nullptr) < 0) { avcodec_free_context(&d.ctx); return -1; }
+    if (!d.ctx) { if (d.hw_device) av_buffer_unref(&d.hw_device); return -1; }
+    if (d.hw_device) {
+        d.ctx->hw_device_ctx = av_buffer_ref(d.hw_device);
+        d.selection = std::make_shared<HardwareSelection>();
+        d.selection->format = d.hw_pix_fmt;
+        d.selection->require_hardware = false;   // a software frame is still a picture
+        d.ctx->opaque = d.selection.get();
+        d.ctx->get_format = select_video_format;
+    }
+    if (avcodec_open2(d.ctx, av, nullptr) < 0) {
+        avcodec_free_context(&d.ctx);
+        if (d.hw_device) av_buffer_unref(&d.hw_device);
+        return -1;
+    }
     d.frame = av_frame_alloc();
+    d.sw_frame = av_frame_alloc();
     d.packet = av_packet_alloc();
-    if (!d.frame || !d.packet) {
+    if (!d.frame || !d.sw_frame || !d.packet) {
         if (d.frame) av_frame_free(&d.frame);
+        if (d.sw_frame) av_frame_free(&d.sw_frame);
         if (d.packet) av_packet_free(&d.packet);
         avcodec_free_context(&d.ctx);
+        if (d.hw_device) av_buffer_unref(&d.hw_device);
         return -1;
     }
     std::lock_guard<std::mutex> lk(g_au_mutex);
     const int id = g_next_au_id++;
     g_au_decoders[id] = d;
-    fprintf(stderr, "[vdec2] access-unit H.264 decoder opened (id=%d)\n", id);
+    // Deliberately says REQUESTED, not "using". Whether hardware is actually negotiated is only
+    // known when a frame comes back in the hardware pixel format, and the first version of this
+    // line claimed hardware while every frame decoded in software.
+    fprintf(stderr, "[vdec2] access-unit H.264 decoder opened (id=%d, VA-API %s)\n", id,
+            d.hw_device ? "requested" : "unavailable -- software");
     return id;
 }
 
@@ -969,16 +1018,48 @@ bool VaapiBackend::decode_au(int id, const uint8_t* au, size_t bytes, VideoFrame
     }
     if (sent < 0 || got < 0) return false;   // needs more input: NOT an error
 
-    if (d.frame->format != AV_PIX_FMT_YUV420P) {
+    // HARDWARE: the decoded surface is already NV12. Transfer it to CPU-visible memory and hand
+    // the planes over as they are -- no colour conversion, no chroma interleave, nothing per-pixel
+    // on the CPU beyond the transfer the guest's own buffer requires anyway.
+    const AVFrame* pic = d.frame;
+    if (d.hw_pix_fmt != AV_PIX_FMT_NONE && d.frame->format == d.hw_pix_fmt) {
+        av_frame_unref(d.sw_frame);
+        d.sw_frame->format = AV_PIX_FMT_NV12;          // ask for NV12 directly from the surface
+        if (av_hwframe_transfer_data(d.sw_frame, d.frame, 0) < 0) return false;
+        pic = d.sw_frame;
+    }
+
+    d.width = static_cast<uint32_t>(pic->width);
+    d.height = static_cast<uint32_t>(pic->height);
+
+    if (pic->format == AV_PIX_FMT_NV12) {
+        // Already the guest's layout. Copy plane-wise only because the strides may exceed the
+        // width; when they do not this is two straight memcpys.
+        const size_t y_bytes = static_cast<size_t>(d.width) * d.height;
+        d.nv12.resize(y_bytes + y_bytes / 2);
+        for (uint32_t row = 0; row < d.height; ++row)
+            std::memcpy(d.nv12.data() + static_cast<size_t>(row) * d.width,
+                        pic->data[0] + static_cast<size_t>(row) * pic->linesize[0], d.width);
+        for (uint32_t row = 0; row < d.height / 2; ++row)
+            std::memcpy(d.nv12.data() + y_bytes + static_cast<size_t>(row) * d.width,
+                        pic->data[1] + static_cast<size_t>(row) * pic->linesize[1], d.width);
+    } else if (pic->format == AV_PIX_FMT_YUV420P) {
+        // SOFTWARE fallback only. This is the per-frame CPU chroma interleave the hardware path
+        // exists to avoid -- 12.4 MB per frame at 3840x2160 -- so it is a correctness net, not a
+        // design. If a host ever runs here permanently, that is a bug to chase, not a tradeoff.
+        static std::atomic<int> warned{0};
+        if (warned.fetch_add(1) == 0)
+            fprintf(stderr, "[vdec2] software decode path: paying a per-frame YUV420P->NV12 CPU "
+                            "interleave; VA-API was unavailable (#2270)\n");
+        yuv420p_to_nv12(pic, d.nv12, d.width, d.height);
+    } else {
         static std::atomic<int> warned{0};
         if (warned.fetch_add(1) < 8)
-            fprintf(stderr, "[vdec2] unexpected decoded pixel format %d (want YUV420P); no picture\n",
-                    d.frame->format);
+            fprintf(stderr, "[vdec2] unexpected decoded pixel format %d; no picture\n",
+                    pic->format);
         return false;
     }
-    d.width = static_cast<uint32_t>(d.frame->width);
-    d.height = static_cast<uint32_t>(d.frame->height);
-    yuv420p_to_nv12(d.frame, d.nv12, d.width, d.height);
+
     out.y = d.nv12.data();
     out.uv = d.nv12.data() + static_cast<size_t>(d.width) * d.height;
     out.width = d.width;
@@ -994,8 +1075,10 @@ void VaapiBackend::close_decoder(int id) {
     auto it = g_au_decoders.find(id);
     if (it == g_au_decoders.end()) return;
     if (it->second.frame) av_frame_free(&it->second.frame);
+    if (it->second.sw_frame) av_frame_free(&it->second.sw_frame);
     if (it->second.packet) av_packet_free(&it->second.packet);
     if (it->second.ctx) avcodec_free_context(&it->second.ctx);
+    if (it->second.hw_device) av_buffer_unref(&it->second.hw_device);
     g_au_decoders.erase(it);
 }
 

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -877,6 +877,7 @@ namespace {
 
 struct AuDecoder {
     AVCodecContext* ctx = nullptr;
+    bool checked_first_au = false;    // the codec->bitstream sanity check runs once, in decode_au
     AVFrame* frame = nullptr;
     AVFrame* sw_frame = nullptr;      // hardware path: av_hwframe_transfer_data destination
     AVBufferRef* hw_device = nullptr;
@@ -920,13 +921,37 @@ int VaapiBackend::open_decoder(uint32_t codec) {
     // codec==1 is AVC/H.264: measured on two titles as codec=1 profile=100, and profile_idc 100 is
     // H.264 High Profile. 1920x1088 / 3840x2160 corroborate it -- 1088 is 1080 rounded up to an
     // H.264 16-pixel macroblock row. Anything else is refused rather than guessed at.
-    if (codec != 1) {
-        fprintf(stderr, "[vdec2] open_decoder: codec=%u is not AVC/H.264(1); refusing rather than "
-                        "guessing a bitstream format (#2270)\n", codec);
+    // codec==2382845 is VP9, and that is NOT read off the enum -- the enum value is not a small
+    // ordinal and we have no published table for it. It is read off the BITSTREAM, which is primary
+    // evidence and cannot be argued with: Sonic Racing: CrossWorlds' first access unit begins
+    //
+    //     82 49 83 42 60 ef f0 86 ...
+    //
+    // 0x82 = 1000 0010: frame_marker=0b10 (VP9 requires exactly 2), profile_low=0, profile_high=0
+    // (profile 0), show_existing_frame=0, frame_type=0 (KEY frame), show_frame=1 -- and a VP9 key
+    // frame is followed by the frame sync code 0x49 0x83 0x42, which is exactly bytes 1..3. Later
+    // access units start 0x86, the same layout with frame_type=1 (inter). There are no Annex-B start
+    // codes anywhere in the stream, so it is neither H.264 nor HEVC.
+    //
+    // The decoder contract corroborates the geometry independently: max=3840x2160 with
+    // max_frame_size=12441600, and 12441600 / (3840*2160) = 1.5 bytes/pixel = NV12.
+    //
+    // CONFIDENCE: HIGH that this title's stream is VP9 (sync code, from the guest's own buffer).
+    // CONFIDENCE: MED that the value 2382845 *means* VP9 in general -- that mapping rests on one
+    // title. A second title reporting 2382845 with a non-VP9 stream would falsify it, which is what
+    // the sync-code check in decode_au() below is for: it makes a wrong mapping LOUD rather than
+    // letting libavcodec fail somewhere downstream with an unrelated-looking error.
+    AVCodecID want = AV_CODEC_ID_NONE;
+    const char* want_name = nullptr;
+    if (codec == 1)             { want = AV_CODEC_ID_H264; want_name = "H.264"; }
+    else if (codec == 2382845)  { want = AV_CODEC_ID_VP9;  want_name = "VP9";   }
+    else {
+        fprintf(stderr, "[vdec2] open_decoder: codec=%u is not a bitstream format we have identified "
+                        "(1=AVC/H.264, 2382845=VP9); refusing rather than guessing (#2270)\n", codec);
         return -1;
     }
-    const AVCodec* av = avcodec_find_decoder(AV_CODEC_ID_H264);
-    if (!av) { fprintf(stderr, "[vdec2] no H.264 decoder in this libavcodec build\n"); return -1; }
+    const AVCodec* av = avcodec_find_decoder(want);
+    if (!av) { fprintf(stderr, "[vdec2] no %s decoder in this libavcodec build\n", want_name); return -1; }
 
     AuDecoder d;
     // VA-API FIRST, and not as an optimisation. A VA-API H.264 decoder produces NV12 surfaces
@@ -992,6 +1017,28 @@ bool VaapiBackend::decode_au(int id, const uint8_t* au, size_t bytes, VideoFrame
     auto it = g_au_decoders.find(id);
     if (it == g_au_decoders.end() || !au || !bytes) return false;
     AuDecoder& d = it->second;
+
+    // Make a WRONG codec mapping loud on the very first access unit, instead of letting libavcodec
+    // fail later with an error that reads as a corrupt stream. The VP9 mapping in open_decoder() is
+    // derived from one title's bitstream, so it is exactly the kind of inference that must announce
+    // its own falsification: a VP9 key frame carries frame_marker==0b10 in the top two bits and the
+    // sync code 0x49 0x83 0x42 immediately after the first byte. Checked once per decoder, and it
+    // only ever warns -- a stream that fails this may still decode, and refusing here would turn a
+    // diagnostic into a regression.
+    if (!d.checked_first_au) {
+        d.checked_first_au = true;
+        if (d.ctx && d.ctx->codec_id == AV_CODEC_ID_VP9 && bytes >= 4) {
+            const bool marker = (au[0] & 0xC0) == 0x80;
+            const bool sync   = au[1] == 0x49 && au[2] == 0x83 && au[3] == 0x42;
+            const bool keyfrm = (au[0] & 0x04) == 0;
+            if (!marker || (keyfrm && !sync))
+                fprintf(stderr,
+                        "[vdec2] WARNING: opened as VP9 but the first access unit does not look like "
+                        "VP9 (head=%02x %02x %02x %02x, frame_marker=%s, sync=%s). The codec->format "
+                        "mapping may be wrong for this title -- see open_decoder (#2270).\n",
+                        au[0], au[1], au[2], au[3], marker ? "ok" : "BAD", sync ? "ok" : "absent");
+        }
+    }
 
     // av_packet_from_data would take ownership of a buffer we do not own; the guest's access unit
     // lives in guest memory and must not be freed by libavcodec.

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -14,6 +14,9 @@ extern "C" {
 
 #include <algorithm>
 #include <atomic>
+#include <map>
+#include <mutex>
+#include <vector>
 #include <condition_variable>
 #include <cstdio>
 #include <cstdlib>
@@ -859,5 +862,142 @@ void uninstall_vaapi_backend() {
     auto& vaapi = shared_vaapi_backend();
     if (backend() == &vaapi) set_backend(nullptr);
 }
+
+
+// ===== sceVideodec2 access-unit decoding (#2270) ==============================================
+//
+// Separate from the stream pipeline above because the guest's contract is different: it demuxes
+// itself and submits one compressed access unit at a time. That is send_packet/receive_frame, so
+// this is a second entry point onto libavcodec rather than a second decoder.
+//
+// Output is NV12 because that is what the platform delivers (VideoFrame's own comment) and what the
+// guest allocates for: measured on Tales of Graces f, max_width*max_height = 1920*1088 against a
+// max_frame_size of 3,133,440, i.e. exactly 1.5 bytes per pixel. 2.0 would be YUV422, 4.0 RGBA.
+namespace {
+
+struct AuDecoder {
+    AVCodecContext* ctx = nullptr;
+    AVFrame* frame = nullptr;
+    AVPacket* packet = nullptr;
+    std::vector<uint8_t> nv12;      // interleaved UV staging; owned so `out` stays valid to next call
+    uint32_t width = 0, height = 0;
+};
+
+std::mutex g_au_mutex;
+std::map<int, AuDecoder> g_au_decoders;
+int g_next_au_id = 1;
+
+// libavcodec's H.264 decoder yields planar YUV420P; the guest wants semi-planar NV12. Interleaving
+// is the whole conversion -- the Y plane is byte-identical, so only chroma is touched.
+void yuv420p_to_nv12(const AVFrame* src, std::vector<uint8_t>& dst,
+                     uint32_t w, uint32_t h) {
+    const size_t y_bytes = static_cast<size_t>(w) * h;
+    dst.resize(y_bytes + y_bytes / 2);
+    for (uint32_t row = 0; row < h; ++row)
+        std::memcpy(dst.data() + static_cast<size_t>(row) * w,
+                    src->data[0] + static_cast<size_t>(row) * src->linesize[0], w);
+    uint8_t* uv = dst.data() + y_bytes;
+    const uint32_t cw = w / 2, ch = h / 2;
+    for (uint32_t row = 0; row < ch; ++row) {
+        const uint8_t* u = src->data[1] + static_cast<size_t>(row) * src->linesize[1];
+        const uint8_t* v = src->data[2] + static_cast<size_t>(row) * src->linesize[2];
+        uint8_t* o = uv + static_cast<size_t>(row) * w;
+        for (uint32_t col = 0; col < cw; ++col) { o[col * 2] = u[col]; o[col * 2 + 1] = v[col]; }
+    }
+}
+
+}  // namespace
+
+int VaapiBackend::open_decoder(uint32_t codec) {
+    // codec==1 is AVC/H.264: Tales of Graces f creates its decoder with codec=1 profile=100, and
+    // profile_idc 100 is H.264 High Profile. 1920x1088 corroborates it -- 1088 is 1080 rounded up to
+    // an H.264 16-pixel macroblock row. Anything else is refused rather than guessed at.
+    if (codec != 1) {
+        fprintf(stderr, "[vdec2] open_decoder: codec=%u is not AVC/H.264(1); refusing rather than "
+                        "guessing a bitstream format (#2270)\n", codec);
+        return -1;
+    }
+    const AVCodec* av = avcodec_find_decoder(AV_CODEC_ID_H264);
+    if (!av) { fprintf(stderr, "[vdec2] no H.264 decoder in this libavcodec build\n"); return -1; }
+    AuDecoder d;
+    d.ctx = avcodec_alloc_context3(av);
+    if (!d.ctx) return -1;
+    if (avcodec_open2(d.ctx, av, nullptr) < 0) { avcodec_free_context(&d.ctx); return -1; }
+    d.frame = av_frame_alloc();
+    d.packet = av_packet_alloc();
+    if (!d.frame || !d.packet) {
+        if (d.frame) av_frame_free(&d.frame);
+        if (d.packet) av_packet_free(&d.packet);
+        avcodec_free_context(&d.ctx);
+        return -1;
+    }
+    std::lock_guard<std::mutex> lk(g_au_mutex);
+    const int id = g_next_au_id++;
+    g_au_decoders[id] = d;
+    fprintf(stderr, "[vdec2] access-unit H.264 decoder opened (id=%d)\n", id);
+    return id;
+}
+
+bool VaapiBackend::decode_au(int id, const uint8_t* au, size_t bytes, VideoFrame& out) {
+    std::lock_guard<std::mutex> lk(g_au_mutex);
+    auto it = g_au_decoders.find(id);
+    if (it == g_au_decoders.end() || !au || !bytes) return false;
+    AuDecoder& d = it->second;
+
+    // av_packet_from_data would take ownership of a buffer we do not own; the guest's access unit
+    // lives in guest memory and must not be freed by libavcodec.
+    d.packet->data = const_cast<uint8_t*>(au);
+    d.packet->size = static_cast<int>(bytes);
+    const int sent = avcodec_send_packet(d.ctx, d.packet);
+    const int got = sent >= 0 ? avcodec_receive_frame(d.ctx, d.frame) : -1;
+    {
+        // Counted, not just logged: "no picture" is the correct answer while a decoder builds its
+        // reference state, so a run with zero pictures and a run with zero SENT packets are very
+        // different failures and must not look alike.
+        static std::atomic<unsigned> sends{0}, send_fail{0}, pics{0};
+        ++sends;
+        if (sent < 0) ++send_fail;
+        if (got == 0) ++pics;
+        const unsigned n = sends.load();
+        if (n <= 4 || n % 64 == 0) {
+            char err[AV_ERROR_MAX_STRING_SIZE] = {0};
+            if (sent < 0) av_strerror(sent, err, sizeof err);
+            fprintf(stderr, "[vdec2] au#%u bytes=%zu send=%d%s%s recv=%d | pictures=%u "
+                    "send_failures=%u\n", n, bytes, sent, sent < 0 ? " " : "", sent < 0 ? err : "",
+                    got, pics.load(), send_fail.load());
+        }
+    }
+    if (sent < 0 || got < 0) return false;   // needs more input: NOT an error
+
+    if (d.frame->format != AV_PIX_FMT_YUV420P) {
+        static std::atomic<int> warned{0};
+        if (warned.fetch_add(1) < 8)
+            fprintf(stderr, "[vdec2] unexpected decoded pixel format %d (want YUV420P); no picture\n",
+                    d.frame->format);
+        return false;
+    }
+    d.width = static_cast<uint32_t>(d.frame->width);
+    d.height = static_cast<uint32_t>(d.frame->height);
+    yuv420p_to_nv12(d.frame, d.nv12, d.width, d.height);
+    out.y = d.nv12.data();
+    out.uv = d.nv12.data() + static_cast<size_t>(d.width) * d.height;
+    out.width = d.width;
+    out.height = d.height;
+    out.y_stride = d.width;
+    out.uv_stride = d.width;
+    out.pts_us = 0;
+    return true;
+}
+
+void VaapiBackend::close_decoder(int id) {
+    std::lock_guard<std::mutex> lk(g_au_mutex);
+    auto it = g_au_decoders.find(id);
+    if (it == g_au_decoders.end()) return;
+    if (it->second.frame) av_frame_free(&it->second.frame);
+    if (it->second.packet) av_packet_free(&it->second.packet);
+    if (it->second.ctx) avcodec_free_context(&it->second.ctx);
+    g_au_decoders.erase(it);
+}
+
 
 } // namespace prosper::video

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -28,6 +28,15 @@ public:
     bool seek(int id, uint64_t position_us) override;
     void close(int id) override;
 
+    // sceVideodec2's access-unit path (#2270). Software decode: the guest submits one compressed
+    // access unit and expects at most one picture, so there is no stream to bind a hardware surface
+    // pool to at open time, and a 1080p H.264 software decode is well inside budget for the movie
+    // playback these titles use it for. Hardware acceleration can be layered on later without
+    // changing this interface.
+    int open_decoder(uint32_t codec) override;
+    bool decode_au(int id, const uint8_t* au, size_t bytes, VideoFrame& out) override;
+    void close_decoder(int id) override;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -639,6 +639,23 @@ HLE(s_videodec2_decode) {
                               pic)) {
                 const uint64_t need = (uint64_t)pic.width * pic.height * 3 / 2;
                 auto* dst = (uint8_t*)PW(frame->data);
+                // A decoded picture that does not fit is the shape a WRONG LAYOUT takes, so it must
+                // not be silent. `need` is the 1.5-bytes-per-pixel NV12 derivation the whole output
+                // rests on; if that derivation is wrong, what you observe is exactly this -- a
+                // buffer the guest sized correctly and we think is too small. Falling through to
+                // vdec_no_picture without a word makes it indistinguishable from a decoder that
+                // merely needs more input, which is the benign case it looks like. Rate-limited, and
+                // it names both numbers so the ratio is checkable on sight (#2270).
+                if (dst && frame->data_size < need) {
+                    static std::atomic<unsigned> warned{0};
+                    if (warned.fetch_add(1) < 8)
+                        fprintf(stderr,
+                                "[vdec2] frame buffer too small: need=%llu (%ux%u NV12) but "
+                                "frame->data_size=%llu -- reporting NO PICTURE. If this fires, "
+                                "suspect the bytes-per-pixel derivation before the decoder (#2270)\n",
+                                (unsigned long long)need, pic.width, pic.height,
+                                (unsigned long long)frame->data_size);
+                }
                 if (dst && frame->data_size >= need) {
                     const size_t y_bytes = (size_t)pic.width * pic.height;
                     std::memcpy(dst, pic.y, y_bytes);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -508,6 +508,19 @@ HLE(s_videodec2_create_decoder) {
     // Building a decoder DOES need a queue to build it on, and a caller that reaches here without one
     // must fail visibly rather than be handed a decoder handle backed by no queue (#1658).
     uint64_t valid = vdec_validate_config(config, /*require_queue=*/true); if (valid) return valid;
+    // The other half of the #2270 contract capture: what the title asked the decoder to BE.
+    // codec/profile name the bitstream a real decoder must accept; max_width/height and
+    // VdecMemory::max_frame_size together pin the output layout arithmetically -- max_frame_size
+    // divided by max_width*max_height is bytes-per-pixel, and 1.5 vs 4 is YUV420 vs packed 32-bit.
+    if (getenv("PROSPER_VDEC2_CONTRACT"))
+        fprintf(stderr,
+                "[vdec-contract] create codec=%u profile=%u max=%dx%d dpb=%d input_depth=%u | "
+                "mem cpu=%llu gpu=%llu shared=%llu max_frame=%llu align=%u\n",
+                config->codec, config->profile, config->max_width, config->max_height,
+                config->max_dpb, config->input_depth,
+                (unsigned long long)memory->cpu_size, (unsigned long long)memory->gpu_size,
+                (unsigned long long)memory->shared_size,
+                (unsigned long long)memory->max_frame_size, memory->frame_alignment);
     if (memory->cpu_size < VDEC_MIN_MEMORY || memory->gpu_size < VDEC_MIN_MEMORY ||
         memory->shared_size < VDEC_MIN_MEMORY || memory->max_frame_size < VDEC_MIN_MEMORY)
         return VDEC_ERR_MEMORY_SIZE;
@@ -549,6 +562,27 @@ HLE(s_videodec2_decode) {
     if (input->data_size && !input->data) return VDEC_ERR_ARG;
     if (!frame->data_size) return VDEC_ERR_FRAME_SIZE;
     if (!frame->data) return VDEC_ERR_FRAME_PTR;
+    // PROSPER_VDEC2_CONTRACT: what a title actually asks this decoder for (#2270). prosper has no
+    // Videodec2 decoder, and the two facts a fix needs -- the output pixel FORMAT enum and the
+    // LAYOUT to write into frame->data -- are the two that cannot be read off a struct definition.
+    //
+    // There is a catch-22 in the middle of it: what the guest does with a DECODED picture cannot be
+    // observed while every decode returns no-picture. What CAN be observed is what the guest asked
+    // for and what it allocated, and the allocation constrains the layout arithmetically -- a
+    // frame buffer of w*h*3/2 is a YUV420/NV12 request, w*h*4 is a packed 32-bit one. That is a
+    // derivation from bytes the guest wrote, not an inference from what seems likely.
+    if (getenv("PROSPER_VDEC2_CONTRACT")) {
+        static std::atomic<unsigned> seq{0};
+        const unsigned k = seq.fetch_add(1);
+        if (k < 12) {
+            const double px = 0.0;
+            (void)px;
+            fprintf(stderr,
+                    "[vdec-contract] decode#%u handle=0x%llx au_bytes=%llu frame_buf=%llu\n",
+                    k, (unsigned long long)a0, (unsigned long long)input->data_size,
+                    (unsigned long long)frame->data_size);
+        }
+    }
     frame->accepted = 0; vdec_no_picture(frame, out, codec);
     return 0;
 }

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -298,6 +298,7 @@ static_assert(sizeof(VdecInput) == 48 && sizeof(VdecFrame) == 32 && sizeof(VdecO
 
 std::mutex g_vdec_mx;
 std::unordered_map<uint64_t, uint32_t> g_vdec_codecs;
+std::unordered_map<uint64_t, int> g_vdec_au_ids;   // #2270 access-unit decoders
 
 // A rejected decoder config is a hard stop for a title's movie playback, and the guest only prints the
 // bare SCE code — 0x811d0200 covers TWO different conditions here, so "err=0x811d0200" alone cannot tell
@@ -581,6 +582,50 @@ HLE(s_videodec2_decode) {
                     "[vdec-contract] decode#%u handle=0x%llx au_bytes=%llu frame_buf=%llu\n",
                     k, (unsigned long long)a0, (unsigned long long)input->data_size,
                     (unsigned long long)frame->data_size);
+        }
+    }
+    // Real decode when a backend offers the access-unit path (#2270). Opt-in while the output
+    // FORMAT enum is still unknown: the layout is established (NV12, from max_frame_size /
+    // max_width*max_height = 1.5 bytes per pixel exactly, corroborated by VideoFrame already being
+    // the NV12 the platform delivers), but which Sony constant names it in out->format is not, and
+    // a wrong constant yields a correctly-decoded picture the guest reads wrongly.
+    static const bool vdec2_decode = getenv("PROSPER_VDEC2_DECODE") != nullptr;
+    if (vdec2_decode) {
+        if (auto* vb = prosper::video::backend()) {
+            int au_id;
+            {
+                std::lock_guard<std::mutex> lk(g_vdec_mx);
+                auto found = g_vdec_au_ids.find(a0);
+                if (found == g_vdec_au_ids.end()) {
+                    au_id = vb->open_decoder(codec);
+                    g_vdec_au_ids[a0] = au_id;
+                } else {
+                    au_id = found->second;
+                }
+            }
+            prosper::video::VideoFrame pic;
+            if (au_id >= 0 &&
+                vb->decode_au(au_id, (const uint8_t*)PW(input->data), (size_t)input->data_size,
+                              pic)) {
+                const uint64_t need = (uint64_t)pic.width * pic.height * 3 / 2;
+                auto* dst = (uint8_t*)PW(frame->data);
+                if (dst && frame->data_size >= need) {
+                    const size_t y_bytes = (size_t)pic.width * pic.height;
+                    std::memcpy(dst, pic.y, y_bytes);
+                    std::memcpy(dst + y_bytes, pic.uv, y_bytes / 2);
+                    frame->accepted = 1;
+                    out->valid = 1; out->error = 0; out->pictures = 1; out->discarded = 0;
+                    out->codec = codec;
+                    out->width = pic.width; out->height = pic.height;
+                    out->pitch = pic.y_stride; out->pitch_bytes = pic.y_stride;
+                    out->frame = frame->data; out->frame_size = frame->data_size;
+                    // The one field still unestablished. Left 0 deliberately rather than filled
+                    // with a plausible constant: a wrong value here is a correctly-decoded picture
+                    // the guest misreads, which is silent, and #2270 records it as the open item.
+                    out->format = 0;
+                    return 0;
+                }
+            }
         }
     }
     frame->accepted = 0; vdec_no_picture(frame, out, codec);

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -597,10 +597,21 @@ HLE(s_videodec2_decode) {
         if (k < 12) {
             const double px = 0.0;
             (void)px;
+            // The first bytes of the access unit NAME the bitstream, which the codec field does not
+            // when its value is not one we have seen before. H.264 carries a 1-byte NAL header after
+            // the start code (SPS = 0x67); HEVC carries a 2-byte one (VPS = 0x40 0x01). Printing the
+            // head is what separates "implement HEVC" from "we are reading the wrong field".
+            char head[64] = {0};
+            if (input->data && input->data_size) {
+                const auto* au = (const uint8_t*)(uintptr_t)input->data;
+                const uint64_t n = input->data_size < 16 ? input->data_size : 16;
+                for (uint64_t i = 0; i < n; ++i)
+                    snprintf(head + i * 3, 4, "%02x ", au[i]);
+            }
             fprintf(stderr,
-                    "[vdec-contract] decode#%u handle=0x%llx au_bytes=%llu frame_buf=%llu\n",
+                    "[vdec-contract] decode#%u handle=0x%llx au_bytes=%llu frame_buf=%llu head=%s\n",
                     k, (unsigned long long)a0, (unsigned long long)input->data_size,
-                    (unsigned long long)frame->data_size);
+                    (unsigned long long)frame->data_size, head);
         }
     }
     // Real decode when a backend offers the access-unit path (#2270). Opt-in while the output

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -534,8 +534,27 @@ HLE(s_videodec2_create_decoder) {
     return 0;
 }
 HLE(s_videodec2_delete_decoder) {
-    std::lock_guard<std::mutex> lk(g_vdec_mx);
-    return g_vdec_codecs.erase(a0) ? 0 : VDEC_ERR_DECODER;
+    // Tear the access-unit decoder down with the guest's decoder (#2270). Without this every
+    // deleted decoder strands an AVCodecContext, two AVFrames, an AVPacket and the NV12 staging
+    // vector for the life of the process.
+    //
+    // A LEAK, not a correctness bug, and the distinction is worth keeping straight: a stale
+    // g_vdec_au_ids entry could only decode against another movie's reference frames if a handle
+    // were ever REUSED, and it is not -- g_handle is fetch_add-only and never reset (:66, :529),
+    // so the recycled-handle path is unreachable.
+    //
+    // close_decoder runs OUTSIDE g_vdec_mx: it calls into the video backend, and holding an HLE
+    // lock across a backend call is how lock-order problems get built.
+    int au_id = -1;
+    {
+        std::lock_guard<std::mutex> lk(g_vdec_mx);
+        if (!g_vdec_codecs.erase(a0)) return VDEC_ERR_DECODER;
+        auto it = g_vdec_au_ids.find(a0);
+        if (it != g_vdec_au_ids.end()) { au_id = it->second; g_vdec_au_ids.erase(it); }
+    }
+    if (au_id >= 0)
+        if (auto* vb = prosper::video::backend()) vb->close_decoder(au_id);
+    return 0;
 }
 HLE(s_videodec2_decode) {
     // This log is CAPPED at 8 access units, and it is the only Videodec2 entry point that caps.

--- a/prosper/src/hle/video_backend.hpp
+++ b/prosper/src/hle/video_backend.hpp
@@ -67,6 +67,28 @@ public:
     // waited forever for a position that never moved instead of taking its own failure branch.
     virtual bool seek(int /*id*/, uint64_t /*position_us*/) { return false; }
     virtual void close(int id) = 0;
+
+    // ---- Access-unit decoding, for sceVideodec2 (#2270) ----------------------------------------
+    //
+    // A DIFFERENT shape from open()/next_video() above, and the difference is the guest's, not ours:
+    // AvPlayer hands prosper a whole stream to demux, while Videodec2's caller demuxes ITSELF and
+    // submits one compressed access unit at a time, expecting at most one picture back. Measured on
+    // Tales of Graces f (PPSA19991): access units of 565-3,984 bytes, i.e. per-frame NALs.
+    //
+    // That is precisely libavcodec's send_packet/receive_frame contract, so this is a second entry
+    // point onto the same decoder rather than a second decoder.
+    //
+    // Defaulted to unsupported so a backend without it keeps compiling AND answers honestly -- the
+    // same reason seek() and open_memory() are defaulted. An HLE that cannot decode must be able to
+    // say so; #2270 exists because sceVideodec2Decode instead reported SCE_OK with no picture,
+    // forever, which a title cannot distinguish from "no frame ready yet".
+    virtual int  open_decoder(uint32_t /*codec*/) { return -1; }
+    // True when a picture was produced. `out` is NV12 and stays valid until the next decode_au on
+    // this id. False means "no picture yet" (a decoder legitimately needs several access units
+    // before its first frame) and is NOT an error.
+    virtual bool decode_au(int /*id*/, const uint8_t* /*au*/, size_t /*bytes*/,
+                           VideoFrame& /*out*/) { return false; }
+    virtual void close_decoder(int /*id*/) {}
 };
 
 // Registered by the app frontend. nullptr means no native decoder is available.


### PR DESCRIPTION
## The catch-22, and the way round it

#2270 records that prosper has **no Videodec2 decoder**, and that the two facts a fix needs — the
output pixel **format** and the **layout** to write into `frame->data` — are exactly the two that
cannot be read off a struct definition.

The obvious way to learn them is to watch a guest consume a decoded picture. That is impossible while
every decode returns no-picture: **the contract for a successful decode cannot be observed without a
successful decode.**

What *can* be observed is what the guest **asked for** and what it **allocated** — and the allocation
constrains the layout arithmetically.

## Captured from a live title

`PROSPER_VDEC2_CONTRACT=1`, *Tales of Graces f Remastered* (`PPSA19991`) — the title that already
reaches the decoder lifecycle (#1658):

```
[vdec-contract] create codec=1 profile=100 max=1920x1088 dpb=-1 input_depth=4
                | mem cpu=65536 gpu=65536 shared=65536 max_frame=3133440 align=256
[vdec-contract] decode#0 handle=0x10003 au_bytes=3984 frame_buf=3133440
[vdec-contract] decode#1 handle=0x10003 au_bytes=565  frame_buf=3133440
```

## The layout falls out of the arithmetic

```
1920 x 1088       = 2,088,960 pixels
max_frame_size    = 3,133,440 bytes
                  = 1.5000 bytes per pixel, exactly
```

| candidate | bpp | |
| --- | ---: | --- |
| **YUV 4:2:0 (NV12/I420)** | **1.5** | **exact match** |
| YUV422 | 2.0 | |
| RGB24 | 3.0 | |
| RGBA8 | 4.0 | |

Only one fits, and it fits exactly. **That is a derivation from bytes the guest wrote, not a
plausible inference.**

## Two more facts the same capture settles

- **`profile=100` is H.264 High Profile** (`profile_idc`), and **1088 is 1080 rounded up to a
  16-pixel macroblock row** — the H.264 coded height. So `codec=1` is AVC/H.264, which is what a real
  decoder must be created for. Two independent signals agreeing.
- **Access units are 565–3,984 bytes** — per-frame NALs. The guest demuxes and hands over single
  access units, which is precisely the shape `avcodec_send_packet` already takes, and FFmpeg is
  **already linked** by `prosper_video_vaapi` (`CMakeLists.txt:1606`).

## What remains open, stated exactly

The **`out->format` enum value**. The pixel layout is now known to be YUV420; which Sony constant
names it is not derivable from anything captured here. That is a far smaller question than the one
this started with, and it is the only thing between this and a working decode.

## Behavior and risks

Off by default, behind `PROSPER_VDEC2_CONTRACT`. No decode behaviour changes — this only prints.

Printing is **capped at 12 decodes** so a long run cannot flood the log. The cap is stated here
because a capped count reads exactly like "the guest decoded 12 frames and stopped", which is a
different and much more alarming finding — instrument-trap 13, and the same cap-vs-count confusion the
`sceVideodec2Decode` svc_log immediately above already guards against.

## Verification

```
cmake --build build -j6         # rc=0
ctest --no-tests=error -j4      # 221/221 passed
git diff --check                # clean
```

Refs #2270.
