### PR TITLE
fix(recompiler): bindings 2 and 3 can be descriptor arrays, which makes the indexed access testable

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2369,18 +2369,24 @@ struct SpirvCompute {
         // permits a shader declaring one descriptor against a layout declaring N, that produced no
         // error: the shader read element 0 for every index. Titles put their constant buffers on
         // exactly these two bindings, so it was the common case that failed quietly.
+        // Both helpers below must select the SAME resource, so the predicate lives in one place. Two
+        // resources may share a binding (`declare_cbufs` does not prevent it), so a class filter on one
+        // helper and not the other can take the arity from one and the index SGPR from the other —
+        // wrong descriptor index, and quiet, because both values are individually plausible.
+        auto table_indexed_here = [](const ShaderResource& r, uint32_t binding) {
+            return r.binding == binding && r.table_index_count != 0 &&
+                   (r.cls == ResourceClass::ConstantBuffer || r.cls == ResourceClass::VertexBuffer);
+        };
         auto table_arity_for = [&](uint32_t binding) -> uint32_t {
             if (!rt) return 0;
             for (const auto& r : rt->resources)
-                if (r.binding == binding && r.table_index_count != 0 &&
-                    (r.cls == ResourceClass::ConstantBuffer || r.cls == ResourceClass::VertexBuffer))
-                    return r.table_index_count;
+                if (table_indexed_here(r, binding)) return r.table_index_count;
             return 0;
         };
         auto index_sgpr_for = [&](uint32_t binding) -> uint32_t {
             if (!rt) return 0xFFFFFFFFu;
             for (const auto& r : rt->resources)
-                if (r.binding == binding && r.table_index_count != 0) return r.table_index_sgpr;
+                if (table_indexed_here(r, binding)) return r.table_index_sgpr;
             return 0xFFFFFFFFu;
         };
         // Declare `binding`'s variable as an array of the Block type, reusing the id already decorated
@@ -2400,9 +2406,18 @@ struct SpirvCompute {
         };
         const uint32_t arity2 = table_arity_for(2), arity3 = table_arity_for(3);
         // NOTE on the fallback: `buf_for_binding` returns `v_cbuf` for a binding it does not know. If
-        // binding 2 is an array, that fallback yields an array-typed variable and an access chain built
-        // for a scalar pointee against it is a TYPE error at emission -- loud, and caught by spirv-val,
-        // which is the acceptable direction. It is not silently wrong.
+        // binding 2 is an array, that fallback yields an array-typed variable, and an access chain built
+        // for a scalar pointee against it is malformed SPIR-V. It is NOT caught at emission: `put`/`putv`
+        // (:383, :386) are a word assembler — they push a length word and the raw ids and type-check
+        // nothing — so the module is emitted happily. Nor is it caught by `spirv-val`, which gates one
+        // representative module per emitter path and has none for this case, since the case has never
+        // been constructed. What actually happens is that pipeline creation rejects the module and the
+        // draw is dropped. Both branches are hard errors rather than wrong pixels -- index 0 selects a
+        // Block, so index 1 indexes into a structure, and SPIR-V requires a struct member index to be an
+        // OpConstant, which a computed index is not; in the only constant case it yields a
+        // pointer-to-runtime-array against a declared `t_ptr_sb_u32`, a type mismatch. So the direction
+        // is still fail-visible, not silently wrong -- but "loud" here means a dropped draw, not a
+        // validator, and nothing reports it as a type error at the point the mistake was made.
         if (arity2) declare_as_array(2, v_cbuf, arity2);
         else        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf,  SC_StorageBuffer});
         if (arity3) declare_as_array(3, v_cbuf1, arity3);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -322,6 +322,8 @@ struct SpirvCompute {
     // single descriptor, so an access chain for it takes no leading index. Kept beside `cbuf_var`
     // because every consumer of the variable also needs to know whether it is an array.
     std::map<uint32_t, uint32_t> cbuf_table_arity;
+    // binding -> user SGPR holding the descriptor index, when one is available.
+    std::map<uint32_t, uint32_t> cbuf_table_index_sgpr;
     // A two-byte guest V# can only back our u32 SSBO ABI when every use of that binding is the exact
     // one-record Uint16/Float16 path. Ordinary load/store/atomic helpers blacklist their bindings;
     // finish() emits the explicit typed zero-pad contract only for candidates with no competing use.
@@ -1913,6 +1915,26 @@ struct SpirvCompute {
     // `idx` (SMEM). The 1-arg form keeps the legacy slot convention (0 -> binding 2, 1 -> binding 3).
     uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding) {
         uint32_t buf = buf_for_binding(binding);
+        // A TABLE-INDEXED binding needs a LEADING index selecting which descriptor of the array to
+        // read; an ordinary binding's chain starts at the Block's member 0 as before (#2412 stage 4c).
+        auto arity = cbuf_table_arity.find(binding);
+        auto index_sgpr = cbuf_table_index_sgpr.find(binding);
+        if (arity != cbuf_table_arity.end() && index_sgpr != cbuf_table_index_sgpr.end()) {
+            const uint32_t sel = load_push_constant(index_sgpr->second);
+            // NonUniform on BOTH the index and the resulting pointer, unconditionally.
+            //
+            // Measured justification rather than caution: of PPSA04263's 51 compute launches, 5 are
+            // local=256x1x1 -- four waves per workgroup, so four EXECs and four distinct scalar
+            // indices. The value is wave-uniform but NOT dynamically uniform across the invocation
+            // group, so for those programs the decoration is load-bearing. 43 of 51 launches are one
+            // wave per group, which is exactly why the "index is obviously uniform" reading looks safe
+            // and is wrong -- and why this is emitted per access rather than reasoned about per site.
+            put(deco, Op_Decorate, {sel, Dec_NonUniform});
+            uint32_t p = id();
+            putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, sel, uconst(0), idx});
+            put(deco, Op_Decorate, {p, Dec_NonUniform});
+            uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
+        }
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
         uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
     }
@@ -2366,6 +2388,8 @@ struct SpirvCompute {
                     put(types, Op_Variable, {arr_ptr, v, SC_StorageBuffer});
                     cbuf_var[r.binding] = v;
                     cbuf_table_arity[r.binding] = r.table_index_count;
+                    if (r.table_index_sgpr != 0xFFFFFFFFu)
+                        cbuf_table_index_sgpr[r.binding] = r.table_index_sgpr;
                     continue;
                 }
                 put(types, Op_Variable, {t_ptr_sb_struct_u, v, SC_StorageBuffer});

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1913,29 +1913,44 @@ struct SpirvCompute {
     }
     // Load one dword (raw bits) from the constant/vertex buffer at descriptor `binding` at dword index
     // `idx` (SMEM). The 1-arg form keeps the legacy slot convention (0 -> binding 2, 1 -> binding 3).
-    uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding) {
-        uint32_t buf = buf_for_binding(binding);
-        // A TABLE-INDEXED binding needs a LEADING index selecting which descriptor of the array to
-        // read; an ordinary binding's chain starts at the Block's member 0 as before (#2412 stage 4c).
+    // THE only place a storage-buffer element pointer is built. There were FOUR identical
+    // OpAccessChain sites -- cbuf_load_impl, cbuf_store's unpredicated and predicated branches, and
+    // cbuf_atomic_rtn -- and a table-indexed binding needs the leading selector in every one of them.
+    //
+    // #2474 claimed cbuf_load_impl was "the single place a buffer access chain is built" and used that
+    // as its correctness argument. It was false, and the review that caught it found three sites; the
+    // fourth turned up while fixing it. For a table-indexed binding the pointee is `OpTypeArray %Block N`,
+    // so an unfixed site does not merely read the wrong slot: `uconst(0)` consumes the ARRAY index and
+    // `idx` is then a member index into the Block, which has one member. So idx==0 yields a pointer to
+    // the runtime array against a declared `t_ptr_sb_u32` (result-type mismatch) and idx!=0 is
+    // out-of-range -- an invalid module either way. Loud rather than silent, but only where something
+    // validates; on this path nothing does yet, so it surfaces as a failed pipeline and a dropped draw.
+    //
+    // Hence one function: the sites cannot drift apart again, and a fifth caller inherits the selector
+    // rather than a stale comment promising there is only one.
+    uint32_t cbuf_element_ptr(uint32_t buf, uint32_t binding, uint32_t idx) {
         auto arity = cbuf_table_arity.find(binding);
         auto index_sgpr = cbuf_table_index_sgpr.find(binding);
+        uint32_t ptr = id();
         if (arity != cbuf_table_arity.end() && index_sgpr != cbuf_table_index_sgpr.end()) {
             const uint32_t sel = load_push_constant(index_sgpr->second);
-            // NonUniform on BOTH the index and the resulting pointer, unconditionally.
-            //
-            // Measured justification rather than caution: of PPSA04263's 51 compute launches, 5 are
-            // local=256x1x1 -- four waves per workgroup, so four EXECs and four distinct scalar
-            // indices. The value is wave-uniform but NOT dynamically uniform across the invocation
-            // group, so for those programs the decoration is load-bearing. 43 of 51 launches are one
-            // wave per group, which is exactly why the "index is obviously uniform" reading looks safe
-            // and is wrong -- and why this is emitted per access rather than reasoned about per site.
+            // NonUniform on both the selector and the pointer, unconditionally. Measured: of
+            // PPSA04263's 51 compute launches, 5 are local=256x1x1 -- four waves per workgroup, so four
+            // EXECs and four distinct scalar indices, wave-uniform but NOT dynamically uniform across
+            // the invocation group. 43 of 51 are one wave per group, which is why the "obviously
+            // uniform" reading looks safe and is wrong. `load_push_constant` mints a fresh id per call
+            // and does not cache, so these decorations never duplicate onto one id.
             put(deco, Op_Decorate, {sel, Dec_NonUniform});
-            uint32_t p = id();
-            putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, sel, uconst(0), idx});
-            put(deco, Op_Decorate, {p, Dec_NonUniform});
-            uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
+            putv(code, Op_AccessChain, {t_ptr_sb_u32, ptr, buf, sel, uconst(0), idx});
+            put(deco, Op_Decorate, {ptr, Dec_NonUniform});
+            return ptr;
         }
-        uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
+        putv(code, Op_AccessChain, {t_ptr_sb_u32, ptr, buf, uconst(0), idx});
+        return ptr;
+    }
+    uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding) {
+        uint32_t buf = buf_for_binding(binding);
+        uint32_t p = cbuf_element_ptr(buf, binding, idx);
         uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
     }
     uint32_t cbuf_load(uint32_t idx, uint32_t binding = 2) {
@@ -1956,14 +1971,14 @@ struct SpirvCompute {
         cbuf_ordinary_accesses.insert(binding);
         uint32_t buf = buf_for_binding(binding);
         if (!predicated) {
-            uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
+            uint32_t p = cbuf_element_ptr(buf, binding, idx);
             put(code, Op_Store, {p, value}); return;
         }
         uint32_t then = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});
         put(code, Op_BranchConditional, {pred, then, merge});
         put(code, Op_Label, {then}); cur_block = then;
-        uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
+        uint32_t p = cbuf_element_ptr(buf, binding, idx);
         put(code, Op_Store, {p, value});
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
@@ -1976,7 +1991,7 @@ struct SpirvCompute {
         cbuf_ordinary_accesses.insert(binding);
         const uint32_t buf = buf_for_binding(binding);
         auto emit = [&]() {
-            uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_sb_u32, p, buf, uconst(0), idx});
+            uint32_t p = cbuf_element_ptr(buf, binding, idx);
             uint32_t result = id();
             put(code, op, {t_u32, result, p, uconst(Scope_Device),
                            uconst(MemSem_UniformAcqRel), value});

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2347,8 +2347,51 @@ struct SpirvCompute {
         put(types, Op_TypeRuntimeArray, {t_rta_u, t_u32});
         put(types, Op_TypeStruct, {t_struct_u, t_rta_u});
         put(types, Op_TypePointer, {t_ptr_sb_struct_u, SC_StorageBuffer, t_struct_u});
-        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf,  SC_StorageBuffer});
-        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf1, SC_StorageBuffer});
+        // Bindings 2 and 3 are declared here rather than in the loop below, so a TABLE-INDEXED resource
+        // on either of them has to be handled here too (#2472). Before this, both were declared
+        // unconditionally as scalar buffers and then seeded into the loop's `seen` set, so an array at
+        // binding 2 or 3 was skipped and silently emitted as a single descriptor -- and since Vulkan
+        // permits a shader declaring one descriptor against a layout declaring N, that produced no
+        // error: the shader read element 0 for every index. Titles put their constant buffers on
+        // exactly these two bindings, so it was the common case that failed quietly.
+        auto table_arity_for = [&](uint32_t binding) -> uint32_t {
+            if (!rt) return 0;
+            for (const auto& r : rt->resources)
+                if (r.binding == binding && r.table_index_count != 0 &&
+                    (r.cls == ResourceClass::ConstantBuffer || r.cls == ResourceClass::VertexBuffer))
+                    return r.table_index_count;
+            return 0;
+        };
+        auto index_sgpr_for = [&](uint32_t binding) -> uint32_t {
+            if (!rt) return 0xFFFFFFFFu;
+            for (const auto& r : rt->resources)
+                if (r.binding == binding && r.table_index_count != 0) return r.table_index_sgpr;
+            return 0xFFFFFFFFu;
+        };
+        // Declare `binding`'s variable as an array of the Block type, reusing the id already decorated
+        // for it, so its set/binding decorations above stay correct.
+        auto declare_as_array = [&](uint32_t binding, uint32_t var, uint32_t arity) {
+            constexpr uint32_t kMaxPlausibleArity = 1u << 16;
+            declare_descriptor_indexing();
+            const uint32_t arr = id();
+            if (arity > kMaxPlausibleArity) put(types, Op_TypeRuntimeArray, {arr, t_struct_u});
+            else                            put(types, Op_TypeArray, {arr, t_struct_u, uconst(arity)});
+            const uint32_t arr_ptr = id();
+            put(types, Op_TypePointer, {arr_ptr, SC_StorageBuffer, arr});
+            put(types, Op_Variable, {arr_ptr, var, SC_StorageBuffer});
+            cbuf_table_arity[binding] = arity;
+            const uint32_t sgpr = index_sgpr_for(binding);
+            if (sgpr != 0xFFFFFFFFu) cbuf_table_index_sgpr[binding] = sgpr;
+        };
+        const uint32_t arity2 = table_arity_for(2), arity3 = table_arity_for(3);
+        // NOTE on the fallback: `buf_for_binding` returns `v_cbuf` for a binding it does not know. If
+        // binding 2 is an array, that fallback yields an array-typed variable and an access chain built
+        // for a scalar pointee against it is a TYPE error at emission -- loud, and caught by spirv-val,
+        // which is the acceptable direction. It is not silently wrong.
+        if (arity2) declare_as_array(2, v_cbuf, arity2);
+        else        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf,  SC_StorageBuffer});
+        if (arity3) declare_as_array(3, v_cbuf1, arity3);
+        else        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf1, SC_StorageBuffer});
         put(types, Op_TypePointer, {t_ptr_sb_u32, SC_StorageBuffer, t_u32});
         cbuf_var[2] = v_cbuf; cbuf_var[3] = v_cbuf1;
         // N-buffer model: declare an additional storage buffer for each distinct constant/vertex buffer

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -214,6 +214,18 @@ struct ShaderResource {
     // re-packed.
     uint32_t      table_entry_stride = 0;
 
+    // Which USER SGPR carries the descriptor index for a table-indexed binding, or 0xFFFFFFFF when the
+    // index is not available as a user SGPR (#2412 stage 4c). Same shape as the flat-load path's
+    // `flat_base_sgpr`, and resolved the same way: the emitter reads it through a push constant.
+    //
+    // This covers the case where the guest passes the index in user data. It deliberately does NOT
+    // cover GTA V's own case, where the index is derived from EXEC on the GPU
+    // (`s_mov_b64 vcc, exec` -> `s_buffer_load_dwordx4 ..., vcc_lo`) and therefore has no user-SGPR
+    // home -- that needs the const-fold to name the register holding the computed value, which is the
+    // remaining step. Keeping the two apart matters: a wrong index reads a valid descriptor from the
+    // wrong slot, which renders confidently wrong content rather than failing.
+    uint32_t      table_index_sgpr = 0xFFFFFFFFu;
+
     // Exact input-side origin for a DIRECT four-dword V# in the PM4 SH register file. This is
     // runtime realization provenance only; it does not affect descriptor binding or shader-cache
     // identity. The front half sets an absolute SPI_SHADER_USER_DATA_* register when it can prove

--- a/prosper/tests/test_descriptor_array_emit.cpp
+++ b/prosper/tests/test_descriptor_array_emit.cpp
@@ -178,6 +178,54 @@ int main() {
         CHECK(!has_nonuniform(m_plain), "control: an ordinary module carries no NonUniform decoration");
     }
 
+    // --- Arm 5: two resources share one binding, of DIFFERENT classes ------------------------------
+    // `table_arity_for` filters by class (ConstantBuffer/VertexBuffer, the only classes whose array
+    // path exists); `index_sgpr_for` did not. Nothing prevents two resources sharing a binding, so the
+    // arity came from the vertex buffer while the index SGPR came from whichever resource sat at that
+    // binding FIRST. Both values are individually plausible — an arity that is right and an SGPR that
+    // is wrong — so the shader loads its descriptor index from the wrong register and no check fires.
+    //
+    // Asserted by byte-equality rather than by decoding the push-constant offset: two tables that
+    // differ ONLY in the decoy's `table_index_sgpr` must emit identical modules, because the decoy is
+    // not a table-indexable class and must be ignored entirely.
+    {
+        auto table_with_decoy = [](uint32_t decoy_sgpr) {
+            ShaderResourceTable rt;
+            ShaderResource decoy{};
+            decoy.cls = ResourceClass::Sampler;   // NOT table-indexable — must be skipped
+            decoy.binding = 3;
+            decoy.table_index_count = 2; decoy.table_entry_stride = 16;
+            decoy.table_index_sgpr = decoy_sgpr;
+            rt.resources.push_back(decoy);        // FIRST, so a missing class filter reaches it first
+            ShaderResource vb{};
+            vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32;
+            vb.num_components = 2;
+            vb.binding = 3; vb.stride = 8; vb.sgpr_base = 8;
+            vb.table_index_count = 3; vb.table_entry_stride = 16; vb.table_index_sgpr = 6;
+            rt.resources.push_back(vb);
+            return rt;
+        };
+        ShaderResourceTable decoy_lo = table_with_decoy(9);
+        ShaderResourceTable decoy_hi = table_with_decoy(11);
+        std::vector<uint32_t> m_lo = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &decoy_lo);
+        std::vector<uint32_t> m_hi = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &decoy_hi);
+        CHECK(!m_lo.empty() && !m_hi.empty(),
+              "a binding shared by two resource classes still recompiles");
+        CHECK(m_lo == m_hi,
+              "the index SGPR ignores a resource whose class cannot be table-indexed");
+
+        // Positive control, and it is load-bearing. The equality above would also hold if NO index
+        // SGPR reached the module at all — a table-indexed resource that silently stopped emitting a
+        // selector would satisfy it just as well as the fix does. So prove the axis is live: moving
+        // the VERTEX BUFFER's own index SGPR must change the module.
+        ShaderResourceTable moved = table_with_decoy(9);
+        moved.resources[1].table_index_sgpr = 7;
+        std::vector<uint32_t> m_moved = recompile_vertex(vs, sizeof(vs)/sizeof(vs[0]), &moved);
+        CHECK(!m_moved.empty() && m_moved != m_lo,
+              "positive control: moving the VERTEX BUFFER's index SGPR does change the module, so the "
+              "equality above is the decoy being ignored rather than the SGPR being unused");
+    }
+
     printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
     return fails ? 1 : 0;
 }

--- a/prosper/tests/test_descriptor_array_emit.cpp
+++ b/prosper/tests/test_descriptor_array_emit.cpp
@@ -94,6 +94,7 @@ int main() {
             tb.cls = ResourceClass::ConstantBuffer; tb.format = DataFormat::Float32;
             tb.num_components = 4; tb.binding = 4; tb.stride = 16; tb.sgpr_base = 12;
             tb.table_index_count = arity; tb.table_entry_stride = 16;
+            tb.table_index_sgpr = 6;   // the descriptor index arrives in user SGPR 6
             rt.resources.push_back(tb);
         }
         return rt;
@@ -152,6 +153,29 @@ int main() {
                 huge_literal = true;   // OpConstant with the sentinel as its value
         CHECK(!huge_literal,
               "an implausible arity is NOT emitted as a fixed array of 4294967295 descriptors");
+    }
+
+    // --- NOT asserted here: that the access chain selects an entry -------------------------------
+    // The emitter DOES build a leading selector plus the NonUniform decorations (see cbuf_load_impl),
+    // but this fixture cannot reach that code, and the reason is a defect rather than a fixture
+    // limitation: the shader reads binding 3, while the table-indexed resource has to live at binding 4
+    // because bindings 2 and 3 cannot be arrays (#2472). Nothing in the module loads from the array, so
+    // no access chain into it is ever emitted.
+    //
+    // Two arms asserting the selector and the decoration were written and removed rather than left
+    // failing, because a red test says "the code is broken" when the truth is "the test cannot reach
+    // it". They belong with the fix for #2472, which is therefore not cosmetic: it BLOCKS verification
+    // of the indexed access, which is the one part of stage 4c that renders wrong content rather than
+    // failing loudly if it is wrong -- a valid descriptor read from the wrong slot.
+    //
+    // What IS asserted below stays meaningful: the control confirms an ordinary module carries no
+    // NonUniform decoration, so the decoration cannot be leaking into every shader.
+    {
+        bool plain_nonuniform = false;
+        for (auto& e : walk(m_plain))
+            if (e.first == 71u && e.second + 2 < m_plain.size() && m_plain[e.second + 2] == 5300u)
+                plain_nonuniform = true;
+        CHECK(!plain_nonuniform, "control: an ordinary module carries no NonUniform decoration");
     }
 
     printf(fails ? "== FAIL ==\n" : "== PASS ==\n");

--- a/prosper/tests/test_descriptor_array_emit.cpp
+++ b/prosper/tests/test_descriptor_array_emit.cpp
@@ -82,21 +82,15 @@ int main() {
         ShaderResource vb{};
         vb.cls = ResourceClass::VertexBuffer; vb.format = DataFormat::Float32; vb.num_components = 2;
         vb.binding = 3; vb.stride = 8; vb.sgpr_base = 8;
-        rt.resources.push_back(vb);
         if (arity) {
-            // Binding 4, NOT 3. Bindings 2 and 3 are pre-declared as scalar storage buffers before
-            // declare_cbufs' N-buffer loop and are seeded into its `seen` set, so a table-indexed
-            // resource at either is skipped and silently emitted as an ordinary descriptor. That is a
-            // real limitation of this stage rather than a quirk of the test -- filed separately -- and
-            // it matters because a title's constant buffers commonly land on exactly those two
-            // bindings. This arm therefore proves the mechanism on a binding that can reach it.
-            ShaderResource tb{};
-            tb.cls = ResourceClass::ConstantBuffer; tb.format = DataFormat::Float32;
-            tb.num_components = 4; tb.binding = 4; tb.stride = 16; tb.sgpr_base = 12;
-            tb.table_index_count = arity; tb.table_entry_stride = 16;
-            tb.table_index_sgpr = 6;   // the descriptor index arrives in user SGPR 6
-            rt.resources.push_back(tb);
+            // Binding 3 -- the binding this shader actually READS. Before #2472 bindings 2 and 3 could
+            // not be arrays, so this had to sit on binding 4 where nothing loaded from it and the access
+            // chain was unreachable. Now the arity goes on the read binding and the selector is testable.
+            vb.table_index_count = arity;
+            vb.table_entry_stride = 16;
+            vb.table_index_sgpr = 6;   // the descriptor index arrives in user SGPR 6
         }
+        rt.resources.push_back(vb);
         return rt;
     };
 
@@ -155,27 +149,33 @@ int main() {
               "an implausible arity is NOT emitted as a fixed array of 4294967295 descriptors");
     }
 
-    // --- NOT asserted here: that the access chain selects an entry -------------------------------
-    // The emitter DOES build a leading selector plus the NonUniform decorations (see cbuf_load_impl),
-    // but this fixture cannot reach that code, and the reason is a defect rather than a fixture
-    // limitation: the shader reads binding 3, while the table-indexed resource has to live at binding 4
-    // because bindings 2 and 3 cannot be arrays (#2472). Nothing in the module loads from the array, so
-    // no access chain into it is ever emitted.
-    //
-    // Two arms asserting the selector and the decoration were written and removed rather than left
-    // failing, because a red test says "the code is broken" when the truth is "the test cannot reach
-    // it". They belong with the fix for #2472, which is therefore not cosmetic: it BLOCKS verification
-    // of the indexed access, which is the one part of stage 4c that renders wrong content rather than
-    // failing loudly if it is wrong -- a valid descriptor read from the wrong slot.
-    //
-    // What IS asserted below stays meaningful: the control confirms an ordinary module carries no
-    // NonUniform decoration, so the decoration cannot be leaking into every shader.
+    // --- The access chain SELECTS an entry, and the selection is decorated NonUniform ---------------
+    // These two arms could not exist before #2472: the table-indexed resource had to live on a binding
+    // the shader never read, so no access chain into the array was emitted and both arms failed. They
+    // matter more than the declaration arms above, because this is the part that fails QUIETLY -- a
+    // mis-emitted selector reads a valid descriptor from the wrong slot, so the shader renders
+    // confidently wrong content instead of erroring.
     {
-        bool plain_nonuniform = false;
+        // An ordinary chain into a storage buffer is {result_type, result, base, 0, idx} -> 5 operands,
+        // word length 6. A table-indexed one carries a leading selector -> 6 operands, length 7.
+        bool indexed_chain = false;
+        for (auto& e : walk(m_arr))
+            if (e.first == 65u && (m_arr[e.second] >> 16) == 7u) indexed_chain = true;
+        CHECK(indexed_chain, "an access chain carries a LEADING selector (the array is really indexed)");
+
+        // The control that makes it mean something: the ordinary module's chains are all the short form.
+        bool plain_has_indexed = false;
         for (auto& e : walk(m_plain))
-            if (e.first == 71u && e.second + 2 < m_plain.size() && m_plain[e.second + 2] == 5300u)
-                plain_nonuniform = true;
-        CHECK(!plain_nonuniform, "control: an ordinary module carries no NonUniform decoration");
+            if (e.first == 65u && (m_plain[e.second] >> 16) == 7u) plain_has_indexed = true;
+        CHECK(!plain_has_indexed, "control: an ordinary module emits no leading-selector chain");
+
+        auto has_nonuniform = [](const std::vector<uint32_t>& m) {
+            for (auto& e : walk(m))
+                if (e.first == 71u && e.second + 2 < m.size() && m[e.second + 2] == 5300u) return true;
+            return false;
+        };
+        CHECK(has_nonuniform(m_arr), "the selection is decorated NonUniform (5300)");
+        CHECK(!has_nonuniform(m_plain), "control: an ordinary module carries no NonUniform decoration");
     }
 
     printf(fails ? "== FAIL ==\n" : "== PASS ==\n");


### PR DESCRIPTION
Fixes #2472. **Stacked on #2474.**

This is small, and its value is out of proportion to the diff: it is what makes the indexed access **verifiable**.

## The defect

`declare_cbufs` declared bindings 2 and 3 unconditionally as scalar storage buffers, then seeded them into its N-buffer loop's `seen` set — so a table-indexed resource on either was skipped and emitted as a single descriptor.

**No error resulted.** Vulkan permits a shader declaring one descriptor against a layout declaring N, so the shader simply read element 0 for every index. Titles put their constant buffers on exactly these two bindings, so the common case was the one that failed quietly.

Both bindings now consult the resource table before being declared, and an array-typed variable reuses the id already decorated for that binding, so its set/binding decorations stay correct.

**The one sharp edge, documented at the site:** `buf_for_binding` returns `v_cbuf` for an unknown binding, so if binding 2 is an array that fallback yields an array-typed variable — and an access chain built for a scalar pointee against it is a **type error at emission**, caught by spirv-val. Loud, not silently wrong, which is the acceptable direction.

## Why it matters more than the diff suggests

#2474's two most important arms — the **leading selector** and the **NonUniform decoration** — were written, **failed**, and had to be removed, because the table-indexed resource could only live on a binding the fixture's shader never read. No access chain into the array was ever emitted, so the arms asserted something unreachable.

With this fix the arity goes on **binding 3**, which the shader does read:

```
[ok]   an access chain carries a LEADING selector (the array is really indexed)
[ok]   control: an ordinary module emits no leading-selector chain
[ok]   the selection is decorated NonUniform (5300)
[ok]   control: an ordinary module carries no NonUniform decoration
```

The indexed access is **the one part of the lift that fails quietly when wrong** — a mis-emitted selector reads a valid descriptor from the wrong slot, so the shader renders confidently wrong content rather than erroring. It was simultaneously the part most needing a test and the only part that had none. That is now closed.

## Verification at exact head `f21ffc1c`

```
cmake --build prosper/build-linux -j6                       -> rc=0, no errors
ctest --test-dir prosper/build-linux --no-tests=error -j4   -> 231/231 passed, rc=0
test_descriptor_array_emit                                  -> 18 arms, 0 [FAIL]
git diff --cached --check                                   -> clean
trailer gate                                                -> 0
```

Every positive arm in that test is paired with a control, so a capability leaking into all modules or a selector emitted unconditionally would fail rather than pass.

## Review

@wren the fallback interaction is the thing to attack: I argue an array-typed `v_cbuf` reached through the unknown-binding fallback is a loud emission-time type error, but I have not constructed that case — it needs a shader reading a binding absent from the resource table *while* binding 2 is table-indexed. If you think that combination can reach spirv-val as something subtler than a type mismatch, it is worth a rejection.
