### PR TITLE
hle: scePthreadAttrSetstacksize must refuse what its sibling already refuses

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1323,18 +1323,39 @@ HLE(k_attr_destroy) {
     }
     return 0;
 }
+// The guard MIRRORS k_attr_setstack below: same three rejected conditions, same answer (#2183).
+// It used to wrap the success path in `if (a0 && *a0 && a1 >= 16384)` and return 0 regardless, so a
+// guest asking for an 8 KiB stack was told YES here and NO by scePthreadAttrSetstack -- the same
+// question answered two ways (the #1873 shape) -- and the thread was then created with whatever size
+// the attribute already carried. The guest believed it had configured a stack it had not.
+//
+// Rejecting rather than clamping, because k_attr_setstack already assumes rejection and FreeBSD's
+// pthread_attr_setstacksize returns EINVAL below PTHREAD_STACK_MIN. CONFIDENCE: MED on the boundary
+// itself -- no live title evidence pins the PS5's behaviour at exactly 16 KiB, and the 16384 here is
+// inherited from the sibling rather than independently established.
+//
+// The rejection LOGS unconditionally rather than under PROSPER_SYNCLOG. This handler previously
+// could not fail, so any title relying on the silent acceptance changes behaviour here, and that
+// must not be invisible: a refused stack request is exactly the kind of thing that surfaces later as
+// an unexplained thread fault with nothing connecting it back to this call.
 HLE(k_attr_setstacksize) {
-    if (a0 && *(void**)a0 && a1 >= 16384) {
-        auto* at = (GuestPthreadAttr*)*(void**)a0;
-        int rc = pthread_attr_setstacksize(&at->host, a1);
-        if (getenv("PROSPER_SYNCLOG"))
-            fprintf(stderr, "[thread] attr setstacksize attr=%p size=0x%llx rc=%d\n",
-                    (void*)at, (unsigned long long)a1, rc);
-        if (rc == 0) {
-            at->supplied_stack = nullptr; at->supplied_stack_size = 0;
-        }
+    if (!a0 || !*(void**)(uintptr_t)a0 || a1 < 16384) {
+        static std::atomic<unsigned> refused{0};
+        if (refused.fetch_add(1) < 16)
+            fprintf(stderr, "[thread] attr setstacksize REFUSED attr=0x%llx size=0x%llx "
+                            "(null/uninitialised attr, or below the 16 KiB minimum) -- #2183\n",
+                    (unsigned long long)a0, (unsigned long long)a1);
+        return 0x16;   // bare EINVAL; the Sony spelling encodes it through the alias below
     }
-    return 0;
+    auto* at = (GuestPthreadAttr*)*(void**)a0;
+    int rc = pthread_attr_setstacksize(&at->host, a1);
+    if (getenv("PROSPER_SYNCLOG"))
+        fprintf(stderr, "[thread] attr setstacksize attr=%p size=0x%llx rc=%d\n",
+                (void*)at, (unsigned long long)a1, rc);
+    if (rc == 0) {
+        at->supplied_stack = nullptr; at->supplied_stack_size = 0;
+    }
+    return fbsd_errno(rc);
 }
 HLE(k_attr_setstack) {
     // Sony and every host backend we support require at least 16 KiB here.  MinGW's winpthreads
@@ -1359,6 +1380,17 @@ HLE(k_attr_setstack) {
     return fbsd_errno(rc);
 #endif
 }
+// Both stack-setting entry points are fallible, so both need the Sony/POSIX split (#1984, #2178).
+// setstacksize needs it because #2183 just MADE it fallible: landing that without the alias would
+// have started handing scePthreadAttrSetstacksize a bare FreeBSD errno, which is exactly the defect
+// the alias exists to prevent -- the two are one change, not two.
+//
+// setstack gets one in the same commit because it was ALREADY returning a bare errno from both its
+// 0x16 and its fbsd_errno(rc) paths. Fixing only its sibling would have left the pair still
+// disagreeing about the ENCODING, i.e. moved the "same question answered two ways" defect one step
+// rather than removing it.
+SCE_PTHREAD_ALIAS(k_sce_attr_setstacksize, k_attr_setstacksize)
+SCE_PTHREAD_ALIAS(k_sce_attr_setstack,     k_attr_setstack)
 HLE(k_attr_setguardsize) {
     if (!a0 || !*(void**)(uintptr_t)a0) return 0x16;   // SCE_KERNEL_ERROR_EINVAL
     auto* at = (GuestPthreadAttr*)*(void**)(uintptr_t)a0;
@@ -4079,8 +4111,8 @@ void register_kernel_hle() {
     R("scePthreadExit", k_pthread_exit);
     R("scePthreadAttrInit", k_attr_init);
     R("scePthreadAttrDestroy", k_attr_destroy);
-    R("scePthreadAttrSetstack", k_attr_setstack);
-    R("scePthreadAttrSetstacksize", k_attr_setstacksize);
+    R("scePthreadAttrSetstack", k_sce_attr_setstack);            // encoded (#2183)
+    R("scePthreadAttrSetstacksize", k_sce_attr_setstacksize);    // encoded (#2183)
     R("scePthreadAttrSetguardsize", k_attr_setguardsize);
     R("scePthreadAttrSetinheritsched", k_attr_noop);
     R("scePthreadAttrSetschedpolicy", k_attr_noop);

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -69,6 +69,13 @@ struct Row {
 // object provokes EINVAL in all of them (each body opens with a `!a0` / `ensure_*` guard), so one
 // zero-argument call exercises every row uniformly.
 const Row kRows[] = {
+    // --- thread attributes: the two stack setters (#2183) ---
+    // scePthreadAttrSetstacksize was previously INFALLIBLE, and for the wrong reason: it swallowed
+    // a null attr and an undersized request and reported success, while scePthreadAttrSetstack
+    // rejected the same three conditions. Making it fallible and giving it its alias are one
+    // change, not two -- splitting them would have started handing the Sony spelling a bare errno.
+    {"scePthreadAttrSetstacksize",   "pthread_attr_setstacksize",   "#2183"},
+    {"scePthreadAttrSetstack",       "pthread_attr_setstack",       "#2183, alias was missing"},
     // --- mutex attributes ---
     {"scePthreadMutexattrInit",      "pthread_mutexattr_init",      "#2178"},
     {"scePthreadMutexattrSettype",   "pthread_mutexattr_settype",   "#2178"},

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -162,6 +162,50 @@ int main() {
         }
     }
 
+    // ===== scePthreadAttrSetstacksize: fallible, and encoded on the Sony spelling (#2183) =======
+    // It used to accept a null attr and any size, silently, reporting success -- while its sibling
+    // scePthreadAttrSetstack rejected the SAME three conditions with EINVAL. A guest asking for an
+    // 8 KiB stack was told yes by one entry point and no by the other, and its thread was then
+    // created with whatever size the attribute already carried.
+    {
+        auto attr_init    = Hle::lookup(nid_hash("scePthreadAttrInit"));
+        auto sce_setsize  = Hle::lookup(nid_hash("scePthreadAttrSetstacksize"));
+        auto pos_setsize  = Hle::lookup(nid_hash("pthread_attr_setstacksize"));
+        auto getsize      = Hle::lookup(nid_hash("scePthreadAttrGetstacksize"));
+        auto attr_destroy = Hle::lookup(nid_hash("scePthreadAttrDestroy"));
+        CHECK(attr_init && sce_setsize && pos_setsize && getsize && attr_destroy,
+              "the pthread-attr stack entry points are registered");
+        if (attr_init && sce_setsize && pos_setsize && getsize && attr_destroy) {
+            void* at = nullptr;
+            const uint64_t slot = (uint64_t)(uintptr_t)&at;
+            attr_init(slot, 0, 0, 0, 0, 0);
+            CHECK(at != nullptr, "the attribute initializes");
+
+            // The pair, on the same undersized request. Neither spelling alone can see the other
+            // drifting, which is the whole reason #2178 asserts both halves per entry point.
+            CHECK(sce_setsize(slot, 4096, 0, 0, 0, 0) == 0x80020016ull,
+                  "scePthreadAttrSetstacksize refuses a 4 KiB stack with encoded EINVAL "
+                  "(0x80020016), the same answer its scePthreadAttrSetstack sibling already gave");
+            CHECK(pos_setsize(slot, 4096, 0, 0, 0, 0) ==
+                      static_cast<uint64_t>(FreeBsdErrno::EInval),
+                  "pthread_attr_setstacksize refuses the same request with the bare errno (22)");
+            CHECK(sce_setsize(0, 256 * 1024, 0, 0, 0, 0) == 0x80020016ull,
+                  "a null attribute handle is refused even for a valid size");
+
+            // The arm that stops "reject everything" from passing: a VALID size must still be
+            // stored and must read back. Without it the three arms above are equally satisfied by a
+            // handler broken in the other direction, which is the cheaper mistake to make here.
+            CHECK(sce_setsize(slot, 256 * 1024, 0, 0, 0, 0) == 0,
+                  "a 256 KiB stack is still accepted");
+            size_t stored = 0;
+            getsize(slot, (uint64_t)(uintptr_t)&stored, 0, 0, 0, 0);
+            CHECK(stored == 256 * 1024,
+                  "scePthreadAttrGetstacksize reads back the size that was accepted");
+
+            attr_destroy(slot, 0, 0, 0, 0, 0);
+        }
+    }
+
     // ---- behavioral: scePthreadMutexTimedlock timeout --------------------------------------
     {
         auto mtx_init = Hle::lookup(nid_hash("scePthreadMutexInit"));


### PR DESCRIPTION
`scePthreadAttrSetstacksize` accepted a null attribute handle, an uninitialised one, or an undersized
stack **silently, and reported success**:

```cpp
HLE(k_attr_setstacksize) {
    if (a0 && *(void**)a0 && a1 >= 16384) { ...store... }
    return 0;                      // every rejected case landed here
}
```

`k_attr_setstack` rejects the **same three conditions** with EINVAL. So a guest asking *"give this
thread an 8 KiB stack"* was told **yes** by one entry point and **no** by the other, and the thread
was then created with whatever size the attribute already carried — the guest believing it had
configured a stack it had not. That is the #1873 "same question answered two ways" shape, in its
quiet direction.

## Why the alias travels with it

#2183 is *why* `scePthreadAttrSetstacksize` appears in #2178's sweep as "infallible, correctly no
alias". It was infallible for the wrong reason: it **swallowed** its failures rather than not having
any. Making it fallible and giving it its `SCE_PTHREAD_ALIAS` are **one change, not two** — landing
the first alone would have started handing the Sony spelling a bare FreeBSD errno, which is precisely
the #1984 defect the alias exists to prevent.

**`scePthreadAttrSetstack` gets an alias in the same commit, and that is a deliberate addition to the
issue's scope.** It was *already* returning a bare errno from both its `0x16` and its
`fbsd_errno(rc)` paths. Fixing only its sibling would have left the pair still disagreeing — about
the *encoding* instead of the *acceptance*. The defect would have moved rather than gone, which the
charter calls out explicitly.

## Rejecting, not clamping

`k_attr_setstack` already assumes rejection, and FreeBSD's `pthread_attr_setstacksize` returns EINVAL
below `PTHREAD_STACK_MIN`. `CONFIDENCE: MED` on the boundary itself — no live title evidence pins the
PS5's behaviour at exactly 16 KiB, and the `16384` is inherited from the sibling rather than
independently established.

## The corpus check the issue asked for

Silently accepting was load-bearing in the direction of "nothing breaks", so a title that asks for a
small stack and is now refused could take a path it never took before. The refusal therefore **logs
unconditionally** (capped at 16), not under `PROSPER_SYNCLOG` — this must never be invisible, because
a refused stack request is exactly the kind of thing that resurfaces later as an unexplained thread
fault with nothing connecting it back.

```
PPSA25009  Blue Prince     30 s   REFUSED = 0
PPSA24651  The Messenger   30 s   REFUSED = 0
PPSA13579  Blasphemous 2   30 s   REFUSED = 0
```

The diagnostic is demonstrably **able** to fire — the new test arms emit it, so this is not a null
from a silent instrument. Three titles over boot and early run is **not** the whole corpus and is not
claimed to be.

## Tests

`test_sce_errno.cpp` (builds on every host, so it is verifiable locally):

| arm | expected |
| --- | --- |
| `scePthreadAttrSetstacksize(attr, 4096)` | `0x80020016` |
| `pthread_attr_setstacksize(attr, 4096)` | `22` |
| `scePthreadAttrSetstacksize(nullptr, 256K)` | `0x80020016` |
| **positive**: `(attr, 256K)` then `scePthreadAttrGetstacksize` | `0`, reads back `256K` |

The positive arm is the one that matters most: without it, the three refusal arms are **equally
satisfied by a handler broken in the other direction**, which is the cheaper mistake to make here.

`test_pthread_error_encoding.cpp` gets two sweep rows in the #2178 paired style.

The two existing tests that drive this entry point (`test_stack_registry.cpp:130`,
`test_win_kernel_is_stack.cpp:173`) pass 2 MiB and 64 KiB — both far above the threshold — so neither
needed an arm changed.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

**Mutation-verified**: relaxing the size check to `a1 < 0` — keeping the null guard, so the arms
*fail* rather than crash on a null deref — fails exactly the two undersized arms. Reverted and re-run
green. (My first mutation disabled the whole guard and segfaulted instead, which is a blunter signal
than a failing assertion; the sharper one isolates the condition actually under test.)

**Not verified locally**: `test_pthread_error_encoding` is inside `CMakeLists.txt`'s `if(UNIX)` and
does not build on MinGW. Syntax-checked by hand; the Linux and macOS CI jobs execute it.

Fixes #2183
