### PR TITLE
fix(diag): stop the timing line printing wall and thread-summed times as peers

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -7213,10 +7213,20 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                          "spans=%.1f shaders: hit=%.1f miss=%.1f bypass=%.1f "
                          "decode: hit=%.1f miss=%.1f invalid=%.1f "
                          "readable: hit=%.1f/%.1f os=%.1f "
-                         "avg_ms: total=%.2f realize_draws=%.2f tables=%.2f shader_lookup=%.2f "
-                         "shader_compile=%.2f table_parts: metadata=%.2f fold=%.2f resources=%.2f "
-                         "parallel: batches=%.2f draws=%.1f threads=%.1f wall=%.2f "
-                         "realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f\n",
+                         // #2215 trap 143: the WALL fields are printed together and they compose to
+                         // `total`; the thread-summed ones are fenced off behind an explicit label.
+                         // They used to be interleaved, and three of them are individually LARGER
+                         // than `total` (tables=918 against total=464 on one Blue Prince window),
+                         // because realization runs on `threads` workers and these are sums across
+                         // them. A reader who divided one by `total` got a share that is not a
+                         // share -- six of those shipped from one lane in a day, and the other
+                         // lane retracted one of the same shape.
+                         "avg_ms[wall, sums to total]: total=%.2f realize_draws=%.2f "
+                         "realize_compute=%.2f plan=%.2f backend=%.2f publish=%.2f "
+                         "| [SUMMED OVER %.1f THREADS -- divide by threads before comparing to "
+                         "total]: tables=%.2f shader_lookup=%.2f shader_compile=%.2f "
+                         "metadata=%.2f fold=%.2f resources=%.2f "
+                         "| parallel[wall]: batches=%.2f draws=%.1f wall=%.2f\n",
                          (unsigned long long)window.submits, window.draws / wn,
                          window.dispatches / wn, window.render_spans / wn,
                          window.shader_hits / wn, window.shader_misses / wn,
@@ -7224,18 +7234,23 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
                          window.decode_misses / wn, window.decode_invalidations / wn,
                          window.readable_hits / wn, window.readable_calls / wn,
                          window.readable_os_probes / wn, window_total / wn,
-                         window.realize_draws / wn, window.table_build / wn,
+                         window.realize_draws / wn,
+                         window.realize_compute / wn, window.plan / wn, window.backend / wn,
+                         window.publish / wn,
+                         // 1.0, not 0.0, when no parallel batch ran: realization was then SERIAL,
+                         // so these sums already ARE wall and dividing by the printed figure is
+                         // still the right instruction. Printing 0.0 told the reader to divide by
+                         // zero, which is worse than the ambiguity this line was fixed to remove.
+                         window.parallel_batches
+                             ? static_cast<double>(window.parallel_threads) /
+                                   static_cast<double>(window.parallel_batches)
+                             : 1.0,
+                         window.table_build / wn,
                          window.shader_lookup / wn, window.shader_compile / wn,
                          window.table_metadata / wn, window.table_dynamic_fold / wn,
                          window.table_resources / wn,
                          window.parallel_batches / wn, window.parallel_draws / wn,
-                         window.parallel_batches
-                             ? static_cast<double>(window.parallel_threads) /
-                                   static_cast<double>(window.parallel_batches)
-                             : 0.0,
-                         window.parallel_wall / wn,
-                         window.realize_compute / wn, window.plan / wn, window.backend / wn,
-                         window.publish / wn);
+                         window.parallel_wall / wn);
             window = {};
         }
     }


### PR DESCRIPTION
Refs #2215, #2276. Removes the hazard recorded as trap 143 in #2369 rather than only documenting it.

## The defect

The per-submit timing line interleaved **wall-clock** totals with **thread-summed** component times and marked neither. So `component / total` from that line read as a share and was not one. On a real Blue Prince window three components are individually **larger than the total**:

```
total=464.05 realize_draws=230.55 tables=918.47 shader_lookup=532.45
  table_parts: metadata=516.13 fold=243.83 ... parallel: threads=8.0 wall=228.63
```

`tables`, `shader_lookup` and `metadata` are sums across 8 realization threads. Only `wall` was labelled.

**It is a trap rather than an obvious inconsistency** because the fields a reader meets *first* — `realize_draws`, `backend` — genuinely are wall and genuinely do compose to `total`. The first arithmetic you try works, which confirms the habit before the impossible values appear at the end of a long line.

## The fix

```
avg_ms[wall, sums to total]: total=21.85 realize_draws=1.26 realize_compute=0.00 plan=0.00
  backend=20.60 publish=0.00
| [SUMMED OVER 8.0 THREADS -- divide by threads before comparing to total]:
  tables=0.63 shader_lookup=0.39 shader_compile=0.01 metadata=0.29 fold=0.22 resources=0.03
| parallel[wall]: batches=0.00 draws=0.0 wall=0.00
```

Wall fields grouped and labelled; thread-summed fields fenced behind an explicit instruction.

## One thing the new output taught me immediately

The first version printed **`SUMMED OVER 0.0 THREADS`** when no parallel batch had run — i.e. it told the reader to divide by zero, which is worse than the ambiguity being removed. It is 1.0 now: no parallel batch means realization was **serial**, so those sums already *are* wall and dividing by the printed figure is still the correct instruction.

I found that by reading the live output, not by reasoning about the change. Worth stating because it is the same lesson as the rest of this: the line was wrong in a way that only showed up when someone looked at it.

## What it cost before being fixed

Six wrong shares from this lane in one day — `buffer copy` at 2.4% (which sat in `CLAUDE.md` and sent the other lane through five dead hypotheses), `gpu-device` at "43% of the frame", `draw_setup` at "61% of the frame" (61% of the *backend*, ~21% of the frame), a subtraction across two accountings that do not compose, a "13× gap" from a per-run sum against a cumulative average, and the headline **"30–39 fps gameplay"** that was a menu present-rate. The Linux lane retracted *"54% of the thread is copying a hash map"*, same shape, same line.

## Risk

**This changes the format of a diagnostic line that both lanes parse by hand.** Deliberate — the old format's readability was the defect — but it will break ad-hoc greps, so it is called out rather than buried.

## Verification

`ctest --no-tests=error -j8` → **179 tests, 179 passed, 0 failed** (Windows, MinGW WinLibs UCRT g++ 16.1.0). Verified on a live window that the wall fields sum to the total: `1.26 + 20.60 = 21.86` against `total=21.85`.

— Wren
