### PR TITLE
hle: sceSaveDataDirNameSearchPs4 must report NOT_FOUND, not SCE_OK over an unwritten result

### DIFF
--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -4232,6 +4232,36 @@ HLE(s_savedata_transfermount_ps4) {
     return SAVE_DATA_ERR_NOT_FOUND;
 }
 
+// sceSaveDataDirNameSearchPs4 (X4MYzukPc3g) -- the PS4 sibling of sceSaveDataDirNameSearch
+// (dyIhnXq-0SM, registered below), and with the entry point above the ONLY two PS4-namespace exports
+// libSceSaveData has across all 275 PS5 3.20 libraries. Fixing it closes the pair (#2210).
+//
+// Unregistered, this reached prosper_on_unimpl's `return 0` -- SCE_OK for this contract, the FALSE
+// SUCCESS class (#2081). The caller is told a search over PS4 save data SUCCEEDED and the result
+// struct it passed is never written. That reads as "zero hits" only because callers happen to zero
+// the struct first: right by accident, not by construction. A caller reusing a result struct, or one
+// whose hit count lands on non-zero stack residue, is handed a count over memory nothing wrote --
+// the #213 shape, where a garbage count sized a 34 GB array.
+//
+// NOT_FOUND is derived from local inventory, not assumed: prosper has no PS4 save-data store at all
+// (its two save areas are both PS5-side -- PROSPER_SAVEDATA_DIR -> save-data-memory, PROSPER_SAVE0 ->
+// the mounted /savedata0) and no local dump carries a PS4 save area, so a search over PS4 save data
+// honestly finds nothing. Same 0x809F facility, same answer a search of a nonexistent save returns.
+//
+// NOTHING is written to the result, deliberately. Returning SCE_OK with an explicitly-zeroed hit
+// count would also be defensible -- but only if the argument layout were established from live
+// evidence, and it is not. Inventing a written result is the exact mirror of the defect being fixed
+// (#2208's failure was a guest reading an unwritten result). A caller that reads a result after an
+// error is reading its own buffer, which is what must not be papered over.
+//
+// CONFIDENCE: HIGH that success is wrong here (it is SCE_OK over an unwritten out-struct by
+// construction); MED on NOT_FOUND being the precise firmware errno; LOW on the argument layout --
+// nothing is assumed about it because nothing is read or written.
+HLE(s_savedata_dirname_search_ps4) {
+    svc_log("sceSaveDataDirNameSearchPs4", a0,a1,a2,a3,a4,a5);
+    return SAVE_DATA_ERR_NOT_FOUND;
+}
+
 // sceSystemServiceGetNoticeScreenSkipFlag(bool* flag) — polled from DOLL's front-end menu.
 // PS5-only (no reference). Live capture pinned the out-pointer to an ODD stack address
 // (0x...ff307), so the flag is a single byte (bool), NOT an int32 — a 4-byte write would clobber
@@ -4640,6 +4670,7 @@ void register_service_hle() {
     Hle::register_fn("lPDO62PpJIA", (HleFn)s_npent_skuflag, "sceNpEntitlementAccessGetSkuFlag");
     Hle::register_fn("WAzWTZm1H+I", (HleFn)s_savedata_transfermount, "sceSaveDataTransferringMount");
     Hle::register_fn("RjMlsR8EXrw", (HleFn)s_savedata_transfermount_ps4, "sceSaveDataTransferringMountPs4");
+    Hle::register_fn("X4MYzukPc3g", (HleFn)s_savedata_dirname_search_ps4, "sceSaveDataDirNameSearchPs4");
     Hle::register_fn("3RQ5aQfnstU", (HleFn)s_syss_noticeskip, "sceSystemServiceGetNoticeScreenSkipFlag");
     // libSceNpUniversalDataSystem — inert ids (guarded LOW-confidence out-writes).
     Hle::register_fn("sjaobBgqeB4", (HleFn)s_npuds_ok,     "sceNpUniversalDataSystemInitialize");

--- a/prosper/tests/test_false_success_nids.cpp
+++ b/prosper/tests/test_false_success_nids.cpp
@@ -33,6 +33,7 @@ constexpr const char* kNpTrophy2GetGameInfo       = "4IzqhhUQ3nk";  // already r
 constexpr const char* kNpTrophy2GetTrophyInfoArray = "y3zHpdZO6ME"; // already registered
 constexpr const char* kSaveDataTransferringMount    = "WAzWTZm1H+I";
 constexpr const char* kSaveDataTransferringMountPs4 = "RjMlsR8EXrw";
+constexpr const char* kSaveDataDirNameSearchPs4     = "X4MYzukPc3g";
 
 bool all_bytes_equal(const unsigned char* p, size_t n, unsigned char v) {
     for (size_t i = 0; i < n; ++i) if (p[i] != v) return false;
@@ -199,6 +200,44 @@ void test_savedata_transferring_mount() {
     // unresolved — a lead, not a conclusion. Frontiers gates on the SIGN alone, so nothing here
     // depends on it.
     CHECK(answers[0] == answers[1], "both transferring-mount entry points give the same answer");
+
+    // sceSaveDataDirNameSearchPs4 (#2210). With the mount above, these are the ONLY two
+    // PS4-namespace exports libSceSaveData has across all 275 PS5 3.20 libraries, so the pair is
+    // closed here rather than left one-registered -- which is the state that reads as covered.
+    {
+        HleFn fn = Hle::lookup(kSaveDataDirNameSearchPs4);
+        // Kills: the unregistered path, where prosper_on_unimpl returns 0 == SCE_OK for this
+        // contract and the caller is told a PS4 save-data search SUCCEEDED over a result it never
+        // wrote. Imported by 13 modules across 12 titles, including PPSA25009/PPSA24651/PPSA13579,
+        // verified with nid_census against the local dumps.
+        CHECK(fn != nullptr, "sceSaveDataDirNameSearchPs4 is registered");
+        if (fn) {
+            // POISONED, not zeroed, and that is the difference that makes this arm mean something.
+            // The mounts block above zeroes its result, so its "untouched" assertion cannot tell a
+            // handler that wrote zeros from one that wrote nothing. 0x5A can.
+            unsigned char result[64];
+            memset(result, 0x5A, sizeof(result));
+            uint64_t param[8] = { 0, 0, 0, 0, 0, 0, 0, 0 };
+            const uint64_t r = fn((uint64_t)(uintptr_t)param, (uint64_t)(uintptr_t)result, 0, 0, 0, 0);
+
+            // Kills: THE BUG, and equally a hand-written `return 0` stub replacing it.
+            CHECK(r != 0, "sceSaveDataDirNameSearchPs4 reports unavailable rather than success");
+            // Sign, not merely non-zero: Sony errors are 0x8xxxxxxx and guest sites gate with
+            // `test eax,eax; js`, so `return 1` would reinstate the bug with a non-zero check green.
+            CHECK((int32_t)(uint32_t)r < 0,
+                  "sceSaveDataDirNameSearchPs4 error is NEGATIVE as int32 (the sign call sites test)");
+            // Kills: inventing a written result -- a zeroed hit count over a layout nobody has
+            // established. That is the exact MIRROR of the defect being fixed, and it is the more
+            // tempting mistake because it looks more helpful.
+            CHECK(all_bytes_equal(result, sizeof(result), 0x5A),
+                  "sceSaveDataDirNameSearchPs4 writes NOTHING to the caller's result buffer");
+            // Kills: the two PS4-namespace entry points drifting apart. Both derive their answer
+            // from the same local-inventory fact -- prosper has no PS4 save-data store -- so a
+            // title's behaviour must not depend on which of them it happened to call.
+            CHECK(r == answers[1],
+                  "both PS4-namespace savedata entry points give the same answer");
+        }
+    }
 }
 
 } // namespace


### PR DESCRIPTION
`X4MYzukPc3g` = **`sceSaveDataDirNameSearchPs4`** was unregistered, so it reached
`prosper_on_unimpl`'s `return 0` — **`SCE_OK` for this contract**. The caller is told a search over
PS4 save data *succeeded*, and the result struct it passed is never written. The FALSE SUCCESS class
(#2081).

That reads as "zero hits" only because callers happen to zero the struct first — **right by accident,
not by construction**. A caller reusing a result struct, or one whose hit count lands on non-zero
stack residue, is handed a count over memory nothing wrote: the #213 shape, where a garbage count
sized a 34 GB array.

With `sceSaveDataTransferringMountPs4` (`RjMlsR8EXrw`, fixed in #2208) these are the **only two**
PS4-namespace exports `libSceSaveData` has across all 275 PS5 3.20 libraries, so this closes the
pair. Leaving one registered is precisely the state that reads as covered.

## The answer is derived, not chosen

prosper has **no PS4 save-data store at all** — both its save areas are PS5-side
(`PROSPER_SAVEDATA_DIR` → save-data-memory, `PROSPER_SAVE0` → the mounted `/savedata0`) and no local
dump carries a PS4 save area. So a search over PS4 save data honestly finds nothing:
`SCE_SAVE_DATA_ERROR_NOT_FOUND` (`0x809F0008`), same facility and same answer a search of a
nonexistent save returns. **Local inventory answering, not a hardcoded refusal.**

**Nothing is written to the result, deliberately.** `SCE_OK` with an explicitly-zeroed hit count
would also be defensible — but only with the argument layout established from live evidence, and it
is not. Inventing a written result is the exact mirror of the defect being fixed, and it is the more
tempting mistake because it looks more helpful.

## Verified rather than taken from the issue

```
NID -> name    PS5-3.20_Libs/libSceSaveData.native.c:266 -> sceSaveDataDirNameSearchPs4
unregistered   0 occurrences of X4MYzukPc3g in hle_service.cpp before this change
imported by    nid_census over the local dumps, listed as UNREGISTERED:
                 PPSA25009 Blue Prince     1
                 PPSA24651 The Messenger   1
                 PPSA13579 Blasphemous 2   1
                 PPSA17942 / PPSA02664 / PPSA15552   0
```

## Test

Four arms in `test_false_success_nids.cpp`, in the block's existing style: **registered** ·
**reports unavailable** (kills the dispatcher's `return 0` *and* a hand-written `return 0` stub) ·
**negative as int32** — not merely non-zero, because guest sites gate with `test eax,eax; js` and
`return 1` would reinstate the bug with a non-zero check green · **writes nothing**.

The result buffer is **poisoned with `0x5A` rather than zeroed**, and that is what makes the last arm
mean anything: the mounts block above zeroes its result, so its "untouched" assertion cannot
distinguish a handler that wrote zeros from one that wrote nothing. `0x5A` can.

A fifth arm locks the two PS4-namespace entry points to the same answer — both derive from the same
local-inventory fact, so a title's behaviour must not depend on which one it happened to call.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

**Mutation-verified**: removing the registration fails the arm
(`[FAIL] sceSaveDataDirNameSearchPs4 is registered`). Reverted and re-run green.

## Not claimed

`CONFIDENCE: HIGH` that success is wrong here (it is `SCE_OK` over an unwritten out-struct by
construction). `MED` on `NOT_FOUND` being the precise firmware errno. `LOW` on the argument layout —
nothing is assumed about it because nothing is read or written.

Not observed being **called** at any boot depth reached so far; the census above is static, so treat
reachability as an upper bound.

Fixes #2210
