### PR TITLE
fix(recompiler): advance GTA V compute workloads

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2214,6 +2214,9 @@ struct VulkanComputeContext {
                 std::fprintf(stderr, "[compute] descriptor indexing %s (inherited from the adopted "
                                      "device)\n",
                              descriptor_indexing_support ? "ENABLED" : "unavailable");
+                std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s "
+                                     "(inherited from the adopted device)\n",
+                             shared.storage_buffer_int64_atomics ? "ENABLED" : "unavailable");
                 return true;
             }
             // Anything failing here must fall through to a private device rather than killing the
@@ -2259,6 +2262,7 @@ struct VulkanComputeContext {
         }
         VkPhysicalDeviceFeatures enabled{};
         enabled.robustBufferAccess = VK_TRUE;
+        enabled.shaderInt64 = supported.shaderInt64;
         // Image bindings (#590): enable the format-free storage-image features when available.
         image_support = supported.shaderStorageImageReadWithoutFormat &&
                         supported.shaderStorageImageWriteWithoutFormat;
@@ -2333,6 +2337,40 @@ struct VulkanComputeContext {
         if (!di_ext_advertised)
             std::fprintf(stderr, "[compute] descriptor indexing unavailable: "
                                  "VK_EXT_descriptor_indexing not advertised by this device\n");
+        // Live raw translation chooses its qword-atomic config from SharedVulkanContext before this
+        // lazy private-device path can run, so private discovery deliberately does not advertise an
+        // admission capability. Still enable the feature here when available: this path can execute
+        // already-compiled/captured modules whose config was established by their replay owner.
+        VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+        bool atomic_int64_ext_advertised = false;
+        bool private_storage_buffer_int64_atomics = false;
+        { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);
+          std::vector<VkExtensionProperties> de(ne);
+          vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, de.data());
+          for (const auto& e : de) {
+              if (std::strcmp(e.extensionName, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
+                  continue;
+              atomic_int64_ext_advertised = true;
+              VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+              f2.pNext = &atomic_int64_features;
+              vkGetPhysicalDeviceFeatures2(physical, &f2);
+              if (supported.shaderInt64 &&
+                  atomic_int64_features.shaderBufferInt64Atomics) {
+                  VkPhysicalDeviceShaderAtomicInt64Features want{
+                      VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+                  want.shaderBufferInt64Atomics = VK_TRUE;
+                  atomic_int64_features = want;
+                  atomic_int64_features.pNext = const_cast<void*>(dci.pNext);
+                  dci.pNext = &atomic_int64_features;
+                  dev_exts.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
+                  private_storage_buffer_int64_atomics = true;
+              }
+              break;
+          } }
+        std::fprintf(stderr, "[compute] storage-buffer int64 atomics %s (own device%s)\n",
+                     private_storage_buffer_int64_atomics ? "ENABLED" : "unavailable",
+                     atomic_int64_ext_advertised ? "" : ", extension not advertised");
 #ifdef __APPLE__
         // Spec-mandated on MoltenVK: enable VK_KHR_portability_subset when advertised (always is).
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(physical, nullptr, &ne, nullptr);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -113,7 +113,9 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // v47 (#2481): retain each realized/failed-stage image resource's instruction-scoped zero-mip proof.
 // v48 (#2481): retain BVH BOX_SORT_EN for raw replay. Sorting changes generated SPIR-V, so replay
 // must not silently compile a sorted guest descriptor with the historical physical-child order.
-constexpr uint32_t kVersion = 48;
+// v49 (#2481): retain the exact linear stride-8 qword-atomic record count. Size/stride alone do not
+// preserve the descriptor's OOB_SELECT proof, which controls the all-or-nothing record range check.
+constexpr uint32_t kVersion = 49;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -255,22 +257,24 @@ void write_compute_config(Writer& w, const ComputeShaderConfig& config) {
                           (config.tgid_y_en ? 2u : 0u) |
                           (config.tgid_z_en ? 4u : 0u) |
                           (config.tg_size_en ? 8u : 0u) |
-                          (config.packed_r11_storage ? 16u : 0u);
+                          (config.packed_r11_storage ? 16u : 0u) |
+                          (config.storage_buffer_int64_atomics ? 32u : 0u);
     w.u8(flags);
     w.u32(config.lds_bytes);
     w.u32(config.native_subgroup_size);
     w.u32(config.native_storage_format_support);
 }
 
-bool read_compute_config(Reader& r, ComputeShaderConfig& config) {
+bool read_compute_config(Reader& r, ComputeShaderConfig& config, uint32_t capture_version) {
     uint8_t exact = 0, flags = 0;
+    const uint8_t valid_flags = capture_version >= 49 ? 0x3fu : 0x1fu;
     if (!r.words_bounded(config.user_sgprs, 32,
                          "invalid compute user-SGPR count") ||
         !r.u32(config.local_x) || !r.u32(config.local_y) ||
         !r.u32(config.local_z) || !r.u8(exact) || exact > 1u ||
         !r.u32(config.threads_x) || !r.u32(config.threads_y) ||
         !r.u32(config.threads_z) || !r.u32(config.wave_size) ||
-        !r.u32(config.tidig_comp_cnt) || !r.u8(flags) || (flags & ~0x1fu) ||
+        !r.u32(config.tidig_comp_cnt) || !r.u8(flags) || (flags & ~valid_flags) ||
         !r.u32(config.lds_bytes) || !r.u32(config.native_subgroup_size) ||
         !r.u32(config.native_storage_format_support))
         return false;
@@ -280,6 +284,7 @@ bool read_compute_config(Reader& r, ComputeShaderConfig& config) {
     config.tgid_z_en = (flags & 4u) != 0;
     config.tg_size_en = (flags & 8u) != 0;
     config.packed_r11_storage = (flags & 16u) != 0;
+    config.storage_buffer_int64_atomics = capture_version >= 49 && (flags & 32u) != 0;
     return true;
 }
 
@@ -2720,6 +2725,20 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     for (const auto& diagnostic : c.failure_diagnostics)
         for (const auto& stage : diagnostic.stages)
             write_bvh_sort_state(stage.resource_table);
+    // v49 retains the exact qword record count in the same complete resource enumeration.
+    w.u32(static_cast<uint32_t>(sample_resource_count));
+    auto write_atomic_x2_state = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources)
+            w.u32(captured.resource.atomic_x2_record_count);
+    };
+    for (const auto& draw : c.draws) {
+        write_atomic_x2_state(draw.vrt);
+        write_atomic_x2_state(draw.prt);
+    }
+    for (const auto& compute : c.computes) write_atomic_x2_state(compute.resources);
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            write_atomic_x2_state(stage.resource_table);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3558,7 +3577,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 }
                 continue;
             }
-            if (!read_compute_config(r, compute.recompile_config)) return false;
+            if (!read_compute_config(r, compute.recompile_config, version)) return false;
             if (!validate_compute_recompile_state(compute, error)) return false;
         }
     }
@@ -3690,7 +3709,7 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 if (!stage.recompile_config_available) continue;
                 if (diagnostic.kind != SubmitOperationKind::Dispatch ||
                     stage.stage != ShaderProgramStage::Compute ||
-                    !read_compute_config(r, stage.recompile_config) ||
+                    !read_compute_config(r, stage.recompile_config, version) ||
                     !validate_compute_config(stage.recompile_config,
                                              diagnostic.compute_launch,
                                              stage.recompile_config.native_subgroup_size,
@@ -3903,6 +3922,46 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             for (auto& stage : diagnostic.stages)
                 if (!read_bvh_sort_state(stage.resource_table)) {
                     error = "invalid BVH sort state";
+                    return false;
+                }
+    }
+    if (version >= 49) {
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        for (const auto& diagnostic : c.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                expected += stage.resource_table.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid atomic-x2 state count";
+            return false;
+        }
+        auto read_atomic_x2_state = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                uint32_t record_count = 0;
+                if (!r.u32(record_count)) return false;
+                captured.resource.atomic_x2_record_count = record_count;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_atomic_x2_state(draw.vrt) ||
+                !read_atomic_x2_state(draw.prt)) {
+                error = "invalid atomic-x2 state";
+                return false;
+            }
+        for (auto& compute : c.computes)
+            if (!read_atomic_x2_state(compute.resources)) {
+                error = "invalid atomic-x2 state";
+                return false;
+            }
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_atomic_x2_state(stage.resource_table)) {
+                    error = "invalid atomic-x2 state";
                     return false;
                 }
     }

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -111,7 +111,9 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // PM4 last-write provenance. Replay decodes this input independently and compares it with the v45
 // normalized descriptor; unsupported/ambiguous paths are recorded as explicitly unavailable.
 // v47 (#2481): retain each realized/failed-stage image resource's instruction-scoped zero-mip proof.
-constexpr uint32_t kVersion = 47;
+// v48 (#2481): retain BVH BOX_SORT_EN for raw replay. Sorting changes generated SPIR-V, so replay
+// must not silently compile a sorted guest descriptor with the historical physical-child order.
+constexpr uint32_t kVersion = 48;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobBytes = 1ull << 30;
@@ -2702,6 +2704,22 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     for (const auto& diagnostic : c.failure_diagnostics)
         for (const auto& stage : diagnostic.stages)
             write_zero_mip_state(stage.resource_table);
+    // v48 preserves the BVH sort semantic separately from the v40 BOX_GROW tail so every older
+    // capture prefix remains byte-exact. Non-BVH resources carry false in the same deterministic
+    // complete-resource enumeration used by v44/v47.
+    w.u32(static_cast<uint32_t>(sample_resource_count));
+    auto write_bvh_sort_state = [&](const GpuCapturedTable& table) {
+        for (const auto& captured : table.resources)
+            w.u8(captured.resource.bvh_sort_enabled ? 1u : 0u);
+    };
+    for (const auto& draw : c.draws) {
+        write_bvh_sort_state(draw.vrt);
+        write_bvh_sort_state(draw.prt);
+    }
+    for (const auto& compute : c.computes) write_bvh_sort_state(compute.resources);
+    for (const auto& diagnostic : c.failure_diagnostics)
+        for (const auto& stage : diagnostic.stages)
+            write_bvh_sort_state(stage.resource_table);
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
@@ -3846,6 +3864,45 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             for (auto& stage : diagnostic.stages)
                 if (!read_zero_mip_state(stage.resource_table)) {
                     error = "invalid resource zero-mip state";
+                    return false;
+                }
+    }
+    if (version >= 48) {
+        size_t expected = 0;
+        for (const auto& draw : c.draws)
+            expected += draw.vrt.resources.size() + draw.prt.resources.size();
+        for (const auto& compute : c.computes)
+            expected += compute.resources.resources.size();
+        for (const auto& diagnostic : c.failure_diagnostics)
+            for (const auto& stage : diagnostic.stages)
+                expected += stage.resource_table.resources.size();
+        uint32_t count = 0;
+        if (!r.u32(count) || count != expected) {
+            error = "invalid BVH sort-state count";
+            return false;
+        }
+        auto read_bvh_sort_state = [&](GpuCapturedTable& table) {
+            for (auto& captured : table.resources) {
+                uint8_t enabled = 0;
+                if (!r.u8(enabled) || enabled > 1u) return false;
+                captured.resource.bvh_sort_enabled = enabled != 0;
+            }
+            return true;
+        };
+        for (auto& draw : c.draws)
+            if (!read_bvh_sort_state(draw.vrt) || !read_bvh_sort_state(draw.prt)) {
+                error = "invalid BVH sort state";
+                return false;
+            }
+        for (auto& compute : c.computes)
+            if (!read_bvh_sort_state(compute.resources)) {
+                error = "invalid BVH sort state";
+                return false;
+            }
+        for (auto& diagnostic : c.failure_diagnostics)
+            for (auto& stage : diagnostic.stages)
+                if (!read_bvh_sort_state(stage.resource_table)) {
+                    error = "invalid BVH sort state";
                     return false;
                 }
     }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -210,12 +210,12 @@ struct SrtUse {
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
-    // Fully-known V# whose NUM_RECORDS is zero. This covers scalar buffer loads, ordinary RAW
-    // loads/stores, the exact format-load shapes admitted by the producer, and the emitter-supported
-    // 32-bit atomic set; unsupported shapes remain fail-closed. It is distinct from the scalar-SMEM
-    // raw-pointer convention, where a zero decoded size means "unbounded" and required_size supplies
-    // the proven access span. Only resolve_dynamic_fetch may set this after decoding all four live
-    // descriptor words at the exact consuming instruction.
+    // Fully-known V# whose NUM_RECORDS is zero. This covers scalar buffer loads proven to begin beyond
+    // their effective scalar bound, ordinary RAW loads/stores, format loads whose selected OOB values
+    // are all zero, and the emitter-supported 32-bit atomic set; unsupported shapes remain fail-closed.
+    // It is distinct from the scalar-SMEM raw-pointer convention, where a zero decoded size means
+    // "unbounded" and required_size supplies the proven access span. Only resolve_dynamic_fetch may set
+    // this after decoding all four live descriptor words at the exact consuming instruction.
     bool zero_record_raw = false;
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -210,12 +210,12 @@ struct SrtUse {
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
     std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
-    // Fully-known raw/untyped MUBUF V# whose NUM_RECORDS is zero. This covers ordinary RAW
-    // loads/stores and the emitter-supported 32-bit atomic set; typed and unsupported atomic shapes
-    // remain fail-closed. It is distinct from the scalar-SMEM raw-pointer convention, where a zero
-    // decoded size means "unbounded" and required_size supplies the proven access span. Only
-    // resolve_dynamic_fetch may set this after decoding all four live descriptor words at the exact
-    // consuming instruction.
+    // Fully-known V# whose NUM_RECORDS is zero. This covers scalar buffer loads, ordinary RAW
+    // loads/stores, the exact format-load shapes admitted by the producer, and the emitter-supported
+    // 32-bit atomic set; unsupported shapes remain fail-closed. It is distinct from the scalar-SMEM
+    // raw-pointer convention, where a zero decoded size means "unbounded" and required_size supplies
+    // the proven access span. Only resolve_dynamic_fetch may set this after decoding all four live
+    // descriptor words at the exact consuming instruction.
     bool zero_record_raw = false;
     bool has_samp = false;
     std::array<uint32_t, 4> s4{};    // paired S# dwords (kind 0, when the SSAMP load also resolved)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -223,6 +223,11 @@ struct SrtUse {
     // scalar descriptors carry usable base bits but do not expose a conventional bounded V# size;
     // the exact observed access span is sufficient for their pc-keyed upload.
     uint32_t required_size = 0;      // kind 1 only
+    // Exact RDNA2 qword-atomic V# contract exercised by GTA V: a dispatch-sized count of eight-byte
+    // records at an eight-byte-aligned base with OOB_SELECT=0. Keep the count/proof explicit because
+    // ShaderResource does not otherwise retain OOB_SELECT, and the emitter must not infer this
+    // all-or-nothing record-index contract from byte size alone.
+    uint32_t atomic_x2_record_count = 0;
     // PER-USE pc provenance (#273 — DOLL's title-composite image_sample_b): the pc of the consuming
     // image op. The load-immediate key model breaks when the same immediate appears against two
     // different table pointers (a key-0 EUD sharp colliding with a key-0 table T#) or when the load
@@ -761,6 +766,9 @@ struct SharedVulkanContext {
     // creation is the renderer's decision -- a physically capable device whose owner declined them cannot
     // execute an indexed descriptor array, and asking the driver would answer the wrong question.
     bool descriptor_indexing = false;
+    // VK_KHR_shader_atomic_int64's storage-buffer feature, ENABLED on the borrowed device together
+    // with core shaderInt64. Physical support alone is insufficient for module admission.
+    bool storage_buffer_int64_atomics = false;
     uint32_t max_compute_workgroup_subgroups = 0;
     uint32_t max_compute_workgroup_size_x = 0;
     uint32_t max_compute_workgroup_invocations = 0;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2012,6 +2012,36 @@ bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc
 // value that would depend on a VGPR/lane is left unknown (the op's dest becomes unknown), so we never
 // fabricate a per-lane-dependent descriptor. CONFIDENCE: MED (covers this game's fetch-shader shape).
 // External linkage (DynFetch + declaration in gpu_execute.hpp) so the fold is unit-testable.
+static bool zero_record_sbuffer_access_is_oob(const Rdna2Inst& in,
+                                              const DecodedBufferDescriptor& descriptor) {
+    if (in.fmt != Rdna2Format::SMEM || in.opcode < 0x8u || in.opcode > 0xCu ||
+        descriptor.num_records != 0u || descriptor.size_bytes != 0u ||
+        static_cast<int32_t>(in.literal) < 0)
+        return false;
+
+    // Scalar-buffer bounds differ from vector-buffer bounds when STRIDE=0: hardware substitutes a
+    // one-dword M_SIZE instead of using NUM_RECORDS directly. SOFFSET is unsigned, so the immediate
+    // names the minimum possible dword. Only specialize when even that minimum begins out of range.
+    const uint32_t scalar_dwords = descriptor.stride == 0u ? 1u : descriptor.num_records;
+    const uint32_t minimum_dword = in.literal >> 2;
+    return minimum_dword >= scalar_dwords;
+}
+
+static bool zero_record_format_selectors_are_zero(const Rdna2Inst& in,
+                                                   const uint32_t descriptor_words[4]) {
+    if (in.fmt != Rdna2Format::MUBUF || in.opcode > 0x3u)
+        return false;
+    const uint32_t components = in.opcode + 1u;
+    for (uint32_t component = 0; component < components; ++component) {
+        const uint32_t selector = (descriptor_words[3] >> (component * 3u)) & 0x7u;
+        // SQ_SEL_0 and X/Y/Z/W all yield zero for an OOB record. SQ_SEL_1 yields one; 2/3 are
+        // reserved and stay fail-closed rather than acquiring an invented constant value.
+        if (selector != 0u && selector < 4u)
+            return false;
+    }
+    return true;
+}
+
 std::vector<DynFetch>
 resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_sgprs, uint32_t nsgpr,
                       uint32_t user_sgpr_base, std::vector<SrtUse>* srt_uses,
@@ -3234,12 +3264,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 if (n != 0 && live_sbase_vsharp_known) {
                     const DecodedBufferDescriptor d =
                         decode_buffer_descriptor(live_sbase_vsharp.data());
-                    if (d.num_records == 0u && d.size_bytes == 0u) {
-                        // A zero-record V# makes every S_BUFFER_LOAD address OOB, including one whose
-                        // SOFFSET comes from a wave value the CPU fold cannot know. Publish the outer
-                        // descriptor at this exact pc so the SPIR-V emitter can remove the memory
-                        // access, and make the result itself exact zero so a descriptor loaded through
-                        // it remains provably empty at a later MUBUF consumer.
+                    if (zero_record_sbuffer_access_is_oob(in, d)) {
+                        // This exact scalar access begins beyond the descriptor's effective M_SIZE,
+                        // including at the minimum value of a wave-derived SOFFSET. Publish the outer
+                        // descriptor at this pc so the SPIR-V emitter can remove the memory access,
+                        // and make the result exact zero so a descriptor loaded through it remains
+                        // provably empty at a later MUBUF consumer.
                         if (srt_uses && have_pending_srt_use) {
                             pending_srt_use.zero_record_raw = true;
                             pending_srt_use.required_size = 0;
@@ -3831,8 +3861,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // as one all-or-nothing access. Preserve that proof at this exact consumer pc.
                         // MTBUF, format stores, unsupported atomics, and an addr0 descriptor with
                         // nonzero records remain outside the marker contract.
+                        const bool zero_record_format =
+                            format_load_use && zero_record_format_selectors_are_zero(in, u.v4.data());
                         const bool zero_record_raw =
-                            (format_load_use || raw_buffer_use || atomic_buffer_use) &&
+                            (zero_record_format || raw_buffer_use || atomic_buffer_use) &&
                             d.num_records == 0u && d.size_bytes == 0u;
                         if (zero_record_raw || (!format_load_use &&
                             (d.base > 0x10000 && d.size_bytes != 0 &&
@@ -4305,6 +4337,16 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             if (u.instruction_format != UINT32_MAX || d.num_records != 0u ||
                 d.size_bytes != 0u || u.required_size != 0u)
                 continue;
+            if (u.use_pc >= dwords)
+                continue;
+            const Rdna2Inst marker_consumer =
+                rdna2_decode_one(code + u.use_pc, dwords - u.use_pc);
+            if (marker_consumer.fmt == Rdna2Format::SMEM &&
+                !zero_record_sbuffer_access_is_oob(marker_consumer, d))
+                continue;
+            if (marker_consumer.fmt == Rdna2Format::MUBUF && marker_consumer.opcode <= 0x3u &&
+                !zero_record_format_selectors_are_zero(marker_consumer, u.v4.data()))
+                continue;
             ShaderResource r;
             r.cls = ResourceClass::ConstantBuffer;
             r.format = DataFormat::Unknown;
@@ -4315,6 +4357,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             r.srt_offset = 0xFFFFFFFFu;
             r.sgpr_base = 0xFFFFFFFFu;
             r.fetch_pc = u.use_pc;
+            for (uint32_t component = 0; component < 4u; ++component)
+                r.swizzle[component] = (u.v4[3] >> (component * 3u)) & 0x7u;
             table.resources.push_back(r);
             continue;
         }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3511,8 +3511,17 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         bool live_known = valid_reg(bbase) && valid_reg(bbase + 3);
                         for (int k = 0; live_known && k < 4; ++k)
                             live_known &= known(bbase + k, live_bvh[(size_t)k]);
+                        const DecodedBvhDescriptor d = live_known
+                            ? decode_bvh_descriptor(live_bvh.data()) : DecodedBvhDescriptor{};
+                        // GTA V's sorted builder rewrites an aligned four-word window from its x16
+                        // header load. A historical snapshot proves only the bytes it actually loaded;
+                        // if the sorted live words differ, require the exact builder chain below. Keep
+                        // the established snapshot semantics for unsorted descriptors, whose supported
+                        // builders predate the narrow BOX_SORT_EN provenance proof.
                         const bool snapshot_provenance = valid_reg(bbase) &&
-                            descr_known.test((size_t)bbase);
+                            descr_known.test((size_t)bbase) &&
+                            (!d.sort_enabled ||
+                             (live_known && live_bvh == descr[(size_t)bbase]));
                         const bool seed_provenance = !snapshot_provenance &&
                             (untouched_seed_range(bbase, 4) ||
                              consecutive_seed_copy_range(bbase, 4));
@@ -3528,8 +3537,6 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                 bvh_build_origin[(size_t)(bbase + k)] == builder_origin &&
                                 bvh_build_role[(size_t)(bbase + k)] ==
                                     expected_builder_roles[k];
-                        const DecodedBvhDescriptor d = live_known
-                            ? decode_bvh_descriptor(live_bvh.data()) : DecodedBvhDescriptor{};
                         const bool plausible = live_known &&
                             (snapshot_provenance || seed_provenance || builder_provenance) &&
                             d.type == 8u && d.base > 0x10000u && d.size_bytes != 0;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -288,6 +288,7 @@ struct ShaderResourceCompileKey {
     uint32_t binding = 0;
     uint32_t stride = 0;
     uint32_t one_record_tail_semantic = 0;
+    uint32_t atomic_x2_record_count = 0;
     uint32_t srt_offset = 0;
     uint32_t sgpr_base = 0;
     uint32_t fetch_pc = 0;
@@ -336,6 +337,7 @@ struct ShaderCompileKey {
     uint32_t compute_lds_bytes = 0;
     uint32_t compute_native_subgroup_size = 0;
     uint32_t compute_native_storage_format_support = 0;
+    bool compute_storage_buffer_int64_atomics = false;
     bool compute_packed_r11_storage = true;
     uint32_t vertex_lds_dwords = 0;
     uint32_t vertices_per_instance = 0;
@@ -386,6 +388,8 @@ struct ShaderCompileKey {
                compute_native_subgroup_size == other.compute_native_subgroup_size &&
                compute_native_storage_format_support ==
                    other.compute_native_storage_format_support &&
+               compute_storage_buffer_int64_atomics ==
+                   other.compute_storage_buffer_int64_atomics &&
                compute_packed_r11_storage == other.compute_packed_r11_storage &&
                vertex_lds_dwords == other.vertex_lds_dwords &&
                vertices_per_instance == other.vertices_per_instance &&
@@ -449,6 +453,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, key.compute_lds_bytes);
             hash = hash_mix(hash, key.compute_native_subgroup_size);
             hash = hash_mix(hash, key.compute_native_storage_format_support);
+            hash = hash_mix(hash, key.compute_storage_buffer_int64_atomics);
             hash = hash_mix(hash, key.compute_packed_r11_storage);
         }
         hash = hash_mix(hash, key.vertex_lds_dwords);
@@ -474,6 +479,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.binding);
             hash = hash_mix(hash, resource.stride);
             hash = hash_mix(hash, resource.one_record_tail_semantic);
+            hash = hash_mix(hash, resource.atomic_x2_record_count);
             hash = hash_mix(hash, resource.srt_offset);
             hash = hash_mix(hash, resource.sgpr_base);
             hash = hash_mix(hash, resource.fetch_pc);
@@ -1112,6 +1118,8 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
         key.compute_native_subgroup_size = compute_config->native_subgroup_size;
         key.compute_native_storage_format_support =
             compute_config->native_storage_format_support;
+        key.compute_storage_buffer_int64_atomics =
+            compute_config->storage_buffer_int64_atomics;
         key.compute_packed_r11_storage = compute_config->packed_r11_storage;
     }
     const std::shared_ptr<const ShaderCodeAnalysis> analysis =
@@ -1201,6 +1209,18 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
                     : one_record_tail && resource.format == DataFormat::Float16
                         ? StorageBufferTailSemantic::Float16
                         : StorageBufferTailSemantic::None);
+            // A warm cache hit bypasses emitter-side resource revalidation. Partition on the
+            // complete resource-side admission result, not the serialized marker alone, so an
+            // opaque/corrupt marker cannot borrow a valid module across size, alignment, or array
+            // shape changes. Address identity remains intentionally absent; only alignment matters.
+            const bool atomic_x2_exact_admission =
+                resource.atomic_x2_record_count != 0u &&
+                resource.atomic_x2_record_count <= 0x02000000u &&
+                static_cast<uint64_t>(resource.atomic_x2_record_count) * 8u == resource.size &&
+                resource.stride == 8u &&
+                (resource.gpu_addr & 7u) == 0u && resource.table_index_count == 0u;
+            compiled.atomic_x2_record_count =
+                atomic_x2_exact_admission ? resource.atomic_x2_record_count : 0u;
             compiled.srt_offset = resource.srt_offset;
             compiled.sgpr_base = resource.sgpr_base;
             compiled.fetch_pc = resource.fetch_pc;
@@ -2065,6 +2085,36 @@ static bool zero_record_format_selectors_are_zero(const Rdna2Inst& in,
             return false;
     }
     return true;
+}
+
+// GTA V rebuilds the same linear qword-atomic V# shape with dispatch-sized record counts (the routed
+// scene exercises 25, 2, 3, and 1). RDNA2 range-checks INDEX against NUM_RECORDS and OFFSET against
+// STRIDE, so the exact concrete count can be compiled as the all-or-nothing qword bound. Keep every
+// other packet/descriptor control deliberately narrow; SLC/TFE/reserved dword1 variants have
+// different or invalid contracts and the decoder does not otherwise retain those bits.
+static uint32_t exact_atomic_x2_record_count(
+        const Rdna2Inst& in, const DecodedBufferDescriptor& descriptor,
+        const uint32_t descriptor_words[4]) {
+    const uint32_t offset = in.literal & 0xfffu;
+    const bool offen = ((in.literal >> 12u) & 1u) != 0;
+    const bool idxen = ((in.literal >> 13u) & 1u) != 0;
+    const bool zero_soffset =
+        (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
+        (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
+    const bool supported_opcode = in.opcode == 0x50u || in.opcode == 0x5au;
+    const bool exact = in.fmt == Rdna2Format::MUBUF && supported_opcode &&
+           idxen && !offen && offset == 0u && zero_soffset &&
+           !in.mubuf_dlc && !in.mubuf_lds && (in.words[0] & 0x00020000u) == 0u &&
+           (in.words[1] & 0x00e00000u) == 0u &&
+           in.src[0].kind == OperandKind::VGPR && descriptor.base > 0x10000u &&
+           (descriptor.base & 7u) == 0u && descriptor.stride == 8u &&
+           descriptor.num_records != 0u && descriptor.num_records <= 0x02000000u &&
+           descriptor.size_bytes == static_cast<uint64_t>(descriptor.num_records) * 8u &&
+           (descriptor_words[1] & 0xc0000000u) == 0u && // no swizzled addressing
+           // Exact observed upper controls: no INDEX_STRIDE/ADD_TID/RESOURCE_LEVEL/reserved bits,
+           // OOB_SELECT=0, and buffer TYPE=0. The normalized ShaderResource retains none of these.
+           (descriptor_words[3] & 0xfff80000u) == 0u;
+    return exact ? descriptor.num_records : 0u;
 }
 
 std::vector<DynFetch>
@@ -3846,15 +3896,19 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     ((in.opcode >= 0x08 && in.opcode <= 0x0F) ||
                      (in.opcode >= 0x1C && in.opcode <= 0x1F));
                 const bool format_store_use = in.opcode >= 0x04 && in.opcode <= 0x07;
-                // Keep this exact set aligned with the 32-bit RMW opcodes the SPIR-V emitter lowers.
-                // The holes are not aliases: cmp-swap/csub/inc/dec and the x2 family need different
-                // operand/result semantics and must remain fail-closed until those are implemented.
-                const bool atomic_buffer_use =
+                // Keep the generic set aligned with the 32-bit RMW opcodes the SPIR-V emitter lowers.
+                // Opcodes 0x50/0x5a reach descriptor inspection separately: only GTA V's exact
+                // linear stride-8 qword proof below is published; every sibling x2 shape stays
+                // fail-closed rather than inheriting ordinary 32-bit bounds.
+                const bool atomic_buffer_use_32 =
                     !is_mtbuf &&
                     (in.opcode == 0x30 || in.opcode == 0x32 || in.opcode == 0x33 ||
                      (in.opcode >= 0x35 && in.opcode <= 0x3B));
+                const bool atomic_x2_candidate =
+                    !is_mtbuf && (in.opcode == 0x50u || in.opcode == 0x5au);
                 if (srt_uses &&
-                    (format_load_use || format_store_use || raw_buffer_use || atomic_buffer_use)) {
+                    (format_load_use || format_store_use || raw_buffer_use ||
+                     atomic_buffer_use_32 || atomic_x2_candidate)) {
                     const int srsrc = in.src[1].value;
                     std::array<uint32_t, 4> current{};
                     bool current_known = true;
@@ -3921,6 +3975,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             if (have_common_key) u.key = common_key;
                         }
                         DecodedBufferDescriptor d = decode_buffer_descriptor(u.v4.data());
+                        const uint32_t atomic_x2_record_count = atomic_x2_candidate
+                            ? exact_atomic_x2_record_count(in, d, u.v4.data()) : 0u;
+                        if (atomic_x2_record_count)
+                            u.atomic_x2_record_count = atomic_x2_record_count;
                         DataFormat inst_format = DataFormat::Unknown;
                         uint32_t inst_components = 0;
                         if (is_mtbuf)
@@ -3946,11 +4004,12 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         const bool zero_record_format =
                             format_load_use && zero_record_format_selectors_are_zero(in, u.v4.data());
                         const bool zero_record_raw =
-                            (zero_record_format || raw_buffer_use || atomic_buffer_use) &&
+                            (zero_record_format || raw_buffer_use || atomic_buffer_use_32) &&
                             d.num_records == 0u && d.size_bytes == 0u;
                         if (zero_record_raw || (!format_load_use &&
                             (d.base > 0x10000 && d.size_bytes != 0 &&
-                             d.size_bytes <= 0x10000000u && stride_supported && format_supported))) {
+                             d.size_bytes <= 0x10000000u && stride_supported && format_supported &&
+                             (!atomic_x2_candidate || atomic_x2_record_count != 0u)))) {
                             u.zero_record_raw = zero_record_raw;
                             if (trc) fprintf(stderr,
                                              "[dyntrace] MUBUF pc=%u live V# s%d base=0x%llx "
@@ -4463,7 +4522,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         } else if (scalar_size < u.required_size) {
             scalar_size = u.required_size;
         }
-        if (clash && !exact_mtbuf) {
+        if (clash && !exact_mtbuf && !u.atomic_x2_record_count) {
             bool piggybacked = false;
             for (auto& r0 : table.resources) {
                 if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
@@ -4494,6 +4553,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         r.gpu_addr = d.base;
         r.size = scalar_size;
         r.stride = scalar_stride;
+        r.atomic_x2_record_count = u.atomic_x2_record_count;
         r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
         r.fetch_pc = u.use_pc;
         table.resources.push_back(r);
@@ -6043,6 +6103,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
             shared_vulkan.storage_image_write_without_format;
         config.native_storage_format_support = shared_compute_adoptable
             ? shared_vulkan.native_storage_format_support : 0;
+        config.storage_buffer_int64_atomics = shared_compute_adoptable &&
+            shared_vulkan.storage_buffer_int64_atomics;
         const uint32_t replay_native_storage_format_support =
             config.native_storage_format_support;
         config.packed_r11_storage =

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -3119,6 +3119,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // below (SBASE and SDST ranges may overlap).
                 SrtUse pending_srt_use;
                 bool have_pending_srt_use = false;
+                bool live_sbase_vsharp_known = false;
                 if (srt_uses && is_buffer) {
                     bool current_known = true, current_key_known = true;
                     uint32_t current_key = 0;
@@ -3153,6 +3154,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         pending_srt_use.use_pc = in.pc;
                         have_pending_srt_use = true;
                     }
+                }
+                // The zero-record decision below must be based on the four words live at this
+                // instruction, never only on an older descriptor snapshot. Callers that do not
+                // request SRT uses still need the known-zero result to propagate to later consumers.
+                std::array<uint32_t, 4> live_sbase_vsharp{};
+                if (is_buffer) {
+                    live_sbase_vsharp_known = true;
+                    for (int k = 0; k < 4; ++k)
+                        live_sbase_vsharp_known &= known(sbase + k, live_sbase_vsharp[(size_t)k]);
                 }
                 // RAW-POINTER scalar load (#2412). `s_load_dword`/`x2` (op < 8) take SBASE as a plain
                 // 64-bit pointer rather than a V#, and no use was recorded for them at all — the
@@ -3221,6 +3231,31 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                  "soff_field=%u soff_val=0x%x soff_ok=%d imm=0x%x n=%u\n", in.opcode,
                                  is_buffer ? "bufload" : "load", sdst, sbase, (unsigned long long)base, base_ok,
                                  soff_field, soff_val, soff_ok, in.literal, n);
+                if (n != 0 && live_sbase_vsharp_known) {
+                    const DecodedBufferDescriptor d =
+                        decode_buffer_descriptor(live_sbase_vsharp.data());
+                    if (d.num_records == 0u && d.size_bytes == 0u) {
+                        // A zero-record V# makes every S_BUFFER_LOAD address OOB, including one whose
+                        // SOFFSET comes from a wave value the CPU fold cannot know. Publish the outer
+                        // descriptor at this exact pc so the SPIR-V emitter can remove the memory
+                        // access, and make the result itself exact zero so a descriptor loaded through
+                        // it remains provably empty at a later MUBUF consumer.
+                        if (srt_uses && have_pending_srt_use) {
+                            pending_srt_use.zero_record_raw = true;
+                            pending_srt_use.required_size = 0;
+                            srt_uses->push_back(pending_srt_use);
+                        }
+                        for (uint32_t k = 0; k < n; ++k)
+                            set_value(sdst + static_cast<int>(k), 0u);
+                        if (n == 4 && valid_reg(sdst) && valid_reg(sdst + 3)) {
+                            descr[(size_t)sdst] = {0u, 0u, 0u, 0u};
+                            descr_known.set((size_t)sdst);
+                            descr_key[(size_t)sdst] = 0xFFFFFFFFu;
+                            descr_key_known.set((size_t)sdst);
+                        }
+                        break;
+                    }
+                }
                 if (n == 0 || !base_ok || !soff_ok) {
                     // A wave-derived scalar SOFFSET (for example v_readfirstlane -> VCC_LO) is
                     // deliberately not concrete in this CPU-side fold. The V# can still be exact,
@@ -3690,8 +3725,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             case Rdna2Format::MTBUF: {
                 const bool is_mtbuf = in.fmt == Rdna2Format::MTBUF;
                 // Buffer stores, raw loads/stores, and supported atomics need a kind-1 resource use.
-                // Format loads are intentionally handled only by DynFetch below: it snapshots the V#
-                // live at the instruction and resolves by exact pc, avoiding a duplicate stale SRT use.
+                // Nonempty format loads are intentionally handled only by DynFetch below: it snapshots
+                // the V# live at the instruction and resolves by exact pc, avoiding a duplicate stale
+                // SRT use. An empty format load is the exception because it has no materializable
+                // DynFetch resource, yet its exact zero result needs the same no-backing marker.
+                const bool format_load_use = !is_mtbuf && in.opcode <= 0x03;
                 const bool raw_buffer_use = !is_mtbuf &&
                     ((in.opcode >= 0x08 && in.opcode <= 0x0F) ||
                      (in.opcode >= 0x1C && in.opcode <= 0x1F));
@@ -3703,7 +3741,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     !is_mtbuf &&
                     (in.opcode == 0x30 || in.opcode == 0x32 || in.opcode == 0x33 ||
                      (in.opcode >= 0x35 && in.opcode <= 0x3B));
-                if (srt_uses && (format_store_use || raw_buffer_use || atomic_buffer_use)) {
+                if (srt_uses &&
+                    (format_load_use || format_store_use || raw_buffer_use || atomic_buffer_use)) {
                     const int srsrc = in.src[1].value;
                     std::array<uint32_t, 4> current{};
                     bool current_known = true;
@@ -3787,18 +3826,17 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         // Byte-addressed raw/atomic V#s validly use stride zero: NUM_RECORDS is bytes.
                         // Typed format stores retain the strided record requirement.
                         const bool stride_supported = !format_store_use || d.stride != 0;
-                        // A fully-known raw/untyped MUBUF with NUM_RECORDS=0 is not a missing
-                        // descriptor: hardware returns zero for loads, drops stores, and range-checks
-                        // an atomic as one all-or-nothing access. Preserve that proof at this exact
-                        // consumer pc for ordinary raw operations and the exact 32-bit atomic set
-                        // admitted above. MTBUF, format stores, unsupported atomics, and an addr0
-                        // descriptor with nonzero records remain outside the marker contract.
-                        const bool zero_record_raw = (raw_buffer_use || atomic_buffer_use) &&
-                                                     d.num_records == 0u &&
-                                                     d.size_bytes == 0u;
-                        if (zero_record_raw ||
+                        // A fully-known admitted V# with NUM_RECORDS=0 is not a missing descriptor:
+                        // hardware returns zero for loads, drops stores, and range-checks an atomic
+                        // as one all-or-nothing access. Preserve that proof at this exact consumer pc.
+                        // MTBUF, format stores, unsupported atomics, and an addr0 descriptor with
+                        // nonzero records remain outside the marker contract.
+                        const bool zero_record_raw =
+                            (format_load_use || raw_buffer_use || atomic_buffer_use) &&
+                            d.num_records == 0u && d.size_bytes == 0u;
+                        if (zero_record_raw || (!format_load_use &&
                             (d.base > 0x10000 && d.size_bytes != 0 &&
-                             d.size_bytes <= 0x10000000u && stride_supported && format_supported)) {
+                             d.size_bytes <= 0x10000000u && stride_supported && format_supported))) {
                             u.zero_record_raw = zero_record_raw;
                             if (trc) fprintf(stderr,
                                              "[dyntrace] MUBUF pc=%u live V# s%d base=0x%llx "

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -294,6 +294,7 @@ struct ShaderResourceCompileKey {
     uint32_t fetch_index_mode = 0;
     uint32_t flat_base_sgpr = 0;
     uint32_t bvh_box_grow = 0;
+    bool bvh_sort_enabled = false;
     bool null_bvh = false;
     bool zero_record_raw = false;
     bool srgb = false;
@@ -479,6 +480,7 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.fetch_index_mode);
             hash = hash_mix(hash, resource.flat_base_sgpr);
             hash = hash_mix(hash, resource.bvh_box_grow);
+            hash = hash_mix(hash, resource.bvh_sort_enabled);
             hash = hash_mix(hash, resource.null_bvh);
             hash = hash_mix(hash, resource.zero_record_raw);
             hash = hash_mix(hash, resource.srgb);
@@ -1205,6 +1207,7 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
             compiled.fetch_index_mode = static_cast<uint32_t>(resource.fetch_index_mode);
             compiled.flat_base_sgpr = resource.flat_base_sgpr;
             compiled.bvh_box_grow = resource.bvh_box_grow;
+            compiled.bvh_sort_enabled = resource.bvh_sort_enabled;
             compiled.null_bvh = is_proven_null_bvh(resource);
             // gpu_addr/size intentionally stay out of the module key, but this semantic is compiled
             // into zero-producing/no-op instructions. Partition exactly this proven marker so a
@@ -2106,6 +2109,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::array<uint32_t, kFoldSgprs> null_chain_origin{};
     std::bitset<kFoldSgprs> null_chain_known;
     uint32_t next_null_chain_origin = 0;
+    // Exact provenance for GTA V's RTIP 1.1 descriptor builder. A successful mapped x16 header
+    // load seeds candidate qword origins; only the observed mask/lshl/load-count/bfe/carry/header
+    // chain can turn one into a complete descriptor. This is deliberately separate from concrete
+    // value knowledge: four literal-built words that merely decode as TYPE=8 remain unresolved.
+    enum class BvhBuildRole : uint8_t {
+        None,
+        HeaderLo, HeaderHi,
+        PointerLo, PointerHi,
+        CountLo, CountHi, CountPlusOne,
+        SizeLo, SizeHi, SizeHiMasked, DescriptorHi,
+        BaseLo, BaseHi, SortedBaseHi,
+    };
+    std::array<uint32_t, kFoldSgprs> bvh_build_origin{};
+    std::array<BvhBuildRole, kFoldSgprs> bvh_build_role{};
+    uint32_t next_bvh_build_origin = 0;
+    uint32_t bvh_count_carry_origin = 0;
     // SGPRs overwritten by an s_load since seeding — the seed-V# MUBUF fallback below must not use a
     // stale user-data snapshot once the register was RELOADED from memory (ALU patches deliberately
     // don't count: descriptor snapshots are load-time semantics, pre-patch, like `descr`).
@@ -2167,6 +2186,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
             null_chain_known.reset((size_t)r);
+            bvh_build_origin[(size_t)r] = 0;
+            bvh_build_role[(size_t)r] = BvhBuildRole::None;
             mask_state[(size_t)r] = FoldMask::Unknown;
         }
     };
@@ -2179,6 +2200,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
             null_chain_known.reset((size_t)r);
+            bvh_build_origin[(size_t)r] = 0;
+            bvh_build_role[(size_t)r] = BvhBuildRole::None;
             mask_state[(size_t)r] = FoldMask::Unknown;
             // Remember WHICH instruction made this register unknown (#2412). `[mubuf-unknown]` names
             // the V# word that is not provable; it could not name the instruction responsible, so the
@@ -2322,6 +2345,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         std::bitset<kFoldSgprs> descr8_key_known;
         std::array<uint32_t, kFoldSgprs> null_chain_origin;
         std::bitset<kFoldSgprs> null_chain_known;
+        std::array<uint32_t, kFoldSgprs> bvh_build_origin;
+        std::array<BvhBuildRole, kFoldSgprs> bvh_build_role;
+        uint32_t bvh_count_carry_origin;
         std::bitset<kFoldSgprs> reloaded;
         std::array<FoldMask, kFoldSgprs> mask_state;
         std::array<VertexFetchIndexMode, kFoldVgprs> vector_index_mode;
@@ -2359,6 +2385,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         s.descr8 = descr8; s.descr8_known = descr8_known;
         s.descr8_key = descr8_key; s.descr8_key_known = descr8_key_known;
         s.null_chain_origin = null_chain_origin; s.null_chain_known = null_chain_known;
+        s.bvh_build_origin = bvh_build_origin; s.bvh_build_role = bvh_build_role;
+        s.bvh_count_carry_origin = bvh_count_carry_origin;
         s.reloaded = reloaded; s.mask_state = mask_state;
         s.vector_index_mode = vector_index_mode; s.scc = scc;
         return s;
@@ -2373,6 +2401,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         descr8 = s.descr8; descr8_known = s.descr8_known;
         descr8_key = s.descr8_key; descr8_key_known = s.descr8_key_known;
         null_chain_origin = s.null_chain_origin; null_chain_known = s.null_chain_known;
+        bvh_build_origin = s.bvh_build_origin; bvh_build_role = s.bvh_build_role;
+        bvh_count_carry_origin = s.bvh_count_carry_origin;
         reloaded = s.reloaded; mask_state = s.mask_state;
         vector_index_mode = s.vector_index_mode; scc = s.scc;
     };
@@ -2415,6 +2445,19 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         if (!origin || !valid_reg(r)) return;
         null_chain_origin[(size_t)r] = origin;
         null_chain_known.set((size_t)r);
+    };
+    auto mark_bvh_build = [&](int r, uint32_t origin, BvhBuildRole role) {
+        if (!origin || role == BvhBuildRole::None || !valid_reg(r)) return;
+        bvh_build_origin[(size_t)r] = origin;
+        bvh_build_role[(size_t)r] = role;
+    };
+    auto operand_bvh_build = [&](const Operand& operand, BvhBuildRole role,
+                                 uint32_t& origin) {
+        if ((operand.kind != OperandKind::SGPR && operand.kind != OperandKind::Special) ||
+            !valid_reg(operand.value) || bvh_build_role[(size_t)operand.value] != role)
+            return false;
+        origin = bvh_build_origin[(size_t)operand.value];
+        return origin != 0;
     };
     auto operand_null_origin = [&](const Operand& operand) -> uint32_t {
         if ((operand.kind == OperandKind::SGPR || operand.kind == OperandKind::Special) &&
@@ -2659,6 +2702,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     // provenance while applying that constant field patch.
                     uint32_t old_value = 0, bit_index = 0;
                     const uint32_t old_null_origin = null_origin(in.dst.value);
+                    const uint32_t old_bvh_origin = valid_reg(in.dst.value)
+                        ? bvh_build_origin[(size_t)in.dst.value] : 0u;
+                    const BvhBuildRole old_bvh_role = valid_reg(in.dst.value)
+                        ? bvh_build_role[(size_t)in.dst.value] : BvhBuildRole::None;
                     const bool old_known = known(in.dst.value, old_value);
                     const bool bit_known = in.src[0].kind == OperandKind::Literal
                         ? (bit_index = in.literal, true) : srcval(in.src[0], bit_index);
@@ -2670,6 +2717,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         forget(in.dst.value);
                     }
                     mark_null_origin(in.dst.value, old_null_origin);
+                    if (in.opcode == 0x1d && bit_known && bit_index == 31u &&
+                        old_bvh_role == BvhBuildRole::BaseHi)
+                        mark_bvh_build(in.dst.value, old_bvh_origin,
+                                       BvhBuildRole::SortedBaseHi);
                 } else if (in.opcode == 0x04 &&                 // s_mov_b64
                            in.dst.kind == OperandKind::SGPR &&
                            in.src[0].kind == OperandKind::SGPR) {
@@ -2769,7 +2820,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // Several SOP1 ops write SCC (s_abs_i32, s_not_b32, s_and_saveexec_*, …). Only the moves
                 // (s_mov_b32 0x03 / s_mov_b64 0x04) are known not to — anything else invalidates the
                 // tracked SCC, or a later s_cselect folds with a stale compare result.
-                if (in.opcode != 0x03 && in.opcode != 0x04) scc = -1;
+                if (in.opcode != 0x03 && in.opcode != 0x04) {
+                    scc = -1;
+                    bvh_count_carry_origin = 0;
+                }
                 break;
             case Rdna2Format::SOP2: {
                 // s_cselect_b64 is commonly used to make an all-lanes/zero mask for the following
@@ -2796,6 +2850,26 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 int next_scc = scc;
                 const uint32_t null0 = operand_null_origin(in.src[0]);
                 const uint32_t null1 = operand_null_origin(in.src[1]);
+                auto source_bvh_state = [&](const Operand& operand, int add,
+                                            uint32_t& origin, BvhBuildRole& role) {
+                    const int reg = operand.value + add;
+                    if ((operand.kind != OperandKind::SGPR &&
+                         operand.kind != OperandKind::Special) || !valid_reg(reg)) {
+                        origin = 0;
+                        role = BvhBuildRole::None;
+                        return;
+                    }
+                    origin = bvh_build_origin[(size_t)reg];
+                    role = bvh_build_role[(size_t)reg];
+                };
+                uint32_t bvh0_origin = 0, bvh1_origin = 0, bvh0_hi_origin = 0;
+                BvhBuildRole bvh0_role = BvhBuildRole::None;
+                BvhBuildRole bvh1_role = BvhBuildRole::None;
+                BvhBuildRole bvh0_hi_role = BvhBuildRole::None;
+                source_bvh_state(in.src[0], 0, bvh0_origin, bvh0_role);
+                source_bvh_state(in.src[1], 0, bvh1_origin, bvh1_role);
+                source_bvh_state(in.src[0], 1, bvh0_hi_origin, bvh0_hi_role);
+                const uint32_t previous_bvh_count_carry_origin = bvh_count_carry_origin;
                 // s_addc_u32 remains derived from the same pointer chain even when its concrete
                 // carry is unknown; the taint is provenance, not a claim about the folded value.
                 const bool null_chain_opcode =
@@ -2926,7 +3000,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     fprintf(stderr, "[dyntrace]   SOP2 pc=%u op=0x%x dst=s%d src0=%d(k%d) src1=%d(k%d) ok=%d r=0x%x\n",
                             in.pc, in.opcode, d, in.src[0].value, ka, in.src[1].value, kc, ok, r);
                 scc = ok ? next_scc : -1;
-                if (ok) { set_value(d, r); if (wrote_pair) set_value(d + 1, hi64); }
+                if (ok) {
+                    set_value(d, r);
+                    if (wrote_pair) set_value(d + 1, hi64);
+                }
                 // A 64-bit-dst op invalidates BOTH dwords even when its source was unknown (the
                 // opcode switch may not have reached the point that marks wrote_pair).
                 else    { forget(d); if (wrote_pair || in.opcode == 0x1F || in.opcode == 0x21 ||
@@ -2934,9 +3011,65 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 mark_null_origin(d, propagated_null_origin);
                 if (wrote_pair || in.opcode == 0x1F || in.opcode == 0x21 || in.opcode == 0x29)
                     mark_null_origin(d + 1, propagated_null_origin);
+                // Every SOP2 writes SCC, so a count carry survives only when this exact instruction
+                // creates it. Capture the old origin above for the following s_addc_u32.
+                bvh_count_carry_origin = 0;
+                if (ok) {
+                    auto role_plus_constant = [&](BvhBuildRole wanted, uint32_t constant,
+                                                  uint32_t& origin) {
+                        if (bvh0_role == wanted && c == constant) {
+                            origin = bvh0_origin;
+                            return origin != 0;
+                        }
+                        if (bvh1_role == wanted && a == constant) {
+                            origin = bvh1_origin;
+                            return origin != 0;
+                        }
+                        return false;
+                    };
+                    uint32_t origin = 0;
+                    if (in.opcode == 0x0Eu &&
+                        role_plus_constant(BvhBuildRole::HeaderHi, 0x003fffffu, origin)) {
+                        mark_bvh_build(d, origin, BvhBuildRole::HeaderHi);
+                    } else if (in.opcode == 0x1Fu && c == 3u &&
+                               bvh0_role == BvhBuildRole::HeaderLo &&
+                               bvh0_hi_role == BvhBuildRole::HeaderHi &&
+                               bvh0_origin && bvh0_origin == bvh0_hi_origin) {
+                        mark_bvh_build(d, bvh0_origin, BvhBuildRole::PointerLo);
+                        mark_bvh_build(d + 1, bvh0_origin, BvhBuildRole::PointerHi);
+                    } else if (in.opcode == 0x29u && c == 0x00280008u &&
+                               bvh0_role == BvhBuildRole::PointerLo &&
+                               bvh0_hi_role == BvhBuildRole::PointerHi &&
+                               bvh0_origin && bvh0_origin == bvh0_hi_origin) {
+                        mark_bvh_build(d, bvh0_origin, BvhBuildRole::BaseLo);
+                        mark_bvh_build(d + 1, bvh0_origin, BvhBuildRole::BaseHi);
+                    } else if (in.opcode == 0x02u &&
+                               role_plus_constant(BvhBuildRole::CountLo, 1u, origin)) {
+                        mark_bvh_build(d, origin, BvhBuildRole::CountPlusOne);
+                    } else if (in.opcode == 0x00u &&
+                               role_plus_constant(BvhBuildRole::CountPlusOne,
+                                                  UINT32_MAX, origin)) {
+                        mark_bvh_build(d, origin, BvhBuildRole::SizeLo);
+                        bvh_count_carry_origin = origin;
+                    } else if (in.opcode == 0x04u &&
+                               previous_bvh_count_carry_origin &&
+                               ((a == UINT32_MAX && c == 0u) ||
+                                (c == UINT32_MAX && a == 0u))) {
+                        mark_bvh_build(d, previous_bvh_count_carry_origin,
+                                       BvhBuildRole::SizeHi);
+                    } else if (in.opcode == 0x0Eu &&
+                               role_plus_constant(BvhBuildRole::SizeHi, 0x3ffu, origin)) {
+                        mark_bvh_build(d, origin, BvhBuildRole::SizeHiMasked);
+                    } else if (in.opcode == 0x10u &&
+                               role_plus_constant(BvhBuildRole::SizeHiMasked,
+                                                  0x81000000u, origin)) {
+                        mark_bvh_build(d, origin, BvhBuildRole::DescriptorHi);
+                    }
+                }
                 break;
             }
             case Rdna2Format::SOPC: {   // scalar compare -> SCC (feeds the format patch's s_cselect)
+                bvh_count_carry_origin = 0;
                 uint32_t a, c;
                 bool ka = (in.src[0].kind == OperandKind::Literal) ? (a = in.literal, true) : srcval(in.src[0], a);
                 bool kc = (in.src[1].kind == OperandKind::Literal) ? (c = in.literal, true) : srcval(in.src[1], c);
@@ -3239,7 +3372,32 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 }
                 const uint32_t* mem = (const uint32_t*)(uintptr_t)addr;
                 const bool imm_only = (soff_field == 125) && (int32_t)in.literal >= 0;   // SGPR_NULL soffset
+                uint32_t bvh_count_origin = 0;
+                if (!is_buffer && n == 4 && imm_only && in.literal == 0x58u &&
+                    valid_reg(sbase) && valid_reg(sbase + 1) &&
+                    bvh_build_role[(size_t)sbase] == BvhBuildRole::PointerLo &&
+                    bvh_build_role[(size_t)(sbase + 1)] == BvhBuildRole::PointerHi &&
+                    bvh_build_origin[(size_t)sbase] &&
+                    bvh_build_origin[(size_t)sbase] ==
+                        bvh_build_origin[(size_t)(sbase + 1)])
+                    bvh_count_origin = bvh_build_origin[(size_t)sbase];
                 for (uint32_t k = 0; k < n; k++) set_value(sdst + (int)k, mem[k]);
+                if (bvh_count_origin) {
+                    mark_bvh_build(sdst, bvh_count_origin, BvhBuildRole::CountLo);
+                    mark_bvh_build(sdst + 1, bvh_count_origin, BvhBuildRole::CountHi);
+                }
+                if (!is_buffer && n == 16 && imm_only && in.literal == 0u) {
+                    // The title's object header is fetched as one mapped 16-dword block. Seed each
+                    // aligned qword independently: only the qword later consumed by the exact
+                    // descriptor builder can reach a ray instruction, and unrelated header fields
+                    // must not share provenance with it.
+                    for (uint32_t first = 0; first < n; first += 2) {
+                        uint32_t origin = ++next_bvh_build_origin;
+                        if (!origin) origin = ++next_bvh_build_origin;
+                        mark_bvh_build(sdst + (int)first, origin, BvhBuildRole::HeaderLo);
+                        mark_bvh_build(sdst + (int)first + 1, origin, BvhBuildRole::HeaderHi);
+                    }
+                }
                 if (!is_buffer && n == 2 && mem[0] == 0 && mem[1] == 0) {
                     uint32_t origin = ++next_null_chain_origin;
                     if (!origin) origin = ++next_null_chain_origin;
@@ -3358,9 +3516,22 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         const bool seed_provenance = !snapshot_provenance &&
                             (untouched_seed_range(bbase, 4) ||
                              consecutive_seed_copy_range(bbase, 4));
+                        uint32_t builder_origin = valid_reg(bbase)
+                            ? bvh_build_origin[(size_t)bbase] : 0u;
+                        const BvhBuildRole expected_builder_roles[4] = {
+                            BvhBuildRole::BaseLo, BvhBuildRole::SortedBaseHi,
+                            BvhBuildRole::SizeLo, BvhBuildRole::DescriptorHi,
+                        };
+                        bool builder_provenance = builder_origin != 0 && valid_reg(bbase + 3);
+                        for (int k = 0; builder_provenance && k < 4; ++k)
+                            builder_provenance =
+                                bvh_build_origin[(size_t)(bbase + k)] == builder_origin &&
+                                bvh_build_role[(size_t)(bbase + k)] ==
+                                    expected_builder_roles[k];
                         const DecodedBvhDescriptor d = live_known
                             ? decode_bvh_descriptor(live_bvh.data()) : DecodedBvhDescriptor{};
-                        const bool plausible = live_known && (snapshot_provenance || seed_provenance) &&
+                        const bool plausible = live_known &&
+                            (snapshot_provenance || seed_provenance || builder_provenance) &&
                             d.type == 8u && d.base > 0x10000u && d.size_bytes != 0;
                         uint32_t proven_null_origin = valid_reg(bbase) ? null_origin(bbase) : 0u;
                         for (int k = 1; proven_null_origin && k < 4; ++k)
@@ -3370,9 +3541,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             guarded_bvh_use(ins, in.pc);
                         if (trc) {
                             fprintf(stderr,
-                                    "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d "
+                                    "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d builder=%d "
                                     "live_known=%d bvh=",
-                                    in.pc, bbase, snapshot_provenance, seed_provenance, live_known);
+                                    in.pc, bbase, snapshot_provenance, seed_provenance,
+                                    builder_provenance, live_known);
                             if (live_known) {
                                 for (uint32_t word : live_bvh) fprintf(stderr, "%08x ", word);
                             } else {
@@ -3850,6 +4022,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // tracked SCC — a stale SCC consumed by a later s_cselect would fabricate a
                 // confidently-wrong V# patch.
                 scc = -1;
+                bvh_count_carry_origin = 0;
                 if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);
                 break;
             default:
@@ -4036,7 +4209,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             const DecodedBvhDescriptor d = decode_bvh_descriptor(u.bvh4.data());
             if (d.type != 8u || d.base <= 0x10000u || d.size_bytes == 0 ||
                 d.size_bytes > 0x10000000u || d.size_bytes > UINT32_MAX ||
-                !d.triangle_return_mode || d.box_node_64b || d.sort_enabled)
+                !d.triangle_return_mode || d.box_node_64b)
                 continue;
             const uint64_t dk = 0x8000000200000000ull | u.use_pc;
             if (!seen.insert(dk).second) continue;
@@ -4044,7 +4217,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             for (auto& r0 : table.resources) {
                 if (r0.cls != ResourceClass::ConstantBuffer || r0.gpu_addr != d.base ||
                     r0.size != static_cast<uint32_t>(d.size_bytes) ||
-                    r0.bvh_box_grow != d.box_grow)
+                    r0.bvh_box_grow != d.box_grow ||
+                    r0.bvh_sort_enabled != d.sort_enabled)
                     continue;
                 if (r0.fetch_pc == 0xFFFFFFFFu) r0.fetch_pc = u.use_pc;
                 if (r0.fetch_pc == u.use_pc) { mapped = true; break; }
@@ -4058,6 +4232,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             r.size = static_cast<uint32_t>(d.size_bytes);
             r.fetch_pc = u.use_pc;
             r.bvh_box_grow = d.box_grow;
+            r.bvh_sort_enabled = d.sort_enabled;
             table.resources.push_back(r);
             continue;
         }

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2139,6 +2139,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::array<uint32_t, kFoldSgprs> null_chain_origin{};
     std::bitset<kFoldSgprs> null_chain_known;
     uint32_t next_null_chain_origin = 0;
+    // Null-pointer provenance carried by SCC between the low and high halves of an exact
+    // s_add_u32/s_addc_u32 pair. The concrete carry can be unknown after a failed null dereference;
+    // this records only that the high result still belongs to that null chain.
+    uint32_t null_count_carry_origin = 0;
     // Exact provenance for GTA V's RTIP 1.1 descriptor builder. A successful mapped x16 header
     // load seeds candidate qword origins; only the observed mask/lshl/load-count/bfe/carry/header
     // chain can turn one into a complete descriptor. This is deliberately separate from concrete
@@ -2375,6 +2379,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         std::bitset<kFoldSgprs> descr8_key_known;
         std::array<uint32_t, kFoldSgprs> null_chain_origin;
         std::bitset<kFoldSgprs> null_chain_known;
+        uint32_t null_count_carry_origin;
         std::array<uint32_t, kFoldSgprs> bvh_build_origin;
         std::array<BvhBuildRole, kFoldSgprs> bvh_build_role;
         uint32_t bvh_count_carry_origin;
@@ -2415,6 +2420,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         s.descr8 = descr8; s.descr8_known = descr8_known;
         s.descr8_key = descr8_key; s.descr8_key_known = descr8_key_known;
         s.null_chain_origin = null_chain_origin; s.null_chain_known = null_chain_known;
+        s.null_count_carry_origin = null_count_carry_origin;
         s.bvh_build_origin = bvh_build_origin; s.bvh_build_role = bvh_build_role;
         s.bvh_count_carry_origin = bvh_count_carry_origin;
         s.reloaded = reloaded; s.mask_state = mask_state;
@@ -2431,6 +2437,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         descr8 = s.descr8; descr8_known = s.descr8_known;
         descr8_key = s.descr8_key; descr8_key_known = s.descr8_key_known;
         null_chain_origin = s.null_chain_origin; null_chain_known = s.null_chain_known;
+        null_count_carry_origin = s.null_count_carry_origin;
         bvh_build_origin = s.bvh_build_origin; bvh_build_role = s.bvh_build_role;
         bvh_count_carry_origin = s.bvh_count_carry_origin;
         reloaded = s.reloaded; mask_state = s.mask_state;
@@ -2852,6 +2859,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // tracked SCC, or a later s_cselect folds with a stale compare result.
                 if (in.opcode != 0x03 && in.opcode != 0x04) {
                     scc = -1;
+                    null_count_carry_origin = 0;
                     bvh_count_carry_origin = 0;
                 }
                 break;
@@ -2899,6 +2907,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 source_bvh_state(in.src[0], 0, bvh0_origin, bvh0_role);
                 source_bvh_state(in.src[1], 0, bvh1_origin, bvh1_role);
                 source_bvh_state(in.src[0], 1, bvh0_hi_origin, bvh0_hi_role);
+                const uint32_t previous_null_count_carry_origin = null_count_carry_origin;
                 const uint32_t previous_bvh_count_carry_origin = bvh_count_carry_origin;
                 // s_addc_u32 remains derived from the same pointer chain even when its concrete
                 // carry is unknown; the taint is provenance, not a claim about the folded value.
@@ -2914,6 +2923,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     else if (null0 && !null1 && kc) propagated_null_origin = null0;
                     else if (null1 && !null0 && ka) propagated_null_origin = null1;
                 }
+                // GTA V forms the high descriptor count with `s_add_u32 -1,null_value` followed by
+                // `s_addc_u32 -1,0`. The failed dereference intentionally makes the concrete SCC
+                // unknown, but the carry still depends exclusively on the same proven null chain.
+                // Keep this narrower than general SCC taint: accept only that exact constant pair.
+                if (in.opcode == 0x04u && previous_null_count_carry_origin && ka && kc &&
+                    ((a == UINT32_MAX && c == 0u) || (c == UINT32_MAX && a == 0u)))
+                    propagated_null_origin = previous_null_count_carry_origin;
                 if (ok) switch (in.opcode) {
                     case 0x00: {                                           // s_add_u32
                         const uint64_t sum = static_cast<uint64_t>(a) + c;
@@ -3043,6 +3059,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     mark_null_origin(d + 1, propagated_null_origin);
                 // Every SOP2 writes SCC, so a count carry survives only when this exact instruction
                 // creates it. Capture the old origin above for the following s_addc_u32.
+                null_count_carry_origin = 0;
+                if (in.opcode == 0x00u && propagated_null_origin &&
+                    ((null0 && kc && c == UINT32_MAX) ||
+                     (null1 && ka && a == UINT32_MAX)))
+                    null_count_carry_origin = propagated_null_origin;
                 bvh_count_carry_origin = 0;
                 if (ok) {
                     auto role_plus_constant = [&](BvhBuildRole wanted, uint32_t constant,
@@ -3099,6 +3120,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 break;
             }
             case Rdna2Format::SOPC: {   // scalar compare -> SCC (feeds the format patch's s_cselect)
+                null_count_carry_origin = 0;
                 bvh_count_carry_origin = 0;
                 uint32_t a, c;
                 bool ka = (in.src[0].kind == OperandKind::Literal) ? (a = in.literal, true) : srcval(in.src[0], a);
@@ -3461,6 +3483,16 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         if (!origin) origin = ++next_bvh_build_origin;
                         mark_bvh_build(sdst + (int)first, origin, BvhBuildRole::HeaderLo);
                         mark_bvh_build(sdst + (int)first + 1, origin, BvhBuildRole::HeaderHi);
+
+                        // A zero qword in the same successful header read is also an exact null
+                        // pointer. Give each pair its own origin so adjacent zero fields cannot be
+                        // spliced into one descriptor, then let only dependent scalar ALU retain it.
+                        if (mem[first] == 0u && mem[first + 1] == 0u) {
+                            uint32_t null_origin = ++next_null_chain_origin;
+                            if (!null_origin) null_origin = ++next_null_chain_origin;
+                            mark_null_origin(sdst + (int)first, null_origin);
+                            mark_null_origin(sdst + (int)first + 1, null_origin);
+                        }
                     }
                 }
                 if (!is_buffer && n == 2 && mem[0] == 0 && mem[1] == 0) {
@@ -4099,6 +4131,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // tracked SCC — a stale SCC consumed by a later s_cselect would fabricate a
                 // confidently-wrong V# patch.
                 scc = -1;
+                null_count_carry_origin = 0;
                 bvh_count_carry_origin = 0;
                 if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);
                 break;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -1966,6 +1966,10 @@ bool has_indirect_control_flow(const std::vector<Rdna2Inst>& instructions) {
 }
 
 bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc) {
+    // An indirect target can enter the guarded interval after its EXECZ check, or leave and later
+    // re-enter it. No scan over direct SOPP displacements can prove dominance in that program.
+    if (has_indirect_control_flow(instructions)) return false;
+
     const auto& is_branch = sopp_is_branch;
     const auto& target = sopp_branch_target;
 
@@ -1998,6 +2002,27 @@ bool guarded_bvh_use(const std::vector<Rdna2Inst>& instructions, uint32_t use_pc
         if (!external_entry) return true;
     }
     return false;
+}
+
+// The x16-header null proof deliberately accepts one observed straight-line descriptor builder, not
+// a general scalar phi analysis. Every instruction that carries the root from its mapped load to the
+// ray must therefore execute whenever the ray does. Reject a branch inside that interval, or any
+// edge entering it after the load; branches that skip both the load and the ray remain harmless.
+bool straight_line_null_chain_dominates(const std::vector<Rdna2Inst>& instructions,
+                                        uint32_t definition_pc, uint32_t use_pc) {
+    if (definition_pc >= use_pc) return false;
+    bool found_definition = false, found_use = false;
+    for (const Rdna2Inst& in : instructions) {
+        found_definition |= in.pc == definition_pc;
+        found_use |= in.pc == use_pc;
+        if (!sopp_is_branch(in)) continue;
+        const int64_t branch_target = sopp_branch_target(in);
+        if (in.pc > definition_pc && in.pc < use_pc) return false;
+        if (branch_target > static_cast<int64_t>(definition_pc) &&
+            branch_target <= static_cast<int64_t>(use_pc))
+            return false;
+    }
+    return found_definition && found_use;
 }
 
 // --- Bindless-dynamic vertex-fetch resolution (const-fold the scalar setup) ---------------------------
@@ -2139,6 +2164,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::array<uint32_t, kFoldSgprs> null_chain_origin{};
     std::bitset<kFoldSgprs> null_chain_known;
     uint32_t next_null_chain_origin = 0;
+    // Only x16-header roots need the narrow straight-line dominance contract added for GTA V. The
+    // generic mapped-qword null proof predates this shape and has separate loop/CFG validation.
+    // Origin ids are monotonic and never restored, so this metadata is immutable once published.
+    std::vector<uint32_t> x16_null_origin_pc(1u, UINT32_MAX);
     // Null-pointer provenance carried by SCC between the low and high halves of an exact
     // s_add_u32/s_addc_u32 pair. The concrete carry can be unknown after a failed null dereference;
     // this records only that the high result still belongs to that null chain.
@@ -2888,6 +2917,11 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 int next_scc = scc;
                 const uint32_t null0 = operand_null_origin(in.src[0]);
                 const uint32_t null1 = operand_null_origin(in.src[1]);
+                uint32_t null0_hi = 0;
+                if ((in.src[0].kind == OperandKind::SGPR ||
+                     in.src[0].kind == OperandKind::Special) &&
+                    valid_reg(in.src[0].value + 1))
+                    null0_hi = null_origin(in.src[0].value + 1);
                 auto source_bvh_state = [&](const Operand& operand, int add,
                                             uint32_t& origin, BvhBuildRole& role) {
                     const int reg = operand.value + add;
@@ -2918,7 +2952,15 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     in.opcode == 0x27 || in.opcode == 0x1F || in.opcode == 0x21 ||
                     in.opcode == 0x29;
                 uint32_t propagated_null_origin = 0;
-                if (null_chain_opcode) {
+                const bool null_chain_64bit_opcode =
+                    in.opcode == 0x1Fu || in.opcode == 0x21u || in.opcode == 0x29u;
+                if (null_chain_64bit_opcode) {
+                    // A 64-bit value is one provenance unit. Looking only at its low SGPR lets two
+                    // independently loaded zero qwords be spliced with scalar moves and then
+                    // collapsed onto one origin by the shift/BFE result.
+                    if (null0 && null0_hi == null0 && kc)
+                        propagated_null_origin = null0;
+                } else if (null_chain_opcode) {
                     if (null0 && null1 && null0 == null1) propagated_null_origin = null0;
                     else if (null0 && !null1 && kc) propagated_null_origin = null0;
                     else if (null1 && !null0 && ka) propagated_null_origin = null1;
@@ -3490,6 +3532,9 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         if (mem[first] == 0u && mem[first + 1] == 0u) {
                             uint32_t null_origin = ++next_null_chain_origin;
                             if (!null_origin) null_origin = ++next_null_chain_origin;
+                            if (x16_null_origin_pc.size() <= null_origin)
+                                x16_null_origin_pc.resize((size_t)null_origin + 1u, UINT32_MAX);
+                            x16_null_origin_pc[(size_t)null_origin] = in.pc;
                             mark_null_origin(sdst + (int)first, null_origin);
                             mark_null_origin(sdst + (int)first + 1, null_origin);
                         }
@@ -3641,8 +3686,13 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         for (int k = 1; proven_null_origin && k < 4; ++k)
                             if (null_origin(bbase + k) != proven_null_origin)
                                 proven_null_origin = 0;
+                        bool null_control_proven = true;
+                        if (proven_null_origin < x16_null_origin_pc.size() &&
+                            x16_null_origin_pc[(size_t)proven_null_origin] != UINT32_MAX)
+                            null_control_proven = straight_line_null_chain_dominates(
+                                ins, x16_null_origin_pc[(size_t)proven_null_origin], in.pc);
                         const bool guarded_null = !plausible && proven_null_origin &&
-                            guarded_bvh_use(ins, in.pc);
+                            null_control_proven && guarded_bvh_use(ins, in.pc);
                         if (trc) {
                             fprintf(stderr,
                                     "[dyntrace] BVH pc=%u srsrc=s%d snapshot=%d seed=%d builder=%d "

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -950,7 +950,15 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords) {
             if (src0 == 0xFAu && max_dwords >= 2 && vf != Rdna2Format::VOPC) {
                 const uint32_t d1 = code[1];
                 const uint32_t ctrl = (d1 >> 8) & 0x1FFu;
-                const bool modeled_ctrl = ctrl < 0x100u || (ctrl >= 0x111u && ctrl <= 0x11Fu);
+                // GTA V's screen-space compute passes use one additional exact DPP form:
+                // V_MIN_F32 ROW_ROR:8 with full masks and BOUND_CTRL=1.  Keep the opcode and
+                // bound behavior in this admission predicate so the neighboring V_MOV/V_MAX
+                // rotates, other rotate amounts, and BC0 remain fail-visible.
+                const bool gta_vmin_row_ror8 =
+                    vf == Rdna2Format::VOP2 && ((w >> 25) & 0x3Fu) == 0x0Fu &&
+                    ctrl == 0x128u && ((d1 >> 19) & 1u) == 1u;
+                const bool modeled_ctrl = ctrl < 0x100u ||
+                    (ctrl >= 0x111u && ctrl <= 0x11Fu) || gta_vmin_row_ror8;
                 if (modeled_ctrl && ((d1 >> 28) & 0xFu) == 0xFu && ((d1 >> 24) & 0xFu) == 0xFu &&
                     ((d1 >> 20) & 0xFu) == 0u && ((d1 >> 18) & 1u) == 0u) {
                     i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -125,8 +125,10 @@ uint32_t rdna2_vgpr_write_count(const Rdna2Inst& in) {
             return 1;
         case Rdna2Format::VOP3:
             if (in.opcode == 0x360u) return 0; // v_readlane_b32 writes an SGPR.
-            // v_div_scale_f64 and the two integer MAD64 forms write a VGPR pair.
-            return in.opcode == 0x16eu || in.opcode == 0x176u || in.opcode == 0x177u ? 2u : 1u;
+            // v_div_scale_f64, the two integer MAD64 forms, and the 64-bit reversed left shift
+            // write a consecutive VGPR pair.
+            return in.opcode == 0x16eu || in.opcode == 0x176u || in.opcode == 0x177u ||
+                   in.opcode == 0x2ffu ? 2u : 1u;
         case Rdna2Format::DS:
             // Keep this aligned with the DS result opcodes admitted by the emitter. Other DS
             // encodings in that subset are stores or no-return atomics whose VDST field is a source.
@@ -634,11 +636,12 @@ void decode_operands(Rdna2Inst& i) {
                 i.src[2] = {};
                 i.n_src = 2;
             }
-            // V_LDEXP_F32 and V_BFM_B32 are two-source VOP3A instructions. Their reserved SRC2 bits
-            // are zero in GTA V's exact packets and therefore decode as s0 unless cleared here.
+            // V_LSHLREV_B64, V_LDEXP_F32, and V_BFM_B32 are two-source VOP3A instructions. Their
+            // reserved SRC2 bits are zero in GTA V's exact packets and therefore decode as s0 unless
+            // cleared here.
             // Exposing that phantom scalar read can make CFG/provenance analysis reject an otherwise
             // valid instruction when s0 differs across a merge, before the opcode emitter is reached.
-            if (i.opcode == 0x362u || i.opcode == 0x363u) {
+            if (i.opcode == 0x2ffu || i.opcode == 0x362u || i.opcode == 0x363u) {
                 i.src[2] = {};
                 i.n_src = 2;
             }

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -950,15 +950,19 @@ Rdna2Inst rdna2_decode_one(const uint32_t* code, size_t max_dwords) {
             if (src0 == 0xFAu && max_dwords >= 2 && vf != Rdna2Format::VOPC) {
                 const uint32_t d1 = code[1];
                 const uint32_t ctrl = (d1 >> 8) & 0x1FFu;
-                // GTA V's screen-space compute passes use one additional exact DPP form:
-                // V_MIN_F32 ROW_ROR:8 with full masks and BOUND_CTRL=1.  Keep the opcode and
-                // bound behavior in this admission predicate so the neighboring V_MOV/V_MAX
-                // rotates, other rotate amounts, and BC0 remain fail-visible.
-                const bool gta_vmin_row_ror8 =
-                    vf == Rdna2Format::VOP2 && ((w >> 25) & 0x3Fu) == 0x0Fu &&
-                    ctrl == 0x128u && ((d1 >> 19) & 1u) == 1u;
+                // GTA V's screen-space compute passes use one additional exact DPP family:
+                // V_MOV_B32 / V_MIN_F32 / V_MAX_F32 ROW_ROR:8 with full masks and
+                // BOUND_CTRL=1. Keep the opcode and bound behavior in this admission predicate so
+                // other operations, rotate amounts, and BC0 remain fail-visible.
+                const uint32_t vop1_opcode = (w >> 9) & 0xffu;
+                const uint32_t vop2_opcode = (w >> 25) & 0x3fu;
+                const bool gta_row_ror8 =
+                    ctrl == 0x128u && ((d1 >> 19) & 1u) == 1u &&
+                    ((vf == Rdna2Format::VOP1 && vop1_opcode == 0x01u) ||
+                     (vf == Rdna2Format::VOP2 &&
+                      (vop2_opcode == 0x0fu || vop2_opcode == 0x10u)));
                 const bool modeled_ctrl = ctrl < 0x100u ||
-                    (ctrl >= 0x111u && ctrl <= 0x11Fu) || gta_vmin_row_ror8;
+                    (ctrl >= 0x111u && ctrl <= 0x11Fu) || gta_row_ror8;
                 if (modeled_ctrl && ((d1 >> 28) & 0xFu) == 0xFu && ((d1 >> 24) & 0xFu) == 0xFu &&
                     ((d1 >> 20) & 0xFu) == 0u && ((d1 >> 18) & 1u) == 0u) {
                     i.has_modifier = false; i.has_dpp = true; i.dpp_ctrl = (uint16_t)ctrl;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -141,7 +141,8 @@ enum : uint32_t {
     Op_ImageFetch=95, Op_ImageGather=96, Op_Image=100,
     Op_ImageRead=98, Op_ImageWrite=99, Op_ImageQuerySizeLod=103, Op_ImageQuerySize=104,
     Op_ImageQueryLod=105, Op_ImageQueryLevels=106,
-    Op_TypeArray=28, Op_ControlBarrier=224, Op_MemoryBarrier=225, Op_AtomicExchange=229, Op_AtomicIAdd=234,
+    Op_TypeArray=28, Op_ControlBarrier=224, Op_MemoryBarrier=225, Op_AtomicLoad=227,
+    Op_AtomicExchange=229, Op_AtomicCompareExchange=230, Op_AtomicIAdd=234,
     Op_AtomicISub=235,
     Op_AtomicSMin=236, Op_AtomicUMin=237, Op_AtomicSMax=238, Op_AtomicUMax=239,
     Op_AtomicAnd=240, Op_AtomicOr=241, Op_AtomicXor=242,
@@ -193,7 +194,8 @@ enum : uint32_t {
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
     MemSem_UniformRelease=0x44,                          // Release | UniformMemory
-    MemSem_UniformAcqRel=0x48, MemSem_WGAcqRel=0x108,   // storage-buffer/LDS AcquireRelease semantics
+    MemSem_UniformAcqRel=0x48, MemSem_WGAcquire=0x102,
+    MemSem_WGAcqRel=0x108,                              // storage-buffer/LDS AcquireRelease semantics
     MemSem_ImageAcqRel=0x808,                            // AcquireRelease | ImageMemory
     MemAccess_Volatile=0x1,
     Dec_Block=2, Dec_ArrayStride=6, Dec_BuiltIn=11, Dec_NoPerspective=13, Dec_Flat=14,
@@ -2314,6 +2316,74 @@ struct SpirvCompute {
         };
         if (!predicated) { emit(); return; }
         uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        emit();
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+    }
+    // RDNA2 DS_MIN/MAX_F32 are numeric floating-point atomics: one NaN yields the number, infinities
+    // and denormals retain their IEEE ordering, and signed-zero ties choose -0 for min / +0 for max.
+    // SPIR-V 1.3 has no core floating atomic min/max, while integer AtomicS/UMin orders the raw bits
+    // incorrectly. Implement the architectural operation as a u32 compare-exchange loop instead.
+    // The ordering key is monotonic for every non-NaN binary32 bit pattern and therefore does not
+    // depend on the host driver's denormal mode. AMD's both-NaN MINNUM/MAXNUM rule returns a quieted
+    // first operand; the resident `*ptr` value is that first operand for an atomic min/max update.
+    void lds_atomic_fminmax(uint32_t idx, uint32_t value, bool is_min,
+                            bool predicated, uint32_t pred) {
+        auto ordered_key = [&](uint32_t bits) {
+            const uint32_t negative = ucmp(
+                Op_INotEqual, ibin(Op_BitwiseAnd, bits, uconst(0x80000000u)), uconst(0));
+            return sel(negative, iun(Op_Not, bits),
+                       ibin(Op_BitwiseXor, bits, uconst(0x80000000u)));
+        };
+        auto minmax_bits = [&](uint32_t resident) {
+            const uint32_t resident_abs = ibin(
+                Op_BitwiseAnd, resident, uconst(0x7fffffffu));
+            const uint32_t value_abs = ibin(
+                Op_BitwiseAnd, value, uconst(0x7fffffffu));
+            const uint32_t resident_nan = ucmp(
+                Op_UGreaterThan, resident_abs, uconst(0x7f800000u));
+            const uint32_t value_nan = ucmp(
+                Op_UGreaterThan, value_abs, uconst(0x7f800000u));
+            const uint32_t ordered = ucmp(
+                is_min ? Op_ULessThan : Op_UGreaterThan,
+                ordered_key(value), ordered_key(resident));
+            const uint32_t numeric = sel(ordered, value, resident);
+            const uint32_t resident_number = sel(value_nan, resident, numeric);
+            const uint32_t quiet_resident = ibin(
+                Op_BitwiseOr, resident, uconst(0x00400000u));
+            return sel(resident_nan, sel(value_nan, quiet_resident, value), resident_number);
+        };
+        auto emit = [&]() {
+            const uint32_t p = id();
+            putv(code, Op_AccessChain, {t_ptr_lds_u32, p, lds_var, idx});
+            const uint32_t initial = id();
+            put(code, Op_AtomicLoad,
+                {t_u32, initial, p, uconst(Scope_Workgroup), uconst(MemSem_WGAcquire)});
+
+            const uint32_t preheader = cur_block;
+            const uint32_t header = id(), again = id(), merge = id();
+            put(code, Op_Branch, {header});
+            put(code, Op_Label, {header}); cur_block = header;
+            size_t retry_patch = 0;
+            const uint32_t expected = emit_phi2(t_u32, initial, preheader, retry_patch);
+            const uint32_t desired = minmax_bits(expected);
+            const uint32_t observed = id();
+            put(code, Op_AtomicCompareExchange,
+                {t_u32, observed, p, uconst(Scope_Workgroup), uconst(MemSem_WGAcqRel),
+                 uconst(MemSem_WGAcquire), desired, expected});
+            const uint32_t succeeded = ucmp(Op_IEqual, observed, expected);
+            put(code, Op_LoopMerge, {merge, again, 0});
+            put(code, Op_BranchConditional, {succeeded, merge, again});
+            put(code, Op_Label, {again}); cur_block = again;
+            put(code, Op_Branch, {header});
+            patch_phi(retry_patch, observed, again);
+            put(code, Op_Label, {merge}); cur_block = merge;
+        };
+        if (!predicated) { emit(); return; }
+        const uint32_t then = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});
         put(code, Op_BranchConditional, {pred, then, merge});
         put(code, Op_Label, {then}); cur_block = then;
@@ -12401,7 +12471,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 (in.opcode != 0x00 && in.opcode != 0x05 && in.opcode != 0x06 &&
                                   in.opcode != 0x07 && in.opcode != 0x08 &&
                                   in.opcode != 0x09 && in.opcode != 0x0a &&
-                                  in.opcode != 0x0b && in.opcode != 0x20 &&
+                                  in.opcode != 0x0b && in.opcode != 0x12 &&
+                                  in.opcode != 0x13 && in.opcode != 0x20 &&
                                   in.opcode != 0x2d &&
                                   in.opcode != 0x0d && in.opcode != 0x0e &&
                                   in.opcode != 0x36 && in.opcode != 0x37 &&
@@ -12503,6 +12574,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 return true;
             }
             if (b.ngg_private_lds && (in.opcode == 0x00 || in.opcode == 0x07 || in.opcode == 0x08 ||
+                                     in.opcode == 0x12 || in.opcode == 0x13 ||
                                      in.opcode == 0x20 || in.opcode == 0x2d)) {
                 // Cross-lane/atomic NGG LDS effects do not have a proven single-lane reduction yet.
                 ok = false; return true;
@@ -12510,6 +12582,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             if (in.opcode == 0x00) {                     // ds_add_u32: LDS += DATA0, no VGPR return
                 b.lds_atomic(Op_AtomicIAdd, idx, vread(in.src[1].value),
                              rs.exec_narrowed, rs.exec);
+            } else if (in.opcode == 0x12 || in.opcode == 0x13) {
+                // Exact ordinary GFX10 encoding: ADDR + DATA0 only. DATA1 and VDST are reserved for
+                // these non-returning forms (llvm-mc gfx1030 emits both as zero); reject a packet
+                // carrying either field instead of interpreting an unmodeled SRC2/return variant.
+                if ((in.words[1] & 0xffff0000u) != 0u) { ok = false; return true; }
+                b.lds_atomic_fminmax(idx, vread(in.src[1].value), in.opcode == 0x12,
+                                     rs.exec_narrowed, rs.exec);
             } else if (in.opcode >= 0x05 && in.opcode <= 0x0b) {
                 // Non-returning 32-bit LDS atomics map directly to SPIR-V atomics. DS_OR_B32
                 // (0x0a) occurs in Plucky's first-gameplay compute path; supporting the adjacent

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10304,10 +10304,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 ok = false; return true;
             }
             // The front half proved all four live SBASE words at this exact scalar-buffer load and
-            // decoded NUM_RECORDS=0. Every possible immediate/register SOFFSET is therefore OOB, so
-            // the result is exact zero without declaring or touching a dummy storage binding. Check
-            // this before SOFFSET tracking: the point of the proof is that even an unknown runtime
-            // offset cannot change the result.
+            // proved that its minimum unsigned offset begins beyond the effective scalar bound. The
+            // result is therefore exact zero without declaring or touching a dummy storage binding.
+            // Check this before SOFFSET tracking: even an unknown runtime offset cannot reduce it.
             const ShaderResource* zero_record_sbuffer =
                 rt && in.opcode >= 0x8u ? rt->by_fetch_pc(in.pc) : nullptr;
             if (zero_record_sbuffer && is_zero_record_raw_buffer(*zero_record_sbuffer)) {
@@ -10753,11 +10752,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     ok = false; return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
-                    // The exact live V# is empty, so format selection is never observed: every load
-                    // component returns zero and no backing buffer exists. Apply the result only to
-                    // active EXEC lanes, preserving the old destination in masked lanes.
+                    // The exact live V# is empty. The producer admitted only selectors whose OOB
+                    // result is zero; re-check that contract so a malformed table cannot silently
+                    // turn SQ_SEL_1 into zero. Apply the result only to active EXEC lanes, preserving
+                    // the old destination in masked lanes, and never declare a backing buffer.
                     if (is_store) { ok = false; return true; }
                     for (uint32_t k = 0; k < n; ++k) {
+                        const uint32_t selector = res->swizzle[k];
+                        if (selector != 0u && selector < 4u) { ok = false; return true; }
                         const int d = in.dst.value + static_cast<int>(k);
                         const uint32_t old = vreg_old(b, rs, d);
                         rs.vreg[d] = b.uconst(0);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -409,6 +409,12 @@ struct SpirvCompute {
     uint32_t ngg_vertex_index_value = 0;
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
+    // S_CSELECT_B64 normally needs both scalar source dwords. A captured GTA V kernel consumes
+    // only the selected VCC_LO word and leaves VCC_HI dead on every successor path; the whole-stream
+    // liveness proof records that exact exception before emission. Keep it builder-local so recursive
+    // phase/CFG emitters see the proof derived from the original complete instruction stream.
+    bool cselect_b64_low_only_analysis_done = false;
+    std::unordered_set<uint32_t> cselect_b64_low_only_pcs;
     bool     declared_subgroup=0, declared_subgroup_vote=0, declared_subgroup_arithmetic=0;
     // When non-zero, the backend promises to create this compute pipeline with an exact required
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
@@ -3864,6 +3870,28 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
     return true;   // every reachable path hit a redefinition/end without a read
 }
 
+std::unordered_set<uint32_t> proven_cselect_b64_low_only_pcs(
+        const std::vector<Rdna2Inst>& ins) {
+    std::unordered_set<uint32_t> result;
+    for (const Rdna2Inst& in : ins) {
+        if (in.is_end) break;
+        // GTA V 0x413cf9a00 pc60 selects two scalar-data pairs into VCC, then reads only
+        // VCC_LO as one scalar dword. Its second alternative currently has only the low word
+        // available (the zero-record S_BUFFER load at pc16 writes s16, not s17). Admit that
+        // incomplete-source form only for the exact ordinary-SGPR-to-VCC packet shape and only
+        // when the shared CFG liveness walk proves VCC_HI dead from the following instruction.
+        // An implicit VCC consumer counts as a high-half read in that walk, so no per-lane mask
+        // can observe the unavailable selected word.
+        if (in.fmt == Rdna2Format::SOP2 && in.opcode == 0x0bu &&
+            in.dst.kind == OperandKind::SGPR && in.dst.value == 106 &&
+            in.src[0].kind == OperandKind::SGPR &&
+            in.src[1].kind == OperandKind::SGPR &&
+            sgpr_dead_at_merge(ins, in.pc + in.len_dwords, 107))
+            result.insert(in.pc);
+    }
+    return result;
+}
+
 // #2418: does this shader read SCC anywhere? Used to decide whether the fragment stage should pay for
 // an exact wave vote when a mask op writes SCC. Deliberately CONSERVATIVE and whole-shader: it answers
 // "could SCC ever be consumed", not "is this particular write live". A false positive costs one shader a
@@ -7308,9 +7336,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            if (in.opcode == 0x0b) {   // s_cselect_b64: 64-bit MASK dst = SCC ? src0 : src1 (mask domain)
+            if (in.opcode == 0x0b) {   // s_cselect_b64: SCC ? src0 : src1 (mask or scalar-pair domain)
                 // Operands/dest are wave masks (EXEC/VCC/saved/inline), NOT uint bits — resolve like the
-                // SOP1 mask ops and select in the bool domain. (s_cselect_b32 0x0a stays in the uint path.)
+                // SOP1 mask ops and select in the bool domain. Keep this path first so established
+                // mask lifetimes retain byte-identical behavior even when Function-backed scalar
+                // placeholders coexist in a CFG dispatcher. (s_cselect_b32 stays in the uint path.)
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
                 auto mask = [&](const Operand& o) -> uint32_t {
                     if (o.value == 106 || o.value == 107) return rs.vcc;
@@ -7322,13 +7352,99 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return 0;   // not a recognizable mask
                 };
                 uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
-                if (!m0 || !m1 || !rs.scc) { ok = false; return true; }   // !rs.scc: SCC poisoned by a mask op
-                uint32_t r = b.bsel(rs.scc, m0, m1);
-                if (is_exec(in.dst)) { rs.exec = r; rs.exec_narrowed = true; }
-                else if (in.dst.value == 106 || in.dst.value == 107) { rs.vcc = r; rs.sreg_bool_narrowed[in.dst.value] = true;
-                                                                       mask_write_clobbers_pair(rs, in.dst.value); }
-                else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true;   // conservative flag
-                       mask_write_clobbers_pair(rs, in.dst.value); }
+                if (m0 && m1) {
+                    if (!rs.scc) { ok = false; return true; }   // SCC poisoned by a mask op
+                    uint32_t r = b.bsel(rs.scc, m0, m1);
+                    if (is_exec(in.dst)) { rs.exec = r; rs.exec_narrowed = true; }
+                    else if (in.dst.value == 106 || in.dst.value == 107) { rs.vcc = r; rs.sreg_bool_narrowed[in.dst.value] = true;
+                                                                           mask_write_clobbers_pair(rs, in.dst.value); }
+                    else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true;   // conservative flag
+                           mask_write_clobbers_pair(rs, in.dst.value); }
+                    return true;
+                }
+
+                // Ordinary scalar-data pairs are selected word-for-word. Unlike EXEC, VCC has a
+                // dual role: its two physical scalar dwords remain readable as data, while vector
+                // instructions consume the bit for this invocation. Materialize both views from
+                // the same selected pair so native and portable compute paths agree exactly.
+                struct ScalarPair {
+                    uint32_t lo = 0, hi = 0;
+                    bool have_lo = false, have_hi = false;
+                };
+                auto scalar_word = [&](int reg, uint32_t& value) {
+                    auto current = rs.sreg.find(reg);
+                    if (current != rs.sreg.end()) { value = current->second; return true; }
+                    auto input = rs.sreg_input.find(reg);
+                    if (input != rs.sreg_input.end()) { value = input->second; return true; }
+                    return false;
+                };
+                auto scalar_pair = [&](const Operand& source) {
+                    ScalarPair pair;
+                    if (source.kind == OperandKind::SGPR ||
+                        (source.kind == OperandKind::Special &&
+                         source.value >= 106 && source.value < 124)) {
+                        pair.have_lo = scalar_word(source.value, pair.lo);
+                        pair.have_hi = scalar_word(source.value + 1, pair.hi);
+                    } else if (source.kind == OperandKind::InlineInt) {
+                        pair.lo = b.uconst(static_cast<uint32_t>(source.value));
+                        pair.hi = b.uconst(source.value < 0 ? UINT32_MAX : 0u);
+                        pair.have_lo = pair.have_hi = true;
+                    } else if (source.kind == OperandKind::Literal) {
+                        pair.lo = b.uconst(in.literal);
+                        pair.hi = b.uconst(0);
+                        pair.have_lo = pair.have_hi = true;
+                    }
+                    return pair;
+                };
+                if (is_exec(in.dst) || !rs.scc) { ok = false; return true; }
+                const ScalarPair p0 = scalar_pair(in.src[0]);
+                const ScalarPair p1 = scalar_pair(in.src[1]);
+                const bool complete = p0.have_lo && p0.have_hi && p1.have_lo && p1.have_hi;
+                const bool low_only = p0.have_lo && p1.have_lo &&
+                    b.is_compute && b.wave_size == 64 &&
+                    b.cselect_b64_low_only_pcs.contains(in.pc);
+                if (!complete && !low_only) { ok = false; return true; }
+
+                const uint32_t selected_lo = b.sel(rs.scc, p0.lo, p1.lo);
+                const uint32_t selected_hi = complete
+                    ? b.sel(rs.scc, p0.hi, p1.hi) : b.uconst(0);
+                rs.sreg[in.dst.value] = selected_lo;
+                if (complete) rs.sreg[in.dst.value + 1] = selected_hi;
+                else rs.sreg.erase(in.dst.value + 1);
+                rs.sreg_srt.erase(in.dst.value);
+                rs.sreg_srt.erase(in.dst.value + 1);
+
+                // A scalar pair write ends every overlapping saved-mask/B32 lifetime. The complete
+                // VCC form immediately installs its newly-derived predicate below; the GTA low-only
+                // form deliberately leaves VCC unavailable because the CFG proof says no implicit
+                // mask consumer can observe it.
+                auto erase_mask_alias = [&](int base) {
+                    rs.sreg_bool.erase(base);
+                    rs.sreg_bool_narrowed.erase(base);
+                    rs.sreg_bool_b32.erase(base);
+                };
+                if (in.dst.value > 0) erase_mask_alias(in.dst.value - 1);
+                erase_mask_alias(in.dst.value);
+                erase_mask_alias(in.dst.value + 1);
+                if (in.dst.value == 106) {
+                    if (complete) {
+                        uint32_t lane = b.ibin(
+                            Op_BitwiseAnd, b.guest_lane_id(), b.uconst(b.wave_size - 1));
+                        const uint32_t high = b.ucmp(
+                            Op_UGreaterThanEqual, lane, b.uconst(32));
+                        const uint32_t word = b.sel(high, selected_hi, selected_lo);
+                        const uint32_t bit = b.ibin(Op_BitwiseAnd, lane, b.uconst(31));
+                        rs.vcc = b.ucmp(
+                            Op_INotEqual,
+                            b.ibin(Op_BitwiseAnd,
+                                   b.ibin(Op_ShiftRightLogical, word, bit), b.uconst(1)),
+                            b.uconst(0));
+                        rs.sreg_bool[106] = rs.vcc;
+                        rs.sreg_bool_narrowed[106] = true;
+                    } else {
+                        rs.vcc = 0;
+                    }
+                }
                 return true;
             }
             if (in.opcode == 0x0f || in.opcode == 0x11 || in.opcode == 0x13 || in.opcode == 0x15 ||
@@ -16622,6 +16738,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                // code/dwords: raw stream for forward-if target checks; inherited_dead_masks keeps
                // whole-shader liveness valid when a barrier-separated body is compiled in phases.
     rs.max_vgpr = std::max(rs.max_vgpr, shader_max_vgpr(ins));
+    if (!b.cselect_b64_low_only_analysis_done) {
+        b.cselect_b64_low_only_pcs = proven_cselect_b64_low_only_pcs(ins);
+        b.cselect_b64_low_only_analysis_done = true;
+    }
     if (!rs.smem_x16_descriptor_analysis_done) {
         rs.smem_x16_descriptor_loads = proven_smem_x16_descriptor_loads(ins, rt);
         rs.smem_x16_descriptor_analysis_done = true;
@@ -18218,6 +18338,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
 
     // A scratch builder/state so emit_alu can run; its emitted code is discarded — we only want `ok`.
     SpirvCompute b; b.begin(1);
+    b.cselect_b64_low_only_pcs = proven_cselect_b64_low_only_pcs(ins);
+    b.cselect_b64_low_only_analysis_done = true;
     b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6120,15 +6120,29 @@ bool is_inplace_vadd_nc_u32_dpp_row_shr(const Rdna2Inst& in) {
         in.dst.value == in.src[1].value;
 }
 
-// Exact bounded row rotate emitted by GTA V's screen-space compute passes. The decoder has already
-// proved FI=0/no source modifiers; repeat every retained control field here so both the ordinary
-// emitter and CFG dispatcher share one fail-closed contract.
-bool is_vmin_f32_dpp_row_ror8(const Rdna2Inst& in) {
-    return in.fmt == Rdna2Format::VOP2 && in.opcode == 0x0f && in.has_dpp &&
-        in.dpp_bound_ctrl && in.dpp_ctrl == 0x128u &&
-        in.dpp_row_mask == 0xfu && in.dpp_bank_mask == 0xfu &&
-        in.dst.kind == OperandKind::VGPR && in.src[0].kind == OperandKind::VGPR &&
-        in.src[1].kind == OperandKind::VGPR;
+enum class DppRowRor8Op : uint32_t {
+    None = 0,
+    MovB32 = 1,
+    MinF32 = 2,
+    MaxF32 = 3,
+};
+
+// Exact bounded row-rotate family emitted by GTA V's screen-space compute passes. The decoder has
+// already proved FI=0/no source modifiers; repeat every retained control field here so the ordinary
+// emitter and CFG dispatcher share one fail-closed contract. VOP1 MOV has only the permuted SRC0;
+// the two VOP2 float operations combine that value with the destination lane's unpermuted SRC1.
+DppRowRor8Op dpp_row_ror8_op(const Rdna2Inst& in) {
+    if (!in.has_dpp || !in.dpp_bound_ctrl || in.dpp_ctrl != 0x128u ||
+        in.dpp_row_mask != 0xfu || in.dpp_bank_mask != 0xfu ||
+        in.dst.kind != OperandKind::VGPR || in.src[0].kind != OperandKind::VGPR)
+        return DppRowRor8Op::None;
+    if (in.fmt == Rdna2Format::VOP1 && in.opcode == 0x01)
+        return DppRowRor8Op::MovB32;
+    if (in.fmt != Rdna2Format::VOP2 || in.src[1].kind != OperandKind::VGPR)
+        return DppRowRor8Op::None;
+    if (in.opcode == 0x0f) return DppRowRor8Op::MinF32;
+    if (in.opcode == 0x10) return DppRowRor8Op::MaxF32;
+    return DppRowRor8Op::None;
 }
 
 // Exact identity-QUAD_PERM tail of the same reduction. No value crosses lanes; ROW_MASK selects
@@ -8151,7 +8165,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // when the host subgroup width differs from the guest wave width.
             if (in.has_dpp) {
                 const bool row_shr = in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11Fu;
-                if (row_shr) {
+                const bool row_ror8 = in.dpp_ctrl == 0x128u;
+                if (row_ror8) {
+                    // Direct shuffle is valid only when one native subgroup is exactly one guest
+                    // wave. Portable/default-subgroup compute is routed through synchronized CFG
+                    // scratch below. FI=0 checks the rotated source's EXEC bit and BC1 supplies 0.
+                    if (!b.is_compute || dpp_row_ror8_op(in) != DppRowRor8Op::MovB32 ||
+                        !b.native_subgroup_size) {
+                        ok = false; return true;
+                    }
+                    uint32_t valid_source = 0;
+                    const uint32_t rotated = b.subgroup_row_ror8(a, rs.exec, &valid_source);
+                    a = b.sel(valid_source, rotated, b.uconst(0));
+                } else if (row_shr) {
                     // The portable NGG vertex shell represents the one live guest lane as lane 0.
                     // Every non-zero row-right shift therefore addresses a lane before the start of
                     // its row; BOUND_CTRL=1 supplies the architectural zero.  An unbounded access
@@ -8642,10 +8668,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
                 if (row_ror8) {
-                    // The decoder admits only GTA V's full-mask, BC1, FI0 V_MIN_F32 packet. Direct
-                    // subgroup shuffle is valid only when one native subgroup is exactly one guest
-                    // wave; portable/default-subgroup compute is routed through CFG scratch below.
-                    if (!b.is_compute || !is_vmin_f32_dpp_row_ror8(in) ||
+                    // The decoder admits only GTA V's full-mask, BC1, FI0 MIN/MAX packets here.
+                    // Direct subgroup shuffle is valid only when one native subgroup is exactly one
+                    // guest wave; portable/default-subgroup compute uses CFG scratch below.
+                    if (!b.is_compute || dpp_row_ror8_op(in) == DppRowRor8Op::None ||
                         !b.native_subgroup_size) {
                         ok = false; return true;
                     }
@@ -13524,11 +13550,11 @@ bool emit_cfg_state_machine(
         return b.is_compute && is_inplace_vadd_nc_u32_dpp_row_shr(in);
     };
 
-    // GTA V's V_MIN_F32 ROW_ROR:8 has the same synchronization requirement as the add ladder:
-    // exact native waves can shuffle in the uniform dispatcher case, while portable waves publish
-    // an event-tagged source through workgroup scratch in the common phase.
-    auto compute_dpp_min_row_ror8 = [&](const Rdna2Inst& in) {
-        return b.is_compute && is_vmin_f32_dpp_row_ror8(in);
+    // GTA V's MOV/MIN/MAX ROW_ROR:8 family has the same synchronization requirement as the add
+    // ladder: exact native waves can shuffle in the uniform dispatcher case, while portable waves
+    // publish an event-tagged source through workgroup scratch in the common phase.
+    auto compute_dpp_row_ror8 = [&](const Rdna2Inst& in) {
+        return b.is_compute && dpp_row_ror8_op(in) != DppRowRor8Op::None;
     };
 
     // The row reduction is followed by an identity QUAD_PERM whose partial ROW_MASK selects rows
@@ -13672,9 +13698,9 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> compute_dpp_add_row_shr_pcs;
     std::unordered_map<uint32_t, uint32_t> compute_dpp_add_event_for_pc;
     std::set<int> compute_dpp_add_row_shr_dsts;
-    std::unordered_set<uint32_t> compute_dpp_min_row_ror8_pcs;
-    std::unordered_map<uint32_t, uint32_t> compute_dpp_min_ror8_event_for_pc;
-    std::set<int> compute_dpp_min_row_ror8_dsts;
+    std::unordered_set<uint32_t> compute_dpp_row_ror8_pcs;
+    std::unordered_map<uint32_t, uint32_t> compute_dpp_ror8_event_for_pc;
+    std::set<int> compute_dpp_row_ror8_dsts;
     uint32_t next_compute_dpp_event = 1;
     std::unordered_set<uint32_t> compute_dpp_add_row_mask_pcs;
     for (size_t i = 0; i < ins.size(); ++i) {
@@ -13721,11 +13747,11 @@ bool emit_cfg_state_machine(
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
         }
-        if (compute_dpp_min_row_ror8(in)) {
-            compute_dpp_min_row_ror8_pcs.insert(in.pc);
-            compute_dpp_min_ror8_event_for_pc.emplace(
+        if (compute_dpp_row_ror8(in)) {
+            compute_dpp_row_ror8_pcs.insert(in.pc);
+            compute_dpp_ror8_event_for_pc.emplace(
                 in.pc, next_compute_dpp_event++);
-            compute_dpp_min_row_ror8_dsts.insert(in.dst.value);
+            compute_dpp_row_ror8_dsts.insert(in.dst.value);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -13776,10 +13802,10 @@ bool emit_cfg_state_machine(
     }
     const bool has_portable_compute_dpp_add =
         !b.native_subgroup_size && !compute_dpp_add_row_shr_pcs.empty();
-    const bool has_portable_compute_dpp_min_ror8 =
-        !b.native_subgroup_size && !compute_dpp_min_row_ror8_pcs.empty();
+    const bool has_portable_compute_dpp_ror8 =
+        !b.native_subgroup_size && !compute_dpp_row_ror8_pcs.empty();
     const bool has_portable_compute_dpp =
-        has_portable_compute_dpp_add || has_portable_compute_dpp_min_ror8;
+        has_portable_compute_dpp_add || has_portable_compute_dpp_ror8;
     // Portable DPP needs a full-width value beside an event/EXEC word for every invocation. The
     // first plane remains reusable by MBCNT/votes after DPP's trailing barrier; only shaders that
     // actually contain this event pay for the second plane.
@@ -14463,7 +14489,7 @@ bool emit_cfg_state_machine(
                 swizzle_pcs.contains(in.pc) ||
                 fragment_dpp_min_row_shr_pcs.contains(in.pc) ||
                 compute_dpp_add_row_shr_pcs.contains(in.pc) ||
-                compute_dpp_min_row_ror8_pcs.contains(in.pc) ||
+                compute_dpp_row_ror8_pcs.contains(in.pc) ||
                 compute_dpp_add_row_mask_pcs.contains(in.pc) ||
                 mask_zero_compare_candidate_source(in) >= 0 ||
                 exec_saved_mask_compare_source(in) >= 0 ||
@@ -14660,17 +14686,19 @@ bool emit_cfg_state_machine(
         ? b.function_var(b.t_u32, ptr_u32) : 0;
     const uint32_t dpp_add_event_var = has_portable_compute_dpp_add
         ? b.function_var(b.t_u32, ptr_u32) : 0;
-    const uint32_t dpp_min_ror8_pending_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_pending_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_bool, ptr_bool) : 0;
-    const uint32_t dpp_min_ror8_active_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_active_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_bool, ptr_bool) : 0;
-    const uint32_t dpp_min_ror8_src0_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_src0_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_u32, ptr_u32) : 0;
-    const uint32_t dpp_min_ror8_src1_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_src1_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_u32, ptr_u32) : 0;
-    const uint32_t dpp_min_ror8_dst_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_op_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_u32, ptr_u32) : 0;
-    const uint32_t dpp_min_ror8_event_var = has_portable_compute_dpp_min_ror8
+    const uint32_t dpp_ror8_dst_var = has_portable_compute_dpp_ror8
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_ror8_event_var = has_portable_compute_dpp_ror8
         ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
@@ -14733,11 +14761,12 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_add_dst_var, zero);
         b.store_function(dpp_add_event_var, zero);
     }
-    if (has_portable_compute_dpp_min_ror8) {
-        b.store_function(dpp_min_ror8_src0_var, zero);
-        b.store_function(dpp_min_ror8_src1_var, zero);
-        b.store_function(dpp_min_ror8_dst_var, zero);
-        b.store_function(dpp_min_ror8_event_var, zero);
+    if (has_portable_compute_dpp_ror8) {
+        b.store_function(dpp_ror8_src0_var, zero);
+        b.store_function(dpp_ror8_src1_var, zero);
+        b.store_function(dpp_ror8_op_var, zero);
+        b.store_function(dpp_ror8_dst_var, zero);
+        b.store_function(dpp_ror8_event_var, zero);
     }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
@@ -14907,10 +14936,10 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_add_active_var, no);
         b.store_function(dpp_add_event_var, zero);
     }
-    if (has_portable_compute_dpp_min_ror8) {
-        b.store_function(dpp_min_ror8_pending_var, no);
-        b.store_function(dpp_min_ror8_active_var, no);
-        b.store_function(dpp_min_ror8_event_var, zero);
+    if (has_portable_compute_dpp_ror8) {
+        b.store_function(dpp_ror8_pending_var, no);
+        b.store_function(dpp_ror8_active_var, no);
+        b.store_function(dpp_ror8_event_var, zero);
     }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
@@ -14964,7 +14993,7 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* swizzle = nullptr;
         const Rdna2Inst* dpp_min_row_shr = nullptr;
         const Rdna2Inst* dpp_add_row_shr = nullptr;
-        const Rdna2Inst* dpp_min_row_ror8 = nullptr;
+        const Rdna2Inst* dpp_row_ror8 = nullptr;
         const Rdna2Inst* dpp_add_row_mask = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
@@ -14984,7 +15013,7 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_swizzle = nullptr;
             const Rdna2Inst* block_dpp_min_row_shr = nullptr;
             const Rdna2Inst* block_dpp_add_row_shr = nullptr;
-            const Rdna2Inst* block_dpp_min_row_ror8 = nullptr;
+            const Rdna2Inst* block_dpp_row_ror8 = nullptr;
             const Rdna2Inst* block_dpp_add_row_mask = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
@@ -15030,14 +15059,15 @@ bool emit_cfg_state_machine(
                     block_dpp_add_row_shr = &in;
                     break;
                 }
-                if (compute_dpp_min_row_ror8_pcs.contains(in.pc)) {
+                if (compute_dpp_row_ror8_pcs.contains(in.pc)) {
                     if (getenv("PROSPER_DBG"))
                         std::fprintf(stderr,
-                                     "[compute-cfg-dpp-min-row-ror8] "
-                                     "pc=%u dst=v%d src0=v%d src1=v%d\n",
-                                     in.pc, in.dst.value,
-                                     in.src[0].value, in.src[1].value);
-                    block_dpp_min_row_ror8 = &in;
+                                     "[compute-cfg-dpp-row-ror8] "
+                                     "pc=%u op=%u dst=v%d src0=v%d src1=v%d\n",
+                                     in.pc, static_cast<uint32_t>(dpp_row_ror8_op(in)),
+                                     in.dst.value, in.src[0].value,
+                                     in.n_src > 1 ? in.src[1].value : -1);
+                    block_dpp_row_ror8 = &in;
                     break;
                 }
                 if (compute_dpp_add_row_mask_pcs.contains(in.pc)) {
@@ -15178,7 +15208,7 @@ bool emit_cfg_state_machine(
                 // Group construction admits only one-successor plain blocks before the tail.
                 if (block_mbcnt || block_append || block_swizzle ||
                     block_dpp_min_row_shr || block_dpp_add_row_shr ||
-                    block_dpp_min_row_ror8 ||
+                    block_dpp_row_ror8 ||
                     block_dpp_add_row_mask || block_mask_compare ||
                     block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
                     block_vopc_mask_compare ||
@@ -15194,7 +15224,7 @@ bool emit_cfg_state_machine(
             swizzle = block_swizzle;
             dpp_min_row_shr = block_dpp_min_row_shr;
             dpp_add_row_shr = block_dpp_add_row_shr;
-            dpp_min_row_ror8 = block_dpp_min_row_ror8;
+            dpp_row_ror8 = block_dpp_row_ror8;
             dpp_add_row_mask = block_dpp_add_row_mask;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
@@ -15357,19 +15387,23 @@ bool emit_cfg_state_machine(
                 b.store_function(dpp_add_event_var, b.uconst(event->second));
             }
         }
-        if (dpp_min_row_ror8) {
-            if (!compute_dpp_min_row_ror8(*dpp_min_row_ror8))
-                return reject_cfg(dpp_min_row_ror8->pc, "dpp-min-row-ror8-contract");
-            const auto event = compute_dpp_min_ror8_event_for_pc.find(dpp_min_row_ror8->pc);
-            if (event == compute_dpp_min_ror8_event_for_pc.end())
-                return reject_cfg(dpp_min_row_ror8->pc, "dpp-min-row-ror8-event");
-            const int dst = dpp_min_row_ror8->dst.value;
+        if (dpp_row_ror8) {
+            const DppRowRor8Op operation = dpp_row_ror8_op(*dpp_row_ror8);
+            if (!compute_dpp_row_ror8(*dpp_row_ror8))
+                return reject_cfg(dpp_row_ror8->pc, "dpp-row-ror8-contract");
+            const auto event = compute_dpp_ror8_event_for_pc.find(dpp_row_ror8->pc);
+            if (event == compute_dpp_ror8_event_for_pc.end())
+                return reject_cfg(dpp_row_ror8->pc, "dpp-row-ror8-event");
+            const int dst = dpp_row_ror8->dst.value;
             const auto old = state.vreg.find(dst);
-            const auto src0 = state.vreg.find(dpp_min_row_ror8->src[0].value);
-            const auto src1 = state.vreg.find(dpp_min_row_ror8->src[1].value);
+            const auto src0 = state.vreg.find(dpp_row_ror8->src[0].value);
             const uint32_t old_value = old == state.vreg.end() ? zero : old->second;
             const uint32_t src0_value = src0 == state.vreg.end() ? zero : src0->second;
-            const uint32_t src1_value = src1 == state.vreg.end() ? zero : src1->second;
+            uint32_t src1_value = zero;
+            if (dpp_row_ror8->n_src > 1) {
+                const auto src1 = state.vreg.find(dpp_row_ror8->src[1].value);
+                src1_value = src1 == state.vreg.end() ? zero : src1->second;
+            }
             if (b.native_subgroup_size) {
                 // One exact native subgroup is one guest wave and this case is subgroup-uniform.
                 // FI=0 checks the rotated source's EXEC bit; BC1 substitutes zero when it is clear.
@@ -15377,20 +15411,26 @@ bool emit_cfg_state_machine(
                 const uint32_t rotated = b.subgroup_row_ror8(
                     src0_value, state.exec, &valid_source);
                 const uint32_t bounded = b.sel(valid_source, rotated, zero);
-                const uint32_t result = b.fext2(Glsl_NMin, bounded, src1_value);
+                uint32_t result = bounded;
+                if (operation == DppRowRor8Op::MinF32)
+                    result = b.fext2(Glsl_NMin, bounded, src1_value);
+                else if (operation == DppRowRor8Op::MaxF32)
+                    result = b.fext2(Glsl_NMax, bounded, src1_value);
                 state.vreg[dst] = b.sel(state.exec, result, old_value);
                 for (auto& vg : state.vgpr_lane_slots)
                     if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
                 for (auto& vg : state.vgpr_lane_mask_slots)
                     if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
             } else {
-                b.store_function(dpp_min_ror8_pending_var, yes);
-                b.store_function(dpp_min_ror8_active_var, state.exec);
-                b.store_function(dpp_min_ror8_src0_var, src0_value);
-                b.store_function(dpp_min_ror8_src1_var, src1_value);
-                b.store_function(dpp_min_ror8_dst_var,
+                b.store_function(dpp_ror8_pending_var, yes);
+                b.store_function(dpp_ror8_active_var, state.exec);
+                b.store_function(dpp_ror8_src0_var, src0_value);
+                b.store_function(dpp_ror8_src1_var, src1_value);
+                b.store_function(dpp_ror8_op_var,
+                    b.uconst(static_cast<uint32_t>(operation)));
+                b.store_function(dpp_ror8_dst_var,
                     b.uconst(static_cast<uint32_t>(dst)));
-                b.store_function(dpp_min_ror8_event_var, b.uconst(event->second));
+                b.store_function(dpp_ror8_event_var, b.uconst(event->second));
             }
         }
         if (dpp_add_row_mask) {
@@ -15586,10 +15626,9 @@ bool emit_cfg_state_machine(
             if (!set_next(dpp_add_row_shr->pc + dpp_add_row_shr->len_dwords))
                 return reject_cfg(dpp_add_row_shr->pc,
                                   "dpp-add-row-shr-successor");
-        } else if (dpp_min_row_ror8) {
-            if (!set_next(dpp_min_row_ror8->pc + dpp_min_row_ror8->len_dwords))
-                return reject_cfg(dpp_min_row_ror8->pc,
-                                  "dpp-min-row-ror8-successor");
+        } else if (dpp_row_ror8) {
+            if (!set_next(dpp_row_ror8->pc + dpp_row_ror8->len_dwords))
+                return reject_cfg(dpp_row_ror8->pc, "dpp-row-ror8-successor");
         } else if (dpp_add_row_mask) {
             if (!set_next(dpp_add_row_mask->pc + dpp_add_row_mask->len_dwords))
                 return reject_cfg(dpp_add_row_mask->pc,
@@ -15911,17 +15950,17 @@ bool emit_cfg_state_machine(
     b.barrier();
     }
 
-    // Portable compute DPP V_MIN_F32 ROW_ROR:8 common phase. This is deliberately separate from
-    // the ROW_SHR add phase above: each phase publishes its own pending state, consumes it between
-    // two workgroup barriers, and only then permits the other operation to reuse the scratch planes.
-    // The scan assigned disjoint event IDs across both operation families as a second guard against
-    // a future phase combination accidentally accepting metadata from the other DPP instruction.
-    if (has_portable_compute_dpp_min_ror8) {
-    const uint32_t dpp_pending = b.load_function(b.t_bool, dpp_min_ror8_pending_var);
-    const uint32_t dpp_active = b.load_function(b.t_bool, dpp_min_ror8_active_var);
-    const uint32_t dpp_src0 = b.load_function(b.t_u32, dpp_min_ror8_src0_var);
-    const uint32_t dpp_src1 = b.load_function(b.t_u32, dpp_min_ror8_src1_var);
-    const uint32_t dpp_event = b.load_function(b.t_u32, dpp_min_ror8_event_var);
+    // Portable compute DPP ROW_ROR:8 common phase. This is deliberately separate from the ROW_SHR
+    // add phase above: each phase publishes its own pending state, consumes it between two workgroup
+    // barriers, and only then permits the other operation to reuse the scratch planes. Event IDs
+    // distinguish static sites; the operation tag distinguishes MOV/MIN/MAX semantics per invocation.
+    if (has_portable_compute_dpp_ror8) {
+    const uint32_t dpp_pending = b.load_function(b.t_bool, dpp_ror8_pending_var);
+    const uint32_t dpp_active = b.load_function(b.t_bool, dpp_ror8_active_var);
+    const uint32_t dpp_src0 = b.load_function(b.t_u32, dpp_ror8_src0_var);
+    const uint32_t dpp_src1 = b.load_function(b.t_u32, dpp_ror8_src1_var);
+    const uint32_t dpp_operation = b.load_function(b.t_u32, dpp_ror8_op_var);
+    const uint32_t dpp_event = b.load_function(b.t_u32, dpp_ror8_event_var);
     b.cfg_scratch_store(
         b.ibin(Op_IAdd, b.uconst(dpp_value_base), b.linear_localid), dpp_src0);
     const uint32_t dpp_metadata = b.sel(
@@ -15959,14 +15998,23 @@ bool emit_cfg_state_machine(
         b.land(dpp_source_active,
                b.ucmp(Op_IEqual, dpp_source_event, dpp_event)));
     // FI=0 requires an EXEC-active source. BOUND_CTRL=1 supplies zero when that source is invalid,
-    // but the active destination still writes the resulting NMin with its lane-local SRC1.
+    // but the active destination still writes the operation's result. MOV uses the bounded source;
+    // MIN/MAX combine it with the destination lane's unpermuted SRC1.
     const uint32_t dpp_bounded = b.sel(dpp_valid_source, dpp_rotated, zero);
-    const uint32_t dpp_result = b.fext2(Glsl_NMin, dpp_bounded, dpp_src1);
+    uint32_t dpp_result = dpp_bounded;
+    dpp_result = b.sel(
+        b.ucmp(Op_IEqual, dpp_operation,
+               b.uconst(static_cast<uint32_t>(DppRowRor8Op::MinF32))),
+        b.fext2(Glsl_NMin, dpp_bounded, dpp_src1), dpp_result);
+    dpp_result = b.sel(
+        b.ucmp(Op_IEqual, dpp_operation,
+               b.uconst(static_cast<uint32_t>(DppRowRor8Op::MaxF32))),
+        b.fext2(Glsl_NMax, dpp_bounded, dpp_src1), dpp_result);
     const uint32_t dpp_write = b.land(dpp_pending, dpp_active);
-    const uint32_t dpp_dst = b.load_function(b.t_u32, dpp_min_ror8_dst_var);
-    for (int reg : compute_dpp_min_row_ror8_dsts) {
+    const uint32_t dpp_dst = b.load_function(b.t_u32, dpp_ror8_dst_var);
+    for (int reg : compute_dpp_row_ror8_dsts) {
         const auto kv = vv.find(reg);
-        if (kv == vv.end()) return reject_cfg(0, "missing-dpp-min-row-ror8-dst");
+        if (kv == vv.end()) return reject_cfg(0, "missing-dpp-row-ror8-dst");
         const uint32_t selected = b.land(
             dpp_write, b.ucmp(Op_IEqual, dpp_dst,
                               b.uconst(static_cast<uint32_t>(reg))));
@@ -15976,7 +16024,7 @@ bool emit_cfg_state_machine(
     // A physical destination definition invalidates scalar lane aliases even when EXEC suppresses
     // this invocation's data write, matching predicate_write and the existing DPP add phase.
     for (const auto& kv : lv) {
-        if (!compute_dpp_min_row_ror8_dsts.contains(kv.first.first)) continue;
+        if (!compute_dpp_row_ror8_dsts.contains(kv.first.first)) continue;
         const uint32_t selected = b.land(
             dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
                                 b.uconst(static_cast<uint32_t>(kv.first.first))));
@@ -15984,7 +16032,7 @@ bool emit_cfg_state_machine(
         b.store_function(kv.second, b.sel(selected, zero, old));
     }
     for (const auto& kv : lmv) {
-        if (!compute_dpp_min_row_ror8_dsts.contains(kv.first.first)) continue;
+        if (!compute_dpp_row_ror8_dsts.contains(kv.first.first)) continue;
         const uint32_t selected = b.land(
             dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
                                 b.uconst(static_cast<uint32_t>(kv.first.first))));
@@ -16610,7 +16658,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     ins.begin(), ins.begin() + phased.end_index,
                     [](const Rdna2Inst& in) {
                         return is_inplace_vadd_nc_u32_dpp_row_shr(in) ||
-                            is_vmin_f32_dpp_row_ror8(in);
+                            dpp_row_ror8_op(in) != DppRowRor8Op::None;
                     });
                 const uint32_t scratch_dwords = padded_lanes +
                     (has_portable_dpp ? padded_lanes : 0u) + wave_count + 1;
@@ -17318,12 +17366,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                              b.code.size() - checkpoint);
             return -1;
         };
-        const bool portable_compute_dpp_min_ror8 = b.is_compute &&
+        const bool portable_compute_dpp_ror8 = b.is_compute &&
             !b.native_subgroup_size &&
             std::any_of(ins.begin(), ins.end(), [](const Rdna2Inst& in) {
-                return is_vmin_f32_dpp_row_ror8(in);
+                return dpp_row_ror8_op(in) != DppRowRor8Op::None;
             });
-        if (allow_cfg_dispatcher && portable_compute_dpp_min_ror8) {
+        if (allow_cfg_dispatcher && portable_compute_dpp_ror8) {
             // The generic straight-line/structured emitter can use ROW_ROR only when the backend
             // guarantees one exact native guest wave. Otherwise the complete program must enter the
             // synchronized dispatcher so every invocation reaches both scratch barriers uniformly.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -6120,6 +6120,17 @@ bool is_inplace_vadd_nc_u32_dpp_row_shr(const Rdna2Inst& in) {
         in.dst.value == in.src[1].value;
 }
 
+// Exact bounded row rotate emitted by GTA V's screen-space compute passes. The decoder has already
+// proved FI=0/no source modifiers; repeat every retained control field here so both the ordinary
+// emitter and CFG dispatcher share one fail-closed contract.
+bool is_vmin_f32_dpp_row_ror8(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::VOP2 && in.opcode == 0x0f && in.has_dpp &&
+        in.dpp_bound_ctrl && in.dpp_ctrl == 0x128u &&
+        in.dpp_row_mask == 0xfu && in.dpp_bank_mask == 0xfu &&
+        in.dst.kind == OperandKind::VGPR && in.src[0].kind == OperandKind::VGPR &&
+        in.src[1].kind == OperandKind::VGPR;
+}
+
 // Exact identity-QUAD_PERM tail of the same reduction. No value crosses lanes; ROW_MASK selects
 // architectural DPP16 rows 1 and 3, while the other rows preserve VDST.
 bool is_vadd_nc_u32_dpp_partial_row(const Rdna2Inst& in) {
@@ -8631,12 +8642,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
                 if (row_ror8) {
-                    // The decoder admits only GTA V's full-mask, BC1, FI0 V_MIN_F32 packet. Repeat
-                    // that contract at the production emission site: a straight-line region is
-                    // wave-visible, while structured compute requires one exact native guest wave.
-                    if (!b.is_compute || in.opcode != 0x0fu || !in.dpp_bound_ctrl ||
-                        in.dpp_row_mask != 0xfu || in.dpp_bank_mask != 0xfu ||
-                        (!allow_wave && !b.native_subgroup_size)) {
+                    // The decoder admits only GTA V's full-mask, BC1, FI0 V_MIN_F32 packet. Direct
+                    // subgroup shuffle is valid only when one native subgroup is exactly one guest
+                    // wave; portable/default-subgroup compute is routed through CFG scratch below.
+                    if (!b.is_compute || !is_vmin_f32_dpp_row_ror8(in) ||
+                        !b.native_subgroup_size) {
                         ok = false; return true;
                     }
                     uint32_t valid_source = 0;
@@ -13484,6 +13494,13 @@ bool emit_cfg_state_machine(
         return b.is_compute && is_inplace_vadd_nc_u32_dpp_row_shr(in);
     };
 
+    // GTA V's V_MIN_F32 ROW_ROR:8 has the same synchronization requirement as the add ladder:
+    // exact native waves can shuffle in the uniform dispatcher case, while portable waves publish
+    // an event-tagged source through workgroup scratch in the common phase.
+    auto compute_dpp_min_row_ror8 = [&](const Rdna2Inst& in) {
+        return b.is_compute && is_vmin_f32_dpp_row_ror8(in);
+    };
+
     // The row reduction is followed by an identity QUAD_PERM whose partial ROW_MASK selects rows
     // 1 and 3. No value crosses lanes: selected EXEC-active lanes add their current VDST/SRC0 to a
     // distinct SRC1, while masked rows preserve VDST. Keeping this a dedicated dispatcher case
@@ -13625,6 +13642,10 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> compute_dpp_add_row_shr_pcs;
     std::unordered_map<uint32_t, uint32_t> compute_dpp_add_event_for_pc;
     std::set<int> compute_dpp_add_row_shr_dsts;
+    std::unordered_set<uint32_t> compute_dpp_min_row_ror8_pcs;
+    std::unordered_map<uint32_t, uint32_t> compute_dpp_min_ror8_event_for_pc;
+    std::set<int> compute_dpp_min_row_ror8_dsts;
+    uint32_t next_compute_dpp_event = 1;
     std::unordered_set<uint32_t> compute_dpp_add_row_mask_pcs;
     for (size_t i = 0; i < ins.size(); ++i) {
         const auto& in = ins[i];
@@ -13664,8 +13685,17 @@ bool emit_cfg_state_machine(
         if (compute_dpp_add_row_shr(in)) {
             compute_dpp_add_row_shr_pcs.insert(in.pc);
             compute_dpp_add_event_for_pc.emplace(
-                in.pc, static_cast<uint32_t>(compute_dpp_add_event_for_pc.size() + 1));
+                in.pc, next_compute_dpp_event++);
             compute_dpp_add_row_shr_dsts.insert(in.dst.value);
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (compute_dpp_min_row_ror8(in)) {
+            compute_dpp_min_row_ror8_pcs.insert(in.pc);
+            compute_dpp_min_ror8_event_for_pc.emplace(
+                in.pc, next_compute_dpp_event++);
+            compute_dpp_min_row_ror8_dsts.insert(in.dst.value);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -13716,13 +13746,17 @@ bool emit_cfg_state_machine(
     }
     const bool has_portable_compute_dpp_add =
         !b.native_subgroup_size && !compute_dpp_add_row_shr_pcs.empty();
+    const bool has_portable_compute_dpp_min_ror8 =
+        !b.native_subgroup_size && !compute_dpp_min_row_ror8_pcs.empty();
+    const bool has_portable_compute_dpp =
+        has_portable_compute_dpp_add || has_portable_compute_dpp_min_ror8;
     // Portable DPP needs a full-width value beside an event/EXEC word for every invocation. The
     // first plane remains reusable by MBCNT/votes after DPP's trailing barrier; only shaders that
     // actually contain this event pay for the second plane.
-    const uint32_t dpp_add_value_base = 0;
-    const uint32_t dpp_add_metadata_base = padded_lanes;
+    const uint32_t dpp_value_base = 0;
+    const uint32_t dpp_metadata_base = padded_lanes;
     const uint32_t wave_result_base = padded_lanes +
-        (has_portable_compute_dpp_add ? padded_lanes : 0u);
+        (has_portable_compute_dpp ? padded_lanes : 0u);
     const uint32_t group_active_slot = wave_result_base + wave_count;
     if (b.is_compute && !b.native_subgroup_size &&
         !b.declare_cfg_scratch(group_active_slot + 1))
@@ -14399,6 +14433,7 @@ bool emit_cfg_state_machine(
                 swizzle_pcs.contains(in.pc) ||
                 fragment_dpp_min_row_shr_pcs.contains(in.pc) ||
                 compute_dpp_add_row_shr_pcs.contains(in.pc) ||
+                compute_dpp_min_row_ror8_pcs.contains(in.pc) ||
                 compute_dpp_add_row_mask_pcs.contains(in.pc) ||
                 mask_zero_compare_candidate_source(in) >= 0 ||
                 exec_saved_mask_compare_source(in) >= 0 ||
@@ -14595,6 +14630,18 @@ bool emit_cfg_state_machine(
         ? b.function_var(b.t_u32, ptr_u32) : 0;
     const uint32_t dpp_add_event_var = has_portable_compute_dpp_add
         ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_ror8_pending_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_min_ror8_active_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t dpp_min_ror8_src0_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_ror8_src1_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_ror8_dst_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t dpp_min_ror8_event_var = has_portable_compute_dpp_min_ror8
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -14655,6 +14702,12 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_add_amount_var, zero);
         b.store_function(dpp_add_dst_var, zero);
         b.store_function(dpp_add_event_var, zero);
+    }
+    if (has_portable_compute_dpp_min_ror8) {
+        b.store_function(dpp_min_ror8_src0_var, zero);
+        b.store_function(dpp_min_ror8_src1_var, zero);
+        b.store_function(dpp_min_ror8_dst_var, zero);
+        b.store_function(dpp_min_ror8_event_var, zero);
     }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
@@ -14824,6 +14877,11 @@ bool emit_cfg_state_machine(
         b.store_function(dpp_add_active_var, no);
         b.store_function(dpp_add_event_var, zero);
     }
+    if (has_portable_compute_dpp_min_ror8) {
+        b.store_function(dpp_min_ror8_pending_var, no);
+        b.store_function(dpp_min_ror8_active_var, no);
+        b.store_function(dpp_min_ror8_event_var, zero);
+    }
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -14876,6 +14934,7 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* swizzle = nullptr;
         const Rdna2Inst* dpp_min_row_shr = nullptr;
         const Rdna2Inst* dpp_add_row_shr = nullptr;
+        const Rdna2Inst* dpp_min_row_ror8 = nullptr;
         const Rdna2Inst* dpp_add_row_mask = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
@@ -14895,6 +14954,7 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_swizzle = nullptr;
             const Rdna2Inst* block_dpp_min_row_shr = nullptr;
             const Rdna2Inst* block_dpp_add_row_shr = nullptr;
+            const Rdna2Inst* block_dpp_min_row_ror8 = nullptr;
             const Rdna2Inst* block_dpp_add_row_mask = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
@@ -14938,6 +14998,16 @@ bool emit_cfg_state_machine(
                                      in.pc, in.dst.value,
                                      static_cast<uint32_t>(in.dpp_ctrl - 0x110u));
                     block_dpp_add_row_shr = &in;
+                    break;
+                }
+                if (compute_dpp_min_row_ror8_pcs.contains(in.pc)) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-cfg-dpp-min-row-ror8] "
+                                     "pc=%u dst=v%d src0=v%d src1=v%d\n",
+                                     in.pc, in.dst.value,
+                                     in.src[0].value, in.src[1].value);
+                    block_dpp_min_row_ror8 = &in;
                     break;
                 }
                 if (compute_dpp_add_row_mask_pcs.contains(in.pc)) {
@@ -15078,6 +15148,7 @@ bool emit_cfg_state_machine(
                 // Group construction admits only one-successor plain blocks before the tail.
                 if (block_mbcnt || block_append || block_swizzle ||
                     block_dpp_min_row_shr || block_dpp_add_row_shr ||
+                    block_dpp_min_row_ror8 ||
                     block_dpp_add_row_mask || block_mask_compare ||
                     block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
                     block_vopc_mask_compare ||
@@ -15093,6 +15164,7 @@ bool emit_cfg_state_machine(
             swizzle = block_swizzle;
             dpp_min_row_shr = block_dpp_min_row_shr;
             dpp_add_row_shr = block_dpp_add_row_shr;
+            dpp_min_row_ror8 = block_dpp_min_row_ror8;
             dpp_add_row_mask = block_dpp_add_row_mask;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
@@ -15253,6 +15325,42 @@ bool emit_cfg_state_machine(
                 b.store_function(dpp_add_dst_var,
                     b.uconst(static_cast<uint32_t>(dst)));
                 b.store_function(dpp_add_event_var, b.uconst(event->second));
+            }
+        }
+        if (dpp_min_row_ror8) {
+            if (!compute_dpp_min_row_ror8(*dpp_min_row_ror8))
+                return reject_cfg(dpp_min_row_ror8->pc, "dpp-min-row-ror8-contract");
+            const auto event = compute_dpp_min_ror8_event_for_pc.find(dpp_min_row_ror8->pc);
+            if (event == compute_dpp_min_ror8_event_for_pc.end())
+                return reject_cfg(dpp_min_row_ror8->pc, "dpp-min-row-ror8-event");
+            const int dst = dpp_min_row_ror8->dst.value;
+            const auto old = state.vreg.find(dst);
+            const auto src0 = state.vreg.find(dpp_min_row_ror8->src[0].value);
+            const auto src1 = state.vreg.find(dpp_min_row_ror8->src[1].value);
+            const uint32_t old_value = old == state.vreg.end() ? zero : old->second;
+            const uint32_t src0_value = src0 == state.vreg.end() ? zero : src0->second;
+            const uint32_t src1_value = src1 == state.vreg.end() ? zero : src1->second;
+            if (b.native_subgroup_size) {
+                // One exact native subgroup is one guest wave and this case is subgroup-uniform.
+                // FI=0 checks the rotated source's EXEC bit; BC1 substitutes zero when it is clear.
+                uint32_t valid_source = 0;
+                const uint32_t rotated = b.subgroup_row_ror8(
+                    src0_value, state.exec, &valid_source);
+                const uint32_t bounded = b.sel(valid_source, rotated, zero);
+                const uint32_t result = b.fext2(Glsl_NMin, bounded, src1_value);
+                state.vreg[dst] = b.sel(state.exec, result, old_value);
+                for (auto& vg : state.vgpr_lane_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = zero;
+                for (auto& vg : state.vgpr_lane_mask_slots)
+                    if (vg.first == dst) for (auto& slot : vg.second) slot.second = no;
+            } else {
+                b.store_function(dpp_min_ror8_pending_var, yes);
+                b.store_function(dpp_min_ror8_active_var, state.exec);
+                b.store_function(dpp_min_ror8_src0_var, src0_value);
+                b.store_function(dpp_min_ror8_src1_var, src1_value);
+                b.store_function(dpp_min_ror8_dst_var,
+                    b.uconst(static_cast<uint32_t>(dst)));
+                b.store_function(dpp_min_ror8_event_var, b.uconst(event->second));
             }
         }
         if (dpp_add_row_mask) {
@@ -15448,6 +15556,10 @@ bool emit_cfg_state_machine(
             if (!set_next(dpp_add_row_shr->pc + dpp_add_row_shr->len_dwords))
                 return reject_cfg(dpp_add_row_shr->pc,
                                   "dpp-add-row-shr-successor");
+        } else if (dpp_min_row_ror8) {
+            if (!set_next(dpp_min_row_ror8->pc + dpp_min_row_ror8->len_dwords))
+                return reject_cfg(dpp_min_row_ror8->pc,
+                                  "dpp-min-row-ror8-successor");
         } else if (dpp_add_row_mask) {
             if (!set_next(dpp_add_row_mask->pc + dpp_add_row_mask->len_dwords))
                 return reject_cfg(dpp_add_row_mask->pc,
@@ -15699,7 +15811,7 @@ bool emit_cfg_state_machine(
     const uint32_t dpp_source = b.load_function(b.t_u32, dpp_add_source_var);
     const uint32_t dpp_event = b.load_function(b.t_u32, dpp_add_event_var);
     b.cfg_scratch_store(
-        b.ibin(Op_IAdd, b.uconst(dpp_add_value_base), b.linear_localid), dpp_source);
+        b.ibin(Op_IAdd, b.uconst(dpp_value_base), b.linear_localid), dpp_source);
     const uint32_t dpp_metadata = b.sel(
         dpp_pending,
         b.ibin(Op_BitwiseOr,
@@ -15707,7 +15819,7 @@ bool emit_cfg_state_machine(
                b.sel(dpp_active, b.uconst(1), zero)),
         zero);
     b.cfg_scratch_store(
-        b.ibin(Op_IAdd, b.uconst(dpp_add_metadata_base), b.linear_localid),
+        b.ibin(Op_IAdd, b.uconst(dpp_metadata_base), b.linear_localid),
         dpp_metadata);
     b.barrier();
 
@@ -15723,9 +15835,9 @@ bool emit_cfg_state_machine(
         b.ibin(Op_ISub, b.linear_localid, dpp_amount),
         b.linear_localid);
     const uint32_t dpp_shifted = b.cfg_scratch_load(
-        b.ibin(Op_IAdd, b.uconst(dpp_add_value_base), dpp_source_index));
+        b.ibin(Op_IAdd, b.uconst(dpp_value_base), dpp_source_index));
     const uint32_t dpp_source_metadata = b.cfg_scratch_load(
-        b.ibin(Op_IAdd, b.uconst(dpp_add_metadata_base), dpp_source_index));
+        b.ibin(Op_IAdd, b.uconst(dpp_metadata_base), dpp_source_index));
     const uint32_t dpp_source_event = b.ibin(
         Op_ShiftRightLogical, dpp_source_metadata, b.uconst(1));
     const uint32_t dpp_source_active = b.ucmp(
@@ -15760,6 +15872,89 @@ bool emit_cfg_state_machine(
     }
     for (const auto& kv : lmv) {
         if (!compute_dpp_add_row_shr_dsts.contains(kv.first.first)) continue;
+        const uint32_t selected = b.land(
+            dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    b.barrier();
+    }
+
+    // Portable compute DPP V_MIN_F32 ROW_ROR:8 common phase. This is deliberately separate from
+    // the ROW_SHR add phase above: each phase publishes its own pending state, consumes it between
+    // two workgroup barriers, and only then permits the other operation to reuse the scratch planes.
+    // The scan assigned disjoint event IDs across both operation families as a second guard against
+    // a future phase combination accidentally accepting metadata from the other DPP instruction.
+    if (has_portable_compute_dpp_min_ror8) {
+    const uint32_t dpp_pending = b.load_function(b.t_bool, dpp_min_ror8_pending_var);
+    const uint32_t dpp_active = b.load_function(b.t_bool, dpp_min_ror8_active_var);
+    const uint32_t dpp_src0 = b.load_function(b.t_u32, dpp_min_ror8_src0_var);
+    const uint32_t dpp_src1 = b.load_function(b.t_u32, dpp_min_ror8_src1_var);
+    const uint32_t dpp_event = b.load_function(b.t_u32, dpp_min_ror8_event_var);
+    b.cfg_scratch_store(
+        b.ibin(Op_IAdd, b.uconst(dpp_value_base), b.linear_localid), dpp_src0);
+    const uint32_t dpp_metadata = b.sel(
+        dpp_pending,
+        b.ibin(Op_BitwiseOr,
+               b.ibin(Op_ShiftLeftLogical, dpp_event, b.uconst(1)),
+               b.sel(dpp_active, b.uconst(1), zero)),
+        zero);
+    b.cfg_scratch_store(
+        b.ibin(Op_IAdd, b.uconst(dpp_metadata_base), b.linear_localid),
+        dpp_metadata);
+    b.barrier();
+
+    // XOR 8 exchanges the two eight-lane halves without crossing an architectural DPP16 row.
+    // This uses guest linear-local order, not the implementation-defined Vulkan subgroup lane ID.
+    const uint32_t dpp_rotated_index = b.ibin(
+        Op_BitwiseXor, b.linear_localid, b.uconst(8));
+    const uint32_t dpp_source_in_bounds = b.ucmp(
+        Op_ULessThan, dpp_rotated_index, b.uconst(b.local_count));
+    // A partial final DPP16 row has no invocation to initialize the rotated slot. Address this
+    // lane's initialized placeholder and let BC1's validity gate supply zero for the missing peer.
+    const uint32_t dpp_source_index = b.sel(
+        dpp_source_in_bounds, dpp_rotated_index, b.linear_localid);
+    const uint32_t dpp_rotated = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(dpp_value_base), dpp_source_index));
+    const uint32_t dpp_source_metadata = b.cfg_scratch_load(
+        b.ibin(Op_IAdd, b.uconst(dpp_metadata_base), dpp_source_index));
+    const uint32_t dpp_source_event = b.ibin(
+        Op_ShiftRightLogical, dpp_source_metadata, b.uconst(1));
+    const uint32_t dpp_source_active = b.ucmp(
+        Op_INotEqual,
+        b.ibin(Op_BitwiseAnd, dpp_source_metadata, b.uconst(1)), zero);
+    const uint32_t dpp_valid_source = b.land(
+        dpp_source_in_bounds,
+        b.land(dpp_source_active,
+               b.ucmp(Op_IEqual, dpp_source_event, dpp_event)));
+    // FI=0 requires an EXEC-active source. BOUND_CTRL=1 supplies zero when that source is invalid,
+    // but the active destination still writes the resulting NMin with its lane-local SRC1.
+    const uint32_t dpp_bounded = b.sel(dpp_valid_source, dpp_rotated, zero);
+    const uint32_t dpp_result = b.fext2(Glsl_NMin, dpp_bounded, dpp_src1);
+    const uint32_t dpp_write = b.land(dpp_pending, dpp_active);
+    const uint32_t dpp_dst = b.load_function(b.t_u32, dpp_min_ror8_dst_var);
+    for (int reg : compute_dpp_min_row_ror8_dsts) {
+        const auto kv = vv.find(reg);
+        if (kv == vv.end()) return reject_cfg(0, "missing-dpp-min-row-ror8-dst");
+        const uint32_t selected = b.land(
+            dpp_write, b.ucmp(Op_IEqual, dpp_dst,
+                              b.uconst(static_cast<uint32_t>(reg))));
+        const uint32_t old = b.load_function(b.t_u32, kv->second);
+        b.store_function(kv->second, b.sel(selected, dpp_result, old));
+    }
+    // A physical destination definition invalidates scalar lane aliases even when EXEC suppresses
+    // this invocation's data write, matching predicate_write and the existing DPP add phase.
+    for (const auto& kv : lv) {
+        if (!compute_dpp_min_row_ror8_dsts.contains(kv.first.first)) continue;
+        const uint32_t selected = b.land(
+            dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
+                                b.uconst(static_cast<uint32_t>(kv.first.first))));
+        const uint32_t old = b.load_function(b.t_u32, kv.second);
+        b.store_function(kv.second, b.sel(selected, zero, old));
+    }
+    for (const auto& kv : lmv) {
+        if (!compute_dpp_min_row_ror8_dsts.contains(kv.first.first)) continue;
         const uint32_t selected = b.land(
             dpp_pending, b.ucmp(Op_IEqual, dpp_dst,
                                 b.uconst(static_cast<uint32_t>(kv.first.first))));
@@ -17092,6 +17287,25 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                              b.code.size() - checkpoint);
             return -1;
         };
+        const bool portable_compute_dpp_min_ror8 = b.is_compute &&
+            !b.native_subgroup_size &&
+            std::any_of(ins.begin(), ins.end(), [](const Rdna2Inst& in) {
+                return is_vmin_f32_dpp_row_ror8(in);
+            });
+        if (allow_cfg_dispatcher && portable_compute_dpp_min_ror8) {
+            // The generic straight-line/structured emitter can use ROW_ROR only when the backend
+            // guarantees one exact native guest wave. Otherwise the complete program must enter the
+            // synchronized dispatcher so every invocation reaches both scratch barriers uniformly.
+            if (!cfg_dispatch_safe) {
+                log_recompile_diagnostic(
+                    b.diagnostic, "compute-cfg-reject", "terminal",
+                    "reason=portable-dpp-row-ror8-dispatcher-unsafe guest-barrier=1");
+                return false;
+            }
+            const int emitted = try_cfg_dispatcher();
+            if (emitted > 0) return true;
+            return false;
+        }
         if (allow_cfg_dispatcher && complex_compute_cfg && (cf_rejected || Ls.empty())) {
             const int emitted = try_cfg_dispatcher();
             if (emitted > 0) return true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5919,6 +5919,17 @@ bool is_scalar_cselect_b32_to_vcc_lo(const Rdna2Inst& in) {
         in.src[1].kind == OperandKind::InlineInt && in.src[1].value == 0;
 }
 
+// GTA V's Wave32 terrain kernel deliberately uses VCC_HI as an ordinary scalar word. Keep the
+// syntactic exception in one place so the dispatcher and emitter cannot disagree about whether the
+// physical register starts a mask or scalar-data lifetime. Callers must separately prove an exact
+// native Wave32 subgroup before materializing EXEC_LO as a complete scalar dword.
+bool is_gtav_wave32_vcchi_scalar_packet(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::SOP2 && in.opcode == 0x0e &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value == 107 &&
+        in.src[0].kind == OperandKind::Special && in.src[0].value == 126 &&
+        in.src[1].kind == OperandKind::Literal && in.literal == 0x0fffffffu;
+}
+
 bool allows_compute_scalar_vcc_bridge(const SpirvCompute& b) {
     return b.is_compute && b.allow_b32_masks && b.wave_size == 32;
 }
@@ -7293,6 +7304,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::SOP2: {
+            const bool gtav_wave32_vcchi_scalar_packet =
+                allows_compute_scalar_vcc_bridge(b) && b.native_subgroup_size == 32 &&
+                is_gtav_wave32_vcchi_scalar_packet(in);
             if (b.allow_b32_masks &&
                 (b.is_fragment || (b.is_compute && b.wave_size == 32)) &&
                 in.opcode == 0x0a &&
@@ -7367,6 +7381,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             }
             if (b.allow_b32_masks &&
                 (b.is_fragment || (b.is_compute && b.wave_size == 32)) &&
+                !gtav_wave32_vcchi_scalar_packet &&
                 (in.opcode == 0x0e || in.opcode == 0x10 || in.opcode == 0x12 ||
                  in.opcode == 0x14 || in.opcode == 0x16 || in.opcode == 0x18 ||
                  in.opcode == 0x1a || in.opcode == 0x1c) &&
@@ -7397,6 +7412,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     if (o.kind == OperandKind::InlineInt)
                         return inline_int_mask_bit(b, o.value);
+                    if (o.kind == OperandKind::Literal)
+                        return inline_int_mask_bit(
+                            b, static_cast<int32_t>(in.literal));
                     return 0;
                 };
                 const uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
@@ -7808,14 +7826,16 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             return false;
                     }
                 };
-                if ((!b.is_fragment && !b.is_compute) ||
+                if ((!b.is_fragment && !b.is_compute) || gtav_wave32_vcchi_scalar_packet ||
                     (has_scalar_data(in.src[0]) && has_scalar_data(in.src[1]))) {
                     // The vertex shell is a complete one-lane virtual wave, so its scalar VCC
                     // dwords are representable: LO starts as {bit0=vcc}, HI as zero, and later B32
-                    // operations may use either as ordinary scratch. Fragment/compute shaders also
-                    // use VCC_LO/HI as ordinary scalar scratch; when BOTH inputs have complete
-                    // scalar-data representations, retain that full dword rather than collapsing it
-                    // into a per-lane mask. The captured Plucky Squire tonemap shader, for example,
+                    // operations may use either as ordinary scratch. In Wave32 compute, VCC_HI is
+                    // entirely outside the architectural mask and is therefore always scalar
+                    // scratch; an exact 32-lane subgroup also lets operand_bits materialize an
+                    // EXEC_LO/VCC_LO source through one complete ballot. Other fragment/compute
+                    // forms retain a full dword only when BOTH inputs already have scalar-data
+                    // representations. The captured Plucky Squire tonemap shader, for example,
                     // computes `s_and_b32 vcc_lo, loop_index, 3` and immediately compares VCC_LO as
                     // a uint. True VOPC/mask inputs have no scalar representation and continue into
                     // the wave-mask path below.
@@ -14341,7 +14361,8 @@ bool emit_cfg_state_machine(
                           b64_masks.contains(source.value)));
                 };
                 auto source_mask = [&](const Operand& source) {
-                    return register_mask(source) || source.kind == OperandKind::InlineInt;
+                    return register_mask(source) || source.kind == OperandKind::InlineInt ||
+                        source.kind == OperandKind::Literal;
                 };
                 if (in.fmt == Rdna2Format::SOP1 &&
                     (in.opcode == 0x03 || in.opcode == 0x07 || in.opcode == 0x09 ||
@@ -14357,6 +14378,9 @@ bool emit_cfg_state_machine(
                                            in.opcode <= 0x1c && (in.opcode & 1u) == 0))) {
                     const bool scalar_vcc_bridge = compute_scalar_vcc_bridge &&
                         is_scalar_cselect_b32_to_vcc_lo(in);
+                    const bool scalar_vcchi_packet = compute_scalar_vcc_bridge &&
+                        b.native_subgroup_size == 32 &&
+                        is_gtav_wave32_vcchi_scalar_packet(in);
                     const bool mask_domain = in.dst.value == 126 || in.src[0].value == 126 ||
                         in.src[1].value == 126 ||
                         (((in.src[0].kind == OperandKind::SGPR ||
@@ -14365,9 +14389,10 @@ bool emit_cfg_state_machine(
                         (((in.src[1].kind == OperandKind::SGPR ||
                            in.src[1].kind == OperandKind::Special) &&
                           masks.contains(in.src[1].value)));
-                    writes_b32_mask = scalar_vcc_bridge ||
-                        (mask_domain && source_mask(in.src[0]) &&
-                         source_mask(in.src[1]) && in.dst.value != 127);
+                    writes_b32_mask = !scalar_vcchi_packet &&
+                        (scalar_vcc_bridge ||
+                         (mask_domain && source_mask(in.src[0]) &&
+                          source_mask(in.src[1]) && in.dst.value != 127));
                 }
 
                 int b32_write_reg = writes_b32_mask ? in.dst.value : -1;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -17481,8 +17481,12 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         (ins[i].opcode != 0x36 || ins[i].ds_gds))
                         return false;
                 for (const auto& read : ins) {
-                    if (read.pc <= loop.exit_branch_pc || read.pc >= loop.backedge_pc ||
+                    if (read.pc < loop.header_pc || read.pc >= loop.backedge_pc ||
                         read.fmt != Rdna2Format::DS) continue;
+                    // The condition region runs before the top-of-loop EXEC test. A load there has
+                    // no active-lane proof yet, so the emitter's unconditional Workgroup access is
+                    // not safe even though the rest of the phase is read-only.
+                    if (read.pc <= loop.exit_branch_pc) return false;
                     for (const auto& prior : ins) {
                         if (prior.pc <= loop.exit_branch_pc || prior.pc >= read.pc) continue;
                         if (rdna2_instruction_may_change_exec(prior)) return false;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8434,6 +8434,36 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (in.src_neg[0]) d = b.fneg(d);
                     break;
                 }
+                case 0x0C: {                                        // v_cvt_rpi_i32_f32
+                    // AMD RDNA2 ISA: D.i = (int)floor(S0.f + 0.5), i.e. nearest integer with
+                    // halfway cases rounded toward +infinity (not ceil for every fraction).
+                    // The guide does not restate NaN/out-of-range handling for this specialized
+                    // form, so use the adjacent f32->i32 conversion's deterministic convention:
+                    // NaN -> 0 and saturation at INT_MIN/INT_MAX. cvt_f2i also keeps the SPIR-V
+                    // conversion operand representable on every backend.
+                    //
+                    // Only GTA V's exact plain e32 form is established here. SDWA/DPP and source
+                    // or output modifiers remain fail-visible instead of being silently ignored.
+                    // CONFIDENCE: MED (rounding formula HIGH; exceptional-value policy follows the
+                    // established adjacent architectural conversion because this opcode omits it).
+                    if (in.has_sdwa || in.has_dpp || in.src_abs[0] || in.src_neg[0] ||
+                        in.clamp || in.omod) {
+                        ok = false;
+                        break;
+                    }
+                    // Do not literally add 0.5 in f32 before floor: the float immediately below
+                    // 0.5 would double-round to 1.0. Split off the fractional part, then apply the
+                    // >= tie rule; for integral large magnitudes the fraction is already zero.
+                    const uint32_t lower = b.fext1(Glsl_Floor, a);
+                    const uint32_t fraction = b.fbin(Op_FSub, a, lower);
+                    const uint32_t round_up = b.fcmp(
+                        Op_FOrdGreaterThanEqual, fraction, b.uconst(fbits(0.5f)));
+                    const uint32_t rounded = b.fbin(
+                        Op_FAdd, lower,
+                        b.sel(round_up, b.uconst(fbits(1.0f)), b.uconst(fbits(0.0f))));
+                    d = b.cvt_f2i(rounded);
+                    break;
+                }
                 case 0x0D:                                          // v_cvt_flr_i32_f32
                     // AMD RDNA2 ISA: floor the f32 value before converting to signed i32. This is
                     // observably different from v_cvt_i32_f32's truncation for negative fractions.

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -8169,7 +8169,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (row_ror8) {
                     // Direct shuffle is valid only when one native subgroup is exactly one guest
                     // wave. Portable/default-subgroup compute is routed through synchronized CFG
-                    // scratch below. FI=0 checks the rotated source's EXEC bit and BC1 supplies 0.
+                    // scratch below. FI=0 makes an EXEC-inactive rotated source read as zero; a
+                    // ROW_ROR source is always in-range, so BOUND_CTRL does not decide this case.
                     if (!b.is_compute || dpp_row_ror8_op(in) != DppRowRor8Op::MovB32 ||
                         !b.native_subgroup_size) {
                         ok = false; return true;
@@ -15406,7 +15407,8 @@ bool emit_cfg_state_machine(
             }
             if (b.native_subgroup_size) {
                 // One exact native subgroup is one guest wave and this case is subgroup-uniform.
-                // FI=0 checks the rotated source's EXEC bit; BC1 substitutes zero when it is clear.
+                // FI=0 makes an EXEC-inactive rotated source read as zero. ROW_ROR:8 always names
+                // an in-range lane in its 16-lane row, so BOUND_CTRL does not decide this case.
                 uint32_t valid_source = 0;
                 const uint32_t rotated = b.subgroup_row_ror8(
                     src0_value, state.exec, &valid_source);
@@ -15981,7 +15983,7 @@ bool emit_cfg_state_machine(
     const uint32_t dpp_source_in_bounds = b.ucmp(
         Op_ULessThan, dpp_rotated_index, b.uconst(b.local_count));
     // A partial final DPP16 row has no invocation to initialize the rotated slot. Address this
-    // lane's initialized placeholder and let BC1's validity gate supply zero for the missing peer.
+    // lane's initialized placeholder and let FI=0's validity gate supply zero for the missing peer.
     const uint32_t dpp_source_index = b.sel(
         dpp_source_in_bounds, dpp_rotated_index, b.linear_localid);
     const uint32_t dpp_rotated = b.cfg_scratch_load(

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -16570,19 +16570,20 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         if (phased.found &&
             (phased.guarded || initial_dispatch_active || force_barrier_phases)) {
             // Every phase shares one immutable Workgroup OpTypeArray. Size it from the complete
-            // phased stream before the first dispatcher: a later portable DPP add needs a second
-            // per-lane plane even when the earlier phase needed only votes/liveness.
+            // phased stream before the first dispatcher: a later portable DPP operation needs a
+            // second per-lane plane even when the earlier phase needed only votes/liveness.
             if (!b.native_subgroup_size) {
                 const uint32_t wave_count =
                     (b.local_count + b.wave_size - 1) / b.wave_size;
                 const uint32_t padded_lanes = wave_count * b.wave_size;
-                const bool has_portable_dpp_add = std::any_of(
+                const bool has_portable_dpp = std::any_of(
                     ins.begin(), ins.begin() + phased.end_index,
                     [](const Rdna2Inst& in) {
-                        return is_inplace_vadd_nc_u32_dpp_row_shr(in);
+                        return is_inplace_vadd_nc_u32_dpp_row_shr(in) ||
+                            is_vmin_f32_dpp_row_ror8(in);
                     });
                 const uint32_t scratch_dwords = padded_lanes +
-                    (has_portable_dpp_add ? padded_lanes : 0u) + wave_count + 1;
+                    (has_portable_dpp ? padded_lanes : 0u) + wave_count + 1;
                 if (!b.declare_cfg_scratch(scratch_dwords)) return false;
             }
             uint32_t merge_label = 0;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -162,7 +162,8 @@ enum : uint32_t { Glsl_FAbs=4, Glsl_RoundEven=2, Glsl_Trunc=3, Glsl_Floor=8, Gls
                   Glsl_FindUMsb=75,   // bit index of the highest set bit (undefined at zero)
                   Glsl_NMin=79, Glsl_NMax=80 };   // NaN-aware min/max: one-NaN operand -> the other operand
 enum : uint32_t {
-    Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
+    Cap_Shader=1, Cap_Geometry=2, Cap_Int64=11, Cap_Int64Atomics=12,
+    Cap_GroupNonUniform=61, Cap_GroupNonUniformVote=62,
     Cap_GroupNonUniformArithmetic=63, Cap_GroupNonUniformBallot=64, Cap_GroupNonUniformShuffle=65, Cap_GroupNonUniformQuad=68,
     Cap_TransformFeedback=53,   // VK_EXT_transform_feedback (geometry-probe capture of gl_Position, gated)
     // Descriptor indexing (#2412 stage 4b). These are CORE only from SPIR-V 1.5; this emitter writes
@@ -384,11 +385,13 @@ struct SpirvCompute {
     uint32_t linear_localid = 0, local_count = 64, wave_size = 64;
     uint32_t v_cbuf=0, v_cbuf1=0, t_ptr_sb_u32=0;   // scalar-memory constant buffers (bindings 2 and 3)
     uint32_t t_ptr_sb_struct_u=0;                    // shared runtime-u32 Block pointer type
+    uint32_t t_ptr_sb_u64=0, t_ptr_sb_struct_u64=0; // lazy alias view for 64-bit buffer atomics
     uint32_t t_ptr_img_u32=0;                       // OpImageTexelPointer result for R32_UINT atomics
     uint32_t guest_scratch=0, t_ptr_guest_scratch_u32=0;
     int32_t guest_scratch_min_byte=0, guest_scratch_saddr=-1;
     uint32_t guest_scratch_dwords=0;
     std::map<uint32_t, uint32_t> cbuf_var;          // binding -> storage-buffer var (N-buffer model; 2/3 map to v_cbuf/v_cbuf1)
+    std::map<uint32_t, uint32_t> cbuf_u64_var;      // binding -> runtime-u64 alias variable
     // binding -> declared array length for a TABLE-INDEXED binding (#2412). Absent means an ordinary
     // single descriptor, so an access chain for it takes no leading index. Kept beside `cbuf_var`
     // because every consumer of the variable also needs to know whether it is an array.
@@ -427,6 +430,7 @@ struct SpirvCompute {
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
     uint32_t native_subgroup_size=0;
     uint32_t native_storage_format_support=0;
+    bool storage_buffer_int64_atomics=false;
     bool packed_r11_storage=true;
     uint32_t compute_min_subgroup_size=0;             // non-semantic backend contract (4/16/32/64)
     uint32_t fragment_required_subgroup_size=0;       // exact guest-wave contract (32 or 64)
@@ -1277,7 +1281,7 @@ struct SpirvCompute {
     uint32_t bfe_u(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t offc = uext2(Glsl_UMin, off, uconst(32)); uint32_t r = id(); put(code, Op_BitFieldUExtract, {t_u32, r, base, offc, bfe_clamp_cnt(offc, cnt)}); return r; }
     uint32_t bfe_s(uint32_t base, uint32_t off, uint32_t cnt) { uint32_t offc = uext2(Glsl_UMin, off, uconst(32)); uint32_t ri = id(); put(code, Op_BitFieldSExtract, {t_i32, ri, bcs(base), offc, bfe_clamp_cnt(offc, cnt)}); return i2u(ri); }
     // Lazily declared 64-bit uint (+ Int64 capability), for s_bfe_u64 etc. that operate on SGPR pairs.
-    uint32_t t_u64_cache = 0; bool declared_int64 = false;
+    uint32_t t_u64_cache = 0; bool declared_int64 = false, declared_int64_atomics = false;
     uint32_t t_u64() { if (!t_u64_cache) { if (!declared_int64) { put(caps, Op_Capability, {Cap_Int64}); declared_int64 = true; }
                        t_u64_cache = id(); put(types, Op_TypeInt, {t_u64_cache, 64, 0}); } return t_u64_cache; }
     // A 64-bit uint constant needs two value words. Shift amounts MUST be u64 here: a u32 shift operand on
@@ -1325,6 +1329,9 @@ struct SpirvCompute {
     uint32_t u64_lo(uint32_t v64) { uint32_t r = id(); put(code, Op_UConvert, {t_u32, r, v64}); return r; }  // truncate low 32
     uint32_t u64_hi(uint32_t v64) { uint32_t s = id(); put(code, Op_ShiftRightLogical, {t_u64(), s, v64, uconst64(32)});
         uint32_t r = id(); put(code, Op_UConvert, {t_u32, r, s}); return r; }
+    uint32_t sel64(uint32_t cond, uint32_t yes, uint32_t no) {
+        uint32_t r = id(); put(code, Op_Select, {t_u64(), r, cond, yes, no}); return r;
+    }
     uint32_t u64_bit(uint32_t v64, uint32_t bit) {
         uint32_t shift = id(); put(code, Op_UConvert, {t_u64(), shift, bit});
         uint32_t shifted = id(); put(code, Op_ShiftRightLogical, {t_u64(), shifted, v64, shift});
@@ -2111,6 +2118,32 @@ struct SpirvCompute {
         if (binding == 3) return v_cbuf1;
         auto it = cbuf_var.find(binding); return it != cbuf_var.end() ? it->second : v_cbuf;
     }
+    // Logical-addressing SPIR-V cannot bitcast a pointer into the ordinary runtime-u32 Block to a
+    // u64 pointer. Declare a second, aliased StorageBuffer variable at the SAME descriptor binding.
+    // Vulkan binds both declarations to one VkBuffer; ArrayStride=8 gives the qword atomics their
+    // natural record index. The narrow caller excludes descriptor arrays.
+    uint32_t u64_buf_for_binding(uint32_t binding) {
+        if (auto found = cbuf_u64_var.find(binding); found != cbuf_u64_var.end())
+            return found->second;
+        if (!t_ptr_sb_struct_u64) {
+            const uint32_t runtime_array = id(), block = id();
+            t_ptr_sb_struct_u64 = id();
+            t_ptr_sb_u64 = id();
+            put(deco, Op_Decorate, {runtime_array, Dec_ArrayStride, 8});
+            put(deco, Op_MemberDecorate, {block, 0, Dec_Offset, 0});
+            put(deco, Op_Decorate, {block, Dec_Block});
+            put(types, Op_TypeRuntimeArray, {runtime_array, t_u64()});
+            put(types, Op_TypeStruct, {block, runtime_array});
+            put(types, Op_TypePointer, {t_ptr_sb_struct_u64, SC_StorageBuffer, block});
+            put(types, Op_TypePointer, {t_ptr_sb_u64, SC_StorageBuffer, t_u64()});
+        }
+        const uint32_t variable = id();
+        put(deco, Op_Decorate, {variable, Dec_DescriptorSet, desc_set});
+        put(deco, Op_Decorate, {variable, Dec_Binding, binding});
+        declare_external_storage_buffer(t_ptr_sb_struct_u64, variable);
+        cbuf_u64_var[binding] = variable;
+        return variable;
+    }
     void mark_cbuf_coherent(uint32_t binding) {
         const uint32_t buf = buf_for_binding(binding);
         if (cbuf_coherent_vars.insert(buf).second)
@@ -2225,6 +2258,37 @@ struct SpirvCompute {
         put(code, Op_Branch, {merge});
         put(code, Op_Label, {merge}); cur_block = merge;
         return emit_phi_2way(t_u32, result, then_end, fallback, entry);
+    }
+    // One true 64-bit RMW for the exact naturally-strided guest contract. The caller supplies the
+    // SPIR-V atomic opcode and original qword record index, and range-checks it before entry.
+    uint32_t cbuf_atomic_x2_rtn(uint32_t op, uint32_t index, uint32_t value, uint32_t binding,
+                                uint32_t pred, uint32_t fallback) {
+        cbuf_ordinary_accesses.insert(binding);
+        if (!declared_int64_atomics) {
+            put(caps, Op_Capability, {Cap_Int64Atomics});
+            declared_int64_atomics = true;
+        }
+        const uint32_t buf = u64_buf_for_binding(binding);
+        auto emit = [&]() {
+            const uint32_t pointer = id();
+            putv(code, Op_AccessChain,
+                 {t_ptr_sb_u64, pointer, buf, uconst(0), index});
+            const uint32_t result = id();
+            put(code, op,
+                {t_u64(), result, pointer, uconst(Scope_Device),
+                 uconst(MemSem_UniformAcqRel), value});
+            return result;
+        };
+        const uint32_t entry = cur_block;
+        const uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        const uint32_t result = emit();
+        const uint32_t then_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        return emit_phi_2way(t_u64(), result, then_end, fallback, entry);
     }
     // RADV currently hangs/reset-poisons the device on Astro Bot's compute R32_UINT image atomic.
     // Compute lowers that exact 2D resource through a detiled storage-buffer view instead. The live
@@ -10927,7 +10991,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // later register consumers, so reject until status-return semantics are implemented.
             if (in.fmt == Rdna2Format::MTBUF && in.mtbuf_tfe) { ok = false; return true; }
             uint32_t n = 0; bool is_format = false, is_store = false, is_atomic = false;
+            bool is_atomic_x2 = false;
             uint32_t atomic_op = 0;   // SPIR-V atomic RMW opcode for is_atomic (set by the switch)
+            uint32_t atomic_x2_record_count = 0;
             bool raw_subword = false, raw_signed = false;
             uint32_t raw_bits = 32;
             switch (in.opcode) {
@@ -10957,8 +11023,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // mem = mem OP VDATA and returns the PRE-op value in VDATA. They all share the generic
                 // OpAtomic<Op>(ptr, Device, AcqRel, value) shape emitted by cbuf_atomic_rtn. VDATA is one
                 // dword. CMPSWAP (0x31, two-operand), CSUB (0x34, conditional-subtract), INC/DEC
-                // (0x3c/0x3d, wrap semantics), and the x2 64-bit variants stay deferred (fail-visible)
-                // via the default case below — they need distinct lowering, not a plain RMW.
+                // (0x3c/0x3d, wrap semantics), and most x2 64-bit variants stay deferred
+                // (fail-visible) via the default case below. Opcodes 0x50/0x5a have separately
+                // guarded GTA V lowerings: one true qword RMW, never two ordinary 32-bit atomics.
                 case 0x30: n = 1; is_atomic = true; atomic_op = Op_AtomicExchange; break; // swap
                 case 0x32: n = 1; is_atomic = true; atomic_op = Op_AtomicIAdd;     break; // add
                 case 0x33: n = 1; is_atomic = true; atomic_op = Op_AtomicISub;     break; // sub
@@ -10969,6 +11036,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x39: n = 1; is_atomic = true; atomic_op = Op_AtomicAnd;      break; // and
                 case 0x3a: n = 1; is_atomic = true; atomic_op = Op_AtomicOr;       break; // or
                 case 0x3b: n = 1; is_atomic = true; atomic_op = Op_AtomicXor;      break; // xor
+                case 0x50: n = 2; is_atomic = true; is_atomic_x2 = true;
+                           atomic_op = Op_AtomicExchange; break;                    // swap_x2
+                case 0x5a: n = 2; is_atomic = true; is_atomic_x2 = true;
+                           atomic_op = Op_AtomicOr; break;                          // or_x2
                 default: ok = false; return true;           // remaining typed/atomic opcodes deferred
             }
             uint32_t offset = in.literal & 0xFFFu;
@@ -11205,6 +11276,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 if (raw_bits == 8) fmt = raw_signed ? DataFormat::Sint8 : DataFormat::Uint8;
                 else               fmt = raw_signed ? DataFormat::Sint16 : DataFormat::Uint16;
             }
+            if (is_atomic_x2) {
+                const bool zero_soffset =
+                    (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||
+                    (in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0);
+                const bool exact_shape = b.storage_buffer_int64_atomics && resolved_buffer &&
+                    resolved_buffer->fetch_pc == in.pc &&
+                    resolved_buffer->table_index_count == 0u &&
+                    resolved_buffer->stride == 8u &&
+                    resolved_buffer->atomic_x2_record_count != 0u &&
+                    resolved_buffer->atomic_x2_record_count <= 0x02000000u &&
+                    static_cast<uint64_t>(resolved_buffer->atomic_x2_record_count) * 8u ==
+                        resolved_buffer->size &&
+                    (resolved_buffer->gpu_addr & 7u) == 0u && idxen && !offen &&
+                    offset == 0u && zero_soffset && !in.mubuf_dlc &&
+                    !in.mubuf_lds && (in.words[0] & 0x00020000u) == 0u &&
+                    (in.words[1] & 0x00e00000u) == 0u &&
+                    in.src[0].kind == OperandKind::VGPR;
+                if (!exact_shape) { ok = false; return true; }
+                atomic_x2_record_count = resolved_buffer->atomic_x2_record_count;
+            }
             // else (rt == nullptr): table-less offline compute shell (recompile_valu without a resource
             // table — the unit-test harness). Keep the legacy single-cbuf convention: binding 2, stride 0.
             // The live graphics path can never reach here table-less: recompile_vertex/recompile_fragment
@@ -11371,6 +11462,34 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             auto load_dword = [&](uint32_t dword_idx) {
                 return b.cbuf_load(dword_idx, binding, coherent_load);
             };
+            if (is_atomic_x2) {
+                const int d = in.dst.value;
+                const uint32_t old_lo = vreg_old(b, rs, d);
+                const uint32_t old_hi = vreg_old(b, rs, d + 1);
+                const auto lo_it = rs.vreg.find(d), hi_it = rs.vreg.find(d + 1);
+                const uint32_t value_lo = lo_it == rs.vreg.end() ? b.uconst(0) : lo_it->second;
+                const uint32_t value_hi = hi_it == rs.vreg.end() ? b.uconst(0) : hi_it->second;
+                const uint32_t value = b.u64_from_lohi(value_lo, value_hi);
+                // Range-check the original qword record index against this dispatch's concrete V#.
+                // Each valid index addresses its natural eight-byte record; larger indices are OOB.
+                const uint32_t record_index = val(in.src[0]);
+                const uint32_t in_bounds =
+                    b.ucmp(Op_ULessThan, record_index, b.uconst(atomic_x2_record_count));
+                const uint32_t access = rs.exec_narrowed
+                    ? b.land(rs.exec, in_bounds) : in_bounds;
+                uint32_t fallback = b.uconst64(0);
+                if (rs.exec_narrowed)
+                    fallback = b.sel64(rs.exec, fallback, b.u64_from_lohi(old_lo, old_hi));
+                const uint32_t pre = b.cbuf_atomic_x2_rtn(
+                    atomic_op, record_index, value, binding, access, fallback);
+                // GLC=0 preserves BOTH data VGPRs. GLC=1 returns the pre-op qword; active OOB lanes
+                // receive zero and inactive EXEC lanes receive their original pair via fallback.
+                if (in.mubuf_glc) {
+                    rs.vreg[d] = b.u64_lo(pre);
+                    rs.vreg[d + 1] = b.u64_hi(pre);
+                }
+                return true;
+            }
             if (is_atomic) {
                 const int d = in.dst.value;
                 const uint32_t old = vreg_old(b, rs, d);
@@ -18649,6 +18768,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                                     "of waves")))));
     }
     b.native_storage_format_support = config.native_storage_format_support;
+    b.storage_buffer_int64_atomics = config.storage_buffer_int64_atomics;
     b.packed_r11_storage = config.packed_r11_storage;
     b.begin(1, rt, local_x, local_y, local_z, wave_size,
             static_cast<uint32_t>(config.user_sgprs.size()));

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -9255,14 +9255,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // predicate_write.
             // VERIFIED(round-trip llvm-mc gfx1030: 0xd761 v_writelane_b32 / 0xd760 v_readlane_b32).
             if (in.opcode == 0x361) {                                 // v_writelane_b32 vDST, sSRC, lane
-                if (b.is_compute && b.wave_size == 32 && b.native_subgroup_size == 32 &&
+                if (b.is_compute && (b.wave_size == 32 || b.wave_size == 64) &&
+                    b.native_subgroup_size == b.wave_size &&
                     in.src[1].kind != OperandKind::InlineInt) {
-                    // RDNA2 masks the scalar selector to the Wave32 lane range and replaces VDST
-                    // only in that physical lane. Under the enforced 32-wide native-subgroup
+                    // RDNA2 masks the scalar selector to the active wave width and replaces VDST
+                    // only in that physical lane. Under the enforced exact-width native-subgroup
                     // contract, SubgroupLocalInvocationId is that architectural lane. The scalar
                     // source and selector are uniform, so this needs no shuffle or barrier. Astro's
-                    // traversal kernel reaches this form after readlane publishes its chosen hit as
-                    // scalar data.
+                    // Wave32 and GTA V's Wave64 traversal kernels reach this form after readlane or
+                    // a mask scan publishes the chosen hit as scalar data.
                     if (in.src[1].kind == OperandKind::VGPR ||
                         rs.vgpr_lane_slots.count(in.dst.value) ||
                         rs.vgpr_lane_mask_slots.count(in.dst.value)) {
@@ -9274,7 +9275,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint32_t lane = b.subgroup_local_id();
                     const uint32_t selected = b.ucmp(
                         Op_IEqual, lane,
-                        b.ibin(Op_BitwiseAnd, selector, b.uconst(31)));
+                        b.ibin(Op_BitwiseAnd, selector, b.uconst(b.wave_size - 1u)));
                     rs.vreg[in.dst.value] = b.sel(
                         selected, value, vreg_old(b, rs, in.dst.value));
                     rs.invalidated_vgpr_lane_slots.erase(in.dst.value);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -2290,6 +2290,24 @@ struct SpirvCompute {
         uint32_t p = id(); putv(code, Op_AccessChain, {t_ptr_lds_u32, p, lds_var, idx});
         uint32_t r = id(); put(code, Op_Load, {t_u32, r, p}); return r;
     }
+    // EXEC-predicated LDS load. The inactive arm must not merely discard a loaded value: its
+    // address VGPR retains the old, potentially arbitrary bits when the instruction is masked off,
+    // so even forming an AccessChain/OpLoad there can access outside the Workgroup array or race an
+    // active lane. Keep the memory access inside the active selection and join the architectural
+    // old destination through OpPhi, matching the returning-atomic helper below.
+    uint32_t lds_load(uint32_t idx, bool predicated, uint32_t pred, uint32_t fallback) {
+        if (!predicated) return lds_load(idx);
+        const uint32_t entry = cur_block;
+        const uint32_t then = id(), merge = id();
+        put(code, Op_SelectionMerge, {merge, 0});
+        put(code, Op_BranchConditional, {pred, then, merge});
+        put(code, Op_Label, {then}); cur_block = then;
+        const uint32_t result = lds_load(idx);
+        const uint32_t then_end = cur_block;
+        put(code, Op_Branch, {merge});
+        put(code, Op_Label, {merge}); cur_block = merge;
+        return emit_phi_2way(t_u32, result, then_end, fallback, entry);
+    }
     // Store to LDS[idx]; EXEC-predicated (conditional store) under a narrowed mask, like cbuf_store.
     void lds_store(uint32_t idx, uint32_t value, bool predicated, uint32_t pred) {
         if (!predicated) {
@@ -12414,8 +12432,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                 rs.exec_narrowed, rs.exec);
                 } else {
                     const uint32_t old = vreg_old(b, rs, in.dst.value);
-                    rs.vreg[in.dst.value] = b.lds_load(idx);
-                    predicate_write(b, rs, in.dst.value, old);
+                    rs.vreg[in.dst.value] = b.lds_load(
+                        idx, rs.exec_narrowed, rs.exec, old);
                 }
                 return true;
             }
@@ -12532,8 +12550,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 };
                 for (int k = 0; k < 4; ++k) {
                     const uint32_t old = vreg_old(b, rs, in.dst.value + k);
-                    rs.vreg[in.dst.value + k] = b.lds_load(indices[k]);
-                    predicate_write(b, rs, in.dst.value + k, old);
+                    rs.vreg[in.dst.value + k] = b.lds_load(
+                        indices[k], rs.exec_narrowed, rs.exec, old);
                 }
                 return true;
             }
@@ -12548,8 +12566,8 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 };
                 for (int k = 0; k < 2; ++k) {
                     const uint32_t old = vreg_old(b, rs, in.dst.value + k);
-                    rs.vreg[in.dst.value + k] = b.lds_load(indices[k]);
-                    predicate_write(b, rs, in.dst.value + k, old);
+                    rs.vreg[in.dst.value + k] = b.lds_load(
+                        indices[k], rs.exec_narrowed, rs.exec, old);
                 }
                 return true;
             }
@@ -12631,13 +12649,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 for (int k = 0; k < dwords; ++k) {
                     const uint32_t old = vreg_old(b, rs, in.dst.value + k);
                     const uint32_t at = k ? b.ibin(Op_IAdd, idx, b.uconst((uint32_t)k)) : idx;
-                    rs.vreg[in.dst.value + k] = b.lds_load(at);
-                    predicate_write(b, rs, in.dst.value + k, old);
+                    rs.vreg[in.dst.value + k] = b.lds_load(
+                        at, rs.exec_narrowed, rs.exec, old);
                 }
             } else {                                    // ds_read_b32: VDST = LDS[idx]
                 uint32_t old = vreg_old(b, rs, in.dst.value);
-                rs.vreg[in.dst.value] = b.lds_load(idx);
-                predicate_write(b, rs, in.dst.value, old);
+                rs.vreg[in.dst.value] = b.lds_load(
+                    idx, rs.exec_narrowed, rs.exec, old);
             }
             return true;
         }
@@ -16953,15 +16971,19 @@ BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>
 // idiom: select EXEC=1, initialize six adjacent dwords with one B64 and one B128 write, restore
 // EXEC=-1, set vaddr=0, then issue three DS_MIN_F32 and three DS_MAX_F32 operations.
 //
-// Recognize only that byte-exact sequence and insert an emitter-only S_BARRIER before the first
-// atomic. A straight-line shader emits it directly. With scalar control flow, a no-crossing-edge
-// proof keeps the boundary top-level in the compact structurizer or lets the existing phase route
-// lift it outside a complex dispatcher, so every workgroup invocation reaches the same dynamic
-// barrier. Any other float atomic following an unsynchronized ordinary LDS store rejects visibly;
-// a real guest barrier, or an atomic with no preceding ordinary store in its phase, remains
-// architectural and needs no synthesized edge.
+// Recognize only that byte-exact sequence, including its lane-zero B128+B64 gather, and insert
+// emitter-only S_BARRIERs before and after the six atomics. The first publishes lane zero's plain
+// stores before every lane enters the CAS group; the second makes every lane finish all six CAS
+// loops before lane zero reads the result. AcquireRelease on an individual atomic orders memory but
+// is not an arrival barrier, so neither edge can be omitted. A straight-line shader emits both
+// directly. With scalar control flow, a no-crossing-edge proof keeps each boundary top-level in the
+// compact structurizer or lets the existing phase route lift it outside a complex dispatcher, so
+// every workgroup invocation reaches the same dynamic barrier. Any other float atomic following an
+// unsynchronized ordinary LDS store rejects visibly; a real guest barrier, or an atomic with no
+// preceding ordinary store in its phase, remains architectural and needs no synthesized edge.
 bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
-                                         RecompileDiagnosticContext diagnostic) {
+                                         RecompileDiagnosticContext diagnostic,
+                                         bool at_most_one_guest_wave) {
     auto ordinary_lds_store = [](const Rdna2Inst& in) {
         if (in.fmt != Rdna2Format::DS || in.ds_gds) return false;
         return in.opcode == 0x0d || in.opcode == 0x0e || in.opcode == 0x4d ||
@@ -16999,7 +17021,7 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
         }
         if (!float_lds_atomic(in) || phase_stores.empty()) continue;
 
-        bool exact = i >= 4 && i + 5 < ins.size() && phase_stores.size() == 2 &&
+        bool exact = i >= 4 && i + 9 < ins.size() && phase_stores.size() == 2 &&
             phase_stores[0] == i - 4 && phase_stores[1] == i - 3 &&
             words_are(ins[i - 4], 0xd9340010u, 0x0000040cu) &&
             words_are(ins[i - 3], 0xdb7c0000u, 0x0000000cu) &&
@@ -17007,6 +17029,11 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
             ins[i - 1].words[0] == 0x7e000280u;   // v_mov_b32 v0, 0
         for (size_t atomic = 0; exact && atomic < 6; ++atomic)
             exact = words_are(ins[i + atomic], kAtomicWord0[atomic], kAtomicWord1[atomic]);
+        exact = exact &&
+            ins[i + 6].words[0] == 0xbefe0481u && // pc81 s_mov_b64 exec, 1
+            ins[i + 7].words[0] == 0x7e080280u && // pc82 v_mov_b32 v4, 0
+            words_are(ins[i + 8], 0xdbfc0000u, 0x00000004u) && // pc83 ds_read_b128 v[0:3],v4
+            words_are(ins[i + 9], 0xd9d80010u, 0x04000004u);   // pc85 ds_read_b64 v[4:5],v4
 
         bool found_lane0 = false;
         uint32_t lane0_pc = UINT32_MAX;
@@ -17054,10 +17081,21 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
                 "pc=%u reason=unsynchronized-lds-store-before-ds-fminmax", in.pc);
             return false;
         }
+        // EXEC=1 selects lane zero independently in every guest wave. The exact initializer uses
+        // ordinary same-address stores, so more than one wave would race even though each wave has
+        // only one active lane. Keep the title-observed single-wave workgroup admissible and leave a
+        // different launch shape fail-visible until its cross-wave ownership can be proved.
+        if (!at_most_one_guest_wave) {
+            log_recompile_diagnostic(
+                diagnostic, "compute-recompile-reject", "terminal",
+                "pc=%u reason=multiwave-lds-fminmax-initializer", in.pc);
+            return false;
+        }
 
         synth_before.push_back(i);
+        synth_before.push_back(i + 6);
         phase_stores.clear();
-        i += 5; // the byte-exact six-atomic group shares the one publication barrier
+        i += 9; // both synthesized boundaries belong to this complete live atomic/gather group
     }
 
     std::vector<uint32_t> synth_pcs;
@@ -18384,7 +18422,8 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     // converge in the host SPIR-V without inventing further guest execution. Graphics exports keep
     // separate side-effect bookkeeping and remain on the conservative reject path for this shape.
     (void)extend_terminating_if_else(code, dwords, ins);
-    if (!prepare_lds_fminmax_synchronization(ins, {})) return {};
+    // The synthetic test shell is one Wave64 workgroup, matching the live GTA dispatch.
+    if (!prepare_lds_fminmax_synchronization(ins, {}, true)) return {};
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     // Size the LDS array from the shader's real allocation when known (#130): bytes -> dwords, at
@@ -18415,6 +18454,11 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                                         const ShaderResourceTable* rt,
                                         const ComputeShaderConfig& config,
                                         RecompileDiagnosticContext diagnostic) {
+    const uint32_t local_x = std::max(1u, config.local_x);
+    const uint32_t local_y = std::max(1u, config.local_y);
+    const uint32_t local_z = std::max(1u, config.local_z);
+    const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
+    const uint64_t local_count = static_cast<uint64_t>(local_x) * local_y * local_z;
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     // A dispatch-scoped proven-null BVH can collapse an exact no-hit exit and fully matched empty-stack
@@ -18426,7 +18470,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
     // only a place to finish the invocation after either guest arm has terminated.
     (void)extend_terminating_if_else(code, dwords, ins);
-    if (!prepare_lds_fminmax_synchronization(ins, diagnostic)) return {};
+    if (!prepare_lds_fminmax_synchronization(
+            ins, diagnostic, local_count <= wave_size))
+        return {};
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     b.diagnostic = diagnostic;
@@ -18434,11 +18480,6 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
         uint32_t dw = (config.lds_bytes + 3) / 4;
         b.lds_dwords = std::min(16384u, std::max(1u, dw));
     }
-    const uint32_t local_x = std::max(1u, config.local_x);
-    const uint32_t local_y = std::max(1u, config.local_y);
-    const uint32_t local_z = std::max(1u, config.local_z);
-    const uint32_t wave_size = config.wave_size == 32 ? 32u : 64u;
-    const uint64_t local_count = static_cast<uint64_t>(local_x) * local_y * local_z;
     const bool has_partial_workgroup = config.threads_x % local_x != 0 ||
                                        config.threads_y % local_y != 0 ||
                                        config.threads_z % local_z != 0;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5984,9 +5984,13 @@ void loop_written_regs(const std::vector<Rdna2Inst>& ins, uint32_t lo, uint32_t 
                 // produce scalar SGPR data, so carrying a scalar value through a loop/if merge is
                 // both unnecessary and semantically wrong.
                 if (in.opcode != 0x21 || (in.dst.value != 126 && in.dst.value != 127)) {
-                    sregs.insert(in.dst.value);
-                    if (in.opcode == 0x1f || in.opcode == 0x21)
-                        sregs.insert(in.dst.value + 1);
+                    uint32_t words = 1;
+                    if (in.opcode == 0x0b)
+                        words = scalar_write_width(in);
+                    else if (in.opcode == 0x1f || in.opcode == 0x21)
+                        words = 2;
+                    for (uint32_t word = 0; word < words; ++word)
+                        sregs.insert(in.dst.value + static_cast<int>(word));
                 }
                 break;
             case Rdna2Format::SMEM: {                                      // s_load/s_buffer_load: N consecutive SGPRs
@@ -14376,8 +14380,10 @@ bool emit_cfg_state_machine(
     std::unordered_map<uint32_t, int> proven_wave64_mbcnt_mask_root_for_pc;
     // Retain the entry facts beyond the consumer-specialization pass below. Function Bool
     // variables persist values only; this MUST set is the separate lifetime tag load_state needs
-    // before reconstructing a saved-mask RegState entry in each dispatcher case.
+    // before reconstructing a saved-mask RegState entry in each dispatcher case. Domain conflicts
+    // at joins remain ambiguous until a definite overwrite and reject on their first read.
     std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
+    std::vector<std::set<int>> wave64_b64_ambiguous_in(starts.size());
     std::vector<bool> wave64_b64_reachable(starts.size(), false);
     auto wave64_mask_reduction_source = [&](const Rdna2Inst& in) -> int {
         if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::SOP1 ||
@@ -14410,8 +14416,32 @@ bool emit_cfg_state_machine(
         if (initial.vcc) wave64_b64_mask_in.front().insert(106);
         wave64_b64_reachable.front() = true;
 
-        auto advance_wave64_b64_masks = [&](std::set<int>& masks, const Rdna2Inst& in,
+        auto advance_wave64_b64_masks = [&](std::set<int>& masks,
+                                            std::set<int>& ambiguous,
+                                            const Rdna2Inst& in,
                                             bool record_compare) {
+            // A block-entry join where the same physical pair is a mask on one predecessor and
+            // scalar data on another has no runtime type tag. Reject the first observable read;
+            // loading either the Bool's false placeholder or the scalar variable's zero placeholder
+            // would silently choose one predecessor's domain for both paths.
+            bool reads_ambiguous = false;
+            for (uint32_t source = 0; source < in.n_src; ++source) {
+                const Operand& operand = in.src[source];
+                if (operand.kind != OperandKind::SGPR &&
+                    operand.kind != OperandKind::Special)
+                    continue;
+                for (int base : ambiguous)
+                    reads_ambiguous |= operand.value == base || operand.value == base + 1;
+            }
+            const bool implicit_vcc_read =
+                (in.fmt == Rdna2Format::SOPP &&
+                 (in.opcode == 0x06 || in.opcode == 0x07)) ||
+                (in.fmt == Rdna2Format::VOP2 &&
+                 (in.opcode == 0x01 || (in.opcode >= 0x28 && in.opcode <= 0x2a)));
+            reads_ambiguous |= implicit_vcc_read && ambiguous.contains(106);
+            if (reads_ambiguous)
+                return reject_cfg(in.pc, "wave64-ambiguous-mask-read");
+
             const int reduction_source = wave64_mask_reduction_source(in);
             if (record_compare && reduction_source >= 0 && masks.contains(reduction_source))
                 proven_wave64_mask_reduction_pcs.insert(in.pc);
@@ -14470,14 +14500,18 @@ bool emit_cfg_state_machine(
             }
 
             auto erase_overlapping = [&](int base, uint32_t width) {
-                for (auto it = masks.begin(); it != masks.end();) {
-                    const int mask_base = *it;
-                    if (base < mask_base + 2 &&
-                        mask_base < base + static_cast<int>(width))
-                        it = masks.erase(it);
-                    else
-                        ++it;
-                }
+                auto erase = [&](std::set<int>& values) {
+                    for (auto it = values.begin(); it != values.end();) {
+                        const int mask_base = *it;
+                        if (base < mask_base + 2 &&
+                            mask_base < base + static_cast<int>(width))
+                            it = values.erase(it);
+                        else
+                            ++it;
+                    }
+                };
+                erase(masks);
+                erase(ambiguous);
             };
             for_each_scalar_write(in, erase_overlapping, /*wave32_one_word_masks*/false);
             // An implicit VOPC destination is architectural VCC and is absent from the explicit
@@ -14485,7 +14519,11 @@ bool emit_cfg_state_machine(
             if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
                 !(in.dst.kind == OperandKind::SGPR && in.dst.value <= 105))
                 erase_overlapping(106, 2);
-            if (mask_write >= 0) masks.insert(mask_write);
+            if (mask_write >= 0) {
+                masks.insert(mask_write);
+                ambiguous.erase(mask_write);
+            }
+            return true;
         };
 
         std::vector<uint32_t> pending{0};
@@ -14493,27 +14531,41 @@ bool emit_cfg_state_machine(
             const uint32_t block = pending.back();
             pending.pop_back();
             std::set<int> masks = wave64_b64_mask_in[block];
+            std::set<int> ambiguous = wave64_b64_ambiguous_in[block];
             const uint32_t lo = starts[block];
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
-                advance_wave64_b64_masks(masks, in, /*record_compare*/false);
+                if (!advance_wave64_b64_masks(
+                        masks, ambiguous, in, /*record_compare*/false))
+                    return false;
             }
             for (uint32_t successor : successors[block]) {
                 if (!wave64_b64_reachable[successor]) {
                     wave64_b64_reachable[successor] = true;
                     wave64_b64_mask_in[successor] = masks;
+                    wave64_b64_ambiguous_in[successor] = ambiguous;
                     pending.push_back(successor);
                     continue;
                 }
                 std::set<int> joined;
+                std::set<int> joined_ambiguous = wave64_b64_ambiguous_in[successor];
                 std::set_intersection(
                     wave64_b64_mask_in[successor].begin(),
                     wave64_b64_mask_in[successor].end(),
                     masks.begin(), masks.end(),
                     std::inserter(joined, joined.end()));
-                if (joined != wave64_b64_mask_in[successor]) {
+                for (int base : wave64_b64_mask_in[successor])
+                    if (!masks.contains(base)) joined_ambiguous.insert(base);
+                for (int base : masks)
+                    if (!wave64_b64_mask_in[successor].contains(base))
+                        joined_ambiguous.insert(base);
+                joined_ambiguous.insert(ambiguous.begin(), ambiguous.end());
+                for (int base : joined_ambiguous) joined.erase(base);
+                if (joined != wave64_b64_mask_in[successor] ||
+                    joined_ambiguous != wave64_b64_ambiguous_in[successor]) {
                     wave64_b64_mask_in[successor] = std::move(joined);
+                    wave64_b64_ambiguous_in[successor] = std::move(joined_ambiguous);
                     pending.push_back(successor);
                 }
             }
@@ -14521,11 +14573,14 @@ bool emit_cfg_state_machine(
         for (uint32_t block = 0; block < starts.size(); ++block) {
             if (!wave64_b64_reachable[block]) continue;
             std::set<int> masks = wave64_b64_mask_in[block];
+            std::set<int> ambiguous = wave64_b64_ambiguous_in[block];
             const uint32_t lo = starts[block];
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
-                advance_wave64_b64_masks(masks, in, /*record_compare*/true);
+                if (!advance_wave64_b64_masks(
+                        masks, ambiguous, in, /*record_compare*/true))
+                    return false;
             }
         }
     }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -16965,6 +16965,7 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
     auto ordinary_lds_store = [](const Rdna2Inst& in) {
         if (in.fmt != Rdna2Format::DS || in.ds_gds) return false;
         return in.opcode == 0x0d || in.opcode == 0x0e || in.opcode == 0x4d ||
+               in.opcode == 0x4e ||
                in.opcode == 0xb0 || in.opcode == 0xde || in.opcode == 0xdf;
     };
     auto float_lds_atomic = [](const Rdna2Inst& in) {
@@ -17008,11 +17009,13 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
             exact = words_are(ins[i + atomic], kAtomicWord0[atomic], kAtomicWord1[atomic]);
 
         bool found_lane0 = false;
+        uint32_t lane0_pc = UINT32_MAX;
         if (exact) {
             for (size_t j = i - 4; j-- > 0;) {
                 const Rdna2Inst& prefix = ins[j];
                 if (prefix.words[0] == 0xbefe0481u) { // s_mov_b64 exec, 1
                     found_lane0 = true;
+                    lane0_pc = prefix.pc;
                     for (size_t k = j + 1; k < i - 2; ++k) {
                         const Rdna2Inst& between = ins[k];
                         if (between.fmt == Rdna2Format::SOPP ||
@@ -17027,6 +17030,22 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
                 if (prefix.fmt == Rdna2Format::SOPP ||
                     rdna2_instruction_may_change_exec(prefix))
                     break;
+            }
+        }
+        if (found_lane0) {
+            const uint32_t last_store_pc = ins[i - 3].pc;
+            for (const Rdna2Inst& edge : ins) {
+                if (edge.pc >= lane0_pc || edge.fmt != Rdna2Format::SOPP ||
+                    edge.opcode < 0x02 || edge.opcode > 0x09 || edge.opcode == 0x03)
+                    continue;
+                const uint32_t target = branch_target(edge);
+                // The exact EXEC=1 writer must dominate both initializer stores. An edge from its
+                // prefix may target the writer itself, but entering after it can leave EXEC full
+                // and turn the supposedly single-writer OpStores into same-address races.
+                if (target > lane0_pc && target <= last_store_pc) {
+                    found_lane0 = false;
+                    break;
+                }
             }
         }
         if (!exact || !found_lane0) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3720,6 +3720,7 @@ inline bool sopk_sets_full_flat_scratch_base(const Rdna2Inst& in) {
 
 namespace {
 uint32_t scalar_write_width(const Rdna2Inst& in);
+uint32_t scalar_implicit_destination_read_width(const Rdna2Inst& in);
 }
 
 inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t target, int R) {
@@ -3795,11 +3796,13 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
             case Rdna2Format::VOP1: case Rdna2Format::VOP2: case Rdna2Format::VOP3: case Rdna2Format::VOPC:
             case Rdna2Format::DS:    // DS operands are VGPR/M0 only; it cannot read an ordinary SGPR/VCC
             case Rdna2Format::EXP: { // EXP data sources are all VGPRs — it can never read an SGPR
-                // s_bitset{0,1}_b32 reads its destination before replacing that same word; the
-                // decoded source is only the bit index, so the generic operand walk cannot see it.
-                if (in.fmt == Rdna2Format::SOP1 &&
-                    (in.opcode == 0x1c || in.opcode == 0x1d) &&
-                    in.dst.value == R)
+                // Conditional moves, SOPK immediate operations, and SOP1 bitsets may read their
+                // encoded destination before replacing it. Their decoded source list does not
+                // contain that old value, so consult the shared implicit-read inventory first.
+                const uint32_t implicit_read_width =
+                    scalar_implicit_destination_read_width(in);
+                if (implicit_read_width && R >= in.dst.value &&
+                    R < in.dst.value + static_cast<int>(implicit_read_width))
                     return false;
                 for (int k = 0; k < in.n_src; k++) {
                     if (in.src[k].kind != OperandKind::SGPR &&
@@ -5205,6 +5208,32 @@ uint32_t scalar_write_width(const Rdna2Inst& in) {
             }
         case Rdna2Format::VOP1: return in.opcode == 0x02 ? 1u : 0u; // v_readfirstlane
         case Rdna2Format::VOP3: return in.opcode == 0x360 ? 1u : 0u; // v_readlane
+        default: return 0;
+    }
+}
+
+// Scalar instructions whose encoded destination is also an implicit source. These reads must be
+// observed before writer transfer functions invalidate the old lifetime. SOPK has no decoded src
+// operands at all; conditional moves preserve the old destination on one SCC outcome, comparisons
+// consume SDST without writing it, and ADDK/MULK are ordinary read-modify-write operations. SOP1
+// conditional moves and bitset operations have an explicit source too, but it is the replacement
+// value/bit index rather than the old destination.
+uint32_t scalar_implicit_destination_read_width(const Rdna2Inst& in) {
+    if (in.dst.kind != OperandKind::SGPR) return 0;
+    if (in.fmt == Rdna2Format::SOPK) {
+        if (in.opcode == 0x02 ||                         // s_cmovk_i32
+            (in.opcode >= 0x03 && in.opcode <= 0x10))   // s_cmpk_*, s_addk, s_mulk
+            return 1;
+        return 0;
+    }
+    if (in.fmt != Rdna2Format::SOP1) return 0;
+    switch (in.opcode) {
+        case 0x05: return 1; // s_cmov_b32
+        case 0x06: return 2; // s_cmov_b64
+        case 0x1b: return 1; // s_bitset0_b32
+        case 0x1c: return 2; // s_bitset0_b64
+        case 0x1d: return 1; // s_bitset1_b32
+        case 0x1e: return 2; // s_bitset1_b64
         default: return 0;
     }
 }
@@ -14439,6 +14468,14 @@ bool emit_cfg_state_machine(
                 (in.fmt == Rdna2Format::VOP2 &&
                  (in.opcode == 0x01 || (in.opcode >= 0x28 && in.opcode <= 0x2a)));
             reads_ambiguous |= implicit_vcc_read && ambiguous.contains(106);
+            const uint32_t implicit_scalar_words =
+                scalar_implicit_destination_read_width(in);
+            if (implicit_scalar_words) {
+                const int first = in.dst.value;
+                const int last = first + static_cast<int>(implicit_scalar_words);
+                for (int mask_base : ambiguous)
+                    reads_ambiguous |= first < mask_base + 2 && mask_base < last;
+            }
             if (reads_ambiguous)
                 return reject_cfg(in.pc, "wave64-ambiguous-mask-read");
 
@@ -14500,18 +14537,27 @@ bool emit_cfg_state_machine(
             }
 
             auto erase_overlapping = [&](int base, uint32_t width) {
-                auto erase = [&](std::set<int>& values) {
-                    for (auto it = values.begin(); it != values.end();) {
-                        const int mask_base = *it;
-                        if (base < mask_base + 2 &&
-                            mask_base < base + static_cast<int>(width))
-                            it = values.erase(it);
-                        else
-                            ++it;
-                    }
-                };
-                erase(masks);
-                erase(ambiguous);
+                for (auto it = masks.begin(); it != masks.end();) {
+                    const int mask_base = *it;
+                    if (base < mask_base + 2 &&
+                        mask_base < base + static_cast<int>(width))
+                        it = masks.erase(it);
+                    else
+                        ++it;
+                }
+                // A one-word scalar write kills the definite-mask fact for the physical pair, but
+                // it resolves only the addressed half of an ambiguous pair. Keep the ambiguity
+                // until one definite write covers both halves; otherwise the untouched word could
+                // be reloaded from the wrong Function-variable domain. Pair-conservative retention
+                // after two separate B32 writes is intentional and fail-closed.
+                for (auto it = ambiguous.begin(); it != ambiguous.end();) {
+                    const int mask_base = *it;
+                    if (base <= mask_base &&
+                        base + static_cast<int>(width) >= mask_base + 2)
+                        it = ambiguous.erase(it);
+                    else
+                        ++it;
+                }
             };
             for_each_scalar_write(in, erase_overlapping, /*wave32_one_word_masks*/false);
             // An implicit VOPC destination is architectural VCC and is absent from the explicit

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -1121,6 +1121,22 @@ struct SpirvCompute {
                               uint32_t* valid_lane = nullptr) {
         return subgroup_row_shr_dynamic(value, active, uconst(amount), 0, valid_lane);
     }
+    uint32_t subgroup_row_ror8(uint32_t value, uint32_t active,
+                               uint32_t* valid_lane = nullptr) {
+        mark_subgroup_min16();
+        const uint32_t lane = subgroup_local_id();
+        // ROW_ROR:8 swaps the two eight-lane halves of each architectural DPP16 row. XOR 8 is
+        // exactly (row_lane - 8) modulo 16 while preserving every row/subgroup bit above bit 3.
+        const uint32_t source_lane = ibin(Op_BitwiseXor, lane, uconst(8));
+        const uint32_t rotated = subgroup_shuffle(value, source_lane);
+        // FI=0 makes an EXEC-inactive source invalid. The one admitted form has BOUND_CTRL=1,
+        // whose caller substitutes zero for that invalid source before V_MIN_F32.
+        const uint32_t source_active = subgroup_shuffle(
+            sel(active, uconst(1), uconst(0)), source_lane);
+        const uint32_t valid = ucmp(Op_INotEqual, source_active, uconst(0));
+        if (valid_lane) *valid_lane = valid;
+        return sel(valid, rotated, value);
+    }
     uint32_t subgroup_quad_permute(uint32_t value, uint32_t ctrl) {
         const uint32_t lane = subgroup_local_id();
         const uint32_t quad_lane = ibin(Op_BitwiseAnd, lane, uconst(3));
@@ -8610,10 +8626,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // ROW_SHR in the proven one-live-lane NGG projection supplies zero for lane 0.
             if (in.has_dpp) {
                 const bool row_shr = in.dpp_ctrl >= 0x111u && in.dpp_ctrl <= 0x11Fu;
+                const bool row_ror8 = in.dpp_ctrl == 0x128u;
                 const bool fop = in.opcode == 0x03 || in.opcode == 0x04 || in.opcode == 0x05 ||
                                  in.opcode == 0x08 || in.opcode == 0x0F || in.opcode == 0x10 ||
                                  in.opcode == 0x1F || in.opcode == 0x2B;
-                if (row_shr) {
+                if (row_ror8) {
+                    // The decoder admits only GTA V's full-mask, BC1, FI0 V_MIN_F32 packet. Repeat
+                    // that contract at the production emission site: a straight-line region is
+                    // wave-visible, while structured compute requires one exact native guest wave.
+                    if (!b.is_compute || in.opcode != 0x0fu || !in.dpp_bound_ctrl ||
+                        in.dpp_row_mask != 0xfu || in.dpp_bank_mask != 0xfu ||
+                        (!allow_wave && !b.native_subgroup_size)) {
+                        ok = false; return true;
+                    }
+                    uint32_t valid_source = 0;
+                    const uint32_t rotated = b.subgroup_row_ror8(a, rs.exec, &valid_source);
+                    a = b.sel(valid_source, rotated, b.uconst(0));
+                } else if (row_shr) {
                     if (b.is_vertex) {
                         if (!b.ngg_one_lane || in.opcode != 0x25 || !in.dpp_bound_ctrl) {
                             ok = false; return true;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4509,6 +4509,7 @@ struct DivLoop {
     std::vector<uint32_t> break_pcs;   // extra forward vccz/execz -> exit_pc (lowered as body ifs)
     bool direct_exec_breaks = false;   // unconditional back-edge: an interior execz exits directly
     bool direct_wave_breaks = false;   // fragment wave64: an interior vccz exits the complete wave
+    bool bottom_tested = false;        // s_cbranch_execnz back-edge is the condition (do-while)
     Condition condition = Condition::Exec;
     // EXECZ/VCCZ and SCC0 all continue while their represented predicate is set. SCC1 is the one
     // admitted opposite-polarity canonical exit: it leaves the loop while SCC is set.
@@ -4769,24 +4770,48 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
             }
             // (tgt <= backedge_pc: an interior forward if — validated by detect_forward_ifs.)
         }
-        if (!L.exit_branch_pc) return {};         // no exit test: not this shape
-        // The canonical exit must be the FIRST branch in the loop, so the condition region
-        // [header, exit_branch) is branch-free (it is emitted straight-line).
-        for (const auto& in : ins) {
-            if (in.pc >= L.exit_branch_pc) break;
-            if (in.pc < L.header_pc || in.fmt != Rdna2Format::SOPP) continue;
-            if (in.opcode >= 0x02 && in.opcode <= 0x09 && in.opcode != 0x03 && !safe.count(in.pc))
-                return {};
+        if (!L.exit_branch_pc) {
+            // Bottom-tested EXEC loop: the back-edge itself is `s_cbranch_execnz HEADER`, so the
+            // complete body executes once before the first condition. Require the instruction
+            // immediately preceding the branch to update EXEC; accepting a stale entry mask here
+            // would turn an arbitrary backward branch into a do-while (and commonly an infinite
+            // one). GTA V's nested lighting loop ends in V_CMPX; the regression uses S_MOV_B64
+            // EXEC,0. Nested child branches were already validated and skipped above.
+            if (!execnz) return {};
+            const Rdna2Inst* condition_writer = nullptr;
+            for (const auto& in : ins) {
+                if (in.pc < L.header_pc) continue;
+                if (in.pc >= L.backedge_pc) break;
+                condition_writer = &in;
+            }
+            if (!condition_writer ||
+                !rdna2_instruction_may_change_exec(*condition_writer)) return {};
+            L.exit_branch_pc = L.backedge_pc;
+            L.condition = DivLoop::Condition::Exec;
+            L.continue_on_set = true;
+            L.bottom_tested = true;
+        }
+        if (!L.bottom_tested) {
+            // A top-tested loop's canonical exit must be the FIRST branch, so its condition region
+            // [header, exit_branch) is branch-free and can be emitted straight-line. A bottom-tested
+            // loop instead puts its complete, already-validated structured body in this region.
+            for (const auto& in : ins) {
+                if (in.pc >= L.exit_branch_pc) break;
+                if (in.pc < L.header_pc || in.fmt != Rdna2Format::SOPP) continue;
+                if (in.opcode >= 0x02 && in.opcode <= 0x09 && in.opcode != 0x03 &&
+                    !safe.count(in.pc)) return {};
+            }
         }
         // The execnz flavor's unconditional-continue lowering requires the header check to
         // immediately re-test EXEC (empty condition region) — see the shape comment.
-        if (execnz && L.exit_branch_pc != L.header_pc) return {};
+        if (execnz && !L.bottom_tested && L.exit_branch_pc != L.header_pc) return {};
     }
     // A nested child must lie entirely within its parent's BODY: after the parent's canonical exit
     // test (the condition region [header, exit_branch) stays branch-free) and before its back-edge.
     for (size_t i = 0; i < out.size(); i++)
         for (size_t j = i + 1; j < out.size(); j++)
             if (out[j].exit_pc <= out[i].backedge_pc &&        // nested per the classification above
+                !out[i].bottom_tested &&
                 out[j].header_pc <= out[i].exit_branch_pc) return {};
     // Pass 3: no branch from OUTSIDE a loop may target its interior (an unstructured entry edge).
     for (const auto& in : ins) {
@@ -17721,9 +17746,16 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // An EXEC-governed loop predicates vector writes. VCC/SCC-governed loops branch on their
             // represented predicate but do not themselves change EXEC, matching the hardware body.
             if (L.condition == DivLoop::Condition::Exec) rs.exec_narrowed = true;
-            // Condition region [header, exit_branch): branch-free (validated), straight-line.
+            // A top-tested condition region is branch-free. For a bottom-tested EXEC loop the
+            // same interval is the complete do-while body and may contain validated nested loops;
+            // recurse so those children keep their own structured merges before the latch test.
             const uint32_t condition_entry_scc = rs.scc;
-            if (!emit_range(L.header_pc, L.exit_branch_pc)) return false;
+            if (L.bottom_tested) {
+                if (!emit_structured(
+                        L.header_pc, L.exit_branch_pc, L.exit_branch_pc)) return false;
+            } else if (!emit_range(L.header_pc, L.exit_branch_pc)) {
+                return false;
+            }
             // A canonical SCC loop must compute a fresh representable scalar predicate on every
             // header visit. Reusing the header phi would admit stale SCC, while a B64 wave-mask
             // producer poisons rs.scc to zero; both remain fail-visible.
@@ -17757,7 +17789,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             uint32_t* prior_direct_wave_continue = active_direct_wave_continue;
             active_direct_wave_loop = &L;
             active_direct_wave_continue = &direct_wave_continue;
-            const bool body_ok = emit_structured(
+            const bool body_ok = L.bottom_tested || emit_structured(
                 L.exit_branch_pc + 1, L.backedge_pc, L.backedge_pc);
             active_direct_wave_loop = prior_direct_wave_loop;
             active_direct_wave_continue = prior_direct_wave_continue;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3681,6 +3681,21 @@ inline bool sopk_writes_scalar_data(uint32_t opcode) {
            opcode == 0x10 || opcode == 0x12;
 }
 
+inline bool sopk_sets_full_flat_scratch_base(const Rdna2Inst& in) {
+    if (in.fmt != Rdna2Format::SOPK || in.opcode != 0x13 ||
+        in.dst.kind != OperandKind::SGPR)
+        return false;
+    // S_SETREG_B32's SIMM16 is HWREG(id, offset, width-1). Prosper represents guest scratch as a
+    // private Function-storage array and intentionally has no physical FLAT_SCR base, so the exact
+    // full-half base relocation emitted by GTA V is semantically absorbed by that abstraction.
+    // Partial fields and every other hardware register remain fail-visible.
+    const uint32_t hwreg = static_cast<uint16_t>(in.simm16);
+    const uint32_t id = hwreg & 0x3fu;
+    const uint32_t offset = (hwreg >> 6) & 0x1fu;
+    const uint32_t width_minus_one = (hwreg >> 11) & 0x1fu;
+    return (id == 20u || id == 21u) && offset == 0u && width_minus_one == 31u;
+}
+
 namespace {
 uint32_t scalar_write_width(const Rdna2Inst& in);
 }
@@ -8088,6 +8103,13 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.device_uniform_release_barrier();
                     break;
                 case 0x18: case 0x19: case 0x1A: break;
+                case 0x13:                                // s_setreg_b32
+                    // The encoded SDST field is the SOURCE SGPR. Do not read it: this admission
+                    // discards only the physical FLAT_SCR relocation which Prosper's private
+                    // scratch model does not expose. Unsupported/dynamic scratch accesses still
+                    // reject independently in the FLAT emitter.
+                    if (!b.is_compute || !sopk_sets_full_flat_scratch_base(in)) ok = false;
+                    break;
                 default: ok = false;
             }
             return true;
@@ -9852,6 +9874,30 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     vreg[in.dst.value] = b.sel(
                         b.ucmp(Op_ULessThan, byte, b.uconst(4)), low,
                         b.sel(b.ucmp(Op_ULessThan, byte, b.uconst(8)), upper, b.uconst(0)));
+                }
+            } else if (in.opcode == 0x2FF) {                          // v_lshlrev_b64
+                // GTA V constructs a per-lane bit as `1ull << lane` immediately after MBCNT. This
+                // bounded admission keeps SRC1 at the exact inline integer 1; general register-pair
+                // and floating-inline sources need wider source-span/provenance handling.
+                const uint32_t opsel = (in.words[0] >> 11) & 0xFu;
+                const bool exact_one = in.src[1].kind == OperandKind::InlineInt &&
+                                       in.src[1].value == 1;
+                if (in.dst.value < 0 || in.dst.value >= 255 || !exact_one ||
+                    in.src_abs[0] || in.src_abs[1] || in.src_abs[2] ||
+                    in.src_neg[0] || in.src_neg[1] || in.src_neg[2] ||
+                    in.clamp || in.omod || opsel) {
+                    ok = false;
+                } else {
+                    const uint32_t amount = b.ibin(
+                        Op_BitwiseAnd, val(in.src[0]), b.uconst(63));
+                    const uint32_t result = b.u64_shift(
+                        Op_ShiftLeftLogical,
+                        b.u64_from_lohi(b.uconst(1), b.uconst(0)), amount);
+                    const int hi_dst = in.dst.value + 1;
+                    const uint32_t old_hi = vreg_old(b, rs, hi_dst);
+                    vreg[in.dst.value] = b.u64_lo(result);
+                    vreg[hi_dst] = b.u64_hi(result);
+                    predicate_write(b, rs, hi_dst, old_hi);
                 }
             } else if (in.opcode == 0x363) {                          // v_bfm_b32
                 // RDNA2: D.u32 = ((1 << S0[4:0]) - 1) << S1[4:0]. Mask both shift

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -17452,8 +17452,36 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // differ across a workgroup, so a barrier inside the loop would be workgroup-divergent
             // control flow (UB); barriers AFTER the loop are fine (the loop merge reconverges).
             bool compute_ok = !Ls.empty();
+            const BarrierPhasedCompute phased = analyze_barrier_phased_compute(ins);
+            auto has_stable_post_barrier_lds_reads = [&](const DivLoop& loop) {
+                if (!phased.found) return false;
+                size_t phase_begin = ins.size();
+                size_t phase_end = phased.end_index;
+                for (size_t barrier : phased.barriers) {
+                    if (ins[barrier].pc < loop.header_pc) {
+                        phase_begin = barrier + 1;
+                        continue;
+                    }
+                    phase_end = barrier;
+                    break;
+                }
+                if (phase_begin == ins.size() ||
+                    (phase_end < ins.size() && loop.exit_pc > ins[phase_end].pc))
+                    return false;
+                // This narrow exception is read-only for the COMPLETE phase. A preceding proved
+                // top-level barrier publishes earlier LDS initialization; with no later LDS write,
+                // atomic, GDS access, or other DS opcode, each per-lane loop may repeat its own
+                // ordinary DS_READ_B32 without introducing visibility or synchronization edges.
+                for (size_t i = phase_begin; i < phase_end; ++i)
+                    if (ins[i].fmt == Rdna2Format::DS &&
+                        (ins[i].opcode != 0x36 || ins[i].ds_gds))
+                        return false;
+                return true;
+            };
             for (const auto& L : Ls) {
                 if (!compute_ok) break;
+                const bool stable_post_barrier_reads =
+                    has_stable_post_barrier_lds_reads(L);
                 for (const auto& in : ins) {
                     if (in.is_end || in.pc >= L.exit_pc) break;
                     if (in.pc < L.header_pc) continue;
@@ -17461,11 +17489,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                         (in.opcode == 0x35 || in.opcode == 0x3d || in.opcode == 0x3e);
                     // SCC is architectural scalar control, so an SCC loop executes ordinary LDS
                     // effects uniformly within each guest wave just like the existing CountedLoop
-                    // path. EXEC/VCC loops retain their per-invocation approximation and therefore
-                    // keep rejecting all LDS. Cross-lane DS collectives, MBCNT, and a guest barrier
-                    // remain unavailable in every multi-loop condition domain.
+                    // path. EXEC/VCC loops retain their per-invocation approximation: only ordinary
+                    // read-only LDS in the proved stable post-barrier phase above is safe. Cross-lane
+                    // DS collectives, writes/atomics, MBCNT, and a guest barrier remain unavailable.
+                    const bool stable_lds_read = stable_post_barrier_reads &&
+                        in.fmt == Rdna2Format::DS && in.opcode == 0x36 && !in.ds_gds;
                     if ((in.fmt == Rdna2Format::DS &&
-                         (L.condition != DivLoop::Condition::Scc || ds_wave_collective)) ||
+                         ((L.condition != DivLoop::Condition::Scc && !stable_lds_read) ||
+                          ds_wave_collective)) ||
                         (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) ||
                         (in.fmt == Rdna2Format::VOP3 &&
                          (in.opcode == 0x365 || in.opcode == 0x366))) { compute_ok = false; break; }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -16946,6 +16946,146 @@ BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdna2Inst>
     return result;
 }
 
+// RDNA waves order their own LDS instructions, but the portable compute shell represents guest
+// wave lanes as independent Vulkan invocations. A plain OpStore performed by lane 0 therefore does
+// not publish its value to a following cross-lane atomic merely because every invocation reaches
+// the atomic later in program order. GTA V's BVH bounds kernel uses this exact wave-synchronous
+// idiom: select EXEC=1, initialize six adjacent dwords with one B64 and one B128 write, restore
+// EXEC=-1, set vaddr=0, then issue three DS_MIN_F32 and three DS_MAX_F32 operations.
+//
+// Recognize only that byte-exact sequence and insert an emitter-only S_BARRIER before the first
+// atomic. A straight-line shader emits it directly. With scalar control flow, a no-crossing-edge
+// proof keeps the boundary top-level in the compact structurizer or lets the existing phase route
+// lift it outside a complex dispatcher, so every workgroup invocation reaches the same dynamic
+// barrier. Any other float atomic following an unsynchronized ordinary LDS store rejects visibly;
+// a real guest barrier, or an atomic with no preceding ordinary store in its phase, remains
+// architectural and needs no synthesized edge.
+bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
+                                         RecompileDiagnosticContext diagnostic) {
+    auto ordinary_lds_store = [](const Rdna2Inst& in) {
+        if (in.fmt != Rdna2Format::DS || in.ds_gds) return false;
+        return in.opcode == 0x0d || in.opcode == 0x0e || in.opcode == 0x4d ||
+               in.opcode == 0xb0 || in.opcode == 0xde || in.opcode == 0xdf;
+    };
+    auto float_lds_atomic = [](const Rdna2Inst& in) {
+        return in.fmt == Rdna2Format::DS && !in.ds_gds &&
+               (in.opcode == 0x12 || in.opcode == 0x13);
+    };
+    auto words_are = [](const Rdna2Inst& in, uint32_t word0, uint32_t word1) {
+        return in.words[0] == word0 && in.words[1] == word1;
+    };
+
+    static constexpr uint32_t kAtomicWord0[6] = {
+        0xd8480000u, 0xd8480004u, 0xd8480008u,
+        0xd84c000cu, 0xd84c0010u, 0xd84c0014u,
+    };
+    static constexpr uint32_t kAtomicWord1[6] = {
+        0x00000900u, 0x00000a00u, 0x00000b00u,
+        0x00000600u, 0x00000700u, 0x00000800u,
+    };
+
+    std::vector<size_t> phase_stores;
+    std::vector<size_t> synth_before;
+    for (size_t i = 0; i < ins.size(); ++i) {
+        const Rdna2Inst& in = ins[i];
+        if (in.fmt == Rdna2Format::SOPP && in.opcode == 0x0a) {
+            phase_stores.clear();
+            continue;
+        }
+        if (ordinary_lds_store(in)) {
+            phase_stores.push_back(i);
+            continue;
+        }
+        if (!float_lds_atomic(in) || phase_stores.empty()) continue;
+
+        bool exact = i >= 4 && i + 5 < ins.size() && phase_stores.size() == 2 &&
+            phase_stores[0] == i - 4 && phase_stores[1] == i - 3 &&
+            words_are(ins[i - 4], 0xd9340010u, 0x0000040cu) &&
+            words_are(ins[i - 3], 0xdb7c0000u, 0x0000000cu) &&
+            ins[i - 2].words[0] == 0xbefe04c1u && // s_mov_b64 exec, -1
+            ins[i - 1].words[0] == 0x7e000280u;   // v_mov_b32 v0, 0
+        for (size_t atomic = 0; exact && atomic < 6; ++atomic)
+            exact = words_are(ins[i + atomic], kAtomicWord0[atomic], kAtomicWord1[atomic]);
+
+        bool found_lane0 = false;
+        if (exact) {
+            for (size_t j = i - 4; j-- > 0;) {
+                const Rdna2Inst& prefix = ins[j];
+                if (prefix.words[0] == 0xbefe0481u) { // s_mov_b64 exec, 1
+                    found_lane0 = true;
+                    for (size_t k = j + 1; k < i - 2; ++k) {
+                        const Rdna2Inst& between = ins[k];
+                        if (between.fmt == Rdna2Format::SOPP ||
+                            (rdna2_instruction_may_change_exec(between) &&
+                             between.words[0] != 0xbefe04c1u)) {
+                            found_lane0 = false;
+                            break;
+                        }
+                    }
+                    break;
+                }
+                if (prefix.fmt == Rdna2Format::SOPP ||
+                    rdna2_instruction_may_change_exec(prefix))
+                    break;
+            }
+        }
+        if (!exact || !found_lane0) {
+            log_recompile_diagnostic(
+                diagnostic, "compute-recompile-reject", "terminal",
+                "pc=%u reason=unsynchronized-lds-store-before-ds-fminmax", in.pc);
+            return false;
+        }
+
+        synth_before.push_back(i);
+        phase_stores.clear();
+        i += 5; // the byte-exact six-atomic group shares the one publication barrier
+    }
+
+    std::vector<uint32_t> synth_pcs;
+    synth_pcs.reserve(synth_before.size());
+    for (size_t index : synth_before) synth_pcs.push_back(ins[index].pc);
+    for (auto it = synth_before.rbegin(); it != synth_before.rend(); ++it) {
+        Rdna2Inst barrier;
+        barrier.pc = ins[*it].pc; // boundary immediately before the atomic at this guest PC
+        barrier.fmt = Rdna2Format::SOPP;
+        barrier.opcode = 0x0a;
+        barrier.words[0] = 0xbf8a0000u;
+        barrier.len_dwords = 0;   // emitter-only marker; never part of the guest byte stream
+        ins.insert(ins.begin() + static_cast<std::ptrdiff_t>(*it), barrier);
+    }
+
+    // Prove each synthesized boundary is top-level even when the compact structurizer (rather than
+    // the phase dispatcher) owns the program. Branches and loops may finish before the boundary,
+    // but no edge may skip it, enter it from the far side, or carry only part of a workgroup back
+    // across it. Traps/indirect PC changes before it also fail closed. This is the same edge
+    // invariant used by the barrier-phase route without its unrelated >2-branch selection policy.
+    for (uint32_t barrier_pc : synth_pcs) {
+        bool uniform = true;
+        for (const Rdna2Inst& in : ins) {
+            if (in.pc < barrier_pc &&
+                (in.is_end ||
+                 (in.fmt == Rdna2Format::SOPP && in.opcode == 0x12) ||
+                 (in.fmt == Rdna2Format::SOP1 && in.opcode >= 0x20u && in.opcode <= 0x22u)))
+                uniform = false;
+            if (in.fmt != Rdna2Format::SOPP || in.opcode < 0x02 || in.opcode > 0x09 ||
+                in.opcode == 0x03 || in.opcode == 0x0a)
+                continue;
+            const uint32_t target = branch_target(in);
+            if ((in.pc < barrier_pc && target >= barrier_pc) ||
+                (in.pc > barrier_pc && target <= barrier_pc))
+                uniform = false;
+        }
+        if (!uniform) {
+            log_recompile_diagnostic(
+                diagnostic, "compute-recompile-reject", "terminal",
+                "pc=%u reason=lds-fminmax-publication-barrier-not-workgroup-uniform",
+                barrier_pc);
+            return false;
+        }
+    }
+    return true;
+}
+
 // Emit the instruction body (shared by every stage). Handles a single recognized COUNTED loop as a real
 // structured SPIR-V loop (OpLoopMerge + OpPhi for loop-carried registers); loop-FREE streams walk straight
 // through, byte-identical to the pre-loop-feature behavior. `exp_fn` handles an EXP instruction per stage
@@ -18225,6 +18365,7 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     // converge in the host SPIR-V without inventing further guest execution. Graphics exports keep
     // separate side-effect bookkeeping and remain on the conservative reject path for this shape.
     (void)extend_terminating_if_else(code, dwords, ins);
+    if (!prepare_lds_fminmax_synchronization(ins, {})) return {};
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     // Size the LDS array from the shader's real allocation when known (#130): bytes -> dwords, at
@@ -18266,6 +18407,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     // See recompile_valu: compute has no branch-external EXP state, so the common host-shell merge is
     // only a place to finish the invocation after either guest arm has terminated.
     (void)extend_terminating_if_else(code, dwords, ins);
+    if (!prepare_lds_fminmax_synchronization(ins, diagnostic)) return {};
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     b.diagnostic = diagnostic;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -417,6 +417,11 @@ struct SpirvCompute {
     // phase/CFG emitters see the proof derived from the original complete instruction stream.
     bool cselect_b64_low_only_analysis_done = false;
     std::unordered_set<uint32_t> cselect_b64_low_only_pcs;
+    // GTA V also selects one B32 scalar directly into Wave64 VCC_LO and consumes only that low word.
+    // The untouched VCC_HI mask is unrepresentable once the pair becomes a mixed data/mask lifetime;
+    // retain only sites whose whole-stream proof shows that high half dead before any mask read.
+    bool vcc_b32_low_only_analysis_done = false;
+    std::unordered_set<uint32_t> vcc_b32_low_only_pcs;
     bool     declared_subgroup=0, declared_subgroup_vote=0, declared_subgroup_arithmetic=0;
     // When non-zero, the backend promises to create this compute pipeline with an exact required
     // subgroup size equal to the PS5 wave. Native votes/scans are then architecture-exact.
@@ -3983,6 +3988,29 @@ std::unordered_set<uint32_t> proven_cselect_b64_low_only_pcs(
     return result;
 }
 
+// GTA V 0x413e15400 pc152 selects the scalar constant 1 or 2 into VCC_LO, copies that dword to a
+// VGPR, and then replaces architectural VCC before any mask consumer. The low word is exactly
+// representable as scalar data; the old high-half predicate is not. Admit only this byte-exact
+// packet and only when the shared CFG liveness walk proves VCC_HI dead on every successor path.
+bool is_gtav_wave64_vcc_lo_scalar_cselect(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::SOP2 && in.opcode == 0x0au &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value == 106 &&
+        in.src[0].kind == OperandKind::InlineInt && in.src[0].value == 1 &&
+        in.src[1].kind == OperandKind::InlineInt && in.src[1].value == 2;
+}
+
+std::unordered_set<uint32_t> proven_wave64_vcc_b32_low_only_pcs(
+        const std::vector<Rdna2Inst>& ins) {
+    std::unordered_set<uint32_t> result;
+    for (const Rdna2Inst& in : ins) {
+        if (in.is_end) break;
+        if (is_gtav_wave64_vcc_lo_scalar_cselect(in) &&
+            sgpr_dead_at_merge(ins, in.pc + in.len_dwords, 107))
+            result.insert(in.pc);
+    }
+    return result;
+}
+
 // #2418: does this shader read SCC anywhere? Used to decide whether the fragment stage should pay for
 // an exact wave vote when a mask op writes SCC. Deliberately CONSERVATIVE and whole-shader: it answers
 // "could SCC ever be consumed", not "is this particular write live". A false positive costs one shader a
@@ -7307,6 +7335,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool gtav_wave32_vcchi_scalar_packet =
                 allows_compute_scalar_vcc_bridge(b) && b.native_subgroup_size == 32 &&
                 is_gtav_wave32_vcchi_scalar_packet(in);
+            if (b.is_compute && b.wave_size == 64 && in.opcode == 0x0a &&
+                in.dst.kind == OperandKind::SGPR && in.dst.value == 106) {
+                // A B32 write leaves Wave64 VCC_HI untouched, so the resulting mixed physical pair
+                // cannot remain in the architectural mask domain. Keep every non-live packet and
+                // every path with a later high-half/mask read fail-visible. At the proved GTA site,
+                // preserve only the selected low scalar word and poison VCC until its later VOPC
+                // replacement; the liveness proof guarantees nothing can observe that poison.
+                if (!is_gtav_wave64_vcc_lo_scalar_cselect(in) ||
+                    !b.vcc_b32_low_only_pcs.contains(in.pc) || !rs.scc) {
+                    ok = false; return true;
+                }
+                const uint32_t selected = b.sel(
+                    rs.scc, val(in.src[0]), val(in.src[1]));
+                if (!ok) return true;
+                rs.sreg[106] = selected;
+                rs.sreg_srt.erase(106);
+                rs.sreg_bool.erase(106);
+                rs.sreg_bool_narrowed.erase(106);
+                rs.sreg_bool_b32.erase(106);
+                rs.vcc = 0;
+                return true;
+            }
             if (b.allow_b32_masks &&
                 (b.is_fragment || (b.is_compute && b.wave_size == 32)) &&
                 in.opcode == 0x0a &&
@@ -14707,6 +14757,12 @@ bool emit_cfg_state_machine(
                 }
             };
             for_each_scalar_write(in, erase_overlapping, /*wave32_one_word_masks*/false);
+            // This exact B32 write resolves VCC_LO to scalar data while the whole-stream proof
+            // guarantees the untouched high half cannot be observed before a complete replacement.
+            // It is therefore safe to clear the pair-domain ambiguity for this path; a later join
+            // with a mask path will recreate the ambiguity in the ordinary MUST merge below.
+            if (b.vcc_b32_low_only_pcs.contains(in.pc))
+                ambiguous.erase(106);
             // An implicit VOPC destination is architectural VCC and is absent from the explicit
             // scalar-writer inventory.
             if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
@@ -17189,6 +17245,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         b.cselect_b64_low_only_pcs = proven_cselect_b64_low_only_pcs(ins);
         b.cselect_b64_low_only_analysis_done = true;
     }
+    if (!b.vcc_b32_low_only_analysis_done) {
+        b.vcc_b32_low_only_pcs = proven_wave64_vcc_b32_low_only_pcs(ins);
+        b.vcc_b32_low_only_analysis_done = true;
+    }
     if (!rs.smem_x16_descriptor_analysis_done) {
         rs.smem_x16_descriptor_loads = proven_smem_x16_descriptor_loads(ins, rt);
         rs.smem_x16_descriptor_analysis_done = true;
@@ -18846,6 +18906,8 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
     SpirvCompute b; b.begin(1);
     b.cselect_b64_low_only_pcs = proven_cselect_b64_low_only_pcs(ins);
     b.cselect_b64_low_only_analysis_done = true;
+    b.vcc_b32_low_only_pcs = proven_wave64_vcc_b32_low_only_pcs(ins);
+    b.vcc_b32_low_only_analysis_done = true;
     b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -10303,6 +10303,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             in.pc, in.opcode);
                 ok = false; return true;
             }
+            // The front half proved all four live SBASE words at this exact scalar-buffer load and
+            // decoded NUM_RECORDS=0. Every possible immediate/register SOFFSET is therefore OOB, so
+            // the result is exact zero without declaring or touching a dummy storage binding. Check
+            // this before SOFFSET tracking: the point of the proof is that even an unknown runtime
+            // offset cannot change the result.
+            const ShaderResource* zero_record_sbuffer =
+                rt && in.opcode >= 0x8u ? rt->by_fetch_pc(in.pc) : nullptr;
+            if (zero_record_sbuffer && is_zero_record_raw_buffer(*zero_record_sbuffer)) {
+                for (uint32_t k = 0; k < n; ++k) {
+                    rs.sreg[in.dst.value + static_cast<int>(k)] = b.uconst(0);
+                    rs.sreg_srt.erase(in.dst.value + static_cast<int>(k));
+                }
+                return true;
+            }
             // SOFFSET handling. Immediate-only loads encode SOFFSET = SGPR_NULL (125). A register
             // SOFFSET adds an SGPR-computed byte offset:
             //  * a DESCRIPTOR s_load (x4/x8 = V#/T#) with a computed offset is the bindless fetch's
@@ -10737,6 +10751,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                 rt ? rt->resources.size() : 0u);
                     }
                     ok = false; return true;
+                }
+                if (is_zero_record_raw_buffer(*res)) {
+                    // The exact live V# is empty, so format selection is never observed: every load
+                    // component returns zero and no backing buffer exists. Apply the result only to
+                    // active EXEC lanes, preserving the old destination in masked lanes.
+                    if (is_store) { ok = false; return true; }
+                    for (uint32_t k = 0; k < n; ++k) {
+                        const int d = in.dst.value + static_cast<int>(k);
+                        const uint32_t old = vreg_old(b, rs, d);
+                        rs.vreg[d] = b.uconst(0);
+                        predicate_write(b, rs, d, old);
+                    }
+                    return true;
                 }
                 resolved_buffer = res;
                 binding = res->binding;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -11169,7 +11169,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // four-dword BVH descriptor and eleven NSA VGPR operands. Vulkan ray-query support is
             // not available on every backend/device Prosper supports, so lower the exact RTIP 1.1
             // contract used by Astro Bot to ordinary read-only SSBO loads and scalar ALU. The
-            // front-half admits only TYPE=8, triangle-return-mode=1, unsorted descriptors; keeping
+            // front-half admits only TYPE=8, triangle-return-mode=1 descriptors; keeping
             // the instruction gate equally narrow makes every unverified variant fail visibly.
             if (in.opcode == 0xe6u) {
                 const ShaderResource* bvh = rt->by_fetch_pc(in.pc);
@@ -11320,9 +11320,11 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 tri_out[3] = swizzled_bary(j_selector);
 
                 // Convert each FP16 box payload to the same six-float representation as an FP32
-                // box, then apply the slab test to all four children. Sorting is deliberately absent:
-                // the admitted Astro descriptor has BOX_SORT_EN=0, so architectural order is kept.
+                // box, then apply the slab test to all four children. BOX_SORT_EN orders valid hits
+                // by increasing near intersection time; misses receive +INF and therefore remain at
+                // the end. Strict compare-swaps retain physical child order for equal-time hits.
                 uint32_t box_out[4]{};
+                uint32_t box_key[4]{};
                 uint32_t ray_inv[3] = {a[8], a[9], a[10]};
                 for (uint32_t child = 0; child < 4; ++child) {
                     const uint32_t hbase = 4u + child * 3u;
@@ -11360,7 +11362,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.logical_not(nan_interval),
                         b.fcmp(Op_FOrdLessThanEqual, near_t,
                                fmul(far_t, b.uconst(std::bit_cast<uint32_t>(box_multiplier)))));
-                    box_out[child] = b.sel(b.land(box_valid, hit), w[child], invalid);
+                    const uint32_t valid_hit = b.land(box_valid, hit);
+                    box_out[child] = b.sel(valid_hit, w[child], invalid);
+                    box_key[child] = b.sel(valid_hit, near_t, b.uconst(0x7f800000u));
+                }
+                if (bvh->bvh_sort_enabled) {
+                    auto compare_swap = [&](uint32_t left, uint32_t right) {
+                        const uint32_t left_key = box_key[left];
+                        const uint32_t right_key = box_key[right];
+                        const uint32_t left_out = box_out[left];
+                        const uint32_t right_out = box_out[right];
+                        const uint32_t swap = b.fcmp(
+                            Op_FOrdGreaterThan, left_key, right_key);
+                        box_key[left] = b.sel(swap, right_key, left_key);
+                        box_key[right] = b.sel(swap, left_key, right_key);
+                        box_out[left] = b.sel(swap, right_out, left_out);
+                        box_out[right] = b.sel(swap, left_out, right_out);
+                    };
+                    compare_swap(0, 1);
+                    compare_swap(2, 3);
+                    compare_swap(0, 2);
+                    compare_swap(1, 3);
+                    compare_swap(1, 2);
                 }
 
                 for (uint32_t k = 0; k < 4; ++k) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -14374,6 +14374,11 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> proven_exec_saved_mask_compare_pcs;
     std::unordered_set<uint32_t> proven_wave64_mask_reduction_pcs;
     std::unordered_map<uint32_t, int> proven_wave64_mbcnt_mask_root_for_pc;
+    // Retain the entry facts beyond the consumer-specialization pass below. Function Bool
+    // variables persist values only; this MUST set is the separate lifetime tag load_state needs
+    // before reconstructing a saved-mask RegState entry in each dispatcher case.
+    std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
+    std::vector<bool> wave64_b64_reachable(starts.size(), false);
     auto wave64_mask_reduction_source = [&](const Rdna2Inst& in) -> int {
         if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::SOP1 ||
             (in.opcode != 0x10 && in.opcode != 0x14))
@@ -14399,8 +14404,6 @@ bool emit_cfg_state_machine(
         return root >= 0 && root <= 105 ? root : -1;
     };
     if ((b.is_compute || b.is_fragment) && b.wave_size == 64 && !starts.empty()) {
-        std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
-        std::vector<bool> wave64_b64_reachable(starts.size(), false);
         for (const auto& mask : initial.sreg_bool)
             if (!initial.sreg_bool_b32.contains(mask.first) && mask.first <= 105)
                 wave64_b64_mask_in.front().insert(mask.first);
@@ -14450,6 +14453,12 @@ bool emit_cfg_state_machine(
             } else if (in.fmt == Rdna2Format::SOP2 && in.dst.value <= 107) {
                 if (in.opcode == 0x25)
                     mask_write = in.dst.value;
+                else if (in.opcode == 0x0b && in.dst.value == 106 &&
+                         !b.cselect_b64_low_only_pcs.contains(in.pc))
+                    // A complete scalar-data pair selected into VCC has a dual lifetime: emit_alu
+                    // derives its per-lane predicate even though neither input is a mask. The one
+                    // incomplete GTA form deliberately has no predicate and is excluded here.
+                    mask_write = 106;
                 else if ((in.opcode == 0x0b ||
                           (in.opcode >= 0x0f && in.opcode <= 0x1d &&
                            (in.opcode & 1u) == 1)) &&
@@ -14902,22 +14911,31 @@ bool emit_cfg_state_machine(
         for (const auto& kv : sv) state.sreg[kv.first] = b.load_function(b.t_u32, kv.second);
         const std::set<int>* entry_b32 = nullptr;
         const std::set<int>* entry_b64 = nullptr;
+        const std::set<int>* entry_wave64_b64 = nullptr;
+        uint32_t entry_block = UINT32_MAX;
+        if (dispatch != UINT32_MAX)
+            entry_block = dispatch_blocks[dispatch].front();
+        else if (const auto terminal = block_for_pc.find(end_pc);
+                 terminal != block_for_pc.end())
+            entry_block = terminal->second;
         if (b.allow_b32_masks) {
-            uint32_t entry_block = UINT32_MAX;
-            if (dispatch != UINT32_MAX)
-                entry_block = dispatch_blocks[dispatch].front();
-            else if (const auto terminal = block_for_pc.find(end_pc);
-                     terminal != block_for_pc.end())
-                entry_block = terminal->second;
             if (entry_block != UINT32_MAX && b32_mask_reachable[entry_block]) {
                 entry_b32 = &b32_mask_in[entry_block];
                 entry_b64 = &b64_mask_in[entry_block];
             }
         }
+        const bool filters_wave64_b64 = (b.is_compute || b.is_fragment) &&
+            b.wave_size == 64;
+        if (filters_wave64_b64 && entry_block != UINT32_MAX &&
+            wave64_b64_reachable[entry_block])
+            entry_wave64_b64 = &wave64_b64_mask_in[entry_block];
         for (const auto& kv : mv) {
             if (b.allow_b32_masks &&
                 (!entry_b64 || !entry_b64->contains(kv.first)) &&
                 (!entry_b32 || !entry_b32->contains(kv.first)))
+                continue;
+            if (filters_wave64_b64 &&
+                (!entry_wave64_b64 || !entry_wave64_b64->contains(kv.first)))
                 continue;
             state.sreg_bool[kv.first] = b.load_function(b.t_bool, kv.second);
             state.sreg_bool_narrowed[kv.first] = true;
@@ -14929,8 +14947,10 @@ bool emit_cfg_state_machine(
             state.vgpr_lane_mask_slots[kv.first.first][kv.first.second] =
                 b.load_function(b.t_bool, kv.second);
         state.scc = b.load_function(b.t_bool, scc_var);
-        state.vcc = (!entry_b32 || entry_b32->contains(106))
-            ? b.load_function(b.t_bool, vcc_var) : 0;
+        const bool live_vcc = filters_wave64_b64
+            ? entry_wave64_b64 && entry_wave64_b64->contains(106)
+            : (!entry_b32 || entry_b32->contains(106));
+        state.vcc = live_vcc ? b.load_function(b.t_bool, vcc_var) : 0;
         state.exec = b.load_function(b.t_bool, exec_var);
         if (entry_b32) {
             for (int reg : *entry_b32) {
@@ -18492,6 +18512,16 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
         }
     }
     return cov;
+}
+
+std::vector<uint32_t> cselect_b64_low_only_pcs_for_test(
+        const uint32_t* code, size_t dwords) {
+    std::vector<Rdna2Inst> ins;
+    rdna2_walk(code, dwords, ins);
+    const auto proven = proven_cselect_b64_low_only_pcs(ins);
+    std::vector<uint32_t> result(proven.begin(), proven.end());
+    std::sort(result.begin(), result.end());
+    return result;
 }
 
 static uint64_t shader_program_hash(const uint32_t* code, size_t dwords) {

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -17454,7 +17454,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             bool compute_ok = !Ls.empty();
             const BarrierPhasedCompute phased = analyze_barrier_phased_compute(ins);
             auto has_stable_post_barrier_lds_reads = [&](const DivLoop& loop) {
-                if (!phased.found) return false;
+                // The structured emitter performs the Workgroup load before predicating the VGPR
+                // result. Limit this exception to a top-tested EXEC loop, where the body entry
+                // proves this invocation active, and keep that proof live through every DS read.
+                if (!phased.found || loop.condition != DivLoop::Condition::Exec ||
+                    loop.bottom_tested) return false;
                 size_t phase_begin = ins.size();
                 size_t phase_end = phased.end_index;
                 for (size_t barrier : phased.barriers) {
@@ -17476,6 +17480,14 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     if (ins[i].fmt == Rdna2Format::DS &&
                         (ins[i].opcode != 0x36 || ins[i].ds_gds))
                         return false;
+                for (const auto& read : ins) {
+                    if (read.pc <= loop.exit_branch_pc || read.pc >= loop.backedge_pc ||
+                        read.fmt != Rdna2Format::DS) continue;
+                    for (const auto& prior : ins) {
+                        if (prior.pc <= loop.exit_branch_pc || prior.pc >= read.pc) continue;
+                        if (rdna2_instruction_may_change_exec(prior)) return false;
+                    }
+                }
                 return true;
             };
             for (const auto& L : Ls) {

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -408,6 +408,12 @@ struct RecompileCoverage {
 };
 RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords);
 
+// Test seam for the whole-stream liveness gate on GTA V's incomplete S_CSELECT_B64 source pair.
+// A returned PC is admitted at the select itself; later failure to materialize VCC_HI cannot make
+// this proof pass accidentally.
+std::vector<uint32_t> cselect_b64_low_only_pcs_for_test(
+    const uint32_t* code, size_t dwords);
+
 // A general (non-scratch) FLAT load resolved to a base user-SGPR pointer pair (#1171). The 64-bit
 // address VGPR pair of a `base + offset` flat access is `v[vaddr_lo_reg : vaddr_lo_reg+1]`, and the
 // base pointer's low/high dwords live in consecutive user SGPRs `s[base_sgpr : base_sgpr+1]`. With the

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -253,6 +253,10 @@ struct ComputeShaderConfig {
     // frontend. Offline callers default to the portable raw path; live execution supplies the exact
     // physical-device mask so unsupported typed formats compile to the raw uvec4 fallback.
     uint32_t native_storage_format_support = 0;
+    // True only when the Vulkan device that will execute this module was created with shaderInt64
+    // and shaderBufferInt64Atomics enabled. The exact qword-atomic lowerings reject when false
+    // instead of emitting a module whose capability the device merely advertises.
+    bool storage_buffer_int64_atomics = false;
     // Use an exact typed R32_UINT storage image for R11G11B10 when the device cannot store that
     // packed float format natively. The generated shader packs/unpacks the guest word in SPIR-V,
     // avoiding the portable but much wider RGBA32_UINT CPU-conversion interchange format.

--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -1007,8 +1007,44 @@ DescriptorValidationReport validate_spirv_descriptor_interface(
     }
     if (consumed_zero_pad_markers.size() != zero_pad_markers.size()) add_malformed(report);
     std::sort(report.descriptors.begin(), report.descriptors.end(), [](const auto& a, const auto& b) {
-        return a.set != b.set ? a.set < b.set : a.binding < b.binding;
+        if (a.set != b.set) return a.set < b.set;
+        if (a.binding != b.binding) return a.binding < b.binding;
+        return a.variable_id < b.variable_id;
     });
+    // Logical-addressing SPIR-V needs a separate runtime-u64 Block variable for a 64-bit atomic over
+    // the ordinary runtime-u32 storage-buffer ABI. Both variables deliberately name one Vulkan
+    // descriptor binding. Reflection is a binding contract, not a variable list: coalesce compatible
+    // storage-buffer aliases so the backend creates one VkDescriptorSetLayoutBinding, while retaining
+    // the strongest byte/access requirements from either view. Any incompatible duplicate remains a
+    // malformed module instead of being papered over here.
+    std::vector<SpirvDescriptorBinding> coalesced;
+    coalesced.reserve(report.descriptors.size());
+    for (const SpirvDescriptorBinding& descriptor : report.descriptors) {
+        if (coalesced.empty() || coalesced.back().set != descriptor.set ||
+            coalesced.back().binding != descriptor.binding) {
+            coalesced.push_back(descriptor);
+            continue;
+        }
+        SpirvDescriptorBinding& prior = coalesced.back();
+        const bool compatible =
+            prior.kind == SpirvDescriptorKind::StorageBuffer &&
+            descriptor.kind == SpirvDescriptorKind::StorageBuffer &&
+            prior.stage == descriptor.stage &&
+            prior.descriptor_count == descriptor.descriptor_count &&
+            prior.zero_pad_logical_bytes == descriptor.zero_pad_logical_bytes &&
+            prior.zero_pad_binding_bytes == descriptor.zero_pad_binding_bytes &&
+            prior.zero_pad_semantic == descriptor.zero_pad_semantic;
+        if (!compatible) {
+            add_malformed(report);
+            continue;
+        }
+        prior.required_bytes = std::max(prior.required_bytes, descriptor.required_bytes);
+        prior.dynamic_access |= descriptor.dynamic_access;
+        prior.readable |= descriptor.readable;
+        prior.writable |= descriptor.writable;
+        prior.atomic_access |= descriptor.atomic_access;
+    }
+    report.descriptors = std::move(coalesced);
 
     // Reflection depends only on immutable SPIR-V. Runtime addresses, sizes, metadata, and the
     // expected stage/set are validated below on every call. Keeping those out of this cache lets a

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -455,9 +455,9 @@ inline bool is_proven_null_bvh(const ShaderResource& resource) {
            resource.host_data_size >= resource.size;
 }
 
-// Exact-PC marker for a fully-known raw/untyped MUBUF descriptor with NUM_RECORDS=0. Such a descriptor
-// has architectural zero-read/drop-write behavior and performs no memory operation for atomics,
-// regardless of its base, so it deliberately has no guest or host backing. The unusual
+// Exact-PC marker for a fully-known buffer descriptor with NUM_RECORDS=0. Such a descriptor has
+// architectural zero-read/drop-write behavior for the admitted scalar, raw, format-load, and atomic
+// operations, regardless of its base, so it deliberately has no guest or host backing. The unusual
 // Unknown/zero-component shape keeps it distinct from an ordinary explicit null buffer and survives
 // capture/replay without adding a serialized descriptor field.
 inline bool is_zero_record_raw_buffer(const ShaderResource& resource) {

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -248,6 +248,11 @@ struct ShaderResource {
     // ConstantBuffer view created from a validated BVH descriptor.
     uint32_t      bvh_box_grow  = 0;
 
+    // BVH descriptor BOX_SORT_EN (bit 63). When set, IMAGE_BVH_INTERSECT_RAY returns box-child
+    // pointers in increasing intersection-time order instead of physical node order. This changes
+    // generated SPIR-V and therefore participates in compile-cache and capture identity.
+    bool          bvh_sort_enabled = false;
+
     // FLAT-window (#1171) provenance: for a general flat_load whose 64-bit source pointer lives in the
     // consecutive user SGPRs s[flat_base_sgpr : +1], the executor binds the containing guest allocation
     // as this SSBO (keyed by the load's fetch_pc) and the emitter lowers the load to an indexed read at

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -456,10 +456,10 @@ inline bool is_proven_null_bvh(const ShaderResource& resource) {
 }
 
 // Exact-PC marker for a fully-known buffer descriptor with NUM_RECORDS=0. Such a descriptor has
-// architectural zero-read/drop-write behavior for the admitted scalar, raw, format-load, and atomic
-// operations, regardless of its base, so it deliberately has no guest or host backing. The unusual
-// Unknown/zero-component shape keeps it distinct from an ordinary explicit null buffer and survives
-// capture/replay without adding a serialized descriptor field.
+// architectural zero-read/drop-write behavior for the admitted bounded scalar, raw, format-load, and
+// atomic operations, regardless of its base, so it deliberately has no guest or host backing. The
+// unusual Unknown/zero-component shape keeps it distinct from an ordinary explicit null buffer and
+// survives capture/replay without adding a serialized descriptor field.
 inline bool is_zero_record_raw_buffer(const ShaderResource& resource) {
     return resource.cls == ResourceClass::ConstantBuffer &&
            resource.format == DataFormat::Unknown && resource.num_components == 0u &&

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -375,6 +375,12 @@ struct ShaderResource {
     // later operation consumes the same version. Production tables leave both fields zero and use guest memory.
     uint8_t*       host_data        = nullptr;
     uint64_t       host_data_size   = 0;
+
+    // Instruction-scoped record-count proof for GTA V's exact linear stride-8 qword-atomic V#. Appended
+    // after the historical aggregate-initialized fields so positional test fixtures remain stable.
+    // OOB_SELECT is not otherwise retained by this normalized resource, so emission, cache identity,
+    // capture, and per-dispatch revalidation carry the proof explicitly.
+    uint32_t       atomic_x2_record_count = 0;
 };
 
 // A one-layer guest 2D-array descriptor is byte-identical to an ordinary 2D image, and some guest

--- a/prosper/tests/compute_runner.h
+++ b/prosper/tests/compute_runner.h
@@ -5,6 +5,7 @@
 #pragma once
 #include <vulkan/vulkan.h>
 #include <cstdint>
+#include <cstring>
 #include <vector>
 
 namespace prosper::test {
@@ -41,6 +42,43 @@ inline ComputeSubgroupProperties default_compute_subgroup_properties() {
     return result;
 }
 
+inline bool default_compute_buffer_int64_atomics_supported() {
+    VkApplicationInfo app{VK_STRUCTURE_TYPE_APPLICATION_INFO};
+    app.apiVersion = VK_API_VERSION_1_1;
+    VkInstanceCreateInfo ici{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO};
+    ici.pApplicationInfo = &app;
+    VkInstance instance = VK_NULL_HANDLE;
+    if (vkCreateInstance(&ici, nullptr, &instance) != VK_SUCCESS || !instance) return false;
+    bool result = false;
+    uint32_t count = 0;
+    vkEnumeratePhysicalDevices(instance, &count, nullptr);
+    if (count) {
+        std::vector<VkPhysicalDevice> devices(count);
+        vkEnumeratePhysicalDevices(instance, &count, devices.data());
+        VkPhysicalDeviceFeatures core{};
+        vkGetPhysicalDeviceFeatures(devices[0], &core);
+        uint32_t extension_count = 0;
+        vkEnumerateDeviceExtensionProperties(devices[0], nullptr, &extension_count, nullptr);
+        std::vector<VkExtensionProperties> extensions(extension_count);
+        vkEnumerateDeviceExtensionProperties(
+            devices[0], nullptr, &extension_count, extensions.data());
+        for (const auto& extension : extensions) {
+            if (std::strcmp(extension.extensionName,
+                            VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
+                continue;
+            VkPhysicalDeviceShaderAtomicInt64Features atomics{
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+            VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+            features.pNext = &atomics;
+            vkGetPhysicalDeviceFeatures2(devices[0], &features);
+            result = core.shaderInt64 && atomics.shaderBufferInt64Atomics;
+            break;
+        }
+    }
+    vkDestroyInstance(instance, nullptr);
+    return result;
+}
+
 // Run `spirv` over storage buffer 0 = `input`, storage buffer 1 = output. `invocations` compute
 // threads are dispatched (default = input.size()) in groups of `local_size_x` (default 64); the
 // output buffer holds `out_count` floats (default = input.size()). Returns the output, or {} on any
@@ -50,7 +88,8 @@ inline std::vector<float> run_compute(const std::vector<uint32_t>& spirv, const 
                                       const std::vector<uint32_t>& cbuf = {},
                                       const std::vector<uint32_t>& cbuf1 = {},
                                       std::vector<uint32_t>* cbuf1_out = nullptr,
-                                      uint32_t local_size_x = 64) {
+                                      uint32_t local_size_x = 64,
+                                      std::vector<uint32_t>* cbuf_out = nullptr) {
     const uint32_t IN_N = (uint32_t)input.size();
     if (invocations == 0) invocations = IN_N;
     if (out_count == 0)   out_count = IN_N;
@@ -79,7 +118,41 @@ inline std::vector<float> run_compute(const std::vector<uint32_t>& spirv, const 
     dci.queueCreateInfoCount = 1; dci.pQueueCreateInfos = &qci;
     // robustBufferAccess: out-of-range storage-buffer reads/writes are well-defined (return 0 / no-op)
     // rather than UB — so a predicated memory op executed by an inactive lane (narrowed EXEC) is safe.
-    VkPhysicalDeviceFeatures feats{}; feats.robustBufferAccess = VK_TRUE; dci.pEnabledFeatures = &feats;
+    VkPhysicalDeviceFeatures supported{};
+    vkGetPhysicalDeviceFeatures(phys, &supported);
+    VkPhysicalDeviceFeatures feats{};
+    // Preserve the harness's pre-existing fail-closed requirement: if robustBufferAccess is not
+    // supported, vkCreateDevice must fail rather than allowing OOB-sensitive tests to run with UB.
+    feats.robustBufferAccess = VK_TRUE;
+    feats.shaderInt64 = supported.shaderInt64;
+    dci.pEnabledFeatures = &feats;
+    VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features{
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+    std::vector<const char*> device_extensions;
+    uint32_t extension_count = 0;
+    vkEnumerateDeviceExtensionProperties(phys, nullptr, &extension_count, nullptr);
+    std::vector<VkExtensionProperties> available_extensions(extension_count);
+    vkEnumerateDeviceExtensionProperties(
+        phys, nullptr, &extension_count, available_extensions.data());
+    for (const auto& extension : available_extensions) {
+        if (std::strcmp(extension.extensionName,
+                        VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
+            continue;
+        VkPhysicalDeviceFeatures2 features{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+        features.pNext = &atomic_int64_features;
+        vkGetPhysicalDeviceFeatures2(phys, &features);
+        if (supported.shaderInt64 && atomic_int64_features.shaderBufferInt64Atomics) {
+            VkPhysicalDeviceShaderAtomicInt64Features want{
+                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+            want.shaderBufferInt64Atomics = VK_TRUE;
+            atomic_int64_features = want;
+            dci.pNext = &atomic_int64_features;
+            device_extensions.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
+        }
+        break;
+    }
+    dci.enabledExtensionCount = static_cast<uint32_t>(device_extensions.size());
+    dci.ppEnabledExtensionNames = device_extensions.empty() ? nullptr : device_extensions.data();
     VkDevice dev = VK_NULL_HANDLE;
     if (vkCreateDevice(phys, &dci, nullptr, &dev) != VK_SUCCESS || !dev) { vkDestroyInstance(inst, nullptr); return out; }
     VkQueue queue; vkGetDeviceQueue(dev, qfi, 0, &queue);
@@ -194,6 +267,12 @@ inline std::vector<float> run_compute(const std::vector<uint32_t>& spirv, const 
         void* rp = nullptr; vkMapMemory(dev, cbMem1, 0, cbBytes1, 0, &rp);
         for (uint32_t i = 0; i < CB1_N; i++) (*cbuf1_out)[i] = ((uint32_t*)rp)[i];
         vkUnmapMemory(dev, cbMem1);
+    }
+    if (cbuf_out) {
+        cbuf_out->resize(CB_N);
+        void* rp = nullptr; vkMapMemory(dev, cbMem, 0, cbBytes, 0, &rp);
+        for (uint32_t i = 0; i < CB_N; i++) (*cbuf_out)[i] = ((uint32_t*)rp)[i];
+        vkUnmapMemory(dev, cbMem);
     }
 
     vkDestroyFence(dev, fence, nullptr); vkDestroyCommandPool(dev, pool, nullptr);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -816,6 +816,7 @@ struct RenderVkCtx {
     // note and not a correctness one here: our index is computed in scalar registers so it is
     // wave-uniform, and a driver waterfall over the distinct values present converges in one iteration.
     bool descriptor_indexing = false;
+    bool storage_buffer_int64_atomics = false;
     bool compute_full_subgroups = false;
     uint32_t min_subgroup_size = 0, max_subgroup_size = 0;
     uint32_t max_compute_workgroup_subgroups = 0;
@@ -985,6 +986,8 @@ inline const RenderVkCtx& render_vk_ctx() {
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT};
         VkPhysicalDeviceDescriptorIndexingFeaturesEXT di_features{
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT};
+        VkPhysicalDeviceShaderAtomicInt64Features atomic_int64_features{
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
         { uint32_t ne = 0; vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, nullptr);
           std::vector<VkExtensionProperties> de(ne);
           vkEnumerateDeviceExtensionProperties(r.phys, nullptr, &ne, de.data());
@@ -1050,6 +1053,22 @@ inline const RenderVkCtx& render_vk_ctx() {
                               (int)di_features.shaderStorageBufferArrayNonUniformIndexing,
                               (int)di_features.shaderSampledImageArrayNonUniformIndexing,
                               (int)di_features.shaderStorageImageArrayNonUniformIndexing);
+                  }
+              }
+              if (!strcmp(de[i].extensionName, VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME)) {
+                  VkPhysicalDeviceFeatures2 f2{VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2};
+                  f2.pNext = &atomic_int64_features;
+                  vkGetPhysicalDeviceFeatures2(r.phys, &f2);
+                  if (supported.shaderInt64 &&
+                      atomic_int64_features.shaderBufferInt64Atomics) {
+                      VkPhysicalDeviceShaderAtomicInt64Features want{
+                          VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES};
+                      want.shaderBufferInt64Atomics = VK_TRUE;
+                      atomic_int64_features = want;
+                      atomic_int64_features.pNext = const_cast<void*>(dci.pNext);
+                      dci.pNext = &atomic_int64_features;
+                      dev_exts.push_back(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME);
+                      r.storage_buffer_int64_atomics = true;
                   }
               }
               if (!strcmp(de[i].extensionName, VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME)) {
@@ -1153,6 +1172,8 @@ inline const RenderVkCtx& render_vk_ctx() {
             // above: `r.descriptor_indexing` is set only where the five features were actually requested at
             // device creation, never from `supported`.
             shared.descriptor_indexing = r.descriptor_indexing;
+            shared.storage_buffer_int64_atomics =
+                r.storage_buffer_int64_atomics && feats.shaderInt64;
             shared.min_compute_subgroup_size = r.min_subgroup_size;
             shared.max_compute_subgroup_size = r.max_subgroup_size;
             shared.max_compute_workgroup_subgroups = r.max_compute_workgroup_subgroups;

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1511,6 +1511,25 @@ int main() {
               gta_pc1180_table.resources[0].bvh_sort_enabled,
           "GTA pc1180 materializes BOX_SORT_EN in its instruction-scoped BVH binding");
 
+    std::vector<uint32_t> gta_unproven_pc1180 = gta_bvh_pc1180;
+    gta_unproven_pc1180[1160] = 0x8f948318u; // same lshl site/value, but s24:s25 has no x16 origin
+    std::array<uint32_t, 78> gta_unproven_pc1180_seed = gta_pc1180_seed;
+    gta_unproven_pc1180_seed[24] = static_cast<uint32_t>(astro_bvh_base8);
+    gta_unproven_pc1180_seed[25] = static_cast<uint32_t>(astro_bvh_base8 >> 32);
+    std::vector<SrtUse> gta_unproven_pc1180_uses;
+    resolve_dynamic_fetch(gta_unproven_pc1180.data(), gta_unproven_pc1180.size(),
+                          gta_unproven_pc1180_seed.data(), gta_unproven_pc1180_seed.size(), 0,
+                          &gta_unproven_pc1180_uses);
+    CHECK(gta_unproven_pc1180_uses.empty(),
+          "GTA pc1180 rejects byte-identical descriptor values from an unproven pointer origin");
+    ShaderResourceTable gta_unproven_pc1180_table;
+    add_compute_buffer_resources(gta_unproven_pc1180_table, gta_unproven_pc1180.data(),
+                                 gta_unproven_pc1180.size(),
+                                 gta_unproven_pc1180_seed.data(),
+                                 gta_unproven_pc1180_seed.size());
+    CHECK(gta_unproven_pc1180_table.resources.empty(),
+          "GTA pc1180 cannot materialize an ALU-modified historical x16 snapshot");
+
     std::vector<uint32_t> gta_bvh_pc313(319u, 0xbf800000u); // s_nop 0
     put_words(gta_bvh_pc313, 244u, {0xf4100203u, 0xfa000000u});
     put_words(gta_bvh_pc313, 294u, {

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1530,6 +1530,67 @@ int main() {
     CHECK(gta_unproven_pc1180_table.resources.empty(),
           "GTA pc1180 cannot materialize an ALU-modified historical x16 snapshot");
 
+    // The live pc1180 dispatch carries a null root in header qword s20:s21. Unlike the non-null
+    // positive above, its count dereference at pc1161 must fail; the exact scalar chain still proves
+    // that all four descriptor words derive from that one null qword. Keep the real EXEC writer and
+    // EXECZ branch, shortened only by replacing their distant merge body with NOPs.
+    alignas(8) std::array<uint32_t, 17> gta_null_bvh_header{};
+    const uint64_t gta_null_bvh_header_addr =
+        reinterpret_cast<uint64_t>(gta_null_bvh_header.data());
+    std::vector<uint32_t> gta_null_pc1180 = gta_bvh_pc1180;
+    gta_null_pc1180.resize(1489u, 0xbf800000u);
+    gta_null_pc1180[1099] = 0xbeca246au; // s_and_saveexec_b64 s[74:75],vcc
+    gta_null_pc1180[1100] = 0xbf880182u; // s_cbranch_execz pc1487
+    gta_null_pc1180[1185] = 0xbf800000u; // do not terminate before the guard merge
+    gta_null_pc1180[1487] = 0xbf800000u;
+    gta_null_pc1180[1488] = 0xbf810000u;
+    std::array<uint32_t, 78> gta_null_pc1180_seed{};
+    gta_null_pc1180_seed[76] = static_cast<uint32_t>(gta_null_bvh_header_addr);
+    gta_null_pc1180_seed[77] = static_cast<uint32_t>(gta_null_bvh_header_addr >> 32);
+    std::vector<SrtUse> gta_null_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_pc1180.data(), gta_null_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_pc1180_uses);
+    CHECK(gta_null_pc1180_uses.size() == 1 && gta_null_pc1180_uses[0].kind == 3 &&
+              gta_null_pc1180_uses[0].use_pc == 1180u,
+          "GTA pc1180 publishes its guarded x16-header null BVH use");
+    ShaderResourceTable gta_null_pc1180_table;
+    add_compute_buffer_resources(gta_null_pc1180_table, gta_null_pc1180.data(),
+                                 gta_null_pc1180.size(), gta_null_pc1180_seed.data(),
+                                 gta_null_pc1180_seed.size());
+    CHECK(gta_null_pc1180_table.resources.size() == 1 &&
+              gta_null_pc1180_table.resources[0].fetch_pc == 1180u &&
+              is_proven_null_bvh(gta_null_pc1180_table.resources[0]),
+          "GTA pc1180 materializes its guarded null root as a no-hit BVH marker");
+
+    std::vector<uint32_t> gta_null_offset_pc1180 = gta_null_pc1180;
+    gta_null_offset_pc1180[1108] = 0xfa000004u; // same x16 load, not the header-base site
+    std::vector<SrtUse> gta_null_offset_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_offset_pc1180.data(), gta_null_offset_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_offset_pc1180_uses);
+    CHECK(gta_null_offset_pc1180_uses.empty(),
+          "GTA pc1180 does not seed null provenance from a shifted x16 header load");
+
+    std::vector<uint32_t> gta_null_unproven_pc1180 = gta_null_pc1180;
+    gta_null_unproven_pc1180[1160] = 0x8f948318u; // s24:s25 is zero but not header-derived
+    std::vector<SrtUse> gta_null_unproven_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_unproven_pc1180.data(), gta_null_unproven_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_unproven_pc1180_uses);
+    CHECK(gta_null_unproven_pc1180_uses.empty(),
+          "GTA pc1180 rejects byte-identical nulls from an unproven qword");
+
+    std::vector<uint32_t> gta_null_unguarded_pc1180 = gta_null_pc1180;
+    gta_null_unguarded_pc1180[1100] = 0xbf800000u; // remove exact EXECZ region proof
+    std::vector<SrtUse> gta_null_unguarded_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_unguarded_pc1180.data(),
+                          gta_null_unguarded_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_unguarded_pc1180_uses);
+    CHECK(gta_null_unguarded_pc1180_uses.empty(),
+          "GTA pc1180 keeps an unguarded x16-header null BVH fail-visible");
+
     std::vector<uint32_t> gta_bvh_pc313(319u, 0xbf800000u); // s_nop 0
     put_words(gta_bvh_pc313, 244u, {0xf4100203u, 0xfa000000u});
     put_words(gta_bvh_pc313, 294u, {

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1454,6 +1454,106 @@ int main() {
               built_bvh.type == 8u && built_bvh.triangle_return_mode,
           "Astro's carry/shift descriptor builder resolves the exact BVH binding");
 
+    // GTA V builds the same RTIP 1.1 descriptor from a pointer inside a mapped 16-dword object
+    // header. Both live programs enable BOX_SORT_EN. The second relocates the final descriptor from
+    // the loaded s8:s23 range into s44:s47, so a load-time snapshot alone cannot prove it.
+    astro_bvh_backing[22] = 63u; // descriptor stores count-minus-one: 64 * 64 = 4096 bytes
+    astro_bvh_backing[23] = 0u;
+    alignas(8) std::array<uint32_t, 16> gta_bvh_header{};
+    gta_bvh_header[12] = static_cast<uint32_t>(astro_bvh_base8);
+    gta_bvh_header[13] = static_cast<uint32_t>(astro_bvh_base8 >> 32);
+    const uint64_t gta_bvh_header_addr = reinterpret_cast<uint64_t>(gta_bvh_header.data());
+    auto put_words = [](std::vector<uint32_t>& code, uint32_t pc,
+                        std::initializer_list<uint32_t> words) {
+        std::copy(words.begin(), words.end(), code.begin() + pc);
+    };
+
+    std::vector<uint32_t> gta_bvh_pc1180(1186u, 0xbf800000u); // s_nop 0
+    put_words(gta_bvh_pc1180, 1107u, {0xf4100226u, 0xfa000000u});
+    put_words(gta_bvh_pc1180, 1158u, {
+        0x8715ff15u, 0x003fffffu,             // s_and_b32 s21,s21,0x003fffff
+        0x8f948314u,                          // s_lshl_b64 s[20:21],s[20:21],3
+        0xf408000au, 0xfa000058u,             // s_load_dwordx4 s[0:3],s[20:21],0x58
+        0x9490ff14u, 0x00280008u,             // s_bfe_u64 s[16:17],s[20:21],8:40
+        0xbf8cc07fu,                          // s_waitcnt
+        0x816a8100u,                          // s_add_i32 vcc_lo,s0,1
+        0x8801ff15u, 0x00080000u,             // unrelated header patch
+        0x80126ac1u,                          // s_add_u32 s18,-1,vcc_lo
+        0xbe800314u,                          // unrelated move
+        0x821380c1u,                          // s_addc_u32 s19,-1,0
+        0xbe8303ffu, 0x00016204u,             // unrelated move
+        0x876a13ffu, 0x000003ffu,             // s_and_b32 vcc_lo,0x3ff,s19
+        0xbe911d9fu,                          // s_bitset1_b32 s17,31
+        0x8813ff6au, 0x81000000u,             // s_or_b32 s19,vcc_lo,TYPE/mode
+        0xbf8c3f70u,
+        0xf1989f07u, 0x00040006u, 0x2726251cu, 0x2f2a2928u, 0x00002d2eu,
+        0xbf810000u,
+    });
+    std::array<uint32_t, 78> gta_pc1180_seed{};
+    gta_pc1180_seed[76] = static_cast<uint32_t>(gta_bvh_header_addr);
+    gta_pc1180_seed[77] = static_cast<uint32_t>(gta_bvh_header_addr >> 32);
+    std::vector<SrtUse> gta_pc1180_uses;
+    resolve_dynamic_fetch(gta_bvh_pc1180.data(), gta_bvh_pc1180.size(),
+                          gta_pc1180_seed.data(), gta_pc1180_seed.size(), 0,
+                          &gta_pc1180_uses);
+    CHECK(gta_pc1180_uses.size() == 1 && gta_pc1180_uses[0].kind == 2 &&
+              gta_pc1180_uses[0].use_pc == 1180u &&
+              decode_bvh_descriptor(gta_pc1180_uses[0].bvh4.data()).sort_enabled,
+          "GTA pc1180 publishes its exact sorted BVH descriptor");
+    ShaderResourceTable gta_pc1180_table;
+    add_compute_buffer_resources(gta_pc1180_table, gta_bvh_pc1180.data(),
+                                 gta_bvh_pc1180.size(), gta_pc1180_seed.data(),
+                                 gta_pc1180_seed.size());
+    CHECK(gta_pc1180_table.resources.size() == 1 &&
+              gta_pc1180_table.resources[0].fetch_pc == 1180u &&
+              gta_pc1180_table.resources[0].gpu_addr == astro_bvh_base &&
+              gta_pc1180_table.resources[0].size == sizeof(astro_bvh_backing) &&
+              gta_pc1180_table.resources[0].bvh_sort_enabled,
+          "GTA pc1180 materializes BOX_SORT_EN in its instruction-scoped BVH binding");
+
+    std::vector<uint32_t> gta_bvh_pc313(319u, 0xbf800000u); // s_nop 0
+    put_words(gta_bvh_pc313, 244u, {0xf4100203u, 0xfa000000u});
+    put_words(gta_bvh_pc313, 294u, {
+        0x8715ff15u, 0x003fffffu,             // s_and_b32 s21,s21,0x003fffff
+        0x8f888314u,                          // s_lshl_b64 s[8:9],s[20:21],3
+        0xf4080304u, 0xfa000058u,             // s_load_dwordx4 s[12:15],s[8:9],0x58
+        0xbf8cc07fu,
+        0x816a810cu,                          // s_add_i32 vcc_lo,s12,1
+        0x94acff08u, 0x00280008u,             // s_bfe_u64 s[44:45],s[8:9],8:40
+        0x802e6ac1u,                          // s_add_u32 s46,-1,vcc_lo
+        0xbe8a030eu,                          // unrelated move
+        0x822f80c1u,                          // s_addc_u32 s47,-1,0
+        0xbe891d93u,                          // unrelated bitset
+        0x876a2fffu, 0x000003ffu,             // s_and_b32 vcc_lo,0x3ff,s47
+        0xbead1d9fu,                          // s_bitset1_b32 s45,31
+        0x882fff6au, 0x81000000u,             // s_or_b32 s47,vcc_lo,TYPE/mode
+        0xbf8c3f70u,
+        0xf1989f07u, 0x000b0004u, 0x2322211bu, 0x2b262524u, 0x0000292au,
+        0xbf810000u,
+    });
+    std::array<uint32_t, 26> gta_pc313_seed{};
+    gta_pc313_seed[6] = static_cast<uint32_t>(gta_bvh_header_addr);
+    gta_pc313_seed[7] = static_cast<uint32_t>(gta_bvh_header_addr >> 32);
+    gta_pc313_seed[24] = static_cast<uint32_t>(astro_bvh_base8);
+    gta_pc313_seed[25] = static_cast<uint32_t>(astro_bvh_base8 >> 32);
+    std::vector<SrtUse> gta_pc313_uses;
+    resolve_dynamic_fetch(gta_bvh_pc313.data(), gta_bvh_pc313.size(),
+                          gta_pc313_seed.data(), gta_pc313_seed.size(), 0,
+                          &gta_pc313_uses);
+    CHECK(gta_pc313_uses.size() == 1 && gta_pc313_uses[0].kind == 2 &&
+              gta_pc313_uses[0].use_pc == 313u &&
+              decode_bvh_descriptor(gta_pc313_uses[0].bvh4.data()).sort_enabled,
+          "GTA pc313 proves the relocated sorted BVH descriptor builder");
+
+    std::vector<uint32_t> gta_unproven_pc313 = gta_bvh_pc313;
+    gta_unproven_pc313[296] = 0x8f888318u; // same lshl site, identical seed value, no x16 origin
+    std::vector<SrtUse> gta_unproven_pc313_uses;
+    resolve_dynamic_fetch(gta_unproven_pc313.data(), gta_unproven_pc313.size(),
+                          gta_pc313_seed.data(), gta_pc313_seed.size(), 0,
+                          &gta_unproven_pc313_uses);
+    CHECK(gta_unproven_pc313_uses.empty(),
+          "GTA pc313 rejects byte-identical descriptor values from an unproven pointer origin");
+
     // Astro Bot's live visibility packet consumes a direct R32_UINT T# in s[0:7]. Opcode 0x0f is
     // IMAGE_ATOMIC_SWAP, so its instruction-scoped resource must be materialized as a storage image
     // even though the packet's unused SSAMP field aliases s0.

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2127,8 +2127,9 @@ int main() {
 
     // GTA V's 0x413ce6000/0x413ce6d00 programs load a four-dword V# through an S_BUFFER_LOAD whose
     // VCC-derived SOFFSET is intentionally unknown to this CPU fold. The outer V# is fully known and
-    // has NUM_RECORDS=0, so every possible access is OOB: publish a marker for the scalar load itself,
-    // propagate four exact zero dwords, and let the exact raw-MUBUF consumer publish its own marker.
+    // has NUM_RECORDS=0, while the positive immediate begins beyond its effective scalar bound: publish
+    // a marker for the scalar load itself, propagate four exact zero dwords, and let the exact raw-MUBUF
+    // consumer publish its own marker.
     // These are the live scalar-load and first consumer packets (relocated to pc1/pc3 in the fixture).
     const uint32_t zero_record_sbuffer_chain[] = {
         0x7ed40500u,              // v_readfirstlane_b32 vcc_lo, v0 (runtime-uniform, fold-unknown)
@@ -2259,6 +2260,30 @@ int main() {
                                 &one_record_sbuffer_table,
                                 one_record_sbuffer_config).empty(),
           "base-zero one-record scalar-load chain stays unresolved");
+
+    // NUM_RECORDS=0 does not by itself make a stride-zero scalar descriptor empty: scalar SMEM uses
+    // an effective one-dword M_SIZE. With immediate zero the first dword remains in range, so the
+    // unknown SOFFSET prevents folding and neither the scalar load nor its consumer gets a marker.
+    const uint32_t zero_record_sbuffer_at_zero[] = {
+        0x7ed40500u,
+        0xf4280202u, 0xd4000000u,
+        0xe0382000u, 0x80020006u,
+        0xbf810000u,
+    };
+    ShaderResourceTable zero_record_sbuffer_at_zero_table;
+    const std::vector<SrtUse> zero_record_sbuffer_at_zero_uses = add_compute_buffer_resources(
+        zero_record_sbuffer_at_zero_table, zero_record_sbuffer_at_zero,
+        std::size(zero_record_sbuffer_at_zero), zero_record_sbuffer_seed,
+        std::size(zero_record_sbuffer_seed));
+    CHECK(zero_record_sbuffer_at_zero_table.resources.empty() &&
+              std::none_of(zero_record_sbuffer_at_zero_uses.begin(),
+                           zero_record_sbuffer_at_zero_uses.end(),
+                           [](const SrtUse& use) { return use.zero_record_raw; }) &&
+              recompile_compute(zero_record_sbuffer_at_zero,
+                                std::size(zero_record_sbuffer_at_zero),
+                                &zero_record_sbuffer_at_zero_table,
+                                zero_record_sbuffer_config).empty(),
+          "stride-zero zero-record scalar load at immediate zero stays unresolved");
 
     // Evergate's title PS uses a bounded PC-relative dispatch. An omitted alternative reloads the
     // same T# SGPRs that the selected arm consumes directly; a linear fold used to walk that reload
@@ -2447,6 +2472,9 @@ int main() {
               zero_record_format_uses[0].zero_record_raw &&
               zero_record_format_table.resources.size() == 1 &&
               is_zero_record_raw_buffer(zero_record_format_table.resources[0]) &&
+              std::all_of(std::begin(zero_record_format_table.resources[0].swizzle),
+                          std::end(zero_record_format_table.resources[0].swizzle),
+                          [](uint32_t selector) { return selector == 0u; }) &&
               zero_record_format_table.by_fetch_pc(67) &&
               !recompile_compute(zero_record_format_load.data(), zero_record_format_load.size(),
                                  &zero_record_format_table,
@@ -2461,6 +2489,19 @@ int main() {
         one_record_format_seed, std::size(one_record_format_seed));
     CHECK(one_record_format_uses.empty() && one_record_format_table.resources.empty(),
           "exact GTA V pc67 FORMAT load keeps base-zero one-record V# unresolved");
+
+    // SQ_SEL_1 is the other zero-record boundary: an OOB FORMAT component selected as constant one
+    // does not have an all-zero result. It must not acquire the no-backing zero marker.
+    uint32_t one_selector_format_seed[4]{};
+    one_selector_format_seed[3] = 1u; // DST_SEL_X = SQ_SEL_1
+    ShaderResourceTable one_selector_format_table;
+    const std::vector<SrtUse> one_selector_format_uses = add_compute_buffer_resources(
+        one_selector_format_table, zero_record_format_load.data(), zero_record_format_load.size(),
+        one_selector_format_seed, std::size(one_selector_format_seed));
+    CHECK(one_selector_format_table.resources.empty() &&
+              std::none_of(one_selector_format_uses.begin(), one_selector_format_uses.end(),
+                           [](const SrtUse& use) { return use.zero_record_raw; }),
+          "zero-record FORMAT load with SQ_SEL_1 stays unresolved");
 
     // Astro Bot's 7f5f world-map NGG shader patches only NUM_RECORDS in its direct s[16:19] V#
     // (`s_mov_b32 s18, 1`) before a raw buffer_load_dwordx4 at pc2761. The consumer is itself the

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -1581,6 +1581,45 @@ int main() {
     CHECK(gta_null_unproven_pc1180_uses.empty(),
           "GTA pc1180 rejects byte-identical nulls from an unproven qword");
 
+    // Each aligned zero qword receives a distinct origin. Copy one dword from each of two adjacent
+    // qwords into a nominal 64-bit operand: the shift must not collapse that splice onto one origin.
+    std::vector<uint32_t> gta_null_spliced_pc1180 = gta_null_pc1180;
+    gta_null_spliced_pc1180[1156] = 0xbe980314u; // s_mov_b32 s24,s20 (qword A low)
+    gta_null_spliced_pc1180[1157] = 0xbe990316u; // s_mov_b32 s25,s22 (qword B low)
+    gta_null_spliced_pc1180[1160] = 0x8f948318u; // consume spliced s24:s25 pair
+    std::vector<SrtUse> gta_null_spliced_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_spliced_pc1180.data(), gta_null_spliced_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_spliced_pc1180_uses);
+    CHECK(gta_null_spliced_pc1180_uses.empty(),
+          "GTA pc1180 rejects a 64-bit pair spliced from distinct header qwords");
+
+    // A conditional edge may not bypass the mapped x16 load and then enter its dependent builder.
+    // Seed the skipped path with a non-null root so accepting the linear walk as null would change
+    // guest-visible ray results, not merely attach an imprecise provenance label.
+    std::vector<uint32_t> gta_null_skipped_load_pc1180 = gta_null_pc1180;
+    gta_null_skipped_load_pc1180[1105] = 0xbf850003u; // s_cbranch_scc1 pc1109
+    std::array<uint32_t, 78> gta_null_skipped_load_seed = gta_null_pc1180_seed;
+    gta_null_skipped_load_seed[20] = static_cast<uint32_t>(astro_bvh_base8);
+    gta_null_skipped_load_seed[21] = static_cast<uint32_t>(astro_bvh_base8 >> 32);
+    std::vector<SrtUse> gta_null_skipped_load_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_skipped_load_pc1180.data(),
+                          gta_null_skipped_load_pc1180.size(),
+                          gta_null_skipped_load_seed.data(),
+                          gta_null_skipped_load_seed.size(), 0,
+                          &gta_null_skipped_load_pc1180_uses);
+    CHECK(gta_null_skipped_load_pc1180_uses.empty(),
+          "GTA pc1180 rejects null provenance whose x16 seed does not dominate the use");
+
+    std::vector<uint32_t> gta_null_indirect_pc1180 = gta_null_pc1180;
+    gta_null_indirect_pc1180[1101] = 0xbe802000u; // s_setpc_b64 s[0:1]
+    std::vector<SrtUse> gta_null_indirect_pc1180_uses;
+    resolve_dynamic_fetch(gta_null_indirect_pc1180.data(), gta_null_indirect_pc1180.size(),
+                          gta_null_pc1180_seed.data(), gta_null_pc1180_seed.size(), 0,
+                          &gta_null_indirect_pc1180_uses);
+    CHECK(gta_null_indirect_pc1180_uses.empty(),
+          "GTA pc1180 rejects a null proof in a program with indirect control flow");
+
     std::vector<uint32_t> gta_null_unguarded_pc1180 = gta_null_pc1180;
     gta_null_unguarded_pc1180[1100] = 0xbf800000u; // remove exact EXECZ region proof
     std::vector<SrtUse> gta_null_unguarded_pc1180_uses;

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2125,6 +2125,141 @@ int main() {
                                  &wave_offset_sbuffer_table, direct_sbuffer_config).empty(),
           "Astro wave-derived SOFFSET binds its descriptor range and recompiles dynamically");
 
+    // GTA V's 0x413ce6000/0x413ce6d00 programs load a four-dword V# through an S_BUFFER_LOAD whose
+    // VCC-derived SOFFSET is intentionally unknown to this CPU fold. The outer V# is fully known and
+    // has NUM_RECORDS=0, so every possible access is OOB: publish a marker for the scalar load itself,
+    // propagate four exact zero dwords, and let the exact raw-MUBUF consumer publish its own marker.
+    // These are the live scalar-load and first consumer packets (relocated to pc1/pc3 in the fixture).
+    const uint32_t zero_record_sbuffer_chain[] = {
+        0x7ed40500u,              // v_readfirstlane_b32 vcc_lo, v0 (runtime-uniform, fold-unknown)
+        0xf4280202u, 0xd4000008u, // s_buffer_load_dwordx4 s[8:11], s[4:7], vcc_lo offset:8
+        0xe0382000u, 0x80020006u, // buffer_load_dwordx4 v[0:3], v6, s[8:11], 0
+        0xbf810000u,
+    };
+    uint32_t zero_record_sbuffer_seed[8]{};
+    std::vector<SrtUse> zero_record_sbuffer_uses;
+    resolve_dynamic_fetch(zero_record_sbuffer_chain, std::size(zero_record_sbuffer_chain),
+                          zero_record_sbuffer_seed, std::size(zero_record_sbuffer_seed), 0,
+                          &zero_record_sbuffer_uses);
+    CHECK(zero_record_sbuffer_uses.size() == 2 &&
+              zero_record_sbuffer_uses[0].use_pc == 1 &&
+              zero_record_sbuffer_uses[0].zero_record_raw &&
+              zero_record_sbuffer_uses[1].use_pc == 3 &&
+              zero_record_sbuffer_uses[1].zero_record_raw &&
+              std::all_of(zero_record_sbuffer_uses[1].v4.begin(),
+                          zero_record_sbuffer_uses[1].v4.end(),
+                          [](uint32_t word) { return word == 0u; }),
+          "zero-record dynamic-SOFFSET S_BUFFER_LOAD produces an exact zero V# consumer");
+    ShaderResourceTable zero_record_sbuffer_table;
+    add_compute_buffer_resources(zero_record_sbuffer_table, zero_record_sbuffer_chain,
+                                 std::size(zero_record_sbuffer_chain), zero_record_sbuffer_seed,
+                                 std::size(zero_record_sbuffer_seed));
+    assign_convention_bindings(zero_record_sbuffer_table, 2);
+    ComputeShaderConfig zero_record_sbuffer_config;
+    zero_record_sbuffer_config.user_sgprs.assign(
+        zero_record_sbuffer_seed,
+        zero_record_sbuffer_seed + std::size(zero_record_sbuffer_seed));
+    zero_record_sbuffer_config.local_x = zero_record_sbuffer_config.local_y =
+        zero_record_sbuffer_config.local_z = 1;
+    const std::vector<uint32_t> zero_record_sbuffer_spirv = recompile_compute(
+        zero_record_sbuffer_chain, std::size(zero_record_sbuffer_chain),
+        &zero_record_sbuffer_table, zero_record_sbuffer_config);
+    const DescriptorValidationReport zero_record_sbuffer_report =
+        validate_spirv_descriptor_interface(zero_record_sbuffer_spirv,
+                                            &zero_record_sbuffer_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(zero_record_sbuffer_table.resources.size() == 2 &&
+              is_zero_record_raw_buffer(zero_record_sbuffer_table.resources[0]) &&
+              is_zero_record_raw_buffer(zero_record_sbuffer_table.resources[1]) &&
+              zero_record_sbuffer_table.by_fetch_pc(1) &&
+              zero_record_sbuffer_table.by_fetch_pc(3) &&
+              !zero_record_sbuffer_spirv.empty() && zero_record_sbuffer_report.ok() &&
+              zero_record_sbuffer_report.descriptors.empty(),
+          "production zero-record scalar-load chain recompiles without backing buffers");
+
+    // The sibling 0x413ce6d00 site uses the same shape at pc148 with different registers. Preserve
+    // its exact scalar packet and first raw consumer too, so register-specific decode drift cannot
+    // leave one program behind while the other fixture stays green.
+    const uint32_t zero_record_sbuffer_chain_6d[] = {
+        0x7ed40500u,
+        0xf4280508u, 0xd4000008u, // s_buffer_load_dwordx4 s[20:23], s[16:19], vcc_lo offset:8
+        0xe0382000u, 0x80050006u, // buffer_load_dwordx4 v[0:3], v6, s[20:23], 0
+        0xbf810000u,
+    };
+    uint32_t zero_record_sbuffer_seed_6d[20]{};
+    std::vector<SrtUse> zero_record_sbuffer_uses_6d;
+    resolve_dynamic_fetch(zero_record_sbuffer_chain_6d,
+                          std::size(zero_record_sbuffer_chain_6d),
+                          zero_record_sbuffer_seed_6d,
+                          std::size(zero_record_sbuffer_seed_6d), 0,
+                          &zero_record_sbuffer_uses_6d);
+    CHECK(zero_record_sbuffer_uses_6d.size() == 2 &&
+              zero_record_sbuffer_uses_6d[0].use_pc == 1 &&
+              zero_record_sbuffer_uses_6d[0].zero_record_raw &&
+              zero_record_sbuffer_uses_6d[1].use_pc == 3 &&
+              zero_record_sbuffer_uses_6d[1].zero_record_raw,
+          "second GTA V zero-record scalar packet reaches its exact raw consumer");
+
+    // 0x413d59600 consumes the same empty V# through x4, x1 and x16 scalar loads. These are its
+    // exact pc16/pc20/pc22 packets, relocated together after one fold-unknown VCC producer.
+    const uint32_t zero_record_sbuffer_widths[] = {
+        0x7ed40500u,
+        0xf4280b06u, 0xd4000004u, // x4  s[44:47], s[12:15], vcc_lo offset:4
+        0xf42000c6u, 0xd4000014u, // x1  s3,       s[12:15], vcc_lo offset:20
+        0xf4300706u, 0xd4000038u, // x16 s[28:43], s[12:15], vcc_lo offset:56
+        0xbf810000u,
+    };
+    uint32_t zero_record_sbuffer_width_seed[16]{};
+    ShaderResourceTable zero_record_sbuffer_width_table;
+    const std::vector<SrtUse> zero_record_sbuffer_width_uses = add_compute_buffer_resources(
+        zero_record_sbuffer_width_table, zero_record_sbuffer_widths,
+        std::size(zero_record_sbuffer_widths), zero_record_sbuffer_width_seed,
+        std::size(zero_record_sbuffer_width_seed));
+    assign_convention_bindings(zero_record_sbuffer_width_table, 2);
+    ComputeShaderConfig zero_record_sbuffer_width_config;
+    zero_record_sbuffer_width_config.user_sgprs.assign(
+        zero_record_sbuffer_width_seed,
+        zero_record_sbuffer_width_seed + std::size(zero_record_sbuffer_width_seed));
+    zero_record_sbuffer_width_config.local_x = zero_record_sbuffer_width_config.local_y =
+        zero_record_sbuffer_width_config.local_z = 1;
+    const std::vector<uint32_t> zero_record_sbuffer_width_spirv = recompile_compute(
+        zero_record_sbuffer_widths, std::size(zero_record_sbuffer_widths),
+        &zero_record_sbuffer_width_table, zero_record_sbuffer_width_config);
+    const DescriptorValidationReport zero_record_sbuffer_width_report =
+        validate_spirv_descriptor_interface(zero_record_sbuffer_width_spirv,
+                                            &zero_record_sbuffer_width_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(zero_record_sbuffer_width_uses.size() == 3 &&
+              zero_record_sbuffer_width_table.resources.size() == 3 &&
+              std::all_of(zero_record_sbuffer_width_uses.begin(),
+                          zero_record_sbuffer_width_uses.end(),
+                          [](const SrtUse& use) { return use.zero_record_raw; }) &&
+              !zero_record_sbuffer_width_spirv.empty() &&
+              zero_record_sbuffer_width_report.ok() &&
+              zero_record_sbuffer_width_report.descriptors.empty(),
+          "GTA V zero-record x1/x4/x16 scalar loads compile to exact zeros without bindings");
+
+    // NUM_RECORDS is the production-site boundary. A null-base descriptor with one record does not
+    // make a runtime SOFFSET knowable and must not acquire either zero marker.
+    uint32_t one_record_sbuffer_seed[8]{};
+    one_record_sbuffer_seed[6] = 1u;
+    ShaderResourceTable one_record_sbuffer_table;
+    const std::vector<SrtUse> one_record_sbuffer_uses = add_compute_buffer_resources(
+        one_record_sbuffer_table, zero_record_sbuffer_chain,
+        std::size(zero_record_sbuffer_chain), one_record_sbuffer_seed,
+        std::size(one_record_sbuffer_seed));
+    ComputeShaderConfig one_record_sbuffer_config = zero_record_sbuffer_config;
+    one_record_sbuffer_config.user_sgprs.assign(
+        one_record_sbuffer_seed, one_record_sbuffer_seed + std::size(one_record_sbuffer_seed));
+    CHECK(one_record_sbuffer_table.resources.empty() &&
+              std::none_of(one_record_sbuffer_uses.begin(), one_record_sbuffer_uses.end(),
+                           [](const SrtUse& use) { return use.zero_record_raw; }) &&
+              recompile_compute(zero_record_sbuffer_chain,
+                                std::size(zero_record_sbuffer_chain),
+                                &one_record_sbuffer_table,
+                                one_record_sbuffer_config).empty(),
+          "base-zero one-record scalar-load chain stays unresolved");
+
     // Evergate's title PS uses a bounded PC-relative dispatch. An omitted alternative reloads the
     // same T# SGPRs that the selected arm consumes directly; a linear fold used to walk that reload
     // and attach the alternative texture to the selected image_sample's pc. Specialize the fold to
@@ -2288,6 +2423,44 @@ int main() {
                                  std::size(addr0_nonzero_record_seed));
     CHECK(addr0_nonzero_record_uses.empty() && addr0_nonzero_record_table.resources.empty(),
           "addr0 plus nonzero NUM_RECORDS stays rejected at the zero-record boundary");
+
+    // GTA V 0x413d59600 pc67 uses this exact FORMAT-load packet through the all-zero descriptor
+    // produced by its earlier zero-record scalar loads. Keep the exact pc because the marker is
+    // deliberately per-consumer; ordinary nonempty format loads remain on DynFetch's typed path.
+    std::vector<uint32_t> zero_record_format_load(70, 0x7e000000u); // v_nop padding
+    zero_record_format_load[67] = 0xe0082000u;
+    zero_record_format_load[68] = 0x8000110cu;
+    zero_record_format_load[69] = 0xbf810000u;
+    const uint32_t zero_record_format_seed[4]{};
+    ShaderResourceTable zero_record_format_table;
+    const std::vector<SrtUse> zero_record_format_uses = add_compute_buffer_resources(
+        zero_record_format_table, zero_record_format_load.data(), zero_record_format_load.size(),
+        zero_record_format_seed, std::size(zero_record_format_seed));
+    assign_convention_bindings(zero_record_format_table, 2);
+    ComputeShaderConfig zero_record_format_config;
+    zero_record_format_config.user_sgprs.assign(
+        zero_record_format_seed, zero_record_format_seed + std::size(zero_record_format_seed));
+    zero_record_format_config.local_x = zero_record_format_config.local_y =
+        zero_record_format_config.local_z = 1;
+    CHECK(zero_record_format_uses.size() == 1 &&
+              zero_record_format_uses[0].use_pc == 67 &&
+              zero_record_format_uses[0].zero_record_raw &&
+              zero_record_format_table.resources.size() == 1 &&
+              is_zero_record_raw_buffer(zero_record_format_table.resources[0]) &&
+              zero_record_format_table.by_fetch_pc(67) &&
+              !recompile_compute(zero_record_format_load.data(), zero_record_format_load.size(),
+                                 &zero_record_format_table,
+                                 zero_record_format_config).empty(),
+          "exact GTA V pc67 zero-record FORMAT load lowers without a backing buffer");
+
+    uint32_t one_record_format_seed[4]{};
+    one_record_format_seed[2] = 1u;
+    ShaderResourceTable one_record_format_table;
+    const std::vector<SrtUse> one_record_format_uses = add_compute_buffer_resources(
+        one_record_format_table, zero_record_format_load.data(), zero_record_format_load.size(),
+        one_record_format_seed, std::size(one_record_format_seed));
+    CHECK(one_record_format_uses.empty() && one_record_format_table.resources.empty(),
+          "exact GTA V pc67 FORMAT load keeps base-zero one-record V# unresolved");
 
     // Astro Bot's 7f5f world-map NGG shader patches only NUM_RECORDS in its direct s[16:19] V#
     // (`s_mov_b32 s18, 1`) before a raw buffer_load_dwordx4 at pc2761. The consumer is itself the

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -3295,15 +3295,173 @@ int main() {
               gta_413d884_report.descriptors.empty(),
           "GTA V 0x413d884 pc163 exact synthetic empty OR recompiles binding-free by PC");
 
-    // These encodings need distinct operands or semantics. In particular op 0x50 is GTA V's
-    // buffer_atomic_swap_x2, not a 32-bit atomic with a neighboring opcode. They must not acquire a
-    // resource merely because their descriptor is concrete; both discovery and emission stay loud.
+    // GTA V 0x413e154 pc154 rebuilds the exact BUFFER_ATOMIC_SWAP_X2 V# at pcs142-146.
+    // s13 is dispatch-dependent: the routed scene exercises 25, 2, 3, and 1 qword records.
+    alignas(8) uint32_t gta_swap_x2_backing[50] = {0x11223344u, 0x55667788u};
+    const uint64_t gta_swap_x2_base = reinterpret_cast<uint64_t>(gta_swap_x2_backing);
+    uint32_t gta_swap_x2_seed[15] = {};
+    gta_swap_x2_seed[8] = static_cast<uint32_t>(gta_swap_x2_base);
+    gta_swap_x2_seed[9] = static_cast<uint32_t>(gta_swap_x2_base >> 32);
+    gta_swap_x2_seed[13] = 25u;
+    std::vector<uint32_t> gta_swap_x2_site(154, 0xBF800000u);
+    gta_swap_x2_site[142] = 0x8801FF09u; // s_or_b32 s1, s9, 0x00080000
+    gta_swap_x2_site[143] = 0x00080000u;
+    gta_swap_x2_site[144] = 0xBE800308u; // s_mov_b32 s0, s8
+    gta_swap_x2_site[145] = 0xBE82030Du; // s_mov_b32 s2, s13
+    gta_swap_x2_site[146] = 0xBE8303FFu; // s_mov_b32 s3, 0x00016204
+    gta_swap_x2_site[147] = 0x00016204u;
+    gta_swap_x2_site.push_back(0xE1402000u);
+    gta_swap_x2_site.push_back(0x80000913u);
+    gta_swap_x2_site.push_back(0xBF810000u);
+    ShaderResourceTable gta_swap_x2_table;
+    const std::vector<SrtUse> gta_swap_x2_uses = add_compute_buffer_resources(
+        gta_swap_x2_table, gta_swap_x2_site.data(), gta_swap_x2_site.size(),
+        gta_swap_x2_seed, std::size(gta_swap_x2_seed));
+    assign_convention_bindings(gta_swap_x2_table, 2);
+    ComputeShaderConfig gta_swap_x2_config;
+    gta_swap_x2_config.user_sgprs.assign(std::begin(gta_swap_x2_seed),
+                                          std::end(gta_swap_x2_seed));
+    gta_swap_x2_config.local_x = gta_swap_x2_config.local_y =
+        gta_swap_x2_config.local_z = 1;
+    gta_swap_x2_config.storage_buffer_int64_atomics = true;
+    const std::vector<uint32_t> gta_swap_x2_spirv = recompile_compute(
+        gta_swap_x2_site.data(), gta_swap_x2_site.size(), &gta_swap_x2_table,
+        gta_swap_x2_config);
+    const DescriptorValidationReport gta_swap_x2_report =
+        validate_spirv_descriptor_interface(gta_swap_x2_spirv, &gta_swap_x2_table, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(gta_swap_x2_uses.size() == 1 &&
+              gta_swap_x2_uses[0].use_pc == 154u &&
+              gta_swap_x2_uses[0].required_size == 0u &&
+              gta_swap_x2_uses[0].atomic_x2_record_count == 25u &&
+              gta_swap_x2_table.resources.size() == 1 &&
+              gta_swap_x2_table.resources[0].size == 200u &&
+              gta_swap_x2_table.resources[0].stride == 8u &&
+              gta_swap_x2_table.resources[0].fetch_pc == 154u &&
+              gta_swap_x2_table.resources[0].atomic_x2_record_count == 25u &&
+              !gta_swap_x2_spirv.empty() && gta_swap_x2_report.ok() &&
+              gta_swap_x2_report.descriptors.size() == 1 &&
+              gta_swap_x2_report.descriptors[0].required_bytes == 8u &&
+              gta_swap_x2_report.descriptors[0].readable &&
+              gta_swap_x2_report.descriptors[0].writable &&
+              gta_swap_x2_report.descriptors[0].atomic_access,
+          "GTA V 0x413e154 pc154 publishes one exact 25-record qword-atomic resource");
+    uint32_t live_sized_atomic_x2_arms = 0;
+    for (uint32_t record_count : {1u, 2u, 3u}) {
+        uint32_t live_seed[15] = {};
+        std::copy(std::begin(gta_swap_x2_seed), std::end(gta_swap_x2_seed), live_seed);
+        live_seed[13] = record_count;
+        ShaderResourceTable live_table;
+        const std::vector<SrtUse> live_uses = add_compute_buffer_resources(
+            live_table, gta_swap_x2_site.data(), gta_swap_x2_site.size(),
+            live_seed, std::size(live_seed));
+        live_sized_atomic_x2_arms += live_uses.size() == 1u &&
+            live_uses[0].atomic_x2_record_count == record_count &&
+            live_table.resources.size() == 1u &&
+            live_table.resources[0].atomic_x2_record_count == record_count &&
+            live_table.resources[0].size == record_count * 8u;
+    }
+    CHECK(live_sized_atomic_x2_arms == 3u,
+          "pc145 carries GTA V's live 1/2/3-record dispatch bounds into qword atomics");
+    ComputeShaderConfig gta_swap_x2_unsupported_config = gta_swap_x2_config;
+    gta_swap_x2_unsupported_config.storage_buffer_int64_atomics = false;
+    CHECK(recompile_compute(gta_swap_x2_site.data(), gta_swap_x2_site.size(),
+                            &gta_swap_x2_table, gta_swap_x2_unsupported_config).empty(),
+          "GTA V swap_x2 remains fail-visible without an enabled Vulkan int64-atomic contract");
+
+    // The same rebuilt V# reaches pc172's BUFFER_ATOMIC_OR_X2. It is the next chronological live
+    // rejection after pc154 and must publish the same semantic proof at its own consumer PC.
+    std::vector<uint32_t> gta_or_x2_site(172, 0xBF800000u);
+    std::copy_n(gta_swap_x2_site.begin(), 154, gta_or_x2_site.begin());
+    gta_or_x2_site[154] = 0xBF800000u;
+    gta_or_x2_site[155] = 0xBF800000u;
+    gta_or_x2_site.push_back(0xE1686000u);
+    gta_or_x2_site.push_back(0x80000913u);
+    gta_or_x2_site.push_back(0xBF810000u);
+    ShaderResourceTable gta_or_x2_table;
+    const std::vector<SrtUse> gta_or_x2_uses = add_compute_buffer_resources(
+        gta_or_x2_table, gta_or_x2_site.data(), gta_or_x2_site.size(),
+        gta_swap_x2_seed, std::size(gta_swap_x2_seed));
+    CHECK(gta_or_x2_uses.size() == 1 && gta_or_x2_uses[0].use_pc == 172u &&
+              gta_or_x2_uses[0].atomic_x2_record_count == 25u &&
+              gta_or_x2_table.resources.size() == 1 &&
+              gta_or_x2_table.resources[0].size == 200u &&
+              gta_or_x2_table.resources[0].stride == 8u &&
+              gta_or_x2_table.resources[0].fetch_pc == 172u &&
+              gta_or_x2_table.resources[0].atomic_x2_record_count == 25u,
+          "GTA V 0x413e154 pc172 publishes the same exact proof for atomic_or_x2");
+
+    uint32_t rejected_atomic_x2_shapes = 0;
+    const auto atomic_x2_rejected = [&](const uint32_t user_sgprs[15], uint32_t word0,
+                                        uint32_t word1) {
+        std::vector<uint32_t> code = gta_swap_x2_site;
+        code[154] = word0;
+        code[155] = word1;
+        std::vector<SrtUse> uses;
+        resolve_dynamic_fetch(code.data(), code.size(), user_sgprs, 15, 0, &uses);
+        return uses.empty();
+    };
+    uint32_t mutated_swap_x2_seed[15];
+    std::copy(std::begin(gta_swap_x2_seed), std::end(gta_swap_x2_seed),
+              mutated_swap_x2_seed);
+    mutated_swap_x2_seed[9] |= 4u << 16; // pc142 rebuilds stride 12 instead of 8
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        mutated_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    std::copy(std::begin(gta_swap_x2_seed), std::end(gta_swap_x2_seed),
+              mutated_swap_x2_seed);
+    mutated_swap_x2_seed[13] = 0u;
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        mutated_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    std::copy(std::begin(gta_swap_x2_seed), std::end(gta_swap_x2_seed),
+              mutated_swap_x2_seed);
+    gta_swap_x2_site[147] |= 1u << 28; // OOB_SELECT=1 at the exact descriptor-build site
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    gta_swap_x2_site[147] &= ~(1u << 28);
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402004u, 0x80000913u); // instruction offset 4
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1403000u, 0x80000913u); // OFFEN as well as IDXEN
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x00000913u); // register SOFFSET
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x80400913u); // SLC
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE140A000u, 0x80000913u); // DLC
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1412000u, 0x80000913u); // LDS transfer
+    std::copy(std::begin(gta_swap_x2_seed), std::end(gta_swap_x2_seed),
+              mutated_swap_x2_seed);
+    mutated_swap_x2_seed[9] |= 0x80000000u; // SWIZZLE_ENABLE
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        mutated_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    gta_swap_x2_site[147] |= 1u << 23; // ADD_TID_ENABLE
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    gta_swap_x2_site[147] &= ~(1u << 23);
+    gta_swap_x2_site[147] |= 1u << 21; // INDEX_STRIDE
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    gta_swap_x2_site[147] &= ~(1u << 21);
+    gta_swap_x2_site[147] |= 1u << 24; // RESOURCE_LEVEL
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1402000u, 0x80000913u);
+    gta_swap_x2_site[147] &= ~(1u << 24);
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1422000u, 0x80000913u); // reserved dword0 bit 17
+    // A separately dumped OR_X2 uses offset 24 without IDXEN; exact live proof must not spread to it.
+    rejected_atomic_x2_shapes += atomic_x2_rejected(
+        gta_swap_x2_seed, 0xE1680018u, 0x80000000u);
+    CHECK(rejected_atomic_x2_shapes == 15u,
+          "qword-atomic discovery rejects every unproved stride/count/OOB/address sibling shape");
+
+    // These neighboring encodings still need distinct operands or wrap/conditional semantics. They
+    // must not acquire a resource merely because their descriptor is concrete.
     const uint32_t unsupported_atomic_dw0[] = {
         0xE0C40000u, // cmp-swap
         0xE0D00000u, // csub
         0xE0F00000u, // inc
         0xE0F40000u, // dec
-        0xE1402000u, // swap_x2, exact GTA V dword 0
     };
     uint32_t unsupported_atomic_uses = 0;
     uint32_t unsupported_atomic_resources = 0;
@@ -3334,7 +3492,7 @@ int main() {
     CHECK(unsupported_atomic_uses == 0 && unsupported_atomic_resources == 0 &&
               unsupported_atomic_recompiles == 0 && unsupported_empty_atomic_uses == 0 &&
               unsupported_empty_atomic_resources == 0,
-          "unsupported cmp-swap/csub/inc/dec/x2 atomics remain fail-closed even when empty");
+          "unsupported cmp-swap/csub/inc/dec atomics remain fail-closed even when empty");
 
     // Terminator 2D supplies descriptor dwords separately, then reassembles its destination V# in
     // s[0:3] with four scalar moves immediately before format stores. This has no SRT-load tag and

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -138,6 +138,7 @@ int main(int argc, char** argv) {
     ShaderResource b{}; b.cls = ResourceClass::ConstantBuffer; b.binding = 2; b.gpu_addr = 0x1008;
     b.size = 16; b.format = DataFormat::Float32; b.num_components = 4; b.srt_offset = 0x20;
     b.bvh_box_grow = 6;
+    b.bvh_sort_enabled = true;
     ShaderResource dcc{}; dcc.cls = ResourceClass::Texture; dcc.binding = 4; dcc.gpu_addr = 0x1000;
     dcc.size = 16; dcc.format = DataFormat::Unorm8; dcc.num_components = 4;
     dcc.width = dcc.height = 2; dcc.max_uncompressed_block_size = 2;
@@ -405,8 +406,7 @@ int main(int argc, char** argv) {
               GpuCaptureResourceInputVerdict::Mismatch,
           "FORMAT=INVALID V# still rejects a normalized byte-size disagreement");
 
-    // v47: one zero-mip specialization byte per realized and failed-stage resource.
-    auto v47_tail = [](const GpuCaptureFile& f) -> size_t {
+    auto resource_bool_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t rc = 0;
         for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
         for (const auto& cm : f.computes) rc += cm.resources.resources.size();
@@ -415,21 +415,27 @@ int main(int argc, char** argv) {
                 rc += stage.resource_table.resources.size();
         return 4 + rc;
     };
+    // v47/v48: one zero-mip / BVH-sort byte per realized and failed-stage resource.
+    auto v47_tail = [&](const GpuCaptureFile& f) -> size_t { return resource_bool_tail(f); };
+    auto v48_tail = [&](const GpuCaptureFile& f) -> size_t { return resource_bool_tail(f); };
 
     // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness. Mutate the
     // serialized tail, rather than merely constructing invalid in-memory objects, so the reader's
     // hostile-input boundary proves the exact pack contract it accepts.
     std::vector<uint8_t> valid_v46_bytes;
     CHECK(serialize_gpu_capture(provenance_loaded, valid_v46_bytes, error) &&
-              valid_v46_bytes.size() >= 104u + v47_tail(provenance_loaded),
+              valid_v46_bytes.size() >= 104u + v47_tail(provenance_loaded) +
+                  v48_tail(provenance_loaded),
           "v46 resource input witness has a complete validation tail");
     const size_t v46_tail_base = valid_v46_bytes.size() >=
-            104u + v47_tail(provenance_loaded)
-        ? valid_v46_bytes.size() - v47_tail(provenance_loaded) - 104u : 0u;
+            104u + v47_tail(provenance_loaded) + v48_tail(provenance_loaded)
+        ? valid_v46_bytes.size() - v48_tail(provenance_loaded) -
+              v47_tail(provenance_loaded) - 104u : 0u;
     auto malformed_tail_rejected = [&](size_t offset,
                                        std::initializer_list<uint8_t> replacement,
                                        const char* wanted_error) {
-        if (valid_v46_bytes.size() < 104u + v47_tail(provenance_loaded) ||
+        if (valid_v46_bytes.size() < 104u + v47_tail(provenance_loaded) +
+                v48_tail(provenance_loaded) ||
             offset > valid_v46_bytes.size() - replacement.size())
             return false;
         std::vector<uint8_t> bytes = valid_v46_bytes;
@@ -516,13 +522,15 @@ int main(int argc, char** argv) {
     GpuCaptureFile v45_provenance_loaded;
     CHECK(serialize_gpu_capture(provenance_loaded, v45_provenance_bytes, error) &&
               v45_provenance_bytes.size() >=
-                  v47_tail(provenance_loaded) +
+                  v48_tail(provenance_loaded) + v47_tail(provenance_loaded) +
                       4u + 100u * provenance_loaded.resource_provenance.size(),
           "v46 resource input tail is removable for a v45 compatibility fixture");
-    if (v45_provenance_bytes.size() >= v47_tail(provenance_loaded) +
+    if (v45_provenance_bytes.size() >= v48_tail(provenance_loaded) +
+            v47_tail(provenance_loaded) +
             4u + 100u * provenance_loaded.resource_provenance.size()) {
         v45_provenance_bytes.resize(
-            v45_provenance_bytes.size() - v47_tail(provenance_loaded));
+            v45_provenance_bytes.size() - v48_tail(provenance_loaded) -
+                v47_tail(provenance_loaded));
         v45_provenance_bytes.resize(
             v45_provenance_bytes.size() -
             (4u + 100u * provenance_loaded.resource_provenance.size()));
@@ -896,6 +904,7 @@ int main(int argc, char** argv) {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v48_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v47_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v46_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v45_tail(v16_scissor_source));
@@ -1015,7 +1024,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 47 &&
+              msaa_loaded.format_version == 48 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1042,7 +1051,7 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
     const uint32_t two_samples = 2;
     std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() -
-                    v47_tail(msaa_capture) - v46_tail(msaa_capture) -
+                    v48_tail(msaa_capture) - v47_tail(msaa_capture) - v46_tail(msaa_capture) -
                     v45_tail(msaa_capture) - 4u,
                 &two_samples, sizeof(two_samples));
     GpuCaptureFile mismatched_msaa_loaded;
@@ -1066,6 +1075,7 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v48_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v47_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v46_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v45_tail(v43_msaa_source));
@@ -1124,7 +1134,7 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 47 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 48 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -1135,7 +1145,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 47 &&
+              video_loaded.format_version == 48 &&
               video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
@@ -1143,6 +1153,7 @@ int main(int argc, char** argv) {
               video_replay.items[0].prt->resources[0].host_data_size == video_memory.size(),
           "v28 replay round-trips and binds the complete pitch-padded source span");
     std::vector<uint8_t> v46_zero_mip_bytes = video_capture_bytes;
+    v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v48_tail(video_capture));
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v47_tail(video_capture));
     v46_zero_mip_bytes[8] = 46;
     GpuCaptureFile v46_zero_mip_loaded;
@@ -1150,7 +1161,8 @@ int main(int argc, char** argv) {
               !v46_zero_mip_loaded.draws[0].prt.resources[0].resource.proven_zero_mip,
           "v46 capture reopens without manufacturing a zero-mip specialization proof");
     std::vector<uint8_t> malformed_zero_mip_bytes = video_capture_bytes;
-    malformed_zero_mip_bytes.back() = 2;
+    malformed_zero_mip_bytes[malformed_zero_mip_bytes.size() -
+                             v48_tail(video_capture) - 1u] = 2;
     GpuCaptureFile malformed_zero_mip_loaded;
     CHECK(!deserialize_gpu_capture(
               malformed_zero_mip_bytes, malformed_zero_mip_loaded, error) &&
@@ -1173,7 +1185,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 47 &&
+              upgraded_video.format_version == 48 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1255,7 +1267,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 47 &&
+              array_layout_loaded.format_version == 48 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1354,6 +1366,7 @@ int main(int argc, char** argv) {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v48_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v47_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v46_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v45_tail(volume_capture));
@@ -1459,6 +1472,7 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v48_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v47_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v46_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v45_tail(pre_v31_source));
@@ -1539,6 +1553,7 @@ int main(int argc, char** argv) {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v48_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v47_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v46_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v45_tail(captured));
@@ -1558,12 +1573,34 @@ int main(int argc, char** argv) {
     CHECK(loaded.draws[0].vrt.resources[0].resource.fetch_index_mode ==
               VertexFetchIndexMode::Instance,
           "v30 fetch-index provenance round-trips explicitly for gpu_replay");
-    CHECK(loaded.draws[0].vrt.resources[1].resource.bvh_box_grow == 6,
-          "v40 BVH box-grow state round-trips explicitly for raw replay");
+    CHECK(loaded.draws[0].vrt.resources[1].resource.bvh_box_grow == 6 &&
+              loaded.draws[0].vrt.resources[1].resource.bvh_sort_enabled,
+          "v40/v48 BVH box-grow and sort state round-trip explicitly for raw replay");
+    std::vector<uint8_t> v48_bvh_bytes;
+    CHECK(serialize_gpu_capture(captured, v48_bvh_bytes, error) &&
+              v48_bvh_bytes.size() >= v48_tail(captured),
+          "v48 BVH sort state has a complete append-only tail");
+    std::vector<uint8_t> v47_bvh_bytes = v48_bvh_bytes;
+    v47_bvh_bytes.resize(v47_bvh_bytes.size() - v48_tail(captured));
+    v47_bvh_bytes[8] = 47;
+    v47_bvh_bytes[9] = v47_bvh_bytes[10] = v47_bvh_bytes[11] = 0;
+    GpuCaptureFile v47_bvh_loaded;
+    CHECK(deserialize_gpu_capture(v47_bvh_bytes, v47_bvh_loaded, error) &&
+              v47_bvh_loaded.draws[0].vrt.resources[1].resource.bvh_box_grow == 6 &&
+              !v47_bvh_loaded.draws[0].vrt.resources[1].resource.bvh_sort_enabled,
+          "v47 capture reopens without manufacturing BVH sorting");
+    std::vector<uint8_t> malformed_bvh_sort_bytes = v48_bvh_bytes;
+    malformed_bvh_sort_bytes.back() = 2u;
+    GpuCaptureFile malformed_bvh_sort_loaded;
+    CHECK(!deserialize_gpu_capture(malformed_bvh_sort_bytes,
+                                   malformed_bvh_sort_loaded, error) &&
+              error == "invalid BVH sort state",
+          "v48 capture rejects a non-boolean BVH sort marker");
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-              v24_resolve_bytes.size() >= v47_tail(pre_v31_source) +
+              v24_resolve_bytes.size() >= v48_tail(pre_v31_source) +
+                  v47_tail(pre_v31_source) +
                   v46_tail(pre_v31_source) +
               v45_tail(pre_v31_source) +
               v44_tail(pre_v31_source) +
@@ -1580,7 +1617,8 @@ int main(int argc, char** argv) {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v47_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v48_tail(pre_v31_source) +
+            v47_tail(pre_v31_source) +
             v46_tail(pre_v31_source) +
             v45_tail(pre_v31_source) +
             v44_tail(pre_v31_source) +
@@ -1596,6 +1634,7 @@ int main(int argc, char** argv) {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v48_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v47_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v46_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v45_tail(pre_v31_source));
@@ -1697,10 +1736,11 @@ int main(int argc, char** argv) {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v47_tail(captured) + v46_tail(captured) + v45_tail(captured) +
+        v48_tail(captured) + v47_tail(captured) + v46_tail(captured) + v45_tail(captured) +
         v44_tail(captured) + v43_tail(captured) +
             v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v48_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v47_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v46_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v45_tail(captured));
@@ -1895,7 +1935,8 @@ int main(int argc, char** argv) {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v47_tail(v36_compute_source) + v46_tail(v36_compute_source) +
+                  v48_tail(v36_compute_source) + v47_tail(v36_compute_source) +
+                  v46_tail(v36_compute_source) +
                   v45_tail(v36_compute_source) +
                       v44_tail(v36_compute_source) +
                       v43_tail(v36_compute_source) +
@@ -1905,7 +1946,8 @@ int main(int argc, char** argv) {
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v47_tail(v36_compute_source) + v46_tail(v36_compute_source) +
+        v48_tail(v36_compute_source) + v47_tail(v36_compute_source) +
+        v46_tail(v36_compute_source) +
         v45_tail(v36_compute_source) +
             v44_tail(v36_compute_source) +
             v43_tail(v36_compute_source) +
@@ -1913,6 +1955,7 @@ int main(int argc, char** argv) {
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v48_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v47_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v46_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v45_tail(v36_compute_source));
@@ -2298,7 +2341,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 47 &&
+              failed_compute_loaded.format_version == 48 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -2311,7 +2354,8 @@ int main(int argc, char** argv) {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v47_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v48_tail(failed_compute_capture) -
+            v47_tail(failed_compute_capture) -
         v46_tail(failed_compute_capture) -
             v45_tail(failed_compute_capture) -
             v44_tail(failed_compute_capture) -
@@ -2532,7 +2576,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 47 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 48 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -2570,7 +2614,8 @@ int main(int argc, char** argv) {
         // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
         // so this is exactly its v44 sample-count record rather than a preceding extension field.
         std::memcpy(malformed_failed_sample_bytes.data() +
-                        malformed_failed_sample_bytes.size() - v47_tail(failed_capture) -
+                        malformed_failed_sample_bytes.size() - v48_tail(failed_capture) -
+                        v47_tail(failed_capture) -
                         v46_tail(failed_capture) -
                             v45_tail(failed_capture) -
                             sizeof(uint32_t),
@@ -2586,18 +2631,21 @@ int main(int argc, char** argv) {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v47_tail(failed_capture) + v46_tail(failed_capture) +
+                  v48_tail(failed_capture) + v47_tail(failed_capture) +
+                  v46_tail(failed_capture) +
                   v45_tail(failed_capture) +
                       v44_tail(failed_capture) +
                       v43_tail(failed_capture) +
                       v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v47_tail(failed_capture) + v46_tail(failed_capture) +
+        v48_tail(failed_capture) + v47_tail(failed_capture) +
+        v46_tail(failed_capture) +
         v45_tail(failed_capture) +
             v44_tail(failed_capture) +
             v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v48_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v47_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v46_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v45_tail(failed_capture));
@@ -2684,6 +2732,7 @@ int main(int argc, char** argv) {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v48_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v47_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v46_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v45_tail(legacy_source));
@@ -2729,6 +2778,7 @@ int main(int argc, char** argv) {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v48_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v47_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v46_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v45_tail(legacy_source));
@@ -2800,9 +2850,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 48;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 49;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 48",
+          error == "unsupported capture version 49",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -415,9 +415,12 @@ int main(int argc, char** argv) {
                 rc += stage.resource_table.resources.size();
         return 4 + rc;
     };
-    // v47/v48: one zero-mip / BVH-sort byte per realized and failed-stage resource.
+    // v47/v48 use one proof byte per resource; v49 stores one qword record-count dword.
     auto v47_tail = [&](const GpuCaptureFile& f) -> size_t { return resource_bool_tail(f); };
     auto v48_tail = [&](const GpuCaptureFile& f) -> size_t { return resource_bool_tail(f); };
+    auto v49_tail = [&](const GpuCaptureFile& f) -> size_t {
+        return 4u + (resource_bool_tail(f) - 4u) * sizeof(uint32_t);
+    };
 
     // The fixed v46 tail is 4 bytes of count plus 100 bytes per selected witness. Mutate the
     // serialized tail, rather than merely constructing invalid in-memory objects, so the reader's
@@ -425,17 +428,19 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> valid_v46_bytes;
     CHECK(serialize_gpu_capture(provenance_loaded, valid_v46_bytes, error) &&
               valid_v46_bytes.size() >= 104u + v47_tail(provenance_loaded) +
-                  v48_tail(provenance_loaded),
+                  v48_tail(provenance_loaded) + v49_tail(provenance_loaded),
           "v46 resource input witness has a complete validation tail");
     const size_t v46_tail_base = valid_v46_bytes.size() >=
-            104u + v47_tail(provenance_loaded) + v48_tail(provenance_loaded)
-        ? valid_v46_bytes.size() - v48_tail(provenance_loaded) -
+            104u + v47_tail(provenance_loaded) + v48_tail(provenance_loaded) +
+                v49_tail(provenance_loaded)
+        ? valid_v46_bytes.size() - v49_tail(provenance_loaded) -
+              v48_tail(provenance_loaded) -
               v47_tail(provenance_loaded) - 104u : 0u;
     auto malformed_tail_rejected = [&](size_t offset,
                                        std::initializer_list<uint8_t> replacement,
                                        const char* wanted_error) {
         if (valid_v46_bytes.size() < 104u + v47_tail(provenance_loaded) +
-                v48_tail(provenance_loaded) ||
+                v48_tail(provenance_loaded) + v49_tail(provenance_loaded) ||
             offset > valid_v46_bytes.size() - replacement.size())
             return false;
         std::vector<uint8_t> bytes = valid_v46_bytes;
@@ -522,14 +527,16 @@ int main(int argc, char** argv) {
     GpuCaptureFile v45_provenance_loaded;
     CHECK(serialize_gpu_capture(provenance_loaded, v45_provenance_bytes, error) &&
               v45_provenance_bytes.size() >=
-                  v48_tail(provenance_loaded) + v47_tail(provenance_loaded) +
+                  v49_tail(provenance_loaded) + v48_tail(provenance_loaded) +
+                      v47_tail(provenance_loaded) +
                       4u + 100u * provenance_loaded.resource_provenance.size(),
           "v46 resource input tail is removable for a v45 compatibility fixture");
-    if (v45_provenance_bytes.size() >= v48_tail(provenance_loaded) +
-            v47_tail(provenance_loaded) +
+    if (v45_provenance_bytes.size() >= v49_tail(provenance_loaded) +
+            v48_tail(provenance_loaded) + v47_tail(provenance_loaded) +
             4u + 100u * provenance_loaded.resource_provenance.size()) {
         v45_provenance_bytes.resize(
-            v45_provenance_bytes.size() - v48_tail(provenance_loaded) -
+            v45_provenance_bytes.size() - v49_tail(provenance_loaded) -
+                v48_tail(provenance_loaded) -
                 v47_tail(provenance_loaded));
         v45_provenance_bytes.resize(
             v45_provenance_bytes.size() -
@@ -904,6 +911,7 @@ int main(int argc, char** argv) {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v49_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v48_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v47_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v46_tail(v16_scissor_source));
@@ -1024,7 +1032,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 48 &&
+              msaa_loaded.format_version == 49 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1051,7 +1059,8 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> mismatched_msaa_metadata = msaa_bytes;
     const uint32_t two_samples = 2;
     std::memcpy(mismatched_msaa_metadata.data() + mismatched_msaa_metadata.size() -
-                    v48_tail(msaa_capture) - v47_tail(msaa_capture) - v46_tail(msaa_capture) -
+                    v49_tail(msaa_capture) - v48_tail(msaa_capture) -
+                    v47_tail(msaa_capture) - v46_tail(msaa_capture) -
                     v45_tail(msaa_capture) - 4u,
                 &two_samples, sizeof(two_samples));
     GpuCaptureFile mismatched_msaa_loaded;
@@ -1075,6 +1084,7 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v49_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v48_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v47_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v46_tail(v43_msaa_source));
@@ -1134,7 +1144,7 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 48 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 49 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -1145,7 +1155,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 48 &&
+              video_loaded.format_version == 49 &&
               video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
@@ -1153,6 +1163,7 @@ int main(int argc, char** argv) {
               video_replay.items[0].prt->resources[0].host_data_size == video_memory.size(),
           "v28 replay round-trips and binds the complete pitch-padded source span");
     std::vector<uint8_t> v46_zero_mip_bytes = video_capture_bytes;
+    v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v49_tail(video_capture));
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v48_tail(video_capture));
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v47_tail(video_capture));
     v46_zero_mip_bytes[8] = 46;
@@ -1162,7 +1173,7 @@ int main(int argc, char** argv) {
           "v46 capture reopens without manufacturing a zero-mip specialization proof");
     std::vector<uint8_t> malformed_zero_mip_bytes = video_capture_bytes;
     malformed_zero_mip_bytes[malformed_zero_mip_bytes.size() -
-                             v48_tail(video_capture) - 1u] = 2;
+                             v49_tail(video_capture) - v48_tail(video_capture) - 1u] = 2;
     GpuCaptureFile malformed_zero_mip_loaded;
     CHECK(!deserialize_gpu_capture(
               malformed_zero_mip_bytes, malformed_zero_mip_loaded, error) &&
@@ -1185,7 +1196,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 48 &&
+              upgraded_video.format_version == 49 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1267,7 +1278,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 48 &&
+              array_layout_loaded.format_version == 49 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1366,6 +1377,7 @@ int main(int argc, char** argv) {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v49_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v48_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v47_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v46_tail(volume_capture));
@@ -1472,6 +1484,7 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v49_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v48_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v47_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v46_tail(pre_v31_source));
@@ -1553,6 +1566,7 @@ int main(int argc, char** argv) {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v49_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v48_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v47_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v46_tail(captured));
@@ -1578,8 +1592,11 @@ int main(int argc, char** argv) {
           "v40/v48 BVH box-grow and sort state round-trip explicitly for raw replay");
     std::vector<uint8_t> v48_bvh_bytes;
     CHECK(serialize_gpu_capture(captured, v48_bvh_bytes, error) &&
-              v48_bvh_bytes.size() >= v48_tail(captured),
+              v48_bvh_bytes.size() >= v49_tail(captured) + v48_tail(captured),
           "v48 BVH sort state has a complete append-only tail");
+    v48_bvh_bytes.resize(v48_bvh_bytes.size() - v49_tail(captured));
+    v48_bvh_bytes[8] = 48;
+    v48_bvh_bytes[9] = v48_bvh_bytes[10] = v48_bvh_bytes[11] = 0;
     std::vector<uint8_t> v47_bvh_bytes = v48_bvh_bytes;
     v47_bvh_bytes.resize(v47_bvh_bytes.size() - v48_tail(captured));
     v47_bvh_bytes[8] = 47;
@@ -1596,10 +1613,39 @@ int main(int argc, char** argv) {
                                    malformed_bvh_sort_loaded, error) &&
               error == "invalid BVH sort state",
           "v48 capture rejects a non-boolean BVH sort marker");
+
+    GpuCaptureFile atomic_capture = captured;
+    atomic_capture.draws[0].vrt.resources[0].resource
+        .atomic_x2_record_count = 25u;
+    std::vector<uint8_t> v49_atomic_bytes;
+    GpuCaptureFile v49_atomic_loaded;
+    CHECK(serialize_gpu_capture(atomic_capture, v49_atomic_bytes, error) &&
+              v49_atomic_bytes.size() >= v49_tail(atomic_capture) &&
+              deserialize_gpu_capture(v49_atomic_bytes, v49_atomic_loaded, error) &&
+              v49_atomic_loaded.format_version == 49 &&
+              v49_atomic_loaded.draws[0].vrt.resources[0].resource
+                  .atomic_x2_record_count == 25u,
+          "v49 capture round-trips the exact qword-atomic record count");
+    std::vector<uint8_t> v48_atomic_bytes = v49_atomic_bytes;
+    v48_atomic_bytes.resize(v48_atomic_bytes.size() - v49_tail(atomic_capture));
+    v48_atomic_bytes[8] = 48;
+    v48_atomic_bytes[9] = v48_atomic_bytes[10] = v48_atomic_bytes[11] = 0;
+    GpuCaptureFile v48_atomic_loaded;
+    CHECK(deserialize_gpu_capture(v48_atomic_bytes, v48_atomic_loaded, error) &&
+              !v48_atomic_loaded.draws[0].vrt.resources[0].resource
+                   .atomic_x2_record_count,
+          "v48 capture reopens without manufacturing a qword-atomic descriptor proof");
+    std::vector<uint8_t> malformed_atomic_bytes = v49_atomic_bytes;
+    malformed_atomic_bytes.pop_back();
+    GpuCaptureFile malformed_atomic_loaded;
+    CHECK(!deserialize_gpu_capture(malformed_atomic_bytes, malformed_atomic_loaded, error) &&
+              error == "invalid atomic-x2 state",
+          "v49 capture rejects a truncated qword-atomic record count");
     std::vector<uint8_t> v24_resolve_bytes;
     GpuCaptureFile v24_resolve_loaded;
     CHECK(serialize_gpu_capture(pre_v31_source, v24_resolve_bytes, error) &&
-              v24_resolve_bytes.size() >= v48_tail(pre_v31_source) +
+              v24_resolve_bytes.size() >= v49_tail(pre_v31_source) +
+                  v48_tail(pre_v31_source) +
                   v47_tail(pre_v31_source) +
                   v46_tail(pre_v31_source) +
               v45_tail(pre_v31_source) +
@@ -1617,8 +1663,8 @@ int main(int argc, char** argv) {
               v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
               v25_tail(pre_v31_source),
           "v25 capture exposes a removable trailing resolve-state block");
-    if (v24_resolve_bytes.size() >= v48_tail(pre_v31_source) +
-            v47_tail(pre_v31_source) +
+    if (v24_resolve_bytes.size() >= v49_tail(pre_v31_source) +
+            v48_tail(pre_v31_source) + v47_tail(pre_v31_source) +
             v46_tail(pre_v31_source) +
             v45_tail(pre_v31_source) +
             v44_tail(pre_v31_source) +
@@ -1634,6 +1680,7 @@ int main(int argc, char** argv) {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v49_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v48_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v47_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v46_tail(pre_v31_source));
@@ -1736,10 +1783,12 @@ int main(int argc, char** argv) {
               v37_compatible_bytes.size() >= 12,
           "current capture prepares the layout-compatible v37 fixture");
     if (v37_compatible_bytes.size() >=
-        v48_tail(captured) + v47_tail(captured) + v46_tail(captured) + v45_tail(captured) +
+        v49_tail(captured) + v48_tail(captured) + v47_tail(captured) +
+        v46_tail(captured) + v45_tail(captured) +
         v44_tail(captured) + v43_tail(captured) +
             v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v49_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v48_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v47_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v46_tail(captured));
@@ -1905,6 +1954,34 @@ int main(int argc, char** argv) {
               mixed_replay.raw_shader_versions.size() &&
           mixed_replay.computes[0].resources->resources[0].host_data[0] == repeated[32],
           "offline materialization owns compute resources and preserves raw-recompile state");
+    GpuCaptureFile mixed_atomic = mixed;
+    mixed_atomic.computes[0].recompile_config.storage_buffer_int64_atomics = true;
+    // Capture serialization treats the marker as opaque provenance; the emitter separately
+    // revalidates the live descriptor's size/stride/address before it can use this proof.
+    mixed_atomic.computes[0].resources.resources[0].resource
+        .atomic_x2_record_count = 25u;
+    std::vector<uint8_t> mixed_atomic_bytes;
+    GpuCaptureFile mixed_atomic_loaded;
+    GpuReplayFrame mixed_atomic_replay;
+    CHECK(serialize_gpu_capture(mixed_atomic, mixed_atomic_bytes, error) &&
+              deserialize_gpu_capture(mixed_atomic_bytes, mixed_atomic_loaded, error) &&
+              mixed_atomic_loaded.computes[0]
+                  .recompile_config.storage_buffer_int64_atomics &&
+              materialize_gpu_replay(mixed_atomic_loaded, mixed_atomic_replay, error) &&
+              mixed_atomic_replay.computes[0]
+                  .recompile_config.storage_buffer_int64_atomics &&
+              mixed_atomic_replay.computes[0].resources->resources[0]
+                  .atomic_x2_record_count == 25u,
+          "v49 raw-compute replay preserves qword-atomic device support and record count");
+    std::vector<uint8_t> v48_reserved_atomic_flag = mixed_atomic_bytes;
+    v48_reserved_atomic_flag.resize(v48_reserved_atomic_flag.size() - v49_tail(mixed_atomic));
+    v48_reserved_atomic_flag[8] = 48;
+    v48_reserved_atomic_flag[9] = v48_reserved_atomic_flag[10] =
+        v48_reserved_atomic_flag[11] = 0;
+    GpuCaptureFile v48_reserved_atomic_loaded;
+    CHECK(!deserialize_gpu_capture(v48_reserved_atomic_flag,
+                                   v48_reserved_atomic_loaded, error),
+          "v48 capture rejects the int64-atomic config bit that was reserved before v49");
     GpuCaptureFile invalid_subgroup = mixed;
     invalid_subgroup.computes[0].required_subgroup_size = 16;
     std::vector<uint8_t> invalid_subgroup_bytes;
@@ -1935,7 +2012,8 @@ int main(int argc, char** argv) {
     v36_compute_source.raw_shader_versions.clear();
     CHECK(serialize_gpu_capture(v36_compute_source, v36_compute_bytes, error) &&
               v36_compute_bytes.size() >=
-                  v48_tail(v36_compute_source) + v47_tail(v36_compute_source) +
+                  v49_tail(v36_compute_source) + v48_tail(v36_compute_source) +
+                  v47_tail(v36_compute_source) +
                   v46_tail(v36_compute_source) +
                   v45_tail(v36_compute_source) +
                       v44_tail(v36_compute_source) +
@@ -1946,7 +2024,8 @@ int main(int argc, char** argv) {
                       v37_tail(v36_compute_source),
           "v37 capture exposes a removable compute subgroup-contract tail");
     if (v36_compute_bytes.size() >=
-        v48_tail(v36_compute_source) + v47_tail(v36_compute_source) +
+        v49_tail(v36_compute_source) + v48_tail(v36_compute_source) +
+        v47_tail(v36_compute_source) +
         v46_tail(v36_compute_source) +
         v45_tail(v36_compute_source) +
             v44_tail(v36_compute_source) +
@@ -1955,6 +2034,7 @@ int main(int argc, char** argv) {
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v49_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v48_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v47_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v46_tail(v36_compute_source));
@@ -2341,7 +2421,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 48 &&
+              failed_compute_loaded.format_version == 49 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -2354,7 +2434,8 @@ int main(int argc, char** argv) {
 
     std::vector<uint8_t> v41_failed_compute_bytes = failed_compute_bytes;
     v41_failed_compute_bytes.resize(
-        v41_failed_compute_bytes.size() - v48_tail(failed_compute_capture) -
+        v41_failed_compute_bytes.size() - v49_tail(failed_compute_capture) -
+            v48_tail(failed_compute_capture) -
             v47_tail(failed_compute_capture) -
         v46_tail(failed_compute_capture) -
             v45_tail(failed_compute_capture) -
@@ -2576,7 +2657,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 48 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 49 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -2614,7 +2695,8 @@ int main(int argc, char** argv) {
         // Fragment is the final stage with resources, and its MSAA descriptor is the final resource,
         // so this is exactly its v44 sample-count record rather than a preceding extension field.
         std::memcpy(malformed_failed_sample_bytes.data() +
-                        malformed_failed_sample_bytes.size() - v48_tail(failed_capture) -
+                        malformed_failed_sample_bytes.size() - v49_tail(failed_capture) -
+                        v48_tail(failed_capture) -
                         v47_tail(failed_capture) -
                         v46_tail(failed_capture) -
                             v45_tail(failed_capture) -
@@ -2631,7 +2713,8 @@ int main(int argc, char** argv) {
     GpuCaptureFile v40_failed_loaded;
     CHECK(serialize_gpu_capture(failed_capture, v40_failed_bytes, error) &&
               v40_failed_bytes.size() >=
-                  v48_tail(failed_capture) + v47_tail(failed_capture) +
+                  v49_tail(failed_capture) + v48_tail(failed_capture) +
+                  v47_tail(failed_capture) +
                   v46_tail(failed_capture) +
                   v45_tail(failed_capture) +
                       v44_tail(failed_capture) +
@@ -2639,12 +2722,14 @@ int main(int argc, char** argv) {
                       v42_tail(failed_capture) + v41_tail(failed_capture),
           "v41 failed-stage resource tail is removable for a v40 compatibility fixture");
     if (v40_failed_bytes.size() >=
-        v48_tail(failed_capture) + v47_tail(failed_capture) +
+        v49_tail(failed_capture) + v48_tail(failed_capture) +
+        v47_tail(failed_capture) +
         v46_tail(failed_capture) +
         v45_tail(failed_capture) +
             v44_tail(failed_capture) +
             v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v49_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v48_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v47_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v46_tail(failed_capture));
@@ -2732,6 +2817,7 @@ int main(int argc, char** argv) {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v49_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v48_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v47_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v46_tail(legacy_source));
@@ -2778,6 +2864,7 @@ int main(int argc, char** argv) {
     if (legacy_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        legacy_bytes.resize(legacy_bytes.size() - v49_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v48_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v47_tail(legacy_source));
         legacy_bytes.resize(legacy_bytes.size() - v46_tail(legacy_source));
@@ -2850,9 +2937,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 49;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 50;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 49",
+          error == "unsupported capture version 50",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -136,6 +136,17 @@ int main() {
           rdna2_vgpr_write_count(gta_lshlrev_b64) == 2u &&
           rdna2_vgpr_destination_span(gta_lshlrev_b64) == 2u,
           "GTA V v_lshlrev_b64 decodes two sources and a two-VGPR destination");
+    // GTA V exec_cs_205b54f200 pc21, exact llvm-mc gfx1030 packet:
+    // `v_cvt_rpi_i32_f32_e32 v1, v1`. Keep the plain one-dword form distinct from the
+    // modifier encodings that the emitter intentionally leaves unsupported.
+    const uint32_t gta_cvt_rpi_words[] = {0x7e021901u};
+    const Rdna2Inst gta_cvt_rpi = rdna2_decode_one(gta_cvt_rpi_words, 1);
+    CHECK(gta_cvt_rpi.fmt == Rdna2Format::VOP1 && gta_cvt_rpi.len_dwords == 1u &&
+          gta_cvt_rpi.opcode == 0x0cu && isV(gta_cvt_rpi.dst, 1) &&
+          gta_cvt_rpi.n_src == 1u && isV(gta_cvt_rpi.src[0], 1) &&
+          !gta_cvt_rpi.has_literal && !gta_cvt_rpi.has_modifier &&
+          !gta_cvt_rpi.has_sdwa && !gta_cvt_rpi.has_dpp,
+          "GTA V v_cvt_rpi_i32_f32 decodes exact plain VOP1 operands");
     // inst7: s_load_dwordx4 s[0:3], s[4:5], 0x0 (SMEM) -> op 0x2, SDATA s0, SBASE s4 (pair), offset 0
     CHECK(ins[7].fmt == Rdna2Format::SMEM && ins[7].opcode == 0x2u && isS(ins[7].dst, 0) &&
           isS(ins[7].src[0], 4) && ins[7].literal == 0x0u, "s_load_dwordx4 SMEM op/SDATA/SBASE/offset");

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -441,6 +441,22 @@ int main() {
           gvr0.dpp_bound_ctrl && isV(gvr0.dst, 0) &&
           isV(gvr0.src[0], 0) && isV(gvr0.src[1], 0),
           "GTA V in-place V_MIN_F32 ROW_ROR:8 packet decodes its DPP SRC0");
+    const uint32_t gta_vmax_row_ror8[] = { 0x200406fau, 0xff092803u };
+    Rdna2Inst gvx = rdna2_decode_one(gta_vmax_row_ror8, 2);
+    CHECK(gvx.fmt == Rdna2Format::VOP2 && gvx.opcode == 0x10u &&
+          !gvx.has_modifier && gvx.has_dpp && gvx.dpp_ctrl == 0x128u &&
+          gvx.dpp_bound_ctrl && gvx.dpp_row_mask == 0xfu &&
+          gvx.dpp_bank_mask == 0xfu && isV(gvx.dst, 2) &&
+          isV(gvx.src[0], 3) && isV(gvx.src[1], 3),
+          "GTA V exact V_MAX_F32 ROW_ROR:8 packet decodes its permuted SRC0");
+    const uint32_t gta_vmov_row_ror8[] = { 0x7e2402fau, 0xff092811u };
+    Rdna2Inst gvm = rdna2_decode_one(gta_vmov_row_ror8, 2);
+    CHECK(gvm.fmt == Rdna2Format::VOP1 && gvm.opcode == 0x01u &&
+          !gvm.has_modifier && gvm.has_dpp && gvm.dpp_ctrl == 0x128u &&
+          gvm.dpp_bound_ctrl && gvm.dpp_row_mask == 0xfu &&
+          gvm.dpp_bank_mask == 0xfu && isV(gvm.dst, 18) &&
+          isV(gvm.src[0], 17) && gvm.n_src == 1u,
+          "GTA V exact V_MOV_B32 ROW_ROR:8 packet decodes its sole permuted source");
     const std::pair<uint32_t, uint32_t> gta_vmin_row_ror8_mutants[] = {
         {0x1c2024fau, 0xff092812u}, // different VOP2 opcode
         {0x1e2024fau, 0xff012812u}, // BOUND_CTRL=0
@@ -449,13 +465,29 @@ int main() {
         {0x1e2024fau, 0xfe092812u}, // partial BANK_MASK
         {0x1e2024fau, 0xff192812u}, // SRC0_NEG
         {0x1e2024fau, 0xff0d2812u}, // FI=1
-        {0x7e2002fau, 0xff092812u}, // V_MOV_B32 rather than V_MIN_F32
     };
     for (const auto& mutant : gta_vmin_row_ror8_mutants) {
         const uint32_t words[] = {mutant.first, mutant.second};
         Rdna2Inst rejected = rdna2_decode_one(words, 2);
         CHECK(rejected.has_modifier && !rejected.has_dpp,
               "GTA V ROW_ROR:8 admission rejects opcode/control/mask/modifier mutations");
+    }
+    const std::pair<uint32_t, uint32_t> gta_new_row_ror8_mutants[] = {
+        {0x200406fau, 0xff012803u}, // V_MAX_F32 BOUND_CTRL=0
+        {0x200406fau, 0xff092903u}, // V_MAX_F32 ROW_ROR:9
+        {0x200406fau, 0xef092803u}, // V_MAX_F32 partial ROW_MASK
+        {0x200406fau, 0xff192803u}, // V_MAX_F32 SRC0_NEG
+        {0x7e2402fau, 0xff012811u}, // V_MOV_B32 BOUND_CTRL=0
+        {0x7e2402fau, 0xff092911u}, // V_MOV_B32 ROW_ROR:9
+        {0x7e2402fau, 0xfe092811u}, // V_MOV_B32 partial BANK_MASK
+        {0x7e2402fau, 0xff192811u}, // V_MOV_B32 SRC0_NEG
+        {0x060406fau, 0xff092803u}, // V_ADD_F32 is outside the admitted live family
+    };
+    for (const auto& mutant : gta_new_row_ror8_mutants) {
+        const uint32_t words[] = {mutant.first, mutant.second};
+        Rdna2Inst rejected = rdna2_decode_one(words, 2);
+        CHECK(rejected.has_modifier && !rejected.has_dpp,
+              "GTA V new ROW_ROR:8 sites reject control, mask, modifier, and opcode mutations");
     }
     const uint32_t gta_row_mask_add[] = { 0x4a2826fau, 0xaf00e414u };
     Rdna2Inst grm = rdna2_decode_one(gta_row_mask_add, 2);

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstdio>
 #include <cstdint>
+#include <utility>
 
 using namespace prosper::gpu;
 
@@ -425,6 +426,37 @@ int main() {
           dp.dpp_ctrl == 0x111u && !dp.dpp_bound_ctrl &&
           dp.dpp_row_mask == 0xfu && dp.dpp_bank_mask == 0xfu,
           "VOP2 DPP16 ROW_SHR form retains its unbounded lane control");
+    const uint32_t gta_vmin_row_ror8[] = { 0x1e2024fau, 0xff092812u };
+    Rdna2Inst gvr = rdna2_decode_one(gta_vmin_row_ror8, 2);
+    CHECK(gvr.fmt == Rdna2Format::VOP2 && gvr.opcode == 0x0fu &&
+          gvr.len_dwords == 2u && !gvr.has_modifier && gvr.has_dpp &&
+          gvr.dpp_ctrl == 0x128u && gvr.dpp_bound_ctrl &&
+          gvr.dpp_row_mask == 0xfu && gvr.dpp_bank_mask == 0xfu &&
+          isV(gvr.dst, 16) && isV(gvr.src[0], 18) && isV(gvr.src[1], 18),
+          "GTA V V_MIN_F32 ROW_ROR:8 packet retains exact control and operands");
+    const uint32_t gta_vmin_row_ror8_v0[] = { 0x1e0000fau, 0xff092800u };
+    Rdna2Inst gvr0 = rdna2_decode_one(gta_vmin_row_ror8_v0, 2);
+    CHECK(gvr0.fmt == Rdna2Format::VOP2 && gvr0.opcode == 0x0fu &&
+          !gvr0.has_modifier && gvr0.has_dpp && gvr0.dpp_ctrl == 0x128u &&
+          gvr0.dpp_bound_ctrl && isV(gvr0.dst, 0) &&
+          isV(gvr0.src[0], 0) && isV(gvr0.src[1], 0),
+          "GTA V in-place V_MIN_F32 ROW_ROR:8 packet decodes its DPP SRC0");
+    const std::pair<uint32_t, uint32_t> gta_vmin_row_ror8_mutants[] = {
+        {0x1c2024fau, 0xff092812u}, // different VOP2 opcode
+        {0x1e2024fau, 0xff012812u}, // BOUND_CTRL=0
+        {0x1e2024fau, 0xff092912u}, // ROW_ROR:9
+        {0x1e2024fau, 0xef092812u}, // partial ROW_MASK
+        {0x1e2024fau, 0xfe092812u}, // partial BANK_MASK
+        {0x1e2024fau, 0xff192812u}, // SRC0_NEG
+        {0x1e2024fau, 0xff0d2812u}, // FI=1
+        {0x7e2002fau, 0xff092812u}, // V_MOV_B32 rather than V_MIN_F32
+    };
+    for (const auto& mutant : gta_vmin_row_ror8_mutants) {
+        const uint32_t words[] = {mutant.first, mutant.second};
+        Rdna2Inst rejected = rdna2_decode_one(words, 2);
+        CHECK(rejected.has_modifier && !rejected.has_dpp,
+              "GTA V ROW_ROR:8 admission rejects opcode/control/mask/modifier mutations");
+    }
     const uint32_t gta_row_mask_add[] = { 0x4a2826fau, 0xaf00e414u };
     Rdna2Inst grm = rdna2_decode_one(gta_row_mask_add, 2);
     CHECK(grm.fmt == Rdna2Format::VOP2 && grm.opcode == 0x25u &&

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -123,6 +123,19 @@ int main() {
           gta_bfm.src[1].kind == OperandKind::InlineInt && gta_bfm.src[1].value == 0 &&
           gta_bfm.src[2].kind == OperandKind::None,
           "GTA V v_bfm_b32 decodes two sources and no phantom s0");
+    // GTA V exec_cs_205b658800 pc61: `v_lshlrev_b64 v[24:25], v4, 1`. The reserved SRC2 field
+    // must not surface as s0, and the shared writer inventory must retain both result halves.
+    const uint32_t gta_lshlrev_b64_words[] = {0xd6ff0018u, 0x00010304u};
+    const Rdna2Inst gta_lshlrev_b64 = rdna2_decode_one(gta_lshlrev_b64_words, 2);
+    CHECK(gta_lshlrev_b64.fmt == Rdna2Format::VOP3 &&
+          gta_lshlrev_b64.opcode == 0x2ffu && gta_lshlrev_b64.n_src == 2 &&
+          isV(gta_lshlrev_b64.dst, 24) && isV(gta_lshlrev_b64.src[0], 4) &&
+          gta_lshlrev_b64.src[1].kind == OperandKind::InlineInt &&
+          gta_lshlrev_b64.src[1].value == 1 &&
+          gta_lshlrev_b64.src[2].kind == OperandKind::None &&
+          rdna2_vgpr_write_count(gta_lshlrev_b64) == 2u &&
+          rdna2_vgpr_destination_span(gta_lshlrev_b64) == 2u,
+          "GTA V v_lshlrev_b64 decodes two sources and a two-VGPR destination");
     // inst7: s_load_dwordx4 s[0:3], s[4:5], 0x0 (SMEM) -> op 0x2, SDATA s0, SBASE s4 (pair), offset 0
     CHECK(ins[7].fmt == Rdna2Format::SMEM && ins[7].opcode == 0x2u && isS(ins[7].dst, 0) &&
           isS(ins[7].src[0], 4) && ins[7].literal == 0x0u, "s_load_dwordx4 SMEM op/SDATA/SBASE/offset");

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -4944,6 +4944,14 @@ int main() {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY was accepted without its BVH bytes\n");
         return 1;
     }
+    ShaderResourceTable sorted_bvh = rt_bvh;
+    sorted_bvh.resources[0].bvh_sort_enabled = true;
+    const std::vector<uint32_t> sorted_bvh_spv = recompile_compute(
+        cs_bvh_intersect.data(), cs_bvh_intersect.size(), &sorted_bvh, bvh_config);
+    if (sorted_bvh_spv.empty() || sorted_bvh_spv == bvh_spv) {
+        printf("  [FAIL] sorted IMAGE_BVH_INTERSECT_RAY lacks distinct box-order lowering\n");
+        return 1;
+    }
     std::vector<uint32_t> unsupported_bvh = cs_bvh_intersect;
     unsupported_bvh[gta_bvh_pc] &= ~(1u << 15); // R128=0 has a different destination contract.
     if (!recompile_compute(unsupported_bvh.data(), unsupported_bvh.size(),
@@ -4972,7 +4980,7 @@ int main() {
         printf("  [FAIL] IMAGE_BVH_INTERSECT_RAY accepted a non-constant-buffer resource\n");
         return 1;
     }
-    printf("  [ok]   GTA's exact-pc 64-byte IMAGE_BVH_INTERSECT_RAY lowers through a bounded BVH SSBO\n");
+    printf("  [ok]   GTA's exact-pc sorted/unsorted IMAGE_BVH_INTERSECT_RAY lowers through a bounded BVH SSBO\n");
 
     // Astro Bot's visibility kernel sanitizes a generated coordinate with an explicit-SDST
     // v_cmp_class_f32 SDWA (mask 3 = sNaN|qNaN), followed by v_cndmask reading s[8:9]. Rejecting

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -115,6 +115,43 @@ uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
     return count;
 }
 
+bool has_capability(const std::vector<uint32_t>& spv, uint32_t capability) {
+    constexpr uint32_t OpCapability = 17;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpCapability && wc == 2 && spv[i + 1] == capability) return true;
+        i += wc;
+    }
+    return false;
+}
+
+bool has_u64_atomic_and_stride8_alias(const std::vector<uint32_t>& spv,
+                                      uint32_t atomic_opcode) {
+    constexpr uint32_t OpDecorate = 71;
+    constexpr uint32_t DecorationArrayStride = 6;
+    std::unordered_set<uint32_t> u64_types;
+    bool stride8 = false, u64_atomic = false;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == OpTypeInt && wc == 4 && spv[i + 2] == 64u && spv[i + 3] == 0u)
+            u64_types.insert(spv[i + 1]);
+        if (op == OpDecorate && wc == 4 &&
+            spv[i + 2] == DecorationArrayStride && spv[i + 3] == 8u)
+            stride8 = true;
+        i += wc;
+    }
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return false;
+        if (op == atomic_opcode && wc >= 7 && u64_types.contains(spv[i + 1]))
+            u64_atomic = true;
+        i += wc;
+    }
+    return stride8 && u64_atomic;
+}
+
 // Prove that a subgroup vote is persisted through the CFG dispatcher's bool register file and then
 // consumed as the condition of a later OpSelect.  This is the structural shape of a scalar mask
 // comparison followed by s_cselect: opcode presence alone would not prove that SCC survived the
@@ -4699,6 +4736,109 @@ int main() {
         return 1;
     }
     printf("  [ok]   image_get_resinfo 3D lowers to size/level image queries\n");
+
+    // GTA V's exact stride-8/25-record BUFFER_ATOMIC_SWAP_X2 must be one qword exchange. Include an
+    // ordinary dword load through the same binding so both the u32 and u64 Block variables are
+    // statically used; reflection must coalesce those compatible aliases into one Vulkan binding.
+    alignas(8) uint32_t swap_x2_backing[50] = {};
+    ShaderResourceTable rt_swap_x2;
+    { ShaderResource buffer{}; buffer.cls = ResourceClass::ConstantBuffer;
+      buffer.format = DataFormat::Uint32; buffer.num_components = 1;
+      buffer.binding = 2; buffer.gpu_addr = reinterpret_cast<uint64_t>(swap_x2_backing);
+      buffer.size = 200; buffer.stride = 8; buffer.sgpr_base = 0; buffer.fetch_pc = 2;
+      buffer.atomic_x2_record_count = 25;
+      rt_swap_x2.resources.push_back(buffer); }
+    const uint32_t cs_swap_x2[] = {
+        0xe0302000u, 0x80000013u, // buffer_load_dword v0, v19, s[0:3], idxen
+        0xe1402000u, 0x80000913u, // buffer_atomic_swap_x2 v[9:10], v19, s[0:3], idxen
+        0xbf810000u,
+    };
+    ComputeShaderConfig swap_x2_config;
+    swap_x2_config.local_x = 1;
+    swap_x2_config.storage_buffer_int64_atomics = true;
+    const std::vector<uint32_t> swap_x2_spv = recompile_compute(
+        cs_swap_x2, std::size(cs_swap_x2), &rt_swap_x2, swap_x2_config);
+    const DescriptorValidationReport swap_x2_report = validate_spirv_descriptor_interface(
+        swap_x2_spv, &rt_swap_x2, 0, SpirvShaderStage::Compute, false);
+    if (swap_x2_spv.empty() || opcode_count(swap_x2_spv, 229u) != 1u ||
+        !has_capability(swap_x2_spv, 11u) || !has_capability(swap_x2_spv, 12u) ||
+        !has_u64_atomic_and_stride8_alias(swap_x2_spv, 229u) ||
+        !swap_x2_report.ok() || swap_x2_report.descriptors.size() != 1u ||
+        swap_x2_report.descriptors[0].required_bytes != 8u ||
+        !swap_x2_report.descriptors[0].readable ||
+        !swap_x2_report.descriptors[0].writable ||
+        !swap_x2_report.descriptors[0].atomic_access) {
+        printf("  [FAIL] swap_x2 is not one reflected u64 atomic over a stride-8 alias\n");
+        return 1;
+    }
+    printf("  [ok]   swap_x2 emits one u64 atomic and coalesces its u32/u64 binding aliases\n");
+
+    ShaderResourceTable mutated_swap_x2 = rt_swap_x2;
+    mutated_swap_x2.resources[0].atomic_x2_record_count = 0;
+    if (!recompile_compute(cs_swap_x2, std::size(cs_swap_x2), &mutated_swap_x2,
+                           swap_x2_config).empty()) {
+        printf("  [FAIL] swap_x2 emitter ignored its exact record-count production proof\n");
+        return 1;
+    }
+    ShaderResourceTable oversized_swap_x2 = rt_swap_x2;
+    oversized_swap_x2.resources[0].size = 0x10000008u;
+    oversized_swap_x2.resources[0].atomic_x2_record_count = 0x02000001u;
+    if (!recompile_compute(cs_swap_x2, std::size(cs_swap_x2), &oversized_swap_x2,
+                           swap_x2_config).empty()) {
+        printf("  [FAIL] swap_x2 emitter admitted an out-of-contract record count\n");
+        return 1;
+    }
+    ComputeShaderConfig unsupported_swap_x2 = swap_x2_config;
+    unsupported_swap_x2.storage_buffer_int64_atomics = false;
+    if (!recompile_compute(cs_swap_x2, std::size(cs_swap_x2), &rt_swap_x2,
+                           unsupported_swap_x2).empty()) {
+        printf("  [FAIL] swap_x2 emitted without the enabled int64-atomic device contract\n");
+        return 1;
+    }
+    printf("  [ok]   swap_x2 rejects marker and device-capability mutations at emission\n");
+
+    // pc172/183 use OR_X2 with GLC=1 as a qword atomic read/retry. It must be one u64 OpAtomicOr;
+    // replacing it with exchange or two independent dword ORs changes visible memory/return state.
+    ShaderResourceTable rt_or_x2 = rt_swap_x2;
+    rt_or_x2.resources[0].fetch_pc = 0;
+    const uint32_t cs_or_x2[] = {
+        0xe1686000u, 0x80000913u, // buffer_atomic_or_x2 v[9:10], v19, s[0:3], idxen glc
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> or_x2_spv = recompile_compute(
+        cs_or_x2, std::size(cs_or_x2), &rt_or_x2, swap_x2_config);
+    const DescriptorValidationReport or_x2_report = validate_spirv_descriptor_interface(
+        or_x2_spv, &rt_or_x2, 0, SpirvShaderStage::Compute, false);
+    if (or_x2_spv.empty() || opcode_count(or_x2_spv, 241u) != 1u ||
+        opcode_count(or_x2_spv, 229u) != 0u ||
+        !has_capability(or_x2_spv, 11u) || !has_capability(or_x2_spv, 12u) ||
+        !has_u64_atomic_and_stride8_alias(or_x2_spv, 241u) ||
+        !or_x2_report.ok() || or_x2_report.descriptors.size() != 1u ||
+        !or_x2_report.descriptors[0].readable ||
+        !or_x2_report.descriptors[0].writable ||
+        !or_x2_report.descriptors[0].atomic_access) {
+        printf("  [FAIL] or_x2 is not one reflected u64 atomic-or over a stride-8 alias\n");
+        return 1;
+    }
+    const uint32_t slc_or_x2[] = {
+        0xe1686000u, 0x80400913u,
+        0xbf810000u,
+    };
+    if (!recompile_compute(slc_or_x2, std::size(slc_or_x2), &rt_or_x2,
+                           swap_x2_config).empty()) {
+        printf("  [FAIL] or_x2 emitter accepted the unproved SLC packet sibling\n");
+        return 1;
+    }
+    const uint32_t reserved_or_x2[] = {
+        0xe16a6000u, 0x80000913u,
+        0xbf810000u,
+    };
+    if (!recompile_compute(reserved_or_x2, std::size(reserved_or_x2), &rt_or_x2,
+                           swap_x2_config).empty()) {
+        printf("  [FAIL] or_x2 emitter accepted reserved dword0 bit 17\n");
+        return 1;
+    }
+    printf("  [ok]   or_x2 emits one u64 OpAtomicOr and rejects exact-site packet mutations\n");
 
     // Astro Bot's exact visibility-image packet: exchange v9 with R32_UINT texel (v0,v1), GLC=1.
     // Both SPIR-V operations are essential: accepting the MIMG without a real texel pointer/atomic

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1286,6 +1286,44 @@ int main() {
     CHECK(has_spirv_local_size(native_spv17d, 64, 1, 1),
           "multidimensional guest wave flattens Vulkan LocalSize X for full subgroups");
 
+    // Kernel 17d0: GTA V's pc160..184 region is a bottom-tested EXEC loop whose body contains an
+    // ordinary nested EXEC loop. The old detector required the execz header form, discarded every
+    // loop when it saw the bottom `s_cbranch_execnz`, then misread the inner back-edge as a backward
+    // else. Keep a workgroup barrier immediately AFTER the outer loop: it makes the generic CFG
+    // dispatcher unavailable, while every invocation has reconverged and may legally reach it.
+    // The inner loop executes once, clears EXEC, and exits on its second header check; the outer
+    // body restores EXEC, writes 7, clears EXEC again, and falls through its bottom test.
+    const uint32_t code17d0[] = {
+        0xbe82047eu,              // s_mov_b64 s[2:3],exec
+        0x7e040280u,              // v_mov_b32 v2,0
+        0x7e060280u,              // OUTER: v_mov_b32 v3,0
+        0xbf880003u,              // INNER: s_cbranch_execz pc7
+        0x7e040281u,              // v_mov_b32 v2,1
+        0xbefe0480u,              // s_mov_b64 exec,0
+        0xbf82fffcu,              // s_branch pc3
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
+        0x7e040287u,              // v_mov_b32 v2,7
+        0xbefe0480u,              // s_mov_b64 exec,0 (bottom condition writer)
+        0xbf89fff7u,              // s_cbranch_execnz pc2
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
+        0xbf8a0000u,              // s_barrier after reconvergence
+        0x7e040d02u,              // v_cvt_f32_u32 v2,v2
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv17d0 = recompile_valu(
+        code17d0, std::size(code17d0), 1, /*out_vgpr*/2);
+    CHECK(!spv17d0.empty(),
+          "GTA bottom-tested EXEC loop nests structurally before a top-level barrier");
+    const std::vector<float> got17d0 = spv17d0.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv17d0, std::vector<float>(N, 0.0f), N, N);
+    CHECK(got17d0 == std::vector<float>(N, 7.0f),
+          "bottom-tested EXEC loop preserves its exit-iteration value and reconverges");
+    std::vector<uint32_t> stale17d0(std::begin(code17d0), std::end(code17d0));
+    stale17d0[9] = 0x7e060280u; // v_mov_b32 v3,0: no fresh EXEC condition at the latch
+    CHECK(recompile_valu(stale17d0.data(), stale17d0.size(), 1, /*out_vgpr*/2).empty(),
+          "bottom-tested EXEC loop rejects a stale entry mask at its back-edge");
+
     // Kernel 17d1: Astro's Wave32 BVH traversal turns a VOPC predicate into the first matching
     // lane with s_ff1_i32_b32, then immediately uses VCC_LO as ordinary scalar data. The first
     // subgroup has one match at lane 5; the second subgroup is empty and must return -1. Store the

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1383,6 +1383,116 @@ int main() {
       dst.format = DataFormat::Uint32; dst.num_components = 1;
       dst.binding = 3; dst.stride = 4; dst.sgpr_base = 8;
       rt17d1.resources.push_back(dst); }
+
+    // GTA V 0x413e15400 pc152 recycles only Wave64 VCC_LO as scalar scratch, copies that dword to
+    // v10, then replaces the complete VCC pair before any implicit mask consumer. Keep the exact
+    // pc106..153 loop suffix to exercise its scalar semantics and high-half liveness proof.
+    const uint32_t code17d1_vcc_low[] = {
+        0xbe820380u, 0xbe8c0380u, 0xbf0a1202u, 0xbf840020u,
+        0xbefc0302u, 0x81028102u, 0xbf8c3f70u, 0x7e148701u,
+        0x4c121480u, 0xbeea287eu, 0x02281480u, 0x4a2828fau,
+        0xff011114u, 0x4a2828fau, 0xff011214u, 0x4a2828fau,
+        0xff011414u, 0x4a2828fau, 0xff011814u, 0xd7781013u,
+        0x03058314u, 0x4a2826fau, 0xaf00e414u, 0x92fea0a0u,
+        0xd7600000u, 0x00013f14u, 0x4a282800u, 0xbefe046au,
+        0xd76d0009u, 0x0426280cu, 0xd760006au, 0x00017f14u,
+        0x7e140314u, 0x7e028509u, 0x810c6a0cu, 0xbf82ffdeu,
+        0x8801ff09u, 0x00080000u, 0xbe800308u, 0xbe82030du,
+        0xbe8303ffu, 0x00016204u, 0xbefe0481u, 0x7e26020fu,
+        0xbf08800fu, 0x7e12020cu,
+        0x856a8281u,              // exact pc152: s_cselect_b32 vcc_lo,1,2
+        0x7e14026au,              // exact pc153: v_mov_b32 v10,vcc_lo
+        0x7d840100u,              // complete VOPC replacement makes old VCC_HI dead
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv17d1_vcc_low = recompile_valu(
+        code17d1_vcc_low, std::size(code17d1_vcc_low), 1, /*out_vgpr*/10);
+    CHECK(!spv17d1_vcc_low.empty(),
+          "GTA Wave64 VCC_LO scalar scratch recompiles with its captured loop suffix");
+    if (!spv17d1_vcc_low.empty()) {
+        const std::vector<float> got17d1_vcc_low = prosper::test::run_compute(
+            spv17d1_vcc_low, std::vector<float>(64, 0.0f), 64, 64);
+        uint32_t bad17d1_vcc_low = 0;
+        for (uint32_t lane = 0; lane < got17d1_vcc_low.size(); ++lane)
+            bad17d1_vcc_low += bits_of(got17d1_vcc_low[lane]) != (lane == 0 ? 2u : 0u);
+        CHECK(got17d1_vcc_low.size() == 64 && bad17d1_vcc_low == 0,
+              "Wave64 VCC_LO scratch copies the selected dword to the active lane exactly");
+    }
+
+    // The live dispatcher's pair-domain ambiguity is established before pc106, across the repeated
+    // optional descriptor loads. Preserve the exact pc0..153 CFG and replace only those nine MUBUF
+    // packets with equal-width NOPs so this remains a resource-free regression. Without clearing
+    // the proved mixed lifetime at the exact pc152 write, pc153 rejects as an ambiguous mask read.
+    const uint32_t code17d1_vcc_low_dispatch[] = {
+        0xbfa00003u, 0x8790817eu, 0xbefe0410u, 0xbf880003u,
+        0x7e020281u, 0xbf800000u, 0xbf800000u, 0xbf8c3f70u,
+        0xd760000fu, 0x00010101u, 0xbefe04c1u, 0x9012860cu,
+        0xbf0a1280u, 0x93000c0fu, 0x4a240000u, 0x7d88240eu,
+        0xbf840006u, 0x7e020280u, 0xbefe046au, 0xbf880002u,
+        0xbf800000u, 0xbf800000u, 0xbefe04c1u, 0xd76d0011u,
+        0x04018000u, 0xbf0a1281u, 0x7d88220eu, 0xbf840006u,
+        0x7e040280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d0010u, 0x0401fe00u,
+        0x00000080u, 0xbf0a1282u, 0x7d88200eu, 0xbf840006u,
+        0x7e060280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d000fu, 0x0401fe00u,
+        0x000000c0u, 0xbf0a1283u, 0x7d881e0eu, 0xbf840006u,
+        0x7e080280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d000eu, 0x0401fe00u,
+        0x00000100u, 0xbf0a1284u, 0x7d881c0eu, 0xbf840006u,
+        0x7e0a0280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d000du, 0x0401fe00u,
+        0x00000140u, 0xbf0a1285u, 0x7d881a0eu, 0xbf840006u,
+        0x7e0c0280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d000cu, 0x0401fe00u,
+        0x00000180u, 0xbf0a1286u, 0x7d88180eu, 0xbf840006u,
+        0x7e0e0280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xd76d000bu, 0x0401fe00u,
+        0x000001c0u, 0xbf0a1287u, 0x7d88160eu, 0xbf840006u,
+        0x7e100280u, 0xbefe046au, 0xbf880002u, 0xbf800000u,
+        0xbf800000u, 0xbefe04c1u, 0xbe820380u, 0xbe8c0380u,
+        0xbf0a1202u, 0xbf840020u, 0xbefc0302u, 0x81028102u,
+        0xbf8c3f70u, 0x7e148701u, 0x4c121480u, 0xbeea287eu,
+        0x02281480u, 0x4a2828fau, 0xff011114u, 0x4a2828fau,
+        0xff011214u, 0x4a2828fau, 0xff011414u, 0x4a2828fau,
+        0xff011814u, 0xd7781013u, 0x03058314u, 0x4a2826fau,
+        0xaf00e414u, 0x92fea0a0u, 0xd7600000u, 0x00013f14u,
+        0x4a282800u, 0xbefe046au, 0xd76d0009u, 0x0426280cu,
+        0xd760006au, 0x00017f14u, 0x7e140314u, 0x7e028509u,
+        0x810c6a0cu, 0xbf82ffdeu, 0x8801ff09u, 0x00080000u,
+        0xbe800308u, 0xbe82030du, 0xbe8303ffu, 0x00016204u,
+        0xbefe0481u, 0x7e26020fu, 0xbf08800fu, 0x7e12020cu,
+        0x856a8281u,              // exact pc152: s_cselect_b32 vcc_lo,1,2
+        0x7e14026au,              // exact pc153: v_mov_b32 v10,vcc_lo
+        0x7d840100u,              // complete VCC replacement
+        0xbf870001u,              // force the whole shader through the CFG dispatcher
+        0xbf82fffdu, 0xbf810000u,
+    };
+    CHECK(!recompile_compute(code17d1_vcc_low_dispatch,
+                             std::size(code17d1_vcc_low_dispatch), nullptr,
+                             native_cfg17d).empty(),
+          "GTA Wave64 VCC_LO scalar scratch resolves the live dispatcher ambiguity");
+
+    // Same-site packet mutation and a surviving implicit VCC read both remain fail-visible. The
+    // first prevents this byte-exact exception from silently becoming a general Wave64 bridge; the
+    // second proves the old high-half mask really must be dead, not merely unused by the assertion.
+    const uint32_t code17d1_vcc_low_mutated[] = {
+        0xbe8f0380u, 0xbf08800fu,
+        0x856a8381u,              // s_cselect_b32 vcc_lo,1,3 (mutated live packet)
+        0x7e02026au, 0x7d840100u, 0xbf810000u,
+    };
+    const uint32_t code17d1_vcc_low_mask_live[] = {
+        0xbe8f0380u, 0xbf08800fu, 0x856a8281u, 0x7e02026au,
+        0xbf860001u,              // implicit VCCZ observes the untouched high half
+        0xbf800000u, 0xbf810000u,
+    };
+    CHECK(recompile_compute(code17d1_vcc_low_mutated,
+                            std::size(code17d1_vcc_low_mutated), nullptr,
+                            native_cfg17d).empty() &&
+              recompile_compute(code17d1_vcc_low_mask_live,
+                                std::size(code17d1_vcc_low_mask_live), nullptr,
+                                native_cfg17d).empty(),
+          "Wave64 VCC_LO scalar exception rejects packet drift and a live high-half mask");
     ComputeShaderConfig native_cfg17d1;
     native_cfg17d1.local_x = 64;
     native_cfg17d1.wave_size = 32;

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -8207,13 +8207,109 @@ int main() {
     CHECK(ror8ThenAddGot.size() == 128 && ror8ThenAddBad == 0,
           "T25b-ror8: combined rotate/add phases reuse scratch without cross-matching events");
 
+    // T25b-ror8-family (#2481): the first admitted V_MIN site exposes the next two exact GTA V
+    // packets in the same reduction family. DPP transforms SRC0 only: V_MAX combines the rotated
+    // v3 with lane-local v3, while V_MOV returns the rotated v17 bits unchanged. Keep the original
+    // register numbers so decode, dispatcher discovery, and the synchronized production sites are
+    // all exercised, with plain moves used only to seed/read those registers.
+    const uint32_t codeT25bRor8Max[] = {
+        0x200406fau, 0xff092803u,            // exact pc88: v_max_f32_dpp v2,v3,v3 row_ror:8 BC:1
+        0x7e000302u,                         // v_mov_b32 v0,v2
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT25bRor8Max = recompile_valu(
+        codeT25bRor8Max, std::size(codeT25bRor8Max), 4, 0);
+    std::vector<float> ror8MaxInput(128 * 4, 0.0f), ror8MaxExpected(128);
+    for (uint32_t lane = 0; lane < 128; ++lane) {
+        const float value = (lane & 8u) ? 1000.0f - static_cast<float>(lane)
+                                        : static_cast<float>(lane);
+        ror8MaxInput[lane * 4 + 3] = value;
+    }
+    for (uint32_t lane = 0; lane < 128; ++lane)
+        ror8MaxExpected[lane] = std::max(
+            ror8MaxInput[((lane ^ 8u) * 4) + 3], ror8MaxInput[lane * 4 + 3]);
+    std::vector<float> ror8MaxGot;
+    if (!spvT25bRor8Max.empty())
+        ror8MaxGot = prosper::test::run_compute(
+            spvT25bRor8Max, ror8MaxInput, 128, 128);
+    CHECK(!spvT25bRor8Max.empty() && ror8MaxGot == ror8MaxExpected,
+          "T25b-ror8-family: exact GTA V V_MAX rotates SRC0 and keeps SRC1 lane-local");
+
+    const uint32_t codeT25bRor8Mov[] = {
+        0x7e220303u,                         // v_mov_b32 v17,v3
+        0x7e2402fau, 0xff092811u,            // exact pc87: v_mov_b32_dpp v18,v17 row_ror:8 BC:1
+        0x7e000312u,                         // v_mov_b32 v0,v18
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT25bRor8Mov = recompile_valu(
+        codeT25bRor8Mov, std::size(codeT25bRor8Mov), 4, 0);
+    std::vector<float> ror8MovInput(128 * 4, 0.0f), ror8MovExpected(128);
+    for (uint32_t lane = 0; lane < 128; ++lane)
+        ror8MovInput[lane * 4 + 3] = static_cast<float>(lane) + 0.25f;
+    for (uint32_t lane = 0; lane < 128; ++lane)
+        ror8MovExpected[lane] = ror8MovInput[((lane ^ 8u) * 4) + 3];
+    std::vector<float> ror8MovGot;
+    if (!spvT25bRor8Mov.empty())
+        ror8MovGot = prosper::test::run_compute(
+            spvT25bRor8Mov, ror8MovInput, 128, 128);
+    CHECK(!spvT25bRor8Mov.empty() && ror8MovGot == ror8MovExpected,
+          "T25b-ror8-family: exact GTA V V_MOV returns the bounded rotated bits unchanged");
+
+    // The game selects the native path when the device exposes exact Wave64 subgroups. Exercise
+    // both new operation arms there too; the portable tests above cannot reach emit_alu's direct
+    // shuffle path. Local ID seeds v0, and the existing resource-backed output contract stores v1.
+    const uint32_t codeT25bRor8MaxNative[] = {
+        0x7e060d00u,                         // v_cvt_f32_u32 v3,v0
+        0x200406fau, 0xff092803u,            // exact V_MAX_F32 ROW_ROR:8
+        0x7e020302u,                         // v_mov_b32 v1,v2
+        0xe0702000u, 0x80020100u,            // buffer_store_dword v1,v0,s[8:11] idxen
+        0xbf810000u,
+    };
+    const uint32_t codeT25bRor8MovNative[] = {
+        0x7e220d00u,                         // v_cvt_f32_u32 v17,v0
+        0x7e2402fau, 0xff092811u,            // exact V_MOV_B32 ROW_ROR:8
+        0x7e020312u,                         // v_mov_b32 v1,v18
+        0xe0702000u, 0x80020100u,            // buffer_store_dword v1,v0,s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> nativeRor8MaxSpv = recompile_compute(
+        codeT25bRor8MaxNative, std::size(codeT25bRor8MaxNative),
+        &ror8BackendTable, nativeRor8Config);
+    const std::vector<uint32_t> nativeRor8MovSpv = recompile_compute(
+        codeT25bRor8MovNative, std::size(codeT25bRor8MovNative),
+        &ror8BackendTable, nativeRor8Config);
+    CHECK(!nativeRor8MaxSpv.empty() && !nativeRor8MovSpv.empty() &&
+              count_spirv_opcode(nativeRor8MaxSpv, 345) == 2 &&
+              count_spirv_opcode(nativeRor8MovSpv, 345) == 2 &&
+              count_spirv_opcode(nativeRor8MaxSpv, 224) == 0 &&
+              count_spirv_opcode(nativeRor8MovSpv, 224) == 0,
+          "T25b-ror8-family: native Wave64 lowers exact V_MAX/V_MOV to direct shuffles");
+    if (canExecuteNativeRor8 && !nativeRor8MaxSpv.empty() && !nativeRor8MovSpv.empty()) {
+        std::vector<uint32_t> nativeMaxGot, nativeMovGot;
+        prosper::test::run_compute(
+            nativeRor8MaxSpv, std::vector<float>(128, 0.0f), 128, 128, {},
+            std::vector<uint32_t>(128, 0xdeadbeefu), &nativeMaxGot);
+        prosper::test::run_compute(
+            nativeRor8MovSpv, std::vector<float>(128, 0.0f), 128, 128, {},
+            std::vector<uint32_t>(128, 0xdeadbeefu), &nativeMovGot);
+        std::vector<uint32_t> nativeMaxExpected(128), nativeMovExpected(128);
+        for (uint32_t lane = 0; lane < 128; ++lane) {
+            nativeMaxExpected[lane] = bits_of(static_cast<float>(
+                std::max(lane, lane ^ 8u)));
+            nativeMovExpected[lane] = bits_of(static_cast<float>(lane ^ 8u));
+        }
+        CHECK(nativeMaxGot == nativeMaxExpected && nativeMovGot == nativeMovExpected,
+              "T25b-ror8-family: native Wave64 executes exact V_MAX/V_MOV semantics");
+    } else {
+        std::printf("  [skip] T25b-ror8-family native execution: host contract unavailable\n");
+    }
+
     const uint32_t unsupportedRor8[][2] = {
         {0x1e0000fau, 0xff012800u},           // V_MIN_F32 BOUND_CTRL=0
         {0x1e0000fau, 0xff092900u},           // V_MIN_F32 ROW_ROR:9
         {0x1e0000fau, 0xef092800u},           // partial ROW_MASK
         {0x1e0000fau, 0xff192800u},           // source modifier
-        {0x200000fau, 0xff092800u},           // V_MAX_F32
-        {0x7e0002fau, 0xff092800u},           // V_MOV_B32
+        {0x060000fau, 0xff092800u},           // V_ADD_F32 is outside the live family
     };
     for (const auto& unsupported : unsupportedRor8) {
         const uint32_t code[] = {unsupported[0], unsupported[1], 0xbf810000u};

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1671,6 +1671,57 @@ int main() {
                     subgroup17d1.size);
     }
 
+    // Kernel 17d1w64: GTA V's Wave64 BVH traversal repeatedly writes the scalar result of a mask
+    // scan into an ordinary VGPR at a dynamic scalar lane. Keep the exact first live packet after
+    // the established irreducible dispatcher prefix. Selector 127 must wrap to lane 63,
+    // distinguishing the full Wave64 selector from the established Wave32 form above.
+    const uint32_t code17d1w64[] = {
+        0x7e040280u,              // v_mov_b32 v2, 0
+        0x7c020300u,              // v_cmp_lt_u32 vcc, v0, v1
+        0xbf860001u,              // s_cbranch_vccz pc4
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0
+        0xbf870001u,              // s_cbranch_vccnz pc7
+        0xbf82fffdu,              // s_branch pc4 (irreducible dispatcher back-edge)
+        0x7e3c0300u,              // v_mov_b32 v30, v0
+        0xbe9003ffu, 0x0000007bu, // s_mov_b32 s16, 123
+        0xbed603ffu, 0x0000007fu, // s_mov_b32 s86, 127
+        0xd761001eu, 0x0000ac10u, // GTA pc12: v_writelane_b32 v30, s16, s86
+        0xe0702000u, 0x80021e00u, // buffer_store_dword v30, v0, s[8:11] idxen
+        0xbf810000u,
+    };
+    ComputeShaderConfig native_cfg17d1w64 = native_cfg17d;
+    native_cfg17d1w64.local_x = 64;
+    native_cfg17d1w64.local_y = 1;
+    const std::vector<uint32_t> native_spv17d1w64 = recompile_compute(
+        code17d1w64, std::size(code17d1w64), &rt17d1, native_cfg17d1w64);
+    CHECK(!native_spv17d1w64.empty(),
+          "GTA Wave64 dynamic v_writelane lowers inside the exact native CFG dispatcher");
+    ComputeShaderConfig portable_cfg17d1w64 = native_cfg17d1w64;
+    portable_cfg17d1w64.native_subgroup_size = 0;
+    ComputeShaderConfig mismatched_cfg17d1w64 = native_cfg17d1w64;
+    mismatched_cfg17d1w64.native_subgroup_size = 32;
+    CHECK(recompile_compute(code17d1w64, std::size(code17d1w64), &rt17d1,
+                            portable_cfg17d1w64).empty() &&
+              recompile_compute(code17d1w64, std::size(code17d1w64), &rt17d1,
+                                mismatched_cfg17d1w64).empty(),
+          "Wave64 dynamic v_writelane rejects portable and mismatched subgroup contracts");
+    if (can_execute17d1b && !native_spv17d1w64.empty()) {
+        std::vector<uint32_t> initial17d1w64(64, 0u), got17d1w64;
+        prosper::test::run_compute(native_spv17d1w64, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, initial17d1w64, &got17d1w64);
+        uint32_t bad17d1w64 = 0;
+        for (uint32_t lane = 0; lane < 64 && got17d1w64.size() == 64; ++lane) {
+            const uint32_t expected = lane == 63u ? 123u : lane;
+            bad17d1w64 += got17d1w64[lane] != expected;
+        }
+        CHECK(got17d1w64.size() == 64 && bad17d1w64 == 0,
+              "Wave64 dynamic writelane masks its selector to six bits and updates only lane 63");
+    } else {
+        std::printf("  [skip] Wave64 dynamic writelane execution: host default subgroup is %u\n",
+                    subgroup17d1.size);
+    }
+
     // Kernel 17d2: Astro's mask-priority sequence compares a VOPC-produced SGPR pair against zero,
     // then uses that wave-uniform SCC in s_cselect_b64.  Keep the irreducible prefix so this exercises
     // the generic dispatcher.  Wave 0's mask is empty and selects all lanes; wave 1 has one set bit in

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1884,14 +1884,8 @@ int main() {
                 count_spirv_opcode(native_spv17d, 335),
                 count_spirv_opcode(native_spv17d2v, 335),
                 count_spirv_opcode(native_ambiguous_join, 335));
-    CHECK(!portable_ambiguous_join.empty() &&
-              count_spirv_opcode(portable_ambiguous_join, 224) ==
-                  count_spirv_opcode(spv17d, 224),
-          "portable VCC-vs-zero does not vote an ambiguous mask/scalar lifetime join");
-    CHECK(!native_ambiguous_join.empty() &&
-              count_spirv_opcode(native_ambiguous_join, 335) ==
-                  count_spirv_opcode(native_spv17d, 335),
-          "native VCC-vs-zero does not vote an ambiguous mask/scalar lifetime join");
+    CHECK(portable_ambiguous_join.empty() && native_ambiguous_join.empty(),
+          "Wave64 VCC mask/scalar lifetime join rejects before its u64 consumer");
 
     // Kernel 17d2x: Syberia's fullscreen compute pass compares current EXEC with a mask written
     // directly to s[16:17] by VOPC.  Keep the irreducible prefix so the comparison must use the
@@ -5308,6 +5302,50 @@ int main() {
     CHECK(pair_true_got.size() == 128 && pair_false_got.size() == 128 && pair_bad == 0,
           "S_CSELECT_B64 selects both scalar dwords for SCC true and false");
 
+    // Select the pair inside a counted loop and consume both words only after its exit. Both
+    // destinations therefore need loop-header PHIs; carrying just the encoded low destination
+    // leaves the high-word definition inside the loop body without dominance at the postlude.
+    const uint32_t code38_pair_loop[] = {
+        0xbe80038bu,              // s_mov_b32 s0,11
+        0xbe81038cu,              // s_mov_b32 s1,12
+        0xbe820395u,              // s_mov_b32 s2,21
+        0xbe830396u,              // s_mov_b32 s3,22
+        0xbe940380u,              // s_mov_b32 s20,0 (induction variable)
+        0xbe950382u,              // s_mov_b32 s21,2 (trip count)
+        0xbf0a1514u,              // loop: s_cmp_lt_u32 s20,s21
+        0xbf840005u,              // s_cbranch_scc0 +5 -> postlude
+        0xbe8c0381u,              // s_mov_b32 s12,1
+        0xbf07800cu,              // SCC=true for the pair select
+        0x85840200u,              // s_cselect_b64 s[4:5],s[0:1],s[2:3]
+        0x81148114u,              // s_add_i32 s20,s20,1
+        0xbf82fff9u,              // s_branch -7 -> loop header
+        0x7e020204u,              // v_mov_b32 v1,s4
+        0xe0702000u, 0x80020100u, // output[lane] = selected low
+        0x4a0400c0u,              // v_add_nc_u32 v2,64,v0
+        0x7e020205u,              // v_mov_b32 v1,s5
+        0xe0702000u, 0x80020102u, // output[64+lane] = selected high
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> pair_loop_words(
+        std::begin(code38_pair_loop), std::end(code38_pair_loop));
+    const auto pair_loop_portable = compile_cselect_pair(
+        pair_loop_words, cselect_portable_config);
+    const auto pair_loop_native = compile_cselect_pair(
+        pair_loop_words, cselect_native_config);
+    CHECK(!pair_loop_portable.empty() && !pair_loop_native.empty(),
+          "counted loop carries both S_CSELECT_B64 scalar destination words");
+    CHECK(count_spirv_opcode(pair_loop_portable, 245) == 6 &&
+              count_spirv_opcode(pair_loop_native, 245) == 6,
+          "counted loop emits separate PHIs for both selected destination dwords");
+    const auto pair_loop_got = run_cselect_pair(pair_loop_portable);
+    uint32_t pair_loop_bad = 0;
+    for (uint32_t lane = 0; lane < 64 && pair_loop_got.size() == 128; ++lane) {
+        pair_loop_bad += pair_loop_got[lane] != 11u;
+        pair_loop_bad += pair_loop_got[64 + lane] != 12u;
+    }
+    CHECK(pair_loop_got.size() == 128 && pair_loop_bad == 0,
+          "counted-loop postlude observes both selected scalar dwords");
+
     // Force the arbitrary-CFG dispatcher, select two ordinary scalar pairs in one case, then
     // consume them with a second S_CSELECT_B64 after an explicit successor edge. The dispatcher's
     // Bool backing variables exist because this opcode can also select masks, but mere variable
@@ -5332,8 +5370,6 @@ int main() {
         0x85860200u,              // s_cselect_b64 s[6:7],s[0:1],s[2:3] -> 21:22
         0xbf820001u,              // cross a dispatcher edge to pc19
         0xbf800000u,
-        0xbe85038cu,              // replace s5 after reload; isolate low-root domain persistence
-        0xbe870396u,              // replace s7 after reload
         0xbe8c0381u,              // s_mov_b32 s12,1
         0xbf07800cu,              // SCC=true
         0x858e0604u,              // s_cselect_b64 s[14:15],s[4:5],s[6:7]
@@ -5360,6 +5396,44 @@ int main() {
     }
     CHECK(pair_dispatch_got.size() == 128 && pair_dispatch_bad == 0,
           "dispatcher successor consumes both selected scalar dwords as data");
+
+    // The same physical pair cannot be reconstructed at a join when one predecessor owns a saved
+    // wave mask and the other owns ordinary scalar data. The dispatcher has separate Bool/u32
+    // backing variables but no runtime domain tag, so consuming s[4:5] at the join must reject in
+    // both portable and native paths instead of silently reading either variable's zero placeholder.
+    const uint32_t code38_pair_ambiguous_join[] = {
+        0x7e040280u,              // irreducible dispatcher prefix (same shape as kernel 17d)
+        0x7d840100u,
+        0xbf860001u,
+        0x7e040281u,
+        0x7d840100u,
+        0xbf870001u,
+        0xbf82fffdu,
+        0xbe80038bu,              // s_mov_b32 s0,11
+        0xbe81038cu,              // s_mov_b32 s1,12
+        0xbf800000u,              // s12 remains a dynamic entry user SGPR
+        0xbf07800cu,              // SCC=(s12 != 0), so both CFG successors remain reachable
+        0xbf840002u,              // s_cbranch_scc0 +2 -> scalar-data predecessor
+        0xbe84046au,              // mask predecessor: s_mov_b64 s[4:5],vcc
+        0xbf820001u,              // -> join
+        0xbe840400u,              // data predecessor: s_mov_b64 s[4:5],s[0:1]
+        0xbf138004u,              // join consumer: s_cmp_lg_u64 s[4:5],0
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> pair_ambiguous_join_words(
+        std::begin(code38_pair_ambiguous_join), std::end(code38_pair_ambiguous_join));
+    ComputeShaderConfig pair_ambiguous_portable_config = cselect_portable_config;
+    pair_ambiguous_portable_config.user_sgprs.resize(13);
+    ComputeShaderConfig pair_ambiguous_native_config = cselect_native_config;
+    pair_ambiguous_native_config.user_sgprs.resize(13);
+    const auto pair_ambiguous_portable = compile_cselect_pair(
+        pair_ambiguous_join_words, pair_ambiguous_portable_config);
+    const auto pair_ambiguous_native = compile_cselect_pair(
+        pair_ambiguous_join_words, pair_ambiguous_native_config);
+    CHECK(pair_ambiguous_portable.empty(),
+          "portable dispatcher rejects a Wave64 mask/scalar pair join at its u64 consumer");
+    CHECK(pair_ambiguous_native.empty(),
+          "native dispatcher rejects a Wave64 mask/scalar pair join at its u64 consumer");
 
     const uint32_t code38_vcc_true[] = {
         0xbe8003ffu, 0x80000001u, // source0 low: lanes 0 and 31

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6097,6 +6097,68 @@ int main() {
     CHECK(bfm_modifiers_reject,
           "GTA V v_bfm_b32 same-site modifier mutations remain fail-visible");
 
+    // Kernel 65c: GTA V exec_cs_205b658800 pc61 constructs one 64-bit bit per lane after MBCNT.
+    // Shift amounts are masked to six bits, and both destination halves remain live in the shader.
+    const uint32_t code65c[] = {
+        0xD6FF0018u, 0x00010304u, // v_lshlrev_b64 v[24:25], v4, 1
+        0xBF810000u,
+    };
+    const uint32_t shifts65c[] = {0u, 1u, 31u, 32u, 33u, 63u, 64u, 65u};
+    const uint32_t expected65c_lo[] = {
+        1u, 2u, 0x80000000u, 0u, 0u, 0u, 1u, 2u,
+    };
+    const uint32_t expected65c_hi[] = {
+        0u, 0u, 0u, 1u, 2u, 0x80000000u, 0u, 0u,
+    };
+    std::vector<float> in65c(std::size(shifts65c) * 5u, 0.0f);
+    for (size_t i = 0; i < std::size(shifts65c); ++i)
+        in65c[i * 5u + 4u] = std::bit_cast<float>(shifts65c[i]);
+    const std::vector<uint32_t> spv65c_lo = recompile_valu(
+        code65c, std::size(code65c), 5, /*out_vgpr*/24);
+    const std::vector<uint32_t> spv65c_hi = recompile_valu(
+        code65c, std::size(code65c), 5, /*out_vgpr*/25);
+    const std::vector<float> got65c_lo = prosper::test::run_compute(
+        spv65c_lo, in65c, std::size(shifts65c), std::size(shifts65c));
+    const std::vector<float> got65c_hi = prosper::test::run_compute(
+        spv65c_hi, in65c, std::size(shifts65c), std::size(shifts65c));
+    uint32_t bad65c = 0;
+    for (size_t i = 0; i < std::size(shifts65c) &&
+                       got65c_lo.size() == std::size(shifts65c) &&
+                       got65c_hi.size() == std::size(shifts65c); ++i) {
+        if (bits_of(got65c_lo[i]) != expected65c_lo[i] ||
+            bits_of(got65c_hi[i]) != expected65c_hi[i])
+            ++bad65c;
+    }
+    CHECK(!spv65c_lo.empty() && !spv65c_hi.empty() &&
+          got65c_lo.size() == std::size(shifts65c) &&
+          got65c_hi.size() == std::size(shifts65c) && bad65c == 0,
+          "GTA V v_lshlrev_b64 writes both halves with six-bit shift semantics");
+
+    // Same-site modifier and destination-bound mutations remain fail-visible. These raw fields are
+    // reserved for this integer opcode; accepting them would silently discard architectural bits.
+    bool lshlrev_b64_mutants_reject = true;
+    for (uint32_t modifier : bfm_word0_modifiers) {
+        const uint32_t mutant[] = {
+            code65c[0] | modifier, code65c[1], 0xBF810000u,
+        };
+        lshlrev_b64_mutants_reject &= recompile_valu(
+            mutant, std::size(mutant), 5, 24).empty();
+    }
+    for (uint32_t modifier : bfm_word1_modifiers) {
+        const uint32_t mutant[] = {
+            code65c[0], code65c[1] | modifier, 0xBF810000u,
+        };
+        lshlrev_b64_mutants_reject &= recompile_valu(
+            mutant, std::size(mutant), 5, 24).empty();
+    }
+    const uint32_t lshlrev_b64_oob[] = {
+        0xD6FF00FFu, code65c[1], 0xBF810000u,
+    };
+    lshlrev_b64_mutants_reject &= recompile_valu(
+        lshlrev_b64_oob, std::size(lshlrev_b64_oob), 5, 24).empty();
+    CHECK(lshlrev_b64_mutants_reject,
+          "GTA V v_lshlrev_b64 same-site modifiers and v255 pair overflow reject");
+
     // Kernel 66: RAW MUBUF SRSRC RESOLUTION (#91). Same code as kernel 21 (buffer_load_dword v0, v0
     // offen, SRSRC s[8:11]) but WITH a resource table mapping s[8:11] -> binding 3. The load must
     // route to binding 3 (cbuf1), not the old hardcoded binding 2 — binding 2 (cbuf0) is bound with
@@ -8559,8 +8621,12 @@ int main() {
     CHECK(!spvA9b.empty(),
           "A9b: a real s_cmp between the mask op and the consumer re-arms SCC (recompiles)");
 
-    // A10 (#458): a fixed-offset compiler spill/fill preserves the exact per-invocation VGPR bits.
+    // A10 (#458/#2481): fixed-offset compiler spill/fill preserves exact per-invocation VGPR bits.
+    // GTA V installs both full FLAT_SCR base halves before using private scratch. Prosper's private
+    // Function-storage model absorbs that physical relocation without widening supported accesses.
     const uint32_t codeA10[] = {
+        0xb9e0f814u,              // s_setreg_b32 hwreg(HW_REG_FLAT_SCR_LO), s96
+        0xb9e1f815u,              // s_setreg_b32 hwreg(HW_REG_FLAT_SCR_HI), s97
         0xdc704010u, 0x00000000u, // scratch_store_dword off, v0, s0 offset:16
         0x7e000280u,              // v_mov_b32 v0, 0
         0xdc304010u, 0x00000000u, // scratch_load_dword v0, off, s0 offset:16
@@ -8574,6 +8640,28 @@ int main() {
         static_cast<uint32_t>(scratch_in.size()));
     CHECK(gotA10 == scratch_in,
           "A10: private dword spill/fill round-trips exact values for every invocation");
+    const RecompileCoverage coverageA10 = recompile_coverage(codeA10, std::size(codeA10));
+    CHECK(coverageA10.unsupported == 0,
+          "A10: full FLAT_SCR LO/HI base writes are handled by the private-scratch abstraction");
+
+    // Mutate the exact live SETREG site: another target, a 31-bit field, or a non-zero field offset
+    // must still reject. Keeping the positive HI packet also makes a LO-only admission fail the test.
+    const uint32_t flat_scr_mutated_words[] = {
+        0xb9e0f801u, // HW_REG_MODE instead of FLAT_SCR_LO
+        0xb9e0f014u, // FLAT_SCR_LO width 31 instead of 32
+        0xb9e0f854u, // FLAT_SCR_LO offset 1 instead of 0
+    };
+    bool flat_scr_mutants_reject = true;
+    for (uint32_t mutated_word : flat_scr_mutated_words) {
+        uint32_t mutant[std::size(codeA10)];
+        std::copy(std::begin(codeA10), std::end(codeA10), std::begin(mutant));
+        mutant[0] = mutated_word;
+        const RecompileCoverage coverage = recompile_coverage(mutant, std::size(mutant));
+        flat_scr_mutants_reject &= recompile_valu(
+            mutant, std::size(mutant), 1, 0).empty() && coverage.unsupported == 1;
+    }
+    CHECK(flat_scr_mutants_reject,
+          "A10: FLAT_SCR target, width, and offset same-site mutations remain fail-visible");
 
     // A11 (#458): vector forms use consecutive VGPRs while retaining one private offset range.
     const uint32_t codeA11[] = {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5237,6 +5237,202 @@ int main() {
     printf("  kernel38 mismatches=%u (out[5]=%g expect=10)\n", bad38, got38.size()==N?got38[5]:-1);
     CHECK(got38.size()==N && bad38==0, "recompiled kernel 38 (s_cselect_b64 -> exec mask -> cndmask) computes 10");
 
+    // GTA V compute program 0x413cf9a00 exposes the other S_CSELECT_B64 domain: ordinary scalar
+    // pairs. Pin both selected dwords and both SCC outcomes before exercising its VCC destination.
+    // These kernels use no subgroup operation, so both portable and exact-native compilation must
+    // accept identical semantics; native execution is gated only because the standalone Vulkan
+    // runner cannot request the backend's promised subgroup size.
+    ShaderResourceTable cselect_pair_table;
+    { ShaderResource output{}; output.cls = ResourceClass::ConstantBuffer;
+      output.format = DataFormat::Uint32; output.num_components = 1;
+      output.binding = 3; output.stride = 4; output.sgpr_base = 8;
+      cselect_pair_table.resources.push_back(output); }
+    ComputeShaderConfig cselect_portable_config;
+    cselect_portable_config.local_x = 64;
+    cselect_portable_config.wave_size = 64;
+    ComputeShaderConfig cselect_native_config = cselect_portable_config;
+    cselect_native_config.native_subgroup_size = 64;
+
+    const uint32_t code38_pair_true[] = {
+        0xbe80038bu,              // s_mov_b32 s0,11
+        0xbe81038cu,              // s_mov_b32 s1,12
+        0xbe820395u,              // s_mov_b32 s2,21
+        0xbe830396u,              // s_mov_b32 s3,22
+        0xbe860381u,              // s_mov_b32 s6,1
+        0xbf078006u,              // s_cmp_lg_u32 s6,0 -> SCC=true
+        0x85840200u,              // s_cselect_b64 s[4:5],s[0:1],s[2:3]
+        0x7e020204u,              // v_mov_b32 v1,s4 (selected low consumer)
+        0xe0702000u, 0x80020100u, // output[lane] = selected low
+        0x4a0400c0u,              // v_add_nc_u32 v2,64,v0
+        0x7e020205u,              // v_mov_b32 v1,s5 (selected high consumer)
+        0xe0702000u, 0x80020102u, // output[64+lane] = selected high
+        0xbf810000u,
+    };
+    std::vector<uint32_t> code38_pair_false(
+        std::begin(code38_pair_true), std::end(code38_pair_true));
+    code38_pair_false[4] = 0xbe860380u; // same select, SCC=false
+    auto compile_cselect_pair = [&](const auto& code, const ComputeShaderConfig& config) {
+        return recompile_compute(code.data(), code.size(), &cselect_pair_table, config);
+    };
+    const std::vector<uint32_t> pair_true_words(
+        std::begin(code38_pair_true), std::end(code38_pair_true));
+    const auto pair_true_portable = compile_cselect_pair(pair_true_words, cselect_portable_config);
+    const auto pair_false_portable = compile_cselect_pair(code38_pair_false, cselect_portable_config);
+    const auto pair_true_native = compile_cselect_pair(pair_true_words, cselect_native_config);
+    const auto pair_false_native = compile_cselect_pair(code38_pair_false, cselect_native_config);
+    CHECK(!pair_true_portable.empty() && !pair_false_portable.empty() &&
+              !pair_true_native.empty() && !pair_false_native.empty(),
+          "S_CSELECT_B64 scalar pairs compile in portable/native modes for both SCC outcomes");
+    std::vector<uint32_t> pair_exec_dst = pair_true_words;
+    pair_exec_dst[6] = 0x85fe0200u; // same data pair select into architectural EXEC
+    CHECK(compile_cselect_pair(pair_exec_dst, cselect_portable_config).empty() &&
+              compile_cselect_pair(pair_exec_dst, cselect_native_config).empty(),
+          "S_CSELECT_B64 scalar data rejects an EXEC destination in both modes");
+    auto run_cselect_pair = [&](const std::vector<uint32_t>& module) {
+        std::vector<uint32_t> output;
+        if (module.empty()) return output;
+        prosper::test::run_compute(module, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, std::vector<uint32_t>(128, 0), &output);
+        return output;
+    };
+    const auto pair_true_got = run_cselect_pair(pair_true_portable);
+    const auto pair_false_got = run_cselect_pair(pair_false_portable);
+    uint32_t pair_bad = 0;
+    for (uint32_t lane = 0; lane < 64 && pair_true_got.size() == 128 &&
+         pair_false_got.size() == 128; ++lane) {
+        pair_bad += pair_true_got[lane] != 11u;
+        pair_bad += pair_true_got[64 + lane] != 12u;
+        pair_bad += pair_false_got[lane] != 21u;
+        pair_bad += pair_false_got[64 + lane] != 22u;
+    }
+    CHECK(pair_true_got.size() == 128 && pair_false_got.size() == 128 && pair_bad == 0,
+          "S_CSELECT_B64 selects both scalar dwords for SCC true and false");
+
+    const uint32_t code38_vcc_true[] = {
+        0xbe8003ffu, 0x80000001u, // source0 low: lanes 0 and 31
+        0xbe8103ffu, 0x80000001u, // source0 high: lanes 32 and 63
+        0xbe8203ffu, 0x40000002u, // source1 low: lanes 1 and 30
+        0xbe8303ffu, 0x40000002u, // source1 high: lanes 33 and 62
+        0xbe860381u,              // s_mov_b32 s6,1
+        0xbf078006u,              // s_cmp_lg_u32 s6,0 -> SCC=true
+        0x85ea0200u,              // s_cselect_b64 vcc,s[0:1],s[2:3]
+        0x7e02028bu,              // v_mov_b32 v1,11
+        0x7e040296u,              // v_mov_b32 v2,22
+        0x02020501u,              // v_cndmask_b32 v1,v1,v2,vcc
+        0xe0702000u, 0x80020100u, // output[lane] = selected VCC bit ? 22 : 11
+        0xbf810000u,
+    };
+    std::vector<uint32_t> code38_vcc_false(
+        std::begin(code38_vcc_true), std::end(code38_vcc_true));
+    code38_vcc_false[8] = 0xbe860380u; // same complete pairs, SCC=false
+    const std::vector<uint32_t> vcc_true_words(
+        std::begin(code38_vcc_true), std::end(code38_vcc_true));
+    const auto vcc_true_portable = compile_cselect_pair(vcc_true_words, cselect_portable_config);
+    const auto vcc_false_portable = compile_cselect_pair(code38_vcc_false, cselect_portable_config);
+    const auto vcc_true_native = compile_cselect_pair(vcc_true_words, cselect_native_config);
+    const auto vcc_false_native = compile_cselect_pair(code38_vcc_false, cselect_native_config);
+    CHECK(!vcc_true_portable.empty() && !vcc_false_portable.empty() &&
+              !vcc_true_native.empty() && !vcc_false_native.empty(),
+          "complete scalar-pair selects into VCC compile in portable/native modes");
+    const auto vcc_true_got = run_cselect_pair(vcc_true_portable);
+    const auto vcc_false_got = run_cselect_pair(vcc_false_portable);
+    uint32_t vcc_bad = 0;
+    for (uint32_t lane = 0; lane < 64 && vcc_true_got.size() == 128 &&
+         vcc_false_got.size() == 128; ++lane) {
+        const bool true_bit = lane == 0 || lane == 31 || lane == 32 || lane == 63;
+        const bool false_bit = lane == 1 || lane == 30 || lane == 33 || lane == 62;
+        vcc_bad += vcc_true_got[lane] != (true_bit ? 22u : 11u);
+        vcc_bad += vcc_false_got[lane] != (false_bit ? 22u : 11u);
+    }
+    CHECK(vcc_true_got.size() >= 64 && vcc_false_got.size() >= 64 && vcc_bad == 0,
+          "complete VCC pair select derives the correct predicate bit in both 32-lane halves");
+
+    // Exact GTA V pc57..62 packet. Source0 is a complete pair, while source1 intentionally has
+    // only s16: s17 is neither an entry SGPR nor written by this stream. VCC_HI is dead after pc60,
+    // and pc62 consumes VCC_LO as scalar data. The positive compiles in portable/native modes; a
+    // high-half consumer and a mutation of the production pc60 destination each close the proof.
+    auto gta_cselect_low_only = [](bool scc) {
+        std::vector<uint32_t> code(66, 0xbf800000u); // s_nop 0
+        code[0] = 0x7e040300u;                       // preserve local id: v_mov_b32 v2,v0
+        code[1] = 0xbe8003a1u;                       // s_mov_b32 s0,33
+        code[2] = 0xbe8103acu;                       // s_mov_b32 s1,44
+        code[3] = 0xbe9003b7u;                       // s_mov_b32 s16,55 (no s17 writer)
+        code[4] = scc ? 0xbe840381u : 0xbe840380u;  // seed pc57's SCC outcome
+        code[57] = 0xbf078004u;                      // exact pc57: s_cmp_lg_u32 s4,0
+        code[58] = 0x4a0620f9u;                      // exact pc58 VOP2 SDWA, preserves SCC
+        code[59] = 0x86860681u;
+        code[60] = 0x85ea1000u;                      // exact pc60: s_cselect_b64 vcc,s[0:1],s[16:17]
+        code[61] = 0x7e000210u;                      // exact pc61: v_mov_b32 v0,s16
+        code[62] = 0x7e10026au;                      // exact pc62: v_mov_b32 v8,vcc_lo
+        code[63] = 0xe0702000u;
+        code[64] = 0x80020802u;                      // output[v2] = v8
+        code[65] = 0xbf810000u;
+        return code;
+    };
+    const auto gta_low_true = gta_cselect_low_only(true);
+    const auto gta_low_false = gta_cselect_low_only(false);
+    const auto gta_low_true_portable = compile_cselect_pair(gta_low_true, cselect_portable_config);
+    const auto gta_low_false_portable = compile_cselect_pair(gta_low_false, cselect_portable_config);
+    const auto gta_low_true_native = compile_cselect_pair(gta_low_true, cselect_native_config);
+    const auto gta_low_false_native = compile_cselect_pair(gta_low_false, cselect_native_config);
+    CHECK(!gta_low_true_portable.empty() && !gta_low_false_portable.empty() &&
+              !gta_low_true_native.empty() && !gta_low_false_native.empty(),
+          "exact GTA pc60 low-only pair compiles in portable/native modes for both SCC outcomes");
+    const auto gta_low_true_got = run_cselect_pair(gta_low_true_portable);
+    const auto gta_low_false_got = run_cselect_pair(gta_low_false_portable);
+    uint32_t gta_low_bad = 0;
+    for (uint32_t lane = 0; lane < 64 && gta_low_true_got.size() >= 64 &&
+         gta_low_false_got.size() >= 64; ++lane) {
+        gta_low_bad += gta_low_true_got[lane] != 33u;
+        gta_low_bad += gta_low_false_got[lane] != 55u;
+    }
+    CHECK(gta_low_true_got.size() >= 64 && gta_low_false_got.size() >= 64 &&
+              gta_low_bad == 0,
+          "exact GTA pc60 low-only pair selects VCC_LO for SCC true and false");
+    std::vector<uint32_t> gta_high_live = gta_low_true;
+    gta_high_live[62] = 0x7e10026bu; // v_mov_b32 v8,vcc_hi: high output is now live
+    std::vector<uint32_t> gta_site_mutation = gta_low_true;
+    gta_site_mutation[60] = 0x85861000u; // same pc60 select into ordinary s[6:7]
+    CHECK(compile_cselect_pair(gta_high_live, cselect_portable_config).empty() &&
+              compile_cselect_pair(gta_high_live, cselect_native_config).empty() &&
+              compile_cselect_pair(gta_site_mutation, cselect_portable_config).empty() &&
+              compile_cselect_pair(gta_site_mutation, cselect_native_config).empty(),
+          "GTA low-only admission rejects a live high half and a pc60 destination mutation");
+    const bool can_execute_cselect_native = exec_ballot_subgroup.size == 64 &&
+        (exec_ballot_subgroup.stages & VK_SHADER_STAGE_COMPUTE_BIT);
+    if (can_execute_cselect_native) {
+        const auto pair_true_native_got = run_cselect_pair(pair_true_native);
+        const auto pair_false_native_got = run_cselect_pair(pair_false_native);
+        const auto vcc_true_native_got = run_cselect_pair(vcc_true_native);
+        const auto vcc_false_native_got = run_cselect_pair(vcc_false_native);
+        const auto gta_low_true_native_got = run_cselect_pair(gta_low_true_native);
+        const auto gta_low_false_native_got = run_cselect_pair(gta_low_false_native);
+        uint32_t native_bad = 0;
+        for (uint32_t lane = 0; lane < 64 && pair_true_native_got.size() >= 128 &&
+             pair_false_native_got.size() >= 128 && vcc_true_native_got.size() >= 64 &&
+             vcc_false_native_got.size() >= 64 && gta_low_true_native_got.size() >= 64 &&
+             gta_low_false_native_got.size() >= 64; ++lane) {
+            native_bad += pair_true_native_got[lane] != 11u;
+            native_bad += pair_true_native_got[64 + lane] != 12u;
+            native_bad += pair_false_native_got[lane] != 21u;
+            native_bad += pair_false_native_got[64 + lane] != 22u;
+            const bool true_bit = lane == 0 || lane == 31 || lane == 32 || lane == 63;
+            const bool false_bit = lane == 1 || lane == 30 || lane == 33 || lane == 62;
+            native_bad += vcc_true_native_got[lane] != (true_bit ? 22u : 11u);
+            native_bad += vcc_false_native_got[lane] != (false_bit ? 22u : 11u);
+            native_bad += gta_low_true_native_got[lane] != 33u;
+            native_bad += gta_low_false_native_got[lane] != 55u;
+        }
+        CHECK(pair_true_native_got.size() >= 128 && pair_false_native_got.size() >= 128 &&
+                  vcc_true_native_got.size() >= 64 && vcc_false_native_got.size() >= 64 &&
+                  gta_low_true_native_got.size() >= 64 &&
+                  gta_low_false_native_got.size() >= 64 && native_bad == 0,
+              "native Wave64 executes scalar-pair, VCC-predicate, and GTA low-only selects");
+    } else {
+        std::printf("  [skip] native S_CSELECT_B64 execution: host subgroup is %u\n",
+                    exec_ballot_subgroup.size);
+    }
+
     // Kernel 39: trivial SDWA (all sels = DWORD) with SGPR operands — the form the game uses to give a
     //   VOP2 two scalar sources (e32 can't). s0=100, s1=23; v_add_nc_u32_sdwa v2, s0, s1 (all DWORD) = 123;
     //   v3=(float)123; out = a0 + 123. Verifies the decoder decodes SDWA operands + un-flags the no-op case.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -9436,6 +9436,41 @@ int main() {
         }
         CHECK(box_ok, "IMAGE_BVH_INTERSECT_RAY returns the four unsorted FP32-box child hits");
 
+        // GTA V sets BOX_SORT_EN. Keep the same live instruction and node-production site, but make
+        // every child hit at a deliberately shuffled distance. The false arm proves physical order;
+        // toggling only descriptor semantics proves the production compare-swap path.
+        const float shuffled_near[4] = {4.0f, 1.0f, 3.0f, 2.0f};
+        for (uint32_t child = 0; child < 4; ++child) {
+            const uint32_t base = 4u + child * 6u;
+            box_words[base + 0] = bits_of(-1.0f);
+            box_words[base + 1] = bits_of(-1.0f);
+            box_words[base + 2] = bits_of(-5.0f + shuffled_near[child]);
+            box_words[base + 3] = bits_of(1.0f);
+            box_words[base + 4] = bits_of(1.0f);
+            box_words[base + 5] = bits_of(-4.5f + shuffled_near[child]);
+        }
+        const uint32_t physical_expect[4] = {0x100u, 0x200u, 0x300u, 0x400u};
+        const uint32_t sorted_expect[4] = {0x200u, 0x400u, 0x300u, 0x100u};
+        auto box_order_matches = [&](const uint32_t expected[4]) {
+            bool matches = true;
+            for (uint32_t component = 0; component < 4; ++component) {
+                const std::vector<uint32_t> module = recompile_valu(
+                    bvh_code, std::size(bvh_code), inputs_per_lane, 3u + component, &bvh_rt);
+                const std::vector<float> output = prosper::test::run_compute(
+                    module, bvh_inputs, lanes, lanes, box_words);
+                matches &= !module.empty() && output.size() == lanes;
+                for (uint32_t lane = 0; lane < output.size(); ++lane)
+                    matches &= bits_of(output[lane]) == expected[component];
+            }
+            return matches;
+        };
+        CHECK(box_order_matches(physical_expect),
+              "BOX_SORT_EN=0 preserves physical box-child order");
+        bvh_rt.resources[0].bvh_sort_enabled = true;
+        CHECK(box_order_matches(sorted_expect),
+              "BOX_SORT_EN=1 stably returns box children from nearest to furthest");
+        bvh_rt.resources[0].bvh_sort_enabled = false;
+
         // Make the X near edge one float ULP beyond the Y far edge. BOX_GROW=0 must miss;
         // BOX_GROW=6 expands the far edge by six 2^-24 increments and retains the child.
         for (uint32_t lane = 0; lane < lanes; ++lane) {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5435,6 +5435,46 @@ int main() {
     CHECK(pair_ambiguous_native.empty(),
           "native dispatcher rejects a Wave64 mask/scalar pair join at its u64 consumer");
 
+    auto rejects_ambiguous_pair = [&](const std::vector<uint32_t>& words) {
+        return compile_cselect_pair(words, pair_ambiguous_portable_config).empty() &&
+               compile_cselect_pair(words, pair_ambiguous_native_config).empty();
+    };
+    std::vector<uint32_t> pair_ambiguous_low_overwrite = pair_ambiguous_join_words;
+    pair_ambiguous_low_overwrite.insert(
+        pair_ambiguous_low_overwrite.begin() + 15,
+        0xbe840380u);              // overwrite only s4 after the join
+    pair_ambiguous_low_overwrite[16] =
+        0x7e020205u;               // read untouched ambiguous s5
+    CHECK(rejects_ambiguous_pair(pair_ambiguous_low_overwrite),
+          "Wave64 pair ambiguity survives a low-half overwrite before a high-half read");
+
+    std::vector<uint32_t> pair_ambiguous_high_overwrite = pair_ambiguous_join_words;
+    pair_ambiguous_high_overwrite.insert(
+        pair_ambiguous_high_overwrite.begin() + 15,
+        0xbe850380u);              // overwrite only s5 after the join
+    pair_ambiguous_high_overwrite[16] =
+        0x7e020204u;               // read untouched ambiguous s4
+    CHECK(rejects_ambiguous_pair(pair_ambiguous_high_overwrite),
+          "Wave64 pair ambiguity survives a high-half overwrite before a low-half read");
+
+    std::vector<uint32_t> pair_ambiguous_addk = pair_ambiguous_join_words;
+    pair_ambiguous_addk[15] =
+        0xb7840001u;               // s_addk_i32 s4,1 implicitly reads/writes SDST
+    CHECK(rejects_ambiguous_pair(pair_ambiguous_addk),
+          "Wave64 pair ambiguity rejects an implicit SOPK read-modify-write");
+
+    std::vector<uint32_t> pair_ambiguous_cmpk = pair_ambiguous_join_words;
+    pair_ambiguous_cmpk[15] =
+        0xb2050000u;               // s_cmpk_lg_i32 s5,0 implicitly reads SDST
+    CHECK(rejects_ambiguous_pair(pair_ambiguous_cmpk),
+          "Wave64 pair ambiguity rejects an implicit SOPK comparison read");
+
+    std::vector<uint32_t> pair_ambiguous_bitset = pair_ambiguous_join_words;
+    pair_ambiguous_bitset[15] =
+        0xbe841d81u;               // s_bitset1_b32 s4,1 reads old SDST and an explicit bit index
+    CHECK(rejects_ambiguous_pair(pair_ambiguous_bitset),
+          "Wave64 pair ambiguity rejects an implicit SOP1 bitset destination read");
+
     const uint32_t code38_vcc_true[] = {
         0xbe8003ffu, 0x80000001u, // source0 low: lanes 0 and 31
         0xbe8103ffu, 0x80000001u, // source0 high: lanes 32 and 63

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3631,6 +3631,99 @@ int main() {
     CHECK(got32c.size()==1 && std::fabs(got32c[0]-7.0f)<1e-3f,
           "kernel 32c LDS min/max atomics update shared memory exactly");
 
+    // GTA V exec_cs_413ced900 pc69 is the exact non-returning DS_MIN_F32 packet below. The shader
+    // initializes six LDS bounds to infinities, atomically reduces three minima and three maxima,
+    // then reads the completed box. SPIR-V 1.3 has no core float atomic min/max, so the lowering
+    // must use an integer compare-exchange loop while preserving AMD MINNUM/MAXNUM semantics.
+    auto run_ds_fminmax = [&](uint32_t atomic_word0, uint32_t atomic_word1,
+                              uint32_t initial_bits,
+                              const std::vector<uint32_t>& operand_bits,
+                              const char* compile_message) {
+        const uint32_t byte_offset = atomic_word0 & 0xffffu;
+        const uint32_t data_vgpr = (atomic_word1 >> 8u) & 0xffu;
+        std::vector<uint32_t> code = {
+            0x7e000301u | (data_vgpr << 17u),    // v_mov_b32 data0, v1 (per-lane operand)
+            0x7e000f00u,                         // v_cvt_u32_f32 v0, v0 (lane index)
+            0x7e0402ffu, initial_bits,           // v_mov_b32 v2, initial_bits
+            0x7da40080u,                         // v_cmpx_eq_u32 0, v0 (lane zero initializes)
+            0x7e000280u,                         // v_mov_b32 v0, 0
+            0xd8340000u | byte_offset, 0x00000200u, // ds_write_b32 v0, v2, matching offset
+            0xbefe04c1u,                         // s_mov_b64 exec, -1
+            0x7e000280u,                         // v_mov_b32 v0, 0 (live has no pre-atomic barrier)
+            atomic_word0, atomic_word1,          // exact live vaddr/data0 fields
+            0xbf8a0000u,                         // s_barrier
+            0xd8d80000u | byte_offset, 0x0a000000u, // ds_read_b32 v10, v0, matching offset
+            0xbf810000u,
+        };
+        std::vector<uint32_t> spv = recompile_valu(
+            code.data(), code.size(), 2, 10);
+        CHECK(!spv.empty(), compile_message);
+        CHECK(count_spirv_opcode(spv, 230) == 1 &&
+                  count_spirv_opcode(spv, 236) == 0 &&
+                  count_spirv_opcode(spv, 237) == 0,
+              "GTA DS_MIN/MAX_F32 uses one compare-exchange loop, not integer min");
+        if (spv.empty()) return std::vector<float>{};
+        std::vector<float> input(WG * 2u);
+        for (uint32_t lane = 0; lane < WG; ++lane) {
+            input[lane * 2u] = static_cast<float>(lane);
+            const uint32_t bits = operand_bits[lane % operand_bits.size()];
+            std::memcpy(&input[lane * 2u + 1u], &bits, sizeof(bits));
+        }
+        return prosper::test::run_compute(spv, input, WG, WG);
+    };
+    auto all_bits_are = [&](const std::vector<float>& values, uint32_t expected) {
+        if (values.size() != WG) return false;
+        return std::all_of(values.begin(), values.end(), [&](float value) {
+            return bits_of(value) == expected;
+        });
+    };
+
+    const std::vector<float> got32c_fmin = run_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u,
+        {0x7fc12345u, 0x40800000u, 0xc0600000u, 0x00000001u, 0x80000001u},
+        "recompiled GTA pc69 exact DS_MIN_F32 packet -> SPIR-V");
+    CHECK(all_bits_are(got32c_fmin, 0xc0600000u),
+          "GTA DS_MIN_F32 atomically reduces finite, NaN, and denormal operands");
+
+    const std::vector<float> got32c_fmin_zero = run_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x00000000u,
+        {0x00000000u, 0x80000000u, 0x7fc00001u},
+        "recompiled GTA DS_MIN_F32 signed-zero arm -> SPIR-V");
+    CHECK(all_bits_are(got32c_fmin_zero, 0x80000000u),
+          "GTA DS_MIN_F32 orders -0 below +0 and ignores a lone NaN");
+
+    const std::vector<float> got32c_fmax_zero = run_ds_fminmax(
+        0xd84c000cu, 0x00000600u, 0x80000000u,
+        {0x80000000u, 0x00000000u, 0xffc00001u},
+        "recompiled GTA pc75 adjacent DS_MAX_F32 packet -> SPIR-V");
+    CHECK(all_bits_are(got32c_fmax_zero, 0x00000000u),
+          "GTA DS_MAX_F32 orders +0 above -0 and ignores a lone NaN");
+
+    const std::vector<float> got32c_fmin_denorm = run_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x00800000u, {0x00000001u, 0x00000002u},
+        "recompiled GTA DS_MIN_F32 denormal arm -> SPIR-V");
+    CHECK(all_bits_are(got32c_fmin_denorm, 0x00000001u),
+          "GTA DS_MIN_F32 retains binary32 denormal ordering independent of host float mode");
+
+    const std::vector<float> got32c_fmin_nan = run_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7fa12345u, {0x7fc22222u, 0xffc33333u},
+        "recompiled GTA DS_MIN_F32 all-NaN arm -> SPIR-V");
+    CHECK(all_bits_are(got32c_fmin_nan, 0x7fe12345u),
+          "GTA DS_MIN_F32 quiets and preserves the resident payload when both operands are NaN");
+
+    // Encoding boundaries: the live opcode is LDS-only and has no DATA1/VDST operand. These two
+    // one-bit mutations perturb that exact production packet and must remain fail-visible.
+    const uint32_t bad_ds_fmin_gds[] = {
+        0xd84a0000u, 0x00000900u, 0xbf810000u,
+    };
+    const uint32_t bad_ds_fmin_data1[] = {
+        0xd8480000u, 0x00010900u, 0xbf810000u,
+    };
+    CHECK(recompile_valu(bad_ds_fmin_gds, std::size(bad_ds_fmin_gds), 10, 0).empty(),
+          "GTA DS_MIN_F32 GDS mutation remains rejected");
+    CHECK(recompile_valu(bad_ds_fmin_data1, std::size(bad_ds_fmin_data1), 10, 0).empty(),
+          "GTA DS_MIN_F32 reserved DATA1 mutation remains rejected");
+
     // Plucky Squire's first-gameplay compute shaders use the non-returning DS_OR_B32 form. Seed an
     // LDS dword with 4, OR in 3 using the exact opcode-0x0a encoding, then read back 7.
     const uint32_t code32c_or[] = {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1345,6 +1345,14 @@ int main() {
     write17d0[16] = 0x00000300u;
     CHECK(recompile_valu(write17d0.data(), write17d0.size(), 1, /*out_vgpr*/2).empty(),
           "EXEC-loop LDS writes remain rejected even after a proved barrier");
+    std::vector<uint32_t> inactive_read17d0(std::begin(code17d0), std::end(code17d0));
+    inactive_read17d0[14] = 0xbf880005u; // shifted exit target: pc20
+    inactive_read17d0.insert(inactive_read17d0.begin() + 15,
+                             0xbefe0480u); // s_mov_b64 exec,0 before ds_read_b32
+    inactive_read17d0[19] = 0xbf82fffau;   // shifted back-edge: pc14
+    CHECK(recompile_valu(inactive_read17d0.data(), inactive_read17d0.size(),
+                         1, /*out_vgpr*/2).empty(),
+          "EXEC-loop LDS reads reject when an intervening write can deactivate the lane");
     std::vector<uint32_t> stale17d0(std::begin(code17d0), std::end(code17d0));
     stale17d0[9] = 0x7e060280u; // v_mov_b32 v3,0: no fresh EXEC condition at the latch
     CHECK(recompile_valu(stale17d0.data(), stale17d0.size(), 1, /*out_vgpr*/2).empty(),

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -7913,8 +7913,10 @@ int main() {
         codeT25bRor8, std::size(codeT25bRor8), 1, 0);
     CHECK(!spvT25bRor8.empty(),
           "recompiled T25b-ror8 (GTA V exact V_MIN_F32 ROW_ROR:8) -> SPIR-V");
-    CHECK(compute_spirv_min_subgroup_size(spvT25bRor8) == 16,
-          "T25b-ror8: row rotate advertises its 16-lane host contract");
+    CHECK(compute_spirv_min_subgroup_size(spvT25bRor8) == 0 &&
+              count_spirv_opcode(spvT25bRor8, 345) == 0 &&
+              count_spirv_opcode(spvT25bRor8, 224) == 4,
+          "T25b-ror8: portable lowering uses scratch barriers without a subgroup contract");
 
     const uint32_t codeT25bRor8Distinct[] = {
         0x1e0402fau, 0xff092800u,             // v_min_f32_dpp v2,v0,v1 row_ror:8 BC:1
@@ -7939,8 +7941,7 @@ int main() {
     CHECK(!spvT25bRor8Exec.empty(),
           "T25b-ror8: exact live v2 packet recompiles with narrowed EXEC");
 
-    if (can_shuffleT25b && subgroupT25b.size >= 16 &&
-        !spvT25bRor8.empty() && !spvT25bRor8Distinct.empty() &&
+    if (!spvT25bRor8.empty() && !spvT25bRor8Distinct.empty() &&
         !spvT25bRor8Exec.empty()) {
         std::vector<float> inRor8(128), expectedRor8(128);
         std::vector<float> inRor8Distinct(128 * 3), expectedRor8Distinct(128);
@@ -7970,16 +7971,139 @@ int main() {
             spvT25bRor8Distinct, inRor8Distinct, 128, 128);
         const std::vector<float> gotRor8Exec = prosper::test::run_compute(
             spvT25bRor8Exec, inRor8Exec, 128, 128);
-        CHECK(gotRor8 == expectedRor8,
-              "T25b-ror8: exact packet rotates within each DPP16 row before V_MIN_F32");
+        CHECK(gotRor8 == expectedRor8 && gotRor8.size() == 128 &&
+                  gotRor8[0] == expectedRor8[0] && gotRor8[64] == expectedRor8[64],
+              "T25b-ror8: portable CFG rotates two guest waves in linear-local DPP16 rows");
         CHECK(gotRor8Distinct == expectedRor8Distinct,
               "T25b-ror8: DPP transforms SRC0 while SRC1 stays in the current lane");
         CHECK(gotRor8Exec == expectedRor8Exec,
               "T25b-ror8: BC1 source invalidation and destination EXEC are independent");
     } else {
-        std::printf("  [skip] T25b-ror8 execution: host subgroup %u is narrower than 16\n",
+        std::printf("  [skip] T25b-ror8 execution: portable modules failed to compile\n");
+    }
+
+    // The live backend can still select the direct shuffle when it can require one exact Wave64
+    // subgroup. Use one resource-backed kernel for both modes: the portable module runs two guest
+    // waves through CFG scratch independent of host subgroup layout, while the native module must
+    // contain the two ROW_ROR shuffles (value + source EXEC) and no workgroup barrier.
+    const uint32_t codeT25bRor8Backend[] = {
+        0x7e020d00u,                         // v_cvt_f32_u32 v1,v0
+        0x1e0202fau, 0xff092801u,            // v_min_f32_dpp v1,v1,v1 row_ror:8 BC:1
+        0xe0702000u, 0x80020100u,            // buffer_store_dword v1,v0,s[8:11] idxen
+        0xbf810000u,
+    };
+    ShaderResourceTable ror8BackendTable;
+    { ShaderResource output{}; output.cls = ResourceClass::ConstantBuffer;
+      output.format = DataFormat::Uint32; output.num_components = 1;
+      output.binding = 3; output.stride = 4; output.sgpr_base = 8;
+      ror8BackendTable.resources.push_back(output); }
+    ComputeShaderConfig portableRor8Config;
+    portableRor8Config.local_x = 128;
+    portableRor8Config.wave_size = 64;
+    portableRor8Config.native_subgroup_size = 0;
+    const std::vector<uint32_t> portableRor8Spv = recompile_compute(
+        codeT25bRor8Backend, std::size(codeT25bRor8Backend),
+        &ror8BackendTable, portableRor8Config);
+    ComputeShaderConfig nativeRor8Config = portableRor8Config;
+    nativeRor8Config.native_subgroup_size = 64;
+    const std::vector<uint32_t> nativeRor8Spv = recompile_compute(
+        codeT25bRor8Backend, std::size(codeT25bRor8Backend),
+        &ror8BackendTable, nativeRor8Config);
+    CHECK(!portableRor8Spv.empty() &&
+              compute_spirv_min_subgroup_size(portableRor8Spv) == 0 &&
+              count_spirv_opcode(portableRor8Spv, 345) == 0 &&
+              count_spirv_opcode(portableRor8Spv, 224) == 4,
+          "T25b-ror8: explicit native-size-zero backend selects portable CFG scratch");
+    CHECK(!nativeRor8Spv.empty() &&
+              count_spirv_opcode(nativeRor8Spv, 345) == 2 &&
+              count_spirv_opcode(nativeRor8Spv, 224) == 0,
+          "T25b-ror8: exact Wave64 backend selects two direct shuffles and no barrier");
+    std::vector<uint32_t> expectedRor8Backend(128);
+    for (uint32_t lane = 0; lane < 128; ++lane) {
+        const uint32_t source = (lane & ~15u) | ((lane & 15u) ^ 8u);
+        expectedRor8Backend[lane] = bits_of(
+            std::min(static_cast<float>(source), static_cast<float>(lane)));
+    }
+    std::vector<uint32_t> portableRor8Got;
+    if (!portableRor8Spv.empty())
+        prosper::test::run_compute(
+            portableRor8Spv, std::vector<float>(128, 0.0f), 128, 128, {},
+            std::vector<uint32_t>(128, 0xdeadbeefu), &portableRor8Got);
+    CHECK(portableRor8Got == expectedRor8Backend,
+          "T25b-ror8: explicit portable backend executes two Wave64 rows exactly");
+    ComputeShaderConfig partialRor8Config = portableRor8Config;
+    partialRor8Config.local_x = 73;
+    const std::vector<uint32_t> partialRor8Spv = recompile_compute(
+        codeT25bRor8Backend, std::size(codeT25bRor8Backend),
+        &ror8BackendTable, partialRor8Config);
+    std::vector<uint32_t> partialRor8Expected(73), partialRor8Got;
+    for (uint32_t lane = 0; lane < partialRor8Expected.size(); ++lane) {
+        const uint32_t source = (lane & ~15u) | ((lane & 15u) ^ 8u);
+        const float sourceValue = source < partialRor8Expected.size()
+            ? static_cast<float>(source) : 0.0f;
+        partialRor8Expected[lane] = bits_of(
+            std::min(sourceValue, static_cast<float>(lane)));
+    }
+    if (!partialRor8Spv.empty())
+        prosper::test::run_compute(
+            partialRor8Spv, std::vector<float>(73, 0.0f), 73, 73, {},
+            std::vector<uint32_t>(73, 0xdeadbeefu), &partialRor8Got);
+    CHECK(!partialRor8Spv.empty() && partialRor8Got == partialRor8Expected,
+          "T25b-ror8: BC1 zero-fills missing sources in a partial final DPP16 row");
+    const bool canExecuteNativeRor8 = subgroupT25b.size == 64 &&
+        (subgroupT25b.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
+        (subgroupT25b.operations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT);
+    if (canExecuteNativeRor8 && !nativeRor8Spv.empty()) {
+        std::vector<uint32_t> nativeRor8Got;
+        prosper::test::run_compute(
+            nativeRor8Spv, std::vector<float>(128, 0.0f), 128, 128, {},
+            std::vector<uint32_t>(128, 0xdeadbeefu), &nativeRor8Got);
+        CHECK(nativeRor8Got == expectedRor8Backend,
+              "T25b-ror8: exact Wave64 native backend executes both guest waves exactly");
+    } else {
+        std::printf("  [skip] T25b-ror8 native execution: host subgroup is %u or lacks shuffle\n",
                     subgroupT25b.size);
     }
+
+    // Keep the two portable DPP operation families in one module. They intentionally have separate
+    // pending state and barrier-bracketed scratch phases, plus one shared disjoint event namespace;
+    // the ROW_SHR phase must not consume ROW_ROR metadata (or vice versa) while scratch is reused.
+    const uint32_t codeT25bRor8ThenAdd[] = {
+        0x1e0000fau, 0xff092800u,            // v_min_f32_dpp v0,v0,v0 row_ror:8 BC:1
+        0x4a0000fau, 0xff011100u,            // v_add_nc_u32_dpp v0,v0,v0 row_shr:1 BC:0
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> ror8ThenAddSpv = recompile_valu(
+        codeT25bRor8ThenAdd, std::size(codeT25bRor8ThenAdd), 1, 0);
+    CHECK(!ror8ThenAddSpv.empty() && count_spirv_opcode(ror8ThenAddSpv, 345) == 0 &&
+              count_spirv_opcode(ror8ThenAddSpv, 224) == 6,
+          "T25b-ror8: combined portable DPP families retain isolated scratch phases");
+    std::vector<float> ror8ThenAddInput(128), ror8ThenAddGot;
+    std::vector<uint32_t> ror8ThenAddExpected(128);
+    for (uint32_t lane = 0; lane < 128; ++lane)
+        ror8ThenAddInput[lane] = static_cast<float>(1000u + lane);
+    for (uint32_t lane = 0; lane < 128; ++lane) {
+        const uint32_t source = (lane & ~15u) | ((lane & 15u) ^ 8u);
+        const uint32_t rotatedMin = bits_of(std::min(
+            ror8ThenAddInput[source], ror8ThenAddInput[lane]));
+        if ((lane & 15u) == 0) {
+            ror8ThenAddExpected[lane] = rotatedMin;
+        } else {
+            const uint32_t priorSource = ((lane - 1u) & ~15u) |
+                (((lane - 1u) & 15u) ^ 8u);
+            const uint32_t priorMin = bits_of(std::min(
+                ror8ThenAddInput[priorSource], ror8ThenAddInput[lane - 1u]));
+            ror8ThenAddExpected[lane] = rotatedMin + priorMin;
+        }
+    }
+    if (!ror8ThenAddSpv.empty())
+        ror8ThenAddGot = prosper::test::run_compute(
+            ror8ThenAddSpv, ror8ThenAddInput, 128, 128);
+    uint32_t ror8ThenAddBad = 0;
+    for (uint32_t lane = 0; lane < 128 && ror8ThenAddGot.size() == 128; ++lane)
+        ror8ThenAddBad += bits_of(ror8ThenAddGot[lane]) != ror8ThenAddExpected[lane];
+    CHECK(ror8ThenAddGot.size() == 128 && ror8ThenAddBad == 0,
+          "T25b-ror8: combined rotate/add phases reuse scratch without cross-matching events");
 
     const uint32_t unsupportedRor8[][2] = {
         {0x1e0000fau, 0xff012800u},           // V_MIN_F32 BOUND_CTRL=0

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1415,6 +1415,21 @@ int main() {
     CHECK(recompile_compute(code17d1s.data(), code17d1s.size(), nullptr,
                             portable_cfg17d1s).empty(),
           "Wave32 mask SCC branch rejects without an exact native subgroup contract");
+
+    // A literal operand is also one complete Wave32 mask word. Keep the irreducible dispatcher
+    // suffix and branch immediately on the new VCC lifetime: this specifically exercises the
+    // dispatcher's mask-domain classification, not only emit_alu's literal lowering.
+    std::vector<uint32_t> code17d1_literal_mask = {
+        0x7d840100u,              // v_cmp_eq_u32 vcc,v0,v0
+        0x876aff6au, 0x55555555u, // s_and_b32 vcc_lo,vcc_lo,0x55555555
+        0xbf860001u,              // s_cbranch_vccz +1
+        0xbf800000u,              // fallthrough work
+    };
+    code17d1_literal_mask.insert(
+        code17d1_literal_mask.end(), std::begin(code17d), std::end(code17d));
+    CHECK(!recompile_compute(code17d1_literal_mask.data(), code17d1_literal_mask.size(),
+                             nullptr, native_cfg17d1).empty(),
+          "Wave32 literal mask remains live through an irreducible VCC branch");
     const std::vector<uint32_t> native_spv17d1 = recompile_compute(
         code17d1, std::size(code17d1), &rt17d1, native_cfg17d1);
     CHECK(!native_spv17d1.empty() && count_spirv_opcode(native_spv17d1, 349) >= 2 &&
@@ -1430,6 +1445,43 @@ int main() {
         (subgroup17d1.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
         (subgroup17d1.operations & VK_SUBGROUP_FEATURE_ARITHMETIC_BIT) &&
         (subgroup17d1.operations & VK_SUBGROUP_FEATURE_VOTE_BIT);
+
+    // Kernel 17d1h: GTA V's Wave32 terrain kernel uses VCC_HI as ordinary scalar scratch. The
+    // exact pc57 packet materializes EXEC_LO, masks it into VCC_HI, and later reads that dword at
+    // pc67. VCC_LO remains the architectural mask: pc59 narrows it, and pc68 reads its complete
+    // dword through the same exact Wave32 ballot. Append the irreducible dispatcher tail so this
+    // exercises the same emit_alu call site as the live shader rather than only straight-line code.
+    std::vector<uint32_t> code17d1h = {
+        0xbe9403c1u,              // s_mov_b32 s20,-1
+        0x7d840100u,              // v_cmp_eq_u32 vcc,v0,v0
+        0x876bff7eu, 0x0fffffffu, // pc57: s_and_b32 vcc_hi,exec_lo,0x0fffffff
+        0xbf068000u,              // synthetic scalar condition keeps the exact lifetime at a join
+        0xbf840001u,              // s_cbranch_scc0 +1
+        0xbf800000u,              // alternate-path work
+        0x876aff6au, 0x7ffffffeu, // pc59: s_and_b32 vcc_lo,vcc_lo,0x7ffffffe
+        0x871a6b14u,              // pc67: s_and_b32 s26,s20,vcc_hi
+        0x811b6a82u,              // pc68: s_add_u32 s27,2,vcc_lo
+        0x811a1b1au,              // s_add_u32 s26,s26,s27
+        0x7e02021au,              // v_mov_b32 v1,s26
+        0xe0702000u, 0x80020100u, // buffer_store_dword v1,v0,s[8:11] idxen
+    };
+    code17d1h.insert(code17d1h.end(), std::begin(code17d), std::end(code17d));
+    const std::vector<uint32_t> native_spv17d1h = recompile_compute(
+        code17d1h.data(), code17d1h.size(), &rt17d1, native_cfg17d1);
+    CHECK(!native_spv17d1h.empty() && count_spirv_opcode(native_spv17d1h, 339) == 2,
+          "GTA Wave32 VCC_HI scratch materializes exact EXEC/VCC ballots");
+    CHECK(recompile_compute(code17d1h.data(), code17d1h.size(), &rt17d1,
+                            portable_cfg17d1).empty(),
+          "Wave32 VCC_HI scratch rejects without an exact subgroup ballot");
+    const bool can_execute17d1h = can_execute17d1 &&
+        (subgroup17d1.operations & VK_SUBGROUP_FEATURE_BALLOT_BIT);
+    if (can_execute17d1h) {
+        std::vector<uint32_t> got17d1h;
+        prosper::test::run_compute(native_spv17d1h, std::vector<float>(64, 0.0f),
+                                   64, 64, {}, std::vector<uint32_t>(64, 0u), &got17d1h);
+        CHECK(got17d1h == std::vector<uint32_t>(64, 0x8fffffffu),
+              "VCC_HI scalar scratch and VCC_LO mask dwords remain independently exact");
+    }
     if (can_execute17d1) {
         std::vector<uint32_t> initial17d1(64, 0u), got17d1;
         prosper::test::run_compute(native_spv17d1, std::vector<float>(64, 0.0f),

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6438,6 +6438,49 @@ int main() {
               got68_zero_load.size() == N && bad68_zero_load == 0,
           "zero-record raw load returns zero under EXEC and preserves masked VGPR lanes");
 
+    // GTA V 0x413d59600 pc67: exact buffer_load_format_xyz packet through a zero-record V#.
+    // Pad with real v_nop encodings so the exact-PC resource marker remains 67. The active lanes
+    // receive zero while masked lanes retain v17=7, and the module must add no storage-buffer access.
+    std::vector<uint32_t> code68_zero_format(72, 0x7e000000u);
+    code68_zero_format[0] = 0x7E000F00u; // v_cvt_u32_f32 v0, v0
+    code68_zero_format[1] = 0x7E020F01u; // v_cvt_u32_f32 v1, v1
+    code68_zero_format[2] = 0x7E220287u; // v_mov_b32 v17, 7
+    code68_zero_format[3] = 0x7DA80300u; // v_cmpx_gt_u32 vcc, v0, v1
+    code68_zero_format[67] = 0xE0082000u;
+    code68_zero_format[68] = 0x8000110Cu;
+    code68_zero_format[69] = 0xBEFE04C1u; // s_mov_b64 exec, -1
+    code68_zero_format[70] = 0x7E220D11u; // v_cvt_f32_u32 v17, v17
+    code68_zero_format[71] = 0xBF810000u;
+    ShaderResourceTable rt68_zero_format;
+    rt68_zero_format.resources.push_back(zero_record_resource(67));
+    const std::vector<uint32_t> spv68_zero_format = recompile_valu(
+        code68_zero_format.data(), code68_zero_format.size(), 2, 17,
+        &rt68_zero_format);
+    std::vector<uint32_t> code68_zero_format_control = code68_zero_format;
+    code68_zero_format_control[67] = 0x7E000000u;
+    code68_zero_format_control[68] = 0x7E000000u;
+    const std::vector<uint32_t> spv68_zero_format_control = recompile_valu(
+        code68_zero_format_control.data(), code68_zero_format_control.size(), 2, 17,
+        &rt68_zero_format);
+    CHECK(!spv68_zero_format.empty() && !spv68_zero_format_control.empty() &&
+              count_spirv_opcode(spv68_zero_format, 61) ==
+                  count_spirv_opcode(spv68_zero_format_control, 61) &&
+              count_spirv_opcode(spv68_zero_format, 62) ==
+                  count_spirv_opcode(spv68_zero_format_control, 62) &&
+              count_spirv_opcode(spv68_zero_format, 65) ==
+                  count_spirv_opcode(spv68_zero_format_control, 65),
+          "exact zero-record FORMAT load adds no storage-buffer access/load/store instructions");
+    const std::vector<float> got68_zero_format = spv68_zero_format.empty()
+        ? std::vector<float>{}
+        : prosper::test::run_compute(spv68_zero_format, in68_zero_load, N, N, {},
+                                     std::vector<uint32_t>(1, 0xDEADBEEFu));
+    uint32_t bad68_zero_format = 0;
+    for (uint32_t i = 0; i < N && got68_zero_format.size() == N; ++i)
+        if (got68_zero_format[i] != expected68_zero_load[i]) ++bad68_zero_format;
+    CHECK(active68_zero_load > 0 && active68_zero_load < N &&
+              got68_zero_format.size() == N && bad68_zero_format == 0,
+          "exact zero-record FORMAT load preserves masked VGPR lanes");
+
     ShaderResourceTable rt68_zero_store;
     rt68_zero_store.resources.push_back(zero_record_resource(2));
     const std::vector<uint32_t> spv68_zero_store = recompile_valu(

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3269,6 +3269,76 @@ int main() {
     CHECK(got32b3.size()==1 && std::fabs(got32b3[0]-189.0f)<1e-3f,
           "kernel 32b3 masks U24 multiplication and floors negative f32 before i32 conversion");
 
+    // GTA V exec_cs_205b54f200 pc21: exact `v_cvt_rpi_i32_f32_e32 v1, v1` packet.
+    // RDNA2 specifies floor(x + 0.5): nearest integer with halfway cases toward +infinity.
+    // Read the integer result bits directly so the positive rail checks INT_MAX itself rather than
+    // losing that distinction in an i32->f32 round-trip. Exceptional values follow prosper's
+    // adjacent saturating f32->i32 convention: NaN -> 0, infinities/overflow -> signed rails.
+    const uint32_t code32b3_rpi[] = {
+        0x7e021901u,               // live pc21: v_cvt_rpi_i32_f32 v1, v1
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spv32b3_rpi = recompile_valu(
+        code32b3_rpi, std::size(code32b3_rpi), 2, 1);
+    CHECK(!spv32b3_rpi.empty(),
+          "recompiled GTA V pc21 v_cvt_rpi_i32_f32 packet -> SPIR-V");
+    CHECK(count_spirv_opcode(spv32b3_rpi, 110) == 0 &&
+              count_spirv_opcode(spv32b3_rpi, 109) != 0,
+          "v_cvt_rpi_i32_f32 uses the defined saturating conversion path");
+    const float rpi_sources[] = {
+        -INFINITY, -2147483904.0f, -2147483648.0f,
+        -2.75f, -2.5f, -2.25f, -1.5f, -0.75f, -0.5f, -0.25f,
+        -std::numeric_limits<float>::denorm_min(), -0.0f, 0.0f,
+        std::numeric_limits<float>::denorm_min(),
+        std::nextafter(0.5f, 0.0f), 0.5f, std::nextafter(0.5f, 1.0f),
+        0.75f, 1.25f, 1.5f, 1.75f,
+        2147483520.0f, 2147483648.0f, INFINITY, std::nanf(""),
+    };
+    const uint32_t rpi_expected[] = {
+        0x80000000u, 0x80000000u, 0x80000000u,
+        0xfffffffdu, 0xfffffffeu, 0xfffffffeu, 0xffffffffu,
+        0xffffffffu, 0u, 0u, 0u, 0u, 0u, 0u,
+        0u, 1u, 1u, 1u, 1u, 2u, 2u,
+        0x7fffff80u, 0x7fffffffu, 0x7fffffffu, 0u,
+    };
+    static_assert(std::size(rpi_sources) == std::size(rpi_expected));
+    std::vector<float> in32b3_rpi(std::size(rpi_sources) * 2u, 0.0f);
+    for (size_t i = 0; i < std::size(rpi_sources); ++i)
+        in32b3_rpi[i * 2u + 1u] = rpi_sources[i];
+    const std::vector<float> got32b3_rpi = prosper::test::run_compute(
+        spv32b3_rpi, in32b3_rpi, static_cast<uint32_t>(std::size(rpi_sources)),
+        static_cast<uint32_t>(std::size(rpi_sources)));
+    uint32_t bad32b3_rpi = 0;
+    for (size_t i = 0; i < got32b3_rpi.size() && i < std::size(rpi_expected); ++i) {
+        if (bits_of(got32b3_rpi[i]) == rpi_expected[i]) continue;
+        if (bad32b3_rpi == 0)
+            printf("  pc21 first mismatch i=%zu src=0x%08x got=0x%08x expect=0x%08x\n",
+                   i, bits_of(rpi_sources[i]), bits_of(got32b3_rpi[i]), rpi_expected[i]);
+        ++bad32b3_rpi;
+    }
+    CHECK(got32b3_rpi.size() == std::size(rpi_expected) && bad32b3_rpi == 0,
+          "GTA V pc21 rounds fractions/ties and saturates exceptional values exactly");
+
+    // Modifier-bearing siblings are not part of the proven live shape. The trivial-DWORD SDWA
+    // packet is deliberately useful here: the decoder admits it structurally, so this assertion
+    // reaches the opcode's own fail-visible gate rather than a generic malformed-packet reject.
+    const uint32_t cvt_rpi_sdwa[] = {
+        0x7e0218f9u, 0x00060601u,  // v_cvt_rpi_i32_f32_sdwa v1,v1, DWORD/PAD/DWORD
+        0xbf810000u,
+    };
+    const uint32_t cvt_rpi_sdwa_neg[] = {
+        0x7e0218f9u, 0x00160601u,  // same packet with src0 negate
+        0xbf810000u,
+    };
+    const uint32_t cvt_rpi_dpp[] = {
+        0x7e0218fau, 0xff00e401u,  // identity quad_perm, full row/bank masks
+        0xbf810000u,
+    };
+    CHECK(recompile_valu(cvt_rpi_sdwa, std::size(cvt_rpi_sdwa), 2, 1).empty() &&
+              recompile_valu(cvt_rpi_sdwa_neg, std::size(cvt_rpi_sdwa_neg), 2, 1).empty() &&
+              recompile_valu(cvt_rpi_dpp, std::size(cvt_rpi_dpp), 2, 1).empty(),
+          "unproven v_cvt_rpi_i32_f32 SDWA/DPP/modifier forms remain fail-visible");
+
     // Kernel 32b4: exact DS_WRITE_B96/B128 and DS_READ_B96/B128 forms from Astro. Store 1,2,3 at
     // byte 0x510 and 4,5,6,7 at byte 0, read both vectors back, and sum all seven dwords to 28.
     const uint32_t code32b4[] = {

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3765,6 +3765,14 @@ int main() {
     CHECK(recompile_valu(
               skipped_ds_fmin_barrier.data(), skipped_ds_fmin_barrier.size(), 2, 10).empty(),
           "branch that skips the LDS publication boundary remains rejected");
+    std::vector<uint32_t> skipped_ds_fmin_lane0 = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    const auto lane0_exec = std::find(
+        skipped_ds_fmin_lane0.begin(), skipped_ds_fmin_lane0.end(), 0xbefe0481u);
+    skipped_ds_fmin_lane0.insert(lane0_exec, 0xbf840001u); // branch over EXEC=1 only
+    CHECK(recompile_valu(
+              skipped_ds_fmin_lane0.data(), skipped_ds_fmin_lane0.size(), 2, 10).empty(),
+          "branch entering after GTA's lane-zero EXEC writer invalidates the single-writer proof");
 
     // Encoding boundaries: the live opcode is LDS-only and has no DATA1/VDST operand. These two
     // one-bit mutations perturb that exact production packet and must remain fail-visible.
@@ -3794,6 +3802,14 @@ int main() {
     };
     CHECK(recompile_valu(unproved_ds_fmin_store, std::size(unproved_ds_fmin_store), 10, 0).empty(),
           "ordinary LDS store before DS_MIN_F32 stays rejected without a uniform publication proof");
+    const uint32_t unproved_ds_write2_b64_fmin[] = {
+        0x7e000280u,
+        0xd9380000u, 0x00030100u, // ds_write2_b64 v0, v[1:2], v[3:4]
+        0xd8480000u, 0x00000900u, 0xbf810000u,
+    };
+    CHECK(recompile_valu(
+              unproved_ds_write2_b64_fmin, std::size(unproved_ds_write2_b64_fmin), 10, 0).empty(),
+          "DS_WRITE2_B64 before DS_MIN_F32 remains an inventoried unsynchronized store");
 
     // Plucky Squire's first-gameplay compute shaders use the non-returning DS_OR_B32 form. Seed an
     // LDS dword with 4, OR in 3 using the exact opcode-0x0a encoding, then read back 7.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -5308,6 +5308,59 @@ int main() {
     CHECK(pair_true_got.size() == 128 && pair_false_got.size() == 128 && pair_bad == 0,
           "S_CSELECT_B64 selects both scalar dwords for SCC true and false");
 
+    // Force the arbitrary-CFG dispatcher, select two ordinary scalar pairs in one case, then
+    // consume them with a second S_CSELECT_B64 after an explicit successor edge. The dispatcher's
+    // Bool backing variables exist because this opcode can also select masks, but mere variable
+    // existence must not reclassify these data lifetimes as masks when the successor reloads state.
+    const uint32_t code38_pair_dispatch[] = {
+        0x7e040280u,              // v_mov_b32 v2, 0
+        0x7d840100u,              // v_cmp_eq_u32 vcc, v0, v0
+        0xbf860001u,              // s_cbranch_vccz +1
+        0x7e040281u,              // v_mov_b32 v2, 1
+        0x7d840100u,              // fresh VCC for the loop exit
+        0xbf870001u,              // s_cbranch_vccnz +1
+        0xbf82fffdu,              // s_branch -3: forces generic dispatcher shape
+        0xbe80038bu,              // s_mov_b32 s0,11
+        0xbe81038cu,              // s_mov_b32 s1,12
+        0xbe820395u,              // s_mov_b32 s2,21
+        0xbe830396u,              // s_mov_b32 s3,22
+        0xbe8c0381u,              // s_mov_b32 s12,1
+        0xbf07800cu,              // SCC=true
+        0x85840200u,              // s_cselect_b64 s[4:5],s[0:1],s[2:3] -> 11:12
+        0xbe8c0380u,              // s_mov_b32 s12,0
+        0xbf07800cu,              // SCC=false
+        0x85860200u,              // s_cselect_b64 s[6:7],s[0:1],s[2:3] -> 21:22
+        0xbf820001u,              // cross a dispatcher edge to pc19
+        0xbf800000u,
+        0xbe85038cu,              // replace s5 after reload; isolate low-root domain persistence
+        0xbe870396u,              // replace s7 after reload
+        0xbe8c0381u,              // s_mov_b32 s12,1
+        0xbf07800cu,              // SCC=true
+        0x858e0604u,              // s_cselect_b64 s[14:15],s[4:5],s[6:7]
+        0x7e02020eu,              // v_mov_b32 v1,s14
+        0xe0702000u, 0x80020100u, // output[lane] = selected low
+        0x4a0400c0u,              // v_add_nc_u32 v2,64,v0
+        0x7e02020fu,              // v_mov_b32 v1,s15
+        0xe0702000u, 0x80020102u, // output[64+lane] = selected high
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> pair_dispatch_words(
+        std::begin(code38_pair_dispatch), std::end(code38_pair_dispatch));
+    const auto pair_dispatch_portable = compile_cselect_pair(
+        pair_dispatch_words, cselect_portable_config);
+    const auto pair_dispatch_native = compile_cselect_pair(
+        pair_dispatch_words, cselect_native_config);
+    CHECK(!pair_dispatch_portable.empty() && !pair_dispatch_native.empty(),
+          "dispatcher preserves S_CSELECT_B64 scalar-pair domain across a successor edge");
+    const auto pair_dispatch_got = run_cselect_pair(pair_dispatch_portable);
+    uint32_t pair_dispatch_bad = 0;
+    for (uint32_t lane = 0; lane < 64 && pair_dispatch_got.size() == 128; ++lane) {
+        pair_dispatch_bad += pair_dispatch_got[lane] != 11u;
+        pair_dispatch_bad += pair_dispatch_got[64 + lane] != 12u;
+    }
+    CHECK(pair_dispatch_got.size() == 128 && pair_dispatch_bad == 0,
+          "dispatcher successor consumes both selected scalar dwords as data");
+
     const uint32_t code38_vcc_true[] = {
         0xbe8003ffu, 0x80000001u, // source0 low: lanes 0 and 31
         0xbe8103ffu, 0x80000001u, // source0 high: lanes 32 and 63
@@ -5393,29 +5446,43 @@ int main() {
     gta_high_live[62] = 0x7e10026bu; // v_mov_b32 v8,vcc_hi: high output is now live
     std::vector<uint32_t> gta_site_mutation = gta_low_true;
     gta_site_mutation[60] = 0x85861000u; // same pc60 select into ordinary s[6:7]
+    const auto gta_low_only_pcs = cselect_b64_low_only_pcs_for_test(
+        gta_low_true.data(), gta_low_true.size());
+    const auto gta_high_live_pcs = cselect_b64_low_only_pcs_for_test(
+        gta_high_live.data(), gta_high_live.size());
+    const auto gta_site_mutation_pcs = cselect_b64_low_only_pcs_for_test(
+        gta_site_mutation.data(), gta_site_mutation.size());
+    CHECK(std::find(gta_low_only_pcs.begin(), gta_low_only_pcs.end(), 60u) !=
+              gta_low_only_pcs.end() &&
+              gta_high_live_pcs.empty() && gta_site_mutation_pcs.empty(),
+          "GTA low-only liveness seam admits pc60 and rejects high-live/destination mutations there");
     CHECK(compile_cselect_pair(gta_high_live, cselect_portable_config).empty() &&
               compile_cselect_pair(gta_high_live, cselect_native_config).empty() &&
               compile_cselect_pair(gta_site_mutation, cselect_portable_config).empty() &&
               compile_cselect_pair(gta_site_mutation, cselect_native_config).empty(),
-          "GTA low-only admission rejects a live high half and a pc60 destination mutation");
+          "GTA low-only negative streams remain fail-visible in portable/native modes");
     const bool can_execute_cselect_native = exec_ballot_subgroup.size == 64 &&
         (exec_ballot_subgroup.stages & VK_SHADER_STAGE_COMPUTE_BIT);
     if (can_execute_cselect_native) {
         const auto pair_true_native_got = run_cselect_pair(pair_true_native);
         const auto pair_false_native_got = run_cselect_pair(pair_false_native);
+        const auto pair_dispatch_native_got = run_cselect_pair(pair_dispatch_native);
         const auto vcc_true_native_got = run_cselect_pair(vcc_true_native);
         const auto vcc_false_native_got = run_cselect_pair(vcc_false_native);
         const auto gta_low_true_native_got = run_cselect_pair(gta_low_true_native);
         const auto gta_low_false_native_got = run_cselect_pair(gta_low_false_native);
         uint32_t native_bad = 0;
         for (uint32_t lane = 0; lane < 64 && pair_true_native_got.size() >= 128 &&
-             pair_false_native_got.size() >= 128 && vcc_true_native_got.size() >= 64 &&
+             pair_false_native_got.size() >= 128 && pair_dispatch_native_got.size() >= 128 &&
+             vcc_true_native_got.size() >= 64 &&
              vcc_false_native_got.size() >= 64 && gta_low_true_native_got.size() >= 64 &&
              gta_low_false_native_got.size() >= 64; ++lane) {
             native_bad += pair_true_native_got[lane] != 11u;
             native_bad += pair_true_native_got[64 + lane] != 12u;
             native_bad += pair_false_native_got[lane] != 21u;
             native_bad += pair_false_native_got[64 + lane] != 22u;
+            native_bad += pair_dispatch_native_got[lane] != 11u;
+            native_bad += pair_dispatch_native_got[64 + lane] != 12u;
             const bool true_bit = lane == 0 || lane == 31 || lane == 32 || lane == 63;
             const bool false_bit = lane == 1 || lane == 30 || lane == 33 || lane == 62;
             native_bad += vcc_true_native_got[lane] != (true_bit ? 22u : 11u);
@@ -5424,6 +5491,7 @@ int main() {
             native_bad += gta_low_false_native_got[lane] != 55u;
         }
         CHECK(pair_true_native_got.size() >= 128 && pair_false_native_got.size() >= 128 &&
+                  pair_dispatch_native_got.size() >= 128 &&
                   vcc_true_native_got.size() >= 64 && vcc_false_native_got.size() >= 64 &&
                   gta_low_true_native_got.size() >= 64 &&
                   gta_low_false_native_got.size() >= 64 && native_bad == 0,

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3631,6 +3631,26 @@ int main() {
     CHECK(got32c.size()==1 && std::fabs(got32c[0]-7.0f)<1e-3f,
           "kernel 32c LDS min/max atomics update shared memory exactly");
 
+    // Inactive lanes retain the old address VGPR when GTA narrows EXEC to lane zero. Give those
+    // lanes a deliberately out-of-range address before the exact B128+B64 gather: the six LDS
+    // AccessChain/OpLoad pairs must live inside their active branches, while OpPhi preserves each
+    // inactive destination. Counting the six structural regions pins that production call site;
+    // merely selecting the result after an unconditional load would have no such regions.
+    const uint32_t predicated_wide_lds_reads[] = {
+        0x7e0802ffu, 0xfffffffcu,            // v4 = stale/OOB byte address in every lane
+        0xbefe0481u,                         // s_mov_b64 exec, 1
+        0x7e080280u,                         // v_mov_b32 v4, 0 in lane zero only
+        0xdbfc0000u, 0x00000004u,            // exact ds_read_b128 v[0:3], v4
+        0xd9d80010u, 0x04000004u,            // exact ds_read_b64 v[4:5], v4
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> predicated_wide_lds_spv = recompile_valu(
+        predicated_wide_lds_reads, std::size(predicated_wide_lds_reads), 6, 0);
+    CHECK(!predicated_wide_lds_spv.empty() &&
+              count_spirv_opcode(predicated_wide_lds_spv, 247) == 6 &&
+              count_spirv_opcode(predicated_wide_lds_spv, 245) == 6,
+          "GTA's lane-zero B128+B64 gather branches around all six LDS loads and phi-merges fallbacks");
+
     // GTA V exec_cs_413ced900 pc69 is the exact non-returning DS_MIN_F32 packet below. The shader
     // initializes six LDS bounds to infinities, atomically reduces three minima and three maxima,
     // then reads the completed box. SPIR-V 1.3 has no core float atomic min/max, so the lowering
@@ -3654,6 +3674,7 @@ int main() {
         for (uint32_t vgpr = 6; vgpr <= 8; ++vgpr) literal(vgpr, 0xff800000u);
         for (uint32_t vgpr = 9; vgpr <= 11; ++vgpr) literal(vgpr, 0x7f800000u);
         code.push_back(0x7e000301u | (data_vgpr << 17u)); // v_mov_b32 data0, v1
+        literal(4, 0xfffffffcu);                          // stale/OOB in inactive gather lanes
         code.push_back(0xbefe0481u);                      // s_mov_b64 exec, 1
         for (uint32_t vgpr = 0; vgpr < 6; ++vgpr) literal(vgpr, initial[vgpr]);
         const uint32_t live_tail[] = {
@@ -3668,8 +3689,14 @@ int main() {
             0xd84c000cu, 0x00000600u,            // pc75/77/79 three exact DS_MAX_F32
             0xd84c0010u, 0x00000700u,
             0xd84c0014u, 0x00000800u,
-            0xbf8a0000u,                         // s_barrier
-            0xd8d80000u | byte_offset, 0x0a000000u, // ds_read_b32 v10, v0, matching offset
+            0xbefe0481u,                         // pc81 s_mov_b64 exec, 1
+            0x7e080280u,                         // pc82 v_mov_b32 v4, 0
+            0xdbfc0000u, 0x00000004u,            // pc83 ds_read_b128 v[0:3], v4
+            0xd9d80010u, 0x04000004u,            // pc85 ds_read_b64 v[4:5], v4
+            0xbf8cc17fu,                         // pc87 s_waitcnt lgkmcnt(0)
+            0xbefe04c1u,                         // s_mov_b64 exec, -1
+            0x7e0002ffu, byte_offset,            // v_mov_b32 v0, selected result address
+            0xd8d80000u, 0x0a000000u,            // ds_read_b32 v10, v0 (semantic check)
             0xbf810000u,
         };
         code.insert(code.end(), std::begin(live_tail), std::end(live_tail));
@@ -3689,7 +3716,10 @@ int main() {
                   count_spirv_opcode(spv, 237) == 0,
               "GTA DS_MIN/MAX_F32 group uses six compare-exchange loops, not integer min");
         CHECK(count_spirv_opcode(spv, 224) == 2,
-              "GTA lane-zero LDS initialization gains one publication barrier before its guest barrier");
+              "GTA LDS atomic group gains publication and completion barriers without a guest barrier");
+        CHECK(count_spirv_opcode(spv, 247) == 12 &&
+                  count_spirv_opcode(spv, 245) == 12,
+              "GTA lane-zero initializer and gather keep six LDS loads inside EXEC selections");
         if (spv.empty()) return std::vector<float>{};
         std::vector<float> input(WG * 2u);
         for (uint32_t lane = 0; lane < WG; ++lane) {
@@ -3705,6 +3735,34 @@ int main() {
             return bits_of(value) == expected;
         });
     };
+
+    // EXEC=1 means one ordinary-store writer per guest wave, not per workgroup. GTA's live
+    // local64/Wave64 launch therefore has exactly one initializer; a two-wave workgroup would race
+    // the same six addresses and must stay fail-visible in both portable and native subgroup modes.
+    const std::vector<uint32_t> ds_fminmax_launch_code = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    ComputeShaderConfig portable_ds_fminmax_config;
+    portable_ds_fminmax_config.local_x = 64;
+    portable_ds_fminmax_config.wave_size = 64;
+    const std::vector<uint32_t> portable_ds_fminmax_spv = recompile_compute(
+        ds_fminmax_launch_code.data(), ds_fminmax_launch_code.size(), nullptr,
+        portable_ds_fminmax_config);
+    ComputeShaderConfig native_ds_fminmax_config = portable_ds_fminmax_config;
+    native_ds_fminmax_config.native_subgroup_size = 64;
+    const std::vector<uint32_t> native_ds_fminmax_spv = recompile_compute(
+        ds_fminmax_launch_code.data(), ds_fminmax_launch_code.size(), nullptr,
+        native_ds_fminmax_config);
+    CHECK(!portable_ds_fminmax_spv.empty() && !native_ds_fminmax_spv.empty(),
+          "GTA's single-wave LDS float atomic launch recompiles in portable and native modes");
+    ComputeShaderConfig portable_multiwave_ds_fminmax_config = portable_ds_fminmax_config;
+    portable_multiwave_ds_fminmax_config.local_x = 128;
+    ComputeShaderConfig native_multiwave_ds_fminmax_config = native_ds_fminmax_config;
+    native_multiwave_ds_fminmax_config.local_x = 128;
+    CHECK(recompile_compute(ds_fminmax_launch_code.data(), ds_fminmax_launch_code.size(), nullptr,
+                            portable_multiwave_ds_fminmax_config).empty() &&
+              recompile_compute(ds_fminmax_launch_code.data(), ds_fminmax_launch_code.size(), nullptr,
+                                native_multiwave_ds_fminmax_config).empty(),
+          "GTA's lane-zero LDS initializer rejects an unproved multi-wave workgroup in both modes");
 
     const std::vector<float> got32c_fmin = run_ds_fminmax(
         0xd8480000u, 0x00000900u, 0x7f800000u,
@@ -3773,6 +3831,33 @@ int main() {
     CHECK(recompile_valu(
               skipped_ds_fmin_lane0.data(), skipped_ds_fmin_lane0.size(), 2, 10).empty(),
           "branch entering after GTA's lane-zero EXEC writer invalidates the single-writer proof");
+    std::vector<uint32_t> crossed_ds_fmin_completion = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    const auto completion_first_fmin = std::find(
+        crossed_ds_fmin_completion.begin(), crossed_ds_fmin_completion.end(), 0xd8480000u);
+    const auto completion_lane0 = std::find(
+        completion_first_fmin, crossed_ds_fmin_completion.end(), 0xbefe0481u);
+    const auto completion_read64 = std::find(
+        completion_lane0, crossed_ds_fmin_completion.end(), 0xd9d80010u);
+    CHECK(completion_first_fmin != crossed_ds_fmin_completion.end() &&
+              completion_lane0 != crossed_ds_fmin_completion.end() &&
+              completion_read64 != crossed_ds_fmin_completion.end(),
+          "GTA LDS completion regression contains the exact atomic/gather suffix");
+    if (completion_lane0 != crossed_ds_fmin_completion.end() &&
+        completion_read64 != crossed_ds_fmin_completion.end()) {
+        const uint32_t target_pc = static_cast<uint32_t>(
+            std::distance(crossed_ds_fmin_completion.begin(), completion_lane0));
+        const auto branch_at = completion_read64 + 2;
+        const uint32_t branch_pc = static_cast<uint32_t>(
+            std::distance(crossed_ds_fmin_completion.begin(), branch_at));
+        const int32_t simm = static_cast<int32_t>(target_pc) -
+                             static_cast<int32_t>(branch_pc + 1u);
+        crossed_ds_fmin_completion.insert(
+            branch_at, 0xbf820000u | static_cast<uint16_t>(simm));
+    }
+    CHECK(recompile_valu(crossed_ds_fmin_completion.data(),
+                         crossed_ds_fmin_completion.size(), 2, 10).empty(),
+          "back-edge after GTA's gather cannot cross the synthesized completion barrier");
 
     // Encoding boundaries: the live opcode is LDS-only and has no DATA1/VDST operand. These two
     // one-bit mutations perturb that exact production packet and must remain fail-visible.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6481,6 +6481,14 @@ int main() {
               got68_zero_format.size() == N && bad68_zero_format == 0,
           "exact zero-record FORMAT load preserves masked VGPR lanes");
 
+    ShaderResourceTable rt68_zero_format_one;
+    ShaderResource zero_record_format_one = zero_record_resource(67);
+    zero_record_format_one.swizzle[0] = 1u; // SQ_SEL_1: OOB result is one, never zero
+    rt68_zero_format_one.resources.push_back(zero_record_format_one);
+    CHECK(recompile_valu(code68_zero_format.data(), code68_zero_format.size(), 2, 17,
+                         &rt68_zero_format_one).empty(),
+          "zero-record FORMAT marker rejects SQ_SEL_1 instead of emitting a wrong zero");
+
     ShaderResourceTable rt68_zero_store;
     rt68_zero_store.resources.push_back(zero_record_resource(2));
     const std::vector<uint32_t> spv68_zero_store = recompile_valu(

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3000,6 +3000,139 @@ int main() {
     CHECK(!spv_atomic_or.empty() && or_buf_out.size() == 1 && or_buf_out[0] == 7u,
           "#590: buffer_atomic_or is idempotent (4 | 3 = 7), distinct from add/max/swap");
 
+    // GTA V rebuilds this exact stride-8 V# with a dispatch-sized record count. Use its live two-
+    // record arm: two valid lanes prove the dynamic qword index, and indices {0,2} prove the compiled
+    // count bound. Results are copied through binding 3 so both VDATA halves remain observable.
+    alignas(8) uint32_t swap_x2_backing[4] = {};
+    ShaderResourceTable rt_swap_x2;
+    { ShaderResource atomic{}; atomic.cls = ResourceClass::ConstantBuffer;
+      atomic.format = DataFormat::Uint32; atomic.num_components = 1;
+      atomic.binding = 2; atomic.gpu_addr = reinterpret_cast<uint64_t>(swap_x2_backing);
+      atomic.size = 16; atomic.stride = 8; atomic.sgpr_base = 0; atomic.fetch_pc = 3;
+      atomic.atomic_x2_record_count = 2;
+      rt_swap_x2.resources.push_back(atomic);
+      ShaderResource result{}; result.cls = ResourceClass::ConstantBuffer;
+      result.format = DataFormat::Uint32; result.num_components = 1;
+      result.binding = 3; result.size = 16; result.stride = 8;
+      result.sgpr_base = 4; result.fetch_pc = 5;
+      rt_swap_x2.resources.push_back(result); }
+    const uint32_t swap_x2_no_glc[] = {
+        0x7e260300u,               // v_mov_b32 v19, v0 (LocalInvocationId.x)
+        0x7e120291u,               // v_mov_b32 v9, 17
+        0x7e1402a2u,               // v_mov_b32 v10, 34
+        0xe1402000u, 0x80000913u,  // buffer_atomic_swap_x2 v[9:10], v19, s[0:3], idxen
+        0xe0742000u, 0x80010900u,  // buffer_store_dwordx2 v[9:10], v0, s[4:7], idxen
+        0xbf810000u,
+    };
+    ComputeShaderConfig swap_x2_config;
+    swap_x2_config.local_x = 2;
+    swap_x2_config.storage_buffer_int64_atomics = true;
+    const std::vector<uint32_t> swap_x2_no_glc_spv = recompile_compute(
+        swap_x2_no_glc, std::size(swap_x2_no_glc), &rt_swap_x2, swap_x2_config);
+    CHECK(!swap_x2_no_glc_spv.empty(),
+          "GTA V swap_x2 GLC=0 recompiles through the exact int64-atomic contract");
+
+    if (prosper::test::default_compute_buffer_int64_atomics_supported()) {
+        const std::vector<float> swap_x2_dummy(2, 0.0f);
+        std::vector<uint32_t> initial_qwords(4, 0u);
+        initial_qwords[0] = 0x11223344u;
+        initial_qwords[1] = 0x55667788u;
+        initial_qwords[2] = 0x99aabbccu;
+        initial_qwords[3] = 0xddeeff00u;
+        const std::vector<uint32_t> result_seed(4, 0xdeadbeefu);
+        std::vector<uint32_t> no_glc_results, no_glc_memory;
+        prosper::test::run_compute(swap_x2_no_glc_spv, swap_x2_dummy, 2, 2,
+                                   initial_qwords, result_seed, &no_glc_results, 2,
+                                   &no_glc_memory);
+        std::vector<uint32_t> swapped_qwords = initial_qwords;
+        swapped_qwords[0] = swapped_qwords[2] = 17u;
+        swapped_qwords[1] = swapped_qwords[3] = 34u;
+        CHECK(no_glc_memory == swapped_qwords &&
+                  no_glc_results == std::vector<uint32_t>({17u, 34u, 17u, 34u}),
+              "swap_x2 GLC=0 indexes two qwords and preserves both lanes' VDATA pairs");
+
+        const uint32_t swap_x2_glc[] = {
+            0x7e260300u, 0x7e120291u, 0x7e1402a2u,
+            0xe1406000u, 0x80000913u,
+            0xe0742000u, 0x80010900u,
+            0xbf810000u,
+        };
+        const std::vector<uint32_t> swap_x2_glc_spv = recompile_compute(
+            swap_x2_glc, std::size(swap_x2_glc), &rt_swap_x2, swap_x2_config);
+        std::vector<uint32_t> glc_results, glc_memory;
+        prosper::test::run_compute(swap_x2_glc_spv, swap_x2_dummy, 2, 2,
+                                   initial_qwords, result_seed, &glc_results, 2, &glc_memory);
+        CHECK(glc_memory == swapped_qwords &&
+                  glc_results ==
+                      std::vector<uint32_t>({0x11223344u, 0x55667788u,
+                                             0x99aabbccu, 0xddeeff00u}),
+              "swap_x2 GLC=1 returns each dynamically indexed pre-operation qword");
+
+        const uint32_t swap_x2_oob[] = {
+            0x34260081u,             // v_lshlrev_b32 v19, 1, v0 -> indices {0,2}
+            0x7e120291u, 0x7e1402a2u,
+            0xe1406000u, 0x80000913u,
+            0xe0742000u, 0x80010900u,
+            0xbf810000u,
+        };
+        const std::vector<uint32_t> swap_x2_oob_spv = recompile_compute(
+            swap_x2_oob, std::size(swap_x2_oob), &rt_swap_x2, swap_x2_config);
+        std::vector<uint32_t> oob_results, oob_memory;
+        prosper::test::run_compute(swap_x2_oob_spv, swap_x2_dummy, 2, 2,
+                                   initial_qwords, result_seed, &oob_results, 2, &oob_memory);
+        std::vector<uint32_t> one_swapped_qword = initial_qwords;
+        one_swapped_qword[0] = 17u;
+        one_swapped_qword[1] = 34u;
+        CHECK(oob_memory == one_swapped_qword &&
+                  oob_results ==
+                      std::vector<uint32_t>({0x11223344u, 0x55667788u, 0u, 0u}),
+              "swap_x2 GLC=1 returns zero and drops the complete qword at index==record_count");
+
+        const uint32_t or_x2_glc[] = {
+            0x7e260300u, 0x7e120291u, 0x7e1402a2u,
+            0xe1686000u, 0x80000913u,
+            0xe0742000u, 0x80010900u,
+            0xbf810000u,
+        };
+        const std::vector<uint32_t> or_x2_glc_spv = recompile_compute(
+            or_x2_glc, std::size(or_x2_glc), &rt_swap_x2, swap_x2_config);
+        std::vector<uint32_t> initial_or_qwords(4, 0u);
+        initial_or_qwords[0] = 1u; initial_or_qwords[1] = 2u;
+        initial_or_qwords[2] = 4u; initial_or_qwords[3] = 8u;
+        std::vector<uint32_t> or_x2_results, or_x2_memory;
+        prosper::test::run_compute(or_x2_glc_spv, swap_x2_dummy, 2, 2,
+                                   initial_or_qwords, result_seed,
+                                   &or_x2_results, 2, &or_x2_memory);
+        std::vector<uint32_t> expected_or_qwords = initial_or_qwords;
+        expected_or_qwords[0] = 17u; expected_or_qwords[1] = 34u;
+        expected_or_qwords[2] = 21u; expected_or_qwords[3] = 42u;
+        CHECK(or_x2_memory == expected_or_qwords &&
+                  or_x2_results == std::vector<uint32_t>({1u, 2u, 4u, 8u}),
+              "or_x2 performs one u64 OR per record and returns both old dwords");
+
+        // Narrow EXEC to u0>u1 after mapping VADDR to {0,2}: lane 0 is inactive/in-bounds and lane
+        // 1 is active/OOB. Restoring EXEC before the result store exposes both fallback contracts.
+        ShaderResourceTable rt_swap_x2_exec = rt_swap_x2;
+        rt_swap_x2_exec.resources[0].fetch_pc = 5;
+        rt_swap_x2_exec.resources[1].fetch_pc = 8;
+        const uint32_t swap_x2_exec[] = {
+            0x34260081u, 0x7e020280u, 0x7e120291u, 0x7e1402a2u,
+            0x7da80300u,
+            0xe1406000u, 0x80000913u,
+            0xbefe04c1u,
+            0xe0742000u, 0x80010900u,
+            0xbf810000u,
+        };
+        const std::vector<uint32_t> swap_x2_exec_spv = recompile_compute(
+            swap_x2_exec, std::size(swap_x2_exec), &rt_swap_x2_exec, swap_x2_config);
+        std::vector<uint32_t> exec_results, exec_memory;
+        prosper::test::run_compute(swap_x2_exec_spv, swap_x2_dummy, 2, 2,
+                                   initial_qwords, result_seed, &exec_results, 2, &exec_memory);
+        CHECK(exec_memory == initial_qwords &&
+                  exec_results == std::vector<uint32_t>({17u, 34u, 0u, 0u}),
+              "swap_x2 inactive in-bounds lane preserves VDATA and cannot exchange memory");
+    }
+
     // Kernel 24store (#590): integer sub-dword FORMAT store at a runtime byte address. Every lane stores
     // its gid as a Uint16 into element[gid] of a stride-2 buffer, so elements 2k and 2k+1 SHARE dword k.
     // A plain read-modify-write would race; the atomicAnd(clear field)+atomicOr(set field) of each lane's

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -8151,7 +8151,7 @@ int main() {
             partialRor8Spv, std::vector<float>(73, 0.0f), 73, 73, {},
             std::vector<uint32_t>(73, 0xdeadbeefu), &partialRor8Got);
     CHECK(!partialRor8Spv.empty() && partialRor8Got == partialRor8Expected,
-          "T25b-ror8: BC1 zero-fills missing sources in a partial final DPP16 row");
+          "T25b-ror8: FI0 zero-fills inactive sources in a partial final DPP16 row");
     const bool canExecuteNativeRor8 = subgroupT25b.size == 64 &&
         (subgroupT25b.stages & VK_SHADER_STAGE_COMPUTE_BIT) &&
         (subgroupT25b.operations & VK_SUBGROUP_FEATURE_SHUFFLE_BIT);
@@ -8302,6 +8302,63 @@ int main() {
               "T25b-ror8-family: native Wave64 executes exact V_MAX/V_MOV semantics");
     } else {
         std::printf("  [skip] T25b-ror8-family native execution: host contract unavailable\n");
+    }
+
+    // The direct native kernels above exercise emit_alu. The generic CFG dispatcher has a separate
+    // native DPP site, so keep the established irreducible prefix from kernel 17d in front of each
+    // exact GTA packet. Both kernels execute the operation after leaving the loop and write its
+    // result to a real buffer. The expected values distinguish the dispatcher's NMax arm from NMin
+    // and its MOV arm from the lane-local SRC1 placeholder used by binary operations.
+    const uint32_t codeT25bRor8MaxNativeCfg[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0x7e060d00u,                         // v_cvt_f32_u32 v3,v0
+        0x200406fau, 0xff092803u,            // exact V_MAX_F32 ROW_ROR:8
+        0x7e020302u,                         // v_mov_b32 v1,v2
+        0xe0702000u, 0x80020100u,            // buffer_store_dword v1,v0,s[8:11] idxen
+        0xbf810000u,
+    };
+    const uint32_t codeT25bRor8MovNativeCfg[] = {
+        0x7e040280u, 0x7c020300u, 0xbf860001u, 0x7e040281u,
+        0x7d840100u, 0xbf870001u, 0xbf82fffdu,
+        0x7e220d00u,                         // v_cvt_f32_u32 v17,v0
+        0x7e2402fau, 0xff092811u,            // exact V_MOV_B32 ROW_ROR:8
+        0x7e020312u,                         // v_mov_b32 v1,v18
+        0xe0702000u, 0x80020100u,            // buffer_store_dword v1,v0,s[8:11] idxen
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> nativeRor8MaxCfgSpv = recompile_compute(
+        codeT25bRor8MaxNativeCfg, std::size(codeT25bRor8MaxNativeCfg),
+        &ror8BackendTable, nativeRor8Config);
+    const std::vector<uint32_t> nativeRor8MovCfgSpv = recompile_compute(
+        codeT25bRor8MovNativeCfg, std::size(codeT25bRor8MovNativeCfg),
+        &ror8BackendTable, nativeRor8Config);
+    CHECK(!nativeRor8MaxCfgSpv.empty() && !nativeRor8MovCfgSpv.empty() &&
+              count_spirv_opcode(nativeRor8MaxCfgSpv, 345) == 2 &&
+              count_spirv_opcode(nativeRor8MovCfgSpv, 345) == 2 &&
+              count_spirv_opcode(nativeRor8MaxCfgSpv, 224) == 0 &&
+              count_spirv_opcode(nativeRor8MovCfgSpv, 224) == 0,
+          "T25b-ror8-family: native CFG dispatcher lowers exact V_MAX/V_MOV to shuffles");
+    if (canExecuteNativeRor8 && !nativeRor8MaxCfgSpv.empty() &&
+        !nativeRor8MovCfgSpv.empty()) {
+        std::vector<uint32_t> nativeCfgMaxGot, nativeCfgMovGot;
+        prosper::test::run_compute(
+            nativeRor8MaxCfgSpv, std::vector<float>(64, 0.0f), 64, 64, {},
+            std::vector<uint32_t>(64, 0xdeadbeefu), &nativeCfgMaxGot);
+        prosper::test::run_compute(
+            nativeRor8MovCfgSpv, std::vector<float>(64, 0.0f), 64, 64, {},
+            std::vector<uint32_t>(64, 0xdeadbeefu), &nativeCfgMovGot);
+        std::vector<uint32_t> nativeCfgMaxExpected(64), nativeCfgMovExpected(64);
+        for (uint32_t lane = 0; lane < 64; ++lane) {
+            nativeCfgMaxExpected[lane] = bits_of(static_cast<float>(
+                std::max(lane, lane ^ 8u)));
+            nativeCfgMovExpected[lane] = bits_of(static_cast<float>(lane ^ 8u));
+        }
+        CHECK(nativeCfgMaxGot == nativeCfgMaxExpected &&
+                  nativeCfgMovGot == nativeCfgMovExpected,
+              "T25b-ror8-family: native CFG dispatcher executes V_MAX/V_MOV semantics");
+    } else {
+        std::printf("  [skip] T25b-ror8-family native CFG execution: host contract unavailable\n");
     }
 
     const uint32_t unsupportedRor8[][2] = {
@@ -9693,7 +9750,7 @@ int main() {
     // The exact sibling regression for GTA V's V_MIN_F32 ROW_ROR:8. Whole-stream scratch sizing
     // must see the later rotate even though the first phase itself needs only one plane. Convert
     // local ID to f32 so the execution oracle is independent of subnormal flushing; in the partial
-    // final DPP16 row, BC1 supplies zero when XOR 8 names an absent padded invocation.
+    // final DPP16 row, FI=0 supplies zero when XOR 8 names an inactive padded invocation.
     std::vector<uint32_t> phasedRorScratch(
         std::begin(phasedDppScratch), std::end(phasedDppScratch));
     phasedRorScratch[5] = 0x7E020D00u;        // v_cvt_f32_u32 v1,v0

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1353,6 +1353,14 @@ int main() {
     CHECK(recompile_valu(inactive_read17d0.data(), inactive_read17d0.size(),
                          1, /*out_vgpr*/2).empty(),
           "EXEC-loop LDS reads reject when an intervening write can deactivate the lane");
+    std::vector<uint32_t> condition_read17d0(std::begin(code17d0), std::end(code17d0));
+    condition_read17d0[13] = 0xbefe0480u; // enter this loop with EXEC clear
+    condition_read17d0[14] = 0xd8d80000u; // move ds_read_b32 into the condition region
+    condition_read17d0[15] = 0x03000000u;
+    condition_read17d0[16] = 0xbf880002u; // s_cbranch_execz pc19 after the read
+    CHECK(recompile_valu(condition_read17d0.data(), condition_read17d0.size(),
+                         1, /*out_vgpr*/2).empty(),
+          "EXEC-loop LDS reads reject before the active-lane header test");
     std::vector<uint32_t> stale17d0(std::begin(code17d0), std::end(code17d0));
     stale17d0[9] = 0x7e060280u; // v_mov_b32 v3,0: no fresh EXEC condition at the latch
     CHECK(recompile_valu(stale17d0.data(), stale17d0.size(), 1, /*out_vgpr*/2).empty(),

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -3635,33 +3635,61 @@ int main() {
     // initializes six LDS bounds to infinities, atomically reduces three minima and three maxima,
     // then reads the completed box. SPIR-V 1.3 has no core float atomic min/max, so the lowering
     // must use an integer compare-exchange loop while preserving AMD MINNUM/MAXNUM semantics.
-    auto run_ds_fminmax = [&](uint32_t atomic_word0, uint32_t atomic_word1,
-                              uint32_t initial_bits,
-                              const std::vector<uint32_t>& operand_bits,
-                              const char* compile_message) {
+    auto build_ds_fminmax = [&](uint32_t atomic_word0, uint32_t atomic_word1,
+                                uint32_t initial_bits) {
         const uint32_t byte_offset = atomic_word0 & 0xffffu;
         const uint32_t data_vgpr = (atomic_word1 >> 8u) & 0xffu;
-        std::vector<uint32_t> code = {
-            0x7e000301u | (data_vgpr << 17u),    // v_mov_b32 data0, v1 (per-lane operand)
-            0x7e000f00u,                         // v_cvt_u32_f32 v0, v0 (lane index)
-            0x7e0402ffu, initial_bits,           // v_mov_b32 v2, initial_bits
-            0x7da40080u,                         // v_cmpx_eq_u32 0, v0 (lane zero initializes)
-            0x7e000280u,                         // v_mov_b32 v0, 0
-            0xd8340000u | byte_offset, 0x00000200u, // ds_write_b32 v0, v2, matching offset
-            0xbefe04c1u,                         // s_mov_b64 exec, -1
-            0x7e000280u,                         // v_mov_b32 v0, 0 (live has no pre-atomic barrier)
-            atomic_word0, atomic_word1,          // exact live vaddr/data0 fields
+        std::array<uint32_t, 6> initial = {
+            0x7f800000u, 0x7f800000u, 0x7f800000u,
+            0xff800000u, 0xff800000u, 0xff800000u,
+        };
+        initial[byte_offset / 4u] = initial_bits;
+        std::vector<uint32_t> code;
+        auto literal = [&](uint32_t vgpr, uint32_t bits) {
+            code.push_back(0x7e0002ffu | (vgpr << 17u));
+            code.push_back(bits);
+        };
+        // Neutral operands for the other five exact live atomics; overwrite the selected source
+        // from v1 before GTA's lane-zero EXEC mask narrows the initializer sequence.
+        for (uint32_t vgpr = 6; vgpr <= 8; ++vgpr) literal(vgpr, 0xff800000u);
+        for (uint32_t vgpr = 9; vgpr <= 11; ++vgpr) literal(vgpr, 0x7f800000u);
+        code.push_back(0x7e000301u | (data_vgpr << 17u)); // v_mov_b32 data0, v1
+        code.push_back(0xbefe0481u);                      // s_mov_b64 exec, 1
+        for (uint32_t vgpr = 0; vgpr < 6; ++vgpr) literal(vgpr, initial[vgpr]);
+        const uint32_t live_tail[] = {
+            0x7e180280u,                         // v_mov_b32 v12, 0
+            0xd9340010u, 0x0000040cu,            // pc63 ds_write_b64 v12, v[4:5] offset:16
+            0xdb7c0000u, 0x0000000cu,            // pc65 ds_write_b128 v12, v[0:3]
+            0xbefe04c1u,                         // pc67 s_mov_b64 exec, -1
+            0x7e000280u,                         // pc68 v_mov_b32 v0, 0
+            0xd8480000u, 0x00000900u,            // pc69/71/73 three exact DS_MIN_F32
+            0xd8480004u, 0x00000a00u,
+            0xd8480008u, 0x00000b00u,
+            0xd84c000cu, 0x00000600u,            // pc75/77/79 three exact DS_MAX_F32
+            0xd84c0010u, 0x00000700u,
+            0xd84c0014u, 0x00000800u,
             0xbf8a0000u,                         // s_barrier
             0xd8d80000u | byte_offset, 0x0a000000u, // ds_read_b32 v10, v0, matching offset
             0xbf810000u,
         };
+        code.insert(code.end(), std::begin(live_tail), std::end(live_tail));
+        return code;
+    };
+    auto run_ds_fminmax = [&](uint32_t atomic_word0, uint32_t atomic_word1,
+                              uint32_t initial_bits,
+                              const std::vector<uint32_t>& operand_bits,
+                              const char* compile_message) {
+        std::vector<uint32_t> code = build_ds_fminmax(
+            atomic_word0, atomic_word1, initial_bits);
         std::vector<uint32_t> spv = recompile_valu(
             code.data(), code.size(), 2, 10);
         CHECK(!spv.empty(), compile_message);
-        CHECK(count_spirv_opcode(spv, 230) == 1 &&
+        CHECK(count_spirv_opcode(spv, 230) == 6 &&
                   count_spirv_opcode(spv, 236) == 0 &&
                   count_spirv_opcode(spv, 237) == 0,
-              "GTA DS_MIN/MAX_F32 uses one compare-exchange loop, not integer min");
+              "GTA DS_MIN/MAX_F32 group uses six compare-exchange loops, not integer min");
+        CHECK(count_spirv_opcode(spv, 224) == 2,
+              "GTA lane-zero LDS initialization gains one publication barrier before its guest barrier");
         if (spv.empty()) return std::vector<float>{};
         std::vector<float> input(WG * 2u);
         for (uint32_t lane = 0; lane < WG; ++lane) {
@@ -3711,6 +3739,33 @@ int main() {
     CHECK(all_bits_are(got32c_fmin_nan, 0x7fe12345u),
           "GTA DS_MIN_F32 quiets and preserves the resident payload when both operands are NaN");
 
+    // GTA reaches this publication point after a completed two-edge loop. Prove the synthesized
+    // barrier remains top-level through that control-flow route as well as the straight-line
+    // execution arms above; neither edge crosses the initializer/atomic boundary.
+    const uint32_t pre_atomic_loop[] = {
+        0xb0020005u, 0xbe800380u, 0x7e020280u, 0xbf0a0200u,
+        0xbf840003u, 0x4a020200u, 0x81008100u, 0xbf82fffbu,
+    };
+    std::vector<uint32_t> looped_ds_fmin = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    looped_ds_fmin.insert(
+        looped_ds_fmin.begin(), std::begin(pre_atomic_loop), std::end(pre_atomic_loop));
+    const std::vector<uint32_t> looped_ds_fmin_spv = recompile_valu(
+        looped_ds_fmin.data(), looped_ds_fmin.size(), 2, 10);
+    CHECK(!looped_ds_fmin_spv.empty() && count_spirv_opcode(looped_ds_fmin_spv, 224) == 2,
+          "GTA-style completed pre-atomic loop retains a top-level LDS publication barrier");
+    std::vector<uint32_t> skipped_ds_fmin_barrier = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    const auto first_fmin = std::find(
+        skipped_ds_fmin_barrier.begin(), skipped_ds_fmin_barrier.end(), 0xd8480000u);
+    const uint32_t first_fmin_pc = static_cast<uint32_t>(
+        std::distance(skipped_ds_fmin_barrier.begin(), first_fmin));
+    skipped_ds_fmin_barrier.insert(
+        skipped_ds_fmin_barrier.begin(), 0xbf840000u | first_fmin_pc);
+    CHECK(recompile_valu(
+              skipped_ds_fmin_barrier.data(), skipped_ds_fmin_barrier.size(), 2, 10).empty(),
+          "branch that skips the LDS publication boundary remains rejected");
+
     // Encoding boundaries: the live opcode is LDS-only and has no DATA1/VDST operand. These two
     // one-bit mutations perturb that exact production packet and must remain fail-visible.
     const uint32_t bad_ds_fmin_gds[] = {
@@ -3723,6 +3778,22 @@ int main() {
           "GTA DS_MIN_F32 GDS mutation remains rejected");
     CHECK(recompile_valu(bad_ds_fmin_data1, std::size(bad_ds_fmin_data1), 10, 0).empty(),
           "GTA DS_MIN_F32 reserved DATA1 mutation remains rejected");
+    std::vector<uint32_t> bad_ds_fmin_restore = build_ds_fminmax(
+        0xd8480000u, 0x00000900u, 0x7f800000u);
+    auto restore = std::find(
+        bad_ds_fmin_restore.begin(), bad_ds_fmin_restore.end(), 0xbefe04c1u);
+    CHECK(restore != bad_ds_fmin_restore.end(),
+          "GTA LDS initializer regression contains the exact full-EXEC restore");
+    if (restore != bad_ds_fmin_restore.end()) *restore ^= 1u;
+    CHECK(recompile_valu(bad_ds_fmin_restore.data(), bad_ds_fmin_restore.size(), 2, 10).empty(),
+          "GTA LDS initializer restore mutation cannot bypass the publication proof");
+    const uint32_t unproved_ds_fmin_store[] = {
+        0x7e000280u, 0x7e0402ffu, 0x7f800000u,
+        0xd8340000u, 0x00000200u,
+        0xd8480000u, 0x00000900u, 0xbf810000u,
+    };
+    CHECK(recompile_valu(unproved_ds_fmin_store, std::size(unproved_ds_fmin_store), 10, 0).empty(),
+          "ordinary LDS store before DS_MIN_F32 stays rejected without a uniform publication proof");
 
     // Plucky Squire's first-gameplay compute shaders use the non-returning DS_OR_B32 form. Seed an
     // LDS dword with 4, OR in 3 using the exact opcode-0x0a encoding, then read back 7.

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -1291,8 +1291,11 @@ int main() {
     // loop when it saw the bottom `s_cbranch_execnz`, then misread the inner back-edge as a backward
     // else. Keep a workgroup barrier immediately AFTER the outer loop: it makes the generic CFG
     // dispatcher unavailable, while every invocation has reconverged and may legally reach it.
-    // The inner loop executes once, clears EXEC, and exits on its second header check; the outer
-    // body restores EXEC, writes 7, clears EXEC again, and falls through its bottom test.
+    // The two read-only LDS loops after that barrier reproduce the surrounding captured context:
+    // the old all-or-nothing compute guard discarded EVERY recognized loop when it found either
+    // DS_READ_B32, then misclassified the earlier inner back-edge as a backward else. The inner loop
+    // executes once, clears EXEC, and exits on its second header check; the outer body restores EXEC,
+    // writes 7, clears EXEC again, and falls through its bottom test.
     const uint32_t code17d0[] = {
         0xbe82047eu,              // s_mov_b64 s[2:3],exec
         0x7e040280u,              // v_mov_b32 v2,0
@@ -1307,6 +1310,18 @@ int main() {
         0xbf89fff7u,              // s_cbranch_execnz pc2
         0xbefe0402u,              // s_mov_b64 exec,s[2:3]
         0xbf8a0000u,              // s_barrier after reconvergence
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
+        0xbf880004u,              // READ0: s_cbranch_execz pc19
+        0xd8d80000u, 0x03000000u, // ds_read_b32 v3,v0
+        0xbefe0480u,              // s_mov_b64 exec,0
+        0xbf82fffbu,              // s_branch READ0
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
+        0xbf880004u,              // READ1: s_cbranch_execz pc26
+        0xd8d80000u, 0x04000000u, // ds_read_b32 v4,v0
+        0xbefe0480u,              // s_mov_b64 exec,0
+        0xbf82fffbu,              // s_branch READ1
+        0xbefe0402u,              // s_mov_b64 exec,s[2:3]
         0x7e040d02u,              // v_cvt_f32_u32 v2,v2
         0xbf810000u,
     };
@@ -1319,6 +1334,17 @@ int main() {
         : prosper::test::run_compute(spv17d0, std::vector<float>(N, 0.0f), N, N);
     CHECK(got17d0 == std::vector<float>(N, 7.0f),
           "bottom-tested EXEC loop preserves its exit-iteration value and reconverges");
+    std::vector<uint32_t> late_barrier17d0(std::begin(code17d0), std::end(code17d0));
+    late_barrier17d0[12] = 0xbf800000u; // s_nop 0: reads no longer have a preceding phase boundary
+    late_barrier17d0.insert(late_barrier17d0.end() - 2, 0xbf8a0000u);
+    CHECK(recompile_valu(late_barrier17d0.data(), late_barrier17d0.size(),
+                         1, /*out_vgpr*/2).empty(),
+          "EXEC-loop LDS reads reject when the proved barrier follows their phase");
+    std::vector<uint32_t> write17d0(std::begin(code17d0), std::end(code17d0));
+    write17d0[15] = 0xd8340000u; // ds_write_b32 v0,v3 in the post-barrier loop
+    write17d0[16] = 0x00000300u;
+    CHECK(recompile_valu(write17d0.data(), write17d0.size(), 1, /*out_vgpr*/2).empty(),
+          "EXEC-loop LDS writes remain rejected even after a proved barrier");
     std::vector<uint32_t> stale17d0(std::begin(code17d0), std::end(code17d0));
     stale17d0[9] = 0x7e060280u; // v_mov_b32 v3,0: no fresh EXEC condition at the latch
     CHECK(recompile_valu(stale17d0.data(), stale17d0.size(), 1, /*out_vgpr*/2).empty(),

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -9492,6 +9492,43 @@ int main() {
     CHECK(phasedDppResult.size() == kPartialLaunch && phasedDppBad == 0,
           "#2481: later portable DPP phase produces exact rows and preserves padded canaries");
 
+    // The exact sibling regression for GTA V's V_MIN_F32 ROW_ROR:8. Whole-stream scratch sizing
+    // must see the later rotate even though the first phase itself needs only one plane. Convert
+    // local ID to f32 so the execution oracle is independent of subnormal flushing; in the partial
+    // final DPP16 row, BC1 supplies zero when XOR 8 names an absent padded invocation.
+    std::vector<uint32_t> phasedRorScratch(
+        std::begin(phasedDppScratch), std::end(phasedDppScratch));
+    phasedRorScratch[5] = 0x7E020D00u;        // v_cvt_f32_u32 v1,v0
+    phasedRorScratch[12] = 0x1E0202FAu;       // v_min_f32_dpp v1,v1,v1
+    phasedRorScratch[13] = 0xFF092801u;       //   row_ror:8 BC:1
+    const std::vector<uint32_t> phasedRorSpv = recompile_compute(
+        phasedRorScratch.data(), phasedRorScratch.size(), &partialBarrierTable,
+        partialBarrierConfig);
+    CHECK(!phasedRorSpv.empty() &&
+              spirv_has_array_length(phasedRorSpv, kPhasedDppScratchDwords),
+          "#2481: phased portable ROW_ROR pre-sizes both scratch planes");
+    std::vector<uint32_t> phasedRorInitial(kPartialLaunch, kPartialCanary), phasedRorResult;
+    if (!phasedRorSpv.empty())
+        prosper::test::run_compute(
+            phasedRorSpv, std::vector<float>(1, 0.0f), kPartialThreads, 1,
+            {}, phasedRorInitial, &phasedRorResult, 256);
+    uint32_t phasedRorBad = 0;
+    for (uint32_t lane = 0; lane < phasedRorResult.size(); ++lane) {
+        uint32_t expected = kPartialCanary;
+        if (lane < kPartialThreads) {
+            const uint32_t groupBase = lane & ~255u;
+            const uint32_t local = lane & 255u;
+            const uint32_t source = (local & ~15u) | ((local & 15u) ^ 8u);
+            const uint32_t activeInGroup = std::min(256u, kPartialThreads - groupBase);
+            const float result = source < activeInGroup
+                ? static_cast<float>(std::min(local, source)) : 0.0f;
+            expected = bits_of(result);
+        }
+        phasedRorBad += phasedRorResult[lane] != expected;
+    }
+    CHECK(phasedRorResult.size() == kPartialLaunch && phasedRorBad == 0,
+          "#2481: phased ROW_ROR executes full rows, BC1 partial rows, and padded canaries");
+
     // #2396: a CFG-dispatcher attempt that fails PART WAY THROUGH must not leave its half-written
     // dispatcher in the module. emit_cfg_state_machine writes the dispatcher loop's OpLoopMerge,
     // its OpSelectionMerge and the OpSwitch before it emits the per-case bodies, so a reject inside

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -7902,6 +7902,99 @@ int main() {
         std::printf("  [skip] T25b execution: host lacks compute subgroup shuffle support\n");
     }
 
+    // T25b-ror8 (#2481): GTA V's two screen-space compute programs use the exact full-mask,
+    // bounded V_MIN_F32 ROW_ROR:8 packets below. A rotate by eight exchanges the two halves of
+    // every DPP16 row, transforms SRC0 only, and leaves SRC1 in the destination lane.
+    const uint32_t codeT25bRor8[] = {
+        0x1e0000fau, 0xff092800u,             // exact live v_min_f32_dpp v0,v0,v0 row_ror:8 BC:1
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT25bRor8 = recompile_valu(
+        codeT25bRor8, std::size(codeT25bRor8), 1, 0);
+    CHECK(!spvT25bRor8.empty(),
+          "recompiled T25b-ror8 (GTA V exact V_MIN_F32 ROW_ROR:8) -> SPIR-V");
+    CHECK(compute_spirv_min_subgroup_size(spvT25bRor8) == 16,
+          "T25b-ror8: row rotate advertises its 16-lane host contract");
+
+    const uint32_t codeT25bRor8Distinct[] = {
+        0x1e0402fau, 0xff092800u,             // v_min_f32_dpp v2,v0,v1 row_ror:8 BC:1
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT25bRor8Distinct = recompile_valu(
+        codeT25bRor8Distinct, std::size(codeT25bRor8Distinct), 3, 2);
+    CHECK(!spvT25bRor8Distinct.empty(),
+          "T25b-ror8: distinct VDST/SRC0/SRC1 form recompiles");
+
+    // The second exact live packet executes under narrowed EXEC. Lanes 0..7 of each row are
+    // destinations whose rotated sources (lanes 8..15) are inactive. FI=0 makes those sources
+    // invalid and BOUND_CTRL=1 substitutes zero; inactive destinations independently preserve v2.
+    const uint32_t codeT25bRor8Exec[] = {
+        0x7da80300u,                         // v_cmpx_gt_u32 vcc,v0,v1
+        0x1e0404fau, 0xff092802u,            // exact live v_min_f32_dpp v2,v2,v2 row_ror:8 BC:1
+        0xbefe04c1u,                         // s_mov_b64 exec,-1
+        0xbf810000u,
+    };
+    const std::vector<uint32_t> spvT25bRor8Exec = recompile_valu(
+        codeT25bRor8Exec, std::size(codeT25bRor8Exec), 3, 2);
+    CHECK(!spvT25bRor8Exec.empty(),
+          "T25b-ror8: exact live v2 packet recompiles with narrowed EXEC");
+
+    if (can_shuffleT25b && subgroupT25b.size >= 16 &&
+        !spvT25bRor8.empty() && !spvT25bRor8Distinct.empty() &&
+        !spvT25bRor8Exec.empty()) {
+        std::vector<float> inRor8(128), expectedRor8(128);
+        std::vector<float> inRor8Distinct(128 * 3), expectedRor8Distinct(128);
+        std::vector<float> inRor8Exec(128 * 3), expectedRor8Exec(128);
+        for (uint32_t i = 0; i < 128; ++i) {
+            const uint32_t source = (i & ~15u) | ((i & 15u) ^ 8u);
+            inRor8[i] = static_cast<float>(100u + i);
+
+            inRor8Distinct[i * 3] = static_cast<float>(400u + i);
+            inRor8Distinct[i * 3 + 1] = (i & 1u) ? 50.0f : 1000.0f;
+
+            const uint32_t control = (i & 15u) < 8u ? 0xffffffffu : 0u;
+            const uint32_t threshold = 1u;
+            std::memcpy(&inRor8Exec[i * 3], &control, sizeof(control));
+            std::memcpy(&inRor8Exec[i * 3 + 1], &threshold, sizeof(threshold));
+            inRor8Exec[i * 3 + 2] = static_cast<float>(200u + i);
+
+            expectedRor8[i] = std::min(
+                static_cast<float>(100u + source), inRor8[i]);
+            expectedRor8Distinct[i] = std::min(
+                static_cast<float>(400u + source), inRor8Distinct[i * 3 + 1]);
+            expectedRor8Exec[i] = (i & 15u) < 8u ? 0.0f : inRor8Exec[i * 3 + 2];
+        }
+        const std::vector<float> gotRor8 = prosper::test::run_compute(
+            spvT25bRor8, inRor8, 128, 128);
+        const std::vector<float> gotRor8Distinct = prosper::test::run_compute(
+            spvT25bRor8Distinct, inRor8Distinct, 128, 128);
+        const std::vector<float> gotRor8Exec = prosper::test::run_compute(
+            spvT25bRor8Exec, inRor8Exec, 128, 128);
+        CHECK(gotRor8 == expectedRor8,
+              "T25b-ror8: exact packet rotates within each DPP16 row before V_MIN_F32");
+        CHECK(gotRor8Distinct == expectedRor8Distinct,
+              "T25b-ror8: DPP transforms SRC0 while SRC1 stays in the current lane");
+        CHECK(gotRor8Exec == expectedRor8Exec,
+              "T25b-ror8: BC1 source invalidation and destination EXEC are independent");
+    } else {
+        std::printf("  [skip] T25b-ror8 execution: host subgroup %u is narrower than 16\n",
+                    subgroupT25b.size);
+    }
+
+    const uint32_t unsupportedRor8[][2] = {
+        {0x1e0000fau, 0xff012800u},           // V_MIN_F32 BOUND_CTRL=0
+        {0x1e0000fau, 0xff092900u},           // V_MIN_F32 ROW_ROR:9
+        {0x1e0000fau, 0xef092800u},           // partial ROW_MASK
+        {0x1e0000fau, 0xff192800u},           // source modifier
+        {0x200000fau, 0xff092800u},           // V_MAX_F32
+        {0x7e0002fau, 0xff092800u},           // V_MOV_B32
+    };
+    for (const auto& unsupported : unsupportedRor8) {
+        const uint32_t code[] = {unsupported[0], unsupported[1], 0xbf810000u};
+        CHECK(recompile_valu(code, std::size(code), 1, 0).empty(),
+              "T25b-ror8: unsupported controls/opcodes remain fail-visible");
+    }
+
     // T25c (#1390): Plucky's second gameplay dispatch converts a permuted float after arbitrary
     // quad tables (not merely XOR swaps). Exercise its exact 0xee control: [2,3,2,3].
     const uint32_t codeT25c[] = {

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1231,6 +1231,10 @@ int main() {
     bvh_table.resources[0].bvh_box_grow = 0;
     const auto bvh_grow_0_again = recompile_compute_shader_cached(
         kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    bvh_table.resources[0].bvh_sort_enabled = true;
+    const auto sorted_bvh = recompile_compute_shader_cached(
+        kBvhCompute, std::size(kBvhCompute), &bvh_table, bvh_config);
+    bvh_table.resources[0].bvh_sort_enabled = false;
     alignas(256) static uint32_t null_bvh_words[64] = {};
     bvh_table.resources[0].size = sizeof(null_bvh_words);
     bvh_table.resources[0].host_data = reinterpret_cast<uint8_t*>(null_bvh_words);
@@ -1245,10 +1249,11 @@ int main() {
     stats = shader_recompile_cache_stats();
     CHECK(!bvh_grow_0.empty() && !bvh_grow_6.empty() &&
               bvh_grow_0 != bvh_grow_6 && bvh_grow_0_again == bvh_grow_0 &&
+              !sorted_bvh.empty() && sorted_bvh != bvh_grow_0 &&
               !guarded_null_bvh.empty() && guarded_null_bvh != bvh_grow_0 &&
               bvh_grow_0_after_null == bvh_grow_0 &&
-              stats.misses == 3 && stats.hits == 2 && stats.entries == 3,
-          "compute cache separates BVH box growth and guarded-null lowering");
+              stats.misses == 4 && stats.hits == 2 && stats.entries == 4,
+          "compute cache separates BVH box growth, sorting, and guarded-null lowering");
 
     // Manual shadow comparison bakes the enable, compare op, filter mode, address modes, and border
     // color into SPIR-V. In particular depth_compare=false must not reuse a previously successful

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1205,6 +1205,85 @@ int main() {
               stats.misses == 2 && stats.hits == 1 && stats.entries == 2,
           "compute cache separates image-atomic modules with different embedded extents");
 
+    // Qword-atomic code generation depends on the enabled device feature, exact linear descriptor
+    // proof, and dispatch-sized record count embedded in the OOB check. All three must partition the
+    // cache so one dispatch cannot lend its module or bound to a different/unproved sibling.
+    clear_shader_recompile_cache();
+    static const uint32_t kSwapX2Compute[] = {
+        0xe1402000u, 0x80000900u,
+        0xbf810000u,
+    };
+    alignas(8) uint32_t swap_x2_words[50] = {};
+    ShaderResource swap_x2_resource;
+    swap_x2_resource.cls = ResourceClass::ConstantBuffer;
+    swap_x2_resource.format = DataFormat::Uint32;
+    swap_x2_resource.num_components = 1;
+    swap_x2_resource.binding = 2;
+    swap_x2_resource.gpu_addr = reinterpret_cast<uint64_t>(swap_x2_words);
+    swap_x2_resource.size = 200;
+    swap_x2_resource.stride = 8;
+    swap_x2_resource.sgpr_base = 0;
+    swap_x2_resource.fetch_pc = 0;
+    swap_x2_resource.atomic_x2_record_count = 25;
+    ShaderResourceTable swap_x2_table;
+    swap_x2_table.resources.push_back(swap_x2_resource);
+    ComputeShaderConfig swap_x2_config;
+    swap_x2_config.local_x = 1;
+    swap_x2_config.storage_buffer_int64_atomics = true;
+    const auto swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute), &swap_x2_table, swap_x2_config);
+    ShaderResourceTable two_record_swap_x2_table = swap_x2_table;
+    two_record_swap_x2_table.resources[0].size = 16;
+    two_record_swap_x2_table.resources[0].atomic_x2_record_count = 2;
+    const auto two_record_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &two_record_swap_x2_table, swap_x2_config);
+    ShaderResourceTable oversized_swap_x2_table = swap_x2_table;
+    oversized_swap_x2_table.resources[0].size = 0x10000008u;
+    oversized_swap_x2_table.resources[0].atomic_x2_record_count = 0x02000001u;
+    const auto oversized_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &oversized_swap_x2_table, swap_x2_config);
+    // These retain the opaque marker but violate separate resource-side emitter gates. They run
+    // immediately after the valid warm entry: if the cache keys only the marker, each silently
+    // borrows that module without reaching the gate it mutated.
+    ShaderResourceTable wrong_size_swap_x2_table = swap_x2_table;
+    wrong_size_swap_x2_table.resources[0].size = 198;
+    const auto wrong_size_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &wrong_size_swap_x2_table, swap_x2_config);
+    ShaderResourceTable misaligned_swap_x2_table = swap_x2_table;
+    misaligned_swap_x2_table.resources[0].gpu_addr += 4;
+    const auto misaligned_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &misaligned_swap_x2_table, swap_x2_config);
+    ShaderResourceTable indexed_swap_x2_table = swap_x2_table;
+    indexed_swap_x2_table.resources[0].table_index_count = 1;
+    const auto indexed_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &indexed_swap_x2_table, swap_x2_config);
+    ComputeShaderConfig no_int64_atomic = swap_x2_config;
+    no_int64_atomic.storage_buffer_int64_atomics = false;
+    const auto unsupported_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute), &swap_x2_table, no_int64_atomic);
+    ShaderResourceTable unproved_swap_x2_table = swap_x2_table;
+    unproved_swap_x2_table.resources[0].atomic_x2_record_count = 0;
+    const auto unproved_swap_x2 = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute), &unproved_swap_x2_table, swap_x2_config);
+    const auto swap_x2_again = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute), &swap_x2_table, swap_x2_config);
+    const auto two_record_swap_x2_again = recompile_compute_shader_cached(
+        kSwapX2Compute, std::size(kSwapX2Compute),
+        &two_record_swap_x2_table, swap_x2_config);
+    stats = shader_recompile_cache_stats();
+    CHECK(!swap_x2.empty() && !two_record_swap_x2.empty() && oversized_swap_x2.empty() &&
+              swap_x2 != two_record_swap_x2 && wrong_size_swap_x2.empty() &&
+              misaligned_swap_x2.empty() && indexed_swap_x2.empty() &&
+              unsupported_swap_x2.empty() && unproved_swap_x2.empty() &&
+              swap_x2_again == swap_x2 && two_record_swap_x2_again == two_record_swap_x2 &&
+              stats.misses == 4 && stats.hits == 6 && stats.entries == 4,
+          "swap_x2 cache separates record count, capability, and every admission gate");
+
     // BVH BOX_GROW is embedded as the slab-test far-edge multiplier. A descriptor change must
     // compile a distinct module even when the BVH allocation and instruction provenance match.
     clear_shader_recompile_cache();

--- a/prosper/tools/gpu_replay/compute_recompile.hpp
+++ b/prosper/tools/gpu_replay/compute_recompile.hpp
@@ -55,6 +55,8 @@ inline bool recompile_captured_compute(
             replay_device->storage_image_write_without_format;
         config.native_storage_format_support = adoptable
             ? replay_device->native_storage_format_support : 0;
+        config.storage_buffer_int64_atomics = adoptable &&
+            replay_device->storage_buffer_int64_atomics;
         const bool native_multiwave = force_native_multiwave ||
             gpu::compute_shader_prefers_native_multiwave(
                 raw.words.data(), raw.words.size(), diagnostic);

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -425,10 +425,17 @@ int main(int argc, char** argv) {
       dump(dir, "compute_lds", recompile_valu(c, sizeof(c)/4, 1, 0)); }
     // GTA V exec_cs_413ced900 pc69: exact DS_MIN_F32 fields. Strictly validate the core-SPIR-V
     // compare-exchange loop used in place of an unavailable portable float atomic min.
-    { const uint32_t c[] = {0x7e000280u, 0x7e120301u,
-                            0xd8340000u, 0x00000900u,
+    { const uint32_t c[] = {0xbefe0481u, 0x7e180280u,
+                            0xd9340010u, 0x0000040cu,
+                            0xdb7c0000u, 0x0000000cu,
+                            0xbefe04c1u, 0x7e000280u,
                             0xd8480000u, 0x00000900u,
-                            0xd8d80000u, 0x00000000u, 0xbf810000u};
+                            0xd8480004u, 0x00000a00u,
+                            0xd8480008u, 0x00000b00u,
+                            0xd84c000cu, 0x00000600u,
+                            0xd84c0010u, 0x00000700u,
+                            0xd84c0014u, 0x00000800u,
+                            0xbf8a0000u, 0xd8d80000u, 0x00000000u, 0xbf810000u};
       dump(dir, "compute_ds_min_f32", recompile_valu(c, std::size(c), 2, 0)); }
     // Compute MUBUF store (buffer_store_format_x).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0xe0102000u,0x80020302u,0xbf810000u};

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -120,6 +120,7 @@ static const NotAnEmitter kNotEmitters[] = {
     {"safe_execz_branches_for_test", "returns a transformed RDNA2 instruction stream, not SPIR-V"},
     {"structured_execz_branches_for_test", "returns analyzed RDNA2 branch PCs, not SPIR-V"},
     {"mask_test_branches_for_test",  "returns a transformed RDNA2 instruction stream, not SPIR-V"},
+    {"cselect_b64_low_only_pcs_for_test", "returns CFG-proven instruction PCs, not SPIR-V"},
     {"recompile_graphics_shader_cached",
      "caching wrapper; ctest shader_recompile_cache asserts its words are byte-identical to the "
      "direct emitter, which is validated here"},

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -461,6 +461,23 @@ int main(int argc, char** argv) {
       ShaderResource poll=publish; poll.binding=6; poll.fetch_pc=6; rt.resources.push_back(poll);
       ComputeShaderConfig cfg; cfg.local_x=64; cfg.wave_size=64;
       dump(dir, "compute_coherent_alias", recompile_compute(c, sizeof(c)/4, &rt, cfg)); }
+    // GTA V's exact qword-atomic resource uses same-binding u32/u64 aliased Block variables. Validate
+    // both RMW opcodes strictly: driver acceptance alone does not prove the duplicate binding, u64
+    // AccessChain, capability, or atomic result type is legal Vulkan SPIR-V.
+    { const uint32_t swap[] = {0xe0302000u,0x80000013u,
+                               0xe1402000u,0x80000913u,0xbf810000u};
+      const uint32_t bit_or[] = {0xe0302000u,0x80000013u,
+                                 0xe1686000u,0x80000913u,0xbf810000u};
+      ShaderResourceTable rt; ShaderResource atomic{};
+      atomic.cls=ResourceClass::ConstantBuffer; atomic.format=DataFormat::Uint32;
+      atomic.num_components=1; atomic.binding=2; atomic.gpu_addr=0x2000;
+      atomic.size=200; atomic.stride=8; atomic.sgpr_base=0; atomic.fetch_pc=2;
+      atomic.atomic_x2_record_count=25; rt.resources.push_back(atomic);
+      ComputeShaderConfig cfg; cfg.local_x=1; cfg.storage_buffer_int64_atomics=true;
+      dump(dir, "compute_atomic_swap_x2",
+           recompile_compute(swap, std::size(swap), &rt, cfg));
+      dump(dir, "compute_atomic_or_x2",
+           recompile_compute(bit_or, std::size(bit_or), &rt, cfg)); }
     // Astro Bot exact raw buffer_store_dwordx3 packet.
     { const uint32_t c[] = {0x7e140f00u,0x7e060281u,0x7e080282u,0x7e0a0283u,
                             0xe07c2000u,0x8004030au,0xbf810000u};

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -423,6 +423,13 @@ int main(int argc, char** argv) {
     { const uint32_t c[] = {0x7e020f00u,0x34040282u,0x34060281u,0x4a060681u,0xd8340000u,0x00000302u,0xbf8a0000u,
                             0x4c0a02bfu,0x340c0a82u,0xd8d80000u,0x07000006u,0x7e000d07u,0xbf810000u};
       dump(dir, "compute_lds", recompile_valu(c, sizeof(c)/4, 1, 0)); }
+    // GTA V exec_cs_413ced900 pc69: exact DS_MIN_F32 fields. Strictly validate the core-SPIR-V
+    // compare-exchange loop used in place of an unavailable portable float atomic min.
+    { const uint32_t c[] = {0x7e000280u, 0x7e120301u,
+                            0xd8340000u, 0x00000900u,
+                            0xd8480000u, 0x00000900u,
+                            0xd8d80000u, 0x00000000u, 0xbf810000u};
+      dump(dir, "compute_ds_min_f32", recompile_valu(c, std::size(c), 2, 0)); }
     // Compute MUBUF store (buffer_store_format_x).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0xe0102000u,0x80020302u,0xbf810000u};
       ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer; vb.format=DataFormat::Float32;

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -435,7 +435,11 @@ int main(int argc, char** argv) {
                             0xd84c000cu, 0x00000600u,
                             0xd84c0010u, 0x00000700u,
                             0xd84c0014u, 0x00000800u,
-                            0xbf8a0000u, 0xd8d80000u, 0x00000000u, 0xbf810000u};
+                            0xbefe0481u,                         // pc81 exec = lane zero
+                            0x7e080280u,                         // pc82 v4 = byte address zero
+                            0xdbfc0000u, 0x00000004u,            // pc83 ds_read_b128 v[0:3], v4
+                            0xd9d80010u, 0x04000004u,            // pc85 ds_read_b64 v[4:5], v4
+                            0xbf8cc17fu, 0xbf810000u};           // wait; end (no guest barrier)
       dump(dir, "compute_ds_min_f32", recompile_valu(c, std::size(c), 2, 0)); }
     // Compute MUBUF store (buffer_store_format_x).
     { const uint32_t c[] = {0x7e040f00u,0x06060100u,0xe0102000u,0x80020302u,0xbf810000u};


### PR DESCRIPTION
## Summary

Advance GTA V's compute workload past a coherent set of RDNA2 recompiler blockers encountered on the route to gameplay:

- lower the exact scalar/vector ALU forms used for scratch setup, 64-bit shifts, RPI conversion, DPP row rotation, dynamic writelane, scalar pair selects, and Wave32/Wave64 VCC scratch
- preserve and prove GTA V descriptor semantics for sorted BVH traversal, null header chains, zero-record loads, and dynamic qword record counts
- structure the captured bottom-tested EXEC/LDS loops and lower the float LDS atomic gather with synchronization and active-lane proofs
- lower exact stride-8 `BUFFER_ATOMIC_SWAP_X2`/`BUFFER_ATOMIC_OR_X2` packets as predicated Vulkan `u64` atomics, gated by the device feature contract
- persist new replay-critical semantics through capture versions 48/49 and partition shader cache identity accordingly

## Why

These were terminal gaps in GTA V's compute shaders at gameplay entry. The central issue was not one missing opcode: exact instruction forms, mask/data-domain lifetime, CFG structure, resource provenance, replay state, and synchronization all had to agree. Each admission remains narrowly fail-closed when its packet, descriptor, wave contract, or dominance proof differs.

The latest live run has zero terminal failures or dispatch skips for qword-atomic program `0x413e15400`, including dispatches with 1, 2, 3, and 25 records. GTA V reaches gameplay without device loss, but the world remains black; the next dominant family is Wave64 ambiguous-mask handling and work continues in #2481.

## Validation

- `ctest --no-tests=error -j4`: **232/232 passed** in the project distrobox
- strict SPIR-V validation and real Vulkan execution coverage
- capture round-trip/backward-compatibility and shader-cache partition coverage
- exact-site mutation arms for production discovery, CFG, cache, capture, and emitter paths
- independent code review throughout; the immutable head received a final no-findings review and an independent focused **6/6** test pass
- 200-second routed GTA V validation: no device loss and no terminal reject for the qword-atomic target

Tracking: #2481
