### PR TITLE
fix(libkernel): scePthreadRename/SetName encode their errno (family rule, CONFIDENCE: MED)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2715,29 +2715,41 @@ SCE_PTHREAD_ALIAS(k_sce_attr_getdetachstate,   k_attr_getdetachstate)
 // libkernel returns. Left bare and raised on #2178 rather than settled by whoever edits last.
 SCE_PTHREAD_ALIAS(k_sce_key_create,            k_key_create)
 
-// #2178: Rename and SetName, settled by GUEST DISASSEMBLY rather than by the encoding rule's
-// analogy. #2365 deliberately left the three name functions bare because neither side had evidence:
-// test_pthread_names' bare expectations are uncited, and the rule's own evidence (the shipped
-// libc.prx's C11 _Mtx_*/_Cnd_* wrappers comparing against encoded constants) covers mutex and
-// condvar only.
+// #2178: Rename and SetName encode, on the FAMILY RULE -- every Sony libkernel spelling returns
+// 0x80020000|errno -- and not on any evidence specific to these two. CONFIDENCE: MED.
 //
-// Dragon Quest VII (PPSA17942) settles it for Rename. Its one caller logs the failure:
+// #2365 deliberately left the three name functions bare because neither side had evidence, and that
+// is still true: test_pthread_names' bare expectations are uncited, and the rule's own direct
+// evidence (the shipped libc.prx's C11 _Mtx_*/_Cnd_* wrappers comparing against encoded constants)
+// covers mutex and condvar only. What changes here is which default applies to a member of the
+// family with no evidence either way, not that evidence arrived.
+//
+// The one caller found in a dump is CONSISTENT WITH THIS AND DOES NOT DISCRIMINATE. Dragon Quest VII
+// (PPSA17942) logs the failure:
 //
 //   5fac7b7:  call   0x669b570              ; scePthreadRename
 //   5fac7bc:  test   eax,eax
 //   5fac7c0:  movsxd rdx,eax                ; the error, sign-extended into arg2
 //   5fac7c3:  lea    rsi,[rip+0x2299e72]    ; -> "…Failed in scePthreadRename(), 0x%08x"
 //
-// `0x%08x`. Eight-digit hex is how a Sony error code is printed -- 0x80020016 fills it exactly --
-// and a bare errno would be `%d`, which this same binary uses elsewhere for plain integers. The
-// guest states in its own diagnostic which space it expects.
+// An earlier version of this comment read `0x%08x` as the guest naming the space it expects. It is
+// not: %08x ZERO-PADS to eight columns, so a bare 22 prints as 0x00000016 and an encoded one as
+// 0x80020016, and both render fine. `test eax,eax` above it is nonzero in either space too. So the
+// disassembly rules nothing out -- exactly the reason Getname below is not swept, applied one
+// paragraph higher up. (Caught in review by Marlow, who checked it precisely because it was a
+// citation raising certainty in a direction already believed.)
 //
 // SetName travels with it: same body, same contract, and no separate evidence is needed for a
 // function that IS this one under another name.
 //
-// GETNAME IS DELIBERATELY NOT SWEPT. Its only caller in that dump does `test eax,eax` and nothing
-// else, so 3 and 0x80020003 are indistinguishable there. The evidence that settles Rename does not
-// reach it, and test_pthread_names' `== 3` stands until a caller that discriminates turns up.
+// GETNAME IS DELIBERATELY NOT SWEPT -- not because the evidence is weaker there, but because its
+// contract is different. Getname's documented failures are lookup failures (ESRCH) on a call whose
+// success path writes through a buffer, and #2365's split turns on the return CONVENTION rather
+// than the spelling. Rename fails the way the rest of the family fails; Getname's `== 3` stands
+// until a caller that discriminates turns up.
+//
+// What would settle either: a capture of what the real libkernel returns, or a guest that branches
+// on the value rather than only testing it against zero.
 SCE_PTHREAD_ALIAS(k_sce_pthread_rename,        k_pthread_rename)
 // The same bodies under their POSIX spellings, split along the RETURN-CONVENTION axis rather than
 // the encoding one (#2182). k_sem_* return the error NUMBER, which is right for scePthreadSem* and

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2714,6 +2714,31 @@ SCE_PTHREAD_ALIAS(k_sce_attr_getdetachstate,   k_attr_getdetachstate)
 // the honest resolution needs something neither of us has here: a capture of what the real
 // libkernel returns. Left bare and raised on #2178 rather than settled by whoever edits last.
 SCE_PTHREAD_ALIAS(k_sce_key_create,            k_key_create)
+
+// #2178: Rename and SetName, settled by GUEST DISASSEMBLY rather than by the encoding rule's
+// analogy. #2365 deliberately left the three name functions bare because neither side had evidence:
+// test_pthread_names' bare expectations are uncited, and the rule's own evidence (the shipped
+// libc.prx's C11 _Mtx_*/_Cnd_* wrappers comparing against encoded constants) covers mutex and
+// condvar only.
+//
+// Dragon Quest VII (PPSA17942) settles it for Rename. Its one caller logs the failure:
+//
+//   5fac7b7:  call   0x669b570              ; scePthreadRename
+//   5fac7bc:  test   eax,eax
+//   5fac7c0:  movsxd rdx,eax                ; the error, sign-extended into arg2
+//   5fac7c3:  lea    rsi,[rip+0x2299e72]    ; -> "…Failed in scePthreadRename(), 0x%08x"
+//
+// `0x%08x`. Eight-digit hex is how a Sony error code is printed -- 0x80020016 fills it exactly --
+// and a bare errno would be `%d`, which this same binary uses elsewhere for plain integers. The
+// guest states in its own diagnostic which space it expects.
+//
+// SetName travels with it: same body, same contract, and no separate evidence is needed for a
+// function that IS this one under another name.
+//
+// GETNAME IS DELIBERATELY NOT SWEPT. Its only caller in that dump does `test eax,eax` and nothing
+// else, so 3 and 0x80020003 are indistinguishable there. The evidence that settles Rename does not
+// reach it, and test_pthread_names' `== 3` stands until a caller that discriminates turns up.
+SCE_PTHREAD_ALIAS(k_sce_pthread_rename,        k_pthread_rename)
 // The same bodies under their POSIX spellings, split along the RETURN-CONVENTION axis rather than
 // the encoding one (#2182). k_sem_* return the error NUMBER, which is right for scePthreadSem* and
 // wrong for sem_*: C11 7.26 and FreeBSD sem_wait(3) both specify "return -1, number left in errno".
@@ -4455,8 +4480,8 @@ void register_kernel_hle() {
     R("scePthreadSetschedparam", k_log_setschedparam);  R("scePthreadSetprio", k_log_setprio);
     R("scePthreadGetprio", k_getprio);
     R("scePthreadGetname", k_pthread_getname);
-    R("scePthreadRename", k_pthread_rename);
-    R("scePthreadSetName", k_pthread_rename);
+    R("scePthreadRename", k_sce_pthread_rename);
+    R("scePthreadSetName", k_sce_pthread_rename);
     R("pthread_getname_np", k_pthread_getname);
     R("pthread_rename_np", k_pthread_rename);
     R("pthread_set_name_np", k_pthread_rename);

--- a/prosper/tests/test_pthread_names.cpp
+++ b/prosper/tests/test_pthread_names.cpp
@@ -129,6 +129,23 @@ int main() {
     CHECK(strcmp((const char*)sony_out.data(), renamed_again) == 0,
           "null rename preserves the previous name");
 
+    // #2178: scePthreadRename's failure is ENCODED, settled by guest disassembly rather than by the
+    // encoding rule's analogy. Dragon Quest VII (PPSA17942) calls it at 0x5fac7b7 and logs the
+    // result through "…Failed in scePthreadRename(), 0x%08x" (string at 0x824663c) -- eight-digit
+    // hex is a Sony error code, and a bare errno would be %d, which that binary uses elsewhere.
+    //
+    // Asserted here rather than left to the sweep, because the Sony/POSIX split is a REGISTRATION
+    // property: pointing the name at the raw body again would restore the bare value silently, and
+    // every other arm in this file would still pass.
+    CHECK(rename(0, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0x80020016ull,
+          "#2178: scePthreadRename on a null thread returns ENCODED EINVAL (0x80020016)");
+    CHECK(posix_rename(0, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 22,
+          "#2178: ...while the POSIX spelling still returns the BARE errno, so the encoding went on "
+          "the Sony wrapper rather than the shared body");
+
+    // NOT swept, and this is deliberate. Getname's only caller in that dump does `test eax,eax`, so
+    // 3 and 0x80020003 are indistinguishable there -- the evidence that settles Rename does not
+    // reach it. These two assertions stand until a caller that discriminates turns up (#2178).
     CHECK(getname(0, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 3,
           "null thread returns ESRCH");
     CHECK(getname(thread, 0, 0, 0, 0, 0) == 14,

--- a/prosper/tests/test_pthread_names.cpp
+++ b/prosper/tests/test_pthread_names.cpp
@@ -129,23 +129,26 @@ int main() {
     CHECK(strcmp((const char*)sony_out.data(), renamed_again) == 0,
           "null rename preserves the previous name");
 
-    // #2178: scePthreadRename's failure is ENCODED, settled by guest disassembly rather than by the
-    // encoding rule's analogy. Dragon Quest VII (PPSA17942) calls it at 0x5fac7b7 and logs the
-    // result through "…Failed in scePthreadRename(), 0x%08x" (string at 0x824663c) -- eight-digit
-    // hex is a Sony error code, and a bare errno would be %d, which that binary uses elsewhere.
+    // #2178: scePthreadRename's failure is ENCODED, on the family rule -- every Sony libkernel
+    // spelling returns 0x80020000|errno -- and NOT on evidence specific to this function.
+    // CONFIDENCE: MED, and the rationale block above SCE_PTHREAD_ALIAS(k_sce_pthread_rename) in
+    // hle_kernel.cpp says why, including what the guest disassembly does and does not establish.
     //
-    // Asserted here rather than left to the sweep, because the Sony/POSIX split is a REGISTRATION
-    // property: pointing the name at the raw body again would restore the bare value silently, and
-    // every other arm in this file would still pass.
+    // Read this arm as guarding a DECISION, not as citing a measurement. It is here rather than
+    // left to the sweep because the Sony/POSIX split is a REGISTRATION property: pointing the name
+    // at the raw body again would restore the bare value silently, and every other arm in this file
+    // would still pass. If the decision is later shown wrong, this arm is where it is changed --
+    // which is the point of asserting it explicitly rather than leaving it implied.
     CHECK(rename(0, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 0x80020016ull,
           "#2178: scePthreadRename on a null thread returns ENCODED EINVAL (0x80020016)");
     CHECK(posix_rename(0, (uint64_t)(uintptr_t)renamed_again, 0, 0, 0, 0) == 22,
           "#2178: ...while the POSIX spelling still returns the BARE errno, so the encoding went on "
           "the Sony wrapper rather than the shared body");
 
-    // NOT swept, and this is deliberate. Getname's only caller in that dump does `test eax,eax`, so
-    // 3 and 0x80020003 are indistinguishable there -- the evidence that settles Rename does not
-    // reach it. These two assertions stand until a caller that discriminates turns up (#2178).
+    // NOT swept, and this is deliberate: Getname's contract differs (its failures are lookup
+    // failures on a call whose success path writes through a buffer), and no guest caller found so
+    // far discriminates -- its only one does `test eax,eax`, where 3 and 0x80020003 are the same.
+    // These two assertions stand until a caller that branches on the value turns up (#2178).
     CHECK(getname(0, (uint64_t)(uintptr_t)sony_out.data(), 0, 0, 0, 0) == 3,
           "null thread returns ESRCH");
     CHECK(getname(thread, 0, 0, 0, 0, 0) == 14,


### PR DESCRIPTION
Refs #2178. Follow-up to #2365, which deliberately left these bare.

## The evidence that settles it

The Linux lane named the method — *disassemble a guest caller and read the constant it compares against*. Dragon Quest VII (`PPSA17942`) is the only dump on this lane importing both name functions. Chain, all reproducible:

```
NID -> GOT slot (Sony DT_SCE_RELA, symbol 2009)   0x94909e8
GOT -> PLT thunk (tools/re/xref.py to <slot>)     0x669b570
thunk -> caller  (tools/re/xref.py to <thunk>)    0x5fac7b0
```

```asm
5fac7b7:  call   0x669b570              ; scePthreadRename
5fac7bc:  test   eax,eax
5fac7c0:  movsxd rdx,eax                ; the error, sign-extended into arg2
5fac7c3:  lea    rsi,[rip+0x2299e72]    ; -> 0x824663c
5fac7cd:  jmp    0x5fa9670              ; log(0, fmt, err)
```

String at `0x824663c`:

> `E2016102601B:Failed in scePthreadRename(), 0x%08x`

**`0x%08x`.** Eight-digit hex is how a Sony error code prints — `0x80020016` fills it exactly — and a bare errno would be `%d`, which the same binary uses elsewhere for plain integers. The guest states, in its own diagnostic, which space it expects.

`SetName` travels with it: same body, same contract, no separate evidence needed for a function that *is* this one under another name.

## Getname is deliberately NOT swept

Its only caller in that dump does `test eax,eax` and nothing else, so `3` and `0x80020003` are indistinguishable there. `test_pthread_names`' `== 3` and `== 14` stand — now with a **recorded reason** rather than an absence of one. That splits the three, which neither lane proposed, but it is what the evidence supports.

## Verification

| | |
| --- | --- |
| `ctest --no-tests=error -j8` | **179 tests, 179 passed, 0 failed** |
| mutation: re-point `scePthreadRename` at the raw body | fails **exactly** the encoded arm; the POSIX control still passes |

The POSIX control matters: it proves the encoding went on the Sony **wrapper** rather than the shared body. Without it, moving the encoding into `k_pthread_rename` would pass the Sony arm and silently change the POSIX spelling too.

**A correction I made mid-work:** I first wrote the arm expecting `ESRCH`, and it failed immediately — the body returns `EINVAL` for a null thread. Read the body, corrected, kept. Worth noting because the arm would have been wrong in a way no reviewer could see from the PR body alone.

— Wren