### PR TITLE
diag(compute): PROSPER_COMPUTE_SKIP_PROGRAM — decline named compute programs

### DIFF
--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4181,6 +4181,14 @@ void report_compute_decline(const prosper::gpu::ComputeItem& item, const char* r
 //
 // The skip reports itself through the ordinary decline census, so a run made with it set can never
 // be mistaken for a default run when the log is read later.
+//
+// Two limits a reader of the result has to know, because neither is visible in the output:
+//   * A skip IS a decline. It clears `producer_epoch_ok` exactly as a real refusal does, which the
+//     next ParserStall latches into `indirect_dependencies_ok` for the rest of the submit. What you
+//     get is therefore not "the frame minus that dispatch" -- it is that frame minus the dispatch
+//     minus every indirect draw and dispatch after the next parser stall.
+//   * A program that takes `execute_cpu_fast_path` never reaches here, so naming one has no effect
+//     and produces no line. Silence is not proof the selector matched.
 const std::set<uint64_t>& compute_skip_programs() {
     static const std::set<uint64_t> programs = [] {
         std::set<uint64_t> parsed;

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4209,8 +4209,6 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         report_compute_decline(item, reason);
         return false;
     };
-    if (!compute_skip_programs().empty() && compute_skip_programs().count(item.code_addr))
-        return decline("skipped-by-selector");
     const auto phase_start = ComputeClock::now();
     auto phase_setup = phase_start;
     auto phase_pipeline = phase_start;
@@ -4230,6 +4228,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
     maybe_dump_traced_compute_spirv(item, trace);
+    // Deliberately below the trace and SPIR-V dump: a skipped dispatch must still be observable by
+    // the other instruments, so a run can answer "what would this program have been?" without also
+    // running the dispatch that is under suspicion. That combination — dump the module, skip the
+    // dispatch — is what lets a recompiler change be checked against a program that hangs the GPU.
+    if (!compute_skip_programs().empty() && compute_skip_programs().count(item.code_addr))
+        return decline("skipped-by-selector");
     if (item.required_subgroup_size &&
         (!ctx.borrowed || !ctx.native_subgroup_contract ||
          item.required_subgroup_size < ctx.min_native_subgroup_size ||

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4171,6 +4171,37 @@ void report_compute_decline(const prosper::gpu::ComputeItem& item, const char* r
                  item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
 }
 
+// PROSPER_COMPUTE_SKIP_PROGRAM=0xADDR[,0xADDR...] — decline the named compute programs.
+//
+// A bisection instrument, not a workaround, and it is deliberately impossible to enable by accident:
+// unset it and nothing changes. It exists because a single dispatch can take down everything after
+// it — a GPU hang costs the whole process its compute backend, and a wrong write corrupts every
+// consumer downstream — so "which dispatch is responsible?" is a question worth being able to ask
+// directly instead of by rebuilding.
+//
+// The skip reports itself through the ordinary decline census, so a run made with it set can never
+// be mistaken for a default run when the log is read later.
+const std::set<uint64_t>& compute_skip_programs() {
+    static const std::set<uint64_t> programs = [] {
+        std::set<uint64_t> parsed;
+        const char* spec = std::getenv("PROSPER_COMPUTE_SKIP_PROGRAM");
+        if (!spec) return parsed;
+        for (const char* cursor = spec; *cursor;) {
+            char* end = nullptr;
+            const uint64_t address = std::strtoull(cursor, &end, 0);
+            if (end == cursor) break;          // not a number: stop rather than guess
+            if (address) parsed.insert(address);
+            cursor = end;
+            while (*cursor == ',' || *cursor == ' ') ++cursor;
+        }
+        std::fprintf(stderr,
+                     "[compute] PROSPER_COMPUTE_SKIP_PROGRAM=%s -> %zu program(s) will be declined\n",
+                     spec, parsed.size());
+        return parsed;
+    }();
+    return programs;
+}
+
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
@@ -4178,6 +4209,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         report_compute_decline(item, reason);
         return false;
     };
+    if (!compute_skip_programs().empty() && compute_skip_programs().count(item.code_addr))
+        return decline("skipped-by-selector");
     const auto phase_start = ComputeClock::now();
     auto phase_setup = phase_start;
     auto phase_pipeline = phase_start;

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -865,6 +865,39 @@ prints a per-submit no-match line while a dimension filter is active. Supported 
 Vulkan in retained PM4 order. `PROSPER_COMPUTELOG_CODE=0x...` and `PROSPER_COMPUTELOG_SIZE=N` restrict
 writeback before/after hashes to a matching program and/or storage-buffer size during long live runs.
 
+**`[compute-decline]` — why the live backend refused a dispatch.** Always on, no variable needed.
+`execute_item` has sixteen refusal paths (fifteen, plus the selector below); each names itself:
+
+```
+[compute-decline] program=0x413cea300 reason=no-bindable-descriptor count=128 submit=3958 dispatch=16 order=1041 groups=1x1x1
+```
+
+**Read the `count`.** The line is limited to the first 8 per `(program, reason)` and every 64th
+after, and the running count is printed precisely so the limiter cannot be mistaken for the rate —
+`[compute] skip unsupported program` prints once per program and has twice been quoted as a census.
+A refusal also clears `producer_epoch_ok`, which the next `ParserStall` latches into
+`indirect_dependencies_ok` for the rest of the submit, so one decline early in a submit drops every
+later **indirect** draw and dispatch untried. A single named decline can therefore account for a
+frame's worth of missing geometry.
+
+**`PROSPER_COMPUTE_SKIP_PROGRAM=0xADDR[,0xADDR...]` — decline named compute programs.** A bisection
+instrument: one dispatch can take down everything after it (a GPU hang costs the process its compute
+backend), so "which dispatch is responsible?" is worth asking directly instead of by rebuilding. It
+announces itself at parse time and reports each skip through the census above as
+`reason=skipped-by-selector`, so a log from a run made with it set cannot later be mistaken for a
+default run. Two things to know before reading a result:
+
+- **A skip is a decline**, so it poisons the submit's indirect latch exactly as a real refusal would.
+  The output is *not* "the frame minus that dispatch"; it is that frame minus the dispatch minus
+  every indirect operation after the next parser stall.
+- **A program taking the CPU fast path never reaches the selector**, so naming one has no effect and
+  produces no line.
+
+It is ordered **after** `trace_compute_item` and `maybe_dump_traced_compute_spirv`, which makes
+*dump the module, skip the dispatch* work — the only way to inspect what the recompiler produced for
+a program that hangs the GPU without losing the device. Combined with `PROSPER_COMPUTELOG_CODE` /
+`PROSPER_COMPUTELOG_SPIRV`, a recompiler change can be A/B'd by module hash at zero device cost.
+
 `PROSPER_PROVENANCE_DIM=WxH` retains every decoded `CB_COLOR0_BASE` write across submits, then reports
 the last matching writer whenever a draw samples an image of that size. Descriptor resolution can be
 limited to likely target submits with `PROSPER_PROVENANCE_MIN_DRAWS=N`; color-target history is still


### PR DESCRIPTION
Stacked on #2539 (base `fix/empty-guest-kernel-poisons-submit`); retarget to `master` as that stack
merges.

## What it is

```
PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700,0x413cf9200
```

A bisection instrument for the question *"which dispatch is responsible for this?"*. One compute
dispatch can take down everything after it — a GPU hang costs the whole process its compute backend
and, through the indirect latch, every later indirect draw in the submit; a wrong write corrupts every
consumer downstream. Until now the only way to test a single program's contribution was to rebuild
with an edit.

## Why it is safe to have

- **Unset, nothing changes.** It cannot be enabled by accident.
- **It announces itself at parse time**, before any dispatch:
  `[compute] PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700 -> 1 program(s) will be declined`
- **Every skip reports through the ordinary decline census** as `reason=skipped-by-selector` (#2538),
  so a log from a run made with it set can never be mistaken for a default run when it is read back
  later. That property is the point: diagnostic runs get filed and re-read months later.
- **Parsing stops at the first non-numeric token** rather than guessing past it, so a malformed
  selector skips *fewer* programs than intended and says so in its own count. It can never silently
  skip more than asked.

It is deliberately not a workaround. It cannot make a title render correctly; it can only remove a
dispatch and let you see what that dispatch was contributing.

## What it established on its first use

GTA V `PPSA04263` loses the GPU to a RADV hard recovery at program `0x413dc6700`, deterministically,
at the same dispatch index in every run. With that one program skipped:

- **zero device losses** across a full 300 s route (previously lost at ~59 s, twice out of two)
- 42 dispatches declined as `skipped-by-selector`, and nothing else declined
- and the frame shows **real scene content for the first time**: the sun with its anamorphic lens
  flare, the radar rendering actual street geometry with player and blip markers, and the
  first-person-camera tutorial text

which localises the remaining black-world defect to that single program. Detail in #2481.

## Verification

```
cmake --build prosper/build-linux --target screenshot -j6     # clean
ctest --no-tests=error -j4                                    # 100% tests passed out of 241
```

Linux/RADV, `AMD Radeon 8060S Graphics (RADV STRIX_HALO)`. No screenshots are attached as progression
evidence: the run that produced them had a dispatch forcibly skipped, which the charter classifies as
illustrating an investigation rather than demonstrating progress.

Refs #2481
