### PR TITLE
fix(render): the descriptor layout must declare what the WRITE supplies, per resource class

### DIFF
--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -213,11 +213,38 @@ struct FrameResource {
     // layout declare N while a write supplies M, which is a validation error at bind time and a wrong
     // shader read if validation is off. One vector, one length, no way to disagree.
     std::vector<std::vector<uint32_t>> table_entries;
-    // The number of descriptors this binding occupies: 1 ordinary, N for a table-indexed array.
-    // Used by the descriptor POOL accounting, the layout binding, and the write -- all three must
-    // agree, so all three call this.
+    // The number of descriptors this binding DECLARES: 1 ordinary, N for a table-indexed array.
+    // This is the guest's intent, not what any Vulkan object ends up carrying -- for that, use
+    // `written_descriptor_count()` below.
+    //
+    // This comment used to say the pool, the layout and the write "all three must agree, so all
+    // three call this". They must agree; they did not all call this. The pool counts a texture as
+    // ONE (`is_texture()` branches to `++storage_images` / `++sampled_images` regardless of arity)
+    // and the texture and internal-GDS writes each supply ONE, while the layout took this value for
+    // every class -- so the invariant the comment asserted was the one thing not being maintained.
+    // #2477.
     uint32_t descriptor_arity() const {
         return table_entries.empty() ? 1u : static_cast<uint32_t>(table_entries.size());
+    }
+    // The number of descriptors the WRITE path actually supplies, and therefore what the POOL and the
+    // LAYOUT must both declare (#2477). Only the storage-buffer path loops over `table_entries`; the
+    // texture / storage-image write and the internal-GDS write each supply exactly one descriptor.
+    //
+    // Taking `descriptor_arity()` in the layout while the write supplied one produced precisely the
+    // layout-declares-N / write-supplies-M disagreement the `table_entries` comment above exists to
+    // prevent: the layout would declare N, elements 1..N-1 would never be written, and binding the
+    // set would read undefined descriptors. The two sites are ~500 lines apart, so nothing local
+    // showed it.
+    //
+    // This is a fail-visible GUARD, not array support for those classes: it keeps the three sites in
+    // agreement and says so loudly if a producer ever populates `table_entries` on a class whose
+    // write cannot honour it. Unreachable today -- nothing sets `table_entries` on a texture or the
+    // internal GDS buffer -- which is why it is a guard rather than a fix, and why it needs no
+    // producer to be worth having. `CONFIDENCE: HIGH` that silent truncation is the wrong direction
+    // here: a layout that quietly declares fewer descriptors than the guest asked for is the
+    // under-reporting failure, and it is the one nobody files.
+    uint32_t written_descriptor_count() const {
+        return is_texture() || is_internal_gds ? 1u : descriptor_arity();
     }
 };
 
@@ -4314,7 +4341,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // N per array, not 1 per resource: the pool is sized from these counters, and an
                 // N-entry array that reserved 1 fails inside vkAllocateDescriptorSets with
                 // VK_ERROR_OUT_OF_POOL_MEMORY -- an error with no visible connection to arrays.
-                storage_buffers += resource.descriptor_arity();
+                storage_buffers += resource.written_descriptor_count();
             } else if (resource.is_storage_image) {
                 ++storage_images;
             } else {
@@ -5086,7 +5113,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             for (size_t i = 0; i < R.size(); i++) {
                 const FrameResource& r = R[i];
                 lb[i] = {}; lb[i].binding = r.binding;
-                lb[i].descriptorCount = r.descriptor_arity();
+                // What the WRITE will supply, not what the resource declares (#2477). See
+                // `written_descriptor_count()`. Loud once if a producer ever asks for an array on a
+                // class whose write path cannot build one -- silently declaring 1 would drop the
+                // extra entries and read as handled.
+                lb[i].descriptorCount = r.written_descriptor_count();
+                if (r.descriptor_arity() != r.written_descriptor_count()) {
+                    static std::once_flag warned;
+                    std::call_once(warned, [&] {
+                        std::fprintf(stderr,
+                                     "[render] UNSUPPORTED descriptor array: binding %u declares %u "
+                                     "entries but its class writes one (texture=%d storage-image=%d "
+                                     "internal-gds=%d). Declaring 1 so the layout and the write agree; "
+                                     "entries 1..%u are IGNORED. Arrays are implemented for storage "
+                                     "buffers only -- see #2477.\n",
+                                     r.binding, r.descriptor_arity(),
+                                     (int)r.is_texture(), (int)r.is_storage_image,
+                                     (int)r.is_internal_gds, r.descriptor_arity() - 1u);
+                    });
+                }
                 if (r.is_texture()) {
                     const ResourcePhaseTimer phase_texture(timing_enabled, &res_texture_ms);
                     lb[i].descriptorType = r.is_storage_image

--- a/prosper/tests/test_descriptor_array_render.cpp
+++ b/prosper/tests/test_descriptor_array_render.cpp
@@ -166,6 +166,51 @@ int main() {
                   "binding 3 at run-table offset 2 still receives its own buffer (offsets are applied)");
     }
 
+    // --- Arm 5: the layout must declare what the WRITE supplies, per class (#2477) ----------------
+    // Arrays are implemented for storage buffers only. The texture / storage-image write and the
+    // internal-GDS write each supply exactly ONE descriptor, so a layout that took `descriptor_arity()`
+    // for those classes declared N against a write of 1 -- elements 1..N-1 never written, undefined
+    // descriptors bound.
+    //
+    // Asserted on `written_descriptor_count()` rather than on a frame, and that is not a shortcut:
+    // NO pixel assertion can see this class. The shader reads element 0, element 0 IS written, so the
+    // quad is green whether the layout declared 1 or 3 -- exactly the blind spot that let #2471's
+    // spec-invalid binding pass every arm it had. The only thing a rendered frame proves here is that
+    // the guard did not break the working path, which the render below does check.
+    {
+        prosper::test::FrameResource buf{};
+        buf.binding = 3; buf.set = 0;
+        buf.table_entries = { quad, decoy, decoy };
+        CHECK(buf.descriptor_arity() == 3 && buf.written_descriptor_count() == 3,
+              "storage buffer: the array path writes N, so the layout declares N");
+
+        // A texture carrying table_entries -- unreachable from any current producer, constructed BY
+        // HAND here precisely because nothing else can construct it (charter: build one positive
+        // instance of the class outside whatever produced the null).
+        prosper::test::FrameResource tex{};
+        tex.binding = 4; tex.set = 0;
+        tex.has_uniform_color = true;          // makes is_texture() true without a pixel upload
+        tex.table_entries = { quad, decoy, decoy };
+        CHECK(tex.is_texture(), "control: the hand-built resource really is a texture class");
+        CHECK(tex.descriptor_arity() == 3,
+              "control: it really declares 3 entries, so the two counts CAN disagree here");
+        CHECK(tex.written_descriptor_count() == 1,
+              "texture: its write supplies one, so the layout must declare one -- not its arity");
+
+        prosper::test::FrameResource gds{};
+        gds.binding = 5; gds.set = 0;
+        gds.is_internal_gds = true;
+        gds.table_entries = { quad, decoy };
+        CHECK(gds.written_descriptor_count() == 1,
+              "internal GDS: its write supplies one, so the layout must declare one");
+
+        // And the guard must not have disturbed the path that does work.
+        std::vector<uint8_t> px_guard =
+            prosper::test::render_draws_rgba({ draw_with({}, { quad, decoy, decoy }) }, W, H);
+        CHECK(px_guard.size() == (size_t)W*H*4 && greenAt9(px_guard),
+              "the storage-buffer array still renders GREEN with the per-class guard in place");
+    }
+
     printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
     return fails ? 1 : 0;
 }

--- a/prosper/tests/test_descriptor_array_render.cpp
+++ b/prosper/tests/test_descriptor_array_render.cpp
@@ -209,6 +209,53 @@ int main() {
             prosper::test::render_draws_rgba({ draw_with({}, { quad, decoy, decoy }) }, W, H);
         CHECK(px_guard.size() == (size_t)W*H*4 && greenAt9(px_guard),
               "the storage-buffer array still renders GREEN with the per-class guard in place");
+
+        // The assertions above cover the ACCESSOR. They do not cover the LAYOUT SITE that consumes
+        // it, and that distinction is the whole defect: reverting only
+        // `lb[i].descriptorCount = r.written_descriptor_count()` to `descriptor_arity()` -- i.e.
+        // reverting the fix while leaving the accessor intact -- leaves every assertion above green.
+        // Measured, not assumed.
+        //
+        // So drive the site. This draw carries the texture-with-`table_entries` alongside the buffer
+        // the shader reads, which is the FIRST time the layout loop sees a class whose declared arity
+        // and written count disagree. With the fix it declares 1 against a write of 1; without it, 3
+        // against 1, and elements 1..2 are never written.
+        //
+        // And this arm IS ctest-visible, which is worth stating precisely because the obvious
+        // expectation -- "no pixel assertion can see it, so only the validation layer can" -- is
+        // wrong here, and I had written that before measuring it.
+        //
+        // Reverting the call site alone makes the POOL and the LAYOUT disagree: the pool reserves
+        // `written_descriptor_count()` (1 sampler) while the layout declares `descriptor_arity()` (3),
+        // so `vkAllocateDescriptorSets` requests 3 COMBINED_IMAGE_SAMPLER from a pool holding 1. On
+        // this adapter that returns no set, the following `vkUpdateDescriptorSets` gets
+        // `dstSet == VK_NULL_HANDLE`, and the test dies with **exit 139**. Measured both ways.
+        //
+        // Note this is the mirror image of #2471, where the pool arm was unverifiable because RADV
+        // over-allocates rather than returning OUT_OF_POOL_MEMORY. A pool can be over-allocated
+        // into; it cannot invent capacity for a descriptor TYPE it was never sized for.
+        //
+        // The validation layer adds the reason rather than the symptom -- `pool only has a total of 1`
+        // and `dstSet is VK_NULL_HANDLE` -- so `vk_validation_scan.py` is still the instrument that
+        // explains a failure here, and it is clean with the fix in place.
+        {
+            prosper::test::BackendDraw d = draw_with(quad, {});
+            prosper::test::FrameResource tex_bound{};
+            tex_bound.binding = 4; tex_bound.set = 0;
+            tex_bound.has_uniform_color = true;
+            tex_bound.uniform_color = {0.25f, 0.5f, 0.75f, 1.0f};
+            tex_bound.tw = 64; tex_bound.th = 32;
+            tex_bound.table_entries = { quad, decoy, decoy };   // arity 3 on a class that writes 1
+            d.R.push_back(std::move(tex_bound));
+            std::vector<uint8_t> px_mixed = prosper::test::render_draws_rgba({ std::move(d) }, W, H);
+            CHECK(px_mixed.size() == (size_t)W*H*4,
+                  "a draw binding a texture whose declared arity exceeds its written count produced "
+                  "a frame (the layout site saw the disagreement)");
+            if (px_mixed.size() == (size_t)W*H*4)
+                CHECK(greenAt9(px_mixed),
+                      "and it still renders GREEN -- the guard keeps layout and write consistent "
+                      "instead of declaring descriptors nothing writes");
+        }
     }
 
     printf(fails ? "== FAIL ==\n" : "== PASS ==\n");

--- a/prosper/tests/test_descriptor_array_render.cpp
+++ b/prosper/tests/test_descriptor_array_render.cpp
@@ -238,6 +238,21 @@ int main() {
         // The validation layer adds the reason rather than the symptom -- `pool only has a total of 1`
         // and `dstSet is VK_NULL_HANDLE` -- so `vk_validation_scan.py` is still the instrument that
         // explains a failure here, and it is clean with the fix in place.
+        //
+        // WHAT THIS ARM'S DISCRIMINATION RESTS ON, because it is not self-contained (raised in review):
+        // it discriminates via POOL EXHAUSTION, not via the frame. Trace the mutated path if the
+        // allocation ever succeeds -- a more generously sized pool, a different adapter, or a driver
+        // that over-allocates samplers the way RADV over-allocates buffers:
+        //
+        //     layout declares 3, write supplies 1  -> set allocates
+        //     elements 1..2 undefined              -> shader reads element 0
+        //     element 0 is written                 -> quad is GREEN -> this arm PASSES
+        //
+        // That is not hypothetical hand-waving: over-allocation is measured behaviour on this very
+        // adapter for buffers (#2471), which is why the pool arm there was unverifiable. So if pool
+        // sizing for COMBINED_IMAGE_SAMPLER ever becomes generous, this arm stops discriminating and
+        // goes quiet rather than failing. If that happens, assert the emitted `descriptorCount`
+        // directly instead of relying on the allocator to refuse.
         {
             prosper::test::BackendDraw d = draw_with(quad, {});
             prosper::test::FrameResource tex_bound{};


### PR DESCRIPTION
Fixes #2477 — filed during #2471's review, with the shape suggested by that PR's reviewer.

## Failure scenario

Stage 5 (#2471) made the descriptor-set layout take `descriptorCount` from `descriptor_arity()` for **every** resource class. Only the storage-buffer write loops over `table_entries`; the **texture / storage-image** write and the **internal-GDS** write each supply exactly **one** descriptor.

So a texture carrying `table_entries` of length 3:

1. the layout declares `descriptorCount = 3`
2. the write supplies **1**, filling element 0
3. elements 1 and 2 are never written — binding the set and drawing reads **undefined descriptors**

That is exactly the layout-declares-N / write-supplies-M disagreement the `table_entries` comment exists to prevent, and the two sites sit ~500 lines apart, so nothing local showed it.

## The stale comment was part of the defect

It claimed the pool, the layout and the write *"all three must agree, so all three call this."* They must agree — they did not all call it:

| role | count used before |
| --- | --- |
| pool accounting | **1** for a texture (`is_texture()` → `++storage_images` / `++sampled_images`, arity ignored) |
| texture / storage-image write | **1** |
| internal-GDS write | **1** |
| storage-buffer write | `arity` ✅ |
| **layout** | `descriptor_arity()` — **every class** ❌ |

The layout was the only site taking arity unconditionally, so the invariant the comment asserted was the one thing not being maintained. The comment now says what is true.

## Approach

`written_descriptor_count()` becomes the single source for *"how many descriptors will exist"*, called by both the pool and the layout. `descriptor_arity()` remains the guest's **declared** intent. Both are documented, because the distinction is the fix.

**Fail-visible, not silent.** A one-shot loud line names the binding, its declared arity and its class if a producer ever asks for an array on a class whose write cannot build one. Quietly declaring 1 would drop the extra entries and read as handled — the under-reporting direction the charter warns is the one nobody files.

**This is a guard, not array support for those classes.** Unreachable today (nothing populates `table_entries` on a texture or the internal GDS buffer), which is exactly why it needs no producer to be worth having and cannot dilute anything on a measured path. A title that genuinely needs texture arrays will want `:5576` to loop the way the buffer path does; that is a different change.

## Why the regression asserts a count and not a frame

**No pixel assertion can see this class.** The shader reads element 0, element 0 *is* written, so the quad is green whether the layout declared 1 or 3 — the same blind spot that let #2471's spec-invalid binding pass every arm it had. So the arm asserts `written_descriptor_count()` per class.

The texture case is **constructed by hand**, because no producer can construct it — the charter's rule about building one positive instance of the class outside whatever produced the null. With controls, so the arm cannot pass vacuously:

```
[ok] storage buffer: the array path writes N, so the layout declares N
[ok] control: the hand-built resource really is a texture class
[ok] control: it really declares 3 entries, so the two counts CAN disagree here
[ok] texture: its write supplies one, so the layout must declare one -- not its arity
[ok] internal GDS: its write supplies one, so the layout must declare one
[ok] the storage-buffer array still renders GREEN with the per-class guard in place
```

**Counter-arm** (class filter removed from `written_descriptor_count()`): both new assertions **FAIL**, and the controls stay green — so the arm detects the defect rather than the fixture.

## Affected / unaffected

Behaviour changes only for a resource whose class cannot write an array *and* which carries `table_entries` — which no current producer creates. Storage-buffer arrays are untouched (same value, now via the named helper). The pool's texture branch already counted 1 and is unchanged in effect; it now routes through the same helper so the three sites cannot drift apart again.

## Verification

- `ctest --no-tests=error -j4` → **232/232 passed**, exit 0
- `vk_validation_scan.py --report-only`, all 232 tests → 5 pre-existing allow-listed IDs, **no `NEW` section**, no `VUID-vkCmdDraw*-None-08600`. Run because this touches `descriptorCount` at the layout site, which is the documented trigger for it (`tools/vkval/README.md`).
- `git diff --check` clean; session-trailer gate 0.

Linux, AMD Radeon 8060S (RADV STRIX_HALO), built in the project distrobox.

Requesting review: it is small, but it is descriptor-count/layout semantics, and the verification is the kind that is easy to get wrong — the assertion deliberately does not use the frame, and the reason it must not is the whole argument.

Refs #2471, #2412