### PR TITLE
tools(re): xref imm refuses an empty needle instead of answering 0

### DIFF
--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -175,12 +175,19 @@ def imm():
 
         # Under 4 bytes the window floor cannot exist, so the query is refused rather than answered
         # with every plain occurrence of those bytes in the instruction stream.
-        try:
-            XREF.find_immediate_builds(module, b"cfg")
-        except ValueError:
-            pass
-        else:
-            raise AssertionError("a 3-byte needle must be refused, not answered")
+        #
+        # Every sub-4-byte length goes through the one guard, INCLUDING the empty needle (#2099).
+        # b"" used to return [] and print a clean "0 constructions" -- the misleading zero this mode
+        # exists to eliminate, reproduced inside the mode. The 3-byte case alone would not have
+        # caught it: they were two separate code paths, and only one was guarded.
+        for bad in (b"cfg", b"ab", b"a", b""):
+            try:
+                XREF.find_immediate_builds(module, bad)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(
+                    "a %d-byte needle (%r) must be refused, not answered" % (len(bad), bad))
     finally:
         if path:
             os.unlink(path)

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -178,8 +178,13 @@ def find_immediate_builds(m, needle, span=0x60):
         those. The reported [lo:hi] sizes are how a reader tells the two cases apart.
     """
     n = len(needle)
-    if n == 0:
-        return []
+    # The empty needle refuses through the SAME guard as 1-3 bytes (#2099). It used to return [],
+    # which printed "inline-immediate constructions of '' (0 bytes): 0" -- a clean, confident zero,
+    # indistinguishable in form from a real "nothing builds this string". That is precisely the
+    # misleading zero this mode exists to eliminate, reproduced inside the mode itself, and it bites
+    # hardest where the mode is most useful: an agent scripting `imm` over parsed names gets the same
+    # answer for an unset variable as for a genuinely unreferenced string, with nothing separating
+    # them. The message below already reads correctly at n == 0.
     if n < 4:
         raise ValueError(
             "needle %r is %d byte(s); `imm` needs at least 4. Below that the >=4-byte window floor "


### PR DESCRIPTION
`find_immediate_builds` returned `[]` for a zero-length needle, so `xref.py <mod> imm ''` printed:

```
inline-immediate constructions of '' (0 bytes): 0
literal copies in non-executable segments: 0
```

That is **the misleading zero this mode exists to eliminate, reproduced inside the mode itself.** The
output is indistinguishable in form and confidence from a real *"nothing builds this string"*, when
the query was never meaningful.

It bites hardest exactly where `imm` is most useful: an agent scripting it over parsed names — a
manifest, a `--filter`ed dump, a shell loop with an unset variable — gets the same clean `0` for the
empty entry as for the entries that genuinely are unreferenced, with nothing separating them.

#2093 added the `ValueError` refusal for 1–3 byte needles for exactly this reason. The `n == 0` early
return predates it and was a **second, unguarded path to the same place**. Folded into the one guard;
the existing message already reads correctly at zero:

```
refused: needle b'' is 0 byte(s); `imm` needs at least 4. Below that the >=4-byte window
floor that makes a match meaningful cannot apply, ...
```

## Test

`test_xref.py`'s refusal arm exercised only the 3-byte case, which **could not have caught this** —
they were two separate code paths and only one was guarded. It now sweeps every sub-4-byte length
including the empty one:

```python
for bad in (b"cfg", b"ab", b"a", b""):
```

**Mutation-verified**: restoring the `if n == 0: return []` early return fails the new arm with
`a 0-byte needle (b'') must be refused, not answered`.

End-to-end on a flattened module, **with the positive control** that stops this being an
over-refusal:

```
imm ''           ->  refused: needle b'' is 0 byte(s); ...
imm 'sceKernel'  ->  inline-immediate constructions of 'sceKernel' (9 bytes): 0
```

The second is a genuine zero for a 51 KB module, and it is the arm showing the guard did not start
refusing valid queries.

## Verification

```
python prosper/tools/re/test_xref.py  ->  xref decoder: PASS / xref imm: PASS
git diff --check -> clean
```

Fixes #2099