### PR TITLE
gpu: advance GTA V compute executable frontier

### DIFF
--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -658,7 +658,7 @@ void decode_operands(Rdna2Inst& i) {
             // sources. Their reserved SRC2 bits commonly decode as s0 unless cleared here.
             // Exposing that phantom scalar read can make CFG/provenance analysis reject an otherwise
             // valid instruction when s0 differs across a merge, before the opcode emitter is reached.
-            if (vop3_opcode_has_two_data_sources(i.opcode)) {
+            if (emitted_vop3_opcode_has_two_data_sources(i.opcode)) {
                 i.src[2] = {};
                 i.n_src = 2;
             }

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -654,18 +654,11 @@ void decode_operands(Rdna2Inst& i) {
             // carry-in. Their reserved SRC2 field commonly decodes as s0; exposing that phantom
             // operand makes CFG provenance reject a valid instruction when s0 differs across a
             // join, before the instruction can replace it with its fresh carry result.
-            if (i.opcode == 0x30Fu || i.opcode == 0x310u || i.opcode == 0x319u) {
-                i.src[2] = {};
-                i.n_src = 2;
-            }
-            // V_MAC_F32, V_LSHLREV_B64, V_LSHRREV_B64, V_LDEXP_F32, and V_BFM_B32 are
-            // two-source VOP3A instructions. Their reserved SRC2 bits are zero in GTA V's packets and
-            // therefore decode as s0 unless cleared here.
+            // The no-carry-in VOP3B family above and several VOP3A operations have two explicit
+            // sources. Their reserved SRC2 bits commonly decode as s0 unless cleared here.
             // Exposing that phantom scalar read can make CFG/provenance analysis reject an otherwise
             // valid instruction when s0 differs across a merge, before the opcode emitter is reached.
-            if (i.opcode == 0x11fu || i.opcode == kVop3OpcodeLshlrevB64 ||
-                i.opcode == kVop3OpcodeLshrrevB64 ||
-                i.opcode == 0x362u || i.opcode == 0x363u) {
+            if (vop3_opcode_has_two_data_sources(i.opcode)) {
                 i.src[2] = {};
                 i.n_src = 2;
             }

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -62,8 +62,10 @@ inline constexpr uint32_t kSop1OpcodeAndn1SaveexecB32 = 0x44;
 inline constexpr uint32_t kSop1OpcodeOrn1SaveexecB32 = 0x45;
 inline constexpr uint32_t kSop1OpcodeAndn1WrexecB32 = 0x46;
 inline constexpr uint32_t kSop1OpcodeAndn2WrexecB32 = 0x47;
-inline constexpr uint32_t kSop2OpcodeCselectB32 = 0x0a;
+inline constexpr uint32_t kSop2OpcodeAddU32 = 0x00;
 inline constexpr uint32_t kSop2OpcodeAddI32 = 0x02;
+inline constexpr uint32_t kSop2OpcodeAddcU32 = 0x04;
+inline constexpr uint32_t kSop2OpcodeCselectB32 = 0x0a;
 inline constexpr uint32_t kSop1OpcodeMovreldB32 = 0x30;
 inline constexpr uint32_t kSop1OpcodeMovreldB64 = 0x31;
 inline constexpr uint32_t kSop1OpcodeMovrelsd2B32 = 0x49;
@@ -187,15 +189,25 @@ inline constexpr uint32_t kVop3OpcodeLdexpF32 = 0x362;
 inline constexpr uint32_t kVop3OpcodeBfmB32 = 0x363;
 
 // VOP3 reserves three encoded source fields even for operations with only two explicit data
-// sources. Keep the architectural arity in one inventory so the decoder never exposes those
-// reserved bits as a phantom scalar dependency to control-flow or resource analysis.
-inline constexpr bool vop3_opcode_has_two_data_sources(uint32_t opcode) {
-    return opcode == kVop3OpcodeMacF32 || opcode == kVop3OpcodeMulLoU32 ||
+// sources. Keep the complete inventory for every currently emitted two-source operation here so
+// the decoder never exposes reserved bits as a phantom scalar dependency to control-flow or
+// resource analysis. Unsupported opcodes retain all three fields and remain fail-closed.
+inline constexpr bool emitted_vop3_opcode_has_two_data_sources(uint32_t opcode) {
+    return (opcode >= 0x103u && opcode <= 0x105u) ||
+           opcode == 0x107u || opcode == 0x108u || opcode == 0x10fu || opcode == 0x110u ||
+           opcode == kVop3OpcodeMacF32 || opcode == 0x12fu ||
+           opcode == kVop3OpcodeMulLoU32 ||
            opcode == kVop3OpcodeMulHiU32 || opcode == kVop3OpcodeMulHiI32 ||
            opcode == kVop3OpcodeLshlrevB64 || opcode == kVop3OpcodeLshrrevB64 ||
            opcode == kVop3OpcodeAddCoU32 || opcode == kVop3OpcodeSubCoU32 ||
-           opcode == kVop3OpcodeSubrevCoU32 || opcode == kVop3OpcodeLdexpF32 ||
-           opcode == kVop3OpcodeBfmB32;
+           opcode == kVop3OpcodeSubrevCoU32 ||
+           (opcode >= 0x303u && opcode <= 0x305u) ||
+           (opcode >= 0x307u && opcode <= 0x30eu) ||
+           opcode == 0x311u || opcode == 0x314u ||
+           opcode == 0x360u || opcode == 0x361u ||
+           opcode == kVop3OpcodeLdexpF32 || opcode == kVop3OpcodeBfmB32 ||
+           opcode == 0x364u || opcode == 0x365u || opcode == 0x366u ||
+           opcode == 0x368u || opcode == 0x369u || opcode == 0x36au;
 }
 
 // GFX10.3 DS cross-lane/float-atomic opcodes shared by decode-side write accounting, control-flow

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -172,9 +172,31 @@ inline constexpr uint32_t kVopcOpcodeCmpxEqU32 = 0xd2;
 // independent B32 operands.
 inline constexpr uint32_t kVop3OpcodeLshlrevB64 = 0x2ff;
 inline constexpr uint32_t kVop3OpcodeLshrrevB64 = 0x300;
+inline constexpr uint32_t kVop3OpcodeMacF32 = 0x11f;
+inline constexpr uint32_t kVop3OpcodeMadU32U24 = 0x143;
+inline constexpr uint32_t kVop3OpcodeMulLoU32 = 0x169;
+inline constexpr uint32_t kVop3OpcodeMulHiU32 = 0x16a;
+inline constexpr uint32_t kVop3OpcodeMulHiI32 = 0x16c;
+inline constexpr uint32_t kVop3OpcodeAddCoU32 = 0x30f;
+inline constexpr uint32_t kVop3OpcodeSubCoU32 = 0x310;
+inline constexpr uint32_t kVop3OpcodeSubrevCoU32 = 0x319;
 inline constexpr uint32_t kVop3OpcodeLshlAddU32 = 0x346;
 inline constexpr uint32_t kVop3OpcodeAdd3U32 = 0x36d;
 inline constexpr uint32_t kVop3OpcodeAndOrB32 = 0x371;
+inline constexpr uint32_t kVop3OpcodeLdexpF32 = 0x362;
+inline constexpr uint32_t kVop3OpcodeBfmB32 = 0x363;
+
+// VOP3 reserves three encoded source fields even for operations with only two explicit data
+// sources. Keep the architectural arity in one inventory so the decoder never exposes those
+// reserved bits as a phantom scalar dependency to control-flow or resource analysis.
+inline constexpr bool vop3_opcode_has_two_data_sources(uint32_t opcode) {
+    return opcode == kVop3OpcodeMacF32 || opcode == kVop3OpcodeMulLoU32 ||
+           opcode == kVop3OpcodeMulHiU32 || opcode == kVop3OpcodeMulHiI32 ||
+           opcode == kVop3OpcodeLshlrevB64 || opcode == kVop3OpcodeLshrrevB64 ||
+           opcode == kVop3OpcodeAddCoU32 || opcode == kVop3OpcodeSubCoU32 ||
+           opcode == kVop3OpcodeSubrevCoU32 || opcode == kVop3OpcodeLdexpF32 ||
+           opcode == kVop3OpcodeBfmB32;
+}
 
 // GFX10.3 DS cross-lane/float-atomic opcodes shared by decode-side write accounting, control-flow
 // admission, and emission. These inline constants compile to the same immediate comparisons as raw

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5931,19 +5931,20 @@ std::unordered_set<uint32_t> proven_structured_wave64_mask_reduction_pcs(
     return proven;
 }
 
-// Prove GTA V's S_LOAD_DWORDX2 descriptor-fragment shapes: the general register-offset table fetch
-// and GTA V's exact immediate +0x50/+0x58 descriptor-table entries. The load supplies one or two
-// live words of a four-dword V#; scalar code fills or replaces the other words before MUBUF, MTBUF,
-// or S_BUFFER_LOAD consumes the complete live descriptor. The front half has already read the guest
-// words and published the resulting resource at that exact consumer PC, so the loaded fragment is
-// provenance-only in SPIR-V and can be represented by zero placeholders.
+// Prove S_LOAD_DWORDX2 descriptor-fragment shapes. The load supplies one or two live words of a
+// four-dword V#; scalar code fills or replaces the other words before MUBUF, MTBUF, or S_BUFFER_LOAD
+// consumes the complete live descriptor. The front half has already read the guest words and
+// published the resulting resource at that exact consumer PC, so the loaded fragment is
+// provenance-only in SPIR-V and can be represented by zero placeholders. Immediate descriptor-table
+// offsets are admitted by this use proof rather than a title-specific offset inventory.
 //
 // This is deliberately a whole-CFG use proof, not opcode-wide admission. Every reachable path is
 // followed until the loaded words are overwritten or execution ends. A loaded word may only be read
 // through an exact-PC, key-less buffer descriptor; every ordinary scalar/address read and every
 // unresolved control edge rejects the candidate. CONFIDENCE: HIGH for the admitted shape.
 std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
-        const std::vector<Rdna2Inst>& ins, const ShaderResourceTable* rt) {
+        const std::vector<Rdna2Inst>& ins, const ShaderResourceTable* rt,
+        uint32_t wave_size) {
     std::unordered_set<uint32_t> proven;
     if (!rt || ins.empty()) return proven;
 
@@ -5966,6 +5967,29 @@ std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
         return resource->cls == ResourceClass::ConstantBuffer ||
                resource->cls == ResourceClass::VertexBuffer;
     };
+    auto scalar_register_is = [&](const Operand& operand, int reg) {
+        return is_scalar_operand(operand) && operand.value == reg;
+    };
+    auto instruction_reads_scc = [](const Rdna2Inst& in) {
+        for (uint32_t source = 0; source < in.n_src; ++source)
+            if (in.src[source].kind == OperandKind::Special && in.src[source].value == 253)
+                return true;
+        if (in.fmt == Rdna2Format::SOP2)
+            return in.opcode == kSop2OpcodeAddcU32 || in.opcode == 0x05u ||
+                   in.opcode == kSop2OpcodeCselectB32 ||
+                   in.opcode == kSop2OpcodeCselectB64;
+        if (in.fmt == Rdna2Format::SOPP)
+            return in.opcode == kSoppOpcodeCbranchScc0 || in.opcode == 0x05u;
+        if (in.fmt == Rdna2Format::SOP1)
+            return in.opcode == kSop1OpcodeCmovB32 || in.opcode == kSop1OpcodeCmovB64;
+        return in.fmt == Rdna2Format::SOPK && in.opcode == kSopkOpcodeCmovkI32;
+    };
+
+    std::unordered_set<uint32_t> direct_branch_targets;
+    for (const Rdna2Inst& in : ins)
+        if (!in.is_end && in.fmt == Rdna2Format::SOPP &&
+            sopp_opcode_is_direct_branch(in.opcode))
+            direct_branch_targets.insert(branch_target(in));
 
     for (size_t load_index = 0; load_index < ins.size(); ++load_index) {
         const Rdna2Inst& load = ins[load_index];
@@ -5976,38 +6000,127 @@ std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
         const bool optional_null_immediate =
             load.src[1].kind == OperandKind::Special && load.src[1].value == 125 &&
             load.literal == kGtaOptionalBufferPointerOffset;
-        const bool gta_descriptor_immediate = optional_null_immediate ||
-            (load.src[1].kind == OperandKind::Special && load.src[1].value == 125 &&
-             load.literal == kGtaBufferDescriptorFragmentOffset);
+        const bool aligned_immediate =
+            load.src[1].kind == OperandKind::Special && load.src[1].value == 125 &&
+            static_cast<int32_t>(load.literal) >= 0 && (load.literal & 3u) == 0;
         if (load.is_end || load.fmt != Rdna2Format::SMEM ||
             load.opcode != kSmemOpcodeLoadDwordX2 ||
             load.dst.kind != OperandKind::SGPR || load.dst.value < 0 ||
-            load.dst.value + 1 > 105 || (!register_offset && !gta_descriptor_immediate))
+            (load.dst.value > 104 && load.dst.value != 106) ||
+            (!register_offset && !aligned_immediate))
             continue;
 
         const int base = load.dst.value;
-        auto overlap = [base](uint8_t live, int first, uint32_t words) {
+        struct DescriptorRelocation {
+            size_t low_index = SIZE_MAX;
+            size_t high_index = SIZE_MAX;
+            int destination_base = -1;
+        } relocation;
+
+        // Some descriptor builders relocate a loaded 64-bit address with an ordinary carry pair:
+        //   s_add_u32  dst.lo, loaded.lo, base.lo
+        //   s_addc_u32 dst.hi, loaded.hi, base.hi
+        // Admit only the exact pair in one straight-line SCC lifetime. Interposed scalar moves are
+        // SCC-transparent, and the produced final carry must have no later observer. This keeps the
+        // loaded address as descriptor provenance without treating general scalar arithmetic as a
+        // descriptor transformation.
+        for (size_t low_index = load_index + 1;
+             low_index < ins.size() && relocation.low_index == SIZE_MAX; ++low_index) {
+            const Rdna2Inst& low = ins[low_index];
+            if (low.is_end ||
+                (low.fmt == Rdna2Format::SOPP && !sopp_is_noop(low)) ||
+                (low.fmt == Rdna2Format::SOP1 &&
+                 low.opcode >= kSop1OpcodeSetpcB64 && low.opcode <= kSop1OpcodeRfeB64))
+                break;
+            if (low.fmt != Rdna2Format::SOP2 || low.opcode != kSop2OpcodeAddU32 ||
+                low.dst.kind != OperandKind::SGPR || low.dst.value < 0 ||
+                low.dst.value + 3 > 105 || low.n_src != 2)
+                continue;
+            if (low.dst.value <= base + 1 && base <= low.dst.value + 1)
+                continue;
+            int loaded_source = -1;
+            if (scalar_register_is(low.src[0], base)) loaded_source = 0;
+            if (scalar_register_is(low.src[1], base)) {
+                if (loaded_source >= 0) continue;
+                loaded_source = 1;
+            }
+            if (loaded_source < 0 ||
+                !is_scalar_operand(low.src[static_cast<uint32_t>(1 - loaded_source)]))
+                continue;
+            const int other_base = low.src[static_cast<uint32_t>(1 - loaded_source)].value;
+            if (other_base < 0 || other_base + 1 > 105 ||
+                (other_base <= base + 1 && base <= other_base + 1) ||
+                (other_base <= low.dst.value + 1 &&
+                 low.dst.value <= other_base + 1))
+                continue;
+
+            for (size_t high_index = low_index + 1; high_index < ins.size(); ++high_index) {
+                const Rdna2Inst& high = ins[high_index];
+                if (direct_branch_targets.contains(high.pc)) break;
+                if (high.fmt == Rdna2Format::SOP2 &&
+                    high.opcode == kSop2OpcodeAddcU32 && high.n_src == 2 &&
+                    high.dst.kind == OperandKind::SGPR &&
+                    high.dst.value == low.dst.value + 1) {
+                    const bool matched_sources =
+                        (scalar_register_is(high.src[0], base + 1) &&
+                         scalar_register_is(high.src[1], other_base + 1)) ||
+                        (scalar_register_is(high.src[1], base + 1) &&
+                         scalar_register_is(high.src[0], other_base + 1));
+                    if (!matched_sources) break;
+                    bool carry_observed = false;
+                    for (size_t later = high_index + 1; later < ins.size(); ++later)
+                        if (instruction_reads_scc(ins[later])) {
+                            carry_observed = true;
+                            break;
+                        }
+                    if (!carry_observed)
+                        relocation = {low_index, high_index, low.dst.value};
+                    break;
+                }
+                if (high.fmt != Rdna2Format::SOP1 ||
+                    high.opcode != kSop1OpcodeMovB32)
+                    break;
+                if (instruction_reads_scc(high)) break;
+                if (high.dst.value == base || high.dst.value == base + 1 ||
+                    high.dst.value == low.dst.value ||
+                    high.dst.value == low.dst.value + 1)
+                    break;
+            }
+        }
+
+        auto overlap = [base, &relocation](uint8_t live, int first, uint32_t words) {
             if (first < 0 || !words) return false;
             for (uint32_t word = 0; word < words; ++word) {
-                const int relative = first + static_cast<int>(word) - base;
-                if (relative >= 0 && relative < 2 && (live & (1u << relative)))
+                const int reg = first + static_cast<int>(word);
+                const int original_relative = reg - base;
+                if (original_relative >= 0 && original_relative < 2 &&
+                    (live & (1u << original_relative)))
+                    return true;
+                const int relocated_relative = reg - relocation.destination_base;
+                if (relocation.destination_base >= 0 && relocated_relative >= 0 &&
+                    relocated_relative < 2 && (live & (1u << (relocated_relative + 2))))
                     return true;
             }
             return false;
         };
-        auto clear_written = [base](uint8_t& live, int first, uint32_t words) {
+        auto clear_written = [base, &relocation](uint8_t& live, int first, uint32_t words) {
             if (first < 0) return;
             for (uint32_t word = 0; word < words; ++word) {
-                const int relative = first + static_cast<int>(word) - base;
-                if (relative >= 0 && relative < 2)
-                    live &= static_cast<uint8_t>(~(1u << relative));
+                const int reg = first + static_cast<int>(word);
+                const int original_relative = reg - base;
+                if (original_relative >= 0 && original_relative < 2)
+                    live &= static_cast<uint8_t>(~(1u << original_relative));
+                const int relocated_relative = reg - relocation.destination_base;
+                if (relocation.destination_base >= 0 && relocated_relative >= 0 &&
+                    relocated_relative < 2)
+                    live &= static_cast<uint8_t>(~(1u << (relocated_relative + 2)));
             }
         };
 
         struct PendingState { size_t index; uint8_t live; };
         std::vector<PendingState> pending;
         if (load_index + 1 < ins.size()) pending.push_back({load_index + 1, 0x3u});
-        std::vector<uint8_t> visited(ins.size(), 0);
+        std::vector<uint16_t> visited(ins.size(), 0);
         bool consumed = false;
         bool valid = true;
 
@@ -6028,7 +6141,7 @@ std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
             PendingState state = pending.back();
             pending.pop_back();
             if (!state.live || state.index >= ins.size()) continue;
-            const uint8_t state_bit = static_cast<uint8_t>(1u << state.live);
+            const uint16_t state_bit = static_cast<uint16_t>(1u << state.live);
             if (visited[state.index] & state_bit) continue;
             visited[state.index] |= state_bit;
 
@@ -6062,8 +6175,25 @@ std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
                 in.n_src == 2 && in.src[0].kind == OperandKind::SGPR &&
                 in.src[0].value == in.dst.value && in.src[1].kind == OperandKind::Literal &&
                 in.literal == kGtavBufferDescriptorHighControlBits;
+            const bool relocation_low = state.index == relocation.low_index;
+            const bool relocation_high = state.index == relocation.high_index;
             const bool descriptor_patch = bitset_descriptor_patch || or_descriptor_patch ||
-                high_control_descriptor_patch;
+                high_control_descriptor_patch || relocation_low || relocation_high;
+
+            // A load overlapping physical VCC also creates a mask lifetime. Reject every implicit
+            // mask observation until a real VCC writer replaces the live half or pair; explicit
+            // scalar observations remain covered by the ordinary operand walk below.
+            const bool implicit_vcc_read =
+                overlap(live, 106, wave_size == 32 ? 1u : 2u) &&
+                ((in.fmt == Rdna2Format::SOPP &&
+                  (in.opcode == 0x06u || in.opcode == 0x07u)) ||
+                 (in.fmt == Rdna2Format::VOP2 &&
+                  (in.opcode == 0x01u ||
+                   (in.opcode >= 0x28u && in.opcode <= 0x2au))));
+            if (implicit_vcc_read) {
+                valid = false;
+                break;
+            }
 
             bool branch = false;
             bool fallthrough = true;
@@ -6158,10 +6288,22 @@ std::unordered_set<uint32_t> proven_smem_x2_descriptor_fragment_loads(
                 if (!valid) break;
             }
 
-            if (!descriptor_patch) {
+            if (relocation_low || relocation_high) {
+                const uint8_t destination_bit = relocation_low ? 0x4u : 0x8u;
+                const bool source_live = relocation_low
+                    ? (live & 0x1u) != 0
+                    : (live & (0x2u | 0x4u)) != 0;
+                clear_written(live,
+                              relocation.destination_base + (relocation_high ? 1 : 0), 1);
+                if (source_live) live |= destination_bit;
+            } else if (!descriptor_patch) {
                 for_each_scalar_write(in, [&](int first, uint32_t words) {
                     clear_written(live, first, words);
-                });
+                }, wave_size == 32);
+                if (in.fmt == Rdna2Format::VOPC && !vopc_is_cmpx(in.opcode) &&
+                    (in.dst.kind == OperandKind::SGPR ||
+                     in.dst.kind == OperandKind::Special) && in.dst.value == 106)
+                    clear_written(live, 106, wave_size == 32 ? 1u : 2u);
             }
             if (!live) continue;
 
@@ -12014,12 +12156,12 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             }
-            // GTA V assembles a four-dword V# from a register-offset or exact immediate +0x58
-            // S_LOAD_DWORDX2 fragment plus later scalar writes. The whole-CFG proof established that
-            // the loaded words are never scalar/address data and that every descriptor observation
-            // resolves through an exact-PC resource, so no runtime load belongs in the emitted
-            // module. Keep this before generic SOFFSET handling: the offset selects front-half
-            // provenance, not emitted scalar data.
+            // The whole-CFG proof established that this register-offset or aligned-immediate
+            // S_LOAD_DWORDX2 feeds only a complete V# (possibly after an exact scalar carry-pair
+            // relocation), never ordinary scalar/address or mask state. Every descriptor observation
+            // resolves through an exact-PC resource, so no runtime load belongs in the emitted module.
+            // Keep this before generic SOFFSET handling: the offset selects front-half provenance,
+            // not emitted scalar data.
             if (rt && in.opcode == kSmemOpcodeLoadDwordX2 &&
                 rs.smem_x2_descriptor_fragment_loads.contains(in.pc)) {
                 for (uint32_t k = 0; k < n; ++k) {
@@ -20521,7 +20663,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
     }
     if (!rs.smem_x2_descriptor_fragment_analysis_done) {
         rs.smem_x2_descriptor_fragment_loads =
-            proven_smem_x2_descriptor_fragment_loads(ins, rt);
+            proven_smem_x2_descriptor_fragment_loads(ins, rt, b.wave_size);
         rs.smem_x2_descriptor_fragment_analysis_done = true;
     }
     // Fold PC-relative embedded-table loads (s_getpc_b64-built V#s) before the walk — emit_alu's

--- a/prosper/src/gpu/shader_resources.hpp
+++ b/prosper/src/gpu/shader_resources.hpp
@@ -575,9 +575,6 @@ inline bool is_zero_record_raw_buffer(const ShaderResource& resource) {
 // sampler_sgpr_base because that field is serialized for every resource but is otherwise inert for
 // a ConstantBuffer; 0xFFFFFFFE is not a valid scalar-register base.
 inline constexpr uint32_t kGtaOptionalBufferTableBytes = 272u;
-// GTA V's adjacent +0x50 pair is loaded as the low descriptor fragment for exact-PC raw buffers;
-// the whole-CFG proof in the recompiler verifies every surviving use before eliding that SMEM load.
-inline constexpr uint32_t kGtaBufferDescriptorFragmentOffset = 0x50u;
 inline constexpr uint32_t kGtaOptionalBufferPointerOffset = 0x58u;
 inline constexpr uint32_t kGtaOptionalBufferStride = 4u;
 inline constexpr uint32_t kGtaOptionalBufferStrideWord = kGtaOptionalBufferStride << 16u;

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -3284,34 +3284,34 @@ int main() {
               gta_zero_record_pc27_binding->dynamic_access,
           "GTA pc47 descriptor fragment elides without enlarging pc27's exact 32-byte output");
 
-    std::array<uint32_t, 319> gta_zero_record_pc47_wrong_offset =
+    std::array<uint32_t, 319> gta_zero_record_pc47_wrong_dst =
         prosper::test::kGta5ZeroRecordExeczProgram;
-    gta_zero_record_pc47_wrong_offset[48] = 0xfa00004cu; // pc47 immediate +0x50 -> +0x4c
-    ShaderResourceTable gta_zero_record_pc47_wrong_offset_table =
+    gta_zero_record_pc47_wrong_dst[47] = 0xf4040200u; // pc47 SDATA s[4:5] -> s[8:9]
+    ShaderResourceTable gta_zero_record_pc47_wrong_dst_table =
         gta_zero_record_compile_resources();
-    const std::vector<uint32_t> gta_zero_record_pc47_wrong_offset_spirv =
-        recompile_compute(gta_zero_record_pc47_wrong_offset.data(),
-                          gta_zero_record_pc47_wrong_offset.size(),
-                          &gta_zero_record_pc47_wrong_offset_table,
+    const std::vector<uint32_t> gta_zero_record_pc47_wrong_dst_spirv =
+        recompile_compute(gta_zero_record_pc47_wrong_dst.data(),
+                          gta_zero_record_pc47_wrong_dst.size(),
+                          &gta_zero_record_pc47_wrong_dst_table,
                           gta_zero_record_compile_config);
-    const DescriptorValidationReport gta_zero_record_pc47_wrong_offset_report =
+    const DescriptorValidationReport gta_zero_record_pc47_wrong_dst_report =
         validate_spirv_descriptor_interface(
-            gta_zero_record_pc47_wrong_offset_spirv,
-            &gta_zero_record_pc47_wrong_offset_table, 0,
+            gta_zero_record_pc47_wrong_dst_spirv,
+            &gta_zero_record_pc47_wrong_dst_table, 0,
             SpirvShaderStage::Compute, false);
-    const size_t gta_zero_record_pc47_wrong_offset_issues = std::count_if(
-        gta_zero_record_pc47_wrong_offset_report.issues.begin(),
-        gta_zero_record_pc47_wrong_offset_report.issues.end(),
+    const size_t gta_zero_record_pc47_wrong_dst_issues = std::count_if(
+        gta_zero_record_pc47_wrong_dst_report.issues.begin(),
+        gta_zero_record_pc47_wrong_dst_report.issues.end(),
         [](const DescriptorValidationIssue& issue) {
             return issue.code == DescriptorIssueCode::UndersizedBuffer &&
-                issue.binding == 2u && issue.required_bytes == 84u &&
+                issue.binding == 2u && issue.required_bytes == 88u &&
                 issue.available_bytes == 32u;
         });
-    CHECK(!gta_zero_record_pc47_wrong_offset_spirv.empty() &&
-              !gta_zero_record_pc47_wrong_offset_report.ok() &&
-              gta_zero_record_pc47_wrong_offset_report.issues.size() == 1u &&
-              gta_zero_record_pc47_wrong_offset_issues == 1u,
-          "same-site pc47 immediate mutation restores the exact accidental binding-2 read");
+    CHECK(!gta_zero_record_pc47_wrong_dst_spirv.empty() &&
+              !gta_zero_record_pc47_wrong_dst_report.ok() &&
+              gta_zero_record_pc47_wrong_dst_report.issues.size() == 1u &&
+              gta_zero_record_pc47_wrong_dst_issues == 1u,
+          "same-site pc47 SDATA mutation restores the exact accidental binding-2 read");
 
     ShaderResourceTable gta_zero_record_compile_ne_table =
         gta_zero_record_compile_resources();

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -134,6 +134,22 @@ int main() {
           gta_vmac.src[2].kind == OperandKind::None && gta_vmac.src_neg[0] &&
           !gta_vmac.src_neg[1],
           "GTA V v_mac_f32 decodes two sources and no phantom s0");
+    // GTA V exec_cs_205b67ce00 pc576: `v_mul_lo_u32 v1, v2, v1`. The encoded SRC2 field is
+    // reserved. Mutating only this packet's opcode to v_mad_u32_u24 makes the exact same field a
+    // real third source, pinning the arity decision to the production site.
+    const uint32_t gta_mul_lo_words[] = {0xd5690001u, 0x00020302u};
+    const Rdna2Inst gta_mul_lo = rdna2_decode_one(gta_mul_lo_words, 2);
+    CHECK(gta_mul_lo.fmt == Rdna2Format::VOP3 &&
+          gta_mul_lo.opcode == kVop3OpcodeMulLoU32 && gta_mul_lo.n_src == 2 &&
+          isV(gta_mul_lo.dst, 1) && isV(gta_mul_lo.src[0], 2) &&
+          isV(gta_mul_lo.src[1], 1) && gta_mul_lo.src[2].kind == OperandKind::None,
+          "GTA V v_mul_lo_u32 decodes two sources and no phantom s0");
+    const uint32_t gta_mul_lo_mutation_words[] = {0xd5430001u, 0x00020302u};
+    const Rdna2Inst gta_mul_lo_mutation =
+        rdna2_decode_one(gta_mul_lo_mutation_words, 2);
+    CHECK(gta_mul_lo_mutation.opcode == kVop3OpcodeMadU32U24 &&
+          gta_mul_lo_mutation.n_src == 3 && isS(gta_mul_lo_mutation.src[2], 0),
+          "same-site three-source multiply mutation retains its real s0 dependency");
     // GTA V exec_cs_205b658800 pc61: `v_lshlrev_b64 v[24:25], v4, 1`. The reserved SRC2 field
     // must not surface as s0, and the shared writer inventory must retain both result halves.
     const uint32_t gta_lshlrev_b64_words[] = {0xd6ff0018u, 0x00010304u};

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -150,6 +150,18 @@ int main() {
     CHECK(gta_mul_lo_mutation.opcode == kVop3OpcodeMadU32U24 &&
           gta_mul_lo_mutation.n_src == 3 && isS(gta_mul_lo_mutation.src[2], 0),
           "same-site three-source multiply mutation retains its real s0 dependency");
+    const uint32_t emitted_vop3_float_words[] = {0xd5030001u, 0x00020300u};
+    const Rdna2Inst emitted_vop3_float = rdna2_decode_one(emitted_vop3_float_words, 2);
+    CHECK(emitted_vop3_float.opcode == 0x103u && emitted_vop3_float.n_src == 2 &&
+          isV(emitted_vop3_float.src[0], 0) && isV(emitted_vop3_float.src[1], 1) &&
+          emitted_vop3_float.src[2].kind == OperandKind::None,
+          "shared emitted VOP3 arity inventory covers ordinary two-source float ALU");
+    const uint32_t emitted_vop3_bcnt_words[] = {0xd7640002u, 0x00020903u};
+    const Rdna2Inst emitted_vop3_bcnt = rdna2_decode_one(emitted_vop3_bcnt_words, 2);
+    CHECK(emitted_vop3_bcnt.opcode == 0x364u && emitted_vop3_bcnt.n_src == 2 &&
+          isV(emitted_vop3_bcnt.src[0], 3) && isV(emitted_vop3_bcnt.src[1], 4) &&
+          emitted_vop3_bcnt.src[2].kind == OperandKind::None,
+          "shared emitted VOP3 arity inventory covers late two-source integer ALU");
     // GTA V exec_cs_205b658800 pc61: `v_lshlrev_b64 v[24:25], v4, 1`. The reserved SRC2 field
     // must not surface as s0, and the shared writer inventory must retain both result halves.
     const uint32_t gta_lshlrev_b64_words[] = {0xd6ff0018u, 0x00010304u};

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -2132,6 +2132,47 @@ int main() {
     }
     printf("  [ok]   Wave32 CFG admits exact two-source VOP3B carry packet at an s0 join\n");
 
+    // The exact GTA V pc576 VOP3 packet is v_mul_lo_u32, whose encoded SRC2 field is reserved.
+    // Join a scalar and mask lifetime in s0 before it, then force the portable dispatcher with the
+    // same irreducible tail used above. The two-source opcode must ignore SRC2; mutating only that
+    // opcode to a genuine three-source v_mad_u32_u24 must restore the ambiguous s0 rejection.
+    uint32_t wave32_compute_vop3_mul_two_source_join[] = {
+        0x7d8a06f9u, 0x06868080u,            // pc0: exact VOPC SDWA packet -> s0 mask
+        0xbf068008u,                         // pc2: independent scalar branch condition
+        0xbf840001u,                         // pc3: one edge retains the s0 mask
+        0xbe800380u,                         // pc4: other edge replaces s0 with scalar data
+        0xd5690001u, 0x00020302u,            // pc5: exact v_mul_lo_u32 v1,v2,v1
+        0x7e040280u,                         // pc7: irreducible crossing-CFG tail
+        0x7c020300u,                         // pc8: v_cmp_lt_u32_e32 vcc, v0, v1
+        0xbf860001u,                         // pc9: s_cbranch_vccz -> pc11
+        0x7e040281u,                         // pc10: v_mov_b32_e32 v2, 1
+        0x7d840100u,                         // pc11: v_cmp_eq_u32_e32 vcc, v0, v0
+        0xbf870001u,                         // pc12: s_cbranch_vccnz -> pc14
+        0xbf82fffdu,                         // pc13: s_branch -> pc11
+        0x7e040d02u,                         // pc14: v_mov_b32_e32 v2, v2
+        0xbf810000u,
+    };
+    const auto vop3_mul_two_source_join_spv = recompile_compute(
+        wave32_compute_vop3_mul_two_source_join,
+        std::size(wave32_compute_vop3_mul_two_source_join), nullptr,
+        wave32_vop3b_two_source_config);
+    if (vop3_mul_two_source_join_spv.empty() ||
+        !has_opcode(vop3_mul_two_source_join_spv, 251) ||
+        !type_result_ids_are_nonzero(vop3_mul_two_source_join_spv, nullptr) ||
+        !phi_ids_are_nonzero(vop3_mul_two_source_join_spv)) {
+        printf("  [FAIL] Wave32 CFG treated two-source VOP3 multiply as reading SRC2\n");
+        return 1;
+    }
+    wave32_compute_vop3_mul_two_source_join[5] = 0xd5430001u;
+    if (!recompile_compute(
+             wave32_compute_vop3_mul_two_source_join,
+             std::size(wave32_compute_vop3_mul_two_source_join), nullptr,
+             wave32_vop3b_two_source_config).empty()) {
+        printf("  [FAIL] genuine three-source mutation lost its ambiguous s0 dependency\n");
+        return 1;
+    }
+    printf("  [ok]   Wave32 VOP3 multiply arity survives exact-site three-source mutation\n");
+
     // GTA V's rejected Wave32 compute siblings produce a fresh VCC_LO carry at PC79 with the
     // no-carry-in VOP3B family, then consume it at PC83 through implicit VCC. A later crossing CFG
     // forces the portable arbitrary-CFG dispatcher, which must carry that one-word mask lifetime

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -395,6 +395,137 @@ int main() {
                             smem_x2_descriptor_fragment_config).empty(),
           "x2 fragment rejects a consumer lacking key-less exact-PC provenance");
 
+    // Program 0x413cf9a00 uses ordinary aligned descriptor-table offsets outside the two offsets
+    // that originally motivated this proof. Keep its exact pc3 load and pc11 consumer: the whole-CFG
+    // use proof, rather than an immediate-value allowlist, must establish that the pair is descriptor
+    // provenance and omit the fallback constant-buffer range.
+    const uint32_t smem_x2_aligned_immediate_fragment[] = {
+        0xbfa00003u,
+        0xd7460000u, 0x04010c07u,
+        0xf4040500u, 0xfa000090u,   // pc3: s_load_dwordx2 s[20:21], s[0:1], 0x90
+        0xbe960304u,
+        0xbe9703ffu, 0x00016204u,
+        0xbf8cc07fu,
+        0xbe951d92u,
+        0x816ac104u,
+        0xe0302000u, 0x80050100u,   // pc11: buffer_load_dword v1, v0, s[20:23], 0
+        0xbf810000u,
+    };
+    ShaderResourceTable smem_x2_aligned_immediate_rt;
+    { ShaderResource buffer{}; buffer.cls = ResourceClass::ConstantBuffer;
+      buffer.format = DataFormat::Uint32; buffer.num_components = 1; buffer.binding = 4;
+      buffer.gpu_addr = 0x240000u; buffer.size = 120; buffer.fetch_pc = 11;
+      smem_x2_aligned_immediate_rt.resources.push_back(buffer); }
+    ComputeShaderConfig smem_x2_aligned_immediate_config =
+        smem_x2_descriptor_fragment_config;
+    smem_x2_aligned_immediate_config.user_sgprs.resize(24);
+    const std::vector<uint32_t> smem_x2_aligned_immediate_spv = recompile_compute(
+        smem_x2_aligned_immediate_fragment,
+        std::size(smem_x2_aligned_immediate_fragment),
+        &smem_x2_aligned_immediate_rt, smem_x2_aligned_immediate_config);
+    const DescriptorValidationReport smem_x2_aligned_immediate_report =
+        validate_spirv_descriptor_interface(smem_x2_aligned_immediate_spv,
+                                            &smem_x2_aligned_immediate_rt, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(!smem_x2_aligned_immediate_spv.empty() &&
+              smem_x2_aligned_immediate_report.ok() &&
+              find_spirv_descriptor_binding(smem_x2_aligned_immediate_report, 0, 4) &&
+              !find_spirv_descriptor_binding(smem_x2_aligned_immediate_report, 0, 2),
+          "aligned immediate x2 fragment routes pc11 without an inflated fallback cbuf");
+    uint32_t smem_x2_aligned_immediate_wrong_dst[
+        std::size(smem_x2_aligned_immediate_fragment)];
+    std::copy(std::begin(smem_x2_aligned_immediate_fragment),
+              std::end(smem_x2_aligned_immediate_fragment),
+              std::begin(smem_x2_aligned_immediate_wrong_dst));
+    smem_x2_aligned_immediate_wrong_dst[3] = 0xf4040480u; // pc3: load s[18:19]
+    CHECK(recompile_compute(smem_x2_aligned_immediate_wrong_dst,
+                            std::size(smem_x2_aligned_immediate_wrong_dst),
+                            &smem_x2_aligned_immediate_rt,
+                            smem_x2_aligned_immediate_config).empty(),
+          "aligned immediate x2 same-site SDATA mutation remains fail-visible");
+
+    // Program 0x413dd6e00 loads its address fragment into physical VCC, then relocates it into the
+    // final V# with one carry pair. Keep the production pc23/26/29/34 packets and their exact PCs.
+    // The loaded VCC mask cannot be observed, the final carry is dead, and only the exact pc34
+    // resource consumes the derived words.
+    std::vector<uint32_t> smem_x2_relocated_fragment(23, 0xbf800000u);
+    const uint32_t smem_x2_relocated_tail[] = {
+        0xf4041a80u, 0xfa000050u,   // pc23: s_load_dwordx2 vcc, s[0:1], 0x50
+        0xbf8cc07fu,
+        0x8014006au,               // pc26: s_add_u32 s20, vcc_lo, s0
+        0xbe9703ffu, 0x00016204u,
+        0x8215016bu,               // pc29: s_addc_u32 s21, vcc_hi, s1
+        0xbe960380u,
+        0xbf800000u,
+        0xbe951d92u,
+        0xbf8cc07fu,
+        0xe0302000u, 0x80050201u,   // pc34: buffer_load_dword v2, v1, s[20:23], 0
+        0xbf810000u,
+    };
+    smem_x2_relocated_fragment.insert(smem_x2_relocated_fragment.end(),
+                                       std::begin(smem_x2_relocated_tail),
+                                       std::end(smem_x2_relocated_tail));
+    ShaderResourceTable smem_x2_relocated_rt;
+    { ShaderResource buffer{}; buffer.cls = ResourceClass::ConstantBuffer;
+      buffer.format = DataFormat::Uint32; buffer.num_components = 1; buffer.binding = 4;
+      buffer.gpu_addr = 0x280000u; buffer.size = 120; buffer.fetch_pc = 34;
+      smem_x2_relocated_rt.resources.push_back(buffer); }
+    ComputeShaderConfig smem_x2_relocated_config = smem_x2_descriptor_fragment_config;
+    smem_x2_relocated_config.user_sgprs.resize(24);
+    const std::vector<uint32_t> smem_x2_relocated_spv = recompile_compute(
+        smem_x2_relocated_fragment.data(), smem_x2_relocated_fragment.size(),
+        &smem_x2_relocated_rt, smem_x2_relocated_config);
+    const DescriptorValidationReport smem_x2_relocated_report =
+        validate_spirv_descriptor_interface(smem_x2_relocated_spv,
+                                            &smem_x2_relocated_rt, 0,
+                                            SpirvShaderStage::Compute, false);
+    CHECK(!smem_x2_relocated_spv.empty() && smem_x2_relocated_report.ok() &&
+              find_spirv_descriptor_binding(smem_x2_relocated_report, 0, 4) &&
+              !find_spirv_descriptor_binding(smem_x2_relocated_report, 0, 2),
+          "VCC x2 fragment relocates through its carry pair without a fallback cbuf");
+    std::vector<uint32_t> smem_x2_relocated_wrong_high = smem_x2_relocated_fragment;
+    smem_x2_relocated_wrong_high[29] = 0x82150169u; // pc29: high source s105, not vcc_hi
+    CHECK(recompile_compute(smem_x2_relocated_wrong_high.data(),
+                            smem_x2_relocated_wrong_high.size(),
+                            &smem_x2_relocated_rt,
+                            smem_x2_relocated_config).empty(),
+          "relocated x2 same-site high-source mutation remains fail-visible");
+    std::vector<uint32_t> smem_x2_relocated_reads_vcc = smem_x2_relocated_fragment;
+    smem_x2_relocated_reads_vcc[25] = 0x02020100u; // pc25: implicit VCC predicate
+    CHECK(recompile_compute(smem_x2_relocated_reads_vcc.data(),
+                            smem_x2_relocated_reads_vcc.size(),
+                            &smem_x2_relocated_rt,
+                            smem_x2_relocated_config).empty(),
+          "relocated x2 rejects an implicit VCC observation of the loaded pair");
+    std::vector<uint32_t> smem_x2_relocated_gap_scc = smem_x2_relocated_fragment;
+    smem_x2_relocated_gap_scc[27] = 0xbe9703fdu; // pc27: s_mov_b32 s23,scc
+    smem_x2_relocated_gap_scc[28] = 0xbf800000u;
+    CHECK(recompile_compute(smem_x2_relocated_gap_scc.data(),
+                            smem_x2_relocated_gap_scc.size(),
+                            &smem_x2_relocated_rt,
+                            smem_x2_relocated_config).empty(),
+          "relocated x2 rejects an SCC observation between low and high address adds");
+    std::vector<uint32_t> smem_x2_relocated_later_scc = smem_x2_relocated_fragment;
+    smem_x2_relocated_later_scc[30] = 0xbe960580u; // pc30: s_cmov_b32 s22,0
+    CHECK(recompile_compute(smem_x2_relocated_later_scc.data(),
+                            smem_x2_relocated_later_scc.size(),
+                            &smem_x2_relocated_rt,
+                            smem_x2_relocated_config).empty(),
+          "relocated x2 rejects a later observer of the final descriptor-add carry");
+    std::vector<uint32_t> smem_x2_relocated_wave32_high_read =
+        smem_x2_relocated_fragment;
+    smem_x2_relocated_wave32_high_read.back() = 0x7d840000u; // pc36: VOPC replaces VCC_LO only
+    smem_x2_relocated_wave32_high_read.push_back(0x7e02026bu); // pc37: read loaded VCC_HI
+    smem_x2_relocated_wave32_high_read.push_back(0xbf810000u);
+    ComputeShaderConfig smem_x2_relocated_wave32_config = smem_x2_relocated_config;
+    smem_x2_relocated_wave32_config.wave_size = 32;
+    smem_x2_relocated_wave32_config.native_subgroup_size = 32;
+    CHECK(recompile_compute(smem_x2_relocated_wave32_high_read.data(),
+                            smem_x2_relocated_wave32_high_read.size(),
+                            &smem_x2_relocated_rt,
+                            smem_x2_relocated_wave32_config).empty(),
+          "Wave32 VOPC does not hide a later read of loaded VCC_HI");
+
     // Program 0x413dc6700 has the same family at exact pc10, this time feeding the V# consumed by
     // S_BUFFER_LOAD at pc67. Keep both production packets at their original PCs; transparent NOPs
     // stand in for the unrelated body between descriptor construction and consumption.


### PR DESCRIPTION
Part of #2481.

## What changed

- Correct the RDNA2 decoder's VOP3 source arity for all emitted two-input operations, so reserved `SRC2` bits are no longer decoded as a phantom operand.
- Generalize whole-CFG descriptor-fragment provenance to prove aligned x2 scalar-memory loads at arbitrary immediate offsets.
- Carry that provenance through the exact low/high `S_ADD_U32` / `S_ADDC_U32` relocation sequence before the descriptor is consumed.
- Keep the proof conservative around pair overlap, carry lifetime, SCC observations, VCC observations, branch targets, and Wave32 versus Wave64 mask widths.
- Replace the obsolete GTA-specific descriptor-fragment offset constant with the generic proof.
- Add exact production-shape regression tests and same-site mutation arms for both fixes and their safety boundaries.

## Root cause

Two independent false negatives were rejecting valid guest compute kernels:

1. The decoder treated some two-input VOP3 operations as though they consumed three inputs. Garbage in the reserved source field therefore entered later analyses as a real dependency.
2. Descriptor reconstruction only recognized a title-specific pair of load offsets and lost the relationship when the loaded address was relocated through a scalar add-with-carry pair. The information needed for a generic proof was present; the proof and conservative lifetime checks were missing.

## Current compute frontier

These counts combine the last fresh routed capture at the merged #2519 tip with exact retained-kernel replay on this branch. They are the expected frontier for the next routed run, not a claim that GTA V has already been rerun at this exact commit.

| Category | Launches |
|---|---:|
| Raw compute packets observed | 190 |
| Hardware no-op dispatches, intentionally culled | 134 |
| Actual-work launches | 56 |
| Actual-work launches compiling with an accepted interface contract | 45 |
| Actual-work launches still rejected | 11 |

Compared with the previous checkpoint, compiling actual-work launches move from **35 to 45**, while rejected actual-work launches fall from **21 to 11**. All ten retained descriptor-contract failures targeted here now compile and pass contract validation.

The remaining 11 launches collapse to only **three unique kernels**:

- one Wave32 kernel represented once;
- one Wave32 kernel represented seven times;
- one Wave64 kernel represented three times.

All three now converge on the same generic frontier: a bounded per-record pointer loaded into a VGPR pair and subsequently consumed by global-memory operations. There is no remaining independent descriptor-contract family in the retained actual-work set.

The last live screenshot still showed a black world, and the known device-lossing kernel remains outside this PR's scope. A fresh routed boot is the next live confirmation after this checkpoint.

## Validation

- `ctest --no-tests=error -j4 --output-on-failure`: **240/240 passed**
- Exact retained retries for the ten affected actual-work launches: **10/10 accepted**
- Independent code-review subagent verdict: **GO**, with all findings resolved before publication

## Next step

Implement a generic, bounded indirect-pointer proof for the three remaining unique kernels, preserving the same mutation-backed safety standard, then run a fresh routed GTA V gameplay capture to measure the live frontier and rendering result.
