### PR TITLE
fix(app): correct the --volume defects, and make the default unity

### DIFF
--- a/prosper/frontends/audio_sdl3/audio_sdl3.hpp
+++ b/prosper/frontends/audio_sdl3/audio_sdl3.hpp
@@ -21,9 +21,9 @@ void set_sdl3_audio_paused(bool paused);
 // Applied via SDL_SetAudioStreamGain, so no sample data is copied or clipped by prosper.
 // Takes effect immediately on open streams and is remembered for streams opened later.
 //
-// prosper-app defaults this to 0.25. Guest audio that is mixed or decoded incorrectly tends to
-// arrive at or near full scale, and full-scale wrong audio is genuinely painful to listen to
-// while iterating -- a lower default costs nothing and can be raised with --volume.
+// prosper-app defaults this to 1.0 -- the title's own mix, unedited, which is the only output a
+// compatibility layer can call correct. Attenuate a bring-up run with `--volume N` rather than
+// changing the default; see kDefaultVolumePercent in prosper-app/main.cpp.
 void set_sdl3_audio_gain(float gain);
 
 // Uninstall the SDL3 sink (restores the default), closing any open streams and SDL audio.

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -137,13 +137,9 @@ public:
     // whether it is set before or after the guest creates its ports.
 
     void set_gain(float g) {
-
         std::lock_guard<std::mutex> lk(mx_);
-
         gain_ = g;
-
         for (auto& s : slots_) if (s.stream) SDL_SetAudioStreamGain(s.stream, gain_);
-
     }
 
     void set_paused(bool paused) {

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -51,10 +51,15 @@
 #include "audio_sdl3.hpp"              // install_sdl3_audio_sink (route sceAudioOut to the host)
 #endif
 
-// Default playback volume for prosper-app, as a percent. Deliberately low: guest audio that is
-// mixed or decoded incorrectly arrives at or near full scale, and full-scale wrong audio is
-// genuinely painful while iterating on a title. Raise it with --volume.
-static constexpr int kDefaultVolumePercent = 25;
+// Default playback volume for prosper-app, as a percent.
+//
+// UNITY, deliberately. prosper is a compatibility layer, so the title's own mix is the correct
+// output and anything else is us editing it. This shipped as 25 in #2411 -- a bring-up default that
+// made distorted audio bearable while iterating -- and that reasoning does not survive contact with
+// a release: the AppImage and the tarball carry this value, and a user who finds prosper quieter
+// than their console has no way to know we chose that for them. Attenuation during bring-up belongs
+// on the command line (`--volume 25`), not in the default every user inherits.
+static constexpr int kDefaultVolumePercent = 100;
 static int g_volume_percent = kDefaultVolumePercent;   // set by --volume before backends install
 #ifdef PROSPER_AUDIO_FFMPEG
 #include "ajm_ffmpeg.hpp"              // install AJM MP3 decoder before guest instance creation
@@ -1155,9 +1160,7 @@ int main(int argc, char** argv) {
     // Whether to offer the host folder picker at startup (#1469); resolved by should_pick_at_startup.
     prosper::frontend::StartupPickInputs pick{};
     pick.bare_launch = (argc <= 1);
-        // Playback volume as a percent, applied to the SDL3 audio sink. 25 by default -- see
-    // --volume below and audio_sdl3.hpp for why a low default is deliberate.
-for (int i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         if (a == "--test-pattern") testPattern = true;
         else if (a == "--frames" && i + 1 < argc) exitAfter = atoi(argv[++i]);   // present N frames then exit (CI/smoke)
@@ -1166,9 +1169,7 @@ for (int i = 1; i < argc; i++) {
         // arguments and needs the appended one to override whatever selected the current game.
         else if (a == "--dump" && i + 1 < argc) dump = argv[++i];                // boot the game at this app0 dir
         else if (a == "--volume" && i + 1 < argc) {
-            // Percent, 0-100. Defaults to 25 (see kDefaultVolumePercent): guest audio that is
-            // mixed or decoded wrongly arrives near full scale, and full-scale wrong audio is
-            // painful while iterating. Clamped rather than rejected so a typo cannot deafen.
+            // Percent, 0-100. Clamped rather than rejected so a typo cannot deafen.
             g_volume_percent = atoi(argv[++i]);
             if (g_volume_percent < 0) g_volume_percent = 0;
             if (g_volume_percent > 100) g_volume_percent = 100;


### PR DESCRIPTION
Marlow's review of #2411 landed 10 minutes after that PR merged. Three findings; this addresses all three on master.

**Two editing accidents.** A comment fragment left mid-statement in `main.cpp` between `pick.bare_launch` and the argument loop, with `for (int i = 1; i < argc; i++)` un-indented to column zero; and `set_gain` in `audio_sink_sdl3.cpp` carrying a blank line between every line, eleven for what is four.

**One that is not cosmetic, and the reviewer was right.** The default volume was 25%, and the rationale in the comment was a developer's: full-scale wrong audio is painful while iterating on a title. That is true, and it is a *bring-up* cost. It does not survive contact with a release -- this value ships in the AppImage and the tarball, so every user inherits an attenuation chosen for a debugging convenience, and a user who finds prosper quieter than their console has no way to attribute it to us.

prosper is a compatibility layer, so the title's own mix is the correct output and anything else is us editing content we were asked to reproduce. **Default is now 100%**; attenuate a bring-up run with `--volume 25`, which is what the flag exists for.

The stale `// prosper-app defaults this to 0.25` contract note in `audio_sdl3.hpp` is corrected in the same change, so the header does not keep asserting a value the code no longer uses.

## Verification

- `cmake --build prosper/build-app -j6 --target prosper-app` -- exit 0, links clean.
- `git diff --check` -- clean.
- Clamping, gain-before-install safety and the `SDL_SetAudioStreamGain` path are unchanged; this PR touches the default value, one comment block, and whitespace only.

Refs #2411.