### PR TITLE
fix(gpu): the image-atomic opcode list existed in three places and all three had to agree

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3044,8 +3044,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         SrtUse u; u.kind = 0; u.t8 = *t8;
                         u.key = tkey;
                         u.use_pc = in.pc;
+                        // image_store plus EVERY integer image atomic -- an atomic is a read-modify-write, so a
+                        // resource one targets can never be a sampled texture. This list used to be 0x08/0x0f/0x11,
+                        // which is exactly the set the RECOMPILER emitted: classifier and emitter kept in lockstep,
+                        // neither generalised. Opcodes verified with llvm-mc, positive control image_atomic_add ->
+                        // word0 0xf0440128, byte-identical to the guest's own dword (#2275).
                         u.is_storage_image = in.opcode == 0x08 || in.opcode == 0x0f ||
-                                             in.opcode == 0x11;
+                                             (in.opcode >= 0x11 && in.opcode <= 0x1a && in.opcode != 0x13);
                         u.is_depth_compare = (in.opcode >= 0x28 && in.opcode <= 0x2f) ||
                                              (in.opcode >= 0x38 && in.opcode <= 0x3f) ||
                                              (in.opcode >= 0x58 && in.opcode <= 0x5f);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10099,8 +10099,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             // Exact per-use provenance wins over table keys. A sample and store may consume the same
             // T# through a colliding offset but require different Vulkan descriptor classes.
+            // image_store plus EVERY integer image atomic. This was the THIRD copy of the 0x08/0x0f/0x11
+            // triple -- the others are the storage-image classifier in gpu_executor.cpp and the emitter's
+            // own is_atomic test -- and all three must agree for an image atomic to compile. They did
+            // agree, on the wrong set: exactly the ops the emitter happened to support.
+            //
+            // The failure mode when they DISAGREE is the instructive part. Widening the classifier alone
+            // made this gate reject harder: the resource correctly became a StorageImage, and the clause
+            // below then read "0x17 is not a storage op, so it must want a Texture; it is not a Texture"
+            // and discarded it. A half-applied fix was worse than none (#2275).
+            //
+            // Opcodes verified by assembling each with llvm-mc, positive control image_atomic_add ->
+            // word0 0xf0440128, byte-identical to the dword decoded from the guest here.
             const bool storage_only_op = in.opcode == 0x08 || in.opcode == 0x0f ||
-                                         in.opcode == 0x11;
+                                         (in.opcode >= 0x11 && in.opcode <= 0x1a && in.opcode != 0x13);
             if ((storage_only_op && res && res->cls != ResourceClass::StorageImage) ||
                 (in.opcode != 0x00 && !storage_only_op && in.opcode != 0x0e &&
                  res && res->cls != ResourceClass::Texture))
@@ -10125,13 +10137,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                       res->format == DataFormat::Uint32;
 
             // --- Storage-image path: image_load (0x00), image_store (0x08), and R32_UINT
-            // image_atomic_swap/add (0x0f/0x11), without a sampler. ---
             if (res->cls == ResourceClass::StorageImage) {
                 const bool is_ld = in.opcode == 0x00;
                 const bool is_st = in.opcode == 0x08;
-                const bool is_atomic_swap = in.opcode == 0x0f;
-                const bool is_atomic_add = in.opcode == 0x11;
-                const bool is_atomic = is_atomic_swap || is_atomic_add;
+                // Opcodes verified with llvm-mc; add/positive-control matches the guest's own word0 (#2275).
+                uint16_t spirv_atomic = 0;
+                switch (in.opcode) {
+                    case 0x0f: spirv_atomic = Op_AtomicExchange; break;
+                    case 0x11: spirv_atomic = Op_AtomicIAdd;     break;
+                    case 0x12: spirv_atomic = Op_AtomicISub;     break;
+                    case 0x14: spirv_atomic = Op_AtomicSMin;     break;
+                    case 0x15: spirv_atomic = Op_AtomicUMin;     break;
+                    case 0x16: spirv_atomic = Op_AtomicSMax;     break;
+                    case 0x17: spirv_atomic = Op_AtomicUMax;     break;
+                    case 0x18: spirv_atomic = Op_AtomicAnd;      break;
+                    case 0x19: spirv_atomic = Op_AtomicOr;       break;
+                    case 0x1a: spirv_atomic = Op_AtomicXor;      break;
+                    default: break;
+                }
+                const bool is_atomic = spirv_atomic != 0;
                 if (!is_ld && !is_st && !is_atomic) { ok = false; return true; }
                 uint32_t dim, ncoord; bool arrayed = false, ms = false;
                 switch (in.mimg_dim) {   // SQ_RSRC dim -> SPIR-V Dim + coord count (+ array layer / MSAA sample)
@@ -10156,7 +10180,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // be exactly 1 only in the non-arrayed case.
                 const bool atomic_2d_array = in.mimg_dim == SQ_DIM_2D_ARRAY && arrayed && !ms;
                 if (is_atomic &&
-                    ((in.mimg_dim != SQ_DIM_2D && !atomic_2d_array) || ms || in.len_dwords != 2 ||
+                    ((in.mimg_dim != SQ_DIM_2D && !atomic_2d_array) || ms || in.len_dwords < 2 ||
                      in.mimg_unorm || in.mimg_dmask != 1u ||
                      (!arrayed && (res->img_dim != 1u || res->depth != 1u)) ||
                      (arrayed && (res->img_dim != SQ_DIM_2D_ARRAY || !res->depth)) ||
@@ -10239,7 +10263,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // preserves the old register value for EXEC-inactive lanes.
                     const int vd = in.dst.value;
                     const uint32_t old = vreg_old(b, rs, vd);
-                    const uint16_t atomic_op = is_atomic_add ? Op_AtomicIAdd : Op_AtomicExchange;
+                    const uint16_t atomic_op = spirv_atomic;
                     uint32_t result;
                     if (compute_atomic_buffer) {
                         const uint32_t index = b.ibin(


### PR DESCRIPTION
## Three hardcoded copies of one opcode list, all required to agree

An integer image atomic could only compile if **three** independent lists agreed on its opcode — and
all three carried the same triple, `0x08/0x0f/0x11`, which is exactly the set the emitter happened to
support:

| where | decides |
| --- | --- |
| `gpu_executor.cpp:3047` `is_storage_image` | StorageImage vs sampled Texture |
| `rdna2_to_spirv.cpp` `is_atomic` | whether to emit at all (fixed in #2272) |
| `rdna2_to_spirv.cpp` **`storage_only_op`** | whether to **keep the resolved resource**, before either of the above |

**The third is the one that hid.** It sits *ahead* of the class check, so an unlisted atomic had its
resource discarded and never reached the storage-image path at all — which is why widening the
classifier alone changed nothing observable, and why the emitter's own reject looked like the whole
story.

## The half-applied fix was worse than none

Widening only the classifier made the resource correctly a `StorageImage` — and `storage_only_op` then
read *"0x17 is not a storage op, so it must want a Texture; it is not a Texture"* and discarded it.

**Two correct changes in the wrong order look like a regression.** That is the part I would carry
forward from this: a rule split across three sites fails in a way where fixing one site is not
partial progress toward fixing all three.

## Opcodes verified, not remembered

```
0x0f swap  0x11 add  0x12 sub  0x14 smin 0x15 umin
0x16 smax  0x17 umax 0x18 and  0x19 or   0x1a xor
```

Each assembled with `llvm-mc -mcpu=gfx1010 -show-encoding` and its opcode field read back. **The
positive control is `image_atomic_add`: word0 `0xf0440128`, byte-identical to the dword prosper
decodes from the guest** — which is what makes the table verified rather than plausible.

`0x10` cmpswap and `0x1b`/`0x1c` inc/dec are deliberately absent: a comparand pair and wrapping forms
are not one-for-one SPIR-V atomics, and guessing an equivalent is a subtly wrong image rather than a
loud failure.

## Result — and the falsification is worth more than the fix

Sonic Racing: CrossWorlds issues `image_atomic_umax` (`0x17`, NSA `len=3`) on a default launch:

| | before | after |
| --- | ---: | ---: |
| `recompile-reject op=0x17` | 4 | **0** |
| all MIMG rejects | present | **gone** |
| the umax's resource class | Texture (2) | **StorageImage (4)**, bindings 52 and 54 |

**And the composite still collapses.** The title still goes uniform to RGB(1,0,1) after the SEGA logo,
with a marginal gain at one sample (1,373 colours where master gives 1).

So **"CrossWorlds' uniform composite is caused by rejected shaders" is now dead** — zero MIMG rejects,
same collapse. That hypothesis has driven this title's investigation since #2013, and it is worth more
retired than the opcode fix is worth landing.

## Verification

```
cmake --build build -j6         # rc=0
ctest --no-tests=error -j4      # 221/221 passed
git diff --check                # clean
```

@Wren — worth attacking: I widened `storage_only_op` to the same family as the other two, but that
clause also governs the *negative* branch (`!storage_only_op` → must be a Texture). I have reasoned
that no non-atomic op moves between branches, and I have not proved it for the sample/gather opcodes.

Refs #2275, #2265.
