### PR TITLE
diag(render): separate an unarmed write journal from a stale one, and correct #2289

### DIFF
--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -217,6 +217,43 @@ were confirmed as legitimate frustum culls.
 
 ## Ruled out (do-not-redo list)
 
+**Persistent-texture revalidation, 2026-08-07 (Windows / NVIDIA RTX 4090, #2289 / #2290 / #2295).**
+**43.6% of the frame is `memcmp` revalidating 19 cached, unchanged textures** — 233 GiB of
+comparison per ~55 s route, on a cache running 34,303 hits against 19 misses. That number stands.
+Three ways of removing it are dead, and two of them died because *I published the wrong mechanism
+first*:
+
+- **"The write journal is not armed on the renderer's path."** FALSE. `execute_ordered_and_present`
+  branches on `needs_ordered_realization` and *both* arms reach a scope — the non-ordered one via
+  `execute_ordered_items` -> `execute_ordered_items_impl`, which constructs it as its first
+  statement (`gpu_executor.cpp:5681`) and calls the renderer at `:5737`, lexically inside it and on
+  the same thread. Measured `unarmed=0 stale=33438`: every `Unknown` is a **serial mismatch**, and
+  `guest_gpu_writes_since()` is answering *correctly* — the journal is intra-submit by construction
+  and cannot answer a cross-submit question. Citing the two construction sites is not the same as
+  tracing which one the branch lands in (#2295).
+- **"In-submit reuse is worth ~9x."** FALSE, and it was a misread of the instrument. `8.9
+  refs/submit` is the total across ALL cached textures, not references to one: `33437 hits / 3875
+  submits / 19 entries = 0.47 refs per ENTRY per submit`. A texture is referenced about once every
+  *two* submits, so there is essentially no intra-submit repeat to exploit. The counters already
+  implied it — `unknown == validations` means a same-submit second reference never happens (#2295).
+- **`MEM_WRITE_WATCH` / `GetWriteWatch`.** BLOCKED, measured with a positive control. Guest dmem is
+  a sparse file + `CreateFileMappingW` section mapped as views (`hle_kernel_mem.cpp:3168`), which
+  PS5 `sceKernelMapDirectMemory` aliasing *requires*. `GetWriteWatch` on a private
+  `VirtualAlloc(MEM_WRITE_WATCH)` region works (`rc=0`, 2 dirty pages, granularity 4096); on a
+  section-backed view it returns `-1` with `GetLastError()=87`. `MEM_WRITE_WATCH` is an attribute of
+  private committed memory and a mapped view can never carry it.
+
+So this is **a Windows structural limit under the current design**, not a missing optimisation: the
+page-protection watch Linux uses is barred here by the red-zone hazard in `guest_write_watch.cpp`
+(exception-dispatch frames land in the guest's SysV 128-byte red zone), and that hazard is real.
+**Do not "fix" it by validating a prefix, validating every N submits, or trusting the GPU-write
+journal alone** — each is unsound against raw guest CPU stores, which is exactly what the exact
+compare exists to catch, and the failure mode is silently-stale texture pixels.
+
+The open measurement that would size the prize is the **Linux `watch_reuse` count** on this title:
+Linux takes the real mprotect tracker (`guest_write_watch.cpp:520`), so its reuse rate is what a
+working cross-submit watch would be worth here.
+
 **Frontend frame decomposition, 2026-08-07 (Windows / NVIDIA RTX 4090, #2266 / #2262 / #2276).**
 `pass_control` was 27% of the frame and was a *residual*, not a measurement. Partitioning it took
 four steps and three of them killed a hypothesis. Each cost a 13-minute route; none is recoverable

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1232,6 +1232,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // Overlap means the guest genuinely rewrote those bytes and the revalidation is
                 // CORRECT. A single zero cannot tell those apart, so count them separately.
                 uint64_t persistent_submit_unknown = 0, persistent_submit_overlap = 0;
+                // ...and WHY the Unknowns were unknown (#2289). Two structurally different
+                // causes that a single Unknown count cannot separate, and the difference
+                // decides whether the cost is addressable by the submit journal AT ALL:
+                //   unarmed  the journal is not armed on this thread -> missing instrumentation
+                //   stale    it IS armed, but the snapshot came from an EARLIER submit. That is
+                //            not a defect: the journal is intra-submit by construction, so a
+                //            cross-submit question can only ever answer Unknown through it,
+                //            and only a cross-submit WATCH can answer it at all.
+                uint64_t persistent_submit_unarmed = 0, persistent_submit_stale = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
                 // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -2988,9 +2997,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 resource_texture_submit_query =
                                     static_cast<int>(submit_query);
                                 if (timing_enabled && submit_reuse_enabled) {
-                                    if (submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown)
+                                    if (submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown) {
                                         pending_timing.persistent_submit_unknown++;
-                                    else if (submit_query == prosper::gpu::GuestGpuWriteQuery::Overlap)
+                                        if (prosper::gpu::guest_gpu_write_tracking_active())
+                                            pending_timing.persistent_submit_stale++;
+                                        else
+                                            pending_timing.persistent_submit_unarmed++;
+                                    } else if (submit_query == prosper::gpu::GuestGpuWriteQuery::Overlap)
                                         pending_timing.persistent_submit_overlap++;
                                 }
                                 const bool submit_unchanged = submit_reuse_enabled &&
@@ -7052,6 +7065,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     uint64_t persistent_watch_reuses = 0, persistent_watch_dirty = 0;
                     uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
                     uint64_t persistent_submit_unknown = 0, persistent_submit_overlap = 0;
+                    uint64_t persistent_submit_unarmed = 0, persistent_submit_stale = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                     // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -7169,6 +7183,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.persistent_watch_unknown += pending_timing.persistent_watch_unknown;
                     timing.persistent_submit_unknown += pending_timing.persistent_submit_unknown;
                     timing.persistent_submit_overlap += pending_timing.persistent_submit_overlap;
+                    timing.persistent_submit_unarmed += pending_timing.persistent_submit_unarmed;
+                    timing.persistent_submit_stale += pending_timing.persistent_submit_stale;
                     timing.persistent_watch_disabled += pending_timing.persistent_watch_disabled;
                     timing.buffers += pending_timing.buffers;
                     timing.buffer_views += pending_timing.buffer_views;
@@ -7523,7 +7539,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     }
                     fprintf(stderr,
                             "[render-timing] texture_cache hits=%llu submit_reuse=%llu "
-                            "(submit_unknown=%llu submit_overlap=%llu) misses=%llu "
+                            "(submit_unknown=%llu [unarmed=%llu stale=%llu] submit_overlap=%llu) misses=%llu "
                             "watch_reuse=%llu watch_dirty=%llu watch_unknown=%llu watch_disabled=%llu "
                             "invalid=%llu "
                             "validations=%llu %.1f GiB entries=%zu %.1f MiB "
@@ -7531,6 +7547,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (unsigned long long)totals.persistent_hits,
                             (unsigned long long)totals.persistent_submit_reuses,
                             (unsigned long long)totals.persistent_submit_unknown,
+                            (unsigned long long)totals.persistent_submit_unarmed,
+                            (unsigned long long)totals.persistent_submit_stale,
                             (unsigned long long)totals.persistent_submit_overlap,
                             (unsigned long long)totals.persistent_misses,
                             (unsigned long long)totals.persistent_watch_reuses,

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -611,6 +611,17 @@ GuestGpuWriteSnapshot guest_gpu_write_snapshot();
 GuestGpuWriteQuery guest_gpu_writes_since(const GuestGpuWriteSnapshot& snapshot,
                                            uint64_t addr, uint64_t size);
 
+// Whether the per-submit write journal is armed ON THIS THREAD (#2289). Diagnostic only.
+//
+// guest_gpu_writes_since() returns Unknown for two structurally different reasons and a caller
+// cannot tell them apart: the journal is not armed here at all, or it IS armed but the snapshot
+// carries a different submit serial. The second is not a defect -- the journal is intra-submit by
+// construction, so a snapshot taken in an earlier submit can only ever answer Unknown. Conflating
+// them is how a cross-submit cost gets mistaken for missing instrumentation.
+//
+// The journal is thread_local, so this answers for the calling thread and nothing else.
+bool guest_gpu_write_tracking_active();
+
 // Register the synchronous live compute backend. execute_compute_dispatches realizes every retained
 // dispatch from its state snapshot and invokes the backend in stream order.
 void set_submit_compute(LiveComputeFn fn);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6973,6 +6973,7 @@ GuestGpuWriteSnapshot guest_gpu_write_snapshot() {
     if (!g_guest_gpu_writes.active || g_guest_gpu_writes.overflowed) return {};
     return {g_guest_gpu_writes.submit_serial, g_guest_gpu_writes.writes.size()};
 }
+bool guest_gpu_write_tracking_active() { return g_guest_gpu_writes.active; }
 GuestGpuWriteQuery guest_gpu_writes_since(const GuestGpuWriteSnapshot& snapshot,
                                            uint64_t addr, uint64_t size) {
     if (!snapshot.submit_serial || !g_guest_gpu_writes.active ||


### PR DESCRIPTION
**I published two claims on #2289 that this measurement falsifies.** Both were mine, both carried
`file:line` citations, and the second was load-bearing for a "~9× win" that does not exist.

## What I claimed

1. *"`GuestGpuWriteSubmitScope` is instantiated only in `execute_ordered_items_impl` and
   `execute_ordered_gpustate`, so `g_guest_gpu_writes.active` is false on this path."*
2. *"At 9.5 references per texture per submit, making in-submit reuse work is worth roughly **9×** on
   243 GiB."*

## Claim 1 is wrong — the journal **is** armed

`execute_ordered_and_present` branches on `needs_ordered_realization`, and **both** arms reach a
scope: the ordered arm via `execute_ordered_gpustate`, the other via `execute_ordered_items` →
`execute_ordered_items_impl`, which constructs the scope as its **first statement** (`:5681`) and
calls the renderer at `:5737` — lexically inside it, on the same thread.

I cited the two construction sites correctly and then drew the wrong conclusion from them, because I
never traced which one the non-ordered branch actually lands in.

This PR's counter split proves it rather than arguing it:

```
hits=33437 submit_reuse=0 (submit_unknown=33438 [unarmed=0 stale=33438] submit_overlap=0)
misses=19 validations=33438 233.8 GiB entries=19
```

**`unarmed=0, stale=33438`.** Every `Unknown` is a **serial mismatch**: the stored
`validation_snapshot` came from an *earlier* submit, and each submit takes a fresh serial.
`guest_gpu_writes_since()` then exits `Unknown` on its first branch — **correctly**. The journal is
intra-submit *by construction* and structurally cannot answer a cross-submit question. That is a
design boundary, not missing instrumentation.

## Claim 2 is wrong — I misread my own instrument

`8.9 refs/submit` is the total across **all** cached textures, not references to one:

```
33437 hits / 3875 submits   =  8.85 refs per submit
8.85 / 19 entries           =  0.47 refs per ENTRY per submit
```

A texture is referenced roughly **once every two submits**. In-submit reuse only helps when the same
texture is referenced twice *within* one submit, so at 0.47 it has essentially nothing to win.

The counters already implied this and I did not read them that way: a second reference inside one
submit would have matched the current serial and answered `Unchanged` or `Overlap`, so
`unknown == validations` was *itself* evidence that the intra-submit repeat case never occurs.

## What it means for #2289

**Direction 1 (make in-submit reuse work) is a dead end, on both counts.** The 233.8 GiB is a
cross-submit cost, and the only mechanism that can address it is the cross-submit **write watch** —
exactly what is disabled on Windows by design (`guest_write_watch.cpp`, the red-zone argument).
Direction 2 (`MEM_WRITE_WATCH` / `GetWriteWatch`, which uses no page protection and raises no
exception, so the red-zone objection does not apply) is not merely the better option; it is the
only one.

**The 43.6%-of-frame measurement is unaffected.** It is a count and a byte volume; neither claim
above entered it.

## Why the split is worth keeping

`Unknown` covered two causes with opposite prospects — *not instrumented* (fixable) versus *asking a
question the instrument cannot answer* (not fixable here) — and one count cannot separate them. That
ambiguity is exactly what let me publish a wrong mechanism with a citation attached, which the
charter names as the most contagious error this project produces.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Counters sit behind `timing_enabled`, so a default run computes nothing extra. The line is
self-checking: `unarmed + stale` must equal `submit_unknown`, and on this run `0 + 33438 == 33438`
exactly.

## Not claimed

- Not that `MEM_WRITE_WATCH` is feasible against prosper's guest allocator — still unverified.
- Not that this route generalises. It reaches ~11 draws/submit and never enters the FMV or gameplay
  regimes, where the refs-per-entry ratio could differ.

Refs #2289
