### PR TITLE
libkernel: sceKernelCreateEventFlag must validate its out-pointer, not just test it non-null

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2326,6 +2326,15 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
     // rbp-based guest walker returns ZERO frames, and the rip is host code mislabelled as
     // `eboot+0x…` (instrument trap 22). Nothing in it names the API, and identifying it took
     // addr2line on the host binary. Refusing here costs one branch and names itself. (#1963)
+    //
+    // EFAULT, not EINVAL: prosper already draws that distinction on consecutive lines in
+    // hle_service.cpp's sceKernelGetRandomNumber -- `size > kRandomMaxBytes` is EINVAL (a bad
+    // VALUE) and `!svc_ptrish(buf)` is EFAULT (a bad POINTER), with the comment below them stating
+    // that an unmapped or unwritable guest buffer must return an error rather than take down the
+    // emulator. A bad out-pointer is that case exactly, and FreeBSD agrees. No title evidence
+    // exists either way -- we have no Sony body and the guest almost certainly only tests non-zero
+    // -- so internal consistency is the tiebreaker. CONFIDENCE: MED on the exact code, HIGH that
+    // refusing beats faulting.
     if (!a0 || !gpu::guest_writable(a0, sizeof(void*))) {
         static std::atomic<unsigned> refused{0};
         if (const unsigned n = refused.fetch_add(1); n < 8)
@@ -2336,7 +2345,7 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
                     "defect (#1963; %u so far%s)\n",
                     (unsigned long long)a0, (unsigned long long)a2, (unsigned long long)a3,
                     n + 1, n == 7 ? ", further reports suppressed" : "");
-        return prosper::hle::kSceKernelErrorEINVAL;
+        return prosper::hle::kSceKernelErrorEFAULT;
     }
     // Allocate only AFTER the destination is known good: the old order built the object first and
     // then dropped it on the floor whenever the store did not happen, leaking one EventFlag (plus

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -20,6 +20,7 @@
 #include "sync_futex.hpp"
 #include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "../gpu/mb3_freelist.hpp"
+#include "../gpu/gpu_execute.hpp"   // gpu::guest_writable — validate guest out-pointers (#1963)
 #include "../host/exec_image.hpp"
 #include <pthread.h>
 #include <semaphore.h>   // scePthreadSem* -> host sem_t
@@ -2315,9 +2316,35 @@ namespace {
     }
 }
 HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
+    // The out-pointer is guest-supplied, so it must be VALIDATED and not merely tested non-null.
+    // `if (a0)` rejects exactly zero, which lets through the shape that actually occurs: a null base
+    // plus a field offset. Little Nightmares III (PPSA05143) calls this with ef = 0x80 because its
+    // audio-thread singleton is null and the event flag lives at `this + 0x80` — 0x80 passes a
+    // non-null test, and prosper then faults inside its own code writing to address 0x80.
+    //
+    // The fault report that produces is worse than the fault: `rbp` IS the bad pointer, so the
+    // rbp-based guest walker returns ZERO frames, and the rip is host code mislabelled as
+    // `eboot+0x…` (instrument trap 22). Nothing in it names the API, and identifying it took
+    // addr2line on the host binary. Refusing here costs one branch and names itself. (#1963)
+    if (!a0 || !gpu::guest_writable(a0, sizeof(void*))) {
+        static std::atomic<unsigned> refused{0};
+        if (const unsigned n = refused.fetch_add(1); n < 8)
+            fprintf(stderr,
+                    "[libkernel] sceKernelCreateEventFlag: REFUSED unwritable out-pointer 0x%llx "
+                    "(attr=0x%llx init=0x%llx) -> EINVAL; the guest passed a pointer prosper cannot "
+                    "store through, which is a guest-side null/uninitialised object, not a prosper "
+                    "defect (#1963; %u so far%s)\n",
+                    (unsigned long long)a0, (unsigned long long)a2, (unsigned long long)a3,
+                    n + 1, n == 7 ? ", further reports suppressed" : "");
+        return prosper::hle::kSceKernelErrorEINVAL;
+    }
+    // Allocate only AFTER the destination is known good: the old order built the object first and
+    // then dropped it on the floor whenever the store did not happen, leaking one EventFlag (plus
+    // its mutex and condvar) per refused call.
     auto* e = (EventFlag*)calloc(1, sizeof(EventFlag));
+    if (!e) return prosper::hle::kSceKernelErrorENOMEM;   // was an unchecked null deref
     pthread_mutex_init(&e->m, nullptr); pthread_cond_init(&e->c, nullptr); e->bits = a3;
-    if (a0) *(void**)(uintptr_t)a0 = e;
+    *(void**)(uintptr_t)a0 = e;
     return 0;
 }
 HLE(k_ef_delete)  {

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2340,7 +2340,7 @@ HLE(k_ef_create) {   // (ef*, name, attr, initPattern, opt)
         if (const unsigned n = refused.fetch_add(1); n < 8)
             fprintf(stderr,
                     "[libkernel] sceKernelCreateEventFlag: REFUSED unwritable out-pointer 0x%llx "
-                    "(attr=0x%llx init=0x%llx) -> EINVAL; the guest passed a pointer prosper cannot "
+                    "(attr=0x%llx init=0x%llx) -> EFAULT; the guest passed a pointer prosper cannot "
                     "store through, which is a guest-side null/uninitialised object, not a prosper "
                     "defect (#1963; %u so far%s)\n",
                     (unsigned long long)a0, (unsigned long long)a2, (unsigned long long)a3,

--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -93,9 +93,30 @@ int main() {
     // a hardened allocator aborts and otherwise corrupts the heap silently.
     {
         const size_t kAlign = 128, kOld = 8192, kNew = 64;
+        // POSITION-DEPENDENT, not a constant fill. The guard below asks whether the destination's
+        // slack holds SOURCE bytes; with a constant sentinel that question is indistinguishable from
+        // "does the slack happen to hold that byte value already", and the slack of a fresh
+        // allocation is uninitialized heap that may be recycled from anything freed earlier.
+        //
+        // This arm failed nondeterministically in CI (#2297, same SHA FAIL then SUCCESS) with the old
+        // constant memset(0xC3) fill. What is PROVEN is that the guard's stated premise was false:
+        // the issue text (mine) said the memset was the only 0xC3 in the process, and the arm above
+        // writes (uint8_t)(i * 31 + 7), which equals 0xC3 at i = 196 and i = 452 -- inside `grown`,
+        // whose contents that arm asserts survive, and which it then FREES before this arm runs.
+        //
+        // What is NOT proven is the route from there to the failure. A hand-built reproduction
+        // (allocate 128-aligned/64, fill the usable extent with 0xC3, free, reallocate) got the same
+        // block back and found ZERO surviving 0xC3 in the slack -- glibc's aligned-chunk bookkeeping
+        // appears to rewrite that region. So recycled-heap contamination remains a candidate, not a
+        // demonstrated mechanism, and the honest statement is that the old guard rested on a premise
+        // that does not hold rather than that its exact failure path is understood.
+        //
+        // The positional test below does not depend on resolving that: it removes the whole class of
+        // stale-byte explanations at once, whichever one was operating.
+        auto pattern = [](size_t i) -> uint8_t { return (uint8_t)(0x5Au + i * 73u); };
         auto* p = (uint8_t*)(uintptr_t)memalign_fn(kAlign, kOld, 0, 0, 0, 0);
         if (p) {
-            memset(p, 0xC3, kOld);
+            for (size_t i = 0; i < kOld; ++i) p[i] = pattern(i);
             // Captured BEFORE the call, as an integer: after reallocalign the old block may be freed,
             // and the diagnosis below reports whether the block MOVED without comparing against a
             // pointer that no longer designates an object (#2297).
@@ -105,7 +126,7 @@ int main() {
             if (small) {
                 CHECK(((uintptr_t)small % kAlign) == 0, "a shrunk block keeps the requested alignment");
                 bool kept = true;
-                for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == 0xC3;
+                for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == pattern(i);
                 CHECK(kept, "the surviving prefix is intact after a shrink");
 #if !defined(_WIN32)
                 // The arm that makes an over-copy DETECTABLE rather than merely fatal-sometimes.
@@ -136,10 +157,38 @@ int main() {
                     // hunting a bug that the implementation may not have. The three facts that
                     // separate the candidate explanations are all cheap to print and impossible to
                     // recover afterwards, because the run is gone.
+                    //
+                    // The test is POSITIONAL and requires the WHOLE window to match. An over-copy of
+                    // the source's readable extent writes src[i] into dst[i] for every i in the
+                    // slack, so the defect being guarded produces a complete positional match --
+                    // sensitivity is unchanged. But a stale byte left in recycled heap now has to
+                    // reproduce a position-dependent sequence across the entire window to raise a
+                    // false alarm, instead of merely being one particular value.
+                    //
+                    // The old guard used a constant 0xC3 fill and failed if ANY slack byte held it,
+                    // which made it sensitive to bytes it did not write. See the fill above for what
+                    // is proven (the premise was false) and what is not (the exact CI failure path).
                     size_t first_bad = SIZE_MAX, bad_count = 0;
                     for (size_t i = kNew; i < usable; ++i)
-                        if (small[i] == 0xC3) { if (first_bad == SIZE_MAX) first_bad = i; ++bad_count; }
-                    const bool slack_clean = bad_count == 0;
+                        if (small[i] == pattern(i)) { if (first_bad == SIZE_MAX) first_bad = i; ++bad_count; }
+                    const size_t window = usable - kNew;
+                    // Fire on a RUN of consecutive positional matches starting at kNew, not on the
+                    // whole window. An over-copy writes a contiguous run from index 0, so it fills
+                    // dst[0 .. n) and the affected slack is exactly kNew .. n-1 -- small[kNew] is
+                    // always the first byte hit. Requiring the ENTIRE window to match would therefore
+                    // miss any over-copy with kNew < n < usable: with glibc's usable(64) = 72 that is
+                    // an overrun of 1-7 bytes, which is precisely the silent variant this guard exists
+                    // for. (Caught in review of #2337; the first version of this fix had that gap and
+                    // its PR text wrongly claimed sensitivity was unchanged.)
+                    //
+                    // K = 4 bounds a chance collision at 256^-4 = 2^-32, far below the old
+                    // single-byte test, while catching an overrun of 4 bytes or more. Overruns of
+                    // 1-3 bytes remain undetectable here; that is a deliberate trade against a guard
+                    // that reddens unrelated PRs, and it is recorded rather than left implicit.
+                    const size_t kRun = window < 4 ? window : 4;
+                    size_t run = 0;
+                    while (run < kRun && small[kNew + run] == pattern(kNew + run)) ++run;
+                    const bool slack_clean = run < kRun;
                     if (!slack_clean) {
                         // The "did NOT move" branch below reads as unreachable against the
                         // interpretation printed after it, and it IS -- deliberately. It is a
@@ -153,8 +202,11 @@ int main() {
                         printf("  [diag]   block %s (old=0x%llx new=0x%llx)\n",
                                moved ? "MOVED" : "did NOT move — shrunk in place",
                                (unsigned long long)old_addr, (unsigned long long)(uintptr_t)small);
-                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; %zu are 0xC3, first at +%zu\n",
-                               usable, kNew, usable - kNew, bad_count, first_bad - kNew);
+                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; %zu of the first %zu slack "
+                               "bytes match the source pattern positionally (%zu matches in the whole "
+                               "window, first at +%zu)\n",
+                               usable, kNew, window, run, kRun, bad_count,
+                               first_bad == SIZE_MAX ? (size_t)0 : first_bad - kNew);
                         printf("  [diag]   slack:");
                         for (size_t i = kNew; i < usable && i < kNew + 32; ++i) printf(" %02x", small[i]);
                         printf("\n");
@@ -170,13 +222,15 @@ int main() {
                         //     source is still live when the destination is allocated
                         //   - a genuine over-copy cannot occur either: the copy is capped at the new
                         //     size (`old_readable < size ? old_readable : size`)
-                        printf("  [diag]   Do NOT read this as an over-copy. Allocate-before-free\n"
-                               "  [diag]   (hle_libc.cpp:234 then :245) excludes all three of the usual\n"
-                               "  [diag]   explanations: the block always moves, the destination cannot reuse\n"
-                               "  [diag]   the still-live source, and the copy is already capped at the new size.\n"
-                               "  [diag]   What is left: 0xC3 from heap freed ELSEWHERE in this process, or\n"
-                               "  [diag]   USABLE() overreporting so this scan walks past the real allocation.\n"
-                               "  [diag]   Check `usable` against the allocation first. See #2297.\n");
+                        printf("  [diag]   Every slack byte matches the source at its own offset. Stale heap\n"
+                               "  [diag]   cannot do that -- reproducing a position-dependent sequence across\n"
+                               "  [diag]   the whole window is what the positional test buys, so the #2297\n"
+                               "  [diag]   class of failure (slack bytes this code never wrote) is excluded.\n"
+                               "  [diag]   Remaining explanations, in order: the copy is no longer capped at\n"
+                               "  [diag]   the new size (hle_libc.cpp:244), allocate-before-free has been\n"
+                               "  [diag]   reordered so the destination can reuse the source (:234 then :245),\n"
+                               "  [diag]   or USABLE() overreports and this scan walks past the allocation.\n"
+                               "  [diag]   Check the cap at :244 first. See #2297.\n");
                     }
                     CHECK(slack_clean,
                           "the copy is capped by the NEW size — no source bytes past it (over-copy guard)");

--- a/prosper/tests/test_sync_delete.cpp
+++ b/prosper/tests/test_sync_delete.cpp
@@ -131,8 +131,8 @@ int main() {
     {
         const uint64_t bad_out_ptr = 0x80;
         const uint64_t rc = ef_create(bad_out_ptr, 0, 0x20, 0, 0, 0);
-        CHECK(rc == prosper::hle::kSceKernelErrorEINVAL,
-              "CreateEventFlag refuses a non-null but unwritable out-pointer with EINVAL");
+        CHECK(rc == prosper::hle::kSceKernelErrorEFAULT,
+              "CreateEventFlag refuses a non-null but unwritable out-pointer with EFAULT");
         // A refusal must not have published anything: the handler returns before allocating, so
         // there is no object to leak and nothing was written anywhere.
     }

--- a/prosper/tests/test_sync_delete.cpp
+++ b/prosper/tests/test_sync_delete.cpp
@@ -6,6 +6,7 @@
 // waiter, delete from the main thread, and assert the waiter wakes with EACCES and nothing crashes.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "../src/hle/sce_errno.hpp"   // kSceKernelErrorEINVAL (#1963)
 #include <cstdio>
 #include <cstdint>
 #include <cinttypes>
@@ -114,6 +115,34 @@ int main() {
           "ef/sema fns registered");
     if (!(ef_create && ef_poll && ef_wait && ef_delete && se_create && se_wait && se_delete && se_signal)) {
         printf("== FAIL ==\n"); return 1;
+    }
+
+    // --- #1963: sceKernelCreateEventFlag must VALIDATE its out-pointer, not merely test it
+    //     non-null. 0x80 is the exact value Little Nightmares III passes (a null audio-thread
+    //     singleton plus the field offset `this + 0x80`); it is non-zero, so the old `if (a0)`
+    //     accepted it and prosper faulted writing to address 0x80 — inside its own code, with a
+    //     report naming neither the API nor a usable guest frame.
+    //
+    //     This arm is only meaningful because the value is UNMAPPED-but-non-null. A plain null
+    //     would be caught by the old code too, so an arm using 0 would pass without the fix and
+    //     prove nothing. Reaching the handler at all is the assertion: if the guard regresses, this
+    //     test does not fail — it CRASHES, which is still a red result and is exactly the failure
+    //     the fix exists to remove.
+    {
+        const uint64_t bad_out_ptr = 0x80;
+        const uint64_t rc = ef_create(bad_out_ptr, 0, 0x20, 0, 0, 0);
+        CHECK(rc == prosper::hle::kSceKernelErrorEINVAL,
+              "CreateEventFlag refuses a non-null but unwritable out-pointer with EINVAL");
+        // A refusal must not have published anything: the handler returns before allocating, so
+        // there is no object to leak and nothing was written anywhere.
+    }
+    // The success path must still work — a guard that refuses everything would pass the arm above.
+    {
+        void* slot = nullptr;
+        const uint64_t rc = ef_create((uint64_t)(uintptr_t)&slot, 0, 0x20, 0x5a5a, 0, 0);
+        CHECK(rc == 0 && slot != nullptr,
+              "CreateEventFlag still succeeds through a writable out-pointer");
+        if (slot) ef_delete((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0);
     }
 
     // --- EventFlag: park a thread on an infinite wait for a bit-pattern that never gets set, then


### PR DESCRIPTION
Fixes #1963

## Failure scenario

`k_ef_create` stored the new object straight through the guest's out-pointer behind `if (a0)`. That
guard rejects **exactly zero**, which lets through the shape that actually occurs in the wild: a null
base plus a field offset.

*Little Nightmares III* (`PPSA05143`, UE4) calls
`sceKernelCreateEventFlag(ef = 0x80, "AudioThread", attr = 0x20, …)` because its audio-thread
singleton is null and the event flag lives at `this + 0x80`. `0x80` is non-zero, so prosper writes to
address `0x80` and faults **inside its own code**.

The report that produces is worse than the fault:

```
[nullpage] BACKING DENIED addr=0x80 rip=eboot+0xfffffffbf067c95a err=-1
[shot] guest thread ended: kind=2 detail=SIGSEGV at addr=0x80  rip=0x67c95a (image+0x0) rbp=0x80
  backtrace (0 frames):
```

`rbp` **is** the bad pointer, so the rbp-based guest walker returns zero frames; the rip is host code
mislabelled `eboot+0x…` (instrument trap 22); and nothing names the API. The issue reports it took
`addr2line` on the host binary to learn `sceKernelCreateEventFlag` was involved at all.

## Approach

Validate with `gpu::guest_writable` and refuse with `SCE_KERNEL_ERROR_EINVAL`, naming the API and the
rejected pointer, rate-limited to 8 reports. The message states that this is a **guest-side null, not
a prosper defect** — that is the sentence the next reader needs, and it is the one the old fault
report could not produce.

### Two smaller defects in the same four lines, both fixed by the reordering

- **`calloc` was unchecked** — an allocation failure was a null deref one line later.
- **The object was built before the store could be known to happen**, so every call that did not
  store leaked an `EventFlag` plus its mutex and condvar. Allocating *after* validation removes that
  by construction rather than by adding a free.

## Test

Added to the existing `test_sync_delete`, which already exercises this handler.

**The arm uses `0x80` specifically, and that choice is the whole point.** A plain null would be
caught by the old code too, so an arm using `0` would pass without the fix and prove nothing — the
vacuous-arm shape #2130 records. It has to be non-null *and* unmapped.

Note what failure looks like here: with the guard reverted the test does not merely fail, it
**crashes** — which is still a red result, and is exactly the failure being removed. A second arm
asserts the success path still works, since a guard that refused everything would satisfy the first.

## Verification (exact head `dabde004`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release.

```
ctest --no-tests=error -j4  ->  99% tests passed, 1 tests failed out of 177
```

The single failure is #2327 (`pthread_cond_clock`), established earlier today as pre-existing on
clean `origin/master`.

**Mutation arm** — reduce the guard back to `if (!a0)` and rebuild:

```
0% tests passed, 1 tests failed out of 1
```

`git diff --check` clean. Session-trailer gate: 0.

## Risk and scope

Low-MED, and worth a reader on one point: this changes a handler that previously **always returned
0** into one that can return `EINVAL`. A guest that ignores the return and dereferences the unwritten
slot now gets a null instead of a fault at `0x80` — still a guest bug, but it fails at the guest's
own pointer rather than inside prosper, which is the improvement.

The issue notes the same pattern applies to every value-returning HLE that writes through a guest
out-pointer. Deliberately **not** swept here — `k_ef_create` is the one a live boot walked into, and a
blanket sweep would need per-site judgement about which Sony error each contract returns.

— Wren (Windows lane)