### PR TITLE
feat(recompiler): declare an indexed descriptor array, with the capability and extension SPIR-V 1.3 needs (stage 4b)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1507,6 +1507,10 @@ if(TARGET prosper_core)
       add_executable(test_rdna2_to_spirv tests/test_rdna2_to_spirv.cpp)
       target_link_libraries(test_rdna2_to_spirv PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME rdna2_to_spirv_exec COMMAND test_rdna2_to_spirv)
+      add_executable(test_descriptor_array_emit tests/test_descriptor_array_emit.cpp)
+      target_link_libraries(test_descriptor_array_emit PRIVATE PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME descriptor_array_emit COMMAND test_descriptor_array_emit)
+
 
       # The per-draw internal-GDS scan memo (#2334). Two registrations of ONE binary: the second
       # sets the opt-out, so the pair proves the memo both fires and can be turned off, on a single

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -56,7 +56,7 @@ FragmentInterpolationLayout::FragmentInterpolationLayout() {
 namespace {
 
 enum : uint32_t {
-    Op_ExtInstImport=11, Op_ExtInst=12, Op_MemoryModel=14, Op_EntryPoint=15, Op_ExecutionMode=16,
+    Op_Extension=10, Op_ExtInstImport=11, Op_ExtInst=12, Op_MemoryModel=14, Op_EntryPoint=15, Op_ExecutionMode=16,
     Op_Capability=17, Op_TypeVoid=19, Op_TypeBool=20, Op_TypeInt=21, Op_TypeFloat=22, Op_TypeVector=23,
     Op_TypeRuntimeArray=29, Op_TypeStruct=30, Op_TypePointer=32, Op_TypeFunction=33,
     Op_ConstantTrue=41, Op_ConstantFalse=42, Op_Constant=43, Op_Function=54, Op_FunctionEnd=56, Op_Variable=59,
@@ -104,6 +104,16 @@ enum : uint32_t {
     Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
     Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformBallot=64, Cap_GroupNonUniformShuffle=65, Cap_GroupNonUniformQuad=68,
     Cap_TransformFeedback=53,   // VK_EXT_transform_feedback (geometry-probe capture of gl_Position, gated)
+    // Descriptor indexing (#2412 stage 4b). These are CORE only from SPIR-V 1.5; this emitter writes
+    // 1.3, so they additionally require OpExtension "SPV_EXT_descriptor_indexing" -- emitted together
+    // by declare_descriptor_indexing() and only when an indexed binding actually exists.
+    //
+    // Cap_ShaderNonUniform is NOT one of the Cap_GroupNonUniform* values above. Those are wave/subgroup
+    // operations that merely share the word; `grep -c NonUniform` on this file returns 45 hits and every
+    // one of them is a GroupNonUniform op, which reads exactly like descriptor indexing is already
+    // supported. It was not.
+    Cap_ShaderNonUniform=5301, Cap_RuntimeDescriptorArray=5302,
+    Cap_StorageBufferArrayNonUniformIndexing=5306,
     Addr_Logical=0, Mem_GLSL450=1, Exec_Vertex=0, Exec_Geometry=3, Exec_Fragment=4, Exec_GLCompute=5,
     EM_OriginUpperLeft=7, EM_DepthReplacing=12, EM_LocalSize=17, EM_Triangles=22,
     EM_OutputVertices=26, EM_OutputTriangleStrip=29, EM_Xfb=11,   // transform-feedback execution mode
@@ -127,6 +137,8 @@ enum : uint32_t {
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
     Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35, Dec_XfbBuffer=36, Dec_XfbStride=37,
+    // Decoration 5300 -- descriptor indexing's NonUniform, unrelated to the GroupNonUniform ops.
+    Dec_NonUniform=5300,
     BI_Position=0, BI_FragCoord=15, BI_FragDepth=22, BI_HelperInvocation=23,
     BI_WorkgroupId=26, BI_LocalInvocationId=27,
     BI_GlobalInvocationId=28, BI_SubgroupId=40, BI_SubgroupLocalInvocationId=41,
@@ -271,7 +283,24 @@ bool inline_16bit_operand_dword(const Operand& o, uint32_t& out) {
 // A compute-shader SPIR-V builder specialized for "load N floats -> compute over SSA floats ->
 // store 1 float", with helpers the VALU translator drives.
 struct SpirvCompute {
-    std::vector<uint32_t> caps, extimp, mem, entry, exec, debug, deco, types, code;
+    // `exts` holds OpExtension. SPIR-V requires it AFTER every OpCapability and BEFORE
+    // OpExtInstImport, which is why it is a separate section rather than appended to `caps` or
+    // prepended to `extimp` -- see the module assembly order below. Getting that order wrong fails
+    // spirv-val with a LAYOUT complaint that says nothing about descriptors.
+    std::vector<uint32_t> caps, exts, extimp, mem, entry, exec, debug, deco, types, code;
+    bool descriptor_indexing_declared = false;
+    // Declare the capability set and extension for an indexed descriptor array, once per module and
+    // only when one is actually declared, so every module that does not use one is byte-identical to
+    // what this emitter produced before stage 4b.
+    void declare_descriptor_indexing() {
+        if (descriptor_indexing_declared) return;
+        descriptor_indexing_declared = true;
+        put(caps, Op_Capability, {Cap_ShaderNonUniform});
+        put(caps, Op_Capability, {Cap_RuntimeDescriptorArray});
+        put(caps, Op_Capability, {Cap_StorageBufferArrayNonUniformIndexing});
+        std::vector<uint32_t> o; pstr(o, "SPV_EXT_descriptor_indexing");
+        putv(exts, Op_Extension, o);
+    }
     std::unordered_map<uint32_t, uint32_t> fconst_cache, uconst_cache;
     uint32_t next_id = 1;
     uint32_t stride = 1;
@@ -289,6 +318,10 @@ struct SpirvCompute {
     int32_t guest_scratch_min_byte=0, guest_scratch_saddr=-1;
     uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
+    // binding -> declared array length for a TABLE-INDEXED binding (#2412). Absent means an ordinary
+    // single descriptor, so an access chain for it takes no leading index. Kept beside `cbuf_var`
+    // because every consumer of the variable also needs to know whether it is an array.
+    std::map<uint32_t, uint32_t> cbuf_table_arity;
     // A two-byte guest V# can only back our u32 SSBO ABI when every use of that binding is the exact
     // one-record Uint16/Float16 path. Ordinary load/store/atomic helpers blacklist their bindings;
     // finish() emits the explicit typed zero-pad contract only for candidates with no competing use.
@@ -2306,6 +2339,35 @@ struct SpirvCompute {
                 if (!seen.insert(r.binding).second) continue;
                 uint32_t v = id();
                 put(deco, Op_Decorate, {v, Dec_DescriptorSet, desc_set}); put(deco, Op_Decorate, {v, Dec_Binding, r.binding});
+                if (r.table_index_count != 0) {
+                    // TABLE-INDEXED binding (#2412 stage 4b): the descriptor is one OF an array,
+                    // selected by an index only the GPU knows. The pointee becomes an array of the same
+                    // Block type rather than the Block itself, so this binding occupies
+                    // `table_index_count` descriptors and an access chain needs a leading index.
+                    //
+                    // A count of 0 never reaches here -- it means "not table-indexed".
+                    //
+                    // An IMPLAUSIBLE length emits a runtime array rather than a fixed array of that
+                    // length. This is the defensive path for a length that reflection could not read:
+                    // #2463 gives such a length its own sentinel (UINT32_MAX), and emitting
+                    // `OpTypeArray %Block 4294967295` would ask the driver for a 4-billion-descriptor
+                    // binding. The numeric guard catches that sentinel without this branch having to
+                    // depend on #2463 being merged first, and catches any other absurd count on the way.
+                    constexpr uint32_t kMaxPlausibleArity = 1u << 16;
+                    declare_descriptor_indexing();
+                    const uint32_t arr = id();
+                    if (r.table_index_count > kMaxPlausibleArity) {
+                        put(types, Op_TypeRuntimeArray, {arr, t_struct_u});
+                    } else {
+                        put(types, Op_TypeArray, {arr, t_struct_u, uconst(r.table_index_count)});
+                    }
+                    const uint32_t arr_ptr = id();
+                    put(types, Op_TypePointer, {arr_ptr, SC_StorageBuffer, arr});
+                    put(types, Op_Variable, {arr_ptr, v, SC_StorageBuffer});
+                    cbuf_var[r.binding] = v;
+                    cbuf_table_arity[r.binding] = r.table_index_count;
+                    continue;
+                }
                 put(types, Op_Variable, {t_ptr_sb_struct_u, v, SC_StorageBuffer});
                 cbuf_var[r.binding] = v;
             }
@@ -2989,7 +3051,7 @@ struct SpirvCompute {
             putv(debug, Op_ModuleProcessed, words);
         }
         std::vector<uint32_t> m{0x07230203u, 0x00010300u, 0u, next_id, 0u};
-        for (auto* s : {&caps, &extimp, &mem, &entry, &exec, &debug, &deco, &types, &code})
+        for (auto* s : {&caps, &exts, &extimp, &mem, &entry, &exec, &debug, &deco, &types, &code})
             m.insert(m.end(), s->begin(), s->end());
         return m;
     }

--- a/prosper/tests/test_descriptor_array_emit.cpp
+++ b/prosper/tests/test_descriptor_array_emit.cpp
@@ -1,0 +1,159 @@
+// test_descriptor_array_emit — the emitter declares an indexed descriptor ARRAY for a table-indexed
+// resource, with the capability set and the OpExtension that SPIR-V 1.3 requires (#2412 stage 4b).
+//
+// Nothing in the guest path sets `table_index_count` yet, so without this test the entire array-emission
+// path is structurally inexpressible in the suite: every other test would pass whether or not the code
+// existed. Same hole test_descriptor_array_render closes on the backend side.
+//
+// What each arm establishes:
+//
+//   1. A table-indexed resource emits OpExtension "SPV_EXT_descriptor_indexing" plus the three
+//      capabilities. They are core only from SPIR-V 1.5 and this emitter writes 1.3 (0x00010300), so
+//      the extension is mandatory, not optional.
+//   2. The extension is emitted in the RIGHT PLACE. SPIR-V requires OpExtension after every
+//      OpCapability and before OpExtInstImport. Getting this wrong fails spirv-val with a layout
+//      complaint that mentions nothing about descriptors, so it is asserted structurally here rather
+//      than left to CI to discover.
+//   3. The pointee is an OpTypeArray, so the binding occupies N descriptors instead of 1.
+//   4. THE CONTROL, and the one that makes the rest mean anything: an ordinary resource emits NONE of
+//      it. If the capability leaked into every module, arm 1 would pass for the wrong reason and every
+//      existing shader would start demanding an extension it does not use.
+#include "../src/gpu/rdna2_to_spirv.hpp"
+#include "../src/gpu/shader_resources.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+#include <string>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// Minimal SPIR-V word walk: yields (opcode, word_index) for each instruction after the 5-word header.
+static std::vector<std::pair<uint32_t, size_t>> walk(const std::vector<uint32_t>& m) {
+    std::vector<std::pair<uint32_t, size_t>> out;
+    for (size_t i = 5; i < m.size();) {
+        const uint32_t len = m[i] >> 16, op = m[i] & 0xFFFFu;
+        if (len == 0) break;
+        out.push_back({op, i});
+        i += len;
+    }
+    return out;
+}
+static bool has_op(const std::vector<uint32_t>& m, uint32_t op) {
+    for (auto& e : walk(m)) if (e.first == op) return true;
+    return false;
+}
+static bool has_capability(const std::vector<uint32_t>& m, uint32_t cap) {
+    for (auto& e : walk(m)) if (e.first == 17u && m[e.second + 1] == cap) return true;   // OpCapability
+    return false;
+}
+static std::string extension_name(const std::vector<uint32_t>& m) {
+    for (auto& e : walk(m)) {
+        if (e.first != 10u) continue;                                                     // OpExtension
+        const char* p = reinterpret_cast<const char*>(&m[e.second + 1]);
+        return std::string(p);
+    }
+    return {};
+}
+// Index of the first instruction with `op`, or SIZE_MAX.
+static size_t first_index_of(const std::vector<uint32_t>& m, uint32_t op) {
+    for (auto& e : walk(m)) if (e.first == op) return e.second;
+    return SIZE_MAX;
+}
+static size_t last_index_of(const std::vector<uint32_t>& m, uint32_t op) {
+    size_t found = SIZE_MAX;
+    for (auto& e : walk(m)) if (e.first == op) found = e.second;
+    return found;
+}
+
+int main() {
+    printf("== test_descriptor_array_emit ==\n");
+
+    // The vertex-fetch VS used across the render tests: fetches (x,y) from the buffer at binding 3.
+    const uint32_t vs[] = {
+        0x7e060280u, 0x7e0802f2u, 0xe0042000u, 0x80020100u, 0xf80008cfu, 0x04030201u, 0xbf810000u,
+    };
+
+    auto table_with_arity = [](uint32_t arity) {
+        ShaderResourceTable rt;
+        ShaderResource vb{};
+        vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32; vb.num_components = 2;
+        vb.binding = 3; vb.stride = 8; vb.sgpr_base = 8;
+        rt.resources.push_back(vb);
+        if (arity) {
+            // Binding 4, NOT 3. Bindings 2 and 3 are pre-declared as scalar storage buffers before
+            // declare_cbufs' N-buffer loop and are seeded into its `seen` set, so a table-indexed
+            // resource at either is skipped and silently emitted as an ordinary descriptor. That is a
+            // real limitation of this stage rather than a quirk of the test -- filed separately -- and
+            // it matters because a title's constant buffers commonly land on exactly those two
+            // bindings. This arm therefore proves the mechanism on a binding that can reach it.
+            ShaderResource tb{};
+            tb.cls = ResourceClass::ConstantBuffer; tb.format = DataFormat::Float32;
+            tb.num_components = 4; tb.binding = 4; tb.stride = 16; tb.sgpr_base = 12;
+            tb.table_index_count = arity; tb.table_entry_stride = 16;
+            rt.resources.push_back(tb);
+        }
+        return rt;
+    };
+
+    // --- Arm 4 first: the CONTROL. An ordinary resource must emit none of this. -------------------
+    ShaderResourceTable plain = table_with_arity(0);
+    std::vector<uint32_t> m_plain = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &plain);
+    CHECK(!m_plain.empty(), "control: ordinary resource still recompiles");
+    if (m_plain.empty()) { printf("== FAIL ==\n"); return 1; }
+    CHECK(!has_op(m_plain, 10u), "control: an ordinary resource emits NO OpExtension");
+    CHECK(!has_capability(m_plain, 5301u) && !has_capability(m_plain, 5302u) &&
+              !has_capability(m_plain, 5306u),
+          "control: an ordinary resource declares NO descriptor-indexing capability");
+
+    // --- Arms 1-3: a table-indexed resource ------------------------------------------------------
+    ShaderResourceTable indexed = table_with_arity(8);
+    std::vector<uint32_t> m_arr = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &indexed);
+    CHECK(!m_arr.empty(), "a table-indexed resource recompiles");
+    if (m_arr.empty()) { printf("== FAIL ==\n"); return 1; }
+
+    CHECK(m_arr[1] == 0x00010300u, "the module is SPIR-V 1.3, which is why the extension is required");
+    CHECK(extension_name(m_arr) == "SPV_EXT_descriptor_indexing",
+          "OpExtension SPV_EXT_descriptor_indexing is emitted");
+    CHECK(has_capability(m_arr, 5301u), "ShaderNonUniform capability declared");
+    CHECK(has_capability(m_arr, 5302u), "RuntimeDescriptorArray capability declared");
+    CHECK(has_capability(m_arr, 5306u), "StorageBufferArrayNonUniformIndexing capability declared");
+
+    // Layout: every OpCapability precedes OpExtension, which precedes OpExtInstImport.
+    const size_t last_cap = last_index_of(m_arr, 17u);
+    const size_t ext = first_index_of(m_arr, 10u);
+    const size_t extinst = first_index_of(m_arr, 11u);
+    CHECK(last_cap != SIZE_MAX && ext != SIZE_MAX && last_cap < ext,
+          "OpExtension follows every OpCapability (required section order)");
+    CHECK(extinst == SIZE_MAX || ext < extinst,
+          "OpExtension precedes OpExtInstImport (required section order)");
+
+    CHECK(has_op(m_arr, 28u), "the binding's pointee is an OpTypeArray — it occupies N descriptors");
+
+    // Deliberately NOT asserted: the absence of OpTypeRuntimeArray. The Block type this emitter builds
+    // for every storage buffer already contains one (a runtime array of u32 IS the buffer's payload), so
+    // "no runtime array in the module" is false for every module and an assertion on it would either be
+    // vacuous or wrong. The fixed-vs-runtime distinction is asserted below on the arity instead.
+
+    // --- An absurd count must not be emitted as a fixed array of that length ----------------------
+    // #2463 gives an unreadable length the sentinel UINT32_MAX. Emitting OpTypeArray with that length
+    // would ask a driver for a 4-billion-descriptor binding, so the emitter degrades to a runtime
+    // array instead. Asserted here so the guard cannot be removed silently once #2463 merges.
+    ShaderResourceTable absurd = table_with_arity(0xFFFFFFFFu);
+    std::vector<uint32_t> m_absurd = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &absurd);
+    CHECK(!m_absurd.empty(), "an implausible arity still recompiles");
+    if (!m_absurd.empty()) {
+        bool huge_literal = false;
+        for (auto& e : walk(m_absurd))
+            if (e.first == 43u && e.second + 3 < m_absurd.size() && m_absurd[e.second + 3] == 0xFFFFFFFFu)
+                huge_literal = true;   // OpConstant with the sentinel as its value
+        CHECK(!huge_literal,
+              "an implausible arity is NOT emitted as a fixed array of 4294967295 descriptors");
+    }
+
+    printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Stage 4b of #2412 — the emitter half. Independent of #2470/#2471 (the backend half), so reviewable in either order.

## What the emitter did not have

| missing | why it matters |
| --- | --- |
| `Op_Extension` **and an `exts` section** | SPIR-V requires OpExtension **after** every OpCapability and **before** OpExtInstImport, so it cannot be appended to `caps` or prepended to `extimp` — the assembly order gains a slot between them. Getting it wrong fails `spirv-val` with a *layout* complaint that mentions nothing about descriptors. |
| `ShaderNonUniform` (5301), `RuntimeDescriptorArray` (5302), `StorageBufferArrayNonUniformIndexing` (5306) | Core only from SPIR-V **1.5**; this emitter writes **1.3** (`0x00010300`), which is precisely why the extension is mandatory rather than optional. |
| `Dec_NonUniform` (5300) | `grep -c NonUniform` on this file returns **45**, and every one is a `GroupNonUniform*` **wave op** that merely shares the word. The decoration descriptor indexing needs did not exist here. |

A resource carrying `table_index_count` now emits a binding whose pointee is an `OpTypeArray` of the Block type instead of the Block itself, so it occupies N descriptors. All of it is emitted **only when such a binding exists**, so a module without one is byte-identical to before — asserted by a control arm, not assumed.

An implausible arity degrades to `OpTypeRuntimeArray` rather than a fixed array of that length: #2463 gives an unreadable length the sentinel `UINT32_MAX`, and `OpTypeArray %Block 4294967295` would ask a driver for a four-billion-descriptor binding. The guard is **numeric** so this branch does not have to wait for #2463.

## Tests

Nothing in the guest path sets `table_index_count`, so this path is otherwise structurally inexpressible — every existing test passes whether or not the code exists.

```
[ok]   control: an ordinary resource emits NO OpExtension
[ok]   control: an ordinary resource declares NO descriptor-indexing capability
[ok]   the module is SPIR-V 1.3, which is why the extension is required
[ok]   OpExtension SPV_EXT_descriptor_indexing is emitted
[ok]   ShaderNonUniform / RuntimeDescriptorArray / StorageBufferArrayNonUniformIndexing declared
[ok]   OpExtension follows every OpCapability (required section order)
[ok]   OpExtension precedes OpExtInstImport (required section order)
[ok]   the binding's pointee is an OpTypeArray — it occupies N descriptors
[ok]   an implausible arity is NOT emitted as a fixed array of 4294967295 descriptors
```

The **control arms come first** and are what stop the rest passing for the wrong reason: if the capability leaked into every module, "OpExtension is emitted" would be true and meaningless.

I also removed a vacuous assertion I had written (`CHECK(!has_op(m, 29u) || true, ...)` — always true) and recorded *why* the absence of `OpTypeRuntimeArray` cannot be asserted: this emitter's Block type contains one for every storage buffer, since a runtime array of u32 **is** the payload.

## Known limitation, and the test found it by failing first

**Bindings 2 and 3 cannot be arrays** — filed as #2472. They are pre-declared as scalar buffers before `declare_cbufs`' N-buffer loop and seeded into its `seen` set, so a table-indexed resource at either is skipped and emitted as an ordinary descriptor, **silently**. Combined with #2471 that produces the quiet-wrong case: layout says N, SPIR-V says 1, Vulkan permits it, and the shader reads element 0 for every index.

The test's first run had `table_index_count = 8` at binding 3 and went six arms red. It now uses binding 4 and says why in a comment. **Had I written it at binding 4 to begin with, this would have shipped invisible** — which is the argument for writing the test before believing the code.

## Verification at exact head `8958b7c0`

```
cmake --build prosper/build-linux -j6                       -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4   -> 231/231 passed, rc=0
git diff --cached --check                                   -> clean
trailer gate                                                -> 0
```

## Review

@wren the parts worth attacking: whether `RuntimeDescriptorArray` should be declared at all when the emitter only produces a *fixed* `OpTypeArray` in the normal path (it is needed for the degradation branch, but declaring a capability a module does not exercise is the kind of thing a strict driver may object to); and whether the numeric `kMaxPlausibleArity` guard is the right shape versus taking the dependency on #2463's sentinel once it merges.

**What is still missing for pixels:** the access chain. This declares the array; a shader that *indexes* it needs the index expression, which comes from the scalar register the const-fold could not resolve — that plumbing is the remaining step, and it is the one that finally connects to GTA V's 53 skipped dispatches.
