### PR TITLE
diag(recompiler): separate "no lowering exists" from "the lowering could not resolve an operand"

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1085,12 +1085,42 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 // here, and the guard correctly drops it — but the log then looks identical to a
                 // genuinely absent resource. Printing the words separates "not a descriptor" from
                 // "a descriptor we mis-decoded", which need opposite fixes.
-                if (getenv("PROSPER_SHARPLOG"))
+                if (getenv("PROSPER_SHARPLOG")) {
+                    // Which of the two candidate BASE readings is actually mapped guest memory. A V#
+                    // stores base at bit 0 (Base48); the Gen5 256-byte-unit form used by
+                    // decode_bvh_descriptor just below stores it shifted, `base_256 << 8`. If the
+                    // shifted reading is mapped and the direct one is not, this slot is not a V# and
+                    // no adjustment to the plausibility guard can make it one.
+                    const uint64_t shifted =
+                        (((uint64_t)user_sgprs[reg] |
+                          ((uint64_t)(user_sgprs[reg + 1] & 0xFFu) << 32)) << 8);
+                    // THE decisive test for "this slot is a POINTER, not an inline descriptor".
+                    // If d.base is mapped and the 16 bytes AT d.base decode as a sane V#, then the
+                    // four SGPR dwords are a pointer pair and reading them as a descriptor is the
+                    // defect. Printing the dereferenced decode makes that a measurement rather than
+                    // an inference (#2412).
+                    if (d.base && guest_readable(d.base, 16)) {
+                        const uint32_t* at = reinterpret_cast<const uint32_t*>(
+                            static_cast<uintptr_t>(d.base));
+                        const DecodedBufferDescriptor deref = decode_buffer_descriptor(at);
+                        fprintf(stderr,
+                                "[direct-deref] type=%u sgpr=%u at=0x%llx words=%08x:%08x:%08x:%08x "
+                                "-> base=0x%llx rd=%d size=%llu stride=%u fmt=%u comps=%u\n",
+                                type, reg, (unsigned long long)d.base, at[0], at[1], at[2], at[3],
+                                (unsigned long long)deref.base,
+                                deref.base ? (int)guest_readable(deref.base, 16) : -1,
+                                (unsigned long long)deref.size_bytes, deref.stride,
+                                static_cast<unsigned>(deref.format), deref.num_components);
+                    }
                     fprintf(stderr,
                             "[direct-reject] type=%u sgpr=%u words=%08x:%08x:%08x:%08x "
-                            "base=0x%llx size=%llu stride=%u fmt=%u comps=%u why=%s%s%s%s%s\n",
+                            "base=0x%llx rd=%d | shifted=0x%llx rd=%d | "
+                            "size=%llu stride=%u fmt=%u comps=%u why=%s%s%s%s%s\n",
                             type, reg, user_sgprs[reg], user_sgprs[reg + 1], user_sgprs[reg + 2],
                             user_sgprs[reg + 3], (unsigned long long)d.base,
+                            d.base ? (int)guest_readable(d.base, 16) : -1,
+                            (unsigned long long)shifted,
+                            shifted ? (int)guest_readable(shifted, 16) : -1,
                             (unsigned long long)d.size_bytes, d.stride,
                             static_cast<unsigned>(d.format), d.num_components,
                             d.base == 0 ? "base0 " : "",
@@ -1098,6 +1128,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                             d.size_bytes > 0x10000000u ? "size>256M " : "",
                             d.format == DataFormat::Unknown ? "fmt-unknown " : "",
                             !d.num_components ? "comps0" : "");
+                }
                 continue;
             }
             ShaderResource r;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1079,7 +1079,27 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
             // pointer/data dwords decode with FORMAT=0. Dynamic descriptors whose format is patched by
             // shader ALU are recovered by resolve_dynamic_fetch instead of this metadata-only path.
             if (d.base == 0 || d.size_bytes == 0 || d.size_bytes > 0x10000000u ||
-                d.format == DataFormat::Unknown || !d.num_components) continue;
+                d.format == DataFormat::Unknown || !d.num_components) {
+                // #2412: name WHICH clause rejected, and show the raw dwords. A direct slot that is
+                // really a 64-bit POINTER to an in-memory descriptor table decodes as a nonsense V#
+                // here, and the guard correctly drops it — but the log then looks identical to a
+                // genuinely absent resource. Printing the words separates "not a descriptor" from
+                // "a descriptor we mis-decoded", which need opposite fixes.
+                if (getenv("PROSPER_SHARPLOG"))
+                    fprintf(stderr,
+                            "[direct-reject] type=%u sgpr=%u words=%08x:%08x:%08x:%08x "
+                            "base=0x%llx size=%llu stride=%u fmt=%u comps=%u why=%s%s%s%s%s\n",
+                            type, reg, user_sgprs[reg], user_sgprs[reg + 1], user_sgprs[reg + 2],
+                            user_sgprs[reg + 3], (unsigned long long)d.base,
+                            (unsigned long long)d.size_bytes, d.stride,
+                            static_cast<unsigned>(d.format), d.num_components,
+                            d.base == 0 ? "base0 " : "",
+                            d.size_bytes == 0 ? "size0 " : "",
+                            d.size_bytes > 0x10000000u ? "size>256M " : "",
+                            d.format == DataFormat::Unknown ? "fmt-unknown " : "",
+                            !d.num_components ? "comps0" : "");
+                continue;
+            }
             ShaderResource r;
             r.cls            = compute_buffer ? ResourceClass::ConstantBuffer : ResourceClass::VertexBuffer;
             r.format         = d.format;

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -1131,6 +1131,15 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                 }
                 continue;
             }
+            // #2412: the INLINE direct reading succeeding. Counting these across titles answers
+            // whether the inline interpretation is load-bearing anywhere, which is the gate on any
+            // change to this path: if type 8/10 never resolve inline on any title, the inline reading
+            // for those types is dead and can be replaced; if they do, it cannot.
+            if (getenv("PROSPER_SHARPLOG"))
+                fprintf(stderr,
+                        "[direct-accept] type=%u sgpr=%u base=0x%llx size=%llu stride=%u fmt=%u\n",
+                        type, reg, (unsigned long long)d.base, (unsigned long long)d.size_bytes,
+                        d.stride, static_cast<unsigned>(d.format));
             ShaderResource r;
             r.cls            = compute_buffer ? ResourceClass::ConstantBuffer : ResourceClass::VertexBuffer;
             r.format         = d.format;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5323,6 +5323,41 @@ std::vector<ComputeItem> realize_compute_dispatches(
             if (logged.insert(code_addr).second) {
                 std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
                              (unsigned long long)code_addr);
+                // #2412: print the table this program was offered, next to the keys the shader looks
+                // up by. Every one of GTA V's 951 recompiler rejects is `mode=unresolved-operand`
+                // (#2416) — the lowering exists and the descriptor does not resolve — so the useful
+                // question is no longer "which instruction" but "which KEY missed". The recompiler
+                // matches a resource three ways: by fetch pc, by SRT offset, and by SGPR base; a
+                // resource carrying `srt=0xffffffff sgpr=0xffffffff` can be matched by none of them
+                // and is invisible to every lookup, however correct its address and size are.
+                if (std::getenv("PROSPER_DBG")) {
+                    if (!item.resources || item.resources->resources.empty()) {
+                        std::fprintf(stderr,
+                                     "[compute-table] program 0x%llx has NO resources at all\n",
+                                     (unsigned long long)code_addr);
+                    } else {
+                        size_t keyless = 0;
+                        for (const auto& r : item.resources->resources) {
+                            const bool no_key = r.srt_offset == 0xffffffffu &&
+                                                r.sgpr_base == 0xffffffffu &&
+                                                r.fetch_pc == 0xffffffffu;
+                            keyless += no_key ? 1 : 0;
+                            std::fprintf(stderr,
+                                         "[compute-table] program 0x%llx binding=%u class=%u "
+                                         "addr=0x%llx size=%llu stride=%u srt=0x%x sgpr=%u pc=%u%s\n",
+                                         (unsigned long long)code_addr, r.binding,
+                                         static_cast<unsigned>(r.cls),
+                                         (unsigned long long)r.gpu_addr,
+                                         (unsigned long long)r.size, r.stride, r.srt_offset,
+                                         r.sgpr_base, r.fetch_pc, no_key ? "  <-- UNMATCHABLE" : "");
+                        }
+                        std::fprintf(stderr,
+                                     "[compute-table] program 0x%llx: %zu resource(s), %zu with no "
+                                     "lookup key\n",
+                                     (unsigned long long)code_addr,
+                                     item.resources->resources.size(), keyless);
+                    }
+                }
                 // PROSPER_SHADER_DUMP=<dir>: write the failed COMPUTE program's raw bytes for offline
                 // shader_inspect, mirroring the graphics VS/PS dump (gpu_execute.hpp). The graphics
                 // path was the only dumper, so a failing dispatch's CFG could not be mapped offline.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2759,6 +2759,55 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         have_pending_srt_use = true;
                     }
                 }
+                // RAW-POINTER scalar load (#2412). `s_load_dword`/`x2` (op < 8) take SBASE as a plain
+                // 64-bit pointer rather than a V#, and no use was recorded for them at all — the
+                // branch above is gated on `is_buffer`. GTA V's compute shaders read their constants
+                // exactly this way: `user_sgprs=6` holding three pointers and no descriptor anywhere,
+                // so `by_sgpr_base_cls(..., ConstantBuffer)` has nothing to find, the load rejects as
+                // `unresolved-cbuf`, and the whole program is skipped.
+                //
+                // The fold already proves what is needed: both SBASE dwords are const-folded, so the
+                // pointer is exact and wave-uniform, and the commit below measures the exact accessed
+                // span into `required_size`. Publish a key-less ConstantBuffer use keyed by the
+                // consuming pc — the same per-instruction provenance direct MIMG/MUBUF discovery uses,
+                // and the key the recompiler's SMEM path already tries FIRST (`by_fetch_pc(in.pc)`).
+                //
+                // `v4` carries only the pointer; words 2/3 stay zero so `decode_buffer_descriptor`
+                // yields size 0 and the consumer takes its documented `required_size` path, which is
+                // gated on exactly this key-less shape (`u.key != 0xFFFFFFFFu -> continue`).
+                //
+                // Deliberately USE-DRIVEN: it fires only for a scalar load the shader actually
+                // performs, never for a slot that merely parses. A declaration-driven version of this
+                // idea was tried in build_shader_resources and regressed the frame (#2412) precisely
+                // because it lacked that condition.
+                // SINGLE-DWORD loads only. `s_load_dword` reads one scalar of DATA; every wider form
+                // is a pointer or descriptor fetch whose result the fold already tracks as V#/T#/BVH
+                // provenance, and publishing a ConstantBuffer for those shadows the uses those paths
+                // exist to produce. `dynfetch_fold` establishes the bound empirically: at `n <= 2` its
+                // three BVH-root cases fail (a BVH root is a two-dword pointer load), and at `n <= 16`
+                // six cases fail including the x16 T#/S# publications. This is the widest form that
+                // is unambiguously data.
+                if (srt_uses && !is_buffer && n == 1 &&
+                    valid_reg(sbase) && valid_reg(sbase + 1) &&
+                    val_known.test((size_t)sbase) && val_known.test((size_t)(sbase + 1))) {
+                    const uint64_t ptr = (uint64_t)val[(size_t)sbase] |
+                                         ((uint64_t)val[(size_t)(sbase + 1)] << 32);
+                    if (ptr > 0x10000) {   // matches the consumer's own null/low-pointer guard
+                        pending_srt_use = SrtUse{};
+                        pending_srt_use.kind = 1;
+                        pending_srt_use.key = 0xFFFFFFFFu;         // no SRT tag: resolved by use_pc
+                        pending_srt_use.v4[0] = (uint32_t)(ptr & 0xFFFFFFFFu);
+                        pending_srt_use.v4[1] = (uint32_t)(ptr >> 32);
+                        pending_srt_use.v4[2] = 0;                 // size comes from required_size
+                        pending_srt_use.v4[3] = 0;
+                        pending_srt_use.use_pc = in.pc;
+                        have_pending_srt_use = true;
+                        if (trc)
+                            fprintf(stderr,
+                                    "[dyntrace] rawptr-use pc=%u sbase=s%d ptr=0x%llx imm=0x%x\n",
+                                    in.pc, sbase, (unsigned long long)ptr, in.literal);
+                    }
+                }
                 for (uint32_t k = 0; k < n; k++)
                     if (valid_reg(sdst + (int)k)) reloaded.set((size_t)(sdst + (int)k));
                 uint64_t base = 0; bool base_ok;
@@ -3651,12 +3700,29 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 if (r0.srt_offset == u.key) { clash = true; break; }
 
         const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
-        if (d.base <= 0x10000 || d.size_bytes == 0 || d.size_bytes > 0x10000000u) continue;
+        if (d.base <= 0x10000 || d.size_bytes > 0x10000000u) continue;
+        // A scalar consumer whose base is a RAW POINTER has no bounded V# size to report, so
+        // `size_bytes == 0` here means "unbounded", not "empty" (#2412). The graphics builder already
+        // makes exactly this distinction and documents it — *"Scalar SMEM only needs V#.Base plus the
+        // consuming load's exact byte span"* — and caps the pc-keyed upload to the measured access.
+        // Compute dropped the use instead, which is why GTA V's compute programs, whose entire user
+        // data is pointers, resolved nothing. Mirror the graphics rule rather than inventing a second
+        // one: key-less only, a real measured span, and the same 1 MiB ceiling.
+        uint32_t scalar_size = d.size_bytes;
+        uint32_t scalar_stride = d.stride;
+        if (scalar_size == 0) {
+            if (u.key != 0xFFFFFFFFu || u.required_size == 0 || u.required_size > (1u << 20))
+                continue;
+            scalar_size = u.required_size;
+            scalar_stride = 0;
+        } else if (scalar_size < u.required_size) {
+            scalar_size = u.required_size;
+        }
         if (clash && !exact_mtbuf) {
             bool piggybacked = false;
             for (auto& r0 : table.resources) {
                 if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
-                    r0.size != d.size_bytes)
+                    r0.size != scalar_size)
                     continue;
                 if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
                 piggybacked = r0.fetch_pc == u.use_pc;
@@ -3669,13 +3735,20 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         if (u.instruction_format != UINT32_MAX) {
             rdna2_buffer_format(u.instruction_format, &r.format, &r.num_components);
             if (r.format == DataFormat::Unknown || r.num_components == 0) continue;
-        } else {
+        } else if (d.format != DataFormat::Unknown) {
             r.format = d.format;
             r.num_components = d.num_components ? d.num_components : 1;
+        } else {
+            // A raw-pointer scalar consumer carries no format bits — its V# words 2 and 3 are zero
+            // because there is no descriptor, only an address. The access is a run of dwords, which
+            // is exactly what the scalar path reads, so describe it as such rather than propagating
+            // Unknown into a resource the renderer would then have to guess about (#2412).
+            r.format = DataFormat::Uint32;
+            r.num_components = 1;
         }
         r.gpu_addr = d.base;
-        r.size = d.size_bytes;
-        r.stride = d.stride;
+        r.size = scalar_size;
+        r.stride = scalar_stride;
         r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
         r.fetch_pc = u.use_pc;
         table.resources.push_back(r);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2025,6 +2025,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     // mistaken for an instruction. (The two earlier scanning loops in this function build branch edges
     // and mutate no fold state.)
     uint32_t watch_pc = 0xffffffffu;   // 0xffffffff = pre-loop seeding, not an instruction
+    // Raw words of the instruction being folded, so a FORGOTTEN line can be decoded directly with
+    // `llvm-mc -disassemble` instead of matched back to a dumped shader by pc -- pcs are
+    // program-local and several of this title's shaders share a prologue, which makes that match
+    // unreliable (#2412).
+    uint32_t watch_w0 = 0, watch_w1 = 0; uint32_t watch_len = 0;
     const int watch_sgpr = [] {
         const char* w = std::getenv("PROSPER_DYNTRACE_SGPR");
         return w ? (int)strtol(w, nullptr, 0) : -1;
@@ -2043,7 +2048,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     };
     auto forget = [&](int r) {
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] pc=%u s%d <- FORGOTTEN\n", watch_pc, r);
+            fprintf(stderr, "[sgprwatch] pc=%u s%d <- FORGOTTEN words=%08x:%08x len=%u\n",
+                    watch_pc, r, watch_w0, watch_w1, watch_len);
         if (valid_reg(r)) {
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
@@ -2330,6 +2336,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
 
     for (const auto& in : ins) {
         watch_pc = in.pc;
+        watch_w0 = in.words[0]; watch_w1 = in.len_dwords > 1 ? in.words[1] : 0u;
+        watch_len = in.len_dwords;
         if (in.is_end) break;
         // #2132. RESTORE FIRST, THEN SAVE — the order is load-bearing and getting it wrong
         // reproduces the very defect this rule exists to fix (#2202 review, B3). One instruction can

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2014,7 +2014,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     // The SPI loads the user-data block starting at shader SGPR `user_sgpr_base` (s0..s7 are NGG system
     // SGPRs). So user-data block index k lands in shader SGPR (user_sgpr_base + k).
     auto valid_reg = [](int r) { return r >= 0 && r < (int)kFoldSgprs; };
+    // PROSPER_DYNTRACE_SGPR=<n>: report every fold-visible transition of one scalar register. The
+    // existing traces cover SMEM/MIMG/MUBUF/BVH and deliberately not scalar ALU, so a register the fold
+    // ends up not knowing is invisible in them by construction -- which is #2412's remaining question
+    // ("what makes the fold lose the descriptor-table pointer") and nothing in the log could answer it.
+    //
+    // DELIBERATELY PRINTS NO pc. set_value/forget are reached from THREE separate instruction loops in
+    // this function, so a "current pc" captured in one of them is stale in the others: an early version
+    // of this line carried a pc and attributed s60's loss to VOP2 instructions writing VGPRs, which
+    // cannot forget a scalar register at all. The transitions and values below are exact; attributing
+    // them to an instruction needs a pc threaded through every caller, not one loop's variable.
+    const int watch_sgpr = [] {
+        const char* w = std::getenv("PROSPER_DYNTRACE_SGPR");
+        return w ? (int)strtol(w, nullptr, 0) : -1;
+    }();
     auto set_value = [&](int r, uint32_t v) {
+        if (r == watch_sgpr)
+            fprintf(stderr, "[sgprwatch] s%d <- KNOWN 0x%08x\n", r, v);
         if (valid_reg(r)) {
             val[(size_t)r] = v;
             val_known.set((size_t)r);
@@ -2025,6 +2041,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         }
     };
     auto forget = [&](int r) {
+        if (r == watch_sgpr)
+            fprintf(stderr, "[sgprwatch] s%d <- FORGOTTEN\n", r);
         if (valid_reg(r)) {
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2811,9 +2811,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 for (uint32_t k = 0; k < n; k++)
                     if (valid_reg(sdst + (int)k)) reloaded.set((size_t)(sdst + (int)k));
                 uint64_t base = 0; bool base_ok;
-                if (is_buffer) { uint32_t b0, b1; base_ok = known(sbase, b0) && known(sbase + 1, b1);
+                // `known()` leaves its out-param UNTOUCHED when it returns false, and both halves are
+                // composed into `base` regardless of `base_ok` — so an unknown SBASE used to read
+                // uninitialized stack and print it. That is undefined behaviour, and it produced a
+                // diagnostic that actively lied: a half-unknown pointer rendered as a plausible guest
+                // VA, because stale stack here is full of real addresses whose high dword is 0x20.
+                // It cost a session's worth of chasing a table pointer that was never known (#2412).
+                // Zero-initialise so an unknown half reads as an obvious 0 rather than as evidence.
+                if (is_buffer) { uint32_t b0 = 0, b1 = 0; base_ok = known(sbase, b0) && known(sbase + 1, b1);
                                  base = ((uint64_t)b0 | ((uint64_t)b1 << 32)) & 0xFFFFFFFFFFFFull; }   // V#.Base48
-                else { uint32_t p0, p1; base_ok = known(sbase, p0) && known(sbase + 1, p1);
+                else { uint32_t p0 = 0, p1 = 0; base_ok = known(sbase, p0) && known(sbase + 1, p1);
                        base = (uint64_t)p0 | ((uint64_t)p1 << 32); }        // raw pointer
                 if (trc) fprintf(stderr, "[dyntrace] SMEM op=0x%x %s sdst=s%d sbase=s%d base=0x%llx base_ok=%d "
                                  "soff_field=%u soff_val=0x%x soff_ok=%d imm=0x%x n=%u\n", in.opcode,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2019,18 +2019,19 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     // ends up not knowing is invisible in them by construction -- which is #2412's remaining question
     // ("what makes the fold lose the descriptor-table pointer") and nothing in the log could answer it.
     //
-    // DELIBERATELY PRINTS NO pc. set_value/forget are reached from THREE separate instruction loops in
-    // this function, so a "current pc" captured in one of them is stale in the others: an early version
-    // of this line carried a pc and attributed s60's loss to VOP2 instructions writing VGPRs, which
-    // cannot forget a scalar register at all. The transitions and values below are exact; attributing
-    // them to an instruction needs a pc threaded through every caller, not one loop's variable.
+    // The pc is trustworthy, and that was checked rather than assumed. Every set_value/forget call that
+    // can fire during the walk is inside the ONE instruction loop below; the only calls outside it are
+    // the pre-loop seeding of system/user SGPRs, which report the sentinel 0xffffffff and so cannot be
+    // mistaken for an instruction. (The two earlier scanning loops in this function build branch edges
+    // and mutate no fold state.)
+    uint32_t watch_pc = 0xffffffffu;   // 0xffffffff = pre-loop seeding, not an instruction
     const int watch_sgpr = [] {
         const char* w = std::getenv("PROSPER_DYNTRACE_SGPR");
         return w ? (int)strtol(w, nullptr, 0) : -1;
     }();
     auto set_value = [&](int r, uint32_t v) {
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] s%d <- KNOWN 0x%08x\n", r, v);
+            fprintf(stderr, "[sgprwatch] pc=%u s%d <- KNOWN 0x%08x\n", watch_pc, r, v);
         if (valid_reg(r)) {
             val[(size_t)r] = v;
             val_known.set((size_t)r);
@@ -2042,7 +2043,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     };
     auto forget = [&](int r) {
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] s%d <- FORGOTTEN\n", r);
+            fprintf(stderr, "[sgprwatch] pc=%u s%d <- FORGOTTEN\n", watch_pc, r);
         if (valid_reg(r)) {
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
@@ -2328,6 +2329,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     };
 
     for (const auto& in : ins) {
+        watch_pc = in.pc;
         if (in.is_end) break;
         // #2132. RESTORE FIRST, THEN SAVE — the order is load-bearing and getting it wrong
         // reproduces the very defect this rule exists to fix (#2202 review, B3). One instruction can

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3251,6 +3251,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         current_known &= known(srsrc + k, current[(size_t)k]);
                     const bool loaded_provenance = valid_reg(srsrc) &&
                                                    descr_known.test((size_t)srsrc);
+                    // #2412: WHY a MUBUF publishes no descriptor use. A use is created only when the
+                    // fold knows all four SRSRC words; ~1.8% of sites fail that, and those are exactly
+                    // the instructions whose shaders then reject. This names which word was unknown, so
+                    // the causes can be enumerated per shader instead of guessed one at a time -- one
+                    // cause (VCC consumed as scalar data) was traced and fixed for 27 draws, so there
+                    // are demonstrably others.
+                    if (!current_known && std::getenv("PROSPER_MUBUF_UNKNOWN_LOG")) {
+                        int unknown_word = -1;
+                        for (int k = 0; k < 4 && unknown_word < 0; ++k) {
+                            uint32_t probe = 0;
+                            if (!known(srsrc + k, probe)) unknown_word = k;
+                        }
+                        fprintf(stderr,
+                                "[mubuf-unknown] pc=%u op=0x%x srsrc=s%d unknown_word=%d "
+                                "loaded_provenance=%d\n",
+                                in.pc, in.opcode, srsrc, unknown_word, (int)loaded_provenance);
+                    }
                     if (current_known) {
                         // MUBUF/MTBUF itself is definitive that its four SRSRC words are a V#. Publish
                         // the values LIVE at the consumer whenever the scalar fold knows all of them.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5416,8 +5416,9 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                                 r.fetch_pc == 0xffffffffu;
                             keyless += no_key ? 1 : 0;
                             std::fprintf(stderr,
-                                         "[compute-table] program 0x%llx binding=%u class=%u "
+                                         "[compute-table] rt=%p program 0x%llx binding=%u class=%u "
                                          "addr=0x%llx size=%llu stride=%u srt=0x%x sgpr=%u pc=%u%s\n",
+                                         (const void*)item.resources.get(),
                                          (unsigned long long)code_addr, r.binding,
                                          static_cast<unsigned>(r.cls),
                                          (unsigned long long)r.gpu_addr,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -592,6 +592,34 @@ struct SpirvCompute {
             {t_bool, result, uconst(Scope_Subgroup), active_bit});
         return result;
     }
+    // Fragment-side ballot (#2412). Same exactness argument as native_wave_ballot_half, but the
+    // fragment stage establishes its exact-wave contract differently: it does not carry
+    // native_subgroup_size, it DECLARES the width it needs via fragment_required_subgroup_size, which
+    // the backend then enforces (or skips the draw). Mirrors fragment_wave_any, which exists for the
+    // reduction form of the same problem.
+    //
+    // This is a REDUCE in #2410's taxonomy -- the bits become guest scalar DATA -- so the wave64
+    // requirement it records must NOT be relaxed to a narrower subgroup: half a mask reported as whole
+    // is silent wrong data.
+    uint32_t fragment_wave_ballot_half(uint32_t mask_bit, uint32_t half) {
+        if (!is_fragment || !mask_bit) return 0;
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!declared_subgroup_ballot) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformBallot});
+            declared_subgroup_ballot = true;
+        }
+        fragment_required_subgroup_size = wave_size;
+        fragment_wave_reasons |= kFragmentWaveReasonWaveAny;
+        const uint32_t ballot = id();
+        put(code, Op_GroupNonUniformBallot,
+            {t_v4u(), ballot, uconst(Scope_Subgroup), mask_bit});
+        const uint32_t result = id();
+        putv(code, Op_CompositeExtract, {t_u32, result, ballot, half});
+        return result;
+    }
     uint32_t subgroup_id() {
         if (!declared_subgroup) {
             put(caps, Op_Capability, {Cap_GroupNonUniform});
@@ -5477,6 +5505,66 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
     if (in.has_modifier) { ok = false; return true; }
     switch (in.fmt) {
         case Rdna2Format::SOP1: {
+            // s_quadmask_b64 D, S (#2412): D[i] = S[4i]|S[4i+1]|S[4i+2]|S[4i+3] for i in 0..15, upper
+            // bits zero. Each output bit ORs a QUAD of lanes, so a per-invocation bool cannot form it.
+            // `s_quadmask_b64 vcc, vcc` (0xbeea2d6a, confirmed with llvm-mc) is the first reject in 20
+            // of GTA V's 59 failing shaders.
+            //
+            // A ballot gives the source mask exactly; the quadmask is then integer arithmetic over it.
+            // BOTH representations prosper keeps for a mask register are produced -- the scalar DATA
+            // value in sreg and the per-lane bool -- so it cannot matter which a later instruction
+            // consumes; writing one and leaving the other stale would be silent wrong rendering.
+            //
+            // Wave64 only, and each stage supplies its exact-wave contract its own way: compute carries
+            // native_subgroup_size, the fragment stage DECLARES fragment_required_subgroup_size. An
+            // earlier revision gated on native_subgroup_size alone and therefore never fired for the
+            // graphics shaders that need it -- dead code that ctest could not see, caught only by
+            // measuring the failing-shader count. Vertex has neither mechanism and still rejects.
+            if (in.opcode == 0x2d && b.wave_size == 64 &&
+                (b.is_fragment || (b.native_subgroup_size == b.wave_size))) {
+                uint32_t src_mask = 0;
+                if (in.src[0].value == 106 || in.src[0].value == 107) src_mask = rs.vcc;
+                else if (in.src[0].value == 126 || in.src[0].value == 127) src_mask = rs.exec;
+                else if (in.src[0].kind == OperandKind::SGPR) {
+                    auto it = rs.sreg_bool.find(in.src[0].value);
+                    if (it != rs.sreg_bool.end()) src_mask = it->second;
+                }
+                const uint32_t lo = src_mask ? (b.is_fragment
+                        ? b.fragment_wave_ballot_half(src_mask, 0)
+                        : b.native_wave_ballot_half(src_mask, 0)) : 0;
+                const uint32_t hi = src_mask ? (b.is_fragment
+                        ? b.fragment_wave_ballot_half(src_mask, 1)
+                        : b.native_wave_ballot_half(src_mask, 1)) : 0;
+                if (lo && hi) {
+                    uint32_t value = b.uconst(0);
+                    for (uint32_t i = 0; i < 16; ++i) {
+                        const uint32_t word = i < 8 ? lo : hi;
+                        const uint32_t shift = (i < 8 ? i : i - 8) * 4u;
+                        const uint32_t nibble = b.ibin(
+                            Op_BitwiseAnd,
+                            b.ibin(Op_ShiftRightLogical, word, b.uconst(shift)), b.uconst(0xFu));
+                        value = b.ibin(Op_BitwiseOr, value,
+                                       b.sel(b.ucmp(Op_INotEqual, nibble, b.uconst(0)),
+                                             b.uconst(1u << i), b.uconst(0)));
+                    }
+                    const int dst = in.dst.value;
+                    rs.sreg[dst] = value;
+                    rs.sreg[dst + 1] = b.uconst(0);
+                    rs.sreg_srt.erase(dst); rs.sreg_srt.erase(dst + 1);
+                    const uint32_t lane = b.ibin(Op_BitwiseAnd, b.subgroup_local_id(),
+                                                 b.uconst(b.wave_size - 1));
+                    const uint32_t my_bit = b.ibin(
+                        Op_BitwiseAnd, b.ibin(Op_ShiftRightLogical, value, lane), b.uconst(1u));
+                    const uint32_t as_bool = b.land(
+                        b.ucmp(Op_ULessThan, lane, b.uconst(16u)),
+                        b.ucmp(Op_INotEqual, my_bit, b.uconst(0)));
+                    if (dst == 126 || dst == 127) { rs.exec = as_bool; rs.exec_narrowed = true; }
+                    else if (dst == 106 || dst == 107) rs.vcc = as_bool;
+                    else rs.sreg_bool[dst] = as_bool;
+                    rs.scc = b.ucmp(Op_INotEqual, value, b.uconst(0));
+                    return true;
+                }
+            }
             if (b.is_compute && b.wave_size == 32 && b.native_subgroup_size == 32 &&
                 in.opcode == 0x13) { // s_ff1_i32_b32
                 // RDNA2 returns the first set bit from the low end, or 0xffffffff for an empty

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3093,6 +3093,13 @@ struct RegState {
                                                    // (descriptor provenance: s_load_dwordx4 tags, s_buffer_load resolves)
     uint32_t vcc = 0;
     uint32_t scc = 0;          // scalar condition code (bool); set by s_cmp_*/SCC-writing SOP2, read by s_cselect
+    // #2418: does this shader read SCC anywhere? A STATIC property of the decoded stream, computed
+    // once before emission, never mutated during it — so it carries none of the lifetime hazards a
+    // stateful "pending reduction" marker would. It exists so the fragment stage can re-arm SCC after
+    // a mask op (which needs an exact wave vote, and so forces wave64) ONLY for shaders that actually
+    // consume it. Re-arming unconditionally is correct but makes every shader that merely saves EXEC
+    // pay a subgroup-size requirement it does not need, which gates the draw on a 32-wide device.
+    bool reads_scc = false;
     uint32_t exec = 0;         // per-lane execution mask (bool); v_cmpx narrows it, output store honors it
     bool exec_narrowed = false; // true once EXEC is narrowed below all-lanes-on (so VGPR writes predicate)
     // PC-relative EMBEDDED TABLES (#273): load pc -> the table's dwords, resolved by
@@ -3389,6 +3396,34 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
         if (index + 1 < ins.size()) pending.push_back(index + 1);
     }
     return true;   // every reachable path hit a redefinition/end without a read
+}
+
+// #2418: does this shader read SCC anywhere? Used to decide whether the fragment stage should pay for
+// an exact wave vote when a mask op writes SCC. Deliberately CONSERVATIVE and whole-shader: it answers
+// "could SCC ever be consumed", not "is this particular write live". A false positive costs one shader a
+// subgroup-size requirement it might not have needed; a false NEGATIVE would silently drop the vote a
+// consumer depends on, so every reader is listed even where the recompiler handles it elsewhere.
+//
+// SCC readers on RDNA2 (doc 70648): SOP2 s_cselect_b32/b64 (0x0a/0x0b) and the carry-in forms
+// s_addc_u32/s_subb_u32 (0x04/0x05); SOPP s_cbranch_scc0/scc1 (0x04/0x05); SOP1 s_cmov_b32/b64
+// (0x02/0x03). SOPC and s_cmp_* WRITE SCC and are not readers.
+inline bool shader_reads_scc(const std::vector<Rdna2Inst>& ins) {
+    for (const auto& in : ins) {
+        switch (in.fmt) {
+            case Rdna2Format::SOP2:
+                if (in.opcode == 0x04 || in.opcode == 0x05 ||
+                    in.opcode == 0x0a || in.opcode == 0x0b) return true;
+                break;
+            case Rdna2Format::SOPP:
+                if (in.opcode == 0x04 || in.opcode == 0x05) return true;
+                break;
+            case Rdna2Format::SOP1:
+                if (in.opcode == 0x02 || in.opcode == 0x03) return true;
+                break;
+            default: break;
+        }
+    }
+    return false;
 }
 
 std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& ins) {
@@ -5927,6 +5962,31 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // EXECZ guard is conservatively (and incorrectly) rejected.
                     const bool source_is_exec = in.src[0].value == 126 || in.src[0].value == 127;
                     rs.exec_narrowed = !((in.opcode == 0x28 || in.opcode == 0x2b) && source_is_exec);
+                    // RE-ARM SCC for the FRAGMENT stage (#2418). The poison above is the right default
+                    // — SCC here is `(result != 0)` over the whole 64-lane mask, which one lane's bool
+                    // cannot express — but the fragment stage has an exact instrument for precisely
+                    // this reduction, and this file already uses it for the same purpose after v_cmpx
+                    // narrows EXEC (`rs.scc = b.is_fragment ? b.fragment_wave_any(rs.exec) : 0;`).
+                    // `fragment_wave_any`'s contract is "exact scalar wave vote for fragment control
+                    // flow AND MASK REDUCTIONS".
+                    //
+                    // Without it, the poisoned SCC makes every later consumer reject — `s_cselect_b32`
+                    // at the SOP2 switch (`if (!rs.scc) { ok = false; }`), `s_addc`, and SCC branch
+                    // emission — which is a large share of GTA V's 23,386 skipped draws, since
+                    // saveexec-then-`s_cbranch_scc0` is an ordinary shape in its pixel shaders.
+                    //
+                    // GATED ON `reads_scc`, and that gate is the whole point. `fragment_wave_any` sets
+                    // `fragment_required_subgroup_size`, so an unconditional re-arm would give every
+                    // shader that merely saves EXEC a wave64 requirement it does not need — and that
+                    // shader is then GATED on a 32-wide device where it works today. On a native-wave64
+                    // host that regression is invisible, which is exactly why it is guarded here rather
+                    // than discovered later on other hardware.
+                    //
+                    // This is a REDUCE in #2410's taxonomy: the value becomes a guest scalar consumed
+                    // as data, so forcing wave64 where it IS used is correct and must not be relaxed.
+                    // Compute and vertex keep the poison — compute has its own synchronized guest-wave
+                    // reduction paths, and the vertex stage has no equivalent exact vote at all.
+                    if (b.is_fragment && rs.reads_scc) rs.scc = b.fragment_wave_any(rs.exec);
                 }
                 return true;
             }
@@ -16321,6 +16381,10 @@ static std::vector<uint32_t> recompile_fragment_impl(
         }
     }
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
+    // #2418: a static property of the decoded stream, set once and never mutated during emission.
+    // Gates the fragment SCC re-arm after mask ops so only shaders that actually consume SCC pay the
+    // exact-wave-vote's subgroup-size requirement.
+    rs.reads_scc = shader_reads_scc(ins);
     if (system_inputs) {
         // RDNA2 PS system values are packed in field order. ADDR reserves each field's documented
         // width even when ENA is clear, allowing a driver to keep later VGPR numbers stable. Vulkan

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -90,7 +90,7 @@ enum : uint32_t {
     Op_SelectionMerge=247, Op_Label=248, Op_Branch=249, Op_BranchConditional=250, Op_Switch=251,
     Op_EmitVertex=218, Op_EndPrimitive=219,
     Op_Kill=252, Op_Return=253, Op_ModuleProcessed=330, Op_GroupNonUniformAny=335,
-    Op_GroupNonUniformShuffle=345,
+    Op_GroupNonUniformBallot=339, Op_GroupNonUniformShuffle=345,
     Op_GroupNonUniformIAdd=349,
 };
 // GLSL.std.450 extended-instruction numbers.
@@ -102,7 +102,7 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
-    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformShuffle=65, Cap_GroupNonUniformQuad=68,
+    Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformBallot=64, Cap_GroupNonUniformShuffle=65, Cap_GroupNonUniformQuad=68,
     Cap_TransformFeedback=53,   // VK_EXT_transform_feedback (geometry-probe capture of gl_Position, gated)
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
@@ -645,6 +645,29 @@ struct SpirvCompute {
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny,
             {t_bool, result, uconst(Scope_Subgroup), value});
+        return result;
+    }
+    // One 32-bit HALF of the guest wave mask, materialised from this lane's bool (#2420).
+    // OpGroupNonUniformBallot returns a uvec4 whose .x/.y are lanes 0..31 / 32..63 OF THIS SUBGROUP,
+    // so it equals the guest mask only when the subgroup is exactly the guest wave. The caller must
+    // establish that; a narrower subgroup would report half a mask as though it were whole, which is
+    // silent wrong data rather than a visible reject.
+    bool declared_subgroup_ballot = false;
+    uint32_t native_wave_ballot_half(uint32_t mask_bit, uint32_t half) {
+        if (!native_subgroup_size || !mask_bit) return 0;
+        if (!declared_subgroup) {
+            put(caps, Op_Capability, {Cap_GroupNonUniform});
+            declared_subgroup = true;
+        }
+        if (!declared_subgroup_ballot) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformBallot});
+            declared_subgroup_ballot = true;
+        }
+        const uint32_t ballot = id();
+        put(code, Op_GroupNonUniformBallot,
+            {t_v4u(), ballot, uconst(Scope_Subgroup), mask_bit});
+        const uint32_t result = id();
+        putv(code, Op_CompositeExtract, {t_u32, result, ballot, half});
         return result;
     }
     uint32_t native_wave_first_active(uint32_t mask_bit) {
@@ -5356,6 +5379,26 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
             // is zero. Compute/fragment keep their real multi-lane masks and must not take this path.
             if (!b.is_compute && !b.is_fragment && (o.value == 106 || o.value == 107))
                 return o.value == 106 ? b.sel(rs.vcc, b.uconst(1), b.uconst(0)) : b.uconst(0);
+            // VCC read as scalar DATA, materialised exactly (#2420). GTA V computes a descriptor-table
+            // pointer from the compare mask -- `s_add_u32 s60, s36, vcc_lo` -- and a per-invocation
+            // bool has no 32-bit value to add, so s60 became unknown, its s_load's base was unknown,
+            // the MUBUF reading that SRSRC could not fold, and the shader rejected. 23,166 draws of
+            // that title die this way (#2412).
+            //
+            // `subgroupBallot` supplies those bits EXACTLY, and only under one condition: its .x/.y
+            // are lanes 0..31 / 32..63 of THIS SUBGROUP, so it equals the guest wave mask only when
+            // the subgroup IS the guest wave. Narrower and it would report half a mask as though it
+            // were whole -- a wrong descriptor address, i.e. silent wrong rendering. So the exact-size
+            // contract is required, and anything else keeps rejecting exactly as before.
+            //
+            // Reached only on the path that already sets ok=false, so this can only turn a reject into
+            // working code; no shader that compiles today changes.
+            if ((o.value == 106 || o.value == 107) && rs.vcc &&
+                b.native_subgroup_size && b.native_subgroup_size == b.wave_size) {
+                const uint32_t half =
+                    b.native_wave_ballot_half(rs.vcc, o.value == 106 ? 0u : 1u);
+                if (half) return half;
+            }
             if (ok) *ok = false;
             if (getenv("PROSPER_DBG"))
                 std::fprintf(stderr,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -14863,10 +14863,15 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     // instructions are buffer_store_dword / buffer_load_dwordx2 / buffer_load_dword,
                     // all lowered at :9343-9362, so a census without this field reads as "implement
                     // MUBUF" when nothing about MUBUF is missing.
-                    fprintf(stderr, "[recompile-reject] mode=%s pc=%u words=%s fmt=%d op=0x%x "
+                    // Shader identity (#2412): the reject lines carry a program-local pc and nothing
+                    // else, so a census cannot group them by SHADER -- which is the unit that matters,
+                    // since 24,485 skipped GTA V draws turned out to be 43 distinct shaders. The first
+                    // code dword plus the span identifies one cheaply and stably.
+                    fprintf(stderr, "[recompile-reject] sh=%08x/%zu mode=%s pc=%u words=%s fmt=%d op=0x%x "
                                     "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
                                     "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u "
                                     "sext=%d/%d\n",
+                        dwords ? code[0] : 0u, dwords,
                         handled ? "unresolved-operand" : "unknown-encoding",
                         in.pc, reject_words_text(in).c_str(), (int)in.fmt, in.opcode,
                         in.dst.value, (int)in.dst.kind,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3457,7 +3457,20 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
 //
 // SCC readers on RDNA2 (doc 70648): SOP2 s_cselect_b32/b64 (0x0a/0x0b) and the carry-in forms
 // s_addc_u32/s_subb_u32 (0x04/0x05); SOPP s_cbranch_scc0/scc1 (0x04/0x05); SOP1 s_cmov_b32/b64
-// (0x02/0x03). SOPC and s_cmp_* WRITE SCC and are not readers.
+// (0x02/0x03); SOPK s_cmovk_i32 (0x02). SOPC and s_cmp_*/s_cmpk_* WRITE SCC and are not readers.
+//
+// SOPK was omitted in the first version of this scan and that was a genuine false negative -- the
+// direction this function's own contract calls the dangerous one, since a missed reader silently
+// drops the vote its consumer depends on. Caught in review of #2416. The file already documents the
+// hazard at the `sopk_writes_scalar_data` exclusion note: "several SOPK ops (s_addk/s_mulk/s_cmovk/
+// s_cmpk) READ or read-modify-write their dst via the implicit SIMM16".
+//
+// Only s_cmovk_i32 READS SCC in this space, verified rather than taken from a table --
+// `llvm-mc -mcpu=gfx1030 -disassemble` over the SOPK opcode range gives 0x00 s_movk_i32,
+// 0x02 s_cmovk_i32, 0x03.. s_cmpk_* (which WRITE SCC), 0x0f s_addk_i32, 0x10 s_mulk_i32,
+// 0x12/0x13 s_getreg/s_setreg. Including the whole SOPK format would be conservative in the safe
+// direction but costs every shader containing an s_movk -- which is nearly all of them -- a
+// subgroup-size requirement it does not need.
 inline bool shader_reads_scc(const std::vector<Rdna2Inst>& ins) {
     for (const auto& in : ins) {
         switch (in.fmt) {
@@ -3470,6 +3483,9 @@ inline bool shader_reads_scc(const std::vector<Rdna2Inst>& ins) {
                 break;
             case Rdna2Format::SOP1:
                 if (in.opcode == 0x02 || in.opcode == 0x03) return true;
+                break;
+            case Rdna2Format::SOPK:
+                if (in.opcode == 0x02) return true;   // s_cmovk_i32: conditional move ON SCC
                 break;
             default: break;
         }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9608,8 +9608,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (getenv("PROSPER_DBG")) {
                         const ShaderResource* pp = rt->by_fetch_pc(in.pc);
                         fprintf(stderr,
-                                "[mubuf-raw-unresolved] pc=%u srsrc=s%d srt_tag=%s0x%x "
+                                "[mubuf-raw-unresolved] rt=%p pc=%u srsrc=s%d srt_tag=%s0x%x "
                                 "key_res=%s pc_res=%s rewritten=%d (%zu res)\n",
+                                (const void*)rt,
                                 in.pc, in.src[1].value, has_srt_tag ? "" : "NONE ", srt_tag,
                                 has_srt_tag && rt->by_srt_offset(srt_tag) ? "yes" : "null",
                                 pp ? "yes" : "null",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13535,8 +13535,15 @@ bool emit_cfg_state_machine(
                         // Its sibling at the ALU reject site already prints these; this one did not,
                         // so half the rejects from a run were unidentifiable and the two diagnostics
                         // could not be compared (#2309).
+                        // `mode` as at the ALU reject site (#2412): `unknown-encoding` means no
+                        // lowering exists and one must be written; `unresolved-operand` means the
+                        // lowering ran and could not resolve an operand or a resource-table
+                        // descriptor. Without it a census cannot tell "implement this" from
+                        // "this instruction is fine, its descriptor is not".
                         std::fprintf(stderr,
-                                     "[cfg-recompile-reject] pc=%u words=%s len=%u fmt=%d op=0x%x\n",
+                                     "[cfg-recompile-reject] mode=%s pc=%u words=%s len=%u "
+                                     "fmt=%d op=0x%x\n",
+                                     handled ? "unresolved-operand" : "unknown-encoding",
                                      in.pc, reject_words_text(in).c_str(), in.len_dwords,
                                      static_cast<int>(in.fmt), in.opcode);
                     return false;
@@ -14743,10 +14750,20 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
                 if (getenv("PROSPER_DBG")) {
-                    fprintf(stderr, "[recompile-reject] pc=%u words=%s fmt=%d op=0x%x "
+                    // `mode` separates the two rejections that used to print identically and want
+                    // OPPOSITE work (#2412). `unknown-encoding` (handled=false) means no lowering
+                    // exists — write the emitter. `unresolved-operand` (handled=true, ok=false)
+                    // means the lowering exists and could not resolve an operand or a V#/T#/S#
+                    // through the resource table — the emitter is fine and the descriptor is the
+                    // defect. GTA V's black 3D world is the worked example: its top three rejected
+                    // instructions are buffer_store_dword / buffer_load_dwordx2 / buffer_load_dword,
+                    // all lowered at :9343-9362, so a census without this field reads as "implement
+                    // MUBUF" when nothing about MUBUF is missing.
+                    fprintf(stderr, "[recompile-reject] mode=%s pc=%u words=%s fmt=%d op=0x%x "
                                     "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
                                     "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u "
                                     "sext=%d/%d\n",
+                        handled ? "unresolved-operand" : "unknown-encoding",
                         in.pc, reject_words_text(in).c_str(), (int)in.fmt, in.opcode,
                         in.dst.value, (int)in.dst.kind,
                         in.src[0].value, (int)in.src[0].kind,

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1062,10 +1062,30 @@ int main() {
     wave64_compute_config.wave_size = 64;
     wave64_compute_config.native_subgroup_size = 64;
     wave64_compute_config.local_x = 64;
-    if (!recompile_compute(wave32_compute_vopc_preserves_vcc_hi_data,
-                           std::size(wave32_compute_vopc_preserves_vcc_hi_data), nullptr,
-                           wave64_compute_config).empty()) {
-        printf("  [FAIL] implicit Wave64 VOPC preserved overwritten VCC_HI scalar data\n");
+    // In Wave64 the VOPC overwrites the WHOLE of VCC, so the 0.75f placed in VCC_HI is gone and the
+    // later read must NOT return it. That requirement is unchanged. What changed is the outcome: this
+    // used to be expressed as "the shader must reject", because a per-invocation bool could not
+    // express what VCC_HI now holds. It can — after a Wave64 v_cmp, VCC_HI is exactly lanes 32..63 of
+    // the compare mask, and `subgroupBallot(vcc).y` is exactly those bits when the subgroup IS the
+    // guest wave, which this config establishes (native_subgroup_size = 64). See #2420.
+    //
+    // Asserting the BALLOT OPCODE rather than mere non-emptiness is what pins the distinction: a
+    // module that compiled by some other route — in particular by resurrecting the stale scalar, the
+    // exact defect this case exists to catch — would not contain it.
+    const std::vector<uint32_t> wave64_vcc_hi = recompile_compute(
+        wave32_compute_vopc_preserves_vcc_hi_data,
+        std::size(wave32_compute_vopc_preserves_vcc_hi_data), nullptr, wave64_compute_config);
+    auto has_opcode = [](const std::vector<uint32_t>& m, uint32_t op) {
+        for (size_t i = 5; i < m.size();) {
+            const uint32_t len = m[i] >> 16;
+            if (len == 0 || i + len > m.size()) break;
+            if ((m[i] & 0xffffu) == op) return true;
+            i += len;
+        }
+        return false;
+    };
+    if (wave64_vcc_hi.empty() || !has_opcode(wave64_vcc_hi, 339)) {   // OpGroupNonUniformBallot
+        printf("  [FAIL] Wave64 VCC_HI read did not materialise the mask half via subgroupBallot\n");
         return 1;
     }
     printf("  [ok]   implicit VOPC preserves VCC_HI scalar data only in Wave32\n");


### PR DESCRIPTION
## What this changes

`[recompile-reject]` and `[cfg-recompile-reject]` printed an identical line for two rejections that want
**opposite** work. They now carry a `mode=` field:

| mode | condition | what it means |
| --- | --- | --- |
| `unknown-encoding` | `handled == false` | no lowering exists — **write the emitter** |
| `unresolved-operand` | `handled == true, ok == false` | the lowering ran and could not resolve an operand or a V#/T#/S# through the resource table — **the emitter is fine, the descriptor is the defect** |

## Why it is not cosmetic

GTA V (`PPSA04263`) at gameplay renders a black 3D world (#2412) and produces **951 rejects per run**. By
raw `fmt`/`op` the top three are MUBUF `0x1c`, `0x0d`, `0x0c` — `buffer_store_dword`,
`buffer_load_dwordx2`, `buffer_load_dword`. All three are lowered explicitly at
`rdna2_to_spirv.cpp:9343-9362`.

Read without this field, that census says **"implement MUBUF"**. Nothing about MUBUF is missing.

With the field, the same run on the same route reads:

```
951 mode=unresolved-operand
  0 mode=unknown-encoding
```

**Zero** unknown encodings. The title's entire remaining shader work is resource resolution, and it
contains no recompiler-coverage gap at all — the opposite of the conclusion the old line supported. That
redirects the frontier from the recompiler to descriptor provenance, and it is what let the chain behind
#2412 be traced in one further run:

```
[smem-reject] reason=unresolved-cbuf src0=s0/s12   (80)   the s_load that would materialise the descriptor
        -> [mubuf-raw-unresolved] rewritten=1      (474)  so the SRSRC V# is never resolvable
        -> [recompile-reject] mode=unresolved-operand
        -> [compute] skip unsupported program      (52)   and the world does not draw
```

The charter's standing instruction for a reject is to implement the operation it names. That is exactly
right when the mode is `unknown-encoding`, and exactly wrong here — which is the case this field exists to
stop anyone from mis-reading.

## Scope

Diagnostic only. Both sites are already inside `if (getenv("PROSPER_DBG"))`, `handled` is already in scope
at both, and no behaviour changes.

## Verified — Linux/AMD

```
ctest --no-tests=error -j4     230/230 passed, exit 0
```

Plus the live GTA V census quoted above, on the committed route
(`PROSPER_PAD_SCRIPT=@prosper/scripts/gta5/reach-story-mode.pad`).

Refs #2412
