### PR TITLE
perf(gpu): recycle per-draw GpuState snapshots instead of allocating them

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -382,6 +382,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_reallocalign PRIVATE prosper_core)
   add_test(NAME reallocalign COMMAND test_reallocalign)
 
+  # Per-draw GpuState snapshot recycling (#2334): the reset is complete, and the recycling actually
+  # removes the per-entry allocations rather than silently allocating fresh every time.
+  add_executable(test_gpustate_pool tests/test_gpustate_pool.cpp)
+  target_link_libraries(test_gpustate_pool PRIVATE prosper_core)
+  add_test(NAME gpustate_pool COMMAND test_gpustate_pool)
+
   add_executable(test_reallocf tests/test_reallocf.cpp)
   target_link_libraries(test_reallocf PRIVATE prosper_core)
   add_test(NAME reallocf COMMAND test_reallocf)

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -69,8 +69,21 @@ struct GpuStateSnapshotPool {
     std::vector<GpuState*> free_list;
 };
 GpuStateSnapshotPool& gpustate_snapshot_pool() {
-    static GpuStateSnapshotPool pool;
-    return pool;
+    // Deliberately leaked, and this is load-bearing rather than laziness. A snapshot's lifetime is
+    // owned by a shared_ptr that can outlive any particular scope, so the deleter may run during
+    // STATIC DESTRUCTION -- after a function-local `static GpuStateSnapshotPool pool` would already
+    // have been destroyed. Pushing into that destroyed vector is a write through freed storage.
+    //
+    // Windows caught it and Linux did not: `agc_submit_to_gpustate` failed with
+    // 0xc0000374 (STATUS_HEAP_CORRUPTION) at teardown while every assertion in it passed, and the
+    // same tree was 225/225 green on Linux. Destruction order is not something either platform
+    // promises here, so the fix is to remove the dependency rather than to rely on the ordering
+    // that happens to work.
+    //
+    // The leak is bounded by kGpuStateSnapshotPoolMax objects and lives until process exit, which
+    // is exactly when it stops mattering. Deleting them at exit is what would be unsafe.
+    static GpuStateSnapshotPool* pool = new GpuStateSnapshotPool();
+    return *pool;
 }
 // Bounded so a pathological submit cannot retain snapshots indefinitely; past this, released
 // objects are simply deleted. 256 is far above the live-snapshot count of any observed frame.

--- a/prosper/src/gpu/command_processor.cpp
+++ b/prosper/src/gpu/command_processor.cpp
@@ -35,6 +35,106 @@ namespace prosper { void prosper_eq_trigger_eop(); }
 
 namespace prosper::gpu {
 
+// --- per-draw snapshot recycling (#2334) ----------------------------------------------------
+//
+// A draw's snapshot deep-copies the three register files. Copying an unordered_map into a FRESH
+// map allocates one node per entry; copying into a still-populated one REUSES the nodes it already
+// has (libstdc++ `_ReuseOrAllocNode`). Measured on a 245-entry map, the size of `cx`:
+//
+//     fresh destination each time : 246.0 allocations per copy
+//     reused destination          :   0.0
+//     reused, source mutating     :   1.0
+//
+// Blue Prince's collapsed state takes 900,000 snapshots in 100 s at ~347 entries each -- 312
+// million node allocations, ~3.12 million/second, and roughly half the saturated render thread
+// between the allocator and the copying (#2215). So the snapshots are recycled rather than
+// allocated, and the container is left alone: no `.cx`/`.sh`/`.uc` call site changes.
+//
+// THE RESET IS THE WHOLE CORRECTNESS ARGUMENT. `GpuState` has 25 top-level data members and a
+// snapshot site assigns only seven of them. On a fresh object the rest are default-constructed; on
+// a naively recycled one they would carry the PREVIOUS snapshot's values -- `draws`, `dispatches`,
+// `dma_copies`, `ordered_memory_effects`, and worst of all `last_snapshot_`, which is itself a
+// `shared_ptr<const GpuState>` and would chain every retired snapshot into the next one. Wrong
+// data, and unbounded retention, with nothing to make either visible.
+//
+// So a recycled object is reset by assigning a default-constructed `GpuState` over it, which
+// covers every member INCLUDING ones added after this was written -- the reset cannot silently
+// fall behind the struct. The three register maps are moved aside first and moved back after, so
+// exactly the nodes worth keeping survive the reset and nothing else does. Both moves are O(1)
+// pointer steals.
+namespace {
+
+struct GpuStateSnapshotPool {
+    std::mutex mutex;
+    std::vector<GpuState*> free_list;
+};
+GpuStateSnapshotPool& gpustate_snapshot_pool() {
+    static GpuStateSnapshotPool pool;
+    return pool;
+}
+// Bounded so a pathological submit cannot retain snapshots indefinitely; past this, released
+// objects are simply deleted. 256 is far above the live-snapshot count of any observed frame.
+constexpr size_t kGpuStateSnapshotPoolMax = 256;
+
+// Counters for the regression test, which asserts recycling actually happens rather than trusting
+// that it does -- a pool that silently never hits would leave every measurement above unchanged
+// and look exactly like this code working.
+std::atomic<uint64_t> g_gpustate_snapshot_acquires{0};
+std::atomic<uint64_t> g_gpustate_snapshot_pool_hits{0};
+
+void release_gpustate_snapshot(GpuState* state) {
+    if (!state) return;
+    // Reset EVERY member, then restore only the register files' node storage.
+    auto cx_nodes = std::move(state->cx);
+    auto sh_nodes = std::move(state->sh);
+    auto uc_nodes = std::move(state->uc);
+    *state = GpuState{};
+    state->cx = std::move(cx_nodes);
+    state->sh = std::move(sh_nodes);
+    state->uc = std::move(uc_nodes);
+    auto& pool = gpustate_snapshot_pool();
+    {
+        std::lock_guard<std::mutex> lock(pool.mutex);
+        if (pool.free_list.size() < kGpuStateSnapshotPoolMax) {
+            pool.free_list.push_back(state);
+            return;
+        }
+    }
+    delete state;
+}
+
+}  // namespace
+
+std::shared_ptr<GpuState> acquire_gpustate_snapshot() {
+    g_gpustate_snapshot_acquires.fetch_add(1, std::memory_order_relaxed);
+    // PROSPER_NO_GPUSTATE_POOL: opt out, so the A/B for this change is single-variable on ONE
+    // binary rather than a comparison of two builds. Same reason as PROSPER_NO_SUBGROUP_SCAN_MEMO
+    // (#2259), PROSPER_NO_GDS_SCAN_MEMO (#2334) and PROSPER_NO_INDEX_ARENA (#2258). Read once:
+    // nothing arms this at runtime, and this is a per-draw path.
+    static const bool disabled = getenv("PROSPER_NO_GPUSTATE_POOL") != nullptr;
+    if (disabled) return std::make_shared<GpuState>();
+    GpuState* raw = nullptr;
+    {
+        auto& pool = gpustate_snapshot_pool();
+        std::lock_guard<std::mutex> lock(pool.mutex);
+        if (!pool.free_list.empty()) {
+            raw = pool.free_list.back();
+            pool.free_list.pop_back();
+            g_gpustate_snapshot_pool_hits.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+    if (!raw) raw = new GpuState();
+    return std::shared_ptr<GpuState>(raw, release_gpustate_snapshot);
+}
+
+// Test hook (#2334): recycling is invisible from outside -- same types, same behaviour, only fewer
+// allocations -- so the guard needs the counters to tell "the pool is working" from "the pool never
+// hits and everything still passes".
+void gpustate_snapshot_pool_stats(uint64_t& acquires, uint64_t& pool_hits) {
+    acquires = g_gpustate_snapshot_acquires.load(std::memory_order_relaxed);
+    pool_hits = g_gpustate_snapshot_pool_hits.load(std::memory_order_relaxed);
+}
+
 std::vector<RegWatchEntry> parse_reg_watch(const char* setting) {
     std::vector<RegWatchEntry> entries;
     if (!setting || !*setting) return entries;
@@ -4454,7 +4554,7 @@ void GpuState::apply(const Pm4Command& c) {
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
             if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
+                auto snap = acquire_gpustate_snapshot();   // recycled, not allocated (#2334)
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
@@ -4505,7 +4605,7 @@ void GpuState::apply(const Pm4Command& c) {
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
             if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
+                auto snap = acquire_gpustate_snapshot();   // recycled, not allocated (#2334)
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
@@ -4548,7 +4648,7 @@ void GpuState::apply(const Pm4Command& c) {
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
             if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
+                auto snap = acquire_gpustate_snapshot();   // recycled, not allocated (#2334)
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
@@ -4795,7 +4895,7 @@ void GpuState::apply(const Pm4Command& c) {
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
             if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
+                auto snap = acquire_gpustate_snapshot();   // recycled, not allocated (#2334)
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot
@@ -4827,7 +4927,7 @@ void GpuState::apply(const Pm4Command& c) {
                             rd(0xc8), rd(0x8b), rd(0x8c), rd(0x8d), rd(0x8e), rd(0x8f));
             }
             if (state_dirty_ || !last_snapshot_) {
-                auto snap = std::make_shared<GpuState>();
+                auto snap = acquire_gpustate_snapshot();   // recycled, not allocated (#2334)
                 snap->cx = cx; snap->sh = sh; snap->uc = uc; snap->index_type = index_type;
                 snap->num_instances = num_instances;
                 snap->command_order = command_order;   // #305 instrument: order at snapshot

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -349,6 +349,19 @@ struct RegWatchEntry {
 // so one bad entry cannot silently disable a whole watch. An empty/absent setting yields no entries.
 std::vector<RegWatchEntry> parse_reg_watch(const char* setting);
 
+// Per-draw snapshot recycling (#2334). Hands back a GpuState that is default-valued in every member
+// EXCEPT the three register files, which deliberately retain their node storage so the caller's
+// `snap->cx = cx` reuses those nodes instead of allocating one per entry. Returned through a
+// shared_ptr whose deleter resets the object and returns it to the pool.
+//
+// Exposed rather than kept file-local so the regression guard can inspect a recycled object
+// directly. That matters because recycling is invisible from outside -- same types, same behaviour,
+// only fewer allocations -- so a pool that never recycled, and a reset that leaked the previous
+// snapshot's `draws`/`last_snapshot_`, would both leave every externally observable property
+// unchanged. The guard checks the object, not the behaviour.
+std::shared_ptr<GpuState> acquire_gpustate_snapshot();
+void gpustate_snapshot_pool_stats(uint64_t& acquires, uint64_t& pool_hits);
+
 // Whether GpuState::sh_prov write provenance is being recorded for #305 or selected capture #1853.
 bool udprov_enabled();
 

--- a/prosper/tests/test_gpustate_pool.cpp
+++ b/prosper/tests/test_gpustate_pool.cpp
@@ -1,0 +1,119 @@
+// Regression guard for per-draw GpuState snapshot recycling (#2334).
+//
+// The point of recycling is that a snapshot's `snap->cx = cx` copy-assigns into a map that still
+// owns its nodes, so libstdc++ reuses them instead of allocating one per entry. Blue Prince's
+// collapsed state takes 900,000 snapshots at ~347 entries each -- 312 million node allocations.
+//
+// Recycling is deliberately INVISIBLE from outside: same types, same values, only fewer
+// allocations. So a pool that never actually recycled would leave every ordinary assertion passing.
+// Both arms below are written to fail in that case rather than to confirm what already works.
+
+#include "../src/gpu/command_processor.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what);
+}
+
+// Global allocation counter. Only counts while `g_counting` is set, so the harness's own
+// allocations do not drown the measurement.
+static bool g_counting = false;
+static long g_allocs = 0;
+void* operator new(size_t n) {
+    if (g_counting) ++g_allocs;
+    void* p = std::malloc(n);
+    if (!p) throw std::bad_alloc();
+    return p;
+}
+void operator delete(void* p) noexcept { std::free(p); }
+void operator delete(void* p, size_t) noexcept { std::free(p); }
+
+int main() {
+    using namespace prosper::gpu;
+
+    // A register file the size of the real `cx` in the collapsed state.
+    std::unordered_map<uint32_t, uint32_t> source;
+    for (uint32_t i = 0; i < 245; ++i) source[i * 7 + 1] = i;
+
+    // ---- ARM 1: a recycled snapshot must come back RESET in every member but the register files.
+    //
+    // This is the arm that catches the naive pool. GpuState has 25 top-level data members and a
+    // snapshot site assigns seven; the rest are default-constructed on a fresh object. A pool that
+    // skipped the reset would hand back the previous snapshot's `draws`, `dispatches`, and
+    // `last_snapshot_` -- the last being a shared_ptr<const GpuState> INSIDE GpuState, which chains
+    // every retired snapshot into the next one. Wrong data and unbounded retention, both silent.
+    GpuState* first_raw = nullptr;
+    {
+        auto snap = acquire_gpustate_snapshot();
+        first_raw = snap.get();
+        snap->cx = source;
+        snap->index_type = 7;
+        snap->num_instances = 99;
+        snap->command_order = 1234;
+        snap->draws.emplace_back();                       // must not survive recycling
+        snap->dispatch_count = 55;                        // must not survive recycling
+        // `last_snapshot_` is private (command_processor.hpp:228), so it cannot be set or read
+        // here. It is still covered: the reset assigns a default-constructed GpuState over the
+        // whole object, and member-wise assignment does not care about access control. Noted
+        // because it is the member with the worst failure mode -- a shared_ptr<const GpuState>
+        // inside GpuState, which would chain every retired snapshot into the next -- and a reader
+        // should know it is handled by construction rather than by an assertion below.
+        check(!snap->draws.empty(),
+              "arm 1 precondition: the snapshot really carries state to be cleared");
+    }
+    {
+        auto snap = acquire_gpustate_snapshot();
+        // Not asserted: that this is the same object. The pool is a stack, so it is in practice,
+        // but a future pool that round-robins would still be correct and should not fail here.
+        check(snap->draws.empty(),            "recycled snapshot: draws cleared");
+        check(snap->dispatches.empty(),       "recycled snapshot: dispatches cleared");
+        check(snap->dispatch_count == 0,      "recycled snapshot: dispatch_count reset");
+        check(snap->index_type == 0,          "recycled snapshot: index_type reset");
+        check(snap->num_instances == 1,       "recycled snapshot: num_instances back to its default");
+        check(snap->command_order == 0,       "recycled snapshot: command_order reset");
+        // ...and the one thing that must NOT be cleared, because it is the entire point:
+        check(snap->cx.bucket_count() > 1,
+              "recycled snapshot: cx RETAINED its node storage (the reuse this change exists for)");
+    }
+
+    // ---- ARM 2: recycling must actually remove the allocations.
+    //
+    // Asserted as a bound rather than exactly zero: the first iterations warm the pool, and a source
+    // that gains a key can legitimately allocate one node.
+    uint64_t acquires_before = 0, hits_before = 0;
+    gpustate_snapshot_pool_stats(acquires_before, hits_before);
+
+    constexpr int kIterations = 200;
+    g_allocs = 0;
+    g_counting = true;
+    for (int i = 0; i < kIterations; ++i) {
+        auto snap = acquire_gpustate_snapshot();
+        snap->cx = source;   // the copy whose per-entry allocations this change removes
+    }
+    g_counting = false;
+
+    uint64_t acquires_after = 0, hits_after = 0;
+    gpustate_snapshot_pool_stats(acquires_after, hits_after);
+    const uint64_t hits = hits_after - hits_before;
+
+    std::fprintf(stderr, "  %d snapshots x 245 entries -> %ld allocations (%.2f per snapshot); "
+                         "pool hits %llu of %llu acquires\n",
+                 kIterations, g_allocs, (double)g_allocs / kIterations,
+                 (unsigned long long)hits,
+                 (unsigned long long)(acquires_after - acquires_before));
+
+    // Without recycling this is ~246 per snapshot, i.e. ~49,200 total. The bound is deliberately
+    // loose: it must fail loudly on a regression to per-entry allocation, not police a small drift.
+    check(g_allocs < kIterations * 4L,
+          "recycled snapshots allocate far below one node per entry");
+    check(hits >= (uint64_t)kIterations - 1,
+          "the pool actually recycled -- it is not silently allocating fresh every time");
+
+    std::fprintf(stderr, "%s\n", failures ? "== FAILURES ==" : "== all checks passed ==");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
## What

A draw's snapshot deep-copies three `unordered_map` register files. Copying into a **fresh** map
allocates one node per entry; copying into a **still-populated** one reuses the nodes it already has.
Blue Prince's collapsed state takes **900,000 snapshots at ~347 entries each — 312 million node
allocations, ~3.12 million/second** (#2334).

So snapshots are recycled through a pool rather than allocated. The container is untouched: **none of
the 395 `.cx`/`.sh`/`.uc` call sites change**, and no indexing semantics change — which is why this is
not the shape #2334 originally scoped (a container swap across all of them).

## The reset is the correctness argument, and a naive pool gets it wrong

`GpuState` has **25 top-level data members**; a snapshot site assigns **seven**. On a fresh object the
rest are default-constructed. On a naively recycled one they would carry the previous snapshot's
`draws`, `dispatches`, `dma_copies`, `ordered_memory_effects` — and `last_snapshot_`, which is a
`shared_ptr<const GpuState>` **inside** `GpuState` and would chain every retired snapshot into the
next. Wrong data and unbounded retention, both silent.

A recycled object is reset by **assigning a default-constructed `GpuState` over it**, which covers
every member *including ones added after this was written* — the reset cannot silently fall behind the
struct. The three register maps are moved aside first and moved back after, so exactly the nodes worth
keeping survive and nothing else does. Both moves are O(1) pointer steals.

## Measured — and the honest summary is "targeted metric moved, frame rate did not"

`perf -F 499` on the busiest thread, 20 s inside the collapsed steady state, **one binary**, both arms
reaching the same state (195 vs 197 tick delta over 2 s):

| | pool **ON** | pool **OFF** |
| --- | ---: | ---: |
| `_int_free_chunk` | 7.99% | 9.99% |
| `_int_malloc` | 6.63% | 7.90% |
| `__libc_malloc2` | 6.04% | 7.40% |
| `_int_free_create_chunk` | 3.03% | 3.39% |
| **allocator total** | **23.69%** | **28.68%** |
| `__memmove` | 29.61% | 27.75% |
| **cumulative frames** | **6720** | **6720** |

Every allocator symbol falls and none rises: **−5.0 points, −17% relative**.

**Frames are identical, so this does not fix the collapse and I make no frame-rate claim.** `memmove`
is unchanged within noise, which is the expected shape — recycling removes the *allocation*, not the
*copy*.

### CORRECTION to the framing (not to the numbers)

`#2334` said "~54% of the thread is copying a hash map". **That was wrong**, and the A/B above is what
exposed it: removing essentially all the per-snapshot node allocations moved the allocator share only
5 points. That is a falsification of the attribution, not a weak result.

The callgraph decomposes it into three unrelated costs, and the snapshot copy is the **smallest**:

| | share | is it this PR? |
| --- | ---: | --- |
| `memmove` under `render_draws_rgba` (via `register_live_renderer`) | ~21 pts | **No** — the render path's own copying, untouched by any of this |
| `GpuState::apply` inserting into the LIVE register maps | ~5.5 pts | **No** — and this is the part a flat-array container *would* remove |
| the snapshot's control block + nodes | ~5 pts | **Yes** |

I had the allocation volume (312 million) and the `_Sp_counted_ptr_inplace<GpuState>` frames, and
fused them into a time share I never checked. The volume measurement stands; the inference did not.

**So size this PR as a measured 5-point reduction in allocator time on one thread, with no frame-rate
change** — not as an attack on half the frame. Everything in the measurement table above was always
accurate; only the framing around it was inflated.

### Why I think it is still worth landing, stated so it can be argued with

1. The mechanism is proven by test (246 → 1 allocations per snapshot), not inferred.
2. The targeted metric moved consistently across all four allocator symbols, in one direction.
3. 312 million fewer allocations per 100 s is a systemic reduction in allocator pressure that a
   single-thread profile cannot fully see — I did not measure cross-thread contention and am not
   claiming it, but the traffic is real.
4. It **unblocks the next measurement**: the remaining ~28% `memmove` is the larger half, and it
   cannot be attacked in isolation while allocation and copying are entangled on the same path.

If you weigh that differently — this is the third "defensible but small" perf change on this issue,
and you declined to ship yours this morning on exactly that reasoning — say so and I will close it.
The measurement stands either way and belongs on #2334.

## Test

`tests/test_gpustate_pool.cpp`, two arms, both written to fail against the naive implementation
rather than to confirm what already works:

- **Reset arm** — populates `draws`/`dispatch_count`/`index_type`/…, releases, re-acquires, and
  asserts they are cleared *while `cx` kept its node storage*. This is the arm a naive pool fails.
  (`last_snapshot_` is private at `command_processor.hpp:228` so it cannot be asserted here; it is
  still covered, because member-wise assignment ignores access control. Noted in the test.)
- **Allocation arm** — counts global `operator new` across 200 snapshots of a 245-entry map:
  **200 allocations, 1.00 per snapshot**, against ~246 without recycling. The residual 1 is the
  `shared_ptr` control block. It also asserts the pool **actually hit** (200/200), because a pool that
  never recycled would leave every other assertion passing.

`PROSPER_NO_GPUSTATE_POOL` opts out, matching `PROSPER_NO_SUBGROUP_SCAN_MEMO` (#2259),
`PROSPER_NO_GDS_SCAN_MEMO` (#2335) and `PROSPER_NO_INDEX_ARENA` (#2258).

## Verification

```
cmake -S prosper -B build -DPROSPER_APP=ON -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build -j6            # rc=0
ctest --no-tests=error -j4         # rc=0, 225/225 passed
```

No snapshots run: no rendered output changes — the snapshot's *observable* contents are identical, by
construction and by the reset arm.

## Risk

Object recycling with a lifetime invariant. The two failure modes are (a) an incomplete reset, which
the whole-object assignment prevents structurally and the reset arm checks, and (b) a future
"cleanup" that clears the maps on release, which would silently destroy the entire benefit while
looking correct — the allocation arm fails loudly if that happens.

Refs #2334