### PR TITLE
docs(dq): record a Windows pre-lift baseline for the descriptor lift's blast radius

### DIFF
--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -449,7 +449,7 @@ wall-clock window, and a 60 s window lands in different phases on different runs
 
 **Every figure in this table is Windows/NVIDIA (RTX 4090), and the wave64 column is a device property, not
 a title property.** Whether a wave64 fragment shader is skipped is decided by a **seven-way disjunction over
-adapter properties** (`render_runner.h:4469`–`:4478`) — subgroup-size control, min and max subgroup size,
+adapter properties** (`render_runner.h:4487`–`:4496`) — subgroup-size control, min and max subgroup size,
 `requiredSubgroupSizeStages`, `subgroupSupportedStages`, the subgroup feature set, and internal-GDS use
 without fragment stores/atomics. On this project's Linux lane — AMD Radeon 8060S (RADV STRIX_HALO) — **all
 seven terms are false**, so that adapter is expected to report **0** skips for the same title:
@@ -478,8 +478,8 @@ committed while assembling a baseline whose purpose is to avoid exactly that.
 ### The wave64 column counts SHADERS, not skipped draws — do not divide it by the draw count
 
 `[render] skip draw: fragment shader requires subgroup size 64` is emitted inside a dedupe guard keyed on
-fragment-shader identity (`render_runner.h:4484`, `logged.insert(shader_key).second`), while the `continue`
-that actually drops the draw sits **outside** it at `:4558`. So the line fires **once per distinct shader**
+fragment-shader identity (`render_runner.h:4502`, `logged.insert(shader_key).second`), while the `continue`
+that actually drops the draw sits **outside** it at `:4576`. So the line fires **once per distinct shader**
 and the skip happens **per draw**: `grep -c` over that message counts shaders, and the number of draws lost
 to wave64 is **not measured by any current diagnostic**.
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -432,7 +432,9 @@ Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 
 ### Assert these — they held on every run
 
 - **`recompile-reject` count is 0.** Every run, rendered or stalled. This title has no recompiler rejects at
-  all, which is what distinguishes it from GTA V's 951 (all `unresolved-operand`) and is why the descriptor
+  all, which is what distinguishes it from GTA V's 951 (all `unresolved-operand`; run-local like every
+  other count here — the same class measured 920–933 across the Linux lane's runs, so do not quote 951
+  as a constant) and is why the descriptor
   lift is **not** expected to change DQ's composite. A non-zero count after the lift is a real regression.
 - **`crc=666f7b3f` on every run that rendered at least one frame**, and `crc=08ed2210` on every run that
   rendered none — 3/3 each way, no overlap. So the crc **also diagnoses which mode a run was in**, which is
@@ -444,6 +446,16 @@ Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 
 **Frames (189–862), draws (1926–3497), and wave64 shader lines (4–21) all vary by more than 2x between runs
 of the same binary.** They are not noise around a value; they depend on how far the boot got inside a fixed
 wall-clock window, and a 60 s window lands in different phases on different runs.
+
+**Every figure in this table is Windows/NVIDIA (RTX 4090), and one of them is 0 on Linux by construction.**
+The wave64 column is a **device property, not a title property**: on Linux/RADV the same title over the same
+route gives **0** skips, because that adapter reports `maxSubgroupSize = 64`, so the `required > max` disjunct
+that accounts for every skip measured here **cannot fire at all**. A Linux reader comparing against this
+baseline would otherwise see 4–21 → 0 and have every reason to file a regression. Frames and draws are
+host-speed-dependent for the same reason the spread above exists — a fixed wall-clock window reaches a
+different point on a different machine — so compare against this table only from a Windows/NVIDIA run, and
+re-derive it locally otherwise. Cross-platform, only the two assertions above (`recompile-reject = 0` and the
+crc dichotomy) carry.
 
 **Draws-per-frame is not an invariant either, and this was nearly recorded as one.** base1 and base2 agreed to
 two decimal places (4.06, 4.05), which looked like a stable normalisation that would survive the ±12% spread

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -447,15 +447,27 @@ Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 
 of the same binary.** They are not noise around a value; they depend on how far the boot got inside a fixed
 wall-clock window, and a 60 s window lands in different phases on different runs.
 
-**Every figure in this table is Windows/NVIDIA (RTX 4090), and one of them is 0 on Linux by construction.**
-The wave64 column is a **device property, not a title property**: on Linux/RADV the same title over the same
-route gives **0** skips, because that adapter reports `maxSubgroupSize = 64`, so the `required > max` disjunct
-that accounts for every skip measured here **cannot fire at all**. A Linux reader comparing against this
-baseline would otherwise see 4–21 → 0 and have every reason to file a regression. Frames and draws are
-host-speed-dependent for the same reason the spread above exists — a fixed wall-clock window reaches a
-different point on a different machine — so compare against this table only from a Windows/NVIDIA run, and
-re-derive it locally otherwise. Cross-platform, only the two assertions above (`recompile-reject = 0` and the
-crc dichotomy) carry.
+**Every figure in this table is Windows/NVIDIA (RTX 4090), and the wave64 column is a device property, not
+a title property.** Whether a wave64 fragment shader is skipped is decided by a **seven-way disjunction over
+adapter properties** (`render_runner.h:4469`–`:4478`) — subgroup-size control, min and max subgroup size,
+`requiredSubgroupSizeStages`, `subgroupSupportedStages`, the subgroup feature set, and internal-GDS use
+without fragment stores/atomics. On this project's Linux lane — AMD Radeon 8060S (RADV STRIX_HALO) — **all
+seven terms are false**, so that adapter is expected to report **0** skips for the same title:
+`subgroupSizeControl=true`, `minSubgroupSize=32`, `maxSubgroupSize=64`, `requiredSubgroupSizeStages` and
+`subgroupSupportedStages` both include `FRAGMENT`, `subgroupSupportedOperations` includes
+VOTE/ARITHMETIC/SHUFFLE, `fragmentStoresAndAtomics=true`. **That 0 is derived from device properties, not
+measured over this route** — no Linux run of this title over this configuration has been taken.
+
+**Surprise is possible in BOTH directions, so re-derive rather than compare.** An adapter that omits
+`FRAGMENT` from `requiredSubgroupSizeStages` fires disjunct 4 for *every* wave64 fragment shader and will read
+far **above** 4–21; an adapter like the Linux lane's reads 0. Neither is a regression. Run `vulkaninfo`
+against the seven properties before concluding anything from this column — citing `maxSubgroupSize` alone is
+not enough, because it licenses only "disjunct 3 cannot fire" and says nothing about the other six.
+
+Frames and draws are host-speed-dependent for the same reason the spread above exists — a fixed wall-clock
+window reaches a different point on a different machine — so compare against this table only from a
+Windows/NVIDIA run, and re-derive it locally otherwise. Cross-platform, only the two assertions above
+(`recompile-reject = 0` and the crc dichotomy) carry.
 
 **Draws-per-frame is not an invariant either, and this was nearly recorded as one.** base1 and base2 agreed to
 two decimal places (4.06, 4.05), which looked like a stable normalisation that would survive the ±12% spread
@@ -466,8 +478,8 @@ committed while assembling a baseline whose purpose is to avoid exactly that.
 ### The wave64 column counts SHADERS, not skipped draws — do not divide it by the draw count
 
 `[render] skip draw: fragment shader requires subgroup size 64` is emitted inside a dedupe guard keyed on
-fragment-shader identity (`render_runner.h:4346`, `logged.insert(shader_key).second`), while the `continue`
-that actually drops the draw sits **outside** it at `:4394`. So the line fires **once per distinct shader**
+fragment-shader identity (`render_runner.h:4484`, `logged.insert(shader_key).second`), while the `continue`
+that actually drops the draw sits **outside** it at `:4558`. So the line fires **once per distinct shader**
 and the skip happens **per draw**: `grep -c` over that message counts shaders, and the number of draws lost
 to wave64 is **not measured by any current diagnostic**.
 

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -409,6 +409,67 @@ current build.
   1.78 M non-zero samples at peak 0.38976. Every port and context line now carries a never-reset
   total for exactly this reason. See instrument-trap 39.
 
+## Windows pre-lift baseline (2026-08-10, master `a6043524`)
+
+Recorded **before** the runtime-selected-descriptor lift (#2412) begins landing its layers, so that a
+cross-title regression on this title is detectable afterwards. The lift changes device creation, reflection,
+SPIR-V emission and the executor, so every title is in its blast radius even though DQ is not the title it
+targets.
+
+Six runs, `screenshot --seconds 60 --count 1`, `PROSPER_NULL_PAGE=1 PROSPER_GUEST_ARGS= `
+`PROSPER_NO_RTT_SNAPSHOT_BORROW=1 PROSPER_GFXLOG=1 PROSPER_DBG=1`, no input route.
+Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 1.4.350.0.
+
+| run | frames | `[render] item` draws | wave64 skips | `recompile-reject` | composite crc |
+| --- | --- | --- | --- | --- | --- |
+| base1 | 862 | 3497 | 4 | 0 | `666f7b3f` |
+| base2 | 769 | 3114 | 4 | 0 | `666f7b3f` |
+| base5 | 189 | 1926 | 21 | 0 | `666f7b3f` |
+| base3 | 0 | 0 | 0 | 0 | `08ed2210` |
+| base4 | 0 | 0 | 0 | 0 | `08ed2210` |
+| base6 | 0 | 0 | 0 | 0 | `08ed2210` |
+
+### Assert these — they held on every run
+
+- **`recompile-reject` count is 0.** Every run, rendered or stalled. This title has no recompiler rejects at
+  all, which is what distinguishes it from GTA V's 951 (all `unresolved-operand`) and is why the descriptor
+  lift is **not** expected to change DQ's composite. A non-zero count after the lift is a real regression.
+- **`crc=666f7b3f` on every run that rendered at least one frame**, and `crc=08ed2210` on every run that
+  rendered none — 3/3 each way, no overlap. So the crc **also diagnoses which mode a run was in**, which is
+  useful because the two are otherwise easy to confuse.
+- Boot reaches guest execution (`File root is /app0/`) on 6 of 6.
+
+### Do NOT assert these — they are phase-dependent and will cry wolf
+
+**Frames (189–862), draws (1926–3497), and wave64 skips (4–21) all vary by more than 2x between runs of the
+same binary.** They are not noise around a value; they depend on how far the boot got inside a fixed
+wall-clock window, and a 60 s window lands in different phases on different runs.
+
+**Draws-per-frame is not an invariant either, and this was nearly recorded as one.** base1 and base2 agreed to
+two decimal places (4.06, 4.05), which looked like a stable normalisation that would survive the ±12% spread
+in the raw counts. base5 gives **10.19**. The agreement was coincidence — both runs happened to sample the
+same phase. This is instrument trap 146 (a ratio over a moving sequence measures *when the window landed*),
+committed while assembling a baseline whose purpose is to avoid exactly that.
+
+### The acceptance rule, which is load-bearing
+
+**A run counts only if it reached guest execution AND rendered at least one frame.** `File root is /app0/`
+alone is insufficient: base3/4/6 all satisfy it, render nothing, and return a *different crc*. Scored
+naively, the baseline would read "crc may be either value" and a stalled run after the lift would present as a
+composite change.
+
+### Stall rate here is 50%, and that is an apparatus figure
+
+3 of 6 runs rendered nothing. That is far worse than the **1 stall in 11** measured on 120 s runs **without**
+`GFXLOG`/`DBG` (#2448) — those diagnostics are high-volume and slow the boot, so a 60 s window is much more
+likely to close before rendering starts. **Do not quote 50% as a property of the title**; it is the rate for
+*this* configuration. The comparable no-diagnostic figure is on #2448.
+
+### How to use this after a lift stage lands
+
+Re-run the same command, discard any run that fails the acceptance rule, and compare only the asserted
+invariants. A change in frames, draws or wave64 skips is **not** evidence of anything on its own.
+
 ## Ruled out — eliminated, do not re-run these
 
 - **"The failing draws run with the previous pipeline's *user data*."** This title's own

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -420,7 +420,7 @@ Six runs, `screenshot --seconds 60 --count 1`, `PROSPER_NULL_PAGE=1 PROSPER_GUES
 `PROSPER_NO_RTT_SNAPSHOT_BORROW=1 PROSPER_GFXLOG=1 PROSPER_DBG=1`, no input route.
 Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 1.4.350.0.
 
-| run | frames | `[render] item` draws | wave64 skips | `recompile-reject` | composite crc |
+| run | frames | `[render] item` draws | wave64 shader lines | `recompile-reject` | composite crc |
 | --- | --- | --- | --- | --- | --- |
 | base1 | 862 | 3497 | 4 | 0 | `666f7b3f` |
 | base2 | 769 | 3114 | 4 | 0 | `666f7b3f` |
@@ -441,8 +441,8 @@ Windows 11, RTX 4090 driver 32.0.16.1047, MinGW-w64 UCRT gcc 16.1.0, Vulkan SDK 
 
 ### Do NOT assert these — they are phase-dependent and will cry wolf
 
-**Frames (189–862), draws (1926–3497), and wave64 skips (4–21) all vary by more than 2x between runs of the
-same binary.** They are not noise around a value; they depend on how far the boot got inside a fixed
+**Frames (189–862), draws (1926–3497), and wave64 shader lines (4–21) all vary by more than 2x between runs
+of the same binary.** They are not noise around a value; they depend on how far the boot got inside a fixed
 wall-clock window, and a 60 s window lands in different phases on different runs.
 
 **Draws-per-frame is not an invariant either, and this was nearly recorded as one.** base1 and base2 agreed to
@@ -450,6 +450,22 @@ two decimal places (4.06, 4.05), which looked like a stable normalisation that w
 in the raw counts. base5 gives **10.19**. The agreement was coincidence — both runs happened to sample the
 same phase. This is instrument trap 146 (a ratio over a moving sequence measures *when the window landed*),
 committed while assembling a baseline whose purpose is to avoid exactly that.
+
+### The wave64 column counts SHADERS, not skipped draws — do not divide it by the draw count
+
+`[render] skip draw: fragment shader requires subgroup size 64` is emitted inside a dedupe guard keyed on
+fragment-shader identity (`render_runner.h:4346`, `logged.insert(shader_key).second`), while the `continue`
+that actually drops the draw sits **outside** it at `:4394`. So the line fires **once per distinct shader**
+and the skip happens **per draw**: `grep -c` over that message counts shaders, and the number of draws lost
+to wave64 is **not measured by any current diagnostic**.
+
+This is recorded because the mistake is easy and was made here: a census on #2448 compared this count against
+the `[render] item` draw total and reported *"22 skipped draws of 1,467, i.e. 1.5%"*, concluding that wave64
+could not explain a black composite. **Numerator and denominator were different units.** The conclusion may
+still be right, but that measurement does not support it, and the honest statement is that the skipped-draw
+count is unknown.
+
+Counting skipped draws needs a counter at the `continue`, not at the log line.
 
 ### The acceptance rule, which is load-bearing
 


### PR DESCRIPTION
Refs #2412, #2448, #1874. Docs-only, one section added to `DRAGON_QUEST_STATUS.md`.

## Why now

The descriptor lift changes **device creation, reflection, SPIR-V emission and the executor**. Every title is
in that blast radius, including ones the lift does not target. This records what DQ does on Windows *before*
the layers land, so a later regression is detectable rather than argued about from memory — and it has a
deadline set by someone else's work, since a baseline taken after stage 2 measures stage 2.

## What is assertable — held on 6 of 6 runs

- **`recompile-reject` = 0.** This title has no recompiler rejects at all, against GTA V's 951 (all
  `unresolved-operand`). That is also why the lift is **not** expected to change DQ's composite: it is not on
  the descriptor-resolution frontier. A non-zero count afterwards is a genuine regression.
- **`crc=666f7b3f` on every run that rendered ≥1 frame; `crc=08ed2210` on every run that rendered none** —
  3/3 each way, no overlap. The crc therefore also identifies *which mode* a run was in.

## What is NOT assertable, and nearly was

Frames (189–862), draws (1926–3497) and wave64 skips (4–21) vary **more than 2x** between runs of the same
binary. They depend on how far the boot got inside a fixed wall-clock window.

**Draws-per-frame was nearly recorded as the headline invariant.** base1 and base2 agreed to two decimal
places — 4.06 and 4.05 — which looked like exactly the normalisation that would survive the ±12% spread in
raw counts. base5 gives **10.19**. The agreement was coincidence: both runs happened to sample the same phase.

That is **instrument trap 146 committed while assembling a baseline whose purpose is to avoid it** — a ratio
over a moving sequence measures when the window landed, not correctness. The section records the near-miss
rather than dropping the metric quietly, because the next person will find 4.06 and 4.05 just as convincing as
I did.

## The acceptance rule is load-bearing

A run counts only if it reached guest execution **and** rendered ≥1 frame. `File root is /app0/` alone is
insufficient: three runs satisfy it, render nothing, and return a *different* crc. Scored naively the baseline
would read "crc may be either value", and a stalled run after the lift would present as a composite change.

## One figure explicitly marked as apparatus

The 50% stall rate in this batch is for **60 s runs under `GFXLOG`+`DBG`**, which are high-volume and slow the
boot. The comparable no-diagnostic figure is **1 in 11** on 120 s runs (#2448). The section says not to quote
the 50% as a property of the title.

## Verification

```
git diff --check                                     -> clean (rc=0)
all-md numbered-table gate                           -> clean
non-.md files in diff                                -> 0
session-trailer gate                                 -> 0
```

Docs-only, but it defines the regression criteria another lane will rely on when the lift lands, so I would
rather have a reader than merge it on my own judgement.
