### PR TITLE
perf(gpu): stop taking a process-wide lock twice per draw on every render worker

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -987,10 +987,24 @@ inline void trace_color_state_if_requested(const RenderState& rs,
 // states) and renders vcount_hint vertices non-indexed. Returns false (and leaves `out` untouched) if
 // the draw is a no-op (no PGM bound, recompile failed, or no color/depth/stencil effect). Shared by the default
 // (folded-state, one item) and PROSPER_PERDRAW (per-draw) paths so their per-draw handling is identical.
+// `hoisted_validate_mode` (#2287): a POINTER to a PROSPER_DESCRIPTOR_VALIDATE value the caller
+// already read once for the whole submit, or nullptr to read it here as before. The extra
+// indirection is what distinguishes "the caller hoisted it and it was unset" (non-null pointer to a
+// null string) from "the caller did not hoist" (null pointer) -- a plain `const char*` cannot say
+// both, and defaulting the ambiguous case to "off" would silently disable validation for every
+// caller that had not been converted.
+//
+// Why it is worth plumbing rather than reading here: this function is called once per draw from
+// parallel_draw_worker_execute, and on Windows getenv takes a process-wide lock on every call, so
+// two reads per draw across every worker is contention rather than a per-call constant -- and it
+// gets worse with more workers, which is the opposite of what parallelising the loop is for.
+// #2285 removed the equivalent pair from the serial build_bds path and measured the unit at
+// 1.26 us/call, 5.49 ms/submit at the 2,179 draws/submit this title reaches in the FMV phase.
 inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, uint32_t vcount_hint,
                               uint32_t max_shader_dwords, bool log, DrawItem& out,
                               OperationRealizationFailure* failure = nullptr,
-                              bool retain_shared_shader_words = false) {
+                              bool retain_shared_shader_words = false,
+                              const char* const* hoisted_validate_mode = nullptr) {
     RenderState rs = extract_render_state(ds);
     if (failure) {
         *failure = {};
@@ -1387,8 +1401,17 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         }
         return false;
     }
-    if (!validate_runtime_descriptor_contract("VS", vs_words, vrt.get(), 0, SpirvShaderStage::Vertex) ||
-        !validate_runtime_descriptor_contract("PS", fs_words, prt.get(), 1, SpirvShaderStage::Fragment)) {
+    // One read per submit when the caller hoisted it, one per call otherwise -- never one per draw
+    // per stage on a parallel worker (#2287). The read stays LIVE either way, deliberately not
+    // PROSPER_ENV_VALUE: test_shader_resources.cpp and test_gpu_capture_render.cpp arm this variable
+    // at runtime, and a process-lifetime cache would make those arms vacuous rather than failing --
+    // the #2214 defect that check_cached_env.py gates.
+    const char* const validate_mode = hoisted_validate_mode ? *hoisted_validate_mode
+                                                            : getenv("PROSPER_DESCRIPTOR_VALIDATE");
+    if (!validate_runtime_descriptor_contract("VS", vs_words, vrt.get(), 0, SpirvShaderStage::Vertex,
+                                              validate_mode) ||
+        !validate_runtime_descriptor_contract("PS", fs_words, prt.get(), 1, SpirvShaderStage::Fragment,
+                                              validate_mode)) {
         if (failure) failure->reason = RealizationFailureReason::DescriptorContract;
         if (log) fprintf(stderr, "[exec] skip draw: strict descriptor contract failed "
                                 "(es=0x%llx ps=0x%llx color0=0x%llx)\n",

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6074,6 +6074,16 @@ struct ParallelDrawContext {
     uint32_t max_shader_dwords = 0;
     bool retain_shared_shader_words = false;
     bool parent_readable_active = false;
+    // PROSPER_DESCRIPTOR_VALIDATE, read ONCE for this submit and handed to every worker (#2287).
+    // Previously each worker read it twice per draw, and on Windows getenv takes a process-wide
+    // lock, so the cost was contention across workers rather than a constant per call.
+    //
+    // Read here rather than assumed unset. It is in parallel_draw_diagnostic_active's list, so this
+    // path only runs when the variable is clear and passing nullptr would be correct TODAY -- but
+    // that would make descriptor validation depend on a diagnostic list it has no visible
+    // relationship to, and removing the entry from that list would silently stop validating instead
+    // of failing. One getenv per submit costs nothing and owes nothing to that coupling.
+    const char* descriptor_validate_mode = nullptr;
     std::vector<ParallelDrawSlot> slots;
     std::vector<ParallelWorkerMeasurement> measurements;
 };
@@ -6095,7 +6105,7 @@ void parallel_draw_worker_execute(void* opaque, size_t draw_index, size_t) {
     slot.realized = realize_draw_item(
         state.state_at_draw(draw_index), &draw, draw.index_count,
         context.max_shader_dwords, false, slot.item, nullptr,
-        context.retain_shared_shader_words);
+        context.retain_shared_shader_words, &context.descriptor_validate_mode);
     if (slot.realized) {
         slot.item.draw_index = draw_index;
         slot.item.command_order = draw.command_order;
@@ -6161,6 +6171,7 @@ std::vector<DrawItem> realize_gpustate_draws_parallel(
     context.max_shader_dwords = max_shader_dwords;
     context.retain_shared_shader_words = retain_shared_shader_words;
     context.parent_readable_active = g_guest_readable_cache.active;
+    context.descriptor_validate_mode = getenv("PROSPER_DESCRIPTOR_VALIDATE");   // once, not per draw
     context.slots.resize(st.draws.size());
     context.measurements.resize(worker_count + 1);
 

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -11,6 +11,22 @@
 #include "../src/host/guest_write_watch.hpp"
 #include "render_runner.h"
 #include "test_scratch.h"
+
+// #2287 uses these to capture the validator's own stderr output; MSVC/MinGW spell the POSIX names
+// with a leading underscore.
+#ifdef _WIN32
+#include <io.h>
+#define PROSPER_DUP _dup
+#define PROSPER_DUP2 _dup2
+#define PROSPER_FILENO _fileno
+#define PROSPER_CLOSE _close
+#else
+#include <unistd.h>
+#define PROSPER_DUP dup
+#define PROSPER_DUP2 dup2
+#define PROSPER_FILENO fileno
+#define PROSPER_CLOSE close
+#endif
 #include <algorithm>
 #include <array>
 #include <cstdio>
@@ -577,6 +593,69 @@ int main() {
         CHECK(made3 && it3.vertex_count == 3u, "non-zero vertex-count draw still realizes");
         CHECK(made3 && it3.raw_draw_count == 3u && !it3.raw_indexed,
               "#1256: realize_draw_item records the raw non-indexed draw-packet count (3) for capture");
+
+        // #2287: realize_draw_item resolves PROSPER_DESCRIPTOR_VALIDATE from the caller's hoisted
+        // value when given one, and reads the environment only when it is not. The parallel draw
+        // workers call this once per draw, and on Windows getenv takes a process-wide lock, so two
+        // reads per draw per worker is contention that grows with the worker count.
+        //
+        // The obvious test here is an EQUIVALENCE -- "hoisted strict behaves like live strict" --
+        // and it is worthless on this fixture. Measured, not assumed: this state realizes
+        // identically under `strict` and `off`, so all three equivalence arms passed while the
+        // parameter was being ignored. That is exactly #2130, and it is why the observable below is
+        // the validator's OUTPUT rather than its verdict.
+        //
+        // `mode=all` prints a `[descriptor]` line even when the report is clean, whereas an unset
+        // mode returns on the first line and prints nothing. So a hoisted `all` against an unset
+        // environment produces output that CANNOT be produced by ignoring the parameter.
+        {
+            auto set_mode = [](const char* v) {
+#ifdef _WIN32
+                _putenv_s("PROSPER_DESCRIPTOR_VALIDATE", v);
+#else
+                if (*v) setenv("PROSPER_DESCRIPTOR_VALIDATE", v, 1);
+                else unsetenv("PROSPER_DESCRIPTOR_VALIDATE");
+#endif
+            };
+            // Capture stderr around one realization and return what it wrote.
+            auto realize_capturing = [&](const char* const* hoisted) {
+                const std::string path =
+                    (prosper_test::test_scratch_dir() / "descriptor_mode_probe.txt").string();
+                fflush(stderr);
+                const int saved = PROSPER_DUP(PROSPER_FILENO(stderr));
+                FILE* sink = fopen(path.c_str(), "w");
+                PROSPER_DUP2(PROSPER_FILENO(sink), PROSPER_FILENO(stderr));
+                DrawItem item;
+                realize_draw_item(st, nullptr, /*vcount_hint*/3u, 0x10000u, /*log*/false,
+                                  item, nullptr, false, hoisted);
+                fflush(stderr);
+                PROSPER_DUP2(saved, PROSPER_FILENO(stderr));
+                PROSPER_CLOSE(saved);
+                fclose(sink);
+                std::string text;
+                if (FILE* f = fopen(path.c_str(), "rb")) {
+                    char buf[512];
+                    size_t n;
+                    while ((n = fread(buf, 1, sizeof buf, f)) > 0) text.append(buf, n);
+                    fclose(f);
+                }
+                return text;
+            };
+
+            set_mode("");                                   // environment says: validation OFF
+            const char* const verbose_mode = "all";
+            const std::string hoisted_out = realize_capturing(&verbose_mode);
+            CHECK(hoisted_out.find("[descriptor]") != std::string::npos,
+                  "#2287: realize_draw_item uses the caller's hoisted validation mode -- a hoisted "
+                  "'all' validates even though the environment is unset");
+
+            // The control, and the half that makes the arm above mean something: same fixture, same
+            // unset environment, no hoisted value. Ignoring the parameter would produce THIS.
+            const std::string live_out = realize_capturing(nullptr);
+            CHECK(live_out.find("[descriptor]") == std::string::npos,
+                  "#2287: with no hoisted value the environment is still what decides, and it is "
+                  "unset here, so nothing is validated");
+        }
 
         GpuState rect = st;
         rect.uc[P::VGT_PRIMITIVE_TYPE] = 7;


### PR DESCRIPTION
Fixes #2287.

## What

`realize_draw_item` read `PROSPER_DESCRIPTOR_VALIDATE` on every call, **twice** — once per shader stage — and it is called **once per draw** from `parallel_draw_worker_execute`. On Windows the UCRT's `getenv` takes `__acrt_environment_lock` on every call, so unlike the serial pair #2285 removed this is not a per-call constant: it is **contention between the render workers**, and it grows with the worker count, which is the opposite of what parallelising the loop is for.

At the **2,105 draws/submit** this title reaches in the collapsed phase (measured here with `PROSPER_RENDER_TIMING`), that is **4,210 locked environment reads per submit**, every one of them re-establishing that a diagnostic is switched off.

## The approach, and the two judgment calls in it

Follows #2285: hoist the mode once per submit into `ParallelDrawContext`, hand it to every worker.

**Why a pointer and not a `const char*`.** The parameter is `const char* const*` so that *"hoisted, and it was unset"* stays distinguishable from *"not hoisted"*. A plain `const char*` cannot express both, and defaulting the ambiguous case to "off" would silently stop validating for every caller not yet converted. Unconverted callers pass nothing and read the environment exactly as before.

**Why hoist at all, when `nullptr` would be correct today.** `PROSPER_DESCRIPTOR_VALIDATE` is in `parallel_draw_diagnostic_active`'s list (`gpu_executor.cpp:6043`), and a set value makes the parallel path bail at `:6153` — so the workers provably only run when it is clear, and passing `nullptr` unconditionally would be correct *right now*. I did not do that: it would make descriptor validation depend on a diagnostic list it has no visible relationship to, and deleting the entry from that list would **silently stop validating** rather than fail. One `getenv` per submit costs nothing and owes nothing to that coupling.

The read stays live per submit rather than becoming `PROSPER_ENV_VALUE` — two tests arm this variable at runtime, and a process-lifetime cache would make their arms vacuous rather than failing (#2214). `check_cached_env.py` passes.

## The test, and a correction to my first version of it

The natural test is an equivalence — *hoisted "strict" behaves like live "strict"* — and I wrote that first, with a precondition asserting the fixture's outcome actually depends on the mode.

**The precondition failed.** This state realizes identically under `strict` and `off`, so all three equivalence arms passed **while the parameter was being ignored**:

```
[FAIL] #2287 precondition: this fixture's realization must actually depend on the validation mode
[ok]   #2287: a hoisted 'off' overrides a live 'strict' environment
[ok]   #2287: a hoisted 'strict' overrides a live 'off' environment
[ok]   #2287: without a hoisted value the environment is still read live
```

That is #2130 exactly, and without the precondition it would have shipped as three green arms proving nothing. So the arm now observes the validator's **output** rather than its verdict: `mode=all` prints a `[descriptor]` line even on a clean report, while an unset mode returns before printing anything — so a hoisted `all` against an unset environment produces output that ignoring the parameter **cannot** produce.

## Verification (Windows, MinGW WinLibs UCRT g++ 16.1.0)

| check | result |
| --- | --- |
| `ctest --no-tests=error -j8` | **177 tests, 177 passed, 0 failed** |
| `test_gpu_execute` | exit **0**, 0 `[FAIL]` lines |
| `tools/env/check_cached_env.py prosper` | all checks passed |
| **mutation** — force the hoisted value to be ignored | fails **exactly** the new arm, and correctly leaves its control arm passing |

`test_gpu_execute` is inside the `if(Vulkan_FOUND)` block and is not registered in either of my local build directories, so I linked and ran it by hand against `libprosper_core.a` and the system Vulkan loader. Stating that explicitly because it means the figure above came from a hand-driven build rather than from ctest.

**Not claimed:** a before/after route A/B. #2240's A/B on this title was void — its control channel moved more than the channel under test — and my own getenv-hoist A/B came back within noise. The falsifiable number here is the call count removed, not a frame time.

— Wren
