### PR TITLE
diag(ampr): make the Windows constructor and its two stubbed NIDs visible to PROSPER_AMPRLOG

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -5321,9 +5321,26 @@ HLE(k_ampr_init) {
     if (a0 > 0xffff)
         ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
                           a2 >= 0x20 && a2 <= 0x100000); // match the POSIX 3.20 discriminator
+    // The POSIX arm logs this call; this arm did not, so a Windows run could not answer
+    // "was the command buffer ever CONSTRUCTED?" at all -- and that is the question a zero
+    // GetCurrentOffset raises (#2384). Same tag as POSIX so one grep works on both.
+    ampr_arglog("8aI7R7WaOlc(CommandBufferConstructor)", a0, a1, a2, a3, a4, a5);
     return 0;
 }
 HLE(k_ampr_reset) { ampr_cb_reset(a0); return 0; }
+// Two NIDs that the Windows arm answers with the shared `k_ampr_ok` (a bare `return 0`).
+// They get NAMED stubs purely so PROSPER_AMPRLOG can see them: a shared handler cannot carry
+// a per-NID tag, so routing both through k_ampr_ok made them invisible -- and these two are
+// exactly where a Windows run diverges from POSIX (#2384: POSIX has k_ampr_begin and
+// k_ampr_push_map here). Behavior is UNCHANGED -- still `return 0` -- because porting those
+// two handlers is a separate, behavioral change that needs its own evidence and review.
+// Being able to SEE the divergence in a log is the prerequisite for fixing it.
+HLE(k_ampr_apr_cb_construct_stub) {
+    return ampr_arglog("a8uLzYY--tM(AprCommandBufferConstructor, WINDOWS STUB)", a0, a1, a2, a3, a4, a5);
+}
+HLE(k_ampr_set_buffer_stub) {
+    return ampr_arglog("N-FSPA4S3nI(SetBuffer, WINDOWS STUB)", a0, a1, a2, a3, a4, a5);
+}
 HLE(k_ampr_destruct) { ampr_cb_destroy_320(a0); return 0; }
 HLE(k_ampr_getsize) {
     if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
@@ -5706,8 +5723,8 @@ void register_kernel_mem_hle() {
     Hle::register_fn("q2y-wDIVWZA", (HleFn)k_wake_by_address, "sceKernelWakeByAddress?");
     // libSceAmpr / APR command-buffer trio + teardown — no-op stubs on Windows (area:ue4).
     Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init, "sceAmprCommandBufferConstructor");
-    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_ok, "sceAmprAprCommandBufferConstructor");
-    Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_ok, "sceAmprCommandBufferSetBuffer");
+    Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_apr_cb_construct_stub, "sceAmprAprCommandBufferConstructor");
+    Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_set_buffer_stub, "sceAmprCommandBufferSetBuffer");
     Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_reset, "sceAmprCommandBufferReset");
     Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_reset, "sceAmprCommandBufferClearBuffer");
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");


### PR DESCRIPTION
Refs #2384. Follow-on to #2385, which closed three AMPR logging gaps. Three more remained, and each
cost a separate 90-second run to find — because **a silent handler and an uncalled one produce the
same empty log.**

## What was invisible

- **Windows `k_ampr_init`** (`8aI7R7WaOlc`, `sceAmprCommandBufferConstructor`) logged nothing while
  its POSIX twin does. A Windows run therefore could not answer *"was this command buffer ever
  constructed?"* — precisely the question a zero `GetCurrentOffset` raises.
- **`a8uLzYY--tM`** (`sceAmprAprCommandBufferConstructor`) and **`N-FSPA4S3nI`** (`SetBuffer`) are
  answered on Windows by the **shared** `k_ampr_ok`, a bare `return 0`. A shared handler cannot carry
  a per-NID tag, so both were invisible to any tag-based diagnostic.

## What it bought, immediately

The GTA V (`PPSA04263`) constructor trace became readable, and the answer inverted my working
hypothesis: the failing buffer **was** constructed.

```
8aI7R7WaOlc(CommandBufferConstructor) a0=0x20003f13f0 a1=0x31006400001370 a2=0x6400001370
```

`a2` is packed — low 32 bits `0x1370` is a plausible capacity, the high half a count — so the
`a2 >= 0x20 && a2 <= 0x100000` discriminator rejects it and clears `tracks_offset`. That is why the
cursor never advances and `GetCurrentOffset` answers 0 into a RAGE assert. Root cause and a clean
3×3 A/B are on #2384.

I had been about to conclude the buffer was never constructed, from an empty log. It wasn't empty
because the guest was quiet; it was empty because the handler was.

## Contract

**No behavior change on any platform.** The two stubs return exactly what `k_ampr_ok` returned —
`ampr_arglog` returns 0 by design, so `return ampr_arglog(...)` yields the same value. With
`PROSPER_AMPRLOG` unset (every non-diagnostic run) nothing executes beyond a cached `getenv`.

Naming the stubs does more than log: it puts the divergence **in the source**. The Windows arm
previously read as an ordinary registration; on POSIX these two NIDs go to `k_ampr_begin` and
`k_ampr_push_map`, which do real work. Porting those is behavioral, needs its own evidence, and is
deliberately **not** in this PR.

## Verification

- MinGW/UCRT clean; `diff --check` clean; no `Claude-Session` trailers.
- `ctest --no-tests=error -j4` → **180 of 181 passed**. The one failure is `build_revision_refresh`,
  the known pre-existing Windows crash (#2386) — established pre-existing on the previous PR by
  stashing rather than assumed, and it neither touches this file nor links `prosper_core`.
- Live: five GTA V runs on this head, three of them a repeated baseline arm stable to ±1 log line.

## Review note

Low risk, but I'd rather this one were read than waved through, because the *previous* PR in this
pair I merged under the trivial-code rule. This one adds two new handler symbols and rewires two
registrations, which is a slightly larger claim than "adds a log line".
