### PR TITLE
fix(libkernel): barrier destroy must refuse while threads are parked

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -392,6 +392,11 @@ if(TARGET prosper_core)
   target_link_libraries(test_sce_pthread_encoding PRIVATE prosper_core)
   add_test(NAME sce_pthread_encoding COMMAND test_sce_pthread_encoding)
 
+  # #2168 (barrier half): a barrier destroy must refuse while threads are parked.
+  add_executable(test_barrier_destroy_busy tests/test_barrier_destroy_busy.cpp)
+  target_link_libraries(test_barrier_destroy_busy PRIVATE prosper_core)
+  add_test(NAME barrier_destroy_busy COMMAND test_barrier_destroy_busy)
+
   add_executable(test_reallocf tests/test_reallocf.cpp)
   target_link_libraries(test_reallocf PRIVATE prosper_core)
   add_test(NAME reallocf COMMAND test_reallocf)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2795,6 +2795,13 @@ HLE(k_barrier_destroy) {
     // than via SCE_PTHREAD_ALIAS because this body is Sony-only -- there is no
     // `pthread_barrier_destroy` registration -- and its sibling k_barrier_init already returns
     // kSceKernelError* directly.
+    //
+    // This NARROWS the window; it does not close it, and the same qualification applies to the
+    // condvar half that landed first. A thread can register as a waiter between this check and the
+    // `pt_claim_slot` below, and it would then be retired out from under. Closing it needs the
+    // peek and the claim to be one atomic step -- possible, since both are lock-free atomics rather
+    // than lock-holders, but not cheap. What the check buys is the case the guest actually hits:
+    // threads ALREADY parked when the destroy arrives. Raised in review of this PR by Marlow.
     if (auto* existing = (pthread_barrier_t*)pt_peek_slot(a0))
         if (guest_barrier_has_waiters(existing)) return prosper::hle::kSceKernelErrorEBUSY;
     if (void* b = pt_claim_slot(a0)) retire_sync_object(b, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); });   // #2176

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2752,11 +2752,54 @@ POSIX_SEM_ALIAS(k_posix_sem_getvalue, k_sem_getvalue)
 // No POSIX spelling is registered on either body, so both encode in place (#2178). The serial
 // thread's -1 is NOT an errno and must survive untouched: sce_pthread_rc passes it through because
 // its high bits are set, which is exactly the case the pass-through guard exists for.
+// #2168 (barrier half). FreeBSD's pthread_barrier_destroy refuses a barrier that still has waiters
+// (`bar->b_waiters > 0` -> EBUSY) and does not free it. prosper kept no waiter count, so a guest
+// destroying a barrier out from under parked threads was told it succeeded and had its slot cleared.
+//
+// Deliberately the same shape as the condvar half (#2359): one registry keyed by the host object, an
+// RAII scope around the wait so an early return cannot leak a waiter and wedge every later destroy
+// into a permanent EBUSY, and the busy check BEFORE pt_claim_slot so a refusal leaves the guest a
+// working object rather than a handle to storage prosper has already quarantined.
+//
+// The barrier is the easier of the two to get right and the worse one to get wrong: every waiter is
+// parked until the count is reached, so destroying underneath them strands ALL of them, not one.
+std::mutex g_guest_barrier_waiters_mutex;
+std::unordered_map<pthread_barrier_t*, uint32_t> g_guest_barrier_waiters;
+
+struct GuestBarrierWaiterScope {
+    pthread_barrier_t* barrier;
+    explicit GuestBarrierWaiterScope(pthread_barrier_t* b) : barrier(b) {
+        std::lock_guard<std::mutex> lock(g_guest_barrier_waiters_mutex);
+        ++g_guest_barrier_waiters[b];
+    }
+    ~GuestBarrierWaiterScope() {
+        std::lock_guard<std::mutex> lock(g_guest_barrier_waiters_mutex);
+        auto found = g_guest_barrier_waiters.find(barrier);
+        if (found != g_guest_barrier_waiters.end() && found->second && !--found->second)
+            g_guest_barrier_waiters.erase(found);
+    }
+};
+
+inline bool guest_barrier_has_waiters(pthread_barrier_t* b) {
+    std::lock_guard<std::mutex> lock(g_guest_barrier_waiters_mutex);
+    auto found = g_guest_barrier_waiters.find(b);
+    return found != g_guest_barrier_waiters.end() && found->second > 0;
+}
+
 HLE(k_barrier_init)    { if (!a0 || a2 == 0) return prosper::hle::kSceKernelErrorEINVAL; auto* b = (pthread_barrier_t*)calloc(1, sizeof(pthread_barrier_t)); pthread_barrier_init(b, nullptr, (unsigned)a2); *(void**)(uintptr_t)a0 = b; return 0; }
-HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return prosper::hle::kSceKernelErrorEINVAL; int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : sce_pthread_rc(fbsd_errno(rc)); }
+HLE(k_barrier_wait)    { auto* b = ensure_barrier(a0); if (!b) return prosper::hle::kSceKernelErrorEINVAL; GuestBarrierWaiterScope waiting(b); /* #2168 */ int rc = pthread_barrier_wait(b); return rc == PTHREAD_BARRIER_SERIAL_THREAD ? (uint64_t)(int64_t)-1 : sce_pthread_rc(fbsd_errno(rc)); }
 // Quarantined, not freed (#2042) — `pthread_barrier_wait` parks every arriving thread inside the
 // object, the widest window in the family. See the contract block above k_mutex_destroy.
-HLE(k_barrier_destroy) { if (void* b = pt_claim_slot(a0)) retire_sync_object(b, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); }); return 0; }   // #2176
+HLE(k_barrier_destroy) {
+    // #2168: refuse while threads are parked, and BEFORE claiming the slot. Encoded in place rather
+    // than via SCE_PTHREAD_ALIAS because this body is Sony-only -- there is no
+    // `pthread_barrier_destroy` registration -- and its sibling k_barrier_init already returns
+    // kSceKernelError* directly.
+    if (auto* existing = (pthread_barrier_t*)pt_peek_slot(a0))
+        if (guest_barrier_has_waiters(existing)) return prosper::hle::kSceKernelErrorEBUSY;
+    if (void* b = pt_claim_slot(a0)) retire_sync_object(b, SyncObjectKind::Barrier, [](void* p) { pthread_barrier_destroy((pthread_barrier_t*)p); });   // #2176
+    return 0;
+}
 HLE(k_ef_wait)    { // (ef, pattern, waitMode, resultPat*, SceKernelUseconds* timeout)
     // The timeout arg (a4) was previously IGNORED — a bounded guest wait blocked forever (the
     // same class of silent hang root-caused for wait_on_address, hle_kernel_mem.cpp). Sony

--- a/prosper/tests/test_barrier_destroy_busy.cpp
+++ b/prosper/tests/test_barrier_destroy_busy.cpp
@@ -1,0 +1,106 @@
+// #2168 (barrier half): scePthreadBarrierDestroy must refuse a barrier that still has waiters.
+//
+// FreeBSD's pthread_barrier_destroy returns EBUSY when `bar->b_waiters > 0` and does NOT free the
+// object. prosper returned 0 unconditionally, so a guest destroying a barrier out from under parked
+// threads was told it succeeded and had its slot cleared.
+//
+// The barrier is worse than the condvar half (#2359) in one specific way, and the test is shaped
+// around it: every waiter is parked until the count is reached, so a destroy underneath them strands
+// ALL of them, not one. That means a regression here HANGS rather than fails, which is why the joins
+// below are watchdogged — a CI timeout with no message is strictly worse than a failure.
+
+#include "hle/dispatch.hpp"
+#include "hle/nid.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <thread>
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what);
+}
+
+using prosper::Hle;
+using prosper::HleFn;
+
+static uint64_t call(HleFn fn, uint64_t a0 = 0, uint64_t a1 = 0, uint64_t a2 = 0) {
+    return fn(a0, a1, a2, 0, 0, 0);
+}
+
+int main() {
+    std::fprintf(stderr, "== test_barrier_destroy_busy ==\n");
+    prosper::register_kernel_hle();
+
+    const auto by_name = [](const char* n) { return Hle::lookup(prosper::nid_hash(n)); };
+    HleFn init    = by_name("scePthreadBarrierInit");
+    HleFn wait    = by_name("scePthreadBarrierWait");
+    HleFn destroy = by_name("scePthreadBarrierDestroy");
+    check(init && wait && destroy, "the barrier entry points are registered");
+    if (failures) { std::fprintf(stderr, "== FAIL ==\n"); return 1; }
+
+    // --- the control FIRST: a barrier with no waiters must still destroy cleanly ----------------
+    // Asserted before the busy case so a change returning EBUSY unconditionally cannot pass this
+    // file. Its own barrier, so it cannot disturb the one below.
+    {
+        uint64_t spare = 0;
+        call(init, (uint64_t)(uintptr_t)&spare, 0, 2);
+        check(call(destroy, (uint64_t)(uintptr_t)&spare) == 0,
+              "control: destroying a barrier with no waiters returns 0");
+    }
+
+    // A barrier of 2: one worker parks, and the main thread never arrives, so it stays parked.
+    uint64_t slot = 0;
+    call(init, (uint64_t)(uintptr_t)&slot, 0, 2);
+
+    std::atomic<bool> entered{false}, released{false};
+    std::thread waiter([&] {
+        entered.store(true, std::memory_order_release);
+        call(wait, (uint64_t)(uintptr_t)&slot);
+        released.store(true, std::memory_order_release);
+    });
+
+    // ONE probe, after a delay — never a poll. `entered` says the thread reached the call, not that
+    // it is inside it, and there is no portable way to observe the moment a barrier parks.
+    //
+    // I first wrote this as a polling loop with a comment claiming it was safe "because destroy is
+    // side-effect-free while it refuses". That is true only WHILE it refuses. The FIRST probe runs
+    // before the waiter has parked, so it does not refuse — it destroys the barrier, and every later
+    // probe then peeks a retired slot and also returns 0. The loop cannot converge, and it reported
+    // this fix as broken when the fix was fine.
+    //
+    // That is the identical defect recorded in test_cond_destroy_busy.cpp, reproduced here by me
+    // after writing that comment. A probe that mutates what it probes is not made safe by being
+    // repeated; it is made worse. So: sleep past the park, then probe exactly once.
+    while (!entered.load(std::memory_order_acquire)) std::this_thread::yield();
+    std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    const uint64_t busy_rc = call(destroy, (uint64_t)(uintptr_t)&slot);
+
+    // The Sony encoding, not the bare errno: this body is Sony-only (there is no
+    // pthread_barrier_destroy registration) and its sibling scePthreadBarrierInit already returns
+    // kSceKernelError* directly, so a bare 16 here would be the #1984 split defect.
+    check(busy_rc == 0x80020010ull,
+          "scePthreadBarrierDestroy with a thread parked returns ENCODED EBUSY (0x80020010)");
+    check(slot != 0, "a refused destroy leaves the barrier slot intact");
+
+    // Release the waiter by arriving ourselves, and confirm the object still works after refusal.
+    call(wait, (uint64_t)(uintptr_t)&slot);
+    for (int spin = 0; spin < 1000 && !released.load(std::memory_order_acquire); ++spin)
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    if (!released.load(std::memory_order_acquire)) {
+        check(false, "the waiter did not wake within 5 s — the barrier was destroyed out from "
+                     "under a parked thread, so arriving reached nothing (#2168 regressed)");
+        waiter.detach();
+        std::fprintf(stderr, "== FAIL ==\n");
+        return 1;
+    }
+    waiter.join();
+    check(call(destroy, (uint64_t)(uintptr_t)&slot) == 0,
+          "once the waiter has left, the destroy succeeds");
+
+    std::fprintf(stderr, failures ? "== FAIL ==\n" : "== PASS ==\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Refs #2168 — completes the **barrier** half. The condvar half is #2359 (merged); **mutex remains untouched** and needs owner tracking that deliberately does not exist on POSIX hosts (#719/#793).

FreeBSD's `pthread_barrier_destroy` returns EBUSY when `bar->b_waiters > 0` and does not free the object. prosper returned 0 unconditionally.

Same shape as #2359: waiter registry, RAII scope around the wait, busy check **before** `pt_claim_slot` so a refusal leaves the guest a working object rather than a handle to quarantined storage. Encoded in place because the body is Sony-only and `k_barrier_init` already returns `kSceKernelError*`.

**The barrier is worse than the condvar in one specific way:** every waiter is parked until the count is reached, so a destroy underneath them strands *all* of them. A regression hangs rather than fails — hence the watchdogged join, because a CI timeout with no message is worse than a failure.

## I reproduced #2359's test defect while writing this test

The first version polled `destroy` in a loop, with a comment asserting it was safe *"because destroy is side-effect-free while it refuses"*. True only **while** it refuses — the first probe runs before the waiter parks, so it destroys the barrier, and every later probe peeks a retired slot and also returns 0. It reported this fix as broken when the fix was fine.

That is the identical defect **already recorded in `test_cond_destroy_busy.cpp`**, reproduced by me hours after writing the comment warning about it. Replaced with a single probe after the park, and the reasoning now lives in the test.

## Verification

| | |
| --- | --- |
| `ctest --no-tests=error -j8` | **180 tests, 180 passed, 0 failed** |
| mutation: disable the busy check | fails **both** arms — the EBUSY assertion and the watchdog — in 16.7 s rather than hanging |
| control | a barrier with no waiters still destroys cleanly, asserted **first** so an unconditional-EBUSY change cannot pass |

— Wren