### PR TITLE
diag(render): report the publish source's colour format — #2283's blocking arm

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1241,6 +1241,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 //            cross-submit question can only ever answer Unknown through it,
                 //            and only a cross-submit WATCH can answer it at all.
                 uint64_t persistent_submit_unarmed = 0, persistent_submit_stale = 0;
+                // #2283's blocking arm. publish_selected_fmt0 must stay 0 over a full route for
+                // the disabled-target readback skip to be safe by construction. `unknown` is
+                // separate so a selection whose source pass could not be identified is never
+                // silently counted as a clean one.
+                uint64_t publish_selected = 0, publish_selected_fmt0 = 0;
+                uint64_t publish_selected_unknown = 0, publish_candidate_fmt0 = 0;
                 uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                 double texture_ms = 0, buffer_ms = 0;
                 // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -5302,6 +5308,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             uint32_t px_vo_w = 0, px_vo_h = 0;
             uint32_t px_last_w = 0, px_last_h = 0;
             uint64_t px_front_base = 0, px_vo_base = 0, px_last_base = 0;
+            // The raw CB_COLOR0_INFO.FORMAT of the pass that produced each present candidate, so the
+            // SELECTED one's format can be reported (#2283). UINT32_MAX is "no candidate recorded",
+            // deliberately not 0: 0 is CB_COLOR_INVALID, a real and meaningful value here, and the
+            // whole question is how often it reaches the publish source. Absent and disabled must
+            // not be the same number.
+            constexpr uint32_t kNoPassFormat = UINT32_MAX;
+            uint32_t px_front_fmt = kNoPassFormat, px_vo_fmt = kNoPassFormat,
+                     px_last_fmt = kNoPassFormat;
             // Fail-visible: a submit that renders yet offers no present-extent source is exactly the
             // Frontiers wall, and before #1968's diagnostics nothing anywhere said so — the publish
             // counter simply stopped while the guest kept submitting. Never expected, so it reports
@@ -6345,17 +6359,34 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             }
                         }
                     }
+                    // The POPULATION that the publish zero is a zero OVER, counted BEFORE the
+                    // emptiness/format gates below -- so it sees every pass whose colour target
+                    // is disabled, not just those that already qualified as candidates.
+                    //
+                    // This placement is the whole point. A same-source positive control proves
+                    // the DISCRIMINATOR fires; it can never prove the DOMAIN contains the case.
+                    // Counting the population in the same run is what separates "disabled-target
+                    // passes exist and none is ever published" from "none exists, so the zero
+                    // says nothing" -- and those are opposite conclusions about whether #2283's
+                    // readback skip is safe.
+                    if (timing_enabled && !pass.empty() && pass.front()->ps.color0_format == 0)
+                        ++pending_timing.publish_candidate_fmt0;
                     if (!rendered_pixels.empty() && pass_format == VK_FORMAT_R8G8B8A8_UNORM) {
+                        // Recorded alongside each candidate rather than re-derived at selection
+                        // time: by then the pass loop has moved on and `pass` no longer refers to
+                        // the pass that produced these pixels (#2283).
+                        const uint32_t candidate_fmt =
+                            pass.empty() ? kNoPassFormat : pass.front()->ps.color0_format;
                         if (base && base == front_va) {                          // the flipped buffer
                             px_front = pass_pixels; px_front_w = gw; px_front_h = gh;
-                            px_front_base = base;
+                            px_front_base = base; px_front_fmt = candidate_fmt;
                         }
                         if (is_vo) {                                            // any registered scanout
                             px_vo = pass_pixels; px_vo_w = gw; px_vo_h = gh;
-                            px_vo_base = base;
+                            px_vo_base = base; px_vo_fmt = candidate_fmt;
                         }
                         px_last = pass_pixels;                                  // last non-empty (fallback)
-                        px_last_w = gw; px_last_h = gh; px_last_base = base;
+                        px_last_w = gw; px_last_h = gh; px_last_base = base; px_last_fmt = candidate_fmt;
                     } else if (!rendered_pixels.empty() && prefix_inspect_publish()) {
                         // #1330: under gpu_replay's ordered-prefix inspection (--draw/--draw-steps/
                         // --through-operation set PROSPER_PREFIX_INSPECT), a prefix ending on a
@@ -6508,6 +6539,25 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 : present_choice == PresentSourceChoice::Vo    ? px_vo
                                 : present_choice == PresentSourceChoice::Last  ? px_last
                                 : nullptr;
+                // #2283's blocking arm, measured rather than argued: is a pass whose colour target is
+                // DISABLED (CB_COLOR0_INFO.FORMAT == 0, CB_COLOR_INVALID) ever chosen as the frame
+                // that gets published? The proposed fix stops forcing a readback on such a pass, and
+                // it is safe by CONSTRUCTION only if the answer is never. Nothing checked it before,
+                // and the guard that looks like it would -- pass_format == R8G8B8A8_UNORM at the
+                // candidate site -- does NOT exclude a disabled target, because backend_color_format()
+                // FALLS BACK to R8G8B8A8_UNORM for anything it does not recognise, including 0.
+                if (timing_enabled) {
+                    const uint32_t chosen_fmt =
+                        present_choice == PresentSourceChoice::Front ? px_front_fmt
+                      : present_choice == PresentSourceChoice::Vo    ? px_vo_fmt
+                      : present_choice == PresentSourceChoice::Last  ? px_last_fmt
+                      : kNoPassFormat;
+                    if (selected_pixels) {
+                        ++pending_timing.publish_selected;
+                        if (chosen_fmt == 0) ++pending_timing.publish_selected_fmt0;
+                        else if (chosen_fmt == kNoPassFormat) ++pending_timing.publish_selected_unknown;
+                    }
+                }
                 // The one new semantic path: a non-empty higher-priority candidate was passed over on
                 // extent. Unreachable today (a VO/front-buffer pass has its extent pinned to the present
                 // extent at :5060-5063 before it renders, so those candidates always fit), which is
@@ -7066,6 +7116,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     uint64_t persistent_watch_unknown = 0, persistent_watch_disabled = 0;
                     uint64_t persistent_submit_unknown = 0, persistent_submit_overlap = 0;
                     uint64_t persistent_submit_unarmed = 0, persistent_submit_stale = 0;
+                    uint64_t publish_selected = 0, publish_selected_fmt0 = 0;
+                    uint64_t publish_selected_unknown = 0, publish_candidate_fmt0 = 0;
                     uint64_t texture_bytes = 0, buffer_bytes = 0, buffer_materialized_bytes = 0;
                     double texture_ms = 0, buffer_ms = 0;
                     // Attribution of texture_ms by OUTCOME class (#2262). After #2259 removed the
@@ -7185,6 +7237,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     timing.persistent_submit_overlap += pending_timing.persistent_submit_overlap;
                     timing.persistent_submit_unarmed += pending_timing.persistent_submit_unarmed;
                     timing.persistent_submit_stale += pending_timing.persistent_submit_stale;
+                    timing.publish_selected += pending_timing.publish_selected;
+                    timing.publish_selected_fmt0 += pending_timing.publish_selected_fmt0;
+                    timing.publish_selected_unknown += pending_timing.publish_selected_unknown;
+                    timing.publish_candidate_fmt0 += pending_timing.publish_candidate_fmt0;
                     timing.persistent_watch_disabled += pending_timing.persistent_watch_disabled;
                     timing.buffers += pending_timing.buffers;
                     timing.buffer_views += pending_timing.buffer_views;
@@ -7392,6 +7448,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             backend_buffers.cached_buffers,
                             backend_buffers.cached_bytes / (1024.0 * 1024.0),
                             (unsigned long long)backend_buffers.evictions);
+                    fprintf(stderr,
+                            "[render-timing] publish_source selected=%llu fmt0=%llu unknown=%llu passes_fmt0=%llu\n",
+                            (unsigned long long)totals.publish_selected,
+                            (unsigned long long)totals.publish_selected_fmt0,
+                            (unsigned long long)totals.publish_selected_unknown,
+                            (unsigned long long)totals.publish_candidate_fmt0);
                     fprintf(stderr,
                             "[render-timing] color_targets writes=%llu load_hits=%llu sample_hits=%llu "
                             "readbacks=%llu deferred=%llu cached=%llu %.1f MiB\n",


### PR DESCRIPTION
Marlow — this is the arm you asked me to check on #2283, built and measured. **It does not settle the
question, and the reason is worth more than a confirmation would have been.**

## What you asked for

> The arm that must be **shown** before implementing: no pass with `ps.color0_format == 0` is ever
> selected as the publish source over a full route. If that holds, the change is safe by construction
> rather than by argument.

Nothing measured it, so I added the instrument:

```
[render-timing] publish_source selected=8777 fmt0=0 unknown=0 passes_fmt0=0
```

| field | meaning |
| --- | --- |
| `selected` | frames actually published |
| `fmt0` | …whose source pass had a **disabled** colour target — **must be 0** |
| `unknown` | …whose source pass could not be identified — must be 0 |
| `passes_fmt0` | passes with a disabled target that **occurred at all** |

## The guard that looks sufficient is not

Worth flagging because it's the reason this needed measuring rather than reading: the candidate site
is gated on `pass_format == VK_FORMAT_R8G8B8A8_UNORM`, which *looks* like it excludes a disabled
target. It doesn't — `backend_color_format()` falls back to `R8G8B8A8_UNORM` for anything
unrecognised, **including 0**. Same trap as your `fmt=37` near-miss, one layer along.

## The result: my route can't settle it

PPSA25009, Windows/MinGW, 90 s, 8,777 publish selections → `fmt0=0`, `unknown=0`.

**But `passes_fmt0=0` too.** No pass with a disabled colour target occurred on this route at all, so
the `fmt0=0` is a **zero over an empty domain** and proves nothing. Your evidence counted 2,375 such
passes, so the population exists — just not on the route I can reach from here.

I'm reporting that as a non-result rather than as agreement. A zero whose population is also zero is
exactly the shape that reads as confirmation and carries no information, and I'd have handed you a
false green.

## The positive control, and what it deliberately does not cover

Forcing every candidate to report format 0 gives `fmt0=1327` of `selected=1327` — the discriminator
fires and the counter is wired correctly.

That control draws from the same route as the null, so **by construction it tests the discriminator
and never the domain**. That is precisely why `passes_fmt0` exists, and why it is counted *before*
the emptiness/format gates rather than beside the candidate assignment — my first placement sat
inside the candidate block and could only ever have seen passes that already qualified, which would
have reported a reassuring zero for a second, different wrong reason. I caught that one only because
the first number came back suspiciously clean.

## What you need to do with it

Run it on the route where your 2,375 base-less passes appear:

```
PROSPER_RENDER_TIMING=1 ...   # read the [render-timing] publish_source line
```

The arm is satisfied when **`passes_fmt0 > 0` while `fmt0 == 0` and `unknown == 0`**. If `fmt0` is
ever non-zero, the readback skip is *not* safe by construction and needs a different argument.

This matters more than when you filed it: `backend` is ~50% of the Blue Prince frame here and its
`draw_setup` accounts for only 0.39 ms of 5.97, with **3.04 fence waits per submit** — so the
GPU-round-trip half is now the larger of the two addressable halves. The texture-revalidation half I
was chasing turned out to be structurally blocked on Windows (#2289, both directions closed with
measurements).

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Counters sit behind `timing_enabled`; a default run computes nothing extra. No behaviour change.

Refs #2283
