### PR TITLE
ci: build and test the diagnostics implementation, on all three platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,6 +379,14 @@ jobs:
       # See the linux job (#2187) for --no-tests=error. This job is the one it matters most for:
       # it is the only job testing a directory other than build-ci, so a --test-dir that drifted
       # back to the common name would find an absent or unbuilt tree, register nothing, and pass.
+      #
+      # It is ALSO the only job that runs ctest against a core built with PROSPER_DIAGNOSTICS at
+      # its default (OFF). linux, windows-mingw and macos all pass -DPROSPER_DIAGNOSTICS=ON, so
+      # diagnostics_disabled_stubs executes here and nowhere else -- this job is what keeps the
+      # configuration users actually get from going untested. That dependency is invisible from
+      # this file's own text, which is why it is written down: adding the flag here to make the
+      # jobs 'consistent' would silently delete the last coverage of the default build. Raised in
+      # review on #2496.
       # The comment lives out here rather than inside the block below because `run: >-` is a
       # FOLDED scalar: every line is joined into ONE command, so a `#` line would comment out the
       # rest of it -- which is exactly what a first attempt at this edit did.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # shader-recompiler and GPU-execution differential. They are designed for a software device
       # (llvmpipe/lavapipe) and run in seconds locally, so CI can run them too.
       - name: Configure
-        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_DIAGNOSTICS=ON
 
       # A configuration that quietly loses Vulkan would silently drop those tests again and still
       # report 100% green. Fail the job instead of shrinking the suite.
@@ -327,7 +327,7 @@ jobs:
 
       - name: Configure
         shell: msys2 {0}
-        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE -DPROSPER_DIAGNOSTICS=ON
 
       - name: Build
         shell: msys2 {0}
@@ -454,7 +454,7 @@ jobs:
       - name: Configure
         # Vulkan is disabled (Homebrew's loader is arm64-only; the headless core + substrate tests
         # don't need it — MoltenVK is a later frontier). x86_64 target, run under Rosetta.
-        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE
+        run: cmake -S prosper -B prosper/build-ci -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE -DPROSPER_DIAGNOSTICS=ON
 
       - name: Build
         run: cmake --build prosper/build-ci


### PR DESCRIPTION
Follow-up to #2495, and the gap I raised while reviewing it.

## The problem

#2495 landed `src/diagnostics/` behind `option(PROSPER_DIAGNOSTICS "..." OFF)`. No CI job sets it. So in every job the option defaulted off, this line dropped the implementation from the build

```cmake
list(FILTER PROSPER_SRC EXCLUDE REGEX "src/diagnostics/")
```

and CMake never registered the two tests that exercise it, because they live inside `if(PROSPER_DIAGNOSTICS)`. The PR's eight green checks were real, and they certified the disabled stub path only.

This is the same shape as #2485 (four green jobs that never compiled the file under review) and instrument-trap 151 (a UNIX-gated suite invisible to Windows CI). An absent job and a passing job are indistinguishable from the outside, which is what makes the family worth naming each time it recurs.

Control for the zero, since an absence claim is only as good as its instrument: `grep -c PROSPER_DIAGNOSTICS .github/workflows/ci.yml` returned 0 on master, while the same grep for `PROSPER_APP` returned matches. The zero was real, not a bad pattern.

## Why all three platforms and not Linux only

The flag goes on `linux`, `windows-mingw` and `macos` -- the three jobs that already build `prosper_core` and run ctest. Linux-only was the tempting answer and I do not think it survives contact with the numbers: the marginal cost is a few hundred lines of compilation against a 56-second suite, and the platforms differ in precisely the ways that catch defects in new code. A missing include or a bad format specifier surfaces under MinGW GCC and Apple Clang; it does not surface under Linux GCC. Declining that for a flag would be choosing the #2485 shape deliberately, one level down.

## Why not everywhere

Setting it globally would trade one blind spot for its mirror -- nothing would build the configuration users actually get. `linux-app`, `linux-app-package`, `windows-app` and `macos-app` keep the default, so the excluded-sources path and the header's stub branch in `boot_program.cpp` still compile on all three platforms, and `windows-app` still runs `diagnostics_disabled_stubs` against an off build.

`diagnostics_disabled_stubs` is unchanged in meaning by this. It never defines `PROSPER_DIAGNOSTICS` itself, so it sees the header's stub branch in both configurations and asserts the same contract either way. It links `prosper_core`, which under `-DPROSPER_DIAGNOSTICS=ON` holds the real implementation, but every stub is an inline function in the header, so there is nothing to resolve against it and nothing to diverge.

## Verification

Linux, `-DPROSPER_DIAGNOSTICS=ON`, this branch:

```
cmake -S prosper -B <build> -G Ninja -DCMAKE_BUILD_TYPE=Debug -DPROSPER_DIAGNOSTICS=ON   # rc=0
cmake --build <build> -j6                                                                # 0 errors
ctest --test-dir <build> --output-on-failure --timeout 600 --no-tests=error              # rc=0
100% tests passed, 0 tests failed out of 230
```

Quoting the count alongside the exit code, per VERIFICATION.md: 230 tests, one skip (`117 - plugin_autolink`). The three diagnostics tests register as #114 `diagnostics_disabled_stubs`, #115 `diagnostics_enabled_capture`, #116 `diagnostics_json_format` and all pass. Before this change only #114 existed -- that delta is the whole point of the PR, and it is the falsifiable part.

Windows and macOS coverage is what this PR is asking CI to establish, so I am not claiming it in advance; the checks on this PR are the evidence.

## Risk

Low, and it fails loudly. If the diagnostics implementation does not compile under MinGW or Apple Clang, this PR goes red and we learn something we currently cannot learn. The default configuration is untouched.

Refs #2495