### PR TITLE
fix(test): build_revision_refresh survives Git's read-only loose objects on Windows

### DIFF
--- a/prosper/tools/revision/test_build_revision.py
+++ b/prosper/tools/revision/test_build_revision.py
@@ -7,9 +7,32 @@ import argparse
 import os
 from pathlib import Path
 import shutil
+import stat
 import subprocess
 import sys
 import time
+
+
+def _drop_readonly(func, path, _exc):
+    """rmtree error handler: clear the read-only attribute and retry the failed operation.
+
+    Git marks every loose object under `.git/objects` read-only, and Windows refuses to unlink a
+    read-only file -- so a plain `shutil.rmtree` over a scratch repository dies with
+    `PermissionError: [WinError 5] Access is denied` on the first object it reaches (#2286). POSIX
+    decides unlink from the *directory's* permissions, so the same tree removes without complaint
+    there, which is why this only ever failed on the Windows lane.
+    """
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def remove_tree(path: Path) -> None:
+    """`shutil.rmtree` that survives Git's read-only loose objects on Windows."""
+    # `onexc` is 3.12+; `onerror` is the older spelling, still accepted and identical in arity.
+    if sys.version_info >= (3, 12):
+        shutil.rmtree(path, onexc=_drop_readonly)
+    else:
+        shutil.rmtree(path, onerror=_drop_readonly)
 
 
 def run(command: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> str:
@@ -93,7 +116,7 @@ def main() -> int:
 
     scratch = args.scratch_root.resolve()
     if scratch.exists():
-        shutil.rmtree(scratch)
+        remove_tree(scratch)
     scratch.mkdir(parents=True)
 
     source = scratch / "repo"
@@ -159,6 +182,13 @@ def main() -> int:
     build(args.cmake, nongit_build)
     if query(nongit_build) != "unknown":
         raise AssertionError("non-Git build did not use the unknown revision fallback")
+
+    # Remove the scratch tree on SUCCESS only -- a failing run must keep its repositories and
+    # build directories for post-mortem. Doing it here is also what keeps `remove_tree` covered:
+    # every green run deletes a real repository with read-only loose objects (plus a linked
+    # worktree), so a regression in the read-only handling fails `build_revision_refresh` on
+    # Windows instead of waiting to surface as a confusing setup-time error on the *next* run.
+    remove_tree(scratch)
 
     print(f"build revision refreshed {revision_a[:12]} -> {revision_b[:12]} with identical trees")
     return 0


### PR DESCRIPTION
Fixes #2286

## Failure scenario

`ctest --no-tests=error -R build_revision_refresh` fails on Windows in the scratch-directory
removal rather than in anything it asserts:

```
PermissionError: [WinError 5] Access is denied:
  '...\build-revision-regression\repo\.git\objects\13\089a8f231b0243441bca706a1eb115e6c661a1'
```

Git marks every loose object under `.git/objects` **read-only**; Windows refuses to `unlink` a
read-only file. POSIX decides unlink from the *directory's* permissions, so the identical tree
removes without complaint on Linux and macOS — which is why only the Windows lane ever saw it.

Every assertion in the test passes. The red is entirely the cleanup, which is the worst shape for a
gate: it trains readers to treat a red result as noise.

### Correction to the issue text

The issue calls `test_build_revision.py:96` a *teardown*. It is not — it is the **setup** cleanup of
a previous run's leftovers (`if scratch.exists(): shutil.rmtree(scratch)`), and before this PR the
test had no teardown at all. That is also why the issue's "reproduces from clean" line is wrong as
written: on a genuinely empty scratch root line 96 is never reached. The real trigger is the
**second consecutive run**. I wrote the issue and got that detail wrong; the mechanism and the
traceback in it are correct.

## Approach

- `remove_tree(path)` — `shutil.rmtree` with a handler that clears the read-only attribute and
  retries the failed operation. `onexc` on Python 3.12+, `onerror` below it (older spelling, still
  accepted, identical arity).
- Use it for the setup removal.
- **Remove the scratch tree on SUCCESS**, which is what keeps the helper covered: every green run now
  deletes a real repository with read-only loose objects, so a regression fails
  `build_revision_refresh` directly instead of surfacing as a confusing setup-time error on the
  *next* run — exactly how #2286 presented. A **failing** run still keeps its repositories and build
  directories for post-mortem, because the exception propagates before the removal.

## Deliberately unaffected

- No assertion, arm, or ordering changed; the diff adds a helper and two call sites.
- Linux/macOS behaviour is identical apart from the scratch tree no longer persisting after a green
  run. The `onexc` handler never fires there.
- The **sibling** `test_check_build_revision.py` was checked and does *not* share the hazard: its
  `tempfile.TemporaryDirectory` scratch holds only generated build directories — `make_build_dir`
  creates no Git repository, so there are no read-only objects to trip over.
- The three other `shutil.rmtree` sites in `tools/` (`snapshot.py:674`, `:958`, `hang_probe.py:136`)
  all pass `ignore_errors=True` and none of them removes a Git repository, so none can raise here.

## Risk

Low. Test-only, one file. The one behavioural change beyond the fix is deleting the scratch tree
after a green run; a failing run is unchanged.

## Verification (exact head `86eaff4e`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Python 3.12, cmake + Ninja.

**Mechanism reproduced in isolation** — `git init` + one commit, then a plain `rmtree`:

```
loose objects: 3
  r/.git/objects\45\b983be36... writable= False
rmtree FAILED: PermissionError [WinError 5] Access is denied
```

**Two consecutive runs green** (the second is the case the issue reports):

```
run1 rc=0  build revision refreshed a62da6683949 -> 3a0008a37937 with identical trees
run2 rc=0  build revision refreshed 6d3bce45fcbf -> d8bbd1cbb0a6 with identical trees
```

**Mutation arm** — revert *only* the new teardown call to a plain `shutil.rmtree`, leaving everything
else in place. It reproduces this issue's exact error, so the green above is the helper's doing:

```
  File "...\shutil.py", line 633, in _rmtree_unsafe
    os.unlink(fullname)
PermissionError: [WinError 5] Access is denied: '...\brr\repo\.git\objects\13\089a8f231b...'
rc=1
```

`git diff --check` clean. Session-trailer gate: 0.

## Note for the Linux lane — an environment trap I hit getting here

Not part of this diff, recorded because it cost me a wrong diagnosis and will cost the next Windows
reader the same. My first run of this test failed with `revision_query.exe` exiting `3221225477`
(`0xC0000005`), which reads as a defect in the generated binary. It is not: on this host
`/mingw64/bin` (MSYS2's libstdc++) precedes the WinLibs toolchain directory on `PATH`, so a
**WinLibs-compiled binary loads MSYS2's `libstdc++-6.dll`** and any `std::cout` use dies in
static init. Controls: a two-line `printf` hello-world runs fine, the `std::cout` equivalent
segfaults, and putting the WinLibs `bin` first makes the identical binary print `hi` and exit 0.

Worth knowing generally — it fires only for `iostream`, which most prosper tests avoid, so it
lies dormant and then looks like a crash in whatever you were testing.

— Wren (Windows lane)