### PR TITLE
fix(win): skip the guest's int $0x41 debugbreak, as Linux already does

### DIFF
--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1045,7 +1045,17 @@ namespace {
         // bytes really are CD 41, so no other title is affected (none emit int 0x41). Disable with
         // PROSPER_NO_INT41_SKIP to get the fatal path back for debugging, matching Linux.
         if (code == EXCEPTION_ACCESS_VIOLATION && g_base && c->Rip >= g_base &&
-            (!g_image_end || c->Rip < g_image_end) && addr_readable(c->Rip)) {
+            // BOTH bytes are validated, not just the first. This test runs on EVERY access
+            // violation whose rip is in the guest image -- not only on int41 faults -- so it
+            // speculatively reads ins[1] at arbitrary guest rips. addr_readable is a single
+            // VirtualQuery on the page containing its argument (:343), so a rip on the last byte of
+            // a committed page would leave ins[1] on an uncommitted successor and fault INSIDE the
+            // VEH: a nested exception rather than a clean diagnostic. Linux avoids this differently
+            // -- it bounds by an explicit g_base + 4 GiB band and argues the 2-byte read is safe
+            // within it -- so the Windows version needs its own second check rather than inheriting
+            // that argument. (Review finding on #2423.)
+            (!g_image_end || c->Rip < g_image_end) &&
+            addr_readable(c->Rip) && addr_readable(c->Rip + 1)) {
             const auto* ins = (const uint8_t*)(uintptr_t)c->Rip;
             static const bool int41_skip = getenv("PROSPER_NO_INT41_SKIP") == nullptr;
             if (int41_skip && ins[0] == 0xCDu && ins[1] == 0x41u) {

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -1027,6 +1027,36 @@ namespace {
         if (code == EXCEPTION_ACCESS_VIOLATION && addr_readable(c->Rip) &&
             insn_is_fs_relative((const uint8_t*)(uintptr_t)c->Rip) && guest_fs_reapply())
             return EXCEPTION_CONTINUE_EXECUTION;
+        // Guest `int $0x41` (opcode CD 41) is RAGE's software breakpoint / assert trap (GTA V,
+        // PPSA04263). This mirrors the Linux path at exec_image_linux.cpp:2257 and #1138, which
+        // Windows never received -- the platforms disagreed, and only the fatal one shipped here.
+        //
+        // On PS5 an int with a userspace-illegal vector raises #GP; with no debugger attached the
+        // kernel's trap handler returns past it, so the title continues into its OWN error-reporting
+        // and recovery code. Windows instead raises an ACCESS_VIOLATION whose faulting address is
+        // -1 (there is no such address; it is how a software interrupt with no mapping surfaces),
+        // and with nothing skipping it the guest thread dies.
+        //
+        // Measured on PPSA04263 before this change: the Story-Mode route reached ~2880 frames and
+        // then took `code=0xc0000005 rip=<guest> addr=0xffffffffffffffff` with `cd 41` at rip.
+        //
+        // Runs BEFORE the t_armed gate, like the %fs re-apply above, because the trap fires on guest
+        // worker threads that were never armed. Only fires for a rip inside the guest image whose
+        // bytes really are CD 41, so no other title is affected (none emit int 0x41). Disable with
+        // PROSPER_NO_INT41_SKIP to get the fatal path back for debugging, matching Linux.
+        if (code == EXCEPTION_ACCESS_VIOLATION && g_base && c->Rip >= g_base &&
+            (!g_image_end || c->Rip < g_image_end) && addr_readable(c->Rip)) {
+            const auto* ins = (const uint8_t*)(uintptr_t)c->Rip;
+            static const bool int41_skip = getenv("PROSPER_NO_INT41_SKIP") == nullptr;
+            if (int41_skip && ins[0] == 0xCDu && ins[1] == 0x41u) {
+                static std::atomic<int> logged{0};
+                if (logged.fetch_add(1) < 8)
+                    fprintf(stderr, "[int41] guest int $0x41 (debugbreak) at eboot+0x%llx -> skipped\n",
+                            (unsigned long long)(c->Rip - g_base));
+                c->Rip += 2;   // advance past the 2-byte int instruction
+                return EXCEPTION_CONTINUE_EXECUTION;
+            }
+        }
         if (code != EXCEPTION_ACCESS_VIOLATION && code != EXCEPTION_ILLEGAL_INSTRUCTION &&
             code != EXCEPTION_IN_PAGE_ERROR && code != EXCEPTION_PRIV_INSTRUCTION &&
             code != EXCEPTION_DATATYPE_MISALIGNMENT)


### PR DESCRIPTION
## The defect

GTA V (`PPSA04263`) runs RAGE, which fires `int $0x41` as a software breakpoint / assert trap. On PS5 an int with a userspace-illegal vector raises #GP; with no debugger attached the kernel's trap handler returns past it, so the title continues into its **own** error-reporting and recovery code.

**Linux emulates that** (`exec_image_linux.cpp:2257`, #1138). **Windows never received it.** The platforms disagreed and only the fatal one shipped here.

## Why it stayed hidden

Windows surfaces the trap as `EXCEPTION_ACCESS_VIOLATION` with a faulting address of **-1**. There is no such address — it is how a software interrupt with no mapping appears — so it resembles neither the Linux `SIGSEGV` nor an ordinary memory bug. Nothing on Windows named the trap; it just looked like a crash deep into the run.

`grep -c int41`: `exec_image_linux.cpp` **8**, `exec_image_win.cpp` **0**.

## Evidence

Story-Mode route on `PPSA04263`, Windows/NVIDIA, before:

```
[veh] tid=78148 code=0xc0000005 rip=0x412babe07 addr=0xffffffffffffffff
[veh] bytes@rip: cd 41 c7 83 20 8c 00 00 ...
```

`cd 41` at rip **is** the trap. After:

```
[int41] guest int $0x41 (debugbreak) at eboot+0x2babe07 -> skipped
```

## What this does NOT do

**It does not make GTA V reach gameplay on Windows.** The run still ends in a fault — but a *different* one, and that is the point: a `vmovntdqa` streaming load from `0x1550880000` (guest video-memory band; the FMV's Y plane sits at `0x1558c00000`). That is the next layer, filed separately.

Skipping the assert is correct regardless of what follows: the guest is entitled to trap and continue, exactly as it does on PS5 and on Linux.

## Scope and safety

- Runs **before** the `t_armed` gate, like the guest-`%fs` re-apply directly above it, because the trap fires on guest worker threads that were never armed.
- Only fires for a rip **inside the guest image** whose bytes really are `CD 41`. Titles that never emit `int 0x41` are unaffected — no other title in the tree does.
- `PROSPER_NO_INT41_SKIP` restores the fatal path, matching the Linux switch.
- `addr_readable(c->Rip)` guards the 2-byte read; the rip page is mapped and executable by construction (the trap was fetched from it).

## Verification

- `cmake --build prosper/build-app -j6 --target prosper-app` — exit 0.
- Live route on `PPSA04263`: skip fires exactly once, run continues past it, fault relocates to a different rip and a different (real) address.
- `git diff --check` clean.

Platform-specific by nature; this is the Windows half of behaviour Linux already had.

Refs #2396