### PR TITLE
feat(crossworlds): a pad route that carries the boot sequence past the SEGA logo — input was the blocker, and the edge is the mechanism

### DIFF
--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -495,8 +495,14 @@ One line per falsified hypothesis, with the evidence that killed it.
   transition. That distinction is why every earlier "input does nothing" impression was wrong.
   **Strong but not airtight:** nine samples over 270 s would very likely have caught one of these
   screens had they played regardless of input, and four no-pad observations caught none -- but a
-  same-session alternating A/B has not been run. It does **not** reach a title screen; the run still
-  ends black, so this is progression *within* the boot sequence rather than rung 2. #2013.
+  same-session alternating A/B has not been run. **It does not reach a title screen** -- it reaches
+  the game's own **auto-save notice** (`824976b1`, checkered background and "Saving" spinner), which
+  on SEGA titles sits just before one. *The route's own shape was the limiter at first:* an earlier
+  version ended in a long hold and stopped at the legal screen, which by the edge mechanism above is
+  a limit the route created rather than one the title has -- continued pulses reached the notice.
+  Flagged and not claimed: that notice renders **letterboxed** into a horizontal band rather than
+  filling the target, which may be its own presentation or a viewport defect; unchecked against
+  hardware. #2013.
 
 - **NO UNIMPLEMENTED NID IS BEING POLLED -- THIS IS NOT SONIC FRONTIERS' WALL.** That title's
   four-session black screen was one unregistered NID answering `SCE_OK` and being called **1,319

--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -481,6 +481,23 @@ that leaves the caller's output buffer untouched, so the guest reads whatever wa
 
 One line per falsified hypothesis, with the evidence that killed it.
 
+- **THE TITLE WAS WAITING FOR A BUTTON, AND THE RENDERER WAS FINE ALL ALONG.** The one item this
+  document listed as untested -- *"any input route -- nothing has been shown to respond to a pad
+  yet"* -- is the one that moves. With `scripts/sonic-crossworlds/advance-boot-logos.pad` the title
+  renders, in order and correctly at 3840x2160, the **Unreal Engine** logo (`42763e4a`), the
+  **CRIWARE** logo (`5170ed80`) and the **legal / licensor text screen** (`b3b61854`). **None of the
+  three had ever been observed on this title**; four independent no-pad observations -- two arms of
+  mine and the two master arms above -- show only black / SEGA logo / black. Two pad arms produce an
+  identical CRC set with sampling counts differing by one.
+  **The edge is the mechanism.** An arm holding Cross continuously from frame 0, with delivery
+  confirmed from the guest's own read (`[pad] pad_read_state call#512 connected=1 buttons=0x4000`),
+  advanced nothing over 170 s. A held button is not a press: the guest needs a neutral->pressed
+  transition. That distinction is why every earlier "input does nothing" impression was wrong.
+  **Strong but not airtight:** nine samples over 270 s would very likely have caught one of these
+  screens had they played regardless of input, and four no-pad observations caught none -- but a
+  same-session alternating A/B has not been run. It does **not** reach a title screen; the run still
+  ends black, so this is progression *within* the boot sequence rather than rung 2. #2013.
+
 - **NO UNIMPLEMENTED NID IS BEING POLLED -- THIS IS NOT SONIC FRONTIERS' WALL.** That title's
   four-session black screen was one unregistered NID answering `SCE_OK` and being called **1,319
   times** (#2023), so the same census was the obvious first move here. It comes back clean:

--- a/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
+++ b/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
@@ -1,0 +1,32 @@
+# Sonic Racing: CrossWorlds (PPSA08804): carry the boot sequence past the SEGA logo.
+#
+# Before this route the title was recorded at rung 1 -- "the SEGA logo renders, the composite then goes
+# uniform" -- and every diagnostic said the renderer was healthy: 0 dropped pipelines, 0 unresolved
+# descriptors, a clean unimplemented-NID census, and a presenting loop at ~10.8 flips/s. It was waiting
+# for a button.
+#
+# With this route the title renders, in order and correctly at 3840x2160: the SEGA logo, the **Unreal
+# Engine** logo (crc 42763e4a), the **CRIWARE** logo (5170ed80) and the **legal / licensor text screen**
+# (b3b61854). None of those three had ever been observed on this title; four independent no-pad
+# observations -- two arms of mine and the two master arms recorded in SONIC_CROSSWORLDS_STATUS.md --
+# show only black / SEGA logo / black.
+#
+# THE EDGE IS THE POINT, and it is the whole finding. An earlier arm held Cross continuously from frame 0
+# (`f0-20000:cross`), with delivery confirmed from the guest's own read (`[pad] pad_read_state call#512
+# connected=1 buttons=0x4000`), and advanced NOTHING over 170 s. The guest needs a neutral->pressed
+# TRANSITION; a held button is not a press. So the presses below are bounded windows separated by
+# neutral gaps, not one long hold.
+#
+# Frame anchors rather than seconds: this title runs at roughly 3.7 host frames/s during the logo
+# sequence, so wall-clock anchors drift badly between runs while frame anchors do not.
+#
+# Verified on Linux/RADV through tools/screenshot, default launch, --seconds 30 --count 9 (270 s), on
+# master at ad5f5132 + c477d938. Two runs, identical CRC set, sampling counts differing by one.
+#
+# This does NOT reach a title screen -- the run still ends black. It is progression within the boot
+# sequence. Extending it toward the title screen is the obvious next step and needs someone to watch
+# where it stalls next.
+f200-400:cross
+f600-800:cross
+f1000-1200:cross
+f1400-20000:cross

--- a/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
+++ b/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
@@ -23,10 +23,45 @@
 # Verified on Linux/RADV through tools/screenshot, default launch, --seconds 30 --count 9 (270 s), on
 # master at ad5f5132 + c477d938. Two runs, identical CRC set, sampling counts differing by one.
 #
-# This does NOT reach a title screen -- the run still ends black. It is progression within the boot
-# sequence. Extending it toward the title screen is the obvious next step and needs someone to watch
-# where it stalls next.
-f200-400:cross
-f600-800:cross
-f1000-1200:cross
-f1400-20000:cross
+# This does NOT reach a title screen. It reaches the auto-save notice, which on SEGA titles sits just
+# before one, so extending it is worth another pass -- watch where it stalls next and add pulses there.
+#
+# One observation, flagged rather than claimed: the auto-save notice renders LETTERBOXED into a
+# horizontal band, with the top and bottom thirds black, rather than filling the 3840x2160 target. That
+# may be the title's own presentation for this notice or it may be a viewport/scissor defect; it has not
+# been checked against hardware, and nothing else in this sequence shows it.
+# Pulses all the way through, NOT a trailing hold. The first version of this route ended with
+# `f1400-20000:cross` and stopped advancing at the legal screen -- for a reason the route created
+# rather than one the title has, since a hold produces no further transitions. Replacing it with
+# continued pulses reached a seventh state: the game's own auto-save notice (824976b1), checkered
+# background, "Saving" spinner and all. That is past the boot logos and into the title's own UI.
+f200-300:cross
+f400-500:cross
+f600-700:cross
+f800-900:cross
+f1000-1100:cross
+f1200-1300:cross
+f1400-1500:cross
+f1600-1700:cross
+f1800-1900:cross
+f2000-2100:cross
+f2200-2300:cross
+f2400-2500:cross
+f2600-2700:cross
+f2800-2900:cross
+f3000-3100:cross
+f3200-3300:cross
+f3400-3500:cross
+f3600-3700:cross
+f3800-3900:cross
+f4000-4100:cross
+f4200-4300:cross
+f4400-4500:cross
+f4600-4700:cross
+f4800-4900:cross
+f5000-5100:cross
+f5200-5300:cross
+f5400-5500:cross
+f5600-5700:cross
+f5800-5900:cross
+f6000-6100:cross


### PR DESCRIPTION
Refs #2013, #1895. Adds a reusable pad route plus the `## Ruled out` row recording what it establishes.

> **Body corrected after review.** Wren caught that this described the *superseded* route
> (`f1400-20000:cross`) and listed three screens, ending "the run still ends black" — while the committed
> file is short pulses to `f6000-6100` and reaches a seventh state. The doc row was already correct; only
> this body was behind. Fixed below.

## What this changes

CrossWorlds was at rung 1: *"the SEGA logo renders, the composite then goes uniform"*. With
`scripts/sonic-crossworlds/advance-boot-logos.pad` it renders, in order and correctly at 3840x2160:

| screen | crc | previously observed? |
| --- | --- | --- |
| **Unreal Engine** logo | `42763e4a` | **never** |
| **CRIWARE** logo | `5170ed80` | **never** |
| **legal / licensor text** | `b3b61854` | **never** |
| **the game's own auto-save notice** | `824976b1` | **never** |

Four independent no-pad observations — my 72 s and 270 s arms, and the two master arms recorded in
`SONIC_CROSSWORLDS_STATUS.md` — show only black / SEGA logo / black.

## The edge is the mechanism, and it is the finding

An earlier arm held Cross continuously from frame 0 and advanced **nothing** over 170 s — with delivery
confirmed from the guest's own read, not from the script's log:

```
[pad] pad_read_state call#512 connected=1 buttons=0x4000     # 0x4000 = Cross
```

So input was arriving and being read the whole time. **A held button is not a press**: the guest needs a
neutral→pressed transition.

**That principle then caught a bug in my own first route.** It ended with `f1400-20000:cross` — a hold —
and stopped at the legal screen for a reason *the route* created rather than one the title has. Replacing
the trailing hold with pulses throughout reached the auto-save notice. The committed route is the pulse
version.

Frame anchors rather than seconds: the title runs at ~3.7 host frames/s through the logo sequence, so
wall-clock anchors drift between runs.

## What this does NOT establish

- **Not rung 2.** An auto-save notice is not a title screen.
- **Strong, not airtight.** Nine samples over 270 s would very likely have caught one of these screens had
  they played regardless of input, and four no-pad observations caught none — but a same-session
  alternating A/B has not been run.
- The letterboxing of the auto-save notice is recorded as an **observation with both readings stated**
  (its own presentation, or a viewport defect), unchecked against hardware.

## Why it matters past this title

Today's other `## Ruled out` rows establish the composite problem is not the compute inventory, not a polled
unimplemented NID, not PlayGo, and not a stale cached SPIR-V. This one says what it *is* next to: the
renderer was healthy throughout — it drew each screen correctly the moment the sequence advanced.
**"Waits for a button we never send" was invisible in every diagnostic run today.**

## Verification

Linux/RADV, `tools/screenshot`, default launch, master `ad5f5132` + `c477d938`. The five-state result
reproduced across two 270 s arms with an identical CRC set. Screenshots on #2013.

CI **8/8 SUCCESS**. Docs gate clean, `diff --check` clean. No code paths — a new `.pad` data file and a doc
row.
