### PR TITLE
docs(blue-prince): record the three performance regimes, and the counter that hid them

### DIFF
--- a/prosper/docs/BLUE_PRINCE_STATUS.md
+++ b/prosper/docs/BLUE_PRINCE_STATUS.md
@@ -277,6 +277,30 @@ published and retracted the same day: it compared 40 validations against 4,449 r
 it small without computing the cost. `watch_reuse = 0.0` — the write watch never once returns
 `Unchanged`, so every persistent hit falls to exact comparison (26,261 validations, 79.8 GiB a run).
 
+**THIS TITLE HAS THREE PERFORMANCE REGIMES THAT DIFFER BY ~50x. State which one a number is
+from, or the number means nothing.** Measured on one run that logged frame rate and draw activity
+together (RTX 4090 / Windows, default launch):
+
+| on screen | draws/submit | cost | `[app] … fps` |
+| --- | ---: | ---: | ---: |
+| main menu | ~12 | trivial | **64.0** |
+| **real gameplay** | **~2,100** | **156 ms/submit** | **single digits** |
+| FMV collapse (#2215) | ~2,250 | 938 ms/frame | 1.2-1.6 |
+
+Median across 70 render windows is **12.2** draws/submit and the max is **2,258**, so an unqualified
+average over a run is dominated by the menu and says nothing about gameplay.
+
+**The `[app]` counter is a PRESENT rate, not a render rate** — the line reads
+`fps (N frames, gpu-present)`. During the menu it reports a sustained 64.0 while a frame captured
+inside that window is **entirely black, one distinct colour**. Nothing is being drawn; presents
+continue regardless.
+
+This is recorded because it was believed and published. A session quoted "30-39 fps gameplay" from
+that counter, while the same session had already written "2,108 draws cost 156 ms/submit" into the
+#2276 discussion -- which is ~6 fps. Two numbers about the same title, in the same session, never
+compared against each other; the project owner watched a live run and said it plainly was not 30+.
+**Before quoting a frame rate here, state the regime and cross-check it against draws/submit.**
+
 **60 FPS is not reachable by CPU work alone on this workload (#2276).** `gpu_device` measures
 **30-45 ms/submit** against a 16.7 ms budget, so a renderer with zero CPU cost lands near 30 FPS as
 the frame is currently submitted. `PROSPER_RENDER_SCALE=2` did **not** reduce it (43.47 vs 45.24 at


### PR DESCRIPTION
Refs #2215, #2276. Docs-only; docs gate run locally.

## What this corrects

I quoted **"30–39 fps gameplay"** for Blue Prince, repeatedly, including on #2241 and #2276 where the other lane was sizing decisions against it. It was wrong, and the correction goes the wrong way.

The `[app]` counter is a **present rate** — its own line says `fps (N frames, gpu-present)`. The figure I quoted was the **main menu**, which submits ~12 draws. A frame captured inside that sustained-64 fps window is **entirely black, one distinct colour**: nothing is being drawn and presents continue regardless.

| on screen | draws/submit | cost | `[app] … fps` |
| --- | ---: | ---: | ---: |
| main menu | ~12 | trivial | **64.0** |
| **real gameplay** | **~2,100** | **156 ms/submit** | **single digits** |
| FMV collapse (#2215) | ~2,250 | 938 ms/frame | 1.2–1.6 |

Median across 70 render windows is **12.2** draws/submit, max **2,258** — so an unqualified average over a run is dominated by the menu and says nothing about gameplay.

## Why this is recorded rather than merely retracted

**The trap reproduces for anyone who reads that counter**: it reports a healthy number while nothing is drawn. And I had the discriminator the whole time — the same session wrote *"2,108 draws cost 156 ms/submit"* into the #2276 discussion, which is ~6 fps, and never compared the two numbers against each other. Two figures about one title, from one lane, in one session.

The project owner watched a live run and said plainly that it was not 30+. That is what caught it, not any instrument of mine.

## What it changes

- **Gameplay needs roughly 5× to reach 30 fps**, not the near-parity I claimed.
- #2276's CPU/GPU split (~170 ms CPU against ~30 ms `gpu_device`) is **unaffected** — the direction of both lanes' work is right, there is simply more of it than I implied.
- Any future frame-rate claim on this title must state its regime and cross-check against draws/submit. The doc now says so explicitly.

## Verification

`git diff --name-only origin/master...HEAD | grep -v '\.md$'` → empty. `diff --check` clean. Docs gate:

```
prosper/docs/BLUE_PRINCE_STATUS.md: 2 table(s), 7 rows, unbroken, every row matching its header
prosper/docs/GAME_COMPAT_ORCHESTRATION.md: 14 table(s), 203 rows, contiguous and unbroken
```

Addition only — it does not rewrite an existing `## Ruled out` row or reproduction route.

— Wren
