### PR TITLE
tools: give nid_census the loader's real link set, not a tree scan

### DIFF
--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -101,11 +101,26 @@ std::vector<std::string> discover_extra_plugin_modules(
 
 namespace prosper {
 
-bool boot_program(const std::string& d, Program& p, std::string* err,
-                  const std::function<void()>& after_hle_registered) {
-    auto fail = [&](const std::string& m) { if (err) *err = m; return false; };
-
-    // libc.prx loaded last => its init_array runs first (deepest dependency), before eboot's entry.
+// The loader's ACTUAL link set, exposed so it has exactly one definition (#2199).
+//
+// nid_census used to build its own module set by scanning the file tree, and the two differed in
+// ways that silently removed rows from its report: only Media/Plugins is auto-discovered, .sprx is
+// never auto-linked, sce_module contributes exactly two named files, and modules whose file is
+// absent or that the linker refuses are dropped. The census excludes any import satisfied by a
+// SIBLING module's export -- sound only if the sibling set matches what the loader links. Where the
+// tool's set was larger, it excluded a binding that in fact falls to the dispatcher's `return 0` at
+// runtime, i.e. a FALSE ABSENCE from a report whose whole purpose is to list what reaches the
+// dispatcher. A missing row looks like nothing at all.
+//
+// Split out of boot_program() as a pure prefix: it depends only on `d`, has no early exit, and
+// boot_program now calls it, so the two cannot drift. Note it PRINTS while it works (auto-link and
+// case-correction lines) -- that output is part of the loader's existing behaviour and is now also
+// visible to any other caller.
+std::vector<LinkInput> boot_link_inputs(const std::string& d, bool verbose) {
+    // `verbose` exists only so a TOOL can call this without corrupting its own stdout: the
+    // four prints below are the loader's, and nid_census --tsv writes machine-readable rows to
+    // the same stream. boot_program passes true, so loader output is byte-identical (#2199).
+    const auto say = [&](auto&&... args) { if (verbose) printf(args...); };
     std::vector<LinkInput> in = {
         { d + "/eboot.bin", BOOT_EBOOT },
         { d + "/Media/Modules/Il2cppUserAssemblies.prx", BOOT_IL2CPP },
@@ -170,12 +185,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         unsigned slot = 0;
         for (const auto& path : extra) {
             if (slot >= BOOT_PLUGIN_AUTO_SLOTS) {
-                printf("plugin auto-link: no free base slot for %s (max %u) — NOT linked\n",
+                say("plugin auto-link: no free base slot for %s (max %u) — NOT linked\n",
                        path.c_str(), BOOT_PLUGIN_AUTO_SLOTS);
                 continue;
             }
             const uint64_t base = BOOT_PLUGIN_AUTO_BASE + (uint64_t)slot * BOOT_PLUGIN_AUTO_STRIDE;
-            printf("plugin auto-link: %s @ 0x%llx\n", path.c_str(), (unsigned long long)base);
+            say("plugin auto-link: %s @ 0x%llx\n", path.c_str(), (unsigned long long)base);
             // skip_on_export_collision: never introduce a duplicate NID export. A title can ship two
             // builds of the same library (Evergate's libfmod.prx + libfmodL.prx export identical
             // NIDs); linking both would run two init_arrays and make dlsym answer differently per
@@ -198,12 +213,21 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     for (size_t i = in.size(); i-- > 1; ) {
         std::string resolved = resolve_host_path_case(in[i].path);
         if (resolved != in[i].path) {
-            printf("module path case-corrected: %s -> %s\n", in[i].path.c_str(), resolved.c_str());
+            say("module path case-corrected: %s -> %s\n", in[i].path.c_str(), resolved.c_str());
             in[i].path = std::move(resolved);
         }
         if (FILE* f = fopen(in[i].path.c_str(), "rb")) fclose(f);
-        else { printf("skipping absent module: %s\n", in[i].path.c_str()); in.erase(in.begin() + (ptrdiff_t)i); }
+        else { say("skipping absent module: %s\n", in[i].path.c_str()); in.erase(in.begin() + (ptrdiff_t)i); }
     }
+    return in;
+}
+
+bool boot_program(const std::string& d, Program& p, std::string* err,
+                  const std::function<void()>& after_hle_registered) {
+    auto fail = [&](const std::string& m) { if (err) *err = m; return false; };
+
+    // libc.prx loaded last => its init_array runs first (deepest dependency), before eboot's entry.
+    std::vector<LinkInput> in = boot_link_inputs(d);
 
     std::string e;
     if (!link_program(in, BOOT_STUB, p, &e)) return fail("link failed: " + e);

--- a/prosper/src/host/boot_program.hpp
+++ b/prosper/src/host/boot_program.hpp
@@ -153,6 +153,11 @@ inline bool guest_va_in_module_code(uint64_t a) {
 //
 // Available on every platform with a guest-execution substrate (currently Linux, Windows, and macOS).
 // Other platforms return false.
+// The loader's actual link set for a dump root (#2199). boot_program() calls this, so a second
+// consumer -- nid_census, whose cross-module exclusions are only sound over the set the loader
+// really links -- cannot drift from it. Prints auto-link and case-correction lines as it works.
+std::vector<LinkInput> boot_link_inputs(const std::string& dump_root, bool verbose = true);
+
 bool boot_program(const std::string& dump_root, Program& out, std::string* err,
                   const std::function<void()>& after_hle_registered = {});
 

--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -42,6 +42,7 @@
 // pairs directly. `--self-check` re-derives each pair with prosper's own `nid_hash` and reports
 // any disagreement: the name table is the instrument this tool reads the census through, so it
 // gets a control of its own rather than being trusted.
+#include "host/boot_program.hpp"
 #include "../../src/hle/dispatch.hpp"
 #include "../../src/hle/nid.hpp"
 #include "../../src/loader/linker.hpp"
@@ -132,15 +133,31 @@ bool is_module_file(const fs::path& p) {
     return ext == ".prx" || ext == ".sprx";
 }
 
+// The module set is now the LOADER'S link set, not a tree scan (#2199).
+//
+// This tool's central inference is that an import satisfied by a SIBLING module's export never
+// reaches the dispatcher, so it is excluded from the census. That is sound only if the sibling set
+// matches what the loader actually links. A tree scan is strictly larger -- it picks up .sprx (never
+// auto-linked), everything under sce_module/ (the loader takes exactly two named files), plugin
+// directories other than Media/Plugins/ (the only one auto-discovered), and modules whose file the
+// loader would drop or refuse. Every one of those made the tool exclude a binding that DOES fall to
+// the dispatcher's `return 0` at runtime.
+//
+// The direction of that error is what made it worth fixing: a FALSE ABSENCE. The row is missing
+// rather than wrong, so nothing in the output looks suspicious, in a report whose entire purpose is
+// to enumerate what reaches the dispatcher.
+//
+// A single regular file still means "just this module", which is how --lib and single-module runs
+// work; only a dump ROOT goes through the loader's set.
 std::vector<fs::path> collect_modules(const std::string& input) {
     std::vector<fs::path> out;
     std::error_code ec;
     const fs::path root(input);
     if (fs::is_regular_file(root, ec)) { out.push_back(root); return out; }
-    for (const auto& e : fs::recursive_directory_iterator(
-             root, fs::directory_options::skip_permission_denied, ec)) {
-        if (e.is_regular_file(ec) && is_module_file(e.path())) out.push_back(e.path());
-    }
+    // verbose=false: boot_link_inputs prints the loader's auto-link and case-correction lines, and
+    // --tsv writes machine-readable rows to the same stdout.
+    for (const auto& li : prosper::boot_link_inputs(input, /*verbose=*/false))
+        out.push_back(fs::path(li.path));
     std::sort(out.begin(), out.end());
     return out;
 }


### PR DESCRIPTION
`nid_census` built its module set by scanning the file tree, while the loader links a **fixed** set
constructed in `boot_program()`. The tool's central inference — *an import satisfied by a sibling
module's export never reaches the dispatcher, so it is excluded* — is sound only if the sibling set
matches what the loader actually links.

`boot_link_inputs()` is that set, split out of `boot_program()` as a pure prefix (depends only on the
dump root, no early exit) and now called by both. Two lists cannot drift when there is one list.

## The measured effect is the opposite of the issue's premise

#2199 predicted false **absences**: a NID satisfied by an unlinked module's export, excluded from the
census but reaching the dispatcher at runtime. Measured by diffing the NID lists before and after:

```
PPSA25009 Blue Prince     new=0   gone=30
PPSA13579 Blasphemous 2   new=0   gone=53
```

**Zero newly-visible NIDs.** That case does not occur in this corpus. What the change actually
removes is false **presences** — NIDs imported only by modules the loader never links, which
therefore never reach the dispatcher either. Dropping a module removes its *imports* as well as its
exports, and here that dominates.

I'm reporting it this way round rather than as the issue framed it, because the issue's stated
direction is what a reader would otherwise assume had been confirmed.

Arguably it's the more useful correction. This tool's output gets acted on — I used it twice today to
decide blast radius (#2292, #2210) — and a false positive sends someone implementing a NID no title
reaches, which is wasted work that looks fully justified.

| | before (tree scan) | after (loader set) |
| --- | --- | --- |
| PPSA25009 | 12 modules, 877 NIDs, 343 unregistered | **10, 834, 313** |
| PPSA13579 | 19 modules, 883 NIDs, 361 unregistered | **14, 818, 308** |
| PPSA24651 | 8 modules, 809 NIDs, 294 unregistered | **7, 809, 294** |

The module deltas reconcile **exactly** against the loader's rules — dropped = `.sprx` (never
auto-linked) + `sce_module` entries beyond the two it names:

```
PPSA25009   2 .sprx + 0 extra sce_module = 2    (12 -> 10)
PPSA13579   1 .sprx + 4 extra sce_module = 5    (19 -> 14)
PPSA24651   1 .sprx + 0 extra sce_module = 1    ( 8 ->  7)
```

That the arithmetic closes on all three is the evidence the new set really is the loader's rules,
rather than merely a different set.

## A `verbose` flag, and why

`boot_link_inputs` prints as it works (auto-link, case-correction, absent-module lines).
`nid_census --tsv` writes machine-readable rows to the same stdout, so it passes `verbose=false`.
`boot_program` passes `true`, so **loader output is byte-identical**.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

The extraction's guard is the three tests that call `boot_program` and exercise the moved logic —
`plugin_autolink` (the auto-discovery this moves), `module_path_case` (the case resolution),
`guest_module_label` — all green, with `plugin_autolink`'s four discovery assertions **running**
rather than skipping (checked with `-V`).

The before/after is an A/B in one tree: `collect_modules` reverted to the tree scan, `nid_census`
relinked, measured; restored, relinked, measured.

## Risk

This splits a function on every title's boot path. The split is mechanical — the extracted region is
a contiguous prefix that depends only on `d`, contains no `return`, and produces exactly one value —
and `boot_program` now calls it in the same place with the same argument, so the linked set and its
**order** are unchanged. Order matters here (init runs in reverse link order, which the surrounding
comments stress repeatedly), which is why the extraction preserves the sequence verbatim rather than
rebuilding it.

Fixes #2199
