### PR TITLE
diag(win): say why a fixed MAP_DIRECT failed instead of returning silently

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -4279,7 +4279,39 @@ namespace {
         }
         // A private fixed mapping would report success while severing the physical alias contract.
         // Older Windows versions without placeholder replacement fail visibly instead.
-        if (fixed) return nullptr;
+        //
+        // This return is the one that KILLS A TITLE, and until #2424 it was the only failure path in
+        // this function that said nothing. The private fallback immediately below logs; this did not,
+        // so a fixed MAP_DIRECT that failed was indistinguishable in a log from one that never ran.
+        // Reconstructing GTA V's (PPSA04263) wall took a VEH dump, a guest disassembly and a batchmap
+        // return code, all to learn that this line had been taken.
+        //
+        // The placeholder spans are dumped with it because the suspected mechanism is which LIST a
+        // span sits in: coalescing is deliberately confined to spans of the same guest ownership
+        // (remember_placeholder_locked), so two adjacent halves in g_free_placeholders and
+        // g_guest_placeholders can never merge, and MapViewOfFile3 cannot span two placeholders.
+        // Printing both lists is what distinguishes that from a same-list coalesce that simply
+        // failed -- a different bug with a different fix.
+        if (fixed) {
+            if (memlog()) {   // guard the lock too: MLOG alone would still take g_dview_mx
+                const DWORD err = GetLastError();
+                MLOG("map_dmem FIXED FAILED hint=0x%llx len=0x%llx phys=0x%llx align=0x%llx error=%lu"
+                     " -- guest gets ENOMEM\n",
+                     (unsigned long long)hint, (unsigned long long)len,
+                     (unsigned long long)phys, (unsigned long long)align, (unsigned long)err);
+                std::lock_guard<std::mutex> lk(g_dview_mx);
+                const uint64_t lo = hint, hi = hint + len;
+                for (const PlaceholderSpan& s : g_free_placeholders)
+                    if (s.base < hi && lo < s.base + s.size)
+                        MLOG("  overlapping FREE placeholder base=0x%llx size=0x%llx\n",
+                             (unsigned long long)s.base, (unsigned long long)s.size);
+                for (const PlaceholderSpan& s : g_guest_placeholders)
+                    if (s.base < hi && lo < s.base + s.size)
+                        MLOG("  overlapping GUEST placeholder base=0x%llx size=0x%llx\n",
+                             (unsigned long long)s.base, (unsigned long long)s.size);
+            }
+            return nullptr;
+        }
         MLOG("map_dmem private fallback hint=0x%llx len=0x%llx phys=0x%llx align=0x%llx error=%lu\n",
              (unsigned long long)hint, (unsigned long long)len,
              (unsigned long long)phys, (unsigned long long)align, GetLastError());


### PR DESCRIPTION
`win_map_phys`'s `if (fixed) return nullptr` is the failure path that **kills a title** — the guest gets ENOMEM from `sceKernelBatchMap` and asserts — and it was the only path in that function that logged nothing. The private fallback directly below it logs; this did not. So a fixed MAP_DIRECT that failed was indistinguishable, in a log, from one that never ran.

## What it cost to not have this

Reconstructing GTA V's (`PPSA04263`) Windows wall without it took a VEH dump, a guest disassembly, an opcode decode and a batchmap return code — and still produced a **wrong hypothesis** about which placeholder list was implicated (#2424).

With it, one run gives the answer in three lines, and kills that hypothesis immediately:

```
[memhle] map_dmem FIXED FAILED hint=0x1550880000 len=0x80000 phys=0xd2480000 align=0x0 error=487 -- guest gets ENOMEM
[memhle]   overlapping FREE placeholder base=0x1550880000 size=0x40000
[memhle] batchmap n=14 done=13 -> 0x8002000c
```

The whole defect is visible at a glance: an `0x80000` view requested against a `0x40000` placeholder, `error=487` = `ERROR_INVALID_ADDRESS`, because `MapViewOfFile3` with `MEM_REPLACE_PLACEHOLDER` requires the view to match a **single** placeholder exactly.

## Why both lists are printed

Which list an overlapping span sits in distinguishes an **ownership-boundary** problem from a **size mismatch**. Those have different fixes, and guessing between them is how a title-specific ENOMEM becomes cross-title VA corruption. Printing both is what let the wrong hypothesis die in one run rather than surviving into a patch.

## Scope

- **Diagnostic only.** No behavioural change; the `return nullptr` is unchanged and still correct (a private fixed mapping would report success while severing the physical alias contract).
- Behind the existing `PROSPER_MEMLOG` gate.
- `memlog()` is checked **before** taking `g_dview_mx`, so a default run pays neither the lock nor the scan.

## Verification

- `cmake --build prosper/build-app -j6 --target prosper-app` — exit 0.
- Live route on `PPSA04263` with `PROSPER_MEMLOG=1`: emits exactly the output above at the failing map.
- Default run (no `PROSPER_MEMLOG`): silent, no lock taken.
- `git diff --check` clean.

Refs #2424