### PR TITLE
feat(gpu): carry table-indexed descriptor provenance on ShaderResource (stage 2)

### DIFF
--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -186,6 +186,34 @@ struct ShaderResource {
     uint32_t      srt_offset    = 0xFFFFFFFFu;
     uint32_t      sgpr_base     = 0xFFFFFFFFu;
 
+    // TABLE-INDEXED provenance (#2412, stage 2 of the runtime-selected-descriptor lift). A fifth,
+    // deliberately SEPARATE shape rather than a variation on the four above.
+    //
+    // The others all answer "where did this descriptor come from" -- an SRT offset, an SGPR index, a
+    // fetch pc. This one cannot: the shader loads a descriptor from a table at an index that is only
+    // known on the GPU (GTA V derives it from EXEC after `s_and_saveexec_b64`), so the descriptor is
+    // identified by *a table plus a runtime index*, not by an origin. Folding it into `srt_offset`
+    // would be the tempting shortcut and would erase exactly the distinction later validation has to
+    // see: `srt_offset` promises "the descriptor is AT this offset", while this promises "the
+    // descriptor is one OF these, selected later".
+    //
+    // `table_index_count` is the number of array elements the binding declares -- 0 means this resource
+    // is not table-indexed and the stride below is inert, so existing resources are unaffected by
+    // construction. When non-zero, `binding` names the ARRAY and the shader supplies the element.
+    //
+    // Nothing produces these yet. This stage is representation only; the following stages teach
+    // reflection and validation to see an array, emit the indexed access, and materialise the entries.
+    // The count is carried here first so those stages have something to agree about, and so a
+    // half-finished lift cannot be mistaken for a working one: a resource with a count but no
+    // reflection support must be REJECTED, not bound.
+    uint32_t      table_index_count = 0;
+
+    // Byte stride between consecutive descriptors in the guest table. 16 for a V#, 32 for a T#; kept
+    // explicit rather than derived from `cls` because the guest chooses the packing and a table of
+    // V#s addressed with a 32-byte stride is a real shape (padded slots) that must not be silently
+    // re-packed.
+    uint32_t      table_entry_stride = 0;
+
     // Exact input-side origin for a DIRECT four-dword V# in the PM4 SH register file. This is
     // runtime realization provenance only; it does not affect descriptor binding or shader-cache
     // identity. The front half sets an absolute SPI_SHADER_USER_DATA_* register when it can prove

--- a/prosper/tests/test_convention_bindings.cpp
+++ b/prosper/tests/test_convention_bindings.cpp
@@ -107,6 +107,43 @@ int main() {
               "an empty vertex chain retains the absent resource-table contract");
     }
 
+    // Stage 2 of the runtime-selected-descriptor lift (#2412): TABLE-INDEXED provenance is a fifth,
+    // separate shape and must be INERT until the later stages exist. These arms pin that, because the
+    // failure mode of a half-finished lift is a resource carrying an array count that some layer then
+    // treats as a scalar binding — which today validates SILENTLY (no DescriptorIssueCode covers an
+    // array-vs-scalar mismatch), so nothing would report it.
+    {
+        ShaderResource r;
+        CHECK(r.table_index_count == 0 && r.table_entry_stride == 0,
+              "table-indexed fields default to inert, so existing resources are unaffected by construction");
+
+        // A count is NOT a provenance key: it must not disturb the four mutually-exclusive ones, and a
+        // table-indexed resource still resolves by whichever of them it carries.
+        ShaderResource t;
+        t.cls = ResourceClass::ConstantBuffer;
+        t.srt_offset = 0x40;
+        t.table_index_count = 8;
+        t.table_entry_stride = 16;
+        CHECK(t.srt_offset == 0x40 && t.sgpr_base == 0xFFFFFFFFu &&
+                  t.fetch_pc == 0xFFFFFFFFu,
+              "a table-indexed resource leaves the four origin keys exactly as set");
+
+        // Binding assignment must be untouched by the count: `binding` names the ARRAY, and stage 2
+        // changes no layout. If this ever differs, a later stage has silently repurposed the binding
+        // scalar and every existing table's layout moves with it.
+        auto tbl = std::make_shared<ShaderResourceTable>();
+        ShaderResource a; a.cls = ResourceClass::ConstantBuffer; a.srt_offset = 0x00;
+        ShaderResource b; b.cls = ResourceClass::ConstantBuffer; b.srt_offset = 0x10;
+        b.table_index_count = 4; b.table_entry_stride = 16;
+        tbl->resources = {a, b};
+        assign_convention_bindings(*tbl, 2);
+        CHECK(tbl->resources[0].binding == 2 && tbl->resources[1].binding == 3,
+              "an array count does not change how bindings are assigned (stage 2 is representation only)");
+        CHECK(tbl->resources[1].table_index_count == 4 &&
+                  tbl->resources[1].table_entry_stride == 16,
+              "binding assignment preserves the array count and stride it did not set");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Stage 2 of the runtime-selected-descriptor lift. **Representation only** — two fields on `ShaderResource`, nothing produces them, nothing reads them.

Refs #2412.

## Why this shape is needed

GTA V (`PPSA04263`) loads a descriptor from a table at an index the CPU cannot know. Measured chain:

```
EXEC (narrowed by s_and_saveexec_b64)
  -> s_mov_b64 vcc, exec                              VCC unknowable to a CPU fold
  -> s_buffer_load_dwordx4 s[92:95], s[28:31], vcc_lo  soffset unknown -> load FAILS
  -> forgets its destination                          = V# word 0
  -> MUBUF srsrc has no descriptor                    10,153/10,153 writer-BEFORE-use
  -> unresolved-operand -> 53 compute dispatches skipped -> world never shaded
```

Expressing that resource at all needs a shape prosper does not currently have.

## The design decision under review

`table_index_count` / `table_entry_stride` are a **fifth, deliberately separate** provenance shape rather than a variation on the four that exist.

The existing four — `fetch_pc`, `srt_offset`, `sgpr_base`, and the direct-V# register origin — all answer *"where did this descriptor come from"*. **This one cannot.** The descriptor is identified by *a table plus a runtime index*, not by an origin.

Folding it into `srt_offset` is the tempting shortcut, and it would erase exactly the distinction later validation has to see:

| field | promises |
| --- | --- |
| `srt_offset` | the descriptor is **AT** this offset |
| `table_index_count` | the descriptor is **one OF** these, selected later |

Two further choices worth challenging:

- **`table_index_count == 0` means "not table-indexed"**, and the stride is then inert. Existing resources are unaffected *by construction* rather than by inspection — there is no value of the old fields that changes meaning.
- **The stride is explicit rather than derived from `cls`.** The guest chooses the packing, and a table of V#s addressed with a 32-byte stride is a real shape (padded slots). Deriving 16-from-V# would silently re-pack it.

## Why it lands before its consumers

So the consuming stages have something to agree about, and so a half-finished lift cannot be mistaken for a working one: a resource carrying a count but with no reflection support behind it must be **rejected**, not bound.

## Tests — and what they cannot establish

Four arms in `test_convention_bindings`. Stating the limit plainly: **there is no behavior in this PR, so these are compile-and-invariant guards, not proof of function.** No mutation arm is possible for a field nothing reads.

```
[ok]   table-indexed fields default to inert, so existing resources are unaffected by construction
[ok]   a table-indexed resource leaves the four origin keys exactly as set
[ok]   an array count does not change how bindings are assigned (stage 2 is representation only)
[ok]   binding assignment preserves the array count and stride it did not set
```

The last two are the ones with teeth: they fail if a later change makes the count participate in binding assignment, which is the specific regression this stage must not introduce.

## Affected / unaffected

- **Affected:** the layout of `ShaderResource` (two `uint32_t` appended in the provenance group).
- **Deliberately unaffected:** binding assignment, reflection, validation, materialization, every backend, and the capture format. No behavior changes on any title.
- **Not in this PR:** the `DescriptorIssueCode` for arity mismatch and the validation that fires it (that is the next stage, split out on the reviewer's structuring), the SPIR-V array emission, and materialization.

## Risks

Low. The fields are inert and additive. The real risk is *conceptual* and is what review should attack: if the fifth shape is the wrong decomposition, every later stage inherits it. Worth pushing on now rather than at stage 5.

## Verification at exact head `84caea2c`

```
cmake --build prosper/build-linux -j6                              -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4          -> 230/230 passed, rc=0
git diff --cached --check                                          -> clean
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:' -> 0
```

Independent of #2458 (stage 1) — review in either order.
