### PR TITLE
diag(gpu): a fragment ballot must not report itself as a vote

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -612,7 +612,11 @@ struct SpirvCompute {
             declared_subgroup_ballot = true;
         }
         fragment_required_subgroup_size = wave_size;
-        fragment_wave_reasons |= kFragmentWaveReasonWaveAny;
+        // Ballot, not vote: the reason bit must say which, because only one of the two can ever be
+        // relaxed to a narrower subgroup and the skip diagnostic is where that question gets asked
+        // (#2441). This records the same width as before -- the gate keys on
+        // fragment_required_subgroup_size, not on the reason -- so behaviour is unchanged.
+        fragment_wave_reasons |= kFragmentWaveReasonWaveBallot;
         const uint32_t ballot = id();
         put(code, Op_GroupNonUniformBallot,
             {t_v4u(), ballot, uconst(Scope_Subgroup), mask_bit});

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -295,11 +295,18 @@ uint32_t fragment_spirv_required_subgroup_size(const std::vector<uint32_t>& spir
 //
 // These name the emitter path that raised the contract. A module may set several.
 inline constexpr uint32_t kFragmentWaveReasonLaneId     = 1u << 0;  // lane id from SubgroupLocalInvocationId
-inline constexpr uint32_t kFragmentWaveReasonWaveAny    = 1u << 1;  // OpGroupNonUniformAny (guard AND reduce)
+inline constexpr uint32_t kFragmentWaveReasonWaveAny    = 1u << 1;  // OpGroupNonUniformAny (vote)
 inline constexpr uint32_t kFragmentWaveReasonDppRow16   = 1u << 2;  // DPP row, needs >= 16
 inline constexpr uint32_t kFragmentWaveReasonPermLane32 = 1u << 3;  // PERMLANEX16, needs >= 32
 inline constexpr uint32_t kFragmentWaveReasonReadLane64 = 1u << 4;  // V_READLANE_B32 across a wave64
 inline constexpr uint32_t kFragmentWaveReasonShuffle    = 1u << 5;  // lane-addressed shuffle
+// OpGroupNonUniformBallot. Separate from WaveAny because the two have OPPOSITE prospects under a
+// wave32 lowering, which is the same distinction #2147 drew between lane-id and vote and the same
+// reason it drew it (#2441). A ballot's bits become guest scalar DATA -- half a mask reported as
+// whole is silently wrong -- so its width requirement can never be relaxed, whereas a vote's may
+// be. Reporting both as "wave-any" made the recoverable and unrecoverable cases one number: on
+// PPSA04263 that number was 68 of 112 skipped fragment shaders, with no way to ask how it divides.
+inline constexpr uint32_t kFragmentWaveReasonWaveBallot = 1u << 6;  // OpGroupNonUniformBallot (reduce)
 
 // Reasons recorded by the emitter, or UINT32_MAX when the module carries no reason marker at
 // all (built, cached or captured before #2147). Absent must not read as none.

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -4370,6 +4370,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         {prosper::gpu::kFragmentWaveReasonPermLane32, " permlane32"},
                         {prosper::gpu::kFragmentWaveReasonReadLane64, " readlane64"},
                         {prosper::gpu::kFragmentWaveReasonShuffle,    " shuffle"},
+                        {prosper::gpu::kFragmentWaveReasonWaveBallot, " wave-ballot"},
                     };
                     for (const auto& entry : kReasonNames)
                         if ((why & entry.bit) && n > 0 && n < static_cast<int>(sizeof why_text))

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -937,6 +937,71 @@ int main() {
     }
     printf("  [ok]   fragment private spill/fill emits structurally valid Function storage\n");
 
+    // #2441: the fragment skip diagnostic must say WHICH cross-lane form raised the wave64 contract,
+    // because the two have opposite prospects under a wave32 lowering. A vote MAY be width-agnostic
+    // (two 32-lane votes union to the same executed-pixel set); a ballot never is, since its bits
+    // become guest scalar DATA and half a mask reported as whole is silently wrong -- which
+    // rdna2_to_spirv.cpp's own comment on fragment_wave_ballot_half already says. Both used to set
+    // kFragmentWaveReasonWaveAny, so the recoverable and unrecoverable cases were a single number:
+    // on PPSA04263, 68 of 112 skipped fragment shaders, with no way to ask how it divides.
+    //
+    // s_quadmask_b64 vcc, vcc (0xbeea2d6a) is the ballot path. It reads VCC as a mask, so the v_cmp
+    // ahead of it is load-bearing: without a real per-lane bool in VCC the lowering takes no ballot.
+    const uint32_t quadmask_fragment[] = {
+        0x7e020280u,              // v_mov_b32 v1, 0
+        0x7c2200f0u,              // v_cmp_* -> VCC (per-lane bool)
+        0xbeea2d6au,              // s_quadmask_b64 vcc, vcc
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u, // exp mrt0 v0,v1,v2,v3
+        0xbf810000u,
+    };
+    const auto quadmask_spv = recompile_fragment(quadmask_fragment, std::size(quadmask_fragment));
+    if (quadmask_spv.empty()) {
+        printf("  [FAIL] fragment s_quadmask_b64 did not recompile\n");
+        return 1;
+    }
+    const uint32_t quadmask_reasons = fragment_spirv_required_subgroup_reasons(quadmask_spv);
+    if (quadmask_reasons == UINT32_MAX) {
+        printf("  [FAIL] fragment s_quadmask_b64 module carries no wave-reason marker\n");
+        return 1;
+    }
+    // The arm that fails without the split: before it, nothing ever set WaveBallot.
+    if (!(quadmask_reasons & prosper::gpu::kFragmentWaveReasonWaveBallot)) {
+        printf("  [FAIL] s_quadmask_b64 reported its wave64 contract as a vote, not a ballot "
+               "(reasons=0x%x)\n", quadmask_reasons);
+        return 1;
+    }
+    // The width itself must be unchanged: this split is diagnostic, not a behavioural relaxation.
+    if (fragment_spirv_required_subgroup_size(quadmask_spv) != 64) {
+        printf("  [FAIL] ballot module stopped advertising its exact wave64 requirement\n");
+        return 1;
+    }
+    printf("  [ok]   s_quadmask_b64 records a BALLOT reason, distinct from a vote, still wave64\n");
+
+    // The other direction, so that moving the wrong call site cannot pass: a module whose only
+    // cross-lane form is a branch-guard vote must NOT claim a ballot raised its contract.
+    const uint32_t execz_vote_fragment[] = {
+        0x7e020280u,              // v_mov_b32 v1, 0
+        0x7c2200f0u,              // v_cmp_* -> VCC
+        0xbf880002u,              // s_cbranch_execz +2  (routes through the fragment wave vote)
+        0xbe8503f2u, 0x7e020205u,
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    const auto execz_vote_spv =
+        recompile_fragment(execz_vote_fragment, std::size(execz_vote_fragment));
+    if (!execz_vote_spv.empty()) {
+        const uint32_t vote_reasons = fragment_spirv_required_subgroup_reasons(execz_vote_spv);
+        if (vote_reasons != UINT32_MAX &&
+            (vote_reasons & prosper::gpu::kFragmentWaveReasonWaveBallot)) {
+            printf("  [FAIL] a vote-only fragment module claimed a ballot (reasons=0x%x)\n",
+                   vote_reasons);
+            return 1;
+        }
+        printf("  [ok]   a vote-only fragment module does not claim a ballot\n");
+    }
+
     // Astro Bot's Wave32 graphics shaders save/copy/restore active-lane masks through the low
     // halves of EXEC and VCC.  These are the B32 equivalents of the B64 mask moves already modeled
     // below, not scalar-data transfers: treating EXEC_LO as ordinary data rejected the entire draw.


### PR DESCRIPTION
Fixes #2441
Refs #2429

## The failure scenario

The fragment subgroup-size skip decodes **why** a module requires its exact guest-wave width (#2147), so that a shader needing 64 for lane **identity** — which can never run at 32, because `SubgroupLocalInvocationId` *is* the guest lane id — stops printing identically to one needing it only for a branch-guard **vote**, which may be width-agnostic (two 32-lane votes union to the same executed-pixel set).

That split was drawn and it works. But the other bit still merged two cases just as far apart:

| emitter | SPIR-V op | reason bit set (before) | can its width ever be relaxed? |
| --- | --- | --- | --- |
| `fragment_wave_any` (`rdna2_to_spirv.cpp:578`) | `OpGroupNonUniformAny` | `WaveAny` | **maybe** — open question |
| `fragment_wave_ballot_half` (`:604`) | `OpGroupNonUniformBallot` | `WaveAny` | **never** |

The second row's own comment (`:601-603`) states the opposite conclusion in the strongest terms available: *"This is a REDUCE in #2410's taxonomy — the bits become guest scalar DATA — so the wave64 requirement it records must NOT be relaxed to a narrower subgroup: half a mask reported as whole is silent wrong data."* The bit declaration admitted the conflation in words (`rdna2_to_spirv.hpp:298`: `// OpGroupNonUniformAny (guard AND reduce)`), and the name was wrong independently of the roles, since `Ballot` is not `Any`.

**The cost is that the recoverable and the unrecoverable cases were a single number.** Measured on *Grand Theft Auto V* (`PPSA04263`), Windows/NVIDIA, master `d10da190`, a run reaching gameplay:

```
 11  why=0x1 lane-id
 68  why=0x2 wave-any        <- this bucket
 33  why=0x3 lane-id wave-any
112  distinct fragment shaders skipped
```

68 of 112, with no instrument in the tree able to say how it divides. That is why #2429 had no cost estimate.

## The behavioural contract, and what is deliberately unchanged

`kFragmentWaveReasonWaveBallot = 1u << 6` is added; `fragment_wave_ballot_half` sets it instead of `WaveAny`; `render_runner.h`'s decode table prints ` wave-ballot`.

**This is diagnostic only and changes no rendering behaviour.** The skip gate at `tests/render_runner.h:4331` keys on `required_fragment_subgroup_size` and the `kFragmentSubgroup*` capability bits, and never reads the reason bits — they exist solely to explain a decision already made. The ballot module still advertises the same exact wave64 requirement it always did; the test asserts that explicitly, so a future change that relaxed the width while renaming the reason would fail here.

**Deliberately NOT attempted:** separating guard from reduce *within* `OpGroupNonUniformAny`. That role is decided by the consumer — several of the ten `fragment_wave_any` call sites assign `rs.scc`, which may then be branched on (guard) *or* read as data (reduce) — so it needs the #2410 criterion applied as dataflow, not a per-call-site label. Bundling it here would have turned a mechanical change into a judgement call about wave semantics.

## Verification (exact head `f5bd8153`, Windows/NVIDIA)

**The new arm fails without the fix.** With `fragment_wave_ballot_half` temporarily restored to setting `WaveAny`:

```
[FAIL] s_quadmask_b64 reported its wave64 contract as a vote, not a ballot (reasons=0x3)
exit 1
```

`0x3` is `LaneId|WaveAny` — no ballot bit anywhere. With the fix:

```
[ok]   s_quadmask_b64 records a BALLOT reason, distinct from a vote, still wave64
[ok]   a vote-only fragment module does not claim a ballot
== PASS ==
```

The second arm is the mis-edit guard: a module whose only cross-lane form is a vote must not claim a ballot, so moving the wrong call site cannot pass.

```
cmake --build build-rwdi -j6                  exit 0, 0 errors
ctest --no-tests=error -j4                    179/180 passed
  rdna2_spirv_struct  (#142)                  Passed  0.21 s
```

### The one failing test, and why this diff provably cannot reach it

`build_revision_refresh` (#17) fails with `0xC0000005` inside a generated `revision_query.exe`. That executable is built by `prosper/tools/revision/test_build_revision.py` into its own scratch CMake project and links **`test_build_revision` only — never `prosper_core`** (`test_build_revision.py:59-60`), while this diff touches `prosper_core` sources and two test translation units. There is no path from one to the other. Its history is also a run of Windows-specific repairs to this same test (#2148, #2232, #2326).

I am reporting it rather than filtering it out, and I have **not** reproduced it on a clean master — the claim here is reachability, not a baseline comparison.

### Test placement

The assertions live in `test_rdna2_spirv_struct` rather than `test_recompiled_fragment`, because the whole Vulkan render-test block is `if(UNIX)`-gated (`CMakeLists.txt:1283`) and so cannot build on Windows at all. The behaviour under test is SPIR-V metadata, needs no device, and now runs on every platform including the one that measured the problem.

## Risks

- **New reason bit in a persisted marker.** `fragment_spirv_required_subgroup_reasons` reads reasons back from non-semantic module metadata, so cached or captured modules built before this change report the old encoding. That is already handled by the existing contract — absent reads as `UINT32_MAX`, not as none (`rdna2_to_spirv.hpp:304-305`) — and bit 6 was previously unused, so an old module can never spuriously appear to claim a ballot.
- **Diagnostic strings are matched by tooling.** ` wave-ballot` is a new token in the skip line. Anything grepping for `wave-any` to count ballot cases will now under-count — which is the point of the change, and the census above is the number that should be re-derived rather than carried over.

## Review

Requested from the Linux lane. The judgement worth challenging is not the bit split but the framing: whether `fragment_wave_ballot_half` is genuinely always a reduce (its own comment says so; I did not re-derive it), and whether leaving the guard/reduce question inside `OpGroupNonUniformAny` untouched is the right seam to stop at.
