### PR TITLE
diag(gpu): identify the program on every sgprwatch line

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2035,8 +2035,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         return w ? (int)strtol(w, nullptr, 0) : -1;
     }();
     auto set_value = [&](int r, uint32_t v) {
+        // `sh=` identifies WHICH PROGRAM this transition belongs to, derived exactly as the reject
+        // lines derive it (first code dword + span; rdna2_to_spirv.cpp:14974). Without it the watch
+        // is a bare register number across every program folded in the run, and register numbers are
+        // program-local — so two lanes tracing "s16" can legitimately observe different registers and
+        // reach contradictory conclusions about the same chain. That happened: a Windows trace of s16
+        // showed ZERO forget sites while the Linux fold attributed the loss of the descriptor-table
+        // pointer to a v_cmp writing s16, and neither observation was wrong. (#2412)
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] pc=%u s%d <- KNOWN 0x%08x\n", watch_pc, r, v);
+            fprintf(stderr, "[sgprwatch] sh=%08x/%zu pc=%u s%d <- KNOWN 0x%08x\n",
+                    dwords ? code[0] : 0u, dwords, watch_pc, r, v);
         if (valid_reg(r)) {
             val[(size_t)r] = v;
             val_known.set((size_t)r);
@@ -2048,8 +2056,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     };
     auto forget = [&](int r) {
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] pc=%u s%d <- FORGOTTEN words=%08x:%08x len=%u\n",
-                    watch_pc, r, watch_w0, watch_w1, watch_len);
+            fprintf(stderr, "[sgprwatch] sh=%08x/%zu pc=%u s%d <- FORGOTTEN words=%08x:%08x len=%u\n",
+                    dwords ? code[0] : 0u, dwords, watch_pc, r, watch_w0, watch_w1, watch_len);
         if (valid_reg(r)) {
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);


### PR DESCRIPTION
`PROSPER_DYNTRACE_SGPR` watches one scalar register across **every program the run folds**, and register numbers are **program-local**. A bare `s16` in the log is therefore ambiguous: two readers tracing the same register number can legitimately observe different registers in different programs and reach contradictory conclusions about one chain.

`sh=` is derived exactly as the reject lines derive it — first code dword plus span (`rdna2_to_spirv.cpp:14974`) — and `resolve_dynamic_fetch` already has both `code` and `dwords` in scope, so this needs no plumbing.

**This is the same fix `f8ab0570` applied to `[recompile-reject]`, for the same reason, one diagnostic later.**

## How it was found, stated accurately

I hit a contradiction between a Windows `s16` trace and the Linux fold's attribution of #2412's chain, and assumed the missing program filter explained it.

**It did not.** My trace was simply broken — 101 lines where a comparable register in the same session produced 168,661 — and the contradiction evaporated on re-run. The ambiguity this PR fixes is real and was already understood; it just was not the cause of that particular confusion, and I would rather the commit say so than imply this resolved something.

## Scope

Diagnostic only, behind the existing `PROSPER_DYNTRACE_SGPR` gate. No behaviour change; both sgprwatch `fprintf`s gain the same field.

## Verification

`cmake --build prosper/build-app -j6 --target prosper-app` — exit 0. Live route emits e.g. `[sgprwatch] sh=befc0300/44 pc=… s16 <- FORGOTTEN …`, with 8 distinct programs touching s16 in one run — which is precisely the ambiguity the field removes.

Refs #2412