### PR TITLE
docs(vkval): the focused-scan FAIL is an artifact of the filter, and when to run the guard deliberately

### DIFF
--- a/prosper/tools/vkval/README.md
+++ b/prosper/tools/vkval/README.md
@@ -33,12 +33,60 @@ python3 tools/vkval/vk_validation_scan.py --build-dir prosper/build-linux --repo
 
 # re-parse a log you already have
 python3 tools/vkval/vk_validation_scan.py --log prosper/build-linux/Testing/Temporary/LastTest.log
+
+# one test only, while iterating on a fix (~40 s instead of the full suite)
+python3 tools/vkval/vk_validation_scan.py --build-dir prosper/build-linux \
+    --report-only --ctest-arg=-R --ctest-arg=descriptor_array_render
 ```
+
+`--ctest-arg=-R`, not `--ctest-arg -R` — argparse consumes the bare flag as its own and exits 2.
+
+**A focused run ends in a `FAIL` that is an artifact of the filter, not a regression.** Restricting the
+test set means the tests that produce the other allow-listed messages never execute, so the scan
+reports them missing:
+
+```
+[vkval] FAIL: 4 allow-listed id(s) marked `required` produced no messages, while the layer
+        demonstrably loaded.
+```
+
+That is expected under `-R` and appears on a completely healthy tree. The full scan has no such line.
+Read it as "you filtered the suite", and take only the `NEW — not on the allow-list` section as a
+finding from a focused run.
 
 The layer package is `vulkan-validationlayers` on Debian/Ubuntu and `vulkan-validation-layers` on
 Fedora. **Build in an environment that actually has Vulkan** — a configure that quietly loses it
 drops every Vulkan execution test and the scan then observes nothing (#1675). On this project's
 Bazzite box that means the `ps5ys` distrobox, not the host.
+
+## When to run this deliberately
+
+CI runs the gate, so most changes need nothing. **Run it yourself, before opening the PR, for any
+change touching descriptor counts, descriptor-set layouts, or pipeline keys.** That trigger list is
+not a guess — it is the shape of the one defect this guard has caught that nothing else could:
+
+#2471 bound a 3-entry descriptor array whose `VkPipeline` had been created under an **arity-1**
+`VkPipelineLayout` and was replayed with the **arity-3** layout bound
+(`VUID-vkCmdDrawIndexed-None-08600`, *"Set 0 binding 0 descriptorCount 3 doesn't match 1"*). Two
+independent blind spots hid it, and between them they cover every check a normal PR gets:
+
+- **A pixel assertion cannot see it.** The stale pipeline still draws a correct green quad, so every
+  pixel arm passed. Confirmed by mutation: reverting the fix returns the VUID byte-identically **while
+  the test still passes**. Author verification, author re-reading, and independent review all went
+  green on a spec-invalid draw.
+- **On Windows the job does not exist.** `test_descriptor_array_render` is triple-gated in
+  `CMakeLists.txt` — `if(TARGET prosper_core)` → `if(UNIX)` → `if(Vulkan_FOUND)` — so the whole
+  Vulkan-execution render suite (`multidraw_render`, `indexed_render`, `texture_sample_render` too) is
+  never configured there. `UNIX` is the operative gate: Vulkan **is** found in Windows build caches, so
+  installing the SDK changes nothing.
+
+And the reflex that does not help: a second **driver** cannot discriminate this class either, because
+`08600` is a **usage** error raised by the validation layer rather than driver behaviour, so it is
+driver-independent close to by construction.
+
+**So `ctest` green is not evidence about spec validity, on any platform.** This scan is the only check
+in the repo that sees this class. Instrument-trap 151 in `docs/GAME_COMPAT_ORCHESTRATION.md` records
+the whole case.
 
 ## The instrument trap this tool is built around
 

--- a/prosper/tools/vkval/README.md
+++ b/prosper/tools/vkval/README.md
@@ -62,8 +62,20 @@ Bazzite box that means the `ps5ys` distrobox, not the host.
 ## When to run this deliberately
 
 CI runs the gate, so most changes need nothing. **Run it yourself, before opening the PR, for any
-change touching descriptor counts, descriptor-set layouts, or pipeline keys.** That trigger list is
-not a guess — it is the shape of the one defect this guard has caught that nothing else could:
+change touching descriptor counts, descriptor-set layouts, or pipeline keys.**
+
+That trigger list is the shape of the one defect this guard has caught **during review, with every
+other check on the PR already green** — which is a narrower claim than "the one defect it has caught",
+and the narrowness is the point. The six entries in `allowlist.txt` (#1710, #1712, #1713, #1714,
+#1715, #1716, #1717, #1726) are also findings this guard surfaced, but they are pre-existing
+conditions catalogued when it was switched on (#1704). #2471 is different in kind: it arrived *inside*
+a change under active review. That is what justifies running it yourself rather than trusting CI.
+
+**So treat the list as a floor, not a ceiling.** It is derived from a single case, and those six
+allow-listed IDs are evidence nobody has mined for what else belongs on it. Start here; do not read it
+as complete.
+
+The case, and why nothing else could see it:
 
 #2471 bound a 3-entry descriptor array whose `VkPipeline` had been created under an **arity-1**
 `VkPipelineLayout` and was replayed with the **arity-3** layout bound
@@ -80,9 +92,10 @@ independent blind spots hid it, and between them they cover every check a normal
   never configured there. `UNIX` is the operative gate: Vulkan **is** found in Windows build caches, so
   installing the SDK changes nothing.
 
-And the reflex that does not help: a second **driver** cannot discriminate this class either, because
-`08600` is a **usage** error raised by the validation layer rather than driver behaviour, so it is
-driver-independent close to by construction.
+And the reflex that does not help: a second **driver** cannot discriminate this class. `08600` is a
+**usage** error — the layer compares the pipeline's own layout against the layout the descriptor sets
+were bound with and reports a mismatch, without consulting the driver at all. So there is no driver
+behaviour to differ, and "try it on another GPU" is wasted effort here.
 
 **So `ctest` green is not evidence about spec validity, on any platform.** This scan is the only check
 in the repo that sees this class. Instrument-trap 151 in `docs/GAME_COMPAT_ORCHESTRATION.md` records


### PR DESCRIPTION
Two additions to `tools/vkval/README.md`, both from #2471. Suggested by the reviewer on that PR: the trap table is read by people who are already suspicious, while the README is read by the person about to touch a pipeline key for the first time.

## 1. The focused-scan `FAIL` that is an artifact of the filter

Adds the `--ctest-arg=-R <test>` recipe for iterating on a fix (~40 s instead of the full suite), with the argparse gotcha spelled out — `--ctest-arg=-R`, **not** `--ctest-arg -R`, which argparse consumes as its own flag and exits 2.

And the thing that reads as a regression and is not. A focused run ends in:

```
[vkval] FAIL: 4 allow-listed id(s) marked `required` produced no messages, while the layer
        demonstrably loaded.
```

Restricting the test set means the tests that produce the other allow-listed messages never execute, so the scan reports them missing. **Measured on a healthy tree**: the focused run emits that line, the full scan does not. Only the `NEW — not on the allow-list` section is a finding from a focused run.

This cost me a moment of doubt mid-investigation on #2471, and the message is emphatic enough ("while the layer demonstrably loaded") that a first-time reader would reasonably stop and investigate the tool instead of their change.

## 2. When to run the guard deliberately

CI runs the gate, so most changes need nothing. The added trigger list is: **any change touching descriptor counts, descriptor-set layouts, or pipeline keys.**

That list is not a guess — it is the shape of the one defect this guard has caught that nothing else could. #2471 replayed a cached `VkPipeline` created under an arity-1 `VkPipelineLayout` with the arity-3 layout bound (`VUID-vkCmdDrawIndexed-None-08600`, *"Set 0 binding 0 descriptorCount 3 doesn't match 1"*). Two blind spots hid it, and between them they cover every check an ordinary PR receives:

- **A pixel assertion cannot see it.** The stale pipeline still draws a correct green quad. Confirmed by mutation: reverting the fix returns the VUID byte-identically **while the test still passes**. Author verification, author re-reading, and independent review all went green on a spec-invalid draw.
- **On Windows the job does not exist.** The Vulkan-execution render suite is triple-gated `if(TARGET prosper_core)` → `if(UNIX)` → `if(Vulkan_FOUND)`, and `UNIX` is the operative gate — Vulkan *is* found in Windows build caches, so installing the SDK changes nothing.

Plus the reflex that does not help: a second **driver** cannot discriminate this class either, because `08600` is a validation-layer **usage** error rather than driver behaviour.

## Verification

- Diff is `.md`-only: `git diff --name-only origin/master...HEAD | grep -v '\.md$'` is empty.
- Docs gate over every tracked `.md`: passes.
- `git diff --check`: clean. Session-trailer gate: 0.
- Every measurement quoted (the focused-run `FAIL` text and count, the mutation behaviour, the triple gate) was taken by me on `53abeeb8` and is recorded on #2471 and in instrument-trap 151.

No code changes, so nothing to test beyond the gate. Docs-only, so per the charter this may merge without waiting on CI — but I would like a reader on it rather than self-merging, since it makes claims about what a check does and does not prove, and I am the one who wrote those claims into three other places today.

Refs #2471