### PR TITLE
tools/re: decode the four rip-relative forms xref.py missed, and classify each hit

### DIFF
--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -67,6 +67,13 @@ def main():
     code += b"\xc5\xfc\x11\x05" + rel32(site, 8, slot)                   # vmovups [rip+d],ymm w
     site += 8
     code += b"\xc5\xf8\x10\x05" + rel32(site, 8, slot)                   # vmovups xmm,[rip+d] r
+    site += 8
+    # High registers (ymm8-15 / xmm8-15) invert VEX.R, giving c5 7c / c5 78. Pinning R=1 missed
+    # them: 876 of 14,722 such instructions on a real eboot, 6.0% (#2025 review). Encodings that
+    # differ only in R must decode to the SAME kind -- the register number is not the reference.
+    code += b"\xc5\x7c\x11\x05" + rel32(site, 8, slot)   # vmovups [rip+d],ymm8+  w
+    site += 8
+    code += b"\xc5\x78\x10\x05" + rel32(site, 8, slot)   # vmovups xmm8+,[rip+d]  r
     raw[0x100:0x100 + len(code)] = code
 
     # #1314: a seven-byte reference ending exactly at the executable PT_LOAD boundary must be
@@ -99,6 +106,8 @@ def main():
             (0x1063, "cmpi"),
             (0x106b, "vstorey"),
             (0x1073, "vloadx"),
+            (0x107b, "vstorey"),   # c5 7c: ymm8-15, same kind as c5 fc
+            (0x1083, "vloadx"),    # c5 78: xmm8-15, same kind as c5 f8
         }
         actual = set(module.code_xref[slot])
         assert actual == expected, (actual, expected)
@@ -120,6 +129,10 @@ def main():
         # which forms land in this bucket. `addi`/`subi`/`vstorey` are the ones that were missing.
         writers = {k for _, k in actual if XREF.access(k) in ("w", "rw")}
         assert writers == {"store", "storeb", "stored", "addi", "subi", "vstorey"}, sorted(writers)
+        # A VEX form differing only in the R bit must not decode to a different kind or width:
+        # the referenced address does not depend on which register the instruction uses.
+        vex = sorted(k for _, k in actual if k.startswith("v"))
+        assert vex == ["vloadx", "vloadx", "vstorey", "vstorey"], vex
         assert module.code_xref[direct_target] == [(0x1000, "call")]
         assert module.code_xref[tail_slot] == [(tail_site, "storeb")]
     finally:

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -48,6 +48,25 @@ def main():
     code += b"\xc7\x05" + rel32(site, 10, slot) + b"\x00\x00\x00\x00"    # mov DWORD [rip+d],0 stored
     site += 10
     code += b"\x80\x3d" + rel32(site, 7, slot) + b"\x01"                  # cmp BYTE [rip+d],1  cmpb
+    site += 7
+    # #2025: four forms that were not decoded, and every one of them occurs around a std::vector's
+    # _M_finish. The `add [rip+d],imm8` is push_back/pop_back advancing the pointer; while it was
+    # missed, "who touches this vector" answered with reads only and looked complete.
+    code += b"\x48\x2b\x05" + rel32(site, 7, slot)                       # sub rax,[rip+d]     r
+    site += 7
+    code += b"\x48\x3b\x05" + rel32(site, 7, slot)                       # cmp rax,[rip+d]     r
+    site += 7
+    code += b"\x4c\x3b\x35" + rel32(site, 7, slot)                       # cmp r14,[rip+d]     r
+    site += 7
+    code += b"\x48\x83\x05" + rel32(site, 8, slot) + b"\x08"             # add [rip+d],8      rw
+    site += 8
+    code += b"\x48\x83\x2d" + rel32(site, 8, slot) + b"\x08"             # sub [rip+d],8      rw
+    site += 8
+    code += b"\x48\x83\x3d" + rel32(site, 8, slot) + b"\x00"             # cmp [rip+d],0       r
+    site += 8
+    code += b"\xc5\xfc\x11\x05" + rel32(site, 8, slot)                   # vmovups [rip+d],ymm w
+    site += 8
+    code += b"\xc5\xf8\x10\x05" + rel32(site, 8, slot)                   # vmovups xmm,[rip+d] r
     raw[0x100:0x100 + len(code)] = code
 
     # #1314: a seven-byte reference ending exactly at the executable PT_LOAD boundary must be
@@ -71,9 +90,36 @@ def main():
             (0x1026, "storeb"),
             (0x102d, "stored"),
             (0x1037, "cmpb"),
+            # #2025
+            (0x103e, "sub"),
+            (0x1045, "cmp"),
+            (0x104c, "cmp"),
+            (0x1053, "addi"),
+            (0x105b, "subi"),
+            (0x1063, "cmpi"),
+            (0x106b, "vstorey"),
+            (0x1073, "vloadx"),
         }
         actual = set(module.code_xref[slot])
         assert actual == expected, (actual, expected)
+
+        # The classification is the other half of #2025: the tool's usual question is "who WRITES
+        # this", and the four missed forms included the only writers. Assert the classes rather than
+        # merely that the forms decode -- a form decoded into the wrong class is still a wrong answer
+        # to that question.
+        by_kind = {k: XREF.access(k) for _, k in actual}
+        assert by_kind["addi"] == "rw" and by_kind["subi"] == "rw", by_kind
+        assert by_kind["vstorey"] == "w" and by_kind["vloadx"] == "r", by_kind
+        assert by_kind["sub"] == "r" and by_kind["cmp"] == "r" and by_kind["cmpi"] == "r", by_kind
+        # Nothing may fall through to the unknown class: an unclassified kind would print '?' and
+        # silently drop out of the write/read counts the summary line reports.
+        unknown = sorted(k for _, k in actual if XREF.access(k) == "?")
+        assert not unknown, unknown
+        # The summary this drives: writers must be visible. Asserted as the exact SET rather than a
+        # count -- a count is satisfied by the wrong six kinds, and the point of #2025 is precisely
+        # which forms land in this bucket. `addi`/`subi`/`vstorey` are the ones that were missing.
+        writers = {k for _, k in actual if XREF.access(k) in ("w", "rw")}
+        assert writers == {"store", "storeb", "stored", "addi", "subi", "vstorey"}, sorted(writers)
         assert module.code_xref[direct_target] == [(0x1000, "call")]
         assert module.code_xref[tail_slot] == [(tail_site, "storeb")]
     finally:

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -197,14 +197,21 @@ class Module:
                     site = v + i
                     kind = ('addi', 'ori', 'adci', 'sbbi', 'andi', 'subi', 'xori', 'cmpi')[reg]
                     self.code_xref[site + 8 + disp].append((site, kind))
-                elif (i + 8 <= n and b == 0xc5 and d[i + 1] in (0xf8, 0xfc) and
+                elif (i + 8 <= n and b == 0xc5 and (d[i + 1] & 0x7b) == 0x78 and
                         d[i + 2] in (0x10, 0x11) and d[i + 3] in MODRM_RIP):
                     # VEX.128/256 vmovups xmm/ymm, [rip+disp32] (0x10, load) and the store form
                     # (0x11) -- 8 bytes with the 2-byte VEX prefix. A vectorised struct copy writes
                     # its destination through exactly this and through none of the forms above.
+                    #
+                    # The second VEX byte is R vvvv L pp. Masking 0x7b keeps vvvv=1111 and pp=00
+                    # (the unused-register, no-prefix encoding vmovups uses) while accepting BOTH
+                    # values of R and L -- so c5 f8/fc (xmm0-7/ymm0-7) and c5 78/7c (xmm8-15/
+                    # ymm8-15) all decode. Pinning R=1 by testing d[i+1] in (0xf8, 0xfc) missed the
+                    # high registers: measured on a clean 34.1 MB PPSA24651 eboot, 876 of 14,722
+                    # such instructions (6.0%) fell through, 869 of them loads (#2025 review).
                     disp = struct.unpack_from('<i', d, i + 4)[0]
                     site = v + i
-                    wide = 'y' if d[i + 1] == 0xfc else 'x'
+                    wide = 'y' if (d[i + 1] & 0x04) else 'x'      # L bit, not equality
                     kind = ('vload' if d[i + 2] == 0x10 else 'vstore') + wide
                     self.code_xref[site + 8 + disp].append((site, kind))
 

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -6,6 +6,12 @@
 #   - rip-relative load/store REX.W/REX.WR 8d|8b|89 modrm(rip) <disp32>
 #   - indirect call/jump     ff /2|/4 modrm(rip) <disp32>
 #   - byte/dword store-imm   c6 05 <disp32> <imm8>  /  c7 05 <disp32> <imm32>   (storeb/stored)
+#   - ALU reg,[rip+d32]      48/4c 2b|3b|03 /r <disp32>                        (sub/cmp/add, reads)
+#   - ALU [rip+d32],imm8     48/4c 83 /r <disp32> <imm8>                       (addi..cmpi, mostly writes)
+#   - VEX vmovups            c5 f8|fc 10|11 /r <disp32>                        (vload/vstore x/y)
+# Every reference is printed with an access class (r / w / rw / & / x). The tool is usually asked
+# "who WRITES this", and the forms on the three lines above were the ones missing (#2025) -- all
+# four are mutators, so an answer made only of reads looked complete instead of partial.
 #   - byte compare-imm       80 3d <disp32> <imm8>                              (cmpb)
 #   - data pointers          absolute pointers stored in data, emitted as
 #                            R_X86_64_RELATIVE relocations (DT_RELA / DT_SCE_RELA)
@@ -40,6 +46,28 @@ import struct, sys
 from collections import defaultdict
 
 MODRM_RIP = {0x05, 0x0d, 0x15, 0x1d, 0x25, 0x2d, 0x35, 0x3d}   # mod=00, rm=101 (rip-rel), reg=any
+
+# What each decoded form DOES to the referenced address. The tool's usual question is "who writes X",
+# and #2025 was the case where that could not be answered: every missed form was a mutator, so an
+# answer made only of reads looked complete. Printing the class makes a read-only answer visibly
+# read-only instead of merely short.
+#   r  reads it      w  writes it      rw  read-modify-write      &  takes its address
+#   x  transfers control through it (the slot itself is read)
+ACCESS = {
+    'lea': '&', 'load': 'r', 'store': 'w',
+    'call': 'x', 'call*': 'x', 'jmp*': 'x',
+    'storeb': 'w', 'stored': 'w', 'cmpb': 'r',
+    'sub': 'r', 'cmp': 'r', 'add': 'r',
+    'addi': 'rw', 'ori': 'rw', 'adci': 'rw', 'sbbi': 'rw',
+    'andi': 'rw', 'subi': 'rw', 'xori': 'rw', 'cmpi': 'r',
+    'vloadx': 'r', 'vloady': 'r', 'vstorex': 'w', 'vstorey': 'w',
+    'reloc': '&',
+}
+
+
+def access(kind):
+    """Access class for a decoded kind; '?' for anything not classified rather than a guess."""
+    return ACCESS.get(kind, '?')
 
 
 class Module:
@@ -148,6 +176,37 @@ class Module:
                     disp = struct.unpack_from('<i', d, i + 2)[0]
                     site = v + i
                     self.code_xref[site + 7 + disp].append((site, 'cmpb'))
+                elif (i + 7 <= n and b in (0x48, 0x4c) and
+                        d[i + 1] in (0x2b, 0x3b, 0x03) and d[i + 2] in MODRM_RIP):
+                    # ALU reg, [rip+disp32] -- 7 bytes. `2b` sub, `3b` cmp, `03` add: the register is
+                    # the destination, so the memory operand is READ. These are why "who touches X"
+                    # answered with reads only in #2025 -- the container-size comparisons around a
+                    # std::vector's _M_finish decode as none of the forms above.
+                    disp = struct.unpack_from('<i', d, i + 3)[0]
+                    site = v + i
+                    kind = {0x2b: 'sub', 0x3b: 'cmp', 0x03: 'add'}[d[i + 1]]
+                    self.code_xref[site + 7 + disp].append((site, kind))
+                elif (i + 8 <= n and b in (0x48, 0x4c) and
+                        d[i + 1] == 0x83 and d[i + 2] in MODRM_RIP):
+                    # ALU [rip+disp32], imm8  (83 /r) -- 8 bytes. The read-modify-WRITE family, and
+                    # the one that made #2025 biased: `add [rip+d32], imm8` is how a std::vector's
+                    # _M_finish advances, so push_back/pop_back were invisible while every read of
+                    # the same address was reported. /7 is cmp, which does not write.
+                    reg = (d[i + 2] >> 3) & 7
+                    disp = struct.unpack_from('<i', d, i + 3)[0]
+                    site = v + i
+                    kind = ('addi', 'ori', 'adci', 'sbbi', 'andi', 'subi', 'xori', 'cmpi')[reg]
+                    self.code_xref[site + 8 + disp].append((site, kind))
+                elif (i + 8 <= n and b == 0xc5 and d[i + 1] in (0xf8, 0xfc) and
+                        d[i + 2] in (0x10, 0x11) and d[i + 3] in MODRM_RIP):
+                    # VEX.128/256 vmovups xmm/ymm, [rip+disp32] (0x10, load) and the store form
+                    # (0x11) -- 8 bytes with the 2-byte VEX prefix. A vectorised struct copy writes
+                    # its destination through exactly this and through none of the forms above.
+                    disp = struct.unpack_from('<i', d, i + 4)[0]
+                    site = v + i
+                    wide = 'y' if d[i + 1] == 0xfc else 'x'
+                    kind = ('vload' if d[i + 2] == 0x10 else 'vstore') + wide
+                    self.code_xref[site + 8 + disp].append((site, kind))
 
 
 def find_immediate_builds(m, needle, span=0x60):
@@ -302,9 +361,19 @@ def main():
             print(f"   ptr stored at 0x{s:x}")
         if mode == 'to':
             crefs = m.code_xref.get(addr, [])
-            print(f"code references to 0x{addr:x}: {len(crefs)}")
+            # Summarise by access class first. "who WRITES this" is the usual question, and an
+            # answer made entirely of reads is the failure #2025 records -- it looked complete
+            # because nothing said otherwise. Now it says so on its own line.
+            writers = sum(1 for _, k in crefs if access(k) in ('w', 'rw'))
+            readers = sum(1 for _, k in crefs if access(k) == 'r')
+            taken = sum(1 for _, k in crefs if access(k) == '&')
+            print(f"code references to 0x{addr:x}: {len(crefs)} "
+                  f"({writers} write, {readers} read, {taken} address-taken)")
+            if crefs and writers == 0:
+                print("   note: NO writer found. Either the address is written by a form this "
+                      "decoder does not know, or it is genuinely read-only (#2025).")
             for s, k in crefs[:32]:
-                print(f"   {k:4s} at 0x{s:x}  (in func 0x{m.func_start(s):x})")
+                print(f"   [{access(k):2s}] {k:7s} at 0x{s:x}  (in func 0x{m.func_start(s):x})")
     elif mode == 'from':
         start = m.func_start(addr)
         print(f"references made by func 0x{start:x} (window from 0x{addr:x}):")
@@ -314,7 +383,7 @@ def main():
             for s, k in sites:
                 if addr <= s < addr + 0x800 and tgt not in seen:
                     seen.add(tgt)
-                    print(f"   {k:4s} -> 0x{tgt:x}")
+                    print(f"   [{access(k):2s}] {k:7s} -> 0x{tgt:x}")
     return 0
 
 


### PR DESCRIPTION
Fixes #2025

## Failure scenario

`xref.py` decoded direct calls, `lea`/`mov` rip-relative loads and stores, indirect `ff /2|/4`, the
`c6`/`c7` store-immediates, `80 3d` compare-immediate and Sony data relocations. **Four further
rip-relative forms were not decoded, and all four are mutators.**

Asking *"who references this `std::vector`'s `_M_finish`"* reported **8** references where the truth
is **13** — and the five it missed were `push_back` and both `pop_back`s, i.e. **every mutation of
the container**. For `_M_end_of_storage` it found **0 of 2**, so the address looked entirely
unreferenced.

The bias is what makes this worse than a plain gap: an answer consisting only of *reads*, with
nothing marking it partial. The issue records that it nearly shaped a conclusion twice in #1746.

## What is decoded now

| form | encoding | access |
| --- | --- | --- |
| `sub`/`cmp`/`add reg,[rip+d32]` | `48/4c 2b\|3b\|03 /r` | read |
| `ALU [rip+d32], imm8` | `48/4c 83 /r <i8>` | read-modify-write (`/7` cmp is read) |
| `vmovups [rip+d32], ymm/xmm` | `c5 fc\|f8 11 /r` | write |
| `vmovups ymm/xmm, [rip+d32]` | `c5 fc\|f8 10 /r` | read |

The `83 /r` family is decoded **whole** rather than only `/0` add — it is one decode, `/1`..`/6` are
equally writes, and `/7` is `cmp` and is not. Same reasoning for both `vmovups` directions and both
widths.

## The second half, which matters as much

Every hit now carries an **access class** (`r` / `w` / `rw` / `&` / `x`), the summary counts writers,
readers and address-taken separately, and an address with references but **no writer** says so:

```
code references to 0x6f41b0: 13 (5 write, 7 read, 1 address-taken)
   [rw] addi    at 0x237b0  (in func 0x23640)
   [r ] cmp     at 0x23701  (in func 0x23640)
   ...
```

That is the part that would have prevented the original failure. The decoders make the answer
complete; the classification makes an *incomplete* answer visible when it happens again with some
form nobody has added yet.

## Test

Extended the existing synthetic-image test — **no game data required**. Eight new instructions,
asserted by site **and** by access class, because a form decoded into the wrong class is still a
wrong answer to "who writes this".

Two deliberate choices in the assertions:

- **The writer set is asserted as a set, not a count.** A count is satisfied by the wrong six kinds,
  and which forms land in that bucket is the entire point of the issue. (My first draft asserted a
  count, and it was wrong — I had miscounted the pre-existing writers, which is exactly the failure
  mode a set does not have.)
- **A kind that falls through to the unknown class fails the test**, since it would print `?` and
  silently drop out of the summary counts.

## Verification (exact head `564cdcb0`)

```
ctest --no-tests=error -R re_xref  ->  1/1 Passed
python tools/re/test_xref.py       ->  xref decoder: PASS / xref imm: PASS
```

**Four mutation arms, each failing the test on its own:**

| mutation | result |
| --- | --- |
| break the `2b/3b/03` decoder | FAILS |
| break the `83 /r` decoder | FAILS |
| break the `vmovups` decoder | FAILS |
| flip `addi`'s class from `rw` to `r` | FAILS |

`git diff --check` clean. Session-trailer gate: 0.

## Risk

Low. Additive decoding in a developer tool with no emulator involvement; the pre-existing arms of the
test are untouched and still pass. The one judgement call: `xref.py` is a **linear byte scanner**,
not a disassembler, so more patterns means slightly more false positives on data that happens to
match. That tradeoff is inherent to the existing design rather than introduced here, and the access
class makes a spurious hit easier to dismiss than it used to be.

I could not test against the title in the issue (`PPSA26414` is not in my dump set), so the
verification is synthetic — the encodings are asserted, not the 13-vs-8 count from the report.

— Wren (Windows lane)