### PR TITLE
docs(gpu): AMD's GPU profiler already works on prosper — check vendor tooling before building another timer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,14 +278,20 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   are milestones worth recording (issue/`COMPATIBILITY.md`), not stopping points.
 - **Reach for free vendor/open-source tooling BEFORE building a `PROSPER_*` switch.** prosper is an
   ordinary Vulkan application, so AMD's and Khronos' own tools work on it directly and need no
-  per-title work. Verified on Linux/AMD 2026-08-08 with **no change to prosper's code**: a one-variable
-  RGP capture (`MESA_VK_TRACE=rgp MESA_VK_TRACE_FRAME=<n>`) yields per-draw *hardware* timing,
-  wavefront occupancy, instruction timing, cache counters and **queue/barrier events** — the last of
-  which no `PROSPER_*` switch measures at all. RenderDoc installs here and `renderdoccmd convert -c
-  chrome.json` is the headless export path. **`docs/GPU_PROFILING_EXTERNAL.md` has the recipes, what
-  each tool answers, and the traps** (RGP writes to `/tmp`; the Fedora RenderDoc package ships no
-  Python bindings). Build a `PROSPER_*` switch only for something the guest-facing layer knows and the
-  GPU vendor cannot see.
+  per-title work. **Measured on Linux/AMD 2026-08-08 with no change to prosper's code**, stated as
+  what was actually observed rather than as what the tools promise:
+  - **An RGP capture succeeds** from one variable (`MESA_VK_TRACE=rgp`), and RADV reports
+    `instruction timing: enabled, cache counters: enabled, queue events: enabled` on it. **Reading a
+    `.rgp` needs AMD's GUI — nobody here has opened one**, so treat its per-draw timing and occupancy
+    as the tool's documented capability, not as a project measurement.
+  - **`radeontop` answers "is this GPU-bound?" in one run, no capture and no GUI.** *Blue Prince* at
+    ~3.2 fps leaves the GPU at **4.17%** against a `vkcube` control at **56.31%** — so with #2215's
+    30-45 ms/submit, its submits are long because they **wait**. That control is mandatory here: the
+    tool prints "Unknown Radeon card" and its `ta`/`ee` counters are dead on this chip.
+  **`docs/GPU_PROFILING_EXTERNAL.md` has the recipes and the way each tool lies** — RGP writes to
+  `/tmp`, a frame ordinal silently captures the wrong regime, and the Fedora RenderDoc package ships
+  no Python bindings. Build a `PROSPER_*` switch only for something the guest-facing layer knows and
+  the GPU vendor cannot see.
 - **Build tools — don't avoid them.** This project is a long reverse-engineering effort, and getting
   progressively more complicated games running will keep demanding new instrumentation. When you hit a
   question the existing tools can't answer — "who references this address in the unsymbolicated eboot?",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -276,6 +276,16 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
      `tools/snapshot`, so regressions are caught without a human.
   Only after step 6 is a title considered **"done"**, and work moves to the next game. Earlier rungs
   are milestones worth recording (issue/`COMPATIBILITY.md`), not stopping points.
+- **Reach for free vendor/open-source tooling BEFORE building a `PROSPER_*` switch.** prosper is an
+  ordinary Vulkan application, so AMD's and Khronos' own tools work on it directly and need no
+  per-title work. Verified on Linux/AMD 2026-08-08 with **no change to prosper's code**: a one-variable
+  RGP capture (`MESA_VK_TRACE=rgp MESA_VK_TRACE_FRAME=<n>`) yields per-draw *hardware* timing,
+  wavefront occupancy, instruction timing, cache counters and **queue/barrier events** — the last of
+  which no `PROSPER_*` switch measures at all. RenderDoc installs here and `renderdoccmd convert -c
+  chrome.json` is the headless export path. **`docs/GPU_PROFILING_EXTERNAL.md` has the recipes, what
+  each tool answers, and the traps** (RGP writes to `/tmp`; the Fedora RenderDoc package ships no
+  Python bindings). Build a `PROSPER_*` switch only for something the guest-facing layer knows and the
+  GPU vendor cannot see.
 - **Build tools — don't avoid them.** This project is a long reverse-engineering effort, and getting
   progressively more complicated games running will keep demanding new instrumentation. When you hit a
   question the existing tools can't answer — "who references this address in the unsymbolicated eboot?",

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -1,0 +1,87 @@
+# External GPU profiling tools — what works on prosper today
+
+**Read this before building another timer.** prosper is an ordinary Vulkan application, so the free
+vendor and open-source GPU tooling works on it directly. Everything below was verified on this
+Linux/AMD box on 2026-08-08, on `prosper-app`, with **no change to prosper's own code**.
+
+The project has seventeen `PROSPER_*` timing switches, a per-pass GPU timer, a capture/replay stack
+and two report scripts. They are individually good. The tools here answer questions none of them can
+— per-draw hardware timing, wavefront occupancy, and barrier/queue events — and they answer them on
+**any title, with no per-title work**.
+
+## AMD Radeon GPU Profiler (RGP) — verified working
+
+RADV ships the capture side; nothing needs installing to *produce* a trace.
+
+```bash
+# Capture frame 900. Set the output directory FIRST -- see the /tmp warning below.
+mkdir -p ~/work/rgp && cd ~/work/rgp
+MESA_VK_TRACE=rgp MESA_VK_TRACE_FRAME=900 \
+PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+    <WORKTREE>/build/prosper-app <DUMP_ROOT>/<TITLE>-app0
+```
+
+Verified output on Blue Prince (`PPSA25009`), first attempt, 1.8 MB:
+
+```
+radv: Thread trace support is enabled (initial buffer size: 32 MiB,
+      instruction timing: enabled, cache counters: enabled, queue events: enabled)
+RGP capture saved to 'prosper-app_2026.08.08_19.58.22_frame901.rgp'
+```
+
+**What it gives that we cannot:** per-draw and per-dispatch *hardware* timing, wavefront occupancy,
+instruction timing, cache counters, and **queue events / barriers** — i.e. synchronisation stalls,
+which no `PROSPER_*` switch measures at all.
+
+Selectors: `MESA_VK_TRACE_FRAME=<n>`, `MESA_VK_TRACE_TRIGGER=<file>` (create the file to trigger),
+`MESA_VK_TRACE_PER_SUBMIT=1`, `RADV_THREAD_TRACE_BUFFER_SIZE=<MiB>`. Other backends: `rra` (ray
+tracing), `rmv` (memory), `ctxroll`.
+
+**Reading it needs the RGP GUI** (free download from AMD, Linux build available). There is no headless
+reader, so an agent can *produce* a capture but a human opens it. Say so when handing one over rather
+than implying you read it.
+
+## RenderDoc — installs here, and `convert` is the headless half
+
+```bash
+sudo dnf install -y renderdoc      # 1.45 on this box, Vulkan supported
+renderdoccmd convert -f cap.rdc -c chrome.json -o cap.json
+```
+
+`convert` targets `chrome.json` (Chrome/Perfetto timeline — parseable by script and openable in the
+Perfetto UI) and `xml`. That is the route for headless per-event analysis.
+
+**The Fedora package does NOT ship the Python bindings** — `rpm -ql renderdoc` gives `qrenderdoc` (the
+GUI) and `librenderdoc.so`, no `renderdoc.so` python module. So the scripted-analysis route is
+`convert`, not the Python API, and any recipe assuming `import renderdoc` will fail here.
+
+`renderdoccmd capture` triggers on a keypress rather than a frame ordinal, which makes it awkward
+headless; RGP's `MESA_VK_TRACE_FRAME` is the better automated capture.
+
+## Also available, free, not yet explored
+
+| tool | install | for |
+| --- | --- | --- |
+| `umr` | `dnf install umr` | AMD GPU register/ring debugger — hangs and resets |
+| `radeontop` | `dnf install radeontop` | coarse live GPU utilisation |
+| `perf` | installed | CPU side; already used across this project |
+
+## The `/tmp` warning, and it is the charter's own
+
+**RGP writes to `/tmp` by default.** On this box `/tmp` is a RAM-backed tmpfs with a per-user quota
+shared by every concurrent agent, and filling it does not merely fail your write — it kills the Bash
+tool for every agent on the machine (`CLAUDE.md`, *Write run artifacts to the real disk*). A single
+frame capture was 1.8 MB, but `MESA_VK_TRACE_PER_SUBMIT=1` over a long run is not bounded by anything
+you have chosen. **`cd` to a directory under `$HOME` before capturing**, and move any capture that
+lands in `/tmp` immediately.
+
+## Why this document exists
+
+The instinct on hitting a performance question here has been to add a `PROSPER_*` timer. That produced
+a large, individually-correct, collectively-unattributable set of instruments — and on 2026-08-08 six
+published shares from two lanes were wrong for arithmetic reasons rather than measurement ones
+(instrument traps 141, 143). Vendor tooling that reads the hardware's own thread trace is not subject
+to that class of error, costs nothing to run, and needs no maintenance from us.
+
+Reach for these first. Build a `PROSPER_*` switch only for something the guest-facing layer knows and
+the GPU vendor cannot see.

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -83,12 +83,43 @@ GUI) and `librenderdoc.so`, no `renderdoc.so` python module. So the scripted-ana
 `renderdoccmd capture` triggers on a keypress rather than a frame ordinal, which makes it awkward
 headless; RGP's `MESA_VK_TRACE_FRAME` is the better automated capture.
 
+## `radeontop` — the 60-second "is this even GPU-bound?" triage
+
+Verified, and it is the cheapest useful answer in this document: **no capture, no GUI, one run, any
+title.** Install with `dnf install radeontop`.
+
+```bash
+# 1. Start the title. 2. Sample INSIDE the regime you care about, never across a phase boundary.
+radeontop -d - -l 60
+```
+
+Measured on *Blue Prince* in its collapsed regime (t > 70 s, 60 samples) against a `vkcube` control:
+
+| | `gpu` mean | max | `spi` | `cb` | `sclk` |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `vkcube` (control) | **56.31%** | 66.67% | 29.64% | 11.17% | 99.95% |
+| Blue Prince, collapsed | **4.17%** | 7.50% | 3.43% | 1.32% | 38.1% |
+
+**Blue Prince at ~3.2 fps leaves the GPU ~96% idle.** Combined with #2215's measured 30-45 ms/submit
+`gpu_device`, that means those submits are long because they **wait**, not because they work — a
+synchronisation question rather than a shading-cost one, and the two have completely different fixes.
+
+### Run the control. It is one command and it is not optional here.
+
+`radeontop` prints **"Unknown Radeon card"** on this STRIX_HALO APU, so a low reading is ambiguous between
+*the GPU is idle* and *radeontop cannot read this chip*. `vkcube` renders continuously; if the counters
+move for it, they are live.
+
+**The control also found dead counters.** `ta` (texture addresser) and `ee` read **0.00% under vkcube**,
+which certainly samples a texture — so they are not readable on this hardware. **Trust `gpu`, `spi`, `cb`,
+`sx`, `sclk`. Do not quote `ta` or `ee`.** A triage step that silently reads zero on an unsupported block
+is worse than no triage step, and that distinction exists only because a control ran.
+
 ## Also available, free, not yet explored
 
 | tool | install | for |
 | --- | --- | --- |
 | `umr` | `dnf install umr` | AMD GPU register/ring debugger — hangs and resets |
-| `radeontop` | `dnf install radeontop` | coarse live GPU utilisation |
 | `perf` | installed | CPU side; already used across this project |
 
 ## The `/tmp` warning, and it is the charter's own

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -37,6 +37,31 @@ Selectors: `MESA_VK_TRACE_FRAME=<n>`, `MESA_VK_TRACE_TRIGGER=<file>` (create the
 `MESA_VK_TRACE_PER_SUBMIT=1`, `RADV_THREAD_TRACE_BUFFER_SIZE=<MiB>`. Other backends: `rra` (ray
 tracing), `rmv` (memory), `ctxroll`.
 
+### Use the TRIGGER, not a frame ordinal — and capture the regime you mean
+
+**A frame number is not portable across runs, and a title with performance regimes makes it actively
+misleading.** Both halves cost a capture here:
+
+* `MESA_VK_TRACE_FRAME=900` on Blue Prince lands at **t ~ 5 s**, because the load phase runs at
+  108-223 flips/s while the collapse runs at 3.2. That capture is a **menu frame** — the wrong regime
+  for any performance question, and nothing in the file says so.
+* `MESA_VK_TRACE_FRAME=7500`, chosen from a previous run's counters, produced **no capture at all**:
+  that run reached only 6,763 presents before it ended. Two runs of the same route pace differently.
+
+Use the trigger file and fire it when the condition you care about is true:
+
+```bash
+out=~/work/rgp; mkdir -p $out; cd $out; rm -f $out/trigger
+MESA_VK_TRACE=rgp MESA_VK_TRACE_TRIGGER=$out/trigger ... ./build/prosper-app <DUMP> &
+sleep 110          # or wait for whatever marks the regime -- a log line, a flip rate, a screenshot
+touch $out/trigger
+```
+
+**Sanity-check the regime from the capture's own size.** On Blue Prince the menu frame is **1.8 MB**
+and the collapsed frame is **35.9 MB** — a 20x difference, matching ~12 draws/submit against ~4,060.
+A capture that is far smaller than expected is very likely the wrong phase, and that is the cheapest
+check available before anyone spends time reading it.
+
 **Reading it needs the RGP GUI** (free download from AMD, Linux build available). There is no headless
 reader, so an agent can *produce* a capture but a human opens it. Say so when handing one over rather
 than implying you read it.


### PR DESCRIPTION
Refs #2215. Docs only: a new `docs/GPU_PROFILING_EXTERNAL.md` plus a pointer in `CLAUDE.md`.

## The finding

**prosper is an ordinary Vulkan application, so AMD's own profiler works on it directly.** Verified on this Linux/AMD box with **no change to prosper's code**:

```bash
MESA_VK_TRACE=rgp MESA_VK_TRACE_FRAME=900 ./build/prosper-app <DUMP>
```
```
radv: Thread trace support is enabled (initial buffer size: 32 MiB,
      instruction timing: enabled, cache counters: enabled, queue events: enabled)
RGP capture saved to 'prosper-app_2026.08.08_19.58.22_frame901.rgp'
```

Blue Prince frame 901, 1.8 MB, first attempt. That yields **per-draw hardware timing, wavefront occupancy, instruction timing, cache counters, and queue/barrier events** — on any title, with no per-title work.

**The barrier/queue events matter most**: no `PROSPER_*` switch measures synchronisation at all, and "where is it stalling" has been unanswerable with our own instruments.

## Why this belongs in the charter

The reflex here on a performance question has been to add a `PROSPER_*` timer. There are now **seventeen** of them plus a per-pass GPU timer, a capture/replay stack and two report scripts — individually good, collectively unattributable. On 2026-08-08 **six published shares from two lanes were wrong for arithmetic reasons rather than measurement ones** (traps 141, 143).

A tool reading the hardware's own thread trace is not subject to that class of error, costs nothing to run, and needs no maintenance from us.

## Also recorded

- **RenderDoc 1.45 installs** (`dnf install renderdoc`); `renderdoccmd convert -c chrome.json` is the headless export path (Perfetto-openable, script-parseable).
- **The Fedora RenderDoc package ships NO Python bindings** — only `qrenderdoc` and `librenderdoc.so`. Any recipe assuming `import renderdoc` fails here. Worth stating because that is the route most guides suggest.
- `renderdoccmd capture` triggers on a **keypress**, not a frame ordinal, which makes `MESA_VK_TRACE_FRAME` the better automated path.
- `umr` and `radeontop` are installable.

## Two traps

1. **RGP writes to `/tmp` by default** — the shared RAM tmpfs whose exhaustion kills the Bash tool for *every* agent on this box (`CLAUDE.md`). One frame was 1.8 MB; `MESA_VK_TRACE_PER_SUBMIT=1` over a long run is not bounded by anything you chose. `cd` under `$HOME` first.
2. **Reading a `.rgp` needs the GUI.** There is no headless reader, so an agent can produce a capture but a human opens it — say so when handing one over rather than implying you read it.

## Honest scope

I verified **capture**. I have not read a `.rgp` (no GUI here), so I am not claiming any finding *from* one — only that the pipeline produces valid captures on our titles. The Blue Prince analysis that follows is for whoever has the GUI.

Docs gate clean, `diff --check` clean, no session trailers.