### PR TITLE
fix(gpu): reject an image descriptor whose base is below the low-pointer guard

### DIFF
--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -424,10 +424,16 @@ const char* image_descriptor_reject_reason(const DecodedImageDescriptor& d) {
     // A materialized bogus resource is worse than a rejected one: lookups are first-match, so it can
     // occupy the provenance a real descriptor needed, and unlike a rejection it produces no diagnostic.
     //
-    // The threshold matches the raw-pointer guard in `resolve_dynamic_fetch` (`gpu_executor.cpp`, the
-    // #2412 raw-pointer block: `if (ptr > 0x10000)`), whose comment says it "matches the consumer's own
-    // null/low-pointer guard". Aligning the two means one address is not plausible to a pointer screen
-    // and implausible to a descriptor screen.
+    // The threshold ALIGNS WITH the raw-pointer guard in `resolve_dynamic_fetch` (`gpu_executor.cpp`,
+    // the #2412 raw-pointer block: `if (ptr > 0x10000)`), whose comment says it "matches the consumer's
+    // own null/low-pointer guard", so one address is not plausible to a pointer screen and implausible
+    // to a descriptor screen.
+    //
+    // "Aligns with" rather than "matches", because the boundary value itself differs: the five existing
+    // sites accept `> 0x10000` and this one accepts `>= 0x10000`, so exactly 0x10000 is rejected there
+    // and accepted here. Deliberate under the discovery/validation split below — a screen that only
+    // validates should not reject the one address its sibling happens to exclude — but the off-by-one is
+    // real and stating it is cheaper than the next reader re-deriving whether it was intentional.
     //
     // NOT the `0x1000000000` PS5 guest-VA floor used by the two direct V# paths below, and the
     // difference is the two predicates' jobs rather than an inconsistency. Those paths are SPECULATIVE

--- a/prosper/src/gpu/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc_shader_layout.cpp
@@ -410,6 +410,35 @@ DecodedImageDescriptor decode_image_descriptor(const uint32_t t[8]) {
 // descriptor decode of BASE_ARRAY/LAST_ARRAY is pinned by test_build_shader_resources).
 const char* image_descriptor_reject_reason(const DecodedImageDescriptor& d) {
     if (d.base == 0) return "base-zero";
+    // A base BELOW the PS5 guest-VA floor is as unusable as zero, and used to pass this screen (#2446).
+    // Observed on PPSA04263 (GTA V) at gameplay with the compute materialization verdict logged:
+    //
+    //   pc=18 key=0xffffffff base=0x100        512x512 type=13 fmt=11 tile=24 -> materialize
+    //   pc=18 key=0xffffffff base=0x20972c0000 512x512 type=13 fmt=11 tile=24 -> materialize
+    //
+    // `0x100` is 256 bytes. It is the signature of a fold that resolved `base + imm` with the base
+    // unknown-or-zero — the same mechanism behind the bare-offset addresses recorded on #2412 (0x38,
+    // 0xb0, 0x128, 0x1a0, 0x218). Those reach `readable()` and fail loudly; this one never got that far,
+    // because only exact zero was screened, so it became a table entry.
+    //
+    // A materialized bogus resource is worse than a rejected one: lookups are first-match, so it can
+    // occupy the provenance a real descriptor needed, and unlike a rejection it produces no diagnostic.
+    //
+    // The threshold matches the raw-pointer guard in `resolve_dynamic_fetch` (`gpu_executor.cpp`, the
+    // #2412 raw-pointer block: `if (ptr > 0x10000)`), whose comment says it "matches the consumer's own
+    // null/low-pointer guard". Aligning the two means one address is not plausible to a pointer screen
+    // and implausible to a descriptor screen.
+    //
+    // NOT the `0x1000000000` PS5 guest-VA floor used by the two direct V# paths below, and the
+    // difference is the two predicates' jobs rather than an inconsistency. Those paths are SPECULATIVE
+    // DISCOVERY — they scan writable slots deciding whether arbitrary dwords even are a descriptor, so a
+    // high floor buys them precision against false positives, alongside a stride requirement and a
+    // 256 MiB extent ceiling. This predicate VALIDATES a descriptor already believed to be a T# by the
+    // instruction that consumed it, so it must reject only what is genuinely unusable. Applying the
+    // discovery floor here rejected 19 existing assertions whose synthetic bases (0x12000000,
+    // 0x123456780, …) are incidental scaffolding for mip/DCC/format behaviour — an over-strict
+    // validation screen throwing away descriptors that decode perfectly well.
+    if (d.base < 0x10000ull) return "base-below-low-pointer-guard";
     if (d.width == 0 || d.height == 0) return "zero-extent";
     // depth = LAST_ARRAY - BASE_ARRAY + 1, and the decoder emits 0 for LAST_ARRAY < BASE_ARRAY —
     // a malformed inverted range, not a single layer. It must keep failing visibly (#2005).

--- a/prosper/tests/test_build_shader_resources.cpp
+++ b/prosper/tests/test_build_shader_resources.cpp
@@ -379,6 +379,26 @@ int main() {
                          "base-zero") == 0,
               "a zero-base T# is rejected as base-zero");
 
+        // #2446: a base BELOW the PS5 guest-VA floor used to pass, because only exact zero was
+        // screened. 0x100 is the shape a fold produces when it resolves `base + imm` with the base
+        // unknown-or-zero, and it was observed materializing as a valid 512x512 image on PPSA04263.
+        // Fails without the fix: the predicate returns nullptr and this CHECK reports "accepted".
+        uint32_t low_base[8]; memcpy(low_base, good, sizeof good);
+        make_tsharp(low_base, 0x100ull, 512, 512, /*RGBA16F*/71, /*tile*/27, /*2D*/9);
+        {
+            const char* why = image_descriptor_reject_reason(decode_image_descriptor(low_base));
+            CHECK(why != nullptr && strcmp(why, "base-below-low-pointer-guard") == 0,
+                  "a T# whose base is below the low-pointer guard is rejected, not materialized");
+        }
+        // The discriminator: the SAME descriptor shape with a base ABOVE the floor must still pass, so
+        // the rejection is attributable to the base and not to the 512x512 extent or the tile mode.
+        {
+            uint32_t at_guard[8];
+            make_tsharp(at_guard, 0x10000ull, 512, 512, /*RGBA16F*/71, /*tile*/27, /*2D*/9);
+            CHECK(image_descriptor_reject_reason(decode_image_descriptor(at_guard)) == nullptr,
+                  "the same shape at the low-pointer guard is accepted (the base is what was rejected)");
+        }
+
         uint32_t bad_type[8]; memcpy(bad_type, good, sizeof good);
         bad_type[3] = (bad_type[3] & ~(0xfu << 28)) | (0u << 28);   // TYPE 0 = buffer, not an image
         CHECK(image_descriptor_reject_reason(decode_image_descriptor(bad_type)) != nullptr &&


### PR DESCRIPTION
## The defect

`image_descriptor_reject_reason` screened only `d.base == 0`, so a small non-zero base passed every remaining
test and materialized as a valid image resource. Observed on `PPSA04263` (GTA V) at gameplay with the compute
materialization verdict logged:

```
pc=18 key=0xffffffff base=0x100        512x512 type=13 fmt=11 tile=24 -> materialize
pc=18 key=0xffffffff base=0x20972c0000 512x512 type=13 fmt=11 tile=24 -> materialize
```

`0x100` is 256 bytes — the signature of a fold that resolved `base + imm` with the base unknown-or-zero, the
same mechanism behind the bare-offset addresses on #2412 (`0x38`, `0xb0`, `0x128`). Those reach `readable()`
and fail loudly; this one never got that far.

**A materialized bogus resource is worse than a rejected one.** Lookups are first-match, so it can occupy the
provenance a real descriptor needed, and unlike a rejection it produces no diagnostic at all.

## The threshold, and why NOT the obvious one

`0x10000`, matching the raw-pointer guard in `resolve_dynamic_fetch` whose comment says it "matches the
consumer's own null/low-pointer guard". Aligning them means one address is not simultaneously plausible to a
pointer screen and implausible to a descriptor screen.

**I first used the `0x1000000000` PS5 guest-VA floor** — documented in this very file and used by the two
direct V# discovery paths — because it looked like the more rigorous choice. **It broke 19 existing
assertions**, whose synthetic bases (`0x12000000`, `0x123456780`, …) are incidental scaffolding for mip/DCC/
format behaviour.

The tests were right and the reasoning was wrong: those paths are **speculative discovery**, deciding whether
arbitrary dwords even *are* a descriptor, where a high floor buys precision against false positives alongside a
stride requirement and an extent ceiling. This predicate **validates** a descriptor the consuming instruction
already established, so it must reject only what is genuinely unusable. Discovery strict, validation
permissive. The comment records the distinction so the dead end is not re-derived.

## Verification

```
ctest --test-dir prosper/build-linux --no-tests=error -j4      230/230 passed
```

**Mutation-verified.** With the new check commented out, exactly **1** test fails — the new arm — and it names
itself: `a T# whose base is below the low-pointer guard is rejected, not materialized`.

**The arm has a discriminator.** A rejection assertion alone would pass even if the predicate were rejecting on
the 512x512 extent or the tile mode, so a second arm asserts *the same descriptor shape at the guard* is
accepted. That pins the base as what changed the verdict.

**Live control**, Linux/AMD, The Messenger (PPSA24651, rung 6): renders correctly at 1920x1080, PEAK=255,
coverage **9.28% — identical to the pre-change reference frame** — and **zero** `base-below-low-pointer-guard`
rejections, i.e. the new screen does not fire on a known-good title.

`git diff --check` clean. No `Claude-Session:` trailers.

Refs #2446
