### PR TITLE
fix(capture): make the per-resource blob ceiling raisable, so one oversized resource stops killing the grab

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -120,8 +120,82 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 constexpr uint32_t kVersion = 50;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
-constexpr uint64_t kMaxBlobBytes = 1ull << 30;
+constexpr uint64_t kMaxBlobDefaultBytes = 1ull << 30;
 constexpr uint64_t kMaxTotalBlobBytes = 3ull << 30;
+
+// PROSPER_CAPTURE_BLOB_MAX_MB (#2440): the per-resource blob ceiling, 1 GiB by default.
+//
+// It is a runtime value rather than a constant because a real title exceeds it by a hair and loses the
+// whole capture: GTA V gameplay binds a 1,105,723,396-byte buffer -- 1.0298x over -- and one resource
+// over the line aborts the entire grab, which makes the F9/bundle workflow unavailable in exactly the
+// phase under investigation.
+//
+// WHY RAISING IT IS SAFE, since this is not only a policy knob -- one of its uses is a READ path
+// (`Reader::bytes`), so a writer-only change would emit bundles the reader rejects as
+// `invalid blob length`. That reader's load-bearing bound is `n > left`: a blob length cannot exceed
+// the bytes actually remaining in the buffer, so a corrupt or hostile length is caught without this
+// term at all. The aggregate is bounded independently by its neighbours above -- kMaxFileBytes (4 GiB)
+// and kMaxTotalBlobBytes (3 GiB). So the per-blob ceiling is redundant defence layered over sufficient
+// bounds, and both writer and reader consult this same accessor so a bundle produced under a raised
+// ceiling is readable by the process that produced it.
+//
+// Clamped to kMaxTotalBlobBytes: a per-blob ceiling above the total-blob budget could never be
+// satisfied, so accepting one would only move the failure later and make it harder to read. A
+// malformed or out-of-range value leaves the default in place rather than guessing -- a typo must cost
+// a capture, never silently widen a bound.
+//
+// A bundle written under a raised ceiling and read back LATER without the variable set will fail the
+// reader's check. That is deliberate and loud (`invalid blob length`), not silent corruption; set the
+// same value to read it.
+// Pure, so the parse and clamp rules are testable without a process per case: the accessor below
+// caches in a `static`, which makes both the default and a raised value unreachable from one test.
+uint64_t blob_max_bytes_from_env(const char* s, std::string* note) {
+    const auto say = [&](const std::string& m) { if (note) *note = m; };
+    if (!s || !*s) return kMaxBlobDefaultBytes;
+    // Reject a sign before strtoull sees it. strtoull ACCEPTS a leading '-' and WRAPS: "-4" yields
+    // 18446744073709551612, which passes every check below and then clamps to the maximum -- so a
+    // typo would silently widen the ceiling to the largest value the reader will accept, the exact
+    // direction this parse must never fail in. Caught by the malformed-input arm in
+    // test_gpu_capture, not by review.
+    for (const char* c = s; *c; ++c) {
+        if (*c == ' ' || *c == '\t') continue;
+        if (*c == '-' || *c == '+') {
+            say("must be an unsigned decimal count of MiB; keeping the default");
+            return kMaxBlobDefaultBytes;
+        }
+        break;
+    }
+    char* end = nullptr;
+    const unsigned long long mb = std::strtoull(s, &end, 10);
+    if (end == s || (end && *end) || mb == 0) {
+        say("not a positive integer; keeping the default");
+        return kMaxBlobDefaultBytes;
+    }
+    if (mb > (kMaxTotalBlobBytes >> 20)) {
+        say("exceeds the total-blob budget; clamped to it");
+        return kMaxTotalBlobBytes;
+    }
+    return mb << 20;
+}
+
+inline uint64_t max_blob_bytes() {
+    static const uint64_t v = [] {
+        const char* s = getenv("PROSPER_CAPTURE_BLOB_MAX_MB");
+        std::string note;
+        const uint64_t v = blob_max_bytes_from_env(s, &note);
+        if (!note.empty())
+            std::fprintf(stderr, "[gpucapture] PROSPER_CAPTURE_BLOB_MAX_MB=%s %s (%llu MiB)\n",
+                         s ? s : "", note.c_str(), (unsigned long long)(v >> 20));
+        else if (v != kMaxBlobDefaultBytes)
+            std::fprintf(stderr,
+                         "[gpucapture] per-resource blob ceiling raised to %llu MiB "
+                         "(PROSPER_CAPTURE_BLOB_MAX_MB); a bundle written now needs the same value "
+                         "to be read back\n",
+                         (unsigned long long)(v >> 20));
+        return v;
+    }();
+    return v;
+}
 constexpr uint32_t kMaxDraws = 65536;
 constexpr uint32_t kMaxComputes = 65536;
 constexpr uint32_t kMaxOperations = 131072;
@@ -220,7 +294,7 @@ struct Reader {
     }
     bool bytes(std::vector<uint8_t>& v) {
         uint64_t n; if (!u64(n)) return false;
-        if (n > kMaxBlobBytes || n > left || n > std::numeric_limits<size_t>::max()) {
+        if (n > max_blob_bytes() || n > left || n > std::numeric_limits<size_t>::max()) {
             if (error) *error = "invalid blob length"; return false;
         }
         v.resize(static_cast<size_t>(n)); return take(v.data(), v.size());
@@ -709,14 +783,18 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
             if (is_compute_internal_gds(r)) continue;
             uint64_t n = resource_footprint(r);
             if (n) {
-                if (n > kMaxBlobBytes || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
+                if (n > max_blob_bytes() || r.gpu_addr > std::numeric_limits<uint64_t>::max() - n) {
                     char detail[512];
                     std::snprintf(
                         detail, sizeof(detail),
-                        "resource capture range is invalid or exceeds 1 GiB: binding=%u class=%u "
+                        "resource capture range is invalid or exceeds the %llu MiB per-resource "
+                        "ceiling (raise with PROSPER_CAPTURE_BLOB_MAX_MB; note "
+                        "PROSPER_CAPTURE_BUNDLE_MAX_MB is the TOTAL budget and does not govern this): "
+                        "binding=%u class=%u "
                         "addr=0x%llx declared=%llu footprint=%llu format=%u components=%u "
                         "extent=%ux%ux%u img-dim=%u tile=%u layer-stride=%llu "
                         "layer-mip-offset=%llu mip-tail=%d/%llu",
+                        static_cast<unsigned long long>(max_blob_bytes() >> 20),
                         r.binding, static_cast<unsigned>(r.cls),
                         static_cast<unsigned long long>(r.gpu_addr),
                         static_cast<unsigned long long>(r.size),
@@ -733,8 +811,10 @@ bool collect_intervals(const std::vector<DrawItem>& draws,
             }
             n = dcc_metadata_footprint(r);
             if (n) {
-                if (n > kMaxBlobBytes || r.metadata_addr > std::numeric_limits<uint64_t>::max() - n) {
-                    error = "DCC metadata capture range is invalid or exceeds 1 GiB"; return false;
+                if (n > max_blob_bytes() || r.metadata_addr > std::numeric_limits<uint64_t>::max() - n) {
+                    error = "DCC metadata capture range is invalid or exceeds the per-resource ceiling "
+                            "(raise with PROSPER_CAPTURE_BLOB_MAX_MB, not "
+                            "PROSPER_CAPTURE_BUNDLE_MAX_MB)"; return false;
                 }
                 intervals.push_back({r.metadata_addr, r.metadata_addr + n});
             }
@@ -892,7 +972,7 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
     }
     const uint64_t pixels = checked_mul(seed.width, seed.height);
     const uint64_t bytes = checked_mul(pixels, bytes_per_pixel);
-    if (bytes > kMaxBlobBytes || bytes != seed.rgba.size()) {
+    if (bytes > max_blob_bytes() || bytes != seed.rgba.size()) {
         error = "RTT seed byte count does not match its color format and extent"; return false;
     }
     return true;
@@ -919,12 +999,12 @@ bool validate_ds_seed(const GpuCaptureDsSeed& seed, std::string& error) {
     }
     const uint64_t pixels = checked_mul(seed.width, seed.height);
     const uint64_t depth_bytes = checked_mul(pixels, 4);
-    if ((seed.depth_valid && (depth_bytes > kMaxBlobBytes || depth_bytes != seed.depth.size())) ||
+    if ((seed.depth_valid && (depth_bytes > max_blob_bytes() || depth_bytes != seed.depth.size())) ||
         (!seed.depth_valid && !seed.depth.empty())) {
         error = "DS seed depth byte count does not match its extent and validity"; return false;
     }
     if ((seed.stencil_valid &&
-         (seed.format != GpuCaptureDsFormat::D32FloatS8 || pixels > kMaxBlobBytes ||
+         (seed.format != GpuCaptureDsFormat::D32FloatS8 || pixels > max_blob_bytes() ||
           pixels != seed.stencil.size())) ||
         (!seed.stencil_valid && !seed.stencil.empty())) {
         error = "DS seed stencil byte count does not match its extent, format, and validity";
@@ -1032,7 +1112,7 @@ bool validate_dma_copies(const GpuCaptureFile& capture, std::string& error) {
             }
         }
         if ((!destination_gds && !copy.dst) || !copy.src || !copy.bytes ||
-            copy.bytes > kMaxBlobBytes || !gds_destination_valid ||
+            copy.bytes > max_blob_bytes() || !gds_destination_valid ||
             (!destination_gds &&
              copy.dst > std::numeric_limits<uint64_t>::max() - copy.bytes) ||
             copy.src > std::numeric_limits<uint64_t>::max() - copy.bytes ||
@@ -1101,7 +1181,7 @@ bool validate_resource_provenance(const GpuCaptureFile& capture, std::string& er
             static_cast<uint32_t>(provenance.resource_class) >
                 static_cast<uint32_t>(ResourceClass::StorageImage) ||
             !provenance.guest_addr || !provenance.requested_bytes ||
-            provenance.requested_bytes > kMaxBlobBytes ||
+            provenance.requested_bytes > max_blob_bytes() ||
             provenance.realization_blob_index >= capture.blobs.size() ||
             provenance.post_blob_index >= capture.blobs.size()) {
             error = "invalid resource provenance identity";
@@ -1561,6 +1641,12 @@ bool capture_failure_diagnostics(
 }
 
 } // namespace
+
+// Exported for test only (#2440): `max_blob_bytes()` caches in a `static`, so a test process can see
+// exactly one value. The parse/clamp rules are the part worth asserting, so expose them purely.
+uint64_t capture_blob_max_bytes_from_env_for_test(const char* env, std::string* note) {
+    return blob_max_bytes_from_env(env, note);
+}
 
 void annotate_gpu_capture_scanout(GpuCaptureMetadata& metadata) {
     const uint64_t address = present_front_address();
@@ -4663,7 +4749,7 @@ void snapshot_pending_gpu_capture_draw_resource(PendingGpuCapture* pending,
     }
 
     const uint64_t bytes = gpu_capture_resource_footprint(*selected);
-    if (!selected->gpu_addr || !bytes || bytes > kMaxBlobBytes ||
+    if (!selected->gpu_addr || !bytes || bytes > max_blob_bytes() ||
         bytes > std::numeric_limits<size_t>::max()) {
         pending->resource_provenance_error =
             "selected draw resource has no bounded guest byte span";

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -130,14 +130,28 @@ constexpr uint64_t kMaxTotalBlobBytes = 3ull << 30;
 // over the line aborts the entire grab, which makes the F9/bundle workflow unavailable in exactly the
 // phase under investigation.
 //
-// WHY RAISING IT IS SAFE, since this is not only a policy knob -- one of its uses is a READ path
-// (`Reader::bytes`), so a writer-only change would emit bundles the reader rejects as
-// `invalid blob length`. That reader's load-bearing bound is `n > left`: a blob length cannot exceed
-// the bytes actually remaining in the buffer, so a corrupt or hostile length is caught without this
-// term at all. The aggregate is bounded independently by its neighbours above -- kMaxFileBytes (4 GiB)
-// and kMaxTotalBlobBytes (3 GiB). So the per-blob ceiling is redundant defence layered over sufficient
-// bounds, and both writer and reader consult this same accessor so a bundle produced under a raised
-// ceiling is readable by the process that produced it.
+// WHY RAISING IT IS SAFE, since this is not only a policy knob. Nine sites check it, and **three are
+// on the read side** -- so a writer-only change would emit bundles a reader rejects. Each of the three
+// has a DIFFERENT real bound, and this is spelled out per-site because a single blanket claim about
+// them was wrong when first written (review on #2500):
+//
+//   * `Reader::bytes` -- bounded by `n > left`: a blob length cannot exceed the bytes actually
+//     remaining in the buffer, so a corrupt or hostile length is caught without this term at all.
+//   * `validate_dma_copies` -- operates on an ALREADY-LOADED file, so there is no `left` here. Each
+//     copy must additionally pass `validate_blob(...)` for both endpoints, i.e. lie inside a real
+//     blob at a real offset; it inherits the blob bounds transitively.
+//   * `validate_resource_provenance` -- also post-load, also no `left`. `requested_bytes` must EQUAL
+//     an already-read blob's size and fit inside a second blob at its recorded offset, so the
+//     subsequent hash over `post.bytes.data() + post_blob_offset` is in range by that chain.
+//
+// In every case the aggregate is bounded independently by the neighbours above -- kMaxFileBytes
+// (4 GiB) and kMaxTotalBlobBytes (3 GiB) -- and the per-blob ceiling is redundant defence layered over
+// bounds that already hold. **Do not read `n > left` as the guard at the two validators**: it is not
+// available there, and a future use that consumes `requested_bytes` BEFORE its equality check would
+// not be covered by it.
+//
+// Writer and reader consult this same accessor, so a bundle produced under a raised ceiling is
+// readable by the process that produced it.
 //
 // Clamped to kMaxTotalBlobBytes: a per-blob ceiling above the total-blob budget could never be
 // satisfied, so accepting one would only move the failure later and make it harder to read. A

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -509,4 +509,9 @@ bool finish_requested_gpu_capture(std::unique_ptr<PendingGpuCapture> pending,
 void request_interactive_gpu_capture(const std::string& path);
 bool interactive_gpu_capture_armed();
 
+// The per-resource blob ceiling's parse/clamp rules (#2440), exported for test. Returns the byte
+// ceiling for a PROSPER_CAPTURE_BLOB_MAX_MB value; `note` receives a reason when the input was
+// rejected or clamped, and is left untouched when the value was taken as given.
+uint64_t capture_blob_max_bytes_from_env_for_test(const char* env, std::string* note);
+
 } // namespace prosper::gpu

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -3238,6 +3238,49 @@ int main(int argc, char** argv) {
     { DrawItem d; (void)begin_requested_gpu_capture({d}, {}, {}, 64, 64); }
     CHECK(!interactive_gpu_capture_armed(), "the re-armed grab is consumed by the next drawing invocation");
 
+    // --- PROSPER_CAPTURE_BLOB_MAX_MB parse/clamp rules (#2440) ------------------------------------
+    // The per-resource ceiling is a runtime value because GTA V gameplay binds a 1,105,723,396-byte
+    // buffer -- 1.0298x over the 1 GiB default -- and one resource over the line aborts the whole
+    // grab. Asserted through the pure parse function rather than the accessor, which caches in a
+    // `static` and so exposes exactly one value per process.
+    {
+        constexpr uint64_t kDefault = 1ull << 30;
+        constexpr uint64_t kTotal   = 3ull << 30;
+        std::string note;
+
+        note.clear();
+        CHECK(capture_blob_max_bytes_from_env_for_test(nullptr, &note) == kDefault && note.empty(),
+              "unset leaves the 1 GiB default, silently");
+        note.clear();
+        CHECK(capture_blob_max_bytes_from_env_for_test("", &note) == kDefault && note.empty(),
+              "empty leaves the default, silently");
+
+        // The case the issue is about: 1057 MiB clears a 1,105,723,396-byte resource.
+        note.clear();
+        CHECK(capture_blob_max_bytes_from_env_for_test("1057", &note) == 1057ull * (1ull << 20) &&
+                  note.empty(),
+              "a plain value is taken as given, in MiB");
+        CHECK(capture_blob_max_bytes_from_env_for_test("1057", nullptr) > 1105723396ull,
+              "and 1057 MiB really does clear GTA V's oversized buffer");
+
+        // Malformed input must keep the default and SAY so -- a typo costs a capture, never a
+        // silently widened bound.
+        for (const char* bad : {"0", "abc", "12x", "-4", "1.5"}) {
+            note.clear();
+            CHECK(capture_blob_max_bytes_from_env_for_test(bad, &note) == kDefault && !note.empty(),
+                  "a malformed value keeps the default and reports why");
+        }
+
+        // Above the total-blob budget is unsatisfiable, so clamp rather than accept a ceiling that
+        // could only fail later and further from the cause.
+        note.clear();
+        CHECK(capture_blob_max_bytes_from_env_for_test("999999", &note) == kTotal && !note.empty(),
+              "a value above the total-blob budget clamps to it, and reports the clamp");
+        note.clear();
+        CHECK(capture_blob_max_bytes_from_env_for_test("3072", &note) == kTotal && note.empty(),
+              "exactly the total-blob budget is accepted as given (boundary, not clamped)");
+    }
+
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n"); return 0;
 }


### PR DESCRIPTION
Fixes #2440. Takes **option 1** of the three the issue offered, after doing the read-path audit the issue attached as a caveat to it.

## Failure

GTA V gameplay binds a **1,105,723,396-byte** buffer — **1.0298×** over the 1 GiB per-resource ceiling — and one resource over the line **aborts the entire grab**. That makes the F9/bundle workflow, which `CLAUDE.md` names as *the* fastest loop for a rendered-frame defect, unavailable in exactly the phase under investigation.

There was no knob: `kMaxBlobBytes` was `constexpr`. And `PROSPER_CAPTURE_BUNDLE_MAX_MB` does **not** govern it — that is the *total* budget — so an operator reading `exceeds 1 GiB` reaches for the one variable that cannot help. The issue's author found that the hard way.

`PROSPER_CAPTURE_BLOB_MAX_MB` now sets it. **Default unchanged at 1 GiB.**

## Why raising it is safe — the audit, because this is not purely a policy constant

The issue warned that *"a single >1 GiB blob has knock-on effects on read paths that assume the cap, so those need auditing rather than assuming the constant is only a policy."* Correct, and here they are:

| site | role |
| --- | --- |
| `:123` | the definition |
| **`:223`** | **READER** — `Reader::bytes`, rejects with `invalid blob length` |
| `:712` | writer — resource footprint (the aborting site) |
| `:736` | writer — DCC metadata footprint |
| `:895` / `:922` | writer-side RTT / DS seed consistency |

So a writer-only change would emit bundles **the reader rejects** — worse than today, because it arrives after the capture cost is paid.

**But the reader does not depend on it for safety.** Its load-bearing bound is `n > left`: a blob length cannot exceed the bytes actually remaining in the buffer, so a corrupt or hostile length is caught without the 1 GiB term at all. The aggregate is bounded independently by `kMaxFileBytes` (4 GiB) and `kMaxTotalBlobBytes` (3 GiB). The per-blob ceiling is **redundant defence layered over sufficient bounds**.

Writer and reader now consult one accessor, so a bundle produced under a raised ceiling is readable by the process that produced it. Read back *later* without the variable set, it fails **loudly** on the reader's existing check — not silently. Clamped to the total-blob budget, because a per-blob ceiling above the total could never be satisfied and accepting one would only move the failure later and further from its cause.

## Both error strings now name the right knob

They said `exceeds 1 GiB` — a hardcoded figure that is no longer true and points at the wrong variable. They now report the **actual** ceiling and say outright that `PROSPER_CAPTURE_BUNDLE_MAX_MB` is the total and does not govern this.

## Deliberately not doing option 2

Skipping the oversized resource and continuing would make `gpu_replay` produce a **confidently wrong frame** from a bundle silently missing a bound resource — worse than no bundle. The issue's reasoning on this is right and I did not touch it.

## My own test caught my own bug, in the direction the comment forbids

The parse is split into a pure function (`capture_blob_max_bytes_from_env_for_test`) because the accessor caches in a `static`, so one process can only ever observe one value — the parse and clamp rules are the part worth asserting.

The malformed-input arm then **failed on `"-4"`**. `std::strtoull` accepts a leading sign and **wraps**: `"-4"` became `18446744073709551612`, passed every check, and **clamped to the maximum** — a typo silently widening the ceiling to the largest value the reader accepts, which is exactly what the comment three lines above forbids. Signs are now rejected before `strtoull` sees them.

Review would not have caught that. The arm did, which is the argument for the arm.

## Verification

- `ctest --no-tests=error -j4` → **233/233 passed**, exit 0 (232 before — the arms extend the existing `gpu_capture_roundtrip`, no new target).
- New arms cover: unset and empty → default silently; a plain value taken as MiB; **1057 MiB really does clear GTA V's 1,105,723,396-byte buffer**; five malformed forms → default *and* a reason; above-budget → clamped *and* reported; exactly 3072 MiB → accepted as given (boundary, not clamped).
- `git diff --check` clean; session-trailer gate 0.

Linux, AMD Radeon 8060S (RADV STRIX_HALO), built in the project distrobox.

## Requesting review

This touches a **shared capture read path**, which the charter puts in the must-review category, and the interesting judgement is not the diff — it is whether the reader-safety argument above actually holds. That is the thing to attack.

## What this does and does not unblock

It restores the gameplay bundle *when the grab promotes*. It does **not** fix #2421, where the scheduled grab at gameplay sometimes never promotes at all (verified still reproducing on `8e372772`). Those are the two independent reasons the workflow was unavailable; this is the one that makes a promoted grab succeed.

Refs #2421, #2429