### PR TITLE
fix(ampr): a packed constructor a2 must still mark the command buffer as tracking its cursor

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -820,6 +820,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_apr_registry PRIVATE prosper_core)
   add_test(NAME apr_registry_resolution COMMAND test_apr_registry)
 
+  # #2384: the AMPR tracks-offset predicate. Its NEW case is provable by a boot; what needs a unit
+  # test is that the widening is strictly ADDITIVE, because the predicate is shared by every title
+  # that constructs a command buffer and none of their dumps are available to CI. Pure function of a
+  # 64-bit argument, so it needs no dump and cannot skip silently.
+  add_executable(test_ampr_tracks_offset tests/test_ampr_tracks_offset.cpp)
+  target_link_libraries(test_ampr_tracks_offset PRIVATE prosper_core)
+  add_test(NAME ampr_tracks_offset COMMAND test_ampr_tracks_offset)
+
   # GTA V (#1139/#1142) net-new HLE regression guards: sceKernelAprGetFileStat fills the real stat
   # (#1133) and sceAudioOut2GetSpeakerArrayMemorySize returns a non-zero allocation size (#1134). The
   # AGC GetSize third piece is covered separately by test_agc_getsize (#1208).

--- a/prosper/src/hle/guest_memory_topology.hpp
+++ b/prosper/src/hle/guest_memory_topology.hpp
@@ -30,4 +30,10 @@ bool guest_memory_gpu_write(uint64_t destination, const void* source, size_t byt
 // for one pair of physically aliased but VA-disjoint views.
 uint64_t guest_memory_gpu_write_successes_for_test();
 
+// #2384: does an AMPR constructor's `a2` say the command buffer keeps a byte cursor? Exposed for
+// test because the answer is a PREDICATE over guest-supplied bit patterns, and the only way to show
+// the widening is strictly additive is to assert it over the shapes the working titles pass -- which
+// a boot test cannot do without those titles' dumps. The implementation lives in hle_kernel_mem.cpp.
+bool ampr_cb_tracks_offset_arg_for_test(uint64_t a2);
+
 } // namespace prosper

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -56,6 +56,44 @@ struct AmprCbState { uint64_t capacity = 0, offset = 0; bool tracks_offset = fal
 std::mutex g_ampr_cb_state_mx;
 std::unordered_map<uint64_t, AmprCbState> g_ampr_cb_state;
 
+// Does the constructor's `a2` say this command buffer keeps a byte cursor?
+//
+// Two shapes answer yes, and the second is #2384.
+//
+//  PLAIN   a2 IS the capacity -- Pathless's PS5 3.20 IoStore batch passes 0x560. Unchanged.
+//  PACKED  a2 is (count << 32) | capacity -- Grand Theft Auto V (PPSA04263). Its ten constructor
+//          calls in one boot carry a2 = 0x6400001370, 0x5f00001610, 0x5e00001680, 0x5d000016f0,
+//          0x5c00001760, 0x9c000022b0, 0xe7000008a0, 0x7500000c70, 0x6700001290, 0x5700001990.
+//
+// The four consecutive calls at 0x5f/0x5e/0x5d/0x5c are why this is a decomposition and not a curve
+// fit: as the high field falls 95, 94, 93, 92 the low field rises by exactly 0x70 each step -- a
+// pool carved 112 bytes at a time, with the remaining-entry count in the high half. Monotone in both
+// fields at a fixed stride is not something an arbitrary 64-bit value does.
+//
+// This predicate is STRICTLY ADDITIVE, which is the property that matters for the titles already
+// working -- but the reason is the ORDER, not the `count != 0` guard, and I had that backwards until
+// mutation testing corrected it. The plain arm runs first and returns true for every a2 it accepts,
+// so no currently-accepted value ever reaches the packed arm at all. DOLL's a2 = 0 and a2 = 1 are
+// rejected by both arms. tests/test_ampr_tracks_offset.cpp asserts this over a SWEEP rather than
+// over examples, because examples cannot establish a disjointness claim.
+//
+// `count != 0` is therefore REDUNDANT and deliberately kept: when count is zero, a2 IS cap, so the
+// plain arm has already decided. Deleting it is an equivalent mutation and no test can kill it --
+// which is exactly why there is no arm claiming to. It stays as a cheap statement of intent, on the
+// same footing as the `bc.eq` term in apr_submit_common. The `count <= 0xffff` bound is NOT
+// redundant and does have a discriminating arm.
+//
+// CONFIDENCE: MED -- the shape is inferred from one title's live capture, with no disassembly of the
+// guest-side constructor yet. What would raise it: a second title with the same packing, or the
+// constructor's own code showing the two fields written separately.
+bool ampr_a2_is_capacity(uint64_t a2) { return a2 >= 0x20 && a2 <= 0x100000; }
+
+bool ampr_cb_tracks_offset_arg(uint64_t a2) {
+    if (ampr_a2_is_capacity(a2)) return true;                  // PLAIN
+    const uint64_t count = a2 >> 32, cap = a2 & 0xffffffffull; // PACKED
+    return count != 0 && count <= 0xffff && ampr_a2_is_capacity(cap);
+}
+
 uint64_t ampr_cb_capacity_arg(uint64_t a1, uint64_t a2, uint64_t a5) {
     // Observed constructor shapes place capacity in a1 (APR request), a2 (Pathless IoStore batch),
     // or a5 (DOLL IoStore batch). Pointer-valued arguments are outside this conservative bound.
@@ -66,6 +104,10 @@ uint64_t ampr_cb_capacity_arg(uint64_t a1, uint64_t a2, uint64_t a5) {
     if (a5 && a5 <= 0x100000) return a5;
     return 0;
 }
+
+}  // namespace  -- the AMPR arg predicates above are internal; this is their test seam
+bool ampr_cb_tracks_offset_arg_for_test(uint64_t a2) { return ampr_cb_tracks_offset_arg(a2); }
+namespace {
 
 void ampr_cb_construct(uint64_t cb, uint64_t capacity, bool tracks_offset) {
     if (!cb) return;
@@ -1777,7 +1819,7 @@ HLE(k_ampr_init) {
     if (a3 > 0xffff && a1 && a1 <= 0x10000) { g_apr_last_cb = a3; g_apr_last_cb_size = a1; }
     if (a0 > 0xffff)
         ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
-                          a2 >= 0x20 && a2 <= 0x100000); // Pathless 3.20 uses a2=0x560; DOLL uses 0/1
+                          ampr_cb_tracks_offset_arg(a2));   // #2384
     if (amprlog()) {
         fprintf(stderr, "[amprlog] init  a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
                 (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
@@ -2437,6 +2479,12 @@ bool guest_memory_gpu_write(uint64_t destination, const void* source, size_t byt
     return complete;
 }
 
+// POSIX ARM. There are TWO definitions of this function in this file, ~3,200 lines apart,
+// and the only thing distinguishing them is the `#if defined(__linux__) || defined(__APPLE__)`
+// that opens far above. Nothing local tells you which arm you are in, which is the mechanism
+// behind three separate one-arm-read-as-the-whole-file errors in a single session (#2376,
+// #2384). Naming the arm here costs a comment and removes the trap. Raised by Marlow in review
+// of #2388.
 void register_kernel_mem_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceKernelReserveVirtualRange", k_reserve_vrange);
@@ -5320,7 +5368,7 @@ HLE(k_ampr_init) {
     // two different contents (#1970).
     if (a0 > 0xffff)
         ampr_cb_construct(a0, ampr_cb_capacity_arg(a1, a2, a5),
-                          a2 >= 0x20 && a2 <= 0x100000); // match the POSIX 3.20 discriminator
+                          ampr_cb_tracks_offset_arg(a2));   // #2384
     // The POSIX arm logs this call; this arm did not, so a Windows run could not answer
     // "was the command buffer ever CONSTRUCTED?" at all -- and that is the question a zero
     // GetCurrentOffset raises (#2384). Same tag as POSIX so one grep works on both.
@@ -5692,6 +5740,12 @@ bool guest_memory_gpu_write(uint64_t destination, const void* source, size_t byt
     return written;
 }
 
+// WINDOWS ARM. There are TWO definitions of this function in this file, ~3,200 lines apart,
+// and the only thing distinguishing them is the `#if defined(__linux__) || defined(__APPLE__)`
+// that opens far above. Nothing local tells you which arm you are in, which is the mechanism
+// behind three separate one-arm-read-as-the-whole-file errors in a single session (#2376,
+// #2384). Naming the arm here costs a comment and removes the trap. Raised by Marlow in review
+// of #2388.
 void register_kernel_mem_hle() {
     #define R(str, fn) Hle::register_fn(nid_hash(str), (HleFn)(fn), str)
     R("sceKernelReserveVirtualRange", k_reserve_vrange);

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -83,6 +83,25 @@ std::unordered_map<uint64_t, AmprCbState> g_ampr_cb_state;
 // same footing as the `bc.eq` term in apr_submit_common. The `count <= 0xffff` bound is NOT
 // redundant and does have a discriminating arm.
 //
+// KNOWN FALSE-POSITIVE CLASS, raised by Marlow in review and recorded because it cannot be fixed by
+// range-checking: a GUEST POINTER can satisfy the packed arm. The guest VA range is
+// 0x2000000000-0x9fc0000000, so any pointer whose LOW 32 BITS land in [0x20, 0x100000] -- the first
+// MiB of every 4 GiB-aligned window -- decomposes into a plausible count and capacity. That defeats
+// the "pointer-valued arguments are outside this conservative bound" guard in ampr_cb_capacity_arg
+// directly above, because taking the low 32 bits discards exactly the high bits that made a pointer
+// recognisable.
+//
+// It is not separable by value, and that is the part worth knowing before anyone tries: GTA V's own
+// packed a2 values (0x6400001370, 0x5f00001610, 0x9c000022b0) are themselves numerically inside the
+// guest VA range, so a "reject anything that looks like a pointer" test would reject the very calls
+// this exists to accept. Distinguishing them needs a signal other than the 64-bit value -- the
+// calling NID, or a constructor shape captured from a title that passes a pointer here.
+//
+// Accepted deliberately: no title has been observed to pass that shape, the change is additive for
+// every title that works today, and the consequence of a false positive is a cursor tracked for a
+// buffer that does not want one -- not a wrong answer to the guest. Revisit if a title regresses in
+// AMPR submit timing.
+//
 // CONFIDENCE: MED -- the shape is inferred from one title's live capture, with no disassembly of the
 // guest-side constructor yet. What would raise it: a second title with the same packing, or the
 // constructor's own code showing the two fields written separately.

--- a/prosper/tests/test_ampr_tracks_offset.cpp
+++ b/prosper/tests/test_ampr_tracks_offset.cpp
@@ -1,0 +1,132 @@
+// #2384: an AMPR command buffer whose constructor passes a PACKED `a2` must still track its cursor.
+//
+// `sceAmprCommandBufferGetCurrentOffset` answers from a per-buffer cursor that only advances when
+// the constructor recorded `tracks_offset`. That flag was inferred from `a2 >= 0x20 && a2 <=
+// 0x100000` -- "is a2 itself a plausible capacity". Grand Theft Auto V (PPSA04263) passes a packed
+// `(count << 32) | capacity`, which fails that test, so its cursor never moved, GetCurrentOffset
+// answered 0 forever, and the guest's own assertion at eboot+0x2b2c463 trapped on it.
+//
+// WHAT THIS FILE GUARDS IS THE ADDITIVITY, NOT THE NEW CASE.
+//
+// The new case is one line and a boot proves it. The dangerous half is the other direction: this
+// predicate is shared by every title that constructs an AMPR command buffer, and turning tracking ON
+// for a buffer that previously had it OFF changes when that title submits (UE4 batches until
+// `GetSize - GetCurrentOffset` can no longer hold the next packet). None of those titles' dumps are
+// available to CI, so a boot test cannot speak for them -- but the predicate is a pure function of a
+// 64-bit argument, and the shapes they pass are recorded. Asserting over those shapes is the only
+// check that can run here and the only one that would fail if the widening leaked.
+
+#include "hle/guest_memory_topology.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int failures = 0;
+static void check(bool ok, const std::string& what) {
+    if (!ok) { std::fprintf(stderr, "FAIL: %s\n", what.c_str()); ++failures; }
+    else std::fprintf(stderr, "ok: %s\n", what.c_str());
+}
+
+static std::string hex(uint64_t v) {
+    char b[32]; std::snprintf(b, sizeof b, "0x%llx", (unsigned long long)v); return b;
+}
+
+int main() {
+    std::fprintf(stderr, "== test_ampr_tracks_offset ==\n");
+    const auto tracks = &prosper::ampr_cb_tracks_offset_arg_for_test;
+
+    // ---- the new case: GTA V's ten constructor calls from one live boot -------------------------
+    //
+    // Recorded verbatim under PROSPER_AMPRLOG=1, not synthesized. The four consecutive entries in
+    // the middle are the evidence that `a2` decomposes rather than merely happening to have a
+    // nonzero high half: as the high field falls 95, 94, 93, 92 the low field rises by exactly 0x70
+    // each step. That stride is asserted below, because it is the whole basis for reading the low
+    // half as a capacity -- if a future edit "fixes" these constants, the arm that made them
+    // meaningful should break too.
+    const uint64_t gta[] = {
+        0x6400001370ull, 0x5f00001610ull, 0x5e00001680ull, 0x5d000016f0ull,
+        0x5c00001760ull, 0x9c000022b0ull, 0xe7000008a0ull, 0x7500000c70ull,
+        0x6700001290ull, 0x5700001990ull,
+    };
+    for (uint64_t a2 : gta)
+        check(tracks(a2), "GTA V packed a2 " + hex(a2) + " tracks its offset");
+
+    // The stride, over the run of four -- which is entries [1]..[4], NOT [0]..[3]. This arm caught
+    // that off-by-one when it was first written: [0] -> [1] is count -5 and capacity +0x2a0, so the
+    // pair is not on the same carve, and a loop that included it failed. Left as a bounded loop over
+    // the exact run rather than widened to fit, because the claim being guarded is about those four
+    // and admitting [0] would have meant weakening the assertion to make it pass.
+    //
+    // This is a property of the RECORDING, so it can only fail if someone edits the constants --
+    // which is exactly when the comment above stops being true.
+    for (int i = 2; i <= 4; ++i) {
+        const uint64_t prev = gta[i - 1], cur = gta[i];
+        check((prev >> 32) - (cur >> 32) == 1 &&
+                  (cur & 0xffffffffull) - (prev & 0xffffffffull) == 0x70,
+              "consecutive GTA V pair " + std::to_string(i) +
+                  ": count falls by 1 while capacity rises by 0x70");
+    }
+
+    // ---- ADDITIVITY: everything that answered yes before still answers yes ----------------------
+    // Pathless's PS5 3.20 IoStore batch passes the capacity directly.
+    check(tracks(0x560ull), "Pathless plain a2=0x560 still tracks (unchanged)");
+    check(tracks(0x20ull),  "the low boundary 0x20 still tracks (unchanged)");
+    check(tracks(0x100000ull), "the high boundary 0x100000 still tracks (unchanged)");
+
+    // ---- ADDITIVITY: everything that answered no before still answers no, where it must ---------
+    // DOLL passes a2 = 0 or 1 as a mode flag and carries capacity in a5. If the widening reached
+    // these, DOLL would start tracking a cursor for a buffer that has none.
+    check(!tracks(0ull), "DOLL a2=0 still does NOT track");
+    check(!tracks(1ull), "DOLL a2=1 still does NOT track");
+    check(!tracks(0x1full), "0x1f, just below the plain floor, still does NOT track");
+    check(!tracks(0x100001ull), "0x100001, just above the plain ceiling, still does NOT track");
+
+    // THE STRUCTURAL ARGUMENT, asserted rather than asserted-in-a-comment. Additivity comes from the
+    // ORDER: the plain arm runs first and returns true for everything it accepts, so no
+    // previously-accepted value ever reaches the packed arm to be re-decided. An earlier version of
+    // this comment credited the `count != 0` guard instead; mutation testing showed that guard is
+    // REDUNDANT -- deleting it survives, because when count is zero a2 IS cap and the plain arm has
+    // already answered. The guard stays as a statement of intent, but it is not what makes this safe.
+    //
+    // A hand-picked list of examples could not establish this; a sweep can. The claim is a
+    // DISJOINTNESS one, and no finite list of examples is evidence for disjointness.
+    for (uint64_t cap = 0; cap <= 0x100100ull; cap += 0x37ull) {
+        const bool plain_says_yes = (cap >= 0x20 && cap <= 0x100000);
+        if (plain_says_yes && !tracks(cap)) {
+            check(false, "sweep: plain-accepted " + hex(cap) + " must still track");
+            break;
+        }
+        if (!plain_says_yes && cap <= 0x100000ull && tracks(cap)) {
+            check(false, "sweep: plain-rejected " + hex(cap) + " must NOT start tracking");
+            break;
+        }
+    }
+    check(true, "sweep over 0..0x100100 found no value whose plain-arm answer changed");
+
+    // ---- the packed arm's own bounds ------------------------------------------------------------
+    // A pointer-shaped a2 must not be mistaken for a packed descriptor. Guest pointers in these
+    // captures look like 0x20003f13f0 -- high half 0x20, low half 0x003f13f0, which is far above the
+    // capacity ceiling and so already excluded. Asserted because "the ceiling happens to exclude
+    // pointers" is load-bearing and invisible.
+    check(!tracks(0x20003f13f0ull),
+          "a guest POINTER 0x20003f13f0 is not mistaken for a packed descriptor");
+    check(!tracks(0xffffffffffffffffull), "the -1 sentinel does not track");
+    check(!tracks(0x100000000ull), "count=1 with capacity=0 does not track");
+
+    // The `count <= 0xffff` bound needs a case where the COUNT is the only thing rejecting the
+    // value -- i.e. the capacity half is perfectly plausible. Mutation testing is what forced this
+    // arm: deleting the bound SURVIVED the first version of this file, because every large-count
+    // case here also had an out-of-range capacity and was rejected twice over. An assertion that
+    // two guards jointly reject something says nothing about either guard.
+    check(!tracks((0x10000ull << 32) | 0x1000ull),
+          "count=0x10000 with a PLAUSIBLE capacity 0x1000 is still rejected -- the count bound is "
+          "load-bearing and not merely shadowed by the capacity check");
+    check(tracks((0xffffull << 32) | 0x1000ull),
+          "...while count=0xffff with the same capacity IS accepted, so the bound is a boundary "
+          "rather than a blanket rejection");
+
+    std::fprintf(stderr, failures ? "== FAIL ==\n" : "== PASS ==\n");
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #2384 — GTA V's (`PPSA04263`) second Windows wall.

## The defect

`sceAmprCommandBufferGetCurrentOffset` answers from a per-buffer cursor that only advances when the
constructor recorded `tracks_offset`. That flag was inferred from `a2 >= 0x20 && a2 <= 0x100000` —
*"is `a2` itself a plausible capacity"*. GTA V passes a **packed** `(count << 32) | capacity`, which
fails that test, so its cursor never moved, `GetCurrentOffset` answered 0 forever, and the guest's
own assertion trapped on it:

```
2b2c434:  call GnxKOHEawhk      ; sceAmprCommandBufferGetCurrentOffset(cb)
2b2c43d:  je   0x2b2c463        ; offset == 0 -> TRAP
2b2c463:  int  0x41
```

Ten constructor calls in one boot: `0x6400001370, 0x5f00001610, 0x5e00001680, 0x5d000016f0,
0x5c00001760, 0x9c000022b0, 0xe7000008a0, 0x7500000c70, 0x6700001290, 0x5700001990`. The four
consecutive entries are why this is a decomposition and not a curve fit: as the high field falls
95, 94, 93, 92 the low field rises by **exactly 0x70** each step — a pool carved 112 bytes at a time
with the remaining-entry count in the high half. `CONFIDENCE: MED` (one title, no guest-side
constructor disassembly yet).

## The arm matrix, including the part that contradicted me

| arm | `tracks_offset` | WriteAddress +32 | log lines | GetCurrentOffset |
| --- | --- | --- | --- | --- |
| A baseline | discriminator | no | 230, 230, 230 | 1, 1, 1 |
| **B tracks_offset only** | forced true | no | **574, 574** | **23, 23** |
| C advance only | discriminator | +32 | 340, 340 | 1, 1 |
| D both | forced true | +32 | 463, 464, 463 | 23, 23, 23 |

**B is the fix and it is sufficient.** C alone cannot clear the assert — `prosper_ampr_advance`
no-ops while `tracks_offset` is false. And **D < B**: adding the 32-byte `WriteAddress` advance makes
the title get *less* far.

I had intended to ship that advance, on the reasoning that `MeasureWriteAddress` already promises the
guest the record costs 32 bytes. The data says it is harmful, so **it is not in this change**. C is
also not inert (340 vs 230), meaning it moves cursors for *other* buffers — a cross-title risk that
would have shipped unmeasured had I not split the arms.

## Safety for the titles already working

The predicate is strictly additive because of the **order**: the plain arm runs first and returns
true for everything it accepts, so no currently-accepted `a2` ever reaches the new arm. Asserted over
a **sweep**, not examples — disjointness is not something a finite example list can establish.

Confirmed empirically as well: Blue Prince (`PPSA25009`), DQ VII (`PPSA17942`) and The Messenger
(`PPSA24651`) pass 5, 3 and 4 distinct constructor `a2` values in a live boot, and **zero** are
packed. The change cannot reach them.

`count != 0` is **redundant** — when count is zero, `a2` *is* `cap` and the plain arm has already
decided. Mutation testing established that, correcting a comment I had written claiming that guard
was what made the change additive. It is kept as a statement of intent and deliberately has **no test
arm claiming to cover it**, since no such arm can exist.

## Verification

- MinGW/UCRT clean; `diff --check` clean; no `Claude-Session` trailers.
- `ctest --no-tests=error -j4` → **181 of 182 passed**. The one failure is `build_revision_refresh`,
  the known pre-existing Windows crash (#2386), independently established.
- **Mutation arms, with a control that must survive:**

| mutation | verdict | arms failed |
| --- | --- | --- |
| CONTROL (no mutation) | **SURVIVED** | 0 |
| revert the widening | KILLED | 11 |
| drop the `count <= 0xffff` bound | KILLED | 1 |
| always track | KILLED | 9 |
| widen capacity ceiling to 2^32 | KILLED | 2 |
| lower capacity floor to 0 | KILLED | 5 |

  The control arm is there because an earlier version of this harness reported all five as KILLED
  with zero failing assertions — it was invoking the exe through a shell path that did not resolve,
  so every arm "died" identically. Uniform results across arms that should differ is the tell.

- Live: 3 runs on this exact head → 573/574/573 log lines and 23 `GetCurrentOffset` calls each,
  against a 3-run baseline of 230/230/230 and 1.

## Also included

From Marlow's review of #2388: both `register_kernel_mem_hle()` definitions now name their platform
arm. Nothing local distinguished them — the only signal was a `#if` some 3,200 lines above — and that
is the mechanism behind three separate one-arm-read-as-the-whole-file errors in a single session.
Comment only; it rides along because this PR already edits both sites.

## Scope

**GTA V still faults later. This is not a title-screen claim.**

## Review

Please do review this one. It changes shared AMPR state used by every title that constructs a command
buffer, the additivity argument is the load-bearing part rather than the new case, and the `a2`
decomposition is `CONFIDENCE: MED` off a single title.
