### PR TITLE
perf(render): stop paying a getenv per draw to discover that validation is off

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -5150,11 +5150,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // && of the positives rather than || of the negations: identical short-circuit
                     // and identical outcome, but it puts the accounting below on a path the
                     // `continue` cannot skip.
+                    // descriptor_validate_mode is the per-submit hoist made for poison_R above, and
+                    // it serves this pair for the same reason: without it each call re-reads getenv,
+                    // and with the variable unset that read IS the whole call. It measured
+                    // 5.77 ms/submit in the build_resources partition -- larger than the validation
+                    // it was declining to do.
                     const bool contract_ok =
                         prosper::gpu::validate_runtime_descriptor_contract(
-                            "VS/backend", bd.vs_words(), it.vrt.get(), 0, prosper::gpu::SpirvShaderStage::Vertex) &&
+                            "VS/backend", bd.vs_words(), it.vrt.get(), 0,
+                            prosper::gpu::SpirvShaderStage::Vertex, descriptor_validate_mode) &&
                         prosper::gpu::validate_runtime_descriptor_contract(
-                            "PS/backend", bd.fs_words(), it.prt.get(), 1, prosper::gpu::SpirvShaderStage::Fragment);
+                            "PS/backend", bd.fs_words(), it.prt.get(), 1,
+                            prosper::gpu::SpirvShaderStage::Fragment, descriptor_validate_mode);
                     const auto bt2 = timing_enabled ? RenderClock::now() : RenderClock::time_point{};
                     if (timing_enabled) {
                         pending_timing.build_r_ms +=

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -804,6 +804,28 @@ bool validate_runtime_descriptor_contract(const char* stage_name,
                                            uint32_t expected_set,
                                            SpirvShaderStage expected_stage);
 
+// Same, with the mode string supplied by the caller instead of read here.
+//
+// For per-draw callers only, and the reason is measured rather than assumed. The form above reads
+// getenv on EVERY call and is invoked twice per draw, so the read is the entire cost of the fast
+// path: when the variable is unset the function returns on the very next line. On this Windows host
+// one missing getenv costs 1.26 us (86 environ entries, ~15 ns each on a linear scan), so at the
+// 2,179 draws/submit recorded beside the poison_R hoist in live_renderer.cpp that is 2 x 2,179 x
+// 1.26 us = 5.49 ms/submit spent discovering that a diagnostic is switched off. The renderer's own
+// build_resources partition measured this leaf at 5.77 ms/submit -- a 5% agreement with a number
+// derived independently, which is what established that the leaf is the read and not the work.
+//
+// `mode` must come from a live getenv hoisted to submit scope, NOT from PROSPER_ENV_VALUE:
+// test_gpu_capture_render.cpp and test_shader_resources.cpp arm PROSPER_DESCRIPTOR_VALIDATE at
+// runtime, and a process-lifetime cache would leave their second write unobserved -- the #2214
+// defect that `cached_env_arming_logic` gates. Passing nullptr means "unset", i.e. validation off.
+bool validate_runtime_descriptor_contract(const char* stage_name,
+                                           const std::vector<uint32_t>& spirv,
+                                           const ShaderResourceTable* runtime,
+                                           uint32_t expected_set,
+                                           SpirvShaderStage expected_stage,
+                                           const char* mode);
+
 // Byte size of one index element for a GpuState::index_type (the last SetIndexType value).
 // 0 -> 16-bit, 1 -> 32-bit, exactly Kyty's index_type_and_size switch (GraphicsRender.cpp:4724) and
 // the hardware VGT_INDEX_TYPE encoding; 0 is also the reset default, matching this title, which never

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4547,7 +4547,20 @@ bool validate_runtime_descriptor_contract(const char* stage_name,
                                            const ShaderResourceTable* runtime,
                                            uint32_t expected_set,
                                            SpirvShaderStage expected_stage) {
-    const char* mode = getenv("PROSPER_DESCRIPTOR_VALIDATE");
+    // The read stays LIVE here (not PROSPER_ENV_VALUE): two tests arm this variable at runtime and
+    // a process-lifetime cache would make their arms vacuous rather than failing -- #2214. Callers
+    // on a per-draw path pass the mode in via the overload below instead of paying this per call.
+    return validate_runtime_descriptor_contract(stage_name, spirv, runtime, expected_set,
+                                                expected_stage,
+                                                getenv("PROSPER_DESCRIPTOR_VALIDATE"));
+}
+
+bool validate_runtime_descriptor_contract(const char* stage_name,
+                                           const std::vector<uint32_t>& spirv,
+                                           const ShaderResourceTable* runtime,
+                                           uint32_t expected_set,
+                                           SpirvShaderStage expected_stage,
+                                           const char* mode) {
     if (!mode || !*mode || !strcmp(mode, "off") || !strcmp(mode, "0")) return true;
 
     DescriptorValidationReport report = validate_spirv_descriptor_interface(

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -528,6 +528,38 @@ int main() {
     CHECK(!dr.ok() && has_issue(dr, DescriptorIssueCode::DuplicateBinding),
           "duplicate runtime binding is rejected as ambiguous");
 
+    // --- validate_runtime_descriptor_contract: the mode-carrying overload (#2239 candidate 3) ---
+    //
+    // The per-draw form takes its mode from the caller so a hot loop can hoist the getenv to submit
+    // scope. These four arms pin the property that makes that split safe, in both directions: the
+    // overload must honour the mode it is GIVEN and ignore the environment, while the original
+    // signature must keep reading the environment LIVE -- this file and test_gpu_capture_render.cpp
+    // both arm the variable at runtime, and a cached read would make those arms vacuous rather than
+    // failing (#2214, gated by cached_env_arming_logic).
+    //
+    // `missing` is an empty table against a module that statically uses binding 9, so strict
+    // validation must REJECT it. That is what makes each arm falsifiable: without a table that
+    // genuinely fails, an arm returning true because validation was switched off would be
+    // indistinguishable from one returning true because validation ran and passed.
+    set_descriptor_mode("");                         // environment says: validation off
+    CHECK(!validate_runtime_descriptor_contract("test", spv, &missing, 0,
+                                                SpirvShaderStage::Vertex, "strict"),
+          "overload validates on the mode it is passed, with the environment cleared");
+    set_descriptor_mode("strict");                   // environment says: validation on
+    CHECK(validate_runtime_descriptor_contract("test", spv, &missing, 0,
+                                               SpirvShaderStage::Vertex, nullptr),
+          "overload ignores the environment: a null mode stays off even when the env says strict");
+    // The two arms above would both still pass if the overload read the environment AND the
+    // environment happened to agree with the argument. They cannot both pass in that case, which is
+    // the point of running them with the env and the argument set to OPPOSITE values.
+    CHECK(!validate_runtime_descriptor_contract("test", spv, &missing, 0,
+                                                SpirvShaderStage::Vertex),
+          "env-reading signature still rejects while the environment says strict");
+    set_descriptor_mode("");
+    CHECK(validate_runtime_descriptor_contract("test", spv, &missing, 0,
+                                               SpirvShaderStage::Vertex),
+          "env-reading signature still observes a runtime write that clears the mode");
+
     ShaderResource short_buffer = good; short_buffer.size = 16;
     ShaderResourceTable short_table; short_table.resources.push_back(short_buffer);
     auto sr = validate_spirv_descriptor_interface(spv, &short_table, 0, SpirvShaderStage::Vertex);


### PR DESCRIPTION
`validate_runtime_descriptor_contract` reads `PROSPER_DESCRIPTOR_VALIDATE` on every call, and
`build_bds` calls it **twice per draw**. With the variable unset — the shipping configuration — the
function returns on the line after that read:

```cpp
const char* mode = getenv("PROSPER_DESCRIPTOR_VALIDATE");
if (!mode || !*mode || !strcmp(mode, "off") || !strcmp(mode, "0")) return true;
```

So on a default run the read **is** the call. #2240 hoisted the three other per-draw `getenv` calls
out of this same loop but could not reach this one — it lives behind a function-call boundary in
`gpu_executor.cpp`, not in the loop body. This is that leftover, and it is candidate 3 of the three
named in #2239.

## What it costs

The claim is quantitative and the unit had never been measured, so I measured it by hand, outside
the renderer:

```
getenv miss (PROSPER_DESCRIPTOR_VALIDATE)   1.26 us/call
getenv hit  (PATH)                          0.82 us/call
loop overhead                               0.00 us/call
environ entries                             86        (~15 ns each -> a linear scan)
```

#2239 independently measured **1.105 µs** on this host, so the unit is corroborated rather than
self-reported. The cost is then `2 × draws/submit × 1.26 µs` — entirely phase-dependent, which is
why no single number describes it:

| phase (PPSA25009) | draws/submit | predicted | observed |
| --- | ---: | ---: | ---: |
| FMV | 2,179 | 5.49 ms/submit | **5.77 ms/submit** |
| gameplay | 477 | 1.20 ms/submit | — |
| early boot / menu | 11.6 | 0.03 ms/submit | 0.00 ms/submit |

The FMV row is the load-bearing one. 5.49 ms predicted from the microbenchmark and the draw count
recorded in `live_renderer.cpp`'s own `poison_R` comment agrees to **5%** with the 5.77 ms the
`build_resources` partition measured for this leaf. Two independent routes to the same number is
what established that the leaf is the environment read and not the validation — a single timer
reading 5.77 ms would not have distinguished those.

## Approach

An overload taking the mode as a parameter, for per-draw callers. The original signature stays and
forwards to it after doing the `getenv`, so **every other caller is untouched**.
`live_renderer.cpp` passes `descriptor_validate_mode` — the per-submit hoist #2240 already created
for `poison_R`, three lines up the same scope.

Deliberately **not** `PROSPER_ENV_VALUE`. `test_shader_resources.cpp` and
`test_gpu_capture_render.cpp` arm this variable at runtime, and a process-lifetime cache would not
make them fail — it would make them **vacuous**, which is the #2214 defect `cached_env_arming_logic`
exists to gate. `check_cached_env.py`'s own docstring names the remedy for exactly this case:
*"make it a live getenv or hoist it — do not add an exception."* A per-submit hoist keeps every
runtime write observable from the next submit on.

## Tests

Four arms in `test_shader_resources.cpp`, run against an empty table and a module that statically
uses binding 9, so strict validation must **reject**. Without a table that genuinely fails, an arm
returning true because validation was *off* would be indistinguishable from one returning true
because validation *ran and passed* — the arms would be unfalsifiable.

The two overload arms set the environment and the argument to **opposite** values, so they cannot
both pass if the overload reads the environment.

**Mutation-verified.** Reintroducing `mode = getenv(...)` inside the overload:

```
[FAIL] overload validates on the mode it is passed, with the environment cleared
[FAIL] overload ignores the environment: a null mode stays off even when the env says strict
[ok]   env-reading signature still rejects while the environment says strict
[ok]   env-reading signature still observes a runtime write that clears the mode
```

Exactly the two arms that test the overload fail, and the two wrapper arms correctly keep passing —
the mutation does not touch the wrapper. Re-reverted and re-run green.

## What is NOT claimed

**No before/after route A/B, deliberately.** #2240's own A/B on this title was *void* — its control
channel `backend` moved 5–32%, more than the channel under test — and #2239 concluded a targeted
timer beats another route run here.

I did make a live run, and it does not support the claim: it reached only **11.6 draws/submit**,
where both arms predict 0.03 ms and print `validate=0.00`. It is reported in the table above as
non-discriminating rather than as agreement. Reaching the FMV phase needs a route I did not drive.

The second per-draw pair, in `realize_draw_item` (`gpu_execute.hpp:1357`), is **untouched** and
filed separately — it runs on parallel worker threads, where `getenv`'s process-wide lock makes the
cost contention rather than a constant, so it wants its own measurement rather than an assumption
that this result carries over.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only: the test's own shutil.rmtree
     teardown hits PermissionError on a read-only .git object. Reproduces on a cleared
     scratch dir; this diff contains no Python and touches no git. Filed separately.
python prosper/tools/env/check_cached_env.py prosper  ->  all checks passed
git diff origin/master --check  ->  clean
```

Behaviour is unchanged in every configuration: with the variable unset both forms return true, and
with it set the hot loop now validates against a mode read once per submit instead of once per call.

Refs #2239
