### PR TITLE
diag(render): split the persistent-texture submit query into unknown vs overlap

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1221,6 +1221,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 uint64_t persistent_validation_bytes = 0;
                 uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
                 uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
+                // WHY in-submit reuse never fires (#2289). persistent_submit_reuses is 0 across
+                // 55,820 hits on PPSA25009, and the two ways that happens have OPPOSITE prospects:
+                // Unknown means prosper is not tracking guest writes on this path at all (fixable,
+                // and worth ~9x, since the same texture is referenced 9.5 times per submit), while
+                // Overlap means the guest genuinely rewrote those bytes and the revalidation is
+                // CORRECT. A single zero cannot tell those apart, so count them separately.
+                uint64_t persistent_submit_unknown = 0, persistent_submit_overlap = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
                 // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -2972,6 +2979,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     : prosper::gpu::GuestGpuWriteQuery::Unknown;
                                 resource_texture_submit_query =
                                     static_cast<int>(submit_query);
+                                if (timing_enabled && submit_reuse_enabled) {
+                                    if (submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown)
+                                        pending_timing.persistent_submit_unknown++;
+                                    else if (submit_query == prosper::gpu::GuestGpuWriteQuery::Overlap)
+                                        pending_timing.persistent_submit_overlap++;
+                                }
                                 const bool submit_unchanged = submit_reuse_enabled &&
                                     submit_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
                                 prosper::host::GuestWriteWatchQuery watch_query =
@@ -6973,6 +6986,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     uint64_t persistent_validation_bytes = 0;
                     uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
                     uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
+                    uint64_t persistent_submit_unknown = 0, persistent_submit_overlap = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                     // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -7084,6 +7098,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.persistent_watch_reuses += pending_timing.persistent_watch_reuses;
                     timing.persistent_watch_dirty += pending_timing.persistent_watch_dirty;
                     timing.persistent_watch_unknown += pending_timing.persistent_watch_unknown;
+                    timing.persistent_submit_unknown += pending_timing.persistent_submit_unknown;
+                    timing.persistent_submit_overlap += pending_timing.persistent_submit_overlap;
                     timing.persistent_watch_disabled += pending_timing.persistent_watch_disabled;
                     timing.buffers += pending_timing.buffers;
                     timing.buffer_views += pending_timing.buffer_views;
@@ -7431,13 +7447,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         }
                     }
                     fprintf(stderr,
-                            "[render-timing] texture_cache hits=%llu submit_reuse=%llu misses=%llu "
+                            "[render-timing] texture_cache hits=%llu submit_reuse=%llu "
+                            "(submit_unknown=%llu submit_overlap=%llu) misses=%llu "
                             "watch_reuse=%llu watch_dirty=%llu watch_unknown=%llu watch_disabled=%llu "
                             "invalid=%llu "
                             "validations=%llu %.1f GiB entries=%zu %.1f MiB "
                             "(source=%.1f pixels=%.1f MiB watch-only=%zu saved=%.1f MiB)\n",
                             (unsigned long long)totals.persistent_hits,
                             (unsigned long long)totals.persistent_submit_reuses,
+                            (unsigned long long)totals.persistent_submit_unknown,
+                            (unsigned long long)totals.persistent_submit_overlap,
                             (unsigned long long)totals.persistent_misses,
                             (unsigned long long)totals.persistent_watch_reuses,
                             (unsigned long long)totals.persistent_watch_dirty,


### PR DESCRIPTION
#2289 measured that **43% of Blue Prince's frame on Windows is spent memcmp-ing textures that are
already cached and unchanged** — 393.5 GiB of comparison to revalidate 19 entries. Two fast paths
exist to avoid that comparison and both read zero. One of those zeros was ambiguous in a way that
decided whether the cost is fixable at all, and this PR resolves it.

## The ambiguity

`submit_reuse=0` across 55,820 hits means `guest_gpu_writes_since()` never returned `Unchanged`. It
has two other returns, and they point in opposite directions:

| return | meaning | prospects |
| --- | --- | --- |
| `Unknown` | prosper is not tracking guest writes on this path | the revalidation is **uninformed, and removable** |
| `Overlap` | the guest really did rewrite those bytes | the revalidation is **correct**, and nothing may skip it |

A single `0` in `submit_reuse` cannot tell those apart, so the line could not say whether there was
anything to win. Absent and zero are the same number and opposite facts.

## What it reports now

Two counters beside the existing `watch_*` ones, incremented at the site the query is made:

```
[render-timing] texture_cache hits=35382 submit_reuse=0
                (submit_unknown=35383 submit_overlap=0) misses=19 watch_reuse=0
                watch_dirty=0 watch_unknown=15861 watch_disabled=0 invalid=1
                validations=35383 243.3 GiB entries=19 350.0 MiB
```

Measured on `PPSA25009`, Windows/MinGW (WinLibs UCRT g++ 16.1.0), `tools/screenshot`, 60 s.

**`submit_overlap=0`, `submit_unknown=35383`** — and `submit_unknown` equals `validations`
*exactly*, so every single validation was one the tracker had no opinion about.

The guest is **not** rewriting these textures. `GuestGpuWriteSubmitScope` is instantiated only in
`execute_ordered_items_impl` (`gpu_executor.cpp:5681`) and `execute_ordered_gpustate` (`:6473`), so
`g_guest_gpu_writes.active` is false on this path, the stored snapshot carries `submit_serial == 0`,
and the query exits `Unknown` on its very first branch.

That is the fact #2289 was blocked on: the comparison is removable in principle, and since the same
texture is referenced **9.5 times per submit**, making in-submit reuse work is worth roughly **9×**
on 243 GiB.

## Deliberately diagnostic-only

The obvious next step — arm the write-journal scope on this path — is **not** in this PR and should
not be inferred from it. The journal is filled at a site gated on the same `active` flag, so arming
the scope without first establishing that *every* guest-visible GPU write on this path is journaled
would produce false `Unchanged` answers and serve **stale texture pixels**. That is a
silent-corruption failure mode; it needs its own evidence and an independent reader, not a
follow-on commit riding this one.

## Why this shape

The counters sit behind `timing_enabled`, so a default run computes nothing extra — the instrument
does not charge for being read, which is the specific defect #2239 warned about for new timers.

They also carry their own validity check: `submit_unknown + submit_overlap` must account for every
validation the same run reports. On this run it does exactly (35,383 = 35,383). If a future run
shows them disagreeing, the classification is wrong and the line says so rather than quietly
misattributing.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff origin/master --check  ->  clean
```

No behaviour change on any path: two counters, one format string, both inside the existing
`timing_enabled` gate.

## Not claimed

- Not that arming the scope is safe — see above; that is the open question, not a conclusion.
- Not a frame-rate figure. `ms/submit` is not `ms/frame`, and I did not establish the submit-to-frame
  ratio on this route.
- The route reaches ~11 draws/submit and never enters the FMV or gameplay regimes (2,179 and 477
  draws/submit per #2239), so the *ratio* of refs to validations may differ there.

Refs #2289
