### PR TITLE
fix(recompiler): advance GTA Wave64 CFG consumers

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -636,12 +636,13 @@ void decode_operands(Rdna2Inst& i) {
                 i.src[2] = {};
                 i.n_src = 2;
             }
-            // V_LSHLREV_B64, V_LDEXP_F32, and V_BFM_B32 are two-source VOP3A instructions. Their
-            // reserved SRC2 bits are zero in GTA V's exact packets and therefore decode as s0 unless
-            // cleared here.
+            // V_MAC_F32, V_LSHLREV_B64, V_LDEXP_F32, and V_BFM_B32 are two-source VOP3A
+            // instructions. Their reserved SRC2 bits are zero in GTA V's exact packets and
+            // therefore decode as s0 unless cleared here.
             // Exposing that phantom scalar read can make CFG/provenance analysis reject an otherwise
             // valid instruction when s0 differs across a merge, before the opcode emitter is reached.
-            if (i.opcode == 0x2ffu || i.opcode == 0x362u || i.opcode == 0x363u) {
+            if (i.opcode == 0x11fu || i.opcode == 0x2ffu ||
+                i.opcode == 0x362u || i.opcode == 0x363u) {
                 i.src[2] = {};
                 i.n_src = 2;
             }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -7849,6 +7849,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                                                        mask_write_clobbers_pair(rs, in.dst.value); }
                 else { rs.sreg_bool[in.dst.value] = r; rs.sreg_bool_narrowed[in.dst.value] = true;
                        mask_write_clobbers_pair(rs, in.dst.value); }
+                // One exact native subgroup per guest Wave64 also makes the logical result's
+                // architectural SGPR pair available. GTA joins an early scalar EXEC ballot with
+                // a later S_ANDN2_B64 survivor mask and then compares s[56:57] as u64. Preserve
+                // both views from the same Bool; portable/unknown subgroup modes remain mask-only.
+                if (!is_exec(in.dst) && b.is_compute && b.wave_size == 64 &&
+                    b.native_subgroup_size == 64) {
+                    rs.sreg[in.dst.value] = b.native_wave_ballot_half(r, 0);
+                    rs.sreg[in.dst.value + 1] = b.native_wave_ballot_half(r, 1);
+                    rs.sreg_srt.erase(in.dst.value);
+                    rs.sreg_srt.erase(in.dst.value + 1);
+                }
                 return true;
             }
             // The NGG wave-packing s_lshr_b64 form (dst = EXEC) sets EXEC to the count of active
@@ -14926,7 +14937,7 @@ bool emit_cfg_state_machine(
                     }
                 case Rdna2Format::VOP3:
                     // Decode exposes an unused SRC2=s0 on the lane read/write encodings. Their real
-                    // scalar data and lane-selector operands are each one dword. The three ordinary
+                    // scalar data and lane-selector operands are each one dword. The six ordinary
                     // VOP3A operations below are the exact GTA consumers in this reject family and
                     // likewise broadcast one scalar dword per source. Retain the conservative pair
                     // rule for every un-inventoried VOP3 opcode, including explicit mask inputs.
@@ -14934,7 +14945,14 @@ bool emit_cfg_state_machine(
                         return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::None;
                     if (in.opcode == 0x365 || in.opcode == 0x366)
                         return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::None;
-                    if (in.opcode == 0x141 || in.opcode == 0x143 || in.opcode == 0x347)
+                    if (in.opcode == 0x11f)
+                        return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::None;
+                    // CNDMASK's two data operands are dwords; SRC2 remains a Wave64 condition
+                    // pair and deliberately keeps the conservative full-pair inventory.
+                    if (in.opcode == 0x101)
+                        return source < 2 ? ScalarSourceRead::B32 : ScalarSourceRead::Pair;
+                    if (in.opcode == 0x141 || in.opcode == 0x143 ||
+                        in.opcode == 0x347 || in.opcode == 0x36f)
                         return ScalarSourceRead::B32;
                     return ScalarSourceRead::Pair;
                 default:
@@ -15046,8 +15064,9 @@ bool emit_cfg_state_machine(
                     mask_write = in.dst.value;
                 else if (in.opcode >= 0x0f && in.opcode <= 0x1d &&
                          (in.opcode & 1u) == 1)
-                    // Emission for every B64 logical is mask-only. Scalar pairs are projected to
-                    // their per-lane bit before the operation, so the result is never scalar DATA.
+                    // Every B64 logical has a Bool-domain result. Exact native Wave64 additionally
+                    // materializes that result's ballot words below, but its mask lifetime remains
+                    // the primary classification here.
                     mask_write = in.dst.value;
                 else if (in.opcode == 0x0b && in.dst.value == 106 &&
                          !b.cselect_b64_low_only_pcs.contains(in.pc))
@@ -15131,8 +15150,12 @@ bool emit_cfg_state_machine(
                     !b.cselect_b64_low_only_pcs.contains(in.pc) &&
                     !(source_is_mask(in.src[0]) && source_is_mask(in.src[1])) &&
                     complete_scalar_pair(in.src[0]) && complete_scalar_pair(in.src[1]);
+                const bool logical_native_ballot = in.fmt == Rdna2Format::SOP2 &&
+                    in.opcode >= 0x0f && in.opcode <= 0x1d &&
+                    (in.opcode & 1u) == 1 && b.is_compute && b.wave_size == 64 &&
+                    b.native_subgroup_size == 64;
                 const bool dual_domain_scalar_write =
-                    mov_dual_domain || cselect_scalar_branch;
+                    mov_dual_domain || cselect_scalar_branch || logical_native_ballot;
                 if (!dual_domain_scalar_write) {
                     scalar_words.erase(mask_write);
                     scalar_words.erase(mask_write + 1);

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -124,6 +124,16 @@ int main() {
           gta_bfm.src[1].kind == OperandKind::InlineInt && gta_bfm.src[1].value == 0 &&
           gta_bfm.src[2].kind == OperandKind::None,
           "GTA V v_bfm_b32 decodes two sources and no phantom s0");
+    // GTA V exec_cs_205b658800 pc2546: `v_mac_f32_e64 v15, -s31, v2`. V_MAC reads
+    // SRC0/SRC1 and its old VDST; the encoded SRC2 field is reserved and must not invent s0.
+    const uint32_t gta_vmac_words[] = {0xd51f000fu, 0x2002041fu};
+    const Rdna2Inst gta_vmac = rdna2_decode_one(gta_vmac_words, 2);
+    CHECK(gta_vmac.fmt == Rdna2Format::VOP3 && gta_vmac.opcode == 0x11fu &&
+          gta_vmac.n_src == 2 && isV(gta_vmac.dst, 15) &&
+          isS(gta_vmac.src[0], 31) && isV(gta_vmac.src[1], 2) &&
+          gta_vmac.src[2].kind == OperandKind::None && gta_vmac.src_neg[0] &&
+          !gta_vmac.src_neg[1],
+          "GTA V v_mac_f32 decodes two sources and no phantom s0");
     // GTA V exec_cs_205b658800 pc61: `v_lshlrev_b64 v[24:25], v4, 1`. The reserved SRC2 field
     // must not surface as s0, and the shared writer inventory must retain both result halves.
     const uint32_t gta_lshlrev_b64_words[] = {0xd6ff0018u, 0x00010304u};

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -1033,9 +1033,10 @@ int main() {
                             &dispatch_rt, wave64_dispatch_config).empty(),
           "v_readlane still rejects an ambiguous SGPR used as its real dynamic selector");
 
-    // Three ordinary VOP3A operations account for the other live GTA source-width rejects. Each
-    // scalar source is one broadcast dword. Keep VCC_HI unresolved after the join while replacing
-    // VCC_LO, then execute the exact observed packets so widening any of them to Pair fails here.
+    // Three ordinary VOP3A arithmetic operations account for the other live GTA source-width
+    // rejects. Each scalar source is one broadcast dword. Keep VCC_HI unresolved after the join
+    // while replacing VCC_LO, then execute the exact observed packets so widening any of them to
+    // Pair fails here.
     std::vector<uint32_t> compute_cfg_dispatch_exact_vop3_b32_sources = {
         0xBF068008u,                         // pc0: scalar branch condition
         0xBF840003u,                         // pc1: branch to mask-producing arm
@@ -1093,6 +1094,124 @@ int main() {
                             compute_cfg_dispatch_vop3_wrong_b32_half.size(), &dispatch_rt,
                             wave64_dispatch_config).empty(),
           "GTA's exact VOP3A consumers reject when only the other VCC half is replaced");
+
+    // exec_cs_413d22d00 pc665 is V_CNDMASK_B32_E64 with scalar SRC1=s17. An unrelated
+    // mask/scalar join leaves s18 ambiguous, so widening the one-dword s17 operand to a pair
+    // incorrectly rejects this packet. Keep the production words intact and mutate SRC1 at that
+    // same site to s18 so the negative arm still observes the genuinely ambiguous dword.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_vop3_cndmask_b32_source = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE920381u,                         // pc2: scalar arm s18 = 1
+        0xBE930380u,                         // pc3: scalar arm s19 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE920A7Eu,                         // pc5: mask-only WQM s[18:19] = exec
+        0xBE910381u,                         // pc6: definite scalar s17 = 1
+        0x7E300280u,                         // pc7: v24 = 0
+        0x7E2A0280u,                         // pc8: v21 = 0
+        0x7D8414F9u, 0x06868E82u,            // pc9: exact live compare writes mask s[14:15]
+        0xD5010015u, 0x00382318u,            // pc11: exact live cndmask v21,v24,s17,s[14:15]
+    };
+    compute_cfg_dispatch_exact_vop3_cndmask_b32_source.insert(
+        compute_cfg_dispatch_exact_vop3_cndmask_b32_source.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_vop3_cndmask_b32_source.data(),
+                             compute_cfg_dispatch_exact_vop3_cndmask_b32_source.size(),
+                             &dispatch_rt, wave64_dispatch_config).empty(),
+          "GTA's exact VOP3 cndmask consumes only its scalar source dword");
+
+    std::vector<uint32_t> compute_cfg_dispatch_vop3_cndmask_ambiguous_source =
+        compute_cfg_dispatch_exact_vop3_cndmask_b32_source;
+    compute_cfg_dispatch_vop3_cndmask_ambiguous_source[12] =
+        0x00382518u;                         // same pc11 packet with SRC1=s18
+    CHECK(recompile_compute(compute_cfg_dispatch_vop3_cndmask_ambiguous_source.data(),
+                            compute_cfg_dispatch_vop3_cndmask_ambiguous_source.size(),
+                            &dispatch_rt, wave64_dispatch_config).empty(),
+          "VOP3 cndmask rejects an unresolved scalar dword at its exact source field");
+
+    // exec_cs_205b654a00 pc2232 is V_LSHL_OR_B32 with scalar SRC0=s8. The preceding
+    // V_READFIRSTLANE definitely replaces s8, while the adjacent s9 remains ambiguous after a
+    // mask/scalar join. Every source of this integer VOP3A operation is one dword; mutating only
+    // SRC0 at the production packet to s9 must still observe and reject the unresolved value.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_lshl_or_b32_source = {
+        0xBF068008u,                         // pc0: scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE880381u,                         // pc2: scalar arm s8 = 1
+        0xBE890380u,                         // pc3: scalar arm s9 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE880A7Eu,                         // pc5: mask-only WQM s[8:9] = exec
+        0x7E000280u,                         // pc6: v0 = 0
+        0x7E100500u,                         // pc7: exact upstream readfirstlane s8,v0
+        0xBE920384u, 0xBE930382u,            // pc8: scalar s[18:19] = {4,2}
+        0xBE940384u, 0xBE950382u,            // pc10: scalar s[20:21] = {4,2}
+        0xBF068008u,                         // pc12: define SCC for the pair selection
+        0x85EA1412u,                         // pc13: materialize scalar pair in VCC
+        0xD76F0002u, 0x01A92008u,            // pc14: exact lshl_or v2,s8,16,vcc_lo
+        0xBE880480u,                         // pc16: clear the unrelated pair for the tail
+    };
+    const size_t lshl_or_dispatch_base =
+        compute_cfg_dispatch_exact_lshl_or_b32_source.size();
+    compute_cfg_dispatch_exact_lshl_or_b32_source.insert(
+        compute_cfg_dispatch_exact_lshl_or_b32_source.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    // This fixture deliberately overwrites s8, which is also the synthetic tail's direct V#.
+    // Preserve the tail's instruction count and CFG while removing that unrelated descriptor read.
+    compute_cfg_dispatch_exact_lshl_or_b32_source[lshl_or_dispatch_base + 12] = 0xBF800000u;
+    compute_cfg_dispatch_exact_lshl_or_b32_source[lshl_or_dispatch_base + 13] = 0xBF800000u;
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_lshl_or_b32_source.data(),
+                             compute_cfg_dispatch_exact_lshl_or_b32_source.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact VOP3 lshl_or consumes only its definitely replaced scalar dword");
+
+    std::vector<uint32_t> compute_cfg_dispatch_lshl_or_ambiguous_source =
+        compute_cfg_dispatch_exact_lshl_or_b32_source;
+    compute_cfg_dispatch_lshl_or_ambiguous_source[15] =
+        0x01A92009u;                         // same pc14 packet with SRC0=s9
+    CHECK(recompile_compute(compute_cfg_dispatch_lshl_or_ambiguous_source.data(),
+                            compute_cfg_dispatch_lshl_or_ambiguous_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "VOP3 lshl_or rejects an unresolved scalar dword at its exact source field");
+
+    // exec_cs_205b658800 pc2546 is two-source V_MAC_F32 with real SRC0=s31. A scalar load
+    // replaces through s31, but s32 remains ambiguous. Keep a second ambiguity at s0 so this
+    // fixture also requires the decoder to suppress V_MAC's reserved SRC2 field. The same-site
+    // mutation changes only real SRC0 to s32 and must remain fail-visible.
+    std::vector<uint32_t> compute_cfg_dispatch_exact_vmac_b32_source = {
+        0xBF068008u,                         // pc0: first scalar branch condition
+        0xBF840003u,                         // pc1: branch to mask-producing arm
+        0xBE800381u,                         // pc2: scalar arm s0 = 1
+        0xBE810380u,                         // pc3: scalar arm s1 = 0
+        0xBF820001u,                         // pc4: merge
+        0xBE800A7Eu,                         // pc5: mask-only WQM s[0:1] = exec
+        0xBF068008u,                         // pc6: second scalar branch condition
+        0xBF840003u,                         // pc7: branch to mask-producing arm
+        0xBEA00381u,                         // pc8: scalar arm s32 = 1
+        0xBEA10380u,                         // pc9: scalar arm s33 = 0
+        0xBF820001u,                         // pc10: merge
+        0xBEA00A7Eu,                         // pc11: mask-only WQM s[32:33] = exec
+        0xBE9F0381u,                         // pc12: definite scalar s31 = 1
+        0x7E040280u,                         // pc13: v2 = 0
+        0x7E1E0280u,                         // pc14: old v15 = 0
+        0xD51F000Fu, 0x2002041Fu,            // pc15: exact v_mac v15,-s31,v2
+        0xBE800480u,                         // pc17: clear s[0:1] for the tail
+        0xBEA00480u,                         // pc18: clear s[32:33] for the tail
+    };
+    compute_cfg_dispatch_exact_vmac_b32_source.insert(
+        compute_cfg_dispatch_exact_vmac_b32_source.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_exact_vmac_b32_source.data(),
+                             compute_cfg_dispatch_exact_vmac_b32_source.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "GTA's exact VOP3 v_mac ignores reserved SRC2 and reads one scalar dword");
+
+    std::vector<uint32_t> compute_cfg_dispatch_vmac_ambiguous_source =
+        compute_cfg_dispatch_exact_vmac_b32_source;
+    compute_cfg_dispatch_vmac_ambiguous_source[16] =
+        0x20020420u;                         // same pc15 packet with real SRC0=s32
+    CHECK(recompile_compute(compute_cfg_dispatch_vmac_ambiguous_source.data(),
+                            compute_cfg_dispatch_vmac_ambiguous_source.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "VOP3 v_mac rejects an unresolved scalar dword at its exact source field");
 
     // A B64 logical may combine a proved wave mask with a complete scalar ballot pair. Its earlier
     // VOP3B join roots an ambiguous mask pair at odd s55: the scalar operand starts at base+1 and
@@ -1167,6 +1286,39 @@ int main() {
                             compute_cfg_dispatch_unmaterialized_vcc_pair.size(), &dispatch_rt,
                             wave64_dispatch_config).empty(),
           "the mixed VCC join rejects when its entry producer lacks scalar ballot words");
+
+    // The next site in exec_cs_205b5e8600 joins early exits that retain scalar EXEC ballot words
+    // s[56:57] with the normal path's exact pc1798 S_ANDN2_B64 survivor mask. Under native Wave64,
+    // the logical result has the same exact ballot-word representation as the early path, so the
+    // pc1802 S_CMP_EQ_U64 consumer is safe. Replacing only pc1798 with mask-only WQM removes those
+    // scalar words and must reject at the unchanged full-pair consumer.
+    std::vector<uint32_t> compute_cfg_dispatch_logical_ballot_join = {
+        0xBEB8037Eu,                         // pc0: scalar s56 = exec_lo
+        0xBEB9037Fu,                         // pc1: scalar s57 = exec_hi
+        0x7E400280u,                         // pc2: v32 = 0
+        0xBF068008u,                         // pc3: unresolved choice keeps both paths
+        0xBF840003u,                         // pc4: early path skips pc5-pc7 to join
+        0x7D8A40C1u,                         // pc5: exact pc1797 compare creates VCC
+        0x8AB86A38u,                         // pc6: exact pc1798 andn2 s56,s56,vcc
+        0xBF800000u,                         // pc7: normal path reaches join
+        0xBF128038u,                         // pc8: exact pc1802 cmp_eq_u64 s[56:57],0
+    };
+    compute_cfg_dispatch_logical_ballot_join.insert(
+        compute_cfg_dispatch_logical_ballot_join.end(), compute_cfg_dispatch,
+        compute_cfg_dispatch + std::size(compute_cfg_dispatch));
+    CHECK(!recompile_compute(compute_cfg_dispatch_logical_ballot_join.data(),
+                             compute_cfg_dispatch_logical_ballot_join.size(), &dispatch_rt,
+                             wave64_dispatch_config).empty(),
+          "native Wave64 retains exact scalar ballot words for a B64 logical result");
+
+    std::vector<uint32_t> compute_cfg_dispatch_mask_only_logical_join =
+        compute_cfg_dispatch_logical_ballot_join;
+    compute_cfg_dispatch_mask_only_logical_join[6] =
+        0xBEB80A7Eu;                         // same pc6: WQM has no scalar-word view
+    CHECK(recompile_compute(compute_cfg_dispatch_mask_only_logical_join.data(),
+                            compute_cfg_dispatch_mask_only_logical_join.size(), &dispatch_rt,
+                            wave64_dispatch_config).empty(),
+          "a mask-only mutation cannot supply pc1802's scalar pair");
 
     // A fresh VCC mask can itself overlap the high word of an older odd-rooted ambiguity. The exact
     // pc1467 packet reads VCC in the Bool domain and s[56:57] in the scalar domain, so only the latter

--- a/prosper/tools/spv_validate/spv_validate.cpp
+++ b/prosper/tools/spv_validate/spv_validate.cpp
@@ -597,6 +597,25 @@ int main(int argc, char** argv) {
       vb.binding=3; vb.sgpr_base=8; vb.stride=16; vb.format=DataFormat::Float32;
       vb.num_components=4; rt.resources.push_back(vb);
       dump(dir, "compute_cfg_dispatch", recompile_valu(c, sizeof(c)/4, 0, 0, &rt)); }
+    // GTA V Wave64 survivor-mask join: one arm retains scalar EXEC words while the other computes
+    // the same physical pair through S_ANDN2_B64. Validate the native subgroup ballots that make
+    // the logical result scalar-readable at the exact trailing S_CMP_EQ_U64.
+    { const uint32_t c[] = {
+          0xBEB8037Eu,0xBEB9037Fu,0x7E400280u,0xBF068008u,0xBF840003u,
+          0x7D8A40C1u,0x8AB86A38u,0xBF800000u,0xBF128038u,
+          0xBE800380u,0x7E000280u,0x7E020300u,
+          0xD7610013u,0x00014A7Eu,0xD7610013u,0x0001507Fu,
+          0xD760000Eu,0x00014B13u,0xD760000Fu,0x00015113u,0xBEFE040Eu,
+          0xE00C2000u,0x80020400u,0x7DB900F9u,0x86050007u,
+          0x7D020200u,0xBF860006u,0xBF0A8204u,0x360000FDu,0xBF840001u,
+          0x81008100u,0x81008100u,0xBF82FFF4u,0xBF810000u};
+      ShaderResourceTable rt; ShaderResource vb{}; vb.cls=ResourceClass::VertexBuffer;
+      vb.binding=3; vb.sgpr_base=8; vb.stride=16; vb.format=DataFormat::Float32;
+      vb.num_components=4; rt.resources.push_back(vb);
+      ComputeShaderConfig cfg; cfg.local_x=64; cfg.wave_size=64;
+      cfg.native_subgroup_size=64;
+      dump(dir, "compute_wave64_logical_ballot",
+           recompile_compute(c, sizeof(c)/4, &rt, cfg)); }
     // Ordinary e64 integer-pair comparisons (unsigned then signed), separate from mask provenance.
     { const uint32_t c[] = {0xd4e4006au,0x00010000u,0xd4a4006au,0x00010000u,
                             0xbf810000u};


### PR DESCRIPTION
## Summary

- preserve exact scalar ballot words for native Wave64 B64 logical results while retaining their mask view
- classify the remaining live GTA V VOP3 scalar operands at their architectural dword widths
- decode V_MAC_F32 as a two-source instruction so its reserved SRC2 field cannot invent an s0 dependency
- cover all four captured sites with exact packets, same-site fail-visible mutations, and strict SPIR-V validation

## Root cause

The Wave64 CFG transfer treated every B64 logical result as mask-only even when an exact native guest-size subgroup can materialize its architectural low/high ballot words. Separately, conservative pair-width accounting widened scalar dword VALU sources, while V_MAC_F32 exposed its reserved SRC2 bits as a phantom scalar operand. Those three mismatches rejected valid guest control-flow states before their existing opcode emitters could run.

## Validation

- Release: 232/232 tests passed with ctest --no-tests=error -j4
- Debug focused gate: 4/4 passed
- independent recompiler review: approved with no findings; reviewer independently passed Release 3/3 and Debug 3/3 and confirmed all four packets with llvm-mc
- 200-second routed GTA V Story Mode run completed without device loss

The routed run directly advanced every target program:

- 0x205b5e8600: terminal pc1802 removed; next terminal pc242
- 0x205b654a00: terminal pc2232 removed; next terminal pc114
- 0x205b658800: terminal pc2546 removed; next terminal pc263
- 0x413d22d00: pc665 removed and no terminal dispatch skip remains

The 3D world is still black, so this PR claims shader advancement rather than the final visual fix.

Refs #2481
