### PR TITLE
gpu: the cfg reject diagnostic must print the instruction word

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13440,8 +13440,21 @@ bool emit_cfg_state_machine(
                 if (handled && ok) record_scalar_write(state, in);
                 if (!handled || !ok) {
                     if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr, "[cfg-recompile-reject] pc=%u fmt=%d op=0x%x\n",
-                                     in.pc, static_cast<int>(in.fmt), in.opcode);
+                        // The raw INSTRUCTION WORDS, because without them this line cannot be acted
+                        // on. `fmt` and `op` are our decoder's own labels, so they identify the
+                        // instruction only if you already trust the decode -- and a reject is
+                        // precisely the case where you should not. The word is ground truth and
+                        // names the instruction in one command:
+                        //     llvm-mc -arch=amdgcn -mcpu=gfx1010 -show-encoding
+                        // assemble the candidate and compare, exactly as #2275 identified the image
+                        // atomics and #2309 identified s_cbranch_vccz from `bf860051`.
+                        // Its sibling at the ALU reject site already prints these; this one did not,
+                        // so half the rejects from a run were unidentifiable and the two diagnostics
+                        // could not be compared (#2309).
+                        std::fprintf(stderr,
+                                     "[cfg-recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x\n",
+                                     in.pc, in.words[0], in.words[1],
+                                     static_cast<int>(in.fmt), in.opcode);
                     return false;
                 }
                 // Ordinary scalar B64 logicals already produced an exact nonzero SCC id above.


### PR DESCRIPTION
One line of diagnostic, verified by the two instructions it immediately identified.

## The defect

`[cfg-recompile-reject]` (`rdna2_to_spirv.cpp:13357`) printed `pc`, `fmt` and `op` — but **not the
instruction words**. Its sibling at the ALU reject site (`:14563`) has always printed them.

`fmt` and `op` are **our own decoder's labels**. They identify the instruction only if you already
trust the decode — and a reject is precisely the case where you should not. The raw word is ground
truth: it survives a wrong decode, and `llvm-mc` turns it into a name in one command.

The practical consequence: on a run producing both kinds of reject, **half were unidentifiable**, and
the two diagnostics could not be compared against each other.

## What it buys, measured

*Sonic Racing: CrossWorlds* produces both kinds. Before this change, two families were dead ends —
`pc=101 fmt=1 op=0x16` and `pc=2038 fmt=7 op=0x1`, and nothing more to go on. After:

```
[cfg-recompile-reject] pc=101   words=beea160e,00000000 fmt=1 op=0x16
[cfg-recompile-reject] pc=2038  words=7e1402fa,ff096404 fmt=7 op=0x1
```

```
$ echo '0x0e,0x16,0xea,0xbe' | llvm-mc -arch=amdgcn -mcpu=gfx1010 -disassemble
        s_flbit_i32_b64 vcc_lo, s[14:15]

$ echo '0xfa,0x02,0x14,0x7e,0x04,0x64,0x09,0xff' | llvm-mc -arch=amdgcn -mcpu=gfx1010 -disassemble
        v_mov_b32_dpp v10, v4 row_xmask:4 row_mask:0xf bank_mask:0xf bound_ctrl:1
```

**Two unimplemented instructions with names**, from a line that previously said nothing actionable.
Both are now recorded on #2309 as concrete recompiler gaps rather than unknowns.

## Verification

- `ctest --no-tests=error -j4` → **221/221**
- **The diagnostic was observed firing**, not assumed. That is the part worth noting: I could not
  verify it on this branch alone, because reaching the shaders that trigger it requires CrossWorlds
  to get past its splash, which needs #2281's decoder. So I applied #2281's change on top
  temporarily, confirmed the output above, then **reverted** it — #2281's worktree is clean and its
  diff is unchanged at 4 files / 412 insertions. This branch is the one-line change alone.

Shipping a `printf` nobody has seen execute is the same vacuous pass this project keeps recording, so
it seemed worth the extra build.

## Risk

`PROSPER_DBG`-gated, diagnostic-only, no behaviour change on any path. The two words are read from
the same `in.words[]` the sibling site already prints.

Refs #2309
