### PR TITLE
diag(shader-tap): a tap that did not apply must say so, not report clip positions

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1,4 +1,5 @@
 // rdna2_to_spirv.cpp — see rdna2_to_spirv.hpp. Internal SpirvCompute builder + the VALU translator.
+#include <atomic>
 #include "rdna2_to_spirv.hpp"
 #include "diagnostic_selectors.hpp"
 #include "rdna2_decode.hpp"
@@ -2515,7 +2516,34 @@ struct SpirvCompute {
         // gl_Position instead of the real clip position, so the geometry-probe capture reads it back.
         uint32_t v;
         if (tap_vec) { v = tap_vec; }
-        else { v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(x), bcf(y), bcf(z), bcf(w)}); }
+        else {
+            // A tap was REQUESTED and is not available here, which is the silent-degradation case
+            // (#2064): tap_vec is set only when the instruction at tap_pc is walked, so a tap_pc
+            // AFTER this shader's EXP POS0 leaves it 0 and the real clip position is exported --
+            // while the readout still prints "values below are the tapped VGPR". A plausible,
+            // well-labelled, completely wrong answer.
+            //
+            // Warned rather than rejected, and the distinction matters: tap_pc is GLOBAL across
+            // stages, so a PC tapped in the pixel shader is legitimately absent from every vertex
+            // shader. Refusing here would drop every draw in the frame for a tap that is doing
+            // exactly what it was asked to do. The warning names both PCs so a reader can tell the
+            // two apart immediately -- "after the export" is the defect, "not in this shader" is not.
+            if (tap_pc != 0xFFFFFFFFu) {
+                // Atomic, not a plain counter: parallel_draw_worker_execute realizes draws on
+                // worker threads and realization recompiles, and I could not establish that
+                // the recompile itself runs under ShaderCache's mutex rather than only the
+                // lookup. An unverified serialization claim is not worth one relaxed add.
+                static std::atomic<unsigned> warned{0};
+                if (warned.fetch_add(1, std::memory_order_relaxed) < 8)
+                    fprintf(stderr,
+                            "[shader-tap] NOT APPLIED at the position export: PROSPER_SHADER_TAP "
+                            "pc=%u was not reached before EXP POS0 in this vertex shader, so the "
+                            "REAL clip position is exported. If pc=%u is after the export, move it "
+                            "earlier; if it belongs to another stage, this line is expected (#2064)\n",
+                            tap_pc, tap_pc);
+            }
+            v = id(); putv(code, Op_CompositeConstruct, {t_v4f, v, bcf(x), bcf(y), bcf(z), bcf(w)});
+        }
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_out_v4f, p, v_pos, uconst(0)});
         put(code, Op_Store, {p, v});
     }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -6345,9 +6345,16 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // Shader I/O tap mode (PROSPER_SHADER_TAP): the captured "positions" are actually the tapped
                 // intermediate VGPR (dst..dst+3) at that PC, so print the raw hex too (values are often
                 // integers/bitfields, not clip floats) and skip the meaningless clip classification.
+                // Gated on the REQUEST, not on whether the redirect happened -- and those differ
+                // (#2064). tap_vec is set only when the instruction at tap_pc is walked, so a
+                // tap_pc after this shader's EXP POS0 exports the REAL clip position while this
+                // header still says "the tapped VGPR". The recompiler now prints
+                // `[shader-tap] NOT APPLIED ...` naming the PC in that case, so the two lines
+                // must be read together: this header states what was ASKED FOR, and the ABSENCE
+                // of a NOT APPLIED line is what says it was delivered.
                 const bool is_tap = getenv("PROSPER_SHADER_TAP") != nullptr;
                 if (is_tap)
-                    fprintf(stderr, "[geom-probe] draw=%llu SHADER-TAP: values below are the tapped VGPR "
+                    fprintf(stderr, "[geom-probe] draw=%llu SHADER-TAP REQUESTED (see any [shader-tap] NOT APPLIED line for this shader, which means these are the REAL clip positions -- #2064): values below are the tapped VGPR "
                                     "(dst+3) at that PC, not clip positions (bbox/tags meaningless)\n",
                             geom_target_label);
                 else

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -361,6 +361,25 @@ and byte-identical when the env var is unset. Tap a PC in the shader's **straigh
 vertex-fetch/transform prologue) — a PC inside a loop or if-body defines the value in a block that doesn't
 dominate the position export, so the shader fails to compile (fail-visible: the draw drops, no output line).
 
+**The tapped PC must also come BEFORE the shader's `EXP POS0`**, which for an NGG VS is often well short of
+the end of the program (#2064). The redirect is applied when the instruction at the tapped PC is walked, so a
+PC *after* the position export leaves it unapplied — and until #2064 that degraded **silently**: the real clip
+positions were exported while the probe header still announced "values below are the tapped VGPR". A
+plausible, well-labelled, completely wrong answer.
+
+It is now fail-visible. The recompiler prints, capped:
+
+```
+[shader-tap] NOT APPLIED at the position export: PROSPER_SHADER_TAP pc=439 was not reached before
+EXP POS0 in this vertex shader, so the REAL clip position is exported.
+```
+
+Read that line together with the probe's `SHADER-TAP REQUESTED` header: the header says what was *asked
+for*, and the **absence** of a NOT APPLIED line for the same shader is what says it was delivered. Note the
+line is expected and harmless when the tapped PC belongs to another stage — `PROSPER_SHADER_TAP` is global, so
+a PC tapped in the pixel shader is legitimately absent from every vertex shader. That is why this warns rather
+than rejecting: refusing would drop every draw in the frame for a tap doing exactly what it was asked.
+
 ## Fragment I/O value tap — `PROSPER_FS_TAP=DRAW:PC` (what did the fragment shader compute at PC?)
 
 ```bash


### PR DESCRIPTION
`PROSPER_SHADER_TAP=PC` redirects `gl_Position` to the VGPR snapshotted at `PC`. The redirect is
applied when the instruction at `tap_pc` is **walked** — so a `tap_pc` *after* the shader's
`EXP POS0` leaves `tap_vec` at 0 and the **real clip position** is exported, while the readout still
prints *"values below are the tapped VGPR"*.

A plausible, well-labelled, completely wrong answer, with nothing in the output distinguishing it
from a working tap. The README already called the loop/if case fail-visible (*"the draw drops, no
output line"*); this case was not visible at all.

## Warned, not rejected — and that is the load-bearing choice

The issue prefers refusal, on the correct general principle that *an instrument which cannot show its
lever moved should refuse rather than answer*. **It does not hold here**, because `tap_pc` is
**global across stages**: a PC tapped in the pixel shader is legitimately absent from every vertex
shader in the frame. Refusing at the position export would drop **every draw** for a tap doing
exactly what it was asked.

So the line names the PC and lets a reader separate the defect (*"pc is after the export"*) from the
expected (*"pc belongs to another stage"*) immediately:

```
[shader-tap] NOT APPLIED at the position export: PROSPER_SHADER_TAP pc=439 was not reached
before EXP POS0 in this vertex shader, so the REAL clip position is exported.
```

Capped at 8.

## Both halves, because either alone still misleads

The recompiler warns; and the probe header — which was gated on the **request** rather than on
whether the redirect happened — now reads `SHADER-TAP REQUESTED` and points at the NOT APPLIED line.
They must be read together: the header states what was *asked for*, and the **absence** of a NOT
APPLIED line for that shader is what says it was delivered.

## An unverified claim I nearly shipped

The warn counter was first a plain `static unsigned`, with a comment asserting *"recompile is
serialized"*. I could not establish that — `parallel_draw_worker_execute` realizes draws on worker
threads and realization recompiles, and `ShaderCache`'s mutex demonstrably guards the *cache* without
my being able to show it also spans the recompile.

It is now `std::atomic` with that reasoning recorded in place. One relaxed add is not worth an
unverified serialization claim sitting in a comment where the next reader inherits it.

## README

`tools/gpu_replay/README.md` gains the constraint next to the existing loop/if caveat: the tapped PC
must precede `EXP POS0`, which for an NGG VS is often well short of the end of the program.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  176 tests, 174 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

**Diagnostic-only**: the emitted SPIR-V is unchanged in every case — the `else` branch builds the
same `CompositeConstruct` it always did — and nothing prints unless `PROSPER_SHADER_TAP` is set.

Fixes #2064