### PR TITLE
diag(ampr): make PROSPER_AMPRLOG cover the same NIDs on Windows as on POSIX

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1879,6 +1879,7 @@ namespace { bool wa_log() { static int v = getenv("PROSPER_FILELOG") ? 1 : 0; re
 extern "C" int prosper_reserved_range_state(uint64_t addr);   // defined below (lazy-commit tracking)
 HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
     (void)a0;
+    ampr_arglog("j0+3uJMxYJY(WriteAddress)", a0, a1, a2, a3, a4, a5);
     if (!a1) return 0;
     uint64_t value = a2;
     struct iovec local { &value, sizeof(value) };
@@ -5358,8 +5359,20 @@ HLE(k_ampr_submit_plain) {           // eE4Szl8sil8: same submit, no result slot
                 (unsigned long long)a2, (unsigned long long)a3);
     return apr_submit_common(a0, a1, /*out1=*/0, /*out2=*/0, /*write_result_outputs=*/false);
 }
-HLE(k_ampr_get_current_offset) { return ampr_cb_offset(a0); }
-HLE(k_ampr_measure_write_address) { return 32; }
+// These two logged on POSIX and were SILENT on Windows, which is worse than not logging at all:
+// PROSPER_AMPRLOG=1 on a Windows GTA V (PPSA04263) run reported ZERO GetCurrentOffset calls beside
+// 47 submits, and the honest reading of that -- "the guest never calls it" -- was a property of the
+// INSTRUMENT. Adding these two lines turned the same run into one call, immediately before the
+// fault, which is what located the wall (#2384). A diagnostic whose coverage depends on the host
+// platform manufactures a per-platform difference in the SUBJECT. Bodies unchanged.
+HLE(k_ampr_get_current_offset) {
+    ampr_arglog("GnxKOHEawhk(GetCurrentOffset)", a0, a1, a2, a3, a4, a5);
+    return ampr_cb_offset(a0);
+}
+HLE(k_ampr_measure_write_address) {
+    ampr_arglog("4fgtGfXDrFc(MeasureWriteAddress)", a0, a1, a2, a3, a4, a5);
+    return 32;
+}
 
 // APR command-buffer WriteAddress (NID j0+3uJMxYJY) — the completion-notification write (#1149).
 // Windows sibling of the POSIX handler above (full contract documented there): write `value` (a2)
@@ -5367,6 +5380,7 @@ HLE(k_ampr_measure_write_address) { return 32; }
 // mapped target is skipped rather than faulting the emulator (mirrors windows_prepare_guest_write).
 HLE(k_ampr_write_address) {   // j0+3uJMxYJY (cb, address, value, flags)
     (void)a0; (void)a3;
+    ampr_arglog("j0+3uJMxYJY(WriteAddress)", a0, a1, a2, a3, a4, a5);
     if (a1) {
         MEMORY_BASIC_INFORMATION mbi{};
         constexpr DWORD kWritable = PAGE_READWRITE | PAGE_WRITECOPY |


### PR DESCRIPTION
Refs #2384.

Three `libSceAmpr` entry points logged under `PROSPER_AMPRLOG` on POSIX and were **silent on
Windows**: `GetCurrentOffset`, `MeasureWriteAddress`, and — on both arms — `WriteAddress`.

## Why this is worth its own PR

Silence is indistinguishable from a negative result. A Windows GTA V (`PPSA04263`) run with
`PROSPER_AMPRLOG=1` reported **zero** `GetCurrentOffset` calls beside 47 submits. The honest reading
of that report is "the guest never calls it" — and it was a property of the **instrument**. Adding
these lines turned the identical run into:

```
[amprlog] j0+3uJMxYJY(WriteAddress)     a0=0x20003f13f0 a1=0x20003f1430 a2=0x0
[amprlog] GnxKOHEawhk(GetCurrentOffset) a0=0x20003f13f0    <-- last line before the fault
```

which located GTA V's second wall (#2384) after twelve hypotheses had been eliminated against it.

`WriteAddress` is added to **both** arms rather than only Windows: it was missing from each, and it
is the call that appends the command whose cursor `GetCurrentOffset` then reports — the two are only
useful read together.

## Contract

Bodies unchanged. Every added line calls the existing `ampr_arglog`, which is defined outside the
platform split and already no-ops unless `PROSPER_AMPRLOG` is set. With the variable unset — every
non-diagnostic run, on every platform — this is a no-op.

## Verification

- MinGW/UCRT: `prosper-app` and the full test target set build clean.
- `ctest --no-tests=error -j4` → **178 of 179 passed**.
- The one failure, `build_revision_refresh`, is **pre-existing and unrelated**. Verified rather than
  assumed: it fails identically with this change **stashed** (`revision_query.exe` exits
  `0xC0000005`; it is a standalone mini-build that does not link `prosper_core`). Filed separately.
- Live: the GTA V run above, on this exact head.

## Deliberately not in this PR

The behavioral divergence #2384 documents — `sceAmprAprCommandBufferConstructor` and
`sceAmprCommandBufferSetBuffer` registered to a bare `return 0` on Windows and to real handlers on
POSIX. That needs a fault-safe port of `k_ampr_begin`'s guest-memory writes and a live A/B, and it
should not ride along with a diagnostic change whose whole claim is that it changes no behavior.

## Risk

Low. Diagnostic-only, gated, no behavior change with the env var unset. The one way it could be
wrong is a compile break in the Windows arm if `ampr_arglog` were not visible there — it is defined
unconditionally at `hle_kernel_mem.cpp:176`, above the split, and the Windows build linked.
