### PR TITLE
fix(recompiler): a CFG-dispatcher attempt that fails part way must not leave its half-written switch in the module

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -15301,6 +15301,13 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // control flow therefore needs no workgroup vote: the dispatcher selects the next block from
         // this pixel/vertex's SCC, VCC, or EXEC bit. Keep ordinary structured shaders on their compact
         // SSA path and use the Function-variable fallback only after the narrow structurizer rejects.
+        // Only one of these two blocks can run: complex_compute_cfg requires b.is_compute and
+        // complex_graphics_cfg requires graphics_cfg (b.is_fragment || b.is_vertex), and a module is
+        // one or the other. That exclusivity is what makes a clean reject (0) from the compute block
+        // safe to fall through — it reaches this block only in a stage that cannot enter it. If the
+        // stage predicates above ever stop being disjoint, this second attempt would run against
+        // builder state the first had already touched, and the checkpoint would no longer describe an
+        // untouched buffer.
         if (allow_cfg_dispatcher && complex_graphics_cfg && cf_rejected) {
             const int emitted = try_cfg_dispatcher();
             if (emitted > 0) return true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -15268,18 +15268,44 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 return false;
             return true;
         }
-        if (allow_cfg_dispatcher && complex_compute_cfg && (cf_rejected || Ls.empty()) &&
-            emit_cfg_state_machine(b, rs, ins, safe, rt,
-                                   allow_exec_update, allow_smem, exp_fn, code, dwords))
-            return true;
+        // Attempting the dispatcher is only recoverable while it has emitted NOTHING.
+        // emit_cfg_state_machine writes the dispatcher loop's OpLoopMerge, its OpSelectionMerge and
+        // the OpSwitch into b.code *before* it emits the per-case block bodies, and it can still
+        // reject inside a case body (an unlowerable instruction, an unresolvable successor). Falling
+        // through to the structurizer after that leaves the half-written construct in the module: the
+        // switch and both merges survive, referencing case / default / continue / merge labels that
+        // are never emitted. That is structurally invalid SPIR-V, and nothing downstream catches it —
+        // `spirv-val` is a CI gate over representative modules, not over game shaders, so the module
+        // reaches the driver, `spirv_to_nir` returns NULL, and RADV dereferences that NULL (#2396).
+        // So the attempt is transactional: fall back only when the buffer is untouched, and reject
+        // loudly once anything has been written.
+        auto try_cfg_dispatcher = [&]() -> int {           // 1 = emitted, 0 = clean reject, -1 = partial
+            const size_t checkpoint = b.code.size();
+            if (emit_cfg_state_machine(b, rs, ins, safe, rt,
+                                       allow_exec_update, allow_smem, exp_fn, code, dwords))
+                return 1;
+            if (b.code.size() == checkpoint) return 0;
+            if (getenv("PROSPER_DBG"))
+                std::fprintf(stderr,
+                             "[cfg-dispatcher-partial] rejected after emitting %zu words; failing the "
+                             "shader instead of shipping a half-written dispatcher\n",
+                             b.code.size() - checkpoint);
+            return -1;
+        };
+        if (allow_cfg_dispatcher && complex_compute_cfg && (cf_rejected || Ls.empty())) {
+            const int emitted = try_cfg_dispatcher();
+            if (emitted > 0) return true;
+            if (emitted < 0) return false;
+        }
         // In graphics, the SPIR-V invocation already represents one guest lane. Complex reducible
         // control flow therefore needs no workgroup vote: the dispatcher selects the next block from
         // this pixel/vertex's SCC, VCC, or EXEC bit. Keep ordinary structured shaders on their compact
         // SSA path and use the Function-variable fallback only after the narrow structurizer rejects.
-        if (allow_cfg_dispatcher && complex_graphics_cfg && cf_rejected &&
-            emit_cfg_state_machine(b, rs, ins, safe, rt,
-                                   allow_exec_update, allow_smem, exp_fn, code, dwords))
-            return true;
+        if (allow_cfg_dispatcher && complex_graphics_cfg && cf_rejected) {
+            const int emitted = try_cfg_dispatcher();
+            if (emitted > 0) return true;
+            if (emitted < 0) return false;
+        }
         if (cf_rejected) Ls.clear();   // unmodeled CF somewhere: fall through to straight-line (loud reject)
         if (Fs.empty() && Ls.empty()) {
             wave_ok = true;   // straight-line: barriers are wave-uniform, so cross-lane mbcnt is safe here

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -15,6 +15,7 @@
 #include "compute_runner.h"
 #include <algorithm>
 #include <bit>
+#include <set>
 #include <cstdio>
 #include <cmath>
 #include <cstring>
@@ -7230,6 +7231,86 @@ int main() {
         };
         CHECK(recompile_valu(overlap_cs, std::size(overlap_cs), 1, 2).empty(),
               "#590: partially-overlapping loops remain REJECTED (unstructured region)");
+    }
+
+    // #2396: a CFG-dispatcher attempt that fails PART WAY THROUGH must not leave its half-written
+    // dispatcher in the module. emit_cfg_state_machine writes the dispatcher loop's OpLoopMerge,
+    // its OpSelectionMerge and the OpSwitch before it emits the per-case bodies, so a reject inside
+    // a case body used to fall through to the structurizer with those instructions still in the
+    // buffer — referencing case/default/continue/merge labels that were never emitted. The result
+    // was structurally invalid SPIR-V that nothing downstream caught: RADV's spirv_to_nir returns
+    // NULL on it and radv_shader.c:542 dereferences that NULL, which is how GTA V (PPSA04263)
+    // segfaulted the render thread on Linux/AMD.
+    //
+    // The stream forces the dispatcher (varying VCC branch + back-edge loop, as kernel 17d does) and
+    // then puts an instruction the dispatcher CANNOT lower into a later block. The MUBUF is the exact
+    // pair of guest dwords GTA V's rejected compute program contains; with no ShaderResourceTable it
+    // cannot resolve, so the reject lands after the switch header is already written.
+    {
+        const uint32_t partial_dispatcher_cs[] = {
+            0xBE800380u,               //  0: s_mov_b32 s0, 0
+            0x7E020284u,               //  1: v_mov_b32 v1, 4
+            0x7DA20200u,               //  2: A_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF880008u,               //  3: s_cbranch_execz +8 -> 12
+            0x7DA20200u,               //  4: B_HDR: v_cmpx_lt_u32 s0, v1
+            0xBF880008u,               //  5: s_cbranch_execz +8 -> 14
+            0xf4000480u, 0xfa000078u,  //  6: SMEM s_load_dword — with no ShaderResourceTable the
+                                       //     base pointer cannot resolve, so this rejects inside
+                                       //     emit_alu DURING case emission, after the loop/switch
+                                       //     header is already written
+            0x81008100u,               //  8: s0++
+            0xBF82FFF8u,               //  9: s_branch -8 -> 2 (A back-edge; A=[2,9])
+            0x81008100u,               // 10: s0++
+            0xBF82FFF8u,               // 11: s_branch -8 -> 4 (B back-edge; overlaps A, not nested)
+            0x7E040280u,               // 12: v_mov_b32 v2, 0
+            0x7E040280u,               // 13: v_mov_b32 v2, 0
+            0xBF810000u,               // 14: s_endpgm
+        };
+        const std::vector<uint32_t> spv =
+            recompile_valu(partial_dispatcher_cs, std::size(partial_dispatcher_cs), 1, 2);
+
+        // NOTE ON WHAT THIS TEST DOES AND DOES NOT PROVE. It asserts the INVARIANT — no emitted
+        // module may reference a label it never defines — and it is not a counter-arm for the fix
+        // that motivated it. Reproducing the defect in a unit needs the dispatcher to partial-fail
+        // AND the structurizer fallback to then SUCCEED, and in every synthetic stream tried here
+        // the fallback rejects too, so the partial output is discarded and nothing ships either way.
+        // Streams that merely reach the partial path (kernel 17d1s at line ~686 is one; verified
+        // with a temporary probe) end up empty with and without the fix, so asserting emptiness on
+        // them would pass for the wrong reason. The regression evidence for the fix itself is the
+        // live GTA V (PPSA04263) run recorded on #2396: before, the run segfaults and Mesa's
+        // MESA_SPIRV_DUMP_PATH module fails `spirv-val` with six undefined forward references;
+        // after, the route reaches gameplay and 199 of 200 dumped modules validate.
+        auto every_referenced_label_is_defined = [](const std::vector<uint32_t>& m) {
+            if (m.size() < 5) return true;
+            std::set<uint32_t> defined, referenced;
+            for (size_t i = 5; i < m.size();) {
+                const uint32_t op = m[i] & 0xffffu, len = m[i] >> 16;
+                if (len == 0 || i + len > m.size()) break;
+                switch (op) {
+                    case 248: defined.insert(m[i+1]); break;                    // OpLabel
+                    case 249: referenced.insert(m[i+1]); break;                 // OpBranch
+                    case 250: referenced.insert(m[i+2]);                        // OpBranchConditional
+                              referenced.insert(m[i+3]); break;
+                    case 246: referenced.insert(m[i+1]);                        // OpLoopMerge
+                              referenced.insert(m[i+2]); break;
+                    case 247: referenced.insert(m[i+1]); break;                 // OpSelectionMerge
+                    // OpSwitch %selector %default (<literal> <label>)* — words are
+                    // [1]=selector [2]=default [3]=literal0 [4]=label0 [5]=literal1 [6]=label1 ...
+                    // so the case LABELS are the even offsets from 4, not the odd ones.
+                    case 251: referenced.insert(m[i+2]);
+                              for (uint32_t w = 4; w < len; w += 2)
+                                  referenced.insert(m[i+w]);
+                              break;
+                    default: break;
+                }
+                i += len;
+            }
+            for (uint32_t label : referenced)
+                if (!defined.count(label)) return false;
+            return true;
+        };
+        CHECK(every_referenced_label_is_defined(spv),
+              "#2396: no emitted module references a label it never defines");
     }
 
     // Astro Bot's exact RTIP 1.1 IMAGE_BVH_INTERSECT_RAY lowering, executed on real Vulkan. The


### PR DESCRIPTION
## What breaks

GTA V (`PPSA04263`) segfaults the render thread on Linux/AMD entering 3D gameplay. The fault is inside
RADV, and the mechanism recorded on #2396 until now was wrong in the half that chose the next suspect.

`emit_cfg_state_machine` writes the dispatcher loop's `OpLoopMerge`, its `OpSelectionMerge` and the
`OpSwitch` into `b.code` **before** it emits the per-case block bodies, and it can still reject inside a
case body. Both fallback call sites used

```cpp
if (cond && emit_cfg_state_machine(...)) return true;      // falls through on false
```

so a mid-emission reject fell through to the structurizer with the half-written construct still in the
buffer. The structurizer appended its own code, the module was finalized, and it shipped referencing
case, default, continue and merge labels that were never emitted.

Captured from a live run with Mesa's own `MESA_SPIRV_DUMP_PATH` (no code change needed), the module GTA V
hands the driver fails `spirv-val` with exactly that:

```
error: line 0: The following forward referenced IDs have not been defined:
'230[%230]' '229[%229]' '225[%225]' '222[%222]' '223[%223]' '224[%224]'
```

Those six are the `OpSwitch` default, cases 3 and 4, the selection merge, and the loop's continue and
merge targets. Cases 0/1/2 are present; the function then simply ends.

## Why it crashes instead of failing cleanly

`spirv_to_nir` **rejects** the module and returns NULL, and `radv_shader.c:542` dereferences that NULL:

```c
540    nir = spirv_to_nir(...);
542    nir->info.internal |= is_internal;      // <- faults
```

Established on the exact running driver (mesa 26.1.4, build-id `1e9f2c56…`) three ways: the source
fetched by build-id, the disassembly (`or %r10b,0x40(%rax)` where `%rax` is `spirv_to_nir`'s return), and
the fault address being `0x40` itself. The missing NULL check is RADV's defect; handing it invalid
SPIR-V is ours.

**This class is invisible to our existing gate**: `tools/spv_validate` covers one representative module
per emitter path in CI, never a game shader.

## The fix

Make the dispatcher attempt transactional. Checkpoint `b.code.size()` around it and separate a **clean**
reject (nothing emitted → fall back exactly as before) from a **partial** one (something emitted →
reject the shader loudly). Behaviour is unchanged for every shader whose attempt rejects before writing
anything, which is the case the fallback exists for.

## Verified — Linux/AMD, this exact head

| check | result |
| --- | --- |
| build | clean |
| `ctest --no-tests=error -j4` | **230/230 passed, exit 0** |
| GTA V route, before | segfault ~frame 3600, `WORKER-THREAD FAULT sig=11 addr=0x40` |
| GTA V route, after | **exit 0, zero faults, reaches frame 7201**, reproduced twice |
| dumped modules after | **199/200 pass `spirv-val`** (before: the one dumped module invalid) |

Route: `PROSPER_PAD_SCRIPT=@prosper/scripts/gta5/reach-story-mode.pad`, live renderer, headless
`tools/screenshot` (this worktree has no SDL3, so no `prosper-app`).

**GTA V now reaches gameplay** — the Prologue HUD renders with a live radar, player marker, blips and
tutorial text ("The Radar shows your position within the world"), which it never reached before.

## Deliberately not fixed here

The offending compute program is now **rejected** rather than miscompiled, so its dispatch is skipped and
the 3D world still renders black. That is the fail-visible backstop rather than an end state;
implementing the instructions it rejects on is follow-up work, tracked separately.

The one remaining invalid module is an unrelated `OpPhi` dominance defect, filed separately.

## On the test, stated plainly

The added case asserts the **invariant** — no emitted module may reference a label it never defines — and
is **not** claimed as a counter-arm. Reproducing the defect in a unit needs the dispatcher to partial-fail
*and* the fallback to then succeed; in every synthetic stream I tried the fallback also rejects, so both
configurations end empty and an emptiness assertion would pass for the wrong reason. I verified that
directly (two candidate triggers passed identically with and without the fix before I discarded them),
and the test comment records it. The regression evidence is the live before/after above.

## Risk

Shared recompiler path, so it wants review. The narrow question for a reviewer: is `b.code.size()` a
sound proxy for "the attempt emitted nothing"? The attempt can also append to `types`/`deco`, but this
change never truncates — it only chooses between falling back and failing — so leftover unused
declarations cannot make a shipped module invalid.

Refs #2396
