### PR TITLE
gpu: bind a runtime-selected descriptor table as a descriptor array

### DIFF
--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -200,6 +200,12 @@ struct DynFetch {
 // The recompiler tags such a load's dest SGPRs with the load IMMEDIATE (sreg_srt) and resolves the
 // consumer via by_srt_offset(imm) — so `key` here is exactly that immediate, and build_stage_table
 // turns each use into a ShaderResource with srt_offset = key.
+// A Vulkan descriptor array costs one descriptor per element and every element's backing has to be
+// resolved and bound, so cap a runtime-selected table's declared arity well below the emitter's own
+// 4096 guard (#2481). The observed GTA V tables are five records; a vastly larger count is far more
+// likely a misread V# than a real table, and rejecting keeps that fail-visible.
+inline constexpr uint32_t kMaxSelectedTableRecords = 256u;
+
 struct SrtUse {
     int kind = 0;                    // 0 = texture, 1 = constant buffer, 2 = BVH buffer,
                                      // 3 = proven guarded null BVH
@@ -213,6 +219,17 @@ struct SrtUse {
     // This is diagnostic provenance only; resource lookup and materialization never consume it.
     uint64_t descriptor_source_addr = 0;
     std::array<uint32_t, 4> v4{};    // V# dwords as loaded (kind 1)
+    // RUNTIME-SELECTED descriptor table (#2481). Non-zero record count means this consumer's SRSRC
+    // was produced by a `s_buffer_load_dwordx4` through a bounded outer V# with a scalar offset the
+    // CPU fold cannot resolve, so the descriptor is one OF a declared table rather than a known set
+    // of words. `v4` is therefore NOT populated for such a use: the selection happens on the GPU.
+    // The stage builder binds all `table_record_count` entries and the emitter takes the index from
+    // the producer instruction's own live scalar value, so `table_load_pc` is authority, not a hint.
+    uint32_t table_record_count = 0;
+    uint32_t table_entry_stride = 0;
+    uint32_t table_element_offset = 0;
+    uint32_t table_load_pc = 0xFFFFFFFFu;
+    uint64_t table_base = 0;
     std::array<uint32_t, 4> bvh4{};  // BVH descriptor dwords live at IMAGE_BVH_INTERSECT_RAY (kind 2)
     uint32_t instruction_format = UINT32_MAX; // MTBUF BUF_FMT override for kind 1
     // Fully-known V# whose NUM_RECORDS is zero. This covers scalar buffer loads proven to begin beyond

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2725,6 +2725,23 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     std::unordered_map<uint32_t, uint32_t> scalar_spill_slots; // (VGPR << 6) | lane -> scalar value
     std::array<std::array<uint32_t, 4>, kFoldSgprs> descr{}; // load-time V# snapshots by base SGPR
     std::bitset<kFoldSgprs> descr_known;
+    // RUNTIME-SELECTED descriptor table (#2481). A `s_buffer_load_dwordx4` whose scalar offset the
+    // fold cannot resolve still names a descriptor that is one OF a bounded table, because the outer
+    // V# it reads through is fully known. The selected element is not knowable here — GTA V derives
+    // it from `v_readfirstlane` inside a waterfall loop, so it genuinely varies per wave — but the
+    // TABLE is, and that is what a Vulkan descriptor array binds. Record the producer so a later
+    // MUBUF consumer of these SGPRs can publish the whole declared table plus the exact instruction
+    // whose live scalar value selects within it. Deliberately kept apart from `descr`: that promises
+    // "the descriptor IS these words", this promises "the descriptor is one of these N".
+    struct FoldTableSource {
+        uint32_t load_pc = 0xFFFFFFFFu;
+        uint64_t base = 0;
+        uint32_t stride = 0;
+        uint32_t records = 0;
+        uint32_t element_offset = 0;   // byte offset of the V# inside each table record
+    };
+    std::array<FoldTableSource, kFoldSgprs> table_source{};
+    std::bitset<kFoldSgprs> table_source_known;
     // Descriptor-TABLE provenance (#294): for each snapshotted 4/8-dword s_load, the load's IMMEDIATE
     // byte offset — the recompiler's sreg_srt/by_srt_offset key. 0xFFFFFFFF = not provenance-usable
     // (register-SOFFSET or negative-immediate load, which emit_alu doesn't tag).
@@ -2841,6 +2858,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         if (valid_reg(r)) {
             val[(size_t)r] = v;
             val_known.set((size_t)r);
+            table_source_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
             descriptor_word_source_known.reset((size_t)r);
@@ -2859,6 +2877,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
             val_known.reset((size_t)r);
             val_srt_key_known.reset((size_t)r);
             val_seed_origin_known.reset((size_t)r);
+            table_source_known.reset((size_t)r);
             descriptor_word_source_known.reset((size_t)r);
             null_chain_known.reset((size_t)r);
             optional_null_role[(size_t)r] = OptionalNullRole::None;
@@ -2999,6 +3018,8 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         std::unordered_map<uint32_t, uint32_t> scalar_spill_slots;
         std::array<std::array<uint32_t, 4>, kFoldSgprs> descr;
         std::bitset<kFoldSgprs> descr_known;
+        std::array<FoldTableSource, kFoldSgprs> table_source;
+        std::bitset<kFoldSgprs> table_source_known;
         std::array<uint32_t, kFoldSgprs> descr_key;
         std::bitset<kFoldSgprs> descr_key_known;
         std::array<std::array<uint32_t, 8>, kFoldSgprs> descr8;
@@ -3047,6 +3068,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         s.val_srt_key = val_srt_key; s.val_srt_key_known = val_srt_key_known;
         s.scalar_spill_slots = scalar_spill_slots;
         s.descr = descr; s.descr_known = descr_known;
+        s.table_source = table_source; s.table_source_known = table_source_known;
         s.descr_key = descr_key; s.descr_key_known = descr_key_known;
         s.descr8 = descr8; s.descr8_known = descr8_known;
         s.descr8_key = descr8_key; s.descr8_key_known = descr8_key_known;
@@ -3067,6 +3089,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         val_srt_key = s.val_srt_key; val_srt_key_known = s.val_srt_key_known;
         scalar_spill_slots = s.scalar_spill_slots;
         descr = s.descr; descr_known = s.descr_known;
+        table_source = s.table_source; table_source_known = s.table_source_known;
         descr_key = s.descr_key; descr_key_known = s.descr_key_known;
         descr8 = s.descr8; descr8_known = s.descr8_known;
         descr8_key = s.descr8_key; descr8_key_known = s.descr8_key_known;
@@ -4063,6 +4086,43 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         forget(sdst + (int)k);
                         mark_null_origin(sdst + (int)k, null_base_origin);
                     }
+                    // #2481: the offset is unknown, but the OUTER V# is fully known and bounded, so
+                    // this x4 load names one entry of a declared descriptor table. Record that
+                    // provenance for the destination quad; a MUBUF consumer republishes it as a
+                    // table-indexed binding and the emitter selects with this instruction's own
+                    // runtime scalar value. `forget` above already cleared any stale entry, so this
+                    // runs after it. Every bound here is the guest's own declaration — never an
+                    // inferred one — and an element that does not fit its record rejects.
+                    if (is_buffer && n == 4u && live_sbase_vsharp_known &&
+                        valid_reg(sdst) && valid_reg(sdst + 3)) {
+                        const DecodedBufferDescriptor& outer = live_sbase_descriptor;
+                        const uint32_t element = in.literal;
+                        const bool bounded_table =
+                            outer.base > 0x10000u && outer.stride >= 16u &&
+                            outer.size_bytes != 0u &&
+                            outer.size_bytes % outer.stride == 0u &&
+                            static_cast<int32_t>(in.literal) >= 0 &&
+                            (element % 4u) == 0u &&
+                            static_cast<uint64_t>(element) + 16u <= outer.stride;
+                        const uint32_t records =
+                            bounded_table ? outer.size_bytes / outer.stride : 0u;
+                        if (bounded_table && records >= 1u && records <= kMaxSelectedTableRecords) {
+                            FoldTableSource source;
+                            source.load_pc = in.pc;
+                            source.base = outer.base;
+                            source.stride = outer.stride;
+                            source.records = records;
+                            source.element_offset = element;
+                            table_source[(size_t)sdst] = source;
+                            table_source_known.set((size_t)sdst);
+                            if (trc)
+                                fprintf(stderr,
+                                        "[dyntrace] selected-table pc=%u s%d base=0x%llx stride=%u "
+                                        "records=%u element=+0x%x\n",
+                                        in.pc, sdst, (unsigned long long)outer.base, outer.stride,
+                                        records, element);
+                        }
+                    }
                     break;
                 }
                 // in.literal is the SIGN-EXTENDED 21-bit immediate (#149) — add it as signed so a
@@ -4738,6 +4798,39 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                                 unk_valid ? forget_pc[(size_t)unk_reg] : 0xffffffffu,
                                 unk_valid ? forget_w0[(size_t)unk_reg] : 0u,
                                 unk_valid ? forget_w1[(size_t)unk_reg] : 0u);
+                    }
+                    // #2481: the SRSRC words are NOT known, but the fold proved they were produced
+                    // by an x4 scalar load of one element of a bounded descriptor table. Publish the
+                    // table itself; the emitter resolves the element at run time. Restricted to the
+                    // untyped load family the table-indexed emitter already admits — a typed fetch,
+                    // store or atomic through a selected descriptor needs per-entry treatment that
+                    // does not exist yet, and must keep failing visibly rather than binding element
+                    // zero. Note this is checked BEFORE `current_known`, which is false here by
+                    // construction: `forget` cleared those words when the offset proved dynamic.
+                    if (!current_known && srt_uses && valid_reg(srsrc) &&
+                        table_source_known.test((size_t)srsrc) &&
+                        in.fmt == Rdna2Format::MUBUF && !is_mtbuf &&
+                        (in.opcode == kMubufOpcodeLoadDword ||
+                         in.opcode == kMubufOpcodeLoadDwordX2 ||
+                         in.opcode == kMubufOpcodeLoadDwordX3 ||
+                         in.opcode == kMubufOpcodeLoadDwordX4)) {
+                        const FoldTableSource& source = table_source[(size_t)srsrc];
+                        SrtUse u;
+                        u.kind = 1;
+                        u.key = 0xFFFFFFFFu;
+                        u.use_pc = in.pc;
+                        u.table_record_count = source.records;
+                        u.table_entry_stride = source.stride;
+                        u.table_element_offset = source.element_offset;
+                        u.table_load_pc = source.load_pc;
+                        u.table_base = source.base;
+                        srt_uses->push_back(u);
+                        if (trc)
+                            fprintf(stderr,
+                                    "[dyntrace] MUBUF pc=%u selected-table s%d producer=%u "
+                                    "records=%u stride=%u element=+0x%x\n",
+                                    in.pc, srsrc, source.load_pc, source.records, source.stride,
+                                    source.element_offset);
                     }
                     if (current_known) {
                         // MUBUF/MTBUF itself is definitive that its four SRSRC words are a V#. Publish
@@ -5446,6 +5539,124 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             continue;
         }
         if (u.kind != 1) continue;
+        if (u.table_record_count) {
+            // #2481: a runtime-selected descriptor table. The element is chosen on the GPU, so the
+            // binding declares every entry and the emitter indexes it. Re-derive the whole contract
+            // from guest memory here rather than trusting the use: a forged SrtUse must not be able
+            // to name an arbitrary address range as a descriptor array.
+            const uint64_t table_key = 0x8000000600000000ull | u.use_pc;
+            if (!seen.insert(table_key).second) continue;
+            if (u.instruction_format != UINT32_MAX || u.zero_record_raw ||
+                u.table_entry_stride < 16u || u.table_record_count == 0u ||
+                u.table_record_count > kMaxSelectedTableRecords ||
+                static_cast<uint64_t>(u.table_element_offset) + 16u > u.table_entry_stride ||
+                (u.table_element_offset % 4u) != 0u || u.table_base <= 0x10000u ||
+                u.table_load_pc == 0xFFFFFFFFu || u.table_load_pc >= dwords)
+                continue;
+            // Every element must be a readable, individually valid V#. One malformed entry rejects
+            // the whole table: binding a partially populated descriptor array would let the guest's
+            // own index select a slot prosper never resolved, which renders confidently wrong
+            // content instead of failing visibly.
+            std::vector<ShaderBufferTableEntry> entries;
+            entries.reserve(u.table_record_count);
+            bool table_ok = true;
+            for (uint32_t index = 0; index < u.table_record_count && table_ok; ++index) {
+                const uint64_t entry_addr =
+                    u.table_base + static_cast<uint64_t>(index) * u.table_entry_stride +
+                    u.table_element_offset;
+                std::array<uint32_t, 4> words{};
+                if (!guest_readable(entry_addr, static_cast<uint32_t>(sizeof(words)))) {
+                    table_ok = false;
+                    break;
+                }
+                std::memcpy(words.data(),
+                            reinterpret_cast<const void*>(static_cast<uintptr_t>(entry_addr)),
+                            sizeof(words));
+                const DecodedBufferDescriptor entry = decode_buffer_descriptor(words.data());
+                if (entry.base <= 0x10000u || entry.size_bytes == 0u ||
+                    entry.size_bytes > 0x10000000u || entry.forbid_unknown_fallback) {
+                    table_ok = false;
+                    break;
+                }
+                ShaderBufferTableEntry slot;
+                slot.vsharp = words;
+                slot.gpu_addr = entry.base;
+                slot.size = entry.size_bytes;
+                slot.stride = entry.stride;
+                entries.push_back(slot);
+            }
+            if (!table_ok || entries.size() != u.table_record_count) {
+                if (std::getenv("PROSPER_DBG"))
+                    std::fprintf(stderr,
+                                 "[srt] selected-table pc=%u REJECTED base=0x%llx stride=%u "
+                                 "records=%u resolved=%zu\n",
+                                 u.use_pc, (unsigned long long)u.table_base, u.table_entry_stride,
+                                 u.table_record_count, entries.size());
+                continue;
+            }
+            // A descriptor array is ONE Vulkan binding, so its declared element stride, format and
+            // component count are shared by every entry — `valid_shader_buffer_table_contract`
+            // requires exactly that. Derive them from the entries and reject a heterogeneous table
+            // rather than picking one entry's shape and binding the rest through it.
+            const DecodedBufferDescriptor first =
+                decode_buffer_descriptor(entries.front().vsharp.data());
+            bool homogeneous = true;
+            uint32_t widest = 0u;
+            for (const ShaderBufferTableEntry& slot : entries) {
+                const DecodedBufferDescriptor entry =
+                    decode_buffer_descriptor(slot.vsharp.data());
+                homogeneous &= entry.stride == first.stride &&
+                               entry.format == first.format &&
+                               entry.num_components == first.num_components;
+                widest = std::max(widest, slot.size);
+            }
+            if (!homogeneous) {
+                if (std::getenv("PROSPER_DBG"))
+                    std::fprintf(stderr,
+                                 "[srt] selected-table pc=%u REJECTED heterogeneous entries\n",
+                                 u.use_pc);
+                continue;
+            }
+            ShaderResource r;
+            r.cls = ResourceClass::ConstantBuffer;
+            r.format = first.format;
+            r.num_components = first.num_components ? first.num_components : 1u;
+            // `gpu_addr` names the table so dependency closure and capture see the guest range the
+            // selection reads through; `size`/`stride` describe the ELEMENTS, because that is what
+            // the binding's descriptors are.
+            r.gpu_addr = u.table_base;
+            r.size = widest;
+            r.stride = first.stride;
+            r.srt_offset = 0xFFFFFFFFu;
+            r.sgpr_base = 0xFFFFFFFFu;
+            r.fetch_pc = u.use_pc;
+            r.table_index_count = u.table_record_count;
+            r.table_entry_stride = u.table_entry_stride;
+            r.table_selector_mode = BufferTableSelectorMode::DynamicSbufferByteOffset;
+            r.table_load_pc = u.table_load_pc;
+            r.table_entries = std::move(entries);
+            // Publish only a table the whole pipeline can actually honour. An invalid contract makes
+            // `declare_cbufs` poison the ENTIRE shader (`invalid_cbuf_array_access`), so publishing
+            // one optimistically would turn shaders that compile today into silent empty modules.
+            // Failing to publish costs exactly what the previous behaviour cost: an unresolved
+            // descriptor at the consumer, fail-visible.
+            if (!valid_shader_buffer_table_contract(r)) {
+                if (std::getenv("PROSPER_DBG"))
+                    std::fprintf(stderr,
+                                 "[srt] selected-table pc=%u REJECTED contract stride=%u fmt=%u "
+                                 "comps=%u\n",
+                                 u.use_pc, r.stride, (unsigned)r.format, r.num_components);
+                continue;
+            }
+            if (std::getenv("PROSPER_DBG"))
+                std::fprintf(stderr,
+                             "[srt] selected-table pc=%u producer=%u base=0x%llx stride=%u "
+                             "records=%u element=+0x%x\n",
+                             u.use_pc, u.table_load_pc, (unsigned long long)u.table_base,
+                             u.table_entry_stride, u.table_record_count, u.table_element_offset);
+            table.resources.push_back(r);
+            continue;
+        }
         if (u.use_pc == proven_linear_store_pc) continue;
         if (u.instruction_format != UINT32_MAX && ((u.v4[3] >> 12) & 0x7Fu) == 0)
             continue;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -408,6 +408,16 @@ struct SpirvCompute {
     // a live SSA value instead of a push constant. Absent means no producer has executed on this
     // path yet, which must keep failing visibly rather than silently selecting element zero.
     std::map<uint32_t, uint32_t> cbuf_table_selector_value;
+    // Label id of the block that emitted each selector above. A raw SSA id is only usable where the
+    // producer DOMINATES the consumer, and nothing here guarantees that: the CFG dispatcher emits
+    // one switch case per guest block, and sibling switch cases do not dominate one another (a
+    // structured if/endif has the same problem). Consuming across that boundary would emit an
+    // OpAccessChain against an id outside its dominance region -- malformed SPIR-V that `spirv-val`
+    // does not catch here for want of a representative module, surfacing instead as a dropped
+    // dispatch. Requiring producer and consumer to be the SAME block is the conservative subset
+    // that is always sound; carrying the value through a Function variable would lift the
+    // restriction and is the right long-term shape.
+    std::map<uint32_t, uint32_t> cbuf_table_selector_block;
     // binding -> user SGPR holding the descriptor index, when one is available.
     std::map<uint32_t, uint32_t> cbuf_table_index_sgpr;
     // Set when an array access cannot be represented exactly. The backend already refuses writable
@@ -2296,6 +2306,7 @@ struct SpirvCompute {
         auto arity = cbuf_table_arity.find(binding);
         auto index_sgpr = cbuf_table_index_sgpr.find(binding);
         auto live_selector = cbuf_table_selector_value.find(binding);
+        auto selector_block = cbuf_table_selector_block.find(binding);
         uint32_t ptr = id();
         if (arity != cbuf_table_arity.end()) {
             // A live GPU-computed selector takes precedence over the user-SGPR convention: the two
@@ -2303,7 +2314,14 @@ struct SpirvCompute {
             // push-constant home at all.
             const bool have_live_selector =
                 is_compute && arity->second <= 4096u &&
-                live_selector != cbuf_table_selector_value.end() && live_selector->second != 0;
+                live_selector != cbuf_table_selector_value.end() && live_selector->second != 0 &&
+                // Dominance, see cbuf_table_selector_block. Failing this leaves `have_live_selector`
+                // false and, since this mode never sets `table_index_sgpr`, drops through to
+                // `invalid_cbuf_array_access` below -- the module is discarded. That is exactly what
+                // the same shader does WITHOUT this feature (its MUBUF cannot resolve), so the guard
+                // cannot regress anything: it can only decline a case that was never sound.
+                selector_block != cbuf_table_selector_block.end() &&
+                selector_block->second == cur_block;
             // Only the compute shell declares the user-SGPR push-constant block. Graphics paths do
             // not currently have a runtime source for this selector, so emitting an access there
             // would manufacture type/variable id zero and an invalid module.
@@ -12728,6 +12746,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         continue;
                     b.cbuf_table_selector_value[resource.binding] =
                         b.ibin(Op_UDiv, soff_bits, b.uconst(resource.table_entry_stride));
+                    b.cbuf_table_selector_block[resource.binding] = b.cur_block;
                     if (getenv("PROSPER_DBG"))
                         fprintf(stderr,
                                 "[selected-table] producer pc=%u binding=%u stride=%u arity=%u\n",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -402,6 +402,12 @@ struct SpirvCompute {
     // single descriptor, so an access chain for it takes no leading index. Kept beside `cbuf_var`
     // because every consumer of the variable also needs to know whether it is an array.
     std::map<uint32_t, uint32_t> cbuf_table_arity;
+    // #2481: a DynamicSbufferByteOffset table's element index is not in user data — it is whatever
+    // the producing `s_buffer_load_dwordx4` had in its SOFFSET at run time. The emitter stores that
+    // already-divided index here when it lowers the producer, so `cbuf_element_ptr` can select with
+    // a live SSA value instead of a push constant. Absent means no producer has executed on this
+    // path yet, which must keep failing visibly rather than silently selecting element zero.
+    std::map<uint32_t, uint32_t> cbuf_table_selector_value;
     // binding -> user SGPR holding the descriptor index, when one is available.
     std::map<uint32_t, uint32_t> cbuf_table_index_sgpr;
     // Set when an array access cannot be represented exactly. The backend already refuses writable
@@ -2289,20 +2295,30 @@ struct SpirvCompute {
         if (array_valid) *array_valid = 0;
         auto arity = cbuf_table_arity.find(binding);
         auto index_sgpr = cbuf_table_index_sgpr.find(binding);
+        auto live_selector = cbuf_table_selector_value.find(binding);
         uint32_t ptr = id();
         if (arity != cbuf_table_arity.end()) {
+            // A live GPU-computed selector takes precedence over the user-SGPR convention: the two
+            // are different contracts, and a table whose index the guest derives on the GPU has no
+            // push-constant home at all.
+            const bool have_live_selector =
+                is_compute && arity->second <= 4096u &&
+                live_selector != cbuf_table_selector_value.end() && live_selector->second != 0;
             // Only the compute shell declares the user-SGPR push-constant block. Graphics paths do
             // not currently have a runtime source for this selector, so emitting an access there
             // would manufacture type/variable id zero and an invalid module.
-            if (!is_compute || arity->second > 4096u ||
+            if (!have_live_selector &&
+                (!is_compute || arity->second > 4096u ||
                 index_sgpr == cbuf_table_index_sgpr.end() ||
-                index_sgpr->second >= push_constant_dword_count) {
+                index_sgpr->second >= push_constant_dword_count)) {
                 invalid_cbuf_array_access = true;
                 putv(code, Op_AccessChain,
                      {t_ptr_sb_u32, ptr, buf, uconst(0), uconst(0), idx});
                 return ptr;
             }
-            const uint32_t selector = load_push_constant(index_sgpr->second);
+            const uint32_t selector = have_live_selector
+                ? live_selector->second
+                : load_push_constant(index_sgpr->second);
             const uint32_t valid = ucmp(Op_ULessThan, selector, uconst(arity->second));
             const uint32_t safe_selector = sel(valid, selector, uconst(0));
             if (array_valid) *array_valid = valid;
@@ -12696,6 +12712,29 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t loaded = b.cbuf_load(safe_index, binding);
                 return b.sel(in_bounds, loaded, b.uconst(0u));
             };
+            // #2481: this exact instruction is the producer of a runtime-selected descriptor table.
+            // Its SOFFSET is the byte offset of the chosen record, so the element index is
+            // SOFFSET / record-stride. Publish it as the live selector for that array binding before
+            // the consumer runs; the consumer is a later instruction on the same path, so the value
+            // dominates it. `cbuf_element_ptr` still range-checks the index against the declared
+            // arity, so an out-of-range runtime selector reads element zero rather than out of
+            // bounds -- and the front half proved every declared element is a valid descriptor.
+            if (rt && soff_dyn) {
+                for (const ShaderResource& resource : rt->resources) {
+                    if (resource.table_selector_mode !=
+                            BufferTableSelectorMode::DynamicSbufferByteOffset ||
+                        resource.table_load_pc != in.pc || resource.table_index_count == 0u ||
+                        resource.table_entry_stride == 0u)
+                        continue;
+                    b.cbuf_table_selector_value[resource.binding] =
+                        b.ibin(Op_UDiv, soff_bits, b.uconst(resource.table_entry_stride));
+                    if (getenv("PROSPER_DBG"))
+                        fprintf(stderr,
+                                "[selected-table] producer pc=%u binding=%u stride=%u arity=%u\n",
+                                in.pc, resource.binding, resource.table_entry_stride,
+                                resource.table_index_count);
+                }
+            }
             if (soff_dyn) {
                 // Dynamic dword index: (soffset + signed imm) >> 2 (uint add == two's-complement add).
                 uint32_t idx0 = b.ibin(Op_ShiftRightLogical,

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2634,6 +2634,95 @@ int main() {
               narrow_stride_sbuffer_plan.binding_bytes == 4u,
           "stride-1 S_BUFFER bounds its scalar dwords by the V# byte footprint");
 
+    // #2481: a RUNTIME-SELECTED descriptor table. GTA V's 0x413ce6000 picks a vertex buffer with
+    // `v_readfirstlane_b32 vcc_lo, v7` inside a waterfall loop, multiplies by the 120-byte record
+    // stride, and loads the chosen V# with `s_buffer_load_dwordx4 ..., vcc_lo offset:0x8`. The index
+    // is per-wave by construction, so the CPU fold cannot resolve it -- but the TABLE is fully
+    // declared by the outer V#, which is exactly what a Vulkan descriptor array binds. The MUBUF
+    // packet below is byte-identical to that title's pc156 consumer.
+    alignas(16) static uint32_t selected_table_payload[5][16]{};
+    for (uint32_t entry = 0; entry < 5u; ++entry)
+        for (uint32_t word = 0; word < 16u; ++word)
+            selected_table_payload[entry][word] = (entry << 16) | word;
+    alignas(16) static uint32_t selected_table_records[5][30]{};   // 5 records x 120 bytes
+    for (uint32_t entry = 0; entry < 5u; ++entry) {
+        const uint64_t payload = reinterpret_cast<uint64_t>(selected_table_payload[entry]);
+        // The selected V# lives at byte +8 of each record: base48, stride 16, four records.
+        selected_table_records[entry][2] = static_cast<uint32_t>(payload);
+        selected_table_records[entry][3] =
+            (static_cast<uint32_t>(payload >> 32) & 0xffffu) | (16u << 16);
+        selected_table_records[entry][4] = 4u;
+        // Conventional linear V#: DST_SEL identity (0xfac) and a Uint32 data format (code 20). The
+        // descriptor-array contract requires every entry to normalize back to exactly these words.
+        selected_table_records[entry][5] = 0xfacu | (20u << 12u);
+    }
+    const uint64_t selected_table_base = reinterpret_cast<uint64_t>(selected_table_records);
+    uint32_t selected_table_seed[16]{};
+    selected_table_seed[0] = static_cast<uint32_t>(selected_table_base);
+    selected_table_seed[1] =
+        (static_cast<uint32_t>(selected_table_base >> 32) & 0xffffu) | (120u << 16);
+    selected_table_seed[2] = 5u;                      // NUM_RECORDS -> a five-entry table
+    selected_table_seed[3] = 0u;
+    const std::array<uint32_t, 8> selected_table_shader = {
+        0x7ed40500u,               // pc0: v_readfirstlane_b32 vcc_lo, v0  (per-lane -> unknowable)
+        0xb86a0078u,               // pc1: s_mulk_i32 vcc_lo, 0x78         (index * record stride)
+        0xf4280200u, 0xd4000008u,  // pc2: s_buffer_load_dwordx4 s[8:11], s[0:3], vcc_lo offset:0x8
+        0xbf8cc07fu,               // pc4: s_waitcnt lgkmcnt(0)
+        0xe0382000u, 0x80020006u,  // pc5: buffer_load_dwordx4 v[0:3], v6, s[8:11], 0 idxen
+        0xbf810000u,               // pc7: s_endpgm
+    };
+    ShaderResourceTable selected_table_rt;
+    add_compute_buffer_resources(
+        selected_table_rt, selected_table_shader.data(), selected_table_shader.size(),
+        selected_table_seed, std::size(selected_table_seed));
+    assign_convention_bindings(selected_table_rt, 2);
+    const ShaderResource* selected_table_resource = selected_table_rt.by_fetch_pc(5u);
+    ComputeShaderConfig selected_table_config;
+    selected_table_config.user_sgprs.assign(
+        selected_table_seed, selected_table_seed + std::size(selected_table_seed));
+    selected_table_config.local_x = selected_table_config.local_y =
+        selected_table_config.local_z = 1;
+    const std::vector<uint32_t> selected_table_spirv = recompile_compute(
+        selected_table_shader.data(), selected_table_shader.size(), &selected_table_rt,
+        selected_table_config);
+    bool selected_table_entries_exact = selected_table_resource &&
+        selected_table_resource->table_entries.size() == 5u;
+    if (selected_table_entries_exact)
+        for (uint32_t entry = 0; entry < 5u; ++entry)
+            selected_table_entries_exact &=
+                selected_table_resource->table_entries[entry].gpu_addr ==
+                    reinterpret_cast<uint64_t>(selected_table_payload[entry]) &&
+                selected_table_resource->table_entries[entry].size == 64u &&
+                selected_table_resource->table_entries[entry].stride == 16u;
+    CHECK(selected_table_resource &&
+              selected_table_resource->table_index_count == 5u &&
+              selected_table_resource->table_entry_stride == 120u &&
+              selected_table_resource->table_selector_mode ==
+                  BufferTableSelectorMode::DynamicSbufferByteOffset &&
+              selected_table_resource->table_load_pc == 2u &&
+              selected_table_entries_exact && !selected_table_spirv.empty(),
+          "a dynamic scalar offset publishes its whole declared descriptor table");
+
+    // Same-site mutation: shrink the outer V# so the element at +8 no longer fits inside one
+    // record. The selection is then not expressible as an array index and must fail visibly rather
+    // than binding a differently-shaped table.
+    uint32_t selected_table_short_seed[16]{};
+    std::memcpy(selected_table_short_seed, selected_table_seed, sizeof(selected_table_seed));
+    selected_table_short_seed[1] =
+        (static_cast<uint32_t>(selected_table_base >> 32) & 0xffffu) | (16u << 16);
+    ShaderResourceTable selected_table_short_rt;
+    add_compute_buffer_resources(
+        selected_table_short_rt, selected_table_shader.data(), selected_table_shader.size(),
+        selected_table_short_seed, std::size(selected_table_short_seed));
+    const ShaderResource* selected_table_short_resource =
+        selected_table_short_rt.by_fetch_pc(5u);
+    // The producer's own outer-V# use must still be published, so this arm cannot pass merely
+    // because the fold stopped walking: it distinguishes "declined the table" from "saw nothing".
+    CHECK(selected_table_short_rt.by_fetch_pc(2u) != nullptr &&
+              (!selected_table_short_resource ||
+               selected_table_short_resource->table_index_count == 0u),
+          "an element that does not fit its record publishes no descriptor table");
+
     // GTA V's 0x413ce6000/0x413ce6d00 programs load a four-dword V# through an S_BUFFER_LOAD whose
     // VCC-derived SOFFSET is intentionally unknown to this CPU fold. The outer V# is fully known and
     // has NUM_RECORDS=0, while the positive immediate begins beyond its effective scalar bound: publish


### PR DESCRIPTION
Refs #2481. **Stacked on #2531** — that PR's commit is the first of the two here; review/merge it first
and this diff reduces to the second commit.

## What this closes

`shader_resources.hpp:263` has named the gap since #2412: the descriptor-array representation is
complete end to end — declared arity, `valid_shader_buffer_table_contract`, capture, dependency
closure, and the SPIR-V `OpTypeArray %Block N` binding with a NonUniform selector — but
`BufferTableSelectorMode::DynamicSbufferByteOffset` had **no production producer**, and the emitter's
only selector source was a user-SGPR push constant. That field's own comment says it *"deliberately
does NOT cover GTA V's own case, where the index is derived from EXEC on the GPU."*

That case is `0x413ce6000`:

```
144  v_readfirstlane_b32 vcc_lo, v7                              ; waterfall: first active lane's index
146  v_cmpx_eq_u32_e32 vcc_lo, v7                                ; EXEC &= lanes sharing it
149  s_mulk_i32 vcc_lo, 0x78                                     ; index * 120-byte record stride
150  s_load_dwordx4 s[4:7], s[0:1], 0xa8                         ; the table V# (600 bytes, 5 records)
153  s_buffer_load_dwordx4 s[8:11], s[4:7], vcc_lo offset:0x8    ; the V# at record[index] + 8
156  buffer_load_dwordx4 v[0:3], v6, s[8:11], 0 idxen            ; <-- the terminal
```

The index is per-wave by construction, so no CPU fold can produce it. The **table** is fully declared
by the outer V#, and that is what a descriptor array binds.

## Approach

- **Fold**: at an x4 scalar load whose offset is dynamic but whose outer V# is fully known and
  bounded, record the table's base/stride/record-count/element-offset against the destination quad.
  Kept apart from `descr`, which promises "the descriptor IS these words"; this promises "the
  descriptor is one of these N". Invalidated by `forget`/`set_value` and carried through the fold's
  branch snapshot like every other per-SGPR fact.
- **Consumer**: a raw MUBUF load through those SGPRs republishes the table with its own pc. Typed
  fetches, stores and atomics are excluded — the table-indexed emitter already rejects them, and they
  need per-entry treatment that does not exist.
- **Builder**: re-derives the whole contract from guest memory rather than trusting the use, resolves
  every element, and requires the table to be homogeneous (one Vulkan binding has one element stride,
  format and component count).
- **Emitter**: the producer instruction publishes `SOFFSET / record-stride` as the binding's live
  selector, and `cbuf_element_ptr` prefers it over the push-constant convention. `cbuf_element_ptr`
  still range-checks against the declared arity, and the front half proved every declared element is
  a valid descriptor.

## Safety

The important property is that this **cannot regress a shader that compiles today**. An invalid table
contract makes `declare_cbufs` set `invalid_cbuf_array_access`, which discards the entire module — so
an optimistic publish would turn working shaders into silent empty modules. The builder therefore runs
`valid_shader_buffer_table_contract` itself and declines to publish when it fails. Declining costs
exactly what today costs: an unresolved descriptor at the consumer, fail-visible.

Also declined: a heterogeneous table, an element that does not fit its record, an unreadable or
malformed entry, a base at or below 64 KiB, an entry beyond the 256 MiB ceiling, and an arity above
`kMaxSelectedTableRecords` (256, well under the emitter's 4096 guard — the observed tables are 5).

## Tests

`a dynamic scalar offset publishes its whole declared descriptor table` builds a real 5-record table
in host memory behind a real V#, drives it with the **byte-identical GTA V pc156 MUBUF packet**
(`e0382000, 80020006`), and asserts the published arity, stride, selector mode, producer pc and all
five resolved entries — then that the shader recompiles (893 SPIR-V dwords), which exercises the
emitter's live-selector path.

The mutation arm shrinks the outer V# so the element no longer fits one record, and asserts the table
is declined **while the producer's own outer-V# use is still published** — so it distinguishes
"declined the table" from "the fold saw nothing", which is how that arm could otherwise pass
vacuously.

## What this does NOT yet do

GTA V's own tables are still declined, and the reason is now exact: their entries carry `DST_SEL`
`0x3ac` (XYZ1, three-component) where `valid_shader_buffer_table_contract` requires the identity
`0xfac`. DST_SEL is **inert** for the raw untyped loads this path admits — the emitter already notes
that untyped ops move raw dwords regardless of the V#'s declared format — so the relaxation looks
straightforward, but it widens a contract that guards descriptor identity and belongs in its own
reviewed change rather than bundled here.

So this does not by itself make `0x413ce6000` compile. It makes the mechanism exist, generically, with
the remaining constraint named.

## Verification

```
ctest --no-tests=error -j4     ->  242/242 passed, exit 0
git diff --check               ->  clean
```
