### PR TITLE
perf(render): memoize the per-draw internal-GDS shader scan

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1461,6 +1461,16 @@ if(TARGET prosper_core)
       target_link_libraries(test_rdna2_to_spirv PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME rdna2_to_spirv_exec COMMAND test_rdna2_to_spirv)
 
+      # The per-draw internal-GDS scan memo (#2334). Two registrations of ONE binary: the second
+      # sets the opt-out, so the pair proves the memo both fires and can be turned off, on a single
+      # build. Both must PASS -- the binary flips its own expectation from the environment.
+      add_executable(test_gds_scan_memo tests/test_gds_scan_memo.cpp)
+      target_link_libraries(test_gds_scan_memo PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME gds_scan_memo COMMAND test_gds_scan_memo)
+      add_test(NAME gds_scan_memo_disabled COMMAND test_gds_scan_memo)
+      set_tests_properties(gds_scan_memo_disabled PROPERTIES
+                           ENVIRONMENT "PROSPER_NO_GDS_SCAN_MEMO=1")
+
       # Render a triangle whose PIXEL shader is recompiled from RDNA2 (EXP MRT0 -> color output).
       add_executable(test_recompiled_fragment tests/test_recompiled_fragment.cpp)
       target_link_libraries(test_recompiled_fragment PRIVATE prosper_core Vulkan::Vulkan)

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2961,6 +2961,44 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
     return true;
 }
 
+// fragment_spirv_uses_internal_gds walks the ENTIRE SPIR-V module and builds two unordered_maps,
+// and both call sites below invoke it once per DRAW on a module that changes only when the shader
+// does. On Blue Prince's collapsed Day One state (~4,048 draws/submit) it measured 5.64% of the
+// saturated render thread, plus the allocator churn of two map constructions per draw (#2334).
+//
+// Memoized on fs_identity -- the same key, and for the same reason, as the subgroup-scan memo
+// (#2259) further down: DrawItem identities come from the shader-recompile cache as
+// `cache.next_identity++` (src/gpu/gpu_executor.cpp), a monotonic counter that is never reset,
+// never decremented and untouched by eviction. So an identity denotes one module for the life of
+// the process -- an evicted shader recompiles to a NEW identity, which misses here and refills,
+// and the stale entry is simply never looked up again. The counter starts at 1, so identity 0 is
+// never minted and the identity-0 fallthrough below cannot collide with a real module.
+//
+// The memoized value is a pure function of the module words alone -- it reads no device state --
+// so a hit is exactly what the call would have returned.
+//
+// PROSPER_NO_GDS_SCAN_MEMO: opt out, so the A/B for this change is single-variable on ONE binary
+// rather than a comparison of two builds, matching PROSPER_NO_SUBGROUP_SCAN_MEMO (#2259),
+// PROSPER_NO_INDEX_ARENA (#2258) and the PROSPER_NO_BACKEND_* family.
+inline bool fragment_uses_internal_gds_memoized(uint64_t fs_identity,
+                                                const std::vector<uint32_t>& fs_words) {
+    static const bool no_gds_scan_memo = getenv("PROSPER_NO_GDS_SCAN_MEMO") != nullptr;
+    if (!fs_identity || no_gds_scan_memo)
+        return prosper::gpu::fragment_spirv_uses_internal_gds(fs_words);
+    static thread_local std::unordered_map<uint64_t, bool> gds_scan_memo;
+    constexpr size_t kGdsScanMemoMaxEntries = 4096;
+    const auto found = gds_scan_memo.find(fs_identity);
+    if (found != gds_scan_memo.end()) return found->second;
+    const bool uses = prosper::gpu::fragment_spirv_uses_internal_gds(fs_words);
+    // Cleared wholesale rather than aged, for the same reason as the subgroup-scan memo: there is no
+    // LRU bookkeeping worth paying for on a path this hot, and a clear means this memo has STOPPED
+    // WORKING (the scans are paid again in full, plus the churn) rather than that a threshold was
+    // brushed. 523 distinct shaders per submit leaves ample headroom against 4,096.
+    if (gds_scan_memo.size() >= kGdsScanMemoMaxEntries) gds_scan_memo.clear();
+    gds_scan_memo.emplace(fs_identity, uses);
+    return uses;
+}
+
 // `submission_batch` is an explicit live-renderer ownership scope. Calls with no requested CPU
 // readback may return after recording; `flush_submission_batch` submits every accumulated command
 // buffer in order, waits once, and releases all retained resources. Omitting the batch preserves the
@@ -3920,7 +3958,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     std::vector<std::vector<FrameResource>> effective_resources(draws.size());
     for (size_t i = 0; i < draws.size(); ++i) {
         effective_resources[i] = draws[i].R;
-        if (prosper::gpu::fragment_spirv_uses_internal_gds(draws[i].fs_words())) {
+        if (fragment_uses_internal_gds_memoized(draws[i].fs_identity, draws[i].fs_words())) {
             FrameResource gds;
             gds.set = 1;
             gds.binding = 0;
@@ -4131,7 +4169,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         if (ctx.subgroup_operations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT)
             available_fragment_subgroup_features |= prosper::gpu::kFragmentSubgroupShuffle;
         const bool uses_internal_gds =
-            prosper::gpu::fragment_spirv_uses_internal_gds(bd_fs);
+            fragment_uses_internal_gds_memoized(bd.fs_identity, bd_fs);
         if (required_fragment_subgroup_size &&
             (!ctx.subgroup_size_control ||
              required_fragment_subgroup_size < ctx.min_subgroup_size ||

--- a/prosper/tests/test_gds_scan_memo.cpp
+++ b/prosper/tests/test_gds_scan_memo.cpp
@@ -1,0 +1,78 @@
+// Regression test for the per-draw internal-GDS scan memo (#2334).
+//
+// fragment_spirv_uses_internal_gds walks the entire SPIR-V module and builds two unordered_maps.
+// render_runner.h called it once per DRAW at two sites, on a module that changes only when the
+// shader does; on Blue Prince's collapsed state (~4,048 draws/submit) it measured 5.64% of the
+// saturated render thread. fragment_uses_internal_gds_memoized caches the result on fs_identity.
+//
+// The modules here are built BY HAND rather than recompiled, so the positive case is constructed
+// outside whatever produces the negative one -- a fixture that generated both from one recompile
+// could share a defect that makes the GDS case inexpressible, and the test would then pass without
+// ever exercising it.
+
+#include "render_runner.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what);
+}
+
+// A minimal module the scanner can parse: 5-word header, then OpDecorate pairs.
+// The scanner reports true when some id carries DescriptorSet==1 AND Binding==0.
+static std::vector<uint32_t> make_module(uint32_t descriptor_set) {
+    constexpr uint32_t kOpDecorate = 71, kDecBinding = 33, kDecDescriptorSet = 34;
+    const uint32_t decorate = (4u << 16) | kOpDecorate;   // 4-word OpDecorate
+    return {
+        0x07230203u, 0x00010000u, 0u, 8u, 0u,             // magic, version, generator, bound, schema
+        decorate, 1u, kDecDescriptorSet, descriptor_set,
+        decorate, 1u, kDecBinding, 0u,
+    };
+}
+
+int main() {
+    const bool memo_disabled = getenv("PROSPER_NO_GDS_SCAN_MEMO") != nullptr;
+    const std::vector<uint32_t> gds = make_module(1);      // set=1, binding=0 -> internal GDS
+    const std::vector<uint32_t> plain = make_module(2);    // set=2            -> not internal GDS
+
+    // The underlying scanner must disagree about these two modules, or every arm below is vacuous.
+    check(prosper::gpu::fragment_spirv_uses_internal_gds(gds),
+          "hand-built set=1/binding=0 module scans as internal GDS");
+    check(!prosper::gpu::fragment_spirv_uses_internal_gds(plain),
+          "hand-built set=2 module does not scan as internal GDS");
+
+    // Distinct identities must not contaminate each other.
+    check(prosper::test::fragment_uses_internal_gds_memoized(101, gds), "identity 101 -> gds true");
+    check(!prosper::test::fragment_uses_internal_gds_memoized(102, plain), "identity 102 -> plain false");
+    check(prosper::test::fragment_uses_internal_gds_memoized(101, gds), "identity 101 repeat -> true");
+    check(!prosper::test::fragment_uses_internal_gds_memoized(102, plain), "identity 102 repeat -> false");
+
+    // THE DISCRIMINATOR. Re-ask under an identity already cached, but hand it the OTHER module's
+    // words. A memo that is actually consulted returns the cached answer and never looks at the
+    // words; a memo that silently does nothing re-walks them and returns the other result. This is
+    // the only arm that can tell "cached" from "recomputed the same answer", and it is why the two
+    // modules must disagree (asserted above).
+    //
+    // Reusing one identity for two different modules cannot happen in production -- identities come
+    // from a monotonic never-reset counter, so an evicted shader recompiles to a NEW identity. It is
+    // done here precisely because it is the observable consequence of caching.
+    const bool stale = prosper::test::fragment_uses_internal_gds_memoized(101, plain);
+    if (memo_disabled)
+        check(!stale, "PROSPER_NO_GDS_SCAN_MEMO: identity 101 + plain words re-scans -> false");
+    else
+        check(stale, "memo hit: identity 101 + plain words returns the CACHED true, not a re-scan");
+
+    // Identity 0 is never minted by the recompile cache and must bypass the memo entirely, so it
+    // can never collide with a real module. Both answers must track the words handed in.
+    check(prosper::test::fragment_uses_internal_gds_memoized(0, gds), "identity 0 + gds -> true");
+    check(!prosper::test::fragment_uses_internal_gds_memoized(0, plain), "identity 0 + plain -> false");
+    check(prosper::test::fragment_uses_internal_gds_memoized(0, gds), "identity 0 + gds again -> true");
+
+    std::fprintf(stderr, "%s (%s)\n", failures ? "FAILURES" : "all arms passed",
+                 memo_disabled ? "memo disabled" : "memo enabled");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What and why

`fragment_spirv_uses_internal_gds` walks the **entire SPIR-V module** and builds two
`unordered_map`s. `render_runner.h` called it **once per draw** at two sites, on a module that changes
only when the shader does.

This is the smaller, self-contained half of **#2334**. That issue establishes — by per-thread `/proc`
attribution summing to 100%, then `perf record` — that Blue Prince's frame-rate collapse is CPU-bound
on the render thread (72% -> 95% on-CPU while its GPU-fence wait falls 25% -> 5%, and CPU work per
frame rises ~9.9x). This scan measured **5.64%** of that saturated thread.

The dominant cost in #2334 is something else entirely (deep-copying `GpuState`'s three
`unordered_map` register files per draw, ~54%). That needs a container change across 395 call sites
and is deliberately **not** in this PR.

## Approach

Memoized on `fs_identity`, the same key and the same reasoning as the subgroup-scan memo (#2259) —
whose sibling scans sit at *the very same call site* and are consequently already absent from the
profile. This scan was simply left out of that memo.

Identities come from the shader-recompile cache as `cache.next_identity++`, a monotonic counter that
is never reset, never decremented, and untouched by eviction. So one identity denotes one module for
the life of the process: an evicted shader recompiles to a **new** identity, misses, and refills,
while the stale entry is never looked up again. The counter starts at 1, so identity 0 is never
minted and is routed past the memo entirely.

The memoized value is a pure function of the module words — it reads no device state — so a hit is
exactly what the call would have returned.

`PROSPER_NO_GDS_SCAN_MEMO` opts out, so the A/B below is single-variable **on one binary** rather than
a comparison of two builds, matching `PROSPER_NO_SUBGROUP_SCAN_MEMO` (#2259) and
`PROSPER_NO_INDEX_ARENA` (#2258).

## Measured effect

`perf record -F 499` on the busiest thread, 20 s inside the collapsed steady state, both arms from the
same binary, both reaching the same state (busiest-thread tick delta 196 vs 199 over 2 s):

| | `fragment_spirv_uses_internal_gds` | `__memmove` | `_int_free_chunk` |
| --- | ---: | ---: | ---: |
| `PROSPER_NO_GDS_SCAN_MEMO=1` | **5.38%** | 25.70% | 9.70% |
| default (memoized) | **absent** (below the 0.4% cut) | 27.07% | 9.60% |

The scan is gone; everything else is unchanged, which is the expected shape — this memo does not touch
the `GpuState` copying that dominates.

**No frame-rate claim.** Both arms ended on the same cumulative frame count, and that counter advances
in steps of 60, so ~5% of one thread is below what this route can resolve. The claim here is that a
per-draw full-module walk is eliminated, not that the collapse is fixed. It is not.

## Test

`tests/test_gds_scan_memo.cpp`, registered **twice against one binary** — once plain, once with the
opt-out — and both must pass, because the binary flips its own expectation from the environment.

The discriminating arm re-asks under an **already-cached identity while handing over the other
module's words**: memoized it returns the cached answer, unmemoized it re-walks and returns the
opposite. So the two arms assert **opposite outcomes on identical input**, which is what separates
"the memo was consulted" from "it recomputed the same answer anyway". A test that only checked the
answer was correct would pass with the memo deleted.

Both modules are constructed **by hand** rather than recompiled, so the positive case does not come
from the same generator as the negative one. The test also asserts up front that the underlying
scanner disagrees about the two modules — without that, every later arm would be vacuous.

Observed:
```
memo enabled : ok: memo hit: identity 101 + plain words returns the CACHED true, not a re-scan
memo disabled: ok: PROSPER_NO_GDS_SCAN_MEMO: identity 101 + plain words re-scans -> false
```

## Verification

```
cmake -S prosper -B build -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6                       # rc=0
ctest --no-tests=error -j4                    # rc=0, 224/224 passed
```

An earlier run of the same tree showed 222/224 with `module_loads_eboot` and
`boot_reaches_first_syscall` red; both were my build directory pointing `GAME_DUMP` at Blue Prince
rather than the Messenger dump those two tests load, and both are green after reconfiguring. Recorded
rather than dropped, since "2 failures that turned out to be mine" is exactly the kind of thing that
should be visible in the record.

No snapshots run — this changes no rendered output; the memoized value is a pure function of bytes
already being read.

## Risk

The one hazard is an identity reused for a different module, which would return a stale answer. That
is the invariant the comment documents and the identity-0 bypass protects; it is also precisely what
the discriminating test arm exercises deliberately. Same key, same lifetime, same failure mode as
#2259, which has been in place since then.

Refs #2334
