### PR TITLE
fix(gpu): 2D_ARRAY image atomics — one shared shape predicate, and the layer reaches the index

### DIFF
--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -488,11 +488,15 @@ One line per falsified hypothesis, with the evidence that killed it.
   `skip invalid descriptor contract` line goes 1 -> **0**, the 20 `[compute-descriptor]` issues go to
   **0**, and the staging trace reports `atomic-image buffer binding=37 ... bytes=66355200` **164
   times** -- `3840*2160*2*4`, i.e. both layers, where a single-layer staging would read 33,177,600.
-  **The presented frame is unchanged.** `tools/screenshot`, default launch, `--seconds 8 --count 9`,
-  9 frames: composite CRCs are `666f7b3f` (x4) and `0d70a70a` (x5), **both already recorded above as
-  master values**, and the frames still show the SEGA logo on black. So the uniform-composite
-  frontier is not the compute inventory: five restored programs across two sessions have now left it
-  byte-identical. Look elsewhere before spending on the three remaining `skip unsupported program`
+  **The presented frame is byte-identical to master across the whole documented route.**
+  `tools/screenshot`, default launch, `--seconds 30 --count 9` (270 s -- the same arm as the composite
+  row above): all **three** master states reproduce exactly, `666f7b3f` (x1), `0d70a70a` (x1) and
+  `8bf1b518` (x7). Frames were opened rather than judged by hash: `666f7b3f` and `8bf1b518` are both
+  black (different CRCs, visually identical) and `0d70a70a` is the SEGA logo on black, so the route
+  is black -> logo -> black and stays there. **Match the window to the claim:** a first pass at
+  `--seconds 8 --count 9` (72 s) ends on the logo and never reaches `8bf1b518` at all, so it cannot
+  speak to the post-logo state that #2013 is about -- the arm was re-run at 270 s for that reason.
+  Five restored programs across two sessions have now left the composite byte-identical. Look elsewhere before spending on the three remaining `skip unsupported program`
   entries -- their restoration is worth doing on the charter's own grounds, but it should not be
   expected to change the picture. #2356, Refs #2265 / #2013.
 

--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -481,6 +481,21 @@ that leaves the caller's output buffer untouched, so the guest reads whatever wa
 
 One line per falsified hypothesis, with the evidence that killed it.
 
+- **RESTORING THE LAYERED ATOMIC DISPATCH DOES NOT MOVE THE COMPOSITE.** #2265's full-screen
+  `IMAGE_ATOMIC_ADD` dispatch was the strongest remaining candidate -- it writes the image the
+  presented frame is composed from, and unlike the four programs restored before it, it covers the
+  whole screen. With the fix (#2356) the gap is provably closed on a live boot: the
+  `skip invalid descriptor contract` line goes 1 -> **0**, the 20 `[compute-descriptor]` issues go to
+  **0**, and the staging trace reports `atomic-image buffer binding=37 ... bytes=66355200` **164
+  times** -- `3840*2160*2*4`, i.e. both layers, where a single-layer staging would read 33,177,600.
+  **The presented frame is unchanged.** `tools/screenshot`, default launch, `--seconds 8 --count 9`,
+  9 frames: composite CRCs are `666f7b3f` (x4) and `0d70a70a` (x5), **both already recorded above as
+  master values**, and the frames still show the SEGA logo on black. So the uniform-composite
+  frontier is not the compute inventory: five restored programs across two sessions have now left it
+  byte-identical. Look elsewhere before spending on the three remaining `skip unsupported program`
+  entries -- their restoration is worth doing on the charter's own grounds, but it should not be
+  expected to change the picture. #2356, Refs #2265 / #2013.
+
 - **THE DESCRIPTOR-CONTRACT SKIP IS NOT A STALE CACHED SPIR-V.** The hypothesis was that the program
   compiled once against a single-layer resolution, was cached by `recompile_compute_shader_cached`,
   and is validated on later dispatches against the two-layer resource -- which would make it a

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2305,6 +2305,8 @@ struct BoundBuffer {
     size_t guest_bytes = 0;             // physical guest backing (may exceed logical image bytes)
     bool writable = false;              // reflected OpStore/writing-atomic reachability
     bool atomic_image = false;           // R32_UINT StorageImage exposed as a linear atomic SSBO
+    uint32_t atomic_layers = 1;          // #2265: array layers staged for that view (1 when plain 2D)
+    size_t atomic_slice_bytes = 0;       // physical guest bytes PER LAYER (tiled slices are padded)
     bool persistent = false;
     bool upload_skipped = false;
     VkBuffer result_baseline = VK_NULL_HANDLE;
@@ -4298,22 +4300,31 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             "invalid storage-buffer materialization contract");
                 break;
             }
+            // #2265: one shared shape test with the lowering gate and the descriptor validator.
             buffers[i].atomic_image = descriptors[i].atomic_access &&
-                resource->cls == ResourceClass::StorageImage &&
-                resource->format == DataFormat::Uint32 && resource->num_components == 1 &&
-                resource->img_dim == 1 && resource->depth == 1 &&
-                !resource->depth_compare && !resource->in_mip_tail &&
-                !resource->compression_enabled && resource->width && resource->height;
+                shader_resource_supports_atomic_image_buffer(*resource);
+            buffers[i].atomic_layers = buffers[i].atomic_image
+                ? shader_resource_atomic_image_layers(*resource) : 1u;
+            // LOGICAL staging extent -- what the shader indexes, tightly packed across layers.
             const uint64_t linear_image_bytes = static_cast<uint64_t>(resource->width) *
-                resource->height * sizeof(uint32_t);
+                resource->height * buffers[i].atomic_layers * sizeof(uint32_t);
             if (buffers[i].atomic_image) {
                 const size_t tight_pitch = static_cast<size_t>(resource->width) * sizeof(uint32_t);
-                const size_t guest_image_bytes = resource->tile_mode
+                // PHYSICAL slice footprint. Deliberately NOT the logical w*h*4: a tiled slice is a
+                // padded, 64 KiB-aligned unit, so using the logical size here would under-bound the
+                // readability probe and the detile source would walk past the region proven
+                // readable. Measured for CrossWorlds' (3840, 2160, bpe 4, tile 27): physical
+                // 33,423,360 against logical 33,177,600, and tiled_mip_chain_bytes -- which is
+                // documented as the array slice stride -- returns the same 33,423,360, so the two
+                // candidate strides agree and the slice needs no further alignment.
+                buffers[i].atomic_slice_bytes = resource->tile_mode
                     ? tiled_surface_bytes(resource->width, resource->height,
                                           resource->tile_mode, 0, sizeof(uint32_t))
                     : (resource->linear_row_pitch_bytes
                            ? static_cast<size_t>(resource->linear_row_pitch_bytes)
                            : tight_pitch) * resource->height;
+                const size_t guest_image_bytes =
+                    buffers[i].atomic_slice_bytes * buffers[i].atomic_layers;
                 if (linear_image_bytes > UINT32_MAX ||
                     (!resource->tile_mode && resource->linear_row_pitch_bytes &&
                      resource->linear_row_pitch_bytes < tight_pitch) ||
@@ -4339,6 +4350,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (!prior || prior->gpu_addr != resource->gpu_addr ||
                     prior->size != resource->size ||
                     buffers[j].atomic_image != buffers[i].atomic_image ||
+                    // #2265: two views of one allocation that differ only in layering must not
+                    // alias -- their linear staging has a different shape even when the byte
+                    // totals coincide.
+                    buffers[j].atomic_layers != buffers[i].atomic_layers ||
+                    buffers[j].atomic_slice_bytes != buffers[i].atomic_slice_bytes ||
                     buffers[j].bytes != buffers[i].bytes ||
                     buffers[j].guest_bytes != buffers[i].guest_bytes ||
                     prior->host_data != resource->host_data ||
@@ -4357,17 +4373,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     : resource_bytes(resource);
                 if (buffers[i].atomic_image) {
                     buffers[i].linear_seed.resize(buffers[i].bytes);
-                    if (resource->tile_mode) {
-                        detile_surface(buffers[i].linear_seed.data(), source,
-                                       resource->width, resource->height,
-                                       resource->tile_mode, 0, sizeof(uint32_t));
-                    } else {
-                        const size_t tight_pitch = static_cast<size_t>(resource->width) * 4u;
-                        const size_t source_pitch = resource->linear_row_pitch_bytes
-                            ? resource->linear_row_pitch_bytes : tight_pitch;
-                        for (uint32_t y = 0; y < resource->height; ++y)
-                            std::memcpy(buffers[i].linear_seed.data() + y * tight_pitch,
-                                        source + y * source_pitch, tight_pitch);
+                    // #2265: per-layer 2D detile at the physical slice stride, into a tightly
+                    // packed linear volume. Deliberately NOT detile_volume(): that is for a 3D
+                    // texture, where Z participates in the mode-27 pipe-XOR swizzle. A 2D_ARRAY's
+                    // slices are independently tiled 2D surfaces separated by a stride, so using
+                    // the volume path here would compile, run, and produce plausible garbage.
+                    const size_t layer_linear_bytes =
+                        static_cast<size_t>(resource->width) * resource->height * 4u;
+                    for (uint32_t layer = 0; layer < buffers[i].atomic_layers; ++layer) {
+                        uint8_t* dst = buffers[i].linear_seed.data() + layer * layer_linear_bytes;
+                        const uint8_t* src = source + layer * buffers[i].atomic_slice_bytes;
+                        if (resource->tile_mode) {
+                            detile_surface(dst, src, resource->width, resource->height,
+                                           resource->tile_mode, 0, sizeof(uint32_t));
+                        } else {
+                            const size_t tight_pitch = static_cast<size_t>(resource->width) * 4u;
+                            const size_t source_pitch = resource->linear_row_pitch_bytes
+                                ? resource->linear_row_pitch_bytes : tight_pitch;
+                            for (uint32_t y = 0; y < resource->height; ++y)
+                                std::memcpy(dst + y * tight_pitch,
+                                            src + y * source_pitch, tight_pitch);
+                        }
                     }
                     source = buffers[i].linear_seed.data();
                     if (trace)
@@ -7427,17 +7453,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 if (!buffer.resource->host_data && buffer.resource->gpu_addr)
                     prosper::host::guest_write_watch_notify_host_write(
                         buffer.resource->gpu_addr, buffer.guest_bytes);
-                if (buffer.resource->tile_mode) {
-                    tile_surface(destination, result,
-                                 buffer.resource->width, buffer.resource->height,
-                                 buffer.resource->tile_mode, 0, sizeof(uint32_t));
-                } else {
-                    const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
-                    const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
-                        ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
-                    for (uint32_t y = 0; y < buffer.resource->height; ++y)
-                        std::memcpy(destination + y * destination_pitch,
-                                    result + y * tight_pitch, tight_pitch);
+                // #2265: mirror of the upload -- per-layer 2D retile at the physical slice stride.
+                const size_t layer_linear_bytes =
+                    static_cast<size_t>(buffer.resource->width) * buffer.resource->height * 4u;
+                for (uint32_t layer = 0; layer < buffer.atomic_layers; ++layer) {
+                    uint8_t* dst = destination + layer * buffer.atomic_slice_bytes;
+                    const uint8_t* src = result + layer * layer_linear_bytes;
+                    if (buffer.resource->tile_mode) {
+                        tile_surface(dst, src, buffer.resource->width, buffer.resource->height,
+                                     buffer.resource->tile_mode, 0, sizeof(uint32_t));
+                    } else {
+                        const size_t tight_pitch = static_cast<size_t>(buffer.resource->width) * 4u;
+                        const size_t destination_pitch = buffer.resource->linear_row_pitch_bytes
+                            ? buffer.resource->linear_row_pitch_bytes : tight_pitch;
+                        for (uint32_t y = 0; y < buffer.resource->height; ++y)
+                            std::memcpy(dst + y * destination_pitch,
+                                        src + y * tight_pitch, tight_pitch);
+                    }
                 }
                 ctx.unmap_memory(buffer.memory);
                 if (buffer.resource->gpu_addr)

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10207,15 +10207,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // had not. `res->depth` is the layer COUNT for an arrayed view, so it is required to
                 // be exactly 1 only in the non-arrayed case.
                 const bool atomic_2d_array = in.mimg_dim == SQ_DIM_2D_ARRAY && arrayed && !ms;
+                // #2265: the RESOURCE half is now shader_resource_supports_atomic_image_buffer,
+                // shared with the descriptor validator and the backend materialization. Those three
+                // had drifted -- #2272 widened this gate over the array layer and left the other
+                // two on the single-layer clause, so this lowering emitted a StorageBuffer binding
+                // that its own validator then rejected as WrongType and the dispatch was skipped
+                // every frame. The INSTRUCTION half stays here, because only this site sees it.
                 if (is_atomic &&
                     ((in.mimg_dim != SQ_DIM_2D && !atomic_2d_array) || ms || in.len_dwords < 2 ||
                      in.mimg_unorm || in.mimg_dmask != 1u ||
-                     (!arrayed && (res->img_dim != 1u || res->depth != 1u)) ||
-                     (arrayed && (res->img_dim != SQ_DIM_2D_ARRAY || !res->depth)) ||
-                     res->depth_compare ||
-                     res->format != DataFormat::Uint32 || components != 1u ||
-                     !res->width || !res->height || res->in_mip_tail ||
-                     res->compression_enabled)) {
+                     arrayed != (res->img_dim == SQ_DIM_2D_ARRAY) ||
+                     !shader_resource_supports_atomic_image_buffer(*res))) {
                     ok = false;
                     return true;
                 }
@@ -10294,12 +10296,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint16_t atomic_op = spirv_atomic;
                     uint32_t result;
                     if (compute_atomic_buffer) {
+                        // #2265: the backend stages an arrayed view as layers tightly packed in
+                        // layer-major order (live_compute.cpp detiles each slice from its physical
+                        // stride into w*h*4 of linear), so the flat index is
+                        // (z*height + y)*width + x. The layer MUST be in the bound as well as the
+                        // index: Vulkan leaves an out-of-bounds image atomic undefined, robust
+                        // buffer access does not cover atomics, and the 2D path's own comment
+                        // records that RADV can spend seconds in one before resetting the device.
+                        const uint32_t row = arrayed
+                            ? b.ibin(Op_IAdd, coords[1],
+                                     b.ibin(Op_IMul, coords[2], b.uconst(res->height)))
+                            : coords[1];
                         const uint32_t index = b.ibin(
                             Op_IAdd, coords[0],
-                            b.ibin(Op_IMul, coords[1], b.uconst(res->width)));
+                            b.ibin(Op_IMul, row, b.uconst(res->width)));
                         uint32_t active = b.land(
                             b.ucmp(Op_ULessThan, coords[0], b.uconst(res->width)),
                             b.ucmp(Op_ULessThan, coords[1], b.uconst(res->height)));
+                        if (arrayed)
+                            active = b.land(active,
+                                            b.ucmp(Op_ULessThan, coords[2],
+                                                   b.uconst(res->depth ? res->depth : 1u)));
                         if (rs.exec_narrowed) active = b.land(rs.exec, active);
                         result = b.cbuf_atomic_rtn(
                             atomic_op, index, vread(vd), res->binding,
@@ -16027,9 +16044,18 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                                msaa_address_shape;
                     }
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
-                    if (i.opcode == 0x0fu || i.opcode == 0x11u)                // image_atomic_swap/add R32_UINT 2D
-                        return i.mimg_dim == 1u && i.mimg_dmask == 1u &&
-                               !i.mimg_unorm && i.len_dwords == 2u;
+                    if (i.opcode == 0x0fu || i.opcode == 0x11u)   // image_atomic_swap/add R32_UINT 2D / 2D_ARRAY
+                        // #2265: 2D_ARRAY (dim 5) admitted alongside 2D. This is the COVERAGE
+                        // predicate -- it decides whether the instruction counts as supported for
+                        // the census, and it was the last of the four sites still reporting the
+                        // arrayed form as unsupported after #2272 widened the lowering. A 2D_ARRAY
+                        // arrayed atomic reaches its layer through the address VGPRs, not through a
+                        // longer ENCODING: CrossWorlds' own instruction is `dim=5 ... len=2`, so
+                        // `len_dwords` is the NSA-vs-packed encoding length and pinning it to 3 for
+                        // dim 5 would reject exactly the instruction this admits. Matches the
+                        // lowering gate, which rejects only `len_dwords < 2`.
+                        return (i.mimg_dim == 1u || i.mimg_dim == 5u) && i.mimg_dmask == 1u &&
+                               !i.mimg_unorm && i.len_dwords >= 2u;
                     if (i.opcode == 0x0eu) return i.mimg_dim <= 2u;             // image_get_resinfo 1D/2D/3D
                     if (i.opcode == 0x60u)                                     // fragment image_get_lod 2D
                         return i.mimg_dim == 1u && i.len_dwords == 2u &&

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10303,6 +10303,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         // index: Vulkan leaves an out-of-bounds image atomic undefined, robust
                         // buffer access does not cover atomics, and the 2D path's own comment
                         // records that RADV can spend seconds in one before resetting the device.
+                        //
+                        // `width`, `height` and `depth` are baked into the module as OpConstants,
+                        // which is only safe because all three are part of the shader cache key, so
+                        // a module compiled for one extent can never be reused against a smaller
+                        // one: `gpu_executor.cpp` sets `compiled.width`/`height` under
+                        // `atomic_extent` (an R32_UINT single-component storage image -- exactly
+                        // this case) and `compiled.depth`/`img_dim` under `storage_image`, and
+                        // `ShaderResourceCompileKey` has a defaulted member-wise `operator==`. Check
+                        // that still holds before baking a fourth quantity in here.
                         const uint32_t row = arrayed
                             ? b.ibin(Op_IAdd, coords[1],
                                      b.ibin(Op_IMul, coords[2], b.uconst(res->height)))

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -1023,15 +1023,18 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         }
         const ShaderResource& r = *matches.front();
         SpirvDescriptorKind actual = resource_kind(r);
+        // #2265: the shape test is shared with the lowering gate and the backend materialization so
+        // the three cannot drift again -- see shader_resource_supports_atomic_image_buffer. The size
+        // bound is LOGICAL (width*height*layers*4): a descriptor's `size` is the linear extent, not
+        // the tiled physical footprint, which is larger. Measured on CrossWorlds' 3840x2160x2 R32
+        // image: size = 66,355,200 = w*h*depth*4 exactly, while the tiled footprint is 66,846,720.
         const bool atomic_image_buffer =
             expected_stage == SpirvShaderStage::Compute &&
             d.kind == SpirvDescriptorKind::StorageBuffer && d.atomic_access &&
             actual == SpirvDescriptorKind::StorageImage &&
-            r.format == DataFormat::Uint32 && r.num_components == 1 &&
-            r.img_dim == 1 && r.depth == 1 && !r.depth_compare &&
-            !r.in_mip_tail && !r.compression_enabled &&
-            r.width && r.height &&
-            static_cast<uint64_t>(r.width) * r.height * sizeof(uint32_t) <= r.size;
+            shader_resource_supports_atomic_image_buffer(r) &&
+            static_cast<uint64_t>(r.width) * r.height *
+                    shader_resource_atomic_image_layers(r) * sizeof(uint32_t) <= r.size;
         if (actual != d.kind && !atomic_image_buffer) {
             report.issues.push_back({DescriptorIssueCode::WrongType, true, d.set, d.binding,
                                      d.kind, actual, d.required_bytes, r.size});

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -361,6 +361,38 @@ constexpr bool shader_resource_uses_native_2d_storage_image(
             !resource.depth_compare);
 }
 
+// The RESOURCE half of "may this R32_UINT storage image be lowered to a detiled linear atomic SSBO"
+// (the RADV image-atomic workaround: RADV hangs/reset-poisons the device on a compute R32_UINT image
+// atomic, so compute reaches the image through a buffer view instead).
+//
+// This lives in one place because it has already drifted twice. #2293 was titled "the image-atomic
+// opcode list existed in THREE places and all three had to agree"; #2272 then generalised the
+// LOWERING gate over the array layer and left the descriptor validator and the backend
+// materialization on the single-layer clause, so a shader compiled into a binding its own validator
+// rejected -- Sonic Racing: CrossWorlds' full-screen dispatch, skipped every frame (#2265). Callers
+// add their own INSTRUCTION-side conditions (dmask, unorm, length); this answers only the question
+// that every site was answering separately and differently.
+//
+// `depth` is the layer COUNT for an arrayed view, so it is pinned to 1 only in the non-arrayed case;
+// dim 5 is SQ 2D_ARRAY. A layered resource additionally requires the caller to stage every layer --
+// see shader_resource_atomic_image_layers below, and note that the slice stride is NOT
+// width*height*bpe for a tiled surface.
+constexpr bool shader_resource_supports_atomic_image_buffer(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::StorageImage &&
+           resource.format == DataFormat::Uint32 &&
+           (resource.num_components ? resource.num_components : 1u) == 1u &&
+           (resource.img_dim == 1u ? resource.depth == 1u
+                                   : (resource.img_dim == 5u && resource.depth >= 1u)) &&
+           !resource.depth_compare && !resource.in_mip_tail &&
+           !resource.compression_enabled && resource.width && resource.height;
+}
+
+// Layer count to stage for such a resource: an arrayed view carries `depth` layers, a plain 2D one
+// carries exactly one regardless of what `depth` happens to hold.
+constexpr uint32_t shader_resource_atomic_image_layers(const ShaderResource& resource) {
+    return resource.img_dim == 5u ? (resource.depth ? resource.depth : 1u) : 1u;
+}
+
 // A null BVH is represented by a bounded host-owned marker. The front-half creates this only after
 // proving that a mapped zero pointer feeds the complete descriptor inside an EXEC-guarded region.
 // The exact shape survives capture/replay without adding a capture-format field and cannot alias a

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3545,12 +3545,26 @@ int main() {
         }
         printf("  [ok]   2D_ARRAY image_atomic_add recompiles AND validates as an atomic buffer\n");
 
-        // Scan the constant pool for a 32-bit OpConstant with this literal.
-        const auto has_u32_constant = [](const std::vector<uint32_t>& spv, uint32_t value) {
+        // Is `value` used as a MULTIPLIER -- does some OpIMul take the constant carrying it?
+        //
+        // Mere PRESENCE of the constant is not a discriminator, and assuming it was is how two
+        // earlier versions of this arm passed while the layer was deleted from the index: the
+        // bounds check `coords[1] < height` already puts `height` in the constant pool, so it is
+        // there either way. Only the arrayed index MULTIPLIES by it, in (z*height + y).
+        const auto multiplies_by = [](const std::vector<uint32_t>& spv, uint32_t value) {
+            uint32_t constant_id = 0;
             for (size_t w = 5; w + 1 < spv.size();) {
                 const uint32_t count = spv[w] >> 16, op = spv[w] & 0xffffu;
                 if (!count || w + count > spv.size()) break;
-                if (op == 43u && count == 4u && spv[w + 3] == value) return true;
+                if (op == 43u && count == 4u && spv[w + 3] == value) { constant_id = spv[w + 2]; break; }
+                w += count;
+            }
+            if (!constant_id) return false;
+            for (size_t w = 5; w + 1 < spv.size();) {
+                const uint32_t count = spv[w] >> 16, op = spv[w] & 0xffffu;
+                if (!count || w + count > spv.size()) break;
+                if (op == 132u && count == 5u &&                      // OpIMul
+                    (spv[w + 3] == constant_id || spv[w + 4] == constant_id)) return true;
                 w += count;
             }
             return false;
@@ -3560,14 +3574,16 @@ int main() {
         // x + y*width for every layer, every layer aliases layer 0, and the dispatch produces a
         // silently wrong result rather than being skipped: strictly worse than the bug it replaces.
         // `height` (3) appears only if the layer was multiplied in.
-        if (!has_u32_constant(layered_spv, 97u)) {
+        if (!multiplies_by(layered_spv, 97u)) {
             printf("  [FAIL] the 2D_ARRAY atomic index does not multiply by height -- every layer "
                    "aliases layer 0\n");
             return 1;
         }
-        if (has_u32_constant(atomic_add_spv, 97u)) {
-            printf("  [FAIL] the discriminator is void: the NON-arrayed module also carries the "
-                   "height constant, so its presence proves nothing\n");
+        // Paired negative, so the discriminator's own validity is checked rather than assumed:
+        // the 1x1 non-arrayed fixture must NOT multiply by its own height.
+        if (multiplies_by(atomic_add_spv, 1u)) {
+            printf("  [FAIL] the discriminator is void: the NON-arrayed index also multiplies by "
+                   "its height, so the arrayed result proves nothing\n");
             return 1;
         }
         printf("  [ok]   the layer reaches the index (height constant present only when arrayed)\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3514,14 +3514,17 @@ int main() {
             0xf0442128u, 0x00000900u,
             0xbf810000u,
         };
-        // Distinct width and height so "did the layer stride enter the index" is decidable from the
-        // constant pool: the 2D index is x + y*width and never needs `height`, while the arrayed
-        // index is x + (z*height + y)*width and must multiply by it.
+        // Height is 97 -- prime, and chosen so its appearance in the constant pool CANNOT be
+        // incidental. The first version of this arm used height 3 and was VOID: a 3 occurs in the
+        // module for unrelated reasons, so deleting the layer from the index left the arm passing.
+        // The discriminator is only as good as the improbability of the constant it looks for.
+        // The 2D index is x + y*width and never needs `height`; the arrayed index is
+        // x + (z*height + y)*width and cannot avoid it.
         ShaderResourceTable rt_layered;
-        std::vector<uint32_t> layered_backing(4u * 3u * 2u, 0u);
+        std::vector<uint32_t> layered_backing(5u * 97u * 2u, 0u);
         { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
           image.format = DataFormat::Uint32; image.num_components = 1;
-          image.binding = 4; image.img_dim = 5; image.width = 4; image.height = 3;
+          image.binding = 4; image.img_dim = 5; image.width = 5; image.height = 97;
           image.depth = 2; image.sgpr_base = 0;
           image.size = layered_backing.size() * sizeof(uint32_t);
           image.host_data = reinterpret_cast<uint8_t*>(layered_backing.data());
@@ -3557,12 +3560,12 @@ int main() {
         // x + y*width for every layer, every layer aliases layer 0, and the dispatch produces a
         // silently wrong result rather than being skipped: strictly worse than the bug it replaces.
         // `height` (3) appears only if the layer was multiplied in.
-        if (!has_u32_constant(layered_spv, 3u)) {
+        if (!has_u32_constant(layered_spv, 97u)) {
             printf("  [FAIL] the 2D_ARRAY atomic index does not multiply by height -- every layer "
                    "aliases layer 0\n");
             return 1;
         }
-        if (has_u32_constant(atomic_add_spv, 3u)) {
+        if (has_u32_constant(atomic_add_spv, 97u)) {
             printf("  [FAIL] the discriminator is void: the NON-arrayed module also carries the "
                    "height constant, so its presence proves nothing\n");
             return 1;
@@ -3572,7 +3575,7 @@ int main() {
         // MUTATION ARM 2 -- the layer must reach the SIZE BOUND. A backing sized for one layer must
         // be rejected; the pre-#2265 check was width*height*4 <= size and would accept it.
         ShaderResourceTable one_layer_backing = rt_layered;
-        one_layer_backing.resources[0].size = 4u * 3u * sizeof(uint32_t);
+        one_layer_backing.resources[0].size = 5u * 97u * sizeof(uint32_t);
         if (validate_spirv_descriptor_interface(layered_spv, &one_layer_backing, 0,
                                                 SpirvShaderStage::Compute, false).ok()) {
             printf("  [FAIL] a two-layer atomic image was accepted against one layer of backing\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3579,11 +3579,26 @@ int main() {
                    "aliases layer 0\n");
             return 1;
         }
-        // Paired negative, so the discriminator's own validity is checked rather than assumed:
-        // the 1x1 non-arrayed fixture must NOT multiply by its own height.
-        if (multiplies_by(atomic_add_spv, 1u)) {
-            printf("  [FAIL] the discriminator is void: the NON-arrayed index also multiplies by "
-                   "its height, so the arrayed result proves nothing\n");
+        // Paired negative, so the discriminator's validity is checked rather than assumed -- and it
+        // must use the SAME distinctive constant, on a NON-arrayed shader, or it tests nothing. An
+        // earlier version asked whether the 1x1 fixture multiplies by 1; it does, because 1 is
+        // multiplied all over any module, and that arm then failed on correct code. Here the shape
+        // is 5x97 and non-arrayed, so 97 is present as a bound and must NOT be a multiplier: the 2D
+        // index is x + y*width and reaches only the WIDTH.
+        ShaderResourceTable rt_tall_2d;
+        std::vector<uint32_t> tall_backing(5u * 97u, 0u);
+        { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+          image.format = DataFormat::Uint32; image.num_components = 1;
+          image.binding = 4; image.img_dim = 1; image.width = 5; image.height = 97;
+          image.depth = 1; image.sgpr_base = 0;
+          image.size = tall_backing.size() * sizeof(uint32_t);
+          image.host_data = reinterpret_cast<uint8_t*>(tall_backing.data());
+          image.host_data_size = image.size; rt_tall_2d.resources.push_back(image); }
+        const std::vector<uint32_t> tall_2d_spv = recompile_compute(
+            cs_image_atomic_add, std::size(cs_image_atomic_add), &rt_tall_2d, atomic_add_config);
+        if (tall_2d_spv.empty() || multiplies_by(tall_2d_spv, 97u)) {
+            printf("  [FAIL] the discriminator is void: a NON-arrayed 5x97 index also multiplies by "
+                   "97, so the arrayed result proves nothing\n");
             return 1;
         }
         printf("  [ok]   the layer reaches the index (height constant present only when arrayed)\n");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -3496,6 +3496,91 @@ int main() {
         return 1;
     }
     printf("  [ok]   compute atomic-buffer view rejects an undersized image backing\n");
+
+    // --- #2265: IMAGE_ATOMIC_ADD on a 2D_ARRAY R32_UINT image ----------------------------------
+    // Sonic Racing: CrossWorlds issues this on a default launch against a two-layer 3840x2160 R32
+    // image and the whole full-screen dispatch was skipped every frame. The cause was not a missing
+    // feature: #2272 widened the LOWERING gate over the array layer while the descriptor validator
+    // and the backend materialization kept the single-layer clause, so the recompiler emitted a
+    // StorageBuffer binding that its own validator rejected as WrongType.
+    //
+    // The instruction is the 2D fixture above with DIM changed from 1 to 5. `mimg_dim` is
+    // `(word0 >> 3) & 0x7` (rdna2_decode.cpp:675), so bits [5:3] go 001 -> 101 and the low byte goes
+    // 0x08 -> 0x28 -- which is exactly the low byte of CrossWorlds' own `f0440128`. Its `len` is 2,
+    // not 3: an arrayed atomic reaches its layer through the address VGPRs, not a longer encoding.
+    {
+        const uint32_t cs_atomic_add_2d_array[] = {
+            0x7e000280u, 0x7e020280u, 0x7e120281u,
+            0xf0442128u, 0x00000900u,
+            0xbf810000u,
+        };
+        // Distinct width and height so "did the layer stride enter the index" is decidable from the
+        // constant pool: the 2D index is x + y*width and never needs `height`, while the arrayed
+        // index is x + (z*height + y)*width and must multiply by it.
+        ShaderResourceTable rt_layered;
+        std::vector<uint32_t> layered_backing(4u * 3u * 2u, 0u);
+        { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+          image.format = DataFormat::Uint32; image.num_components = 1;
+          image.binding = 4; image.img_dim = 5; image.width = 4; image.height = 3;
+          image.depth = 2; image.sgpr_base = 0;
+          image.size = layered_backing.size() * sizeof(uint32_t);
+          image.host_data = reinterpret_cast<uint8_t*>(layered_backing.data());
+          image.host_data_size = image.size; rt_layered.resources.push_back(image); }
+
+        const std::vector<uint32_t> layered_spv = recompile_compute(
+            cs_atomic_add_2d_array, std::size(cs_atomic_add_2d_array),
+            &rt_layered, atomic_add_config);
+        const DescriptorValidationReport layered_report = validate_spirv_descriptor_interface(
+            layered_spv, &rt_layered, 0, SpirvShaderStage::Compute, false);
+        if (layered_spv.empty() || !layered_report.ok() ||
+            layered_report.descriptors.size() != 1 ||
+            layered_report.descriptors[0].kind != SpirvDescriptorKind::StorageBuffer ||
+            !layered_report.descriptors[0].atomic_access) {
+            printf("  [FAIL] 2D_ARRAY image_atomic_add did not recompile into an accepted "
+                   "atomic-buffer contract (this is the #2265 skip)\n");
+            return 1;
+        }
+        printf("  [ok]   2D_ARRAY image_atomic_add recompiles AND validates as an atomic buffer\n");
+
+        // Scan the constant pool for a 32-bit OpConstant with this literal.
+        const auto has_u32_constant = [](const std::vector<uint32_t>& spv, uint32_t value) {
+            for (size_t w = 5; w + 1 < spv.size();) {
+                const uint32_t count = spv[w] >> 16, op = spv[w] & 0xffffu;
+                if (!count || w + count > spv.size()) break;
+                if (op == 43u && count == 4u && spv[w + 3] == value) return true;
+                w += count;
+            }
+            return false;
+        };
+
+        // MUTATION ARM 1 -- the layer must reach the INDEX. Without it the lowering computes
+        // x + y*width for every layer, every layer aliases layer 0, and the dispatch produces a
+        // silently wrong result rather than being skipped: strictly worse than the bug it replaces.
+        // `height` (3) appears only if the layer was multiplied in.
+        if (!has_u32_constant(layered_spv, 3u)) {
+            printf("  [FAIL] the 2D_ARRAY atomic index does not multiply by height -- every layer "
+                   "aliases layer 0\n");
+            return 1;
+        }
+        if (has_u32_constant(atomic_add_spv, 3u)) {
+            printf("  [FAIL] the discriminator is void: the NON-arrayed module also carries the "
+                   "height constant, so its presence proves nothing\n");
+            return 1;
+        }
+        printf("  [ok]   the layer reaches the index (height constant present only when arrayed)\n");
+
+        // MUTATION ARM 2 -- the layer must reach the SIZE BOUND. A backing sized for one layer must
+        // be rejected; the pre-#2265 check was width*height*4 <= size and would accept it.
+        ShaderResourceTable one_layer_backing = rt_layered;
+        one_layer_backing.resources[0].size = 4u * 3u * sizeof(uint32_t);
+        if (validate_spirv_descriptor_interface(layered_spv, &one_layer_backing, 0,
+                                                SpirvShaderStage::Compute, false).ok()) {
+            printf("  [FAIL] a two-layer atomic image was accepted against one layer of backing\n");
+            return 1;
+        }
+        printf("  [ok]   the size bound counts every layer, not just the first\n");
+    }
+
     ShaderResourceTable compressed_atomic_image = rt_atomic_image;
     compressed_atomic_image.resources[0].compression_enabled = true;
     const DescriptorValidationReport compressed_atomic_report =


### PR DESCRIPTION
Refs #2265. **Needs independent review** — shader indexing plus memory bounds, and the failure mode of
getting it half-right is silent corruption rather than a visible break.

## The failure

*Sonic Racing: CrossWorlds* issues `IMAGE_ATOMIC_ADD` at `dim=2D_ARRAY` against a two-layer 3840x2160
R32_UINT image on a default launch. Its **full-screen** dispatch — `240x135` groups of 64 threads is
exactly 1920x1080 in 8x8 tiles — is skipped every frame:

```
[compute] skip invalid descriptor contract for program 0x288012e000
[compute-descriptor] wrong descriptor type binding=37 expected=storage-buffer actual=storage-image
[compute-resource]   binding=37 class=4 fmt=2 comps=1 dims=3840x2160x2 pc=751
```

## Why — four copies of one predicate, and #2272 updated one

| site | 2D_ARRAY before this PR |
| --- | --- |
| `rdna2_to_spirv.cpp` coverage predicate | no |
| `rdna2_to_spirv.cpp` lowering gate | **yes — #2272** |
| `shader_resources.cpp` validator carve-out | no |
| `live_compute.cpp` backend staging | no |

So the recompiler emitted a `StorageBuffer` binding for the arrayed atomic and **its own validator
rejected that binding** as `WrongType`. That is why the capture reads `recompiled=yes` with
`descriptors=20` *and* a descriptor-contract failure — a pair that looks contradictory until all four
sites are read together.

This is **#2293 one iteration on** (*"the image-atomic opcode list existed in THREE places and all three
had to agree"*) — same triple plus a fourth, now on the dimension clause.

## Approach

The **resource** half of the predicate moves to one place every site calls,
`shader_resource_supports_atomic_image_buffer` in `shader_resources.hpp`, so a fifth drift is not
expressible. The **instruction** half stays at the lowering gate, the only site that sees it.

Layering, which had to be right *before* any predicate could be widened:

- Shader index becomes `(z*height + y)*width + x`, and the layer enters the **bound** as well — Vulkan
  leaves an out-of-bounds image atomic undefined and robust buffer access does not cover atomics.
- The backend stages every layer: per-layer 2D detile/retile at the **physical** slice stride into a
  tightly packed linear volume. Deliberately **not** `detile_volume()` — a 2D_ARRAY is not a 3D texture,
  and mode 27's volume path swizzles Z into the pipe-XOR bits, so it would run and produce plausible
  garbage.
- Physical and logical sizes stay distinct. For this descriptor the tiled slice is **33,423,360** (already
  64 KiB-aligned; `tiled_mip_chain_bytes`, documented as the array slice stride, returns the same value)
  while the logical layer is **33,177,600**. The guest's `size` field is logical, so using it to bound the
  readability probe would under-read by 491,520 bytes and the detile would walk past the proven region.

**Widening the predicates without the index change would have been worse than the bug**: the dispatch
would run with every layer accumulating into layer 0's texels — a silent wrong result on a device-scope
atomic that would have looked like the fix working, because CrossWorlds' composite would have moved.

## Verification

`ctest --no-tests=error -j6` → **224 tests, 224 passed, 0 failed** (Linux/RADV, `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`).

**Each half of the fix has an arm that fails without it** — mutated one at a time on this branch:

| mutation | arm that fires |
| --- | --- |
| validator carve-out back to single-layer | `2D_ARRAY image_atomic_add did not recompile into an accepted atomic-buffer contract` |
| layer dropped from the shader index | `the 2D_ARRAY atomic index does not multiply by height — every layer aliases layer 0` |
| size bound back to one layer | `a two-layer atomic image was accepted against one layer of backing` |
| *(restored)* | exit 0 |

### Two of my own discriminators were void first, and the mutation run is the only reason I know

Worth reading before trusting the index arm, because it nearly shipped meaningless:

1. First version asserted the constant `3` (the fixture height) appears in the module. Deleting the layer
   from the index left it **passing** — a 3 occurs incidentally.
2. Second version used `97` (prime) but still only checked **presence**. Still passing, and for a
   structural reason: the bounds check `coords[1] < height` puts `height` in the constant pool either
   way. The arm could not have failed.
3. Third version asked whether the *non-arrayed* module multiplies by `1` as its paired negative. `1` is
   multiplied throughout any module, so that arm failed on **correct** code.

The arm now finds the `OpConstant` carrying 97 and asks whether any `OpIMul` takes it, with the paired
negative being a **5x97 non-arrayed** image compiled from the same 2D instruction — same distinctive
constant, one variable. Only then did the mutation fail.

## Not established

That this moves CrossWorlds' composite. The dispatch is full-screen and writes the image the presented
frame is composed from, but the first four restored compute programs did not move it, and I have not
re-run the title on this branch. `CONFIDENCE: HIGH` on the mechanism, `CONFIDENCE: LOW` on the visible
outcome.
