### PR TITLE
fix(gpu): print the dwords a rejected instruction actually has, and its length

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -41,7 +41,7 @@ inline std::string reject_words_text(const Rdna2Inst& in) {
     char buf[16];
     for (uint32_t i = 0; i < count; ++i) {
         std::snprintf(buf, sizeof buf, "%08x", in.words[i]);
-        if (i) out += (char)44;
+        if (i) out += ',';
         out += buf;
     }
     return out;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -18,6 +18,36 @@
 
 namespace prosper::gpu {
 
+// #2319: render exactly the dwords the instruction HAS, not a fixed two.
+//
+// `words[]` is `uint32_t words[5] = {0,...}`, so a ONE-dword instruction printed as
+// `words=bf860051,00000000` is indistinguishable from a two-dword instruction whose second dword
+// is genuinely zero. That defeats the purpose of printing raw words (#2312), which is that a
+// reader can name the instruction with one command:
+//
+//     echo '0x0e,0x16,0xea,0xbe' | llvm-mc -arch=amdgcn -mcpu=gfx1010 -disassemble
+//
+// A reader who takes `words=x,00000000` at face value feeds EIGHT bytes, and llvm-mc decodes a
+// second, entirely fictitious instruction from the zero dword -- output that looks exactly as
+// authoritative as the correct answer. On the CrossWorlds census pc=101 needed four bytes and
+// pc=2038 needed eight, and nothing in either line said which.
+//
+// Clamped to the array bound as well as to len_dwords: len_dwords comes from the decoder, and a
+// decode that failed badly enough to be rejected here is not a source to trust for indexing.
+inline std::string reject_words_text(const Rdna2Inst& in) {
+    const uint32_t count = std::min<uint32_t>(in.len_dwords ? in.len_dwords : 1u,
+                                              (uint32_t)(sizeof(in.words) / sizeof(in.words[0])));
+    std::string out;
+    char buf[16];
+    for (uint32_t i = 0; i < count; ++i) {
+        std::snprintf(buf, sizeof buf, "%08x", in.words[i]);
+        if (i) out += (char)44;
+        out += buf;
+    }
+    return out;
+}
+
+
 FragmentInterpolationLayout::FragmentInterpolationLayout() {
     for (auto& locations : parameter_locations) locations.fill(kUnusedLocation);
     system_locations.fill(kUnusedLocation);
@@ -13506,8 +13536,8 @@ bool emit_cfg_state_machine(
                         // so half the rejects from a run were unidentifiable and the two diagnostics
                         // could not be compared (#2309).
                         std::fprintf(stderr,
-                                     "[cfg-recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x\n",
-                                     in.pc, in.words[0], in.words[1],
+                                     "[cfg-recompile-reject] pc=%u words=%s len=%u fmt=%d op=0x%x\n",
+                                     in.pc, reject_words_text(in).c_str(), in.len_dwords,
                                      static_cast<int>(in.fmt), in.opcode);
                     return false;
                 }
@@ -14713,11 +14743,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
                 if (getenv("PROSPER_DBG")) {
-                    fprintf(stderr, "[recompile-reject] pc=%u words=%08x,%08x fmt=%d op=0x%x "
+                    fprintf(stderr, "[recompile-reject] pc=%u words=%s fmt=%d op=0x%x "
                                     "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
                                     "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u "
                                     "sext=%d/%d\n",
-                        in.pc, in.words[0], in.words[1], (int)in.fmt, in.opcode,
+                        in.pc, reject_words_text(in).c_str(), (int)in.fmt, in.opcode,
                         in.dst.value, (int)in.dst.kind,
                         in.src[0].value, (int)in.src[0].kind,
                         in.src[1].value, (int)in.src[1].kind,


### PR DESCRIPTION
Fixes #2319.

## The failure

Both recompiler reject diagnostics printed two dwords unconditionally:

```
[recompile-reject]     pc=36  words=bf860051,00000000 fmt=4 op=0x6 ...
[cfg-recompile-reject] pc=101 words=beea160e,00000000 fmt=1 op=0x16
```

`words=<x>,00000000` is ambiguous between **two different facts**: a two-dword instruction whose second dword is genuinely zero, or a one-dword instruction whose second slot is an unused array element (`words[5] = {0,…}`).

That defeats the purpose of printing raw words at all (#2312), which is that a reader can name the instruction with one command:

```
echo '0x0e,0x16,0xea,0xbe' | llvm-mc -arch=amdgcn -mcpu=gfx1010 -disassemble
```

A reader who takes the line at face value feeds **eight** bytes, and `llvm-mc` decodes a second, entirely fictitious instruction from the zero dword — **output that looks exactly as authoritative as the correct answer**. On the CrossWorlds census `pc=101` needed four bytes and `pc=2038` needed eight, and neither line said which.

## The fix

Render exactly `len_dwords` words, and print `len=` at the cfg site so the count is legible without counting commas:

```
[cfg-recompile-reject] pc=101 words=beea160e len=1 fmt=1 op=0x16
```

**Clamped to the array bound as well as to `len_dwords`.** That is not defensive padding: `len_dwords` comes from the decoder, and this line only ever prints for an instruction the decoder *failed on*, so it is precisely the wrong source to trust for indexing. The decode header even documents the case — a bad encoding "returns fmt=Unknown with len_dwords clamped so a walker still terminates" — but the clamp belongs here too rather than being inherited by assumption.

## Verification

`ctest --no-tests=error -j8` → **177 tests, 177 passed, 0 failed** (Windows, MinGW WinLibs UCRT g++ 16.1.0).

No behavioural change — both call sites are inside `PROSPER_DBG`-gated blocks and only the rendered text differs. No new test: the change is a format string, and the property that matters (the reader can paste the bytes) is not something a unit test can assert more convincingly than reading the line.

— Wren
