### PR TITLE
capture: let a compute failure carry compute state, and enumerate candidates

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -6028,14 +6028,27 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
         // because `candidate_draw_count` is the DRAW count and a compute-only submit has none. Before
         // this line the only way to reach the later phase was to re-run with successive AT values and
         // inspect each capsule, at one routed run apiece (#2481).
-        if (std::getenv("PROSPER_GPU_CAPTURE_LOG"))
+        if (std::getenv("PROSPER_GPU_CAPTURE_LOG")) {
+            // The widest viewport any draw in this submit uses. A draw COUNT cannot tell a main-view
+            // pass from a shadow pass — shadow atlases have high draw counts and share the main
+            // target's dimensions, differing only in viewport — so a census without this cannot be
+            // aimed at "the submit that draws the world" (#2481).
+            float widest_w = 0.0f, widest_h = 0.0f;
+            for (const DrawItem& draw : draws) {
+                if (!draw.ps.has_viewport) continue;
+                const float w = draw.ps.viewport_w < 0.0f ? -draw.ps.viewport_w : draw.ps.viewport_w;
+                const float h = draw.ps.viewport_h < 0.0f ? -draw.ps.viewport_h : draw.ps.viewport_h;
+                if (w * h > widest_w * widest_h) { widest_w = w; widest_h = h; }
+            }
             std::fprintf(stderr,
                          "[gpucap] candidate at=%llu submit=%llu draws=%zu computes=%zu "
-                         "semantic-dispatches=%zu%s\n",
+                         "semantic-dispatches=%zu viewport=%.0fx%.0f%s\n",
                          static_cast<unsigned long long>(current),
                          static_cast<unsigned long long>(submit_no), draws.size(), computes.size(),
                          semantic_state ? semantic_state->dispatches.size() : size_t{0},
+                         widest_w, widest_h,
                          claimed.load() ? " (already claimed)" : "");
+        }
         if (!output_triggered) {
             uint64_t wanted = 0;
             if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -2065,7 +2065,16 @@ bool capture_failure_diagnostics(
             stage.first_descriptor_issue = runtime_stage.first_descriptor_issue;
             stage.recompile_config = runtime_stage.recompile_config;
             stage.recompile_config_available = runtime_stage.recompile_config_available;
-            if (!capture_table(runtime_stage.resources.get(), {}, false, false,
+            // A retained COMPUTE failure carries compute state, including any packed-pointer or
+            // indirect-relocation marker its table acquired before the dispatch failed. The guard
+            // exists to keep compute-only state out of GRAPHICS tables — its own message says
+            // "only valid for a compute dispatch" — and passing false unconditionally here rejected
+            // exactly the case it is meant to permit. GTA V's later 234-dispatch submit could not be
+            // captured at all because of it, which is the phase its remaining device loss lives in
+            // (#2481). The realized-compute table at the other call site already allows this.
+            const bool compute_stage =
+                runtime_stage.stage == ShaderProgramStage::Compute;
+            if (!capture_table(runtime_stage.resources.get(), {}, false, compute_stage,
                                stage.resource_table, error)) return false;
             if (!capture_raw_shader_version(stage.program_addr, reader, capture, raw_words,
                                             raw_shader_index_by_address,
@@ -6006,6 +6015,21 @@ std::unique_ptr<PendingGpuCapture> begin_requested_gpu_capture(
         if (candidate_draw_count < min_draws || candidate_draw_count > max_draws) return {};
         static std::atomic<uint64_t> sequence{0}; static std::atomic<bool> claimed{false};
         current = sequence.fetch_add(1);
+        // Enumerate every submit that PASSED the selectors, so `PROSPER_GPU_CAPTURE_AT` can be aimed
+        // at a specific phase instead of guessed. A title reruns one compute program across wildly
+        // different populations — GTA V's `0x413dc6700` appears in an early 2,735-dispatch submit and
+        // again in a later ~234-dispatch one — and `MIN_DRAWS`/`MAX_DRAWS` cannot separate them,
+        // because `candidate_draw_count` is the DRAW count and a compute-only submit has none. Before
+        // this line the only way to reach the later phase was to re-run with successive AT values and
+        // inspect each capsule, at one routed run apiece (#2481).
+        if (std::getenv("PROSPER_GPU_CAPTURE_LOG"))
+            std::fprintf(stderr,
+                         "[gpucap] candidate at=%llu submit=%llu draws=%zu computes=%zu "
+                         "semantic-dispatches=%zu%s\n",
+                         static_cast<unsigned long long>(current),
+                         static_cast<unsigned long long>(submit_no), draws.size(), computes.size(),
+                         semantic_state ? semantic_state->dispatches.size() : size_t{0},
+                         claimed.load() ? " (already claimed)" : "");
         if (!output_triggered) {
             uint64_t wanted = 0;
             if (const char* at = std::getenv("PROSPER_GPU_CAPTURE_AT")) wanted = std::strtoull(at, nullptr, 0);

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -2192,6 +2192,12 @@ const char* realization_failure_reason_name(RealizationFailureReason reason) {
         case RealizationFailureReason::RetainedDrawNotSelected: return "retained-draw-not-selected";
         case RealizationFailureReason::IndirectArguments: return "indirect-arguments";
         case RealizationFailureReason::IndirectDependencies: return "indirect-dependencies";
+        case RealizationFailureReason::ComputeBackendUnavailable:
+            return "compute-backend-unavailable";
+        case RealizationFailureReason::SuspiciousDispatchSkipped:
+            return "suspicious-dispatch-skipped";
+        case RealizationFailureReason::ComputeExecutionDeclined:
+            return "compute-execution-declined";
     }
     return "unknown";
 }

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -599,13 +599,17 @@ enum class RealizationFailureReason : uint8_t {
     // Unknown because "nothing was attempted, and here is why" is the answer an investigation needs
     // (#1636) — collapsing them to Unknown is indistinguishable from the reason being lost.
     RetainedDrawNotSelected,   // the retained-submit policy did not select this draw index
-    IndirectArguments,         // indirect DRAW arguments could not be resolved. Dispatches
-                               // have the same failure but realize_retained_compute still
-                               // returns a bare false for it, so they remain Unknown.
+    IndirectArguments,         // indirect DRAW or DISPATCH arguments could not be resolved --
+                               // a null, misaligned or unreadable argument address
     IndirectDependencies,      // an indirect operation's producer had not landed for this submit
+    ComputeBackendUnavailable, // the dispatch was ready, but no live compute backend is installed
+    SuspiciousDispatchSkipped, // the parent-walk diagnostic deliberately skipped this dispatch
+    ComputeExecutionDeclined,  // realized and submitted, but the live compute backend declined it
+                               // (an unsupported format, an unresolved binding, a skipped image);
+                               // the backend's own reason is on its `[compute] skip` line
 };
 inline constexpr RealizationFailureReason kMaxRealizationFailureReason =
-    RealizationFailureReason::IndirectDependencies;
+    RealizationFailureReason::ComputeExecutionDeclined;
 
 // Capture-facing facts collected at the exact point an operation is dropped. These contain no raw
 // shader bytes; gpu_capture reads those through its fault-safe, size-bounded memory reader.

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -7674,7 +7674,14 @@ std::vector<ComputeItem> realize_compute_dispatches(
         const bool indirect_pointer_valid = discover_rdna2_indirect_pointer_relocations(
             reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
             shader_dwords, config, *table);
-        if (indirect_pointer_valid && std::getenv("PROSPER_DBG")) {
+        // Report the DECLINE as well as the success, and name the program in both. Printing only
+        // successes made a declined proof indistinguishable from a program the analyzers were never
+        // offered, and the line carried no address, so a run's several hundred records could not be
+        // attributed to any shader at all. Both gaps cost real time on #2481: GTA V's
+        // `0x413d14100` is byte-for-byte the StaticFootprint analyzer's own 386-dword target and
+        // still rejects at its GLOBAL consumer, and nothing in the log said whether the analyzer
+        // had declined it or matched and failed during discovery.
+        if (std::getenv("PROSPER_DBG")) {
             const auto source_it = std::find_if(
                 table->resources.begin(), table->resources.end(),
                 is_indirect_pointer_relocation_resource);
@@ -7684,8 +7691,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 ? source->indirect_pointer_relocation
                 : IndirectPointerRelocationBinding{};
             std::fprintf(stderr,
-                         "[indirect-pointer-relocation] valid=1 records=%u segments=%u "
-                         "source-bytes=%llu binding-bytes=%u\n",
+                         "[indirect-pointer-relocation] program=0x%llx valid=%d records=%u "
+                         "segments=%u source-bytes=%llu binding-bytes=%u\n",
+                         static_cast<unsigned long long>(code_addr),
+                         static_cast<int>(indirect_pointer_valid),
                          marker.record_count, marker.segment_count,
                          static_cast<unsigned long long>(source ? source->size : 0u),
                          marker.binding_bytes);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9490,9 +9490,12 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         ComputeAuthorityBoundaryKind::Compute,
                         submit_no, operation.command_order);
                     if (capture_trace) {
+                        // A dispatch's indirect arguments fail exactly as a draw's do; recording it
+                        // as Unknown was the documented gap in the reason enum, not a distinct case.
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
-                            operation.command_order, RealizationFailureReason::Unknown});
+                            operation.command_order,
+                            RealizationFailureReason::IndirectArguments});
                     }
                     producer_epoch_ok = false;
                     previous_compute_code = current_compute_code;
@@ -9505,9 +9508,13 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         ComputeAuthorityBoundaryKind::Compute,
                         submit_no, operation.command_order);
                     if (capture_trace) {
+                        // The dispatch was ready and nothing about it failed: there is simply no
+                        // live compute backend. Recording that as Unknown makes a configuration
+                        // fact indistinguishable from a defect in the dispatch itself.
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
-                            operation.command_order, RealizationFailureReason::Unknown});
+                            operation.command_order,
+                            RealizationFailureReason::ComputeBackendUnavailable});
                     }
                     producer_epoch_ok = false;
                     previous_compute_code = current_compute_code;
@@ -9536,9 +9543,13 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                             ComputeAuthorityBoundaryKind::Compute,
                             submit_no, operation.command_order);
                         if (capture_trace) {
+                            // A deliberate diagnostic skip, not a failure of the dispatch. Naming it
+                            // keeps the census honest about how much of a phase prosper chose not to
+                            // run versus could not.
                             capture_trace->failures.push_back({
                                 SubmitOperationKind::Dispatch, operation.index,
-                                operation.command_order, RealizationFailureReason::Unknown});
+                                operation.command_order,
+                                RealizationFailureReason::SuspiciousDispatchSkipped});
                         }
                         producer_epoch_ok = false;
                         previous_compute_code = current_compute_code;
@@ -9551,9 +9562,14 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     if (capture_trace && executed)
                         capture_trace->computes.push_back(std::move(item));
                     if (capture_trace && !executed) {
+                        // Everything about the dispatch resolved; the live backend refused to run
+                        // it. That is a different investigation from an unresolved argument or a
+                        // missing producer, and recording all three as Unknown hid which one a
+                        // phase was actually made of.
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Dispatch, operation.index,
-                            operation.command_order, RealizationFailureReason::Unknown});
+                            operation.command_order,
+                            RealizationFailureReason::ComputeExecutionDeclined});
                     }
                     result.compute_executed |= executed;
                     producer_epoch_ok &= executed;

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -1422,8 +1422,12 @@ int main() {
                   unresolved_failure->kind == SubmitOperationKind::Dispatch &&
                   unresolved_failure->source_index == 3 &&
                   unresolved_failure->command_order == unresolved_dispatch.command_order &&
+                  // #2481: an unresolvable indirect ARGUMENT address is now named, not collapsed
+                  // into the catch-all. GTA V's later compute phase is 67 root failures of this
+                  // family cascading into 128 dependency failures, and every one of them read as
+                  // "unknown" until these three sites were separated.
                   unresolved_failure->reason ==
-                      RealizationFailureReason::Unknown &&
+                      RealizationFailureReason::IndirectArguments &&
                   unresolved_failure->compute_launch.groups_x == 0 &&
                   unresolved_failure->compute_launch.groups_y == 0 &&
                   unresolved_failure->compute_launch.groups_z == 0 &&


### PR DESCRIPTION
Refs #2481. Branched from `work/gta5-table-null-slots` (#2534), so its commits appear here too;
this PR's own diff is its final commit.

## Why

Two separate things made GTA V's later 234-dispatch submit **impossible to capture**. That is the
phase its remaining device loss and black world live in, so nothing about it could be examined
offline.

### 1. A compute failure could not carry compute state

`capture_table` was called with `allow_packed_pointer=false` unconditionally for failure diagnostics.
A retained **compute** failure legitimately carries compute state, including any packed-pointer or
indirect-relocation marker its table acquired before the dispatch failed — so the guard whose own
message reads *"packed-pointer state is only valid for a compute dispatch"* rejected exactly the case
it exists to permit, and the whole capture failed to write:

```
[gpucap] write failed: packed-pointer state is only valid for a compute dispatch
```

The realized-compute table at the other call site already passes `true`. Graphics stages keep
`false`, which is the distinction the guard is actually for.

### 2. Aiming at a phase required guessing

`PROSPER_GPU_CAPTURE_AT` selects the Nth submit matching the selectors, but nothing reported what the
candidates were. `MIN_DRAWS`/`MAX_DRAWS` cannot separate compute phases at all — `candidate_draw_count`
is the **draw** count, and a compute-only submit has none, so those selectors either match everything
or nothing. Reaching a later phase therefore meant re-running with successive `AT` values and
inspecting each capsule, at one routed run apiece.

Now one run enumerates them under `PROSPER_GPU_CAPTURE_LOG`:

```
[gpucap] candidate at=0 submit=3623 draws=0 computes=0 semantic-dispatches=2975
[gpucap] candidate at=1 submit=4038 draws=0 computes=0 semantic-dispatches=903
[gpucap] candidate at=2 submit=4449 draws=0 computes=0 semantic-dispatches=234
[gpucap] candidate at=3 submit=4864 draws=0 computes=0 semantic-dispatches=234
```

`at=2` is the phase #2523's handoff named, and it is now directly addressable.

## What it immediately showed

The later phase was captured (submit 4453, 234 operations, 39 MB) and its failure census is **nothing
like** the early phase this issue has been tracking:

| reason | count |
| --- | ---: |
| `indirect-dependencies` | 128 |
| `unknown` | 67 |
| `shader-recompile` | **1** |

The recompiler is essentially done for this phase. The 128 indirect-dependency failures are a
**cascade** — the first realization failure clears `producer_epoch_ok` and every later indirect
dispatch inherits it — so the real population is the 67 `unknown` roots, led by `0x413dc6700` itself
with 9. Details on #2481.

## Verification

```
ctest --no-tests=error -j4     ->  242/242 passed, exit 0
git diff --check               ->  clean
```

Capture verified end to end: the previously unwritable submit now writes and reopens with
`--inspect-only`.
