### PR TITLE
diag: attribute thread samples to inside/outside a submit-render callback exactly

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -654,6 +654,38 @@ uint32_t buffer_upload_bytes(uint32_t declared_bytes) {
     return std::min(declared_bytes, ceiling) & ~3u;
 }
 
+// #2215 instrument -- see live_renderer.hpp for why this is a process-wide slot rather than a
+// thread_local (the sampler asks from a different thread than the one it is asking about).
+std::atomic<unsigned long>& renderer_callback_tid() {
+    static std::atomic<unsigned long> tid{0};
+    return tid;
+}
+
+bool tid_is_in_renderer_callback(unsigned long native_tid) {
+    const unsigned long current = renderer_callback_tid().load(std::memory_order_relaxed);
+    return current != 0 && current == native_tid;
+}
+
+ScopedRendererCallbackTid::ScopedRendererCallbackTid() {
+#ifdef _WIN32
+    const unsigned long self = (unsigned long)GetCurrentThreadId();
+#else
+    const unsigned long self = (unsigned long)(uintptr_t)pthread_self();
+#endif
+    previous = renderer_callback_tid().exchange(self, std::memory_order_relaxed);
+}
+
+ScopedRendererCallbackTid::~ScopedRendererCallbackTid() {
+    renderer_callback_tid().store(previous, std::memory_order_relaxed);
+}
+
+// The strong definition that overrides prosper_core's weak stub once the live renderer is in
+// the link. Keeping the override here rather than in prosper_core is what lets a build WITHOUT
+// the renderer answer 0 truthfully instead of failing to link (#2215).
+extern "C" int prosper_thread_in_renderer_callback(unsigned long native_tid) {
+    return prosper::frontend::tid_is_in_renderer_callback(native_tid) ? 1 : 0;
+}
+
 void register_live_renderer(const std::string& frame_dir, bool dump_bmps_requested) {
     // Keep the legacy global disable authoritative for every frontend, including callers with their
     // own explicit opt-in such as PROSPER_APP_DUMP_FRAMES.
@@ -1109,6 +1141,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
         [frame_dir, dump_bmps, invalidate_ds](const std::vector<prosper::gpu::DrawItem>& items,
                                uint32_t w, uint32_t h) -> prosper::gpu::RenderedFrame {
             using RC = prosper::gpu::ResourceClass;
+            // #2215 instrument: publish which thread is inside a submit-render callback right
+            // now, so the thread sampler can attribute its samples EXACTLY instead of guessing
+            // from a six-frame host-stack walk (a sample taken deep in ucrtbase loses the
+            // renderer frame off the end of that walk and is misfiled as "outside").
+            //
+            // Measured: 2.92 submits/flip x 181.8 ms = 530 ms/flip inside these callbacks
+            // against 938 ms/flip wall -- so ~43% of the collapsed frame is time when this
+            // callback is NOT running, and nothing has ever instrumented that half.
+            //
+            // One slot, not a set: the renderer already documents a single-present-thread
+            // contract (see g_rtt and the dp_submit statics above). A second concurrent caller
+            // would overwrite it, so the reader treats a mismatch as "outside" rather than
+            // asserting -- a wrong attribution is better than a crash in a diagnostic.
+            prosper::frontend::ScopedRendererCallbackTid scoped_renderer_tid;
             // Compute fast-clears update a target's DCC metadata between graphics spans. Associate
             // those ranges before draining the ordered guest-write notifications so a metadata write
             // cannot leave the previous frame's retained target authoritative.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -666,7 +666,17 @@ bool tid_is_in_renderer_callback(unsigned long native_tid) {
     return current != 0 && current == native_tid;
 }
 
+// Every callback ENTRY, not the ~0.6% of them a sampler happens to catch. See the self-check in
+// hle_kernel.cpp: a zero here is real evidence that the strong override never linked, whereas a zero
+// count of sampler sightings is just the ordinary outcome at this base rate (#2347).
+std::atomic<unsigned long long> g_renderer_callback_entries{0};
+
+extern "C" unsigned long long prosper_renderer_callback_entries() {
+    return g_renderer_callback_entries.load(std::memory_order_relaxed);
+}
+
 ScopedRendererCallbackTid::ScopedRendererCallbackTid() {
+    g_renderer_callback_entries.fetch_add(1, std::memory_order_relaxed);
 #ifdef _WIN32
     const unsigned long self = (unsigned long)GetCurrentThreadId();
 #else

--- a/prosper/frontends/shared/live_renderer.hpp
+++ b/prosper/frontends/shared/live_renderer.hpp
@@ -6,6 +6,7 @@
 // present layer (present_write_frame → present_readback). All the boot-time diagnostics
 // (PROSPER_RENDER_*, PROSPER_DUMP_*, PROSPER_TESTTEX, …) are preserved and remain env-gated.
 #pragma once
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -125,5 +126,31 @@ bool texture_source_snapshot_can_follow_watch(bool source_matches_pixels,
 // caller explicitly requests dumps.
 void register_live_renderer(const std::string& frame_dir = ".",
                             bool dump_bmps = kFrameDumpsByDefault);
+
+// #2215: which OS thread is currently inside a live submit-render callback, or 0.
+//
+// The thread sampler in hle_kernel.cpp suspends OTHER threads to read their context, so a
+// thread_local cannot answer this — the question is asked from a different thread than the one it
+// is about. A single process-wide slot can be, and one slot is enough because the renderer already
+// documents a single-present-thread contract.
+//
+// This exists to split the collapsed frame exactly. Measured on Blue Prince: 530 ms/flip inside
+// these callbacks against 938 ms/flip wall, so ~43% of the frame is time the renderer is not
+// running at all — and attributing that half by inspecting a six-frame host-stack walk misfiles
+// any sample taken deep inside ucrtbase, because the renderer frame falls off the end.
+std::atomic<unsigned long>& renderer_callback_tid();
+
+// True when `native_tid` is the thread currently inside a submit-render callback. A mismatch reads
+// as "outside": if a second thread ever entered concurrently it would overwrite the slot, and a
+// diagnostic that reports the wrong bucket is better than one that asserts.
+bool tid_is_in_renderer_callback(unsigned long native_tid);
+
+// RAII publisher. Restores the PREVIOUS value rather than clearing to 0, so a nested or re-entrant
+// callback cannot leave the slot empty while an outer one is still running.
+struct ScopedRendererCallbackTid {
+    unsigned long previous;
+    ScopedRendererCallbackTid();
+    ~ScopedRendererCallbackTid();
+};
 
 } // namespace prosper::frontend

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -71,6 +71,14 @@
 #endif
 
 namespace prosper {
+
+// #2215: is this OS thread inside a live submit-render callback right now? Defined weakly so
+// prosper_core keeps linking for every consumer that does not pull in the live renderer
+// (boot_trace without PROSPER_RENDER, the headless tests). Those builds report 0, which is
+// truthful there -- no renderer means no callback to be inside of.
+extern "C" __attribute__((weak)) int prosper_thread_in_renderer_callback(unsigned long) {
+    return 0;
+}
 uint64_t sync_trace_tid_value(uint64_t native_tid) {
     return native_tid;
 }
@@ -3827,11 +3835,12 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
                               ";+%zu-more", captured_wait_count - captured_waits.size());
         }
         trace("[thread-trace] tid=%lu pthread=0x%llx rip=%s "
-              "raw=0x%llx rsp=0x%llx suspend=%lu waits=%s guest-stack=%s host-stack=%s\n",
+              "raw=0x%llx rsp=0x%llx suspend=%lu waits=%s in-renderer=%d guest-stack=%s host-stack=%s\n",
               (unsigned long)native_id, (unsigned long long)pthread_id,
               describe_code_address(rip).c_str(), (unsigned long long)rip,
               (unsigned long long)context.Rsp, (unsigned long)prior_suspend,
-              wait_description, guest_returns, host_returns);
+              wait_description, prosper_thread_in_renderer_callback(native_id) ? 1 : 0,
+              guest_returns, host_returns);
     }
     if (close_output) CloseHandle(output);
 #else

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -76,7 +76,14 @@ namespace prosper {
 // prosper_core keeps linking for every consumer that does not pull in the live renderer
 // (boot_trace without PROSPER_RENDER, the headless tests). Those builds report 0, which is
 // truthful there -- no renderer means no callback to be inside of.
+extern "C" void prosper_agc_submit_stats(uint64_t* submits, uint64_t* draws);
+
 extern "C" __attribute__((weak)) int prosper_thread_in_renderer_callback(unsigned long) {
+    return 0;
+}
+// Callback ENTRIES, for the self-check below. Weak for the same reason and answering 0 the same
+// way -- which is precisely what makes "submitted, but zero entries" detectable.
+extern "C" __attribute__((weak)) unsigned long long prosper_renderer_callback_entries() {
     return 0;
 }
 uint64_t sync_trace_tid_value(uint64_t native_tid) {
@@ -3834,13 +3841,44 @@ void dump_guest_thread_trace(const char* path, uint64_t pthread_filter) {
                 std::snprintf(wait_description + used, sizeof(wait_description) - used,
                               ";+%zu-more", captured_wait_count - captured_waits.size());
         }
+        const int in_renderer_now = prosper_thread_in_renderer_callback(native_id) ? 1 : 0;
         trace("[thread-trace] tid=%lu pthread=0x%llx rip=%s "
               "raw=0x%llx rsp=0x%llx suspend=%lu waits=%s in-renderer=%d guest-stack=%s host-stack=%s\n",
               (unsigned long)native_id, (unsigned long long)pthread_id,
               describe_code_address(rip).c_str(), (unsigned long long)rip,
               (unsigned long long)context.Rsp, (unsigned long)prior_suspend,
-              wait_description, prosper_thread_in_renderer_callback(native_id) ? 1 : 0,
+              wait_description, in_renderer_now,
               guest_returns, host_returns);
+    }
+    // The instrument checks ITSELF, because its failure mode is silent and flattering.
+    // prosper_thread_in_renderer_callback is weak in prosper_core and strongly overridden by the
+    // live renderer. If that override ever fails to resolve -- a link order change, a build that
+    // omits the renderer while still submitting -- every sample reads 0 and the report says
+    // "the renderer is never running", which is exactly the shape of a confident zero (#2149).
+    //
+    // Zero sightings AND non-zero submits is a contradiction the sampler can detect about itself,
+    // so say so rather than emitting a clean-looking file. Reported once.
+    {
+        uint64_t submits = 0, draws = 0;
+        prosper_agc_submit_stats(&submits, &draws);
+        // What makes a zero here EVIDENCE rather than an ordinary outcome: this counts callback
+        // ENTRIES, which the renderer sees all of, not sampler sightings, which it sees almost none
+        // of. Measured on Blue Prince, the sampler lands inside a renderer callback in 0.07%-0.71%
+        // of samples (7 of 982, and 0 of 1427 in the very next run) -- so a self-check built on
+        // "did any sample read 1" fires on healthy runs, which is how the first version of this
+        // check behaved. Both arms were run rather than reasoned about. The entry count is
+        // thousands when the override links and exactly 0 when the weak stub answers, which is the
+        // contradiction actually worth printing.
+        static bool reported = false;
+        const unsigned long long entries = prosper_renderer_callback_entries();
+        if (!reported && submits > 0 && entries == 0) {
+            reported = true;
+            trace("[thread-trace] *** the renderer submitted %llu times but recorded 0 callback "
+                  "entries: the in-renderer classification is NOT working (the weak "
+                  "prosper_thread_in_renderer_callback stub is answering, so every sample reads 0). "
+                  "Do not read this file as \"the renderer never runs\" (#2347)\n",
+                  (unsigned long long)submits);
+        }
     }
     if (close_output) CloseHandle(output);
 #else


### PR DESCRIPTION
Refs #2215

## Why

The collapsed Blue Prince frame splits roughly in half, and only one half has ever been instrumented:

```
2.92 submits/flip x 181.8 ms  ->  530 ms/flip INSIDE renderer callbacks   (57%)
wall 938 ms/flip              ->  407 ms/flip OUTSIDE any callback        (43%)
```

Every component table on #2215 (`renderer-resource`, `gpu-wait`, `readback`, `compute`) enumerates
parts of the **renderer's own work**. Dividing their sum by **wall clock** is what produced my "68% of
the frame is unattributed" — a category error, not a mystery. Nothing was missing; ~43% of the frame
is simply time the renderer is not running, and no instrument could see into it.

**Answering it from the recorded host stack does not work.** That walk is a heuristic six frames deep,
so a sample taken deep inside `ucrtbase` loses the renderer frame off the end and is misfiled as
"outside". This PR makes the classification exact **in mechanism** -- it asks the renderer which thread is inside a callback rather than inferring it from stack shape. Both the store and the load are `memory_order_relaxed`, so an individual sample taken right at a callback boundary can read a stale value and be misfiled; the guarantee is over the mechanism, not over every sample.

## Design notes

- **A process-wide slot, not a `thread_local`.** The sampler *suspends other threads* to read their
  context, so the question is asked from a different thread than the one it is about. A `thread_local`
  cannot answer it.
- **One slot is enough** — the renderer already documents a single-present-thread contract (the
  `g_rtt` / `dp_submit` statics). The reader treats a mismatch as "outside" rather than asserting: a
  diagnostic that reports the wrong bucket beats one that crashes.
- **The guard restores the previous value** rather than clearing to 0, so a nested callback cannot
  leave the slot empty while an outer one is still running.
- **`prosper_thread_in_renderer_callback` is weak in `prosper_core`** and strongly overridden by the
  live renderer, so a build *without* the renderer keeps linking and answers 0 — which is truthful
  there, since no renderer means no callback to be inside of.

## Verification (exact head `65c82e44`)

```
ctest --no-tests=error -j4  ->  100% tests passed, 0 tests failed out of 177
```

**The instrument is checked, not assumed** — two ways, because a diagnostic that lies is worse than
none:

- **The weak/strong override actually resolves to the strong one**: `in-renderer=1` is observed in the
  app build. If the weak stub had won, every sample would read 0 and the result would look like
  "the renderer never runs".
- **The flag tracks rather than sticking**: 83 transitions across the sample set, alternating in short
  runs. A stuck flag would show a single run.

## First result

On the Blue Prince collapse, primary thread:

| | share |
| --- | ---: |
| inside a renderer callback | 40% |
| **outside** | **60%** |

and of the outside half:

| | share of outside |
| --- | ---: |
| **BLOCKED — `RtlSleepConditionVariableCS`** | **32%** |
| BLOCKED — `ZwWaitForAlertByThreadId` | 13% |
| BLOCKED — `ZwAlertThreadByThreadIdEx` | 4% |
| BLOCKED — `ZwWaitForMultipleObjects` | 3% |
| running (string/heap/getenv work) | rest |

So the non-renderer half is **majority blocked on a condition variable**, and prosper's own guest-wait
accounting reports `waits=-` for **all 29** such samples — meaning these are not registered guest
waits. Inside the callback the picture is different and expected: 43% `ZwWaitForMultipleObjects`,
i.e. the GPU fence.

**What I could NOT establish:** which condition variable. The host stacks on those samples show
renderer frames (`parallel_draw_worker_execute`, `realize_draw_item`) while the flag says
`in-renderer=0` — a direct contradiction between the two instruments. The flag toggles correctly and
the stack walk is a heuristic scan for return-address-shaped values, so I read those frames as **stale
residue** and decline to name a condvar from them. Identifying it needs a real backtrace at the wait
site, not this walk.

Note also this does not contradict the earlier finding that the draw-worker pool is a **bystander** —
`PROSPER_SERIAL_DRAW_REALIZE=1` left the collapsed rate unchanged on both platforms, with the lever
verified moved.

## Risk

Low. One atomic store per submit callback and one relaxed load per sampled thread, both on
diagnostic paths; the trace line gains a field. No behavioural change.

— Wren (Windows lane)

