### PR TITLE
gpu: let a raw-only selected table carry a three-component DST_SEL

### DIFF
--- a/prosper/src/gpu/shader_resources.cpp
+++ b/prosper/src/gpu/shader_resources.cpp
@@ -207,6 +207,15 @@ bool valid_shader_buffer_table_contract(const ShaderResource& resource) {
             return false;
     }
 
+    // DST_SEL is a FORMAT-fetch control: it names which component each returned channel takes. The
+    // dynamic-scalar-offset selection is admitted for untyped loads only — the emitter rejects a
+    // typed fetch, store or atomic through a selected descriptor — and an untyped load moves raw
+    // dwords regardless of the descriptor's declared swizzle. So for that mode the swizzle cannot
+    // decide whether the table is bindable, while the user-SGPR mode, whose consumers may be typed,
+    // keeps requiring the identity mapping. GTA V's tables are three-component (0x3ac, X/Y/Z/1);
+    // requiring 0xfac rejected every one of them for a field none of their consumers reads (#2481).
+    const bool raw_only_selection =
+        resource.table_selector_mode == BufferTableSelectorMode::DynamicSbufferByteOffset;
     for (const ShaderBufferTableEntry& entry : resource.table_entries) {
         const uint64_t decoded_addr =
             (static_cast<uint64_t>(entry.vsharp[0]) |
@@ -236,7 +245,7 @@ bool valid_shader_buffer_table_contract(const ShaderResource& resource) {
              (entry.stride != resource.stride ||
               decoded_format != resource.format ||
               decoded_components != resource.num_components ||
-              dst_sel != 0xfacu)) ||
+              (dst_sel != 0xfacu && !raw_only_selection))) ||
             (null_descriptor && dst_sel != 0u && dst_sel != 0xfacu) ||
             (!entry.host_data && entry.host_data_size != 0u) ||
             (entry.host_data && entry.host_data_size < entry.size))

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2703,6 +2703,41 @@ int main() {
               selected_table_entries_exact && !selected_table_spirv.empty(),
           "a dynamic scalar offset publishes its whole declared descriptor table");
 
+    // GTA V's real tables carry DST_SEL 0x3ac (X,Y,Z,1) rather than the identity 0xfac, because the
+    // selected buffers are three-component. Every consumer this path admits is an UNTYPED load, for
+    // which DST_SEL and the data format are inert -- the emitter states that untyped ops move raw
+    // dwords regardless of the V#'s declared format -- so the swizzle must not decide whether the
+    // table can be bound at all. Same table, same shader, only the selector word differs.
+    alignas(16) static uint32_t selected_table_xyz1[5][30]{};
+    std::memcpy(selected_table_xyz1, selected_table_records, sizeof(selected_table_records));
+    for (uint32_t entry = 0; entry < 5u; ++entry)
+        selected_table_xyz1[entry][5] = 0x3acu | (20u << 12u);
+    const uint64_t selected_table_xyz1_base = reinterpret_cast<uint64_t>(selected_table_xyz1);
+    uint32_t selected_table_xyz1_seed[16]{};
+    std::memcpy(selected_table_xyz1_seed, selected_table_seed, sizeof(selected_table_seed));
+    selected_table_xyz1_seed[0] = static_cast<uint32_t>(selected_table_xyz1_base);
+    selected_table_xyz1_seed[1] =
+        (static_cast<uint32_t>(selected_table_xyz1_base >> 32) & 0xffffu) | (120u << 16);
+    ShaderResourceTable selected_table_xyz1_rt;
+    add_compute_buffer_resources(
+        selected_table_xyz1_rt, selected_table_shader.data(), selected_table_shader.size(),
+        selected_table_xyz1_seed, std::size(selected_table_xyz1_seed));
+    assign_convention_bindings(selected_table_xyz1_rt, 2);
+    const ShaderResource* selected_table_xyz1_resource =
+        selected_table_xyz1_rt.by_fetch_pc(5u);
+    ComputeShaderConfig selected_table_xyz1_config = selected_table_config;
+    selected_table_xyz1_config.user_sgprs.assign(
+        selected_table_xyz1_seed,
+        selected_table_xyz1_seed + std::size(selected_table_xyz1_seed));
+    const std::vector<uint32_t> selected_table_xyz1_spirv = recompile_compute(
+        selected_table_shader.data(), selected_table_shader.size(), &selected_table_xyz1_rt,
+        selected_table_xyz1_config);
+    CHECK(selected_table_xyz1_resource &&
+              selected_table_xyz1_resource->table_index_count == 5u &&
+              selected_table_xyz1_resource->table_entries.size() == 5u &&
+              !selected_table_xyz1_spirv.empty(),
+          "a three-component DST_SEL still binds its descriptor table for untyped loads");
+
     // Same-site mutation: shrink the outer V# so the element at +8 no longer fits inside one
     // record. The selection is then not expressible as an array index and must fail visibly rather
     // than binding a differently-shaped table.


### PR DESCRIPTION
Refs #2481. **Stacked on #2532** (which is stacked on #2531) — review those first; this PR's own diff
is its final commit.

## What this changes

`valid_shader_buffer_table_contract` required every descriptor-array entry to carry the identity
`DST_SEL` (`0xfac`). GTA V's selected buffers are three-component and carry `0x3ac` (X/Y/Z/1), so
**every one of its tables was rejected** for a field none of their consumers reads.

`DST_SEL` is a format-fetch control: it names which component each returned channel takes. The
dynamic-scalar-offset selection introduced by #2532 is admitted for **untyped loads only** — the
emitter rejects a typed fetch, store or atomic through a selected descriptor — and an untyped load
moves raw dwords regardless of the descriptor's declared swizzle. So for that mode the swizzle cannot
decide whether the table is bindable. The user-SGPR selection mode, whose consumers may be typed,
keeps requiring the identity mapping.

## Test

The new arm differs from the one above it **only in the selector word** — same table, same shader,
same everything else — so it isolates `DST_SEL` from the rest of the contract. It fails before this
change and passes after.

## Live result

Routed Story Mode at this branch tip. The mechanism now fires on GTA V's exact shape:

```
[srt] selected-table pc=156 producer=153 base=0x203f339b38 stride=120 records=5 element=+0x8
[srt] selected-table pc=158 producer=153 ...
```

`pc=156` and `pc=158` are precisely the two consumers of `0x413ce6000`'s waterfall selection, and
`pc=153` is its `s_buffer_load_dwordx4`. **26 tables were bound live.**

## What it does not do, and the exact next step

The world is still black and `0x413dc6700` still loses the device. `0x413ce6000` still reports one
terminal at `pc=156`, because **50 of the 76 attempts declined with `resolved=0`** — the entry
descriptors were not `guest_readable` at fold time:

```
[srt] selected-table pc=156 REJECTED base=0x203f339b38 stride=120 records=5 resolved=0
```

The tables are per-frame ring allocations (their bases walk upward, all ending `9b38`), and roughly a
third of them resolve. Declining is the correct behaviour — a partially populated descriptor array
would let the guest's own index select a slot prosper never resolved, which renders confidently wrong
content instead of failing visibly — but the *cause* of the unreadability is not yet established.

That is the next step, and it needs one diagnostic that reports which entry failed and whether the
table base itself was readable, rather than another guess. I have deliberately not speculated about it
here.

## Verification

```
ctest --no-tests=error -j4     ->  242/242 passed, exit 0
git diff --check               ->  clean
```
