### PR TITLE
fix(tools): xref.py must refuse a SELF, not answer 0 references for every address

### DIFF
--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -254,6 +254,98 @@ def imm():
     print("xref imm: PASS")
 
 
+def refusal():
+    """#2346: inputs this tool cannot answer must be REFUSED, never answered with zeros.
+
+    Every arm here asserts an exception. That is the point: before the fix, each of these inputs
+    constructed a Module without complaint and then reported `0 references` for every address --
+    output that is byte-identical to a true negative, which is the answer people run this tool to
+    establish. The arms are written so that a regression re-opens as a FAILURE to raise, rather than
+    as a wrong number nobody notices.
+    """
+    def build(prefix, phentsize=56, phnum=1, seg_flags=5, body=b"\x90" * 0x40):
+        raw = bytearray(0x200)
+        raw[:4] = prefix
+        struct.pack_into("<Q", raw, 0x20, 0x40)
+        struct.pack_into("<HH", raw, 0x36, phentsize, phnum)
+        struct.pack_into("<IIQQQQQQ", raw, 0x40,
+                         1, seg_flags, 0x100, 0x1000, 0, len(body), len(body), 0x1000)
+        raw[0x100:0x100 + len(body)] = body
+        fd, path = tempfile.mkstemp(suffix=".bin")
+        os.write(fd, bytes(raw))
+        os.close(fd)
+        return path
+
+    def refuses(path, why, must_mention=None):
+        try:
+            XREF.Module(path)
+        except XREF.BadModule as exc:
+            if must_mention and must_mention not in str(exc):
+                raise AssertionError("%s: message must mention %r, got: %s" % (why, must_mention, exc))
+        else:
+            raise AssertionError("%s: constructed a Module instead of refusing" % why)
+
+    paths = []
+    try:
+        # The reported case: a real SELF starts with this container magic, and its bytes at 0x20/0x36
+        # decode as e_phoff=0x110004, phentsize=0, phnum=45792 -- which is why the old code built an
+        # empty segment table rather than crashing. The message must name the flattening step,
+        # because "refused" without the remedy just moves the dead end.
+        p = build(b"\x4f\x15\x3d\x1d"); paths.append(p)
+        refuses(p, "a SELF container", must_mention="prx_to_elf.py")
+
+        # Not an ELF and not a SELF either -- must still refuse rather than parse whatever is at 0x20.
+        p = build(b"MZ\x90\x00"); paths.append(p)
+        refuses(p, "a non-ELF file")
+
+        # phentsize=0 is what a SELF actually yields, and it makes the header loop re-read one offset
+        # phnum times. Covered on its own so the guard survives someone relaxing the magic check.
+        p = build(b"\x7fELF", phentsize=0); paths.append(p)
+        refuses(p, "e_phentsize of 0")
+
+        # A well-formed ELF whose only PT_LOAD is non-executable. Every form this tool decodes lives
+        # in an executable segment, so it could only ever answer 0.
+        p = build(b"\x7fELF", seg_flags=6); paths.append(p)
+        refuses(p, "no executable segment")
+
+        # The backstop, and the arm that matters most: this file passes every structural check above
+        # -- real ELF magic, sane phentsize, an executable PT_LOAD -- and still yields no references,
+        # because its "code" is all single-byte nops. A module that decodes to nothing has failed
+        # whatever its header claimed, so the tool must detect that about itself rather than trust
+        # that the checks above were exhaustive.
+        #
+        # It must be MODULE-SIZED to be refused, and that is not incidental. The backstop's premise
+        # ("no references at all means the decoder failed") is false for a small ELF, and this test
+        # is how that was found: an earlier version had no threshold and refused the `imm` fixture
+        # above, which is 256 bytes of legitimately reference-free executable segment.
+        big = 0x10000 + 0x40
+        p = build(b"\x7fELF", body=b"\x90" * big); paths.append(p)
+        refuses(p, "a module-sized ELF with zero decodable references", must_mention="ZERO references")
+
+        # The negative half of that threshold: the SAME reference-free body, below module scale, must
+        # be ACCEPTED. Otherwise the guard has just moved the failure from a silent wrong answer to a
+        # loud wrong refusal.
+        p = build(b"\x7fELF", body=b"\x90" * 0x40); paths.append(p)
+        XREF.Module(p)
+
+        # ...and the control for the backstop itself, built by hand rather than drawn from the same
+        # generator as the nulls (charter: a same-source control tests the discriminator, not the
+        # domain). ONE direct call in an otherwise module-sized nop field is enough to make it
+        # plausible, and it must be accepted. Without this arm the backstop could refuse every
+        # large module and still pass every assertion above.
+        body = bytearray(b"\x90" * big)
+        body[0:5] = b"\xe8" + rel32(0x1000, 5, 0x1020)
+        p = build(b"\x7fELF", body=bytes(body)); paths.append(p)
+        module = XREF.Module(p)
+        assert module.code_xref[0x1020] == [(0x1000, "call")], dict(module.code_xref)
+    finally:
+        for p in paths:
+            os.unlink(p)
+
+    print("xref refusal: PASS")
+
+
 if __name__ == "__main__":
     main()
     imm()
+    refusal()

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -25,6 +25,12 @@
 # function at <addr> reference".
 #
 # Input is a FLATTENED ELF (p_offset==p_vaddr) as produced by tools/il2cpp/prx_to_elf.py.
+# Handing it the SELF instead (`eboot.bin` as it ships) is REFUSED, not answered — see #2346. It used
+# to parse the SCE container header as though it were an ELF and report 0 references for every
+# address, which is the one answer this tool must never produce by accident: "who writes X" answered
+# with 0 reads as "nobody writes X", and that is a conclusion strong enough to redirect an
+# investigation. Flatten first:
+#     python3 tools/il2cpp/prx_to_elf.py <DUMP>/eboot.bin /tmp/eboot.elf
 # Runtime address = module_load_base + VA (e.g. eboot base 0x410000000; it moved from
 # 0x400000000 in #825 — see prosper/src/host/boot_program.hpp for the authoritative set).
 #
@@ -70,12 +76,47 @@ def access(kind):
     return ACCESS.get(kind, '?')
 
 
+ELF_MAGIC = b'\x7fELF'
+SELF_MAGIC = b'\x4f\x15\x3d\x1d'   # PS5/PS4 SELF container (eboot.bin, *.sprx as shipped)
+
+
+class BadModule(ValueError):
+    """The input is not a module this tool can answer questions about.
+
+    Raised instead of returning zeros. #2346: handed an `eboot.bin` (a SELF), this tool used to read
+    e_phoff/phnum straight out of the SCE container header -- on a real one that yields phnum=45792
+    with phentsize=0 -- build an empty segment table, and then answer **0 references** for every
+    address, including the target of a direct `call`. That output is indistinguishable from a true
+    negative, and a true negative ("nobody writes this address") is precisely what people run this
+    tool to establish. One was nearly reported as a finding on #2345.
+    """
+
+
 class Module:
     def __init__(self, path):
         self.raw = open(path, 'rb').read()
         raw = self.raw
+        # Refuse before parsing, not after. Everything below reads fixed offsets that exist in ANY
+        # file long enough, so without this the tool cannot fail -- it can only answer wrongly.
+        if len(raw) < 0x40:
+            raise BadModule(f"{path}: {len(raw)} bytes is too short to be an ELF")
+        if raw[:4] == SELF_MAGIC:
+            raise BadModule(
+                f"{path} is a SELF container, not a module ELF. Flatten it first:\n"
+                f"    python3 tools/il2cpp/prx_to_elf.py {path} <out.elf>\n"
+                f"and run this tool on <out.elf>. (Answering the question on the SELF would mean "
+                f"reporting 0 references for every address -- see #2346.)")
+        if raw[:4] != ELF_MAGIC:
+            raise BadModule(f"{path}: not an ELF (magic {raw[:4].hex()}), and not a SELF either")
         e_phoff, = struct.unpack_from('<Q', raw, 0x20)
         phentsize, phnum = struct.unpack_from('<HH', raw, 0x36)
+        # A well-formed ELF64 program header is exactly 56 bytes. A garbage phentsize (0 on a SELF)
+        # makes the loop below re-read one offset phnum times and produce nonsense segments.
+        if phentsize != 56:
+            raise BadModule(f"{path}: e_phentsize is {phentsize}, not 56 — this is not an ELF64")
+        if not phnum or e_phoff + phnum * phentsize > len(raw):
+            raise BadModule(f"{path}: program header table (phoff=0x{e_phoff:x}, phnum={phnum}) "
+                            f"does not fit in {len(raw)} bytes")
         self.segs = []          # (va, foff, filesz, flags)
         self.dyn_va = 0
         for i in range(phnum):
@@ -84,7 +125,30 @@ class Module:
                 self.segs.append((va, off, fs, fl))
             elif t == 2:
                 self.dyn_va = va
+        if not self.segs:
+            raise BadModule(f"{path}: no PT_LOAD segments — nothing to search")
+        if not any(fl & 1 for _, _, _, fl in self.segs):
+            raise BadModule(f"{path}: no executable PT_LOAD segment — every code reference this "
+                            f"tool decodes lives in one, so every answer would be 0")
         self._build()
+        # The backstop, and the reason it is here rather than in a comment: the checks above reject
+        # the input shapes we KNOW about, and a silent zero is exactly the failure that arrives in a
+        # shape nobody anticipated. A real PS5 module has thousands of internal references; a decoder
+        # that finds none of them has failed, whatever the file claimed to be. So make the tool
+        # detect its own invalidity instead of trusting that the magic check was sufficient.
+        #
+        # The size threshold is load-bearing and was found by the guard firing on a legitimate input:
+        # the premise "a module with no references at all has failed" is only true at MODULE scale.
+        # A small hand-built ELF -- this repo's own `imm` test fixture is 256 bytes of executable
+        # segment -- can honestly contain no reference of any decoded form. Refusing those would
+        # trade a silent wrong answer for a loud wrong refusal, which is not an improvement. 64 KiB
+        # is far below any real PS5 eboot/PRX and far above any fixture.
+        exec_bytes = sum(fs for _, _, fs, fl in self.segs if fl & 1)
+        if exec_bytes >= 0x10000 and not self.code_xref and not self.data_xref:
+            raise BadModule(
+                f"{path}: parsed as an ELF, but ZERO references of any kind were decoded across "
+                f"{exec_bytes} bytes of executable segment. That is not a plausible module - "
+                f"refusing rather than answering 0 for every address (#2346).")
 
     def foff(self, va):
         for v, o, fs, fl in self.segs:
@@ -327,7 +391,13 @@ def main():
     if len(sys.argv) < 4:
         print(__doc__)
         return 1
-    m = Module(sys.argv[1])
+    try:
+        m = Module(sys.argv[1])
+    except BadModule as exc:
+        # Non-zero exit as well as the message: a caller that pipes this into a report must not be
+        # able to mistake a refusal for an empty result set (#2346).
+        print(f"refused: {exc}", file=sys.stderr)
+        return 2
     mode = sys.argv[2]
     if mode == 'imm':
         text = sys.argv[3]


### PR DESCRIPTION
Fixes #2346.

## The failure

`xref.py` read `e_phoff`/`e_phnum` from fixed offsets without checking what the file was. On a real SELF those offsets hold `phoff=0x110004, phentsize=0, phnum=45792`, so the header loop re-read one offset 45,792 times, built an empty segment table, and every query then answered **0 references** — with **exit code 0**.

The problem is not the wrong answer, it is that the wrong answer is the *same output as the right one*. "Who writes this address" answered with 0 reads as "nobody writes it", which is a conclusion strong enough to redirect an investigation. #2346 reports being one step from posting that as a finding on #2345, with a tool citation attached.

## The fix

Refuse, with the remedy in the message and a **non-zero exit** so a caller piping the output cannot read a refusal as an empty result set:

```
$ python3 tools/re/xref.py <DUMP_ROOT>/<TITLE>-app0/eboot.bin to 0x6f41a8
refused: …/eboot.bin is a SELF container, not a module ELF. Flatten it first:
    python3 tools/il2cpp/prx_to_elf.py …/eboot.bin <out.elf>
and run this tool on <out.elf>. (Answering the question on the SELF would mean
reporting 0 references for every address -- see #2346.)
$ echo $?
2
```

Also refused, each because it could only ever answer 0: a non-ELF, an `e_phentsize` that is not 56, and an ELF with no executable `PT_LOAD`.

## The backstop, and why its threshold is the interesting part

The four checks above reject the shapes we already know about. A silent zero arrives in the shape nobody anticipated — so a **module-sized** ELF that decodes to zero references of any kind is refused as well. The tool detects its own invalidity rather than trusting that the magic check was exhaustive.

**The size threshold is load-bearing, and I found it by the guard firing on a legitimate input.** The premise "no references at all means the decoder failed" is only true at module scale. My first version had no threshold and refused this repo's own `imm` test fixture — 256 bytes of honestly reference-free executable segment. That would have traded a silent wrong answer for a loud wrong refusal, which is not an improvement. 64 KiB is far below any real eboot/PRX and far above any fixture, and the test now pins **both** sides of it.

## Verification

| arm | result |
| --- | --- |
| pre-fix, the reported repro | `0 references`, **exit 0** |
| pre-fix, the new test | **FAILS** — `a SELF container: constructed a Module instead of refusing` |
| post-fix, real SELF | refused, exit 2 |
| post-fix, same SELF flattened via `prx_to_elf.py` | **128,740** referenced addresses |
| post-fix, positive control on that ELF | a hand-picked direct-`call` target reports **3,834** references |

The positive control is built by hand from a `call` found by scanning the executable segment, not drawn from the same generator as the nulls — per the charter, a same-source control tests the discriminator rather than the domain. The test carries the same structure: the reference-free body is asserted **accepted** below the threshold and **refused** above it, and one direct call in an otherwise module-sized nop field must be accepted, so a backstop that refused every large module could not pass.

`ctest --no-tests=error -R re_xref_decoder` → **1/1 passed** (MinGW UCRT, Windows). No emulator code touched; the change is confined to `tools/re/`.

— Wren
