### PR TITLE
perf(gpu): register files as a sorted flat vector — allocator 19.7% -> 7.0%, hashing gone from the draw path (no frame-rate change)

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -7398,6 +7398,34 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             totals.dcc_materialize_ms / nsub,
                             static_cast<double>(totals.dcc_materialize_surfaces) / nsub,
                             totals.dcc_materialize_bytes / (nsub * 1024.0 * 1024.0));
+                    // #2395: the shader-analysis cache's counters existed and were read by NOTHING
+                    // outside two unit tests, so at runtime the cache was unobservable. A profile of
+                    // Blue Prince gameplay put ~17% of all CPU in rdna2_walk / make_shader_compile_key /
+                    // resolve_dynamic_fetch -- i.e. shaders being re-analysed during steady-state play --
+                    // and there was no way to tell WHY without rebuilding with instrumentation.
+                    //
+                    // `invalidations` is the discriminator and the reason this line exists. The cache is
+                    // keyed on the guest CODE ADDRESS and validated by memcmp, so:
+                    //   misses high, invalidations ~0  -> cold or capacity-bound (see evict/entries)
+                    //   invalidations high             -> the guest reuses addresses for DIFFERENT code,
+                    //                                     so every reuse costs a full re-analysis. That
+                    //                                     is a keying problem, not a sizing one, and no
+                    //                                     amount of cache MB fixes it.
+                    // Those two call for opposite fixes, which is exactly why the number has to be
+                    // visible rather than inferred from a flame graph.
+                    {
+                        const prosper::gpu::ShaderAnalysisCacheStats sa =
+                            prosper::gpu::shader_analysis_cache_stats();
+                        const uint64_t lookups = sa.hits + sa.misses;
+                        fprintf(stderr,
+                                "[render-timing] shader_analysis hits=%llu misses=%llu (%.1f%% hit) "
+                                "invalidations=%llu evictions=%llu bypasses=%llu entries=%llu %.1f MiB\n",
+                                (unsigned long long)sa.hits, (unsigned long long)sa.misses,
+                                lookups ? 100.0 * (double)sa.hits / (double)lookups : 0.0,
+                                (unsigned long long)sa.invalidations, (unsigned long long)sa.evictions,
+                                (unsigned long long)sa.bypasses, (unsigned long long)sa.entries,
+                                sa.bytes / (1024.0 * 1024.0));
+                    }
                     // pass_control, split (#2266). `pre` and `post` are the per-group work either
                     // side of build_resources+backend; `other` is the SIGNED remainder -- groups that
                     // returned before reaching the render, the tail after the group loop, and the

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6033,8 +6033,25 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             else if (cpu_needed_same_batch) bucket = kSameBatchCpu;
                             else if (sampled_exact_later && feedback_later) bucket = kFeedback;
                             ++counts[bucket];
-                            bytes[bucket] += static_cast<uint64_t>(gw) * gh *
-                                prosper::test::backend_color_bytes_per_pixel(pass_format);
+                            // #2398: bill bytes only when colour pixels are ACTUALLY requested.
+                            // #2283 narrowed the readback to `want_color_readback` (the same
+                            // any_of over pass_bases used at the call below) and this accounting
+                            // never followed it -- so a depth-only pass, whose slot bases are all
+                            // zero and which therefore lands in the `no_base` bucket BY
+                            // CONSTRUCTION, was billed a full frame of colour it never copied.
+                            //
+                            // That is not a rounding error: on Blue Prince it reported 15.6 GB
+                            // against `no_base` and made depth passes look like the frame-rate
+                            // wall. The count was right; the column that made it actionable was
+                            // measuring a world from before #2283. An instrument that drifts from
+                            // the code it measures reads as evidence, which is worse than silence.
+                            const bool billed_color = std::any_of(
+                                pass_bases.begin(),
+                                pass_bases.begin() + std::min<size_t>(mrt_count, pass_bases.size()),
+                                [](uint64_t slot_base) { return slot_base != 0; });
+                            if (billed_color)
+                                bytes[bucket] += static_cast<uint64_t>(gw) * gh *
+                                    prosper::test::backend_color_bytes_per_pixel(pass_format);
                             static std::atomic<uint64_t> last_report{0};
                             const uint64_t t = ++c_total;
                             if (t >= last_report.load(std::memory_order_relaxed) + 200) {

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -41,6 +41,20 @@ struct ShaderReg { uint32_t offset; uint32_t value; };
 // The sparse contract is preserved exactly and is the thing to be careful about: an offset that was
 // never written must remain ABSENT (`find() == end()`, `count() == 0`), not read as 0. Every lookup
 // here goes through the same presence test as before; nothing invents a zero.
+//
+// ONE LIFETIME RULE DID CHANGE, and it is the only behavioural difference from the unordered_map:
+// `std::unordered_map::insert` does not invalidate references or pointers to existing elements.
+// `std::vector::insert` invalidates BOTH references and iterators when it reallocates. So this is
+// fine before the swap and undefined behaviour after it:
+//
+//     uint32_t& v = f[a];
+//     f[b] = x;            // may reallocate
+//     v = y;               // dangling
+//
+// No caller in the tree does that today -- every `find` result is consumed immediately with no
+// intervening mutation -- but nothing in the type stops the next one, so it is written down here
+// rather than left to be rediscovered. Raised in review by Wren, who went looking for the pattern
+// specifically because it is what a map-to-vector swap silently changes.
 class RegisterFile {
 public:
     using value_type = std::pair<uint32_t, uint32_t>;

--- a/prosper/src/gpu/command_processor.hpp
+++ b/prosper/src/gpu/command_processor.hpp
@@ -12,7 +12,10 @@
 #include "pm4_decode.hpp"
 #include <cstdint>
 #include <memory>
+#include <algorithm>
+#include <stdexcept>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace prosper::gpu {
@@ -20,9 +23,89 @@ namespace prosper::gpu {
 // A {register offset, value} pair — the element type of a Set*RegistersIndirect array.
 struct ShaderReg { uint32_t offset; uint32_t value; };
 
+// #2395: the register files used to be `std::unordered_map<uint32_t, uint32_t>`, and the cost was
+// not lookup — it was the COPY. `command_processor.cpp` snapshots GpuState on every dirty draw
+// (five sites) with `snap->cx = cx; snap->sh = sh; snap->uc = uc;`, and copying an unordered_map
+// allocates one heap node PER ENTRY. A perf profile of Blue Prince gameplay at 3.3-4.0 fps put
+// 16.98% of all CPU in __memmove_avx512 and 19.73% in the allocator — ~37%, from this one choice,
+// scaling with draw count.
+//
+// A sorted flat vector copies as a single contiguous allocation plus one memcpy, which is what a
+// per-draw snapshot needs. Lookups become a branch-predictable binary search over a few hundred
+// cache-adjacent entries instead of a hash plus a pointer-chase into scattered nodes.
+//
+// This is a DROP-IN for the operations the codebase actually uses (measured: 44 `count`, 21
+// `find`/`end`, 1 `size`, 3 `operator[]`, and zero iteration over the maps). `find` returns a real
+// vector const_iterator, so `it->second` and `it == f.end()` keep working unchanged.
+//
+// The sparse contract is preserved exactly and is the thing to be careful about: an offset that was
+// never written must remain ABSENT (`find() == end()`, `count() == 0`), not read as 0. Every lookup
+// here goes through the same presence test as before; nothing invents a zero.
+class RegisterFile {
+public:
+    using value_type = std::pair<uint32_t, uint32_t>;
+    using const_iterator = std::vector<value_type>::const_iterator;
+
+    const_iterator begin() const { return entries_.begin(); }
+    const_iterator end() const { return entries_.end(); }
+    size_t size() const { return entries_.size(); }
+    bool empty() const { return entries_.empty(); }
+    void clear() { entries_.clear(); }
+
+    const_iterator find(uint32_t offset) const {
+        const auto it = lower(offset);
+        return (it != entries_.end() && it->first == offset) ? it : entries_.end();
+    }
+    size_t count(uint32_t offset) const { return find(offset) != entries_.end() ? 1u : 0u; }
+
+    // Same contract as std::unordered_map::at — THROWS on an absent offset rather than inserting or
+    // reading zero. Kept faithful because tests use it as an assertion that a register was written;
+    // returning 0 for a missing one would turn those into silent passes.
+    const uint32_t& at(uint32_t offset) const {
+        const auto it = find(offset);
+        if (it == entries_.end()) throw std::out_of_range("RegisterFile::at: register not set");
+        return it->second;
+    }
+    uint32_t& at(uint32_t offset) {
+        const auto it = lower(offset);
+        if (it == entries_.end() || it->first != offset)
+            throw std::out_of_range("RegisterFile::at: register not set");
+        return it->second;
+    }
+
+    // Erases an offset, making it ABSENT again (not zero). Used by tests that check the
+    // fallback path taken when a register was never written.
+    size_t erase(uint32_t offset) {
+        const auto it = lower(offset);
+        if (it == entries_.end() || it->first != offset) return 0;
+        entries_.erase(it);
+        return 1;
+    }
+
+    // Inserts a zero-valued entry when absent, matching std::unordered_map::operator[]. Register
+    // writes arrive in bursts of ascending offsets (SET_*_REG writes a consecutive run), so the
+    // common insert lands at or near the end and the memmove is short.
+    uint32_t& operator[](uint32_t offset) {
+        const auto it = lower(offset);
+        if (it != entries_.end() && it->first == offset) return it->second;
+        return entries_.insert(it, value_type{offset, 0u})->second;
+    }
+
+private:
+    std::vector<value_type>::iterator lower(uint32_t offset) {
+        return std::lower_bound(entries_.begin(), entries_.end(), offset,
+                                [](const value_type& e, uint32_t k) { return e.first < k; });
+    }
+    const_iterator lower(uint32_t offset) const {
+        return std::lower_bound(entries_.begin(), entries_.end(), offset,
+                                [](const value_type& e, uint32_t k) { return e.first < k; });
+    }
+    std::vector<value_type> entries_;   // sorted by offset, unique
+};
+
 // Folded GPU state after replaying a command stream.
 struct GpuState {
-    std::unordered_map<uint32_t, uint32_t> cx, sh, uc;   // register files by offset
+    RegisterFile cx, sh, uc;   // register files by offset (#2395: was unordered_map)
     // PROSPER_UDPROV=1 (issue #305) or an armed resource-provenance selector (#1853): per-SH-register
     // last-write provenance. Resolved register VALUES cannot distinguish "this draw's bind wrote this dword"
     // from "a previous pipeline's bind wrote it and no newer write arrived" — which is exactly the

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -812,7 +812,13 @@ std::shared_ptr<const ShaderCodeAnalysis> analyze_shader_code_cached(const uint3
 
     if (!code || !dwords) return analyze();
     auto& cache = shader_analysis_cache();
-    if (getenv("PROSPER_NO_SHADER_ANALYSIS_CACHE")) {
+    // #2395: was a getenv PER LOOKUP -- 1,697,925 of them in one Blue Prince gameplay run,
+    // and `getenv` showed at 1.34% of total CPU in a profile of that run. The environment
+    // cannot change under a running process, so reading it once is not merely an
+    // optimisation, it is the correct semantics. Same hoist as #2214 did for the live
+    // renderer's per-resource reads.
+    static const bool bypass_analysis_cache = getenv("PROSPER_NO_SHADER_ANALYSIS_CACHE") != nullptr;
+    if (bypass_analysis_cache) {
         std::lock_guard lock(cache.mutex);
         ++cache.stats.bypasses;
         return analyze();
@@ -976,7 +982,10 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
     key.vertices_per_instance = stage == ShaderProgramStage::Vertex && resources
         ? resources->vertices_per_instance : 0u;
     key.has_resource_table = resources != nullptr;
-    key.force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
+    // #2395: also once, not per key. make_shader_compile_key is 4.52% of total CPU in Blue
+    // Prince gameplay and runs per draw per stage.
+    static const bool force_position_w = getenv("PROSPER_FORCE_W") != nullptr;
+    key.force_position_w = force_position_w;
     key.capture_position = stage == ShaderProgramStage::Vertex && capture_position;
     key.has_pixel_inputs = stage != ShaderProgramStage::Compute && pixel_inputs != nullptr;
     if (key.has_pixel_inputs) key.pixel_inputs = *pixel_inputs;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -178,7 +178,7 @@ private:
 // SPI_SHADER_USER_DATA_*_0 register offset; absent registers read as 0. 32 (not 16) because NGG merged
 // shaders place descriptors in the extended user SGPRs s16..s31 (e.g. vertex buffers at s16/s18).
 static constexpr uint32_t kUserSgprs = 32;
-void read_user_sgprs(const std::unordered_map<uint32_t, uint32_t>& sh, uint32_t base, uint32_t out[kUserSgprs]) {
+void read_user_sgprs(const RegisterFile& sh, uint32_t base, uint32_t out[kUserSgprs]) {
     for (uint32_t i = 0; i < kUserSgprs; i++) { auto it = sh.find(base + i); out[i] = it == sh.end() ? 0u : it->second; }
 }
 
@@ -4729,7 +4729,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
     if (failures) failures->clear();
     if (st.dispatches.empty()) return {};
     namespace P = prosper::agc::Pm4;
-    auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
+    auto rd = [](const RegisterFile& regs, uint32_t off) {
         auto it = regs.find(off);
         return it == regs.end() ? 0u : it->second;
     };
@@ -5400,7 +5400,7 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     }
 
     namespace P = prosper::agc::Pm4;
-    auto rd = [](const std::unordered_map<uint32_t, uint32_t>& regs, uint32_t off) {
+    auto rd = [](const RegisterFile& regs, uint32_t off) {
         auto it = regs.find(off); return it == regs.end() ? 0u : it->second;
     };
     size_t matched = 0;

--- a/prosper/src/gpu/render_state.cpp
+++ b/prosper/src/gpu/render_state.cpp
@@ -18,7 +18,7 @@ namespace {
 namespace P = prosper::agc::Pm4;
 
 // Read a register value from a class file (0 if unset).
-uint32_t rd(const std::unordered_map<uint32_t, uint32_t>& file, uint32_t off) {
+uint32_t rd(const RegisterFile& file, uint32_t off) {
     auto it = file.find(off);
     return it == file.end() ? 0u : it->second;
 }


### PR DESCRIPTION
Fixes #2395 (the allocator/hashing half). **Does not fix Blue Prince's frame rate — see the measurement.**

## Change

`GpuState`'s `cx`/`sh`/`uc` register files were `std::unordered_map<uint32_t,uint32_t>`. The cost was never
lookup — it was the **copy**. `command_processor.cpp` snapshots GpuState on every dirty draw at five sites
(`snap->cx = cx; snap->sh = sh; snap->uc = uc;`), and copying an unordered_map allocates **one heap node per
entry**. Replaced with a sorted flat vector, which copies as one contiguous allocation plus a memcpy.

`RegisterFile` is a drop-in for the operations actually used — enumerated before writing it, not assumed:
44 `count`, 21 `find`/`end`, 1 `size`, 3 `operator[]`, `at`/`erase` in tests, and **no iteration**. `find`
returns a real vector `const_iterator`, so `it->second` and `it == f.end()` are unchanged at every site.

**The sparse contract is what had to be exact**, because getting it wrong corrupts register state silently
instead of failing loudly: an offset never written stays ABSENT (`find()==end()`, `count()==0`); nothing
reads as zero. `at()` keeps `unordered_map`'s throwing behaviour deliberately — tests use it to assert a
register *was* written, and returning 0 would turn those into silent passes.

## Measured, same route, same Mount Holly regime, `perf -F 199 -g`

| symbol | before | after |
| --- | ---: | ---: |
| `_int_malloc` | 5.67% | **2.96%** |
| `_int_free_chunk` | 6.63% | **2.42%** |
| `__libc_malloc2` | 4.97% | **1.61%** |
| `_int_free_create_chunk` | 2.46% | **< 1.2%** |
| **allocator total** | **19.73%** | **~7.0%** |
| `_Hashtable<unsigned,…>::find` | 3.43% | **gone** |
| `_Hashtable<…>::erase` | 0.95% | **gone** |
| `RegisterFile` lookup (`rd`) | — | 1.59% |
| `__memmove_avx512` | 16.98% | 19.75% |

**~17 points of CPU removed from allocation and hashing; ~3 given back to memmove** (the flat copy is now
a memcpy where it used to be node-chasing). Net ≈ **14 percentage points of CPU freed**, and the hash
machinery is gone from the draw path entirely.

## What it did NOT do

**Frame rate did not measurably improve: 4.3–4.5 fps after, against 3.3–4.2 before.** That is inside the
run-to-run spread I have seen on this route, so I am claiming **no** frame-rate win.

Freeing 14 points of CPU without moving fps means the frame time is bounded by something else. The profile
now points at two things it did not before:

1. **`__memmove_avx512` rose to 19.75% and is now the largest single entry.** The snapshot copy is cheaper
   per draw but still happening per draw. The next lever is not making the copy faster — it is **not
   copying**: copy-on-write, or snapshotting only the registers that changed.
2. **Shader re-walking is now the biggest identified block**: `rdna2_walk` 8.37% + `resolve_dynamic_fetch`
   5.34% + `make_shader_compile_key` 4.61% = **18.3%**, and it went *up* in share as the allocator fell.
   The analysis cache is at 100% hit (#2397 surfaces those counters), so this is per-draw work happening
   *around* a cache that is working.

## Verification

- **228/228** ctest `--no-tests=error`, default dump.
- Before/after profiles from the **same route and phase** (`PROSPER_IME_AUTOKEY=1`, ~700 s to the hall).
  Both are gameplay, not a menu — the distinction that invalidated every earlier measurement in this
  investigation (#2395).
- Risk: this replaces the hottest data structure in the renderer. The suite passes, but a reviewer should
  attack the sparse semantics specifically — `operator[]` inserting zero on absent, `at()` throwing, and
  `erase` making an offset absent rather than zero.
