### PR TITLE
tools/scripts: stop setting PROSPER_GUEST_FS where it is never read

### DIFF
--- a/prosper/docs/ASTERIX_BABYLON_STATUS.md
+++ b/prosper/docs/ASTERIX_BABYLON_STATUS.md
@@ -19,9 +19,10 @@ Current verified rung: **2 — title screen reached and rendered**
 ## The splash deadlock and what fixed it (2026-08-05)
 
 The title screen is reached by a default `screenshot` route with no title-specific switches
-(`PROSPER_RENDER=1`, the tool's own `PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct`
-defaults — `PROSPER_GUEST_FS` is inert here, read only on macOS/Rosetta, and is named only because
-`screenshot` sets it). Two independent bounded runs reproduce it.
+(`PROSPER_RENDER=1`, the tool's own `PROSPER_GUEST_ARGS=-force-gfx-direct`
+defaults). Two independent bounded runs reproduce it. `PROSPER_GUEST_FS` used to be named here
+because `screenshot` set it; since #2098 it no longer does on Linux or Windows, where the variable
+is never read — guest TLS is on by default and the opt-out is `PROSPER_NO_GUEST_FS`.
 
 `sceAvPlayerJumpToTime` (`XC9wM+xULz8`) was unregistered, so the dispatcher's default `0` reached the
 guest as a completed seek. Three things had to be true together before the title could advance, and

--- a/prosper/scripts/dead-cells/progression-matrix.ps1
+++ b/prosper/scripts/dead-cells/progression-matrix.ps1
@@ -47,7 +47,7 @@ $captureRoute = [IO.Path]::GetFullPath(
     (Join-Path $PSScriptRoot 'reach-first-gameplay-capture.pad'))
 
 $controlledEnvironment = @(
-    'PROSPER_CAPTURE_TITLE', 'PROSPER_GUEST_FS', 'PROSPER_GUEST_ARGS',
+    'PROSPER_CAPTURE_TITLE', 'PROSPER_GUEST_ARGS',
     'PROSPER_PAD_SCRIPT', 'PROSPER_PAD_SCRIPT_LOG', 'PROSPER_SAVEDATA_DIR',
     'PROSPER_PROGRESS', 'PROSPER_GPU_TIMELINE', 'PROSPER_RENDER',
     'PROSPER_NO_FRAME_DUMPS', 'PROSPER_PRESENT_EVERY', 'PROSPER_RENDER_EVERY',
@@ -72,7 +72,7 @@ function Set-RunEnvironment {
     Reset-ControlledEnvironment
     $common = @{
         PROSPER_CAPTURE_TITLE = 'PPSA15552'
-        PROSPER_GUEST_FS = '1'
+        # PROSPER_GUEST_FS omitted: Apple-only, never read on Windows (#2098).
         PROSPER_GUEST_ARGS = ''
         PROSPER_PAD_SCRIPT = "@$($Spec.Route)"
         PROSPER_PAD_SCRIPT_LOG = '1'

--- a/prosper/scripts/plucky-squire/run-first-gameplay.sh
+++ b/prosper/scripts/plucky-squire/run-first-gameplay.sh
@@ -42,7 +42,8 @@ mkdir -- "$run_dir/save0" "$run_dir/savedata"
 run_dir="$(CDPATH='' cd -- "$run_dir" && pwd)"
 dump_dir="$(CDPATH='' cd -- "$dump_dir" && pwd)"
 
-export PROSPER_GUEST_FS=1
+# PROSPER_GUEST_FS omitted: Apple-only (guest_tls.cpp:46); Linux defaults guest TLS ON and
+# reads the opt-OUT PROSPER_NO_GUEST_FS instead (#2098).
 export PROSPER_GUEST_ARGS="${PROSPER_GUEST_ARGS:--force-gfx-direct}"
 export PROSPER_RENDER=1
 export PROSPER_RENDER_EVERY=1

--- a/prosper/scripts/run-windows.ps1
+++ b/prosper/scripts/run-windows.ps1
@@ -108,7 +108,9 @@ $runArgs = @()
 if ($TestPattern) {
     $runArgs += '--test-pattern'
 } else {
-    $env:PROSPER_GUEST_FS = '1'
+    # PROSPER_GUEST_FS is not set: guest_tls.cpp reads it only under `#ifdef __APPLE__`.
+    # On Windows (`:240`) guest TLS is ON by default; the real switch is the opt-OUT
+    # PROSPER_NO_GUEST_FS (#2098).
     $env:PROSPER_GUEST_ARGS = $GuestArgs
     if ($SavedataDir) { $env:PROSPER_SAVEDATA_DIR = [IO.Path]::GetFullPath($SavedataDir) }
     $runArgs += @('--dump', $Dump)

--- a/prosper/scripts/start-prosper.ps1
+++ b/prosper/scripts/start-prosper.ps1
@@ -36,7 +36,9 @@ if ($TestPattern) {
 
     $SavedataDir = [IO.Path]::GetFullPath($SavedataDir)
     New-Item -ItemType Directory -Path $SavedataDir -Force | Out-Null
-    $env:PROSPER_GUEST_FS = '1'
+    # PROSPER_GUEST_FS is not set: guest_tls.cpp reads it only under `#ifdef __APPLE__`.
+    # On Windows (`:240`) guest TLS is ON by default; the real switch is the opt-OUT
+    # PROSPER_NO_GUEST_FS (#2098).
     $env:PROSPER_GUEST_ARGS = $GuestArgs
     $env:PROSPER_SAVEDATA_DIR = $SavedataDir
     $runArgs += @('--dump', $Dump)

--- a/prosper/scripts/start-prosper.sh
+++ b/prosper/scripts/start-prosper.sh
@@ -91,7 +91,9 @@ else
     dump="$(cd "$dump" && pwd)"
     mkdir -p "$savedata_dir"
     savedata_dir="$(cd "$savedata_dir" && pwd)"
-    export PROSPER_GUEST_FS=1
+    # PROSPER_GUEST_FS is not set: it is read at guest_tls.cpp:46 only under
+    # `#ifdef __APPLE__`. On Linux (`:58`) guest TLS is ON by default and the variable
+    # that exists is the opt-OUT PROSPER_NO_GUEST_FS (#2098).
     export PROSPER_GUEST_ARGS="$guest_args"
     export PROSPER_SAVEDATA_DIR="$savedata_dir"
     args+=(--dump "$dump")

--- a/prosper/tools/hang_probe/hang_probe.py
+++ b/prosper/tools/hang_probe/hang_probe.py
@@ -99,7 +99,10 @@ def one_run(args, i):
     log = tempfile.NamedTemporaryFile(prefix=f"hangprobe_run{i}_", suffix=".log", delete=False).name
     env = dict(os.environ)
     env.update({
-        "PROSPER_INITLOG": "1", "PROSPER_GUEST_FS": "1",
+        "PROSPER_INITLOG": "1",
+        # Apple-only (#2098): read at guest_tls.cpp:46 under `#ifdef __APPLE__`. Linux and Windows
+        # read the opt-OUT PROSPER_NO_GUEST_FS and default guest TLS ON.
+        **({"PROSPER_GUEST_FS": "1"} if sys.platform == "darwin" else {}),
         "PROSPER_GUEST_ARGS": "-force-gfx-direct", "PROSPER_RENDER": "1",
         "PROSPER_NO_FRAME_DUMPS": "1", "PROSPER_SAVE0": save,
     })

--- a/prosper/tools/perf/ab_compute.sh
+++ b/prosper/tools/perf/ab_compute.sh
@@ -40,7 +40,9 @@ echo "# route=$ROUTE  reps=$REPS  seconds=$SECS  off_switch=$SWITCH"
 echo "# started=$(date -u +%Y-%m-%dT%H:%M:%SZ)  logs=$OUT"
 
 run() { # $1=label  $2=extra env ("" for ON)
-  env SDL_AUDIO_DRIVER=dummy PROSPER_GUEST_FS=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+  # PROSPER_GUEST_FS dropped: read only under `#ifdef __APPLE__` (guest_tls.cpp:46); this is a
+  # Linux A/B and guest TLS is ON by default there (#2098).
+  env SDL_AUDIO_DRIVER=dummy PROSPER_GUEST_ARGS=-force-gfx-direct \
       PROSPER_RENDER=1 PROSPER_VULKAN_LIB=libvulkan.so.1 PROSPER_RENDER_TIMING=1 $2 \
       PROSPER_PAD_SCRIPT="@$ROUTE" \
       timeout "$SECS" ./build-linux/prosper-app --dump "$DUMP" > "$OUT/$1.log" 2>&1

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -117,17 +117,22 @@ first second. Rendered frames spread the shots evenly across the run.
 ## Guest environment
 
 Reaching a rendering frame loop needs the render-frontier guest switches. This tool defaults
-`PROSPER_GUEST_FS=1` and `PROSPER_GUEST_ARGS=-force-gfx-direct` (Unity/Messenger recipe) if unset. For
-other titles set the appropriate env first, e.g. a UE4 title:
+`PROSPER_GUEST_ARGS=-force-gfx-direct` (Unity/Messenger recipe) if unset. For other titles set the
+appropriate env first, e.g. a UE4 title:
 
 ```bash
 PROSPER_GUEST_ARGS= PROSPER_NULL_PAGE=1 screenshot /path/PPSA01885-app0
 ```
 
-`PROSPER_GUEST_FS=1` is named above because the tool really does set it, not because a run needs it:
-guest `%fs` TLS is **on by default** on Linux (since #825) and Windows (since #624), and is opted out
-of with `PROSPER_NO_GUEST_FS=1`. `PROSPER_GUEST_FS` is read only on macOS/Rosetta. Do not carry it
-into a new recipe (#2095).
+`PROSPER_GUEST_FS` is **no longer set on Linux or Windows** (#2098). Guest `%fs` TLS is **on by
+default** there — Linux since #825, Windows since #624 — and the variable that exists is the
+opt-OUT, `PROSPER_NO_GUEST_FS=1`. The name is read at exactly one place in the tree,
+`guest_tls.cpp:46`, inside `#ifdef __APPLE__`, where it opts in to Rosetta trap-mode `%fs`
+emulation; the tool still sets it there, because on macOS dropping it would turn trap mode off.
+
+Do not carry it into a new recipe (#2095). Setting it on Linux or Windows is harmless at runtime and
+misleading in the way that matters: it turns a default-on path into one people believe they are
+enabling, so nobody checks it when guest TLS is the actual cause.
 
 ## Example
 

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -388,7 +388,19 @@ int main(int argc, char** argv) {
     int pad = 2; for (int m = count - 1, d = 1; ; m /= 10, d++) { if (m < 10) { if (d > pad) pad = d; break; } }
 
     // Sane render-frontier defaults (don't override if the caller set them for another title).
+    // PROSPER_GUEST_FS is APPLE-ONLY, and setting it anywhere else taught a false model (#2098).
+    // guest_tls.cpp reads this name at exactly one place -- `:46`, inside `#ifdef __APPLE__`, where
+    // it opts IN to Rosetta trap-mode %fs emulation. Linux (`:58`) and Windows (`:240`) read
+    // `PROSPER_NO_GUEST_FS` instead: guest TLS is ON by default there and the real variable is the
+    // opt-OUT. Setting it on those platforms was harmless and misleading in the way that matters --
+    // this file is where an agent copies a recipe from, and a run that appears to enable something
+    // is a run nobody re-checks when guest TLS is the actual cause.
+    //
+    // Guarded rather than deleted, because on macOS deleting it is NOT a no-op: it would turn trap
+    // mode off and take guest TLS with it.
+#ifdef __APPLE__
     set_environment("PROSPER_GUEST_FS",   "1", false);
+#endif
     set_environment("PROSPER_GUEST_ARGS", "-force-gfx-direct", false);
     if (warmup_seconds_set) {
         char delay_ms[32];

--- a/prosper/tools/snapshot/snapshot.py
+++ b/prosper/tools/snapshot/snapshot.py
@@ -802,7 +802,11 @@ def capture(entry, run_log=None):
     # Defaults every title needs to reach the frame loop, then the render/target knobs. The manifest
     # entry's own `env` wins so a title can add its specific switches.
     env.update({
-        "PROSPER_GUEST_FS": "1",
+        # PROSPER_GUEST_FS is Apple-only (#2098): guest_tls.cpp reads it at :46 inside
+        # `#ifdef __APPLE__` to opt in to Rosetta trap mode. Linux/Windows read the OPT-OUT
+        # PROSPER_NO_GUEST_FS and have guest TLS on by default, so setting it there taught a
+        # false model. Kept for darwin, where dropping it would turn trap mode off.
+        **({"PROSPER_GUEST_FS": "1"} if sys.platform == "darwin" else {}),
         "PROSPER_GUEST_ARGS": "-force-gfx-direct",
         "PROSPER_RENDER": "1",
         "PROSPER_RENDER_EVERY": "1",     # render every draw submit -> frame_<F> == F-th draw submit
@@ -901,7 +905,8 @@ def capture_content(entry, run_log=None):
         raise RuntimeError("sample_seconds must be positive")
     env = dict(os.environ)
     env.update({
-        "PROSPER_GUEST_FS": "1", "PROSPER_GUEST_ARGS": "-force-gfx-direct",
+        **({"PROSPER_GUEST_FS": "1"} if sys.platform == "darwin" else {}),   # Apple-only (#2098)
+        "PROSPER_GUEST_ARGS": "-force-gfx-direct",
         "PROSPER_RENDER": "1", "PROSPER_RENDER_EVERY": "1", "PROSPER_RENDER_FIRST": "0",
         "PROSPER_RENDER_SCALE": str(scale), "PROSPER_FAULT_ONSTACK": "1",
     })


### PR DESCRIPTION
The name is read at **exactly one place in the tree** — `guest_tls.cpp:46`, inside `#ifdef __APPLE__`,
where it opts in to Rosetta trap-mode `%fs` emulation. Linux (`:58`) and Windows (`:240`) read
`PROSPER_NO_GUEST_FS`: guest TLS is **on by default** there and the real variable is the **opt-out**.

Verified before changing anything, because `CLAUDE.md` records this exact claim propagating wrongly
through a review, a briefing, a shipped code comment and an author's own verification — with nobody
opening the file at any step:

```
grep -rn 'getenv("PROSPER_GUEST_FS")' prosper/src prosper/frontends prosper/tools
  ->  prosper/src/host/guest_tls.cpp:46      (and nothing else)
```

#2095/#2097 fixed the 36 Markdown files that *prescribe* it. This is the code half.

## Guarded, not deleted, where deleting would regress macOS

The issue says to drop the assignment. That is right for the platform-specific launchers and **wrong
for the cross-platform harnesses**: on macOS the variable is live, and removing it turns trap mode
off and takes guest TLS with it. **macOS CI does not run `screenshot` or `snapshot`, so nothing would
have caught it.**

| file | change |
| --- | --- |
| `screenshot.cpp` | `#ifdef __APPLE__` around the `set_environment` |
| `snapshot.py` | `**({...} if sys.platform == "darwin" else {})` — both env dicts |
| `hang_probe.py` | same |

That also puts the platform truth *at the point of use*, which is the actual cure for a false model —
a reader now sees **why** it is Apple-only without going to `guest_tls.cpp`.

## Deleted where the script is single-platform

`start-prosper.sh` (Linux tarball) · `start-prosper.ps1` · `run-windows.ps1` ·
`dead-cells/progression-matrix.ps1` (the set **and** the clear-list entry) ·
`plucky-squire/run-first-gameplay.sh` · `tools/perf/ab_compute.sh`

Each keeps a one-line comment saying where the name **is** read, so it does not get re-added.

`tools/dbg/` (~55 files) and `scripts/diag/` are left alone — historical scratch, as the issue
directs.

Tests that `setenv` it are untouched: they exercise the guest-TLS path and the Apple arm reads it
(`test_tls_dtv_purge.cpp:119`, `test_ime_fs.cpp:66`, `test_hle_stack_args.cpp:104`). I checked the
issue's stated precondition — **no test asserts the variable is present in a child environment**.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
```

**Behavioural, not just textual:**

```
strings build-mingw/screenshot.exe | grep -c '^PROSPER_GUEST_FS$'          -> 0
strings build-mingw/screenshot.exe | grep -c 'PROSPER_GUEST_ARGS|RENDER'   -> 2
```

The second is the **control**: `strings` does surface these names in this binary, so the zero is a
real absence and the guard genuinely compiled the setter out on Windows.

`bash -n` on all three shell scripts; PowerShell AST parse on all three `.ps1`; `ast.parse` on both
Python harnesses. All clean.

Docs updated in the same commit, as the issue requires: `tools/screenshot/README.md` and
`docs/ASTERIX_BABYLON_STATUS.md` both documented that `screenshot` sets this and were accurate until
now.

Fixes #2098