### PR TITLE
diag(mem): name the failing entry when sceKernelBatchMap fails — and correct a platform-crossed conclusion

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2360,10 +2360,22 @@ HLE(k_batch_map) {
             // SEPARATE function (see the `#else` half of this file) where UNMAP and PROTECT can
             // also fail, so do not carry that two-op conclusion across platforms -- #2450 did, and
             // it excluded the two ops most likely to be responsible there.
-            fprintf(stderr,
-                    "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
-                    i, n, op, (unsigned long long)start, (unsigned long long)phys,
-                    (unsigned long long)len, prot);
+            // Bounded, but the cap ANNOUNCES itself. Uncapped, a guest allocator that retries on
+            // failure could emit one line per attempt; silently capped, the case where the
+            // interesting instance is the 200th attempt rather than the first is hidden. Saying
+            // "further ... suppressed" costs one line and tells the reader a tail exists, so
+            // raising the cap later is an informed decision rather than a guess.
+            {
+                static std::atomic<unsigned> logged{0};
+                const unsigned seen = logged.fetch_add(1, std::memory_order_relaxed);
+                if (seen < 8)
+                    fprintf(stderr,
+                            "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+                            i, n, op, (unsigned long long)start, (unsigned long long)phys,
+                            (unsigned long long)len, prot);
+                else if (seen == 8)
+                    fprintf(stderr, "[batchmap-fail] further BatchMap failures suppressed after 8\n");
+            }
             if (!ret) ret = 0x8002000Cull;   // ENOMEM on a failed map
             break;
         }
@@ -5527,10 +5539,22 @@ HLE(k_batch_map) {
             // still zero on Windows: MAP_DIRECT and MAP_FLEXIBLE via a null view, UNMAP via
             // win_unmap, and PROTECT/TYPE_PROTECT via win_protect. `op` is therefore load-bearing
             // rather than decorative.
-            fprintf(stderr,
-                    "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
-                    i, n, op, (unsigned long long)start, (unsigned long long)phys,
-                    (unsigned long long)len, prot);
+            // Bounded, but the cap ANNOUNCES itself. Uncapped, a guest allocator that retries on
+            // failure could emit one line per attempt; silently capped, the case where the
+            // interesting instance is the 200th attempt rather than the first is hidden. Saying
+            // "further ... suppressed" costs one line and tells the reader a tail exists, so
+            // raising the cap later is an informed decision rather than a guess.
+            {
+                static std::atomic<unsigned> logged{0};
+                const unsigned seen = logged.fetch_add(1, std::memory_order_relaxed);
+                if (seen < 8)
+                    fprintf(stderr,
+                            "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+                            i, n, op, (unsigned long long)start, (unsigned long long)phys,
+                            (unsigned long long)len, prot);
+                else if (seen == 8)
+                    fprintf(stderr, "[batchmap-fail] further BatchMap failures suppressed after 8\n");
+            }
             if (!ret) ret = 0x8002000Cull;
             break;
         }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2345,7 +2345,28 @@ HLE(k_batch_map) {
             }
             default: ok = false; ret = 0x80020016ull; break;
         }
-        if (!ok) { if (!ret) ret = 0x8002000Cull; break; }   // ENOMEM on a failed map
+        if (!ok) {
+            // A failed entry is FATAL to the caller -- UE4 titles turn the resulting ENOMEM into
+            // `LowLevelFatalError ... sceKernelBatchMap failed with error code: 0x8002000c` and kill
+            // the process (#2450, Dragon Quest VII PPSA17942). Report it unconditionally: this fires
+            // only on an actual failure, so it costs nothing on a healthy run, and without it the
+            // only way to learn WHICH entry failed is PROSPER_MEMLOG, which logs every map in the
+            // title -- thousands of lines, and enough added overhead that it perturbs the timing of
+            // the very allocation failure being diagnosed.
+            //
+            // `op` is the discriminator that matters. On THIS (POSIX) path only 0 = MAP_DIRECT and
+            // 3 = MAP_FLEXIBLE can reach here with `ret` still zero: UNMAP cannot fail and both
+            // PROTECT forms assign `ret` themselves. The Windows implementation of this call is a
+            // SEPARATE function (see the `#else` half of this file) where UNMAP and PROTECT can
+            // also fail, so do not carry that two-op conclusion across platforms -- #2450 did, and
+            // it excluded the two ops most likely to be responsible there.
+            fprintf(stderr,
+                    "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+                    i, n, op, (unsigned long long)start, (unsigned long long)phys,
+                    (unsigned long long)len, prot);
+            if (!ret) ret = 0x8002000Cull;   // ENOMEM on a failed map
+            break;
+        }
         done++;
     }
     MLOG("batchmap n=%d done=%d first{op=%d start=0x%llx len=0x%llx prot=0x%x} -> 0x%llx\n",
@@ -5494,7 +5515,25 @@ HLE(k_batch_map) {
             }
             default: ok = false; ret = 0x80020016ull; break;
         }
-        if (!ok) { if (!ret) ret = 0x8002000Cull; break; }
+        if (!ok) {
+            // Name the failing entry (#2450). A failed entry is fatal to the caller: UE4 titles
+            // turn the resulting ENOMEM into `LowLevelFatalError ... sceKernelBatchMap failed with
+            // error code: 0x8002000c` and kill the process (Dragon Quest VII, PPSA17942). Fires
+            // only on an actual failure, so it is free on a healthy run -- and the alternative,
+            // PROSPER_MEMLOG, logs every map in the title and perturbs the timing of the very
+            // allocation failure being diagnosed.
+            //
+            // Unlike the POSIX implementation, ALL FOUR mapping ops can reach here with `ret`
+            // still zero on Windows: MAP_DIRECT and MAP_FLEXIBLE via a null view, UNMAP via
+            // win_unmap, and PROTECT/TYPE_PROTECT via win_protect. `op` is therefore load-bearing
+            // rather than decorative.
+            fprintf(stderr,
+                    "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+                    i, n, op, (unsigned long long)start, (unsigned long long)phys,
+                    (unsigned long long)len, prot);
+            if (!ret) ret = 0x8002000Cull;
+            break;
+        }
         done++;
     }
     if (a2) *(int32_t*)(uintptr_t)a2 = done;

--- a/prosper/tests/test_dmem.cpp
+++ b/prosper/tests/test_dmem.cpp
@@ -201,6 +201,22 @@ int main() {
                 (uint64_t)(uintptr_t)&batch_done, 0, 0, 0) != 0 && batch_done == 0,
           "BatchMap reports an invalid host unmap instead of counting it as complete");
 
+    // A MAP_FLEXIBLE entry that cannot possibly be satisfied must report ENOMEM and count zero
+    // entries done -- and, since #2450, must NAME the failing entry on stderr. This is the only
+    // arm that reaches the `if (!ok)` branch in k_batch_map: UNMAP above never sets ok=false and
+    // both PROTECT forms assign `ret` themselves, so without this the failure diagnostic added for
+    // #2450 is compiled but never executed by any test.
+    alignas(8) uint8_t impossible_map[0x20]{};
+    *(uint64_t*)(impossible_map + 0x00) = 0;                       // no fixed VA
+    *(uint64_t*)(impossible_map + 0x10) = 0x4000000000000ull;      // 1 PiB -- cannot be mapped
+    impossible_map[0x18] = 0x03;                                   // read|write
+    *(int32_t*)(impossible_map + 0x1c) = 3;                        // MAP_FLEXIBLE
+    int32_t impossible_done = -1;
+    CHECK((uint32_t)batch((uint64_t)(uintptr_t)impossible_map, 1,
+                          (uint64_t)(uintptr_t)&impossible_done, 0, 0, 0) == 0x8002000Cu &&
+              impossible_done == 0,
+          "BatchMap returns ENOMEM and counts zero entries for an unsatisfiable MAP_FLEXIBLE");
+
     // Direct memory is one physical pool, not private memory per virtual mapping. Dead Cells
     // releases and reuses small physical ranges aggressively; independent Windows allocations
     // let its allocator observe different metadata through two aliases and corrupt adjacent VA.


### PR DESCRIPTION
Refs #2450.

## Failure scenario

A failed `sceKernelBatchMap` entry is fatal to the caller: UE4 titles turn the resulting ENOMEM into
`LowLevelFatalError ... sceKernelBatchMap failed with error code: 0x8002000c` and kill the process. That is
what stops *Dragon Quest VII* (`PPSA17942`) on Windows once input advances the title (#2450) — and nothing in
the log says **which** entry failed, or with which op.

The only existing way to find out is `PROSPER_MEMLOG`, which logs **every** map in the title (13,696 lines in
a 60 s run that never even reached input) and appears to perturb the timing of the very allocation failure
being diagnosed. This logs only on an actual failure, so it is free on a healthy run.

## The correction this PR also carries

**I published a wrong narrowing on #2450 and this fixes its cause.** I read `k_batch_map`, found ENOMEM has a
single source line, and concluded it was reachable from exactly two ops — `MAP_DIRECT` and `MAP_FLEXIBLE` —
because UNMAP cannot fail and both PROTECT forms assign `ret` themselves.

That is true of the **POSIX** implementation. `hle_kernel_mem.cpp` splits at
`#if defined(__linux__) || defined(__APPLE__) … #else … #endif` and **defines `k_batch_map` twice** (`:2281`
and `:5446`). On Windows:

| op | POSIX | Windows |
| --- | --- | --- |
| 0 `MAP_DIRECT` | can fail | can fail |
| 3 `MAP_FLEXIBLE` | can fail | can fail |
| 1 `UNMAP` | **cannot fail** | **`ok = !start \|\| win_unmap(...)` — can fail** |
| 2/4 `PROTECT` | sets `ret` itself | **`ok = win_protect(...)` — can leave `ret` zero** |

So on the platform the bug is actually on, **all four** mapping ops reach that line — and my narrowing excluded
the two most likely to be responsible. Both comments now state which platform they describe, and the POSIX one
carries an explicit warning not to carry the two-op conclusion across.

## Why this was caught

The diagnostic was written into the POSIX branch first, where it is dead code on Windows. **Building it and
running the tests did not reveal that** — it compiled, linked, and 179/180 passed exactly as before.

What revealed it was checking that the new line is **reached**, not merely compiled:

```
strings build-rwdi/CMakeFiles/prosper_core.dir/src/hle/hle_kernel_mem.cpp.obj | grep -c batchmap-fail
  -> 0        # with a positive control: sceKernelBatchMap -> 2, so the grep works
```

An object that recompiles cleanly and does not contain your string is code the preprocessor removed.

## Verification

**The lever moved.** Both arms emit it on Windows:

```
[batchmap-fail] entry=0/1 op=1 va=0x30000020000 phys=0x0 len=0x4000 prot=0x0
[batchmap-fail] entry=0/1 op=3 va=0x0  phys=0x0 len=0x4000000000000 prot=0x3
```

The **`op=1` line is the pre-existing invalid-unmap test**, and is direct empirical evidence that UNMAP fails
on Windows — the case my POSIX-derived analysis had excluded. The instrument's first output falsified the claim
it was built to investigate.

`test_dmem` gains an arm for an unsatisfiable `MAP_FLEXIBLE`. Without it the new line is compiled and never
executed by any test on either platform: the pre-existing failing arm is `op=1`, which cannot reach it on POSIX.

```
cmake --build prosper/build-rwdi -j 8                                   clean
ctest --test-dir prosper/build-rwdi --no-tests=error -j 4               179/180 passed, 1 failed
```

The failure is `build_revision_refresh` (`0xC0000005` in a separate `revision_query.exe` sub-build that links
only `test_build_revision`, never `prosper_core`) — the known pre-existing Windows breakage, unrelated to this
diff. `git diff --check` clean; session-trailer gate 0.

## Risk

Low. One `fprintf` on an already-failing path in each implementation, no control-flow or return-value change —
`ret` is assigned exactly as before. No behaviour change on a run where no batch entry fails.

## Review

HLE memory-mapping code and a cross-platform claim I already got wrong once, so I would like a reader rather
than merging on my own verification.
