### PR TITLE
docs(crossworlds): rung 2 — the title screen renders completely, reproduced across two runs

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -22,7 +22,7 @@ Last updated: 2026-08-06
 | *Space Adventure Cobra — The Awakening* | `PPSA17337` | Unity / IL2CPP | ✅ Tutorial combat | [#1870](https://github.com/mattias800/prosper/issues/1870) |
 | *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 4K SEGA logo; the boot sequence then holds on a white screen before a title screen | [#1871](https://github.com/mattias800/prosper/issues/1871) |
 | *Sonic Frontiers* | `PPSA03831` | Hedgehog Engine 2 (Needle) | 🚧 Full 4K opening sequence, title screen and main menu; the menu heading draws the wrong string | [#1891](https://github.com/mattias800/prosper/issues/1891) |
-| *Sonic Racing: CrossWorlds* | `PPSA08804` | Unreal Engine 5 | 🔬 4K SEGA logo; the composite goes uniform before a title screen | [#1895](https://github.com/mattias800/prosper/issues/1895) |
+| *Sonic Racing: CrossWorlds* | `PPSA08804` | Unreal Engine 5 | 🔬 4K title screen and menus with a pad route; needs input to advance past the logos | [#1895](https://github.com/mattias800/prosper/issues/1895) |
 | *Terminator 2D: NO FATE* | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay | [#1872](https://github.com/mattias800/prosper/issues/1872) |
 | *Blue Prince* | `PPSA25009` | Unity | 🚧 Manor entrance-hall gameplay | [#1808](https://github.com/mattias800/prosper/issues/1808) |
 | *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Title and main menu | [#1873](https://github.com/mattias800/prosper/issues/1873) |
@@ -144,12 +144,25 @@ logo belongs, and a panel that opens over the menu renders almost none of its te
 
 ## Sonic Racing: CrossWorlds — `PPSA08804`
 
-<p align="center"><img src="assets/screenshots/sonic-crossworlds-sega-logo.png" alt="Sonic Racing: CrossWorlds — SEGA logo"></p>
+<p align="center"><img src="assets/screenshots/sonic-crossworlds-title.png" alt="Sonic Racing: CrossWorlds — title screen"></p>
 
-A default launch reaches the game's SEGA logo, composited by the live renderer at 3840×2160. The
-engine keeps producing frames afterwards, but the composite becomes a single uniform colour before a
-title screen is reached. See [`docs/SONIC_CROSSWORLDS_STATUS.md`](prosper/docs/SONIC_CROSSWORLDS_STATUS.md)
-and the [tracker](https://github.com/mattias800/prosper/issues/1895).
+The title screen, composited by the live renderer at 3840×2160 — the full 3D scene, every character,
+the track and the UI.
+
+**It needs controller input to get there.** A default launch with no pad stops at the SEGA logo, which
+is what this title was recorded as doing for months: the engine keeps producing frames and the composite
+stays black, so every renderer diagnostic reads healthy while nothing advances. The title is simply
+waiting for a button. With `prosper/scripts/sonic-crossworlds/advance-boot-logos.pad` it walks the whole
+sequence — SEGA logo, Unreal Engine, CRIWARE, the licensor screen, the auto-save notice, the title
+screen, and into the player-profile menu.
+
+One detail that matters if you write your own route: **a held button is not a press.** Holding Cross
+advances nothing; the guest needs a neutral→pressed transition, so the route uses short pulses.
+
+Beyond the title screen the profile menu renders its UI correctly but leaves the central content panel
+black, and the sequence eventually holds on white. See
+[`docs/SONIC_CROSSWORLDS_STATUS.md`](prosper/docs/SONIC_CROSSWORLDS_STATUS.md) and the
+[tracker](https://github.com/mattias800/prosper/issues/1895).
 
 ## Terminator 2D: NO FATE — `PPSA25872`
 

--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -481,6 +481,26 @@ that leaves the caller's output buffer untouched, so the guest reads whatever wa
 
 One line per falsified hypothesis, with the evidence that killed it.
 
+- **RUNG 2 REACHED -- THE TITLE SCREEN RENDERS COMPLETELY, AND "THE COMPOSITE GOES UNIFORM" WAS NEVER
+  THE RIGHT DESCRIPTION.** With denser pulses on the route above (`scripts/sonic-crossworlds/`), the
+  full sequence is **black -> SEGA -> Unreal Engine -> CRIWARE -> licensor -> auto-save notice ->
+  TITLE SCREEN -> player-profile menu -> white**. The title screen is complete at 3840x2160: the 3D
+  scene, every character, the track, the logo, `PRESS`, `License Information`, `(C)SEGA` and version
+  `1.1.2`. **Reproduced across two independent 560 s runs.** Note the composite CRC does **not**
+  match between them -- the scene is animated -- so the comparison is by content signature:
+  **113,524 / 113,676** distinct sampled colours at 99.6% coverage in the first run against
+  **113,476 / 114,379** at 99.6% in the second, at the same sample positions. For scale this document
+  records the SEGA logo at 1,373 colours.
+  *Method worth reusing:* opening twenty 4K frames is expensive, so the unexamined ones were **scored
+  before being opened** -- distinct sampled colours and non-black ratio -- and the two that stood two
+  orders of magnitude above the rest were the only ones opened. A CRC tells you frames differ; it does
+  not tell you which one is worth looking at.
+  **The defect is now per-screen, not global.** The title screen's scene renders; the profile menu's
+  UI composites correctly (rank badge, account name, BACK / VIEW PLAYER / NEXT) while its central
+  content panel stays black. So "no scene-geometry pass" is a statement about *some* screens. The
+  terminal white state and the letterboxed auto-save notice remain unexplained. Rung 3 (gameplay) is
+  not reached. #2013.
+
 - **THE TITLE WAS WAITING FOR A BUTTON, AND THE RENDERER WAS FINE ALL ALONG.** The one item this
   document listed as untested -- *"any input route -- nothing has been shown to respond to a pad
   yet"* -- is the one that moves. With `scripts/sonic-crossworlds/advance-boot-logos.pad` the title
@@ -496,8 +516,8 @@ One line per falsified hypothesis, with the evidence that killed it.
   **Strong but not airtight:** nine samples over 270 s would very likely have caught one of these
   screens had they played regardless of input, and four no-pad observations caught none -- but a
   same-session alternating A/B has not been run. **It does not reach a title screen** -- it reaches
-  the game's own **auto-save notice** (`824976b1`, checkered background and "Saving" spinner), which
-  on SEGA titles sits just before one. *The route's own shape was the limiter at first:* an earlier
+  the game's own **auto-save notice** (`824976b1`) -- and past that, with denser pulses, **the title
+  screen itself** and then the player-profile menu. *The route's own shape was the limiter at first:* an earlier
   version ended in a long hold and stopped at the legal screen, which by the edge mechanism above is
   a limit the route created rather than one the title has -- continued pulses reached the notice.
   Flagged and not claimed: that notice renders **letterboxed** into a horizontal band rather than


### PR DESCRIPTION
Refs #2013, #1895, #2358. Records the milestone and updates the user-facing entry.

## The result

With denser pulses on the route merged in #2358, the full sequence is:

**black → SEGA → Unreal Engine → CRIWARE → licensor → auto-save notice → TITLE SCREEN → player-profile menu → white**

The title screen is complete at 3840×2160 — the 3D scene, every character, the track, the logo, `PRESS`, `License Information`, `©SEGA`, version `1.1.2`. Screenshot committed as `assets/screenshots/sonic-crossworlds-title.png`.

This title was recorded this morning as **rung 1**: *"the SEGA logo renders; the composite then goes uniform."*

## Reproduced — and the comparison is by content, not CRC

Two independent 560 s runs. **The composite CRC does not match between them, and should not**: the title screen is an animated scene. So the comparison is the content signature at the same sample positions:

| run | frame 09 | frame 10 | coverage |
| --- | ---: | ---: | ---: |
| first | 113,524 | 113,676 | 99.6% |
| second | 113,476 | 114,379 | 99.6% |

The status doc records the SEGA logo at **1,373** colours for scale.

## Method worth reusing

Opening twenty 4K frames is expensive, so the unexamined ones were **scored before being opened** — distinct sampled colours and non-black ratio:

```
frame 06: distinct=   755  non-black= 35.9%   (UI)
frame 09: distinct=113524  non-black= 99.6%   <- opened
frame 10: distinct=113676  non-black= 99.6%   <- opened
frame 14: distinct=     2  non-black=100.0%   (white)
```

Two stood two orders of magnitude above the rest. **A CRC tells you frames differ; it does not tell you which is worth looking at.**

## What this does and does not claim

- **Rung 2**, not rung 3. No gameplay.
- The defect is now **per-screen, not global**: the title screen's scene renders, while the profile menu composites its UI correctly over a **black central panel**. "No scene-geometry pass" is a statement about *some* screens — a better-posed question than "the composite goes uniform".
- The terminal **white** state and the **letterboxed** auto-save notice remain unexplained.

## COMPATIBILITY.md

The user-facing entry now leads with the title screen and states plainly that **the title needs controller input to advance past the logos** — a default launch stops at the SEGA logo while every renderer diagnostic reads healthy, which is exactly how this sat misdiagnosed. It also carries the thing someone writing their own route needs: *a held button is not a press.*

Docs gate clean, `diff --check` clean. Two `.md` files plus one screenshot.