### PR TITLE
agc: name w1KFAHVqpaU sceAgcCbBranch, and record its known-absent siblings

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1707,7 +1707,7 @@ uint64_t g_submit_count = 0;
 // Serializes every access to the shared GpuState (fold + render + stats). DOLL's UE4 RHI submits
 // from TWO guest threads concurrently (core-proven, issue #278: one thread inside
 // agc_driver_submit_dcb -> execute_and_present -> extract_render_state reading st.cx/sh/uc while
-// another is inside agc_driver_submit_dcb_variant -> run_command_buffer writing them). An
+// another is inside agc_cb_branch -> run_command_buffer writing them). An
 // unordered_map rehash under a lock-free reader tears bucket pointers -> #GP with si_addr=0 (the
 // "rip=0 / writer 0x0" steady-state crash that ended runs as the scene began). The real driver
 // serializes ring submission internally — concurrent guest submits are legal and processed one at
@@ -1890,7 +1890,7 @@ static bool execute_submit_work(gpu::GpuState& st, uint64_t submit_no, unsigned&
 
 // Fold one raw Dcb dword stream through the CommandProcessor, fire the GPU EOP completion events, and
 // (if a live renderer is wired and the submit produced draws) execute+present. Shared by the primary
-// submit path (sceAgcDriverSubmitDcb) and the DOLL warmup-submit variant (w1KFAHVqpaU) below.
+// submit path (sceAgcDriverSubmitDcb) and sceAgcCbBranch (w1KFAHVqpaU) below.
 // `dw_num == 0` means "length unknown" — decode_pm4 self-terminates at the first non-type-3 dword, and
 // we cap the walk at kUnknownCap dwords as a runaway guard (a bounded ring can't legitimately exceed it).
 extern "C" uint64_t prosper_guest_tsc_ns();                    // shared guest clock (hle_kernel_time)
@@ -2372,7 +2372,24 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
     return 0;
 }
 
-// sceAgc submit variant (NID w1KFAHVqpaU) — DOLL's UE4 RHI submits its per-frame command buffers
+// sceAgcCbBranch (NID w1KFAHVqpaU). The identity is a determination, not a guess:
+// nid_hash("sceAgcCbBranch") == w1KFAHVqpaU, from the round-trip over all 39,158 published pairs in
+// the PS5 3.20 export tables with 0 mismatches (nid_census --self-check, #2081). It was previously
+// labelled a "submit variant" here, which was wrong in a way that cost something: "submit variant"
+// implies a second submit entry point, while "CbBranch" implies a control-flow packet in a command
+// stream, and those predict different things about the arguments and about what
+// sceAgcCbBranchGetSize should return (#2173).
+//
+// The BEHAVIOUR below is right and must not be "fixed" to match the new label -- it resolved the
+// #232 wall. The two readings agree: a command-buffer chain CALLS its intermediate buffers and
+// BRANCHES to the last one (a tail-jump, so the final buffer never returns), which is exactly the
+// pattern the RE notes describe. Folding -- executing -- the stream at that address is therefore the
+// correct thing for a software command processor to do, and sceAgcCbBranch semantics EXPLAIN the
+// RE'd ABI rather than contradict it. CONFIDENCE: HIGH on the identity; MED on the chain-tail-jump
+// reading of why DOLL calls it here (it fits the recorded disassembly, but no capture was taken to
+// confirm the final buffer is entered by branch rather than by call).
+//
+// DOLL's UE4 RHI submits its per-frame command buffers
 // through TWO driver entry points: intermediate buffers via sceAgcDriverSubmitDcb (UglJIZjGssM,
 // folded above) and the FINAL buffer of a SubmitCommandBuffers batch through THIS one (the guest's
 // SubmitCommandBuffers impl at eboot+0x220a9a0 loops the buffer array, calling the indirect submit for
@@ -2394,7 +2411,7 @@ static uint64_t submit_dcb_stream(const uint32_t* addr, uint32_t dw_num, const c
 // logger stack-smash) — intermittent because it depends on what got reallocated under the stale fences.
 // CONFIDENCE: HIGH on the arg9=count ABI (callsite + adapter disassembly agree, and the count matches
 // the primary path's Packet.dw_num field offset).
-HLE9(agc_driver_submit_dcb_variant) {
+HLE9(agc_cb_branch) {
     // The generated return hook is attached to this import invocation even when validation rejects
     // it. Begin before every early return so nested/re-entrant tagged calls remain exactly paired.
     prosper_gpu_submit_scope_begin();
@@ -3000,6 +3017,9 @@ HLE(agc_cb_nop_get_size)          { uint32_t n = (uint32_t)a0; if (n == 0) n = 1
 void register_agc_hle() {
     #define RN(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid)
     #define RN_SUBMIT(nid, fn) Hle::register_fn(nid, (HleFn)(fn), nid, &prosper_gpu_submit_scope_end)
+    // Same, but with the real exported name for logs and hle_calls. Separate from RN_SUBMIT
+    // because the rest of this file registers the NID as its own display name by convention.
+    #define RN_SUBMIT_NAMED(nid, fn, name) Hle::register_fn(nid, (HleFn)(fn), name, &prosper_gpu_submit_scope_end)
     RN("VEGu4dixjUg", agc_dcb_jump_get_size);        // sceAgcDcbJumpGetSize (#1137)
     RN("-vnlTPPXPrw", agc_dcb_acquire_mem_get_size); // sceAgcDcbAcquireMemGetSize
     RN("ewobAQeMo5k", agc_dcb_acquire_mem_get_size); // sceAgcAcbAcquireMemGetSize (same size)
@@ -3131,7 +3151,25 @@ void register_agc_hle() {
     // trampoline. This per-NID checkpoint ends the submit scope immediately before guest return.
     RN_SUBMIT("UglJIZjGssM", agc_driver_submit_dcb);   // sceAgcDriverSubmitDcb -> CommandProcessor replay
     RN_SUBMIT("gSRnr79F8tQ", agc_driver_submit_acb);   // sceAgcDriverSubmitAcb -> ordered compute replay
-    RN_SUBMIT("w1KFAHVqpaU", agc_driver_submit_dcb_variant);  // final-buffer submit variant (#232, DOLL RHI batch)
+    // sceAgcCbBranch (#2173) — named, so logs and hle_calls do not report a bare NID for the one
+    // entry here whose published name is established. See the block above agc_cb_branch.
+    RN_SUBMIT_NAMED("w1KFAHVqpaU", agc_cb_branch, "sceAgcCbBranch");
+    // The rest of the branch family is KNOWN-ABSENT rather than overlooked (#2173). libSceAgc
+    // exports them together; no title has been observed calling them, and each is left
+    // unregistered so a caller faults visibly instead of getting a silent wrong answer:
+    //   uZW-mqsxkrM  sceAgcCbBranchGetSize
+    //   GXBlM-ekzrI  sceAgcBranchPatchSetCompareAddress
+    //   QmfvaYpsOcI  sceAgcBranchPatchSetElseTarget
+    //   xb8VgcXQhvI  sceAgcBranchPatchSetThenTarget
+    // nid_census flags "builder registered, GetSize unregistered" for this pair, which normally
+    // means the guest reserves 0 dwords while prosper writes N. Here it is BENIGN ONLY BECAUSE
+    // agc_cb_branch folds the target stream and appends NOTHING to the guest buffer. If it is
+    // ever changed to emit a real branch packet, sceAgcCbBranchGetSize must be registered in the
+    // SAME change or the guest reserves nothing for what prosper then writes.
+    // The three BranchPatch* entries patch a branch's then/else targets and compare address
+    // AFTER it has been written, which a fold cannot honour: prosper folds unconditionally at
+    // build time and any later patch would be dropped. Whether a title does this is open.
+    #undef RN_SUBMIT_NAMED
     #undef RN_SUBMIT
     #undef RN
 }


### PR DESCRIPTION
`hle_agc.cpp` registered NID `w1KFAHVqpaU` as a **"submit variant"**. The PS5 3.20 export tables name
it **`sceAgcCbBranch`**. Naming and documentation only — and the behaviour must **not** be changed to
match the new label.

## The identity, verified rather than inherited

The issue asserted this; I checked it two ways before putting it in a code comment.

```
grep w1KFAHVqpaU ../PS5-3.20_Libs/
  libSceAgc.c:1426     -> __ptr_sceAgcCbBranch
  libSceAgcVsh.c:1426  -> __ptr_sceAgcCbBranch

nid_census <dump> --self-check --names <PS5-3.20_Libs>
  [names] 39158 NID<->name pairs
  [names] self-check: 0 mismatch(es) against nid_hash()
```

The second is the one that matters: the pairing is confirmed by **prosper's own hash function over
the entire published table**, not merely read out of it. `CONFIDENCE: HIGH` on the identity.

## The handler is right — only the label was wrong

This is load-bearing code; it resolved the **#232** wall. So the comment now says explicitly that the
behaviour must not be "fixed" to match the rename, because a future reader arriving via the new name
is exactly the person at risk of doing that.

The two readings agree. A command-buffer chain **calls** its intermediate buffers and **branches** to
the last one — a tail-jump, so the final buffer never returns. That is precisely the pattern the
existing RE notes describe from the guest's `SubmitCommandBuffers` loop (indirect submit for buffers
`[0..n-2]`, this NID for `n-1`). Folding — executing — the stream at that address is therefore the
correct thing for a software command processor to do. **`sceAgcCbBranch` semantics explain the RE'd
ABI rather than contradict it.**

All the hard-won RE notes are kept verbatim: the adapter thunk at `eboot+0x58df3f0`, the `arg8`/`arg9`
marshalling, and the stale-ring-tail hazard behind #241.

`CONFIDENCE: MED` on the chain-tail-jump reading of *why* DOLL calls it here — it fits the recorded
disassembly, but no capture was taken to confirm the final buffer is entered by branch rather than by
call, and I did not take one.

## Why the wrong label cost something

"Submit variant" implies a second submit entry point. "CbBranch" implies a control-flow packet in a
command stream. Those predict different things about the arguments and about what
`sceAgcCbBranchGetSize` should return — so the wrong name starts the next reader from the wrong
model, and hides the related surface entirely.

## Changes

- `agc_driver_submit_dcb_variant` → `agc_cb_branch` (3 sites, compiler-checked).
- Block header retitled; the shared-helper comment no longer calls it a "warmup-submit variant".
- **`RN_SUBMIT_NAMED`**, so logs and `hle_calls` report `sceAgcCbBranch` instead of a bare NID. A
  separate macro rather than a change to `RN_SUBMIT`, because every other entry in this file
  registers the NID as its own display name by convention and this is the one entry whose published
  name is established — changing the macro would have silently altered two unrelated registrations.
- The four unregistered siblings recorded as **known-absent** rather than overlooked
  (`sceAgcCbBranchGetSize`, `sceAgcBranchPatchSet{CompareAddress,ElseTarget,ThenTarget}`), each left
  unregistered so a caller faults visibly instead of getting a silent wrong answer.

One caveat is written into the code because it is easy to get wrong later: `nid_census` flags
*"builder registered, GetSize unregistered"* for this pair, which normally means the guest reserves 0
dwords while prosper writes N. It is benign **only because** `agc_cb_branch` folds and appends
**nothing** to the guest buffer. If that is ever changed to emit a real branch packet,
`sceAgcCbBranchGetSize` must land in the *same* change or the guest reserves nothing for what prosper
then writes.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
agc_submit_to_gpustate, agc_dcb_callback_abi, nid_hash_matches_imports -> 3/3 passed
git diff origin/master --check -> clean
```

No new test: the diff changes an identifier, comments, and the display string passed to
`register_fn`. The NID→handler mapping is unchanged and is already covered by the three tests above.

## Not claimed

- Not that any title calls the four sibling functions — unknown, and recorded as the open question.
- Not that the branch is conditional in practice. If a title ever builds a conditional branch and
  patches its targets afterwards, prosper folds unconditionally at build time and the patches would
  be dropped. That remains open and is now discoverable from the code.

Fixes #2173
