### PR TITLE
docs(dq): the Linux/RADV title renders with zero wave64 skips, and two traps that nearly inverted it

### DIFF
--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -512,6 +512,32 @@ blocker.
    timestamp — `…-210000-123.bmp` and `…-210000-123-2.prgbundle` are two different grabs despite an
    identical title and millisecond. The `stat` habit still applies to artifacts captured before that
    landed (`captures/frame_grab_001.*` is exactly that shape) and to anything else named by ordinal.
+7. **`PROSPER_GFXLOG=1` PERTURBS this title's routed capture — the diagnostic changes what it observes.**
+   Measured 2026-08-10 on current master (`08d42aea`), Linux, native 3840x2160, the documented
+   `reach-title-screen.pad` route with fresh save roots. Identical command except for the variable:
+
+   | run | frames 33-44 | verdict a naive reader takes |
+   | --- | --- | --- |
+   | documented recipe (no `GFXLOG`) | title held, mean luminance 173-220, 38 of 45 frames with content | correct |
+   | `PROSPER_GFXLOG=1` added | **pure black**, mean 0.00, from frame 33 to 39 | "the title regressed on master" |
+
+   `PROSPER_GFXLOG` emits roughly **160,000 lines** over this route (counted: 159,619 `[render] item`
+   lines in one run) and slows it enough to shift a **time-dependent pad script** out of alignment with
+   the sampled frames. The presses themselves are delivered on schedule — `[pad-script] elapsed=30.049
+   frame=479 buttons=cross` — so `PROSPER_PAD_SCRIPT_LOG` *confirms the route ran* while the game is in a
+   different state by the time each screenshot fires. Both halves look healthy; only the composite is
+   wrong. **Every routed capture in this project is timing-dependent, so add no logging variable to a
+   scripted route without re-establishing the baseline under the same variable.** This nearly produced a
+   phantom title-screen regression report on a clean master.
+8. **A no-input black frame here is the authored Slate state, and it will invert a cross-platform
+   conclusion if taken as data.** Also 2026-08-10: a default 90 s launch is black with
+   `pixel-distinct=1`, and it was one step away from being published as "Linux composites black with zero
+   wave64 skips, therefore wave64 cannot explain the Windows black composite" — a *falsification* of the
+   leading hypothesis (#2448) drawn entirely from a state this document and
+   `scripts/dragon-quest-vii/README.md` both already describe as authored. The routed run says the
+   opposite: the title renders correctly. **Read the route README before the run, not after it** — the
+   warning is in the first paragraph, and the black frame is convincing enough that nothing downstream
+   would have questioned it.
 
 ## What has been fixed
 


### PR DESCRIPTION
Docs-only. Two methodology traps on `DRAGON_QUEST_STATUS.md`, both measured while running the cross-platform discriminator for the wave64 hypothesis.

Refs #2448, #2465. The measurement itself is recorded on #2448.

## Why these two are worth a doc

Each was one step from becoming a published wrong conclusion, and in opposite directions.

### Trap 7 — `PROSPER_GFXLOG=1` perturbs this title's routed capture

Identical command, current master `08d42aea`, Linux, native 3840x2160, documented `reach-title-screen.pad` route, fresh save roots. Only the variable differs:

| run | frames 33-44 | what a reader concludes |
| --- | --- | --- |
| documented recipe | title held, mean luminance 173-220, 38 of 45 frames with content | correct |
| `PROSPER_GFXLOG=1` added | **pure black**, mean 0.00, frames 33-39 | "the title regressed on master" |

`PROSPER_GFXLOG` emits ~160,000 lines over this route (159,619 `[render] item` lines counted) and slows it enough to shift a **time-dependent pad script** out of alignment with the sampled frames.

The part that makes it dangerous: the presses *are* delivered on schedule — `[pad-script] elapsed=30.049 frame=479 buttons=cross` — so `PROSPER_PAD_SCRIPT_LOG` **confirms the route ran**. Both halves look healthy; only the composite is wrong. The instrument that would normally catch a route failure reports success.

**Every routed capture in this project is timing-dependent**, so this generalises past DQ: adding a logging variable to a scripted route requires re-establishing the baseline under the same variable.

### Trap 8 — a no-input black frame is the authored Slate state, and it inverts the conclusion

A default 90 s launch is black with `pixel-distinct=1`. I was one message from publishing *"Linux composites black with zero wave64 skips, therefore wave64 cannot explain the Windows black composite"* — a **falsification of the leading hypothesis** on #2448, drawn entirely from a state that both this document and `scripts/dragon-quest-vii/README.md` already describe as authored opaque black.

The routed run says the opposite: the title renders correctly and completely at native 4K.

The rule is one I broke and then recovered by luck of ordering: **read the route README before the run, not after it.** The warning is in its first paragraph. A black 4K frame is convincing enough that nothing downstream would have questioned it.

## The result these traps guard

On #2448: **zero** `skip draw: fragment shader requires subgroup size` occurrences on Linux/RADV, against Windows/NVIDIA's **56% of draws**. Mechanistic rather than incidental — `GPU0 AMD Radeon 8060S (RADV STRIX_HALO) maxSubgroupSize = 64`, so the `required > max` disjunct that accounts for every measured Windows skip **cannot fire** on this device.

Two guards so the zero is not a silent instrument: the skip log has **no env gate** (only the gate condition plus a per-shader dedupe), and a companion run logged **159,619 `[render] item` lines** as a positive control on the apparatus.

## Verification

```
check_numbered_table.py DRAGON_QUEST_STATUS.md   -> 8 tables, 39 rows, unbroken, rc=0
git diff --check                                 -> clean
diff is .md only                                 -> confirmed
trailer gate                                     -> 0
```

Docs-only, so no CI to wait on — but @wren should read trap 7: it bears on every routed measurement either of us takes, and the number it nearly cost was one of yours.
