### PR TITLE
libkernel: claim the sync slot atomically, and clamp the quarantine window

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -333,6 +333,24 @@ namespace {
     // Loud, because this is a BEHAVIOUR CHANGE: the operation used to succeed. A guest that
     // use-after-destroys is buggy, but it was buggy silently, and a title that somehow depended on
     // the old self-init must announce itself rather than fail somewhere else later.
+    // Take the slot ATOMICALLY and return whatever it held (#2176). Two threads racing destroy on
+    // the same slot both used to read the non-sentinel pointer before either cleared it, and both
+    // handed the SAME storage to retire_sync_object. Before #2042 that double-freed immediately;
+    // with the quarantine it double-frees ~30 s later from an unrelated call, which is strictly
+    // harder to diagnose -- it cuts against the very argument the quarantine was made for.
+    //
+    // The exchange installs the destroyed sentinel, so it also closes the second edge in the same
+    // move: every handler used to retire BEFORE clearing the slot, leaving a window where another
+    // thread could still resolve the object out of it after its quarantine clock had started. Now
+    // the object is unreachable the instant the clock starts, and exactly one racer gets a
+    // non-sentinel pointer back to retire.
+    inline void* pt_claim_slot(uint64_t slot_addr) {
+        if (!slot_addr) return nullptr;
+        void* prev = __atomic_exchange_n((void**)(uintptr_t)slot_addr,
+                                         (void*)kPtDestroyed, __ATOMIC_ACQ_REL);
+        return pt_static_sentinel(prev) ? nullptr : prev;
+    }
+
     inline void pt_report_destroyed(const char* what) {
         static std::atomic<unsigned> seen{0};
         if (seen.fetch_add(1) < 16)
@@ -639,8 +657,10 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // CONFIDENCE: HIGH on the table above (read out of libthr and libc, the guest's own platform);
 // CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
 // corpus can currently settle either way — a title observed testing a Destroy result would.
-HLE(k_mutex_destroy) { if (a0 && !pt_static_sentinel(*(void**)a0)) { auto* m = (pthread_mutex_t*)*(void**)a0; guest_mutex_unregister(m); retire_sync_object(m, SyncObjectKind::Mutex,
-                                    [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } if (a0) *(void**)a0 = (void*)kPtDestroyed; return 0; }   // #2170: destroyed != uninitialised
+HLE(k_mutex_destroy) { auto* m = (pthread_mutex_t*)pt_claim_slot(a0);   // #2176: claim, then retire
+    if (m) { guest_mutex_unregister(m); retire_sync_object(m, SyncObjectKind::Mutex,
+                                    [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); }
+    return 0; }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -928,8 +948,7 @@ SCE_PTHREAD_ALIAS(k_sce_condattr_getclock,     k_condattr_getclock)
 SCE_PTHREAD_ALIAS(k_sce_condattr_setpshared,   k_condattr_setpshared)
 SCE_PTHREAD_ALIAS(k_sce_condattr_getpshared,   k_condattr_getpshared)
 HLE(k_cond_destroy) {
-    if (a0 && !pt_static_sentinel(*(void**)a0)) {
-        auto* cond = (pthread_cond_t*)*(void**)a0;
+    if (auto* cond = (pthread_cond_t*)pt_claim_slot(a0)) {   // #2176: claim, then retire
         // Quarantined, not freed, and the host `pthread_cond_destroy` runs at reclaim rather than
         // here — see the contract block above k_mutex_destroy and sync_retire.hpp (#2042). A thread
         // parked in interruptible_cond_wait is inside this very object.
@@ -938,7 +957,6 @@ HLE(k_cond_destroy) {
         retire_sync_object(cond, SyncObjectKind::Cond,
                            [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); });
     }
-    if (a0) *(void**)a0 = (void*)kPtDestroyed;   // #2170: destroyed != uninitialised
     return 0;
 }
 HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_signal(c); } return 0; }
@@ -998,9 +1016,9 @@ HLE(k_rwlock_init) {
 // EBUSY refusal would be a divergence rather than a fix. See the contract table above
 // k_mutex_destroy. The return value, and the cleared slot, are exactly what they were before.
 HLE(k_rwlock_destroy) {
-    if (a0 && !pt_static_sentinel(*(void**)a0)) retire_sync_object(*(void**)a0, SyncObjectKind::Rwlock,
-            [](void* p) { auto* g = (GuestRwlock*)p; pthread_rwlock_destroy(&g->rw); g->~GuestRwlock(); });
-    if (a0) *(void**)a0 = (void*)kPtDestroyed;   // #2170: destroyed != uninitialised
+    if (void* g = pt_claim_slot(a0))            // #2176: claim, then retire
+        retire_sync_object(g, SyncObjectKind::Rwlock,
+            [](void* p) { auto* r = (GuestRwlock*)p; pthread_rwlock_destroy(&r->rw); r->~GuestRwlock(); });
     return 0;
 }
 // An UNMATCHED unlock must never reach the host lock (#2012).
@@ -2468,7 +2486,7 @@ HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = s
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 // Quarantined, not freed, and `sem_destroy` deferred to reclaim — a thread parked in `sem_wait` is
 // inside this object. See the contract block above k_mutex_destroy and sync_retire.hpp (#2042).
-HLE(k_sem_destroy)   { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Sem, [](void* p) { sem_destroy((sem_t*)p); }); *slot = nullptr; } } return 0; }
+HLE(k_sem_destroy)   { if (void* s = pt_claim_slot(a0)) retire_sync_object(s, SyncObjectKind::Sem, [](void* p) { sem_destroy((sem_t*)p); }); return 0; }   // #2176
 // The Sony spellings of the fallible semaphore entry points (#2178). SemDestroy is absent because
 // it returns 0 unconditionally — #2042 made it quarantine its object rather than free it, which
 // changes what it does but not what it reports, so it still needs no alias. NOTE that the POSIX
@@ -2521,7 +2539,7 @@ HLE(k_barrier_init)    { if (!a0 || a2 == 0) return prosper::hle::kSceKernelErro
 HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return prosper::hle::kSceKernelErrorEINVAL; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : sce_pthread_rc(fbsd_errno(rc)); }
 // Quarantined, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the
 // object, the widest window in the family. See the contract block above k_mutex_destroy.
-HLE(k_barrier_destroy) { if (a0) { void** slot = (void**)(uintptr_t)a0; if (!pt_static_sentinel(*slot)) { retire_sync_object(*slot, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); }); *slot = nullptr; } } return 0; }
+HLE(k_barrier_destroy) { if (void* b = pt_claim_slot(a0)) retire_sync_object(b, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); }); return 0; }   // #2176
 HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
     // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
     // same class of silent hang root-caused for wait_on_address, hle_kernel_mem.cpp). Sony

--- a/prosper/src/hle/sync_retire.cpp
+++ b/prosper/src/hle/sync_retire.cpp
@@ -57,7 +57,14 @@ namespace {
             char* end = nullptr;
             const double v = strtod(e, &end);
             if (end == e || *end != '\0' || !(v >= 0.0)) return 30.0;   // !(v>=0) also rejects NaN
-            return v;
+            // Clamp the upper end too (#2176). strtod accepts `inf` and `1e300`, and both
+            // overflow the duration_cast to steady_clock::duration below -- undefined
+            // behaviour, even though the direction observed happens to be the safe one
+            // (nothing is ever reclaimed). An hour is far past any window that could be
+            // deliberate: the default is 30 s, and the guard's whole premise is bounding the
+            // retained set by RATE, which a 3,600 s window stops doing usefully anyway.
+            constexpr double kMaxWindowSeconds = 3600.0;
+            return v > kMaxWindowSeconds ? kMaxWindowSeconds : v;
         }();
         return seconds;
     }

--- a/prosper/tests/test_posix_sem.cpp
+++ b/prosper/tests/test_posix_sem.cpp
@@ -36,8 +36,15 @@ int main() {
     CHECK(post((uint64_t)sem, 0, 0, 0, 0, 0) == 0, "sem_post wakes one waiter");
     consumer.join();
     CHECK(released.load(std::memory_order_acquire), "blocked waiter resumes successfully");
-    CHECK(destroy((uint64_t)sem, 0, 0, 0, 0, 0) == 0 && *(void**)sem == nullptr,
-          "semaphore destroys and clears its guest handle");
+    // The PROPERTY, not the literal: #2170 gave destroyed slots their own sentinel and #2176 routed
+    // every destroy through one atomic claim, so this now holds kPtDestroyed rather than NULL. The
+    // guest cannot tell the two apart -- ensure_sem refuses any sentinel with EINVAL, and sem_init
+    // overwrites the slot unconditionally either way -- but the old assertion pinned the value.
+    void* const sem_before = *(void**)sem;
+    CHECK(destroy((uint64_t)sem, 0, 0, 0, 0, 0) == 0,
+          "semaphore destroys without reporting failure");
+    CHECK(*(void**)sem != sem_before && (uintptr_t)*(void**)sem < 0x1000,
+          "semaphore destroy detaches the guest handle from the object (a sentinel, not a pointer)");
 
     std::printf(failures ? "== FAIL: %d ==\n" : "== PASS ==\n", failures);
     return failures ? 1 : 0;

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -16,6 +16,7 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/sce_errno.hpp"
+#include "../src/hle/sync_retire.hpp"
 
 #include <cerrno>
 #include <chrono>
@@ -258,6 +259,46 @@ int main() {
             snprintf(msg, sizeof msg, "the re-initialised %s works again", o.what);
             CHECK(use(h, 0, 0, 0, 0, 0) == 0, msg);
             destroy(h, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ===== destroy CLAIMS the slot, so a double destroy retires once (#2176) ==================
+    // Two threads racing destroy on one slot both used to read the non-sentinel pointer before
+    // either cleared it, and both handed the SAME storage to retire_sync_object. Before the #2042
+    // quarantine that double-freed immediately; with it, the second free lands ~30 s later from an
+    // unrelated call -- strictly harder to diagnose, which cuts against the quarantine's own
+    // argument. The fix claims the slot with an atomic exchange, so exactly one caller gets a
+    // pointer back.
+    {
+        auto init = Hle::lookup(nid_hash("scePthreadMutexInit"));
+        auto destroy = Hle::lookup(nid_hash("scePthreadMutexDestroy"));
+        CHECK(init && destroy, "mutex init/destroy are registered");
+        if (init && destroy) {
+            // Sequential arm. Deterministic, and it is the case #2176 notes is reachable with no
+            // race at all on the C11 spellings.
+            alignas(16) uint8_t slot[32]{};
+            const uint64_t h = (uint64_t)(uintptr_t)slot;
+            init(h, 0, 0, 0, 0, 0);
+            const uint64_t before = prosper::retired_sync_object_count();
+            destroy(h, 0, 0, 0, 0, 0);
+            const uint64_t after_one = prosper::retired_sync_object_count();
+            CHECK(after_one == before + 1, "the first destroy retires the object exactly once");
+            destroy(h, 0, 0, 0, 0, 0);
+            CHECK(prosper::retired_sync_object_count() == after_one,
+                  "a second destroy of the same slot retires NOTHING (the slot was claimed)");
+
+            // There is deliberately NO concurrent arm here, and that is worth stating rather
+            // than leaving as an omission. I wrote one -- two threads racing destroy on one slot,
+            // asserting exactly one retire, which holds for every interleaving -- and could not make
+            // it DISCRIMINATE: against a deliberately non-atomic read-then-write claim (with a yield
+            // opened in the window) it fired once in 40 runs, then not once in 246 more across 200
+            // rounds per run. An arm that cannot show its lever moved is not evidence, and a 200-
+            // round thread-pair loop that proves nothing is worse than none: it reads as coverage.
+            //
+            // The concurrent case is guarded BY CONSTRUCTION instead: __atomic_exchange_n returns
+            // the previous value to exactly one caller, so at most one racer can ever receive a
+            // non-sentinel pointer to retire. The arm above tests the same claim through the path a
+            // test can observe deterministically.
         }
     }
 


### PR DESCRIPTION
Three of #2176's five findings. **Partial by design** — `Refs`, not `Fixes` — and what remains is
listed below and on the issue.

## Findings 1 + 2 — a double retire is a *delayed* double free, and the clock started early

Two threads racing `scePthreadMutexDestroy` on one slot both read the non-sentinel pointer before
either cleared it, and both handed the **same storage** to `retire_sync_object`. Before #2042 that
double-freed immediately; with the quarantine it double-frees ~30 s later from an unrelated call —
strictly harder to diagnose, which cuts against the argument the quarantine was built on.

Separately, every handler retired **before** clearing the slot, so another thread could still resolve
the object out of it after its quarantine clock had started.

One atomic claim closes both:

```cpp
void* prev = __atomic_exchange_n(slot, (void*)kPtDestroyed, __ATOMIC_ACQ_REL);
return pt_static_sentinel(prev) ? nullptr : prev;
```

Exactly one racer receives a non-sentinel pointer, and the object is unreachable the instant the
clock starts. Applied to all five handlers in `hle_kernel.cpp`.

## Finding 4 — the window is clamped

`strtod` accepts `inf` and `1e300`, and both overflow the `duration_cast` to
`steady_clock::duration` — UB, though the observed direction is the safe one. Clamped to one hour:
far past any deliberate window (the default is 30 s), and past the point where bounding the retained
set *by rate* means anything.

## A guest-invisible change to sem/barrier, stated rather than smuggled

Sharing one claim helper means `k_sem_destroy` and `k_barrier_destroy` now write `kPtDestroyed` where
they wrote `nullptr`. **The guest cannot tell**: `ensure_sem`/`ensure_barrier` already refused *any*
sentinel with EINVAL, and the init handlers overwrite the slot unconditionally. It also aligns them
with the three #2170 changed.

`test_posix_sem.cpp` asserted the literal `nullptr` and now asserts the property — the slot no longer
names the object and is a sentinel. **That test failing locally is how I found the change**, which is
the argument for it being in the suite.

## Tests

Sequential and deterministic, in `test_sce_errno.cpp`:

```
[ok] the first destroy retires the object exactly once
[ok] a second destroy of the same slot retires NOTHING (the slot was claimed)
```

**Mutation-verified**: dropping the sentinel filter from `pt_claim_slot` fails the second arm.

**There is deliberately no concurrent arm**, and the reason is recorded in the test rather than left
as an omission. I wrote one — two threads racing destroy, asserting exactly one retire, which holds
for every interleaving — and **could not make it discriminate**. Against a deliberately non-atomic
read-then-write claim with a yield opened in the window, it fired **once in 40 runs**, then not once
in **246 more** across 200 rounds per run. An arm that cannot show its lever moved is not evidence,
and a 200-round thread-pair loop that proves nothing is worse than none: it reads as coverage.

The concurrent case is guarded **by construction** — `__atomic_exchange_n` returns the previous value
to exactly one caller, so at most one racer can ever receive a pointer to retire.

## What remains on #2176

- **Finding 1's C11 half**: `_Mtx_destroy`/`_Cnd_destroy` never clear their slot, so even a
  *sequential* double destroy retires twice. Giving them a clear is guest-visible (`m_mtx_lock`
  tests the slot), so it wants its own arm and its own evidence.
- **Finding 3**: reclaim latency is not amortised. A perf change needing measurement, not a
  correctness one.
- **Finding 5**: two prose claims to tighten. The corrected figures are the reviewer's measurements,
  not mine, so I left them for whoever can re-measure rather than restating numbers I did not take.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Refs #2176