### PR TITLE
gpu: cull zero-workgroup compute dispatches

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -5468,7 +5468,10 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
         // before capture_submit_items would otherwise synthesize a permanently empty Unknown.
         for (size_t index = 0; index < semantic_state->dispatches.size(); ++index) {
             const GpuState::Dispatch& dispatch = semantic_state->dispatches[index];
-            const bool captured_operation = operations.empty() || std::any_of(
+            // An exact ordered trace may legitimately contain no operations after zero-workgroup
+            // dispatches are removed. Only the semantic fallback treats an empty plan as "all";
+            // otherwise it would fabricate Unknown failures for hardware no-ops.
+            const bool captured_operation = std::any_of(
                 operations.begin(), operations.end(), [&](const SubmitOperation& operation) {
                     return operation.kind == SubmitOperationKind::Dispatch &&
                            operation.index == index &&
@@ -5546,8 +5549,9 @@ bool materialize_pending_gpu_capture(PendingGpuCapture& pending,
     const std::vector<ComputeItem> snapshot_computes =
         with_pending_gds_snapshot(pending, computes);
     const std::vector<SubmitOperation> semantic_operations =
-        operations.empty() && semantic_state ? plan_submit_operations(*semantic_state)
-                                             : std::vector<SubmitOperation>{};
+        operations.empty() && semantic_state && !exact_failures
+            ? plan_submit_operations(*semantic_state)
+            : std::vector<SubmitOperation>{};
     const std::vector<SubmitOperation>& exact_operations =
         semantic_operations.empty() ? operations : semantic_operations;
     const CaptureMemoryReader reader = pending_capture_reader(pending);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -6606,6 +6606,17 @@ ComputeLaunchDimensions resolve_compute_launch(const GpuState::Dispatch& d) {
     return out;
 }
 
+// A direct dispatch with zero workgroups on any axis launches no waves and therefore cannot read
+// its program, descriptors, or backing memory. Cull it before realization rather than reporting an
+// unreachable shader/resource failure. Indirect dimensions are not available at this boundary and
+// remain on the ordered argument-resolution path, which applies the same hardware no-op rule after
+// reading their three argument dwords.
+static bool direct_compute_dispatch_is_noop(const GpuState::Dispatch& dispatch) {
+    if (dispatch.indirect) return false;
+    const ComputeLaunchDimensions launch = resolve_compute_launch(dispatch);
+    return !launch.groups_x || !launch.groups_y || !launch.groups_z;
+}
+
 ComputeCpuFastPath classify_compute_cpu_fast_path(const uint32_t* code, size_t dwords) {
     // Compiler-generated 16-byte buffer fill:
     //   record = (tgid.x << 6) + tid.x; buffer[record] = {s4, s5, s6, s7}
@@ -6648,6 +6659,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
     items.reserve(st.dispatches.size());
     for (size_t dispatch_index = 0; dispatch_index < st.dispatches.size(); dispatch_index++) {
         const auto& dispatch = st.dispatches[dispatch_index];
+        if (direct_compute_dispatch_is_noop(dispatch)) continue;
         const GpuState& ds = dispatch.state ? *dispatch.state : st;
         const uint64_t code_addr = compute_dispatch_code_addr(st, dispatch);
         OperationRealizationFailure failure;
@@ -7441,8 +7453,20 @@ struct OrderedGpustateCaptureTrace {
     std::vector<DrawItem> draws;
     std::vector<ComputeItem> computes;
     std::vector<OperationRealizationFailure> failures;
+    std::vector<SubmitOperation> noops;
     PendingGpuCapture* pending_capture = nullptr;
 };
+
+static void omit_noop_dispatches(std::vector<SubmitOperation>& operations,
+                                 const std::vector<SubmitOperation>& noops) {
+    std::erase_if(operations, [&](const SubmitOperation& operation) {
+        return operation.kind == SubmitOperationKind::Dispatch &&
+            std::any_of(noops.begin(), noops.end(), [&](const SubmitOperation& noop) {
+                return noop.kind == operation.kind && noop.index == operation.index &&
+                       noop.command_order == operation.command_order;
+            });
+    });
+}
 
 static OrderedSubmitResult execute_ordered_gpustate(
     const GpuState& st, uint32_t width, uint32_t height, uint64_t submit_no,
@@ -7487,6 +7511,7 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
         std::string error;
         notify_compute_authority_unknown(
             ComputeAuthorityBoundaryKind::Capture, submit_no);
+        omit_noop_dispatches(capture_operations, capture_trace.noops);
         if (!finish_requested_gpu_capture(
                 std::move(pending_capture), {}, error,
                 can_defer_capture ? &capture_trace.draws : nullptr,
@@ -7791,7 +7816,9 @@ std::vector<SubmitOperation> plan_submit_operations(const GpuState& st) {
     for (size_t i = 0; i < st.draws.size(); ++i)
         operations.push_back({SubmitOperationKind::Draw, i, st.draws[i].command_order});
     for (size_t i = 0; i < st.dispatches.size(); ++i)
-        operations.push_back({SubmitOperationKind::Dispatch, i, st.dispatches[i].command_order});
+        if (!direct_compute_dispatch_is_noop(st.dispatches[i]))
+            operations.push_back({SubmitOperationKind::Dispatch, i,
+                                  st.dispatches[i].command_order});
     for (size_t i = 0; i < st.dma_copies.size(); ++i)
         operations.push_back({SubmitOperationKind::DmaCopy, i, st.dma_copies[i].command_order});
     std::stable_sort(operations.begin(), operations.end(), [](const auto& a, const auto& b) {
@@ -8425,10 +8452,14 @@ bool resolve_indirect_draw_arguments(const GpuState& submit, const GpuState::Dra
     return true;
 }
 
-bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
-                                         GpuState::Dispatch& resolved) {
+enum class DispatchArgumentResolution : uint8_t { Ready, Noop, Invalid };
+
+DispatchArgumentResolution resolve_indirect_dispatch_arguments(
+        const GpuState::Dispatch& source, GpuState::Dispatch& resolved) {
     resolved = source;
-    if (!source.indirect) return true;
+    if (!source.indirect)
+        return direct_compute_dispatch_is_noop(source)
+            ? DispatchArgumentResolution::Noop : DispatchArgumentResolution::Ready;
     constexpr uint32_t kArgumentBytes = 3u * sizeof(uint32_t);
     if (!source.indirect_args_addr || (source.indirect_args_addr & 3u) ||
         !guest_readable(source.indirect_args_addr, kArgumentBytes)) {
@@ -8436,11 +8467,12 @@ bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
         if (warned.fetch_add(1) < 24)
             std::fprintf(stderr, "[agc] indirect dispatch skipped: unreadable arguments at 0x%llx\n",
                          static_cast<unsigned long long>(source.indirect_args_addr));
-        return false;
+        return DispatchArgumentResolution::Invalid;
     }
     uint32_t args[3] = {};
     std::memcpy(args, reinterpret_cast<const void*>(source.indirect_args_addr), sizeof(args));
-    if (!args[0] || !args[1] || !args[2]) return false;  // hardware no-op
+    if (!args[0] || !args[1] || !args[2])
+        return DispatchArgumentResolution::Noop;
     resolved.threads_x = args[0];
     resolved.threads_y = args[1];
     resolved.threads_z = args[2];
@@ -8454,7 +8486,7 @@ bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
                          "%ux%ux%u workgroups\n",
                          args[0], args[1], args[2], launch.groups_x, launch.groups_y,
                          launch.groups_z);
-        return false;
+        return DispatchArgumentResolution::Noop;
     }
     if (std::getenv("PROSPER_INDIRECTLOG")) {
         static std::atomic<int> logged{0};
@@ -8469,10 +8501,10 @@ bool resolve_indirect_dispatch_arguments(const GpuState::Dispatch& source,
                          args[0], args[1], args[2], launch.groups_x, launch.groups_y,
                          launch.groups_z);
     }
-    return true;
+    return DispatchArgumentResolution::Ready;
 }
 
-// `failure`, when supplied, is filled on every false return — mirroring realize_retained_compute.
+// `failure`, when supplied, is filled on every failure return from the draw path below.
 // The two exits above realize_draw_item name themselves, because nothing was attempted there and a
 // shader/pipeline diagnostic cannot exist; the third forwards whatever realize_draw_item determined
 // (#1636). Callers that do not want a diagnostic keep passing nothing.
@@ -8518,17 +8550,18 @@ bool realize_retained_draw(const GpuState& st, size_t index, float scale_x, floa
     return true;
 }
 
-bool realize_retained_compute(const GpuState& st, size_t index, uint64_t submit_no,
-                              ComputeItem& item,
-                              OperationRealizationFailure* failure = nullptr) {
-    if (index >= st.dispatches.size()) return false;
+enum class RetainedComputeRealization : uint8_t { Realized, Failed };
+
+RetainedComputeRealization realize_retained_compute(
+        const GpuState& st, size_t index, const GpuState::Dispatch& resolved_dispatch,
+        uint64_t submit_no, ComputeItem& item,
+        OperationRealizationFailure* failure = nullptr) {
+    if (index >= st.dispatches.size()) return RetainedComputeRealization::Failed;
     // DMA-bearing submits are uncommon. A one-dispatch state keeps the mature realization path
     // intact while ensuring it runs only after every preceding ordered producer has landed.
     GpuState one = st.dispatches[index].state ? *st.dispatches[index].state : st;
     one.dispatches.clear();
-    GpuState::Dispatch dispatch;
-    if (!resolve_indirect_dispatch_arguments(st.dispatches[index], dispatch)) return false;
-    one.dispatches.push_back(std::move(dispatch));
+    one.dispatches.push_back(resolved_dispatch);
     std::vector<OperationRealizationFailure> failures;
     std::vector<ComputeItem> realized = realize_compute_dispatches(
         one, submit_no, failure ? &failures : nullptr);
@@ -8538,11 +8571,11 @@ bool realize_retained_compute(const GpuState& st, size_t index, uint64_t submit_
             failure->index = index;
             failure->command_order = st.dispatches[index].command_order;
         }
-        return false;
+        return RetainedComputeRealization::Failed;
     }
     item = std::move(realized.front());
     item.dispatch_index = index;
-    return true;
+    return RetainedComputeRealization::Realized;
 }
 
 struct LiveComputeParentWalkPreflight {
@@ -8792,7 +8825,9 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
         if (retained_draw_selected(st, i))
             executable.push_back({RetainedSubmitKind::Draw, i, st.draws[i].command_order});
     for (size_t i = 0; i < st.dispatches.size(); ++i)
-        executable.push_back({RetainedSubmitKind::Dispatch, i, st.dispatches[i].command_order});
+        if (!direct_compute_dispatch_is_noop(st.dispatches[i]))
+            executable.push_back({RetainedSubmitKind::Dispatch, i,
+                                  st.dispatches[i].command_order});
     for (size_t i = 0; i < st.dma_copies.size(); ++i)
         executable.push_back({RetainedSubmitKind::DmaCopy, i, st.dma_copies[i].command_order});
     for (size_t i = 0; i < st.parser_stalls.size(); ++i)
@@ -8934,6 +8969,34 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     previous_compute_executed = false;
                     break;
                 }
+                GpuState::Dispatch resolved_dispatch;
+                const DispatchArgumentResolution argument_resolution =
+                    resolve_indirect_dispatch_arguments(
+                        st.dispatches[operation.index], resolved_dispatch);
+                if (argument_resolution == DispatchArgumentResolution::Noop) {
+                    // Argument memory is readable and proves that no wave launches. This is neutral
+                    // even when no compute backend is installed: there is no producer to execute.
+                    if (capture_trace)
+                        capture_trace->noops.push_back({
+                            SubmitOperationKind::Dispatch, operation.index,
+                            operation.command_order});
+                    break;
+                }
+                if (argument_resolution != DispatchArgumentResolution::Ready) {
+                    notify_compute_authority_unknown(
+                        ComputeAuthorityBoundaryKind::Compute,
+                        submit_no, operation.command_order);
+                    if (capture_trace) {
+                        capture_trace->failures.push_back({
+                            SubmitOperationKind::Dispatch, operation.index,
+                            operation.command_order, RealizationFailureReason::Unknown});
+                    }
+                    producer_epoch_ok = false;
+                    previous_compute_code = current_compute_code;
+                    previous_compute_realized = false;
+                    previous_compute_executed = false;
+                    break;
+                }
                 if (!compute) {
                     notify_compute_authority_unknown(
                         ComputeAuthorityBoundaryKind::Compute,
@@ -8951,9 +9014,10 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 }
                 ComputeItem item;
                 OperationRealizationFailure failure;
-                if (realize_retained_compute(
-                        st, operation.index, submit_no, item,
-                        capture_trace ? &failure : nullptr)) {
+                const RetainedComputeRealization realization = realize_retained_compute(
+                    st, operation.index, resolved_dispatch, submit_no, item,
+                    capture_trace ? &failure : nullptr);
+                if (realization == RetainedComputeRealization::Realized) {
                     const LiveComputeParentWalkPreflight preflight =
                         preflight_compute_parent_walk(
                             item, previous_compute_code, previous_compute_realized,
@@ -9456,6 +9520,7 @@ bool execute_ordered_and_present(const GpuState& st, uint32_t width, uint32_t he
         std::string error;
         notify_compute_authority_unknown(
             ComputeAuthorityBoundaryKind::Capture, submit_no);
+        omit_noop_dispatches(operations, capture_trace.noops);
         const std::vector<DrawItem>* capture_draws = needs_ordered_realization
             ? &capture_trace.draws : &draws;
         const std::vector<ComputeItem>* capture_computes = needs_ordered_realization

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -374,6 +374,7 @@ int main() {
         after.command_order = 300;
         mixed.draws = {before, after};
         GpuState::Dispatch dispatch;
+        dispatch.threads_x = dispatch.threads_y = dispatch.threads_z = 1;
         dispatch.command_order = 200;
         mixed.dispatches.push_back(dispatch);
         auto operations = plan_submit_operations(mixed);
@@ -568,6 +569,7 @@ int main() {
             (uint64_t)(uintptr_t)&target, (uint64_t)(uintptr_t)&source,
             1, 0, 100, 0});
         GpuState::Dispatch dispatch;
+        dispatch.threads_x = dispatch.threads_y = dispatch.threads_z = 1;
         dispatch.command_order = 200;
         compute_only.dispatches.push_back(dispatch);
         const auto operations = plan_submit_operations(compute_only);
@@ -1221,20 +1223,141 @@ int main() {
         GpuState nonrender;
         nonrender.sh[P::COMPUTE_PGM_LO] = compute_registers[0].value;
         nonrender.sh[P::COMPUTE_PGM_HI] = compute_registers[1].value;
+
+        // A zero direct dimension is a hardware no-op. Keep it out of resource realization,
+        // ordered execution, and the semantic operation plan; otherwise an unreachable shader gap
+        // is counted as a failed dispatch and can poison a later indirect consumer epoch. Mutating
+        // the same X dimension to one must cross all three boundaries and execute normally.
+        GpuState zero_direct = nonrender;
+        GpuState::Dispatch zero_dispatch;
+        zero_dispatch.threads_x = 0;
+        zero_dispatch.threads_y = zero_dispatch.threads_z = 1;
+        zero_dispatch.command_order = 13;
+        zero_direct.dispatches.push_back(zero_dispatch);
+        std::vector<OperationRealizationFailure> zero_failures;
+        const std::vector<ComputeItem> zero_items =
+            realize_compute_dispatches(zero_direct, 1440, &zero_failures);
+        const std::vector<SubmitOperation> zero_operations =
+            plan_submit_operations(zero_direct);
+        uint32_t zero_backend_calls = 0;
+        set_submit_compute([&](const std::vector<ComputeItem>& items) {
+            zero_backend_calls += static_cast<uint32_t>(items.size());
+            return !items.empty();
+        });
+        const bool zero_executed = execute_nonrender_submit_work(zero_direct, 1440);
+        set_submit_compute({});
+        CHECK(zero_items.empty() && zero_failures.empty() && zero_operations.empty() &&
+                  !zero_executed && zero_backend_calls == 0,
+              "zero direct compute dimension is an unplanned hardware no-op");
+
+        GpuState one_direct = zero_direct;
+        one_direct.dispatches[0].threads_x = 1;
+        std::vector<OperationRealizationFailure> one_failures;
+        const std::vector<ComputeItem> one_items =
+            realize_compute_dispatches(one_direct, 1440, &one_failures);
+        const std::vector<SubmitOperation> one_operations =
+            plan_submit_operations(one_direct);
+        uint32_t one_backend_calls = 0;
+        set_submit_compute([&](const std::vector<ComputeItem>& items) {
+            one_backend_calls += static_cast<uint32_t>(items.size());
+            return !items.empty();
+        });
+        const bool one_executed = execute_nonrender_submit_work(one_direct, 1440);
+        set_submit_compute({});
+        CHECK(one_items.size() == 1 && one_failures.empty() &&
+                  one_operations.size() == 1 && one_executed && one_backend_calls == 1,
+              "nonzero mutation reaches direct compute realization, planning, and execution");
+
+        // Indirect dimensions become known only at their ordered position. A zero indirect packet
+        // must be a neutral no-op rather than a failed producer epoch; after the parser stall, the
+        // following valid indirect consumer still executes.
+        alignas(4) uint32_t zero_indirect_args[3] = {0, 1, 1};
+        alignas(4) uint32_t one_indirect_args[3] = {1, 1, 1};
+        GpuState indirect_noop_then_work = nonrender;
+        GpuState::Dispatch indirect_zero;
+        indirect_zero.indirect = true;
+        indirect_zero.indirect_args_addr =
+            reinterpret_cast<uint64_t>(zero_indirect_args);
+        indirect_zero.command_order = 10;
+        GpuState::Dispatch indirect_one = indirect_zero;
+        indirect_one.indirect_args_addr =
+            reinterpret_cast<uint64_t>(one_indirect_args);
+        indirect_one.command_order = 30;
+        indirect_noop_then_work.dispatches = {indirect_zero, indirect_one};
+        indirect_noop_then_work.parser_stalls.push_back({20});
+        uint32_t indirect_backend_calls = 0;
+        set_submit_compute([&](const std::vector<ComputeItem>& items) {
+            indirect_backend_calls += static_cast<uint32_t>(items.size());
+            return !items.empty();
+        });
+        const bool indirect_after_noop_executed =
+            execute_nonrender_submit_work(indirect_noop_then_work, 1440);
+        set_submit_compute({});
+        CHECK(indirect_after_noop_executed && indirect_backend_calls == 1,
+              "zero indirect dispatch does not poison the following producer epoch");
+
+        // Classification precedes backend selection. With no compute callback, the zero packet is
+        // still neutral; mutating the same runtime argument to one makes the missing backend an
+        // unknown compute boundary.
+        GpuState backendless_indirect = indirect_noop_then_work;
+        backendless_indirect.dispatches.resize(1);
+        backendless_indirect.parser_stalls.clear();
+        std::vector<ComputeAuthorityBoundary> backendless_boundaries;
+        set_submit_compute({});
+        set_submit_renderer([](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+            return RenderedFrame{};
+        });
+        set_compute_authority_boundary_observer(
+            [&](const ComputeAuthorityBoundary& boundary) {
+                backendless_boundaries.push_back(boundary);
+            });
+        const bool backendless_zero_executed =
+            execute_ordered_and_present(
+                backendless_indirect, W, H, 1440, /*publish=*/false);
+        const bool backendless_zero_unknown = std::any_of(
+            backendless_boundaries.begin(), backendless_boundaries.end(),
+            [](const ComputeAuthorityBoundary& boundary) {
+                return boundary.kind == ComputeAuthorityBoundaryKind::Compute;
+            });
+        zero_indirect_args[0] = 1;
+        backendless_boundaries.clear();
+        const bool backendless_one_executed =
+            execute_ordered_and_present(
+                backendless_indirect, W, H, 1440, /*publish=*/false);
+        const bool backendless_one_unknown = std::any_of(
+            backendless_boundaries.begin(), backendless_boundaries.end(),
+            [](const ComputeAuthorityBoundary& boundary) {
+                return boundary.kind == ComputeAuthorityBoundaryKind::Compute;
+            });
+        set_compute_authority_boundary_observer({});
+        set_submit_renderer({});
+        zero_indirect_args[0] = 0;
+        CHECK(!backendless_zero_executed && !backendless_zero_unknown &&
+                  !backendless_one_executed && backendless_one_unknown,
+              "indirect no-op classification precedes the compute-backend requirement");
+
+        // The production capture below sees the same indirect argument address twice: first as a
+        // zero-workgroup no-op, then after the ordered WRITE_DATA mutates X to one. This is the
+        // capture mutation arm for the no-op classifier itself.
+        GpuState::Dispatch captured_zero_dispatch = indirect_zero;
+        captured_zero_dispatch.command_order = 16;
+        nonrender.dispatches.push_back(captured_zero_dispatch);
         GpuState::Dispatch direct_dispatch;
         direct_dispatch.threads_x = direct_dispatch.threads_y = direct_dispatch.threads_z = 1;
         direct_dispatch.command_order = 17;
         nonrender.dispatches.push_back(direct_dispatch);
+        GpuState::Dispatch captured_one_dispatch = captured_zero_dispatch;
+        captured_one_dispatch.command_order = 19;
+        nonrender.dispatches.push_back(captured_one_dispatch);
         GpuState::Dispatch unresolved_dispatch;
         unresolved_dispatch.indirect = true;
         unresolved_dispatch.indirect_args_addr = 0xdead00000000ull;
-        unresolved_dispatch.command_order = 19;
+        unresolved_dispatch.command_order = 20;
         nonrender.dispatches.push_back(unresolved_dispatch);
-        uint32_t authority_effect_target = 0;
-        const uint32_t authority_effect_value = 0x1854cafeu;
+        const uint32_t authority_effect_value = 1;
         Pm4Command authority_effect;
         authority_effect.kind = Pm4Command::Kind::WriteData;
-        authority_effect.wd_addr = reinterpret_cast<uint64_t>(&authority_effect_target);
+        authority_effect.wd_addr = reinterpret_cast<uint64_t>(zero_indirect_args);
         authority_effect.wd_declared_num = 1;
         authority_effect.wd_num = 1;
         authority_effect.wd_data = &authority_effect_value;
@@ -1279,20 +1402,25 @@ int main() {
         const GpuCapturedStageDiagnostic* unresolved_stage = unresolved_failure &&
             unresolved_failure->stages.size() == 1
                 ? &unresolved_failure->stages.front() : nullptr;
-        CHECK(executed && compute_calls == 1 && captured_read &&
-                  captured.metadata.submit_index == 1441 && captured.computes.size() == 1 &&
+        CHECK(executed && compute_calls == 2 && captured_read &&
+                  captured.metadata.submit_index == 1441 && captured.computes.size() == 2 &&
                   captured.computes[0].code_addr == reinterpret_cast<uint64_t>(kNoopCs) &&
-                  captured.operations.size() == 2 && captured.operations[0].realized &&
+                  captured.computes[1].code_addr == reinterpret_cast<uint64_t>(kNoopCs) &&
+                  captured.operations.size() == 3 && captured.operations[0].realized &&
                   captured.operations[0].kind == SubmitOperationKind::Dispatch &&
-                  captured.operations[0].source_index == 0 &&
+                  captured.operations[0].source_index == 1 &&
                   captured.operations[0].command_order == direct_dispatch.command_order &&
-                  !captured.operations[1].realized &&
+                  captured.operations[1].realized &&
                   captured.operations[1].kind == SubmitOperationKind::Dispatch &&
-                  captured.operations[1].source_index == 1 &&
-                  captured.operations[1].command_order == unresolved_dispatch.command_order &&
+                  captured.operations[1].source_index == 2 &&
+                  captured.operations[1].command_order == captured_one_dispatch.command_order &&
+                  !captured.operations[2].realized &&
+                  captured.operations[2].kind == SubmitOperationKind::Dispatch &&
+                  captured.operations[2].source_index == 3 &&
+                  captured.operations[2].command_order == unresolved_dispatch.command_order &&
                   captured.failure_diagnostics.size() == 1 && unresolved_failure &&
                   unresolved_failure->kind == SubmitOperationKind::Dispatch &&
-                  unresolved_failure->source_index == 1 &&
+                  unresolved_failure->source_index == 3 &&
                   unresolved_failure->command_order == unresolved_dispatch.command_order &&
                   unresolved_failure->reason ==
                       RealizationFailureReason::Unknown &&
@@ -1307,7 +1435,7 @@ int main() {
                   captured.raw_shader_versions[unresolved_stage->raw_shader_index].words ==
                       std::vector<uint32_t>(std::begin(kNoopCs), std::end(kNoopCs)) &&
                   !captured.expected_output_valid,
-              "ordered capture retains exact direct and unresolved indirect compute evidence");
+              "ordered capture omits an indirect no-op and retains its nonzero mutation");
         CHECK(nonrender_authority_boundaries.size() == 5 &&
                   nonrender_authority_boundaries[0].kind ==
                       ComputeAuthorityBoundaryKind::SubmitBegin &&
@@ -1316,19 +1444,79 @@ int main() {
                       ComputeAuthorityBoundaryKind::OrderedMemoryEffect &&
                   nonrender_authority_boundaries[1].range_known &&
                   nonrender_authority_boundaries[1].address ==
-                      reinterpret_cast<uint64_t>(&authority_effect_target) &&
+                      reinterpret_cast<uint64_t>(zero_indirect_args) &&
                   nonrender_authority_boundaries[1].bytes == sizeof(uint32_t) &&
                   nonrender_authority_boundaries[1].command_order == 18 &&
-                  authority_effect_target == authority_effect_value &&
+                  zero_indirect_args[0] == authority_effect_value &&
                   nonrender_authority_boundaries[2].kind ==
                       ComputeAuthorityBoundaryKind::Compute &&
                   !nonrender_authority_boundaries[2].range_known &&
-                  nonrender_authority_boundaries[2].command_order == 19 &&
+                  nonrender_authority_boundaries[2].command_order ==
+                      unresolved_dispatch.command_order &&
                   nonrender_authority_boundaries[3].kind ==
                       ComputeAuthorityBoundaryKind::Capture &&
                   nonrender_authority_boundaries[4].kind ==
                       ComputeAuthorityBoundaryKind::SubmitEnd,
               "non-render authority hook fail-closes unrealized compute before capture and end");
+        zero_indirect_args[0] = 0;
+        std::filesystem::remove(path, filesystem_error);
+
+        // Exact capture has no operation to replay for a zero-workgroup indirect packet. Exercise
+        // the empty-exact-plan seam so capture does not synthesize an Unknown shader failure merely
+        // because no ComputeItem was produced.
+        GpuState captured_indirect_noop = indirect_noop_then_work;
+        captured_indirect_noop.dispatches.clear();
+        captured_indirect_noop.parser_stalls.clear();
+        captured_indirect_noop.dispatches.push_back(indirect_zero);
+
+        auto captured_noop_pending = std::make_unique<PendingGpuCapture>();
+        captured_noop_pending->materialized = false;
+        captured_noop_pending->path = path.string();
+        captured_noop_pending->capture.metadata.submit_index = 1442;
+        const std::vector<SubmitOperation> captured_noop_operations;
+        const std::vector<OperationRealizationFailure> captured_noop_failures;
+        const std::vector<DrawItem> captured_noop_draws;
+        const std::vector<ComputeItem> captured_noop_computes;
+        const bool captured_noop_written = finish_requested_gpu_capture(
+            std::move(captured_noop_pending), {}, capture_error,
+            &captured_noop_draws, &captured_noop_computes,
+            &captured_noop_operations, &captured_indirect_noop,
+            &captured_noop_failures);
+        GpuCaptureFile captured_noop;
+        const bool captured_noop_read = captured_noop_written &&
+            read_gpu_capture(path.string(), captured_noop, capture_error);
+        CHECK(captured_noop_read && captured_noop.operations.empty() &&
+                  captured_noop.computes.empty() &&
+                  captured_noop.failure_diagnostics.empty(),
+              "exact capture omits an indirect zero-workgroup hardware no-op");
+        std::filesystem::remove(path, filesystem_error);
+
+        // Mutating that exact plan to retain the same dispatch must synthesize the missing failure;
+        // this guards the empty-plan distinction rather than only asserting an already-empty input.
+        auto captured_matching_pending = std::make_unique<PendingGpuCapture>();
+        captured_matching_pending->materialized = false;
+        captured_matching_pending->path = path.string();
+        captured_matching_pending->capture.metadata.submit_index = 1442;
+        const std::vector<SubmitOperation> captured_matching_operations = {
+            {SubmitOperationKind::Dispatch, 0, indirect_zero.command_order},
+        };
+        const bool captured_matching_written = finish_requested_gpu_capture(
+            std::move(captured_matching_pending), {}, capture_error,
+            &captured_noop_draws, &captured_noop_computes,
+            &captured_matching_operations, &captured_indirect_noop,
+            &captured_noop_failures);
+        GpuCaptureFile captured_matching;
+        const bool captured_matching_read = captured_matching_written &&
+            read_gpu_capture(path.string(), captured_matching, capture_error);
+        CHECK(captured_matching_read && captured_matching.operations.size() == 1 &&
+                  !captured_matching.operations[0].realized &&
+                  captured_matching.failure_diagnostics.size() == 1 &&
+                  captured_matching.failure_diagnostics[0].reason ==
+                      RealizationFailureReason::Unknown &&
+                  captured_matching.failure_diagnostics[0].source_index == 0 &&
+                  captured_matching.failure_diagnostics[0].command_order ==
+                      indirect_zero.command_order,
+              "retaining the matching operation synthesizes its missing exact failure");
         std::filesystem::remove(path, filesystem_error);
 
         // A partial exact trace can identify an operation whose source index happens to exist in


### PR DESCRIPTION
## Summary

- classify direct and ordered indirect zero-workgroup compute packets as hardware no-ops before shader/resource realization
- keep no-op dispatches neutral across compute producer epochs, including when no compute backend is installed
- remove no-op dispatches from exact capture plans instead of fabricating unreachable shader failures
- add same-site zero-to-one mutation coverage through realization, execution, ordered dependency handling, and production capture

Closes no issue; this is one checkpoint in #2481.

## GTA V compute frontier

The latest routed gameplay census contains 190 raw compute packets:

| Class | Count | Meaning |
|---|---:|---|
| Hardware no-op | 134 | At least one workgroup dimension is zero; no wave launches |
| Realized, nonzero | 35 | Shader recompiles and reaches the compute backend |
| Failed, nonzero | 21 | Current executable compute frontier |
| **Total** | **190** | **56 packets actually launch work** |

Before separating hardware no-ops, the raw diagnostics looked like 157 realized / 33 failed. That obscured the actionable frontier: 122 of those realized packets and 12 of those failures launch no work. This change removes those 134 packets from shader-gap and exact-capture accounting.

The previously suspected eight-dispatch runtime descriptor-selector family is entirely zero-workgroup in the current capture, so it is not blocking the observed gameplay run. Its nonzero selector domain remains deliberately unproven; this PR does not add speculative selector behavior.

The 21 remaining nonzero failures are currently grouped as:

- 8 Wave32 shader-recompile failures across one kernel family
- 8 undersized-buffer descriptor-contract failures from one program
- 2 undersized nullable-output descriptor-contract failures
- 3 shader-recompile failures from one additional program

The next investigation should start with those nonzero families. The census and the dynamic-selector negative result are also recorded on #2481 so future agents do not spend time implementing unreachable shapes.

## Correctness details

Indirect arguments are resolved at their ordered execution position, after any preceding DMA or WRITE_DATA producer. A readable zero dimension is classified before checking for a compute backend, because no backend work is required. Invalid/unreadable indirect arguments remain fail-closed and still poison dependent epochs.

Exact capture records only operations that can execute. The regression mutates the same indirect argument address from zero to one with an ordered write between two dispatches: the zero dispatch is omitted, while the nonzero dispatch executes and is retained as realized. A second mutation arm proves that explicitly retaining an unrealized matching operation synthesizes the expected failure instead of silently treating every empty exact plan as semantic fallback.

## Verification

- `ctest --no-tests=error -j4`: **240/240 passed**
- focused compute/capture set: **4/4 passed**
- independent code review: **GO** on exact commit `f0588086`; reviewer also ran **240/240** tests

## Routed gameplay result

A fresh 200-second Linux/RADV run at exact commit `f0588086` used the checked-in Story Mode input route and confirmed the expected title/build revision. It exited normally and produced a valid final capture, but the 3D world remains black. The previously known compute device-loss program still triggered a RADV hard recovery during the route, after which live compute was disabled for the rest of the process.

That outcome is consistent with this PR's scope: it removes unreachable zero-workgroup packets from the blocker set, but does not change any of the 21 nonzero failing launches. Those executable families remain the next frontier.
