### PR TITLE
diag(render): nest gpu_wait's children under it, and give draw_setup a signed residual

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -7358,10 +7358,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         totals.backend_gpu_wait_ms + totals.backend_readback_ms +
                         totals.backend_cleanup_ms;
                     fprintf(stderr,
+                            // detail is the SIX-term partition (target draw_setup record_upload
+                            // gpu_wait readback cleanup) and `other` is measured - detail, so the
+                            // row IS exhaustive. What it used to invite was summing NINE terms:
+                            // gpu_device and gpu_overhead are printed here too, and
+                            // gpu_overhead is COMPUTED as gpu_wait - gpu_device, so those two
+                            // add up to gpu_wait exactly and a nine-term sum double-counts it.
+                            // That is why the residual equalled gpu_wait to the hundredth
+                            // (#2248) -- not because gpu_wait was nested in a neighbour, but
+                            // because its own two CHILDREN were printed as its siblings.
+                            //
+                            // Parenthesised now, so the nesting is in the syntax rather than
+                            // recoverable only by arithmetic, and `other` is signed so the row
+                            // states whether it balances instead of leaving that to be derived.
                             "[render-timing] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
                             "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
-                            "gpu_wait=%.2f gpu_device=%.2f gpu_overhead=%.2f readback=%.2f "
-                            "cleanup=%.2f other=%.2f\n",
+                            "gpu_wait=%.2f (device=%.2f overhead=%.2f) readback=%.2f "
+                            "cleanup=%.2f other=%+.2f\n",
                             totals.backend_calls / nsub, totals.backend_draws / nsub,
                             totals.backend_ms / nsub, backend_detail_ms / nsub,
                             totals.backend_target_ms / nsub, totals.backend_draw_setup_ms / nsub,
@@ -7384,14 +7397,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (double)totals.flush_explicit / nsub,
                             (double)totals.flush_no_batch / nsub);
                     fprintf(stderr,
+                            // draw_setup is the PARENT one line above; these four are its leaves
+                            // and they did not add up to it -- 75.16 against 82.46 in the window
+                            // that found this, a 7.30 ms gap nothing named (#2249). An unmeasured
+                            // region does not read as unmeasured, it reads as somebody else's
+                            // cost, and 7.30 ms is small enough that nobody chases it and large
+                            // enough to hide an instrument -- which is exactly how trap 130's
+                            // 305 ms/submit got billed to the renderer.
                             "[render-timing] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
-                            "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
+                            "resources=%.2f pipeline=%.2f other=%+.2f  fixed{index_upload=%.2f blend=%.2f "
                             "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
                             "other=%+.2f} pre_index{subgroup_scan=%.2f other=%+.2f}\n",
                             totals.backend_setup_shader_ms / nsub,
                             totals.backend_setup_fixed_ms / nsub,
                             totals.backend_setup_resources_ms / nsub,
                             totals.backend_setup_pipeline_ms / nsub,
+                            (totals.backend_draw_setup_ms - totals.backend_setup_shader_ms -
+                             totals.backend_setup_fixed_ms - totals.backend_setup_resources_ms -
+                             totals.backend_setup_pipeline_ms) / nsub,
                             totals.backend_res_fixed_index_upload_ms / nsub,
                             totals.backend_res_fixed_blend_ms / nsub,
                             totals.backend_res_fixed_depth_stencil_ms / nsub,
@@ -7772,10 +7795,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         window.backend_gpu_wait_ms + window.backend_readback_ms +
                         window.backend_cleanup_ms;
                     fprintf(stderr,
+                            // detail is the SIX-term partition (target draw_setup record_upload
+                            // gpu_wait readback cleanup) and `other` is measured - detail, so the
+                            // row IS exhaustive. What it used to invite was summing NINE terms:
+                            // gpu_device and gpu_overhead are printed here too, and
+                            // gpu_overhead is COMPUTED as gpu_wait - gpu_device, so those two
+                            // add up to gpu_wait exactly and a nine-term sum double-counts it.
+                            // That is why the residual equalled gpu_wait to the hundredth
+                            // (#2248) -- not because gpu_wait was nested in a neighbour, but
+                            // because its own two CHILDREN were printed as its siblings.
+                            //
+                            // Parenthesised now, so the nesting is in the syntax rather than
+                            // recoverable only by arithmetic, and `other` is signed so the row
+                            // states whether it balances instead of leaving that to be derived.
                             "[render-window] backend-submit calls=%.2f draws=%.1f avg_ms: measured=%.2f "
                             "detail=%.2f target=%.2f draw_setup=%.2f record_upload=%.2f "
-                            "gpu_wait=%.2f gpu_device=%.2f gpu_overhead=%.2f readback=%.2f "
-                            "cleanup=%.2f other=%.2f\n",
+                            "gpu_wait=%.2f (device=%.2f overhead=%.2f) readback=%.2f "
+                            "cleanup=%.2f other=%+.2f\n",
                             window.backend_calls / wn, window.backend_draws / wn,
                             window.backend_ms / wn, window_backend_detail_ms / wn,
                             window.backend_target_ms / wn, window.backend_draw_setup_ms / wn,
@@ -7799,13 +7835,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             (double)window.flush_no_batch / wn);
                     fprintf(stderr,
                             "[render-window] backend-submit draw_setup avg_ms: shaders=%.2f fixed=%.2f "
-                            "resources=%.2f pipeline=%.2f  fixed{index_upload=%.2f blend=%.2f "
+                            "resources=%.2f pipeline=%.2f other=%+.2f  fixed{index_upload=%.2f blend=%.2f "
                             "depth_stencil=%.2f viewport=%.2f stages=%.2f pre_index_unsplit=%.2f "
                             "other=%+.2f} pre_index{subgroup_scan=%.2f other=%+.2f}\n",
                             window.backend_setup_shader_ms / wn,
                             window.backend_setup_fixed_ms / wn,
                             window.backend_setup_resources_ms / wn,
                             window.backend_setup_pipeline_ms / wn,
+                            (window.backend_draw_setup_ms - window.backend_setup_shader_ms -
+                             window.backend_setup_fixed_ms - window.backend_setup_resources_ms -
+                             window.backend_setup_pipeline_ms) / wn,
                             window.backend_res_fixed_index_upload_ms / wn,
                             window.backend_res_fixed_blend_ms / wn,
                             window.backend_res_fixed_depth_stencil_ms / wn,


### PR DESCRIPTION
Two rows of the `backend-submit` block read as partitions and were not. Both are presentation defects
in the same fprintf pair, which is why they land together — fixing one alone leaves a reader still
summing the other.

## #2248 — `gpu_device` and `gpu_overhead` are `gpu_wait`'s **children**

The row printed nine flat millisecond terms under one measured total. Summing them double-counts
`gpu_wait`, and the issue's evidence showed the residual equal to `gpu_wait` **to the hundredth** in
every window sampled.

From that, #2248 inferred *"`gpu_wait` is nested inside one of its neighbours — most likely `readback`
or `gpu_overhead`"*. **The nesting runs the other way**, and one line of the argument list says so:

```cpp
std::max(0.0, totals.backend_gpu_wait_ms - totals.backend_gpu_device_ms)   // <- gpu_overhead
```

`gpu_overhead` is *computed as* `gpu_wait − gpu_device`, so `gpu_device + gpu_overhead == gpu_wait`
identically. `gpu_wait`'s own two **children** were being printed as its siblings.

**The row was already internally consistent, and nobody could tell.** `backend_detail_ms` sums exactly
**six** terms — target, draw_setup, record_upload, gpu_wait, readback, cleanup — counting `gpu_wait`
once and `gpu_device`/`gpu_overhead` not at all, and `other` was already `measured − detail`. The
issue's own numbers confirm it: `111.75` (six) + `8.28` (the two children) + `1.59` (other) =
`121.62`, exactly the nine-term sum it reported.

So the fix is presentational, deliberately:

```
gpu_wait=7.34 (device=5.68 overhead=1.66)
```

The nesting is now in the **syntax** rather than recoverable only by arithmetic, and `other` is signed
(`%+.2f`) so the row *states* whether it balances instead of leaving that to be derived.

## #2249 — `draw_setup`'s four leaves had no residual

They sit under a `draw_setup` total one line above and did not add up to it — 75.16 against 82.46 in
the window that found it, a **7.30 ms gap nothing named**. Now:

```
draw_setup avg_ms: shaders=0.00 fixed=0.14 resources=0.22 pipeline=0.02 other=+0.10
```

An unmeasured region does not read as unmeasured; it reads as somebody else's cost. 7.30 ms is small
enough that nobody chases it and large enough to hide an instrument — which is exactly how trap 130's
305 ms/submit got billed to the renderer.

## Verification

Windows, MinGW (WinLibs UCRT g++ 16.1.0), PPSA25009, 55 s:

```
backend-submit calls=4.05 draws=10.8 avg_ms: measured=9.27 detail=9.25 target=0.08
  draw_setup=0.48 record_upload=0.16 gpu_wait=7.34 (device=5.68 overhead=1.66)
  readback=1.11 cleanup=0.07 other=+0.02
backend-submit draw_setup avg_ms: shaders=0.00 fixed=0.14 resources=0.22 pipeline=0.02 other=+0.10
```

| check | result |
| --- | --- |
| `5.68 + 1.66` | `7.34` — equals `gpu_wait` |
| `0.08+0.48+0.16+7.34+1.11+0.07 = 9.24` vs `measured 9.27` | `other=+0.02` |
| `0.00+0.14+0.22+0.02 = 0.38` vs parent `0.48` | `other=+0.10` |

```
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Both rows are diagnostic output behind `PROSPER_RENDER_TIMING`. **No measurement changes** — the
six-term partition is untouched; only how it is displayed, plus one previously-silent remainder that
is now named.

## One thing the numbers make visible

`gpu_wait` is **7.34 of 9.27 measured — 79% of backend time** on this route. That is what the row was
obscuring by inviting a nine-term denominator summing to 107% of the real total: the single largest
term in the backend half was being read against an inflated base.

Fixes #2248
Fixes #2249
