### PR TITLE
fix(gpu): const-fold s_movk_i32 instead of discarding it — 2 GTA V compute programs leave the failing set

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3550,9 +3550,30 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 }
                 break;
             case Rdna2Format::SOPK:
+                // s_movk_i32 (op 0x00) is `SDST = signext(SIMM16)` — a compile-time constant, and the one
+                // SOPK this fold has direct evidence it must not discard. Measured on PPSA04263 (GTA V) at
+                // gameplay, a single register watch (`PROSPER_DYNTRACE_SGPR=16`) reports **66,507** forgets
+                // of s16 to this encoding — `b0100092` = `s_movk_i32 s16, 0x92`, round-trip-decoded with
+                // llvm-mc gfx1030 against a positive control, not read off a table. Forgetting a literal
+                // assignment is pure loss: the value is in the instruction.
+                //
+                // It also does NOT write SCC. The comment below already said so and the code invalidated
+                // SCC anyway, which is safe but costs every later s_cselect that depended on a live SCC.
+                //
+                // Deliberately ONE opcode. The rest of the format stays exactly as before — conservative
+                // and correct — because s_addk_i32/s_cmpk_* genuinely do write SCC, and a stale SCC
+                // consumed by a later s_cselect fabricates a confidently-wrong V# patch. Widening this
+                // needs its own evidence per opcode; the sibling ops are not free just because they are
+                // adjacent in the encoding.
+                if (in.opcode == 0x00) {                         // s_movk_i32: constant, no SCC write
+                    if (in.dst.kind == OperandKind::SGPR)
+                        set_value(in.dst.value, (uint32_t)(int32_t)in.simm16);
+                    break;
+                }
                 // s_cmpk_* / s_addk_i32 write SCC (only s_movk/s_version/s_cmovk/s_mulk don't); this
-                // interpreter doesn't model SOPK, so ANY SOPK conservatively invalidates the tracked SCC —
-                // a stale SCC consumed by a later s_cselect would fabricate a confidently-wrong V# patch.
+                // interpreter doesn't model the rest of SOPK, so they conservatively invalidate the
+                // tracked SCC — a stale SCC consumed by a later s_cselect would fabricate a
+                // confidently-wrong V# patch.
                 scc = -1;
                 if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);
                 break;


### PR DESCRIPTION
## The defect

The scalar const-fold has **no SOPK model**. Every SOPK instruction invalidated SCC and forgot its
destination:

```cpp
case Rdna2Format::SOPK:
    // s_cmpk_* / s_addk_i32 write SCC (only s_movk/s_version/s_cmovk/s_mulk don't); this
    // interpreter doesn't model SOPK, so ANY SOPK conservatively invalidates the tracked SCC
    scc = -1;
    if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);
```

`s_movk_i32` is `SDST = signext(SIMM16)` — a **compile-time constant** — and it does not write SCC. The
comment above already said so, and the code discarded it anyway. Forgetting a literal assignment is pure
loss: the value is in the instruction.

## Evidence it matters

One register watch on `PPSA04263` (GTA V) at gameplay, `PROSPER_DYNTRACE_SGPR=16`:

```
66,507 forgets of s16 to encoding b0100092
```

Round-trip-decoded with `llvm-mc -mcpu=gfx1030` **against a positive control**, not read off a table:

```
CONTROL:  850b6a0b -> s_cselect_b32 s11, s11, vcc_lo     (method verified)
SUBJECT:  b0100092 -> s_movk_i32 s16, 0x92
```

## Measured — like-for-like A/B, both arms from the same instrument

Same binary lineage, same route, same command, same grep. Set comparison of failing compute programs
(membership, not counts — counts track how far the route ran, per the analysis on #2412):

```
                          master      with fix
failing compute programs      53            51
s_movk forgets (lever)    62,625             0
fps profile          n=145 13.4-166.4  n=148 13.4-178.1

FIXED        : 413cf9000, 413d88c00     (2 programs)
NEW failures : none
overlap      : 51
```

**The lever fires in both directions** — 62,625 forgets on master, 0 with the fix — so the change is
demonstrably responsible rather than incidentally correlated. **The 51-program overlap is its own control**:
had program addresses been run-local, overlap would have been near zero and the method would have announced
its own invalidity instead of producing a plausible number.

## Scope — deliberately one opcode

`s_addk_i32` and `s_cmpk_*` genuinely **do** write SCC, and a stale SCC consumed by a later `s_cselect`
fabricates a confidently-wrong V# patch. The rest of the format keeps its conservative handling unchanged.
Adjacent encodings are not free just because they sit next to each other in the table; widening this needs
its own per-opcode evidence.

## What this does NOT do

**It does not make GTA V's world render.** 51 of 53 programs still fail, on the descriptor-resolution
frontier described in #2412. This is 2 programs and a real but small step.

Single run per arm. The overlap of 51 and the zero new failures are the stability evidence; run-to-run
determinism of the specific 2 is not separately established.

## Verification

```
ctest --test-dir prosper/build-linux --no-tests=error -j4
  230/230 tests passed
```

`git diff --check` clean. No `Claude-Session:` trailers (gate returns 0). 23 insertions, 2 deletions, one
file.

Refs #2412
