### PR TITLE
feat(gpu): reject a descriptor-array arity mismatch instead of validating it silently (stage 3)

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -4973,7 +4973,13 @@ bool validate_runtime_descriptor_contract(const char* stage_name,
             // Contract errors with different proven ranges are distinct. Warning-only unused
             // resources are not: their guest address/size can change every draw and must not flood
             // a long diagnostic run with the same module/binding warning.
-            if (issue.error) { mix(issue.required_bytes); mix(issue.available_bytes); }
+            // Counts are mixed alongside the byte ranges so the property survives codes that report
+            // counts instead of ranges: two arity mismatches at one binding differing only in how many
+            // descriptors each side declared stay distinct rather than deduping into one line.
+            if (issue.error) {
+                mix(issue.required_bytes); mix(issue.available_bytes);
+                mix(issue.shader_count); mix(issue.runtime_count);
+            }
         }
         if (logged.insert(key).second) {
             fprintf(stderr, "[descriptor] %s module=%016llx used=%zu runtime=%zu result=%s mode=%s\n",
@@ -4991,6 +4997,11 @@ bool validate_runtime_descriptor_contract(const char* stage_name,
                         spirv_descriptor_kind_name(issue.actual),
                         (unsigned long long)issue.required_bytes,
                         (unsigned long long)issue.available_bytes);
+            for (const auto& issue : report.issues)
+                if (issue.code == DescriptorIssueCode::ArrayBindingArityMismatch)
+                    fprintf(stderr, "[descriptor]     arity set=%u binding=%u shader_declares=%u "
+                                    "runtime_supplies=%u\n",
+                            issue.set, issue.binding, issue.shader_count, issue.runtime_count);
             if (runtime) for (const auto& r : runtime->resources)
                 fprintf(stderr, "[descriptor]   runtime binding=%u cls=%u addr=0x%llx size=%u "
                                 "stride=%u fmt=%u comps=%u srt=0x%x sgpr=%u pc=%u\n",
@@ -5739,6 +5750,11 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                  spirv_descriptor_kind_name(issue.actual),
                                  (unsigned long long)issue.required_bytes,
                                  (unsigned long long)issue.available_bytes, issue.error ? 1 : 0);
+                    if (issue.code == DescriptorIssueCode::ArrayBindingArityMismatch)
+                        std::fprintf(stderr,
+                                     "[compute-descriptor]   arity binding=%u shader_declares=%u "
+                                     "runtime_supplies=%u\n",
+                                     issue.binding, issue.shader_count, issue.runtime_count);
                     if (item.resources) for (const auto& resource : item.resources->resources)
                         if (resource.binding == issue.binding)
                             std::fprintf(stderr,

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -1063,14 +1063,16 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         const bool runtime_is_array = runtime_count != 0;
         if (shader_is_array != runtime_is_array ||
             (shader_is_array && shader_count != 0 && shader_count != runtime_count)) {
-            // `DescriptorValidationIssue` has no count fields, so the two COUNTS ride in the
-            // `required_bytes` / `available_bytes` slots (this initializer is positional). Nothing
-            // currently renders those two fields for any issue, so no message is wrong today -- but a
-            // future formatter that prints "required N bytes" would report "8 bytes" for an eight-element
-            // array. Read them as counts for this code only, or give the struct explicit count fields
-            // before writing such a formatter.
-            report.issues.push_back({DescriptorIssueCode::ArrayBindingArityMismatch, true, d.set,
-                                     d.binding, d.kind, actual, shader_count, runtime_count});
+            // The counts go in their own fields and the byte slots stay zero. An earlier revision rode
+            // them in `required_bytes`/`available_bytes` on the belief that nothing rendered those --
+            // false: `gpu_executor.cpp` prints both for every issue in the `[descriptor]` and
+            // `[compute-descriptor]` dumps, and mixes them into the dedupe hash for error issues, so a
+            // fired check printed `required=8 available=0` about descriptors rather than bytes.
+            DescriptorValidationIssue arity{DescriptorIssueCode::ArrayBindingArityMismatch, true, d.set,
+                                            d.binding, d.kind, actual};
+            arity.shader_count = shader_count;
+            arity.runtime_count = runtime_count;
+            report.issues.push_back(arity);
             continue;
         }
         // Explicit null descriptors are valid guest state: resource reads return zero and the backend

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -587,6 +587,8 @@ const char* descriptor_issue_name(DescriptorIssueCode code) {
         case DescriptorIssueCode::InvalidImageMetadata:return "invalid image metadata";
         case DescriptorIssueCode::UndersizedBuffer:    return "undersized buffer";
         case DescriptorIssueCode::UnusedRuntimeBinding:return "unused runtime binding";
+        case DescriptorIssueCode::ArrayBindingArityMismatch:
+                                                        return "descriptor array arity mismatch";
         default:                                        return "unknown descriptor issue";
     }
 }
@@ -1038,6 +1040,37 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
         if (actual != d.kind && !atomic_image_buffer) {
             report.issues.push_back({DescriptorIssueCode::WrongType, true, d.set, d.binding,
                                      d.kind, actual, d.required_bytes, r.size});
+            continue;
+        }
+        // ARITY (#2412, stage 3). Checked before any byte-range reasoning, because for an array binding
+        // `required_bytes` is not a byte range at all: reflection folds the array index into the same
+        // offset arithmetic it uses inside a buffer, so an eight-element array reports one binding with
+        // a nonsense requirement. Comparing that against `r.size` produces a confident verdict about a
+        // quantity neither side is talking about.
+        //
+        // Both directions are errors and for different reasons. Array SPIR-V against a scalar resource
+        // means the shader can index past the one descriptor the backend will bind — reading whatever
+        // the next binding holds. A scalar shader against a table-indexed resource means the executor
+        // built an array the module cannot address, so entries beyond the first are unreachable and the
+        // dispatch silently uses one slot of a table it was given.
+        //
+        // This is deliberately introduced BEFORE arrays work. Until stage 4 emits them and stage 5
+        // materialises them, the correct behaviour for a mismatch is to REJECT, and rejecting loudly is
+        // the whole point: the pre-stage-3 code compared an array against a scalar and said nothing.
+        const uint32_t shader_count  = d.descriptor_count;
+        const uint32_t runtime_count = r.table_index_count;
+        const bool shader_is_array  = shader_count != 1;
+        const bool runtime_is_array = runtime_count != 0;
+        if (shader_is_array != runtime_is_array ||
+            (shader_is_array && shader_count != 0 && shader_count != runtime_count)) {
+            // `DescriptorValidationIssue` has no count fields, so the two COUNTS ride in the
+            // `required_bytes` / `available_bytes` slots (this initializer is positional). Nothing
+            // currently renders those two fields for any issue, so no message is wrong today -- but a
+            // future formatter that prints "required N bytes" would report "8 bytes" for an eight-element
+            // array. Read them as counts for this code only, or give the struct explicit count fields
+            // before writing such a formatter.
+            report.issues.push_back({DescriptorIssueCode::ArrayBindingArityMismatch, true, d.set,
+                                     d.binding, d.kind, actual, shader_count, runtime_count});
             continue;
         }
         // Explicit null descriptors are valid guest state: resource reads return zero and the backend

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -556,6 +556,23 @@ struct SpirvDescriptorBinding {
     uint64_t zero_pad_logical_bytes = 0;
     uint64_t zero_pad_binding_bytes = 0;
     StorageBufferTailSemantic zero_pad_semantic = StorageBufferTailSemantic::None;
+
+    // Number of descriptors the binding declares: 1 for an ordinary binding, N for a fixed-size array,
+    // and 0 for an `OpTypeRuntimeArray` of descriptors whose length is supplied at bind time (#2412).
+    //
+    // Distinct from `required_bytes` on purpose. Reflection folds an array index into the same offset
+    // arithmetic it uses for byte offsets inside a buffer, because it treats `TypeKind::Array`
+    // uniformly -- so an array of descriptors reports one binding with a nonsense byte requirement.
+    // This field is what lets validation tell "eight descriptors" from "one descriptor, 128 bytes in".
+    //
+    // DELIBERATELY LAST, and anything added later must also go last. Reflection builds this struct with
+    // a POSITIONAL aggregate initializer (`shader_resources.cpp`, `SpirvDescriptorBinding descriptor{
+    // var, si->second, ... }`) that names no field, so a field inserted anywhere above silently shifts
+    // every initializer after it by one -- `readable` receives `descriptor_count`'s slot and so on down.
+    // It compiles without a warning. Measured: inserting this field after `dynamic_access` turned 0 test
+    // failures into 15. Appending leaves the initializer's positions untouched and this member falls to
+    // its default initializer, which is what an ordinary single-descriptor binding must report anyway.
+    uint32_t descriptor_count = 1;
 };
 
 struct StorageBufferMaterializationPlan {
@@ -595,6 +612,16 @@ enum class DescriptorIssueCode : uint32_t {
     InvalidImageMetadata,
     UndersizedBuffer,
     UnusedRuntimeBinding,
+    // The SPIR-V declares an ARRAY of descriptors at this binding while the resource table supplies a
+    // single one, or the reverse (#2412).
+    //
+    // Added BEFORE arrays are made to work, deliberately. Today an array binding reflects as one binding
+    // with a `required_bytes` computed as though the array index were a byte offset, and is then compared
+    // against a scalar `ShaderResource` -- and no existing code covers that, so the mismatch validates
+    // SILENTLY. Introducing the code first turns the rest of this work into "make this stop firing",
+    // which is a lever that can be watched, instead of "change reflection and hope validation still means
+    // something". A layer whose job is catching mis-binding must not be the layer that fails quietly.
+    ArrayBindingArityMismatch,
 };
 
 struct DescriptorValidationIssue {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -633,6 +633,19 @@ struct DescriptorValidationIssue {
     SpirvDescriptorKind actual = SpirvDescriptorKind::Unknown;
     uint64_t required_bytes = 0;
     uint64_t available_bytes = 0;
+
+    // Descriptor counts for `ArrayBindingArityMismatch`, and zero for every other code (#2412).
+    //
+    // These exist rather than reusing the byte slots above, which was the first attempt: those two are
+    // rendered for EVERY issue by `gpu_executor.cpp` (the `[descriptor]` and `[compute-descriptor]`
+    // dumps) and are mixed into the diagnostic dedupe hash for error issues, so an eight-element array
+    // against a scalar printed `required=8 available=0` -- a byte count that was really a descriptor
+    // count, in a line a human reads while debugging the very stages this check exists to guard.
+    //
+    // APPEND-ONLY, like `SpirvDescriptorBinding`: this struct is brace-initialised positionally at every
+    // `report.issues.push_back({...})` site, so a field inserted above silently shifts them all. #2462.
+    uint32_t shader_count = 0;
+    uint32_t runtime_count = 0;
 };
 
 struct DescriptorValidationReport {

--- a/prosper/tests/test_shader_resources.cpp
+++ b/prosper/tests/test_shader_resources.cpp
@@ -528,6 +528,35 @@ int main() {
     CHECK(!dr.ok() && has_issue(dr, DescriptorIssueCode::DuplicateBinding),
           "duplicate runtime binding is rejected as ambiguous");
 
+    // Descriptor-array arity (#2412). A resource that declares a table of descriptors selected by a
+    // runtime index, bound against SPIR-V that reflects ONE descriptor at that binding, must be
+    // rejected. Before this code existed the pair validated SILENTLY: the array count was invisible to
+    // validation, so a half-finished lift -- a count carried but no reflection or emission behind it --
+    // would have bound as though it were an ordinary single descriptor and produced wrong pixels rather
+    // than a diagnostic.
+    //
+    // Only this DIRECTION is constructible today, and that is the point rather than a shortcut: the
+    // reverse (SPIR-V declaring an array against a scalar resource) needs reflection to report
+    // `descriptor_count != 1`, which is exactly the defect the next stage fixes -- reflection folds an
+    // array index into byte-offset arithmetic and reports one binding. So the arm for the reverse
+    // direction cannot exist until that lands, and it must land WITH one; asserting it now would be a
+    // test whose inputs cannot express the case it claims to cover.
+    ShaderResource table_indexed = good;
+    table_indexed.table_index_count = 8;
+    table_indexed.table_entry_stride = 16;
+    ShaderResourceTable arity; arity.resources.push_back(table_indexed);
+    auto arr = validate_spirv_descriptor_interface(spv, &arity, 0, SpirvShaderStage::Vertex);
+    CHECK(!arr.ok() && has_issue(arr, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "a table-indexed resource at a binding the shader declares as a single descriptor is rejected");
+
+    // Discriminator: the arity check must not reject the ordinary case. `good` is byte-for-byte the
+    // resource above minus the count, so a failure here would mean the new code rejects every scalar
+    // binding -- which the arm above could not distinguish from working correctly.
+    ShaderResourceTable scalar_ok; scalar_ok.resources.push_back(good);
+    auto sok = validate_spirv_descriptor_interface(spv, &scalar_ok, 0, SpirvShaderStage::Vertex);
+    CHECK(!has_issue(sok, DescriptorIssueCode::ArrayBindingArityMismatch),
+          "an ordinary scalar resource is not reported as an arity mismatch");
+
     // --- validate_runtime_descriptor_contract: the mode-carrying overload (#2239 candidate 3) ---
     //
     // The per-draw form takes its mode from the caller so a hot loop can hoist the getenv to submit


### PR DESCRIPTION
**Replaces #2461**, which GitHub closed irreversibly when its base branch (`feat/stage2-...`, #2460) was deleted on merge — a closed PR cannot be reopened *or* retargeted once its base is gone, so the branch needed a new PR. Same branch, same work, rebased onto master, **plus the fix for the blocking finding on #2461**.

**Read #2461's review first** — the reviewer enumerated all eight arity combinations and found a blocking defect: the two descriptor counts were riding in `DescriptorValidationIssue::required_bytes` / `available_bytes` under a comment claiming nothing rendered those fields. Three consumers on master do. Fixed here per their option (1): explicit `shader_count` / `runtime_count`, appended; byte slots left zero; dedupe hash mixes the new fields so the "two arity mismatches at one binding stay distinct" property survives the move; both diagnostic dumps print `shader_declares=` / `runtime_supplies=`.

---

Stage 3 of the runtime-selected-descriptor lift. **Stage 2 is merged (48d978ab)** — its check reads `ShaderResource::table_index_count`, so merge that first.

Refs #2412.

## The defect this closes

Today an array binding reflects as **one** binding whose `required_bytes` was computed as though the array index were a byte offset, and is then compared against a scalar `ShaderResource`. **No `DescriptorIssueCode` covers that**, so the mismatch validates *silently* — the layer whose whole job is catching mis-binding is the layer that fails quietly.

The consequence for the lift: a half-finished stage would bind a table-indexed resource as an ordinary single descriptor and produce **wrong pixels rather than a diagnostic**.

Introducing the code and the check **before** arrays work turns the remaining stages into *"make this stop firing"* — a lever that can be watched — instead of *"change reflection and hope validation still means something"*.

## What is here

- `DescriptorIssueCode::ArrayBindingArityMismatch` + its name string.
- `SpirvDescriptorBinding::descriptor_count` — 1 ordinary, N fixed array, 0 `OpTypeRuntimeArray`.
- The arity comparison in `validate_spirv_descriptor_interface`, placed after the type compare and **before any byte-range reasoning**, because a byte range derived from an array index is meaningless and would otherwise be reported as the defect.

## The landmine found while writing it — worth a reviewer's attention

`descriptor_count` is **deliberately the last member of the struct**, and the comment says so.

Reflection builds `SpirvDescriptorBinding` with a **positional aggregate initializer that names no field**:

```cpp
SpirvDescriptorBinding descriptor{
    var, si->second, bi->second, descriptor_vars[var], stage,
    required[var], dynamic[var], read_vars.count(var) != 0, ...
```

So a member inserted anywhere above silently shifts every initializer after it by one — `readable` receives `descriptor_count`'s slot, and so on down the struct. **It compiles without a warning.**

**Measured, not theorised:** inserting the field after `dynamic_access` turned **0 test failures into 15**, all of them reflection assertions with no obvious connection to the change (`zero-pad marker`, `sampled-image reflection`, `write-only atomic access`). Grep did not find the initializer either — `SpirvDescriptorBinding *{` misses it because the variable name sits between the type and the brace, so the *field names* are absent from every left-hand side and the *type* name is separated from the `{`.

Appending leaves the initializer's positions untouched and the member falls to its default initializer — which is what an ordinary single-descriptor binding must report anyway.

One consequence worth noting: `DescriptorValidationIssue` has no count fields, so the two counts ride in the `required_bytes` / `available_bytes` slots. Nothing renders those fields for any issue today, so no message is wrong — flagged in a comment at the push site so a future formatter does not print "required 8 bytes" for an eight-element array.

## Tests, and which direction each can establish

```
[ok]   a table-indexed resource at a binding the shader declares as a single descriptor is rejected
[ok]   an ordinary scalar resource is not reported as an arity mismatch
```

- The first is **the only direction constructible today, deliberately.** The reverse — SPIR-V declaring an array against a scalar resource — requires reflection to report `descriptor_count != 1`, which is the very defect stage 4 fixes. Asserting it now would be a test whose inputs cannot express the case it claims to cover, so **stage 4 must land with that arm.**
- The second is a **discriminator**: without it the first arm cannot distinguish a working check from one that rejects every scalar binding.

**Mutation arm, obtained during the bisect rather than constructed after the fact:** with the field present and the check absent, the suite reports exactly **one** failure — the arity arm — and adding the check takes it to **0**. The arm fails without the code that is supposed to make it pass.

## Affected / unaffected

- **Affected:** validation now rejects a table-indexed resource bound against a shader that reflects a single descriptor. Nothing produces `table_index_count` yet, so no title reaches this path on master.
- **Deliberately unaffected:** reflection's treatment of arrays (stage 4), SPIR-V emission, materialization, every backend, the capture format.

## Risks

The check runs on every descriptor of every validated shader. Its guard is `shader_count != 1 || runtime_count != 0`, both of which are the default on every existing resource, so the fast path is two integer compares and no existing shape can enter the branch. The 230/230 run includes the full reflection/validation suite.

## Verification at exact head `11ab8090`

```
cmake --build prosper/build-linux -j6                              -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4          -> 230/230 passed, rc=0
test_shader_resources                                              -> 0 [FAIL]
git diff --cached --check                                          -> clean
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:' -> 0
```
