### PR TITLE
hle: the POSIX sem_* spellings return -1 with the number in errno

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2411,15 +2411,44 @@ HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_st
 // The Sony spellings of the fallible semaphore entry points (#2178). SemDestroy is absent because
 // it returns 0 unconditionally — #2042 made it quarantine its object rather than free it, which
 // changes what it does but not what it reports, so it still needs no alias. NOTE that the POSIX
-// names registered on these same bodies — sem_init/sem_wait/sem_trywait/sem_post/sem_getvalue —
-// have a separate, pre-existing problem: the C contract is "return -1, number in errno", and these
-// bodies return the number. That is not this rule and is not fixed here; the alias only stops the
-// SONY side from reporting a bare errno.
+// names registered on these same bodies are handled just below, along the OTHER
+// axis (#2182): the return CONVENTION rather than the error ENCODING.
 SCE_PTHREAD_ALIAS(k_sce_sem_init,     k_sem_init)
 SCE_PTHREAD_ALIAS(k_sce_sem_wait,     k_sem_wait)
 SCE_PTHREAD_ALIAS(k_sce_sem_trywait,  k_sem_trywait)
 SCE_PTHREAD_ALIAS(k_sce_sem_post,     k_sem_post)
 SCE_PTHREAD_ALIAS(k_sce_sem_getvalue, k_sem_getvalue)
+// The same bodies under their POSIX spellings, split along the RETURN-CONVENTION axis rather than
+// the encoding one (#2182). k_sem_* return the error NUMBER, which is right for scePthreadSem* and
+// wrong for sem_*: C11 7.26 and FreeBSD sem_wait(3) both specify "return -1, number left in errno".
+//
+// The failure this fixes is quiet in both idioms. A guest writing `if (sem_wait(s) < 0)` -- the form
+// the C standard prescribes -- saw SUCCESS on every failure, because a positive errno is not
+// negative. One writing `if (sem_wait(s) != 0)` saw the failure but could not read it out of errno,
+// because nothing had been put there.
+//
+// The value published is the FreeBSD-numbered errno the body already returned, NOT the host's, and
+// that distinction is load-bearing: the guest is a FreeBSD-ABI binary comparing against FreeBSD
+// constants, and it reads this through __error, which hle_libc.cpp resolves to the host thread's
+// &errno. The two numbering schemes are not interchangeable -- EAGAIN is 35 on the PS5 and 11 here,
+// which is exactly why fbsd_errno() exists (see the k_sem_trywait comment above).
+//
+// sem_timedwait has no POSIX spelling registered, so it is absent here and encodes in place.
+// sem_destroy is absent because returning 0 unconditionally already IS its POSIX contract.
+namespace {
+    inline uint64_t posix_sem_rc(uint64_t fbsd_rc) {
+        if (fbsd_rc == 0) return 0;
+        errno = (int)(uint32_t)fbsd_rc;
+        return (uint64_t)(int64_t)-1;
+    }
+}
+#define POSIX_SEM_ALIAS(posix_name, body) HLE(posix_name) { return posix_sem_rc(body(a0, a1, a2, a3, a4, a5)); }
+POSIX_SEM_ALIAS(k_posix_sem_init,     k_sem_init)
+POSIX_SEM_ALIAS(k_posix_sem_wait,     k_sem_wait)
+POSIX_SEM_ALIAS(k_posix_sem_trywait,  k_sem_trywait)
+POSIX_SEM_ALIAS(k_posix_sem_post,     k_sem_post)
+POSIX_SEM_ALIAS(k_posix_sem_getvalue, k_sem_getvalue)
+#undef POSIX_SEM_ALIAS
 // scePthreadBarrier* -- were MISSING -> the generic stub returned 0, so BarrierWait let every thread sail
 // past a rendezvous before its peers arrived: the barrier's downstream invariant (all-arrived) is false ->
 // reads of not-yet-produced data (the async-load race class). Back with host pthread_barrier_t; the serial
@@ -4144,9 +4173,11 @@ void register_kernel_hle() {
     R("scePthreadAttrSetaffinity", k_attr_noop); R("pthread_setname_np", k_attr_noop);
     // Plain libScePosix sem_* imports use the same guest object representation as scePthreadSem*.
     // Registering only the Sony-prefixed spellings left successful no-op imports in native engines.
-    R("sem_init", k_sem_init);       R("sem_destroy", k_sem_destroy);
-    R("sem_wait", k_sem_wait);       R("sem_trywait", k_sem_trywait);
-    R("sem_post", k_sem_post);       R("sem_getvalue", k_sem_getvalue);
+    // POSIX spellings take the -1/errno wrappers (#2182). sem_destroy keeps the shared body:
+    // returning 0 unconditionally is already its POSIX contract.
+    R("sem_init", k_posix_sem_init);       R("sem_destroy", k_sem_destroy);
+    R("sem_wait", k_posix_sem_wait);       R("sem_trywait", k_posix_sem_trywait);
+    R("sem_post", k_posix_sem_post);       R("sem_getvalue", k_posix_sem_getvalue);
     // event flags + semaphores (engine thread synchronization)
     R("sceKernelCreateEventFlag", k_ef_create); R("sceKernelDeleteEventFlag", k_ef_delete);
     R("sceKernelSetEventFlag", k_ef_set);       R("sceKernelClearEventFlag", k_ef_clear);

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -63,6 +63,12 @@ struct Row {
     const char* sony;
     const char* posix;    // nullptr = Sony-only body
     const char* note;
+    // The POSIX spelling's RETURN CONVENTION, which is not uniform across these families (#2182).
+    // pthread_* genuinely returns the error number, so those rows assert a bare errno. The sem_*
+    // family does not: C11 7.26 and FreeBSD sem_wait(3) specify "return -1, number left in errno",
+    // so those rows assert -1 AND read the number back out of errno. Getting this wrong in either
+    // direction is silent at the guest, which is why it is a per-row property and not a global one.
+    bool posix_returns_minus1 = false;
 };
 
 // Every fallible entry point in the synchronisation-object families, in registration order. A null
@@ -105,12 +111,12 @@ const Row kRows[] = {
     {"scePthreadRwlockattrInit",     "pthread_rwlockattr_init",     "#2178"},
     {"scePthreadRwlockattrDestroy",  "pthread_rwlockattr_destroy",  "#2178"},
     // --- semaphores ---
-    {"scePthreadSemInit",            "sem_init",                    "#2178"},
-    {"scePthreadSemWait",            "sem_wait",                    "#2178"},
-    {"scePthreadSemTrywait",         "sem_trywait",                 "#2178"},
+    {"scePthreadSemInit",            "sem_init",                    "#2178", true},
+    {"scePthreadSemWait",            "sem_wait",                    "#2178", true},
+    {"scePthreadSemTrywait",         "sem_trywait",                 "#2178", true},
     {"scePthreadSemTimedwait",       nullptr,                       "#2178, in place"},
-    {"scePthreadSemPost",            "sem_post",                    "#2178"},
-    {"scePthreadSemGetvalue",        "sem_getvalue",                "#2178"},
+    {"scePthreadSemPost",            "sem_post",                    "#2178", true},
+    {"scePthreadSemGetvalue",        "sem_getvalue",                "#2178", true},
     // --- barriers (no POSIX spelling registered on either body) ---
     {"scePthreadBarrierInit",        nullptr,                       "#2178, in place"},
     {"scePthreadBarrierWait",        nullptr,                       "#2178, in place"},
@@ -156,10 +162,18 @@ int main() {
         }
         // The half a single-spelling test cannot do: the POSIX name on the same body must NOT
         // encode. Without this line, aliasing both spellings would look like a clean pass.
-        const uint64_t bare = call0(posix);
-        snprintf(msg, sizeof msg, "%-30s -> bare EINVAL 22 (got %llu)",
-                 r.posix, (unsigned long long)bare);
-        CHECK(bare == kBareEINVAL, msg);
+        errno = 0;
+        const uint64_t got_posix = call0(posix);
+        if (r.posix_returns_minus1) {
+            snprintf(msg, sizeof msg,
+                     "%-30s -> -1 with EINVAL 22 in errno (got %lld, errno %d)",
+                     r.posix, (long long)(int64_t)got_posix, errno);
+            CHECK(got_posix == (uint64_t)(int64_t)-1 && errno == (int)kBareEINVAL, msg);
+        } else {
+            snprintf(msg, sizeof msg, "%-30s -> bare EINVAL 22 (got %llu)",
+                     r.posix, (unsigned long long)got_posix);
+            CHECK(got_posix == kBareEINVAL, msg);
+        }
     }
 
     // ===== 2. M3: a forwarded HOST errno, where host and FreeBSD numbering disagree ============
@@ -167,7 +181,9 @@ int main() {
     // is 11, which is FreeBSD's EDEADLK. This row is the only one that can tell a correct mapping
     // from a passed-through host number, because every other row's errno is EINVAL(22), which every
     // platform agrees on. It also carries the full contract at once: Sony gets 0x80020023, POSIX
-    // gets 35, and neither gets 11.
+    // gets -1 with 35 in errno, and neither gets 11. Since #2182 the POSIX half is the strongest
+    // arm in this file: it is the only place that can show WHICH numbering reaches the guest's
+    // errno, because it is the only errno in the suite where host and FreeBSD disagree.
     printf("-- a forwarded host errno (EAGAIN: FreeBSD 35, host 11) --\n");
     {
         HleFn sem_init    = Hle::lookup(nid_hash("scePthreadSemInit"));
@@ -183,8 +199,17 @@ int main() {
             CHECK(sem_trywait((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0) == 0x80020023ull,
                   "scePthreadSemTrywait on an empty semaphore reports encoded FreeBSD EAGAIN "
                   "(0x80020023) — not a bare 35, and not the host's 11");
-            CHECK(posix_trywait((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0) == 35,
-                  "sem_trywait on the same semaphore reports bare FreeBSD EAGAIN (35)");
+            // The POSIX half, and the sharpest arm in the file: -1 is the C contract, and the
+            // 35 in errno is FreeBSD's EAGAIN where the host's is 11. An implementation that
+            // published the host number would still return -1 here and would still look right to
+            // any check that only tested the return value (#2182).
+            errno = 0;
+            const uint64_t posix_rc = posix_trywait((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0);
+            CHECK(posix_rc == (uint64_t)(int64_t)-1,
+                  "sem_trywait on the same semaphore returns -1, per C11 7.26 / sem_wait(3)");
+            CHECK(errno == 35,
+                  "sem_trywait leaves FreeBSD EAGAIN (35) in errno — not the host's 11, which is "
+                  "FreeBSD's EDEADLK and would turn a retryable wait into a deadlock report");
             sem_destroy((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0);
         }
     }

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -153,9 +153,13 @@ int main() {
             // The POSIX spelling shares the body and must NOT encode. Without this line the arm
             // above cannot distinguish a correct alias from both spellings being encoded.
             auto posix_trywait = Hle::lookup(nid_hash("sem_trywait"));
-            CHECK(posix_trywait && posix_trywait((uint64_t)slot, 0, 0, 0, 0, 0)
-                      == static_cast<uint64_t>(FreeBsdErrno::EAgain),
-                  "sem_trywait keeps the bare FreeBSD EAGAIN (35)");
+            errno = 0;
+            const uint64_t posix_rc =
+                posix_trywait ? posix_trywait((uint64_t)slot, 0, 0, 0, 0, 0) : 0;
+            CHECK(posix_trywait && posix_rc == (uint64_t)(int64_t)-1 &&
+                      errno == static_cast<int>(FreeBsdErrno::EAgain),
+                  "sem_trywait returns -1 and leaves FreeBSD EAGAIN (35) in errno (#2182) — the "
+                  "POSIX contract, and the FreeBSD numbering the guest compares against");
             sem_destroy((uint64_t)slot, 0, 0, 0, 0, 0);
         } else {
             std::printf("  [skip] scePthreadSem* not registered on this platform\n");


### PR DESCRIPTION
The POSIX `sem_*` names were registered onto the `k_sem_*` bodies, which return a **FreeBSD errno**.
The C contract is **"return -1 and leave the number in `errno`"** (C11 7.26, FreeBSD `sem_wait(3)`).

The Sony `scePthreadSem*` spellings are **unaffected** — returning the number *is* their contract,
and since #2178 they return it libkernel-encoded.

## How it failed, in both idioms

```c
if (sem_wait(s) < 0)    // saw SUCCESS on every failure: a positive errno is not negative.
                        // This is the form the C standard prescribes, so it is the likelier
                        // one for a guest to have written.

if (sem_wait(s) != 0)   // saw the failure, but could not read it out of errno,
                        // because nothing had been put there.
```

## Approach

The same split the mutex/rwlock families already use, but along the **return-convention** axis rather
than the **error-encoding** one. `k_sem_*` stays the "returns the number" body that the Sony alias
wraps; `POSIX_SEM_ALIAS` gives the POSIX names a thin wrapper that publishes the number to `errno`
and returns `-1`.

Covers `sem_init` / `sem_wait` / `sem_trywait` / `sem_post` / `sem_getvalue`. `sem_timedwait` has no
POSIX spelling registered, so it is untouched. `sem_destroy` keeps the shared body — returning 0
unconditionally already *is* its POSIX contract.

## Which errno number is published — the part worth reviewing

The **FreeBSD-numbered** errno the body already returned, **not the host's**. The issue explicitly
warned not to assume here, so I checked: the guest reads `errno` through `__error`, which
`hle_libc.cpp` resolves to the host thread's `&errno`, with a comment recording that guest threads
*are* host pthreads. But the guest is a FreeBSD-ABI binary comparing against **FreeBSD** constants,
so the number stored has to be the FreeBSD one.

The two schemes are not interchangeable, and the gap is not theoretical: **EAGAIN is 35 on the PS5
and 11 here — and 11 is FreeBSD's `EDEADLK`.** Publishing the host number would turn a retryable
"would block" into a deadlock report. That is precisely why `fbsd_errno()` exists, and the
`k_sem_trywait` comment already recorded it.

## Tests

#2182 called out that two existing assertions encode the **wrong** behaviour and would otherwise read
as a guard proving the fix unnecessary. Both are updated:

- **`test_pthread_error_encoding.cpp`** — `Row` gains `posix_returns_minus1`, set on the five sem
  rows. Per-row rather than global because the convention genuinely is not uniform: `pthread_*` does
  return the number, and flattening that would be wrong in the other direction.
- **`test_sce_errno.cpp`** — the `sem_trywait` arm now asserts `-1` **and reads 35 back out of
  `errno`**.

The EAGAIN arm is the strongest in the suite, and this is why it is worth having: it is the **only**
errno in these tests where host and FreeBSD numbering disagree, so it is the only place that can show
*which* numbering reaches the guest. An implementation publishing the host's 11 would still return
`-1` and would still satisfy any check that only tested the return value.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

**Mutation-verified**: pointing `R("sem_trywait", ...)` back at the unwrapped body fails the new arm
(`[FAIL] sem_trywait returns -1 and leaves FreeBSD EAGAIN (35) in errno`). Reverted and re-run green.

**Not verified locally, and flagging it rather than letting CI discover it**:
`test_pthread_error_encoding` sits inside `CMakeLists.txt`'s `if(UNIX)` block, and MinGW is not UNIX
to CMake, so it does not build on this host — it is genuinely absent from the 176. I syntax-checked
it by hand (`g++ -std=c++20 -fsyntax-only`, clean) and the **Linux and macOS CI jobs are what
actually execute it**.

## Not claimed

- `CONFIDENCE: HIGH` that the contract is as described — POSIX/C11 is unambiguous and FreeBSD's
  `sem_wait(3)` matches.
- `CONFIDENCE: MED` on the blast radius, unchanged from the issue: no title in the corpus is known to
  import the plain `sem_*` names *and* check the result, so this may be latent rather than active. I
  did not survey the corpus to confirm that either way.

Fixes #2182
