### PR TITLE
ci: gate the two contribution shapes that waste review time, and document the rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,10 @@ jobs:
       - name: Check the contribution shape of this PR
         if: github.event_name == 'pull_request'
         run: |
-          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+          # No --depth here: `fetch-depth: 0` above already fetched full history, and
+          # `--depth=0` is rejected outright (`fatal: depth 0 is not a positive number`) --
+          # which is how this job failed on its own first run.
+          git fetch --no-tags origin "${{ github.base_ref }}"
           python3 prosper/tools/ci/check_contribution_shape.py --github \
             --base "origin/${{ github.base_ref }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,48 @@ jobs:
         run: |
           python3 prosper/tools/vkval/vk_validation_scan.py --build-dir prosper/build-ci
 
+  contribution-shape:
+    name: Contribution shape
+    runs-on: ubuntu-latest
+    steps:
+      # Its own job, like Docs and for the same reason: it needs nothing built, finishes in seconds,
+      # and a false positive here must not cost the build-and-test signal from an unrelated job.
+      #
+      # It answers two questions no other job in this pipeline can, because both are about what a
+      # PR ADDS rather than about what the build produces:
+      #
+      #   1. Did this PR add a file OUTSIDE the build tree? Every job here builds prosper, and
+      #      prosper globs `prosper/src/*.cpp`. A file added at the repository root is compiled by
+      #      nothing -- so every job goes green while certifying the absence of the code rather than
+      #      its correctness. Measured on #2507-#2510 (2026-08-12): 4,541 added lines in six headers
+      #      at the repository root, three PRs reporting 8 SUCCESS, and not one line compiled by any
+      #      job. Instrument-trap 151's family, one level further out.
+      #
+      #   2. Did this PR add a new source file and touch no test at all? A new .cpp is picked up
+      #      automatically by the CONFIGURE_DEPENDS glob, so it can arrive fully built and entirely
+      #      unexercised -- the #2492 shape, where "it compiles" was the only checkable claim.
+      #
+      # fetch-depth: 0 because the check is a diff against the base branch, and a shallow clone has
+      # no merge base to diff against.
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Runs before the check itself: the selftest holds hand-written violating AND compliant inputs,
+      # so a gate that has silently stopped discriminating fails here rather than passing everything
+      # downstream. A checker that cannot show it still fires is indistinguishable from one that was
+      # disabled.
+      - name: Verify the checker still discriminates
+        run: python3 prosper/tools/ci/check_contribution_shape.py --selftest
+
+      - name: Check the contribution shape of this PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags --depth=0 origin "${{ github.base_ref }}"
+          python3 prosper/tools/ci/check_contribution_shape.py --github \
+            --base "origin/${{ github.base_ref }}"
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to prosper
+
+prosper is a PS5→PC compatibility layer — the same class of project as Wine, Proton, RPCS3 or DXVK.
+External contributions are welcome. This page exists so a good one is not rejected for a mechanical
+reason, and so you do not spend hours on something that cannot be reviewed.
+
+Read `CLAUDE.md` first if you plan to touch anything beyond a small fix. It is the project charter
+and it is binding.
+
+## The one idea behind all of the rules
+
+**A contribution is worth what a reviewer can check.** Not what it claims, not how much of it there
+is — what can be independently confirmed. Everything below follows from that, and it is why a
+200-line change with a failing-without-the-fix test lands easily while a 4,000-line one that compiles
+in isolation does not land at all.
+
+This cuts both ways, and the good direction is the important one: a small change carrying its own
+evidence needs very little from us, and usually merges quickly.
+
+## Enforced by CI
+
+The `Contribution shape` job fails on two things. Both are mechanical, both are fast, and both exist
+because they cost real review time before they were automated.
+
+**1. Every new file lives under `prosper/`.**
+
+The build collects exactly one set of sources:
+
+```cmake
+file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)   # relative to prosper/
+target_include_directories(prosper_core PUBLIC src)          # include root is prosper/src
+```
+
+A file added at the repository root — `core/thing.hpp`, `plugins/thing.hpp` — is globbed by nothing,
+on no include path, and referenced by nothing. It compiles nowhere. **Every CI job then reports
+success, because each one built prosper and prosper does not contain your file.** Green means the
+code was absent, not that it was correct.
+
+Diagnostics belong in `prosper/src/diagnostics/`. Tests belong in `prosper/tests/`.
+
+**2. A new `.cpp` under `prosper/src/` requires touching something under `prosper/tests/`.**
+
+Because of the glob, a new source file needs no build-system change — so it can arrive fully compiled
+and completely unexercised, where "it compiles" is the only claim anyone can check. Modifying an
+existing file does not trip this; only adding a new one does.
+
+## Judged by review
+
+**One change per pull request, and prefer the smallest version that works.** A 1,200-line header
+cannot be usefully reviewed: the reader cannot hold it, so the findings you get back will be shallow
+exactly when the change most needs deep ones. If you have a subsystem in mind, land its core first
+and build on it.
+
+**Wire it to something.** An observer that nothing calls cannot be shown to observe anything, and a
+facility with no caller hides its own defects — an incompatible signature, a broken disabled-path
+stub, a state that can never be reached. One real call site surfaces more than any amount of
+self-contained code.
+
+**Rebase before you submit.** This repository moves fast, with several agents and a maintainer landing
+work daily. Check that what you are adding does not already exist: a class re-declared in a namespace
+that already has one is a redefinition, not an addition.
+
+**A test should fail without your change.** If it passes either way, it documents the code rather than
+constraining it. Say in the PR body what you did to confirm this — reverting the fix and watching the
+test go red is the whole check.
+
+**Claims need the command that reproduces them.** Numbers are welcome and useful; unverifiable numbers
+are worse than none, because they cost a reviewer the time to discover they cannot be checked. If you
+report a measurement, give the exact invocation and attach the artefact. `-fsyntax-only` proves a
+header parses; it is not a build, and should not be described as one.
+
+Be careful with clean zeros in particular — "0 failures", "0 divergences", "100% match". Before
+reporting one, construct a failing case by hand and confirm your harness reports it. Until that arm
+exists, *zero* and *cannot detect* are the same number.
+
+## What you cannot verify, and that is fine
+
+You will not have a PS5 game dump, so you cannot run the boot tests or the snapshot guards. That is
+expected and it is not a barrier — say what you could not check rather than implying you did. Plenty
+of valuable work needs no dump at all: host-side tooling, the loader and SELF/ELF paths, tests,
+diagnostics, build and packaging, documentation.
+
+## What will be rejected
+
+- Entitlement or add-content APIs made to return "owned" unconditionally. prosper answers those from
+  local inventory. See `CLAUDE.md` — this one is not negotiable and is not a style preference.
+- Code copied from other emulators. Behaviour must be re-derived in prosper's own architecture.
+- Shims that fake output to make something appear to work.
+- Anything containing Sony code, firmware or keys.
+
+## A worked example
+
+PR #2495 is the template, and it is worth reading before you open anything substantial. It arrived as
+6,428 lines compiled by a glob with no call sites and no tests, and was rejected. It came back as 821
+lines: opt-in behind a CMake option, zero-cost stubs when disabled, seven real call sites in
+`boot_program.cpp`, three tests. It merged.
+
+The subject did not change. The evidence did.
+
+## Practical notes
+
+- Build: `cmake -S prosper -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug && cmake --build build`
+- Test: `ctest --test-dir build --no-tests=error` — quote the **count** alongside the exit code.
+  Plain `ctest` exits 0 when it finds no tests at all, so "nothing ran" and "everything passed" look
+  identical without that flag.
+- Do not put absolute paths from your machine in commits, PR text or committed files. Use
+  `<REPO_ROOT>`, `<DUMP_ROOT>`, `<WORKTREE>`.
+- Open an issue first for anything large. It is much cheaper to hear "that subsystem already exists"
+  before you write it than after.

--- a/prosper/tools/ci/check_contribution_shape.py
+++ b/prosper/tools/ci/check_contribution_shape.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Reject the two contribution shapes that cost review time without needing a reviewer.
+
+Both rules here exist because a human (or an agent) spent an afternoon discovering something a
+command could have reported in a second. Neither is a style preference; each encodes a defect that
+CI could not otherwise see, and each fires on real merged history rather than on a hypothetical.
+
+RULE 1 -- a new file outside the build tree.
+
+  prosper's sources live under `prosper/`. The build collects exactly one thing:
+
+      file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)   # relative to prosper/
+      target_include_directories(prosper_core PUBLIC src)          # include root is prosper/src
+
+  So a file added at the repository root -- `core/event_bus.hpp`, `plugins/foo_plugin.hpp` -- is not
+  globbed, not on any include path, and not referenced by anything. It compiles nowhere. CI then goes
+  green, because every job built prosper and prosper does not contain the file.
+
+  Measured instance (#2507-#2510, 2026-08-12): four PRs, 4,541 added lines, six headers at the
+  repository root. Three reported 8 SUCCESS. Not one line was compiled by any job. Green certified
+  the absence of the code rather than its correctness -- the same family as instrument-trap 151, but
+  further out: there a configuration was missing, here no configuration can reach the file at all.
+
+  The allowlist is the set of top-level entries that actually exist, plus root-level Markdown and
+  the usual repository metadata. A NEW top-level directory is the thing being rejected, so adding one
+  deliberately means adding it here, in a commit that says why.
+
+RULE 2 -- a new source file with no test touched anywhere.
+
+  A new `prosper/src/**/*.cpp` is compiled automatically by the glob above, so it needs no build-system
+  change and can arrive fully wired and completely unexercised. That is the #2492 shape: a subsystem
+  with no call site and no test, where "it compiles" is the only claim anyone can check.
+
+  Deliberately narrow, so the gate stays trusted:
+    * ADDED .cpp only. Modifying an existing source file does not trip it -- a comment fix, a
+      diagnostic, a one-line correction must not demand a test it cannot meaningfully have.
+    * ANY file under prosper/tests/ satisfies it, added or modified. The rule asks whether the author
+      considered the question, not whether a particular test exists; a reviewer judges the rest.
+
+  A refactor that genuinely splits a file without touching tests will trip this. That is the intended
+  cost: it is rare, and the fix is one line in the PR body explaining it, which is cheaper than the
+  case the rule catches.
+
+EXIT STATUS IS THE VERDICT. This exits non-zero on any violation, with or without --github.
+Recorded explicitly because the author of this file publicly claimed, three times, that a sibling
+gate reported problems and still exited 0 -- and then measured it and found it exits 1. The real
+failure there was `> /dev/null` plus an unchecked `$?` (trap 40). A checker whose status can be
+ignored is a checker that will be.
+
+  --selftest runs both rules against hand-written violating AND compliant inputs. A gate that cannot
+  demonstrate it fires is void; a gate that cannot demonstrate it stays quiet on good input gets
+  disabled by the first person it annoys.
+"""
+
+import argparse
+import subprocess
+import sys
+
+# Top-level entries that exist on master, plus metadata a contributor may legitimately add.
+ALLOWED_TOP_LEVEL = {
+    ".github",
+    ".gitignore",
+    ".gitattributes",
+    "assets",
+    "docs",
+    "prosper",
+    "scripts",
+}
+
+# Root-level files that are fine regardless of the set above (documentation and licensing).
+ALLOWED_ROOT_SUFFIXES = (".md",)
+ALLOWED_ROOT_NAMES = {"LICENSE", "LICENSE.txt", "LICENSE.md", "NOTICE"}
+
+
+def top_level(path):
+    return path.split("/", 1)[0]
+
+
+def is_allowed_addition(path):
+    """Whether a newly ADDED file may live at `path`."""
+    head = top_level(path)
+    if head in ALLOWED_TOP_LEVEL:
+        return True
+    if "/" not in path:  # a root-level file
+        if path in ALLOWED_ROOT_NAMES:
+            return True
+        return path.endswith(ALLOWED_ROOT_SUFFIXES)
+    return False
+
+
+def check(changes):
+    """`changes` is a list of (status, path). Returns a list of problem strings."""
+    problems = []
+
+    added = [p for s, p in changes if s == "A"]
+    touched = [p for _, p in changes]
+
+    # Rule 1 -- outside the build tree.
+    for path in added:
+        if not is_allowed_addition(path):
+            problems.append(
+                "%s: new file outside the build tree. prosper's sources live under `prosper/`; "
+                "the build globs `prosper/src/*.cpp` and includes `prosper/src`, so nothing here "
+                "is compiled or included by any job -- CI would go green without building it. "
+                "Move it under `prosper/` (diagnostics belong in `prosper/src/diagnostics/`), or "
+                "add its top-level directory to ALLOWED_TOP_LEVEL in %s with a reason."
+                % (path, __file__.replace("\\", "/").split("/")[-1])
+            )
+
+    # Rule 2 -- a new source file with no test touched.
+    new_sources = [
+        p for p in added
+        if p.startswith("prosper/src/") and p.endswith(".cpp")
+    ]
+    tests_touched = any(p.startswith("prosper/tests/") for p in touched)
+    if new_sources and not tests_touched:
+        problems.append(
+            "adds %d new source file(s) under prosper/src/ but touches nothing under "
+            "prosper/tests/: %s. A new .cpp is compiled automatically by the CONFIGURE_DEPENDS "
+            "glob, so it can arrive fully built and completely unexercised -- 'it compiles' is "
+            "then the only claim a reviewer can check. Add a test that fails without the change. "
+            "If this is a pure refactor with no behaviour to assert, say so in the PR body."
+            % (len(new_sources), ", ".join(sorted(new_sources)[:5]))
+        )
+
+    return problems
+
+
+def parse_name_status(text):
+    """Parse `git diff --name-status` output into (status, path) pairs."""
+    changes = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        status = parts[0][:1]          # R100 -> R, etc.
+        path = parts[-1]               # for renames, the destination
+        changes.append((status, path))
+    return changes
+
+
+def selftest():
+    """Both rules, against inputs that must fail and inputs that must not."""
+    must_fail = [
+        ("rule 1: header at the repo root (#2507)", [("A", "core/event_bus.hpp")]),
+        ("rule 1: plugin dir at the repo root (#2508)", [("A", "plugins/boot_state_machine_plugin.hpp")]),
+        ("rule 1: a new top-level directory", [("A", "framework/thing.hpp")]),
+        ("rule 2: new source, no test touched", [("A", "prosper/src/diagnostics/foo.cpp")]),
+        ("both rules at once", [("A", "core/x.hpp"), ("A", "prosper/src/y.cpp")]),
+    ]
+    must_pass = [
+        ("source plus a test", [("A", "prosper/src/diagnostics/foo.cpp"),
+                                ("A", "prosper/tests/test_foo.cpp")]),
+        ("source plus a MODIFIED test", [("A", "prosper/src/foo.cpp"),
+                                         ("M", "prosper/tests/test_gpu_capture.cpp")]),
+        ("modifying an existing source, no test", [("M", "prosper/src/gpu/gpu_capture.cpp")]),
+        ("docs only", [("M", "prosper/docs/GAME_COMPAT_ORCHESTRATION.md")]),
+        ("root-level markdown", [("A", "CONTRIBUTING.md")]),
+        ("workflow change", [("M", ".github/workflows/ci.yml")]),
+        ("a new header under prosper/src (no .cpp)", [("A", "prosper/src/diagnostics/x.hpp")]),
+        ("scripts and assets", [("A", "scripts/x.sh"), ("A", "assets/x.png")]),
+        ("a deleted root file", [("D", "core/old.hpp")]),
+    ]
+
+    failures = 0
+    for label, changes in must_fail:
+        if not check(changes):
+            print("selftest: FAILED to reject -- %s" % label, file=sys.stderr)
+            failures += 1
+    for label, changes in must_pass:
+        problems = check(changes)
+        if problems:
+            print("selftest: wrongly rejected -- %s\n    %s" % (label, problems[0]), file=sys.stderr)
+            failures += 1
+
+    total = len(must_fail) + len(must_pass)
+    print("selftest: %d arms (%d must-fail, %d must-pass), %d failed"
+          % (total, len(must_fail), len(must_pass), failures))
+    return 1 if failures else 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--base", help="git ref to diff against (e.g. origin/master)")
+    ap.add_argument("--name-status-file", help="a file holding `git diff --name-status` output")
+    ap.add_argument("--github", action="store_true",
+                    help="emit ::error:: annotations so failures surface on the Actions summary")
+    ap.add_argument("--selftest", action="store_true",
+                    help="run both rules against hand-written violating and compliant inputs")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    if args.name_status_file:
+        with open(args.name_status_file, encoding="utf-8") as fh:
+            text = fh.read()
+    elif args.base:
+        text = subprocess.run(
+            ["git", "diff", "--name-status", "%s...HEAD" % args.base],
+            capture_output=True, text=True, check=True).stdout
+    else:
+        ap.error("one of --base, --name-status-file or --selftest is required")
+
+    changes = parse_name_status(text)
+    problems = check(changes)
+
+    if not problems:
+        print("contribution shape: %d changed path(s), both rules satisfied" % len(changes))
+        return 0
+
+    for p in problems:
+        if args.github:
+            print("::error::%s" % p.replace("\n", " "))
+        print("error: %s" % p, file=sys.stderr)
+    print("\n%d problem(s) found." % len(problems), file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Makes mechanical two things that have each cost a reviewer an afternoon, and writes down the rest as `CONTRIBUTING.md`.

The goal is not to keep external contributions out. It is to make a bad-shaped PR cost a bot comment in ten seconds instead of a careful review eight hours later — and to tell a good contributor what is expected *before* they write 4,000 lines.

## Rule 1 — a new file outside the build tree

```cmake
file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)   # relative to prosper/
target_include_directories(prosper_core PUBLIC src)          # include root is prosper/src
```

A file added at the repository root is globbed by nothing and included by nothing. **Every job then reports success, because each one built prosper and prosper does not contain the file.** Green certifies the *absence* of the code rather than its correctness.

Measured on **#2507–#2510** (2026-08-12): 4,541 added lines across six headers at the repository root; three of the four reported **8 SUCCESS**; not one line was compiled by any job.

This is instrument-trap 151's family one level further out. There a *configuration* was missing (#2495's option defaulted off, fixed in #2496). Here **no configuration can reach the file at all.**

## Rule 2 — a new source file with no test touched

The `CONFIGURE_DEPENDS` glob means a new `.cpp` needs no build-system change, so it can arrive fully compiled and entirely unexercised — the #2492 shape, where *"it compiles"* was the only claim a reviewer could check.

Deliberately narrow, so the gate stays trusted rather than resented:

- **Only ADDED sources trip it.** Modifying an existing file does not — a comment fix, a diagnostic, a one-line correction must not demand a test it cannot meaningfully have.
- **Any file under `prosper/tests/` satisfies it**, added or modified. The rule asks whether the author considered the question; a reviewer judges the rest.

## Validated against real history, not only the selftest

Hand-written arms prove the matcher works on cases I invented and say nothing about the domain — the trap-122 problem. So I ran it over the actual file lists of eleven real PRs:

| | PRs | result |
| --- | --- | --- |
| **fires** | #2507 #2508 #2509 #2510 | the four it exists for |
| quiet | #2513 #2495 #2496 #2497 #2500 | correctly-shaped external work, and both lanes |
| quiet | #2517 #2519 | large in-flight compute work |

**Four true positives, seven true negatives, no false positive on any merged work** — including Codex's large compute PRs and a capture change touching `gpu_capture.cpp`.

Note #2513 passing: that is the same contributor's next PR, submitted 38 minutes after review, in the correct shape. The gate would not have obstructed it.

## Exit status is the verdict

The checker exits **non-zero** on violation, with or without `--github`.

Worth stating because I claimed three times this week that the sibling docs gate reports problems and still exits 0 — then measured it and found it **exits 1**, `--github` included. The real failure behind trap 152 was `> /dev/null` plus an unchecked `$?`, which is trap 40, not a defect in the tool. I have corrected that on #2497. A checker whose status can be ignored is one that will be.

The CI job runs `--selftest` **before** the check, so a gate that has silently stopped discriminating fails loudly rather than passing everything downstream.

## CONTRIBUTING.md

States the two enforced rules with their reasons, and the expectations that cannot be mechanised: one change per PR, wire it to a call site, a test that fails without the change, and a reproduction command for any measurement. It is explicit that **an external contributor will not have a game dump** — that this is expected, not a barrier, and which work needs none.

It also asks for care with clean zeros specifically: *before reporting one, construct a failing case by hand and confirm the harness reports it — until that arm exists, zero and cannot-detect are the same number.*

The worked example is **#2495**, because it is this contributor's own: 6,428 lines rejected, back as 821 with call sites and tests, merged. The subject did not change; the evidence did.

## Verification

```
selftest                     14 arms (5 must-fail, 9 must-pass), 0 failed, exit 0
against 11 real PR file lists 4 fire / 7 quiet, as tabled above
self-check on this branch    3 changed paths, both rules satisfied, exit 0
docs gate on CONTRIBUTING.md clean, exit 0
YAML re-parsed               10 jobs, new job's 3 steps as intended
diff --check                 clean
```

## Risk

Low and it fails loudly in the safe direction. A false positive blocks a PR with a message naming the file and the fix, and the allowlist is one edit away. The job builds nothing and finishes in seconds.

One thing I did **not** fold in, to keep this reviewable: `*.prperf` is not gitignored, so a capture artifact sitting in a worktree can be committed by a stray `git add -A` — which nearly happened while preparing this. The charter says captures are never committed. Separate PR unless you would rather I add it here.