### PR TITLE
agc: the six remaining packet patchers must probe writability before touching cmd

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -722,11 +722,22 @@ HLE(agc_dcb_set_predication) {  // sceAgcDcbSetPredication(dcb, 1, op, 1, cond_a
     cmd[3] = (uint32_t)a2;
     return (uint64_t)(uintptr_t)cmd;
 }
+// #2157: every patcher below dereferences a caller-supplied `cmd` behind nothing but a null check,
+// and each reads cmd[0] inside patch_check / dma_patch_ready before anything validates the pointer.
+// patch_target_writable (landed by #1650) answers from the DCB ring registry first -- a range
+// compare, no syscall -- and only probes the OS on a miss, so these families hit the registry too.
+//
+// The spans below are the dwords each handler actually TOUCHES, not the packet's nominal length.
+// Two of them have two packet shapes, so they probe the header span first and re-probe before
+// reaching the extended tail: a packet at the end of a mapping otherwise passes the header check
+// and faults on the store, which is the sharper half of this issue.
 HLE(agc_set_packet_predication) {  // sceAgcSetPacketPredication(packet, ...)
     // Marks an already-built packet as participating in the enclosing predication window. For our
     // R_JUMP encoding that is payload[3] (cmd[4]). Header-verified like the other packet patchers —
     // a different packet kind means the RE drifted, so refuse loudly rather than corrupt the stream.
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    // Writes cmd[4], five dwords in, after validating cmd[0] (#2157).
+    if (!patch_target_writable(a0, 5 * sizeof(uint32_t), "SetPacketPredication")) return 0;
     if (!patch_check(cmd, R_JUMP, "SetPacketPredication")) return 0;
     cmd[4] = 1;
     return 0;
@@ -893,12 +904,14 @@ static bool dma_patch_ready(uint32_t* cmd, const char* who) {
 }
 HLE(agc_patch_dma_data_dst) {  // (cmd, address)
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 3 * sizeof(uint32_t), "DmaDataPatchSetDst")) return 0;
     if (!dma_patch_ready(cmd, "DmaDataPatchSetDst")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
     // Defensive tolerance for the historical 9-dword shape, not a live path: with #1756 every packet
     // reachable here at runtime is a 7-dword one this file just built.
     uint32_t len = ((cmd[0] >> 16) & 0x3fffu) + 2;
-    if (len >= 9) {
+    // Re-probe: the tail is four dwords past what the header span covered (#2157).
+    if (len >= 9 && patch_target_writable(a0, 9 * sizeof(uint32_t), "DmaDataPatchSetDst")) {
         uint64_t build_pre = label_build_pre(a1, cmd[5]);
         cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
     }
@@ -906,6 +919,7 @@ HLE(agc_patch_dma_data_dst) {  // (cmd, address)
 }
 HLE(agc_patch_dma_data_src) {  // (cmd, addressOrImmediate)
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 5 * sizeof(uint32_t), "DmaDataPatchSetSrc")) return 0;
     if (!dma_patch_ready(cmd, "DmaDataPatchSetSrc")) return 0;
     cmd[3] = (uint32_t)(a1 & 0xffffffffu); cmd[4] = (uint32_t)(a1 >> 32u);
     return 0;
@@ -2815,6 +2829,7 @@ HLE(agc_patch_set_num_registers_uc) {
 // + offset arithmetic all agree).
 HLE(agc_patch_write_data_addr) {  // fPSCdQxgpSw (cmd, address): WriteData payload [1..2] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 4 * sizeof(uint32_t), "WriteDataPatchAddress")) return 0;
     if (!patch_check(cmd, R_WRITE_DATA, "WriteDataPatchAddress")) return 0;
     cmd[2] = (uint32_t)(a1 & 0xffffffffu); cmd[3] = (uint32_t)(a1 >> 32u);
     prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
@@ -2822,6 +2837,7 @@ HLE(agc_patch_write_data_addr) {  // fPSCdQxgpSw (cmd, address): WriteData paylo
 }
 HLE(agc_patch_wait_reg_mem_addr) {  // 3KDcnM3lrcU (cmd, address): WaitRegMem payload [0..1] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 3 * sizeof(uint32_t), "WaitRegMemPatchAddress")) return 0;
     if (!patch_check(cmd, R_WAIT_MEM_64, "WaitRegMemPatchAddress")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
     prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build
@@ -2829,6 +2845,7 @@ HLE(agc_patch_wait_reg_mem_addr) {  // 3KDcnM3lrcU (cmd, address): WaitRegMem pa
 }
 HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem payload [0..1] = address
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 4 * sizeof(uint32_t), "ReleaseMemPatchAddress")) return 0;
     if (!patch_check(cmd, R_RELEASE_MEM, "ReleaseMemPatchAddress")) return 0;
     cmd[1] = (uint32_t)(a1 & 0xffffffffu); cmd[2] = (uint32_t)(a1 >> 32u);
     uint32_t len = ((cmd[0] >> 16) & 0x3fffu) + 2;
@@ -2836,10 +2853,12 @@ HLE(agc_patch_release_mem_addr) {  // 0fWWK5uG9rQ (cmd, address): ReleaseMem pay
     // at runtime is one agc_cb_release_mem just built, i.e. 8 dwords, keeping only the high half;
     // the >= 9 arm is defensive tolerance for the historical shape, not a live path (a replayed
     // capture never re-enters the HLE — gpu_replay executes recorded dwords directly).
-    if (len >= 9) {
+    // Both tails reach cmd[7]/cmd[8], past the 4-dword header span probed above (#2157).
+    if (len >= 9 && patch_target_writable(a0, 9 * sizeof(uint32_t), "ReleaseMemPatchAddress")) {
         uint64_t build_pre = label_build_pre(a1, cmd[3] == 1 ? 4 : 8);
         cmd[7] = (uint32_t)build_pre; cmd[8] = (uint32_t)(build_pre >> 32);
-    } else if (len >= 8) {
+    } else if (len >= 8 && len < 9 &&
+               patch_target_writable(a0, 8 * sizeof(uint32_t), "ReleaseMemPatchAddress")) {
         cmd[7] = (uint32_t)(label_build_pre(a1, cmd[3] == 1 ? 4 : 8) >> 32);
     }
     prosper_fence_journal_record((uint64_t)(uintptr_t)cmd, a1);   // #312: target set post-build

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -294,6 +294,49 @@ int main() {
               "#1650: out-of-ring pointers DO reach the write probe — so arm1's zero-probe "
               "assertion measures the registry rather than a counter stuck at zero");
 
+        // Arm 4b — the SAME undereferenceable-pointer case, for the six patchers #1650 left
+        // behind (#2157): predication, the DMA dst/src pair, and the WriteData / WaitRegMem /
+        // ReleaseMem sync patchers. Each read cmd[0] inside its header check before anything
+        // validated the pointer, so on master this arm SIGSEGVs rather than failing.
+        //
+        // Two of them are the sharper ones and are why the spans are per-handler rather than one
+        // constant: SetPacketPredication validates cmd[0] and then writes **cmd[4]**, and
+        // ReleaseMem writes cmd[7]/cmd[8] on its long arm. A packet at the very end of a mapping
+        // passes a header-sized probe and faults on the store, so those re-probe before the tail.
+        {
+            const struct { const char* nid; const char* name; } late[] = {
+                { "w6Dj1VJt5qY", "SetPacketPredication"    },
+                { "IxYiarKlXxM", "DmaDataPatchSetDst"      },
+                { "cdDRpqcFGbU", "DmaDataPatchSetSrc"      },
+                { "fPSCdQxgpSw", "WriteDataPatchAddress"   },
+                { "3KDcnM3lrcU", "WaitRegMemPatchAddress"  },
+                { "0fWWK5uG9rQ", "ReleaseMemPatchAddress"  },
+            };
+            char log2[8192] = {0};
+            const bool captured2 = capture_stderr([&] {
+                for (const auto& l : late) {
+                    HleFn fn = Hle::lookup(l.nid);
+                    if (fn) fn(unmapped_addr, 0x5555555566666666ull, 0, 0, 0, 0);
+                }
+            }, log2, sizeof log2);
+            CHECK(captured2, "#2157: stderr capture around the late-patcher refusals worked");
+
+            // Reaching this line at all is the primary assertion: on master the cmd[0] read faults.
+            for (const auto& l : late) {
+                char msg[200];
+                snprintf(msg, sizeof msg, "#2157: %s is registered", l.name);
+                CHECK(Hle::lookup(l.nid) != nullptr, msg);
+                // Naming the call site matters as much as refusing: a shared message could not tell
+                // a reader WHICH patcher was handed the bad pointer, and these six are reached from
+                // different guest paths.
+                snprintf(msg, sizeof msg,
+                         "#2157: %s refuses an undereferenceable packet and names itself", l.name);
+                CHECK(strstr(log2, l.name) != nullptr, msg);
+            }
+            CHECK(strstr(log2, "is not writable guest memory") != nullptr,
+                  "#2157: the refusal is the writability probe, not an incidental header mismatch");
+        }
+
         // Arm 5 — the diagnostic budget is PER CALL SITE.
         //
         // It used to be a single 8-message counter shared by every patcher family in the


### PR DESCRIPTION
#1650 closed the mappedness gap on the `Set*RegsIndirect` patchers. **Six others still dereferenced a
caller-supplied `cmd` behind nothing but a null check**, each reading `cmd[0]` inside `patch_check` /
`dma_patch_ready` before anything validated the pointer: `SetPacketPredication`, the DmaData dst/src
pair, and the WriteData / WaitRegMem / ReleaseMem sync patchers.

All six now route through `patch_target_writable()` — the helper #1650 landed, which answers from the
DCB ring registry first (a range compare, no syscall) and probes the OS only on a miss. These
families build into the same rings, so they hit the registry and the per-call cost is a range
compare.

## Scale, stated so nobody over-prioritises it

**Materially smaller than #1650 was.** All six already called `patch_check` / `dma_patch_ready`, so
the *silent corruption* case — a mapped pointer that is not the expected packet — was caught and
logged before this change. What is closed here is the **unmapped** case, where the `cmd[0]` read
faults the host: a loud crash, not quiet corruption.

## The spans are per-handler, and that is the point

Each probe covers the dwords the handler actually **touches**, not the packet's nominal length. Two
are sharper than the rest, and a single header-sized probe would not have covered them:

| handler | why |
| --- | --- |
| `SetPacketPredication` | validates `cmd[0]`, then writes **`cmd[4]`** — five dwords in |
| `ReleaseMem` | writes **`cmd[7]`/`cmd[8]`** on its long arm |

A packet at the very end of a mapping passes a header-sized check and **faults on the store**. Both
variable-length handlers (DmaData dst, ReleaseMem) therefore probe the header span first and
**re-probe** before reaching the tail.

**Behaviour on a refused tail**: the header-span writes have already happened (that span *was*
writable), so the packet is patched but its #312 label snapshot is not. That is a degraded diagnostic
rather than a corrupted stream, and the refusal is logged with its call site. The alternative is the
fault this issue is about.

The `len >= 8` arm of ReleaseMem gained an explicit `len < 9` guard, so the else-if cannot now run
when the `>= 9` arm's probe refuses — without it a refused long arm would fall through into the short
one and write `cmd[7]` anyway.

## Test

Arm 4b in `test_agc_dcb.cpp`, extending #1650's existing refusal block and reusing its
`unmapped_addr = 0x800`: every one of the six is called with an undereferenceable pointer.

**Reaching the end of that arm is the primary assertion** — on master the `cmd[0]` read faults, so
the arm does not fail, it **SIGSEGVs**. On top of that, each refusal must **name its call site** (the
six are reached from different guest paths, and a shared message could not say which was handed the
bad pointer), and the log must contain `is not writable guest memory` so the refusal is the
writability probe rather than an incidental header mismatch.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

**Not verified locally**: `test_agc_dcb` is inside `CMakeLists.txt`'s `if(UNIX)` and does not build
on MinGW. Syntax-checked by hand (`g++ -fsyntax-only`, clean, status read without a pipe), and the
new arm's scope was checked programmatically against the block declaring `unmapped_addr`. The Linux
and macOS CI jobs execute it — as they should, since the last UNIX-only test I touched was caught red
there and not here.

Fixes #2157