### PR TITLE
fix(kernel): answer QueryMemoryProtection from the host when the tracker has no entry — GTA V reaches its title screen on Windows

### DIFF
--- a/prosper/scripts/gta5/reach-story-mode.pad
+++ b/prosper/scripts/gta5/reach-story-mode.pad
@@ -1,0 +1,65 @@
+# Grand Theft Auto V (PPSA04263, RAGE) — Windows lane. Reach Story Mode gameplay.
+#
+# Route, established by capture rather than assumed:
+#   boot -> "Continue" title card -> main menu, which opens on the ONLINE tab.
+# The menu's own tab bar reads  [L1]  ONLINE  GTA+  STORY  [R1]  — so STORY is TWO tabs right of
+# where the menu lands, reached with R1 twice, then Cross to enter.
+#
+# FLIP TIMING, measured from PROSPER_PAD_SCRIPT_LOG on this title rather than estimated:
+#     f600 = t 59.2s | f800 = 77.8s | f1000 = 87.6s | f1200 = 95.0s | f1400 = 102.5s | f1600 = 109.9s
+# The rate is NOT constant — the first 600 flips take 59 s (boot and the IoStore-bound load) and the
+# next 1000 take 51 s. An early anchor is therefore much "later" in wall-clock terms than a linear
+# reading suggests, which is why the leading sweep starts at f600 rather than being packed at the
+# front: before that the title is still loading and a press is swallowed.
+#
+# The leading Cross sweep dismisses the title card and any dialog between it and the menu. It is a
+# SWEEP, deliberately: the flip at which the card appears has not been pinned to a single value, and
+# an extra Cross on a settled menu re-enters the currently selected tab rather than doing damage.
+#
+# The tab navigation is spaced 100 flips apart so each input lands on a settled screen. Pressing R1
+# twice in quick succession risks the second being eaten by the tab-change animation.
+
+f600-620:cross
+f800-820:cross
+f1000-1020:cross
+f1200-1220:cross
+f1400-1420:cross
+f1600-1620:cross
+f1800-1820:cross
+f2000-2020:cross
+f2200-2220:cross
+f2400-2420:cross
+
+# --- ONLINE -> GTA+ -> STORY, then enter -------------------------------------------------------
+f2600-2620:r1
+f2750-2770:r1
+f2900-2920:cross
+
+# A second Cross well after, in case the first landed during a transition. If STORY was already
+# entered, this lands on whatever the story flow presents (a save-slot or difficulty prompt), which
+# is progress rather than a wrong turn.
+f3200-3220:cross
+f3600-3620:cross
+
+# --- WHAT THIS ROUTE REACHES TODAY, and where it stops ------------------------------------------
+#
+# Verified on Windows with #2390 + #2394: this drives the title through
+#     "Continue" title card -> main menu (opens on ONLINE) -> R1, R1 -> STORY tab
+# all rendering at 4K. Capture 12 of the run (frame 2831, t=156.1 s) shows the STORY tab selected
+# with the Franklin key art, the "GRAND THEFT AUTO V STORY MODE" blurb, and the "Resume Story"
+# prompt.
+#
+# The process then SEGFAULTS shortly after the f2900 Cross that enters Story Mode, at t~158-190 s.
+# The fault produces NO [veh] record and no fault address, which is itself informative: the Windows
+# VEH logger sees nothing, so this is not a guest-code access violation of the kind that stopped the
+# three earlier walls. It is a host-side crash, and it needs a different instrument than the ones
+# that found those.
+#
+# So: this file is a working route to the STORY tab and NOT yet a route to gameplay. Do not read the
+# trailing Cross pulses as evidence they land on anything.
+#
+# Two smaller observations from the same captures, recorded because they are cheap to lose:
+#   * The bottom-right prompt renders as "Re u e Sto y" — glyph dropouts in "Resume Story". The
+#     surrounding UI text is intact, so this is a per-glyph gap, not a font failure.
+#   * The main menu's ONLINE tab correctly reports NO CONNECTION rather than hanging on a network
+#     probe, which is the right behaviour for an offline compatibility layer.

--- a/prosper/scripts/gta5/reach-story-mode.pad
+++ b/prosper/scripts/gta5/reach-story-mode.pad
@@ -31,15 +31,31 @@ f2200-2220:cross
 f2400-2420:cross
 
 # --- ONLINE -> GTA+ -> STORY, then enter -------------------------------------------------------
+# FOUR R1 presses, not two, and the reason is measured: in one run only ONE of two registered, the
+# menu stayed on GTA+, and the following Cross entered GTA+ (an online feature) instead of STORY.
+# STORY is the RIGHTMOST tab -- the bar reads [L1] ONLINE GTA+ STORY [R1] -- so a press that lands
+# when already on STORY clamps rather than overshooting. Extra presses are therefore free in the
+# right-hand direction and are the cheap fix for an eaten input; two were not enough.
 f2600-2620:r1
-f2750-2770:r1
-f2900-2920:cross
+f2700-2720:r1
+f2800-2820:r1
+f2880-2900:r1
+f3000-3020:cross
 
 # A second Cross well after, in case the first landed during a transition. If STORY was already
 # entered, this lands on whatever the story flow presents (a save-slot or difficulty prompt), which
 # is progress rather than a wrong turn.
-f3200-3220:cross
+f3300-3320:cross
 f3600-3620:cross
+
+# Past the Story Mode entry: the flow presents a save-slot / "Resume Story" confirmation before the
+# world loads. Spaced pulses rather than a burst, same reason as above.
+f4000-4020:cross
+f4400-4420:cross
+f4800-4820:cross
+f5200-5220:cross
+f5600-5620:cross
+f6000-6020:cross
 
 # --- WHAT THIS ROUTE REACHES TODAY, and where it stops ------------------------------------------
 #

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -1638,12 +1638,83 @@ HLE(k_get_direct_memory_type) {
 // without VirtualQuery's larger result structure. Every output is optional; an untracked address
 // fails before touching any of them. Copying the Mapping under g_mx avoids retaining a vector
 // element pointer while another thread splits or replaces the tracker.
+// #2391: the tracker is not the whole truth about guest memory, and this query is where it shows.
+//
+// `g_maps` records what the kernel-memory HLE mapped. It does NOT record the LOADER's module images:
+// map_image reserves the whole module at its guest base and registers it with nothing. So a guest
+// asking about an address in its OWN module -- code, data, or bss -- got EACCES, as if the memory did
+// not exist. GTA V (PPSA04263) asserts on exactly that: it queries an address in its own zero-fill
+// bss (ph[7], past filesz) and traps at eboot+0x2b2be48 on the non-zero return.
+//
+// The tracker stays AUTHORITATIVE when it has an entry, because it carries the guest's REQUESTED
+// protection, which legitimately differs from the host's -- prosper maps images RWX regardless of
+// segment flags, so consulting the host first would tell a guest its read-only segment is writable.
+// The host is consulted only where prosper's own bookkeeping has nothing to say.
+//
+// Deliberately NOT done: registering module images in `g_maps`. That is the more complete fix, but
+// `g_maps` also feeds `range_is_free_reservation` and the MAP_FIXED safety checks -- whose own
+// comment says a gap means "an untracked host mapping / loaded image, so MAP_FIXED must fail". Adding
+// entries there changes MAPPING behavior; this changes only the answer to a question. See #2391.
+//
+// THE TRAP, and the reason the protection VALUE matters as much as the success code: the guest reads
+// `prot & 0x80` immediately after this call. Returning a placeholder 0 would satisfy its assertion
+// and then send it down a branch chosen by a value we invented -- a QUIETER failure than the loud one
+// being fixed, and far harder to attribute later. So the fallback reports real host protection mapped
+// onto the Sony CPU bits, never a placeholder, and fails closed when the host has nothing either.
+// Host-side fallback for k_query_memory_protection (#2391). Reports the containing host mapping and
+// its REAL protection, translated to the Sony CPU bits (READ 0x1 / WRITE 0x2 / EXEC 0x4). Returns
+// false when the address is not mapped at all, so an unmapped query still fails closed with EACCES.
+static bool query_host_mapping(uint64_t addr, uint64_t& out_base, uint64_t& out_end, uint32_t& out_prot) {
+#if defined(__APPLE__)
+    mach_vm_address_t region = (mach_vm_address_t)addr;
+    mach_vm_size_t size = 0;
+    vm_region_basic_info_data_64_t info{};
+    mach_msg_type_number_t count = VM_REGION_BASIC_INFO_COUNT_64;
+    mach_port_t object = MACH_PORT_NULL;
+    if (mach_vm_region(mach_task_self(), &region, &size, VM_REGION_BASIC_INFO_64,
+                       (vm_region_info_t)&info, &count, &object) != KERN_SUCCESS)
+        return false;
+    if (addr < (uint64_t)region || addr >= (uint64_t)region + (uint64_t)size) return false;
+    out_base = (uint64_t)region; out_end = (uint64_t)region + (uint64_t)size;
+    out_prot = ((info.protection & VM_PROT_READ)    ? 0x1u : 0u) |
+               ((info.protection & VM_PROT_WRITE)   ? 0x2u : 0u) |
+               ((info.protection & VM_PROT_EXECUTE) ? 0x4u : 0u);
+    return true;
+#else
+    // Linux: /proc/self/maps is the only source that reports protection per range. One pass, stopping
+    // at the containing line -- this is a cold path (the tracker answers every mapped-by-HLE query).
+    FILE* maps = fopen("/proc/self/maps", "re");
+    if (!maps) return false;
+    char line[512];
+    bool found = false;
+    while (fgets(line, sizeof line, maps)) {
+        unsigned long long lo = 0, hi = 0; char perms[8] = {0};
+        if (sscanf(line, "%llx-%llx %7s", &lo, &hi, perms) != 3) continue;
+        if (addr < lo || addr >= hi) continue;
+        out_base = (uint64_t)lo; out_end = (uint64_t)hi;
+        out_prot = (perms[0] == 'r' ? 0x1u : 0u) | (perms[1] == 'w' ? 0x2u : 0u) |
+                   (perms[2] == 'x' ? 0x4u : 0u);
+        found = true;
+        break;
+    }
+    fclose(maps);
+    return found;
+#endif
+}
+
 HLE(k_query_memory_protection) {
     Mapping mapping{};
-    if (!snapshot_mapping(a0, mapping)) return 0x8002000dull;  // SCE_KERNEL_ERROR_EACCES
-    if (a1) *(uint64_t*)(uintptr_t)a1 = mapping.base;
-    if (a2) *(uint64_t*)(uintptr_t)a2 = mapping.base + mapping.size;
-    if (a3) *(uint32_t*)(uintptr_t)a3 = mapping.guest_prot;
+    if (snapshot_mapping(a0, mapping)) {
+        if (a1) *(uint64_t*)(uintptr_t)a1 = mapping.base;
+        if (a2) *(uint64_t*)(uintptr_t)a2 = mapping.base + mapping.size;
+        if (a3) *(uint32_t*)(uintptr_t)a3 = mapping.guest_prot;
+        return 0;
+    }
+    uint64_t hb = 0, he = 0; uint32_t hp = 0;
+    if (!query_host_mapping(a0, hb, he, hp)) return 0x8002000dull;  // SCE_KERNEL_ERROR_EACCES
+    if (a1) *(uint64_t*)(uintptr_t)a1 = hb;
+    if (a2) *(uint64_t*)(uintptr_t)a2 = he;
+    if (a3) *(uint32_t*)(uintptr_t)a3 = hp;
     return 0;
 }
 
@@ -5362,12 +5433,66 @@ HLE(k_get_direct_memory_type) {
     return 0;
 }
 
+// #2391: the tracker is not the whole truth about guest memory, and this query is where it shows.
+//
+// `g_maps` records what the kernel-memory HLE mapped. It does NOT record the LOADER's module images:
+// map_image reserves the whole module at its guest base and registers it with nothing. So a guest
+// asking about an address in its OWN module -- code, data, or bss -- got EACCES, as if the memory did
+// not exist. GTA V (PPSA04263) asserts on exactly that: it queries an address in its own zero-fill
+// bss (ph[7], past filesz) and traps at eboot+0x2b2be48 on the non-zero return.
+//
+// The tracker stays AUTHORITATIVE when it has an entry, because it carries the guest's REQUESTED
+// protection, which legitimately differs from the host's -- prosper maps images RWX regardless of
+// segment flags, so consulting the host first would tell a guest its read-only segment is writable.
+// The host is consulted only where prosper's own bookkeeping has nothing to say.
+//
+// Deliberately NOT done: registering module images in `g_maps`. That is the more complete fix, but
+// `g_maps` also feeds `range_is_free_reservation` and the MAP_FIXED safety checks -- whose own
+// comment says a gap means "an untracked host mapping / loaded image, so MAP_FIXED must fail". Adding
+// entries there changes MAPPING behavior; this changes only the answer to a question. See #2391.
+//
+// THE TRAP, and the reason the protection VALUE matters as much as the success code: the guest reads
+// `prot & 0x80` immediately after this call. Returning a placeholder 0 would satisfy its assertion
+// and then send it down a branch chosen by a value we invented -- a QUIETER failure than the loud one
+// being fixed, and far harder to attribute later. So the fallback reports real host protection mapped
+// onto the Sony CPU bits, never a placeholder, and fails closed when the host has nothing either.
+// Host-side fallback for k_query_memory_protection (#2391). See the contract block above the POSIX
+// arm's copy. Reserved-but-uncommitted memory reports as NOT mapped: the guest asked what protection
+// applies, and a reservation has none.
+static bool query_host_mapping(uint64_t addr, uint64_t& out_base, uint64_t& out_end, uint32_t& out_prot) {
+    MEMORY_BASIC_INFORMATION mbi{};
+    if (!VirtualQuery((const void*)(uintptr_t)addr, &mbi, sizeof(mbi))) return false;
+    if (mbi.State != MEM_COMMIT) return false;
+    const DWORD prot = mbi.Protect & 0xffu;   // strip PAGE_GUARD / NOCACHE / WRITECOMBINE modifiers
+    if (prot == 0 || prot == PAGE_NOACCESS) return false;
+    uint32_t sony = 0;
+    if (prot & (PAGE_READONLY | PAGE_READWRITE | PAGE_WRITECOPY |
+                PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+        sony |= 0x1u;
+    if (prot & (PAGE_READWRITE | PAGE_WRITECOPY | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+        sony |= 0x2u;
+    if (prot & (PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY))
+        sony |= 0x4u;
+    if (prot & PAGE_EXECUTE) sony |= 0x4u;
+    out_base = (uint64_t)(uintptr_t)mbi.BaseAddress;
+    out_end  = out_base + (uint64_t)mbi.RegionSize;
+    out_prot = sony;
+    return true;
+}
+
 HLE(k_query_memory_protection) {
     Mapping mapping{};
-    if (!snapshot_mapping(a0, mapping)) return 0x8002000dull;
-    if (a1) *(uint64_t*)(uintptr_t)a1 = mapping.base;
-    if (a2) *(uint64_t*)(uintptr_t)a2 = mapping.base + mapping.size;
-    if (a3) *(uint32_t*)(uintptr_t)a3 = mapping.guest_prot;
+    if (snapshot_mapping(a0, mapping)) {
+        if (a1) *(uint64_t*)(uintptr_t)a1 = mapping.base;
+        if (a2) *(uint64_t*)(uintptr_t)a2 = mapping.base + mapping.size;
+        if (a3) *(uint32_t*)(uintptr_t)a3 = mapping.guest_prot;
+        return 0;
+    }
+    uint64_t hb = 0, he = 0; uint32_t hp = 0;
+    if (!query_host_mapping(a0, hb, he, hp)) return 0x8002000dull;  // SCE_KERNEL_ERROR_EACCES
+    if (a1) *(uint64_t*)(uintptr_t)a1 = hb;
+    if (a2) *(uint64_t*)(uintptr_t)a2 = he;
+    if (a3) *(uint32_t*)(uintptr_t)a3 = hp;
     return 0;
 }
 


### PR DESCRIPTION
Fixes #2391. **Stacked on #2390 — merge that first.**

## With both applied, GTA V (`PPSA04263`) reaches its TITLE SCREEN on Windows

Three runs on this exact head: **2880 / 2880 / 2940 frames presented, zero `[veh]` exceptions, zero
faults of any kind.** `tools/screenshot` captured the full-colour *Grand Theft Auto V* logo at 4K with
correct typography, the green mesh V, and the "Continue" prompt — not a black or diagnostic frame.

Wall progression for this title:

| # | address | mechanism | fixed by |
| --- | --- | --- | --- |
| 1 | >2 GiB reads | `stat` truncation returned zero bytes reporting success | #2375 |
| 2 | `eboot+0x2b2c463` | `GetCurrentOffset` returned 0 — packed constructor `a2` cleared `tracks_offset` | #2390 |
| 3 | `eboot+0x2b2be48` | `QueryMemoryProtection` returned EACCES for the guest's own bss | **this PR** |

## The defect

`k_query_memory_protection` answered only from `g_maps`, the tracker the *kernel-memory HLE*
populates. The **loader's** module images are not in it — `map_image` reserves the whole module at its
guest base and registers it with nothing. So a guest asking about an address in its **own module** got
EACCES, as if the memory did not exist. GTA V queries an address in its own zero-fill bss (`ph[7]`,
past `filesz`) and asserts on the non-zero return.

## Design

The tracker stays **authoritative** when it has an entry, because it carries the guest's *requested*
protection, which legitimately differs from the host's — prosper maps images RWX regardless of segment
flags, so consulting the host first would tell a guest its read-only segment is writable. The host is
consulted only where prosper's own bookkeeping has nothing to say.

**Both platform arms**, from one shared contract block. A Windows-only fix would have created the very
POSIX/Windows divergence that caused #2384 and cost this lane three separate
read-one-arm-as-the-whole-file errors in a single session.

### The trap, and why the protection *value* matters as much as the success code

The guest reads `prot & 0x80` immediately after the call:

```
2b2be48:  int  0x41                       ; the failure this fixes
2b2be4a:  test BYTE PTR [rbp-0x38],0x80
2b2be4e:  jne  0x2b2bedc
```

Returning a placeholder `0` would satisfy the assertion and then send the guest down a branch chosen
by a value we invented — **a quieter failure than the loud one being fixed**, and far harder to
attribute later. So the fallback reports real host protection mapped onto the Sony CPU bits
(`READ 0x1` / `WRITE 0x2` / `EXEC 0x4`), and **fails closed** with EACCES when the host has nothing
either. Reserved-but-uncommitted memory counts as nothing — the guest asked what protection applies,
and a reservation has none.

## Deliberately not done

Registering module images in `g_maps`. That is the more complete fix, but `g_maps` also feeds
`range_is_free_reservation` and the MAP_FIXED safety checks — whose own comment says a gap means *"an
untracked host mapping / loaded image, so MAP_FIXED must fail"*. Adding entries there changes
**mapping behaviour**; this changes only the answer to a question. Both options are written up on
#2391 for whoever wants the fuller version.

## Verification

- MinGW/UCRT clean.
- `ctest --no-tests=error -j4` → **181 of 182 passed**; the one failure is `build_revision_refresh`,
  the known pre-existing Windows crash (#2386), independently established by stashing.
- Live: 3 runs, results above. Baselines: without this change the run dies at `eboot+0x2b2be48`;
  without #2390 beneath it, at `eboot+0x2b2c463` (I measured that too, by testing this fix on plain
  master first — it moved the wall back one step, which is how I confirmed the stack order).

## Review

Worth a read. It changes what a memory-safety-adjacent query reports, on both platforms, and the
`prot`-value argument above is the part where being wrong would be silent rather than loud. No
regression test yet — the honest reason is that exercising it needs a loaded module image, and I did
not want to claim a synthetic test proved something it could not. #2391 records the shape the real one
should take (query each segment, including one past `filesz`).
