### PR TITLE
fix(win): never emulate an %fs/%gs read as a null-page read — Dragon Quest VII boots on Windows

### DIFF
--- a/prosper/docs/WINDOWS_PORT_HANDOFF.md
+++ b/prosper/docs/WINDOWS_PORT_HANDOFF.md
@@ -259,6 +259,25 @@ that thread waits on becomes the focus, so matching signals from other threads a
 - Windows resets the user `%fs` base to 0 on every kernel transition; guest TLS survives only via the
   VEH `wrfsbase` re-apply (`hle_kernel_mem.cpp`/`guest_tls.cpp`). Native FSGSBASE (`rd/wrfsbase`,
   `WaitOnAddress`, `WakeByAddress*`) works and needs `-lsynchronization` (linked into `prosper_core`).
+  - **That re-apply is fault-driven, so anything that SWALLOWS the fault silently breaks guest TLS.**
+    `PROSPER_NULL_PAGE` did exactly that until #2112: Windows cannot map the reserved bottom 64 KiB, so
+    the VEH emulates a faulting low-address read by zeroing the destination register and stepping over
+    the instruction — and `decode_low_read_dest` treated the `0x64`/`0x65` segment prefixes as ignorable,
+    so a drifted-base `%fs` read looked like a read of a guest null field. The distinction is about
+    meaning, not encoding: with no override the faulting linear address IS what the guest computed, so a
+    sub-64-KiB fault really is a null-field read; with an FS/GS override it is `segbase + offset`, so a
+    low fault means *our* base is wrong and the guest's offset was small. Fixed by declining FS/GS in the
+    decoder; CS/DS/ES/SS stay ignorable because x86-64 forces those bases to zero.
+  - **Do not restate #2112's original diagnosis: it said page 0 is "mapped and readable" on Windows so
+    the `%fs` read *succeeds* and returns zeros.** That is the Linux mechanism. On Windows the read does
+    fault; the null-page *emulator* then answered it. The conclusion ("`PROSPER_NULL_PAGE` and the
+    fault-driven re-apply are mutually incompatible") was right, but the route to it was not — and the
+    route is what tells you where the fix goes. `PROSPER_NULL_PAGE_LOG=1` settles it in one run: a
+    `[nullpage]` line whose rip is the instruction *after* the faulting `%fs` access is the signature.
+  - The symptom does not look like a TLS bug, which is why it cost a title's whole boot: the emulated
+    read succeeds, and the crash lands on the *next* instruction at a nonsense address
+    (`0xfffffffffffffff0` = `[rax-0x10]` with `rax` fabricated to 0), pointing at the guest rather than
+    at us.
 - MinGW `longjmp` does an SEH unwind that can't cross guest/asm frames → use `__builtin_setjmp/longjmp`.
 - `boot_trace` on Windows is nondeterministic-crash-prone ONLY if a diagnostic reads raw stack words —
   the sync-caller scanner is `VirtualQuery`-guarded now; keep any new stack-walk guarded.

--- a/prosper/src/host/x86_read_decode.hpp
+++ b/prosper/src/host/x86_read_decode.hpp
@@ -14,6 +14,19 @@
 // Everything else — 8-bit (0x8A) and 16-bit (0x66-prefixed) partial-register writes, RIP-relative-only
 // oddities aside, any other opcode, and register-source (ModRM.mod==3) forms — returns false so the
 // caller falls through to the normal fault path and never silently mishandles an instruction.
+//
+// %fs/%gs-overridden accesses are declined for a reason that is about MEANING, not encoding (#2112). For
+// every other prefix the faulting linear address IS the address the guest computed, so "it faulted below
+// 64 KiB" really does mean "the guest read a null field" and zeroing the destination reproduces the Linux
+// zero page. With an FS/GS override the linear address is segbase + offset, so a fault below 64 KiB means
+// OUR segment base is wrong — on Windows the kernel zeroes the user FS base at every kernel transition —
+// and the guest's own offset was small, not null. Emulating that read as zero manufactures a value the
+// guest never asked for AND consumes the fault that exec_image_win.cpp's guest_fs_reapply() needs to
+// restore the base and retry. Measured on Dragon Quest VII (PPSA17942) before this change: the guest's
+// `mov rax, %fs:0x0` TCB-self-pointer load was emulated to rax=0 (one `[nullpage] addr=0x0` line), and
+// the next instruction, `cmp BYTE PTR [rax-0x10]`, took a fatal access violation at 0xfffffffffffffff0.
+// CS/DS/ES/SS overrides (0x2E/0x36/0x3E/0x26) stay ignorable: x86-64 forces those bases to zero, so they
+// are genuinely equivalent to no prefix. CONFIDENCE: HIGH.
 #pragma once
 #include <cstdint>
 #include <cstddef>
@@ -33,8 +46,9 @@ inline bool decode_low_read_dest(const uint8_t* p, size_t avail, int* dest_reg, 
         if (!need(1)) return false;
         uint8_t b = p[i];
         if (b == 0x66) { opsize16 = true; i++; continue; }
+        if (b == 0x64 || b == 0x65) return false;   // %fs/%gs: a low fault means a wrong base, not a null read
         if (b == 0x67 || b == 0xF0 || b == 0xF2 || b == 0xF3 ||
-            b == 0x2E || b == 0x36 || b == 0x3E || b == 0x26 || b == 0x64 || b == 0x65) { i++; continue; }
+            b == 0x2E || b == 0x36 || b == 0x3E || b == 0x26) { i++; continue; }
         break;
     }
     if (!need(1)) return false;

--- a/prosper/tests/test_x86_read_decode.cpp
+++ b/prosper/tests/test_x86_read_decode.cpp
@@ -74,6 +74,35 @@ int main() {
     // --- Rejected: truncated instruction (fewer bytes than the encoding needs). ---
     expect_reject("truncated disp8",        {0x48,0x8b,0x42});         // needs a disp8 byte
 
+    // --- Rejected: %fs/%gs-overridden reads (#2112). ---
+    // A low-address fault on a segment-overridden access means OUR segment base is wrong (Windows zeroes
+    // the user FS base at every kernel transition), NOT that the guest read a null field. Emulating it as
+    // zero both fabricates a value and consumes the fault guest_fs_reapply() needs.
+    //
+    // These are the VERBATIM bytes at eboot+0x24d3c30 in Dragon Quest VII Reimagined (PPSA17942) — the
+    // guest's TCB self-pointer load, `mov rax,QWORD PTR fs:0x0`, padded to 12 bytes with three redundant
+    // 0x66 prefixes. On master this decoded to reg=rax/len=12, so the emulator set rax=0 and advanced Rip
+    // to 0x24d3c3c, where `cmp BYTE PTR [rax-0x10],0x0` took a fatal access violation at 0xfffffffffffffff0.
+    expect_reject("DQ7 mov rax,fs:0x0 [66x3]", {0x66,0x66,0x66,0x64,0x48,0x8b,0x04,0x25,0,0,0,0});
+    expect_reject("mov rax,fs:0x0 [canonical]",{0x64,0x48,0x8b,0x04,0x25,0,0,0,0});
+    expect_reject("mov rax,fs:0x28 [canary]",  {0x64,0x48,0x8b,0x04,0x25,0x28,0,0,0});
+    expect_reject("mov rax,gs:0x0",            {0x65,0x48,0x8b,0x04,0x25,0,0,0,0});
+    expect_reject("movzx eax,BYTE fs:(%rsi)",  {0x64,0x0f,0xb6,0x06});
+    expect_reject("mov eax,fs:(%rax) [32-bit]",{0x64,0x8b,0x00});
+
+    // DISCRIMINATOR for the four rejections above: the SAME instruction with the 0x64 removed must still
+    // be ACCEPTED, with the triple-0x66 padding intact and REX.W still overriding it. Without this arm the
+    // rejections could equally be caused by the padding, by the SIB/disp32 form, or by a decoder that had
+    // simply stopped accepting anything — and the test would pass just as loudly while proving nothing.
+    // It fails if the new reject is wider than "has an FS/GS override".
+    expect_ok("same insn, no fs prefix",    {0x66,0x66,0x66,0x48,0x8b,0x04,0x25,0,0,0,0}, 0, 11);
+    // CS/DS/ES/SS overrides must STAY accepted: x86-64 forces those segment bases to zero, so the faulting
+    // linear address really is the address the guest computed and zeroing the destination is still correct.
+    expect_ok("mov rax,ds:(%rdx) [0x3e]",   {0x3e,0x48,0x8b,0x02},                        0, 4);
+    expect_ok("mov rax,cs:(%rdx) [0x2e]",   {0x2e,0x48,0x8b,0x02},                        0, 4);
+    expect_ok("mov rax,ss:(%rdx) [0x36]",   {0x36,0x48,0x8b,0x02},                        0, 4);
+    expect_ok("mov rax,es:(%rdx) [0x26]",   {0x26,0x48,0x8b,0x02},                        0, 4);
+
     if (g_fail) { fprintf(stderr, "test_x86_read_decode: %d failure(s)\n", g_fail); return 1; }
     printf("test_x86_read_decode: all cases passed\n");
     return 0;


### PR DESCRIPTION
Fixes #2112
Refs #1874

## Failure scenario

*Dragon Quest VII Reimagined* (`PPSA17942`) did not boot on Windows at all. It died in the UE4
bootstrap with `ACCESS-VIOLATION at addr=0xfffffffffffffff0 rip=eboot+0x24d3c3c`, **0 frames
rendered**, under both `tools/screenshot` and `prosper-app`. Reproduced on master `6528a43f`.

`PROSPER_NULL_PAGE`, which UE4 titles need, cannot map the reserved bottom 64 KiB on Windows, so
`exec_image_win.cpp` emulates a faulting low-address READ by zeroing the destination register and
stepping over the instruction. `decode_low_read_dest()` skipped `0x64`/`0x65` as ignorable legacy
prefixes, so an `%fs`-relative access qualified as "a read of a guest null field".

## Behavioral contract

It is not one, and the distinction is about **meaning, not encoding**:

- For every other prefix the faulting linear address **is** the address the guest computed, so a fault
  below 64 KiB really does mean the guest read a null field, and zeroing the destination reproduces
  the Linux zero page.
- With an FS/GS override the address is `segbase + offset`. A low fault therefore means **our base is
  wrong** — Windows zeroes the user FS base at every kernel transition — and the guest's own offset was
  small, not null. Emulating it as zero both fabricates a value the guest never asked for **and
  consumes the fault** that `guest_fs_reapply()` needs to restore the base and retry.

CS/DS/ES/SS (`0x2E/0x36/0x3E/0x26`) stay ignorable: x86-64 forces those segment bases to zero, so they
are genuinely equivalent to no prefix.

## Evidence

Verbatim bytes at `eboot+0x24d3c30` (from `eboot.bin`, `ph[0]` file offset `0x34050`):

```
66 66 66 64 48 8b 04 25 00 00 00 00   mov rax,QWORD PTR fs:0x0    (12 bytes)
80 b8 f0 ff ff ff 00                  cmp BYTE PTR [rax-0x10],0x0 @ 0x24d3c3c
```

`0x24d3c30 + 12 = 0x24d3c3c`. With `PROSPER_NULL_PAGE_LOG=1` the run log shows **exactly one**
emulation, and it is this instruction:

```
[nullpage] #1 addr=0x0 rip=eboot+0x24d3c3c (read->0)
[shot] guest thread ended: kind=2 detail=ACCESS-VIOLATION at addr=0xfffffffffffffff0  rip=0x4124d3c3c (eboot+0x24d3c3c)
```

The rip in the `[nullpage]` line is the instruction *after* the emulated one, so it chains directly
into the faulting `cmp`. `addr=0x0` is offset 0 against a zeroed FS base. That single emulation **was**
the bug — the null-page emulator had no legitimate hit on this title.

| | master `6528a43f` | this branch |
| --- | --- | --- |
| `ACCESS-VIOLATION at 0xfffffffffffffff0` | yes, boot ends | **gone** |
| `[nullpage]` emulations | 1 | **0** |
| exit code | 1 | **0** |
| AGC device init | not reached | `[agc] register defaults requested for SDK version 13` |
| frames | 0 | 168 in 6 s; 2,896 in 75 s on the routed run |

## Deliberately NOT claimed

**This is a boot fix, not visible progression.** The title now runs, submits, and renders, but the
frames are still black past the routed input pulses, so there are no progression screenshots to
attach and none are included — per the charter, black captures are not progression evidence. What is
behind that black frame is the next investigation in the DQ lane and is not part of this PR.

## Verification

`decode_low_read_dest` is a pure, host-independent function, so the regression is exact rather than
inferred. Tests use the **verbatim** DQ7 encoding.

The load-bearing arm is the **discriminator**: the same instruction with `0x64` removed must still
decode (`reg=rax, len=11`). Without it the six rejections could equally come from the triple-`0x66`
padding, the SIB/disp32 form, or a decoder that had simply stopped accepting anything — and the test
would pass just as loudly while proving nothing. Four more arms assert CS/DS/ES/SS stay accepted.

Built against the **unfixed** header, the six new reject arms fail and all four discriminator arms
pass — so they fail for the intended reason:

```
FAIL DQ7 mov rax,fs:0x0 [66x3]   : expected reject but decoded reg=0 len=12
FAIL mov rax,fs:0x0 [canonical]  : expected reject but decoded reg=0 len=9
FAIL mov rax,fs:0x28 [canary]    : expected reject but decoded reg=0 len=9
FAIL mov rax,gs:0x0              : expected reject but decoded reg=0 len=9
FAIL movzx eax,BYTE fs:(%rsi)    : expected reject but decoded reg=0 len=4
FAIL mov eax,fs:(%rax) [32-bit]  : expected reject but decoded reg=0 len=3
test_x86_read_decode: 6 failure(s)
```

`reg=0 len=12` on the DQ7 arm is the same register and length the runtime log shows, so the unit test
reproduces the live failure rather than a lookalike.

Full `ctest` results are posted as an exact-head comment below.

## Risk

Narrow. The only behavior change is that FS/GS-overridden low-address reads now fall through to the
normal fault path instead of being emulated — which is where the `%fs` re-apply already lives
(`exec_image_win.cpp:1027`). Windows-only in effect (`try_emulate_null_read` is the sole caller);
Linux backs the null page with a real mapping and never reaches this decoder. If a guest genuinely
read a null field *through* an FS override with a correct base, it would now fault instead of reading
zero — but that access could not have been reaching guest TLS anyway, and failing visibly is the
charter's preferred direction.

## Review

Host/ABI work touching fault handling and instruction decoding, so this wants an independent reader
per the charter rather than a self-merge.
