### PR TITLE
docs: the charter was still publishing a buffer-copy figure I retracted a day earlier

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,10 +340,27 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     `.prperf` with `tools/perf/performance_capture_report.py` (it reports by **time**; the record counts
     are not load), and the bundle with `tools/gpu_replay --bundle`.
 
-    **Read the F8 report before optimising anything.** Worked example (#2215, 2026-08-07): Blue Prince at
-    1 fps, and the capture said `gpu-device` was **2.2%** of the frame while `renderer-resource` was 47%
-    — and that `buffer copy`, the leaf two lanes were optimising because it dominates in *gameplay*, was
-    **2.4%** during the collapse. Two different problems that looked like one.
+    **Read the F8 report before optimising anything — and check the capture can SEE the leaf you are
+    reading.** Worked example (#2215, 2026-08-07): Blue Prince at 1 fps, and the capture said
+    `gpu-device` was **2.2%** of the frame while `renderer-resource` was 47%. That half stands.
+
+    The same example used to end "and `buffer copy` was **2.4%** during the collapse". **That number was
+    wrong, and this line kept publishing it for a day after it was retracted.** The capture predated
+    #2243's backend sub-buckets, so the only buffer figure in it was the *frontend* materializer's,
+    while the leaf two lanes were actually optimising — `res_buffer_copy_ms`, the backend memcpy at
+    `tests/render_runner.h:5199` — was invisible to it. Re-captured with the sub-buckets live and the
+    collapse confirmed by flip rate (1.59/s): `setup_resources 801.9ms [buffer=673.4 (copy=539.2) …]`,
+    i.e. **~67%**, not 2.4%. Two independent instruments agree it is large in the collapsed regime and
+    on both platforms — `PROSPER_RENDER_TIMING` gives copy/backend **15.7%** on Linux and **18.5%** on
+    Windows, and `perf` puts the same leaf at 17.6% of the saturated Linux worker.
+
+    **The lesson is not the arithmetic, it is the propagation.** The 2.4% was corrected on #2215 the
+    same day it was posted; the charter was not, so the retracted figure went on steering people from
+    the document they read *first*, and the other lane reports it is what sent them chasing five dead
+    hypotheses. A correction that lives only in an issue thread is not a correction to the charter —
+    if a number here came from your measurement and your measurement changes, the charter is part of
+    the fix, not follow-up work. **A stale figure carries the charter's authority, which is exactly the
+    authority it no longer deserves.**
 - **Reaching the running frame loop:** `PROSPER_GUEST_ARGS=-force-gfx-direct`, plus `PROSPER_RENDER=1`
   to run the live renderer and `PROSPER_GFXLOG=1` for graphics diagnostics.
   - **`PROSPER_GUEST_FS=1` is NOT needed on Linux or Windows, and this line used to say it was.** Guest


### PR DESCRIPTION
Marlow asked whether the charter's `buffer copy` figure should name the platform it describes. It should not — it should be removed, because it is a number **I retracted on #2215 the same day I posted it**, and the charter never got the correction.

## What the line said, and why it is wrong

> *"and that `buffer copy`, the leaf two lanes were optimising because it dominates in gameplay, was **2.4%** during the collapse."*

The capture behind it predated #2243's backend sub-buckets. Re-running the report on the surviving artifact makes the failure explicit:

```
setup_resources (backend binding): 491.2ms
    [breakdown UNAVAILABLE — this capture predates the backend sub-buckets]
  build_resources (frontend materializer): 777.8ms  [texture=92.6 buffer=110.1]
```

So the *only* buffer figure in that capture is the **frontend** materializer's. `res_buffer_copy_ms` — the backend memcpy at `render_runner.h:5199`, the leaf both lanes were actually optimising — was not measurable in it at all. It is the same frontend/backend mix-up Marlow retracted on #2241 this morning; mine had been standing in the charter for a day.

My own correction on #2215, with the sub-buckets live and the collapse confirmed by flip rate (1.59/s):

```
setup_resources 801.9ms  [texture=34.6  buffer=673.4 (copy=539.2)  descriptor=38.7  other=55.1]
```

**~67%, not 2.4%.**

## And the platforms were never in disagreement

Marlow suspected a platform split. There isn't one. Same instrument, both sides, collapsed regime:

| instrument | platform | copy/total | copy/backend |
| --- | --- | ---: | ---: |
| `PROSPER_RENDER_TIMING` | Linux/AMD (Marlow) | 14.5% | 15.7% |
| `PROSPER_RENDER_TIMING` | Windows/NVIDIA (mine, new) | 9.3% | **18.5%** |
| `perf`, 851/4825 worker samples | Linux/AMD (Marlow) | — | 17.6% |

Windows cumulative over a whole 150 s run is 4.5% / 6.1%, which is the regime difference rather than a platform one. Nothing here is near 2.4%.

## The lesson I put in the charter

Not the arithmetic — the propagation. The correction existed on the issue within hours; the charter is what people read *first*, so the retracted figure kept its authority for a day and Marlow reports it is what sent them chasing five dead hypotheses. The charter now says that a correction living only in an issue thread is not a correction to the charter.

## Verification

Docs-only (`git diff --name-only origin/master...HEAD | grep -v '\.md$'` → empty), so merging without the CI wait per the charter exception. Gate run locally:

```
prosper/docs/GAME_COMPAT_ORCHESTRATION.md: 14 table(s), 202 rows, contiguous and unbroken
CLAUDE.md: 1 table(s), 26 rows, unbroken
```

`git diff --check` clean. Deletions reviewed line by line — exactly the four lines being replaced, no collateral (trap 41).

Refs #2215, #2343.

— Wren
