### PR TITLE
docs: the charter's 2.4% buffer-copy figure is Windows-only; Linux measures ~15%

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,20 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     1 fps, and the capture said `gpu-device` was **2.2%** of the frame while `renderer-resource` was 47%
     — and that `buffer copy`, the leaf two lanes were optimising because it dominates in *gameplay*, was
     **2.4%** during the collapse. Two different problems that looked like one.
+    - **Those figures are Windows/NVIDIA, and the `buffer copy` one does NOT hold on Linux/AMD.** On Linux
+      the same leaf is **~15%** of the collapsed render work, corroborated by two independent instruments
+      on one run: prosper's own `res_buffer_copy_ms` (`copy=1.68` against `total=11.55` ms/submit over
+      6,275 submits = 14.5%) and external `perf` sampling resolved to the line
+      (`render_runner.h:5199`, 851 of 4,825 worker samples = 17.6%). That is 10.5 s of `memcpy` in a
+      110 s run. #2289 records why the platforms diverge here at all — Windows pays a
+      texture-revalidation `memcmp` that Linux does not.
+      **So do not read the 2.4% as a reason to skip buffer copy without naming your platform first.**
+      An unqualified per-title performance share is the thing that sent #2343 through five dead
+      hypotheses; a share is only meaningful with its platform, its phase and its denominator attached
+      (#2343). The same trap has a sharper edge inside one log: `[render-timing]` prints a leaf called
+      `buffer` under **both** the frontend `build_resources` phase (0.34 ms/submit here) and the
+      **backend** `backend-submit resources` phase (2.11, of which `copy=1.68`). They are different
+      measurements with the same name, and picking the wrong one turns a 15% into a 3%.
 - **Reaching the running frame loop:** `PROSPER_GUEST_ARGS=-force-gfx-direct`, plus `PROSPER_RENDER=1`
   to run the live renderer and `PROSPER_GFXLOG=1` for graphics diagnostics.
   - **`PROSPER_GUEST_FS=1` is NOT needed on Linux or Windows, and this line used to say it was.** Guest


### PR DESCRIPTION
## What

`CLAUDE.md` states, unqualified, that `buffer copy` "was **2.4%** during the collapse" — presented as a
reason not to optimise that leaf in the collapsed regime. **That figure is Windows/NVIDIA and does not hold
on Linux/AMD**, where the same leaf is **~15%** of the collapsed render work and the largest named cost on
the saturated worker thread.

## Why this is a correction and not a competing claim

Two independent instruments, one run, same line:

| instrument | share |
| --- | ---: |
| prosper's own `res_buffer_copy_ms`: `copy=1.68` / `total=11.55` ms/submit, 6,275 submits | **14.5%** |
| same timer against `backend=10.70` | **15.7%** |
| external `perf`, resolved to `render_runner.h:5199`: 851 of 4,825 worker samples | **17.6%** |

A scoped in-code wall-clock timer and external address-resolved CPU sampling landing within ~3 points is
the strongest corroboration available here. In absolute terms: **10.5 s of `memcpy` in a ~110 s run**.

`#2289` already records why the platforms diverge in this title — Windows pays a texture-revalidation
`memcmp` that Linux does not — so both figures are most likely right about their own machine. The defect is
that only one of them is written down, and it reads as universal.

## The second half, which cost this investigation a false retraction

`[render-timing]` prints a leaf called **`buffer`** under **two different phases**:

```
build_resources 1.04 ms/submit [... buffer=0.34 ...]                      <- frontend
backend-submit resources avg_ms: ... buffer=2.11 (copy=1.68 ...)          <- backend
```

`render_runner.h:5199` is in the render callback, i.e. the **backend** one. I first quoted the frontend
`0.34`, computed 2.9%, and posted that my own sampler was contradicted — a retraction I then had to
withdraw. Same name, different measurement, 5x apart. That is now recorded next to the figure so the next
reader does not repeat it.

## Deliberately unchanged

- **The 2.2% `gpu-device` figure and the 47% `renderer-resource`** — those are Wren's Windows numbers and I
  have not re-measured them; only the `buffer copy` claim is corrected.
- **The "read the F8 report before optimising anything" rule itself**, which is right and is the reason the
  original example is in the charter at all.
- No claim that buffer copy *causes* the collapse, or that removing it recovers 15%. Five hypotheses on
  that number have already died (#2343); this PR fixes a documented share, not a cause.

## Verification

Docs-only diff (`git diff --name-only origin/master...HEAD | grep -v '\.md$'` is empty).

```
python3 prosper/tools/docs/check_numbered_table.py --sequential \
    --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md
  -> 14 table(s), 202 rows, contiguous and unbroken, every row matching its header

git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
  -> clean

git diff --check  -> clean
```

Per the charter a docs-only PR may merge without waiting for CI — but this one edits the charter's own
guidance on a `## Ruled out`-style steer, which is exactly the case the same paragraph says still wants a
reader. **Not merging without review.**

Refs #2343, #2215, #2289
