### PR TITLE
gpu: lower GTA selected scalar-buffer dispatch

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1030,6 +1030,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_dynfetch_fold PRIVATE prosper_core)
   add_test(NAME dynfetch_fold COMMAND test_dynfetch_fold)
 
+  add_executable(test_gta5_selected_sbuffer tests/test_gta5_selected_sbuffer.cpp)
+  target_link_libraries(test_gta5_selected_sbuffer PRIVATE prosper_core)
+  add_test(NAME gta5_selected_sbuffer COMMAND test_gta5_selected_sbuffer)
+
   # Cross-submit readability reuse is valid only while the HLE mapping generation is unchanged.
   add_executable(test_guest_memory_map tests/test_guest_memory_map.cpp)
   target_link_libraries(test_guest_memory_map PRIVATE prosper_core)

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -4378,6 +4378,16 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         if (compute.recompile_config_available)
             compute.user_sgprs = compute.recompile_config.user_sgprs;
         if (!table(x.resources, compute.resources)) return false;
+        // The selected-SBUFFER marker is deliberately derived rather than serialized. A raw replay
+        // with complete captured backing can reconstruct it from the exact shader/launch/source
+        // domain; metadata-only captures retain their already-compiled SPIR-V and remain materializable.
+        if (compute.resources && compute.recompile_config_available &&
+            compute.raw_shader_index < c.raw_shader_versions.size()) {
+            const auto& raw = c.raw_shader_versions[compute.raw_shader_index].words;
+            if (rdna2_gta5_selected_sbuffer_shader(raw.data(), raw.size()))
+                (void)discover_rdna2_gta5_selected_sbuffer(
+                    raw.data(), raw.size(), compute.recompile_config, *compute.resources);
+        }
         out.computes.push_back(std::move(compute));
     }
     out.dma_copies.reserve(c.dma_copies.size());

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -302,6 +302,8 @@ struct ShaderResourceCompileKey {
     bool optional_null_raw_load = false;
     bool proven_null_guarded_raw_store = false;
     bool proven_null_nullable_raw_buffer = false;
+    uint32_t selected_sbuffer_soffset = UINT32_MAX;
+    std::array<uint32_t, 4> selected_sbuffer_words{};
     bool srgb = false;
     bool depth_compare = false;
     uint32_t depth_compare_func = 0;
@@ -499,6 +501,9 @@ struct ShaderCompileKeyHash {
             hash = hash_mix(hash, resource.optional_null_raw_load);
             hash = hash_mix(hash, resource.proven_null_guarded_raw_store);
             hash = hash_mix(hash, resource.proven_null_nullable_raw_buffer);
+            hash = hash_mix(hash, resource.selected_sbuffer_soffset);
+            for (const uint32_t word : resource.selected_sbuffer_words)
+                hash = hash_mix(hash, word);
             hash = hash_mix(hash, resource.srgb);
             hash = hash_mix(hash, resource.depth_compare);
             hash = hash_mix(hash, resource.depth_compare_func);
@@ -1252,6 +1257,10 @@ ShaderCompileKey make_shader_compile_key(ShaderProgramStage stage, const uint32_
                 is_proven_null_guarded_raw_store(resource);
             compiled.proven_null_nullable_raw_buffer =
                 is_proven_null_nullable_raw_buffer(resource);
+            if (is_gta5_selected_sbuffer_descriptor(resource)) {
+                compiled.selected_sbuffer_soffset = resource.selected_sbuffer_soffset;
+                compiled.selected_sbuffer_words = resource.selected_sbuffer_words;
+            }
             compiled.srgb = storage_image && resource.srgb;
             compiled.depth_compare = (manual_compare || storage_image) && resource.depth_compare;
             compiled.depth_compare_func = manual_compare ? resource.depth_compare_func : 0u;
@@ -1550,6 +1559,9 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     const bool has_nullable_output_raw_buffer = resources &&
         std::any_of(resources->resources.begin(), resources->resources.end(),
                     is_nullable_raw_buffer_marker_candidate);
+    const bool has_selected_sbuffer_descriptor = resources &&
+        std::any_of(resources->resources.begin(), resources->resources.end(),
+                    is_gta5_selected_sbuffer_marker_candidate);
     // Push-constant values intentionally stay out of the general compute cache key. Conditional
     // store elision is the exception: validate its raw shader and exact dispatch before even looking
     // in the cache, so a warm null-dispatch module cannot be returned for changed s2:s3.
@@ -1559,6 +1571,9 @@ std::vector<uint32_t> recompile_compute_shader_cached(
         return {};
     if (has_nullable_output_raw_buffer &&
         !rdna2_gta5_nullable_output_dispatch(code, dwords, config, *resources))
+        return {};
+    if (has_selected_sbuffer_descriptor &&
+        !rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, *resources))
         return {};
     ShaderCompileKey key = make_shader_compile_key(
         ShaderProgramStage::Compute, code, dwords, resources, nullptr, nullptr,
@@ -6511,7 +6526,6 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                  path_report.removed_pcs[index]);
                 std::fprintf(stderr, "\n");
             }
-            assign_convention_bindings(*table, 2);
             native_multiwave_wave_work = compute_shader_prefers_native_multiwave(
                 decoded, reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                 shader_dwords, recompile_diagnostic);
@@ -6635,6 +6649,25 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                       P::COMPUTE_PGM_RSRC2_TIDIG_COMP_CNT_MASK);
         config.lds_bytes = field(P::COMPUTE_PGM_RSRC2_LDS_SIZE_SHIFT,
                                  P::COMPUTE_PGM_RSRC2_LDS_SIZE_MASK) * 512u;
+
+        // GTA V 0x413ce6000 selects one V# from a scalar-buffer table with a wave-uniform value
+        // derived from live source records. Generic const-folding intentionally cannot manufacture
+        // that dynamic descriptor. Certify this dispatch's complete selector domain and materialize
+        // the sole in-bounds record before assigning Vulkan bindings.
+        const bool selected_sbuffer_candidate = rdna2_gta5_selected_sbuffer_shader(
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+            shader_dwords);
+        const bool selected_sbuffer_valid = discover_rdna2_gta5_selected_sbuffer(
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
+            shader_dwords, config, *table);
+        if (selected_sbuffer_candidate &&
+            (selected_sbuffer_valid || config.threads_x == kGtaSelectedSbufferThreads) &&
+            std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr,
+                         "[gta-selected-sbuffer] code=0x%llx valid=%d resources=%zu\n",
+                         static_cast<unsigned long long>(code_addr),
+                         static_cast<int>(selected_sbuffer_valid), table->resources.size());
+        assign_convention_bindings(*table, 2);
 
         ComputeItem item;
         item.spirv = recompile_compute_shader_cached(

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -160,6 +160,9 @@ inline constexpr uint32_t kMubufOpcodeStoreDwordX3 = 0x1f;
 inline constexpr uint32_t kSopcOpcodeCmpEqU64 = 0x12;
 
 inline constexpr uint32_t kMubufOpcodeLoadDword         = 0x0c;
+inline constexpr uint32_t kMubufOpcodeLoadDwordX2       = 0x0d;
+inline constexpr uint32_t kMubufOpcodeLoadDwordX4       = 0x0e;
+inline constexpr uint32_t kMubufOpcodeLoadDwordX3       = 0x0f;
 inline constexpr uint32_t kMubufOpcodeAtomicSwap        = 0x30;
 inline constexpr uint32_t kMubufOpcodeAtomicCompareSwap = 0x31;
 inline constexpr uint32_t kMubufOpcodeAtomicAdd         = 0x32;

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
@@ -1,11 +1,14 @@
 #include "rdna2_gta5_compute_contracts.hpp"
 
+#include "agc_shader_layout.hpp"
 #include "rdna2_decode.hpp"
 #include "rdna2_to_spirv.hpp"
 #include "shader_resources.hpp"
 
 #include <algorithm>
 #include <array>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -18,6 +21,92 @@ bool guest_readable(uint64_t address, uint32_t bytes);
 namespace {
 
 enum class NullableProgram : uint8_t { None, WorkgroupStore, WorkgroupProcess };
+enum class SelectedSbufferDomain : uint8_t { Reject, AllOob, Record4 };
+
+constexpr uint32_t kSelectedSbufferSourcePc = 70u;
+constexpr uint32_t kSelectedSbufferOuterPc = 153u;
+constexpr uint32_t kSelectedSbufferLoadX4Pc = 156u;
+constexpr uint32_t kSelectedSbufferLoadX2Pc = 158u;
+constexpr uint32_t kSelectedSbufferSourceRecords = kGtaSelectedSbufferThreads;
+constexpr uint32_t kSelectedSbufferSourceStride = 8u;
+constexpr uint32_t kSelectedSbufferOuterStride = 120u;
+constexpr uint32_t kSelectedSbufferOuterRecords = 5u;
+constexpr uint32_t kSelectedSbufferLoadBytes = 4u * sizeof(uint32_t);
+
+// Exact consumed words from routed GTA V PPSA04263 kernel 0x413ce6000. Full comparison is the
+// static authority boundary: the specialization depends on the complete scalar/EXEC path that
+// carries v5>>3 through readfirstlane and s_mul_i32 into pc153/156/158.
+constexpr std::array<uint32_t, 276> kSelectedSbufferProgram = {
+0xbfa00003u, 0xd746000bu, 0x04010c0bu, 0x8f6a820au,
+0xf4080400u, 0xfa000070u, 0xf40c0800u, 0xfa000040u,
+0xbf8cc07fu, 0x81161211u, 0x8815ff27u, 0x00040000u,
+0xbe940326u, 0xbe9703ffu, 0x00016204u, 0x8819ff23u,
+0x000c0000u, 0xbe980322u, 0xbe9a0311u, 0xbe9b03ffu,
+0x00016204u, 0xbea60311u, 0xbea703ffu, 0x10016204u,
+0xbea20312u, 0xbea303ffu, 0x00016204u, 0x84118212u,
+0xbf076a80u, 0xbe9c0302u, 0xbe9d0303u, 0xbe9e0304u,
+0xbe9f0305u, 0xbea51d96u, 0xbea11d94u, 0xbf84001au,
+0xe0302008u, 0x8008060bu, 0x92009788u, 0x7e0602ffu,
+0xff800000u, 0x7e0802ffu, 0xff800000u, 0x7e0a02ffu,
+0xff800000u, 0xbf8c3f70u, 0xe03c2000u, 0x80070006u,
+0xbf8c3f70u, 0x7c100100u, 0x021800f9u, 0x86060600u,
+0x021a00f9u, 0x86060601u, 0x021c00f9u, 0x86060602u,
+0xbeea376au, 0xbf880002u, 0xe03c200cu, 0x80070306u,
+0xbefe046au, 0xbf820076u, 0xf4040100u, 0xfa000098u,
+0xbe860312u, 0xbe8703ffu, 0x00016204u, 0xbf8cc07fu,
+0xbe851d93u, 0xbe82047eu, 0xe0342000u, 0x8001050bu,
+0xbf8c3f70u, 0x36000a87u, 0x2c0e0a83u, 0x7daa0087u,
+0xbf88003eu, 0x26000082u, 0xd54f0006u, 0x0415fe80u,
+0x3024240cu, 0xd54f0008u, 0x0415fe80u, 0x00301818u,
+0x81ea1380u, 0xf4080100u, 0xfa0000b8u, 0x34000082u,
+0xd76d0003u, 0x041d886au, 0xbeea03ffu, 0x7f7fffffu,
+0x7e1802ffu, 0x7f800000u, 0x7e1a02ffu, 0x7f800000u,
+0xd7460004u, 0x04010300u, 0x7e1c02ffu, 0x7f800000u,
+0xbf8cc07fu, 0xe03c3000u, 0x80010003u, 0x36080cffu,
+0x000000ffu, 0xe03c3000u, 0x80010503u, 0x360810ffu,
+0x000000ffu, 0xe03c3000u, 0x80010803u, 0xbf8c3f70u,
+0xd554000fu, 0x04160108u, 0x7c061ef9u, 0x0686846au,
+0xbeea3704u, 0xbf880006u, 0xd551000cu, 0x04160108u,
+0xd551000du, 0x041a0309u, 0xd551000eu, 0x041e050au,
+0xbefe046au, 0x7e0602ffu, 0xff800000u, 0x7e0802ffu,
+0xff800000u, 0x7e0a02ffu, 0xff800000u, 0xbeea3704u,
+0xbf880005u, 0xd5540004u, 0x041a0309u, 0xd5540005u,
+0x041e050au, 0x7e06030fu, 0xbefe046au, 0x8afe7e02u,
+0xbf880026u, 0x7e100281u, 0x7daa1080u, 0xbf880023u,
+0x7ed40507u, 0xbe92047eu, 0x7da40e6au, 0xbf88001du,
+0x7e100280u, 0xb86a0078u, 0xf4080100u, 0xfa0000a8u,
+0xbf8cc07fu, 0xf4280202u, 0xd4000008u, 0xbf8cc07fu,
+0xe0382000u, 0x80020006u, 0xe0342010u, 0x80020406u,
+0x920c9788u, 0x920d9789u, 0xbf8c3f71u, 0x7c100100u,
+0x021818f9u, 0x86060600u, 0x021a18f9u, 0x86060601u,
+0x021c18f9u, 0x86060602u, 0x02061af9u, 0x86060603u,
+0xbf8c3f70u, 0x02081af9u, 0x86060604u, 0x020a1af9u,
+0x86060605u, 0xbefe0412u, 0xbf82ffdbu, 0xbefe0402u,
+0xd76d0000u, 0x042d8211u, 0xbf8c3f70u, 0x7c0218f9u,
+0x06068003u, 0x7c021b04u, 0x7c021cf9u, 0x06068205u,
+0x92049788u, 0xe0302000u, 0x80050600u, 0x92059789u,
+0x88ea6a00u, 0x88ea026au, 0x020008f9u, 0x8606060cu,
+0x020208f9u, 0x8606060du, 0x020408f9u, 0x8606060eu,
+0x02060af9u, 0x86060603u, 0x02100af9u, 0x86060604u,
+0x02120af9u, 0x86060605u, 0xbf8c3f70u, 0xd548000au,
+0x026d0706u, 0xbf880041u, 0x2c180c9eu, 0x16161898u,
+0xe0787010u, 0x8009000au, 0xe0747020u, 0x8009080au,
+0xbbfd0000u, 0x7e080281u, 0xe0c86008u, 0x8006040au,
+0xbf8c3f70u, 0x3608088fu, 0x7daa0880u, 0xbf880033u,
+0xe0342000u, 0x8006040au, 0x7e0c02c1u, 0x7e0e02c1u,
+0x4c161880u, 0x34161683u, 0xd746000bu, 0x042d030bu,
+0xbf8c3f70u, 0x301c0881u, 0x30180a81u, 0xd5490004u,
+0x02050104u, 0xd5490005u, 0x02050105u, 0xd746000fu,
+0x0281070eu, 0xd746000du, 0x0281070cu, 0xd747000eu,
+0x020e1c10u, 0xd747000cu, 0x020e1810u, 0x381e1e85u,
+0x381a1a85u, 0xd54a0004u, 0x043e1d04u, 0xd54a0005u,
+0x04361905u, 0xe0786000u, 0x8009040au, 0xe038f028u,
+0x8009040au, 0xe034f038u, 0x80090b0au, 0xbf8c3f71u,
+0x1e000104u, 0x1e020b01u, 0x1e040d02u, 0x20060707u,
+0xbf8c3f70u, 0x20101708u, 0x20121909u, 0x7daa1480u,
+0xbf880006u, 0xe0302000u, 0x8005060au, 0xbf8c3f70u,
+0xd548000au, 0x026d0706u, 0xbf82ffbeu, 0xbf810000u,
+};
 
 // Exact consumed words from routed GTA V PPSA04263 kernels 0x413e19200 and 0x413e1ac00. Full byte
 // comparison is intentional: a write-elision proof must not inherit the scalar fold's linear-walk
@@ -169,6 +258,86 @@ bool witness_is_zero(const ShaderResource& marker) {
     uint64_t pointer = UINT64_MAX;
     std::memcpy(&pointer, bytes + kGtaNullableOutputPointerOffset, sizeof(pointer));
     return pointer == 0u;
+}
+
+const uint8_t* complete_resource_bytes(const ShaderResource& resource, uint32_t bytes) {
+    if (resource.host_data)
+        return resource.host_data_size >= bytes ? resource.host_data : nullptr;
+    if (!resource.gpu_addr || !guest_readable(resource.gpu_addr, bytes)) return nullptr;
+    return reinterpret_cast<const uint8_t*>(static_cast<uintptr_t>(resource.gpu_addr));
+}
+
+bool selected_sbuffer_source_shape(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::ConstantBuffer &&
+           resource.fetch_pc == kSelectedSbufferSourcePc &&
+           resource.gpu_addr > 0x10000u &&
+           resource.stride == kSelectedSbufferSourceStride &&
+           resource.size == kSelectedSbufferSourceRecords * kSelectedSbufferSourceStride;
+}
+
+bool selected_sbuffer_outer_shape(const ShaderResource& resource) {
+    return resource.cls == ResourceClass::ConstantBuffer &&
+           resource.fetch_pc == kSelectedSbufferOuterPc &&
+           resource.gpu_addr > 0x10000u &&
+           resource.stride == kSelectedSbufferOuterStride &&
+           resource.size == kSelectedSbufferOuterRecords * kSelectedSbufferOuterStride;
+}
+
+bool selected_sbuffer_target_descriptor(const std::array<uint32_t, 4>& words,
+                                        DecodedBufferDescriptor& decoded) {
+    decoded = decode_buffer_descriptor(words.data());
+    return decoded.base > 0x10000u && decoded.stride == 20u &&
+           decoded.num_records == 668u && decoded.size_bytes == 13360u &&
+           decoded.format == DataFormat::Float32 && decoded.num_components == 3u &&
+           !decoded.forbid_unknown_fallback;
+}
+
+bool selected_sbuffer_target_resource(const ShaderResource& resource,
+                                      uint32_t pc,
+                                      const DecodedBufferDescriptor& decoded) {
+    return resource.cls == ResourceClass::ConstantBuffer && resource.fetch_pc == pc &&
+           resource.gpu_addr == decoded.base && resource.size == decoded.size_bytes &&
+           resource.stride == decoded.stride && resource.format == decoded.format &&
+           resource.num_components == decoded.num_components &&
+           resource.table_index_count == 0u;
+}
+
+SelectedSbufferDomain selected_sbuffer_domain(const ShaderResource& source) {
+    const uint8_t* bytes = complete_resource_bytes(source, source.size);
+    if (!bytes) return SelectedSbufferDomain::Reject;
+    bool uses_record4 = false;
+    for (uint32_t record = 0; record < kSelectedSbufferSourceRecords; ++record) {
+        uint32_t first = 0;
+        std::memcpy(&first, bytes + record * kSelectedSbufferSourceStride, sizeof(first));
+        const uint32_t selector = first >> 3u;
+        const uint32_t soffset = selector * kSelectedSbufferOuterStride;
+        if (soffset == kGtaSelectedSbufferRecord4Soffset) {
+            uses_record4 = true;
+            continue;
+        }
+        // pc153 adds eight and reads four consecutive dwords. Partial in-bounds reads would need
+        // per-component table semantics, so admit only a wholly OOB access. Mirror the hardware's
+        // uint32 address addition before testing the bound: a large SOFFSET can wrap back into the
+        // five-record table and must not be mistaken for OOB merely because its pre-wrap value is big.
+        const uint32_t first_byte = soffset + 8u;
+        if (first_byte < kSelectedSbufferOuterRecords * kSelectedSbufferOuterStride ||
+            first_byte > UINT32_MAX - (kSelectedSbufferLoadBytes - 1u))
+            return SelectedSbufferDomain::Reject;
+    }
+    return uses_record4 ? SelectedSbufferDomain::Record4
+                        : SelectedSbufferDomain::AllOob;
+}
+
+template <typename Table>
+auto exact_fetch_resource(Table& resources, uint32_t pc) {
+    using ResourcePtr = decltype(&resources.resources.front());
+    ResourcePtr found = nullptr;
+    for (auto& resource : resources.resources) {
+        if (resource.fetch_pc != pc) continue;
+        if (found) return ResourcePtr{};
+        found = &resource;
+    }
+    return found;
 }
 
 } // namespace
@@ -416,6 +585,234 @@ bool rdna2_gta5_nullable_output_dispatch(
     return marker_count == expected_count &&
            std::all_of(found.begin(), found.begin() + expected_count,
                        [](bool value) { return value; });
+}
+
+bool rdna2_gta5_selected_sbuffer_shader(const uint32_t* code, size_t dwords) {
+    return exact_program(code, dwords, kSelectedSbufferProgram);
+}
+
+bool rdna2_gta5_selected_sbuffer_launch(
+        const uint32_t* code, size_t dwords,
+        const ComputeShaderConfig& config) {
+    return rdna2_gta5_selected_sbuffer_shader(code, dwords) &&
+           config.user_sgprs.size() == 11u &&
+           config.local_x == 64u && config.local_y == 1u && config.local_z == 1u &&
+           config.exact_thread_extent &&
+           config.threads_x == kSelectedSbufferSourceRecords &&
+           config.threads_y == 1u && config.threads_z == 1u &&
+           config.wave_size == 64u && config.tgid_x_en &&
+           !config.tgid_y_en && !config.tgid_z_en && config.tidig_comp_cnt == 0u;
+}
+
+bool discover_rdna2_gta5_selected_sbuffer(
+        const uint32_t* code, size_t dwords,
+        const ComputeShaderConfig& config,
+        ShaderResourceTable& resources) {
+    // Derived authority never survives a failed refresh. Consumer resources are ordinary bindings
+    // and remain inert unless a new marker passes the final dispatch validator.
+    for (ShaderResource& resource : resources.resources) {
+        resource.selected_sbuffer_soffset = UINT32_MAX;
+        resource.selected_sbuffer_words = {};
+    }
+    if (!rdna2_gta5_selected_sbuffer_launch(code, dwords, config)) {
+        if (rdna2_gta5_selected_sbuffer_shader(code, dwords) &&
+            config.threads_x == kGtaSelectedSbufferThreads && std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr,
+                         "[gta-selected-sbuffer] reject=launch user=%zu local=%ux%ux%u "
+                         "exact=%d threads=%ux%ux%u wave=%u tgid=%d/%d/%d tidig=%u\n",
+                         config.user_sgprs.size(), config.local_x, config.local_y, config.local_z,
+                         static_cast<int>(config.exact_thread_extent),
+                         config.threads_x, config.threads_y, config.threads_z, config.wave_size,
+                         static_cast<int>(config.tgid_x_en), static_cast<int>(config.tgid_y_en),
+                         static_cast<int>(config.tgid_z_en), config.tidig_comp_cnt);
+        return false;
+    }
+
+    ShaderResource* source = exact_fetch_resource(resources, kSelectedSbufferSourcePc);
+    ShaderResource* outer = exact_fetch_resource(resources, kSelectedSbufferOuterPc);
+    const bool zero_source = source && is_zero_record_raw_buffer(*source);
+    const bool zero_outer = outer && is_zero_record_raw_buffer(*outer);
+    if (zero_source || zero_outer) {
+        if (!zero_source || !zero_outer) return false;
+        ShaderResource* target_x4 = exact_fetch_resource(resources, kSelectedSbufferLoadX4Pc);
+        ShaderResource* target_x2 = exact_fetch_resource(resources, kSelectedSbufferLoadX2Pc);
+        if ((target_x4 && !is_zero_record_raw_buffer(*target_x4)) ||
+            (target_x2 && !is_zero_record_raw_buffer(*target_x2)))
+            return false;
+        auto add_zero_target = [&](uint32_t pc) {
+            ShaderResource target;
+            target.cls = ResourceClass::ConstantBuffer;
+            target.format = DataFormat::Unknown;
+            target.num_components = 0u;
+            target.fetch_pc = pc;
+            resources.resources.push_back(target);
+        };
+        if (!target_x4) add_zero_target(kSelectedSbufferLoadX4Pc);
+        if (!target_x2) add_zero_target(kSelectedSbufferLoadX2Pc);
+        outer = exact_fetch_resource(resources, kSelectedSbufferOuterPc);
+        if (!outer) return false;
+        outer->selected_sbuffer_soffset = kGtaSelectedSbufferZeroChainSoffset;
+        return rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, resources);
+    }
+    if (!source || !outer || !selected_sbuffer_source_shape(*source) ||
+        !selected_sbuffer_outer_shape(*outer)) {
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr,
+                         "[gta-selected-sbuffer] reject=resource-shape source=%p outer=%p "
+                         "source-shape=%d outer-shape=%d resources=%zu "
+                         "source{class=%u addr=0x%llx size=%u stride=%u pc=%u} "
+                         "outer{class=%u addr=0x%llx size=%u stride=%u pc=%u}\n",
+                         static_cast<void*>(source), static_cast<void*>(outer),
+                         source && selected_sbuffer_source_shape(*source),
+                         outer && selected_sbuffer_outer_shape(*outer), resources.resources.size(),
+                         source ? static_cast<uint32_t>(source->cls) : UINT32_MAX,
+                         source ? static_cast<unsigned long long>(source->gpu_addr) : 0ull,
+                         source ? source->size : 0u, source ? source->stride : 0u,
+                         source ? source->fetch_pc : UINT32_MAX,
+                         outer ? static_cast<uint32_t>(outer->cls) : UINT32_MAX,
+                         outer ? static_cast<unsigned long long>(outer->gpu_addr) : 0ull,
+                         outer ? outer->size : 0u, outer ? outer->stride : 0u,
+                         outer ? outer->fetch_pc : UINT32_MAX);
+        return false;
+    }
+    const SelectedSbufferDomain domain = selected_sbuffer_domain(*source);
+    if (domain == SelectedSbufferDomain::Reject) {
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr, "[gta-selected-sbuffer] reject=selector-domain\n");
+        return false;
+    }
+
+    if (domain == SelectedSbufferDomain::AllOob) {
+        ShaderResource* target_x4 = exact_fetch_resource(resources, kSelectedSbufferLoadX4Pc);
+        ShaderResource* target_x2 = exact_fetch_resource(resources, kSelectedSbufferLoadX2Pc);
+        if ((target_x4 && !is_zero_record_raw_buffer(*target_x4)) ||
+            (target_x2 && !is_zero_record_raw_buffer(*target_x2)))
+            return false;
+        auto add_zero_target = [&](uint32_t pc) {
+            ShaderResource target;
+            target.cls = ResourceClass::ConstantBuffer;
+            target.format = DataFormat::Unknown;
+            target.num_components = 0u;
+            target.fetch_pc = pc;
+            resources.resources.push_back(target);
+        };
+        if (!target_x4) add_zero_target(kSelectedSbufferLoadX4Pc);
+        if (!target_x2) add_zero_target(kSelectedSbufferLoadX2Pc);
+        outer = exact_fetch_resource(resources, kSelectedSbufferOuterPc);
+        if (!outer) return false;
+        outer->selected_sbuffer_soffset = kGtaSelectedSbufferAllOobSoffset;
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr, "[gta-selected-sbuffer] domain=all-oob\n");
+        return rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, resources);
+    }
+
+    const uint8_t* outer_bytes = complete_resource_bytes(*outer, outer->size);
+    if (!outer_bytes) {
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr, "[gta-selected-sbuffer] reject=outer-unreadable\n");
+        return false;
+    }
+    std::array<uint32_t, 4> selected_words{};
+    std::memcpy(selected_words.data(),
+                outer_bytes + kGtaSelectedSbufferRecord4Soffset + 8u,
+                sizeof(selected_words));
+    DecodedBufferDescriptor selected{};
+    if (!selected_sbuffer_target_descriptor(selected_words, selected)) {
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr,
+                         "[gta-selected-sbuffer] reject=selected-vsharp words=%08x:%08x:%08x:%08x "
+                         "base=0x%llx stride=%u records=%u size=%u format=%u components=%u\n",
+                         selected_words[0], selected_words[1], selected_words[2], selected_words[3],
+                         static_cast<unsigned long long>(selected.base), selected.stride,
+                         selected.num_records, selected.size_bytes,
+                         static_cast<uint32_t>(selected.format), selected.num_components);
+        return false;
+    }
+
+    ShaderResource* target_x4 = exact_fetch_resource(resources, kSelectedSbufferLoadX4Pc);
+    ShaderResource* target_x2 = exact_fetch_resource(resources, kSelectedSbufferLoadX2Pc);
+    if ((target_x4 && !selected_sbuffer_target_resource(
+                          *target_x4, kSelectedSbufferLoadX4Pc, selected)) ||
+        (target_x2 && !selected_sbuffer_target_resource(
+                          *target_x2, kSelectedSbufferLoadX2Pc, selected)))
+    {
+        if (std::getenv("PROSPER_DBG"))
+            std::fprintf(stderr, "[gta-selected-sbuffer] reject=consumer-resource\n");
+        return false;
+    }
+
+    auto add_target = [&](uint32_t pc) {
+        ShaderResource target;
+        target.cls = ResourceClass::ConstantBuffer;
+        target.format = selected.format;
+        target.num_components = selected.num_components;
+        target.gpu_addr = selected.base;
+        target.size = selected.size_bytes;
+        target.stride = selected.stride;
+        target.fetch_pc = pc;
+        resources.resources.push_back(target);
+    };
+    if (!target_x4) add_target(kSelectedSbufferLoadX4Pc);
+    if (!target_x2) add_target(kSelectedSbufferLoadX2Pc);
+
+    // push_back may have moved the vector, so reacquire the owning outer record.
+    outer = exact_fetch_resource(resources, kSelectedSbufferOuterPc);
+    if (!outer) return false;
+    outer->selected_sbuffer_soffset = kGtaSelectedSbufferRecord4Soffset;
+    outer->selected_sbuffer_words = selected_words;
+    return rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, resources);
+}
+
+bool rdna2_gta5_selected_sbuffer_dispatch(
+        const uint32_t* code, size_t dwords,
+        const ComputeShaderConfig& config,
+        const ShaderResourceTable& resources) {
+    if (!rdna2_gta5_selected_sbuffer_launch(code, dwords, config)) return false;
+    const ShaderResource* source = exact_fetch_resource(resources, kSelectedSbufferSourcePc);
+    const ShaderResource* outer = exact_fetch_resource(resources, kSelectedSbufferOuterPc);
+    const ShaderResource* target_x4 = exact_fetch_resource(resources, kSelectedSbufferLoadX4Pc);
+    const ShaderResource* target_x2 = exact_fetch_resource(resources, kSelectedSbufferLoadX2Pc);
+    if (!source || !outer || !target_x4 || !target_x2)
+        return false;
+
+    size_t markers = 0;
+    for (const ShaderResource& resource : resources.resources) {
+        if (!is_gta5_selected_sbuffer_marker_candidate(resource)) continue;
+        if (&resource != outer || !is_gta5_selected_sbuffer_descriptor(resource)) return false;
+        ++markers;
+    }
+    if (markers != 1u) return false;
+
+    if (outer->selected_sbuffer_soffset == kGtaSelectedSbufferZeroChainSoffset)
+        return is_zero_record_raw_buffer(*source) && is_zero_record_raw_buffer(*outer) &&
+               is_zero_record_raw_buffer(*target_x4) && is_zero_record_raw_buffer(*target_x2);
+
+    if (
+        !selected_sbuffer_source_shape(*source) ||
+        !selected_sbuffer_outer_shape(*outer) ||
+        !is_gta5_selected_sbuffer_descriptor(*outer))
+        return false;
+
+    const SelectedSbufferDomain domain = selected_sbuffer_domain(*source);
+    if (outer->selected_sbuffer_soffset == kGtaSelectedSbufferAllOobSoffset)
+        return domain == SelectedSbufferDomain::AllOob &&
+               is_zero_record_raw_buffer(*target_x4) &&
+               is_zero_record_raw_buffer(*target_x2);
+    if (domain != SelectedSbufferDomain::Record4) return false;
+
+    const uint8_t* outer_bytes = complete_resource_bytes(*outer, outer->size);
+    if (!outer_bytes) return false;
+    std::array<uint32_t, 4> live_words{};
+    std::memcpy(live_words.data(),
+                outer_bytes + kGtaSelectedSbufferRecord4Soffset + 8u,
+                sizeof(live_words));
+    if (live_words != outer->selected_sbuffer_words) return false;
+    DecodedBufferDescriptor selected{};
+    if (!selected_sbuffer_target_descriptor(live_words, selected)) return false;
+    return selected_sbuffer_target_resource(
+               *target_x4, kSelectedSbufferLoadX4Pc, selected) &&
+           selected_sbuffer_target_resource(
+               *target_x2, kSelectedSbufferLoadX2Pc, selected);
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.hpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.hpp
@@ -12,6 +12,8 @@ struct ComputeShaderConfig;
 struct Rdna2Inst;
 struct ShaderResourceTable;
 
+inline constexpr uint32_t kGtaSelectedSbufferThreads = 2064u;
+
 // Exact raw-store consumers in GTA V 0x413cf9a00's null-output region. This is packet identity only;
 // callers must independently prove the pc42..48 EXEC guard and the dispatch's null pointer.
 bool rdna2_gta5_null_guarded_raw_store_site(const Rdna2Inst& in);
@@ -56,6 +58,29 @@ bool rdna2_gta5_nullable_output_launch(
 // Final trust boundary: repeat byte/launch validation, require the complete exact marker set, and
 // read its retained 40-byte table witness to prove s0:s1+0x20 is still the zero qword.
 bool rdna2_gta5_nullable_output_dispatch(
+    const uint32_t* code, size_t dwords,
+    const ComputeShaderConfig& config,
+    const ShaderResourceTable& resources);
+
+// Exact GTA V 0x413ce6000 program and launch identity. The selected-SBUFFER specialization is
+// dispatch-scoped because the selector domain comes from a live 2,064-record source buffer.
+bool rdna2_gta5_selected_sbuffer_shader(const uint32_t* code, size_t dwords);
+bool rdna2_gta5_selected_sbuffer_launch(
+    const uint32_t* code, size_t dwords,
+    const ComputeShaderConfig& config);
+
+// Discover the source/outer descriptors; propagate their complete zero-record state, prove a wholly
+// OOB selector domain, or retain the sole possible in-bounds record-4 V#. Add ordinary resources for
+// the exact pc156/158 consumers in every admitted mode. Existing marker state is cleared first,
+// making this safe to repeat at replay materialization.
+bool discover_rdna2_gta5_selected_sbuffer(
+    const uint32_t* code, size_t dwords,
+    const ComputeShaderConfig& config,
+    ShaderResourceTable& resources);
+
+// Final compiler/cache trust boundary. Repeats the full byte, launch, descriptor, source-domain,
+// marker, and consumer-resource proof without mutating the supplied table.
+bool rdna2_gta5_selected_sbuffer_dispatch(
     const uint32_t* code, size_t dwords,
     const ComputeShaderConfig& config,
     const ShaderResourceTable& resources);

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -416,6 +416,12 @@ struct SpirvCompute {
     uint32_t ngg_vertex_index_value = 0;
     bool     is_compute=0;                            // true in the compute shell (gates LDS / s_barrier)
     bool     uses_barrier=0;                          // guest or synthesized workgroup barrier emitted
+    // GTA V 0x413ce6000's exact pc153 scalar descriptor-table read is admitted only after the
+    // complete dispatch/source/table proof has been repeated at the final compiler boundary.
+    // Keeping that authority on the builder, rather than inferring it from a resource field inside
+    // emit_alu, prevents a hand-built or stale marker from enabling instruction-local shortcuts.
+    bool gta5_selected_sbuffer_dispatch_validated = false;
+    uint32_t gta5_selected_sbuffer_soffset = UINT32_MAX;
     // S_CSELECT_B64 normally needs both scalar source dwords. A captured GTA V kernel consumes
     // only the selected VCC_LO word and leaves VCC_HI dead on every successor path; the whole-stream
     // liveness proof records that exact exception before emission. Keep it builder-local so recursive
@@ -11818,6 +11824,58 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                             in.pc, in.opcode);
                 ok = false; return true;
             }
+            // GTA V 0x413ce6000 partitions the active wave by a read-first-lane selector, multiplies
+            // that selector by the outer V# stride, then reads one four-dword inner V# at pc153.
+            // The front half has proved, for this exact dispatch, that every post-MUL SOFFSET is
+            // either the sole reachable in-bounds record (480 bytes, record 4) or wholly outside the
+            // 600-byte scalar-buffer range. Materialize the architectural per-dword SMEM result here:
+            // selected record words for 480, zero otherwise. The complete-dispatch authority bit is
+            // deliberately required in addition to the serialized marker shape.
+            const ShaderResource* selected_sbuffer =
+                rt && in.opcode == kSmemOpcodeBufferLoadDwordX4
+                    ? rt->by_fetch_pc(in.pc) : nullptr;
+            const bool exact_gta5_selected_sbuffer_site =
+                in.pc == 153u && in.fmt == Rdna2Format::SMEM && in.len_dwords == 2u &&
+                in.dst.kind == OperandKind::SGPR && in.dst.value == 8 &&
+                in.src[0].kind == OperandKind::SGPR && in.src[0].value == 4 &&
+                in.src[1].kind == OperandKind::Special && in.src[1].value == 106 &&
+                in.literal == 8u && in.words[0] == 0xf4280202u &&
+                in.words[1] == 0xd4000008u;
+            if (selected_sbuffer &&
+                is_gta5_selected_sbuffer_marker_candidate(*selected_sbuffer)) {
+                if (!b.gta5_selected_sbuffer_dispatch_validated ||
+                    !is_gta5_selected_sbuffer_descriptor(*selected_sbuffer) ||
+                    !exact_gta5_selected_sbuffer_site || n != 4u) {
+                    ok = false;
+                    return true;
+                }
+                if (selected_sbuffer->selected_sbuffer_soffset ==
+                        kGtaSelectedSbufferZeroChainSoffset ||
+                    selected_sbuffer->selected_sbuffer_soffset ==
+                        kGtaSelectedSbufferAllOobSoffset) {
+                    for (uint32_t k = 0; k < n; ++k) {
+                        rs.sreg[in.dst.value + static_cast<int>(k)] = b.uconst(0u);
+                        rs.sreg_srt.erase(in.dst.value + static_cast<int>(k));
+                    }
+                    return true;
+                }
+                const auto soff = rs.sreg.find(in.src[1].value);
+                if (soff == rs.sreg.end()) {
+                    ok = false;
+                    return true;
+                }
+                const uint32_t selected = b.ucmp(
+                    Op_IEqual, soff->second,
+                    b.uconst(selected_sbuffer->selected_sbuffer_soffset));
+                for (uint32_t k = 0; k < n; ++k) {
+                    rs.sreg[in.dst.value + static_cast<int>(k)] = b.sel(
+                        selected,
+                        b.uconst(selected_sbuffer->selected_sbuffer_words[k]),
+                        b.uconst(0u));
+                    rs.sreg_srt.erase(in.dst.value + static_cast<int>(k));
+                }
+                return true;
+            }
             // The front half proved all four live SBASE words at this exact scalar-buffer load and
             // proved that its minimum unsigned offset begins beyond the effective scalar bound. The
             // result is therefore exact zero without declaring or touching a dummy storage binding.
@@ -12110,11 +12168,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 case 0x9: n = 1; raw_subword = true; raw_signed = true; raw_bits = 8; break; // sbyte
                 case 0xA: n = 1; raw_subword = true; raw_bits = 16; break;  // buffer_load_ushort
                 case 0xB: n = 1; raw_subword = true; raw_signed = true; raw_bits = 16; break; // sshort
-                case 0xC: n = 1; break;                     // buffer_load_dword
-                case 0xD: n = 2; break;                     // buffer_load_dwordx2
-                case 0xE: n = 4; break;                     // buffer_load_dwordx4
-                case 0xF: n = 3; break;                     // buffer_load_dwordx3 (round-trip llvm-mc gfx1010:
-                                                            // 0xe03c… op 0x0F — x3 sorts AFTER x4 in this ISA)
+                case kMubufOpcodeLoadDword:   n = 1; break;
+                case kMubufOpcodeLoadDwordX2: n = 2; break;
+                case kMubufOpcodeLoadDwordX4: n = 4; break;
+                case kMubufOpcodeLoadDwordX3: n = 3; break; // x3 sorts after x4 (llvm-mc gfx1010)
                 case 0x0: n = 1; is_format = true; break;   // buffer_load_format_x  (vertex fetch)
                 case 0x1: n = 2; is_format = true; break;   // buffer_load_format_xy
                 case 0x2: n = 3; is_format = true; break;   // buffer_load_format_xyz
@@ -12218,6 +12275,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             bool instance_vfetch = false;
             bool folded_vfetch = false; // by-fetch V# base already includes OFFSET/SOFFSET
             const ShaderResource* resolved_buffer = nullptr;
+            bool gta5_selected_sbuffer_consumer = false;
             if (is_format) {
                 // A format load reads a vertex/buffer attribute — it needs the V# descriptor for the
                 // binding, stride, and data format. Resolve SRSRC (src[1]) via provenance: an s_load
@@ -12448,6 +12506,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     return true;
                 }
+                const bool exact_consumer =
+                    (in.pc == 156u && in.opcode == kMubufOpcodeLoadDwordX4 && n == 4u &&
+                     in.words[0] == 0xe0382000u && in.words[1] == 0x80020006u) ||
+                    (in.pc == 158u && in.opcode == kMubufOpcodeLoadDwordX2 && n == 2u &&
+                     in.words[0] == 0xe0342010u && in.words[1] == 0x80020406u);
+                if (b.gta5_selected_sbuffer_dispatch_validated && exact_consumer) {
+                    const bool exact_operands = in.fmt == Rdna2Format::MUBUF && !is_format &&
+                        !is_store && !is_atomic && !raw_subword && in.len_dwords == 2u &&
+                        in.dst.kind == OperandKind::VGPR &&
+                        in.dst.value == (in.pc == 156u ? 0 : 4) &&
+                        in.src[0].kind == OperandKind::VGPR && in.src[0].value == 6 &&
+                        in.src[1].kind == OperandKind::SGPR && in.src[1].value == 8 &&
+                        in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0;
+                    if (!exact_operands) {
+                        ok = false;
+                        return true;
+                    }
+                    gta5_selected_sbuffer_consumer = true;
+                }
                 resolved_buffer = res;
                 binding = res->binding;
                 stride  = res->stride;
@@ -12641,6 +12718,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // typed, packed, and dynamically addressed component below consumes dwords through this
             // wrapper, so adding another format shape cannot accidentally drop GLC/DLC semantics.
             auto load_dword = [&](uint32_t dword_idx) {
+                if (gta5_selected_sbuffer_consumer) {
+                    const auto soff = rs.sreg.find(106);
+                    if (soff == rs.sreg.end()) {
+                        ok = false;
+                        return b.uconst(0u);
+                    }
+                    const uint32_t selected = b.ucmp(
+                        Op_IEqual, soff->second,
+                        b.uconst(b.gta5_selected_sbuffer_soffset));
+                    // A SPIR-V select does not short-circuit its operands. Redirect rejected
+                    // partitions to the proven non-empty binding's dword zero before loading, then
+                    // select the architectural OOB zero, so an arbitrary guest v6 cannot create an
+                    // out-of-range host access on a path whose V# was actually the zero descriptor.
+                    const uint32_t safe_idx = b.sel(selected, dword_idx, b.uconst(0u));
+                    const uint32_t value = b.cbuf_load(safe_idx, binding, coherent_load);
+                    return b.sel(selected, value, b.uconst(0u));
+                }
                 return b.cbuf_load(dword_idx, binding, coherent_load);
             };
             if (is_atomic_x2) {
@@ -20666,7 +20760,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 return false;
             }
             if (!emit_cfg_state_machine(b, rs, ins, safe, rt,
-                                        allow_exec_update, allow_smem, exp_fn, code, dwords))
+                                        allow_exec_update, allow_smem, exp_fn, code, dwords,
+                                        initial_dispatch_active))
                 return false;
             return true;
         }
@@ -20684,7 +20779,8 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
         auto try_cfg_dispatcher = [&]() -> int {           // 1 = emitted, 0 = clean reject, -1 = partial
             const size_t checkpoint = b.code.size();
             if (emit_cfg_state_machine(b, rs, ins, safe, rt,
-                                       allow_exec_update, allow_smem, exp_fn, code, dwords))
+                                       allow_exec_update, allow_smem, exp_fn, code, dwords,
+                                       initial_dispatch_active))
                 return 1;
             if (b.code.size() == checkpoint) return 0;
             if (getenv("PROSPER_DBG"))
@@ -21210,6 +21306,11 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const bool has_nullable_output_raw_buffer = rt &&
         std::any_of(rt->resources.begin(), rt->resources.end(),
                     is_nullable_raw_buffer_marker_candidate);
+    const bool has_selected_sbuffer_descriptor = rt &&
+        std::any_of(rt->resources.begin(), rt->resources.end(),
+                    is_gta5_selected_sbuffer_marker_candidate);
+    const ShaderResource* selected_sbuffer_descriptor =
+        has_selected_sbuffer_descriptor ? rt->by_fetch_pc(153u) : nullptr;
     // A resource table is externally constructible and can outlive the shader bytes or dispatch
     // that produced it. Re-establish the complete static guard and dynamic null-entry contract at
     // the final translation boundary before any marker is permitted to erase a real store.
@@ -21219,6 +21320,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
         return {};
     if (has_nullable_output_raw_buffer &&
         !rdna2_gta5_nullable_output_dispatch(code, dwords, config, *rt))
+        return {};
+    if (has_selected_sbuffer_descriptor &&
+        !rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, *rt))
         return {};
     const uint32_t local_x = std::max(1u, config.local_x);
     const uint32_t local_y = std::max(1u, config.local_y);
@@ -21244,6 +21348,9 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const StaticScratchLayout scratch = analyze_static_scratch(ins);
     SpirvCompute b;
     b.diagnostic = diagnostic;
+    b.gta5_selected_sbuffer_dispatch_validated = has_selected_sbuffer_descriptor;
+    if (selected_sbuffer_descriptor && has_selected_sbuffer_descriptor)
+        b.gta5_selected_sbuffer_soffset = selected_sbuffer_descriptor->selected_sbuffer_soffset;
     if (config.lds_bytes) {
         uint32_t dw = (config.lds_bytes + 3) / 4;
         b.lds_dwords = std::min(16384u, std::max(1u, dw));
@@ -21254,11 +21361,14 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     const BarrierPhasedCompute barrier_phases = analyze_barrier_phased_compute(ins);
     const bool partial_barrier_phases = config.exact_thread_extent && has_partial_workgroup &&
         barrier_phases.found && !barrier_phases.guarded;
+    const bool gta5_selected_partial_dispatcher = config.exact_thread_extent &&
+        has_partial_workgroup && b.gta5_selected_sbuffer_dispatch_validated;
     b.native_subgroup_size = config.native_subgroup_size == wave_size &&
         local_count <= UINT32_MAX && local_count % wave_size == 0 ? wave_size : 0u;
     // A partial guest wave needs the portable dispatcher's per-lane ACTIVE bit. Native subgroup
     // operations cannot be entered by only the real prefix of the final host subgroup.
-    if (partial_barrier_phases) b.native_subgroup_size = 0;
+    if (partial_barrier_phases || gta5_selected_partial_dispatcher)
+        b.native_subgroup_size = 0;
     // PROSPER_DBG: report the inputs to that decision, not just its outcome (#2429).
     //
     // Every wave-width-dependent lowering in this file gates on `b.native_subgroup_size` -- the
@@ -21340,7 +21450,7 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
     b.allow_b32_masks = wave_size == 32;
     b.declare_guest_scratch(scratch);
     uint32_t initial_dispatch_active = 0;
-    if (partial_barrier_phases)
+    if (partial_barrier_phases || gta5_selected_partial_dispatcher)
         initial_dispatch_active = b.invocation_within_extent(
             config.threads_x, config.threads_y, config.threads_z);
     else if (config.exact_thread_extent && has_partial_workgroup)
@@ -21389,6 +21499,8 @@ std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,
                    code, dwords, nullptr, true, initial_dispatch_active, false,
                    synchronize_lds_fminmax))
         return {};
+    if (gta5_selected_partial_dispatcher && b.uses_barrier)
+        b.partial_barrier_phases_emitted = true;
     // The entry guard is intentionally divergent only in the final partial workgroup. Vulkan requires
     // every workgroup invocation to participate uniformly in OpControlBarrier, including barriers the
     // recompiler synthesizes for wave operations. Reject this uncommon combination instead of emitting

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -13,6 +13,8 @@
 // front-half fills. See docs/RESOURCE_BINDING.md for the model, the descriptor-provenance mechanism,
 // and the staged implementation plan.
 #pragma once
+#include <algorithm>
+#include <array>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -381,7 +383,45 @@ struct ShaderResource {
     // OOB_SELECT is not otherwise retained by this normalized resource, so emission, cache identity,
     // capture, and per-dispatch revalidation carry the proof explicitly.
     uint32_t       atomic_x2_record_count = 0;
+
+    // Dispatch-scoped proof for GTA V 0x413ce6000's pc153 scalar descriptor-table lookup. The
+    // front half admits either the complete zero-descriptor chain, or only the one in-bounds SOFFSET
+    // (record 4) plus wholly OOB offsets, then keeps the exact selected V# words here. UINT32_MAX
+    // means this is an ordinary resource. The marker lives only on pc153; pc156/158 remain ordinary
+    // target bindings (including ordinary zero-record bindings in the all-zero mode).
+    uint32_t       selected_sbuffer_soffset = UINT32_MAX;
+    std::array<uint32_t, 4> selected_sbuffer_words{};
 };
+
+inline bool is_gta5_selected_sbuffer_marker_candidate(const ShaderResource& resource) {
+    return resource.selected_sbuffer_soffset != UINT32_MAX;
+}
+
+inline constexpr uint32_t kGtaSelectedSbufferRecord4Soffset = 480u;
+inline constexpr uint32_t kGtaSelectedSbufferZeroChainSoffset = UINT32_MAX - 1u;
+inline constexpr uint32_t kGtaSelectedSbufferAllOobSoffset = UINT32_MAX - 2u;
+
+inline bool is_gta5_selected_sbuffer_descriptor(const ShaderResource& resource) {
+    if (resource.cls != ResourceClass::ConstantBuffer || resource.fetch_pc != 153u)
+        return false;
+    if (resource.selected_sbuffer_soffset == kGtaSelectedSbufferZeroChainSoffset)
+        return resource.format == DataFormat::Unknown && resource.num_components == 0u &&
+               resource.gpu_addr == 0u && resource.size == 0u && resource.stride == 0u &&
+               resource.srt_offset == UINT32_MAX && resource.sgpr_base == UINT32_MAX &&
+               resource.host_data == nullptr && resource.host_data_size == 0u &&
+               std::all_of(resource.selected_sbuffer_words.begin(),
+                           resource.selected_sbuffer_words.end(),
+                           [](uint32_t word) { return word == 0u; });
+    if (resource.selected_sbuffer_soffset == kGtaSelectedSbufferAllOobSoffset)
+        return resource.gpu_addr > 0x10000u && resource.stride == 120u &&
+               resource.size == 600u &&
+               std::all_of(resource.selected_sbuffer_words.begin(),
+                           resource.selected_sbuffer_words.end(),
+                           [](uint32_t word) { return word == 0u; });
+    return resource.gpu_addr > 0x10000u && resource.stride == 120u &&
+           resource.size == 600u &&
+           resource.selected_sbuffer_soffset == kGtaSelectedSbufferRecord4Soffset;
+}
 
 // A one-layer guest 2D-array descriptor is byte-identical to an ordinary 2D image, and some guest
 // shaders deliberately address it with a non-arrayed DIM=2D instruction. Keep that established

--- a/prosper/tests/test_gta5_selected_sbuffer.cpp
+++ b/prosper/tests/test_gta5_selected_sbuffer.cpp
@@ -1,0 +1,313 @@
+#include "gpu/gpu_execute.hpp"
+#include "gpu/rdna2_gta5_compute_contracts.hpp"
+#include "gpu/rdna2_to_spirv.hpp"
+#include "gpu/shader_resources.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+
+int failures = 0;
+#define CHECK(condition, message) do { \
+    if (!(condition)) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; } \
+} while (0)
+
+// Exact 276-dword consumed prefix of routed GTA V 0x413ce6000. Hex keeps the fixture compact while
+// still making packet mutations address the production word PCs directly.
+constexpr char kProgramHex[] =
+"0300a0bf0b0046d70b0c01040a826a8f000408f4700000fa00080cf4400000fa7fc08cbf1112168127ff158800000400260394beff0397be0462010023ff198800000c00220398be11039abeff039bbe046201001103a6beff03a7be046201101203a2beff03a3be0462010012821184806a07bf02039cbe03039dbe04039ebe05039fbe961da5be941da1be1a0084bf082030e00b06088088970092ff02067e000080ffff02087e000080ffff020a7e000080ff703f8cbf00203ce006000780703f8cbf0001107cf900180200060686f9001a0201060686f9001c02020606866a37eabe020088bf0c203ce0060307806a04febe760082bf000104f4980000fa120386beff0387be046201007fc08cbf931d85be7e0482be002034e00b050180703f8cbf870a0036830a0e2c8700aa7d3e0088bf8200002606004fd580fe15040c24243008004fd580fe1504181830008013ea81000108f4b80000fa8200003403006dd76a881d04ff03eabeffff7f7fff02187e0000807fff021a7e0000807f040046d700030104ff021c7e0000807f7fc08cbf00303ce003000180ff0c0836ff00000000303ce003050180ff100836ff00000000303ce003080180703f8cbf0f0054d508011604f91e067c6a8486060437eabe060088bf0c0051d5080116040d0051d509031a040e0051d50a051e046a04febeff02067e000080ffff02087e000080ffff020a7e000080ff0437eabe050088bf040054d509031a04050054d50a051e040f03067e6a04febe027efe8a260088bf8102107e8010aa7d230088bf0705d47e7e0492be6a0ea47d1d0088bf8002107e78006ab8000108f4a80000fa7fc08cbf020228f4080000d47fc08cbf002038e006000280102034e00604028088970c9289970d92713f8cbf0001107cf918180200060686f9181a0201060686f9181c0202060686f91a060203060686703f8cbff91a080204060686f91a0a02050606861204febedbff82bf0204febe00006dd711822d04703f8cbff918027c03800606041b027cf91c027c0582060688970492002030e00006058089970592006aea886a02ea88f90800020c060686f90802020d060686f90804020e060686f90a060203060686f90a100204060686f90a120205060686703f8cbf0a0048d506076d02410088bf9e0c182c98181616107078e00a000980207074e00a0809800000fdbb8102087e0860c8e00a040680703f8cbf8f0808368008aa7d330088bf002034e00a040680c1020c7ec1020e7e8018164c831616340b0046d70b032d04703f8cbf81081c30810a1830040049d504010502050049d5050105020f0046d70e0781020d0046d70c0781020e0047d7101c0e020c0047d710180e02851e1e38851a1a3804004ad5041d3e0405004ad505193604006078e00a04098028f038e00a04098038f034e00a0b0980713f8cbf0401001e010b021e020d041e07070620703f8cbf08171020091912208014aa7d060088bf002030e00a060580703f8cbf0a0048d506076d02beff82bf000081bf";
+
+uint8_t nibble(char c) {
+    return c >= '0' && c <= '9' ? static_cast<uint8_t>(c - '0')
+                                : static_cast<uint8_t>(c - 'a' + 10);
+}
+
+std::vector<uint32_t> program() {
+    static_assert(sizeof(kProgramHex) - 1u == 276u * 8u);
+    std::vector<uint32_t> words(276u);
+    auto* bytes = reinterpret_cast<uint8_t*>(words.data());
+    for (size_t index = 0; index < words.size() * sizeof(uint32_t); ++index)
+        bytes[index] = static_cast<uint8_t>(
+            nibble(kProgramHex[index * 2u]) << 4u | nibble(kProgramHex[index * 2u + 1u]));
+    return words;
+}
+
+struct Fixture {
+    std::vector<uint32_t> source = std::vector<uint32_t>(2064u * 2u);
+    std::array<uint8_t, 600> outer{};
+    std::vector<uint8_t> target = std::vector<uint8_t>(13360u);
+    ShaderResourceTable table;
+    ComputeShaderConfig config;
+
+    Fixture() {
+        for (uint32_t record = 0; record < 2064u; ++record)
+            source[record * 2u] = (record + 4u) << 3u;
+
+        const uint64_t target_address = reinterpret_cast<uint64_t>(target.data());
+        const std::array<uint32_t, 4> selected{
+            static_cast<uint32_t>(target_address),
+            static_cast<uint32_t>((target_address >> 32u) & 0xffffu) | (20u << 16u),
+            668u,
+            0x0004a3acu,
+        };
+        std::memcpy(outer.data() + 488u, selected.data(), sizeof(selected));
+
+        ShaderResource source_resource;
+        source_resource.cls = ResourceClass::ConstantBuffer;
+        source_resource.format = DataFormat::Uint32;
+        source_resource.num_components = 1u;
+        source_resource.gpu_addr = reinterpret_cast<uint64_t>(source.data());
+        source_resource.size = 16512u;
+        source_resource.stride = 8u;
+        source_resource.fetch_pc = 70u;
+        source_resource.host_data = reinterpret_cast<uint8_t*>(source.data());
+        source_resource.host_data_size = source.size() * sizeof(uint32_t);
+        table.resources.push_back(source_resource);
+
+        ShaderResource outer_resource;
+        outer_resource.cls = ResourceClass::ConstantBuffer;
+        outer_resource.format = DataFormat::Uint32;
+        outer_resource.num_components = 1u;
+        outer_resource.gpu_addr = reinterpret_cast<uint64_t>(outer.data());
+        outer_resource.size = 600u;
+        outer_resource.stride = 120u;
+        outer_resource.fetch_pc = 153u;
+        outer_resource.host_data = outer.data();
+        outer_resource.host_data_size = outer.size();
+        table.resources.push_back(outer_resource);
+
+        config.user_sgprs.resize(11u);
+        config.local_x = 64u;
+        config.local_y = config.local_z = 1u;
+        config.exact_thread_extent = true;
+        config.threads_x = 2064u;
+        config.threads_y = config.threads_z = 1u;
+        config.wave_size = 64u;
+        config.tgid_x_en = true;
+        config.tidig_comp_cnt = 0u;
+    }
+};
+
+size_t marker_count(const ShaderResourceTable& table) {
+    size_t count = 0;
+    for (const ShaderResource& resource : table.resources)
+        count += is_gta5_selected_sbuffer_marker_candidate(resource);
+    return count;
+}
+
+} // namespace
+
+int main() {
+    const std::vector<uint32_t> exact = program();
+    Fixture valid;
+    CHECK(rdna2_gta5_selected_sbuffer_shader(exact.data(), exact.size()),
+          "exact routed program identity");
+    CHECK(discover_rdna2_gta5_selected_sbuffer(
+              exact.data(), exact.size(), valid.config, valid.table),
+          "complete selector domain specializes");
+    CHECK(marker_count(valid.table) == 1u &&
+              valid.table.by_fetch_pc(153u) &&
+              is_gta5_selected_sbuffer_descriptor(*valid.table.by_fetch_pc(153u)),
+          "one marker belongs to the outer pc153 resource");
+    CHECK(valid.table.by_fetch_pc(156u) && valid.table.by_fetch_pc(158u) &&
+              !is_gta5_selected_sbuffer_marker_candidate(*valid.table.by_fetch_pc(156u)) &&
+              !is_gta5_selected_sbuffer_marker_candidate(*valid.table.by_fetch_pc(158u)),
+          "pc156/158 are separate ordinary resources");
+    CHECK(rdna2_gta5_selected_sbuffer_dispatch(
+              exact.data(), exact.size(), valid.config, valid.table),
+          "final compiler-boundary proof accepts current witnesses");
+
+    // Mirror the remaining ordinary/empty exact-PC resources from the routed table so the test
+    // crosses the actual pc153 emitter and both pc156/158 raw-load gates, not only discovery.
+    auto add_buffer = [&](uint32_t pc, uint32_t size, uint32_t stride) {
+        ShaderResource resource;
+        resource.cls = ResourceClass::ConstantBuffer;
+        resource.format = size ? DataFormat::Uint32 : DataFormat::Unknown;
+        resource.num_components = size ? 1u : 0u;
+        resource.gpu_addr = size ? reinterpret_cast<uint64_t>(valid.target.data()) : 0u;
+        resource.size = size;
+        resource.stride = stride;
+        resource.fetch_pc = pc;
+        valid.table.resources.push_back(resource);
+    };
+    add_buffer(36u, 33024u, 16u);
+    add_buffer(46u, 0u, 0u);
+    add_buffer(58u, 0u, 0u);
+    for (uint32_t pc : {101u, 105u, 109u}) add_buffer(pc, 132096u, 64u);
+    add_buffer(189u, 16508u, 4u);
+    for (uint32_t pc : {212u, 214u, 253u, 255u, 257u})
+        add_buffer(pc, 132032u, 64u);
+    for (uint32_t pc : {218u, 224u}) add_buffer(pc, 24756u, 12u);
+    add_buffer(269u, 16508u, 4u);
+    assign_convention_bindings(valid.table, 2u);
+    const std::vector<uint32_t> translated = recompile_compute(
+        exact.data(), exact.size(), &valid.table, valid.config,
+        {RecompileDiagnosticStage::Compute, 0x413ce6000u});
+    CHECK(!translated.empty(),
+          "production emitter crosses pc153 and both selected-buffer consumers");
+    CHECK(validate_spirv_descriptor_interface(
+              translated, &valid.table, 0u, SpirvShaderStage::Compute, false).ok(),
+          "record-4 module matches the routed descriptor contract");
+
+    Fixture zero_chain;
+    zero_chain.table.resources.clear();
+    for (const uint32_t pc : {70u, 153u}) {
+        ShaderResource zero;
+        zero.cls = ResourceClass::ConstantBuffer;
+        zero.format = DataFormat::Unknown;
+        zero.num_components = 0u;
+        zero.fetch_pc = pc;
+        zero_chain.table.resources.push_back(zero);
+    }
+    CHECK(discover_rdna2_gta5_selected_sbuffer(
+              exact.data(), exact.size(), zero_chain.config, zero_chain.table) &&
+              marker_count(zero_chain.table) == 1u &&
+              zero_chain.table.by_fetch_pc(156u) && zero_chain.table.by_fetch_pc(158u) &&
+              is_zero_record_raw_buffer(*zero_chain.table.by_fetch_pc(156u)) &&
+              is_zero_record_raw_buffer(*zero_chain.table.by_fetch_pc(158u)),
+          "exact zero source/outer descriptors propagate through both raw consumers");
+    CHECK(rdna2_gta5_selected_sbuffer_dispatch(
+              exact.data(), exact.size(), zero_chain.config, zero_chain.table),
+          "final boundary accepts the complete zero-descriptor chain");
+    for (const ShaderResource& resource : valid.table.resources) {
+        if (resource.fetch_pc == 70u || resource.fetch_pc == 153u ||
+            resource.fetch_pc == 156u || resource.fetch_pc == 158u)
+            continue;
+        zero_chain.table.resources.push_back(resource);
+    }
+    assign_convention_bindings(zero_chain.table, 2u);
+    const std::vector<uint32_t> zero_translated = recompile_compute(
+        exact.data(), exact.size(), &zero_chain.table, zero_chain.config,
+        {RecompileDiagnosticStage::Compute, 0x413ce6000u});
+    CHECK(!zero_translated.empty(),
+          "production emitter propagates the zero descriptor through pc153/156/158");
+    CHECK(validate_spirv_descriptor_interface(
+              zero_translated, &zero_chain.table, 0u, SpirvShaderStage::Compute, false).ok(),
+          "zero-chain module matches the routed descriptor contract");
+
+    Fixture all_oob;
+    for (uint32_t record = 0; record < 2064u; ++record)
+        all_oob.source[record * 2u] = (record + 5u) << 3u;
+    const std::array<uint32_t, 4> dead_record{
+        0x3f800000u, 0x3f800000u, 0x3f800000u, 0x3f800000u,
+    };
+    std::memcpy(all_oob.outer.data() + 488u, dead_record.data(), sizeof(dead_record));
+    CHECK(discover_rdna2_gta5_selected_sbuffer(
+              exact.data(), exact.size(), all_oob.config, all_oob.table) &&
+              all_oob.table.by_fetch_pc(153u) &&
+              all_oob.table.by_fetch_pc(153u)->selected_sbuffer_soffset ==
+                  kGtaSelectedSbufferAllOobSoffset &&
+              all_oob.table.by_fetch_pc(156u) && all_oob.table.by_fetch_pc(158u) &&
+              is_zero_record_raw_buffer(*all_oob.table.by_fetch_pc(156u)) &&
+              is_zero_record_raw_buffer(*all_oob.table.by_fetch_pc(158u)),
+          "all-OOB selector domain ignores dead record-4 bytes and zeroes consumers");
+    CHECK(rdna2_gta5_selected_sbuffer_dispatch(
+              exact.data(), exact.size(), all_oob.config, all_oob.table),
+          "final boundary rescans and accepts the all-OOB selector domain");
+    all_oob.source[0] = 4u << 3u;
+    CHECK(!rdna2_gta5_selected_sbuffer_dispatch(
+               exact.data(), exact.size(), all_oob.config, all_oob.table),
+          "same pc70 source site: final boundary rejects stale all-OOB authority");
+    all_oob.source[0] = 5u << 3u;
+    for (const ShaderResource& resource : valid.table.resources) {
+        if (resource.fetch_pc == 70u || resource.fetch_pc == 153u ||
+            resource.fetch_pc == 156u || resource.fetch_pc == 158u)
+            continue;
+        all_oob.table.resources.push_back(resource);
+    }
+    assign_convention_bindings(all_oob.table, 2u);
+    const std::vector<uint32_t> all_oob_translated = recompile_compute(
+        exact.data(), exact.size(), &all_oob.table, all_oob.config,
+        {RecompileDiagnosticStage::Compute, 0x413ce6000u});
+    CHECK(!all_oob_translated.empty(),
+          "production emitter zeroes pc153/156/158 for an all-OOB domain");
+    CHECK(validate_spirv_descriptor_interface(
+              all_oob_translated, &all_oob.table, 0u,
+              SpirvShaderStage::Compute, false).ok(),
+          "all-OOB module matches the routed descriptor contract");
+
+    Fixture mixed_zero;
+    mixed_zero.table.resources.front().format = DataFormat::Unknown;
+    mixed_zero.table.resources.front().num_components = 0u;
+    mixed_zero.table.resources.front().gpu_addr = 0u;
+    mixed_zero.table.resources.front().size = 0u;
+    mixed_zero.table.resources.front().stride = 0u;
+    mixed_zero.table.resources.front().host_data = nullptr;
+    mixed_zero.table.resources.front().host_data_size = 0u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               exact.data(), exact.size(), mixed_zero.config, mixed_zero.table),
+          "one zero descriptor cannot authorize a mixed source/outer chain");
+
+    Fixture oob_only;
+    oob_only.source[0] = 5u << 3u;
+    CHECK(discover_rdna2_gta5_selected_sbuffer(
+              exact.data(), exact.size(), oob_only.config, oob_only.table),
+          "selector 5 is a valid wholly-OOB partition");
+
+    Fixture partial;
+    partial.source[0] = 3u << 3u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               exact.data(), exact.size(), partial.config, partial.table) &&
+              marker_count(partial.table) == 0u,
+          "same pc70 source site: selector 3 rejects as an unmodelled in-bounds record");
+
+    Fixture wrapped;
+    // (0x88888888 >> 3) * 120 == 0xfffffff8; pc153's +8 wraps back to byte zero.
+    wrapped.source[0] = 0x88888888u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               exact.data(), exact.size(), wrapped.config, wrapped.table),
+          "same pc70 source site: uint32 address wrap into the table rejects");
+
+    Fixture component_wrapped;
+    // (0x11111110 >> 3) * 120 == 0xfffffff0. The immediate +8 remains high-OOB,
+    // but the third dword of the 16-byte pc153 read would wrap to byte zero.
+    component_wrapped.source[0] = 0x11111110u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               exact.data(), exact.size(), component_wrapped.config,
+               component_wrapped.table),
+          "same pc70 source site: component address wrap into the table rejects");
+
+    Fixture pc153_mutation;
+    std::vector<uint32_t> changed_pc153 = exact;
+    changed_pc153[153] ^= 1u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               changed_pc153.data(), changed_pc153.size(),
+               pc153_mutation.config, pc153_mutation.table),
+          "same pc153 production packet mutation rejects");
+
+    Fixture pc156_mutation;
+    std::vector<uint32_t> changed_pc156 = exact;
+    changed_pc156[156] ^= 1u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               changed_pc156.data(), changed_pc156.size(),
+               pc156_mutation.config, pc156_mutation.table),
+          "same pc156 downstream-gate packet mutation rejects");
+
+    ShaderResource* marker = nullptr;
+    for (ShaderResource& resource : valid.table.resources)
+        if (is_gta5_selected_sbuffer_marker_candidate(resource)) marker = &resource;
+    CHECK(marker != nullptr, "marker remains available for stale-proof mutation");
+    if (marker) marker->selected_sbuffer_words[0] ^= 4u;
+    CHECK(!rdna2_gta5_selected_sbuffer_dispatch(
+               exact.data(), exact.size(), valid.config, valid.table),
+          "final boundary rejects stale selected descriptor words");
+
+    Fixture launch_mutation;
+    launch_mutation.config.threads_x = 2000u;
+    CHECK(!discover_rdna2_gta5_selected_sbuffer(
+               exact.data(), exact.size(), launch_mutation.config, launch_mutation.table),
+          "non-observed launch cannot acquire the marker");
+
+    if (failures) {
+        std::fprintf(stderr, "%d selected-SBUFFER contract assertion(s) failed\n", failures);
+        return 1;
+    }
+    std::puts("GTA V selected-SBUFFER contract tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- prove GTA V compute `0x413ce6000`'s exact launch and complete 2,064-record selector domain before specializing its dynamic scalar-buffer descriptor lookup
- support the observed populated record-4, wholly-OOB, and complete zero-record chains while keeping unproved states fail-closed
- gate the exact pc156/pc158 raw consumers with the same selected SOFFSET and partition shader-cache/replay authority correctly
- allow the exact 2,064-thread dispatch's padded final workgroup lanes to participate in the portable dispatcher's uniform synthesized barriers without executing guest work
- add named raw-load opcode constants and an exact production regression

## Root cause

The shader reads a V# from a five-record scalar-buffer table using a wave-uniform selector derived from live source records. Generic descriptor discovery cannot represent that dynamic selection. The only reachable in-bounds value is record 4; every other admitted access is wholly OOB and must produce zero. Its 2,064-thread extent also leaves a partial 64-lane workgroup, which previously made the barrier-using fallback reject after the structured route declined.

## Validation

- independent full-diff/recompiler review: **APPROVE**, no findings after adding the requested same-pc70 stale all-OOB mutation
- distrobox full build: passed
- `ctest --no-tests=error -j4`: **234/234 passed**
- focused regression validates populated, all-OOB, and zero chains; uint32 first/component wrap; exact pc153/pc156 packet mutations; stale source/marker authority; full production emission; and SPIR-V descriptor interfaces
- fresh 120-second PPSA04263 Story Mode route: all **8** observed exact dispatch tables validated; zero `0x413ce6000` terminal/consequent rejects; no Vulkan device loss
- gameplay frame remains black (`crc=666f7b3f`), so this is a blocker reduction rather than the final rendering fix

Progress on #2481.