### PR TITLE
fix(hle): publish FreeBSD errno numbers where prosper picks the value itself

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1191,6 +1191,12 @@ int host_settable_status_mask() {
 // FreeBSD/Orbis and host fcntl ABIs only coincide for a subset of commands, and their O_* status
 // bits differ substantially on Linux. Translate the descriptor/status operations used by libc and
 // game runtimes; reject record-lock commands until their FreeBSD flock layout is translated too.
+// The ENOTSUP refusals below publish FreeBSD's 45 rather than the host's (Linux 95, MinGW 129):
+// f_fcntl is registered for BOTH `fcntl` and `sceKernelFcntl` (see the R() line near the bottom of
+// this file), and both spellings return -1 with the guest reading the slot directly -- no wrapper
+// re-converts it, so translating here is safe and is what the guest actually tests against (#2296).
+// The `errno = ...` sites in the f_stat/f_open/f_read family are deliberately NOT translated: their
+// sceKernel wrappers pass that slot through file_sce_error(), which translates it a second time.
 HLE(f_fcntl) {
     if (a0 > INT_MAX) {
         errno = EBADF;
@@ -1206,7 +1212,7 @@ HLE(f_fcntl) {
         const int minimum = (int)a2 < 3 ? 3 : (int)a2;
 #ifdef _WIN32
         if (windows_directory_path(fd, nullptr)) {
-            errno = ENOTSUP;
+            hle::set_guest_errno(ENOTSUP);
             return (uint64_t)-1;
         }
         return (uint64_t)(int64_t)windows_duplicate_at_least(fd, minimum);
@@ -1248,7 +1254,7 @@ HLE(f_fcntl) {
             // Synthetic directory descriptors never escape to a child process. Their fixed
             // CLOEXEC state cannot be cleared without introducing descriptor inheritance.
             if (a2 & kGuestFdCloExec) return 0;
-            errno = ENOTSUP;
+            hle::set_guest_errno(ENOTSUP);
             return (uint64_t)-1;
         }
         {
@@ -1272,7 +1278,7 @@ HLE(f_fcntl) {
     case kGuestFGetFl:
 #ifdef _WIN32
         // UCRT has no status-flag query. Do not preserve the old missing-import false success.
-        errno = ENOTSUP;
+        hle::set_guest_errno(ENOTSUP);
         return (uint64_t)-1;
 #else
         {
@@ -1283,7 +1289,7 @@ HLE(f_fcntl) {
     case kGuestFSetFl:
 #ifdef _WIN32
         // Likewise, UCRT cannot update O_NONBLOCK/O_APPEND on an existing descriptor.
-        errno = ENOTSUP;
+        hle::set_guest_errno(ENOTSUP);
         return (uint64_t)-1;
 #else
         {
@@ -1294,7 +1300,7 @@ HLE(f_fcntl) {
             // after open. Reject a requested transition instead of claiming success while the
             // host descriptor remains unchanged.
             if ((old_guest_flags ^ a2) & kGuestOSync) {
-                errno = ENOTSUP;
+                hle::set_guest_errno(ENOTSUP);
                 return (uint64_t)-1;
             }
             const int new_flags = (old_flags & ~host_settable_status_mask()) |
@@ -1304,14 +1310,14 @@ HLE(f_fcntl) {
 #endif
     case kGuestFGetOwn:
 #ifdef _WIN32
-        errno = ENOTSUP;
+        hle::set_guest_errno(ENOTSUP);
         return (uint64_t)-1;
 #else
         return (uint64_t)(int64_t)::fcntl(fd, F_GETOWN);
 #endif
     case kGuestFSetOwn:
 #ifdef _WIN32
-        errno = ENOTSUP;
+        hle::set_guest_errno(ENOTSUP);
         return (uint64_t)-1;
 #else
         return (uint64_t)(int64_t)::fcntl(fd, F_SETOWN, (int)a2);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1192,11 +1192,20 @@ int host_settable_status_mask() {
 // bits differ substantially on Linux. Translate the descriptor/status operations used by libc and
 // game runtimes; reject record-lock commands until their FreeBSD flock layout is translated too.
 // The ENOTSUP refusals below publish FreeBSD's 45 rather than the host's (Linux 95, MinGW 129):
-// f_fcntl is registered for BOTH `fcntl` and `sceKernelFcntl` (see the R() line near the bottom of
-// this file), and both spellings return -1 with the guest reading the slot directly -- no wrapper
-// re-converts it, so translating here is safe and is what the guest actually tests against (#2296).
-// The `errno = ...` sites in the f_stat/f_open/f_read family are deliberately NOT translated: their
-// sceKernel wrappers pass that slot through file_sce_error(), which translates it a second time.
+// f_fcntl is registered for BOTH `fcntl` and `sceKernelFcntl` -- one R() line, grep it rather than
+// trusting a line number -- and both spellings return -1 with the guest reading the slot directly;
+// no wrapper re-converts it, so translating here is safe and is what the guest tests against (#2296).
+//
+// Sorting the rest of this file needs THREE buckets, not two, and the third is the trap:
+//   1. converted downstream -- the f_stat/f_open/f_read family, whose sceKernel wrappers pass the
+//      slot through file_sce_error(). Translating there would convert TWICE. Leave alone.
+//   2. not converted, value diverges -- the ENOTSUP refusals below. Must translate.
+//   3. not converted, value HAPPENS to agree on every host -- the EBADF/EINVAL assignments in this
+//      same function. They are correct today only because 9 and 22 are identical on FreeBSD, Linux
+//      and MinGW. They are in bucket 2, not bucket 1: nothing downstream converts them.
+// So: ANY errno added to f_fcntl whose FreeBSD number differs from the host must go through
+// hle::set_guest_errno -- in practice anything above 34, where the two numberings part company.
+// Do not read the untranslated EBADF/EINVAL here as evidence that this function is bucket 1.
 HLE(f_fcntl) {
     if (a0 > INT_MAX) {
         errno = EBADF;

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -469,10 +469,15 @@ uint64_t select_unsupported(const char* fn, uint64_t nfds,
                 (unsigned long long)writefds, (unsigned long long)exceptfds, n,
                 no_sets ? "  <- examines no descriptor; likely a sleep, but unobserved: report it"
                         : "");
-    // Follows the existing libScePosix wrapper convention in hle_file.cpp: set the host errno that
-    // __error()/h_errno_location hands back and return -1. Whether that number should be translated
-    // to FreeBSD's is the separate concern tracked by #1612, not something to diverge on here.
-    errno = ENOSYS;
+    // Follows the existing libScePosix wrapper convention in hle_file.cpp: set the errno that
+    // __error()/h_errno_location hands back and return -1. The number must be FREEBSD's, because
+    // that is what the guest compares against: host ENOSYS is 38 on Linux and 40 on MinGW, while
+    // the guest tests for 78, so an untranslated write sends it down a generic-error path instead
+    // of the fallback branch its author wrote (#2296). Nothing re-converts this slot -- k_select
+    // and k_pselect return this value straight through -- so publishing FreeBSD's here is the
+    // whole fix for this call. (This comment used to cite #1612; that issue is closed and was
+    // about the `0x80020000|errno` RETURN encoding, a different slot with the same trap.)
+    hle::set_guest_errno(ENOSYS);
     return (uint64_t)(int64_t)-1;
 }
 } // namespace

--- a/prosper/src/hle/sce_errno.hpp
+++ b/prosper/src/hle/sce_errno.hpp
@@ -603,6 +603,35 @@ inline uint64_t sce_error_from_host_errno(int host_errno,
     return sce_kernel_error(freebsd_errno_from_host(host_errno, fallback));
 }
 
+
+// Publish a prosper-CHOSEN error into the guest-visible errno slot.
+//
+// `__error()` / `__errno_location()` (hle_libc.cpp `h_errno_location`) hands the guest the address
+// of the HOST thread's `errno`, and the guest is a FreeBSD-ABI binary that compares what it reads
+// against FreeBSD constants. So a wrapper that returns -1 and picks its own errno must write the
+// FREEBSD number, not this host's: `errno = ENOSYS` publishes 38 on Linux and 40 on MinGW where
+// the guest is testing for 78, so its "unimplemented, use the fallback" branch never runs and it
+// takes a generic-error path instead. `ENOTSUP` is the same shape (host 95 / 129, FreeBSD 45).
+//
+// ############################################################################################
+// #  DO NOT apply this blanket to every `errno = ...` in the HLE. It is only correct where     #
+// #  prosper CHOOSES the value AND nothing downstream converts the slot again.                 #
+// ############################################################################################
+//
+// The trap is concrete, not hypothetical. In `hle_file.cpp` the libc and sceKernel spellings share
+// one worker: `HLE(k_stat)` (and twenty of its siblings) calls `f_stat`, then feeds the errno that
+// worker left into `file_sce_error()` -- which applies `freebsd_errno_from_host` itself. Converting
+// inside such a worker translates twice, and the second pass reads an already-FreeBSD number as a
+// host one: 78 is EBADFD on Linux, so ENOSYS would arrive at the guest as neither. Those workers
+// must keep leaving HOST numbers in the slot.
+//
+// The general remainder -- that a host libc failure inside any wrapper also leaves a host-numbered
+// errno for the guest to misread -- is not fixable at an assignment site at all, because there is
+// no assignment to fix. It needs the accessor to publish, and that is tracked separately in #2296.
+inline void set_guest_errno(int host_errno) {
+    errno = host_errno == 0 ? 0 : static_cast<int>(freebsd_errno_from_host(host_errno));
+}
+
 // Decode the errno out of an encoded SCE error. Returns false when `value` is not in the family.
 inline bool sce_kernel_error_errno(uint64_t value, FreeBsdErrno& out) {
     if ((value & ~0xffull) != 0x80020000ull) return false;

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -34,6 +34,12 @@ static int fails = 0;
 static constexpr uint64_t kGuestFDupFd = 0;
 static constexpr uint64_t kGuestFGetFd = 1;
 static constexpr uint64_t kGuestFSetFd = 2;
+// FreeBSD's ENOTSUP, spelled out because the host's <errno.h> is the WRONG source here: the
+// guest reads prosper's errno slot through __error() and compares against FreeBSD's numbering, so
+// an arm written as `errno == ENOTSUP` asserts the host value and passes on exactly the code #2296
+// is about. Host values measured: Linux 95, MinGW-w64 UCRT 129, Darwin 45 (see the coincidence
+// note printed below -- on Darwin these arms cannot distinguish, and say so rather than pretending).
+static constexpr int kFreeBsdENotSupp = 45;
 static constexpr uint64_t kGuestFGetFl = 3;
 static constexpr uint64_t kGuestFSetFl = 4;
 static constexpr uint64_t kGuestFdCloExec = 1;
@@ -49,6 +55,12 @@ static_assert(sizeof(GuestTimeval) == 0x10, "SceKernelTimeval ABI");
 
 int main() {
     std::printf("== test_file_binary ==\n");
+    // Say up front whether the ENOTSUP arms below can distinguish a FreeBSD publish from a host
+    // one. They cannot on a host whose ENOTSUP is already 45 (Darwin) -- a green run there is
+    // silent about #2296 rather than evidence for it, and a reader should not have to guess which.
+    std::printf("  [note] host ENOTSUP=%d, FreeBSD=%d -- ENOTSUP arms %s here\n",
+                ENOTSUP, kFreeBsdENotSupp,
+                ENOTSUP == kFreeBsdENotSupp ? "CANNOT distinguish" : "discriminate");
     // PROSPER_DENY_SUBSTR (#1237): armed for the whole process BEFORE any guest file op (the
     // substring list is cached on first use). The unique marker cannot collide with any other
     // path this test opens; the case-variant open below proves matching is case-insensitive
@@ -472,9 +484,10 @@ int main() {
     uint64_t dir_fd_flags = dir_fd >= 0 && fcntl_fn
         ? fcntl_fn((uint64_t)dir_fd, kGuestFGetFd, 0, 0, 0, 0)
         : 0;
-    CHECK(clear_dir_cloexec == -1 && clear_dir_errno == ENOTSUP &&
+    CHECK(clear_dir_cloexec == -1 && clear_dir_errno == kFreeBsdENotSupp &&
               dir_fd_flags == kGuestFdCloExec,
-          "Windows directory fcntl rejects an unrepresentable close-on-exec change");
+          "Windows directory fcntl rejects an unrepresentable close-on-exec change "
+          "with FreeBSD's ENOTSUP");
 #endif
 
     // Darwin's getdents compatibility path owns a duplicated descriptor behind DIR*. A raw
@@ -793,9 +806,9 @@ int main() {
     uint64_t flags_after_sync_change = fcntl_fn && fd >= 0
         ? fcntl_fn((uint64_t)fd, kGuestFGetFl, 0, 0, 0, 0)
         : ~uint64_t{0};
-    CHECK(unsupported_sync_change == -1 && errno == ENOTSUP &&
+    CHECK(unsupported_sync_change == -1 && errno == kFreeBsdENotSupp &&
               (flags_after_sync_change & kGuestOSync) == 0,
-          "fcntl rejects an unsupported O_SYNC change instead of reporting false success");
+          "fcntl rejects an unsupported O_SYNC change with FreeBSD's ENOTSUP, not the host's");
 #else
     // UCRT exposes neither F_GETFL nor F_SETFL. Until the secondary Windows host grows an
     // equivalent descriptor-status layer, report that limitation instead of fake success.
@@ -809,9 +822,9 @@ int main() {
         ? (int64_t)kernel_fcntl_fn((uint64_t)fd, kGuestFSetFl,
                                    kGuestONonblock | kGuestOAppend, 0, 0, 0)
         : 0;
-    CHECK(guest_flags == -1 && getfl_errno == ENOTSUP &&
-              set_flags == -1 && errno == ENOTSUP,
-          "Windows fcntl status commands fail explicitly instead of returning false success");
+    CHECK(guest_flags == -1 && getfl_errno == kFreeBsdENotSupp &&
+              set_flags == -1 && errno == kFreeBsdENotSupp,
+          "Windows fcntl status commands fail explicitly with FreeBSD's ENOTSUP, not the host's");
 #endif
 
     int64_t set_fd_flags = fcntl_fn && fd >= 0

--- a/prosper/tests/test_sce_errno.cpp
+++ b/prosper/tests/test_sce_errno.cpp
@@ -375,6 +375,34 @@ int main() {
         }
     }
 
+    // ---- behavioral: the guest-visible errno slot carries FreeBSD numbers (#2296) -----------
+    //
+    // `select` with a descriptor set is unsupported (no socket backing), and the handler reports
+    // that the libScePosix way: return -1 and leave an errno for __error()/h_errno_location to
+    // hand back. The guest compares that against ITS OWN ENOSYS, which is 78 -- so publishing the
+    // host number (Linux 38, MinGW-w64 40) sends it down a generic-error path instead of the
+    // "unimplemented, use the fallback" branch its author wrote.
+    //
+    // Neither pointer is dereferenced on this path (`select_is_pure_sleep` only compares, and the
+    // refusal only logs the values), so passing a bare non-zero readfds is safe and is what makes
+    // the call miss the pure-sleep shape.
+    {
+        auto select_fn = Hle::lookup(nid_hash("select"));
+        if (select_fn) {
+            std::printf("  [note] host ENOSYS=%d, FreeBSD=%d -- this arm %s here\n",
+                        ENOSYS, (int)FreeBsdErrno::ENoSys,
+                        ENOSYS == (int)FreeBsdErrno::ENoSys ? "CANNOT distinguish" : "discriminates");
+            errno = 0;
+            const uint64_t rc = select_fn(1 /* nfds>0 */, 0x1000 /* readfds, never dereferenced */,
+                                          0, 0, 0, 0);
+            const int published = errno;
+            CHECK((int64_t)rc == -1 && published == (int)FreeBsdErrno::ENoSys,
+                  "select's unsupported-shape refusal publishes FreeBSD ENOSYS (78), not the host's");
+        } else {
+            std::printf("  [skip] select not registered on this platform\n");
+        }
+    }
+
     std::printf(failures ? "== FAIL: %d ==\n" : "== PASS ==\n", failures);
     return failures ? 1 : 0;
 }

--- a/prosper/tests/test_select_sleep.cpp
+++ b/prosper/tests/test_select_sleep.cpp
@@ -17,6 +17,7 @@
 // Both halves fail without the fix: (1) elapses ~0 ms against the unimplemented stub, and (2)
 // returns 0 rather than -1.
 #include "../src/hle/dispatch.hpp"
+#include "../src/hle/sce_errno.hpp"
 #include "../src/hle/nid.hpp"
 #include <chrono>
 #include <cerrno>
@@ -101,7 +102,13 @@ int main() {
                                       (uint64_t)(uintptr_t)tv, 0);
         printf("  select(4, &readfds, ...) -> %lld (errno=%d)\n", (long long)(int64_t)rc, errno);
         CHECK((int64_t)rc == -1, "select with a readfds set fails visibly (-1), never a false 0");
-        CHECK(errno == ENOSYS, "select sets errno=ENOSYS for the unimplemented descriptor query");
+        // FreeBSD ENOSYS (78), NOT the host constant: the guest reads this slot through
+        // __error() and compares against its own numbering (host ENOSYS is 38 on Linux, 40 on
+        // MinGW). Writing `ENOSYS` here would assert the host value and pass on exactly the
+        // code #2296 is about. On a host whose ENOSYS is already 78 (Darwin) this arm cannot
+        // distinguish -- the printf above shows which case a given run is.
+        CHECK(errno == (int)prosper::hle::FreeBsdErrno::ENoSys,
+              "select publishes FreeBSD ENOSYS (78) for the unimplemented descriptor query");
     }
     {
         uint64_t fdset[16] = {0};


### PR DESCRIPTION
Fixes #2296

## Failure scenario

`__error()` / `__errno_location()` (`hle_libc.cpp:469`) hands the guest the address of the **host**
thread's `errno`, and the guest is a FreeBSD-ABI binary comparing what it reads against FreeBSD
constants. A wrapper that returns -1 and picks its own errno must therefore write **FreeBSD's**
number.

Two of the constants prosper writes diverge. Measured on this host, not taken from memory:

| constant | FreeBSD (what the guest tests) | Linux | MinGW-w64 UCRT |
| --- | --- | --- | --- |
| `ENOSYS` | 78 | 38 | **40** |
| `ENOTSUP` | 45 | 95 | **129** |

So a guest that calls `select`/`pselect` with a descriptor set, or an `fcntl` command this host
cannot serve, gets a number that never matches its own `ENOSYS`/`ENOTSUP` — and takes a generic
error branch instead of the "unimplemented, use the fallback" branch its author wrote. The other
five constants written this way (`EBADF`, `EFAULT`, `EINVAL`, `EISDIR`, `ENOMEM`) are identical on
all three, which is why this survived: every value a reviewer double-checks by reflex is one of the
five that agree.

## Approach

`set_guest_errno()` in `sce_errno.hpp` — one converter, beside the table it uses — and the eight
divergent sites routed through it: seven `ENOTSUP` refusals in `f_fcntl`, and the select/pselect
`ENOSYS`.

### Why this is NOT applied to every `errno = ...` in the HLE

The issue's suggested fix was "make the direct `errno = E*` assignments go through it". **I wrote
that issue and it is wrong**, in a way that would have shipped a regression, so the helper carries
the reason at length:

In `hle_file.cpp` the libc and sceKernel spellings **share one worker**. `HLE(k_stat)` and twenty
siblings do

```cpp
uint64_t r = f_stat(...); int e = errno; return kernel_file_result32(r, e);
```

and `kernel_file_result32` → `file_sce_error` applies `freebsd_errno_from_host` *itself*. Converting
inside such a worker translates **twice**, and the second pass reads an already-FreeBSD number as a
host one — 78 is `EBADFD` on Linux, so `ENOSYS` would reach the guest as neither value. Those
workers must keep leaving host numbers in the slot.

The two sites changed here have no such consumer, and I checked rather than assumed:

- `f_fcntl` is registered **directly** for both `fcntl` and `sceKernelFcntl` (`hle_file.cpp:2913`) —
  both spellings return -1 and the guest reads the slot; nothing re-converts.
- `select_unsupported`'s value is returned straight through by `k_select` and `k_pselect`
  (`hle_kernel_time.cpp:482`, `:494`), its only two callers.

### What this deliberately does not fix

The general remainder: a **host libc** failure inside any wrapper also leaves a host-numbered errno
for the guest to misread. That is not fixable at an assignment site because there is no assignment —
it needs the accessor to publish, which is a design change with its own hazards. Recorded on #2296
with the analysis rather than half-done here.

## Tests

**Three arms already existed and asserted the host constant** — so they passed on exactly the code
this fixes, in all three test binaries:

- `test_file_binary.cpp:477` Windows directory `F_SETFD` → `clear_dir_errno == ENOTSUP`
- `test_file_binary.cpp:795` POSIX `F_SETFL` O_SYNC rejection → `errno == ENOTSUP`
- `test_select_sleep.cpp:104` → `errno == ENOSYS`

All three now assert a **named FreeBSD constant** instead of `<errno.h>`, with a comment saying why
the host header is the wrong source here. A fourth arm is new in `test_sce_errno.cpp`: a behavioural
check through the registered `select` handler (neither pointer is dereferenced on that path).

**Non-vacuity is reported, not assumed.** Each binary prints whether its arms can discriminate on
the host running them, because on **Darwin** both `ENOSYS` (78) and `ENOTSUP` (45) already equal
FreeBSD's — a green macOS run is silence about this bug, not evidence for the fix:

```
  [note] host ENOSYS=40, FreeBSD=78 -- this arm discriminates here
  [note] host ENOTSUP=129, FreeBSD=45 -- ENOTSUP arms discriminate here
```

## Verification (exact head `908ef4c1`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release, ctest 4.4.0.

```
ctest --no-tests=error -j4    ->  99% tests passed, 2 tests failed out of 177
```

Both failures are **pre-existing on clean `origin/master`**, established by stashing every edit and
rebuilding: `build_revision_refresh` (#2286, fixed by #2326) and `pthread_cond_clock` (filed as
**#2327** — Windows-only arm from #2178, invisible to CI for the same reason #2141 was).

**Mutation arms.** Reverting each fix independently fails exactly the intended arms and nothing else:

```
# hle::set_guest_errno(ENOSYS)  ->  errno = ENOSYS
  [FAIL] select's unsupported-shape refusal publishes FreeBSD ENOSYS (78), not the host's
# hle::set_guest_errno(ENOTSUP) ->  errno = ENOTSUP   (all 7 sites)
  [FAIL] Windows directory fcntl rejects an unrepresentable close-on-exec change with FreeBSD's ENOTSUP
  [FAIL] Windows fcntl status commands fail explicitly with FreeBSD's ENOTSUP, not the host's
0% tests passed, 2 tests failed out of 2
```

The POSIX `O_SYNC` arm is `#ifndef _WIN32` and does not run here — Linux CI covers it, and it is the
one arm that exercises the shared `f_fcntl` body on the platform where `ENOTSUP` is 95.

`git diff --check` clean. Session-trailer gate: 0.

## Risk and review

**MED, and I'd like a second reader** — this is reverse-engineered ABI semantics on a slot every
title touches, and the interesting part is the *boundary* of the change rather than the change:
whether the eight sites I translated really have no downstream converter, and whether the
twenty-one I left alone really do. Those two claims are the whole PR. The double-conversion trap is
what makes the obvious version of this fix wrong, and it is exactly the kind of thing an independent
reader can challenge better than the author who just talked himself out of it.

Not merging until reviewed.

— Wren (Windows lane)