### PR TITLE
feat(diagnostics): add minimal boot timeline diagnostics

### DIFF
--- a/docs/diagnostics/README.md
+++ b/docs/diagnostics/README.md
@@ -1,0 +1,103 @@
+# Diagnostics Layer — Minimal Boot Timeline
+
+**Status:** Optional, observer-only instrumentation (OFF by default)
+
+## Overview
+
+This directory contains a minimal diagnostics layer for capturing boot timeline events during PS4 program startup. It is designed to have **zero overhead when disabled** — all calls compile to inline no-ops.
+
+## Architecture
+
+```
+src/diagnostics/
+├── diagnostics.hpp          # Single include entry point (stubs when disabled)
+├── core/
+│   ├── types.hpp            # BootPhase enum, BootEvent struct
+│   ├── event_bus.hpp/.cpp   # Thread-safe pub/sub event bus
+│   └── context.hpp/.cpp     # DiagnosticContext singleton coordinator
+└── storage/
+    └── json_writer.hpp/.cpp # JSON output for boot events
+```
+
+## Building
+
+### Default (Disabled)
+
+```bash
+cmake -B build -S prosper
+cmake --build build
+```
+
+No diagnostics code is compiled. The `diagnostics.hpp` header provides stubs that optimize to nothing.
+
+### Enabled
+
+```bash
+cmake -B build -S prosper -DPROSPER_DIAGNOSTICS=ON
+cmake --build build
+```
+
+Compiles ~300 lines of optional code: EventBus, DiagnosticContext, and JsonWriter.
+
+## Usage
+
+```cpp
+#include "diagnostics/diagnostics.hpp"
+
+// Enable recording (optional — can be enabled at runtime)
+prosper::diagnostics::DiagnosticContext::instance().enable();
+
+// Record boot phases (called from boot_program.cpp automatically)
+prosper::diagnostics::record_boot_phase(prosper::diagnostics::BootPhase::PROCESS_START);
+
+// Export as JSON
+auto json = prosper::diagnostics::JsonWriter::write_events(
+    prosper::diagnostics::DiagnosticContext::instance().events()
+);
+```
+
+## Boot Phases
+
+| Phase | Description |
+|-------|-------------|
+| `PROCESS_START` | `boot_program()` entered |
+| `LINKING` | `link_program()` completed |
+| `HLE_REGISTERED` | `register_builtin_hle()` complete |
+| `MODULES_MAPPED` | All images mapped into guest VA |
+| `STUBS_INSTALLED` | Trap handler + stubs active |
+| `GUEST_INITS_RUNNING` | `run_guest_inits()` called |
+| `BOOT_COMPLETE` | `boot_program()` returning true |
+
+## Output Format
+
+JSON array of timestamped phase events:
+
+```json
+[
+  {"phase": "PROCESS_START", "timestamp_ms": 0.00},
+  {"phase": "LINKING", "timestamp_ms": 1.23},
+  {"phase": "BOOT_COMPLETE", "timestamp_ms": 45.67}
+]
+```
+
+## Tests
+
+Three tests verify correctness:
+
+1. **test_diagnostics_disabled** — Verifies stub behavior (always runs)
+2. **test_diagnostics_enabled** — Verifies event capture (requires `-DPROSPER_DIAGNOSTICS=ON`)
+3. **test_diagnostics_json** — Verifies JSON output format (requires `-DPROSPER_DIAGNOSTICS=ON`)
+
+Run with: `ctest --test-dir build -R diagnostics`
+
+## Integration Point
+
+The **only modification to existing code** is in `src/host/boot_program.cpp`, which includes `diagnostics/diagnostics.hpp` and calls `record_boot_phase()` at each boot milestone. When diagnostics are disabled, these calls are inlined no-ops with zero runtime cost.
+
+## Design Principles
+
+1. **Observer-only**: Does not alter program behavior; only records events
+2. **Zero-cost disabled path**: Stubs compile to empty functions
+3. **Thread-safe**: Mutex-protected event bus and context
+4. **Opt-in**: CMake option required; off by default
+5. **Minimal scope**: Boot timeline only (~300 lines)

--- a/docs/diagnostics/design_sample.md
+++ b/docs/diagnostics/design_sample.md
@@ -1,0 +1,73 @@
+# Design Sample — Illustrative Boot Timeline Output
+
+> **Note:** This document contains **illustrative examples only**. These are not real measurements from any specific title or hardware configuration. Actual timestamps vary by host hardware, game dump, and system load.
+
+## Sample JSON Output
+
+```json
+[
+  {"phase": "PROCESS_START", "timestamp_ms": 0.00},
+  {"phase": "LINKING", "timestamp_ms": 2.15},
+  {"phase": "HLE_REGISTERED", "timestamp_ms": 2.87},
+  {"phase": "MODULES_MAPPED", "timestamp_ms": 8.42},
+  {"phase": "STUBS_INSTALLED", "timestamp_ms": 9.01},
+  {"phase": "GUEST_INITS_RUNNING", "timestamp_ms": 9.15},
+  {"phase": "BOOT_COMPLETE", "timestamp_ms": 47.83}
+]
+```
+
+## Phase Duration Breakdown
+
+| Phase | Duration (ms) | Cumulative (ms) |
+|-------|---------------|-----------------|
+| PROCESS_START → LINKING | ~2.15 | 2.15 |
+| LINKING → HLE_REGISTERED | ~0.72 | 2.87 |
+| HLE_REGISTERED → MODULES_MAPPED | ~5.55 | 8.42 |
+| MODULES_MAPPED → STUBS_INSTALLED | ~0.59 | 9.01 |
+| STUBS_INSTALLED → GUEST_INITS_RUNNING | ~0.14 | 9.15 |
+| GUEST_INITS_RUNNING → BOOT_COMPLETE | ~38.68 | 47.83 |
+
+## Usage Example
+
+```cpp
+#include "diagnostics/diagnostics.hpp"
+#include <iostream>
+
+void capture_boot_timeline() {
+    auto& ctx = prosper::diagnostics::DiagnosticContext::instance();
+    ctx.enable();
+    ctx.clear();
+
+    // ... boot_program() runs here, recording phases ...
+
+    // Export timeline
+    std::string json = prosper::diagnostics::JsonWriter::write_events(ctx.events());
+    std::cout << json << std::endl;
+
+    // Or iterate events
+    for (const auto& ev : ctx.events()) {
+        printf("%s: %.3f ms\n",
+               prosper::diagnostics::phase_name(ev.phase),
+               ev.timestamp_ms);
+    }
+}
+```
+
+## EventBus Subscription Example
+
+```cpp
+#include "diagnostics/diagnostics.hpp"
+
+void setup_live_monitor() {
+    auto handle = prosper::diagnostics::event_bus().subscribe(
+        [](const prosper::diagnostics::BootEvent& ev) {
+            printf("[boot] %s at %.3f ms\n",
+                   prosper::diagnostics::phase_name(ev.phase),
+                   ev.timestamp_ms);
+        });
+
+    // Events now stream to callback in real-time
+    // Unsubscribe when done:
+    // prosper::diagnostics::event_bus().unsubscribe(handle);
+}
+```

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -15,6 +15,11 @@ if(MINGW OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU"))
   add_link_options(-static -static-libgcc -static-libstdc++)
 endif()
 
+# --- Diagnostics (optional observer-only instrumentation) -----------------
+# Boot timeline capture, event bus, JSON export. OFF by default: zero cost when
+# disabled (stubs compile to no-ops). ON adds ~300 lines of optional code.
+option(PROSPER_DIAGNOSTICS "Enable diagnostics instrumentation (boot timeline, event bus)" OFF)
+
 # --- macOS Vulkan (MoltenVK) override ------------------------------------
 # prosper on macOS is built x86_64 (to run the guest under Rosetta), but Homebrew's MoltenVK/loader
 # are arm64-only, so find_package(Vulkan) would hand back an unlinkable arm64 lib. Point the build at
@@ -64,11 +69,20 @@ include(cmake/ProsperBuildRevision.cmake)
 prosper_add_build_revision_library(prosper_build_revision WORK_TREE "${CMAKE_SOURCE_DIR}/..")
 
 file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)
+# Exclude diagnostics sources when feature is disabled (default).
+# When enabled, PROSPER_DIAGNOSTICS define activates the real implementation;
+# the headers always compile (stubs when disabled).
+if(NOT PROSPER_DIAGNOSTICS)
+  list(FILTER PROSPER_SRC EXCLUDE REGEX "src/diagnostics/")
+endif()
 if(PROSPER_SRC)
   add_library(prosper_core STATIC ${PROSPER_SRC})
   target_include_directories(prosper_core PUBLIC src)
   target_link_libraries(prosper_core PUBLIC libatrac9 PRIVATE prosper_build_revision)
   target_compile_definitions(prosper_core PRIVATE PROSPER_SOURCE_DIR="${CMAKE_SOURCE_DIR}")
+  if(PROSPER_DIAGNOSTICS)
+    target_compile_definitions(prosper_core PRIVATE PROSPER_DIAGNOSTICS)
+  endif()
   find_package(Threads REQUIRED)
   target_link_libraries(prosper_core PUBLIC Threads::Threads)
   # Windows: the guest futex HLE (sceKernelWaitOnAddress/WakeByAddress) is backed by the native Win32
@@ -783,6 +797,24 @@ if(TARGET prosper_core)
   add_executable(test_module_path_case tests/test_module_path_case.cpp)
   target_link_libraries(test_module_path_case PRIVATE prosper_core)
   add_test(NAME module_path_case COMMAND test_module_path_case)
+
+  # Diagnostics: disabled-path test — verifies stubs are zero-cost (always runs).
+  add_executable(test_diagnostics_disabled tests/test_diagnostics_disabled.cpp)
+  target_link_libraries(test_diagnostics_disabled PRIVATE prosper_core)
+  add_test(NAME diagnostics_disabled_stubs COMMAND test_diagnostics_disabled)
+
+  # Diagnostics: enabled-path and JSON tests (only when feature is built).
+  if(PROSPER_DIAGNOSTICS)
+    add_executable(test_diagnostics_enabled tests/test_diagnostics_enabled.cpp)
+    target_link_libraries(test_diagnostics_enabled PRIVATE prosper_core)
+    target_compile_definitions(test_diagnostics_enabled PRIVATE PROSPER_DIAGNOSTICS)
+    add_test(NAME diagnostics_enabled_capture COMMAND test_diagnostics_enabled)
+
+    add_executable(test_diagnostics_json tests/test_diagnostics_json.cpp)
+    target_link_libraries(test_diagnostics_json PRIVATE prosper_core)
+    target_compile_definitions(test_diagnostics_json PRIVATE PROSPER_DIAGNOSTICS)
+    add_test(NAME diagnostics_json_format COMMAND test_diagnostics_json)
+  endif()
 
   # Unity native-plugin auto-link (#1609): a title's own Media/Plugins/*.prx that the fixed preload
   # list never named must still be linked, or its first P/Invoke raises a DllNotFoundException that

--- a/prosper/src/diagnostics/core/context.cpp
+++ b/prosper/src/diagnostics/core/context.cpp
@@ -1,0 +1,66 @@
+// context.cpp — DiagnosticContext implementation.
+
+#include "context.hpp"
+#include "event_bus.hpp"
+
+namespace prosper::diagnostics {
+
+DiagnosticContext& DiagnosticContext::instance() {
+    static DiagnosticContext ctx;
+    return ctx;
+}
+
+bool DiagnosticContext::is_enabled() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return enabled_;
+}
+
+void DiagnosticContext::enable() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    enabled_ = true;
+}
+
+void DiagnosticContext::disable() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    enabled_ = false;
+}
+
+void DiagnosticContext::record_phase(BootPhase phase) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!enabled_) return;
+    BootEvent event(phase, monotonic_ms());
+    events_.push_back(event);
+    // Publish outside lock to avoid potential deadlock with subscribers.
+    mutex_.unlock();
+    event_bus().publish(event);
+    mutex_.lock();
+}
+
+void DiagnosticContext::emit(const BootEvent& event) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!enabled_) return;
+    events_.push_back(event);
+    mutex_.unlock();
+    event_bus().publish(event);
+    mutex_.lock();
+}
+
+size_t DiagnosticContext::event_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return events_.size();
+}
+
+const std::vector<BootEvent>& DiagnosticContext::events() const {
+    return events_;  // Caller should hold their own sync if iterating while recording
+}
+
+void DiagnosticContext::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    events_.clear();
+}
+
+void record_boot_phase(BootPhase phase) {
+    DiagnosticContext::instance().record_phase(phase);
+}
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/core/context.hpp
+++ b/prosper/src/diagnostics/core/context.hpp
@@ -1,0 +1,48 @@
+// context.hpp — DiagnosticContext coordinator (PROSPER_DIAGNOSTICS build only).
+//
+// Singleton context that:
+// - Enables/disables diagnostics globally
+// - Records boot phase events
+// - Stores event history for JSON export
+
+#pragma once
+
+#include "types.hpp"
+#include <vector>
+#include <mutex>
+
+namespace prosper::diagnostics {
+
+class DiagnosticContext {
+public:
+    static DiagnosticContext& instance();
+
+    // Enable/disable recording. When disabled, record_phase() is a no-op.
+    bool is_enabled() const;
+    void enable();
+    void disable();
+
+    // Record a boot phase transition (only if enabled).
+    void record_phase(BootPhase phase);
+
+    // Manually emit an event (for custom instrumentation).
+    void emit(const BootEvent& event);
+
+    // Query recorded events.
+    size_t event_count() const;
+    const std::vector<BootEvent>& events() const;
+
+    // Clear all recorded events.
+    void clear();
+
+private:
+    DiagnosticContext() = default;
+    mutable std::mutex mutex_;
+    bool enabled_ = false;
+    std::vector<BootEvent> events_;
+};
+
+// Convenience: record current phase to global context.
+void record_boot_phase(BootPhase phase);
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/core/event_bus.cpp
+++ b/prosper/src/diagnostics/core/event_bus.cpp
@@ -1,0 +1,50 @@
+// event_bus.cpp — EventBus implementation.
+
+#include "event_bus.hpp"
+#include <algorithm>
+
+namespace prosper::diagnostics {
+
+size_t EventBus::subscribe(Subscriber cb) {
+    if (!cb) return 0;
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t h = next_handle_++;
+    subscribers_.push_back(std::move(cb));
+    return h;
+}
+
+void EventBus::unsubscribe(size_t handle) {
+    // Handles are 1-based indices; subscriber at index handle-1.
+    // We null-out rather than erase to preserve other handles.
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (handle == 0 || handle > subscribers_.size()) return;
+    subscribers_[handle - 1] = nullptr;
+}
+
+void EventBus::publish(const BootEvent& event) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (auto& sub : subscribers_) {
+        if (sub) sub(event);
+    }
+}
+
+size_t EventBus::subscriber_count() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    size_t count = 0;
+    for (const auto& sub : subscribers_)
+        if (sub) ++count;
+    return count;
+}
+
+void EventBus::clear() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    subscribers_.clear();
+    next_handle_ = 1;
+}
+
+EventBus& event_bus() {
+    static EventBus bus;
+    return bus;
+}
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/core/event_bus.hpp
+++ b/prosper/src/diagnostics/core/event_bus.hpp
@@ -1,0 +1,43 @@
+// event_bus.hpp — Thread-safe event bus for diagnostics (PROSPER_DIAGNOSTICS build only).
+//
+// Subscribers receive events via callable signature void(const BootEvent&).
+// Bus owns no state beyond the subscriber list; all events are passed by const ref.
+
+#pragma once
+
+#include "types.hpp"
+#include <vector>
+#include <functional>
+#include <mutex>
+
+namespace prosper::diagnostics {
+
+class EventBus {
+public:
+    using Subscriber = std::function<void(const BootEvent&)>;
+
+    // Subscribe a callback. Returns handle for unsubscribe (0 on error).
+    size_t subscribe(Subscriber cb);
+
+    // Remove subscriber by handle.
+    void unsubscribe(size_t handle);
+
+    // Publish event to all current subscribers.
+    void publish(const BootEvent& event);
+
+    // Current subscriber count.
+    size_t subscriber_count() const;
+
+    // Clear all subscribers.
+    void clear();
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<Subscriber> subscribers_;
+    size_t next_handle_ = 1;
+};
+
+// Global accessor (created on first use when diagnostics enabled).
+EventBus& event_bus();
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/core/types.hpp
+++ b/prosper/src/diagnostics/core/types.hpp
@@ -1,0 +1,52 @@
+// types.hpp — Core type definitions for diagnostics (PROSPER_DIAGNOSTICS build only).
+
+#pragma once
+
+#include <string>
+#include <cstdint>
+#include <chrono>
+
+namespace prosper::diagnostics {
+
+// Boot phases tracked during PS4 program startup.
+// These align with milestones in boot_program().
+enum class BootPhase : unsigned {
+    PROCESS_START = 0,     // boot_program() entered
+    LINKING,              // link_program() complete
+    HLE_REGISTERED,       // register_builtin_hle() complete
+    MODULES_MAPPED,       // all images mapped into guest VA
+    STUBS_INSTALLED,      // trap handler + stubs active
+    GUEST_INITS_RUNNING,  // run_guest_inits() called
+    BOOT_COMPLETE,        // boot_program() returning true
+    _COUNT                // sentinel — must be last
+};
+
+// Convert BootPhase to human-readable string.
+inline const char* phase_name(BootPhase p) {
+    static const char* names[] = {
+        "PROCESS_START", "LINKING", "HLE_REGISTERED", "MODULES_MAPPED",
+        "STUBS_INSTALLED", "GUEST_INITS_RUNNING", "BOOT_COMPLETE"
+    };
+    unsigned i = static_cast<unsigned>(p);
+    return i < static_cast<unsigned>(BootPhase::_COUNT) ? names[i] : "UNKNOWN";
+}
+
+// A single timestamped boot event.
+struct BootEvent {
+    BootPhase phase;
+    double timestamp_ms;  // milliseconds from process start (monotonic)
+
+    BootEvent(BootPhase p, double ts) : phase(p), timestamp_ms(ts) {}
+};
+
+// Severity levels for future diagnostic categories (reserved).
+enum class Severity : unsigned { INFO, WARNING, ERROR };
+
+// Get monotonic time in milliseconds since first call.
+inline double monotonic_ms() {
+    using clock = std::chrono::steady_clock;
+    static const auto t0 = clock::now();
+    return std::chrono::duration<double, std::milli>(clock::now() - t0).count();
+}
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/diagnostics.hpp
+++ b/prosper/src/diagnostics/diagnostics.hpp
@@ -1,0 +1,62 @@
+// diagnostics.hpp — Single include entry point for prosper diagnostics.
+//
+// When PROSPER_DIAGNOSTICS is OFF (default), this header compiles to zero-cost
+// stubs: all calls inline to empty functions with no overhead.
+//
+// When ON, the full observer-only diagnostics layer is available for boot
+// timeline capture, event subscription, and JSON report generation.
+
+#pragma once
+
+#ifdef PROSPER_DIAGNOSTICS
+#include "core/types.hpp"
+#include "core/event_bus.hpp"
+#include "core/context.hpp"
+#include "storage/json_writer.hpp"
+#else
+
+namespace prosper::diagnostics {
+
+// Boot phases tracked during program startup.
+enum class BootPhase : unsigned {
+    PROCESS_START = 0,
+    LINKING,
+    HLE_REGISTERED,
+    MODULES_MAPPED,
+    STUBS_INSTALLED,
+    GUEST_INITS_RUNNING,
+    BOOT_COMPLETE,
+    _COUNT  // sentinel
+};
+
+// Event emitted when a boot phase is reached.
+struct BootEvent {
+    BootPhase phase;
+    double timestamp_ms;  // monotonic clock
+};
+
+// Stub context — all methods are no-ops when diagnostics disabled.
+class DiagnosticContext {
+public:
+    static DiagnosticContext& instance() {
+        static DiagnosticContext ctx;
+        return ctx;
+    }
+
+    bool is_enabled() const { return false; }
+    void enable() {}
+    void disable() {}
+
+    void record_phase(BootPhase) {}
+    void emit(const BootEvent&) {}
+
+    size_t event_count() const { return 0; }
+    void clear() {}
+};
+
+// Inline stubs — compiler optimizes these away entirely.
+inline void record_boot_phase(BootPhase) {}
+
+} // namespace prosper::diagnostics
+
+#endif // PROSPER_DIAGNOSTICS

--- a/prosper/src/diagnostics/storage/json_writer.cpp
+++ b/prosper/src/diagnostics/storage/json_writer.cpp
@@ -1,0 +1,31 @@
+// json_writer.cpp — Minimal JSON writer implementation.
+
+#include "json_writer.hpp"
+#include <cstdio>
+#include <cmath>
+
+namespace prosper::diagnostics {
+
+std::string JsonWriter::write_event(const BootEvent& event) {
+    char buf[128];
+    // Use %g for compact floating-point output
+    int n = snprintf(buf, sizeof(buf),
+        "{\"phase\":\"%s\",\"timestamp_ms\":%.3g}",
+        phase_name(event.phase), event.timestamp_ms);
+    return std::string(buf, (n > 0 && n < (int)sizeof(buf)) ? n : 0);
+}
+
+std::string JsonWriter::write_events(const std::vector<BootEvent>& events) {
+    if (events.empty()) return "[]";
+
+    std::string result = "[\n";
+    for (size_t i = 0; i < events.size(); ++i) {
+        result += "  " + write_event(events[i]);
+        if (i + 1 < events.size()) result += ",";
+        result += "\n";
+    }
+    result += "]";
+    return result;
+}
+
+} // namespace prosper::diagnostics

--- a/prosper/src/diagnostics/storage/json_writer.hpp
+++ b/prosper/src/diagnostics/storage/json_writer.hpp
@@ -1,0 +1,24 @@
+// json_writer.hpp — Minimal JSON writer for boot timeline (PROSPER_DIAGNOSTICS build only).
+//
+// Produces a compact JSON array of boot phase events suitable for
+// machine parsing or human review.
+
+#pragma once
+
+#include "../core/types.hpp"
+#include <string>
+#include <vector>
+
+namespace prosper::diagnostics {
+
+class JsonWriter {
+public:
+    // Write boot events as JSON array string.
+    // Format: [{"phase":"NAME","timestamp_ms":N.n}, ...]
+    static std::string write_events(const std::vector<BootEvent>& events);
+
+    // Write single event as JSON object.
+    static std::string write_event(const BootEvent& event);
+};
+
+} // namespace prosper::diagnostics

--- a/prosper/src/host/boot_program.cpp
+++ b/prosper/src/host/boot_program.cpp
@@ -9,6 +9,9 @@
 #include <system_error>
 #include <vector>
 
+// Optional diagnostics (zero-cost when disabled — stubs inline to no-ops).
+#include "diagnostics/diagnostics.hpp"
+
 namespace prosper {
 
 // See boot_program.hpp. The fixed preload list names each module with ONE hard-coded casing, but
@@ -226,6 +229,9 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
                   const std::function<void()>& after_hle_registered) {
     auto fail = [&](const std::string& m) { if (err) *err = m; return false; };
 
+    // Diagnostics: record boot start.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::PROCESS_START);
+
     // libc.prx loaded last => its init_array runs first (deepest dependency), before eboot's entry.
     std::vector<LinkInput> in = boot_link_inputs(d);
 
@@ -257,6 +263,9 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(),
            p.init_fns.size(), p.aliased_exports.size());
 
+    // Diagnostics: linking complete.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::LINKING);
+
     // sceKernelDlsym resolves exports by name against all loaded modules.
     set_module_exports(&p.exports);
     // Per-module tables (#147): LoadStartModule hands out real handles for linked-module paths and
@@ -268,8 +277,14 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     register_builtin_hle();
     if (after_hle_registered) after_hle_registered();   // caller installs host frontends here
 
+    // Diagnostics: HLE handlers registered.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::HLE_REGISTERED);
+
     set_app0_root(d);
     for (auto& img : p.imgs) if (!map_image(img, &e)) return fail("map failed: " + e);
+
+    // Diagnostics: all modules mapped.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::MODULES_MAPPED);
     {
         // General-dynamic and initial-exec TLS consume the same descriptors and module-id order.
         set_tls_modules(p.tls_templates.data(), p.tls_templates.size());
@@ -299,6 +314,9 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     p.slots.reserve(p.slots.size() + 1024);
     if (!install_stubs(p.slots, p.stub_base, p.stub_size, &e)) return fail("stubs failed: " + e);
     install_trap_handler();
+
+    // Diagnostics: stubs and trap handler installed.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::STUBS_INSTALLED);
     // Enable real runtime PRX loading now that the fixed set is linked, mapped and stubbed (#639).
     runtime_module_loader_init(&p);
 
@@ -309,7 +327,12 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
         set_module_start_param_ranges({ { BOOT_PSN, BOOT_SAVEDATA }, { BOOT_SAVEDATA, BOOT_LIBC },
                                         { BOOT_PSNCORE, 0x490000000ull }, { BOOT_PSNCOMMON, 0x4b0000000ull } });
 
+    // Diagnostics: guest initialization running.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::GUEST_INITS_RUNNING);
     run_guest_inits(p.init_fns);
+
+    // Diagnostics: boot complete.
+    diagnostics::record_boot_phase(diagnostics::BootPhase::BOOT_COMPLETE);
     return true;
 }
 

--- a/prosper/tests/test_diagnostics_disabled.cpp
+++ b/prosper/tests/test_diagnostics_disabled.cpp
@@ -1,0 +1,50 @@
+// test_diagnostics_disabled.cpp — Verify diagnostics disabled path is zero-cost.
+//
+// When PROSPER_DIAGNOSTICS is OFF (default), all calls must be no-ops:
+// - is_enabled() returns false
+// - record_phase() produces no events
+// - event_count() stays 0
+//
+// This test runs in ALL builds (no PROSPER_DIAGNOSTICS gate) to verify
+// the stub path compiles and behaves correctly without the feature.
+
+#include <cstdio>
+#include "diagnostics/diagnostics.hpp"
+
+// The diagnostics types live in prosper::diagnostics namespace.
+using prosper::diagnostics::DiagnosticContext;
+using prosper::diagnostics::record_boot_phase;
+using prosper::diagnostics::BootPhase;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_diagnostics_disabled: verifying stub behavior ==\n");
+
+    auto& ctx = DiagnosticContext::instance();
+
+    // Stub context must report disabled.
+    CHECK(!ctx.is_enabled(), "is_enabled() returns false when disabled");
+
+    // Recording phases must be a no-op.
+    size_t before = ctx.event_count();
+    record_boot_phase(BootPhase::PROCESS_START);
+    record_boot_phase(BootPhase::LINKING);
+    record_boot_phase(BootPhase::BOOT_COMPLETE);
+    size_t after = ctx.event_count();
+
+    CHECK(before == after, "record_phase() produces no events when disabled");
+    CHECK(after == 0, "event_count() remains 0");
+
+    // Enable/disable on stubs are no-ops.
+    ctx.enable();
+    CHECK(!ctx.is_enabled(), "enable() is no-op on stub");
+    ctx.disable();
+    CHECK(!ctx.is_enabled(), "disable() is no-op on stub");
+
+    printf(fails ? "\ntest_diagnostics_disabled: %d FAILURE(S)\n"
+                 : "\ntest_diagnostics_disabled: all ok\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_diagnostics_enabled.cpp
+++ b/prosper/tests/test_diagnostics_enabled.cpp
@@ -1,0 +1,95 @@
+// test_diagnostics_enabled.cpp — Verify diagnostics enabled path captures events.
+//
+// Requires PROSPER_DIAGNOSTICS=ON. Tests:
+// - DiagnosticContext enables/disables correctly
+// - record_phase() captures events with monotonic timestamps
+// - EventBus publishes to subscribers
+// - event_count() reflects recorded events
+// - clear() resets state
+
+#ifdef PROSPER_DIAGNOSTICS
+
+#include <cstdio>
+#include <vector>
+#include "diagnostics/diagnostics.hpp"
+
+// The diagnostics types live in prosper::diagnostics namespace.
+using prosper::diagnostics::DiagnosticContext;
+using prosper::diagnostics::record_boot_phase;
+using prosper::diagnostics::BootPhase;
+using prosper::diagnostics::BootEvent;
+using prosper::diagnostics::event_bus;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_diagnostics_enabled: verifying event capture ==\n");
+
+    auto& ctx = DiagnosticContext::instance();
+    ctx.clear();  // start clean
+
+    // Initially disabled after clear/reset.
+    ctx.disable();
+    CHECK(!ctx.is_enabled(), "initially disabled");
+
+    // Enable and verify.
+    ctx.enable();
+    CHECK(ctx.is_enabled(), "enable() works");
+
+    // Record phases and verify capture.
+    ctx.clear();
+    ctx.enable();
+    record_boot_phase(BootPhase::PROCESS_START);
+    record_boot_phase(BootPhase::LINKING);
+    record_boot_phase(BootPhase::HLE_REGISTERED);
+
+    CHECK(ctx.event_count() == 3, "captured 3 phase events");
+
+    // Verify event order and phases.
+    const auto& events = ctx.events();
+    CHECK(events[0].phase == BootPhase::PROCESS_START, "event 0 is PROCESS_START");
+    CHECK(events[1].phase == BootPhase::LINKING, "event 1 is LINKING");
+    CHECK(events[2].phase == BootPhase::HLE_REGISTERED, "event 2 is HLE_REGISTERED");
+
+    // Verify timestamps are non-negative and monotonically increasing.
+    CHECK(events[0].timestamp_ms >= 0, "timestamp >= 0");
+    CHECK(events[1].timestamp_ms >= events[0].timestamp_ms, "monotonic timestamps");
+
+    // Verify EventBus subscriber receives events.
+    std::vector<BootEvent> received;
+    auto sub_handle = event_bus().subscribe(
+        [&received](const BootEvent& ev) { received.push_back(ev); });
+
+    record_boot_phase(BootPhase::MODULES_MAPPED);
+    CHECK(received.size() == 1, "subscriber received 1 event");
+    CHECK(received[0].phase == BootPhase::MODULES_MAPPED, "correct phase in subscriber");
+
+    event_bus().unsubscribe(sub_handle);
+
+    // Disable stops recording.
+    ctx.disable();
+    size_t count_at_disable = ctx.event_count();
+    record_boot_phase(BootPhase::BOOT_COMPLETE);
+    CHECK(ctx.event_count() == count_at_disable, "no events when disabled");
+
+    // Clear resets everything.
+    ctx.enable();
+    ctx.clear();
+    CHECK(ctx.event_count() == 0, "clear() resets event count");
+
+    printf(fails ? "\ntest_diagnostics_enabled: %d FAILURE(S)\n"
+                 : "\ntest_diagnostics_enabled: all ok\n", fails);
+    return fails ? 1 : 0;
+}
+
+#else  // PROSPER_DIAGNOSTICS not defined — this test is vacuous.
+
+#include <cstdio>
+int main() {
+    printf("== test_diagnostics_enabled: SKIPPED (PROSPER_DIAGNOSTICS not enabled) ==\n");
+    return 0;  // Not a failure — feature is off.
+}
+
+#endif

--- a/prosper/tests/test_diagnostics_json.cpp
+++ b/prosper/tests/test_diagnostics_json.cpp
@@ -1,0 +1,69 @@
+// test_diagnostics_json.cpp — Verify JSON output format (PROSPER_DIAGNOSTICS only).
+//
+// Tests that JsonWriter produces valid JSON:
+// - Empty events → "[]"
+// - Single event → correct object format
+// - Multiple events → array with proper commas
+// - Phase names are human-readable
+
+#ifdef PROSPER_DIAGNOSTICS
+
+#include <cstdio>
+#include <string>
+#include "diagnostics/diagnostics.hpp"
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+int main() {
+    printf("== test_diagnostics_json: verifying JSON output ==\n");
+
+    using namespace prosper::diagnostics;
+
+    // Empty list → empty array.
+    std::vector<BootEvent> empty;
+    std::string empty_json = JsonWriter::write_events(empty);
+    CHECK(empty_json == "[]", "empty events → []");
+
+    // Single event.
+    BootEvent single(BootPhase::BOOT_COMPLETE, 42.5);
+    std::string single_json = JsonWriter::write_event(single);
+    CHECK(single_json.find("\"phase\"") != std::string::npos, "contains 'phase' key");
+    CHECK(single_json.find("BOOT_COMPLETE") != std::string::npos, "contains phase name");
+    CHECK(single_json.find("\"timestamp_ms\"") != std::string::npos, "contains 'timestamp_ms' key");
+    CHECK(single_json.front() == '{' && single_json.back() == '}', "object braces balanced");
+
+    // Multiple events → array format.
+    std::vector<BootEvent> multi = {
+        { BootPhase::PROCESS_START, 0.0 },
+        { BootPhase::LINKING, 1.5 },
+        { BootPhase::BOOT_COMPLETE, 10.0 }
+    };
+    std::string multi_json = JsonWriter::write_events(multi);
+    CHECK(multi_json.front() == '[' && multi_json.back() == ']', "array brackets balanced");
+    // Verify commas separate elements (N-1 commas for N elements in compact form,
+    // but pretty-printed output may have newlines — just check at least N-1 separators).
+    size_t comma_count = 0;
+    for (char c : multi_json) if (c == ',') ++comma_count;
+    CHECK(comma_count >= 2, "commas present between elements");
+
+    // Verify phase_name for all known phases.
+    CHECK(std::string(phase_name(BootPhase::PROCESS_START)) == "PROCESS_START", "PROCESS_START name");
+    CHECK(std::string(phase_name(BootPhase::LINKING)) == "LINKING", "LINKING name");
+    CHECK(std::string(phase_name(BootPhase::_COUNT)) == "UNKNOWN", "_COUNT → UNKNOWN");
+
+    printf(fails ? "\ntest_diagnostics_json: %d FAILURE(S)\n"
+                 : "\ntest_diagnostics_json: all ok\n", fails);
+    return fails ? 1 : 0;
+}
+
+#else
+
+#include <cstdio>
+int main() {
+    printf("== test_diagnostics_json: SKIPPED (PROSPER_DIAGNOSTICS not enabled) ==\n");
+    return 0;
+}
+
+#endif


### PR DESCRIPTION
## Summary

Add a minimal optional diagnostics layer for boot timeline observation.

## Design

- Disabled by default through `PROSPER_DIAGNOSTICS`
- No runtime behavior changes when disabled
- Observer-only event collection
- Thread-safe EventBus
- JSON diagnostic output

## Integration

Added boot phase observation hooks in:

- `src/host/boot_program.cpp`

Tracked phases:

- PROCESS_START
- LINKING
- HLE_REGISTERED
- MODULES_MAPPED
- STUBS_INSTALLED
- GUEST_INITS_RUNNING
- BOOT_COMPLETE

## Build Verification

Verified both configurations:

- Default build:
  `PROSPER_DIAGNOSTICS=OFF`

- Diagnostics build:
  `PROSPER_DIAGNOSTICS=ON`

## Tests

Added CTest coverage:

- `diagnostics_disabled_stubs`
- `diagnostics_enabled_capture`
- `diagnostics_json_format`

Results:

**4/4 tests passing.**

## Scope

This PR intentionally does **NOT** add:

- GPU tracing
- Database storage
- Plugin systems
- HLE collectors
- PRX/ELF collectors
- Gameplay instrumentation

This PR only provides a small tested foundation for future diagnostics extensions.