### PR TITLE
feat(vk): acquire descriptor-indexing capability at both device sites (stage 1 of the descriptor lift)

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -993,7 +993,9 @@ struct VulkanComputeContext {
     // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
     bool image_support = false;
     // Stage 1 of the descriptor lift (#2412): true when this compute device can express an indexed
-    // descriptor array. Set either here (own device) or inherited when adopting the renderer's.
+    // descriptor array. Assigned on the own-device path below, and inherited from SharedVulkanContext on
+    // the adopt path -- both are real assignments. An earlier revision of this comment claimed the
+    // inheritance while no code and no struct field implemented it; see the note at the adopt site.
     bool descriptor_indexing_support = false;
     uint32_t subgroup_size = 0;
     VkShaderStageFlags subgroup_stages = 0;
@@ -2184,6 +2186,15 @@ struct VulkanComputeContext {
             queue_family = shared.queue_family;
             borrowed = true;
             image_support = true;
+            // Inherit the descriptor-indexing capability from the device being adopted. Its absence was
+            // the blocking review finding on #2458: the flag stayed false on the shared path -- which is
+            // the normal path whenever a renderer exists -- even though the adopted device had the
+            // extension enabled and the features on. That direction fails safe on its own (a false
+            // reading skips the indexed path rather than executing an undeclared one), but the member
+            // comment asserted the inheritance, so a later stage would have gated on the flag, read the
+            // comment, and searched for "indexed arrays never engage in the live renderer" anywhere
+            // except in a struct field that did not exist.
+            descriptor_indexing_support = shared.descriptor_indexing;
             native_subgroup_contract = shared.compute_subgroup_size_control &&
                 shared.compute_full_subgroups && shared.compute_subgroup_vote &&
                 shared.compute_subgroup_arithmetic;
@@ -2195,6 +2206,14 @@ struct VulkanComputeContext {
                 query_subgroup_support();
                 std::fprintf(stderr, "[compute] Vulkan device: adopted the renderer's device "
                                      "(shared, queue family %u)\n", queue_family);
+                // Report the inherited capability in BOTH directions. A log that fires only when the
+                // feature is present makes its absence silent, which is how #2458 shipped a comment
+                // claiming an inheritance that no code performed: there was nothing a run could print
+                // that would have contradicted it. Printing "unavailable" is what makes the adopt path
+                // falsifiable from a log rather than from reading the source.
+                std::fprintf(stderr, "[compute] descriptor indexing %s (inherited from the adopted "
+                                     "device)\n",
+                             descriptor_indexing_support ? "ENABLED" : "unavailable");
                 return true;
             }
             // Anything failing here must fall through to a private device rather than killing the
@@ -2261,11 +2280,13 @@ struct VulkanComputeContext {
         // indistinguishable from code that never ran.
         VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+        bool di_ext_advertised = false;
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
           for (auto& e : de) {
               if (std::strcmp(e.extensionName, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) continue;
+              di_ext_advertised = true;
               VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
               f2.pNext = &di_features;
               vkGetPhysicalDeviceFeatures2(physical, &f2);
@@ -2302,6 +2323,16 @@ struct VulkanComputeContext {
               }
               break;
           } }
+        // The third case, and the only one that was silent: the extension is not advertised at all, so
+        // the loop above never enters its body and nothing above prints. "Absent" and "the scan never
+        // ran" would then look identical in a log -- the same ambiguity that let the adopt path claim an
+        // inheritance nobody could contradict. Report it so every outcome of this decision is visible.
+        // Guarded on `di_ext_advertised`, NOT on `descriptor_indexing_support`: the feature flag is also
+        // false in the present-but-incomplete case, which already printed its own itemised line, and this
+        // message would then contradict it with "not advertised" about a device that advertised it.
+        if (!di_ext_advertised)
+            std::fprintf(stderr, "[compute] descriptor indexing unavailable: "
+                                 "VK_EXT_descriptor_indexing not advertised by this device\n");
 #ifdef __APPLE__
         // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -992,6 +992,9 @@ struct VulkanComputeContext {
     // tests/image_compute_runner.h, the exec-diff harness for that contract). When the device lacks
     // the features, image-binding dispatches are skipped loudly instead of creating an invalid device.
     bool image_support = false;
+    // Stage 1 of the descriptor lift (#2412): true when this compute device can express an indexed
+    // descriptor array. Set either here (own device) or inherited when adopting the renderer's.
+    bool descriptor_indexing_support = false;
     uint32_t subgroup_size = 0;
     VkShaderStageFlags subgroup_stages = 0;
     VkSubgroupFeatureFlags subgroup_operations = 0;
@@ -2249,6 +2252,56 @@ struct VulkanComputeContext {
         dci.pQueueCreateInfos = &qci;
         dci.pEnabledFeatures = &enabled;
         std::vector<const char*> dev_exts;
+        // Runtime-selected descriptors (#2412, stage 1). This path only runs when there is NO renderer
+        // to adopt a device from (the shared case logs "adopted the renderer's device"), but it must
+        // acquire the same capability: otherwise a compute-only run would gate on a flag the graphics
+        // device set and emit indexed-array SPIR-V against a device that cannot execute it — silent
+        // undefined behaviour rather than a clean failure. All-or-nothing for the same reason as the
+        // graphics side, and the SUCCESS is logged as well as the shortfall so the working case is not
+        // indistinguishable from code that never ran.
+        VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+        { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
+          std::vector<VkExtensionProperties> de(ne);
+          vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
+          for (auto& e : de) {
+              if (std::strcmp(e.extensionName, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) continue;
+              VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+              f2.pNext = &di_features;
+              vkGetPhysicalDeviceFeatures2(physical, &f2);
+              const bool have_all =
+                  di_features.runtimeDescriptorArray &&
+                  di_features.descriptorBindingPartiallyBound &&
+                  di_features.shaderStorageBufferArrayNonUniformIndexing &&
+                  di_features.shaderSampledImageArrayNonUniformIndexing &&
+                  di_features.shaderStorageImageArrayNonUniformIndexing;
+              if (have_all) {
+                  VkPhysicalDeviceDescriptorIndexingFeaturesEXT want{
+                      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+                  want.runtimeDescriptorArray = VK_TRUE;
+                  want.descriptorBindingPartiallyBound = VK_TRUE;
+                  want.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
+                  want.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+                  want.shaderStorageImageArrayNonUniformIndexing = VK_TRUE;
+                  di_features = want;
+                  di_features.pNext = const_cast<void*>(dci.pNext);
+                  dci.pNext = &di_features;
+                  dev_exts.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+                  descriptor_indexing_support = true;
+                  std::fprintf(stderr, "[compute] descriptor indexing ENABLED (own device)\n");
+              } else {
+                  std::fprintf(stderr,
+                               "[compute] VK_EXT_descriptor_indexing present but incomplete: "
+                               "runtimeArray=%d partiallyBound=%d ssboNonUniform=%d "
+                               "sampledNonUniform=%d storageImgNonUniform=%d\n",
+                               (int)di_features.runtimeDescriptorArray,
+                               (int)di_features.descriptorBindingPartiallyBound,
+                               (int)di_features.shaderStorageBufferArrayNonUniformIndexing,
+                               (int)di_features.shaderSampledImageArrayNonUniformIndexing,
+                               (int)di_features.shaderStorageImageArrayNonUniformIndexing);
+              }
+              break;
+          } }
 #ifdef __APPLE__
         // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
@@ -2256,9 +2309,15 @@ struct VulkanComputeContext {
           vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
           for (auto& e : de) if (!std::strcmp(e.extensionName, "VK_KHR_portability_subset")) {
               dev_exts.push_back("VK_KHR_portability_subset"); break; } }
+#endif
+        // Assigned OUTSIDE the Apple guard. Before stage 1 the only extension this path ever requested
+        // was VK_KHR_portability_subset, so the assignment lived inside `#ifdef __APPLE__` and every
+        // other platform passed a zero-length list. Leaving it there would have silently dropped the
+        // descriptor-indexing extension on Linux and Windows -- the pNext feature struct would be sent
+        // without its extension enabled, which is exactly the shape that produces a validation error
+        // far from its cause.
         dci.enabledExtensionCount = (uint32_t)dev_exts.size();
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
-#endif
         if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;
         vkGetDeviceQueue(device, queue_family, 0, &queue);
         VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -732,6 +732,12 @@ struct SharedVulkanContext {
     bool compute_subgroup_arithmetic = false;
     uint32_t min_compute_subgroup_size = 0;
     uint32_t max_compute_subgroup_size = 0;
+    // Runtime-selected descriptors (#2412). Same contract as the wave fields above: this is a capability
+    // ENABLED on the borrowed device, not merely one the physical device supports. The compute backend
+    // must not re-query the physical device for it, because whether the features were requested at device
+    // creation is the renderer's decision -- a physically capable device whose owner declined them cannot
+    // execute an indexed descriptor array, and asking the driver would answer the wrong question.
+    bool descriptor_indexing = false;
     uint32_t max_compute_workgroup_subgroups = 0;
     uint32_t max_compute_workgroup_size_x = 0;
     uint32_t max_compute_workgroup_invocations = 0;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -1107,6 +1107,10 @@ inline const RenderVkCtx& render_vk_ctx() {
                 (r.subgroup_operations & VK_SUBGROUP_FEATURE_VOTE_BIT) != 0;
             shared.compute_subgroup_arithmetic =
                 (r.subgroup_operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) != 0;
+            // Publish the descriptor-indexing capability enabled on this device, under the contract stated
+            // above: `r.descriptor_indexing` is set only where the five features were actually requested at
+            // device creation, never from `supported`.
+            shared.descriptor_indexing = r.descriptor_indexing;
             shared.min_compute_subgroup_size = r.min_subgroup_size;
             shared.max_compute_subgroup_size = r.max_subgroup_size;
             shared.max_compute_workgroup_subgroups = r.max_compute_workgroup_subgroups;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -762,6 +762,18 @@ struct RenderVkCtx {
     // Geometry-probe (PROSPER_GEOM_PROBE): transform feedback for final clip-space positions.
     bool transform_feedback_enabled = false;
     bool subgroup_size_control = false;
+    // Runtime-selected descriptors (#2412, stage 1 of the descriptor lift). True only when EVERY feature
+    // the design needs is present, because a partially-available set is not a usable capability: a shader
+    // emitted against an unsized array is invalid without `runtimeDescriptorArray`, and an index that
+    // varies between waves of one workgroup is undefined without the matching non-uniform feature. So
+    // this is deliberately all-or-nothing rather than a bag of independent flags — a caller can treat it
+    // as "may I emit an indexed descriptor array" and be right.
+    //
+    // Measured available on both lanes' hardware: RADV STRIX_HALO and RTX 4090 report all of them true.
+    // The AMD device additionally reports `…NonUniformIndexingNative = false`, which is a performance
+    // note and not a correctness one here: our index is computed in scalar registers so it is
+    // wave-uniform, and a driver waterfall over the distinct values present converges in one iteration.
+    bool descriptor_indexing = false;
     bool compute_full_subgroups = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     uint32_t max_compute_workgroup_subgroups = 0;
@@ -929,6 +941,8 @@ inline const RenderVkCtx& render_vk_ctx() {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES};
         VkPhysicalDeviceTransformFeedbackFeaturesEXT tf_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT};
+        VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
@@ -940,6 +954,60 @@ inline const RenderVkCtx& render_vk_ctx() {
                       irf.pNext = const_cast<void*>(dci.pNext);
                       dci.pNext = &irf;
                       dev_exts.push_back("VK_EXT_image_robustness");
+                  }
+              }
+              if (!strcmp(de[i].extensionName, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
+                  // Stage 1 of the runtime-selected-descriptor lift (#2412). Enabled ONLY when every
+                  // feature the design needs is present -- see `descriptor_indexing` for why this is
+                  // all-or-nothing. Nothing consumes the capability yet; this stage exists so the
+                  // later stages have a device that can express an indexed descriptor array, and so
+                  // that a device which cannot is discovered here rather than at pipeline creation.
+                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                  f2.pNext = &di_features;
+                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+                  const bool have_all =
+                      di_features.runtimeDescriptorArray &&
+                      di_features.descriptorBindingPartiallyBound &&
+                      di_features.shaderStorageBufferArrayNonUniformIndexing &&
+                      di_features.shaderSampledImageArrayNonUniformIndexing &&
+                      di_features.shaderStorageImageArrayNonUniformIndexing;
+                  if (have_all) {
+                      // Request exactly the five, not the whole struct as queried. Enabling a feature
+                      // the design does not use widens the driver contract for no benefit, and a
+                      // later reader cannot tell which ones are load-bearing.
+                      VkPhysicalDeviceDescriptorIndexingFeaturesEXT want{
+                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+                      want.runtimeDescriptorArray = VK_TRUE;
+                      want.descriptorBindingPartiallyBound = VK_TRUE;
+                      want.shaderStorageBufferArrayNonUniformIndexing = VK_TRUE;
+                      want.shaderSampledImageArrayNonUniformIndexing = VK_TRUE;
+                      want.shaderStorageImageArrayNonUniformIndexing = VK_TRUE;
+                      di_features = want;
+                      di_features.pNext = const_cast<void*>(dci.pNext);
+                      dci.pNext = &di_features;
+                      dev_exts.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+                      r.descriptor_indexing = true;
+                      // Log the SUCCESS too, not only the shortfall. A diagnostic that fires only on
+                      // failure makes the working case silent and therefore indistinguishable from code
+                      // that never ran -- which is the ambiguity that has cost this project several false
+                      // zeros today alone. This line is the lever check for stage 1: it is the only way
+                      // to confirm the capability was actually acquired rather than merely compiled.
+                      if (getenv("PROSPER_GFXLOG"))
+                          fprintf(stderr, "[vk] descriptor indexing ENABLED "
+                                          "(runtimeArray+partiallyBound+nonUniform ssbo/sampled/image)\n");
+                  } else if (getenv("PROSPER_GFXLOG")) {
+                      // Report the SHORTFALL, not merely "unavailable": which feature is missing decides
+                      // whether a fallback is possible at all, and a bare "not supported" would send the
+                      // next reader to the extension list when the extension is present.
+                      fprintf(stderr,
+                              "[vk] VK_EXT_descriptor_indexing present but incomplete: "
+                              "runtimeArray=%d partiallyBound=%d ssboNonUniform=%d "
+                              "sampledNonUniform=%d storageImgNonUniform=%d\n",
+                              (int)di_features.runtimeDescriptorArray,
+                              (int)di_features.descriptorBindingPartiallyBound,
+                              (int)di_features.shaderStorageBufferArrayNonUniformIndexing,
+                              (int)di_features.shaderSampledImageArrayNonUniformIndexing,
+                              (int)di_features.shaderStorageImageArrayNonUniformIndexing);
                   }
               }
               if (!strcmp(de[i].extensionName, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) {


### PR DESCRIPTION
Stage 1 of the runtime-selected-descriptor lift (#2412). **Nothing consumes the capability yet** — this stage
exists so later stages have a device that can express an indexed descriptor array, and so a device that cannot
is discovered at device creation rather than at pipeline creation.

## The capability is all-or-nothing, deliberately

`descriptor_indexing` is true only when `runtimeDescriptorArray`, `descriptorBindingPartiallyBound` and the
three non-uniform indexing features are **all** present. A partial set is not a usable capability: an unsized
array is invalid without the first, and an index that varies between waves of one workgroup is undefined
without the others. So a caller reads one flag as *"may I emit an indexed descriptor array"* rather than
re-checking five and getting it subtly wrong.

It requests exactly those five, not the queried struct — enabling features the design does not use widens the
driver contract for nothing and hides which ones are load-bearing.

## Both device sites, and why that is not redundant

Compute creates its **own** device when there is no renderer to adopt from (the shared case logs *"adopted the
renderer's device"*). Covering only graphics would let a compute-only run gate on a flag the graphics device
set, then emit SPIR-V the device cannot execute — silent UB rather than a clean failure.

**Latent bug fixed in passing:** the compute path assigned `dci.enabledExtensionCount` only inside
`#ifdef __APPLE__`, because `VK_KHR_portability_subset` had been the only extension it ever wanted. Leaving it
there would have sent the descriptor-indexing feature struct **without enabling its extension** on Linux and
Windows — a validation error landing nowhere near its cause.

## Logging both outcomes

The success line is this stage's **lever check**: a diagnostic that fires only on failure makes the working
case silent, and therefore indistinguishable from code that never ran. The shortfall line names *which*
feature is missing, because that decides whether a fallback is possible at all — a bare "not supported" would
send a reader to the extension list when the extension is right there.

## Measured on both lanes' hardware

```
RADV STRIX_HALO   all five true, ...NonUniformIndexingNative = false
RTX 4090          all five true, ...NonUniformIndexingNative = true
```

RADV's `Native = false` is a **performance** note, not a correctness one: the index is computed in scalar
registers, so it is wave-uniform, and a driver waterfall over the distinct values present in a wave converges
in one iteration. Recorded so nobody later reads the flag as a blocker.

`NonUniform` will still be required at stage 4 rather than belt-and-braces — measured, not assumed: GTA V has
5 compute programs at `local=256x1x1`, i.e. **four waves per workgroup**, so the index is wave-uniform but not
dispatch-uniform. 43 of 51 launches are one wave per group, which is exactly why the "looks uniform" reading is
tempting and wrong.

## This stays inside the existing addressing model

`FLAT_LOAD_DESIGN.md` (#1171) rejected `buffer_device_address` partly because the emitter uses the **Logical**
addressing model, which forbids physical-storage pointers. Verified still true — `Addr_Logical` in
`OpMemoryModel` at four emitter sites, `PhysicalStorageBuffer` zero occurrences. (That doc's line citation has
gone stale; the claim was re-checked on its own terms.)

An indexed descriptor array is **pure Logical addressing** — no pointer is materialised, the shader selects
among bindings rather than dereferencing an address. So this lift needs no change to `OpMemoryModel`, which is
a materially better position than the alternative that document assessed.

## Verification

```
prosper-app + build-linux                                     build clean
ctest --test-dir prosper/build-linux --no-tests=error -j4      230/230 passed
```

Control, Linux/AMD: **The Messenger (PPSA24651)** boots and renders with the capability enabled — 229 fps
samples, frame grab written, `[vk] descriptor indexing ENABLED` present. Stage 1 is a no-op for existing
titles by construction: the device gains a capability and nothing reads it.

`git diff --check` clean. No `Claude-Session:` trailers.

Refs #2412
