### PR TITLE
tools(perf): stack_profile — name the code location where each thread is blocked

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -170,6 +170,15 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME compute_phase_report_logic
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_phase_report.py")
+  # stack_profile's frame classifier, against RECORDED gdb output. Deliberately needs no gdb and no
+  # ptrace: an end-to-end variant would skip silently wherever ptrace is unavailable, and a silently
+  # skipped test is indistinguishable from a passing one. What it pins is the case that already
+  # produced a wrong answer once — a versioned glibc symbol (`pthread_cond_wait@@GLIBC_2.3.2`) that
+  # defeated the `$`-anchored plumbing patterns, so a libc internal was named as the application's
+  # blocking site. Reverting only the version-stripping fix fails four of these cases.
+  add_test(NAME stack_profile_logic
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/perf/test_stack_profile.py")
   if(GIT_EXECUTABLE)
     # The provenance GATE: refuses to quote a measurement from a build that is not the revision the
     # author thinks it is. Pure argument/exit-status contract, no build required — but it resolves

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -511,6 +511,32 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   First result: `docs/RENDERER_PERFORMANCE_2026_07.md` § Astro Bot compute decomposition.
 - **`perf/ab_compute.sh`** — A/B one `PROSPER_*` switch against a routed live run, refusing to
   measure while another `prosper-app` holds the GPU and stamping commit/route/reps onto the result.
+- **`perf/stack_profile.py`** — when a title is slow because threads are **waiting**, this names the
+  code location each one waits at, by periodically attaching gdb and aggregating stacks per thread.
+  It is the second half of a pair: read `/proc` first for *how much* a thread blocks (cheap, high
+  rate), then use this for *where* (expensive, low rate).
+  ```bash
+  python3 tools/perf/stack_profile.py --pid $(pgrep -x prosper-app) --samples 12 --interval 5
+  ```
+  Three things about it are deliberate, and each came from a measured failure during bring-up:
+  - **`/proc` alone cannot answer "which lock".** A mutex wait and a condition-variable wait are the
+    same state, the same `wchan` (`futex_do_wait`) and the same syscall (202). On a purpose-built
+    control with three threads blocked in three known functions, `/proc` reported two of them
+    identically; the stack separated them. Do not conclude *which* primitive from `wchan`.
+  - **Run it on the HOST.** Inside distrobox/toolbox, gdb cannot ptrace a host process
+    (`Operation not permitted`) — and that failure produces *no stacks*, which is byte-identical to a
+    process with nothing blocked. The tool detects this case by name; it counts any empty sample as
+    FAILED, prints the failed count even when zero, and exits non-zero if every sample failed rather
+    than printing an empty report that reads clean.
+  - **Every sample stops the process** (~90 ms on a 4-thread toy, more on prosper). The report prints
+    total stopped time as a share of wall clock *before* any finding, and warns above 10%, because a
+    profiler that quietly steals wall clock will manufacture the frame-rate problem you came to find.
+
+  `test_stack_profile.py` self-tests the classifier against **recorded** gdb output, so it needs no
+  gdb and cannot skip silently. Its fixture is the real output that broke the first version: glibc
+  reports `pthread_cond_wait@@GLIBC_2.3.2`, whose version suffix defeated the `$`-anchored patterns,
+  so libc internals were reported as the application's blocking site — a wrong answer that looks
+  entirely plausible, and was caught only because the control had known-correct answers to contradict.
 
 Verification here is agentic-first (see `docs/VERIFICATION.md`): prefer a
 programmatic check (ctest exit code, `spirv-val`, a snapshot hash) over eyeballing.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -523,11 +523,14 @@ the shipped runtime. Build them from `build-linux/` like everything else.
     same state, the same `wchan` (`futex_do_wait`) and the same syscall (202). On a purpose-built
     control with three threads blocked in three known functions, `/proc` reported two of them
     identically; the stack separated them. Do not conclude *which* primitive from `wchan`.
-  - **Run it on the HOST.** Inside distrobox/toolbox, gdb cannot ptrace a host process
-    (`Operation not permitted`) — and that failure produces *no stacks*, which is byte-identical to a
-    process with nothing blocked. The tool detects this case by name; it counts any empty sample as
-    FAILED, prints the failed count even when zero, and exits non-zero if every sample failed rather
-    than printing an empty report that reads clean.
+  - **Run gdb on the same side of the container boundary as the target.** Measured both ways:
+    host+host works, distrobox+distrobox works, and **host process + in-container gdb is
+    `ptrace: Operation not permitted`**. Since `prosper-app` normally runs inside distrobox, run this
+    inside the same container. The rule is *same namespace*, not *always the host*. This matters
+    because the denial produces **no stacks**, which is byte-identical to a process with nothing
+    blocked — so a mis-sited gdb reads as a clean result. The tool detects that case by name; it
+    counts any empty sample as FAILED, prints the failed count even when zero, and exits non-zero if
+    every sample failed rather than printing an empty report that reads clean.
   - **Every sample stops the process** (~90 ms on a 4-thread toy, more on prosper). The report prints
     total stopped time as a share of wall clock *before* any finding, and warns above 10%, because a
     profiler that quietly steals wall clock will manufacture the frame-rate problem you came to find.

--- a/prosper/tools/perf/stack_profile.py
+++ b/prosper/tools/perf/stack_profile.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 """stack_profile — name the code location where each thread is blocked.
 
+LINUX ONLY, like its sibling `wait_profile.py`. It drives `gdb -p` and checks /proc/<pid>, so
+the Windows and macOS lanes cannot run it at all. Stated in the first line because these two
+tools are now the standard way to answer "why is this title stalled" in this project, and half
+the lanes can run neither -- a reader on those platforms should learn that here rather than
+from an empty report.
+
 `wait_profile.py` answers *how much* each thread waits, cheaply, by reading /proc.
 It cannot answer *where*, and the gap is not a detail: a mutex wait and a condition-variable
 wait are the SAME `/proc` state, the same `wchan` (`futex_do_wait`) and the same syscall

--- a/prosper/tools/perf/stack_profile.py
+++ b/prosper/tools/perf/stack_profile.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""stack_profile — name the code location where each thread is blocked.
+
+`wait_profile.py` answers *how much* each thread waits, cheaply, by reading /proc.
+It cannot answer *where*, and the gap is not a detail: a mutex wait and a condition-variable
+wait are the SAME `/proc` state, the same `wchan` (`futex_do_wait`) and the same syscall
+(202). Measured on a hand-built control with three threads blocked in three known
+functions, `/proc` reported two of them identically; only a stack could tell them apart.
+
+So this tool periodically attaches gdb, walks every thread's stack, and aggregates the
+result by call site. It is the expensive half of the pair — run it at a low rate alongside
+`wait_profile`, not instead of it.
+
+    tools/perf/stack_profile.py --pid 12345 --samples 12 --interval 5
+
+WHAT THIS COSTS, AND WHY THE TOOL INSISTS ON TELLING YOU
+--------------------------------------------------------
+Every sample STOPS the process (ptrace). On a 4-thread toy that is ~85-90 ms; on a large
+binary with many threads it is longer. That is a real perturbation of the thing you are
+measuring, so the report always prints the total stopped time and its share of wall clock.
+If you are chasing a frame-rate problem, a tool that silently steals 20% of the wall clock
+will invent one. Read that line before reading anything else.
+
+THE FAILURE MODE THAT MADE THIS TOOL PRINT SO LOUDLY
+-----------------------------------------------------
+When gdb cannot attach it prints an error and produces NO stacks -- which is
+character-for-character what a process with nothing blocked produces. During development
+this tool reported "no blocked threads" for a process that had four, because the attach was
+failing and stderr had been discarded. So:
+
+  * a sample that yields no stacks is counted as FAILED, never as "nothing was blocked";
+  * the failed count is printed even when it is zero, so its absence is never ambiguous;
+  * if EVERY sample failed the tool exits non-zero and says so, rather than printing an
+    empty report that reads like a clean result.
+
+A tool that cannot distinguish "I did not measure" from "there was nothing to measure" is
+not a negative result, it is a void one.
+
+PTRACE MUST RUN WHERE THE PROCESS LIVES
+---------------------------------------
+On a distrobox/toolbox setup, run this on the HOST. Inside the container gdb fails with
+`ptrace: Operation not permitted` for host processes -- which, per the above, previously
+looked exactly like a healthy idle process. The tool detects this specific error and names
+it rather than reporting an empty profile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+# gdb frames that are plumbing rather than an answer. A stack whose top frame is
+# `futex_wait` tells you nothing you did not already know from /proc; the first frame
+# BELOW this set is the one that names the lock.
+PLUMBING = re.compile(
+    r"^_*("
+    r"futex\w*|\w*futex_\w+|"
+    r"pthread_cond_\w+|pthread_mutex_\w+|pthread_rwlock_\w+|pthread_join\w*|"
+    r"lll_\w+|"
+    r"sem_(wait|timedwait)\w*|new_sem_wait\w*|"
+    r"clock_nanosleep\w*|nanosleep|usleep|sleep|"
+    r"poll|ppoll|select|pselect|epoll_wait|epoll_pwait|read|recv|recvmsg|"
+    r"syscall\w*|internal_syscall\w*|syscall_cancel\w*|internal_syscall_cancel\w*|"
+    r"libc_\w*(read|poll|select|wait)\w*|GI_\w+"
+    r")$"
+)
+
+# glibc reports versioned symbols as `pthread_mutex_lock@@GLIBC_2.2.5`. Matching against
+# the raw string silently fails every `$`-anchored pattern above, which does not produce an
+# error -- it produces a plausible-looking answer naming a libc internal instead of the
+# caller. Caught only because the control had known-correct answers to disagree with.
+VERSION_SUFFIX = re.compile(r"@+[A-Za-z0-9_.]+$")
+
+
+def strip_symbol(fn: str) -> str:
+    return VERSION_SUFFIX.sub("", fn).strip()
+
+FRAME_RE = re.compile(
+    r"^#(?P<n>\d+)\s+"
+    r"(?:0x[0-9a-fA-F]+\s+in\s+)?"
+    r"(?P<fn>[^(]+?)\s*\("
+)
+THREAD_RE = re.compile(
+    r'^Thread\s+\d+\s+\(Thread\s+\S+\s+\(LWP\s+(?P<lwp>\d+)\)\s*(?:"(?P<name>[^"]*)")?'
+)
+
+
+def gdb_stacks(pid: int, gdb: str, timeout: float):
+    """One sample. Returns (threads, stopped_seconds, error_or_None).
+
+    `threads` maps lwp -> (thread_name, [frame function names, outermost last]).
+    An empty mapping with error=None is still reported as a failure by the caller: see
+    the module docstring on why "no stacks" must never be read as "nothing blocked".
+    """
+    cmd = [
+        gdb, "-p", str(pid), "-batch", "-nx",
+        "-iex", "set auto-solib-add off",   # do not pay for shared-library symbols
+        "-iex", "set confirm off",
+        "-iex", "set pagination off",
+        "-ex", "thread apply all bt",
+    ]
+    started = time.monotonic()
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        return {}, time.monotonic() - started, f"gdb exceeded {timeout:g}s"
+    except FileNotFoundError:
+        return {}, 0.0, f"{gdb} not found"
+    stopped = time.monotonic() - started
+    blob = proc.stdout + proc.stderr
+
+    if "Operation not permitted" in blob:
+        return {}, stopped, (
+            "ptrace: Operation not permitted -- run this on the HOST, not inside "
+            "distrobox/toolbox (a container cannot ptrace a host process)"
+        )
+    if "No such process" in blob or "not being run" in blob:
+        return {}, stopped, f"pid {pid} is gone"
+
+    threads, lwp, name, frames = {}, None, None, []
+    for line in blob.splitlines():
+        m = THREAD_RE.match(line)
+        if m:
+            if lwp is not None:
+                threads[lwp] = (name, frames)
+            lwp, name, frames = int(m.group("lwp")), (m.group("name") or "?"), []
+            continue
+        f = FRAME_RE.match(line.strip())
+        if f and lwp is not None:
+            fn = strip_symbol(f.group("fn"))
+            if fn and not fn.startswith("0x"):
+                frames.append(fn)
+    if lwp is not None:
+        threads[lwp] = (name, frames)
+
+    if not threads:
+        detail = next((l for l in blob.splitlines() if "rror" in l or "ptrace" in l), "")
+        return {}, stopped, f"gdb produced no stacks{': ' + detail.strip() if detail else ''}"
+    return threads, stopped, None
+
+
+def blocking_site(frames, depth: int):
+    """The first non-plumbing frame, plus `depth-1` callers beneath it.
+
+    Returns None when a thread's whole stack is plumbing -- that is a real outcome
+    (a pure library wait with no symbolized caller), reported as such rather than
+    silently bucketed with something else.
+    """
+    for i, fn in enumerate(frames):
+        if not PLUMBING.match(fn):
+            return " <- ".join(frames[i:i + depth])
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Name where each thread is blocked, by periodic gdb stack sampling.")
+    ap.add_argument("--pid", type=int, required=True)
+    ap.add_argument("--samples", type=int, default=10, help="number of stack samples")
+    ap.add_argument("--interval", type=float, default=5.0,
+                    help="seconds between samples (keep high; each one stops the process)")
+    ap.add_argument("--depth", type=int, default=3, help="caller frames per reported site")
+    ap.add_argument("--top", type=int, default=3, help="sites listed per thread")
+    ap.add_argument("--gdb", default=os.environ.get("PROSPER_GDB", "gdb"))
+    ap.add_argument("--gdb-timeout", type=float, default=60.0)
+    args = ap.parse_args()
+
+    if shutil.which(args.gdb) is None:
+        print(f"error: {args.gdb} not found. Install gdb, or pass --gdb.", file=sys.stderr)
+        return 2
+    if not os.path.isdir(f"/proc/{args.pid}"):
+        print(f"error: no process {args.pid}", file=sys.stderr)
+        return 2
+
+    # thread key -> Counter of blocking sites; plus how many samples saw the thread at all.
+    sites = collections.defaultdict(collections.Counter)
+    seen = collections.Counter()
+    ok = failed = 0
+    errors = collections.Counter()
+    stopped_total = 0.0
+
+    wall_start = time.monotonic()
+    for i in range(args.samples):
+        threads, stopped, err = gdb_stacks(args.pid, args.gdb, args.gdb_timeout)
+        stopped_total += stopped
+        if err or not threads:
+            failed += 1
+            errors[err or "gdb produced no stacks"] += 1
+        else:
+            ok += 1
+            for lwp, (name, frames) in threads.items():
+                key = f"{name}/{lwp}"
+                seen[key] += 1
+                site = blocking_site(frames, args.depth)
+                sites[key][site if site else "(no symbolized caller -- pure library wait)"] += 1
+        if i + 1 < args.samples:
+            time.sleep(args.interval)
+    wall = time.monotonic() - wall_start
+
+    print(f"\nstack_profile: pid {args.pid}")
+    print(f"  samples: {ok} succeeded, {failed} FAILED  (of {args.samples} attempted)")
+    for msg, n in errors.most_common():
+        print(f"    failure x{n}: {msg}")
+    # Perturbation is printed before any finding, because it bounds how much of the
+    # finding the tool itself caused.
+    share = (stopped_total / wall * 100.0) if wall > 0 else 0.0
+    print(f"  process stopped by this tool: {stopped_total:.2f}s of {wall:.2f}s wall "
+          f"({share:.1f}% -- this is perturbation, not a measurement of the program)")
+    if share > 10.0:
+        print("    WARNING: over 10% of wall clock was spent stopped. Raise --interval "
+              "before trusting any timing conclusion drawn alongside this run.")
+
+    if ok == 0:
+        print("\n  NO SAMPLES SUCCEEDED -- this is not a result. Nothing below is a finding.")
+        return 1
+
+    print(f"\n  {'thread':<28} {'seen':>5}  blocking site (top {args.top}, by sample count)")
+    print(f"  {'-' * 28} {'-' * 5}  {'-' * 60}")
+    for key in sorted(seen, key=lambda k: -seen[k]):
+        first = True
+        for site, n in sites[key].most_common(args.top):
+            pct = n / seen[key] * 100.0
+            label = f"{key:<28} {seen[key]:>5}" if first else f"{'':<28} {'':>5}"
+            print(f"  {label}  {pct:5.1f}%  {site}")
+            first = False
+    print(f"\n  Shares are per thread: n/(samples in which THAT thread was seen), so a "
+          f"thread\n  that started late is not diluted by samples it could not appear in.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/perf/stack_profile.py
+++ b/prosper/tools/perf/stack_profile.py
@@ -36,12 +36,20 @@ failing and stderr had been discarded. So:
 A tool that cannot distinguish "I did not measure" from "there was nothing to measure" is
 not a negative result, it is a void one.
 
-PTRACE MUST RUN WHERE THE PROCESS LIVES
----------------------------------------
-On a distrobox/toolbox setup, run this on the HOST. Inside the container gdb fails with
-`ptrace: Operation not permitted` for host processes -- which, per the above, previously
-looked exactly like a healthy idle process. The tool detects this specific error and names
-it rather than reporting an empty profile.
+RUN THIS WHERE THE TARGET RUNS
+-------------------------------
+gdb must be on the same side of the container boundary as the process. Measured both ways
+on this box:
+
+    process on host      + gdb on host       -> works
+    process in distrobox + gdb in distrobox  -> works
+    process on host      + gdb in distrobox  -> ptrace: Operation not permitted
+
+So for a `prosper-app` launched inside distrobox, run this inside the same container; for a
+host process, run it on the host. The rule is "same namespace", not "always the host" -- and
+getting that backwards costs nothing but confusion, because per the section above the denial
+produces an empty profile that reads like a healthy process. The tool detects this specific
+error and names it.
 """
 
 from __future__ import annotations
@@ -117,8 +125,9 @@ def gdb_stacks(pid: int, gdb: str, timeout: float):
 
     if "Operation not permitted" in blob:
         return {}, stopped, (
-            "ptrace: Operation not permitted -- run this on the HOST, not inside "
-            "distrobox/toolbox (a container cannot ptrace a host process)"
+            "ptrace: Operation not permitted -- run gdb on the SAME side of the container "
+            "boundary as the target (a container cannot ptrace a host process; "
+            "in-container gdb against an in-container prosper-app works)"
         )
     if "No such process" in blob or "not being run" in blob:
         return {}, stopped, f"pid {pid} is gone"

--- a/prosper/tools/perf/test_stack_profile.py
+++ b/prosper/tools/perf/test_stack_profile.py
@@ -142,7 +142,10 @@ class TestFailureIsNotAResult(unittest.TestCase):
     def test_container_ptrace_denial_is_named_specifically(self):
         _, _, err = self._run_with("", "ptrace: Operation not permitted.")
         self.assertIsNotNone(err)
-        self.assertIn("HOST", err, "the ptrace denial must tell the user where to run it")
+        # The message must state the *siting* rule, because the denial is otherwise silent:
+        # no stacks is byte-identical to a process with nothing blocked.
+        self.assertIn("container", err,
+                      "the ptrace denial must tell the user which side to run gdb on")
 
     def test_dead_process_is_named(self):
         _, _, err = self._run_with("", "ptrace: No such process.")

--- a/prosper/tools/perf/test_stack_profile.py
+++ b/prosper/tools/perf/test_stack_profile.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for stack_profile's frame classification.
+
+These run everywhere: they exercise the parsing and classification against RECORDED gdb
+output, so they need no gdb, no ptrace and no live process. That matters more than
+convenience -- an end-to-end test needing ptrace would skip silently on any machine
+without it, and a silently skipped test is indistinguishable from a passing one.
+
+The fixture below is verbatim gdb 17.2 output for a purpose-built control whose three
+threads block in three known functions. It is the input that broke the first version of
+the tool, kept because the failure was invisible without a known-correct answer to
+disagree with: the tool reported `__internal_syscall_cancel`, which is not wrong-looking.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import stack_profile as sp  # noqa: E402
+
+
+# Verbatim `gdb -p <pid> -batch -ex 'thread apply all bt'`, glibc 2.4x, gdb 17.2.
+REAL_GDB_OUTPUT = """
+Thread 4 (Thread 0x7faee0f5b6c0 (LWP 910931) "known"):
+#0  0x00007faee0fda312 in __syscall_cancel_arch () from /lib64/libc.so.6
+#1  0x00007faee0fce52c in __internal_syscall_cancel () from /lib64/libc.so.6
+#2  0x00007faee0fd4b1a in __futex_abstimed_wait_common () from /lib64/libc.so.6
+#3  0x00007faee0fd1a51 in pthread_mutex_lock@@GLIBC_2.2.5 () from /lib64/libc.so.6
+#4  0x00000000004004e4 in marlow_blocks_on_mutex () at known.c:10
+#5  0x0000000000400560 in t_mutex (a=0x0) at known.c:14
+
+Thread 3 (Thread 0x7faee075a6c0 (LWP 910932) "known"):
+#0  0x00007faee0fda312 in __syscall_cancel_arch () from /lib64/libc.so.6
+#1  0x00007faee0fce52c in __internal_syscall_cancel () from /lib64/libc.so.6
+#2  0x00007faee0fce877 in __futex_abstimed_wait_cancelable64 () from /lib64/libc.so.6
+#3  0x00007faee0fd10cc in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libc.so.6
+#4  0x000000000040050e in marlow_blocks_on_condvar () at known.c:11
+
+Thread 2 (Thread 0x7faee0f596c0 (LWP 910933) "known"):
+#0  0x00007faee0fda312 in __syscall_cancel_arch () from /lib64/libc.so.6
+#1  0x00007faee0fce52c in __internal_syscall_cancel () from /lib64/libc.so.6
+#2  0x00007faee0f8b8e7 in clock_nanosleep@@GLIBC_2.2.5 () from /lib64/libc.so.6
+#3  0x00007faee0f90d63 in sleep () from /lib64/libc.so.6
+#4  0x000000000040051f in marlow_blocks_on_sleep () at known.c:12
+"""
+
+
+class TestSymbolStripping(unittest.TestCase):
+    def test_version_suffix_removed(self):
+        # The bug: `$`-anchored patterns never matched a versioned symbol, so glibc
+        # frames were classified as application code.
+        self.assertEqual(sp.strip_symbol("pthread_cond_wait@@GLIBC_2.3.2"), "pthread_cond_wait")
+        self.assertEqual(sp.strip_symbol("clock_nanosleep@GLIBC_2.2.5"), "clock_nanosleep")
+
+    def test_unversioned_symbol_untouched(self):
+        self.assertEqual(sp.strip_symbol("marlow_blocks_on_mutex"), "marlow_blocks_on_mutex")
+
+    def test_versioned_plumbing_is_recognised_as_plumbing(self):
+        # Directly guards the regression: this is the assertion that fails if the `$`
+        # anchor is reintroduced without stripping.
+        for sym in ("pthread_cond_wait@@GLIBC_2.3.2", "pthread_mutex_lock@@GLIBC_2.2.5",
+                    "clock_nanosleep@@GLIBC_2.2.5"):
+            self.assertIsNotNone(sp.PLUMBING.match(sp.strip_symbol(sym)),
+                                 f"{sym} must classify as plumbing")
+
+
+class TestBlockingSite(unittest.TestCase):
+    """The tool's actual job: skip the wait machinery, name the caller."""
+
+    def _sites(self, depth=1):
+        threads, _, err = self._parse()
+        self.assertIsNone(err)
+        return {lwp: sp.blocking_site(frames, depth) for lwp, (_, frames) in threads.items()}
+
+    def _parse(self):
+        # Exercise the real parser by faking one gdb invocation.
+        import subprocess
+        real = subprocess.run
+
+        class Fake:
+            stdout, stderr, returncode = REAL_GDB_OUTPUT, "", 0
+
+        subprocess.run = lambda *a, **k: Fake()
+        try:
+            return sp.gdb_stacks(1, "gdb", 10.0)
+        finally:
+            subprocess.run = real
+
+    def test_all_three_known_sites_are_named(self):
+        sites = set(self._sites().values())
+        self.assertIn("marlow_blocks_on_mutex", sites)
+        self.assertIn("marlow_blocks_on_condvar", sites)
+        self.assertIn("marlow_blocks_on_sleep", sites)
+
+    def test_mutex_and_condvar_are_distinguished(self):
+        # /proc cannot do this: both threads are state S, wchan futex_do_wait, syscall 202.
+        # Being able to separate them is the entire reason this tool exists.
+        sites = self._sites()
+        self.assertNotEqual(sites[910931], sites[910932])
+
+    def test_no_libc_internal_is_ever_reported_as_the_site(self):
+        # The original failure mode: a plausible-looking libc frame in place of the answer.
+        for lwp, site in self._sites().items():
+            self.assertFalse(site.startswith("__"),
+                             f"lwp {lwp} reported libc internal {site!r} as the blocking site")
+
+    def test_depth_includes_callers(self):
+        self.assertEqual(self._sites(depth=2)[910931],
+                         "marlow_blocks_on_mutex <- t_mutex")
+
+    def test_thread_identity_is_parsed(self):
+        threads, _, err = self._parse()
+        self.assertIsNone(err)
+        self.assertEqual(len(threads), 3)
+        self.assertEqual(threads[910932][0], "known")
+
+
+class TestFailureIsNotAResult(unittest.TestCase):
+    """A sample that yields nothing must be a FAILURE, never 'nothing was blocked'."""
+
+    def _run_with(self, stdout, stderr=""):
+        import subprocess
+        real = subprocess.run
+
+        class Fake:
+            returncode = 0
+
+        Fake.stdout, Fake.stderr = stdout, stderr
+        subprocess.run = lambda *a, **k: Fake()
+        try:
+            return sp.gdb_stacks(1, "gdb", 10.0)
+        finally:
+            subprocess.run = real
+
+    def test_empty_output_reports_an_error(self):
+        threads, _, err = self._run_with("")
+        self.assertEqual(threads, {})
+        self.assertIsNotNone(err, "empty gdb output must not be reported as a clean sample")
+
+    def test_container_ptrace_denial_is_named_specifically(self):
+        _, _, err = self._run_with("", "ptrace: Operation not permitted.")
+        self.assertIsNotNone(err)
+        self.assertIn("HOST", err, "the ptrace denial must tell the user where to run it")
+
+    def test_dead_process_is_named(self):
+        _, _, err = self._run_with("", "ptrace: No such process.")
+        self.assertIsNotNone(err)
+        self.assertIn("gone", err)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Why

The user's framing, which reset my priorities: *"the primary goal is making it easy to find the cause of
bad performance in games… good FPS in Blue Prince is worth nothing if we fix it by luck."*

#2377 (`wait_profile`) answers **how much** each thread waits. Using it on Blue Prince localised the stall
to the main thread sitting **54.4% blocked on futexes** while 13 Job.Workers parked on a *different*
address. Useful — and then it stops, because it cannot say **which lock**, and that is the next question in
every such investigation.

This PR is the other half of the pair.

## The limit it removes, demonstrated rather than asserted

I built a control with three threads blocked in three known functions and read `/proc`:

```
tid=908640  state=S  wchan=futex_do_wait        syscall=202     <- blocked on a MUTEX
tid=908641  state=S  wchan=futex_do_wait        syscall=202     <- blocked on a CONDVAR
tid=908642  state=S  wchan=hrtimer_nanosleep    syscall=230
```

**A mutex wait and a condvar wait are indistinguishable in `/proc`** — same state, same `wchan`, same
syscall. Anyone reading `wchan` to decide *which primitive* a thread is on is reading something that cannot
carry that information.

`stack_profile` attaches gdb, skips the wait machinery, and reports the first application frame:

```
thread                        seen  blocking site
known/910703                     3  100.0%  marlow_blocks_on_mutex
known/910704                     3  100.0%  marlow_blocks_on_condvar
known/910705                     3  100.0%  marlow_blocks_on_sleep
known/910701                     3  100.0%  main
```

All three named; mutex and condvar separated.

## Three properties that are the actual point

Each came from a failure I measured, not from a design preference.

**1. A failed attach and a healthy process look identical.** gdb that cannot attach produces no stacks —
byte-identical to a process with nothing blocked. **This fooled me during development**: I ran it with
stderr discarded, got an empty report, and read it as "nothing blocked" for a process that had four blocked
threads. So an empty sample counts as `FAILED`, the failed count prints **even when zero**, and an
all-failed run exits non-zero rather than printing a clean-looking empty report:

```
  samples: 0 succeeded, 2 FAILED  (of 2 attempted)
  NO SAMPLES SUCCEEDED -- this is not a result. Nothing below is a finding.
  exit=1
```

**2. Run it on the HOST.** Inside distrobox, gdb cannot ptrace a host process (`Operation not permitted`)
— and by (1) that failure is silent. The tool detects and names that exact case.

**3. Perturbation prints before any finding.** Each sample stops the process (~85–92 ms measured over 8
trials on a 4-thread toy; more on prosper). The report leads with stopped time as a share of wall clock and
warns above 10%. A profiler that quietly steals wall clock will manufacture the frame-rate problem you came
to investigate.

## Verification

`test_stack_profile.py` — **11/11 green** — pins the classifier against **recorded** gdb output, so it
needs neither gdb nor ptrace and **cannot skip silently** (an end-to-end variant would skip wherever ptrace
is unavailable, and a silently skipped test is indistinguishable from a passing one).

**Mutation arm:** reverting *only* the version-stripping fix fails **4 of the 11** cases. The tests are not
void.

**The bug that arm guards is the one my own control caught.** My first version reported:

```
known/910704   100.0%  __internal_syscall_cancel <- __futex_abstimed_wait_cancelable64
```

instead of `marlow_blocks_on_condvar`. glibc reports `pthread_cond_wait@@GLIBC_2.3.2`, and the `@@GLIBC…`
suffix defeated every `$`-anchored pattern, so libc internals were named as the application's blocking
site. **That output looks entirely plausible** — it is a real function, genuinely on the stack. It was
caught only because the control had known-correct answers to contradict it, which is the charter's rule
about constructing a positive instance by hand, outside whatever produced the result.

Pure additions (`+427/-0`), no deletions. `diff --check` clean, docs gate clean, no `Claude-Session`
trailers.

## Not verified

Not yet run against a live `prosper-app` — **no game dump is mounted on this machine right now** (only
run-output directories and a synthetic fixture). The per-sample cost on prosper's ~20 threads and much
larger symbol table will be higher than the toy's 90 ms, and I have not measured it. Nothing here claims
otherwise; the numbers quoted are the control's.

Refs #2241
