### PR TITLE
diag(gpu): PROSPER_DESCR_COHERENCE — measure whether the guest rewrites descriptor bytes (stage 0 of the descriptor lift)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -208,6 +208,8 @@ bool descr_coherence_enabled() {
 namespace {
 struct DescriptorCoherenceState {
     std::mutex mx;
+    // Grows with DISTINCT addresses and is never pruned — ~125k entries on a 210 s GTA V route. Fine for
+    // an opt-in diagnostic at that scale; a much longer route would want a cap or an eviction policy.
     std::unordered_map<uint64_t, uint64_t> seen;   // descriptor address -> last observed hash
     uint64_t checked = 0, changed = 0;
     // Summary is emitted PERIODICALLY, not at exit. The first version of this probe reported from a
@@ -231,12 +233,20 @@ void record_descriptor_observation(uint64_t addr, uint64_t hash) {
     DescriptorCoherenceState& s = descr_coherence_state();
     std::lock_guard<std::mutex> lk(s.mx);
     ++s.checked;
-    auto it = s.seen.find(addr);
-    if (it == s.seen.end()) { s.seen.emplace(addr, hash); return; }
+    // Reported BEFORE the first-sight early return below, so emission depends only on `checked`.
+    // Placed after it, this line could fire only on a REPEAT observation — and in a run whose slots are
+    // rarely re-read inside the window that means `checked` in the hundreds of thousands, zero RUNNING
+    // lines, and zero CHANGED lines (a first sight can never mismatch), which is indistinguishable from
+    // the probe never having run. That is exactly the ambiguity the control exists to remove, and the
+    // mechanism is trap 147: the report was not unarmed, it was STARVED by an early return consuming the
+    // path before the trigger. Found in review; the published 8.5% figure was unaffected because both
+    // measured runs reached repeat observations, but the next run need not have.
     if ((s.checked % DescriptorCoherenceState::kReportEvery) == 0)
         std::fprintf(stderr,
                      "[descr-coherence] RUNNING checked=%llu distinct_addrs=%zu changed=%llu\n",
                      (unsigned long long)s.checked, s.seen.size(), (unsigned long long)s.changed);
+    auto it = s.seen.find(addr);
+    if (it == s.seen.end()) { s.seen.emplace(addr, hash); return; }
     if (it->second != hash) {
         // Report the first few individually — an aggregate alone cannot say WHICH slot moves, and a
         // table whose entries all churn is a different problem from one slot being rewritten.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -191,6 +191,64 @@ void read_user_sgprs(const RegisterFile& sh, uint32_t base, uint32_t out[kUserSg
 // by the HLE submit mutex, so a plain global is safe there.
 bool g_dyntrace_force = false;
 
+// PROSPER_DESCR_COHERENCE=1 — stage 0 of the runtime-selected-descriptor lift (#2412). Records the
+// bytes seen at each descriptor address and counts how often the same address later yields DIFFERENT
+// bytes, i.e. whether the guest rewrites descriptor-table slots under us. See the call site for why
+// this gates the whole design rather than being a checkpoint inside it.
+//
+// Reports `checked` alongside `changed` because a bare zero cannot distinguish "the table is stable"
+// from "the probe never ran"; `checked` is the control line. Also reports distinct addresses, so a
+// large `checked` with tiny `distinct` (the same slot re-read every dispatch) is not mistaken for
+// broad coverage.
+bool descr_coherence_enabled() {
+    static const bool on = std::getenv("PROSPER_DESCR_COHERENCE") != nullptr;
+    return on;
+}
+
+namespace {
+struct DescriptorCoherenceState {
+    std::mutex mx;
+    std::unordered_map<uint64_t, uint64_t> seen;   // descriptor address -> last observed hash
+    uint64_t checked = 0, changed = 0;
+    // Summary is emitted PERIODICALLY, not at exit. The first version of this probe reported from a
+    // destructor with a comment explaining that a summary must not depend on reaching a particular exit
+    // path — and a destructor is exactly such a path: every routed run here is terminated by `timeout`,
+    // whose SIGTERM runs no static destructors, so the run that produced the finding printed the
+    // per-slot lines and no totals at all. Cost: one wasted 220 s run and a result with no denominator.
+    //
+    // Periodic emission has no such dependency: whatever the run does, the last line printed is a valid
+    // running total. `checked` is the control (a bare `changed` cannot separate "stable" from "never
+    // ran") and `distinct_addrs` guards against reading one slot re-read many times as broad coverage.
+    static constexpr uint64_t kReportEvery = 20000;
+};
+DescriptorCoherenceState& descr_coherence_state() {
+    static DescriptorCoherenceState s;
+    return s;
+}
+}  // namespace
+
+void record_descriptor_observation(uint64_t addr, uint64_t hash) {
+    DescriptorCoherenceState& s = descr_coherence_state();
+    std::lock_guard<std::mutex> lk(s.mx);
+    ++s.checked;
+    auto it = s.seen.find(addr);
+    if (it == s.seen.end()) { s.seen.emplace(addr, hash); return; }
+    if ((s.checked % DescriptorCoherenceState::kReportEvery) == 0)
+        std::fprintf(stderr,
+                     "[descr-coherence] RUNNING checked=%llu distinct_addrs=%zu changed=%llu\n",
+                     (unsigned long long)s.checked, s.seen.size(), (unsigned long long)s.changed);
+    if (it->second != hash) {
+        // Report the first few individually — an aggregate alone cannot say WHICH slot moves, and a
+        // table whose entries all churn is a different problem from one slot being rewritten.
+        if (s.changed < 8)
+            std::fprintf(stderr, "[descr-coherence] CHANGED addr=0x%llx %016llx -> %016llx\n",
+                         (unsigned long long)addr, (unsigned long long)it->second,
+                         (unsigned long long)hash);
+        ++s.changed;
+        it->second = hash;
+    }
+}
+
 bool dyntrace_failed_shader_enabled(uint64_t code_addr) {
     if (!std::getenv("PROSPER_DYNTRACE_FAIL")) return false;
     const char* filter = std::getenv("PROSPER_DYNTRACE_FAIL_ADDR");
@@ -3072,6 +3130,37 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // A 4-dword load is a V# candidate — snapshot it now (before any later stride patch) so a
                 // vertex fetch using these SGPRs resolves to the descriptor as loaded. An 8-dword load is
                 // a T# candidate (image_sample SRSRC), snapshotted the same way (#294).
+                // PROSPER_DESCR_COHERENCE=1 — stage 0 of the runtime-selected-descriptor lift (#2412).
+                //
+                // The planned design pre-materialises a descriptor TABLE on the CPU and lets the shader
+                // select an entry by runtime index. That is only sound if the table's contents at the
+                // moment we read them are the contents the dispatch expects. A bindless renderer
+                // rewriting table slots per frame is not exotic — it is the ordinary reason to be
+                // bindless — and if it happens here the failure is SILENT: the index is in range, the
+                // descriptor is valid, and the bytes are a previous frame's. Nothing else in the plan
+                // detects that, which is why it is measured before any of the five layers are touched.
+                //
+                // The probe: remember the bytes seen at each descriptor ADDRESS and report when the same
+                // address later yields different bytes. That answers "does the guest rewrite descriptor
+                // slots" directly, without plumbing a hash through to submit.
+                //
+                // BOTH counters are reported, deliberately. A bare "0 mismatches" is indistinguishable
+                // from "the probe never ran" — the ambiguity that has cost this project several false
+                // zeros — so `checked` is the control line and is printed alongside.
+                // Gated on `is_buffer` (s_buffer_load, op >= 8) — a V#-RELATIVE load, which is what
+                // reading a descriptor table looks like. The first version hooked every 4-dword scalar
+                // load and so measured ordinary constant data too: 2.22M observations over 404,343
+                // addresses, 21% of which changed at least once. That number is real but its population
+                // is far broader than "descriptor tables", and the design question is specifically about
+                // table slots. Narrowing costs one run and makes the answer actionable instead of
+                // suggestive.
+                if (descr_coherence_enabled() && n == 4 && is_buffer) {
+                    uint64_t h = 1469598103934665603ull;              // FNV-1a over the four dwords
+                    for (int k = 0; k < 4; ++k) {
+                        h ^= mem[k]; h *= 1099511628211ull;
+                    }
+                    record_descriptor_observation(addr, h);
+                }
                 if (n == 4 && valid_reg(sdst)) {
                               descr[(size_t)sdst] = { mem[0], mem[1], mem[2], mem[3] };
                               descr_known.set((size_t)sdst);


### PR DESCRIPTION
## Why this exists

Mattias decided to lift the runtime-selected-descriptor limitation rather than accept GTA V's world not
rendering. The plan is six staged layers; the Windows lane raised a hole that gates all of them, so it was
measured before any layer was touched.

**The design was:** read the descriptor table CPU-side, materialise every entry as a real Vulkan descriptor,
let the shader select by runtime index. That is only sound if the bytes we read are the bytes the dispatch
expects — and **a bindless renderer rewriting table slots per frame is the ordinary reason to be bindless.**
If it happens, the failure is silent: index in range, descriptor valid, contents from a previous frame. Nothing
else in the plan detects it.

## The measurement

`PROSPER_DESCR_COHERENCE=1` remembers the bytes at each descriptor address and counts how often the same
address later yields different bytes. Gated on `is_buffer` — a V#-relative load, which is what reading a
descriptor table looks like.

```
PPSA04263 gameplay route, control present (119 fps samples)

checked  720,000     distinct_addrs  125,563     changed  10,630
```

**8.5% of distinct descriptor addresses are rewritten during a single routed run.** So invalidation is not a
narrow guard against a rare rewrite, and **eager whole-table pre-materialisation is not viable.** Stage 5 must
be lazy-per-index or generation-invalidated — which is also the better answer for the guest→host copy cost, and
it means the coherence hole and the cost hole are one design problem with one signal.

## Two instrument decisions, both from failures earned tonight

**It reports `checked` and `distinct_addrs`, not just `changed`.** A bare zero cannot separate "the table is
stable" from "the probe never ran" — the ambiguity that has produced several false zeros in this project — so
`checked` is the control line, and `distinct_addrs` stops a single slot re-read many times from reading as broad
coverage.

**The summary is emitted periodically, not from a destructor.** The first version used a destructor *while its
own comment explained that a summary must not depend on reaching a particular exit path*. A destructor is
exactly such a path: every routed run here ends under `timeout`, whose SIGTERM runs no static destructors, so
that run printed per-slot lines and no denominator. One wasted 220 s run; the comment now records it.

Also worth keeping: the first probe hooked **all** 4-dword scalar loads and reported 21% of 404,343 addresses.
That number is real but its population is far broader than the design question. Narrowing it cost one run and
turned a suggestive figure into an actionable one. The issue records both so nobody quotes the larger one.

## Risk

Opt-in and read-only. With `PROSPER_DESCR_COHERENCE` unset, `descr_coherence_enabled()` is a cached `getenv`
returning false and nothing else runs. No fold state is touched, no binding decision changes.

## Verification

```
prosper-app + build-linux                                    build clean
ctest --test-dir prosper/build-linux --no-tests=error -j4     230/230 passed
```

`git diff --check` clean. No `Claude-Session:` trailers.

Refs #2412
