### PR TITLE
gpu: add generic indirect pointer relocation carrier

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1038,6 +1038,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_gta5_packed_pointer PRIVATE prosper_core)
   add_test(NAME gta5_packed_pointer COMMAND test_gta5_packed_pointer)
 
+  add_executable(test_indirect_buffer_shadow tests/test_indirect_buffer_shadow.cpp)
+  target_link_libraries(test_indirect_buffer_shadow PRIVATE prosper_core)
+  add_test(NAME indirect_buffer_shadow COMMAND test_indirect_buffer_shadow)
+
   add_executable(test_gta5_cf9200 tests/test_gta5_cf9200.cpp)
   target_link_libraries(test_gta5_cf9200 PRIVATE prosper_core)
   add_test(NAME gta5_cf9200_no_backing COMMAND test_gta5_cf9200)

--- a/prosper/src/gpu/rdna2_indirect_buffer_shadow.cpp
+++ b/prosper/src/gpu/rdna2_indirect_buffer_shadow.cpp
@@ -32,6 +32,54 @@ void store_u64(uint8_t* bytes, size_t offset, uint64_t value) {
     std::memcpy(bytes + offset, &value, sizeof(value));
 }
 
+constexpr size_t kRelocationHeaderBytes = 40u;
+constexpr size_t kRelocationRecordBytes = 24u;
+constexpr size_t kRelocationSegmentBytes = 24u;
+
+bool relocation_layout_valid(const ShaderResource& source,
+                             const IndirectBufferRelocationLayout& layout,
+                             size_t record_count) {
+    return layout.tag && layout.version == 2u && layout.max_records &&
+           layout.max_segments && layout.max_binding_bytes &&
+           record_count && record_count <= layout.max_records &&
+           source.size && source.size <= UINT32_MAX;
+}
+
+bool interval_end(uint64_t address, uint32_t bytes, uint64_t& end) {
+    if (!address || !bytes || bytes > UINT64_MAX - address) return false;
+    end = address + bytes;
+    return true;
+}
+
+struct RelocationInterval { uint64_t begin, end; };
+
+bool canonical_relocation_intervals(
+        std::span<const IndirectBufferRelocationRecord> records,
+        std::vector<RelocationInterval>& merged) {
+    std::vector<RelocationInterval> intervals;
+    intervals.reserve(records.size());
+    for (const auto& record : records) {
+        if (!record.guest_address || !record.byte_count) {
+            if (record.guest_address || record.byte_count) return false;
+            continue;
+        }
+        uint64_t end = 0;
+        if (!interval_end(record.guest_address, record.byte_count, end)) return false;
+        intervals.push_back({record.guest_address, end});
+    }
+    std::sort(intervals.begin(), intervals.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs.begin < rhs.begin || (lhs.begin == rhs.begin && lhs.end < rhs.end);
+    });
+    merged.clear();
+    for (const auto& interval : intervals) {
+        if (merged.empty() || interval.begin > merged.back().end)
+            merged.push_back(interval);
+        else
+            merged.back().end = std::max(merged.back().end, interval.end);
+    }
+    return true;
+}
+
 bool record_offsets_fit(const ShaderResource& source,
                         const IndirectBufferShadowLayout& layout,
                         std::span<const uint32_t> pointer_records) {
@@ -215,6 +263,270 @@ bool current_indirect_buffer_shadow_matches(
         cursor = offset + sizeof(uint64_t);
     }
     return std::memcmp(source.host_data + cursor, guest + cursor, source_bytes - cursor) == 0;
+}
+
+bool parse_indirect_buffer_relocation(
+        const ShaderResource& source, const uint8_t* bytes, size_t byte_count,
+        const IndirectBufferRelocationLayout& layout,
+        std::span<const IndirectBufferRelocationRecord> expected_records,
+        IndirectBufferRelocationInfo& info) {
+    info = {};
+    if (!bytes || !relocation_layout_valid(source, layout, expected_records.size())) return false;
+    const size_t source_bytes = static_cast<size_t>(source.size);
+    if (source_bytes > byte_count || kRelocationHeaderBytes > byte_count - source_bytes)
+        return false;
+    const size_t header = source_bytes;
+    const uint32_t record_count = load_u32(bytes, header + 16u);
+    const uint32_t segment_count = load_u32(bytes, header + 20u);
+    const uint32_t witness_count = load_u32(bytes, header + 24u);
+    const uint32_t payload_offset = load_u32(bytes, header + 28u);
+    const uint32_t payload_bytes = load_u32(bytes, header + 32u);
+    if (load_u32(bytes, header) != layout.tag ||
+        load_u32(bytes, header + 4u) != layout.version ||
+        load_u32(bytes, header + 8u) != layout.tag ||
+        load_u32(bytes, header + 12u) != source.size ||
+        load_u32(bytes, header + 36u) != (layout.tag ^ source.size ^ record_count ^
+                                         segment_count ^ payload_offset ^ payload_bytes) ||
+        record_count != expected_records.size() || segment_count > layout.max_segments ||
+        witness_count != layout.witness_word_count)
+        return false;
+
+    const uint64_t record_bytes = static_cast<uint64_t>(record_count) * kRelocationRecordBytes;
+    const uint64_t segment_bytes = static_cast<uint64_t>(segment_count) * kRelocationSegmentBytes;
+    const uint64_t witness_bytes = static_cast<uint64_t>(witness_count) * sizeof(uint32_t);
+    const uint64_t expected_payload = static_cast<uint64_t>(source_bytes) +
+        kRelocationHeaderBytes + record_bytes + segment_bytes + witness_bytes;
+    if (expected_payload > UINT32_MAX || payload_offset != expected_payload ||
+        payload_bytes > layout.max_binding_bytes ||
+        payload_offset > layout.max_binding_bytes - payload_bytes ||
+        byte_count != static_cast<size_t>(payload_offset) + payload_bytes)
+        return false;
+
+    info.source_bytes = static_cast<uint32_t>(source_bytes);
+    info.payload_byte_offset = payload_offset;
+    info.payload_bytes = payload_bytes;
+    info.records.resize(record_count);
+    const size_t records_base = header + kRelocationHeaderBytes;
+    uint64_t prior_source_end = 0;
+    for (size_t index = 0; index < record_count; ++index) {
+        const size_t offset = records_base + index * kRelocationRecordBytes;
+        auto& record = info.records[index];
+        record.source_byte_offset = load_u32(bytes, offset);
+        const uint32_t segment = load_u32(bytes, offset + 4u);
+        record.guest_address = load_u64(bytes, offset + 8u);
+        record.byte_count = load_u32(bytes, offset + 16u);
+        if (load_u32(bytes, offset + 20u) != 0u ||
+            record.source_byte_offset != expected_records[index].source_byte_offset ||
+            record.guest_address != expected_records[index].guest_address ||
+            record.byte_count != expected_records[index].byte_count ||
+            record.source_byte_offset > source.size ||
+            sizeof(uint64_t) > source.size - record.source_byte_offset ||
+            record.source_byte_offset < prior_source_end ||
+            load_u64(bytes, record.source_byte_offset) != record.guest_address)
+            return false;
+        prior_source_end = static_cast<uint64_t>(record.source_byte_offset) + sizeof(uint64_t);
+        if (!record.guest_address || !record.byte_count) {
+            if (record.guest_address || record.byte_count || segment != UINT32_MAX) return false;
+        } else if (segment >= segment_count) {
+            return false;
+        }
+    }
+
+    const size_t segments_base = records_base + static_cast<size_t>(record_bytes);
+    std::vector<RelocationInterval> canonical_segments;
+    if (!canonical_relocation_intervals(expected_records, canonical_segments) ||
+        canonical_segments.size() != segment_count)
+        return false;
+    info.segments.resize(segment_count);
+    uint64_t prior_end = 0;
+    uint32_t prior_packed_end = payload_offset;
+    for (size_t index = 0; index < segment_count; ++index) {
+        const size_t offset = segments_base + index * kRelocationSegmentBytes;
+        auto& segment = info.segments[index];
+        segment.guest_address = load_u64(bytes, offset);
+        segment.byte_count = load_u32(bytes, offset + 8u);
+        segment.packed_byte_offset = load_u32(bytes, offset + 12u);
+        uint64_t end = 0;
+        if (load_u64(bytes, offset + 16u) != 0u ||
+            !interval_end(segment.guest_address, segment.byte_count, end) ||
+            segment.guest_address != canonical_segments[index].begin ||
+            end != canonical_segments[index].end ||
+            (index && segment.guest_address < prior_end) ||
+            segment.packed_byte_offset != prior_packed_end ||
+            segment.packed_byte_offset > byte_count ||
+            segment.byte_count > byte_count - segment.packed_byte_offset)
+            return false;
+        prior_end = end;
+        if (segment.byte_count > UINT32_MAX - prior_packed_end) return false;
+        prior_packed_end += segment.byte_count;
+    }
+    if (prior_packed_end != byte_count) return false;
+
+    std::vector<bool> referenced_segments(segment_count, false);
+    for (size_t index = 0; index < record_count; ++index) {
+        if (!info.records[index].guest_address) continue;
+        const size_t offset = records_base + index * kRelocationRecordBytes;
+        const uint32_t segment_index = load_u32(bytes, offset + 4u);
+        referenced_segments[segment_index] = true;
+        const auto& segment = info.segments[segment_index];
+        uint64_t record_end = 0, segment_end = 0;
+        if (!interval_end(info.records[index].guest_address,
+                          info.records[index].byte_count, record_end) ||
+            !interval_end(segment.guest_address, segment.byte_count, segment_end) ||
+            info.records[index].guest_address < segment.guest_address ||
+            record_end > segment_end)
+            return false;
+    }
+    if (std::find(referenced_segments.begin(), referenced_segments.end(), false) !=
+        referenced_segments.end())
+        return false;
+
+    const size_t witness_base = segments_base + static_cast<size_t>(segment_bytes);
+    info.witness_words.resize(witness_count);
+    for (size_t index = 0; index < witness_count; ++index)
+        info.witness_words[index] = load_u32(bytes, witness_base + index * sizeof(uint32_t));
+    return true;
+}
+
+bool build_indirect_buffer_relocation(
+        const ShaderResource& source, const uint8_t* source_bytes,
+        const IndirectBufferRelocationLayout& layout,
+        std::span<const IndirectBufferRelocationRecord> records,
+        std::span<const uint32_t> witness_words,
+        std::shared_ptr<std::vector<uint8_t>>& owner,
+        IndirectBufferRelocationInfo& info) {
+    owner.reset();
+    info = {};
+    if (!source_bytes || !relocation_layout_valid(source, layout, records.size()) ||
+        witness_words.size() != layout.witness_word_count)
+        return false;
+
+    uint64_t prior_source_end = 0;
+    for (const auto& record : records) {
+        if (record.source_byte_offset > source.size ||
+            sizeof(uint64_t) > source.size - record.source_byte_offset ||
+            record.source_byte_offset < prior_source_end)
+            return false;
+        prior_source_end = static_cast<uint64_t>(record.source_byte_offset) + sizeof(uint64_t);
+        uint64_t source_pointer = 0;
+        std::memcpy(&source_pointer, source_bytes + record.source_byte_offset,
+                    sizeof(source_pointer));
+        if (source_pointer != record.guest_address) return false;
+        if (!record.guest_address || !record.byte_count) {
+            if (record.guest_address || record.byte_count) return false;
+            continue;
+        }
+        uint64_t end = 0;
+        if (!interval_end(record.guest_address, record.byte_count, end) ||
+            !guest_readable(record.guest_address, record.byte_count))
+            return false;
+    }
+    std::vector<RelocationInterval> merged;
+    if (!canonical_relocation_intervals(records, merged)) return false;
+    if (merged.size() > layout.max_segments) return false;
+
+    const uint64_t record_bytes = static_cast<uint64_t>(records.size()) * kRelocationRecordBytes;
+    const uint64_t segment_bytes = static_cast<uint64_t>(merged.size()) * kRelocationSegmentBytes;
+    const uint64_t witness_bytes = static_cast<uint64_t>(witness_words.size()) * sizeof(uint32_t);
+    const uint64_t payload_offset64 = source.size + kRelocationHeaderBytes + record_bytes +
+        segment_bytes + witness_bytes;
+    uint64_t payload_bytes64 = 0;
+    for (const auto& interval : merged) {
+        const uint64_t bytes = interval.end - interval.begin;
+        if (bytes > UINT64_MAX - payload_bytes64) return false;
+        payload_bytes64 += bytes;
+    }
+    if (payload_offset64 > UINT32_MAX || payload_bytes64 > UINT32_MAX ||
+        payload_offset64 > layout.max_binding_bytes ||
+        payload_bytes64 > layout.max_binding_bytes - payload_offset64)
+        return false;
+    const uint32_t payload_offset = static_cast<uint32_t>(payload_offset64);
+    const uint32_t payload_bytes = static_cast<uint32_t>(payload_bytes64);
+    owner = std::make_shared<std::vector<uint8_t>>(
+        static_cast<size_t>(payload_offset) + payload_bytes);
+    std::memcpy(owner->data(), source_bytes, static_cast<size_t>(source.size));
+    const size_t header = static_cast<size_t>(source.size);
+    store_u32(owner->data(), header, layout.tag);
+    store_u32(owner->data(), header + 4u, layout.version);
+    store_u32(owner->data(), header + 8u, layout.tag);
+    store_u32(owner->data(), header + 12u, static_cast<uint32_t>(source.size));
+    store_u32(owner->data(), header + 16u, static_cast<uint32_t>(records.size()));
+    store_u32(owner->data(), header + 20u, static_cast<uint32_t>(merged.size()));
+    store_u32(owner->data(), header + 24u, static_cast<uint32_t>(witness_words.size()));
+    store_u32(owner->data(), header + 28u, payload_offset);
+    store_u32(owner->data(), header + 32u, payload_bytes);
+    store_u32(owner->data(), header + 36u,
+              layout.tag ^ static_cast<uint32_t>(source.size) ^
+                  static_cast<uint32_t>(records.size()) ^
+                  static_cast<uint32_t>(merged.size()) ^ payload_offset ^ payload_bytes);
+
+    const size_t records_base = header + kRelocationHeaderBytes;
+    for (size_t index = 0; index < records.size(); ++index) {
+        const auto& record = records[index];
+        const size_t offset = records_base + index * kRelocationRecordBytes;
+        uint32_t segment_index = UINT32_MAX;
+        if (record.guest_address) {
+            auto segment = std::find_if(merged.begin(), merged.end(), [&](const auto& candidate) {
+                return record.guest_address >= candidate.begin &&
+                       record.guest_address <= candidate.end &&
+                       record.byte_count <= candidate.end - record.guest_address;
+            });
+            if (segment == merged.end()) return false;
+            segment_index = static_cast<uint32_t>(segment - merged.begin());
+        }
+        store_u32(owner->data(), offset, record.source_byte_offset);
+        store_u32(owner->data(), offset + 4u, segment_index);
+        store_u64(owner->data(), offset + 8u, record.guest_address);
+        store_u32(owner->data(), offset + 16u, record.byte_count);
+        store_u32(owner->data(), offset + 20u, 0u);
+    }
+
+    const size_t segments_base = records_base + static_cast<size_t>(record_bytes);
+    uint32_t packed_offset = payload_offset;
+    for (size_t index = 0; index < merged.size(); ++index) {
+        const size_t offset = segments_base + index * kRelocationSegmentBytes;
+        const uint32_t bytes = static_cast<uint32_t>(merged[index].end - merged[index].begin);
+        store_u64(owner->data(), offset, merged[index].begin);
+        store_u32(owner->data(), offset + 8u, bytes);
+        store_u32(owner->data(), offset + 12u, packed_offset);
+        store_u64(owner->data(), offset + 16u, 0u);
+        std::memcpy(owner->data() + packed_offset,
+                    reinterpret_cast<const void*>(static_cast<uintptr_t>(merged[index].begin)),
+                    bytes);
+        packed_offset += bytes;
+    }
+    const size_t witness_base = segments_base + static_cast<size_t>(segment_bytes);
+    for (size_t index = 0; index < witness_words.size(); ++index)
+        store_u32(owner->data(), witness_base + index * sizeof(uint32_t), witness_words[index]);
+
+    return parse_indirect_buffer_relocation(
+        source, owner->data(), owner->size(), layout, records, info);
+}
+
+bool current_indirect_buffer_relocation_matches(
+        const ShaderResourceTable& table, const ShaderResource& source,
+        const IndirectBufferRelocationLayout& layout,
+        std::span<const IndirectBufferRelocationRecord> expected_records) {
+    IndirectBufferRelocationInfo info;
+    if (!parse_indirect_buffer_relocation(
+            source, source.host_data, source.host_data_size, layout, expected_records, info))
+        return false;
+    if (!source.host_data || !table_owns(table, source.host_data))
+        return source.host_data != nullptr;
+    if (!guest_readable(source.gpu_addr, static_cast<uint32_t>(source.size))) return false;
+    const auto* live_source = reinterpret_cast<const uint8_t*>(
+        static_cast<uintptr_t>(source.gpu_addr));
+    if (std::memcmp(source.host_data, live_source, static_cast<size_t>(source.size)) != 0)
+        return false;
+    for (const auto& segment : info.segments) {
+        if (!guest_readable(segment.guest_address, segment.byte_count) ||
+            std::memcmp(source.host_data + segment.packed_byte_offset,
+                        reinterpret_cast<const void*>(
+                            static_cast<uintptr_t>(segment.guest_address)),
+                        segment.byte_count) != 0)
+            return false;
+    }
+    return true;
 }
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_indirect_buffer_shadow.cpp
+++ b/prosper/src/gpu/rdna2_indirect_buffer_shadow.cpp
@@ -59,10 +59,8 @@ bool canonical_relocation_intervals(
     std::vector<RelocationInterval> intervals;
     intervals.reserve(records.size());
     for (const auto& record : records) {
-        if (!record.guest_address || !record.byte_count) {
-            if (record.guest_address || record.byte_count) return false;
-            continue;
-        }
+        if (!record.byte_count) continue; // statically inactive or nullable record
+        if (!record.guest_address) return false;
         uint64_t end = 0;
         if (!interval_end(record.guest_address, record.byte_count, end)) return false;
         intervals.push_back({record.guest_address, end});
@@ -325,9 +323,9 @@ bool parse_indirect_buffer_relocation(
             load_u64(bytes, record.source_byte_offset) != record.guest_address)
             return false;
         prior_source_end = static_cast<uint64_t>(record.source_byte_offset) + sizeof(uint64_t);
-        if (!record.guest_address || !record.byte_count) {
-            if (record.guest_address || record.byte_count || segment != UINT32_MAX) return false;
-        } else if (segment >= segment_count) {
+        if (!record.byte_count) {
+            if (segment != UINT32_MAX) return false;
+        } else if (!record.guest_address || segment >= segment_count) {
             return false;
         }
     }
@@ -364,7 +362,7 @@ bool parse_indirect_buffer_relocation(
 
     std::vector<bool> referenced_segments(segment_count, false);
     for (size_t index = 0; index < record_count; ++index) {
-        if (!info.records[index].guest_address) continue;
+        if (!info.records[index].byte_count) continue;
         const size_t offset = records_base + index * kRelocationRecordBytes;
         const uint32_t segment_index = load_u32(bytes, offset + 4u);
         referenced_segments[segment_index] = true;
@@ -386,6 +384,31 @@ bool parse_indirect_buffer_relocation(
     for (size_t index = 0; index < witness_count; ++index)
         info.witness_words[index] = load_u32(bytes, witness_base + index * sizeof(uint32_t));
     return true;
+}
+
+bool inspect_indirect_buffer_relocation(
+        const ShaderResource& source, const uint8_t* bytes, size_t byte_count,
+        const IndirectBufferRelocationLayout& layout,
+        IndirectBufferRelocationInfo& info) {
+    info = {};
+    if (!bytes || source.size > byte_count ||
+        kRelocationHeaderBytes > byte_count - source.size)
+        return false;
+    const size_t header = static_cast<size_t>(source.size);
+    const uint32_t record_count = load_u32(bytes, header + 16u);
+    if (!relocation_layout_valid(source, layout, record_count)) return false;
+    const uint64_t record_bytes = static_cast<uint64_t>(record_count) * kRelocationRecordBytes;
+    if (record_bytes > byte_count - header - kRelocationHeaderBytes) return false;
+    const size_t records_base = header + kRelocationHeaderBytes;
+    std::vector<IndirectBufferRelocationRecord> records(record_count);
+    for (size_t index = 0; index < records.size(); ++index) {
+        const size_t offset = records_base + index * kRelocationRecordBytes;
+        records[index].source_byte_offset = load_u32(bytes, offset);
+        records[index].guest_address = load_u64(bytes, offset + 8u);
+        records[index].byte_count = load_u32(bytes, offset + 16u);
+    }
+    return parse_indirect_buffer_relocation(
+        source, bytes, byte_count, layout, records, info);
 }
 
 bool build_indirect_buffer_relocation(
@@ -412,10 +435,8 @@ bool build_indirect_buffer_relocation(
         std::memcpy(&source_pointer, source_bytes + record.source_byte_offset,
                     sizeof(source_pointer));
         if (source_pointer != record.guest_address) return false;
-        if (!record.guest_address || !record.byte_count) {
-            if (record.guest_address || record.byte_count) return false;
-            continue;
-        }
+        if (!record.byte_count) continue; // retain nonzero inactive pointers as source witnesses
+        if (!record.guest_address) return false;
         uint64_t end = 0;
         if (!interval_end(record.guest_address, record.byte_count, end) ||
             !guest_readable(record.guest_address, record.byte_count))
@@ -465,7 +486,7 @@ bool build_indirect_buffer_relocation(
         const auto& record = records[index];
         const size_t offset = records_base + index * kRelocationRecordBytes;
         uint32_t segment_index = UINT32_MAX;
-        if (record.guest_address) {
+        if (record.byte_count) {
             auto segment = std::find_if(merged.begin(), merged.end(), [&](const auto& candidate) {
                 return record.guest_address >= candidate.begin &&
                        record.guest_address <= candidate.end &&

--- a/prosper/src/gpu/rdna2_indirect_buffer_shadow.hpp
+++ b/prosper/src/gpu/rdna2_indirect_buffer_shadow.hpp
@@ -35,6 +35,40 @@ struct IndirectBufferShadowAccess {
     uint32_t components = 0;
 };
 
+// Version-2 relocation shadows preserve the source bytes verbatim. Each proven source record names
+// one bounded guest interval; overlapping intervals are normalized into disjoint packed segments.
+// The translated shader keeps computing the original guest address and relocates only at a proven
+// GLOBAL consumer, so guest pointer arithmetic (including high-word canonicalization) stays intact.
+struct IndirectBufferRelocationLayout {
+    uint32_t tag = 0;
+    uint32_t version = 2;
+    uint32_t max_records = 0;
+    uint32_t max_segments = 0;
+    uint32_t max_binding_bytes = 0;
+    uint32_t witness_word_count = 0;
+};
+
+struct IndirectBufferRelocationRecord {
+    uint32_t source_byte_offset = 0;
+    uint64_t guest_address = 0;
+    uint32_t byte_count = 0;
+};
+
+struct IndirectBufferRelocationSegment {
+    uint64_t guest_address = 0;
+    uint32_t byte_count = 0;
+    uint32_t packed_byte_offset = 0;
+};
+
+struct IndirectBufferRelocationInfo {
+    uint32_t source_bytes = 0;
+    uint32_t payload_byte_offset = 0;
+    uint32_t payload_bytes = 0;
+    std::vector<IndirectBufferRelocationRecord> records;
+    std::vector<IndirectBufferRelocationSegment> segments;
+    std::vector<uint32_t> witness_words;
+};
+
 size_t indirect_buffer_shadow_header_bytes(const IndirectBufferShadowLayout& layout);
 
 bool parse_indirect_buffer_shadow(
@@ -51,5 +85,24 @@ bool build_indirect_buffer_shadow(
 bool current_indirect_buffer_shadow_matches(
     const ShaderResourceTable& table, const ShaderResource& source,
     const IndirectBufferShadowLayout& layout, std::span<const uint32_t> pointer_records);
+
+bool parse_indirect_buffer_relocation(
+    const ShaderResource& source, const uint8_t* bytes, size_t byte_count,
+    const IndirectBufferRelocationLayout& layout,
+    std::span<const IndirectBufferRelocationRecord> expected_records,
+    IndirectBufferRelocationInfo& info);
+
+bool build_indirect_buffer_relocation(
+    const ShaderResource& source, const uint8_t* source_bytes,
+    const IndirectBufferRelocationLayout& layout,
+    std::span<const IndirectBufferRelocationRecord> records,
+    std::span<const uint32_t> witness_words,
+    std::shared_ptr<std::vector<uint8_t>>& owner,
+    IndirectBufferRelocationInfo& info);
+
+bool current_indirect_buffer_relocation_matches(
+    const ShaderResourceTable& table, const ShaderResource& source,
+    const IndirectBufferRelocationLayout& layout,
+    std::span<const IndirectBufferRelocationRecord> expected_records);
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/rdna2_indirect_buffer_shadow.hpp
+++ b/prosper/src/gpu/rdna2_indirect_buffer_shadow.hpp
@@ -52,6 +52,8 @@ struct IndirectBufferRelocationRecord {
     uint32_t source_byte_offset = 0;
     uint64_t guest_address = 0;
     uint32_t byte_count = 0;
+
+    bool operator==(const IndirectBufferRelocationRecord&) const = default;
 };
 
 struct IndirectBufferRelocationSegment {
@@ -90,6 +92,15 @@ bool parse_indirect_buffer_relocation(
     const ShaderResource& source, const uint8_t* bytes, size_t byte_count,
     const IndirectBufferRelocationLayout& layout,
     std::span<const IndirectBufferRelocationRecord> expected_records,
+    IndirectBufferRelocationInfo& info);
+
+// Syntax-only inspection for backend/capture boundaries that do not own the shader proof. It
+// derives the serialized record directory and still enforces source-qword identity plus the exact
+// canonical segment union. A compiler/discovery boundary must additionally call the overload above
+// with independently derived expected records before granting relocation authority.
+bool inspect_indirect_buffer_relocation(
+    const ShaderResource& source, const uint8_t* bytes, size_t byte_count,
+    const IndirectBufferRelocationLayout& layout,
     IndirectBufferRelocationInfo& info);
 
 bool build_indirect_buffer_relocation(

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4296,6 +4296,19 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                      in.src[2].kind == OperandKind::Special) && in.src[2].value == R)
                     return false;
                 break;
+            case Rdna2Format::FLAT:
+                // FLAT/GLOBAL/SCRATCH packets keep every data/address operand in VGPRs except
+                // SADDR, the optional scalar address pair at src[1]. NULL/off (125) reads no
+                // scalar register. An LDS transfer also observes M0 implicitly, so keep that
+                // uncommon form fail-closed. Account for the complete SADDR pair conservatively;
+                // this liveness proof does not imply that the memory operation is translatable.
+                if (in.flat_lds) return false;
+                if ((in.src[1].kind == OperandKind::SGPR ||
+                     in.src[1].kind == OperandKind::Special) &&
+                    in.src[1].value != 125 &&
+                    (in.src[1].value == R || in.src[1].value + 1 == R))
+                    return false;
+                break;
             default:
                 return false;   // memory/branch/interp/unknown: can't bound reads of R -> assume live
         }

--- a/prosper/tests/test_indirect_buffer_shadow.cpp
+++ b/prosper/tests/test_indirect_buffer_shadow.cpp
@@ -43,6 +43,7 @@ int main() {
     store_u64(source_bytes.data(), 0u, pointer0);
     store_u64(source_bytes.data(), 16u, pointer1);
     store_u64(source_bytes.data(), 32u, 0u);
+    store_u64(source_bytes.data(), 48u, pointer0 + 64u);
 
     ShaderResource source;
     source.cls = ResourceClass::ConstantBuffer;
@@ -57,10 +58,11 @@ int main() {
 
     const IndirectBufferRelocationLayout layout{
         0x1d1e2481u, 2u, 4u, 4u, 4096u, 2u};
-    const std::array<IndirectBufferRelocationRecord, 3> records{{
+    const std::array<IndirectBufferRelocationRecord, 4> records{{
         {0u, pointer0, 32u},
         {16u, pointer1, 32u},
         {32u, 0u, 0u},
+        {48u, pointer0 + 64u, 0u},
     }};
     const std::array<uint32_t, 2> witnesses{0x12345678u, 0x9abcdef0u};
 
@@ -73,7 +75,7 @@ int main() {
         std::fputs("FAIL: relocation shadow owner was not produced\n", stderr);
         return 1;
     }
-    CHECK(owner && info.records.size() == 3u && info.segments.size() == 1u &&
+    CHECK(owner && info.records.size() == 4u && info.segments.size() == 1u &&
               info.segments[0].guest_address == pointer0 &&
               info.segments[0].byte_count == 48u && info.payload_bytes == 48u,
           "overlapping pointee intervals normalize to one disjoint segment");
@@ -90,6 +92,16 @@ int main() {
               source, owner->data(), owner->size(), layout, records, reparsed) &&
               reparsed.payload_byte_offset == info.payload_byte_offset,
           "serialized relocation directory reparses against its exact record proof");
+    CHECK(owner && inspect_indirect_buffer_relocation(
+              source, owner->data(), owner->size(), layout, reparsed) &&
+              reparsed.records == info.records,
+          "syntax-only inspection retains null and nonzero inactive record witnesses");
+    auto inactive_pointer_corrupt = *owner;
+    inactive_pointer_corrupt[48u] ^= 1u;
+    CHECK(!inspect_indirect_buffer_relocation(
+              source, inactive_pointer_corrupt.data(), inactive_pointer_corrupt.size(),
+              layout, reparsed),
+          "syntax-only inspection rejects a changed inactive nonzero pointer witness");
 
     ShaderResourceTable table;
     table.owned_host_data.push_back(owner);

--- a/prosper/tests/test_indirect_buffer_shadow.cpp
+++ b/prosper/tests/test_indirect_buffer_shadow.cpp
@@ -1,0 +1,162 @@
+#include "gpu/rdna2_indirect_buffer_shadow.hpp"
+#include "gpu/shader_resources.hpp"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+using namespace prosper::gpu;
+
+namespace {
+
+int failures = 0;
+#define CHECK(condition, message) do { \
+    if (!(condition)) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; } \
+} while (0)
+
+void store_u64(uint8_t* bytes, size_t offset, uint64_t value) {
+    std::memcpy(bytes + offset, &value, sizeof(value));
+}
+
+uint32_t load_u32(const uint8_t* bytes, size_t offset) {
+    uint32_t value = 0;
+    std::memcpy(&value, bytes + offset, sizeof(value));
+    return value;
+}
+
+void store_u32(uint8_t* bytes, size_t offset, uint32_t value) {
+    std::memcpy(bytes + offset, &value, sizeof(value));
+}
+
+} // namespace
+
+int main() {
+    std::vector<uint8_t> source_bytes(64u, 0x5au);
+    std::array<uint8_t, 80> pointee{};
+    for (size_t index = 0; index < pointee.size(); ++index)
+        pointee[index] = static_cast<uint8_t>(index * 3u + 1u);
+    const uint64_t pointer0 = reinterpret_cast<uint64_t>(pointee.data());
+    const uint64_t pointer1 = pointer0 + 16u;
+    store_u64(source_bytes.data(), 0u, pointer0);
+    store_u64(source_bytes.data(), 16u, pointer1);
+    store_u64(source_bytes.data(), 32u, 0u);
+
+    ShaderResource source;
+    source.cls = ResourceClass::ConstantBuffer;
+    source.format = DataFormat::Uint32;
+    source.num_components = 1u;
+    source.gpu_addr = reinterpret_cast<uint64_t>(source_bytes.data());
+    source.size = source_bytes.size();
+    source.stride = 16u;
+    source.fetch_pc = 6u;
+    source.host_data = source_bytes.data();
+    source.host_data_size = source_bytes.size();
+
+    const IndirectBufferRelocationLayout layout{
+        0x1d1e2481u, 2u, 4u, 4u, 4096u, 2u};
+    const std::array<IndirectBufferRelocationRecord, 3> records{{
+        {0u, pointer0, 32u},
+        {16u, pointer1, 32u},
+        {32u, 0u, 0u},
+    }};
+    const std::array<uint32_t, 2> witnesses{0x12345678u, 0x9abcdef0u};
+
+    std::shared_ptr<std::vector<uint8_t>> owner;
+    IndirectBufferRelocationInfo info;
+    CHECK(build_indirect_buffer_relocation(
+              source, source_bytes.data(), layout, records, witnesses, owner, info),
+          "overlapping and null records build one preserved-source relocation shadow");
+    if (!owner) {
+        std::fputs("FAIL: relocation shadow owner was not produced\n", stderr);
+        return 1;
+    }
+    CHECK(owner && info.records.size() == 3u && info.segments.size() == 1u &&
+              info.segments[0].guest_address == pointer0 &&
+              info.segments[0].byte_count == 48u && info.payload_bytes == 48u,
+          "overlapping pointee intervals normalize to one disjoint segment");
+    CHECK(owner && std::memcmp(owner->data(), source_bytes.data(), source_bytes.size()) == 0,
+          "version-2 shadow preserves every source byte including pointer qwords");
+    CHECK(owner && std::memcmp(owner->data() + info.payload_byte_offset,
+                               pointee.data(), 48u) == 0,
+          "normalized segment copies the exact bounded pointee bytes");
+    CHECK(info.witness_words == std::vector<uint32_t>(witnesses.begin(), witnesses.end()),
+          "proof witnesses survive the serialized carrier");
+
+    IndirectBufferRelocationInfo reparsed;
+    CHECK(owner && parse_indirect_buffer_relocation(
+              source, owner->data(), owner->size(), layout, records, reparsed) &&
+              reparsed.payload_byte_offset == info.payload_byte_offset,
+          "serialized relocation directory reparses against its exact record proof");
+
+    ShaderResourceTable table;
+    table.owned_host_data.push_back(owner);
+    source.host_data = owner->data();
+    source.host_data_size = owner->size();
+    table.resources.push_back(source);
+    CHECK(current_indirect_buffer_relocation_matches(table, table.resources[0], layout, records),
+          "owned shadow revalidates the live source and pointee bytes");
+
+    source_bytes[40] ^= 1u;
+    CHECK(!current_indirect_buffer_relocation_matches(table, table.resources[0], layout, records),
+          "same live source snapshot mutation invalidates authority");
+    source_bytes[40] ^= 1u;
+    source_bytes[0] ^= 1u;
+    CHECK(!current_indirect_buffer_relocation_matches(table, table.resources[0], layout, records),
+          "same source pointer-qword mutation invalidates record authority");
+    source_bytes[0] ^= 1u;
+    pointee[47] ^= 1u;
+    CHECK(!current_indirect_buffer_relocation_matches(table, table.resources[0], layout, records),
+          "same copied pointee endpoint mutation invalidates authority");
+    pointee[47] ^= 1u;
+
+    auto corrupt = *owner;
+    const size_t segment_base = source_bytes.size() + 40u + records.size() * 24u;
+    if (segment_base + 16u > corrupt.size()) {
+        std::fputs("FAIL: relocation segment directory is truncated\n", stderr);
+        return 1;
+    }
+    store_u32(corrupt.data(), segment_base + 12u,
+              load_u32(corrupt.data(), segment_base + 12u) + 4u);
+    CHECK(!parse_indirect_buffer_relocation(
+              source, corrupt.data(), corrupt.size(), layout, records, reparsed),
+          "directory payload-offset mutation fails closed");
+
+    corrupt = *owner;
+    store_u64(corrupt.data(), segment_base, pointer0 - 4u);
+    CHECK(!parse_indirect_buffer_relocation(
+              source, corrupt.data(), corrupt.size(), layout, records, reparsed),
+          "segment range widened before the canonical proof union fails closed");
+
+    corrupt = *owner;
+    store_u32(corrupt.data(), segment_base + 8u,
+              load_u32(corrupt.data(), segment_base + 8u) + 4u);
+    CHECK(!parse_indirect_buffer_relocation(
+              source, corrupt.data(), corrupt.size(), layout, records, reparsed),
+          "segment byte count widened beyond the canonical proof union fails closed");
+
+    auto wrong_records = records;
+    ++wrong_records[1].byte_count;
+    CHECK(!parse_indirect_buffer_relocation(
+              source, owner->data(), owner->size(), layout, wrong_records, reparsed),
+          "changed static bound proof cannot reuse a serialized shadow");
+
+    const IndirectBufferRelocationLayout too_small{
+        layout.tag, layout.version, layout.max_records, layout.max_segments,
+        static_cast<uint32_t>(info.payload_byte_offset + info.payload_bytes - 1u),
+        layout.witness_word_count};
+    std::shared_ptr<std::vector<uint8_t>> rejected_owner;
+    CHECK(!build_indirect_buffer_relocation(
+              source, source_bytes.data(), too_small, records, witnesses,
+              rejected_owner, reparsed),
+          "binding cap rejects the same production payload before allocation");
+
+    if (failures) {
+        std::fprintf(stderr, "%d indirect-buffer shadow assertion(s) failed\n", failures);
+        return 1;
+    }
+    std::puts("indirect-buffer relocation shadow tests passed");
+    return 0;
+}

--- a/prosper/tests/test_recompile_coverage.cpp
+++ b/prosper/tests/test_recompile_coverage.cpp
@@ -897,6 +897,38 @@ int main() {
                             b64_kill_config).empty(),
           "a low-half-only B32 write does not kill live VCC_HI at the merge");
 
+    // A GLOBAL packet's only scalar input is its optional SADDR pair. Failure 27's null-SADDR
+    // loads sit after a guarded VCC scratch write and before a complete VOPC replacement; they do
+    // not observe the old VCC value and must be transparent to post-merge scalar liveness.
+    const uint32_t flat_vcc_scratch_guard[] = {
+        0x7daa0481u,                 // 0: v_cmpx_ne_u32 1,v2; narrows EXEC
+        0xbf880001u,                 // 1: s_cbranch_execz -> pc 3
+        0x87ea0e6au,                 // 2: s_and_b64 vcc,vcc,s[14:15] (guarded scratch write)
+        0xdc308018u, 0x027d0018u,   // 3: global_load_dword ...,v[24:25],off,+24
+        0x7d8a0080u,                 // 5: v_cmp_ne_u32 vcc,0,v0 (complete replacement)
+        0xbf810000u,
+    };
+    CHECK(has(structured_execz_branches_for_test(flat_vcc_scratch_guard,
+                                                  std::size(flat_vcc_scratch_guard)), 1u),
+          "a null-SADDR GLOBAL is transparent to post-merge VCC liveness");
+
+    // Same-site mutation: changing that exact GLOBAL packet from NULL SADDR to the VCC pair makes
+    // the guarded write observable, so the structurizer must keep rejecting the branch.
+    uint32_t flat_reads_vcc[std::size(flat_vcc_scratch_guard)];
+    std::copy(std::begin(flat_vcc_scratch_guard), std::end(flat_vcc_scratch_guard),
+              std::begin(flat_reads_vcc));
+    flat_reads_vcc[4] = 0x026a0018u;
+    CHECK(!has(structured_execz_branches_for_test(flat_reads_vcc,
+                                                   std::size(flat_reads_vcc)), 1u),
+          "a GLOBAL SADDR overlapping VCC keeps the guarded scalar write live");
+
+    std::copy(std::begin(flat_vcc_scratch_guard), std::end(flat_vcc_scratch_guard),
+              std::begin(flat_reads_vcc));
+    flat_reads_vcc[3] = 0xdc30a018u; // same pc3 GLOBAL with LDS transfer (implicit M0 read)
+    CHECK(!has(structured_execz_branches_for_test(flat_reads_vcc,
+                                                   std::size(flat_reads_vcc)), 1u),
+          "a GLOBAL LDS-transfer remains fail-closed in scalar liveness");
+
     // Wave32 kernels use one-word mask instructions around EXEC: compare into VCC_LO, invert that
     // mask, copy it to EXEC_LO, then restore EXEC_LO. These are mask-domain operations, not scalar
     // reads of an unrepresentable VCC dword.


### PR DESCRIPTION
## Summary

- add a generic version-2 indirect-pointer relocation carrier that preserves source pointer bytes and appends only the exact canonical union of proven pointee intervals
- validate the record directory, proof witnesses, packed segments, source pointer qwords, binding cap, and live source/pointee bytes before reuse
- retain nonzero pointers from statically inactive records as witnesses without granting them segment authority
- teach compute CFG liveness the scalar inputs of ordinary FLAT/GLOBAL/SCRATCH packets, while keeping LDS transfers fail-closed because they also observe M0

This is the shared representation and safety boundary for the remaining GTA V indirect-pointer kernels. It deliberately does not yet make those kernels executable: producer-domain analysis and SPIR-V range relocation remain the next patch.

## Why

The remaining kernels compute guest addresses from pointer qwords loaded out of dispatch records. Rewriting those qwords into tagged host offsets is not general enough: two Wave32 kernels inspect and canonicalize the original high pointer dword before their loads. Version 2 therefore preserves the complete source snapshot verbatim and relocates only a final address at an independently proven GLOBAL consumer.

The Wave64 kernel also had an independent CFG false negative. Its post-merge GLOBAL loads have null SADDR and cannot observe the guarded VCC scratch value; the liveness walker previously treated every FLAT packet as unknowable. With the exact scalar inventory, all five forward branches structure successfully and the kernel now reaches its real unresolved-pointer terminal.

## Current GTA V compute frontier

Current exact replay of the retained gameplay submit contains 190 raw compute packets:

- 134 are hardware no-ops and are culled
- 56 launch actual work
- 45/56 currently recompile and satisfy their descriptor contracts
- 11/56 remain rejected
- those 11 launches collapse to 3 unique shader kernels: one launch of the first Wave32 kernel, seven launches of its sibling, and three launches of the Wave64 kernel

All three unique rejects now converge on the same high-level class: a GLOBAL load through a pointer loaded from another guest buffer. The Wave64 member previously also declined CFG structurization; after this PR its retained offline retry reports five structured forward branches, no CFG rejection, and then stops at the first unresolved GLOBAL load as intended.

The next implementation step is to connect this carrier to the generic `StaticFootprint` producer proof for the three Wave64 launches, then add the `DescriptorRange` producer proof shared by the two Wave32 kernels. The carrier is common to both.

## Safety and review

The parser recomputes the canonical sorted/merged interval union from independently expected records and requires the serialized directory to match it exactly. It rejects widened ranges, bridged gaps, stale source qwords, unreferenced payload segments, offset wrap, malformed directories, and changed live bytes.

Regression mutations exercise the same sites as the fixes, including:

- source pointer qwords, including an inactive nonzero witness
- serialized segment base, size, and payload offset
- changed static bounds and binding caps
- live source and pointee bytes
- the exact GLOBAL packet changed from null SADDR to VCC SADDR
- the exact GLOBAL packet changed to an LDS transfer

An independent code-review agent reviewed the carrier and CFG change to GO after two rounds of mutation hardening.

## Validation

- full distrobox build succeeded
- `ctest --no-tests=error -j4 --output-on-failure`: **241/241 passed**
- retained Wave64 offline retry: old VCC-liveness route decline absent; `structured_ifs=5`, `cf_rejected=0`; unresolved GLOBAL remains the terminal
- `git diff --check`: clean

Progresses #2481.
