### PR TITLE
feat(recompiler): report the inputs to the wave-width decision, not just its outcome

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -11,6 +11,7 @@
 #include <cstdlib>
 #include <functional>
 #include <map>
+#include <mutex>
 #include <set>
 #include <unordered_map>
 #include <unordered_set>
@@ -16186,6 +16187,46 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint64_t local_count = static_cast<uint64_t>(local_x) * local_y * local_z;
     b.native_subgroup_size = config.native_subgroup_size == wave_size &&
         local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
+    // PROSPER_DBG: report the inputs to that decision, not just its outcome (#2429).
+    //
+    // Every wave-width-dependent lowering in this file gates on `b.native_subgroup_size` -- the
+    // VCC-as-scalar-data path at :5604 most consequentially, since when it is 0 the guest's
+    // `s_add_u32 sN, sM, vcc_lo` never resolves, the descriptor never lands, and the draw is
+    // skipped. Nothing printed any of this, under any variable, so "was that path active on this
+    // device?" could only be inferred from the adapter's advertised width.
+    //
+    // That inference is WRONG, and reporting only the effective value would preserve the error:
+    // the expression above is zero for THREE independent reasons -- the device width not matching
+    // `wave_size`, an implausible `local_count`, or a workgroup that is not a whole number of waves
+    // (`local_count % wave_size`). A dispatch with a partial final wave disables the path on an
+    // adapter whose width matches perfectly. #2429 attributes it entirely to the first cause, and
+    // that is checkable only if all three inputs are printed.
+    //
+    // Deduplicated on the full tuple rather than rate-limited, because the interesting event is a
+    // DISTINCT combination appearing, not the hundredth repeat of one -- and a kernel that disables
+    // the path for a different reason than its predecessors is exactly what a rate limit would drop.
+    if (getenv("PROSPER_DBG")) {
+        static std::mutex mx;
+        static std::set<uint64_t> seen;
+        const uint64_t key = (uint64_t)config.native_subgroup_size << 40 |
+                             (uint64_t)wave_size << 32 |
+                             (uint64_t)(local_count % (wave_size ? wave_size : 1u)) << 8 |
+                             (uint64_t)(b.native_subgroup_size ? 1u : 0u);
+        std::lock_guard<std::mutex> lk(mx);
+        if (seen.insert(key).second)
+            std::fprintf(stderr,
+                         "[subgroup-width] device=%u wave=%u local=%llu local%%wave=%llu -> "
+                         "native_subgroup_size=%u (%s)\n",
+                         config.native_subgroup_size, wave_size,
+                         (unsigned long long)local_count,
+                         (unsigned long long)(local_count % (wave_size ? wave_size : 1u)),
+                         b.native_subgroup_size,
+                         b.native_subgroup_size
+                             ? "width-dependent lowerings ENABLED"
+                             : (config.native_subgroup_size != wave_size
+                                    ? "DISABLED: device width != wave_size"
+                                    : "DISABLED: workgroup is not a whole number of waves"));
+    }
     b.native_storage_format_support = config.native_storage_format_support;
     b.packed_r11_storage = config.packed_r11_storage;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -16196,10 +16196,21 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // device?" could only be inferred from the adapter's advertised width.
     //
     // `config.native_subgroup_size` is NOT the adapter's advertised width -- it is the OUTPUT of
-    // select_native_compute_subgroup_size() (gpu_executor.cpp:7359), a ~14-condition adoption
-    // decision over device features, queue support and the dispatch's own dimensions, which yields
-    // 0 when it declines. Zero therefore means "no native width was adopted", NOT "the device is
-    // narrower than wave_size", and the three cases below are distinguished for that reason.
+    // select_native_compute_subgroup_size() (gpu_executor.cpp), an adoption decision with THREE
+    // `return 0` sites comprising 22 clauses -- 25 if `adoptable`'s four ANDed device checks are
+    // counted individually, which is defensible since each is independently sufficient. It spans
+    // device features, queue support, workgroup limits and the dispatch's own dimensions, and
+    // yields 0 when it declines. Zero therefore means "no native width was adopted", NOT "the
+    // device is narrower than wave_size", and the three cases below are distinguished for that
+    // reason.
+    //
+    // Counted rather than estimated, because two lanes published two different guesses at it on the
+    // same day (#2483 "~14", #2484 "roughly eight") and neither had derived the number.
+    //
+    // This line dedupes on the full input tuple, so it answers "which combinations exist" cheaply --
+    // 2 lines for a whole boot. For a per-dispatch CENSUS (how many dispatches fall in each
+    // category, which this instrument's dedupe destroys) use PROSPER_SUBGROUP_LOG in
+    // gpu_executor.cpp instead.
     //
     // That inference is WRONG, and reporting only the effective value would preserve the error:
     // the expression above is zero for THREE independent reasons -- the device width not matching

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <mutex>
 #include <set>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -16207,9 +16208,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // Counted rather than estimated, because two lanes published two different guesses at it on the
     // same day (#2483 "~14", #2484 "roughly eight") and neither had derived the number.
     //
-    // This line dedupes on the full input tuple, so it answers "which combinations exist" cheaply --
-    // 2 lines for a whole boot. For a per-dispatch CENSUS (how many dispatches fall in each
-    // category, which this instrument's dedupe destroys) use PROSPER_SUBGROUP_LOG in
+    // This line dedupes on the exact input tuple, so it answers "which combinations exist" cheaply --
+    // a couple of lines for a whole boot. For a per-dispatch CENSUS (how many dispatches fall in
+    // each category, which this instrument's dedupe destroys by design) use PROSPER_SUBGROUP_LOG in
     // gpu_executor.cpp instead.
     //
     // That inference is WRONG, and reporting only the effective value would preserve the error:
@@ -16219,18 +16220,23 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // adapter whose width matches perfectly. #2429 attributes it entirely to the first cause, and
     // that is checkable only if all three inputs are printed.
     //
-    // Deduplicated on the full tuple rather than rate-limited, because the interesting event is a
+    // Deduplicated on the exact tuple rather than rate-limited, because the interesting event is a
     // DISTINCT combination appearing, not the hundredth repeat of one -- and a kernel that disables
     // the path for a different reason than its predecessors is exactly what a rate limit would drop.
     if (getenv("PROSPER_DBG")) {
         static std::mutex mx;
-        static std::set<uint64_t> seen;
-        const uint64_t key = (uint64_t)config.native_subgroup_size << 40 |
-                             (uint64_t)wave_size << 32 |
-                             (uint64_t)(local_count % (wave_size ? wave_size : 1u)) << 8 |
-                             (uint64_t)(b.native_subgroup_size ? 1u : 0u);
+        // Keyed on the EXACT inputs, local_count included. An earlier revision packed
+        // `local_count % wave_size` instead, which collapsed dispatches that differ only in
+        // workgroup shape -- and the line prints `local=`, so one row then named whichever
+        // instance arrived first and stood silently for the rest. Measured on GTA V's six
+        // native=0 shapes, that key produced three rows, one of which represented 1024, 256,
+        // 256 and 256 while printing only 1024 -- and the 256-wide ones were the multi-wave
+        // case that mattered. A diagnostic may aggregate, but it must not name one member of
+        // a bucket as though it were the bucket.
+        static std::set<std::tuple<uint32_t, uint32_t, uint64_t, uint32_t>> seen;
         std::lock_guard<std::mutex> lk(mx);
-        if (seen.insert(key).second)
+        if (seen.insert(std::make_tuple(config.native_subgroup_size, wave_size,
+                                        local_count, b.native_subgroup_size)).second)
             std::fprintf(stderr,
                          "[subgroup-width] device=%u wave=%u local=%llu local%%wave=%llu -> "
                          "native_subgroup_size=%u (%s)\n",
@@ -16245,7 +16251,11 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                       "select_native_compute_subgroup_size() declined"
                                     : (config.native_subgroup_size != wave_size
                                            ? "DISABLED: adopted width != wave_size"
-                                           : "DISABLED: workgroup is not a whole number of waves")));
+                                           : (local_count > UINT32_MAX
+                                                  ? "DISABLED: local_count exceeds the plausibility "
+                                                    "guard"
+                                                  : "DISABLED: workgroup is not a whole number "
+                                                    "of waves"))));
     }
     b.native_storage_format_support = config.native_storage_format_support;
     b.packed_r11_storage = config.packed_r11_storage;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -16195,6 +16195,12 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // skipped. Nothing printed any of this, under any variable, so "was that path active on this
     // device?" could only be inferred from the adapter's advertised width.
     //
+    // `config.native_subgroup_size` is NOT the adapter's advertised width -- it is the OUTPUT of
+    // select_native_compute_subgroup_size() (gpu_executor.cpp:7359), a ~14-condition adoption
+    // decision over device features, queue support and the dispatch's own dimensions, which yields
+    // 0 when it declines. Zero therefore means "no native width was adopted", NOT "the device is
+    // narrower than wave_size", and the three cases below are distinguished for that reason.
+    //
     // That inference is WRONG, and reporting only the effective value would preserve the error:
     // the expression above is zero for THREE independent reasons -- the device width not matching
     // `wave_size`, an implausible `local_count`, or a workgroup that is not a whole number of waves
@@ -16223,9 +16229,12 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                          b.native_subgroup_size,
                          b.native_subgroup_size
                              ? "width-dependent lowerings ENABLED"
-                             : (config.native_subgroup_size != wave_size
-                                    ? "DISABLED: device width != wave_size"
-                                    : "DISABLED: workgroup is not a whole number of waves"));
+                             : (config.native_subgroup_size == 0
+                                    ? "DISABLED: no native width adopted -- "
+                                      "select_native_compute_subgroup_size() declined"
+                                    : (config.native_subgroup_size != wave_size
+                                           ? "DISABLED: adopted width != wave_size"
+                                           : "DISABLED: workgroup is not a whole number of waves")));
     }
     b.native_storage_format_support = config.native_storage_format_support;
     b.packed_r11_storage = config.packed_r11_storage;


### PR DESCRIPTION
Refs #2429, #2481. Adds a `PROSPER_DBG` line reporting the **inputs** to the wave-width decision, not just its outcome.

## Why it did not exist and why that mattered

Every wave-width-dependent lowering in `rdna2_to_spirv.cpp` gates on `b.native_subgroup_size` — the VCC-as-scalar-data path at `:5604` most consequentially, since when it is 0 the guest's `s_add_u32 sN, sM, vcc_lo` never resolves, the descriptor never lands, and the draw is skipped.

**Nothing printed that value, or any of its inputs, under any environment variable.** Confirmed by grep with a control: 35 references in the file, zero inside a `printf`/`fprintf`. So "was that path active on this device?" could only be *inferred*, and #2429 is built on such an inference.

## It found something on its first run

```
[subgroup-width] device=0 wave=64 local=64  local%wave=0  -> native_subgroup_size=0 (DISABLED: …declined)
[subgroup-width] device=0 wave=64 local=125 local%wave=61 -> native_subgroup_size=0 (DISABLED: …declined)
```

**`device=0`, not 32.** #2429 states *"this device reports `native_subgroup_size = 32` against `wave_size = 64`"*. That describes the field as the adapter's advertised width. It is not:

> `config.native_subgroup_size` is the **output** of `select_native_compute_subgroup_size()` (`gpu_executor.cpp:7359`) — a ~14-condition adoption decision over device features, queue support, workgroup limits and the dispatch's own dimensions — which yields **0 when it declines**.

So 0 means *no native width was adopted*, not *the device is narrower than wave_size*. The second line is independently useful: `local=125, local%wave=61` is a workgroup that is not a whole number of waves, which disables the path **even on a perfectly matched 64-wide adapter**.

**Scope of that claim:** this is *Dragon Quest VII* on Windows/NVIDIA. #2429's measurement was *GTA V*. The device-feature half of the selector is shared between them on one box; the per-dispatch half is not. So this does **not** yet establish that #2429's `32` is wrong for its own title — it establishes that the field does not mean what the issue says it means, and that the number wants re-measuring rather than re-quoting.

## Why all three inputs are printed rather than the outcome

The expression is zero for three independent reasons:

```cpp
b.native_subgroup_size = config.native_subgroup_size == wave_size &&
    local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
```

Printing only the effective value would have preserved exactly the error #2429 makes — attributing a disabled path to a width mismatch when it may be a declined adoption or a partial final wave. A diagnostic that cannot distinguish its own causes is how a confident wrong attribution gets made.

Dedupe is on the **full tuple** rather than a rate limit, because the interesting event is a *distinct combination* appearing; a kernel disabled for a different reason than its predecessors is precisely what a rate limit drops.

## The second commit is a defect in this PR's own diagnostic, caught by running it

The first version printed `DISABLED: device width != wave_size` whenever the value was 0 — implying a mismatch that had not happened. **Shipping a diagnostic that names the wrong cause is worse than shipping none**: it is read exactly when someone is attributing a failure, which is the failure mode this instrument exists to prevent. Corrected to distinguish declined / adopted-but-different / partial-wave, and re-verified on a live boot.

## Verification at exact head `8d18f362`

```
cmake --build prosper/build-mingw --target prosper_core -j6   -> rc=0, no new warnings
cmake --build prosper/build-app  --target screenshot   -j6    -> rc=0
live DQ VII boot, PROSPER_DBG=1                               -> 2 distinct tuples emitted (above)
control: same boot without PROSPER_DBG                        -> no [subgroup-width] lines
git diff --check                                              -> rc=0
trailer gate                                                  -> 0
```

Adds `#include <mutex>`; the two `std::mutex` uses are the ones introduced here, and the build failed loudly without it rather than picking it up transitively.

## Review

@marlow two things worth attacking.

**First, whether `PROSPER_DBG` is the right gate.** It is where the recompiler's other reject census lives, so it is consistent — but it means anyone already running `PROSPER_DBG` for a reject census now also gets this. Volume is bounded by distinct tuples (2 on a whole DQ boot), so I judged that acceptable rather than adding another variable nobody knows exists.

**Second, my `device=0` claim is one title on one box.** I have deliberately not touched #2429's text on the strength of it. If you have a routed GTA V run handy with this branch, that number is the one that actually settles the precondition I asked you about — and per your own message, no such line existed to give it before this.
