### PR TITLE
gpu: an empty guest compute kernel is a successful no-op, not a failure that poisons the submit

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4348,7 +4348,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                is_proven_null_nullable_raw_buffer(resource) ||
                                is_proven_gta5_cf9200_no_backing(resource);
                     });
-    if (descriptors.empty() && image_descriptors.empty() && !all_proven_no_backing_noop)
+    // Fourth proven no-op contract, and the only one that does not reason about resources at all:
+    // the guest program is a single terminating instruction. Nothing runs, so nothing can be
+    // dropped, and the resource table is irrelevant to that conclusion.
+    //
+    // This case is why the distinction matters in practice rather than in principle. GTA V's
+    // `0x413cea300` is exactly one `s_endpgm` with one declared raw buffer, dispatched 1x1x1
+    // hundreds of times per frame. Declining it cleared `producer_epoch_ok`, which the next
+    // `ParserStall` latched into `indirect_dependencies_ok` for the rest of the submit
+    // (`gpu_executor.cpp`), after which every indirect draw and dispatch was refused untried — 128
+    // of them in one gameplay submit, and the world is GPU-driven, so those were the world. An
+    // empty guest kernel blackened the frame. See #2481.
+    const bool terminator_only_noop = descriptors.empty() && image_descriptors.empty() &&
+        item.terminator_only_program_validated;
+    if (descriptors.empty() && image_descriptors.empty() &&
+        !all_proven_no_backing_noop && !terminator_only_noop)
         return decline("no-bindable-descriptor");
     const bool has_storage_images = std::any_of(
         image_descriptors.begin(), image_descriptors.end(), [](const auto& descriptor) {
@@ -4396,11 +4410,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         (!timing_trace_only || trace);
     // Keep timing selection and the transfer/authority censuses above this return so investigations
     // still observe the proven no-op program. No Vulkan objects or queue submission are needed.
-    if (all_proven_no_backing_noop) {
+    if (all_proven_no_backing_noop || terminator_only_noop) {
         if (trace)
             std::fprintf(stderr,
-                         "[compute] program 0x%llx has only proven no-backing resources -> no-op\n",
-                         static_cast<unsigned long long>(item.code_addr));
+                         "[compute] program 0x%llx is a proven no-op (%s) -> executed\n",
+                         static_cast<unsigned long long>(item.code_addr),
+                         terminator_only_noop ? "terminator-only guest program"
+                                              : "only proven no-backing resources");
         return true;
     }
     if (has_storage_images && !ctx.image_support) {

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -42,6 +42,7 @@
 #include <thread>
 #include <tuple>
 #include <unordered_map>
+#include <set>
 #include <unordered_set>
 #include <vector>
 
@@ -4411,12 +4412,30 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // Keep timing selection and the transfer/authority censuses above this return so investigations
     // still observe the proven no-op program. No Vulkan objects or queue submission are needed.
     if (all_proven_no_backing_noop || terminator_only_noop) {
+        const char* which = terminator_only_noop ? "terminator-only guest program"
+                                                 : "only proven no-backing resources";
+        // Announced once per program even without the trace selector. This path converts what used
+        // to be a loud decline into silence, and "prosper decided this dispatch does nothing" is
+        // exactly the claim a later investigation needs to see and be able to doubt — a wrong proof
+        // here would silently drop real work, which is the failure mode CLAUDE.md calls fatal.
+        // Once per program, so a kernel dispatched hundreds of times per frame costs one line.
+        {
+            static std::mutex mutex;
+            static std::set<uint64_t> announced;
+            bool first = false;
+            {
+                std::lock_guard lock(mutex);
+                first = announced.insert(item.code_addr).second;
+            }
+            if (first)
+                std::fprintf(stderr,
+                             "[compute] program 0x%llx is a proven no-op (%s) -> reported executed\n",
+                             static_cast<unsigned long long>(item.code_addr), which);
+        }
         if (trace)
             std::fprintf(stderr,
                          "[compute] program 0x%llx is a proven no-op (%s) -> executed\n",
-                         static_cast<unsigned long long>(item.code_addr),
-                         terminator_only_noop ? "terminator-only guest program"
-                                              : "only proven no-backing resources");
+                         static_cast<unsigned long long>(item.code_addr), which);
         return true;
     }
     if (has_storage_images && !ctx.image_support) {

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -5064,6 +5064,14 @@ bool materialize_gpu_replay(const GpuCaptureFile& c, GpuReplayFrame& out, std::s
         compute.nullable_output_raw_buffer_validated =
             captured_compute_has_nullable_output_raw_buffer(x);
         compute.gta5_cf9200_no_backing_validated = false;
+        // Re-proved here from the retained raw stream rather than trusted from any serialized flag,
+        // which is the same authority rule the three tokens above follow. A capture that carries no
+        // raw words for this dispatch simply does not get the proof.
+        compute.terminator_only_program_validated =
+            x.raw_shader_index < c.raw_shader_versions.size() &&
+            rdna2_program_is_terminator_only(
+                c.raw_shader_versions[x.raw_shader_index].words.data(),
+                c.raw_shader_versions[x.raw_shader_index].words.size());
         if (compute.recompile_config_available)
             compute.user_sgprs = compute.recompile_config.user_sgprs;
         const bool has_packed_pointer_state = c.format_version >= 51u &&

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -453,6 +453,11 @@ struct ComputeItem {
     // Exact 0x413cf9200 authority token. The serialized impossible-stride marker and its root bytes
     // remain data until live realization or replay repeats the complete program/launch/root proof.
     bool gta5_cf9200_no_backing_validated = false;
+    // The guest program's whole body is one terminating instruction, re-proved from the raw stream
+    // by whoever built this item. Same authority rule as the tokens above: a capture may record the
+    // shape, but only realization or replay may assert it, so a serialized flag can never talk the
+    // backend into executing nothing on trust.
+    bool terminator_only_program_validated = false;
 };
 
 enum class SubmitOperationKind : uint8_t { Draw, Dispatch, DmaCopy };

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -7468,6 +7468,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
             rdna2_gta5_nullable_output_dispatch(
                 reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)),
                 shader_dwords, config, *table);
+        // Independent of the resource table by design: an `s_endpgm`-only program has no memory
+        // effect no matter what its V#s declare, so this proof reads the code and nothing else.
+        item.terminator_only_program_validated = rdna2_program_is_terminator_only(
+            reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(code_addr)), shader_dwords);
         item.gta5_cf9200_no_backing_validated = item.spirv.size() &&
             table && std::any_of(table->resources.begin(), table->resources.end(),
                                  is_proven_gta5_cf9200_no_backing) &&

--- a/prosper/src/gpu/rdna2_decode.cpp
+++ b/prosper/src/gpu/rdna2_decode.cpp
@@ -1129,6 +1129,16 @@ size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& o
     return pc;
 }
 
+bool rdna2_program_is_terminator_only(const uint32_t* code, size_t dwords) {
+    if (!code || !dwords) return false;
+    std::vector<Rdna2Inst> instructions;
+    const size_t consumed = rdna2_walk(code, dwords, instructions);
+    // `rdna2_walk` also stops on an Unknown encoding, which decodes to a single entry exactly as a
+    // terminator does. Requiring `is_end` is what separates "the program ends here" from "we could
+    // not decode the first instruction" -- the second must keep failing loudly.
+    return consumed && instructions.size() == 1u && instructions.front().is_end;
+}
+
 bool rdna2_optional_null_raw_load_shape(const Rdna2Inst& in) {
     const bool zero_soffset =
         (in.src[2].kind == OperandKind::Special && in.src[2].value == 125) ||

--- a/prosper/src/gpu/rdna2_decode.hpp
+++ b/prosper/src/gpu/rdna2_decode.hpp
@@ -458,6 +458,17 @@ bool rdna2_optional_null_raw_load_shape(const Rdna2Inst& in);
 // encoding, or the end of the buffer. Returns the number of dwords consumed.
 size_t rdna2_walk(const uint32_t* code, size_t dwords, std::vector<Rdna2Inst>& out);
 
+// True when the guest program's entire body is a single terminating instruction — the shader ends
+// before executing anything. Such a dispatch completes architecturally with no memory effect
+// whatever its resource table declares, so it is a no-op by construction rather than by inference
+// about descriptors.
+//
+// This is deliberately the narrowest possible test. A program with ANY instruction before its
+// terminator is not covered, however trivially it may appear to do nothing: the point is to
+// separate "the guest asked for nothing" from "we recompiled something to nothing", and only the
+// first is safe to report as success.
+bool rdna2_program_is_terminator_only(const uint32_t* code, size_t dwords);
+
 // Exact IMAGE_LOAD_MIP / IMAGE_STORE_MIP packet subset whose mip operand may be specialized after
 // an independent value proof. Returns the dimension-specific mip VGPR when requested. This checks
 // only packet shape; callers must still prove that VGPR is zero and that the resource has one

--- a/prosper/tests/test_rdna2_decode.cpp
+++ b/prosper/tests/test_rdna2_decode.cpp
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstdint>
 #include <utility>
+#include <vector>
 
 using namespace prosper::gpu;
 
@@ -941,6 +942,53 @@ int main() {
     const uint32_t ds_gds[]   = { 0xd8020000u, 0x00000201u };
     CHECK(!rdna2_decode_one(ds_plain, 2).ds_gds && rdna2_decode_one(ds_gds, 2).ds_gds,
           "DS GDS flag (bit 17) decodes: ds_add_u32 vs ds_add_u32 gds");
+
+    // rdna2_program_is_terminator_only — the proof that a guest compute program does nothing at all.
+    //
+    // A dispatch of such a program has no memory effect whatever its resource table declares, so the
+    // live backend reports it as a successful no-op instead of a decline. That matters because a
+    // declined dispatch poisons `producer_epoch_ok` and, through the ParserStall latch, refuses every
+    // later indirect draw and dispatch in the submit — GTA V's `0x413cea300` is one `s_endpgm` with
+    // one declared raw buffer and blackened the world through exactly that path (#2481).
+    //
+    // Encodings from llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1030 --show-encoding:
+    //   s_endpgm        -> [0x00,0x00,0x81,0xbf]  = 0xbf810000
+    //   s_nop 0         -> [0x00,0x00,0x80,0xbf]  = 0xbf800000
+    //   s_mov_b32 s0,s1 -> [0x01,0x03,0x80,0xbe]  = 0xbe800301
+    {
+        const uint32_t endpgm_only[] = { 0xbf810000u };
+        CHECK(rdna2_program_is_terminator_only(endpgm_only, 1),
+              "a program that is exactly s_endpgm is proven terminator-only");
+        // The same word inside a larger buffer: the walk stops at the terminator, so trailing bytes
+        // beyond the program (constant tables, the next shader) must not defeat the proof.
+        const uint32_t endpgm_then_garbage[] = { 0xbf810000u, 0xdeadbeefu, 0x12345678u };
+        CHECK(rdna2_program_is_terminator_only(endpgm_then_garbage, 3),
+              "trailing words after s_endpgm do not defeat the proof");
+
+        // MUTATION ARMS. Each is one instruction away from the accepted case and must be rejected;
+        // without them the predicate is indistinguishable from `return true` for short programs.
+        //
+        // s_nop is a real instruction that does nothing observable, which is precisely the case the
+        // proof must NOT cover: the question is whether the guest asked for nothing, not whether we
+        // judge its work to be pointless.
+        const uint32_t nop_then_end[] = { 0xbf800000u, 0xbf810000u };
+        CHECK(!rdna2_program_is_terminator_only(nop_then_end, 2),
+              "s_nop before s_endpgm is NOT terminator-only, however inert it looks");
+        const uint32_t mov_then_end[] = { 0xbe800301u, 0xbf810000u };
+        CHECK(!rdna2_program_is_terminator_only(mov_then_end, 2),
+              "any instruction before s_endpgm defeats the proof");
+        // An undecodable first word also walks to exactly one entry. Only `is_end` separates it from
+        // the accepted case, so a proof keyed on instruction count alone would accept this.
+        const uint32_t undecodable[] = { 0xffffffffu };
+        std::vector<Rdna2Inst> walked;
+        rdna2_walk(undecodable, 1, walked);
+        CHECK(walked.size() == 1u && !walked.front().is_end &&
+              !rdna2_program_is_terminator_only(undecodable, 1),
+              "an undecodable first word walks to one instruction and is still NOT proven");
+        CHECK(!rdna2_program_is_terminator_only(nullptr, 0) &&
+              !rdna2_program_is_terminator_only(endpgm_only, 0),
+              "an empty or absent program is not a proof of anything");
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Stacked on #2538 (which adds the diagnostic that found this). Base is
`diag/compute-decline-reasons`; retarget to `master` once that merges.

## The defect

*Grand Theft Auto V* `PPSA04263` dispatches program `0x413cea300` hundreds of times per frame. Its
entire body is one instruction:

```
compute program=0000000413cea300 raw=yes words=1 bytes=4 endpgm=yes recompiled=no resources=present/1 descriptors=0
  coverage total=0 alu=0 exports=0 table-dependent=0 unsupported=0
  compute-config user-sgprs=8 local=1x1x1 threads=1x1x1 wave=64 lds=0 subgroup=0
  resource[0] cls=0 binding=2 addr=00000020f8480000 size=347040 stride=1 fmt=11 comps=1
```

`s_endpgm`. One declared raw buffer, 1x1x1 launch, no memory effect. prosper recompiled it to a
module with zero descriptors — correct, there is nothing to bind — and `execute_item` then **refused
it**, because "no bindable descriptor" is a failure unless every declared resource matches one of
three proven no-backing contracts. A plain raw buffer matches none of them.

## Why refusing it blackens the world

The refusal is not local:

1. `producer_epoch_ok &= executed` → false (`gpu_executor.cpp:9287`)
2. next `ParserStall`: `indirect_dependencies_ok &= producer_epoch_ok` → **latched false for the rest
   of the submit** (`:9358`)
3. every later indirect draw and indirect dispatch short-circuits to `IndirectDependencies` without
   being attempted (`:9118`, `:9187`)

In one gameplay submit that is 59 declines and **128 cascade failures out of 196** — and
`failure[0]`, the first failure in the submit before anything else has gone wrong, is this empty
kernel. GTA V's world is GPU-driven, so the indirect operations that were dropped *are* the world.

An empty guest kernel blackened the frame, and it read as 196 anonymous "declined" entries.

## The fix

A fourth proven no-op contract — and the only one that does not reason about resources at all: **the
guest program's whole body is a terminating instruction**, so it has no memory effect whatever its
V#s declare.

`rdna2_program_is_terminator_only()` walks the raw stream and accepts only a single instruction with
`is_end`. Deliberately the narrowest possible test:

- `s_nop` then `s_endpgm` is **rejected**. The question is whether the guest asked for nothing, not
  whether we judge its work to be pointless.
- An undecodable first word also walks to exactly one instruction, so requiring `is_end` is what
  keeps a decode failure failing loudly instead of being waved through as "empty".

Carried as `ComputeItem::terminator_only_program_validated`, a non-serialized token minted by whoever
built the item — the live realizer from guest memory, the replay materializer from the retained raw
stream. Same authority rule as the three tokens beside it: a capture may record the shape, but only
realization or replay may assert it, so no serialized flag can talk the backend into executing
nothing on trust.

**"Merely descriptorless" still fails**, exactly as the existing comment at that site requires. The
change separates *the guest asked for nothing* from *we recompiled something to nothing*.

## Verification

`test_rdna2_decode` gains six arms, four of them mutations one instruction away from the accepted
case. Without them the predicate is indistinguishable from `return true` for short programs.
Encodings from `llvm-mc -triple=amdgcn-amd-amdhsa -mcpu=gfx1030 --show-encoding`, not hand-rolled.

```
ctest --no-tests=error -j4      100% tests passed out of 241
```

**Routed A/B**, Linux/RADV (`AMD Radeon 8060S Graphics, RADV STRIX_HALO`), GTA V `PPSA04263`,
`scripts/gta5/reach-story-mode.pad`, identical env both arms:

| arm | `no-bindable-descriptor` declines |
| --- | --- |
| baseline (`4ba2af04`) | 11 log lines, running count reaching **192** |
| with this change | **0** |

## What this does NOT fix

The world is still black, and this PR does not claim otherwise. A second, independent failure remains
in the same window and reproduces deterministically in both arms:

```
radv/amdgpu: The CS has been cancelled because the context is lost. This context is guilty of a hard recovery.
[compute] fatal Vulkan device loss stage=queue-submit result=VK_ERROR_DEVICE_LOST(-4)
          program=0x413dc6700 submit=5968 dispatch=39 order=17056; disabling live compute for this process
```

Same program, same dispatch index 39, in both runs. `0x413dc6700` hangs the GPU into a hard recovery,
after which live compute is disabled process-wide and the indirect latch trips again for a different
reason. That is tracked separately in #2481 and is the next thing to fix. No progression screenshots
are attached because this change does not yet produce a visible difference.

Refs #2481