### PR TITLE
hle: register libSceSysmodule's eight *Internal entry points

### DIFF
--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -563,11 +563,12 @@ HLE(k_ok)              { return 0; }                       // generic success no
 // would share an entry. The tripwire is therefore an observed id >= 0x10000; the corpus's widest is
 // 0x130, so nothing is close, and if one ever appears this mask is the first thing to revisit.
 //
-// NOT fixed here, and it is the same defect on a parallel path: the eight *Internal entry points
-// (sceSysmoduleIsLoadedInternal ynFKQ5bfGks, LoadModule{,ByName,WithArg}Internal,
-// UnloadModule{,ByName,WithArg}Internal, GetModuleHandleInternal) are unregistered, so they fall to
-// prosper_on_unimpl, which also returns 0. No dump in the local corpus imports any of them —
-// measured, which is why this stays focused — but a title that uses them reproduces #2002 exactly.
+// The eight *Internal entry points were the same defect on a parallel path, and are fixed in #2128:
+// unregistered, they fell to prosper_on_unimpl, which returns 0 — SUCCESS — without recording
+// anything, so a title that loaded through one of them and later called IsLoaded was told UNLOADED
+// about a load prosper itself had just reported as succeeding. Still no dump in the local corpus
+// imports any of them (re-measured on five, with the plain LoadModule NID as a positive control),
+// so this closes a class rather than fixing an observed symptom.
 constexpr uint64_t k_sysmodule_error_unloaded = 0x805A1001;   // SCE_SYSMODULE_ERROR_UNLOADED
 
 namespace {
@@ -605,6 +606,38 @@ HLE(k_sysmodule_unload) {
     std::lock_guard lk(g_sysmodule_mx);
     g_sysmodule_state[id] = false;
     return 0;
+}
+
+// sceSysmoduleLoadModuleByNameInternal (CU8m+Qs+HN4) / ...UnloadModuleByNameInternal (vpTHmA6Knvg).
+//
+// These take a NAME, not an id, so they cannot write the id-keyed map above — and prosper has no
+// name→id table to build one from. Registered anyway, to a handler that REFUSES, because leaving
+// them unregistered is not neutral: prosper_on_unimpl returns 0, which for this contract is success,
+// and the caller then believes a module is loaded that nothing recorded (#2128).
+//
+// An error is the honest answer of the two available. A refused load is a path the guest already
+// has; a success it cannot see the consequences of is not.
+HLE(k_sysmodule_by_name_unsupported) {
+    static std::atomic<unsigned> seen{0};
+    if (seen.fetch_add(1) < 8)
+        fprintf(stderr, "[sysmodule] LoadModuleByName/UnloadModuleByName refused: prosper's load "
+                        "state is keyed by module ID and there is no name->id table, so this call "
+                        "cannot be recorded. Reporting failure rather than an unrecorded "
+                        "success (#2128)\n");
+    return k_sysmodule_error_unloaded;
+}
+
+// sceSysmoduleGetModuleHandleInternal (D8cuU4d72xM). Never 0: for THIS contract 0 is a valid handle
+// shape and the caller will dereference it, which is strictly worse than the missing implementation
+// it stands in for. prosper has no per-sysmodule-id handles to hand out at all, so the answer is the
+// same whether or not the id was loaded — and saying so is the point.
+HLE(k_sysmodule_get_handle_internal) {
+    static std::atomic<unsigned> seen{0};
+    if (seen.fetch_add(1) < 8)
+        fprintf(stderr, "[sysmodule] GetModuleHandleInternal(0x%x) refused: prosper keeps loaded "
+                        "STATE per id but no module handle, and returning 0 here would hand the "
+                        "guest a dereferenceable handle it never got (#2128)\n", (unsigned)a0);
+    return k_sysmodule_error_unloaded;
 }
 
 // sceSysmoduleIsLoaded(uint16_t id) -> SCE_OK when this process loaded it, else UNLOADED.
@@ -1574,6 +1607,18 @@ void register_kernel_time_hle() {
     R("sceSysmoduleLoadModule", k_sysmodule_load);
     R("sceSysmoduleUnloadModule", k_sysmodule_unload);
     R("sceSysmoduleIsLoaded", k_sysmodule_is_loaded);
+    // The *Internal variants, onto the SAME recording handlers (#2128). The id-taking forms share
+    // them directly: LoadModuleInternalWithArg's extra (args, argp, pRes) follow the id in a0, so
+    // the recording path is identical and only the ignored tail differs.
+    R("sceSysmoduleLoadModuleInternal", k_sysmodule_load);
+    R("sceSysmoduleLoadModuleInternalWithArg", k_sysmodule_load);
+    R("sceSysmoduleUnloadModuleInternal", k_sysmodule_unload);
+    R("sceSysmoduleUnloadModuleInternalWithArg", k_sysmodule_unload);
+    R("sceSysmoduleIsLoadedInternal", k_sysmodule_is_loaded);
+    // The two the id-keyed map cannot represent, and the one that must never answer 0.
+    R("sceSysmoduleLoadModuleByNameInternal", k_sysmodule_by_name_unsupported);
+    R("sceSysmoduleUnloadModuleByNameInternal", k_sysmodule_by_name_unsupported);
+    R("sceSysmoduleGetModuleHandleInternal", k_sysmodule_get_handle_internal);
 #ifndef _WIN32
     R("sceKernelLoadStartModule", k_load_start_mod_entry);   // entry-rsp trampoline (#639)
 #else

--- a/prosper/tests/test_sysmodule_state.cpp
+++ b/prosper/tests/test_sysmodule_state.cpp
@@ -85,6 +85,51 @@ int main() {
           "load-low-byte-twin");
     CHECK(is_loaded(kAppContent, 0, 0, 0, 0, 0) == kUnloaded, "id-key-is-not-byte-wide");
 
+    // ===== the *Internal entry points share the same state (#2128) ============================
+    // Unregistered, all eight fell to prosper_on_unimpl's `return 0` -- SUCCESS for this contract,
+    // recorded nowhere. A title that loaded through one of them and then called IsLoaded was told
+    // UNLOADED about a load prosper had just reported as succeeding: #2002's defect on a parallel
+    // path, and invisible to every assertion above because those drive only the plain spellings.
+    {
+        HleFn load_i    = Hle::lookup(nid_hash("sceSysmoduleLoadModuleInternal"));
+        HleFn load_arg  = Hle::lookup(nid_hash("sceSysmoduleLoadModuleInternalWithArg"));
+        HleFn unload_i  = Hle::lookup(nid_hash("sceSysmoduleUnloadModuleInternal"));
+        HleFn unload_a  = Hle::lookup(nid_hash("sceSysmoduleUnloadModuleInternalWithArg"));
+        HleFn isload_i  = Hle::lookup(nid_hash("sceSysmoduleIsLoadedInternal"));
+        HleFn by_name_l = Hle::lookup(nid_hash("sceSysmoduleLoadModuleByNameInternal"));
+        HleFn by_name_u = Hle::lookup(nid_hash("sceSysmoduleUnloadModuleByNameInternal"));
+        HleFn get_hand  = Hle::lookup(nid_hash("sceSysmoduleGetModuleHandleInternal"));
+        CHECK(load_i && load_arg && unload_i && unload_a && isload_i && by_name_l && by_name_u &&
+              get_hand, "all-eight-internal-entry-points-registered");
+
+        if (load_i && isload_i && unload_i && load_arg && unload_a) {
+            const uint64_t kInt = 0x0222;
+            // CROSS-SPELLING, which is the whole point: load through *Internal, query through the
+            // PLAIN one. A per-spelling map would satisfy a same-spelling round trip and still leave
+            // the contradiction this issue is about.
+            CHECK(load_i(kInt, 0, 0, 0, 0, 0) == 0, "internal-load-succeeds");
+            CHECK(is_loaded(kInt, 0, 0, 0, 0, 0) == 0, "internal-load-is-visible-to-plain-IsLoaded");
+            CHECK(isload_i(kInt, 0, 0, 0, 0, 0) == 0, "internal-load-is-visible-to-IsLoadedInternal");
+            CHECK(unload_i(kInt, 0, 0, 0, 0, 0) == 0 && is_loaded(kInt, 0, 0, 0, 0, 0) == kUnloaded,
+                  "internal-unload-is-visible-to-plain-IsLoaded");
+            // The WithArg forms carry (args, argp, pRes) after the id; the id is still a0, so they
+            // must record identically. Passing junk in the tail is the point of this arm.
+            CHECK(load_arg(kInt, 7, 0xDEAD, 0xBEEF, 0, 0) == 0 &&
+                  is_loaded(kInt, 0, 0, 0, 0, 0) == 0, "withArg-load-records-on-the-id");
+            CHECK(unload_a(kInt, 7, 0xDEAD, 0xBEEF, 0, 0) == 0 &&
+                  is_loaded(kInt, 0, 0, 0, 0, 0) == kUnloaded, "withArg-unload-records-on-the-id");
+        }
+
+        // The three that CANNOT be served honestly must not answer 0. For ByName the id-keyed map
+        // has no key to write; for GetModuleHandle a 0 is a valid handle shape the caller will
+        // dereference -- worse than the missing implementation it stands in for.
+        if (by_name_l && by_name_u && get_hand) {
+            CHECK(by_name_l(0, 0, 0, 0, 0, 0) != 0, "LoadModuleByName-refuses-rather-than-succeeds");
+            CHECK(by_name_u(0, 0, 0, 0, 0, 0) != 0, "UnloadModuleByName-refuses-rather-than-succeeds");
+            CHECK(get_hand(kAppContent, 0, 0, 0, 0, 0) != 0, "GetModuleHandleInternal-never-answers-0");
+        }
+    }
+
     printf(fails ? "== FAILURES: %d ==\n" : "== all checks passed ==\n", fails);
     return fails ? 1 : 0;
 }


### PR DESCRIPTION
Eight of `libSceSysmodule`'s entry points were unregistered, so they fell to `prosper_on_unimpl` —
which returns **0, success for this contract, without recording anything**. Three of the eight are
*loads*. A title that loaded through one and later called `sceSysmoduleIsLoaded` was told
`SCE_SYSMODULE_ERROR_UNLOADED` **about a load prosper itself had just reported as succeeding**.

That is #2002's defect on a parallel path. #2002/#2021 made `IsLoaded` answer from real load history;
this is the other half — a load path that never reached it.

## Five register onto the existing recording handlers

| entry point | handler |
| --- | --- |
| `LoadModuleInternal`, `LoadModuleInternalWithArg` | `k_sysmodule_load` |
| `UnloadModuleInternal`, `UnloadModuleInternalWithArg` | `k_sysmodule_unload` |
| `IsLoadedInternal` | `k_sysmodule_is_loaded` |

The `WithArg` forms carry `(args, argp, pRes)` *after* the id, so the id is still `a0` and the
recording path is identical — only the ignored tail differs.

## Three cannot be served honestly, and answer so

**`LoadModuleByNameInternal` / `UnloadModuleByNameInternal`** take a **name**. The state map is
id-keyed and prosper has no name→id table, so there is no key to write. Registered anyway to a
refusing handler, because leaving them unregistered is **not neutral** — `prosper_on_unimpl`'s `0` is
success, and the caller then believes a module is loaded that nothing recorded. A refused load is a
path the guest already has; a success it cannot see the consequences of is not.

**`GetModuleHandleInternal`** must never answer `0`: for this contract `0` is a **valid handle shape**
and the caller will dereference it — strictly worse than the missing implementation it stands in for.
prosper keeps loaded *state* per id but no module *handle*, so it refuses and says why.

All three log, capped.

## Verified rather than inherited

Every NID read off the firmware export table, not the issue: `39iV5E1HoCk`, `hHrGoGoNf+s`,
`vXZhrtJxkGc`, `aKa6YfBKZs4`, `ynFKQ5bfGks`, `CU8m+Qs+HN4`, `vpTHmA6Knvg`, `D8cuU4d72xM`.

Corpus: **0 of 5 dumps import any of the eight**, re-measured — **with a positive control**, since a
clean zero is exactly the shape that has misled here before. The plain `sceSysmoduleLoadModule` NID
(`g8cM39EUZ6o`) is found **5 and 6 times** in two of the same dumps, so the grep works and the zeros
are real absences.

This closes a class rather than fixing an observed symptom, and the stale *"NOT fixed here"*
paragraph above the handlers is updated to say so.

## Tests

`test_sysmodule_state.cpp` gains a block driving each new entry point.

The load/query arms are deliberately **cross-spelling** — load through `*Internal`, query through the
**plain** `IsLoaded` — because that is the contradiction the issue is about. A per-spelling map would
satisfy a same-spelling round trip and leave the defect exactly where it was.

The `WithArg` arms pass junk in the ignored tail (`7, 0xDEAD, 0xBEEF`), so they would fail if a future
change started reading `a0`'s neighbours as part of the key.

**Mutation-verified**: unregistering `LoadModuleInternal` again fails
`all-eight-internal-entry-points-registered`.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

Fixes #2128