### PR TITLE
fix(app): give prosper-app audio by default, and say so loudly when it has none

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1738,9 +1738,17 @@ endif()
 # backend would silently have no device. So acquire SDL3 ONCE here, with the UNION of the subsystems
 # the enabled frontends need (JOYSTICK/HIDAPI only when the pad frontend is on). Both consumer blocks
 # below just use the resulting SDL3::SDL3 target.
-option(PROSPER_AUDIO_SDL3 "Build the optional SDL3 audio frontend"   OFF)
-option(PROSPER_PAD_SDL3   "Build the optional SDL3 gamepad frontend" OFF)
 option(PROSPER_APP        "Build the prosper-app frontend (SDL3 window + Vulkan present)" OFF)
+# The app frontend defaults to having audio, because it is the frontend a USER runs and a silent
+# one is indistinguishable from broken audio. With PROSPER_AUDIO_SDL3 off, install_sdl3_audio_sink()
+# is compiled out of prosper-app entirely and NOTHING is logged about it -- GTA V appeared to have
+# no audio for exactly this reason, while the guest was publishing 99.9%-non-zero PCM that prosper
+# mixed correctly into a sink with no device behind it (#2402).
+#
+# option() honours an existing cache entry, so an explicit -DPROSPER_AUDIO_SDL3=OFF still wins;
+# this only changes the DEFAULT, and only when the app is being built.
+option(PROSPER_AUDIO_SDL3 "Build the optional SDL3 audio frontend"   ${PROSPER_APP})
+option(PROSPER_PAD_SDL3   "Build the optional SDL3 gamepad frontend" OFF)
 if((PROSPER_AUDIO_SDL3 OR PROSPER_PAD_SDL3 OR PROSPER_APP) AND TARGET prosper_core AND NOT TARGET SDL3::SDL3)
   # On macOS the build is x86_64 (Rosetta), but a system SDL3 (e.g. Homebrew) is arm64-only and won't
   # link — so skip discovery there and always FetchContent+build SDL3 for the requested architecture.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -918,12 +918,19 @@ static void install_host_backends() {
         fprintf(stderr, "[app] native video backend disabled.\n");
     }
 #endif
+    // Loud by design. Built without SDL3 audio support this whole block vanishes, prosper-app has
+    // NO playback device, and nothing says so. The PCM is still decoded, mixed and delivered -- to
+    // an internal sink that reports "open" while nothing plays, which is indistinguishable from a
+    // title simply being silent. That cost a full investigation on GTA V (#2402).
 #ifdef PROSPER_AUDIO_SDL3
     if (!getenv("PROSPER_APP_DISABLE_AUDIO")) {
         prosper::install_sdl3_audio_sink();
     } else {
         fprintf(stderr, "[app] SDL audio backend disabled; using the realtime silent sink.\n");
     }
+#else
+    fprintf(stderr, "[app] BUILT WITHOUT SDL3 AUDIO SUPPORT -- there will be no sound. "
+                    "Reconfigure with -DPROSPER_AUDIO_SDL3=ON.\n");
 #endif
 #ifdef PROSPER_PAD_SDL3
     if (!getenv("PROSPER_APP_DISABLE_PAD")) {


### PR DESCRIPTION
Refs #2402. **prosper-app has no audio unless you know to ask for it, and nothing tells you.**

## The defect

`PROSPER_AUDIO_SDL3` defaults to `OFF`, so `libprosper_audio_sdl3.a` is never built and `install_sdl3_audio_sink()` is compiled out of `prosper-app` entirely (`main.cpp:921`, `#ifdef PROSPER_AUDIO_SDL3`). The app runs with **no playback device and logs nothing about it** — the existing `else` only prints when `PROSPER_APP_DISABLE_AUDIO` is explicitly set.

So a build without audio support and a build whose audio is merely quiet produce **identical output**.

Meanwhile the guest was doing everything right. GTA V publishes 99.9%-non-zero PCM (`port77`, `nonzero=81860/81920`), prosper reads it, mixes it (`reads=160 mixed=160 no-pcm=0 skip-fmt=0 short=0`), and delivers it to a sink reporting `sink=open` — **open on nothing**. Every layer reported health. That cost most of a day to run down.

## The changes

**1. `PROSPER_AUDIO_SDL3` now defaults to `${PROSPER_APP}`.** The app frontend is the one a *user* runs, and a silent one is indistinguishable from broken audio. `option()` honours an existing cache entry, so an explicit `-DPROSPER_AUDIO_SDL3=OFF` still wins — only the default changes, and only when the app is being built. `PROSPER_APP` is declared first so it can be referenced.

**2. The `#ifdef` gets an `#else`** printing `BUILT WITHOUT SDL3 AUDIO SUPPORT -- there will be no sound` unconditionally. The absence becomes visible rather than inferred.

## Verification

```
prosper-audio: SDL3 audio backend installed
prosper-audio: opened port 17 on Speakers (USB AUDIO  CODEC) (wasapi), 48000 Hz/2 channels
prosper-audio: opened port 18 on Speakers (USB AUDIO  CODEC) (wasapi), 48000 Hz/2 channels
```

Port 18 is `ctx1` — the context carrying GTA V's signal (`bed-peak=0.09869`). Real WASAPI device, 48 kHz stereo. Build clean on MinGW/UCRT.

## Risk

Low, and mostly about build time: enabling the audio frontend by default for `PROSPER_APP` builds pulls SDL3 audio into a configuration that previously skipped it. SDL3 is already fetched for `PROSPER_APP` regardless (it needs the window and Vulkan present), so this adds a compilation unit rather than a dependency.

The `#else` is unconditional output on a path that produces no sound — deliberately, since the silent case is the one that misleads.

## Note on the edit

Two earlier attempts patched the **wrong** `#ifdef` — the include-block guard at line 49, whose *comment* mentions `install_sdl3_audio_sink` — which would not have compiled. The install site is line 921 and is identified here by an actual call rather than a name match. Recording it because "grep for the symbol" found the comment first, and the resulting patch looked plausible in a diff.

## Review

Straightforward, but it is a **default-behaviour change to the user-facing frontend**, which is a project-owner call as much as a technical one. If the preference is to keep audio opt-in, change 2 alone (the loud `#else`) still fixes the diagnosability half and I would take that outcome happily.
