### PR TITLE
fix(perf): stack_profile reported plumbing and unresolved frames as blocking sites

### DIFF
--- a/prosper/tools/perf/stack_profile.py
+++ b/prosper/tools/perf/stack_profile.py
@@ -85,6 +85,12 @@ UNRESOLVED = re.compile(r"^\?+$")
 # that thread, the second is a real finding about the program.
 UNRESOLVED_ONLY = "(no symbolized frame -- gdb resolved nothing in this stack)"
 
+# A thread whose stack produced NO frames at all. Distinct again: `UNRESOLVED_ONLY` means gdb
+# walked the stack and could not name the frames; this means nothing was parsed for the thread.
+# Both are tool failures for that thread and neither is a finding about the program -- which is
+# the whole reason they are not allowed to share the "pure library wait" label.
+NO_FRAMES = "(no frames parsed for this thread -- tool failure, not a finding)"
+
 # C++ wait wrappers. These are plumbing exactly like the C ones, but they are TEMPLATED --
 # `std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, ...> > >`
 # -- so an anchored `$` pattern over the whole symbol cannot match them. Matched by prefix.
@@ -224,13 +230,30 @@ def blocking_site(frames, depth: int):
     for i, fn in enumerate(frames):
         if is_plumbing(fn) or UNRESOLVED.match(fn):
             continue
-        # Callers below may themselves be unresolved; drop those from the displayed chain
-        # rather than padding the site with `??`.
-        chain = [f for f in frames[i:] if not UNRESOLVED.match(f)][:depth]
-        return " <- ".join(chain)
-    if frames and all(UNRESOLVED.match(f) for f in frames):
+        # `<-` reads as "called by", so the displayed chain must stay CONTIGUOUS. An earlier
+        # version filtered `??` out of the middle, turning ["answer", "??", "caller2"] into
+        # "answer <- caller2" -- which asserts an adjacency that does not exist. Truncate at
+        # the first unresolved caller instead and mark the cut, so the gap is visible.
+        chain, truncated = [], False
+        for f in frames[i:]:
+            if UNRESOLVED.match(f):
+                truncated = True
+                break
+            chain.append(f)
+            if len(chain) == depth:
+                break
+        site = " <- ".join(chain)
+        if truncated and len(chain) < depth:
+            site += " <- ..."      # callers below exist but did not resolve
+        return site
+    # No named site. Three different reasons, and only one of them is a statement about the
+    # PROGRAM -- so they must not share a label. An earlier version collapsed all three into
+    # "pure library wait", which claims a finding in the two cases that support none.
+    if not frames:
+        return NO_FRAMES
+    if any(UNRESOLVED.match(f) for f in frames):
         return UNRESOLVED_ONLY
-    return None
+    return None            # genuinely all plumbing: a real finding about the program
 
 
 def main() -> int:

--- a/prosper/tools/perf/stack_profile.py
+++ b/prosper/tools/perf/stack_profile.py
@@ -69,6 +69,49 @@ import subprocess
 import sys
 import time
 
+# An UNRESOLVED frame. `set auto-solib-add off` (which this tool passes, to avoid paying for
+# shared-library symbols on every attach) makes gdb print `??` for any frame in a library it
+# did not load. `??` is not an answer and must never be reported as the blocking site -- but it
+# is also not plumbing to be silently swallowed, because a stack that is ENTIRELY `??` means the
+# tool has told you nothing and should say so. Both cases are handled in blocking_site().
+#
+# Found by review, not by the control: the control ran where gdb resolved libc, so its frames
+# came back named (`pthread_cond_wait@@GLIBC_2.3.2`) and `??` never appeared. The first live
+# prosper run printed `?? <- ??` as a blocking site for four threads and I read past it.
+UNRESOLVED = re.compile(r"^\?+$")
+
+# Sentinel: distinguishes "nothing in this stack resolved" from "this stack is all plumbing".
+# They look the same in a report and mean opposite things -- the first is a tool failure for
+# that thread, the second is a real finding about the program.
+UNRESOLVED_ONLY = "(no symbolized frame -- gdb resolved nothing in this stack)"
+
+# C++ wait wrappers. These are plumbing exactly like the C ones, but they are TEMPLATED --
+# `std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, ...> > >`
+# -- so an anchored `$` pattern over the whole symbol cannot match them. Matched by prefix.
+#
+# Also from review. The first live run reported
+#   GfxFlipThread  100.0%  std::__condvar::wait_until <- std::condition_variable::__wait_until_impl
+# as a finding, when it is the wait machinery itself: the tool named the thing it exists to skip.
+CXX_PLUMBING_PREFIXES = (
+    "std::__condvar::",
+    "std::condition_variable::",
+    "std::condition_variable_any::",
+    "std::mutex::lock",
+    "std::mutex::try_lock",
+    "std::recursive_mutex::lock",
+    "std::timed_mutex::",
+    "std::shared_mutex::",
+    "std::unique_lock",
+    "std::lock_guard",
+    "std::this_thread::sleep_for",
+    "std::this_thread::sleep_until",
+    "std::this_thread::yield",
+    "std::thread::join",
+    "std::__atomic_futex_unaligned",
+    "__gthread_cond_",
+    "__gthread_mutex_",
+)
+
 # gdb frames that are plumbing rather than an answer. A stack whose top frame is
 # `futex_wait` tells you nothing you did not already know from /proc; the first frame
 # BELOW this set is the one that names the lock.
@@ -160,16 +203,33 @@ def gdb_stacks(pid: int, gdb: str, timeout: float):
     return threads, stopped, None
 
 
-def blocking_site(frames, depth: int):
-    """The first non-plumbing frame, plus `depth-1` callers beneath it.
+def is_plumbing(fn: str) -> bool:
+    """True for wait machinery, in C or C++ spelling."""
+    return bool(PLUMBING.match(fn)) or fn.startswith(CXX_PLUMBING_PREFIXES)
 
-    Returns None when a thread's whole stack is plumbing -- that is a real outcome
-    (a pure library wait with no symbolized caller), reported as such rather than
-    silently bucketed with something else.
+
+def blocking_site(frames, depth: int):
+    """The first frame that is neither plumbing nor unresolved, plus `depth-1` callers.
+
+    Three distinct outcomes, kept distinct because they call for different actions:
+      * a named site            -> the answer
+      * None                    -> the whole stack is plumbing (a pure library wait)
+      * UNRESOLVED_ONLY         -> every frame is `??`; the tool measured nothing here and
+                                   the caller must say so rather than print `?? <- ??`
+
+    `??` frames are skipped when they sit ABOVE a named frame, because with
+    `auto-solib-add off` they are precisely the library plumbing we mean to skip. They are
+    only fatal to the answer when nothing below them resolved.
     """
     for i, fn in enumerate(frames):
-        if not PLUMBING.match(fn):
-            return " <- ".join(frames[i:i + depth])
+        if is_plumbing(fn) or UNRESOLVED.match(fn):
+            continue
+        # Callers below may themselves be unresolved; drop those from the displayed chain
+        # rather than padding the site with `??`.
+        chain = [f for f in frames[i:] if not UNRESOLVED.match(f)][:depth]
+        return " <- ".join(chain)
+    if frames and all(UNRESOLVED.match(f) for f in frames):
+        return UNRESOLVED_ONLY
     return None
 
 
@@ -225,8 +285,15 @@ def main() -> int:
     # Perturbation is printed before any finding, because it bounds how much of the
     # finding the tool itself caused.
     share = (stopped_total / wall * 100.0) if wall > 0 else 0.0
-    print(f"  process stopped by this tool: {stopped_total:.2f}s of {wall:.2f}s wall "
-          f"({share:.1f}% -- this is perturbation, not a measurement of the program)")
+    # UPPER BOUND, not a measurement: this is gdb's whole wall time -- process spawn, attach,
+    # symbol work, unwind, detach -- and the target is only actually stopped for part of it.
+    # Labelled as a bound because a tool that argues perturbation numbers must be trustworthy
+    # cannot then quote one that overstates itself without saying which way it errs. Erring
+    # high is the safe direction: it can cause an unnecessary --interval increase, never a
+    # falsely-clean run.
+    print(f"  perturbation UPPER BOUND: gdb held {stopped_total:.2f}s of {wall:.2f}s wall "
+          f"({share:.1f}%) -- includes gdb startup/symbol/detach, so the true stopped time is "
+          f"lower. Not a measurement of the program.")
     if share > 10.0:
         print("    WARNING: over 10% of wall clock was spent stopped. Raise --interval "
               "before trusting any timing conclusion drawn alongside this run.")

--- a/prosper/tools/perf/test_stack_profile.py
+++ b/prosper/tools/perf/test_stack_profile.py
@@ -173,6 +173,54 @@ class TestReviewFindings(unittest.TestCase):
             self.assertFalse(sp.is_plumbing(sym), f"{sym} must NOT be swallowed as plumbing")
 
 
+class TestOutcomesThatAreNotFindings(unittest.TestCase):
+    """Second review pass: three ways to have no named site, only ONE of which is a finding.
+
+    Collapsing them shares a label that asserts something about the program in the two cases
+    that support nothing. This is the tool's own central thesis -- "I did not measure" must
+    never render as "there was nothing to measure" -- applied one level below where the first
+    pass stopped.
+    """
+
+    def test_all_plumbing_is_a_real_finding_and_keeps_the_None_outcome(self):
+        # This one IS a statement about the program: every frame resolved, and all were waits.
+        self.assertIsNone(sp.blocking_site(["pthread_cond_wait", "sem_wait"], 2))
+
+    def test_plumbing_plus_unresolved_is_not_a_pure_library_wait(self):
+        # Frames genuinely did not resolve, so "pure library wait" is one possibility of several.
+        self.assertEqual(sp.blocking_site(["pthread_cond_wait", "??", "??"], 2),
+                         sp.UNRESOLVED_ONLY)
+
+    def test_empty_stack_has_its_own_outcome(self):
+        self.assertEqual(sp.blocking_site([], 2), sp.NO_FRAMES)
+
+    def test_the_three_outcomes_are_all_distinct(self):
+        outcomes = {
+            sp.blocking_site(["pthread_cond_wait", "sem_wait"], 2),   # all plumbing -> None
+            sp.blocking_site(["pthread_cond_wait", "??"], 2),          # -> UNRESOLVED_ONLY
+            sp.blocking_site([], 2),                                   # -> NO_FRAMES
+        }
+        self.assertEqual(len(outcomes), 3, "the three no-site outcomes must not share a label")
+
+
+class TestChainContiguity(unittest.TestCase):
+    """`<-` reads as 'called by', so an elided middle frame asserts a false adjacency."""
+
+    def test_unresolved_middle_frame_truncates_rather_than_eliding(self):
+        site = sp.blocking_site(["real_answer", "??", "caller2"], 3)
+        self.assertNotIn("real_answer <- caller2", site,
+                         "eliding `??` claims real_answer is called by caller2, which is false")
+        self.assertTrue(site.startswith("real_answer"))
+        self.assertIn("...", site, "the truncation must be visible")
+
+    def test_contiguous_named_callers_are_still_joined(self):
+        self.assertEqual(sp.blocking_site(["a", "b", "c"], 3), "a <- b <- c")
+
+    def test_depth_reached_before_the_gap_needs_no_marker(self):
+        # Truncation by --depth is not a gap in the data, so it must not be marked as one.
+        self.assertEqual(sp.blocking_site(["a", "b", "??"], 2), "a <- b")
+
+
 class TestFailureIsNotAResult(unittest.TestCase):
     """A sample that yields nothing must be a FAILURE, never 'nothing was blocked'."""
 

--- a/prosper/tools/perf/test_stack_profile.py
+++ b/prosper/tools/perf/test_stack_profile.py
@@ -117,6 +117,62 @@ class TestBlockingSite(unittest.TestCase):
         self.assertEqual(threads[910932][0], "known")
 
 
+class TestReviewFindings(unittest.TestCase):
+    """Three cases the hand-built control could not produce, found by review of a live run.
+
+    The control ran where gdb resolved libc and where no C++ wait wrappers appeared, so all
+    three were structurally inexpressible in it -- the exact "positive control drawn from the
+    same source as the null" shape CLAUDE.md warns about. The frame NAMES below are verbatim
+    from stack_profile's own output on a live prosper-app (Blue Prince, 87 threads); the
+    surrounding gdb line formatting is reconstructed, which is faithful because the classifier
+    only ever sees the names.
+    """
+
+    def test_unresolved_frames_are_never_the_reported_site(self):
+        # `set auto-solib-add off` yields `??` for unloaded libraries. The live run printed
+        # `?? <- ??` as the blocking site for four threads.
+        self.assertEqual(sp.blocking_site(["??", "??", "prosper::disk_worker_loop"], 2),
+                         "prosper::disk_worker_loop")
+
+    def test_stack_of_only_unresolved_frames_says_so(self):
+        # Distinct from "all plumbing": here the TOOL failed for this thread, and reporting it
+        # as a finding about the program would be a fabrication.
+        self.assertEqual(sp.blocking_site(["??", "??", "??"], 3), sp.UNRESOLVED_ONLY)
+        self.assertIsNotNone(sp.UNRESOLVED_ONLY)
+
+    def test_cxx_condition_variable_wrappers_are_plumbing(self):
+        # The live run reported this chain as GfxFlipThread's blocking SITE. It is the wait
+        # machinery itself -- the tool named the thing it exists to skip.
+        frames = [
+            "std::__condvar::wait_until",
+            "std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >",
+            "std::condition_variable::wait_until<std::chrono::duration<long, std::ratio<1l, 1000000000l> > >",
+            "prosper::gfx_flip_wait_for_work",
+        ]
+        self.assertEqual(sp.blocking_site(frames, 1), "prosper::gfx_flip_wait_for_work")
+
+    def test_cxx_sleep_wrappers_are_plumbing(self):
+        frames = [
+            "std::this_thread::sleep_for<long, std::ratio<1l, 1000000000l> >",
+            "std::this_thread::sleep_until<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > >",
+            "prosper::fmod_audio_out_tick",
+        ]
+        self.assertEqual(sp.blocking_site(frames, 1), "prosper::fmod_audio_out_tick")
+
+    def test_gthread_wrappers_are_plumbing(self):
+        # `__gthread_cond_wait` is the one that reads as already-covered but is not: the `_*`
+        # prefix eats the underscores, and then `pthread_cond_\w+` needs a literal "pthread".
+        for sym in ("__gthread_cond_wait", "__gthread_mutex_lock"):
+            self.assertTrue(sp.is_plumbing(sym), f"{sym} must classify as plumbing")
+
+    def test_a_real_application_frame_is_still_not_plumbing(self):
+        # The paired negative: the widened filter must not swallow the answers.
+        for sym in ("prosper::test::readback_persistent_color_target",
+                    "prosper::k_wait_on_address",
+                    "std::vector<unsigned char, std::allocator<unsigned char> >::assign<unsigned char const*, void>"):
+            self.assertFalse(sp.is_plumbing(sym), f"{sym} must NOT be swallowed as plumbing")
+
+
 class TestFailureIsNotAResult(unittest.TestCase):
     """A sample that yields nothing must be a FAILURE, never 'nothing was blocked'."""
 


### PR DESCRIPTION
## Three defects in the tool merged an hour ago, all found by review, none findable by my control

Wren's review of #2380 raised three things. All three were **visible in the live-run output I published in
that PR**, and I read past every one:

```
prosper:disk$0    100.0%  ?? <- ??
GfxFlipThread     100.0%  std::__condvar::wait_until <- std::condition_variable::__wait_until_impl
FMOD AudioOut t   100.0%  std::this_thread::sleep_for <- std::this_thread::sleep_until
```

The second line is the sharpest: I reported `std::condition_variable::wait_until` as a **blocking site**.
That is the wait machinery — the exact thing this tool exists to skip. The tool named the thing it was
built to look past, in its first real run, in my own PR body.

## Why the control could not have caught any of them

My hand-built control had three threads blocked in three known functions and it validated the classifier
correctly. But it ran on a box where **gdb resolved libc**, so `??` never appeared, and it used raw
`pthread_*` calls, so **no C++ wrapper ever appeared**. Both defect classes were *structurally
inexpressible* in it.

That is precisely the failure CLAUDE.md records — a positive control drawn from the same source as the null
tests the discriminator, not the domain. I built the control specifically to avoid trusting a clean result,
it did its job on the case it could express, and it was blind to two whole classes anyway. The
generalisation I'd draw: **a control validates the classifier over the inputs it can generate, and says
nothing about inputs it cannot.** Mine generated no unresolved frames and no C++ frames.

## The fixes

**1. `??` is no longer a site.** `set auto-solib-add off` (which this tool passes, to keep attaches cheap)
prints `??` for unloaded libraries, and `??` passed the plumbing filter. Now skipped when a named frame
sits below it — which is correct, since those frames *are* the library plumbing — and a stack where
**nothing** resolved gets its own outcome, kept distinct from "all plumbing" because one is a tool failure
for that thread and the other is a real finding about the program.

**2. C++ wait wrappers are plumbing.** They are templated
(`std::condition_variable::__wait_until_impl<std::chrono::duration<long, std::ratio<1l, ...> > >`), so no
`$`-anchored pattern can reach them; matched by prefix now. `__gthread_cond_wait` is the trap of the set and
Wren flagged it by name: `_*` eats the underscores, and then `pthread_cond_\w+` still requires a literal
`pthread`, so it reads as already-covered and is not.

**3. Perturbation is labelled an UPPER BOUND.** The figure is gdb's whole wall time — spawn, attach, symbol
work, unwind, detach — and the target is only stopped for part of it. It errs high, which is the safe
direction (an unnecessary `--interval` bump, never a falsely-clean run), but a tool whose central argument
is that perturbation numbers must be trustworthy cannot quote one that overstates itself without saying
which way.

## Verification

**17/17 green.** Mutation arms, because a widened filter is exactly the kind of change that can pass by
swallowing everything:

| mutation | tests killed |
| --- | --- |
| drop the C++ prefix check | 3 |
| stop skipping unresolved frames | 1 |

There is also a **paired negative** asserting the widened filter does *not* swallow real answers —
`prosper::test::readback_persistent_color_target`, `prosper::k_wait_on_address`, and a
`std::vector<unsigned char>::assign` specialisation all remain non-plumbing. Without it, "classify
everything as plumbing" would pass the other four.

New fixtures use frame names verbatim from the live Blue Prince run; only the surrounding gdb line
formatting is reconstructed, which is faithful because the classifier only sees names.

## Consequence for #2381

The RGBA16F readback finding is **unaffected** — `readback_persistent_color_target` was never plumbing and
is asserted as such by the new paired negative. What changes is that `GfxFlipThread` and `FMOD AudioOut`
will now report their real callers instead of the condvar wrapper, and the four `?? <- ??` threads will
either name something or say plainly that nothing resolved.

Refs #2241
