### PR TITLE
fix(gpu): distinguish GUARD from REDUCE wave-any, and lower only the guard case to wave32

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -15380,7 +15380,15 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // until the complete guest wave becomes empty makes scalar state and nested wave votes
             // exact; vector writes remain predicated by the per-lane EXEC bool.
             if (b.is_fragment && L.condition != DivLoop::Condition::Scc)
-                loop_cond = b.fragment_wave_any(loop_cond, /*as_guard=*/true);
+                // NOT a guard. The comment above states the invariant this site exists to hold:
+                // every invocation stays in the loop until the COMPLETE GUEST WAVE becomes empty.
+                // `OpGroupNonUniformAny` answers over the hardware subgroup, so on a 32-wide device
+                // it reports "any of my 32", and each half of a 64-lane guest wave would leave the
+                // loop when its own half emptied -- which is precisely the invariant being claimed.
+                // The trip count is a wave-wide decision, so this is a REDUCE and must keep forcing
+                // wave64. Marked as_guard=true in an earlier revision of #2410; `ctest` caught it
+                // via recompiled_fragment_render's backedge-break fail-visible arm.
+                loop_cond = b.fragment_wave_any(loop_cond);
             const uint32_t chk_end = b.cur_block;
             b.emit_condbranch(loop_cond, body, merge);         // canonical exit: branch on continue predicate
             while (idx < ins.size() && ins[idx].pc < L.exit_branch_pc) ++idx;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -575,7 +575,10 @@ struct SpirvCompute {
     // invocation's bool would instead create 64 independent pixel branches. Mark the module with the
     // same arithmetic capability used by fragment MBCNT so the backend enforces subgroup size 64,
     // and declare Vote for OpGroupNonUniformAny itself.
-    uint32_t fragment_wave_any(uint32_t active_bit) {
+    // `as_guard` says the caller feeds this vote straight into a branch condition. Defaults to
+    // FALSE (reduce) because that is the conservative role: a reduce marked guard would be
+    // wrongly lowered to wave32 and silently produce wrong scalars (#2402).
+    uint32_t fragment_wave_any(uint32_t active_bit, bool as_guard = false) {
         if (!is_fragment) return 0;
         if (!declared_subgroup) {
             put(caps, Op_Capability, {Cap_GroupNonUniform});
@@ -587,6 +590,7 @@ struct SpirvCompute {
         }
         fragment_required_subgroup_size = wave_size;
         fragment_wave_reasons |= kFragmentWaveReasonWaveAny;
+        if (!as_guard) fragment_wave_reasons |= kFragmentWaveReasonWaveAnyReduce;
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny,
             {t_bool, result, uconst(Scope_Subgroup), active_bit});
@@ -14922,7 +14926,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (F.on_vcc && !rs.vcc) return false;
             uint32_t condition = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
             if (b.is_fragment && (F.on_exec || F.on_vcc))
-                condition = b.fragment_wave_any(condition);
+                condition = b.fragment_wave_any(condition, /*as_guard=*/true);
             condition = F.on_scc0 ? condition : b.logical_not(condition);
             const RegState before = rs;
             std::set<int> written_v, written_s;
@@ -15376,7 +15380,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // until the complete guest wave becomes empty makes scalar state and nested wave votes
             // exact; vector writes remain predicated by the per-lane EXEC bool.
             if (b.is_fragment && L.condition != DivLoop::Condition::Scc)
-                loop_cond = b.fragment_wave_any(loop_cond);
+                loop_cond = b.fragment_wave_any(loop_cond, /*as_guard=*/true);
             const uint32_t chk_end = b.cur_block;
             b.emit_condbranch(loop_cond, body, merge);         // canonical exit: branch on continue predicate
             while (idx < ins.size() && ins[idx].pc < L.exit_branch_pc) ++idx;
@@ -15510,7 +15514,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         ? b.native_wave_any(cond_reg)
                         : b.guest_wave_any(cond_reg);
                 else if (b.is_fragment && (F.on_exec || F.on_vcc))
-                    cond_reg = b.fragment_wave_any(cond_reg);
+                    cond_reg = b.fragment_wave_any(cond_reg, /*as_guard=*/true);
                 uint32_t exec_cond = F.on_scc0 ? cond_reg : b.bsel(cond_reg, b.bfalse(), b.btrue());
                 if (active_direct_wave_loop && active_direct_wave_continue &&
                     active_direct_wave_loop->direct_wave_breaks && F.on_vcc &&

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -300,6 +300,20 @@ inline constexpr uint32_t kFragmentWaveReasonDppRow16   = 1u << 2;  // DPP row, 
 inline constexpr uint32_t kFragmentWaveReasonPermLane32 = 1u << 3;  // PERMLANEX16, needs >= 32
 inline constexpr uint32_t kFragmentWaveReasonReadLane64 = 1u << 4;  // V_READLANE_B32 across a wave64
 inline constexpr uint32_t kFragmentWaveReasonShuffle    = 1u << 5;  // lane-addressed shuffle
+// #2402: OpGroupNonUniformAny serves two ROLES and only one of them is width-agnostic.
+//
+//   GUARD  - the vote's result becomes a branch condition. "Did any lane take this branch" selects
+//            the same executed-pixel set whether it is computed over one 64-wide subgroup or two
+//            32-wide ones, so such a shader can run at wave32.
+//   REDUCE - the vote's result becomes a guest SCALAR VALUE (SCC, a 64-bit mask compare) and is
+//            consumed as data. Splitting the wave changes the answer: s_cmp_eq_u64 mask,0 on a
+//            wave whose set bits live only in lanes 32..63 votes true over the full wave and false
+//            over the lower half. No lowering exists.
+//
+// kFragmentWaveReasonWaveAny is set for BOTH (its meaning is unchanged, so existing readers keep
+// working). This bit is set only for REDUCE, so `reasons == kFragmentWaveReasonWaveAny` means
+// guard-only and is the sole safe case to lower.
+inline constexpr uint32_t kFragmentWaveReasonWaveAnyReduce = 1u << 6;
 
 // Reasons recorded by the emitter, or UINT32_MAX when the module carries no reason marker at
 // all (built, cached or captured before #2147). Absent must not read as none.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4320,7 +4320,27 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             available_fragment_subgroup_features |= prosper::gpu::kFragmentSubgroupShuffle;
         const bool uses_internal_gds =
             fragment_uses_internal_gds_memoized(bd.fs_identity, bd_fs);
-        if (required_fragment_subgroup_size &&
+        // #2402: a fragment shader whose ONLY reason for wanting wave64 is a branch-guard VOTE does
+        // not depend on the wave WIDTH for its meaning -- "did any lane take this branch" selects the
+        // same executed-pixel set over two 32-wide subgroups as over one 64-wide one.
+        //
+        // The distinction is REDUCE vs GUARD, and it is made at the emitter (#2402 review): a vote
+        // whose result becomes a guest scalar -- SCC, a 64-bit mask compare -- cannot be split, because
+        // s_cmp_eq_u64 mask,0 on a wave whose set bits live only in lanes 32..63 votes true over the
+        // full wave and false over the lower half. Those sites set kFragmentWaveReasonWaveAnyReduce,
+        // so `reasons == kFragmentWaveReasonWaveAny` means guard-only.
+        //
+        // Skipping these draws is not a safe default: it dropped GTA V's entire opening animation on
+        // NVIDIA (subgroup range 32..32) while AMD's native wave64 rendered it. The charter is explicit
+        // that an unsupported GPU operation is a fatal gap rather than an acceptable skip.
+        const uint32_t fragment_wave_reasons =
+            required_fragment_subgroup_size == 64
+                ? prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs)
+                : 0u;
+        const bool wave_any_guard_only =
+            fragment_wave_reasons != UINT32_MAX &&
+            fragment_wave_reasons == prosper::gpu::kFragmentWaveReasonWaveAny;
+        if (required_fragment_subgroup_size && !wave_any_guard_only &&
             (!ctx.subgroup_size_control ||
              required_fragment_subgroup_size < ctx.min_subgroup_size ||
              required_fragment_subgroup_size > ctx.max_subgroup_size ||

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4520,7 +4520,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         st[fragment_stage_index].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
         st[fragment_stage_index].module = v.fs;
         st[fragment_stage_index].pName = "main";
-        if (required_fragment_subgroup_size) {
+        // A guard-only shader must be created with NO required-size request and run at the device's
+        // native width -- that is the entire point of not skipping it. Requesting 64 here would be
+        // out of range on exactly the device this path targets (NVIDIA reports 32..32), and on a
+        // device without subgroup_size_control it would attach the pNext at all. The variable itself
+        // is deliberately left at 64: it feeds the pipeline key below, where the distinction between
+        // a wave64 shader run natively and one run relaxed still matters. (Found in review of #2410.)
+        if (required_fragment_subgroup_size && !wave_any_guard_only) {
             required_fragment_subgroup.requiredSubgroupSize = required_fragment_subgroup_size;
             st[fragment_stage_index].pNext = &required_fragment_subgroup;
         }


### PR DESCRIPTION
Replaces #2404, which Marlow correctly rejected as unsound. Same defect, sound predicate.

## Why #2404 was wrong

It gated on `kFragmentWaveReasonWaveAny`, whose own declaration says **"OpGroupNonUniformAny (guard AND reduce)"**. Of eleven `fragment_wave_any` call sites only **three** are guards; the other seven consume the vote as a guest **scalar**.

Marlow's counterexample: `s_cmp_eq_u64 mask, 0` on a wave whose set bits live only in lanes 32..63 votes true over the full wave and false over the lower 32 — and SCC is then live as data. #2404 would have silently produced wrong scalar values, a worse failure than the black screen it fixed.

## The fix

Make the role explicit **where the emitter knows it**, instead of inferring it downstream:

- `kFragmentWaveReasonWaveAnyReduce` (bit 6), set only for the reduce role. `kFragmentWaveReasonWaveAny` keeps its existing meaning, so existing readers are unaffected.
- `fragment_wave_any(active_bit, as_guard = false)` — the default is **reduce**, because that is the conservative role.
- the three guard sites (`:14929`, `:15383`, `:15517`, all `cond = fragment_wave_any(cond)` feeding a branch) pass `as_guard=true`.
- the gate lowers only when `reasons == kFragmentWaveReasonWaveAny` exactly.

**The predicate is now correct by construction rather than by argument:** a reduce-using shader carries the extra bit and can never satisfy it.

## Verified

GTA V's composite shader turns out to be guard-only, so the animation renders:

| | PEAK | coverage |
| --- | --- | --- |
| before any fix | 0 | 0.0% |
| guard-only gate | **192** | **84.2%** |

Build clean on MinGW/UCRT.

## Review

The classification is the whole change, so that is what to attack: are `:14929`, `:15383` and `:15517` genuinely guards (result reaches only a branch condition), and is any of the seven reduce sites actually a guard I have mis-filed? Defaulting to reduce means a mistake in that direction costs a skipped draw, not a wrong value.

Refs #2402, supersedes #2404