### PR TITLE
tools(gpu_replay): --dump-compute-raw — the guest stream of a REALIZED compute

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -97,14 +97,20 @@ falsification.
 - **The hang is a non-uniform early exit.** The 14,370-line disassembled module contains exactly
   **one** `OpReturn`, at the end. No `OpKill`, none inside any of the three dispatcher loops. #2481.
 - **A lost atomic corrupts the traversal table.** The table that hangs `0x413dc6700` is a linked list
-  whose corruption is 61 **two-cycles** (`i` and `i+2` pointing at each other), which is the classic
-  signature of a non-atomic concurrent insertion — two threads each linking to the other because both
-  read the head before either wrote. Its producer `0x413ce3400` contains **no atomic instructions at
-  all**: zero `OpAtomic*` in 3,881 lines of recompiled SPIR-V, and zero
-  `(buffer|global|flat|ds)_atomic_*` in its 507-dword guest stream (dumped with `--dump-compute-raw`).
-  **Positive control, from a different program in a different capsule**: the identical grep finds
-  **6 atomics** in `0x413ced900`'s guest stream, so the instrument does fire — the zero is a real
-  negative and not a broken pattern. #2542.
+  whose corruption is 61 **two-cycles** (`i` and `i+2` pointing at each other), the classic signature
+  of a non-atomic concurrent insertion — two threads each linking to the other because both read the
+  head before either wrote. Its producer `0x413ce3400` performs **no atomic operation of any kind**,
+  and the strong form of that is structural rather than grep-shaped: its entire memory footprint is
+  **29 buffer loads and stores** (`buffer_load_dword` x15, `buffer_load_dwordx2` x9,
+  `buffer_store_dword` x4, `buffer_store_dwordx3` x1) and **zero `ds_*` instructions**, so there is no
+  LDS family in which an atomic could hide. Zero `OpAtomic*` in its 3,881-line recompiled SPIR-V
+  agrees. **Positive control, a different program in a different capsule**: `0x413ced900` contains
+  `buffer_atomic_fmax` x3, `buffer_atomic_fmin` x3, `ds_max_f32` x3 and `ds_min_f32` x3 — so the
+  instrument fires on the buffer family *and* the LDS family, and the zero is a real negative.
+  **Note what the control also demonstrates:** a `(buffer|global|flat|ds)_atomic_*` pattern silently
+  misses LDS atomics entirely, because RDNA2 spells them `ds_max_f32`, not `ds_atomic_max` — the
+  control's own `ds_min/max_f32` would not have been found by it. That gap is why the claim above
+  rests on the absence of the whole DS family rather than on an atomic-shaped pattern. #2542.
 - **The hang is an unconditionally infinite loop.** The same program executes successfully at dispatch
   38 and hangs at dispatch 39 of the same submit. Whatever spins is data-dependent. #2481.
 - **Bounding the CFG dispatcher's trip count stops the hang.** Tried at 4096 and at 2^20; the device

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -96,6 +96,15 @@ falsification.
   invocation iterates together. #2481.
 - **The hang is a non-uniform early exit.** The 14,370-line disassembled module contains exactly
   **one** `OpReturn`, at the end. No `OpKill`, none inside any of the three dispatcher loops. #2481.
+- **A lost atomic corrupts the traversal table.** The table that hangs `0x413dc6700` is a linked list
+  whose corruption is 61 **two-cycles** (`i` and `i+2` pointing at each other), which is the classic
+  signature of a non-atomic concurrent insertion — two threads each linking to the other because both
+  read the head before either wrote. Its producer `0x413ce3400` contains **no atomic instructions at
+  all**: zero `OpAtomic*` in 3,881 lines of recompiled SPIR-V, and zero
+  `(buffer|global|flat|ds)_atomic_*` in its 507-dword guest stream (dumped with `--dump-compute-raw`).
+  **Positive control, from a different program in a different capsule**: the identical grep finds
+  **6 atomics** in `0x413ced900`'s guest stream, so the instrument does fire — the zero is a real
+  negative and not a broken pattern. #2542.
 - **The hang is an unconditionally infinite loop.** The same program executes successfully at dispatch
   38 and hangs at dispatch 39 of the same submit. Whatever spins is data-dependent. #2481.
 - **Bounding the CFG dispatcher's trip count stops the hang.** Tried at 4096 and at 2^20; the device

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -262,6 +262,7 @@ render-state resolve, executor ordering, detile) — it is the right guard for c
 ./build-linux/gpu_replay --dump-shader 18:fs /tmp/fragment.spv /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-realized-shader 18:fs /tmp/fragment-rdna2.bin /tmp/submit.prgcap
 ./build-linux/gpu_replay --dump-compute 0 /tmp/compute.spv /tmp/submit.prgcap
+./build-linux/gpu_replay --dump-compute-raw 0 /tmp/compute-rdna2.bin --inspect-only /tmp/submit.prgcap
 ./build-linux/gpu_replay --compute-only 0 /tmp/submit.prgcap
 ./build-linux/gpu_replay --compute-only 0 --override-compute-spv 0 /tmp/reduced.spv \
   /tmp/submit.prgcap
@@ -480,6 +481,23 @@ executor cannot realize. `--inspect-only` prints the failure reason, decoded tar
 state, every referenced stage address, resource-table presence/count, descriptor issues, recompile coverage,
 and the first rejected opcode/format at its exact dword PC. It also prints the raw RDNA2 content hash, byte
 count, and whether the retained stream reached `s_endpgm`.
+
+`--dump-compute-raw N PATH` writes the **guest RDNA2 stream** of a *realized* compute — the input the
+recompiler saw, where `--dump-compute` writes its output. Use it to ask whether the guest uses an
+instruction the emitted SPIR-V does not contain:
+
+```bash
+gpu_replay --inspect-only --dump-compute-raw 29 /tmp/cs.bin /tmp/submit.prgcap
+llvm-mc -arch=amdgcn -mcpu=gfx1030 -disassemble -show-encoding < <(hexdump-of /tmp/cs.bin)
+```
+
+Two things to know. **Pass `--inspect-only`** unless you want a full Vulkan replay as well — the flag
+does not by itself select a non-rendering mode. And its precondition is *weaker* than the `raw=` column
+in `--inspect-only` output: that column reports whether the capture retained a raw stream for a
+program, while this flag needs only a valid `raw_shader_index` for the selected compute, so `raw=no`
+elsewhere does not mean the dump is unavailable. It fails closed — a capture with no retained stream
+says so and exits 2 rather than writing a truncated file, and the `fclose` is checked, so a full disk
+cannot produce a "dumped" line over an empty file.
 
 `--dump-failed-shader FAILURE:STAGE PATH` writes that raw stream for `shader_inspect` or a focused recompiler
 fixture. Both indices are the zero-based values printed by `--inspect-only`; they are not draw indices. Each raw

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -69,6 +69,7 @@ void usage(const char* argv0) {
                          "[--override-resource DRAW:vs|ps:BINDING PATH] "
                          "[--dump-rtt-seed ADDR PATH] "
                          "[--dump-shader DRAW:vs|fs PATH] [--dump-compute N PATH] "
+                         "[--dump-compute-raw N PATH] "
                          "[--dump-realized-shader DRAW:vs|vs-main|fs PATH] "
                          "[--override-compute-spv N PATH] "
                          "[--dump-failed-shader FAILURE:STAGE PATH] "
@@ -1875,6 +1876,7 @@ int main(int argc, char** argv) {
     uint32_t warmup_repeats = 0;
     std::string dump_spec, dump_path, shader_spec, shader_path;
     std::string compute_shader_spec, compute_shader_path;
+    std::string compute_raw_spec, compute_raw_path;
     std::string compute_override_spec, compute_override_path;
     bool resource_override_requested = false;
     prosper::tools::ResourceOverrideSelector resource_override_selector;
@@ -2047,6 +2049,9 @@ int main(int argc, char** argv) {
         else if (std::string(argv[i]) == "--dump-compute" && i + 2 < argc) {
             compute_shader_spec = argv[++i]; compute_shader_path = argv[++i];
         }
+        else if (std::string(argv[i]) == "--dump-compute-raw" && i + 2 < argc) {
+            compute_raw_spec = argv[++i]; compute_raw_path = argv[++i];
+        }
         else if (std::string(argv[i]) == "--override-compute-spv" && i + 2 < argc) {
             compute_override_spec = argv[++i]; compute_override_path = argv[++i];
         }
@@ -2110,6 +2115,7 @@ int main(int argc, char** argv) {
             compute_only >= 0 ||
             warmup_repeats || !dump_spec.empty() || rtt_seed_addr ||
             !shader_spec.empty() || !compute_shader_spec.empty() ||
+            !compute_raw_spec.empty() ||
             !realized_shader_spec.empty() ||
             !compute_override_spec.empty() ||
             resource_override_requested ||
@@ -2943,6 +2949,41 @@ int main(int argc, char** argv) {
         std::fclose(f);
         std::fprintf(stderr, "[gpureplay] dumped compute %ld (%zu bytes) to %s\n",
                      index, bytes, compute_shader_path.c_str());
+    }
+    // The GUEST stream for a realized compute. `--dump-failed-shader` already exposes this for a
+    // FAILED stage, which left the common case unreachable: a dispatch that ran and produced wrong
+    // data is exactly the one whose original RDNA2 you want to disassemble, and it is never a
+    // failure. Answering "does the guest use an instruction our SPIR-V does not contain?" needed
+    // both halves, and only one existed.
+    if (!compute_raw_spec.empty()) {
+        char* end = nullptr;
+        const long index = std::strtol(compute_raw_spec.c_str(), &end, 0);
+        if (!end || *end || index < 0 || static_cast<size_t>(index) >= replay.computes.size()) {
+            std::fprintf(stderr, "gpu_replay: invalid compute selector %s\n",
+                         compute_raw_spec.c_str());
+            return 2;
+        }
+        const auto& compute = replay.computes[static_cast<size_t>(index)];
+        if (compute.raw_shader_index >= replay.raw_shader_versions.size()) {
+            std::fprintf(stderr,
+                         "gpu_replay: compute %ld retains no raw guest stream "
+                         "(capture predates v39, or the program was not recorded)\n", index);
+            return 2;
+        }
+        const auto& raw = replay.raw_shader_versions[compute.raw_shader_index];
+        const size_t bytes = raw.words.size() * sizeof(uint32_t);
+        FILE* f = std::fopen(compute_raw_path.c_str(), "wb");
+        if (!f || std::fwrite(raw.words.data(), 1, bytes, f) != bytes) {
+            if (f) std::fclose(f);
+            std::fprintf(stderr, "gpu_replay: cannot write %s\n", compute_raw_path.c_str());
+            return 2;
+        }
+        std::fclose(f);
+        std::fprintf(stderr,
+                     "[gpureplay] dumped compute %ld raw guest stream code=0x%llx "
+                     "(%zu dwords, %zu bytes, endpgm=%d) to %s\n",
+                     index, static_cast<unsigned long long>(compute.code_addr),
+                     raw.words.size(), bytes, raw.has_endpgm ? 1 : 0, compute_raw_path.c_str());
     }
     if (!compute_resource_spec.empty()) {
         const size_t colon = compute_resource_spec.find(':');

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -2973,12 +2973,18 @@ int main(int argc, char** argv) {
         const auto& raw = replay.raw_shader_versions[compute.raw_shader_index];
         const size_t bytes = raw.words.size() * sizeof(uint32_t);
         FILE* f = std::fopen(compute_raw_path.c_str(), "wb");
-        if (!f || std::fwrite(raw.words.data(), 1, bytes, f) != bytes) {
-            if (f) std::fclose(f);
+        // fclose is CHECKED, unlike the sibling dumps. A guest stream is small enough to sit
+        // entirely inside stdio's buffer -- this one is 2 KiB against a 4 KiB default -- so nothing
+        // reaches the filesystem until the close, and ENOSPC/EDQUOT surfaces THERE and nowhere
+        // earlier. Ignoring it would print "dumped" and exit 0 over a truncated or empty file, on a
+        // machine whose scratch filesystem hits EDQUOT routinely. That is the exact shape this flag
+        // exists to avoid: an instrument that reports success while producing nothing.
+        const bool wrote = f && std::fwrite(raw.words.data(), 1, bytes, f) == bytes;
+        const bool closed = f && std::fclose(f) == 0;
+        if (!wrote || !closed) {
             std::fprintf(stderr, "gpu_replay: cannot write %s\n", compute_raw_path.c_str());
             return 2;
         }
-        std::fclose(f);
         std::fprintf(stderr,
                      "[gpureplay] dumped compute %ld raw guest stream code=0x%llx "
                      "(%zu dwords, %zu bytes, endpgm=%d) to %s\n",


### PR DESCRIPTION
## The gap

`gpu_replay` could already dump the **recompiled** module for any compute (`--dump-compute`), and the
**guest** stream for a stage that *failed* (`--dump-failed-shader FAILURE:STAGE`). It could not dump
the guest stream for a compute that **succeeded**.

That is backwards for the case that matters most. A dispatch which failed is loud and already has a
diagnostic path; a dispatch which **ran and produced wrong data** is silent, and it is exactly the one
whose original RDNA2 you need in front of you. The question "does the guest use an instruction our
SPIR-V does not contain?" needs both halves of the comparison, and only one half was reachable.

## The flag

```
gpu_replay --inspect-only --dump-compute-raw 29 out.raw capture.prgcap
[gpureplay] dumped compute 29 raw guest stream code=0x413ce3400 (507 dwords, 2028 bytes, endpgm=1) to out.raw

llvm-mc -arch=amdgcn -mcpu=gfx1030 -disassemble -show-encoding < <(hexdump-of out.raw)
```

The line reports the program address, dword count and `endpgm` alongside the path, so a dump can be
tied back to a program without a second lookup.

**Fail-closed.** A capture retaining no raw stream for the selected compute — pre-v39, or a program
that was not recorded — says so and exits 2 rather than writing a truncated or empty file:

```
gpu_replay: compute 29 retains no raw guest stream (capture predates v39, or the program was not recorded)
```

The selector is validated against `computes.size()` and `raw_shader_index` against
`raw_shader_versions.size()` (which is also the `0xFFFFFFFFu` sentinel check) before either is used.

## What it was built for

GTA V #2542. The producer that corrupts a traversal table turns an acyclic linked list into one with
61 two-cycles, which hangs its consumer's pointer-chase and takes the GPU down. **A 2-cycle is the
classic signature of a lost atomic** — two threads each linking to the other because both read the
head before either wrote — and the recompiled SPIR-V contains zero `OpAtomic*` in 3,881 lines.

So: does the guest use atomics that we dropped? With this flag, one command answers it — and the
first command I ran was **wrong**, which is itself the better advertisement:

```
grep -oE '(buffer|global|flat|ds)_atomic_[a-z0-9_]+' ce3400.guest.asm    # (nothing)
```

That pattern's fourth alternative is dead: RDNA2 spells LDS atomics `ds_add_u32` / `ds_max_f32`, not
`ds_atomic_*`, so it never searched LDS at all. Review caught it. The honest form is structural, and
the flag is what makes it answerable:

```
grep -oE '\b(buffer|global|flat|ds|scratch)_[a-z0-9_]+' ce3400.guest.asm | sort | uniq -c
     15 buffer_load_dword     9 buffer_load_dwordx2     4 buffer_store_dword     1 buffer_store_dwordx3
```

**Zero `ds_*` instructions of any kind**, so no LDS family exists in which an atomic could hide — a
conclusion that does not depend on knowing every mnemonic. The positive control, an independent
capsule, demonstrates the original pattern's blind spot in itself: `0x413ced900` contains
`buffer_atomic_fmax` x3, `buffer_atomic_fmin` x3 **and** `ds_max_f32` x3, `ds_min_f32` x3 — the last
four invisible to the grep above.

Hypothesis dead, on a program that is *realized* and therefore previously undumpable. That is the
argument for the flag, and the correction is the argument for reviewing what it produces.

## Verification

```
cmake --build prosper/build-linux --target gpu_replay -j6      # clean
```

Exercised on a real capsule (a pre-#2536 one, since this branch is off `master` and lacks that PR's
reader):

```
[gpureplay] dumped compute 5 raw guest stream code=0x205b67e400 (662 dwords, 2648 bytes, endpgm=1)
```

`diff --check` clean; zero `Claude-Session:` trailers. Diagnostic-only: no behaviour changes, and the
flag does nothing unless passed.

Refs #2542