### PR TITLE
diag(win): carry the Win32 error to the BatchMap failure line

### DIFF
--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -5507,10 +5507,17 @@ HLE(k_batch_map) {
             break;
         }
         bool ok = true;
+        // The Win32 reason for a failed op, captured AT the failing call and carried to the
+        // [batchmap-fail] line below (#2450). It cannot be read at that line: `track()`,
+        // `untrack()` and the switch's own bookkeeping run in between and are free to set it.
+        // Same hazard as #2431, one level up -- there the gate ran before the capture, here
+        // the capture would run long after the failure.
+        DWORD win_err = 0;
         switch (op) {
             case 0: {                               // MAP_DIRECT: shared physical backing
                 void* p = win_map_phys(start, len, host_prot(prot), phys, 0, start != 0);
                 ok = (p != nullptr);
+                if (!ok) win_err = GetLastError();
                 if (ok) {
                     const bool sparse = sparse_dmem_view_contains(
                         (uint64_t)p, (uint64_t)p + len);
@@ -5524,12 +5531,14 @@ HLE(k_batch_map) {
             case 3: {                               // MAP_FLEXIBLE: anonymous/private
                 void* p = win_commit(start, len, host_prot(prot));
                 ok = (p != nullptr);
+                if (!ok) win_err = GetLastError();
                 if (ok) track((uint64_t)p, len, host_prot(prot), prot, true,
                               "batch-flex", kVirtualQueryFlexible);
                 break;
             }
             case 1: {                               // UNMAP
                 ok = !start || win_unmap(start, len);
+                if (!ok) win_err = GetLastError();
                 if (ok && start) untrack(start, len);
                 break;
             }
@@ -5545,6 +5554,7 @@ HLE(k_batch_map) {
                     if (!protect_len) break;
                     DWORD error = ERROR_SUCCESS;
                     ok = win_protect(protect_start, protect_len, host_prot(prot), &error);
+                    if (!ok) win_err = error;   // out-param, already captured at the call
                     if (ok) {
                         retrack_prot(protect_start, protect_len, host_prot(prot), prot,
                                      "batch-prot");
@@ -5579,9 +5589,10 @@ HLE(k_batch_map) {
                 const unsigned seen = logged.fetch_add(1, std::memory_order_relaxed);
                 if (seen < 8)
                     fprintf(stderr,
-                            "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx prot=0x%x\n",
+                            "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx "
+                            "prot=0x%x error=%lu\n",
                             i, n, op, (unsigned long long)start, (unsigned long long)phys,
-                            (unsigned long long)len, prot);
+                            (unsigned long long)len, prot, (unsigned long)win_err);
                 else if (seen == 8)
                     fprintf(stderr, "[batchmap-fail] further BatchMap failures suppressed after 8\n");
             }

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -5513,11 +5513,20 @@ HLE(k_batch_map) {
         // Same hazard as #2431, one level up -- there the gate ran before the capture, here
         // the capture would run long after the failure.
         DWORD win_err = 0;
+        // Whether `win_err` was actually captured. Not all failures come from Win32: a
+        // TYPE_PROTECT whose range will not normalise, and an unknown `op`, both set `ret`
+        // themselves without any API call failing. Printing the uninitialised `win_err` for
+        // those would print 0 -- and 0 is ERROR_SUCCESS, so the line would claim the OS
+        // reported success on a path that never asked it anything. A diagnostic that is silent
+        // about a cause is worse than one that names it; a diagnostic that names the WRONG
+        // cause is worse than both, and it is read exactly when someone is attributing a
+        // failure. Raised in review on #2486.
+        bool win_err_valid = false;
         switch (op) {
             case 0: {                               // MAP_DIRECT: shared physical backing
                 void* p = win_map_phys(start, len, host_prot(prot), phys, 0, start != 0);
                 ok = (p != nullptr);
-                if (!ok) win_err = GetLastError();
+                if (!ok) { win_err = GetLastError(); win_err_valid = true; }
                 if (ok) {
                     const bool sparse = sparse_dmem_view_contains(
                         (uint64_t)p, (uint64_t)p + len);
@@ -5531,14 +5540,14 @@ HLE(k_batch_map) {
             case 3: {                               // MAP_FLEXIBLE: anonymous/private
                 void* p = win_commit(start, len, host_prot(prot));
                 ok = (p != nullptr);
-                if (!ok) win_err = GetLastError();
+                if (!ok) { win_err = GetLastError(); win_err_valid = true; }
                 if (ok) track((uint64_t)p, len, host_prot(prot), prot, true,
                               "batch-flex", kVirtualQueryFlexible);
                 break;
             }
             case 1: {                               // UNMAP
                 ok = !start || win_unmap(start, len);
-                if (!ok) win_err = GetLastError();
+                if (!ok) { win_err = GetLastError(); win_err_valid = true; }
                 if (ok && start) untrack(start, len);
                 break;
             }
@@ -5554,7 +5563,7 @@ HLE(k_batch_map) {
                     if (!protect_len) break;
                     DWORD error = ERROR_SUCCESS;
                     ok = win_protect(protect_start, protect_len, host_prot(prot), &error);
-                    if (!ok) win_err = error;   // out-param, already captured at the call
+                    if (!ok) { win_err = error; win_err_valid = true; }   // out-param
                     if (ok) {
                         retrack_prot(protect_start, protect_len, host_prot(prot), prot,
                                      "batch-prot");
@@ -5585,14 +5594,25 @@ HLE(k_batch_map) {
             // "further ... suppressed" costs one line and tells the reader a tail exists, so
             // raising the cap later is an informed decision rather than a guess.
             {
+                // `ret` is printed because it is the value the guest surfaces: the title's own
+                // `sceKernelBatchMap failed with error code: 0x8002000c` is this number, so the
+                // line now joins our diagnosis to the string a user reports. When `ret` is still
+                // zero here the shared tail below sets ENOMEM, so that is what is shown.
+                char win_err_text[64];
+                if (win_err_valid)
+                    std::snprintf(win_err_text, sizeof win_err_text, "%lu",
+                                  (unsigned long)win_err);
+                else
+                    std::snprintf(win_err_text, sizeof win_err_text, "n/a (guest-rejected)");
                 static std::atomic<unsigned> logged{0};
                 const unsigned seen = logged.fetch_add(1, std::memory_order_relaxed);
                 if (seen < 8)
                     fprintf(stderr,
                             "[batchmap-fail] entry=%d/%d op=%d va=0x%llx phys=0x%llx len=0x%llx "
-                            "prot=0x%x error=%lu\n",
+                            "prot=0x%x error=%s ret=0x%llx\n",
                             i, n, op, (unsigned long long)start, (unsigned long long)phys,
-                            (unsigned long long)len, prot, (unsigned long)win_err);
+                            (unsigned long long)len, prot, win_err_text,
+                            (unsigned long long)(ret ? ret : 0x8002000Cull));
                 else if (seen == 8)
                     fprintf(stderr, "[batchmap-fail] further BatchMap failures suppressed after 8\n");
             }


### PR DESCRIPTION
Refs #2450. Windows-only, one file, 13 insertions.

## What #2450 turned out to be

Reproduced with the stimulus asserted — 3 `[pad-script]` lines with `buttons=cross`, then `EXIT=139`. The whole chain is in one log:

```
:106  [batchmap-fail] entry=0/1 op=0 va=0x7ec37b0000 phys=0xa7dc0000 len=0x10000 prot=0xf2
:107  LowLevelFatalError [File:Unknown] [Line: 1285]
:108  sceKernelBatchMap failed with error code: 0x8002000c
:135  [veh] code=0xc0000005 rip=0x5c00048e0 addr=0xffffffffffffffff
```

**The `exit=139` is a deliberate UE4 abort, not a memory-safety bug.** `addr=0xffffffffffffffff` means no faulting data address, and `bytes@rip: cd 45 90 0f 0b` decodes as `int 0x45` / `nop` / **`ud2`** followed by `int3` padding. UE4 hit `LowLevelFatalError`, printed the reason, and trapped. Nothing dereferenced a bad pointer — the crash is the *consequence* of our ENOMEM, which also explains why two runs entering from different callers share an identical 8-frame tail: it is one abort path.

So the open question is narrow: **why does that one fixed MAP_DIRECT fail?** And the line that reports it does not say.

## Why the obvious instrument cannot answer it

`va` is non-zero, so this is the fixed-hint path, whose failure diagnostic is `map_dmem FIXED FAILED … error=%lu` — the line #2431 was about and #2482 just made trustworthy. But turning it on removes the failure:

| | crashing run | `+ PROSPER_MEMLOG=1` |
| --- | --- | --- |
| `[pad-script]` lines | 3 | **7** |
| presses delivered | `cross` @ 3.111 | `cross` @ 3.048, **@ 8.001** |
| `[batchmap-fail]` | 1 | **0** |
| exit | **139** | **0** |

The delivery assertion passes in both, so this is not the never-polled trap — the memlog run delivered **more** input and got **further**, past the press that killed the other run. **Instrument-trap 150 in its sharpest form: the only instrument that can answer the question is the one that prevents the question arising.** Pre-registered on the issue before I ran it, so it is a fact about the apparatus rather than a non-reproduction.

## The fix: put the answer on the line that already survives

`[batchmap-fail]` is **not gated on `memlog()`** — a plain `fprintf` with a self-announcing atomic cap, which is precisely why it appeared in the crashing run while everything memlog-gated did not. Adding `error=%lu` there costs nothing: it fires only on failure and is capped at 8.

**Captured at each failing call, not read at the log site.** `track()`, `untrack()` and the switch's own bookkeeping run between the failure and the shared logging block, and any of them may reset last-error — the same hazard as #2431 one level up, where the gate ran *before* the capture rather than the capture long *after* the failure. `PROTECT`/`TYPE_PROTECT` reuses `win_protect`'s existing out-param rather than re-reading.

## Scope

Windows `k_batch_map` only. The POSIX copy is untouched, and `GetLastError`/`SetLastError` appear nowhere before the platform `#else` — checked, because this file is instrument-trap 148's own subject and its two halves have byte-identical helpers.

## Verification at exact head `2552a849`

```
cmake --build prosper/build-mingw --target prosper_core -j6   -> rc=0, no new warnings
git diff --check                                              -> rc=0
POSIX half: grep win_err before the #else                     -> 0 hits
CRLF preserved; 13 insertions, 2 deletions
trailer gate                                                  -> 0
```

## What this PR does NOT do

**It does not close #2450**, and I have not seen the error code yet. Two runs since have delivered **zero** `[pad-script]` lines, so the answer is gated on the pad-poll delivery rate rather than on this change — which is itself the standing blocker on all routed DQ measurement in this lane.

I am proposing it now rather than holding it until a run lands, because it is a strict improvement to a diagnostic that is reviewable on its own merits: the current line reports a failure without its cause, in the one place that survives the conditions under which the failure occurs.

## Review

@marlow the thing worth attacking is whether `win_err` should be reported when `ret` was already set by the op itself (`default:` and the malformed-PROTECT paths set `0x80020016`). Today those print `error=0`, which is honest but could read as "the OS said success". An alternative is printing `error=n/a` when no Win32 call failed — I left it as `0` because adding a sentinel invites its own misreading, but I do not feel strongly.
