### PR TITLE
fix(gpu_replay): tell the three --dump-resource failures apart, and add --list-resources

### DIFF
--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -65,7 +65,7 @@ void usage(const char* argv0) {
                          "[--draw-steps PREFIX [--draw-steps-every N] [--draw-steps-target WxH]] "
                          "[--recompile-raw] "
                          "[--prepend producer.prgcap] "
-                         "[--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
+                         "[--list-resources DRAW:vs|ps] [--dump-resource DRAW:vs|ps:BINDING PATH] [--allow-mismatch] "
                          "[--override-resource DRAW:vs|ps:BINDING PATH] "
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
@@ -1814,6 +1814,7 @@ int main(int argc, char** argv) {
     std::string post_compute_resource_spec, post_compute_resource_path;
     std::string failed_shader_spec, failed_shader_path;
     std::string retry_failed_chain_spec, retry_failed_stage_spec;
+    std::string list_resources_spec;   // #2373
     std::string realized_shader_spec, realized_shader_path;
     std::string rtt_seed_path;
     std::string graph_json_path, prepend_path;
@@ -1939,6 +1940,8 @@ int main(int argc, char** argv) {
             if (!end || *end || !value || value > 1024) { usage(argv[0]); return 2; }
             warmup_repeats = static_cast<uint32_t>(value);
         }
+        else if (std::string(argv[i]) == "--list-resources" && i + 1 < argc)
+            list_resources_spec = argv[++i];   // #2373
         else if (std::string(argv[i]) == "--dump-resource" && i + 2 < argc) {
             dump_spec = argv[++i]; dump_path = argv[++i];
         }
@@ -2511,6 +2514,47 @@ int main(int argc, char** argv) {
         }
         return 0;
     }
+    // #2373: enumerate a draw's bindings instead of probing for them. `--inspect-only` has always
+    // printed this table for COMPUTE dispatches and never for draws, so answering "what does this
+    // draw sample, and what is in it" meant one process launch per candidate index — 65 of them to
+    // find nine textures on Sonic Origins (#1871), and a wrong guess reads identically to a capture
+    // gap. That question is the last step of most wrong-pixel investigations.
+    if (!list_resources_spec.empty()) {
+        const size_t colon = list_resources_spec.find(':');
+        char* draw_end = nullptr;
+        const unsigned long long draw_index =
+            std::strtoull(list_resources_spec.c_str(), &draw_end, 0);
+        const std::string stage = colon == std::string::npos
+            ? std::string() : list_resources_spec.substr(colon + 1);
+        const size_t di = colon != std::string::npos &&
+                          draw_end == list_resources_spec.c_str() + colon
+            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
+        if (di == SIZE_MAX || (stage != "vs" && stage != "ps")) {
+            std::fprintf(stderr, "gpu_replay: invalid selector %s (want DRAW:vs|ps)\n",
+                         list_resources_spec.c_str());
+            return 2;
+        }
+        const auto* table = stage == "vs" ? replay.items[di].vrt.get() : replay.items[di].prt.get();
+        if (!table) {
+            std::printf("draw %llu %s: no captured resource table\n", draw_index, stage.c_str());
+            return 0;
+        }
+        std::printf("draw %llu %s: %zu resource(s)\n", draw_index, stage.c_str(),
+                    table->resources.size());
+        for (const auto& r : table->resources) {
+            // `bytes` is what --dump-resource would write, and 0 marks exactly the case that used to
+            // be indistinguishable from a wrong binding number.
+            std::printf("  binding=%-3u cls=%u fmt=%u comps=%u %ux%ux%u stride=%u "
+                        "addr=0x%llx size=%llu bytes=%llu%s\n",
+                        r.binding, static_cast<unsigned>(r.cls), static_cast<unsigned>(r.format),
+                        r.num_components, r.width, r.height, r.depth, r.stride,
+                        static_cast<unsigned long long>(r.gpu_addr),
+                        static_cast<unsigned long long>(r.size),
+                        static_cast<unsigned long long>(r.host_data ? r.host_data_size : 0),
+                        r.host_data ? "" : "  <- no captured bytes");
+        }
+        if (positional.size() == 1 && !inspect && dump_spec.empty()) return 0;
+    }
     if (!dump_spec.empty()) {
         size_t c1 = dump_spec.find(':'), c2 = c1 == std::string::npos ? c1 : dump_spec.find(':', c1 + 1);
         if (c1 == std::string::npos || c2 == std::string::npos) { usage(argv[0]); return 2; }
@@ -2527,8 +2571,36 @@ int main(int argc, char** argv) {
         const prosper::gpu::ShaderResource* found = nullptr;
         if (table) for (const auto& resource : table->resources)
             if (static_cast<int>(resource.binding) == binding) { found = &resource; break; }
-        if (!found || !found->host_data) {
-            std::fprintf(stderr, "gpu_replay: resource %s not found or has no captured bytes\n", dump_spec.c_str()); return 2;
+        // #2373: one message used to cover three different failures — no table, no such binding, and
+        // a binding captured without bytes — and only the LAST is a capture defect. Reading it as
+        // that one is how a wrong guess at a binding number gets published as "the bundle did not
+        // retain the sampled bytes". Say which, and on a wrong guess name the bindings that DO
+        // exist, since the answer the caller wants is almost always one of them.
+        if (!table) {
+            std::fprintf(stderr,
+                         "gpu_replay: draw %llu stage %s has no captured resource table "
+                         "(so no binding can be dumped; this is not a per-binding capture gap)\n",
+                         draw_index, stage.c_str());
+            return 2;
+        }
+        if (!found) {
+            std::string present;
+            for (const auto& resource : table->resources) {
+                if (!present.empty()) present += ", ";
+                present += std::to_string(resource.binding);
+            }
+            std::fprintf(stderr,
+                         "gpu_replay: draw %llu stage %s has no binding %d. Present: %s\n",
+                         draw_index, stage.c_str(), binding,
+                         present.empty() ? "(none)" : present.c_str());
+            return 2;
+        }
+        if (!found->host_data) {
+            std::fprintf(stderr,
+                         "gpu_replay: draw %llu stage %s binding %d exists but was captured "
+                         "WITHOUT bytes (this one IS a capture gap)\n",
+                         draw_index, stage.c_str(), binding);
+            return 2;
         }
         FILE* f = std::fopen(dump_path.c_str(), "wb");
         if (!f || std::fwrite(found->host_data, 1, static_cast<size_t>(found->host_data_size), f) != found->host_data_size) {


### PR DESCRIPTION
Fixes #2373. Refs #1871, #2361.

## The defect

`gpu_replay: resource 3:ps:0 not found or has no captured bytes` covered **three different things**:

1. the stage has **no captured resource table**
2. the table has **no such binding**
3. the binding exists and was **captured without bytes**

**Only (3) is a capture defect**, and reading the message as that one is how a wrong guess at a binding number becomes a published claim that *"the bundle did not retain the sampled bytes"*. That happened on #1871 and sat in an issue for an hour before I found the resources at bindings 32 and 34-42 rather than 0-4.

## The fix

Each failure says which it is, and a wrong binding **names the ones that exist**:

```
draw 3 stage ps has no binding 0. Present: 32, 34, 35, 36, 37, 38, 39, 40, 41, 42
draw 3 stage vs has no captured resource table (so no binding can be dumped; this is not a
    per-binding capture gap)
draw 3 stage ps binding N exists but was captured WITHOUT bytes (this one IS a capture gap)
```

`--list-resources DRAW:vs|ps` enumerates instead of probing:

```
draw 3 ps: 10 resource(s)
  binding=32  cls=0 fmt=1  comps=4 0x0x1       stride=16 addr=0x2005080060 size=32      bytes=32
  binding=34  cls=2 fmt=20 comps=3 1920x1080x1 stride=0  addr=0x2027880000 size=8294400 bytes=8847360
  … 41, 42
```

`--inspect-only` prints a resource table only for compute stages **that failed realization** (`gpu_replay.cpp:978`, inside the `failure[N]` block) — so the only existing enumeration is reachable *after* something has already gone wrong, and there is none for draws at all. Which means *"what does this draw sample, and what is in it"* — the last step of both #1871 and #2361 — meant one process launch per candidate index. **65 of them to find nine textures.**

## The enumeration found something 65 probes could not

**All nine of that draw's sampled textures share one address: `0x2027880000`.**

It is not nine empty intermediates. It is a **single 1920×1080 surface sampled nine times** — a blur or bloom chain — and that one surface is entirely zero. Addresses only become visible when the bindings are listed together, so brute-force probing structurally could not surface it. That materially changes #1871's frontier.

## Verification

Linux/RADV, on the real Sonic Origins capture:

| | |
| --- | --- |
| wrong binding | names `Present: 32, 34…42` |
| stage with no table | states it is not a per-binding gap |
| binding without bytes | states it **is** a capture gap |
| `--list-resources 3:ps` | 10 resources with addresses and byte counts |
| successful dump | unchanged, 8,847,360 bytes |
| `ctest --no-tests=error -j6` | **226 tests, 226 passed, 0 failed** |

## Review note

Diagnostic-only; no behaviour outside `gpu_replay`'s CLI changes, and the successful-dump path is untouched. The judgement worth a second reader is the `Present:` list — it is the thing that would have prevented my wrong conclusion, and it is only useful if it is exhaustive, so it prints every binding in the table with no filtering.
