### PR TITLE
fix(ampr): both platform arms must answer sceAmprCommandBufferGetSize the same way

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2542,10 +2542,13 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
             if (apr_peek(a4 + o, &pv)) fprintf(stderr, "[apr]   desc+0x%02x = 0x%016llx\n", o, (unsigned long long)pv);
         // The real read command lives in the Ampr command buffer registered at init (a3 of the
         // (req, cbSize, 0, cbBuf, poolCtx, 3) init call); "CB offset 40" is decimal 40 = 0x28 into it.
-        // g_apr_last_cb is defined in hle_kernel_mem.cpp, which is entirely #ifdef __linux__ (the whole
-        // Ampr/APR path is Linux-only), so this diagnostic must be Linux-only too or MinGW fails to
-        // link (undefined reference to prosper::g_apr_last_cb).
-#ifndef _WIN32
+        // This block used to be #ifndef _WIN32, on the stated grounds that hle_kernel_mem.cpp is
+        // "entirely #ifdef __linux__ (the whole Ampr/APR path is Linux-only)" and MinGW would fail to
+        // link. That was already wrong about the path -- hle_kernel_mem.cpp has a full Windows Ampr
+        // arm -- and right only about the SYMBOL: g_apr_last_cb happened to be defined inside the
+        // POSIX half of the platform split. It is now defined above the split (#1970), so the guard
+        // has no reason left and the diagnostic runs on both. apr_peek is a local lambda already used
+        // unguarded a few lines above, so nothing else here was platform-bound.
         if (g_apr_last_cb) {
             fprintf(stderr, "[apr]   cb=0x%llx size=0x%llx\n",
                     (unsigned long long)g_apr_last_cb, (unsigned long long)g_apr_last_cb_size);
@@ -2556,7 +2559,6 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
                     fprintf(stderr, "[apr]   cb+0x%02llx = 0x%016llx\n", (unsigned long long)o,
                             (unsigned long long)pv);
         }
-#endif
     }
     // a3 is the APR file id (read1 a3=1 global.utoc, read2 a3=3 pakchunk2-ps5.utoc, read3 a3=4
     // pakchunk1-ps5.pak — read3's stack record is pure frame residue, which is what proved a3 is

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -96,6 +96,7 @@ void ampr_cb_destroy_320(uint64_t cb) {
         g_ampr_cb_state.erase(it);
 }
 
+
 uint64_t ampr_cb_capacity(uint64_t cb) {
     std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
     auto it = g_ampr_cb_state.find(cb);
@@ -108,6 +109,30 @@ uint64_t ampr_cb_offset(uint64_t cb) {
     return it == g_ampr_cb_state.end() ? 0 : it->second.offset;
 }
 }
+
+// Last Ampr command-buffer (address/size) seen at init: the APR read-submit path inits its request
+// with (req, cbSize, 0, cbBuf, poolCtx, 3) — the actual read COMMAND (file offset / dest / size)
+// lives inside cbBuf (the "CB offset 40" of the guest's error message is a byte offset into it).
+// Exposed so the read-submit HLE can locate and decode the real command. CONFIDENCE: MED.
+//
+// Atomic because GetSize now reads them as a PAIR — it serves g_apr_last_cb_size only when a0
+// matches g_apr_last_cb — and both are written from arbitrary guest threads. A torn read that
+// matched a freshly stored cb against the previous size would hand that cb a too-small capacity,
+// which is precisely the failure this fix exists to remove. Relaxed is enough: the pair is a hint,
+// nothing is published through it, and a stale-but-consistent read is harmless.
+//
+// Defined HERE -- OUTSIDE the anonymous namespace above, and above the
+// `#if defined(__linux__) || defined(__APPLE__)` platform split -- rather than inside the POSIX arm
+// where it used to live. Both arms implement `sceAmprCommandBufferGetSize` and both must answer it
+// identically: a capacity is a fact about the guest's buffer, not about the host prosper happens to
+// be running on (#1970). While the pair was POSIX-only, the Windows arm could not see a capacity
+// prosper had already recorded and answered the roomy default -- the OVER-large direction, which
+// risks a guest appending past the end of a real buffer rather than merely stalling.
+//
+// The anonymous namespace matters and is not a style point: hle_file.cpp declares these `extern`
+// (`prosper::g_apr_last_cb`), so internal linkage does not fail to compile -- it fails to LINK, and
+// only for the targets that pull in hle_file.cpp. A syntax-only check passes happily.
+std::atomic<uint64_t> g_apr_last_cb{0}, g_apr_last_cb_size{0};
 
 // The ReadFile builder lives in hle_file.cpp; expose the one state transition it shares with the
 // other AMPR builders without exposing the map itself.
@@ -1742,17 +1767,6 @@ HLE(k_ampr_ok) { return 0; }
 // the APR read destination from a begin-cursor we never populate (k_ampr_ok returns 0 without
 // writing outputs) — i.e. whether the stale value in *(a1)/*(a2) is where the bogus
 // req+0x20 = freed-pool-block pointer comes from.
-// Last Ampr command-buffer (address/size) seen at init: the APR read-submit path inits its request
-// with (req, cbSize, 0, cbBuf, poolCtx, 3) — the actual read COMMAND (file offset / dest / size)
-// lives inside cbBuf (the "CB offset 40" of the guest's error message is a byte offset into it).
-// Exposed so the read-submit HLE can locate and decode the real command. CONFIDENCE: MED.
-//
-// Atomic because GetSize now reads them as a PAIR — it serves g_apr_last_cb_size only when a0
-// matches g_apr_last_cb — and both are written from arbitrary guest threads. A torn read that
-// matched a freshly stored cb against the previous size would hand that cb a too-small capacity,
-// which is precisely the failure this fix exists to remove. Relaxed is enough: the pair is a hint,
-// nothing is published through it, and a stale-but-consistent read is harmless.
-std::atomic<uint64_t> g_apr_last_cb{0}, g_apr_last_cb_size{0};
 // Per-cb capacity, recorded at init (issue #208 follow-up). Live-captured init flavors carry the
 // size in different args: the APR read flow uses a1; Pathless's IoStore batch uses a2=0x560; and
 // DOLL's IoStore batch uses a5=0x720. The
@@ -5294,14 +5308,29 @@ HLE(k_query_memory_protection) {
 // Windows yet. Pure size/offset queries below keep their platform-independent return contracts.
 HLE(k_ampr_ok) { return 0; }
 HLE(k_ampr_init) {
-    ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
-                      a2 >= 0x20 && a2 <= 0x100000); // match the POSIX 3.20 discriminator
+    // Same legacy (a3 = cb, a1 = size) recording as the POSIX arm (#1970). Without it the pair
+    // stays empty on Windows and GetSize below can never take its matched branch, so a capacity
+    // legible only through this shape would be discarded.
+    if (a3 > 0xffff && a1 && a1 <= 0x10000) { g_apr_last_cb = a3; g_apr_last_cb_size = a1; }
+    // The `a0 > 0xffff` plausibility guard is the POSIX arm's too, and its absence here was a
+    // second divergence found while fixing the first: ampr_cb_construct only rejects a0 == 0, so a
+    // small non-zero a0 -- an SDK flow passing a handle or a count where POSIX declines to guess a
+    // cb address -- created a bogus capacity entry on Windows and none on POSIX. Same shared map,
+    // two different contents (#1970).
+    if (a0 > 0xffff)
+        ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
+                          a2 >= 0x20 && a2 <= 0x100000); // match the POSIX 3.20 discriminator
     return 0;
 }
 HLE(k_ampr_reset) { ampr_cb_reset(a0); return 0; }
 HLE(k_ampr_destruct) { ampr_cb_destroy_320(a0); return 0; }
 HLE(k_ampr_getsize) {
     if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
+    // Byte-for-byte the POSIX arm's contract (#1970). The `a0 == g_apr_last_cb` test is NOT
+    // optional bookkeeping: serving the pair for any OTHER buffer is #1960, which hung The
+    // Forgotten City's IoService thread forever on a 129-byte answer. Matched, it recovers a real
+    // capacity; unmatched, the roomy default is the only safe answer for an unknown one.
+    if (a0 && a0 == g_apr_last_cb && g_apr_last_cb_size) return g_apr_last_cb_size;
     return 0x10000;
 }
 HLE(k_ampr_measure_write_equeue) { return 20; }

--- a/prosper/tests/test_ampr_getsize_fallback.cpp
+++ b/prosper/tests/test_ampr_getsize_fallback.cpp
@@ -51,20 +51,15 @@ int main() {
 
     CHECK(get_size(kRecordedCb, 0, 0, 0, 0, 0) == kRecordedSize,
           "a cb with a legible capacity still reports exactly that capacity");
-#if defined(__linux__) || defined(__APPLE__)
-    // POSIX-only, and deliberately so rather than by oversight. `hle_kernel_mem.cpp` is a platform
-    // split: `g_apr_last_cb`/`g_apr_last_cb_size` are defined inside the POSIX arm and recorded by
-    // its `k_ampr_init`, so the Windows arm's `k_ampr_getsize` has no legacy path to preserve — it
-    // has always returned the unknown-capacity default unconditionally. Windows therefore never had
-    // the bug this file guards, and also never had this behaviour to keep. Asserting it there is
-    // asserting a mechanism that does not exist. Tracked as #1970; the arms below are not guarded
-    // because they are the actual fix and must hold on every platform.
+    // Unguarded since #1970. This arm used to be `#if defined(__linux__) || defined(__APPLE__)`
+    // because `g_apr_last_cb`/`g_apr_last_cb_size` lived inside the POSIX arm of the platform
+    // split, so Windows had no legacy path to assert. That guard was not a property of the test —
+    // it was the defect, written down: the two arms answered one guest ABI question differently,
+    // and Windows discarded a capacity prosper had already recorded. The pair is now defined above
+    // the split and recorded by both `k_ampr_init`s, so this holds everywhere. If it ever needs a
+    // platform guard again, the divergence has come back rather than the test having got stricter.
     CHECK(get_size(kLegacyCb, 0, 0, 0, 0, 0) == kRecordedSize,
-          "the legacy global still answers for the cb it was recorded against");
-#else
-    (void)kLegacyCb;
-    std::printf("  [skip] legacy-global arm: the Windows arm has no g_apr_last_cb path (#1970)\n");
-#endif
+          "the legacy global answers for the cb it was recorded against, on every platform");
 
     // PPSA03026's IoService cb: a1 is zero and a2/a5 are guest pointers far above any plausible
     // command-buffer capacity, so no capacity can be recovered from the constructor arguments.


### PR DESCRIPTION
Fixes #1970

## Failure scenario

`hle_kernel_mem.cpp` is a platform split and `k_ampr_getsize` is defined **twice**.
`g_apr_last_cb`/`g_apr_last_cb_size` lived inside the POSIX arm, so the Windows arm could not see
them and returned the unknown-capacity default unconditionally.

Windows never had **#1960**'s bug (serving one command buffer's capacity for another) because it
never consulted the pair at all. But it also **discards a capacity prosper has already recorded**:
when the guest constructs a buffer whose size is legible only through the legacy `(a3 = cb,
a1 = size)` shape, POSIX answers the true size and Windows answers `0x10000`. If the real capacity
is smaller, Windows reports **more room than exists** — the over-large direction, which risks a guest
appending past the end of a real buffer rather than merely stalling.

This is the charter's *"answer the same question the same way through every library that exposes
it"* rule, one level down: same question, same process, two arms of one file.

## Approach

Move the pair above the split, record it from **both** `k_ampr_init`s, and give the Windows
`k_ampr_getsize` the same pair-matched fallback — **including** the `a0 == g_apr_last_cb` test, whose
absence is #1960 and which hung The Forgotten City's IoService thread forever on a 129-byte answer.

### Two further divergences found while fixing this one

- **The `a0 > 0xffff` plausibility guard** around `ampr_cb_construct` was POSIX-only.
  `ampr_cb_construct` itself rejects only `a0 == 0`, so a small non-zero `a0` wrote a bogus capacity
  entry on Windows and none on POSIX — one shared map, two different contents. Aligned.
- **`hle_file.cpp`'s `[apr]` command-buffer dump was `#ifndef _WIN32`**, on the stated grounds that
  *"the whole Ampr/APR path is Linux-only"*. That was already wrong about the **path** — there is a
  full Windows Ampr arm a few thousand lines down — and right only about the **symbol**. With the
  pair above the split the guard has no reason left, so the diagnostic runs on both. `apr_peek` is a
  local lambda already used unguarded a few lines above, so nothing else there was platform-bound.

Both are in scope because both are the same defect as the one the issue names; leaving a comment
behind that asserts a false thing about the codebase would be worse than the guard.

## Test

The regression is the **existing** `test_ampr_getsize_fallback` arm with its platform guard removed.
That guard was not a property of the test — it was this defect written down, and the issue was filed
*because* CI made it visible. If it ever needs a guard again, the divergence has come back rather
than the test having got stricter.

## Verification (exact head `0b3f1cc1`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release.

```
ctest --no-tests=error -j4   ->  99% tests passed, 1 tests failed out of 177
```

The single failure is **#2327** (`pthread_cond_clock`), which I established earlier today is
pre-existing on clean `origin/master` by stashing every edit and rebuilding. `build_revision_refresh`
now passes, since #2326 merged.

**Mutation arm** — remove *only* the Windows matched fallback, leaving everything else:

```
  [FAIL] the legacy global answers for the cb it was recorded against, on every platform
0% tests passed, 1 tests failed out of 1
```

`git diff --check` clean. Session-trailer gate: 0.

### One process note, because it nearly shipped

My first attempt put the definition at what I believed was `namespace prosper` scope. A
`-fsyntax-only` check on the Windows arm passed, so I recorded the Windows arm as able to see the
symbol. **It could not.** The definition had landed inside the anonymous namespace opened at `:54`
and closing at `:130`, giving it internal linkage — which does not fail to *compile*, it fails to
*link*, and only for the targets pulling in `hle_file.cpp` (which declares the pair `extern`):

```
undefined reference to `prosper::g_apr_last_cb'
```

Two things worth carrying forward. **A syntax-only check cannot see a linkage error**, so it is not a
substitute for a build when the change is about where a symbol lives. And the ctest run I did over
the failed build reported `ampr_getsize_fallback ... Passed` — against a **stale binary**, because
the failing links were other targets. A green test after a red build is a fact about the previous
build. The comment above the definition now says why its position matters, so the next person moving
it gets the reason rather than rediscovering it at link time.

## Risk

Low-MED. Behavioural on Windows only; POSIX is byte-identical apart from the definition's position.
The Windows arm now returns a *smaller* (true) capacity where it previously returned `0x10000`,
which is the safe direction — a guest that trusted the old answer was being told it had room it did
not have.

Happy to have a second reader on whether the two extra divergences belong in this PR.

— Wren (Windows lane)


## Verification split (added after review)

The two arms are verified by different people in different ways, and it is worth stating precisely
because this PR is about two arms diverging:

- **Windows arm — executed here.** Full `ctest --no-tests=error -j4` on native MinGW (176/177; the
  one failure is the pre-existing #2327), plus the mutation arm above, which proves the assertion
  discriminates rather than passing incidentally.
- **POSIX arm — executed by the reviewer**, plus CI. I cannot run it on this host.
- **Neither of us has run a live title that exercises the legacy `(a3 = cb, a1 = size)` shape on
  Windows.** The test proves the contract; no boot proves a guest takes the path. The Forgotten City
  is the title that does, and it is a Linux-lane subject. So: contract verified on both platforms by
  execution, guest path exercised on neither.
