### PR TITLE
feat(app): --volume, defaulting to 25%

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -17,6 +17,15 @@ bool install_sdl3_audio_sink();
 // No-op when the SDL3 sink is not installed.
 void set_sdl3_audio_paused(bool paused);
 
+// Set the playback gain applied to every stream, as a linear multiplier (1.0 = unchanged).
+// Applied via SDL_SetAudioStreamGain, so no sample data is copied or clipped by prosper.
+// Takes effect immediately on open streams and is remembered for streams opened later.
+//
+// prosper-app defaults this to 0.25. Guest audio that is mixed or decoded incorrectly tends to
+// arrive at or near full scale, and full-scale wrong audio is genuinely painful to listen to
+// while iterating -- a lower default costs nothing and can be raised with --volume.
+void set_sdl3_audio_gain(float gain);
+
 // Uninstall the SDL3 sink (restores the default), closing any open streams and SDL audio.
 void shutdown_sdl3_audio_sink();
 

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -58,6 +58,7 @@ public:
         s.freq = info.freq;
         s.put_failed = false;
         s.next = {};   // (re)start the per-grain pacing clock on the first output()
+        SDL_SetAudioStreamGain(s.stream, gain_);
         const bool stream_ready = paused_ ? SDL_PauseAudioStreamDevice(s.stream)
                                           : SDL_ResumeAudioStreamDevice(s.stream);
         if (!stream_ready) {
@@ -131,6 +132,20 @@ public:
         s.frame_bytes = s.grain_bytes = 0;
     }
 
+    // Applies to open streams immediately AND is remembered for later opens, so it works
+
+    // whether it is set before or after the guest creates its ports.
+
+    void set_gain(float g) {
+
+        std::lock_guard<std::mutex> lk(mx_);
+
+        gain_ = g;
+
+        for (auto& s : slots_) if (s.stream) SDL_SetAudioStreamGain(s.stream, gain_);
+
+    }
+
     void set_paused(bool paused) {
         std::lock_guard<std::mutex> lk(mx_);
         if (paused_ == paused) return;
@@ -158,6 +173,7 @@ private:
     std::mutex mx_;
     std::array<Slot, kMaxPorts> slots_{};
     bool paused_ = false;
+    float gain_ = 1.0f;   // linear playback gain, applied via SDL_SetAudioStreamGain
 };
 
 Sdl3AudioSink g_sink;
@@ -172,6 +188,11 @@ bool install_sdl3_audio_sink() {
     g_installed = true;
     SDL_Log("prosper-audio: SDL3 audio backend installed");
     return true;
+}
+
+void set_sdl3_audio_gain(float gain) {
+    if (gain < 0.0f) gain = 0.0f;
+    g_sink.set_gain(gain);   // safe before install: the value is remembered and applied on open
 }
 
 void set_sdl3_audio_paused(bool paused) {

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -50,6 +50,12 @@
 #ifdef PROSPER_AUDIO_SDL3
 #include "audio_sdl3.hpp"              // install_sdl3_audio_sink (route sceAudioOut to the host)
 #endif
+
+// Default playback volume for prosper-app, as a percent. Deliberately low: guest audio that is
+// mixed or decoded incorrectly arrives at or near full scale, and full-scale wrong audio is
+// genuinely painful while iterating on a title. Raise it with --volume.
+static constexpr int kDefaultVolumePercent = 25;
+static int g_volume_percent = kDefaultVolumePercent;   // set by --volume before backends install
 #ifdef PROSPER_AUDIO_FFMPEG
 #include "ajm_ffmpeg.hpp"              // install AJM MP3 decoder before guest instance creation
 #endif
@@ -921,6 +927,9 @@ static void install_host_backends() {
 #ifdef PROSPER_AUDIO_SDL3
     if (!getenv("PROSPER_APP_DISABLE_AUDIO")) {
         prosper::install_sdl3_audio_sink();
+        prosper::set_sdl3_audio_gain(g_volume_percent / 100.0f);
+        fprintf(stderr, "[app] audio volume %d%%%s\n", g_volume_percent,
+                g_volume_percent == kDefaultVolumePercent ? " (default; --volume N to change)" : "");
     } else {
         fprintf(stderr, "[app] SDL audio backend disabled; using the realtime silent sink.\n");
     }
@@ -1106,7 +1115,9 @@ int main(int argc, char** argv) {
     // Whether to offer the host folder picker at startup (#1469); resolved by should_pick_at_startup.
     prosper::frontend::StartupPickInputs pick{};
     pick.bare_launch = (argc <= 1);
-    for (int i = 1; i < argc; i++) {
+        // Playback volume as a percent, applied to the SDL3 audio sink. 25 by default -- see
+    // --volume below and audio_sdl3.hpp for why a low default is deliberate.
+for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         if (a == "--test-pattern") testPattern = true;
         else if (a == "--frames" && i + 1 < argc) exitAfter = atoi(argv[++i]);   // present N frames then exit (CI/smoke)
@@ -1114,6 +1125,14 @@ int main(int argc, char** argv) {
         // relaunch_with_dump() depends on that: it appends "--dump <new title>" to this run's own
         // arguments and needs the appended one to override whatever selected the current game.
         else if (a == "--dump" && i + 1 < argc) dump = argv[++i];                // boot the game at this app0 dir
+        else if (a == "--volume" && i + 1 < argc) {
+            // Percent, 0-100. Defaults to 25 (see kDefaultVolumePercent): guest audio that is
+            // mixed or decoded wrongly arrives near full scale, and full-scale wrong audio is
+            // painful while iterating. Clamped rather than rejected so a typo cannot deafen.
+            g_volume_percent = atoi(argv[++i]);
+            if (g_volume_percent < 0) g_volume_percent = 0;
+            if (g_volume_percent > 100) g_volume_percent = 100;
+        }
         else if (a == "--pick") pick.forced = true;         // open the folder picker at startup
         else if (a == "--no-pick") pick.suppressed = true;  // never open it (scripts, CI, kiosk runs)
         else if (a == "--games-dir") {                       // where the titles are, this run only


### PR DESCRIPTION
Guest audio that is mixed or decoded incorrectly arrives at or near full scale, and full-scale wrong audio is genuinely painful while iterating on a title. A low default costs nothing; the flag raises it when the audio is worth hearing properly.

```
prosper-app --dump <title>              -> [app] audio volume 25% (default; --volume N to change)
prosper-app --dump <title> --volume 60  -> [app] audio volume 60%
```

## Implementation notes

**`SDL_SetAudioStreamGain`, not sample scaling** — no buffer copy, no per-format handling for F32 vs S16, and no clipping introduced by prosper.

**Applied to open streams *and* remembered for later ones.** That matters here: the app installs the sink during startup while the guest opens its ports much later, so a set-once-on-open implementation would silently do nothing.

**Clamped to 0..100 rather than rejected**, so a typo cannot produce a deafening multiplier. The startup line always prints the value and marks the default — an unexpected volume should be visible rather than something you go looking for.

## Verified

GTA V (`PPSA04263`), native Windows: default prints 25% and opens both WASAPI ports at 48 kHz stereo; `--volume 60` prints 60%. Build clean on MinGW/UCRT.

## Note

prosper-app has audio at all only when built with `-DPROSPER_AUDIO_SDL3=ON`; that default is addressed separately in #2407.