### PR TITLE
fix(libkernel): sweep the Sony-spelling encoding rule across the pthread family

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -382,6 +382,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_reallocalign PRIVATE prosper_core)
   add_test(NAME reallocalign COMMAND test_reallocalign)
 
+  # #2178: no Sony pthread spelling may return a bare FreeBSD errno.
+  add_executable(test_sce_pthread_encoding tests/test_sce_pthread_encoding.cpp)
+  target_link_libraries(test_sce_pthread_encoding PRIVATE prosper_core)
+  add_test(NAME sce_pthread_encoding COMMAND test_sce_pthread_encoding)
+
   add_executable(test_reallocf tests/test_reallocf.cpp)
   target_link_libraries(test_reallocf PRIVATE prosper_core)
   add_test(NAME reallocf COMMAND test_reallocf)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2623,6 +2623,34 @@ SCE_PTHREAD_ALIAS(k_sce_sem_wait,     k_sem_wait)
 SCE_PTHREAD_ALIAS(k_sce_sem_trywait,  k_sem_trywait)
 SCE_PTHREAD_ALIAS(k_sce_sem_post,     k_sem_post)
 SCE_PTHREAD_ALIAS(k_sce_sem_getvalue, k_sem_getvalue)
+
+// #2178: the rest of the sweep. Every body below returns a BARE FreeBSD errno on at least one path
+// -- verified per body rather than assumed: `once` 0x16; `create` 12 and fbsd_errno(r); `attr_init`
+// 12; `setguardsize` 0x16 and fbsd_errno(rc); `set/getdetachstate` 0x16; `getname` 3 and 14;
+// `rename` 22 and 3; `key_create` 0x16, ENOMEM and fbsd_errno(r) -- and NONE of them encodes in
+// place, so every Sony spelling registered straight onto one handed the guest a value in the wrong
+// space. That is #1984's shape, the one that killed Oregon Trail until 38619f29.
+//
+// Worth restating because it is why this is a sweep and not a fix: the answer must not depend on
+// which spelling the guest happened to call, and a family where three members encode and the fourth
+// does not is the #1873 defect with a different subject.
+SCE_PTHREAD_ALIAS(k_sce_pthread_once,          k_pthread_once)
+SCE_PTHREAD_ALIAS(k_sce_pthread_create,        k_pthread_create)
+SCE_PTHREAD_ALIAS(k_sce_attr_init,             k_attr_init)
+SCE_PTHREAD_ALIAS(k_sce_attr_setguardsize,     k_attr_setguardsize)
+SCE_PTHREAD_ALIAS(k_sce_attr_setdetachstate,   k_attr_setdetachstate)
+SCE_PTHREAD_ALIAS(k_sce_attr_getdetachstate,   k_attr_getdetachstate)
+// DELIBERATELY NOT SWEPT: scePthreadGetname / Rename / SetName.
+//
+// They match the rule -- `k_pthread_getname` returns bare 3 and 14, `k_pthread_rename` bare 22 and
+// 3 -- and applying it makes them encode like every other Sony spelling. But `test_pthread_names`
+// already asserts the BARE values (`== 3` for ESRCH, `== 14` for EFAULT), and changing a passing
+// test so it agrees with a change is how a wrong change gets ratified.
+//
+// The test carries no rationale for those values, so it is weak evidence -- but it is evidence, and
+// the honest resolution needs something neither of us has here: a capture of what the real
+// libkernel returns. Left bare and raised on #2178 rather than settled by whoever edits last.
+SCE_PTHREAD_ALIAS(k_sce_key_create,            k_key_create)
 // The same bodies under their POSIX spellings, split along the RETURN-CONVENTION axis rather than
 // the encoding one (#2182). k_sem_* return the error NUMBER, which is right for scePthreadSem* and
 // wrong for sem_*: C11 7.26 and FreeBSD sem_wait(3) both specify "return -1, number left in errno".
@@ -4334,25 +4362,25 @@ void register_kernel_hle() {
     R("scePthreadBarrierDestroy", k_barrier_destroy);
     R("scePthreadBarrierattrInit", k_attr_noop);  R("scePthreadBarrierattrDestroy", k_attr_noop);
     R("scePthreadBarrierattrSetpshared", k_attr_noop);
-    R("scePthreadOnce", k_pthread_once);             R("pthread_once", k_pthread_once);
+    R("scePthreadOnce", k_sce_pthread_once);             R("pthread_once", k_pthread_once);
     R("scePthreadSelf", k_pthread_self);
     R("scePthreadEqual", k_pthread_equal);
     R("scePthreadYield", k_pthread_yield);
     R("__stack_chk_fail", k_stack_chk_fail);   // diagnostic: log the guest canary on a canary-check failure
-    R("scePthreadCreate", k_pthread_create);
+    R("scePthreadCreate", k_sce_pthread_create);
     R("scePthreadJoin", k_pthread_join);
     R("scePthreadDetach", k_pthread_detach);
     R("scePthreadExit", k_pthread_exit);
-    R("scePthreadAttrInit", k_attr_init);
+    R("scePthreadAttrInit", k_sce_attr_init);
     R("scePthreadAttrDestroy", k_attr_destroy);
     R("scePthreadAttrSetstack", k_sce_attr_setstack);            // encoded (#2183)
     R("scePthreadAttrSetstacksize", k_sce_attr_setstacksize);    // encoded (#2183)
-    R("scePthreadAttrSetguardsize", k_attr_setguardsize);
+    R("scePthreadAttrSetguardsize", k_sce_attr_setguardsize);
     R("scePthreadAttrSetinheritsched", k_attr_noop);
     R("scePthreadAttrSetschedpolicy", k_attr_noop);
     R("scePthreadAttrSetschedparam", k_log_attr_setschedparam);
-    R("scePthreadAttrSetdetachstate", k_attr_setdetachstate);   // was no-op -> detached threads leaked
-    R("scePthreadAttrGetdetachstate", k_attr_getdetachstate);   // was MISSING -> uninitialized *state
+    R("scePthreadAttrSetdetachstate", k_sce_attr_setdetachstate);   // was no-op -> detached threads leaked
+    R("scePthreadAttrGetdetachstate", k_sce_attr_getdetachstate);   // was MISSING -> uninitialized *state
     R("scePthreadAttrGetschedparam", k_attr_getschedparam);
     R("scePthreadAttrGet", k_attr_get);
     R("scePthreadAttrGetstackaddr", k_attr_getstackaddr);
@@ -4371,7 +4399,7 @@ void register_kernel_hle() {
     R("pthread_set_name_np", k_pthread_rename);
     R("scePthreadGetstack", k_attr_getstackaddr);
     // TLS keys (POSIX + Sony names -> host pthread keys)
-    R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_key_create);
+    R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_sce_key_create);
     R("pthread_key_delete", k_key_delete);   R("scePthreadKeyDelete", k_key_delete);
     R("pthread_getspecific", k_getspecific); R("scePthreadGetspecific", k_getspecific);
     R("pthread_setspecific", k_setspecific); R("scePthreadSetspecific", k_setspecific);
@@ -4450,7 +4478,12 @@ void register_kernel_hle() {
     Hle::register_fn("g0VTBxfJyu0", (HleFn)k_attr_noop, "sceKernelGetCurrentCpu");
     Hle::register_fn("Tz4RNUCBbGI", (HleFn)k_attr_noop, "_sceKernelRtldThreadAtexitIncrement");
     Hle::register_fn("jh+8XiK4LeE", (HleFn)k_attr_noop, "sceKernelIsAddressSanitizerEnabled");
-    Hle::register_fn("El+cQ20DynU", (HleFn)k_attr_setguardsize, "scePthreadAttrSetguardsize");
+    // #2178: the Sony wrapper, not the raw body. This explicit-NID line registers the SAME NID
+    // as the R("scePthreadAttrSetguardsize", ...) above and runs later, so it silently won --
+    // the sweep re-pointed the name-based registration and this one put the bare-errno body
+    // straight back. Caught by the invariant test rather than by reading, which is the whole
+    // argument for asserting the property over the family instead of listing instances.
+    Hle::register_fn("El+cQ20DynU", (HleFn)k_sce_attr_setguardsize, "scePthreadAttrSetguardsize");
     #undef R
     register_kernel_mem_hle();    // virtual/direct memory
     register_kernel_time_hle();   // time/clock + C11 threads + stubs

--- a/prosper/tests/test_sce_pthread_encoding.cpp
+++ b/prosper/tests/test_sce_pthread_encoding.cpp
@@ -1,0 +1,91 @@
+// #2178: a Sony pthread spelling must never hand the guest a BARE FreeBSD errno.
+//
+// Every other libkernel entry point returns `0x80020000 | errno`. A Sony name registered straight
+// onto a fallible POSIX body returns the bare value instead, so the guest gets a number in the wrong
+// space -- #1984's shape, the one that killed Oregon Trail until 38619f29. #2158 fixed two
+// instances; this file guards the rule rather than the instances.
+//
+// The assertion is deliberately an INVARIANT over the whole family, not a list of expected values.
+// A list would have to be extended by hand every time a function is added, and the failure mode of
+// forgetting is silent -- which is exactly how the instances below survived. Anything that returns
+// non-zero must have the libkernel prefix; what the errno IS is the POSIX body's business and is
+// tested elsewhere.
+
+#include "hle/dispatch.hpp"
+#include "hle/nid.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void check(bool ok, const std::string& what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what.c_str()); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what.c_str());
+}
+
+using prosper::Hle;
+using prosper::HleFn;
+
+int main() {
+    std::fprintf(stderr, "== test_sce_pthread_encoding ==\n");
+    prosper::register_kernel_hle();
+
+    // Each entry is called with arguments chosen to FAIL: a null output slot, an invalid enum, or a
+    // bad handle. The point is to reach a return path that carries an errno at all -- a call that
+    // succeeds proves nothing about encoding.
+    struct Case { const char* name; uint64_t a0, a1, a2; };
+    const Case cases[] = {
+        {"scePthreadOnce",                0, 0, 0},   // null control / null routine -> EINVAL
+        {"scePthreadAttrInit",            0, 0, 0},   // null attr slot
+        {"scePthreadAttrSetguardsize",    0, 0, 0},
+        {"scePthreadAttrSetdetachstate",  0, 99, 0},  // 99 is not a detach state
+        {"scePthreadAttrGetdetachstate",  0, 0, 0},
+        {"scePthreadKeyCreate",           0, 0, 0},
+        {"scePthreadCreate",              0, 0, 0},
+        // The families #2158 and #2359 already fixed, kept here so a regression in ANY of them is
+        // caught by this one file rather than by whichever test happened to cover it.
+        {"scePthreadMutexUnlock",         0, 0, 0},
+        {"scePthreadRwlockattrInit",      0, 0, 0},
+        {"scePthreadRwlockattrDestroy",   0, 0, 0},
+        {"scePthreadCondDestroy",         0, 0, 0},
+    };
+
+    size_t exercised = 0;
+    for (const Case& c : cases) {
+        HleFn fn = Hle::lookup(prosper::nid_hash(c.name));
+        if (!fn) { check(false, std::string(c.name) + " is registered"); continue; }
+        const uint64_t rc = fn(c.a0, c.a1, c.a2, 0, 0, 0);
+        if (rc == 0) continue;                      // this argument pattern succeeded; says nothing
+        ++exercised;
+        const bool encoded = (rc & 0xffff0000ull) == 0x80020000ull;
+        check(encoded, std::string(c.name) + " returns an ENCODED error (0x8002xxxx), not a bare "
+                       "errno -- got 0x" + [&] {
+                           char buf[32]; std::snprintf(buf, sizeof buf, "%llx",
+                                                       (unsigned long long)rc); return std::string(buf);
+                       }());
+    }
+
+    // Without this the file would pass vacuously if every call above started returning 0 -- which is
+    // a real possibility, since the arguments are chosen to provoke failure and a future change
+    // could make one of them legal. A green run that exercised nothing is the #2130 trap, and it is
+    // the reason this counter exists rather than a comment saying the arms are meaningful.
+    check(exercised >= 6,
+          "at least 6 of the calls actually reached an error path (got " +
+              std::to_string(exercised) + ") -- otherwise the assertions above are vacuous");
+
+    // The CONTROL, and the half that proves the test can tell the two spellings apart: the POSIX
+    // name must still return the bare errno. If encoding had been applied to the shared body instead
+    // of the Sony wrapper, every assertion above would pass and this one would fail.
+    if (HleFn posix_attr_init = Hle::lookup(prosper::nid_hash("pthread_attr_init"))) {
+        const uint64_t rc = posix_attr_init(0, 0, 0, 0, 0, 0);
+        check(rc == 0 || (rc & 0xffff0000ull) == 0,
+              "control: the POSIX spelling still returns a BARE errno, so encoding was added to the "
+              "Sony wrapper rather than to the shared body");
+    }
+
+    std::fprintf(stderr, failures ? "== FAIL ==\n" : "== PASS ==\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Refs #2178. **Seven of ten swept; three deliberately left — see the last section, it is the part worth reviewing.**

## What

#2158 established the rule and applied it once. This is the sweep, done by script rather than by working through the issue's table: enumerate every `R("scePthread*", body)`, drop the ones already pointing at a `SCE_PTHREAD_ALIAS` wrapper, and check whether the remaining bodies can return non-zero. **Most of #2178's own table is already fixed on master** — the sweep found a different and larger set. Each body's return paths were then read individually rather than trusted to the regex:

| function | bare values it returned |
| --- | --- |
| `scePthreadOnce` | `0x16` |
| `scePthreadCreate` | `12`, `fbsd_errno(r)` |
| `scePthreadAttrInit` | `12` |
| `scePthreadAttrSetguardsize` | `0x16`, `fbsd_errno(rc)` |
| `scePthreadAttrSetdetachstate` | `0x16` |
| `scePthreadAttrGetdetachstate` | `0x16` |
| `scePthreadKeyCreate` | `0x16`, `ENOMEM`, `fbsd_errno(r)` |

None encoded in place, so every one handed the guest a value in the wrong space.

## The test found one the sweep alone would have missed

`scePthreadAttrSetguardsize` is registered **twice** — once by name, and once by explicit NID at the bottom of the registrar pointing straight at the raw body:

```cpp
Hle::register_fn("El+cQ20DynU", (HleFn)k_attr_setguardsize, "scePthreadAttrSetguardsize");
```

The explicit line runs later and silently won, so re-pointing the name-based registration achieved **nothing**. No amount of reading the sweep's output would have shown this. The test did, immediately, because it asserts the *property* rather than the edit.

That is why it is an **invariant over the family** — *nothing may return a bare errno* — rather than a list of expected values. A list has to be extended by hand whenever a function is added, and forgetting is silent, which is exactly how these instances survived #2158 in the first place.

It also carries a vacuity guard: at least 6 of the calls must actually reach an error path (11 do). The arguments are chosen to provoke failure, so a future change making one of them legal would otherwise leave the file green having asserted nothing — #2130's shape.

And a **control**: the POSIX spelling must still return a bare errno. If encoding had been added to the shared body instead of the Sony wrapper, every other assertion would pass and only this one would fail.

## Deliberately NOT swept, and this is the judgment call

`scePthreadGetname` / `Rename` / `SetName` match the rule — `k_pthread_getname` returns bare `3` and `14`, `k_pthread_rename` bare `22` and `3`. Applying it makes **`test_pthread_names` fail**, because that test asserts the bare values:

```cpp
CHECK(getname(0, …) == 3,  "null thread returns ESRCH");
CHECK(getname(thread, 0, …) == 14, "null Sony output returns EFAULT");
```

**Changing a passing test so that it agrees with a change is how a wrong change gets ratified**, so I did not. The test carries no rationale for those values, which makes it weak evidence — but it is evidence, and someone chose them. Resolving it needs a capture of what the real libkernel returns for these three, which I do not have.

Left bare, and raised on #2178 rather than settled by whoever edits last. If you think the rule plainly governs and the test simply codified the defect, say so and I will extend the sweep and update it in a follow-up with the reasoning recorded.

## Verification (Windows, MinGW WinLibs UCRT g++ 16.1.0)

`ctest --no-tests=error -j8` → **178 tests, 178 passed, 0 failed**.

## Review note

Guest-visible return values on entry points every title calls. The specific thing worth a second reader is the **duplicate-registration** class: I fixed the one instance the test caught, but I have not established that no other explicit-NID line in the registrar shadows a name-based one.

— Wren
