### PR TITLE
hle: four callsite scans used the weak module predicate, accepting stub addresses

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -984,7 +984,11 @@ HLE9(agc_cb_release_mem) {  // sceAgcCbReleaseMem(buf, action, gcr_cntl, dst, ca
         uint64_t ra = 0, ra2 = 0, ra3 = 0;
         for (int i = 1; i < 96; i++) {
             uint64_t v = stack_scan[i];
-            if (prosper::guest_va_in_module(v)) {   // #1659: was a stale literal base
+            // guest_va_in_module_code, not guest_va_in_module: the weak form accepts the BOOT_STUB
+            // aperture, so a stack slot holding an import trampoline's address is taken for a guest
+            // return address. Here that address is a CORRELATION KEY, so a stub address does not
+            // merely mislabel a log line -- it changes chain identity (#2045, same fix as #2000).
+            if (prosper::guest_va_in_module_code(v)) {   // #1659: was a stale literal base
                 if (!ra) ra = v; else if (!ra2) ra2 = v; else { ra3 = v; break; }
             }
         }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -562,7 +562,9 @@ namespace {
         int n = 0;
         for (int i = 1; i < scan && n < kWant; i++) {
             const uint64_t v = frame[i];
-            if (!guest_va_in_module(v)) continue;
+            // guest_va_in_module_code: the weak form accepts BOOT_STUB, so an import
+            // trampoline's address would be recovered as the dmem caller (#2045).
+            if (!guest_va_in_module_code(v)) continue;
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
             ra[n++] = v;
         }
@@ -2700,7 +2702,9 @@ namespace {
         int n = 0;
         for (int i = 1; i < scan && n < kWant; i++) {
             const uint64_t v = frame[i];
-            if (!guest_va_in_module(v)) continue;
+            // guest_va_in_module_code: the weak form accepts BOOT_STUB, so an import
+            // trampoline's address would be recovered as the dmem caller (#2045).
+            if (!guest_va_in_module_code(v)) continue;
             if (n && ra[n - 1] == v) continue;      // collapse an adjacent duplicate spill
             ra[n++] = v;
         }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -1124,7 +1124,9 @@ HLE(k_eq_wait)   {   // (eq, SceKernelEvent* ev, int num, int* out, SceKernelUse
             uint64_t* sp = (uint64_t*)__builtin_frame_address(0);
             for (int i = 0; i < 160; i++) {
                 uint64_t v = sp[i];
-                if (!prosper::guest_va_in_module(v)) continue;   // any fixed guest module (#1659)
+                // _code: the weak form accepts BOOT_STUB, and the call-shape check below is
+                // explicitly written for an in-eboot thunk rather than the stub region (#2045).
+                if (!prosper::guest_va_in_module_code(v)) continue;   // any fixed guest module (#1659)
                 // A genuine caller is a return address preceded by a call: `call rel32` (0xe8 at v-5,
                 // any target — the import call goes through an in-eboot thunk, NOT straight to the
                 // stub region, so no target filter) or an indirect `call` (0xff at v-6/-3/-2).


### PR DESCRIPTION
**Part 2 of #2045.** `Refs`, not `Fixes` — part 1 (`--values` out-structs) is a feature, not a swap,
and what remains is recorded on the issue.

#2000 fixed two guest-callsite scans in `hle_file.cpp`. Four more had the same defect, and the
difference between the predicates is one clause:

```cpp
guest_va_in_module_code(a) == guest_va_in_module(a) && !(a >= BOOT_STUB && a < BOOT_STUB_END)
```

So the weak form **accepts the import-trampoline aperture**. A stack slot holding a stub address is
then taken for a guest return address, and the scan reports the trampoline instead of the guest's
real call site.

**Two of the four are stronger cases than the ones already fixed**, because the recovered address is
a **correlation key** rather than only printed — a stub address there changes chain identity, not
just a log line.

| file | scan |
| --- | --- |
| `hle_agc.cpp` | guest callsite attribution |
| `hle_kernel_mem.cpp` | both dmem caller scans — the correlation-key pair |
| `hle_kernel_time.cpp` | `PROSPER_WAITCALLER` scan |

Each was **read before swapping**, and all four are stack scans recovering guest return addresses —
every one wants guest *code*, so the swap is correct at each rather than mechanically applied.
`grep 'guest_va_in_module(' | grep -v '_code('` over `src/hle` is now empty.

The time site is worth a note: its own comment already says a genuine caller is a return address
preceded by a call, and that *"the import call goes through an in-eboot thunk, **not** straight to the
stub region"*. **The predicate it used contradicted the filter written directly beneath it.**

## Not done, and why

The issue also asks to clamp `hle_agc`'s scan to `stack_words_above()` while there — it reads `sp[i]`
for `i < 96` unclamped, and `hle_file.cpp`'s equivalent carries the comment *"a diagnostic must not be
able to fault the load it is describing"*.

Correct, and not folded in: **`stack_words_above` is file-static in `hle_file.cpp`**, so clamping
needs it lifted across translation units — a different change with a different blast radius. The
`hle_kernel_time` scan (`i < 160`) is unclamped for the same reason and wants the same treatment.
Both recorded on the issue rather than left implicit.

Line numbers in the issue are stale (238/2601/984 vs 987/565/2703/1127); the sites were located by
predicate rather than by line.

## Verification

```
Windows, MinGW (WinLibs UCRT g++ 16.1.0)
ctest --no-tests=error -j4  ->  177 tests, 175 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

No test asserts on these scans: they are diagnostic output whose values are **run-local addresses**,
and a test that pinned one would pin the address. The change is a one-clause narrowing of a
predicate, verified by reading each of the four sites and by the now-empty grep.

Refs #2045