### PR TITLE
feat(gpu): reflect the declared descriptor-array arity, and assert the direction stage 3 could not (stage 4a)

### DIFF
--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -409,6 +409,43 @@ SpirvDescriptorKind descriptor_kind(const VariableInfo& var,
     return SpirvDescriptorKind::Unknown;
 }
 
+// How many descriptors this ONE binding declares (#2412 stage 4). 1 for an ordinary binding, N for
+// `OpTypeArray` of descriptors with a resolved length, 0 for `OpTypeRuntimeArray` (length supplied at
+// bind time).
+//
+// Deliberately conservative, because every existing shader must keep reporting 1 and a wrong answer
+// here now REJECTS a draw (stage 3 turned an arity mismatch into an error). Two guards:
+//
+//   - Only the OUTERMOST wrapper counts. `descriptor_kind` walks *through* arrays to find the
+//     underlying image or block, so it cannot distinguish "an array of eight buffers" from "one buffer
+//     whose block contains an array" -- and those are entirely different bindings. A storage buffer's
+//     block almost always contains a runtime array (that is the buffer's data), so anything deeper than
+//     one level is the buffer's own contents and not a descriptor count.
+//   - The wrapper's element must itself be descriptor-shaped (Struct, Image, SampledImage). A pointer
+//     to a bare array of scalars is not a descriptor array, and reading it as one would report an
+//     arity that rejects a binding that has always worked.
+//
+// A resolved length of zero from `OpTypeArray` is reported as a runtime array rather than as "no
+// descriptors": the count is resolved from `OpConstant` earlier in this pass, and a length that failed
+// to resolve leaves `count` at 0. Reporting 1 there would silently bind element 0 of an array whose
+// size we could not read.
+uint32_t descriptor_array_arity(const VariableInfo& var,
+                                const std::unordered_map<uint32_t, TypeInfo>& types) {
+    auto pi = types.find(var.pointer_type);
+    if (pi == types.end() || pi->second.kind != TypeKind::Pointer) return 1;
+    auto outer = types.find(pi->second.element);
+    if (outer == types.end()) return 1;
+    if (outer->second.kind != TypeKind::Array && outer->second.kind != TypeKind::RuntimeArray)
+        return 1;
+    auto elem = types.find(outer->second.element);
+    if (elem == types.end()) return 1;
+    if (elem->second.kind != TypeKind::Struct && elem->second.kind != TypeKind::Image &&
+        elem->second.kind != TypeKind::SampledImage)
+        return 1;
+    if (outer->second.kind == TypeKind::RuntimeArray) return 0;
+    return outer->second.count ? outer->second.count : 0;
+}
+
 const TypeInfo* descriptor_image_type(const VariableInfo& var,
                                       const std::unordered_map<uint32_t, TypeInfo>& types) {
     auto pi = types.find(var.pointer_type);
@@ -739,6 +776,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     }
 
     std::unordered_map<uint32_t, SpirvDescriptorKind> descriptor_vars;
+    std::unordered_map<uint32_t, uint32_t> descriptor_arities;
     std::set<uint32_t> sampled_float_vars;
     std::set<uint32_t> storage_float_vars;
     std::unordered_map<uint32_t, SpirvImageNumericClass> image_numeric_classes;
@@ -746,6 +784,7 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         SpirvDescriptorKind kind = descriptor_kind(var, types);
         if (kind != SpirvDescriptorKind::Unknown) {
             descriptor_vars[id] = kind;
+            descriptor_arities[id] = descriptor_array_arity(var, types);
             const SpirvImageNumericClass numeric_class =
                 descriptor_image_numeric_class(var, types);
             image_numeric_classes[id] = numeric_class;
@@ -940,6 +979,10 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
             image_arrayed, image_multisampled, image_depth,
             atomic_vars.count(var) != 0};
         descriptor.image_numeric_class = image_numeric_classes[var];
+        // Assigned here rather than added to the initializer above: that initializer is positional and
+        // names no field, so extending it is how #2462 happens. See the note on the member.
+        if (auto ai = descriptor_arities.find(var); ai != descriptor_arities.end())
+            descriptor.descriptor_count = ai->second;
         const uint64_t marker_key = (static_cast<uint64_t>(descriptor.set) << 32u) |
                                     descriptor.binding;
         if (auto marker = zero_pad_markers.find(marker_key); marker != zero_pad_markers.end()) {

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -425,10 +425,12 @@ SpirvDescriptorKind descriptor_kind(const VariableInfo& var,
 //     to a bare array of scalars is not a descriptor array, and reading it as one would report an
 //     arity that rejects a binding that has always worked.
 //
-// A resolved length of zero from `OpTypeArray` is reported as a runtime array rather than as "no
-// descriptors": the count is resolved from `OpConstant` earlier in this pass, and a length that failed
-// to resolve leaves `count` at 0. Reporting 1 there would silently bind element 0 of an array whose
-// size we could not read.
+// An `OpTypeArray` whose length did not resolve reports `kDescriptorArityUnknown`, NOT 0 and not 1.
+// All three were considered and the first two are wrong in opposite directions: 1 would silently bind
+// element 0 of an array whose size we could not read, and 0 means `OpTypeRuntimeArray` -- which
+// validation treats as compatible with any table size, so a decode failure would become the most
+// permissive answer available. Unknown must be the least permissive, because it is the case we know
+// least about; validation rejects it regardless of what the table supplies.
 uint32_t descriptor_array_arity(const VariableInfo& var,
                                 const std::unordered_map<uint32_t, TypeInfo>& types) {
     auto pi = types.find(var.pointer_type);
@@ -443,7 +445,11 @@ uint32_t descriptor_array_arity(const VariableInfo& var,
         elem->second.kind != TypeKind::SampledImage)
         return 1;
     if (outer->second.kind == TypeKind::RuntimeArray) return 0;
-    return outer->second.count ? outer->second.count : 0;
+    // No `count ? count : 0` no-op here: an unresolved length is its own answer. `count` stays 0 when
+    // the length id resolved to no `OpConstant` in this pass -- an `OpSpecConstant`, or a constant this
+    // pass does not decode.
+    if (outer->second.count == 0) return kDescriptorArityUnknown;
+    return outer->second.count;
 }
 
 const TypeInfo* descriptor_image_type(const VariableInfo& var,
@@ -1104,7 +1110,13 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         const uint32_t runtime_count = r.table_index_count;
         const bool shader_is_array  = shader_count != 1;
         const bool runtime_is_array = runtime_count != 0;
-        if (shader_is_array != runtime_is_array ||
+        // An unread array length is a mismatch whatever the table supplies -- tested FIRST and named,
+        // rather than left to fall out of the comparison below. The arithmetic would reject it today
+        // (kDescriptorArityUnknown equals neither 1 nor any plausible table size), but only by accident:
+        // the sentinel would stop rejecting the moment someone changed the comparison, and nothing in
+        // the expression would show that a decode failure was ever meant to be caught here.
+        const bool shader_arity_unknown = shader_count == kDescriptorArityUnknown;
+        if (shader_arity_unknown || shader_is_array != runtime_is_array ||
             (shader_is_array && shader_count != 0 && shader_count != runtime_count)) {
             // The counts go in their own fields and the byte slots stay zero. An earlier revision rode
             // them in `required_bytes`/`available_bytes` on the belief that nothing rendered those --

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -500,6 +500,17 @@ enum class StorageBufferTailSemantic : uint32_t {
 // recompiler, reflection, live backend, and their contract tests cannot drift through magic values.
 constexpr uint32_t kSpirvImageFormatR32ui = 33;
 
+// A declared descriptor-array length that reflection could not read (#2412). Distinct from 0, which
+// means exactly `OpTypeRuntimeArray` -- a length deliberately supplied at bind time and therefore
+// compatible with any table size.
+//
+// The distinction is load-bearing rather than tidy. Validation treats 0 as permissive, so folding
+// "unresolved" into it made a DECODE FAILURE the most permissive value in the space, inside the check
+// whose entire purpose is to stop silent acceptance: a shader declaring 16 entries whose length did not
+// resolve was accepted against a table of 8, and then indexes past the set. An `OpSpecConstant` length
+// reaches this -- valid SPIR-V, and `OpSpecConstant` is not among the opcodes this pass resolves.
+inline constexpr uint32_t kDescriptorArityUnknown = 0xFFFFFFFFu;
+
 struct SpirvDescriptorBinding {
     uint32_t variable_id = 0;
     uint32_t set = 0;

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -83,6 +83,31 @@ static std::vector<uint32_t> descriptor_test_spirv() {
     return s;
 }
 
+// An ARRAY of eight storage-buffer descriptors at one binding (#2412 stage 4). Same shape as
+// descriptor_test_spirv, with the variable's pointee wrapped in `OpTypeArray %Block %8` so the binding
+// declares eight descriptors rather than one, and the access chain carrying the extra leading index that
+// selects among them.
+static std::vector<uint32_t> descriptor_array_test_spirv() {
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 32, 0};
+    emit(s, 15, {0, 20, 0x6e69616d, 0});                    // OpEntryPoint Vertex %20 "main"
+    emit(s, 21, {1, 32, 0});                                // %1 = u32
+    emit(s, 29, {2, 1});                                    // %2 = runtime array u32 (the block's data)
+    emit(s, 30, {3, 2});                                    // %3 = struct {%2}  -- the Block
+    emit(s, 43, {1, 14, 8});                                // %14 = 8
+    emit(s, 28, {15, 3, 14});                               // %15 = array of 8 x %3  <- descriptor array
+    emit(s, 32, {4, 12, 15});                               // %4 = StorageBuffer pointer to the ARRAY
+    emit(s, 32, {5, 12, 1});                                // %5 = StorageBuffer pointer to u32
+    emit(s, 43, {1, 6, 0});                                 // %6 = 0
+    emit(s, 43, {1, 7, 4});                                 // %7 = 4
+    emit(s, 59, {4, 8, 12});                                // %8 = the array-of-descriptors variable
+    emit(s, 71, {2, 6, 4});                                 // ArrayStride 4 on the block's data
+    emit(s, 72, {3, 0, 35, 0});                             // member 0 Offset 0
+    emit(s, 71, {8, 34, 0}); emit(s, 71, {8, 33, 9});       // set 0 binding 9
+    emit(s, 65, {5, 9, 8, 6, 6, 7});                        // %9 = &buffer[0][0][4] -- extra leading index
+    emit(s, 61, {1, 10, 9});                                // %10 = load %9
+    return s;
+}
+
 static std::vector<uint32_t> atomic_descriptor_test_spirv() {
     std::vector<uint32_t> s = descriptor_test_spirv();
     // %12 points at binding 10. AtomicAnd is result-producing, so its pointer is operand 2 after
@@ -556,6 +581,42 @@ int main() {
     auto sok = validate_spirv_descriptor_interface(spv, &scalar_ok, 0, SpirvShaderStage::Vertex);
     CHECK(!has_issue(sok, DescriptorIssueCode::ArrayBindingArityMismatch),
           "an ordinary scalar resource is not reported as an arity mismatch");
+
+    // Stage 4: reflection reports the DECLARED arity. Before this, an array of eight descriptors
+    // reflected as one binding and the count was invisible, which is what made the mismatch above
+    // undetectable from the shader side.
+    const std::vector<uint32_t> array_spv = descriptor_array_test_spirv();
+    ShaderResourceTable array_runtime; array_runtime.resources.push_back(table_indexed);
+    auto avr = validate_spirv_descriptor_interface(array_spv, &array_runtime, 0,
+                                                   SpirvShaderStage::Vertex);
+    const SpirvDescriptorBinding* abind = find_spirv_descriptor_binding(avr, 0, 9);
+    CHECK(abind && abind->descriptor_count == 8,
+          "reflection reports eight descriptors for an OpTypeArray of eight blocks at one binding");
+
+    // The DIRECTION stage 3 could not construct, now constructible and asserted: SPIR-V declaring an
+    // array against a runtime table supplying a single descriptor must be rejected. This is the arm
+    // stage 3's PR promised would land with stage 4.
+    ShaderResourceTable array_vs_scalar; array_vs_scalar.resources.push_back(good);
+    auto asr = validate_spirv_descriptor_interface(array_spv, &array_vs_scalar, 0,
+                                                   SpirvShaderStage::Vertex);
+    CHECK(!asr.ok() && has_issue(asr, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "a shader-declared descriptor array bound against a single resource is rejected");
+
+    // Discriminator for the arity REPORT, not merely for the issue: the ordinary fixture must still
+    // report exactly one descriptor. Without this, `descriptor_count = 8` everywhere would satisfy the
+    // two arms above.
+    ShaderResourceTable one; one.resources.push_back(good);
+    auto onr = validate_spirv_descriptor_interface(spv, &one, 0, SpirvShaderStage::Vertex);
+    const SpirvDescriptorBinding* obind = find_spirv_descriptor_binding(onr, 0, 9);
+    CHECK(obind && obind->descriptor_count == 1,
+          "an ordinary non-array binding still reflects exactly one descriptor");
+
+    // And the matched pair validates: eight declared against eight supplied raises no arity issue.
+    ShaderResource eight = good; eight.table_index_count = 8; eight.table_entry_stride = 16;
+    ShaderResourceTable matched; matched.resources.push_back(eight);
+    auto mar = validate_spirv_descriptor_interface(array_spv, &matched, 0, SpirvShaderStage::Vertex);
+    CHECK(!has_issue(mar, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "eight declared descriptors against eight supplied table entries is not an arity mismatch");
 
     // --- validate_runtime_descriptor_contract: the mode-carrying overload (#2239 candidate 3) ---
     //

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -108,6 +108,30 @@ static std::vector<uint32_t> descriptor_array_test_spirv() {
     return s;
 }
 
+// The same eight-descriptor array with its length as an `OpSpecConstant` instead of `OpConstant`, so the
+// length id resolves to nothing in this pass and the arity is genuinely UNREADABLE (#2412). Valid SPIR-V;
+// `OpSpecConstant` (50) is not among the opcodes reflection decodes into `constants`.
+static std::vector<uint32_t> descriptor_array_specconst_test_spirv() {
+    std::vector<uint32_t> s = {0x07230203u, 0x00010000u, 0, 32, 0};
+    emit(s, 15, {0, 20, 0x6e69616d, 0});                    // OpEntryPoint Vertex %20 "main"
+    emit(s, 21, {1, 32, 0});                                // %1 = u32
+    emit(s, 29, {2, 1});                                    // %2 = runtime array u32 (the block's data)
+    emit(s, 30, {3, 2});                                    // %3 = struct {%2}  -- the Block
+    emit(s, 50, {1, 14, 8});                                // %14 = OpSpecConstant 8  <- NOT resolved
+    emit(s, 28, {15, 3, 14});                               // %15 = array of %14 x %3
+    emit(s, 32, {4, 12, 15});                               // %4 = StorageBuffer pointer to the ARRAY
+    emit(s, 32, {5, 12, 1});                                // %5 = StorageBuffer pointer to u32
+    emit(s, 43, {1, 6, 0});                                 // %6 = 0
+    emit(s, 43, {1, 7, 4});                                 // %7 = 4
+    emit(s, 59, {4, 8, 12});                                // %8 = the array-of-descriptors variable
+    emit(s, 71, {2, 6, 4});                                 // ArrayStride 4 on the block's data
+    emit(s, 72, {3, 0, 35, 0});                             // member 0 Offset 0
+    emit(s, 71, {8, 34, 0}); emit(s, 71, {8, 33, 9});       // set 0 binding 9
+    emit(s, 65, {5, 9, 8, 6, 6, 7});                        // %9 = &buffer[0][0][4]
+    emit(s, 61, {1, 10, 9});                                // %10 = load %9
+    return s;
+}
+
 static std::vector<uint32_t> atomic_descriptor_test_spirv() {
     std::vector<uint32_t> s = descriptor_test_spirv();
     // %12 points at binding 10. AtomicAnd is result-producing, so its pointer is operand 2 after
@@ -617,6 +641,34 @@ int main() {
     auto mar = validate_spirv_descriptor_interface(array_spv, &matched, 0, SpirvShaderStage::Vertex);
     CHECK(!has_issue(mar, DescriptorIssueCode::ArrayBindingArityMismatch),
           "eight declared descriptors against eight supplied table entries is not an arity mismatch");
+
+    // An UNREADABLE array length is its own value, not folded onto 0 (which means OpTypeRuntimeArray and
+    // is treated as compatible with any table size). Reported as a review finding on #2463: collapsing
+    // the two made a decode failure the most permissive answer in the space.
+    const std::vector<uint32_t> spec_spv = descriptor_array_specconst_test_spirv();
+    ShaderResourceTable spec_eight; spec_eight.resources.push_back(eight);
+    auto spr = validate_spirv_descriptor_interface(spec_spv, &spec_eight, 0, SpirvShaderStage::Vertex);
+    const SpirvDescriptorBinding* sbind = find_spirv_descriptor_binding(spr, 0, 9);
+    CHECK(sbind && sbind->descriptor_count == kDescriptorArityUnknown,
+          "an OpSpecConstant array length reflects as unknown arity, not as zero or one");
+
+    // The property that matters, and the one the previous revision got wrong: rejected REGARDLESS of what
+    // the table supplies. Eight entries is the size that would have been ACCEPTED when unknown collapsed
+    // onto 0, so this arm fails on the exact defect rather than merely near it.
+    CHECK(!spr.ok() && has_issue(spr, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "an unreadable array length is rejected even against a table that supplies eight entries");
+
+    ShaderResourceTable spec_scalar; spec_scalar.resources.push_back(good);
+    auto ssr = validate_spirv_descriptor_interface(spec_spv, &spec_scalar, 0, SpirvShaderStage::Vertex);
+    CHECK(!ssr.ok() && has_issue(ssr, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "an unreadable array length is rejected against a scalar resource too");
+
+    // Discriminator: a genuine OpTypeRuntimeArray must still mean "any length", so the fix above must not
+    // have made every unresolved-looking array reject. Zero and unknown are different answers.
+    SpirvDescriptorBinding probe{};
+    probe.descriptor_count = 0;
+    CHECK(probe.descriptor_count != kDescriptorArityUnknown,
+          "zero (OpTypeRuntimeArray) and unknown arity are distinct values");
 
     // --- validate_runtime_descriptor_contract: the mode-carrying overload (#2239 candidate 3) ---
     //


### PR DESCRIPTION
Stage 4a of the runtime-selected-descriptor lift. **Stacked on #2461** (stage 3).

Refs #2412.

## What this closes

Stage 3 introduced `ArrayBindingArityMismatch` but could only test **one** direction — a table-indexed resource against a shader reflecting a single descriptor. The reverse (SPIR-V declaring an array against a scalar resource) was **inexpressible**, because reflection always reported one descriptor per binding. #2461's description committed to that arm landing with stage 4. **This is that arm, plus the reflection that makes it possible.**

## `descriptor_array_arity()`

Reports what a binding declares: **1** ordinary, **N** for `OpTypeArray` with a resolved length, **0** for `OpTypeRuntimeArray`.

Deliberately conservative, because every existing shader must keep reporting 1 and — since stage 3 — a wrong answer here now **rejects a draw**:

- **Only the outermost wrapper counts.** `descriptor_kind` walks *through* arrays to reach the underlying image or block, so it cannot tell "an array of eight buffers" from "one buffer whose block contains an array". A storage buffer's block almost always contains a runtime array — that is the buffer's *data*. Anything deeper than one level is contents, not a count.
- **The wrapper's element must itself be descriptor-shaped** (`Struct`/`Image`/`SampledImage`). A pointer to a bare array of scalars is not a descriptor array, and reading it as one would reject a binding that has always worked.
- **An `OpTypeArray` whose length did not resolve reports 0**, not 1. Reporting 1 would silently bind element 0 of an array whose size we could not read.

Assigned to the reflected binding **after** construction rather than by extending the positional aggregate initializer — see #2462.

## Tests

```
[ok]   reflection reports eight descriptors for an OpTypeArray of eight blocks at one binding
[ok]   a shader-declared descriptor array bound against a single resource is rejected
[ok]   an ordinary non-array binding still reflects exactly one descriptor
[ok]   eight declared descriptors against eight supplied table entries is not an arity mismatch
```

New fixture `descriptor_array_test_spirv()` — the existing `descriptor_test_spirv` shape with the variable's pointee wrapped in `OpTypeArray %Block %8`, and the access chain carrying the extra leading index that selects among the eight.

Arms 3 and 4 are the ones that make arms 1 and 2 mean something: without arm 3, returning 8 unconditionally would satisfy both; without arm 4, rejecting every array would.

**Mutation arm, predicted before running.** Neutering the probe to `return 1` should fail exactly the three arms that depend on it and leave the discriminator alone. Observed:

```
FAIL count: 3
  [FAIL] reflection reports eight descriptors for an OpTypeArray of eight blocks at one binding
  [FAIL] a shader-declared descriptor array bound against a single resource is rejected
  [FAIL] eight declared descriptors against eight supplied table entries is not an arity mismatch
```

Exactly the prediction; `an ordinary non-array binding still reflects exactly one descriptor` continued to pass. That last part is what distinguishes "the probe works" from "the suite is insensitive".

## Affected / unaffected

- **Affected:** reflection now reports a real `descriptor_count`. Combined with stage 3, a shader declaring a descriptor array against a scalar runtime resource is rejected instead of silently binding element 0.
- **Unaffected:** every shader in the suite still reflects `descriptor_count == 1`, asserted by arm 3 and by 230/230 including the whole reflection/validation suite. No emission change — the emitter still never produces a descriptor array; that is stage 4b.

## Risks

The probe runs once per descriptor variable and returns 1 on every shape prosper emits today. The conservatism is the risk control: it takes three positive conditions (outer wrapper is an array, its element is descriptor-shaped, length resolves) before reporting anything but 1. The failure direction if a guard is wrong is a **rejected draw**, which is loud, rather than a silently wrong binding.

## Verification at exact head `4b8f3959`

```
cmake --build prosper/build-linux -j6                              -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4          -> 230/230 passed, rc=0
test_shader_resources                                              -> 0 [FAIL]
mutation (arity probe -> return 1)                                 -> 3 [FAIL], exactly as predicted
git diff --cached --check                                          -> clean
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:' -> 0
```
