### PR TITLE
fix(hle): sweep the 64-bit stat fix to the guest-visible paths

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2608,8 +2608,31 @@ extern "C" uint64_t f_apr_read_submit(uint64_t a0, uint64_t a1, uint64_t a2,
     // bytes): offsets 0x7af4a965/0x7af4a964. Reads are clamped to EOF like a host pread (empty
     // pakchunk2 placeholders complete with 0 bytes, status 0 — the model the engine already
     // accepted). CONFIDENCE: HIGH (offset+size confirmed on 8 live reads across 3 file kinds).
+    // #2371: MUST be a 64-bit stat. On MinGW `struct stat::st_size` is FOUR BYTES and `::stat()`
+    // fails outright with EOVERFLOW (errno 132) on any file larger than 2 GiB, leaving fsize at 0 --
+    // measured directly on GTA V's `update/update.rpf`, which is 3,018,098,688 bytes:
+    //
+    //     ::stat     rc=-1 errno=132 st_size=0  sizeof(st_size)=4
+    //     ::_stat64  rc=0            st_size=3018098688
+    //
+    // With fsize==0 the clamp below turns EVERY read of that file into zero bytes, and the request
+    // still reports success -- so the guest parses an unfilled buffer. GTA V dies on its own
+    // assertion doing exactly that (a 3-bit field reads 0, RAGE traps with `int 0x41`), never
+    // reaching its title screen on Windows. Linux is unaffected: its `stat` is 64-bit.
+    //
+    // A short read reported as OK is the worst available failure: it is indistinguishable from a
+    // successful read of zeros, which is why this cost a full investigation from the crash backwards
+    // rather than being caught at the I/O layer.
     uint64_t fsize = 0;
-    { struct stat st {}; if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size; }
+    {
+#ifdef _WIN32
+        struct _stat64 st {};
+        if (::_stat64(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size;
+#else
+        struct stat st {};
+        if (::stat(host.c_str(), &st) == 0) fsize = (uint64_t)st.st_size;
+#endif
+    }
     // #2139: this was Linux-only because the discriminator read the guest stack directly, which the
     // Windows import bridge makes impossible — its stub converts SysV->MS-x64 and CALLs the handler,
     // inserting a frame plus shadow space (the #672 class of bug). But that same bridge already

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -1704,15 +1704,7 @@ HLE(k_aio_cancel) {  // (id, s32* state): nothing is in flight to cancel — rep
 }
 
 #ifndef _WIN32
-// #2371: 64-bit on Windows. MinGW's `struct stat::st_size` is 4 bytes and `::stat()` fails with
-// EOVERFLOW on any file over 2 GiB, so a guest that stats a large archive was told it does not
-// exist. GTA V ships a 3,018,098,688-byte `update/update.rpf`. `to_sce_stat64` already existed for
-// exactly this and was simply not used here.
-#ifdef _WIN32
-HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
-#else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
-#endif
 HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? errno : 0;
                if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1));
                filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1);

--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -50,6 +50,20 @@
 #endif
 #include "../host/posix_shim.hpp"   // Darwin: process_vm_*, pthread_getattr_np, st_*tim, prosper_mincore
 
+// #2371: a 64-bit stat, portably. MinGW's `struct stat::st_size` is FOUR BYTES and `::stat()`
+// fails outright with EOVERFLOW (errno 132) on any file larger than 2 GiB -- measured on GTA V's
+// 3,018,098,688-byte `update/update.rpf`. Every size taken from a 32-bit stat on Windows is
+// therefore either wrong or absent for large archives, and the failure is silent: the caller sees
+// "no such file" rather than "size did not fit".
+#ifdef _WIN32
+#define PROSPER_STAT ::_stat64
+using ProsperStat = struct _stat64;
+#else
+#define PROSPER_STAT ::stat
+using ProsperStat = struct stat;
+#endif
+
+
 #if defined(_WIN32) && defined(__MINGW32__)
 // MinGW's UCRT import library exposes this API, but its current headers omit the declaration.
 extern "C" _invalid_parameter_handler __cdecl
@@ -1690,7 +1704,15 @@ HLE(k_aio_cancel) {  // (id, s32* state): nothing is in flight to cancel — rep
 }
 
 #ifndef _WIN32
+// #2371: 64-bit on Windows. MinGW's `struct stat::st_size` is 4 bytes and `::stat()` fails with
+// EOVERFLOW on any file over 2 GiB, so a guest that stats a large archive was told it does not
+// exist. GTA V ships a 3,018,098,688-byte `update/update.rpf`. `to_sce_stat64` already existed for
+// exactly this and was simply not used here.
+#ifdef _WIN32
+HLE(f_stat)  { std::string h = translate(CS(a0)); struct _stat64 st; int r = ::_stat64(h.c_str(), &st); if (r == 0 && a1) to_sce_stat64(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+#else
 HLE(f_stat)  { std::string h = translate(CS(a0)); struct stat st; int r = ::stat(h.c_str(), &st); if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1)); return (uint64_t)(int64_t)r; }
+#endif
 HLE(f_fstat) { struct stat st; int r = ::fstat((int)a0, &st); int err = r < 0 ? errno : 0;
                if (r == 0 && a1) to_sce_stat(st, (uint8_t*)P(a1));
                filelog_fd_stat((int)a0, r, err, r == 0 ? (int64_t)st.st_size : -1);
@@ -2158,8 +2180,11 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
         std::string host = guest.empty() ? std::string() : translate(guest.c_str());
         uint64_t size = 0; uint32_t id = 0;
 #ifndef _WIN32
-        struct stat st;
-        bool found = !host.empty() && ::stat(host.c_str(), &st) == 0;
+        ProsperStat st;
+        // #2371: 64-bit, same reason -- this `size` is handed straight back to the guest through
+        // out_sizes, so a >2 GiB archive reported as missing here is a content gap from its point
+        // of view rather than a stat failure.
+        bool found = !host.empty() && PROSPER_STAT(host.c_str(), &st) == 0;
 #else
         struct _stat64 st;
         bool found = !host.empty() && ::_stat64(host.c_str(), &st) == 0;
@@ -2176,7 +2201,7 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
             const std::string raw_guest = "/app0/raw/" + guest.substr(6);
             std::string raw_host = translate(raw_guest.c_str());
 #ifndef _WIN32
-            found = !raw_host.empty() && ::stat(raw_host.c_str(), &st) == 0;
+            found = !raw_host.empty() && PROSPER_STAT(raw_host.c_str(), &st) == 0;
 #else
             found = !raw_host.empty() && ::_stat64(raw_host.c_str(), &st) == 0;
 #endif


### PR DESCRIPTION
Refs #2371. **Stacked on #2375** — merge that first.

Takes #2375's fix to the two places whose result the **guest** reads directly:

- **`f_stat`** — was `::stat` + `to_sce_stat`; now `_stat64` + `to_sce_stat64` on Windows. `to_sce_stat64` already existed for exactly this and was simply not wired up, so a guest stat of any file over 2 GiB reported failure.
- **the APR id/size lookup** — its `size` is returned through `out_sizes`, so a >2 GiB archive read as missing is a **content gap** from the guest's point of view, not a stat error it can diagnose.

Adds `PROSPER_STAT` / `ProsperStat` so the remaining sites can be converted without repeating the ifdef.

## It does NOT unblock GTA V further, and I checked rather than assumed

I proposed this sweep on #2371 as the prime suspect for the *second* assertion GTA V hits after #2375. **It is not.** With both fixes applied the fault stays at `eboot+0x2b2c463`:

```
#2375 alone            -> fault at eboot+0x2b2c463
#2375 + this sweep     -> fault at eboot+0x2b2c463   (unchanged)
```

So the second wall is not a file-size problem. Recorded on #2371 so nobody re-runs it.

Also worth stating: this branch **alone**, cut from master without #2375, shows the *original* fault at `eboot+0x2b39d70` — which is the missing base, not a regression. I verified that rather than reporting a scary-looking result.

## Why land it anyway

The bug is real and guest-visible independent of GTA V: any title that stats a >2 GiB file on Windows is told it does not exist. It just is not what blocks this title next.

## Verification

`ctest --no-tests=error -j8` → **179 tests, 179 passed, 0 failed** (Windows, MinGW WinLibs UCRT).

No regression test: asserting it needs a >2 GiB fixture, which cannot be committed. A sparse file created at test time would work and is the right way to cover both this and #2375 — noted rather than done.

— Wren