### PR TITLE
host: make the fatal-report block's "never returns" invariant structural

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -2786,12 +2786,26 @@ namespace {
             // end the process, and under PROSPER_WORKER_PARK a LATER fault can take the gate and
             // get a full report of its own.
             prosper::host::release_fault_report(dump_owner, fc.tid);
+            // These two are INSIDE the block on purpose (#2163). fault_context.hpp explains that
+            // release_fault_report is safe without a nesting count only because "the fatal report
+            // block never returns -- its every exit is _exit or an unbounded park", and that property
+            // used to be enforced by these statements sitting AFTER the block, which control flow
+            // fell off the end of. Anyone adding an early `return` above broke the invariant with no
+            // failing check and no test; the consequence is the report gate released while a report
+            // is still printing, i.e. two re-entrant reports interleaved on one stderr.
+            //
+            // Inside the brace, the block demonstrably has no fall-off-the-end exit, so the comment
+            // in fault_context.hpp is enforced by structure rather than by everyone remembering to
+            // read it. Moving them is behaviour-preserving because the block at :2311 is an
+            // UNCONDITIONAL bare block, not an `if` -- "inside, at the end" and "immediately after"
+            // run in exactly the same cases.
+            //
+            // PROSPER_WORKER_PARK=1 (diagnostic): instead of terminating the whole process on a guest
+            // worker-thread fault, park the faulting thread so the main thread can proceed to its own
+            // recoverable crash (lets CRASHPEEK/PEEK_CLASS run). May deadlock if the worker held a lock.
+            if (getenv("PROSPER_WORKER_PARK")) { for (;;) pause(); }
+            _exit(90);
         }
-        // PROSPER_WORKER_PARK=1 (diagnostic): instead of terminating the whole process on a guest
-        // worker-thread fault, park the faulting thread so the main thread can proceed to its own
-        // recoverable crash (lets CRASHPEEK/PEEK_CLASS run). May deadlock if the worker held a lock.
-        if (getenv("PROSPER_WORKER_PARK")) { for (;;) pause(); }
-        _exit(90);
     }
 
     std::string trap_detail() {

--- a/prosper/src/host/fault_context.hpp
+++ b/prosper/src/host/fault_context.hpp
@@ -99,6 +99,12 @@ inline bool claim_fault_report(std::atomic<long>& owner, long tid, long* already
 // because the fatal report block never returns — its every exit is `_exit` or an unbounded park —
 // so an inner report ends the process rather than unwinding back into the outer one. If that ever
 // stops being true, this needs a depth count, not a bool.
+//
+// That property is now STRUCTURAL rather than documentary (#2163): the park and the _exit(90)
+// live INSIDE the fatal block's braces in exec_image_linux.cpp, so it has no fall-off-the-end
+// exit and an inserted early `return` is a visible change to a block that provably terminates.
+// They used to sit after the closing brace, where the invariant held only as long as every
+// future editor read this paragraph first.
 inline void release_fault_report(std::atomic<long>& owner, long tid) {
     long expected = tid;
     owner.compare_exchange_strong(expected, 0);


### PR DESCRIPTION
`fault_context.hpp` documents that `release_fault_report()` is safe without a nesting count only
because of a property of its caller:

> the fatal report block never returns — its every exit is `_exit` or an unbounded park — so an inner
> report ends the process rather than unwinding back into the outer one. **If that ever stops being
> true, this needs a depth count, not a bool.**

True — but enforced by two statements sitting **after** the block's closing brace, which control flow
fell off the end of. An early `return` inserted above them breaks the invariant with no failing check
and no test, and the consequence surfaces as two re-entrant reports interleaved on one stderr.

Moved inside the brace. The block now demonstrably has no fall-off-the-end exit, so an inserted
`return` becomes a visible change to a block that provably terminates.

## Why the move is behaviour-preserving — the thing worth checking

This same move would be a **real defect** if the block were conditional: statements after a not-taken
`if` still run, and moving them inside would silently skip them. That is the one way this change
could be wrong, so I checked it rather than assumed.

It is not conditional. The block opens at `:2311` as a bare unconditional `{` — verified by matching
braces backwards from the closing one programmatically, not by eye. So *"inside, at the end"* and
*"immediately after"* execute in exactly the same cases.

The handler has **two** exits, and both are now structurally terminating:

| line | path | status |
| --- | --- | --- |
| `:2367` | inside `if (!claim_fault_report(...)) { … _exit(90); }` — the claim **loser** | already enclosed, unchanged here |
| `:2807` | the fatal-report block itself | **this change** |

`fault_context.hpp`'s paragraph is updated to say the property is now structural and where it is
enforced, so the comment and the code cannot drift apart — that drift is the whole failure mode the
issue is about.

## Not done, deliberately

The issue also suggests `__builtin_unreachable()` after the `_exit`. Left out: `_exit` is already
`[[noreturn]]`, so the compiler has the information, and the extra statement is dead code that some
warning configurations flag. The brace is the enforcement; a redundant hint beside it is noise.

## Verification

**Neither file compiles on this host, and I'm flagging that rather than letting CI discover it.**
`exec_image_linux.cpp` is Linux-only and `fault_context.hpp` is included by nothing else, so MinGW
builds neither. **The Linux and macOS CI jobs are what actually compile this.**

What I could check locally:

```
brace balance over the whole file      541 open / 541 close, delta 0
enclosing block of the moved lines     resolves to the `{` at :2311 (programmatic brace match)
Windows build + ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

No behaviour change on any path: the diff moves two statements within an unconditional block and adds
comments.

Fixes #2163
