### PR TITLE
libkernel: a condition wait on a mutex the caller does not own returns EPERM, not EINVAL

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -408,6 +408,21 @@ namespace {
                found->second.type == PTHREAD_MUTEX_ERRORCHECK &&
                found->second.owner == (uint64_t)pthread_self();
     }
+    // #2327: FreeBSD returns EPERM from a condition wait whose mutex the caller does not own
+    // (libthr checks _mutex_owned before parking). winpthreads returns EINVAL instead, so the
+    // guest saw the wrong errno under the right encoding -- and a guest testing for EPERM, which
+    // is what Sony's own C11 _Cnd_timedwait does, could not match it.
+    //
+    // "Not owned" deliberately includes "not locked at all" (owner == 0): waiting on a mutex
+    // nobody holds is the same contract violation and FreeBSD answers it the same way. Returns
+    // false for a mutex this registry has never seen, so an unregistered object keeps whatever
+    // the host decides rather than being refused on missing evidence.
+    bool guest_mutex_not_owned_by_self(pthread_mutex_t* mutex) {
+        std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
+        auto found = g_guest_mutex_states.find(mutex);
+        return found != g_guest_mutex_states.end() &&
+               found->second.owner != (uint64_t)pthread_self();
+    }
     void guest_mutex_acquired(pthread_mutex_t* mutex) {
         std::lock_guard<std::mutex> lock(g_guest_mutex_state_mutex);
         auto found = g_guest_mutex_states.find(mutex);
@@ -437,6 +452,7 @@ namespace {
     inline void guest_mutex_register(pthread_mutex_t*, int) {}
     inline void guest_mutex_unregister(pthread_mutex_t*) {}
     inline bool guest_mutex_self_deadlock(pthread_mutex_t*) { return false; }
+    inline bool guest_mutex_not_owned_by_self(pthread_mutex_t*) { return false; }
     inline void guest_mutex_acquired(pthread_mutex_t*) {}
     inline bool guest_mutex_released(pthread_mutex_t*) { return false; }
 #endif
@@ -2407,6 +2423,12 @@ HLE(k_mutex_timedlock) {
 HLE(k_cond_timedwait_sce) {
     auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
     if (!c || !m) return prosper::hle::kSceKernelErrorEINVAL;
+    // FreeBSD refuses a wait on a mutex the caller does not own, with EPERM, BEFORE parking.
+    // Answer that here rather than forwarding the host's: winpthreads reports EINVAL for this
+    // case, so the guest got the right encoding carrying the wrong errno (#2327). Only fires
+    // where prosper actually tracks ownership -- the registry is Windows-only, and on POSIX the
+    // host already implements the FreeBSD contract itself.
+    if (guest_mutex_not_owned_by_self(m)) return prosper::hle::kSceKernelErrorEPERM;
     timespec dl = abs_deadline_us(a2);
     int rc = interruptible_cond_timedwait(c, m, &dl, GuestWaitKind::ConditionSequence, 0,
                                           nullptr, kGuestMutexCondWaitBookkeeping);


### PR DESCRIPTION
Fixes #2327

## Failure scenario

`scePthreadCondTimedwait` forwarded the **host's** errno for the non-owner case. On Windows that is
winpthreads' `EINVAL`; FreeBSD's libthr checks `_mutex_owned` before parking and returns `EPERM`.

So the guest received the right **encoding** carrying the wrong **errno** — `0x80020016` where it
tests for `0x80020001` — and Sony's own C11 `_Cnd_timedwait`, which compares against EPERM, could not
match.

**Measured rather than assumed.** I filed #2327 this morning saying explicitly that I had *not*
captured what the call returns. A probe settles it:

```
[probe] non-owner -> 0x80020016 want 0x80020001
```

That also disposes of the leading hypothesis in the issue — that the value was left *bare*.
It is not: `k_cond_timedwait_sce` already encodes correctly via `sce_pthread_rc`. The encoding was
never the problem; the number inside it was.

## Approach

Answer FreeBSD's contract directly, from ownership prosper already tracks, instead of forwarding
whatever the host decides.

Three deliberate choices:

- **"Not owned" includes "not locked at all"** (`owner == 0`). Waiting on a mutex nobody holds is the
  same contract violation and FreeBSD answers it the same way.
- **An unregistered mutex keeps host behaviour.** The predicate returns false when the registry has
  never seen the object, so nothing is refused on missing evidence.
- **POSIX hosts are untouched.** The ownership registry is inside `#ifdef _WIN32` with no-op stubs
  elsewhere (`hle_kernel.cpp:387`, `:437`), so on Linux/macOS the check cannot fire — and glibc
  already implements the FreeBSD contract there.

## Verification (exact head `84175003`)

Windows 11, WinLibs MinGW-w64 UCRT g++ 16.1.0, Ninja, Release.

```
ctest --no-tests=error -j4  ->  100% tests passed, 0 tests failed out of 177
```

**That is the first fully green Windows run of this session.** `pthread_cond_clock` had been red on
every run — 8/8 at `-j16` and in all 20 full parallel runs I measured while investigating #2277.

**Mutation arm** — remove the guard, rebuild:

```
63 - pthread_cond_clock (Failed)
```

`git diff --check` clean. Session-trailer gate: 0. No new test: the assertion this fixes already
existed (`test_cond_clock.cpp`, the `#ifdef _WIN32` non-owner arm added by #2178) and has simply
never passed on this platform.

## Risk

Low. 22 added lines, no deletions; behaviour changes only on a path that was already failing, only on
Windows, and only for a mutex prosper has registered.

## Related, found while here and deliberately NOT in scope

`scePthreadCondWait` and `pthread_cond_wait` share `k_cond_wait`, whose body **discards the wait
result entirely** and always returns 0 — so a non-owner wait reports success on both spellings. That
is #1983's rule (a Sony spelling on a fallible body needs the alias split) plus the silent-success
class, and fixing it needs the `SCE_PTHREAD_ALIAS` split rather than an edit to the shared body —
exactly the double-consumer hazard that made #2296's obvious fix wrong. Recorded on #1983 rather than
folded in here.

— Wren (Windows lane)