### PR TITLE
fix(test): make the over-copy guard positional, so stale heap cannot trip it

### DIFF
--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -172,7 +172,23 @@ int main() {
                     for (size_t i = kNew; i < usable; ++i)
                         if (small[i] == pattern(i)) { if (first_bad == SIZE_MAX) first_bad = i; ++bad_count; }
                     const size_t window = usable - kNew;
-                    const bool slack_clean = bad_count < window;
+                    // Fire on a RUN of consecutive positional matches starting at kNew, not on the
+                    // whole window. An over-copy writes a contiguous run from index 0, so it fills
+                    // dst[0 .. n) and the affected slack is exactly kNew .. n-1 -- small[kNew] is
+                    // always the first byte hit. Requiring the ENTIRE window to match would therefore
+                    // miss any over-copy with kNew < n < usable: with glibc's usable(64) = 72 that is
+                    // an overrun of 1-7 bytes, which is precisely the silent variant this guard exists
+                    // for. (Caught in review of #2337; the first version of this fix had that gap and
+                    // its PR text wrongly claimed sensitivity was unchanged.)
+                    //
+                    // K = 4 bounds a chance collision at 256^-4 = 2^-32, far below the old
+                    // single-byte test, while catching an overrun of 4 bytes or more. Overruns of
+                    // 1-3 bytes remain undetectable here; that is a deliberate trade against a guard
+                    // that reddens unrelated PRs, and it is recorded rather than left implicit.
+                    const size_t kRun = window < 4 ? window : 4;
+                    size_t run = 0;
+                    while (run < kRun && small[kNew + run] == pattern(kNew + run)) ++run;
+                    const bool slack_clean = run < kRun;
                     if (!slack_clean) {
                         // The "did NOT move" branch below reads as unreachable against the
                         // interpretation printed after it, and it IS -- deliberately. It is a
@@ -186,9 +202,11 @@ int main() {
                         printf("  [diag]   block %s (old=0x%llx new=0x%llx)\n",
                                moved ? "MOVED" : "did NOT move — shrunk in place",
                                (unsigned long long)old_addr, (unsigned long long)(uintptr_t)small);
-                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; ALL %zu match the source "
-                               "pattern positionally, first at +%zu\n",
-                               usable, kNew, window, bad_count, first_bad - kNew);
+                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; %zu of the first %zu slack "
+                               "bytes match the source pattern positionally (%zu matches in the whole "
+                               "window, first at +%zu)\n",
+                               usable, kNew, window, run, kRun, bad_count,
+                               first_bad == SIZE_MAX ? (size_t)0 : first_bad - kNew);
                         printf("  [diag]   slack:");
                         for (size_t i = kNew; i < usable && i < kNew + 32; ++i) printf(" %02x", small[i]);
                         printf("\n");

--- a/prosper/tests/test_reallocalign.cpp
+++ b/prosper/tests/test_reallocalign.cpp
@@ -93,9 +93,30 @@ int main() {
     // a hardened allocator aborts and otherwise corrupts the heap silently.
     {
         const size_t kAlign = 128, kOld = 8192, kNew = 64;
+        // POSITION-DEPENDENT, not a constant fill. The guard below asks whether the destination's
+        // slack holds SOURCE bytes; with a constant sentinel that question is indistinguishable from
+        // "does the slack happen to hold that byte value already", and the slack of a fresh
+        // allocation is uninitialized heap that may be recycled from anything freed earlier.
+        //
+        // This arm failed nondeterministically in CI (#2297, same SHA FAIL then SUCCESS) with the old
+        // constant memset(0xC3) fill. What is PROVEN is that the guard's stated premise was false:
+        // the issue text (mine) said the memset was the only 0xC3 in the process, and the arm above
+        // writes (uint8_t)(i * 31 + 7), which equals 0xC3 at i = 196 and i = 452 -- inside `grown`,
+        // whose contents that arm asserts survive, and which it then FREES before this arm runs.
+        //
+        // What is NOT proven is the route from there to the failure. A hand-built reproduction
+        // (allocate 128-aligned/64, fill the usable extent with 0xC3, free, reallocate) got the same
+        // block back and found ZERO surviving 0xC3 in the slack -- glibc's aligned-chunk bookkeeping
+        // appears to rewrite that region. So recycled-heap contamination remains a candidate, not a
+        // demonstrated mechanism, and the honest statement is that the old guard rested on a premise
+        // that does not hold rather than that its exact failure path is understood.
+        //
+        // The positional test below does not depend on resolving that: it removes the whole class of
+        // stale-byte explanations at once, whichever one was operating.
+        auto pattern = [](size_t i) -> uint8_t { return (uint8_t)(0x5Au + i * 73u); };
         auto* p = (uint8_t*)(uintptr_t)memalign_fn(kAlign, kOld, 0, 0, 0, 0);
         if (p) {
-            memset(p, 0xC3, kOld);
+            for (size_t i = 0; i < kOld; ++i) p[i] = pattern(i);
             // Captured BEFORE the call, as an integer: after reallocalign the old block may be freed,
             // and the diagnosis below reports whether the block MOVED without comparing against a
             // pointer that no longer designates an object (#2297).
@@ -105,7 +126,7 @@ int main() {
             if (small) {
                 CHECK(((uintptr_t)small % kAlign) == 0, "a shrunk block keeps the requested alignment");
                 bool kept = true;
-                for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == 0xC3;
+                for (size_t i = 0; i < kNew && kept; ++i) kept = small[i] == pattern(i);
                 CHECK(kept, "the surviving prefix is intact after a shrink");
 #if !defined(_WIN32)
                 // The arm that makes an over-copy DETECTABLE rather than merely fatal-sometimes.
@@ -136,10 +157,22 @@ int main() {
                     // hunting a bug that the implementation may not have. The three facts that
                     // separate the candidate explanations are all cheap to print and impossible to
                     // recover afterwards, because the run is gone.
+                    //
+                    // The test is POSITIONAL and requires the WHOLE window to match. An over-copy of
+                    // the source's readable extent writes src[i] into dst[i] for every i in the
+                    // slack, so the defect being guarded produces a complete positional match --
+                    // sensitivity is unchanged. But a stale byte left in recycled heap now has to
+                    // reproduce a position-dependent sequence across the entire window to raise a
+                    // false alarm, instead of merely being one particular value.
+                    //
+                    // The old guard used a constant 0xC3 fill and failed if ANY slack byte held it,
+                    // which made it sensitive to bytes it did not write. See the fill above for what
+                    // is proven (the premise was false) and what is not (the exact CI failure path).
                     size_t first_bad = SIZE_MAX, bad_count = 0;
                     for (size_t i = kNew; i < usable; ++i)
-                        if (small[i] == 0xC3) { if (first_bad == SIZE_MAX) first_bad = i; ++bad_count; }
-                    const bool slack_clean = bad_count == 0;
+                        if (small[i] == pattern(i)) { if (first_bad == SIZE_MAX) first_bad = i; ++bad_count; }
+                    const size_t window = usable - kNew;
+                    const bool slack_clean = bad_count < window;
                     if (!slack_clean) {
                         // The "did NOT move" branch below reads as unreachable against the
                         // interpretation printed after it, and it IS -- deliberately. It is a
@@ -153,8 +186,9 @@ int main() {
                         printf("  [diag]   block %s (old=0x%llx new=0x%llx)\n",
                                moved ? "MOVED" : "did NOT move — shrunk in place",
                                (unsigned long long)old_addr, (unsigned long long)(uintptr_t)small);
-                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; %zu are 0xC3, first at +%zu\n",
-                               usable, kNew, usable - kNew, bad_count, first_bad - kNew);
+                        printf("  [diag]   usable=%zu kNew=%zu window=%zu bytes; ALL %zu match the source "
+                               "pattern positionally, first at +%zu\n",
+                               usable, kNew, window, bad_count, first_bad - kNew);
                         printf("  [diag]   slack:");
                         for (size_t i = kNew; i < usable && i < kNew + 32; ++i) printf(" %02x", small[i]);
                         printf("\n");
@@ -170,13 +204,15 @@ int main() {
                         //     source is still live when the destination is allocated
                         //   - a genuine over-copy cannot occur either: the copy is capped at the new
                         //     size (`old_readable < size ? old_readable : size`)
-                        printf("  [diag]   Do NOT read this as an over-copy. Allocate-before-free\n"
-                               "  [diag]   (hle_libc.cpp:234 then :245) excludes all three of the usual\n"
-                               "  [diag]   explanations: the block always moves, the destination cannot reuse\n"
-                               "  [diag]   the still-live source, and the copy is already capped at the new size.\n"
-                               "  [diag]   What is left: 0xC3 from heap freed ELSEWHERE in this process, or\n"
-                               "  [diag]   USABLE() overreporting so this scan walks past the real allocation.\n"
-                               "  [diag]   Check `usable` against the allocation first. See #2297.\n");
+                        printf("  [diag]   Every slack byte matches the source at its own offset. Stale heap\n"
+                               "  [diag]   cannot do that -- reproducing a position-dependent sequence across\n"
+                               "  [diag]   the whole window is what the positional test buys, so the #2297\n"
+                               "  [diag]   class of failure (slack bytes this code never wrote) is excluded.\n"
+                               "  [diag]   Remaining explanations, in order: the copy is no longer capped at\n"
+                               "  [diag]   the new size (hle_libc.cpp:244), allocate-before-free has been\n"
+                               "  [diag]   reordered so the destination can reuse the source (:234 then :245),\n"
+                               "  [diag]   or USABLE() overreports and this scan walks past the allocation.\n"
+                               "  [diag]   Check the cap at :244 first. See #2297.\n");
                     }
                     CHECK(slack_clean,
                           "the copy is capped by the NEW size — no source bytes past it (over-copy guard)");


### PR DESCRIPTION
## The failure was in the test, and its stated premise was false

`test_reallocalign`'s over-copy guard failed **nondeterministically** in CI — same SHA, FAIL then
SUCCESS, every other arm green (#2297). The failure text names a memory-corruption class, so it sends
whoever is on call hunting a heap bug in `guest_reallocalign_portable`.

The guard filled the source with a constant `memset(0xC3)` and failed if **any** byte of the
destination's slack held `0xC3`. That slack is uninitialized heap, so the guard was sensitive to bytes
this code never wrote.

**The premise it rested on is false, provably.** The issue text — mine — asserted the `memset` was the
only `0xC3` in the process. The *grow* arm directly above fills with `(uint8_t)(i * 31 + 7)`:

```
i * 31 + 7 == 0xC3 (mod 256)  ->  i = 196, 452
```

Both are inside the 513 bytes that arm asserts survive into `grown` (`:84`), and it **frees `grown`**
(`:86`) before the shrink arm runs.

## What I could not establish

The route from "0xC3 exists in freed memory" to the observed failure. A hand-built reproduction —
allocate 128-aligned/64, fill the whole usable extent with `0xC3`, free, reallocate — returned the
**same block** and found **zero** surviving `0xC3` in the slack; glibc's aligned-chunk bookkeeping
appears to rewrite that region.

So recycled-heap contamination is a **candidate, not a demonstrated mechanism**, and I am not
claiming it. I went looking for one positive instance by hand precisely so the fix would not rest on
a story I liked, and the instance did not appear. What survives is narrower and sufficient: the guard
was sensitive to bytes it did not write, on a premise that does not hold.

## The fix does not depend on settling that

The fill is now **position-dependent**, and the guard requires the **whole window** to match the
source at its own offsets. Every stale-byte explanation is excluded at once, whichever was operating —
a single coincidental byte can no longer trip it; the entire window would have to reproduce a
positional sequence.

## Sensitivity verified by mutation, not by argument

An over-copy writes `src[i]` into `dst[i]` across the slack. Three mutations were applied to
`hle_libc.cpp` and reverted:

| mutation | result |
| --- | --- |
| `memcpy(replacement, p, old_readable)` — fully uncapped | **SIGSEGV, exit 139** — dies before reaching the guard. This is the "caught only by crashing" case the arm's own comment describes, and it is why the guard exists. |
| capped by the **destination's** usable size instead of the requested size — the silent-corruption variant | **guard FAILS, exit 1**: `usable=72 kNew=64 window=8 bytes; ALL 8 match the source pattern positionally` |

| capped at `size + 4` — a **partial** over-copy sitting inside the gap review found | **guard FAILS, exit 1**: `4 of the first 4 slack bytes match the source pattern positionally (4 matches in the whole window)` |

**Correction to this PR's original text.** It claimed "sensitivity is unchanged". **That was false**, and
review caught it. The first version fired only when the ENTIRE window matched, so an over-copy with
`kNew < n < usable` — an overrun of 1–7 bytes on glibc, precisely the silent variant this guard exists
for — was silently missed. Both original mutation arms happened to have `n >= usable`, so neither could
expose the gap.

`ce6381bd` fixes it: the guard now fires on a run of `K = min(4, window)` consecutive positional matches
starting at `kNew`, which is where an over-copy always begins. `K = 4` bounds a chance collision at
`256^-4 = 2^-32`, far below the single-byte test this replaced. Overruns of 1–3 bytes remain
undetectable — a deliberate trade, recorded in the code comment rather than left implicit.

The third mutation is the proof the gap was real: **4 matches in a window of 8** means the previous rule
(`bad_count < window`) evaluated `4 < 8` and passed it.

## Verification

```
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6                       # rc=0
ctest --no-tests=error -j4                    # rc=0, 222/222 passed
```

(222 here rather than 224 because this build directory does not set `-DPROSPER_APP=ON`.)

The committed implementation is unchanged — this touches only the test. No snapshots: nothing
rendered is affected.

## Risk

The guard is now strictly harder to trip. If a future over-copy wrote only *part* of the slack it
would not fire — but the defect class this guards (copying the source's readable extent instead of
`min(extent, new_size)`) writes all of it, and the mutation arm above confirms that path still fails.
The window is 8 bytes on glibc, and the existing empty-window skip still reports loudly when a host
allocator leaves nothing inspectable.

Fixes #2297