### PR TITLE
fix(gpu): seed the compute const-fold with the dispatch's declared user-SGPR count, not all 32

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5030,10 +5030,29 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // recompiler resolves. Compute-specific delta: an image_store use becomes a STORAGE image
         // (the recompiler's storage path requires ResourceClass::StorageImage), a sampled use a
         // Texture. Never shadow an existing resource at the same srt_offset (first-match-wins).
+        // Seed the fold with the registers the dispatch ACTUALLY initializes, not all 32 (#590).
+        // COMPUTE_PGM_RSRC2.USER_SGPR declares how many user SGPRs the hardware loads; s[user_count..31]
+        // are undefined. Passing kUserSgprs made the fold mark every one of those as a KNOWN value of
+        // zero, because `sgprs` is a zero-filled kUserSgprs array. "Known zero" and "never established"
+        // are not the same thing to a const-fold: a descriptor chain rooted in an undefined register
+        // then folds to base=0, the address becomes a bare immediate offset (0x38, 0xb0, 0x128 ...),
+        // `readable()` fails, and the use is dropped — or worse, four zero dwords are published as a V#
+        // that shadows a real descriptor under first-match-wins.
+        //
+        // Measured on PPSA04263 (GTA V) at gameplay: ALL 52 failing compute programs declare fewer than
+        // 32 (range 2..15), so 17-30 phantom registers were marked known in every one of them; the same
+        // run reports 1,988 SMEM loads with `base=0x0 base_ok=1` and 475 unreadable bare-offset
+        // addresses.
+        //
+        // This function already encodes the same bound ~180 lines below, where the push-constant path
+        // computes `fw_user_count = min(user_count, kUserSgprs)` and skips a fold result whose
+        // `base_sgpr` lands in [user_count, 31] — because indexing past the block would be wrong. The
+        // fold call had not been given that bound, so the two disagreed about which registers exist.
+        const uint32_t fold_user_count = std::min<uint32_t>(user_count, kUserSgprs);
         {
             const std::vector<SrtUse> srt_uses = add_compute_buffer_resources(
                 *table, (const uint32_t*)(uintptr_t)code_addr, shader_dwords,
-                sgprs, kUserSgprs,
+                sgprs, fold_user_count,
                 linear_store_proof_context ? launch.local_x : 0,
                 linear_store_proof_context ? launch.threads_x : 0,
                 linear_store_proof_context ? user_count : UINT32_MAX);
@@ -5377,13 +5396,22 @@ std::vector<ComputeItem> realize_compute_dispatches(
                            &config);
             // PROSPER_DYNTRACE_FAIL=1: replay the FAILED compute program's resource build with the
             // const-fold walk trace + user-data dump forced on (once per distinct program) — the
-            // compute analog of the graphics VS/PS fail-replay (gpu_execute.hpp). Compute dispatches
-            // only run build_shader_resources (the DIRECT front-half table) and NEVER the const-fold
-            // resolve_dynamic_fetch that graphics stages use, so a bindless storage-image U# / T#
-            // (image_store SRSRC, image_sample) can't be recovered by pc-provenance for a dispatch.
-            // This trace reveals whether the failing dispatch's descriptors ARE const-fold-resolvable
-            // (i.e. loaded via a foldable s_load chain) — the ground truth for #590 before extending
-            // the compute resource build. Read-only: it does not change what the executor binds.
+            // compute analog of the graphics VS/PS fail-replay (gpu_execute.hpp).
+            //
+            // STALE TEXT REMOVED, and what it cost is why this note replaces it rather than deleting
+            // it silently. This comment used to assert that compute dispatches "only run
+            // build_shader_resources (the DIRECT front-half table) and NEVER the const-fold
+            // resolve_dynamic_fetch that graphics stages use". That stopped being true when
+            // add_compute_buffer_resources landed: the compute table build calls it (see the #590
+            // block above), and it calls resolve_dynamic_fetch directly. An agent investigating GTA V's
+            // black world read this comment, cited it with a file:line as the mechanism, and published
+            // "the fold is never run for compute, so run it" as the fix — for a fold that had been
+            // running the whole time. A stale comment is read as verified fact precisely because it
+            // sits next to the code it describes.
+            //
+            // What the trace is actually for: it reveals whether a failing dispatch's descriptors are
+            // const-fold-resolvable (i.e. loaded via a foldable s_load chain), which is the ground
+            // truth for #590. Read-only: it does not change what the executor binds.
             if (dyntrace_failed_shader_enabled(code_addr)) {
                 static std::set<uint64_t> traced_cs;
                 if (traced_cs.insert(code_addr).second) {
@@ -5405,8 +5433,13 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                      sgprs[i], sgprs[i + 1], sgprs[i + 2], sgprs[i + 3]);
                     std::vector<SrtUse> cs_uses;
                     g_dyntrace_force = true;
+                    // Same bound as the production call above. A diagnostic seeded differently from
+                    // the path it exists to explain reports a resolution the executor never had —
+                    // which is how this fold's phantom-register seeding stayed invisible: the trace
+                    // and production agreed with each other while both over-claimed.
                     resolve_dynamic_fetch((const uint32_t*)(uintptr_t)code_addr, shader_dwords,
-                                          sgprs, kUserSgprs, 0, &cs_uses);
+                                          sgprs, std::min<uint32_t>(user_count, kUserSgprs), 0,
+                                          &cs_uses);
                     g_dyntrace_force = false;
                     std::fprintf(stderr,
                                  "[dynfail]   pre-specialization raw const-fold recovered %zu "


### PR DESCRIPTION
## What this is, stated first because it matters for how you review it

**This fixes no user-visible behaviour.** It is a correctness change to what the compute const-fold is
allowed to claim it knows. I found it while chasing GTA V's black world, it is not the cause of that, and
I am not presenting it as progress on it.

Please review it on the narrow merits below, and reject it if you think touching shared renderer code for
no measured behavioural gain is not worth it. That is a reasonable position and I would rather it be argued
than assumed.

## The defect

`COMPUTE_PGM_RSRC2.USER_SGPR` declares how many user SGPRs the hardware initializes for a dispatch;
`s[user_count..31]` are undefined. `gpu_executor.cpp` called the fold with `kUserSgprs` (32) over a
zero-filled 32-entry array, so **every register the dispatch never initialized was seeded as a KNOWN value
of zero.**

To a const-fold "known zero" and "never established" are different facts:

- a descriptor chain rooted in an undefined register folds to `base=0`, the address becomes a bare
  immediate (`0x38`, `0xb0`, `0x128`, `0x1a0`), `readable()` fails, and the use is dropped
- or four zero dwords are published as a V# that **shadows a real descriptor** under first-match-wins

**This function already encodes the correct bound ~180 lines below**: the push-constant path computes
`fw_user_count = min(user_count, kUserSgprs)` and explicitly skips a fold result whose `base_sgpr` lands in
`[user_count, 31]`, with a comment saying why indexing past the block would be wrong. The fold call had
simply never been given that bound, so two parts of one function disagreed about which registers exist.

## The change

Three functional lines: seed `min(user_count, kUserSgprs)` in the production call and in the
`PROSPER_DYNTRACE_FAIL` diagnostic. Everything else in the diff is comments.

The diagnostic is changed deliberately. A trace seeded differently from the path it exists to explain
reports a resolution the executor never had — which is how this stayed invisible: **the trace and production
agreed with each other while both over-claimed.**

## Measured, PPSA04263 (GTA V), committed Story-Mode route, same build

```
                             before    after
base=0x0 AND base_ok=1        1988      1696    <- -292: the fold stops claiming what it does not know
descriptor addr unreadable     475       473
[compute] skip lines            54        54    <- UNCHANGED
distinct skipped programs       52        52    <- UNCHANGED
```

**The lever demonstrably moves and the outcome does not.** That asymmetry is the point of including both
rows: had the change been inert (wrong path, misread `user_count`, never reached), the first row would also
have been unchanged and "no improvement" would have been indistinguishable from "the experiment never ran."

## Why land it anyway

1. **It removes an internal inconsistency** — the same bound is already computed and enforced elsewhere in
   the same function.
2. **The false claims actively misled an investigation.** 1,988 `base=0x0 base_ok=1` readings look exactly
   like a smoking gun for a black world and are not one. A fold that asserts knowledge of undefined
   registers will mislead the next reader the same way; I have the issue comments to prove it misled this one.
3. **It makes a diagnostic honest** about what production sees.

## Against

It touches shared renderer code used by every title, for no measured behavioural gain. The risk direction is
under-seeding: if `user_count` were decoded wrongly we would lose real resolutions rather than false ones.
Mitigating that, the field is the hardware's own declaration and the identical bound is already trusted by
the push-constant path in this function.

## Also in this diff: a stale comment removed, with a note about what it cost

A comment asserted that compute dispatches "only run `build_shader_resources` ... and NEVER the const-fold
`resolve_dynamic_fetch` that graphics stages use". That has been false since `add_compute_buffer_resources`
landed — the compute table build calls it, and it calls `resolve_dynamic_fetch` directly.

I read that comment, cited it with a `file:line` as the mechanism behind GTA V's black world, and published
"the fold is never run for compute, so run it" as the fix — for a fold that had been running the whole time.
I have retracted that on #590 and #2412. The replacement comment records the episode rather than quietly
deleting the text, because a stale comment reads as verified fact precisely because it sits next to the code
it describes.

## Verification

```
ctest --test-dir prosper/build-linux --no-tests=error -j4
  230/230 tests passed
```

Control, live renderer, Linux/AMD: **The Messenger (PPSA24651)** renders its intro cutscene in full colour
(1920x1080, PEAK=255, 9.28% coverage, sprites/moon/text all correct) with **0 compute skips** — unchanged.

`git diff --check` clean. No `Claude-Session:` trailers (gate returns 0).

Refs #590
