### PR TITLE
render: admit a one-layer 2D array to the native R8 upload path

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2635,8 +2635,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // VK_FORMAT_R8_UNORM sampled image consumes. Expanding every byte to RGBA on the
                         // CPU multiplied Astro Bot's 3840x3240 FMV traffic by four and cost 26-31 ms per
                         // frame. Keep the historical grayscale broadcast through the image-view swizzle.
+                        // img_dim is tested through avp_plane_is_one_layer_2d rather than
+                        // `== 1u`: a title may declare a single-channel plane as a ONE-LAYER 2D
+                        // ARRAY (dim 5, depth 1), which is the same memory and the same sampled
+                        // values but missed this fast path and was CPU-expanded to RGBA8 --
+                        // R-Type Delta (PPSA26414) ships its AvPlayer luma plane that way, so
+                        // every movie frame moved 4x the bytes it needed (#2034). The helper
+                        // also requires no layer stride and no layer mip offset, so a REAL
+                        // multi-layer array still fails and keeps the expanded path.
                         const bool native_r8_sampled =
-                            r.cls == RC::Texture && r.img_dim == 1u &&
+                            r.cls == RC::Texture && prosper::frontend::avp_plane_is_one_layer_2d(r) &&
                             r.format == prosper::gpu::DataFormat::Unorm8 &&
                             r.num_components == 1 && r.tile_mode == 0u &&
                             !r.compression_enabled && !linear_padded_read;

--- a/prosper/frontends/shared/test_avplayer_plane_policy.cpp
+++ b/prosper/frontends/shared/test_avplayer_plane_policy.cpp
@@ -186,6 +186,27 @@ int main() {
         CHECK(v.reason == AvpChromaReason::MatchedSiblingLumaPlane);
     }
 
+    // #2034: the same one-layer-2D-array predicate now gates the native R8 luma upload in
+    // live_renderer.cpp, not only the chroma classifier. R-Type Delta declares its AvPlayer
+    // LUMA plane as dim=5/depth=1, which the old `img_dim == 1u` test missed -- so every movie
+    // frame was CPU-expanded to RGBA8 and moved 4x the bytes it needed.
+    {
+        ShaderResource luma = rtype_luma_plane();
+        CHECK(prosper::frontend::avp_plane_is_one_layer_2d(luma));   // dim=5, depth=1
+        ShaderResource plain = luma; plain.img_dim = 1;
+        CHECK(prosper::frontend::avp_plane_is_one_layer_2d(plain));  // the historical dim=1 case
+
+        // A REAL array must still fail, or the fast path would upload one layer of many and
+        // silently drop the rest. Each rejection is asserted on its own so a predicate that
+        // stopped checking one of them cannot hide behind the others.
+        ShaderResource deep = luma;  deep.depth = 2;
+        CHECK(!prosper::frontend::avp_plane_is_one_layer_2d(deep));
+        ShaderResource strided = luma; strided.layer_stride_bytes = 0x1000;
+        CHECK(!prosper::frontend::avp_plane_is_one_layer_2d(strided));
+        ShaderResource mipped = luma;  mipped.layer_mip_offset_bytes = 0x40;
+        CHECK(!prosper::frontend::avp_plane_is_one_layer_2d(mipped));
+    }
+
     if (!failures) std::printf("avplayer_plane_policy: OK\n");
     return failures ? 1 : 0;
 }


### PR DESCRIPTION
Fixes #2034

## Failure scenario

`native_r8_sampled` required `img_dim == 1u`, so a single-channel `Unorm8` texture a title declares
as a **one-layer 2D array** (`dim 5, depth 1`) missed the `VK_FORMAT_R8_UNORM` fast path and was
CPU-expanded to RGBA8 — four times the upload bytes for identical sampled values.

R-Type Delta (`PPSA26414`) ships its AvPlayer **luma** plane exactly that way — `2048x1080 Unorm8
ncomp=1 dim=5 depth=1` — so every movie frame expanded 2,211,840 source bytes into an 8,847,360-byte
staging buffer.

## Approach

Test `img_dim` through `avp_plane_is_one_layer_2d`, the predicate the chroma classifier already uses.

Worth noting it is **stricter** than the neighbouring `linear_padded_read` test two lines above, which
accepts `dim 1 || dim 5` with no further conditions. The helper also requires `depth <= 1`, no
`layer_stride_bytes` and no `layer_mip_offset_bytes` — so a real multi-layer array still fails and
keeps the expanded path, rather than uploading one layer of many.

Outputs are identical either way: native R8 with the view swizzle forced to `(R,R,R,R)`, or RGBA8 with
the byte broadcast on the CPU. This changes upload **cost** only.

## Verification (exact head `cfa97307`)

```
ctest --no-tests=error -j4  ->  99% tests passed, 1 tests failed out of 177
```

The single failure is `pthread_cond_clock`, pre-existing on this branch's base — its fix is #2342,
awaiting review on a separate branch. Verified it fails identically with and without this change.

**Mutation arm** — drop the `depth` check from the helper: `avplayer_plane_policy` **fails**.

The test asserts each rejection **separately** (depth, layer stride, layer mip offset) rather than as
one combined case, so a predicate that stopped checking any one of them cannot hide behind the others.

## The measurement I could not take, stated plainly

The issue explicitly asks for a before/after rather than riding along on a colour fix. **I cannot
supply it: `PPSA26414` is not in my dump set.**

What I could measure is a clean negative. Blue Prince (`PPSA25009`) under `PROSPER_AVPCHROMA_LOG=1`
reports **42** narrow `Unorm8` sampled resources, and every one is `dim=1` **and** `tile=5`:

```
42  ncomp=1 tile=5 dim=1 depth=1
```

So none takes the native path before or after — tiled sources fail `tile_mode == 0` regardless of
`img_dim` — and this change is a **no-op** for that title. That bounds the blast radius but does not
demonstrate the win.

**So: the predicate is unit-tested; the bandwidth win is not measured here.** If someone with
`PPSA26414` runs `PROSPER_RENDER_TIMING=1` across the opening movie before and after, that closes the
gap. I would rather ship the guard with the hole named than imply a measurement I did not take.

## Risk

Low-MED. The predicate only widens, and only toward a case the surrounding code already treats as
equivalent (`sampled_2d_view` at `:2096` and `linear_padded_read` at `:2629` both accept dim 5). The
judgement call is that a one-layer array and a plain 2D texture are the same memory — which is what
`avp_plane_is_one_layer_2d` already asserts for the chroma plane in shipped code.

— Wren (Windows lane)