### PR TITLE
libSceJson2: implement Value(const char*) instead of stubbing a constructor

### DIFF
--- a/prosper/src/hle/hle_json2.cpp
+++ b/prosper/src/hle/hle_json2.cpp
@@ -428,7 +428,16 @@ JHLE(value_ctor_cstr) {
         ++length;
     // An UNTERMINATED or unreadable string yields the Null value rather than a partial one: the
     // guest asked for the text at that pointer, and prosper cannot honour half of it truthfully.
-    if (length == kMaxJsonCString) return a0;
+    // The loop exits on THREE conditions -- the cap, an unreadable byte, or the terminator --
+    // so testing only the cap let a string that runs into an unmapped page before any NUL fall
+    // through and construct a String from the readable PREFIX. That is a wrong answer wearing
+    // the shape of a success, which is the exact thing the rest of this function refuses to do,
+    // and it contradicted the comment above it. Require the terminator positively instead.
+    const bool terminated =
+        length < kMaxJsonCString &&
+        prosper::gpu::guest_readable(a1 + length, 1) &&
+        *reinterpret_cast<const char*>(static_cast<uintptr_t>(a1 + length)) == 0;
+    if (!terminated) return a0;
     // A readable EMPTY string is not that case. `Value("")` is a String whose text is empty, and
     // returning Null for it would be a silent wrong ANSWER rather than a refusal -- `getType()`
     // would report 0 where the guest constructed a string, and every later `getString()` would

--- a/prosper/src/hle/hle_json2.cpp
+++ b/prosper/src/hle/hle_json2.cpp
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include "gpu/gpu_execute.hpp"   // gpu::guest_readable — validate the guest C string (#1967)
 #include <map>
 #include <limits>
 #include <string>
@@ -388,6 +389,40 @@ JHLE(init_parameter2_set_file_buffer_size) {
     return 0;
 }
 JHLE(value_ctor) { if (auto* value = ptr<Value>(a0)) *value = Value{}; return a0; }
+// sce::Json::Value::Value(const char*) -- b9V6fmppLXY. NOT the same as setString: the argument is a
+// raw C string, not a Sony `String` object, and this constructs into caller-provided storage rather
+// than assigning to a live value.
+//
+// The dispatcher's `return 0` default is the safe answer for a status-returning function and is
+// actively unsafe for a CONSTRUCTOR: the guest reserves the storage (usually a stack slot), expects
+// the callee to write the object into it, and prosper wrote nothing -- so the guest went on to use
+// whatever residue was in that slot as a live Json::Value. A return value cannot make that safe,
+// which is why an unimplemented constructor has to be implemented rather than stubbed (#1967).
+//
+// The source pointer is validated rather than trusted, and the copy is bounded. This is a guest
+// pointer arriving at a C++ constructor: the same class as #1963, where `if (p)` let 0x80 through
+// and prosper faulted inside its own code. Constructing the EMPTY value first means a rejected or
+// empty string still leaves the guest a well-formed null Json::Value -- which is the whole point of
+// the fix -- instead of the uninitialised storage the stub left behind.
+JHLE(value_ctor_cstr) {
+    auto* value = ptr<Value>(a0);
+    if (!value) return a0;
+    *value = Value{};                      // a valid, empty Json::Value even if the text is rejected
+    if (!a1) return a0;                    // Value(nullptr) is a null value, not a crash
+    constexpr uint32_t kMaxJsonCString = 1u << 20;   // 1 MiB: a JSON scalar, not a document
+    uint32_t length = 0;
+    while (length < kMaxJsonCString &&
+           prosper::gpu::guest_readable(a1 + length, 1) &&
+           *reinterpret_cast<const char*>(static_cast<uintptr_t>(a1 + length)) != '\0')
+        ++length;
+    // An unterminated or unreadable string yields the empty value rather than a partial one: the
+    // guest asked for the text at that pointer, and prosper cannot honour half of it truthfully.
+    if (length == 0 || length == kMaxJsonCString) return a0;
+    value->type = ValueType::String;
+    value->data.string = new String{new std::string(
+        reinterpret_cast<const char*>(static_cast<uintptr_t>(a1)), length)};
+    return a0;
+}
 JHLE(value_dtor) { clear(ptr<Value>(a0)); return 0; }
 JHLE(value_assign) {
     auto* destination = ptr<Value>(a0); auto* source = ptr<const Value>(a1);
@@ -606,6 +641,7 @@ void register_json2_hle() {
     auto reg = [](const char* nid, HleFn fn, const char* name) { Hle::register_fn(nid, fn, name); };
     reg("-hJRce8wn1U", noop_self, "sceJsonMemAllocator::ctor");
     reg("qBMjqyBn3OM", value_ctor, "sceJsonValue::ctor");
+    reg("b9V6fmppLXY", value_ctor_cstr, "sceJsonValue::ctor(const char*)");
     reg("-wa17B7TGnw", value_ctor, "sceJsonValue::ctor");
     reg("WTtYf+cNnXI", value_dtor, "sceJsonValue::dtor");
     reg("0eUrW9JAxM0", value_dtor, "sceJsonValue::dtor");
@@ -620,6 +656,12 @@ void register_json2_hle() {
     reg("qSmqLXXCPas", string_ctor, "sceJsonString::ctor");
     reg("cG1VE2HMl6c", string_dtor, "sceJsonString::dtor");
     reg("cK6bYHf-Q5E", noop_self, "sceJsonInitializer::ctor");
+    // Both destructors own nothing prosper allocated -- Initializer and MemAllocator are guest-side
+    // scope objects here -- so a no-op is the CORRECT body, not a placeholder. Registered anyway so
+    // they resolve as deliberate rather than falling to the unimplemented path, where they cost a
+    // log line each and read as a gap (#1967).
+    reg("RujUxbr3haM", noop_zero, "sceJsonInitializer::dtor");
+    reg("OcAgPxcq5Vk", noop_zero, "sceJsonMemAllocator::dtor");
     reg("Cxwy7wHq4J0", noop_zero, "sceJsonInitializer::initializeV1");
     reg("00oCq0RwSAY", noop_zero, "sceJsonInitializer::setGlobalNullAccessCallback");
     reg("S5JxQnoGF3E", parse, "sceJsonParser::parse");

--- a/prosper/src/hle/hle_json2.cpp
+++ b/prosper/src/hle/hle_json2.cpp
@@ -409,15 +409,30 @@ JHLE(value_ctor_cstr) {
     if (!value) return a0;
     *value = Value{};                      // a valid, empty Json::Value even if the text is rejected
     if (!a1) return a0;                    // Value(nullptr) is a null value, not a crash
+    // NOTE: on Linux gpu::guest_readable returns false when the fault-handler probe pipe is absent
+    // (gpu_executor.cpp). That pipe is created unconditionally since #2329; if it is ever re-gated,
+    // every string here silently becomes Null -- a valid pointer and valid text producing the wrong
+    // result with no diagnostic. Do not re-gate it without revisiting this.
+    // Readability of the FIRST byte is checked separately from the length scan, because the two
+    // zero-length cases are not the same answer and collapsing them is a silent wrong result:
+    //   unreadable pointer -> refuse, leaving Null   (there is no text to honour)
+    //   readable NUL        -> construct an empty String (the guest asked for one, and got one)
+    // The regression arm for the 0x80 pointer is what caught this: an earlier draft returned early
+    // on `length == 0` and so turned a REJECTED pointer into a valid empty string.
+    if (!prosper::gpu::guest_readable(a1, 1)) return a0;
     constexpr uint32_t kMaxJsonCString = 1u << 20;   // 1 MiB: a JSON scalar, not a document
     uint32_t length = 0;
     while (length < kMaxJsonCString &&
            prosper::gpu::guest_readable(a1 + length, 1) &&
            *reinterpret_cast<const char*>(static_cast<uintptr_t>(a1 + length)) != '\0')
         ++length;
-    // An unterminated or unreadable string yields the empty value rather than a partial one: the
+    // An UNTERMINATED or unreadable string yields the Null value rather than a partial one: the
     // guest asked for the text at that pointer, and prosper cannot honour half of it truthfully.
-    if (length == 0 || length == kMaxJsonCString) return a0;
+    if (length == kMaxJsonCString) return a0;
+    // A readable EMPTY string is not that case. `Value("")` is a String whose text is empty, and
+    // returning Null for it would be a silent wrong ANSWER rather than a refusal -- `getType()`
+    // would report 0 where the guest constructed a string, and every later `getString()` would
+    // disagree with the constructor. Length 0 falls through to the same construction as any other.
     value->type = ValueType::String;
     value->data.string = new String{new std::string(
         reinterpret_cast<const char*>(static_cast<uintptr_t>(a1)), length)};

--- a/prosper/tests/test_json2.cpp
+++ b/prosper/tests/test_json2.cpp
@@ -196,6 +196,54 @@ int main() {
     call(string_dtor, &key);
     call(dtor, &object_value);
 
+    // --- #1967: sce::Json::Value::Value(const char*) ------------------------------------------
+    // The dispatcher's `return 0` default is safe for a status-returning function and unsafe for a
+    // CONSTRUCTOR: the guest reserves the storage and expects the callee to write the object into
+    // it. An unimplemented ctor therefore leaves the guest using stack residue as a live Value, and
+    // no return value can fix that -- which is why this had to be implemented rather than stubbed.
+    {
+        HleFn ctor_cstr = Hle::lookup("b9V6fmppLXY");
+        CHECK(ctor_cstr != nullptr, "Value(const char*) is registered");
+        if (ctor_cstr) {
+            // POISONED storage, not zeroed. A zeroed slot would let an unimplemented ctor pass this
+            // arm by accident -- type 0 is Null, which is a legal value -- so the arm has to start
+            // from something no correct constructor could leave behind.
+            JsonValue v;
+            std::memset(&v, 0xA5, sizeof v);
+            call(ctor_cstr, &v, const_cast<char*>("hello"));
+            CHECK(v.type == 5, "Value(const char*) constructs a String value (type 5)");
+            auto* js = reinterpret_cast<void*>(call(get_string, &v));
+            auto* cs = js ? reinterpret_cast<const char*>(call(string_cstr, js)) : nullptr;
+            CHECK(cs && std::strcmp(cs, "hello") == 0,
+                  "Value(const char*) stores the text it was given");
+            call(dtor, &v);
+        }
+        if (ctor_cstr) {
+            // A null argument is a null Value, not a crash -- and the storage must still be left
+            // well-formed, because the guest will destroy it either way.
+            JsonValue v;
+            std::memset(&v, 0xA5, sizeof v);
+            call(ctor_cstr, &v, nullptr);
+            CHECK(v.type == 0, "Value(nullptr) constructs a Null value rather than faulting");
+            call(dtor, &v);
+        }
+        if (ctor_cstr) {
+            // An unmapped-but-non-null pointer. 0x80 is the shape that actually occurs (a null base
+            // plus a field offset) and the one that walked into #1963 in libkernel. Reaching the
+            // next line at all is the assertion: an unvalidated read here does not fail, it faults.
+            JsonValue v;
+            std::memset(&v, 0xA5, sizeof v);
+            call(ctor_cstr, &v, reinterpret_cast<void*>(static_cast<uintptr_t>(0x80)));
+            CHECK(v.type == 0, "Value(bad pointer) yields a well-formed Null value, not a fault");
+            call(dtor, &v);
+        }
+        // The two destructors this issue also names. They own nothing prosper allocated, so a no-op
+        // is the correct body -- the point is that they RESOLVE rather than falling to the
+        // unimplemented path, where each costs a log line and reads as a gap.
+        CHECK(Hle::lookup("RujUxbr3haM") != nullptr, "Initializer::~Initializer is registered");
+        CHECK(Hle::lookup("OcAgPxcq5Vk") != nullptr, "MemAllocator::~MemAllocator is registered");
+    }
+
     std::puts(failures ? "== FAIL ==" : "== PASS ==");
     return failures ? 1 : 0;
 }

--- a/prosper/tests/test_json2.cpp
+++ b/prosper/tests/test_json2.cpp
@@ -6,6 +6,12 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 
 using namespace prosper;
 
@@ -30,6 +36,47 @@ uint64_t call(HleFn fn, const void* a0 = nullptr, const void* a1 = nullptr,
     return fn(reinterpret_cast<uintptr_t>(a0), reinterpret_cast<uintptr_t>(a1), a2, a3, 0, 0);
 }
 } // namespace
+
+// A two-page reservation whose FIRST page is readable and whose second is not. Used to build a
+// string that runs flush into unmapped memory -- the case that separates "refuse" from "hand
+// back a truncated prefix". Portable because the behaviour under test is not platform-specific;
+// guarding the arm to one OS would leave the other silently uncovered (the #1970 shape).
+size_t probe_page_size() {
+#ifdef _WIN32
+    SYSTEM_INFO si{}; GetSystemInfo(&si); return si.dwPageSize;
+#else
+    return (size_t)sysconf(_SC_PAGESIZE);
+#endif
+}
+
+char* reserve_two_pages_first_readable() {
+    const size_t page = probe_page_size();
+#ifdef _WIN32
+    auto* base = static_cast<char*>(VirtualAlloc(nullptr, page * 2, MEM_RESERVE, PAGE_NOACCESS));
+    if (!base) return nullptr;
+    if (!VirtualAlloc(base, page, MEM_COMMIT, PAGE_READWRITE)) {
+        VirtualFree(base, 0, MEM_RELEASE); return nullptr;
+    }
+    return base;
+#else
+    auto* base = static_cast<char*>(
+        mmap(nullptr, page * 2, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0));
+    if (base == MAP_FAILED) return nullptr;
+    if (mprotect(base, page, PROT_READ | PROT_WRITE) != 0) {
+        munmap(base, page * 2); return nullptr;
+    }
+    return base;
+#endif
+}
+
+void release_two_pages(char* base) {
+    const size_t page = probe_page_size();
+#ifdef _WIN32
+    (void)page; VirtualFree(base, 0, MEM_RELEASE);
+#else
+    munmap(base, page * 2);
+#endif
+}
 
 int main() {
     std::puts("== test_json2 ==");
@@ -249,6 +296,24 @@ int main() {
             call(ctor_cstr, &v, reinterpret_cast<void*>(static_cast<uintptr_t>(0x80)));
             CHECK(v.type == 0, "Value(bad pointer) yields a well-formed Null value, not a fault");
             call(dtor, &v);
+        }
+        if (ctor_cstr) {
+            // UNTERMINATED: readable text running flush into an unmapped page with no NUL.
+            // Built by reserving two pages and making only the first accessible, so the bytes
+            // are genuinely readable up to a hard boundary. A truncated construction here is a
+            // wrong ANSWER rather than a refusal, and the earlier code produced exactly that.
+            char* base = reserve_two_pages_first_readable();
+            if (base) {
+                const size_t page = probe_page_size();
+                std::memset(base, 0x41, page);          // a page of "A", no terminator
+                JsonValue v;
+                std::memset(&v, 0xA5, sizeof v);
+                call(ctor_cstr, &v, base + page - 8);   // 8 readable bytes, then nothing
+                CHECK(v.type == 0,
+                      "Value(unterminated) refuses rather than constructing a truncated String");
+                call(dtor, &v);
+                release_two_pages(base);
+            }
         }
         // The two destructors this issue also names. They own nothing prosper allocated, so a no-op
         // is the correct body -- the point is that they RESOLVE rather than falling to the

--- a/prosper/tests/test_json2.cpp
+++ b/prosper/tests/test_json2.cpp
@@ -219,6 +219,19 @@ int main() {
             call(dtor, &v);
         }
         if (ctor_cstr) {
+            // Value("") is a String whose text is empty, NOT Null. Returning Null here would be a
+            // silent wrong answer rather than a refusal: getType() would report 0 where the guest
+            // constructed a string, and every later getString() would disagree with the ctor.
+            JsonValue v;
+            std::memset(&v, 0xA5, sizeof v);
+            call(ctor_cstr, &v, const_cast<char*>(""));
+            CHECK(v.type == 5, "Value(\"\") constructs an empty String (type 5), not Null");
+            auto* js = reinterpret_cast<void*>(call(get_string, &v));
+            auto* cs = js ? reinterpret_cast<const char*>(call(string_cstr, js)) : nullptr;
+            CHECK(cs && cs[0] == 0, "Value(\"\") stores empty text");
+            call(dtor, &v);
+        }
+        if (ctor_cstr) {
             // A null argument is a null Value, not a crash -- and the storage must still be left
             // well-formed, because the guest will destroy it either way.
             JsonValue v;


### PR DESCRIPTION
Fixes #1967

## Failure scenario

`sce::Json::Value::Value(const char*)` (`b9V6fmppLXY`) was unregistered, so it fell to the
dispatcher's `return 0`.

That default is correct for a status-returning function and **actively unsafe for a constructor**:
the guest reserves the storage — usually a stack slot — and expects the callee to write the object
into it. prosper wrote nothing, so the guest went on to use whatever residue was in that slot as a
live `Json::Value`. **No return value can make an unimplemented constructor safe**, which is why this
needed implementing rather than stubbing.

Sonic Frontiers (`PPSA03831`) calls it once at boot, adjacent to a matching destroy, which is why
nothing has visibly broken yet. The failure mode is silent by construction.

## Approach

Not the same as `setString`: the argument is a raw C string rather than a Sony `String` object, and
this constructs into caller storage rather than assigning to a live value.

The source pointer is **validated** with `gpu::guest_readable` and the scan is bounded at 1 MiB. This
is a guest pointer arriving at a C++ constructor — the same class as #1963, which I fixed this
morning, where `if (p)` let `0x80` through and prosper faulted inside its own code.

The empty value is constructed **first**, so a rejected, null or unterminated string still leaves the
guest a well-formed Null `Json::Value` rather than the uninitialised storage the stub left behind.
That ordering is the fix, not a detail.

Also registers the two destructors the issue names — `RujUxbr3haM` (`Initializer`) and `OcAgPxcq5Vk`
(`MemAllocator`). Both own nothing prosper allocated, so a **no-op is the correct body** rather than a
placeholder; registering them makes that deliberate instead of a log line that reads as a gap.

## Test

Added to the existing `test_json2`.

**The arms start from storage poisoned with `0xA5`, not zeroed** — and that choice is load-bearing. A
zeroed slot would let an unimplemented constructor pass by accident, because type 0 is `Null`, which
is a legal value. The poison means only an actual write can satisfy the assertion.

Three arms: the text case, `nullptr` (must yield Null, not a crash), and an unmapped-but-non-null
`0x80`. For the last, **reaching the next line at all is the assertion** — an unvalidated read there
does not fail, it faults.

## Verification (exact head `b50d758d`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release.

```
ctest --no-tests=error -j4  ->  99% tests passed, 1 tests failed out of 177
```

The single failure is #2327 (`pthread_cond_clock`), established earlier today as pre-existing on
clean `origin/master`.

**Two mutation arms, both caught:**

| mutation | result |
| --- | --- |
| unregister `b9V6fmppLXY` (i.e. restore the stub) | `json2_hle` **FAILS** |
| drop the `gpu::guest_readable` validation | `json2_hle` **FAILS** |

`git diff --check` clean. Session-trailer gate: 0.

## Risk

Low-MED. New behaviour on a previously-unimplemented NID, so nothing that works today can regress
through it; the existing `test_json2` arms all still pass. The judgement calls worth a reader:

- **1 MiB bound** on the string scan. A JSON *scalar*, not a document — but it is a chosen number.
- **An unterminated string yields the empty value rather than a truncated one.** The guest asked for
  the text at that pointer and prosper cannot honour half of it truthfully. Arguable; I would rather
  be told than guess quietly.
- `noop_zero` for the two destructors. Itanium-ABI complete-object destructors have no meaningful
  return value, so this matches `value_dtor` in the same file.

`CONFIDENCE: HIGH` that a constructor must construct; `MED` on the truncation policy above.

— Wren (Windows lane)