### PR TITLE
tools(il2cpp): --sections, so objdump -d can disassemble the flattened module

### DIFF
--- a/prosper/tools/il2cpp/README.md
+++ b/prosper/tools/il2cpp/README.md
@@ -48,8 +48,25 @@ The image has program headers but **no section header table**, so `e_shoff`, `e_
 `il2cpp_prx_to_elf_header`). That is enough for binutils to *accept* the file — `objdump -f`,
 `objdump -p` and `objdump -T` all work, and `-T` is genuinely useful: it lists the module's Sony
 NID dynamic symbols. It is **not** enough for `objdump -d`, which disassembles sections and finds
-none; disassembly still needs `objdump -D -b binary -m i386:x86-64 --start-address=…`, or
-`tools/re/xref.py`. Synthesizing section headers from the PT_LOADs would fix that and is #2154.
+none.
+
+**`--sections` fixes that (#2154).** It synthesizes one section per `PT_LOAD` plus a `.shstrtab`,
+with `sh_addr == sh_offset == p_vaddr` — which follows directly from the flattening, so nothing is
+derived or guessed; each section is the segment restated in the form objdump reads. `objdump -d`
+then disassembles with real virtual addresses and resolves call targets, instead of the old
+`objdump -D -b binary -m i386:x86-64 --start-address=…` workaround that throws every
+program-header-derived address away.
+
+```
+python3 prx_to_elf.py <module>.prx out.elf --sections
+objdump -d --start-address=0x2140d0 --stop-address=0x214100 out.elf
+```
+
+It is **opt-in, and the default output is byte-identical** to what it was — verified on
+`Il2cppUserAssemblies.prx` with `cmp`, and asserted by `test_prx_to_elf.py`. Il2CppDumper reads
+program headers and the dynamic segment and does not need sections, but its ELF reader does consult
+them on some paths and that has not been re-run end to end, so the dump path is left untouched. Use
+`--sections` for disassembly; leave it off for a dump.
 
 ### Ruled out
 - **"binutils also needs `e_ident[EI_OSABI]`/`[EI_ABIVERSION]` cleared" (#2016's own note) — false.**

--- a/prosper/tools/il2cpp/prx_to_elf.py
+++ b/prosper/tools/il2cpp/prx_to_elf.py
@@ -1,15 +1,21 @@
 #!/usr/bin/env python3
 # prx_to_elf.py — flatten an unencrypted PS5 SELF/PRX into a loadable ET_DYN ELF
 # (p_offset == p_vaddr), the input Il2CppDumper needs. Usage:
-#   python3 prx_to_elf.py <in.prx> <out.elf>
+#   python3 prx_to_elf.py <in.prx> <out.elf> [--sections]
 # Then:
 #   printf '0\n0\n0\n' | dotnet Il2CppDumper.dll out.elf global-metadata.dat outdir
 # (answer "0" to the "dump file" prompt to force the registration auto-scan).
 # Produces dump.cs (method RVAs), script.json, il2cpp.h. Runtime addr of a method =
 # module_base (e.g. 0x440000000 for Il2CppUserAssemblies.prx) + its RVA.
+#
+# --sections synthesizes a section header table so `objdump -d` can disassemble the result (#2154).
+# OPT-IN, not the default: Il2CppDumper reads program headers and the dynamic segment and does not
+# need them, but its ELF reader does consult sections on some paths and I could not run it here, so
+# the default output is byte-for-byte what it was. Turn it on for disassembly, leave it off for a
+# dump.
 import struct, sys
 
-def main(src, dst):
+def main(src, dst, want_sections=False):
     f = open(src, "rb").read()
     nseg, = struct.unpack_from("<H", f, 0x18)
     segs = [struct.unpack_from("<QQQQ", f, 0x20 + i*32) for i in range(nseg)]
@@ -43,8 +49,58 @@ def main(src, dst):
     struct.pack_into("<H", buf, 0x3e, 0)       # e_shstrndx = SHN_UNDEF
     for i, p in enumerate(phdrs):              # p_offset := p_vaddr for every phdr
         struct.pack_into("<IIQQQQQQ", buf, 0x40+i*56, p[0], p[1], p[3], p[3], p[4], p[5], p[6], p[7])
+    if want_sections:
+        total = add_sections(buf, phdrs)
     open(dst, "wb").write(buf)
-    print("wrote %s size=%#x" % (dst, total))
+    print("wrote %s size=%#x%s" % (dst, total, " (+sections)" if want_sections else ""))
+
+# One SHT_PROGBITS section per PT_LOAD, plus .shstrtab, appended after the image (#2154).
+#
+# Without a section header table `objdump -f/-p/-T` work but `objdump -d` prints NOTHING: it
+# disassembles SECTIONS and there are none. The documented workaround throws the addresses away
+# (`objdump -D -b binary --start-address=...`), which defeats the point of flattening with
+# p_offset == p_vaddr -- file offset and virtual address are already the same number, and a section
+# table is what lets objdump use it.
+#
+# sh_addr == sh_offset == p_vaddr follows directly from that flattening, so nothing here is derived
+# or guessed; each section is the segment restated in the form objdump reads.
+def add_sections(buf, phdrs):
+    SHT_PROGBITS, SHT_NOBITS, SHT_STRTAB = 1, 8, 3
+    SHF_WRITE, SHF_ALLOC, SHF_EXECINSTR = 0x1, 0x2, 0x4
+    secs, names, blob = [], bytearray(b"\0"), None
+    def intern(nm):
+        off = len(names); names.extend(nm.encode() + b"\0"); return off
+    for i, p in enumerate(phdrs):
+        if p[0] != 1 or (p[5] == 0 and p[6] == 0):     # PT_LOAD carrying something
+            continue
+        x, w = bool(p[1] & 1), bool(p[1] & 2)
+        # A bss-only PT_LOAD is SHT_NOBITS so the file does not grow by p_memsz; everything else is
+        # PROGBITS over the bytes actually present.
+        bss = p[5] == 0
+        base = ".bss" if bss else (".text" if x else (".data" if w else ".rodata"))
+        flags = SHF_ALLOC | (SHF_EXECINSTR if x else 0) | (SHF_WRITE if w else 0)
+        secs.append((intern("%s%d" % (base, i)), SHT_NOBITS if bss else SHT_PROGBITS, flags,
+                     p[3], p[3], p[6] if bss else p[5], p[7] or 1))
+    # .shstrtab last, and it is a real file section, so it needs an offset inside the file.
+    shstr_name = intern(".shstrtab")
+    shstr_off = len(buf)
+    buf.extend(names)
+    sh_off = (len(buf) + 7) & ~7                       # 8-align the table itself
+    buf.extend(b"\0" * (sh_off - len(buf)))
+    # Index 0 is the mandatory all-zero SHN_UNDEF entry.
+    table = bytearray(struct.pack("<IIQQQQIIQQ", 0, 0, 0, 0, 0, 0, 0, 0, 0, 0))
+    for (nm, typ, flags, addr, off, size, align) in secs:
+        table.extend(struct.pack("<IIQQQQIIQQ", nm, typ, flags, addr, off, size, 0, 0, align, 0))
+    table.extend(struct.pack("<IIQQQQIIQQ", shstr_name, SHT_STRTAB, 0, 0,
+                             shstr_off, len(names), 0, 0, 1, 0))
+    buf.extend(table)
+    nsec = len(secs) + 2                               # + null + .shstrtab
+    struct.pack_into("<Q", buf, 0x28, sh_off)          # e_shoff
+    struct.pack_into("<H", buf, 0x3a, 64)              # e_shentsize (ELF64 section header)
+    struct.pack_into("<H", buf, 0x3c, nsec)            # e_shnum
+    struct.pack_into("<H", buf, 0x3e, nsec - 1)        # e_shstrndx = the .shstrtab we just wrote
+    return len(buf)
 
 if __name__ == "__main__":
-    main(sys.argv[1], sys.argv[2])
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    main(args[0], args[1], "--sections" in sys.argv[1:])

--- a/prosper/tools/il2cpp/test_prx_to_elf.py
+++ b/prosper/tools/il2cpp/test_prx_to_elf.py
@@ -229,6 +229,67 @@ def main():
             print("objdump arm: RAN and DISCRIMINATED — accepts the fixed header, "
                   "rejects the #2016 header")
 
+    # ---- --sections (#2154): objdump -d disassembles SECTIONS, and there were none -------------
+    #
+    # Without a section header table objdump -f/-p/-T all work and objdump -d prints NOTHING, which
+    # is the single most confusing failure this tool can produce: every other binutils command
+    # behaves, so the file looks fine.
+    sec = os.path.join(tmp, "synthetic-sections.elf")
+    proc_s = subprocess.run([sys.executable, TOOL, src, sec, "--sections"],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    check(proc_s.returncode == 0,
+          "prx_to_elf.py --sections failed: %s" % proc_s.stdout.decode("utf-8", "replace"),
+          "the flag being unrecognised or the synthesis throwing")
+    with open(sec, "rb") as fh:
+        sec_bytes = fh.read()
+
+    # THE SAFETY PROPERTY, and the reason --sections is opt-in: Il2CppDumper's input must be
+    # unchanged. A regression here is silent -- a dump that subtly differs is far worse than one
+    # that fails.
+    proc_d = subprocess.run([sys.executable, TOOL, src, dst],
+                            stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    with open(dst, "rb") as fh:
+        default_again = fh.read()
+    check(default_again == out and proc_d.returncode == 0,
+          "the DEFAULT output changed when --sections was added to the tool",
+          "synthesising sections unconditionally, which would alter Il2CppDumper's input")
+
+    check(u64(sec_bytes, E_SHOFF) != 0 and u16(sec_bytes, E_SHNUM) >= 3,
+          "--sections wrote no usable section table (e_shoff=%#x e_shnum=%d)"
+          % (u64(sec_bytes, E_SHOFF), u16(sec_bytes, E_SHNUM)),
+          "emitting headers without pointing the ELF header at them")
+    check(u16(sec_bytes, E_SHSTRNDX) == u16(sec_bytes, E_SHNUM) - 1,
+          "e_shstrndx (%d) does not name the last section, where .shstrtab is written"
+          % u16(sec_bytes, E_SHSTRNDX),
+          "an index off by one, which makes every section name garbage")
+
+    # The arm that matters, and it carries its own control: the SAME objdump -d on the
+    # SAME address range must print nothing for the sectionless file and instructions for this one.
+    # Without the control this asserts that objdump works, not that the sections do.
+    def objdump_d(path):
+        try:
+            r = subprocess.run(["objdump", "-d", path],
+                               stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        except OSError:
+            return None
+        return r.stdout
+    d_sec, d_plain = objdump_d(sec), objdump_d(dst)
+    if d_sec is None:
+        print("objdump -d arm: VOID — binutils not on PATH; the byte checks above are the gate")
+    else:
+        has_insns = b"Disassembly of section" in d_sec
+        plain_has = b"Disassembly of section" in d_plain
+        check(has_insns,
+              "objdump -d still disassembles nothing WITH --sections",
+              "sections that binutils does not accept as containing code")
+        if plain_has:
+            print("objdump -d arm: VOID — this binutils disassembles the sectionless file too, "
+                  "so the fixed file doing so discriminates nothing")
+        else:
+            print("objdump -d arm: RAN and DISCRIMINATED — disassembles with sections, "
+                  "prints nothing without them")
+    os.unlink(sec)
+
     for f in (src, dst, ctl):
         os.unlink(f)
     os.rmdir(tmp)


### PR DESCRIPTION
`prx_to_elf.py` produced an ELF with program headers and **no section header table**. binutils
*accepts* that — `objdump -f`, `-p` and `-T` all work — but **`objdump -d` disassembles sections,
finds none, and prints nothing at all.**

That is the most confusing failure this tool can produce, because every other binutils command
behaves and the file looks fine. The workaround people keep rediscovering,
`objdump -D -b binary -m i386:x86-64 --start-address=…`, throws away every program-header-derived
address and forces manual VA arithmetic on every lookup — which defeats the point of flattening with
`p_offset == p_vaddr` in the first place.

## What it does

`--sections` synthesizes one section per `PT_LOAD` plus a `.shstrtab`, with
`sh_addr == sh_offset == p_vaddr`. **Nothing there is derived or guessed**: that equality follows
directly from the flattening, so each section is the segment restated in the form objdump reads.
Flags come from `p_flags` (`ALLOC`, `+EXECINSTR` for `PF_X`, `+WRITE` for `PF_W`), and a bss-only
`PT_LOAD` (`p_filesz == 0`) is `SHT_NOBITS` so the file does not grow by `p_memsz`.

Measured on `PPSA24651`'s `Il2cppUserAssemblies.prx`:

| | `objdump -d --start-address=0x2140d0 --stop-address=0x214100` |
| --- | --- |
| before | *(nothing)* |
| after | real x86-64, with call targets as virtual addresses (`call 0x13dba0`) |

`0x2140d0` is the exact address the issue used. The section table costs **504 bytes** on a 45.6 MB
image.

## Opt-in, and the default is byte-identical

Il2CppDumper reads program headers and the dynamic segment and does not need sections, but its ELF
reader **does** consult them on some paths and I could not run it here. So the default output is
unchanged and this is a flag.

```
cmp <master's output> <this build's default output>   ->  identical
45,663,560 bytes both ways;  --sections is 45,664,064
```

The test asserts that property directly, because a regression there is **silent**: a dump that
subtly differs is far worse than one that fails.

## Tests

`test_prx_to_elf.py` gains a `--sections` arm in the file's existing style:

- the flag runs and writes a usable table (`e_shoff != 0`, `e_shnum >= 3`)
- `e_shstrndx` names the **last** section, where `.shstrtab` is written — an index off by one makes
  every section name garbage
- **the default output is unchanged**
- `objdump -d` disassembles **with** sections and prints nothing **without** them

That last arm **carries its own control**, which is the point: the same `objdump` on the same file
pair. Without the sectionless comparison it would assert that objdump works, not that the sections
do. Both objdump arms report `RAN and DISCRIMINATED` on this host.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0), binutils objdump on PATH
python prosper/tools/il2cpp/test_prx_to_elf.py -> PASS
  objdump arm:    RAN and DISCRIMINATED
  objdump -d arm: RAN and DISCRIMINATED
```

Generality: also run on `PS5Util.prx` (a much smaller module) — sections synthesized correctly there
too. `objdump -f` / `-T` on the sectioned file still behave (dynamic symbols readable), so the
pre-existing capabilities did not regress.

**Not verified**: an end-to-end Il2CppDumper run. That is precisely why the flag is opt-in rather
than the default.

README updated with the new usage and the opt-in reasoning.

Fixes #2154