### PR TITLE
host: create the fault-handler probe pipe unconditionally

### DIFF
--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -3176,7 +3176,21 @@ void install_trap_handler() {
             mb3w_arm_current_thread(base);
         };
     }
-    if (g_faultmem || g_skip_null_companion || g_null_page) ensure_probe_pipe();
+    // UNCONDITIONAL (#2078). This used to be gated on
+    // `g_faultmem || g_skip_null_companion || g_null_page`, and the gate was wrong because it does
+    // not cover every consumer: `nullpage_deep_dump` also runs from the WORKER-FAULT path (:2752),
+    // which no flag guards -- that call site exists precisely because those faults "land here, not
+    // on the nullpage path".
+    //
+    // Without the pipe, `probe_readable` returns false for EVERY address (:612 short-circuits on
+    // `g_probe_pipe[1] < 0`), so an ordinary worker-fault report loses its `insn @rip` line and all
+    // sixteen register memory windows -- including `rsp`, which is the faulting thread's own stack
+    // and cannot be unreadable. The report still prints four bare register lines, so it looks like a
+    // report that ran and found nothing rather than one whose probe was disabled.
+    //
+    // It must be created HERE and not from the handler: `ensure_probe_pipe` guards a magic static,
+    // whose initialisation lock is not async-signal-safe. Cost when unused is one pipe pair.
+    ensure_probe_pipe();
     // PROSPER_PEEK="r15:0x140,0x1a0;rbx:0x78,0x88;r15:*0x18+0x0" — N specs (';'), each reg:off[,off];
     // a '*pre+off' offset chases one pointer level ([[reg+pre]+off]). Parsed once (getenv unsafe at fault).
     if (const char* pk = getenv("PROSPER_PEEK")) {

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -3178,7 +3178,7 @@ void install_trap_handler() {
     }
     // UNCONDITIONAL (#2078). This used to be gated on
     // `g_faultmem || g_skip_null_companion || g_null_page`, and the gate was wrong because it does
-    // not cover every consumer: `nullpage_deep_dump` also runs from the WORKER-FAULT path (:2752),
+    // not cover every consumer: `nullpage_deep_dump` also runs from the WORKER-FAULT path (:2782),
     // which no flag guards -- that call site exists precisely because those faults "land here, not
     // on the nullpage path".
     //


### PR DESCRIPTION
Fixes #2078.

## Failure scenario

`nullpage_deep_dump`'s per-register memory windows print nothing on ordinary runs — 9/9 in the
report, **including for `rsp`**, which is the faulting thread's own stack and cannot be unreadable.

## Cause

`probe_readable` short-circuits to false for **every** address when the probe pipe is absent:

```cpp
bool probe_readable(uint64_t a) {
    if (a < 0x1000 || g_probe_pipe[1] < 0) return false;   // :612
```

and the pipe was created only under a three-flag gate:

```cpp
if (g_faultmem || g_skip_null_companion || g_null_page) ensure_probe_pipe();
```

**That gate misses a consumer.** `nullpage_deep_dump` also runs from the **worker-fault** path
(`:2752`), which no flag guards — and that call site exists *precisely* because those faults "land
here, not on the nullpage path".

So on an ordinary run the report lost its `insn @rip` line and all sixteen register windows, while
still printing four bare register lines. **It read as a probe that ran and found nothing, rather than
one that was disabled** — which is why the issue reported it as a bug in the register loop's filter.

## Fix

Create the pipe unconditionally at install time. Not from the handler: `ensure_probe_pipe` guards a
magic static whose initialisation lock is not async-signal-safe. Cost when unused is one pipe pair.

## A/B, same ordinary `boot_trace` route, ArcRunner (`PPSA21406`), no flags

| | `[nullpage]` | `insn @rip` | `mem@` |
| --- | ---: | ---: | ---: |
| before (master) | 4 | **0** | **0** |
| after | 12 | **1** | **7** |

The `rsp` window the issue names is present:

```
rsp=0x7f0f423e5e40 mem@0x7f0f423e5e20
insn @rip: c5 f9 2e 01 74 b5 c5 fb 11 01 eb af 66 66 66 66
```

`ctest --no-tests=error -j4` → **222/222**.

## Worth reading before the diff: I falsified this exact hypothesis and was wrong

I reached "the pipe is never created" early, then **talked myself out of it** by checking the call
sites:

```
$ grep -n 'nullpage_deep_dump' prosper/src/host/exec_image_linux.cpp | head -4
153:  void nullpage_deep_dump(...);      # decl
201:  nullpage_deep_dump(uc, rip);       # inside try_emulate_denied_null_read
896:  void nullpage_deep_dump(...) {     # definition
2150: nullpage_deep_dump(uc, rip);       # inside `if (g_null_page && ...)` at :2128
```

Both real call sites were under `g_null_page`, so the pipe *would* exist, so the hypothesis was dead.
I posted that falsification on the issue.

**`head -4` hid `:2752`.** There were five matches, not four, and the fifth is the one that is not
gated. The truncation produced a *confident* wrong conclusion — not "I found nothing", but "I checked
and it cannot be that", which is much worse because it closes the question.

Two things saved it, and both are cheap:

1. **Reproducing on the reporter's route rather than mine.** `prosper-app` with `PROSPER_NULL_PAGE=1`
   showed the diagnostic working perfectly (7 `mem@` lines) — a clean all-clear. The issue used
   `boot_trace` with no flags, and that route reproduces the symptom exactly. Trap 127 is "the
   frontend is an apparatus"; here the *flag* was the apparatus too.
2. **Re-running the search without the truncation** once the reproduction contradicted the
   falsification.

Suggested trap row, if it earns one: **a `head -N` on a search can hide the decisive match and turn
"not found" into "ruled out"** — the failure is silent, and the conclusion it produces is stronger
and more wrong than no conclusion at all. Sort or count first (`| wc -l`) when the search is load-
bearing for a negative claim.

---

## Added after review (@Wren)

### Larger blast radius than "sixteen register windows": macOS loses two more sections

`safe_qword` has **two definitions**. The Linux arm (`:2717`) uses `SYS_process_vm_readv` and is
unaffected by the pipe. The `#else` arm (`:2724`) is **`probe_readable` + deref**:

```cpp
auto safe_qword = [](uint64_t addr, uint64_t* value) -> bool {
    if (!probe_readable(addr)) return false;
    *value = *(const uint64_t*)(uintptr_t)addr;
    return true;
};
```

It feeds the **guest fp-chain** (`:2735`) and the **rsp stack scan** (`:2751`). So on **macOS** those
two report sections were *also* silently empty on any ordinary run, by the same mechanism, and this
fix restores them. My A/B is Linux-only and cannot show it — recorded so anyone auditing the Darwin
fault report later knows when it started working. Verified by reading both arms, not by running them.

### This forecloses the issue's own suggested fix

#2078 proposes `process_vm_readv` as a remedy. The codebase **already has** that primitive on Linux —
in this very lambda, thirty lines from the defect. The probe technique was never the problem; the
pipe's absence was. Creating the pipe is the smaller and more correct change, and nobody should
re-propose the rewrite.

### Correction to my own post-mortem above

I wrote that `head -4` truncated my search and hid `:2782`. True, but **not the real error** — and the
better diagnosis is @Wren's:

> you enumerated the sites that call `ensure_probe_pipe` and concluded coverage, when the question was
> which sites call `probe_readable`. **The consumer set, not the producer set.**

I checked **5** `nullpage_deep_dump` call sites. The question was who consumes the pipe, and
`probe_readable(` appears **74 times** in this file. A complete, untruncated enumeration of the set I
chose would have misled me exactly as badly — the truncation was incidental to picking the wrong
question.

So the trap worth recording is not "`head -N` hides matches" (though it does). It is: **when a
resource is missing, enumerate its CONSUMERS, not the producers of the thing you noticed first.** The
producer set was 5 and gated; the consumer set is 74 and mostly not.