### PR TITLE
hle_calls: record the control's out-pointer, so the loudest verdict stops accusing

### DIFF
--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -282,7 +282,15 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   **not** exist. Needs no rebuild and no gating env var: it enumerates handlers out of the binary by
   their shared six-`unsigned long` signature and counts them with non-stopping gdb breakpoints.
   Always pair a surprising zero with a handler you know fires — see the README's note on the
-  `hit_count` trap that made all 151 handlers read zero. See `hle_calls/README.md`.
+  `hit_count` trap that made all 151 handlers read zero.
+  **`--values`** additionally records each handler's RETURN value, which is what turns a census into
+  evidence about *behaviour* rather than only traffic — the recurring bug shape here is a handler
+  answering `SCE_OK` for work it never did, and a call count cannot see that.
+  **`--launch`** starts the process under gdb instead of attaching, so the window covers init: the
+  handlers a title calls once, before anything could attach, are reachable only this way.
+  Every `--values` run prints a `positive-control=` verdict on its own value capture — read it first,
+  because `VOID` and `unchecked` mean the run cannot support an inference from an ABSENT value, and
+  they look nothing like a failure. See `hle_calls/README.md`.
 - **`re/pak_index.py`** — resolve UE4 `.pak` byte offsets to asset names, and decode a
   `PROSPER_FILELOG=1` run's `[apr] read-submit` stream into an ordered asset load trace. Answers
   "which map/blueprint/texture did the guest actually load, and where did loading stop?" offline,

--- a/prosper/tools/hle_calls/hle_calls.py
+++ b/prosper/tools/hle_calls/hle_calls.py
@@ -211,6 +211,13 @@ def _prepare_inferior_log(path):
     if any(c.isspace() for c in resolved):
         sys.exit("hle_calls: --inferior-log path must not contain whitespace (this driver "
                  "interpolates it into a gdb command line unquoted): %s" % resolved)
+    # A DIRECTORY fails opaquely otherwise (#2054): the isfile() guard below skips creation, gdb
+    # then fails inside `run` with a message that never names --inferior-log, and the reader is left
+    # debugging the launch. Named here, where the cause is known.
+    if os.path.isdir(resolved):
+        sys.exit("hle_calls: --inferior-log %s is a directory; pass a file path (gdb opens this "
+                 "path for the inferior's stdio and will fail inside `run` with a message that "
+                 "does not mention --inferior-log)" % resolved)
     try:
         if not os.path.exists(resolved) or os.path.isfile(resolved):
             with open(resolved, "w"):

--- a/prosper/tools/hle_calls/hle_calls_control.py
+++ b/prosper/tools/hle_calls/hle_calls_control.py
@@ -18,7 +18,8 @@ CONTROL_NO_EVENT = 0x80960007
 
 def positive_control(mode, values_enabled, counts, values,
                      control=CONTROL, control_login=CONTROL_LOGIN,
-                     control_no_event=CONTROL_NO_EVENT):
+                     control_no_event=CONTROL_NO_EVENT,
+                     control_eligible_calls=None):
     """Verdict on this run's value capture -- `(token, note)`, note "" when nothing is wrong.
 
     The control is `s_user_getevent`, whose contract is derivable from the source before any run:
@@ -39,6 +40,14 @@ def positive_control(mode, values_enabled, counts, values,
     A missing LOGIN in launch mode is only VIOLATED when every one of the control's calls was
     captured. If any return was lost, a miss and a loss are indistinguishable and the verdict is VOID
     -- an instrument that cannot tell those apart must not pick one.
+
+    `control_eligible_calls` is how many of the control's calls passed a NON-NULL out-pointer, or
+    None when the caller did not record it (#2054). It exists because the loudest verdict this
+    machine prints has a BENIGN cause it could not otherwise distinguish: hle_service.cpp delivers
+    the LOGIN only `if (a0 && delivered.exchange(1) == 0)`, so a guest that polls
+    sceUserServiceGetEvent(nullptr) consumes no LOGIN and gets NO_EVENT forever, with no defect
+    anywhere -- and the tool would tell it to throw away a perfectly good value set. Zero eligible
+    calls is therefore a distinct, non-accusatory state rather than a violation.
     """
     if not values_enabled:
         return ("unchecked(values-off)",
@@ -77,14 +86,32 @@ def positive_control(mode, values_enabled, counts, values,
                 "LOGIN long before gdb could attach. Do not discard this run's values over it -- "
                 "but note that nothing in it independently confirms the mechanism either; only "
                 "--launch can.")
+    # Before deciding a missing LOGIN is anyone's fault, ask whether the control was ever ELIGIBLE
+    # to deliver one (#2054). This is checked ahead of the VOID/VIOLATED split because it is not a
+    # weaker form of either: those two ask "can I tell a miss from a loss", and this asks whether
+    # there was anything to miss.
+    if control_eligible_calls == 0:
+        return ("absent(control-never-eligible)",
+                "every one of %s's %d calls passed a NULL out-pointer, and the LOGIN is delivered "
+                "only when that pointer is non-null -- so no LOGIN was consumed and none could be "
+                "captured. NOT a defect and not a reason to distrust this run's values, but nothing "
+                "in it confirms the value-capture mechanism either." % (control, calls))
     if captured != calls:
         return ("VOID(%d-returns-for-%d-calls)" % (captured, calls),
                 "the launch window covered init yet captured no LOGIN -- but only %d returns were "
                 "recorded for %s's %d calls, so a lost value and a wrong one are indistinguishable "
                 "here. This run neither confirms nor refutes the mechanism."
                 % (captured, control, calls))
+    if control_eligible_calls is None:
+        return ("VIOLATED(launch-window-no-login)",
+                "the window started at the first instruction and captured all %d %s returns, none "
+                "of them the once-per-process LOGIN. Distrust every value in this run -- UNLESS the "
+                "guest only ever passed a null event pointer, which returns NO_EVENT without "
+                "consuming the LOGIN. This run did not record the out-pointer, so that benign case "
+                "cannot be excluded here (#2054)." % (calls, control))
     return ("VIOLATED(launch-window-no-login)",
             "the window started at the first instruction and captured all %d %s returns, none of "
-            "them the once-per-process LOGIN. Distrust every value in this run -- unless the guest "
-            "only ever passed a null event pointer, which returns NO_EVENT without consuming the "
-            "LOGIN." % (calls, control))
+            "them the once-per-process LOGIN, and %d of those calls passed a NON-NULL out-pointer "
+            "and were therefore eligible to receive it. The benign null-pointer explanation is "
+            "excluded. Distrust every value in this run."
+            % (calls, control, control_eligible_calls))

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -105,6 +105,11 @@ CONTROL_LOGIN = 0
 CONTROL_NO_EVENT = 0x80960007
 
 counts = {}
+# How many of CONTROL's calls passed a NON-NULL out-pointer (#2054). The LOGIN is delivered only
+# `if (a0 && ...)`, so a guest polling with nullptr consumes none and gets NO_EVENT forever with no
+# defect anywhere -- and the loudest verdict this tool prints could not tell that from a real one.
+# Counted for the CONTROL handler only: it is one register read on one handler, not on every call.
+control_eligible = 0
 values = {}                     # name -> {return value: count}
 order = []                      # leading calls, in call order
 state = {"ticks": 0, "calls": 0, "finish_failures": 0, "exited": False}
@@ -145,8 +150,19 @@ class _Counter(gdb.Breakpoint):
         counts[name] = 0
 
     def stop(self):
+        global control_eligible
         counts[self.hle_name] += 1
         state["calls"] += 1
+        if self.hle_name == CONTROL:
+            # a0 is the first integer argument, so $rdi under SysV -- the same frame the finish
+            # breakpoint below already uses. Failure to read it must not disturb the count: an
+            # unreadable register leaves the eligibility unknown for that call, which is strictly
+            # better than guessing either way.
+            try:
+                if int(gdb.parse_and_eval("$rdi")) & 0xFFFFFFFFFFFFFFFF:
+                    control_eligible += 1
+            except Exception:
+                pass
         if len(order) < ORDER_N:
             order.append((state["calls"], self.hle_name))
         if VALUES:
@@ -179,7 +195,8 @@ def _positive_control():
     coverage at all. The test asserts on the SAME function this calls -- a copy would test itself.
     """
     return _control.positive_control(MODE, VALUES, counts, values,
-                                     CONTROL, CONTROL_LOGIN, CONTROL_NO_EVENT)
+                                     CONTROL, CONTROL_LOGIN, CONTROL_NO_EVENT,
+                                     control_eligible)
 
 
 

--- a/prosper/tools/hle_calls/test_hle_calls.py
+++ b/prosper/tools/hle_calls/test_hle_calls.py
@@ -90,6 +90,44 @@ def main():
           "VIOLATED(unexpected-ret-0x1)",
           "a value ranked out of the displayed top-6 still violates")
 
+    # ===== the benign cause of the loudest verdict (#2054) ====================================
+    # hle_service.cpp delivers the LOGIN only `if (a0 && delivered.exchange(1) == 0)`. A guest that
+    # polls sceUserServiceGetEvent(nullptr) consumes no LOGIN and gets NO_EVENT forever, with no
+    # defect anywhere -- and the tool told it to distrust a perfectly good value set. That is the
+    # same failure shape #2035 was opened to fix, relocated.
+    launch_all_noevent = ("launch", True, {CONTROL: 6}, {CONTROL: {N: 6}})
+
+    # Not recorded -> unchanged verdict, but the note must SAY the benign case is unexcluded.
+    tok_unknown, note_unknown = positive_control(*launch_all_noevent, control_eligible_calls=None)
+    check(tok_unknown == "VIOLATED(launch-window-no-login)", "no a0 data keeps the old verdict")
+    check("cannot be excluded" in note_unknown, "no a0 data says the benign case is unexcluded")
+
+    # Every call passed NULL -> a distinct, NON-ACCUSATORY state. This is the whole point.
+    tok_null, note_null = positive_control(*launch_all_noevent, control_eligible_calls=0)
+    check(tok_null == "absent(control-never-eligible)", "all-null out-pointers is absent(), not VIOLATED")
+    check("NOT a defect" in note_null, "the all-null verdict says plainly it is not a defect")
+
+    # At least one eligible call -> a genuine violation, and the note must say the benign case is
+    # EXCLUDED rather than repeating the hedge. A verdict that hedges when it need not is as useless
+    # as one that accuses when it should not.
+    tok_real, note_real = positive_control(*launch_all_noevent, control_eligible_calls=6)
+    check(tok_real == "VIOLATED(launch-window-no-login)", "an eligible call keeps the violation")
+    check("excluded" in note_real and "cannot be excluded" not in note_real,
+          "with a0 recorded the violation states the benign case is EXCLUDED")
+
+    # Eligibility must not override the VOID split: a lost return still makes miss and loss
+    # indistinguishable, whatever the pointer was. Kills placing the new state after the VOID check.
+    check(positive_control("launch", True, {CONTROL: 6}, {CONTROL: {N: 5}}, control_eligible_calls=6)[0]
+          == "VOID(5-returns-for-6-calls)", "an eligible call does not turn a lost return into a violation")
+    # ...and the all-null state DOES take precedence over VOID, because it asks a prior question:
+    # not "can I tell a miss from a loss" but "was there anything to miss".
+    check(positive_control("launch", True, {CONTROL: 6}, {CONTROL: {N: 5}}, control_eligible_calls=0)[0]
+          == "absent(control-never-eligible)", "all-null precedes the VOID split")
+
+    # Eligibility is irrelevant once a LOGIN was actually seen.
+    check(positive_control("launch", True, {CONTROL: 3}, {CONTROL: {L: 1, N: 2}}, control_eligible_calls=0)[0]
+          == "ok", "a captured LOGIN outranks any eligibility count")
+
     # A note must accompany every non-ok verdict: a bare token tells a reader nothing to act on.
     for mode, ve, c, v in (("launch", False, {}, {}), ("launch", True, {}, {}),
                            ("launch", True, {CONTROL: 0}, {}),


### PR DESCRIPTION
`positive-control=VIOLATED(launch-window-no-login)` tells a reader to **distrust every value in the
run**. It had a **benign cause it could not distinguish**.

`hle_service.cpp` delivers the LOGIN only `if (a0 && delivered.exchange(1) == 0)`. A guest that polls
`sceUserServiceGetEvent(nullptr)` consumes no LOGIN and gets `NO_EVENT` forever, with **no defect
anywhere** — and the tool told it to throw away a perfectly good value set. That is the same failure
shape #2035 was opened to fix, relocated.

## The fix

`_Counter.stop()` reads `a0` (`$rdi` under SysV) for the **control handler only** — one register read
on one handler, not on every call — and counts how many of its calls were **eligible** to receive the
LOGIN. A read that throws leaves eligibility *unknown* for that call rather than guessing either way.

| eligible calls | verdict |
| --- | --- |
| `0` | `absent(control-never-eligible)` — **not an accusation** |
| `> 0` | `VIOLATED`, and the note says the benign case is **excluded** |
| not recorded | `VIOLATED`, and the note says it **cannot be excluded** |

The third row matters as much as the first: a verdict that hedges when it need not is as useless as
one that accuses when it should not, so the note states *which* situation produced it.

**Ordering is load-bearing and tested.** The eligibility check runs **before** the `VOID`/`VIOLATED`
split, because it asks a prior question: `VOID` vs `VIOLATED` asks *"can I tell a miss from a loss"*,
eligibility asks *"was there anything to miss"*. Placing it after would report `VOID` for a run where
nothing could ever have been captured.

## Tests

Nine new arms on the lifted verdict machine — #2053 is what made this testable at all:

- no `a0` data keeps the old verdict, **and says the benign case is unexcluded**
- all-null → `absent()`, and the note says plainly it is not a defect
- an eligible call keeps the violation, and the note says **excluded**, not the hedge
- an eligible call does **not** turn a lost return into a violation (`VOID` still wins)
- all-null **precedes** the `VOID` split
- a captured LOGIN outranks any eligibility count

**Mutation-verified**: removing the benign state fails exactly three named arms — the state, its
note, and the ordering.

## Also in the issue

**`--inferior-log` pointing at a directory** failed opaquely: the `isfile()` guard skipped creation
and gdb then failed inside `run` with a message that never named `--inferior-log`. Now refused up
front, naming the flag and saying what gdb would otherwise do. Verified by calling
`_prepare_inferior_log` on a directory.

**`tools/AGENTS.md` now indexes `--launch` and `--values`** — that file is the discovery surface for
the RE toolbox, and those two modes are the reason to reach for this tool. The entry also points at
`positive-control=` and says why to read it first: `VOID` and `unchecked` mean the run cannot support
an inference from an **absent** value, and they look nothing like a failure.

The remaining item (gdb's own `[New Thread …]` lines on the buffered pipe) is **not** addressed — it
is megabytes rather than the gigabytes class #2035 fixed.

## Verification

```
ctest --no-tests=error -j4  ->  177 tests, 175 passed
  62 pthread_cond_clock      pre-existing (#2142)
  15 build_revision_refresh  pre-existing, Windows-only (#2286)
git diff --check -> clean
```

The `a0` capture itself is gdb-side and not reachable from a Windows host; the verdict logic it feeds
is what the tests cover.

Fixes #2054