### PR TITLE
recompiler: preserve GTA Wave64 scalar mask words

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4128,6 +4128,17 @@ inline bool vop3b_fresh_carry_output(const Rdna2Inst& in) {
            (in.opcode == 0x30f || in.opcode == 0x310 || in.opcode == 0x319);
 }
 
+// Decoder storage has an SDST-shaped field on every VOP3 packet, but only this exact VOP3B
+// inventory architecturally writes it. VOP3A lane operations use `dst` for their scalar result;
+// treating their overlapping bits as a second destination invents a mask write (notably for GTA's
+// v_readlane reconstruction of VCC_LO/HI).
+inline bool vop3_writes_mask_sdst(const Rdna2Inst& in) {
+    return in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR &&
+           ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
+            in.opcode == 0x16d || in.opcode == 0x16e || in.opcode == 0x176 ||
+            in.opcode == 0x177 || vop3b_fresh_carry_output(in));
+}
+
 std::unordered_set<uint32_t> safe_execz_branches(const std::vector<Rdna2Inst>& ins) {
     std::unordered_set<uint32_t> safe;
     // pc of the terminating s_endpgm — a forward execz whose target is here skips straight to the end.
@@ -4328,7 +4339,7 @@ std::unordered_set<uint32_t> mask_test_branches(const std::vector<Rdna2Inst>& in
         if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
             in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
             erase_written_words(in.dst.value, 1);
-        if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
+        if (vop3_writes_mask_sdst(in))
             erase_written_words(in.sdst.value,
                 ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
                  vop3b_fresh_carry_output(in)) ? 1u : 2u);
@@ -5455,7 +5466,7 @@ void for_each_scalar_write(const Rdna2Inst& in, Visitor&& visit,
     if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
         in.dst.kind == OperandKind::SGPR && in.dst.value <= 105)
         visit(in.dst.value, wave32_one_word_masks ? 1u : 2u);
-    if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR)
+    if (vop3_writes_mask_sdst(in))
         visit(in.sdst.value, wave32_one_word_masks &&
                               ((in.opcode >= 0x128 && in.opcode <= 0x12a) ||
                                vop3b_fresh_carry_output(in)) ? 1u : 2u);
@@ -5996,8 +6007,7 @@ bool scalar_write_is_b64_mask(const Rdna2Inst& in, int base) {
     if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
         in.dst.kind == OperandKind::SGPR && in.dst.value == base && base <= 105)
         return true;
-    return in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR &&
-           in.sdst.value == base;
+    return vop3_writes_mask_sdst(in) && in.sdst.value == base;
 }
 
 // GTA V's Wave32 post-process kernel selects one scalar dword directly into VCC_LO, then uses
@@ -6046,10 +6056,9 @@ void record_scalar_write(RegState& rs, const Rdna2Inst& in,
             invalidate_mask_pair(in.dst.value);
         }
     }
-    const bool vop3_b32_mask = in.fmt == Rdna2Format::VOP3 &&
-        in.sdst.kind == OperandKind::SGPR &&
+    const bool vop3_b32_mask = vop3_writes_mask_sdst(in) &&
         rs.sreg_bool_b32.contains(in.sdst.value);
-    if (in.fmt == Rdna2Format::VOP3 && in.sdst.kind == OperandKind::SGPR) {
+    if (vop3_writes_mask_sdst(in)) {
         if (vop3_b32_mask) {
             rs.sreg.erase(in.sdst.value);
             rs.sreg_srt.erase(in.sdst.value);
@@ -6267,7 +6276,20 @@ uint32_t operand_bits(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, const 
             auto it = rs.sreg.find(o.value);
             if (it != rs.sreg.end()) return it->second;
             auto input = rs.sreg_input.find(o.value);
-            return input == rs.sreg_input.end() ? b.uconst(0) : input->second;
+            if (input != rs.sreg_input.end()) return input->second;
+            // A persisted B64 wave mask has no ordinary scalar dword unless the transfer proof
+            // retained that word explicitly. Reject a data-domain read of either physical half;
+            // returning the generic unwritten-SGPR zero here would silently replace live ballot
+            // bits after a CFG-dispatcher reload. Bool-domain consumers bypass operand_bits.
+            const auto is_b64_mask_base = [&](int base) {
+                return rs.sreg_bool.contains(base) &&
+                       !rs.sreg_bool_b32.contains(base);
+            };
+            if (is_b64_mask_base(o.value) ||
+                (o.value > 0 && is_b64_mask_base(o.value - 1))) {
+                if (ok) *ok = false;
+            }
+            return b.uconst(0);
         }
         case OperandKind::InlineInt:   return b.uconst((uint32_t)o.value);
         case OperandKind::InlineFloat: return b.uconst(fbits(inline_float_value((uint32_t)o.value)));
@@ -7091,14 +7113,28 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         bool data_copied = false;
                         if (in.src[0].kind == OperandKind::SGPR ||
                             (in.src[0].kind == OperandKind::Special && in.src[0].value >= 106 && in.src[0].value <= 123)) {
+                            bool complete_pair = true;
                             for (int k = 0; k < 2; k++) {
                                 int s = in.src[0].value + k, dr = in.dst.value + k;
                                 auto it = rs.sreg.find(s);
-                                if (it != rs.sreg.end()) rs.sreg[dr] = it->second; else rs.sreg.erase(dr);
+                                if (it != rs.sreg.end()) {
+                                    rs.sreg[dr] = it->second;
+                                } else {
+                                    auto input = rs.sreg_input.find(s);
+                                    if (input != rs.sreg_input.end())
+                                        rs.sreg[dr] = input->second;
+                                    else {
+                                        rs.sreg.erase(dr);
+                                        complete_pair = false;
+                                    }
+                                }
                                 auto jt = rs.sreg_srt.find(s);
                                 if (jt != rs.sreg_srt.end()) rs.sreg_srt[dr] = jt->second; else rs.sreg_srt.erase(dr);
                             }
-                            data_copied = true;
+                            // Preserve the established unwritten-SGPR-as-zero behavior for an
+                            // ordinary data move. A Bool alias needs both real words, however; an
+                            // incomplete pair must fall through to exact ballot materialization.
+                            data_copied = complete_pair || !m;
                         } else if (in.src[0].kind == OperandKind::InlineInt) {   // 64-bit sign-extended constant
                             rs.sreg[in.dst.value]     = b.uconst((uint32_t)in.src[0].value);
                             rs.sreg[in.dst.value + 1] = b.uconst(in.src[0].value < 0 ? 0xFFFFFFFFu : 0u);
@@ -7111,6 +7147,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             rs.sreg[in.dst.value]     = b.uconst(in.literal);
                             rs.sreg[in.dst.value + 1] = b.uconst(0);
                             rs.sreg_srt.erase(in.dst.value); rs.sreg_srt.erase(in.dst.value + 1);
+                            data_copied = true;
+                        }
+                        // One exact native subgroup per guest Wave64 makes the Bool mask's two
+                        // architectural SGPR words available as subgroup-ballot .x/.y. Preserve
+                        // both representations for S_MOV_B64. GTA's BVH loop enters with
+                        // `vcc=exec` and reaches its backedge with VCC rebuilt by v_readlane; this
+                        // materialization gives that mixed-domain join one common scalar form.
+                        if (m && !data_copied && b.is_compute && b.wave_size == 64 &&
+                            b.native_subgroup_size == 64) {
+                            rs.sreg[in.dst.value] = b.native_wave_ballot_half(m, 0);
+                            rs.sreg[in.dst.value + 1] = b.native_wave_ballot_half(m, 1);
+                            rs.sreg_srt.erase(in.dst.value);
+                            rs.sreg_srt.erase(in.dst.value + 1);
                             data_copied = true;
                         }
                         if (data_copied && !m) {   // data-only move: drop any stale saved-mask alias
@@ -7621,7 +7670,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // placeholders coexist in a CFG dispatcher. (s_cselect_b32 stays in the uint path.)
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
                 auto mask = [&](const Operand& o) -> uint32_t {
-                    if (o.value == 106 || o.value == 107) return rs.vcc;
+                    if ((o.value == 106 || o.value == 107) && rs.vcc) return rs.vcc;
                     if (o.value == 126 || o.value == 127) return rs.exec;
                     if (o.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(o.value);
                         if (it != rs.sreg_bool.end()) return it->second; }
@@ -7736,12 +7785,50 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // s_cselect_b64.
                 auto is_exec = [](const Operand& o){ return o.value == 126 || o.value == 127; };
                 auto mask = [&](const Operand& o) -> uint32_t {
-                    if (o.value == 106 || o.value == 107) return rs.vcc;
+                    if ((o.value == 106 || o.value == 107) && rs.vcc) return rs.vcc;
                     if (o.value == 126 || o.value == 127) return rs.exec;
                     if (o.kind == OperandKind::SGPR) { auto it = rs.sreg_bool.find(o.value);
                         if (it != rs.sreg_bool.end()) return it->second; }
                     if (o.kind == OperandKind::InlineInt)
                         return inline_int_mask_bit(b, o.value);
+                    // A native Wave64 subgroup can project an ordinary scalar pair into the same
+                    // per-invocation Bool representation used for wave masks: select this guest
+                    // lane's 32-bit half, then extract its bit. GTA copies EXEC_LO/HI ballots into
+                    // scalar scratch and intersects that pair with VCC at pc1467. Both halves must
+                    // exist; narrower/unknown subgroup modes remain fail-visible.
+                    if (b.is_compute && b.wave_size == 64 && b.native_subgroup_size == 64 &&
+                        (o.kind == OperandKind::SGPR ||
+                         (o.kind == OperandKind::Special &&
+                          (o.value == 106 || o.value == 107)))) {
+                        auto scalar_word = [&](int reg, uint32_t& value) {
+                            auto current = rs.sreg.find(reg);
+                            if (current != rs.sreg.end()) {
+                                value = current->second;
+                                return true;
+                            }
+                            auto input = rs.sreg_input.find(reg);
+                            if (input != rs.sreg_input.end()) {
+                                value = input->second;
+                                return true;
+                            }
+                            return false;
+                        };
+                        uint32_t lo = 0, hi = 0;
+                        if (scalar_word(o.value, lo) && scalar_word(o.value + 1, hi)) {
+                            // Invert the ballot with the same subgroup-local index that assigned
+                            // its bits; this needs no LocalInvocationIndex ordering assumption.
+                            const uint32_t lane = b.ibin(
+                                Op_BitwiseAnd, b.subgroup_local_id(), b.uconst(63));
+                            const uint32_t word = b.sel(
+                                b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32)), hi, lo);
+                            const uint32_t bit = b.ibin(Op_BitwiseAnd, lane, b.uconst(31));
+                            return b.ucmp(
+                                Op_INotEqual,
+                                b.ibin(Op_BitwiseAnd,
+                                       b.ibin(Op_ShiftRightLogical, word, bit), b.uconst(1)),
+                                b.uconst(0));
+                        }
+                    }
                     return 0;
                 };
                 uint32_t m0 = mask(in.src[0]), m1 = mask(in.src[1]);
@@ -14600,8 +14687,8 @@ bool emit_cfg_state_machine(
                 // add/sub carry, div-scale flag, and 64-bit multiply-add carry outputs. Each SDST
                 // is a per-lane scalar mask/flag; ordinary VOP3A scalar data never appears here
                 // (v_readlane uses `dst`, not `sdst`).
-                if (in.fmt == Rdna2Format::VOP3 && !vop3_b32_carry &&
-                    in.sdst.kind == OperandKind::SGPR && in.sdst.value <= 105)
+                if (vop3_writes_mask_sdst(in) && !vop3_b32_carry &&
+                    in.sdst.value <= 105)
                     writes_b64_mask = true;
                 int b64_write_reg = writes_b64_mask ?
                     (in.fmt == Rdna2Format::VOP3 ? in.sdst.value : in.dst.value) : -1;
@@ -14729,6 +14816,12 @@ bool emit_cfg_state_machine(
     // at joins remain ambiguous until a definite overwrite and reject on their first read.
     std::vector<std::set<int>> wave64_b64_mask_in(starts.size());
     std::vector<std::set<int>> wave64_b64_ambiguous_in(starts.size());
+    // A mask/scalar join poisons the physical pair, but a later definite B32 write still makes the
+    // addressed scalar word safe to consume. Track those post-conflict scalar definitions with a
+    // separate MUST fact: the other half remains ambiguous until it too is definitely replaced.
+    // This matters for GTA V's scalar scratch in VCC/ordinary mask pairs, where readfirstlane,
+    // SMEM, or a B32 scalar ALU defines one half before a one-dword VALU/SALU consumer.
+    std::vector<std::set<int>> wave64_scalar_word_in(starts.size());
     std::vector<bool> wave64_b64_reachable(starts.size(), false);
     auto wave64_mask_reduction_source = [&](const Rdna2Inst& in) -> int {
         if (!b.is_compute || b.wave_size != 64 || in.fmt != Rdna2Format::SOP1 ||
@@ -14759,10 +14852,99 @@ bool emit_cfg_state_machine(
             if (!initial.sreg_bool_b32.contains(mask.first) && mask.first <= 105)
                 wave64_b64_mask_in.front().insert(mask.first);
         if (initial.vcc) wave64_b64_mask_in.front().insert(106);
+        for (const auto& value : initial.sreg)
+            if (value.first <= 107) wave64_scalar_word_in.front().insert(value.first);
+        for (const auto& value : initial.sreg_input)
+            if (value.first <= 107) wave64_scalar_word_in.front().insert(value.first);
         wave64_b64_reachable.front() = true;
+
+        enum class ScalarSourceRead : uint8_t {
+            None = 0, B32 = 1, Pair = 2, Quad = 4, Oct = 8,
+        };
+        auto scalar_source_read = [&](const Rdna2Inst& in, uint32_t source)
+                -> ScalarSourceRead {
+            switch (in.fmt) {
+                case Rdna2Format::SOP1:
+                    if (in.opcode == 0x1f) return ScalarSourceRead::None; // s_getpc has no source
+                    if (in.opcode == 0x10 || in.opcode == 0x14 ||
+                        in.opcode == 0x16 || in.opcode == 0x18 || in.opcode == 0x2d)
+                        return ScalarSourceRead::Pair; // bcnt/ff1/flbit consume a B64 pair
+                    return scalar_write_width(in) == 1
+                        ? ScalarSourceRead::B32 : ScalarSourceRead::Pair;
+                case Rdna2Format::SOP2:
+                    // B64 shifts take a B64 value followed by a one-dword shift count. BFM's width
+                    // and offset operands are likewise B32 even though its result is a B64 mask.
+                    if (in.opcode == 0x1f || in.opcode == 0x21)
+                        return source == 1 ? ScalarSourceRead::B32 : ScalarSourceRead::Pair;
+                    if (in.opcode == 0x25) return ScalarSourceRead::B32;
+                    if (in.opcode == 0x29)
+                        return source == 1 ? ScalarSourceRead::B32 : ScalarSourceRead::Pair;
+                    return scalar_write_width(in) == 1
+                        ? ScalarSourceRead::B32 : ScalarSourceRead::Pair;
+                case Rdna2Format::SOPC:
+                    return in.opcode == 0x12 || in.opcode == 0x13
+                        ? ScalarSourceRead::Pair : ScalarSourceRead::B32;
+                case Rdna2Format::SMEM:
+                    // Ordinary scalar memory uses a two-word base. S_BUFFER_* opcodes use a
+                    // complete four-word descriptor; SOFFSET remains one scalar dword.
+                    if (source == 1) return ScalarSourceRead::B32;
+                    return in.opcode >= 0x08
+                        ? ScalarSourceRead::Quad : ScalarSourceRead::Pair;
+                case Rdna2Format::MUBUF:
+                case Rdna2Format::MTBUF:
+                    // The four-word V# starts at SRC1 while optional SOFFSET is one dword.
+                    return source == 1 ? ScalarSourceRead::Quad : ScalarSourceRead::B32;
+                case Rdna2Format::MIMG: {
+                    // T# is eight words; the exact BVH form uses a four-word descriptor instead.
+                    // Storage/load/resinfo/BVH packets have no sampler, while sampled operations
+                    // consume the complete four-word S#.
+                    if (source == 1)
+                        return in.opcode == 0xe6
+                            ? ScalarSourceRead::Quad : ScalarSourceRead::Oct;
+                    const bool storage_only_op = in.opcode == 0x08 || in.opcode == 0x09 ||
+                        in.opcode == 0x0f ||
+                        (in.opcode >= 0x11 && in.opcode <= 0x1a && in.opcode != 0x13);
+                    if (source == 2)
+                        return in.opcode == 0x00 || in.opcode == 0x01 ||
+                                   in.opcode == 0x0e || in.opcode == 0xe6 || storage_only_op
+                            ? ScalarSourceRead::None : ScalarSourceRead::Quad;
+                    return ScalarSourceRead::B32;
+                }
+                case Rdna2Format::VOP1:
+                case Rdna2Format::VOP2:
+                    return ScalarSourceRead::B32;
+                case Rdna2Format::VOPC:
+                    // The e64 integer B64 comparison family encodes the low word of a pair. Other
+                    // scalar VALU operands, including SDWA, broadcast exactly one dword.
+                    {
+                        const uint32_t effective = vopc_is_cmpx(in.opcode)
+                            ? in.opcode - 0x10u : in.opcode;
+                        const bool integer64 =
+                            (effective >= 0xa1u && effective <= 0xa6u) ||
+                            (effective >= 0xe1u && effective <= 0xe6u);
+                        return integer64 ? ScalarSourceRead::Pair : ScalarSourceRead::B32;
+                    }
+                case Rdna2Format::VOP3:
+                    // Decode exposes an unused SRC2=s0 on the lane read/write encodings. Their real
+                    // scalar data and lane-selector operands are each one dword. The three ordinary
+                    // VOP3A operations below are the exact GTA consumers in this reject family and
+                    // likewise broadcast one scalar dword per source. Retain the conservative pair
+                    // rule for every un-inventoried VOP3 opcode, including explicit mask inputs.
+                    if (in.opcode == 0x360 || in.opcode == 0x361)
+                        return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::None;
+                    if (in.opcode == 0x365 || in.opcode == 0x366)
+                        return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::None;
+                    if (in.opcode == 0x141 || in.opcode == 0x143 || in.opcode == 0x347)
+                        return ScalarSourceRead::B32;
+                    return ScalarSourceRead::Pair;
+                default:
+                    return ScalarSourceRead::Pair;
+            }
+        };
 
         auto advance_wave64_b64_masks = [&](std::set<int>& masks,
                                             std::set<int>& ambiguous,
+                                            std::set<int>& scalar_words,
                                             const Rdna2Inst& in,
                                             bool record_compare) {
             // A block-entry join where the same physical pair is a mask on one predecessor and
@@ -14770,13 +14952,45 @@ bool emit_cfg_state_machine(
             // loading either the Bool's false placeholder or the scalar variable's zero placeholder
             // would silently choose one predecessor's domain for both paths.
             bool reads_ambiguous = false;
+            auto source_is_mask = [&](const Operand& source) {
+                if (source.kind == OperandKind::InlineInt) return true;
+                if (source.kind != OperandKind::SGPR &&
+                    source.kind != OperandKind::Special)
+                    return false;
+                if (source.value == 126 || source.value == 127) return true;
+                return masks.contains(source.value);
+            };
             for (uint32_t source = 0; source < in.n_src; ++source) {
                 const Operand& operand = in.src[source];
                 if (operand.kind != OperandKind::SGPR &&
                     operand.kind != OperandKind::Special)
                     continue;
-                for (int base : ambiguous)
-                    reads_ambiguous |= operand.value == base || operand.value == base + 1;
+                // The mask-only emitter for B64 logical operations consumes a proved Bool-domain
+                // source directly. A fresh VCC pair can overlap the high word of an older odd-rooted
+                // ambiguity without becoming scalar data; only the scalar-pair operand below needs
+                // per-word resolution. MBCNT likewise consumes one proved mask half, not a scalar
+                // pair beginning at its encoded SGPR.
+                const bool b64_logical_mask_source =
+                    in.fmt == Rdna2Format::SOP2 && in.opcode >= 0x0f &&
+                    in.opcode <= 0x1d && (in.opcode & 1u) && source_is_mask(operand);
+                const int mbcnt_root = in.opcode == 0x366
+                    ? operand.value - 1 : operand.value;
+                const bool mbcnt_mask_source = in.fmt == Rdna2Format::VOP3 && source == 0 &&
+                    (in.opcode == 0x365 || in.opcode == 0x366) &&
+                    (operand.value == (in.opcode == 0x366 ? 127 : 126) ||
+                     operand.value == (in.opcode == 0x366 ? 107 : 106) ||
+                     masks.contains(mbcnt_root));
+                if (b64_logical_mask_source || mbcnt_mask_source) continue;
+                const ScalarSourceRead read = scalar_source_read(in, source);
+                if (read == ScalarSourceRead::None) continue;
+                const int first = operand.value;
+                const int last = first + static_cast<int>(read);
+                for (int base : ambiguous) {
+                    const int overlap_first = std::max(first, base);
+                    const int overlap_last = std::min(last, base + 2);
+                    for (int word = overlap_first; word < overlap_last; ++word)
+                        if (!scalar_words.contains(word)) reads_ambiguous = true;
+                }
             }
             const bool implicit_vcc_read =
                 (in.fmt == Rdna2Format::SOPP &&
@@ -14789,8 +15003,11 @@ bool emit_cfg_state_machine(
             if (implicit_scalar_words) {
                 const int first = in.dst.value;
                 const int last = first + static_cast<int>(implicit_scalar_words);
-                for (int mask_base : ambiguous)
-                    reads_ambiguous |= first < mask_base + 2 && mask_base < last;
+                for (int word = first; word < last; ++word)
+                    for (int mask_base : ambiguous)
+                        if ((word == mask_base || word == mask_base + 1) &&
+                            !scalar_words.contains(word))
+                            reads_ambiguous = true;
             }
             if (reads_ambiguous)
                 return reject_cfg(in.pc, "wave64-ambiguous-mask-read");
@@ -14813,15 +15030,6 @@ bool emit_cfg_state_machine(
                 masks.contains(pair_compare[0]) && masks.contains(pair_compare[1]))
                 proven_saved_mask_pair_compare_pcs.insert(in.pc);
 
-            auto source_is_mask = [&](const Operand& source) {
-                if (source.kind == OperandKind::InlineInt) return true;
-                if (source.kind != OperandKind::SGPR &&
-                    source.kind != OperandKind::Special)
-                    return false;
-                if (source.value == 126 || source.value == 127) return true;
-                return masks.contains(source.value);
-            };
-
             int mask_write = -1;
             if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode)) {
                 mask_write = in.dst.kind == OperandKind::SGPR && in.dst.value <= 105
@@ -14836,19 +15044,21 @@ bool emit_cfg_state_machine(
             } else if (in.fmt == Rdna2Format::SOP2 && in.dst.value <= 107) {
                 if (in.opcode == 0x25)
                     mask_write = in.dst.value;
+                else if (in.opcode >= 0x0f && in.opcode <= 0x1d &&
+                         (in.opcode & 1u) == 1)
+                    // Emission for every B64 logical is mask-only. Scalar pairs are projected to
+                    // their per-lane bit before the operation, so the result is never scalar DATA.
+                    mask_write = in.dst.value;
                 else if (in.opcode == 0x0b && in.dst.value == 106 &&
                          !b.cselect_b64_low_only_pcs.contains(in.pc))
                     // A complete scalar-data pair selected into VCC has a dual lifetime: emit_alu
                     // derives its per-lane predicate even though neither input is a mask. The one
                     // incomplete GTA form deliberately has no predicate and is excluded here.
                     mask_write = 106;
-                else if ((in.opcode == 0x0b ||
-                          (in.opcode >= 0x0f && in.opcode <= 0x1d &&
-                           (in.opcode & 1u) == 1)) &&
+                else if (in.opcode == 0x0b &&
                          source_is_mask(in.src[0]) && source_is_mask(in.src[1]))
                     mask_write = in.dst.value;
-            } else if (in.fmt == Rdna2Format::VOP3 &&
-                       in.sdst.kind == OperandKind::SGPR && in.sdst.value <= 107) {
+            } else if (vop3_writes_mask_sdst(in) && in.sdst.value <= 107) {
                 mask_write = in.sdst.value;
             }
 
@@ -14864,8 +15074,9 @@ bool emit_cfg_state_machine(
                 // A one-word scalar write kills the definite-mask fact for the physical pair, but
                 // it resolves only the addressed half of an ambiguous pair. Keep the ambiguity
                 // until one definite write covers both halves; otherwise the untouched word could
-                // be reloaded from the wrong Function-variable domain. Pair-conservative retention
-                // after two separate B32 writes is intentional and fail-closed.
+                // be reloaded from the wrong Function-variable domain. The separate scalar-word
+                // MUST facts below can validate exactly the overwritten word while complete-pair
+                // consumers remain fail-closed until both halves are definitely scalar.
                 for (auto it = ambiguous.begin(); it != ambiguous.end();) {
                     const int mask_base = *it;
                     if (base <= mask_base &&
@@ -14875,7 +15086,11 @@ bool emit_cfg_state_machine(
                         ++it;
                 }
             };
-            for_each_scalar_write(in, erase_overlapping, /*wave32_one_word_masks*/false);
+            std::vector<std::pair<int, uint32_t>> scalar_writes;
+            for_each_scalar_write(in, [&](int base, uint32_t width) {
+                scalar_writes.emplace_back(base, width);
+                erase_overlapping(base, width);
+            }, /*wave32_one_word_masks*/false);
             // This exact B32 write resolves VCC_LO to scalar data while the whole-stream proof
             // guarantees the untouched high half cannot be observed before a complete replacement.
             // It is therefore safe to clear the pair-domain ambiguity for this path; a later join
@@ -14890,6 +15105,46 @@ bool emit_cfg_state_machine(
             if (mask_write >= 0) {
                 masks.insert(mask_write);
                 ambiguous.erase(mask_write);
+                // An inline S_MOV_B64 is represented in both domains by emit_alu: its Bool
+                // view is an exact wave mask and its two scalar words are the same architectural bit
+                // pattern. GTA joins `s_mov_b64 s[16:17], 0` against an SMEM load, then consumes the
+                // pair as scalar data. Preserve that dual definition; other mask writes still erase
+                // scalar facts because their Boolean value cannot be materialized as two SGPR words.
+                auto complete_scalar_pair = [&](const Operand& source) {
+                    if (source.kind == OperandKind::InlineInt ||
+                        source.kind == OperandKind::Literal)
+                        return true;
+                    if (source.kind != OperandKind::SGPR &&
+                        source.kind != OperandKind::Special)
+                        return false;
+                    return scalar_words.contains(source.value) &&
+                           scalar_words.contains(source.value + 1);
+                };
+                const bool mov_dual_domain = in.fmt == Rdna2Format::SOP1 &&
+                    in.opcode == 0x04 &&
+                    (in.src[0].kind == OperandKind::InlineInt ||
+                     complete_scalar_pair(in.src[0]) ||
+                     (b.is_compute && b.wave_size == 64 &&
+                      b.native_subgroup_size == 64 && source_is_mask(in.src[0])));
+                const bool cselect_scalar_branch = in.fmt == Rdna2Format::SOP2 &&
+                    in.opcode == 0x0b && in.dst.value == 106 &&
+                    !b.cselect_b64_low_only_pcs.contains(in.pc) &&
+                    !(source_is_mask(in.src[0]) && source_is_mask(in.src[1])) &&
+                    complete_scalar_pair(in.src[0]) && complete_scalar_pair(in.src[1]);
+                const bool dual_domain_scalar_write =
+                    mov_dual_domain || cselect_scalar_branch;
+                if (!dual_domain_scalar_write) {
+                    scalar_words.erase(mask_write);
+                    scalar_words.erase(mask_write + 1);
+                } else {
+                    for (const auto& [base, width] : scalar_writes)
+                        for (uint32_t word = 0; word < width; ++word)
+                            scalar_words.insert(base + static_cast<int>(word));
+                }
+            } else {
+                for (const auto& [base, width] : scalar_writes)
+                    for (uint32_t word = 0; word < width; ++word)
+                        scalar_words.insert(base + static_cast<int>(word));
             }
             return true;
         };
@@ -14900,12 +15155,13 @@ bool emit_cfg_state_machine(
             pending.pop_back();
             std::set<int> masks = wave64_b64_mask_in[block];
             std::set<int> ambiguous = wave64_b64_ambiguous_in[block];
+            std::set<int> scalar_words = wave64_scalar_word_in[block];
             const uint32_t lo = starts[block];
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
                 if (!advance_wave64_b64_masks(
-                        masks, ambiguous, in, /*record_compare*/false))
+                        masks, ambiguous, scalar_words, in, /*record_compare*/false))
                     return false;
             }
             for (uint32_t successor : successors[block]) {
@@ -14913,6 +15169,7 @@ bool emit_cfg_state_machine(
                     wave64_b64_reachable[successor] = true;
                     wave64_b64_mask_in[successor] = masks;
                     wave64_b64_ambiguous_in[successor] = ambiguous;
+                    wave64_scalar_word_in[successor] = scalar_words;
                     pending.push_back(successor);
                     continue;
                 }
@@ -14930,10 +15187,18 @@ bool emit_cfg_state_machine(
                         joined_ambiguous.insert(base);
                 joined_ambiguous.insert(ambiguous.begin(), ambiguous.end());
                 for (int base : joined_ambiguous) joined.erase(base);
+                std::set<int> joined_scalar_words;
+                std::set_intersection(
+                    wave64_scalar_word_in[successor].begin(),
+                    wave64_scalar_word_in[successor].end(),
+                    scalar_words.begin(), scalar_words.end(),
+                    std::inserter(joined_scalar_words, joined_scalar_words.end()));
                 if (joined != wave64_b64_mask_in[successor] ||
-                    joined_ambiguous != wave64_b64_ambiguous_in[successor]) {
+                    joined_ambiguous != wave64_b64_ambiguous_in[successor] ||
+                    joined_scalar_words != wave64_scalar_word_in[successor]) {
                     wave64_b64_mask_in[successor] = std::move(joined);
                     wave64_b64_ambiguous_in[successor] = std::move(joined_ambiguous);
+                    wave64_scalar_word_in[successor] = std::move(joined_scalar_words);
                     pending.push_back(successor);
                 }
             }
@@ -14942,12 +15207,13 @@ bool emit_cfg_state_machine(
             if (!wave64_b64_reachable[block]) continue;
             std::set<int> masks = wave64_b64_mask_in[block];
             std::set<int> ambiguous = wave64_b64_ambiguous_in[block];
+            std::set<int> scalar_words = wave64_scalar_word_in[block];
             const uint32_t lo = starts[block];
             const uint32_t hi = block + 1 < starts.size() ? starts[block + 1] : UINT32_MAX;
             for (const auto& in : ins) {
                 if (in.pc < lo || in.pc >= hi || in.is_end) continue;
                 if (!advance_wave64_b64_masks(
-                        masks, ambiguous, in, /*record_compare*/true))
+                        masks, ambiguous, scalar_words, in, /*record_compare*/true))
                     return false;
             }
         }
@@ -15335,6 +15601,7 @@ bool emit_cfg_state_machine(
         const std::set<int>* entry_b32 = nullptr;
         const std::set<int>* entry_b64 = nullptr;
         const std::set<int>* entry_wave64_b64 = nullptr;
+        const std::set<int>* entry_wave64_scalar_words = nullptr;
         uint32_t entry_block = UINT32_MAX;
         if (dispatch != UINT32_MAX)
             entry_block = dispatch_blocks[dispatch].front();
@@ -15350,8 +15617,10 @@ bool emit_cfg_state_machine(
         const bool filters_wave64_b64 = (b.is_compute || b.is_fragment) &&
             b.wave_size == 64;
         if (filters_wave64_b64 && entry_block != UINT32_MAX &&
-            wave64_b64_reachable[entry_block])
+            wave64_b64_reachable[entry_block]) {
             entry_wave64_b64 = &wave64_b64_mask_in[entry_block];
+            entry_wave64_scalar_words = &wave64_scalar_word_in[entry_block];
+        }
         for (const auto& kv : mv) {
             if (b.allow_b32_masks &&
                 (!entry_b64 || !entry_b64->contains(kv.first)) &&
@@ -15375,6 +15644,22 @@ bool emit_cfg_state_machine(
             : (!entry_b32 || entry_b32->contains(106));
         state.vcc = live_vcc ? b.load_function(b.t_bool, vcc_var) : 0;
         state.exec = b.load_function(b.t_bool, exec_var);
+        // `sv` has a Function variable for every statically observed scalar lifetime, including
+        // zero placeholders stored while the same physical pair carries only a Bool-domain mask.
+        // Do not let those placeholders shadow the live mask after a dispatcher reload. A genuinely
+        // dual-domain value (an inline/native-ballot S_MOV or scalar CSELECT-to-VCC) retains exact
+        // scalar-word MUST facts and therefore keeps its scalar loads.
+        if (entry_wave64_b64) {
+            for (int base : *entry_wave64_b64) {
+                for (int word = base; word < base + 2; ++word) {
+                    if (entry_wave64_scalar_words &&
+                        entry_wave64_scalar_words->contains(word))
+                        continue;
+                    state.sreg.erase(word);
+                    state.sreg_input.erase(word);
+                }
+            }
+        }
         if (entry_b32) {
             for (int reg : *entry_b32) {
                 state.sreg.erase(reg);

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -2009,7 +2009,7 @@ int main() {
     // that diagnosed the production kernel at this site.
     const uint32_t wave32_compute_vop3b_two_source_join[] = {
         0x7d8a06f9u, 0x06868080u,            // pc0: exact VOPC SDWA packet -> s0 mask
-        0xbf060000u,                         // pc2: scalar branch condition
+        0xbf068008u,                         // pc2: independent scalar branch condition
         0xbf840001u,                         // pc3: one edge retains the s0 mask
         0xbe800380u,                         // pc4: other edge replaces s0 with scalar data
         0xd70f0016u, 0x00021f1bu,            // pc5: exact v_add_co_u32 v22,s0,v27,v15

--- a/prosper/tests/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/test_rdna2_to_spirv.cpp
@@ -6038,9 +6038,10 @@ int main() {
           "dispatcher successor consumes both selected scalar dwords as data");
 
     // The same physical pair cannot be reconstructed at a join when one predecessor owns a saved
-    // wave mask and the other owns ordinary scalar data. The dispatcher has separate Bool/u32
-    // backing variables but no runtime domain tag, so consuming s[4:5] at the join must reject in
-    // both portable and native paths instead of silently reading either variable's zero placeholder.
+    // wave mask and the other owns ordinary scalar data. Portable dispatch has separate Bool/u32
+    // backing variables but no runtime domain tag, so consuming s[4:5] at the join must reject
+    // instead of silently reading either variable's zero placeholder. Exact native Wave64 can
+    // materialize VCC as ballot low/high words, so both predecessors also define scalar data there.
     const uint32_t code38_pair_ambiguous_join[] = {
         0x7e040280u,              // irreducible dispatcher prefix (same shape as kernel 17d)
         0x7d840100u,
@@ -6070,14 +6071,12 @@ int main() {
         pair_ambiguous_join_words, pair_ambiguous_portable_config);
     const auto pair_ambiguous_native = compile_cselect_pair(
         pair_ambiguous_join_words, pair_ambiguous_native_config);
-    CHECK(pair_ambiguous_portable.empty(),
-          "portable dispatcher rejects a Wave64 mask/scalar pair join at its u64 consumer");
-    CHECK(pair_ambiguous_native.empty(),
-          "native dispatcher rejects a Wave64 mask/scalar pair join at its u64 consumer");
+    CHECK(pair_ambiguous_portable.empty() && !pair_ambiguous_native.empty(),
+          "portable rejects an untagged pair while native Wave64 materializes its ballot words");
 
-    auto rejects_ambiguous_pair = [&](const std::vector<uint32_t>& words) {
+    auto portable_rejects_native_materializes = [&](const std::vector<uint32_t>& words) {
         return compile_cselect_pair(words, pair_ambiguous_portable_config).empty() &&
-               compile_cselect_pair(words, pair_ambiguous_native_config).empty();
+               !compile_cselect_pair(words, pair_ambiguous_native_config).empty();
     };
     std::vector<uint32_t> pair_ambiguous_low_overwrite = pair_ambiguous_join_words;
     pair_ambiguous_low_overwrite.insert(
@@ -6085,8 +6084,8 @@ int main() {
         0xbe840380u);              // overwrite only s4 after the join
     pair_ambiguous_low_overwrite[16] =
         0x7e020205u;               // read untouched ambiguous s5
-    CHECK(rejects_ambiguous_pair(pair_ambiguous_low_overwrite),
-          "Wave64 pair ambiguity survives a low-half overwrite before a high-half read");
+    CHECK(portable_rejects_native_materializes(pair_ambiguous_low_overwrite),
+          "portable ambiguity survives a low overwrite; native retains the ballot high word");
 
     std::vector<uint32_t> pair_ambiguous_high_overwrite = pair_ambiguous_join_words;
     pair_ambiguous_high_overwrite.insert(
@@ -6094,26 +6093,26 @@ int main() {
         0xbe850380u);              // overwrite only s5 after the join
     pair_ambiguous_high_overwrite[16] =
         0x7e020204u;               // read untouched ambiguous s4
-    CHECK(rejects_ambiguous_pair(pair_ambiguous_high_overwrite),
-          "Wave64 pair ambiguity survives a high-half overwrite before a low-half read");
+    CHECK(portable_rejects_native_materializes(pair_ambiguous_high_overwrite),
+          "portable ambiguity survives a high overwrite; native retains the ballot low word");
 
     std::vector<uint32_t> pair_ambiguous_addk = pair_ambiguous_join_words;
     pair_ambiguous_addk[15] =
         0xb7840001u;               // s_addk_i32 s4,1 implicitly reads/writes SDST
-    CHECK(rejects_ambiguous_pair(pair_ambiguous_addk),
-          "Wave64 pair ambiguity rejects an implicit SOPK read-modify-write");
+    CHECK(portable_rejects_native_materializes(pair_ambiguous_addk),
+          "portable ambiguity rejects an implicit SOPK read while native has ballot words");
 
     std::vector<uint32_t> pair_ambiguous_cmpk = pair_ambiguous_join_words;
     pair_ambiguous_cmpk[15] =
         0xb2050000u;               // s_cmpk_lg_i32 s5,0 implicitly reads SDST
-    CHECK(rejects_ambiguous_pair(pair_ambiguous_cmpk),
-          "Wave64 pair ambiguity rejects an implicit SOPK comparison read");
+    CHECK(portable_rejects_native_materializes(pair_ambiguous_cmpk),
+          "portable ambiguity rejects a SOPK compare while native has ballot words");
 
     std::vector<uint32_t> pair_ambiguous_bitset = pair_ambiguous_join_words;
     pair_ambiguous_bitset[15] =
         0xbe841d81u;               // s_bitset1_b32 s4,1 reads old SDST and an explicit bit index
-    CHECK(rejects_ambiguous_pair(pair_ambiguous_bitset),
-          "Wave64 pair ambiguity rejects an implicit SOP1 bitset destination read");
+    CHECK(portable_rejects_native_materializes(pair_ambiguous_bitset),
+          "portable ambiguity rejects a SOP1 bitset while native has ballot words");
 
     const uint32_t code38_vcc_true[] = {
         0xbe8003ffu, 0x80000001u, // source0 low: lanes 0 and 31
@@ -10168,11 +10167,13 @@ int main() {
     CHECK(spvA9.empty(),
           "A9: a non-adjacent SCC consumer after a 64-bit mask op is REJECTED (SCC poison)");
 
-    // A9b: the SAME consumer after a real s_cmp (which re-arms SCC) still recompiles — the poison
-    // only rejects when the last SCC writer was an unrepresentable mask op, not in general.
+    // A9b: the SAME consumer after a real s_cmp on independently defined scalar data (which
+    // re-arms SCC) still recompiles. Reading s0 here would instead be a valid fail-closed rejection:
+    // the preceding mask-only S_AND_B64 does not materialize scalar low/high words.
     const uint32_t codeA9b[] = {
         0x87806a6au,   // s_and_b64 s[0:1], vcc, vcc  (poisons SCC)
-        0xbf068000u,   // s_cmp_eq_u32 s0, 0          (re-arms SCC with a representable value)
+        0xbe820380u,   // s_mov_b32 s2, 0             (independent scalar data; preserves SCC)
+        0xbf068002u,   // s_cmp_eq_u32 s2, 0          (re-arms SCC with a representable value)
         0x8503848bu,   // s_cselect_b32 s3, 11, 4     (reads the fresh SCC -> OK)
         0x4a020203u,   // v_add_nc_u32 v1, s3, v1
         0xBF810000u,

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -879,7 +879,7 @@ int main() {
         0xBE900381u, // scalar-data arm: s_mov_b32 s16, 1
         0xBE910380u, //                  s_mov_b32 s17, 0
         0xBF820001u, // s_branch +1 -> merge
-        0xBE90047Eu, // mask arm: s_mov_b64 s[16:17], exec
+        0xBE900A7Eu, // mask arm: s_wqm_b64 s[16:17], exec (no scalar words)
     };
     compute_cfg_dispatch_ambiguous_ff1_b64.insert(
         compute_cfg_dispatch_ambiguous_ff1_b64.end(), compute_cfg_dispatch,
@@ -894,6 +894,599 @@ int main() {
                             compute_cfg_dispatch_ambiguous_ff1_b64.size(), &dispatch_rt,
                             wave64_dispatch_config).empty(),
           "a Wave64 mask/scalar join remains ambiguous at the exact S_FF1 consumer");
+
+    // GTA V's exec_cs_413d22d00 reaches this exact PC105 SDWA packet after s[16:17] has joined a
+    // saved-mask and scalar-data lifetime. PC102 then definitely overwrites only s16. The explicit
+    // SRC1 is a one-dword scalar value, so the unresolved s17 half must not poison that read; the
+    // implicit VCC predicate comes from the fresh compare immediately before it. Keep a crossing
+    // tail so the fixture exercises the production Wave64 dispatcher dataflow rather than SSA.
+    std::vector<uint32_t> compute_cfg_dispatch_resolved_b32_half = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE900381u,                         // pc2: scalar arm s16 = 1
+        0xBE910380u,                         // pc3: scalar arm s17 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE900A7Eu,                         // pc5: mask-only WQM s[16:17] = exec
+        0x7D840000u,                         // pc6: fresh implicit VCC predicate
+        0xBE900381u,                         // pc7: exact B32 overwrite corresponding to live pc102
+        0x020E20F9u, 0x86860680u,            // pc8: exact live pc105 cndmask SDWA reads s16
+    };
+    compute_cfg_dispatch_resolved_b32_half.insert(
+        compute_cfg_dispatch_resolved_b32_half.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_resolved_b32_half.data(),
+                             compute_cfg_dispatch_resolved_b32_half.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "a definite B32 overwrite resolves the exact half consumed after a Wave64 domain join");
+
+    std::vector<uint32_t> compute_cfg_dispatch_wrong_b32_half =
+        compute_cfg_dispatch_resolved_b32_half;
+    compute_cfg_dispatch_wrong_b32_half[7] =
+        0xBE910381u;                         // overwrite s17; the consumed s16 remains ambiguous
+    CHECK(recompile_compute(compute_cfg_dispatch_wrong_b32_half.data(),
+                            compute_cfg_dispatch_wrong_b32_half.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "overwriting the other pair half cannot validate GTA's exact one-dword consumer");
+
+    std::vector<uint32_t> compute_cfg_dispatch_b64_after_b32_half =
+        compute_cfg_dispatch_resolved_b32_half;
+    compute_cfg_dispatch_b64_after_b32_half[8] =
+        0xBE841410u;                         // s_ff1_i32_b64 s4,s[16:17]
+    compute_cfg_dispatch_b64_after_b32_half[9] = 0xBF800000u;
+    CHECK(recompile_compute(compute_cfg_dispatch_b64_after_b32_half.data(),
+                            compute_cfg_dispatch_b64_after_b32_half.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a B32 overwrite leaves the untouched half fail-visible to a whole-pair consumer");
+
+    std::vector<uint32_t> compute_cfg_dispatch_flbit_b64_after_b32_half =
+        compute_cfg_dispatch_resolved_b32_half;
+    compute_cfg_dispatch_flbit_b64_after_b32_half[8] =
+        0xBE841610u;                         // s_flbit_i32_b64 s4,s[16:17]
+    compute_cfg_dispatch_flbit_b64_after_b32_half[9] = 0xBF800000u;
+    CHECK(recompile_compute(compute_cfg_dispatch_flbit_b64_after_b32_half.data(),
+                            compute_cfg_dispatch_flbit_b64_after_b32_half.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a B64 flbit cannot consume a pair whose high half remains ambiguous");
+
+    // Signed/unsigned 64-bit VOPC compares read both scalar source dwords. The raw signed-i64
+    // opcode sits below the u64 window, so classify the effective opcode rather than treating all
+    // high VOPC numbers as pairs (which also incorrectly catches adjacent f16 compares).
+    std::vector<uint32_t> compute_cfg_dispatch_i64_compare_after_b32_half =
+        compute_cfg_dispatch_resolved_b32_half;
+    compute_cfg_dispatch_i64_compare_after_b32_half[8] =
+        0xD4A2006Au;                         // v_cmp_eq_i64_e64 vcc,s[16:17],0
+    compute_cfg_dispatch_i64_compare_after_b32_half[9] = 0x00010010u;
+    CHECK(recompile_compute(compute_cfg_dispatch_i64_compare_after_b32_half.data(),
+                            compute_cfg_dispatch_i64_compare_after_b32_half.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a signed-i64 VOPC source cannot consume an unresolved high scalar half");
+
+    // exec_cs_205b66f800's other member of this family is s_getpc_b64. Decode exposes the SDST
+    // field as SRC0 for that SOP1 encoding, but architecturally getpc reads no scalar register and
+    // replaces both destination words. Put it directly after the same domain join and retain a
+    // separate valid embedded-table chain so production getpc admission stays fail-closed.
+    std::vector<uint32_t> compute_cfg_dispatch_ambiguous_getpc = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE800381u,                         // pc2: scalar arm s0 = 1
+        0xBE810380u,                         // pc3: scalar arm s1 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE800A7Eu,                         // pc5: mask-only WQM s[0:1] = exec
+        0xBE801F00u,                         // pc6: exact s_getpc_b64 s[0:1], no source read
+    };
+    compute_cfg_dispatch_ambiguous_getpc.insert(
+        compute_cfg_dispatch_ambiguous_getpc.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch) - 1);
+    compute_cfg_dispatch_ambiguous_getpc.insert(
+        compute_cfg_dispatch_ambiguous_getpc.end(), {
+            0xBE841F00u,                     // pc31: independent folded getpc (next byte 128)
+            0x800404A8u,                     // pc32: table byte 168 = next PC + 40
+            0x82050580u,                     // pc33: s_addc_u32 s5,0,s5
+            0xB0060010u,                     // pc34: stride/record field
+            0xBE8703FFu, 0x10005004u,        // pc35: exact V# config
+            0x7E020280u,                     // pc37: byte offset v1 = 0
+            0xE0301000u, 0x80010101u,        // pc38: folded embedded-table load
+            0xBF8C3F70u,                     // pc40: wait for the folded load
+            0xBF810000u,                     // pc41: endpgm
+            7u, 11u, 13u, 17u,               // pc42: embedded table
+        });
+    CHECK(!recompile_compute(compute_cfg_dispatch_ambiguous_getpc.data(),
+                             compute_cfg_dispatch_ambiguous_getpc.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "folded s_getpc overwrites an ambiguous Wave64 pair without reading its fake SRC0");
+    std::vector<uint32_t> compute_cfg_dispatch_getpc_real_pair_read =
+        compute_cfg_dispatch_ambiguous_getpc;
+    compute_cfg_dispatch_getpc_real_pair_read[6] =
+        0xBE800400u;                         // same site: s_mov_b64 s[0:1],s[0:1] really reads it
+    CHECK(recompile_compute(compute_cfg_dispatch_getpc_real_pair_read.data(),
+                            compute_cfg_dispatch_getpc_real_pair_read.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a real B64 source read at the getpc site still rejects the ambiguous pair");
+
+    // V_READLANE decode exposes an unused SRC2=s0 after its real VGPR and scalar lane-selector
+    // operands. GTA's exact pc261 packet writes s0, so treating that synthetic operand as a read of
+    // the old ambiguous pair deadlocks the very instruction that replaces it.
+    std::vector<uint32_t> compute_cfg_dispatch_readlane_fake_src2 = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE800381u,                         // pc2: scalar arm s0 = 1
+        0xBE810380u,                         // pc3: scalar arm s1 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE800A7Eu,                         // pc5: mask-only WQM s[0:1] = exec
+        0x7E0C0280u,                         // pc6: v6 = 0
+        0xD7600000u, 0x00013F06u,            // pc7: exact GTA v_readlane_b32 s0,v6,31
+    };
+    compute_cfg_dispatch_readlane_fake_src2.insert(
+        compute_cfg_dispatch_readlane_fake_src2.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_readlane_fake_src2.data(),
+                             compute_cfg_dispatch_readlane_fake_src2.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "v_readlane ignores its decoded fake SRC2 before replacing the ambiguous destination");
+
+    std::vector<uint32_t> compute_cfg_dispatch_readlane_true_ambiguous_selector =
+        compute_cfg_dispatch_readlane_fake_src2;
+    compute_cfg_dispatch_readlane_true_ambiguous_selector[8] =
+        0x00000106u;                         // v_readlane_b32 s0,v6,s0: SRC1 really is read
+    CHECK(recompile_compute(compute_cfg_dispatch_readlane_true_ambiguous_selector.data(),
+                            compute_cfg_dispatch_readlane_true_ambiguous_selector.size(),
+                            &dispatch_rt, wave64_dispatch_config).empty(),
+          "v_readlane still rejects an ambiguous SGPR used as its real dynamic selector");
+
+    // Three ordinary VOP3A operations account for the other live GTA source-width rejects. Each
+    // scalar source is one broadcast dword. Keep VCC_HI unresolved after the join while replacing
+    // VCC_LO, then execute the exact observed packets so widening any of them to Pair fails here.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_vop3_b32_sources = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBEEA0381u,                         // pc2: scalar arm vcc_lo = 1
+        0xBEEB0380u,                         // pc3: scalar arm vcc_hi = 0
+        0xBF820001u,                         // pc4: merge
+        0xBEEA0A7Eu,                         // pc5: mask-only WQM vcc = exec
+        0xBEEA0380u,                         // pc6: definite B32 overwrite of vcc_lo only
+        0xBE950381u,                         // pc7: s21 = 1
+        0x7E020280u,                         // pc8: v1 = 0
+        0x7E060280u,                         // pc9: v3 = 0
+        0x7E180280u,                         // pc10: v12 = 0
+        0xD543000Eu, 0x01A82B01u,            // pc11: exact v_mad_u32_u24, VCC_LO in SRC2
+        0xD5418004u, 0x01AA18FFu, 0x39D1B717u, // pc13: exact v_mad_f32, VCC_LO in SRC2
+        0xD7470002u, 0x020E066Au,            // pc16: exact v_add_lshl_u32, VCC_LO in SRC0
+    };
+    compute_cfg_dispatch_exact_vop3_b32_sources.insert(
+        compute_cfg_dispatch_exact_vop3_b32_sources.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_vop3_b32_sources.data(),
+                             compute_cfg_dispatch_exact_vop3_b32_sources.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact ordinary VOP3A packets consume only the definitely replaced scalar dword");
+
+    std::vector<uint32_t> compute_cfg_dispatch_vop3_143_ambiguous_source =
+        compute_cfg_dispatch_exact_vop3_b32_sources;
+    compute_cfg_dispatch_vop3_143_ambiguous_source[12] =
+        0x01AC2B01u;                         // same 0x143 site: SRC2=vcc_hi remains ambiguous
+    CHECK(recompile_compute(compute_cfg_dispatch_vop3_143_ambiguous_source.data(),
+                            compute_cfg_dispatch_vop3_143_ambiguous_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "VOP3 opcode 0x143 rejects an unresolved scalar dword at its exact source field");
+    std::vector<uint32_t> compute_cfg_dispatch_vop3_141_ambiguous_source =
+        compute_cfg_dispatch_exact_vop3_b32_sources;
+    compute_cfg_dispatch_vop3_141_ambiguous_source[14] =
+        0x01AE18FFu;                         // same 0x141 site: SRC2=vcc_hi remains ambiguous
+    CHECK(recompile_compute(compute_cfg_dispatch_vop3_141_ambiguous_source.data(),
+                            compute_cfg_dispatch_vop3_141_ambiguous_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "VOP3 opcode 0x141 rejects an unresolved scalar dword at its exact source field");
+    std::vector<uint32_t> compute_cfg_dispatch_vop3_347_ambiguous_source =
+        compute_cfg_dispatch_exact_vop3_b32_sources;
+    compute_cfg_dispatch_vop3_347_ambiguous_source[17] =
+        0x020E066Bu;                         // same 0x347 site: SRC0=vcc_hi remains ambiguous
+    CHECK(recompile_compute(compute_cfg_dispatch_vop3_347_ambiguous_source.data(),
+                            compute_cfg_dispatch_vop3_347_ambiguous_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "VOP3 opcode 0x347 rejects an unresolved scalar dword at its exact source field");
+
+    std::vector<uint32_t> compute_cfg_dispatch_vop3_wrong_b32_half =
+        compute_cfg_dispatch_exact_vop3_b32_sources;
+    compute_cfg_dispatch_vop3_wrong_b32_half[6] =
+        0xBEEB0380u;                         // replace vcc_hi; VCC_LO remains ambiguous
+    CHECK(recompile_compute(compute_cfg_dispatch_vop3_wrong_b32_half.data(),
+                            compute_cfg_dispatch_vop3_wrong_b32_half.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "GTA's exact VOP3A consumers reject when only the other VCC half is replaced");
+
+    // A B64 logical may combine a proved wave mask with a complete scalar ballot pair. Its earlier
+    // VOP3B join roots an ambiguous mask pair at odd s55: the scalar operand starts at base+1 and
+    // only overlaps s56, which is definitely replaced. Validate actual read-range overlap, then
+    // reconstruct this lane's Bool bit from the complete scalar pair under native Wave64.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_scalar_pair_mask = {
+        0x7E000280u,                         // pc0: v0 = 0
+        0x7E020280u,                         // pc1: v1 = 0
+        0xBF068008u,                         // pc2: scalar branch condition
+        0xBF840003u,                         // pc3: branch to mask-producing arm
+        0xBEB70381u,                         // pc4: scalar arm s55 = 1
+        0xBEB80380u,                         // pc5: scalar arm s56 = 0
+        0xBF820002u,                         // pc6: merge after two-dword VOP3B
+        0xD70F3700u, 0x00020300u,            // pc7: mask arm v_add_co_u32 ...,s55
+        0xBEB6037Eu,                         // pc9: s54 = exec_lo
+        0xBEB8037Eu,                         // pc10: s56 = exec_lo
+        0xBEB9037Fu,                         // pc11: s57 = exec_hi
+        0xBEEA047Eu,                         // pc12: vcc = exec
+        0x87EA386Au,                         // pc13: exact live s_and_b64 vcc,vcc,s[56:57]
+        0xBF068008u,                         // pc14: fresh SCC condition
+        0xBF840001u,                         // pc15: conditional edge forces a dispatcher reload
+        0xBF800000u,                         // pc16: fallthrough arm rejoins the consumer
+        0xBE84146Au,                         // pc17: s_ff1_i32_b64 s4,vcc after reload
+        0x7E040204u,                         // pc18: consume scalar reduction result
+    };
+    compute_cfg_dispatch_exact_scalar_pair_mask.insert(
+        compute_cfg_dispatch_exact_scalar_pair_mask.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_scalar_pair_mask.data(),
+                             compute_cfg_dispatch_exact_scalar_pair_mask.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact B64 logical projects a fully materialized scalar ballot pair to a mask");
+
+    std::vector<uint32_t> compute_cfg_dispatch_shifted_unresolved_pair =
+        compute_cfg_dispatch_exact_scalar_pair_mask;
+    compute_cfg_dispatch_shifted_unresolved_pair[13] =
+        0x87EA366Au;                         // same site reads s[54:55], overlapping unresolved s55
+    CHECK(recompile_compute(compute_cfg_dispatch_shifted_unresolved_pair.data(),
+                            compute_cfg_dispatch_shifted_unresolved_pair.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a pair rooted before an odd ambiguous mask rejects its unresolved overlapping word");
+
+    // exec_cs_205b5e8600 pc1467 has a different, exact mixed-domain VCC join. The first-entry arm
+    // executes `s_mov_b64 vcc,exec`; the loop backedge reconstructs VCC_LO/HI with v_readlane.
+    // Native-Wave64 S_MOV materializes ballot words, so both predecessors carry exact scalar words
+    // and the live s_and_b64 can project that common pair back to its per-lane predicate. Replacing
+    // only the entry producer with mask-only WQM removes those words and must reject at the join.
+    std::vector<uint32_t> compute_cfg_dispatch_live_mixed_vcc_pair = {
+        0xBE800380u,                         // pc0: s0 = 0
+        0x7E000280u, 0x7E020280u,            // pc1: v0/v1 = 0
+        0xBF068008u,                         // pc3: unresolved choice keeps both arms reachable
+        0xBF840002u,                         // pc4: branch to v_readlane arm
+        0xBEEA047Eu,                         // pc5: exact live producer s_mov_b64 vcc,exec
+        0xBF820004u,                         // pc6: skip scalar reconstruction
+        0xD760006Au, 0x00010100u,            // pc7: v_readlane_b32 vcc_lo,v0,0
+        0xD760006Bu, 0x00010101u,            // pc9: v_readlane_b32 vcc_hi,v1,0
+        0xBEB8037Eu, 0xBEB9037Fu,            // pc11: scalar ballot pair s[56:57]
+        0x87EA386Au,                         // pc13: exact live AND vcc,vcc,s[56:57]
+    };
+    compute_cfg_dispatch_live_mixed_vcc_pair.insert(
+        compute_cfg_dispatch_live_mixed_vcc_pair.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_live_mixed_vcc_pair.data(),
+                             compute_cfg_dispatch_live_mixed_vcc_pair.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact mixed VCC join reaches pc1467 through native ballot words");
+    std::vector<uint32_t> compute_cfg_dispatch_unmaterialized_vcc_pair =
+        compute_cfg_dispatch_live_mixed_vcc_pair;
+    compute_cfg_dispatch_unmaterialized_vcc_pair[5] =
+        0xBEEA0A7Eu;                         // same producer: WQM retains only the mask view
+    CHECK(recompile_compute(compute_cfg_dispatch_unmaterialized_vcc_pair.data(),
+                            compute_cfg_dispatch_unmaterialized_vcc_pair.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "the mixed VCC join rejects when its entry producer lacks scalar ballot words");
+
+    // A fresh VCC mask can itself overlap the high word of an older odd-rooted ambiguity. The exact
+    // pc1467 packet reads VCC in the Bool domain and s[56:57] in the scalar domain, so only the latter
+    // needs scalar-word facts. Mutating SRC0 at that same site to s[104:105] makes the unresolved s105
+    // word a real scalar-pair read and must reject.
+    std::vector<uint32_t> compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity = {
+        0x7E000280u,                         // pc0: v0 = 0
+        0x7E020280u,                         // pc1: v1 = 0
+        0xBF068008u,                         // pc2: scalar branch condition
+        0xBF840003u,                         // pc3: branch to odd mask-producing arm
+        0xBEE90381u,                         // pc4: scalar arm s105 = 1
+        0xBEEA0380u,                         // pc5: scalar arm vcc_lo = 0
+        0xBF820002u,                         // pc6: merge after two-dword VOP3B
+        0xD70F6900u, 0x00020300u,            // pc7: mask arm v_add_co_u32 ...,s105
+        0xBEB8037Eu,                         // pc9: s56 = exec_lo
+        0xBEB9037Fu,                         // pc10: s57 = exec_hi
+        0xBEEA047Eu,                         // pc11: fresh vcc = exec, overlapping old root105
+        0x87EA386Au,                         // pc12: exact live s_and_b64 vcc,vcc,s[56:57]
+    };
+    compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity.insert(
+        compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity.data(),
+                             compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "a proved VCC mask ignores an older overlapping scalar-domain ambiguity");
+    std::vector<uint32_t> compute_cfg_dispatch_real_odd_scalar_source =
+        compute_cfg_dispatch_fresh_vcc_over_odd_ambiguity;
+    compute_cfg_dispatch_real_odd_scalar_source[12] =
+        0x87EA3868u;                         // same site: SRC0=s[104:105], s105 unresolved
+    CHECK(recompile_compute(compute_cfg_dispatch_real_odd_scalar_source.data(),
+                            compute_cfg_dispatch_real_odd_scalar_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "the same B64 logical rejects when its overlapping source is a real scalar pair");
+
+    // The next live site in exec_cs_205b654a00 is V_MBCNT_HI with mask word s1 and a fake SRC2=s0.
+    // Each MBCNT half consumes one B32 mask word; widening s1 to a pair incorrectly reaches the
+    // unrelated ambiguity rooted at s2. The source mutation to s3 makes that ambiguity real.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_mbcnt_hi_word = {
+        0xBE80047Eu,                         // pc0: saved mask s[0:1] = exec
+        0xBF068008u,                         // pc1: scalar branch condition
+        0xBF840003u,                         // pc2: branch to mask-producing arm
+        0xBE820381u,                         // pc3: scalar arm s2 = 1
+        0xBE830380u,                         // pc4: scalar arm s3 = 0
+        0xBF820001u,                         // pc5: merge
+        0xBE820A7Eu,                         // pc6: mask-only WQM s[2:3] = exec
+        0xD7660003u, 0x00010001u,            // pc7: exact pc2036 mbcnt_hi v3,s1,0
+        0xBE820480u,                         // pc9: resolve s[2:3] after the observed packet
+    };
+    compute_cfg_dispatch_exact_mbcnt_hi_word.insert(
+        compute_cfg_dispatch_exact_mbcnt_hi_word.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_mbcnt_hi_word.data(),
+                             compute_cfg_dispatch_exact_mbcnt_hi_word.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact MBCNT_HI consumes one proved mask word beside an unrelated ambiguity");
+    std::vector<uint32_t> compute_cfg_dispatch_ambiguous_mbcnt_hi_word =
+        compute_cfg_dispatch_exact_mbcnt_hi_word;
+    compute_cfg_dispatch_ambiguous_mbcnt_hi_word[8] =
+        0x00010003u;                         // same site: MBCNT_HI now names ambiguous s3
+    CHECK(recompile_compute(compute_cfg_dispatch_ambiguous_mbcnt_hi_word.data(),
+                            compute_cfg_dispatch_ambiguous_mbcnt_hi_word.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "MBCNT_HI rejects an unresolved mask/scalar word at the same source site");
+
+    // The final live site joins an exact scalar load against `s_mov_b64 s[16:17], 0`. The constant
+    // move has both an empty-mask view and the identical two-word scalar value in production. A
+    // mask-only EXEC move at the same site is the mutation arm and must remain rejected.
+    std::vector<uint32_t> compute_cfg_dispatch_dual_domain_b64_constant = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to constant-mask arm
+        0xBE900380u,                         // pc2: scalar arm s16 = 0
+        0xBE910380u,                         // pc3: scalar arm s17 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE900480u,                         // pc5: s_mov_b64 s[16:17], 0 in both domains
+        0x7E000210u,                         // pc6: v0 = s16
+        0x7E020211u,                         // pc7: v1 = s17
+    };
+    compute_cfg_dispatch_dual_domain_b64_constant.insert(
+        compute_cfg_dispatch_dual_domain_b64_constant.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_dual_domain_b64_constant.data(),
+                             compute_cfg_dispatch_dual_domain_b64_constant.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "an inline B64 constant remains scalar-readable across a mask/scalar join");
+
+    std::vector<uint32_t> compute_cfg_dispatch_mask_only_b64_move =
+        compute_cfg_dispatch_dual_domain_b64_constant;
+    compute_cfg_dispatch_mask_only_b64_move[5] =
+        0xBE900A7Eu;                         // s_wqm_b64 s[16:17],exec has no scalar-word view
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_only_b64_move.data(),
+                            compute_cfg_dispatch_mask_only_b64_move.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a mask-only B64 move cannot masquerade as scalar data at the same consumer");
+
+    // A definite mask lifetime (as opposed to an ambiguous join) must survive the dispatcher's
+    // Function-variable round trip without its synthetic scalar-zero placeholders shadowing the
+    // Bool value. Scalar use of that mask remains fail-visible; changing the exact producer to an
+    // inline constant gives both physical words a real scalar lifetime and makes the same use valid.
+    std::vector<uint32_t> compute_cfg_dispatch_mask_only_scalar_reload = {
+        0xBE900A7Eu,                         // pc0: mask-only s_wqm_b64 s[16:17],exec
+        0xBF068008u,                         // pc1: fresh SCC condition
+        0xBF840001u,                         // pc2: conditional dispatcher edge to consumer
+        0xBF800000u,                         // pc3: fallthrough arm rejoins consumer
+        0x7E040210u,                         // pc4: invalid scalar read v2=s16 after reload
+    };
+    compute_cfg_dispatch_mask_only_scalar_reload.insert(
+        compute_cfg_dispatch_mask_only_scalar_reload.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_only_scalar_reload.data(),
+                            compute_cfg_dispatch_mask_only_scalar_reload.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a reloaded mask-only pair cannot be read through scalar placeholder variables");
+    std::vector<uint32_t> compute_cfg_dispatch_dual_scalar_reload =
+        compute_cfg_dispatch_mask_only_scalar_reload;
+    compute_cfg_dispatch_dual_scalar_reload[0] =
+        0xBE900480u;                         // same producer: inline zero has real scalar words
+    CHECK(!recompile_compute(compute_cfg_dispatch_dual_scalar_reload.data(),
+                             compute_cfg_dispatch_dual_scalar_reload.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "an inline B64 constant retains both scalar words across a dispatcher reload");
+
+    // Native Wave64 S_MOV_B64 materializes an exact ballot pair as well as its Bool alias, even
+    // when its saved-SGPR source has only a mask representation. That copy must retain both words
+    // across a real dispatcher boundary. Replacing the copy with mask-only WQM at the exact site
+    // removes the scalar representation, so CSELECT must reject instead of reading zeros.
+    std::vector<uint32_t> compute_cfg_dispatch_dual_mask_move_reload = {
+        0xBE900A7Eu,                         // pc0: mask-only saved s[16:17] = WQM(exec)
+        0xBE920410u,                         // pc1: S_MOV materializes s[18:19] ballot words
+        0xBE940381u, 0xBE950380u,            // pc2: scalar-only s[20:21] = 1
+        0xBF068008u,                         // pc4: fresh SCC condition
+        0xBF840001u,                         // pc5: conditional dispatcher edge
+        0xBF800000u,                         // pc6: fallthrough rejoins consumer
+        0x85EA1412u,                         // pc7: cselect vcc,s[18:19],s[20:21]
+    };
+    compute_cfg_dispatch_dual_mask_move_reload.insert(
+        compute_cfg_dispatch_dual_mask_move_reload.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_dual_mask_move_reload.data(),
+                             compute_cfg_dispatch_dual_mask_move_reload.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "a dual-domain S_MOV_B64 copy retains scalar words across a dispatcher reload");
+    std::vector<uint32_t> compute_cfg_dispatch_mask_only_move_reload =
+        compute_cfg_dispatch_dual_mask_move_reload;
+    compute_cfg_dispatch_mask_only_move_reload[1] =
+        0xBE920A7Eu;                         // same site: WQM writes a mask without scalar words
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_only_move_reload.data(),
+                            compute_cfg_dispatch_mask_only_move_reload.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "the same mixed-domain consumer rejects after a mask-only producer mutation");
+
+    // A complete scalar S_CSELECT_B64 into VCC also emits both views: its selected pair remains
+    // scalar-readable while VCC consumers use the lane predicate. Force a second CSELECT after a
+    // boundary to require both views. Mutating the first CSELECT to choose between two masks takes
+    // its mask-only branch and makes that downstream scalar-pair use fail visibly.
+    std::vector<uint32_t> compute_cfg_dispatch_dual_cselect_reload = {
+        0xBE920381u, 0xBE930380u,            // pc0: scalar-only s[18:19] = 1
+        0xBE940382u, 0xBE950380u,            // pc2: scalar-only s[20:21] = 2
+        0xBF068008u,                         // pc4: define SCC for first cselect
+        0x85EA1412u,                         // pc5: dual cselect vcc,s18,s20
+        0xBF068008u,                         // pc6: fresh branch SCC
+        0xBF840001u,                         // pc7: conditional dispatcher edge
+        0xBF800000u,                         // pc8: fallthrough rejoins consumer
+        0x8598146Au,                         // pc9: cselect s[24:25],vcc,s[20:21]
+    };
+    compute_cfg_dispatch_dual_cselect_reload.insert(
+        compute_cfg_dispatch_dual_cselect_reload.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_dual_cselect_reload.data(),
+                             compute_cfg_dispatch_dual_cselect_reload.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "a scalar-pair CSELECT into VCC retains both domains across a dispatcher reload");
+    std::vector<uint32_t> compute_cfg_dispatch_mask_cselect_reload =
+        compute_cfg_dispatch_dual_cselect_reload;
+    compute_cfg_dispatch_mask_cselect_reload[5] =
+        0x85EA807Eu;                         // same site: cselect vcc,exec,0 is mask-only
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_cselect_reload.data(),
+                            compute_cfg_dispatch_mask_cselect_reload.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a mask-only CSELECT mutation cannot supply scalar words after reload");
+
+    // exec_cs_205b654a00 pc2121 stores through T# s[32:39]. IMAGE_STORE has no sampler, although
+    // generic MIMG decode exposes the reserved SSAMP field as SRC2=s0. Keep s[0:1] ambiguous at the
+    // exact packet: the storage form must ignore it, while a same-site IMAGE_SAMPLE mutation makes
+    // S# s[0:3] real and must reject. Clear the pair only after the packet so the appended dispatcher
+    // can continue without turning a successfully ignored source into a later unrelated rejection.
+    std::vector<uint32_t> compute_cfg_dispatch_image_store_fake_sampler = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE800381u,                         // pc2: scalar arm s0 = 1
+        0xBE810380u,                         // pc3: scalar arm s1 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE800A7Eu,                         // pc5: mask-only WQM s[0:1] = exec
+        0x7E000280u, 0x7E020280u,            // pc6: v0/v1 = 0
+        0x7E040280u, 0x7E060280u,            // pc8: v2/v3 = 0
+        0x7E180280u, 0x7E1A0280u,            // pc10: v12/v13 = 0
+        0xF0200F08u, 0x0008000Cu,            // pc12: exact image_store, T# s32, fake S# s0
+        0xBE800480u,                         // pc14: resolve s[0:1] after the observed packet
+    };
+    compute_cfg_dispatch_image_store_fake_sampler.insert(
+        compute_cfg_dispatch_image_store_fake_sampler.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    ShaderResourceTable wave64_store_rt = dispatch_rt;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+      image.format = DataFormat::Float32; image.num_components = 4;
+      image.binding = 4; image.fetch_pc = 12; image.sgpr_base = 32; image.img_dim = 1;
+      image.width = image.height = image.depth = 1; wave64_store_rt.resources.push_back(image); }
+    ComputeShaderConfig wave64_store_config = wave64_dispatch_config;
+    wave64_store_config.user_sgprs.resize(40);
+    CHECK(!recompile_compute(compute_cfg_dispatch_image_store_fake_sampler.data(),
+                             compute_cfg_dispatch_image_store_fake_sampler.size(), &wave64_store_rt,
+                             wave64_store_config).empty(),
+          "GTA's exact IMAGE_STORE ignores its decoded fake sampler source");
+
+    std::vector<uint32_t> compute_cfg_dispatch_image_sample_real_sampler =
+        compute_cfg_dispatch_image_store_fake_sampler;
+    compute_cfg_dispatch_image_sample_real_sampler[12] =
+        0xF0800F08u;                         // same site: image_sample now consumes S# s[0:3]
+    ShaderResourceTable wave64_sample_rt = dispatch_rt;
+    { ShaderResource image{}; image.cls = ResourceClass::Texture;
+      image.format = DataFormat::Float32; image.num_components = 4;
+      image.binding = 4; image.fetch_pc = 12; image.sgpr_base = 32;
+      image.sampler_sgpr_base = 0; image.img_dim = 1;
+      image.width = image.height = image.depth = 1; wave64_sample_rt.resources.push_back(image); }
+    CHECK(recompile_compute(compute_cfg_dispatch_image_sample_real_sampler.data(),
+                            compute_cfg_dispatch_image_sample_real_sampler.size(), &wave64_sample_rt,
+                            wave64_store_config).empty(),
+          "a sampled-image mutation rejects the same ambiguous SGPRs when they become a real S#");
+
+    std::vector<uint32_t> compute_cfg_dispatch_image_store_ambiguous_resource =
+        compute_cfg_dispatch_image_store_fake_sampler;
+    compute_cfg_dispatch_image_store_ambiguous_resource[13] =
+        0x0000000Cu;                         // same site: real eight-word T# moves onto s[0:7]
+    ShaderResourceTable wave64_ambiguous_store_rt = dispatch_rt;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+      image.format = DataFormat::Float32; image.num_components = 4;
+      image.binding = 4; image.fetch_pc = 12; image.sgpr_base = 0; image.img_dim = 1;
+      image.width = image.height = image.depth = 1;
+      wave64_ambiguous_store_rt.resources.push_back(image); }
+    CHECK(recompile_compute(compute_cfg_dispatch_image_store_ambiguous_resource.data(),
+                            compute_cfg_dispatch_image_store_ambiguous_resource.size(),
+                            &wave64_ambiguous_store_rt, wave64_store_config).empty(),
+          "IMAGE_STORE still rejects an ambiguous real T# while ignoring only its fake S#");
+
+    // S_BUFFER_* reads a complete four-word descriptor. Put an unresolved pair only in the upper
+    // half of s[16:19]: treating SBASE as an ordinary two-word scalar address would miss the overlap
+    // and silently admit it. Moving that exact packet's SBASE to non-overlapping s[20:23] is the
+    // same-site control arm and must compile with the corresponding captured resource.
+    std::vector<uint32_t> compute_cfg_dispatch_sbuffer_quad_descriptor = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-only arm
+        0xBE920381u, 0xBE930380u,            // pc2: scalar s[18:19]
+        0xBF820001u,                         // pc4: merge
+        0xBE920A7Eu,                         // pc5: mask-only WQM s[18:19]
+        0xF4200708u, 0xFA000000u,            // pc6: s_buffer_load_dword s28,s[16:19],0
+        0xBE920480u,                         // pc8: resolve the pair after the exact packet
+    };
+    compute_cfg_dispatch_sbuffer_quad_descriptor.insert(
+        compute_cfg_dispatch_sbuffer_quad_descriptor.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    ShaderResourceTable wave64_sbuffer_rt = dispatch_rt;
+    { ShaderResource constants{}; constants.cls = ResourceClass::ConstantBuffer;
+      constants.binding = 5; constants.size = 64; constants.fetch_pc = 6;
+      constants.sgpr_base = 16; wave64_sbuffer_rt.resources.push_back(constants); }
+    ComputeShaderConfig wave64_descriptor_config = wave64_dispatch_config;
+    wave64_descriptor_config.user_sgprs.resize(24);
+    CHECK(recompile_compute(compute_cfg_dispatch_sbuffer_quad_descriptor.data(),
+                            compute_cfg_dispatch_sbuffer_quad_descriptor.size(),
+                            &wave64_sbuffer_rt, wave64_descriptor_config).empty(),
+          "S_BUFFER rejects ambiguity in the upper half of its four-word descriptor");
+    std::vector<uint32_t> compute_cfg_dispatch_sbuffer_nonoverlap =
+        compute_cfg_dispatch_sbuffer_quad_descriptor;
+    compute_cfg_dispatch_sbuffer_nonoverlap[6] =
+        0xF420070Au;                         // same site: SBASE moves to s[20:23]
+    ShaderResourceTable wave64_sbuffer_nonoverlap_rt = wave64_sbuffer_rt;
+    wave64_sbuffer_nonoverlap_rt.resources.back().sgpr_base = 20;
+    CHECK(!recompile_compute(compute_cfg_dispatch_sbuffer_nonoverlap.data(),
+                             compute_cfg_dispatch_sbuffer_nonoverlap.size(),
+                             &wave64_sbuffer_nonoverlap_rt,
+                             wave64_descriptor_config).empty(),
+          "S_BUFFER accepts the same packet when all four descriptor words are unambiguous");
+
+    // IMAGE_BVH_INTERSECT_RAY is the one MIMG opcode whose SRSRC is a compact four-word BVH
+    // descriptor rather than an eight-word T#. An ambiguity beginning immediately after s[8:11]
+    // is therefore irrelevant; moving the exact packet's SRSRC to s[12:15] makes that same pair
+    // observable and must reject. The reserved sampler field remains non-operational for BVH.
+    std::vector<uint32_t> compute_cfg_dispatch_bvh_quad_descriptor = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-only arm
+        0xBE8C0381u, 0xBE8D0380u,            // pc2: scalar s[12:13]
+        0xBF820001u,                         // pc4: merge
+        0xBE8C0A7Eu,                         // pc5: mask-only WQM s[12:13]
+        0xF1989F07u, 0x00020202u,            // pc6: BVH packet, SRSRC=s[8:11]
+        0x28292C23u, 0x22262725u, 0x00002A24u,
+        0xBE8C0480u,                         // pc11: resolve after the packet
+    };
+    compute_cfg_dispatch_bvh_quad_descriptor.insert(
+        compute_cfg_dispatch_bvh_quad_descriptor.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    uint32_t wave64_bvh_words[16]{};
+    ShaderResourceTable wave64_bvh_rt = dispatch_rt;
+    { ShaderResource bvh{}; bvh.cls = ResourceClass::ConstantBuffer;
+      bvh.format = DataFormat::Uint32; bvh.num_components = 1;
+      bvh.binding = 6; bvh.size = sizeof(wave64_bvh_words); bvh.fetch_pc = 6;
+      bvh.sgpr_base = 8; bvh.host_data = reinterpret_cast<uint8_t*>(wave64_bvh_words);
+      bvh.host_data_size = sizeof(wave64_bvh_words); wave64_bvh_rt.resources.push_back(bvh); }
+    CHECK(!recompile_compute(compute_cfg_dispatch_bvh_quad_descriptor.data(),
+                             compute_cfg_dispatch_bvh_quad_descriptor.size(), &wave64_bvh_rt,
+                             wave64_descriptor_config).empty(),
+          "BVH ignores ambiguity immediately beyond its compact four-word descriptor");
+    std::vector<uint32_t> compute_cfg_dispatch_bvh_ambiguous_descriptor =
+        compute_cfg_dispatch_bvh_quad_descriptor;
+    compute_cfg_dispatch_bvh_ambiguous_descriptor[7] =
+        0x00030202u;                         // same site: SRSRC=s[12:15]
+    ShaderResourceTable wave64_bvh_ambiguous_rt = wave64_bvh_rt;
+    wave64_bvh_ambiguous_rt.resources.back().sgpr_base = 12;
+    CHECK(recompile_compute(compute_cfg_dispatch_bvh_ambiguous_descriptor.data(),
+                            compute_cfg_dispatch_bvh_ambiguous_descriptor.size(),
+                            &wave64_bvh_ambiguous_rt, wave64_descriptor_config).empty(),
+          "BVH rejects ambiguity inside its exact four-word descriptor");
     // GTA V also consumes saved EXEC halves through V_MBCNT after dispatcher boundaries. LOW names
     // the pair root and HIGH names its following dword; both consumers must be admitted only where
     // the Wave64 MUST-domain proof says that same B64 mask lifetime reaches the exact PC.


### PR DESCRIPTION
## Summary

- preserve independently proven scalar low/high words alongside Wave64 lane-mask values
- materialize exact native-Wave64 `S_MOV_B64` ballot words and propagate dual-scalar join facts
- replace broad operand assumptions with exact SOP/SMEM/MUBUF/MIMG/VOP inventories
- keep scalar/mask conversions fail-closed and add exact captured-shape regressions

## Root cause

The recompiler represented a Wave64 scalar pair as either a lane mask or scalar words. GTA V emits joins where the pair is both: one arm obtains VCC through a ballot-like mask operation, while another defines the low and high scalar words. Collapsing that state to mask-only lost valid scalar uses later in the CFG and produced `wave64-ambiguous-mask-read` rejections.

This change tracks per-word scalar MUST facts alongside mask identity. It only reconstructs scalar words where every reaching definition proves them, and keeps ambiguous or synthetic fields rejected.

## GTA V impact

A fresh 200-second Story Mode route advances four exact programs:

- `0x205b5e8600`: terminal pc 1467 -> pc 1802
- `0x205b654a00`: terminal pc 2036 -> pc 2232
- `0x205b658800`: terminal pc 1937 -> pc 2546
- `0x413ce6000`: the old pc 180 Wave64 rejection clears and exposes a pc 156 unresolved operand on the alternate emission route

The run reached gameplay and exited normally with no device loss. The 3D world remains black, so #2481 stays open.

## Validation

- `recompile_coverage`, `rdna2_spirv_struct`, `spv_validate`: 3/3 passed
- full local distrobox suite: 232/232 passed with `ctest --no-tests=error -j4`
- independent control-flow/recompiler review approved commit `904e05ad` and independently reproduced the focused and full gates
- same-production-site mutation arms cover the mixed `S_MOV_B64` join, MBCNT, descriptor widths/classes, exact VOP3 fields, B64 scalar logical operands, and dual-scalar selection

Detailed live evidence is recorded in #2481.