### PR TITLE
fix(recompiler): advance GTA V Wave64 compute masks

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -210,10 +210,12 @@ struct SrtUse {
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
-    // Fully-known RAW MUBUF V# whose NUM_RECORDS is zero. This is distinct from the scalar-SMEM
-    // raw-pointer convention, where a zero decoded size means "unbounded" and required_size supplies
-    // the proven access span. Only resolve_dynamic_fetch may set this after decoding all four live
-    // descriptor words at the exact consuming instruction.
+    // Fully-known raw/untyped MUBUF V# whose NUM_RECORDS is zero. This covers ordinary RAW
+    // loads/stores and the emitter-supported 32-bit atomic set; typed and unsupported atomic shapes
+    // remain fail-closed. It is distinct from the scalar-SMEM raw-pointer convention, where a zero
+    // decoded size means "unbounded" and required_size supplies the proven access span. Only
+    // resolve_dynamic_fetch may set this after decoding all four live descriptor words at the exact
+    // consuming instruction.
     bool zero_record_raw = false;
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3521,8 +3521,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // The holes are not aliases: cmp-swap/csub/inc/dec and the x2 family need different
                 // operand/result semantics and must remain fail-closed until those are implemented.
                 const bool atomic_buffer_use =
-                    in.opcode == 0x30 || in.opcode == 0x32 || in.opcode == 0x33 ||
-                    (in.opcode >= 0x35 && in.opcode <= 0x3B);
+                    !is_mtbuf &&
+                    (in.opcode == 0x30 || in.opcode == 0x32 || in.opcode == 0x33 ||
+                     (in.opcode >= 0x35 && in.opcode <= 0x3B));
                 if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {
                     const int srsrc = in.src[1].value;
                     std::array<uint32_t, 4> current{};
@@ -3607,11 +3608,14 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
                         // Typed format stores retain the strided record requirement.
                         const bool stride_supported = !format_store_use || d.stride != 0;
-                        // A fully-known RAW MUBUF with NUM_RECORDS=0 is not a missing descriptor:
-                        // hardware returns zero for loads and drops stores. Preserve that proof at
-                        // this exact consumer pc, but do not generalize it to MTBUF, format stores,
-                        // atomics, or an addr0 descriptor with nonzero records.
-                        const bool zero_record_raw = raw_buffer_use && d.num_records == 0u &&
+                        // A fully-known raw/untyped MUBUF with NUM_RECORDS=0 is not a missing
+                        // descriptor: hardware returns zero for loads, drops stores, and range-checks
+                        // an atomic as one all-or-nothing access. Preserve that proof at this exact
+                        // consumer pc for ordinary raw operations and the exact 32-bit atomic set
+                        // admitted above. MTBUF, format stores, unsupported atomics, and an addr0
+                        // descriptor with nonzero records remain outside the marker contract.
+                        const bool zero_record_raw = (raw_buffer_use || atomic_buffer_use) &&
+                                                     d.num_records == 0u &&
                                                      d.size_bytes == 0u;
                         if (zero_record_raw ||
                             (d.base > 0x10000 && d.size_bytes != 0 &&

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -634,11 +634,11 @@ void decode_operands(Rdna2Inst& i) {
                 i.src[2] = {};
                 i.n_src = 2;
             }
-            // V_LDEXP_F32 is likewise a two-source VOP3A instruction. Its reserved SRC2 bits are
-            // zero in GTA V's exact packet and therefore decode as s0 unless cleared here. Exposing
-            // that phantom scalar read can make CFG/provenance analysis reject an otherwise valid
-            // instruction when s0 differs across a merge, before the opcode emitter is reached.
-            if (i.opcode == 0x362u) {
+            // V_LDEXP_F32 and V_BFM_B32 are two-source VOP3A instructions. Their reserved SRC2 bits
+            // are zero in GTA V's exact packets and therefore decode as s0 unless cleared here.
+            // Exposing that phantom scalar read can make CFG/provenance analysis reject an otherwise
+            // valid instruction when s0 differs across a merge, before the opcode emitter is reached.
+            if (i.opcode == 0x362u || i.opcode == 0x363u) {
                 i.src[2] = {};
                 i.n_src = 2;
             }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6180,6 +6180,52 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
             }
+            if (b.is_compute && b.wave_size == 64 && b.native_subgroup_size == 64 &&
+                in.opcode == 0x14) { // s_ff1_i32_b64
+                // RDNA2 scans the complete 64-bit source from its least-significant bit and
+                // returns the first set index, or 0xffffffff for an empty mask.  The captured GTA
+                // compute sites feed EXEC, VCC, or a VOPC-saved mask pair into this scalar result.
+                // A required native Wave64 subgroup makes native_wave_first_active architectural;
+                // a 32-wide or unknown subgroup would silently lose bits 32..63.
+                const auto data_word_present = [&](int reg) {
+                    return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
+                };
+                const int source = in.src[0].value;
+                const bool competing_data = data_word_present(source) ||
+                    data_word_present(source + 1);
+                uint32_t mask = 0;
+                if (!competing_data && source == 126) {
+                    mask = rs.exec;
+                } else if (!competing_data && source == 106) {
+                    mask = rs.vcc;
+                } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
+                           !rs.sreg_bool_b32.contains(source)) {
+                    const auto saved = rs.sreg_bool.find(source);
+                    if (saved != rs.sreg_bool.end()) mask = saved->second;
+                }
+                if (!mask || in.dst.value == 126 || in.dst.value == 127) {
+                    ok = false;
+                    return true;
+                }
+
+                const uint32_t result = b.native_wave_first_active(mask);
+                rs.sreg[in.dst.value] = result;
+                rs.sreg_srt.erase(in.dst.value);
+
+                // S_FF1 writes ordinary 32-bit scalar DATA.  End every complete-mask lifetime
+                // overlapping that physical dword, including a pair rooted one register earlier;
+                // otherwise a later implicit predicate consumer could observe the pre-S_FF1 mask.
+                const auto erase_mask_alias = [&](int base) {
+                    rs.sreg_bool.erase(base);
+                    rs.sreg_bool_narrowed.erase(base);
+                    rs.sreg_bool_b32.erase(base);
+                };
+                erase_mask_alias(in.dst.value);
+                if (in.dst.value > 0) erase_mask_alias(in.dst.value - 1);
+                if (in.dst.value == 106 || in.dst.value == 107) rs.vcc = 0;
+                // S_FF1 does not modify SCC.
+                return true;
+            }
             if (b.is_compute && b.wave_size == 32 && b.native_subgroup_size == 32 &&
                 in.opcode == 0x13) { // s_ff1_i32_b32
                 // RDNA2 returns the first set bit from the low end, or 0xffffffff for an empty

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6203,17 +6203,22 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
                 };
                 const int source = in.src[0].value;
-                const bool competing_data = data_word_present(source) ||
-                    data_word_present(source + 1);
                 uint32_t mask = 0;
-                if (!competing_data && source == 126) {
+                // EXEC is architectural mask state, even when structured-loop or dispatcher state
+                // bookkeeping also leaves synthetic scalar placeholders for physical s126/s127.
+                // Unlike VCC and saved SGPR pairs, those words cannot carry competing scalar data.
+                if (in.src[0].kind == OperandKind::Special && source == 126) {
                     mask = rs.exec;
-                } else if (!competing_data && source == 106) {
-                    mask = rs.vcc;
-                } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
-                           !rs.sreg_bool_b32.contains(source)) {
-                    const auto saved = rs.sreg_bool.find(source);
-                    if (saved != rs.sreg_bool.end()) mask = saved->second;
+                } else {
+                    const bool competing_data = data_word_present(source) ||
+                        data_word_present(source + 1);
+                    if (!competing_data && source == 106) {
+                        mask = rs.vcc;
+                    } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
+                               !rs.sreg_bool_b32.contains(source)) {
+                        const auto saved = rs.sreg_bool.find(source);
+                        if (saved != rs.sreg_bool.end()) mask = saved->second;
+                    }
                 }
                 if (!mask || in.dst.value == 126 || in.dst.value == 127) {
                     ok = false;
@@ -6577,17 +6582,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
                     };
                     const int source = in.src[0].value;
-                    const bool competing_data = data_word_present(source) ||
-                                                data_word_present(source + 1);
                     uint32_t source_mask = 0;
-                    if (!competing_data && source == 126) {
+                    // Match S_FF1's EXEC rule above: canonical special:126 names architectural
+                    // EXEC, while structured state may also carry synthetic scalar placeholders
+                    // for the same physical words.  VCC and saved SGPR pairs can genuinely be
+                    // recycled as scalar data and therefore retain their ambiguity checks.
+                    if (in.src[0].kind == OperandKind::Special && source == 126) {
                         source_mask = rs.exec;
-                    } else if (!competing_data && source == 106) {
-                        source_mask = rs.vcc;
-                    } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
-                               !rs.sreg_bool_b32.contains(source) &&
-                               mask != rs.sreg_bool.end()) {
-                        source_mask = mask->second;
+                    } else {
+                        const bool competing_data = data_word_present(source) ||
+                                                    data_word_present(source + 1);
+                        if (!competing_data && source == 106) {
+                            source_mask = rs.vcc;
+                        } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
+                                   !rs.sreg_bool_b32.contains(source) &&
+                                   mask != rs.sreg_bool.end()) {
+                            source_mask = mask->second;
+                        }
                     }
                     if (source_mask) {
                         result = b.native_wave_popcount(source_mask);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10536,11 +10536,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (is_zero_record_raw_buffer(*res)) {
                     // The front half proved all four live V# words at this exact instruction and
                     // decoded NUM_RECORDS=0. RDNA2's OOB contract returns zero for every raw load
-                    // component and drops raw stores. Keep inactive lanes' destination values just
-                    // like a normal EXEC-predicated load, and never touch a shared dummy buffer on
-                    // the store side. Atomics are outside the producer's admitted subset and remain
-                    // fail-closed if a hand-built table tries to apply the marker to one.
-                    if (is_atomic) { ok = false; return true; }
+                    // component, drops raw stores, and performs no memory operation for an atomic.
+                    // For atomics GLC=0 leaves VDATA untouched; GLC=1 returns the pre-op value, which
+                    // is zero for an empty descriptor. Apply that return only to active EXEC lanes,
+                    // exactly like an ordinary predicated VGPR write. Never declare or touch a dummy
+                    // binding: one empty operation cannot then leak state into another.
+                    if (is_atomic) {
+                        if (in.mubuf_glc) {
+                            const int d = in.dst.value;
+                            const uint32_t old = vreg_old(b, rs, d);
+                            rs.vreg[d] = b.uconst(0);
+                            predicate_write(b, rs, d, old);
+                        }
+                        return true;
+                    }
                     if (is_store) return true;
                     for (uint32_t k = 0; k < n; ++k) {
                         const int d = in.dst.value + static_cast<int>(k);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3627,8 +3627,10 @@ uint32_t inline_int_mask_bit_hi(SpirvCompute& b, int value) {
 
 // Per-invocation bit of a 64-bit mask consumed by V_MBCNT. The HI instruction names the odd SGPR
 // of an aligned scalar pair (for example s7 for s[6:7]), while our bool-domain mask is keyed by the
-// pair's low register. Accept the exact key first for unusual compiler allocations, then the aligned
-// low half. VCC/EXEC are represented directly rather than through the scalar-data register file —
+// pair's low register. The LOW instruction names that root directly; the HIGH instruction names the
+// following register, so only source-1 can represent its mask bits. An exact HIGH key would instead
+// describe source:source+1 and silently read the wrong physical dword. VCC/EXEC are represented
+// directly rather than through the scalar-data register file —
 // but only in the canonical pairing (LO with the low half, HI with the high half); a cross-pairing
 // (e.g. v_mbcnt_lo with exec_hi) reads OTHER lanes' bits, which the per-invocation model cannot
 // represent, so it returns the 0 reject sentinel.
@@ -3642,13 +3644,10 @@ uint32_t mbcnt_source_bit(SpirvCompute& b, const RegState& rs, const Operand& so
         return high_half ? inline_int_mask_bit_hi(b, source.value)
                          : inline_int_mask_bit(b, source.value);
     if (source.kind != OperandKind::SGPR) return 0;
-    auto found = rs.sreg_bool.find(source.value);
-    if (found != rs.sreg_bool.end()) return found->second;
-    if (high_half && source.value > 0) {
-        found = rs.sreg_bool.find(source.value - 1);
-        if (found != rs.sreg_bool.end()) return found->second;
-    }
-    return 0;
+    const int root = high_half ? source.value - 1 : source.value;
+    if (root < 0) return 0;
+    const auto found = rs.sreg_bool.find(root);
+    return found == rs.sreg_bool.end() ? 0 : found->second;
 }
 
 bool sopp_is_noop(const Rdna2Inst& in) {
@@ -9854,6 +9853,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ucmp(Op_ULessThan, byte, b.uconst(4)), low,
                         b.sel(b.ucmp(Op_ULessThan, byte, b.uconst(8)), upper, b.uconst(0)));
                 }
+            } else if (in.opcode == 0x363) {                          // v_bfm_b32
+                // RDNA2: D.u32 = ((1 << S0[4:0]) - 1) << S1[4:0]. Mask both shift
+                // amounts before emitting SPIR-V so neither can reach the undefined >=32 range;
+                // in particular, an input width of 32 wraps to zero rather than producing all ones.
+                // The instruction has no defined modifier forms. OP_SEL is not retained by the
+                // generic decoder for this opcode, so reject its raw field explicitly as well.
+                const uint32_t opsel = (in.words[0] >> 11) & 0xFu;
+                if (in.src_abs[0] || in.src_abs[1] || in.src_abs[2] ||
+                    in.src_neg[0] || in.src_neg[1] || in.src_neg[2] ||
+                    in.clamp || in.omod || opsel) {
+                    ok = false;
+                } else {
+                    const uint32_t width = b.ibin(
+                        Op_BitwiseAnd, val(in.src[0]), b.uconst(31));
+                    const uint32_t offset = b.ibin(
+                        Op_BitwiseAnd, val(in.src[1]), b.uconst(31));
+                    const uint32_t mask = b.ibin(
+                        Op_ISub,
+                        b.ibin(Op_ShiftLeftLogical, b.uconst(1), width),
+                        b.uconst(1));
+                    vreg[in.dst.value] = b.ibin(Op_ShiftLeftLogical, mask, offset);
+                }
             } else if (in.opcode == 0x364) {                          // v_bcnt_u32_b32
                 // AMD RDNA2: D = popcount(S0) + S1. The third VOP3 source field is unused.
                 vreg[in.dst.value] = b.ibin(Op_IAdd,
@@ -14017,6 +14038,7 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> proven_wave64_mask_zero_compare_pcs;
     std::unordered_set<uint32_t> proven_exec_saved_mask_compare_pcs;
     std::unordered_set<uint32_t> proven_wave64_mask_reduction_pcs;
+    std::unordered_map<uint32_t, int> proven_wave64_mbcnt_mask_root_for_pc;
     auto wave64_mask_reduction_source = [&](const Rdna2Inst& in) -> int {
         if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::SOP1 ||
             (in.opcode != 0x10 && in.opcode != 0x14))
@@ -14029,6 +14051,17 @@ bool emit_cfg_state_machine(
         // Canonical EXEC is already resolved from architectural state by emit_alu.  No other
         // special register or odd half is a complete B64 mask source.
         return -1;
+    };
+    auto wave64_mbcnt_mask_root = [&](const Rdna2Inst& in) -> int {
+        if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::VOP3 ||
+            (in.opcode != 0x365 && in.opcode != 0x366) ||
+            in.src[0].kind != OperandKind::SGPR)
+            return -1;
+        // LOW names the mask pair's low word. HIGH names its high word, while the Bool-domain
+        // value remains keyed by the low word. Architectural EXEC/VCC use Special operands and
+        // continue through mbcnt_source_bit without this saved-SGPR lifetime proof.
+        const int root = in.opcode == 0x366 ? in.src[0].value - 1 : in.src[0].value;
+        return root >= 0 && root <= 105 ? root : -1;
     };
     if ((b.is_compute || b.is_fragment) && b.wave_size == 64 && !starts.empty()) {
         std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
@@ -14044,6 +14077,9 @@ bool emit_cfg_state_machine(
             const int reduction_source = wave64_mask_reduction_source(in);
             if (record_compare && reduction_source >= 0 && masks.contains(reduction_source))
                 proven_wave64_mask_reduction_pcs.insert(in.pc);
+            const int mbcnt_root = wave64_mbcnt_mask_root(in);
+            if (record_compare && mbcnt_root >= 0 && masks.contains(mbcnt_root))
+                proven_wave64_mbcnt_mask_root_for_pc.emplace(in.pc, mbcnt_root);
             const int zero_compare_source = mask_zero_compare_candidate_source(in);
             if (record_compare && zero_compare_source >= 0 &&
                 masks.contains(zero_compare_source))
@@ -14943,8 +14979,22 @@ bool emit_cfg_state_machine(
                 return false;
             }
             bool operand_ok = true;
-            const uint32_t mask = mbcnt_source_bit(
-                b, state, mbcnt->src[0], mbcnt->opcode == 0x366);
+            uint32_t mask = 0;
+            if (b.wave_size == 64 && mbcnt->src[0].kind == OperandKind::SGPR) {
+                // Dispatcher Bool variables preserve values after a scalar overwrite by storing
+                // false, so map membership is not a lifetime proof. Admit a saved SGPR mask only
+                // at the exact consumer where the Wave64 MUST analysis proves its pair root live.
+                const auto proof = proven_wave64_mbcnt_mask_root_for_pc.find(mbcnt->pc);
+                if (proof == proven_wave64_mbcnt_mask_root_for_pc.end())
+                    return reject_cfg(mbcnt->pc, "mbcnt-unproven-saved-mask");
+                const auto live = state.sreg_bool.find(proof->second);
+                if (live == state.sreg_bool.end())
+                    return reject_cfg(mbcnt->pc, "mbcnt-proven-mask-missing-state");
+                mask = live->second;
+            } else {
+                mask = mbcnt_source_bit(
+                    b, state, mbcnt->src[0], mbcnt->opcode == 0x366);
+            }
             const uint32_t acc = operand_bits(b, state, *mbcnt, mbcnt->src[1], &operand_ok);
             const auto event = mbcnt_event_for_pc.find(mbcnt->pc);
             if (!mask || !operand_ok || event == mbcnt_event_for_pc.end()) return false;
@@ -16836,8 +16886,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 return in.fmt != Rdna2Format::SOPP || in.opcode != 0x0a ||
                        top_level_pc(in.pc);
             });
+        const bool structured_has_cross_lane_mbcnt =
+            std::any_of(ins.begin(), ins.end(), [](const Rdna2Inst& in) {
+                return in.fmt == Rdna2Format::VOP3 &&
+                       (in.opcode == 0x365 || in.opcode == 0x366) &&
+                       !(in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1);
+            });
         const bool structured_compute_wave_cfg = exact_compute_wave_cfg && !cf_rejected &&
-            barriers_are_top_level &&
+            barriers_are_top_level && !structured_has_cross_lane_mbcnt &&
             std::all_of(Fs.begin(), Fs.end(), [&](const ForwardIf& branch) {
                 // An exact native guest-size subgroup performs the vote without synthesized
                 // workgroup barriers, so nested wave branches are safe. Portable scratch votes

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -909,6 +909,18 @@ struct SpirvCompute {
             {t_u32, first, uconst(Scope_Subgroup), GroupOp_Reduce, selected_lane});
         return sel(native_wave_any(mask_bit), first, uconst(0xffffffffu));
     }
+    uint32_t native_wave_popcount(uint32_t mask_bit) {
+        if (!native_subgroup_size || !mask_bit) return 0;
+        if (!declared_subgroup_arithmetic) {
+            put(caps, Op_Capability, {Cap_GroupNonUniformArithmetic});
+            declared_subgroup_arithmetic = true;
+        }
+        const uint32_t contribution = sel(mask_bit, uconst(1), uconst(0));
+        uint32_t result = id();
+        put(code, Op_GroupNonUniformIAdd,
+            {t_u32, result, uconst(Scope_Subgroup), GroupOp_Reduce, contribution});
+        return result;
+    }
     uint32_t native_compute_mbcnt(uint32_t mask_bit, uint32_t acc_bits, uint32_t lo) {
         if (!native_subgroup_size) return 0;
         const uint32_t lane = subgroup_local_id();
@@ -6547,16 +6559,47 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // A VOPC may write an arbitrary SGPR pair as a wave mask.  In the portable vertex
                 // shell that pair contains the one represented guest lane, so its exact population
                 // count is 0/1.  Ordinary data pairs retain full uint semantics and use two native
-                // OpBitCount operations.  Multi-lane mask reductions remain fail-closed here; their
-                // compute/fragment lowering needs a real wave reduction rather than scalar data.
+                // OpBitCount operations.  GTA's compute shaders also count EXEC, VCC, and saved
+                // VOPC masks.  Those are exact only when one native subgroup is the complete guest
+                // Wave64; a narrower or unknown host width would silently discard guest lanes.
+                // EXEC is tracked separately from scalar DATA.  Until the scalar count can be
+                // expanded into architectural EXEC bits, reject either EXEC destination for every
+                // source domain rather than only for the native-wave reduction below.
+                if (in.dst.value == 126 || in.dst.value == 127) {
+                    ok = false;
+                    return true;
+                }
                 uint32_t result = 0;
+                bool reduced_wave_mask = false;
                 auto mask = rs.sreg_bool.find(in.src[0].value);
-                if (!b.is_compute && !b.is_fragment && b.ngg_one_lane &&
-                    mask != rs.sreg_bool.end()) {
+                if (b.is_compute && b.wave_size == 64 && b.native_subgroup_size == 64) {
+                    const auto data_word_present = [&](int reg) {
+                        return rs.sreg.contains(reg) || rs.sreg_input.contains(reg);
+                    };
+                    const int source = in.src[0].value;
+                    const bool competing_data = data_word_present(source) ||
+                                                data_word_present(source + 1);
+                    uint32_t source_mask = 0;
+                    if (!competing_data && source == 126) {
+                        source_mask = rs.exec;
+                    } else if (!competing_data && source == 106) {
+                        source_mask = rs.vcc;
+                    } else if (!competing_data && in.src[0].kind == OperandKind::SGPR &&
+                               !rs.sreg_bool_b32.contains(source) &&
+                               mask != rs.sreg_bool.end()) {
+                        source_mask = mask->second;
+                    }
+                    if (source_mask) {
+                        result = b.native_wave_popcount(source_mask);
+                        reduced_wave_mask = true;
+                    }
+                }
+                if (!reduced_wave_mask && !b.is_compute && !b.is_fragment && b.ngg_one_lane &&
+                           mask != rs.sreg_bool.end()) {
                     result = b.sel(mask->second, b.uconst(1), b.uconst(0));
-                } else {
+                } else if (!reduced_wave_mask) {
                     // A Boolean-domain pair is a whole wave mask, not two ordinary scalar dwords.
-                    // Only the byte-exact one-lane NGG projection above can reduce it locally.
+                    // Only the exact native-wave and one-lane NGG projections above can reduce it.
                     if (mask != rs.sreg_bool.end()) { ok = false; return true; }
                     auto scalar_half = [&](int reg, uint32_t& value) {
                         auto current = rs.sreg.find(reg);
@@ -6581,6 +6624,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     result = b.ibin(Op_IAdd, b.iun(Op_BitCount, lo), b.iun(Op_BitCount, hi));
                 }
+                // The result is ordinary scalar DATA regardless of whether its source was a wave
+                // mask or a scalar pair.  A one-dword write can overlap either half of a saved B64
+                // mask, so terminate both possible Boolean-domain aliases.  VCC has the same
+                // split-register hazard and must not retain an older implicit predicate.
+                const auto erase_mask_alias = [&](int base) {
+                    rs.sreg_bool.erase(base);
+                    rs.sreg_bool_narrowed.erase(base);
+                    rs.sreg_bool_b32.erase(base);
+                };
+                erase_mask_alias(in.dst.value);
+                if (in.dst.value > 0) erase_mask_alias(in.dst.value - 1);
+                if (in.dst.value == 106 || in.dst.value == 107) rs.vcc = 0;
                 rs.sreg[in.dst.value] = result;
                 rs.sreg_srt.erase(in.dst.value);
                 // A B32 write to VCC_LO also replaces virtual lane zero's architectural mask bit.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -14016,6 +14016,20 @@ bool emit_cfg_state_machine(
     // live VCC mask from a physical VCC pair that has been recycled as scalar data.
     std::unordered_set<uint32_t> proven_wave64_mask_zero_compare_pcs;
     std::unordered_set<uint32_t> proven_exec_saved_mask_compare_pcs;
+    std::unordered_set<uint32_t> proven_wave64_mask_reduction_pcs;
+    auto wave64_mask_reduction_source = [&](const Rdna2Inst& in) -> int {
+        if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::SOP1 ||
+            (in.opcode != 0x10 && in.opcode != 0x14))
+            return -1;
+        if (in.src[0].kind == OperandKind::SGPR &&
+            in.src[0].value >= 0 && in.src[0].value <= 105)
+            return in.src[0].value;
+        if (in.src[0].kind == OperandKind::Special && in.src[0].value == 106)
+            return 106;
+        // Canonical EXEC is already resolved from architectural state by emit_alu.  No other
+        // special register or odd half is a complete B64 mask source.
+        return -1;
+    };
     if ((b.is_compute || b.is_fragment) && b.wave_size == 64 && !starts.empty()) {
         std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
         std::vector<bool> wave64_b64_reachable(starts.size(), false);
@@ -14027,6 +14041,9 @@ bool emit_cfg_state_machine(
 
         auto advance_wave64_b64_masks = [&](std::set<int>& masks, const Rdna2Inst& in,
                                             bool record_compare) {
+            const int reduction_source = wave64_mask_reduction_source(in);
+            if (record_compare && reduction_source >= 0 && masks.contains(reduction_source))
+                proven_wave64_mask_reduction_pcs.insert(in.pc);
             const int zero_compare_source = mask_zero_compare_candidate_source(in);
             if (record_compare && zero_compare_source >= 0 &&
                 masks.contains(zero_compare_source))
@@ -14826,6 +14843,24 @@ bool emit_cfg_state_machine(
                 if (in.fmt == Rdna2Format::EXP) {
                     if (!exp_fn(state, in)) return reject_cfg(in.pc, "export");
                     continue;
+                }
+                if (proven_wave64_mask_reduction_pcs.contains(in.pc)) {
+                    const int source = wave64_mask_reduction_source(in);
+                    const bool mask_available = source == 106
+                        ? state.vcc != 0
+                        : state.sreg_bool.contains(source);
+                    if (source < 0 || !mask_available)
+                        return reject_cfg(in.pc, "proven mask reduction missing mask state");
+                    // The dispatcher persists the physical SGPR file and Bool-domain masks in
+                    // separate function variables.  At this exact MUST-proven consumer, the u32
+                    // pair is only a synthetic placeholder from an earlier scalar lifetime; leave
+                    // the generic S_FF1/S_BCNT ambiguity guard intact and expose the proven mask by
+                    // removing only those two stale data views.
+                    for (int reg = source; reg <= source + 1; ++reg) {
+                        state.sreg.erase(reg);
+                        state.sreg_input.erase(reg);
+                        state.sreg_srt.erase(reg);
+                    }
                 }
                 bool ok = true;
                 const bool handled = emit_alu(b, state, in, ok, allow_exec_update, &safe,

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -450,10 +450,11 @@ inline bool is_proven_null_bvh(const ShaderResource& resource) {
            resource.host_data_size >= resource.size;
 }
 
-// Exact-PC marker for a fully-known RAW MUBUF descriptor with NUM_RECORDS=0. Such a descriptor has
-// architectural zero-read/drop-write behavior regardless of its base, so it deliberately has no
-// guest or host backing. The unusual Unknown/zero-component shape keeps it distinct from an ordinary
-// explicit null buffer and survives capture/replay without adding a serialized descriptor field.
+// Exact-PC marker for a fully-known raw/untyped MUBUF descriptor with NUM_RECORDS=0. Such a descriptor
+// has architectural zero-read/drop-write behavior and performs no memory operation for atomics,
+// regardless of its base, so it deliberately has no guest or host backing. The unusual
+// Unknown/zero-component shape keeps it distinct from an ordinary explicit null buffer and survives
+// capture/replay without adding a serialized descriptor field.
 inline bool is_zero_record_raw_buffer(const ShaderResource& resource) {
     return resource.cls == ResourceClass::ConstantBuffer &&
            resource.format == DataFormat::Unknown && resource.num_components == 0u &&

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2736,8 +2736,131 @@ int main() {
     resolve_dynamic_fetch(direct_atomic_add, std::size(direct_atomic_add), empty_atomic_seed,
                           std::size(empty_atomic_seed), 0, &empty_atomic_uses);
     CHECK(unknown_atomic_uses.empty() && oversized_atomic_uses.empty() &&
-              empty_atomic_uses.empty(),
-          "supported atomics still require a fully-known bounded nonempty live V#");
+              empty_atomic_uses.size() == 1 && empty_atomic_uses[0].zero_record_raw &&
+              empty_atomic_uses[0].use_pc == 0,
+          "supported atomics require a fully-known bounded or exact zero-record live V#");
+
+    // GTA V 0x413e1ac pc12 is the directly-proven empty site. Its sibling dispatch loads the same
+    // table base and publishes an all-zero V# at offset 0x10. Retain the exact packet, load key, and
+    // consuming PC: a direct-SGPR fallback or a generic address-zero shortcut cannot satisfy these
+    // assertions. The marker has no descriptor in the generated module.
+    alignas(16) uint32_t gta_413e1ac_table_words[8] = {};
+    const uint64_t gta_413e1ac_table_base =
+        reinterpret_cast<uint64_t>(gta_413e1ac_table_words);
+    const uint32_t gta_413e1ac_seed[2] = {
+        static_cast<uint32_t>(gta_413e1ac_table_base),
+        static_cast<uint32_t>(gta_413e1ac_table_base >> 32),
+    };
+    std::vector<uint32_t> gta_413e1ac_site(12, 0xBF800000u); // s_nop padding to exact pc
+    gta_413e1ac_site[8] = 0xF4080300u;  // s_load_dwordx4 s[12:15], s[0:1], 0x10
+    gta_413e1ac_site[9] = 0xFA000010u;
+    gta_413e1ac_site[10] = 0xBF8CC07Fu;
+    gta_413e1ac_site.push_back(0xE0C86000u); // exact pc12 buffer_atomic_add, idxen+glc
+    gta_413e1ac_site.push_back(0x80030201u);
+    gta_413e1ac_site.push_back(0xBF810000u);
+    ShaderResourceTable gta_413e1ac_table;
+    const std::vector<SrtUse> gta_413e1ac_uses = add_compute_buffer_resources(
+        gta_413e1ac_table, gta_413e1ac_site.data(), gta_413e1ac_site.size(),
+        gta_413e1ac_seed, std::size(gta_413e1ac_seed));
+    assign_convention_bindings(gta_413e1ac_table, 2);
+    ComputeShaderConfig gta_413e1ac_config;
+    gta_413e1ac_config.user_sgprs.assign(std::begin(gta_413e1ac_seed),
+                                         std::end(gta_413e1ac_seed));
+    gta_413e1ac_config.local_x = gta_413e1ac_config.local_y =
+        gta_413e1ac_config.local_z = 1;
+    const std::vector<uint32_t> gta_413e1ac_spirv = recompile_compute(
+        gta_413e1ac_site.data(), gta_413e1ac_site.size(), &gta_413e1ac_table,
+        gta_413e1ac_config);
+    const DescriptorValidationReport gta_413e1ac_report =
+        validate_spirv_descriptor_interface(gta_413e1ac_spirv, &gta_413e1ac_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(gta_413e1ac_uses.size() == 1 && gta_413e1ac_uses[0].zero_record_raw &&
+              gta_413e1ac_uses[0].key == 0x10u && gta_413e1ac_uses[0].use_pc == 12u &&
+              gta_413e1ac_table.resources.size() == 1 &&
+              is_zero_record_raw_buffer(gta_413e1ac_table.resources[0]) &&
+              gta_413e1ac_table.resources[0].fetch_pc == 12u &&
+              !gta_413e1ac_spirv.empty() && gta_413e1ac_report.ok() &&
+              gta_413e1ac_report.descriptors.empty(),
+          "GTA V 0x413e1ac pc12 exact empty atomic becomes a binding-free PC marker");
+
+    // 0x413d22d pc33 loads its V# from table offset 0x50. Adjacent live slots are proven empty and
+    // the fully-known target descriptor can only be zero-sized or rejected as oversized; unlike the
+    // site above, no sibling capture directly published this slot. This synthetic zero descriptor
+    // therefore verifies the exact packet/key behavior, not an additional live descriptor claim.
+    alignas(16) uint32_t gta_413d22d_table_words[24] = {};
+    const uint64_t gta_413d22d_table_base =
+        reinterpret_cast<uint64_t>(gta_413d22d_table_words);
+    uint32_t gta_413d22d_seed[4] = {};
+    gta_413d22d_seed[2] = static_cast<uint32_t>(gta_413d22d_table_base);
+    gta_413d22d_seed[3] = static_cast<uint32_t>(gta_413d22d_table_base >> 32);
+    std::vector<uint32_t> gta_413d22d_site(33, 0xBF800000u);
+    gta_413d22d_site[30] = 0xF4080101u; // s_load_dwordx4 s[4:7], s[2:3], 0x50
+    gta_413d22d_site[31] = 0xFA000050u;
+    gta_413d22d_site[32] = 0xBF8CC07Fu;
+    gta_413d22d_site.push_back(0xE0C84000u); // exact pc33 buffer_atomic_add, glc
+    gta_413d22d_site.push_back(0x80010200u);
+    gta_413d22d_site.push_back(0xBF810000u);
+    ShaderResourceTable gta_413d22d_table;
+    const std::vector<SrtUse> gta_413d22d_uses = add_compute_buffer_resources(
+        gta_413d22d_table, gta_413d22d_site.data(), gta_413d22d_site.size(),
+        gta_413d22d_seed, std::size(gta_413d22d_seed));
+    ComputeShaderConfig gta_413d22d_config;
+    gta_413d22d_config.user_sgprs.assign(std::begin(gta_413d22d_seed),
+                                         std::end(gta_413d22d_seed));
+    gta_413d22d_config.local_x = gta_413d22d_config.local_y =
+        gta_413d22d_config.local_z = 1;
+    const std::vector<uint32_t> gta_413d22d_spirv = recompile_compute(
+        gta_413d22d_site.data(), gta_413d22d_site.size(), &gta_413d22d_table,
+        gta_413d22d_config);
+    const DescriptorValidationReport gta_413d22d_report =
+        validate_spirv_descriptor_interface(gta_413d22d_spirv, &gta_413d22d_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(gta_413d22d_uses.size() == 1 && gta_413d22d_uses[0].zero_record_raw &&
+              gta_413d22d_uses[0].key == 0x50u && gta_413d22d_uses[0].use_pc == 33u &&
+              gta_413d22d_table.resources.size() == 1 &&
+              is_zero_record_raw_buffer(gta_413d22d_table.resources[0]) &&
+              gta_413d22d_table.resources[0].fetch_pc == 33u &&
+              !gta_413d22d_spirv.empty() && gta_413d22d_report.ok() &&
+              gta_413d22d_report.descriptors.empty(),
+          "GTA V 0x413d22d pc33 exact synthetic empty packet recompiles binding-free");
+
+    // 0x413d884 pc163 has no surviving SRT tag. The live fold knows base/stride/type and dword2,
+    // but the unpublished value is inferred to be zero because every bounded nonzero value would
+    // already materialize (an oversized value would remain rejected). Use the observed descriptor
+    // fields plus a synthetic zero count to prove only the exact-PC path and exact OR packet.
+    uint32_t gta_413d884_seed[24] = {};
+    gta_413d884_seed[20] = 0xF8480000u;
+    gta_413d884_seed[21] = 0x00040020u; // base 0x20f8480000, stride 4
+    gta_413d884_seed[22] = 0u;          // inferred empty count, not direct live proof
+    gta_413d884_seed[23] = 0x00016204u;
+    std::vector<uint32_t> gta_413d884_site(163, 0xBF800000u);
+    gta_413d884_site.push_back(0xE0E82000u); // exact pc163 buffer_atomic_or, idxen, glc=0
+    gta_413d884_site.push_back(0x80051700u);
+    gta_413d884_site.push_back(0xBF810000u);
+    ShaderResourceTable gta_413d884_table;
+    const std::vector<SrtUse> gta_413d884_uses = add_compute_buffer_resources(
+        gta_413d884_table, gta_413d884_site.data(), gta_413d884_site.size(),
+        gta_413d884_seed, std::size(gta_413d884_seed));
+    ComputeShaderConfig gta_413d884_config;
+    gta_413d884_config.user_sgprs.assign(std::begin(gta_413d884_seed),
+                                         std::end(gta_413d884_seed));
+    gta_413d884_config.local_x = gta_413d884_config.local_y =
+        gta_413d884_config.local_z = 1;
+    const std::vector<uint32_t> gta_413d884_spirv = recompile_compute(
+        gta_413d884_site.data(), gta_413d884_site.size(), &gta_413d884_table,
+        gta_413d884_config);
+    const DescriptorValidationReport gta_413d884_report =
+        validate_spirv_descriptor_interface(gta_413d884_spirv, &gta_413d884_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(gta_413d884_uses.size() == 1 && gta_413d884_uses[0].zero_record_raw &&
+              gta_413d884_uses[0].key == 0xFFFFFFFFu &&
+              gta_413d884_uses[0].use_pc == 163u &&
+              gta_413d884_table.resources.size() == 1 &&
+              is_zero_record_raw_buffer(gta_413d884_table.resources[0]) &&
+              gta_413d884_table.resources[0].fetch_pc == 163u &&
+              !gta_413d884_spirv.empty() && gta_413d884_report.ok() &&
+              gta_413d884_report.descriptors.empty(),
+          "GTA V 0x413d884 pc163 exact synthetic empty OR recompiles binding-free by PC");
 
     // These encodings need distinct operands or semantics. In particular op 0x50 is GTA V's
     // buffer_atomic_swap_x2, not a 32-bit atomic with a neighboring opcode. They must not acquire a
@@ -2752,6 +2875,8 @@ int main() {
     uint32_t unsupported_atomic_uses = 0;
     uint32_t unsupported_atomic_resources = 0;
     uint32_t unsupported_atomic_recompiles = 0;
+    uint32_t unsupported_empty_atomic_uses = 0;
+    uint32_t unsupported_empty_atomic_resources = 0;
     for (uint32_t dw0 : unsupported_atomic_dw0) {
         const uint32_t code[] = { dw0, 0x80000000u, 0xBF810000u };
         std::vector<SrtUse> uses;
@@ -2764,10 +2889,19 @@ int main() {
         unsupported_atomic_resources += !table.resources.empty();
         unsupported_atomic_recompiles +=
             !recompile_compute(code, std::size(code), &table, atomic_config).empty();
+        std::vector<SrtUse> empty_uses;
+        resolve_dynamic_fetch(code, std::size(code), empty_atomic_seed,
+                              std::size(empty_atomic_seed), 0, &empty_uses);
+        unsupported_empty_atomic_uses += !empty_uses.empty();
+        ShaderResourceTable empty_table;
+        add_compute_buffer_resources(empty_table, code, std::size(code), empty_atomic_seed,
+                                     std::size(empty_atomic_seed));
+        unsupported_empty_atomic_resources += !empty_table.resources.empty();
     }
     CHECK(unsupported_atomic_uses == 0 && unsupported_atomic_resources == 0 &&
-              unsupported_atomic_recompiles == 0,
-          "unsupported cmp-swap/csub/inc/dec/x2 MUBUF atomics remain fail-closed");
+              unsupported_atomic_recompiles == 0 && unsupported_empty_atomic_uses == 0 &&
+              unsupported_empty_atomic_resources == 0,
+          "unsupported cmp-swap/csub/inc/dec/x2 atomics remain fail-closed even when empty");
 
     // Terminator 2D supplies descriptor dwords separately, then reassembles its destination V# in
     // s[0:3] with four scalar moves immediately before format stores. This has no SRT-load tag and

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -113,6 +113,16 @@ int main() {
     CHECK(gta_ldexp_modifier.src_abs[0] && gta_ldexp_modifier.src_neg[0] &&
           gta_ldexp_modifier.clamp && gta_ldexp_modifier.omod == 1,
           "v_ldexp_f32 modifier bits remain visible to the fail-closed emitter");
+    // GTA V exec_cs_413d22d00 pc605: `v_bfm_b32 v22, v22, 0`. V_BFM is also a
+    // two-source VOP3A instruction; its reserved zero SRC2 field must not become a phantom s0.
+    const uint32_t gta_bfm_words[] = {0xd7630016u, 0x00010116u};
+    const Rdna2Inst gta_bfm = rdna2_decode_one(gta_bfm_words, 2);
+    CHECK(gta_bfm.fmt == Rdna2Format::VOP3 && gta_bfm.opcode == 0x363u &&
+          gta_bfm.n_src == 2 && isV(gta_bfm.dst, 22) &&
+          isV(gta_bfm.src[0], 22) &&
+          gta_bfm.src[1].kind == OperandKind::InlineInt && gta_bfm.src[1].value == 0 &&
+          gta_bfm.src[2].kind == OperandKind::None,
+          "GTA V v_bfm_b32 decodes two sources and no phantom s0");
     // inst7: s_load_dwordx4 s[0:3], s[4:5], 0x0 (SMEM) -> op 0x2, SDATA s0, SBASE s4 (pair), offset 0
     CHECK(ins[7].fmt == Rdna2Format::SMEM && ins[7].opcode == 0x2u && isS(ins[7].dst, 0) &&
           isS(ins[7].src[0], 4) && ins[7].literal == 0x0u, "s_load_dwordx4 SMEM op/SDATA/SBASE/offset");

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5977,6 +5977,33 @@ int main() {
     CHECK(count_spirv_opcode(native_spv63, 224) == 0,
           "straight-line exact-wave MBCNT emits no workgroup control barrier");
 
+    // Kernel 63a: GTA V saves EXEC in a physical SGPR pair and names the low/high dwords
+    // independently at MBCNT. The Bool-domain mask is keyed only by the pair root (s4): LOW names
+    // s4 directly, while HIGH names s5 and must resolve through s4 rather than an exact s5 key.
+    const uint32_t code63a[] = {
+        0xBE84047Eu,                // s_mov_b64 s[4:5], exec
+        0xD7650001u, 0x00010004u,   // v_mbcnt_lo_u32_b32 v1, s4, 0
+        0xD7660001u, 0x00020205u,   // v_mbcnt_hi_u32_b32 v1, s5, v1
+        0x7E020D01u,                // v_cvt_f32_u32 v1, v1
+        0xBF810000u,                // s_endpgm
+    };
+    const std::vector<uint32_t> spv63a = recompile_valu(
+        code63a, std::size(code63a), 1, /*out_vgpr*/1);
+    const std::vector<float> got63a = spv63a.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv63a, in63, N, N);
+    uint32_t bad63a = 0;
+    for (uint32_t i = 0; i < N && got63a.size() == N; ++i)
+        if (std::fabs(got63a[i] - exp63[i]) > 1e-3f) ++bad63a;
+    CHECK(!spv63a.empty() && got63a.size() == N && bad63a == 0,
+          "saved-EXEC MBCNT resolves LOW/even and HIGH/odd through one mask-pair root");
+
+    uint32_t code63a_wrong_high[std::size(code63a)];
+    std::copy(std::begin(code63a), std::end(code63a), code63a_wrong_high);
+    code63a_wrong_high[4] = 0x00020204u; // same HIGH site, but s5 -> s4 (not the high half of s[4:5])
+    CHECK(recompile_valu(code63a_wrong_high, std::size(code63a_wrong_high), 1, 1).empty(),
+          "saved-EXEC MBCNT rejects a HIGH source that names the pair root instead of its odd half");
+
     // Kernel 64: v_mbcnt with DIVERGENT exec — the real compaction use. v_cmpx narrows exec to (a>thr);
     // then mbcnt gives each active lane its index among active lanes. Even lanes active (a=1>0.5), odd
     // inactive (a=0): active lane L -> L/2 (count of active lanes below); inactive lanes keep 0 (the
@@ -6015,6 +6042,60 @@ int main() {
     uint32_t bad65=0; for(uint32_t i=0;i<N&&got65.size()==N;i++) if(std::fabs(got65[i]-exp65[i])>1e-3f) bad65++;
     printf("  kernel65 mismatches=%u (out[9]=%g exp=%g)\n", bad65, got65.size()==N?got65[9]:-1, exp65[9]);
     CHECK(got65.size()==N && bad65==0, "recompiled kernel 65 (v_mbcnt -1 = localid) correct");
+
+    // Kernel 65b: GTA V exec_cs_413d22d00 pc605, exact `v_bfm_b32 v22,v22,0`.
+    // Width and offset use only five bits, so widths 32/64 wrap to zero rather than all ones.
+    const uint32_t code65b[] = {
+        0xD7630016u, 0x00010116u,
+        0xBF810000u,
+    };
+    const uint32_t widths65b[] = {0u, 1u, 5u, 31u, 32u, 33u, 63u};
+    const uint32_t expected65b[] = {
+        0u, 1u, 0x1fu, 0x7fffffffu, 0u, 1u, 0x7fffffffu,
+    };
+    std::vector<float> in65b(std::size(widths65b) * 23u, 0.0f);
+    for (size_t i = 0; i < std::size(widths65b); ++i)
+        in65b[i * 23u + 22u] = std::bit_cast<float>(widths65b[i]);
+    const std::vector<uint32_t> spv65b = recompile_valu(
+        code65b, std::size(code65b), 23, /*out_vgpr*/22);
+    const std::vector<float> got65b = prosper::test::run_compute(
+        spv65b, in65b, std::size(widths65b), std::size(widths65b));
+    uint32_t bad65b = 0;
+    for (size_t i = 0; i < std::size(widths65b) && got65b.size() == std::size(widths65b); ++i)
+        if (bits_of(got65b[i]) != expected65b[i]) ++bad65b;
+    CHECK(!spv65b.empty() && got65b.size() == std::size(widths65b) && bad65b == 0,
+          "GTA V v_bfm_b32 applies five-bit width semantics exactly");
+
+    // Same-site modifier mutations: no modifier spelling is defined for V_BFM. Test every raw
+    // ABS/OP_SEL/CLAMP/OMOD/NEG bit on the production packet so the admission cannot silently grow.
+    const uint32_t bfm_word0_modifiers[] = {
+        0x00000100u, 0x00000200u, 0x00000400u,
+        0x00000800u, 0x00001000u, 0x00002000u, 0x00004000u,
+        0x00008000u,
+    };
+    const uint32_t bfm_word1_modifiers[] = {
+        0x08000000u, 0x10000000u,
+        0x20000000u, 0x40000000u, 0x80000000u,
+    };
+    bool bfm_modifiers_reject = true;
+    for (uint32_t modifier : bfm_word0_modifiers) {
+        const uint32_t mutant[] = {
+            code65b[0] | modifier, code65b[1], 0xBF810000u,
+        };
+        const RecompileCoverage coverage = recompile_coverage(mutant, std::size(mutant));
+        bfm_modifiers_reject &= recompile_valu(
+            mutant, std::size(mutant), 23, 22).empty() && coverage.unsupported == 1;
+    }
+    for (uint32_t modifier : bfm_word1_modifiers) {
+        const uint32_t mutant[] = {
+            code65b[0], code65b[1] | modifier, 0xBF810000u,
+        };
+        const RecompileCoverage coverage = recompile_coverage(mutant, std::size(mutant));
+        bfm_modifiers_reject &= recompile_valu(
+            mutant, std::size(mutant), 23, 22).empty() && coverage.unsupported == 1;
+    }
+    CHECK(bfm_modifiers_reject,
+          "GTA V v_bfm_b32 same-site modifier mutations remain fail-visible");
 
     // Kernel 66: RAW MUBUF SRSRC RESOLUTION (#91). Same code as kernel 21 (buffer_load_dword v0, v0
     // offen, SRSRC s[8:11]) but WITH a resource table mapping s[8:11] -> binding 3. The load must

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1186,6 +1186,187 @@ int main() {
                     subgroup17d1.size);
     }
 
+    // Kernel 17d1b: GTA V's compact-BVH traversal writes a complete Wave64 VOPC predicate to
+    // s[16:17], scans it with the exact live `beea1410`, and consumes VCC_LO as a scalar lane index
+    // through V_READLANE.  Lane 40 is deliberately above the low dword: truncating the reduction to
+    // B32, deleting the saved-mask resolver, or failing to publish scalar DATA makes this arm red.
+    const uint32_t code17d1b_saved[] = {
+        0x7e0202a8u,              // v_mov_b32 v1, 40
+        0x7e060300u,              // v_mov_b32 v3, v0
+        0x7d8402f9u, 0x06069000u, // v_cmp_eq_u32_sdwa s[16:17], v0, v1
+        0xbeea1410u,              // GTA pc1486: s_ff1_i32_b64 vcc_lo, s[16:17]
+        0xd7600004u, 0x0000d503u, // GTA consumer: v_readlane_b32 s4, v3, vcc_lo
+        0x7e020204u,              // v_mov_b32 v1, s4
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ComputeShaderConfig native_cfg17d1b = native_cfg17d;
+    native_cfg17d1b.local_x = 64;
+    native_cfg17d1b.local_y = 1;
+    const std::vector<uint32_t> native_spv17d1b_saved = recompile_compute(
+        code17d1b_saved, std::size(code17d1b_saved), &rt17d1, native_cfg17d1b);
+    CHECK(!native_spv17d1b_saved.empty() &&
+              count_spirv_opcode(native_spv17d1b_saved, 349) >= 2 &&
+              count_spirv_opcode(native_spv17d1b_saved, 335) >= 1 &&
+              count_spirv_opcode(native_spv17d1b_saved, 345) >= 1,
+          "Wave64 saved-mask s_ff1 lowers to exact reduction and scalar V_READLANE index");
+
+    // The EXEC-source/elect form (`beea147e`) exercises the other captured resolver.  Two Wave64
+    // subgroups share one 128-thread workgroup: wave zero has a sole hit at lane 40 and wave one is
+    // empty.  Seed SCC=false, select through it immediately after S_FF1, and then shift the scalar
+    // result.  Expected 80 / 0xfffffffe therefore catches high-half loss, SCC modification, and a
+    // result left in the mask domain instead of ordinary scalar DATA.
+    const uint32_t code17d1b_exec[] = {
+        0xbe8003a8u,              // s_mov_b32 s0, 40
+        0x7d840000u,              // v_cmp_eq_u32 vcc, s0, v0
+        0xbefe046au,              // s_mov_b64 exec, vcc
+        0xbe810381u,              // s_mov_b32 s1, 1
+        0xbf068001u,              // s_cmp_eq_u32 s1, 0 -> SCC=false
+        0xbeea147eu,              // s_ff1_i32_b64 vcc_lo, exec
+        0x85058081u,              // s_cselect_b32 s5, 1, 0 -> 0 only if SCC was preserved
+        0x8f04816au,              // s_lshl_b32 s4, vcc_lo, 1
+        0x80040504u,              // s_add_u32 s4, s4, s5
+        0xbefe04c1u,              // restore EXEC before vector write/store
+        0x7e020204u,              // v_mov_b32 v1, s4
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ComputeShaderConfig native_cfg17d1b_exec = native_cfg17d1b;
+    native_cfg17d1b_exec.local_x = 128;
+    const std::vector<uint32_t> native_spv17d1b_exec = recompile_compute(
+        code17d1b_exec, std::size(code17d1b_exec), &rt17d1, native_cfg17d1b_exec);
+    CHECK(!native_spv17d1b_exec.empty() &&
+              count_spirv_opcode(native_spv17d1b_exec, 349) >= 2 &&
+              count_spirv_opcode(native_spv17d1b_exec, 335) >= 1,
+          "Wave64 EXEC s_ff1 elect form emits exclusive/reduce IAdd plus Any");
+
+    const bool can_execute17d1b = subgroup17d1.size == 64 &&
+        (subgroup17d1.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_VOTE_BIT);
+    const bool can_shuffle17d1b = can_execute17d1b &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT);
+    if (can_shuffle17d1b && !native_spv17d1b_saved.empty()) {
+        std::vector<uint32_t> got17d1b_saved;
+        prosper::test::run_compute(native_spv17d1b_saved, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, std::vector<uint32_t>(64, 0),
+                                   &got17d1b_saved);
+        uint32_t bad17d1b_saved = 0;
+        for (uint32_t lane = 0; lane < 64 && got17d1b_saved.size() == 64; ++lane)
+            bad17d1b_saved += got17d1b_saved[lane] != 40u;
+        CHECK(got17d1b_saved.size() == 64 && bad17d1b_saved == 0,
+              "Wave64 saved-mask s_ff1 feeds lane 40 to V_READLANE for every invocation");
+    } else {
+        std::printf("  [skip] saved-mask s_ff1 execution: host subgroup is %u or lacks vote/arithmetic/shuffle\n",
+                    subgroup17d1.size);
+    }
+    if (can_execute17d1b && !native_spv17d1b_exec.empty()) {
+        std::vector<uint32_t> got17d1b_exec;
+        prosper::test::run_compute(native_spv17d1b_exec, std::vector<float>(128, 0.0f),
+                                   128, 128, {}, std::vector<uint32_t>(128, 0),
+                                   &got17d1b_exec, 128);
+        uint32_t bad17d1b_exec = 0;
+        for (uint32_t lane = 0; lane < 128 && got17d1b_exec.size() == 128; ++lane) {
+            const uint32_t expected = lane < 64 ? 80u : 0xfffffffeu;
+            bad17d1b_exec += got17d1b_exec[lane] != expected;
+        }
+        CHECK(got17d1b_exec.size() == 128 && bad17d1b_exec == 0,
+              "Wave64 EXEC s_ff1 returns lane 40 / -1 and preserves SCC=false");
+    } else {
+        std::printf("  [skip] EXEC s_ff1 execution: host subgroup is %u or lacks vote/arithmetic\n",
+                    subgroup17d1.size);
+    }
+
+    // VCC is the third admitted complete-mask source.  This structural arm is intentionally
+    // separate from the two exact GTA words above so the resolver cannot accidentally cover only
+    // EXEC and saved SGPR pairs.
+    const uint32_t code17d1b_vcc[] = {
+        0xbe8003a8u,              // s_mov_b32 s0, 40
+        0x7d840000u,              // v_cmp_eq_u32 vcc, s0, v0
+        0xbe84146au,              // s_ff1_i32_b64 s4, vcc
+        0x8f048104u,              // s_lshl_b32 s4, s4, 1
+        0x7e040204u,              // v_mov_b32 v2, s4
+        0xbf810000u,
+    };
+    CHECK(!recompile_compute(code17d1b_vcc, std::size(code17d1b_vcc), nullptr,
+                             native_cfg17d1b).empty(),
+          "exact Wave64 s_ff1 resolves a complete VCC source to scalar data");
+
+    // Fail-visible domain/width arms.  They mutate the same op0x14 production gate and mask
+    // resolver as the positive packets: mismatched/unknown subgroups, plain scalar B64 data,
+    // mask+data ambiguity, an absent saved pair, and either EXEC-half destination must all reject.
+    ComputeShaderConfig native32_cfg17d1b = native_cfg17d1b;
+    native32_cfg17d1b.native_subgroup_size = 32;
+    ComputeShaderConfig unknown_cfg17d1b = native_cfg17d1b;
+    unknown_cfg17d1b.native_subgroup_size = 0;
+    ComputeShaderConfig wave32_cfg17d1b = native_cfg17d1b;
+    wave32_cfg17d1b.wave_size = 32;
+    wave32_cfg17d1b.native_subgroup_size = 32;
+    const uint32_t code17d1b_exec_scalar[] = {
+        0xbe84147eu,              // s_ff1_i32_b64 s4, exec
+        0x7e040204u,              // v_mov_b32 v2, s4
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1b_exec_scalar, std::size(code17d1b_exec_scalar), nullptr,
+                            native32_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_exec_scalar, std::size(code17d1b_exec_scalar), nullptr,
+                                unknown_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_exec_scalar, std::size(code17d1b_exec_scalar), nullptr,
+                                wave32_cfg17d1b).empty(),
+          "S_FF1_I32_B64 rejects native32, unknown-width, and Wave32 execution");
+    const uint32_t code17d1b_unknown_pair[] = {
+        0xbe841410u,              // s_ff1_i32_b64 s4, untracked s[16:17]
+        0xbf810000u,
+    };
+    const uint32_t code17d1b_plain_data[] = {
+        0xbe900381u,              // s_mov_b32 s16, 1
+        0xbe910380u,              // s_mov_b32 s17, 0
+        0xbe841410u,              // s_ff1_i32_b64 s4, scalar s[16:17]
+        0xbf810000u,
+    };
+    const uint32_t code17d1b_ambiguous[] = {
+        0xbe9004c1u,              // s_mov_b64 s[16:17], -1 (both mask and scalar-data views)
+        0xbe841410u,              // s_ff1_i32_b64 s4, ambiguous s[16:17]
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1b_unknown_pair, std::size(code17d1b_unknown_pair), nullptr,
+                            native_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_plain_data, std::size(code17d1b_plain_data), nullptr,
+                                native_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_ambiguous, std::size(code17d1b_ambiguous), nullptr,
+                                native_cfg17d1b).empty(),
+          "Wave64 s_ff1 rejects unknown, scalar-data, and ambiguous B64 sources");
+    const uint32_t code17d1b_exec_lo_dst[] = {0xbefe147eu, 0xbf810000u};
+    const uint32_t code17d1b_exec_hi_dst[] = {0xbeff147eu, 0xbf810000u};
+    CHECK(recompile_compute(code17d1b_exec_lo_dst, std::size(code17d1b_exec_lo_dst), nullptr,
+                            native_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_exec_hi_dst, std::size(code17d1b_exec_hi_dst), nullptr,
+                                native_cfg17d1b).empty(),
+          "Wave64 s_ff1 keeps both EXEC-half scalar destinations fail-visible");
+
+    // A scalar result in VCC_LO destroys the complete Wave64 predicate; it must not be rebuilt from
+    // one dword or left stale.  Likewise, writing the high half of a saved pair ends that pair's
+    // mask lifetime.  These arms specifically kill destination-alias cleanup mutations.
+    const uint32_t code17d1b_stale_vcc[] = {
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0 (live complete VCC)
+        0xbeea147eu,              // s_ff1_i32_b64 vcc_lo, exec (new scalar lifetime)
+        0x02000501u,              // v_cndmask_b32 v0, v1, v2, stale implicit VCC
+        0xbf810000u,
+    };
+    const uint32_t code17d1b_stale_saved_pair[] = {
+        0x7e0202a8u,              // v_mov_b32 v1, 40
+        0x7d8402f9u, 0x06069000u, // v_cmp_eq_u32_sdwa s[16:17], v0, v1
+        0xbe91147eu,              // s_ff1_i32_b64 s17, exec (overwrites saved-mask high half)
+        0xbefe0410u,              // s_mov_b64 exec, s[16:17] must not see stale mask
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1b_stale_vcc, std::size(code17d1b_stale_vcc), nullptr,
+                            native_cfg17d1b).empty() &&
+              recompile_compute(code17d1b_stale_saved_pair,
+                                std::size(code17d1b_stale_saved_pair), nullptr,
+                                native_cfg17d1b).empty(),
+          "S_FF1 scalar destinations invalidate stale VCC and overlapping saved-mask aliases");
+
     // Kernel 17d1m: Astro reuses physical VCC_LO as ordinary scalar data, then copies that complete
     // dword into EXEC_LO.  A Wave32 translation must select this invocation's bit from the scalar
     // value: mask 1 activates lane zero of each guest wave and leaves every other destination word

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -635,6 +635,186 @@ int main() {
                     exec_ballot_subgroup.size);
     }
 
+    // GTA V's Wave64 traversal kernels count complete EXEC, VCC, and VOPC-saved masks.  A native
+    // subgroup reduction is exact only under the required 64-lane contract.  The asymmetric VCC
+    // predicate contains 33 lanes, including lane 32, while the second wave is empty; doubling the
+    // result also keeps the immediately-preceding SCC=false observable after S_BCNT.
+    const uint32_t code9_bcnt_vcc[] = {
+        0x7d8800a1u,              // v_cmp_gt_u32 vcc, 33, v0 -> wave0 lanes 0..32
+        0xbe810381u,              // s_mov_b32 s1, 1
+        0xbf068001u,              // s_cmp_eq_u32 s1, 0 -> SCC=false
+        0xbe84106au,              // s_bcnt1_i32_b64 s4, vcc
+        0x85058081u,              // s_cselect_b32 s5, 1, 0 -> 0 only if SCC is preserved
+        0x8f048104u,              // s_lshl_b32 s4, s4, 1
+        0x80040504u,              // s_add_u32 s4, s4, s5
+        0x7e020204u,              // v_mov_b32 v1, s4
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ShaderResourceTable bcnt_table;
+    { ShaderResource output{}; output.cls = ResourceClass::ConstantBuffer;
+      output.format = DataFormat::Uint32; output.num_components = 1;
+      output.binding = 3; output.stride = 4; output.sgpr_base = 8;
+      bcnt_table.resources.push_back(output); }
+    ComputeShaderConfig bcnt_wave64_config;
+    bcnt_wave64_config.local_x = 128;
+    bcnt_wave64_config.wave_size = 64;
+    bcnt_wave64_config.native_subgroup_size = 64;
+    const std::vector<uint32_t> spv9_bcnt_vcc = recompile_compute(
+        code9_bcnt_vcc, std::size(code9_bcnt_vcc), &bcnt_table, bcnt_wave64_config);
+    CHECK(!spv9_bcnt_vcc.empty() && count_spirv_opcode(spv9_bcnt_vcc, 349) == 1 &&
+              count_spirv_opcode(spv9_bcnt_vcc, 339) == 0,
+          "Wave64 VCC s_bcnt emits one exact subgroup IAdd reduction");
+
+    // The exact live EXEC packet (`be86107e`) and saved-mask packet (`beea1006`) exercise the two
+    // other source resolvers.  The saved predicate has only lane 40 set, so a low-half truncation
+    // produces zero rather than one.  Both publish ordinary scalar DATA for the following move.
+    const uint32_t code9_bcnt_exec[] = {
+        0x7d8800a1u,              // v_cmp_gt_u32 vcc, 33, v0
+        0xbefe046au,              // s_mov_b64 exec, vcc
+        0xbe86107eu,              // GTA pc337: s_bcnt1_i32_b64 s6, exec
+        0xbefe04c1u,              // restore EXEC before vector write/store
+        0x7e020206u,              // v_mov_b32 v1, s6
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    const uint32_t code9_bcnt_saved[] = {
+        0x7e0202a8u,              // v_mov_b32 v1, 40
+        0x7d8402f9u, 0x06068600u, // v_cmp_eq_u32_sdwa s[6:7], v0, v1
+        0xbeea1006u,              // GTA pc2007: s_bcnt1_i32_b64 vcc_lo, s[6:7]
+        0x7e02026au,              // v_mov_b32 v1, vcc_lo (scalar-data lifetime)
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv9_bcnt_exec = recompile_compute(
+        code9_bcnt_exec, std::size(code9_bcnt_exec), &bcnt_table, bcnt_wave64_config);
+    const std::vector<uint32_t> spv9_bcnt_saved = recompile_compute(
+        code9_bcnt_saved, std::size(code9_bcnt_saved), &bcnt_table, bcnt_wave64_config);
+    CHECK(!spv9_bcnt_exec.empty() && count_spirv_opcode(spv9_bcnt_exec, 349) == 1 &&
+              !spv9_bcnt_saved.empty() && count_spirv_opcode(spv9_bcnt_saved, 349) == 1,
+          "exact EXEC and saved-mask s_bcnt packets lower through the Wave64 reduction");
+
+    const bool can_execute_bcnt = exec_ballot_subgroup.size == 64 &&
+        (exec_ballot_subgroup.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (exec_ballot_subgroup.operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT);
+    if (can_execute_bcnt && !spv9_bcnt_vcc.empty() && !spv9_bcnt_exec.empty() &&
+        !spv9_bcnt_saved.empty()) {
+        auto run_bcnt = [&](const std::vector<uint32_t>& spv) {
+            std::vector<uint32_t> got;
+            prosper::test::run_compute(spv, std::vector<float>(128, 0.0f), 128, 128, {},
+                                       std::vector<uint32_t>(128, 0), &got, 128);
+            return got;
+        };
+        const std::vector<uint32_t> got_bcnt_vcc = run_bcnt(spv9_bcnt_vcc);
+        const std::vector<uint32_t> got_bcnt_exec = run_bcnt(spv9_bcnt_exec);
+        const std::vector<uint32_t> got_bcnt_saved = run_bcnt(spv9_bcnt_saved);
+        uint32_t bad_bcnt = 0;
+        for (uint32_t lane = 0; lane < 128 && got_bcnt_vcc.size() == 128 &&
+             got_bcnt_exec.size() == 128 && got_bcnt_saved.size() == 128; ++lane) {
+            bad_bcnt += got_bcnt_vcc[lane] != (lane < 64 ? 66u : 0u);
+            bad_bcnt += got_bcnt_exec[lane] != (lane < 64 ? 33u : 0u);
+            bad_bcnt += got_bcnt_saved[lane] != (lane < 64 ? 1u : 0u);
+        }
+        CHECK(got_bcnt_vcc.size() == 128 && got_bcnt_exec.size() == 128 &&
+                  got_bcnt_saved.size() == 128 && bad_bcnt == 0,
+              "Wave64 s_bcnt counts high-half/empty masks and preserves SCC=false");
+    } else {
+        std::printf("  [skip] Wave64 s_bcnt execution: host subgroup is %u or lacks arithmetic\n",
+                    exec_ballot_subgroup.size);
+    }
+
+    // Width/domain and destination guards mutate the same op0x10 production gate and resolver as
+    // the positive packets.  Plain scalar B64 remains covered by T8b below; unknown masks, ambiguous
+    // mask+data state, non-Wave64 execution, and writes to either EXEC half stay fail-visible.
+    ComputeShaderConfig bcnt_native32_config = bcnt_wave64_config;
+    bcnt_native32_config.native_subgroup_size = 32;
+    ComputeShaderConfig bcnt_unknown_config = bcnt_wave64_config;
+    bcnt_unknown_config.native_subgroup_size = 0;
+    ComputeShaderConfig bcnt_wave32_config = bcnt_wave64_config;
+    bcnt_wave32_config.wave_size = 32;
+    bcnt_wave32_config.native_subgroup_size = 32;
+    const uint32_t code9_bcnt_exec_scalar[] = {
+        0xbe84107eu,              // s_bcnt1_i32_b64 s4, exec
+        0x7e020204u,
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code9_bcnt_exec_scalar, std::size(code9_bcnt_exec_scalar), nullptr,
+                            bcnt_native32_config).empty() &&
+              recompile_compute(code9_bcnt_exec_scalar, std::size(code9_bcnt_exec_scalar), nullptr,
+                                bcnt_unknown_config).empty() &&
+              recompile_compute(code9_bcnt_exec_scalar, std::size(code9_bcnt_exec_scalar), nullptr,
+                                bcnt_wave32_config).empty(),
+          "S_BCNT1_I32_B64 rejects native32, unknown-width, and Wave32 mask execution");
+    const uint32_t code9_bcnt_unknown_pair[] = {0xbe841006u, 0xbf810000u};
+    const uint32_t code9_bcnt_ambiguous[] = {
+        0xbe8604c1u,              // s_mov_b64 s[6:7], -1 (mask and scalar-data views)
+        0xbe841006u,              // s_bcnt1_i32_b64 s4, s[6:7]
+        0xbf810000u,
+    };
+    const uint32_t code9_bcnt_exec_lo_dst[] = {0xbefe107eu, 0xbf810000u};
+    const uint32_t code9_bcnt_exec_hi_dst[] = {0xbeff107eu, 0xbf810000u};
+    const uint32_t code9_bcnt_scalar_exec_lo_dst[] = {0xbefe10c1u, 0xbf810000u};
+    const uint32_t code9_bcnt_scalar_exec_hi_dst[] = {0xbeff10c1u, 0xbf810000u};
+    CHECK(recompile_compute(code9_bcnt_unknown_pair, std::size(code9_bcnt_unknown_pair), nullptr,
+                            bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_ambiguous, std::size(code9_bcnt_ambiguous), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_exec_lo_dst, std::size(code9_bcnt_exec_lo_dst), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_exec_hi_dst, std::size(code9_bcnt_exec_hi_dst), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_scalar_exec_lo_dst,
+                                std::size(code9_bcnt_scalar_exec_lo_dst), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_scalar_exec_hi_dst,
+                                std::size(code9_bcnt_scalar_exec_hi_dst), nullptr,
+                                bcnt_wave64_config).empty(),
+          "Wave64 s_bcnt rejects unknown/ambiguous masks and scalar/mask writes to EXEC");
+
+    // A scalar result overwriting VCC_LO, or the high half of a saved pair, destroys that mask.
+    // Subsequent implicit VCC/EXEC consumers must not observe the pre-S_BCNT Boolean lifetime.
+    const uint32_t code9_bcnt_stale_vcc[] = {
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0 (live complete VCC)
+        0xbeea107eu,              // s_bcnt1_i32_b64 vcc_lo, exec (scalar result)
+        0x02000501u,              // v_cndmask_b32 v0, v1, v2, stale implicit VCC
+        0xbf810000u,
+    };
+    const uint32_t code9_bcnt_stale_saved[] = {
+        0x7e0202a8u,
+        0x7d8402f9u, 0x06068600u, // saved mask rooted at s6
+        0xbe87107eu,              // s_bcnt1_i32_b64 s7, exec overwrites its high half
+        0xbefe0406u,              // s_mov_b64 exec, s[6:7] must not see the stale mask
+        0xbf810000u,
+    };
+    const uint32_t code9_bcnt_scalar_stale_vcc[] = {
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0 (live complete VCC)
+        0xbe880381u,              // s_mov_b32 s8, 1 (ordinary scalar-data pair)
+        0xbe890380u,              // s_mov_b32 s9, 0
+        0xbeeb1008u,              // s_bcnt1_i32_b64 vcc_hi, s[8:9]
+        0x02000501u,              // v_cndmask_b32 v0, v1, v2, stale implicit VCC
+        0xbf810000u,
+    };
+    const uint32_t code9_bcnt_scalar_stale_saved[] = {
+        0x7e0202a8u,
+        0x7d8402f9u, 0x06068600u, // saved mask rooted at s6
+        0xbe880381u,              // s_mov_b32 s8, 1 (ordinary scalar-data pair)
+        0xbe890380u,              // s_mov_b32 s9, 0
+        0xbe871008u,              // s_bcnt1_i32_b64 s7, s[8:9] overwrites saved high half
+        0xbefe0406u,              // s_mov_b64 exec, s[6:7] must not see the stale mask
+        0xbf810000u,
+    };
+    CHECK(recompile_compute(code9_bcnt_stale_vcc, std::size(code9_bcnt_stale_vcc), nullptr,
+                            bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_stale_saved, std::size(code9_bcnt_stale_saved), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_scalar_stale_vcc,
+                                std::size(code9_bcnt_scalar_stale_vcc), nullptr,
+                                bcnt_wave64_config).empty() &&
+              recompile_compute(code9_bcnt_scalar_stale_saved,
+                                std::size(code9_bcnt_scalar_stale_saved), nullptr,
+                                bcnt_wave64_config).empty(),
+          "S_BCNT scalar and mask sources invalidate stale VCC and saved-mask aliases");
+
     // Plucky Squire's post-Desk transition shader clears the top bit of a scalar-data VCC_HI
     // lifetime before combining the two VCC dwords into a buffer address. This is the exact
     // gfx1030 s_bitset0_b32 packet retained by the failed-dispatch capsule for #1554.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5889,6 +5889,79 @@ int main() {
     CHECK(zero_store_after == zero_store_sentinel,
           "zero-record raw store is a no-op and cannot mutate a shared dummy backing");
 
+    // Fully-known NUM_RECORDS=0 atomics use the same exact-PC marker, but their VDATA behavior is
+    // distinct. GLC=1 returns the pre-op value (zero for an empty descriptor) only to active EXEC
+    // lanes; GLC=0 preserves VDATA for every lane. Neither shape may declare a storage binding or
+    // emit an OpAtomic -- there is no backing allocation on which an atomic can operate.
+    auto spirv_atomic_count = [](const std::vector<uint32_t>& spirv) {
+        size_t count = count_spirv_opcode(spirv, 229); // OpAtomicExchange
+        for (uint16_t opcode = 234; opcode <= 242; ++opcode) // IAdd..Xor
+            count += count_spirv_opcode(spirv, opcode);
+        return count;
+    };
+
+    // v2=7; narrow EXEC to u0>u1; exact GTA 0x413e1ac add packet with GLC; restore EXEC;
+    // convert/output v2. Active lanes receive zero and masked lanes retain seven.
+    const uint32_t code68_zero_atomic_glc[] = {
+        0x7E000F00u, 0x7E020F01u, 0x7E040287u, 0x7DA80300u,
+        0xE0C86000u, 0x80030201u,
+        0xBEFE04C1u, 0x7E040D02u, 0xBF810000u,
+    };
+    ShaderResourceTable rt68_zero_atomic_glc;
+    rt68_zero_atomic_glc.resources.push_back(zero_record_resource(4));
+    const std::vector<uint32_t> spv68_zero_atomic_glc = recompile_valu(
+        code68_zero_atomic_glc, std::size(code68_zero_atomic_glc), 2, 2,
+        &rt68_zero_atomic_glc);
+    CHECK(!spv68_zero_atomic_glc.empty() &&
+              spirv_atomic_count(spv68_zero_atomic_glc) == 0,
+          "zero-record GLC atomic emits no OpAtomic");
+    const std::vector<uint32_t> zero_atomic_glc_sentinel = {
+        0xDEADBEEFu, 0xCAFEBABEu,
+    };
+    std::vector<uint32_t> zero_atomic_glc_after;
+    const std::vector<float> got68_zero_atomic_glc = prosper::test::run_compute(
+        spv68_zero_atomic_glc, in68_zero_load, N, N, {}, zero_atomic_glc_sentinel,
+        &zero_atomic_glc_after);
+    uint32_t bad68_zero_atomic_glc = 0;
+    for (uint32_t i = 0; i < N && got68_zero_atomic_glc.size() == N; ++i)
+        if (got68_zero_atomic_glc[i] != expected68_zero_load[i])
+            ++bad68_zero_atomic_glc;
+    CHECK(active68_zero_load > 0 && active68_zero_load < N &&
+              got68_zero_atomic_glc.size() == N && bad68_zero_atomic_glc == 0 &&
+              zero_atomic_glc_after == zero_atomic_glc_sentinel,
+          "zero-record GLC atomic returns zero only to active EXEC lanes and touches no memory");
+
+    // Preserve the live 0x413d884 pc163 OR packet, including VDATA=v23 and GLC=0. The synthetic
+    // marker isolates the architectural empty-resource behavior; the production fold test above is
+    // where the exact live PC and descriptor provenance are checked.
+    const uint32_t code68_zero_atomic_no_glc[] = {
+        0x7E000F00u, 0x7E020F01u, 0x7E2E0287u, 0x7DA80300u,
+        0xE0E82000u, 0x80051700u,
+        0xBEFE04C1u, 0x7E2E0D17u, 0xBF810000u,
+    };
+    ShaderResourceTable rt68_zero_atomic_no_glc;
+    rt68_zero_atomic_no_glc.resources.push_back(zero_record_resource(4));
+    const std::vector<uint32_t> spv68_zero_atomic_no_glc = recompile_valu(
+        code68_zero_atomic_no_glc, std::size(code68_zero_atomic_no_glc), 2, 23,
+        &rt68_zero_atomic_no_glc);
+    CHECK(!spv68_zero_atomic_no_glc.empty() &&
+              spirv_atomic_count(spv68_zero_atomic_no_glc) == 0,
+          "zero-record non-GLC atomic emits no OpAtomic");
+    const std::vector<uint32_t> zero_atomic_no_glc_sentinel = {
+        0x12345678u, 0x89ABCDEFu,
+    };
+    std::vector<uint32_t> zero_atomic_no_glc_after;
+    const std::vector<float> got68_zero_atomic_no_glc = prosper::test::run_compute(
+        spv68_zero_atomic_no_glc, in68_zero_load, N, N, {}, zero_atomic_no_glc_sentinel,
+        &zero_atomic_no_glc_after);
+    const uint32_t retained68_zero_atomic_no_glc = static_cast<uint32_t>(std::count(
+        got68_zero_atomic_no_glc.begin(), got68_zero_atomic_no_glc.end(), 7.0f));
+    CHECK(active68_zero_load > 0 && active68_zero_load < N &&
+              got68_zero_atomic_no_glc.size() == N &&
+              retained68_zero_atomic_no_glc == N &&
+              zero_atomic_no_glc_after == zero_atomic_no_glc_sentinel,
+          "zero-record non-GLC atomic preserves VDATA in active and inactive lanes without memory");
+
     // Kernel N: v_nop (VOP1 op 0x00) between real ALU ops must be a transparent no-op. This was the
     // #121 blocker — PPSA02664's vertex shaders contain v_nop (a common scheduling/hazard filler), and
     // the recompiler rejected it, failing the whole shader and skipping ~182 draws/frame (black screen).

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -803,6 +803,26 @@ int main() {
                              compute_cfg_dispatch_ff1.size(), &dispatch_rt,
                              wave32_dispatch_config).empty(),
           "the complex dispatcher lowers exact Wave32 s_ff1 mask reduction to scalar data");
+    // GTA V reaches S_FF1_I32_B64 inside this same exact-wave dispatcher family.  Prefix the
+    // irreducible fixture with the live saved-VOPC packet and its scalar shift consumer: this
+    // prevents a straight-line-only implementation from claiming the terminal program fixed.
+    ComputeShaderConfig wave64_dispatch_config = wave32_dispatch_config;
+    wave64_dispatch_config.wave_size = 64;
+    wave64_dispatch_config.native_subgroup_size = 64;
+    std::vector<uint32_t> compute_cfg_dispatch_ff1_b64 = {
+        0x7E0202A8u,              // v_mov_b32 v1, 40
+        0x7D8402F9u, 0x06069000u, // v_cmp_eq_u32_sdwa s[16:17], v0, v1
+        0xBEEA1410u,              // GTA pc1486: s_ff1_i32_b64 vcc_lo, s[16:17]
+        0x8F04816Au,              // s_lshl_b32 s4, vcc_lo, 1 (scalar-data consumer)
+        0x7E040204u,              // v_mov_b32 v2, s4
+    };
+    compute_cfg_dispatch_ff1_b64.insert(
+        compute_cfg_dispatch_ff1_b64.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_ff1_b64.data(),
+                             compute_cfg_dispatch_ff1_b64.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "the exact Wave64 dispatcher lowers GTA's saved-mask S_FF1_I32_B64 site");
     std::vector<uint32_t> compute_cfg_dispatch_dynamic_writelane = {
         0x7E780300u,              // v_mov_b32 v60, v0
         0xBEEB0389u,              // s_mov_b32 vcc_hi, 9 (scalar data)

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -894,6 +894,88 @@ int main() {
                             compute_cfg_dispatch_ambiguous_ff1_b64.size(), &dispatch_rt,
                             wave64_dispatch_config).empty(),
           "a Wave64 mask/scalar join remains ambiguous at the exact S_FF1 consumer");
+    // GTA V also consumes saved EXEC halves through V_MBCNT after dispatcher boundaries. LOW names
+    // the pair root and HIGH names its following dword; both consumers must be admitted only where
+    // the Wave64 MUST-domain proof says that same B64 mask lifetime reaches the exact PC.
+    std::vector<uint32_t> compute_cfg_dispatch_persisted_mbcnt_b64 = {
+        0xBE900381u, // earlier scalar lifetime: s_mov_b32 s16, 1
+        0xBE910382u, //                          s_mov_b32 s17, 2
+        0xBE90047Eu, // s_mov_b64 s[16:17], exec (saved-mask lifetime begins)
+    };
+    compute_cfg_dispatch_persisted_mbcnt_b64.insert(
+        compute_cfg_dispatch_persisted_mbcnt_b64.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch) - 1);
+    compute_cfg_dispatch_persisted_mbcnt_b64.insert(
+        compute_cfg_dispatch_persisted_mbcnt_b64.end(), {
+            0xBEFE0410u,              // s_mov_b64 exec, s[16:17]
+            0xD7650003u, 0x00010010u, // v_mbcnt_lo_u32_b32 v3, s16, 0
+            0xD7660003u, 0x00020611u, // v_mbcnt_hi_u32_b32 v3, s17, v3
+            0xBF810000u,
+        });
+    CHECK(!recompile_compute(compute_cfg_dispatch_persisted_mbcnt_b64.data(),
+                             compute_cfg_dispatch_persisted_mbcnt_b64.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "the native Wave64 dispatcher preserves saved EXEC through LOW/even and HIGH/odd MBCNT");
+    ComputeShaderConfig portable_wave64_dispatch_config = wave64_dispatch_config;
+    portable_wave64_dispatch_config.native_subgroup_size = 0;
+    CHECK(!recompile_compute(compute_cfg_dispatch_persisted_mbcnt_b64.data(),
+                             compute_cfg_dispatch_persisted_mbcnt_b64.size(), &dispatch_rt,
+                             portable_wave64_dispatch_config).empty(),
+          "the portable Wave64 dispatcher preserves saved EXEC through synchronized MBCNT");
+
+    std::vector<uint32_t> compute_cfg_dispatch_overwritten_mbcnt_b64 =
+        compute_cfg_dispatch_persisted_mbcnt_b64;
+    compute_cfg_dispatch_overwritten_mbcnt_b64[
+        compute_cfg_dispatch_overwritten_mbcnt_b64.size() - 6] =
+        0xBE910380u; // replace the restore with an s17 overwrite immediately before MBCNT
+    CHECK(recompile_compute(compute_cfg_dispatch_overwritten_mbcnt_b64.data(),
+                            compute_cfg_dispatch_overwritten_mbcnt_b64.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "saved-pair MBCNT rejects after an overlapping high-half scalar overwrite");
+
+    std::vector<uint32_t> compute_cfg_dispatch_ambiguous_mbcnt_b64(
+        compute_cfg_dispatch_persisted_mbcnt_b64.begin(),
+        compute_cfg_dispatch_persisted_mbcnt_b64.end() - 6);
+    compute_cfg_dispatch_ambiguous_mbcnt_b64.insert(
+        compute_cfg_dispatch_ambiguous_mbcnt_b64.end(), {
+            0xBF068014u, // s_cmp_eq_u32 s20, 0
+            0xBF840001u, // s_cbranch_scc0 +1: one predecessor preserves the mask
+            0xBE910380u, // other predecessor overwrites s17
+        });
+    compute_cfg_dispatch_ambiguous_mbcnt_b64.insert(
+        compute_cfg_dispatch_ambiguous_mbcnt_b64.end(),
+        compute_cfg_dispatch_persisted_mbcnt_b64.end() - 6,
+        compute_cfg_dispatch_persisted_mbcnt_b64.end());
+    CHECK(recompile_compute(compute_cfg_dispatch_ambiguous_mbcnt_b64.data(),
+                            compute_cfg_dispatch_ambiguous_mbcnt_b64.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "saved-pair MBCNT rejects a mask/scalar predecessor join at its exact consumer");
+
+    // A forward exact-wave branch normally remains on the compact structured path. A real MBCNT
+    // after its merge still needs the dispatcher's synchronized common phase (the all-ones
+    // lane-index idiom remains locally scalarizable and does not take this route).
+    const uint32_t compute_structured_saved_mbcnt_b64[] = {
+        0xBE84047Eu,                // s_mov_b64 s[4:5], exec
+        0x7E060280u,                // v_mov_b32 v3, 0 (merge live-in)
+        0x7C020300u,                // v_cmp_lt_f32 vcc, v0, v1 (varying guest-wave branch)
+        0xBF860001u,                // s_cbranch_vccz +1 -> merge
+        0x7E060281u,                // guarded write keeps the structured branch live
+        0xD7650003u, 0x00010004u,   // v_mbcnt_lo_u32_b32 v3, s4, 0
+        0xD7660003u, 0x00020605u,   // v_mbcnt_hi_u32_b32 v3, s5, v3
+        0xBF810000u,
+    };
+    const std::vector<uint32_t> native_structured_saved_mbcnt_b64 = recompile_compute(
+        compute_structured_saved_mbcnt_b64,
+        std::size(compute_structured_saved_mbcnt_b64), nullptr,
+        wave64_dispatch_config);
+    CHECK(!native_structured_saved_mbcnt_b64.empty(),
+          "structured compute routes saved-mask MBCNT through the native common phase");
+    const std::vector<uint32_t> portable_structured_saved_mbcnt_b64 = recompile_compute(
+        compute_structured_saved_mbcnt_b64,
+        std::size(compute_structured_saved_mbcnt_b64), nullptr,
+        portable_wave64_dispatch_config);
+    CHECK(!portable_structured_saved_mbcnt_b64.empty(),
+          "structured compute routes saved-mask MBCNT through the portable common phase");
     // GTA V's exec_cs_413d88400 reaches the exact `beea147e` packet at PC336 after
     // structured divergent loops.  Their EXEC restores are represented separately from the
     // architectural EXEC mask, so loop-carried scalar placeholders for s126/s127 must not make

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -823,6 +823,43 @@ int main() {
                              compute_cfg_dispatch_ff1_b64.size(), &dispatch_rt,
                              wave64_dispatch_config).empty(),
           "the exact Wave64 dispatcher lowers GTA's saved-mask S_FF1_I32_B64 site");
+    // GTA V's exec_cs_413d88400 reaches the exact `beea147e` packet at PC336 after
+    // structured divergent loops.  Their EXEC restores are represented separately from the
+    // architectural EXEC mask, so loop-carried scalar placeholders for s126/s127 must not make
+    // the packet look like an ambiguous ordinary SGPR-pair read.
+    const uint32_t compute_structured_exec_ff1_b64[] = {
+        0x7E020283u,               //  0: v_mov_b32 v1, 3        (outer bound)
+        0x7E080284u,               //  1: v_mov_b32 v4, 4        (inner bound)
+        0xBE800380u,               //  2: s_mov_b32 s0, 0        (outer counter)
+        0x7E040280u,               //  3: v_mov_b32 v2, 0
+        0x7E060280u,               //  4: v_mov_b32 v3, 0
+        0xBE82047Eu,               //  5: s_mov_b64 s[2:3], exec (outer save)
+        0x7DA20200u,               //  6: OUTER_HDR: v_cmpx_lt_u32 s0, v1
+        0xBF88000Du,               //  7: s_cbranch_execz +13 -> 21
+        0xBE810380u,               //  8: s_mov_b32 s1, 0
+        0xBE84047Eu,               //  9: s_mov_b64 s[4:5], exec (inner save)
+        0x7DA20801u,               // 10: INNER_HDR: v_cmpx_lt_u32 s1, v4
+        0xBF880004u,               // 11: s_cbranch_execz +4 -> 16
+        0x060606FFu, 0x3D800000u,  // 12: v_add_f32 v3, 0.0625, v3
+        0x81018101u,               // 14: s_add_i32 s1, s1, 1
+        0xBF82FFFAu,               // 15: s_branch -6 -> 10
+        0xBEFE0404u,               // 16: s_mov_b64 exec, s[4:5]
+        0x060404FFu, 0x3E800000u,  // 17: v_add_f32 v2, 0.25, v2
+        0x81008100u,               // 19: s_add_i32 s0, s0, 1
+        0xBF82FFF1u,               // 20: s_branch -15 -> 6
+        0xBEFE0402u,               // 21: s_mov_b64 exec, s[2:3]
+        0xBEEA147Eu,               // 22: GTA PC336: s_ff1_i32_b64 vcc_lo, exec
+        0xBE86107Eu,               // 23: GTA PC337: s_bcnt1_i32_b64 s6, exec
+        0x8F04816Au,               // 24: s_lshl_b32 s4, vcc_lo, 1
+        0x80040604u,               // 25: s_add_u32 s4, s4, s6 (consume both results)
+        0x7E0C0204u,               // 26: v_mov_b32 v6, s4
+        0xBF8A0000u,               // 27: s_barrier forces the structured route
+        0xBF810000u,               // 28: s_endpgm
+    };
+    CHECK(!recompile_compute(compute_structured_exec_ff1_b64,
+                             std::size(compute_structured_exec_ff1_b64), nullptr,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact EXEC S_FF1/S_BCNT packets survive structured loop state");
     std::vector<uint32_t> compute_cfg_dispatch_dynamic_writelane = {
         0x7E780300u,              // v_mov_b32 v60, v0
         0xBEEB0389u,              // s_mov_b32 vcc_hi, 9 (scalar data)

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -823,6 +823,77 @@ int main() {
                              compute_cfg_dispatch_ff1_b64.size(), &dispatch_rt,
                              wave64_dispatch_config).empty(),
           "the exact Wave64 dispatcher lowers GTA's saved-mask S_FF1_I32_B64 site");
+    // The immediate producer above does not cross a dispatcher edge.  GTA's later saved-mask sites
+    // do: the dispatcher persists both the Bool-domain mask and synthetic scalar placeholders for
+    // its physical SGPR pair.  A mask proven live on every predecessor must still reach the exact
+    // S_FF1/S_BCNT reduction packet after that save/reload boundary.
+    std::vector<uint32_t> compute_cfg_dispatch_persisted_ff1_b64 = {
+        0xBE900381u, // earlier scalar lifetime: s_mov_b32 s16, 1
+        0xBE910382u, //                          s_mov_b32 s17, 2
+        0x7E060210u, // v_mov_b32 v3, s16
+        0xBE8203A8u, // s_mov_b32 s2, 40
+        0x7D840002u, // v_cmp_eq_u32 vcc, s2, v0
+        0xBEFE046Au, // s_mov_b64 exec, vcc
+        0xBE90246Au, // s_and_saveexec_b64 s[16:17], vcc
+    };
+    compute_cfg_dispatch_persisted_ff1_b64.insert(
+        compute_cfg_dispatch_persisted_ff1_b64.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch) - 1);
+    compute_cfg_dispatch_persisted_ff1_b64.insert(
+        compute_cfg_dispatch_persisted_ff1_b64.end(), {
+            0xBEFE0410u, // s_mov_b64 exec, s[16:17]
+            0xBEEA1410u, // s_ff1_i32_b64 vcc_lo, s[16:17] (GTA PC1486)
+            0x7E04026Au, // v_mov_b32 v2, vcc_lo
+            0xBF810000u, // s_endpgm
+        });
+    CHECK(!recompile_compute(compute_cfg_dispatch_persisted_ff1_b64.data(),
+                             compute_cfg_dispatch_persisted_ff1_b64.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "the Wave64 dispatcher preserves a saved mask through GTA's exact S_FF1 reduction");
+    std::vector<uint32_t> compute_cfg_dispatch_persisted_bcnt_b64 = {
+        0xBE860381u, // earlier scalar lifetime: s_mov_b32 s6, 1
+        0xBE870382u, //                          s_mov_b32 s7, 2
+        0x7E060206u, // v_mov_b32 v3, s6
+        0xBE8203A8u, // s_mov_b32 s2, 40
+        0x7D840002u, // v_cmp_eq_u32 vcc, s2, v0
+        0xBEFE046Au, // s_mov_b64 exec, vcc
+        0xBE86246Au, // s_and_saveexec_b64 s[6:7], vcc (GTA PC2005 producer)
+    };
+    compute_cfg_dispatch_persisted_bcnt_b64.insert(
+        compute_cfg_dispatch_persisted_bcnt_b64.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch) - 1);
+    compute_cfg_dispatch_persisted_bcnt_b64.insert(
+        compute_cfg_dispatch_persisted_bcnt_b64.end(), {
+            0xBEFE0406u, // s_mov_b64 exec, s[6:7]
+            0xBEEA1006u, // s_bcnt1_i32_b64 vcc_lo, s[6:7] (GTA PC2007)
+            0x7E04026Au, // v_mov_b32 v2, vcc_lo
+            0xBF810000u, // s_endpgm
+        });
+    CHECK(!recompile_compute(compute_cfg_dispatch_persisted_bcnt_b64.data(),
+                             compute_cfg_dispatch_persisted_bcnt_b64.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "the Wave64 dispatcher preserves a saved mask through GTA's exact S_BCNT reduction");
+    std::vector<uint32_t> compute_cfg_dispatch_ambiguous_ff1_b64 = {
+        0xBF068008u, // s_cmp_eq_u32 s8, 0
+        0xBF840003u, // s_cbranch_scc0 +3 -> mask-producing arm
+        0xBE900381u, // scalar-data arm: s_mov_b32 s16, 1
+        0xBE910380u, //                  s_mov_b32 s17, 0
+        0xBF820001u, // s_branch +1 -> merge
+        0xBE90047Eu, // mask arm: s_mov_b64 s[16:17], exec
+    };
+    compute_cfg_dispatch_ambiguous_ff1_b64.insert(
+        compute_cfg_dispatch_ambiguous_ff1_b64.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch) - 1);
+    compute_cfg_dispatch_ambiguous_ff1_b64.insert(
+        compute_cfg_dispatch_ambiguous_ff1_b64.end(), {
+            0xBE841410u, // merge: s_ff1_i32_b64 s4, s[16:17]
+            0x7E040204u, // v_mov_b32 v2, s4
+            0xBF810000u, // s_endpgm
+        });
+    CHECK(recompile_compute(compute_cfg_dispatch_ambiguous_ff1_b64.data(),
+                            compute_cfg_dispatch_ambiguous_ff1_b64.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a Wave64 mask/scalar join remains ambiguous at the exact S_FF1 consumer");
     // GTA V's exec_cs_413d88400 reaches the exact `beea147e` packet at PC336 after
     // structured divergent loops.  Their EXEC restores are represented separately from the
     // architectural EXEC mask, so loop-carried scalar placeholders for s126/s127 must not make


### PR DESCRIPTION
## Summary

- preserve architectural EXEC and saved Wave64 mask values through structured and dispatcher control flow
- lower Wave64 `S_BCNT1_I32_B64`, `S_FF1_I32_B64`, saved-mask `V_MBCNT`, `V_BFM_B32`, and the zero-record buffer atomic form observed in GTA V
- route structured compute containing real cross-lane MBCNT through the synchronized dispatcher common phase while retaining the scalar all-ones lane-index path
- add exact captured-packet, semantic execution, negative lifetime-join, and same-site mutation regressions

## Root cause

The dispatcher persists Bool-domain wave masks separately from scalar SGPR placeholders. At exact Wave64 reduction and MBCNT consumers, generic operand resolution could either reject a live saved mask as ambiguous or mistake stale scalar state for mask provenance. Separately, GTA V reached missing V_BFM and Wave64 scalar-reduction lowerings. Structured compute also disabled cross-lane emission after its branch regions, leaving a valid top-level MBCNT with no synchronized route.

This change uses per-PC MUST/intersection lifetime proofs for saved masks, resolves MBCNT HIGH only through the preceding pair root, and keeps ambiguous joins fail-visible.

## Validation

- local distrobox build and `ctest --no-tests=error -j4`: **232/232 passed**
- independent code-review agents approved every code change
- exact-site mutations failed the intended regressions for decoder operand count, V_BFM width, MBCNT pair-root lookup, MUST proof recording/intersection, and structured routing
- exact offline Wave64/native64 inspection:
  - `exec_cs_413d22d00.bin`: `status=ok`, 27,500 SPIR-V dwords
  - `exec_cs_413d88400.bin`: `status=ok`, 17,296 SPIR-V dwords
- fresh 200-second routed GTA V Story Mode capture completed without device loss; both programs disappeared from the terminal compute skip set
- gameplay world remains black, and the routed run exposed the next terminal instructions in the two descriptor-heavy MBCNT programs

Refs #2481