### PR TITLE
feat(render): bind a runtime-selected descriptor ARRAY — pool, layout, write and run table together

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1555,6 +1555,10 @@ if(TARGET prosper_core)
       target_link_libraries(test_indexed_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME indexed_render COMMAND test_indexed_render)
 
+      add_executable(test_descriptor_array_render tests/test_descriptor_array_render.cpp)
+      target_link_libraries(test_descriptor_array_render PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME descriptor_array_render COMMAND test_descriptor_array_render)
+
       # Storage images: a recompiled compute kernel does MIMG image_load->image_store (no sampler) to
       # copy a 1D storage image bit-exact (the game's blit/copy compute-shader class).
       add_executable(test_storage_image_copy tests/test_storage_image_copy.cpp)

--- a/prosper/docs/FRONTEND_APP.md
+++ b/prosper/docs/FRONTEND_APP.md
@@ -585,7 +585,34 @@ The Vulkan backend retains graphics pipelines across render-target calls. Live d
 process-unique, never-recycled identity from the exact shader cache, so a hot lookup does not copy or
 hash complete SPIR-V modules. Capture, replay, and test draws without those identities fall back to an
 exact full-module key. The rest of the key contains the descriptor-layout contract and every baked
-fixed-function value; equality still compares the complete key after hashing. The cache is bounded to
+fixed-function value; equality still compares the complete key after hashing.
+
+**A shader-cache identity does not imply descriptor ARITY, and the key must carry it separately (#2471).**
+An identity names the exact compile key, including every descriptor's class and binding — but a module is
+byte-identical whether its binding was declared with one descriptor or with N, so arity reaches the
+pipeline *layout* without reaching this key. When the two disagree, a cached `VkPipeline` created under an
+arity-1 layout is replayed with an arity-N layout bound, which is `VUID-vkCmdDraw*-None-08600`
+(*"Set 0 binding 0 descriptorCount 3 doesn't match 1"*) raised at the draw, thousands of lines from either
+cache. Both key branches were affected and for different reasons — the identity branch appended no count at
+all, and the full-module fallback hardcoded `1` — so the arity vector is now appended once, ahead of the
+branch, and `descriptor_arity()` is the single source of truth for the pool, the layout, the write and the
+key. **This class is invisible to a pixel assertion**: the stale pipeline still draws correct output, so the
+test that guards it asserts the cache *decision* (an arity-3 draw must miss against an arity-1 baseline,
+and a second arity-3 draw must still hit) rather than the frame. Only a validation layer sees the rest, so
+run `tools/vkval/vk_validation_scan.py` on any change that touches descriptor counts or layouts.
+
+`PROSPER_PIPEKEY_LOG=1` prints one line per draw pairing the two independent decisions — the pipeline-cache
+key and hit/miss, against the resolved `VkPipelineLayout` handle and the per-binding arity — which is what
+makes a divergence between them readable:
+
+```
+[pipekey] draw=0 key=be1fbdc545dac514 words=423 MISS exact_ids=0 use_desc=1 n_sets=1 arity=[3:1] layout=0x…5a0 pipe=(nil)
+[pipekey] draw=0 key=d8ac419006f6961a words=423 MISS exact_ids=0 use_desc=1 n_sets=1 arity=[3:3] layout=0x…3b0 pipe=(nil)
+[pipekey] draw=0 key=d8ac419006f6961a words=423 HIT  exact_ids=0 use_desc=1 n_sets=1 arity=[3:3] layout=0x…3b0 pipe=0x…240
+```
+
+Two draws sharing a `key=` while differing in `arity=` or `layout=` is the defect; the same `key=` with the
+same `arity=` and `layout=` is a correct reuse. The cache is bounded to
 4096 entries by default. Set `PROSPER_PIPELINE_CACHE_ENTRIES=<N>` to change the entry limit or
 `PROSPER_NO_BACKEND_PIPELINE_CACHE=1` for a transient-pipeline A/B. With `PROSPER_RENDER_TIMING=1`,
 the backend and submit-aligned windows report references, hits, misses, bypasses, current entries, and

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -5763,7 +5763,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(9); // key schema version (complete MRT attachment formats, #1390)
+            append(10); // key schema version (descriptor arity, #2471; MRT formats, #1390)
             append(W); append(H); append(color_count);
             for (uint32_t slot = 0; slot < color_count; ++slot)
                 append(static_cast<uint32_t>(color_formats[slot]));
@@ -5789,12 +5789,26 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             append(static_cast<uint32_t>(bd_gs.size()));
             for (uint32_t word : bd_gs) append(word);
             append(v.use_desc); append(v.n_sets);
-            // A pair of shader-cache identities names the exact compile keys, including every
-            // descriptor's class and binding. External/replay shaders have identity zero and keep
-            // the full layout contract in the fallback key.
+            // Descriptor ARITY is keyed on BOTH branches, and it has to be (#2471). A cached
+            // VkPipeline was created under one VkPipelineLayout and is replayed under whatever
+            // `v.layout` resolves to now; the two are keyed independently (`pipeline_layout_key`,
+            // :5698), so any axis that reaches the layout and not this key silently pairs a
+            // pipeline with an incompatible layout — VUID-vkCmdDraw*-None-08600, "descriptorCount
+            // N doesn't match M", raised at the draw rather than at either cache.
+            //
+            // Arity is exactly such an axis, on both branches and for different reasons:
+            //   * a pair of shader-cache identities names the exact compile keys, including every
+            //     descriptor's class and binding, but NOT its count — a fixed vertex-fetch VS
+            //     reading one binding is a byte-identical module at arity 1 or arity 3;
+            //   * the fallback branch below used to hardcode `append(1)` as the descriptorCount,
+            //     correct only while every binding held one descriptor.
+            // So it is appended here, once, ahead of the split: two copies of the arity rule is the
+            // same drift risk that put a hardcoded 1 in the fallback in the first place. `R.size()`
+            // comes along because the arity list is meaningless without its length.
+            append(static_cast<uint32_t>(R.size()));
+            for (size_t i = 0; i < R.size(); ++i) append(R[i].descriptor_arity());
             append(!exact_shader_identities);
             if (!exact_shader_identities) {
-                append(static_cast<uint32_t>(R.size()));
                 for (size_t i = 0; i < R.size(); ++i) {
                     const bool texture = R[i].is_texture();
                     const VkDescriptorType descriptor_type = !texture
@@ -5805,7 +5819,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     append(R[i].set); append(R[i].binding); append(descriptor_type);
-                    append(1); append(stage_flags);
+                    append(stage_flags);   // count already keyed above, for both branches
                 }
             }
             append(ia.topology); append(ia.primitiveRestartEnable);
@@ -5843,6 +5857,36 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 ++pipeline_stats.hits;
             } else {
                 ++pipeline_stats.misses;
+            }
+            // PROSPER_PIPEKEY_LOG (#2471): pair the graphics-pipeline cache decision with the
+            // pipeline LAYOUT it will run under. The two are keyed independently — `pipeline_key`
+            // here, `pipeline_layout_key` at :5698 — and nothing checks that a cache hit's stored
+            // pipeline was created under a layout equivalent to `v.layout`. When they diverge the
+            // symptom is VUID-vkCmdDraw*-None-08600 ("descriptorCount N doesn't match M") at draw
+            // time, thousands of lines away from either cache, so the two decisions have to be
+            // readable side by side. Prints the per-resource arity because arity is the axis that
+            // reaches the layout without reaching this key.
+            static const bool pipekey_log = getenv("PROSPER_PIPEKEY_LOG") != nullptr;
+            if (pipekey_log) {
+                // Unbounded on purpose: a fixed char buffer would truncate the arity list on a
+                // draw with many resources, and a truncated list is exactly the case this
+                // diagnostic exists to read. It allocates only when the variable is set.
+                std::string arity_text = "[";
+                for (size_t i = 0; i < R.size(); ++i) {
+                    if (i) arity_text += ' ';
+                    arity_text += std::to_string(R[i].binding);
+                    arity_text += ':';
+                    arity_text += std::to_string(R[i].descriptor_arity());
+                }
+                arity_text += ']';
+                std::fprintf(stderr,
+                             "[pipekey] draw=%zu key=%016llx words=%u %s exact_ids=%d "
+                             "use_desc=%d n_sets=%u arity=%s layout=%p pipe=%p\n",
+                             di, (unsigned long long)pipeline_key.hash, pipeline_key.word_count,
+                             create_pipeline ? "MISS" : "HIT ",
+                             (int)exact_shader_identities, (int)v.use_desc, v.n_sets,
+                             arity_text.c_str(), (void*)v.layout, (void*)v.pipe);
+                std::fflush(stderr);
             }
         } else {
             ++pipeline_stats.bypasses;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -204,6 +204,21 @@ struct FrameResource {
         return tex_rgba != nullptr || has_uniform_color || persistent_render_target_id != 0 ||
                persistent_depth_target_id != 0 || borrowed_compute_image != nullptr;
     }
+    // Per-entry payloads for a RUNTIME-SELECTED descriptor array (#2412 stage 5). Empty -- the only
+    // state any producer creates today -- means an ordinary single descriptor and every path below
+    // behaves exactly as before.
+    //
+    // Arity is DERIVED from this vector rather than carried in a separate count field, deliberately:
+    // two sources of truth for "how many descriptors" is precisely the disagreement that makes a
+    // layout declare N while a write supplies M, which is a validation error at bind time and a wrong
+    // shader read if validation is off. One vector, one length, no way to disagree.
+    std::vector<std::vector<uint32_t>> table_entries;
+    // The number of descriptors this binding occupies: 1 ordinary, N for a table-indexed array.
+    // Used by the descriptor POOL accounting, the layout binding, and the write -- all three must
+    // agree, so all three call this.
+    uint32_t descriptor_arity() const {
+        return table_entries.empty() ? 1u : static_cast<uint32_t>(table_entries.size());
+    }
 };
 
 // Optional color-target contract for the live backend. A non-zero ID gives the target a stable
@@ -4296,7 +4311,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         for (const FrameResource& resource : resources) {
             set_count = std::max(set_count, resource.set + 1);
             if (!resource.is_texture()) {
-                ++storage_buffers;
+                // N per array, not 1 per resource: the pool is sized from these counters, and an
+                // N-entry array that reserved 1 fails inside vkAllocateDescriptorSets with
+                // VK_ERROR_OUT_OF_POOL_MEMORY -- an error with no visible connection to arrays.
+                storage_buffers += resource.descriptor_arity();
             } else if (resource.is_storage_image) {
                 ++storage_images;
             } else {
@@ -4868,7 +4886,23 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         std::vector<std::vector<uint64_t>> descriptor_layout_keys(v.n_sets);
         if (v.use_desc) {
             std::vector<VkDescriptorSetLayoutBinding> lb(R.size());
-            std::vector<VkDescriptorBufferInfo> dbi(R.size());
+            // One contiguous run of VkDescriptorBufferInfo per resource, arity entries long. Sized
+            // ONCE, before anything takes an address into it: `wr[].pBufferInfo` points in here and
+            // must stay valid until vkUpdateDescriptorSets, so growing this vector while
+            // materialising entries would silently invalidate pointers already stored in `wr` --
+            // which Vulkan reads as garbage descriptors rather than reporting as an error.
+            std::vector<uint32_t> dbi_offset(R.size(), 0);
+            {
+                uint32_t running = 0;
+                for (size_t i = 0; i < R.size(); i++) {
+                    dbi_offset[i] = running;
+                    running += R[i].descriptor_arity();
+                }
+                (void)running;
+            }
+            const size_t dbi_total = R.empty()
+                ? 0 : static_cast<size_t>(dbi_offset.back()) + R.back().descriptor_arity();
+            std::vector<VkDescriptorBufferInfo> dbi(dbi_total);
                 // Resolve one storage-buffer payload to an index in `shared_buffers` -- the memo lookup,
                 // the size-gated content dedup, and the arena/pool/create upload. Extracted verbatim
                 // from the per-resource site below so it can be called MORE THAN ONCE per resource: an
@@ -5051,7 +5085,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             bool buffer_resources_ready = true;
             for (size_t i = 0; i < R.size(); i++) {
                 const FrameResource& r = R[i];
-                lb[i] = {}; lb[i].binding = r.binding; lb[i].descriptorCount = 1;
+                lb[i] = {}; lb[i].binding = r.binding;
+                lb[i].descriptorCount = r.descriptor_arity();
                 if (r.is_texture()) {
                     const ResourcePhaseTimer phase_texture(timing_enabled, &res_texture_ms);
                     lb[i].descriptorType = r.is_storage_image
@@ -5552,21 +5587,51 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         wr[i].pBufferInfo = &dbi[i];
                         continue;
                     }
-                    const uint32_t* words = r.buffer_words_data();
-                    size_t word_count = r.buffer_word_count();
-                    size_t buffer_index = SIZE_MAX;
-                    // False is the fatal upload path: the zero-word fallback itself failed, so this
-                    // draw cannot be bound. Same effect as the `break` this replaced.
-                    if (!resolve_buffer_upload(words, word_count, r.buffer_identity, r.set, r.binding,
-                                               buffer_index)) {
-                        buffer_resources_ready = false;
-                        break;
+                    // One upload per descriptor this binding occupies. Uniform over entries on
+                    // purpose: an earlier revision took entry 0 from `dwords` and entries 1..N-1 from
+                    // `table_entries`, which leaves `table_entries[0]` counted-but-unused and is the
+                    // same two-sources-of-truth defect the comment on `table_entries` warns about.
+                    //
+                    // With `table_entries` empty -- every producer today -- arity is 1 and this makes
+                    // exactly one call with exactly the arguments the single-descriptor path always
+                    // used, `r.buffer_identity` included, so the memo and dedup behaviour is unchanged.
+                    const uint32_t arity = r.descriptor_arity();
+                    bool entries_ready = true;
+                    for (uint32_t e = 0; e < arity; e++) {
+                        const uint32_t* entry_words = nullptr;
+                        size_t entry_count = 0;
+                        uint64_t entry_identity = 0;
+                        if (r.table_entries.empty()) {
+                            entry_words = r.buffer_words_data();
+                            entry_count = r.buffer_word_count();
+                            entry_identity = r.buffer_identity;
+                        } else {
+                            const std::vector<uint32_t>& entry = r.table_entries[e];
+                            entry_words = entry.empty() ? nullptr : entry.data();
+                            entry_count = entry.size();
+                            // Identity 0 keeps each table entry conservatively distinct. Entries of one
+                            // array are different guest buffers; sharing one identity across them would
+                            // let the per-call memo collapse them into a single descriptor, so the
+                            // shader would read entry 0 for every index.
+                            entry_identity = 0;
+                        }
+                        size_t entry_index = SIZE_MAX;
+                        // False is the fatal upload path: the zero-word fallback itself failed, so this
+                        // draw cannot be bound. Same effect as the `break` this replaced.
+                        if (!resolve_buffer_upload(entry_words, entry_count, entry_identity, r.set,
+                                                  r.binding, entry_index)) {
+                            entries_ready = false;
+                            break;
+                        }
+                        dbi[dbi_offset[i] + e] = {shared_buffers[entry_index].buffer,
+                                                  shared_buffers[entry_index].offset,
+                                                  shared_buffers[entry_index].range};
                     }
-                    dbi[i] = {shared_buffers[buffer_index].buffer,
-                              shared_buffers[buffer_index].offset,
-                              shared_buffers[buffer_index].range};
-                    wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding; wr[i].descriptorCount = 1;
-                    wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER; wr[i].pBufferInfo = &dbi[i];
+                    if (!entries_ready) { buffer_resources_ready = false; break; }
+                    wr[i] = {VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET}; wr[i].dstBinding = r.binding;
+                    wr[i].descriptorCount = arity;
+                    wr[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                    wr[i].pBufferInfo = &dbi[dbi_offset[i]];
                 }
             }
             if (!buffer_resources_ready) continue;

--- a/prosper/tests/test_descriptor_array_render.cpp
+++ b/prosper/tests/test_descriptor_array_render.cpp
@@ -1,0 +1,150 @@
+// test_descriptor_array_render — a runtime-selected descriptor ARRAY actually binds (#2412 stage 5).
+//
+// The backend now sizes the descriptor pool, the layout binding, the write, and the
+// VkDescriptorBufferInfo run table from a resource's arity instead of hardcoding 1. Nothing in the
+// guest path produces an arity yet, so without this test the whole N>1 half of that change is
+// structurally inexpressible in the suite: 230 green tests would say nothing about it, because none
+// of them can build an array. That is the trap this file exists to close.
+//
+// The shader does NOT need to index the array for this to be a real test. A SPIR-V module declaring
+// an ordinary single binding is a declared array size of 1, which Vulkan permits against a layout
+// whose descriptorCount is larger — the shader simply reads element 0. So binding a 3-entry array to
+// the existing vertex-fetch VS exercises every one of the four sites and lets a PIXEL assert the
+// result:
+//
+//   Case A  arity 3, entries[0] = the fullscreen quad          -> GREEN
+//           Proves the layout, the write and the run table agree: a layout declaring 3 against a
+//           write supplying 1 is a validation error, and a mis-sized run table binds the wrong
+//           buffer. It does NOT prove the pool accounting -- measured: reverting the pool fix alone
+//           leaves every arm here passing, because RADV over-allocates rather than returning
+//           VK_ERROR_OUT_OF_POOL_MEMORY. The pool change is spec-correctness for a strict
+//           implementation, and this test cannot see it on this driver. Said explicitly because the
+//           first version of this comment claimed otherwise and a mutation arm refuted it.
+//   Case B  arity 3, entries[0] = an off-screen decoy          -> NOT green
+//           The discriminator that makes Case A mean something: element 0 really is entries[0], not
+//           whatever happened to land there. Note what B alone cannot show: with ONE resource in the
+//           draw the run-table offset is trivially 0, so the offset machinery is untested by A and B.
+//           Case D covers that.
+//   Case D  two bindings, the FIRST with arity 2                -> GREEN
+//           The second resource's run starts at offset 2, so an implementation indexing the run table
+//           by resource index instead of by offset reads the first binding's second entry and the
+//           quad never arrives. This is the only arm that exercises a non-zero offset.
+//   Case C  arity 1 baseline (no table_entries)                -> byte-identical to Case A
+//           Proves routing element 0 through the array path delivers exactly what the
+//           single-descriptor path always delivered, rather than something merely also green.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include "../src/gpu/render_state.hpp"
+#include "render_runner.h"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_descriptor_array_render ==\n");
+    const uint32_t W = 64, H = 64;
+
+    // Same blobs as test_indexed_render: a VS that fetches (x,y) from the storage buffer at binding 3
+    // indexed by vid, and a green PS.
+    const uint32_t vs[] = {
+        0x7e060280u, 0x7e0802f2u, 0xe0042000u, 0x80020100u, 0xf80008cfu, 0x04030201u, 0xbf810000u,
+    };
+    const uint32_t ps[] = { 0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u, 0xF800180Fu,
+                            0x03020100u, 0xBF810000u };
+
+    ShaderResourceTable rt;
+    ShaderResource vb{};
+    vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32; vb.num_components = 2;
+    vb.binding = 3; vb.stride = 8; vb.sgpr_base = 8;
+    rt.resources.push_back(vb);
+
+    std::vector<uint32_t> vert = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &rt);
+    std::vector<uint32_t> frag = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
+    CHECK(!vert.empty() && !frag.empty(), "recompiled vertex-fetch VS + green PS");
+    if (vert.empty() || frag.empty()) { printf("== FAIL ==\n"); return 1; }
+
+    auto f = [](float v) { union { float f; uint32_t u; } c; c.f = v; return c.u; };
+    auto isGreen = [&](const std::vector<uint8_t>& px, uint32_t x, uint32_t y) {
+        const uint8_t* p = &px[((size_t)y * W + x) * 4];
+        return p[1] > 0x80 && p[0] < 0x40 && p[2] < 0x40;
+    };
+    auto greenAt9 = [&](const std::vector<uint8_t>& px) {
+        const uint32_t xs[] = {0, W/2, W-1}, ys[] = {0, H/2, H-1};
+        uint32_t g = 0; for (uint32_t y : ys) for (uint32_t x : xs) if (isGreen(px, x, y)) g++;
+        return g == 9u;
+    };
+
+    // A full-viewport quad in perimeter order, and an entirely off-screen decoy of the same shape.
+    const std::vector<uint32_t> quad = { f(-1.f), f(-1.f),  f(-1.f), f(1.f),
+                                         f( 1.f), f( 1.f),  f( 1.f), f(-1.f) };
+    const std::vector<uint32_t> decoy = { f(9.f), f(9.f),  f(9.f), f(11.f),
+                                          f(11.f), f(11.f), f(11.f), f(9.f) };
+    ResolvedPipelineState list_ps; list_ps.topology = 3;   // VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST
+
+    // `entries` empty -> the single-descriptor path (arity 1). Otherwise an arity-N array.
+    auto draw_with = [&](const std::vector<uint32_t>& single,
+                         std::vector<std::vector<uint32_t>> entries) {
+        prosper::test::BackendDraw d;
+        d.vs = vert; d.fs = frag; d.ps = &list_ps; d.vcount = 4; d.indices = {0,1,2, 2,3,0};
+        prosper::test::FrameResource r; r.binding = 3; r.set = 0;
+        if (entries.empty()) r.dwords = single; else r.table_entries = std::move(entries);
+        d.R.push_back(std::move(r));
+        return d;
+    };
+
+    // --- Case C first, so it is the baseline the others are compared against -----------------------
+    std::vector<uint8_t> px_single = prosper::test::render_draws_rgba({ draw_with(quad, {}) }, W, H);
+    CHECK(px_single.size() == (size_t)W*H*4, "arity-1 baseline produced a frame");
+    if (px_single.size() != (size_t)W*H*4) { printf("== FAIL ==\n"); return 1; }
+    CHECK(greenAt9(px_single), "arity-1 baseline fills the viewport GREEN");
+
+    // --- Case A: a 3-entry array whose element 0 is the quad --------------------------------------
+    std::vector<uint8_t> px_arr =
+        prosper::test::render_draws_rgba({ draw_with({}, { quad, decoy, decoy }) }, W, H);
+    CHECK(px_arr.size() == (size_t)W*H*4,
+          "arity-3 array produced a frame at all (layout, write and run table agree)");
+    if (px_arr.size() != (size_t)W*H*4) { printf("== FAIL ==\n"); return 1; }
+    CHECK(greenAt9(px_arr), "a 3-entry descriptor array binds, and element 0 draws the GREEN quad");
+    CHECK(px_arr == px_single,
+          "routing element 0 through the array path is byte-identical to the single-descriptor path");
+
+    // --- Case B: the discriminator — element 0 really is entries[0] -------------------------------
+    std::vector<uint8_t> px_swapped =
+        prosper::test::render_draws_rgba({ draw_with({}, { decoy, quad, quad }) }, W, H);
+    CHECK(px_swapped.size() == (size_t)W*H*4, "arity-3 array with a decoy at element 0 produced a frame");
+    if (px_swapped.size() != (size_t)W*H*4) { printf("== FAIL ==\n"); return 1; }
+    CHECK(!greenAt9(px_swapped),
+          "a decoy at element 0 is NOT green — element 0 really is entries[0]");
+    CHECK(px_swapped != px_arr,
+          "which entry sits at element 0 changes the picture (entries are not collapsed into one)");
+
+    // --- Case D: a non-zero run-table offset -------------------------------------------------------
+    // Binding 2 comes FIRST and occupies two descriptors, so binding 3's run starts at offset 2. The
+    // shader fetches only binding 3; binding 2 is a layout entry it does not declare, which Vulkan
+    // permits. An implementation that wrote the second resource's info at dbi[resource_index] instead
+    // of dbi[offset] would hand binding 3 the tail of binding 2's array and lose the quad.
+    {
+        prosper::test::BackendDraw d;
+        d.vs = vert; d.fs = frag; d.ps = &list_ps; d.vcount = 4; d.indices = {0,1,2, 2,3,0};
+        prosper::test::FrameResource pad; pad.binding = 2; pad.set = 0;
+        pad.table_entries = { decoy, decoy };
+        prosper::test::FrameResource quad_res; quad_res.binding = 3; quad_res.set = 0;
+        quad_res.dwords = quad;
+        d.R.push_back(std::move(pad));
+        d.R.push_back(std::move(quad_res));
+        std::vector<uint8_t> px_off = prosper::test::render_draws_rgba({ std::move(d) }, W, H);
+        CHECK(px_off.size() == (size_t)W*H*4, "two bindings with a leading arity-2 array produced a frame");
+        if (px_off.size() == (size_t)W*H*4)
+            CHECK(greenAt9(px_off),
+                  "binding 3 at run-table offset 2 still receives its own buffer (offsets are applied)");
+    }
+
+    printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_descriptor_array_render.cpp
+++ b/prosper/tests/test_descriptor_array_render.cpp
@@ -113,6 +113,18 @@ int main() {
     CHECK(greenAt9(px_arr), "a 3-entry descriptor array binds, and element 0 draws the GREEN quad");
     CHECK(px_arr == px_single,
           "routing element 0 through the array path is byte-identical to the single-descriptor path");
+    // The graphics-pipeline cache must NOT hand Case A the pipeline Case C created (#2471). The two
+    // draws share every byte of shader and every item of fixed state, so a key that omits descriptor
+    // arity collides them — and the collision is invisible to every assertion above, because the
+    // stale pipeline still draws a correct green quad. What it is not is spec-valid: the pipeline was
+    // created under an arity-1 VkPipelineLayout and the sets are bound under an arity-3 one, which is
+    // VUID-vkCmdDrawIndexed-None-08600, "Set 0 binding 0 descriptorCount 3 doesn't match 1". A
+    // validation layer sees it; pixels never will. So the arity axis is asserted through the cache
+    // decision instead.
+    const prosper::test::BackendPipelineCacheStats after_a =
+        prosper::test::backend_pipeline_cache_stats();
+    CHECK(after_a.hits == 0 && after_a.misses == 1,
+          "an arity-3 draw does not reuse the arity-1 baseline's pipeline (hits=0, misses=1)");
 
     // --- Case B: the discriminator — element 0 really is entries[0] -------------------------------
     std::vector<uint8_t> px_swapped =
@@ -123,6 +135,15 @@ int main() {
           "a decoy at element 0 is NOT green — element 0 really is entries[0]");
     CHECK(px_swapped != px_arr,
           "which entry sits at element 0 changes the picture (entries are not collapsed into one)");
+    // The other half of the arity assertion, and the one that makes it mean something. Case B has
+    // Case A's shaders AND Case A's arity, so it MUST hit — keying arity is meant to separate
+    // arity-1 from arity-3, not to defeat the cache. Without this arm the check above is satisfied
+    // by any change that makes every draw miss (disabling the cache, keying a pointer, keying a
+    // counter), none of which fixes the layout pairing.
+    const prosper::test::BackendPipelineCacheStats after_b =
+        prosper::test::backend_pipeline_cache_stats();
+    CHECK(after_b.hits == 1 && after_b.misses == 0,
+          "a second arity-3 draw with the same shaders DOES reuse Case A's pipeline (hits=1)");
 
     // --- Case D: a non-zero run-table offset -------------------------------------------------------
     // Binding 2 comes FIRST and occupies two descriptors, so binding 3's run starts at offset 2. The


### PR DESCRIPTION
Stage 5's backend half for #2412. **Stacked on #2470** (the upload extraction) — merge that first.

## Four sites, one commit — deliberately

A layout declaring N against a write supplying 1 is a validation error the moment a producer exists, so there is no safe partial landing:

| site | change |
| --- | --- |
| descriptor **pool** | reserves `descriptor_arity()` entries per resource, not 1 |
| layout binding | declares the arity |
| write | one `VkDescriptorBufferInfo` per entry, each a separate upload through `resolve_buffer_upload` so every entry gets the memo, the dedup and the arena |
| **run table** | sized once, before anything takes an address into it, with a per-resource offset |

The run table is the subtle one: `wr[].pBufferInfo` points into that vector and must stay valid until `vkUpdateDescriptorSets`. Growing it while materialising entries would **silently invalidate pointers already stored**, which Vulkan reads as garbage descriptors rather than reporting as an error.

## One source of truth for arity

Arity is **derived** from `FrameResource::table_entries.size()`, not carried in a separate count field. Two sources of truth for "how many descriptors" is exactly the disagreement that makes a layout declare N while a write supplies M.

**My first attempt had that bug in miniature**: entry 0 came from `dwords` while entries 1..N-1 came from `table_entries`, leaving `table_entries[0]` counted but unused — the same defect the comment I'd just written warned against. The write path is now uniform over entries, and with `table_entries` empty (every producer today) it makes exactly one call with exactly the arguments the single-descriptor path always used, `r.buffer_identity` included.

Each entry uploads with **identity 0**, conservatively distinct: entries of one array are different guest buffers, and sharing one identity would let the per-call memo collapse them, so the shader would read entry 0 for every index.

## The test closes a real hole

Nothing in the guest path produces an arity yet, so the **entire N>1 half was structurally inexpressible in the suite** — 230 green tests said nothing about it. That is the trap this file exists to close.

The shader does not need to index the array: a module declaring an ordinary single binding is a declared array size of 1, which Vulkan permits against a larger `descriptorCount`, so a 3-entry array binds to the existing vertex-fetch VS and a **pixel** asserts the result on real GPU execution.

```
[ok]   arity-1 baseline fills the viewport GREEN
[ok]   arity-3 array produced a frame at all (layout, write and run table agree)
[ok]   a 3-entry descriptor array binds, and element 0 draws the GREEN quad
[ok]   routing element 0 through the array path is byte-identical to the single-descriptor path
[ok]   a decoy at element 0 is NOT green — element 0 really is entries[0]
[ok]   which entry sits at element 0 changes the picture (entries are not collapsed into one)
[ok]   binding 3 at run-table offset 2 still receives its own buffer (offsets are applied)
```

That last arm is the only one exercising a **non-zero** offset — with one resource in the draw the offset is trivially 0, so A and B cannot see the offset machinery at all.

## What this does NOT establish — a mutation arm refuted my own claim

**The pool accounting is unverified.** I asserted that Case A proves the pool reserved 3. Reverting the pool fix alone leaves **every arm passing**, because RADV over-allocates rather than returning `VK_ERROR_OUT_OF_POOL_MEMORY`. The pool change is spec-correctness for a strict implementation and this test cannot see it on this driver.

Both the header comment and the assertion *message* originally carried the wrong claim; both are corrected, because the message is what appears in test output.

@wren this is the one thing your platform can check that mine cannot: does an arity-3 binding still allocate on NVIDIA with the pool fix reverted? If NVIDIA is strict, that arm becomes verifiable there.

## Verification at exact head `a3b14f57`

```
cmake --build prosper/build-linux -j6                       -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4   -> 231/231 passed, rc=0
git diff --cached --check                                   -> clean
trailer gate                                                -> 0
```

## Review

Shared renderer descriptor sizing and indexing — the charter names this class as requiring independent review. The highest-value things to attack: the run-table offset arithmetic (`dbi_total` uses `dbi_offset.back() + R.back().descriptor_arity()`, which is wrong if `R` is empty — guarded, but worth a second reader), and whether identity 0 per entry defeats dedup in a way that matters once a real producer supplies hundreds of entries.
