### PR TITLE
perf(gpu): stop reading back colour nobody asked for, on passes with no colour base

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6039,14 +6039,30 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         nullptr,
                         batch_backend_submits ? &backend_submission : nullptr,
                         pass_i == items.size(), &mrt_outputs,
-                        // #2283: only ask for colour pixels when something will read them. Every
-                        // consumer of the returned vector below is inside an `if (base ...)` guard
-                        // and there is no else, so with base==0 the readback is copied, wrapped in
-                        // a shared_ptr, and dropped. Keyed on the BASE rather than on the draws'
-                        // colour write masks: 457 of 457 such passes are depth-only on this route,
-                        // but that is evidence about this route, and a future title could legally
-                        // mix a colour-writing draw into a pass that has a base.
-                        /*want_color_readback=*/base != 0);
+                        // #2283: only ask for colour pixels when something will read them.
+                        //
+                        // Keyed on the UNION of every bound slot, not on colour-0 alone. Review
+                        // caught that: `gpx`'s only consumer is indeed inside an `if (base ...)`
+                        // pair with no else, but `gpx` is not all the call returns. `mrt_outputs`
+                        // is filled by the same call and its consumer is keyed per slot on
+                        // `pass_bases[slot]`, where an EMPTY vector is not a no-op -- it calls
+                        // `surface.rgba.reset()` and drops that surface's cached pixels.
+                        //
+                        // `mrt_count` does not depend on `base`, so a pass with colour-0 unbound
+                        // and colour-1 bound is reachable by construction -- the same sparse export
+                        // hole the MRT loop already acknowledges, at slot 0 instead of slot 1. On
+                        // `base != 0` alone such a pass would silently lose a live colour-1 RTT.
+                        // Structural rather than observed, which is exactly why the 457/457
+                        // depth-only measurement could not clear it: that evidence is all slot 0.
+                        //
+                        // Depth-only passes have every slot zero, so the win is unchanged.
+                        // Keyed on the base rather than the draws' colour write masks for the
+                        // separate reason that 457/457 is evidence about THIS route, and a future
+                        // title could legally mix a colour-writing draw into a pass that has a base.
+                        /*want_color_readback=*/std::any_of(
+                            pass_bases.begin(),
+                            pass_bases.begin() + std::min<size_t>(mrt_count, pass_bases.size()),
+                            [](uint64_t slot_base) { return slot_base != 0; }));
                     const auto backend_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     const prosper::test::BackendColorTargetStats color_target_call =

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6038,7 +6038,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             : (use_color1 ? render_pass.front()->ps.clear_color1 : nullptr),
                         nullptr,
                         batch_backend_submits ? &backend_submission : nullptr,
-                        pass_i == items.size(), &mrt_outputs);
+                        pass_i == items.size(), &mrt_outputs,
+                        // #2283: only ask for colour pixels when something will read them. Every
+                        // consumer of the returned vector below is inside an `if (base ...)` guard
+                        // and there is no else, so with base==0 the readback is copied, wrapped in
+                        // a shared_ptr, and dropped. Keyed on the BASE rather than on the draws'
+                        // colour write masks: 457 of 457 such passes are depth-only on this route,
+                        // but that is evidence about this route, and a future title could legally
+                        // mix a colour-writing draw into a pass that has a base.
+                        /*want_color_readback=*/base != 0);
                     const auto backend_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     const prosper::test::BackendColorTargetStats color_target_call =

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3015,7 +3015,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                   BackendSubmissionBatch* submission_batch = nullptr,
                                                   bool flush_submission_batch = true,
                                                   std::span<const BackendDraw> logical_ds_draws = {},
-                                                  BackendMrtOutputs* mrt_outputs = nullptr) {
+                                                  BackendMrtOutputs* mrt_outputs = nullptr,
+                                                  // #2283: does the CALLER want colour pixels back?
+                                                  // Not "is there a colour target" -- absent target
+                                                  // already means readback, because then the returned
+                                                  // vector is the only way to get results, which is
+                                                  // how every offscreen test asserts. Defaults true so
+                                                  // every existing caller is bit-identical.
+                                                  bool want_color_readback = true) {
     using TimingClock = std::chrono::steady_clock;
     const bool timing_log_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
     const prosper::frontend::PerformanceTimingMode timing_mode =
@@ -5519,17 +5526,36 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // merely requesting the complete MRT shape must not materialize either GPU-resident image on the
     // CPU. Slots 2+ are currently transient backend attachments, so a caller requesting them through
     // BackendMrtOutputs still needs those planes copied before the images are released.
-    const bool readback_color0 = !persistent_color || color_target->readback;
-    const bool readback_color1 = use_color1 &&
+    // #2283. Split into two questions that used to be one.
+    //
+    // WOULD a readback be requested -- unchanged, and it is what still drives the flush below. The
+    // scope of this change is the COPY only: `readback_requested` also feeds
+    // `synchronous_results_requested` and therefore `flush_now`, which gates persistent attachment
+    // publication. Removing a flush is a real win (each is a queue submit plus a full CPU-GPU fence
+    // wait) and it is a different change with different risk, so it is deliberately NOT taken here.
+    const bool readback_color0_wanted = !persistent_color || color_target->readback;
+    const bool readback_color1_wanted = use_color1 &&
         (!persistent_color1 || color_target->readback1);
-    const bool readback_requested = readback_color0 || readback_color1 || color_count > 2;
+    const bool readback_requested_for_flush =
+        readback_color0_wanted || readback_color1_wanted || color_count > 2;
+
+    // ...and will one actually be PERFORMED. Blue Prince renders 457 depth-only passes with no
+    // colour base per route; every one reads back a fully black surface that the frontend then
+    // never looks at (`live_renderer.cpp:6082`/`:6118` consume the pixels only under `if (base ...)`,
+    // and there is no else). That is up to 8 MB copied and discarded per pass.
+    const bool readback_color0 = want_color_readback && readback_color0_wanted;
+    const bool readback_color1 = want_color_readback && readback_color1_wanted;
+    const bool readback_requested = readback_color0 || readback_color1 ||
+                                    (want_color_readback && color_count > 2);
     const bool storage_writeback_requested = std::any_of(
         texture_uploads.begin(), texture_uploads.end(),
         [](const SharedTextureUpload& upload) {
             return !upload.storage_writebacks.empty();
         });
+    // Deliberately the WOULD-BE value, not the gated one: this change must not alter when the
+    // backend flushes. Verified by the flush-reason counters, which are unchanged in an A/B.
     const bool synchronous_results_requested =
-        readback_requested || storage_writeback_requested;
+        readback_requested_for_flush || storage_writeback_requested;
     const bool flush_now = !submission_batch || synchronous_results_requested ||
                            flush_submission_batch;
     // Attributed in the same order the condition above evaluates, so exactly one bucket is charged
@@ -5538,7 +5564,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     uint64_t flush_reason_storage = 0, flush_reason_explicit = 0;
     if (flush_now) {
         if (!submission_batch) flush_reason_no_batch = 1;
-        else if (readback_requested) flush_reason_readback = 1;
+        // The WOULD-BE value: this bucket answers "why did the backend flush", and the flush is
+        // still caused by a readback being wanted even when #2283 then skips performing it.
+        // Attributing it to `explicit` instead would silently move counts between buckets and make
+        // the flush-reason histogram lie about an unchanged synchronization path.
+        else if (readback_requested_for_flush) flush_reason_readback = 1;
         else if (storage_writeback_requested) flush_reason_storage = 1;
         else flush_reason_explicit = 1;
     }
@@ -7055,14 +7085,16 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
                                               std::vector<uint8_t>* out_rgba1 = nullptr,
                                               BackendSubmissionBatch* submission_batch = nullptr,
                                               bool flush_submission_batch = true,
-                                              BackendMrtOutputs* mrt_outputs = nullptr) {
+                                              BackendMrtOutputs* mrt_outputs = nullptr,
+                                              bool want_color_readback = true) {   // #2283
     const std::span<const BackendDraw> all(draws);
     if (!persist_depth_stencil ||
         depth_feedback_split_index(all, W, H) == all.size())
         return render_draw_pass_rgba(all, W, H, seed_rgba, clear_rgba,
                                      persist_depth_stencil, color_target, seed_rgba1,
                                      clear_rgba1, out_rgba1, submission_batch,
-                                     flush_submission_batch, {}, mrt_outputs);
+                                     flush_submission_batch, {}, mrt_outputs,
+                                     want_color_readback);
 
     BackendColorTargetStats aggregate_color{};
     BackendTextureUploadStats aggregate_textures{};
@@ -7204,7 +7236,7 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             begin ? nullptr : clear_rgba, true, segment_target_ptr, next_seed1,
             begin ? nullptr : clear_rgba1, segment_out1, submission_batch,
             final ? flush_submission_batch : false, all,
-            final ? mrt_outputs : nullptr);
+            final ? mrt_outputs : nullptr, want_color_readback);
         add_stats();
 
         if (final) {


### PR DESCRIPTION
Refs #2283. **Needs a visual check I could not perform on this lane — see the last section before approving.**

## What

Every pass rendered without a colour-0 base reads back a full RGBA surface that the frontend never looks at. `live_renderer.cpp` consumes the returned pixels only inside `if (base && color_target_call.writes)` (`:6082`) and `else if (base && …)` (`:6118`) — **there is no else**, so with `base == 0` the readback is copied, wrapped in a `shared_ptr`, and dropped. #2283 measured **16.9 GB discarded in three minutes**.

## Why the obvious guard is wrong

Skipping the readback whenever the colour target is absent would **break every offscreen test**, and the code says why:

```cpp
const bool readback_color0 = !persistent_color || color_target->readback;
```

`!persistent_color` defaults to readback *because* without a persistent target the returned vector is the only way to get results — which is exactly how `test_*_render.cpp` asserts pixels. The signal is not "no target", it is **"the caller does not want the pixels"**. So this adds `want_color_readback` (defaulting `true`, so every existing caller is bit-identical) and the live renderer passes `base != 0`.

**Keyed on the base, not on the draws' colour write masks.** 457 of 457 such passes are depth-only on this route — measured with #2352's `cwm_draws=` — which is *why* the readback cannot be carrying a result. But that is evidence about this route, and a future title could legally mix a colour-writing draw into a pass that has a base. Keying on the base keeps the two independent.

## Scope: the copy only, and the flush is deliberately untouched

`readback_requested` also fed `synchronous_results_requested` → `flush_now`, which gates persistent attachment publication. The would-be value is now preserved separately and still drives both the flush **and its reason bucket**; only the copy is skipped.

| cumulative backend-submit | master | this branch |
| --- | ---: | ---: |
| `readback` ms | 0.92 | **0.00** |
| `fence_waits`/submit | 4.30 | 4.58 |
| `flush{readback}` | 0.60 | 0.90 |
| `flush{explicit}` | 3.70 | 3.68 |

Flush counts and reasons unchanged within phase variation — that invariant is what this scope rests on. An earlier draft of mine moved counts from the readback bucket into `explicit`; that was a diagnostic regression and is fixed.

**Removing the flush is the larger prize** — each is a queue submit plus a full CPU↔GPU fence wait — and it belongs in its own reviewed change with its own evidence.

## What I could NOT establish, and why I am not claiming it

**Visual equivalence.** My capture point (frame 900) is **fully black on master as well**, so it is not a control — I checked master specifically rather than assuming, and later scheduled captures did not fire within the run. A frame grab on this branch reads **0.2% non-black / 573 distinct colours** against an older master capture's **0.2% / 607**, which corroborates but is not a controlled before/after: different moments, different runs.

So the reasoning for safety is structural (no consumer, 457/457 depth-only, flush invariant held) and **not** demonstrated by pixels. Given that, this should not merge on my evidence alone. The Linux lane's snapshot guard is the right check — #2273 records that `blue-prince-hall` cannot pass on the Windows lane, which is precisely why I cannot run it here.

## Verification (Windows, MinGW WinLibs UCRT g++ 16.1.0)

`ctest --no-tests=error -j8` → **177 tests, 177 passed, 0 failed**.

— Wren
