### PR TITLE
gpu: an empty V# publishes no resource-level scalar bound

### DIFF
--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2552,6 +2552,15 @@ static uint32_t validated_scalar_buffer_dword_count(
         const SrtUse& use, const DecodedBufferDescriptor& descriptor,
         const uint32_t* code, size_t dwords) {
     if (!use.scalar_buffer_dword_count) return 0u;
+    // An EMPTY V# carries no resource-level scalar bound. `scalar_buffer_dword_count` still answers
+    // one dword for the stride-zero empty case, because eece6f84's fold specialization is about
+    // whether a given access is provably out of range — but a RESOURCE built from that descriptor
+    // has `size == 0`, and a carried count of one then contradicts its own footprint. #2529 made
+    // `shader_resource_buffer_binding_bytes` authenticate the count against `size`, which turned
+    // that contradiction into a hard rejection: every GTA V compute capture failed to write with
+    // "invalid scalar-buffer bound metadata", losing the capture/replay tool entirely on that title.
+    // The empty descriptor's zero semantics are carried by `zero_record_raw`, not by this field.
+    if (descriptor.size_bytes == 0u) return 0u;
     if (use.kind != 1 || use.instruction_format != UINT32_MAX || use.use_pc >= dwords)
         return 0u;
     const Rdna2Inst consumer = rdna2_decode_one(code + use.use_pc, dwords - use.use_pc);

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2671,6 +2671,44 @@ int main() {
         zero_record_sbuffer_seed + std::size(zero_record_sbuffer_seed));
     zero_record_sbuffer_config.local_x = zero_record_sbuffer_config.local_y =
         zero_record_sbuffer_config.local_z = 1;
+    // #2528: an EMPTY V# with a REAL BASE must not carry a resource-level scalar bound. `size` is
+    // zero for such a resource, so a carried count of one contradicts its own footprint — and since
+    // #2529 made `shader_resource_buffer_binding_bytes` authenticate the count against `size`, that
+    // contradiction is a hard rejection. This is precisely the invariant the capture writer enforces
+    // before serializing, and violating it made every GTA V compute capture fail to write with
+    // "invalid scalar-buffer bound metadata", losing capture/replay on the title entirely.
+    //
+    // The base must be real: a zero-base V# is discarded by the builder long before any scalar bound
+    // is considered, so a fixture built on one asserts over an empty resource list and cannot fail.
+    alignas(16) static uint32_t empty_bound_backing[4] = {1u, 2u, 3u, 4u};
+    const uint64_t empty_bound_base = reinterpret_cast<uint64_t>(empty_bound_backing);
+    uint32_t empty_bound_seed[8]{};
+    empty_bound_seed[4] = static_cast<uint32_t>(empty_bound_base);
+    empty_bound_seed[5] = static_cast<uint32_t>(empty_bound_base >> 32) & 0xffffu;  // stride 0
+    empty_bound_seed[6] = 0u;                                                       // NUM_RECORDS 0
+    empty_bound_seed[7] = 0u;
+    // Immediate ZERO, unlike the chain above: with a positive immediate the fold proves the access
+    // wholly out of range and takes the zero-record marker path, which never attaches a scalar bound
+    // — so that shape cannot exercise this invariant at all.
+    const uint32_t empty_bound_chain[] = {
+        0x7ed40500u,              // v_readfirstlane_b32 vcc_lo, v0  (fold-unknown SOFFSET)
+        0xf4280202u, 0xd4000000u, // s_buffer_load_dwordx4 s[8:11], s[4:7], vcc_lo offset:0
+        0xe0382000u, 0x80020006u, // buffer_load_dwordx4 v[0:3], v6, s[8:11], 0
+        0xbf810000u,
+    };
+    ShaderResourceTable empty_bound_table;
+    add_compute_buffer_resources(empty_bound_table, empty_bound_chain,
+                                 std::size(empty_bound_chain), empty_bound_seed,
+                                 std::size(empty_bound_seed));
+    bool empty_bound_consistent = true;
+    for (const ShaderResource& resource : empty_bound_table.resources)
+        empty_bound_consistent &=
+            !resource.scalar_buffer_dword_count ||
+            shader_resource_buffer_binding_bytes(resource) != 0u;
+    CHECK(empty_bound_consistent,
+          "an empty V# publishes no scalar-buffer bound the capture writer would reject");
+
+
     const std::vector<uint32_t> zero_record_sbuffer_spirv = recompile_compute(
         zero_record_sbuffer_chain, std::size(zero_record_sbuffer_chain),
         &zero_record_sbuffer_table, zero_record_sbuffer_config);


### PR DESCRIPTION
Refs #2528. **Against master, not stacked** — this is a regression fix for merged code and should go
in ahead of the #2531-#2534 stack.

## Failure scenario

#2529 made `shader_resource_buffer_binding_bytes` authenticate a resource's carried
`scalar_buffer_dword_count` against its own `size`. An **empty V# with a real base** produces
`size == 0`, while `scalar_buffer_dword_count` still answers **one** dword for the stride-zero case —
so the resource contradicts itself and authentication returns 0.

The capture writer enforces exactly that invariant before serializing:

```
[gpucap] captured deferred submit 3622: 0 draws, 2735 computes, 2975 operations, 240 failures
[gpucap] write failed: invalid scalar-buffer bound metadata
```

**Every GTA V compute capture failed to write.** That loses capture and replay on the title
completely, which is the primary investigation tool for #2481 — and it is how I found this: a fresh
capture at the current tip produced no file at all.

## Contract

`eece6f84`'s one-dword answer is a **fold specialization** about whether a given access is provably
out of range. It is not a resource bound. A resource built from an empty descriptor carries no scalar
bound at all; its zero semantics travel on `zero_record_raw`, which is unchanged.

So `validated_scalar_buffer_dword_count` returns 0 for a descriptor whose `size_bytes` is zero. The
fold's own OOB specialization is untouched — it calls `scalar_buffer_dword_count` directly.

## After

The same routed capture now writes a 100 MB capsule and reopens.

## Test — and two fixtures that could not fail

`an empty V# publishes no scalar-buffer bound the capture writer would reject` asserts the writer's
own invariant over every published resource. It needs two properties that are easy to get wrong, and
I got both wrong before checking:

- **A real base.** A zero-base V# is discarded by the builder long before any scalar bound is
  considered, so the assertion loops over an empty resource list. My first fixture did this and
  passed with the fix reverted.
- **A ZERO immediate.** With a positive immediate the fold proves the access wholly out of range and
  takes the zero-record marker path, which never attaches a bound. My second fixture did this and
  also passed with the fix reverted.

Verified in both directions on the final fixture: passes with the fix, and

```
[FAIL] an empty V# publishes no scalar-buffer bound the capture writer would reject
```

with it reverted.

## Verification

```
ctest --no-tests=error -j4     ->  241/241 passed, exit 0
git diff --check               ->  clean
```
