### PR TITLE
diag(compute): PROSPER_SUBGROUP_LOG — the resolved native-subgroup contract, with the inputs that decided it

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5560,12 +5560,15 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // different derivation. Conflating the two is what this line exists to stop.
         //
         // Prints the INPUTS beside the answer, deliberately. `select_native_compute_subgroup_size`
-        // returns 0 -- meaning "no native contract, use the portable shell" -- on any of roughly eight
-        // disqualifiers, and only one of them is about the device's subgroup range. The likeliest cause
-        // of a 0 on a capable adapter is the workgroup-shape rule: unless multiwave is opted into, the
-        // workgroup must be EXACTLY one wave. So a bare `native=0` would send a reader hunting the GPU
-        // when the answer is the kernel's local size, which is why local/invocations and the device
-        // bounds are all on the line.
+        // returns 0 -- meaning "no native contract, use the portable shell" -- from **three `return 0`
+        // sites spanning 22 clauses** (25 if `adoptable`'s four ANDed checks are counted individually
+        // rather than as the one `!adoptable` clause). **Exactly two of those clauses concern the
+        // device's subgroup range** (`wave_size` below `min_compute_subgroup_size` or above
+        // `max_compute_subgroup_size`); the rest are capability bits, workgroup bounds, and the
+        // kernel's own local size. Measured on GTA V, the causes were entirely the last of those:
+        // `invocations % wave_size != 0` and the one-wave rule, never the adapter. So a bare
+        // `native=0` would send a reader hunting the GPU when the answer is the dispatch's local size,
+        // which is why local/invocations and the device bounds are all on the line.
         if (getenv("PROSPER_SUBGROUP_LOG")) {
             const uint64_t local_invocations = static_cast<uint64_t>(config.local_x) *
                 config.local_y * config.local_z;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5548,10 +5548,41 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // preserving one native subgroup per guest wave. Keep the environment switch as an explicit
         // experiment for every other multi-wave shape; this automatic path is shader-address/title
         // independent and remains subject to all device and workgroup bounds below.
+        const bool native_multiwave_requested =
+            native_multiwave_wave_work || getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr;
+        const bool native_subgroup_disabled =
+            getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") != nullptr;
         config.native_subgroup_size = select_native_compute_subgroup_size(
-            shared_vulkan, config,
-            native_multiwave_wave_work || getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr,
-            getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") != nullptr);
+            shared_vulkan, config, native_multiwave_requested, native_subgroup_disabled);
+        // PROSPER_SUBGROUP_LOG (#2429): the resolved native-subgroup contract is a GUARD CONDITION in
+        // several recompiler paths and was printable NOWHERE -- so any claim that turned on it could
+        // only be inferred from the device's reported subgroup size, which is a different value with a
+        // different derivation. Conflating the two is what this line exists to stop.
+        //
+        // Prints the INPUTS beside the answer, deliberately. `select_native_compute_subgroup_size`
+        // returns 0 -- meaning "no native contract, use the portable shell" -- on any of roughly eight
+        // disqualifiers, and only one of them is about the device's subgroup range. The likeliest cause
+        // of a 0 on a capable adapter is the workgroup-shape rule: unless multiwave is opted into, the
+        // workgroup must be EXACTLY one wave. So a bare `native=0` would send a reader hunting the GPU
+        // when the answer is the kernel's local size, which is why local/invocations and the device
+        // bounds are all on the line.
+        if (getenv("PROSPER_SUBGROUP_LOG")) {
+            const uint64_t local_invocations = static_cast<uint64_t>(config.local_x) *
+                config.local_y * config.local_z;
+            std::fprintf(stderr,
+                         "[subgroup] cs=0x%llx guest-wave=%u native=%u local=%ux%ux%u "
+                         "invocations=%llu device-range=%u..%u max-wg-subgroups=%u "
+                         "size-control=%d full-subgroups=%d multiwave=%d disabled=%d\n",
+                         (unsigned long long)code_addr, config.wave_size,
+                         config.native_subgroup_size, config.local_x, config.local_y, config.local_z,
+                         (unsigned long long)local_invocations,
+                         shared_vulkan.min_compute_subgroup_size,
+                         shared_vulkan.max_compute_subgroup_size,
+                         shared_vulkan.max_compute_workgroup_subgroups,
+                         (int)shared_vulkan.compute_subgroup_size_control,
+                         (int)shared_vulkan.compute_full_subgroups,
+                         (int)native_multiwave_requested, (int)native_subgroup_disabled);
+        }
         config.tgid_x_en = tgid_x_en;
         config.tgid_y_en = tgid_y_en;
         config.tgid_z_en = tgid_z_en;


### PR DESCRIPTION
## Why

`native_subgroup_size` is a **guard condition** in several recompiler paths and was printable **nowhere**, under any environment variable. Every claim that turned on it could therefore only be *inferred* from the device's reported subgroup size — a different value with a different derivation.

#2429's precondition rested on exactly that inference (mine, from a `vulkaninfo` `maxSubgroupSize = 64` reading), and the measurement this PR enables shows the inference is **wrong for a quarter of GTA V's wave64 compute dispatches**.

## What it measures

Routed GTA V run, Linux, AMD Radeon 8060S (RADV STRIX_HALO), 93 distinct compute kernels:

| `guest-wave` → `native` | dispatches | share | #2429's guard |
| --- | --- | --- | --- |
| 64 → 64 | 17,950 | 70% | holds |
| 64 → **0** | **6,381** | **25%** | **fails** — no native contract adopted |
| 32 → 32 | 1,191 | 5% | not the 64 case |

**A 64-wide adapter does not imply the contract is adopted.** That is the whole reason the value needs printing rather than deriving.

## It prints the inputs, not just the answer

`select_native_compute_subgroup_size` returns 0 — *"no native contract, use the portable shell"* — on any of roughly eight disqualifiers, and **only one of them concerns the device's subgroup range**. In this run the actual causes were both about the kernel's local size:

| cause | dispatches | local sizes |
| --- | --- | --- |
| `invocations % wave_size != 0` | 3,851 | `32x1x1`, `1x1x1` |
| multi-wave workgroup, multiwave not opted into | 2,530 | `32x32x1`, `256x1x1`, `16x16x1`, `1x256x1` |

Every `native=64` case had `invocations == 64` exactly (`64x1x1`, `8x8x1`). So a bare `native=0` would send a reader hunting the adapter when the answer is the dispatch's local size — which is why `local`/`invocations`, the device range, the workgroup-subgroup bound and the `multiwave`/`disabled` flags are all on the line.

Sample:

```
[subgroup] cs=0x… guest-wave=64 native=0 local=256x1x1 invocations=256 device-range=32..64 \
           max-wg-subgroups=4294967295 size-control=1 full-subgroups=1 multiwave=0 disabled=0
```

`max-wg-subgroups=4294967295` looks like an unset `UINT32_MAX` and is not: I checked `vulkaninfo` before filing it as suspicious, and **RADV genuinely reports that value**, so prosper reads it correctly and the capacity bound is effectively unlimited on this adapter by the driver's own report.

## Placement, and why it matters

Immediately after the assignment and **before** `recompile_compute_shader_cached`, so it also covers kernels whose recompile subsequently **fails**. Those are the interesting ones for #2481 and they would be invisible from a post-recompile site.

## Deliberate non-choices

- **Not deduped by kernel.** One line per dispatch, 25,522 over a 200 s routed run. The same kernel can be dispatched with different local sizes and therefore resolve differently — collapsing on shader address would hide exactly the distribution above, which is the finding.
- **Opt-in and inert when unset** — a single `getenv` on a path that already calls several.

## Affected / unaffected

No behavioural change: the two `getenv` calls that fed `select_native_compute_subgroup_size` are hoisted into named locals so the diagnostic can report them, and the same values are passed in the same order. Nothing else is touched, and the function's result is unchanged.

## Verification

- `ctest --no-tests=error -j4` → **232/232 passed**, exit 0. Linux, AMD Radeon 8060S (RADV STRIX_HALO), built in the project distrobox.
- The measurement above is from a routed GTA V boot with the title verified as `[shot] PPSA04263` in the log — see the retraction on #2429 for why that check is now mandatory in my procedure: an earlier run of this same diagnostic booted the wrong title and reported *"all native=64"*, the exact opposite conclusion, and only the output filename caught it.
- `git diff --check` clean; session-trailer gate 0.

Refs #2429, #2481, #2412