### PR TITLE
docs: refresh the current project handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,13 +62,14 @@ prosper/
 Key docs to orient: `prosper/README.md` (status) and `prosper/docs/ROADMAP.md` (what is planned).
 For anything title- or subsystem-specific, use the table in the next section rather than guessing.
 
-## Where the project stands (2026-08-02)
+## Where the project stands (2026-08-10)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 29 titles, 16 at
-gameplay. Do not duplicate it here; read it, then open the one doc named below for whatever you are
-about to touch. This section is a map, not a status report. Long-lived `tracker:game` issues carry
-each active title's current development rung, route, blockers and evidence; dated cross-title
-performance measurements live in their own ordinary issues (the 2026-08-02 census is #1739).
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 39 tracked titles
+at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
+whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
+issues and their comments carry each active title's current development rung, route, blockers and
+evidence; dated cross-title performance measurements live in their own ordinary issues (the
+2026-08-02 census is #1739).
 
 **Concurrent game work starts with `prosper/docs/GAME_COMPAT_ORCHESTRATION.md`** — lane ownership,
 shared-GPU policy, the instrument-not-the-subject list, and the dated current handoff.
@@ -91,9 +92,10 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *Little Nightmares III* `PPSA05143` | rung 2 — title screen rendered on a default launch; the render-thread stall is fixed (#1987). Most title frames arrive with red and green forced to maximum, reading as a yellow background (#2014) | `docs/LITTLE_NIGHTMARES_3_STATUS.md` |
 | *ArcRunner* `PPSA21406` | rung 0 — renderer bring-up reaches real GPU submissions, then the render thread faults (#1226) | `docs/ARCRUNNER_STATUS.md` |
 | *Sonic Frontiers* `PPSA03831` | rung 2 — 4K opening sequence, auto-save notice, title screen and main menu on a default launch. The four-session black-screen wall was one unregistered NID answering `SCE_OK`: `sceSaveDataTransferringMountPs4` (#2023). The menu heading draws the wrong string (#2206) | `docs/SONIC_FRONTIERS_STATUS.md` |
-| *Sonic Racing: CrossWorlds* `PPSA08804` | rung 1 — the SEGA logo renders; the composite then goes uniform (#2013). The boot deadlock is #2012 | `docs/SONIC_CROSSWORLDS_STATUS.md` |
+| *Sonic Racing: CrossWorlds* `PPSA08804` | rung 2 — a pulsed pad route reaches the complete 4K title screen and profile menu; the profile panel is black and the sequence later holds on white (#2013 / #2358 / #2360) | `docs/SONIC_CROSSWORLDS_STATUS.md` |
+| *Grand Theft Auto V* `PPSA04263` | rung 2 — title and STORY/ONLINE menu. Routed gameplay entry renders the HUD over an absent 3D world; the descriptor-array lift is complete and the current evidence points at compute CFG structurization (#2412 / #2481) | `docs/FLAT_LOAD_DESIGN.md`, tracker #1873, issue #2481 |
 | *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / rung 1 — Sonic's black startup loop is fixed (#1905: `sceSaveDataCreateTransactionResource` must return a positive resource id); it renders the 4K SEGA logo and then holds on white | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
-| Astro Bot, The Plucky Squire, The Pathless | active orchestration lanes | `docs/GAME_COMPAT_ORCHESTRATION.md` |
+| Concurrent title work | the 2026-07-31 lane allocation is historical; use live issue claims for ownership and the dated checkpoint for the current cross-lane handoff | `docs/GAME_COMPAT_ORCHESTRATION.md` |
 | *Tactics Ogre: Reborn* `PPSA03839` | rung 3 — gameplay reached; HEVC movies render, sprite/HUD composition remains open | `docs/TACTICS_OGRE_STATUS.md` |
 | Every other title | — | `COMPATIBILITY.md` |
 | UE4 / IoStore bring-up (shared) | — | `docs/UE4_APR_IOSTORE_BRINGUP.md`, `docs/CROSS_ENGINE_UE4.md` |
@@ -206,7 +208,8 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   `<DUMP_ROOT>/PPSA24651-app0` (gitignored — **never commit it**).
   ```bash
   cd <REPO_ROOT>/prosper/build-linux
-  cmake --build . -j8 && ctest        # 99/99 expected green on Linux
+  cmake --build . -j8
+  ctest --no-tests=error              # report the discovered count and exit code
   ```
 - **Write run artifacts and build temporaries to the real disk, never `/tmp`.** On the Linux box `/tmp`
   is a **RAM-backed tmpfs sized at 50% of RAM, with a per-user quota shared by every concurrent agent**.

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,7 +8,7 @@ bugs. Different title revisions may behave differently.
 Detailed investigation notes, measurements, known defects, and next steps live in the linked
 [game-tracker issues](https://github.com/mattias800/prosper/issues?q=is%3Aissue+%22%5BGame+tracker%5D%22).
 
-Last updated: 2026-08-06
+Last updated: 2026-08-10
 
 ## Summary
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ sudo apt install ninja-build pkg-config libvulkan-dev libavformat-dev libavcodec
 cd prosper
 cmake -G Ninja -B build-linux
 cmake --build build-linux
-ctest --test-dir build-linux          # unit + boot + Vulkan-execution tests
+ctest --test-dir build-linux --no-tests=error  # unit + boot + Vulkan-execution tests
 ```
 
 Add `-DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON` to build the windowed frontend
@@ -186,7 +186,7 @@ pacman -S --needed git mingw-w64-ucrt-x86_64-gcc \
 cmake -S prosper -B prosper/build-windows-core -G Ninja \
   -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
 cmake --build prosper/build-windows-core
-ctest --test-dir prosper/build-windows-core --output-on-failure
+ctest --test-dir prosper/build-windows-core --output-on-failure --no-tests=error
 ```
 
 This builds and tests the headless core without SDL or Vulkan. GitHub Actions runs the same UCRT64

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -6,10 +6,11 @@ Not a CPU emulator: the PS5 is x86-64, so guest code runs **natively**. `prosper
 operating system (FreeBSD-derived), the library ABI (Sony NID-linked modules), and the GPU
 (AGC → Vulkan) underneath the unmodified game binary.
 
-**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). Also exercised:
-`PPSA02664` (Unity/IL2CPP), `PPSA17942` (Unreal Engine), `PPSA13579` (*Blasphemous 2*), and
-`PPSA15552` (*Dead Cells*). Their SELF segments are unencrypted, which is what makes the project
-possible without console keys. Dumps are user-supplied and gitignored.
+**Primary title:** `PPSA24651` — *The Messenger* (Unity 2022 / IL2CPP). The compatibility corpus now
+tracks 39 titles across Unity/IL2CPP, Unreal Engine, RAGE, Hedgehog Engine and custom engines; see
+[`../COMPATIBILITY.md`](../COMPATIBILITY.md) for the current user-visible milestones. Their SELF
+segments are unencrypted, which is what makes the project possible without console keys. Dumps are
+user-supplied and gitignored.
 
 ## Status
 - ✅ **M0–M1 — Recon, tooling & loader.** Format cracked; SELF/ELF → relocatable image → multi-module
@@ -75,22 +76,14 @@ possible without console keys. Dumps are user-supplied and gitignored.
   over an otherwise valid world (#654). A 420-frame sampled-render native capture confirms the complete first
   playable room, and screenshot manifests distinguish new publications from actual pixel progress (#648).
   The route and capture recipe are in `scripts/blasphemous2/README.md`.
-- 🚧 **Active frontiers:** bundle v2 makes long Dead Cells history practical with exact shared-resource
-  chunks, rolling semantic endpoints, final compaction, and suffix replay (#606). A fixed 1,200-submit full-state
-  run reduced 122.97 GiB logical data to 301.1 MiB. A compact exact two-submit closure resolves both temporal
-  642×362 edges without bounded leaves, but the first 80-draw semantic endpoint is the opening vignette rather
-  than playable gameplay. The preserved #608 bundle selected the Jump tutorial with exactly 90 draws and the
-  738x420 pass at draw 79..81. Current routes are selected without submit ordinals by combining 91..94 semantic
-  draws, exactly 8 dispatches, and the 636x420 pass at draw 77..85. Timeline v6 records compact target spans so the
-  predicate can be discovered and validated offline before an expensive detailed capture (#594).
-  The faithful 883-submit closure resolves 1,764 temporal image dependencies and established the stale-depth
-  failure. The draw stream has no `DB_RENDER_CONTROL` clear because hardware observes the compute-written
-  HTILE metadata instead; #611 implements that missing cache boundary. Capture v8 now snapshots exact valid
-  depth/stencil planes with their complete cache identity and embeds the source bundle output oracle. Both the
-  normal production path and an invalidation-disabled stale-depth A/B replay byte-identically from one final
-  capsule in about 3.3 seconds (#569). The Dead Cells splash guard checks the richest frame in its startup window against
-  a measured content threshold, avoiding its nondeterministic animation frame. UE4's measured GPU boundary remains
-  under its area issues.
+- 🚧 **Active frontiers (2026-08-10):** GTA V reaches its title/menu and routed gameplay entry, where
+  the HUD renders over an absent 3D world. The six-stage runtime-selected descriptor-array lift is
+  complete; post-lift Linux and Windows evidence moves the current blocker to about 57 distinct compute
+  control-flow structurization sites (#2412/#2481), with subgroup-contract limits tracked separately
+  in #2429. Dragon Quest VII now boots and submits continuously on Windows (#2447), but routed
+  progression can hit a fixed `sceKernelBatchMap` ENOMEM whose high-volume memory logger suppresses the
+  repro (#2448/#2450). Sonic Racing: CrossWorlds has advanced to rung 2: pulsed input reaches its full
+  4K title screen, while the later profile panel and terminal white state remain open (#2358/#2360).
 
 The completed Messenger black-render investigation and reusable evidence boundary are recorded in
 [`docs/MESSENGER_BLACK_RENDER.md`](docs/MESSENGER_BLACK_RENDER.md). Current work is tracked in GitHub
@@ -122,7 +115,7 @@ prosper/
 ```
 cmake -S . -B build -G Ninja
 cmake --build build
-ctest --test-dir build          # the self-checking suite (count varies by platform)
+ctest --test-dir build --no-tests=error  # report the discovered count; it varies by platform
 ```
 `ctest` needs `spirv-val` on `PATH` — `spirv-tools` on Fedora/Ubuntu,
 `mingw-w64-ucrt-x86_64-spirv-tools` in MSYS2, `brew install spirv-tools` on macOS. The

--- a/prosper/docs/ARCHITECTURE.md
+++ b/prosper/docs/ARCHITECTURE.md
@@ -73,22 +73,31 @@ Maps FreeBSD/libkernel semantics onto the host:
   intermediate). Recompile to **SPIR-V**. This is a self-contained sub-project
   (decoder → SSA IR → SPIR-V emitter), the biggest single effort in the whole layer.
 
-**Implementation status (built, all execution/pixel-verified):** the pipeline is
-`pm4_decode` → `command_processor` (fold a Dcb into a `GpuState`) → `render_state` /
-`resolve_pipeline_state` → `vk_translate` → a real `VkGraphicsPipeline`, plus a resource-layer
-contract (`gpu_resources`). The **RDNA2→SPIR-V recompiler** (`rdna2_decode` + `rdna2_to_spirv`)
-handles ~52 ALU ops + convert/compare/select/bitfield/pack and **divergent control flow** (EXEC
-per-lane predication, `saveexec`/restore, forward `s_cbranch_execz`), at ~67% instruction coverage
-over the game's real shaders (measured by `recompile_coverage`/`shader_histo`). Remaining: `SMEM`/
-`MUBUF`/`MIMG` memory ops (need the resource-binding model) and loops (backward branches). The live
-boot blocker is upstream — Unity's completion-event-driven residency pass never fires under our
-headless equeue (see `docs/GRAPHICS.md`).
+**Implementation status (built and verified in layers):** the pipeline is `pm4_decode` →
+`command_processor` (fold a Dcb into a `GpuState`) → `render_state` / `resolve_pipeline_state` →
+`vk_translate` → real `VkGraphicsPipeline`s, plus the shared live resource layer. The
+**RDNA2→SPIR-V recompiler** (`rdna2_decode` + `rdna2_to_spirv`) handles scalar/vector ALU,
+convert/compare/select/bitfield/pack, `SCC`, EXEC-mask predication and structured branches/loops;
+`SMEM`, `MUBUF`, `MIMG`, LDS/barriers, exports and interpolation; and reflected runtime descriptor
+validation. Runtime-selected descriptor arrays now span device capability acquisition, reflection,
+SPIR-V declaration/indexing, pool/layout/write arity and pipeline-cache identity (#2458–#2475).
 
-### 5. Peripherals (`src/io`, future — not yet a module)
-- `libScePad` → SDL_GameController (DualSense passthrough where possible).
-- `libSceAudioOut(2)` → SDL audio / miniaudio; `libSceAjm` → decode ATRAC9/AAC via
-  ffmpeg or a dedicated ATRAC9 decoder.
-- `libSceAvPlayer` → ffmpeg-backed video → texture.
+The remaining work is data-driven rather than one old percentage: unsupported instructions and
+unprovable resource/operand paths fail visibly, and `recompile_coverage`, live reject diagnostics and
+`shader_inspect` identify the next exact program counter. The current GTA V workload, for example,
+is dominated by compute CFG structurization sites after the descriptor-array lift, not by missing
+`SMEM`/`MUBUF` support (#2481). See `docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md` and
+`docs/RECOMPILER_REMAINING.md`, including each document's `## Ruled out` section, before extending
+the translator.
+
+### 5. Peripherals and frontends
+- `frontends/prosper-app` provides an SDL3 window, Vulkan presentation, controller/keyboard input,
+  audio and native dialogs; the headless tools share the same boot/render core.
+- `libScePad` input is backed by evdev/SDL3 and can be driven by deterministic `.pad` routes for
+  title progression.
+- `libSceAudioOut(2)` has a host audio sink; AJM/ATRAC9 and AvPlayer/Videodec paths feed decoded
+  audio/video into the guest-visible contracts. Per-title codec/layout gaps remain tracked issues,
+  not a future-module placeholder.
 
 ## The ABI question (why host choice matters)
 

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -8,20 +8,25 @@ Read the repository-root `CLAUDE.md` before this document. `CLAUDE.md` remains a
 verification, evidence, review, privacy, and release policy. This document explains how to apply those rules when
 several game agents work at once.
 
-The current-state sections below are dated **2026-07-31**. Update them whenever an investigation materially moves,
-a PR merges, or ownership changes. Do not let this document replace issue comments: issues are the durable evidence
-log, while this document is the map that helps the next orchestrator find and interpret that evidence.
+The checkpoint below was refreshed **2026-08-10**. The named Lane A–F allocation and Wave 1/2 sections remain
+dated historical records; they retain valuable falsifications and apparatus lessons, but their ownership and
+"next assignment" text is not live. Update the checkpoint whenever an investigation materially moves, a PR merges,
+or ownership changes. Do not let this document replace issue comments: issues are the durable evidence log, while
+this document is the map that helps the next orchestrator find and interpret that evidence.
 
 ## Current checkpoint
 
 - Repository: `mattias800/prosper` (renamed from `mattias800/ps5ys`).
 - Remote branch: `master`.
-- Exact master at this update: `9dcb6c4b` (2026-08-04; ~210 commits after `6414f402`).
+- Documentation refresh base: `9e101c70` (2026-08-10).
 - **Game dumps now live in `<REPO_ROOT>/testdata/<TITLE_ID>-app0`** (gitignored). Briefs and commands
   that still say `<DUMP_ROOT>/…` mean this path. All 39 tracked titles have a dump present, and every
   dump has a tracker — the sets match exactly, so there is no unexplored title.
-- Active title lanes (2026-08-04 wave 1): **The Oregon Trail, Sonic Origins, R-Type Delta, Asterix &
-  Obelix Babylon Mission, ArcRunner** — every title currently at rung 0.
+- The 2026-08-04 rung-0 wave below is complete: every listed title produced either a visible milestone
+  or a relocated, evidence-backed blocker. Current activity is centered on GTA V's post-lift compute CFG
+  frontier (#2412/#2481/#2429) and Dragon Quest VII's Windows progression/mapping frontier (#2448/#2450).
+  This sentence is a handoff, not a lock: live `in-progress` labels, claim comments and remote fix branches
+  are authoritative for ownership.
 - GPU state: sharing is the default; see the scheduling rules below.
 
 ### The standing objective, in the user's words

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -24,27 +24,30 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ---
 
-## Current status (2026-07-13) - at a glance
+## Current status (2026-08-10) — at a glance
 
-- **Messenger reaches and renders the first level:** intro, title, menus, save list, dialogue, player,
-  background, foreground tree/terrain, water, and structures render at native 1920×1080. The causal fixes
-  are the grading-LUT producer/target extent (#528), Vulkan front-face translation (#534), and independent
-  depth/stencil aspect validity in the persistent guest-surface cache (#541). The full-resolution route was
-  user-confirmed against the hardware reference; #299, #300, #522, #530, and #540 are closed.
-- **The investigation tools are operational:** #514 provides versioned live GPU capture/replay with exact
-  live/replay hashes and per-draw/resource isolation; #515 provides reflected SPIR-V/runtime descriptor
-  validation in live and offline replay paths. Producer provenance, normal screenshot capture, and the local
-  content-metric snapshot guard complete the current first-bad-contract workflow.
-- **Dead Cells cross-title milestone:** deterministic routing now reaches the controllable Prisoners' Quarters
-  scene with full-color geometry, lighting, player, effects, and HUD. Retained PM4 graphics/compute order (#584),
-  guest-write depth-cache invalidation (#611), and narrowly proved uniform VCCZ lighting loops (#615) restore the
-  producer and depth layers. #626 fixes the last grayscale composition error: multi-target world shaders export
-  MRT3..MRT0, so the single-attachment recompiler must select MRT0 rather than the first emitted G-buffer plane.
-  It also realizes the eighth scene dispatch by resolving its directly placed destination V#. #566 is closed.
-- **Immediate milestone:** extend the capture-first workflow to later Dead Cells rooms and additional 3D titles.
-  Capture v8 preserves complete persistent color/depth state and embeds a source-output oracle (#569), while
-  Timeline v6 supplies offline target-span discovery and a semantic scene selector (#594). Keep reducing new
-  failures through standalone checkpoints and synthetic contracts rather than long unstructured live traces.
+- **Compatibility breadth:** 39 title trackers cover Unity/IL2CPP, Unreal Engine, RAGE, Hedgehog Engine and
+  custom engines. `COMPATIBILITY.md` is the user-facing milestone index; tracker issues and their comments are
+  the live source for rungs, routes and blockers. Messenger, Dead Cells and Blasphemous 2 remain the foundational
+  end-to-end gameplay proofs, and the same shared stack now reaches visible milestones across the wider corpus.
+- **Recent visible progress:** Sonic Racing: CrossWorlds now reaches a complete 4K title screen through a pulsed
+  controller route (#2358/#2360); a held button was not an input edge, so the previous post-logo "renderer wall"
+  was the guest waiting for input. GTA V reaches its title/menu on both primary development platforms, and a
+  routed run reaches gameplay entry with the HUD visible over an absent 3D world. Dragon Quest VII boots and
+  submits continuously on Windows after the `%fs`/`%gs` null-read fix (#2447).
+- **Current graphics frontier:** GTA V's six-stage runtime-selected descriptor-array lift is complete. Live
+  post-lift evidence on Linux/RADV and Windows/NVIDIA shows that the missing 3D world is not waiting on that lift;
+  the dominant measured gap is about 57 distinct compute CFG structurization sites (#2412/#2481). Native subgroup
+  adoption is a per-dispatch contract, not merely a device width: a quarter of routed wave64 compute dispatches on
+  a 64-wide RADV device decline it because of workgroup shape (#2429).
+- **Current Windows frontier:** routed Dragon Quest VII progression can fail a fixed `sceKernelBatchMap` with
+  ENOMEM. UE4 then deliberately enters `LowLevelFatalError`; the resulting exit 139 is not a wild-pointer crash.
+  The high-volume memory logger suppresses the timing-sensitive failure, so diagnosis is being carried on the
+  capped failure line that survives the repro (#2448/#2450).
+- **Verification/tooling direction:** use scheduled F8 performance captures and F9 replay bundles before adding
+  another renderer diagnostic, and require every measurement to expose whether its trigger, window and positive
+  control were valid. The suite grows continuously, so quote the discovered `ctest --no-tests=error` count rather
+  than copying a fixed expected total into documentation.
 
 ## Historical status (2026-07-05) - retained for the milestone log
 

--- a/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
+++ b/prosper/docs/SONIC_CROSSWORLDS_STATUS.md
@@ -5,26 +5,24 @@ Engine: **Unreal Engine 5** (IoStore/APR), with **CRIWARE** (CRI Mana / Sofdec2 
 CRI FS) and the **EOS SDK** (`prx/eossdk-ps5-shipping.prx`) alongside it. 64 guest threads at the
 frame loop.
 
-## Current rung: 1 — the SEGA logo renders
+## Current rung: 2 — the complete 4K title screen renders through a pulsed pad route
 
-**Requires the #2012 fix** (PR #2015, a shared libkernel change reviewed separately). On master
-without it the title still produces no frame at all — see *What unblocked it* below, which is the
-measured before/after.
+**Requires the #2012 fix** (PR #2015, a shared libkernel change reviewed separately) and controller
+edges from `scripts/sonic-crossworlds/advance-boot-logos.pad`. A default launch reaches the SEGA logo
+and then waits for input; the old uniform post-logo observation was a static guest state, not evidence
+of a renderer failure. A held Cross does not advance it — the route must alternate neutral and pressed
+states (#2358).
 
-![Sonic Racing: CrossWorlds — SEGA logo](../../assets/screenshots/sonic-crossworlds-sega-logo.png)
+![Sonic Racing: CrossWorlds — title screen](../../assets/screenshots/sonic-crossworlds-title.png)
 
-Direct, unmodified `tools/screenshot` capture, Linux/RADV (`AMD Radeon 8060S (RADV STRIX_HALO)`),
-native 3840x2160, default switches, no route:
+Two independent direct, unmodified `tools/screenshot` runs on Linux/RADV reached the native 3840x2160
+title screen: the full 3D scene, every character, the track, logo and UI. The animated frames differ in
+CRC but agree in content signature at about 99.6% non-black coverage and 113k sampled colours (#2360).
+The route continues into the player-profile menu, whose UI renders over a black central panel, and
+eventually reaches a uniform white state. Gameplay is not reached.
 
-```bash
-PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_RENDER=1 \
-  ./build-linux/screenshot <DUMP_ROOT>/PPSA08804-app0 --seconds 20 --count 20 --out ~/shots
-```
-
-The logo appears at t≈60 s and holds to t≈80 s (1,373 distinct colours, 430,916 non-black pixels,
-decoded from the PNG rather than scored). A second arm with no diagnostics at all reproduced it at
-t=45 s with the **identical** `pixel_crc32` (`0d70a70a`). From t≈100 s the composite becomes a
-**uniform `RGBA(1,0,1,255)`** while the engine keeps producing frames — see *The frontier* below.
+The sections below retain the default-launch investigation because it records the falsifications that
+prevented the input wait from being found earlier. Read `## Ruled out` before reviving any of them.
 
 ## What unblocked it: #2012
 
@@ -66,7 +64,7 @@ the missing registrations added as well (step 1), the same instrument reports **
 `XhWHn6P5R7U` disappears from the unimplemented-NID list. So the fake "you acquired it" was the
 *source* of the unmatched unlocks, and the guard is the backstop for any other source.
 
-## The frontier: the composite after the logo
+## Historical frontier: the default-launch composite after the logo
 
 From t≈80 s the presented frame is a single colour, `RGBA(1,0,1,255)`, while `frame_seq` and
 `present_count` keep climbing. **This is not a hang, and `frame_seq` climbing is not evidence that

--- a/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
+++ b/prosper/scripts/sonic-crossworlds/advance-boot-logos.pad
@@ -1,4 +1,4 @@
-# Sonic Racing: CrossWorlds (PPSA08804): carry the boot sequence past the SEGA logo.
+# Sonic Racing: CrossWorlds (PPSA08804): carry the boot sequence to the title screen.
 #
 # Before this route the title was recorded at rung 1 -- "the SEGA logo renders, the composite then goes
 # uniform" -- and every diagnostic said the renderer was healthy: 0 dropped pipelines, 0 unresolved
@@ -6,10 +6,11 @@
 # for a button.
 #
 # With this route the title renders, in order and correctly at 3840x2160: the SEGA logo, the **Unreal
-# Engine** logo (crc 42763e4a), the **CRIWARE** logo (5170ed80) and the **legal / licensor text screen**
-# (b3b61854). None of those three had ever been observed on this title; four independent no-pad
-# observations -- two arms of mine and the two master arms recorded in SONIC_CROSSWORLDS_STATUS.md --
-# show only black / SEGA logo / black.
+# Engine** logo (crc 42763e4a), the **CRIWARE** logo (5170ed80), the **legal / licensor text screen**
+# (b3b61854), the auto-save notice, the complete title screen, and the player-profile menu. The profile
+# menu's UI renders over a black central panel and the sequence later holds on white; gameplay is not
+# reached. Four independent no-pad observations show only black / SEGA logo / black because the guest
+# waits for an input edge after the logo.
 #
 # THE EDGE IS THE POINT, and it is the whole finding. An earlier arm held Cross continuously from frame 0
 # (`f0-20000:cross`), with delivery confirmed from the guest's own read (`[pad] pad_read_state call#512
@@ -20,11 +21,12 @@
 # Frame anchors rather than seconds: this title runs at roughly 3.7 host frames/s during the logo
 # sequence, so wall-clock anchors drift badly between runs while frame anchors do not.
 #
-# Verified on Linux/RADV through tools/screenshot, default launch, --seconds 30 --count 9 (270 s), on
-# master at ad5f5132 + c477d938. Two runs, identical CRC set, sampling counts differing by one.
+# Verified on Linux/RADV through tools/screenshot in two independent routed 560 s runs. The title-screen
+# CRC differs because its scene is animated, while the two runs agree in content signature at about 99.6%
+# non-black coverage and 113k sampled colours (#2360).
 #
-# This does NOT reach a title screen. It reaches the auto-save notice, which on SEGA titles sits just
-# before one, so extending it is worth another pass -- watch where it stalls next and add pulses there.
+# This reaches rung 2 (title screen), not rung 3 (gameplay). Continue extending with bounded pulses and
+# inspect the next stable state; do not replace the pulses with a trailing hold.
 #
 # One observation, flagged rather than claimed: the auto-save notice renders LETTERBOXED into a
 # horizontal band, with the top and bottom thirds black, rather than filling the 3840x2160 target. That


### PR DESCRIPTION
## What changed

- refresh the charter, READMEs, roadmap, architecture overview, compatibility timestamp, and orchestration checkpoint from the August 10 evidence
- document the current GTA V descriptor/CFG and Dragon Quest VII Windows mapping frontiers
- reconcile Sonic Racing: CrossWorlds with its evidenced rung 2 title-screen route and update that route's comments
- replace stale fixed test totals and plain `ctest` examples with discovered-count, `--no-tests=error` guidance

## Why

The main entry points had drifted behind recent merged work. In particular, the CrossWorlds status header still claimed rung 1 while its later evidence recorded rung 2; the roadmap still described the July 13 frontier; and the architecture overview still listed memory-op support as future work after that support had landed. This refresh gives the next contributor a consistent handoff without rewriting the dated historical sections.

## Scope

Documentation-only behavior change. The `.pad` route contains comment updates only; no route entries, production code, or test code changed.

## Validation

- `python3 prosper/tools/docs/check_numbered_table.py --sequential --table-header Instrument prosper/docs/GAME_COMPAT_ORCHESTRATION.md`
- `git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py`
- `git diff --check`
- verified the referenced CrossWorlds title-screen asset exists
