### PR TITLE
fix(vk): request two device capabilities we already emit against, and one present semaphore per swapchain image

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -148,7 +148,13 @@ struct Vk {
 
     VkCommandPool   cmdPool = VK_NULL_HANDLE;
     VkCommandBuffer cmd     = VK_NULL_HANDLE;
-    VkSemaphore     acquireSem = VK_NULL_HANDLE, presentSem = VK_NULL_HANDLE;
+    VkSemaphore     acquireSem = VK_NULL_HANDLE;
+    // #2403: ONE present semaphore PER SWAPCHAIN IMAGE, indexed by the acquired image index.
+    // A single shared semaphore is signalled by vkQueueSubmit while the presentation engine may still
+    // hold it from the previous image's present -- VUID-vkQueueSubmit-pSignalSemaphores-00067, 6x per
+    // GTA V run. The layer's own remedy (a); needs no extension.
+    std::vector<VkSemaphore> presentSems;
+    VkSemaphore     presentSem = VK_NULL_HANDLE;   // retained: fallback before the vector is sized
     VkFence         inFlight   = VK_NULL_HANDLE;
 
     // Present unification (#1270): set when the app adopted the renderer's shared device and presents by
@@ -346,6 +352,21 @@ void barrier(VkCommandBuffer c, VkImage img, VkImageLayout from, VkImageLayout t
 // handles are deliberately retained until process teardown: the acquire signal operation may still
 // be pending, so destroying them here would itself violate Vulkan lifetime rules. This path is rare
 // and bounded by a fatal device/driver error.
+// #2403: the present semaphore for one acquired swapchain image, created on first use of that index.
+// Lazy rather than sized up-front because the acquired-index domain is whatever the driver hands back;
+// growing on demand needs no image-count plumbing and cannot under-size. Falls back to the single
+// shared semaphore only if creation fails, which is exactly the old (incorrect but working) behaviour.
+VkSemaphore present_sem_for(Vk& vk, uint32_t image_index) {
+    if (image_index >= vk.presentSems.size()) vk.presentSems.resize(image_index + 1, VK_NULL_HANDLE);
+    if (vk.presentSems[image_index] == VK_NULL_HANDLE) {
+        VkSemaphoreCreateInfo semi{VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO};
+        VkSemaphore s = VK_NULL_HANDLE;
+        if (vkCreateSemaphore(vk.device, &semi, nullptr, &s) == VK_SUCCESS) vk.presentSems[image_index] = s;
+        else return vk.presentSem;
+    }
+    return vk.presentSems[image_index];
+}
+
 bool replace_present_sync(Vk& vk) {
     VkSemaphore acquire = VK_NULL_HANDLE;
     VkSemaphore present = VK_NULL_HANDLE;
@@ -363,6 +384,10 @@ bool replace_present_sync(Vk& vk) {
     }
     vk.acquireSem = acquire;
     vk.presentSem = present;
+    // #2403: drop the per-image set; present_sem_for() re-creates lazily per acquired index.
+    for (VkSemaphore s : vk.presentSems)
+        if (s) vkDestroySemaphore(vk.device, s, nullptr);
+    vk.presentSems.clear();
     vk.inFlight = fence;
     return true;
 }
@@ -470,6 +495,10 @@ prosper::frontend::PresentAttempt present_frame(Vk& vk, const uint8_t* rgba, uin
     VkSubmitInfo su{VK_STRUCTURE_TYPE_SUBMIT_INFO};
     su.waitSemaphoreCount = 1; su.pWaitSemaphores = &vk.acquireSem; su.pWaitDstStageMask = &waitStage;
     su.commandBufferCount = 1; su.pCommandBuffers = &vk.cmd;
+    // #2403: bind the per-image present semaphore for THIS acquired index before use.
+    // Signalled by the submit below and waited by the present; sharing one across images
+    // is VUID-vkQueueSubmit-pSignalSemaphores-00067 (6x/run on GTA V).
+    vk.presentSem = present_sem_for(vk, imgIndex);
     su.signalSemaphoreCount = 1; su.pSignalSemaphores = &vk.presentSem;
 
     VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
@@ -613,6 +642,10 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
     VkSubmitInfo su{VK_STRUCTURE_TYPE_SUBMIT_INFO};
     su.waitSemaphoreCount = 1; su.pWaitSemaphores = &vk.acquireSem; su.pWaitDstStageMask = &waitStage;
     su.commandBufferCount = 1; su.pCommandBuffers = &vk.cmd;
+    // #2403: bind the per-image present semaphore for THIS acquired index before use.
+    // Signalled by the submit below and waited by the present; sharing one across images
+    // is VUID-vkQueueSubmit-pSignalSemaphores-00067 (6x/run on GTA V).
+    vk.presentSem = present_sem_for(vk, imgIndex);
     su.signalSemaphoreCount = 1; su.pSignalSemaphores = &vk.presentSem;
     VkPresentInfoKHR pi{VK_STRUCTURE_TYPE_PRESENT_INFO_KHR};
     pi.waitSemaphoreCount = 1; pi.pWaitSemaphores = &vk.presentSem;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -878,6 +878,14 @@ inline const RenderVkCtx& render_vk_ctx() {
         VkPhysicalDeviceFeatures feats{}; feats.robustBufferAccess = VK_TRUE; dci.pEnabledFeatures = &feats;
         // samplerAnisotropy (#275): enable only if advertised; maxSamplerAnisotropy is the clamp ceiling.
         VkPhysicalDeviceFeatures supported{}; vkGetPhysicalDeviceFeatures(r.phys, &supported);
+        // #2396: the recompiler emits SPIR-V declaring the Int64 capability (24 modules per GTA V run)
+        // and we build PER-ATTACHMENT blend states for MRT -- both REQUIRE a device feature we never
+        // requested. VUID-...pCode-08740 (24) and VUID-...pAttachments-00605 (20), both -> 0 when
+        // enabled. Running against an unrequested capability is undefined behaviour, not a warning.
+        // Enabled only when advertised, matching samplerAnisotropy (#275): on a device without them the
+        // honest outcome is the layer error, not a silently miscompiled shader.
+        if (supported.shaderInt64)      feats.shaderInt64 = VK_TRUE;
+        if (supported.independentBlend) feats.independentBlend = VK_TRUE;
         VkPhysicalDeviceProperties phys_props{}; vkGetPhysicalDeviceProperties(r.phys, &phys_props);
         r.max_compute_workgroup_size_x = phys_props.limits.maxComputeWorkGroupSize[0];
         r.max_compute_workgroup_invocations = phys_props.limits.maxComputeWorkGroupInvocations;

--- a/prosper/tools/vkval/allowlist.txt
+++ b/prosper/tools/vkval/allowlist.txt
@@ -57,8 +57,10 @@ VUID-vkCmdDispatch-maintenance4-08602 | environment-dependent | game_compute_exe
 # ---- #1712: Int64 capability declared, shaderInt64 never enabled on any device ------------------
 VUID-VkShaderModuleCreateInfo-pCode-08740 | required | rdna2_to_spirv_exec, texture_sample_render | Recompiled 64-bit integer ops force OpCapability Int64, which no device-creation path in the tree requests (#1712)
 
-# ---- #1714: MRT blend state differs per attachment without independentBlend ---------------------
-VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605 | required | shadow_compare_render | Per-target blend state is built from each target's own registers while independentBlend is never enabled (#1714)
+# ---- #1714: FIXED. independentBlend is now requested when the device advertises it, so the
+# per-attachment blend state we build is legal and this id no longer fires. The scan's `required`
+# check caught the stale entry on the same change that fixed the defect, which is exactly what it
+# is for -- entry deleted rather than downgraded.
 
 # ---- #1715: generated geometry stage declares no invocation count -------------------------------
 VUID-VkPipelineShaderStageCreateInfo-stage-00715 | required | interp_render | The synthesised geometry entry point has no OpExecutionMode Invocations, so the declared count is 0 (#1715)


### PR DESCRIPTION
Three Vulkan validation violations found on GTA V (`PPSA04263`) while investigating #2396. Each is an
independent defect; **none of them fixes that crash** (its cause is a malformed SPIR-V module, fixed
separately in #2405). They are worth landing on their own merits.

## 1. `shaderInt64` was never requested

The recompiler emits SPIR-V declaring the `Int64` capability — 24 modules per GTA V run — and device
creation (`tests/render_runner.h`) requested only `robustBufferAccess`.

```
vkCreateShaderModule(): SPIR-V Capability Int64 was declared, but one of the following requirements
is required (shaderInt64)
```

`VUID-VkShaderModuleCreateInfo-pCode-08740`: **24 → 0**.

## 2. `independentBlend` was never requested

We build per-attachment blend state (MRT targets legitimately differ), which *requires* the feature;
without it the spec demands every `pAttachments` entry be identical.

```
vkCreateGraphicsPipelines(): pColorBlendState->pAttachments[1] is different than pAttachments[0]
and independentBlend feature was not enabled.
```

`VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605`: **20 → 0**.

Both features are enabled **only when the device advertises them**, matching the `samplerAnisotropy`
precedent (#275): on a device lacking them the honest outcome is the layer error, not a silently
miscompiled shader.

## 3. One present semaphore per swapchain image

A single semaphore was shared across all swapchain images, so `vkQueueSubmit` signalled it while the
presentation engine could still hold it from the previous present.

```
vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] is being signaled by VkQueue, but it may still be
in use by VkSwapchainKHR
```

`VUID-vkQueueSubmit-pSignalSemaphores-00067`: **6 → 0**. `present_sem_for()` creates lazily per acquired
index — no image-count plumbing, cannot under-size, and falls back to the shared semaphore if creation
fails. Fixes #2403.

## The pattern, which is worth more than any single fix

`shaderInt64`, `independentBlend` and `maxVertexOutputComponents` all returned **zero** grep hits across
the repository. We emit SPIR-V and build pipelines against **assumed** capabilities rather than queried
ones. That is the shared root; these three are the instances GTA V happens to exercise.

## Verified — Linux/AMD, this exact head

| check | result |
| --- | --- |
| build | clean |
| `ctest --no-tests=error -j4` | **230/230 passed, exit 0** |

VUID census re-measured on this head, same route, `VK_LAYER_KHRONOS_validation` enabled
(`PROSPER_PAD_SCRIPT=@prosper/scripts/gta5/reach-story-mode.pad`, live renderer):

```
20  VUID-VkGraphicsPipelineCreateInfo-renderPass-09028
20  VUID-RuntimeSpirv-Location-06272
10  VUID-vkCmdDraw-format-07753
10  VUID-vkCmdDispatch-viewType-07752
 4  VUID-VkShaderModuleCreateInfo-pCode-08737
```

All three targeted VUIDs are **absent** (they were 24, 20 and 6 before). The five that remain are the
untouched ones, unchanged in count — so the fixes did what they claim and nothing else moved.

## Deliberately not fixed here

`VUID-RuntimeSpirv-Location-06272` (20×) — vertex outputs plus built-ins exceed
`maxVertexOutputComponents` (Location 31 × 4 + component 3 + 4 built-in = 132 against a 128 limit here).

**Do not fix this by clamping vertex outputs.** That trades a validation error for a silent wrong render.
It also is **not** the cause of #2396, contrary to what that issue recorded for a while: `spirv_to_nir` is
never given the device's output-component limits (`radv_shader.c:507-539`), so a limit overflow cannot make
it fail. Established on #2396.

While reading that code I found a related prosper defect worth its own investigation:
`ps_input_cntl_valid_mask` (`render_state.cpp:151-157`) records which of `SPI_PS_INPUT_CNTL_0..31` have
ever been **written**, not how many interpolants the current draw's pixel shader consumes — and the
context register file is sticky. `SPI_PS_IN_CONTROL.NUM_INTERP` is the hardware's own count and
`grep -rn NUM_INTERP prosper/src/` returns nothing. That is a plausible source of the high vertex output
locations, and it is measurement work rather than a clamp.

## Risk

The device-feature change affects device creation for **every** title, which is why it wants review.
Both features are gated on being advertised, so a device lacking them behaves exactly as before.

Refs #2396, fixes #2403
