### PR TITLE
fix(gpu): let the 64-bit scalar fold read VCC's high half

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2645,7 +2645,24 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     case 0x1F: case 0x21: {  // s_lshl_b64 / s_lshr_b64
                         uint32_t ahi = 0;
                         bool khi = false;
-                        if (in.src[0].kind == OperandKind::SGPR)
+                        // VCC as a 64-bit SOURCE reaches here as Special(106), not SGPR — the same
+                        // asymmetry `srcval` documents above (":2314"): vcc_lo/hi are WRITTEN as SGPR
+                        // 106/107 and READ BACK as Specials with the same field value. `srcval`
+                        // already maps the LOW half onto val[106]; this high-half read did not, so
+                        // `s_lshl_b64 vcc, vcc, N` resolved its low dword and then bailed on the
+                        // high one — two halves of one handler disagreeing about whether VCC is
+                        // addressable.
+                        //
+                        // Only base 106 is accepted. A 64-bit operand names its LOW register, so
+                        // VCC is 106:107; a base of 107 would index 108, which is not the pair's
+                        // high half and is not a valid scalar key.
+                        //
+                        // This does not widen what may be folded: `known()` still has to have a
+                        // value for 107, and returns false if the high dword was never tracked, in
+                        // which case the handler bails exactly as before. It only stops the lookup
+                        // failing for a register the fold demonstrably tracks. (#2412)
+                        if (in.src[0].kind == OperandKind::SGPR ||
+                            (in.src[0].kind == OperandKind::Special && in.src[0].value == 106))
                             khi = known(in.src[0].value + 1, ahi);
                         else if (in.src[0].kind == OperandKind::InlineInt) {
                             ahi = in.src[0].value < 0 ? UINT32_MAX : 0u;
@@ -2677,7 +2694,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // an SGPR number. And an UNTRACKED high dword must not silently fold as 0: if the
                         // field reaches bits >= 32 the result is unknown.
                         bool khi;
-                        if (in.src[0].kind == OperandKind::SGPR)           khi = known(in.src[0].value + 1, ahi);
+                        // Special(106) = VCC read back as a 64-bit source; see the note on the
+                        // s_lshl_b64/s_lshr_b64 handler above for why this is not an SGPR here.
+                        if (in.src[0].kind == OperandKind::SGPR ||
+                            (in.src[0].kind == OperandKind::Special && in.src[0].value == 106))
+                                                                          khi = known(in.src[0].value + 1, ahi);
                         else if (in.src[0].kind == OperandKind::InlineInt) { ahi = in.src[0].value < 0 ? 0xFFFFFFFFu : 0u; khi = true; }
                         else                                               { ahi = 0; khi = true; }   // 32-bit literal
                         if (!khi && wid != 0 && off + wid > 32) { ok = false; wrote_pair = true; break; }


### PR DESCRIPTION
## The defect: one handler disagrees with itself

`srcval` documents the asymmetry at `gpu_executor.cpp:2314` — `vcc_lo`/`vcc_hi` are **written** as SGPR 106/107 and **read back** as `Special` operands with the same field value — and maps the **low** half onto `val[106]` accordingly.

The high-half reads in the `s_lshl_b64`/`s_lshr_b64` (`:2649`) and `s_bfe_u64` (`:2680`) handlers check `kind == SGPR` only. So `s_lshl_b64 vcc, vcc, N` resolves its low dword through `srcval` and then bails on the high one — the same instruction, two different answers about whether VCC is addressable.

Other sites in this file (`:2284`, `:2320`, `:2331`) already handle `Special` alongside `SGPR`; these two were the outliers.

## Scope and safety

**Only base 106 is accepted.** A 64-bit operand names its **low** register, so VCC is 106:107; a base of 107 would index 108, which is not the pair's high half and is not a valid scalar key.

**This does not widen what may be folded.** `known()` must still have a value for 107 and returns false when the high dword was never tracked — in which case the handler bails exactly as before. The change only stops the *lookup* failing for a register the fold demonstrably tracks.

## What this is NOT

**It is not evidence about GTA V's black world, and I am not presenting it as such.**

I found it following that chain — the failing site is `s_add_u32 s60, s36, vcc_lo` at `pc=1545`, fed by `s_lshl_b64 vcc, vcc, 7` at `1544` — and I measured before/after:

| marker | master | with fix |
| --- | --- | --- |
| `smem-reject` | 21 | 21 |
| `mubuf-raw-unresolved` | 536 | 535 |
| `recompile-reject` | 1089 | 1086 |

**Those numbers are not comparable and should not be read.** The fix run ended at 3900 frames still at **64 fps**; the baseline collapsed to **0.1 fps** at 3960 on entering gameplay. The two runs sampled **different phases**, so the counts describe different workloads. The effect on this title is **unknown**.

A valid measurement needs both runs to reach the gameplay collapse. I would rather say that than publish a difference that looks like a result.

## Basis for landing

Internal consistency only — the same basis as #2430: one function should not disagree with itself about which registers exist. Reject it if that is not sufficient grounds for touching shared executor code; that is a reasonable position.

## Verification

`cmake --build prosper/build-app -j6 --target prosper-app` — exit 0. `git diff --check` clean.

Refs #2412