### PR TITLE
libkernel: a guest TLS-key destructor calling scePthreadExit no longer kills the process

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2167,6 +2167,56 @@ std::atomic<void (*)(uint64_t)> g_win_key_delete_after_host_hook{nullptr};
 // winpthreads invokes key destructors with the Microsoft x64 ABI, but every guest callback uses
 // the PS5/FreeBSD SysV ABI. Emit one tiny Microsoft-ABI thunk per live key so winpthreads can retain
 // its normal destructor iteration semantics while the callback value is delivered in guest RDI.
+// #1020: run ONE guest pthread-key destructor with the scePthreadExit escape armed.
+//
+// win_thread_trampoline arms the longjmp only around the guest ENTRY call and clears it before
+// returning. winpthreads then runs the key destructors, so a destructor that calls scePthreadExit
+// found `win_thread_exit_armed()` false, fell through to host pthread_exit, and took the whole
+// process down through RtlRaiseStatus -- the exact failure #997/#1003 removed for the normal case,
+// still reachable from this one. The trampoline's setjmp frame is gone by then, so the escape has
+// to be re-established HERE, around the destructor itself.
+//
+// POSIX says calling pthread_exit from a destructor is undefined. Undefined is not a licence to
+// kill the process: the destructor is abandoned, its remaining work skipped, and the thread
+// continues its ordinary teardown -- which is what a guest doing this on real hardware would see,
+// and is in any case strictly better than exit 0xC00000FF with no diagnostic.
+//
+// The jump buffer and arm flag are SAVED and RESTORED, so a destructor invoked while another guest
+// call up the stack is armed cannot steal that frame's escape.
+// The setjmp lives ALONE in this helper, and deliberately so: GCC cannot interleave
+// __builtin_setjmp with any other exception region in the same function on MinGW -- putting
+// the logging or the std::atomic below into it makes the assembler reject the output with
+// ".seh_handlerdata used outside of .seh_proc block". Nothing here but the jump and the call.
+// Returns true when control arrived back via longjmp rather than by a normal return.
+__attribute__((noinline)) static bool win_run_key_destructor_armed(uint64_t guest_destructor, uint64_t value) {
+    if (__builtin_setjmp(t_thread_exit_jb) != 0) return true;
+    t_thread_exit_armed = 1;
+    prosper_call_guest_sysv(guest_destructor, value, 0);
+    return false;
+}
+
+extern "C" uint64_t prosper_win_key_destructor_call(uint64_t guest_destructor, uint64_t value) {
+    void* saved_jb[5];
+    std::memcpy(saved_jb, t_thread_exit_jb, sizeof saved_jb);
+    const int saved_armed = t_thread_exit_armed;
+    const uint64_t saved_rv = t_thread_exit_rv;
+
+    const bool exited = win_run_key_destructor_armed(guest_destructor, value);
+    if (exited) {
+        static std::atomic<unsigned> reported{0};
+        if (reported.fetch_add(1, std::memory_order_relaxed) == 0)
+            fprintf(stderr,
+                    "[libkernel] a guest pthread-key destructor called scePthreadExit; "
+                    "abandoning it and continuing thread teardown (POSIX undefined; "
+                    "killing the process is worse -- #1020)\n");
+    }
+
+    std::memcpy(t_thread_exit_jb, saved_jb, sizeof saved_jb);
+    t_thread_exit_armed = saved_armed;
+    t_thread_exit_rv = saved_rv;
+    return 0;
+}
+
 void* win_make_key_destructor_thunk(uint64_t guest_destructor) {
     auto* code = static_cast<uint8_t*>(VirtualAlloc(
         nullptr, 0x1000, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE));
@@ -2185,12 +2235,15 @@ void* win_make_key_destructor_thunk(uint64_t guest_destructor) {
     byte(0x48); byte(0x85); byte(0xc9);                 // test rcx, rcx
     byte(0x74); byte(0x24);                             // je final ret
 
-    // rcx=value -> prosper_call_guest_sysv(guest_destructor, value, 0).
+    // rcx=value -> prosper_win_key_destructor_call(guest_destructor, value).
+    // Was a direct call to prosper_call_guest_sysv; it now goes through the helper above so the
+    // scePthreadExit escape is armed for the destructor (#1020). Same MS-ABI shape, so the byte
+    // sequence is unchanged apart from the target -- r8 is still zeroed and simply ignored.
     byte(0x48); byte(0x89); byte(0xca);                 // mov rdx, rcx
     byte(0x48); byte(0xb9); qword(guest_destructor);    // mov rcx, guest_destructor
     byte(0x45); byte(0x31); byte(0xc0);                 // xor r8d, r8d
     byte(0x48); byte(0xb8);
-    qword((uint64_t)(uintptr_t)&prosper_call_guest_sysv); // mov rax, ABI bridge
+    qword((uint64_t)(uintptr_t)&prosper_win_key_destructor_call);   // mov rax, armed bridge
     byte(0x48); byte(0x83); byte(0xec); byte(0x28);     // shadow space + call alignment
     byte(0xff); byte(0xd0);                             // call rax
     byte(0x48); byte(0x83); byte(0xc4); byte(0x28);

--- a/prosper/tests/test_win_pthread_key_destructor.cpp
+++ b/prosper/tests/test_win_pthread_key_destructor.cpp
@@ -23,6 +23,19 @@ std::atomic<uintptr_t> g_values[2]{};
 std::atomic<bool> g_delete_host_done{false};
 std::atomic<bool> g_release_delete{false};
 
+// #1020: a guest key destructor that calls scePthreadExit. winpthreads runs destructors AFTER
+// win_thread_trampoline has returned and cleared its longjmp arm, so before the fix this fell
+// through to host pthread_exit and killed the whole process via RtlRaiseStatus -- the same
+// death #997 removed for the normal worker path.
+pthread_key_t g_exit_key{};
+std::atomic<unsigned> g_exit_dtor_calls{0};
+std::atomic<bool> g_exit_worker_ran{false};
+// Resolved ONCE from main, not inside the destructor. A sysv_abi function that also contains a
+// C++ call with an exception region makes MinGW's assembler reject the object outright with
+// ".seh_handlerdata used outside of .seh_proc block" -- so the guest-ABI callback below must
+// stay free of anything needing unwind data. Hle::lookup is not safe to call from there.
+HleFn g_exit_fn = nullptr;
+
 void delete_after_host_hook(uint64_t) {
     g_delete_host_done.store(true, std::memory_order_release);
     while (!g_release_delete.load(std::memory_order_acquire)) std::this_thread::yield();
@@ -45,6 +58,19 @@ extern "C" __attribute__((sysv_abi)) void* guest_clear_worker(void*) {
     if (!result) result = pthread_setspecific(g_key, nullptr);
     return (void*)(uintptr_t)result;
 }
+extern "C" __attribute__((sysv_abi)) void guest_exiting_destructor(void* value) {
+    g_exit_dtor_calls.fetch_add(1, std::memory_order_relaxed);
+    (void)value;
+    // The call under test: it must not return, and must not take the process with it.
+    if (g_exit_fn) g_exit_fn(0, 0, 0, 0, 0, 0);
+}
+
+extern "C" __attribute__((sysv_abi)) void* guest_exiting_worker(void*) {
+    g_exit_worker_ran.store(true, std::memory_order_release);
+    pthread_setspecific(g_exit_key, (void*)kFirstValue);
+    return nullptr;
+}
+
 }
 
 int main() {
@@ -70,10 +96,35 @@ int main() {
         thread, (uint64_t)(uintptr_t)&worker_result, 0, 0, 0, 0);
     const uint64_t delete_result = key_delete(key, 0, 0, 0, 0, 0);
 
+    // --- #1020 -----------------------------------------------------------------------------
+    // Reaching the line after the join IS the assertion. A regression does not fail a check --
+    // it terminates the process (exit ~0xC00000FF, no output).
+    g_exit_fn = Hle::lookup(nid_hash("scePthreadExit"));
+    uint32_t exit_key = 0;
+    bool exit_arm_ok = key_create((uint64_t)(uintptr_t)&exit_key,
+                                  (uint64_t)(uintptr_t)&guest_exiting_destructor,
+                                  0, 0, 0, 0) == 0;
+    if (exit_arm_ok) {
+        g_exit_key = (pthread_key_t)exit_key;
+        uint64_t exit_thread = 0;
+        exit_arm_ok = thread_create((uint64_t)(uintptr_t)&exit_thread, 0,
+                                    (uint64_t)(uintptr_t)&guest_exiting_worker, 0, 0, 0) == 0;
+        if (exit_arm_ok) exit_arm_ok = thread_join(exit_thread, 0, 0, 0, 0, 0) == 0;
+        key_delete(exit_key, 0, 0, 0, 0, 0);
+    }
+    const bool exit_dtor_ok = exit_arm_ok &&
+        g_exit_worker_ran.load(std::memory_order_acquire) &&
+        g_exit_dtor_calls.load(std::memory_order_relaxed) >= 1;
+    if (!exit_dtor_ok)
+        std::fprintf(stderr, "#1020: armed=%d worker_ran=%d dtor_calls=%u\n",
+                     (int)exit_arm_ok, (int)g_exit_worker_ran.load(std::memory_order_acquire),
+                     g_exit_dtor_calls.load(std::memory_order_relaxed));
+
     const bool ok = join_result == 0 && worker_result == nullptr && delete_result == 0 &&
                     g_calls.load(std::memory_order_relaxed) == 2 &&
                     g_values[0].load(std::memory_order_relaxed) == kFirstValue &&
-                    g_values[1].load(std::memory_order_relaxed) == kSecondValue;
+                    g_values[1].load(std::memory_order_relaxed) == kSecondValue &&
+                    exit_dtor_ok;
     if (!ok) {
         std::fprintf(stderr,
                      "pthread key destructor mismatch: join=%llu worker=%p delete=%llu "


### PR DESCRIPTION
Fixes #1020

## Failure scenario

`win_thread_trampoline` arms the `scePthreadExit` escape **only around the guest entry call** and
clears it before returning. winpthreads then runs the guest pthread-key destructors — so a destructor
calling `scePthreadExit` found `win_thread_exit_armed()` false, fell through to host `pthread_exit`,
and took the whole process down through the un-unwindable guest frames.

That is the exact failure #997/#1003 removed for the normal worker path, still reachable from this
one. Latent — no known title does it — but it is a hard process kill with no diagnostic.

## Approach

The trampoline's `setjmp` frame is gone by the time destructors run, so the escape has to be
re-established **around the destructor itself**. The JIT thunk now calls
`prosper_win_key_destructor_call` instead of `prosper_call_guest_sysv` directly — same MS-ABI shape,
so only the target address changes in the emitted bytes.

POSIX leaves `pthread_exit` from a destructor undefined. **Undefined is not a licence to kill the
process**: the destructor is abandoned, its remaining work skipped, teardown continues, and it says so
once on stderr.

The jump buffer and arm flag are saved and restored around the call, so a destructor running while
another guest frame up the stack is armed cannot steal that frame's escape.

## Two toolchain constraints worth knowing before editing this

Both cost me a build cycle, and neither is obvious from the issue's suggested fix:

- **The `__builtin_setjmp` lives alone in `win_run_key_destructor_armed`.** GCC cannot interleave it
  with any other exception region in the same function on MinGW — putting the logging or the
  `std::atomic` beside it makes the assembler reject the object outright:
  `.seh_handlerdata used outside of .seh_proc block`.
- **The same constraint bit the test.** A `sysv_abi` guest callback must not call anything needing
  unwind data, so the `scePthreadExit` handler is resolved once from `main` into a plain function
  pointer rather than looked up inside the destructor. My first version called `Hle::lookup` from the
  destructor and would not assemble.

## Verification (exact head `8cc95ee9`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release.

```
ctest --no-tests=error -j4  ->  99% tests passed, 1 tests failed out of 177
```

The single failure is #2327 (`pthread_cond_clock`), established earlier today as pre-existing on
clean `origin/master`.

**Mutation arm** — point the thunk back at the unarmed `prosper_call_guest_sysv`:

| arm | exit | output |
| --- | --- | --- |
| fixed | **0** | the diagnostic |
| mutated | **`0xC0000028` STATUS_BAD_STACK** | none at all |

Measured with PowerShell's `ExitCode`, and that detail matters: **bash reports 127** for this
termination, which reads as "command not found", and **`cmd`'s `%ERRORLEVEL%` expands before the run**
so it reports a stale `0`. Both were misleading; only the PowerShell reading is the process's actual
status. I checked all three because the first two disagreed.

**Correction to the issue:** it predicts `~0xC00000FF`. The observed status is **`0xC0000028`**. Same
class — a kernel-side termination with no catchable user-mode exception — but the number differs, so
the issue's code should not be quoted as the signature.

`git diff --check` clean. Session-trailer gate: 0.

## Risk

Low-MED. The changed path runs **only** for guest pthread-key destructors on Windows, and the
existing arms of `test_win_pthread_key_destructor` (callback argument, POSIX retry, the null-value
case) all still pass unchanged.

The judgement call worth a reader: **swallowing the exit rather than propagating it**. The
alternative is to honour it and terminate the thread mid-teardown, which POSIX does not require and
which risks skipping the remaining destructors. I chose the conservative one and made it loud.
`CONFIDENCE: HIGH` that killing the process is wrong; `MED` on abandon-and-continue being the best of
the defined alternatives.

— Wren (Windows lane)