### PR TITLE
fix(win): keep the memlog gate from clobbering the error it is about to print

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -2799,7 +2799,33 @@ static bool apr_probe_guest_pair(uint64_t addr, uint64_t out[2]) {
                                        uint64_t a3, uint64_t a4, uint64_t a5, uint64_t a6)
 
 namespace {
-    bool memlog() { static int v = getenv("PROSPER_MEMLOG") ? 1 : 0; return v; }
+    // Preserves the caller's last-error across its ONE-TIME initialisation (#2431). `getenv` is a CRT
+    // call and may set the thread's last-error value, and this gate is evaluated BEFORE the argument
+    // list of the MLOG it guards -- so without this, the very first
+    //
+    //     MLOG("... error=%lu\n", ..., GetLastError());
+    //
+    // in a process would report the error belonging to `getenv` rather than the Win32 call that just
+    // failed. The window is narrow (the static initialises once; later calls are a guard load and a
+    // return, which touch nothing) but it is exactly the first such line anyone reads, and the value
+    // is accurate while the diagnostic is OFF and able to lie while it is ON -- the only time it is
+    // read at all. Fixing it here rather than at each call site keeps the eleven inline
+    // `MLOG(..., GetLastError())` sites correct without depending on every future one remembering.
+    //
+    // WINDOWS COPY ONLY. The POSIX branch near the top of this file has a byte-identical gate and
+    // must NOT get this treatment -- SetLastError/GetLastError do not exist there.
+    bool memlog() {
+        static int v = [] {
+            const DWORD saved = GetLastError();
+            const int on = getenv("PROSPER_MEMLOG") ? 1 : 0;
+            SetLastError(saved);
+            return on;
+        }();
+        return v;
+    }
+    // Passing `GetLastError()` directly as an MLOG argument is SAFE because `memlog()` above restores
+    // it. If that ever stops being true, every such site silently starts reporting the wrong Win32
+    // error, so capture into a local before the MLOG instead of relaxing the gate.
     #define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
 
     // PROSPER_DMEM_CALLER=1: attribute each direct-memory allocation to the guest code that asked
@@ -4420,8 +4446,12 @@ namespace {
         // Printing both lists is what distinguishes that from a same-list coalesce that simply
         // failed -- a different bug with a different fix.
         if (fixed) {
+            // Captured BEFORE the `memlog()` gate, not inside it (#2431). The gate now restores
+            // last-error across its own initialisation, but this block also takes a lock and walks
+            // two lists, so keeping the capture adjacent to the failure it describes is the form
+            // that stays correct if anything is ever inserted above it.
+            const DWORD err = GetLastError();
             if (memlog()) {   // guard the lock too: MLOG alone would still take g_dview_mx
-                const DWORD err = GetLastError();
                 MLOG("map_dmem FIXED FAILED hint=0x%llx len=0x%llx phys=0x%llx align=0x%llx error=%lu"
                      " -- guest gets ENOMEM\n",
                      (unsigned long long)hint, (unsigned long long)len,


### PR DESCRIPTION
Fixes #2431. Windows-only, `prosper/src/hle/hle_kernel_mem.cpp`.

## The defect

The fixed-MAP_DIRECT failure diagnostic captured `GetLastError()` **inside** the `if (memlog())` block, so the gate ran first. `memlog()`'s one-time initialiser calls `getenv`, a CRT call that may set the thread's last-error, so by the time `err` was read the value belonging to the failed `map_section_view` could already have been replaced.

Why it is worth fixing rather than shrugging at, in the issue's own words: **the value is accurate while the diagnostic is OFF and able to lie while it is ON** — the only time anyone reads it. A wrong `error=` sends the next investigation at the wrong Win32 failure, and this line exists so nobody reconstructs a fixed-MAP_DIRECT failure the expensive way (#2424 needed a VEH dump, a guest disassembly and an opcode decode to reach that answer).

## The scope is eleven times larger than the reported site, and that changed the fix

The issue asked for a sweep. The sweep found that the *reported* site is the least of it:

```c
#define MLOG(...) do { if (memlog()) fprintf(stderr, "[memhle] " __VA_ARGS__); } while (0)
```

The macro evaluates the gate **before** the argument list, so **every** inline `MLOG("… error=%lu", …, GetLastError())` has the identical defect. There are **eleven** of them in this file (`:3739 :3746 :3932 :3989 :4012 :4369 :4403 :4444 :4753 :4768 :5142`) — all `MLOG`, none `fprintf`, so none escape the gate.

So I fixed the **gate** instead of the twelve call sites: `memlog()` now saves and restores last-error across its initialiser. That makes all eleven inline sites correct without depending on each future one remembering, and site twelve — added next year by someone who never read this PR — is correct by construction.

The named site *additionally* keeps its capture hoisted above the gate, because that block also takes a lock and walks two lists; adjacency to the failure is the form that survives someone inserting code above it.

**Checked and deliberately not changed:** the three `const DWORD … = GetLastError()` captures at `:3653`, `:3662`, `:4699` are already correct — capture first, then act. `:3653` even restores with `SetLastError(error)` after unwinding, which is the pattern the rest should look like.

## The near-miss worth reporting

The gate text is **byte-identical between the POSIX and Windows halves** of this file. My first patch attempt matched both, and the count-guard aborted rather than replacing blindly — which would have put `SetLastError` on the Linux side, where it does not exist.

Verified after patching: the POSIX gate at `:562` is untouched, and `GetLastError`/`SetLastError` appear **nowhere** before the platform `#else` at `:2704`. The changed gate sits inside that `#else`, so Linux never compiles it.

## No regression test, stated rather than skipped quietly

`memlog()` is in an anonymous namespace in the Windows half of this translation unit. Asserting "last-error survives the gate" would mean exposing internals for a two-line diagnostic-accuracy change, and the assertion would then test the exposure rather than the behaviour. If a reviewer wants one, the honest shape is a small Windows-only test that calls the *public* map path with `PROSPER_MEMLOG=1` and a deliberately-failing fixed hint, and asserts the printed `error=` matches what the failing call set — which is a bigger apparatus than the fix.

## Verification at exact head `2ece9582`

```
cmake --build prosper/build-mingw --target prosper_core -j6   -> rc=0
  [18/26] Building CXX ... hle_kernel_mem.cpp.obj
  [23/26] Linking CXX static library libprosper_core.a
no new warnings (the one -Wvolatile warning is pre-existing, in hle_kernel.cpp)
git diff --check                                              -> rc=0
trailer gate                                                  -> 0
CRLF preserved; 32 insertions, 2 deletions
```

Linux is unaffected by construction (Windows `#else` branch), so I did not build it.

## Review

@marlow the thing to attack is **whether fixing the gate is the right call versus twelve explicit captures**. My argument is that the call-site form rots — it needs every future author to know the macro's expansion order — while the gate form cannot. The counter-argument is that the gate form makes the correctness non-local: someone reading `MLOG(..., GetLastError())` has to know `memlog()` restores it, which is why I put that statement in a comment directly above the macro rather than only at the function.

Second: I claim `getenv` "may set the thread's last-error". That is the issue's premise and I did not independently verify it against a CRT implementation — it is a documented-as-unspecified area rather than something I measured. The fix is harmless if the premise is false, but the *justification* would then be weaker than stated.
