### PR TITLE
tools: build gpu_replay on Windows so a bundle captured there can be opened there

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1179,8 +1179,11 @@ if(TARGET prosper_core)
 
     # Live Vulkan renderer on Windows (PROSPER_RENDER=1): with the Vulkan SDK present, wire the same
     # shared DrawItem->Vulkan compositor boot_trace uses on Linux so the guest's SubmitDcb draws
-    # execute + present + dump frames. Mirrors the UNIX block below (boot_trace + prosper_live_renderer
-    # only; the extra replay/screenshot tools stay Linux-first for now). See docs/PORTING.md "Windows".
+    # execute + present + dump frames. Mirrors the UNIX block below. `gpu_replay` is built here too
+    # since #2331: the F9/scheduled bundle grab already worked on Windows, so a Windows investigation
+    # could produce a several-hundred-MiB .prgbundle and then have no way to open it -- the documented
+    # "capture, then replay offline" loop was half-available, and the half that was missing was the
+    # half that answers the question. See docs/PORTING.md "Windows".
     if(NOT TARGET Vulkan::Vulkan)
       find_package(Vulkan QUIET)
     endif()
@@ -1211,6 +1214,19 @@ if(TARGET prosper_core)
       add_test(NAME game_compute_exec_no_adaptive_storage_result COMMAND test_game_compute)
       set_tests_properties(game_compute_exec_no_adaptive_storage_result PROPERTIES
         ENVIRONMENT "PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION=1")
+
+      # Local-only realized-submit replayer (#514), on Windows since #2331. Same target as the UNIX
+      # block below, including the -Werror=switch gate: gpu_replay maps LiveTargetPixelFormat itself
+      # in inspect_live_target, and an unhandled member there falls through to the seed's Rgba8Unorm
+      # default and makes --inspect-only mislabel the seed -- sending an investigation down the wrong
+      # path using its own instrument. That failure mode is not platform-specific, so neither is the
+      # gate.
+      add_executable(gpu_replay tools/gpu_replay/gpu_replay.cpp)
+      target_include_directories(gpu_replay PRIVATE src tests)
+      target_link_libraries(gpu_replay PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
+      if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        target_compile_options(gpu_replay PRIVATE -Werror=switch)
+      endif()
     else()
       message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
     endif()

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -9,6 +9,25 @@ same stem means same capture, different stem means different capture — and the
 once that file exists. Replay it with `--bundle <file>`; see `tools/AGENTS.md` (interactive frame grab).
 A zero-byte `.prgbundle` is a grab that was interrupted, and `--bundle` rejects it saying exactly that.
 
+## Windows
+
+`gpu_replay` builds and runs on native Windows since #2331. It was Linux-only because MinGW's UCRT
+headers have no `setenv`/`unsetenv` — a two-line shim, not a porting problem — and because the target
+sat inside the CMake `if(UNIX)` block. The F9 / `PROSPER_GRAB_BUNDLE_*` capture half already worked
+there, so a Windows investigation could produce a several-hundred-MiB `.prgbundle` and then have no
+way to open it.
+
+**Pass Windows-style paths and set `MSYS2_ARG_CONV_EXCL='*'` under Git Bash / MSYS.** Otherwise the
+shell rewrites the arguments and the tool prints its usage block, which reads as a bad flag rather
+than a mangled path:
+
+```bash
+MSYS2_ARG_CONV_EXCL='*' ./build/gpu_replay.exe \
+  --bundle C:/path/to/frame_grab.prgbundle C:/path/to/out.bmp
+```
+
+The trailing output path is required even when you only want the inspection lines.
+
 `gpu_replay` inspects, validates, graphs, and renders a local `.prgcap` without booting the guest.
 Capsules contain title-derived shaders, resource bytes, addresses, ordered DMA endpoints, optional rendered RTT
 pixels, and optional exact persistent Vulkan depth/stencil checkpoint planes.

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1764,6 +1764,25 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
 
 } // namespace
 
+// MinGW's UCRT headers have no setenv/unsetenv, so gpu_replay did not COMPILE on Windows --
+// which is why it was Linux-only. Same shape tools/screenshot/screenshot.cpp already uses.
+// `_putenv_s(name, "")` is the documented Win32 way to remove a variable.
+static bool set_environment(const char* name, const char* value) {
+#ifdef _WIN32
+    return _putenv_s(name, value) == 0;
+#else
+    return setenv(name, value, 1) == 0;
+#endif
+}
+
+static bool clear_environment(const char* name) {
+#ifdef _WIN32
+    return _putenv_s(name, "") == 0;
+#else
+    return unsetenv(name) == 0;
+#endif
+}
+
 int main(int argc, char** argv) {
     bool inspect = false, inspect_only = false, validate_only = false, allow_mismatch = false;
     bool recompile_raw = false;
@@ -2172,7 +2191,7 @@ int main(int argc, char** argv) {
         }
         const char* tap_env_raw = std::getenv("PROSPER_FS_TAP");
         const std::string tap_env = tap_env_raw ? tap_env_raw : "";
-        if (tap_env_raw) unsetenv("PROSPER_FS_TAP");
+        if (tap_env_raw) clear_environment("PROSPER_FS_TAP");
         size_t vs_swapped = 0, fs_swapped = 0, vs_kept = 0, fs_kept = 0;
         for (auto& it : replay.items) {
             const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
@@ -2217,7 +2236,7 @@ int main(int argc, char** argv) {
                 if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) ++fs_kept;
             }
         }
-        if (tap_env_raw) setenv("PROSPER_FS_TAP", tap_env.c_str(), 1);
+        if (tap_env_raw) set_environment("PROSPER_FS_TAP", tap_env.c_str());
         std::fprintf(stderr, "[recompile-raw] substituted vs=%zu fs=%zu kept-stored vs=%zu fs=%zu of %zu draws\n",
                      vs_swapped, fs_swapped, vs_kept, fs_kept, replay.items.size());
     }


### PR DESCRIPTION
Fixes #2331

## Failure scenario

The F9 / `PROSPER_GRAB_BUNDLE_*` capture half already worked on Windows. The **replayer did not exist
there**: `gpu_replay` is defined inside the CMake `if(UNIX)` block (`:1220`–`:1535`), so
`cmake --build --target gpu_replay` answers `ninja: error: unknown target`, which reads as a typo.

A Windows investigation could therefore produce a **449 MiB `.prgbundle`** from the documented
scheduled grab and have no way to open it. That is the workflow `CLAUDE.md` calls *"the fastest
loop"* for a graphical bug or an FPS drop — and it explicitly says the capture triggers are
platform-independent, which is true, and is exactly what hides the gap.

Concretely it blocks the open question on **#2215**: draws per submit rise ×188 at the Blue Prince
collapse while per-draw cost *falls*, and the next step is whether those ~6,540 draws/frame are
distinct geometry or repeated work. `--inspect-only` / `--draw-steps` is the tool for that.

## The port is two lines

MinGW's UCRT headers have no `setenv`/`unsetenv`. That is the entire reason the target was
Linux-first — `tools/screenshot/screenshot.cpp:70` already carries the identical shim. With those two
call sites shimmed and the target added to the **Windows** Vulkan block (mirroring the UNIX one, not
moving it — `prosper_live_renderer` is already built on both), it compiles clean.

The `-Werror=switch` gate is carried over deliberately: `gpu_replay` maps `LiveTargetPixelFormat`
itself in `inspect_live_target`, and an unhandled member falls through to the seed's `Rgba8Unorm`
default and makes `--inspect-only` **mislabel the seed** — sending an investigation down the wrong
path using its own instrument. That failure mode is not platform-specific, so neither is the gate.

## Verification (exact head `43965560`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Vulkan SDK 1.4.350.0, RTX 4090.

**It builds** — `gpu_replay.exe`, 87 MB, no errors.

**It replays a real capture** — the Blue Prince collapsed-state bundle this was blocked on:

```
[gpureplay] bundle v2 submits=2 logical=840075290 unique=470890481 ratio=0.561
            chunks=3804 resources=541 refs=629 exact-reuse=88
[render] Vulkan device: NVIDIA GeForce RTX 4090 (discrete GPU)
[gpureplay] bundle-submit=2250 operations=4086/4086 output_bytes=0 hash=14650fb0739d0383
[gpureplay] bundle-submit=2251 operations=336/336 output_bytes=8294400 hash=5bc20885714a9aa3
[gpureplay] closure temporal-resolved=0 seeded=0 bounded=0 unresolved=0
```

All 4,086 + 336 operations decoded, output written.

**Full suite** — `ctest --no-tests=error -j4` → **176/177**. The single failure is #2327
(`pthread_cond_clock`), established earlier today as pre-existing on clean `origin/master`.

`git diff --check` clean; docs gate clean on the README; session-trailer gate 0.

## README

Adds the invocation Windows needs. Under Git Bash the shell rewrites the arguments unless
`MSYS2_ARG_CONV_EXCL='*'` is set, and the tool answers with its **usage block** — which reads as an
unsupported flag rather than a mangled path. That cost two attempts here.

## Correction to the issue I filed

#2331 frames the `if(UNIX)` placement as a gate nobody noticed. **That is not right** — the Windows
block's own comment says *"the extra replay/screenshot tools stay Linux-first for now"*, so it was a
deliberate, documented decision. What changed since is that the F9 loop became the charter's
first-resort recommendation for graphical and perf work, and `screenshot` was subsequently built on
Windows (`:1542`) while that comment still says it is not. So this is a decision worth revisiting on
its merits, not an oversight — and the comment is now stale on the screenshot half too.

## Risk

Low. Additive: one new target in the Windows block, a portable shim, a docs section. No existing
target, test, or platform behaviour changes; the UNIX definition is untouched.

## Deliberately not done

Whether the **wave64 fragment shaders** this replay skips (17 in one submit — `skip draw: fragment
shader requires subgroup size 64 (device range 32..32)`) matter for Blue Prince on NVIDIA is **#2147**,
not in scope here. Worth noting the replayer now makes that visible on Windows.

— Wren (Windows lane)