### PR TITLE
diag(pad): say so when a route parses to zero entries

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -165,6 +165,17 @@ public:
             if (!error.empty()) log_error(error);
             fprintf(stderr, "[pad] live route reload enabled for %s\n", path_.string().c_str());
         }
+        // A route that loaded without error and still parsed to zero entries is configured-but-inert,
+        // and it used to be indistinguishable from a working one (#2439). The symptom is a title that
+        // sits on its first screen, which reads as a title or emulator defect and sends the reader
+        // after the guest. One measured instance: a 300 s GTA V run reached 13,320 frames at a
+        // sustained 62 fps with no phase change, because the route was passed without its leading '@'
+        // and was therefore parsed as an INLINE route that yields nothing.
+        if (initial_load_succeeded) {
+            const std::string warning =
+                pad_script_empty_route_warning(source_, script_.empty());
+            if (!warning.empty()) fprintf(stderr, "%s\n", warning.c_str());
+        }
     }
 
     bool configured() const { return !source_.empty(); }

--- a/prosper/src/input/pad.cpp
+++ b/prosper/src/input/pad.cpp
@@ -289,6 +289,22 @@ std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::stri
     return parse_pad_script(contents.str());
 }
 
+std::string pad_script_empty_route_warning(const std::string& source, bool parsed_empty) {
+    if (!parsed_empty || source.empty()) return {};
+    // Windows spellings fail the same way and are the reason this tests for separators rather than
+    // for a missing ':' -- "C:/route.pad" DOES contain a colon, so it parses as a seconds anchor of
+    // "C", fails the numeric check, and is dropped just as silently as a path with no colon at all.
+    const bool looks_like_path =
+        source[0] != '@' &&
+        (source.find('/') != std::string::npos || source.find('\\') != std::string::npos ||
+         (source.size() >= 4 && source.compare(source.size() - 4, 4, ".pad") == 0));
+    std::string out =
+        "[pad] PROSPER_PAD_SCRIPT parsed 0 entries; no input will ever be delivered";
+    if (looks_like_path)
+        out += " -- this looks like a file path, so prefix it with '@' to load it as a file";
+    return out;
+}
+
 PadScriptState pad_script_state_at(const std::vector<PadScriptEntry>& script, double elapsed_secs,
                                    double hold_secs, int64_t frame_count, int64_t frame_hold,
                                    int64_t read_count, int64_t read_hold) {

--- a/prosper/src/input/pad.hpp
+++ b/prosper/src/input/pad.hpp
@@ -230,6 +230,17 @@ std::vector<PadScriptEntry> parse_pad_script(const std::string& spec);
 // paths use the process working directory. Returns an empty vector and describes file I/O errors.
 std::vector<PadScriptEntry> load_pad_script(const std::string& source, std::string* error = nullptr);
 
+// Diagnostic for a route that loaded WITHOUT error and still parsed to zero entries (#2439). Such a
+// route is configured-but-inert, and it used to announce itself exactly as a working route does:
+// parse_pad_script drops every unparseable token silently, so the only output is the frame-0 neutral
+// line that a correctly-loaded route ALSO emits before its first press window opens. "Route loaded,
+// first press is still 500 flips away" and "route never existed" printed identically.
+//
+// Returns the text to log, or "" when the route has entries and nothing needs saying. The '@' hint is
+// added only when `source` looks like a file path, so an intentionally empty inline route is reported
+// without being told it meant something else.
+std::string pad_script_empty_route_warning(const std::string& source, bool parsed_empty);
+
 // Full scripted controller state now. Active entries combine buttons and full-deflection stick
 // directions; opposing directions on one axis cancel to an explicitly centered axis.
 PadScriptState pad_script_state_at(const std::vector<PadScriptEntry>& script, double elapsed_secs,

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -359,6 +359,43 @@ int main() {
               (SCE_PAD_BUTTON_LEFT | SCE_PAD_BUTTON_SQUARE | SCE_PAD_BUTTON_R1),
               "names: recorded text round-trips through parser");
 
+        // #2439: a route that parses to ZERO entries is configured-but-inert, and used to print
+        // exactly what a working route prints before its first press window opens. First the
+        // MECHANISM, because it is the part that makes the warning necessary: a bare path is parsed
+        // as an INLINE route, and yields nothing while reporting no error at all.
+        std::string route_err = "unset";
+        const auto path_as_inline =
+            load_pad_script("prosper/scripts/gta5/reach-story-mode.pad", &route_err);
+        CHECK(path_as_inline.empty() && route_err.empty(),
+              "route: a path without '@' parses as an inline route -> 0 entries, NO error");
+        // The Windows spelling has a ':' and still yields nothing, so a colon check would not catch it.
+        CHECK(load_pad_script("C:/routes/reach-story-mode.pad").empty(),
+              "route: a drive-lettered path without '@' also yields 0 entries");
+
+        // Then the warning itself. Without it, each of these is silent.
+        CHECK(pad_script_empty_route_warning("prosper/scripts/gta5/reach-story-mode.pad", true)
+                  .find("prefix it with '@'") != std::string::npos,
+              "route: an empty path-shaped route says it should have been '@'-prefixed");
+        CHECK(pad_script_empty_route_warning("C:\\routes\\x.pad", true)
+                  .find("prefix it with '@'") != std::string::npos,
+              "route: the backslash spelling gets the same hint");
+        CHECK(pad_script_empty_route_warning("route.pad", true)
+                  .find("prefix it with '@'") != std::string::npos,
+              "route: a bare .pad filename gets the hint even with no separator");
+        // An '@' source that is empty is a real (if odd) request, not a spelling mistake: warn that
+        // nothing will be delivered, but do not tell the author to add an '@' they already wrote.
+        const std::string at_warning = pad_script_empty_route_warning("@empty.pad", true);
+        CHECK(!at_warning.empty() && at_warning.find("prefix it with '@'") == std::string::npos,
+              "route: an empty @file route warns without suggesting the '@' it already has");
+        CHECK(pad_script_empty_route_warning("f600-620:cross", true).find("0 entries") !=
+                  std::string::npos,
+              "route: an empty inline route still warns that no input will be delivered");
+        // The case that must stay silent: a route with entries.
+        CHECK(pad_script_empty_route_warning("f600-620:cross", false).empty(),
+              "route: a route that parsed entries says nothing");
+        CHECK(pad_script_empty_route_warning("", true).empty(),
+              "route: an unset PROSPER_PAD_SCRIPT says nothing");
+
         PadRecordState flip_record;
         CHECK(flip_record.observe(9, 0).empty(), "record: initial neutral flip emits nothing");
         CHECK(flip_record.observe(10, SCE_PAD_BUTTON_CROSS).empty(),


### PR DESCRIPTION
Fixes #2439

## The failure scenario

`PROSPER_PAD_SCRIPT` takes an inline route, or an `@`-prefixed file (`src/input/pad.cpp:276` — the `@` is what selects file mode). Passed a **bare path**, it parses the path string itself as an inline route: a path has no `:`, so it dies at `parse_pad_script`'s colon check (`pad.cpp:205`). Every unparseable token is dropped with a bare `continue` and nothing is reported, so the result is an **empty route with no error** — while `configured()` still returns true, because it tests that the env var was set, not that the route has entries (`src/hle/hle_pad.cpp:170`).

With `PROSPER_PAD_SCRIPT_LOG=1` an empty route then emits exactly one line:

```
[pad-script] elapsed=0.000 frame=0 read=0 buttons=neutral
```

which is **byte-identical** to what a correctly loaded route emits before its first press window opens. *"Route loaded, first press is still 500 flips away"* and *"route never existed"* were the same output.

**The symptom is a title sitting on its first screen** — which reads as a title or emulator defect and sends the reader after the guest, not after the harness. Measured instance: a 300 s *Grand Theft Auto V* run reached **13,320 frames at a sustained 62 fps with no phase change**, because of one missing `@`. Reported as "master no longer reaches gameplay on Windows" it would have been a fabricated regression.

## The change

Warn when a route loads **without error** and still parses to zero entries. The `@` hint is added only when the source looks like a file path, so an intentionally empty inline route is reported without being told it meant something else.

The decision is a pure helper, `pad_script_empty_route_warning(source, parsed_empty)`, rather than inline `fprintf` logic. That is deliberate and is the difference between a testable change and an untestable one: `PadScriptRuntime` is a process-wide singleton constructed once, so its constructor cannot be re-entered per case from a unit test. The helper can be called nine times.

**It tests for separators, not for a missing `:`**, because the obvious check does not work. `C:/route.pad` *does* contain a colon, so it parses as a seconds anchor of `C`, fails `parse_number` at `pad.cpp:239`, and is dropped just as silently as the form with no colon at all. Both spellings are covered by tests.

## Verification (exact head `fcf5e529`, Windows/NVIDIA)

**Unit — 9 new assertions in `pad_input`, covering both what must warn and what must stay silent:**

```
[ok] route: a path without '@' parses as an inline route -> 0 entries, NO error
[ok] route: a drive-lettered path without '@' also yields 0 entries
[ok] route: an empty path-shaped route says it should have been '@'-prefixed
[ok] route: the backslash spelling gets the same hint
[ok] route: a bare .pad filename gets the hint even with no separator
[ok] route: an empty @file route warns without suggesting the '@' it already has
[ok] route: an empty inline route still warns that no input will be delivered
[ok] route: a route that parsed entries says nothing
[ok] route: an unset PROSPER_PAD_SCRIPT says nothing
```

The first two are characterization assertions on `load_pad_script` — they pin the *mechanism* that makes the warning necessary, so a future change that made a bare path load as a file would fail here rather than silently making the hint wrong.

**End to end, both directions, on the exact invocation that caused the incident:**

| `PROSPER_PAD_SCRIPT` | warning | route |
| --- | --- | --- |
| `prosper/scripts/gta5/reach-story-mode.pad` | **fires**, with the `@` hint | 0 entries |
| `@<abs>/prosper/scripts/gta5/reach-story-mode.pad` | **0** — silent | 15 `[pad-script]` lines |

A discriminator that only fired would prove nothing; the silent half is what shows it does not simply warn on every run.

```
cmake --build build-rwdi -j6           exit 0
ctest --no-tests=error -j4             179/180 passed
  pad_input (#66)                      Passed  0.14 s
```

### The one failing test

`build_revision_refresh` (#17), `0xC0000005` in a generated `revision_query.exe`. That executable is built into its own scratch CMake project and links **`test_build_revision` only — never `prosper_core`** (`prosper/tools/revision/test_build_revision.py:59-60`), while this diff touches `prosper_core` and one test translation unit. Its history is a run of Windows-specific repairs to the same test (#2148, #2232, #2326). Same pre-existing failure as #2442; the claim is reachability, and I have **not** reproduced it on a clean master.

## Risks

- **A new line on every run with an empty route.** Intentional, and it is one line at construction, not per poll. A route with entries prints nothing, which the tests assert.
- **Heuristic hint.** `looks_like_path` can in principle fire on an inline route that happens to contain `/` or `\` and parses to nothing — but such a route is *already* broken and already warned about; only the trailing hint sentence would be misleading, and the leading sentence is still correct.
- **Not addressed here:** `configured()` still means "the env var was set" rather than "the route has entries". Changing it alters behaviour for callers and belongs in its own change if wanted; the warning alone converts a silent unarmed run into a loud one, which is what #2439 asked for.

## Review

Requested from the Linux lane. Small and additive, but the judgement worth a second reader is the heuristic: whether `looks_like_path` is the right discriminator, and whether warning on an empty **inline** route (with no hint) is helpful or noise.
