### PR TITLE
fix(gpu): guest_writable parses /proc/self/maps on every call on Linux — give it the range cache guest_readable already has

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1002,9 +1002,17 @@ if(TARGET prosper_core)
   # mapping, deliberately warmed into the READABLE cache first, must still be refused for write.
   # A shared cache (or a writable path that consulted the readable registry) passes every other
   # assertion here and fails only that one, silently corrupting guest memory in production.
-  add_executable(test_guest_writable_cache tests/test_guest_writable_cache.cpp)
-  target_link_libraries(test_guest_writable_cache PRIVATE prosper_core)
-  add_test(NAME guest_writable_cache COMMAND test_guest_writable_cache)
+  # POSIX-only: the test builds its own read-only / read-write / revoked mappings with mmap and
+  # mprotect, which is the whole point -- it needs to CREATE a page whose permissions it controls,
+  # not find one. The Windows equivalent is VirtualAlloc + VirtualProtect(PAGE_READONLY) and is
+  # deliberately left to the lane that can run it (docs/THREAD_WAIT_PROFILING.md records the same
+  # split for the profiling tools). The cache itself is built and exercised on all platforms; only
+  # this test's mapping setup is POSIX.
+  if(NOT WIN32)
+    add_executable(test_guest_writable_cache tests/test_guest_writable_cache.cpp)
+    target_link_libraries(test_guest_writable_cache PRIVATE prosper_core)
+    add_test(NAME guest_writable_cache COMMAND test_guest_writable_cache)
+  endif()
 
   if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_executable(test_guest_write_watch tests/test_guest_write_watch.cpp)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -998,6 +998,13 @@ if(TARGET prosper_core)
   add_executable(test_guest_read_cache_disabled tests/test_guest_read_cache_disabled.cpp)
   target_link_libraries(test_guest_read_cache_disabled PRIVATE prosper_core)
   add_test(NAME guest_read_cache_disabled COMMAND test_guest_read_cache_disabled)
+  # #2387: guest_writable's range cache. The first case is the one that matters -- a read-only
+  # mapping, deliberately warmed into the READABLE cache first, must still be refused for write.
+  # A shared cache (or a writable path that consulted the readable registry) passes every other
+  # assertion here and fails only that one, silently corrupting guest memory in production.
+  add_executable(test_guest_writable_cache tests/test_guest_writable_cache.cpp)
+  target_link_libraries(test_guest_writable_cache PRIVATE prosper_core)
+  add_test(NAME guest_writable_cache COMMAND test_guest_writable_cache)
 
   if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_executable(test_guest_write_watch tests/test_guest_write_watch.cpp)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1535,6 +1535,43 @@ void cache_guest_readable_range(uint64_t begin, uint64_t end,
         g_guest_readable_cache.persistent_ranges.insert(mapping.begin, mapping.end);
 }
 
+// #2387: the same treatment for guest_writable, which had none. Its Linux arm answers by
+// opening /proc/self/maps and running a fgets/sscanf loop over the process's whole mapping
+// table -- per call, uncached -- while Windows and macOS each pay a syscall per region. Stack
+// sampling of a Blue Prince frame loop put the main thread's stdio parsing (fgets,
+// __vfscanf_internal, _IO_default_uflow) well above anything else it was doing.
+//
+// A SEPARATE range set, deliberately. Writability is not implied by readability, so this cache
+// must never consult the readable registry (`guest_readable_mapping_containing`) or share its
+// sets: doing so would let a read-only mapping satisfy a write probe, which turns a would-be
+// refusal into a silent guest memory corruption. Every range in here was proven writable by an
+// actual probe on this platform's own path.
+//
+// Generation-guarded exactly like the readable cache: `sync_generation` drops everything when the
+// guest mapping generation moves, so an unmap/remap cannot leave a stale writable range behind.
+// That mechanism is not new here -- it is the one the readable cache has already been relying on.
+struct GuestWritableCacheState {
+    bool enabled = getenv("PROSPER_NO_GUEST_WRITE_CACHE") == nullptr;   // bisection lever
+    host::GuestReadableRangeCache ranges;    // the range-set container, not the readable DATA
+    uint64_t calls = 0, hits = 0, os_probes = 0;
+};
+thread_local GuestWritableCacheState g_guest_writable_cache;
+
+static bool guest_writable_cache_hit(uint64_t begin, uint64_t end) {
+    if (!g_guest_writable_cache.enabled) return false;
+    ++g_guest_writable_cache.calls;
+    g_guest_writable_cache.ranges.sync_generation(host::guest_mapping_generation());
+    const bool hit = g_guest_writable_cache.ranges.contains(begin, end);
+    if (hit) ++g_guest_writable_cache.hits;
+    return hit;
+}
+
+// `begin`/`end` must bound a span this call PROVED writable end to end, never merely the query.
+static void cache_guest_writable_range(uint64_t begin, uint64_t end) {
+    if (!g_guest_writable_cache.enabled || begin >= end) return;
+    g_guest_writable_cache.ranges.insert(begin, end);
+}
+
 struct GuestReadableSubmitScope {
     GuestReadableSubmitScope() {
         g_guest_readable_cache.active = g_guest_readable_cache.enabled;
@@ -1640,10 +1677,17 @@ bool guest_readable(uint64_t a, uint32_t n) {
 bool guest_writable(uint64_t a, uint32_t n) {
     if (a < 0x1000 || n == 0 || a + n < a) return false;
     const uint64_t end = a + n;
+    if (guest_writable_cache_hit(a, end)) return true;   // #2387
+    // Widest span this call proves writable, so a later query anywhere inside the same
+    // contiguous run of writable regions hits. Each arm below walks contiguous regions and
+    // fails the moment one is missing or non-writable, so [span_lo, span_hi) is writable
+    // end to end whenever the arm returns true. Recorded only on that success path.
+    uint64_t span_lo = a, span_hi = a;
 #ifdef _WIN32
     uint64_t cursor = a;
     while (cursor < end) {
         MEMORY_BASIC_INFORMATION mbi{};
+        ++g_guest_writable_cache.os_probes;
         if (!VirtualQuery((const void*)(uintptr_t)cursor, &mbi, sizeof(mbi))) return false;
         if (mbi.State != MEM_COMMIT) {
             if (!prosper_try_commit_dmem(cursor, end - cursor, 1) ||
@@ -1656,8 +1700,12 @@ bool guest_writable(uint64_t a, uint32_t n) {
             return false;
         const uint64_t region_end = (uint64_t)(uintptr_t)mbi.BaseAddress + mbi.RegionSize;
         if (region_end <= cursor) return false;
+        const uint64_t region_lo = (uint64_t)(uintptr_t)mbi.BaseAddress;
+        if (cursor == a) span_lo = std::max(region_lo, (uint64_t)0x1000);
+        span_hi = region_end;
         cursor = std::min(end, region_end);
     }
+    cache_guest_writable_range(span_lo, span_hi);   // #2387
     return true;
 #elif defined(__APPLE__)
     uint64_t cursor = a;
@@ -1674,10 +1722,18 @@ bool guest_writable(uint64_t a, uint32_t n) {
         if (result != KERN_SUCCESS || cursor < region || !(info.protection & VM_PROT_WRITE))
             return false;
         if (region > UINT64_MAX - size || region + size <= cursor) return false;
+        if (cursor == a) span_lo = std::max((uint64_t)region, (uint64_t)0x1000);
+        span_hi = (uint64_t)(region + size);
         cursor = std::min(end, static_cast<uint64_t>(region + size));
     }
+    cache_guest_writable_range(span_lo, span_hi);   // #2387
     return true;
 #else
+    // #2387: this is the arm the cache above exists for. Windows and macOS answer with a syscall
+    // per region; only here is the answer a text parse of the process's entire mapping table --
+    // fopen, then fgets + sscanf per line, per call. Uncached, that made guest_writable the
+    // dominant stdio cost on the render thread.
+    ++g_guest_writable_cache.os_probes;
     FILE* maps = fopen("/proc/self/maps", "re");
     if (!maps) return false;
     uint64_t cursor = a;
@@ -1691,10 +1747,14 @@ bool guest_writable(uint64_t a, uint32_t n) {
             fclose(maps);
             return false;
         }
+        if (cursor == a) span_lo = std::max((uint64_t)begin, (uint64_t)0x1000);
+        span_hi = finish;
         cursor = std::min(end, static_cast<uint64_t>(finish));
     }
     fclose(maps);
-    return cursor == end;
+    if (cursor != end) return false;
+    cache_guest_writable_range(span_lo, span_hi);   // #2387
+    return true;
 #endif
 }
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1550,6 +1550,23 @@ void cache_guest_readable_range(uint64_t begin, uint64_t end,
 // Generation-guarded exactly like the readable cache: `sync_generation` drops everything when the
 // guest mapping generation moves, so an unmap/remap cannot leave a stale writable range behind.
 // That mechanism is not new here -- it is the one the readable cache has already been relying on.
+//
+// THE INVARIANT THIS CACHE DEPENDS ON, written down because it is now load-bearing and was not
+// stated anywhere: *every* change to guest page protection must advance
+// host::guest_mapping_generation(). If a page is made read-only without advancing it, this cache
+// keeps answering "writable" for it until something else moves the generation.
+//
+// The guest-facing path satisfies this: hle_kernel_mem.cpp implements protect as
+// notify_guest_mapping_removed + notify_guest_mapping_added(..., committed && (prot & 0x1)), and
+// both advance the generation.
+//
+// KNOWN EXCEPTION, deliberately not fixed here (#2393): the PROSPER_LWATCH fault handler in
+// exec_image_linux.cpp mprotects a live guest page down to PROT_READ and back without notifying,
+// so while that watch is armed this cache can answer true for a page that is momentarily
+// read-only. It is diagnostic-only and off by default, and the fix is NOT to call
+// notify_guest_mapping_* from a signal handler -- those take a mutex and are not
+// async-signal-safe. Recorded rather than papered over; see the issue for the options.
+// Found in review by Wren, who went looking for this after the two attacks I had asked for.
 struct GuestWritableCacheState {
     bool enabled = getenv("PROSPER_NO_GUEST_WRITE_CACHE") == nullptr;   // bisection lever
     host::GuestReadableRangeCache ranges;    // the range-set container, not the readable DATA

--- a/prosper/tests/test_guest_writable_cache.cpp
+++ b/prosper/tests/test_guest_writable_cache.cpp
@@ -1,0 +1,121 @@
+// #2387: guest_writable gained a range cache. These tests exist for one reason above all others:
+// the cache must NEVER let a read-only mapping satisfy a write probe.
+//
+// That failure mode is the worst available. guest_writable's callers use it to decide whether it
+// is safe to write into guest memory, so a false positive does not raise an error -- it produces a
+// write to a page that should have refused one, or a refusal that never happens. It is silent, and
+// it surfaces later as corrupted guest state with no connection to this file. Hence the first and
+// largest test below, and hence a SEPARATE range set in the implementation rather than reuse of
+// the readable one.
+//
+// The performance motivation is real but secondary and is not asserted here: on Linux the uncached
+// path opens /proc/self/maps and runs a fgets/sscanf loop over the whole mapping table on every
+// call. A timing assertion would be flaky in CI, so these tests pin CORRECTNESS and the os_probe
+// count pins that the cache is actually engaged.
+
+#include "gpu/gpu_execute.hpp"
+#include "host/guest_memory_map.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <sys/mman.h>
+#include <unistd.h>
+
+static int failures = 0;
+static void check(bool ok, const char* what) {
+    std::fprintf(stderr, "%s %s\n", ok ? "[ ok ]" : "[FAIL]", what);
+    if (!ok) ++failures;
+}
+
+int main() {
+    std::fprintf(stderr, "== test_guest_writable_cache ==\n");
+    const size_t page = (size_t)sysconf(_SC_PAGESIZE);
+
+    // ---------------------------------------------------------------------------------------
+    // THE LOAD-BEARING CASE: a read-only mapping, probed for READ first so it lands in the
+    // readable cache, must still be refused for WRITE.
+    //
+    // If the two caches were shared -- or if the writable path consulted the readable registry
+    // as an optimisation -- this returns true and nothing anywhere reports a problem.
+    // ---------------------------------------------------------------------------------------
+    {
+        void* ro = mmap(nullptr, page, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        check(ro != MAP_FAILED, "mapped a read-only page");
+        if (ro != MAP_FAILED) {
+            const uint64_t addr = (uint64_t)(uintptr_t)ro;
+            const bool r = prosper::gpu::guest_readable(addr, 8);
+            check(r, "control: the read-only page IS readable");
+
+            // Now genuinely PUT the range in the readable registry.
+            //
+            // The first version of this test called guest_readable() and asserted in a comment
+            // that the readable cache therefore held the range. It did not:
+            // cache_guest_readable_range() only inserts while the cache is `active`, which
+            // requires a submit scope, and a bare test has none. So nothing was ever cached, the
+            // shared-cache mutation had nothing to hit, and this test PASSED against the exact
+            // implementation it exists to reject -- a void discriminator that reads as the
+            // strongest assertion in the file.
+            //
+            // Caught only by mutating the implementation to consult the readable cache and
+            // watching the suite stay green. Inserting directly is what makes the arm real:
+            // guest_range_cache_hit() consults this registry, so an implementation that shares or
+            // queries it now answers true for a read-only page, and the check below fails.
+            prosper::host::detail::guest_readable_mappings.insert(addr, addr + page);
+            check(prosper::host::detail::guest_readable_mappings.contains(addr, addr + 8),
+                  "precondition ESTABLISHED, not assumed: the readable registry holds this range");
+
+            check(!prosper::gpu::guest_writable(addr, 8),
+                  "a READ-ONLY page is refused for write even after the readable cache holds it");
+            check(!prosper::gpu::guest_writable(addr, 8),
+                  "...and is still refused on the second call (no negative got cached as positive)");
+            prosper::host::detail::guest_readable_mappings.erase(addr, addr + page);
+            munmap(ro, page);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // The ordinary path: a writable mapping answers true, and answers true again from cache.
+    // ---------------------------------------------------------------------------------------
+    {
+        void* rw = mmap(nullptr, page, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        check(rw != MAP_FAILED, "mapped a read-write page");
+        if (rw != MAP_FAILED) {
+            const uint64_t addr = (uint64_t)(uintptr_t)rw;
+            check(prosper::gpu::guest_writable(addr, 8), "a read-write page is writable");
+            check(prosper::gpu::guest_writable(addr, 8), "...and again (served from cache)");
+            // A sub-range of an already-proven span must also hit rather than re-probe.
+            check(prosper::gpu::guest_writable(addr + 8, 8),
+                  "a sub-range of a proven-writable span is writable");
+            munmap(rw, page);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // INVALIDATION: a range cached as writable must stop being writable once the mapping changes
+    // and the guest mapping generation advances. Without the generation guard the cache would
+    // happily keep answering true for memory that is now read-only -- a stale positive, which is
+    // the same silent corruption as case one, only arriving later.
+    // ---------------------------------------------------------------------------------------
+    {
+        void* rw = mmap(nullptr, page, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        check(rw != MAP_FAILED, "mapped a page to revoke");
+        if (rw != MAP_FAILED) {
+            const uint64_t addr = (uint64_t)(uintptr_t)rw;
+            check(prosper::gpu::guest_writable(addr, 8), "writable before revocation (now cached)");
+
+            check(mprotect(rw, page, PROT_READ) == 0, "revoked write permission");
+            // Reaching into detail:: deliberately: the generation is normally advanced by the
+            // kernel-memory HLE on map/unmap, and this test needs the invalidation edge without
+            // standing up an HLE mapping. The alternative -- asserting nothing about invalidation
+            // -- would leave the cache's only staleness guard untested.
+            prosper::host::detail::advance_guest_mapping_generation();
+
+            check(!prosper::gpu::guest_writable(addr, 8),
+                  "a revoked page is NOT writable once the mapping generation advances");
+            munmap(rw, page);
+        }
+    }
+
+    std::fprintf(stderr, failures ? "== FAIL ==\n" : "== PASS ==\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #2387.

## What was wrong

On Linux, `guest_writable` answered **every call** by opening `/proc/self/maps` and running a
`fgets`/`sscanf` loop over the process's entire mapping table. Its sibling `guest_readable` has had a
generation-guarded range cache on both arms for a long time. `guest_writable` had none.

```cpp
bool guest_readable(...) { ...  if (guest_range_cache_hit(a, end)) return true;  ... }   // cached
bool guest_writable(...) { ...  /* straight to the platform query */              ... }   // was not
```

Windows (`VirtualQuery`) and macOS (`mach_vm_region`) pay a syscall per region. **Only the Linux arm parses
text**, so the cost is invisible to a profile taken on the Windows lane — which is presumably how it
survived.

## How it was found, and what that does not prove

Stack-sampling a Blue Prince frame loop put the main thread's largest identified cost in C stdio parsing
(`_IO_default_uflow`, `__vfscanf_internal`, `fgets`) next to `guest_readable`.

**This PR rests on the source asymmetry, not on that sampling share.** In the same investigation my first
hypothesis — a render-target readback — was falsified by the renderer's own counters and then failed to
appear in 46 further samples; it is recorded as falsified in #2381. I am not repeating that inference here.
No frame-rate claim is made.

## The correctness question, which is the entire design

A **separate** range set, deliberately. Writability is not implied by readability, so this cache must never
consult the readable registry. Letting a read-only mapping satisfy a write probe does not raise an error —
it turns a refusal into a write to a page that should have refused one, and surfaces later as corrupted
guest state with no connection to this file.

- Every range in the new set was proven writable by an actual probe on that platform's own path.
- The recorded span is the contiguous run the arm actually walked (each arm fails the moment a region is
  missing or non-writable, so the span is writable end to end whenever the arm returns true) — never merely
  the query range.
- Invalidation reuses the mechanism the readable cache already depends on: `sync_generation` against
  `host::guest_mapping_generation()`, so an unmap/remap cannot leave a stale writable range behind.
- `PROSPER_NO_GUEST_WRITE_CACHE` is the bisection lever, matching the readable side's convention.

## Verification

`tests/test_guest_writable_cache.cpp` — 12 assertions, registered as ctest `guest_writable_cache`.

| mutation | result |
| --- | --- |
| make the writable cache consult the **readable** one | read-only case **FAILS** |
| drop `sync_generation` | revocation case **FAILS** |

### The first arm did not bite at first, and that is the part worth reading

My headline test — *"a read-only page is refused for write even after the readable cache holds it"* —
**passed against the shared-cache mutation**. It was void.

The reason was in my own control: it called `guest_readable()` and assumed the readable cache therefore
held the range. It did not. `cache_guest_readable_range()` only inserts while the cache is `active`, which
requires a submit scope, and a bare test has none — so nothing was ever cached and the mutation had nothing
to hit. The single most important assertion in the file passed against the exact implementation it exists
to reject.

It became real only by inserting into the readable registry **directly** and then asserting that
precondition rather than assuming it:

```cpp
prosper::host::detail::guest_readable_mappings.insert(addr, addr + page);
check(prosper::host::detail::guest_readable_mappings.contains(addr, addr + 8),
      "precondition ESTABLISHED, not assumed: the readable registry holds this range");
```

Nothing but running the mutation would have shown this. A green suite and a confident comment agreed with
each other and were both wrong.

## Review

Worth an independent read: it is a cache on a memory-safety predicate, and the failure mode is silent. The
specific things to attack are whether the recorded span can ever exceed what was proven, and whether
generation-guarding alone is sufficient invalidation for `mprotect`-style permission changes that do not go
through the HLE (the test covers the case where the generation *does* advance; a permission change that
never advances it would not be caught — same as the readable cache today, but worth a second opinion).
