### PR TITLE
capture: re-derive a stale scalar-buffer bound instead of rejecting the capsule

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -4811,6 +4811,25 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                 if (!r.u32(resource.scalar_buffer_dword_count))
                     return false;
                 if (resource.scalar_buffer_dword_count) {
+                    // #2528: the scalar bound IS the V#'s byte footprint, so this field is fully
+                    // derivable from `size` and carries no independent authority — it can only ever
+                    // be a marker plus a checksum. Captures written before that correction stored
+                    // NUM_RECORDS (or one dword for STRIDE==0) here, which disagrees with `size` and
+                    // would otherwise make every retained v54 capsule permanently unreadable. Derive
+                    // the authoritative value rather than trusting the stored one; a disagreement
+                    // cannot widen a binding, because the derived span is exactly `size` either way.
+                    // The WRITER stays strict, so prosper never emits an inconsistent bound itself.
+                    const uint32_t derived =
+                        static_cast<uint32_t>(resource.size / sizeof(uint32_t));
+                    if (resource.scalar_buffer_dword_count != derived) {
+                        if (std::getenv("PROSPER_DBG"))
+                            std::fprintf(stderr,
+                                         "[capture] scalar-buffer bound %u disagrees with the V# "
+                                         "footprint (size=%u); using the derived %u (#2528)\n",
+                                         resource.scalar_buffer_dword_count, resource.size, derived);
+                        resource.scalar_buffer_dword_count = derived;
+                    }
+                    if (!resource.scalar_buffer_dword_count) continue;
                     const uint64_t binding_bytes =
                         shader_resource_buffer_binding_bytes(resource);
                     if (!binding_bytes || captured.captured_size < binding_bytes)

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1724,6 +1724,37 @@ int main(int argc, char** argv) {
                                    short_scalar_reader_loaded, error) &&
               error == "invalid scalar-buffer bound state",
           "v54 reader rejects a serialized scalar-buffer snapshot shorter than its bound");
+    // #2528: a v54 capsule written before the bound was corrected stores NUM_RECORDS here (4 records
+    // of stride 4 -> the pre-correction writer would have stored 4 for a 16-byte V#, and a
+    // pre-correction STRIDE=0 resource would have stored 1). The field is fully derivable from
+    // `size`, so the reader re-derives it instead of rejecting; otherwise every retained
+    // investigation capsule becomes permanently unreadable. Mutate the SERIALIZED dword, not the
+    // in-memory object, so this exercises the reader's own path.
+    std::vector<uint8_t> stale_bound_bytes;
+    CHECK(serialize_gpu_capture(captured, stale_bound_bytes, error) && !stale_bound_bytes.empty(),
+          "v54 stale scalar-buffer bound fixture serializes");
+    const size_t stale_tail = v54_tail(captured);
+    bool stale_patched = false;
+    if (stale_bound_bytes.size() >= stale_tail) {
+        // The v54 tail is `count` followed by one dword per resource, in table order; resource 1 of
+        // draw 0 is the second entry.
+        const size_t first = stale_bound_bytes.size() - stale_tail + 4u;
+        const size_t slot = first + sizeof(uint32_t);
+        if (slot + 4u <= stale_bound_bytes.size() &&
+            stale_bound_bytes[slot] == 4u) {          // the corrected value we wrote
+            stale_bound_bytes[slot] = 1u;             // what a pre-correction STRIDE=0 writer stored
+            stale_patched = true;
+        }
+    }
+    GpuCaptureFile stale_bound_loaded;
+    CHECK(stale_patched &&
+              deserialize_gpu_capture(stale_bound_bytes, stale_bound_loaded, error) &&
+              stale_bound_loaded.draws[0].vrt.resources[1].resource
+                      .scalar_buffer_dword_count == 4u &&
+              shader_resource_buffer_binding_bytes(
+                  stale_bound_loaded.draws[0].vrt.resources[1].resource) == 16u,
+          "v54 reader re-derives a stale pre-correction scalar-buffer bound");
+
     CHECK(serialize_gpu_capture(captured, malformed_scalar_bytes, error) &&
               !malformed_scalar_bytes.empty(),
           "v54 scalar-buffer truncation fixture serializes");


### PR DESCRIPTION
Refs #2528.

## Failure scenario

#2529 corrected the scalar `S_BUFFER` bound to the descriptor's byte footprint. That makes the
carried `scalar_buffer_dword_count` fully derivable from `size` — it now carries no independent
authority and can only ever be a marker plus a checksum.

Every v54 capsule written **before** that correction stores `NUM_RECORDS` there (or one dword for
`STRIDE == 0`), which disagrees with `size`. The reader validated the stored value and rejected the
whole file:

```
gpu_replay: <capsule>.prgcap: invalid scalar-buffer bound state
```

That permanently stranded every retained GTA V investigation capture, including the v54 handoff
capsule #2523 was built around and the `--retry-failed-stage` entry point its handoff names.

## Contract

Derive the authoritative bound on read; treat the stored dword as advisory and log the disagreement
under `PROSPER_DBG`. A mismatch **cannot widen a binding** — the derived span is exactly `size`
either way — so this repairs a redundant field rather than trusting a hostile one. Where the derived
value is zero (a sub-dword V#) the resource simply loses its scalar marker, which is the honest
result.

The **writer stays strict**: `serialize_gpu_capture` still fails with
`"invalid scalar-buffer bound metadata"` on an inconsistent bound, so prosper never emits one itself.
The short-snapshot invariant (`captured_size < binding_bytes`) is unchanged and still rejects.

## Verification

```
ctest --no-tests=error -j4     ->  241/241 passed, exit 0
git diff --check               ->  clean
```

The retained v54 capsule reopens and reproduces its terminal offline again:

```
[cfg-recompile-reject] mode=unresolved-operand pc=354 words=7e02026a len=1 fmt=7 op=0x1
                       stage=compute program=0x413d88400 role=terminal
```

## Test

`v54 reader re-derives a stale pre-correction scalar-buffer bound` mutates the **serialized** tail
dword rather than the in-memory object, so it exercises the reader's own path, and it asserts
`stale_patched` — if the v54 tail layout ever moves, the arm fails instead of silently passing.

## Risk

This is a hostile-input surface, so the change is deliberately narrow: it repairs exactly one field
that the corrected bound made redundant, and only in the direction that cannot grant authority. It
does not relax the captured-span check, the writer, or replay validation.
