### PR TITLE
libkernel: a destroyed pthread object must report EINVAL, not self-initialise

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -314,6 +314,32 @@ HLE(k_mutexattr_destroy)     { if (a0 && *(void**)a0) { auto* at = (GuestMutexAt
 namespace {
     inline bool pt_static_sentinel(void* v) { return (uintptr_t)v < 0x1000; }  // NULL/1/2/3... = static initializer
 
+    // A DESTROYED slot, distinct from an uninitialised one (#2170). FreeBSD writes its own poison
+    // through the caller's handle on *_destroy -- THR_MUTEX_DESTROYED (2), THR_COND_DESTROYED and
+    // THR_RWLOCK_DESTROYED (1) -- and every later operation on it returns EINVAL, loudly. prosper
+    // wrote NULL, which pt_static_sentinel above reads as "statically initialised, self-init me", so
+    // ensure_mutex/cond/rwlock SILENTLY MANUFACTURED a fresh, unheld object and the operation
+    // succeeded. Thread A holds rwlock R, thread B destroys it, A's next rdlock gets a brand-new
+    // lock and enters the critical section alongside A -- no error, no log line. Same silent-unsync
+    // class as #2012, through a different door.
+    //
+    // FreeBSD's own poison values cannot be reused as-is: 1 and 2 are both below the 0x1000
+    // threshold, so pt_static_sentinel swallows them exactly as it swallowed NULL. This needs a
+    // value of its own. Sub-page so it can never be mistaken for a real object pointer, and not
+    // 0/1/2/3 so it cannot collide with an initializer the guest legitimately writes.
+    inline constexpr uintptr_t kPtDestroyed = 0xDEA;
+    inline bool pt_destroyed_sentinel(void* v) { return (uintptr_t)v == kPtDestroyed; }
+
+    // Loud, because this is a BEHAVIOUR CHANGE: the operation used to succeed. A guest that
+    // use-after-destroys is buggy, but it was buggy silently, and a title that somehow depended on
+    // the old self-init must announce itself rather than fail somewhere else later.
+    inline void pt_report_destroyed(const char* what) {
+        static std::atomic<unsigned> seen{0};
+        if (seen.fetch_add(1) < 16)
+            fprintf(stderr, "[pthread] use-after-destroy on a %s: refused with EINVAL "
+                            "(it used to self-initialise a fresh object and succeed) -- #2170\n", what);
+    }
+
     struct GuestCondState {
         int32_t clock_id = 0;
         uint64_t generation = 0;
@@ -409,6 +435,7 @@ namespace {
         void** slot = (void**)(uintptr_t)slot_addr;
         void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
         if (!pt_static_sentinel(cur)) return (pthread_mutex_t*)cur;
+        if (pt_destroyed_sentinel(cur)) { pt_report_destroyed("mutex"); return nullptr; }
         auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t));
         pthread_mutexattr_t at; pthread_mutexattr_init(&at);
 #ifdef _WIN32
@@ -438,6 +465,7 @@ namespace {
         void** slot = (void**)(uintptr_t)slot_addr;
         void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
         if (!pt_static_sentinel(cur)) return (pthread_cond_t*)cur;
+        if (pt_destroyed_sentinel(cur)) { pt_report_destroyed("condition variable"); return nullptr; }
         auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t));
         if (!c) return nullptr;
         if (pthread_cond_init(c, nullptr) != 0) { free(c); return nullptr; }
@@ -506,6 +534,7 @@ namespace {
         void** slot = (void**)(uintptr_t)slot_addr;
         void* cur = __atomic_load_n(slot, __ATOMIC_ACQUIRE);
         if (!pt_static_sentinel(cur)) return (GuestRwlock*)cur;
+        if (pt_destroyed_sentinel(cur)) { pt_report_destroyed("rwlock"); return nullptr; }
         auto* g = guest_rwlock_create();
         if (!g) return nullptr;
         if (__atomic_compare_exchange_n(slot, &cur, (void*)g, false,
@@ -611,7 +640,7 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
 // corpus can currently settle either way — a title observed testing a Destroy result would.
 HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); retire_sync_object(m, SyncObjectKind::Mutex,
-                                    [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } if (a0) *(void**)a0 = nullptr; return 0; }
+                                    [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } if (a0) *(void**)a0 = (void*)kPtDestroyed; return 0; }   // #2170: destroyed != uninitialised
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -909,7 +938,7 @@ HLE(k_cond_destroy) {
         retire_sync_object(cond, SyncObjectKind::Cond,
                            [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); });
     }
-    if (a0) *(void**)a0 = nullptr;
+    if (a0) *(void**)a0 = (void*)kPtDestroyed;   // #2170: destroyed != uninitialised
     return 0;
 }
 HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_signal(c); } return 0; }
@@ -971,7 +1000,7 @@ HLE(k_rwlock_init) {
 HLE(k_rwlock_destroy) {
     if (a0 && !pt_static_sentinel(*(void**)a0)) retire_sync_object(*(void**)a0, SyncObjectKind::Rwlock,
             [](void* p) { auto* g = (GuestRwlock*)p; pthread_rwlock_destroy(&g->rw); g->~GuestRwlock(); });
-    if (a0) *(void**)a0 = nullptr;
+    if (a0) *(void**)a0 = (void*)kPtDestroyed;   // #2170: destroyed != uninitialised
     return 0;
 }
 // An UNMATCHED unlock must never reach the host lock (#2012).

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -210,6 +210,57 @@ int main() {
         }
     }
 
+    // ===== use-after-destroy is EINVAL, not a silently fresh object (#2170) ====================
+    // FreeBSD writes a DESTROYED poison through the caller's handle and every later operation on it
+    // returns EINVAL. prosper wrote NULL, which pt_static_sentinel reads as "statically initialised,
+    // self-init me" -- so ensure_mutex/cond/rwlock manufactured a brand-new UNHELD object and the
+    // operation SUCCEEDED. Thread A holds rwlock R, thread B destroys it, A's next rdlock gets a
+    // fresh lock and enters the critical section alongside A. No error, no log line.
+    //
+    // Each arm below is destroy-then-USE. A test that only checked destroy's own return value could
+    // not see this at all: destroy returned 0 before and returns 0 now.
+    {
+        struct { const char* init; const char* destroy; const char* use; const char* what; } objs[] = {
+            { "scePthreadMutexInit",  "scePthreadMutexDestroy",  "scePthreadMutexLock",   "mutex"  },
+            { "scePthreadRwlockInit", "scePthreadRwlockDestroy", "scePthreadRwlockRdlock","rwlock" },
+        };
+        for (const auto& o : objs) {
+            auto init = Hle::lookup(nid_hash(o.init));
+            auto destroy = Hle::lookup(nid_hash(o.destroy));
+            auto use = Hle::lookup(nid_hash(o.use));
+            char msg[220];
+            snprintf(msg, sizeof msg, "%s / %s / %s are registered", o.init, o.destroy, o.use);
+            CHECK(init && destroy && use, msg);
+            if (!init || !destroy || !use) continue;
+
+            alignas(16) uint8_t slot[32]{};
+            const uint64_t h = (uint64_t)(uintptr_t)slot;
+            snprintf(msg, sizeof msg, "a guest %s initialises", o.what);
+            CHECK(init(h, 0, 0, 0, 0, 0) == 0, msg);
+
+            // Positive control, and it is the arm that stops "reject everything" from passing: the
+            // object must WORK before it is destroyed. Without it, an ensure_* broken to always
+            // return nullptr would satisfy every assertion below.
+            snprintf(msg, sizeof msg, "the %s is usable before destroy", o.what);
+            CHECK(use(h, 0, 0, 0, 0, 0) == 0, msg);
+
+            CHECK(destroy(h, 0, 0, 0, 0, 0) == 0, "destroy succeeds");
+            // THE BUG: this used to return 0, having silently built a fresh unheld object.
+            snprintf(msg, sizeof msg,
+                     "using a destroyed %s reports encoded EINVAL rather than self-initialising",
+                     o.what);
+            CHECK(use(h, 0, 0, 0, 0, 0) == 0x80020016ull, msg);
+
+            // The interaction #2170 flags: re-Init on a destroyed slot must be ACCEPTED. A poison
+            // that made the slot permanently unusable would break every guest that reuses storage.
+            snprintf(msg, sizeof msg, "a destroyed %s slot can be re-initialised", o.what);
+            CHECK(init(h, 0, 0, 0, 0, 0) == 0, msg);
+            snprintf(msg, sizeof msg, "the re-initialised %s works again", o.what);
+            CHECK(use(h, 0, 0, 0, 0, 0) == 0, msg);
+            destroy(h, 0, 0, 0, 0, 0);
+        }
+    }
+
     // ---- behavioral: scePthreadMutexTimedlock timeout --------------------------------------
     {
         auto mtx_init = Hle::lookup(nid_hash("scePthreadMutexInit"));

--- a/prosper/tests/test_sync_destroy_lifetime.cpp
+++ b/prosper/tests/test_sync_destroy_lifetime.cpp
@@ -158,7 +158,16 @@ int main() {
           "precondition: the reader is parked INSIDE k_rwlock_rdlock on this object");
 
     call(RWdes, (uint64_t)(uintptr_t)&slot_a);             // the guest bug: destroy under the waiter
-    CHECK(slot_a == nullptr, "Destroy cleared the guest slot (unchanged behaviour)");
+    // #2170 changed the VALUE written here from NULL to the DESTROYED sentinel, so this waypoint
+    // now asserts the PROPERTY it always meant rather than the literal it happened to be: after
+    // destroy the guest can no longer reach the object through its own slot.
+    //
+    // The property is strictly better served than before. Under NULL, the next operation on this
+    // slot self-initialised a brand-new unheld rwlock and SUCCEEDED -- so "the guest cannot reach
+    // the object" was true while "the guest gets a working lock it should not have" was also true.
+    CHECK(slot_a != parked_object, "Destroy detached the guest slot from the object");
+    CHECK(call(RWrd, (uint64_t)(uintptr_t)&slot_a) != 0,
+          "a destroyed slot reports an error instead of self-initialising a fresh rwlock (#2170)");
 
     void* slot_b = nullptr;
     call(RWinit, (uint64_t)(uintptr_t)&slot_b);
@@ -169,7 +178,7 @@ int main() {
     CHECK(slot_b != parked_object,
           "a new rwlock does not alias the object a thread is parked in");
 
-    // The destroy cleared slot A, so the guest can no longer reach the object it is holding — but
+    // The destroy poisoned slot A, so the guest can no longer reach the object it is holding — but
     // the object itself must still be a live rwlock. Reach it through a slot holding the same
     // pointer (which is exactly what an in-flight handler holds) and release the write hold: the
     // parked reader must then wake. Under the fix this is an ordinary operation on a retired object;


### PR DESCRIPTION
FreeBSD writes a **DESTROYED poison** through the caller's handle on `*_destroy`, and every later
operation on that slot returns `EINVAL` — loudly. prosper wrote **`NULL`**, which
`pt_static_sentinel` reads as *"statically initialised, self-init me"*, so `ensure_mutex` /
`ensure_cond` / `ensure_rwlock` silently **manufactured a brand-new, unheld object** and the
operation **succeeded**.

The failure it allows:

> Thread A write-locks rwlock `R`. Thread B destroys `R` (a guest bug, but one FreeBSD contains).
> A's next `rdlock` self-initialises a **fresh** rwlock and returns immediately — so two threads are
> inside the critical section, each believing they hold the same lock. No error, no log line.

Same silent-unsync class as #2012, arriving through a different door.

## Why FreeBSD's own poison will not do

`THR_MUTEX_DESTROYED` is `2`, `THR_{COND,RWLOCK}_DESTROYED` is `1` — and **both are below
`pt_static_sentinel`'s `0x1000` threshold**, so storing them would be swallowed exactly as `NULL`
was. The destroyed state needs an encoding of its own:

```cpp
inline constexpr uintptr_t kPtDestroyed = 0xDEA;
```

Sub-page, so it can never be mistaken for a real object pointer; and not `0/1/2/3`, so it cannot
collide with an initializer a guest legitimately writes.

Checked before the self-init path in the three `ensure_*` functions, which return `nullptr` — and
every caller already maps that to `0x16`, encoded by the Sony alias and bare for the POSIX spelling.
The #1984 split is **inherited rather than re-implemented**.

**Only three objects were affected.** `ensure_sem` and `ensure_barrier` never self-init (they return
`nullptr` for any sentinel), so semaphores and barriers already failed correctly and are untouched.

The rejection **logs**, capped, because this is a behaviour change: the operation used to succeed. A
guest that use-after-destroys is buggy, but it was buggy *silently*, and a title that somehow
depended on the old self-init must announce itself rather than fail somewhere else later.

## Tests

Each arm is **destroy-then-use**. A test that only checked `destroy`'s own return value could not see
this defect at all — `destroy` returned 0 before and returns 0 now.

| arm | why it is there |
| --- | --- |
| the object is usable **before** destroy | **positive control** |
| using it after destroy → `0x80020016` | the bug |
| the slot can be **re-initialised** | the interaction #2170 flags |
| and works again after re-init | |

The positive control is what stops *"reject everything"* from passing: an `ensure_*` broken to always
return `nullptr` would satisfy every other assertion. Re-init matters because a poison that made a
slot permanently unusable would break every guest that reuses storage — `k_mutex_init` never reads
the slot, so it overwrites the poison, and the arm proves it rather than assuming it.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Nothing regressed, which is the load-bearing part here: many tests in the suite exercise these
destroy paths.

**Mutation-verified**: reverting the mutex destroy to write `nullptr` fails exactly the
*"reports encoded EINVAL rather than self-initialising"* arm. Reverted and re-run green.

## Not claimed

`CONFIDENCE: HIGH` on the divergence — both sides are a plain read of the code. **Not observed in any
title**: this closes a class, it does not fix a symptom. The behaviour change is therefore
unexercised in the corpus as far as anyone has measured, which is why the rejection is loud rather
than silent.

Fixes #2170
