### PR TITLE
fix(gpu): stop skipping fragment shaders whose only wave64 reason is a branch-guard vote — GTA V's intro animation renders on NVIDIA

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4320,7 +4320,30 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             available_fragment_subgroup_features |= prosper::gpu::kFragmentSubgroupShuffle;
         const bool uses_internal_gds =
             fragment_uses_internal_gds_memoized(bd.fs_identity, bd_fs);
-        if (required_fragment_subgroup_size &&
+        // #2402: a fragment shader whose ONLY reason for wanting wave64 is a branch-guard VOTE
+        // (`wave-any`) does not depend on the wave WIDTH for its meaning -- "did any lane take this
+        // branch" is answered the same way over two 32-wide subgroups as over one 64-wide one. That
+        // is the opposite of a lane-IDENTITY dependence, where SubgroupLocalInvocationId *is* the
+        // guest lane id and no lowering exists; #2147 added the reason bits precisely so the two
+        // could be told apart, and its comment below says which has prospects.
+        //
+        // Skipping these draws is not a safe default -- it dropped GTA V's entire opening animation
+        // on NVIDIA (subgroup range 32..32) while AMD, whose wave64 is native, rendered it. The
+        // charter is explicit that an unsupported GPU operation is a fatal gap rather than an
+        // acceptable skip, and a silent skip reads as "handled" when real content is being lost.
+        //
+        // Narrow by construction: only when wave-any is the SOLE reason. Any lane-id, DPP,
+        // permlane, readlane64 or shuffle bit still gates, because those genuinely encode a
+        // 64-lane data layout. CONFIDENCE: MED -- the semantics argument is sound and the failure
+        // mode if wrong is a wrongly-taken branch in one shader, not memory unsafety.
+        const uint32_t fragment_wave_reasons =
+            required_fragment_subgroup_size == 64
+                ? prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs)
+                : 0u;
+        const bool wave_any_is_sole_reason =
+            fragment_wave_reasons != UINT32_MAX &&
+            fragment_wave_reasons == prosper::gpu::kFragmentWaveReasonWaveAny;
+        if (required_fragment_subgroup_size && !wave_any_is_sole_reason &&
             (!ctx.subgroup_size_control ||
              required_fragment_subgroup_size < ctx.min_subgroup_size ||
              required_fragment_subgroup_size > ctx.max_subgroup_size ||


### PR DESCRIPTION
Refs #2402. **Makes GTA V's opening Rockstar animation render on NVIDIA, where it was completely invisible.**

## The defect

GTA V decodes Bink Video **in guest code** — no `sceAvPlayer`, no Sony video API, on either platform. It produces a valid YUV 4:2:0 frame (Y 3840×2160, U/V 1920×1080; Y plane 9.5% lit with full dynamic range), binds the three planes, and issues the composite draw.

prosper then **skipped that draw**:

```
[render] skip draw: fragment shader requires subgroup size 64
         (device range 32..32 ... why=0x2 wave-any)
```

PS5 is RDNA2 and uses wave64. **AMD supports wave64 natively → the draw issues → the animation renders. NVIDIA is warp32 → the draw is dropped → black frame.** The "Windows vs Linux" divergence this was chased as is really **NVIDIA vs AMD**, and it reproduces on Linux+NVIDIA.

## Why this shader is safe to lower

#2147 added the reason bits precisely to separate two cases, and its own comment states the rule:

> a shader needing 64 for lane IDENTITY (which can never run at 32, since `SubgroupLocalInvocationId` IS the guest lane id) printed identically to one needing it only for a branch-guard vote (which **may be width-agnostic**)

This shader reports `why=0x2` — `kFragmentWaveReasonWaveAny` and **nothing else**. "Did any lane take this branch" is answered identically over two 32-wide subgroups as over one 64-wide one.

**Narrow by construction:** the relaxation applies only when wave-any is the *sole* reason. Any `lane-id`, `dpp16`, `permlane32`, `readlane64` or `shuffle` bit still gates the draw, because those encode a genuine 64-lane data layout.

## Verification

Same three frames, before and after, native Windows / NVIDIA RTX 4090:

| frame | before | after |
| --- | --- | --- |
| 60 | PEAK=0 cov=0.0% | **PEAK=206 cov=83.4%** |
| 150 | PEAK=0 cov=0.0% | **PEAK=64 cov=24.1%** |
| 240 | PEAK=98 cov=4.0% | PEAK=204 cov=4.2% |

Frame 60 renders the Rockstar intro — colour gradients and the five-star loading indicator — where it was pure black. **Frame 240 is unchanged**, which is the control: the relaxation does not disturb draws that were already issuing.

## Charter

> An unsupported shader/GPU operation is a FATAL gap, not an acceptable skip — support ALL of them. Silent skips drop real rendered content and read as "handled" when they are not.

This skip dropped an entire opening sequence and surfaced only under debug logging on an isolated replay. Every layer above it reported success: `failed=0`, no recompile reject, no dropped draw, output hash equal to seed hash.

## Review — please read this one properly

`CONFIDENCE: MED` on the semantics. The wave-any argument is sound, but this is a **shared recompiler/backend path used by every title**, gated on a condition only NVIDIA currently hits — so your AMD lane will not exercise the changed branch at all, and that asymmetry is worth knowing while reviewing.

If the argument is wrong, the failure mode is a wrongly-taken branch inside one fragment shader, not memory unsafety. The specific thing to attack: whether any `subgroupAny` in a *fragment* shader can depend on the wave partitioning itself rather than on the predicate.

No new test. The verification is a live before/after on a real title, and I could not construct a synthetic shader that would prove the semantics without asserting the very thing in question.
