### PR TITLE
test(hle_calls): the nine-state positive control, lifted out of gdb so it can be tested

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -118,6 +118,14 @@ if(Python3_Interpreter_FOUND)
   # test reads the produced bytes at their gABI offsets; nothing else can see this class of bug.
   add_test(NAME il2cpp_prx_to_elf_header
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/il2cpp/test_prx_to_elf.py")
+  # hle_calls decides, per run, whether a reader should TRUST an entire measurement -- a nine-state
+  # verdict machine whose most consequential branch is VOID vs VIOLATED ("this run cannot say" vs
+  # "distrust every value in it"). It had no test at all, because hle_calls_gdb.py does `import gdb`
+  # at module scope and nothing in it was reachable outside a gdb process. #2053 lifted the verdict
+  # into hle_calls_control.py, which the gdb script now forwards to, so this asserts on the code that
+  # actually runs rather than on a copy.
+  add_test(NAME hle_calls_positive_control
+           COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/hle_calls/test_hle_calls.py")
   add_test(NAME snapshot_guard_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
   add_test(NAME gpu_replay_regress_logic

--- a/prosper/tools/hle_calls/hle_calls_control.py
+++ b/prosper/tools/hle_calls/hle_calls_control.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""The `hle_calls` value-capture positive control, lifted out of the gdb script (#2053).
+
+`hle_calls_gdb.py` does `import gdb` at module scope, so nothing in it can be imported outside a
+gdb process and no ordinary test could reach any of it. The verdict machine needs nothing from gdb:
+it is a pure function of (mode, values_enabled, counts, values). Lifting it here lets the whole
+nine-state table be tested with no gdb dependency and no fixture process, and leaves the gdb script
+importing the same code the test asserts on -- which is the only arrangement where the test means
+anything.
+
+The docstring on `positive_control` is the contract; it moved here verbatim.
+"""
+
+CONTROL = "s_user_getevent"
+CONTROL_LOGIN = 0
+CONTROL_NO_EVENT = 0x80960007
+
+
+def positive_control(mode, values_enabled, counts, values,
+                     control=CONTROL, control_login=CONTROL_LOGIN,
+                     control_no_event=CONTROL_NO_EVENT):
+    """Verdict on this run's value capture -- `(token, note)`, note "" when nothing is wrong.
+
+    The control is `s_user_getevent`, whose contract is derivable from the source before any run:
+    exactly one LOGIN (`0x0`) per PROCESS, `0x80960007` forever after. **The expected observation is
+    therefore mode-dependent, and that is the whole point of computing it here** -- an earlier
+    revision of this tool documented the launch-mode expectation as if it held everywhere, which told
+    a reader of a perfectly good attach capture to throw it away.
+
+      launch  the window opens at the first instruction, so the single LOGIN falls inside it:
+              exactly one `0x0` is required, and its absence is a signal.
+      attach  init consumed the LOGIN before gdb could attach, so a correct capture has none. Zero or
+              one is normal; only more than one is impossible.
+
+    Absence of the control is not a violation, and the two ways to have none are reported apart:
+    `not-in-filter` (never armed) and `not-called` (armed, never entered). Either way the run carries
+    no value-capture control at all.
+
+    A missing LOGIN in launch mode is only VIOLATED when every one of the control's calls was
+    captured. If any return was lost, a miss and a loss are indistinguishable and the verdict is VOID
+    -- an instrument that cannot tell those apart must not pick one.
+    """
+    if not values_enabled:
+        return ("unchecked(values-off)",
+                "no return values were recorded, so this run has no value-capture control; "
+                "the call counts are unaffected. Re-run with --values to check the mechanism.")
+    if control not in counts:
+        return ("not-in-filter",
+                "%s was never armed (--filter excluded it, or this binary has no such "
+                "handler), so nothing in this run checks the value-capture mechanism. Widen "
+                "--filter to include it before believing a surprising value." % control)
+    calls = counts[control]
+    if calls == 0:
+        return ("not-called",
+                "%s was armed but never entered in this window, so nothing in this run checks "
+                "the value-capture mechanism." % control)
+
+    seen = values.get(control, {})
+    captured = sum(seen.values())
+    logins = seen.get(control_login, 0)
+    unexpected = sorted(v for v in seen if v not in (control_login, control_no_event))
+
+    if unexpected:
+        return ("VIOLATED(unexpected-ret-%#x)" % unexpected[0],
+                "%s can only answer 0x0 or %#x, so a captured %#x means the capture itself is "
+                "wrong (or the handler changed). Distrust every value in this run."
+                % (control, control_no_event, unexpected[0]))
+    if logins > 1:
+        return ("VIOLATED(login-x%d)" % logins,
+                "%s delivers LOGIN once per process, so %d captured 0x0 returns cannot all be "
+                "real. Distrust every value in this run." % (control, logins))
+    if logins == 1:
+        return ("ok", "")
+    if mode != "launch":
+        return ("absent(attach:login-consumed-pre-window)",
+                "expected in attach mode and NOT a defect: init consumed the once-per-process "
+                "LOGIN long before gdb could attach. Do not discard this run's values over it -- "
+                "but note that nothing in it independently confirms the mechanism either; only "
+                "--launch can.")
+    if captured != calls:
+        return ("VOID(%d-returns-for-%d-calls)" % (captured, calls),
+                "the launch window covered init yet captured no LOGIN -- but only %d returns were "
+                "recorded for %s's %d calls, so a lost value and a wrong one are indistinguishable "
+                "here. This run neither confirms nor refutes the mechanism."
+                % (captured, control, calls))
+    return ("VIOLATED(launch-window-no-login)",
+            "the window started at the first instruction and captured all %d %s returns, none of "
+            "them the once-per-process LOGIN. Distrust every value in this run -- unless the guest "
+            "only ever passed a null event pointer, which returns NO_EVENT without consuming the "
+            "LOGIN." % (calls, control))

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -68,7 +68,13 @@ here is a tool bug, not a new emulator defect.
 """
 
 import os
+import sys
 import gdb
+
+# gdb runs this file with `-x`, which does NOT put its directory on sys.path -- so the sibling import
+# below has to be made reachable explicitly (#2053).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import hle_calls_control as _control
 
 
 def _load_syms(path):
@@ -166,82 +172,15 @@ def _on_exited(event):
 
 
 def _positive_control():
-    """Verdict on this run's value capture — `(token, note)`, note "" when nothing is wrong.
+    """Forwards to the lifted, gdb-free verdict machine (#2053).
 
-    The control is `s_user_getevent`, whose contract is derivable from the source before
-    any run: exactly one LOGIN (`0x0`) per PROCESS, `0x80960007` forever after. **The
-    expected observation is therefore mode-dependent, and that is the whole point of
-    computing it here** — an earlier revision of this tool documented the launch-mode
-    expectation as if it held everywhere, which told a reader of a perfectly good attach
-    capture to throw it away.
-
-      launch  the window opens at the first instruction, so the single LOGIN falls
-              inside it: exactly one `0x0` is required, and its absence is a signal.
-      attach  init consumed the LOGIN before gdb could attach, so a correct capture
-              has none. Zero or one is normal; only more than one is impossible.
-
-    Absence of the control is not a violation, and the two ways to have none are
-    reported apart: `not-in-filter` (never armed — `--filter` excluded it, or the binary
-    does not export it) and `not-called` (armed, but the guest never entered it in this
-    window). Either way the run carries no value-capture control at all, which the docs
-    ask for "every time" and nothing else would say.
-
-    A missing LOGIN in launch mode is only reported as VIOLATED when every one of the
-    control's calls was captured. If any return was lost (longjmp/teardown, see
-    `out_of_scope`), a miss and a loss are indistinguishable and the verdict is VOID —
-    an instrument that cannot tell those apart must not pick one.
+    The logic lives in `hle_calls_control.py` so a test can reach it: this file does `import gdb` at
+    module scope, so nothing here is importable outside a gdb process and the nine-state table had no
+    coverage at all. The test asserts on the SAME function this calls -- a copy would test itself.
     """
-    if not VALUES:
-        return ("unchecked(values-off)",
-                "no return values were recorded, so this run has no value-capture control; "
-                "the call counts are unaffected. Re-run with --values to check the mechanism.")
-    if CONTROL not in counts:
-        return ("not-in-filter",
-                "%s was never armed (--filter excluded it, or this binary has no such "
-                "handler), so nothing in this run checks the value-capture mechanism. Widen "
-                "--filter to include it before believing a surprising value." % CONTROL)
-    calls = counts[CONTROL]
-    if calls == 0:
-        return ("not-called",
-                "%s was armed but never entered in this window, so nothing in this run checks "
-                "the value-capture mechanism." % CONTROL)
+    return _control.positive_control(MODE, VALUES, counts, values,
+                                     CONTROL, CONTROL_LOGIN, CONTROL_NO_EVENT)
 
-    seen = values.get(CONTROL, {})
-    captured = sum(seen.values())
-    logins = seen.get(CONTROL_LOGIN, 0)
-    unexpected = sorted(v for v in seen if v not in (CONTROL_LOGIN, CONTROL_NO_EVENT))
-
-    if unexpected:
-        return ("VIOLATED(unexpected-ret-%#x)" % unexpected[0],
-                "%s can only answer 0x0 or %#x, so a captured %#x means the capture itself is "
-                "wrong (or the handler changed). Distrust every value in this run."
-                % (CONTROL, CONTROL_NO_EVENT, unexpected[0]))
-    if logins > 1:
-        return ("VIOLATED(login-x%d)" % logins,
-                "%s delivers LOGIN once per process, so %d captured 0x0 returns cannot all be "
-                "real. Distrust every value in this run." % (CONTROL, logins))
-    if logins == 1:
-        return ("ok", "")
-    # No LOGIN captured.
-    if MODE != "launch":
-        return ("absent(attach:login-consumed-pre-window)",
-                "expected in attach mode and NOT a defect: init consumed the once-per-process "
-                "LOGIN long before gdb could attach. Do not discard this run's values over it — "
-                "but note that nothing in it independently confirms the mechanism either; only "
-                "--launch can.")
-    # Same comparison the per-row `(captured N/M)` makes, and for the same reason: a value set
-    # that does not account for every call cannot support an inference from an ABSENT value.
-    if captured != calls:
-        return ("VOID(%d-returns-for-%d-calls)" % (captured, calls),
-                "the launch window covered init yet captured no LOGIN — but only %d returns were "
-                "recorded for %s's %d calls, so a lost value and a wrong one are indistinguishable "
-                "here. This run neither confirms nor refutes the mechanism."
-                % (captured, CONTROL, calls))
-    return ("VIOLATED(launch-window-no-login)",
-            "the window started at the first instruction and captured all %d %s returns, none of "
-            "them the once-per-process LOGIN. Distrust every value in this run — unless the guest "
-            "only ever passed a null event pointer, which returns NO_EVENT without consuming the "
-            "LOGIN." % (calls, CONTROL))
 
 
 gdb.execute("set pagination off")

--- a/prosper/tools/hle_calls/test_hle_calls.py
+++ b/prosper/tools/hle_calls/test_hle_calls.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""The hle_calls value-capture positive control, one assertion per state (#2053).
+
+Twelve tools under prosper/tools ship a test_<name>.py; hle_calls shipped none -- and it carries a
+nine-state verdict machine that decides whether a reader should trust an entire measurement. A
+refactor that silently broke one arm would have been caught only if a human happened to notice the
+header field in a future run.
+
+The verdict logic was reachable only from inside gdb (`import gdb` at module scope), so #2053 lifted
+it into hle_calls_control.py. This asserts on that same function -- the gdb script forwards to it, so
+a break here is a break there. A copied table would test itself.
+
+The nine rows were verified BY EXECUTION during #2035's review, against a throwaway C++ fixture under
+real gdb 17.2. They are known-correct rather than aspirational; this commits them.
+"""
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from hle_calls_control import positive_control, CONTROL, CONTROL_LOGIN, CONTROL_NO_EVENT
+
+fails = 0
+
+
+def check(cond, label):
+    global fails
+    if cond:
+        print("  [ok]   %s" % label)
+    else:
+        print("  [FAIL] %s" % label)
+        fails += 1
+
+
+def token(mode, values_enabled, counts, values):
+    return positive_control(mode, values_enabled, counts, values)[0]
+
+
+def main():
+    print("== test_hle_calls ==")
+    N = CONTROL_NO_EVENT
+    L = CONTROL_LOGIN
+
+    # --values off: the counts are still good, so this must NOT read as a failure.
+    check(token("launch", False, {}, {}) == "unchecked(values-off)", "values-off is unchecked, not a violation")
+
+    # The two ways to have no control at all, which must stay distinguishable: never armed vs armed
+    # and never entered. Collapsing them would tell a reader to widen --filter when the filter was
+    # already right.
+    check(token("launch", True, {}, {}) == "not-in-filter", "control absent from counts is not-in-filter")
+    check(token("launch", True, {CONTROL: 0}, {}) == "not-called", "control armed but unentered is not-called")
+
+    # A value the contract cannot produce means the CAPTURE is wrong, not the guest.
+    check(token("attach", True, {CONTROL: 3}, {CONTROL: {L: 1, 0x1: 1, N: 1}}).startswith("VIOLATED(unexpected-ret-0x1)"),
+          "an impossible return value violates, naming the value")
+
+    # LOGIN is once per PROCESS, so two cannot both be real.
+    check(token("launch", True, {CONTROL: 4}, {CONTROL: {L: 2, N: 2}}) == "VIOLATED(login-x2)",
+          "two LOGINs violate")
+
+    # The good case.
+    check(token("launch", True, {CONTROL: 3}, {CONTROL: {L: 1, N: 2}}) == "ok", "one LOGIN in launch mode is ok")
+
+    # attach with no LOGIN is EXPECTED -- this is the row an earlier revision got wrong, telling a
+    # reader of a perfectly good attach capture to throw it away.
+    check(token("attach", True, {CONTROL: 5}, {CONTROL: {N: 5}}) == "absent(attach:login-consumed-pre-window)",
+          "attach with no LOGIN is absent(), not a violation")
+
+    # launch, no LOGIN, and NOT every return captured: a miss and a loss are indistinguishable, so
+    # the instrument must refuse to pick one.
+    check(token("launch", True, {CONTROL: 6}, {CONTROL: {N: 5}}) == "VOID(5-returns-for-6-calls)",
+          "launch with a lost return is VOID, not VIOLATED")
+
+    # launch, no LOGIN, every return accounted for: now it IS a violation.
+    check(token("launch", True, {CONTROL: 6}, {CONTROL: {N: 6}}) == "VIOLATED(launch-window-no-login)",
+          "launch with all returns captured and no LOGIN violates")
+
+    # The VOID/VIOLATED boundary is the single most consequential branch here -- it is the difference
+    # between "distrust this run" and "this run cannot say". Pin it at exactly one lost return.
+    check(token("launch", True, {CONTROL: 6}, {CONTROL: {N: 6}}) != token("launch", True, {CONTROL: 6}, {CONTROL: {N: 5}}),
+          "one lost return is what separates VIOLATED from VOID")
+
+    # The display cap and the verdict read DIFFERENT structures: truncation lives in the print loop,
+    # the verdict reads the full dict. A value pushed out of a displayed top-6 must still violate --
+    # exactly the separation a later refactor collapses by accident.
+    buried = {L: 1}
+    for i in range(1, 8):
+        buried[0x8096F000 + i] = 100 - i          # seven values, all outranking the stray below
+    buried[0x1] = 1                                # rank 9: never displayed
+    check(token("attach", True, {CONTROL: sum(buried.values())}, {CONTROL: buried}) ==
+          "VIOLATED(unexpected-ret-0x1)",
+          "a value ranked out of the displayed top-6 still violates")
+
+    # A note must accompany every non-ok verdict: a bare token tells a reader nothing to act on.
+    for mode, ve, c, v in (("launch", False, {}, {}), ("launch", True, {}, {}),
+                           ("launch", True, {CONTROL: 0}, {}),
+                           ("attach", True, {CONTROL: 5}, {CONTROL: {N: 5}}),
+                           ("launch", True, {CONTROL: 6}, {CONTROL: {N: 5}}),
+                           ("launch", True, {CONTROL: 6}, {CONTROL: {N: 6}})):
+        tok, note = positive_control(mode, ve, c, v)
+        check(bool(note.strip()), "verdict %s carries an actionable note" % tok)
+    check(positive_control("launch", True, {CONTROL: 3}, {CONTROL: {L: 1, N: 2}})[1] == "",
+          "the ok verdict carries no note")
+
+    print("== FAILURES: %d ==" % fails if fails else "== all checks passed ==")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Twelve tools under `prosper/tools` ship a `test_<name>.py`. `hle_calls` shipped **none** — and it
carries a nine-state verdict machine that decides, per run, whether a reader should trust an **entire
measurement**. A refactor that silently broke one arm would have been caught only if a human happened
to notice the header field in a future run.

It was **untestable rather than untested**: `hle_calls_gdb.py` does `import gdb` at module scope, so
nothing in it can be imported outside a gdb process.

## The lift

The verdict needs nothing from gdb — it is a pure function of
`(mode, values_enabled, counts, values)`. Moved **verbatim** into `hle_calls_control.py`, which the
gdb script now **forwards to**.

That direction matters: the test asserts on the code that actually runs. A copied table would test
itself.

The gdb script needed `sys.path.insert(dirname(__file__))`, because gdb runs it with `-x`, which does
not put the script's directory on `sys.path`.

## The table

| state | verdict |
| --- | --- |
| `--values` off | `unchecked` — **not** a violation; the counts are unaffected |
| control not in counts | `not-in-filter` (never armed) |
| control armed, 0 calls | `not-called` (armed, never entered) |
| an impossible return value | `VIOLATED`, naming the value |
| two LOGINs | `VIOLATED` — it is once per **process** |
| one LOGIN, launch | `ok` |
| attach, no LOGIN | `absent()` — **not** a violation |
| launch, no LOGIN, a lost return | `VOID` |
| launch, no LOGIN, all returns captured | `VIOLATED` |

The two "no control at all" states are kept **distinguishable** on purpose: collapsing them would
tell a reader to widen `--filter` when the filter was already right. And the `attach` row is the one
an earlier revision got wrong — it told a reader of a perfectly good attach capture to throw it away.

Three more assertions pin boundaries the states alone do not:

- **one lost return is exactly what separates `VOID` from `VIOLATED`** — the most consequential
  branch here, *"this run cannot say"* versus *"distrust every value in it"*;
- **a value ranked out of the displayed top-6 still violates**, because the display cap and the
  verdict read *different structures* (truncation lives in the print loop, the verdict reads the full
  dict) — exactly the separation a later refactor collapses by accident;
- every non-`ok` verdict carries an actionable note, and `ok` carries none.

These nine were verified **by execution** during #2035's review against a throwaway C++ fixture under
real gdb 17.2. They were known-correct and uncommitted; this commits them.

## Mutation-verified

```
removing the VOID branch     -> 2 FAILs (the VOID row and the boundary row)
treating attach like launch  -> 1 FAIL  (the attach row specifically)
```

Each mutation turns a **named row** red rather than the suite — the property that makes the table
diagnostic rather than decorative.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  177 tests, 175 passed   (176 before; the new one is
                                                         hle_calls_positive_control)
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

The gdb script's `-75` lines are the moved function; I spot-checked that the contract docstring
survived **verbatim** in the helper rather than being summarised away.

Fixes #2053