### PR TITLE
fix(hle): 64-bit stat for APR reads — every read of a >2 GiB file returned zero bytes on Windows

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2608,8 +2608,31 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     // bytes): offsets 0x7af4a965/0x7af4a964. Reads are clamped to EOF like a host pread (empty
     // pakchunk2 placeholders complete with 0 bytes, status 0 — the model the engine already
     // accepted). CONFIDENCE: HIGH (offset+size confirmed on 8 live reads across 3 file kinds).
+    // #2371: MUST be a 64-bit stat. On MinGW `struct stat::st_size` is FOUR BYTES and `::stat()`
+    // fails outright with EOVERFLOW (errno 132) on any file larger than 2 GiB, leaving fsize at 0 --
+    // measured directly on GTA V's `update/update.rpf`, which is 3,018,098,688 bytes:
+    //
+    //     ::stat     rc=-1 errno=132 st_size=0  sizeof(st_size)=4
+    //     ::_stat64  rc=0            st_size=3018098688
+    //
+    // With fsize==0 the clamp below turns EVERY read of that file into zero bytes, and the request
+    // still reports success -- so the guest parses an unfilled buffer. GTA V dies on its own
+    // assertion doing exactly that (a 3-bit field reads 0, RAGE traps with `int 0x41`), never
+    // reaching its title screen on Windows. Linux is unaffected: its `stat` is 64-bit.
+    //
+    // A short read reported as OK is the worst available failure: it is indistinguishable from a
+    // successful read of zeros, which is why this cost a full investigation from the crash backwards
+    // rather than being caught at the I/O layer.
     uint64_t fsize = 0;
-    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
+    {
+#ifdef _WIN32
+        struct _stat64 st {};
+        if (::_stat64(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size;
+#else
+        struct stat st {};
+        if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size;
+#endif
+    }
     // #2139: this was Linux-only because the discriminator read the guest stack directly, which the
     // Windows import bridge makes impossible — its stub converts SysV->MS-x64 and CALLs the handler,
     // inserting a frame plus shadow space (the #672 class of bug). But that same bridge already


### PR DESCRIPTION
On MinGW `struct stat::st_size` is **four bytes** and `::stat()` fails with **EOVERFLOW** on any file over 2 GiB. Measured on GTA V's `update/update.rpf` (3,018,098,688 bytes):

```
::stat     rc=-1 errno=132 st_size=0  sizeof(st_size)=4
::_stat64  rc=0            st_size=3018098688
```

The APR read path took `fsize` from that failed call, so it stayed **0**, and the clamp turned **every read of the file into zero bytes while still reporting success**. The guest parsed an unfilled buffer.

A short read reported as OK is the worst available failure mode — indistinguishable from a successful read of zeros — which is why this took an investigation backwards from a crash rather than being caught at the I/O layer.

## Measured effect on GTA V (PPSA04263), Windows

| | before | after |
| --- | --- | --- |
| `past EOF` clamps | present | **0** |
| `update.rpf` read | `size=0 got=0 OK requested=7971` | `off=0x49204200 got=485 OK` |
| fault site | `eboot+0x2b39d70` | **moved** to `eboot+0x2b2c463` |

**Not a full fix for the title.** GTA V still does not reach its title screen on Windows; it now fails later. Tracked on #2371, which carries the full chain from the original crash down to this.

Linux is unaffected — its `stat` is already 64-bit — which is exactly why that lane reaches the main menu while this one rendered nothing.

## Incomplete by design

This fixes the **APR read path only**. `hle_file.cpp` has ~50 other `st_size` uses on 32-bit `struct stat`, including the guest-visible `f_stat`/`f_fstat`, which will misreport any file over 2 GiB. Those deserve a sweep with their own tests rather than being folded in here — and the sweep is worth doing, because any title shipping a >2 GiB archive hits this.

## Verification

`ctest --no-tests=error -j8` → **179 tests, 179 passed, 0 failed** (Windows, MinGW WinLibs UCRT g++ 16.1.0).

No regression test yet: asserting this needs a >2 GiB fixture, which cannot be committed. The sweep above is the right place to solve that properly (a sparse-file fixture created at test time would work).

— Wren