### PR TITLE
fix(recompiler): advance GTA V compute coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ prosper/
 Key docs to orient: `prosper/README.md` (status) and `prosper/docs/ROADMAP.md` (what is planned).
 For anything title- or subsystem-specific, use the table in the next section rather than guessing.
 
-## Where the project stands (2026-08-10)
+## Where the project stands (2026-08-11)
 
 `COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 39 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
@@ -93,7 +93,7 @@ shared-GPU policy, the instrument-not-the-subject list, and the dated current ha
 | *ArcRunner* `PPSA21406` | rung 0 — renderer bring-up reaches real GPU submissions, then the render thread faults (#1226) | `docs/ARCRUNNER_STATUS.md` |
 | *Sonic Frontiers* `PPSA03831` | rung 2 — 4K opening sequence, auto-save notice, title screen and main menu on a default launch. The four-session black-screen wall was one unregistered NID answering `SCE_OK`: `sceSaveDataTransferringMountPs4` (#2023). The menu heading draws the wrong string (#2206) | `docs/SONIC_FRONTIERS_STATUS.md` |
 | *Sonic Racing: CrossWorlds* `PPSA08804` | rung 2 — a pulsed pad route reaches the complete 4K title screen and profile menu; the profile panel is black and the sequence later holds on white (#2013 / #2358 / #2360) | `docs/SONIC_CROSSWORLDS_STATUS.md` |
-| *Grand Theft Auto V* `PPSA04263` | rung 2 — title and STORY/ONLINE menu. Routed gameplay entry renders the HUD over an absent 3D world; the descriptor-array lift is complete and the current evidence points at compute CFG structurization (#2412 / #2481) | `docs/FLAT_LOAD_DESIGN.md`, tracker #1873, issue #2481 |
+| *Grand Theft Auto V* `PPSA04263` | rung 3 — routed gameplay entry with real GPU draws; the HUD, radar and tutorial text render over an absent 3D world. The descriptor-array lift is complete; use the exact program-tagged terminal census in #2481 rather than the superseded aggregate CFG count | `docs/FLAT_LOAD_DESIGN.md` (historical design), tracker #1873, issue #2481 |
 | *GRIS*, *Space Adventure Cobra*, *Sonic Origins* | rung 3 / rung 3 / rung 1 — Sonic's black startup loop is fixed (#1905: `sceSaveDataCreateTransactionResource` must return a positive resource id); it renders the 4K SEGA logo and then holds on white | `docs/GRIS_SONIC_COBRA_BRINGUP.md` |
 | Concurrent title work | the 2026-07-31 lane allocation is historical; use live issue claims for ownership and the dated checkpoint for the current cross-lane handoff | `docs/GAME_COMPAT_ORCHESTRATION.md` |
 | *Tactics Ogre: Reborn* `PPSA03839` | rung 3 — gameplay reached; HEVC movies render, sprite/HUD composition remains open | `docs/TACTICS_OGRE_STATUS.md` |

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,7 +8,7 @@ bugs. Different title revisions may behave differently.
 Detailed investigation notes, measurements, known defects, and next steps live in the linked
 [game-tracker issues](https://github.com/mattias800/prosper/issues?q=is%3Aissue+%22%5BGame+tracker%5D%22).
 
-Last updated: 2026-08-10
+Last updated: 2026-08-11
 
 ## Summary
 
@@ -25,7 +25,7 @@ Last updated: 2026-08-10
 | *Sonic Racing: CrossWorlds* | `PPSA08804` | Unreal Engine 5 | 🔬 4K title screen and menus with a pad route; needs input to advance past the logos | [#1895](https://github.com/mattias800/prosper/issues/1895) |
 | *Terminator 2D: NO FATE* | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay | [#1872](https://github.com/mattias800/prosper/issues/1872) |
 | *Blue Prince* | `PPSA25009` | Unity | 🚧 Manor entrance-hall gameplay | [#1808](https://github.com/mattias800/prosper/issues/1808) |
-| *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Title and main menu | [#1873](https://github.com/mattias800/prosper/issues/1873) |
+| *Grand Theft Auto V* | `PPSA04263` | RAGE | 🚧 Gameplay entry: HUD and radar render; 3D world absent | [#1873](https://github.com/mattias800/prosper/issues/1873) |
 | *Dragon Quest VII Reimagined* | `PPSA17942` | Unreal Engine 4 | 🚧 Title and first-run setup | [#1874](https://github.com/mattias800/prosper/issues/1874) |
 | *Alex Kidd in Miracle World DX* | `PPSA02664` | Unity / IL2CPP | ✅ First-level gameplay | [#1875](https://github.com/mattias800/prosper/issues/1875) |
 | *New Joe &amp; Mac: Caveman Ninja* | `PPSA02801` | Unity / IL2CPP | ✅ Level 1 gameplay | [#1876](https://github.com/mattias800/prosper/issues/1876) |
@@ -182,7 +182,10 @@ The manor entrance hall renders with real 3D gameplay content. See the [tracker]
 <p align="center"><img src="assets/screenshots/gta5-title.png" alt="Grand Theft Auto V — title screen"></p>
 <p align="center"><img src="assets/screenshots/gta5-main-menu.png" alt="Grand Theft Auto V — main menu"></p>
 
-The title and STORY/ONLINE main menu render. See the [tracker](https://github.com/mattias800/prosper/issues/1873).
+The title and STORY/ONLINE main menu render. A checked-in pad route also reaches Story Mode gameplay:
+the HUD, radar and tutorial text are visible, but the 3D world is still black. See the
+[tracker](https://github.com/mattias800/prosper/issues/1873) and the exact compute-failure census in
+[#2481](https://github.com/mattias800/prosper/issues/2481).
 
 ## Dragon Quest VII Reimagined — `PPSA17942`
 

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -21,8 +21,9 @@ user-supplied and gitignored.
   **through** IL2CPP and Unity's GfxDevice into the running frame loop.
 - ✅ **M4 — Graphics (AGC → Vulkan).** AGC frontend (CreateShader + submit; PM4 decode → command
   processor → register-state fold; EOP/DMA/fence writes on the guest timeline). **RDNA2→SPIR-V
-  recompiler:** full ALU + `SCC`; divergent control flow (EXEC predication, saveexec/restore, `execz`
-  if-then + loop exits); `SMEM`, `MUBUF` vertex-fetch/load/store, `MIMG` sample/load, `LDS`+barriers,
+  recompiler:** broad scalar/vector ALU coverage + `SCC`; divergent control flow (EXEC predication,
+  saveexec/restore, `execz` if-then + loop exits); `SMEM`, `MUBUF` vertex-fetch/load/store, `MIMG`
+  sample/load, `LDS` + fail-closed barrier lowering,
   `EXP`/`VINTRP`; EUD-resident descriptor resolution; every SPIR-V emitter `spirv-val`-gated in CI
   (`tools/spv_validate`). Texture decode:
   GFX10 `SW_4KB_S`/`SW_64KB_S` de-swizzle for all element sizes + BC1–7/BC6H, T# format + `DST_SEL`
@@ -76,11 +77,13 @@ user-supplied and gitignored.
   over an otherwise valid world (#654). A 420-frame sampled-render native capture confirms the complete first
   playable room, and screenshot manifests distinguish new publications from actual pixel progress (#648).
   The route and capture recipe are in `scripts/blasphemous2/README.md`.
-- 🚧 **Active frontiers (2026-08-10):** GTA V reaches its title/menu and routed gameplay entry, where
-  the HUD renders over an absent 3D world. The six-stage runtime-selected descriptor-array lift is
-  complete; post-lift Linux and Windows evidence moves the current blocker to about 57 distinct compute
-  control-flow structurization sites (#2412/#2481), with subgroup-contract limits tracked separately
-  in #2429. Dragon Quest VII now boots and submits continuously on Windows (#2447), but routed
+- 🚧 **Active frontiers (2026-08-11):** GTA V reaches its title/menu and routed gameplay entry, where
+  the HUD, radar and tutorial text render over an absent 3D world. The six-stage runtime-selected
+  descriptor-array lift is complete. Program-tagged live evidence proved that the earlier "about 57 CFG
+  sites" count mixed consequent structurizer messages with independent terminal failures; reviewed work
+  now advances the exact failing programs one instruction or resource contract at a time (#2412/#2481),
+  with subgroup-contract limits tracked separately in #2429. Dragon Quest VII now boots and submits
+  continuously on Windows (#2447), but routed
   progression can hit a fixed `sceKernelBatchMap` ENOMEM whose high-volume memory logger suppresses the
   repro (#2448/#2450). Sonic Racing: CrossWorlds has advanced to rung 2: pulsed input reaches its full
   4K title screen, while the later profile panel and terminal white state remain open (#2358/#2360).

--- a/prosper/README.md
+++ b/prosper/README.md
@@ -81,8 +81,10 @@ user-supplied and gitignored.
   the HUD, radar and tutorial text render over an absent 3D world. The six-stage runtime-selected
   descriptor-array lift is complete. Program-tagged live evidence proved that the earlier "about 57 CFG
   sites" count mixed consequent structurizer messages with independent terminal failures; reviewed work
-  now advances the exact failing programs one instruction or resource contract at a time (#2412/#2481),
-  with subgroup-contract limits tracked separately in #2429. Dragon Quest VII now boots and submits
+  now advances the exact failing programs one instruction or resource contract at a time. The current
+  routed sample has 29 recompile-empty programs plus 6 invalid-descriptor programs, a 35-program union
+  with no new failures versus the preceding sample (#2412/#2481). Subgroup-contract limits are tracked
+  separately in #2429. Dragon Quest VII now boots and submits
   continuously on Windows (#2447), but routed
   progression can hit a fixed `sceKernelBatchMap` ENOMEM whose high-volume memory logger suppresses the
   repro (#2448/#2450). Sonic Racing: CrossWorlds has advanced to rung 2: pulsed input reaches its full

--- a/prosper/docs/ARCHITECTURE.md
+++ b/prosper/docs/ARCHITECTURE.md
@@ -84,9 +84,12 @@ SPIR-V declaration/indexing, pool/layout/write arity and pipeline-cache identity
 
 The remaining work is data-driven rather than one old percentage: unsupported instructions and
 unprovable resource/operand paths fail visibly, and `recompile_coverage`, live reject diagnostics and
-`shader_inspect` identify the next exact program counter. The current GTA V workload, for example,
-is dominated by compute CFG structurization sites after the descriptor-array lift, not by missing
-`SMEM`/`MUBUF` support (#2481). See `docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md` and
+`shader_inspect` identify the next exact program counter. GTA V is tracked by routed terminal program
+address + instruction PC with the real resource table, not by raw structurizer line counts: the
+`structured emission stopped` family is consequent, and most `backward else` reports are secondary to
+later instruction, mask-domain or resource failures. Post-lift Wave32 carry, zero-record RAW-buffer and
+DPP-row fixes advance their exact targets while the gameplay 3D world remains black (#2481). See
+`docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md` and
 `docs/RECOMPILER_REMAINING.md`, including each document's `## Ruled out` section, before extending
 the translator.
 

--- a/prosper/docs/ARCHITECTURE.md
+++ b/prosper/docs/ARCHITECTURE.md
@@ -84,11 +84,15 @@ SPIR-V declaration/indexing, pool/layout/write arity and pipeline-cache identity
 
 The remaining work is data-driven rather than one old percentage: unsupported instructions and
 unprovable resource/operand paths fail visibly, and `recompile_coverage`, live reject diagnostics and
-`shader_inspect` identify the next exact program counter. GTA V is tracked by routed terminal program
-address + instruction PC with the real resource table, not by raw structurizer line counts: the
+resource-bearing live/replay captures identify the next exact program counter. A raw `shader_inspect`
+dump is useful for proving that an instruction packet exists, but table-dependent rejection remains
+unattributable without the real resource table. GTA V is tracked by routed terminal program address +
+instruction PC, not by raw structurizer line counts or adjacency in an interleaved stderr stream: the
 `structured emission stopped` family is consequent, and most `backward else` reports are secondary to
-later instruction, mask-domain or resource failures. Post-lift Wave32 carry, zero-record RAW-buffer and
-DPP-row fixes advance their exact targets while the gameplay 3D world remains black (#2481). See
+later instruction, mask-domain or resource failures. Post-lift Wave32 carry, zero-record RAW-buffer,
+full DPP add, VCC-mask/deadness, guest-coherence, FFBH, V_ALIGNBYTE, V_LDEXP_F32 and subword-BFREV
+fixes reduce the routed terminal-program set from 53 to 35 while the gameplay 3D world remains black
+(#2481). See
 `docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md` and
 `docs/RECOMPILER_REMAINING.md`, including each document's `## Ruled out` section, before extending
 the translator.

--- a/prosper/docs/ARCHITECTURE.md
+++ b/prosper/docs/ARCHITECTURE.md
@@ -89,10 +89,12 @@ dump is useful for proving that an instruction packet exists, but table-dependen
 unattributable without the real resource table. GTA V is tracked by routed terminal program address +
 instruction PC, not by raw structurizer line counts or adjacency in an interleaved stderr stream: the
 `structured emission stopped` family is consequent, and most `backward else` reports are secondary to
-later instruction, mask-domain or resource failures. Post-lift Wave32 carry, zero-record RAW-buffer,
-full DPP add, VCC-mask/deadness, guest-coherence, FFBH, V_ALIGNBYTE, V_LDEXP_F32 and subword-BFREV
-fixes reduce the routed terminal-program set from 53 to 35 while the gameplay 3D world remains black
-(#2481). See
+later instruction, mask-domain or resource failures. The reviewed post-lift stack now includes
+Wave32/64 mask and carry, scalar/vector/DPP coverage, guest coherence, zero-mip images, exact-wave
+barrier phasing and compact BVH nodes. On the 2026-08-11 gameplay-entry route the exact live set is 29
+recompile-empty plus 6 invalid-descriptor programs (35 unique), down from 39 in the preceding tagged
+sample with no new program failures; the 3D world remains black (#2481). Counts are route- and
+phase-specific, not title-wide totals. See
 `docs/GRAPHICS.md`, `docs/RESOURCE_BINDING.md` and
 `docs/RECOMPILER_REMAINING.md`, including each document's `## Ruled out` section, before extending
 the translator.

--- a/prosper/docs/FLAT_LOAD_DESIGN.md
+++ b/prosper/docs/FLAT_LOAD_DESIGN.md
@@ -1,10 +1,12 @@
 # General FLAT_LOAD design (#1171) — raw 64-bit-address memory reads in the compute recompiler
 
-**Status:** design / feasibility (2026-07-22). No implementation yet. Closing blocker for GTA V (PPSA04263)
-#1163/#1165 (loading-screen collage + missing legal text), whose content is produced by the rejected
-texture-decode compute kernel `exec_cs_2042d47600`.
+**Status:** implemented and regression-covered; retained as a historical design record (2026-07-22).
+The raw-address windowed load path described here removed the original GTA V (`PPSA04263`)
+`exec_cs_2042d47600` loading-screen blocker. It is not the current explanation for the black 3D world
+at gameplay entry; the runtime-selected descriptor lift is complete and current evidence is tracked
+by exact failed compute program in #2412/#2481.
 
-## The problem
+## The original problem
 
 A general FLAT load reads from a raw 64-bit guest GPU virtual address held in a VGPR pair. prosper's
 recompiler only models FLAT for the compiler's private scratch spill (a per-invocation `SC_Function`

--- a/prosper/docs/RECOMPILER_REMAINING.md
+++ b/prosper/docs/RECOMPILER_REMAINING.md
@@ -4,7 +4,8 @@
 > coverage boundary.** Later routed gameplay exercises a much larger dynamic compute set and still
 > exposes fail-visible instruction, resource and control-flow gaps. The program-tagged terminal census
 > and current fixes live in #2481; do not reuse this document's old conclusion that the recompiler was
-> "done for this title."
+> "done for this title." The 2026-08-11 gameplay-entry sample contains 29 recompile-empty programs and
+> 6 invalid-descriptor programs (35 unique); those route-specific live counts supersede this corpus.
 
 **Date:** 2026-07-06. **Status: ~93.7% instruction coverage in-context; 38 of 41 shaders fully recompile.**
 (The earlier "34/41" was a coverage-tool undercount — it ran a per-instruction check that didn't credit

--- a/prosper/docs/RECOMPILER_REMAINING.md
+++ b/prosper/docs/RECOMPILER_REMAINING.md
@@ -1,5 +1,11 @@
 # RDNA2→SPIR-V recompiler — remaining work
 
+> **Current note (2026-08-11): this is a historical 41-shader bring-up corpus, not the current GTA V
+> coverage boundary.** Later routed gameplay exercises a much larger dynamic compute set and still
+> exposes fail-visible instruction, resource and control-flow gaps. The program-tagged terminal census
+> and current fixes live in #2481; do not reuse this document's old conclusion that the recompiler was
+> "done for this title."
+
 **Date:** 2026-07-06. **Status: ~93.7% instruction coverage in-context; 38 of 41 shaders fully recompile.**
 (The earlier "34/41" was a coverage-tool undercount — it ran a per-instruction check that didn't credit
 `emit_body`'s loop/if reconstruction, so the MSAA-resolve loop shaders 031-034 were mis-flagged as blocked
@@ -59,8 +65,8 @@ in priority: (1) structured s_cbranch_scc0 → +4 shaders (biggest); (2) LDS wav
 (3) v_add_co_ci_u32 → correctness/coverage for address math (0 completions here). Coverage now 93.2%
 in-context (unsupported 107), 34/41 shaders.
 
-**The recompiler is DONE for this title.** Reaching the game's actual pixels is now gated on the GPU-
-execution / render-loop frontier (see `RENDER_LOOP.md`), not the recompiler.
+**Historical conclusion (superseded):** this corpus once suggested that the recompiler was done for
+the title. Routed gameplay later falsified that generalisation; see #2481 for the current dynamic set.
 
 ## How to eventually add the cross-lane wave ops (design note, 2026-07-06)
 The remaining shaders (030/037/038) need `v_mbcnt_lo/hi` (this lane's index among active lanes) and

--- a/prosper/docs/RESOURCE_BINDING.md
+++ b/prosper/docs/RESOURCE_BINDING.md
@@ -1,5 +1,11 @@
 # Resource binding — the front-half ↔ recompiler contract
 
+> **Current note (2026-08-11): the contract and its front-half materialization are implemented.** GTA V's
+> six-stage runtime-selected descriptor-array lift now covers capability negotiation, reflection,
+> SPIR-V indexing, descriptor layouts/writes and pipeline-cache identity. The black world at routed
+> gameplay entry persisted after that lift, so #2412/#2481 track the current exact compute terminals.
+> The staged plan below is retained to explain the contract, not as an open implementation checklist.
+
 **Purpose.** Unblock the format/descriptor-dependent shader memory instructions — `s_buffer_load_*`
 (multi-buffer uniforms), `buffer_load_format_*` (vertex fetch), and `image_sample`/`image_load`
 (textures) — *correctly*, without guessing formats. The seam is `src/gpu/shader_resources.hpp`.
@@ -104,25 +110,24 @@ lives front-half (it owns the descriptor bit layout); the recompiler only consum
   `v_interp_p1/p2/mov` → interpolated Input varying (deferred EntryPoint so varyings join the interface).
 - **`s_cbranch_execz` guard-to-`s_endpgm`** linearization; **SCC** (`s_cmp`/`s_cselect`).
 
-**Status:** the recompiler covers the full shape of a real textured, interpolated, buffer-reading/
-writing draw. The remaining gap to recompiling the game's *own* format-dependent shaders is not the
-recompiler — it is the **resource table**, which `build_shader_resources` (agc_shader_layout) can only
-fill from the shader's *bound user-data SGPRs* (V#/T#/S# descriptors), which the game sets at DRAW time.
-So it is gated on the game reaching draw submission = the parked GfxDevice boot wall (front-half). The
-table-less coverage metric (~74%) therefore *understates* real render-path coverage: every MIMG /
-`buffer_load_format` "blocker" it reports is a shape the recompiler already handles given a table.
+**Historical status at the end of the staged plan:** the recompiler covered the full shape of a real
+textured, interpolated, buffer-reading/writing draw, while the runtime resource-table producer was the
+next missing piece. That producer has since landed: graphics and compute discovery recover direct,
+indirect and runtime-selected V#/T#/S# descriptors, materialize their resources, and pass a reflected
+table to the recompiler. A raw table-less coverage metric still cannot classify a table-dependent
+instruction; use a live or resource-bearing replay result instead.
 
 Stage 2 was the high-value unlock (real VS recompile → real VS+PS frames from the game). Stages 1–3
 depend only on this contract + the front-half filling the table for constant/vertex buffers; stage 4
 adds textures.
 
-## Front-half deliverable (agent 2's next piece)
+## Historical front-half deliverable (implemented)
 
-`ShaderResourceTable build_shader_resources(const Shader& shdr)` (or equivalent): walk the shader's
-`user_data`/SRT, read each V#/T#/S# descriptor, decode `DataFormat`/dims/base/stride, assign bindings,
-and fill `srt_offset` with each descriptor's user_data byte offset. Provide the referenced guest
-bytes to the pipeline via `gpu_addr` (1:1-mapped, so it's a host pointer). No recompiler knowledge
-needed — just the descriptors → the table.
+The implemented producer walks the shader's `user_data`/SRT, reads each V#/T#/S# descriptor, decodes
+format/dimensions/base/stride, assigns bindings, and records the direct SGPR or indirect SRT provenance
+used by the instruction. It then makes the referenced guest bytes or image available to the backend
+and passes the resulting `ShaderResourceTable` into recompilation. Runtime-selected arrays extend this
+same contract with reflected descriptor count and dynamic-index metadata; they are not a parallel path.
 
 ## Ruled out
 

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -37,13 +37,17 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   submits continuously on Windows after the `%fs`/`%gs` null-read fix (#2447).
 - **Current graphics frontier:** GTA V's six-stage runtime-selected descriptor-array lift is complete. Live
   post-lift evidence on Linux/RADV and Windows/NVIDIA shows that the missing 3D world is not waiting on that lift.
-  The first routed terminal-program census on Linux found 53 static compute failures; reviewed Wave32 carry,
-  zero-record RAW-buffer and DPP-row lowering advances every targeted site and reduces that set to 49, but gameplay
-  still presents the HUD/radar over a fully black 3D world (#2412/#2481). The earlier "about 57 CFG sites" framing
-  overstated the independent control-flow work: `structured emission stopped` is a consequent wrapper, and most
-  `backward else` reports precede a later instruction, mask-domain or resource failure. Native subgroup adoption is
-  also a per-dispatch contract, not merely a device width: a quarter of routed wave64 compute dispatches on a
-  64-wide RADV device decline it because of workgroup shape (#2429).
+  The first routed terminal-program census on Linux found 53 static compute failures. Reviewed Wave32 carry,
+  zero-record RAW-buffer, full DPP add, VCC-mask/deadness, VOP3B arity, guest-coherence, FFBH, V_ALIGNBYTE,
+  V_LDEXP_F32 and subword-BFREV work reduces the same routed set to 35. The latest four-program recovery is
+  nevertheless a byte-identical visual negative (`crc=16af853b`): gameplay still presents the HUD/radar over a
+  fully black 3D world (#2412/#2481). The earlier "about 57 CFG sites" framing overstated the independent
+  control-flow work: `structured emission stopped` is a consequent wrapper, and most `backward else` reports
+  precede a later instruction, mask-domain or resource failure. Bare recompiler diagnostics can interleave, so
+  attribute a terminal only when the packet is present in that program's retained binary or the diagnostic carries
+  the program address; log adjacency is not evidence. Native subgroup adoption is also a per-dispatch contract,
+  not merely a device width: a quarter of routed wave64 compute dispatches on a 64-wide RADV device decline it
+  because of workgroup shape (#2429).
 - **Current Windows frontier:** routed Dragon Quest VII progression can fail a fixed `sceKernelBatchMap` with
   ENOMEM. UE4 then deliberately enters `LowLevelFatalError`; the resulting exit 139 is not a wild-pointer crash.
   The high-volume memory logger suppresses the timing-sensitive failure, so diagnosis is being carried on the

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -24,7 +24,7 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
 
 ---
 
-## Current status (2026-08-10) — at a glance
+## Current status (2026-08-11) — at a glance
 
 - **Compatibility breadth:** 39 title trackers cover Unity/IL2CPP, Unreal Engine, RAGE, Hedgehog Engine and
   custom engines. `COMPATIBILITY.md` is the user-facing milestone index; tracker issues and their comments are
@@ -36,10 +36,14 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   routed run reaches gameplay entry with the HUD visible over an absent 3D world. Dragon Quest VII boots and
   submits continuously on Windows after the `%fs`/`%gs` null-read fix (#2447).
 - **Current graphics frontier:** GTA V's six-stage runtime-selected descriptor-array lift is complete. Live
-  post-lift evidence on Linux/RADV and Windows/NVIDIA shows that the missing 3D world is not waiting on that lift;
-  the dominant measured gap is about 57 distinct compute CFG structurization sites (#2412/#2481). Native subgroup
-  adoption is a per-dispatch contract, not merely a device width: a quarter of routed wave64 compute dispatches on
-  a 64-wide RADV device decline it because of workgroup shape (#2429).
+  post-lift evidence on Linux/RADV and Windows/NVIDIA shows that the missing 3D world is not waiting on that lift.
+  The first routed terminal-program census on Linux found 53 static compute failures; reviewed Wave32 carry,
+  zero-record RAW-buffer and DPP-row lowering advances every targeted site and reduces that set to 49, but gameplay
+  still presents the HUD/radar over a fully black 3D world (#2412/#2481). The earlier "about 57 CFG sites" framing
+  overstated the independent control-flow work: `structured emission stopped` is a consequent wrapper, and most
+  `backward else` reports precede a later instruction, mask-domain or resource failure. Native subgroup adoption is
+  also a per-dispatch contract, not merely a device width: a quarter of routed wave64 compute dispatches on a
+  64-wide RADV device decline it because of workgroup shape (#2429).
 - **Current Windows frontier:** routed Dragon Quest VII progression can fail a fixed `sceKernelBatchMap` with
   ENOMEM. UE4 then deliberately enters `LowLevelFatalError`; the resulting exit 139 is not a wild-pointer crash.
   The high-volume memory logger suppresses the timing-sensitive failure, so diagnosis is being carried on the

--- a/prosper/docs/ROADMAP.md
+++ b/prosper/docs/ROADMAP.md
@@ -37,17 +37,20 @@ presented, framebuffer CRC == golden" is. Each change adds the check that proves
   submits continuously on Windows after the `%fs`/`%gs` null-read fix (#2447).
 - **Current graphics frontier:** GTA V's six-stage runtime-selected descriptor-array lift is complete. Live
   post-lift evidence on Linux/RADV and Windows/NVIDIA shows that the missing 3D world is not waiting on that lift.
-  The first routed terminal-program census on Linux found 53 static compute failures. Reviewed Wave32 carry,
-  zero-record RAW-buffer, full DPP add, VCC-mask/deadness, VOP3B arity, guest-coherence, FFBH, V_ALIGNBYTE,
-  V_LDEXP_F32 and subword-BFREV work reduces the same routed set to 35. The latest four-program recovery is
-  nevertheless a byte-identical visual negative (`crc=16af853b`): gameplay still presents the HUD/radar over a
-  fully black 3D world (#2412/#2481). The earlier "about 57 CFG sites" framing overstated the independent
+  The first routed terminal-program census on Linux found 53 static compute failures. Reviewed Wave32/64
+  mask and carry work, DPP/VALU/SOP coverage, guest coherence, descriptor recovery, exact-wave barrier
+  phasing, compact BVH nodes and proved zero-mip image operations reduce the latest tagged sample to 29
+  recompile-empty programs plus 6 invalid-descriptor programs, a 35-program union. Against the immediately
+  preceding routed sample that is 39 -> 35, with four old-only and no new program failures. The visual result
+  is still negative (`crc=d8cc4a44`): gameplay presents populated radar/tutorial UI over a fully black 3D
+  world (#2412/#2481). The earlier "about 57 CFG sites" framing overstated the independent
   control-flow work: `structured emission stopped` is a consequent wrapper, and most `backward else` reports
   precede a later instruction, mask-domain or resource failure. Bare recompiler diagnostics can interleave, so
   attribute a terminal only when the packet is present in that program's retained binary or the diagnostic carries
   the program address; log adjacency is not evidence. Native subgroup adoption is also a per-dispatch contract,
   not merely a device width: a quarter of routed wave64 compute dispatches on a 64-wide RADV device decline it
-  because of workgroup shape (#2429).
+  because of workgroup shape (#2429). These counts describe the checked-in route at gameplay entry on
+  2026-08-11; they are not title-wide totals.
 - **Current Windows frontier:** routed Dragon Quest VII progression can fail a fixed `sceKernelBatchMap` with
   ENOMEM. UE4 then deliberately enters `LowLevelFatalError`; the resulting exit 139 is not a wild-pointer crash.
   The high-volume memory logger suppresses the timing-sensitive failure, so diagnosis is being carried on the

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4189,7 +4189,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 return false;
         }
     }
-    if (descriptors.empty() && image_descriptors.empty()) return false;
+    // A compute program whose every external RAW access was proven NUM_RECORDS=0 contains no
+    // storage/image operation after recompilation. Treat that exact runtime contract as a successful
+    // no-op: reporting failure here would publish an unknown authority boundary and poison later
+    // producer ordering even though the guest operation completed architecturally. Keep the proof
+    // deliberately stronger than merely "descriptorless SPIR-V": the table must be nonempty and every
+    // entry must be the exact-PC marker produced by add_compute_buffer_resources.
+    const bool all_zero_record_raw_noop = descriptors.empty() && image_descriptors.empty() &&
+        item.resources && !item.resources->resources.empty() &&
+        std::all_of(item.resources->resources.begin(), item.resources->resources.end(),
+                    is_zero_record_raw_buffer);
+    if (descriptors.empty() && image_descriptors.empty() && !all_zero_record_raw_noop)
+        return false;
     const bool has_storage_images = std::any_of(
         image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
             return descriptor.kind == SpirvDescriptorKind::StorageImage;
@@ -4234,6 +4245,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     const bool phase_timing =
         phase_timing_requested && timing_item_selected &&
         (!timing_trace_only || trace);
+    // Keep timing selection and the transfer/authority censuses above this return so investigations
+    // still observe the proven no-op program. No Vulkan objects or queue submission are needed.
+    if (all_zero_record_raw_noop) {
+        if (trace)
+            std::fprintf(stderr,
+                         "[compute] program 0x%llx has only zero-record RAW resources -> no-op\n",
+                         static_cast<unsigned long long>(item.code_addr));
+        return true;
+    }
     if (has_storage_images && !ctx.image_support) {
         static bool warned = false;
         if (!warned) { warned = true;

--- a/prosper/scripts/gta5/reach-story-mode.pad
+++ b/prosper/scripts/gta5/reach-story-mode.pad
@@ -1,4 +1,4 @@
-# Grand Theft Auto V (PPSA04263, RAGE) — Windows lane. Reach Story Mode gameplay.
+# Grand Theft Auto V (PPSA04263, RAGE) — Linux/Windows route to Story Mode gameplay.
 #
 # Route, established by capture rather than assumed:
 #   boot -> "Continue" title card -> main menu, which opens on the ONLINE tab.
@@ -57,58 +57,17 @@ f5200-5220:cross
 f5600-5620:cross
 f6000-6020:cross
 
-# --- WHAT THIS ROUTE REACHES TODAY, and where it stops ------------------------------------------
+# --- WHAT THIS ROUTE REACHES TODAY --------------------------------------------------------------
 #
-# Verified on Windows with #2390 + #2394: this drives the title through
-#     "Continue" title card -> main menu (opens on ONLINE) -> R1, R1 -> STORY tab
-# all rendering at 4K. Capture 12 of the run (frame 2831, t=156.1 s) shows the STORY tab selected
-# with the Franklin key art, the "GRAND THEFT AUTO V STORY MODE" blurb, and the "Resume Story"
-# prompt.
+# Verified on Linux/RADV on 2026-08-11 (#2481): the route drives the title through the Continue card,
+# ONLINE/GTA+/STORY navigation and Resume Story into gameplay. A frame captured after the route at
+# frame 6281 shows the in-world radar and the tutorial text "The Radar shows your position within the
+# world." The 3D world is still black, which is a renderer/recompiler frontier rather than a route
+# uncertainty. The run exited normally with no device loss.
 #
-# 2026-08-10 -- the segfault below DID NOT REPRODUCE in 1 of 1 runs on master a6043524 (Windows,
-# RTX 4090): this route ran 200 s to frame 3805, exit 0, with presses delivered at t=142.1 s (f3000),
-# 161.7 s (f3300) and 186.0 s (f3600) -- straight through the t~158-190 s window named below -- and no
-# crash of any kind.
-#
-# That is ONE observation, and the crash's frequency beforehand was never characterised, so treat this
-# route as UNVERIFIED rather than fixed. A single clean pass cannot distinguish "fixed" from
-# "intermittent and did not fire this time", and run-to-run variation here is large enough to matter:
-# DQ reaches pad polling roughly 1 boot in 11, and frame and draw counts vary more than 2x between runs
-# of one binary (#2459). Do NOT read this as evidence that a merged change fixed it -- nothing here
-# identifies a fix, and no run below establishes the crash was deterministic to begin with.
-#
-# The historical note is kept because the conclusion it draws ("a working route to the STORY tab and
-# NOT yet a route to gameplay") is what a reader would otherwise act on, and one clean pass through the
-# window is reason to RETRY the route rather than to abandon it.
-#
-# What is NOT established by that run, and the FIRST item is the one that weakens it most:
-#
-#   * It does not establish that the run ever ENTERED Story Mode. The presses cover t~158-190 s in
-#     TIME, which is not the same as reaching the state that crashed. The four-R1 note above records
-#     exactly how this fails: in one run only one of two R1 presses registered, the menu stayed on
-#     GTA+, and the following Cross entered GTA+ instead of STORY. A run parked on the wrong tab
-#     completes 200 s cleanly for reasons that have nothing to do with the segfault. No frame from
-#     this run was inspected to confirm the tab or the transition, so the honest reading is weaker
-#     than "1 of 1": it is ONE run, with no crash, whose entry into the crashing state is unverified.
-#     A re-run must confirm the tab it landed on -- not merely that it covered the window.
-#   * It does not establish that the WORLD renders. The run ends before the route's trailing pulses
-#     (f4000-f6000) and no frame was inspected for scene content, so "does not crash" is the claim,
-#     not "reaches gameplay". Draws per frame did rise from 7.6 (no route, 90 s) to 30.0 on this run,
-#     which is consistent with heavier content but proves nothing on its own.
-#
-# --- historical, kept for the record ---------------------------------------------------------------
-# The process then SEGFAULTS shortly after the f3000 Cross that enters Story Mode, at t~158-190 s.
-# The fault produces NO [veh] record and no fault address, which is itself informative: the Windows
-# VEH logger sees nothing, so this is not a guest-code access violation of the kind that stopped the
-# three earlier walls. It is a host-side crash, and it needs a different instrument than the ones
-# that found those.
-#
-# So (HISTORICAL): this file is a working route to the STORY tab and NOT yet a route to gameplay. Do not
-# read the trailing Cross pulses as evidence they land on anything.
-#
-# CURRENT: the crash did not reproduce in one run (see the note at the top of this block) -- unverified,
-# not fixed. The trailing pulses still have no verified effect -- that part stands until someone
-# inspects a frame.
+# Earlier Windows captures established the same menu navigation at native 4K. A historical host-side
+# segfault near Story entry subsequently failed to reproduce; it no longer limits what this route can
+# claim because the later Linux run positively identified gameplay-only UI in the captured frame.
 #
 # Two smaller observations from the same captures, recorded because they are cheap to lose:
 #   * The bottom-right prompt renders as "Re u e Sto y" — glyph dropouts in "Resume Story". The

--- a/prosper/scripts/gta5/reach-story-mode.pad
+++ b/prosper/scripts/gta5/reach-story-mode.pad
@@ -60,8 +60,8 @@ f6000-6020:cross
 # --- WHAT THIS ROUTE REACHES TODAY --------------------------------------------------------------
 #
 # Verified on Linux/RADV on 2026-08-11 (#2481): the route drives the title through the Continue card,
-# ONLINE/GTA+/STORY navigation and Resume Story into gameplay. A frame captured after the route at
-# frame 6281 shows the in-world radar and the tutorial text "The Radar shows your position within the
+# ONLINE/GTA+/STORY navigation and Resume Story into gameplay. A fixed 165-second capture at frame
+# 5597 shows the in-world radar and the tutorial text "The Radar shows your position within the
 # world." The 3D world is still black, which is a renderer/recompiler frontier rather than a route
 # uncertainty. The run exited normally with no device loss.
 #

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -110,7 +110,8 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v46 (#1853): retain the selected direct V#'s four raw stage USER_DATA dwords and each dword's
 // PM4 last-write provenance. Replay decodes this input independently and compares it with the v45
 // normalized descriptor; unsupported/ambiguous paths are recorded as explicitly unavailable.
-constexpr uint32_t kVersion = 46;
+// v47 (#2481): retain each realized/failed-stage image resource's instruction-scoped zero-mip proof.
+constexpr uint32_t kVersion = 47;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -2684,6 +2685,23 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         for (const uint64_t write : provenance.input_last_writes) w.u64(write);
         for (const uint64_t source : provenance.input_write_sources) w.u64(source);
     }
+    // v47 preserves the instruction-scoped zero-mip specialization marker for every realized and
+    // failed-stage resource. Raw replay can recompile captured RDNA2, so omitting this bit would let
+    // it silently reuse the level-zero lowering for an instruction whose mip value was never proven.
+    // Keep the same complete resource enumeration as v44's sample-count tail.
+    w.u32(static_cast<uint32_t>(sample_resource_count));
+    auto write_zero_mip_state = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources)
+            w.u8(captured.resource.proven_zero_mip ? 1u : 0u);
+    };
+    for (const auto& draw : c.draws) {
+        write_zero_mip_state(draw.vrt);
+        write_zero_mip_state(draw.prt);
+    }
+    for (const auto& compute : c.computes) write_zero_mip_state(compute.resources);
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            write_zero_mip_state(stage.resource_table);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3791,6 +3809,45 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             for (auto& source : provenance.input_write_sources) if (!r.u64(source)) return false;
         }
         if (!validate_resource_provenance(c, error)) return false;
+    }
+    if (version >= 47) {
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        for (const auto& diagnostic : c.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                expected += stage.resource_table.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid resource zero-mip state count";
+            return false;
+        }
+        auto read_zero_mip_state = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                uint8_t proven = 0;
+                if (!r.u8(proven) || proven > 1u) return false;
+                captured.resource.proven_zero_mip = proven != 0;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_zero_mip_state(draw.vrt) || !read_zero_mip_state(draw.prt)) {
+                error = "invalid resource zero-mip state";
+                return false;
+            }
+        for (auto& compute : c.computes)
+            if (!read_zero_mip_state(compute.resources)) {
+                error = "invalid resource zero-mip state";
+                return false;
+            }
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_zero_mip_state(stage.resource_table)) {
+                    error = "invalid resource zero-mip state";
+                    return false;
+                }
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -227,13 +227,25 @@ struct SrtUse {
     // has no usable key; keying the TEXTURE use by its exact instruction (ShaderResource::fetch_pc,
     // the same per-instruction provenance the vertex fetches use) is unambiguous.
     uint32_t use_pc = 0xFFFFFFFFu;   // exact consuming pc for key-less texture/buffer uses
-    // The consuming image op requires a STORAGE image (image_store 0x08 or an image atomic such as
-    // IMAGE_ATOMIC_SWAP 0x0f), not a sampled texture. Only meaningful for kind 0.
+    // The consuming image op requires a STORAGE image (image_store 0x08, image_store_mip 0x09, or
+    // an image atomic such as IMAGE_ATOMIC_SWAP 0x0f), not a sampled texture. Only meaningful for
+    // kind 0.
     bool is_storage_image = false;
+    // IMAGE_LOAD_MIP / IMAGE_STORE_MIP have one more address operand than their base-level
+    // siblings. The current Vulkan compute backend materializes one mip only, so the fold may
+    // specialize that operand away only after proving its exact VGPR was written in the same basic
+    // block by a plain v_mov_b32 from a known-zero wave-uniform SGPR.
+    bool proven_zero_mip = false;
     // The consuming MIMG opcode is a comparison/depth sample (IMAGE_SAMPLE_C*). This is a
     // property of the use, not merely the S# compare function: NEVER is a valid compare op.
     bool is_depth_compare = false;
 };
+
+// Materialization half of the IMAGE_*_MIP specialization contract. Kept observable so regression
+// tests can mutate the exact DCC/single-level gate used by live resource construction.
+bool shader_resource_allows_zero_mip_specialization(
+    const SrtUse& use, const DecodedImageDescriptor& descriptor,
+    const DecodedImageView& view);
 std::vector<DynFetch> resolve_dynamic_fetch(const uint32_t* code, size_t dwords,
                                             const uint32_t* user_sgprs, uint32_t nsgpr,
                                             uint32_t user_sgpr_base,

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -445,6 +445,9 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     const uint32_t* code, size_t dwords, const ShaderResourceTable* resources,
     const ComputeShaderConfig& config, uint64_t* cache_identity = nullptr,
     RecompileDiagnosticContext diagnostic = {RecompileDiagnosticStage::Compute, 0});
+// Report the final live consequence once per guest program address. Returns true only for the first
+// report so the caller can keep its adjacent resource-table dump on the same distinct-address gate.
+bool report_compute_recompile_skip_once(RecompileDiagnosticContext diagnostic);
 SharedShaderWords recompile_vertex_chain_cached_shared(
     const uint32_t* prolog, size_t prolog_dwords,
     const uint32_t* main, size_t main_dwords,

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -210,6 +210,11 @@ struct SrtUse {
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
+    // Fully-known RAW MUBUF V# whose NUM_RECORDS is zero. This is distinct from the scalar-SMEM
+    // raw-pointer convention, where a zero decoded size means "unbounded" and required_size supplies
+    // the proven access span. Only resolve_dynamic_fetch may set this after decoding all four live
+    // descriptor words at the exact consuming instruction.
+    bool zero_record_raw = false;
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)
     // Minimum byte span needed by this scalar-buffer consumer, measured from V#.Base. Some PS5

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -443,7 +443,8 @@ SharedShaderWords recompile_graphics_shader_cached_shared(
 // generated SPIR-V participates in the key; per-dispatch push-constant values deliberately do not.
 std::vector<uint32_t> recompile_compute_shader_cached(
     const uint32_t* code, size_t dwords, const ShaderResourceTable* resources,
-    const ComputeShaderConfig& config, uint64_t* cache_identity = nullptr);
+    const ComputeShaderConfig& config, uint64_t* cache_identity = nullptr,
+    RecompileDiagnosticContext diagnostic = {RecompileDiagnosticStage::Compute, 0});
 SharedShaderWords recompile_vertex_chain_cached_shared(
     const uint32_t* prolog, size_t prolog_dwords,
     const uint32_t* main, size_t main_dwords,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3403,7 +3403,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     ((in.opcode >= 0x08 && in.opcode <= 0x0F) ||
                      (in.opcode >= 0x1C && in.opcode <= 0x1F));
                 const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
-                const bool atomic_buffer_use = in.opcode == 0x38; // buffer_atomic_umax
+                // Keep this exact set aligned with the 32-bit RMW opcodes the SPIR-V emitter lowers.
+                // The holes are not aliases: cmp-swap/csub/inc/dec and the x2 family need different
+                // operand/result semantics and must remain fail-closed until those are implemented.
+                const bool atomic_buffer_use =
+                    in.opcode == 0x30 || in.opcode == 0x32 || in.opcode == 0x33 ||
+                    (in.opcode >= 0x35 && in.opcode <= 0x3B);
                 if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {
                     const int srsrc = in.src[1].value;
                     std::array<uint32_t, 4> current{};

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2583,10 +2583,25 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             }
         }
         if (in.dst.kind == OperandKind::VGPR && in.dst.value >= 0) {
-            // Four is the largest ordinary vector payload retained by this fold. Clearing an extra
-            // bit for a scalar result only makes the proof decline; it cannot manufacture one.
-            for (int reg = in.dst.value; reg < in.dst.value + 4 && reg < 256; ++reg)
-                same_block_zero_vgprs.reset(static_cast<size_t>(reg));
+            // Invalidate the exact decoded result range. GTA V writes v0 between its v2=zero
+            // definition and IMAGE_LOAD_MIP; treating that scalar VOP2 as a four-dword memory
+            // payload erased the unrelated live mip proof. Wide MIMG/buffer/VALU results still
+            // clear every register in their shared audited result-width inventory.
+            if (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x42u) {
+                // v_movreld_b32 writes VGPR[VDST+M0]. M0 is not tracked by this proof, so no
+                // individual zero fact is safe across the dynamic destination write. Keep this
+                // separate from the consecutive-width inventory; CFG phi discovery models the
+                // same instruction dynamically through loop_written_regs.
+                same_block_zero_vgprs.reset();
+            } else {
+                const uint32_t write_count = rdna2_vgpr_write_count(in);
+                for (int reg = in.dst.value;
+                     reg < in.dst.value + static_cast<int>(write_count) && reg < 256; ++reg)
+                    same_block_zero_vgprs.reset(static_cast<size_t>(reg));
+                const int tfe_status = rdna2_tfe_status_vgpr(in);
+                if (tfe_status >= 0 && tfe_status < 256)
+                    same_block_zero_vgprs.reset(static_cast<size_t>(tfe_status));
+            }
         }
         if (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x01u &&
             in.len_dwords == 1u && !in.has_modifier &&

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1467,7 +1467,8 @@ std::vector<uint32_t> recompile_graphics_shader_cached(
 
 std::vector<uint32_t> recompile_compute_shader_cached(
         const uint32_t* code, size_t dwords, const ShaderResourceTable* resources,
-        const ComputeShaderConfig& config, uint64_t* cache_identity) {
+        const ComputeShaderConfig& config, uint64_t* cache_identity,
+        RecompileDiagnosticContext diagnostic) {
     if (cache_identity) *cache_identity = 0;
     ShaderCompileKey key = make_shader_compile_key(
         ShaderProgramStage::Compute, code, dwords, resources, nullptr, nullptr,
@@ -1475,7 +1476,7 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     auto compile = [&] {
         const uint32_t* owned_code = !key.code || key.code->empty() ? nullptr : key.code->data();
         const size_t owned_dwords = key.code ? key.code->size() : 0u;
-        return recompile_compute(owned_code, owned_dwords, resources, config);
+        return recompile_compute(owned_code, owned_dwords, resources, config, diagnostic);
     };
     if (getenv("PROSPER_NO_SHADER_CACHE")) {
         auto& cache = shader_cache();
@@ -5482,6 +5483,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
             }
         }
         bool native_multiwave_wave_work = false;
+        const RecompileDiagnosticContext recompile_diagnostic{
+            RecompileDiagnosticStage::Compute, code_addr};
         {
             std::vector<Rdna2Inst> decoded;
             rdna2_walk(reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
@@ -5511,7 +5514,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
             assign_convention_bindings(*table, 2);
             native_multiwave_wave_work = compute_shader_prefers_native_multiwave(
                 decoded, reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
-                shader_dwords);
+                shader_dwords, recompile_diagnostic);
             const bool uses_gds = std::any_of(decoded.begin(), decoded.end(), [](const auto& in) {
                 return in.fmt == Rdna2Format::DS && in.ds_gds &&
                        (in.opcode == 0x0d || in.opcode == 0x3d || in.opcode == 0x3e);
@@ -5632,7 +5635,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
 
         ComputeItem item;
         item.spirv = recompile_compute_shader_cached(
-            (const uint32_t*)(uintptr_t)code_addr, 0x10000, table.get(), config);
+            (const uint32_t*)(uintptr_t)code_addr, 0x10000, table.get(), config, nullptr,
+            recompile_diagnostic);
         item.user_sgprs = config.user_sgprs;
         item.required_subgroup_size = config.native_subgroup_size;
         item.cpu_fast_path = classify_compute_cpu_fast_path(

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -293,6 +293,7 @@ struct ShaderResourceCompileKey {
     uint32_t flat_base_sgpr = 0;
     uint32_t bvh_box_grow = 0;
     bool null_bvh = false;
+    bool zero_record_raw = false;
     bool srgb = false;
     bool depth_compare = false;
     uint32_t depth_compare_func = 0;
@@ -475,6 +476,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.flat_base_sgpr);
             hash = hash_mix(hash, resource.bvh_box_grow);
             hash = hash_mix(hash, resource.null_bvh);
+            hash = hash_mix(hash, resource.zero_record_raw);
             hash = hash_mix(hash, resource.srgb);
             hash = hash_mix(hash, resource.depth_compare);
             hash = hash_mix(hash, resource.depth_compare_func);
@@ -1172,6 +1174,10 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.flat_base_sgpr = resource.flat_base_sgpr;
             compiled.bvh_box_grow = resource.bvh_box_grow;
             compiled.null_bvh = is_proven_null_bvh(resource);
+            // gpu_addr/size intentionally stay out of the module key, but this semantic is compiled
+            // into zero-producing/no-op instructions. Partition exactly this proven marker so a
+            // later nonzero descriptor at the same pc cannot reuse the specialized module.
+            compiled.zero_record_raw = is_zero_record_raw_buffer(resource);
             compiled.srgb = storage_image && resource.srgb;
             compiled.depth_compare = (manual_compare || storage_image) && resource.depth_compare;
             compiled.depth_compare_func = manual_compare ? resource.depth_compare_func : 0u;
@@ -3481,13 +3487,21 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
                         // Typed format stores retain the strided record requirement.
                         const bool stride_supported = !format_store_use || d.stride != 0;
-                        if (d.base > 0x10000 && d.size_bytes != 0 &&
-                            d.size_bytes <= 0x10000000u && stride_supported && format_supported) {
+                        // A fully-known RAW MUBUF with NUM_RECORDS=0 is not a missing descriptor:
+                        // hardware returns zero for loads and drops stores. Preserve that proof at
+                        // this exact consumer pc, but do not generalize it to MTBUF, format stores,
+                        // atomics, or an addr0 descriptor with nonzero records.
+                        const bool zero_record_raw = raw_buffer_use && d.num_records == 0u &&
+                                                     d.size_bytes == 0u;
+                        if (zero_record_raw ||
+                            (d.base > 0x10000 && d.size_bytes != 0 &&
+                             d.size_bytes <= 0x10000000u && stride_supported && format_supported)) {
+                            u.zero_record_raw = zero_record_raw;
                             if (trc) fprintf(stderr,
                                              "[dyntrace] MUBUF pc=%u live V# s%d base=0x%llx "
-                                             "stride=%u size=%u\n",
+                                             "stride=%u size=%u zero-record=%d\n",
                                              in.pc, srsrc, (unsigned long long)d.base,
-                                             d.stride, d.size_bytes);
+                                             d.stride, d.size_bytes, (int)zero_record_raw);
                             srt_uses->push_back(u);
                         }
                     }
@@ -3931,6 +3945,26 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 if (r0.srt_offset == u.key) { clash = true; break; }
 
         const DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+        if (u.zero_record_raw) {
+            // Re-check the producer's proof at materialization so a malformed/manually-constructed
+            // SrtUse cannot manufacture zero semantics. The resource deliberately carries only
+            // exact-PC identity; the emitter never accesses its assigned dummy binding.
+            if (u.instruction_format != UINT32_MAX || d.num_records != 0u ||
+                d.size_bytes != 0u || u.required_size != 0u)
+                continue;
+            ShaderResource r;
+            r.cls = ResourceClass::ConstantBuffer;
+            r.format = DataFormat::Unknown;
+            r.num_components = 0;
+            r.gpu_addr = 0;
+            r.size = 0;
+            r.stride = 0;
+            r.srt_offset = 0xFFFFFFFFu;
+            r.sgpr_base = 0xFFFFFFFFu;
+            r.fetch_pc = u.use_pc;
+            table.resources.push_back(r);
+            continue;
+        }
         if (d.base <= 0x10000 || d.size_bytes > 0x10000000u) continue;
         // A scalar consumer whose base is a RAW POINTER has no bounded V# size to report, so
         // `size_bytes == 0` here means "unbounded", not "empty" (#2412). The graphics builder already

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -281,8 +281,10 @@ struct ShaderResourceCompileKey {
     uint32_t depth = 0;
     uint32_t img_dim = 0;
     uint32_t sample_count = 1;
+    uint32_t declared_mip_levels = 1;
     bool in_mip_tail = false;
     bool compression_enabled = false;
+    bool proven_zero_mip = false;
     uint32_t binding = 0;
     uint32_t stride = 0;
     uint32_t one_record_tail_semantic = 0;
@@ -464,8 +466,10 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.depth);
             hash = hash_mix(hash, resource.img_dim);
             hash = hash_mix(hash, resource.sample_count);
+            hash = hash_mix(hash, resource.declared_mip_levels);
             hash = hash_mix(hash, resource.in_mip_tail);
             hash = hash_mix(hash, resource.compression_enabled);
+            hash = hash_mix(hash, resource.proven_zero_mip);
             hash = hash_mix(hash, resource.binding);
             hash = hash_mix(hash, resource.stride);
             hash = hash_mix(hash, resource.one_record_tail_semantic);
@@ -727,11 +731,15 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
         // retain their spill VGPR writes too, so an ordinary VGPR write invalidates any saved lane values.
         std::set<int> scalar_spill_vgprs;
         std::set<int> fetch_vaddr_vgprs;
+        std::set<int> zero_mip_vgprs;
         for (const Rdna2Inst& instruction : decoded) {
             if ((instruction.fmt == Rdna2Format::MUBUF ||
                  instruction.fmt == Rdna2Format::MTBUF) &&
                 instruction.src[0].kind == OperandKind::VGPR)
                 fetch_vaddr_vgprs.insert(instruction.src[0].value);
+            uint32_t mip_vgpr = 0;
+            if (rdna2_mimg_zero_mip_shape(instruction, &mip_vgpr))
+                zero_mip_vgprs.insert(static_cast<int>(mip_vgpr));
             if (instruction.fmt == Rdna2Format::VOP3) {
                 if (instruction.opcode == 0x361 && instruction.dst.kind == OperandKind::VGPR)
                     scalar_spill_vgprs.insert(instruction.dst.value);       // v_writelane_b32
@@ -760,6 +768,23 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
                                                fetch_vaddr_vgprs.contains(instruction.dst.value);
                 const bool scalar_spill_invalidation = instruction.dst.kind == OperandKind::VGPR &&
                                                        scalar_spill_vgprs.contains(instruction.dst.value);
+                // The zero-mip proof needs the unambiguous reaching definition of one exact address
+                // VGPR. Retain every possible writer whose (at most four-dword) result overlaps it;
+                // false-positive retention is cheap, while dropping one would accept a stale v_mov.
+                bool zero_mip_write = false;
+                if (instruction.dst.kind == OperandKind::VGPR) {
+                    for (int reg : zero_mip_vgprs)
+                        if (instruction.dst.value <= reg && instruction.dst.value + 3 >= reg) {
+                            zero_mip_write = true;
+                            break;
+                        }
+                }
+                const bool zero_mip_definition = zero_mip_write &&
+                    instruction.fmt == Rdna2Format::VOP1 && instruction.opcode == 0x01u &&
+                    instruction.len_dwords == 1u && !instruction.has_modifier &&
+                    instruction.src[0].kind == OperandKind::SGPR;
+                const bool zero_mip_intervening_write =
+                    zero_mip_write && !zero_mip_definition;
                 const bool fold_format = instruction.fmt == Rdna2Format::SOP1 ||
                                          instruction.fmt == Rdna2Format::SOP2 ||
                                          instruction.fmt == Rdna2Format::SOPC ||
@@ -769,8 +794,11 @@ std::shared_ptr<const DecodedShader> decode_shader_cached(const uint32_t* code, 
                                          instruction.fmt == Rdna2Format::MIMG ||
                                          instruction.fmt == Rdna2Format::MUBUF ||
                                          instruction.fmt == Rdna2Format::MTBUF;
-                if (fold_format || scalar_spill || vector_index_select || fetch_vaddr_write ||
-                    scalar_spill_invalidation || instruction.dst.kind == OperandKind::SGPR)
+                if (fold_format || rdna2_instruction_may_change_exec(instruction) ||
+                    scalar_spill || vector_index_select || fetch_vaddr_write ||
+                    scalar_spill_invalidation || zero_mip_definition ||
+                    zero_mip_intervening_write ||
+                    instruction.dst.kind == OperandKind::SGPR)
                     retained.push_back(instruction);
             }
         };
@@ -1155,8 +1183,12 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.depth = (storage_image || normalize_unnormalized) ? resource.depth : 0u;
             compiled.img_dim = (texture || storage_image) ? resource.img_dim : 0u;
             compiled.sample_count = (texture || storage_image) ? resource.sample_count : 1u;
-            compiled.in_mip_tail = storage_image && resource.in_mip_tail;
-            compiled.compression_enabled = storage_image && resource.compression_enabled;
+            compiled.declared_mip_levels = (texture || storage_image)
+                ? resource.declared_mip_levels : 1u;
+            compiled.in_mip_tail = (texture || storage_image) && resource.in_mip_tail;
+            compiled.compression_enabled =
+                (texture || storage_image) && resource.compression_enabled;
+            compiled.proven_zero_mip = (texture || storage_image) && resource.proven_zero_mip;
             compiled.binding = resource.binding;
             compiled.stride = resource.stride;
             const bool one_record_tail = resource.num_components == 1u &&
@@ -1931,18 +1963,6 @@ bool has_indirect_control_flow(const std::vector<Rdna2Inst>& instructions) {
 }
 
 bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc) {
-    auto changes_exec = [](const Rdna2Inst& in) {
-        // Every v_cmpx writes EXEC. This listed three of the six windows, so a cmpx from
-        // 0x30-0x3f / 0xb0-0xbe / 0xf0-0xff read as NOT touching EXEC and the dominance proof
-        // below could accept a region whose guard it had mis-located. Use the shared predicate so
-        // this cannot drift from the decoder again (#2120).
-        if (in.fmt == Rdna2Format::VOPC)
-            return vopc_is_cmpx(in.opcode);
-        return in.fmt == Rdna2Format::SOP1 &&
-               ((in.opcode >= 0x24 && in.opcode <= 0x2b) ||
-                in.opcode == 0x37 || in.opcode == 0x38 ||
-                in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44);
-    };
     const auto& is_branch = sopp_is_branch;
     const auto& target = sopp_branch_target;
 
@@ -1957,7 +1977,7 @@ bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc
         const uint32_t merge = static_cast<uint32_t>(merge64);
         const Rdna2Inst& exec_writer = instructions[i - 1];
         if (exec_writer.pc + exec_writer.len_dwords != guard.pc ||
-            !changes_exec(exec_writer))
+            !rdna2_instruction_may_change_exec(exec_writer))
             continue;
         if (std::none_of(instructions.begin(), instructions.end(),
                          [&](const Rdna2Inst& in) { return in.pc == merge; }))
@@ -2450,11 +2470,59 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         return FoldMask::Unknown;
     };
 
-    for (const auto& in : ins) {
+    // A zero mip is useful only when it is a property of the exact use, not a global VGPR guess.
+    // Track plain scalar-to-vector zero moves inside one basic block and clear the proof on every
+    // block boundary or possible overlapping write. Branch targets and branch fall-throughs both
+    // begin blocks; indirect control flow makes this finite edge inventory incomplete and disables
+    // the proof for the whole program. Any EXEC writer also disables later proofs globally: without
+    // a mask dataflow model, a subsequent v_mov may still execute on only a subset of lanes.
+    const bool zero_mip_cfg_known = !has_indirect_control_flow(ins);
+    std::set<uint32_t> zero_mip_block_starts;
+    if (!ins.empty()) zero_mip_block_starts.insert(ins.front().pc);
+    if (zero_mip_cfg_known) {
+        for (const Rdna2Inst& candidate : ins) {
+            if (!sopp_is_branch(candidate)) continue;
+            const int64_t target = sopp_branch_target(candidate);
+            if (target >= 0 && target <= static_cast<int64_t>(UINT32_MAX))
+                zero_mip_block_starts.insert(static_cast<uint32_t>(target));
+            zero_mip_block_starts.insert(candidate.pc + candidate.len_dwords);
+        }
+    }
+    std::bitset<256> same_block_zero_vgprs;
+    uint32_t current_zero_mip_block = UINT32_MAX;
+    bool zero_mip_exec_pristine = true;
+
+    for (size_t instruction_index = 0; instruction_index < ins.size(); ++instruction_index) {
+        const auto& in = ins[instruction_index];
         watch_pc = in.pc;
         watch_w0 = in.words[0]; watch_w1 = in.len_dwords > 1 ? in.words[1] : 0u;
         watch_len = in.len_dwords;
         if (in.is_end) break;
+        uint32_t zero_mip_block = UINT32_MAX;
+        if (zero_mip_cfg_known) {
+            // The retained fold stream may omit the first physical instruction of a block (EXP is
+            // a common example). Classify by the greatest start not after this PC instead of
+            // waiting to observe the start itself, or a pre-branch proof could leak across a block
+            // whose first instruction was compacted out.
+            auto block = zero_mip_block_starts.upper_bound(in.pc);
+            if (block != zero_mip_block_starts.begin())
+                zero_mip_block = *std::prev(block);
+        }
+        if (!zero_mip_cfg_known ||
+            (instruction_index != 0 && zero_mip_block != current_zero_mip_block))
+            same_block_zero_vgprs.reset();
+        current_zero_mip_block = zero_mip_block;
+        // A plain v_mov is still lane-predicated by EXEC. Without tracking the active mask and its
+        // later restoration, no pre-mutation all-lanes zero fact can survive any explicit or
+        // implicit EXEC write (including every v_cmpx encoding).
+        if (rdna2_instruction_may_change_exec(in)) {
+            same_block_zero_vgprs.reset();
+            zero_mip_exec_pristine = false;
+        }
+        uint32_t mip_vgpr = 0;
+        const bool proven_zero_mip_at_use =
+            rdna2_mimg_zero_mip_shape(in, &mip_vgpr) &&
+            same_block_zero_vgprs.test(mip_vgpr);
         // #2132. RESTORE FIRST, THEN SAVE — the order is load-bearing and getting it wrong
         // reproduces the very defect this rule exists to fix (#2202 review, B3). One instruction can
         // be BOTH a qualifying target and the sole-predecessor branch of a later target: a block
@@ -2513,6 +2581,20 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 in.dst.value < static_cast<int>(kFoldVgprs)) {
                 vector_index_mode[(size_t)in.dst.value] = VertexFetchIndexMode::Shader;
             }
+        }
+        if (in.dst.kind == OperandKind::VGPR && in.dst.value >= 0) {
+            // Four is the largest ordinary vector payload retained by this fold. Clearing an extra
+            // bit for a scalar result only makes the proof decline; it cannot manufacture one.
+            for (int reg = in.dst.value; reg < in.dst.value + 4 && reg < 256; ++reg)
+                same_block_zero_vgprs.reset(static_cast<size_t>(reg));
+        }
+        if (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x01u &&
+            in.len_dwords == 1u && !in.has_modifier &&
+            in.dst.kind == OperandKind::VGPR && in.dst.value >= 0 && in.dst.value < 256 &&
+            in.src[0].kind == OperandKind::SGPR) {
+            uint32_t scalar = 1;
+            if (zero_mip_exec_pristine && known(in.src[0].value, scalar) && scalar == 0u)
+                same_block_zero_vgprs.set(static_cast<size_t>(in.dst.value));
         }
         switch (in.fmt) {
             case Rdna2Format::SOP1:
@@ -3387,8 +3469,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // which is exactly the set the RECOMPILER emitted: classifier and emitter kept in lockstep,
                         // neither generalised. Opcodes verified with llvm-mc, positive control image_atomic_add ->
                         // word0 0xf0440128, byte-identical to the guest's own dword (#2275).
-                        u.is_storage_image = in.opcode == 0x08 || in.opcode == 0x0f ||
+                        u.is_storage_image = in.opcode == 0x08 || in.opcode == 0x09 ||
+                                             in.opcode == 0x0f ||
                                              (in.opcode >= 0x11 && in.opcode <= 0x1a && in.opcode != 0x13);
+                        u.proven_zero_mip = proven_zero_mip_at_use;
                         u.is_depth_compare = (in.opcode >= 0x28 && in.opcode <= 0x2f) ||
                                              (in.opcode >= 0x38 && in.opcode <= 0x3f) ||
                                              (in.opcode >= 0x58 && in.opcode <= 0x5f);
@@ -3814,6 +3898,15 @@ static uint32_t linear_dispatch_raw_store_size(const uint32_t* code, size_t dwor
     if (!required || required > descriptor.size_bytes || required > kMaxProvenLinearStore)
         return 0;
     return static_cast<uint32_t>(required);
+}
+
+bool shader_resource_allows_zero_mip_specialization(
+    const SrtUse& use, const DecodedImageDescriptor& descriptor,
+    const DecodedImageView& view) {
+    return use.proven_zero_mip && descriptor.sample_count == 1u &&
+        descriptor.base_level == 0u && descriptor.last_level == 0u &&
+        descriptor.max_mip == 0u && !view.in_mip_tail &&
+        !descriptor.compression_enabled;
 }
 
 std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
@@ -4842,6 +4935,8 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                         continue;
                     }
                     const uint32_t img_dim = image_type_to_dim(d.type);
+                    const bool proven_zero_mip =
+                        shader_resource_allows_zero_mip_specialization(u, d, view);
                     {
                         bool mapped = false;
                         for (auto& r0 : t.resources)
@@ -4850,6 +4945,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                                 r0.depth == d.depth && r0.format == fi.format &&
                                 r0.img_dim == img_dim && r0.sample_count == d.sample_count &&
                                 r0.depth_compare == u.is_depth_compare &&
+                                r0.proven_zero_mip == proven_zero_mip &&
                                 r0.in_mip_tail == view.in_mip_tail &&
                                 r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
                                 r0.mip_tail_x == view.mip_tail_x &&
@@ -4891,6 +4987,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     // uploads as six vertically-stacked faces (#273 — see agc_shader_layout).
                     r.img_dim = img_dim;
                     r.depth_compare = u.is_depth_compare;
+                    r.proven_zero_mip = proven_zero_mip;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     const uint64_t backing_bytes_per_sample = is_bcn
@@ -5345,6 +5442,12 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                                                    : ResourceClass::Texture;
                     const DataFormat view_format = mapped_fmt ? fi.format : DataFormat::Unknown;
                     const uint32_t img_dim = image_type_to_dim(d.type);
+                    // This is deliberately narrower than "the backend currently uploads one mip".
+                    // The instruction proof belongs to this exact use, and the descriptor must also
+                    // declare one uncompressed base level. In particular, do not reinterpret a DCC
+                    // allocation as raw texels merely because IMAGE_*_MIP selected level zero.
+                    const bool proven_zero_mip =
+                        shader_resource_allows_zero_mip_specialization(u, d, view);
                     {
                         bool mapped = false;
                         for (auto& r0 : table->resources)
@@ -5353,6 +5456,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                 r0.depth == d.depth && r0.format == view_format &&
                                 r0.img_dim == img_dim && r0.sample_count == d.sample_count &&
                                 r0.depth_compare == u.is_depth_compare &&
+                                r0.proven_zero_mip == proven_zero_mip &&
                                 r0.in_mip_tail == view.in_mip_tail &&
                                 r0.mip_tail_offset == (view.in_mip_tail ? view.mip_offset : 0) &&
                                 r0.mip_tail_x == view.mip_tail_x &&
@@ -5413,6 +5517,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     r.metadata_addr = shifted_view ? 0 : d.metadata_addr;
                     r.img_dim = img_dim;
                     r.depth_compare = u.is_depth_compare;
+                    r.proven_zero_mip = proven_zero_mip;
                     r.swizzle[0] = d.dst_sel[0]; r.swizzle[1] = d.dst_sel[1];
                     r.swizzle[2] = d.dst_sel[2]; r.swizzle[3] = d.dst_sel[3];
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1533,6 +1533,21 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     return *spirv;
 }
 
+bool report_compute_recompile_skip_once(RecompileDiagnosticContext diagnostic) {
+    static std::mutex mutex;
+    static std::set<uint64_t> logged;
+    {
+        std::lock_guard lock(mutex);
+        if (!logged.insert(diagnostic.program_address).second) return false;
+    }
+    if (std::getenv("PROSPER_DBG"))
+        log_compute_recompile_skip_diagnostic(diagnostic);
+    else
+        std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
+                     static_cast<unsigned long long>(diagnostic.program_address));
+    return true;
+}
+
 ShaderRecompileCacheStats shader_recompile_cache_stats() {
     auto& cache = shader_cache();
     std::lock_guard lock(cache.mutex);
@@ -5744,10 +5759,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     }
                 }
             }
-            static std::set<uint64_t> logged;
-            if (logged.insert(code_addr).second) {
-                std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
-                             (unsigned long long)code_addr);
+            if (report_compute_recompile_skip_once(recompile_diagnostic)) {
                 // #2412: print the table this program was offered, next to the keys the shader looks
                 // up by. Every one of GTA V's 951 recompiler rejects is `mode=unresolved-operand`
                 // (#2416) — the lowering exists and the descriptor does not resolve — so the useful

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -111,7 +111,8 @@ void decode_operands(Rdna2Inst& i) {
                 // or sext keeps has_modifier and is rejected.
                 i.src_neg[0] = ((sd >> 20) & 1u) != 0; i.src_abs[0] = ((sd >> 21) & 1u) != 0;
                 i.clamp = ((sd >> 13) & 1u) != 0; i.omod = (uint8_t)((sd >> 14) & 3u);
-                if (((sd >> 8) & 7u) == 6u && ((sd >> 16) & 7u) == 6u &&
+                if (((w >> 9) & 0xFFu) != 0x38u &&
+                    ((sd >> 8) & 7u) == 6u && ((sd >> 16) & 7u) == 6u &&
                     !((sd >> 19) & 0x9u)) i.has_modifier = false;
                 // WORD-select v_mov_b32_sdwa (#273 — the f16 half-move idiom): dst WORD_0/1 with
                 // UNUSED_PRESERVE, src0 WORD_0/WORD_1/DWORD, no sext/neg/abs/clamp/omod. The
@@ -142,6 +143,25 @@ void decode_operands(Rdna2Inst& i) {
                         i.sdwa_dst_sel = (uint8_t)dsel; i.sdwa_dst_unused = (uint8_t)dun;
                         i.sdwa_src0_sel = (uint8_t)s0sel;
                         i.sdwa_src0_sext = ((sd >> 19) & 1u) != 0;
+                        i.has_modifier = false;
+                    }
+                }
+                // GTA V's compute compaction kernels reverse a selected source word into a full
+                // dword: `v_bfrev_b32_sdwa v6, v6 dst_sel:DWORD dst_unused:UNUSED_PAD
+                // src0_sel:WORD_0` (7e0c70f9 00040606). SDWA selects and zero-extends the word
+                // before BREV, so its bits land in D[31:16] in reversed order. Admit byte/word
+                // selects only for the exact full-dword, zero-extending, unmodified shape; SEXT,
+                // source/output modifiers, partial destinations, and reserved fields remain
+                // fail-visible rather than being interpreted as this narrower operation.
+                else if (((w >> 9) & 0xFFu) == 0x38u) {
+                    const uint32_t dsel = (sd >> 8) & 7u, dun = (sd >> 11) & 3u;
+                    const uint32_t s0sel = (sd >> 16) & 7u;
+                    if (dsel == 6u && dun == 0u && s0sel <= 5u &&
+                        !((sd >> 19) & 0x9u) && !i.clamp && !i.omod &&
+                        !i.src_neg[0] && !i.src_abs[0] && !(sd & 0xff000000u)) {
+                        i.sdwa_dst_sel = static_cast<uint8_t>(dsel);
+                        i.sdwa_dst_unused = static_cast<uint8_t>(dun);
+                        i.sdwa_src0_sel = static_cast<uint8_t>(s0sel);
                         i.has_modifier = false;
                     }
                 }

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -82,6 +82,21 @@ bool vopc_is_cmpx(uint32_t opcode) {
            (opcode >= 0xF0u && opcode <= 0xFFu);     // u64 / f16
 }
 
+bool rdna2_instruction_may_change_exec(const Rdna2Inst& in) {
+    if (in.fmt == Rdna2Format::VOPC && vopc_is_cmpx(in.opcode)) return true;
+    // saveexec writes EXEC implicitly while its explicit destination receives the previous mask.
+    if (in.fmt == Rdna2Format::SOP1 &&
+        ((in.opcode >= 0x24u && in.opcode <= 0x2bu) ||
+         in.opcode == 0x37u || in.opcode == 0x38u ||
+         in.opcode == 0x3cu || in.opcode == 0x40u || in.opcode == 0x44u))
+        return true;
+    auto is_exec = [](const Operand& operand) {
+        return (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
+               (operand.value == 126 || operand.value == 127);
+    };
+    return is_exec(in.dst) || is_exec(in.sdst);
+}
+
 // VERIFIED(round-trip llvm-mc gfx1030, VOP1): 0x54 v_rcp_f16, 0x55 v_sqrt_f16, 0x56 v_rsq_f16,
 // 0x57 v_log_f16, 0x58 v_exp_f16, 0x59 v_frexp_mant_f16, 0x5A v_frexp_exp_i16_f16, 0x5B v_floor_f16,
 // 0x5C v_ceil_f16, 0x5D v_trunc_f16, 0x5E v_rndne_f16, 0x5F v_fract_f16, 0x60 v_sin_f16,
@@ -952,6 +967,34 @@ size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& o
         if (i.is_end || i.fmt == Rdna2Format::Unknown) break;
     }
     return pc;
+}
+
+bool rdna2_mimg_zero_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr) {
+    if (in.fmt != Rdna2Format::MIMG || !in.mimg_unorm || !in.mimg_glc ||
+        in.mimg_dlc || in.mimg_r128 ||
+        in.mimg_tfe || in.mimg_lwe || in.mimg_slc || in.mimg_a16 || in.mimg_d16 ||
+        in.mimg_reserved || in.src[0].kind != OperandKind::VGPR || in.src[0].value < 0)
+        return false;
+
+    uint32_t reg = 0;
+    if (in.opcode == 0x01u && (in.mimg_dmask == 1u || in.mimg_dmask == 0xfu) &&
+        (in.mimg_dim == 1u || in.mimg_dim == 5u) &&
+        in.mimg_nsa == 0u && in.len_dwords == 2u) {
+        // IMAGE_LOAD_MIP: 2D=[x,y,mip], 2D_ARRAY=[x,y,slice,mip].
+        reg = static_cast<uint32_t>(in.src[0].value) +
+              (in.mimg_dim == 5u ? 3u : 2u);
+    } else if (in.opcode == 0x09u && (in.mimg_dmask == 1u || in.mimg_dmask == 0xfu) &&
+               in.mimg_dim == 1u &&
+               in.mimg_nsa == 1u && in.len_dwords == 3u &&
+               (in.words[2] & 0xffff0000u) == 0u) {
+        // IMAGE_STORE_MIP NSA 2D: coord0 is VADDR, then word2 bytes name y and mip.
+        reg = (in.words[2] >> 8) & 0xffu;
+    } else {
+        return false;
+    }
+    if (reg >= 256u) return false;
+    if (mip_vgpr) *mip_vgpr = reg;
+    return true;
 }
 
 uint32_t rdna2_sload_required_bytes(const uint32_t* code, size_t dwords, uint32_t sgpr_base) {

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -97,6 +97,133 @@ bool rdna2_instruction_may_change_exec(const Rdna2Inst& in) {
     return is_exec(in.dst) || is_exec(in.sdst);
 }
 
+static uint32_t mtbuf_vdata_dwords(const Rdna2Inst& in) {
+    if (in.opcode > 15u) return 0;
+    const uint32_t components = (in.opcode & 3u) + 1u;
+    return in.opcode >= 8u ? (components + 1u) / 2u : components;
+}
+
+static uint32_t mimg_vdata_dwords(const Rdna2Inst& in) {
+    uint32_t components = 0;
+    if (in.opcode == 0x47u || in.opcode == 0x57u) {
+        components = 4u; // gather4
+    } else {
+        for (uint32_t component = 0; component < 4; ++component)
+            components += (in.mimg_dmask >> component) & 1u;
+        if (!components) components = 4u; // unknown/empty mask: account conservatively.
+    }
+    return in.mimg_d16 ? (components + 1u) / 2u : components;
+}
+
+uint32_t rdna2_vgpr_write_count(const Rdna2Inst& in) {
+    if (in.dst.kind != OperandKind::VGPR) return 0;
+    switch (in.fmt) {
+        case Rdna2Format::VOP1:
+            return in.opcode == 0x02u ? 0u : 1u; // v_readfirstlane writes the decoded SGPR.
+        case Rdna2Format::VOP2:
+        case Rdna2Format::VOP3P:
+            return 1;
+        case Rdna2Format::VOP3:
+            if (in.opcode == 0x360u) return 0; // v_readlane_b32 writes an SGPR.
+            // v_div_scale_f64 and the two integer MAD64 forms write a VGPR pair.
+            return in.opcode == 0x16eu || in.opcode == 0x176u || in.opcode == 0x177u ? 2u : 1u;
+        case Rdna2Format::DS:
+            // Keep this aligned with the DS result opcodes admitted by the emitter. Other DS
+            // encodings in that subset are stores or no-return atomics whose VDST field is a source.
+            if (in.opcode == 0x35u || in.opcode == 0x36u || in.opcode == 0x3du ||
+                in.opcode == 0x3eu || in.opcode == 0xb1u || in.opcode == 0x20u ||
+                in.opcode == 0x2du)
+                return 1;
+            if (in.opcode == 0x37u || in.opcode == 0x76u) return 2;
+            if (in.opcode == 0xfeu) return 3;
+            if (in.opcode == 0x77u || in.opcode == 0xffu) return 4;
+            return 0;
+        case Rdna2Format::MUBUF:
+            // Format and raw stores read VDATA. Loads use the gfx10 ordering where x3 follows x4.
+            if ((in.opcode >= 0x04u && in.opcode <= 0x07u) ||
+                (in.opcode >= 0x1cu && in.opcode <= 0x1fu))
+                return 0;
+            if (in.opcode <= 0x03u) return in.opcode + 1u;
+            if (in.opcode >= 0x08u && in.opcode <= 0x0cu) return 1;
+            if (in.opcode == 0x0du) return 2;
+            if (in.opcode == 0x0eu) return 4;
+            if (in.opcode == 0x0fu) return 3;
+            // Supported return-value atomics are one dword. Unknown buffer operations remain a
+            // conservative one-register clobber, matching the prior analysis contract.
+            return 1;
+        case Rdna2Format::MTBUF:
+            if (in.opcode <= 3u || (in.opcode >= 8u && in.opcode <= 11u))
+                return mtbuf_vdata_dwords(in); // ordinary and packed-D16 typed loads
+            return 0; // typed stores read VDATA; TFE's trailing status is handled separately.
+        case Rdna2Format::FLAT:
+            switch (in.opcode) {
+                case 0x08u: case 0x09u: case 0x0au: case 0x0bu: case 0x0cu: return 1;
+                case 0x0du: return 2;
+                case 0x0eu: return 4;
+                case 0x0fu: return 3;
+                default: return 0; // audited store/deferred forms do not produce a VGPR result.
+            }
+        case Rdna2Format::MIMG: {
+            if (in.opcode == 0x08u || in.opcode == 0x09u) return 0; // IMAGE_STORE[_MIP]
+            return mimg_vdata_dwords(in);
+        }
+        case Rdna2Format::VINTRP:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
+int rdna2_tfe_status_vgpr(const Rdna2Inst& in) {
+    if (in.dst.kind != OperandKind::VGPR || in.dst.value < 0) return -1;
+    if (in.fmt == Rdna2Format::MIMG && in.mimg_tfe)
+        return in.dst.value + static_cast<int>(mimg_vdata_dwords(in));
+    if (in.fmt == Rdna2Format::MTBUF && in.mtbuf_tfe) {
+        const uint32_t data_dwords = mtbuf_vdata_dwords(in);
+        if (data_dwords) return in.dst.value + static_cast<int>(data_dwords);
+    }
+    return -1;
+}
+
+uint32_t rdna2_vgpr_destination_span(const Rdna2Inst& in) {
+    const uint32_t writes = rdna2_vgpr_write_count(in);
+    if (in.dst.kind != OperandKind::VGPR || in.dst.value < 0) return 0;
+    uint32_t span = writes;
+
+    if (!span) switch (in.fmt) {
+        case Rdna2Format::MUBUF:
+            if (in.opcode >= 0x04u && in.opcode <= 0x07u) span = in.opcode - 3u;
+            else if (in.opcode == 0x1cu) span = 1;
+            else if (in.opcode == 0x1du) span = 2;
+            else if (in.opcode == 0x1eu) span = 4;
+            else if (in.opcode == 0x1fu) span = 3;
+            break;
+        case Rdna2Format::MTBUF:
+            span = mtbuf_vdata_dwords(in);
+            break;
+        case Rdna2Format::FLAT:
+            switch (in.opcode) {
+                case 0x18u: case 0x1au: case 0x1cu: span = 1; break;
+                case 0x1du: span = 2; break;
+                case 0x1eu: span = 4; break;
+                case 0x1fu: span = 3; break;
+                default: break;
+            }
+            break;
+        case Rdna2Format::MIMG: {
+            if (in.opcode == 0x08u || in.opcode == 0x09u)
+                span = mimg_vdata_dwords(in);
+            break;
+        }
+        default:
+            break;
+    }
+    const int status_vgpr = rdna2_tfe_status_vgpr(in);
+    if (status_vgpr >= in.dst.value)
+        span = std::max(span, static_cast<uint32_t>(status_vgpr - in.dst.value + 1));
+    return span;
+}
+
 // VERIFIED(round-trip llvm-mc gfx1030, VOP1): 0x54 v_rcp_f16, 0x55 v_sqrt_f16, 0x56 v_rsq_f16,
 // 0x57 v_log_f16, 0x58 v_exp_f16, 0x59 v_frexp_mant_f16, 0x5A v_frexp_exp_i16_f16, 0x5B v_floor_f16,
 // 0x5C v_ceil_f16, 0x5D v_trunc_f16, 0x5E v_rndne_f16, 0x5F v_fract_f16, 0x60 v_sin_f16,

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -605,6 +605,7 @@ void decode_operands(Rdna2Inst& i) {
             const uint32_t d1 = i.words[1];
             i.opcode = (w >> 18) & 0xFFu;
             i.mubuf_glc = ((w >> 14) & 1u) != 0;   // atomics: return pre-op value to VGPR
+            i.mubuf_dlc = ((w >> 15) & 1u) != 0;   // ordinary loads: bypass device-level cache
             i.mubuf_lds = ((w >> 16) & 1u) != 0;   // buffer<->LDS transfer (rejected in stage 2)
             i.dst    = vgpr(d1 >> 8);                          // VDATA
             i.src[0] = vgpr(d1);                              // VADDR
@@ -627,6 +628,7 @@ void decode_operands(Rdna2Inst& i) {
             i.mtbuf_format = (w >> 19) & 0x7Fu;
             i.mtbuf_tfe = ((d1 >> 23) & 1u) != 0;
             i.mubuf_glc = ((w >> 14) & 1u) != 0;
+            i.mubuf_dlc = ((w >> 15) & 1u) != 0;
             i.dst    = vgpr(d1 >> 8);
             i.src[0] = vgpr(d1);
             i.src[1] = sgpr(((d1 >> 16) & 0x1Fu) << 2);

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -793,6 +793,24 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords) {
                          ((d1 >> 18) & 1u) == 0u) {
                     i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;
                 }
+                // GTA V selects alternate 16-lane rows after its in-row reduction. QUAD_PERM
+                // identity keeps SRC0 in the current lane; ROW_MASK=0xa executes rows 1/3 while
+                // rows 0/2 preserve VDST. Admit only the exact live integer-add control form:
+                // BC=0, BANK_MASK=0xf, no FI/source modifiers, and retain both masks explicitly.
+                else if (vf == Rdna2Format::VOP2 && ((w >> 25) & 0x3Fu) == 0x25u &&
+                         ctrl == 0xe4u &&
+                         ((d1 >> 28) & 0xFu) == 0xau &&
+                         ((d1 >> 24) & 0xFu) == 0xfu &&
+                         ((d1 >> 20) & 0xFu) == 0u &&
+                         ((d1 >> 19) & 1u) == 0u &&
+                         ((d1 >> 18) & 1u) == 0u) {
+                    i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;
+                }
+                if (i.has_dpp) {
+                    i.dpp_bound_ctrl = ((d1 >> 19) & 1u) != 0u;
+                    i.dpp_bank_mask = static_cast<uint8_t>((d1 >> 24) & 0xfu);
+                    i.dpp_row_mask = static_cast<uint8_t>((d1 >> 28) & 0xfu);
+                }
             }
         } else {
             // The six K-carrying VOP2 mul-adds embed a mandatory 32-bit literal K: v_madmk_f32 (0x20),

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -464,6 +464,14 @@ void decode_operands(Rdna2Inst& i) {
                     break;
                 default: break;
             }
+            // The 0x30F/0x310/0x319 _co_ forms produce carry/borrow in SDST but do not consume a
+            // carry-in. Their reserved SRC2 field commonly decodes as s0; exposing that phantom
+            // operand makes CFG provenance reject a valid instruction when s0 differs across a
+            // join, before the instruction can replace it with its fresh carry result.
+            if (i.opcode == 0x30Fu || i.opcode == 0x310u || i.opcode == 0x319u) {
+                i.src[2] = {};
+                i.n_src = 2;
+            }
             // Scalar 16-bit VOP3 operations: OPSEL[2:0] selects each packed source half and OPSEL[3]
             // selects the destination half. Reuse the packed-op selector field for this family.
             // VERIFIED(llvm-mc gfx1030): 0x351/0x354/0x357 are v_min3_f16/v_max3_f16/v_med3_f16

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -472,6 +472,14 @@ void decode_operands(Rdna2Inst& i) {
                 i.src[2] = {};
                 i.n_src = 2;
             }
+            // V_LDEXP_F32 is likewise a two-source VOP3A instruction. Its reserved SRC2 bits are
+            // zero in GTA V's exact packet and therefore decode as s0 unless cleared here. Exposing
+            // that phantom scalar read can make CFG/provenance analysis reject an otherwise valid
+            // instruction when s0 differs across a merge, before the opcode emitter is reached.
+            if (i.opcode == 0x362u) {
+                i.src[2] = {};
+                i.n_src = 2;
+            }
             // Scalar 16-bit VOP3 operations: OPSEL[2:0] selects each packed source half and OPSEL[3]
             // selects the destination half. Reuse the packed-op selector field for this family.
             // VERIFIED(llvm-mc gfx1030): 0x351/0x354/0x357 are v_min3_f16/v_max3_f16/v_med3_f16

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -74,13 +74,15 @@ struct Rdna2Inst {
     // (dst_sel defaults to DWORD=6, hardware PRESERVES the unwritten f16 half) from the SDWA
     // DWORD+UNUSED_PAD form (same field values, hardware ZERO-fills) — ISA Table 88 DST_U.
     bool        has_sdwa = false;
-    // DPP16 QUAD_PERM/ROW_SHR (#273/#1390): a full-mask operation with no neg/abs/FI.  The
-    // recompiler lowers quad permutations through stage-appropriate lane operations and bounded row
-    // shifts in the portable one-live-lane vertex shell.  src[0] holds the REAL source VGPR
-    // (dword1[7:0]); dpp_ctrl and dpp_bound_ctrl retain the architectural control fields.
+    // DPP16 QUAD_PERM/ROW_SHR (#273/#1390): an admitted operation with no neg/abs/FI. The
+    // recompiler lowers full-mask permutations through stage-appropriate lane operations; exact
+    // partial-mask shapes keep their row/bank fields so a narrow stage model can preserve masked
+    // destinations. src[0] holds the REAL source VGPR (dword1[7:0]).
     bool        has_dpp = false;
     uint16_t    dpp_ctrl = 0;
     bool        dpp_bound_ctrl = false;
+    uint8_t     dpp_bank_mask = 0;
+    uint8_t     dpp_row_mask = 0;
     // V_PERMLANE16_B32 / V_PERMLANEX16_B32 overload OPSEL[0:1] as Fetch-Inactive and
     // BOUND_CTRL. Keep these separate from DPP's control word: permlane is a native VOP3 op whose
     // 64-bit selector comes from SRC1:SRC2.

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -132,9 +132,11 @@ struct Rdna2Inst {
     uint32_t exp_en = 0;
     bool     exp_compr = false;     // COMPR: the 4 channels are two f16x2 pairs in src[0] (r,g) / src[1] (b,a)
 
-    // MUBUF-only flags (ISA Table 98): GLC (bit 14) — for atomics, "return pre-op value to VGPR";
-    // LDS (bit 16) — transfer between LDS and memory instead of VGPRs (rejected until modeled).
+    // MUBUF/MTBUF flags (ISA Table 98): GLC (bit 14) — for atomics, "return pre-op value to VGPR";
+    // DLC (bit 15) — device-level cache policy for ordinary loads; LDS (bit 16, MUBUF only) —
+    // transfer between LDS and memory instead of VGPRs (rejected until modeled).
     bool     mubuf_glc = false;
+    bool     mubuf_dlc = false;
     bool     mubuf_lds = false;
     // MTBUF carries the GFX10 combined 7-bit BUF_FMT at dword0[25:19], just like a Gen5 V#.
     // Interpreting these bits as the older PS4 DFMT/NFMT split maps valid gfx1030 formats to the

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -53,6 +53,21 @@ bool vopc_is_cmpx(uint32_t opcode);
 // by control-flow analysis and instruction-scoped value proofs: overlooking a mask mutation can
 // turn a predicated VALU definition into a false all-lanes fact.
 bool rdna2_instruction_may_change_exec(const Rdna2Inst& in);
+// Number of consecutive data VGPRs an instruction writes from its decoded destination. This
+// inventory is shared by control-flow analyses and instruction-scoped value proofs so scalar VALU
+// results are not mistaken for four-register memory payloads, while actual wide results still
+// invalidate every register they define. Known store encodings return zero because their VDATA
+// field is a source. Appended TFE status and dynamic destinations such as v_movreld_b32 are separate:
+// consumers must also use `rdna2_tfe_status_vgpr` and handle dynamic destinations fail-closed.
+uint32_t rdna2_vgpr_write_count(const Rdna2Inst& in);
+// Appended TFE status destination, or -1 when the instruction has none. Unlike the consecutive data
+// result above, a store's decoded VDATA is a source prefix and only the trailing status is written.
+// This remains exact for decoded MTBUF forms that emission rejects, including packed-D16 forms.
+int rdna2_tfe_status_vgpr(const Rdna2Inst& in);
+// Width of the complete consecutive VGPR field rooted at `dst`, including VDATA sources on stores
+// and an appended TFE status destination. Register-file sizing needs this broader footprint even
+// though dataflow invalidation must distinguish sources from writes.
+uint32_t rdna2_vgpr_destination_span(const Rdna2Inst& in);
 // True for the VOP1 f16 unary family: one f16 operand in, one f16 result out, no side effects —
 // 0x54-0x58 (rcp/sqrt/rsq/log/exp) and 0x5B-0x61 (floor/ceil/trunc/rndne/fract/sin/cos). The two
 // FREXP opcodes 0x59/0x5A sit inside that numeric span and are deliberately excluded: 0x59 returns a

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -42,12 +42,17 @@ struct Operand {
 Operand decode_src_field(uint32_t field);
 // The float value an InlineFloat operand encodes (0.5, 1.0, ... , 1/(2*pi)); 0 for non-float codes.
 float inline_float_value(uint32_t code);
+struct Rdna2Inst;
 // True when a VOPC opcode is the `v_cmpx_*` form, which writes EXEC instead of a VCC/SGPR mask.
 // Every one sits at its `v_cmp_*` counterpart + 0x10, so `opcode - 0x10` recovers the base compare.
 // The six windows and the two invalid holes are enumerated (and sourced) at the definition in
 // rdna2_decode.cpp. This is a property of the ENCODING, so it is shared: the decoder's SDWA
 // admission and the recompiler's EXEC/mask bookkeeping must not carry separate copies (#2120).
 bool vopc_is_cmpx(uint32_t opcode);
+// True for every decoded instruction that can explicitly or implicitly write EXEC. This is shared
+// by control-flow analysis and instruction-scoped value proofs: overlooking a mask mutation can
+// turn a predicated VALU definition into a false all-lanes fact.
+bool rdna2_instruction_may_change_exec(const Rdna2Inst& in);
 // True for the VOP1 f16 unary family: one f16 operand in, one f16 result out, no side effects —
 // 0x54-0x58 (rcp/sqrt/rsq/log/exp) and 0x5B-0x61 (floor/ceil/trunc/rndne/fract/sin/cos). The two
 // FREXP opcodes 0x59/0x5A sit inside that numeric span and are deliberately excluded: 0x59 returns a
@@ -200,6 +205,12 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords);
 // Walk from code[0], appending each decoded instruction to `out`, until S_ENDPGM, an Unknown
 // encoding, or the end of the buffer. Returns the number of dwords consumed.
 size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& out);
+
+// Exact IMAGE_LOAD_MIP / IMAGE_STORE_MIP packet subset whose mip operand may be specialized after
+// an independent value proof. Returns the dimension-specific mip VGPR when requested. This checks
+// only packet shape; callers must still prove that VGPR is zero and that the resource has one
+// materialized, uncompressed mip.
+bool rdna2_mimg_zero_mip_shape(const Rdna2Inst& in, uint32_t* mip_vgpr = nullptr);
 
 // Minimum byte range touched by immediate s_load_dword[xN] operations whose 64-bit SBASE begins at
 // `sgpr_base`. Unlike s_buffer_load, s_load consumes an address pair rather than a bounded V#; callers

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -426,6 +426,86 @@ struct SpirvCompute {
     // mirror it exactly and bitcast back. The result is UNDEFINED when the operand is zero —
     // every caller must exclude that input rather than relying on a -1 that is not specified.
     uint32_t find_umsb(uint32_t a) { uint32_t ri = id(); putv(code, Op_ExtInst, {t_i32, ri, glsl, Glsl_FindUMsb, a}); return i2u(ri); }
+    // IEEE-754 binary32 ldexp on raw bits, with round-to-nearest-even for a subnormal result.
+    // GLSL.std.450 Ldexp is NOT sufficient here: its contract leaves an overflowing product and
+    // exp>128 undefined, while a guest exponent is an arbitrary i32. Keep the whole operation in
+    // the integer domain so zero signs, infinities and NaN payloads survive exactly, and so every
+    // shift remains in SPIR-V's defined [0,31] range. Exponents outside [-512,512] can be clamped
+    // before the calculation: every finite nonzero binary32 must overflow above that interval or
+    // round to signed zero below it.
+    uint32_t ldexp_f32_bits(uint32_t bits, uint32_t exponent) {
+        const uint32_t sign = ibin(Op_BitwiseAnd, bits, uconst(0x80000000u));
+        const uint32_t magnitude = ibin(Op_BitwiseAnd, bits, uconst(0x7fffffffu));
+        const uint32_t raw_exp = ibin(Op_ShiftRightLogical, magnitude, uconst(23));
+        const uint32_t fraction = ibin(Op_BitwiseAnd, magnitude, uconst(0x007fffffu));
+
+        // Normalize a subnormal input into a 24-bit significand with bit 23 set. FindUMsb is
+        // undefined at zero, so substitute one for that otherwise-dead calculation; signed zero
+        // is selected back unchanged at the end.
+        const uint32_t fraction_zero = ucmp(Op_IEqual, fraction, uconst(0));
+        const uint32_t safe_fraction = sel(fraction_zero, uconst(1), fraction);
+        const uint32_t sub_shift = ibin(Op_ISub, uconst(23), find_umsb(safe_fraction));
+        const uint32_t sub_significand =
+            ibin(Op_ShiftLeftLogical, fraction, sub_shift); // sub_shift is in [1,23]
+        const uint32_t normal_significand =
+            ibin(Op_BitwiseOr, fraction, uconst(0x00800000u));
+        const uint32_t input_subnormal = ucmp(Op_IEqual, raw_exp, uconst(0));
+        const uint32_t significand =
+            sel(input_subnormal, sub_significand, normal_significand);
+        const uint32_t normal_unbiased = ibin(Op_ISub, raw_exp, uconst(127));
+        const uint32_t sub_unbiased = ibin(Op_ISub, uconst(static_cast<uint32_t>(-126)),
+                                           sub_shift);
+        const uint32_t unbiased = sel(input_subnormal, sub_unbiased, normal_unbiased);
+
+        const uint32_t bounded_exponent = sext2(
+            Glsl_SMin,
+            sext2(Glsl_SMax, exponent, uconst(static_cast<uint32_t>(-512))),
+            uconst(512));
+        const uint32_t adjusted = ibin(Op_IAdd, unbiased, bounded_exponent);
+
+        const uint32_t normal_exp = ibin(
+            Op_ShiftLeftLogical, ibin(Op_IAdd, adjusted, uconst(127)), uconst(23));
+        const uint32_t normal_result = ibin(
+            Op_BitwiseOr, normal_exp,
+            ibin(Op_BitwiseAnd, significand, uconst(0x007fffffu)));
+
+        // For adjusted<-126, shift the normalized 24-bit significand into the subnormal range.
+        // The calculations exist in SSA for every input, so clamp the working shift to [1,24]
+        // even when the normal/overflow result is ultimately selected. shift>=25 is strictly below
+        // half the least subnormal (shift==24 retains the exact halfway tie and its RNE decision).
+        const uint32_t under_shift =
+            ibin(Op_ISub, uconst(static_cast<uint32_t>(-126)), adjusted);
+        const uint32_t safe_under_shift = uext2(
+            Glsl_UMax, uconst(1), uext2(Glsl_UMin, under_shift, uconst(24)));
+        const uint32_t truncated =
+            ibin(Op_ShiftRightLogical, significand, safe_under_shift);
+        const uint32_t remainder_mask = ibin(
+            Op_ISub, ibin(Op_ShiftLeftLogical, uconst(1), safe_under_shift), uconst(1));
+        const uint32_t remainder = ibin(Op_BitwiseAnd, significand, remainder_mask);
+        const uint32_t half = ibin(
+            Op_ShiftLeftLogical, uconst(1), ibin(Op_ISub, safe_under_shift, uconst(1)));
+        const uint32_t remainder_gt_half = ucmp(Op_UGreaterThan, remainder, half);
+        const uint32_t remainder_eq_half = ucmp(Op_IEqual, remainder, half);
+        const uint32_t truncated_odd = ucmp(
+            Op_INotEqual, ibin(Op_BitwiseAnd, truncated, uconst(1)), uconst(0));
+        const uint32_t round_up = lor(remainder_gt_half,
+                                      land(remainder_eq_half, truncated_odd));
+        const uint32_t rounded = ibin(
+            Op_IAdd, truncated, sel(round_up, uconst(1), uconst(0)));
+        const uint32_t too_small = scmp(Op_SGreaterThanEqual, under_shift, uconst(25));
+        const uint32_t subnormal_result = sel(too_small, uconst(0), rounded);
+
+        const uint32_t is_underflow =
+            scmp(Op_SLessThan, adjusted, uconst(static_cast<uint32_t>(-126)));
+        const uint32_t is_overflow = scmp(Op_SGreaterThan, adjusted, uconst(127));
+        uint32_t finite_result = sel(is_underflow, subnormal_result, normal_result);
+        finite_result = sel(is_overflow, uconst(0x7f800000u), finite_result);
+        finite_result = ibin(Op_BitwiseOr, sign, finite_result);
+
+        const uint32_t is_special = ucmp(Op_IEqual, raw_exp, uconst(255));
+        const uint32_t is_zero = ucmp(Op_IEqual, magnitude, uconst(0));
+        return sel(is_special, bits, sel(is_zero, bits, finite_result));
+    }
     // GLSL.std.450 float ext-instructions on bit-operands -> bit-result.
     uint32_t fext1(uint32_t inst, uint32_t a) { uint32_t r = id(); putv(code, Op_ExtInst, {t_f32, r, glsl, inst, bcf(a)}); return bcu(r); }
     uint32_t fext2(uint32_t inst, uint32_t a, uint32_t b) { uint32_t r = id(); putv(code, Op_ExtInst, {t_f32, r, glsl, inst, bcf(a), bcf(b)}); return bcu(r); }
@@ -9286,6 +9366,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t lo = b.uext2(Glsl_UMin, val(in.src[0]), b.uconst(0xFFFFu));
                 uint32_t hi = b.uext2(Glsl_UMin, val(in.src[1]), b.uconst(0xFFFFu));
                 vreg[in.dst.value] = b.ibin(Op_BitwiseOr, lo, b.ibin(Op_ShiftLeftLogical, hi, b.uconst(16)));
+            } else if (in.opcode == 0x362) {                          // v_ldexp_f32
+                // AMD opcode 866: D.f = S0.f * 2**S1.i. The exact GTA V production packet is
+                // d7620000,0002030d (`v_ldexp_f32 v0,v13,v1`) with no modifiers. Admit that proven
+                // shape only for now: ABS/NEG on the integer exponent and output-modifier denormal
+                // behavior need separate contracts, and silently ignoring either would corrupt
+                // mip/scale reconstruction. ldexp_f32_bits covers the full unmodified i32 exponent
+                // domain without relying on GLSL.std.450 Ldexp's undefined overflow cases.
+                if (in.src_abs[0] || in.src_abs[1] || in.src_abs[2] ||
+                    in.src_neg[0] || in.src_neg[1] || in.src_neg[2] ||
+                    in.clamp || in.omod) {
+                    ok = false;
+                } else {
+                    vreg[in.dst.value] = b.ldexp_f32_bits(
+                        val(in.src[0]), val(in.src[1]));
+                }
             } else if (in.opcode >= 0x144 && in.opcode <= 0x147) {
                 // Cubemap coordinate ops (#273 — DOLL's title post PSes' reflection-probe math):
                 // v_cubeid_f32 (0x144) face id, v_cubesc_f32 (0x145) S numerator, v_cubetc_f32

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3658,6 +3658,15 @@ inline bool shader_reads_scc(const std::vector<Rdna2Inst>& ins) {
     return false;
 }
 
+// VOP3B add/subtract without carry-in produces a fresh carry/borrow mask in SDST. Unlike the
+// 0x128-0x12a family, this mask does not depend on a tracked src2 mask. Keep this exact predicate
+// shared by every Wave32 scalar-width/provenance site so the emitter and CFG dispatcher cannot
+// disagree about whether the physical destination is one word or an SGPR pair.
+inline bool vop3b_fresh_carry_output(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR &&
+           (in.opcode == 0x30f || in.opcode == 0x310 || in.opcode == 0x319);
+}
+
 std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& ins) {
     std::unordered_set<uint32_t> safe;
     // pc of the terminating s_endpgm — a forward execz whose target is here skips straight to the end.
@@ -3706,11 +3715,13 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
             // effects (emit_alu writes rs.sreg/rs.vcc/rs.sreg_bool for them, and predicate_write only
             // covers VGPRs) — on hardware the skipped block would have preserved VCC/the SGPR:
             //   VOP1 0x02 v_readfirstlane_b32 (writes an SGPR), VOP2 0x28-0x2A carry ops (write VCC),
-            //   VOP3B 0x128-0x12A (write the carry-out SGPR pair/VCC), and VOP3B v_mad_u64_u32
-            //   0x176 (its 65th-bit carry mask also lands in VCC/an SGPR pair unpredicated).
+            //   VOP3B 0x128-0x12A and 0x30F/0x310/0x319 (write the carry-out SGPR pair/VCC), and
+            //   VOP3B v_mad_u64_u32 0x176 (its 65th-bit carry mask also lands in VCC/an SGPR pair
+            //   unpredicated).
             const bool scalar_side_effect =
                 (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x02) ||
                 (in.fmt == Rdna2Format::VOP2 && in.opcode >= 0x28 && in.opcode <= 0x2A) ||
+                vop3b_fresh_carry_output(in) ||
                 (in.fmt == Rdna2Format::VOP3 &&
                  ((in.opcode >= 0x128 && in.opcode <= 0x12A) || in.opcode == 0x176));
             if (!scalar_side_effect &&
@@ -3843,6 +3854,9 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
                    in.sdst.kind == OperandKind::SGPR) {
             writes_b32_mask = tracked_mask_source(in.src[2]);
             mask_dst = in.sdst.value;
+        } else if (vop3b_fresh_carry_output(in)) {
+            writes_b32_mask = true;
+            mask_dst = in.sdst.value;
         }
 
         auto erase_written_words = [&](int base, uint32_t width) {
@@ -3856,7 +3870,8 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
             erase_written_words(in.dst.value, 1);
         if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
             erase_written_words(in.sdst.value,
-                in.opcode >= 0x128 && in.opcode <= 0x12a ? 1u : 2u);
+                ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
+                 vop3b_fresh_carry_output(in)) ? 1u : 2u);
         if (writes_b32_mask && mask_dst >= 0 && mask_dst != 126)
             masks.insert(mask_dst);
         if (mask_writer) *mask_writer = writes_b32_mask && mask_dst >= 0 && mask_dst != 126;
@@ -5012,7 +5027,8 @@ void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit,
         visit(in.dst.value, wave32_one_word_masks ? 1u : 2u);
     if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
         visit(in.sdst.value, wave32_one_word_masks &&
-                              in.opcode >= 0x128 && in.opcode <= 0x12a ? 1u : 2u);
+                              ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
+                               vop3b_fresh_carry_output(in)) ? 1u : 2u);
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -5681,6 +5697,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
               const ShaderResourceTable* rt = nullptr, bool allow_wave = false) {
     auto& vreg = rs.vreg; uint32_t& vcc = rs.vcc;
     auto val = [&](const Operand& o) { return operand_bits(b, rs, in, o, &ok); };
+    auto write_vop3b_carry_output = [&](uint32_t carry_mask) {
+        if (in.sdst.kind == OperandKind::SGPR && b.allow_b32_masks &&
+            (b.is_fragment || (b.is_compute && b.wave_size == 32))) {
+            // A Wave32 carry destination is one physical word. Preserve an independently-live
+            // adjacent SGPR and register the new lifetime in the B32 mask domain used by CFG joins.
+            rs.sreg_bool[in.sdst.value] = carry_mask;
+            rs.sreg_bool_narrowed[in.sdst.value] = true;
+            rs.sreg_bool_b32.insert(in.sdst.value);
+            rs.sreg.erase(in.sdst.value);
+            rs.sreg_srt.erase(in.sdst.value);
+            if (in.sdst.value == 106) rs.vcc = carry_mask;
+        } else if (in.sdst.value == 106 || in.sdst.value == 107) {
+            rs.vcc = carry_mask;
+        } else if (in.sdst.kind == OperandKind::SGPR) {
+            rs.sreg_bool[in.sdst.value] = carry_mask;
+        } else {
+            ok = false;
+        }
+    };
     // SDWA/DPP forms carry a sub-dword select or cross-lane control word we don't model. The decoder
     // flags them (and gets their length right); reject here rather than compute with a wrong operand.
     if (in.has_modifier) { ok = false; return true; }
@@ -9020,9 +9055,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 vreg[in.dst.value] = d;
                 // ISA 3.9 carry-mask rule: an EXEC-inactive lane's bit is written 0, not its raw carry.
                 const uint32_t carry_masked = rs.exec_narrowed ? b.land(rs.exec, carry) : carry;
-                if (in.sdst.value == 106 || in.sdst.value == 107) rs.vcc = carry_masked;
-                else if (in.sdst.kind == OperandKind::SGPR) rs.sreg_bool[in.sdst.value] = carry_masked;
-                else ok = false;
+                write_vop3b_carry_output(carry_masked);
             } else if (in.opcode == 0x169) {                          // v_mul_lo_u32
                 vreg[in.dst.value] = b.ibin(Op_IMul, val(in.src[0]), val(in.src[1]));
             } else if (in.opcode == 0x16a) {                          // v_mul_hi_u32 (high 32 bits)
@@ -9217,22 +9250,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // carry-out -> sdst mask (VCC or a saved SGPR-pair bool). ISA 3.9: an
                     // EXEC-inactive lane's mask bit is written 0, never its raw carry.
                     const uint32_t cout_masked = rs.exec_narrowed ? b.land(rs.exec, cout) : cout;
-                    if (in.sdst.kind == OperandKind::SGPR && b.allow_b32_masks &&
-                        (b.is_fragment || (b.is_compute && b.wave_size == 32))) {
-                        // In Wave32 every VOP3B carry destination is one physical word. In
-                        // particular, a VCC_LO carry write must not clobber an independently-live
-                        // VCC_HI compare mask (Astro world-map PC1879 -> PC1881).
-                        rs.sreg_bool[in.sdst.value] = cout_masked;
-                        rs.sreg_bool_narrowed[in.sdst.value] = true;
-                        rs.sreg_bool_b32.insert(in.sdst.value);
-                        rs.sreg.erase(in.sdst.value);
-                        rs.sreg_srt.erase(in.sdst.value);
-                        if (in.sdst.value == 106) rs.vcc = cout_masked;
-                    } else if (in.sdst.value == 106 || in.sdst.value == 107) {
-                        rs.vcc = cout_masked;
-                    } else if (in.sdst.kind == OperandKind::SGPR) {
-                        rs.sreg_bool[in.sdst.value] = cout_masked;
-                    }
+                    write_vop3b_carry_output(cout_masked);
                 }
             } else if ((in.opcode == 0x365 || in.opcode == 0x366) && b.ngg_logical_lane &&
                        in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1) {
@@ -12430,7 +12448,8 @@ bool emit_cfg_state_machine(
             const bool wave32_one_word_mask = proven_wave32_masks &&
                 ((in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode)) ||
                  (in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 &&
-                  in.opcode <= 0x12a && base == in.sdst.value));
+                  in.opcode <= 0x12a && base == in.sdst.value) ||
+                 (vop3b_fresh_carry_output(in) && base == in.sdst.value));
             if (wave32_one_word_mask)
                 static_mask_keys.insert(base);
             else if (base <= 105 && scalar_write_is_b64_mask(in, base))
@@ -12825,8 +12844,9 @@ bool emit_cfg_state_machine(
                 (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x43);
             for_each_scalar_write(in, [&](int base, uint32_t width) {
                 const bool wave32_vop3b = proven_wave32_masks &&
-                    in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 &&
-                    in.opcode <= 0x12a && base == in.sdst.value;
+                    ((in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 &&
+                      in.opcode <= 0x12a) || vop3b_fresh_carry_output(in)) &&
+                    base == in.sdst.value;
                 const uint32_t effective_width = wave32_vop3b ? 1u : width;
                 for (uint32_t word = 0; word < effective_width; ++word)
                     scalar_writes[block].insert(base + static_cast<int>(word));
@@ -13021,6 +13041,8 @@ bool emit_cfg_state_machine(
                     in.opcode <= 0x12a && in.sdst.kind == OperandKind::SGPR) {
                     const Operand& carry_in = in.src[2];
                     if (register_mask(carry_in)) b32_write_reg = in.sdst.value;
+                } else if (vop3b_fresh_carry_output(in)) {
+                    b32_write_reg = in.sdst.value;
                 }
 
                 // B64 mask-shaped instructions are not sufficient to prove a live mask lifetime:
@@ -13044,7 +13066,8 @@ bool emit_cfg_state_machine(
                         writes_b64_mask = source_mask(in.src[0]) && source_mask(in.src[1]);
                 }
                 const bool vop3_b32_carry = in.fmt == Rdna2Format::VOP3 &&
-                    in.opcode >= 0x128 && in.opcode <= 0x12a;
+                    ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
+                     vop3b_fresh_carry_output(in));
                 // rdna2_decode populates `sdst` only for its explicit ten-opcode VOP3B whitelist:
                 // add/sub carry, div-scale flag, and 64-bit multiply-add carry outputs. Each SDST
                 // is a per-lane scalar mask/flag; ordinary VOP3A scalar data never appears here

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9948,6 +9948,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     ok = false; return true;   // unresolvable V# -> reject; NEVER default to binding 2
                 }
+                if (is_zero_record_raw_buffer(*res)) {
+                    // The front half proved all four live V# words at this exact instruction and
+                    // decoded NUM_RECORDS=0. RDNA2's OOB contract returns zero for every raw load
+                    // component and drops raw stores. Keep inactive lanes' destination values just
+                    // like a normal EXEC-predicated load, and never touch a shared dummy buffer on
+                    // the store side. Atomics are outside the producer's admitted subset and remain
+                    // fail-closed if a hand-built table tries to apply the marker to one.
+                    if (is_atomic) { ok = false; return true; }
+                    if (is_store) return true;
+                    for (uint32_t k = 0; k < n; ++k) {
+                        const int d = in.dst.value + static_cast<int>(k);
+                        const uint32_t old = vreg_old(b, rs, d);
+                        rs.vreg[d] = b.uconst(0);
+                        predicate_write(b, rs, d, old);
+                    }
+                    return true;
+                }
                 resolved_buffer = res;
                 binding = res->binding;
                 stride  = res->stride;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6008,7 +6008,7 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
         case OperandKind::InlineFloat: return b.uconst(fbits(inline_float_value((uint32_t)o.value)));
         case OperandKind::Literal:     return b.uconst(in.literal);
-        case OperandKind::Special:
+        case OperandKind::Special: {
             if (o.value == 125) return b.uconst(0);   // SGPR_NULL: the one Special whose data value IS 0
             if (o.value == 253) {                     // SCC scalar source
                 // rs.scc == 0 marks SCC poisoned by a 64-bit mask op (its SCC is a cross-lane
@@ -6033,11 +6033,10 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
             // is zero. Compute/fragment keep their real multi-lane masks and must not take this path.
             if (!b.is_compute && !b.is_fragment && (o.value == 106 || o.value == 107))
                 return o.value == 106 ? b.sel(rs.vcc, b.uconst(1), b.uconst(0)) : b.uconst(0);
-            // VCC read as scalar DATA, materialised exactly (#2420). GTA V computes a descriptor-table
-            // pointer from the compare mask -- `s_add_u32 s60, s36, vcc_lo` -- and a per-invocation
-            // bool has no 32-bit value to add, so s60 became unknown, its s_load's base was unknown,
-            // the MUBUF reading that SRSRC could not fold, and the shader rejected. 23,166 draws of
-            // that title die this way (#2412).
+            // VCC/EXEC read as scalar DATA, materialised exactly (#2420/#2481). GTA V computes a
+            // descriptor-table pointer from VCC_LO in graphics shaders, and a Wave64 compute kernel
+            // negates EXEC as an integer pair (`s_sub_u32 ...,exec_lo`; `s_subb_u32 ...,exec_hi`). A
+            // per-invocation bool has no complete 32-bit value for either sequence.
             //
             // `subgroupBallot` supplies those bits EXACTLY, and only under one condition: its .x/.y
             // are lanes 0..31 / 32..63 of THIS SUBGROUP, so it equals the guest wave mask only when
@@ -6045,12 +6044,15 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
             // were whole -- a wrong descriptor address, i.e. silent wrong rendering. So the exact-size
             // contract is required, and anything else keeps rejecting exactly as before.
             //
-            // Reached only on the path that already sets ok=false, so this can only turn a reject into
-            // working code; no shader that compiles today changes.
-            if ((o.value == 106 || o.value == 107) && rs.vcc &&
-                b.native_subgroup_size && b.native_subgroup_size == b.wave_size) {
+            // This is the final path before the operand is rejected, so it can only turn a previous
+            // reject into working code; no shader that already compiled changes.
+            const bool reads_vcc = o.value == 106 || o.value == 107;
+            const bool reads_exec = o.value == 126 || o.value == 127;
+            const uint32_t mask = reads_vcc ? rs.vcc : reads_exec ? rs.exec : 0;
+            if (mask && b.native_subgroup_size && b.native_subgroup_size == b.wave_size) {
                 const uint32_t half =
-                    b.native_wave_ballot_half(rs.vcc, o.value == 106 ? 0u : 1u);
+                    b.native_wave_ballot_half(mask,
+                        (o.value == 106 || o.value == 126) ? 0u : 1u);
                 if (half) return half;
             }
             if (ok) *ok = false;
@@ -6060,6 +6062,7 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
                              in.pc, o.value, rs.sreg.contains(o.value),
                              rs.sreg_bool.contains(o.value));
             return b.uconst(0);
+        }
         default:
             if (ok) *ok = false;
             return b.uconst(0);
@@ -7555,6 +7558,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     d = b.ibin(Op_IAdd, s1, cin);
                     uint32_t k2 = b.ucmp(Op_ULessThan, d, s1);        // wrap in +cin
                     rs.scc = b.bsel(k1, b.btrue(), k2); break;
+                }
+                case 0x05: {   // s_subb_u32: dst = src0 - src1 - SCC(borrow-in); SCC = borrow-out.
+                    if (!rs.scc) { ok = false; break; }   // SCC poisoned by a mask op: borrow-in unknown
+                    const uint32_t bin = b.sel(rs.scc, b.uconst(1), b.uconst(0));
+                    const uint32_t difference = b.ibin(Op_ISub, a, c);
+                    const uint32_t first_borrow = b.ucmp(Op_ULessThan, a, c);
+                    d = b.ibin(Op_ISub, difference, bin);
+                    const uint32_t second_borrow = b.ucmp(Op_ULessThan, difference, bin);
+                    rs.scc = b.bsel(first_borrow, b.btrue(), second_borrow); break;
                 }
                 // s_min/max (0x06 min_i32, 0x07 min_u32, 0x08 max_i32, 0x09 max_u32): SCC = "src0 was
                 // selected", STRICT in both directions per the ISA pseudocode (S_MIN: SCC = S0 < S1;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -11015,7 +11015,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     in.mimg_glc || in.src[2].value != 0 || (in.words[4] & 0xffff0000u) != 0u ||
                     !bvh || bvh->cls != ResourceClass::ConstantBuffer ||
                     bvh->format != DataFormat::Uint32 || bvh->num_components != 1u ||
-                    bvh->size < 128u || (bvh->size & 3u) != 0u) {
+                    bvh->size < 64u || (bvh->size & 3u) != 0u) {
                     ok = false;
                     return true;
                 }
@@ -11049,7 +11049,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t dword_count = bvh->size / 4u;
                 const uint32_t valid64 = b.ucmp(
                     Op_ULessThanEqual, node_offset, b.uconst((bvh->size - 64u) / 8u));
-                const uint32_t valid128 = b.ucmp(
+                const uint32_t valid128 = bvh->size < 128u ? b.bfalse() : b.ucmp(
                     Op_ULessThanEqual, node_offset, b.uconst((bvh->size - 128u) / 8u));
 
                 // Every speculative load is independently clamped to dword zero. Results from a

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7795,6 +7795,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     ? b.bfe_s(a, b.uconst(offset), b.uconst(bits))
                     : b.bfe_u(a, b.uconst(offset), b.uconst(bits));
             }
+            // SDWA BREV selects and zero-extends its byte/word before reversing the resulting
+            // dword. The decoder admits only this unmodified full-destination subset, so neither
+            // sign extension nor destination preservation can reach this path.
+            if (in.opcode == 0x38 && in.has_sdwa && in.sdwa_src0_sel <= 5) {
+                const uint32_t bits = in.sdwa_src0_sel <= 3 ? 8u : 16u;
+                const uint32_t offset = in.sdwa_src0_sel <= 3
+                    ? 8u * in.sdwa_src0_sel : 16u * (in.sdwa_src0_sel - 4u);
+                a = b.bfe_u(a, b.uconst(offset), b.uconst(bits));
+            }
             if (in.opcode == 0x02) {   // v_readfirstlane_b32: SGPR dst = value of the lowest active lane
                 // Cross-lane broadcast. Our per-lane scalar model has no cross-lane reduction, so we use
                 // THIS lane's value. SPECULATIVE(confidence: med): exact only when src0 is wave-uniform —

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3417,6 +3417,12 @@ struct RegState {
     std::unordered_set<int> sreg_bool_b32;
     std::unordered_map<int, uint32_t> sreg_srt;    // SGPR holding a descriptor -> its user_data/SRT byte offset
                                                    // (descriptor provenance: s_load_dwordx4 tags, s_buffer_load resolves)
+    // Immediate S_LOAD_DWORDX16 is typeless: it can be ordinary scalar data, or two adjacent
+    // eight-dword T# descriptors. The latter is admitted only after a whole-stream use proof (see
+    // proven_smem_x16_descriptor_loads). These are load PCs, not SRT keys: an x16 bundle contains
+    // two resources at one byte offset, so every consumer must retain exact-PC provenance.
+    std::unordered_set<uint32_t> smem_x16_descriptor_loads;
+    bool smem_x16_descriptor_analysis_done = false;
     uint32_t vcc = 0;
     uint32_t scc = 0;          // scalar condition code (bool); set by s_cmp_*/SCC-writing SOP2, read by s_cselect
     // #2418: does this shader read SCC anywhere? A STATIC property of the decoded stream, computed
@@ -5156,6 +5162,230 @@ void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit,
         visit(in.sdst.value, wave32_one_word_masks &&
                               ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
                                vop3b_fresh_carry_output(in)) ? 1u : 2u);
+}
+
+// Prove the narrow S_LOAD_DWORDX16 descriptor-bundle shape used by GTA V compute kernels. A wide
+// scalar load is not intrinsically a descriptor fetch: accepting every x16 as two T#s would replace
+// real scalar data with zero placeholders. For each candidate, follow all sixteen loaded words to
+// overwrite/end and require BOTH aligned eight-word halves to be consumed as MIMG SRSRCs. Every such
+// consumer must have its own key-less exact-PC image resource; an SRT tag cannot name two descriptors
+// packed under the load's one immediate offset.
+//
+// The only scalar transformation admitted is the captured compiler's T#.word3 patch (with at most
+// one independent VOP scheduled between the two scalar operations):
+//
+//   s_and_b32 tmp, tword3, 0x0fffffff
+//   s_or_b32  tword3, tmp, 0xd0000000
+//
+// All ordinary scalar/vector reads, partial descriptor writes, samplers overlapping the bundle, and
+// scalar control flow reject the candidate. This is deliberately a use proof, not an opcode-wide
+// declaration that x16 loads are descriptors. CONFIDENCE: HIGH for the admitted shape: the front-half
+// snapshots both halves and publishes the live descriptor at each exact MIMG PC.
+bool smem_x16_patch_gap_reads_implicit_state(const Rdna2Inst& in, int temporary) {
+    // The AND's SCC is descriptor-derived until the matching OR overwrites it. Vector ALU can name
+    // SCC as the scalar source encoding even though it is outside the ordinary SGPR/special range.
+    for (uint32_t source = 0; source < in.n_src; ++source)
+        if (in.src[source].kind == OperandKind::Special && in.src[source].value == 253)
+            return true;
+
+    // E32 cndmask and carry forms consume architectural VCC without exposing it in n_src. This is
+    // observable descriptor-derived data when the compiler chose VCC_LO as its word3 temporary.
+    return (temporary == 106 || temporary == 107) && in.fmt == Rdna2Format::VOP2 &&
+           (in.opcode == 0x01u || (in.opcode >= 0x28u && in.opcode <= 0x2au));
+}
+
+std::unordered_set<uint32_t> proven_smem_x16_descriptor_loads(
+        const std::vector<Rdna2Inst>& ins, const ShaderResourceTable* rt) {
+    std::unordered_set<uint32_t> proven;
+    if (!rt || ins.empty()) return proven;
+
+    // Alternate entries would require path-sensitive lifetime/provenance joins. Keep this first
+    // admission linear: hints, waits and barriers are transparent; every real scalar branch or
+    // indirect PC transfer makes the whole candidate ineligible.
+    for (const Rdna2Inst& in : ins) {
+        if (in.is_end) continue;
+        if (in.fmt == Rdna2Format::SOP1 && in.opcode >= 0x20u && in.opcode <= 0x22u)
+            return proven;
+        if (in.fmt == Rdna2Format::SOPP && !sopp_is_noop(in) && in.opcode != 0x0au)
+            return proven;
+    }
+
+    auto scalar_operand = [](const Operand& operand) {
+        return operand.kind == OperandKind::SGPR ||
+               (operand.kind == OperandKind::Special &&
+                operand.value >= 106 && operand.value <= 124);
+    };
+    auto literal_is = [](const Rdna2Inst& in, const Operand& operand, uint32_t value) {
+        return operand.kind == OperandKind::Literal && in.literal == value;
+    };
+
+    for (size_t load_index = 0; load_index < ins.size(); ++load_index) {
+        const Rdna2Inst& load = ins[load_index];
+        if (load.is_end || load.fmt != Rdna2Format::SMEM || load.opcode != 0x04u ||
+            load.dst.kind != OperandKind::SGPR || load.dst.value < 0 ||
+            load.dst.value + 15 > 105 ||
+            load.src[1].kind != OperandKind::Special || load.src[1].value != 125 ||
+            static_cast<int32_t>(load.literal) < 0)
+            continue;
+
+        const int base = load.dst.value;
+        uint16_t live = 0xffffu;
+        bool consumed[2] = {false, false};
+        bool valid = true;
+        auto live_overlap = [&](int first, uint32_t words) {
+            if (first < 0 || !words) return false;
+            for (uint32_t word = 0; word < words; ++word) {
+                const int relative = first + static_cast<int>(word) - base;
+                if (relative >= 0 && relative < 16 &&
+                    (live & static_cast<uint16_t>(1u << relative)))
+                    return true;
+            }
+            return false;
+        };
+        auto clear_written = [&](int first, uint32_t words) {
+            if (first < 0) return;
+            for (uint32_t word = 0; word < words; ++word) {
+                const int relative = first + static_cast<int>(word) - base;
+                if (relative >= 0 && relative < 16)
+                    live &= static_cast<uint16_t>(~(1u << relative));
+            }
+        };
+
+        for (size_t index = load_index + 1; valid && index < ins.size(); ++index) {
+            const Rdna2Inst& in = ins[index];
+            if (in.is_end) break;
+
+            // Recognize the complete word3 patch as one unit. One captured variant schedules an
+            // independent VOP between the two scalar instructions; admit that exact one-instruction
+            // gap only when it cannot observe or replace either the descriptor bundle or temporary.
+            bool patched = false;
+            if (index + 1 < ins.size() && in.fmt == Rdna2Format::SOP2 &&
+                in.opcode == 0x0eu && in.dst.kind == OperandKind::SGPR &&
+                in.src[0].kind == OperandKind::SGPR &&
+                literal_is(in, in.src[1], 0x0fffffffu)) {
+                const int descriptor_word = in.src[0].value;
+                const int half = descriptor_word == base + 3 ? 0
+                               : descriptor_word == base + 11 ? 1 : -1;
+                // The retained GTA V shape uses VCC_LO exactly. Do not generalize this to M0 or
+                // other architectural scalar registers: their implicit consumers are not all in the
+                // ordinary SGPR liveness inventory (DS observes M0 without a decoded scalar source).
+                const bool exact_patch_temporary = in.dst.value == 106;
+                size_t join_index = index + 1;
+                const Rdna2Inst& possible_gap = ins[join_index];
+                if (possible_gap.fmt != Rdna2Format::SOP2 || possible_gap.opcode != 0x10u) {
+                    bool transparent_gap = possible_gap.fmt == Rdna2Format::VOP1 ||
+                                           possible_gap.fmt == Rdna2Format::VOP2 ||
+                                           possible_gap.fmt == Rdna2Format::VOP3;
+                    if (transparent_gap &&
+                        smem_x16_patch_gap_reads_implicit_state(possible_gap, in.dst.value))
+                        transparent_gap = false;
+                    for (uint32_t source = 0;
+                         transparent_gap && source < possible_gap.n_src; ++source) {
+                        if (!scalar_operand(possible_gap.src[source])) continue;
+                        if (possible_gap.src[source].value == in.dst.value ||
+                            live_overlap(possible_gap.src[source].value, 2))
+                            transparent_gap = false;
+                    }
+                    for_each_scalar_write(possible_gap, [&](int first, uint32_t words) {
+                        if (live_overlap(first, words) ||
+                            (in.dst.value >= first &&
+                             in.dst.value < first + static_cast<int>(words)))
+                            transparent_gap = false;
+                    });
+                    if (transparent_gap) ++join_index;
+                }
+                const Rdna2Inst& join = join_index < ins.size() ? ins[join_index] : in;
+                const bool temporary_unobserved = join_index + 1 >= ins.size() ||
+                    sgpr_dead_at_merge(ins, ins[join_index + 1].pc, in.dst.value);
+                const bool exact_join = half >= 0 && exact_patch_temporary &&
+                    join_index < ins.size() && join.fmt == Rdna2Format::SOP2 &&
+                    join.opcode == 0x10u && join.dst.kind == OperandKind::SGPR &&
+                    join.dst.value == descriptor_word && scalar_operand(join.src[0]) &&
+                    join.src[0].value == in.dst.value &&
+                    literal_is(join, join.src[1], 0xd0000000u) && temporary_unobserved;
+                const uint16_t word_bit = half >= 0
+                    ? static_cast<uint16_t>(1u << (descriptor_word - base)) : 0u;
+                if (exact_join && (live & word_bit)) {
+                    patched = true;
+                    index = join_index;
+                }
+            }
+            if (patched) continue;
+
+            if (in.fmt == Rdna2Format::MIMG) {
+                const bool t_is_scalar = in.src[1].kind == OperandKind::SGPR;
+                const int half = t_is_scalar && in.src[1].value == base ? 0
+                               : t_is_scalar && in.src[1].value == base + 8 ? 1 : -1;
+                const bool touches_t = t_is_scalar && live_overlap(in.src[1].value, 8);
+                const bool touches_sampler = scalar_operand(in.src[2]) &&
+                                             live_overlap(in.src[2].value, 4);
+                if (touches_sampler) { valid = false; break; }
+                if (half >= 0) {
+                    const uint16_t half_mask = static_cast<uint16_t>(0xffu << (half * 8));
+                    const ShaderResource* resource = rt->by_fetch_pc(in.pc);
+                    const bool exact_image = resource && resource->fetch_pc == in.pc &&
+                        resource->srt_offset == 0xffffffffu &&
+                        resource->sgpr_base == 0xffffffffu &&
+                        (resource->cls == ResourceClass::Texture ||
+                         resource->cls == ResourceClass::StorageImage);
+                    if ((live & half_mask) != half_mask || !exact_image) {
+                        valid = false;
+                        break;
+                    }
+                    consumed[half] = true;
+                    continue;
+                }
+                if (touches_t) { valid = false; break; }
+            }
+
+            // Bound implicit descriptor/address reads before the generic decoded operands. These
+            // packet formats encode a base SGPR while consuming a wider range.
+            if (in.fmt == Rdna2Format::SMEM) {
+                const uint32_t base_words = in.opcode >= 0x08u ? 4u : 2u;
+                if (scalar_operand(in.src[0]) && live_overlap(in.src[0].value, base_words)) {
+                    valid = false;
+                    break;
+                }
+                if (scalar_operand(in.src[1]) && live_overlap(in.src[1].value, 1)) {
+                    valid = false;
+                    break;
+                }
+            } else if (in.fmt == Rdna2Format::MUBUF || in.fmt == Rdna2Format::MTBUF) {
+                if ((in.src[1].kind == OperandKind::SGPR &&
+                     live_overlap(in.src[1].value, 4)) ||
+                    (scalar_operand(in.src[2]) && live_overlap(in.src[2].value, 1))) {
+                    valid = false;
+                    break;
+                }
+            } else {
+                for (uint32_t source = 0; source < in.n_src; ++source) {
+                    if (!scalar_operand(in.src[source])) continue;
+                    const uint32_t words =
+                        in.fmt == Rdna2Format::SOP1 ||
+                        in.fmt == Rdna2Format::SOP2 ||
+                        in.fmt == Rdna2Format::SOPC ||
+                        in.fmt == Rdna2Format::VOP3 ? 2u : 1u;
+                    if (live_overlap(in.src[source].value, words)) {
+                        valid = false;
+                        break;
+                    }
+                }
+                if (!valid) break;
+            }
+
+            // SOPK read/modify/write forms do not expose their implicit destination read through
+            // n_src. Treat every live overlap conservatively; the target descriptor bundles use no
+            // SOPK writes, so widening this is unnecessary.
+            if (in.fmt == Rdna2Format::SOPK && in.dst.kind == OperandKind::SGPR &&
+                live_overlap(in.dst.value, 1)) {
+                valid = false;
+                break;
+            }
+            for_each_scalar_write(in, clear_written);
+        }
+        if (valid && consumed[0] && consumed[1]) proven.insert(load.pc);
+    }
+    return proven;
 }
 
 // ---------------------------------------------------------------------------------------------
@@ -9884,6 +10114,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
+            // GTA V packs two adjacent T# descriptors into one immediate S_LOAD_DWORDX16. Admit
+            // only the load PCs certified by the whole-stream proof above. The values are resource
+            // provenance, not scalar data used by the emitted module, so placeholders are exact;
+            // unlike x4/x8, DO NOT attach the load's one SRT offset to either half. Both resources
+            // are key-less and every MIMG consumer resolves by its own fetch_pc.
+            if (rt && !cbuf_resolved && in.opcode == 0x04u &&
+                rs.smem_x16_descriptor_loads.contains(in.pc)) {
+                for (uint32_t k = 0; k < n; ++k) {
+                    rs.sreg[in.dst.value + static_cast<int>(k)] = b.uconst(0);
+                    rs.sreg_srt.erase(in.dst.value + static_cast<int>(k));
+                }
+                // A shared tag here aliases both halves. Keep the invariant executable so the
+                // paired-resource regression fails under a same-site tag mutation.
+                uint32_t accidental_tag = 0;
+                if (sreg_srt_range_tag(rs, in.dst.value, 8, accidental_tag) ||
+                    sreg_srt_range_tag(rs, in.dst.value + 8, 8, accidental_tag)) {
+                    ok = false;
+                }
+                return true;
+            }
             // A data load with a runtime table may retain the legacy binding-2 convention only when
             // that table actually binds a buffer there. VS/compute tables start at binding 2 and use
             // this path legitimately; PS tables start at 32, where keeping the fallback would emit an
@@ -14049,6 +14299,8 @@ bool emit_cfg_state_machine(
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
         RegState state;
         state.sreg_input = initial.sreg_input;
+        state.smem_x16_descriptor_loads = initial.smem_x16_descriptor_loads;
+        state.smem_x16_descriptor_analysis_done = initial.smem_x16_descriptor_analysis_done;
         for (const auto& kv : vv) {
             if (dispatch != UINT32_MAX &&
                 !dispatch_vector_reads[dispatch].contains(kv.first)) continue;
@@ -15665,6 +15917,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                // code/dwords: raw stream for forward-if target checks; inherited_dead_masks keeps
                // whole-shader liveness valid when a barrier-separated body is compiled in phases.
     rs.max_vgpr = std::max(rs.max_vgpr, shader_max_vgpr(ins));
+    if (!rs.smem_x16_descriptor_analysis_done) {
+        rs.smem_x16_descriptor_loads = proven_smem_x16_descriptor_loads(ins, rt);
+        rs.smem_x16_descriptor_analysis_done = true;
+    }
     // Fold PC-relative embedded-table loads (s_getpc_b64-built V#s) before the walk — emit_alu's
     // SMEM/MUBUF/SOP1 handlers consult the proven table maps (#273/#1054).
     if (code) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7909,6 +7909,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x36: d = b.fext1(Glsl_Cos, b.fbin(Op_FMul, a, b.uconst(fbits(6.28318530717958647692f)))); break;
                 case 0x37: d = b.iun(Op_Not, a); break;               // v_not_b32
                 case 0x38: d = b.iun(Op_BitReverse, a); break;        // v_bfrev_b32
+                case 0x39: {                                         // v_ffbh_u32 (plain e32)
+                    // AMD RDNA2 ISA: count the zeroes preceding the first set bit from the MSB;
+                    // return -1 when no bit is set. GLSL.std.450 FindUMsb instead returns the SET
+                    // BIT INDEX (and all bits set at zero). OR bit zero in before calling it (which
+                    // leaves every nonzero input's highest bit unchanged), convert index -> count,
+                    // then explicitly select the architectural zero sentinel. GTA V uses the exact in-place
+                    // e32 packets 7e087304 / 7e047302 in its compute culling kernels.
+                    //
+                    // Keep SDWA out of this admission. The decoder's generic DWORD SDWA path can
+                    // carry NEG/ABS, which the VOP1 prologue above applies in the f32 domain; that
+                    // is not an integer source modifier and would silently change FFBH's operand.
+                    // DPP reaches and rejects in the stage-specific source-transform block above.
+                    if (in.has_sdwa || in.has_dpp) { ok = false; break; }
+                    const uint32_t safe = b.ibin(Op_BitwiseOr, a, b.uconst(1));
+                    const uint32_t leading_zeroes = b.ibin(
+                        Op_ISub, b.uconst(31), b.find_umsb(safe));
+                    d = b.sel(b.ucmp(Op_INotEqual, a, b.uconst(0)),
+                              leading_zeroes, b.uconst(0xffffffffu));
+                    break;
+                }
                 case 0x43: {   // v_movrels_b32: dst = VGPR[src0# + M0] (relative-indexed VGPR read)
                     // M0 is written by plain scalar ALU (s_mov/s_or m0, … decode dst as SGPR 124), so
                     // its per-invocation value lives in rs.sreg[124]. The source register NUMBER is

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13304,9 +13304,12 @@ bool emit_cfg_state_machine(
     // Wave64 dispatcher Bool variables hold values, not lifetime tags. A scalar overwrite stores
     // false for a dead mask, and an unfiltered load at a later case can therefore make mere map
     // membership look like a valid saved mask. Prove the B64 mask domain separately at every
-    // Wave64 whole-mask comparisons (EXEC-vs-saved or saved-vs-saved): mask producers generate the
-    // fact, every overlapping half/pair scalar write kills it, and joins retain it only when all
-    // reachable predecessors agree.
+    // Wave64 whole-mask comparisons (mask-vs-zero, EXEC-vs-saved or saved-vs-saved): mask producers
+    // generate the fact, every overlapping half/pair scalar write kills it, and joins retain it only
+    // when all reachable predecessors agree. Architectural VCC lives in `state.vcc`, not in the
+    // saved-mask map, so this proof is also the lifetime tag that lets the dispatcher distinguish a
+    // live VCC mask from a physical VCC pair that has been recycled as scalar data.
+    std::unordered_set<uint32_t> proven_wave64_mask_zero_compare_pcs;
     std::unordered_set<uint32_t> proven_exec_saved_mask_compare_pcs;
     if ((b.is_compute || b.is_fragment) && b.wave_size == 64 && !starts.empty()) {
         std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
@@ -13319,6 +13322,10 @@ bool emit_cfg_state_machine(
 
         auto advance_wave64_b64_masks = [&](std::set<int>& masks, const Rdna2Inst& in,
                                             bool record_compare) {
+            const int zero_compare_source = mask_zero_compare_candidate_source(in);
+            if (record_compare && zero_compare_source >= 0 &&
+                masks.contains(zero_compare_source))
+                proven_wave64_mask_zero_compare_pcs.insert(in.pc);
             const int compare_source = exec_saved_mask_compare_source(in);
             if (record_compare && compare_source >= 0 && masks.contains(compare_source))
                 proven_exec_saved_mask_compare_pcs.insert(in.pc);
@@ -13420,6 +13427,19 @@ bool emit_cfg_state_machine(
             }
         }
     }
+
+    auto mask_zero_compare_is_proven = [&](const Rdna2Inst& in) {
+        // Wave32 has its own one-word MUST-domain filtering in load_state. Wave64 needs the
+        // pair-width analysis above because a persisted Bool value is not itself a lifetime tag.
+        return b.wave_size != 64 || proven_wave64_mask_zero_compare_pcs.contains(in.pc);
+    };
+    auto mask_zero_compare_value = [&](const RegState& state, int source) -> uint32_t {
+        // The current GTA V sites name canonical VCC_LO as the low word of a B64 source. Its exact
+        // per-lane value is stored separately from ordinary saved SGPR masks.
+        if (b.wave_size == 64 && source == 106) return state.vcc;
+        const auto found = state.sreg_bool.find(source);
+        return found == state.sreg_bool.end() ? 0 : found->second;
+    };
 
     // Fragment scalar PCs are lane-local in the dispatcher.  A saved-mask pair comparison must
     // nevertheless vote over every lane in the guest wave, including lanes currently executing a
@@ -14027,7 +14047,8 @@ bool emit_cfg_state_machine(
                 const int mask_compare_source =
                     mask_zero_compare_candidate_source(in);
                 if (mask_compare_source >= 0 &&
-                    state.sreg_bool.contains(mask_compare_source)) {
+                    mask_zero_compare_is_proven(in) &&
+                    mask_zero_compare_value(state, mask_compare_source)) {
                     if (getenv("PROSPER_DBG"))
                         std::fprintf(stderr,
                                      "[compute-mask-compare] pc=%u source=s%d op=0x%x\n",
@@ -14334,19 +14355,19 @@ bool emit_cfg_state_machine(
                 return false;
             }
             const int source = mask_zero_compare_candidate_source(*mask_compare);
-            const auto value = state.sreg_bool.find(source);
-            if (value == state.sreg_bool.end())
+            const uint32_t value = mask_zero_compare_value(state, source);
+            if (!mask_zero_compare_is_proven(*mask_compare) || !value)
                 return reject_cfg(mask_compare->pc, "missing-mask-compare-source");
             if (b.native_subgroup_size || b.is_fragment) {
                 const uint32_t wave_any = b.is_fragment
-                    ? b.fragment_wave_any(value->second)
-                    : b.native_wave_any(value->second);
+                    ? b.fragment_wave_any(value)
+                    : b.native_wave_any(value);
                 if (!wave_any) return reject_cfg(mask_compare->pc, "mask-vote");
                 state.scc = mask_zero_compare_inverts(*mask_compare)
                     ? b.logical_not(wave_any) : wave_any;
             } else {
                 b.store_function(vote_pending_var, yes);
-                b.store_function(vote_value_var, value->second);
+                b.store_function(vote_value_var, value);
                 b.store_function(vote_invert_var,
                     mask_zero_compare_inverts(*mask_compare) ? yes : no);
                 b.store_function(vote_to_scc_var, yes);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7909,26 +7909,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x36: d = b.fext1(Glsl_Cos, b.fbin(Op_FMul, a, b.uconst(fbits(6.28318530717958647692f)))); break;
                 case 0x37: d = b.iun(Op_Not, a); break;               // v_not_b32
                 case 0x38: d = b.iun(Op_BitReverse, a); break;        // v_bfrev_b32
-                case 0x39: {                                         // v_ffbh_u32 (plain e32)
-                    // AMD RDNA2 ISA: count the zeroes preceding the first set bit from the MSB;
-                    // return -1 when no bit is set. GLSL.std.450 FindUMsb instead returns the SET
-                    // BIT INDEX (and all bits set at zero). OR bit zero in before calling it (which
-                    // leaves every nonzero input's highest bit unchanged), convert index -> count,
-                    // then explicitly select the architectural zero sentinel. GTA V uses the exact in-place
-                    // e32 packets 7e087304 / 7e047302 in its compute culling kernels.
-                    //
-                    // Keep SDWA out of this admission. The decoder's generic DWORD SDWA path can
-                    // carry NEG/ABS, which the VOP1 prologue above applies in the f32 domain; that
-                    // is not an integer source modifier and would silently change FFBH's operand.
-                    // DPP reaches and rejects in the stage-specific source-transform block above.
-                    if (in.has_sdwa || in.has_dpp) { ok = false; break; }
-                    const uint32_t safe = b.ibin(Op_BitwiseOr, a, b.uconst(1));
-                    const uint32_t leading_zeroes = b.ibin(
-                        Op_ISub, b.uconst(31), b.find_umsb(safe));
-                    d = b.sel(b.ucmp(Op_INotEqual, a, b.uconst(0)),
-                              leading_zeroes, b.uconst(0xffffffffu));
-                    break;
-                }
                 case 0x43: {   // v_movrels_b32: dst = VGPR[src0# + M0] (relative-indexed VGPR read)
                     // M0 is written by plain scalar ALU (s_mov/s_or m0, … decode dst as SGPR 124), so
                     // its per-invocation value lives in rs.sreg[124]. The source register NUMBER is

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7586,6 +7586,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x0E: d = b.ibin(Op_BitwiseAnd, a, c); scc_nz(d); break;   // s_and_b32
                 case 0x10: d = b.ibin(Op_BitwiseOr,  a, c); scc_nz(d); break;   // s_or_b32
                 case 0x12: d = b.ibin(Op_BitwiseXor, a, c); scc_nz(d); break;   // s_xor_b32
+                case 0x14: d = b.ibin(Op_BitwiseAnd, a, b.iun(Op_Not, c));       // s_andn2_b32
+                           scc_nz(d); break;
+                case 0x16: d = b.ibin(Op_BitwiseOr, a, b.iun(Op_Not, c));        // s_orn2_b32
+                           scc_nz(d); break;
+                case 0x18: d = b.iun(Op_Not, b.ibin(Op_BitwiseAnd, a, c));       // s_nand_b32
+                           scc_nz(d); break;
+                case 0x1A: d = b.iun(Op_Not, b.ibin(Op_BitwiseOr, a, c));        // s_nor_b32
+                           scc_nz(d); break;
+                case 0x1C: d = b.iun(Op_Not, b.ibin(Op_BitwiseXor, a, c));       // s_xnor_b32
+                           scc_nz(d); break;
                 case 0x1E: { uint32_t sh = b.ibin(Op_BitwiseAnd, c, b.uconst(31));   // s_lshl_b32
                              d = b.ibin(Op_ShiftLeftLogical, a, sh); scc_nz(d); break; }  // dst = src0 << (src1 & 31)
                 case 0x24: { uint32_t w  = b.ibin(Op_BitwiseAnd, a, b.uconst(0x1f));   // s_bfm_b32: bitfield mask

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4486,21 +4486,6 @@ uint32_t vgpr_write_count(const Rdna2Inst& in) {
     }
 }
 
-bool instruction_may_change_exec(const Rdna2Inst& in) {
-    if (in.fmt == Rdna2Format::VOPC && vopc_is_cmpx(in.opcode)) return true;
-    // saveexec writes EXEC implicitly while its explicit destination receives the previous mask.
-    if (in.fmt == Rdna2Format::SOP1 &&
-        ((in.opcode >= 0x24 && in.opcode <= 0x2b) ||
-         in.opcode == 0x37 || in.opcode == 0x38 ||
-         in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44))
-        return true;
-    auto is_exec = [](const Operand& operand) {
-        return (operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
-               (operand.value == 126 || operand.value == 127);
-    };
-    return is_exec(in.dst) || is_exec(in.sdst);
-}
-
 // IMAGE_GET_LOD currently models only the ordinary FP32 sampled-image form. Keep the unsupported
 // Table 100 control families separate so each can be mutation-tested, while production and the
 // table-less coverage classifier consume one shared predicate and cannot drift apart.
@@ -4607,7 +4592,7 @@ bool vcc_exit_is_wave_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch
             // EXEC rule: any later mask change could expose a lane that retained an older value.
             for (const auto& between : ins)
                 if (between.pc > it->pc && between.pc < compare->pc &&
-                    instruction_may_change_exec(between)) return false;
+                    rdna2_instruction_may_change_exec(between)) return false;
 
             bool pure_lane_alu = false;
             if (it->fmt == Rdna2Format::VOP1) {
@@ -5551,7 +5536,7 @@ bool vcc_branch_is_workgroup_uniform(const std::vector<Rdna2Inst>& ins, uint32_t
     // Obligation (1): EXEC is full at the branch along every path.
     const std::vector<uint8_t> exec_full = must_fact_at(
         ins, exec_write_sets_full_mask,
-        [](const Rdna2Inst& in) { return instruction_may_change_exec(in); }, true);
+        [](const Rdna2Inst& in) { return rdna2_instruction_may_change_exec(in); }, true);
     if (exec_full.empty() || !exec_full[branch_index]) return false;
 
     auto is_branch = [](const Rdna2Inst& in) {
@@ -5641,7 +5626,7 @@ bool vcc_branch_is_workgroup_uniform(const std::vector<Rdna2Inst>& ins, uint32_t
         switch (in.fmt) {
             case Rdna2Format::SOP1:
                 if (in.opcode == 0x1f) return true;                     // s_getpc_b64
-                if (instruction_may_change_exec(in) || in.n_src != 1) return false;
+                if (rdna2_instruction_may_change_exec(in) || in.n_src != 1) return false;
                 return uniform_operand(in.src[0], scalar_write_width(in) == 2 ? 2u : 1u, w, depth);
             case Rdna2Format::SOP2: {
                 // Carry and cselect forms consume SCC as well as their decoded operands; the mask
@@ -11234,7 +11219,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             //
             // Opcodes verified by assembling each with llvm-mc, positive control image_atomic_add ->
             // word0 0xf0440128, byte-identical to the dword decoded from the guest here.
-            const bool storage_only_op = in.opcode == 0x08 || in.opcode == 0x0f ||
+            const bool storage_only_op = in.opcode == 0x08 || in.opcode == 0x09 ||
+                                         in.opcode == 0x0f ||
                                          (in.opcode >= 0x11 && in.opcode <= 0x1a && in.opcode != 0x13);
             if ((storage_only_op && res && res->cls != ResourceClass::StorageImage) ||
                 (in.opcode != 0x00 && !storage_only_op && in.opcode != 0x0e &&
@@ -11259,10 +11245,27 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                       res->format == DataFormat::Uint16 ||
                                       res->format == DataFormat::Uint32;
 
-            // --- Storage-image path: image_load (0x00), image_store (0x08), and R32_UINT
+            // --- Storage-image path: image_load (0x00), image_store[_mip] (0x08/0x09), and R32_UINT
             if (res->cls == ResourceClass::StorageImage) {
                 const bool is_ld = in.opcode == 0x00;
-                const bool is_st = in.opcode == 0x08;
+                const bool is_zero_mip_st = in.opcode == 0x09;
+                const bool is_st = in.opcode == 0x08 || is_zero_mip_st;
+                // The backend exposes one materialized mip, but that alone is not permission to
+                // discard a guest operand. IMAGE_STORE_MIP is admitted only for the exact captured
+                // 2D packet whose mip VGPR was proven zero at this use and whose descriptor declares
+                // one uncompressed base level. The live dmask-f packet is exact to the captured
+                // fmt60 Uint8x4 resource; other formats and dynamic/nonzero/general or DCC-backed
+                // forms remain fail-visible.
+                if (is_zero_mip_st &&
+                    (!rdna2_mimg_zero_mip_shape(in) || !res->proven_zero_mip ||
+                     res->img_dim != SQ_DIM_2D || res->sample_count != 1u ||
+                     res->declared_mip_levels != 1u || res->in_mip_tail ||
+                     res->compression_enabled ||
+                     (in.mimg_dmask == 0xfu &&
+                      (res->format != DataFormat::Uint8 || res->num_components != 4u)))) {
+                    ok = false;
+                    return true;
+                }
                 // Opcodes verified with llvm-mc; add/positive-control matches the guest's own word0 (#2275).
                 uint16_t spirv_atomic = 0;
                 switch (in.opcode) {
@@ -11502,7 +11505,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // op and the "samples a 2D texture" behavior are live-title evidence; the exact high-bit
             // family (an RDNA2 gfx10.3 sample variant) is not yet llvm-mc round-trip-verified, so a
             // future title exercising its distinguishing modifier may need a dedicated lowering.
-            const bool is_sample = (in.opcode == 0x20) || (in.opcode == 0xa0), is_load = (in.opcode == 0x00);
+            const bool is_sample = (in.opcode == 0x20) || (in.opcode == 0xa0);
+            const bool is_zero_mip_load = in.opcode == 0x01;
+            const bool is_load = in.opcode == 0x00 || is_zero_mip_load;
             const bool is_sample_l = (in.opcode == 0x24), is_sample_lz = (in.opcode == 0x27);
             const bool is_sample_b = (in.opcode == 0x25), is_gather_lz = (in.opcode == 0x47);
             const bool is_sample_c_lz = (in.opcode == 0x2f);
@@ -11537,6 +11542,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                  !is_gather_lz_o && !is_sample_lz_o && !is_sample_d) ||
                 (!dim2d && !dim3d && !dimcube && !dim_msaa)) { ok = false; return true; }
             if (res->cls != ResourceClass::Texture) { ok = false; return true; }
+            // IMAGE_LOAD_MIP's final address is a real guest mip selector. Specialize it away only
+            // after the per-use fold and the materialized-resource checks agree. The 2D_ARRAY form
+            // retains its slice coordinate; only the separately proven mip operand is discarded.
+            if (is_zero_mip_load &&
+                (!rdna2_mimg_zero_mip_shape(in) || !res->proven_zero_mip ||
+                 res->img_dim != in.mimg_dim || res->sample_count != 1u ||
+                 res->declared_mip_levels != 1u || res->in_mip_tail ||
+                 res->compression_enabled || (in.mimg_dim == 5u && !b.is_compute))) {
+                ok = false;
+                return true;
+            }
             // Guest 2D_MSAA IMAGE_LOAD is represented exactly as a host single-sample 2D array: the
             // guest sample coordinate selects the array layer. Asterix's resolve PS mixes the ordinary
             // consecutive-vaddr packet with three one-extra-dword NSA packets; llvm-mc gfx1030 confirms
@@ -11734,13 +11750,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             } else {
+                const bool mip_load_2d_array = b.is_compute && is_zero_mip_load &&
+                    in.mimg_dim == 5u && res->img_dim == 5u;
                 const bool array_sample = b.is_compute && in.mimg_dim == 5u &&
                     res->img_dim == 5u && (is_sample || is_sample_l || is_sample_lz);
-                const bool host_array = array_sample || msaa_array_fetch;
+                const bool host_array = mip_load_2d_array || array_sample || msaa_array_fetch;
                 if (!b.declare_texture(res->binding, Dim_2D, uint_texture, host_array)) {
                     ok = false; return true;
                 }
-                if (msaa_array_fetch) {
+                if (msaa_array_fetch || mip_load_2d_array) {
                     b.image_fetch_2d_array(
                         res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 } else if (array_sample) {
@@ -15837,10 +15855,10 @@ bool terminal_guard_scc_is_workgroup_uniform(const std::vector<Rdna2Inst>& ins,
             switch (writer.fmt) {
                 case Rdna2Format::SOP1: {
                     // GETPC is identical for every wave. Mask/saveexec operations consume EXEC and
-                    // are rejected by instruction_may_change_exec; ordinary scalar operations trace
+                    // are rejected by rdna2_instruction_may_change_exec; ordinary scalar operations trace
                     // their source at the destination's architectural width.
                     if (writer.opcode == 0x1f) return true;
-                    if (instruction_may_change_exec(writer) || writer.n_src != 1) return false;
+                    if (rdna2_instruction_may_change_exec(writer) || writer.n_src != 1) return false;
                     return uniform_operand(writer.src[0], scalar_write_width(writer) == 2 ? 2u : 1u);
                 }
                 case Rdna2Format::SOP2: {
@@ -16219,7 +16237,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 if (candidate.fmt == Rdna2Format::EXP || candidate.fmt == Rdna2Format::DS ||
                     candidate.fmt == Rdna2Format::MUBUF || candidate.fmt == Rdna2Format::MTBUF ||
                     candidate.fmt == Rdna2Format::MIMG || candidate.fmt == Rdna2Format::FLAT ||
-                    (instruction_may_change_exec(candidate) && !balanced_nested_exec) ||
+                    (rdna2_instruction_may_change_exec(candidate) && !balanced_nested_exec) ||
                     clobbers_guard_mask ||
                     (candidate.fmt == Rdna2Format::SOPP && candidate.opcode == 0x0a)) {
                     side_effect_free = false;
@@ -17590,6 +17608,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                         return i.mimg_dim == 6u && !i.mimg_unorm && !i.has_modifier &&
                                msaa_address_shape;
                     }
+                    if (i.opcode == 0x01u || i.opcode == 0x09u)
+                        return rdna2_mimg_zero_mip_shape(i);
                     if (i.opcode == 0x08u) return st_dim;                       // image_store (no per-sample MSAA store)
                     if (i.opcode == 0x0fu || i.opcode == 0x11u)   // image_atomic_swap/add R32_UINT 2D / 2D_ARRAY
                         // #2265: 2D_ARRAY (dim 5) admitted alongside 2D. This is the COVERAGE
@@ -18451,7 +18471,7 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                 candidate.fmt != Rdna2Format::SOPK)
                 return false;
             bool wrote_data = false;
-            bool safe = !instruction_may_change_exec(candidate);
+            bool safe = !rdna2_instruction_may_change_exec(candidate);
             for_each_scalar_write(candidate, [&](int base, uint32_t width) {
                 wrote_data = true;
                 safe &= base >= 0 && base + static_cast<int>(width) <= 106;
@@ -18618,7 +18638,7 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
                         restores_saved_exec = true;
                         break;
                     }
-                    bool clobbers_saved_mask = instruction_may_change_exec(candidate) ||
+                    bool clobbers_saved_mask = rdna2_instruction_may_change_exec(candidate) ||
                         candidate.fmt == Rdna2Format::VOPC;
                     for_each_scalar_write(candidate, [&](int base, uint32_t width) {
                         clobbers_saved_mask |= base < 108 && 106 < base + static_cast<int>(width);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6,6 +6,7 @@
 #include "shader_resources.hpp"
 #include <algorithm>
 #include <bit>
+#include <cstdarg>
 #include <cstring>
 #include <cstdio>
 #include <cstdlib>
@@ -19,6 +20,58 @@
 #include <vector>
 
 namespace prosper::gpu {
+
+namespace {
+
+const char* recompile_diagnostic_stage_name(RecompileDiagnosticStage stage) {
+    switch (stage) {
+        case RecompileDiagnosticStage::Compute: return "compute";
+        case RecompileDiagnosticStage::Vertex: return "vertex";
+        case RecompileDiagnosticStage::Fragment: return "fragment";
+        case RecompileDiagnosticStage::Standalone: return "standalone";
+    }
+    return "standalone";
+}
+
+// Recompiles can run concurrently. Build the complete diagnostic on the stack and submit it through
+// one stdio call so one program's identity cannot be spliced onto another program's reject payload.
+// The context is an explicit per-call value; no global or thread-local attribution state is involved.
+void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
+                              const char* tag, const char* role, const char* format, ...) {
+    if (!std::getenv("PROSPER_DBG")) return;
+
+    char payload[1536];
+    va_list args;
+    va_start(args, format);
+    const int body = std::vsnprintf(payload, sizeof payload, format, args);
+    va_end(args);
+    if (body < 0) return;
+    payload[sizeof(payload) - 1] = '\0';
+    size_t payload_size = std::strlen(payload);
+    while (payload_size && (payload[payload_size - 1] == '\n' ||
+                            payload[payload_size - 1] == '\r'))
+        payload[--payload_size] = '\0';
+
+    // Preserve the established `[tag] payload` prefix consumed by issue-census scripts. Provenance
+    // is an appended field group, not an insertion between the tag and its historical first field.
+    char line[2048];
+    const int written = diagnostic.program_address
+        ? std::snprintf(line, sizeof line,
+                        "[%s] %s stage=%s program=0x%llx role=%s\n",
+                        tag, payload, recompile_diagnostic_stage_name(diagnostic.stage),
+                        static_cast<unsigned long long>(diagnostic.program_address), role)
+        : std::snprintf(line, sizeof line,
+                        "[%s] %s stage=%s program=none role=%s\n",
+                        tag, payload, recompile_diagnostic_stage_name(diagnostic.stage), role);
+    if (written < 0) return;
+    const size_t used = std::min(static_cast<size_t>(written), sizeof(line) - 1);
+    if (used == sizeof(line) - 1) {
+        line[sizeof(line) - 2] = '\n';
+    }
+    std::fwrite(line, 1, used, stderr);
+}
+
+} // namespace
 
 // #2319: render exactly the dwords the instruction HAS, not a fixed two.
 //
@@ -293,6 +346,7 @@ struct SpirvCompute {
     // prepended to `extimp` -- see the module assembly order below. Getting that order wrong fails
     // spirv-val with a LAYOUT complaint that says nothing about descriptors.
     std::vector<uint32_t> caps, exts, extimp, mem, entry, exec, debug, deco, types, code;
+    RecompileDiagnosticContext diagnostic{};
     bool descriptor_indexing_declared = false;
     // Declare the capability set and extension for an indexed descriptor array, once per module and
     // only when one is actually declared, so every module that does not use one is byte-identical to
@@ -4829,7 +4883,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                                           const std::unordered_set<uint32_t>* skip = nullptr,
                                           const std::vector<DivLoop>* loops = nullptr,
                                           bool* rejected = nullptr,
-                                          bool compute_wave_branches = false) {
+                                          bool compute_wave_branches = false,
+                                          RecompileDiagnosticContext diagnostic = {}) {
     std::vector<ForwardIf> out;
     if (rejected) *rejected = false;
     auto reject = [&]() -> std::vector<ForwardIf> { if (rejected) *rejected = true; return {}; };
@@ -4856,15 +4911,15 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
             case 0x02: continue;                                     // s_branch: validated in pass 2
             case 0x09:                                               // execnz: only as a loop back-edge
                 if (loop_backedge(in.pc)) continue;
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr, "[compute-struct-reject] unclaimed execnz pc=%u\n", in.pc);
+                log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                         "unclaimed execnz pc=%u", in.pc);
                 return reject();
             case 0x08:                                               // execz: safe-linearized predication
                 if (skip && skip->count(in.pc)) continue;            // branch -> emit_alu no-ops it; else a
                 if (loop_exit(in.pc)) continue;                      // loop exit test: the loop emitter's
                 if (!allow_vcc && !compute_wave_branches) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr, "[compute-struct-reject] unsupported execz pc=%u\n", in.pc);
+                    log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                             "unsupported execz pc=%u", in.pc);
                     return reject();
                 }
                 break;                                               // compute lowers the wave-empty test with
@@ -4876,8 +4931,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                     // the architectural whole-wave VCCZ/VCCNZ flag. Accept it for the exact guest-wave
                     // CFG dispatcher; emit_body must never lower it through a native subgroup vote.
                     if (!compute_wave_branches) {
-                        if (getenv("PROSPER_DBG"))
-                            std::fprintf(stderr, "[compute-struct-reject] unsupported vcc branch pc=%u\n", in.pc);
+                        log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                                 "unsupported vcc branch pc=%u", in.pc);
                         return reject();
                     }
                     compute_uniform_vcc = true;
@@ -4894,8 +4949,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
         // A compute-uniform-accepted vcc branch can never be a break (compute loops require the
         // s_branch back-edge Vcc shape, which has no breaks) — reject the combination defensively.
         if (compute_uniform_vcc && loop_break(in.pc)) {
-            if (getenv("PROSPER_DBG"))
-                std::fprintf(stderr, "[compute-struct-reject] uniform vcc loop break pc=%u\n", in.pc);
+            log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                     "uniform vcc loop break pc=%u", in.pc);
             return reject();
         }
         if (const DivLoop* L = loop_break(in.pc)) {
@@ -4911,8 +4966,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
         bool early = false;
         if (tgt > end_pc && tgt != UINT32_MAX) {                     // possible early-out past s_endpgm:
             if (!code || tgt >= dwords) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr, "[compute-struct-reject] target out of range pc=%u target=%u\n", in.pc, tgt);
+                log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                         "target out of range pc=%u target=%u", in.pc, tgt);
                 return reject();                                     // verify the target terminates (see
             }
             std::vector<Rdna2Inst> tail;                             // detect_forward_if for the rationale)
@@ -4924,15 +4979,15 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 break;
             }
             if (!ends_immediately) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr, "[compute-struct-reject] nonterminal early target pc=%u target=%u\n", in.pc, tgt);
+                log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                         "nonterminal early target pc=%u target=%u", in.pc, tgt);
                 return reject();
             }
             tgt = end_pc; early = true;
         }
         if (tgt <= in.pc || tgt > end_pc) {
-            if (getenv("PROSPER_DBG"))
-                std::fprintf(stderr, "[compute-struct-reject] nonforward target pc=%u target=%u\n", in.pc, tgt);
+            log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                     "nonforward target pc=%u target=%u", in.pc, tgt);
             return reject();                                         // must be forward, within the stream
         }
         ForwardIf F;
@@ -4950,19 +5005,16 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (sb.pc + sb.len_dwords != tgt) continue;          // must be the arm's LAST instruction
                 if (loop_backedge(sb.pc)) continue;                  // a loop's back-edge, not an else-jump
                 if (sb.simm16 <= 0) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] backward else pc=%u branch=%u target=%u\n",
-                                     in.pc, sb.pc, tgt);
+                    log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                             "backward else pc=%u branch=%u target=%u",
+                                             in.pc, sb.pc, tgt);
                     return reject();                                 // backward else-jump: a loop, not an if
                 }
                 uint32_t lm = branch_target(sb);
                 if (lm <= tgt || lm > end_pc) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] invalid else merge pc=%u branch=%u "
-                                     "target=%u merge=%u\n",
-                                     in.pc, sb.pc, tgt, lm);
+                    log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                             "invalid else merge pc=%u branch=%u target=%u merge=%u",
+                                             in.pc, sb.pc, tgt, lm);
                     return reject();                                 // merge must be forward, in-stream
                 }
                 F.has_else = true; F.sb_pc = sb.pc; F.merge_pc = lm;
@@ -4982,10 +5034,8 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 if (r.is_end || r.pc >= region_end) break;
                 if (r.pc <= in.pc) continue;
                 if (r.fmt == Rdna2Format::SOPP && r.opcode == 0x0a) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] execz pc=%u contains barrier pc=%u\n",
-                                     in.pc, r.pc);
+                    log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                             "execz pc=%u contains barrier pc=%u", in.pc, r.pc);
                     return reject();
                 }
 
@@ -5008,11 +5058,10 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                 for (int vcc_half = 106; vcc_half <= 107; ++vcc_half) {
                     if (vcc_half < r.dst.value || vcc_half >= r.dst.value + (int)scalar_width) continue;
                     if (!sgpr_dead_at_merge(ins, region_end, vcc_half)) {
-                        if (getenv("PROSPER_DBG"))
-                            std::fprintf(stderr,
-                                         "[compute-struct-reject] execz pc=%u scalar write pc=%u "
-                                         "leaves vcc-half s%d live at merge pc=%u\n",
-                                         in.pc, r.pc, vcc_half, region_end);
+                        log_recompile_diagnostic(
+                            diagnostic, "compute-struct-reject", "route-decline",
+                            "execz pc=%u scalar write pc=%u leaves vcc-half s%d live at merge pc=%u",
+                            in.pc, r.pc, vcc_half, region_end);
                         return reject();
                     }
                 }
@@ -5044,11 +5093,10 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                     ds_wave_collective ||
                     (r.fmt == Rdna2Format::VOP3 &&
                      (r.opcode == 0x365 || r.opcode == 0x366))) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] vcc branch pc=%u contains "
-                                     "synchronized op pc=%u fmt=%d op=0x%x\n",
-                                     in.pc, r.pc, static_cast<int>(r.fmt), r.opcode);
+                    log_recompile_diagnostic(
+                        diagnostic, "compute-struct-reject", "route-decline",
+                        "vcc branch pc=%u contains synchronized op pc=%u fmt=%d op=0x%x",
+                        in.pc, r.pc, static_cast<int>(r.fmt), r.opcode);
                     return reject();
                 }
             }
@@ -5064,10 +5112,9 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
         bool claimed = false;
         for (const auto& F : out) if (F.has_else && F.sb_pc == in.pc) { claimed = true; break; }
         if (!claimed) {
-            if (getenv("PROSPER_DBG"))
-                std::fprintf(stderr,
-                             "[compute-struct-reject] unclaimed s_branch pc=%u target=%u\n",
-                             in.pc, branch_target(in));
+            log_recompile_diagnostic(diagnostic, "compute-struct-reject", "route-decline",
+                                     "unclaimed s_branch pc=%u target=%u",
+                                     in.pc, branch_target(in));
             return reject();
         }
     }
@@ -5092,11 +5139,10 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
             while (!open.empty() && open.back() <= start) open.pop_back();
             if (!open.empty() && span_end > open.back()) {
                 if (!clampable) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] overlapping region start=%u end=%u "
-                                     "parent-end=%u\n",
-                                     start, span_end, open.back());
+                    log_recompile_diagnostic(
+                        diagnostic, "compute-struct-reject", "route-decline",
+                        "overlapping region start=%u end=%u parent-end=%u",
+                        start, span_end, open.back());
                     return reject();                     // plain if / loop escaping its region: not a tree
                 }
                 span_end = open.back();                  // cascade if/else: clamped to the enclosing
@@ -12986,9 +13032,9 @@ bool emit_cfg_state_machine(
     const uint32_t* code, size_t dwords) {
     const bool graphics = b.is_fragment || b.is_vertex;
     auto reject_cfg = [&](uint32_t pc, const char* reason) {
-        if (getenv("PROSPER_DBG"))
-            std::fprintf(stderr, "[%s-cfg-reject] pc=%u reason=%s\n",
-                         b.is_compute ? "compute" : "graphics", pc, reason);
+        log_recompile_diagnostic(b.diagnostic,
+                                 b.is_compute ? "compute-cfg-reject" : "graphics-cfg-reject",
+                                 "terminal", "pc=%u reason=%s", pc, reason);
         return false;
     };
     if ((!b.is_compute && !graphics) || ins.empty()) return false;
@@ -13619,11 +13665,10 @@ bool emit_cfg_state_machine(
                 const int implicit_vcc = implicit_vcc_mask_source(in);
                 if (implicit_vcc >= 0 &&
                     (!masks.contains(implicit_vcc) || ambiguous.contains(implicit_vcc))) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[%s-cfg-reject] pc=%u "
-                                     "reason=missing-wave32-vcc-mask\n",
-                                     b.is_compute ? "compute" : "graphics", in.pc);
+                    log_recompile_diagnostic(
+                        b.diagnostic,
+                        b.is_compute ? "compute-cfg-reject" : "graphics-cfg-reject",
+                        "terminal", "pc=%u reason=missing-wave32-vcc-mask", in.pc);
                     return false;
                 }
 
@@ -13642,11 +13687,10 @@ bool emit_cfg_state_machine(
                     ambiguous.contains(106))
                     reads_ambiguous = true;
                 if (reads_ambiguous) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[%s-cfg-reject] pc=%u "
-                                     "reason=wave32-ambiguous-mask-read\n",
-                                     b.is_compute ? "compute" : "graphics", in.pc);
+                    log_recompile_diagnostic(
+                        b.diagnostic,
+                        b.is_compute ? "compute-cfg-reject" : "graphics-cfg-reject",
+                        "terminal", "pc=%u reason=wave32-ambiguous-mask-read", in.pc);
                     return false;
                 }
 
@@ -14475,15 +14519,21 @@ bool emit_cfg_state_machine(
             b.store_function(active_var, no);
         }
         else if (found == block_for_pc.end()) {
-            if (getenv("PROSPER_DBG"))
-                std::fprintf(stderr,
-                             "[compute-cfg-successor-reject] pc=%u end=%u blocks=%zu\n",
-                             pc, end_pc, block_for_pc.size());
             if (getenv("PROSPER_DBG")) {
-                std::fprintf(stderr, "[compute-cfg-successors]");
-                for (const auto& entry : block_for_pc)
-                    std::fprintf(stderr, " %u", entry.first);
-                std::fprintf(stderr, "\n");
+                log_recompile_diagnostic(
+                    b.diagnostic, "compute-cfg-successor-reject", "terminal",
+                    "pc=%u end=%u blocks=%zu", pc, end_pc, block_for_pc.size());
+                std::string successors;
+                char successor[32];
+                for (const auto& entry : block_for_pc) {
+                    const int written = std::snprintf(successor, sizeof successor, " %u",
+                                                      entry.first);
+                    if (written > 0)
+                        successors.append(successor, std::min<size_t>(
+                            static_cast<size_t>(written), sizeof(successor) - 1));
+                }
+                log_recompile_diagnostic(b.diagnostic, "compute-cfg-successors", "terminal",
+                                         "%s", successors.c_str());
             }
             return false;
         }
@@ -14663,12 +14713,12 @@ bool emit_cfg_state_machine(
                         // lowering ran and could not resolve an operand or a resource-table
                         // descriptor. Without it a census cannot tell "implement this" from
                         // "this instruction is fine, its descriptor is not".
-                        std::fprintf(stderr,
-                                     "[cfg-recompile-reject] mode=%s pc=%u words=%s len=%u "
-                                     "fmt=%d op=0x%x\n",
-                                     handled ? "unresolved-operand" : "unknown-encoding",
-                                     in.pc, reject_words_text(in).c_str(), in.len_dwords,
-                                     static_cast<int>(in.fmt), in.opcode);
+                        log_recompile_diagnostic(
+                            b.diagnostic, "cfg-recompile-reject", "terminal",
+                            "mode=%s pc=%u words=%s len=%u fmt=%d op=0x%x",
+                            handled ? "unresolved-operand" : "unknown-encoding",
+                            in.pc, reject_words_text(in).c_str(), in.len_dwords,
+                            static_cast<int>(in.fmt), in.opcode);
                     return false;
                 }
                 // Ordinary scalar B64 logicals already produced an exact nonzero SCC id above.
@@ -14714,10 +14764,8 @@ bool emit_cfg_state_machine(
         }
         if (mbcnt) {
             if (graphics) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr,
-                                 "[graphics-cfg-reject] pc=%u reason=mbcnt-cross-lane\n",
-                                 mbcnt->pc);
+                log_recompile_diagnostic(b.diagnostic, "graphics-cfg-reject", "terminal",
+                                         "pc=%u reason=mbcnt-cross-lane", mbcnt->pc);
                 return false;
             }
             bool operand_ok = true;
@@ -14755,10 +14803,8 @@ bool emit_cfg_state_machine(
         }
         if (append) {
             if (graphics) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr,
-                                 "[graphics-cfg-reject] pc=%u reason=gds-cross-lane\n",
-                                 append->pc);
+                log_recompile_diagnostic(b.diagnostic, "graphics-cfg-reject", "terminal",
+                                         "pc=%u reason=gds-cross-lane", append->pc);
                 return false;
             }
             const auto m0 = state.sreg.find(124);
@@ -14887,10 +14933,8 @@ bool emit_cfg_state_machine(
         }
         if (mask_compare) {
             if (b.is_vertex) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr,
-                                 "[graphics-cfg-reject] pc=%u reason=wave-mask-compare\n",
-                                 mask_compare->pc);
+                log_recompile_diagnostic(b.diagnostic, "graphics-cfg-reject", "terminal",
+                                         "pc=%u reason=wave-mask-compare", mask_compare->pc);
                 return false;
             }
             const int source = mask_zero_compare_candidate_source(*mask_compare);
@@ -14973,10 +15017,9 @@ bool emit_cfg_state_machine(
         }
         if (vopc_mask_compare) {
             if (b.is_vertex) {
-                if (getenv("PROSPER_DBG"))
-                    std::fprintf(stderr,
-                                 "[graphics-cfg-reject] pc=%u reason=vopc-wave-mask-compare\n",
-                                 vopc_mask_compare->pc);
+                log_recompile_diagnostic(b.diagnostic, "graphics-cfg-reject", "terminal",
+                                         "pc=%u reason=vopc-wave-mask-compare",
+                                         vopc_mask_compare->pc);
                 return false;
             }
             const int source = vopc_mask_zero_compare_source(*vopc_mask_compare);
@@ -15981,9 +16024,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                                      ins[barrier_index].pc);
                     if (!emit_body(b, rs, phase, safe, rt, allow_exec_update, allow_smem,
                                    exp_fn, code, dwords, &dead_masks)) {
-                        if (getenv("PROSPER_DBG"))
-                            std::fprintf(stderr, "[compute-phase-reject] begin=%u end=%u\n",
-                                         phase.front().pc, phase[phase.size() - 2].pc);
+                        log_recompile_diagnostic(
+                            b.diagnostic, "compute-phase-reject", "consequent",
+                            "begin=%u end=%u", phase.front().pc, phase[phase.size() - 2].pc);
                         return false;
                     }
                 }
@@ -15997,9 +16040,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                                  tail.front().pc, tail.back().pc);
                 if (!emit_body(b, rs, tail, safe, rt, allow_exec_update, allow_smem,
                                exp_fn, code, dwords, &dead_masks)) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr, "[compute-phase-reject] begin=%u end=%u tail=1\n",
-                                     tail.front().pc, tail.back().pc);
+                    log_recompile_diagnostic(b.diagnostic, "compute-phase-reject", "consequent",
+                                             "begin=%u end=%u tail=1",
+                                             tail.front().pc, tail.back().pc);
                     return false;
                 }
             }
@@ -16050,10 +16093,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     // else, so a census cannot group them by SHADER -- which is the unit that matters,
                     // since 24,485 skipped GTA V draws turned out to be 43 distinct shaders. The first
                     // code dword plus the span identifies one cheaply and stably.
-                    fprintf(stderr, "[recompile-reject] sh=%08x/%zu mode=%s pc=%u words=%s fmt=%d op=0x%x "
-                                    "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
-                                    "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u "
-                                    "sext=%d/%d\n",
+                    log_recompile_diagnostic(
+                        b.diagnostic, "recompile-reject", "terminal",
+                        "sh=%08x/%zu mode=%s pc=%u words=%s fmt=%d op=0x%x "
+                        "dst=%d(kind%d) src=%d(k%d),%d(k%d),%d(k%d) dmask=0x%x "
+                        "dim=%u glc=%d len=%u modifier=%d dpp=%d sdwa=%u/%u/%u/%u "
+                        "sext=%d/%d",
                         dwords ? code[0] : 0u, dwords,
                         handled ? "unresolved-operand" : "unknown-encoding",
                         in.pc, reject_words_text(in).c_str(), (int)in.fmt, in.opcode,
@@ -16072,10 +16117,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     // consecutive-vaddr form. Keep a separate MIMG-only line so an address-shape
                     // diagnosis sees every decoded extra dword without adding zeros to unrelated ops.
                     if (in.fmt == Rdna2Format::MIMG && in.len_dwords > 2u)
-                        fprintf(stderr,
-                                "[recompile-reject-mimg-address] pc=%u extra=%u words=%08x,%08x,%08x\n",
-                                in.pc, in.len_dwords - 2u,
-                                in.words[2], in.words[3], in.words[4]);
+                        log_recompile_diagnostic(
+                            b.diagnostic, "recompile-reject-mimg-address", "terminal",
+                            "pc=%u extra=%u words=%08x,%08x,%08x",
+                            in.pc, in.len_dwords - 2u,
+                            in.words[2], in.words[3], in.words[4]);
                 }
                 return false;
             }
@@ -16181,7 +16227,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         bool preloop_rejected = false;
         const std::vector<ForwardIf> preloop_ifs = detect_forward_ifs(
             preloop, /*allow_vcc*/!b.is_compute, code, dwords, &effective_safe, nullptr,
-            &preloop_rejected, /*compute_wave_branches*/b.is_compute);
+            &preloop_rejected, /*compute_wave_branches*/b.is_compute, b.diagnostic);
         // detect_forward_ifs clamps a branch to an immediate s_endpgm at its artificial end marker
         // and records it as early_out. In this truncated prelude that can be a real branch over the
         // entire counted loop, so it cannot be structured as an ordinary one-arm conditional.
@@ -16191,10 +16237,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     (branch.has_else ? branch.merge_pc : branch.target_pc) > L.header_pc;
             });
         if (preloop_rejected || preloop_if_unsupported) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr,
-                        "[recompile-reject] counted-loop prelude cfg rejected=%u ifs=%zu header=%u\n",
-                        preloop_rejected, preloop_ifs.size(), L.header_pc);
+            log_recompile_diagnostic(
+                b.diagnostic, "recompile-reject", "terminal",
+                "counted-loop prelude cfg rejected=%u ifs=%zu header=%u",
+                preloop_rejected, preloop_ifs.size(), L.header_pc);
             return false;
         }
         if (preloop_ifs.empty()) {
@@ -16294,8 +16340,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             rs.sreg_written.insert(then_written.begin(), then_written.end());
             for (int reg : then_written) rs.sreg_input.erase(reg);
             if (then_bool != rs.sreg_bool || then_bool_b32 != rs.sreg_bool_b32) {
-                if (getenv("PROSPER_DBG"))
-                    fprintf(stderr, "[recompile-reject] counted-loop prelude changes mask domain\n");
+                log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                         "counted-loop prelude changes mask domain");
                 return false; // no mask-domain PHIs in this narrow composition
             }
             if (!emit_range(merge_pc, L.header_pc)) return false;
@@ -16306,8 +16352,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // fixed-trip culling loop merely because some guest lanes were masked before its header.
         const bool carry_vertex_exec = b.ngg_one_lane && rs.exec_narrowed;
         if (rs.exec_narrowed && !guarded_narrow_entry && !carry_vertex_exec) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr, "[recompile-reject] counted-loop enters with narrowed EXEC\n");
+            log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                     "counted-loop enters with narrowed EXEC");
             return false;
         }
         // 2. Loop-carried registers -> a header OpPhi each. `cond_written` = regs written in the CONDITION
@@ -16365,8 +16411,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         // 4. Body [after exit_branch, back-edge). Must restore EXEC before looping (bail if left narrowed).
         if (!emit_range(L.exit_branch_pc + 1, L.backedge_pc)) return false;
         if (rs.exec_narrowed && !guarded_narrow_entry && !carry_vertex_exec) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr, "[recompile-reject] counted-loop body leaves EXEC narrowed\n");
+            log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                     "counted-loop body leaves EXEC narrowed");
             return false;
         }
         if (idx < ins.size() && ins[idx].pc == L.backedge_pc) ++idx;        // skip the back-edge branch
@@ -16481,7 +16527,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         bool cf_rejected = false;
         const std::vector<ForwardIf> Fs = detect_forward_ifs(ins, /*allow_vcc*/!b.is_compute, code, dwords, &safe,
                                                              Ls.empty() ? nullptr : &Ls, &cf_rejected,
-                                                             /*compute_wave_branches*/b.is_compute);
+                                                             /*compute_wave_branches*/b.is_compute,
+                                                             b.diagnostic);
 
         // UE4's volume-lighting kernels combine nested EXEC loops with a backward VCC vote loop.
         // That shape is intentionally outside the narrow pattern structurizer above. Use the
@@ -16823,27 +16870,21 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 // A poisoned SCC (0: last written by a 64-bit mask op) cannot condition a real
                 // structured if — reject (the ISA-audit #879 stale-SCC consumer).
                 if (!F.on_exec && !F.on_vcc && !rs.scc) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] poisoned SCC at branch pc=%u\n",
-                                     F.branch_pc);
+                    log_recompile_diagnostic(b.diagnostic, "compute-struct-reject", "terminal",
+                                             "poisoned SCC at branch pc=%u", F.branch_pc);
                     return false;
                 }
                 if (F.on_vcc && !rs.vcc) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] missing VCC at branch pc=%u\n",
-                                     F.branch_pc);
+                    log_recompile_diagnostic(b.diagnostic, "compute-struct-reject", "terminal",
+                                             "missing VCC at branch pc=%u", F.branch_pc);
                     return false;
                 }
                 // Compute VCC/EXEC branches normally return through the exact guest-wave dispatcher.
                 // The narrow structured-wave path above accepts only top-level vote sites, where all
                 // workgroup invocations may participate in the scratch barriers uniformly.
                 if (b.is_compute && (F.on_exec || F.on_vcc) && !structured_compute_wave_cfg) {
-                    if (getenv("PROSPER_DBG"))
-                        std::fprintf(stderr,
-                                     "[compute-struct-reject] unavailable wave vote at branch pc=%u\n",
-                                     F.branch_pc);
+                    log_recompile_diagnostic(b.diagnostic, "compute-struct-reject", "terminal",
+                                             "unavailable wave vote at branch pc=%u", F.branch_pc);
                     return false;
                 }
                 uint32_t cond_reg = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
@@ -16897,11 +16938,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                                         return sgpr_dead_at_merge(ins, F.target_pc, reg);
                                     });
                     if (!dead_domain_difference) {
-                        if (getenv("PROSPER_DBG"))
-                            std::fprintf(stderr,
-                                         "[compute-struct-reject] live b32 mask domain differs "
-                                         "across branch pc=%u merge=%u\n",
-                                         F.branch_pc, F.target_pc);
+                        log_recompile_diagnostic(
+                            b.diagnostic, "compute-struct-reject", "terminal",
+                            "live b32 mask domain differs across branch pc=%u merge=%u",
+                            F.branch_pc, F.target_pc);
                         return false;
                     }
                     b.emit_branch(mergeL); b.emit_label(mergeL);
@@ -16946,11 +16986,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     uint32_t else_hi = F.merge_pc;
                     if (F.merge_pc >= hi) {
                         if (F.merge_pc != cont && F.merge_pc != hi) {
-                            if (getenv("PROSPER_DBG"))
-                                std::fprintf(stderr,
-                                             "[compute-struct-reject] escaping merge pc=%u merge=%u "
-                                             "region=%u continuation=%u\n",
-                                             F.branch_pc, F.merge_pc, hi, cont);
+                            log_recompile_diagnostic(
+                                b.diagnostic, "compute-struct-reject", "terminal",
+                                "escaping merge pc=%u merge=%u region=%u continuation=%u",
+                                F.branch_pc, F.merge_pc, hi, cont);
                             return false;
                         }
                         else_hi = hi;
@@ -16994,11 +17033,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     rs.sreg_written.insert(then_written.begin(), then_written.end());
                     for (int reg : then_written) rs.sreg_input.erase(reg);
                     if (then_bool_b32 != rs.sreg_bool_b32) {
-                        if (getenv("PROSPER_DBG"))
-                            std::fprintf(stderr,
-                                         "[compute-struct-reject] b32 mask domain differs across "
-                                         "if/else pc=%u merge=%u\n",
-                                         F.branch_pc, F.merge_pc);
+                        log_recompile_diagnostic(
+                            b.diagnostic, "compute-struct-reject", "terminal",
+                            "b32 mask domain differs across if/else pc=%u merge=%u",
+                            F.branch_pc, F.merge_pc);
                         return false;
                     }
                     // Merge the UNION of mask keys. A mask created in only one arm is false in the
@@ -17028,10 +17066,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 const uint32_t next_pc = idx < ins.size() ? ins[idx].pc : UINT32_MAX;
                 const uint32_t next_if = bi < Fs.size() ? Fs[bi].branch_pc : UINT32_MAX;
                 const uint32_t next_loop = li < Ls.size() ? Ls[li].header_pc : UINT32_MAX;
-                std::fprintf(stderr,
-                             "[compute-struct-reject] structured emission stopped next-pc=%u "
-                             "next-if=%u next-loop=%u\n",
-                             next_pc, next_if, next_loop);
+                log_recompile_diagnostic(
+                    b.diagnostic, "compute-struct-reject", "consequent",
+                    "structured emission stopped next-pc=%u next-if=%u next-loop=%u",
+                    next_pc, next_if, next_loop);
             }
             return false;
         }
@@ -17077,7 +17115,8 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
 
 std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
-                                        const ComputeShaderConfig& config) {
+                                        const ComputeShaderConfig& config,
+                                        RecompileDiagnosticContext diagnostic) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     // A dispatch-scoped proven-null BVH can collapse an exact no-hit exit and fully matched empty-stack
@@ -17091,6 +17130,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     (void)extend_terminating_if_else(code, dwords, ins);
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
+    b.diagnostic = diagnostic;
     if (config.lds_bytes) {
         uint32_t dw = (config.lds_bytes + 3) / 4;
         b.lds_dwords = std::min(16384u, std::max(1u, dw));
@@ -17233,7 +17273,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
 }
 
 bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins,
-                                             const uint32_t* code, size_t dwords) {
+                                             const uint32_t* code, size_t dwords,
+                                             RecompileDiagnosticContext diagnostic) {
     bool low = false;
     bool high = false;
     bool guest_barrier = false;
@@ -17267,7 +17308,7 @@ bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins,
     bool rejected = false;
     const std::vector<ForwardIf> branches = detect_forward_ifs(
         ins, /*allow_vcc*/false, code, dwords, &safe, nullptr, &rejected,
-        /*compute_wave_branches*/true);
+        /*compute_wave_branches*/true, diagnostic);
     if (rejected) return false;
 
     auto top_level_pc = [&](uint32_t pc) {
@@ -17292,10 +17333,11 @@ bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins,
     return structured_wave_votes >= 4;
 }
 
-bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords) {
+bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords,
+                                             RecompileDiagnosticContext diagnostic) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
-    return compute_shader_prefers_native_multiwave(ins, code, dwords);
+    return compute_shader_prefers_native_multiwave(ins, code, dwords, diagnostic);
 }
 
 // See FlatLoadInfo / analyze_flat_loads in the header (#1171). A `base + offset` flat address VGPR pair
@@ -17618,14 +17660,15 @@ static std::vector<uint32_t> recompile_fragment_impl(
         const FragmentInterpolationLayout* interpolation,
         uint32_t wave_size) {
     if (wave_size != 32 && wave_size != 64) return {};
+    const RecompileDiagnosticContext diagnostic{RecompileDiagnosticStage::Fragment, 0};
     std::vector<Rdna2Inst> ins;
     const size_t program_dwords = rdna2_walk(code, dwords, ins);
     if (pcrel_dispatch_target != UINT32_MAX) {
         const PcrelDispatchInfo dispatch = rdna2_pcrel_dispatch_info(code, dwords);
         if (!specialize_pcrel_dispatch(ins, dispatch, pcrel_dispatch_target)) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr, "[recompile-reject] pcrel dispatch specialization target=%u\n",
-                        pcrel_dispatch_target);
+            log_recompile_diagnostic(diagnostic, "recompile-reject", "terminal",
+                                     "pcrel dispatch specialization target=%u",
+                                     pcrel_dispatch_target);
             return {};
         }
     }
@@ -17648,29 +17691,33 @@ static std::vector<uint32_t> recompile_fragment_impl(
     // narrowing EXEC to the surviving samples, so the module intentionally has no color outputs.
     // Keep other unsupported MRT-only programs fail-visible instead of accepting every no-color PS.
     if (!color_mask && !has_null_export && !has_depth_export) {
-        if (getenv("PROSPER_DBG")) {
-            fprintf(stderr,
-                    "[recompile-reject] fragment has no supported export dwords=%zu ins=%zu "
-                    "first=%08x last=%08x",
-                    dwords, ins.size(), dwords ? code[0] : 0u,
-                    dwords ? code[dwords - 1] : 0u);
-            if (pcrel_dispatch_target != UINT32_MAX)
-                fprintf(stderr, " pcrel-target=%u", pcrel_dispatch_target);
-            fputc('\n', stderr);
-        }
+        if (pcrel_dispatch_target != UINT32_MAX)
+            log_recompile_diagnostic(
+                diagnostic, "recompile-reject", "terminal",
+                "fragment has no supported export dwords=%zu ins=%zu first=%08x last=%08x "
+                "pcrel-target=%u",
+                dwords, ins.size(), dwords ? code[0] : 0u,
+                dwords ? code[dwords - 1] : 0u, pcrel_dispatch_target);
+        else
+            log_recompile_diagnostic(
+                diagnostic, "recompile-reject", "terminal",
+                "fragment has no supported export dwords=%zu ins=%zu first=%08x last=%08x",
+                dwords, ins.size(), dwords ? code[0] : 0u,
+                dwords ? code[dwords - 1] : 0u);
         return {};
     }
 
     const FragmentInterpolationLayout derived_interpolation = interpolation
         ? *interpolation : fragment_interpolation_layout(code, dwords, system_inputs);
     if (!derived_interpolation.valid) {
-        if (getenv("PROSPER_DBG"))
-            fprintf(stderr, "[recompile-reject] invalid fragment interpolation layout\n");
+        log_recompile_diagnostic(diagnostic, "recompile-reject", "terminal",
+                                 "invalid fragment interpolation layout");
         return {};
     }
     const uint32_t effective_wave_size = effective_fragment_wave_size(
         wave_size, program_dwords, shader_program_hash(code, program_dwords));
     SpirvCompute b;
+    b.diagnostic = diagnostic;
     b.wave_size = effective_wave_size;
     b.begin_fragment(rt, color_mask);
     // SPI_PS_IN_CONTROL.PS_W32_EN proves that EXEC_HI/VCC_HI are unused and the low-half mask
@@ -17716,11 +17763,10 @@ static std::vector<uint32_t> recompile_fragment_impl(
                     for (uint32_t component = 0; component < widths[field]; ++component) {
                         const uint32_t value = b.system_interpolation_component(field, component);
                         if (!value) {
-                            if (getenv("PROSPER_DBG"))
-                                fprintf(stderr,
-                                        "[recompile-reject] missing fragment system interpolation "
-                                        "field=%u component=%u\n",
-                                        field, component);
+                            log_recompile_diagnostic(
+                                diagnostic, "recompile-reject", "terminal",
+                                "missing fragment system interpolation field=%u component=%u",
+                                field, component);
                             return {};
                         }
                         rs.vreg[(int)(vgpr + component)] = value;
@@ -17798,14 +17844,18 @@ static std::vector<uint32_t> recompile_fragment_impl(
     // resource table. Loops (if any) are reconstructed by emit_body.
     if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/rt != nullptr, exp_fn, code, dwords)) {
         if (getenv("PROSPER_DBG") && pcrel_dispatch_target != UINT32_MAX)
-            fprintf(stderr, "[recompile-reject] pcrel target=%u body failed\n", pcrel_dispatch_target);
+            log_recompile_diagnostic(diagnostic, "recompile-reject", "consequent",
+                                     "pcrel target=%u body failed", pcrel_dispatch_target);
         return {};
     }
     if (!exported[0] && !exported[1] && !has_null_export && !has_depth_export) {
-        if (getenv("PROSPER_DBG"))
-            fprintf(stderr, "[recompile-reject] emitted no fragment color%s%u\n",
-                    pcrel_dispatch_target != UINT32_MAX ? " pcrel-target=" : "",
-                    pcrel_dispatch_target != UINT32_MAX ? pcrel_dispatch_target : 0u);
+        if (pcrel_dispatch_target != UINT32_MAX)
+            log_recompile_diagnostic(diagnostic, "recompile-reject", "terminal",
+                                     "emitted no fragment color pcrel-target=%u",
+                                     pcrel_dispatch_target);
+        else
+            log_recompile_diagnostic(diagnostic, "recompile-reject", "terminal",
+                                     "emitted no fragment color");
         return {};
     }
     return b.finish();
@@ -18294,6 +18344,7 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
 
     SpirvCompute b;
+    b.diagnostic = {RecompileDiagnosticStage::Vertex, 0};
     b.capture_position = capture_position;   // geometry-probe: mark gl_Position for xfb capture (gated)
     b.vertex_lds_dwords = std::min(virtual_lds_dwords, 16384u);
     b.vertices_per_instance = rt ? rt->vertices_per_instance : 0u;
@@ -18588,9 +18639,9 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
         // z/w. Never observed in a vertex stage (compilers export positions/params at 32 bits);
         // reject fail-visibly until a live title exercises one.
         if (in.exp_compr) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr, "[recompile-reject] vertex compressed export pc=%u target=%u\n",
-                        in.pc, in.exp_target);
+            log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                     "vertex compressed export pc=%u target=%u",
+                                     in.pc, in.exp_target);
             return false;
         }
         // v_cmpx is now allowed in the vertex shell (allow_exec_update=true below): a divergent block
@@ -18602,10 +18653,9 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
             in.pc > ngg_output_gate_begin && in.pc < ngg_output_gate_end;
         if (state.exec_narrowed && !terminal_ngg_output && (in.exp_target >= 32 ||
             (in.exp_target >= 12 && in.exp_target <= 16))) {
-            if (getenv("PROSPER_DBG"))
-                fprintf(stderr,
-                        "[recompile-reject] vertex export under narrowed exec pc=%u target=%u\n",
-                        in.pc, in.exp_target);
+            log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                     "vertex export under narrowed exec pc=%u target=%u",
+                                     in.pc, in.exp_target);
             return false;
         }
         if (in.exp_target == 12) {
@@ -18617,10 +18667,9 @@ static std::vector<uint32_t> recompile_vertex_impl(const uint32_t* code, size_t 
             // A position export must supply all four components (EN=0xF); a partial POS0 is not
             // meaningfully completable in the current model, so reject rather than invent components.
             if (in.exp_en != 0xFu) {
-                if (getenv("PROSPER_DBG"))
-                    fprintf(stderr,
-                            "[recompile-reject] partial vertex position export pc=%u en=0x%x\n",
-                            in.pc, in.exp_en);
+                log_recompile_diagnostic(b.diagnostic, "recompile-reject", "terminal",
+                                         "partial vertex position export pc=%u en=0x%x",
+                                         in.pc, in.exp_en);
                 return false;
             }
             uint32_t x = operand_bits(b, state, in, in.src[0], &eok);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5689,6 +5689,28 @@ uint32_t emit_f16_unary(SpirvCompute& b, uint32_t opcode, uint32_t x) {
     }
 }
 
+// Exact in-place integer-add DPP row reduction emitted by GTA V compute shaders. Keeping the
+// register/control contract shared between the ordinary emitter and CFG dispatcher prevents one
+// path from silently widening beyond the reviewed full-mask, BC0 VDST/SRC0/SRC1 shape.
+bool is_inplace_vadd_nc_u32_dpp_row_shr(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::VOP2 && in.opcode == 0x25 && in.has_dpp &&
+        !in.dpp_bound_ctrl && in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11fu &&
+        in.dpp_row_mask == 0xfu && in.dpp_bank_mask == 0xfu &&
+        in.dst.kind == OperandKind::VGPR && in.src[0].kind == OperandKind::VGPR &&
+        in.src[1].kind == OperandKind::VGPR && in.dst.value == in.src[0].value &&
+        in.dst.value == in.src[1].value;
+}
+
+// Exact identity-QUAD_PERM tail of the same reduction. No value crosses lanes; ROW_MASK selects
+// architectural DPP16 rows 1 and 3, while the other rows preserve VDST.
+bool is_vadd_nc_u32_dpp_partial_row(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::VOP2 && in.opcode == 0x25 && in.has_dpp &&
+        !in.dpp_bound_ctrl && in.dpp_ctrl == 0xe4u && in.dpp_row_mask == 0xau &&
+        in.dpp_bank_mask == 0xfu && in.dst.kind == OperandKind::VGPR &&
+        in.src[0].kind == OperandKind::VGPR && in.src[1].kind == OperandKind::VGPR &&
+        in.dst.value == in.src[0].value && in.dst.value != in.src[1].value;
+}
+
 // Emit one ALU instruction (VOP1/2/C/3 or SOP1/2) into `b`, updating `rs`. Returns true if `in` is an
 // ALU format handled here; sets ok=false if it is an ALU op this stage doesn't support yet. Non-ALU
 // formats (EXP/memory/...) return false so the stage-specific caller can handle them.
@@ -7934,6 +7956,40 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
         case Rdna2Format::VOP2: {
             uint32_t a = val(in.src[0]), c = val(in.src[1]); uint32_t old_d = vreg_old(b, rs, in.dst.value);
             uint32_t dpp_active = 0;
+            // The non-dispatch GTA V cohort uses the exact {1,2,4,8} ROW_SHR reduction ladder.
+            // FI=0 makes an EXEC-inactive source invalid, BC0 preserves VDST at the row
+            // edge/invalid source, and the destination write remains independently
+            // EXEC-predicated. Other shift amounts remain limited to the event-isolated CFG
+            // dispatcher below.
+            const bool compute_inplace_add_row_shr = b.is_compute &&
+                is_inplace_vadd_nc_u32_dpp_row_shr(in) &&
+                (in.dpp_ctrl == 0x111u || in.dpp_ctrl == 0x112u ||
+                 in.dpp_ctrl == 0x114u || in.dpp_ctrl == 0x118u);
+            if (compute_inplace_add_row_shr) {
+                uint32_t valid_source = 0;
+                const uint32_t shifted = b.subgroup_row_shr(
+                    a, rs.exec, in.dpp_ctrl - 0x110u, &valid_source);
+                const uint32_t result = b.ibin(Op_IAdd, a, shifted);
+                vreg[in.dst.value] = b.sel(valid_source, result, old_d);
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
+            if (b.is_compute && is_vadd_nc_u32_dpp_partial_row(in)) {
+                const uint32_t lane = b.ibin(
+                    Op_BitwiseAnd, b.guest_lane_id(), b.uconst(b.wave_size - 1u));
+                const uint32_t row = b.ibin(
+                    Op_ShiftRightLogical, lane, b.uconst(4));
+                const uint32_t row_bit = b.ibin(
+                    Op_ShiftLeftLogical, b.uconst(1), row);
+                const uint32_t row_selected = b.ucmp(
+                    Op_INotEqual,
+                    b.ibin(Op_BitwiseAnd, row_bit, b.uconst(in.dpp_row_mask)),
+                    b.uconst(0));
+                const uint32_t result = b.ibin(Op_IAdd, a, c);
+                vreg[in.dst.value] = b.sel(row_selected, result, old_d);
+                predicate_write(b, rs, in.dst.value, old_d);
+                return true;
+            }
             // DPP16 quad_perm on src0 (#273): fragment FLOAT ops and compute quad swaps.  Bounded
             // ROW_SHR in the proven one-live-lane NGG projection supplies zero for lane 0.
             if (in.has_dpp) {
@@ -12573,14 +12629,7 @@ bool emit_cfg_state_machine(
     // portable dispatcher publishes it as an event below because a host subgroup may be narrower
     // than Wave64 and another guest wave can be parked at a different static instruction.
     auto compute_dpp_add_row_shr = [&](const Rdna2Inst& in) {
-        return b.is_compute && in.fmt == Rdna2Format::VOP2 &&
-            in.opcode == 0x25 && in.has_dpp && !in.dpp_bound_ctrl &&
-            in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11fu &&
-            in.dst.kind == OperandKind::VGPR &&
-            in.src[0].kind == OperandKind::VGPR &&
-            in.src[1].kind == OperandKind::VGPR &&
-            in.dst.value == in.src[0].value &&
-            in.dst.value == in.src[1].value;
+        return b.is_compute && is_inplace_vadd_nc_u32_dpp_row_shr(in);
     };
 
     // The row reduction is followed by an identity QUAD_PERM whose partial ROW_MASK selects rows
@@ -12588,15 +12637,7 @@ bool emit_cfg_state_machine(
     // distinct SRC1, while masked rows preserve VDST. Keeping this a dedicated dispatcher case
     // avoids granting arbitrary partial DPP masks to the generic ALU emitter.
     auto compute_dpp_add_row_mask = [&](const Rdna2Inst& in) {
-        return b.is_compute && in.fmt == Rdna2Format::VOP2 &&
-            in.opcode == 0x25 && in.has_dpp && !in.dpp_bound_ctrl &&
-            in.dpp_ctrl == 0xe4u && in.dpp_row_mask == 0xau &&
-            in.dpp_bank_mask == 0xfu &&
-            in.dst.kind == OperandKind::VGPR &&
-            in.src[0].kind == OperandKind::VGPR &&
-            in.src[1].kind == OperandKind::VGPR &&
-            in.dst.value == in.src[0].value &&
-            in.dst.value != in.src[1].value;
+        return b.is_compute && is_vadd_nc_u32_dpp_partial_row(in);
     };
 
     // VOPC e64 can compare a complete 64-bit scalar mask as integer data. Generated Wave64 code

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3497,17 +3497,21 @@ bool sopp_is_noop(const Rdna2Inst& in) {
 
 // Is SGPR `R` provably DEAD at pc `target` — i.e. redefined before any read on the fall-through, so a
 // write to it inside a divergent (execz) block linearized before `target` cannot be observed by later
-// code? Sound/conservative: we only reason across the simple wave-uniform ALU formats whose SGPR source
-// operands we can fully enumerate (at most a single reg or a 64-bit pair). At the first memory / control-
-// flow / interp / export / unknown instruction (whose reads of R we can't bound — e.g. a wide T#/V#
-// descriptor source) we give up and report NOT-dead. Checking value ∈ {R, R-1} covers both a 32-bit read
-// of R and a 64-bit pair whose low half is R-1. (RE-TAG: divergent-block scalar liveness.)
+// code? Sound/conservative: we only scan formats whose complete scalar read/write ranges are decoded,
+// including bounded SMEM/MUBUF/MTBUF/MIMG packets. At the first unsupported memory, control-flow,
+// interpolation, or unknown instruction we give up and report NOT-dead. Checking value ∈ {R, R-1}
+// covers both a 32-bit read of R and a 64-bit pair whose low half is R-1.
+// (RE-TAG: divergent-block scalar liveness.)
 inline bool sopk_writes_scalar_data(uint32_t opcode) {
     // GFX10 SOPK encodes both read-only compares/waits/register-mode operations and genuine SGPR
     // destinations in the same SDST field. Keep the distinction central so CFG/provenance scans do
     // not mistake s_cmpk's source register for a redefinition.
     return opcode == 0x00 || opcode == 0x02 || opcode == 0x0F ||
            opcode == 0x10 || opcode == 0x12;
+}
+
+namespace {
+uint32_t scalar_write_width(const Rdna2Inst& in);
 }
 
 inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t target, int R) {
@@ -3582,7 +3586,7 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
             case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPC:
             case Rdna2Format::VOP1: case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOPC:
             case Rdna2Format::DS:    // DS operands are VGPR/M0 only; it cannot read an ordinary SGPR/VCC
-            case Rdna2Format::EXP:   // EXP data sources are all VGPRs — it can never read an SGPR
+            case Rdna2Format::EXP: { // EXP data sources are all VGPRs — it can never read an SGPR
                 // s_bitset{0,1}_b32 reads its destination before replacing that same word; the
                 // decoded source is only the bit index, so the generic operand walk cannot see it.
                 if (in.fmt == Rdna2Format::SOP1 &&
@@ -3615,13 +3619,27 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                 if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
                     (in.dst.value == 106 || in.dst.value == 107) && (R == 106 || R == 107))
                     continue;
-                // A redefinition kills R for a plain numbered SGPR dst (s0..s105) — and now also for
-                // VCC_LO/HI (106/107), whose implicit readers are enumerated above. EXEC/M0
-                // (124/126/127) still can't be proven dead (implicit reads everywhere). A cmpx
-                // SDWAB's decoded SGPR dst is excluded for the same reason as above (EXEC only).
-                if (in.dst.kind == OperandKind::SGPR && in.dst.value == R && R <= 107 &&
+                // A scalar redefinition kills every word covered by its opcode's write width. Keep
+                // this after the explicit/implicit read checks above: B64 read-modify-write forms
+                // must observe the old pair before replacing it. EXEC/M0 (124/126/127) still cannot
+                // be proven dead (implicit reads everywhere), and cmpx writes EXEC rather than its
+                // decoded SGPR destination.
+                const uint32_t dst_width = scalar_write_width(in);
+                if (dst_width && in.dst.kind == OperandKind::SGPR && R <= 107 &&
+                    R >= in.dst.value && R < in.dst.value + static_cast<int>(dst_width) &&
                     !(in.fmt == Rdna2Format::VOPC && vopc_is_cmpx(in.opcode)))
                     continue;
+                break;
+            }
+            case Rdna2Format::MIMG:
+                // Image packets fully decode both scalar descriptor operands: the eight-dword T#/U#
+                // at src[1] and the four-dword S# at src[2]. Some opcodes do not consume the sampler,
+                // but accounting for both ranges is deliberately conservative and lets the proof scan
+                // through every MIMG without needing a second opcode inventory.
+                if (in.src[1].kind != OperandKind::SGPR ||
+                    in.src[2].kind != OperandKind::SGPR) return false;
+                if (R >= in.src[1].value && R < in.src[1].value + 8) return false;
+                if (R >= in.src[2].value && R < in.src[2].value + 4) return false;
                 break;
             case Rdna2Format::MUBUF:
             case Rdna2Format::MTBUF:
@@ -3805,7 +3823,6 @@ std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& i
 }
 
 namespace {
-uint32_t scalar_write_width(const Rdna2Inst& in);
 // Defined after the scalar-writer inventory it depends on; used by detect_forward_ifs above it.
 bool vcc_branch_is_workgroup_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch_pc);
 }
@@ -16970,6 +16987,19 @@ std::vector<uint32_t> safe_execz_branches_for_test(const uint32_t* code, size_t 
     rdna2_walk(code, dwords, ins);
     const std::unordered_set<uint32_t> s = safe_execz_branches(ins);
     return std::vector<uint32_t>(s.begin(), s.end());
+}
+
+std::vector<uint32_t> structured_execz_branches_for_test(const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    const std::unordered_set<uint32_t> safe = safe_execz_branches(ins);
+    bool rejected = false;
+    const auto branches = detect_forward_ifs(ins, /*allow_vcc*/false, code, dwords, &safe,
+                                             nullptr, &rejected,
+                                             /*compute_wave_branches*/true);
+    std::vector<uint32_t> pcs;
+    if (!rejected) for (const auto& branch : branches) pcs.push_back(branch.branch_pc);
+    return pcs;
 }
 
 std::vector<uint32_t> mask_test_branches_for_test(const uint32_t* code, size_t dwords,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -12449,10 +12449,6 @@ bool emit_cfg_state_machine(
     const uint32_t wave_count = b.is_compute
         ? (b.local_count + b.wave_size - 1) / b.wave_size : 0;
     const uint32_t padded_lanes = wave_count * b.wave_size;
-    const uint32_t wave_result_base = padded_lanes;
-    const uint32_t group_active_slot = wave_result_base + wave_count;
-    if (b.is_compute && !b.native_subgroup_size)
-        b.declare_cfg_scratch(group_active_slot + 1);
 
     // Discover every scalar pair that lives in the per-lane mask domain.  Besides defining the
     // dispatcher variables below, this identifies s_cmp_{eq,lg}_u64 mask,0: its SCC result is a
@@ -12568,6 +12564,39 @@ bool emit_cfg_state_machine(
             in.src[1].kind == OperandKind::VGPR &&
             in.dst.value == in.src[0].value &&
             in.dst.value == in.src[1].value;
+    };
+
+    // GTA V's compute reductions use an in-place V_ADD_NC_U32 ladder over each architectural
+    // DPP16 row. Keep this contract as narrow as the observed packets: unbounded ROW_SHR with no
+    // modifier/mask (the decoder's has_dpp contract), and one physical VGPR as VDST/SRC0/SRC1.
+    // A native exact-wave dispatcher can execute the shuffle in its uniform switch case. The
+    // portable dispatcher publishes it as an event below because a host subgroup may be narrower
+    // than Wave64 and another guest wave can be parked at a different static instruction.
+    auto compute_dpp_add_row_shr = [&](const Rdna2Inst& in) {
+        return b.is_compute && in.fmt == Rdna2Format::VOP2 &&
+            in.opcode == 0x25 && in.has_dpp && !in.dpp_bound_ctrl &&
+            in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11fu &&
+            in.dst.kind == OperandKind::VGPR &&
+            in.src[0].kind == OperandKind::VGPR &&
+            in.src[1].kind == OperandKind::VGPR &&
+            in.dst.value == in.src[0].value &&
+            in.dst.value == in.src[1].value;
+    };
+
+    // The row reduction is followed by an identity QUAD_PERM whose partial ROW_MASK selects rows
+    // 1 and 3. No value crosses lanes: selected EXEC-active lanes add their current VDST/SRC0 to a
+    // distinct SRC1, while masked rows preserve VDST. Keeping this a dedicated dispatcher case
+    // avoids granting arbitrary partial DPP masks to the generic ALU emitter.
+    auto compute_dpp_add_row_mask = [&](const Rdna2Inst& in) {
+        return b.is_compute && in.fmt == Rdna2Format::VOP2 &&
+            in.opcode == 0x25 && in.has_dpp && !in.dpp_bound_ctrl &&
+            in.dpp_ctrl == 0xe4u && in.dpp_row_mask == 0xau &&
+            in.dpp_bank_mask == 0xfu &&
+            in.dst.kind == OperandKind::VGPR &&
+            in.src[0].kind == OperandKind::VGPR &&
+            in.src[1].kind == OperandKind::VGPR &&
+            in.dst.value == in.src[0].value &&
+            in.dst.value != in.src[1].value;
     };
 
     // VOPC e64 can compare a complete 64-bit scalar mask as integer data. Generated Wave64 code
@@ -12700,6 +12729,10 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> fragment_dpp_min_row_shr_pcs;
     std::unordered_map<uint32_t, uint32_t> fragment_dpp_min_event_for_pc;
     std::set<int> fragment_dpp_min_row_shr_dsts;
+    std::unordered_set<uint32_t> compute_dpp_add_row_shr_pcs;
+    std::unordered_map<uint32_t, uint32_t> compute_dpp_add_event_for_pc;
+    std::set<int> compute_dpp_add_row_shr_dsts;
+    std::unordered_set<uint32_t> compute_dpp_add_row_mask_pcs;
     for (size_t i = 0; i < ins.size(); ++i) {
         const auto& in = ins[i];
         if (in.is_end) break;
@@ -12731,6 +12764,21 @@ bool emit_cfg_state_machine(
             fragment_dpp_min_event_for_pc.emplace(
                 in.pc, static_cast<uint32_t>(fragment_dpp_min_event_for_pc.size() + 1));
             fragment_dpp_min_row_shr_dsts.insert(in.dst.value);
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (compute_dpp_add_row_shr(in)) {
+            compute_dpp_add_row_shr_pcs.insert(in.pc);
+            compute_dpp_add_event_for_pc.emplace(
+                in.pc, static_cast<uint32_t>(compute_dpp_add_event_for_pc.size() + 1));
+            compute_dpp_add_row_shr_dsts.insert(in.dst.value);
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (compute_dpp_add_row_mask(in)) {
+            compute_dpp_add_row_mask_pcs.insert(in.pc);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -12773,6 +12821,18 @@ bool emit_cfg_state_machine(
         if (target <= end_pc) start_set.insert(target);
         if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc) start_set.insert(ins[i + 1].pc);
     }
+    const bool has_portable_compute_dpp_add =
+        !b.native_subgroup_size && !compute_dpp_add_row_shr_pcs.empty();
+    // Portable DPP needs a full-width value beside an event/EXEC word for every invocation. The
+    // first plane remains reusable by MBCNT/votes after DPP's trailing barrier; only shaders that
+    // actually contain this event pay for the second plane.
+    const uint32_t dpp_add_value_base = 0;
+    const uint32_t dpp_add_metadata_base = padded_lanes;
+    const uint32_t wave_result_base = padded_lanes +
+        (has_portable_compute_dpp_add ? padded_lanes : 0u);
+    const uint32_t group_active_slot = wave_result_base + wave_count;
+    if (b.is_compute && !b.native_subgroup_size)
+        b.declare_cfg_scratch(group_active_slot + 1);
     start_set.insert(end_pc);
     std::vector<uint32_t> starts(start_set.begin(), start_set.end());
     if (starts.empty() || starts.front() != ins.front().pc) return false;
@@ -13391,6 +13451,8 @@ bool emit_cfg_state_machine(
                 mbcnt_event_for_pc.contains(in.pc) || append_event_for_pc.contains(in.pc) ||
                 swizzle_pcs.contains(in.pc) ||
                 fragment_dpp_min_row_shr_pcs.contains(in.pc) ||
+                compute_dpp_add_row_shr_pcs.contains(in.pc) ||
+                compute_dpp_add_row_mask_pcs.contains(in.pc) ||
                 mask_zero_compare_candidate_source(in) >= 0 ||
                 exec_saved_mask_compare_source(in) >= 0 ||
                 saved_mask_pair_compare_sources(in)[0] >= 0 ||
@@ -13565,6 +13627,18 @@ bool emit_cfg_state_machine(
         ? b.function_var(b.t_u32, ptr_u32) : 0;
     const uint32_t dpp_min_event_var = has_dpp_min_row_shr
         ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_add_pending_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_add_active_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_add_source_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_add_amount_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_add_dst_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_add_event_var = has_portable_compute_dpp_add
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -13619,6 +13693,12 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_min_amount_var, zero);
         b.store_function(dpp_min_dst_var, zero);
         b.store_function(dpp_min_event_var, zero);
+    }
+    if (has_portable_compute_dpp_add) {
+        b.store_function(dpp_add_source_var, zero);
+        b.store_function(dpp_add_amount_var, zero);
+        b.store_function(dpp_add_dst_var, zero);
+        b.store_function(dpp_add_event_var, zero);
     }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
@@ -13778,6 +13858,11 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_min_active_var, no);
         b.store_function(dpp_min_event_var, zero);
     }
+    if (has_portable_compute_dpp_add) {
+        b.store_function(dpp_add_pending_var, no);
+        b.store_function(dpp_add_active_var, no);
+        b.store_function(dpp_add_event_var, zero);
+    }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -13823,6 +13908,8 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* append = nullptr;
         const Rdna2Inst* swizzle = nullptr;
         const Rdna2Inst* dpp_min_row_shr = nullptr;
+        const Rdna2Inst* dpp_add_row_shr = nullptr;
+        const Rdna2Inst* dpp_add_row_mask = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
         const Rdna2Inst* saved_mask_pair_compare = nullptr;
@@ -13840,6 +13927,8 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_append = nullptr;
             const Rdna2Inst* block_swizzle = nullptr;
             const Rdna2Inst* block_dpp_min_row_shr = nullptr;
+            const Rdna2Inst* block_dpp_add_row_shr = nullptr;
+            const Rdna2Inst* block_dpp_add_row_mask = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
             const Rdna2Inst* block_saved_mask_pair_compare = nullptr;
@@ -13872,6 +13961,26 @@ bool emit_cfg_state_machine(
                                      in.pc, in.dst.value,
                                      static_cast<uint32_t>(in.dpp_ctrl - 0x110u));
                     block_dpp_min_row_shr = &in;
+                    break;
+                }
+                if (compute_dpp_add_row_shr_pcs.contains(in.pc)) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-cfg-dpp-add-row-shr] "
+                                     "pc=%u vgpr=v%d amount=%u\n",
+                                     in.pc, in.dst.value,
+                                     static_cast<uint32_t>(in.dpp_ctrl - 0x110u));
+                    block_dpp_add_row_shr = &in;
+                    break;
+                }
+                if (compute_dpp_add_row_mask_pcs.contains(in.pc)) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-cfg-dpp-add-row-mask] "
+                                     "pc=%u dst=v%d src1=v%d row_mask=0x%x\n",
+                                     in.pc, in.dst.value, in.src[1].value,
+                                     in.dpp_row_mask);
+                    block_dpp_add_row_mask = &in;
                     break;
                 }
                 const int mask_compare_source =
@@ -13979,7 +14088,8 @@ bool emit_cfg_state_machine(
             if (!last) {
                 // Group construction admits only one-successor plain blocks before the tail.
                 if (block_mbcnt || block_append || block_swizzle ||
-                    block_dpp_min_row_shr || block_mask_compare ||
+                    block_dpp_min_row_shr || block_dpp_add_row_shr ||
+                    block_dpp_add_row_mask || block_mask_compare ||
                     block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
                     block_vopc_mask_compare ||
                     block_b64_mask_scc_vote ||
@@ -13993,6 +14103,8 @@ bool emit_cfg_state_machine(
             append = block_append;
             swizzle = block_swizzle;
             dpp_min_row_shr = block_dpp_min_row_shr;
+            dpp_add_row_shr = block_dpp_add_row_shr;
+            dpp_add_row_mask = block_dpp_add_row_mask;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
             saved_mask_pair_compare = block_saved_mask_pair_compare;
@@ -14107,6 +14219,70 @@ bool emit_cfg_state_machine(
             b.store_function(dpp_min_dst_var,
                 b.uconst(static_cast<uint32_t>(dpp_min_row_shr->dst.value)));
             b.store_function(dpp_min_event_var, b.uconst(event->second));
+        }
+        if (dpp_add_row_shr) {
+            if (!compute_dpp_add_row_shr(*dpp_add_row_shr))
+                return reject_cfg(dpp_add_row_shr->pc, "dpp-add-row-shr-contract");
+            const auto event = compute_dpp_add_event_for_pc.find(dpp_add_row_shr->pc);
+            if (event == compute_dpp_add_event_for_pc.end())
+                return reject_cfg(dpp_add_row_shr->pc, "dpp-add-row-shr-event");
+            const int dst = dpp_add_row_shr->dst.value;
+            const auto source = state.vreg.find(dst);
+            const uint32_t source_value =
+                source == state.vreg.end() ? zero : source->second;
+            const uint32_t amount = b.uconst(
+                static_cast<uint32_t>(dpp_add_row_shr->dpp_ctrl - 0x110u));
+            if (b.native_subgroup_size) {
+                // One exact native subgroup is one guest wave, and the scalar dispatcher selector
+                // is subgroup-uniform. The source EXEC bit still matters: FI=0/BOUND_CTRL=0
+                // disables a destination whose shifted source lane is inactive.
+                uint32_t valid_source = 0;
+                const uint32_t shifted = b.subgroup_row_shr_dynamic(
+                    source_value, state.exec, amount, 0, &valid_source);
+                const uint32_t result = b.ibin(Op_IAdd, source_value, shifted);
+                state.vreg[dst] = b.sel(
+                    b.land(state.exec, valid_source), result, source_value);
+                for (auto& vg : state.vgpr_lane_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
+                for (auto& vg : state.vgpr_lane_mask_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
+            } else {
+                b.store_function(dpp_add_pending_var, yes);
+                b.store_function(dpp_add_active_var, state.exec);
+                b.store_function(dpp_add_source_var, source_value);
+                b.store_function(dpp_add_amount_var, amount);
+                b.store_function(dpp_add_dst_var,
+                    b.uconst(static_cast<uint32_t>(dst)));
+                b.store_function(dpp_add_event_var, b.uconst(event->second));
+            }
+        }
+        if (dpp_add_row_mask) {
+            if (!compute_dpp_add_row_mask(*dpp_add_row_mask))
+                return reject_cfg(dpp_add_row_mask->pc, "dpp-add-row-mask-contract");
+            const int dst = dpp_add_row_mask->dst.value;
+            const auto old = state.vreg.find(dst);
+            const auto addend = state.vreg.find(dpp_add_row_mask->src[1].value);
+            const uint32_t old_value = old == state.vreg.end() ? zero : old->second;
+            const uint32_t addend_value =
+                addend == state.vreg.end() ? zero : addend->second;
+            const uint32_t lane = b.ibin(
+                Op_BitwiseAnd, b.guest_lane_id(), b.uconst(b.wave_size - 1u));
+            const uint32_t row = b.ibin(
+                Op_ShiftRightLogical, lane, b.uconst(4));
+            const uint32_t row_bit = b.ibin(
+                Op_ShiftLeftLogical, b.uconst(1), row);
+            const uint32_t row_selected = b.ucmp(
+                Op_INotEqual,
+                b.ibin(Op_BitwiseAnd, row_bit,
+                       b.uconst(dpp_add_row_mask->dpp_row_mask)),
+                zero);
+            const uint32_t result = b.ibin(Op_IAdd, old_value, addend_value);
+            state.vreg[dst] = b.sel(
+                b.land(state.exec, row_selected), result, old_value);
+            for (auto& vg : state.vgpr_lane_slots)
+                if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
+            for (auto& vg : state.vgpr_lane_mask_slots)
+                if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
         }
         if (mask_compare) {
             if (b.is_vertex) {
@@ -14272,6 +14448,14 @@ bool emit_cfg_state_machine(
             if (!set_next(dpp_min_row_shr->pc + dpp_min_row_shr->len_dwords))
                 return reject_cfg(dpp_min_row_shr->pc,
                                   "dpp-min-row-shr-successor");
+        } else if (dpp_add_row_shr) {
+            if (!set_next(dpp_add_row_shr->pc + dpp_add_row_shr->len_dwords))
+                return reject_cfg(dpp_add_row_shr->pc,
+                                  "dpp-add-row-shr-successor");
+        } else if (dpp_add_row_mask) {
+            if (!set_next(dpp_add_row_mask->pc + dpp_add_row_mask->len_dwords))
+                return reject_cfg(dpp_add_row_mask->pc,
+                                  "dpp-add-row-mask-successor");
         } else if (mask_compare) {
             if (!set_next(mask_compare->pc + mask_compare->len_dwords))
                 return reject_cfg(mask_compare->pc, "mask-compare-successor");
@@ -14507,6 +14691,88 @@ bool emit_cfg_state_machine(
         b.emit_condbranch(b.load_function(b.t_bool, active_var),
                           loop_header, loop_merge);
     } else {
+    // Portable compute DPP V_ADD_NC_U32 common phase. Host subgroup shuffles cannot model a
+    // Wave64 guest on a subgroup32 device, and different guest waves can reach different static
+    // DPP sites in one dispatcher iteration. Publish a full source value plus an event/EXEC word
+    // for every workgroup invocation, then address the shifted lane directly inside the same guest
+    // 16-lane row. Two barriers bracket the scratch lifetime so later MBCNT/vote phases can reuse
+    // the value plane without observing a peer's previous dispatcher iteration.
+    if (has_portable_compute_dpp_add) {
+    const uint32_t dpp_pending = b.load_function(b.t_bool, dpp_add_pending_var);
+    const uint32_t dpp_active = b.load_function(b.t_bool, dpp_add_active_var);
+    const uint32_t dpp_source = b.load_function(b.t_u32, dpp_add_source_var);
+    const uint32_t dpp_event = b.load_function(b.t_u32, dpp_add_event_var);
+    b.cfg_scratch_store(
+        b.ibin(Op_IAdd, b.uconst(dpp_add_value_base), b.linear_localid), dpp_source);
+    const uint32_t dpp_metadata = b.sel(
+        dpp_pending,
+        b.ibin(Op_BitwiseOr,
+               b.ibin(Op_ShiftLeftLogical, dpp_event, b.uconst(1)),
+               b.sel(dpp_active, b.uconst(1), zero)),
+        zero);
+    b.cfg_scratch_store(
+        b.ibin(Op_IAdd, b.uconst(dpp_add_metadata_base), b.linear_localid),
+        dpp_metadata);
+    b.barrier();
+
+    const uint32_t dpp_amount = b.load_function(b.t_u32, dpp_add_amount_var);
+    const uint32_t dpp_row_lane = b.ibin(
+        Op_BitwiseAnd, b.linear_localid, b.uconst(15));
+    const uint32_t dpp_in_bounds = b.ucmp(
+        Op_UGreaterThanEqual, dpp_row_lane, dpp_amount);
+    // Keep even the disabled lane's scratch address valid. BOUND_CTRL=0 uses the validity gate
+    // below to preserve old VDST rather than consuming this self-addressed placeholder.
+    const uint32_t dpp_source_index = b.sel(
+        dpp_in_bounds,
+        b.ibin(Op_ISub, b.linear_localid, dpp_amount),
+        b.linear_localid);
+    const uint32_t dpp_shifted = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(dpp_add_value_base), dpp_source_index));
+    const uint32_t dpp_source_metadata = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(dpp_add_metadata_base), dpp_source_index));
+    const uint32_t dpp_source_event = b.ibin(
+        Op_ShiftRightLogical, dpp_source_metadata, b.uconst(1));
+    const uint32_t dpp_source_active = b.ucmp(
+        Op_INotEqual,
+        b.ibin(Op_BitwiseAnd, dpp_source_metadata, b.uconst(1)), zero);
+    uint32_t dpp_valid_source = b.land(
+        dpp_in_bounds, dpp_source_active);
+    dpp_valid_source = b.land(
+        dpp_valid_source, b.ucmp(Op_IEqual, dpp_source_event, dpp_event));
+    const uint32_t dpp_result = b.ibin(Op_IAdd, dpp_source, dpp_shifted);
+    const uint32_t dpp_write = b.land(
+        b.land(dpp_pending, dpp_active), dpp_valid_source);
+    const uint32_t dpp_dst = b.load_function(b.t_u32, dpp_add_dst_var);
+    for (int reg : compute_dpp_add_row_shr_dsts) {
+        const auto kv = vv.find(reg);
+        if (kv == vv.end()) return reject_cfg(0, "missing-dpp-add-row-shr-dst");
+        const uint32_t selected = b.land(
+            dpp_write, b.ucmp(Op_IEqual, dpp_dst,
+                              b.uconst(static_cast<uint32_t>(reg))));
+        const uint32_t old = b.load_function(b.t_u32, kv->second);
+        b.store_function(kv->second, b.sel(selected, dpp_result, old));
+    }
+    // The physical VGPR definition invalidates scalar lane-spill aliases even when EXEC or the
+    // shifted source suppresses this invocation's data write.
+    for (const auto& kv : lv) {
+        if (!compute_dpp_add_row_shr_dsts.contains(kv.first.first)) continue;
+        const uint32_t selected = b.land(
+            dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, zero, old));
+    }
+    for (const auto& kv : lmv) {
+        if (!compute_dpp_add_row_shr_dsts.contains(kv.first.first)) continue;
+        const uint32_t selected = b.land(
+            dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    b.barrier();
+    }
+
     // MBCNT common phase. Cases publish an event-tagged mask bit and accumulator, but never emit a
     // barrier themselves. Every invocation—including ended waves and lanes currently at a different
     // guest block—therefore executes these two barriers in identical structured control flow. Event

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7988,6 +7988,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x36: d = b.fext1(Glsl_Cos, b.fbin(Op_FMul, a, b.uconst(fbits(6.28318530717958647692f)))); break;
                 case 0x37: d = b.iun(Op_Not, a); break;               // v_not_b32
                 case 0x38: d = b.iun(Op_BitReverse, a); break;        // v_bfrev_b32
+                case 0x39: {                                         // v_ffbh_u32 (plain e32)
+                    // AMD RDNA2 ISA: count the zeroes preceding the first set bit from the MSB;
+                    // return -1 when no bit is set. GLSL.std.450 FindUMsb instead returns the SET
+                    // BIT INDEX (and all bits set at zero). OR bit zero in before calling it (which
+                    // leaves every nonzero input's highest bit unchanged), convert index -> count,
+                    // then explicitly select the architectural zero sentinel. GTA V uses the exact in-place
+                    // e32 packets 7e087304 / 7e047302 in its compute culling kernels.
+                    //
+                    // Keep SDWA out of this admission. The decoder's generic DWORD SDWA path can
+                    // carry NEG/ABS, which the VOP1 prologue above applies in the f32 domain; that
+                    // is not an integer source modifier and would silently change FFBH's operand.
+                    // DPP reaches and rejects in the stage-specific source-transform block above.
+                    if (in.has_sdwa || in.has_dpp) { ok = false; break; }
+                    const uint32_t safe = b.ibin(Op_BitwiseOr, a, b.uconst(1));
+                    const uint32_t leading_zeroes = b.ibin(
+                        Op_ISub, b.uconst(31), b.find_umsb(safe));
+                    d = b.sel(b.ucmp(Op_INotEqual, a, b.uconst(0)),
+                              leading_zeroes, b.uconst(0xffffffffu));
+                    break;
+                }
                 case 0x43: {   // v_movrels_b32: dst = VGPR[src0# + M0] (relative-indexed VGPR read)
                     // M0 is written by plain scalar ALU (s_mov/s_or m0, … decode dst as SGPR 124), so
                     // its per-invocation value lives in rs.sreg[124]. The source register NUMBER is

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5346,7 +5346,23 @@ bool scalar_write_is_b64_mask(const Rdna2Inst& in, int base) {
            in.sdst.value == base;
 }
 
-void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
+// GTA V's Wave32 post-process kernel selects one scalar dword directly into VCC_LO, then uses
+// that same physical word as the implicit predicate of v_cndmask.  The selected dword remains
+// ordinary scalar data, but in Wave32 it also contains the complete architectural VCC mask.  Keep
+// the admitted packet deliberately exact; the caller still has to prove Wave32 before bridging it.
+bool is_scalar_cselect_b32_to_vcc_lo(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::SOP2 && in.opcode == 0x0a &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value == 106 &&
+        in.src[0].kind == OperandKind::SGPR &&
+        in.src[1].kind == OperandKind::InlineInt && in.src[1].value == 0;
+}
+
+bool allows_compute_scalar_vcc_bridge(const SpirvCompute& b) {
+    return b.is_compute && b.allow_b32_masks && b.wave_size == 32;
+}
+
+void record_scalar_write(RegState& rs, const Rdna2Inst& in,
+                         bool allow_compute_scalar_vcc_bridge) {
     // VOPC/VOP3 mask destinations live in sreg_bool, but they still overwrite the physical SGPR
     // pair. Drop any scalar-data value or SRT descriptor tag left by that pair's earlier lifetime;
     // keeping either would let a later descriptor use observe the pre-overwrite value.
@@ -5399,13 +5415,18 @@ void record_scalar_write(RegState& rs, const Rdna2Inst& in) {
         const bool vopc_b32_mask = vopc_b32_write && base == in.dst.value;
         const bool vop3_b32_mask_write = vop3_b32_mask && base == in.sdst.value;
         const uint32_t effective_width = (vopc_b32_mask || vop3_b32_mask_write) ? 1u : width;
+        const bool scalar_cselect_vcc_bridge =
+            allow_compute_scalar_vcc_bridge && base == 106 &&
+            is_scalar_cselect_b32_to_vcc_lo(in) &&
+            rs.sreg.contains(106) && rs.sreg_bool_b32.contains(106);
         const bool writes_b32_mask = (effective_width == 1 || vopc_b32_mask) &&
-            !rs.sreg.contains(base) &&
             rs.sreg_bool_b32.contains(base) &&
-            ((in.fmt == Rdna2Format::SOP1 &&
-              (in.opcode == 0x03 || in.opcode == 0x07 || in.opcode == 0x09 ||
-               in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44)) ||
-             sop2_b32_mask_domain || vopc_b32_mask || vop3_b32_mask_write);
+            (scalar_cselect_vcc_bridge ||
+             (!rs.sreg.contains(base) &&
+              ((in.fmt == Rdna2Format::SOP1 &&
+                (in.opcode == 0x03 || in.opcode == 0x07 || in.opcode == 0x09 ||
+                 in.opcode == 0x3c || in.opcode == 0x40 || in.opcode == 0x44)) ||
+               sop2_b32_mask_domain || vopc_b32_mask || vop3_b32_mask_write)));
         const bool writes_b64_mask = effective_width == 2 && !vopc_b32_mask &&
             scalar_write_is_b64_mask(in, base);
         for (uint32_t word = 0; word < effective_width; ++word) {
@@ -6623,6 +6644,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.sreg_srt.erase(in.dst.value);
                     if (in.dst.value == 106) rs.vcc = result;
                 }
+                return true;
+            }
+            if (b.is_compute && is_scalar_cselect_b32_to_vcc_lo(in)) {
+                // The mask-domain cselect above remains first: this bridge is only for the distinct
+                // scalar-data lifetime seen in GTA V. Preserve the full selected dword in `sreg`,
+                // publish its bit for this guest lane as VCC, and leave SCC unchanged as required by
+                // S_CSELECT_B32. Wave64 cannot represent both dwords this way and stays rejected.
+                if (!allows_compute_scalar_vcc_bridge(b)) { ok = false; return true; }
+                if (!rs.scc) { ok = false; return true; }
+                const uint32_t selected = b.sel(rs.scc, val(in.src[0]), val(in.src[1]));
+                if (!ok) return true;
+                rs.sreg[106] = selected;
+                rs.sreg_srt.erase(106);
+                const uint32_t lane = b.ibin(
+                    Op_BitwiseAnd, b.guest_lane_id(), b.uconst(31));
+                const uint32_t bit = b.ibin(
+                    Op_BitwiseAnd,
+                    b.ibin(Op_ShiftRightLogical, selected, lane), b.uconst(1));
+                rs.vcc = b.ucmp(Op_INotEqual, bit, b.uconst(0));
+                rs.sreg_bool[106] = rs.vcc;
+                rs.sreg_bool_narrowed[106] = true;
+                rs.sreg_bool_b32.insert(106);
                 return true;
             }
             if (b.allow_b32_masks &&
@@ -12502,6 +12545,7 @@ bool emit_cfg_state_machine(
     const bool direct_dispatch = graphics || b.native_subgroup_size;
     const bool proven_wave32_masks = b.allow_b32_masks &&
         (b.is_fragment || (b.is_compute && b.wave_size == 32));
+    const bool compute_scalar_vcc_bridge = allows_compute_scalar_vcc_bridge(b);
     const uint32_t wave_count = b.is_compute
         ? (b.local_count + b.wave_size - 1) / b.wave_size : 0;
     const uint32_t padded_lanes = wave_count * b.wave_size;
@@ -12518,7 +12562,9 @@ bool emit_cfg_state_machine(
                 ((in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode)) ||
                  (in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 &&
                   in.opcode <= 0x12a && base == in.sdst.value) ||
-                 (vop3b_fresh_carry_output(in) && base == in.sdst.value));
+                 (vop3b_fresh_carry_output(in) && base == in.sdst.value) ||
+                 (compute_scalar_vcc_bridge &&
+                  is_scalar_cselect_b32_to_vcc_lo(in) && base == 106));
             if (wave32_one_word_mask)
                 static_mask_keys.insert(base);
             else if (base <= 105 && scalar_write_is_b64_mask(in, base))
@@ -13142,6 +13188,8 @@ bool emit_cfg_state_machine(
                 if (in.fmt == Rdna2Format::SOP2 &&
                     (in.opcode == 0x0a || (in.opcode >= 0x0e &&
                                            in.opcode <= 0x1c && (in.opcode & 1u) == 0))) {
+                    const bool scalar_vcc_bridge = compute_scalar_vcc_bridge &&
+                        is_scalar_cselect_b32_to_vcc_lo(in);
                     const bool mask_domain = in.dst.value == 126 || in.src[0].value == 126 ||
                         in.src[1].value == 126 ||
                         (((in.src[0].kind == OperandKind::SGPR ||
@@ -13150,8 +13198,9 @@ bool emit_cfg_state_machine(
                         (((in.src[1].kind == OperandKind::SGPR ||
                            in.src[1].kind == OperandKind::Special) &&
                           masks.contains(in.src[1].value)));
-                    writes_b32_mask = mask_domain && source_mask(in.src[0]) &&
-                        source_mask(in.src[1]) && in.dst.value != 127;
+                    writes_b32_mask = scalar_vcc_bridge ||
+                        (mask_domain && source_mask(in.src[0]) &&
+                         source_mask(in.src[1]) && in.dst.value != 127);
                 }
 
                 int b32_write_reg = writes_b32_mask ? in.dst.value : -1;
@@ -14105,7 +14154,10 @@ bool emit_cfg_state_machine(
                 bool ok = true;
                 const bool handled = emit_alu(b, state, in, ok, allow_exec_update, &safe,
                                               allow_smem, rt, /*allow_wave*/false);
-                if (handled && ok) record_scalar_write(state, in);
+                if (handled && ok)
+                    record_scalar_write(
+                        state, in,
+                        allows_compute_scalar_vcc_bridge(b));
                 if (!handled || !ok) {
                     if (getenv("PROSPER_DBG"))
                         // The raw INSTRUCTION WORDS, because without them this line cannot be acted
@@ -15481,7 +15533,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             bool ok = true;
             const bool handled = emit_alu(
                 b, rs, in, ok, allow_exec_update, &effective_safe, allow_smem, rt, wave_ok);
-            if (handled && ok) record_scalar_write(rs, in);
+            if (handled && ok)
+                record_scalar_write(
+                    rs, in,
+                    allows_compute_scalar_vcc_bridge(b));
             // Shader I/O tap: snapshot this instruction's destination VGPR (+3) if it is the tapped PC.
             if (handled && ok && in.pc == b.tap_pc && in.dst.kind == OperandKind::VGPR) {
                 auto tv = [&](int r) { auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
@@ -16925,7 +16980,10 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
         const bool emitted = emit_alu(
             b, rs, in, ok, /*allow_exec_update*/true, &safe_branches,
             /*allow_smem*/true, /*rt*/nullptr, /*allow_wave*/true);
-        if (emitted && ok) record_scalar_write(rs, in);
+        if (emitted && ok)
+            record_scalar_write(
+                rs, in,
+                allows_compute_scalar_vcc_bridge(b));
         bool handled = cf_reconstructed(in) || (emitted && ok);
         // Shapes the recompiler handles only in context (a resource table for MIMG sample/load/LOD/store
         // and buffer_load/store_format; a fragment stage for VINTRP). This table-less compute-shell pass

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -73,6 +73,11 @@ void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
 
 } // namespace
 
+void log_compute_recompile_skip_diagnostic(const RecompileDiagnosticContext& diagnostic) {
+    log_recompile_diagnostic(diagnostic, "compute-recompile-reject", "consequent",
+                             "reason=empty-result dispatch-skipped");
+}
+
 // #2319: render exactly the dwords the instruction HAS, not a fixed two.
 //
 // `words[]` is `uint32_t words[5] = {0,...}`, so a ONE-dword instruction printed as
@@ -16618,8 +16623,13 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // phases. Top-level wave branches use the compact structured reduction above even without
             // a guest barrier; nested wave branches still need this dispatcher. If a guest barrier
             // makes that transformation unsafe, reject rather than silently changing the branch domain.
-            if (!cfg_dispatch_safe ||
-                !emit_cfg_state_machine(b, rs, ins, safe, rt,
+            if (!cfg_dispatch_safe) {
+                log_recompile_diagnostic(
+                    b.diagnostic, "compute-cfg-reject", "terminal",
+                    "reason=exact-wave-dispatcher-unsafe guest-barrier=1");
+                return false;
+            }
+            if (!emit_cfg_state_machine(b, rs, ins, safe, rt,
                                         allow_exec_update, allow_smem, exp_fn, code, dwords))
                 return false;
             return true;
@@ -17268,7 +17278,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // every workgroup invocation to participate uniformly in OpControlBarrier, including barriers the
     // recompiler synthesizes for wave operations. Reject this uncommon combination instead of emitting
     // a module that could deadlock or observe undefined workgroup-memory behavior.
-    if (has_partial_workgroup && b.uses_barrier) return {};
+    if (has_partial_workgroup && b.uses_barrier) {
+        log_recompile_diagnostic(
+            b.diagnostic, "compute-recompile-reject", "terminal",
+            "reason=partial-workgroup-barrier threads=%ux%ux%u local=%ux%ux%u",
+            config.threads_x, config.threads_y, config.threads_z,
+            local_x, local_y, local_z);
+        return {};
+    }
     return b.finish();
 }
 

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -373,6 +373,11 @@ struct SpirvCompute {
     uint32_t v_gid=0, v_groupid=0, v_in=0, v_out=0, gidx=0, f_main=0, glsl=0, bconst_false=0;
     uint32_t globalid_comp[3] = {0, 0, 0}, groupid[3] = {0, 0, 0}, localid_comp[3] = {0, 0, 0};
     uint32_t invocation_guard_merge = 0;
+    // Set only by the barrier-phase emitter when a partial workgroup remains in uniform control
+    // flow and uses the dispatcher's separate ACTIVE bit to suppress padded guest invocations.
+    // recompile_compute uses this proof bit to distinguish that route from the ordinary divergent
+    // entry guard, which is never legal around a workgroup barrier.
+    bool partial_barrier_phases_emitted = false;
     uint32_t v_push_constants = 0, t_ptr_push_u32 = 0;
     uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
@@ -2313,13 +2318,18 @@ struct SpirvCompute {
 
     // Dispatcher-only scratch. Unlike guest LDS, this is private recompiler state: one flag slot per
     // padded hardware-wave lane, one result per wave, and one whole-workgroup liveness result.
-    uint32_t cfg_scratch = 0, t_ptr_cfg_u32 = 0;
-    void declare_cfg_scratch(uint32_t dwords) {
-        if (cfg_scratch) return;
+    uint32_t cfg_scratch = 0, t_ptr_cfg_u32 = 0, cfg_scratch_dwords = 0;
+    bool declare_cfg_scratch(uint32_t dwords) {
+        // OpTypeArray is immutable once emitted. A later phased dispatcher may require a wider
+        // layout than the first phase; fail closed if its caller did not pre-size from the complete
+        // stream instead of emitting an out-of-bounds Workgroup access.
+        if (cfg_scratch) return dwords <= cfg_scratch_dwords;
         uint32_t t_arr = id(); put(types, Op_TypeArray, {t_arr, t_u32, uconst(dwords)});
         uint32_t t_ptr = id(); put(types, Op_TypePointer, {t_ptr, SC_Workgroup, t_arr});
         cfg_scratch = id(); put(types, Op_Variable, {t_ptr, cfg_scratch, SC_Workgroup});
         t_ptr_cfg_u32 = id(); put(types, Op_TypePointer, {t_ptr_cfg_u32, SC_Workgroup, t_u32});
+        cfg_scratch_dwords = dwords;
+        return true;
     }
     uint32_t cfg_scratch_load(uint32_t idx) {
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_cfg_u32, p, cfg_scratch, idx});
@@ -2787,10 +2797,15 @@ struct SpirvCompute {
     // AGC thread-dimension mode can request a non-multiple of the shader's local size. Vulkan still
     // launches the final complete workgroup, so make its excess invocations branch directly to the
     // function merge instead of executing guest instructions (and, in particular, memory stores).
-    void guard_invocation_extent(uint32_t threads_x, uint32_t threads_y, uint32_t threads_z) {
+    uint32_t invocation_within_extent(uint32_t threads_x, uint32_t threads_y,
+                                      uint32_t threads_z) {
         uint32_t within = ucmp(Op_ULessThan, globalid_comp[0], uconst(threads_x));
         within = land(within, ucmp(Op_ULessThan, globalid_comp[1], uconst(threads_y)));
         within = land(within, ucmp(Op_ULessThan, globalid_comp[2], uconst(threads_z)));
+        return within;
+    }
+    void guard_invocation_extent(uint32_t threads_x, uint32_t threads_y, uint32_t threads_z) {
+        const uint32_t within = invocation_within_extent(threads_x, threads_y, threads_z);
         const uint32_t active = id();
         invocation_guard_merge = id();
         emit_selmerge(invocation_guard_merge);
@@ -13074,7 +13089,7 @@ bool emit_cfg_state_machine(
     const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
     bool allow_exec_update, bool allow_smem,
     const std::function<bool(RegState&, const Rdna2Inst&)>& exp_fn,
-    const uint32_t* code, size_t dwords) {
+    const uint32_t* code, size_t dwords, uint32_t initial_active = 0) {
     const bool graphics = b.is_fragment || b.is_vertex;
     auto reject_cfg = [&](uint32_t pc, const char* reason) {
         log_recompile_diagnostic(b.diagnostic,
@@ -13494,8 +13509,9 @@ bool emit_cfg_state_machine(
     const uint32_t wave_result_base = padded_lanes +
         (has_portable_compute_dpp_add ? padded_lanes : 0u);
     const uint32_t group_active_slot = wave_result_base + wave_count;
-    if (b.is_compute && !b.native_subgroup_size)
-        b.declare_cfg_scratch(group_active_slot + 1);
+    if (b.is_compute && !b.native_subgroup_size &&
+        !b.declare_cfg_scratch(group_active_slot + 1))
+        return reject_cfg(ins.front().pc, "cfg-scratch-too-small");
     start_set.insert(end_pc);
     std::vector<uint32_t> starts(start_set.begin(), start_set.end());
     if (starts.empty() || starts.front() != ins.front().pc) return false;
@@ -14210,6 +14226,8 @@ bool emit_cfg_state_machine(
     std::set<int> spill_vgprs;
     for (const auto& slot : lane_slots) spill_vgprs.insert(slot.first);
     for (const auto& slot : mask_lane_slots) spill_vgprs.insert(slot.first);
+    std::unordered_set<int> terminal_invalidated_vgpr_lane_slots =
+        initial.invalidated_vgpr_lane_slots;
     if (!spill_vgprs.empty()) {
         std::vector<std::set<int>> invalidated_in(starts.size());
         std::vector<bool> invalidated_reachable(starts.size(), false);
@@ -14250,6 +14268,11 @@ bool emit_cfg_state_machine(
                 if (invalidated_in[successor].size() != before) pending.push_back(successor);
             }
         }
+        if (const auto terminal = block_for_pc.find(end_pc);
+            terminal != block_for_pc.end() && invalidated_reachable[terminal->second])
+            terminal_invalidated_vgpr_lane_slots = {
+                invalidated_in[terminal->second].begin(),
+                invalidated_in[terminal->second].end()};
     }
 
     uint32_t ptr_u32 = 0, ptr_bool = 0;
@@ -14366,7 +14389,7 @@ bool emit_cfg_state_machine(
     b.store_function(vcc_var, initial.vcc ? initial.vcc : no);
     b.store_function(exec_var, initial.exec);
     b.store_function(pc_var, b.uconst(0));
-    b.store_function(active_var, yes);
+    b.store_function(active_var, initial_active ? initial_active : yes);
     b.store_function(swizzle_source_var, zero);
     b.store_function(swizzle_source_lane_var, zero);
     b.store_function(swizzle_dst_var, zero);
@@ -14387,9 +14410,12 @@ bool emit_cfg_state_machine(
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
         RegState state;
+        state.max_vgpr = initial.max_vgpr;
         state.sreg_input = initial.sreg_input;
         state.smem_x16_descriptor_loads = initial.smem_x16_descriptor_loads;
         state.smem_x16_descriptor_analysis_done = initial.smem_x16_descriptor_analysis_done;
+        state.reads_scc = initial.reads_scc;
+        state.invalidated_vgpr_lane_slots = initial.invalidated_vgpr_lane_slots;
         for (const auto& kv : vv) {
             if (dispatch != UINT32_MAX &&
                 !dispatch_vector_reads[dispatch].contains(kv.first)) continue;
@@ -15748,6 +15774,16 @@ bool emit_cfg_state_machine(
     // Expose the final emulated state to the caller. Graphics exports are emitted in their exact
     // cases, while any post-body bookkeeping still sees this invocation's final register values.
     initial = load_state();
+    if (const auto terminal = block_for_pc.find(end_pc);
+        terminal != block_for_pc.end() && scalar_reachable[terminal->second]) {
+        initial.sreg_written = scalar_may_write_in[terminal->second];
+        for (int reg : initial.sreg_written) initial.sreg_input.erase(reg);
+    }
+    initial.invalidated_vgpr_lane_slots =
+        std::move(terminal_invalidated_vgpr_lane_slots);
+    // sreg_srt and lds_addtid are path-sensitive SSA provenance without dispatcher function
+    // variables. Not reconstructing them across a phase is intentional and fail-closed: a later
+    // descriptor/LDS consumer rejects instead of reviving provenance from an arbitrary path.
     if (proven_wave32_masks) {
         const auto end_block = block_for_pc.find(end_pc);
         if (end_block != block_for_pc.end() &&
@@ -15766,6 +15802,7 @@ struct BarrierPhasedCompute {
     size_t guard_index = 0;
     size_t end_index = 0;
     std::vector<size_t> barriers;
+    bool guarded = false;
     bool found = false;
 };
 
@@ -15912,9 +15949,12 @@ bool terminal_guard_scc_is_workgroup_uniform(const std::vector<Rdna2Inst>& ins,
     return false;
 }
 
-// Recognize a workgroup-uniform scalar terminal guard around barrier-separated compute phases.
-// Keeping this proof shared is important: emit_body uses it to split the shader, while the native
-// subgroup policy uses the same result to make nested wave votes legal inside an individual phase.
+// Recognize barrier-separated compute phases. A generated kernel may wrap the phases in one proven
+// workgroup-uniform terminal SCC guard, but the guard is not essential: an unconditional top-level
+// barrier is itself a valid phase boundary. In either form, every explicit scalar edge must stay in
+// one phase and indirect PC changes fail closed. Keeping this proof shared is important: emit_body
+// uses it to split the shader, while the native subgroup policy uses the same result to make nested
+// wave votes legal inside an individual phase.
 BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>& ins) {
     BarrierPhasedCompute result;
     result.end_index = ins.size();
@@ -15942,9 +15982,8 @@ BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>
             result.guard_index = i;
     }
 
-    bool valid = result.guard_index < first_barrier && first_barrier < result.end_index &&
-        branch_count > 2;
-    bool scalar_prefix = valid;
+    bool guarded = result.guard_index < first_barrier && first_barrier < result.end_index;
+    bool scalar_prefix = guarded;
     for (size_t i = 0; scalar_prefix && i < result.guard_index; ++i) {
         const Rdna2Inst& in = ins[i];
         // Scalar ALU/loads retain workgroup-uniform values when entered from compute user data and
@@ -15967,16 +16006,36 @@ BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>
         for (uint32_t source = 0; source < in.n_src; ++source)
             if (is_exec(in.src[source])) scalar_prefix = false;
     }
-    if (valid && !scalar_prefix)
-        valid = terminal_guard_scc_is_workgroup_uniform(ins, result.guard_index);
+    if (guarded && !scalar_prefix)
+        guarded = terminal_guard_scc_is_workgroup_uniform(ins, result.guard_index);
 
-    for (size_t i = result.guard_index + 1; valid && i < result.end_index; ++i)
+    // If a candidate terminal guard was not proved uniform, include it in the ordinary edge proof.
+    // Since it jumps across every barrier to S_ENDPGM, that proof rejects the conditional barrier.
+    // A proved guard is deliberately excluded: every invocation in the workgroup takes it together.
+    result.guarded = guarded;
+    const size_t body_begin = guarded ? result.guard_index + 1 : 0;
+    bool valid = result.end_index < ins.size() && branch_count > 2;
+
+    for (size_t i = body_begin; valid && i < result.end_index; ++i)
         if (ins[i].fmt == Rdna2Format::SOPP && ins[i].opcode == 0x0a)
             result.barriers.push_back(i);
+    valid = valid && !result.barriers.empty();
+
+    for (size_t i = body_begin; valid && i < result.end_index; ++i) {
+        const Rdna2Inst& in = ins[i];
+        // A trap deactivates its guest wave in the dispatcher. Emitting a host workgroup barrier
+        // afterward would then require an invocation that has left the phase to participate.
+        // Final-phase traps are fine because no outer barrier follows them.
+        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12 &&
+            i < result.barriers.back())
+            valid = false;
+        if (in.fmt == Rdna2Format::SOP1 && in.opcode >= 0x20u && in.opcode <= 0x22u)
+            valid = false;
+    }
     // A phase boundary is valid only when no guest branch jumps across it in either direction.
     for (size_t barrier_index : result.barriers) {
         const uint32_t barrier_pc = ins[barrier_index].pc;
-        for (size_t i = result.guard_index + 1; valid && i < result.end_index; ++i) {
+        for (size_t i = body_begin; valid && i < result.end_index; ++i) {
             const Rdna2Inst& in = ins[i];
             if (in.fmt != Rdna2Format::SOPP || in.opcode < 0x02 || in.opcode > 0x09 ||
                 in.opcode == 0x03 || in.opcode == 0x0a) continue;
@@ -15986,7 +16045,7 @@ BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>
                 valid = false;
         }
     }
-    result.found = valid && !result.barriers.empty();
+    result.found = valid;
     return result;
 }
 
@@ -16001,7 +16060,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                const std::function<bool(RegState&, const Rdna2Inst&)>& exp_fn,
                const uint32_t* code = nullptr, size_t dwords = 0,
                const std::unordered_set<uint32_t>* inherited_dead_masks = nullptr,
-               bool allow_cfg_dispatcher = true) {
+               bool allow_cfg_dispatcher = true,
+               uint32_t initial_dispatch_active = 0,
+               bool force_barrier_phases = false) {
                // code/dwords: raw stream for forward-if target checks; inherited_dead_masks keeps
                // whole-shader liveness valid when a barrier-separated body is compiled in phases.
     rs.max_vgpr = std::max(rs.max_vgpr, shader_max_vgpr(ins));
@@ -16030,22 +16091,60 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
     // barrier remains uniform while the final phase can use the ordinary CFG dispatcher.
     if (b.is_compute) {
         const BarrierPhasedCompute phased = analyze_barrier_phased_compute(ins);
-        if (phased.found) {
-            const std::vector<Rdna2Inst> prefix(
-                ins.begin(), ins.begin() + phased.guard_index);
-            if (!prefix.empty() &&
-                !emit_body(b, rs, prefix, safe, rt, allow_exec_update, allow_smem,
-                           exp_fn, code, dwords, &dead_masks))
-                return false;
-            if (!rs.scc) return false;
-            const uint32_t execute_body = ins[phased.guard_index].opcode == 0x04
-                ? rs.scc : b.logical_not(rs.scc);
-            const uint32_t body_label = b.id(), merge_label = b.id();
-            b.emit_selmerge(merge_label);
-            b.emit_condbranch(execute_body, body_label, merge_label);
-            b.emit_label(body_label);
+        if (phased.found &&
+            (phased.guarded || initial_dispatch_active || force_barrier_phases)) {
+            // Every phase shares one immutable Workgroup OpTypeArray. Size it from the complete
+            // phased stream before the first dispatcher: a later portable DPP add needs a second
+            // per-lane plane even when the earlier phase needed only votes/liveness.
+            if (!b.native_subgroup_size) {
+                const uint32_t wave_count =
+                    (b.local_count + b.wave_size - 1) / b.wave_size;
+                const uint32_t padded_lanes = wave_count * b.wave_size;
+                const bool has_portable_dpp_add = std::any_of(
+                    ins.begin(), ins.begin() + phased.end_index,
+                    [](const Rdna2Inst& in) {
+                        return is_inplace_vadd_nc_u32_dpp_row_shr(in);
+                    });
+                const uint32_t scratch_dwords = padded_lanes +
+                    (has_portable_dpp_add ? padded_lanes : 0u) + wave_count + 1;
+                if (!b.declare_cfg_scratch(scratch_dwords)) return false;
+            }
+            uint32_t merge_label = 0;
+            if (phased.guarded) {
+                // Padded invocations cannot follow a divergent extent guard around this selection.
+                // Keep that uncommon combination on the existing fail-closed path; the unguarded
+                // phase form below is the one proved safe for partial workgroups.
+                if (initial_dispatch_active) return false;
+                const std::vector<Rdna2Inst> prefix(
+                    ins.begin(), ins.begin() + phased.guard_index);
+                if (!prefix.empty() &&
+                    !emit_body(b, rs, prefix, safe, rt, allow_exec_update, allow_smem,
+                               exp_fn, code, dwords, &dead_masks))
+                    return false;
+                if (!rs.scc) return false;
+                const uint32_t execute_body = ins[phased.guard_index].opcode == 0x04
+                    ? rs.scc : b.logical_not(rs.scc);
+                const uint32_t body_label = b.id();
+                merge_label = b.id();
+                b.emit_selmerge(merge_label);
+                b.emit_condbranch(execute_body, body_label, merge_label);
+                b.emit_label(body_label);
+            }
 
-            size_t phase_begin = phased.guard_index + 1;
+            auto emit_phase = [&](std::vector<Rdna2Inst>& phase) {
+                // Unguarded phases are admitted specifically because the whole-stream exact-wave
+                // dispatcher was blocked by a guest barrier. Use that dispatcher directly for each
+                // now barrier-free region; re-entering the narrow structurizer could reject the same
+                // backward-else/complex shape before it ever reaches the fallback.
+                if (!phased.guarded || initial_dispatch_active)
+                    return emit_cfg_state_machine(
+                        b, rs, phase, safe, rt, allow_exec_update, allow_smem,
+                        exp_fn, code, dwords, initial_dispatch_active);
+                return emit_body(b, rs, phase, safe, rt, allow_exec_update, allow_smem,
+                                 exp_fn, code, dwords, &dead_masks);
+            };
+
+            size_t phase_begin = phased.guarded ? phased.guard_index + 1 : 0;
             for (size_t barrier_index : phased.barriers) {
                 std::vector<Rdna2Inst> phase(
                     ins.begin() + phase_begin, ins.begin() + barrier_index);
@@ -16067,8 +16166,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         std::fprintf(stderr, "[compute-phase] begin=%u end=%u barrier=%u\n",
                                      phase.front().pc, phase[phase.size() - 2].pc,
                                      ins[barrier_index].pc);
-                    if (!emit_body(b, rs, phase, safe, rt, allow_exec_update, allow_smem,
-                                   exp_fn, code, dwords, &dead_masks)) {
+                    if (!emit_phase(phase)) {
                         log_recompile_diagnostic(
                             b.diagnostic, "compute-phase-reject", "consequent",
                             "begin=%u end=%u", phase.front().pc, phase[phase.size() - 2].pc);
@@ -16078,21 +16176,24 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 b.barrier();
                 phase_begin = barrier_index + 1;
             }
-            const std::vector<Rdna2Inst> tail(ins.begin() + phase_begin, ins.end());
+            std::vector<Rdna2Inst> tail(ins.begin() + phase_begin, ins.end());
             if (!tail.empty()) {
                 if (getenv("PROSPER_DBG"))
                     std::fprintf(stderr, "[compute-phase] begin=%u end=%u tail=1\n",
                                  tail.front().pc, tail.back().pc);
-                if (!emit_body(b, rs, tail, safe, rt, allow_exec_update, allow_smem,
-                               exp_fn, code, dwords, &dead_masks)) {
+                if (!emit_phase(tail)) {
                     log_recompile_diagnostic(b.diagnostic, "compute-phase-reject", "consequent",
                                              "begin=%u end=%u tail=1",
                                              tail.front().pc, tail.back().pc);
                     return false;
                 }
             }
-            b.emit_branch(merge_label);
-            b.emit_label(merge_label);
+            if (phased.guarded) {
+                b.emit_branch(merge_label);
+                b.emit_label(merge_label);
+            }
+            if (initial_dispatch_active)
+                b.partial_barrier_phases_emitted = true;
             return true;
         }
     }
@@ -16664,6 +16765,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // a guest barrier; nested wave branches still need this dispatcher. If a guest barrier
             // makes that transformation unsafe, reject rather than silently changing the branch domain.
             if (!cfg_dispatch_safe) {
+                const BarrierPhasedCompute phased = analyze_barrier_phased_compute(ins);
+                if (phased.found && !phased.guarded)
+                    return emit_body(
+                        b, rs, ins, safe, rt, allow_exec_update, allow_smem,
+                        exp_fn, code, dwords, &dead_masks, allow_cfg_dispatcher,
+                        /*initial_dispatch_active=*/0, /*force_barrier_phases=*/true);
                 log_recompile_diagnostic(
                     b.diagnostic, "compute-cfg-reject", "terminal",
                     "reason=exact-wave-dispatcher-unsafe guest-barrier=1");
@@ -17190,8 +17297,17 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const uint32_t local_z = std::max(1u, config.local_z);
     const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
     const uint64_t local_count = static_cast<uint64_t>(local_x) * local_y * local_z;
+    const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
+                                       config.threads_y % local_y != 0 ||
+                                       config.threads_z % local_z != 0;
+    const BarrierPhasedCompute barrier_phases = analyze_barrier_phased_compute(ins);
+    const bool partial_barrier_phases = config.exact_thread_extent && has_partial_workgroup &&
+        barrier_phases.found && !barrier_phases.guarded;
     b.native_subgroup_size = config.native_subgroup_size == wave_size &&
         local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
+    // A partial guest wave needs the portable dispatcher's per-lane ACTIVE bit. Native subgroup
+    // operations cannot be entered by only the real prefix of the final host subgroup.
+    if (partial_barrier_phases) b.native_subgroup_size = 0;
     // PROSPER_DBG: report the inputs to that decision, not just its outcome (#2429).
     //
     // Every wave-width-dependent lowering in this file gates on `b.native_subgroup_size` -- the
@@ -17250,7 +17366,10 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                          b.native_subgroup_size,
                          b.native_subgroup_size
                              ? "width-dependent lowerings ENABLED"
-                             : (config.native_subgroup_size == 0
+                             : (partial_barrier_phases
+                                    ? "DISABLED: partial barrier phases require the portable "
+                                      "dispatcher"
+                                : (config.native_subgroup_size == 0
                                     ? "DISABLED: no native width adopted -- "
                                       "select_native_compute_subgroup_size() declined"
                                     : (config.native_subgroup_size != wave_size
@@ -17259,7 +17378,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                                   ? "DISABLED: local_count exceeds the plausibility "
                                                     "guard"
                                                   : "DISABLED: workgroup is not a whole number "
-                                                    "of waves"))));
+                                                    "of waves")))));
     }
     b.native_storage_format_support = config.native_storage_format_support;
     b.packed_r11_storage = config.packed_r11_storage;
@@ -17267,10 +17386,11 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
             static_cast<uint32_t>(config.user_sgprs.size()));
     b.allow_b32_masks = wave_size == 32;
     b.declare_guest_scratch(scratch);
-    const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
-                                       config.threads_y % local_y != 0 ||
-                                       config.threads_z % local_z != 0;
-    if (config.exact_thread_extent && has_partial_workgroup)
+    uint32_t initial_dispatch_active = 0;
+    if (partial_barrier_phases)
+        initial_dispatch_active = b.invocation_within_extent(
+            config.threads_x, config.threads_y, config.threads_z);
+    else if (config.exact_thread_extent && has_partial_workgroup)
         b.guard_invocation_extent(config.threads_x, config.threads_y, config.threads_z);
 
     RegState rs;
@@ -17312,13 +17432,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);
     if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true,
-                   /*allow_smem*/true, [](RegState&, const Rdna2Inst&) { return false; }, code, dwords))
+                   /*allow_smem*/true, [](RegState&, const Rdna2Inst&) { return false; },
+                   code, dwords, nullptr, true, initial_dispatch_active))
         return {};
     // The entry guard is intentionally divergent only in the final partial workgroup. Vulkan requires
     // every workgroup invocation to participate uniformly in OpControlBarrier, including barriers the
     // recompiler synthesizes for wave operations. Reject this uncommon combination instead of emitting
     // a module that could deadlock or observe undefined workgroup-memory behavior.
-    if (has_partial_workgroup && b.uses_barrier) {
+    if (has_partial_workgroup && b.uses_barrier && !b.partial_barrier_phases_emitted) {
         log_recompile_diagnostic(
             b.diagnostic, "compute-recompile-reject", "terminal",
             "reason=partial-workgroup-barrier threads=%ux%ux%u local=%ux%ux%u",
@@ -17346,10 +17467,12 @@ bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& ins,
     }
     if (!guest_barrier || !code) return false;
 
-    // The phase splitter's shared proof is stronger than the whole-stream CFG shape: branches and
-    // loops inside one barrier-free phase do not make the outer uniform guard or its barriers
-    // divergent. Such kernels need an exact native subgroup for nested guest-wave votes.
-    if (analyze_barrier_phased_compute(ins).found) return true;
+    // The guarded phase splitter's shared proof is stronger than the whole-stream CFG shape:
+    // branches and loops inside one barrier-free phase do not make the outer uniform guard or its
+    // barriers divergent. Such kernels need an exact native subgroup for nested guest-wave votes.
+    if (const BarrierPhasedCompute phased = analyze_barrier_phased_compute(ins);
+        phased.found && phased.guarded)
+        return true;
 
     // Mirror the conservative, acyclic subset of emit_body's structured-compute admission. Counting
     // raw VCC/EXEC opcodes is insufficient: kill-mask branches may be safely linearized, loop exits

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4442,65 +4442,6 @@ struct DivLoop {
     bool continue_on_set = true;
 };
 
-// Number of consecutive VGPRs an instruction writes, starting at dst. This is intentionally an
-// over-approximation for memory operations: treating a store's VDATA as clobbered can only make the
-// uniformity proof below reject, while missing a multi-register load could make it accept stale data.
-uint32_t vgpr_write_count(const Rdna2Inst& in) {
-    if (in.dst.kind != OperandKind::VGPR) return 0;
-    switch (in.fmt) {
-        case Rdna2Format::VOP1:
-            return in.opcode == 0x02 ? 0 : 1;                   // v_readfirstlane writes an SGPR
-        case Rdna2Format::VOP2: case Rdna2Format::VOP3P:
-            return 1;
-        case Rdna2Format::VOP3:
-            // v_readlane_b32 (0x360) encodes its destination in VDST but writes an SGPR, exactly like
-            // v_readfirstlane_b32 above; every other consumer of the decode already models it that way
-            // (loop_written_regs / sgpr_write_count). Counting it as a VGPR write made a readlane whose
-            // destination SGPR number collides with a scalar-spill VGPR number look like an ordinary
-            // clobber of that spill slot, which rejected DQ VII's title grading kernel (#1483).
-            if (in.opcode == 0x360) return 0;
-            // 64-bit VGPR results: v_mad_u64_u32 (0x176), v_mad_i64_i32 (0x177), v_div_scale_f64
-            // (0x16E) — ISA opcodes 374/375/366 (the latter two are unimplemented in emit_alu but
-            // must count correctly the day they land).
-            return (in.opcode == 0x176 || in.opcode == 0x177 || in.opcode == 0x16E) ? 2 : 1;
-        case Rdna2Format::DS:
-            // Keep in sync with the DS opcodes the emitter accepts: the rtn atomics ds_add_rtn_u32
-            // (0x20) / ds_wrxchg_rtn_b32 (0x2d) write VDST, ds_read_b96/b128 (0xfe/0xff) write 3/4
-            // VGPRs — returning 0 for them hid their definitions from loop-header phi collection
-            // and from the #615 uniformity proof's defining-write scan.
-            if (in.opcode == 0x35 || in.opcode == 0x36 || in.opcode == 0x3d || in.opcode == 0x3e || in.opcode == 0xb1 ||
-                in.opcode == 0x20 || in.opcode == 0x2d) return 1;
-            if (in.opcode == 0x37 || in.opcode == 0x76) return 2;
-            if (in.opcode == 0xfe) return 3;
-            if (in.opcode == 0x77 || in.opcode == 0xff) return 4;
-            return 0;
-        case Rdna2Format::MUBUF:
-            switch (in.opcode) {
-                case 0x1: case 0x5: case 0xD: return 2;
-                case 0x2: case 0x6: case 0xF: return 3;
-                case 0x3: case 0x7: case 0xE: return 4;
-                default: return 1;
-            }
-        case Rdna2Format::MTBUF:
-            if (in.opcode >= 4u) return 0; // stores read VDATA; they do not write it
-            return in.opcode + 1u;
-        case Rdna2Format::FLAT: {
-            const FlatAccessInfo access = flat_access_info(in.opcode);
-            return access.valid && !access.store ? access.components : 0;
-        }
-        case Rdna2Format::MIMG: {
-            if (in.opcode == 0x47 || in.opcode == 0x57) return 4;  // gather4 always returns four texels
-            uint32_t n = 0;
-            for (uint32_t c = 0; c < 4; ++c) n += (in.mimg_dmask >> c) & 1u;
-            return n ? n : 4;                                     // unknown/empty mask: reject conservatively
-        }
-        case Rdna2Format::VINTRP:
-            return 1;   // v_interp_p1/p2/mov write VDST (per-lane interpolated data — inherently divergent)
-        default:
-            return 0;
-    }
-}
-
 // IMAGE_GET_LOD currently models only the ordinary FP32 sampled-image form. Keep the unsupported
 // Table 100 control families separate so each can be mutation-tested, while production and the
 // table-less coverage classifier consume one shared predicate and cannot drift apart.
@@ -4599,7 +4540,8 @@ bool vcc_exit_is_wave_uniform(const std::vector<Rdna2Inst>& ins, uint32_t branch
         if (operand.kind != OperandKind::VGPR) return false;
         for (auto it = ins.rbegin(); it != ins.rend(); ++it) {
             if (it->pc >= use_pc) continue;
-            const uint32_t writes = vgpr_write_count(*it);
+            if (operand.value == rdna2_tfe_status_vgpr(*it)) return false;
+            const uint32_t writes = rdna2_vgpr_write_count(*it);
             if (!writes || operand.value < it->dst.value ||
                 operand.value >= it->dst.value + (int32_t)writes) continue;
             if (it->dst.value != operand.value || it->has_dpp) return false;
@@ -5919,9 +5861,10 @@ int shader_max_vgpr(const std::vector<Rdna2Inst>& ins) {
         for (uint32_t source = 0; source < in.n_src; ++source)
             if (in.src[source].kind == OperandKind::VGPR)
                 highest = std::max(highest, in.src[source].value);
-        const uint32_t writes = vgpr_write_count(in);
-        if (writes)
-            highest = std::max(highest, in.dst.value + static_cast<int>(writes) - 1);
+        const uint32_t destination_span = rdna2_vgpr_destination_span(in);
+        if (destination_span)
+            highest = std::max(highest,
+                in.dst.value + static_cast<int>(destination_span) - 1);
     }
     return highest;
 }
@@ -5946,18 +5889,20 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
             case Rdna2Format::VOP3:
                 if (in.opcode == 0x360) sregs.insert(in.dst.value);       // v_readlane -> SGPR
                 else {
-                    for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                    for (uint32_t k = 0; k < rdna2_vgpr_write_count(in); ++k)
                         vregs.insert(in.dst.value + (int)k);
                 }
                 break;                                                    // (writelane: slots, not SSA)
             case Rdna2Format::DS:
-                for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                for (uint32_t k = 0; k < rdna2_vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
                 break;
             case Rdna2Format::MUBUF: case Rdna2Format::MTBUF: case Rdna2Format::MIMG:
             case Rdna2Format::FLAT:
-                for (uint32_t k = 0; k < vgpr_write_count(in); ++k)
+                for (uint32_t k = 0; k < rdna2_vgpr_write_count(in); ++k)
                     vregs.insert(in.dst.value + (int)k);
+                if (const int tfe_status = rdna2_tfe_status_vgpr(in); tfe_status >= 0)
+                    vregs.insert(tfe_status);
                 break;
             case Rdna2Format::SOP1:
                 sregs.insert(in.dst.value); break;
@@ -14250,11 +14195,13 @@ bool emit_cfg_state_machine(
                 if (in.fmt == Rdna2Format::VOP3 && in.opcode == 0x360 &&
                     invalidated.contains(in.src[0].value))
                     return reject_cfg(in.pc, "invalidated-vgpr-lane-slot");
-                const uint32_t writes = vgpr_write_count(in);
+                const uint32_t writes = rdna2_vgpr_write_count(in);
                 for (uint32_t word = 0; word < writes; ++word) {
                     const int reg = in.dst.value + static_cast<int>(word);
                     if (spill_vgprs.contains(reg)) invalidated.insert(reg);
                 }
+                const int tfe_status = rdna2_tfe_status_vgpr(in);
+                if (spill_vgprs.contains(tfe_status)) invalidated.insert(tfe_status);
             }
             for (uint32_t successor : successors[block]) {
                 if (!invalidated_reachable[successor]) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9355,6 +9355,41 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t t1 = b.ibin(Op_BitwiseAnd, s0, val(in.src[1]));
                 uint32_t t2 = b.ibin(Op_BitwiseAnd, b.iun(Op_Not, s0), val(in.src[2]));
                 vreg[in.dst.value] = b.ibin(Op_BitwiseOr, t1, t2);
+            } else if (in.opcode == 0x14F) {                          // v_alignbyte_b32
+                // RDNA2 defines D = ({S0,S1} >> (8 * S2[4:0])) & 0xffffffff, where
+                // S0 is the high dword and S1 the low dword.  Keep every SPIR-V shift
+                // below 32: OpSelect is not short-circuiting, so an apparently unused
+                // shift by 32 would still be undefined.  GTA V's live compute packets
+                // use the plain integer form; LLVM rejects ABS/NEG/OMOD for this opcode
+                // and CLAMP is not part of the documented operation, so those shapes
+                // remain fail-visible rather than silently ignoring their modifier bits.
+                const bool modified = in.src_abs[0] || in.src_abs[1] || in.src_abs[2] ||
+                                      in.src_neg[0] || in.src_neg[1] || in.src_neg[2] ||
+                                      in.clamp || in.omod;
+                if (modified) {
+                    ok = false;
+                } else {
+                    const uint32_t s0 = val(in.src[0]);
+                    const uint32_t s1 = val(in.src[1]);
+                    const uint32_t byte = b.ibin(Op_BitwiseAnd, val(in.src[2]), b.uconst(31));
+                    const uint32_t shift = b.ibin(
+                        Op_BitwiseAnd, b.ibin(Op_ShiftLeftLogical, byte, b.uconst(3)),
+                        b.uconst(31));
+                    const uint32_t inv_shift = b.ibin(
+                        Op_BitwiseAnd, b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
+                    const uint32_t joined = b.ibin(
+                        Op_BitwiseOr, b.ibin(Op_ShiftRightLogical, s1, shift),
+                        b.ibin(Op_ShiftLeftLogical, s0, inv_shift));
+                    const uint32_t low = b.sel(b.ucmp(Op_IEqual, byte, b.uconst(0)), s1, joined);
+                    const uint32_t upper_byte = b.ibin(Op_ISub, byte, b.uconst(4));
+                    const uint32_t upper_shift = b.ibin(
+                        Op_BitwiseAnd, b.ibin(Op_ShiftLeftLogical, upper_byte, b.uconst(3)),
+                        b.uconst(31));
+                    const uint32_t upper = b.ibin(Op_ShiftRightLogical, s0, upper_shift);
+                    vreg[in.dst.value] = b.sel(
+                        b.ucmp(Op_ULessThan, byte, b.uconst(4)), low,
+                        b.sel(b.ucmp(Op_ULessThan, byte, b.uconst(8)), upper, b.uconst(0)));
+                }
             } else if (in.opcode == 0x364) {                          // v_bcnt_u32_b32
                 // AMD RDNA2: D = popcount(S0) + S1. The third VOP3 source field is unused.
                 vreg[in.dst.value] = b.ibin(Op_IAdd,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -83,7 +83,7 @@ enum : uint32_t {
     Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQuerySize=104,
     Op_ImageQueryLod=105, Op_ImageQueryLevels=106,
-    Op_TypeArray=28, Op_ControlBarrier=224, Op_AtomicExchange=229, Op_AtomicIAdd=234,
+    Op_TypeArray=28, Op_ControlBarrier=224, Op_MemoryBarrier=225, Op_AtomicExchange=229, Op_AtomicIAdd=234,
     Op_AtomicISub=235,
     Op_AtomicSMin=236, Op_AtomicUMin=237, Op_AtomicSMax=238, Op_AtomicUMax=239,
     Op_AtomicAnd=240, Op_AtomicOr=241, Op_AtomicXor=242,
@@ -134,10 +134,13 @@ enum : uint32_t {
     ImgFmt_R32ui=kSpirvImageFormatR32ui, // exact uint32 storage image format required by image atomics
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
+    MemSem_UniformRelease=0x44,                          // Release | UniformMemory
     MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage-buffer/LDS AcquireRelease semantics
     MemSem_ImageAcqRel=0x808,                            // AcquireRelease | ImageMemory
+    MemAccess_Volatile=0x1,
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
-    Dec_Centroid=16, Dec_Sample=17, Dec_Location=30, Dec_Binding=33,
+    Dec_Centroid=16, Dec_Sample=17, Dec_Aliased=20, Dec_Coherent=23,
+    Dec_Location=30, Dec_Binding=33,
     Dec_DescriptorSet=34, Dec_Offset=35, Dec_XfbBuffer=36, Dec_XfbStride=37,
     // Decoration 5300 -- descriptor indexing's NonUniform, unrelated to the GroupNonUniform ops.
     Dec_NonUniform=5300,
@@ -331,6 +334,7 @@ struct SpirvCompute {
     // finish() emits the explicit typed zero-pad contract only for candidates with no competing use.
     std::map<uint32_t, StorageBufferTailSemantic> cbuf_zero_pad_candidates;
     std::set<uint32_t> cbuf_ordinary_accesses;
+    std::set<uint32_t> cbuf_coherent_vars;
     bool     is_fragment=0;                          // true in the fragment shell (gates VINTRP interp)
     bool     is_vertex=0;                            // true in every vertex shell
     bool     allow_b32_masks=0;                      // proven Wave32 or byte-exact graphics exception
@@ -790,6 +794,15 @@ struct SpirvCompute {
         uint32_t result = id();
         put(code, Op_Load, {t_bool, result, v_helper_invocation});
         return result;
+    }
+    // Distinct guest descriptors can name the same allocation. Under the GLSL450 memory model,
+    // separate StorageBuffer variables otherwise promise non-aliasing to the SPIR-V consumer. The
+    // runtime binding addresses are deliberately absent from the shader cache key, so every external
+    // guest-backed buffer declaration must retain the possibility of aliasing. Internal GDS uses its
+    // own host allocation and intentionally does not go through this helper.
+    void declare_external_storage_buffer(uint32_t pointer_type, uint32_t variable) {
+        put(types, Op_Variable, {pointer_type, variable, SC_StorageBuffer});
+        put(deco, Op_Decorate, {variable, Dec_Aliased});
     }
     void declare_internal_gds(uint32_t set = 1, uint32_t binding = 0) {
         if (v_internal_gds) return;
@@ -1913,6 +1926,15 @@ struct SpirvCompute {
         if (binding == 3) return v_cbuf1;
         auto it = cbuf_var.find(binding); return it != cbuf_var.end() ? it->second : v_cbuf;
     }
+    void mark_cbuf_coherent(uint32_t binding) {
+        const uint32_t buf = buf_for_binding(binding);
+        if (cbuf_coherent_vars.insert(buf).second)
+            put(deco, Op_Decorate, {buf, Dec_Coherent});
+    }
+    void device_uniform_release_barrier() {
+        put(code, Op_MemoryBarrier,
+            {uconst(Scope_Device), uconst(MemSem_UniformRelease)});
+    }
     // Load one dword (raw bits) from the constant/vertex buffer at descriptor `binding` at dword index
     // `idx` (SMEM). The 1-arg form keeps the legacy slot convention (0 -> binding 2, 1 -> binding 3).
     // THE only place a storage-buffer element pointer is built. There were FOUR identical
@@ -1950,38 +1972,46 @@ struct SpirvCompute {
         putv(code, Op_AccessChain, {t_ptr_sb_u32, ptr, buf, uconst(0), idx});
         return ptr;
     }
-    uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding) {
+    uint32_t cbuf_load_impl(uint32_t idx, uint32_t binding, bool coherent_access) {
         uint32_t buf = buf_for_binding(binding);
+        if (coherent_access) mark_cbuf_coherent(binding);
         uint32_t p = cbuf_element_ptr(buf, binding, idx);
-        uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
+        uint32_t r = id();
+        if (coherent_access) put(code, Op_Load, {t_u32, r, p, MemAccess_Volatile});
+        else                 put(code, Op_Load, {t_u32, r, p});
+        return r;
     }
-    uint32_t cbuf_load(uint32_t idx, uint32_t binding = 2) {
+    uint32_t cbuf_load(uint32_t idx, uint32_t binding = 2, bool coherent_access = false) {
         cbuf_ordinary_accesses.insert(binding);
-        return cbuf_load_impl(idx, binding);
+        return cbuf_load_impl(idx, binding, coherent_access);
     }
     uint32_t cbuf_load_zero_padded_tail(uint32_t binding,
-                                        StorageBufferTailSemantic semantic) {
+                                        StorageBufferTailSemantic semantic,
+                                        bool coherent_access = false) {
         auto [candidate, inserted] = cbuf_zero_pad_candidates.emplace(binding, semantic);
         if (!inserted && candidate->second != semantic)
             cbuf_ordinary_accesses.insert(binding);
-        return cbuf_load_impl(uconst(0), binding);
+        return cbuf_load_impl(uconst(0), binding, coherent_access);
     }
     // Store one dword `value` to the buffer at descriptor `binding` at dword index `idx` (MUBUF store).
     // When `predicated`, the store is wrapped in a selection merge on `pred` (the per-lane EXEC bool) so
     // inactive lanes do not write — a real conditional store, not a select of a loaded old value.
-    void cbuf_store(uint32_t idx, uint32_t value, uint32_t binding, bool predicated, uint32_t pred) {
+    void cbuf_store(uint32_t idx, uint32_t value, uint32_t binding, bool predicated,
+                    uint32_t pred, bool coherent_access = false) {
         cbuf_ordinary_accesses.insert(binding);
         uint32_t buf = buf_for_binding(binding);
-        if (!predicated) {
+        if (coherent_access) mark_cbuf_coherent(binding);
+        auto emit = [&]() {
             uint32_t p = cbuf_element_ptr(buf, binding, idx);
-            put(code, Op_Store, {p, value}); return;
-        }
+            if (coherent_access) put(code, Op_Store, {p, value, MemAccess_Volatile});
+            else                 put(code, Op_Store, {p, value});
+        };
+        if (!predicated) { emit(); return; }
         uint32_t then = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});
         put(code, Op_BranchConditional, {pred, then, merge});
         put(code, Op_Label, {then}); cur_block = then;
-        uint32_t p = cbuf_element_ptr(buf, binding, idx);
-        put(code, Op_Store, {p, value});
+        emit();
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
     }
@@ -2033,7 +2063,7 @@ struct SpirvCompute {
         const uint32_t variable = id();
         put(deco, Op_Decorate, {variable, Dec_DescriptorSet, desc_set});
         put(deco, Op_Decorate, {variable, Dec_Binding, binding});
-        put(types, Op_Variable, {t_ptr_sb_struct_u, variable, SC_StorageBuffer});
+        declare_external_storage_buffer(t_ptr_sb_struct_u, variable);
         cbuf_var[binding] = variable;
         atomic_img_buf_bindings.insert(binding);
         return true;
@@ -2401,7 +2431,7 @@ struct SpirvCompute {
             else                            put(types, Op_TypeArray, {arr, t_struct_u, uconst(arity)});
             const uint32_t arr_ptr = id();
             put(types, Op_TypePointer, {arr_ptr, SC_StorageBuffer, arr});
-            put(types, Op_Variable, {arr_ptr, var, SC_StorageBuffer});
+            declare_external_storage_buffer(arr_ptr, var);
             cbuf_table_arity[binding] = arity;
             const uint32_t sgpr = index_sgpr_for(binding);
             if (sgpr != 0xFFFFFFFFu) cbuf_table_index_sgpr[binding] = sgpr;
@@ -2421,9 +2451,9 @@ struct SpirvCompute {
         // is still fail-visible, not silently wrong -- but "loud" here means a dropped draw, not a
         // validator, and nothing reports it as a type error at the point the mistake was made.
         if (arity2) declare_as_array(2, v_cbuf, arity2);
-        else        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf,  SC_StorageBuffer});
+        else        declare_external_storage_buffer(t_ptr_sb_struct_u, v_cbuf);
         if (arity3) declare_as_array(3, v_cbuf1, arity3);
-        else        put(types, Op_Variable, {t_ptr_sb_struct_u, v_cbuf1, SC_StorageBuffer});
+        else        declare_external_storage_buffer(t_ptr_sb_struct_u, v_cbuf1);
         put(types, Op_TypePointer, {t_ptr_sb_u32, SC_StorageBuffer, t_u32});
         cbuf_var[2] = v_cbuf; cbuf_var[3] = v_cbuf1;
         // N-buffer model: declare an additional storage buffer for each distinct constant/vertex buffer
@@ -2460,14 +2490,14 @@ struct SpirvCompute {
                     }
                     const uint32_t arr_ptr = id();
                     put(types, Op_TypePointer, {arr_ptr, SC_StorageBuffer, arr});
-                    put(types, Op_Variable, {arr_ptr, v, SC_StorageBuffer});
+                    declare_external_storage_buffer(arr_ptr, v);
                     cbuf_var[r.binding] = v;
                     cbuf_table_arity[r.binding] = r.table_index_count;
                     if (r.table_index_sgpr != 0xFFFFFFFFu)
                         cbuf_table_index_sgpr[r.binding] = r.table_index_sgpr;
                     continue;
                 }
-                put(types, Op_Variable, {t_ptr_sb_struct_u, v, SC_StorageBuffer});
+                declare_external_storage_buffer(t_ptr_sb_struct_u, v);
                 cbuf_var[r.binding] = v;
             }
         }
@@ -2566,8 +2596,8 @@ struct SpirvCompute {
         put(types, Op_TypeRuntimeArray, {t_rta, t_f32});
         put(types, Op_TypeStruct, {t_struct, t_rta});
         put(types, Op_TypePointer, {t_ptr_sb_struct, SC_StorageBuffer, t_struct});
-        put(types, Op_Variable, {t_ptr_sb_struct, v_in, SC_StorageBuffer});
-        put(types, Op_Variable, {t_ptr_sb_struct, v_out, SC_StorageBuffer});
+        declare_external_storage_buffer(t_ptr_sb_struct, v_in);
+        declare_external_storage_buffer(t_ptr_sb_struct, v_out);
         put(types, Op_TypePointer, {t_ptr_sb_f32, SC_StorageBuffer, t_f32});
         declare_cbufs(rt); // scalar-memory buffers, including table-assigned bindings beyond 2/3
         put(code, Op_Function, {t_void, f_main, FC_None, t_fn});
@@ -7588,14 +7618,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     break;
                 }
-                // s_waitcnt_vscnt/vmcnt/expcnt/lgkmcnt: wait-for-counter — benign no-ops in our
-                // synchronous model (like SOPP s_waitcnt). These are SOPK on gfx10, NOT SOPP 0x7d
-                // as previously claimed (that case was unreachable dead code, and a real
-                // s_waitcnt_vscnt — routinely emitted after buffer/image stores — failed the whole
-                // shader recompile via this default). VERIFIED(round-trip llvm-mc gfx1010):
+                // Scalar wait counters are SOPK on gfx10, NOT SOPP 0x7d. Loads/stores themselves
+                // are synchronous SSA operations in SPIR-V, so vmcnt/expcnt/lgkmcnt remain no-ops.
+                // A completed vscnt(0), however, is also the guest's publication point: GTA V writes
+                // scan data, waits for those stores, then writes a ready flag that other workgroups
+                // poll. Preserve that device-wide UniformMemory ordering with a release barrier.
+                // VERIFIED(round-trip llvm-mc gfx1010):
                 // vscnt=0xBBFD0000 (op 0x17), vmcnt=0xBC7D0000 (0x18), expcnt=0xBCFD0000 (0x19),
                 // lgkmcnt=0xBD7D0000 (0x1A).
-                case 0x17: case 0x18: case 0x19: case 0x1A: break;
+                case 0x17:
+                    if (in.dst.kind == OperandKind::SGPR && in.dst.value == 125 &&
+                        in.simm16 == 0)
+                        b.device_uniform_release_barrier();
+                    break;
+                case 0x18: case 0x19: case 0x1A: break;
                 default: ok = false;
             }
             return true;
@@ -9872,6 +9908,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             uint32_t offset = in.literal & 0xFFFu;
             bool offen = (in.literal >> 12) & 1u, idxen = (in.literal >> 13) & 1u;
+            // GLC/DLC ordinary loads must observe device-visible writes rather than a cached value;
+            // GLC ordinary stores publish through the device cache. Atomics retain their existing
+            // Device/AcquireRelease operands and GLC's separate return-pre-op-value contract below.
+            const bool coherent_load = !is_store && !is_atomic &&
+                                       (in.mubuf_glc || in.mubuf_dlc);
+            const bool coherent_store = is_store && in.mubuf_glc;
             // PC-relative EMBEDDED TABLE (#273): this load's V# was built from s_getpc_b64 and the
             // table bytes live inside the shader blob — detect_pcrel_tables already copied them out.
             // Fold to a compile-time constant lookup: dword index = (inst offset + offen VADDR) >> 2;
@@ -10233,6 +10275,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 addr = b.ibin(Op_IAdd, addr, val(in.src[2]));          // SOFFSET
             }
             uint32_t idx = b.ibin(Op_ShiftRightLogical, addr, b.uconst(2));
+            // Keep the instruction's cache policy at one ordinary-load propagation site. Every raw,
+            // typed, packed, and dynamically addressed component below consumes dwords through this
+            // wrapper, so adding another format shape cannot accidentally drop GLC/DLC semantics.
+            auto load_dword = [&](uint32_t dword_idx) {
+                return b.cbuf_load(dword_idx, binding, coherent_load);
+            };
             if (is_atomic) {
                 const int d = in.dst.value;
                 const uint32_t old = vreg_old(b, rs, d);
@@ -10248,6 +10296,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             if (is_store) {
                 auto vread = [&](int r){ auto it = rs.vreg.find(r); return it == rs.vreg.end() ? b.uconst(0) : it->second; };
+                if (coherent_store) b.mark_cbuf_coherent(binding);
+                // As with loads, keep Volatile propagation shared by raw and packed ordinary stores.
+                auto store_dword = [&](uint32_t dword_idx, uint32_t value) {
+                    b.cbuf_store(dword_idx, value, binding, rs.exec_narrowed, rs.exec,
+                                 coherent_store);
+                };
                 if (dyn_int_store) {
                     // Integer sub-dword store: clear then set THIS lane's disjoint field of the containing
                     // dword with two atomics. Disjoint fields commute (And clears only this field's bits,
@@ -10287,7 +10341,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // Raw/Float32/Uint32: one dword per component.
                     for (uint32_t k = 0; k < store_n; k++) {
                         uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
-                        b.cbuf_store(kidx, vread(in.dst.value + (int)k), binding, rs.exec_narrowed, rs.exec);
+                        store_dword(kidx, vread(in.dst.value + (int)k));
                     }
                 } else {
                     // Packed UNORM/SNORM/Float16: pack the components tightly into ceil(n*bytes/4) dwords
@@ -10305,7 +10359,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             acc = b.ibin(Op_BitwiseOr, acc, field);
                         }
                         uint32_t did = d ? b.ibin(Op_IAdd, idx, b.uconst(d)) : idx;
-                        b.cbuf_store(did, acc, binding, rs.exec_narrowed, rs.exec);
+                        store_dword(did, acc);
                     }
                 }
                 return true;
@@ -10327,7 +10381,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     value = b.uconst(in.fmt != Rdna2Format::MTBUF && k == 3 ? one : 0u);
                 } else if (one_record_16bit_tail) {
                     const uint32_t packed_value = b.cbuf_load_zero_padded_tail(
-                        binding, one_record_tail_semantic);
+                        binding, one_record_tail_semantic, coherent_load);
                     const uint32_t in_bounds = b.ucmp(
                         Op_IEqual, val(in.src[0]), b.uconst(0));
                     const uint32_t typed_value =
@@ -10339,12 +10393,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // Raw byte/short loads use their full byte address, unlike typed packed-format
                     // loads whose component packing is descriptor-defined. A 16-bit access may begin
                     // at byte 3 and straddle two dwords, so join the adjacent words before extracting.
-                    const uint32_t dw0 = b.cbuf_load(idx, binding);
+                    const uint32_t dw0 = load_dword(idx);
                     const uint32_t byte_in_dw = b.ibin(Op_BitwiseAnd, addr, b.uconst(3));
                     const uint32_t shift = b.ibin(Op_ShiftLeftLogical, byte_in_dw, b.uconst(3));
                     uint32_t joined = b.ibin(Op_ShiftRightLogical, dw0, shift);
                     if (raw_bits == 16) {
-                        const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, idx, b.uconst(1)), binding);
+                        const uint32_t dw1 = load_dword(
+                            b.ibin(Op_IAdd, idx, b.uconst(1)));
                         const uint32_t inv_shift = b.ibin(
                             Op_BitwiseAnd,
                             b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
@@ -10358,12 +10413,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         : b.bfe_u(joined, b.uconst(0), b.uconst(raw_bits));
                 } else if (!packed) {
                     uint32_t kidx = k ? b.ibin(Op_IAdd, idx, b.uconst(k)) : idx;
-                    value = b.cbuf_load(kidx, binding);                  // raw 32-bit component
+                    value = load_dword(kidx);  // raw 32-bit component
                 } else if (packed_word) {
                     // All requested components share one packed dword. GFX10 names layouts from high
                     // field to low field, so 2_10_10_10 is logical R/G/B in bits 0/10/20 and A in 30;
                     // 10_11_11 is R/G/B in bits 0/11/22 with widths 11/11/10.
-                    uint32_t dw = b.cbuf_load(idx, binding);
+                    uint32_t dw = load_dword(idx);
                     uint32_t boff = packed_10_11_11 ? (k == 0 ? 0u : k == 1 ? 11u : 22u)
                                                     : (k == 0 ? 0u : k == 1 ? 10u : k == 2 ? 20u : 30u);
                     uint32_t bits = packed_10_11_11 ? (k < 2 ? 11u : 10u) : (k < 3 ? 10u : 2u);
@@ -10386,8 +10441,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
                     const uint32_t shift = b.ibin(Op_ShiftLeftLogical,
                                                   b.ibin(Op_BitwiseAnd, caddr, b.uconst(3)), b.uconst(3));
-                    uint32_t joined = b.ibin(Op_ShiftRightLogical, b.cbuf_load(cidx, binding), shift);
-                    const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, cidx, b.uconst(1)), binding);
+                    uint32_t joined = b.ibin(
+                        Op_ShiftRightLogical, load_dword(cidx), shift);
+                    const uint32_t dw1 = load_dword(
+                        b.ibin(Op_IAdd, cidx, b.uconst(1)));
                     const uint32_t inv_shift = b.ibin(Op_BitwiseAnd,
                         b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
                     const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
@@ -10404,9 +10461,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint32_t cidx  = b.ibin(Op_ShiftRightLogical, caddr, b.uconst(2));
                     const uint32_t shift = b.ibin(Op_ShiftLeftLogical,
                                                   b.ibin(Op_BitwiseAnd, caddr, b.uconst(3)), b.uconst(3));
-                    uint32_t joined = b.ibin(Op_ShiftRightLogical, b.cbuf_load(cidx, binding), shift);
+                    uint32_t joined = b.ibin(
+                        Op_ShiftRightLogical, load_dword(cidx), shift);
                     if (comp_bytes == 2) {
-                        const uint32_t dw1 = b.cbuf_load(b.ibin(Op_IAdd, cidx, b.uconst(1)), binding);
+                        const uint32_t dw1 = load_dword(
+                            b.ibin(Op_IAdd, cidx, b.uconst(1)));
                         const uint32_t inv_shift = b.ibin(Op_BitwiseAnd,
                             b.ibin(Op_ISub, b.uconst(32), shift), b.uconst(31));
                         const uint32_t upper = b.ibin(Op_ShiftLeftLogical, dw1, inv_shift);
@@ -10422,7 +10481,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     uint32_t byte_off = k * comp_bytes;
                     uint32_t drel = byte_off / 4, boff = (byte_off % 4) * 8;
                     uint32_t did = drel ? b.ibin(Op_IAdd, idx, b.uconst(drel)) : idx;
-                    uint32_t dw  = b.cbuf_load(did, binding);
+                    uint32_t dw  = load_dword(did);
                     value = is_half ? b.unpack_half(dw, boff ? 1u : 0u)
                           : is_uint ? b.bfe_u(dw, b.uconst(boff), b.uconst(comp_bytes * 8))
                           : is_sint ? b.bfe_s(dw, b.uconst(boff), b.uconst(comp_bytes * 8))

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -413,6 +413,10 @@ FlatLoadAnalysis analyze_flat_loads(const uint32_t* code, size_t dwords, uint32_
 // backward branch that jumps to at-or-before it — must NOT appear here, so detect_divergent_loops claims
 // it and emit_divloop reconstructs the structured loop; a plain guard-to-end/if execz still does.
 std::vector<uint32_t> safe_execz_branches_for_test(const uint32_t* code, size_t dwords);
+// Test hook: EXECZ branch pcs admitted by the compute structured-if analysis after safe
+// linearizations are removed. This distinguishes the narrow structurizer path from the generic CFG
+// fallback when an end-to-end shader happens to be supported by both.
+std::vector<uint32_t> structured_execz_branches_for_test(const uint32_t* code, size_t dwords);
 std::vector<uint32_t> mask_test_branches_for_test(const uint32_t* code, size_t dwords,
                                                   bool wave32);
 

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -23,6 +23,22 @@ inline constexpr uint32_t kComputeInternalGdsBinding = 127;
 struct ShaderResourceTable;   // resource-binding contract (shader_resources.hpp); optional to recompile_valu
 struct Rdna2Inst;
 
+// Per-invocation provenance for fail-visible shader diagnostics. This is observation-only metadata:
+// it must travel beside the translation inputs rather than participate in compiled-module identity,
+// because the same program bytes and semantic configuration produce the same SPIR-V at every guest
+// address. A zero address is the neutral standalone/tool/test identity.
+enum class RecompileDiagnosticStage : uint8_t {
+    Standalone,
+    Compute,
+    Vertex,
+    Fragment,
+};
+
+struct RecompileDiagnosticContext {
+    RecompileDiagnosticStage stage = RecompileDiagnosticStage::Standalone;
+    uint64_t program_address = 0;
+};
+
 // A narrowly-proven compiler-generated scalar jump table. The shader loads a uniform selector from a
 // direct constant buffer, bounds it, scales it by the 64-bit table-entry size, loads a PC-relative
 // target, and reaches it with s_setpc_b64. Arbitrary indirect control flow remains unsupported: this
@@ -244,16 +260,22 @@ struct ComputeShaderConfig {
 // recompile_valu. Memory effects come only from the program's actual resource operations.
 std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
-                                        const ComputeShaderConfig& config);
+                                        const ComputeShaderConfig& config,
+                                        RecompileDiagnosticContext diagnostic = {
+                                            RecompileDiagnosticStage::Compute, 0});
 
 // True when the program contains enough proven wave work to justify an exact multi-wave subgroup
 // shell: either the canonical low/high MBCNT pair, or at least four VCC/EXEC branches accepted by the
 // structured compute emitter in a shader containing only top-level guest workgroup barriers. Portable
 // compute lowers those operations through synchronized workgroup scratch; native compute uses subgroup
 // scans/votes. This deliberately conservative structural signal is independent of title and address.
-bool compute_shader_prefers_native_multiwave(const uint32_t* code, size_t dwords);
+bool compute_shader_prefers_native_multiwave(
+    const uint32_t* code, size_t dwords,
+    RecompileDiagnosticContext diagnostic = {RecompileDiagnosticStage::Compute, 0});
 bool compute_shader_prefers_native_multiwave(const std::vector<Rdna2Inst>& instructions,
-                                             const uint32_t* code, size_t dwords);
+                                             const uint32_t* code, size_t dwords,
+                                             RecompileDiagnosticContext diagnostic = {
+                                                 RecompileDiagnosticStage::Compute, 0});
 
 // DPP/permlane operations are native subgroup shuffles: quad permutations need four contiguous
 // lanes, row operations need 16, and PERMLANEX16 needs a paired 32-lane row. The backend rejects

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -39,6 +39,9 @@ struct RecompileDiagnosticContext {
     uint64_t program_address = 0;
 };
 
+// Emit the canonical final live compute-skip diagnostic through the recompiler's atomic formatter.
+void log_compute_recompile_skip_diagnostic(const RecompileDiagnosticContext& diagnostic);
+
 // A narrowly-proven compiler-generated scalar jump table. The shader loads a uniform selector from a
 // direct constant buffer, bounds it, scales it by the 64-bit table-entry size, loads a PC-relative
 // target, and reaches it with s_setpc_b64. Arbitrary indirect control flow remains unsupported: this

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -291,6 +291,11 @@ struct ShaderResource {
     // levels instead use mip_tail_x/y within each slice base.
     uint32_t      layer_stride_bytes = 0;
     uint32_t      layer_mip_offset_bytes = 0;
+    // Instruction-scoped proof for IMAGE_LOAD_MIP / IMAGE_STORE_MIP. This is compile semantics,
+    // not descriptor metadata: only the exact fetch_pc whose dimension-specific mip VGPR has a
+    // same-block plain-v_mov zero proof may set it. Cache/capture identity must preserve the marker
+    // so a zero-specialized module can never be reused for a dynamic or nonzero mip.
+    bool          proven_zero_mip   = false;
     bool          srgb              = false;              // T# is a gamma-encoded (sRGB) surface — sample with sRGB->linear (#263)
     uint32_t      sampler_sgpr_base = 0xFFFFFFFFu;
 

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -445,6 +445,19 @@ inline bool is_proven_null_bvh(const ShaderResource& resource) {
            resource.host_data_size >= resource.size;
 }
 
+// Exact-PC marker for a fully-known RAW MUBUF descriptor with NUM_RECORDS=0. Such a descriptor has
+// architectural zero-read/drop-write behavior regardless of its base, so it deliberately has no
+// guest or host backing. The unusual Unknown/zero-component shape keeps it distinct from an ordinary
+// explicit null buffer and survives capture/replay without adding a serialized descriptor field.
+inline bool is_zero_record_raw_buffer(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::ConstantBuffer &&
+           resource.format == DataFormat::Unknown && resource.num_components == 0u &&
+           resource.gpu_addr == 0 && resource.size == 0u && resource.stride == 0u &&
+           resource.srt_offset == 0xFFFFFFFFu && resource.sgpr_base == 0xFFFFFFFFu &&
+           resource.fetch_pc != 0xFFFFFFFFu && resource.host_data == nullptr &&
+           resource.host_data_size == 0u;
+}
+
 // The set of resources a shader uses. The front-half builds it from the shader's user_data; the
 // recompiler consults it while translating memory ops and the pipeline binds from it. Pure data.
 struct ShaderResourceTable {

--- a/prosper/tests/compute_runner.h
+++ b/prosper/tests/compute_runner.h
@@ -1,7 +1,7 @@
 // compute_runner.h — inline helper to run a compute SPIR-V module over an input float buffer and
 // return the output float buffer, via real Vulkan compute (2 storage buffers: binding 0 = in,
-// binding 1 = out; local_size_x = 64). Shared by the execution-differential tests so the Vulkan
-// boilerplate lives in one place. Header-only; the including test links Vulkan::Vulkan.
+// binding 1 = out; local_size_x defaults to 64). Shared by the execution-differential tests so the
+// Vulkan boilerplate lives in one place. Header-only; the including test links Vulkan::Vulkan.
 #pragma once
 #include <vulkan/vulkan.h>
 #include <cstdint>
@@ -42,13 +42,15 @@ inline ComputeSubgroupProperties default_compute_subgroup_properties() {
 }
 
 // Run `spirv` over storage buffer 0 = `input`, storage buffer 1 = output. `invocations` compute
-// threads are dispatched (default = input.size()); the output buffer holds `out_count` floats
-// (default = input.size()). Returns the output, or {} on any Vulkan failure (incl. rejected SPIR-V).
+// threads are dispatched (default = input.size()) in groups of `local_size_x` (default 64); the
+// output buffer holds `out_count` floats (default = input.size()). Returns the output, or {} on any
+// Vulkan failure (including rejected SPIR-V).
 inline std::vector<float> run_compute(const std::vector<uint32_t>& spirv, const std::vector<float>& input,
                                       uint32_t invocations = 0, uint32_t out_count = 0,
                                       const std::vector<uint32_t>& cbuf = {},
                                       const std::vector<uint32_t>& cbuf1 = {},
-                                      std::vector<uint32_t>* cbuf1_out = nullptr) {
+                                      std::vector<uint32_t>* cbuf1_out = nullptr,
+                                      uint32_t local_size_x = 64) {
     const uint32_t IN_N = (uint32_t)input.size();
     if (invocations == 0) invocations = IN_N;
     if (out_count == 0)   out_count = IN_N;
@@ -175,7 +177,7 @@ inline std::vector<float> run_compute(const std::vector<uint32_t>& spirv, const 
     vkBeginCommandBuffer(cmd, &cbbi);
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, pipe);
     vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_COMPUTE, layout, 0, 1, &dset, 0, nullptr);
-    vkCmdDispatch(cmd, (invocations + 63) / 64, 1, 1);
+    vkCmdDispatch(cmd, (invocations + local_size_x - 1) / local_size_x, 1, 1);
     vkEndCommandBuffer(cmd);
     VkSubmitInfo si{VK_STRUCTURE_TYPE_SUBMIT_INFO}; si.commandBufferCount = 1; si.pCommandBuffers = &cmd;
     VkFenceCreateInfo fci{VK_STRUCTURE_TYPE_FENCE_CREATE_INFO}; VkFence fence; vkCreateFence(dev, &fci, nullptr, &fence);

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -63,6 +63,17 @@ static_assert(offsetof(Shader, user_data) == 0x08 && offsetof(Shader, code) == 0
               offsetof(Shader, specials) == 0x28 && offsetof(Shader, type) == 0x5a &&
               offsetof(Shader, num_sh_registers) == 0x5c, "test Shader layout must mirror hle_agc");
 
+static void make_test_tsharp(uint32_t t[8], uint64_t base, uint32_t width,
+                             uint32_t height, uint32_t format) {
+    std::memset(t, 0, 8u * sizeof(uint32_t));
+    const uint64_t encoded_base = base >> 8;
+    t[0] = static_cast<uint32_t>(encoded_base);
+    t[1] = static_cast<uint32_t>((encoded_base >> 32) & 0xffu) |
+           ((format & 0x1ffu) << 20) | (((width - 1u) & 0x3u) << 30);
+    t[2] = (((width - 1u) >> 2) & 0xfffu) | (((height - 1u) & 0x3fffu) << 14);
+    t[3] = (9u << 28) | 0xfacu;               // 2D, linear, identity component selection
+}
+
 int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
@@ -311,6 +322,75 @@ int main() {
           pixel_buffer->direct_vsharp_sh_register_base ==
               prosper::gpu::ShaderResource::kDirectVSharpOriginAmbiguous,
           "shader-constructed pixel V# keeps its resource but no fabricated raw SH origin");
+
+    // The instruction proof is not complete until the real graphics resource builder has paired it
+    // with this exact one-level uncompressed descriptor. Exercise build_stage_table itself so
+    // deleting its marker assignment cannot be hidden by helper-only tests.
+    alignas(256) static uint8_t zero_mip_texture_bytes[8192]{};
+    alignas(256) static uint8_t zero_mip_metadata_bytes[256]{};
+    const uint32_t zero_mip_texture_shader[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0043f08u, 0x00050000u,            // IMAGE_LOAD_MIP v[0:3], [v0,v1,v2], s[20:27]
+        0xbf810000u,
+    };
+    Shader zero_mip_pixel{};
+    zero_mip_pixel.file_header = 0x34333231u;
+    zero_mip_pixel.version = 0x18u;
+    zero_mip_pixel.shader_size = sizeof(zero_mip_texture_shader);
+    zero_mip_pixel.type = 1;
+    dst = nullptr;
+    rc = create_shader(reinterpret_cast<uint64_t>(&dst),
+                       reinterpret_cast<uint64_t>(&zero_mip_pixel),
+                       reinterpret_cast<uint64_t>(zero_mip_texture_shader), 0, 0, 0);
+    CHECK(rc == 0 && dst == &zero_mip_pixel,
+          "zero-mip pixel shader enters the AGC registry");
+    prosper::gpu::GpuState zero_mip_pixel_state;
+    constexpr uint32_t kZeroMipPsUser = prosper::agc::Pm4::SPI_SHADER_USER_DATA_PS_0;
+    uint32_t zero_mip_tsharp[8];
+    make_test_tsharp(zero_mip_tsharp,
+                     reinterpret_cast<uint64_t>(zero_mip_texture_bytes),
+                     4, 4, 60);               // Uint8x4, one declared level
+    zero_mip_pixel_state.sh[kZeroMipPsUser + 7] = 0;
+    for (uint32_t i = 0; i < 8; ++i)
+        zero_mip_pixel_state.sh[kZeroMipPsUser + 20 + i] = zero_mip_tsharp[i];
+    auto realized_zero_mip_pixel = prosper::gpu::build_stage_table(
+        zero_mip_pixel_state, reinterpret_cast<uint64_t>(zero_mip_texture_shader), true, 3);
+    const prosper::gpu::ShaderResource* realized_zero_mip_texture =
+        realized_zero_mip_pixel ? realized_zero_mip_pixel->by_fetch_pc(1) : nullptr;
+    CHECK(realized_zero_mip_texture && realized_zero_mip_texture->proven_zero_mip &&
+              realized_zero_mip_texture->declared_mip_levels == 1 &&
+              !realized_zero_mip_texture->compression_enabled,
+          "build_stage_table materializes the exact safe zero-mip proof on its texture");
+
+    prosper::gpu::GpuState multilevel_zero_mip_pixel_state = zero_mip_pixel_state;
+    multilevel_zero_mip_pixel_state.sh[kZeroMipPsUser + 23] |= 1u << 16;
+    multilevel_zero_mip_pixel_state.sh[kZeroMipPsUser + 25] |= 1u << 4;
+    auto realized_multilevel_zero_mip = prosper::gpu::build_stage_table(
+        multilevel_zero_mip_pixel_state,
+        reinterpret_cast<uint64_t>(zero_mip_texture_shader), true, 3);
+    const prosper::gpu::ShaderResource* multilevel_zero_mip_texture =
+        realized_multilevel_zero_mip
+            ? realized_multilevel_zero_mip->by_fetch_pc(1) : nullptr;
+    CHECK(multilevel_zero_mip_texture &&
+              multilevel_zero_mip_texture->declared_mip_levels == 2 &&
+              !multilevel_zero_mip_texture->proven_zero_mip,
+          "build_stage_table leaves a multilevel IMAGE_LOAD_MIP resource unspecialized");
+
+    prosper::gpu::GpuState dcc_zero_mip_pixel_state = zero_mip_pixel_state;
+    const uint64_t metadata_field =
+        reinterpret_cast<uint64_t>(zero_mip_metadata_bytes) >> 8;
+    dcc_zero_mip_pixel_state.sh[kZeroMipPsUser + 26] =
+        0x00280000u | (static_cast<uint32_t>(metadata_field) << 24);
+    dcc_zero_mip_pixel_state.sh[kZeroMipPsUser + 27] =
+        static_cast<uint32_t>(metadata_field >> 8);
+    auto realized_dcc_zero_mip = prosper::gpu::build_stage_table(
+        dcc_zero_mip_pixel_state,
+        reinterpret_cast<uint64_t>(zero_mip_texture_shader), true, 3);
+    const prosper::gpu::ShaderResource* dcc_zero_mip_texture =
+        realized_dcc_zero_mip ? realized_dcc_zero_mip->by_fetch_pc(1) : nullptr;
+    CHECK(dcc_zero_mip_texture && dcc_zero_mip_texture->compression_enabled &&
+              !dcc_zero_mip_texture->proven_zero_mip,
+          "build_stage_table leaves DCC-backed IMAGE_LOAD_MIP fail-visible");
 
     const uint32_t direct_seed_fetch[] = {
         0xE0002000u, 0x80020100u,   // pc=0: buffer_load_format_x v1, v0, s[8:11], 0 idxen

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2270,6 +2270,139 @@ int main() {
                              &atomic_table, atomic_config).empty(),
           "#636: production resource table keeps stride-zero supported atomic realizable");
 
+    // GTA V reaches the emitter with buffer_atomic_add/or packets whose descriptors are fully
+    // recoverable, but resource discovery historically recognized only atomic_umax. Keep the
+    // producer's accepted set in lock-step with the emitter's exact supported 32-bit RMW set. The
+    // two full packets below are the game's terminal encodings; using their real SRSRC positions
+    // also proves that the result is exact-PC provenance rather than the direct-SGPR fallback.
+    uint32_t exact_add_seed[8] = {};
+    std::copy(std::begin(atomic_seed), std::end(atomic_seed), exact_add_seed + 4);
+    const uint32_t gta_atomic_add[] = {
+        0xE0C84000u, 0x80010200u, // buffer_atomic_add v2, v0, s[4:7], 0 glc
+        0xBF810000u,
+    };
+    std::vector<SrtUse> gta_add_uses;
+    resolve_dynamic_fetch(gta_atomic_add, std::size(gta_atomic_add), exact_add_seed,
+                          std::size(exact_add_seed), 0, &gta_add_uses);
+    ShaderResourceTable gta_add_table;
+    add_compute_buffer_resources(gta_add_table, gta_atomic_add, std::size(gta_atomic_add),
+                                 exact_add_seed, std::size(exact_add_seed));
+    assign_convention_bindings(gta_add_table, 2);
+    ComputeShaderConfig gta_add_config;
+    gta_add_config.user_sgprs.assign(std::begin(exact_add_seed), std::end(exact_add_seed));
+    gta_add_config.local_x = gta_add_config.local_y = gta_add_config.local_z = 1;
+    CHECK(gta_add_uses.size() == 1 && gta_add_uses[0].use_pc == 0 &&
+              gta_add_table.resources.size() == 1 &&
+              gta_add_table.resources[0].fetch_pc == 0 &&
+              !recompile_compute(gta_atomic_add, std::size(gta_atomic_add),
+                                 &gta_add_table, gta_add_config).empty(),
+          "GTA V exact buffer_atomic_add publishes and consumes its exact-PC resource");
+
+    uint32_t exact_or_seed[36] = {};
+    std::copy(std::begin(atomic_seed), std::end(atomic_seed), exact_or_seed + 32);
+    const uint32_t gta_atomic_or[] = {
+        0xE0E82000u, 0x80080200u, // buffer_atomic_or v2, v0, s[32:35], 0
+        0xBF810000u,
+    };
+    std::vector<SrtUse> gta_or_uses;
+    resolve_dynamic_fetch(gta_atomic_or, std::size(gta_atomic_or), exact_or_seed,
+                          std::size(exact_or_seed), 0, &gta_or_uses);
+    ShaderResourceTable gta_or_table;
+    add_compute_buffer_resources(gta_or_table, gta_atomic_or, std::size(gta_atomic_or),
+                                 exact_or_seed, std::size(exact_or_seed));
+    assign_convention_bindings(gta_or_table, 2);
+    ComputeShaderConfig gta_or_config;
+    gta_or_config.user_sgprs.assign(std::begin(exact_or_seed), std::end(exact_or_seed));
+    gta_or_config.local_x = gta_or_config.local_y = gta_or_config.local_z = 1;
+    CHECK(gta_or_uses.size() == 1 && gta_or_uses[0].use_pc == 0 &&
+              gta_or_table.resources.size() == 1 &&
+              gta_or_table.resources[0].fetch_pc == 0 &&
+              !recompile_compute(gta_atomic_or, std::size(gta_atomic_or),
+                                 &gta_or_table, gta_or_config).empty(),
+          "GTA V exact buffer_atomic_or publishes and consumes its exact-PC resource");
+
+    const uint32_t supported_atomic_dw0[] = {
+        0xE0C00000u, // swap
+        0xE0C80000u, // add
+        0xE0CC0000u, // sub
+        0xE0D40000u, // smin
+        0xE0D80000u, // umin
+        0xE0DC0000u, // smax
+        0xE0E00000u, // umax
+        0xE0E40000u, // and
+        0xE0E80000u, // or
+        0xE0EC0000u, // xor
+    };
+    uint32_t supported_atomic_uses = 0;
+    for (uint32_t dw0 : supported_atomic_dw0) {
+        const uint32_t code[] = { dw0, 0x80000000u, 0xBF810000u };
+        std::vector<SrtUse> uses;
+        resolve_dynamic_fetch(code, std::size(code), atomic_seed, std::size(atomic_seed), 0,
+                              &uses);
+        supported_atomic_uses += uses.size() == 1 && uses[0].use_pc == 0;
+    }
+    CHECK(supported_atomic_uses == std::size(supported_atomic_dw0),
+          "resource discovery admits exactly every emitter-supported 32-bit MUBUF RMW opcode");
+
+    const uint32_t unknown_atomic_descriptor[] = {
+        0xBE801F00u,              // s_getpc_b64 s[0:1]: not a concrete entry V# anymore
+        0xE0C80000u, 0x80000000u, // buffer_atomic_add v0, v0, s[0:3]
+        0xBF810000u,
+    };
+    std::vector<SrtUse> unknown_atomic_uses;
+    resolve_dynamic_fetch(unknown_atomic_descriptor, std::size(unknown_atomic_descriptor),
+                          atomic_seed, std::size(atomic_seed), 0, &unknown_atomic_uses);
+    const uint32_t direct_atomic_add[] = {
+        0xE0C80000u, 0x80000000u, // buffer_atomic_add v0, v0, s[0:3]
+        0xBF810000u,
+    };
+    uint32_t oversized_atomic_seed[4];
+    std::copy(std::begin(atomic_seed), std::end(atomic_seed), oversized_atomic_seed);
+    oversized_atomic_seed[2] = 0x10000001u; // stride zero: NUM_RECORDS is the byte size
+    std::vector<SrtUse> oversized_atomic_uses;
+    resolve_dynamic_fetch(direct_atomic_add, std::size(direct_atomic_add),
+                          oversized_atomic_seed, std::size(oversized_atomic_seed), 0,
+                          &oversized_atomic_uses);
+    uint32_t empty_atomic_seed[4];
+    std::copy(std::begin(atomic_seed), std::end(atomic_seed), empty_atomic_seed);
+    empty_atomic_seed[2] = 0;
+    std::vector<SrtUse> empty_atomic_uses;
+    resolve_dynamic_fetch(direct_atomic_add, std::size(direct_atomic_add), empty_atomic_seed,
+                          std::size(empty_atomic_seed), 0, &empty_atomic_uses);
+    CHECK(unknown_atomic_uses.empty() && oversized_atomic_uses.empty() &&
+              empty_atomic_uses.empty(),
+          "supported atomics still require a fully-known bounded nonempty live V#");
+
+    // These encodings need distinct operands or semantics. In particular op 0x50 is GTA V's
+    // buffer_atomic_swap_x2, not a 32-bit atomic with a neighboring opcode. They must not acquire a
+    // resource merely because their descriptor is concrete; both discovery and emission stay loud.
+    const uint32_t unsupported_atomic_dw0[] = {
+        0xE0C40000u, // cmp-swap
+        0xE0D00000u, // csub
+        0xE0F00000u, // inc
+        0xE0F40000u, // dec
+        0xE1402000u, // swap_x2, exact GTA V dword 0
+    };
+    uint32_t unsupported_atomic_uses = 0;
+    uint32_t unsupported_atomic_resources = 0;
+    uint32_t unsupported_atomic_recompiles = 0;
+    for (uint32_t dw0 : unsupported_atomic_dw0) {
+        const uint32_t code[] = { dw0, 0x80000000u, 0xBF810000u };
+        std::vector<SrtUse> uses;
+        resolve_dynamic_fetch(code, std::size(code), atomic_seed, std::size(atomic_seed), 0,
+                              &uses);
+        unsupported_atomic_uses += !uses.empty();
+        ShaderResourceTable table;
+        add_compute_buffer_resources(table, code, std::size(code), atomic_seed,
+                                     std::size(atomic_seed));
+        unsupported_atomic_resources += !table.resources.empty();
+        unsupported_atomic_recompiles +=
+            !recompile_compute(code, std::size(code), &table, atomic_config).empty();
+    }
+    CHECK(unsupported_atomic_uses == 0 && unsupported_atomic_resources == 0 &&
+              unsupported_atomic_recompiles == 0,
+          "unsupported cmp-swap/csub/inc/dec/x2 MUBUF atomics remain fail-closed");
+
     // Terminator 2D supplies descriptor dwords separately, then reassembles its destination V# in
     // s[0:3] with four scalar moves immediately before format stores. This has no SRT-load tag and
     // the destination range no longer equals its entry user data, but the four consecutive seed

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1492,6 +1492,203 @@ int main() {
               atomic_add_uses[0].t8 == expected_atomic_t8,
           "image_atomic_add publishes the live direct T# as a storage-image use");
 
+    // GTA V's gameplay compute programs supply IMAGE_LOAD_MIP's final address VGPR and
+    // IMAGE_STORE_MIP's NSA mip VGPR with a plain move from a zero wave-uniform SGPR. The proof is
+    // instruction-scoped: changing that exact reaching definition, its scalar value, or its basic
+    // block must clear the marker while retaining the ordinary image use for fail-visible lowering.
+    uint32_t zero_mip_seed[28]{};
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed), zero_mip_seed + 20);
+    const uint32_t gta_load_mip_2d[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7 (known zero)
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP 2D [v0,v1,v2], s[20:27]
+        0xbf810000u,
+    };
+    std::vector<SrtUse> zero_mip_load_uses;
+    resolve_dynamic_fetch(gta_load_mip_2d, std::size(gta_load_mip_2d),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &zero_mip_load_uses);
+    CHECK(zero_mip_load_uses.size() == 1 && !zero_mip_load_uses[0].is_storage_image &&
+              zero_mip_load_uses[0].use_pc == 1 && zero_mip_load_uses[0].proven_zero_mip,
+          "GTA V IMAGE_LOAD_MIP 2D carries its same-block v2=zero proof");
+
+    const uint32_t gta_load_mip_2da[] = {
+        0x7e060206u,                         // v_mov_b32 v3, s6 (known zero; v2 is slice)
+        0xf0043128u, 0x00050000u,            // IMAGE_LOAD_MIP 2D_ARRAY [v0,v1,v2,v3]
+        0xbf810000u,
+    };
+    std::vector<SrtUse> zero_mip_array_uses;
+    resolve_dynamic_fetch(gta_load_mip_2da, std::size(gta_load_mip_2da),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &zero_mip_array_uses);
+    CHECK(zero_mip_array_uses.size() == 1 && zero_mip_array_uses[0].proven_zero_mip,
+          "GTA V IMAGE_LOAD_MIP 2D_ARRAY proves v3 without consuming the v2 slice");
+
+    uint32_t nonzero_mip_seed[28]{};
+    std::copy(std::begin(zero_mip_seed), std::end(zero_mip_seed), nonzero_mip_seed);
+    nonzero_mip_seed[7] = 1u;
+    std::vector<SrtUse> nonzero_mip_uses;
+    resolve_dynamic_fetch(gta_load_mip_2d, std::size(gta_load_mip_2d),
+                          nonzero_mip_seed, std::size(nonzero_mip_seed), 0,
+                          &nonzero_mip_uses);
+    CHECK(nonzero_mip_uses.size() == 1 && !nonzero_mip_uses[0].proven_zero_mip,
+          "nonzero wave-uniform mip remains an image use but receives no specialization marker");
+
+    std::array<uint32_t, std::size(gta_load_mip_2d)> changed_mip_writer{};
+    std::copy(std::begin(gta_load_mip_2d), std::end(gta_load_mip_2d),
+              changed_mip_writer.begin());
+    changed_mip_writer[0] = 0x7e060207u;     // same site now writes v3, not the consumed v2
+    clear_shader_decode_cache();
+    std::vector<SrtUse> changed_mip_writer_uses;
+    resolve_dynamic_fetch(changed_mip_writer.data(), changed_mip_writer.size(),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &changed_mip_writer_uses);
+    CHECK(changed_mip_writer_uses.size() == 1 &&
+              !changed_mip_writer_uses[0].proven_zero_mip,
+          "same-site v_mov destination mutation removes the IMAGE_LOAD_MIP proof");
+
+    const uint32_t branched_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xbf820000u,                         // s_branch to the immediately following new block
+        0xf0043108u, 0x00050000u,
+        0xbf810000u,
+    };
+    std::vector<SrtUse> branched_zero_mip_uses;
+    resolve_dynamic_fetch(branched_zero_mip, std::size(branched_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &branched_zero_mip_uses);
+    CHECK(branched_zero_mip_uses.size() == 1 &&
+              !branched_zero_mip_uses[0].proven_zero_mip,
+          "a control-flow boundary prevents a stale zero-mip reaching-definition proof");
+
+    const uint32_t dropped_block_start_zero_mip[] = {
+        0x7e040207u,                         // pc0: v_mov_b32 v2, s7
+        0xbf820000u,                         // pc1: s_branch pc2
+        0xf80000cfu, 0x00000000u,            // pc2: exp (omitted from the compact fold stream)
+        0xf0043108u, 0x00050000u,            // pc4: IMAGE_LOAD_MIP
+        0xbf810000u,
+    };
+    std::vector<SrtUse> dropped_block_start_uses;
+    resolve_dynamic_fetch(dropped_block_start_zero_mip,
+                          std::size(dropped_block_start_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &dropped_block_start_uses);
+    CHECK(dropped_block_start_uses.size() == 1 &&
+              !dropped_block_start_uses[0].proven_zero_mip,
+          "a compacted-out first instruction still starts a new zero-mip proof block");
+
+    const uint32_t exec_changed_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0x7da40100u,                         // v_cmpx_eq_u32 v0,v0 (implicit EXEC write)
+        0xf0043108u, 0x00050000u,
+        0xbf810000u,
+    };
+    std::vector<SrtUse> exec_changed_zero_mip_uses;
+    resolve_dynamic_fetch(exec_changed_zero_mip, std::size(exec_changed_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &exec_changed_zero_mip_uses);
+    CHECK(exec_changed_zero_mip_uses.size() == 1 &&
+              !exec_changed_zero_mip_uses[0].proven_zero_mip,
+          "an otherwise-compacted v_cmpx invalidates the predicated all-lanes zero proof");
+
+    const uint32_t predicated_zero_move[] = {
+        0x7da40100u,                         // v_cmpx_eq_u32 v0,v0 (EXEC is now untracked)
+        0x7e040207u,                         // predicated v_mov_b32 v2, s7
+        0xf0043108u, 0x00050000u,
+        0xbf810000u,
+    };
+    std::vector<SrtUse> predicated_zero_move_uses;
+    resolve_dynamic_fetch(predicated_zero_move, std::size(predicated_zero_move),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &predicated_zero_move_uses);
+    CHECK(predicated_zero_move_uses.size() == 1 &&
+              !predicated_zero_move_uses[0].proven_zero_mip,
+          "a v_mov after an untracked EXEC mutation cannot manufacture an all-lanes zero proof");
+
+    const uint32_t valu_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0x4a040300u,                         // v_add_nc_u32 v2, v0, v1 (compacted without retention)
+        0xf0043108u, 0x00050000u,
+        0xbf810000u,
+    };
+    std::vector<SrtUse> valu_overwrites_zero_mip_uses;
+    resolve_dynamic_fetch(valu_overwrites_zero_mip, std::size(valu_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &valu_overwrites_zero_mip_uses);
+    CHECK(valu_overwrites_zero_mip_uses.size() == 1 &&
+              !valu_overwrites_zero_mip_uses[0].proven_zero_mip,
+          "an otherwise-compacted overlapping VALU writer kills the retained zero proof");
+
+    const uint32_t mimg_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0003108u, 0x00050200u,            // IMAGE_LOAD v2, [v0,v1], s[20:27]
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes the overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> mimg_overwrites_zero_mip_uses;
+    resolve_dynamic_fetch(mimg_overwrites_zero_mip, std::size(mimg_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &mimg_overwrites_zero_mip_uses);
+    const auto overwritten_mip_use = std::find_if(
+        mimg_overwrites_zero_mip_uses.begin(), mimg_overwrites_zero_mip_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(overwritten_mip_use != mimg_overwrites_zero_mip_uses.end() &&
+              !overwritten_mip_use->proven_zero_mip,
+          "an intervening MIMG VDATA write kills the zero proof at the later mip use");
+
+    uint32_t zero_store_mip_seed[20]{};
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed),
+              zero_store_mip_seed + 12);
+    const uint32_t gta_store_mip_2d[] = {
+        0x7e0a0206u,                         // v_mov_b32 v5, s6 (known zero)
+        0xf024310au, 0x00030004u, 0x00000503u, // IMAGE_STORE_MIP v4,[v0,v3,v5],s[12:19]
+        0xbf810000u,
+    };
+    std::vector<SrtUse> zero_store_mip_uses;
+    resolve_dynamic_fetch(gta_store_mip_2d, std::size(gta_store_mip_2d),
+                          zero_store_mip_seed, std::size(zero_store_mip_seed), 0,
+                          &zero_store_mip_uses);
+    CHECK(zero_store_mip_uses.size() == 1 && zero_store_mip_uses[0].is_storage_image &&
+              zero_store_mip_uses[0].use_pc == 1 &&
+              zero_store_mip_uses[0].proven_zero_mip,
+          "GTA V IMAGE_STORE_MIP is classified as storage and carries its v5=zero proof");
+
+    const uint32_t gta_store_mip_xyzw_2d[] = {
+        0x7e0c0206u,                         // v_mov_b32 v6, s6 (known zero)
+        0xf0243f0au, 0x00030005u, 0x00000604u,
+        0xbf810000u,
+    };
+    std::vector<SrtUse> zero_store_mip_xyzw_uses;
+    resolve_dynamic_fetch(gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d),
+                          zero_store_mip_seed, std::size(zero_store_mip_seed), 0,
+                          &zero_store_mip_xyzw_uses);
+    CHECK(zero_store_mip_xyzw_uses.size() == 1 &&
+              zero_store_mip_xyzw_uses[0].is_storage_image &&
+              zero_store_mip_xyzw_uses[0].proven_zero_mip,
+          "GTA V 0x2042f49800 dmask-xyzw IMAGE_STORE_MIP carries its exact v6 proof");
+
+    Gen5ImageFormatInfo zero_mip_format{};
+    const DecodedImageDescriptor zero_mip_descriptor =
+        decode_image_descriptor(atomic_image_seed);
+    CHECK(gen5_image_format(zero_mip_descriptor.format, &zero_mip_format),
+          "zero-mip materialization fixture uses a mapped image format");
+    const DecodedImageView zero_mip_view =
+        image_base_level_view(zero_mip_descriptor, zero_mip_format);
+    const SrtUse materialized_zero_mip_use = zero_mip_load_uses.empty()
+        ? SrtUse{} : zero_mip_load_uses[0];
+    CHECK(shader_resource_allows_zero_mip_specialization(
+              materialized_zero_mip_use, zero_mip_descriptor, zero_mip_view),
+          "single-level uncompressed T# admits the proven IMAGE_LOAD_MIP use at materialization");
+    uint32_t dcc_zero_mip_t8[8]{};
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed), dcc_zero_mip_t8);
+    dcc_zero_mip_t8[6] = 0x00280000u;       // live 0x2042f49a DCC/pipe-aligned control shape
+    dcc_zero_mip_t8[7] = 0x20553100u;       // nonzero metadata address payload
+    const DecodedImageDescriptor dcc_zero_mip_descriptor =
+        decode_image_descriptor(dcc_zero_mip_t8);
+    CHECK(dcc_zero_mip_descriptor.compression_enabled &&
+              !shader_resource_allows_zero_mip_specialization(
+                  materialized_zero_mip_use, dcc_zero_mip_descriptor, zero_mip_view),
+          "GTA V's DCC-backed IMAGE_LOAD_MIP remains fail-visible at materialization");
+
     // The same live Astro visibility kernel assembles a sampled T# in s[44:51] from four
     // consecutive entry-user-data pairs before image_load. Preserve both lanes of s_mov_b64 and
     // accept the reassembled descriptor only while all eight entry origins remain consecutive.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1739,6 +1739,71 @@ int main() {
           direct_v_uses[0].v4[1] == seed5v[1] && direct_v_uses[0].v4[2] == seed5v[2],
           "direct raw-MUBUF V# preserves base/stride/record dwords");
 
+    // GTA V publishes fully-known RAW V#s whose NUM_RECORDS is zero at gameplay entry. These are
+    // architectural zero-read/drop-write resources, not scalar raw pointers: retain one explicit
+    // exact-PC marker for each consumer so the recompiler can lower both sides without a backing
+    // buffer. The captured descriptor shape retains stride/format metadata despite its empty range.
+    const uint32_t zero_record_raw[] = {
+        0xE0300000u, 0x80000000u, // buffer_load_dword v0, off, s[0:3]
+        0xE0700000u, 0x80000100u, // buffer_store_dword v1, off, s[0:3]
+        0xBF810000u,
+    };
+    const uint32_t zero_record_seed[4] = {
+        0x00000000u, 0x00100000u, 0x00000000u, 0x00016204u,
+    };
+    std::vector<SrtUse> zero_record_uses;
+    resolve_dynamic_fetch(zero_record_raw, std::size(zero_record_raw), zero_record_seed,
+                          std::size(zero_record_seed), 0, &zero_record_uses);
+    CHECK(zero_record_uses.size() == 2 && zero_record_uses[0].zero_record_raw &&
+              zero_record_uses[1].zero_record_raw && zero_record_uses[0].use_pc == 0 &&
+              zero_record_uses[1].use_pc == 2 &&
+              decode_buffer_descriptor(zero_record_uses[0].v4.data()).num_records == 0,
+          "fully-known zero-record RAW loads/stores retain exact-PC zero semantics");
+    ShaderResourceTable zero_record_table;
+    const std::vector<SrtUse> materialized_zero_uses = add_compute_buffer_resources(
+        zero_record_table, zero_record_raw, std::size(zero_record_raw), zero_record_seed,
+        std::size(zero_record_seed));
+    assign_convention_bindings(zero_record_table, 2);
+    CHECK(materialized_zero_uses.size() == 2 && zero_record_table.resources.size() == 2 &&
+              is_zero_record_raw_buffer(zero_record_table.resources[0]) &&
+              is_zero_record_raw_buffer(zero_record_table.resources[1]) &&
+              zero_record_table.by_fetch_pc(0) && zero_record_table.by_fetch_pc(2) &&
+              zero_record_table.resources[0].binding == 2 &&
+              zero_record_table.resources[1].binding == 3,
+          "production compute materialization creates distinct zero-record RAW markers");
+    ComputeShaderConfig zero_record_config;
+    zero_record_config.user_sgprs.assign(zero_record_seed,
+                                         zero_record_seed + std::size(zero_record_seed));
+    zero_record_config.local_x = zero_record_config.local_y = zero_record_config.local_z = 1;
+    CHECK(!recompile_compute(zero_record_raw, std::size(zero_record_raw), &zero_record_table,
+                             zero_record_config).empty(),
+          "production zero-record resource table reaches compute translation");
+
+    const uint32_t all_zero_raw_seed[4] = {};
+    std::vector<SrtUse> all_zero_raw_uses;
+    resolve_dynamic_fetch(zero_record_raw, std::size(zero_record_raw), all_zero_raw_seed,
+                          std::size(all_zero_raw_seed), 0, &all_zero_raw_uses);
+    CHECK(all_zero_raw_uses.size() == 2 && all_zero_raw_uses[0].zero_record_raw &&
+              all_zero_raw_uses[1].zero_record_raw,
+          "all-zero unbound RAW V# uses the same exact zero-record contract");
+
+    // The admitted boundary is NUM_RECORDS=0, not merely Base=0. A descriptor with the same zero
+    // address but one 16-byte record remains malformed and must not inherit zero semantics.
+    uint32_t addr0_nonzero_record_seed[4];
+    std::copy(std::begin(zero_record_seed), std::end(zero_record_seed),
+              addr0_nonzero_record_seed);
+    addr0_nonzero_record_seed[2] = 1u;
+    std::vector<SrtUse> addr0_nonzero_record_uses;
+    resolve_dynamic_fetch(zero_record_raw, std::size(zero_record_raw),
+                          addr0_nonzero_record_seed, std::size(addr0_nonzero_record_seed), 0,
+                          &addr0_nonzero_record_uses);
+    ShaderResourceTable addr0_nonzero_record_table;
+    add_compute_buffer_resources(addr0_nonzero_record_table, zero_record_raw,
+                                 std::size(zero_record_raw), addr0_nonzero_record_seed,
+                                 std::size(addr0_nonzero_record_seed));
+    CHECK(addr0_nonzero_record_uses.empty() && addr0_nonzero_record_table.resources.empty(),
+          "addr0 plus nonzero NUM_RECORDS stays rejected at the zero-record boundary");
+
     // Astro Bot's 7f5f world-map NGG shader patches only NUM_RECORDS in its direct s[16:19] V#
     // (`s_mov_b32 s18, 1`) before a raw buffer_load_dwordx4 at pc2761. The consumer is itself the
     // architectural descriptor proof; requiring the four words to retain pristine entry-seed

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1511,6 +1511,51 @@ int main() {
               zero_mip_load_uses[0].use_pc == 1 && zero_mip_load_uses[0].proven_zero_mip,
           "GTA V IMAGE_LOAD_MIP 2D carries its same-block v2=zero proof");
 
+    // Exact 0x2042f49200 gameplay program. The pc10 VOP2 writes only v0: it must not erase the
+    // independent v2=zero definition at pc5 before IMAGE_LOAD_MIP at pc14. The later pc12 v5=zero
+    // definition similarly reaches the exact IMAGE_STORE_MIP packet at pc17.
+    alignas(16) uint32_t live_zero_mip_table[16]{};
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed),
+              std::begin(live_zero_mip_table));
+    uint32_t live_zero_mip_seed[28]{};
+    const uint64_t live_zero_mip_table_address =
+        reinterpret_cast<uint64_t>(live_zero_mip_table);
+    live_zero_mip_seed[0] = static_cast<uint32_t>(live_zero_mip_table_address);
+    live_zero_mip_seed[1] = static_cast<uint32_t>(live_zero_mip_table_address >> 32);
+    std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed),
+              live_zero_mip_seed + 20);
+    const uint32_t gta_live_load_store_mip[] = {
+        0xbfa00001u,
+        0xd7460004u, 0x04010a08u,
+        0x4a020af9u, 0x86860609u,
+        0x7e040207u,                         // pc5: v_mov_b32 v2, s7 (known zero)
+        0xf4100300u, 0xfa000000u,
+        0x4a0606f9u, 0x86860609u,
+        0x4a000804u,                         // pc10: v_add_nc_u32 v0, s4, v4
+        0x4a080802u,
+        0x7e0a0206u,                         // pc12: v_mov_b32 v5, s6 (known zero)
+        0xbf8cc07fu,
+        0xf0043108u, 0x00050000u,            // pc14: IMAGE_LOAD_MIP, mip=v2
+        0xbf8c3f70u,
+        0xf024310au, 0x00030004u, 0x00000503u, // pc17: IMAGE_STORE_MIP, mip=v5
+        0xbf810000u,
+    };
+    std::vector<SrtUse> gta_live_zero_mip_uses;
+    resolve_dynamic_fetch(gta_live_load_store_mip, std::size(gta_live_load_store_mip),
+                          live_zero_mip_seed, std::size(live_zero_mip_seed), 0,
+                          &gta_live_zero_mip_uses);
+    const auto live_load_mip = std::find_if(
+        gta_live_zero_mip_uses.begin(), gta_live_zero_mip_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 14u; });
+    const auto live_store_mip = std::find_if(
+        gta_live_zero_mip_uses.begin(), gta_live_zero_mip_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 17u; });
+    CHECK(live_load_mip != gta_live_zero_mip_uses.end() &&
+              !live_load_mip->is_storage_image && live_load_mip->proven_zero_mip &&
+              live_store_mip != gta_live_zero_mip_uses.end() &&
+              live_store_mip->is_storage_image && live_store_mip->proven_zero_mip,
+          "GTA V's exact pc5/pc10/pc14 load and pc12/pc17 store retain both zero-mip proofs");
+
     const uint32_t gta_load_mip_2da[] = {
         0x7e060206u,                         // v_mov_b32 v3, s6 (known zero; v2 is slice)
         0xf0043128u, 0x00050000u,            // IMAGE_LOAD_MIP 2D_ARRAY [v0,v1,v2,v3]
@@ -1635,6 +1680,97 @@ int main() {
               !overwritten_mip_use->proven_zero_mip,
           "an intervening MIMG VDATA write kills the zero proof at the later mip use");
 
+    const uint32_t wide_mimg_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0003f08u, 0x00050000u,            // IMAGE_LOAD dmask:xyzw writes v[0:3]
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> wide_mimg_overwrite_uses;
+    resolve_dynamic_fetch(wide_mimg_overwrites_zero_mip,
+                          std::size(wide_mimg_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &wide_mimg_overwrite_uses);
+    const auto wide_mimg_mip_use = std::find_if(
+        wide_mimg_overwrite_uses.begin(), wide_mimg_overwrite_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(wide_mimg_mip_use != wide_mimg_overwrite_uses.end() &&
+              !wide_mimg_mip_use->proven_zero_mip,
+          "an overlapping four-register MIMG result kills every covered zero-mip proof");
+
+    const uint32_t wide_valu_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xd5761e01u, 0x040a0100u,            // v_mad_u64_u32 writes v[1:2]
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> wide_valu_overwrite_uses;
+    resolve_dynamic_fetch(wide_valu_overwrites_zero_mip,
+                          std::size(wide_valu_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &wide_valu_overwrite_uses);
+    const auto wide_valu_mip_use = std::find_if(
+        wide_valu_overwrite_uses.begin(), wide_valu_overwrite_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(wide_valu_mip_use != wide_valu_overwrite_uses.end() &&
+              !wide_valu_mip_use->proven_zero_mip,
+          "an overlapping two-register VOP3 result kills the covered zero-mip proof");
+
+    const uint32_t movreld_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xbefc0382u,                         // s_mov_b32 m0, 2
+        0x7e008500u,                         // v_movreld_b32 v0, v0 writes dynamic v2
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> movreld_overwrite_uses;
+    resolve_dynamic_fetch(movreld_overwrites_zero_mip,
+                          std::size(movreld_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &movreld_overwrite_uses);
+    const auto movreld_mip_use = std::find_if(
+        movreld_overwrite_uses.begin(), movreld_overwrite_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(movreld_mip_use != movreld_overwrite_uses.end() &&
+              !movreld_mip_use->proven_zero_mip,
+          "an M0-relative dynamic VGPR destination kills every zero-mip proof");
+
+    const uint32_t mimg_tfe_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0010308u, 0x00050000u,            // IMAGE_LOAD TFE dmask:xy writes data v[0:1], status v2
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> mimg_tfe_overwrite_uses;
+    resolve_dynamic_fetch(mimg_tfe_overwrites_zero_mip,
+                          std::size(mimg_tfe_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &mimg_tfe_overwrite_uses);
+    const auto mimg_tfe_mip_use = std::find_if(
+        mimg_tfe_overwrite_uses.begin(), mimg_tfe_overwrite_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(mimg_tfe_mip_use != mimg_tfe_overwrite_uses.end() &&
+              !mimg_tfe_mip_use->proven_zero_mip,
+          "a MIMG TFE status destination kills the adjacent zero-mip proof");
+
+    const uint32_t mimg_store_tfe_overwrites_zero_mip[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0210308u, 0x00050000u,            // IMAGE_STORE TFE dmask:xy reads v[0:1], writes status v2
+        0xf0043108u, 0x00050000u,            // IMAGE_LOAD_MIP consumes overwritten v2
+        0xbf810000u,
+    };
+    std::vector<SrtUse> mimg_store_tfe_overwrite_uses;
+    resolve_dynamic_fetch(mimg_store_tfe_overwrites_zero_mip,
+                          std::size(mimg_store_tfe_overwrites_zero_mip),
+                          zero_mip_seed, std::size(zero_mip_seed), 0,
+                          &mimg_store_tfe_overwrite_uses);
+    const auto mimg_store_tfe_mip_use = std::find_if(
+        mimg_store_tfe_overwrite_uses.begin(), mimg_store_tfe_overwrite_uses.end(),
+        [](const SrtUse& use) { return use.use_pc == 3u; });
+    CHECK(mimg_store_tfe_mip_use != mimg_store_tfe_overwrite_uses.end() &&
+              !mimg_store_tfe_mip_use->proven_zero_mip,
+          "a MIMG store TFE status destination kills the adjacent zero-mip proof");
+
     uint32_t zero_store_mip_seed[20]{};
     std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed),
               zero_store_mip_seed + 12);
@@ -1678,6 +1814,39 @@ int main() {
     CHECK(shader_resource_allows_zero_mip_specialization(
               materialized_zero_mip_use, zero_mip_descriptor, zero_mip_view),
           "single-level uncompressed T# admits the proven IMAGE_LOAD_MIP use at materialization");
+    // Audit the second live 64x64 mip0:0 descriptor rather than assuming that a tail-sized surface
+    // is a packed-tail view. MAX_MIP=0 means there are no sibling levels sharing the first 4 KiB
+    // block, so the layout correctly treats level zero as a standalone tiled surface. This does not
+    // weaken the real packed-tail gate: the synthetic packed-view arm below remains rejected.
+    const uint32_t live_tail_zero_mip_t8[8] = {
+        0x1095c880u, 0xc3c00000u, 0x000fc00fu, 0x90500f2eu,
+        0x00000000u, 0x00700000u, 0x00000000u, 0x00000000u,
+    };
+    const DecodedImageDescriptor live_tail_zero_mip_descriptor =
+        decode_image_descriptor(live_tail_zero_mip_t8);
+    Gen5ImageFormatInfo live_tail_zero_mip_format{};
+    CHECK(gen5_image_format(live_tail_zero_mip_descriptor.format,
+                            &live_tail_zero_mip_format),
+          "live 64x64 zero-mip tail descriptor uses a mapped image format");
+    const DecodedImageView live_tail_zero_mip_view = image_base_level_view(
+        live_tail_zero_mip_descriptor, live_tail_zero_mip_format);
+    CHECK(live_tail_zero_mip_descriptor.width == 64u &&
+              live_tail_zero_mip_descriptor.height == 64u &&
+              live_tail_zero_mip_descriptor.base_level == 0u &&
+              live_tail_zero_mip_descriptor.last_level == 0u &&
+              live_tail_zero_mip_descriptor.max_mip == 0u,
+          "live 64x64 zero-mip descriptor declares exactly one base level");
+    CHECK(!live_tail_zero_mip_view.in_mip_tail &&
+              shader_resource_allows_zero_mip_specialization(
+                  materialized_zero_mip_use, live_tail_zero_mip_descriptor,
+                  live_tail_zero_mip_view),
+          "live 64x64 single-level surface is standalone, not a packed-tail relaxation");
+    DecodedImageView packed_tail_zero_mip_view = live_tail_zero_mip_view;
+    packed_tail_zero_mip_view.in_mip_tail = true;
+    CHECK(!shader_resource_allows_zero_mip_specialization(
+                  materialized_zero_mip_use, live_tail_zero_mip_descriptor,
+                  packed_tail_zero_mip_view),
+          "a true packed-tail zero-mip view remains fail-visible without a tail proof");
     uint32_t dcc_zero_mip_t8[8]{};
     std::copy(std::begin(atomic_image_seed), std::end(atomic_image_seed), dcc_zero_mip_t8);
     dcc_zero_mip_t8[6] = 0x00280000u;       // live 0x2042f49a DCC/pipe-aligned control shape

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1303,6 +1303,212 @@ int main() {
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
     }
 
+    // GTA V gameplay's exact IMAGE_LOAD_MIP / IMAGE_STORE_MIP packets. The live backend has one
+    // materialized level for these audited descriptors; the shader marker proves only the mip
+    // operand is zero. Exercise all four VDATA components of 0x2042f49800's dmask-f load, preserve a
+    // distinct 2D-array slice, and execute the NSA dmask-x store through its StorageImage contract.
+    const uint32_t gta_load_mip_copy_2d[] = {
+        0x7e080300u,                         // v4 = x (save shell input v0)
+        0x7e020280u,                         // v1 = y = 0
+        0x7e040207u,                         // v2 = mip = s7 = 0
+        0x7e0a0280u,                         // v5 = destination y = 0
+        0xf0043f08u, 0x00050000u,            // IMAGE_LOAD_MIP v[0:3], [v0,v1,v2], s[20:27]
+        0xbf8c3f70u,
+        0xf0200f08u, 0x00020004u,            // IMAGE_STORE v[0:3], [v4,v5], s[8:15]
+        0xbf810000u,
+    };
+    std::vector<uint8_t> mip2d_dst(W * 4, 0x6b);
+    ShaderResourceTable mip2d_rt = irt;
+    for (ShaderResource& resource : mip2d_rt.resources) {
+        if (resource.binding == 4) {
+            resource.cls = ResourceClass::Texture;
+            resource.sgpr_base = 20;
+            resource.fetch_pc = 4;
+            resource.img_dim = 1;
+            resource.proven_zero_mip = true;
+        } else if (resource.binding == 5) {
+            resource.gpu_addr = reinterpret_cast<uint64_t>(mip2d_dst.data());
+            resource.size = static_cast<uint32_t>(mip2d_dst.size());
+        }
+    }
+    const std::vector<uint32_t> gta_load_mip_2d_spirv = recompile_valu(
+        gta_load_mip_copy_2d, std::size(gta_load_mip_copy_2d), 1, 0, &mip2d_rt);
+    CHECK(!gta_load_mip_2d_spirv.empty(),
+          "GTA V dmask-xyzw IMAGE_LOAD_MIP 2D recompiles for live execution");
+    if (!gta_load_mip_2d_spirv.empty()) {
+        ComputeItem item;
+        item.spirv = gta_load_mip_2d_spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(mip2d_rt);
+        item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x248149800ull;
+        CHECK(prosper::frontend::execute_live_compute_items({item}),
+              "live backend executes GTA V's dmask-xyzw IMAGE_LOAD_MIP 2D");
+        CHECK(mip2d_dst == img_src,
+              "IMAGE_LOAD_MIP 2D preserves all four returned channels at level zero");
+    }
+
+    const uint32_t gta_load_mip_copy_2da[] = {
+        0x7e080300u,                         // v4 = x
+        0x7e020280u,                         // v1 = y = 0
+        0x7e040281u,                         // v2 = array slice 1
+        0x7e060206u,                         // v3 = mip = s6 = 0
+        0x7e0a0280u,                         // v5 = destination y = 0
+        0xf0043128u, 0x00050000u,            // IMAGE_LOAD_MIP 2D_ARRAY dmask:x
+        0xbf8c3f70u,
+        0xf0200108u, 0x00020004u,            // IMAGE_STORE x channel
+        0xbf810000u,
+    };
+    std::vector<uint32_t> mip_array_src(W * 2u);
+    std::vector<uint32_t> mip_array_dst(W, 0x6d6d6d6du);
+    for (uint32_t i = 0; i < W; ++i) {
+        mip_array_src[i] = i * 13u + 7u;
+        mip_array_src[W + i] = i * 65537u + 0x120034u;
+    }
+    ShaderResourceTable mip_array_rt = irt;
+    for (ShaderResource& resource : mip_array_rt.resources) {
+        if (resource.binding == 4) {
+            resource.cls = ResourceClass::Texture;
+            resource.sgpr_base = 20;
+            resource.fetch_pc = 5;
+            resource.img_dim = 5;
+            resource.depth = 2;
+            resource.format = DataFormat::Uint32;
+            resource.num_components = 1;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(mip_array_src.data());
+            resource.size = static_cast<uint32_t>(
+                mip_array_src.size() * sizeof(uint32_t));
+            resource.layer_stride_bytes = W * 4u;
+            resource.layer_mip_offset_bytes = 0;
+            resource.proven_zero_mip = true;
+        } else if (resource.binding == 5) {
+            resource.format = DataFormat::Uint32;
+            resource.num_components = 1;
+            resource.gpu_addr = reinterpret_cast<uint64_t>(mip_array_dst.data());
+            resource.size = static_cast<uint32_t>(
+                mip_array_dst.size() * sizeof(uint32_t));
+        }
+    }
+    const std::vector<uint32_t> gta_load_mip_array_spirv = recompile_valu(
+        gta_load_mip_copy_2da, std::size(gta_load_mip_copy_2da), 1, 0, &mip_array_rt);
+    CHECK(!gta_load_mip_array_spirv.empty(),
+          "GTA V IMAGE_LOAD_MIP 2D_ARRAY recompiles with its proven level-zero marker");
+    if (!gta_load_mip_array_spirv.empty()) {
+        ComputeItem item;
+        item.spirv = gta_load_mip_array_spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(mip_array_rt);
+        item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x24814a600ull;
+        CHECK(prosper::frontend::execute_live_compute_items({item}),
+              "live backend executes GTA V's IMAGE_LOAD_MIP 2D_ARRAY");
+        CHECK(std::equal(mip_array_dst.begin(), mip_array_dst.end(),
+                         mip_array_src.begin() + W),
+              "IMAGE_LOAD_MIP 2D_ARRAY fetches distinct slice one instead of dropping the layer");
+    }
+
+    const uint32_t gta_store_mip_2d[] = {
+        0x7e080300u,                         // v4 = x, while v0 remains stored data
+        0x7e060280u,                         // v3 = y = 0
+        0x7e0a0206u,                         // v5 = mip = s6 = 0
+        0xf024310au, 0x00030004u, 0x00000503u,
+        0xbf810000u,
+    };
+    std::vector<uint32_t> store_mip_dst(W, 0xdeadbeefu);
+    ShaderResourceTable store_mip_rt = irt;
+    store_mip_rt.resources.erase(
+        std::remove_if(store_mip_rt.resources.begin(), store_mip_rt.resources.end(),
+                       [](const ShaderResource& resource) {
+                           return resource.cls == ResourceClass::StorageImage;
+                       }),
+        store_mip_rt.resources.end());
+    ShaderResource store_mip_image{};
+    store_mip_image.cls = ResourceClass::StorageImage;
+    store_mip_image.binding = 4; store_mip_image.fetch_pc = 3;
+    store_mip_image.sgpr_base = 12; store_mip_image.img_dim = 1;
+    store_mip_image.format = DataFormat::Uint32; store_mip_image.num_components = 1;
+    store_mip_image.width = W; store_mip_image.height = store_mip_image.depth = 1;
+    store_mip_image.gpu_addr = reinterpret_cast<uint64_t>(store_mip_dst.data());
+    store_mip_image.size = static_cast<uint32_t>(store_mip_dst.size() * sizeof(uint32_t));
+    store_mip_image.proven_zero_mip = true;
+    store_mip_rt.resources.push_back(store_mip_image);
+    const std::vector<uint32_t> gta_store_mip_spirv = recompile_valu(
+        gta_store_mip_2d, std::size(gta_store_mip_2d), 1, 0, &store_mip_rt);
+    CHECK(!gta_store_mip_spirv.empty(),
+          "GTA V IMAGE_STORE_MIP 2D recompiles with StorageImage classification");
+    if (!gta_store_mip_spirv.empty()) {
+        ComputeItem item;
+        item.spirv = gta_store_mip_spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(store_mip_rt);
+        item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x248149a00ull;
+        CHECK(prosper::frontend::execute_live_compute_items({item}),
+              "live backend executes GTA V's IMAGE_STORE_MIP 2D");
+        CHECK(store_mip_dst == lane_index,
+              "IMAGE_STORE_MIP writes every lane's dword to level zero");
+    }
+
+    const uint32_t gta_store_mip_xyzw_2d[] = {
+        0x7e0a0300u,                         // v5 = x, while v0 remains channel X data
+        0x7e080280u,                         // v4 = y = 0
+        0x7e020281u,                         // v1 = channel Y = 1
+        0x7e040282u,                         // v2 = channel Z = 2
+        0x7e060283u,                         // v3 = channel W = 3
+        0x7e0c0206u,                         // v6 = mip = s6 = 0
+        0xf0243f0au, 0x00030005u, 0x00000604u, // live 0x2042f49800 packet
+        0xbf810000u,
+    };
+    std::vector<uint8_t> store_mip_rgba_dst(W * 4u, 0xcdu);
+    ShaderResourceTable store_mip_rgba_rt = irt;
+    store_mip_rgba_rt.resources.erase(
+        std::remove_if(store_mip_rgba_rt.resources.begin(),
+                       store_mip_rgba_rt.resources.end(),
+                       [](const ShaderResource& resource) {
+                           return resource.cls == ResourceClass::StorageImage;
+                       }),
+        store_mip_rgba_rt.resources.end());
+    ShaderResource store_mip_rgba_image{};
+    store_mip_rgba_image.cls = ResourceClass::StorageImage;
+    store_mip_rgba_image.binding = 4; store_mip_rgba_image.fetch_pc = 6;
+    store_mip_rgba_image.sgpr_base = 12; store_mip_rgba_image.img_dim = 1;
+    store_mip_rgba_image.format = DataFormat::Uint8; store_mip_rgba_image.num_components = 4;
+    store_mip_rgba_image.width = W;
+    store_mip_rgba_image.height = store_mip_rgba_image.depth = 1;
+    store_mip_rgba_image.gpu_addr =
+        reinterpret_cast<uint64_t>(store_mip_rgba_dst.data());
+    store_mip_rgba_image.size = static_cast<uint32_t>(store_mip_rgba_dst.size());
+    store_mip_rgba_image.proven_zero_mip = true;
+    store_mip_rgba_rt.resources.push_back(store_mip_rgba_image);
+    const std::vector<uint32_t> gta_store_mip_rgba_spirv = recompile_valu(
+        gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d), 1, 0,
+        &store_mip_rgba_rt);
+    CHECK(!gta_store_mip_rgba_spirv.empty(),
+          "GTA V's live dmask-xyzw IMAGE_STORE_MIP packet recompiles exactly");
+    if (!gta_store_mip_rgba_spirv.empty()) {
+        ComputeItem item;
+        item.spirv = gta_store_mip_rgba_spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(store_mip_rgba_rt);
+        item.launch.threads_x = W; item.launch.local_x = 64; item.launch.groups_x = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x2042f49800ull;
+        CHECK(prosper::frontend::execute_live_compute_items({item}),
+              "live backend executes 0x2042f49800's dmask-xyzw IMAGE_STORE_MIP");
+        bool exact_rgba = true;
+        for (uint32_t x = 0; x < W; ++x) {
+            exact_rgba &= store_mip_rgba_dst[x * 4u + 0u] == static_cast<uint8_t>(x) &&
+                          store_mip_rgba_dst[x * 4u + 1u] == 1u &&
+                          store_mip_rgba_dst[x * 4u + 2u] == 2u &&
+                          store_mip_rgba_dst[x * 4u + 3u] == 3u;
+        }
+        CHECK(exact_rgba,
+              "dmask-xyzw IMAGE_STORE_MIP writes all four live Uint8 channels at mip zero");
+    }
+
     // --- #590: the same production storage-image copy across the INTEGER and packed formats DOLL's
     // UE4 post-process writes its color-grading LUT / exposure / volume dispatches as (a 32x32x32
     // Uint8/Unorm2_10_10_10 3D LUT, a 1x1x1 exposure, a 16x16x16 Uint16 volume). Each dispatch was

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1327,6 +1327,7 @@ int main() {
             resource.img_dim = 1;
             resource.proven_zero_mip = true;
         } else if (resource.binding == 5) {
+            resource.img_dim = 1; // exact destination IMAGE_STORE has DIM=2D
             resource.gpu_addr = reinterpret_cast<uint64_t>(mip2d_dst.data());
             resource.size = static_cast<uint32_t>(mip2d_dst.size());
         }
@@ -1383,6 +1384,7 @@ int main() {
             resource.layer_mip_offset_bytes = 0;
             resource.proven_zero_mip = true;
         } else if (resource.binding == 5) {
+            resource.img_dim = 1; // exact destination IMAGE_STORE has DIM=2D
             resource.format = DataFormat::Uint32;
             resource.num_components = 1;
             resource.gpu_addr = reinterpret_cast<uint64_t>(mip_array_dst.data());

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -1,5 +1,6 @@
 #include "../src/gpu/rdna2_to_spirv.hpp"
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/gpu_execute.hpp"
 #include "../src/gpu/shader_resources.hpp"
 #include "../src/gpu/tile.hpp"
 #include "../src/host/guest_write_watch.hpp"
@@ -640,6 +641,79 @@ int main() {
     item.command_order = 70;
     item.recompile_config = config;
     item.recompile_config_available = true;
+
+    // GTA V reaches two compute programs whose only external operations use fully-known RAW V#s
+    // with NUM_RECORDS=0. Production discovery materializes an exact-PC marker and recompilation
+    // removes the buffer access entirely, so reflection correctly reports no descriptor. The live
+    // backend must recognize only that complete proof as successful without submitting empty work.
+    const uint32_t zero_record_code[] = {
+        0xE0300000u, 0x80000000u, // buffer_load_dword v0, off, s[0:3]
+        0xBF810000u,
+    };
+    const uint32_t zero_record_seed[4] = {
+        0x00000000u, 0x00100000u, 0x00000000u, 0x00016204u,
+    };
+    ShaderResourceTable zero_record_rt;
+    const std::vector<SrtUse> zero_record_uses = add_compute_buffer_resources(
+        zero_record_rt, zero_record_code, std::size(zero_record_code), zero_record_seed,
+        std::size(zero_record_seed));
+    assign_convention_bindings(zero_record_rt, 2);
+    ComputeShaderConfig zero_record_config;
+    zero_record_config.user_sgprs.assign(zero_record_seed,
+                                         zero_record_seed + std::size(zero_record_seed));
+    zero_record_config.local_x = zero_record_config.local_y = zero_record_config.local_z = 1;
+    const std::vector<uint32_t> zero_record_spirv = recompile_compute(
+        zero_record_code, std::size(zero_record_code), &zero_record_rt,
+        zero_record_config);
+    const DescriptorValidationReport zero_record_report = validate_spirv_descriptor_interface(
+        zero_record_spirv, &zero_record_rt, 0, SpirvShaderStage::Compute, false);
+    CHECK(zero_record_uses.size() == 1 && zero_record_rt.resources.size() == 1 &&
+              is_zero_record_raw_buffer(zero_record_rt.resources[0]) &&
+              !zero_record_spirv.empty() && zero_record_report.ok() &&
+              zero_record_report.descriptors.empty(),
+          "production zero-record RAW program recompiles with an exact marker and no descriptors");
+
+    ComputeItem zero_record_item;
+    zero_record_item.spirv = zero_record_spirv;
+    zero_record_item.user_sgprs = zero_record_config.user_sgprs;
+    zero_record_item.resources = std::make_shared<ShaderResourceTable>(zero_record_rt);
+    zero_record_item.launch.threads_x = zero_record_item.launch.threads_y =
+        zero_record_item.launch.threads_z = 1;
+    zero_record_item.launch.local_x = zero_record_item.launch.local_y =
+        zero_record_item.launch.local_z = 1;
+    zero_record_item.launch.groups_x = zero_record_item.launch.groups_y =
+        zero_record_item.launch.groups_z = 1;
+    zero_record_item.code_addr = 0x413cf4900ull;
+    zero_record_item.dispatch_index = 6;
+    zero_record_item.submit_no = 11;
+    zero_record_item.command_order = 69;
+    zero_record_item.recompile_config = zero_record_config;
+    zero_record_item.recompile_config_available = true;
+
+    const uint64_t zero_record_submits_before =
+        prosper::frontend::live_compute_queue_submit_attempts();
+    CHECK(prosper::frontend::execute_live_compute_items({zero_record_item}),
+          "all-marker descriptorless compute completes as a proven live-backend no-op");
+    ComputeItem empty_zero_record_item = zero_record_item;
+    empty_zero_record_item.resources = std::make_shared<ShaderResourceTable>();
+    CHECK(!prosper::frontend::execute_live_compute_items({empty_zero_record_item}),
+          "descriptorless compute with an empty runtime table remains fail-visible");
+    ComputeItem ordinary_zero_record_item = zero_record_item;
+    ordinary_zero_record_item.resources = std::make_shared<ShaderResourceTable>();
+    ShaderResource unused_ordinary_resource;
+    unused_ordinary_resource.cls = ResourceClass::ConstantBuffer;
+    unused_ordinary_resource.format = DataFormat::Uint32;
+    unused_ordinary_resource.num_components = 1;
+    unused_ordinary_resource.binding = 2;
+    unused_ordinary_resource.gpu_addr = reinterpret_cast<uint64_t>(result.data());
+    unused_ordinary_resource.size = sizeof(uint32_t);
+    ordinary_zero_record_item.resources->resources.push_back(unused_ordinary_resource);
+    CHECK(!prosper::frontend::execute_live_compute_items({ordinary_zero_record_item}),
+          "descriptorless compute with an unused ordinary resource remains fail-visible");
+    CHECK(prosper::frontend::live_compute_queue_submit_attempts() ==
+              zero_record_submits_before,
+          "proven and rejected descriptorless programs never attempt a Vulkan queue submit");
+
     CHECK(prosper::frontend::execute_live_compute_items({item}),
           "production live backend executes the game kernel");
     CHECK(result.size() == launched_records * 4, "compute resource retains its padded declared size");

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -405,19 +405,31 @@ int main(int argc, char** argv) {
               GpuCaptureResourceInputVerdict::Mismatch,
           "FORMAT=INVALID V# still rejects a normalized byte-size disagreement");
 
-    // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness.  Mutate the
+    // v47: one zero-mip specialization byte per realized and failed-stage resource.
+    auto v47_tail = [](const GpuCaptureFile& f) -> size_t {
+        size_t rc = 0;
+        for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
+        for (const auto& cm : f.computes) rc += cm.resources.resources.size();
+        for (const auto& diagnostic : f.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                rc += stage.resource_table.resources.size();
+        return 4 + rc;
+    };
+
+    // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness. Mutate the
     // serialized tail, rather than merely constructing invalid in-memory objects, so the reader's
     // hostile-input boundary proves the exact pack contract it accepts.
     std::vector<uint8_t> valid_v46_bytes;
     CHECK(serialize_gpu_capture(provenance_loaded, valid_v46_bytes, error) &&
-              valid_v46_bytes.size() >= 104u,
+              valid_v46_bytes.size() >= 104u + v47_tail(provenance_loaded),
           "v46 resource input witness has a complete validation tail");
-    const size_t v46_tail_base = valid_v46_bytes.size() >= 104u
-        ? valid_v46_bytes.size() - 104u : 0u;
+    const size_t v46_tail_base = valid_v46_bytes.size() >=
+            104u + v47_tail(provenance_loaded)
+        ? valid_v46_bytes.size() - v47_tail(provenance_loaded) - 104u : 0u;
     auto malformed_tail_rejected = [&](size_t offset,
                                        std::initializer_list<uint8_t> replacement,
                                        const char* wanted_error) {
-        if (valid_v46_bytes.size() < 104u ||
+        if (valid_v46_bytes.size() < 104u + v47_tail(provenance_loaded) ||
             offset > valid_v46_bytes.size() - replacement.size())
             return false;
         std::vector<uint8_t> bytes = valid_v46_bytes;
@@ -504,10 +516,13 @@ int main(int argc, char** argv) {
     GpuCaptureFile v45_provenance_loaded;
     CHECK(serialize_gpu_capture(provenance_loaded, v45_provenance_bytes, error) &&
               v45_provenance_bytes.size() >=
-                  4u + 100u * provenance_loaded.resource_provenance.size(),
+                  v47_tail(provenance_loaded) +
+                      4u + 100u * provenance_loaded.resource_provenance.size(),
           "v46 resource input tail is removable for a v45 compatibility fixture");
-    if (v45_provenance_bytes.size() >=
+    if (v45_provenance_bytes.size() >= v47_tail(provenance_loaded) +
             4u + 100u * provenance_loaded.resource_provenance.size()) {
+        v45_provenance_bytes.resize(
+            v45_provenance_bytes.size() - v47_tail(provenance_loaded));
         v45_provenance_bytes.resize(
             v45_provenance_bytes.size() -
             (4u + 100u * provenance_loaded.resource_provenance.size()));
@@ -881,6 +896,7 @@ int main(int argc, char** argv) {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v47_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v46_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v45_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v44_tail(v16_scissor_source));
@@ -999,7 +1015,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 46 &&
+              msaa_loaded.format_version == 47 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1026,7 +1042,8 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
     const uint32_t two_samples = 2;
     std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() -
-                    v46_tail(msaa_capture) - v45_tail(msaa_capture) - 4u,
+                    v47_tail(msaa_capture) - v46_tail(msaa_capture) -
+                    v45_tail(msaa_capture) - 4u,
                 &two_samples, sizeof(two_samples));
     GpuCaptureFile mismatched_msaa_loaded;
     CHECK(!deserialize_gpu_capture(
@@ -1049,6 +1066,7 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v47_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v46_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v45_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v44_tail(v43_msaa_source));
@@ -1106,22 +1124,38 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 46 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 47 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
           "v28 capture retains the complete padded rows and their resolved byte pitch");
+    video_capture.draws[0].prt.resources[0].resource.proven_zero_mip = true;
     std::vector<uint8_t> video_capture_bytes;
     GpuCaptureFile video_loaded;
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 46 &&
+              video_loaded.format_version == 47 &&
+              video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(video_loaded, video_replay, error) &&
               video_replay.items[0].prt->resources[0].host_data_size == video_memory.size(),
           "v28 replay round-trips and binds the complete pitch-padded source span");
+    std::vector<uint8_t> v46_zero_mip_bytes = video_capture_bytes;
+    v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v47_tail(video_capture));
+    v46_zero_mip_bytes[8] = 46;
+    GpuCaptureFile v46_zero_mip_loaded;
+    CHECK(deserialize_gpu_capture(v46_zero_mip_bytes, v46_zero_mip_loaded, error) &&
+              !v46_zero_mip_loaded.draws[0].prt.resources[0].resource.proven_zero_mip,
+          "v46 capture reopens without manufacturing a zero-mip specialization proof");
+    std::vector<uint8_t> malformed_zero_mip_bytes = video_capture_bytes;
+    malformed_zero_mip_bytes.back() = 2;
+    GpuCaptureFile malformed_zero_mip_loaded;
+    CHECK(!deserialize_gpu_capture(
+              malformed_zero_mip_bytes, malformed_zero_mip_loaded, error) &&
+              error == "invalid resource zero-mip state",
+          "v47 capture rejects a non-boolean zero-mip specialization marker");
     GpuCaptureFile legacy_video = video_capture;
     legacy_video.format_version = 27;
     legacy_video.draws[0].prt.resources[0].captured_size = 0;
@@ -1139,7 +1173,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 46 &&
+              upgraded_video.format_version == 47 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1221,7 +1255,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 46 &&
+              array_layout_loaded.format_version == 47 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1320,6 +1354,7 @@ int main(int argc, char** argv) {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v47_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v46_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v45_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v44_tail(volume_capture));
@@ -1424,6 +1459,7 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v47_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v46_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v45_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v44_tail(pre_v31_source));
@@ -1503,6 +1539,7 @@ int main(int argc, char** argv) {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v47_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v46_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v45_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v44_tail(captured));
@@ -1526,7 +1563,8 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-              v24_resolve_bytes.size() >= v46_tail(pre_v31_source) +
+              v24_resolve_bytes.size() >= v47_tail(pre_v31_source) +
+                  v46_tail(pre_v31_source) +
               v45_tail(pre_v31_source) +
               v44_tail(pre_v31_source) +
               v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
@@ -1542,7 +1580,8 @@ int main(int argc, char** argv) {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v46_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v47_tail(pre_v31_source) +
+            v46_tail(pre_v31_source) +
             v45_tail(pre_v31_source) +
             v44_tail(pre_v31_source) +
             v43_tail(pre_v31_source) + v42_tail(pre_v31_source) +
@@ -1557,6 +1596,7 @@ int main(int argc, char** argv) {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v47_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v46_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v45_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v44_tail(pre_v31_source));
@@ -1657,9 +1697,11 @@ int main(int argc, char** argv) {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v46_tail(captured) + v45_tail(captured) + v44_tail(captured) + v43_tail(captured) +
+        v47_tail(captured) + v46_tail(captured) + v45_tail(captured) +
+        v44_tail(captured) + v43_tail(captured) +
             v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v47_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v46_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v45_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v44_tail(captured));
@@ -1853,7 +1895,8 @@ int main(int argc, char** argv) {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v46_tail(v36_compute_source) + v45_tail(v36_compute_source) +
+                  v47_tail(v36_compute_source) + v46_tail(v36_compute_source) +
+                  v45_tail(v36_compute_source) +
                       v44_tail(v36_compute_source) +
                       v43_tail(v36_compute_source) +
                       v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
@@ -1862,13 +1905,15 @@ int main(int argc, char** argv) {
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v46_tail(v36_compute_source) + v45_tail(v36_compute_source) +
+        v47_tail(v36_compute_source) + v46_tail(v36_compute_source) +
+        v45_tail(v36_compute_source) +
             v44_tail(v36_compute_source) +
             v43_tail(v36_compute_source) +
             v42_tail(v36_compute_source) + v41_tail(v36_compute_source) +
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v47_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v46_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v45_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v44_tail(v36_compute_source));
@@ -2253,7 +2298,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 46 &&
+              failed_compute_loaded.format_version == 47 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -2266,7 +2311,8 @@ int main(int argc, char** argv) {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v46_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v47_tail(failed_compute_capture) -
+        v46_tail(failed_compute_capture) -
             v45_tail(failed_compute_capture) -
             v44_tail(failed_compute_capture) -
             v43_tail(failed_compute_capture) -
@@ -2486,7 +2532,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 46 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 47 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -2524,7 +2570,8 @@ int main(int argc, char** argv) {
         // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
         // so this is exactly its v44 sample-count record rather than a preceding extension field.
         std::memcpy(malformed_failed_sample_bytes.data() +
-                        malformed_failed_sample_bytes.size() - v46_tail(failed_capture) -
+                        malformed_failed_sample_bytes.size() - v47_tail(failed_capture) -
+                        v46_tail(failed_capture) -
                             v45_tail(failed_capture) -
                             sizeof(uint32_t),
                     &invalid_samples, sizeof(invalid_samples));
@@ -2539,16 +2586,19 @@ int main(int argc, char** argv) {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v46_tail(failed_capture) + v45_tail(failed_capture) +
+                  v47_tail(failed_capture) + v46_tail(failed_capture) +
+                  v45_tail(failed_capture) +
                       v44_tail(failed_capture) +
                       v43_tail(failed_capture) +
                       v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v46_tail(failed_capture) + v45_tail(failed_capture) +
+        v47_tail(failed_capture) + v46_tail(failed_capture) +
+        v45_tail(failed_capture) +
             v44_tail(failed_capture) +
             v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v47_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v46_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v45_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v44_tail(failed_capture));
@@ -2634,6 +2684,7 @@ int main(int argc, char** argv) {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v47_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v46_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v45_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v44_tail(legacy_source));
@@ -2678,6 +2729,7 @@ int main(int argc, char** argv) {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v47_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v46_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v45_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v44_tail(legacy_source));
@@ -2748,9 +2800,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 47;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 48;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 47",
+          error == "unsupported capture version 48",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -72,6 +72,13 @@ alignas(256) static const uint32_t kDccPs[] = {
     0x7E000280u, 0xF8001803u, 0x00000000u, 0xBF810000u,
 };
 alignas(256) static const uint32_t kNoopCs[] = {0xBF810000u};
+alignas(256) static const uint32_t kRealizeZeroMipCs[] = {
+    0xf40c0500u, 0xfa000000u,                // s_load_dwordx8 s[20:27], s[0:1], 0
+    0x7e040207u,                             // v_mov_b32 v2, s7
+    0xbf8cc07fu,                             // s_waitcnt lgkmcnt(0)
+    0xf0043f08u, 0x00050000u,                // IMAGE_LOAD_MIP, exact 2D dmask-xyzw shape
+    0xbf810000u,
+};
 alignas(256) static uint32_t kOrderedLateCs[] = {0u};
 static void set_pgm(GpuState& st, uint32_t lo_off, uint32_t hi_off, const void* p) {
     uint64_t a = (uint64_t)(uintptr_t)p;
@@ -85,6 +92,17 @@ static void set_test_env(const char* name, const char* value) {
 #else
     if (value) setenv(name, value, 1); else unsetenv(name);
 #endif
+}
+
+static void make_zero_mip_tsharp(uint32_t t[8], uint64_t base,
+                                 uint32_t width, uint32_t height) {
+    std::memset(t, 0, 8u * sizeof(uint32_t));
+    const uint64_t encoded_base = base >> 8;
+    t[0] = static_cast<uint32_t>(encoded_base);
+    t[1] = static_cast<uint32_t>((encoded_base >> 32) & 0xffu) |
+           (60u << 20) | (((width - 1u) & 0x3u) << 30); // Uint8x4
+    t[2] = (((width - 1u) >> 2) & 0xfffu) | (((height - 1u) & 0x3fffu) << 14);
+    t[3] = (9u << 28) | 0xfacu;               // 2D, linear, identity component selection
 }
 
 int main() {
@@ -253,6 +271,99 @@ int main() {
     // An empty (state-only) submit renders nothing — mirrors the game's setup Dcb (0 draws).
     GpuState empty; empty.draws.clear();
     CHECK(execute_gpustate(empty, backend).empty(), "a draw-less GpuState renders no frame (state-only submit)");
+
+    // Exercise the complete compute realization path: user pointer -> s_load T# fold -> per-use zero
+    // proof -> descriptor materialization -> cached recompile. This pins the production assignment in
+    // realize_compute_dispatches, while the unsafe arms prove DCC/multilevel descriptors cannot gain
+    // the marker or reuse the safe module.
+    {
+        auto create_shader = prosper::Hle::lookup("f3dg2CSgRKY");
+        AgcShaderHeader zero_mip_compute_header{};
+        zero_mip_compute_header.file_header = 0x34333231u;
+        zero_mip_compute_header.version = 0x18u;
+        zero_mip_compute_header.shader_size = sizeof(kRealizeZeroMipCs);
+        zero_mip_compute_header.type = 0;
+        void* registered_zero_mip_compute = nullptr;
+        CHECK(create_shader &&
+                  create_shader(reinterpret_cast<uint64_t>(&registered_zero_mip_compute),
+                                reinterpret_cast<uint64_t>(&zero_mip_compute_header),
+                                reinterpret_cast<uint64_t>(kRealizeZeroMipCs), 0, 0, 0) == 0 &&
+                  registered_zero_mip_compute == &zero_mip_compute_header,
+              "register production-realization IMAGE_LOAD_MIP compute shader");
+
+        alignas(256) static uint8_t realized_zero_mip_bytes[8192]{};
+        alignas(256) static uint8_t realized_zero_mip_metadata[256]{};
+        alignas(32) uint32_t safe_tsharp[8];
+        make_zero_mip_tsharp(safe_tsharp,
+                             reinterpret_cast<uint64_t>(realized_zero_mip_bytes), 4, 4);
+        alignas(32) uint32_t multilevel_tsharp[8];
+        std::copy(std::begin(safe_tsharp), std::end(safe_tsharp), multilevel_tsharp);
+        multilevel_tsharp[3] |= 1u << 16;
+        multilevel_tsharp[5] |= 1u << 4;
+        alignas(32) uint32_t dcc_tsharp[8];
+        std::copy(std::begin(safe_tsharp), std::end(safe_tsharp), dcc_tsharp);
+        const uint64_t metadata_field =
+            reinterpret_cast<uint64_t>(realized_zero_mip_metadata) >> 8;
+        dcc_tsharp[6] = 0x00280000u |
+            (static_cast<uint32_t>(metadata_field) << 24);
+        dcc_tsharp[7] = static_cast<uint32_t>(metadata_field >> 8);
+
+        auto make_zero_mip_submit = [&](const uint32_t* descriptor) {
+            GpuState submit;
+            auto dispatch_state = std::make_shared<GpuState>();
+            set_pgm(*dispatch_state, P::COMPUTE_PGM_LO, P::COMPUTE_PGM_HI,
+                    kRealizeZeroMipCs);
+            dispatch_state->sh[P::COMPUTE_PGM_RSRC2] =
+                8u << P::COMPUTE_PGM_RSRC2_USER_SGPR_SHIFT;
+            dispatch_state->sh[P::COMPUTE_NUM_THREAD_X] = 1;
+            dispatch_state->sh[P::COMPUTE_NUM_THREAD_Y] = 1;
+            dispatch_state->sh[P::COMPUTE_NUM_THREAD_Z] = 1;
+            const uint64_t descriptor_addr = reinterpret_cast<uint64_t>(descriptor);
+            dispatch_state->sh[P::COMPUTE_USER_DATA_0 + 0] =
+                static_cast<uint32_t>(descriptor_addr);
+            dispatch_state->sh[P::COMPUTE_USER_DATA_0 + 1] =
+                static_cast<uint32_t>(descriptor_addr >> 32);
+            dispatch_state->sh[P::COMPUTE_USER_DATA_0 + 7] = 0;
+            GpuState::Dispatch dispatch;
+            dispatch.threads_x = dispatch.threads_y = dispatch.threads_z = 1;
+            dispatch.state = std::move(dispatch_state);
+            submit.dispatches.push_back(std::move(dispatch));
+            return submit;
+        };
+
+        clear_shader_recompile_cache();
+        std::vector<OperationRealizationFailure> safe_failures;
+        const std::vector<ComputeItem> safe_items = realize_compute_dispatches(
+            make_zero_mip_submit(safe_tsharp), 2481, &safe_failures);
+        const ShaderResource* safe_texture = safe_items.size() == 1 && safe_items[0].resources
+            ? safe_items[0].resources->by_fetch_pc(4) : nullptr;
+        CHECK(safe_items.size() == 1 && safe_failures.empty() && safe_texture &&
+                  safe_texture->proven_zero_mip &&
+                  safe_texture->declared_mip_levels == 1 &&
+                  !safe_texture->compression_enabled,
+              "realize_compute_dispatches carries the exact safe zero-mip marker into recompilation");
+
+        auto unsafe_realization_fails = [&](const uint32_t* descriptor,
+                                            bool expect_compressed,
+                                            uint32_t expect_levels) {
+            std::vector<OperationRealizationFailure> failures;
+            const std::vector<ComputeItem> items = realize_compute_dispatches(
+                make_zero_mip_submit(descriptor), 2482, &failures);
+            const ShaderResource* texture = nullptr;
+            if (failures.size() == 1 && failures[0].stages.size() == 1 &&
+                failures[0].stages[0].resources)
+                texture = failures[0].stages[0].resources->by_fetch_pc(4);
+            return items.empty() && failures.size() == 1 &&
+                failures[0].reason == RealizationFailureReason::ShaderRecompile && texture &&
+                !texture->proven_zero_mip &&
+                texture->compression_enabled == expect_compressed &&
+                texture->declared_mip_levels == expect_levels;
+        };
+        CHECK(unsafe_realization_fails(multilevel_tsharp, false, 2),
+              "compute realization keeps a multilevel IMAGE_LOAD_MIP fail-visible");
+        CHECK(unsafe_realization_fails(dcc_tsharp, true, 1),
+              "compute realization keeps GTA-shaped DCC IMAGE_LOAD_MIP fail-visible");
+    }
 
     // #584: graphics and compute are one PM4 timeline. The planner must retain the asymmetric
     // draw-before-dispatch-before-draw dependency that exposed Dead Cells' future buffer read.

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -92,6 +92,27 @@ int main() {
     // inst6: v_fma_f32 v0, v1, v2, v3 (VOP3) -> dst VGPR0, srcs VGPR1/2/3
     CHECK(isV(ins[6].dst, 0) && ins[6].n_src == 3 && isV(ins[6].src[0], 1) &&
           isV(ins[6].src[1], 2) && isV(ins[6].src[2], 3), "v_fma_f32 VOP3 operands");
+    // GTA V exec_cs_413d1bf00 pc458, exact llvm-mc gfx1010 packet:
+    // `v_ldexp_f32 v0, v13, v1`. It is a two-source VOP3A op; the zeroed reserved SRC2 field must
+    // not escape as a phantom s0 dependency. Keep modifier decoding visible so the bounded emitter
+    // can reject unproved forms instead of silently dropping them.
+    const uint32_t gta_ldexp_words[] = {0xd7620000u, 0x0002030du};
+    const Rdna2Inst gta_ldexp = rdna2_decode_one(gta_ldexp_words, 2);
+    CHECK(gta_ldexp.fmt == Rdna2Format::VOP3 && gta_ldexp.opcode == 0x362u &&
+          gta_ldexp.n_src == 2 && isV(gta_ldexp.dst, 0) &&
+          isV(gta_ldexp.src[0], 13) && isV(gta_ldexp.src[1], 1) &&
+          gta_ldexp.src[2].kind == OperandKind::None &&
+          !gta_ldexp.clamp && gta_ldexp.omod == 0 &&
+          !gta_ldexp.src_abs[0] && !gta_ldexp.src_abs[1] &&
+          !gta_ldexp.src_neg[0] && !gta_ldexp.src_neg[1],
+          "GTA V v_ldexp_f32 decodes two sources and no phantom s0/modifiers");
+    const uint32_t gta_ldexp_modifier_words[] = {
+        0xd7628100u, 0x2802030du, // src0 ABS, CLAMP, src0 NEG, OMOD x2
+    };
+    const Rdna2Inst gta_ldexp_modifier = rdna2_decode_one(gta_ldexp_modifier_words, 2);
+    CHECK(gta_ldexp_modifier.src_abs[0] && gta_ldexp_modifier.src_neg[0] &&
+          gta_ldexp_modifier.clamp && gta_ldexp_modifier.omod == 1,
+          "v_ldexp_f32 modifier bits remain visible to the fail-closed emitter");
     // inst7: s_load_dwordx4 s[0:3], s[4:5], 0x0 (SMEM) -> op 0x2, SDATA s0, SBASE s4 (pair), offset 0
     CHECK(ins[7].fmt == Rdna2Format::SMEM && ins[7].opcode == 0x2u && isS(ins[7].dst, 0) &&
           isS(ins[7].src[0], 4) && ins[7].literal == 0x0u, "s_load_dwordx4 SMEM op/SDATA/SBASE/offset");

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -524,6 +524,54 @@ int main() {
               rdna2_mimg_zero_mip_shape(gta_store_mip_2d_xyzw, &mip_vgpr) &&
               mip_vgpr == 6u,
           "GTA V 0x2042f49800 IMAGE_STORE_MIP keeps v[0:3], (v5,v4), and v6 mip exact");
+    const uint32_t gta_pc10_vop2_word[] = {0x4a000804u};
+    const uint32_t wide_vop3_words[] = {0xd5761e01u, 0x040a0100u};
+    const uint32_t wide_mimg_words[] = {0xf0003f08u, 0x00050000u};
+    const uint32_t mimg_tfe_words[] = {0xf0010308u, 0x00050000u};
+    const uint32_t mimg_store_tfe_words[] = {0xf0210308u, 0x00050000u};
+    const uint32_t mimg_store_mip_tfe_words[] = {0xf0250308u, 0x00050003u};
+    const uint32_t mtbuf_store_tfe_words[] = {0xe9e72000u, 0x80882008u};
+    const uint32_t wide_mubuf_words[] = {0xe0382020u, 0x80020000u};
+    const Rdna2Inst gta_pc10_vop2 = rdna2_decode_one(gta_pc10_vop2_word, 1);
+    const Rdna2Inst wide_vop3 = rdna2_decode_one(wide_vop3_words, 2);
+    const Rdna2Inst wide_mimg = rdna2_decode_one(wide_mimg_words, 2);
+    const Rdna2Inst mimg_tfe = rdna2_decode_one(mimg_tfe_words, 2);
+    const Rdna2Inst mimg_store_tfe = rdna2_decode_one(mimg_store_tfe_words, 2);
+    const Rdna2Inst mimg_store_mip_tfe = rdna2_decode_one(mimg_store_mip_tfe_words, 2);
+    const Rdna2Inst mtbuf_store_tfe = rdna2_decode_one(mtbuf_store_tfe_words, 2);
+    const Rdna2Inst wide_mubuf = rdna2_decode_one(wide_mubuf_words, 2);
+    CHECK(gta_pc10_vop2.fmt == Rdna2Format::VOP2 && gta_pc10_vop2.dst.value == 0 &&
+              rdna2_vgpr_write_count(gta_pc10_vop2) == 1u &&
+              wide_vop3.fmt == Rdna2Format::VOP3 && wide_vop3.dst.value == 1 &&
+              rdna2_vgpr_write_count(wide_vop3) == 2u &&
+              rdna2_vgpr_write_count(wide_mimg) == 4u &&
+              mimg_tfe.mimg_tfe && mimg_tfe.mimg_dmask == 3u &&
+              rdna2_vgpr_write_count(mimg_tfe) == 2u &&
+              rdna2_tfe_status_vgpr(mimg_tfe) == 2 &&
+              rdna2_vgpr_destination_span(mimg_tfe) == 3u &&
+              rdna2_vgpr_write_count(wide_mubuf) == 4u &&
+              rdna2_vgpr_write_count(mt_tfe) == 1u &&
+              rdna2_tfe_status_vgpr(mt_tfe) == 2 &&
+              rdna2_vgpr_destination_span(mt_tfe) == 2u &&
+              rdna2_vgpr_write_count(gta_store_mip_2d_xyzw) == 0u &&
+              rdna2_vgpr_destination_span(gta_store_mip_2d_xyzw) == 4u,
+          "shared VGPR writer inventory distinguishes scalar, pair, wide memory, and store packets");
+    CHECK(mimg_store_tfe.fmt == Rdna2Format::MIMG &&
+              mimg_store_tfe.opcode == 0x08u && mimg_store_tfe.mimg_tfe &&
+              mimg_store_tfe.mimg_dmask == 3u &&
+              rdna2_vgpr_write_count(mimg_store_tfe) == 0u &&
+              rdna2_tfe_status_vgpr(mimg_store_tfe) == 2 &&
+              rdna2_vgpr_destination_span(mimg_store_tfe) == 3u &&
+              mimg_store_mip_tfe.opcode == 0x09u && mimg_store_mip_tfe.mimg_tfe &&
+              rdna2_vgpr_write_count(mimg_store_mip_tfe) == 0u &&
+              rdna2_tfe_status_vgpr(mimg_store_mip_tfe) == 2 &&
+              rdna2_vgpr_destination_span(mimg_store_mip_tfe) == 3u &&
+              mtbuf_store_tfe.fmt == Rdna2Format::MTBUF &&
+              mtbuf_store_tfe.opcode == 7u && mtbuf_store_tfe.mtbuf_tfe &&
+              rdna2_vgpr_write_count(mtbuf_store_tfe) == 0u &&
+              rdna2_tfe_status_vgpr(mtbuf_store_tfe) == 36 &&
+              rdna2_vgpr_destination_span(mtbuf_store_tfe) == 5u,
+          "store TFE keeps its VDATA source prefix separate from the trailing status write");
     const uint32_t ordinary_load_words[] = {0xf0003108u, 0x00050000u};
     const uint32_t load_without_glc_words[] = {0xf0041108u, 0x00050000u};
     const uint32_t load_partial_mask_words[] = {0xf0043308u, 0x00050000u};

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -576,8 +576,33 @@ int main() {
     Rdna2Inst ac = rdna2_decode_one(addco, 2);
     CHECK(ac.fmt == Rdna2Format::VOP3 && ac.opcode == 0x30Fu &&
           ac.sdst.kind == OperandKind::SGPR && ac.sdst.value == 4 &&
+          ac.n_src == 2 && ac.src[2].kind == OperandKind::None &&
           !ac.src_abs[0] && !ac.src_abs[1] && !ac.src_abs[2],
-          "VOP3B v_add_co_u32 (0x30F) decodes SDST s4 and clears the mis-read abs bits");
+          "VOP3B v_add_co_u32 (0x30F) decodes two sources, SDST s4, and no phantom SRC2");
+    // Exact GTA V packets at the reported join and its later carry consumer. The producer's zero
+    // reserved field must not decode as s0; the _co_ci_ consumer's identically valued SRC2 is real.
+    const uint32_t live_addco[] = { 0xd70f0016u, 0x00021f1bu };
+    const uint32_t live_addcoci[] = { 0xd5286a17u, 0x00024080u };
+    const Rdna2Inst lac = rdna2_decode_one(live_addco, 2);
+    const Rdna2Inst laci = rdna2_decode_one(live_addcoci, 2);
+    CHECK(lac.opcode == 0x30Fu && lac.dst.kind == OperandKind::VGPR && lac.dst.value == 22 &&
+          lac.sdst.kind == OperandKind::SGPR && lac.sdst.value == 0 && lac.n_src == 2 &&
+          lac.src[0].kind == OperandKind::VGPR && lac.src[0].value == 27 &&
+          lac.src[1].kind == OperandKind::VGPR && lac.src[1].value == 15 &&
+          lac.src[2].kind == OperandKind::None &&
+          laci.opcode == 0x128u && laci.sdst.value == 106 && laci.n_src == 3 &&
+          laci.src[2].kind == OperandKind::SGPR && laci.src[2].value == 0,
+          "exact GTA V VOP3B producer has two sources while its carry consumer has three");
+    // The no-carry-in subtract forms have the same two-source VOP3B layout. Keep their decoded
+    // source inventory aligned with emission as well; only the 0x128..0x12A _co_ci_ family has an
+    // architectural carry-in in SRC2.
+    const uint32_t subco[] = { 0xd7100000u | (4u << 8), 0x00020501u };
+    const uint32_t subrevco[] = { 0xd7190000u | (4u << 8), 0x00020501u };
+    const Rdna2Inst sc = rdna2_decode_one(subco, 2);
+    const Rdna2Inst src = rdna2_decode_one(subrevco, 2);
+    CHECK(sc.opcode == 0x310u && sc.n_src == 2 && sc.src[2].kind == OperandKind::None &&
+          src.opcode == 0x319u && src.n_src == 2 && src.src[2].kind == OperandKind::None,
+          "VOP3B v_sub/subrev_co_u32 decode two sources and no phantom SRC2");
     // DS GDS flag is dword0 bit 17 (llvm-mc gfx1030: ds_add_u32 gds = 0xd8020000 vs 0xd8000000;
     // ds_append gds = 0xd8fa0000 vs plain 0xd8f80000).
     const uint32_t ds_plain[] = { 0xd8000000u, 0x00000201u };

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -337,8 +337,23 @@ int main() {
     const uint32_t dpp16[] = { 0x4a0e0cfau, 0xff011106u };   // v_add_nc_u32_dpp v7, v6, v6 row_shr:1
     Rdna2Inst dp = rdna2_decode_one(dpp16, 2);
     CHECK(dp.fmt == Rdna2Format::VOP2 && dp.len_dwords == 2 && !dp.has_modifier && dp.has_dpp &&
-          dp.dpp_ctrl == 0x111u && !dp.dpp_bound_ctrl,
+          dp.dpp_ctrl == 0x111u && !dp.dpp_bound_ctrl &&
+          dp.dpp_row_mask == 0xfu && dp.dpp_bank_mask == 0xfu,
           "VOP2 DPP16 ROW_SHR form retains its unbounded lane control");
+    const uint32_t gta_row_mask_add[] = { 0x4a2826fau, 0xaf00e414u };
+    Rdna2Inst grm = rdna2_decode_one(gta_row_mask_add, 2);
+    CHECK(grm.fmt == Rdna2Format::VOP2 && grm.opcode == 0x25u &&
+          !grm.has_modifier && grm.has_dpp && grm.dpp_ctrl == 0xe4u &&
+          !grm.dpp_bound_ctrl && grm.dpp_row_mask == 0xau &&
+          grm.dpp_bank_mask == 0xfu && isV(grm.dst, 20) &&
+          isV(grm.src[0], 20) && isV(grm.src[1], 19),
+          "GTA V identity DPP add retains exact partial row mask and operands");
+    for (uint32_t mutant : {0x9f00e414u, 0xae00e414u, 0xaf08e414u, 0xaf00e514u}) {
+        const uint32_t words[] = {0x4a2826fau, mutant};
+        Rdna2Inst rejected = rdna2_decode_one(words, 2);
+        CHECK(rejected.has_modifier && !rejected.has_dpp,
+              "GTA V partial DPP admission rejects row/bank/BC/control mutations");
+    }
     const uint32_t ngg_row_shift[] = { 0x4a1e1efau, 0xff09110fu };
     Rdna2Inst nrs = rdna2_decode_one(ngg_row_shift, 2);
     CHECK(nrs.fmt == Rdna2Format::VOP2 && nrs.opcode == 0x25u && !nrs.has_modifier &&

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -483,6 +483,62 @@ int main() {
           n3.mimg_nsa == 1u && n3.mimg_dim == 2u &&
           (n3.words[1] & 0xFFu) == 0u && (n3.words[2] & 0xFFu) == 7u && ((n3.words[2] >> 8) & 0xFFu) == 3u,
           "NSA MIMG 3D captures the extra address dword; coords decode to v0,v7,v3");
+    // GTA V gameplay compute packets. The helper identifies only the audited zero-specializable
+    // IMAGE_*_MIP shapes and returns the dimension-specific mip VGPR; it does not prove its value.
+    const uint32_t gta_load_mip_2d_words[] = {0xf0043108u, 0x00050000u};
+    const uint32_t gta_load_mip_2d_xyzw_words[] = {0xf0043f08u, 0x00050000u};
+    const uint32_t gta_load_mip_2da_words[] = {0xf0043128u, 0x00050000u};
+    const uint32_t gta_store_mip_2d_words[] = {
+        0xf024310au, 0x00030004u, 0x00000503u,
+    };
+    const uint32_t gta_store_mip_2d_xyzw_words[] = {
+        0xf0243f0au, 0x00030005u, 0x00000604u,
+    };
+    const Rdna2Inst gta_load_mip_2d = rdna2_decode_one(gta_load_mip_2d_words, 2);
+    const Rdna2Inst gta_load_mip_2d_xyzw =
+        rdna2_decode_one(gta_load_mip_2d_xyzw_words, 2);
+    const Rdna2Inst gta_load_mip_2da = rdna2_decode_one(gta_load_mip_2da_words, 2);
+    const Rdna2Inst gta_store_mip_2d = rdna2_decode_one(gta_store_mip_2d_words, 3);
+    const Rdna2Inst gta_store_mip_2d_xyzw =
+        rdna2_decode_one(gta_store_mip_2d_xyzw_words, 3);
+    uint32_t mip_vgpr = UINT32_MAX;
+    CHECK(gta_load_mip_2d.opcode == 0x01u && gta_load_mip_2d.mimg_dim == 1u &&
+              rdna2_mimg_zero_mip_shape(gta_load_mip_2d, &mip_vgpr) && mip_vgpr == 2u,
+          "GTA V IMAGE_LOAD_MIP 2D identifies v2 as its mip operand");
+    CHECK(gta_load_mip_2d_xyzw.mimg_dmask == 0xfu &&
+              rdna2_mimg_zero_mip_shape(gta_load_mip_2d_xyzw, &mip_vgpr) &&
+              mip_vgpr == 2u,
+          "GTA V 0x2042f49800 IMAGE_LOAD_MIP accepts its exact xyzw result mask");
+    CHECK(gta_load_mip_2da.opcode == 0x01u && gta_load_mip_2da.mimg_dim == 5u &&
+              rdna2_mimg_zero_mip_shape(gta_load_mip_2da, &mip_vgpr) && mip_vgpr == 3u,
+          "GTA V IMAGE_LOAD_MIP 2D_ARRAY identifies v3 after the preserved slice");
+    CHECK(gta_store_mip_2d.opcode == 0x09u && gta_store_mip_2d.mimg_dim == 1u &&
+              gta_store_mip_2d.mimg_nsa == 1u &&
+              rdna2_mimg_zero_mip_shape(gta_store_mip_2d, &mip_vgpr) && mip_vgpr == 5u,
+          "GTA V IMAGE_STORE_MIP NSA 2D identifies its explicit v5 mip operand");
+    CHECK(gta_store_mip_2d_xyzw.mimg_dmask == 0xfu &&
+              gta_store_mip_2d_xyzw.dst.kind == OperandKind::VGPR &&
+              gta_store_mip_2d_xyzw.dst.value == 0 &&
+              gta_store_mip_2d_xyzw.src[0].kind == OperandKind::VGPR &&
+              gta_store_mip_2d_xyzw.src[0].value == 5 &&
+              rdna2_mimg_zero_mip_shape(gta_store_mip_2d_xyzw, &mip_vgpr) &&
+              mip_vgpr == 6u,
+          "GTA V 0x2042f49800 IMAGE_STORE_MIP keeps v[0:3], (v5,v4), and v6 mip exact");
+    const uint32_t ordinary_load_words[] = {0xf0003108u, 0x00050000u};
+    const uint32_t load_without_glc_words[] = {0xf0041108u, 0x00050000u};
+    const uint32_t load_partial_mask_words[] = {0xf0043308u, 0x00050000u};
+    const uint32_t store_extra_address_words[] = {
+        0xf024310au, 0x00030004u, 0x00010503u,
+    };
+    const uint32_t store_partial_mask_words[] = {
+        0xf024330au, 0x00030004u, 0x00000503u,
+    };
+    CHECK(!rdna2_mimg_zero_mip_shape(rdna2_decode_one(ordinary_load_words, 2)) &&
+              !rdna2_mimg_zero_mip_shape(rdna2_decode_one(load_without_glc_words, 2)) &&
+              !rdna2_mimg_zero_mip_shape(rdna2_decode_one(load_partial_mask_words, 2)) &&
+              !rdna2_mimg_zero_mip_shape(rdna2_decode_one(store_extra_address_words, 3)) &&
+              !rdna2_mimg_zero_mip_shape(rdna2_decode_one(store_partial_mask_words, 3)),
+          "zero-mip shape rejects opcode, control, and unused-address mutations at the packet gate");
     // Astro Bot's world-map ray traversal uses the maximum three NSA dwords to name eleven input
     // VGPRs. Retaining dword4 is required for ray_inv_dir.y/z (v71/v72).
     const uint32_t mimg_bvh[] = {

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -544,6 +544,20 @@ int main() {
     const uint32_t mubuf_noglc[] = { 0xe0e00004u, 0x80000000u };
     CHECK(rdna2_decode_one(mubuf_glc, 2).mubuf_glc && !rdna2_decode_one(mubuf_noglc, 2).mubuf_glc,
           "MUBUF GLC bit 14 decodes (atomics: return pre-op value)");
+    // GTA V pc224: buffer_load_dword ... glc dlc. Clearing only bit 15 is the mutation arm: GLC
+    // remains set while DLC must disappear, so this checks the production decoder field itself.
+    const uint32_t mubuf_glc_dlc[] = { 0xe030e010u, 0x80001e1du };
+    const uint32_t mubuf_glc_only[] = { 0xe0306010u, 0x80001e1du };
+    const Rdna2Inst mubuf_both = rdna2_decode_one(mubuf_glc_dlc, 2);
+    const Rdna2Inst mubuf_without_dlc = rdna2_decode_one(mubuf_glc_only, 2);
+    CHECK(mubuf_both.mubuf_glc && mubuf_both.mubuf_dlc &&
+              mubuf_without_dlc.mubuf_glc && !mubuf_without_dlc.mubuf_dlc,
+          "MUBUF DLC bit 15 decodes independently from GLC on GTA V's exact polling load");
+    const uint32_t mtbuf_dlc[] = { 0xe8b0a000u, 0x80020100u };
+    const uint32_t mtbuf_nodlc[] = { 0xe8b02000u, 0x80020100u };
+    CHECK(rdna2_decode_one(mtbuf_dlc, 2).mubuf_dlc &&
+              !rdna2_decode_one(mtbuf_nodlc, 2).mubuf_dlc,
+          "MTBUF shares the decoded DLC bit 15 cache-policy field");
     // MUBUF LDS (bit 16): hand-set on the plain dword load (llvm-mc gfx1030 rejects the syntax,
     // but the field is architectural — Table 98).
     const uint32_t mubuf_lds[] = { 0xe0310000u, 0x80000000u };

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -262,6 +262,36 @@ int main() {
     CHECK(mz.fmt == Rdna2Format::VOP1 && mz.opcode == 0x01u && !mz.has_modifier &&
           mz.sdwa_src0_sel == 4u && !mz.sdwa_src0_sext,
           "the same encoding without bit 19 decodes as the zero-extending form");
+    // GTA V compute compaction: reverse the selected low word into a full dword. Both retained
+    // kernels use the same WORD_0 + zero-extension shape, differing only in their VGPR number.
+    const uint32_t bfrev6[] = { 0x7e0c70f9u, 0x00040606u };
+    Rdna2Inst br6 = rdna2_decode_one(bfrev6, 2);
+    CHECK(br6.fmt == Rdna2Format::VOP1 && br6.opcode == 0x38u && !br6.has_modifier &&
+          br6.has_sdwa && isV(br6.dst, 6) && isV(br6.src[0], 6) &&
+          br6.sdwa_dst_sel == 6u && br6.sdwa_dst_unused == 0u &&
+          br6.sdwa_src0_sel == 4u,
+          "GTA V v_bfrev_b32_sdwa v6 WORD_0 packet is admitted exactly");
+    const uint32_t bfrev0[] = { 0x7e0070f9u, 0x00040600u };
+    Rdna2Inst br0 = rdna2_decode_one(bfrev0, 2);
+    CHECK(br0.fmt == Rdna2Format::VOP1 && br0.opcode == 0x38u && !br0.has_modifier &&
+          br0.has_sdwa && isV(br0.dst, 0) && isV(br0.src[0], 0) &&
+          br0.sdwa_src0_sel == 4u,
+          "GTA V v_bfrev_b32_sdwa v0 WORD_0 packet is admitted exactly");
+    const uint32_t bfrev_sext[] = { 0x7e0070f9u, 0x000c0600u };
+    const uint32_t bfrev_neg[] = { 0x7e0070f9u, 0x00140600u };
+    const uint32_t bfrev_partial_dst[] = { 0x7e0070f9u, 0x00040400u };
+    const uint32_t bfrev_reserved_high[] = { 0x7e0070f9u, 0x01040600u };
+    const uint32_t bfrev_dword[] = { 0x7e0070f9u, 0x00060600u };
+    const uint32_t bfrev_dword_neg[] = { 0x7e0070f9u, 0x00160600u };
+    const uint32_t bfrev_dword_abs[] = { 0x7e0070f9u, 0x00260600u };
+    CHECK(rdna2_decode_one(bfrev_sext, 2).has_modifier &&
+          rdna2_decode_one(bfrev_neg, 2).has_modifier &&
+          rdna2_decode_one(bfrev_partial_dst, 2).has_modifier &&
+          rdna2_decode_one(bfrev_reserved_high, 2).has_modifier &&
+          rdna2_decode_one(bfrev_dword, 2).has_modifier &&
+          rdna2_decode_one(bfrev_dword_neg, 2).has_modifier &&
+          rdna2_decode_one(bfrev_dword_abs, 2).has_modifier,
+          "v_bfrev_b32 SDWA SEXT, modifiers, reserved fields, DWORD source, and partial dst reject");
     // `v_add_nc_u32_sdwa v4, 8, sext(v5) src0_sel:DWORD src1_sel:WORD_0`: SEXT on the SECOND source
     // only, which is the field the two per-source flags exist to keep apart.
     const uint32_t add_s1_sext[] = { 0x4a080af9u, 0x0c860688u };

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1880,6 +1880,45 @@ int main() {
     }
     printf("  [ok]   implicit VOPC preserves VCC_HI scalar data only in Wave32\n");
 
+    // GTA V's Wave64 compute kernel 0x205b5e8600 negates the current EXEC mask as a scalar integer
+    // pair. The subtraction words below are its exact pc1310/1312 packets: subtract EXEC_LO from
+    // zero, then subtract EXEC_HI and the low-word borrow from zero. An exact 64-lane subgroup can
+    // materialise each EXEC half with subgroupBallot; a portable or mismatched subgroup must keep
+    // rejecting rather than silently treating the architectural mask as zero.
+    const uint32_t gta_wave64_exec_integer_negate[] = {
+        0xbefe04c1u,                         // establish a complete live EXEC mask
+        0x80907e80u,                         // pc1310: s_sub_u32 s16, 0, exec_lo
+        0x82917f80u,                         // pc1312: s_subb_u32 s17, 0, exec_hi
+        0x7e040210u,                         // v_mov_b32 v2, s16 (keep the result live)
+        0x7e060211u,                         // v_mov_b32 v3, s17
+        0xbf810000u,
+    };
+    ComputeShaderConfig gta_wave64_exec_config = wave64_compute_config;
+    const std::vector<uint32_t> gta_wave64_exec_spv = recompile_compute(
+        gta_wave64_exec_integer_negate, std::size(gta_wave64_exec_integer_negate), nullptr,
+        gta_wave64_exec_config);
+    if (gta_wave64_exec_spv.empty() || !has_opcode(gta_wave64_exec_spv, 339)) {
+        printf("  [FAIL] GTA Wave64 EXEC integer negation did not materialise the mask via subgroupBallot\n");
+        return 1;
+    }
+    ComputeShaderConfig gta_portable_exec_config = gta_wave64_exec_config;
+    gta_portable_exec_config.native_subgroup_size = 0;
+    if (!recompile_compute(gta_wave64_exec_integer_negate,
+                           std::size(gta_wave64_exec_integer_negate), nullptr,
+                           gta_portable_exec_config).empty()) {
+        printf("  [FAIL] portable GTA EXEC integer negation compiled without an exact subgroup\n");
+        return 1;
+    }
+    ComputeShaderConfig gta_mismatched_exec_config = gta_wave64_exec_config;
+    gta_mismatched_exec_config.native_subgroup_size = 32;
+    if (!recompile_compute(gta_wave64_exec_integer_negate,
+                           std::size(gta_wave64_exec_integer_negate), nullptr,
+                           gta_mismatched_exec_config).empty()) {
+        printf("  [FAIL] GTA EXEC integer negation compiled for a mismatched subgroup\n");
+        return 1;
+    }
+    printf("  [ok]   GTA Wave64 EXEC integer negation requires and uses an exact-wave ballot\n");
+
     // Astro's exact PC458 packet explicitly selects physical VCC_HI in Wave32. A typed B32 mask in
     // that word must drive the select independently of VCC_LO; absent or path-dependent HI mask
     // lifetimes must remain fail-visible instead of falling back to the implicit VCC predicate.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -457,6 +457,652 @@ bool dpp_min_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv) {
         shuffle_lanes.size() == 1 && min_reaches_store;
 }
 
+// Prove GTA V's portable compute DPP add lowering rather than merely finding an OpIAdd. The two
+// guest waves publish separate value/metadata scratch planes, address SRC0 with linear_id-amount
+// inside a DPP16 row, require the source's static event to match, and select the add over the old
+// persistent VGPR only on that guarded path. Instruction positions additionally prove that two
+// uniform workgroup barriers bracket the scratch exchange and its later reuse.
+bool compute_dpp_add_row_shr_updates_dispatch_vgpr(const std::vector<uint32_t>& spv,
+                                                   uint32_t lanes,
+                                                   uint32_t expected_dst) {
+    constexpr uint32_t OpConstant = 43, OpLoad = 61, OpStore = 62,
+                       OpAccessChain = 65, OpIAdd = 128, OpISub = 130,
+                       OpShiftRightLogical = 194, OpLogicalAnd = 167,
+                       OpSelect = 169, OpIEqual = 170, OpINotEqual = 171,
+                       OpUGreaterThanEqual = 174, OpShiftLeftLogical = 196,
+                       OpBitwiseOr = 197, OpBitwiseAnd = 199,
+                       OpControlBarrier = 224;
+    struct Binary { uint32_t first = 0, second = 0; };
+    struct Select { uint32_t condition = 0, yes = 0, no = 0; };
+    struct Access { uint32_t base = 0, index = 0; };
+    struct Store { uint32_t pointer = 0, value = 0; size_t position = 0; };
+    struct Load { uint32_t pointer = 0; size_t position = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants;
+    std::unordered_map<uint32_t, Binary> iadds, isubs, shifts, shift_lefts,
+                                                logical_ands, equals, not_equals,
+                                                greater_equals, bitwise_ors,
+                                                bitwise_ands;
+    std::unordered_map<uint32_t, Select> selects;
+    std::unordered_map<uint32_t, Access> accesses;
+    std::unordered_map<uint32_t, Load> loads;
+    std::vector<Store> stores;
+    std::vector<size_t> barriers;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4)
+            constants[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLoad && wc == 4)
+            loads[spv[i + 2]] = {spv[i + 3], i};
+        else if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2], i});
+        else if (op == OpAccessChain && wc == 5)
+            accesses[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpIAdd && wc == 5)
+            iadds[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpISub && wc == 5)
+            isubs[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpShiftRightLogical && wc == 5)
+            shifts[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpShiftLeftLogical && wc == 5)
+            shift_lefts[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpLogicalAnd && wc == 5)
+            logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpIEqual && wc == 5)
+            equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpINotEqual && wc == 5)
+            not_equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpUGreaterThanEqual && wc == 5)
+            greater_equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpBitwiseOr && wc == 5)
+            bitwise_ors[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpBitwiseAnd && wc == 5)
+            bitwise_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpSelect && wc == 6)
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+        else if (op == OpControlBarrier)
+            barriers.push_back(i);
+        i += wc;
+    }
+
+    auto literal_other = [&](const Binary& binary, uint32_t literal,
+                             uint32_t* other) {
+        const auto first = constants.find(binary.first);
+        const auto second = constants.find(binary.second);
+        if (first != constants.end() && first->second == literal) {
+            if (other) *other = binary.second;
+            return true;
+        }
+        if (second != constants.end() && second->second == literal) {
+            if (other) *other = binary.first;
+            return true;
+        }
+        return false;
+    };
+    auto pointer_store = [&](uint32_t pointer, uint32_t value, size_t* position) {
+        const auto found = std::find_if(stores.begin(), stores.end(), [&](const Store& store) {
+            return store.pointer == pointer && (!value || store.value == value);
+        });
+        if (found == stores.end()) return false;
+        if (position) *position = found->position;
+        return true;
+    };
+
+    // Locate the loaded source event: scratch metadata >> 1 == the destination's event mailbox.
+    for (const auto& shifted_event : shifts) {
+        const auto one = constants.find(shifted_event.second.second);
+        const auto metadata_load = loads.find(shifted_event.second.first);
+        if (one == constants.end() || one->second != 1 || metadata_load == loads.end()) continue;
+        const auto metadata_access = accesses.find(metadata_load->second.pointer);
+        if (metadata_access == accesses.end()) continue;
+        const auto metadata_index_add = iadds.find(metadata_access->second.index);
+        uint32_t source_index = 0;
+        if (metadata_index_add == iadds.end() ||
+            !literal_other(metadata_index_add->second, lanes, &source_index))
+            continue;
+
+        uint32_t event_match = 0, event_load = 0;
+        for (const auto& equal : equals) {
+            if (equal.second.first == shifted_event.first && loads.contains(equal.second.second)) {
+                event_match = equal.first;
+                event_load = equal.second.second;
+                break;
+            }
+            if (equal.second.second == shifted_event.first && loads.contains(equal.second.first)) {
+                event_match = equal.first;
+                event_load = equal.second.first;
+                break;
+            }
+        }
+        if (!event_match) continue;
+
+        std::unordered_set<uint32_t> event_tags;
+        const uint32_t event_pointer = loads.at(event_load).pointer;
+        for (const auto& store : stores) {
+            if (store.pointer != event_pointer) continue;
+            const auto constant = constants.find(store.value);
+            if (constant != constants.end()) event_tags.insert(constant->second);
+        }
+        uint32_t nonzero_events = 0;
+        for (uint32_t event : event_tags) nonzero_events += event != 0;
+        if (!event_tags.contains(0) || nonzero_events < 2) continue;
+
+        const auto source_select = selects.find(source_index);
+        if (source_select == selects.end()) continue;
+        const auto source_subtract = isubs.find(source_select->second.yes);
+        const auto row_bound = greater_equals.find(source_select->second.condition);
+        uint32_t linear_lane = 0;
+        const auto row_lane = row_bound == greater_equals.end()
+            ? bitwise_ands.end() : bitwise_ands.find(row_bound->second.first);
+        if (source_subtract == isubs.end() || row_bound == greater_equals.end() ||
+            row_lane == bitwise_ands.end() ||
+            !literal_other(row_lane->second, 15, &linear_lane) ||
+            source_subtract->second.first != linear_lane ||
+            source_select->second.no != linear_lane ||
+            source_subtract->second.second != row_bound->second.second)
+            continue;
+        const uint32_t amount = source_subtract->second.second;
+        const auto amount_load = loads.find(amount);
+        if (amount_load == loads.end()) continue;
+        std::unordered_set<uint32_t> amounts;
+        for (const auto& store : stores) {
+            if (store.pointer != amount_load->second.pointer) continue;
+            const auto constant = constants.find(store.value);
+            if (constant != constants.end()) amounts.insert(constant->second);
+        }
+        if (!amounts.contains(1) || !amounts.contains(2) ||
+            !amounts.contains(4) || !amounts.contains(8))
+            continue;
+
+        // The value plane uses the identical dynamic source index and the same scratch variable.
+        uint32_t shifted_value = 0;
+        for (const auto& load : loads) {
+            const auto access = accesses.find(load.second.pointer);
+            if (access == accesses.end() ||
+                access->second.base != metadata_access->second.base)
+                continue;
+            const auto index_add = iadds.find(access->second.index);
+            uint32_t index = 0;
+            if (index_add != iadds.end() &&
+                literal_other(index_add->second, 0, &index) && index == source_index) {
+                shifted_value = load.first;
+                break;
+            }
+        }
+        if (!shifted_value) continue;
+
+        uint32_t add_result = 0, local_value = 0;
+        for (const auto& add : iadds) {
+            if (add.second.first == shifted_value || add.second.second == shifted_value) {
+                const uint32_t local = add.second.first == shifted_value
+                    ? add.second.second : add.second.first;
+                if (loads.contains(local)) {
+                    add_result = add.first;
+                    local_value = local;
+                    break;
+                }
+            }
+        }
+        if (!add_result) continue;
+
+        // Find both plane publications by their common destination invocation index.
+        size_t value_publish = 0, metadata_publish = 0;
+        uint32_t metadata_value = 0;
+        for (const auto& value_store : stores) {
+            const auto value_access = accesses.find(value_store.pointer);
+            if (value_access == accesses.end() ||
+                value_access->second.base != metadata_access->second.base ||
+                value_store.value != local_value)
+                continue;
+            const auto value_index = iadds.find(value_access->second.index);
+            uint32_t lane = 0;
+            if (value_index == iadds.end() ||
+                !literal_other(value_index->second, 0, &lane))
+                continue;
+            for (const auto& metadata_store : stores) {
+                const auto metadata_publish_access = accesses.find(metadata_store.pointer);
+                if (metadata_publish_access == accesses.end() ||
+                    metadata_publish_access->second.base != metadata_access->second.base)
+                    continue;
+                const auto metadata_publish_index =
+                    iadds.find(metadata_publish_access->second.index);
+                uint32_t metadata_lane = 0;
+                if (metadata_publish_index != iadds.end() &&
+                    literal_other(metadata_publish_index->second, lanes, &metadata_lane) &&
+                    metadata_lane == lane) {
+                    value_publish = value_store.position;
+                    metadata_publish = metadata_store.position;
+                    metadata_value = metadata_store.value;
+                    break;
+                }
+            }
+            if (value_publish && metadata_publish) break;
+        }
+        if (!value_publish || !metadata_publish || !metadata_value) continue;
+
+        // Recover the destination pending and EXEC mailboxes from the publication expression:
+        // pending ? ((event << 1) | (active ? 1 : 0)) : 0.
+        const auto metadata_select = selects.find(metadata_value);
+        if (metadata_select == selects.end() ||
+            !loads.contains(metadata_select->second.condition))
+            continue;
+        const auto metadata_zero = constants.find(metadata_select->second.no);
+        const auto encoded = bitwise_ors.find(metadata_select->second.yes);
+        if (metadata_zero == constants.end() || metadata_zero->second != 0 ||
+            encoded == bitwise_ors.end())
+            continue;
+        const uint32_t pending = metadata_select->second.condition;
+        uint32_t active = 0;
+        bool encodes_event = false;
+        for (uint32_t encoded_part : {encoded->second.first, encoded->second.second}) {
+            const auto event_shift = shift_lefts.find(encoded_part);
+            const auto active_select = selects.find(encoded_part);
+            if (event_shift != shift_lefts.end()) {
+                const auto one = constants.find(event_shift->second.second);
+                encodes_event = encodes_event ||
+                    (event_shift->second.first == event_load &&
+                     one != constants.end() && one->second == 1);
+            }
+            if (active_select != selects.end()) {
+                const auto one = constants.find(active_select->second.yes);
+                const auto zero = constants.find(active_select->second.no);
+                if (loads.contains(active_select->second.condition) &&
+                    one != constants.end() && one->second == 1 &&
+                    zero != constants.end() && zero->second == 0)
+                    active = active_select->second.condition;
+            }
+        }
+        if (!encodes_event || !active || active == pending) continue;
+
+        // The selected source lane contributes an independent EXEC predicate.
+        uint32_t source_active = 0;
+        for (const auto& masked : bitwise_ands) {
+            uint32_t metadata = 0;
+            if (!literal_other(masked.second, 1, &metadata) ||
+                metadata != shifted_event.second.first)
+                continue;
+            for (const auto& comparison : not_equals) {
+                uint32_t compared = 0;
+                if (literal_other(comparison.second, 0, &compared) &&
+                    compared == masked.first) {
+                    source_active = comparison.first;
+                    break;
+                }
+            }
+            if (source_active) break;
+        }
+        if (!source_active) continue;
+
+        // The final condition must select the mailbox's physical destination as well.
+        uint32_t destination_match = 0;
+        for (const auto& equal : equals) {
+            uint32_t mailbox = 0;
+            if (!literal_other(equal.second, expected_dst, &mailbox) ||
+                !loads.contains(mailbox))
+                continue;
+            const uint32_t pointer = loads.at(mailbox).pointer;
+            const bool initialized_for_dst = std::any_of(
+                stores.begin(), stores.end(), [&](const Store& store) {
+                    const auto value = constants.find(store.value);
+                    return store.pointer == pointer && value != constants.end() &&
+                        value->second == expected_dst;
+                });
+            if (initialized_for_dst) {
+                destination_match = equal.first;
+                break;
+            }
+        }
+        if (!destination_match) continue;
+
+        auto guard_contains = [&](auto&& self, uint32_t root, uint32_t leaf) -> bool {
+            if (root == leaf) return true;
+            const auto logical_and = logical_ands.find(root);
+            return logical_and != logical_ands.end() &&
+                (self(self, logical_and->second.first, leaf) ||
+                 self(self, logical_and->second.second, leaf));
+        };
+        size_t persistent_store_position = 0;
+        bool preserves_old_vgpr = false;
+        for (const auto& selected : selects) {
+            if (selected.second.yes != add_result ||
+                !loads.contains(selected.second.no) ||
+                !guard_contains(guard_contains, selected.second.condition, pending) ||
+                !guard_contains(guard_contains, selected.second.condition, active) ||
+                !guard_contains(guard_contains, selected.second.condition,
+                                source_select->second.condition) ||
+                !guard_contains(guard_contains, selected.second.condition, source_active) ||
+                !guard_contains(guard_contains, selected.second.condition, event_match) ||
+                !guard_contains(guard_contains, selected.second.condition, destination_match))
+                continue;
+            const uint32_t old_pointer = loads.at(selected.second.no).pointer;
+            const uint32_t source_mailbox_pointer = loads.at(local_value).pointer;
+            const bool old_reaches_source_mailbox = std::any_of(
+                stores.begin(), stores.end(), [&](const Store& store) {
+                    const auto source = loads.find(store.value);
+                    return store.pointer == source_mailbox_pointer &&
+                        source != loads.end() && source->second.pointer == old_pointer;
+                });
+            if (old_reaches_source_mailbox &&
+                pointer_store(old_pointer, selected.first, &persistent_store_position)) {
+                preserves_old_vgpr = true;
+                break;
+            }
+        }
+        if (!preserves_old_vgpr) continue;
+
+        const size_t publish_end = std::max(value_publish, metadata_publish);
+        const auto first_barrier = std::find_if(
+            barriers.begin(), barriers.end(), [&](size_t position) {
+                return position > publish_end && position < metadata_load->second.position;
+            });
+        const auto second_barrier = std::find_if(
+            barriers.begin(), barriers.end(), [&](size_t position) {
+                return position > persistent_store_position;
+            });
+        if (first_barrier != barriers.end() && second_barrier != barriers.end()) return true;
+    }
+    return false;
+}
+
+// Trace the native exact-wave form independently of the portable scratch path. Each live ladder
+// amount must select lane-amount inside a DPP16 row, shuffle both the value and its EXEC bit, add
+// only for EXEC-active destinations with an in-bounds active source, and otherwise keep the old
+// in-place VGPR before that value is persisted by the dispatcher.
+bool compute_dpp_add_native_row_shr_updates_dispatch_vgpr(
+    const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpConstant = 43, OpLoad = 61, OpStore = 62,
+                       OpIAdd = 128, OpISub = 130, OpLogicalAnd = 167,
+                       OpSelect = 169, OpINotEqual = 171,
+                       OpUGreaterThanEqual = 174, OpBitwiseAnd = 199,
+                       OpGroupNonUniformShuffle = 345;
+    struct Binary { uint32_t first = 0, second = 0; };
+    struct Select { uint32_t condition = 0, yes = 0, no = 0; };
+    struct Shuffle { uint32_t value = 0, lane = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants, load_pointers;
+    std::unordered_map<uint32_t, Binary> iadds, isubs, logical_ands,
+                                                not_equals, greater_equals,
+                                                bitwise_ands;
+    std::unordered_map<uint32_t, Select> selects;
+    std::unordered_map<uint32_t, Shuffle> shuffles;
+    std::vector<std::array<uint32_t, 2>> stores;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4)
+            constants[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLoad && wc == 4)
+            load_pointers[spv[i + 2]] = spv[i + 3];
+        else if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2]});
+        else if (op == OpIAdd && wc == 5)
+            iadds[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpISub && wc == 5)
+            isubs[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpLogicalAnd && wc == 5)
+            logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpINotEqual && wc == 5)
+            not_equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpUGreaterThanEqual && wc == 5)
+            greater_equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpBitwiseAnd && wc == 5)
+            bitwise_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpSelect && wc == 6)
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+        else if (op == OpGroupNonUniformShuffle && wc == 6)
+            shuffles[spv[i + 2]] = {spv[i + 4], spv[i + 5]};
+        i += wc;
+    }
+
+    auto literal_other = [&](const Binary& binary, uint32_t literal,
+                             uint32_t* other) {
+        const auto first = constants.find(binary.first);
+        const auto second = constants.find(binary.second);
+        if (first != constants.end() && first->second == literal) {
+            if (other) *other = binary.second;
+            return true;
+        }
+        if (second != constants.end() && second->second == literal) {
+            if (other) *other = binary.first;
+            return true;
+        }
+        return false;
+    };
+    auto exact_and = [&](const Binary& binary, uint32_t first, uint32_t second) {
+        return (binary.first == first && binary.second == second) ||
+               (binary.first == second && binary.second == first);
+    };
+
+    std::unordered_set<uint32_t> proven_amounts;
+    for (const auto& value_shuffle : shuffles) {
+        const uint32_t source_value = value_shuffle.second.value;
+        if (!load_pointers.contains(source_value)) continue;
+        const auto source_lane = selects.find(value_shuffle.second.lane);
+        if (source_lane == selects.end()) continue;
+        const auto source_subtract = isubs.find(source_lane->second.yes);
+        const auto in_bounds = greater_equals.find(source_lane->second.condition);
+        if (source_subtract == isubs.end() || in_bounds == greater_equals.end() ||
+            source_lane->second.no != source_subtract->second.first ||
+            source_subtract->second.second != in_bounds->second.second)
+            continue;
+        const uint32_t lane = source_subtract->second.first;
+        const uint32_t amount_id = source_subtract->second.second;
+        const auto amount = constants.find(amount_id);
+        if (amount == constants.end() ||
+            (amount->second != 1 && amount->second != 2 &&
+             amount->second != 4 && amount->second != 8))
+            continue;
+        const auto row_lane = bitwise_ands.find(in_bounds->second.first);
+        uint32_t row_lane_source = 0;
+        if (row_lane == bitwise_ands.end() ||
+            !literal_other(row_lane->second, 15, &row_lane_source) ||
+            row_lane_source != lane)
+            continue;
+
+        uint32_t destination_active = 0, source_active = 0;
+        for (const auto& active_shuffle : shuffles) {
+            if (active_shuffle.second.lane != value_shuffle.second.lane) continue;
+            const auto active_encoding = selects.find(active_shuffle.second.value);
+            if (active_encoding == selects.end() ||
+                !load_pointers.contains(active_encoding->second.condition))
+                continue;
+            const auto one = constants.find(active_encoding->second.yes);
+            const auto zero = constants.find(active_encoding->second.no);
+            if (one == constants.end() || one->second != 1 ||
+                zero == constants.end() || zero->second != 0)
+                continue;
+            for (const auto& comparison : not_equals) {
+                uint32_t compared = 0;
+                if (literal_other(comparison.second, 0, &compared) &&
+                    compared == active_shuffle.first) {
+                    destination_active = active_encoding->second.condition;
+                    source_active = comparison.first;
+                    break;
+                }
+            }
+            if (source_active) break;
+        }
+        if (!destination_active || !source_active) continue;
+
+        uint32_t valid_source = 0;
+        for (const auto& logical_and : logical_ands) {
+            if (exact_and(logical_and.second, source_lane->second.condition, source_active)) {
+                valid_source = logical_and.first;
+                break;
+            }
+        }
+        if (!valid_source) continue;
+        uint32_t shifted_or_old = 0;
+        for (const auto& selected : selects) {
+            if (selected.second.condition == valid_source &&
+                selected.second.yes == value_shuffle.first &&
+                selected.second.no == source_value) {
+                shifted_or_old = selected.first;
+                break;
+            }
+        }
+        if (!shifted_or_old) continue;
+        uint32_t add_result = 0;
+        for (const auto& add : iadds) {
+            if (exact_and(add.second, source_value, shifted_or_old)) {
+                add_result = add.first;
+                break;
+            }
+        }
+        if (!add_result) continue;
+        uint32_t write = 0;
+        for (const auto& logical_and : logical_ands) {
+            if (exact_and(logical_and.second, destination_active, valid_source)) {
+                write = logical_and.first;
+                break;
+            }
+        }
+        if (!write) continue;
+        for (const auto& selected : selects) {
+            if (selected.second.condition != write || selected.second.yes != add_result ||
+                selected.second.no != source_value)
+                continue;
+            const uint32_t pointer = load_pointers.at(source_value);
+            if (std::any_of(stores.begin(), stores.end(), [&](const auto& store) {
+                    return store[0] == pointer && store[1] == selected.first;
+                })) {
+                proven_amounts.insert(amount->second);
+                break;
+            }
+        }
+    }
+    return proven_amounts == std::unordered_set<uint32_t>({1, 2, 4, 8});
+}
+
+// Prove the exact GTA V identity-QUAD_PERM lowering with ROW_MASK=0xa. The selected rows must
+// integer-add two distinct persistent VGPRs, while the other rows keep the old destination. This
+// traces the emitted values to their persistent store so mutations of the production row selector,
+// add operands, or BC0 fallback cannot be hidden by unrelated SPIR-V instructions.
+bool compute_dpp_add_partial_rows_updates_dispatch_vgpr(
+    const std::vector<uint32_t>& spv) {
+    constexpr uint32_t OpConstant = 43, OpLoad = 61, OpStore = 62,
+                       OpIAdd = 128, OpLogicalAnd = 167, OpSelect = 169,
+                       OpINotEqual = 171, OpShiftRightLogical = 194,
+                       OpShiftLeftLogical = 196, OpBitwiseAnd = 199;
+    struct Binary { uint32_t first = 0, second = 0; };
+    struct Select { uint32_t condition = 0, yes = 0, no = 0; };
+    std::unordered_map<uint32_t, uint32_t> constants, load_pointers;
+    std::unordered_map<uint32_t, Binary> iadds, logical_ands, not_equals,
+                                                shift_rights, shift_lefts, bitwise_ands;
+    std::unordered_map<uint32_t, Select> selects;
+    std::vector<std::array<uint32_t, 2>> stores;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpConstant && wc == 4)
+            constants[spv[i + 2]] = spv[i + 3];
+        else if (op == OpLoad && wc == 4)
+            load_pointers[spv[i + 2]] = spv[i + 3];
+        else if (op == OpStore && wc == 3)
+            stores.push_back({spv[i + 1], spv[i + 2]});
+        else if (op == OpIAdd && wc == 5)
+            iadds[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpLogicalAnd && wc == 5)
+            logical_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpINotEqual && wc == 5)
+            not_equals[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpShiftRightLogical && wc == 5)
+            shift_rights[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpShiftLeftLogical && wc == 5)
+            shift_lefts[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpBitwiseAnd && wc == 5)
+            bitwise_ands[spv[i + 2]] = {spv[i + 3], spv[i + 4]};
+        else if (op == OpSelect && wc == 6)
+            selects[spv[i + 2]] = {spv[i + 3], spv[i + 4], spv[i + 5]};
+        i += wc;
+    }
+
+    auto literal_other = [&](const Binary& binary, uint32_t literal,
+                             uint32_t* other) {
+        const auto first = constants.find(binary.first);
+        const auto second = constants.find(binary.second);
+        if (first != constants.end() && first->second == literal) {
+            if (other) *other = binary.second;
+            return true;
+        }
+        if (second != constants.end() && second->second == literal) {
+            if (other) *other = binary.first;
+            return true;
+        }
+        return false;
+    };
+
+    for (const auto& shift : shift_rights) {
+        const auto four = constants.find(shift.second.second);
+        if (four == constants.end() || four->second != 4) continue;
+        const auto lane_mask = bitwise_ands.find(shift.second.first);
+        if (lane_mask == bitwise_ands.end() ||
+            !literal_other(lane_mask->second, 63, nullptr))
+            continue;
+
+        uint32_t row_bit = 0;
+        for (const auto& left : shift_lefts) {
+            const auto one = constants.find(left.second.first);
+            if (one != constants.end() && one->second == 1 &&
+                left.second.second == shift.first) {
+                row_bit = left.first;
+                break;
+            }
+        }
+        if (!row_bit) continue;
+
+        uint32_t masked_rows = 0;
+        for (const auto& masked : bitwise_ands) {
+            uint32_t other = 0;
+            if (literal_other(masked.second, 0xa, &other) && other == row_bit) {
+                masked_rows = masked.first;
+                break;
+            }
+        }
+        if (!masked_rows) continue;
+
+        uint32_t row_selected = 0;
+        for (const auto& comparison : not_equals) {
+            uint32_t other = 0;
+            if (literal_other(comparison.second, 0, &other) && other == masked_rows) {
+                row_selected = comparison.first;
+                break;
+            }
+        }
+        if (!row_selected) continue;
+
+        std::unordered_set<uint32_t> row_guarded{row_selected};
+        bool changed = true;
+        while (changed) {
+            changed = false;
+            for (const auto& logical_and : logical_ands) {
+                if ((row_guarded.contains(logical_and.second.first) ||
+                     row_guarded.contains(logical_and.second.second)) &&
+                    row_guarded.insert(logical_and.first).second)
+                    changed = true;
+            }
+        }
+
+        for (const auto& selected : selects) {
+            if (!row_guarded.contains(selected.second.condition)) continue;
+            const auto add = iadds.find(selected.second.yes);
+            if (add == iadds.end() || selected.second.no != add->second.first) continue;
+            const auto old_load = load_pointers.find(add->second.first);
+            const auto addend_load = load_pointers.find(add->second.second);
+            if (old_load == load_pointers.end() || addend_load == load_pointers.end() ||
+                old_load->second == addend_load->second)
+                continue;
+            if (std::any_of(stores.begin(), stores.end(), [&](const auto& store) {
+                    return store[0] == old_load->second && store[1] == selected.first;
+                }))
+                return true;
+        }
+    }
+    return false;
+}
+
 // Trace IMAGE_GET_LOD all the way from two known VGPR bit patterns to the fragment output. This is
 // deliberately a dataflow check rather than an opcode-presence check: it proves coordinate
 // provenance, AMD/SPIR-V x/y component order, compact dmask-to-VDATA placement, and the EXEC select
@@ -1534,6 +2180,87 @@ int main() {
     portable_wave64_compute_config.local_x = 128;
     portable_wave64_compute_config.wave_size = 64;
 
+    // GTA V's two live compute failures use this exact in-place V_ADD_NC_U32 DPP row ladder. Two
+    // alternate copies let separate guest waves park at different static events, while the appended
+    // nested/backward CFG forces the portable dispatcher. The host-independent lowering must use
+    // workgroup scratch rather than assuming a Wave64-capable host subgroup.
+    std::vector<uint32_t> gta_compute_dpp_add_cfg = {
+        0x7e280281u,                         // pc0:  v_mov_b32 v20,1
+        0x7d840100u,                         // pc1:  v_cmp_eq_u32 vcc,v0,v0
+        0xbf860009u,                         // pc2:  alternate ladder -> pc12
+        0x4a2828fau, 0xff011114u,            // pc3:  event 1 row_shr:1
+        0x4a2828fau, 0xff011214u,            // pc5:  event 2 row_shr:2
+        0x4a2828fau, 0xff011414u,            // pc7:  event 3 row_shr:4
+        0x4a2828fau, 0xff011814u,            // pc9:  event 4 row_shr:8
+        0xbf820008u,                         // pc11: join -> pc20
+        0x4a2828fau, 0xff011114u,            // pc12: event 5 row_shr:1
+        0x4a2828fau, 0xff011214u,            // pc14: event 6 row_shr:2
+        0x4a2828fau, 0xff011414u,            // pc16: event 7 row_shr:4
+        0x4a2828fau, 0xff011814u,            // pc18: event 8 row_shr:8
+        // Reduced nested/backward compute CFG from the existing dispatcher coverage fixture.
+        0xbe800380u, 0x7e000280u, 0x7e020300u,
+        0xd7610013u, 0x00014a7eu, 0xd7610013u, 0x0001507fu,
+        0xd760000eu, 0x00014b13u, 0xd760000fu, 0x00015113u, 0xbefe040eu,
+        0xe00c2000u, 0x80020400u, 0x7db900f9u, 0x86050007u,
+        0x7d020200u, 0xbf860006u, 0xbf0a8204u, 0x360000fdu, 0xbf840001u,
+        0x81008100u, 0x81008100u, 0xbf82fff4u, 0xbf810000u,
+    };
+    ShaderResourceTable gta_compute_dpp_table;
+    ShaderResource gta_compute_dpp_vb{};
+    gta_compute_dpp_vb.cls = ResourceClass::VertexBuffer;
+    gta_compute_dpp_vb.binding = 3;
+    gta_compute_dpp_vb.sgpr_base = 8;
+    gta_compute_dpp_vb.stride = 16;
+    gta_compute_dpp_vb.format = DataFormat::Float32;
+    gta_compute_dpp_vb.num_components = 4;
+    gta_compute_dpp_table.resources.push_back(gta_compute_dpp_vb);
+    const auto gta_compute_dpp_spv = recompile_compute(
+        gta_compute_dpp_add_cfg.data(), gta_compute_dpp_add_cfg.size(),
+        &gta_compute_dpp_table, portable_wave64_compute_config);
+    if (gta_compute_dpp_spv.empty() || !has_opcode(gta_compute_dpp_spv, 251) ||
+        !compute_dpp_add_row_shr_updates_dispatch_vgpr(gta_compute_dpp_spv, 128, 20) ||
+        !type_result_ids_are_nonzero(gta_compute_dpp_spv, nullptr) ||
+        !phi_ids_are_nonzero(gta_compute_dpp_spv)) {
+        printf("  [FAIL] portable Wave64 CFG did not event-isolate GTA V DPP add ladders\n");
+        return 1;
+    }
+
+    ComputeShaderConfig native_gta_compute_dpp_config = portable_wave64_compute_config;
+    native_gta_compute_dpp_config.local_x = 64;
+    native_gta_compute_dpp_config.native_subgroup_size = 64;
+    const auto native_gta_compute_dpp_spv = recompile_compute(
+        gta_compute_dpp_add_cfg.data(), gta_compute_dpp_add_cfg.size(),
+        &gta_compute_dpp_table, native_gta_compute_dpp_config);
+    if (native_gta_compute_dpp_spv.empty() ||
+        !has_opcode(native_gta_compute_dpp_spv, 345) ||
+        !compute_dpp_add_native_row_shr_updates_dispatch_vgpr(
+            native_gta_compute_dpp_spv) ||
+        !type_result_ids_are_nonzero(native_gta_compute_dpp_spv, nullptr) ||
+        !phi_ids_are_nonzero(native_gta_compute_dpp_spv)) {
+        printf("  [FAIL] native Wave64 CFG rejected GTA V DPP add ladders\n");
+        return 1;
+    }
+
+    std::vector<uint32_t> gta_compute_dpp_distinct_source = gta_compute_dpp_add_cfg;
+    std::vector<uint32_t> gta_compute_dpp_bound_ctrl = gta_compute_dpp_add_cfg;
+    for (size_t word : {4u, 6u, 8u, 10u, 13u, 15u, 17u, 19u}) {
+        gta_compute_dpp_distinct_source[word] =
+            (gta_compute_dpp_distinct_source[word] & ~0xffu) | 0x15u; // SRC0=v21
+        gta_compute_dpp_bound_ctrl[word] |= 1u << 19u;
+    }
+    if (!recompile_compute(gta_compute_dpp_distinct_source.data(),
+                           gta_compute_dpp_distinct_source.size(),
+                           &gta_compute_dpp_table,
+                           portable_wave64_compute_config).empty() ||
+        !recompile_compute(gta_compute_dpp_bound_ctrl.data(),
+                           gta_compute_dpp_bound_ctrl.size(),
+                           &gta_compute_dpp_table,
+                           portable_wave64_compute_config).empty()) {
+        printf("  [FAIL] GTA V DPP add contract admitted distinct-source or BC1 mutations\n");
+        return 1;
+    }
+    printf("  [ok]   GTA V compute DPP add ladders preserve row direction, events, and BC0 VDST\n");
+
     // Syberia source 87 is a real 960x544 dispatch whose only generic-coverage rejects are eight
     // v_max3_f16 instructions. Keep the first exact low/high pair: OPSEL chooses different source
     // halves for each result and the second instruction writes the high destination half. The decode
@@ -1604,6 +2331,34 @@ int main() {
         printf("  [FAIL] live B64 mask SCC did not reach its crossing dispatcher branch\n");
         return 1;
     }
+
+    // GTA V follows its row reduction with this identity QUAD_PERM and partial ROW_MASK. Prefix the
+    // exact packet to the crossing CFG above so it reaches the dispatcher lowering used by the live
+    // shader. Rows 1/3 add distinct v19, rows 0/2 keep the old in-place v20 because BC is zero.
+    std::vector<uint32_t> gta_compute_dpp_partial_rows = {
+        0x7e280300u,                         // pc0: v_mov_b32 v20,v0
+        0x7e260301u,                         // pc1: v_mov_b32 v19,v1
+        0x4a2826fau, 0xaf00e414u,            // pc2: exact live identity DPP add, ROW_MASK=0xa
+    };
+    gta_compute_dpp_partial_rows.insert(
+        gta_compute_dpp_partial_rows.end(),
+        std::begin(wave64_compute_live_b64_mask_scc),
+        std::end(wave64_compute_live_b64_mask_scc));
+    gta_compute_dpp_partial_rows.back() = 0x7e000314u; // expose v20 through v0
+    gta_compute_dpp_partial_rows.push_back(0xbf810000u);
+    const auto gta_compute_dpp_partial_rows_spv = recompile_compute(
+        gta_compute_dpp_partial_rows.data(), gta_compute_dpp_partial_rows.size(), nullptr,
+        portable_wave64_compute_config);
+    if (gta_compute_dpp_partial_rows_spv.empty() ||
+        !has_opcode(gta_compute_dpp_partial_rows_spv, 251) ||
+        !compute_dpp_add_partial_rows_updates_dispatch_vgpr(
+            gta_compute_dpp_partial_rows_spv) ||
+        !type_result_ids_are_nonzero(gta_compute_dpp_partial_rows_spv, nullptr) ||
+        !phi_ids_are_nonzero(gta_compute_dpp_partial_rows_spv)) {
+        printf("  [FAIL] GTA V partial-row DPP add did not preserve masked dispatcher rows\n");
+        return 1;
+    }
+    printf("  [ok]   GTA V partial-row DPP add selects rows 1/3 and preserves BC0 VDST\n");
 
     // A later SOPC owns SCC, so the old mask producer must not be selected speculatively. The
     // crossing graph remains valid and branches on the ordinary scalar comparison.

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -4906,48 +4906,73 @@ int main() {
     }
     printf("  [ok]   compute atomic-buffer view rejects compressed and mip-tail images\n");
 
-    // Astro Bot's world-map traversal kernel uses the RTIP 1.1 BVH instruction with eleven NSA
-    // address operands. It is lowered to ordinary SSBO loads and scalar ALU, so this remains usable
-    // on Vulkan devices without a ray-query feature. Keep the gate exact: accepting a nearby MIMG
-    // flag combination would silently assign the wrong hardware intersection contract.
-    const uint32_t cs_bvh_intersect[] = {
-        0xf1989f07u, 0x00040303u, 0x43440d3fu, 0x46424140u, 0x00004847u,
+    // GTA V's program 0x205b5e8600 uses the supported RTIP 1.1 BVH instruction at exact pc 1476
+    // with eleven NSA address operands and a 64-byte descriptor. It is lowered to ordinary SSBO
+    // loads and scalar ALU, so this remains usable on Vulkan devices without a ray-query feature.
+    // Keep the gate exact: accepting a nearby MIMG flag combination would silently assign the wrong
+    // hardware intersection contract.
+    constexpr uint32_t gta_bvh_pc = 1476u;
+    std::vector<uint32_t> cs_bvh_intersect(gta_bvh_pc, 0xbf800000u); // s_nop 0
+    const uint32_t gta_bvh_packet[] = {
+        0xf1989f07u, 0x00060202u, 0x28292c23u, 0x22262725u, 0x00002a24u,
         0xbf810000u,
     };
-    uint32_t bvh_node_words[32]{};
+    cs_bvh_intersect.insert(cs_bvh_intersect.end(), std::begin(gta_bvh_packet),
+                            std::end(gta_bvh_packet));
+    uint32_t bvh_node_words[16]{};
     ShaderResourceTable rt_bvh;
     { ShaderResource bvh{}; bvh.cls = ResourceClass::ConstantBuffer;
       bvh.format = DataFormat::Uint32; bvh.num_components = 1;
-      bvh.binding = 4; bvh.size = sizeof(bvh_node_words); bvh.fetch_pc = 0;
+      bvh.binding = 4; bvh.size = sizeof(bvh_node_words); bvh.fetch_pc = gta_bvh_pc;
       bvh.host_data = reinterpret_cast<uint8_t*>(bvh_node_words);
       bvh.host_data_size = sizeof(bvh_node_words); rt_bvh.resources.push_back(bvh); }
     ComputeShaderConfig bvh_config;
     bvh_config.local_x = 1;
     const std::vector<uint32_t> bvh_spv = recompile_compute(
-        cs_bvh_intersect, std::size(cs_bvh_intersect), &rt_bvh, bvh_config);
+        cs_bvh_intersect.data(), cs_bvh_intersect.size(), &rt_bvh, bvh_config);
     const DescriptorValidationReport bvh_report = validate_spirv_descriptor_interface(
         bvh_spv, &rt_bvh, 0, SpirvShaderStage::Compute, false);
     if (bvh_spv.empty() || !bvh_report.ok() || bvh_report.descriptors.size() != 1 ||
         bvh_report.descriptors[0].kind != SpirvDescriptorKind::StorageBuffer ||
         !has_opcode(bvh_spv, 61u) || !has_opcode(bvh_spv, 129u) ||
         !has_opcode(bvh_spv, 133u) || !has_opcode(bvh_spv, 169u)) {
-        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY lacks its SSBO/ALU lowering\n");
+        printf("  [FAIL] GTA's 64-byte IMAGE_BVH_INTERSECT_RAY lacks its SSBO/ALU lowering\n");
         return 1;
     }
-    if (!recompile_compute(cs_bvh_intersect, std::size(cs_bvh_intersect),
+    if (!recompile_compute(cs_bvh_intersect.data(), cs_bvh_intersect.size(),
                            nullptr, bvh_config).empty()) {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY was accepted without its BVH bytes\n");
         return 1;
     }
-    uint32_t unsupported_bvh[std::size(cs_bvh_intersect)];
-    std::copy(std::begin(cs_bvh_intersect), std::end(cs_bvh_intersect), unsupported_bvh);
-    unsupported_bvh[0] &= ~(1u << 15); // R128=0 has a different destination contract.
-    if (!recompile_compute(unsupported_bvh, std::size(unsupported_bvh),
+    std::vector<uint32_t> unsupported_bvh = cs_bvh_intersect;
+    unsupported_bvh[gta_bvh_pc] &= ~(1u << 15); // R128=0 has a different destination contract.
+    if (!recompile_compute(unsupported_bvh.data(), unsupported_bvh.size(),
                            &rt_bvh, bvh_config).empty()) {
         printf("  [FAIL] unverified IMAGE_BVH_INTERSECT_RAY flags were accepted\n");
         return 1;
     }
-    printf("  [ok]   Astro IMAGE_BVH_INTERSECT_RAY lowers through a bounded BVH SSBO\n");
+    ShaderResourceTable short_bvh = rt_bvh;
+    short_bvh.resources[0].size = 60u;
+    if (!recompile_compute(cs_bvh_intersect.data(), cs_bvh_intersect.size(),
+                           &short_bvh, bvh_config).empty()) {
+        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY accepted a sub-64-byte BVH\n");
+        return 1;
+    }
+    ShaderResourceTable misaligned_bvh = rt_bvh;
+    misaligned_bvh.resources[0].size = 66u;
+    if (!recompile_compute(cs_bvh_intersect.data(), cs_bvh_intersect.size(),
+                           &misaligned_bvh, bvh_config).empty()) {
+        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY accepted a non-dword-aligned BVH\n");
+        return 1;
+    }
+    ShaderResourceTable wrong_class_bvh = rt_bvh;
+    wrong_class_bvh.resources[0].cls = ResourceClass::VertexBuffer;
+    if (!recompile_compute(cs_bvh_intersect.data(), cs_bvh_intersect.size(),
+                           &wrong_class_bvh, bvh_config).empty()) {
+        printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY accepted a non-constant-buffer resource\n");
+        return 1;
+    }
+    printf("  [ok]   GTA's exact-pc 64-byte IMAGE_BVH_INTERSECT_RAY lowers through a bounded BVH SSBO\n");
 
     // Astro Bot's visibility kernel sanitizes a generated coordinate with an explicit-SDST
     // v_cmp_class_f32 SDWA (mask 3 = sNaN|qNaN), followed by v_cndmask reading s[8:9]. Rejecting

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1200,6 +1200,71 @@ int main() {
     }
     printf("  [ok]   explicit Wave32 VCC_HI cndmask requires its own unambiguous mask\n");
 
+    // GTA V's rejected Wave32 compute siblings produce a fresh VCC_LO carry at PC79 with the
+    // no-carry-in VOP3B family, then consume it at PC83 through implicit VCC. A later crossing CFG
+    // forces the portable arbitrary-CFG dispatcher, which must carry that one-word mask lifetime
+    // through its production dataflow instead of classifying the VOP3B SDST as a two-word mask.
+    // A second fresh carry targets ordinary s4 and narrows/restores EXEC through the explicit B32
+    // saveexec domain before another implicit consumer. That operation pins the emitter's runtime
+    // `sreg_bool_b32` state: merely updating static dispatcher provenance or the legacy `rs.vcc`
+    // shortcut cannot pass it.
+    const uint32_t wave32_compute_fresh_carry_cfg[] = {
+        0x7d840000u,                         // pc0: one incoming VCC mask lifetime
+        0xbf060000u,                         // pc1: scalar branch condition
+        0xbf840001u,                         // pc2: one edge skips the scalar-data lifetime
+        0xbeea0385u,                         // pc3: other edge recycles vcc_lo as scalar data
+        0x7e0202c1u,                         // pc4: v_mov_b32_e32 v1, -1
+        0xd70f6a02u, 0x00020300u,            // pc5: v_add_co_u32 v2,vcc_lo,v0,v1
+        0x50060080u,                         // pc7: v_add_co_ci_u32 v3,vcc_lo,0,v0,vcc_lo
+        0xd70f0402u, 0x00020300u,            // pc8: fresh carry -> ordinary s4 B32 mask
+        0xbe863c04u,                         // pc10: s_and_saveexec_b32 s6, s4
+        0xbefe0306u,                         // pc11: s_mov_b32 exec_lo, s6 (restore)
+        0xbeea0304u,                         // pc12: s_mov_b32 vcc_lo, s4 (explicit mask copy)
+        0x50060080u,                         // pc13: consume the copied mask through implicit VCC
+        0x7e040280u,                         // pc14: v_mov_b32_e32 v2, 0
+        0x7c020300u,                         // pc15: v_cmp_lt_u32_e32 vcc, v0, v1
+        0xbf860001u,                         // pc16: s_cbranch_vccz -> pc18
+        0x7e040281u,                         // pc17: v_mov_b32_e32 v2, 1
+        0x7d840100u,                         // pc18: v_cmp_eq_u32_e32 vcc, v0, v0
+        0xbf870001u,                         // pc19: s_cbranch_vccnz -> pc21
+        0xbf82fffdu,                         // pc20: s_branch -> pc18
+        0x7e040d02u,                         // pc21: v_mov_b32_e32 v2, v2
+        0xbf810000u,
+    };
+    ComputeShaderConfig wave32_carry_cfg_config;
+    wave32_carry_cfg_config.wave_size = 32;
+    wave32_carry_cfg_config.local_x = 64;
+    wave32_carry_cfg_config.native_subgroup_size = 0;
+    const auto fresh_carry_cfg_spv = recompile_compute(
+        wave32_compute_fresh_carry_cfg, std::size(wave32_compute_fresh_carry_cfg), nullptr,
+        wave32_carry_cfg_config);
+    if (fresh_carry_cfg_spv.empty() || !has_opcode(fresh_carry_cfg_spv, 251) ||
+        !type_result_ids_are_nonzero(fresh_carry_cfg_spv, nullptr) ||
+        !phi_ids_are_nonzero(fresh_carry_cfg_spv)) {
+        printf("  [FAIL] Wave32 CFG lost a fresh VOP3B carry before its implicit VCC consumer\n");
+        return 1;
+    }
+    std::vector<uint32_t> fresh_carry_wrong_sdst(
+        std::begin(wave32_compute_fresh_carry_cfg),
+        std::end(wave32_compute_fresh_carry_cfg));
+    fresh_carry_wrong_sdst[5] = 0xd70f0402u; // same producer writes s4, not consumed VCC_LO
+    if (!recompile_compute(fresh_carry_wrong_sdst.data(), fresh_carry_wrong_sdst.size(), nullptr,
+                           wave32_carry_cfg_config).empty()) {
+        printf("  [FAIL] Wave32 CFG accepted an implicit VCC consumer without its carry producer\n");
+        return 1;
+    }
+    std::vector<uint32_t> fresh_carry_tracked_wrong_sdst(
+        std::begin(wave32_compute_fresh_carry_cfg),
+        std::end(wave32_compute_fresh_carry_cfg));
+    fresh_carry_tracked_wrong_sdst[8] = 0xd70f0602u; // producer writes s6; copy still reads s4
+    if (!recompile_compute(fresh_carry_tracked_wrong_sdst.data(),
+                           fresh_carry_tracked_wrong_sdst.size(), nullptr,
+                           wave32_carry_cfg_config).empty()) {
+        printf("  [FAIL] Wave32 CFG accepted an explicit B32 copy from the wrong carry SDST\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 CFG tracks fresh VOP3B carry output at its exact SDST\n");
+
     // Exact control/data lifetime from Astro Bot's world-map phase, reduced only to its register-
     // independent instructions: a scalar-data VCC_LO lifetime feeds CMPX (which changes EXEC but
     // preserves VCC), one crossing arm defines and immediately consumes a fresh VCC mask, and the

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1860,6 +1860,45 @@ int main() {
     }
     printf("  [ok]   explicit Wave32 VCC_HI cndmask requires its own unambiguous mask\n");
 
+    // GTA V's live Wave32 kernel reaches the exact v_add_co_u32 packet below after joining a path
+    // where s0 is a VOPC mask with one where it is scalar data. The instruction has no carry-in:
+    // dword1's zero SRC2 field is reserved/non-operand bits, not an architectural read of s0. It
+    // replaces that ambiguous lifetime with a fresh carry in s0, which the exact later _co_ci_
+    // packet legitimately consumes. The irreducible tail forces the same portable CFG dispatcher
+    // that diagnosed the production kernel at this site.
+    const uint32_t wave32_compute_vop3b_two_source_join[] = {
+        0x7d8a06f9u, 0x06868080u,            // pc0: exact VOPC SDWA packet -> s0 mask
+        0xbf060000u,                         // pc2: scalar branch condition
+        0xbf840001u,                         // pc3: one edge retains the s0 mask
+        0xbe800380u,                         // pc4: other edge replaces s0 with scalar data
+        0xd70f0016u, 0x00021f1bu,            // pc5: exact v_add_co_u32 v22,s0,v27,v15
+        0xd5286a17u, 0x00024080u,            // pc7: exact v_add_co_ci_u32 consumes s0
+        0x7e040280u,                         // pc9: irreducible crossing-CFG tail
+        0x7c020300u,                         // pc10: v_cmp_lt_u32_e32 vcc, v0, v1
+        0xbf860001u,                         // pc11: s_cbranch_vccz -> pc13
+        0x7e040281u,                         // pc12: v_mov_b32_e32 v2, 1
+        0x7d840100u,                         // pc13: v_cmp_eq_u32_e32 vcc, v0, v0
+        0xbf870001u,                         // pc14: s_cbranch_vccnz -> pc16
+        0xbf82fffdu,                         // pc15: s_branch -> pc13
+        0x7e040d02u,                         // pc16: v_mov_b32_e32 v2, v2
+        0xbf810000u,
+    };
+    ComputeShaderConfig wave32_vop3b_two_source_config;
+    wave32_vop3b_two_source_config.wave_size = 32;
+    wave32_vop3b_two_source_config.local_x = 64;
+    wave32_vop3b_two_source_config.native_subgroup_size = 0;
+    const auto vop3b_two_source_join_spv = recompile_compute(
+        wave32_compute_vop3b_two_source_join,
+        std::size(wave32_compute_vop3b_two_source_join), nullptr,
+        wave32_vop3b_two_source_config);
+    if (vop3b_two_source_join_spv.empty() || !has_opcode(vop3b_two_source_join_spv, 251) ||
+        !type_result_ids_are_nonzero(vop3b_two_source_join_spv, nullptr) ||
+        !phi_ids_are_nonzero(vop3b_two_source_join_spv)) {
+        printf("  [FAIL] Wave32 CFG treated two-source VOP3B carry output as reading SRC2\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 CFG admits exact two-source VOP3B carry packet at an s0 join\n");
+
     // GTA V's rejected Wave32 compute siblings produce a fresh VCC_LO carry at PC79 with the
     // no-carry-in VOP3B family, then consume it at PC83 through implicit VCC. A later crossing CFG
     // forces the portable arbitrary-CFG dispatcher, which must carry that one-word mask lifetime

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -4426,6 +4426,137 @@ int main() {
     }
     printf("  [ok]   compute-shell image_sample lowers to OpImageSampleExplicitLod (LOD 0)\n");
 
+    // GTA V gameplay's exact single-level IMAGE_LOAD_MIP / IMAGE_STORE_MIP subset. The resource
+    // marker is the independent materialization proof; removing it, changing the descriptor to DCC,
+    // or changing the storage classification must reject instead of silently treating mip as zero.
+    constexpr uint32_t OpImageFetch = 95, OpImageWrite = 99;
+    const uint32_t gta_load_mip_2d[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7 (production fold proves zero)
+        0xf0043f08u, 0x00050000u,            // IMAGE_LOAD_MIP xyzw 2D, T# s[20:27]
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_zero_mip_2d;
+    { ShaderResource texture{}; texture.cls = ResourceClass::Texture;
+      texture.format = DataFormat::Uint32; texture.num_components = 1;
+      texture.binding = 4; texture.fetch_pc = 1; texture.img_dim = 1;
+      texture.width = 4; texture.height = 4; texture.depth = 1; texture.size = 64;
+      texture.proven_zero_mip = true; rt_zero_mip_2d.resources.push_back(texture); }
+    const std::vector<uint32_t> gta_load_mip_spv = recompile_valu(
+        gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0, &rt_zero_mip_2d);
+    if (gta_load_mip_spv.empty() || !has_opcode(gta_load_mip_spv, OpImageFetch)) {
+        printf("  [FAIL] proven GTA V IMAGE_LOAD_MIP 2D did not lower to OpImageFetch\n");
+        return 1;
+    }
+    ShaderResourceTable unproven_load_mip = rt_zero_mip_2d;
+    unproven_load_mip.resources[0].proven_zero_mip = false;
+    ShaderResourceTable compressed_load_mip = rt_zero_mip_2d;
+    compressed_load_mip.resources[0].compression_enabled = true;
+    ShaderResourceTable multilevel_load_mip = rt_zero_mip_2d;
+    multilevel_load_mip.resources[0].declared_mip_levels = 2;
+    if (!recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
+                        &unproven_load_mip).empty() ||
+        !recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
+                        &compressed_load_mip).empty() ||
+        !recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
+                        &multilevel_load_mip).empty()) {
+        printf("  [FAIL] IMAGE_LOAD_MIP accepted an unproven, DCC, or multilevel resource\n");
+        return 1;
+    }
+    printf("  [ok]   IMAGE_LOAD_MIP 2D requires the exact one-level uncompressed proof\n");
+
+    const uint32_t gta_load_mip_2da[] = {
+        0x7e060206u,                         // v_mov_b32 v3, s6; v2 remains the slice
+        0xf0043128u, 0x00050000u,            // IMAGE_LOAD_MIP 2D_ARRAY
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_zero_mip_2da = rt_zero_mip_2d;
+    rt_zero_mip_2da.resources[0].img_dim = 5;
+    rt_zero_mip_2da.resources[0].depth = 2;
+    rt_zero_mip_2da.resources[0].size = 128;
+    const std::vector<uint32_t> gta_load_mip_array_spv = recompile_valu(
+        gta_load_mip_2da, std::size(gta_load_mip_2da), 1, 0, &rt_zero_mip_2da);
+    const DescriptorValidationReport gta_load_mip_array_report =
+        validate_spirv_descriptor_interface(
+            gta_load_mip_array_spv, &rt_zero_mip_2da, 0, SpirvShaderStage::Compute);
+    const SpirvDescriptorBinding* gta_load_mip_array_descriptor = nullptr;
+    for (const auto& descriptor : gta_load_mip_array_report.descriptors)
+        if (descriptor.binding == 4u) gta_load_mip_array_descriptor = &descriptor;
+    if (gta_load_mip_array_spv.empty() || !has_opcode(gta_load_mip_array_spv, OpImageFetch) ||
+        !gta_load_mip_array_descriptor || !gta_load_mip_array_descriptor->image_arrayed) {
+        printf("  [FAIL] IMAGE_LOAD_MIP 2D_ARRAY dropped its slice/view contract\n");
+        return 1;
+    }
+    printf("  [ok]   IMAGE_LOAD_MIP 2D_ARRAY preserves its slice in an arrayed OpImageFetch\n");
+
+    const uint32_t gta_store_mip_2d[] = {
+        0x7e0a0206u,                         // v_mov_b32 v5, s6 (production fold proves zero)
+        0xf024310au, 0x00030004u, 0x00000503u,
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_zero_store_mip;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+      image.format = DataFormat::Uint32; image.num_components = 1;
+      image.binding = 4; image.fetch_pc = 1; image.img_dim = 1;
+      image.width = 4; image.height = 4; image.depth = 1; image.size = 64;
+      image.proven_zero_mip = true; rt_zero_store_mip.resources.push_back(image); }
+    const std::vector<uint32_t> gta_store_mip_spv = recompile_valu(
+        gta_store_mip_2d, std::size(gta_store_mip_2d), 1, 0, &rt_zero_store_mip);
+    ShaderResourceTable misclassified_store_mip = rt_zero_store_mip;
+    misclassified_store_mip.resources[0].cls = ResourceClass::Texture;
+    ShaderResourceTable unproven_store_mip = rt_zero_store_mip;
+    unproven_store_mip.resources[0].proven_zero_mip = false;
+    std::array<uint32_t, std::size(gta_store_mip_2d)> changed_store_packet{};
+    std::copy(std::begin(gta_store_mip_2d), std::end(gta_store_mip_2d),
+              changed_store_packet.begin());
+    changed_store_packet[1] &= ~0x2000u;     // same instruction loses GLC: no longer audited shape
+    if (gta_store_mip_spv.empty() || !has_opcode(gta_store_mip_spv, OpImageWrite) ||
+        !recompile_valu(gta_store_mip_2d, std::size(gta_store_mip_2d), 1, 0,
+                        &misclassified_store_mip).empty() ||
+        !recompile_valu(gta_store_mip_2d, std::size(gta_store_mip_2d), 1, 0,
+                        &unproven_store_mip).empty() ||
+        !recompile_valu(changed_store_packet.data(), changed_store_packet.size(), 1, 0,
+                        &rt_zero_store_mip).empty()) {
+        printf("  [FAIL] IMAGE_STORE_MIP lowering/classification/packet gate drifted\n");
+        return 1;
+    }
+    printf("  [ok]   IMAGE_STORE_MIP requires storage classification and its exact proven packet\n");
+
+    const uint32_t gta_store_mip_xyzw_2d[] = {
+        0x7e0c0206u,                         // v_mov_b32 v6, s6
+        0xf0243f0au, 0x00030005u, 0x00000604u, // live pc17: v[0:3], (v5,v4), mip v6
+        0xbf810000u,
+    };
+    ShaderResourceTable rt_zero_store_mip_xyzw = rt_zero_store_mip;
+    rt_zero_store_mip_xyzw.resources[0].format = DataFormat::Uint8;
+    rt_zero_store_mip_xyzw.resources[0].num_components = 4;
+    const std::vector<uint32_t> gta_store_mip_xyzw_spv = recompile_valu(
+        gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d), 1, 0,
+        &rt_zero_store_mip_xyzw);
+    ShaderResourceTable wrong_format_store_mip = rt_zero_store_mip_xyzw;
+    wrong_format_store_mip.resources[0].format = DataFormat::Uint32;
+    ShaderResourceTable compressed_store_mip = rt_zero_store_mip_xyzw;
+    compressed_store_mip.resources[0].compression_enabled = true;
+    ShaderResourceTable multilevel_store_mip = rt_zero_store_mip_xyzw;
+    multilevel_store_mip.resources[0].declared_mip_levels = 2;
+    std::array<uint32_t, std::size(gta_store_mip_xyzw_2d)> partial_store_packet{};
+    std::copy(std::begin(gta_store_mip_xyzw_2d), std::end(gta_store_mip_xyzw_2d),
+              partial_store_packet.begin());
+    partial_store_packet[1] = (partial_store_packet[1] & ~0xf00u) | 0x300u;
+    if (gta_store_mip_xyzw_spv.empty() ||
+        !has_opcode(gta_store_mip_xyzw_spv, OpImageWrite) ||
+        !recompile_valu(gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d), 1, 0,
+                        &wrong_format_store_mip).empty() ||
+        !recompile_valu(gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d), 1, 0,
+                        &compressed_store_mip).empty() ||
+        !recompile_valu(gta_store_mip_xyzw_2d, std::size(gta_store_mip_xyzw_2d), 1, 0,
+                        &multilevel_store_mip).empty() ||
+        !recompile_valu(partial_store_packet.data(), partial_store_packet.size(), 1, 0,
+                        &rt_zero_store_mip_xyzw).empty()) {
+        printf("  [FAIL] live dmask-xyzw IMAGE_STORE_MIP widened past its exact format/safety gate\n");
+        return 1;
+    }
+    printf("  [ok]   live dmask-xyzw IMAGE_STORE_MIP keeps exact format/DCC/mip/dmask gates\n");
+
     // Vertex shell: image_sample then export the result as the position.
     const uint32_t vs_sample[] = { 0xf0800f08u, 0x00820000u, 0xf80008cfu, 0x03020100u, 0xbf810000u };
     std::vector<uint32_t> vsspv = recompile_vertex(vs_sample, sizeof(vs_sample)/sizeof(vs_sample[0]), &rt_tex);

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -89,20 +89,6 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
-// Whether the module contains the requested GLSL.std.450 extended instruction number.
-bool has_glsl_ext_inst(const std::vector<uint32_t>& spv, uint32_t instruction) {
-    constexpr uint32_t OpExtInst = 12;
-    if (spv.size() < 5) return false;
-    for (size_t i = 5; i < spv.size();) {
-        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
-        if (!wc || i + wc > spv.size()) return false;
-        // OpExtInst operands: result type, result, instruction set, instruction, operands...
-        if (op == OpExtInst && wc >= 6 && spv[i + 4] == instruction) return true;
-        i += wc;
-    }
-    return false;
-}
-
 uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
     uint32_t count = 0;
     if (spv.size() < 5) return count;
@@ -2384,38 +2370,6 @@ int main() {
         printf("  [FAIL] live B64 mask SCC did not reach its crossing dispatcher branch\n");
         return 1;
     }
-
-    // GTA V's compute culling kernels execute this exact in-place V_FFBH_U32 e32 packet inside
-    // crossing control flow. Replace the SCC-preserving VALU in the proven Wave64 dispatcher
-    // fixture, retaining every branch offset, and require the real FindUMsb lowering to be present.
-    std::vector<uint32_t> gta_compute_ffbh_cfg(
-        std::begin(wave64_compute_live_b64_mask_scc),
-        std::end(wave64_compute_live_b64_mask_scc));
-    gta_compute_ffbh_cfg[5] = 0x7e087304u; // exact live v_ffbh_u32_e32 v4,v4
-    const auto gta_compute_ffbh_cfg_spv = recompile_compute(
-        gta_compute_ffbh_cfg.data(), gta_compute_ffbh_cfg.size(), nullptr,
-        portable_wave64_compute_config);
-    if (gta_compute_ffbh_cfg_spv.empty() ||
-        !has_opcode(gta_compute_ffbh_cfg_spv, 251) || // arbitrary CFG dispatcher
-        !has_glsl_ext_inst(gta_compute_ffbh_cfg_spv, 75) || // FindUMsb
-        !type_result_ids_are_nonzero(gta_compute_ffbh_cfg_spv, nullptr) ||
-        !phi_ids_are_nonzero(gta_compute_ffbh_cfg_spv)) {
-        printf("  [FAIL] GTA V v_ffbh_u32 did not lower inside crossing Wave64 compute CFG\n");
-        return 1;
-    }
-
-    // SDWA source NEG is deliberately outside this plain-e32 admission. Without the gate the
-    // generic VOP1 prologue would negate in the f32 domain before the integer FFBH operation.
-    const uint32_t ffbh_sdwa_neg[] = {
-        0x7e0872f9u, 0x00160604u,             // v_ffbh_u32_sdwa v4,v4 dst:dword src:dword neg
-        0xbf810000u,
-    };
-    if (!recompile_compute(ffbh_sdwa_neg, std::size(ffbh_sdwa_neg), nullptr,
-                           portable_wave64_compute_config).empty()) {
-        printf("  [FAIL] v_ffbh_u32 admitted unsupported SDWA source NEG\n");
-        return 1;
-    }
-    printf("  [ok]   GTA V v_ffbh_u32 lowers in crossing Wave64 CFG; SDWA NEG stays rejected\n");
 
     // GTA V follows its row reduction with this identity QUAD_PERM and partial ROW_MASK. Prefix the
     // exact packet to the crossing CFG above so it reaches the dispatcher lowering used by the live

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -89,6 +89,20 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+// Whether the module contains the requested GLSL.std.450 extended instruction number.
+bool has_glsl_ext_inst(const std::vector<uint32_t>& spv, uint32_t instruction) {
+    constexpr uint32_t OpExtInst = 12;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        // OpExtInst operands: result type, result, instruction set, instruction, operands...
+        if (op == OpExtInst && wc >= 6 && spv[i + 4] == instruction) return true;
+        i += wc;
+    }
+    return false;
+}
+
 uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
     uint32_t count = 0;
     if (spv.size() < 5) return count;
@@ -2331,6 +2345,38 @@ int main() {
         printf("  [FAIL] live B64 mask SCC did not reach its crossing dispatcher branch\n");
         return 1;
     }
+
+    // GTA V's compute culling kernels execute this exact in-place V_FFBH_U32 e32 packet inside
+    // crossing control flow. Replace the SCC-preserving VALU in the proven Wave64 dispatcher
+    // fixture, retaining every branch offset, and require the real FindUMsb lowering to be present.
+    std::vector<uint32_t> gta_compute_ffbh_cfg(
+        std::begin(wave64_compute_live_b64_mask_scc),
+        std::end(wave64_compute_live_b64_mask_scc));
+    gta_compute_ffbh_cfg[5] = 0x7e087304u; // exact live v_ffbh_u32_e32 v4,v4
+    const auto gta_compute_ffbh_cfg_spv = recompile_compute(
+        gta_compute_ffbh_cfg.data(), gta_compute_ffbh_cfg.size(), nullptr,
+        portable_wave64_compute_config);
+    if (gta_compute_ffbh_cfg_spv.empty() ||
+        !has_opcode(gta_compute_ffbh_cfg_spv, 251) || // arbitrary CFG dispatcher
+        !has_glsl_ext_inst(gta_compute_ffbh_cfg_spv, 75) || // FindUMsb
+        !type_result_ids_are_nonzero(gta_compute_ffbh_cfg_spv, nullptr) ||
+        !phi_ids_are_nonzero(gta_compute_ffbh_cfg_spv)) {
+        printf("  [FAIL] GTA V v_ffbh_u32 did not lower inside crossing Wave64 compute CFG\n");
+        return 1;
+    }
+
+    // SDWA source NEG is deliberately outside this plain-e32 admission. Without the gate the
+    // generic VOP1 prologue would negate in the f32 domain before the integer FFBH operation.
+    const uint32_t ffbh_sdwa_neg[] = {
+        0x7e0872f9u, 0x00160604u,             // v_ffbh_u32_sdwa v4,v4 dst:dword src:dword neg
+        0xbf810000u,
+    };
+    if (!recompile_compute(ffbh_sdwa_neg, std::size(ffbh_sdwa_neg), nullptr,
+                           portable_wave64_compute_config).empty()) {
+        printf("  [FAIL] v_ffbh_u32 admitted unsupported SDWA source NEG\n");
+        return 1;
+    }
+    printf("  [ok]   GTA V v_ffbh_u32 lowers in crossing Wave64 CFG; SDWA NEG stays rejected\n");
 
     // GTA V follows its row reduction with this identity QUAD_PERM and partial ROW_MASK. Prefix the
     // exact packet to the crossing CFG above so it reaches the dispatcher lowering used by the live

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -89,6 +89,20 @@ bool has_opcode(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return false;
 }
 
+// Whether the module contains the requested GLSL.std.450 extended instruction number.
+bool has_glsl_ext_inst(const std::vector<uint32_t>& spv, uint32_t instruction) {
+    constexpr uint32_t OpExtInst = 12;
+    if (spv.size() < 5) return false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        // OpExtInst operands: result type, result, instruction set, instruction, operands...
+        if (op == OpExtInst && wc >= 6 && spv[i + 4] == instruction) return true;
+        i += wc;
+    }
+    return false;
+}
+
 uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
     uint32_t count = 0;
     if (spv.size() < 5) return count;
@@ -2435,6 +2449,38 @@ int main() {
         printf("  [FAIL] live B64 mask SCC did not reach its crossing dispatcher branch\n");
         return 1;
     }
+
+    // GTA V's compute culling kernels execute this exact in-place V_FFBH_U32 e32 packet inside
+    // crossing control flow. Replace the SCC-preserving VALU in the proven Wave64 dispatcher
+    // fixture, retaining every branch offset, and require the real FindUMsb lowering to be present.
+    std::vector<uint32_t> gta_compute_ffbh_cfg(
+        std::begin(wave64_compute_live_b64_mask_scc),
+        std::end(wave64_compute_live_b64_mask_scc));
+    gta_compute_ffbh_cfg[5] = 0x7e087304u; // exact live v_ffbh_u32_e32 v4,v4
+    const auto gta_compute_ffbh_cfg_spv = recompile_compute(
+        gta_compute_ffbh_cfg.data(), gta_compute_ffbh_cfg.size(), nullptr,
+        portable_wave64_compute_config);
+    if (gta_compute_ffbh_cfg_spv.empty() ||
+        !has_opcode(gta_compute_ffbh_cfg_spv, 251) || // arbitrary CFG dispatcher
+        !has_glsl_ext_inst(gta_compute_ffbh_cfg_spv, 75) || // FindUMsb
+        !type_result_ids_are_nonzero(gta_compute_ffbh_cfg_spv, nullptr) ||
+        !phi_ids_are_nonzero(gta_compute_ffbh_cfg_spv)) {
+        printf("  [FAIL] GTA V v_ffbh_u32 did not lower inside crossing Wave64 compute CFG\n");
+        return 1;
+    }
+
+    // SDWA source NEG is deliberately outside this plain-e32 admission. Without the gate the
+    // generic VOP1 prologue would negate in the f32 domain before the integer FFBH operation.
+    const uint32_t ffbh_sdwa_neg[] = {
+        0x7e0872f9u, 0x00160604u,             // v_ffbh_u32_sdwa v4,v4 dst:dword src:dword neg
+        0xbf810000u,
+    };
+    if (!recompile_compute(ffbh_sdwa_neg, std::size(ffbh_sdwa_neg), nullptr,
+                           portable_wave64_compute_config).empty()) {
+        printf("  [FAIL] v_ffbh_u32 admitted unsupported SDWA source NEG\n");
+        return 1;
+    }
+    printf("  [ok]   GTA V v_ffbh_u32 lowers in crossing Wave64 CFG; SDWA NEG stays rejected\n");
 
     // GTA V follows its row reduction with this identity QUAD_PERM and partial ROW_MASK. Prefix the
     // exact packet to the crossing CFG above so it reaches the dispatcher lowering used by the live

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -1753,6 +1753,71 @@ int main() {
     }
     printf("  [ok]   full Wave32 scalar VCC_LO write feeds its implicit mask consumer\n");
 
+    // GTA V's exact PC1309/PC1311 producer-consumer packets occupy one dispatcher case, matching the
+    // production basic block. PC1310 stays between them. The crossing tail forces the arbitrary-CFG
+    // switch, so its discovery/dataflow scan must advertise the scalar cselect's new mask lifetime
+    // before that case is emitted; this does not claim a cross-case producer/consumer transfer.
+    const uint32_t wave32_compute_scalar_cselect_cfg[] = {
+        0xbe8403ffu, 0x80000009u,            // pc0: s_mov_b32 s4, lane-bit mask
+        0xbf060000u,                         // pc2: SCC=1
+        0x7e020287u,                         // pc3: v_mov_b32 v1, 7
+        0x856a8004u,                         // pc4: exact s_cselect_b32 vcc_lo,s4,0
+        0x061212f2u,                         // pc5: exact intervening GTA V vector packet
+        0x02020290u,                         // pc6: exact implicit VCC consumer
+        0x7da40100u,                         // pc7: CMPX changes EXEC only
+        0xbf880003u,                         // pc8: execz -> pc12
+        0x7d840100u,                         // pc9: fresh VCC mask in one arm
+        0x02020100u,                         // pc10: consume the arm-local mask
+        0xbf880002u,                         // pc11: execz -> pc14 (crossing region)
+        0xbf060000u,                         // pc12: scalar compare at rejoin
+        0xbf850001u,                         // pc13: third branch -> pc15
+        0x7e040280u,                         // pc14: no mask read before termination
+        0xbf810000u,
+    };
+    const auto scalar_cselect_cfg_spv = recompile_compute(
+        wave32_compute_scalar_cselect_cfg,
+        std::size(wave32_compute_scalar_cselect_cfg), nullptr,
+        wave32_compute_config);
+    if (scalar_cselect_cfg_spv.empty() || !has_opcode(scalar_cselect_cfg_spv, 251) ||
+        !type_result_ids_are_nonzero(scalar_cselect_cfg_spv, nullptr) ||
+        !phi_ids_are_nonzero(scalar_cselect_cfg_spv)) {
+        printf("  [FAIL] Wave32 CFG did not discover GTA V's scalar-cselect VCC lifetime\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 CFG discovers and emits GTA V's scalar-cselect VCC lifetime\n");
+
+    // The scalar-data bridge is deliberately compute-only. In a Wave32 graphics shader, the exact
+    // packet remains an ordinary scalar write to physical VCC_LO and therefore invalidates an older
+    // predicate lifetime. The crossing tail routes this through the graphics dispatcher too: if
+    // either its static inventory/dataflow or record_scalar_write applies the compute-only bridge to
+    // graphics, the stale all-true compare reaches PC6 and this shader is incorrectly accepted.
+    const uint32_t wave32_fragment_scalar_cselect_data_cfg[] = {
+        0x7e000280u,                         // pc0: v_mov_b32 v0, 0
+        0x7d840000u,                         // pc1: all-true VCC predicate
+        0xbe840381u,                         // pc2: s_mov_b32 s4, 1 (ordinary scalar data)
+        0xbf060000u,                         // pc3: SCC=1
+        0x856a8004u,                         // pc4: exact scalar cselect to VCC_LO
+        0x061212f2u,                         // pc5: exact intervening GTA V packet
+        0x02020290u,                         // pc6: stale implicit VCC read must reject
+        0x7da40100u,                         // pc7: crossing CFG tail begins
+        0xbf880003u,                         // pc8: execz -> pc12
+        0x7d840100u,                         // pc9: fresh VCC mask in one arm
+        0x02020100u,                         // pc10: consume the arm-local mask
+        0xbf880002u,                         // pc11: execz -> pc14
+        0xbf060000u,                         // pc12: scalar compare at rejoin
+        0xbf850001u,                         // pc13: third branch -> pc15
+        0x7e040280u,                         // pc14: no mask read before export
+        0xf800000fu, 0x03020100u,            // pc15: export MRT0
+        0xbf810000u,
+    };
+    if (!recompile_fragment_wave32_for_test(
+            wave32_fragment_scalar_cselect_data_cfg,
+            std::size(wave32_fragment_scalar_cselect_data_cfg)).empty()) {
+        printf("  [FAIL] graphics CFG retained compute-only scalar-cselect VCC semantics\n");
+        return 1;
+    }
+    printf("  [ok]   scalar-cselect VCC bridge remains compute-only in graphics CFGs\n");
+
     // Astro's larger world-map sibling keeps an ordinary scalar in VCC_HI while an implicit VOPC
     // compare replaces the complete Wave32 predicate in VCC_LO. The unused high word must retain
     // its data lifetime; the same sequence is intentionally invalid in Wave64, where VCC_HI is the

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -2482,6 +2482,46 @@ int main() {
     }
     printf("  [ok]   GTA V v_ffbh_u32 lowers in crossing Wave64 CFG; SDWA NEG stays rejected\n");
 
+    // GTA V exec_cs_413d1bf00 stops at pc458 on this exact packet. Require the production words,
+    // the two-source decode, and the portable integer-domain lowering. GLSL.std.450 Ldexp (53) is
+    // deliberately forbidden here because its overflow/large-exponent result is undefined; the
+    // FindUMsb used to normalize a nonzero subnormal input is guarded inside the builder helper.
+    const uint32_t gta_ldexp_f32[] = {
+        0xd7620000u, 0x0002030du,             // v_ldexp_f32 v0,v13,v1
+        0xbf810000u,
+    };
+    const auto gta_ldexp_f32_spv = recompile_valu(
+        gta_ldexp_f32, std::size(gta_ldexp_f32), 14, 0);
+    if (gta_ldexp_f32_spv.empty() || has_glsl_ext_inst(gta_ldexp_f32_spv, 53) ||
+        !has_glsl_ext_inst(gta_ldexp_f32_spv, 75) ||
+        !has_signed_i32_type(gta_ldexp_f32_spv) ||
+        !type_result_ids_are_nonzero(gta_ldexp_f32_spv, nullptr)) {
+        printf("  [FAIL] GTA V v_ldexp_f32 did not emit its defined integer-domain SPIR-V\n");
+        return 1;
+    }
+    // Same-site modifier mutations remain outside this bounded admission. These exact bits exercise
+    // each generic VOP3 modifier field; accepting one would mean the opcode case silently lost it.
+    const uint32_t ldexp_abs0[]  = {0xd7620100u, 0x0002030du, 0xbf810000u};
+    const uint32_t ldexp_abs1[]  = {0xd7620200u, 0x0002030du, 0xbf810000u};
+    const uint32_t ldexp_abs2[]  = {0xd7620400u, 0x0002030du, 0xbf810000u};
+    const uint32_t ldexp_neg0[]  = {0xd7620000u, 0x2002030du, 0xbf810000u};
+    const uint32_t ldexp_neg1[]  = {0xd7620000u, 0x4002030du, 0xbf810000u};
+    const uint32_t ldexp_neg2[]  = {0xd7620000u, 0x8002030du, 0xbf810000u};
+    const uint32_t ldexp_clamp[] = {0xd7628000u, 0x0002030du, 0xbf810000u};
+    const uint32_t ldexp_omod[]  = {0xd7620000u, 0x0802030du, 0xbf810000u};
+    if (!recompile_valu(ldexp_abs0, std::size(ldexp_abs0), 14, 0).empty() ||
+        !recompile_valu(ldexp_abs1, std::size(ldexp_abs1), 14, 0).empty() ||
+        !recompile_valu(ldexp_abs2, std::size(ldexp_abs2), 14, 0).empty() ||
+        !recompile_valu(ldexp_neg0, std::size(ldexp_neg0), 14, 0).empty() ||
+        !recompile_valu(ldexp_neg1, std::size(ldexp_neg1), 14, 0).empty() ||
+        !recompile_valu(ldexp_neg2, std::size(ldexp_neg2), 14, 0).empty() ||
+        !recompile_valu(ldexp_clamp, std::size(ldexp_clamp), 14, 0).empty() ||
+        !recompile_valu(ldexp_omod, std::size(ldexp_omod), 14, 0).empty()) {
+        printf("  [FAIL] v_ldexp_f32 admitted an unsupported VOP3 modifier mutation\n");
+        return 1;
+    }
+    printf("  [ok]   GTA V v_ldexp_f32 emits defined SPIR-V; modifier mutations reject\n");
+
     // GTA V follows its row reduction with this identity QUAD_PERM and partial ROW_MASK. Prefix the
     // exact packet to the crossing CFG above so it reaches the dispatcher lowering used by the live
     // shader. Rows 1/3 add distinct v19, rows 0/2 keep the old in-place v20 because BC is zero.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -605,6 +605,75 @@ int main() {
     CHECK(got15c.size() == N && bad15c == 0,
           "recompiled kernel 15c counts leading zeroes and preserves the zero sentinel exactly");
 
+    // Kernel 15d: V_ALIGNBYTE_B32 (VOP3 0x14f).  Exercise every masked byte offset, including
+    // the 4..7 high-dword tail and 8..31 zero region.  Raw input bits avoid float conversion;
+    // src0 is the high dword and src1 the low dword in the ISA's {S0,S1} concatenation.
+    const uint32_t code15d[] = {
+        0xd54f0000u, 0x040a0300u, // v_alignbyte_b32 v0, v0, v1, v2
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv15d = recompile_valu(
+        code15d, std::size(code15d), /*num_inputs*/3, /*out_vgpr*/0);
+    CHECK(!spv15d.empty(), "recompiled kernel 15d (v_alignbyte_b32) -> SPIR-V");
+    std::vector<float> in15d(N * 3);
+    std::vector<uint32_t> exp15d(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const uint32_t s0 = 0xa1b2c3d4u ^ (i * 0x01010101u);
+        const uint32_t s1 = 0x11223344u ^ (i * 0x00010001u);
+        const uint32_t byte = i & 31u;
+        in15d[i * 3 + 0] = std::bit_cast<float>(s0);
+        in15d[i * 3 + 1] = std::bit_cast<float>(s1);
+        in15d[i * 3 + 2] = std::bit_cast<float>(byte);
+        if (byte < 4u) {
+            exp15d[i] = byte == 0u ? s1
+                                   : (s1 >> (byte * 8u)) | (s0 << ((4u - byte) * 8u));
+        } else if (byte < 8u) {
+            exp15d[i] = s0 >> ((byte - 4u) * 8u);
+        } else {
+            exp15d[i] = 0u;
+        }
+    }
+    const std::vector<float> got15d = spv15d.empty()
+        ? std::vector<float>() : prosper::test::run_compute(spv15d, in15d, N, N);
+    uint32_t bad15d = 0;
+    for (uint32_t i = 0; i < N && got15d.size() == N; ++i)
+        if (bits_of(got15d[i]) != exp15d[i]) ++bad15d;
+    printf("  kernel15d mismatches=%u (offset7=0x%08x expect=0x%08x, offset8=0x%08x)\n",
+           bad15d, got15d.size() == N ? bits_of(got15d[7]) : 0u, exp15d[7],
+           got15d.size() == N ? bits_of(got15d[8]) : 0u);
+    CHECK(got15d.size() == N && bad15d == 0,
+          "recompiled kernel 15d aligns all byte offsets with zero fill bit-exactly");
+
+    // Kernel 15e: exact first GTA V packet, including literal placement and v5 byte offset.
+    // The captured src0 is zero, so offsets 0..3 select successive bytes of 0x3024240c and
+    // offsets >=4 are zero.  This pins the decoder/emitter path used by programs 0x413ce6000
+    // and 0x413ce6d00, in addition to the general register-source differential above.
+    const uint32_t code15e[] = {
+        0xd54f0006u, 0x0415fe80u, 0x3024240cu,
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spv15e = recompile_valu(
+        code15e, std::size(code15e), /*num_inputs*/6, /*out_vgpr*/6);
+    CHECK(!spv15e.empty(), "recompiled kernel 15e (GTA V exact v_alignbyte_b32) -> SPIR-V");
+    std::vector<float> in15e(N * 6, 0.0f);
+    std::vector<uint32_t> exp15e(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const uint32_t byte = i & 31u;
+        in15e[i * 6 + 5] = std::bit_cast<float>(byte);
+        exp15e[i] = byte < 4u ? (0x3024240cu >> (byte * 8u)) : 0u;
+    }
+    const std::vector<float> got15e = spv15e.empty()
+        ? std::vector<float>() : prosper::test::run_compute(spv15e, in15e, N, N);
+    uint32_t bad15e = 0;
+    for (uint32_t i = 0; i < N && got15e.size() == N; ++i)
+        if (bits_of(got15e[i]) != exp15e[i]) ++bad15e;
+    printf("  kernel15e mismatches=%u (offset0=0x%08x offset3=0x%08x offset4=0x%08x)\n",
+           bad15e, got15e.size() == N ? bits_of(got15e[0]) : 0u,
+           got15e.size() == N ? bits_of(got15e[3]) : 0u,
+           got15e.size() == N ? bits_of(got15e[4]) : 0u);
+    CHECK(got15e.size() == N && bad15e == 0,
+          "recompiled kernel 15e matches GTA V's exact literal packet bit-exactly");
+
     // Kernel 15b: kernel 15 with s_ttracedata (SOPP 0x16, 0xbf960000) spliced into the body. The
     // instruction sends M0 to the thread-trace stream — a profiling side channel that writes no
     // SGPR/VGPR/memory and does not branch — so the correct lowering emits nothing and the kernel must

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -468,35 +468,6 @@ int main() {
     printf("  kernel15 mismatches=%u (out[1]=0x%08x expect=0x%08x)\n", bad15, got15.size()==N?bits_of(got15[1]):0, exp15[1]);
     CHECK(got15.size()==N && bad15==0, "recompiled kernel 15 (v_bfrev_b32) reverses bits exactly");
 
-    // Kernel 15c: GTA V's exact in-place V_FFBH_U32 e32 packet from its compute culling kernels.
-    // The instruction counts zeroes preceding the first set bit from the MSB and returns -1 for
-    // zero. Feed the raw u32 bits through the float harness so the result is checked bit-exactly.
-    const uint32_t code15c[] = { 0x7e087304u, 0xbf810000u }; // v_ffbh_u32_e32 v4,v4
-    std::vector<uint32_t> spv15c = recompile_valu(
-        code15c, std::size(code15c), /*num_inputs*/5, /*out_vgpr*/4);
-    CHECK(!spv15c.empty(), "recompiled kernel 15c (GTA V v_ffbh_u32 e32) -> SPIR-V");
-    constexpr uint32_t ffbh_inputs[] = {
-        0x00000000u, 0x80000000u, 0x10000000u, 0x0000ffffu,
-        0x00000001u, 0x7fffffffu, 0x00f00000u, 0xffffffffu,
-    };
-    constexpr uint32_t ffbh_expected[] = { 0xffffffffu, 0u, 3u, 16u, 31u, 1u, 8u, 0u };
-    std::vector<float> in15c(N * 5, 0.0f);
-    std::vector<uint32_t> exp15c(N);
-    for (uint32_t i = 0; i < N; ++i) {
-        const size_t sample = i % std::size(ffbh_inputs);
-        in15c[i * 5 + 4] = std::bit_cast<float>(ffbh_inputs[sample]);
-        exp15c[i] = ffbh_expected[sample];
-    }
-    std::vector<float> got15c = spv15c.empty() ? std::vector<float>()
-                                               : prosper::test::run_compute(spv15c, in15c, N, N);
-    uint32_t bad15c = 0;
-    for (uint32_t i = 0; i < N && got15c.size() == N; ++i)
-        if (bits_of(got15c[i]) != exp15c[i]) ++bad15c;
-    printf("  kernel15c mismatches=%u (zero=0x%08x expect=0x%08x)\n", bad15c,
-           got15c.size() == N ? bits_of(got15c[0]) : 0, exp15c[0]);
-    CHECK(got15c.size() == N && bad15c == 0,
-          "recompiled kernel 15c counts leading zeroes and preserves the zero sentinel exactly");
-
     // Kernel 15b: kernel 15 with s_ttracedata (SOPP 0x16, 0xbf960000) spliced into the body. The
     // instruction sends M0 to the thread-trace stream — a profiling side channel that writes no
     // SGPR/VGPR/memory and does not branch — so the correct lowering emits nothing and the kernel must

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -445,6 +445,117 @@ int main() {
     printf("  kernel9 mismatches=%u (out[5]=%g expect=%g)\n", bad9, got9.size()==N?got9[5]:-1, exp9[5]);
     CHECK(got9.size()==N && bad9==0, "recompiled kernel 9 (scalar s_mov/s_add/s_lshl) computes a0+30");
 
+    // GTA V kernel 0x205b5e8600 uses s_sub_u32/s_subb_u32 as a 64-bit subtraction pair while
+    // negating EXEC. Pin both halves of S_SUBB's contract independently: the incoming low-word
+    // borrow changes the high-word data result, and the high-word underflow becomes its outgoing SCC.
+    const uint32_t code9_subb_data[] = {
+        0xbe800380u,              // s_mov_b32 s0,0
+        0xbe820385u,              // s_mov_b32 s2,5
+        0xbe830383u,              // s_mov_b32 s3,3
+        0x80818100u,              // s_sub_u32 s1,s0,1 -> borrow-in=1
+        0x82840302u,              // s_subb_u32 s4,s2,s3 -> 5-3-1 = 1, borrow-out=0
+        0x7e000204u,              // v_mov_b32 v0,s4
+        0x7e000d00u,              // v_cvt_f32_u32 v0,v0
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv9_subb_data = recompile_valu(
+        code9_subb_data, std::size(code9_subb_data), 1, 0);
+    const std::vector<float> got9_subb_data = spv9_subb_data.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv9_subb_data, {0.0f}, 1, 1);
+    CHECK(!spv9_subb_data.empty() && got9_subb_data.size() == 1 &&
+              got9_subb_data[0] == 1.0f,
+          "s_subb_u32 subtracts the incoming low-word borrow from its data result");
+
+    const uint32_t code9_subb_borrow[] = {
+        0xbe800380u,              // s_mov_b32 s0,0
+        0x80818100u,              // s_sub_u32 s1,s0,1 -> borrow-in=1
+        0x82828000u,              // s_subb_u32 s2,s0,0 -> UINT_MAX, borrow-out=1
+        0x85038081u,              // s_cselect_b32 s3,1,0
+        0x7e000203u,              // v_mov_b32 v0,s3
+        0x7e000d00u,              // v_cvt_f32_u32 v0,v0
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv9_subb_borrow = recompile_valu(
+        code9_subb_borrow, std::size(code9_subb_borrow), 1, 0);
+    const std::vector<float> got9_subb_borrow = spv9_subb_borrow.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv9_subb_borrow, {0.0f}, 1, 1);
+    CHECK(!spv9_subb_borrow.empty() && got9_subb_borrow.size() == 1 &&
+              got9_subb_borrow[0] == 1.0f,
+          "s_subb_u32 publishes its high-word borrow through SCC");
+
+    const uint32_t code9_subb_primary_borrow[] = {
+        0xbe800381u,              // s_mov_b32 s0,1
+        0xbe810380u,              // s_mov_b32 s1,0
+        0x80838000u,              // s_sub_u32 s3,s0,0 -> borrow-in=0
+        0x82820001u,              // s_subb_u32 s2,s1,s0 -> UINT_MAX, primary borrow-out=1
+        0x85038081u,              // s_cselect_b32 s3,1,0
+        0x7e000203u,              // v_mov_b32 v0,s3
+        0x7e000d00u,              // v_cvt_f32_u32 v0,v0
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv9_subb_primary_borrow = recompile_valu(
+        code9_subb_primary_borrow, std::size(code9_subb_primary_borrow), 1, 0);
+    const std::vector<float> got9_subb_primary_borrow = spv9_subb_primary_borrow.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv9_subb_primary_borrow, {0.0f}, 1, 1);
+    CHECK(!spv9_subb_primary_borrow.empty() && got9_subb_primary_borrow.size() == 1 &&
+              got9_subb_primary_borrow[0] == 1.0f,
+          "s_subb_u32 publishes a primary src0<src1 borrow through SCC");
+
+    // Execute an asymmetric exact-wave mask when the host can require Wave64. Lanes 0..32 are set,
+    // so ballot(EXEC).x=0xffffffff and .y=1. The exact GTA subtraction pair therefore produces
+    // low=1 and high=0xfffffffe. Store both halves after restoring EXEC; swapping the ballot halves,
+    // extracting .x twice, or omitting either extraction changes at least one complete output range.
+    const uint32_t code9_exec_ballot_halves[] = {
+        0x7d8800a1u,              // v_cmp_gt_u32 vcc, 33, v0 -> lanes 0..32
+        0xbefe046au,              // s_mov_b64 exec,vcc
+        0x80907e80u,              // GTA pc1310: s_sub_u32 s16,0,exec_lo
+        0x82917f80u,              // GTA pc1312: s_subb_u32 s17,0,exec_hi
+        0xbefe04c1u,              // restore EXEC before the stores
+        0x4a0400c0u,              // v_add_nc_u32 v2,64,v0
+        0x7e020210u,              // v_mov_b32 v1,s16
+        0xe0702000u, 0x80020100u, // store low result at output[v0]
+        0x7e020211u,              // v_mov_b32 v1,s17
+        0xe0702000u, 0x80020102u, // store high result at output[v2]
+        0xbf810000u,
+    };
+    ShaderResourceTable exec_ballot_table;
+    { ShaderResource output{}; output.cls = ResourceClass::ConstantBuffer;
+      output.format = DataFormat::Uint32; output.num_components = 1;
+      output.binding = 3; output.stride = 4; output.sgpr_base = 8;
+      exec_ballot_table.resources.push_back(output); }
+    ComputeShaderConfig exec_ballot_config;
+    exec_ballot_config.local_x = 64;
+    exec_ballot_config.wave_size = 64;
+    exec_ballot_config.native_subgroup_size = 64;
+    const std::vector<uint32_t> exec_ballot_spv = recompile_compute(
+        code9_exec_ballot_halves, std::size(code9_exec_ballot_halves),
+        &exec_ballot_table, exec_ballot_config);
+    CHECK(!exec_ballot_spv.empty() && count_spirv_opcode(exec_ballot_spv, 339) == 2,
+          "GTA EXEC integer pair materializes exactly two subgroup ballot halves");
+    const auto exec_ballot_subgroup = prosper::test::default_compute_subgroup_properties();
+    const bool can_execute_exec_ballot = exec_ballot_subgroup.size == 64 &&
+        (exec_ballot_subgroup.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (exec_ballot_subgroup.operations & VK_SUBGROUP_FEATURE_BALLOT_BIT);
+    if (can_execute_exec_ballot && !exec_ballot_spv.empty()) {
+        std::vector<uint32_t> exec_ballot_got;
+        prosper::test::run_compute(exec_ballot_spv, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, std::vector<uint32_t>(128, 0),
+                                   &exec_ballot_got);
+        uint32_t exec_ballot_bad = 0;
+        for (uint32_t lane = 0; lane < 64 && exec_ballot_got.size() == 128; ++lane) {
+            exec_ballot_bad += exec_ballot_got[lane] != 1u;
+            exec_ballot_bad += exec_ballot_got[lane + 64] != 0xfffffffeu;
+        }
+        CHECK(exec_ballot_got.size() == 128 && exec_ballot_bad == 0,
+              "GTA EXEC ballot maps low/high mask halves to .x/.y exactly");
+    } else {
+        std::printf("  [skip] GTA EXEC ballot execution: host subgroup is %u or lacks ballot\n",
+                    exec_ballot_subgroup.size);
+    }
+
     // Plucky Squire's post-Desk transition shader clears the top bit of a scalar-data VCC_HI
     // lifetime before combining the two VCC dwords into a buffer address. This is the exact
     // gfx1030 s_bitset0_b32 packet retained by the failed-dispatch capsule for #1554.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -853,6 +853,149 @@ int main() {
     CHECK(got17d2.size() == N && bad17d2 == 0,
           "#825: dispatcher reduces mask==0 across the full emulated wave64");
 
+    // GTA V's two current terminal compute shaders compare architectural Wave64 VCC directly with
+    // zero (`bf13806a`) after a VOPC producer. VCC is not an ordinary saved-mask SGPR map entry: the
+    // dispatcher persists it in its dedicated predicate state. Keep an SCC/VCC-preserving VOP1
+    // between producer and consumer, as in the longer sibling. Wave 0 has an empty mask; wave 1 has
+    // one set bit at guest lane 63, outside a narrow host subgroup. The SCC branch must therefore
+    // select 1 for every lane of wave 0 and 7 for every lane of wave 1.
+    const uint32_t code17d2v[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1 (fresh Wave64 VCC mask)
+        0x7e060280u,              // SCC/VCC-preserving gap: v_mov_b32 v3, 0
+        0xbf13806au,              // s_cmp_lg_u64 vcc, 0 (exact GTA V terminal packet)
+        0xbf840001u,              // s_cbranch_scc0 +1 (empty mask keeps 1)
+        0x7e040287u,              // nonempty mask -> v_mov_b32 v2, 7
+        0x7e040d02u, 0xbf810000u,
+    };
+    const std::vector<uint32_t> portable_spv17d2v = recompile_valu(
+        code17d2v, std::size(code17d2v), 2, /*out_vgpr*/2);
+    CHECK(!portable_spv17d2v.empty() && count_spirv_opcode(portable_spv17d2v, 224) > 0,
+          "GTA V Wave64 VCC-vs-zero uses the portable dispatcher vote");
+    const std::vector<float> got17d2v = portable_spv17d2v.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(portable_spv17d2v, in17d, N, N);
+    uint32_t bad17d2v = 0;
+    for (uint32_t i = 0; i < N && got17d2v.size() == N; ++i) {
+        const float expected = i < 64 ? 1.0f : 7.0f;
+        bad17d2v += got17d2v[i] != expected;
+    }
+    CHECK(got17d2v.size() == N && bad17d2v == 0,
+          "portable VCC-vs-zero vote sees the sole set guest lane 63");
+
+    const std::vector<uint32_t> native_spv17d2v = recompile_compute(
+        code17d2v, std::size(code17d2v), nullptr, native_cfg17d);
+    CHECK(!native_spv17d2v.empty() &&
+              count_spirv_opcode(native_spv17d2v, 335) ==
+                  count_spirv_opcode(native_spv17d, 335) + 1 &&
+              count_spirv_opcode(native_spv17d2v, 224) == 0,
+          "exact Wave64 VCC-vs-zero adds one native vote and no barrier");
+    // recompile_compute exposes only guest memory effects, so use the same VCC/SOPC/branch shape
+    // with a real resource-backed store for native execution. Local id 63 is the sole matching lane;
+    // its VCC bit must make the uniform SCC branch select 7 for the complete native guest wave.
+    const uint32_t code17d2v_native_exec[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7e0202bfu,              // v_mov_b32 v1, 63
+        0x7d840300u,              // v_cmp_eq_u32 vcc, v0, v1
+        0x7e060280u,              // SCC/VCC-preserving gap: v_mov_b32 v3, 0
+        0xbf13806au,              // s_cmp_lg_u64 vcc, 0
+        0xbf840001u,              // s_cbranch_scc0 +1
+        0x7e040287u,              // nonempty mask -> v_mov_b32 v2, 7
+        0xe0702000u, 0x80020200u, // buffer_store_dword v2, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ShaderResourceTable rt17d2v_native;
+    { ShaderResource dst{}; dst.cls = ResourceClass::ConstantBuffer;
+      dst.format = DataFormat::Uint32; dst.num_components = 1;
+      dst.binding = 3; dst.stride = 4; dst.sgpr_base = 8;
+      rt17d2v_native.resources.push_back(dst); }
+    ComputeShaderConfig native_exec_cfg17d2v = native_cfg17d;
+    native_exec_cfg17d2v.local_x = 64;
+    native_exec_cfg17d2v.local_y = 1;
+    const std::vector<uint32_t> native_exec_spv17d2v = recompile_compute(
+        code17d2v_native_exec, std::size(code17d2v_native_exec),
+        &rt17d2v_native, native_exec_cfg17d2v);
+    CHECK(!native_exec_spv17d2v.empty() &&
+              count_spirv_opcode(native_exec_spv17d2v, 335) ==
+                  count_spirv_opcode(native_spv17d, 335) + 1 &&
+              count_spirv_opcode(native_exec_spv17d2v, 224) == 0,
+          "native VCC-vs-zero execution kernel preserves the exact vote contract");
+    const auto subgroup17d2v = prosper::test::default_compute_subgroup_properties();
+    const bool can_execute17d2v = subgroup17d2v.size == 64 &&
+        (subgroup17d2v.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (subgroup17d2v.operations & VK_SUBGROUP_FEATURE_VOTE_BIT);
+    if (can_execute17d2v && !native_exec_spv17d2v.empty()) {
+        std::vector<uint32_t> native_initial17d2v(64, 0u), native_got17d2v;
+        prosper::test::run_compute(native_exec_spv17d2v, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, native_initial17d2v,
+                                   &native_got17d2v);
+        uint32_t native_bad17d2v = 0;
+        for (uint32_t i = 0; i < 64 && native_got17d2v.size() == 64; ++i)
+            native_bad17d2v += native_got17d2v[i] != 7u;
+        std::printf("  native VCC-zero out[0/62/63]=%u/%u/%u mismatches=%u\n",
+                    native_got17d2v.size() == 64 ? native_got17d2v[0] : UINT32_MAX,
+                    native_got17d2v.size() == 64 ? native_got17d2v[62] : UINT32_MAX,
+                    native_got17d2v.size() == 64 ? native_got17d2v[63] : UINT32_MAX,
+                    native_bad17d2v);
+        CHECK(native_got17d2v.size() == 64 && native_bad17d2v == 0,
+              "native VCC-vs-zero vote sees the sole set lane 63");
+    } else {
+        std::printf("  [skip] native VCC-vs-zero execution: host subgroup is %u or lacks vote\n",
+                    subgroup17d2v.size);
+    }
+
+    // A dedicated VCC Bool variable is a value, not proof that both physical VCC words still hold
+    // that mask. A scalar write to VCC_HI kills the pair lifetime, and a path that may bypass that
+    // write leaves the join ambiguous. Both shapes must stay out of the mask-vote specialization
+    // instead of voting stale predicate state. These negatives exercise the same Wave64 MUST-domain
+    // proof as the admission.
+    std::vector<uint32_t> code17d2v_high_overwrite(
+        std::begin(code17d2v), std::end(code17d2v));
+    code17d2v_high_overwrite.insert(
+        code17d2v_high_overwrite.begin() + 9,
+        0xbeeb0380u);             // s_mov_b32 vcc_hi, 0 destroys the B64 mask lifetime
+    const auto portable_high_overwrite = recompile_valu(
+        code17d2v_high_overwrite.data(), code17d2v_high_overwrite.size(), 2, 2);
+    const auto native_high_overwrite = recompile_compute(
+        code17d2v_high_overwrite.data(), code17d2v_high_overwrite.size(), nullptr,
+        native_cfg17d);
+    CHECK(!portable_high_overwrite.empty() &&
+              count_spirv_opcode(portable_high_overwrite, 224) ==
+                  count_spirv_opcode(spv17d, 224),
+          "portable VCC-vs-zero does not vote stale VCC after a scalar high-half overwrite");
+    CHECK(!native_high_overwrite.empty() &&
+              count_spirv_opcode(native_high_overwrite, 335) ==
+                  count_spirv_opcode(native_spv17d, 335),
+          "native VCC-vs-zero does not vote stale VCC after a scalar high-half overwrite");
+
+    std::vector<uint32_t> code17d2v_ambiguous_join(
+        std::begin(code17d2v), std::end(code17d2v));
+    code17d2v_ambiguous_join.insert(
+        code17d2v_ambiguous_join.begin() + 9,
+        {0xbf840001u,             // one SCC predecessor skips the scalar overwrite
+         0xbeeb0380u});           // the other recycles VCC_HI as scalar data
+    const auto portable_ambiguous_join = recompile_valu(
+        code17d2v_ambiguous_join.data(), code17d2v_ambiguous_join.size(), 2, 2);
+    const auto native_ambiguous_join = recompile_compute(
+        code17d2v_ambiguous_join.data(), code17d2v_ambiguous_join.size(), nullptr,
+        native_cfg17d);
+    std::printf("  VCC-zero votes baseline/accepted/native-ambiguous=%zu/%zu/%zu\n",
+                count_spirv_opcode(native_spv17d, 335),
+                count_spirv_opcode(native_spv17d2v, 335),
+                count_spirv_opcode(native_ambiguous_join, 335));
+    CHECK(!portable_ambiguous_join.empty() &&
+              count_spirv_opcode(portable_ambiguous_join, 224) ==
+                  count_spirv_opcode(spv17d, 224),
+          "portable VCC-vs-zero does not vote an ambiguous mask/scalar lifetime join");
+    CHECK(!native_ambiguous_join.empty() &&
+              count_spirv_opcode(native_ambiguous_join, 335) ==
+                  count_spirv_opcode(native_spv17d, 335),
+          "native VCC-vs-zero does not vote an ambiguous mask/scalar lifetime join");
+
     // Kernel 17d2x: Syberia's fullscreen compute pass compares current EXEC with a mask written
     // directly to s[16:17] by VOPC.  Keep the irreducible prefix so the comparison must use the
     // generic dispatcher's synchronized guest-wave vote.  Wave 0's saved mask equals EXEC; wave 1

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -445,6 +445,58 @@ int main() {
     printf("  kernel9 mismatches=%u (out[5]=%g expect=%g)\n", bad9, got9.size()==N?got9[5]:-1, exp9[5]);
     CHECK(got9.size()==N && bad9==0, "recompiled kernel 9 (scalar s_mov/s_add/s_lshl) computes a0+30");
 
+    // GTA V compute program 0x413cee500 first rejects on the exact pc46 S_ANDN2_B32 packet below.
+    // Exercise the complete complementary B32 logical family numerically and fold SCC into bit 31
+    // of the observed result so both the data operation and SCC=(D!=0) are checked by execution.
+    auto run_sop2_complement = [&](uint32_t opcode_word, uint32_t a, uint32_t c) {
+        const uint32_t code[] = {
+            0xbe8003ffu, a,       // s_mov_b32 s0,a
+            0xbe8103ffu, c,       // s_mov_b32 s1,c
+            opcode_word,          // s_*_b32 s2,s0,s1
+            0x85038081u,          // s_cselect_b32 s3,1,0
+            0x8f039f03u,          // s_lshl_b32 s3,s3,31
+            0x89020302u,          // s_xor_b32 s2,s2,s3
+            0x7e000202u,          // v_mov_b32 v0,s2
+            0xbf810000u,
+        };
+        const std::vector<uint32_t> spv = recompile_valu(code, std::size(code), 1, 0);
+        const std::vector<float> got = spv.empty()
+            ? std::vector<float>{}
+            : prosper::test::run_compute(spv, {0.0f}, 1, 1);
+        return got.size() == 1 ? bits_of(got[0]) : UINT32_MAX;
+    };
+    constexpr uint32_t logical_a = 0x0f0ff00fu;
+    constexpr uint32_t logical_c = 0x00ff00ffu;
+    auto with_scc = [](uint32_t result) {
+        return result ^ (result != 0 ? 0x80000000u : 0u);
+    };
+    CHECK(run_sop2_complement(0x8a020100u, logical_a, logical_c) ==
+              with_scc(logical_a & ~logical_c),
+          "s_andn2_b32 computes scalar data and SCC exactly");
+    CHECK(run_sop2_complement(0x8b020100u, logical_a, logical_c) ==
+              with_scc(logical_a | ~logical_c),
+          "s_orn2_b32 computes scalar data and SCC exactly");
+    CHECK(run_sop2_complement(0x8c020100u, logical_a, logical_c) ==
+              with_scc(~(logical_a & logical_c)),
+          "s_nand_b32 computes scalar data and SCC exactly");
+    CHECK(run_sop2_complement(0x8d020100u, logical_a, logical_c) ==
+              with_scc(~(logical_a | logical_c)),
+          "s_nor_b32 computes scalar data and SCC exactly");
+    CHECK(run_sop2_complement(0x8e020100u, logical_a, logical_c) ==
+              with_scc(~(logical_a ^ logical_c)),
+          "s_xnor_b32 computes scalar data and SCC exactly");
+    CHECK(run_sop2_complement(0x8a020100u, UINT32_MAX, UINT32_MAX) == 0,
+          "s_andn2_b32 clears SCC when its scalar result is zero");
+
+    const uint32_t gta_s_andn2_b32[] = {
+        0xbe8703ffu, 0x12345678u, // establish the live s7 input
+        0x8a07f507u,              // exact GTA pc46: s_andn2_b32 s7,s7,inline-float:245
+        0x7e000207u,              // v_mov_b32 v0,s7
+        0xbf810000u,
+    };
+    CHECK(!recompile_valu(gta_s_andn2_b32, std::size(gta_s_andn2_b32), 1, 0).empty(),
+          "GTA V exact scalar s_andn2_b32 packet recompiles");
+
     // GTA V kernel 0x205b5e8600 uses s_sub_u32/s_subb_u32 as a 64-bit subtraction pair while
     // negating EXEC. Pin both halves of S_SUBB's contract independently: the incoming low-word
     // borrow changes the high-word data result, and the high-word underflow becomes its outgoing SCC.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6634,10 +6634,109 @@ int main() {
         std::memcpy(&inT28b[i * 2 + 1], &addend_bitsT28b, sizeof(uint32_t));
         expT28b[i] = (((i % 64u) / 16u) & 1u) ? 2.0f : 1.0f;
     }
-    std::vector<float> gotT28b = prosper::test::run_compute(
-        spvT28b, inT28b, 128, 128);
+    std::vector<float> gotT28b = spvT28b.empty() ? std::vector<float>{} :
+        prosper::test::run_compute(spvT28b, inT28b, 128, 128);
     CHECK(gotT28b == expT28b,
           "T28b: ROW_MASK=0xa adds rows 1/3 and BC0 preserves rows 0/2 per wave64");
+
+    // T28c (#2481): the terminal GTA V compute cohort uses this exact in-place ROW_SHR:1 packet
+    // outside the CFG dispatcher. Narrow EXEC in a 0,1,1,0 pattern: lane 1 must preserve VDST
+    // because its source lane is inactive, lane 2 must add its active predecessor, and lane 3 must
+    // preserve VDST because the destination itself is inactive. Restoring EXEC exposes every result.
+    const uint32_t codeT28c[] = {
+        0x7da80300u,                         // v_cmpx_gt_u32 vcc,v0,v1
+        0x4a0e0efau, 0xff011107u,            // exact live v_add_nc_u32_dpp v7,v7,v7 row_shr:1
+        0xbefe04c1u,                         // s_mov_b64 exec,-1
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT28c = recompile_valu(
+        codeT28c, std::size(codeT28c), 8, 7);
+    CHECK(!spvT28c.empty(),
+          "recompiled T28c (GTA V ordinary in-place DPP add) -> SPIR-V");
+    std::vector<float> inT28c(128 * 8, 0.0f);
+    std::vector<uint32_t> expT28c(128);
+    for (uint32_t i = 0; i < 128; ++i) {
+        const bool activeT28c = (i & 3u) == 1u || (i & 3u) == 2u;
+        const uint32_t maskT28c = activeT28c ? 0xffffffffu : 0u;
+        const uint32_t thresholdT28c = 1u;
+        const uint32_t valueT28c = i + 1u;
+        std::memcpy(&inT28c[i * 8], &maskT28c, sizeof(uint32_t));
+        std::memcpy(&inT28c[i * 8 + 1], &thresholdT28c, sizeof(uint32_t));
+        std::memcpy(&inT28c[i * 8 + 7], &valueT28c, sizeof(uint32_t));
+        expT28c[i] = (i & 3u) == 2u ? valueT28c + i : valueT28c;
+    }
+    const std::vector<float> gotT28c = spvT28c.empty() ? std::vector<float>{} :
+        prosper::test::run_compute(spvT28c, inT28c, 128, 128);
+    uint32_t badT28c = 0;
+    for (uint32_t i = 0; i < 128 && gotT28c.size() == 128; ++i)
+        badT28c += bits_of(gotT28c[i]) != expT28c[i];
+    CHECK(gotT28c.size() == 128 && badT28c == 0,
+          "T28c: ordinary DPP add honors arithmetic, BC0, source EXEC, and destination EXEC");
+
+    // The other two live programs carry the v1 form inside ordinary scalar structured control.
+    // SCC is true, so the forward SCC0 branch does not skip the exact {1,2,4,8} ladder. Together
+    // the four packets compute an inclusive prefix sum within every DPP16 row; every amount is
+    // needed to reach the row's last lane, while row-leading lanes exercise BC0 at every packet.
+    const uint32_t codeT28d[] = {
+        0xbe800380u,                         // s_mov_b32 s0,0
+        0xbf060000u,                         // s_cmp_eq_u32 s0,s0
+        0xbf840008u,                         // s_cbranch_scc0 -> end
+        0x4a0202fau, 0xff011101u,            // exact live v_add_nc_u32_dpp v1,v1,v1 row_shr:1
+        0x4a0202fau, 0xff011201u,            // row_shr:2
+        0x4a0202fau, 0xff011401u,            // row_shr:4
+        0x4a0202fau, 0xff011801u,            // row_shr:8
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT28d = recompile_valu(
+        codeT28d, std::size(codeT28d), 2, 1);
+    CHECK(!spvT28d.empty(),
+          "recompiled T28d (GTA V structured in-place DPP add) -> SPIR-V");
+    std::vector<float> inT28d(128 * 2, 0.0f);
+    std::vector<uint32_t> expT28d(128);
+    for (uint32_t i = 0; i < 128; ++i) {
+        const uint32_t valueT28d = i + 1u;
+        std::memcpy(&inT28d[i * 2 + 1], &valueT28d, sizeof(uint32_t));
+        expT28d[i] = 0;
+        for (uint32_t lane = i & ~15u; lane <= i; ++lane)
+            expT28d[i] += lane + 1u;
+    }
+    const std::vector<float> gotT28d = spvT28d.empty() ? std::vector<float>{} :
+        prosper::test::run_compute(spvT28d, inT28d, 128, 128);
+    uint32_t badT28d = 0;
+    for (uint32_t i = 0; i < 128 && gotT28d.size() == 128; ++i)
+        badT28d += bits_of(gotT28d[i]) != expT28d[i];
+    CHECK(gotT28d.size() == 128 && badT28d == 0,
+          "T28d: structured {1,2,4,8} DPP ladder computes a per-row inclusive prefix sum");
+
+    // T28e (#2481): the longer live shader carries the exact partial-row identity tail in the
+    // same ordinary structured region as its ladder. Rows 1/3 add SRC1; rows 0/2 preserve VDST.
+    const uint32_t codeT28e[] = {
+        0xbe800380u,                         // s_mov_b32 s0,0
+        0xbf060000u,                         // s_cmp_eq_u32 s0,s0
+        0xbf840002u,                         // s_cbranch_scc0 -> end
+        0x4a0e0cfau, 0xaf00e407u,            // exact live v_add_nc_u32_dpp v7,v7,v6
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT28e = recompile_valu(
+        codeT28e, std::size(codeT28e), 8, 7);
+    CHECK(!spvT28e.empty(),
+          "recompiled T28e (GTA V structured partial-row DPP add) -> SPIR-V");
+    std::vector<float> inT28e(128 * 8, 0.0f);
+    std::vector<uint32_t> expT28e(128);
+    for (uint32_t i = 0; i < 128; ++i) {
+        const uint32_t valueT28e = i + 1u;
+        const uint32_t addendT28e = 7u;
+        std::memcpy(&inT28e[i * 8 + 6], &addendT28e, sizeof(uint32_t));
+        std::memcpy(&inT28e[i * 8 + 7], &valueT28e, sizeof(uint32_t));
+        expT28e[i] = (((i % 64u) / 16u) & 1u) ? valueT28e + addendT28e : valueT28e;
+    }
+    const std::vector<float> gotT28e = spvT28e.empty() ? std::vector<float>{} :
+        prosper::test::run_compute(spvT28e, inT28e, 128, 128);
+    uint32_t badT28e = 0;
+    for (uint32_t i = 0; i < 128 && gotT28e.size() == 128; ++i)
+        badT28e += bits_of(gotT28e[i]) != expT28e[i];
+    CHECK(gotT28e.size() == 128 && badT28e == 0,
+          "T28e: structured partial-row DPP add updates only rows 1/3 per wave64");
 
     // T29: exact S_BFM_B64 word from Astro's title reduction shader.  It creates VCC with the low
     // 32 lanes set, then saveexec predicates a write.  The operation repeats independently in each

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -468,6 +468,35 @@ int main() {
     printf("  kernel15 mismatches=%u (out[1]=0x%08x expect=0x%08x)\n", bad15, got15.size()==N?bits_of(got15[1]):0, exp15[1]);
     CHECK(got15.size()==N && bad15==0, "recompiled kernel 15 (v_bfrev_b32) reverses bits exactly");
 
+    // Kernel 15c: GTA V's exact in-place V_FFBH_U32 e32 packet from its compute culling kernels.
+    // The instruction counts zeroes preceding the first set bit from the MSB and returns -1 for
+    // zero. Feed the raw u32 bits through the float harness so the result is checked bit-exactly.
+    const uint32_t code15c[] = { 0x7e087304u, 0xbf810000u }; // v_ffbh_u32_e32 v4,v4
+    std::vector<uint32_t> spv15c = recompile_valu(
+        code15c, std::size(code15c), /*num_inputs*/5, /*out_vgpr*/4);
+    CHECK(!spv15c.empty(), "recompiled kernel 15c (GTA V v_ffbh_u32 e32) -> SPIR-V");
+    constexpr uint32_t ffbh_inputs[] = {
+        0x00000000u, 0x80000000u, 0x10000000u, 0x0000ffffu,
+        0x00000001u, 0x7fffffffu, 0x00f00000u, 0xffffffffu,
+    };
+    constexpr uint32_t ffbh_expected[] = { 0xffffffffu, 0u, 3u, 16u, 31u, 1u, 8u, 0u };
+    std::vector<float> in15c(N * 5, 0.0f);
+    std::vector<uint32_t> exp15c(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const size_t sample = i % std::size(ffbh_inputs);
+        in15c[i * 5 + 4] = std::bit_cast<float>(ffbh_inputs[sample]);
+        exp15c[i] = ffbh_expected[sample];
+    }
+    std::vector<float> got15c = spv15c.empty() ? std::vector<float>()
+                                               : prosper::test::run_compute(spv15c, in15c, N, N);
+    uint32_t bad15c = 0;
+    for (uint32_t i = 0; i < N && got15c.size() == N; ++i)
+        if (bits_of(got15c[i]) != exp15c[i]) ++bad15c;
+    printf("  kernel15c mismatches=%u (zero=0x%08x expect=0x%08x)\n", bad15c,
+           got15c.size() == N ? bits_of(got15c[0]) : 0, exp15c[0]);
+    CHECK(got15c.size() == N && bad15c == 0,
+          "recompiled kernel 15c counts leading zeroes and preserves the zero sentinel exactly");
+
     // Kernel 15b: kernel 15 with s_ttracedata (SOPP 0x16, 0xbf960000) spliced into the body. The
     // instruction sends M0 to the thread-trace stream — a profiling side channel that writes no
     // SGPR/VGPR/memory and does not branch — so the correct lowering emits nothing and the kernel must

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -576,6 +576,58 @@ int main() {
     printf("  kernel15 mismatches=%u (out[1]=0x%08x expect=0x%08x)\n", bad15, got15.size()==N?bits_of(got15[1]):0, exp15[1]);
     CHECK(got15.size()==N && bad15==0, "recompiled kernel 15 (v_bfrev_b32) reverses bits exactly");
 
+    // Kernel 15a: GTA V's exact v0 packet and the complete admitted SDWA byte/word-select family.
+    // SDWA zero-extends the selected field BEFORE BREV, so a selected low word produces reversed
+    // bits in the high destination word and zero in the low word. Exercise all six selectors with
+    // raw bit patterns; this catches both a missing extraction and a wrong byte/word offset.
+    constexpr uint32_t bfrev_sdwa_inputs[] = {
+        0x00000000u, 0x00000001u, 0x80000000u, 0x01234567u,
+        0x89abcdefu, 0xffff0001u, 0x55aa33ccu, 0xffffffffu,
+    };
+    for (uint32_t sel = 0; sel <= 5; ++sel) {
+        const uint32_t code15a[] = {
+            0x7e0070f9u, (sel << 16) | 0x00000600u, // v_bfrev_b32_sdwa v0,v0, BYTE_n/WORD_n
+            0xbf810000u,
+        };
+        std::vector<uint32_t> spv15a = recompile_valu(
+            code15a, std::size(code15a), /*num_inputs*/1, /*out_vgpr*/0);
+        CHECK(!spv15a.empty(), "recompiled kernel 15a v_bfrev_b32_sdwa selector -> SPIR-V");
+        std::vector<float> in15a(N);
+        std::vector<uint32_t> exp15a(N);
+        const uint32_t width = sel <= 3 ? 8u : 16u;
+        const uint32_t offset = sel <= 3 ? 8u * sel : 16u * (sel - 4u);
+        const uint32_t mask = width == 8u ? 0xffu : 0xffffu;
+        for (uint32_t i = 0; i < N; ++i) {
+            const uint32_t raw = bfrev_sdwa_inputs[i % std::size(bfrev_sdwa_inputs)];
+            in15a[i] = std::bit_cast<float>(raw);
+            exp15a[i] = bitrev32((raw >> offset) & mask);
+        }
+        std::vector<float> got15a = spv15a.empty() ? std::vector<float>()
+                                                   : prosper::test::run_compute(spv15a, in15a, N, N);
+        uint32_t bad15a = 0;
+        for (uint32_t i = 0; i < N && got15a.size() == N; ++i)
+            if (bits_of(got15a[i]) != exp15a[i]) ++bad15a;
+        printf("  kernel15a selector=%u mismatches=%u\n", sel, bad15a);
+        CHECK(got15a.size() == N && bad15a == 0,
+              "recompiled kernel 15a selects then reverses byte/word bits exactly");
+    }
+    // These nearby encodings are different operations, not permissive aliases for the live shape.
+    const uint32_t code15a_sext[] = { 0x7e0070f9u, 0x000c0600u, 0xbf810000u };
+    const uint32_t code15a_neg[] = { 0x7e0070f9u, 0x00140600u, 0xbf810000u };
+    const uint32_t code15a_partial[] = { 0x7e0070f9u, 0x00040400u, 0xbf810000u };
+    const uint32_t code15a_reserved[] = { 0x7e0070f9u, 0x01040600u, 0xbf810000u };
+    const uint32_t code15a_dword[] = { 0x7e0070f9u, 0x00060600u, 0xbf810000u };
+    const uint32_t code15a_dword_neg[] = { 0x7e0070f9u, 0x00160600u, 0xbf810000u };
+    const uint32_t code15a_dword_abs[] = { 0x7e0070f9u, 0x00260600u, 0xbf810000u };
+    CHECK(recompile_valu(code15a_sext, std::size(code15a_sext), 1, 0).empty() &&
+          recompile_valu(code15a_neg, std::size(code15a_neg), 1, 0).empty() &&
+          recompile_valu(code15a_partial, std::size(code15a_partial), 1, 0).empty() &&
+          recompile_valu(code15a_reserved, std::size(code15a_reserved), 1, 0).empty() &&
+          recompile_valu(code15a_dword, std::size(code15a_dword), 1, 0).empty() &&
+          recompile_valu(code15a_dword_neg, std::size(code15a_dword_neg), 1, 0).empty() &&
+          recompile_valu(code15a_dword_abs, std::size(code15a_dword_abs), 1, 0).empty(),
+          "v_bfrev_b32 SDWA modifier, reserved, DWORD-source, and partial-dst forms reject visibly");
+
     // Kernel 15c: GTA V's exact in-place V_FFBH_U32 e32 packet from its compute culling kernels.
     // The instruction counts zeroes preceding the first set bit from the MSB and returns -1 for
     // zero. Feed the raw u32 bits through the float harness so the result is checked bit-exactly.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -4886,6 +4886,97 @@ int main() {
       printf("  kernel68 mismatches=%u (buf[6]=%g expect=12)\n", bad68, f6); }
     CHECK(stored68_out.size() == N && bad68 == 0, "recompiled kernel 68 (raw store routes to binding 3 via SRSRC) correct");
 
+    // GTA V gameplay-entry compute programs consume fully-known RAW V#s with NUM_RECORDS=0. The
+    // production front half represents each use with this exact-PC marker. Loads must produce zero
+    // only for active EXEC lanes; stores must emit no memory write at all (a shared dummy would let
+    // one null store leak into a later null load).
+    auto zero_record_resource = [](uint32_t fetch_pc) {
+        ShaderResource resource{};
+        resource.cls = ResourceClass::ConstantBuffer;
+        resource.format = DataFormat::Unknown;
+        resource.num_components = 0;
+        resource.binding = 3;
+        resource.gpu_addr = 0;
+        resource.size = 0;
+        resource.stride = 0;
+        resource.srt_offset = 0xFFFFFFFFu;
+        resource.sgpr_base = 0xFFFFFFFFu;
+        resource.fetch_pc = fetch_pc;
+        return resource;
+    };
+
+    // v2=7; narrow EXEC to u0>u1; zero-record raw load into v2; restore EXEC; convert/output v2.
+    // Active lanes observe zero, while masked lanes retain the old 7 through predicate_write.
+    const uint32_t code68_zero_load[] = {
+        0x7E000F00u, 0x7E020F01u, 0x7E040287u, 0x7DA80300u,
+        0xE0300000u, 0x80000200u,
+        0xBEFE04C1u, 0x7E040D02u, 0xBF810000u,
+    };
+    ShaderResourceTable rt68_zero_load;
+    rt68_zero_load.resources.push_back(zero_record_resource(4));
+    CHECK(is_zero_record_raw_buffer(rt68_zero_load.resources[0]),
+          "zero-record RAW test uses the explicit production marker shape");
+    const std::vector<uint32_t> spv68_zero_load = recompile_valu(
+        code68_zero_load, std::size(code68_zero_load), 2, 2, &rt68_zero_load);
+    const uint32_t code68_zero_load_control[] = {
+        0x7E000F00u, 0x7E020F01u, 0x7E040287u, 0x7DA80300u,
+        0x7E040280u,
+        0xBEFE04C1u, 0x7E040D02u, 0xBF810000u,
+    };
+    const std::vector<uint32_t> spv68_zero_load_control = recompile_valu(
+        code68_zero_load_control, std::size(code68_zero_load_control), 2, 2,
+        &rt68_zero_load);
+    CHECK(!spv68_zero_load.empty() && !spv68_zero_load_control.empty() &&
+              count_spirv_opcode(spv68_zero_load, 61) ==
+                  count_spirv_opcode(spv68_zero_load_control, 61) &&
+              count_spirv_opcode(spv68_zero_load, 62) ==
+                  count_spirv_opcode(spv68_zero_load_control, 62) &&
+              count_spirv_opcode(spv68_zero_load, 65) ==
+                  count_spirv_opcode(spv68_zero_load_control, 65),
+          "zero-record raw load adds no storage-buffer access/load/store instructions");
+    std::vector<float> in68_zero_load(N * 2), expected68_zero_load(N);
+    uint32_t active68_zero_load = 0;
+    for (uint32_t i = 0; i < N; ++i) {
+        const uint32_t u0 = i % 17u, u1 = i % 13u;
+        in68_zero_load[i * 2] = static_cast<float>(u0);
+        in68_zero_load[i * 2 + 1] = static_cast<float>(u1);
+        expected68_zero_load[i] = u0 > u1 ? 0.0f : 7.0f;
+        active68_zero_load += u0 > u1;
+    }
+    const std::vector<float> got68_zero_load = prosper::test::run_compute(
+        spv68_zero_load, in68_zero_load, N, N, {}, std::vector<uint32_t>(1, 0xDEADBEEFu));
+    uint32_t bad68_zero_load = 0;
+    for (uint32_t i = 0; i < N && got68_zero_load.size() == N; ++i)
+        if (got68_zero_load[i] != expected68_zero_load[i]) ++bad68_zero_load;
+    CHECK(active68_zero_load > 0 && active68_zero_load < N &&
+              got68_zero_load.size() == N && bad68_zero_load == 0,
+          "zero-record raw load returns zero under EXEC and preserves masked VGPR lanes");
+
+    ShaderResourceTable rt68_zero_store;
+    rt68_zero_store.resources.push_back(zero_record_resource(2));
+    const std::vector<uint32_t> spv68_zero_store = recompile_valu(
+        code68, std::size(code68), 1, 0, &rt68_zero_store);
+    const uint32_t code68_zero_store_control[] = {
+        0x7E040F00u, 0x06060100u, 0x7E000000u, 0x7E000000u, 0xBF810000u,
+    };
+    const std::vector<uint32_t> spv68_zero_store_control = recompile_valu(
+        code68_zero_store_control, std::size(code68_zero_store_control), 1, 0,
+        &rt68_zero_store);
+    CHECK(!spv68_zero_store.empty() && !spv68_zero_store_control.empty() &&
+              count_spirv_opcode(spv68_zero_store, 61) ==
+                  count_spirv_opcode(spv68_zero_store_control, 61) &&
+              count_spirv_opcode(spv68_zero_store, 62) ==
+                  count_spirv_opcode(spv68_zero_store_control, 62) &&
+              count_spirv_opcode(spv68_zero_store, 65) ==
+                  count_spirv_opcode(spv68_zero_store_control, 65),
+          "zero-record raw store adds no storage-buffer access/load/store instructions");
+    const std::vector<uint32_t> zero_store_sentinel = {0xDEADBEEFu};
+    std::vector<uint32_t> zero_store_after;
+    prosper::test::run_compute(spv68_zero_store, std::vector<float>{3.0f}, 1, 1, {},
+                               zero_store_sentinel, &zero_store_after);
+    CHECK(zero_store_after == zero_store_sentinel,
+          "zero-record raw store is a no-op and cannot mutate a shared dummy backing");
+
     // Kernel N: v_nop (VOP1 op 0x00) between real ALU ops must be a transparent no-op. This was the
     // #121 blocker — PPSA02664's vertex shaders contain v_nop (a common scheduling/hazard filler), and
     // the recompiler rejected it, failing the whole shader and skipping ~182 draws/frame (black screen).

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -22,6 +22,7 @@
 #include <cstdint>
 #include <limits>
 #include <map>
+#include <tuple>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -75,6 +76,32 @@ static bool has_spirv_local_size(const std::vector<uint32_t>& spv,
             spv[word + 2] == ExecutionModeLocalSize && spv[word + 3] == x &&
             spv[word + 4] == y && spv[word + 5] == z)
             return true;
+        word += count;
+    }
+    return false;
+}
+
+static bool spirv_has_array_length(const std::vector<uint32_t>& spv,
+                                   uint32_t expected_length) {
+    constexpr uint16_t OpTypeArray = 28, OpConstant = 43;
+    std::map<uint32_t, uint32_t> constants;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return false;
+        if (opcode == OpConstant && count == 4)
+            constants[spv[word + 2]] = spv[word + 3];
+        word += count;
+    }
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return false;
+        if (opcode == OpTypeArray && count == 4) {
+            const auto length = constants.find(spv[word + 3]);
+            if (length != constants.end() && length->second == expected_length)
+                return true;
+        }
         word += count;
     }
     return false;
@@ -8346,6 +8373,227 @@ int main() {
         CHECK(recompile_valu(overlap_cs, std::size(overlap_cs), 1, 2).empty(),
               "#590: partially-overlapping loops remain REJECTED (unstructured region)");
     }
+
+    // #2481: GTA V's three exact-wave barrier rejects do not branch through a guest barrier. Their
+    // large CFGs are three concrete sequences of barrier-free phases, so compile each phase through
+    // the arbitrary-CFG dispatcher and reconverge before emitting the guest barrier. Preserve the
+    // capture PCs in these reduced streams: mutation must perturb the same boundary proof as the fix.
+    auto barrier_phase_skeleton = [](uint32_t end_pc,
+                                     std::initializer_list<uint32_t> barriers,
+                                     std::initializer_list<std::tuple<uint32_t, uint32_t, uint32_t>>
+                                         branches) {
+        std::vector<uint32_t> code(end_pc + 1, 0xBF800000u); // s_nop 0
+        for (uint32_t pc : barriers) code[pc] = 0xBF8A0000u;
+        for (const auto& [pc, target, opcode] : branches) {
+            const int32_t delta = static_cast<int32_t>(target) -
+                static_cast<int32_t>(pc + 1);
+            code[pc] = opcode | static_cast<uint16_t>(delta);
+        }
+        code[end_pc] = 0xBF810000u;
+        return code;
+    };
+    std::vector<uint32_t> gta205BarrierPhases = barrier_phase_skeleton(
+        155, {153}, {{30, 56, 0xBF880000u}, {66, 96, 0xBF860000u},
+                     {97, 108, 0xBF880000u}});
+    std::vector<uint32_t> gta413c340BarrierPhases = barrier_phase_skeleton(
+        65, {51, 64}, {{11, 38, 0xBF880000u}, {25, 33, 0xBF880000u},
+                       {32, 23, 0xBF820000u}, {45, 49, 0xBF840000u},
+                       {53, 62, 0xBF880000u}});
+    std::vector<uint32_t> gta413c670BarrierPhases = barrier_phase_skeleton(
+        130, {116, 129}, {{40, 73, 0xBF880000u}, {49, 55, 0xBF860000u},
+                          {60, 67, 0xBF870000u}, {75, 103, 0xBF880000u},
+                          {90, 98, 0xBF880000u}, {97, 88, 0xBF820000u},
+                          {110, 114, 0xBF840000u}, {118, 127, 0xBF880000u}});
+    ComputeShaderConfig gtaBarrierPhaseConfig;
+    gtaBarrierPhaseConfig.local_x = 256;
+    gtaBarrierPhaseConfig.wave_size = 64;
+    gtaBarrierPhaseConfig.exact_thread_extent = true;
+    gtaBarrierPhaseConfig.threads_x = 256;
+    gtaBarrierPhaseConfig.threads_y = gtaBarrierPhaseConfig.threads_z = 1;
+    ComputeShaderConfig gtaPartialPhaseConfig = gtaBarrierPhaseConfig;
+    gtaPartialPhaseConfig.threads_x = 255; // force synchronized partial-workgroup phases
+    const std::vector<uint32_t> gta205BarrierSpv = recompile_compute(
+        gta205BarrierPhases.data(), gta205BarrierPhases.size(), nullptr,
+        gtaBarrierPhaseConfig);
+    const std::vector<uint32_t> gta413c340BarrierSpv = recompile_compute(
+        gta413c340BarrierPhases.data(), gta413c340BarrierPhases.size(), nullptr,
+        gtaBarrierPhaseConfig);
+    const std::vector<uint32_t> gta413c670BarrierSpv = recompile_compute(
+        gta413c670BarrierPhases.data(), gta413c670BarrierPhases.size(), nullptr,
+        gtaBarrierPhaseConfig);
+    CHECK(!gta205BarrierSpv.empty() && !gta413c340BarrierSpv.empty() &&
+              !gta413c670BarrierSpv.empty(),
+          "#2481: all three captured top-level barrier phase layouts recompile");
+
+    // An unconditional branch to the real S_ENDPGM is otherwise a legal proven exit from the
+    // synthetic first-phase dispatcher. This makes the assertion specifically sensitive to the
+    // production phase-boundary proof, rather than to a downstream CFG rejection.
+    std::vector<uint32_t> gtaForwardBarrierCrossing = gta413c340BarrierPhases;
+    gtaForwardBarrierCrossing[45] =
+        0xBF820000u | static_cast<uint16_t>(65 - 46);
+    CHECK(recompile_compute(gtaForwardBarrierCrossing.data(),
+                            gtaForwardBarrierCrossing.size(), nullptr,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: unconditional pc45 exit across pc51/64 rejects at the phase proof");
+    std::vector<uint32_t> gtaBackwardBarrierCrossing = gta413c340BarrierPhases;
+    gtaBackwardBarrierCrossing[53] =
+        0xBF820000u | static_cast<uint16_t>(50 - 54);
+    CHECK(recompile_compute(gtaBackwardBarrierCrossing.data(),
+                            gtaBackwardBarrierCrossing.size(), nullptr,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: backward pc53 edge across pc51 rejects at the phase proof");
+    std::vector<uint32_t> gtaIndirectBarrierCrossing = gta413c340BarrierPhases;
+    gtaIndirectBarrierCrossing[40] = 0xBE802000u; // s_setpc_b64 s[0:1]
+    CHECK(recompile_compute(gtaIndirectBarrierCrossing.data(),
+                            gtaIndirectBarrierCrossing.size(), nullptr,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: indirect PC changes remain incompatible with barrier phase splitting");
+    std::vector<uint32_t> gtaConditionalBarrier = gta205BarrierPhases;
+    gtaConditionalBarrier[97] = 0xBF880000u | static_cast<uint16_t>(154 - 98);
+    CHECK(recompile_compute(gtaConditionalBarrier.data(), gtaConditionalBarrier.size(), nullptr,
+                            gtaBarrierPhaseConfig).empty(),
+          "#2481: mutating the captured pc97 edge around pc153 keeps a conditional barrier rejected");
+    std::vector<uint32_t> gtaTrapBeforeBarrier = gta205BarrierPhases;
+    gtaTrapBeforeBarrier[120] = 0xBF920000u; // s_trap 0
+    CHECK(recompile_compute(gtaTrapBeforeBarrier.data(), gtaTrapBeforeBarrier.size(), nullptr,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: a wave-terminating trap before a later workgroup barrier rejects");
+
+    // The two 0x413d... programs launch 2063 real threads in nine 256-wide Vulkan workgroups. The
+    // final 241 padded invocations must remain in every dispatcher/common/barrier block but execute
+    // no guest instruction. Store a canary-indexed result after two phase boundaries: successful
+    // completion proves the complete host workgroup reaches the barriers, while the untouched tail
+    // proves padded lanes never acquire a guest PC even though guest code may rewrite EXEC.
+    const uint32_t partialBarrierPhases[] = {
+        0xBE810380u,              //  0: s_mov_b32 s1, 0
+        0xBF0A8101u,              //  1: loop: s_cmp_lt_u32 s1, 1
+        0xBF840002u,              //  2: s_cbranch_scc0 +2 -> 5
+        0x81018101u,              //  3: s_add_i32 s1, s1, 1
+        0xBF82FFFCu,              //  4: s_branch -4 -> 1
+        0xBF800000u,              //  5: s_nop 0
+        0xBF8A0000u,              //  6: s_barrier
+        0x7D840100u,              //  7: v_cmp_eq_u32 vcc, v0, v0
+        0xBF860001u,              //  8: s_cbranch_vccz +1 -> 10
+        0xBE820381u,              //  9: s_mov_b32 s2, 1
+        0xBEFE04C1u,              // 10: s_mov_b64 exec, -1 (must not reactivate padding)
+        0xBF8A0000u,              // 11: s_barrier
+        0x8F008800u,              // 12: s_lshl_b32 s0, s0, 8 (group index * 256)
+        0x4A000000u,              // 13: v_add_nc_u32 v0, s0, v0
+        0x7E020287u,              // 14: v_mov_b32 v1, 7
+        0xE0702000u, 0x80020100u, // 15: buffer_store_dword v1, v0, s[8:11] idxen
+        0xBF810000u,              // 17: s_endpgm
+    };
+    ShaderResourceTable partialBarrierTable;
+    { ShaderResource dst{}; dst.cls = ResourceClass::ConstantBuffer;
+      dst.format = DataFormat::Uint32; dst.num_components = 1;
+      dst.binding = 3; dst.stride = 4; dst.sgpr_base = 8;
+      partialBarrierTable.resources.push_back(dst); }
+
+    // DIRECT descriptors are valid only while none of their four entry SGPR words was overwritten.
+    // The first phase writes s8; the tail must see that provenance even though its persistent scalar
+    // value is otherwise independently reconstructed by a new dispatcher.
+    std::vector<uint32_t> phaseDescriptorOverwrite = barrier_phase_skeleton(
+        68, {51, 64}, {{11, 38, 0xBF880000u}, {25, 33, 0xBF880000u},
+                       {32, 23, 0xBF820000u}, {45, 49, 0xBF840000u},
+                       {53, 62, 0xBF880000u}});
+    phaseDescriptorOverwrite[0] = 0xBE880380u;       // s_mov_b32 s8, 0
+    phaseDescriptorOverwrite[65] = 0xE0301000u;      // buffer_load_dword v0, v0,
+    phaseDescriptorOverwrite[66] = 0x80020000u;      //   s[8:11], 0 offen
+    CHECK(recompile_compute(phaseDescriptorOverwrite.data(),
+                            phaseDescriptorOverwrite.size(), &partialBarrierTable,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: a pre-barrier DIRECT descriptor-word overwrite invalidates its tail use");
+
+    // An ordinary write to a VGPR ends a v_writelane scalar-spill lifetime. The tombstone is
+    // compile-time metadata, so it must cross a phase separately from the persisted slot value.
+    std::vector<uint32_t> phaseInvalidatedSpill = barrier_phase_skeleton(
+        68, {51, 64}, {{11, 38, 0xBF880000u}, {25, 33, 0xBF880000u},
+                       {32, 23, 0xBF820000u}, {45, 49, 0xBF840000u},
+                       {53, 62, 0xBF880000u}});
+    phaseInvalidatedSpill[0] = 0xBE800381u; // s_mov_b32 s0, 1
+    phaseInvalidatedSpill[1] = 0xD7610001u; // v_writelane_b32 v1, s0, 0
+    phaseInvalidatedSpill[2] = 0x00010000u;
+    phaseInvalidatedSpill[3] = 0x7E020285u; // ordinary v_mov_b32 v1, 5
+    phaseInvalidatedSpill[65] = 0xD7600002u; // invalid v_readlane_b32 s2, v1, 0
+    phaseInvalidatedSpill[66] = 0x00010101u;
+    CHECK(recompile_compute(phaseInvalidatedSpill.data(), phaseInvalidatedSpill.size(), nullptr,
+                            gtaPartialPhaseConfig).empty(),
+          "#2481: a pre-barrier ordinary VGPR write keeps its spill tombstone in the tail");
+
+    ComputeShaderConfig partialBarrierConfig;
+    partialBarrierConfig.local_x = 256;
+    partialBarrierConfig.wave_size = 64;
+    partialBarrierConfig.native_subgroup_size = 64; // safe route must force portable for padding
+    partialBarrierConfig.exact_thread_extent = true;
+    partialBarrierConfig.threads_x = 2063;
+    partialBarrierConfig.threads_y = partialBarrierConfig.threads_z = 1;
+    partialBarrierConfig.tgid_x_en = true;
+    const std::vector<uint32_t> partialBarrierSpv = recompile_compute(
+        partialBarrierPhases, std::size(partialBarrierPhases), &partialBarrierTable,
+        partialBarrierConfig);
+    CHECK(!partialBarrierSpv.empty() && has_spirv_local_size(partialBarrierSpv, 256, 1, 1),
+          "#2481: 2063/256 partial workgroup barrier phases recompile through portable CFG");
+    constexpr uint32_t kPartialThreads = 2063;
+    constexpr uint32_t kPartialLaunch = 9 * 256;
+    constexpr uint32_t kPartialCanary = 0xccccccccu;
+    std::vector<uint32_t> partialInitial(kPartialLaunch, kPartialCanary), partialResult;
+    prosper::test::run_compute(
+        partialBarrierSpv, std::vector<float>(1, 0.0f), kPartialThreads, 1,
+        {}, partialInitial, &partialResult, 256);
+    uint32_t partialBad = 0;
+    for (uint32_t lane = 0; lane < partialResult.size(); ++lane) {
+        const uint32_t expected = lane < kPartialThreads ? 7u : kPartialCanary;
+        partialBad += partialResult[lane] != expected;
+    }
+    CHECK(partialResult.size() == kPartialLaunch && partialBad == 0,
+          "#2481: padded invocations reach both barriers but produce no guest buffer effects");
+
+    // The first phase has no DPP event and therefore asks for only the ordinary vote/liveness
+    // layout. The second phase's portable ROW_SHR add needs a second complete lane plane. Execute
+    // the partial final workgroup and inspect OpTypeArray so both the allocation and all dynamic
+    // accesses are covered by the same regression.
+    const uint32_t phasedDppScratch[] = {
+        0xBE810380u,              //  0: s_mov_b32 s1, 0
+        0xBF0A8101u,              //  1: loop: s_cmp_lt_u32 s1, 1
+        0xBF840002u,              //  2: s_cbranch_scc0 +2 -> 5
+        0x81018101u,              //  3: s_add_i32 s1, s1, 1
+        0xBF82FFFCu,              //  4: s_branch -4 -> 1
+        0x7E020300u,              //  5: v_mov_b32 v1, v0 (local invocation index)
+        0xBF8A0000u,              //  6: s_barrier
+        0x7D840100u,              //  7: v_cmp_eq_u32 vcc, v0, v0
+        0xBF860001u,              //  8: s_cbranch_vccz +1 -> 10
+        0xBE820381u,              //  9: s_mov_b32 s2, 1
+        0xBEFE04C1u,              // 10: s_mov_b64 exec, -1
+        0xBF8A0000u,              // 11: s_barrier
+        0x4A0202FAu, 0xFF011101u, // 12: v_add_nc_u32_dpp v1,v1,v1 row_shr:1
+        0x8F008800u,              // 14: s_lshl_b32 s0, s0, 8 (group index * 256)
+        0x4A000000u,              // 15: v_add_nc_u32 v0, s0, v0
+        0xE0702000u, 0x80020100u, // 16: buffer_store_dword v1, v0, s[8:11] idxen
+        0xBF810000u,              // 18: s_endpgm
+    };
+    const std::vector<uint32_t> phasedDppSpv = recompile_compute(
+        phasedDppScratch, std::size(phasedDppScratch), &partialBarrierTable,
+        partialBarrierConfig);
+    constexpr uint32_t kPhasedDppScratchDwords = 256 * 2 + 4 + 1;
+    CHECK(!phasedDppSpv.empty() &&
+              spirv_has_array_length(phasedDppSpv, kPhasedDppScratchDwords),
+          "#2481: whole phased stream pre-sizes portable DPP scratch to 517 dwords");
+    std::vector<uint32_t> phasedDppInitial(kPartialLaunch, kPartialCanary), phasedDppResult;
+    if (!phasedDppSpv.empty())
+        prosper::test::run_compute(
+            phasedDppSpv, std::vector<float>(1, 0.0f), kPartialThreads, 1,
+            {}, phasedDppInitial, &phasedDppResult, 256);
+    uint32_t phasedDppBad = 0;
+    for (uint32_t lane = 0; lane < phasedDppResult.size(); ++lane) {
+        uint32_t expected = kPartialCanary;
+        if (lane < kPartialThreads) {
+            const uint32_t local = lane & 255u;
+            expected = (local & 15u) ? 2u * local - 1u : local;
+        }
+        phasedDppBad += phasedDppResult[lane] != expected;
+    }
+    CHECK(phasedDppResult.size() == kPartialLaunch && phasedDppBad == 0,
+          "#2481: later portable DPP phase produces exact rows and preserves padded canaries");
 
     // #2396: a CFG-dispatcher attempt that fails PART WAY THROUGH must not leave its half-written
     // dispatcher in the module. emit_cfg_state_machine writes the dispatcher loop's OpLoopMerge,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -576,6 +576,35 @@ int main() {
     printf("  kernel15 mismatches=%u (out[1]=0x%08x expect=0x%08x)\n", bad15, got15.size()==N?bits_of(got15[1]):0, exp15[1]);
     CHECK(got15.size()==N && bad15==0, "recompiled kernel 15 (v_bfrev_b32) reverses bits exactly");
 
+    // Kernel 15c: GTA V's exact in-place V_FFBH_U32 e32 packet from its compute culling kernels.
+    // The instruction counts zeroes preceding the first set bit from the MSB and returns -1 for
+    // zero. Feed the raw u32 bits through the float harness so the result is checked bit-exactly.
+    const uint32_t code15c[] = { 0x7e087304u, 0xbf810000u }; // v_ffbh_u32_e32 v4,v4
+    std::vector<uint32_t> spv15c = recompile_valu(
+        code15c, std::size(code15c), /*num_inputs*/5, /*out_vgpr*/4);
+    CHECK(!spv15c.empty(), "recompiled kernel 15c (GTA V v_ffbh_u32 e32) -> SPIR-V");
+    constexpr uint32_t ffbh_inputs[] = {
+        0x00000000u, 0x80000000u, 0x10000000u, 0x0000ffffu,
+        0x00000001u, 0x7fffffffu, 0x00f00000u, 0xffffffffu,
+    };
+    constexpr uint32_t ffbh_expected[] = { 0xffffffffu, 0u, 3u, 16u, 31u, 1u, 8u, 0u };
+    std::vector<float> in15c(N * 5, 0.0f);
+    std::vector<uint32_t> exp15c(N);
+    for (uint32_t i = 0; i < N; ++i) {
+        const size_t sample = i % std::size(ffbh_inputs);
+        in15c[i * 5 + 4] = std::bit_cast<float>(ffbh_inputs[sample]);
+        exp15c[i] = ffbh_expected[sample];
+    }
+    std::vector<float> got15c = spv15c.empty() ? std::vector<float>()
+                                               : prosper::test::run_compute(spv15c, in15c, N, N);
+    uint32_t bad15c = 0;
+    for (uint32_t i = 0; i < N && got15c.size() == N; ++i)
+        if (bits_of(got15c[i]) != exp15c[i]) ++bad15c;
+    printf("  kernel15c mismatches=%u (zero=0x%08x expect=0x%08x)\n", bad15c,
+           got15c.size() == N ? bits_of(got15c[0]) : 0, exp15c[0]);
+    CHECK(got15c.size() == N && bad15c == 0,
+          "recompiled kernel 15c counts leading zeroes and preserves the zero sentinel exactly");
+
     // Kernel 15b: kernel 15 with s_ttracedata (SOPP 0x16, 0xbf960000) spliced into the body. The
     // instruction sends M0 to the thread-trace stream — a profiling side channel that writes no
     // SGPR/VGPR/memory and does not branch — so the correct lowering emits nothing and the kernel must

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -21,6 +21,7 @@
 #include <cstring>
 #include <cstdint>
 #include <limits>
+#include <map>
 #include <vector>
 
 using namespace prosper::gpu;
@@ -73,6 +74,113 @@ static bool has_spirv_local_size(const std::vector<uint32_t>& spv,
         if ((spv[word] & 0xFFFFu) == OpExecutionMode && count == 6 &&
             spv[word + 2] == ExecutionModeLocalSize && spv[word + 3] == x &&
             spv[word + 4] == y && spv[word + 5] == z)
+            return true;
+        word += count;
+    }
+    return false;
+}
+
+struct SpirvBufferAccessSummary {
+    uint32_t variable = 0;
+    bool aliased = false;
+    bool coherent = false;
+    size_t loads = 0;
+    size_t volatile_loads = 0;
+    size_t stores = 0;
+    size_t volatile_stores = 0;
+};
+
+static SpirvBufferAccessSummary spirv_buffer_access_summary(
+        const std::vector<uint32_t>& spv, uint32_t binding) {
+    constexpr uint16_t OpVariable = 59, OpLoad = 61, OpStore = 62;
+    constexpr uint16_t OpAccessChain = 65, OpDecorate = 71;
+    constexpr uint32_t StorageBuffer = 12, DecorationAliased = 20;
+    constexpr uint32_t DecorationCoherent = 23, DecorationBinding = 33;
+    constexpr uint32_t MemoryAccessVolatile = 1;
+    SpirvBufferAccessSummary out;
+    std::map<uint32_t, uint32_t> pointer_base;
+    std::set<uint32_t> storage_variables;
+    std::set<uint32_t> aliased, coherent;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return {};
+        if (opcode == OpVariable && count == 4 && spv[word + 3] == StorageBuffer)
+            storage_variables.insert(spv[word + 2]);
+        if (opcode == OpDecorate && count >= 3) {
+            if (spv[word + 2] == DecorationBinding && count >= 4 &&
+                spv[word + 3] == binding)
+                out.variable = spv[word + 1];
+            if (spv[word + 2] == DecorationAliased) aliased.insert(spv[word + 1]);
+            if (spv[word + 2] == DecorationCoherent) coherent.insert(spv[word + 1]);
+        }
+        if (opcode == OpAccessChain && count >= 4)
+            pointer_base[spv[word + 2]] = spv[word + 3];
+        word += count;
+    }
+    if (!storage_variables.count(out.variable)) out.variable = 0;
+    out.aliased = aliased.count(out.variable) != 0;
+    out.coherent = coherent.count(out.variable) != 0;
+    auto root = [&](uint32_t pointer) {
+        std::set<uint32_t> seen;
+        while (pointer_base.count(pointer) && seen.insert(pointer).second)
+            pointer = pointer_base[pointer];
+        return pointer;
+    };
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return {};
+        if (opcode == OpLoad && count >= 4 && root(spv[word + 3]) == out.variable) {
+            ++out.loads;
+            if (count >= 5 && (spv[word + 4] & MemoryAccessVolatile))
+                ++out.volatile_loads;
+        }
+        if (opcode == OpStore && count >= 3 && root(spv[word + 1]) == out.variable) {
+            ++out.stores;
+            if (count >= 4 && (spv[word + 3] & MemoryAccessVolatile))
+                ++out.volatile_stores;
+        }
+        word += count;
+    }
+    return out;
+}
+
+static bool spirv_storage_buffer_has_decoration(const std::vector<uint32_t>& spv,
+                                                uint32_t binding,
+                                                uint32_t decoration) {
+    const SpirvBufferAccessSummary summary = spirv_buffer_access_summary(spv, binding);
+    if (!summary.variable) return false;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        if (!count || word + count > spv.size()) return false;
+        if ((spv[word] & 0xffffu) == 71u && count >= 3 &&
+            spv[word + 1] == summary.variable && spv[word + 2] == decoration)
+            return true;
+        word += count;
+    }
+    return false;
+}
+
+static bool spirv_has_device_uniform_release_barrier(const std::vector<uint32_t>& spv) {
+    constexpr uint16_t OpConstant = 43, OpMemoryBarrier = 225;
+    constexpr uint32_t ScopeDevice = 1, MemorySemanticsUniformRelease = 0x44;
+    std::map<uint32_t, uint32_t> constants;
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return false;
+        if (opcode == OpConstant && count == 4)
+            constants[spv[word + 2]] = spv[word + 3];
+        word += count;
+    }
+    for (size_t word = 5; word < spv.size();) {
+        const uint32_t count = spv[word] >> 16;
+        const uint16_t opcode = static_cast<uint16_t>(spv[word]);
+        if (!count || word + count > spv.size()) return false;
+        if (opcode == OpMemoryBarrier && count == 3 &&
+            constants[spv[word + 1]] == ScopeDevice &&
+            constants[spv[word + 2]] == MemorySemanticsUniformRelease)
             return true;
         word += count;
     }
@@ -1306,6 +1414,220 @@ int main() {
     printf("  kernel21 mismatches=%u (out[7]=%g expect=107)\n", bad21, got21.size()==N?got21[7]:-1);
     CHECK(got21.size()==N && bad21==0, "recompiled kernel 21 (MUBUF per-lane buffer_load -> cbuf[gid]) correct");
 
+    // GTA V's decoupled-lookback scan publishes a record through one V# and polls the same backing
+    // through another. These are the exact pc199 data store, pc201 vmcnt(0), pc202 vscnt(0), pc207
+    // flag store, and pc224 polling-load packet words from exec_cs_413e16400, kept in their original
+    // publication order. Distinct bindings 4/5/6 deliberately carry the same guest address: emitted
+    // variables must permit aliasing, the requested accesses must be individually volatile/coherent,
+    // and the store-completion wait must publish prior UniformMemory writes at Device scope.
+    const uint32_t coherent_publish_poll[] = {
+        0xe0744008u, 0x80001100u, // pc199: buffer_store_dwordx2 ... glc
+        0xbf8c3f70u,              // pc201: s_waitcnt vmcnt(0)
+        0xbbfd0000u,              // pc202: s_waitcnt_vscnt null, 0
+        0xe0706010u, 0x80001211u, // pc207: buffer_store_dword ... glc (ready flag)
+        0xe030e010u, 0x80001e1du, // pc224: buffer_load_dword ... glc dlc (poll)
+        0xbf810000u,
+    };
+    ShaderResourceTable coherent_rt;
+    { ShaderResource publish{}; publish.cls = ResourceClass::ConstantBuffer;
+      publish.format = DataFormat::Uint32; publish.binding = 4; publish.gpu_addr = 0x1000;
+      publish.size = 180; publish.stride = 20; publish.fetch_pc = 0;
+      coherent_rt.resources.push_back(publish); }
+    { ShaderResource flag{}; flag.cls = ResourceClass::ConstantBuffer;
+      flag.format = DataFormat::Uint32; flag.binding = 5; flag.gpu_addr = 0x1000;
+      flag.size = 180; flag.stride = 20; flag.fetch_pc = 4;
+      coherent_rt.resources.push_back(flag); }
+    { ShaderResource poll{}; poll.cls = ResourceClass::ConstantBuffer;
+      poll.format = DataFormat::Uint32; poll.binding = 6; poll.gpu_addr = 0x1000;
+      poll.size = 180; poll.stride = 20; poll.fetch_pc = 6;
+      coherent_rt.resources.push_back(poll); }
+    ComputeShaderConfig coherent_cfg;
+    coherent_cfg.local_x = 64;
+    coherent_cfg.wave_size = 64;
+    const std::vector<uint32_t> coherent_spv = recompile_compute(
+        coherent_publish_poll, std::size(coherent_publish_poll), &coherent_rt, coherent_cfg);
+    const SpirvBufferAccessSummary publish_access =
+        spirv_buffer_access_summary(coherent_spv, 4);
+    const SpirvBufferAccessSummary flag_access =
+        spirv_buffer_access_summary(coherent_spv, 5);
+    const SpirvBufferAccessSummary poll_access =
+        spirv_buffer_access_summary(coherent_spv, 6);
+    CHECK(!coherent_spv.empty() && publish_access.stores == 2 &&
+              publish_access.volatile_stores == 2 && publish_access.coherent &&
+              flag_access.stores == 1 && flag_access.volatile_stores == 1 &&
+              flag_access.coherent &&
+              poll_access.loads == 1 && poll_access.volatile_loads == 1 &&
+              poll_access.coherent,
+          "GLC store and GLC+DLC polling load lower to exact Volatile accesses on Coherent roots");
+    bool every_external_root_aliased = true;
+    for (uint32_t binding : {0u, 1u, 2u, 3u, 4u, 5u, 6u})
+        every_external_root_aliased &=
+            spirv_storage_buffer_has_decoration(coherent_spv, binding, 20u);
+    CHECK(every_external_root_aliased && publish_access.aliased && flag_access.aliased &&
+              poll_access.aliased,
+          "every external StorageBuffer root is Aliased, including aliased views of one guest allocation");
+    CHECK(count_spirv_opcode(coherent_spv, 225) == 1 &&
+              spirv_has_device_uniform_release_barrier(coherent_spv),
+          "exact s_waitcnt_vscnt null,0 emits one Device UniformMemory Release barrier");
+
+    // Negative arms at the same packet sites: clear GLC/DLC without changing either access, then
+    // replace only vscnt with vmcnt. The ordinary accesses remain present but gain no Volatile or
+    // Coherent semantics; vmcnt remains a synchronous-SSA no-op rather than publishing stores.
+    const uint32_t ordinary_publish_poll[] = {
+        0xe0740008u, 0x80001100u,
+        0xbf8c3f70u,
+        0xbbfd0000u,
+        0xe0702010u, 0x80001211u,
+        0xe0302010u, 0x80001e1du,
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> ordinary_spv = recompile_compute(
+        ordinary_publish_poll, std::size(ordinary_publish_poll), &coherent_rt, coherent_cfg);
+    const SpirvBufferAccessSummary ordinary_publish =
+        spirv_buffer_access_summary(ordinary_spv, 4);
+    const SpirvBufferAccessSummary ordinary_flag =
+        spirv_buffer_access_summary(ordinary_spv, 5);
+    const SpirvBufferAccessSummary ordinary_poll =
+        spirv_buffer_access_summary(ordinary_spv, 6);
+    CHECK(!ordinary_spv.empty() && ordinary_publish.stores == 2 &&
+              ordinary_publish.volatile_stores == 0 && !ordinary_publish.coherent &&
+              ordinary_flag.stores == 1 && ordinary_flag.volatile_stores == 0 &&
+              !ordinary_flag.coherent &&
+              ordinary_poll.loads == 1 && ordinary_poll.volatile_loads == 0 &&
+              !ordinary_poll.coherent && ordinary_publish.aliased && ordinary_flag.aliased &&
+              ordinary_poll.aliased,
+          "unmarked ordinary packets keep their accesses non-Volatile/non-Coherent but still Aliased");
+
+    // Each load flag independently requests the same conservative SPIR-V coherence contract. The
+    // combined GTA packet alone cannot distinguish an accidental `GLC && DLC` gate from the required
+    // `GLC || DLC` gate. Conversely DLC alone is not the ordinary-store publication request: only
+    // GLC marks a store coherent/volatile.
+    ShaderResourceTable cache_flag_rt;
+    { ShaderResource buffer{}; buffer.cls = ResourceClass::ConstantBuffer;
+      buffer.format = DataFormat::Uint32; buffer.binding = 4; buffer.size = 180;
+      buffer.stride = 20; buffer.fetch_pc = 0; cache_flag_rt.resources.push_back(buffer); }
+    const uint32_t glc_only_load[] = {0xe0306010u, 0x80001e1du, 0xbf810000u};
+    const uint32_t dlc_only_load[] = {0xe030a010u, 0x80001e1du, 0xbf810000u};
+    const uint32_t dlc_only_store[] = {0xe070a010u, 0x80001211u, 0xbf810000u};
+    const SpirvBufferAccessSummary glc_only_access = spirv_buffer_access_summary(
+        recompile_compute(glc_only_load, std::size(glc_only_load), &cache_flag_rt, coherent_cfg), 4);
+    const SpirvBufferAccessSummary dlc_only_access = spirv_buffer_access_summary(
+        recompile_compute(dlc_only_load, std::size(dlc_only_load), &cache_flag_rt, coherent_cfg), 4);
+    const SpirvBufferAccessSummary dlc_store_access = spirv_buffer_access_summary(
+        recompile_compute(dlc_only_store, std::size(dlc_only_store), &cache_flag_rt, coherent_cfg), 4);
+    CHECK(glc_only_access.loads == 1 && glc_only_access.volatile_loads == 1 &&
+              glc_only_access.coherent && dlc_only_access.loads == 1 &&
+              dlc_only_access.volatile_loads == 1 && dlc_only_access.coherent,
+          "GLC-only and DLC-only ordinary loads each emit Volatile access on a Coherent root");
+    CHECK(dlc_store_access.stores == 1 && dlc_store_access.volatile_stores == 0 &&
+              !dlc_store_access.coherent,
+          "DLC alone does not broaden ordinary-store semantics reserved for GLC");
+
+    // Representative non-dword branches still route through the single instruction-policy wrapper.
+    // Keep separate assertions so a future raw-subword or packed-format bypass is mutation-visible.
+    ShaderResourceTable coherent_raw_rt;
+    { ShaderResource raw{}; raw.cls = ResourceClass::ConstantBuffer;
+      raw.format = DataFormat::Uint32; raw.num_components = 1; raw.binding = 4;
+      raw.size = 16; raw.sgpr_base = 8; raw.fetch_pc = 0;
+      coherent_raw_rt.resources.push_back(raw); }
+    const uint32_t glc_raw_ubyte_load[] = {
+        0xe0205000u, 0x80020000u, 0xbf810000u,
+    };
+    const SpirvBufferAccessSummary glc_raw_ubyte_access = spirv_buffer_access_summary(
+        recompile_compute(glc_raw_ubyte_load, std::size(glc_raw_ubyte_load),
+                          &coherent_raw_rt, coherent_cfg), 4);
+    CHECK(glc_raw_ubyte_access.loads == 1 &&
+              glc_raw_ubyte_access.volatile_loads == 1 && glc_raw_ubyte_access.coherent,
+          "raw ubyte GLC load uses the shared Volatile/Coherent dword policy");
+
+    ShaderResourceTable coherent_packed_rt;
+    { ShaderResource packed{}; packed.cls = ResourceClass::ConstantBuffer;
+      packed.format = DataFormat::Uint2_10_10_10; packed.num_components = 4;
+      packed.binding = 5; packed.size = 16; packed.stride = 4;
+      packed.sgpr_base = 8; packed.fetch_pc = 0;
+      coherent_packed_rt.resources.push_back(packed); }
+    const uint32_t dlc_packed_load[] = {
+        0xe000a000u, 0x80020000u, 0xbf810000u,
+    };
+    const SpirvBufferAccessSummary dlc_packed_access = spirv_buffer_access_summary(
+        recompile_compute(dlc_packed_load, std::size(dlc_packed_load),
+                          &coherent_packed_rt, coherent_cfg), 5);
+    CHECK(dlc_packed_access.loads == 1 && dlc_packed_access.volatile_loads == 1 &&
+              dlc_packed_access.coherent,
+          "packed Uint2_10_10_10 DLC load uses the shared Volatile/Coherent dword policy");
+
+    // Dynamic integer subword stores deliberately bypass ordinary OpStore: atomic clear+set keeps
+    // adjacent Uint16 elements in one dword race-free. GLC must still decorate that root Coherent,
+    // while changing neither the atomic pair nor the ISA atomic-return behavior tested by T32/T32b.
+    ShaderResourceTable coherent_subword_store_rt;
+    { ShaderResource subword{}; subword.cls = ResourceClass::ConstantBuffer;
+      subword.format = DataFormat::Uint16; subword.num_components = 1;
+      subword.binding = 4; subword.size = 64; subword.stride = 2;
+      subword.sgpr_base = 8; subword.fetch_pc = 0;
+      coherent_subword_store_rt.resources.push_back(subword); }
+    const uint32_t glc_subword_store[] = {
+        0xe0106000u, 0x80020100u, 0xbf810000u,
+    };
+    const uint32_t ordinary_subword_store[] = {
+        0xe0102000u, 0x80020100u, 0xbf810000u,
+    };
+    const std::vector<uint32_t> glc_subword_spv = recompile_compute(
+        glc_subword_store, std::size(glc_subword_store),
+        &coherent_subword_store_rt, coherent_cfg);
+    const std::vector<uint32_t> ordinary_subword_spv = recompile_compute(
+        ordinary_subword_store, std::size(ordinary_subword_store),
+        &coherent_subword_store_rt, coherent_cfg);
+    const SpirvBufferAccessSummary glc_subword_access =
+        spirv_buffer_access_summary(glc_subword_spv, 4);
+    const SpirvBufferAccessSummary ordinary_subword_access =
+        spirv_buffer_access_summary(ordinary_subword_spv, 4);
+    CHECK(!glc_subword_spv.empty() &&
+              spirv_storage_buffer_has_decoration(glc_subword_spv, 4, 23u) &&
+              count_spirv_opcode(glc_subword_spv, 240u) == 1 &&
+              count_spirv_opcode(glc_subword_spv, 241u) == 1 &&
+              glc_subword_access.stores == 0,
+          "dynamic Uint16 GLC store keeps atomic clear/set lowering on a Coherent root");
+    CHECK(!ordinary_subword_spv.empty() &&
+              !spirv_storage_buffer_has_decoration(ordinary_subword_spv, 4, 23u) &&
+              count_spirv_opcode(ordinary_subword_spv, 240u) == 1 &&
+              count_spirv_opcode(ordinary_subword_spv, 241u) == 1 &&
+              ordinary_subword_access.stores == 0,
+          "dynamic Uint16 store without GLC keeps the same atomic pair without Coherent");
+
+    // The one-record 16-bit zero-pad contract uses a dedicated load helper rather than the shared
+    // raw/packed dword wrapper. Exercise that propagation site directly: the packet pair differs only
+    // by GLC, while both retain the same exact format_x access and two-byte descriptor shape.
+    ShaderResourceTable coherent_tail_rt;
+    { ShaderResource tail{}; tail.cls = ResourceClass::ConstantBuffer;
+      tail.format = DataFormat::Uint16; tail.num_components = 1; tail.binding = 4;
+      tail.size = 2; tail.stride = 2; tail.sgpr_base = 8; tail.fetch_pc = 1;
+      coherent_tail_rt.resources.push_back(tail); }
+    const uint32_t glc_tail_load[] = {
+        0x7e020f00u, 0xe0006000u, 0x80020101u, 0xbf810000u,
+    };
+    const uint32_t ordinary_tail_load[] = {
+        0x7e020f00u, 0xe0002000u, 0x80020101u, 0xbf810000u,
+    };
+    const SpirvBufferAccessSummary glc_tail_access = spirv_buffer_access_summary(
+        recompile_compute(glc_tail_load, std::size(glc_tail_load),
+                          &coherent_tail_rt, coherent_cfg), 4);
+    const SpirvBufferAccessSummary ordinary_tail_access = spirv_buffer_access_summary(
+        recompile_compute(ordinary_tail_load, std::size(ordinary_tail_load),
+                          &coherent_tail_rt, coherent_cfg), 4);
+    CHECK(glc_tail_access.loads == 1 && glc_tail_access.volatile_loads == 1 &&
+              glc_tail_access.coherent && ordinary_tail_access.loads == 1 &&
+              ordinary_tail_access.volatile_loads == 0 && !ordinary_tail_access.coherent,
+          "one-record Uint16 tail load preserves GLC Volatile/Coherent policy at its dedicated site");
+
+    uint32_t vmcnt_publish_poll[std::size(coherent_publish_poll)];
+    std::copy(std::begin(coherent_publish_poll), std::end(coherent_publish_poll),
+              std::begin(vmcnt_publish_poll));
+    vmcnt_publish_poll[3] = 0xbc7d0000u; // same wait site, vmcnt(0) instead of vscnt(0)
+    const std::vector<uint32_t> vmcnt_spv = recompile_compute(
+        vmcnt_publish_poll, std::size(vmcnt_publish_poll), &coherent_rt, coherent_cfg);
+    CHECK(!vmcnt_spv.empty() && count_spirv_opcode(vmcnt_spv, 225) == 0,
+          "same-site vmcnt mutation does not emit the vscnt publication barrier");
+
     // Kernel 22: MULTI-buffer SMEM via descriptor provenance (the resource-binding contract). Two V#
     // descriptors loaded from SRT offsets 0x20 and 0x40; a ShaderResourceTable maps them to distinct
     // bindings (2 and 3); the two s_buffer_loads must route to two DIFFERENT constant buffers.
@@ -2298,6 +2620,11 @@ int main() {
               compute_gds_binding->kind == SpirvDescriptorKind::StorageBuffer &&
               compute_gds_binding->writable,
           "compute GDS module reflects its writable persistent storage-buffer binding");
+    const SpirvBufferAccessSummary internal_gds_access = spirv_buffer_access_summary(
+        compute_gds_spv, kComputeInternalGdsBinding);
+    CHECK(internal_gds_access.variable && internal_gds_access.stores == 1 &&
+              !internal_gds_access.aliased,
+          "backend-owned internal GDS stays outside the external-buffer Aliased policy");
 
     // Astro Bot's indirect-argument producer uses device-global append counters. Routing this exact
     // GDS form through workgroup LDS made every dispatch begin with undefined counter values and

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -4122,6 +4122,71 @@ int main() {
     CHECK(recompile_valu(code32r19b, std::size(code32r19b), 0, 2).empty(),
           "kernel 32r19b REJECTS a VCC predicate read after s_flbit overwrote the pair with data");
 
+    // Kernel 32r19c (LIVE, exec_cs_413d1bf00 pc458): exact production packet
+    // `v_ldexp_f32 v0,v13,v1`. Exercise it as raw bits because the guest exponent is i32, not f32,
+    // and because signed zero, NaN payloads, and subnormal rounding are observable contracts. The
+    // expected values cover both RNE tie directions and the exponent extremes that make the standard
+    // GLSL Ldexp instruction undefined; the emitter uses only defined integer SPIR-V for this reason.
+    const uint32_t code32r19c[] = {
+        0xd7620000u, 0x0002030du,
+        0xbf810000u,
+    };
+    struct LdexpVector { uint32_t x; int32_t exponent; uint32_t expected; };
+    const LdexpVector ldexp_vectors[] = {
+        {0x00000000u, INT32_MAX, 0x00000000u}, // +0 retains sign at arbitrarily large exponent
+        {0x80000000u, INT32_MIN, 0x80000000u}, // -0 retains sign at arbitrarily small exponent
+        {0x3fc00000u,          2, 0x40c00000u}, // 1.5 * 4 = 6
+        {0xbfc00000u,         -1, 0xbf400000u}, // -1.5 / 2 = -0.75
+        {0x00800000u,         -1, 0x00400000u}, // minimum normal -> exact subnormal
+        {0x00800001u,         -1, 0x00400000u}, // halfway, even truncated significand: round down
+        {0x00800003u,         -1, 0x00400002u}, // halfway, odd truncated significand: round up
+        {0x00ffffffu,         -1, 0x00800000u}, // subnormal rounding carries into minimum normal
+        {0x00800000u,        -24, 0x00000000u}, // exact half-min-subnormal tie rounds to even zero
+        {0x00800001u,        -24, 0x00000001u}, // just over the tie rounds to min subnormal
+        {0x00000001u,          0, 0x00000001u}, // minimum subnormal survives identity
+        {0x00000001u,          1, 0x00000002u}, // subnormal input is normalized before scaling
+        {0x007fffffu,          1, 0x00fffffeu}, // maximum subnormal crosses into normal range
+        {0x7f7fffffu,          1, 0x7f800000u}, // positive overflow
+        {0xff7fffffu,          1, 0xff800000u}, // negative overflow retains sign
+        {0x7f800000u, INT32_MIN, 0x7f800000u}, // +Inf is exponent-independent
+        {0xff800000u, INT32_MAX, 0xff800000u}, // -Inf is exponent-independent
+        {0x7fc12345u,        100, 0x7fc12345u}, // quiet NaN payload is retained bit-exactly
+        {0xffc12345u,       -100, 0xffc12345u}, // negative quiet NaN sign/payload retained
+        {0x3f800000u, INT32_MAX, 0x7f800000u}, // arbitrary positive i32 exponent is defined
+        {0xbf800000u, INT32_MIN, 0x80000000u}, // arbitrary negative i32 exponent -> signed zero
+        {0x3f000000u,        128, 0x7f000000u}, // exp=128 can still produce a finite result
+        {0x3f800000u,       -149, 0x00000001u}, // exact minimum subnormal
+        {0x3f800000u,       -150, 0x00000000u}, // halfway underflow tie -> zero
+        {0x3f800001u,       -150, 0x00000001u}, // just above halfway -> minimum subnormal
+        {0xbf800000u,       -150, 0x80000000u}, // underflow preserves negative-zero sign
+    };
+    const std::vector<uint32_t> spv32r19c = recompile_valu(
+        code32r19c, std::size(code32r19c), 14, 0);
+    CHECK(!spv32r19c.empty(),
+          "recompiled kernel 32r19c (exact GTA V v_ldexp_f32 packet) -> SPIR-V");
+    std::vector<float> in32r19c(std::size(ldexp_vectors) * 14, 0.0f);
+    for (size_t i = 0; i < std::size(ldexp_vectors); ++i) {
+        in32r19c[i * 14 + 13] = std::bit_cast<float>(ldexp_vectors[i].x);
+        in32r19c[i * 14 + 1] =
+            std::bit_cast<float>(static_cast<uint32_t>(ldexp_vectors[i].exponent));
+    }
+    const std::vector<float> got32r19c = spv32r19c.empty()
+        ? std::vector<float>()
+        : prosper::test::run_compute(spv32r19c, in32r19c,
+                                     std::size(ldexp_vectors), std::size(ldexp_vectors));
+    uint32_t bad32r19c = 0;
+    for (size_t i = 0; i < std::size(ldexp_vectors) && got32r19c.size() == std::size(ldexp_vectors); ++i) {
+        const uint32_t got_bits = bits_of(got32r19c[i]);
+        if (got_bits != ldexp_vectors[i].expected) {
+            ++bad32r19c;
+            printf("  ldexp[%zu] x=%08x exp=%d got=%08x expect=%08x\n", i,
+                   ldexp_vectors[i].x, ldexp_vectors[i].exponent,
+                   got_bits, ldexp_vectors[i].expected);
+        }
+    }
+    CHECK(got32r19c.size() == std::size(ldexp_vectors) && bad32r19c == 0,
+          "kernel 32r19c preserves ldexp zero/normal/subnormal/overflow/Inf/NaN contracts");
+
     // Kernel 32r20 (LIVE encoding, exec_cs_290000eb00 pc=34; raised in review): the **SDWA** form of
     // the 16-bit compare. 32r16 covers the plain e32 encodings, so nothing executed the composition
     // of the SDWA source select with the 16-bit narrowing until this kernel.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -7603,6 +7603,8 @@ int main() {
         codeT28d, std::size(codeT28d), 2, 1);
     CHECK(!spvT28d.empty(),
           "recompiled T28d (GTA V structured in-place DPP add) -> SPIR-V");
+    CHECK(compute_spirv_min_subgroup_size(spvT28d) == 16,
+          "T28d: structured row-shuffle ladder advertises its 16-lane host contract");
     std::vector<float> inT28d(128 * 2, 0.0f);
     std::vector<uint32_t> expT28d(128);
     for (uint32_t i = 0; i < 128; ++i) {
@@ -7612,13 +7614,18 @@ int main() {
         for (uint32_t lane = i & ~15u; lane <= i; ++lane)
             expT28d[i] += lane + 1u;
     }
-    const std::vector<float> gotT28d = spvT28d.empty() ? std::vector<float>{} :
-        prosper::test::run_compute(spvT28d, inT28d, 128, 128);
-    uint32_t badT28d = 0;
-    for (uint32_t i = 0; i < 128 && gotT28d.size() == 128; ++i)
-        badT28d += bits_of(gotT28d[i]) != expT28d[i];
-    CHECK(gotT28d.size() == 128 && badT28d == 0,
-          "T28d: structured {1,2,4,8} DPP ladder computes a per-row inclusive prefix sum");
+    if (can_shuffleT25b && subgroupT25b.size >= 16) {
+        const std::vector<float> gotT28d = prosper::test::run_compute(
+            spvT28d, inT28d, 128, 128);
+        uint32_t badT28d = 0;
+        for (uint32_t i = 0; i < 128 && gotT28d.size() == 128; ++i)
+            badT28d += bits_of(gotT28d[i]) != expT28d[i];
+        CHECK(gotT28d.size() == 128 && badT28d == 0,
+              "T28d: structured {1,2,4,8} DPP ladder computes a per-row inclusive prefix sum");
+    } else {
+        std::printf("  [skip] T28d architectural execution: host subgroup %u is narrower than 16\n",
+                    subgroupT25b.size);
+    }
 
     // T28e (#2481): the longer live shader carries the exact partial-row identity tail in the
     // same ordinary structured region as its ladder. Rows 1/3 add SRC1; rows 0/2 preserve VDST.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6600,6 +6600,45 @@ int main() {
     CHECK(gotT28.size() == 128 && badT28 == 0,
           "T28: VOP2 DPP permutes only src0 and adds current-lane src1");
 
+    // T28b (#2481): GTA V's reduction follows its row-shift ladder with this exact in-place
+    // V_ADD_NC_U32 identity QUAD_PERM. ROW_MASK=0xa enables rows 1 and 3; BC0 keeps the old VDST
+    // in rows 0 and 2. The crossing tail forces the same portable CFG dispatcher as the live shader.
+    const uint32_t codeT28b[] = {
+        0x7e280300u,                         // v_mov_b32 v20,v0
+        0x7e260301u,                         // v_mov_b32 v19,v1
+        0x4a2826fau, 0xaf00e414u,            // exact GTA V partial-row DPP add
+        0x7d840000u,
+        0xd4e4006au, 0x0001006au,
+        0xbea0047eu,
+        0x87ea6a20u,
+        0x7e000280u,
+        0xbf840003u,
+        0x7d840100u,
+        0x02020100u,
+        0xbf860002u,
+        0xbf060000u,
+        0xbf850001u,
+        0x7e020280u,
+        0x7e000314u,                         // v_mov_b32 v0,v20
+        0xbf810000u,
+    };
+    std::vector<uint32_t> spvT28b = recompile_valu(
+        codeT28b, std::size(codeT28b), 2, 0);
+    CHECK(!spvT28b.empty(),
+          "recompiled T28b (GTA V partial-row DPP add) -> SPIR-V");
+    std::vector<float> inT28b(128 * 2), expT28b(128);
+    constexpr uint32_t one_bitsT28b = 0x3f800000u;
+    constexpr uint32_t addend_bitsT28b = 0x00800000u;
+    for (uint32_t i = 0; i < 128; ++i) {
+        std::memcpy(&inT28b[i * 2], &one_bitsT28b, sizeof(uint32_t));
+        std::memcpy(&inT28b[i * 2 + 1], &addend_bitsT28b, sizeof(uint32_t));
+        expT28b[i] = (((i % 64u) / 16u) & 1u) ? 2.0f : 1.0f;
+    }
+    std::vector<float> gotT28b = prosper::test::run_compute(
+        spvT28b, inT28b, 128, 128);
+    CHECK(gotT28b == expT28b,
+          "T28b: ROW_MASK=0xa adds rows 1/3 and BC0 preserves rows 0/2 per wave64");
+
     // T29: exact S_BFM_B64 word from Astro's title reduction shader.  It creates VCC with the low
     // 32 lanes set, then saveexec predicates a write.  The operation repeats independently in each
     // architectural wave64 even when the Vulkan workgroup contains two waves.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -789,6 +789,43 @@ int main() {
     CHECK(got17d1m.size() == 64 && bad17d1m == 0,
           "Wave32 scalar mask activates only its selected guest lanes");
 
+    // Kernel 17d1c: GTA V's exact PC1309 packet selects scalar s4 into VCC_LO, preserves the
+    // selected dword as scalar data, and exposes each bit as this lane's implicit cndmask predicate.
+    // PC1310 is retained between producer and consumer. A second scalar cselect pins SCC preservation;
+    // the final XOR pins the simultaneous scalar-data lifetime instead of testing only the mask view.
+    const uint32_t code17d1c[] = {
+        0xbe8403ffu, 0x80000009u, // s_mov_b32 s4, 0x80000009
+        0xbf060000u,              // s_cmp_eq_u32 s0, s0 (SCC=1)
+        0x7e020287u,              // v_mov_b32 v1, 7
+        0x856a8004u,              // s_cselect_b32 vcc_lo, s4, 0 (exact GTA V packet)
+        0x061212f2u,              // PC1310 packet between the cselect and implicit consumer
+        0x02020290u,              // v_cndmask_b32 v1, 16, v1, vcc (exact PC1311 packet)
+        0x85058281u,              // s_cselect_b32 s5, 1, 2 (SCC must still be one)
+        0x4a020205u,              // v_add_nc_u32 v1, s5, v1
+        0x3a02026au,              // v_xor_b32 v1, vcc_lo, v1 (full scalar dword)
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> portable_spv17d1c = recompile_compute(
+        code17d1c, std::size(code17d1c), &rt17d1, portable_cfg17d1);
+    CHECK(!portable_spv17d1c.empty(),
+          "GTA V Wave32 scalar cselect publishes a VCC_LO predicate");
+    std::vector<uint32_t> initial17d1c(64, 0u), got17d1c;
+    prosper::test::run_compute(portable_spv17d1c, std::vector<float>(64, 0.0f),
+                               64, 64, {}, initial17d1c, &got17d1c);
+    constexpr uint32_t scalar_mask17d1c = 0x80000009u;
+    uint32_t bad17d1c = 0;
+    for (uint32_t lane = 0; lane < 64 && got17d1c.size() == 64; ++lane) {
+        const bool selected = ((scalar_mask17d1c >> (lane & 31u)) & 1u) != 0;
+        const uint32_t expected = scalar_mask17d1c ^ (selected ? 8u : 17u);
+        bad17d1c += got17d1c[lane] != expected;
+    }
+    CHECK(got17d1c.size() == 64 && bad17d1c == 0,
+          "scalar cselect selects lane bits, retains its dword, and preserves SCC");
+    CHECK(recompile_compute(code17d1c, std::size(code17d1c), &rt17d1,
+                            native_cfg17d).empty(),
+          "scalar-data cselect into VCC_LO remains rejected for Wave64");
+
     // Kernel 17d1w: the next Astro traversal instruction writes a scalar-data VCC_HI value to the
     // VGPR lane selected by s45. Preserve v1's local-id value in every other lane so execution tests
     // both halves of V_WRITELANE's read/modify/write behavior. These are the exact GFX10 packets for

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -8790,7 +8790,36 @@ int main() {
         CHECK(edge_grown_ok,
               "IMAGE_BVH_INTERSECT_RAY applies descriptor-selected box growth");
 
-        std::vector<uint32_t> tri_words(32, 0u);
+        ShaderResourceTable bvh64_rt = bvh_rt;
+        bvh64_rt.resources[0].size = 64u;
+        bvh64_rt.resources[0].bvh_box_grow = 0u;
+
+        // A 64-byte allocation cannot contain a complete FP32 box node. It must therefore return
+        // no-hit even though the first child's ID and six bounds fit in the allocation and describe
+        // a hit. This catches unsigned underflow in the 128-byte node bound: (64-128)/8 would make
+        // every node offset appear valid while the individually-clamped loads conceal the OOB read.
+        std::vector<uint32_t> short_box_words(16, 0u);
+        short_box_words[0] = 0x100u;
+        short_box_words[4] = bits_of(-1.0f); short_box_words[5] = bits_of(-1.0f);
+        short_box_words[6] = bits_of(-1.0f); short_box_words[7] = bits_of( 1.0f);
+        short_box_words[8] = bits_of( 1.0f); short_box_words[9] = bits_of( 1.0f);
+        for (uint32_t lane = 0; lane < lanes; ++lane)
+            set_ray(lane, 5u, 0.0f, 0.0f, -5.0f);
+        bool short_box_ok = true;
+        for (uint32_t component = 0; component < 4; ++component) {
+            const std::vector<uint32_t> module = recompile_valu(
+                bvh_code, std::size(bvh_code), inputs_per_lane, 3u + component, &bvh64_rt);
+            const std::vector<float> output = module.empty() ? std::vector<float>{} :
+                prosper::test::run_compute(
+                    module, bvh_inputs, lanes, lanes, short_box_words);
+            short_box_ok &= !module.empty() && output.size() == lanes;
+            for (uint32_t lane = 0; lane < output.size(); ++lane)
+                short_box_ok &= bits_of(output[lane]) == 0xffffffffu;
+        }
+        CHECK(short_box_ok,
+              "64-byte IMAGE_BVH_INTERSECT_RAY rejects an incomplete FP32 box node");
+
+        std::vector<uint32_t> tri_words(16, 0u);
         tri_words[0] = bits_of(9.0f); tri_words[1] = bits_of(9.0f); tri_words[2] = bits_of(9.0f);
         tri_words[3] = bits_of(0.0f); tri_words[4] = bits_of(0.0f); tri_words[5] = bits_of(0.0f); // V1
         tri_words[6] = bits_of(0.0f); tri_words[7] = bits_of(1.0f); tri_words[8] = bits_of(0.0f); // V2
@@ -8798,13 +8827,15 @@ int main() {
         tri_words[15] = 0x00000900u; // type-1 I=vertex1, J=vertex2
         for (uint32_t lane = 0; lane < lanes; ++lane) set_ray(lane, 1u, 0.25f, 0.25f, -1.0f);
         const std::vector<uint32_t> tri_module = recompile_valu(
-            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh_rt);
-        const std::vector<float> tri_output = prosper::test::run_compute(
-            tri_module, bvh_inputs, lanes, lanes, tri_words);
+            bvh_code, std::size(bvh_code), inputs_per_lane, 3, &bvh64_rt);
+        const std::vector<float> tri_output = tri_module.empty() ? std::vector<float>{} :
+            prosper::test::run_compute(
+                tri_module, bvh_inputs, lanes, lanes, tri_words);
         bool tri_ok = tri_output.size() == lanes;
         for (uint32_t lane = 0; lane < tri_output.size(); ++lane)
             tri_ok &= bits_of(tri_output[lane]) == bits_of(-1.0f);
-        CHECK(tri_ok, "IMAGE_BVH_INTERSECT_RAY type-1 triangle returns its exact t numerator");
+        CHECK(!tri_module.empty() && tri_ok,
+              "64-byte IMAGE_BVH_INTERSECT_RAY type-1 triangle returns its exact t numerator");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -298,6 +298,193 @@ int main() {
                             &sampled_vcc_rt, sampled_vcc_config).empty(),
           "an MIMG sampler range overlapping VCC keeps the guarded scalar write live");
 
+    // GTA V's texture-transfer compute kernels load two adjacent eight-word T# descriptors with one
+    // immediate s_load_dwordx16. The load has one SRT offset but the halves are distinct resources,
+    // so only exact consuming-PC bindings are sound. Prove both bindings are emitted and the scalar
+    // load does not manufacture the legacy fallback constant buffer at binding 2.
+    auto x16_texture = [](uint32_t binding, uint32_t fetch_pc) {
+        ShaderResource texture{};
+        texture.cls = ResourceClass::Texture;
+        texture.format = DataFormat::Float32;
+        texture.num_components = 4;
+        texture.binding = binding;
+        texture.fetch_pc = fetch_pc;
+        texture.img_dim = 1;
+        texture.width = texture.height = 2;
+        return texture;
+    };
+    const uint32_t smem_x16_pair[] = {
+        0xf4100300u, 0xfa000000u,   // pc0: s_load_dwordx16 s[12:27], s[0:1], 0
+        0xf0800f08u, 0x01630000u,   // pc2: image_sample ..., s[12:19], s[44:47]
+        0xf0800f08u, 0x01850000u,   // pc4: image_sample ..., s[20:27], s[48:51]
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_pair_rt;
+    smem_x16_pair_rt.resources.push_back(x16_texture(4, 2));
+    smem_x16_pair_rt.resources.push_back(x16_texture(5, 4));
+    const std::vector<uint32_t> smem_x16_pair_spv = recompile_valu(
+        smem_x16_pair, std::size(smem_x16_pair), 2, 0, &smem_x16_pair_rt);
+    ShaderResourceTable smem_x16_pair_validation_rt = smem_x16_pair_rt;
+    for (uint32_t binding = 0; binding < 2; ++binding) {
+        ShaderResource io{};
+        io.cls = ResourceClass::VertexBuffer;
+        io.binding = binding;
+        smem_x16_pair_validation_rt.resources.push_back(io);
+    }
+    const DescriptorValidationReport smem_x16_pair_report =
+        validate_spirv_descriptor_interface(smem_x16_pair_spv,
+                                            &smem_x16_pair_validation_rt, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(!smem_x16_pair_spv.empty() && smem_x16_pair_report.ok() &&
+              find_spirv_descriptor_binding(smem_x16_pair_report, 0, 4) &&
+              find_spirv_descriptor_binding(smem_x16_pair_report, 0, 5) &&
+              !find_spirv_descriptor_binding(smem_x16_pair_report, 0, 2),
+          "x16 descriptor bundle routes its two T# halves by exact PC without fallback cbuf");
+
+    // Ordinary data use makes the x16 typeless again. Replacing that SGPR read with a descriptor-only
+    // admission would silently substitute zero for real scalar data.
+    const uint32_t smem_x16_data[] = {
+        0xf4100300u, 0xfa000000u,
+        0x7e04020cu,                 // v_mov_b32 v2, s12: ordinary data read of the loaded range
+        0xf0800f08u, 0x01630000u,
+        0xf0800f08u, 0x01850000u,
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_data_rt;
+    smem_x16_data_rt.resources.push_back(x16_texture(4, 3));
+    smem_x16_data_rt.resources.push_back(x16_texture(5, 5));
+    CHECK(recompile_valu(smem_x16_data, std::size(smem_x16_data), 2, 0,
+                         &smem_x16_data_rt).empty(),
+          "x16 load with an ordinary scalar/vector consumer remains fail-visible");
+
+    ShaderResourceTable smem_x16_missing_rt;
+    smem_x16_missing_rt.resources.push_back(x16_texture(4, 2));
+    CHECK(recompile_valu(smem_x16_pair, std::size(smem_x16_pair), 2, 0,
+                         &smem_x16_missing_rt).empty(),
+          "x16 bundle rejects when one MIMG consumer lacks an exact-PC resource");
+    ShaderResourceTable smem_x16_wrong_rt = smem_x16_pair_rt;
+    smem_x16_wrong_rt.resources[1].cls = ResourceClass::ConstantBuffer;
+    CHECK(recompile_valu(smem_x16_pair, std::size(smem_x16_pair), 2, 0,
+                         &smem_x16_wrong_rt).empty(),
+          "x16 bundle rejects an exact-PC resource of the wrong descriptor class");
+
+    // GTA V also issues two x16 loads, including a nonzero immediate, to form four independent T#s.
+    const uint32_t smem_x16_two_loads[] = {
+        0xf4100300u, 0xfa000040u,   // pc0: s[12:27], byte offset 0x40
+        0xf4100700u, 0xfa000000u,   // pc2: s[28:43], byte offset 0
+        0xf0800f08u, 0x01e30000u,   // pc4:  T# s[12:19], S# s[60:63]
+        0xf0800f08u, 0x01e50000u,   // pc6:  T# s[20:27]
+        0xf0800f08u, 0x01e70000u,   // pc8:  T# s[28:35]
+        0xf0800f08u, 0x01e90000u,   // pc10: T# s[36:43]
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_two_rt;
+    for (uint32_t i = 0; i < 4; ++i)
+        smem_x16_two_rt.resources.push_back(x16_texture(4 + i, 4 + i * 2));
+    const std::vector<uint32_t> smem_x16_two_spv = recompile_valu(
+        smem_x16_two_loads, std::size(smem_x16_two_loads), 2, 0, &smem_x16_two_rt);
+    ShaderResourceTable smem_x16_two_validation_rt = smem_x16_two_rt;
+    for (uint32_t binding = 0; binding < 2; ++binding) {
+        ShaderResource io{};
+        io.cls = ResourceClass::VertexBuffer;
+        io.binding = binding;
+        smem_x16_two_validation_rt.resources.push_back(io);
+    }
+    const DescriptorValidationReport smem_x16_two_report =
+        validate_spirv_descriptor_interface(smem_x16_two_spv,
+                                            &smem_x16_two_validation_rt, 0,
+                                            SpirvShaderStage::Compute, false);
+    bool smem_x16_four_bindings = !smem_x16_two_spv.empty() && smem_x16_two_report.ok();
+    for (uint32_t binding = 4; binding < 8; ++binding)
+        smem_x16_four_bindings &=
+            find_spirv_descriptor_binding(smem_x16_two_report, 0, binding) != nullptr;
+    CHECK(smem_x16_four_bindings &&
+              !find_spirv_descriptor_binding(smem_x16_two_report, 0, 2),
+          "nonzero-offset and two-x16 bundle routes four exact-PC textures without cbuf");
+
+    // The captured patched variant clears/replaces only T#.word3's type bits through a scalar
+    // temporary. Its first patch schedules one unrelated VOP between AND and OR; both exact
+    // resources must remain independently routed after their live descriptor words change.
+    const uint32_t smem_x16_patched[] = {
+        0xf4100300u, 0xfa000000u,
+        0x876aff17u, 0x0fffffffu,   // pc2:  s_and_b32 vcc_lo, s23, 0x0fffffff
+        0x4a080802u,                // pc4:  independent VOP scheduled inside the patch chain
+        0x8817ff6au, 0xd0000000u,   // pc5:  s_or_b32  s23, vcc_lo, 0xd0000000
+        0xf0800f08u, 0x01650000u,   // pc7:  sample T# s[20:27]
+        0x876aff0fu, 0x0fffffffu,   // pc9:  s_and_b32 vcc_lo, s15, 0x0fffffff
+        0x880fff6au, 0xd0000000u,   // pc11: s_or_b32  s15, vcc_lo, 0xd0000000
+        0xf0800f08u, 0x01830000u,   // pc13: sample T# s[12:19]
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_patched_rt;
+    smem_x16_patched_rt.resources.push_back(x16_texture(4, 7));
+    smem_x16_patched_rt.resources.push_back(x16_texture(5, 13));
+    const std::vector<uint32_t> smem_x16_patched_spv = recompile_valu(
+        smem_x16_patched, std::size(smem_x16_patched), 2, 0, &smem_x16_patched_rt);
+    CHECK(!smem_x16_patched_spv.empty(),
+          "x16 descriptor bundle admits the captured scheduled T#.word3 patch chain");
+
+    // The placeholder word3 makes the patch temporary provenance-only too. Any observation before
+    // that temporary is overwritten would consume zero-derived scalar data instead of guest data.
+    const uint32_t smem_x16_patched_temp_read[] = {
+        0xf4100300u, 0xfa000000u,
+        0x876aff17u, 0x0fffffffu,
+        0x4a080802u,
+        0x8817ff6au, 0xd0000000u,
+        0x7e04026au,                // pc7: v_mov_b32 v2, vcc_lo observes the patch temporary
+        0xf0800f08u, 0x01650000u,
+        0x876aff0fu, 0x0fffffffu,
+        0x880fff6au, 0xd0000000u,
+        0xf0800f08u, 0x01830000u,
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_patched_temp_rt;
+    smem_x16_patched_temp_rt.resources.push_back(x16_texture(4, 8));
+    smem_x16_patched_temp_rt.resources.push_back(x16_texture(5, 14));
+    CHECK(recompile_valu(smem_x16_patched_temp_read,
+                         std::size(smem_x16_patched_temp_read), 2, 0,
+                         &smem_x16_patched_temp_rt).empty(),
+          "x16 word3 patch rejects a post-join observation of its descriptor-derived temporary");
+
+    // Same gap site, two implicit data dependencies the decoded ordinary-source walk does not
+    // cover: Special253 observes the AND-produced SCC, and e32 cndmask observes VCC_LO implicitly.
+    uint32_t smem_x16_patched_scc_gap[std::size(smem_x16_patched)];
+    std::copy(std::begin(smem_x16_patched), std::end(smem_x16_patched),
+              std::begin(smem_x16_patched_scc_gap));
+    smem_x16_patched_scc_gap[4] = 0x7e0402fdu; // v_mov_b32 v2, scc
+    CHECK(recompile_valu(smem_x16_patched_scc_gap, std::size(smem_x16_patched_scc_gap),
+                         2, 0, &smem_x16_patched_rt).empty(),
+          "x16 word3 patch gap rejects an observation of the AND-produced SCC");
+    uint32_t smem_x16_patched_vcc_gap[std::size(smem_x16_patched)];
+    std::copy(std::begin(smem_x16_patched), std::end(smem_x16_patched),
+              std::begin(smem_x16_patched_vcc_gap));
+    smem_x16_patched_vcc_gap[4] = 0x02020100u; // v_cndmask_b32 v1,v0,v0,vcc (implicit VCC read)
+    CHECK(recompile_valu(smem_x16_patched_vcc_gap, std::size(smem_x16_patched_vcc_gap),
+                         2, 0, &smem_x16_patched_rt).empty(),
+          "x16 word3 patch gap rejects an implicit VCC observation of its temporary");
+
+    // M0 looks like another scalar temporary to the decoded operand walk, but DS append observes it
+    // implicitly. The admitted compiler shape uses VCC_LO exactly; broadening that register gate
+    // would therefore turn this into a silent placeholder-derived LDS allocator input.
+    const uint32_t smem_x16_patched_m0_ds[] = {
+        0xf4100300u, 0xfa000000u,
+        0x877cff17u, 0x0fffffffu,   // pc2:  s_and_b32 m0, s23, 0x0fffffff
+        0x4a080802u,
+        0x8817ff7cu, 0xd0000000u,   // pc5:  s_or_b32 s23, m0, 0xd0000000
+        0xd8f80008u, 0x03000000u,   // pc7:  ds_append v3 offset:8 implicitly observes m0
+        0xf0800f08u, 0x01650000u,   // pc9:  sample T# s[20:27]
+        0x876aff0fu, 0x0fffffffu,
+        0x880fff6au, 0xd0000000u,
+        0xf0800f08u, 0x01830000u,   // pc15: sample T# s[12:19]
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x16_patched_m0_rt;
+    smem_x16_patched_m0_rt.resources.push_back(x16_texture(4, 9));
+    smem_x16_patched_m0_rt.resources.push_back(x16_texture(5, 15));
+    CHECK(recompile_valu(smem_x16_patched_m0_ds, std::size(smem_x16_patched_m0_ds),
+                         2, 0, &smem_x16_patched_m0_rt).empty(),
+          "x16 word3 patch rejects M0 as a temporary before an implicit DS observation");
+
     // A post-merge B64 scalar write kills both VCC words before v_cndmask consumes the new mask. The
     // high-half proof must use the central scalar write-width inventory: checking only dst==R leaves
     // VCC_HI spuriously live and rejects this otherwise-structured EXECZ guard.

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -50,6 +50,41 @@ int main() {
     CHECK(!co_spv.empty() && co_spv[0] == 0x07230203u,
           "v_add_co_u32 lowers to a valid compute SPIR-V module");
 
+    // GTA V's world-entry compute programs 0x413ce6000 and 0x413ce6d00 contain these exact
+    // V_ALIGNBYTE_B32 packets (including the literal dword).  This is a VOP3A integer result:
+    // {src0,src1} is shifted right by 8*src2[4:0], with src1 as the low dword, and no VCC output.
+    const uint32_t alignbyte_live[] = {
+        0xd54f0006u, 0x0415fe80u, 0x3024240cu, // v_alignbyte_b32 v6, 0, 0x3024240c, v5
+        0xd54f0008u, 0x0415fe80u, 0x00301818u, // v_alignbyte_b32 v8, 0, 0x00301818, v5
+        0xbf810000u,
+    };
+    const RecompileCoverage alignbyte_coverage = recompile_coverage(
+        alignbyte_live, std::size(alignbyte_live));
+    CHECK(alignbyte_coverage.total == 2 && alignbyte_coverage.alu == 2 &&
+              alignbyte_coverage.unsupported == 0 && alignbyte_coverage.first_bad_fmt < 0,
+          "GTA V's exact V_ALIGNBYTE_B32 literal packets report supported ALU coverage");
+    const std::vector<uint32_t> alignbyte_spv = recompile_valu(
+        alignbyte_live, std::size(alignbyte_live), /*num_inputs*/6, /*out_vgpr*/6);
+    CHECK(!alignbyte_spv.empty() && alignbyte_spv[0] == 0x07230203u,
+          "GTA V's exact V_ALIGNBYTE_B32 packet lowers to a compute SPIR-V module");
+
+    // Unsupported modifier encodings must not fall through as the unmodified integer operation.
+    // These mutate the same live production packet, one decoded modifier field at a time.
+    const auto alignbyte_rejects = [](uint32_t word0, uint32_t word1) {
+        const uint32_t code[] = {word0, word1, 0x3024240cu, 0xbf810000u};
+        const RecompileCoverage coverage = recompile_coverage(code, std::size(code));
+        return coverage.unsupported == 1 && coverage.first_bad_op == 0x14f &&
+               recompile_valu(code, std::size(code), 6, 6).empty();
+    };
+    CHECK(alignbyte_rejects(0xd54f0106u, 0x0415fe80u),
+          "V_ALIGNBYTE_B32 ABS mutation remains fail-visible");
+    CHECK(alignbyte_rejects(0xd54f0006u, 0x2415fe80u),
+          "V_ALIGNBYTE_B32 NEG mutation remains fail-visible");
+    CHECK(alignbyte_rejects(0xd54f8006u, 0x0415fe80u),
+          "V_ALIGNBYTE_B32 CLAMP mutation remains fail-visible");
+    CHECK(alignbyte_rejects(0xd54f0006u, 0x0c15fe80u),
+          "V_ALIGNBYTE_B32 OMOD mutation remains fail-visible");
+
     // analyze_flat_loads (#1171): resolve a general (non-scratch) flat_load's 64-bit address to its base
     // user-SGPR pointer pair. Encodings are byte-identical to GTA V's texture-decode kernel
     // exec_cs_2042d47600 (pc=0030/0040): the low address dword adds base-low s12, the high dword adds

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -190,6 +190,114 @@ int main() {
                                              std::size(live_vcc_hi_guard)), 1u),
           "a real VCC_HI vector read keeps the guarded scalar write non-linearizable");
 
+    // GTA V uses a scalar load into VCC_LO as temporary data inside an EXECZ guard, then crosses an
+    // image access before the temporary dies. MIMG's decoded T# and S# ranges are the complete scalar
+    // read set, so an unrelated resource must not stop the merge-liveness proof. Exercise the actual
+    // compute structurizer/emitter path rather than only its liveness helper.
+    const uint32_t mimg_vcc_scratch_guard[] = {
+        0x7E080300u,                 // 0: v_mov_b32 v4, v0 (1D image coordinate)
+        0x7C220080u,                 // 1: v_cmpx_neq_f32 exec, 0, v0
+        0xBF880002u,                 // 2: s_cbranch_execz -> pc=5
+        0xF4201A84u, 0xFA000000u,   // 3: s_buffer_load_dword vcc_lo, s[8:11], 0
+        0xF0000F00u, 0x00000004u,   // 5: image_load v[0:3], v4, s[0:7], dmask:0xf dim:1D
+        0xBF810000u,
+    };
+    ShaderResourceTable mimg_guard_rt;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage; image.binding = 4;
+      image.img_dim = 0; image.sgpr_base = 0; mimg_guard_rt.resources.push_back(image); }
+    { ShaderResource constants{}; constants.cls = ResourceClass::ConstantBuffer;
+      constants.binding = 5; constants.sgpr_base = 8; constants.size = 64;
+      mimg_guard_rt.resources.push_back(constants); }
+    ComputeShaderConfig mimg_guard_config;
+    mimg_guard_config.user_sgprs.resize(16);
+    CHECK(!recompile_compute(mimg_vcc_scratch_guard, std::size(mimg_vcc_scratch_guard),
+                             &mimg_guard_rt, mimg_guard_config).empty(),
+          "an unrelated MIMG T# range is transparent to post-merge VCC liveness");
+
+    // Same-site mutation: move the image's decoded eight-word SRSRC range to s[104:111], which
+    // overlaps VCC_LO/HI. The image now observes the guarded scalar write and must stay fail-visible.
+    uint32_t mimg_vcc_resource[std::size(mimg_vcc_scratch_guard)];
+    std::copy(std::begin(mimg_vcc_scratch_guard), std::end(mimg_vcc_scratch_guard),
+              std::begin(mimg_vcc_resource));
+    mimg_vcc_resource[6] = 0x001A0004u; // image_load ..., s[104:111]
+    ShaderResourceTable mimg_vcc_rt = mimg_guard_rt;
+    mimg_vcc_rt.resources[0].sgpr_base = 104;
+    ComputeShaderConfig mimg_vcc_config = mimg_guard_config;
+    mimg_vcc_config.user_sgprs.resize(112);
+    CHECK(!has(safe_execz_branches_for_test(mimg_vcc_resource,
+                                             std::size(mimg_vcc_resource)), 2u),
+          "an MIMG SRSRC overlap specifically blocks the dead-scalar linearization proof");
+    CHECK(recompile_compute(mimg_vcc_resource, std::size(mimg_vcc_resource),
+                            &mimg_vcc_rt, mimg_vcc_config).empty(),
+          "an MIMG SRSRC range overlapping VCC keeps the guarded scalar write live");
+
+    // Sampled images add a separately decoded four-word sampler source. Prove that the liveness scan
+    // crosses an unrelated S# as well, while a same-site S# mutation onto VCC remains conservative.
+    uint32_t sampled_mimg_guard[std::size(mimg_vcc_scratch_guard)];
+    std::copy(std::begin(mimg_vcc_scratch_guard), std::end(mimg_vcc_scratch_guard),
+              std::begin(sampled_mimg_guard));
+    sampled_mimg_guard[5] = 0xF0800F08u; // image_sample v[0:3], v[0:1], s[0:7], s[16:19]
+    sampled_mimg_guard[6] = 0x00800000u;
+    ShaderResourceTable sampled_guard_rt;
+    { ShaderResource texture{}; texture.cls = ResourceClass::Texture; texture.binding = 4;
+      texture.img_dim = 1; texture.width = 4; texture.height = 4; texture.sgpr_base = 0;
+      texture.sampler_sgpr_base = 16; sampled_guard_rt.resources.push_back(texture); }
+    sampled_guard_rt.resources.push_back(mimg_guard_rt.resources[1]);
+    ComputeShaderConfig sampled_guard_config = mimg_guard_config;
+    sampled_guard_config.user_sgprs.resize(20);
+    CHECK(!recompile_compute(sampled_mimg_guard, std::size(sampled_mimg_guard),
+                             &sampled_guard_rt, sampled_guard_config).empty(),
+          "unrelated MIMG T# and S# ranges are transparent to post-merge VCC liveness");
+    uint32_t sampled_vcc_sampler[std::size(sampled_mimg_guard)];
+    std::copy(std::begin(sampled_mimg_guard), std::end(sampled_mimg_guard),
+              std::begin(sampled_vcc_sampler));
+    sampled_vcc_sampler[6] = 0x03400000u; // image_sample ..., s[0:7], s[104:107]
+    ShaderResourceTable sampled_vcc_rt = sampled_guard_rt;
+    sampled_vcc_rt.resources[0].sampler_sgpr_base = 104;
+    ComputeShaderConfig sampled_vcc_config = sampled_guard_config;
+    sampled_vcc_config.user_sgprs.resize(108);
+    CHECK(!has(safe_execz_branches_for_test(sampled_vcc_sampler,
+                                             std::size(sampled_vcc_sampler)), 2u),
+          "an MIMG sampler overlap specifically blocks the dead-scalar linearization proof");
+    CHECK(recompile_compute(sampled_vcc_sampler, std::size(sampled_vcc_sampler),
+                            &sampled_vcc_rt, sampled_vcc_config).empty(),
+          "an MIMG sampler range overlapping VCC keeps the guarded scalar write live");
+
+    // A post-merge B64 scalar write kills both VCC words before v_cndmask consumes the new mask. The
+    // high-half proof must use the central scalar write-width inventory: checking only dst==R leaves
+    // VCC_HI spuriously live and rejects this otherwise-structured EXECZ guard.
+    const uint32_t b64_vcc_kill_guard[] = {
+        0x7E080300u,                 // 0: v_mov_b32 v4, v0 (1D image coordinate)
+        0x7D840100u,                 // 1: v_cmp_eq_u32 vcc, v0, v0
+        0xBF880001u,                 // 2: s_cbranch_execz -> pc=4
+        0xBEEA047Eu,                 // 3: s_mov_b64 vcc, exec (guarded write)
+        0xBEEA047Eu,                 // 4: s_mov_b64 vcc, exec (kills both words after merge)
+        0xF0000F00u, 0x00000004u,   // 5: unrelated image_load through s[0:7]
+        0x02020100u,                 // 7: v_cndmask_b32 v1, v0, v0, vcc
+        0xBF810000u,
+    };
+    ComputeShaderConfig b64_kill_config;
+    b64_kill_config.user_sgprs.resize(8);
+    CHECK(has(structured_execz_branches_for_test(b64_vcc_kill_guard,
+                                                  std::size(b64_vcc_kill_guard)), 2u),
+          "the B64 pair kill admits the guarded write through the structured compute CFG");
+    CHECK(!recompile_compute(b64_vcc_kill_guard, std::size(b64_vcc_kill_guard), &mimg_guard_rt,
+                             b64_kill_config).empty(),
+          "a post-merge B64 write kills both VCC halves before their next consumer");
+
+    // Same-site mutation: a B32 low-half write cannot kill the guarded high half. The following
+    // whole-VCC consumer makes that surviving value observable, so structurization must reject.
+    uint32_t b32_vcc_lo_kill[std::size(b64_vcc_kill_guard)];
+    std::copy(std::begin(b64_vcc_kill_guard), std::end(b64_vcc_kill_guard),
+              std::begin(b32_vcc_lo_kill));
+    b32_vcc_lo_kill[4] = 0xBEEA037Eu; // s_mov_b32 vcc_lo, exec_lo
+    CHECK(!has(structured_execz_branches_for_test(b32_vcc_lo_kill,
+                                                   std::size(b32_vcc_lo_kill)), 2u),
+          "the B32 low-half mutation is rejected by the structured compute CFG proof");
+    CHECK(recompile_compute(b32_vcc_lo_kill, std::size(b32_vcc_lo_kill), &mimg_guard_rt,
+                            b64_kill_config).empty(),
+          "a low-half-only B32 write does not kill live VCC_HI at the merge");
+
     // Wave32 kernels use one-word mask instructions around EXEC: compare into VCC_LO, invert that
     // mask, copy it to EXEC_LO, then restore EXEC_LO. These are mask-domain operations, not scalar
     // reads of an unrepresentable VCC dword.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -868,6 +868,89 @@ int main() {
               count_occurrences(live_reject_capture.output, live_reject_program) == 1,
           "live shader-recompile failure reports its final dispatch-skipped consequence");
 
+    // IMAGE_LOAD_MIP level-zero lowering is compiled semantics, not runtime descriptor data. A
+    // captured or later dispatch without the instruction-scoped proof must miss and reject rather
+    // than reuse the specialized module; restoring the proof should hit the original entry.
+    clear_shader_recompile_cache();
+    static const uint32_t kZeroMipCompute[] = {
+        0x7e040207u,                         // v_mov_b32 v2, s7
+        0xf0043f08u, 0x00050000u,            // IMAGE_LOAD_MIP xyzw 2D, T# s[20:27]
+        0xbf810000u,
+    };
+    ShaderResource zero_mip_texture;
+    zero_mip_texture.cls = ResourceClass::Texture;
+    zero_mip_texture.format = DataFormat::Uint32;
+    zero_mip_texture.num_components = 1;
+    zero_mip_texture.binding = 4;
+    zero_mip_texture.fetch_pc = 1;
+    zero_mip_texture.img_dim = 1;
+    zero_mip_texture.width = zero_mip_texture.height = 4;
+    zero_mip_texture.depth = 1;
+    zero_mip_texture.size = 64;
+    zero_mip_texture.proven_zero_mip = true;
+    ShaderResourceTable zero_mip_table;
+    zero_mip_table.resources.push_back(zero_mip_texture);
+    ComputeShaderConfig zero_mip_config;
+    zero_mip_config.user_sgprs.resize(28);
+    zero_mip_config.local_x = 1;
+    const auto cached_proven_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    zero_mip_table.resources[0].proven_zero_mip = false;
+    const auto cached_unproven_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    zero_mip_table.resources[0].proven_zero_mip = true;
+    const auto repeated_proven_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    zero_mip_table.resources[0].declared_mip_levels = 2;
+    const auto cached_multilevel_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    zero_mip_table.resources[0].declared_mip_levels = 1;
+    zero_mip_table.resources[0].compression_enabled = true;
+    const auto cached_dcc_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    zero_mip_table.resources[0].compression_enabled = false;
+    zero_mip_table.resources[0].in_mip_tail = true;
+    const auto cached_tail_zero_mip = recompile_compute_shader_cached(
+        kZeroMipCompute, std::size(kZeroMipCompute), &zero_mip_table, zero_mip_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!cached_proven_zero_mip.empty() && cached_unproven_zero_mip.empty() &&
+              repeated_proven_zero_mip == cached_proven_zero_mip &&
+              cached_multilevel_zero_mip.empty() && cached_dcc_zero_mip.empty() &&
+              cached_tail_zero_mip.empty() &&
+              stats.misses == 5 && stats.hits == 1 && stats.entries == 5,
+          "compute cache partitions zero-mip proof, levels, DCC, and texture-tail safety");
+
+    clear_shader_recompile_cache();
+    static const uint32_t kZeroStoreMipCompute[] = {
+        0x7e0a0206u,
+        0xf024310au, 0x00030004u, 0x00000503u,
+        0xbf810000u,
+    };
+    ShaderResource zero_store_mip_image;
+    zero_store_mip_image.cls = ResourceClass::StorageImage;
+    zero_store_mip_image.format = DataFormat::Uint32;
+    zero_store_mip_image.num_components = 1;
+    zero_store_mip_image.binding = 4;
+    zero_store_mip_image.fetch_pc = 1;
+    zero_store_mip_image.img_dim = 1;
+    zero_store_mip_image.width = zero_store_mip_image.height = 4;
+    zero_store_mip_image.depth = 1;
+    zero_store_mip_image.size = 64;
+    zero_store_mip_image.proven_zero_mip = true;
+    ShaderResourceTable zero_store_mip_table;
+    zero_store_mip_table.resources.push_back(zero_store_mip_image);
+    const auto cached_zero_store_mip = recompile_compute_shader_cached(
+        kZeroStoreMipCompute, std::size(kZeroStoreMipCompute),
+        &zero_store_mip_table, zero_mip_config);
+    zero_store_mip_table.resources[0].declared_mip_levels = 2;
+    const auto cached_multilevel_store_mip = recompile_compute_shader_cached(
+        kZeroStoreMipCompute, std::size(kZeroStoreMipCompute),
+        &zero_store_mip_table, zero_mip_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!cached_zero_store_mip.empty() && cached_multilevel_store_mip.empty() &&
+              stats.misses == 2 && stats.hits == 0 && stats.entries == 2,
+          "compute cache keys storage-image declared mip levels inspected by the emitter");
+
     // A one-record 16-bit V# emits an explicit index guard and typed tail marker. Keep the cache
     // partition compact (none/u16/f16), while ensuring a wider range or the sibling conversion can
     // never reuse that specialized module.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -574,6 +574,51 @@ int main() {
               repeated_u16_tail == cached_u16_tail && stats.misses == 3 && stats.hits == 1,
           "compute cache partitions ordinary/u16/f16 one-record tail semantics exactly");
 
+    // A zero-record RAW V# is compiled into constants/no-ops, while a later nonzero descriptor at
+    // the same instruction emits a real buffer access. Addresses and ordinary sizes intentionally
+    // stay out of the module key, so partition only this exact semantic marker.
+    clear_shader_recompile_cache();
+    static const uint32_t kZeroRecordRawCompute[] = {
+        0xe0300000u, 0x80000000u, // buffer_load_dword v0, off, s[0:3]
+        0xbf810000u,
+    };
+    ShaderResource zero_record_raw;
+    zero_record_raw.cls = ResourceClass::ConstantBuffer;
+    zero_record_raw.format = DataFormat::Unknown;
+    zero_record_raw.num_components = 0;
+    zero_record_raw.binding = 3;
+    zero_record_raw.gpu_addr = 0;
+    zero_record_raw.size = 0;
+    zero_record_raw.stride = 0;
+    zero_record_raw.srt_offset = 0xFFFFFFFFu;
+    zero_record_raw.sgpr_base = 0xFFFFFFFFu;
+    zero_record_raw.fetch_pc = 0;
+    ShaderResourceTable zero_record_raw_table;
+    zero_record_raw_table.resources.push_back(zero_record_raw);
+    ComputeShaderConfig zero_record_raw_config;
+    zero_record_raw_config.user_sgprs.resize(4);
+    zero_record_raw_config.local_x = 64;
+    const auto cached_zero_record_raw = recompile_compute_shader_cached(
+        kZeroRecordRawCompute, std::size(kZeroRecordRawCompute), &zero_record_raw_table,
+        zero_record_raw_config);
+    zero_record_raw_table.resources[0].gpu_addr = 0x20000u;
+    zero_record_raw_table.resources[0].size = 4;
+    const auto cached_nonzero_raw = recompile_compute_shader_cached(
+        kZeroRecordRawCompute, std::size(kZeroRecordRawCompute), &zero_record_raw_table,
+        zero_record_raw_config);
+    zero_record_raw_table.resources[0].gpu_addr = 0;
+    zero_record_raw_table.resources[0].size = 0;
+    const auto repeated_zero_record_raw = recompile_compute_shader_cached(
+        kZeroRecordRawCompute, std::size(kZeroRecordRawCompute), &zero_record_raw_table,
+        zero_record_raw_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(is_zero_record_raw_buffer(zero_record_raw_table.resources[0]) &&
+              !cached_zero_record_raw.empty() && !cached_nonzero_raw.empty() &&
+              cached_zero_record_raw != cached_nonzero_raw &&
+              repeated_zero_record_raw == cached_zero_record_raw && stats.misses == 2 &&
+              stats.hits == 1 && stats.entries == 2,
+          "compute cache separates exact zero-record RAW lowering from nonzero buffers");
+
     // Resource descriptor fields that specialize SPIR-V must participate in the cache identity.
     // Storage-image sRGB state changes whether the module declares a native float image or the raw
     // uint-channel fallback, even when the guest code and every binding/provenance field are equal.

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_execute.hpp"
+#include "../src/hle/dispatch.hpp"
 #include <atomic>
 #include <cstdint>
 #include <cstdlib>
@@ -74,6 +75,14 @@ static std::filesystem::path next_stderr_capture_path() {
     return prosper_test::test_scratch_dir() /
         ("shader-recompile-stderr-" +
          std::to_string(capture_sequence.fetch_add(1, std::memory_order_relaxed)) + ".log");
+}
+
+static size_t count_occurrences(const std::string& text, const std::string& needle) {
+    size_t count = 0;
+    for (size_t offset = 0; (offset = text.find(needle, offset)) != std::string::npos;
+         offset += needle.size())
+        ++count;
+    return count;
 }
 
 template <typename F>
@@ -685,6 +694,179 @@ int main() {
               " stage=compute program=none role=terminal\n") !=
               std::string::npos,
           "standalone compute recompilation uses an explicit neutral program identity");
+
+    // A nested guest-wave branch containing s_barrier cannot use either the compact structurizer or
+    // the synchronized CFG dispatcher. This is the exact GTA V route that used to return an empty
+    // module without a terminal line. Cache the rejection, then report two distinct live program
+    // addresses: the second compile must be a cache hit, while the final skip consequence remains
+    // attributable and once-per-address at the production reporting boundary.
+    static const uint32_t kExactWaveBarrierReject[] = {
+        0x7c020300u, // 0: v_cmp_lt_f32 vcc, v0, v1
+        0xbf860001u, // 1: s_cbranch_vccz +1 -> pc3 (exact guest-wave branch)
+        0x7e040281u, // 2: v_mov_b32 v2, 1
+        0xbf060000u, // 3: s_cmp_eq_u32 s0, s0
+        0xbf840002u, // 4: s_cbranch_scc0 +2 -> pc7
+        0xbf8a0000u, // 5: s_barrier nested in the scalar arm
+        0x7e040282u, // 6: v_mov_b32 v2, 2
+        0xbf810000u, // 7: s_endpgm
+    };
+    static const uint32_t kPartialBarrierReject[] = {
+        0xbf8a0000u, // s_barrier
+        0xbf810000u, // s_endpgm
+    };
+    ComputeShaderConfig rejected_config;
+    rejected_config.local_x = 64;
+    rejected_config.wave_size = 64;
+    rejected_config.threads_x = 64;
+    rejected_config.threads_y = rejected_config.threads_z = 1;
+    rejected_config.exact_thread_extent = true;
+    ComputeShaderConfig partial_barrier_config = rejected_config;
+    partial_barrier_config.threads_x = 65;
+    const RecompileDiagnosticContext rejected_diagnostic_a{
+        RecompileDiagnosticStage::Compute, 0x1234567800004455ull};
+    const RecompileDiagnosticContext rejected_diagnostic_b{
+        RecompileDiagnosticStage::Compute, 0xabcdef120000dd55ull};
+    const RecompileDiagnosticContext partial_barrier_diagnostic{
+        RecompileDiagnosticStage::Compute, 0x135724680000aa55ull};
+    clear_shader_recompile_cache();
+    std::vector<uint32_t> rejected_first, rejected_cached, partial_barrier;
+    set_test_env("PROSPER_DBG", "1");
+    const CapturedStderr final_reject_capture = capture_stderr([&] {
+        rejected_first = recompile_compute_shader_cached(
+            kExactWaveBarrierReject, std::size(kExactWaveBarrierReject), nullptr,
+            rejected_config, nullptr, rejected_diagnostic_a);
+        if (rejected_first.empty())
+            (void)report_compute_recompile_skip_once(rejected_diagnostic_a);
+        rejected_cached = recompile_compute_shader_cached(
+            kExactWaveBarrierReject, std::size(kExactWaveBarrierReject), nullptr,
+            rejected_config, nullptr, rejected_diagnostic_b);
+        if (rejected_cached.empty()) {
+            (void)report_compute_recompile_skip_once(rejected_diagnostic_b);
+            (void)report_compute_recompile_skip_once(rejected_diagnostic_b);
+        }
+        partial_barrier = recompile_compute(
+            kPartialBarrierReject, std::size(kPartialBarrierReject), nullptr,
+            partial_barrier_config, partial_barrier_diagnostic);
+    });
+    set_test_env("PROSPER_DBG", nullptr);
+    stats = shader_recompile_cache_stats();
+    const std::string& final_reject_log = final_reject_capture.output;
+    std::error_code final_reject_capture_error;
+    CHECK(final_reject_capture.path.parent_path() == prosper_test::test_scratch_dir() &&
+              !std::filesystem::exists(final_reject_capture.path, final_reject_capture_error) &&
+              !final_reject_capture_error,
+          "final-reject capture uses and cleans the process-private test scratch directory");
+    CHECK(rejected_first.empty() && rejected_cached.empty() &&
+              stats.misses == 1 && stats.hits == 1,
+          "rejected compute modules retain empty results across the real shader cache boundary");
+    CHECK(count_occurrences(
+              final_reject_log,
+              "[compute-cfg-reject] reason=exact-wave-dispatcher-unsafe guest-barrier=1 "
+              "stage=compute program=0x1234567800004455 role=terminal\n") == 1 &&
+              final_reject_log.find(
+              "reason=exact-wave-dispatcher-unsafe guest-barrier=1 stage=compute "
+              "program=0xabcdef120000dd55 role=terminal") == std::string::npos,
+          "exact-wave guest-barrier rejection is terminal at the compiler site and not replayed by a cache hit");
+    CHECK(count_occurrences(
+              final_reject_log,
+              "[compute-recompile-reject] reason=empty-result dispatch-skipped") == 2 &&
+              count_occurrences(
+              final_reject_log,
+              "stage=compute program=0x1234567800004455 role=consequent\n") == 1 &&
+              count_occurrences(
+              final_reject_log,
+              "stage=compute program=0xabcdef120000dd55 role=consequent\n") == 1,
+          "live empty-result consequences cover compile misses and cache hits once per program address");
+    CHECK(partial_barrier.empty() && count_occurrences(
+              final_reject_log,
+              "[compute-recompile-reject] reason=partial-workgroup-barrier "
+              "threads=65x1x1 local=64x1x1 stage=compute "
+              "program=0x135724680000aa55 role=terminal\n") == 1,
+          "partial-workgroup barrier rejection reports its exact terminal cause and program identity");
+
+    const RecompileDiagnosticContext legacy_skip_diagnostic{
+        RecompileDiagnosticStage::Compute, 0x246813570000bb55ull};
+    const CapturedStderr legacy_skip_capture = capture_stderr([&] {
+        (void)report_compute_recompile_skip_once(legacy_skip_diagnostic);
+        (void)report_compute_recompile_skip_once(legacy_skip_diagnostic);
+    });
+    CHECK(count_occurrences(
+              legacy_skip_capture.output,
+              "[compute] skip unsupported program 0x246813570000bb55\n") == 1 &&
+              legacy_skip_capture.output.find("role=consequent") == std::string::npos,
+          "non-debug live skips preserve the legacy once-per-address diagnostic");
+
+    // The unit-level reporter checks above deliberately keep cache-hit and legacy behavior focused,
+    // but they cannot guard the executor's integration site: a live shader-recompile failure must
+    // actually call that reporter before it discards the dispatch. Register a rejected program and
+    // drive it through the complete realization boundary so deleting the production call loses this
+    // consequent even though the compiler's terminal diagnostic and the helper itself still work.
+    prosper::register_agc_hle();
+    auto create_shader = prosper::Hle::lookup("f3dg2CSgRKY");
+    alignas(256) static const uint32_t kLivePartialBarrierReject[] = {
+        0xbf8a0000u, // s_barrier
+        0xbf810000u, // s_endpgm
+    };
+    ShaderReg live_reject_registers[2] = {
+        {prosper::agc::Pm4::COMPUTE_PGM_LO, 0},
+        {prosper::agc::Pm4::COMPUTE_PGM_HI, 0},
+    };
+    AgcShaderHeader live_reject_header{};
+    live_reject_header.file_header = 0x34333231u;
+    live_reject_header.version = 0x18;
+    live_reject_header.sh_registers = live_reject_registers;
+    live_reject_header.shader_size = sizeof(kLivePartialBarrierReject);
+    live_reject_header.type = 0;
+    live_reject_header.num_sh_registers = 2;
+    void* registered_live_reject = nullptr;
+    const bool live_reject_registered = create_shader &&
+        create_shader(reinterpret_cast<uint64_t>(&registered_live_reject),
+                      reinterpret_cast<uint64_t>(&live_reject_header),
+                      reinterpret_cast<uint64_t>(kLivePartialBarrierReject), 0, 0, 0) == 0 &&
+        registered_live_reject == &live_reject_header;
+    CHECK(live_reject_registered,
+          "register a rejected compute program for the live realization boundary");
+
+    GpuState live_reject_state;
+    live_reject_state.sh[prosper::agc::Pm4::COMPUTE_PGM_LO] = live_reject_registers[0].value;
+    live_reject_state.sh[prosper::agc::Pm4::COMPUTE_PGM_HI] = live_reject_registers[1].value;
+    live_reject_state.sh[prosper::agc::Pm4::COMPUTE_NUM_THREAD_X] = 64;
+    live_reject_state.sh[prosper::agc::Pm4::COMPUTE_NUM_THREAD_Y] = 1;
+    live_reject_state.sh[prosper::agc::Pm4::COMPUTE_NUM_THREAD_Z] = 1;
+    GpuState::Dispatch live_reject_dispatch;
+    live_reject_dispatch.threads_x = 65;
+    live_reject_dispatch.threads_y = live_reject_dispatch.threads_z = 1;
+    live_reject_dispatch.modifier =
+        1ull << prosper::agc::Pm4::COMPUTE_DISPATCH_INITIATOR_USE_THREAD_DIMENSIONS_SHIFT;
+    live_reject_dispatch.command_order = 0x2481;
+    live_reject_dispatch.state = std::make_shared<GpuState>(live_reject_state);
+    live_reject_state.dispatches.push_back(live_reject_dispatch);
+
+    std::vector<ComputeItem> live_reject_items;
+    std::vector<OperationRealizationFailure> live_reject_failures;
+    set_test_env("PROSPER_DBG", "1");
+    const CapturedStderr live_reject_capture = capture_stderr([&] {
+        live_reject_items = realize_compute_dispatches(
+            live_reject_state, 0x2481, &live_reject_failures);
+    });
+    set_test_env("PROSPER_DBG", nullptr);
+    char live_reject_program[96];
+    std::snprintf(live_reject_program, sizeof(live_reject_program),
+                  "stage=compute program=0x%llx role=consequent\n",
+                  static_cast<unsigned long long>(
+                      reinterpret_cast<uint64_t>(kLivePartialBarrierReject)));
+    CHECK(live_reject_registered && live_reject_items.empty() &&
+              live_reject_failures.size() == 1 &&
+              live_reject_failures[0].reason == RealizationFailureReason::ShaderRecompile &&
+              live_reject_failures[0].stages.size() == 1 &&
+              live_reject_failures[0].stages[0].program_addr ==
+                  reinterpret_cast<uint64_t>(kLivePartialBarrierReject),
+          "registered rejected compute reaches the live shader-recompile failure boundary");
+    CHECK(count_occurrences(
+              live_reject_capture.output,
+              "[compute-recompile-reject] reason=empty-result dispatch-skipped") == 1 &&
+              count_occurrences(live_reject_capture.output, live_reject_program) == 1,
+          "live shader-recompile failure reports its final dispatch-skipped consequence");
 
     // A one-record 16-bit V# emits an explicit index guard and typed tail marker. Keep the cache
     // partition compact (none/u16/f16), while ensuring a wider range or the sibling conversion can

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1,10 +1,18 @@
 #include "../src/gpu/gpu_execute.hpp"
+#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 #include <cstdio>
 #include <filesystem>
 #include <iterator>
+#include <string>
+#include <utility>
 #include <vector>
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
 #include "test_scratch.h"
 
 using namespace prosper::gpu;
@@ -31,6 +39,84 @@ static size_t count_extension(const std::filesystem::path& directory, const char
         if (it->is_regular_file(ec) && it->path().extension() == extension) ++count;
     }
     return ec ? 0 : count;
+}
+
+struct CapturedStderr {
+    std::filesystem::path path;
+    std::string output;
+};
+
+struct ScratchCaptureFile {
+    std::filesystem::path path;
+    FILE* stream = nullptr;
+
+    explicit ScratchCaptureFile(std::filesystem::path capture_path)
+        : path(std::move(capture_path)) {
+#ifdef _WIN32
+        stream = _wfopen(path.c_str(), L"w+b");
+#else
+        stream = std::fopen(path.c_str(), "w+b");
+#endif
+    }
+
+    ~ScratchCaptureFile() {
+        if (stream) std::fclose(stream);
+        std::error_code error;
+        std::filesystem::remove(path, error);
+    }
+
+    ScratchCaptureFile(const ScratchCaptureFile&) = delete;
+    ScratchCaptureFile& operator=(const ScratchCaptureFile&) = delete;
+};
+
+static std::filesystem::path next_stderr_capture_path() {
+    static std::atomic<uint64_t> capture_sequence{0};
+    return prosper_test::test_scratch_dir() /
+        ("shader-recompile-stderr-" +
+         std::to_string(capture_sequence.fetch_add(1, std::memory_order_relaxed)) + ".log");
+}
+
+template <typename F>
+static CapturedStderr capture_stderr(F&& body) {
+    CapturedStderr result;
+    result.path = next_stderr_capture_path();
+    ScratchCaptureFile capture(result.path);
+    if (!capture.stream || std::fflush(stderr) != 0) return result;
+#ifdef _WIN32
+    const int stderr_fd = _fileno(stderr);
+    const int saved = _dup(stderr_fd);
+    const bool redirected = saved >= 0 && _dup2(_fileno(capture.stream), stderr_fd) == 0;
+#else
+    const int stderr_fd = fileno(stderr);
+    const int saved = dup(stderr_fd);
+    const bool redirected = saved >= 0 && dup2(fileno(capture.stream), stderr_fd) >= 0;
+#endif
+    if (!redirected) {
+        if (saved >= 0) {
+#ifdef _WIN32
+            _close(saved);
+#else
+            close(saved);
+#endif
+        }
+        return result;
+    }
+
+    body();
+    std::fflush(stderr);
+#ifdef _WIN32
+    const bool restored = _dup2(saved, stderr_fd) == 0;
+    _close(saved);
+#else
+    const bool restored = dup2(saved, stderr_fd) >= 0;
+    close(saved);
+#endif
+    if (!restored) return result;
+    std::rewind(capture.stream);
+    char bytes[4096];
+    for (size_t count; (count = std::fread(bytes, 1, sizeof bytes, capture.stream)) != 0;)
+        result.output.append(bytes, count);
+    return result;
 }
 
 // Fullscreen triangle and solid green shaders assembled for gfx1030. These are also used by the
@@ -516,23 +602,89 @@ int main() {
     compute_config.threads_x = 130;
     compute_config.threads_y = compute_config.threads_z = 1;
     compute_config.tgid_x_en = true;
+    const RecompileDiagnosticContext diagnostic_a{
+        RecompileDiagnosticStage::Compute, 0x1111222233334444ull};
+    const RecompileDiagnosticContext diagnostic_b{
+        RecompileDiagnosticStage::Compute, 0xaaaabbbbccccddddull};
     const auto direct_compute = recompile_compute(
         kCompute, std::size(kCompute), &compute_table, compute_config);
+    uint64_t cached_compute_identity = 0, relocated_diagnostic_identity = 0,
+             push_constant_identity = 0;
     const auto cached_compute = recompile_compute_shader_cached(
-        kCompute, std::size(kCompute), &compute_table, compute_config);
+        kCompute, std::size(kCompute), &compute_table, compute_config,
+        &cached_compute_identity, diagnostic_a);
+    const auto relocated_diagnostic_compute = recompile_compute_shader_cached(
+        kCompute, std::size(kCompute), &compute_table, compute_config,
+        &relocated_diagnostic_identity, diagnostic_b);
     ComputeShaderConfig new_push_constants = compute_config;
     new_push_constants.user_sgprs[4] = 0x12345678;
     const auto repeated_compute = recompile_compute_shader_cached(
-        kCompute, std::size(kCompute), &compute_table, new_push_constants);
+        kCompute, std::size(kCompute), &compute_table, new_push_constants,
+        &push_constant_identity, diagnostic_b);
     ComputeShaderConfig changed_launch = compute_config;
     changed_launch.local_x = 32;
     const auto changed_compute = recompile_compute_shader_cached(
         kCompute, std::size(kCompute), &compute_table, changed_launch);
     stats = shader_recompile_cache_stats();
     CHECK(!direct_compute.empty() && cached_compute == direct_compute &&
-              repeated_compute == direct_compute && !changed_compute.empty() &&
-              changed_compute != direct_compute && stats.misses == 2 && stats.hits == 1,
+              relocated_diagnostic_compute == direct_compute && repeated_compute == direct_compute &&
+              !changed_compute.empty() && changed_compute != direct_compute &&
+              stats.misses == 2 && stats.hits == 2,
           "compute cache reuses push-constant variants and separates launch-specialized modules");
+    CHECK(cached_compute_identity != 0 &&
+              relocated_diagnostic_identity == cached_compute_identity &&
+              push_constant_identity == cached_compute_identity,
+          "diagnostic provenance stays outside compute shader cache identity");
+
+    // Diagnostic provenance is not shader semantics. Force two recompiles of one rejected site so
+    // each call must carry its own immutable program identity through the cache wrapper, builder and
+    // structurizer, while a direct standalone call must remain explicitly neutral.
+    static const uint32_t kRejectedCompute[] = {
+        0xbf890000u, // s_cbranch_execnz with target pc1: unclaimed outside a recognized loop
+        0xbf810000u, // s_endpgm
+    };
+    set_test_env("PROSPER_DBG", "1");
+    set_test_env("PROSPER_NO_SHADER_CACHE", "1");
+    const CapturedStderr diagnostic_capture = capture_stderr([&] {
+        (void)recompile_compute_shader_cached(
+            kRejectedCompute, std::size(kRejectedCompute), nullptr, compute_config,
+            nullptr, diagnostic_a);
+        (void)recompile_compute_shader_cached(
+            kRejectedCompute, std::size(kRejectedCompute), nullptr, compute_config,
+            nullptr, diagnostic_b);
+        (void)recompile_compute(kRejectedCompute, std::size(kRejectedCompute), nullptr,
+                                compute_config);
+    });
+    const std::string& diagnostic_log = diagnostic_capture.output;
+    set_test_env("PROSPER_NO_SHADER_CACHE", nullptr);
+    set_test_env("PROSPER_DBG", nullptr);
+    std::error_code diagnostic_capture_error;
+    CHECK(diagnostic_capture.path.parent_path() == prosper_test::test_scratch_dir() &&
+              !std::filesystem::exists(diagnostic_capture.path, diagnostic_capture_error) &&
+              !diagnostic_capture_error,
+          "diagnostic capture uses and cleans the process-private test scratch directory");
+    CHECK(diagnostic_log.find(
+              "[compute-struct-reject] unclaimed execnz pc=0 stage=compute "
+              "program=0x1111222233334444 role=route-decline\n") != std::string::npos &&
+              diagnostic_log.find(
+              "[compute-struct-reject] unclaimed execnz pc=0 stage=compute "
+              "program=0xaaaabbbbccccdddd role=route-decline\n") != std::string::npos,
+          "distinct compute calls retain their own program identity at the structurizer site");
+    CHECK(diagnostic_log.find(
+              " stage=compute program=0x1111222233334444 role=terminal\n") !=
+              std::string::npos &&
+              diagnostic_log.find(
+              " stage=compute program=0xaaaabbbbccccdddd role=terminal\n") !=
+              std::string::npos,
+          "terminal instruction rejects retain the same per-call diagnostic identity");
+    CHECK(diagnostic_log.find(
+              "[compute-struct-reject] unclaimed execnz pc=0 stage=compute "
+              "program=none role=route-decline\n") !=
+              std::string::npos &&
+              diagnostic_log.find(
+              " stage=compute program=none role=terminal\n") !=
+              std::string::npos,
+          "standalone compute recompilation uses an explicit neutral program identity");
 
     // A one-record 16-bit V# emits an explicit index guard and typed tail marker. Keep the cache
     // partition compact (none/u16/f16), while ensuring a wider range or the sibling conversion can

--- a/prosper/tools/gpu_replay/compute_recompile.hpp
+++ b/prosper/tools/gpu_replay/compute_recompile.hpp
@@ -47,6 +47,8 @@ inline bool recompile_captured_compute(
 
     const auto& raw = raw_shader_versions[compute.raw_shader_index];
     gpu::ComputeShaderConfig config = compute.recompile_config;
+    const gpu::RecompileDiagnosticContext diagnostic{
+        gpu::RecompileDiagnosticStage::Compute, compute.code_addr};
     if (replay_device && replay_device->valid()) {
         const bool adoptable = replay_device->compute_queue_supported &&
             replay_device->storage_image_read_without_format &&
@@ -54,13 +56,14 @@ inline bool recompile_captured_compute(
         config.native_storage_format_support = adoptable
             ? replay_device->native_storage_format_support : 0;
         const bool native_multiwave = force_native_multiwave ||
-            gpu::compute_shader_prefers_native_multiwave(raw.words.data(), raw.words.size());
+            gpu::compute_shader_prefers_native_multiwave(
+                raw.words.data(), raw.words.size(), diagnostic);
         config.native_subgroup_size = gpu::select_native_compute_subgroup_size(
             *replay_device, config, native_multiwave, disable_native_subgroup);
     }
     config.packed_r11_storage = packed_r11_storage;
     std::vector<uint32_t> spirv = gpu::recompile_compute_shader_cached(
-        raw.words.data(), raw.words.size(), compute.resources.get(), config);
+        raw.words.data(), raw.words.size(), compute.resources.get(), config, nullptr, diagnostic);
     if (spirv.empty()) return false;
 
     compute.spirv = std::move(spirv);
@@ -105,8 +108,11 @@ inline bool recompile_failed_compute_stage(
         table.resources.push_back(captured.resource);
     const gpu::ShaderResourceTable* resources = stage.resource_table.present ? &table : nullptr;
     const auto& raw = raw_shader_versions[stage.raw_shader_index];
+    const gpu::RecompileDiagnosticContext diagnostic{
+        gpu::RecompileDiagnosticStage::Compute, stage.program_addr};
     spirv = gpu::recompile_compute_shader_cached(
-        raw.words.data(), raw.words.size(), resources, stage.recompile_config);
+        raw.words.data(), raw.words.size(), resources, stage.recompile_config, nullptr,
+        diagnostic);
     return true;
 }
 

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -396,6 +396,21 @@ int main(int argc, char** argv) {
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;
       vb.num_components=1; vb.binding=3; vb.stride=4; vb.sgpr_base=8; rt.resources.push_back(vb);
       dump(dir, "compute_store", recompile_valu(c, sizeof(c)/4, 1, 0, &rt)); }
+    // GTA V's cross-workgroup scan publication shape: distinct descriptor variables alias one guest
+    // allocation, a GLC store is released by vscnt(0), and a GLC+DLC load polls through the alias.
+    // This representative module strictly validates Aliased/Coherent decorations, per-access
+    // Volatile operands, and Device-scope UniformMemory release under SPIR-V 1.3 + Vulkan 1.1.
+    { const uint32_t c[] = {0xe0744008u,0x80001100u,0xbf8c3f70u,0xbbfd0000u,
+                            0xe0706010u,0x80001211u,0xe030e010u,0x80001e1du,
+                            0xbf810000u};
+      ShaderResourceTable rt;
+      ShaderResource publish{}; publish.cls=ResourceClass::ConstantBuffer;
+      publish.format=DataFormat::Uint32; publish.binding=4; publish.gpu_addr=0x1000;
+      publish.size=180; publish.stride=20; publish.fetch_pc=0; rt.resources.push_back(publish);
+      ShaderResource flag=publish; flag.binding=5; flag.fetch_pc=4; rt.resources.push_back(flag);
+      ShaderResource poll=publish; poll.binding=6; poll.fetch_pc=6; rt.resources.push_back(poll);
+      ComputeShaderConfig cfg; cfg.local_x=64; cfg.wave_size=64;
+      dump(dir, "compute_coherent_alias", recompile_compute(c, sizeof(c)/4, &rt, cfg)); }
     // Astro Bot exact raw buffer_store_dwordx3 packet.
     { const uint32_t c[] = {0x7e140f00u,0x7e060281u,0x7e080282u,0x7e0a0283u,
                             0xe07c2000u,0x8004030au,0xbf810000u};

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -118,6 +118,7 @@ static const std::vector<KnownGap> kKnownGaps = {};
 struct NotAnEmitter { const char* name; const char* why; };
 static const NotAnEmitter kNotEmitters[] = {
     {"safe_execz_branches_for_test", "returns a transformed RDNA2 instruction stream, not SPIR-V"},
+    {"structured_execz_branches_for_test", "returns analyzed RDNA2 branch PCs, not SPIR-V"},
     {"mask_test_branches_for_test",  "returns a transformed RDNA2 instruction stream, not SPIR-V"},
     {"recompile_graphics_shader_cached",
      "caching wrapper; ctest shader_recompile_cache asserts its words are byte-identical to the "

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -317,6 +317,27 @@ int main(int argc, char** argv) {
     // Compute + SMEM constant-buffer load (s_buffer_load_dword; routes to binding 2).
     { const uint32_t c[] = {0xf4000000u, 0xfa000004u, 0x7e000200u, 0xbf810000u};
       dump(dir, "compute_smem", recompile_valu(c, sizeof(c)/4, 1, 0)); }
+    // Compute + immediate SMEM x16 descriptor bundle. Both eight-dword halves are independently
+    // resolved by their consuming MIMG PCs; the load's one immediate offset is not a shared key.
+    { const uint32_t c[] = {
+          0xf4100300u, 0xfa000000u,
+          0xf0800f08u, 0x01630000u,
+          0xf0800f08u, 0x01850000u,
+          0xbf810000u};
+      ShaderResourceTable rt;
+      for (uint32_t i = 0; i < 2; ++i) {
+          ShaderResource t{};
+          t.cls = ResourceClass::Texture;
+          t.format = DataFormat::Float32;
+          t.num_components = 4;
+          t.binding = 4 + i;
+          t.fetch_pc = 2 + i * 2;
+          t.img_dim = 1;
+          t.width = t.height = 2;
+          rt.resources.push_back(t);
+      }
+      dump(dir, "compute_smem_x16_descriptor_bundle",
+           recompile_valu(c, sizeof(c)/4, 2, 0, &rt)); }
     // Compute private spill/fill, including a signed short crossing a dword boundary.
     { const uint32_t c[] = {0x7e0002ffu,0x00008001u,0xdc684003u,0x00000000u,0x7e000280u,
                             0xdc2c4003u,0x00000000u,0x7e000b00u,0xBF810000u};

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -309,6 +309,11 @@ int main(int argc, char** argv) {
     // masked-shift lowering: SPIR-V shift operands must stay in the defined 0..31 range.
     { const uint32_t c[] = {0xd54f0006u,0x0415fe80u,0x3024240cu,0xbf810000u};
       dump(dir, "compute_alignbyte", recompile_valu(c, std::size(c), 6, 6), "recompile_valu"); }
+    // GTA V exec_cs_413d1bf00 pc458: exact V_LDEXP_F32 production packet. This exercises the
+    // integer-domain edge lowering under the strict Vulkan SPIR-V validator, not merely the generic
+    // recompile_valu entry point above.
+    { const uint32_t c[] = {0xd7620000u, 0x0002030du, 0xbf810000u};
+      dump(dir, "compute_ldexp", recompile_valu(c, sizeof(c) / sizeof(c[0]), 14, 0)); }
     // Compute + SMEM constant-buffer load (s_buffer_load_dword; routes to binding 2).
     { const uint32_t c[] = {0xf4000000u, 0xfa000004u, 0x7e000200u, 0xbf810000u};
       dump(dir, "compute_smem", recompile_valu(c, sizeof(c)/4, 1, 0)); }

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -481,6 +481,31 @@ int main(int argc, char** argv) {
       // image_load 2D_MSAA_ARRAY (dim 7): coords (x,y,layer) + sample — needs Arrayed+MS + ImageMSArray cap.
       const uint32_t cmsa[] = {0xF0000F3Au,0x00000000u,0x00030201u,0xBF8C3F70u,0xBF810000u};
       dump(dir, "storage_msaa_array_2d", recompile_valu(cmsa, sizeof(cmsa)/4, 1, 0, &rt)); }
+    // GTA V's audited one-level IMAGE_LOAD_MIP / IMAGE_STORE_MIP subset. Validate both sampled
+    // image shapes (including the retained array layer) and the NSA storage write strictly.
+    { ShaderResourceTable rt;
+      ShaderResource t{}; t.cls=ResourceClass::Texture; t.format=DataFormat::Uint32;
+      t.num_components=1; t.binding=4; t.fetch_pc=1; t.img_dim=1;
+      t.width=4; t.height=4; t.depth=1; t.size=64; t.proven_zero_mip=true;
+      rt.resources.push_back(t);
+      const uint32_t c[] = {0x7e040207u,0xf0043f08u,0x00050000u,0xbf810000u};
+      dump(dir, "compute_load_mip_zero_2d", recompile_valu(c, sizeof(c)/4, 1, 0, &rt));
+      rt.resources[0].img_dim=5; rt.resources[0].depth=2; rt.resources[0].size=128;
+      const uint32_t ca[] = {0x7e060206u,0xf0043128u,0x00050000u,0xbf810000u};
+      dump(dir, "compute_load_mip_zero_array", recompile_valu(ca, sizeof(ca)/4, 1, 0, &rt)); }
+    { ShaderResourceTable rt;
+      ShaderResource s{}; s.cls=ResourceClass::StorageImage; s.format=DataFormat::Uint32;
+      s.num_components=1; s.binding=4; s.fetch_pc=1; s.img_dim=1;
+      s.width=4; s.height=4; s.depth=1; s.size=64; s.proven_zero_mip=true;
+      rt.resources.push_back(s);
+      const uint32_t c[] = {
+          0x7e0a0206u,0xf024310au,0x00030004u,0x00000503u,0xbf810000u};
+      dump(dir, "compute_store_mip_zero_2d", recompile_valu(c, sizeof(c)/4, 1, 0, &rt));
+      rt.resources[0].format=DataFormat::Uint8; rt.resources[0].num_components=4;
+      const uint32_t cf[] = {
+          0x7e0c0206u,0xf0243f0au,0x00030005u,0x00000604u,0xbf810000u};
+      dump(dir, "compute_store_mip_zero_xyzw_2d",
+           recompile_valu(cf, sizeof(cf)/4, 1, 0, &rt)); }
     // Compute that SAMPLES a texture and STORES to a storage image (the bloom/downsample shape, shader 006):
     // exercises the sampled-texture path inside a compute shell (needs vec4<float> declared there).
     { ShaderResourceTable rt;

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -459,6 +459,18 @@ int main(int argc, char** argv) {
       ComputeShaderConfig cfg; cfg.local_x=1;
       dump(dir, "compute_bvh_intersect", recompile_compute(c, sizeof(c)/4, &rt, cfg),
            "recompile_compute"); }
+    // GTA V's exact program 0x205b5e8600 pc1476 packet uses a 64-byte BVH. This separately covers
+    // the constant-false 128-byte-node bound that triangle and FP16-box allocations require.
+    { constexpr uint32_t pc = 1476u;
+      std::vector<uint32_t> c(pc, 0xbf800000u); // s_nop 0
+      const uint32_t tail[] = {0xf1989f07u,0x00060202u,0x28292c23u,0x22262725u,0x00002a24u,
+                               0xbf810000u};
+      c.insert(c.end(), tail, tail + sizeof(tail)/sizeof(tail[0]));
+      ShaderResourceTable rt; ShaderResource bvh{}; bvh.cls=ResourceClass::ConstantBuffer;
+      bvh.format=DataFormat::Uint32; bvh.num_components=1; bvh.binding=4;
+      bvh.size=64; bvh.fetch_pc=pc; rt.resources.push_back(bvh);
+      ComputeShaderConfig cfg; cfg.local_x=1;
+      dump(dir, "compute_bvh_intersect_64", recompile_compute(c.data(), c.size(), &rt, cfg)); }
     // Compute EXEC-predicated store (v_cmpx + guard execz + store).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0x7e0a0284u,0x7da20b02u,0xbf880002u,0xe0102000u,0x80020302u,0xbf810000u};
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -305,6 +305,10 @@ int main(int argc, char** argv) {
     // Compute ALU (float chain).
     { const uint32_t c[] = {0x06000300u, 0x10000500u, 0xBF810000u};
       dump(dir, "compute_alu", recompile_valu(c, 3, 3, 0), "recompile_valu"); }
+    // GTA V's exact literal-bearing V_ALIGNBYTE_B32 packet.  Strict validation guards the
+    // masked-shift lowering: SPIR-V shift operands must stay in the defined 0..31 range.
+    { const uint32_t c[] = {0xd54f0006u,0x0415fe80u,0x3024240cu,0xbf810000u};
+      dump(dir, "compute_alignbyte", recompile_valu(c, std::size(c), 6, 6), "recompile_valu"); }
     // Compute + SMEM constant-buffer load (s_buffer_load_dword; routes to binding 2).
     { const uint32_t c[] = {0xf4000000u, 0xfa000004u, 0x7e000200u, 0xbf810000u};
       dump(dir, "compute_smem", recompile_valu(c, sizeof(c)/4, 1, 0)); }


### PR DESCRIPTION
## Summary

- turn GTA V's aggregate compute-CFG noise into exact, program-tagged terminal diagnostics and prove that `structured emission stopped` is consequential rather than an independent 28-site family
- implement the reviewed instruction, mask, resource and exact-wave barrier shapes reached by the routed gameplay workload
- update the user-facing compatibility docs, architecture notes, route contract and GitHub trackers to the current rung-3 gameplay milestone

## What changed

The recompiler now covers the routed shapes behind:

- Wave32/Wave64 VCC and carry/subtract semantics, including scalar complement logical operations
- full DPP add ladders, VOP3B arity, V_ALIGNBYTE, V_LDEXP_F32, subword bit reversal and FFBH
- guest-coherent buffers, zero-record raw resources, exact x16 descriptor bundles and supported-atomic discovery
- proved zero-mip image load/store operations with exact VGPR/TFE writer accounting
- synchronized exact-wave barrier phases with fail-closed cross-phase control flow and padded portable lanes
- compact 64-byte triangle/FP16 BVH nodes while retaining the 128-byte FP32 safety boundary

Diagnostics now attach compute program identity and distinguish terminal failures from route/consequence messages. The documentation no longer presents the completed descriptor lift, implemented FLAT-load design, or historical 41-shader corpus as the current GTA frontier.

## Root cause and live impact

The original ~57-site framing counted structurizer messages, not independent defects. Once failures are attributed by tagged program plus terminal PC, the workload is a mixture of concrete instruction, operand, resource and mask-domain gaps.

A fresh Linux/RADV Story-route capture on `5cb49dbe` reached gameplay at frame 5597 and exited cleanly:

| fail-visible class | before (`5f72edf9`) | now |
| --- | ---: | ---: |
| recompile-empty programs | 33 | **29** |
| invalid-descriptor programs | 6 | **6** |
| union | 39 | **35** |

The union has four old-only programs and no new failures. The exact-wave and compact-BVH changes also advance three retained programs to later, independently attributable terminals.

The 3D world is **still black**. Tutorial text, HUD and a populated radar render (`crc=d8cc4a44`), so this PR advances the compatibility frontier without claiming the final visual defect is fixed. The next bounded family is the separately documented zero-record MUBUF atomic contract.

## Review

Every code patch received an independent code-review-agent pass. Rejected drafts were corrected and re-reviewed before commit. Mutation arms perturb the same production sites as their fixes, including barrier phase edges/state carry, compact-BVH bounds, exact VGPR widths, dynamic destinations, and load/store TFE status writes.

## Verification

- `ctest --no-tests=error -j4 --output-on-failure`: **232/232 passed**
- final documentation check: **1/1 passed**
- strict SPIR-V validation passed
- Vulkan compute/render execution coverage passed
- routed GTA V capture: correct title and pad route, frame 5597, clean exit, no device loss
- `git diff --check`: clean

Refs #1873
Refs #2412
Refs #2429
Refs #2481