### PR TITLE
gpu: the fragment recompiler supported only MRT0/MRT1 — GTA V's G-buffer exports five

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1067,6 +1067,10 @@ if(TARGET prosper_core)
   target_link_libraries(test_compute_parent_walk PRIVATE prosper_core)
   add_test(NAME compute_parent_walk COMMAND test_compute_parent_walk)
 
+  add_executable(test_compute_tree_watch tests/test_compute_tree_watch.cpp)
+  target_link_libraries(test_compute_tree_watch PRIVATE prosper_core)
+  add_test(NAME compute_tree_watch COMMAND test_compute_tree_watch)
+
   # Cross-submit readability reuse is valid only while the HLE mapping generation is unchanged.
   add_executable(test_guest_memory_map tests/test_guest_memory_map.cpp)
   target_link_libraries(test_guest_memory_map PRIVATE prosper_core)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -630,6 +630,13 @@ if(TARGET prosper_core)
   target_include_directories(test_mrt_extent PRIVATE frontends/shared)
   add_test(NAME mrt_extent COMMAND test_mrt_extent)
 
+  # ONE active-colour-binding policy, shared by pass grouping and same-pass feedback detection, built
+  # from a real DrawItem. A second, looser copy of this rule classified stale named state as a live
+  # binding (#2550 review).
+  add_executable(test_mrt_binding frontends/shared/test_mrt_binding.cpp)
+  target_include_directories(test_mrt_binding PRIVATE frontends/shared src)
+  add_test(NAME mrt_binding COMMAND test_mrt_binding)
+
   add_executable(test_rtt_injection frontends/shared/test_rtt_injection.cpp)
   target_include_directories(test_rtt_injection PRIVATE frontends/shared)
   add_test(NAME rtt_injection COMMAND test_rtt_injection)

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,48 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## FALSIFIED: the missing-producer hypothesis is dead (2026-08-15)
+
+`PROSPER_COMPUTE_DISPATCH_LOG` (added here) records **one line per dispatch** with its outcome, which
+no existing signal did — every other one is deduped per program, and reading a once-per-program line
+as a per-dispatch property is how the root-cause claim two sections down got published and retracted.
+
+One 200 s route, 46 submits carrying a `0x413dc3400` dispatch:
+
+| | tree CYCLIC | tree clean |
+| --- | --- | --- |
+| `0x413ce6000` had a declined dispatch that submit | 10 | 0 |
+| `0x413ce6000` executed on **every** dispatch | **29** | 7 |
+
+**29 submits in which the producer ran on every single dispatch and the builder still produced a
+cyclic tree.** A producer decline is therefore **not necessary** for the corruption, and the
+"`0x413ce6000` fails to recompile → stale tags → cyclic tree" story is finished. Do not restart it.
+
+Per-dispatch outcomes over the run: `0x413ce6000` 129 executed / 10 recompile-empty; `0x413cf9200`
+658 executed / 20 recompile-empty; `0x413dc3400` 53 executed / 0 failures. Those recompile-empty
+dispatches are real gaps worth closing on their own merits — an unsupported program is a fatal gap —
+but they are **not** the cause of this defect.
+
+### What the same data shows instead: a route-position boundary
+
+The builder's output is clean for the first seven submits and cyclic from submit ~6795 onward,
+continuously:
+
+```
+3894  clean     6795  CYCLIC     9673  CYCLIC
+4307  clean     7211  CYCLIC    10076  CYCLIC
+4720  clean     7625  CYCLIC    10482  CYCLIC
+5135  clean     8039  CYCLIC    10875  CYCLIC
+5550  clean     8457  CYCLIC    11271  CYCLIC
+5965  clean     8867  CYCLIC    11674  CYCLIC
+6380  clean     9274  CYCLIC    12077  CYCLIC
+```
+
+This is a **transition at a point in the route**, not a per-submit coin flip. Whatever changes around
+submit 6795 — scene content reaching some size or shape — is the thing to characterise next. The
+first clean submit also shows `0x413ce6000` dispatching **94** times against 1 thereafter, so the
+early phase is a different workload entirely and the clean result there may not be comparable.
+
 ## Causal A/B: forcing the producer off collapses the builder entirely (2026-08-15)
 
 `PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700,0x413ce6000`, lever verified in the log

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -515,6 +515,60 @@ Two things must be checked before treating this as a defect, and neither has bee
 Recorded as an observation with its caveats rather than a lead, so the next reader neither chases it
 blind nor loses it.
 
+## THE BREAK: the composite samples `0x14…`/`0x15…`, but every render target is `0x20…` (2026-08-15)
+
+`PROSPER_RTTLOG=1` reports, per sampled texture, whether it resolved to a renderer-owned render
+target or fell through to guest memory. Over a routed run:
+
+```
+14389  -> HIT
+ 1638  -> miss
+   49  -> RTT PATH SKIPPED
+```
+
+A 90% hit rate — so the RTT machinery works. **But the misses are systematically the large surfaces,
+and they are in a different address range from every render target prosper draws into:**
+
+```
+[rtt] sample tex addr=0x1557c00000 3840x2160 fmt=9 -> miss (cache_size=8)
+[rtt] sample tex addr=0x1558c00000 3840x2160 fmt=9 -> miss (cache_size=85)
+[rtt] sample tex addr=0x1543c00000 3840x2160 -> miss
+[rtt] sample tex addr=0x1547c00000 4096x2048 -> miss
+[rtt] sample tex addr=0x14df560000 2048x2048 -> miss   (and four more 2048x2048)
+[rtt] sample tex addr=0x1544400000 1920x1080 -> miss
+```
+
+**Sampled addresses that HIT are `0x20xx…`** (the prefix census is dominated by `0x2066`, `0x206c`,
+`0x20d6`, `0x2067`, `0x205f`, `0x20e0`). **The misses are `0x14…`/`0x15…`.** And the draw census
+shows every colour target prosper renders into is `0x20…` — `0x208e5a0000` (~71,000 draws),
+`0x20431c0000`, `0x20ec7c0000`, and the scanouts `0x215ed10000` / `0x2160cf0000` / `0x2162cd0000`.
+
+**So the two sides of the frame use different virtual addresses for the same surfaces.** prosper's
+RTT cache is keyed on the address its draws rendered to; the composite asks for a different one and
+gets nothing, which for a surface prosper rendered into means it samples empty guest memory.
+
+**That is a mechanism that produces exactly the observed symptom**: ~71,000 draws fill a scene
+buffer, a composite runs and reaches the scanout, and the screen shows no world.
+
+**`CONFIDENCE: MED-HIGH` on the observation** — the hit/miss split, the size distribution and the
+address ranges are all measured. **`CONFIDENCE: LOW` on the cause.** Two readings are open and have
+not been separated:
+
+- **VA aliasing.** PS5 titles can map the same physical memory at more than one virtual address
+  (`sceKernelMapDirectMemory`). If the guest renders through one and samples through another, a
+  VA-keyed cache misses by construction, and the fix is to resolve RTT identity through physical
+  memory or an alias map rather than raw VA.
+- **A genuinely different surface.** The `0x14…`/`0x15…` surfaces may be resources the guest
+  produced by some path prosper does not render at all, in which case the miss is a symptom and the
+  absent producer is the defect.
+
+**The measurement that separates them:** whether any `0x14…`/`0x15…` address and any `0x20…` render
+target resolve to the same physical pages. That is answerable from the guest's own memory mapping and
+needs no further routed run.
+
+**This supersedes the DCC suspicion as the leading candidate.** The three unsupported 4K DCC surfaces
+(`0x2052ac0000`, `0x20e0380000`, `0x20df360000`) are all `0x20…` and are not among these misses.
+
 ## WHERE the draws go: a scene buffer with ~71,000 draws, and a composite that reaches the scanout (2026-08-15)
 
 `PROSPER_DRAW_CENSUS=1` now records each draw's `CB_COLOR0_BASE` (+ `_EXT`, + `CB_COLOR0_VIEW`),

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -97,6 +97,66 @@ one dispatch's pre/post pair there is exactly one writer, and its output is cycl
 - **A lane/wave/workgroup boundary effect.** Damage index mod 2/3/4/8/16 is flat.
 - **An unknown or out-of-bounds writer.** Every observed change reported `toucher=1`.
 
+## ROOT CAUSE: `0x413ce6000` never recompiles, and it is the producer of the tags (2026-08-15)
+
+The chain is complete and every link is measured.
+
+**The alias, from `PROSPER_COMPUTE_RESOURCE_MAP`:**
+
+```
+0x413dc3400  binding=4  fetch-pc=86   base=0x209cc76000 size=132032 stride=64   (READ)
+0x413ce6000  binding=13 fetch-pc=212  base=0x209cc76000 size=132032 stride=64   (STORE)
+0x413ce6000  binding=14 fetch-pc=214  base=0x209cc76000 size=132032 stride=64   (STORE)
+0x413ce6000  binding=17 fetch-pc=253  base=0x209cc76000 size=132032 stride=64   (STORE)
+```
+
+`132032 = 2063 x 64` — one 64-byte record per node, exactly the node count. `fetch-pc=86` is the
+load Codex identified as the source of the classified references: `pc86 loads v56/v57 from
+s24[compacted_node].dword[0:1]`, and `v36 = v56 & 7`, `v37 = v57 & 7` are the tags the six store
+predicates test. Eight more of `0x413dc3400`'s bindings (6, 7, 8, 9, 10, 11, 12, 15) are the same
+buffer.
+
+**So `0x413ce6000` writes the record array whose tags `0x413dc3400` reads — and `0x413ce6000` is
+declined on every single dispatch.**
+
+### The full causal chain
+
+1. `0x413ce6000` fails to recompile: `compute-struct-reject execz pc=76 scalar write pc=84 leaves
+   vcc-half s106 live at merge pc=139`. It is realized 40 times per route, at d36, and executes zero
+   times.
+2. Its output — the 2,063 x 64-byte node record array at `0x209cc76000` — is therefore never written.
+3. `0x413dc3400` at d37 reads its six classified references out of that array.
+4. The stale references fail the `tag == 2 || tag == 5` predicate, so the matching child stores never
+   fire — which is exactly the measured failure mode: **a store that does not execute, leaving the
+   slot holding a stale value**.
+5. 220–461 parents end up with one child instead of two → the parent array is cyclic.
+6. `0x413dc6700` at d39+ walks it with a loop that has no iteration bound and no cycle detector →
+   GPU hang → RADV device loss → live compute disabled process-wide → every later indirect draw
+   dropped → **no world**.
+
+**This is the charter's rule in its purest form: an unsupported program is a fatal gap, not an
+acceptable skip.** One declined compute program, six dispatches upstream, removes the world.
+
+It also explains why `0x413ce3400` gets its tree right. Codex's ISA read: it computes both child
+indices directly from the Morton range/split and stores both links unconditionally, with no tag
+predicate anywhere in its 391 instructions. It does not depend on `0x209cc76000`, so a missing
+producer cannot reach it.
+
+**Do not "fix" this by removing `0x413dc3400`'s predicate.** The guest declines to dereference
+non-materialised references on purpose; making the stores unconditional would turn unmaterialised
+references into indices and change guest semantics. The fix is upstream: make `0x413ce6000` compile.
+
+### Status of that fix
+
+`PROSPER_VCC_SCALAR_DATA_MERGE=1` (this branch) widens the execz VCC-half proof from "not read" to
+"not read as a lane mask" and clears the first reject; `0x413ce6000` then fails at a *second* path
+that logs nothing under any variable. Making that second reject legible is the immediate next step —
+it is one of the five programs in the `reason=unrecorded` set.
+
+Note on a red herring: `[compute] program 0x413ce6000 is a proven no-op (only proven no-backing
+resources)` does appear, but only for an instance with **zero** backed resources (dispatch 968). At
+d36, where it matters, it has **17** backed resources including the three stores above.
+
 ## THE SECOND TABLE IS BUILT PERFECTLY — by a different program (2026-08-15)
 
 `PROSPER_COMPUTE_TREE_WATCH=0x20f848a240:2063`, same route. The two addresses are **not** a

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,54 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Second review round on #2550, all five fixed (2026-08-15)
+
+**1 (blocker) — MRT2–7 reused an image in the wrong Vulkan layout.** The retained image was recorded
+as `COLOR_ATTACHMENT_OPTIMAL` while the pass left it in `TRANSFER_SRC_OPTIMAL` and no restore
+transition existed, so the next group declared an initial layout the image was not in. Codex
+reproduced it under `VK_LAYER_KHRONOS_validation` as `VUID-vkCmdDraw-None-09600`; the pixel assertion
+still passed on RADV, so the ordinary suite could not see it. Slots 2–7 now take the complete MRT0/1
+lifecycle — pre-pass load barrier from the truthful current layout, persistent final layout, readback
+transition, restore, and a recorded layout that matches. Mutation-verified: restoring the old
+recorded layout brings back exactly `VUID-vkCmdDraw-None-09600` (x2) plus
+`VUID-VkImageMemoryBarrier-oldLayout-01197` (x8); the fix gives **zero**, which also proves the layer
+was active rather than silently absent.
+
+**The gate already existed.** `tools/vkval/vk_validation_scan.py` runs the whole suite under the
+layer, allow-lists known IDs, fails on unknown ones, and refuses a clean verdict unless the layer
+provably loaded. Neither VUID is allow-listed, so that scan *is* the regression: `VKVAL_RC=0` now,
+and it fails with the defect present.
+
+**2 (high) — sparse MRT passes bypassed the persistence contract.** The colour target was passed to
+the backend only when MRT0's `base` was non-zero, and the comment at that very call site already
+documented that MRT0-unbound / higher-slot-bound passes are reachable. Such a pass populated
+`persistent_id_slots[2..7]` and then handed the backend `nullptr`. Now gated on the union of every
+bound slot — the same union the readback flag beside it already used. Effect on the live title: **c4
+513,338 → 3,472,691** non-black pixels.
+
+**3 (high) — the cap-order and baseline tests did not exercise the production sites.** They called
+two pure predicates, so moving the cap check back below the capture, or deleting the baseline latch,
+left every assertion green. Replaced with orchestration seams that *own* the properties:
+`frame_bundle_append_submit()` takes the capture step as an injected callable, so a test observes
+whether it ran; `frame_bundle_open_window()` owns the latch. Both mutations Codex named now fail —
+moving the cap below the capture gives 2 failures, deleting the latch gives 3.
+
+**4 (medium) — the MRT2 negative arm could skip itself.** It entered its only assertion under
+`if (cleared.size() == px)` without ever asserting that size, so a regression returning an empty
+buffer would have passed the negative control silently. The extent is asserted now.
+
+**5 (medium) — the capture size bound ran before the v55 tail.** A capture near the 4 GiB ceiling
+could serialize successfully into a file `read_gpu_capture` then rejects as oversized. Re-checked
+after the final tail, with a note that any future tail must move the check again.
+
+### The pattern across both review rounds
+
+Four of the nine findings across the two rounds are the same shape: **a check that cannot fail.** The
+negative arm gated on a size it never asserted; the cap and baseline tests called predicates instead
+of the sites; the timeline assertions sat after their own fail gate; and the layout defect passed
+every pixel assertion while being undefined behaviour. Only the last needed a tool to see — the other
+three were readable in the diff, and I wrote all of them.
+
 ## Review findings on #2550, all four fixed (2026-08-15)
 
 Codex reviewed the MRT work and found four verified issues. All are real; all four were confirmed

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -97,6 +97,41 @@ one dispatch's pre/post pair there is exactly one writer, and its output is cycl
 - **A lane/wave/workgroup boundary effect.** Damage index mod 2/3/4/8/16 is flat.
 - **An unknown or out-of-bounds writer.** Every observed change reported `toucher=1`.
 
+## The selector chain at `0x413ce6000` pc149..156 — the exact fix site
+
+Decoded with prosper's own opcode constants (`rdna2_decode.hpp`), not guessed:
+
+```
+pc149  s_mulk_i32            s106, 120          ; SOPK 0x10. selector * 120, in VCC_LO as scratch
+pc150  s_load_dwordx4        s[4:7], s[0:1], m0 ; the descriptor-ARRAY V#
+pc153  s_buffer_load_dwordx4 s[8:11], s[4:7], s106  ; SELECT one V# at selector*120
+pc156  buffer_load_dwordx3   v[0:2], v6, s[8:11], 0 ; use it   <-- mode=unresolved-operand
+```
+
+**120 is exactly the array's stride.** `PROSPER_DYNTRACE_FAIL` confirms the split:
+
+```
+BUF(v4) key=0xa8       use_pc=153  base=0x203f249b38 stride=120 records=5 size=600   RESOLVED
+BUF(v4) key=0xffffffff use_pc=156  v4=00000000:00000000:00000000:00000000            UNRESOLVED
+```
+
+So the descriptor-array lift **finds the array** at pc153 and **cannot resolve the selected element**
+at pc156: `key=0xffffffff` is the sentinel the executor's own comment names as matchable by none of
+the three routes (fetch pc, SRT offset, SGPR base).
+
+**Why the selector does not resolve. `CONFIDENCE: MED`.** The selector arrives through **VCC_LO used
+as an ordinary scalar register** — GTA V's compiler recycles it, which this file already documents
+elsewhere. prosper's VCC-as-scalar recognition is
+`is_wave64_vcc_lo_scalar_b32_candidate`, and it covers exactly two shapes: `s_cselect_b32` with
+inline operands, and SOP2 B32 logicals. **`s_mulk_i32` is SOPK and is in neither set**, so the write
+at pc149 is not recognised as a scalar-scratch definition. That matches the failure exactly, but the
+alternative — that the const-fold breaks somewhere else along `s106`'s chain — has not been
+separately excluded, so this is a lead and not a conclusion. Verify before building on it.
+
+This is the same underlying difficulty as the execz VCC-half liveness guard cleared earlier today:
+**every remaining obstacle in this program comes from the guest recycling VCC as a general scalar
+register, and prosper modelling VCC specially in each place independently.**
+
 ## THE REMAINING BLOCKER, EXACTLY (2026-08-15)
 
 Every compute reject on a routed run now names its cause without `PROSPER_DBG`. `0x413ce6000` — the

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,45 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## The builder's INPUT differs between the two regimes (2026-08-15)
+
+`PROSPER_COMPUTE_TREE_WATCH_AUX=0x209cc76000:33008` captures the 2,063 x 64-byte record array
+alongside every builder transition, clean and cyclic, from one run. The tags the six store predicates
+test are `record.dword0 & 7` and `record.dword1 & 7`.
+
+**Every submit where the builder emits a perfect tree shares one input signature, and no broken
+submit has it:**
+
+| submit | pairs / unpaired | tag(dword0) | tag(dword1) |
+| --- | --- | --- | --- |
+| 5943 | **1029 / 2** | `{0:970, 2:2, 5:1088, 7:3}` | `{0:977, 1:5, 5:1078, 7:3}` |
+| 7188 | **1029 / 2** | `{0:972, 2:2, 5:1086, 7:3}` | `{0:977, 1:5, 5:1078, 7:3}` |
+| 8016 | **1029 / 2** | `{0:973, 2:2, 5:1085, 7:3}` | `{0:978, 1:5, 5:1077, 7:3}` |
+| 8842 | **1029 / 2** | `{0:973, 2:2, 5:1085, 7:3}` | `{0:978, 1:5, 5:1077, 7:3}` |
+| 9247 | **1029 / 2** | `{0:973, 2:2, 5:1085, 7:3}` | `{0:978, 1:5, 5:1077, 7:3}` |
+| 5528 | 663 / 64 | `{0:1120, 2:3, **4:2**, 5:935, 7:3}` | `{0:1122, **1:15**, 5:923, 7:3}` |
+| 6358 | 608 / 51 | `{0:1098, 2:3, **4:2**, 5:957, 7:3}` | `{0:1107, **1:15**, 5:938, 7:3}` |
+| 10052 | 676 / 74 | `{0:1133, 2:3, **4:2**, 5:922, 7:3}` | `{0:1134, **1:15**, 5:911, 7:3}` |
+
+Two differences are systematic in the early broken submits: **tag 4 appears in dword0** (exactly 2
+records, never present in a perfect submit) and **tag 1 in dword1 jumps from 5 to 15**.
+
+**But neither is the whole story, and the record says so.** The later broken submits (11238 onward)
+carry `1:5` and no tag 4 — the perfect signature on those two axes — and are still broken
+(`pairs≈861, unpaired≈193`), with tag 5 *higher* than in the perfect submits (1301 against 1085). So
+"tag 4 present" and "tag1 == 15" are correlates of the early regime, not the mechanism. Do not
+promote them to a rule.
+
+**What is established:** the array the builder reads changes materially with scene state, and the
+builder's output tracks it. Combined with the eleven perfect submits, that puts the defect **upstream
+of `0x413dc3400`** — in whatever produces `0x209cc76000`.
+
+**Its producers, from `PROSPER_COMPUTE_TREE_WATCH=0x209cc76000`:** `0x413cf9000` (117 changes),
+`0x413cf9200` (117), `0x413cf5400` (29), `0x413cf6100` (29), `0x413ce6000` (26), `0x413d1bf00` (2),
+and `0x413e1ff00` (3, **`toucher=0`**). `0x413cf9200` has 20 recompile-empty dispatches of 678, and
+`0x413e1ff00` writes bytes it does not bind. **Both are unexamined and both are better leads than
+anything remaining on the builder.**
+
 ## THE BUILDER'S LOWERING IS CORRECT — it emits a perfect tree for eleven submits (2026-08-15)
 
 `PROSPER_COMPUTE_DISPATCH_LOG` now carries the launch geometry, so the outcome and the launch can be

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1031,6 +1031,34 @@ is not what these runs were.
 `scc = -1` has a handful of sites in the fold, and each is either a real SCC write or a conservative
 one like the `s_mulk_i32` case that was corrected.
 
+## The `selected_sbuffer` contract NEVER ACCEPTS — it is not on the path at all (2026-08-15)
+
+`PROSPER_GTA5_SBUFFER_ACCEPT=1` (added here) reports the descriptor the contract publishes on the
+dispatches it accepts. Every existing diagnostic on this contract described a **decline**, so the
+accept side had never been looked at.
+
+**It reports nothing. Zero accepts on a full routed run**, against two distinct decline reasons.
+
+Yet `0x413ce6000` **executes 129 times of 139**. So those executions do not go through this contract
+at all — they go through the **generic runtime-array lift**, which is what puts `entries=5` in the
+resource map at `fetch-pc=156/158`.
+
+**Consequence: every section above that reasons about this contract is reasoning about a path that
+does not fire.** The record-4 hardcoding, the selector histogram, the frustum-plane content of the
+outer buffer — all real observations, and all about machinery that declines and is then bypassed.
+They explain the ~10 dispatches that are declined outright; they do not explain the 129 that run.
+
+**The descriptor those 129 executions actually use comes from the generic lift**, and Codex's caveat
+applies to it exactly as it did to the contract: *"it too materializes entries eagerly from
+CPU-visible memory"*, with no command-order snapshot coupling it to the bytes the GPU consumes. A
+descriptor materialised from the wrong epoch is a coherent explanation for node records whose child
+graph is cyclic, and it is now the **only** remaining candidate on this path that has not been
+tested.
+
+**The next measurement is the generic lift's published entries at `0x413ce6000`'s dispatches**, in
+the same style: what addresses it materialises, and whether they change between a dispatch that adds
+cycles and one that does not.
+
 ## The contract reads a BVH NODE-REFERENCE array as a selector array (2026-08-15)
 
 The selector histogram, taken from the same source records the contract's own domain proof walks:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -312,6 +312,47 @@ zero-extent. `num_records = 0` then follows from dword2 being absent, and `size 
 `unresolved-operand` from that. **That is the next thing to test**, and it is a different defect from
 anything this document has chased: not a wrong descriptor, a half-read one.
 
+## THE UNIFYING CAUSE: GTA V recycles VCC_LO as a general scalar register (2026-08-15)
+
+The BVH descriptor at the rejecting instruction is **built in the shader**, and it is built through
+VCC_LO. `0x205b654a00` pc1180 is `image_bvh_intersect_ray` with its descriptor in `s[16:19]`:
+
+```
+pc1171  s19  = <computed>
+pc1174  s106 = s19 & 0x000003ff            ; VCC_LO as scalar scratch
+pc1176  s17  = <computed>
+pc1177  s19  = s106 | 0x81000000           ; and back out of VCC_LO
+pc1179  s_waitcnt
+pc1180  image_bvh_intersect_ray  v[0..], v6, s[16:19], s[0..]
+```
+
+`(x & 0x3ff) | 0x81000000` is the BVH descriptor's dword3 — its size-high bits and type field. **The
+descriptor cannot resolve unless the const-fold tracks a value through VCC_LO.**
+
+That is the same obstacle as everywhere else in this title:
+
+| site | what VCC_LO carries | consequence |
+| --- | --- | --- |
+| `0x205b654a00` pc1174/1177 | the BVH descriptor's dword3 | `image_bvh_intersect_ray` rejects, the ray-tracing pass never compiles |
+| `0x413ce6000` pc149 | `s_mulk_i32 s106, 120`, the descriptor-array selector | `buffer_load_dwordx3` at pc156 rejects |
+| `0x413ce6000` pc84/90 | integer scratch inside an execz arm | the structurizer's VCC-half liveness guard rejects (cleared on this branch) |
+| GTA V generally | `is_gtav_wave64_vcc_lo_scalar_cselect` exists precisely for this | already a known pattern in the code |
+
+**prosper models VCC specially in each place independently — the liveness proof, the scalar-scratch
+recogniser, the descriptor const-fold — and each place has its own, narrower notion of which VCC
+writes count as data.** `is_wave64_vcc_lo_scalar_b32_candidate` admits exactly `s_cselect_b32` with
+inline operands and SOP2 B32 logicals. `s_mulk_i32` (SOPK) is not in it. Neither is the
+`s_and_b32`/`s_or_b32` pair above being tracked *through* to a descriptor.
+
+**This is the frontier.** Not the tree builder, whose lowering is proven correct by eleven perfect
+submits; and not a missing producer, which is falsified. A single coherent treatment of "VCC_LO used
+as an ordinary scalar register" — one recogniser consulted by the liveness proof, the scalar model
+and the const-fold alike — is what the remaining rejects have in common.
+
+`CONFIDENCE: MED` on that being sufficient. It is established that the descriptor passes through
+VCC_LO and that prosper's VCC recognisers do not cover these shapes; it is *not* established that
+covering them is enough to make either program compile, because neither has been tried.
+
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 
 Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -78,6 +78,25 @@ both decoding to parent 296), so it is a flag-bit difference and a separate anom
 **Ruled out by this measurement:** the "lost update" / two-writer race account of the cycle. Within
 one dispatch's pre/post pair there is exactly one writer, and its output is cyclic.
 
+## Falsified for `0x413dc3400` (2026-08-15) — checked, not assumed
+
+- **Barrier uniformity.** All eight `OpControlBarrier`s in the emitted module are in uniform blocks.
+  Three sit in each dispatcher's **continue target** (`OpLoopMerge %163 %162` — %162 is the continue
+  block, reached by every invocation on every iteration) and five at structured merge targets. The
+  design comment in `rdna2_to_spirv.cpp` states this invariant explicitly ("the switch merge is
+  reached by every invocation on every iteration"); it holds in the artefact. A barrier inside a
+  `switch(pc)` *case* would have been a real Vulkan uniformity violation — it is not what is emitted.
+- **Native subgroup / multiwave lowering.** `[subgroup] cs=0x413dc3400 … native=0 … multiwave=0`:
+  the program is already lowered through the portable wave model, so there is no native lowering to
+  blame. `PROSPER_NO_NATIVE_COMPUTE_MULTIWAVE=1` leaves all nine of its module hashes byte-identical.
+- **LDS undersizing.** The module declares 384 dwords = 1,536 bytes = 3 × 512-byte
+  `COMPUTE_PGM_RSRC2.LDS_SIZE` granules; Codex's ISA read puts the largest accessed LDS address at
+  byte 1,028. Sized correctly and over-provisioned either way.
+- **A race.** Two different frames produce broken-pair patterns sharing a 60-character suffix
+  exactly, with the same first damaged index. Deterministic given the input.
+- **A lane/wave/workgroup boundary effect.** Damage index mod 2/3/4/8/16 is flat.
+- **An unknown or out-of-bounds writer.** Every observed change reported `toucher=1`.
+
 ## THE SECOND TABLE IS BUILT PERFECTLY — by a different program (2026-08-15)
 
 `PROSPER_COMPUTE_TREE_WATCH=0x20f848a240:2063`, same route. The two addresses are **not** a

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -10,6 +10,71 @@ presses for a reason).
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
+## What the structure IS: an LBVH / binary-radix-tree parent table from Morton keys
+
+Identified by Codex from the retained ISA (#2542), and it reframes everything below.
+
+- **2,063 = 2 × 1,032 − 1** — exactly the node count of a full binary tree with 1,032 leaves and
+  1,031 internal nodes.
+- **Adjacent pairs are SIBLINGS** sharing one parent; bit 30 identifies the child side. The root is
+  the single unpaired node. That explains the count, the pairing, the parent chase and the depth
+  parity together, where "union-find with path compression" only explained the chase.
+- `0x413cee500` contains the standard 3D Morton bit-dilation constants `0x030000ff`, `0x0300f00f`,
+  `0x030c30c3` and **`0x09249249`**, then stores `buffer_store_dwordx3` at pc274 — Morton key
+  generation.
+- `0x413e1c300` loads two three-dword records, runs a 64-lane LDS compare/exchange loop, and stores
+  two three-dword records — a Morton sort/merge pass upstream of topology construction.
+
+**CORRECTION — `0x09249249` is NOT an empty-slot sentinel.** This document said it was. It is the
+Morton dilation mask, used as a literal by the key generator. In the captured parent view it happens
+to behave as an out-of-range terminator, but that may be an intentional empty value, a Morton key
+left in repurposed scratch, or another phase's encoding. Call it an **observed OOB/unused value**
+until its producing store is identified.
+
+**Naming:** the "malformed head/tail pair" score is measuring a real property, but the neutral name
+is **unpaired sibling records**. Keep it as a quantitative correlation and do NOT promote "must be
+zero" to a correctness rule: clean samples tolerate up to 13, and the slot-level causal test failed.
+A sharper check is whether the active-node count predicts exactly 1,031 sibling pairs.
+
+## Access direction: eight touchers, FIVE may-writers
+
+Codex joined the census's `fetch-pc` values to the retained guest instructions. MUBUF `0x0c..0x0e`
+are loads, `0x1c..0x1e` are stores:
+
+| program | watched instructions | direction |
+| --- | --- | --- |
+| `0x413ce3400` | pc35, 66, 68 … 421, all `buffer_load_dword{,x2}` | **read only** |
+| `0x413ce6000` | pc36 `buffer_load_dword` | **read only** |
+| `0x413cea300` | terminator-only, `fetch-pc=0xffffffff` | **no data access** |
+| `0x413cee500` | pc274 `buffer_store_dwordx3` | **write** |
+| `0x413d88400` | 18 watched pcs, all stores | **write** |
+| `0x413dc3400` | pc597/608/620/632/644/656 stores | **write** |
+| `0x413dc6700` | pc91 load; pc53/65 and 618..677 stores | **read/write** |
+| `0x413e1c300` | pc86/95 loads x3; pc166/176 stores x3 | **read/write** |
+
+So the may-write set is **`0x413cee500`, `0x413d88400`, `0x413dc3400`, `0x413dc6700`,
+`0x413e1c300`**. The two read-only programs and the terminator leave the writer investigation.
+
+**A statically writable descriptor whose range contains the address is a CANDIDATE writer**, not
+proof that a given invocation wrote that 4-byte slot; changed-byte pre/post evidence closes that.
+
+**Address-boundary caveat that must not be lost:** `0x413e1c300`'s observed view is
+`base=0x20f8482140 size=33024`, and `base + size == 0x20f848a240` **exactly**. It therefore may write
+the first table and proves nothing about the second. The census must be re-run for `0x20f848a240`
+before this eight-program set is carried across both ping-pong tables.
+
+## No guest-side escape makes a reachable cycle safe
+
+Checked by Codex against the retained ISA: the pre-loop bound only excludes padded threads (on the
+problematic shape `s18 = 2063` and the launch has 2,063 guest threads, so every active root is
+represented); the loop has no iteration count and no cycle detector; `v_cmpx_ne_u32` only retires
+lanes reaching index zero, so a lane inside a cycle stays active forever; and the `s24` comparison
+happens **after** the walk, so it cannot guard entry.
+
+A builder may hold transiently inconsistent parent links while constructing the hierarchy. Hardware
+still cannot launch this consumer on reachable cyclic links — they must be repaired before it,
+excluded from its active root set, or absent from the bytes it consumes.
+
 ## The current account — read this before anything below it
 
 This document is layered: it grew as an investigation log, and several sections below are historical

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -423,10 +423,22 @@ Result: **`frame-bundle written (25 submits)`, 512 MB**, loading as
 [gpureplay] bundle-submit=19374 operations=1/1 output_bytes=1048576
 ```
 
-**Four consecutive captured submits contain ZERO operations, and the fifth contains one.** At this
-point in the route the guest's submits carry almost no GPU work at all — which is consistent with
-the absent world, and is the first evidence about it that comes from the frame rather than from log
-statistics.
+**Four consecutive captured submits contain ZERO operations, the fifth one, the sixth three.**
+Reproduced on an independent capture (submits 23910–23915 against 19370–19374), and
+`operations=%zu/%zu` is `limit / total`, so the second figure is the submit's real operation count.
+
+**But this window is NOT representative, and reading it as "the guest submits nothing" would be
+wrong.** The tree watch elsewhere in this document reports the BVH builder at `dispatch=37` and the
+scratch reuse at `dispatch=54` **within a single submit** — so submits carrying 50+ operations
+demonstrably exist on this route. The capture simply landed on a quiet stretch: `MAX_SUBMITS` bounds
+it to the *first* 25 of a burst, and the window opens wherever the timed arm falls.
+
+**What it does establish** is that the capture path now works end to end and that submit-level
+operation counts are readable. **What it does not** is anything about where the world's draws are.
+
+**The next step is to aim the capture at a submit known to contain work** — the tree watch names
+them exactly (any submit at its `d37`) — rather than at a wall-clock moment. `PROSPER_CAPTURE_FRAMES`
+arms on time or frame ordinal; landing on a chosen submit needs the arm to be submit-indexed.
 
 **Read with care, `CONFIDENCE: MED`.** Three things are not established: whether `operations=0/0`
 means the guest submitted nothing or the capture recorded nothing; whether the 25-submit window

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -78,6 +78,47 @@ both decoding to parent 296), so it is a flag-bit difference and a separate anom
 **Ruled out by this measurement:** the "lost update" / two-writer race account of the cycle. Within
 one dispatch's pre/post pair there is exactly one writer, and its output is cyclic.
 
+## THE SECOND TABLE IS BUILT PERFECTLY — by a different program (2026-08-15)
+
+`PROSPER_COMPUTE_TREE_WATCH=0x20f848a240:2063`, same route. The two addresses are **not** a
+ping-ponged copy of one structure: they have disjoint writer sets.
+
+| address | writers | result |
+| --- | --- | --- |
+| `0x20f848417c` | `0x413dc3400`, `0x413d88400`, `0x413e1c300`, `0x413cee500` | **37 of 40 dispatches leave it cyclic** |
+| `0x20f848a240` | `0x413ce3400`, `0x413cf5400`, `0x413d88400`, `0x413cdc200` | **clean; 3 of 133 transitions cyclic, each repaired immediately** |
+
+And the decisive line: **`0x413ce3400` produces a PERFECT tree at `0x20f848a240`, every single time.**
+
+```
+program=0x413ce3400 changed=2061 pre{... pairs=0 unpaired=0}
+                              post{cycles=0 cyclic-roots=0 oob-roots=0 max-depth=11 pairs=1030 unpaired=0}
+```
+
+`pairs=1030, unpaired=0, cycles=0, max-depth=11` — exactly the clean ground truth, on all 41 of its
+dispatches. So **prosper can already build this structure correctly.** The defect is specific to
+`0x413dc3400`, and there is now a working reference program to differentially compare against.
+
+The two are different programs, not two instances of one:
+
+| | `0x413ce3400` (correct) | `0x413dc3400` (broken) |
+| --- | --- | --- |
+| instructions | 391 | 765 |
+| DS (LDS) ops | **0** | 5 (`ds_write_b32` x2, `ds_add_rtn_u32`, `ds_read_b32` x2) |
+| `s_barrier` | **0** | 2 |
+| CFG dispatchers | — | 3 (one per barrier-free phase) |
+| MUBUF | 29 | 37 |
+
+**The distinguishing features of the failing one are exactly the workgroup-cooperative machinery**:
+the LDS stream compaction Codex decoded at pc47..74 (`ds_add_rtn_u32` hands each qualifying lane a
+ticket; the two barriers bracket counter initialisation and list publication), and the barrier-phased
+CFG dispatcher that machinery forces. The correct builder has none of it.
+
+That also resolves an inconsistency in the record: the consumer's own captures show ~1029-1030 pairs,
+which matches the `a240` tree rather than `417c`'s 919. The consumer's bound table address alternates
+between the two across frames, so it walks a good tree on some frames and the broken one on others —
+which is why the hang arrives at a particular dispatch rather than the first.
+
 ## The failure mode, exactly: one of the two per-parent stores does not execute
 
 Established from both images of 18 clean -> cyclic transitions.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,37 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The BVH descriptor resolves only when SCC does (2026-08-15)
+
+`PROSPER_DYNTRACE_SGPR=19` on `0x205b654a00`, now that the watch prints a real program identity:
+
+```
+pc=1171 s19 <- FORGOTTEN words=821380c1        pc=1171 s19 <- KNOWN 0x00000000
+pc=1177 s19 <- FORGOTTEN words=8813ff6a        pc=1177 s19 <- KNOWN 0x81000000
+```
+
+**The descriptor's dword3 resolves on some dispatches and not others**, ending at `0x81000000` when
+it does. pc1171 is `s_addc_u32 s19, -1, 0` — **both operands are inline constants**, so the only
+input that can make it unknown is **SCC**.
+
+`s_addc_u32` **is** modelled by the fold (`case 0x04`, guarded by `if (scc < 0) { ok = false; }`).
+*(I first reported it as unmodelled, from a grep for `kSop2OpcodeAddcU32` that missed the literal
+`0x04` at the case label. Corrected here.)* So the BVH descriptor's resolution reduces to: **is SCC
+tracked across the instructions before pc1171?**
+
+That makes SCC invalidation the lever, and it is exactly what the `s_mulk_i32` change touched — that
+op does not write SCC and the fold was clobbering SCC for it anyway.
+
+**Suggestive but confounded, recorded as such.** Across runs on this branch `0x205b654a00`'s reject
+changed from a `compute-struct-reject` to the pc1180 descriptor reject, and the total skip count fell
+18 → 15 → 14 → 13. Neither is evidence: the runs differ in more than one variable and the route
+reaches different phases. **A clean A/B needs one flag toggled with the artefact hashed first**, which
+is not what these runs were.
+
+**The concrete next step** is a census of what invalidates SCC on the path to pc1171 in this program —
+`scc = -1` has a handful of sites in the fold, and each is either a real SCC write or a conservative
+one like the `s_mulk_i32` case that was corrected.
+
 ## The contract reads a BVH NODE-REFERENCE array as a selector array (2026-08-15)
 
 The selector histogram, taken from the same source records the contract's own domain proof walks:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -367,11 +367,34 @@ Folded it: multiply a known destination, forget an unknown one as before, and st
 
 **It did not change the reject.** `0x413ce6000` still fails with `mode=unresolved-operand pc=156`.
 
-**And the arm is VOID, not negative** — the same discipline applied to the multiwave A/B. Nothing in
-this run demonstrates that the fold's output actually changed for this program: the reject is
-produced downstream of several other steps, and no artefact was hashed before the outcome was read.
-Treat "s_mulk folding does not fix `0x413ce6000`" as untested, not as false. The way to test it is to
-show s106 is now *known* at pc153 — which needs a fold-state probe that does not exist.
+**Then the probe was run, and it explains why — the fold was aimed at the wrong thing.**
+
+`PROSPER_DYNTRACE_SGPR=106` gives s106's complete fold history in this program:
+
+```
+pc=3    KNOWN 0x00000000
+pc=56   FORGOTTEN  words=beea376a
+pc=84   KNOWN 0x00000000 / 0xfffff7f0
+pc=90   KNOWN 0x7f7fffff
+pc=116  FORGOTTEN  words=beea3704      <- the break
+pc=131  FORGOTTEN  words=beea3704
+pc=149  FORGOTTEN  words=b86a0078      <- s_mulk_i32 s106, 120, with s106 ALREADY unknown
+```
+
+pc116 and pc131 are `SOP1 op=0x37 s[106:107], s[4:5]`, which prosper classifies as a **B64
+data/mask write** and which the RDNA2 encoding makes **`s_andn1_saveexec_b64`**: `exec = ~s4 & exec`,
+and **`s106` receives the OLD EXEC MASK**. Both are immediately followed by `s_cbranch_execz`.
+
+**So the descriptor-array selector is derived from a saved EXEC mask.** `s_mulk_i32 s106, 120` is
+multiplying a lane mask by the array's record stride. That is a wave-dependent runtime value, not a
+constant, and **no const-fold can ever resolve it** — which is precisely why this program has a
+dedicated `selected_sbuffer` contract that certifies the selector's complete *domain* from live
+source records instead of folding it.
+
+**Conclusion: the `s_mulk_i32` fold does not address this reject and cannot.** The reject is the
+contract's `selected-vsharp` decline — record 4 of the outer array holding float AABB data — and the
+const-fold was never on that path. The fold change stays for its own reasons; this reject needs the
+contract.
 
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,36 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## Causal A/B: forcing the producer off collapses the builder entirely (2026-08-15)
+
+`PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700,0x413ce6000`, lever verified in the log
+(`-> 2 program(s) will be declined`), 200 s route, against the baseline arm.
+
+| | baseline | producer forced off |
+| --- | --- | --- |
+| `0x413dc3400` table-changing dispatches | **40** | **1** |
+| `0x413dc3400` clean -> cyclic | 37 | **0** |
+| clean -> cyclic, all programs | 40 (37 from the builder) | 46 (all from `0x413d88400`) |
+
+**`0x413dc3400` essentially stops writing a tree.** So its output does depend on `0x413ce6000`
+having run — the dependency the resource alias predicted is real and now demonstrated, not inferred.
+
+**The confound, stated because it is not excluded.** A declined compute dispatch clears
+`producer_epoch_ok`, and the next `ParserStall` latches `indirect_dependencies_ok` false for the rest
+of the submit — the indirect latch this document opens with. Forcing `0x413ce6000` to decline
+therefore suppresses later indirect dispatches too, so this arm cannot separate
+
+  (a) `0x413dc3400` runs and reads a stale record array, from
+  (b) `0x413dc3400` is never dispatched at all.
+
+Both predict what was measured. Separating them needs a per-dispatch execute/decline record for both
+programs in the same run, correlated frame by frame — which is the measurement the retracted
+root-cause claim needed and never had.
+
+Also note the dumped post-images differ in *provenance* between the arms: in the forced-off arm the
+clean -> cyclic transitions come from `0x413d88400`, not the builder, so their `pairs=0` is not
+comparable to the baseline builder's `pairs≈819`. The comparable figure is the dispatch count.
+
 ## CORRECTION (2026-08-15): the "never executes" claim above is WRONG
 
 Watching the record array itself — `PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:2063` — refutes the

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,55 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Review findings on #2550, all four fixed (2026-08-15)
+
+Codex reviewed the MRT work and found four verified issues. All are real; all four were confirmed
+against the source before acting.
+
+**1 (blocker) — MRT2–7 did not survive a render group.** Slots 2+ were transient images created per
+backend call with `LOAD_OP_CLEAR` and `initialLayout = UNDEFINED`, and only slots 0 and 1 had a seed
+or persistent path. GTA V's G-buffer accumulates across roughly sixteen pass groups per frame, so
+each group erased its predecessor's slots 2–4 and only the last survived. The MRT widening made the
+recompiler able to emit five outputs while the runtime kept the attachment incomplete.
+
+Fixed by giving slots 2–7 the same persistent-target contract slots 0 and 1 have, with the same
+over-budget fallback to a transient image. Measured on the same route, best non-black pixel count per
+slot: **c2 240,121 → 4,513,318** and **c3 407,957 → 4,513,318** (54% of a 4K frame), c4 313,908 →
+513,338, with 0 validation errors.
+
+**2 (blocker) — layered DS capture identity omitted the slice.** Once two cube faces were valid,
+`snapshot_persistent_ds_images` emitted two seeds that were identical apart from the slice; the writer
+rejected the second as `duplicate DS seed identity`, so F9 capture failed outright, and restore keyed
+every seed at slice 0 so even a written capture could not replay the faces distinctly. Fixed with a
+**v55** capture tail carrying each seed's slice (pre-v55 reads back as slice 0).
+
+**3 (high) — `PROSPER_CAPTURE_MAX_SUBMITS` tested the cap after capturing.** Every post-cap submit
+paid the full capture cost, and a post-cap capture *failure* set `b.failed` and discarded the
+already-valid capped bundle — the exact outcome the cap exists to prevent. The cap is now tested
+before any capture work.
+
+**4 (medium/high) — the empty-window hook counters were process totals.** They accumulate from
+startup and were printed verbatim as evidence about one capture window, so ordinary activity before
+F9 made a genuinely empty window look as though the hook had been reached during it. Now baselined
+when the window opens, with a saturating delta so a missed baseline prints 0 rather than a wrapped
+count near 2^64.
+
+### Two lessons from the review worth more than the fixes
+
+- **A tail must go at the END of the stream, not beside the data it describes.** The v55 slice was
+  first written next to the DS seed records, which round-trips perfectly and desynchronises every
+  later tail the moment the version byte is downgraded — the exact thing eleven legacy-reopen
+  fixtures do. The capture format's append-only convention is not a style preference; it is what
+  makes `serialize at current version → lower the version byte → reparse` work at all.
+- **A test that builds a struct by hand does not cover the code that builds it.** Codex's sharpest
+  point: the first slice regression constructed `PersistentDsKey` directly, so reverting the
+  production decode left it green. The seam is now extracted as `persistent_ds_key_for()` and the
+  test calls it — verified by mutation: replacing the decode with `0u` turns both assertions red,
+  restoring it turns them green.
+- **And the one I got wrong on my own: `ctest` after `cmake --build --target screenshot` tests STALE
+  BINARIES.** The v55 change broke 23 assertions in `test_gpu_capture` while I reported 245/245,
+  because that target had not been rebuilt. Build everything before quoting a suite result.
+
 ## Cube depth: the DS cache overwrote its own faces (2026-08-15, fixed) — and the falsification above is RETRACTED
 
 **Retraction first.** The section below this one records cube shadow maps as falsified. That call was

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,52 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Fifth review round on #2550, all four fixed (2026-08-15)
+
+**1 (blocker) — MRT1 was still discarded under the live renderer's calling convention.** The live
+call passes `out_rgba1 == nullptr` and receives slot 1 through `BackendMrtOutputs`. On a non-final
+split the slot-1 readback therefore landed in `intermediate_mrt.colors[1]`, while the wrapper carried
+a seed forward only inside `if (out_rgba1)` — so MRT1 was lost on every split. The MRT2 regression
+could not see it because it jumps from MRT0 straight to MRT2. **The claim in the previous round that
+"slots 0 and 1 already carry through `seed_rgba`/`seed_rgba1`" was true only of the legacy explicit
+API, and is corrected here.** Added `seed_rgba1_slot`, the carry now takes whichever buffer received
+slot 1, and there is a second Vulkan split regression written with the live signature.
+
+**2 (high) — the MRT2–7 carry was selected by identity, not residency.** A non-zero
+`persistent_id_slots[slot]` does not mean the image survives: persistence also requires
+`persistent_color_targets_enabled` and a successful cache/budget allocation, and the slot-creation
+path falls back to a transient image while leaving the identity non-zero. The wrapper cannot see
+those decisions, so it no longer predicts them — a non-final split segment captures every slot
+unconditionally. Regressed with a non-zero MRT2 identity and
+`PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS=1`.
+
+**3 (high) — the materialization changes had no regression at their call sites.** Reverting either
+production site left everything green. Both decisions are now seams that own their gate —
+`mrt_direct_serves()` and `mrt_uniform_live_serves()` — and the mutation reverting the gate inside the
+seam turns a named assertion red.
+
+**4 (medium) — the binding test asserted a contract production does not have.** `backend_color_format`
+maps every unrecognised value, zero included, onto `R8G8B8A8_UNORM`, so the format term in the
+active-binding rule is **total**: it never rejects a slot. The test modelled `raw != 0` and asserted a
+zero format made a slot inactive. `PROSPER_MRT_CENSUS` had already reported "format known" for every
+slot in all 16,384 pass groups of a routed boot — the column is constant because the predicate is —
+and that measurement is in this document. I read it, wrote it down, and then wrote a test asserting
+the opposite. The test and the header now encode the real contract, and a backend-linked test pins
+the mapping the model depends on.
+
+### A metric with two regimes, and a control that was not one
+
+While verifying, `c4`'s peak read 507,887 where the previous round recorded 3,471,942. A second run
+on the same head gave 516,241, and I took that agreement as evidence of a regression in my own diff.
+It was not: **rebuilding the PREVIOUS head's sources and running them today gives 507,863.** The
+metric has two regimes depending on where the route lands, and two runs inside one regime agree with
+each other while saying nothing about the other.
+
+The lesson is the one this document keeps recording in different clothes: *the control has to be the
+old code run now*, not a number written down earlier. A remembered measurement is a measurement of a
+different machine state. `c2`/`c3` are stable across all of these (4.51–4.53M) and are the numbers
+worth quoting.
+
 ## Fourth review round on #2550, all four fixed (2026-08-15)
 
 **1 (blocker) — a depth-feedback split still discarded MRT2–7 when persistence was unavailable.**

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,7 +399,54 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
-## FALSIFIED: the sparse tree is not "correct but sparse by design" (2026-08-15)
+## The sparse tree IS a faithful consequence of its input (2026-08-15)
+
+Testing the right correspondence — for each parent with only one child, the **two child references in
+that parent's own 64-byte node record**:
+
+```
+submit=10052  lone-child parents=164
+   both refs in {2,5} = 0      exactly one = 155      neither = 9
+   commonest (tag0,tag1): (5,0) x82, (0,5) x73, (0,0) x6
+```
+
+**Never both. 155 of 164 have exactly one linkable reference** — typically one box32 child (type 5)
+and one **triangle** child (type 0), which the `tag == 2 || tag == 5` predicate does not link.
+
+Across submits, over all 2,063 node records:
+
+| submit | pairs / unpaired | both refs linkable | exactly one | neither |
+| --- | --- | --- | --- | --- |
+| 5943 | **1029 / 2** | **1034** | 100 | 929 |
+| 7188 | **1029 / 2** | **1034** | 98 | 931 |
+| 8842 | **1029 / 2** | **1033** | 98 | 932 |
+| 9247 | **1029 / 2** | **1033** | 98 | 932 |
+| 10052 | 676 / 74 | 785 | 266 | 1012 |
+| 10449 | 616 / 73 | 775 | 271 | 1017 |
+
+**In the perfect submits `both ≈ 1033` and `pairs ≈ 1029` — they track each other.** In the broken
+ones `both` falls to ~780 and `exactly one` rises to ~270. The builder's output follows its input.
+
+**So `0x413dc3400` is faithfully building what it is told to build**, and the defect is that the node
+records it reads contain roughly 170 fewer linkable child pairs than they do in the frames that come
+out right. Combined with the eleven perfect submits, this is now two independent measurements saying
+the same thing: **the builder is not the defect; its input is.**
+
+What remains open is whether that input is *wrong* or merely *different* — a scene with more triangle
+leaves genuinely has fewer box-to-box links. Distinguishing them needs to know what the guest expects,
+which is the question outstanding with Codex, and it cannot be settled from the output alone. The
+`0x209cc76000` record array has 23 writers, so "which producer" is not yet a well-posed question
+either.
+
+## RETRACTED: that falsification tested the wrong correspondence (2026-08-15)
+
+**The section below asked the wrong question and its conclusion does not follow.** It tested whether
+a record's OWN node type predicts whether that record is paired. The predicate does not act on a
+record's own type — it acts on the **two child references stored in the PARENT's node record**. The
+right test is whether a lone-child parent's two refs differ in linkability, and it says something
+quite different (next section). The section is kept for the record; do not cite its conclusion.
+
+## OLD (wrong test): the sparse tree is not "correct but sparse by design"
 
 This reading was flagged as capable of inverting the whole investigation, so it was tested rather
 than left standing. If `0x413dc3400`'s `tag == 2 || tag == 5` predicate legitimately skips other node

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,76 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## Six-reference simulation: the builder is PROVABLY faithful (2026-08-15)
+
+Codex's correction (#2542): `0x413dc3400` reads **six** candidate references per node, not two —
+`pc86` loads the first pair, `pc161` follows `(A >> 3) - 4` for a second pair, `pc237` follows
+`(B >> 3) - 4` for a third. **A histogram over record dwords 0/1 covers two of six and cannot predict
+how many parent slots a dispatch writes**, so `pairs == 1030` is an empirical control for one route
+state, not a universal oracle. What survives as a hard oracle is **acyclicity**.
+
+`tools/re/bvh_ref_simulator.py` reproduces all six selections over each captured input and diffs the
+expected destination set against the slots the dispatch actually changed:
+
+| dispatch | expected | written | expected-not-written | **written-not-expected** | ref cycles |
+| --- | --- | --- | --- | --- | --- |
+| s5943 d37 | 2061 | 2061 | 0 | **0** | 0 |
+| s7188 d37 | 2061 | 2061 | 0 | **0** | 0 |
+| s8842 d37 | 2061 | 2061 | 0 | **0** | 0 |
+| s16041 d37 | 2061 | 2061 | 0 | **0** | **117** |
+| s17181 d37 | 2061 | 2061 | 0 | **0** | **117** |
+| s19002 d37 | 2061 | 2061 | 0 | **0** | **117** |
+| s5528 d37 | 1754 | 1457 | 297 | **0** | 0 |
+| s9645 d37 | 1788 | 1283 | 505 | **0** | 0 |
+
+**`written but not expected` is ZERO in every frame measured.** The builder never writes a slot its
+input does not imply — now established over all six references rather than two.
+
+And the decisive rows are s16041 onward: **`expected = written = 2061`, `missing = 0`, and
+`cycles = 117`.** Everything the input implies is written, nothing else is, and the result is cyclic
+**because the input is**. There is no discrepancy left for the builder to be responsible for.
+
+(`expected-not-written` is nonzero in other frames because the simulator walks every node while the
+dispatch processes only its compacted, depth-parity subset. The informative direction is the other
+one, and it is zero everywhere.)
+
+**This closes `0x413dc3400`'s role definitively.** Together with the eleven perfect submits, two
+independent methods now say the same thing: the builder is correct and the defect is entirely
+upstream, in the node records `0x413ce6000` writes.
+
+## Corrections from Codex (#2542) to earlier sections
+
+- **`0x413cf9000` / `0x413cf9200` are arena aliases, not producers of the 64-byte tag records.**
+  `cf9000` is an initializer over an **80-byte** stride; `cf9200` operates **32-byte** records at a
+  320-byte V# near `0x209cc7ab00`. Their 117 changes each are a paired initialise/fill of a small
+  structure that merely overlaps the watched allocation. **So ranking writers by whole-watch change
+  count is misleading, and the +54 cycles this document attributed to `cf9000` should be discounted**
+  — its writes are not 64-byte records and decoding them as such is a category error. The genuine
+  64-byte-view producers are `cf5400`, `cf6100`, `ce6000` and `d1bf00`. `0x413ce6000`'s **+590** is
+  unaffected: it is a real 64-byte-view producer.
+- **The `record 4 + 8` arithmetic is exact**, not over-fitted: `pc74` forms `selector = word >> 3`,
+  `pc144` `v_readfirstlane_b32 vcc_lo, v7`, `pc149` `s_mulk_i32 vcc_lo, 120`, `pc153`
+  `s_buffer_load_dwordx4 … offset:8`. So `4 * 120 + 8 = 488` exactly. **The contract's weakness is
+  TEMPORAL, not arithmetic**: `selected_sbuffer_domain()` reads the source and the outer table
+  through `complete_resource_bytes()` — the currently CPU-visible mapping — with no command-order
+  snapshot coupling either to the bytes the GPU later consumes. Codex has retained evidence of the
+  same outer base decoding as **five coherent V#s** at exactly `+8` in one observation and floats in
+  another, so the buffer is a reused arena observed at different epochs. **The
+  "it holds frustum planes / the contract is over-fitted" framing in this document is therefore
+  wrong about the cause** — the layout is right and the epoch is not.
+- **The selector is `readfirstlane(source_word >> 3)`**, from the pc70 source records — not from a
+  saved EXEC mask, as this document earlier concluded from watching s106 alone. It is still not
+  const-foldable (a readfirstlane of live lane data is runtime state), so the conclusion that no fold
+  can resolve it stands; the stated *route* to it was wrong.
+- **`0x413e1ff00 toucher=0`** — Codex reached the same diagnosis independently: a watch-attribution
+  bug, not memory corruption. Already fixed here with `compute_address_window_hits`.
+
+**A systematic caveat this raises over much of the descriptor work above:** every capture in this
+document reads guest memory at fold or realization time on the CPU. That is not the execution epoch
+the GPU consumes. Codex's recommended discriminator is an ordered GPU-side readback of the pc70
+source, the root V# at `s[0:1] + 0xa8`, and all 600 outer bytes, captured **immediately before the
+dispatch executes** — a CPU reread is not sufficient.
+
 ## ROOT CAUSE, ATTRIBUTED: `0x413ce6000` writes the cyclic child graph (2026-08-15)
 
 Per-dispatch pre/post attribution on the node records at `0x209cc76000`, with the **child-graph cycle

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,45 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## CONCLUSION: both rejecting programs build descriptors from LANE MASKS (2026-08-15)
+
+`PROSPER_DYNTRACE_SGPR=106` on `0x205b654a00`, filtered by program identity:
+
+```
+pc=1091 s106 <- KNOWN 0x00000005
+pc=1092 s106 <- KNOWN 0x00000001
+pc=1097 s106 <- FORGOTTEN words=85ea807e     <- SOP2 0x0b, a B64 op reading EXEC_LO
+pc=1098 s106 <- FORGOTTEN words=87ea6a00
+pc=1101 s106 <- KNOWN 0x00000004
+...
+pc=1154 s106 <- KNOWN 0x0000ffc8
+```
+
+s106 is known on some paths and lost on others, and where it is lost the source is **EXEC** —
+pc1097's `0x85ea807e` is a 64-bit scalar op whose `ssrc0` is `EXEC_LO`.
+
+**So both declined programs compute descriptor fields from lane masks:**
+
+| program | descriptor field | source |
+| --- | --- | --- |
+| `0x205b654a00` | BVH descriptor `s18` = `-1 + VCC_LO` | VCC_LO from **EXEC** at pc1097 |
+| `0x413ce6000` | array selector, `s_mulk_i32 s106, 120` | VCC_LO from **`s_andn1_saveexec_b64`** at pc116/131 |
+
+**A constant-folder cannot resolve either, and no widening of it ever will.** EXEC is a runtime
+wave state. This is not a gap in the fold's opcode coverage — the `s_mulk_i32`, `s_addk_i32`,
+`s_setreg_b32` and `s_waitcnt_vscnt` corrections made on this branch are all real fixes and none of
+them could have helped, which is exactly what their verified-lever negatives showed.
+
+**What this means for the fix.** These descriptors need a mechanism that does not fold: either
+resolving the descriptor from guest memory at dispatch time (the `selected_sbuffer` contract's
+approach — certify the domain, materialise the record), or a lowering that keeps the descriptor
+dynamic. Which one is a design question and needs the ISA read of what the guest intends by deriving
+a descriptor field from EXEC — plausibly a lane count or an active-mask popcount used as a size.
+
+**`CONFIDENCE: HIGH`** that both fields trace to lane masks — measured per register, per program, with
+a program identity that is actually unique. **`CONFIDENCE: LOW`** on what the guest means by it, which
+is the open question worth asking.
+
 ## The BVH descriptor's unresolved word is `s18`, and it depends on VCC_LO (2026-08-15)
 
 Watching each register of the descriptor `s[16:19]` in `0x205b654a00`, one run each:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,59 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## ROOT CAUSE, ATTRIBUTED: `0x413ce6000` writes the cyclic child graph (2026-08-15)
+
+Per-dispatch pre/post attribution on the node records at `0x209cc76000`, with the **child-graph cycle
+count** as the metric:
+
+```
+submit  order   writer         cycles pre -> post
+6765    4550    0x413ce6000       0 -> 324    ADDS 324
+7180    24812   0x413ce6000     324 -> 398    ADDS 74
+7595    26144   0x413ce6000     398 -> 388    removes 10
+8835    26556   0x413ce6000     388 -> 402    ADDS 14
+15271   16831   0x413ce6000     350 -> 436    ADDS 86
+16088   14048   0x413ce6000     436 -> 468    ADDS 32
+16088   14546   0x413cf9000     468 -> 469    ADDS 1
+```
+
+| program | dispatches that add cycles | total added |
+| --- | --- | --- |
+| **`0x413ce6000`** | 7 | **590** |
+| `0x413cf9000` | 12 | 54 |
+
+**`0x413ce6000` is the program that makes the child graph cyclic**, including the transition from a
+completely acyclic graph to 324 cycles in one dispatch. It also *removes* cycles on other dispatches
+(−10, −14, −20, −18), which is the signature of an incremental refit that is partly wrong rather than
+a rebuild that is wholly wrong.
+
+### The complete chain, every link measured
+
+1. **`0x413ce6000`** writes the 2,063 × 64-byte node records at `0x209cc76000`, and its output
+   contains a **cyclic child graph**.
+2. **`0x413dc3400`** builds parent links from those records **faithfully** — its lowering is proven
+   correct by eleven consecutive perfect submits, and its output tracks its input.
+3. The parent table is therefore cyclic.
+4. **`0x413dc6700`** walks it with a loop that has no iteration bound and no cycle detector.
+5. GPU hang → RADV device loss → live compute disabled process-wide → every later indirect draw
+   dropped → **no 3D world**.
+
+**And `0x413ce6000` is exactly the program whose descriptor at pc156 does not resolve**
+(`mode=unresolved-operand`, the `selected_sbuffer` contract declining because the buffer it reads
+holds frustum planes) and which is declined outright on some dispatches. A program that cannot
+resolve one of its descriptors, and is sometimes not run at all, is precisely a program that writes a
+partially-correct node array.
+
+**`CONFIDENCE: HIGH`** on the attribution — per-dispatch pre/post, one writer, one metric, and the
+0 → 324 transition is unambiguous. **`CONFIDENCE: MED`** that the unresolved descriptor is *why* its
+output is wrong; that link is plausible and untested, and the honest alternative is that some other
+part of its lowering is at fault.
+
+**This supersedes the earlier "missing producer" framing without contradicting its falsification.**
+Absence was correctly ruled out — 29 submits with `0x413ce6000` fully executing still went cyclic.
+The cause is its **output**, which the earlier experiments could not distinguish because none of them
+measured what it wrote.
+
 ## FOUND: the CYCLES ARE IN THE INPUT — the node records' own child graph (2026-08-15)
 
 Two results, and together they close the question.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -78,6 +78,81 @@ both decoding to parent 296), so it is a flag-bit difference and a separate anom
 **Ruled out by this measurement:** the "lost update" / two-writer race account of the cycle. Within
 one dispatch's pre/post pair there is exactly one writer, and its output is cyclic.
 
+## The failure mode, exactly: one of the two per-parent stores does not execute
+
+Established from both images of 18 clean -> cyclic transitions.
+
+**Ground truth.** Two clean captures give the target unambiguously: parent-multiplicity
+`{2: 1030, 1: 2}` — every parent has exactly two children — with 1,032 distinct parent values over
+0..2062, 515 of them above 1031, and 1,031 indices never a parent. Leaves and internals are
+interleaved, not segregated into low and high halves.
+
+**`0x413dc3400`'s output** measures `{2: ~872, 1: 220..461}`. For 220–461 parents **exactly one of
+the two children carries that parent**, and the missing child's slot still holds a *stale* value —
+`0x09249249`, `0x12492492` or `0x2db6db6d`, which are the Morton dilation constant times 1, 2 and 5,
+or plain zero. Those slots were never written by this dispatch. **So this is a store that does not
+execute, not a store that computes a wrong address or a wrong value.**
+
+### The store site
+
+All six stores sit in six separately exec-predicated blocks of identical shape (mnemonics from
+prosper's own decoder, `rdna2_to_spirv.cpp` VOP2 0x16 `v_lshrrev_b32`, 0x1B `v_and_b32`,
+0x25 `v_add_nc_u32`):
+
+```
+pc=0611  v_and_b32          v36, 7, v69      ; tag = child_ref & 7
+pc=0612  v_cmp_eq_u32       s8,  2, v36
+pc=0614  v_cmp_eq_u32       vcc, 5, v36
+pc=0615  s_or_b64           vcc, vcc, s8     ; tag == 2 || tag == 5
+pc=0616  s_and_saveexec_b64 vcc, vcc
+pc=0617  s_cbranch_execz    -> 622
+pc=0618  v_lshrrev_b32      v36, 3, v69      ; index = child_ref >> 3
+pc=0619  v_add_nc_u32       v36, -4, v36     ; index -= 4
+pc=0620  buffer_store_dword v40, v36, s0, 0  ; idxen=1, offen=0
+pc=0622  s_mov_b64          exec, vcc
+```
+
+A child is written only when its reference's low three bits are 2 or 5, into slot `(ref >> 3) - 4`.
+**Whether tags outside `{2, 5}` are written by a LATER PASS is the open question** — if they are,
+a stale slot here is expected and the defect is a missing program rather than this one (#2542).
+
+### A gap in the toucher census that may matter more
+
+The baseline routed run **skips 13 compute programs as unsupported**, and a skipped program never
+realizes a resource table — so `PROSPER_COMPUTE_ADDRESS_WATCH` and the tree watch are
+**structurally incapable of seeing any of them**. The clean "no unknown writer" result is therefore
+a statement about programs that ran, and only those. Baseline skip list:
+
+```
+0x2042f49a00 0x205b545c00 0x205b54ee00 0x205b5e8600 0x205b654a00 0x205b657200
+0x205b658800 0x205b67ce00 0x413ce6000 0x413cf9200 0x413cf9a00 0x413cf9d00 0x413d14100
+```
+
+If one of those is the pass that fills the slots `0x413dc3400` deliberately leaves alone, the cyclic
+table is a **missing program**, not a miscompiled one, and the fix is to make it recompile. Per the
+charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
+the next thing to implement regardless of how this particular question resolves.
+
+## Ruled out / retracted here
+
+- **"Sibling pairs are `(odd, even)`."** Retracted. The clean table has 204 parents whose children
+  are `(2j+1, 2j+2)` and **828** whose children are `(2j, 2j+1)` — pairs are adjacent at arbitrary
+  parity. The "first broken pair k=205" figure was computed under the fixed-alignment assumption and
+  its alignment part goes with it. The adjacency-based unpaired and cycle counts never assumed
+  alignment and stand.
+- **"Slot 300's bits[2:0] are an anomaly."** Retracted. `post-36-3.bin` has bits[2:0] == 0 in all
+  2,063 records while `live-a240.bin` carries a mix of 0 and 2, so that field varies legitimately
+  between clean tables.
+- **The LDS-undersizing hypothesis.** Dead: the module declares a Workgroup array of exactly 384
+  dwords = 1,536 bytes = 3 × 512-byte `COMPUTE_PGM_RSRC2.LDS_SIZE` granules, so the real allocation
+  is plumbed through and matched, not defaulted.
+- **Synchronization / race hypotheses for this program.** The broken-pair patterns from two
+  different frames share a 60-character suffix exactly, and `min` damage index is identical across
+  frames: the failure is deterministic given the input.
+- **A lane, wave or workgroup boundary effect.** `k mod 2/3/4/8/16` are all flat.
+- **`PROSPER_NO_NATIVE_COMPUTE_SUBGROUP=1` as an A/B arm.** Void, not negative: it skips 15 *more*
+  programs including `0x413d88400`, so `0x413dc3400` never dispatches and the phase never runs.
+
 ## What the structure IS: an LBVH / binary-radix-tree parent table from Morton keys
 
 Identified by Codex from the retained ISA (#2542), and it reframes everything below.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -515,7 +515,153 @@ Two things must be checked before treating this as a defect, and neither has bee
 Recorded as an observation with its caveats rather than a lead, so the next reader neither chases it
 blind nor loses it.
 
-## THE BREAK: the composite samples `0x14…`/`0x15…`, but every render target is `0x20…` (2026-08-15)
+## `0x413ce6000` IS a bottom-up box32 BVH refit — and pc156 supplies BOUNDS, not references
+
+Codex's ISA read (#2542), with one decode correction to this document: **pc156 is
+`buffer_load_dwordx4`, not x3** (`e0382000 80020006`, GFX10.3 MUBUF op `0x0e`), and pc158
+(`e0342010 80020406`) is `buffer_load_dwordx2`. Together they load **six dwords into `v0..v5`** —
+AABB min/max XYZ.
+
+```
+pc156/158   load six BOUND values through the selected s[8:11]
+pc212       store dwordx4 v[0:3] to node offset +16
+pc214       store dwordx2 v[8:9] to node offset +32
+pc218       atomic allocation/counter through s[24:27]
+pc224       load dwordx2 v[4:5] through s[24:27]
+pc228..251  transform/encode those two indices, including node type 5
+pc253       store dwordx4 v[4:7] at node offset +0     <- the CHILD REFERENCES
+pc255/257   reload the node bounds
+pc260..266  min/max into the running bounds
+pc269       load the next parent/index and loop upward
+```
+
+So it is a **bottom-up construction/refit of box32 internal nodes**: merge six float bounds, obtain
+two child indices, write encoded child references plus bounds, propagate upward.
+
+**Three consequences, and the first retires a link this document asserted:**
+
+1. **The dynamic descriptor at pc156/158 feeds the BOUNDS at +16/+32. It does NOT supply the child
+   references written at pc253.** An epoch-stale pc156 can corrupt AABBs; it **does not directly
+   explain cyclic child references**. The "unresolved descriptor → wrong output → cycles" chain in
+   the sections above is therefore **not established**, and its `CONFIDENCE: MED` was generous.
+2. **The cyclic-reference frontier is the pc218/224 path** — the `s[24:27]` resource/counter/index
+   data, the index/base arithmetic involving `s16`, and the destination selection. That is where
+   ordered execution-epoch capture belongs.
+3. **A decline cannot itself perform the measured 0 → 324 cycle addition** — a declined dispatch
+   writes nothing. A prior decline could leave stale state a later executing invocation consumes, but
+   then the executing path is still part of the defect. The 29 cyclic submits on which every
+   `ce6000` dispatch executes already ruled out decline-alone as sufficient.
+
+The generic lift's CPU-epoch problem remains a real correctness issue; it is just not the direct
+value source for the reference cycles. **Do not close that link without measuring pc224's
+execution-epoch resource and indices.**
+
+## Submit-indexed capture already exists — #2549's workaround was not needed for this
+
+```
+PROSPER_GPU_TIMELINE_CAPTURE=<capture.prgcap>
+PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=1
+PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM=0x413ce6000
+```
+
+With a semantic selector, `CAPTURE_SUBMIT` is the **minimum** submit and the first later submit
+containing that program becomes the endpoint — which is exactly the "aim the capture at a submit that
+contains work" this document asked for, and it was already there.
+`PROSPER_GPU_TIMELINE_CAPTURE_WHEN_DISPATCH_DIM=XxYxZ` qualifies further; a rolling predecessor
+bundle uses `..._CAPTURE_BUNDLE` + `..._CAPTURE_DEPTH`. `...AFTER_COMPUTE_PROGRAM` is a **cross-submit
+phase gate** and is the wrong selector when the endpoint is the submit containing `ce6000` itself.
+
+*(The F9 fixes on this branch remain valid for the interactive grab, and #2549's present-count
+finding still stands. But the capture this investigation needed did not require them.)*
+
+## The indirect-argument high dword is NOT folded into the modifier
+
+Also falsified by Codex. The HLE builder writes `cmd[1] = uint32_t(a1)` (offset), `cmd[2..3]` = the
+64-bit modifier, and PM4 decode reads them faithfully. The failing async-queue packet's live values:
+
+```
+base=0   offset=0xf8480120   modifier=0x21
+low | (modifier_low << 32) = 0x21f8480120   (unreadable)
+0x20f8480120                                (readable)
+```
+
+So the modifier is `0x21`, not `0x20` — the "the high dword is in the modifier" reading is dead, and
+**there is no evidence of a PM4 decoder bug**.
+
+**The decisive probe belongs before packet construction**, in `agc_cb_dispatch_indirect`: log the
+full `a1`, the full `a2`, and which exported NID entered the shared body — both DCB and ACB NIDs
+alias one HLE implementation, and the two forms may carry the address differently.
+
+- `a1 == 0x20f8480120` → the HLE builder truncates a full address and must preserve that ABI form.
+- `a1 == 0xf8480120` → the high bits never reached the builder, and the missing piece is per-ACB/queue
+  base state or another ABI-defined provenance source.
+
+**Until that is measured, aperture recovery stays diagnostic-only.** "Mapped under the common
+aperture" is not proof that it is the intended argument buffer — and this document's earlier framing
+of the truncation as a defect with an in-tree fix was ahead of the evidence.
+
+## RETRACTED — "THE BREAK" was two different presentation phases compared as one (2026-08-15)
+
+**The section below is wrong in its grouping and its interpretation, and is kept only so the
+measurements stay available. Do not cite its conclusion.** Codex falsified it with a
+`PROSPER_MEMLOG=1` + `PROSPER_RTTLOG=1` run (#2542):
+
+- **The physical mappings are disjoint, so VA aliasing is dead.** `VA 0x1557c00000 -> phys
+  0x105000000`; `VA 0x1543c00000 -> phys 0x102800000`; the dominant `0x208e5a0000` target lies inside
+  `VA 0x203de00000 -> phys 0x111000000` and resolves to physical `0x1617a0000`. None overlap. **A
+  physical-page RTT identity would miss exactly as the VA-keyed one does** — so the fix I proposed
+  would not have worked either.
+- **The `0x14…`/`0x15…` misses are not the gameplay composite at all.** They belong to
+  `fs=0x2042f83c00` — one full-resolution plus two half-resolution guest-backed planes, an
+  early/startup presentation path (very likely video/YUV-style input). They are ordinary guest
+  images, so an RTT miss there is **expected**.
+- **The real gameplay chain is entirely in `0x20…` and every link HITS:**
+
+```
+fs=0x205b34be00                       -> target 0x2056740000
+fs=0x205b384a00  samples 0x2056740000 HIT -> target 0x2058720000
+fs=0x205b363c00  samples 0x2058720000 HIT -> SCANOUT
+```
+
+  The last two stages preserve the producer's counts (`rgb_nonblack=1121820`), and the scanout holds
+  the tutorial/UI/light content but no world.
+
+**So the world is already absent at the OUTPUT of `fs=0x205b34be00`. It is not lost in the final
+composite, and not lost to an address mismatch.**
+
+What went wrong in my reasoning: I compared misses drawn from one presentation phase against render
+targets drawn from another, and read the address-range difference as a mismatch between two sides of
+*one* frame. The hit/miss counts and the address ranges were real; the grouping was not. A prefix
+histogram over a whole run cannot tell two phases apart, and I did not check that the sampled
+surfaces and the targets came from the same pass.
+
+## THE ACTUAL FRONTIER: the inputs of `fs=0x205b34be00` (2026-08-15)
+
+That fragment shader produces `0x2056740000`, the first stage of the gameplay chain, and its output
+already lacks the world. Its directly sampled inputs:
+
+| input | state |
+| --- | --- |
+| `0x2052ac0000` 3840x2160 fmt=1 | **RTT miss + DCC-unsupported warning** |
+| `0x2054aa0000` 3840x2160 fmt=11 | **RTT miss** |
+| `0x2063380000` 3840x2160 fmt=20 | HIT |
+| `0x2085de0000` 3840x2160 fmt=4 | HIT |
+
+**So the DCC problem is NOT superseded — it is the live lead, on the real chain.** `0x2052ac0000` is
+a guest-backed 4K surface that misses the RTT cache and then falls through to reading DCC-compressed
+bytes as uncompressed.
+
+Codex's qualification, which matters: **DCC warnings must be classified per surface.** Some
+DCC-described addresses do have a renderer-owned RTT image and hit; genuinely guest-backed ones such
+as `0x2052ac0000` and `0x20e0380000` miss and fall through. The renderer now carries all eight MRT
+bindings and the backend publishes them, so there is no evidence `0x2052ac0000` is merely an
+untracked secondary MRT — its persistent absence from the RTT cache makes **guest-backed DCC, or an
+unidentified producer, the better hypothesis**.
+
+**Next discriminator:** identify `0x2052ac0000`'s allocation and write history and inspect that exact
+input — not change RTT identity.
+
+## OLD (retracted): the composite samples `0x14…`/`0x15…` (2026-08-15)
 
 `PROSPER_RTTLOG=1` reports, per sampled texture, whether it resolved to a renderer-owned render
 target or fell through to guest memory. Over a routed run:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,38 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## Open, unquantified: 38 of 40 logged `WaitRegMem` waits are on UNMAPPED labels (2026-08-15)
+
+```
+[agc] WaitRegMem #3 q=A NOT satisfied at fold time: [0xf58]&0x190 = 0x0, func=5 ref=0xffffffff
+      — dependency violated | built@0ms(age=-1ms) pre@build=0x0 LABEL-UNMAPPED
+```
+
+Of the 40 logged, **38 carry `LABEL-UNMAPPED`** and 38 are on queue A. The awaited address in that
+sample is **`0xf58`** — four-byte aligned, so it passes the call site's gate, and far too small to be
+a guest address, which in this title are `0x20xxxxxxxx`.
+
+**That is the same shape as the indirect-dispatch argument truncation** on the previous section
+(`0xf8480120` for `0x20f8480120`), which has an in-tree aperture recovery. Whether the same recovery
+applies to `WAIT_REG_MEM` labels is untested.
+
+Two things must be checked before treating this as a defect, and neither has been:
+
+- **It may be normal.** `command_processor.cpp` states plainly that an unsatisfied wait is "NORMAL,
+  handled state" and that under content-load bursts it "fires thousands of times a minute". The
+  barrier model behind `PROSPER_WAIT_DEFER=1` exists precisely because the default folds past them.
+- **The count is a LOG CAP, not a measurement.** The diagnostic prints the first 40 and then every
+  1024th, so "40" says nothing about the true rate. Quoting it as a frequency would be the rate-limit
+  trap the orchestration doc warns about.
+- **`wm_addr` may be register space.** PM4 `WAIT_REG_MEM` selects register or memory addressing, and
+  this code path reads `wm_addr` as memory unconditionally (`guest_readable(c.wm_addr, 8)`). A
+  register-space wait would then always read as unmapped. This area carries substantial prior work
+  (#312, #380, #448), so the absence of a `mem_space` check may be deliberate rather than missing —
+  it has not been established either way here.
+
+Recorded as an observation with its caveats rather than a lead, so the next reader neither chases it
+blind nor loses it.
+
 ## What is NOT hiding the world — four eliminations, each with a verified lever (2026-08-15)
 
 Every one of these was measured on a routed run with the lever confirmed to have moved, so each is a

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -97,6 +97,45 @@ one dispatch's pre/post pair there is exactly one writer, and its output is cycl
 - **A lane/wave/workgroup boundary effect.** Damage index mod 2/3/4/8/16 is flat.
 - **An unknown or out-of-bounds writer.** Every observed change reported `toucher=1`.
 
+## The selected-sbuffer contract declines because the SELECTED V# IS FLOAT DATA (2026-08-15)
+
+`PROSPER_GTA5_SBUFFER_REJECT=1` (added on this branch; the six reasons in
+`rdna2_gta5_compute_contracts.cpp` were all behind `PROSPER_DBG`, which desyncs the route) reports
+exactly two declines for `0x413ce6000` on a whole run:
+
+```
+[gta-selected-sbuffer] reject=consumer-resource
+[gta-selected-sbuffer] reject=selected-vsharp
+    words=c540fa56:c51e1625:4373fd8a:45de36cc
+    base=0x1625c540fa56 stride=1310 records=1131675018 size=4294967295
+```
+
+**Those four words are floats**: `0xc540fa56` ≈ **-3087.6**, `0xc51e1625` ≈ **-2529.5**,
+`0x4373fd8a` ≈ **244.0**, `0x45de36cc` ≈ **7110.9**. That is a world-space AABB, not a descriptor —
+and the derived `base=0x1625c540fa56`, `records=1131675018`, `size=0xffffffff` are what you get from
+reinterpreting it. **prosper is correctly refusing to manufacture a descriptor out of it**; the
+contract's `selected-vsharp` guard is doing its job.
+
+So the selector resolves to a record that does not contain a V# at the expected offset. The chain to
+audit, with what is measured about each link:
+
+| link | measured |
+| --- | --- |
+| the selector's source records, pc70 | `base=0x20f848e2bc stride=8 records=2064 size=16512` — resolves |
+| the descriptor array, pc153 | `base=0x203f249b38 stride=120 records=5 size=600` — resolves |
+| `s_buffer_load_dwordx4 s[8:11], s[4:7], s106` | SMEM immediate offset **8**, so the V# is expected at `selector*120 + 8` |
+| the selected element | **float AABB data** |
+
+Three candidates, none yet excluded: the selector value is wrong; the V# lives at a different offset
+within the 120-byte record than `+8`; or the **source records at pc70 are themselves stale because
+their producer also does not run** — which would make this a chain of missing producers rather than
+one. That last one is the possibility to test first, because it is the same failure this whole
+investigation has already found once.
+
+Note the resource map lifts pc156/pc158 as `base=0x203f2e9b38 size=13360 stride=20 entries=5` —
+**stride 20, against the contract's expected 120**. Reconciling those two views is likely the fastest
+route in.
+
 ## The selector chain at `0x413ce6000` pc149..156 — the exact fix site
 
 Decoded with prosper's own opcode constants (`rdna2_decode.hpp`), not guessed:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,44 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The `selected_sbuffer` contract is over-fitted: the "descriptor array" holds FRUSTUM PLANES (2026-08-15)
+
+Dumping **all five** records of the outer array on decline, rather than only the one the contract
+reads, settles what one record could not:
+
+```
+record=0@+8   words=3e177e0d:3d39304e:3f7ceb16:beec6371
+record=1@+128 words=3d044294:bc9a100f:3ce5d234:be5601a6
+record=2@+248 words=bdd106eb:3f7e94ad:bccf32ed:beee4863
+record=3@+368 words=be6fa5cf:bdb9257a:3f581219:bdf01a64
+record=4@+488 words=3f1a1f1a:bdc0f619:3f4afad1:bfa0b479
+```
+
+**None of the five is a descriptor. All five are floats, and they are unit normals plus a scalar:**
+
+| record | xyz | ‖xyz‖ | w |
+| --- | --- | --- | --- |
+| 0 | (0.1479, 0.0452, 0.9879) | **0.999** | −0.461 |
+| 2 | (−0.1020, 0.9944, −0.0253) | **1.000** | −0.465 |
+| 4 | (0.6021, −0.0942, 0.7929) | **1.001** | −1.256 |
+
+A unit 3-vector with a scalar is a **plane equation**. Five of them at stride 120 is a camera
+frustum, not a descriptor table.
+
+**So in the gameplay scene, the buffer the contract reads as a five-entry V# array holds frustum
+planes.** The contract was derived from a phase where record 4 did hold a V#, and it does not
+generalise. That also explains its companion `reject=consumer-resource`.
+
+This is why the earlier framing — "record 4 is stale, find its producer" — was the wrong question.
+The buffer is not stale; it is a **different buffer's worth of data**, correctly written by whoever
+owns it. Either `0x413ce6000`'s pc153 does not load a descriptor on this path in this scene, or the
+resource the contract binds at `fetch_pc=153` is not the one the guest means here.
+
+**`CONFIDENCE: HIGH` that these are planes and not descriptors** — three of five have unit-length
+normals, which floating-point garbage does not do. `CONFIDENCE: MED` on the consequence, because
+"the contract binds the wrong resource" and "the shader takes a different path here" both fit and
+have not been separated.
+
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 
 Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,52 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## The stencil plane of a rendered DS surface was never bridged (2026-08-15, fixed)
+
+`fs=0x205b34be00` samples two planes of **one** depth/stencil surface, and prosper retained only one
+of them:
+
+```
+[dsbridge] DS cache: dr=0x2052ac0000 dw=0x2052ac0000  sr=0x2054aa0000 sw=0x2054aa0000
+                     htile=0x2055310000  3840x2160 fmt=130 (D32_SFLOAT_S8_UINT) dvalid=1 svalid=1
+```
+
+`0x2052ac0000` is the depth plane and bridges correctly (#1275). `0x2054aa0000` is the **stencil
+plane of the same image**: `find_persistent_ds_sampled` matched only the depth bases (`dr`/`dw`), so
+every stencil sample fell through to a guest-byte decode of memory the renderer never writes — zeros.
+That is #1275's exact failure mode, left unfixed on the other plane. The guest declares the two planes
+`Float32` and `Uint8`, which is what a deferred renderer's material and light-volume classification
+reads.
+
+Fixed by matching `sr`/`sw` and binding the image's stencil aspect. Measured over a routed boot:
+`calls=262144 hit(depth=42897 stencil=2982)` — roughly 3,000 binds per run now sample the live image
+instead of zeros, with 0 validation errors.
+
+**This did NOT change the rendered frame, and the claim is kept separate from the fix.** A/B on the
+same route, HUD regions excluded from the metric: before 2.004% of pixels non-black, after 1.993% —
+inside the run-to-run spread of the route itself (0.283%–2.584% across five runs). The two frames are
+visually identical: the same three bloomed light sources and the same faint structure. So the stencil
+bridge is a verified gap fix, not the missing world.
+
+**The instrument that nearly sold it as one.** The bridge's logging printed the first eight hits and
+the first eight misses. On a routed boot all sixteen are consumed during startup by one plane, so it
+could report neither a rate nor a reason, and the "after" image *looks* like it has new content until
+it is put next to the "before" image. Replaced with per-plane counters classifying every miss as
+no-entry / depth-invalid / stencil-invalid / extent / uninitialized — the distinction between "we have
+no such surface" and "we have it and declined it" calls for opposite fixes and was previously
+invisible. The old cache dump also printed with the first miss, which on this route is always before
+the cache has any contents, so it read as "prosper retains no DS images" when it meant "not yet".
+
+### Ruled out by the same measurement
+
+- **The DCC "unsupported sampled image" warning on `0x2052ac0000` is a false alarm.** It fires from a
+  block that checks `!rtt_hit` but not `has_ds_live`, so it prints even when the depth bridge won the
+  binding; `meta=0x2055310000` is the surface's **HTILE**, being read as DCC metadata, and
+  `metadata=0/0` means the copy was correctly skipped because the bridge had already won. It is not
+  evidence of an unsupported path.
+- **`0x2052ac0000` is not an untracked secondary MRT.** It is a depth buffer, which is why it never
+  appears in a colour-target census, and it bridges: `[dsbridge] HIT … plane=depth`.
+
 ## The two inputs nothing writes (2026-08-15, measured)
 
 The gameplay chain is all `0x20…` and every link hits (Codex, #2542), so the world is already absent

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,7 +211,51 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
-## ROOT CAUSE: `0x413ce6000` never recompiles, and it is the producer of the tags (2026-08-15)
+## CORRECTION (2026-08-15): the "never executes" claim above is WRONG
+
+Watching the record array itself — `PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:2063` — refutes the
+strongest form of the claim in the section below. **`0x413ce6000` does write it**, 26 times on a
+150 s route, `toucher=1`. It is not declined on every dispatch; the `[compute] skip unsupported
+program` line that suggested otherwise fires **once per program ever**, so it reports "failed at
+least once", never "never ran". That distinction is stated elsewhere in this document and I still
+built a causal claim on the wrong side of it.
+
+The array's actual writers on one route:
+
+| program | changes | toucher |
+| --- | --- | --- |
+| `0x413cf9000` | 117 | 1 |
+| `0x413cf9200` | 117 | 1 |
+| `0x413cf5400` | 29 | 1 |
+| `0x413cf6100` | 29 | 1 |
+| `0x413ce6000` | **26** | 1 |
+| `0x413d1bf00` | 2 | 1 |
+| `0x413e1ff00` | 3 | **0** |
+
+**What survives** from the section below, because it was measured rather than inferred:
+
+- `0x413dc3400` corrupts the parent table on 37 of 40 dispatches. Unchanged.
+- `0x413dc3400`'s tag source is `0x209cc76000`, binding 4 / fetch-pc 86 — the resource-map alias is
+  exact and stands.
+- `0x413ce6000` writes that same array, is *sometimes* declined, and its reject is
+  `unresolved-operand pc=156`. Also stands.
+
+**What does not survive:** "`0x413ce6000` never executes, therefore the tags are stale, therefore the
+tree is cyclic." The producer runs most of the time, so a missing-producer story cannot be asserted
+on this evidence. It remains a *candidate* — a partially-written array would still leave some records
+stale — but the step from "sometimes declined" to "these particular tags are stale" is not made, and
+the frame-level correlation between a decline and a corrupted tree has not been measured. **Do that
+measurement before building on it.**
+
+`0x413e1ff00` changing the array three times with **`toucher=0`** is the case the tree watch was
+built to be able to report: a program that changes bytes without binding a range containing them.
+That is either an out-of-bounds write or a binding path the resource traversal does not model, and
+it is unexamined.
+
+## `0x413ce6000` is a producer of the tags, and is sometimes declined (2026-08-15)
+
+**Read the CORRECTION above first — this section's causal claim was overstated and the
+"never executes" premise is refuted. The resource alias it establishes is sound.**
 
 The chain is complete and every link is measured.
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -298,10 +298,19 @@ alternative (the guest genuinely supplies a zero-extent descriptor at this point
 excluded, and a `key=0xffffffff` means neither fetch pc, SRT offset nor SGPR base matched — which has
 its own possible causes.
 
-**The check that would settle it** is whether decoding those two 4-dword words with
-`decode_bvh_descriptor` instead of `decode_buffer_descriptor` yields a plausible BVH: a base above
-`0x10000`, a sane `size_bytes`, and a `type` in range. That is an offline computation on four dwords
-and needs no run.
+**FALSIFIED, by running that check.** Decoding the two words with `decode_bvh_descriptor` gives
+`base = 0x20a1f7620000` — the BVH layout shifts its base left by 8, and the result lands far outside
+the guest address space, which sits around `0x20xxxxxxxx`. The **buffer** decode gives
+`base = 0x20a1f76200`, a perfectly plausible guest address. So these are not misclassified BVH
+descriptors, and the reading above is dead. Cost: one four-dword computation, no run.
+
+**What the same words do show.** Dwords 2 and 3 are **entirely zero**, while dwords 0 and 1 carry a
+sane base. A real buffer V# has a nonzero dword3 (it carries format and type bits), so an all-zero
+upper half is the signature of a **partially recovered descriptor** — the const-fold obtained the
+low two dwords and not the high two — rather than of a descriptor the guest genuinely wrote as
+zero-extent. `num_records = 0` then follows from dword2 being absent, and `size = 0` from that, and
+`unresolved-operand` from that. **That is the next thing to test**, and it is a different defect from
+anything this document has chased: not a wrong descriptor, a half-read one.
 
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,36 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## FALSIFIED: the sparse tree is not "correct but sparse by design" (2026-08-15)
+
+This reading was flagged as capable of inverting the whole investigation, so it was tested rather
+than left standing. If `0x413dc3400`'s `tag == 2 || tag == 5` predicate legitimately skips other node
+types, the tree would be *supposed* to be sparse in frames containing them, the 1,030-pair oracle
+would be wrong for exactly the frames called broken, and the defect would be the consumer's unbounded
+walk over a legitimately-sparse table instead.
+
+Cross-referencing each parent-table record's pairing state against its **node type** in the record
+array, from the same dispatch (the aux dump makes this a same-moment comparison):
+
+| submit | unpaired | node types among UNPAIRED | node types among PAIRED |
+| --- | --- | --- | --- |
+| 10052 | 74 | `{0: 60, 5: 14}` | `{0: 318, 4: 1, 5: 357}` |
+| 11238 | 158 | `{0: 37, 5: 121}` | `{0: 414, 5: 518}` |
+| 11637 | 200 | `{0: 29, 5: 171}` | `{0: 313, 5: 587}` |
+| 12434 | 183 | `{0: 57, 5: 126}` | `{0: 223, 4: 1, 5: 445}` |
+
+**Node type does not determine pairing.** Types 0 and 5 appear on both sides in every sample — a
+type-5 record is sometimes paired and sometimes not, and so is a type-0 record. If the predicate
+explained the sparseness, unpaired records would be exactly the types outside `{2, 5}`, and they are
+not.
+
+**So the tree is genuinely malformed, the 1,030-pair oracle stands, and the consumer is not at
+fault.** The eleven perfect submits already showed the lowering is correct; this shows the sparse
+output is not a legitimate alternative shape either. Both point at the input.
+
+(The correspondence used here — parent-table index *i* ↔ record-array index *i* — follows from
+`0x413dc3400` writing `parent[(ref >> 3) - 4]` where the same reference indexes the node array.)
+
 ## CONCLUSION: both rejecting programs build descriptors from LANE MASKS (2026-08-15)
 
 `PROSPER_DYNTRACE_SGPR=106` on `0x205b654a00`, filtered by program identity:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,52 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## The two inputs nothing writes (2026-08-15, measured)
+
+The gameplay chain is all `0x20…` and every link hits (Codex, #2542), so the world is already absent
+at the output of `fs=0x205b34be00`. That shader takes four inputs. Two of them are surfaces **no draw
+in the run ever renders into**:
+
+| input | RTT cache | draws that write it (exact, 131,072-draw run) |
+| --- | --- | --- |
+| `0x2085de0000` | HIT | **130,290** — slot1=8,262, slot4=122,028 |
+| `0x2063380000` | HIT | **1** |
+| `0x2052ac0000` (3840x2160 fmt=1) | MISS | **0 — never a colour target** |
+| `0x2054aa0000` (fmt=11) | MISS | **0 — never a colour target** |
+
+Measured with `PROSPER_TARGET_WATCH=<addr>,…`, which is exact and unsampled over all eight MRT slots.
+
+**Why the zeros are believable here, when a clean zero usually is not.** Two independent properties of
+the same run establish that the instrument could have expressed the result it did not find:
+
+- *The lever moves*: `0x2085de0000` reports 130,290 of 131,072 draws across two slots.
+- *The domain is expressible*: `0x2063380000` reports **exactly one** draw. That is the case a sampled
+  census structurally cannot represent, and it is the reason this measurement exists — see below.
+
+`0x2052ac0000` is also guest-readable and its first 8,252 bytes stay **all-zero for the whole run**
+(`[compute-tree-watch] … pairs=0 unpaired=0`, observed once and never changing). That is expected of any
+render target and is *not* independent evidence, since guest memory does not see GPU writes; it is
+recorded only so the next reader does not spend a run re-deriving it.
+
+### Two instrument defects this found, both of which had already produced a wrong answer
+
+1. **The draw census read only MRT slot 0.** A deferred renderer writes a G-buffer across slots 0–7 in
+   one draw, so a slot-0-only census cannot see most of what a frame renders into — and "is address X
+   ever a render target" was exactly the question being put to it. Its own control exposed it: the two
+   surfaces that demonstrably HIT the RTT cache never appeared in the census at all. Fixed to census all
+   eight slots. `0x2085de0000`'s traffic is 96% in **slot 4**, so the slot-0 census was blind to it.
+2. **The census samples 1 in 32 draws, and a sampled zero cannot answer an "ever" question.** A surface
+   written by ten draws is missed with probability (31/32)^10 ≈ 73%; by one draw, ≈ 97%. The sampling was
+   itself a correct earlier fix — the unsampled first version took a mutex and a map insert on every one
+   of 131,072 draws and stalled the routed run at 1,024 — but it silently changed what the instrument
+   could conclude. `PROSPER_TARGET_WATCH` is the exact form: bounded watch list, per-address atomics, no
+   lock, so it costs eight register lookups per draw and keeps the "ever" question answerable.
+   **`0x2063380000` is written by exactly one draw**, so this distinction is not hypothetical — the
+   sampled census would have reported it as never written, alongside the two that genuinely are.
+
+An unreadable tree-watch window also used to produce **no output at all**, which is indistinguishable
+from "nothing writes this address" — the conclusion it would have supported. It now says so.
+
 ## Ruled out / retracted here
 
 - **"Sibling pairs are `(odd, even)`."** Retracted. The clean table has 204 parents whose children

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,47 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## THE BUILDER'S LOWERING IS CORRECT — it emits a perfect tree for eleven submits (2026-08-15)
+
+`PROSPER_COMPUTE_DISPATCH_LOG` now carries the launch geometry, so the outcome and the launch can be
+read on one line. Across the whole route:
+
+```
+submit  threads       local     tree
+4802    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0     <- exactly correct
+5217    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+5632    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+6047    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+6463    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+6877    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+7292    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+7706    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+8121    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+8951    2063x1x1      256x1x1   pairs=1030 unpaired=0 cycles=0
+9360    2063x1x1      256x1x1   pairs=852  unpaired=247 cycles=57  <- and never correct again
+...     2063x1x1      256x1x1   cyclic for the remaining 30+ submits
+```
+
+**Eleven consecutive submits at pairs=1030, unpaired=0, cycles=0 — the exact clean ground truth — at
+an identical launch geometry, from the same compiled module.** A miscompiled shader does not produce
+the exactly correct answer eleven times in a row.
+
+**So `0x413dc3400`'s lowering is CORRECT, and the defect is in what it is fed.** Every
+lowering-side hypothesis for this program is retired by this one measurement: barrier placement,
+LDS sizing, wave model, the compaction, the exec-mask predication, the store addressing. They all
+produce a correct tree for eleven submits.
+
+The launch is identical on both sides of the boundary — `threads=2063x1x1 local=256x1x1` throughout —
+so an active-record count change is not the trigger either. The transition point is **not a fixed
+submit number**: one run breaks at ~6795, another at ~9360, so it tracks route position and scene
+content rather than a dispatch ordinal.
+
+**The remaining question is therefore narrow and concrete: what changes in the builder's input at
+that boundary?** Its tags come from `0x209cc76000` (2,063 × 64 bytes, binding 4 / fetch-pc 86).
+`PROSPER_COMPUTE_TREE_WATCH_AUX=0xADDR:DWORDS` (added here) dumps a second guest range alongside the
+watched table, and dumps the builder's clean transitions too so there is a control from the same run
+rather than only cyclic samples.
+
 ## FALSIFIED: the missing-producer hypothesis is dead (2026-08-15)
 
 `PROSPER_COMPUTE_DISPATCH_LOG` (added here) records **one line per dispatch** with its outcome, which

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,48 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Cube depth: the DS cache overwrote its own faces (2026-08-15, fixed) — and the falsification above is RETRACTED
+
+**Retraction first.** The section below this one records cube shadow maps as falsified. That call was
+premature and is withdrawn. It read the *final screenshot*, and Codex's correction is right: the
+screenshot is the wrong readout for an input this deep in the frame. Re-run cube-only at both poles,
+reading the lighting output `0x20431c0000` instead:
+
+| cube fill | `0x20431c0000` |
+| --- | --- |
+| `0x00` | max=46, 44.5% non-black (matches baseline) |
+| `0xff` | **max=0, 0.0%** |
+
+The shadow term does not merely move the lighting output, it can zero it completely. The lever moves
+hard, so the cube path is load-bearing and the earlier "not the missing world" verdict was void, not
+negative. Recorded here because it is the second time this session that a black *screenshot* hid a
+large change one stage upstream.
+
+**The defect Codex identified underneath the bridge gate.** A cube shadow map is not six neighbouring
+allocations — it is ONE six-layer allocation whose faces share a depth base and are selected by
+`DB_DEPTH_VIEW.SLICE_START/MAX`. GTA V programs `0x02000000, 0x02002001, 0x02004002 … 0x0200a005`
+(start=max=0..5) against a single base. `PersistentDsKey` omitted the slice, so **every face render
+for a base collided on one key and overwrote the previous face's host image**; only the last face
+survived. No relaxation of the sampling gate could have recovered a valid cube from that cache.
+
+Fixed by adding the slice to the DS identity. Measured on the same route: retained DS surfaces
+**29 → 55**, and a cube base that held one entry now holds one per face:
+
+```
+0x20972c0000 slice=0 … slice=1 … slice=2 … slice=3 … slice=4
+0x20978c0000 slice=0 … slice=1 … slice=2 … slice=3 … slice=4
+```
+
+Non-layered surfaces program `DB_DEPTH_VIEW=0` and key at slice 0 exactly as before, so identity
+widens only where the guest actually used layers.
+
+**Still open (Codex's stage 2):** the cube T# is still gated out of the bridge by `img_dim == 1`, and
+binding it needs the six slices gathered into the backend's stacked sampled representation plus a
+**numeric depth conversion** — the guest surface is `Z16` (`DB_Z_INFO.FORMAT=1`) while prosper
+canonicalises host attachments to `D32_SFLOAT`, so the bridge must do
+`D32 float → clamp [0,1] → quantise to R16_UNORM`, not a bit reinterpretation and not a Z inversion
+(reversed-Z is already carried by the stored values and the comparison direction).
+
 ## ROOT CAUSE: the fragment recompiler supported only MRT0 and MRT1 (2026-08-15, fixed)
 
 GTA V's G-buffer pass exports **five** render targets. prosper's fragment shell carried **two**, so

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,51 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Third review round on #2550, all four fixed (2026-08-15)
+
+Every one a legacy "only MRT0/1 exist" seam that the widening newly reached.
+
+**1 (blocker) — a depth-feedback split dropped MRT2–7 from every non-final segment.** The splitter
+passed `final ? mrt_outputs : nullptr`, and `render_draw_pass_rgba` derives `color_count` from that
+pointer — falling back to `out_rgba1`, which the live renderer passes as null. So every pre-final
+segment of a five-MRT pass rendered with **one** attachment and discarded its MRT1–4 exports; later
+segments were never told to LOAD the higher slots either. The same accumulation loss this PR fixes at
+the frontend's pass groups, reappearing at the backend's own physical boundary.
+
+Fixed by extracting `split_segment_contract()`: the attachment SHAPE is identical across segments and
+only the pixel destination and the load/readback flags differ. Non-final segments now decline
+readback **per slot** — `color_count > 2` alone forced a full-extent copy of every higher slot on
+every segment, so the fix needed `readback_slots[]` to exist at all.
+
+**2 (high) — same-pass feedback detection knew only MRT0/MRT1.** Now that a higher slot's image is
+persistent and sampled-capable, sampling an active MRT2+ target borrowed the very `VkImage` the pass
+was writing. Both halves — the backend's descriptor borrow and the frontend's direct-live decision —
+now go through one `mrt_target_feedback()` policy.
+
+**3 (high) — the sparse-MRT gate had no regression at its production seam.** Reverting
+`any_slot_bound` to `base` left all 245 tests and the validation scan green. The union is now
+`mrt_any_slot_bound()` in the frontend policy header, called by both decisions that key on it and
+tested there.
+
+**4 (medium) — the no-readback publication lifecycle skipped MRT2–7.** `publish_persistent_color()`
+covered slots 0 and 1; a persistent higher slot could reach `SHADER_READ_ONLY_OPTIMAL` with no
+barrier making its writes visible to a later command buffer. Mirrored for every retained slot, keyed
+on whether that slot's readback path actually ran.
+
+All four are mutation-verified at their own sites: dropping the segment shape, dropping the segment
+load, narrowing the feedback policy to slots 0/1, and narrowing the union to colour-0 each turn a
+named assertion red.
+
+Live title after this round: **c2 4,533,513 · c3 4,533,513 · c4 3,472,691** non-black pixels,
+0 validation errors.
+
+### The seam this round is really about
+
+Every finding was the same shape: a policy written when only two colour slots could exist, left
+behind by a change that made eight possible. They were not in the diff — they were in code the diff
+made reachable. Grepping for `persistent_id1` or `color1` finds them; grepping for what changed does
+not.
+
 ## Second review round on #2550, all five fixed (2026-08-15)
 
 **1 (blocker) — MRT2–7 reused an image in the wrong Vulkan layout.** The retained image was recorded

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -10,6 +10,74 @@ presses for a reason).
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
+## THE CORRUPTING PROGRAM IS `0x413dc3400` (2026-08-15)
+
+Measured with `PROSPER_COMPUTE_TREE_WATCH=0x20f848417c:2063` on a 200 s routed run with the hanging
+consumer skipped (`PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700`, so zero device losses, 9,291 frames).
+The watch reads the table before and after **every** realized dispatch, so a change is attributed to
+the dispatch that made it rather than to an interval.
+
+**321 observations. Every clean -> cyclic transition:**
+
+| program | clean -> cyclic | cyclic -> clean | clean -> clean |
+| --- | --- | --- | --- |
+| `0x413dc3400` | **37** | 0 | 3 |
+| `0x413d88400` | 1 | 37 | 2 |
+| `0x413e1c300` | 1 | 1 | 158 |
+| `0x413cee500` | 0 | 1 | 79 |
+
+`0x413dc3400` made the table cyclic on **37 of its 40 dispatches**. Nothing else does it
+systematically.
+
+**Every observed writer reported `toucher=1`.** No change came from a program whose resource table
+does not contain the address, so there is no unknown writer and no out-of-bounds path to chase —
+the watch was built to be able to report that case and did not.
+
+### The per-submit chain, identical every submit
+
+```
+d15,d16  0x413cee500   Morton keys        -> pairs=0     unpaired=0    oob-roots=0   depth=3
+d37      0x413dc3400   topology build     -> cycles=19   pairs=919     unpaired=148  depth=68
+d39..47  0x413dc6700   the consumer       (skipped in this run; this is what hangs)
+d54      0x413d88400   repurposes the RAM -> pairs=0     unpaired=571
+```
+
+`0x413dc3400` writes 2,061 of 2,063 records in one dispatch through six store pcs (bindings/pcs
+`23:597, 25:608, 26:620, 27:632, 28:644, 29:656`), turning a table with **no** cycles into one with
+19 cycles, 57 cyclic roots and depth 68. The consumer runs two dispatches later and walks exactly
+that array. **This is the defect: the builder produces a cyclic parent array, and the hang is the
+downstream symptom.**
+
+The same run also shows `0x413d88400` at d54 leaving `pairs=0` — the allocation is **reused scratch**
+across phases, not one long-lived structure, which is why a pair count compared across phases moves
+by hundreds. Compare pair counts only within the same phase.
+
+### What a correct table looks like — measured, not assumed
+
+Against 91 captured 2,063-dword tables:
+
+| | pairs | unpaired | cycles | max depth |
+| --- | --- | --- | --- | --- |
+| clean parent tables (`live-a240`, `post-36-3`) | **1030** | **0** | 0 | **11** |
+| cyclic captures (85, one resource hash) | 1029 | 1 | 1 | 15 |
+| `0x413dc3400` output, live | 919 | 148 | 19 | 68 |
+
+This **confirms Codex's LBVH identification quantitatively**: a full binary tree over 1,032 leaves
+has 1,031 internal nodes, and a well-formed table measures 1,030 sibling pairs with zero unpaired
+records at depth 11, against log2(1032) = 10.01. Pairs are `(odd, even)`: the odd index is the head
+(side bit clear), the even index its mate (side bit set).
+
+In the 85-capture set the anomaly is *fully deterministic* — the same 4-member cycle
+`(256, 384, 447, 831)` and the same single unpaired record `300` in every one. All 85 share one
+resource hash, so this is one table observed 85 times, i.e. the corruption is **stable** across
+submits 7629 -> 9694 rather than re-derived; nothing repairs it. The four cycle members are each in
+a *well-formed* sibling pair, so the cycle is not caused by a broken pair — the parent links
+themselves are wrong. Slot 300 differs from its mate only in bits[2:0] (`0x942` against `0x940`,
+both decoding to parent 296), so it is a flag-bit difference and a separate anomaly from the cycle.
+
+**Ruled out by this measurement:** the "lost update" / two-writer race account of the cycle. Within
+one dispatch's pre/post pair there is exactly one writer, and its output is cyclic.
+
 ## What the structure IS: an LBVH / binary-radix-tree parent table from Morton keys
 
 Identified by Codex from the retained ISA (#2542), and it reframes everything below.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,40 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
+
+Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather
+than its first 8 KB finds **23 distinct writing programs**, not the seven the narrower window showed:
+
+```
+0x413e15400 652   0x413e14200 651   0x413e14500 651   0x413cf9200 603   0x413cf9000 569
+0x413cdc200 218   0x413cf5400  43   0x413cf6100  43   0x413ce6000  32   0x413e1ff00  31
+0x413ced900  10   0x413d1bf00   9   0x413d21600   8   0x413dc3400   6   0x413d87800   5
+0x413e16400   5   0x413e13000   3   0x413e14900   2   0x413d21800   1   0x413d21c00   1
+0x413d22000   1   0x413d22b00   1   0x413e13200   1
+```
+
+**So this is a shared scratch pool that many programs reuse across phases**, exactly like the
+traversal table itself. `132032 = 2063 x 64` is how `0x413dc3400` and `0x413ce6000` *view* it, not
+proof that the allocation belongs to them.
+
+Two consequences for anything built on the earlier analysis:
+
+- **"The only program binding the full array is `0x413ce6000`" was a statement about the narrow
+  window.** Over the full range there are 23 writers, and the three busiest — `0x413e14200`,
+  `0x413e14500`, `0x413e15400`, ~650 changes each — were entirely invisible to every census before
+  this one. A watch window narrower than the buffer under study reports a writer set that is
+  guaranteed incomplete.
+- **The tag histograms remain valid** because they were captured by the aux dump *at the builder's
+  own dispatch*, which is the only moment that matters. But attributing a tag change to a producer is
+  not possible from writer counts alone with 23 of them interleaved; it needs the last-writer-per-
+  record, which nothing currently records.
+
+The early phase is visible in the same data and is a different workload: at submit 3864
+`0x413ced900` leaves the pool all-zero (`{0: 2063}`) and `0x413d1bf00` fills it progressively over
+eight dispatches. Tag distributions there span all eight values, unlike the two-regime pattern at
+builder time.
+
 ## The builder's INPUT differs between the two regimes (2026-08-15)
 
 `PROSPER_COMPUTE_TREE_WATCH_AUX=0x209cc76000:33008` captures the 2,063 x 64-byte record array

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,38 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Correction: a colour-target census must intersect the WRITE MASK (2026-08-15)
+
+`PROSPER_TARGET_WATCH` and `PROSPER_DRAW_CENSUS` read `CB_COLORn_BASE` for all eight slots and count
+a draw as writing that address. **That over-counts, and the earlier figures published from it are
+wrong.** A base register is sticky: the guest leaves `CB_COLOR4_BASE` programmed long after it stops
+rendering to slot 4, and hardware writes a slot only where `CB_TARGET_MASK & CB_SHADER_MASK` has a
+non-zero nibble for it.
+
+Measured (`PROSPER_MRT_CENSUS`, 16,384 pass groups):
+
+```
+c0 base=16384 format=16384 mask=15590 ACTIVE=15590
+c1 base=11796 format=16384 mask= 2729 ACTIVE= 2729
+c2 base=11796 format=16384 mask=    0 ACTIVE=    0
+c3 base=11796 format=16384 mask=    0 ACTIVE=    0
+c4 base=11796 format=16384 mask=    0 ACTIVE=    0
+```
+
+and over the groups where slot 4 *has* a base, the dominant state is
+`cb_target_mask=0x0000000f cb_shader_mask=0x0000000f` (x11,647) — **slot 0 only**. Both registers are
+present and genuinely narrow; neither is being truncated by prosper, and both default to `0xffffffff`
+when absent, so a zero nibble is real guest state.
+
+**So "0x2085de0000 is written by 130,290 of 131,072 draws, 96% of them in slot 4" is retracted.**
+Those were stale bindings. The renderer is right to drop them, MRT slots 2–7 are not a defect here,
+and the eight-slot census fix — which was itself a correct fix to a slot-0-only census — bought a
+number that still needed the mask to mean anything.
+
+The narrower lesson, which cost two rounds: **an eight-slot census with no mask intersection is not
+"more complete" than a one-slot census, it is differently wrong** — the first under-reports, the
+second over-reports, and only the second looks like progress.
+
 ## Where the picture actually goes (2026-08-15) — and three metrics that lied about it
 
 `tools/gpu_timeline/rtt_pass_graph.py` (new) reassembles a frame's render-pass graph from a

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,72 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## ROOT CAUSE: the fragment recompiler supported only MRT0 and MRT1 (2026-08-15, fixed)
+
+GTA V's G-buffer pass exports **five** render targets. prosper's fragment shell carried **two**, so
+three of the five attachments were silently dropped from every G-buffer pass; the deferred lighting
+pass then sampled buffers nothing had written, and the world rendered into a G-buffer that was lit by
+nothing.
+
+The pass, from `PROSPER_MRT_SHAPE_FOR`:
+
+```
+x1754  tmask=0x000fffff smask=0x0003ffff
+       c0=0x207de60000 c1=0x207fe40000 c2=0x2083e00000 c3=0x2081e20000 c4=0x2085de0000
+```
+
+`tmask & smask = 0x0003ffff` — slots 0–3 at `0xf`, slot 4 at `0x3`. All five enabled by the guest.
+
+**Everything below the shader already carried eight.** The render state decodes all eight slots,
+`active_color_count` scans all eight, and the backend's render pass, framebuffer and blend state are
+generic over `color_count`. Four hard-coded `2`s in the fragment path were the whole limit:
+
+| site | was |
+| --- | --- |
+| `rdna2_to_spirv.cpp` fragment shell `v_color` | `std::array<uint32_t, 2>` |
+| `fragment_color_export_mask` `realized` | `std::array<bool, 2>` |
+| fragment colour-mask scan | `if (in.exp_target < 2)` |
+| emit-side `exported` | `std::array<bool, 2>` |
+| the "did anything export" guard | `!exported[0] && !exported[1]` |
+
+The consequence was not confined to the shader. `gpu_execute.hpp` gates every slot's Vulkan write
+mask by the shader's EXP.EN — `write_mask &= (exp_mask >> slot*4) & 0xf` — so a decoder that can
+never set bits above nibble 1 forces **`write_mask = 0` for slots 2–7 regardless of what
+CB_TARGET_MASK and CB_SHADER_MASK say**. Slots 0 and 1 survived only because `active_color` has
+named-field fallbacks for exactly those two.
+
+Measured, same route, before → after:
+
+```
+c2 ACTIVE=0 -> 2151      per-slot write_mask disagreements with the draw's own
+c3 ACTIVE=0 -> 2083      mask registers: 5,318 -> 0
+c4 ACTIVE=0 -> 1040
+```
+
+`ctest --no-tests=error -j4`: **245/245 pass**, exit 0.
+
+**The world is still not lit after this fix.** It is a verified, necessary defect fix — the G-buffer
+now reaches the lighting pass complete — and it is not by itself sufficient. Recorded that way rather
+than as a solution.
+
+### The instrument that found it, and the two that could not
+
+The disagreement census is the one that mattered: for every draw, the per-slot `write_mask` the
+DrawItem *carries* against the one its own `cb_target_mask & cb_shader_mask` *imply*.
+
+```
+c2 implied=0xf carried=0x0  x1830
+c3 implied=0xf carried=0x0  x2109
+c4 implied=0x3 carried=0x0  x1676
+```
+
+Neither of the two censuses before it could have found this. A per-slot **activation** census says
+slots 2–4 never activate but not why, and its `mask=0` column is equally consistent with "the guest
+disabled them" — which is what the mask histogram appeared to confirm, because that histogram was
+keyed on groups where slot 4 had a *base* and was dominated by unrelated passes whose masks really
+are slot-0-only. The defect only became visible when the same quantity was computed **two ways from
+the same draw** and compared.
+
 ## Correction: a colour-target census must intersect the WRITE MASK (2026-08-15)
 
 `PROSPER_TARGET_WATCH` and `PROSPER_DRAW_CENSUS` read `CB_COLORn_BASE` for all eight slots and count

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -246,9 +246,22 @@ of `0x413dc3400`** — in whatever produces `0x209cc76000`.
 
 **Its producers, from `PROSPER_COMPUTE_TREE_WATCH=0x209cc76000`:** `0x413cf9000` (117 changes),
 `0x413cf9200` (117), `0x413cf5400` (29), `0x413cf6100` (29), `0x413ce6000` (26), `0x413d1bf00` (2),
-and `0x413e1ff00` (3, **`toucher=0`**). `0x413cf9200` has 20 recompile-empty dispatches of 678, and
-`0x413e1ff00` writes bytes it does not bind. **Both are unexamined and both are better leads than
-anything remaining on the builder.**
+and `0x413e1ff00` (3, **`toucher=0`**). `0x413cf9200` has 20 recompile-empty dispatches of 678.
+
+**RETRACTED — `0x413e1ff00` does NOT write bytes it does not bind.** That was my own instrument
+producing a phantom. Its binding 7 is `base=0x209cc76080 size=160 stride=32`, i.e. **128 bytes inside
+the watched window**. The tree watch detects changes anywhere in the WINDOW but its `toucher` field
+asked whether a program binds the window's **first byte** — two different questions, and the
+disagreement reads as an out-of-bounds write. Fixed with `compute_address_window_hits`, and the
+retraction is recorded rather than quietly dropped because the phantom was reported as a lead before
+the resource map contradicted it.
+
+The same run corrects the producer picture in a way that matters: `0x413cf9000` binds only
+`0x209cc76000 size=320`, and `0x413cf9200` binds `size=320` plus a 64-byte view at `+0x140`. **They
+write the first 320 bytes — five records — not the bulk.** The only program binding the full
+132,032-byte array is `0x413ce6000` (bindings 13/14/17). So it *is* the bulk producer of the records,
+which the falsification above does not contradict: it executes on 29 of the cyclic submits, so its
+running is not the variable.
 
 ## THE BUILDER'S LOWERING IS CORRECT — it emits a perfect tree for eleven submits (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,43 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## THE HYPOTHESIS THIS ALL POINTS AT: the parent array is never cleared
+
+If the builder legitimately links only `{2, 5}` children, then **the slots it does not write must
+already hold something that terminates the consumer's walk** — the walk is
+`while (i != 0) i = bfe(rec[i], 3, 27)`, so a zero terminates and anything else does not.
+
+**It is not cleared.** The tree watch's pre-image at the builder's dispatch is not zero: it is the
+previous phase's stride-4 id array (`{0, 0, 0xa9, 1}` repeating). And the slots the builder leaves
+alone were measured holding `0x09249249`, `0x12492492`, `0x2db6db6d` — the Morton dilation constant
+and multiples — or, sometimes, zero.
+
+**A stale Morton key read as a parent index is exactly a divergent walk.** `0x09249249 >> 3` is
+0x1249249, far past 2,063, which terminates by out-of-range; but `0x12492492 >> 3 & 0x7ffffff` is
+0x2492492 — also out of range. The values that *do* trap are the ones left over from an earlier
+generation of the parent array itself, which are in range by construction.
+
+**This unifies every measurement on this branch:**
+
+- the builder's lowering is correct (eleven perfect submits) ✓
+- its output faithfully follows its input (`both` tracks `pairs`) ✓
+- the failure mode is "a store that does not execute, leaving a stale slot" — measured directly ✓
+- the perfect submits are the ones where nearly every node has two linkable children, so nearly
+  every slot gets written and stale values have nowhere to hide ✓
+- the transition is at a route position, because that is when the scene starts containing enough
+  triangle leaves for unwritten slots to appear ✓
+- no producer decline is necessary ✓
+
+**The prediction that would confirm it:** zero the 2,063-record parent array immediately before
+`0x413dc3400`'s dispatch and the cyclicity should vanish, with the tree becoming legitimately sparse
+(`pairs < 1030`, `cycles = 0`). That is a diagnostic-only experiment — it does not fix anything, since
+on hardware something must be doing the clear and the real question is what — but it is decisive, it
+needs no ISA knowledge, and it can be built as a `PROSPER_*` switch in one sitting.
+
+**`CONFIDENCE: MED-HIGH`.** Every measurement fits and nothing contradicts it, but it has not been
+tested, and the alternative — that the guest's own build does write every slot through a path prosper
+declines — is not excluded.
+
 ## The sparse tree IS a faithful consequence of its input (2026-08-15)
 
 Testing the right correspondence — for each parent with only one child, the **two child references in

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,58 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Where the picture actually goes (2026-08-15) — and three metrics that lied about it
+
+`tools/gpu_timeline/rtt_pass_graph.py` (new) reassembles a frame's render-pass graph from a
+`PROSPER_RTTLOG=1` log: every `[rtt] sample tex` line belongs to a draw of the *next* `[rtt] pass`
+line, so a pass's inputs are the samples since the previous pass, and `SCANOUT` delimits frames.
+Neither a draw census nor a target census can find a lost picture, because both count *work* and the
+defect is in the *dataflow*.
+
+What it shows for GTA V's gameplay frame — the deferred lighting pass:
+
+```
+0x20431c0000  3840x2160  draws=19   rgb_nonblack=0
+   <- 0x207de60000  3840x2160 un8   x19          G-buffer, full
+   <- 0x207fe40000  3840x2160 un8   x19          G-buffer, full
+   <- 0x2083e00000  3840x2160 un8   x23          G-buffer, full
+   <- 0x208f340000   256x256  un16  x1    MISS -- guest bytes
+   <- 0x20954c0000   512x512  un16  x1    MISS -- guest bytes      six shadow maps,
+   <- 0x2093cc0000   512x512  un16  x1    MISS -- guest bytes      none resolved from
+   <- 0x2094ec0000   512x512  un16  x1    MISS -- guest bytes      a renderer-owned image
+   <- 0x20948c0000   512x512  un16  x1    MISS -- guest bytes
+   <- 0x20942c0000   512x512  un16  x1    MISS -- guest bytes
+```
+
+Those six addresses also top the DS-invalidation histogram (`20948c0000` x1010, `2094ec0000` x860,
+`2093cc0000` x410 in one run), so they are surfaces prosper retains and then invalidates on a guest
+DMA. `PROSPER_DS_GUEST_WRITE_INVALIDATE=0` does move that lever cleanly — `depth-invalid=0
+stencil-invalid=0 extent=0`, against 1089/858/1628 with it on — but the route diverged in that run and
+never reached the tutorial, so **it is not yet an A/B and is not claimed as one.**
+
+### Three metrics that each read as "the world is black" when it is not
+
+Recorded because all three were acted on in this session before being caught:
+
+1. **`rgb_nonblack` is computed from an RGBA8 conversion, so an HDR f16 target whose values are all
+   below 1/255 reports exactly ZERO while carrying a complete scene.** `0x20431c0000` reports
+   `rgb_nonblack=0` while the very next pass extracts **47.5% non-black** from it. Reading the metric
+   as "black" is a false negative across the entire lighting stage.
+2. **`[rtt] sample tex … -> miss` spoke only for the COLOUR cache.** A 4K depth buffer the depth
+   bridge had resolved correctly and a texture decoded from guest zeros printed the same word, so
+   counting a pass's missing inputs off this log over-counted them. It now prints `DS-DEPTH` /
+   `DS-STENCIL` for a bridged binding.
+3. **A pass whose readback was deferred has EMPTY CPU pixels, and both `rgb_nonblack` and the new
+   dump then report on nothing.** Measured: `0x207de60000` produced `src=0B` on **1,938 of 1,938**
+   passes in a default run. The same target reports `rgb_nonblack=8267460` (99.7%) in a run with
+   `PROSPER_RTTLOG=1` — because **the instrument's own readback is what materialises the pixels it
+   then measures.** So `PROSPER_RTTLOG` changes the subject, and any per-pass content number is a
+   statement about a run that was made differently from a default one.
+
+`PROSPER_DUMP_PASS=0xADDR[,…]` (new, with `PROSPER_DUMP_PASS_EVERY`) writes what a pass actually
+produced as an image, and reports `src=…B` plus `NO CPU PIXELS (readback deferred)` rather than
+writing nothing — which is how defect 3 was found at all.
+
 ## The stencil plane of a rendered DS surface was never bridged (2026-08-15, fixed)
 
 `fs=0x205b34be00` samples two planes of **one** depth/stencil surface, and prosper retained only one

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,34 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## SCC over-invalidation fixed — and it is NOT what gates the BVH descriptor (2026-08-15)
+
+`PROSPER_DYNTRACE_SCC=1` (added here) reports every transition of the fold's tracked SCC with the pc
+and words that caused it. On `0x205b654a00` it found **325 conservative SCC losses**, from three SOPK
+encodings — and **two of them do not write SCC at all**:
+
+| count | encoding | writes SCC? |
+| --- | --- | --- |
+| 188 | `s_setreg_b32` (0x13) | **no** — writes a hardware register |
+| 43 | `s_waitcnt_vscnt` (0x17, sdst=NULL) | **no** — a wait, register-transparent |
+| 94 | `s_addk_i32` (0x0f) | yes, on signed overflow |
+
+Fixed: `s_setreg_b32` and `s_waitcnt_vscnt` no longer touch SCC, and `s_addk_i32` keeps invalidating
+it while now folding its **value** when the destination is known.
+
+**Lever verified: conservative SCC invalidations in that program went 325 → 0.**
+
+**And the reject is unchanged.** `0x205b654a00` still fails with `mode=unresolved-operand pc=1180`.
+Because the lever demonstrably moved, this is a **genuine negative, not a void arm**: SCC
+over-invalidation is not what gates the BVH descriptor.
+
+So of the four registers in the descriptor `s[16:19]`, dword3 (`s19`) was already observed resolving
+to `0x81000000` on some dispatches. **The next measurement is `s16`/`s17`/`s18`** — the base and size
+words — one watch each.
+
+The change stays on its own merits: two encodings were being charged an SCC write they do not
+perform, which is a correctness defect in the fold independent of this title.
+
 ## The BVH descriptor resolves only when SCC does (2026-08-15)
 
 `PROSPER_DYNTRACE_SGPR=19` on `0x205b654a00`, now that the watch prints a real program identity:

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -515,6 +515,56 @@ Two things must be checked before treating this as a defect, and neither has bee
 Recorded as an observation with its caveats rather than a lead, so the next reader neither chases it
 blind nor loses it.
 
+## WHERE the draws go: a scene buffer with ~71,000 draws, and a composite that reaches the scanout (2026-08-15)
+
+`PROSPER_DRAW_CENSUS=1` now records each draw's `CB_COLOR0_BASE` (+ `_EXT`, + `CB_COLOR0_VIEW`),
+sampled 1 in 32 and ranked by busiest:
+
+```
+[draw-census] draws=131072 indirect=0 submit=14180
+[draw-census]   distinct colour targets (sampled): 94
+[draw-census]   color0=0x208e5a0000 view=0x0      draws=2228     -> ~71,000 draws
+[draw-census]   color0=0x20431c0000 view=0x0      draws=457      -> ~14,600
+[draw-census]   color0=0x20ec7c0000 view=0x4002   draws=156  \
+[draw-census]   color0=0x20ec7c0000 view=0x0      draws=98    |  a LAYERED target: five distinct
+[draw-census]   color0=0x20ec7c0000 view=0x2001   draws=77    |  CB_COLOR0_VIEW slices
+[draw-census]   color0=0x20ec7c0000 view=0x8004   draws=55    |
+[draw-census]   color0=0x20ec7c0000 view=0x6003   draws=42   /
+[draw-census]   color0=0x215ed10000 view=0x0      draws=89   \
+[draw-census]   color0=0x2160cf0000 view=0x0      draws=86    |  the SCANOUT buffers
+[draw-census]   color0=0x2162cd0000 view=0x0      draws=83   /
+```
+
+**Two facts settle where the investigation goes next:**
+
+1. **A single dominant scene target takes ~71,000 draws** (`0x208e5a0000`). The world's geometry is
+   being drawn, in quantity, into one surface.
+2. **The scanout buffers each receive ~2,800 draws.** Those addresses are the ones the frame grab
+   reported as `present_front_address()` (`0x215ed10000`, `0x2160cf0000`, `0x2162cd0000`), so the
+   **composite runs and targets the presented surface**.
+
+**So the scene is drawn and the composite reaches the screen — and the screen has no world.** The
+break is between them: whatever the composite samples does not carry `0x208e5a0000`'s contents.
+
+That is a much narrower question than any asked before, and it has a named suspect already in this
+document: when a sampled image is DCC-compressed and the uniform fast-clear decode fails,
+`live_renderer.cpp` falls through to reading compressed bytes as uncompressed. The three unsupported
+4K DCC surfaces are `0x2052ac0000`, `0x20e0380000` and `0x20df360000` — **none of which is
+`0x208e5a0000`**, so that specific mechanism is not yet connected to the scene buffer.
+
+**The measurement that closes it: for the composite draws (those whose colour target is a scanout
+address), which textures do they sample, and does each resolve to prosper's own rendered image (an
+`rtt_hit`) or fall back to reading guest memory?** Guest memory for a surface prosper rendered into
+is black — the scanout dump confirms guest-side scanout is uniformly black, as expected when prosper
+renders into its own Vulkan images and presents those.
+
+### A note on instrument cost, because it cost a run
+
+The first version of this census took a mutex and inserted into a map on **every** one of 131,072
+draws and printed twelve lines at each power of two. The routed run stalled at 1,024 draws and never
+reached gameplay. Sampling 1 in 32 and reporting from 4,096 upward fixed it. An instrument that
+changes the subject's behaviour measures the instrument.
+
 ## THE DRAWS ARE HAPPENING: 131,072 executed, 0 indirect, 0 undecoded packets (2026-08-15)
 
 The most basic number about a missing world had never been measured. `PROSPER_DRAW_CENSUS=1` (added

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -97,6 +97,46 @@ one dispatch's pre/post pair there is exactly one writer, and its output is cycl
 - **A lane/wave/workgroup boundary effect.** Damage index mod 2/3/4/8/16 is flat.
 - **An unknown or out-of-bounds writer.** Every observed change reported `toucher=1`.
 
+## THE REMAINING BLOCKER, EXACTLY (2026-08-15)
+
+Every compute reject on a routed run now names its cause without `PROSPER_DBG`. `0x413ce6000` — the
+producer whose absence removes the world — is blocked by **one instruction**:
+
+```
+0x413ce6000  mode=unresolved-operand pc=156 words=e0382000,80020006 fmt=12 op=0xe
+```
+
+`fmt=12` is MUBUF, `op=0xe` is `buffer_load_dwordx3`. `mode=unresolved-operand` means the **lowering
+exists and the descriptor does not resolve** — the emitter is fine, the descriptor is the defect.
+
+pc156 is the **runtime-selected buffer array**: `PROSPER_COMPUTE_RESOURCE_MAP` shows it resolving in
+the live table as `binding=10 fetch-pc=156 base=0x203f2e9b38 size=13360 stride=20 entries=5`, while
+the pre-specialization const-fold trace (`PROSPER_DYNTRACE_FAIL`) shows it as
+`use_pc=156 v4=00000000:00000000:00000000:00000000 base=0x0 stride=0 records=0`. Its sibling at
+pc158 is the same shape. Those two are the only unresolved uses of the nineteen.
+
+**So the whole "GTA V has no 3D world" chain reduces to one buffer-array descriptor that does not
+const-fold at pc156 of `0x413ce6000`.** That is the next thing to implement.
+
+The full reject census, now legible — every one is `mode=unresolved-operand`, i.e. every one is a
+descriptor that does not resolve rather than an instruction that is not implemented:
+
+| program | pc | fmt/op |
+| --- | --- | --- |
+| `0x413ce6000` | 156 | MUBUF `buffer_load_dwordx3` |
+| `0x413cf9200` | 5 | MUBUF `buffer_load_dword` |
+| `0x413cf9a00` | 11 | MUBUF `buffer_load_dword` |
+| `0x413cf9d00` | 70 | FLAT/GLOBAL `op=0xc` |
+| `0x413d14100` | 6 | MUBUF `buffer_load_dwordx3` |
+| `0x2042f49a00` | 16 | MIMG `op=0x1` |
+| `0x2042f4a600` | 7 | SMEM `op=0x4` |
+| `0x205b545c00` | 98 | VOP2 `op=0xf` |
+| `0x205b54ee00` | 90 | VOP2 `op=0xf` |
+| `0x205b5e8600` | 314 | SOP2 `op=0xe` |
+| `0x205b654a00` | 1180 | MIMG `op=0xe6` |
+| `0x205b657200` | 313 | MIMG `op=0xe6` |
+| `0x205b658800` | 82 | SOP1 `op=0x3` |
+
 ## ROOT CAUSE: `0x413ce6000` never recompiles, and it is the producer of the tags (2026-08-15)
 
 The chain is complete and every link is measured.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -353,6 +353,29 @@ and the const-fold alike — is what the remaining rejects have in common.
 VCC_LO and that prosper's VCC recognisers do not cover these shapes; it is *not* established that
 covering them is enough to make either program compile, because neither has been tried.
 
+## `s_mulk_i32` folding: landed, and it did NOT move the reject (2026-08-15)
+
+The const-fold's SOPK case handles **only** `s_movk_i32`; every other SOPK forgets its destination
+*and* invalidates SCC. Its own comment notes that `s_movk/s_version/s_cmovk/s_mulk` do not write SCC
+— so `s_mulk_i32` was being charged both costs it does not owe, and the comment demands per-opcode
+evidence before widening. That evidence exists: `0x413ce6000` pc149 is `s_mulk_i32 s106, 120` where
+120 is the descriptor array's exact record stride, feeding the select at pc153 and the rejecting load
+at pc156.
+
+Folded it: multiply a known destination, forget an unknown one as before, and stop clobbering SCC.
+245/245 ctest green.
+
+**It did not change the reject.** `0x413ce6000` still fails with `mode=unresolved-operand pc=156`.
+
+**And the arm is VOID, not negative** — the same discipline applied to the multiwave A/B. Nothing in
+this run demonstrates that the fold's output actually changed for this program: the reject is
+produced downstream of several other steps, and no artefact was hashed before the outcome was read.
+Treat "s_mulk folding does not fix `0x413ce6000`" as untested, not as false. The way to test it is to
+show s106 is now *known* at pc153 — which needs a fold-state probe that does not exist.
+
+The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
+backing and it costs nothing — not because it was shown to help.
+
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 
 Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,54 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## What is NOT hiding the world — four eliminations, each with a verified lever (2026-08-15)
+
+Every one of these was measured on a routed run with the lever confirmed to have moved, so each is a
+**genuine negative rather than a void arm**. None of them restores the world.
+
+| candidate | lever, verified | outcome |
+| --- | --- | --- |
+| the compute hang / device loss | consumer skipped → **0 device losses**, 9,363 frames | world still absent |
+| truncated indirect-dispatch arguments | aperture recovery fires 24×, unreadable **24 → 0** | frame unchanged |
+| storage-image contract dropping a whole batch | per-draw drop reports **"kept 0 of 1 draws"** | the batch *is* one draw; identical either way |
+| `CB_COLOR_CONTROL.MODE=0` on 131,072 draws | — | known latching artefact (#1706), not per-draw truth |
+
+### The storage-image rejection, precisely
+
+The failing resource is named exactly, and **the DCC hypothesis for it was wrong**:
+
+```
+[render] storage-image contract: set=1 binding=46 portable-uvec4 REJECTED
+    guest-texel=4 shape=0
+    writable=1  compressed=0  arrayed=0  multisampled=0
+    reflected-dim=1 guest-dim=1 depth=1 fmt=4 comps=2
+```
+
+The only failing term is **`writable=1`** — `portable_storage_shape` requires
+`!writable_storage_image`. Compression, arraying, multisampling and the dimensions are all fine. So
+**writable portable-uvec4 storage images are unsupported in the graphics path**, and that is a real
+gap worth closing on the charter's own terms.
+
+But its blast radius is one draw, not a frame: `PROSPER_RENDER_DROP_UNPROVEN_DRAW=1` reports
+`kept 0 of 1 draws in this batch` every time. The conservative whole-batch abort in `render_runner.h`
+looked alarming and costs nothing extra here.
+
+### Still open, and unquantified
+
+Three 4K DCC-compressed **sampled** images remain unsupported (fmt 1/4/9). That is a separate
+resource from the storage image above — the storage image is not compressed. Whether the composite
+depends on those three has not been established.
+
+### The instrument that would answer this, and why it has not yet
+
+`PROSPER_GRAB_BUNDLE_AFTER_MS` on `prosper-app` is the documented fastest loop for "why does this
+frame look wrong". It was tried at 170 s with `PROSPER_CAPTURE_FRAMES=1` and again with 16, and both
+report **"the capture window contained no GPU submits"** while the same run shows 271 `[agc]`, 60
+`[compute]` and 43 `[render]` lines and reaches 191 s of route. So the capture window and the
+submits are not lining up, and **that mismatch is itself the next thing to understand** — without a
+bundle there is no draw-level view of the frame, and every conclusion above is from log statistics
+rather than from the frame's actual contents.
+
 ## The hang is NOT the only blocker — two more, measured (2026-08-15)
 
 Answering "is the compute hang the reason there is no world" directly, by looking at a frame with

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,39 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The F9 frame grab cannot be used on this title — diagnosed and filed (#2549)
+
+The charter names the F9 grab the fastest loop for a graphical bug, and GTA V — a GPU-driven title
+whose world is absent — is exactly the case it exists for. It could not be run at all, and the
+message said only "the capture window contained no GPU submits".
+
+Instrumenting the submit hook with three counters and the window's wall-clock duration named the
+cause immediately:
+
+```
+[grab] submit hook reached=26840, 19206 while inactive, 7634 while not capturing;
+       window was open 26 ms for 48 presents
+```
+
+**48 presents in 26 ms**, and 12 presents in 7 ms — about **1,700 presents/second** against a 23/s
+average. **GTA V flips in bursts**, so a window defined as a present COUNT has an effectively random
+wall-clock duration, usually far too short to contain a submit.
+
+Two further refusals were found and opened behind `PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1`, which
+reports every acceptance as inspection-only: five packed/indirect-pointer provenance validators that
+abort the whole bundle when one compute dispatch cannot be exactly proven. Right for a replay bundle,
+wrong for a bundle meant to be read — and on this title they fire, so the grab aborted at submit
+19358 before the window problem was even reachable.
+
+With both addressed the capture reaches **181 frames / 22,599 submits**, and then hits the byte
+budget: 28 frames is 3.4 GB against a 3,072 MB maximum. **There is no setting that both lands on
+submits and fits the budget, because one knob controls both.** Filed as **#2549** with a
+time-based-window suggestion.
+
+**Consequence for everything above:** there is still no draw-level view of a GTA V frame. Every
+conclusion in this document about why the world is absent rests on log statistics, not on the frame's
+contents.
+
 ## Open, unquantified: 38 of 40 logged `WaitRegMem` waits are on UNMAPPED labels (2026-08-15)
 
 ```

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,60 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The hang is NOT the only blocker — two more, measured (2026-08-15)
+
+Answering "is the compute hang the reason there is no world" directly, by looking at a frame with
+the hanging consumer skipped: **zero device losses, 9,363 frames, and the world is still absent.**
+Tutorial text and a few light blooms render; no geometry. So the compute chain cannot be the whole
+story, and two further blockers are visible in the same run.
+
+### 1. Indirect dispatch arguments arrive with a TRUNCATED address — and the fix is already in-tree, off
+
+```
+[agc] indirect dispatch skipped: unreadable arguments at 0xf8480120
+```
+
+The real address is `0x20f8480120`; the high byte is gone. `command_processor.cpp` already has an
+aperture-recovery path — `(aperture << 32) | (addr & 0xffffffff)` — behind
+**`PROSPER_INDIRECT_APERTURE_RECOVERY`, which is opt-in and off by default**. Its own comment records
+that with it off, 50 of 64 indirect compute dispatches are skipped as unreadable; with it on, 0 are,
+and the probe found the raw low address unmapped and `aperture | low` mapped on 49 of 49.
+
+**Measured here with the lever verified:** recovery fires 24 times
+(`0xf8480120 -> 0x20f8480120`, queue 2), unreadable-argument skips go **24 → 0**, device losses stay
+at 0. **And the frame is unchanged — still no world.** A genuine negative, not a void arm: the
+lever demonstrably moved.
+
+So the truncation is real and worth resolving on its own merits, but it is not what is hiding the
+world either.
+
+### 2. Three 4K DCC-compressed sampled images are unsupported
+
+```
+[render] DCC-compressed sampled image 3840x2160x1 fmt=1 tile=24 is unsupported; metadata=0/0
+[render] DCC-compressed sampled image 3840x2160x1 fmt=4 tile=27 is unsupported; metadata=81920/81920
+[render] DCC-compressed sampled image 3840x2160x1 fmt=9 tile=27 is unsupported; metadata=49152/49152
+```
+
+`live_renderer.cpp` handles DCC only for the **uniform fast-clear** case
+(`gfx10_dcc_fast_clear_rgba8`). When that fails it warns and **falls through to the ordinary
+format/detile path, which reads the COMPRESSED base bytes as if uncompressed** — garbage or black.
+
+These are full-screen 4K surfaces, they are **not** renderer-owned RTTs (`!rtt_hit`), and there are
+three of them in the formats a scene colour/normal/etc. set would use. **A composite that samples
+them cannot produce a world image regardless of what the geometry passes do.**
+
+`CONFIDENCE: MED-HIGH` that this is an independent blocker; `CONFIDENCE: LOW` on it being *the*
+remaining one, since nothing yet shows the geometry passes fill those surfaces in the first place.
+
+### Not a lead: `CB_COLOR_CONTROL.MODE=0`
+
+The same run reports 131,072 draws with an unmodeled `CB_COLOR_CONTROL.MODE=0` "still executed as an
+ordinary color draw", which looks alarming (MODE 0 is CB_DISABLE). **`render_state.hpp` already
+records that prosper's decoded MODE is not per-draw-trustworthy (#1706): a utility sequence's
+operation bits stay latched onto later ordinary draws.** So the count measures the latching, not
+131,072 draws that should have been suppressed. Checked before chasing.
+
 ## Six-reference simulation: the builder is PROVABLY faithful (2026-08-15)
 
 Codex's correction (#2542): `0x413dc3400` reads **six** candidate references per node, not two —

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -211,6 +211,61 @@ descriptor that does not resolve rather than an instruction that is not implemen
 | `0x205b657200` | 313 | MIMG `op=0xe6` |
 | `0x205b658800` | 82 | SOP1 `op=0x3` |
 
+## REFRAME: this is a RAY-TRACING BVH, and prosper already knows the format (2026-08-15)
+
+The "tag" this investigation has been tracking is the **AMD RDNA2 ray-tracing BVH `NODE_TYPE`**, and
+prosper's own recompiler says so. `rdna2_to_spirv.cpp` (search `is_box16`) software-emulates
+`IMAGE_BVH_INTERSECT_RAY`, loading 28 dwords of a node and branching on:
+
+```cpp
+const uint32_t is_tri0  = b.ucmp(Op_IEqual, node_type, b.uconst(0u));
+const uint32_t is_tri1  = b.ucmp(Op_IEqual, node_type, b.uconst(1u));
+const uint32_t is_box16 = b.ucmp(Op_IEqual, node_type, b.uconst(4u));   // 64-byte node
+const uint32_t is_box32 = b.ucmp(Op_IEqual, node_type, b.uconst(5u));   // 128-byte node
+```
+
+So bits[2:0] of a node reference are the node type: 0–3 triangle, **4 box16**, **5 box32**, 6
+instance, 7 procedural. Everything this investigation measured now has a name:
+
+| observation | reading |
+| --- | --- |
+| `0x209cc76000` at 64-byte stride | an array of **64-byte nodes** (box16 or triangle) |
+| tags 0 / 2 / 5 / 7 dominating | triangle / triangle2 / box32 / procedural |
+| **tag 4 appearing only in broken submits** | **box16 nodes entering the scene** |
+| the sibling-paired parent table | BVH topology |
+| Morton keys and `0x09249249` | an LBVH build, as Codex identified |
+| `0x413dc3400`'s `tag == 2 \|\| tag == 5` predicate | it writes links only for two specific node types |
+
+**`PROSPER_DECODED_BVH` machinery already exists** — `DecodedBvhDescriptor` in
+`agc_shader_layout.hpp` carries `box_grow`, `triangle_return_mode`, `box_node_64b`, `sort_enabled`,
+and the dynfail dump prints `BVH(bvh4)` descriptors. This is a supported surface, not an unknown one.
+
+### The consumers of the BVH do not compile
+
+`IMAGE_BVH_INTERSECT_RAY` is **MIMG opcode 0xe6** (`rdna2_to_spirv.cpp:14145`). Two programs in the
+reject census fail on exactly that instruction:
+
+```
+0x205b654a00  mode=unresolved-operand pc=1180 fmt=14 op=0xe6   image_bvh_intersect_ray
+0x205b657200  mode=unresolved-operand pc=313  fmt=14 op=0xe6   image_bvh_intersect_ray
+```
+
+`mode=unresolved-operand` means **the lowering exists and the BVH descriptor does not resolve**.
+prosper has the full software traversal emulation; the shaders that would use it are declined for a
+descriptor.
+
+**So there are two independent defects on the ray-tracing path, and the second was invisible until
+the reject reasons became readable:**
+
+1. `0x413dc3400` builds a cyclic topology once the scene passes a point — the input-dependent defect
+   this document tracks above.
+2. **The traversal shaders that consume the BVH never compile at all**, because their BVH descriptor
+   does not resolve.
+
+Fixing (1) alone cannot render the world if (2) also holds. **(2) is the better first target**: it is
+a descriptor-resolution problem on an instruction prosper already implements, it is named exactly, and
+unlike (1) it does not depend on scene state.
+
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 
 Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -266,6 +266,43 @@ Fixing (1) alone cannot render the world if (2) also holds. **(2) is the better 
 a descriptor-resolution problem on an instruction prosper already implements, it is named exactly, and
 unlike (1) it does not depend on scene state.
 
+## The BVH traversal shader's descriptor is never classified as a BVH (2026-08-15)
+
+`PROSPER_DYNTRACE_FAIL_ADDR=205b654a00`. The shader is a **full-screen ray-tracing pass**:
+
+```
+launch groups=240x135x1 threads=1920x1080x1 local=8x8x1 user_sgprs=8
+pre-specialization raw const-fold recovered 72 descriptor use(s)
+```
+
+**Not one of the 72 is a `BVH(bvh4)`.** The dynfail dump distinguishes three kinds — `TEX/IMG(t8)`,
+`BUF(v4)` and `BVH(bvh4)` — and this shader, which executes `image_bvh_intersect_ray` at pc1180,
+recovers zero BVH descriptors. Two of its uses are unresolved with a **valid base and zero extent**:
+
+```
+BUF(v4) key=0xffffffff use_pc=1032 v4=a1f76200:00000020:00000000:00000000
+        base=0x20a1f76200 stride=0 records=0 size=0 required=28
+BUF(v4) key=0xffffffff use_pc=1266 v4=a1f76400:00000020:00000000:00000000
+        base=0x20a1f76400 stride=0 records=0 size=0 required=124
+```
+
+`required=28` is notable: prosper's own BVH emulation loads exactly **28 dwords** per node
+(`for (uint32_t k = 0; k < 28; ++k) w[k] = load_node(k);`).
+
+**Reading, `CONFIDENCE: MED`.** These are BVH descriptors being classified and decoded as buffer V#s.
+A GFX10 BVH descriptor has its own 4-dword layout — `decode_bvh_descriptor` in
+`agc_shader_layout.hpp` reads `type`, `box_grow`, `triangle_return_mode`, `box_node_64b`,
+`sort_enabled` from it — and interpreting one as a buffer V# yields `num_records = 0`, hence
+`size = 0`, hence an unbounded use, hence `unresolved-operand`. That fits every observation, but the
+alternative (the guest genuinely supplies a zero-extent descriptor at this point in the route) is not
+excluded, and a `key=0xffffffff` means neither fetch pc, SRT offset nor SGPR base matched — which has
+its own possible causes.
+
+**The check that would settle it** is whether decoding those two 4-dword words with
+`decode_bvh_descriptor` instead of `decode_buffer_descriptor` yields a plausible BVH: a base above
+`0x10000`, a sane `size_bytes`, and a `type` in range. That is an offline computation on four dwords
+and needs no run.
+
 ## `0x209cc76000` is a SHARED POOL with 23 writers, not a dedicated record array (2026-08-15)
 
 Watching the **whole** 132,032-byte range (`PROSPER_COMPUTE_TREE_WATCH=0x209cc76000:33008`) rather

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,51 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The contract reads a BVH NODE-REFERENCE array as a selector array (2026-08-15)
+
+The selector histogram, taken from the same source records the contract's own domain proof walks:
+
+```
+[gta-selected-sbuffer]  selectors distinct=2064 (selector:count) 4:1 5:1 6:1 7:1 8:1 9:1 10:1 ...
+[gta-selected-sbuffer]  record-4 selector would be 4; outer has 5 records of 120 bytes
+```
+
+**All 2,064 source records have a DIFFERENT selector, and they run 4, 5, 6, 7, 8, … — i.e.
+`selector = index + 4`.**
+
+That is not a selector. **It is the BVH node-reference encoding**, the same one `0x413dc3400` decodes
+at pc618–619 with `v_lshrrev_b32 v36, 3, v69` followed by `v_add_nc_u32 v36, -4, v36` —
+`index = (ref >> 3) - 4`. The source array at pc70 (stride 8, 2,064 records) is an array of **node
+references**, and `first >> 3` recovers `index + 4`, exactly as observed.
+
+**So `selected_sbuffer_domain`'s proof passes for an accidental reason.** It admits a record when
+`selector * 120` is either exactly 480 (record 4) or wholly out of bounds. With `selector = index+4`:
+index 0 gives selector 4 → offset 480 → "record 4"; indices 1..2063 give selectors 5..2067 → offsets
+600..248,040, every one past the 600-byte buffer → "wholly OOB". **Both arms are satisfied by an
+array that is not a selector array at all.** The proof is not wrong about the arithmetic; it is
+answering a question about the wrong data.
+
+The contract then reads 16 bytes at `480 + 8` of a 600-byte buffer that holds float data, gets a
+non-descriptor, and declines — correctly, at the last possible moment, having been misled four steps
+earlier.
+
+**This is the complete account of `0x413ce6000`'s reject**, and it is a contract defect rather than a
+missing lowering, a stale buffer, or a wrong selector value:
+
+1. the source array at pc70 holds BVH node references, not table selectors;
+2. `selected_sbuffer_domain` reads `first >> 3` as a selector and its two admissible arms are both
+   satisfied by that data for arithmetic reasons;
+3. the contract therefore reads record 4 of the outer buffer;
+4. the outer buffer holds float data in this scene (unit-normal plane equations, measured);
+5. `selected_sbuffer_target_descriptor` rejects it;
+6. no `selected_sbuffer_soffset` authority is published, so the descriptor for
+   `buffer_load_dwordx3` at pc156 never resolves;
+7. `mode=unresolved-operand pc=156`, and the program is declined.
+
+**`CONFIDENCE: HIGH`** on steps 1–5, all measured. **`CONFIDENCE: MED`** on 6–7 being the only
+remaining link, since the recompiler's descriptor matching has three routes and only the contract one
+has been traced.
+
 ## The `selected_sbuffer` contract is over-fitted: the "descriptor array" holds FRUSTUM PLANES (2026-08-15)
 
 Dumping **all five** records of the outer array on decline, rather than only the one the contract

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,55 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## FOUND: the CYCLES ARE IN THE INPUT — the node records' own child graph (2026-08-15)
+
+Two results, and together they close the question.
+
+### 1. The clear hypothesis is FALSIFIED, with the lever verified
+
+`PROSPER_COMPUTE_ZERO_BEFORE=0x413dc3400:0x20f848417c:2063` zeroes the parent array immediately
+before every builder dispatch. The clear demonstrably fires. **The later submits are still cyclic** —
+`cycles=63..101`, and now with `oob-roots=0`. So the cycles are **not** stale leftovers in the output
+array; the builder writes them into a freshly zeroed one.
+
+### 2. The cycles are in the builder's INPUT
+
+Building the child graph directly from the node records — for each node, its two child references
+decoded as `index = (ref >> 3) - 4` when the tag is in `{2,5}` — and testing that graph for cycles:
+
+```
+s11238 d15,d16,d19..d27   child-graph cycles = 0
+s11238 d37                child-graph cycles = 70     <- appears here
+s11637 d15,d16 ...        child-graph cycles = 70     (carried into the next submit)
+s11637 d37                child-graph cycles = 110
+s12036 ...                child-graph cycles = 110
+s13220 d37                child-graph cycles = 117
+... every later submit    child-graph cycles = 117
+```
+
+**The node records at `0x209cc76000` describe a cyclic child graph, and `0x413dc3400` faithfully
+reproduces it as a cyclic parent table.** Everything below about the builder now has its explanation:
+its lowering is correct, its output tracks its input, and its input is a cyclic graph.
+
+**The cycles appear between dispatch 27 and dispatch 37 of a submit, and they ACCUMULATE**
+(70 → 110 → 117), which is the signature of a structure being partially updated rather than rebuilt.
+The programs running in that window are `0x413ce3400` at d30 and **`0x413ce6000` at d36 — the bulk
+writer of the record array, and the one whose descriptor at pc156 does not resolve.**
+
+**So `0x413ce6000` is back at the centre of this, for a different reason than before.** The earlier
+falsification stands and was correct: its *absence* is not the cause, since 29 submits with it fully
+executing still went cyclic. The cause is its **output**. A program that is sometimes declined and,
+when it does run, has an unresolved descriptor is exactly a program that can write a partially-correct
+node array.
+
+### The next measurement, and it is one run
+
+Attribute the cycle appearance to a dispatch the same way the parent table's was: watch
+`0x209cc76000` with the tree watch's **pre/post** attribution and the child-graph cycle count as the
+metric, rather than the parent-walk metric which is meaningless on a node array. The instrument
+exists; only the analysis differs. That names the writer conclusively instead of by elimination
+between d30 and d36.
+
 ## THE HYPOTHESIS THIS ALL POINTS AT: the parent array is never cleared
 
 If the builder legitimately links only `{2, 5}` children, then **the slots it does not write must

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,45 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## FIRST DRAW-LEVEL VIEW OF A GTA V FRAME — and the captured submits are nearly EMPTY (2026-08-15)
+
+The frame grab now works on this title. Three changes were needed, each opt-in so no existing
+contract moves:
+
+| switch | what it addresses |
+| --- | --- |
+| `PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1` | five packed/indirect-pointer provenance validators that abort the whole bundle; reported per acceptance as inspection-only |
+| `PROSPER_CAPTURE_WAIT_FOR_SUBMITS=1` | keeps the window open past empty presents (bounded at 240), because a present COUNT is not a unit of time on a burst-flipping title |
+| `PROSPER_CAPTURE_MAX_SUBMITS=N` | bounds the bundle by CONTENT — one GTA V burst appended 3.3 GB and blew even the 3,072 MB maximum, so no byte budget could capture it |
+
+Result: **`frame-bundle written (25 submits)`, 512 MB**, loading as
+`bundle v2 submits=25 logical=2002872578 unique=511842881 ratio=0.256 chunks=3773 resources=454`.
+
+### What the frame contains
+
+```
+[gpureplay] bundle-submit=19370 operations=0/0 output_bytes=0
+[gpureplay] bundle-submit=19371 operations=0/0 output_bytes=0
+[gpureplay] bundle-submit=19372 operations=0/0 output_bytes=0
+[gpureplay] bundle-submit=19373 operations=0/0 output_bytes=0
+[gpureplay] bundle-submit=19374 operations=1/1 output_bytes=1048576
+```
+
+**Four consecutive captured submits contain ZERO operations, and the fifth contains one.** At this
+point in the route the guest's submits carry almost no GPU work at all — which is consistent with
+the absent world, and is the first evidence about it that comes from the frame rather than from log
+statistics.
+
+**Read with care, `CONFIDENCE: MED`.** Three things are not established: whether `operations=0/0`
+means the guest submitted nothing or the capture recorded nothing; whether the 25-submit window
+landed on a representative part of the frame (it is bounded by `MAX_SUBMITS`, so it is the *first* 25
+of a burst); and whether the world's work lives in submits outside it. Replay stops at bundle submit
+5 with `indirect-pointer relocation has stale shader, launch, source, or proof state` — expected,
+since the capture was forced past provenance, and it means the later submits were not reconstructed.
+
+**The next step is to widen the cap and see where operations begin**, which is now a matter of one
+setting rather than an unusable tool.
+
 ## The F9 frame grab cannot be used on this title — diagnosed and filed (#2549)
 
 The charter names the F9 grab the fastest loop for a graphical bug, and GTA V — a GPU-driven title

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -399,6 +399,36 @@ contract.
 The change is kept on its own merits — it is a documented over-conservatism corrected with ISA
 backing and it costs nothing — not because it was shown to help.
 
+## The BVH descriptor's unresolved word is `s18`, and it depends on VCC_LO (2026-08-15)
+
+Watching each register of the descriptor `s[16:19]` in `0x205b654a00`, one run each:
+
+| register | state before pc1180 | site |
+| --- | --- | --- |
+| `s16` | **KNOWN** at pc1163 | |
+| `s17` | **KNOWN** at pc1176 | |
+| `s18` | **FORGOTTEN** at pc1169 | `words=80126ac1` = `s_add_u32 s18, -1, vcc_lo` |
+| `s19` | KNOWN `0x81000000` on some dispatches | `s_or_b32 s19, s106, 0x81000000` |
+
+**`s18` is the word that fails, and it is `-1 + VCC_LO`.**
+
+So the ray-tracing pass's BVH descriptor cannot resolve because **two of its four words are computed
+from VCC_LO** — `s18` at pc1169 and `s19` at pc1177 — and prosper does not track a value into VCC_LO
+on this path. That is the same obstacle as `0x413ce6000`'s selector and the same one the execz
+liveness guard was about, now demonstrated by direct measurement on the exact register rather than
+inferred from the ISA.
+
+**This is the sharpest statement of the frontier available:** GTA V's compiler uses VCC_LO as a
+general-purpose scalar register, and prosper's descriptor const-fold loses values through it. Two
+programs — the ray-tracing pass and the BVH producer — are declined for exactly this, and between
+them they are the ray-tracing path.
+
+What is *not* established: **where** s106's value is lost in `0x205b654a00`. The register watch will
+say — `PROSPER_DYNTRACE_SGPR=106` filtered to `program=0x205b654a00`, exactly as was done for
+`0x413ce6000` — and that is the next measurement. In `0x413ce6000` the answer was
+`s_andn1_saveexec_b64`, i.e. a genuine lane mask that no fold can resolve; if the same holds here,
+the fix is a contract rather than a fold, and if it does not, it is a fold gap with a named opcode.
+
 ## SCC over-invalidation fixed — and it is NOT what gates the BVH descriptor (2026-08-15)
 
 `PROSPER_DYNTRACE_SCC=1` (added here) reports every transition of the fold's tracked SCC with the pc

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -1829,6 +1829,50 @@ table is a **missing program**, not a miscompiled one, and the fix is to make it
 charter's rule that an unsupported program is a fatal gap rather than an acceptable skip, these are
 the next thing to implement regardless of how this particular question resolves.
 
+## Fourth review round on #2550, all four fixed (2026-08-15)
+
+**1 (blocker) — a depth-feedback split still discarded MRT2–7 when persistence was unavailable.**
+Carrying the SHAPE through every segment was necessary and not sufficient. When the caller names no
+persistent identities — every path running with live GPU targets disabled: captures, per-target
+diagnostics, replay export, the recovery switch — the later segment gets a fresh transient
+attachment, and LOADing an image that was just created loads nothing. The earlier segment's pixels
+reach it only by being read back and **seeded** in, which is exactly what slots 0 and 1 already do
+through `seed_rgba`/`seed_rgba1`.
+
+Added `seed_slots[]`, the per-slot twin, with the upload path mirroring slot 1's. The splitter reads
+back any non-persistent higher slot it must carry and hands the pixels to the next segment.
+`split_segment_contract()` synthesises a carrier target when the caller gave none, since the seed
+flags have nowhere else to live — behaviourally identical to no target (every identity is zero) apart
+from the carry.
+
+**The regression is a real Vulkan one, and it reproduced the defect before the fix.** Segment 1 writes
+depth and RED to MRT2; the consumer samples that depth, which forces the physical split; the final
+segment never touches MRT2; `color_target` is null. Before the carry, the final MRT2 read
+`(0,0,0)` — after it, `(255,0,0)`. The test also asserts `depth_feedback_split_index() == 1`, so it
+cannot pass by failing to split.
+
+**2 (high) — same-pass feedback materialization kept MRT0-only gates.** The direct-path precheck and
+the uniform fast path still compared against `draw.color0_base`. For an MRT2+ collision the precheck
+said "direct serves", which suppressed the lazy CPU materialisation, and the corrected gate then
+refused the direct image — leaving the resource to fall through to guest bytes with no snapshot to
+use. All three sites (including the diagnostic classification) now use the all-slot rule.
+
+**3 (medium) — the feedback helper was a second, looser copy of "active".** It fell back to the named
+slot-0/1 mask whenever the array mask read zero and never required a defined format, where pass
+grouping falls back only when the array representation is ABSENT and requires base + format + mask.
+Extracted as `frontends/shared/mrt_binding.hpp`, used by both, and tested from a real `DrawItem`.
+
+**4 (low) — `test_mrt_extent` printed `OK` before the new checks ran.** Third instance in this branch
+of a success signal placed ahead of the work it describes.
+
+### Four rounds, one recurring mistake
+
+Rounds two, three and four each contained at least one finding of the form *a check that cannot
+fail*, and three of those were mine in the same shape: **new assertions appended at the end of a
+file, landing after the success print or the fail gate.** The cause is mechanical — inserting before
+the final `return` — and the fix is mechanical too: put new checks with the checks, and read what is
+between them and the exit.
+
 ## Third review round on #2550, all four fixed (2026-08-15)
 
 Every one a legacy "only MRT0/1 exist" seam that the widening newly reached.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -515,6 +515,44 @@ Two things must be checked before treating this as a defect, and neither has bee
 Recorded as an observation with its caveats rather than a lead, so the next reader neither chases it
 blind nor loses it.
 
+## THE DRAWS ARE HAPPENING: 131,072 executed, 0 indirect, 0 undecoded packets (2026-08-15)
+
+The most basic number about a missing world had never been measured. `PROSPER_DRAW_CENSUS=1` (added
+here, counted before the `render` early-out so it reports what the command stream contained):
+
+```
+[draw-census] draws=1024   indirect=0 submit=190
+[draw-census] draws=16384  indirect=0 submit=4248
+[draw-census] draws=131072 indirect=0 submit=13933
+```
+
+**Over 131,000 draws execute, and not one of them is indirect.**
+
+Three things follow, each independently verified:
+
+1. **The indirect dependency latch drops nothing.** A counter at the drop site (also added here —
+   the drop was silent unless a capture trace happened to be active) reports **zero** across a full
+   routed run that reached gameplay, with the instrument confirmed present in the binary and the
+   route confirmed by 44 builder transitions and 9,580 frames. **This retires the premise this
+   document opens with** for the current state: "every later indirect draw short-circuits untried"
+   is not what is happening.
+2. **prosper decodes every packet the title sends.** `pm4_registers.hpp` defines
+   `IT_DRAW_INDIRECT_MULTI = 0x2C` and `IT_DRAW_INDEX_INDIRECT_MULTI = 0x38`, and **neither is
+   referenced anywhere** — the decoder handles only `R_DRAW_INDEX_INDIRECT = 0x22`. That looked like
+   the answer for a GPU-driven title. It is not: the decoder logs each distinct undecoded type-3
+   opcode once, and **no `[pm4] unknown raw type-3 opcode` line appears in any run**. GTA V emits
+   neither MULTI variant. *(The two constants being defined and unused is still worth knowing — a
+   title that does use them would be silently mis-decoded — but it is not this title's defect.)*
+3. **So the world's geometry is somewhere in those 131,072 direct draws, and they execute.**
+
+**That relocates the question entirely.** It is no longer "why are the draws not issued" — they are
+issued and executed. It is **"why does the output of 131,072 executed draws not reach the screen"**.
+
+The strongest remaining candidate is the one already recorded and never quantified: **three 4K
+DCC-compressed sampled images are unsupported**, and when the fast-clear decode fails the renderer
+falls through to reading compressed bytes as uncompressed. A composite that samples the scene through
+those cannot produce a world image no matter how many draws filled them.
+
 ## What is NOT hiding the world — four eliminations, each with a verified lever (2026-08-15)
 
 Every one of these was measured on a routed run with the lever confirmed to have moved, so each is a

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6454,10 +6454,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         ? RenderClock::now() : RenderClock::time_point{};
                     prosper::test::BackendMrtOutputs mrt_outputs;
                     mrt_outputs.color_count = mrt_count;
+                    // The colour target is passed whenever ANY slot is bound, not colour-0 alone.
+                    // The same union the readback flag below already uses, and for the same reason
+                    // the comment there gives: a pass with colour-0 unbound and a higher slot bound
+                    // is reachable by construction. On `base != 0` alone such a pass populated
+                    // persistent_id_slots[2..7] and then handed the backend a nullptr, so those
+                    // active slots stayed transient and were cleared by the next group -- exactly
+                    // the defect the persistence contract exists to remove, reintroduced at the one
+                    // call site that decides whether the contract is used at all.
+                    const bool any_slot_bound = std::any_of(
+                        pass_bases.begin(),
+                        pass_bases.begin() + std::min<size_t>(mrt_count, pass_bases.size()),
+                        [](uint64_t slot_base) { return slot_base != 0; });
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
                         backend_draws, gw, gh, seed,
                         retained_uniform_clear ? retained_uniform_clear : clear_for(render_pass), true,
-                        live_gpu_targets && base ? &backend_target : nullptr,
+                        live_gpu_targets && any_slot_bound ? &backend_target : nullptr,
                         seed1, retained_uniform_clear1 ? retained_uniform_clear1
                             : (use_color1 ? render_pass.front()->ps.clear_color1 : nullptr),
                         nullptr,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -6441,6 +6441,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     backend_target.load_existing1 = seed_rtt;
                     backend_target.readback1 = !defer_readback1;
                     backend_target.format1 = pass_format1;
+                    // Slots 2..7 retain across render groups on the same terms as slots 0 and 1.
+                    // A G-buffer built by several groups against one set of allocations otherwise
+                    // loses every group's work but the last, because slots above 1 were transient
+                    // images cleared per backend call.
+                    for (uint32_t slot = 2; slot < mrt_count; ++slot) {
+                        backend_target.persistent_id_slots[slot] = pass_bases[slot];
+                        backend_target.load_existing_slots[slot] = seed_rtt;
+                    }
                     auto backend_draws = build_bds(render_pass);
                     const auto build_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
@@ -6623,7 +6631,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.format = pass_formats[slot];
                         surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
-                        surface.gpu_valid = slot == 1 &&
+                        // Any slot with a retained target is GPU-valid, not only slot 1. The
+                        // `slot == 1` clause dated from when slots above 1 had no persistent image
+                        // to be valid about.
+                        surface.gpu_valid =
                             prosper::test::find_persistent_color_target(
                                 pass_bases[slot], gw, gh, pass_formats[slot]) != nullptr;
                         if (!pixels.empty())

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2736,9 +2736,32 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             ((reflected_binding->image_dim == 1u && r.img_dim == 1u) ||
                              (reflected_binding->image_dim == 2u && r.img_dim == 2u &&
                               r.depth != 0u));
+                        // A storage-image contract failure does not skip one binding -- the backend
+                        // returns an EMPTY batch, dropping every draw submitted with it
+                        // (render_runner.h, `return out;` in the pre-Vulkan validation loop). So
+                        // "which sub-condition failed" is the difference between one unusable
+                        // resource and a whole frame's geometry going missing, and the existing line
+                        // reports only `materialized=0`, which is the conjunction.
                         if (portable_raw_uvec4_storage &&
-                            (!portable_storage_guest_texel || !portable_storage_shape))
+                            (!portable_storage_guest_texel || !portable_storage_shape)) {
+                            static std::set<std::tuple<uint32_t, uint32_t, uint32_t>> reported;
+                            if (reported.emplace(fr.set, fr.binding,
+                                                 static_cast<uint32_t>(r.format)).second)
+                                std::fprintf(stderr,
+                                    "[render] storage-image contract: set=%u binding=%u "
+                                    "portable-uvec4 REJECTED guest-texel=%u shape=%u "
+                                    "(writable=%u compressed=%u arrayed=%u multisampled=%u "
+                                    "reflected-dim=%u guest-dim=%u depth=%u fmt=%u comps=%u)\n",
+                                    fr.set, fr.binding, portable_storage_guest_texel,
+                                    portable_storage_shape ? 1u : 0u,
+                                    writable_storage_image ? 1u : 0u,
+                                    r.compression_enabled ? 1u : 0u,
+                                    reflected_binding->image_arrayed ? 1u : 0u,
+                                    reflected_binding->image_multisampled ? 1u : 0u,
+                                    reflected_binding->image_dim, r.img_dim, r.depth,
+                                    static_cast<unsigned>(r.format), r.num_components);
                             fr.storage_image_contract_valid = false;
+                        }
                         if (fr.is_storage_image &&
                             reflected_binding->image_numeric_class ==
                                 prosper::gpu::SpirvImageNumericClass::Uint &&

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -162,6 +162,33 @@ void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
         pending.overflowed = true;
 }
 
+// Does this draw bind `addr` as ANY active colour target?
+//
+// The direct-live sampling decision excluded `draw.color0_base` alone. That was complete only while
+// slots above 1 could not be persistent; they can now, so sampling an ACTIVE MRT2+ target would
+// otherwise borrow the very image the draw is writing -- one VkImage used as shader-read and colour
+// attachment at once, bypassing the CPU fallback that exists for exactly this case.
+//
+// "Active" matches the pass-grouping definition: a bound base whose write mask is non-zero. Slots 0
+// and 1 keep their named-field fallbacks, since a draw may carry either form.
+bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr) {
+    uint64_t bases[prosper::gpu::kColorTargetCount]{};
+    bool active[prosper::gpu::kColorTargetCount]{};
+    for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
+        const auto& target = draw.ps.color_targets[slot];
+        uint32_t write_mask = target.write_mask;
+        if (slot == 0 && !write_mask) write_mask = draw.ps.color_write_mask;
+        if (slot == 1 && !write_mask) write_mask = draw.ps.color1_write_mask;
+        uint64_t base = draw.color_targets[slot].base;
+        if (!base && slot == 0) base = draw.color0_base;
+        if (!base && slot == 1) base = draw.color1_base;
+        bases[slot] = base;
+        active[slot] = write_mask != 0u;
+    }
+    return prosper::frontend::mrt_target_feedback(
+        bases, active, prosper::gpu::kColorTargetCount, addr);
+}
+
 void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
     for (auto it = cache.begin(); it != cache.end();) {
@@ -2531,7 +2558,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
                                 normalized_sampling) &&
-                            sampled_source_addr != draw.color0_base &&
+                            !draw_binds_color_target(draw, sampled_source_addr) &&
                             prosper::test::find_persistent_color_target(
                                 sampled_source_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
@@ -6462,10 +6489,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // active slots stayed transient and were cleared by the next group -- exactly
                     // the defect the persistence contract exists to remove, reintroduced at the one
                     // call site that decides whether the contract is used at all.
-                    const bool any_slot_bound = std::any_of(
-                        pass_bases.begin(),
-                        pass_bases.begin() + std::min<size_t>(mrt_count, pass_bases.size()),
-                        [](uint64_t slot_base) { return slot_base != 0; });
+                    const bool any_slot_bound = prosper::frontend::mrt_any_slot_bound(
+                        pass_bases.data(),
+                        static_cast<uint32_t>(std::min<size_t>(mrt_count, pass_bases.size())));
                     std::vector<uint8_t> gpx = prosper::test::render_draws_rgba(
                         backend_draws, gw, gh, seed,
                         retained_uniform_clear ? retained_uniform_clear : clear_for(render_pass), true,
@@ -6495,10 +6521,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // Keyed on the base rather than the draws' colour write masks for the
                         // separate reason that 457/457 is evidence about THIS route, and a future
                         // title could legally mix a colour-writing draw into a pass that has a base.
-                        /*want_color_readback=*/std::any_of(
-                            pass_bases.begin(),
-                            pass_bases.begin() + std::min<size_t>(mrt_count, pass_bases.size()),
-                            [](uint64_t slot_base) { return slot_base != 0; }));
+                        /*want_color_readback=*/any_slot_bound);
                     const auto backend_done = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     const prosper::test::BackendColorTargetStats color_target_call =

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3738,11 +3738,25 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     }
                                 } // malformed/incomplete RTT bytes => miss; decode guest backing below
                             }
+                            // Report HOW the binding resolved, not merely whether the COLOUR cache
+                            // had it. This line used to print "miss" for a resource the depth or
+                            // stencil bridge had already resolved, because `rtt_hit` speaks only for
+                            // g_rtt -- so a correctly-bridged 4K depth buffer and a texture decoded
+                            // from guest zeros were the same word. Reading a pass's inputs off this
+                            // log therefore over-counted missing inputs, which is the one thing the
+                            // log exists to answer.
                             if (rtt_log)
-                                fprintf(stderr, "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s (cache_size=%zu)\n",
+                                fprintf(stderr,
+                                        "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s "
+                                        "(cache_size=%zu)\n",
                                         (unsigned long long)sampled_source_addr, tw, th,
                                         (unsigned)r.format,
-                                        rtt_hit ? "HIT" : "miss", g_rtt.size());
+                                        rtt_hit ? "HIT"
+                                            : has_ds_live
+                                                ? (sampled_ds.aspect == VK_IMAGE_ASPECT_STENCIL_BIT
+                                                       ? "DS-STENCIL" : "DS-DEPTH")
+                                                : "miss",
+                                        g_rtt.size());
                         }
                         // CUBE texture (#273 — DOLL's title reflection probes / skybox): decode six
                         // independent thin-2D faces into the stacked w x 6h image addressed by the
@@ -6389,6 +6403,54 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         backend_call_timing, color_target_call};
                     if (lightweight_rtt_timing) pending_rtt_timing.push_back(rtt_timing_record);
                     else if (timing_enabled && rtt_log) print_rtt_timing(rtt_timing_record);
+                    // PROSPER_DUMP_PASS=0xADDR[,0xADDR…] — write what a pass actually produced, as an
+                    // image, for the named targets. `rgb_nonblack` alone cannot answer "is the world
+                    // there": it is computed from an RGBA8 conversion, so an HDR f16 target whose
+                    // values are all below 1/255 reports EXACTLY ZERO while carrying a complete
+                    // scene. That is not hypothetical here — GTA V's 0x20431c0000 reports
+                    // rgb_nonblack=0 while the very next pass extracts 47.5% non-black from it, so
+                    // reading the metric as "black" is a false negative on the whole lighting stage.
+                    //
+                    // Overwrites one file per target so the last write is the latest frame, and
+                    // dumps every PROSPER_DUMP_PASS_EVERY-th occurrence (default 60) because a 4K
+                    // BMP is 24 MB and a routed boot renders each of these a few hundred times.
+                    {
+                        static const std::string dump_spec =
+                            PROSPER_ENV_VALUE("PROSPER_DUMP_PASS")
+                                ? PROSPER_ENV_VALUE("PROSPER_DUMP_PASS") : "";
+                        if (!dump_spec.empty() && base) {
+                            char needle[24];
+                            std::snprintf(needle, sizeof needle, "0x%llx",
+                                          (unsigned long long)base);
+                            if (dump_spec.find(needle) != std::string::npos) {
+                                static const int every = PROSPER_ENV_VALUE("PROSPER_DUMP_PASS_EVERY")
+                                    ? std::max(1, atoi(getenv("PROSPER_DUMP_PASS_EVERY"))) : 60;
+                                static std::map<uint64_t, int> counted;
+                                if (counted[base]++ % every == 0) {
+                                    const std::vector<uint8_t> shot = inspection_rgba8(
+                                        rendered_pixels, gw, gh, pass_format);
+                                    const char* dir = getenv("PROSPER_FRAME_DIR");
+                                    char path[512];
+                                    std::snprintf(path, sizeof path, "%s/pass_%llx_%ux%u.bmp",
+                                                  dir ? dir : ".", (unsigned long long)base,
+                                                  gw, gh);
+                                    // Report the source size, not just the intent. A pass whose
+                                    // readback was deferred has EMPTY cpu pixels, and both this dump
+                                    // and `rgb_nonblack` are then reporting on nothing — which reads
+                                    // as "the target is black" rather than "we never looked".
+                                    const size_t want = size_t(gw) * gh * 4;
+                                    const bool ok = shot.size() == want &&
+                                        prosper::test::dump_bmp(path, shot, gw, gh);
+                                    fprintf(stderr,
+                                            "[dump-pass] target=0x%llx %ux%u src=%zuB rgba=%zuB/%zuB"
+                                            " -> %s\n",
+                                            (unsigned long long)base, gw, gh,
+                                            rendered_pixels.size(), shot.size(), want,
+                                            ok ? path : "NO CPU PIXELS (readback deferred)");
+                                }
+                            }
+                        }
+                    }
                     if (rtt_log) {
                         const std::vector<uint8_t> inspected = inspection_rgba8(
                             rendered_pixels, gw, gh, pass_format);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3784,7 +3784,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         "(cache_size=%zu)\n",
                                         (unsigned long long)sampled_source_addr, tw, th,
                                         (unsigned)r.format,
-                                        rtt_hit ? "HIT"
+                                        // Which hit path, not merely that one hit. A UNIFORM-colour
+                                        // surface samples as one flat value everywhere, so a shader
+                                        // reading it produces correct geometry with no texture
+                                        // detail at all -- visually a smooth gradient inside a
+                                        // correct mask. That is indistinguishable from a real hit
+                                        // in a log that prints one word for all three paths, and it
+                                        // is exactly what GTA V's lighting output looks like.
+                                        has_uniform_live_rtt ? "HIT-UNIFORM"
+                                            : rtt_hit ? (has_gpu_live_rtt ? "HIT-GPU" : "HIT-CPU")
                                             : has_ds_live
                                                 ? (sampled_ds.aspect == VK_IMAGE_ASPECT_STENCIL_BIT
                                                        ? "DS-STENCIL" : "DS-DEPTH")
@@ -5636,6 +5644,73 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     if (timing_enabled) ++pending_timing.pass_groups_seen;
                     const uint64_t base = items[pass_i].color0_base;
                     const uint32_t requested_color_count = active_color_count(items[pass_i]);
+                    // PROSPER_MRT_CENSUS=1 — per slot, why an attachment did or did not become
+                    // active. A slot needs all three of base, a known format, and a non-zero write
+                    // mask; if any is absent the attachment is dropped silently and the draws that
+                    // wrote it produce nothing. On GTA V only c1 is ever published, while an exact
+                    // draw census shows 122,028 of 131,072 draws binding a colour target at SLOT 4 --
+                    // so one of these three is missing for that slot and nothing said which.
+                    if (PROSPER_ENV_ON("PROSPER_MRT_CENSUS")) {
+                        struct SlotCensus {
+                            std::atomic<uint64_t> seen{0}, has_base{0}, has_format{0},
+                                has_mask{0}, active{0};
+                        };
+                        static std::array<SlotCensus, prosper::gpu::kColorTargetCount> census;
+                        static std::atomic<uint64_t> groups{0};
+                        const auto& d = items[pass_i];
+                        for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
+                            auto& c = census[slot];
+                            c.seen.fetch_add(1, std::memory_order_relaxed);
+                            if (color_binding(d, slot).base)
+                                c.has_base.fetch_add(1, std::memory_order_relaxed);
+                            if (active_format(d, slot) != VK_FORMAT_UNDEFINED)
+                                c.has_format.fetch_add(1, std::memory_order_relaxed);
+                            if (d.ps.color_targets[slot].write_mask ||
+                                (slot == 0 && d.ps.color_write_mask) ||
+                                (slot == 1 && d.ps.color1_write_mask))
+                                c.has_mask.fetch_add(1, std::memory_order_relaxed);
+                            if (active_color(d, slot))
+                                c.active.fetch_add(1, std::memory_order_relaxed);
+                        }
+                        // WHICH of the two masks is narrow. The write mask is
+                        // cb_target_mask & cb_shader_mask, and both default to 0xffffffff when the
+                        // register was never seen -- so a zero nibble means a register really was
+                        // programmed narrow, and the fix differs completely depending on which.
+                        // Histogrammed only over groups where slot 4 HAS a base, i.e. exactly the
+                        // population where the dropped attachment matters.
+                        if (color_binding(d, 4).base) {
+                            static std::mutex mask_mutex;
+                            static std::map<std::pair<uint32_t, uint32_t>, uint64_t> masks;
+                            std::lock_guard lock(mask_mutex);
+                            if (masks.size() < 64)
+                                ++masks[{d.ps.cb_target_mask, d.ps.cb_shader_mask}];
+                            static uint64_t reported = 0;
+                            if (++reported % 4096 == 0) {
+                                fprintf(stderr, "[mrt-census] masks where c4 has a base:\n");
+                                for (const auto& e : masks)
+                                    fprintf(stderr,
+                                            "[mrt-census]   cb_target_mask=0x%08x "
+                                            "cb_shader_mask=0x%08x -> effective=0x%08x  x%llu\n",
+                                            e.first.first, e.first.second,
+                                            e.first.first & e.first.second,
+                                            (unsigned long long)e.second);
+                            }
+                        }
+                        const uint64_t g = groups.fetch_add(1) + 1;
+                        if ((g & (g - 1)) == 0 && g >= 4096) {
+                            fprintf(stderr, "[mrt-census] pass groups=%llu\n",
+                                    (unsigned long long)g);
+                            for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot)
+                                fprintf(stderr,
+                                        "[mrt-census]   c%u base=%llu format=%llu mask=%llu "
+                                        "ACTIVE=%llu\n",
+                                        slot,
+                                        (unsigned long long)census[slot].has_base.load(),
+                                        (unsigned long long)census[slot].has_format.load(),
+                                        (unsigned long long)census[slot].has_mask.load(),
+                                        (unsigned long long)census[slot].active.load());
+                        }
+                    }
                     std::array<uint64_t, prosper::gpu::kColorTargetCount> pass_bases{};
                     std::array<VkFormat, prosper::gpu::kColorTargetCount> pass_formats{};
                     for (uint32_t slot = 0; slot < requested_color_count; ++slot) {
@@ -6306,6 +6381,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         pending_timing.color_target_cached_bytes = color_target_call.cached_bytes;
                         pending_timing.color_target_cached_entries = color_target_call.cached_entries;
                     }
+                    static const std::string dump_spec =
+                        PROSPER_ENV_VALUE("PROSPER_DUMP_PASS")
+                            ? PROSPER_ENV_VALUE("PROSPER_DUMP_PASS") : "";
+                    static const int dump_pass_every =
+                        PROSPER_ENV_VALUE("PROSPER_DUMP_PASS_EVERY")
+                            ? std::max(1, atoi(getenv("PROSPER_DUMP_PASS_EVERY"))) : 60;
                     auto pass_pixels = std::make_shared<const std::vector<uint8_t>>(std::move(gpx));
                     if (base && color_target_call.writes) {
                         RttSurf& surface = g_rtt[base];
@@ -6368,6 +6449,36 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     "px_nonzero=%zu rgb_nonblack=%zu\n",
                                     slot, (unsigned long long)pass_bases[slot],
                                     gw, gh, pass.size(), nz, rgb_nz);
+                        }
+                        // PROSPER_DUMP_PASS covers slots 1..7 too. The first version dumped only
+                        // `base`, so the busiest target in GTA V's frame -- 0x2085de0000, written by
+                        // 130,290 of 131,072 draws, 96% of them in SLOT 4 -- could not be dumped at
+                        // all, and its absence read as "that pass does not run".
+                        if (!dump_spec.empty() && pass_bases[slot]) {
+                            char needle[24];
+                            std::snprintf(needle, sizeof needle, "0x%llx",
+                                          (unsigned long long)pass_bases[slot]);
+                            if (dump_spec.find(needle) != std::string::npos) {
+                                static std::map<uint64_t, int> slot_counted;
+                                if (slot_counted[pass_bases[slot]]++ % dump_pass_every == 0) {
+                                    const std::vector<uint8_t> shot = inspection_rgba8(
+                                        pixels, gw, gh, pass_formats[slot]);
+                                    const char* dir = getenv("PROSPER_FRAME_DIR");
+                                    char path[512];
+                                    std::snprintf(path, sizeof path, "%s/pass_%llx_s%u_%ux%u.bmp",
+                                                  dir ? dir : ".",
+                                                  (unsigned long long)pass_bases[slot], slot,
+                                                  gw, gh);
+                                    const size_t want = size_t(gw) * gh * 4;
+                                    const bool ok = shot.size() == want &&
+                                        prosper::test::dump_bmp(path, shot, gw, gh);
+                                    fprintf(stderr,
+                                            "[dump-pass] target=0x%llx slot=%u %ux%u src=%zuB -> %s\n",
+                                            (unsigned long long)pass_bases[slot], slot, gw, gh,
+                                            pixels.size(),
+                                            ok ? path : "NO CPU PIXELS (readback deferred)");
+                                }
+                            }
                         }
                         RttSurf& surface = g_rtt[pass_bases[slot]];
                         surface.w = gw;
@@ -6500,18 +6611,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // dumps every PROSPER_DUMP_PASS_EVERY-th occurrence (default 60) because a 4K
                     // BMP is 24 MB and a routed boot renders each of these a few hundred times.
                     {
-                        static const std::string dump_spec =
-                            PROSPER_ENV_VALUE("PROSPER_DUMP_PASS")
-                                ? PROSPER_ENV_VALUE("PROSPER_DUMP_PASS") : "";
                         if (!dump_spec.empty() && base) {
                             char needle[24];
                             std::snprintf(needle, sizeof needle, "0x%llx",
                                           (unsigned long long)base);
                             if (dump_spec.find(needle) != std::string::npos) {
-                                static const int every = PROSPER_ENV_VALUE("PROSPER_DUMP_PASS_EVERY")
-                                    ? std::max(1, atoi(getenv("PROSPER_DUMP_PASS_EVERY"))) : 60;
                                 static std::map<uint64_t, int> counted;
-                                if (counted[base]++ % every == 0) {
+                                if (counted[base]++ % dump_pass_every == 0) {
                                     const std::vector<uint8_t> shot = inspection_rgba8(
                                         rendered_pixels, gw, gh, pass_format);
                                     const char* dir = getenv("PROSPER_FRAME_DIR");

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -5,7 +5,8 @@
 #include "rtt_authority.hpp"
 #include "rtt_injection.hpp"
 #include "rtt_scale.hpp"
-#include "mrt_extent.hpp"               // which MRT slot may join a pass (measured extents only)
+#include "mrt_extent.hpp"
+#include "mrt_binding.hpp"               // which MRT slot may join a pass (measured extents only)
 #include "readback_policy.hpp"
 #include "capture_renderer_policy.hpp"
 #include "write_watch_policy.hpp"
@@ -171,22 +172,14 @@ void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
 //
 // "Active" matches the pass-grouping definition: a bound base whose write mask is non-zero. Slots 0
 // and 1 keep their named-field fallbacks, since a draw may carry either form.
+// The backend's notion of a defined colour format, supplied to the shared policy so that header
+// stays backend-free. One mapping, used by grouping and feedback alike.
+bool mrt_format_defined(uint32_t raw) {
+    return prosper::test::backend_color_format(static_cast<VkFormat>(raw)) != VK_FORMAT_UNDEFINED;
+}
+
 bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr) {
-    uint64_t bases[prosper::gpu::kColorTargetCount]{};
-    bool active[prosper::gpu::kColorTargetCount]{};
-    for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
-        const auto& target = draw.ps.color_targets[slot];
-        uint32_t write_mask = target.write_mask;
-        if (slot == 0 && !write_mask) write_mask = draw.ps.color_write_mask;
-        if (slot == 1 && !write_mask) write_mask = draw.ps.color1_write_mask;
-        uint64_t base = draw.color_targets[slot].base;
-        if (!base && slot == 0) base = draw.color0_base;
-        if (!base && slot == 1) base = draw.color1_base;
-        bases[slot] = base;
-        active[slot] = write_mask != 0u;
-    }
-    return prosper::frontend::mrt_target_feedback(
-        bases, active, prosper::gpu::kColorTargetCount, addr);
+    return prosper::frontend::mrt_draw_binds_target(draw, addr, mrt_format_defined);
 }
 
 void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t size) {
@@ -2475,9 +2468,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 prosper::frontend::rtt_sampled_extent_compatible(
                                     tw, th, surface.w, surface.h, render_scale,
                                     normalized_sampling);
+                            // Must use the SAME all-slot rule as the gate it feeds. On colour-0
+                            // alone an MRT2+ feedback collision set direct_serves=true, which
+                            // suppressed the lazy CPU materialisation; the corrected gate below then
+                            // refused the direct image because the collision is real, and the
+                            // resource fell through to stale guest bytes with no snapshot to use.
                             const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
                                 sampled_extent_compatible &&
-                                sampled_source_addr != draw.color0_base &&
+                                !draw_binds_color_target(draw, sampled_source_addr) &&
                                 prosper::test::find_persistent_color_target(
                                     sampled_source_addr, surface.w, surface.h,
                                     surface.format) != nullptr;
@@ -2569,7 +2567,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             live_rtt->second.h &&
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
-                                normalized_sampling) && sampled_source_addr != draw.color0_base;
+                                normalized_sampling) &&
+                            !draw_binds_color_target(draw, sampled_source_addr);
                         const bool has_live_rtt =
                             has_cpu_live_rtt || has_gpu_live_rtt || has_uniform_live_rtt;
                         // A dim-5 base-slice view may need the CPU injection path rather than a direct
@@ -3540,7 +3539,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 else if (!live_rtt->second.gpu_valid) rtt_notvalid++;
                                 else if (live_rtt->second.w != tw || live_rtt->second.h != th)
                                     rtt_dimmismatch++;
-                                else if (sampled_source_addr == draw.color0_base) rtt_self++;
+                                else if (draw_binds_color_target(draw, sampled_source_addr))
+                                    rtt_self++;
                                 else if (prosper::test::find_persistent_color_target(
                                              sampled_source_addr, tw, th,
                                              live_rtt->second.format) == nullptr)
@@ -5665,41 +5665,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // the backbuffer, incremental HUD updates) composites OVER the earlier content instead
                 // of starting from the diagnostic clear. Real RT memory persists exactly this way.
                 static const bool seed_rtt = getenv("PROSPER_RTT_NOSEED") == nullptr;
+                // Pass grouping and same-pass feedback detection must not disagree about what an
+                // active binding is, so both go through frontends/shared/mrt_binding.hpp. These
+                // were duplicated lambdas; a second, looser copy in the feedback path classified
+                // stale named state as a live binding (#2550 review).
                 auto color_binding = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
-                    auto binding = draw.color_targets[slot];
-                    // DrawItem predates the complete array. Preserve direct callers and capture
-                    // versions through v33, whose first two attachments live in the named fields.
-                    if (!binding.base && !binding.width && !binding.height && slot == 0)
-                        binding = prosper::gpu::DrawItem::ColorTargetBinding{
-                            draw.color0_base, draw.color0_width, draw.color0_height};
-                    else if (!binding.base && !binding.width && !binding.height && slot == 1)
-                        binding = prosper::gpu::DrawItem::ColorTargetBinding{
-                            draw.color1_base, draw.color1_width, draw.color1_height};
-                    return binding;
+                    return prosper::frontend::mrt_color_binding(draw, slot);
                 };
                 auto active_format = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
-                    uint32_t raw = draw.ps.color_targets[slot].format;
-                    if (slot == 0 && !raw) raw = draw.ps.color0_format;
-                    if (slot == 1 && !raw) raw = draw.ps.color1_format;
                     return prosper::test::backend_color_format(static_cast<VkFormat>(
-                        raw));
+                        prosper::frontend::mrt_raw_format(draw, slot)));
                 };
-                auto active_color = [&](const prosper::gpu::DrawItem& draw, uint32_t slot) {
-                    const auto binding = color_binding(draw, slot);
-                    const auto& target = draw.ps.color_targets[slot];
-                    uint32_t write_mask = target.write_mask;
-                    if (slot == 0 && !target.format && !draw.color_targets[slot].base)
-                        write_mask = draw.ps.color_write_mask;
-                    else if (slot == 1 && !target.format && !draw.color_targets[slot].base)
-                        write_mask = draw.ps.color1_write_mask;
-                    return write_mask && active_format(draw, slot) != VK_FORMAT_UNDEFINED &&
-                           binding.base ? binding.base : uint64_t{0};
+                auto active_color = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
+                    return prosper::frontend::mrt_active_color(draw, slot, mrt_format_defined);
                 };
-                auto active_color_count = [&](const prosper::gpu::DrawItem& draw) {
-                    uint32_t count = 1;
-                    for (uint32_t slot = 1; slot < prosper::gpu::kColorTargetCount; ++slot)
-                        if (active_color(draw, slot)) count = slot + 1;
-                    return count;
+                auto active_color_count = [](const prosper::gpu::DrawItem& draw) {
+                    return prosper::frontend::mrt_active_color_count(draw, mrt_format_defined);
                 };
                 size_t pass_i = 0;
                 prosper::test::BackendSubmissionBatch backend_submission;

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2473,12 +2473,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // suppressed the lazy CPU materialisation; the corrected gate below then
                             // refused the direct image because the collision is real, and the
                             // resource fell through to stale guest bytes with no snapshot to use.
-                            const bool direct_serves = !fr.is_storage_image && r.img_dim == 1u &&
-                                sampled_extent_compatible &&
-                                !draw_binds_color_target(draw, sampled_source_addr) &&
+                            const bool direct_serves = prosper::frontend::mrt_direct_serves(
+                                draw, sampled_source_addr, fr.is_storage_image, r.img_dim,
+                                sampled_extent_compatible,
                                 prosper::test::find_persistent_color_target(
                                     sampled_source_addr, surface.w, surface.h,
-                                    surface.format) != nullptr;
+                                    surface.format) != nullptr,
+                                mrt_format_defined);
                             const VkFormat surface_format =
                                 prosper::test::backend_color_format(surface.format);
                             const uint32_t surface_bpp =
@@ -2560,15 +2561,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             prosper::test::find_persistent_color_target(
                                 sampled_source_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
-                        const bool has_uniform_live_rtt = !fr.is_storage_image &&
-                            !uniform_cpu_diagnostic_path && sampled_2d_view &&
-                            !r.in_mip_tail && live_rtt != g_rtt.end() &&
-                            live_rtt->second.has_uniform_color && live_rtt->second.w &&
-                            live_rtt->second.h &&
-                            prosper::frontend::rtt_sampled_extent_compatible(
-                                tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
-                                normalized_sampling) &&
-                            !draw_binds_color_target(draw, sampled_source_addr);
+                        const bool has_uniform_live_rtt = prosper::frontend::mrt_uniform_live_serves(
+                            draw, sampled_source_addr,
+                            /*preconditions=*/!fr.is_storage_image &&
+                                !uniform_cpu_diagnostic_path && sampled_2d_view &&
+                                !r.in_mip_tail && live_rtt != g_rtt.end() &&
+                                live_rtt->second.has_uniform_color && live_rtt->second.w &&
+                                live_rtt->second.h &&
+                                prosper::frontend::rtt_sampled_extent_compatible(
+                                    tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
+                                    normalized_sampling),
+                            mrt_format_defined);
                         const bool has_live_rtt =
                             has_cpu_live_rtt || has_gpu_live_rtt || has_uniform_live_rtt;
                         // A dim-5 base-slice view may need the CPU injection path rather than a direct

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2568,6 +2568,39 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 : prosper::test::PersistentDsSampled{};
                         const bool has_ds_live = sampled_ds.image != nullptr;
                         resource_has_ds_live = has_ds_live;
+                        // A binding rejected by the gate above never reaches the lookup, so it is
+                        // absent from every statistic the lookup keeps -- it reads as "we hold no
+                        // such surface" when we may hold it and be perfectly valid. Name the
+                        // failing sub-condition, once per (address, reason).
+                        if (PROSPER_ENV_ON("PROSPER_DSBRIDGE_LOG") && !has_ds_live) {
+                            uint32_t held_w = 0, held_h = 0;
+                            if (!(!has_live_rtt && !fr.is_storage_image && r.img_dim == 1u &&
+                                  r.cls == RC::Texture) &&
+                                prosper::test::is_retained_ds_plane(r.gpu_addr, &held_w, &held_h)) {
+                                static std::mutex gate_mutex;
+                                static std::set<std::pair<uint64_t, int>> reported;
+                                const int reason = has_live_rtt ? 0
+                                    : fr.is_storage_image ? 1
+                                    : r.img_dim != 1u ? 2 : 3;
+                                bool first = false;
+                                {
+                                    std::lock_guard lock(gate_mutex);
+                                    first = reported.emplace(r.gpu_addr, reason).second;
+                                }
+                                if (first)
+                                    fprintf(stderr,
+                                            "[dsbridge] GATED addr=0x%llx T#=%ux%ux%u dim=%u "
+                                            "cls=%u fmt=%u (retained DS %ux%u) never reached the "
+                                            "lookup: %s\n",
+                                            (unsigned long long)r.gpu_addr, tw, th, r.depth,
+                                            r.img_dim, (unsigned)r.cls, (unsigned)r.format,
+                                            held_w, held_h,
+                                            reason == 0 ? "has_live_rtt (colour cache claims it)"
+                                            : reason == 1 ? "is_storage_image"
+                                            : reason == 2 ? "img_dim != 1 (not a plain 2D view)"
+                                                          : "cls != Texture");
+                            }
+                        }
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
                         const uint32_t persistent_pitch = PROSPER_ENV_VALUE("PROSPER_PITCH")
@@ -3806,6 +3839,58 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             (unsigned long long)metadata_bytes,
                                             metadata_got ? metadata[0] : 0u);
                             }
+                        }
+                        // PROSPER_DS_UNBRIDGED_FAR=1 — DIAGNOSTIC ONLY, never a shipped default.
+                        //
+                        // A depth surface prosper rendered into a retained DS image but could not
+                        // bridge decodes from guest memory the renderer never wrote, i.e. zeros. For
+                        // a shadow map zero is the NEAR plane, so every shadow test reads "occluded"
+                        // and the lighting pass outputs black over a perfectly good G-buffer. Filling
+                        // with far instead flips that to "unoccluded", which is equally wrong as
+                        // output but is a decisive discriminator: if the scene lights up, the
+                        // unbridged depth surface is the cause; if it does not, the hypothesis is
+                        // dead and no cube-assembly work is justified. It detects its own invalidity
+                        // in both directions, and it reports whether it fired at all.
+                        //
+                        // TWO POLES, and which one means "unoccluded" is not knowable a priori: a
+                        // reversed-Z depth buffer stores near at 1.0, so filling 0xff is the SAME
+                        // claim as the zeros it was meant to contradict. The experiment is only
+                        // decisive if both poles are run, so the fill byte is a parameter
+                        // (PROSPER_DS_UNBRIDGED_FILL, default 0xff) rather than a constant.
+                        //
+                        // Restricted to cubes by PROSPER_DS_UNBRIDGED_FAR=cube. The first run filled
+                        // every unbridged retained DS plane including the main 4K depth, which is
+                        // depth-tested against by the HUD -- the radar vanished, so the arm measured
+                        // the confound as much as the subject.
+                        static const std::string far_mode =
+                            PROSPER_ENV_VALUE("PROSPER_DS_UNBRIDGED_FAR")
+                                ? PROSPER_ENV_VALUE("PROSPER_DS_UNBRIDGED_FAR") : "";
+                        static const uint8_t far_fill = PROSPER_ENV_VALUE("PROSPER_DS_UNBRIDGED_FILL")
+                            ? static_cast<uint8_t>(strtoul(
+                                  getenv("PROSPER_DS_UNBRIDGED_FILL"), nullptr, 0))
+                            : 0xffu;
+                        if (!rtt_hit && !has_ds_live && !fr.is_storage_image &&
+                            !far_mode.empty() && far_mode != "0" &&
+                            (far_mode != "cube" || r.img_dim == 3u) &&
+                            prosper::test::is_retained_ds_plane(r.gpu_addr)) {
+                            std::fill(texture_pixels.begin(), texture_pixels.end(), far_fill);
+                            static std::mutex far_mutex;
+                            static std::set<uint64_t> far_seen;
+                            static std::atomic<uint64_t> far_count{0};
+                            const uint64_t n = far_count.fetch_add(1) + 1;
+                            bool first = false;
+                            {
+                                std::lock_guard lock(far_mutex);
+                                first = far_seen.insert(r.gpu_addr).second;
+                            }
+                            if (first)
+                                fprintf(stderr,
+                                        "[ds-far] addr=0x%llx %ux%ux%u dim=%u filled 0x%02x "
+                                        "(unbridged retained DS plane; total=%llu)\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, r.depth, r.img_dim,
+                                        (unsigned)far_fill, (unsigned long long)n);
+                            rtt_hit = true;   // do not overwrite it with a guest-byte decode below
+                            resource_rtt_hit = true;
                         }
                         bool cube_done = dcc_fast_clear_done && is_cube;
                         if (is_cube && !rtt_hit && !dcc_fast_clear_done) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -3778,6 +3778,54 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // from guest zeros were the same word. Reading a pass's inputs off this
                             // log therefore over-counted missing inputs, which is the one thing the
                             // log exists to answer.
+                            // PROSPER_RTT_GUESTPEEK=1 — for each distinct sampled surface, how
+                            // much of the GUEST backing is non-zero, next to how prosper resolved
+                            // it. This separates two states that every other signal renders
+                            // identically: a surface nothing ever wrote (guest bytes zero, cache
+                            // zero) from one the guest DID write through a path prosper did not
+                            // observe (guest bytes populated, cache zero) -- the second is a
+                            // prosper defect and the first is not, and they call for opposite work.
+                            // Read the guest VA directly rather than r.host_data: on this path
+                            // host_data is null for every sampled texture (measured: zero peeks in a
+                            // full routed run), so keying on it produced complete silence -- which
+                            // reads as "the guest backing is empty" and is instead "we never
+                            // looked". Guest code runs natively here, so a readability-checked VA is
+                            // the authoritative view of that memory.
+                            if (rtt_log && PROSPER_ENV_ON("PROSPER_RTT_GUESTPEEK") &&
+                                sampled_source_addr &&
+                                prosper::gpu::guest_readable(sampled_source_addr, 4096)) {
+                                static std::mutex peek_mutex;
+                                static std::set<uint64_t> peeked;
+                                bool first = false;
+                                {
+                                    std::lock_guard lock(peek_mutex);
+                                    first = peeked.insert(sampled_source_addr).second;
+                                }
+                                if (first) {
+                                    size_t window = std::min<size_t>(
+                                        prosper::gpu::gpu_capture_resource_footprint(r),
+                                        size_t(1) << 20);
+                                    while (window &&
+                                           !prosper::gpu::guest_readable(
+                                               sampled_source_addr,
+                                               static_cast<uint32_t>(window)))
+                                        window /= 2;
+                                    size_t nz = 0;
+                                    const uint8_t* bytes = reinterpret_cast<const uint8_t*>(
+                                        static_cast<uintptr_t>(sampled_source_addr));
+                                    for (size_t i = 0; i < window; ++i) nz += bytes[i] != 0;
+                                    fprintf(stderr,
+                                            "[rtt-guestpeek] addr=0x%llx %ux%u fmt=%u guest "
+                                            "non-zero=%zu/%zu bytes (%.1f%%) resolved=%s\n",
+                                            (unsigned long long)sampled_source_addr, tw, th,
+                                            (unsigned)r.format, nz, window,
+                                            window ? 100.0 * nz / window : 0.0,
+                                            has_uniform_live_rtt ? "HIT-UNIFORM"
+                                                : rtt_hit ? (has_gpu_live_rtt ? "HIT-GPU"
+                                                                              : "HIT-CPU")
+                                                : has_ds_live ? "DS" : "miss");
+                                }
+                            }
                             if (rtt_log)
                                 fprintf(stderr,
                                         "[rtt] sample tex addr=0x%llx %ux%u fmt=%u -> %s "
@@ -5669,6 +5717,39 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 (slot == 0 && d.ps.color_write_mask) ||
                                 (slot == 1 && d.ps.color1_write_mask))
                                 c.has_mask.fetch_add(1, std::memory_order_relaxed);
+                            // The per-slot mask the DrawItem CARRIES, against the one its own two
+                            // mask registers IMPLY. render_state.cpp computes the first as
+                            // (cb_target_mask & cb_shader_mask) >> (slot*4) & 0xf, so a disagreement
+                            // means the per-slot array did not survive the path that built this
+                            // DrawItem -- and the array is what decides whether the attachment
+                            // exists at all.
+                            {
+                                const uint32_t implied =
+                                    ((d.ps.cb_target_mask & d.ps.cb_shader_mask) >> (slot * 4u))
+                                    & 0xfu;
+                                const uint32_t carried = d.ps.color_targets[slot].write_mask;
+                                if (implied != carried && color_binding(d, slot).base) {
+                                    static std::mutex disagree_mutex;
+                                    static std::map<std::tuple<uint32_t, uint32_t, uint32_t>,
+                                                    uint64_t> disagree;
+                                    std::lock_guard lock(disagree_mutex);
+                                    if (disagree.size() < 48)
+                                        ++disagree[{slot, implied, carried}];
+                                    static uint64_t n = 0;
+                                    if (++n % 8192 == 0) {
+                                        fprintf(stderr,
+                                                "[mrt-mask-disagree] per-slot write_mask carried by "
+                                                "the DrawItem vs implied by its own registers:\n");
+                                        for (const auto& e : disagree)
+                                            fprintf(stderr,
+                                                    "[mrt-mask-disagree]   c%u implied=0x%x "
+                                                    "carried=0x%x  x%llu\n",
+                                                    std::get<0>(e.first), std::get<1>(e.first),
+                                                    std::get<2>(e.first),
+                                                    (unsigned long long)e.second);
+                                    }
+                                }
+                            }
                             if (active_color(d, slot))
                                 c.active.fetch_add(1, std::memory_order_relaxed);
                         }
@@ -5695,6 +5776,62 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             e.first.first & e.first.second,
                                             (unsigned long long)e.second);
                             }
+                        }
+                        // The SHAPE of each distinct pass: its eight slot bases next to the two
+                        // mask registers. The aggregate above says how often a slot activates; it
+                        // cannot say which surfaces a given pass meant to write, which is what
+                        // "buffer X is sampled 23 times and never written" actually needs.
+                        {
+                            static std::mutex shape_mutex;
+                            static std::map<std::array<uint64_t, 10>, uint64_t> shapes;
+                            std::array<uint64_t, 10> shape{};
+                            for (uint32_t slot = 0; slot < 8u; ++slot)
+                                shape[slot] = color_binding(d, slot).base;
+                            shape[8] = d.ps.cb_target_mask;
+                            shape[9] = d.ps.cb_shader_mask;
+                            // PROSPER_MRT_SHAPE_FOR=0xADDR[,...] restricts recording to passes
+                            // whose slot-0 base is named. Without it the map fills with startup and
+                            // scanout passes long before the gameplay G-buffer pass appears, and an
+                            // unfiltered top-10 is then a list of the most FREQUENT shapes rather
+                            // than the ones being asked about.
+                            static const std::string shape_for =
+                                PROSPER_ENV_VALUE("PROSPER_MRT_SHAPE_FOR")
+                                    ? PROSPER_ENV_VALUE("PROSPER_MRT_SHAPE_FOR") : "";
+                            bool shape_wanted = shape_for.empty();
+                            if (!shape_wanted && shape[0]) {
+                                char needle[24];
+                                std::snprintf(needle, sizeof needle, "0x%llx",
+                                              (unsigned long long)shape[0]);
+                                shape_wanted = shape_for.find(needle) != std::string::npos;
+                            }
+                            if (!shape_wanted) goto shape_done;
+                            {
+                            std::lock_guard lock(shape_mutex);
+                            if (shapes.size() < 96 || shapes.count(shape)) ++shapes[shape];
+                            static uint64_t shape_reports = 0;
+                            if (++shape_reports % (shape_for.empty() ? 8192 : 256) == 0) {
+                                std::vector<std::pair<uint64_t, std::array<uint64_t, 10>>> ranked;
+                                for (const auto& e : shapes) ranked.push_back({e.second, e.first});
+                                std::sort(ranked.begin(), ranked.end(),
+                                          [](const auto& a, const auto& b) {
+                                              return a.first > b.first; });
+                                fprintf(stderr, "[mrt-shape] %zu distinct pass shapes\n",
+                                        shapes.size());
+                                for (size_t i = 0; i < ranked.size() && i < 10; ++i) {
+                                    fprintf(stderr, "[mrt-shape]   x%-6llu tmask=0x%08llx "
+                                            "smask=0x%08llx bases:",
+                                            (unsigned long long)ranked[i].first,
+                                            (unsigned long long)ranked[i].second[8],
+                                            (unsigned long long)ranked[i].second[9]);
+                                    for (uint32_t slot = 0; slot < 8u; ++slot)
+                                        if (ranked[i].second[slot])
+                                            fprintf(stderr, " c%u=0x%llx", slot,
+                                                    (unsigned long long)ranked[i].second[slot]);
+                                    fprintf(stderr, "\n");
+                                }
+                            }
+                            }
+                            shape_done: ;
                         }
                         const uint64_t g = groups.fetch_add(1) + 1;
                         if ((g & (g - 1)) == 0 && g >= 4096) {

--- a/prosper/frontends/shared/mrt_binding.hpp
+++ b/prosper/frontends/shared/mrt_binding.hpp
@@ -1,0 +1,91 @@
+#pragma once
+#include <cstdint>
+
+#include "../../src/gpu/gpu_execute.hpp"
+#include "../../src/gpu/render_state.hpp"
+#include "mrt_extent.hpp"
+
+// THE definition of an active colour binding.
+//
+// Two things ask it and they must not disagree: pass grouping, which decides how many attachments a
+// render pass has and which surfaces they are, and same-pass feedback detection, which decides
+// whether a sampled surface is one this pass is writing. A second, looser copy of this rule
+// classified stale named state as a live binding, which denies the authoritative direct-GPU path and
+// — when no CPU snapshot exists — degrades to guest bytes rather than to a slower correct source.
+//
+// The rule: a slot is active when it has a base, a defined format, and a non-zero write mask. The
+// named `color0_*` / `color1_*` fields are consulted ONLY when the array representation is absent,
+// because `DrawItem` predates the complete array and capture versions through v33 carry the first
+// two attachments in those fields. Falling back whenever the array mask merely reads zero is a
+// different and wrong rule: a genuinely masked-off slot then inherits a stale named mask.
+namespace prosper::frontend {
+
+inline prosper::gpu::DrawItem::ColorTargetBinding mrt_color_binding(
+    const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    auto binding = draw.color_targets[slot];
+    if (!binding.base && !binding.width && !binding.height && slot == 0)
+        binding = prosper::gpu::DrawItem::ColorTargetBinding{
+            draw.color0_base, draw.color0_width, draw.color0_height};
+    else if (!binding.base && !binding.width && !binding.height && slot == 1)
+        binding = prosper::gpu::DrawItem::ColorTargetBinding{
+            draw.color1_base, draw.color1_width, draw.color1_height};
+    return binding;
+}
+
+// Raw guest format for a slot, with the same named-field fallback. Left as the raw value so callers
+// that need a backend VkFormat can map it themselves without this header depending on the backend.
+inline uint32_t mrt_raw_format(const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    uint32_t raw = draw.ps.color_targets[slot].format;
+    if (slot == 0 && !raw) raw = draw.ps.color0_format;
+    if (slot == 1 && !raw) raw = draw.ps.color1_format;
+    return raw;
+}
+
+// The write mask that governs this slot, with the named fallback taken only when the array
+// representation is ABSENT -- matching pass grouping exactly.
+inline uint32_t mrt_write_mask(const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    const auto& target = draw.ps.color_targets[slot];
+    if (slot == 0 && !target.format && !draw.color_targets[slot].base)
+        return draw.ps.color_write_mask;
+    if (slot == 1 && !target.format && !draw.color_targets[slot].base)
+        return draw.ps.color1_write_mask;
+    return target.write_mask;
+}
+
+// The base this slot is actively writing, or 0. `format_defined` decides whether a raw guest format
+// counts as defined; callers pass their own mapping so this header stays backend-free.
+template <typename FormatDefined>
+uint64_t mrt_active_color(const prosper::gpu::DrawItem& draw, uint32_t slot,
+                          FormatDefined format_defined) {
+    const auto binding = mrt_color_binding(draw, slot);
+    if (!binding.base) return 0;
+    if (!mrt_write_mask(draw, slot)) return 0;
+    if (!format_defined(mrt_raw_format(draw, slot))) return 0;
+    return binding.base;
+}
+
+// The active attachment prefix: one past the highest active slot, never less than 1.
+template <typename FormatDefined>
+uint32_t mrt_active_color_count(const prosper::gpu::DrawItem& draw, FormatDefined format_defined) {
+    uint32_t count = 1;
+    for (uint32_t slot = 1; slot < prosper::gpu::kColorTargetCount; ++slot)
+        if (mrt_active_color(draw, slot, format_defined)) count = slot + 1;
+    return count;
+}
+
+// Does this draw bind `addr` as any ACTIVE colour target? The feedback question, answered through
+// the same rule pass grouping uses rather than a second interpretation of it.
+template <typename FormatDefined>
+bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
+                           FormatDefined format_defined) {
+    if (!addr) return false;
+    uint64_t bases[prosper::gpu::kColorTargetCount]{};
+    bool active[prosper::gpu::kColorTargetCount]{};
+    for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
+        bases[slot] = mrt_active_color(draw, slot, format_defined);
+        active[slot] = bases[slot] != 0u;
+    }
+    return mrt_target_feedback(bases, active, prosper::gpu::kColorTargetCount, addr);
+}
+
+}  // namespace prosper::frontend

--- a/prosper/frontends/shared/mrt_binding.hpp
+++ b/prosper/frontends/shared/mrt_binding.hpp
@@ -13,7 +13,12 @@
 // classified stale named state as a live binding, which denies the authoritative direct-GPU path and
 // — when no CPU snapshot exists — degrades to guest bytes rather than to a slower correct source.
 //
-// The rule: a slot is active when it has a base, a defined format, and a non-zero write mask. The
+// The rule: a slot is active when it has a base, a non-zero write mask, and a format the backend
+// accepts. That last term is TOTAL in the current backend -- `backend_color_format` maps every
+// unrecognised value, zero included, onto R8G8B8A8_UNORM, so it never rejects anything and a zero
+// format means "use the fallback" rather than "undefined". It is kept as a parameter because it is
+// the backend's decision to make, not this header's, and a backend that ever narrows it must narrow
+// grouping and feedback together. The
 // named `color0_*` / `color1_*` fields are consulted ONLY when the array representation is absent,
 // because `DrawItem` predates the complete array and capture versions through v33 carry the first
 // two attachments in those fields. Falling back whenever the array mask merely reads zero is a
@@ -53,7 +58,9 @@ inline uint32_t mrt_write_mask(const prosper::gpu::DrawItem& draw, uint32_t slot
 }
 
 // The base this slot is actively writing, or 0. `format_defined` decides whether a raw guest format
-// counts as defined; callers pass their own mapping so this header stays backend-free.
+// counts as accepted; callers pass their own mapping so this header stays backend-free. Note it is
+// total in today's backend -- see the file comment; do not read this parameter as evidence that a
+// zero format is rejected anywhere.
 template <typename FormatDefined>
 uint64_t mrt_active_color(const prosper::gpu::DrawItem& draw, uint32_t slot,
                           FormatDefined format_defined) {
@@ -86,6 +93,36 @@ bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
         active[slot] = bases[slot] != 0u;
     }
     return mrt_target_feedback(bases, active, prosper::gpu::kColorTargetCount, addr);
+}
+
+// The two materialization decisions that key on feedback, as seams that OWN their gate.
+//
+// They exist because the gate is the interesting part and a helper called beside it is not: with the
+// comparison written inline at each call site, reverting one to `sampled != draw.color0_base` left
+// every test green, since the tests exercised the helper rather than the decision.
+//
+// The two are coupled, which is why they must agree. `mrt_direct_serves` deciding TRUE suppresses
+// the lazy CPU materialisation for that resource; if the later bind then refuses the direct image --
+// which it must, when the sample really is one of this pass's targets -- there is no snapshot left
+// and the resource degrades to guest bytes. So a feedback collision has to be seen by BOTH, and it
+// used to be seen by neither above slot 1.
+
+// May the retained GPU image serve this sample directly?
+template <typename FormatDefined>
+bool mrt_direct_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
+                       bool is_storage_image, uint32_t img_dim, bool extent_compatible,
+                       bool has_persistent_target, FormatDefined format_defined) {
+    return !is_storage_image && img_dim == 1u && extent_compatible && has_persistent_target &&
+           !mrt_draw_binds_target(draw, sampled, format_defined);
+}
+
+// May the uniform-colour fast path serve this sample? `preconditions` folds the caller's own
+// non-feedback terms (not a storage image, a plain 2D view, not in a mip tail, a uniform cache entry
+// with a usable extent) so this seam owns exactly the feedback gate and nothing it cannot see.
+template <typename FormatDefined>
+bool mrt_uniform_live_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
+                             bool preconditions, FormatDefined format_defined) {
+    return preconditions && !mrt_draw_binds_target(draw, sampled, format_defined);
 }
 
 }  // namespace prosper::frontend

--- a/prosper/frontends/shared/mrt_extent.hpp
+++ b/prosper/frontends/shared/mrt_extent.hpp
@@ -29,6 +29,43 @@ constexpr bool mrt_extent_known(uint32_t w, uint32_t h) {
     return w != 0u && h != 0u;
 }
 
+// Does this pass bind ANY colour slot within its active prefix?
+//
+// Two decisions in the live renderer key on this and both were once written as "is colour-0 bound":
+// whether to hand the backend a BackendColorTarget at all, and whether to ask for colour pixels
+// back. A pass with colour-0 unbound and a higher slot bound is reachable by construction --
+// `mrt_count` does not depend on colour-0 -- and on `base != 0` alone such a pass populated the
+// per-slot persistence contract and then handed the backend a nullptr, so those active slots stayed
+// transient and were cleared by the next render group. Depth-only passes have every slot zero, so
+// the "skip the work" win the readback flag was added for is unchanged.
+//
+// Takes a pointer and a count rather than a container so the production array and a test fixture
+// exercise the identical expression.
+constexpr bool mrt_any_slot_bound(const uint64_t* slot_bases, uint32_t count) {
+    if (!slot_bases) return false;
+    for (uint32_t slot = 0; slot < count; ++slot)
+        if (slot_bases[slot] != 0u) return true;
+    return false;
+}
+
+// Does a sampled surface collide with a colour target this pass is actively writing?
+//
+// `bases[i]` is slot i's bound base and `active[i]` whether that slot is really being written. Both
+// the backend's descriptor borrow and the frontend's direct-live sampling decision ask this, and
+// both once asked it of slots 0 and 1 only -- complete while higher slots could not be persistent,
+// and wrong the moment they could. Sampling an ACTIVE MRT2+ target then borrows the very VkImage the
+// pass is writing, using one image as shader-read and colour-attachment at once and bypassing the
+// CPU fallback that exists for exactly this case.
+//
+// An inactive slot does not collide: a stale base with a zero write mask is not a target.
+constexpr bool mrt_target_feedback(const uint64_t* bases, const bool* active, uint32_t count,
+                                   uint64_t sampled) {
+    if (!bases || !active || !sampled) return false;
+    for (uint32_t slot = 0; slot < count; ++slot)
+        if (active[slot] && bases[slot] == sampled) return true;
+    return false;
+}
+
 // True only when a bound slot's extent is KNOWN to disagree with the extent the pass renders at.
 // An unknown extent on either side yields false: absence of a measurement is not evidence of a
 // mismatch, and the fail-safe direction is to keep a real, actively-written attachment rather than

--- a/prosper/frontends/shared/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/test_mrt_binding.cpp
@@ -1,0 +1,108 @@
+// One active-colour-binding policy, exercised through a real DrawItem.
+//
+// Pass grouping and same-pass feedback detection must agree about what an active binding is. They
+// did not: the feedback path carried a second, looser copy that fell back to the named slot-0/1
+// write mask whenever the ARRAY mask read zero, and never required a defined format. That
+// classifies stale named state as a live binding, which denies the authoritative direct-GPU path --
+// and where no CPU snapshot exists, degrades to guest bytes rather than to a slower correct source.
+#include <cstdio>
+#include <cstdint>
+
+#include "mrt_binding.hpp"
+
+static int failures = 0;
+#define CHECK(cond) do { if (!(cond)) { \
+    std::printf("FAIL %s:%d: %s\n", __FILE__, __LINE__, #cond); ++failures; } } while (0)
+
+namespace {
+
+// The backend maps essentially every raw guest format onto a real VkFormat, with 0 the only
+// "undefined" value. Modelled directly so this test needs no backend.
+bool format_defined(uint32_t raw) { return raw != 0u; }
+
+prosper::gpu::DrawItem make_draw() {
+    prosper::gpu::DrawItem draw{};
+    return draw;
+}
+
+}  // namespace
+
+int main() {
+    using prosper::frontend::mrt_active_color;
+    using prosper::frontend::mrt_active_color_count;
+    using prosper::frontend::mrt_draw_binds_target;
+
+    constexpr uint64_t kMrt0 = 0x2050000000ull;
+    constexpr uint64_t kMrt2 = 0x2083e00000ull;
+
+    // A slot in the ARRAY representation is active with base + format + mask.
+    {
+        auto draw = make_draw();
+        draw.color_targets[2].base = kMrt2;
+        draw.ps.color_targets[2].format = 37u;
+        draw.ps.color_targets[2].write_mask = 0xfu;
+        CHECK(mrt_active_color(draw, 2, format_defined) == kMrt2);
+        CHECK(mrt_draw_binds_target(draw, kMrt2, format_defined));
+        CHECK(mrt_active_color_count(draw, format_defined) == 3u);
+        // The case the MRT0-only feedback rule missed entirely.
+        CHECK(!mrt_draw_binds_target(draw, 0x2099cc0000ull, format_defined));
+    }
+
+    // A base with a ZERO write mask is not a target. Stale bases are sticky in the guest's register
+    // file, so treating one as a binding both over-counts attachments and manufactures feedback.
+    {
+        auto draw = make_draw();
+        draw.color_targets[2].base = kMrt2;
+        draw.ps.color_targets[2].format = 37u;
+        draw.ps.color_targets[2].write_mask = 0u;
+        CHECK(mrt_active_color(draw, 2, format_defined) == 0u);
+        CHECK(!mrt_draw_binds_target(draw, kMrt2, format_defined));
+    }
+
+    // ...and neither is a base whose format was never seen.
+    {
+        auto draw = make_draw();
+        draw.color_targets[2].base = kMrt2;
+        draw.ps.color_targets[2].format = 0u;
+        draw.ps.color_targets[2].write_mask = 0xfu;
+        CHECK(mrt_active_color(draw, 2, format_defined) == 0u);
+        CHECK(!mrt_draw_binds_target(draw, kMrt2, format_defined));
+    }
+
+    // Legacy shape: DrawItem predates the complete array, and captures through v33 carry the first
+    // two attachments in the named fields. With the array ABSENT the named state is authoritative.
+    {
+        auto draw = make_draw();
+        draw.color0_base = kMrt0;
+        draw.ps.color0_format = 37u;
+        draw.ps.color_write_mask = 0xfu;
+        CHECK(mrt_active_color(draw, 0, format_defined) == kMrt0);
+        CHECK(mrt_draw_binds_target(draw, kMrt0, format_defined));
+    }
+
+    // THE defect this policy exists to prevent. The array representation IS present for slot 0 and
+    // says the slot is masked off, while stale named state still carries a non-zero mask. The looser
+    // rule fell back to the named mask whenever the array mask read zero and called this a binding.
+    {
+        auto draw = make_draw();
+        draw.color_targets[0].base = kMrt0;
+        draw.ps.color_targets[0].format = 37u;
+        draw.ps.color_targets[0].write_mask = 0u;   // the array says: masked off
+        draw.color0_base = kMrt0;
+        draw.ps.color0_format = 37u;
+        draw.ps.color_write_mask = 0xfu;            // stale named state says otherwise
+        CHECK(mrt_active_color(draw, 0, format_defined) == 0u);
+        CHECK(!mrt_draw_binds_target(draw, kMrt0, format_defined));
+    }
+
+    // A zero address never binds, and a draw with nothing bound binds nothing.
+    {
+        auto draw = make_draw();
+        CHECK(!mrt_draw_binds_target(draw, 0, format_defined));
+        CHECK(!mrt_draw_binds_target(draw, kMrt0, format_defined));
+        CHECK(mrt_active_color_count(draw, format_defined) == 1u);
+    }
+
+    if (failures == 0) std::printf("mrt_binding: OK\n");
+    return failures == 0 ? 0 : 1;
+}

--- a/prosper/frontends/shared/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/test_mrt_binding.cpp
@@ -16,9 +16,23 @@ static int failures = 0;
 
 namespace {
 
-// The backend maps essentially every raw guest format onto a real VkFormat, with 0 the only
-// "undefined" value. Modelled directly so this test needs no backend.
-bool format_defined(uint32_t raw) { return raw != 0u; }
+// Production's predicate is `backend_color_format(raw) != VK_FORMAT_UNDEFINED`, and
+// backend_color_format's default branch maps EVERY unrecognised value -- including zero -- to
+// R8G8B8A8_UNORM. So the production predicate is total: it returns true for every input, and the
+// format term in the active-binding rule never rejects anything.
+//
+// That is deliberate, not an oversight. Synthetic callers and legacy captures omit CB_COLOR_INFO and
+// rely on the backend's established RGBA8 fallback; requiring a decoded format would discard those
+// otherwise-valid draws (the same reasoning the executor's `color_effect` check records). A live
+// measurement agrees: PROSPER_MRT_CENSUS reported "format known" for every slot in all 16,384 pass
+// groups of a routed GTA V boot -- the column is constant because the predicate is.
+//
+// Modelled here as the constant it is. An earlier version of this test modelled `raw != 0` and
+// asserted a zero format made a slot inactive, which is a behaviour production does not have -- the
+// central policy test proving the opposite of the policy. `mrt_format_total_mapping` in
+// test_recompiled_fragment pins the backend mapping this constant depends on, so a change there
+// fails rather than silently invalidating this file.
+bool format_defined(uint32_t raw) { (void)raw; return true; }
 
 prosper::gpu::DrawItem make_draw() {
     prosper::gpu::DrawItem draw{};
@@ -59,14 +73,17 @@ int main() {
         CHECK(!mrt_draw_binds_target(draw, kMrt2, format_defined));
     }
 
-    // ...and neither is a base whose format was never seen.
+    // A base whose format was never seen IS still active: zero means "use the backend's RGBA8
+    // fallback", not "undefined". Asserted explicitly because the opposite reads as the safer
+    // expectation and is wrong -- rejecting it would drop attachments for every synthetic caller and
+    // every legacy capture that omits CB_COLOR_INFO.
     {
         auto draw = make_draw();
         draw.color_targets[2].base = kMrt2;
         draw.ps.color_targets[2].format = 0u;
         draw.ps.color_targets[2].write_mask = 0xfu;
-        CHECK(mrt_active_color(draw, 2, format_defined) == 0u);
-        CHECK(!mrt_draw_binds_target(draw, kMrt2, format_defined));
+        CHECK(mrt_active_color(draw, 2, format_defined) == kMrt2);
+        CHECK(mrt_draw_binds_target(draw, kMrt2, format_defined));
     }
 
     // Legacy shape: DrawItem predates the complete array, and captures through v33 carry the first
@@ -101,6 +118,55 @@ int main() {
         CHECK(!mrt_draw_binds_target(draw, 0, format_defined));
         CHECK(!mrt_draw_binds_target(draw, kMrt0, format_defined));
         CHECK(mrt_active_color_count(draw, format_defined) == 1u);
+    }
+
+    // The two materialization decisions, at the seams that own their gate. Written against the
+    // decisions rather than the helper because the previous round's tests called
+    // mrt_draw_binds_target() directly and stayed green when either production site was reverted to
+    // `sampled != draw.color0_base`.
+    {
+        using prosper::frontend::mrt_direct_serves;
+        using prosper::frontend::mrt_uniform_live_serves;
+
+        auto draw = make_draw();
+        draw.color_targets[2].base = kMrt2;
+        draw.ps.color_targets[2].format = 37u;
+        draw.ps.color_targets[2].write_mask = 0xfu;
+
+        // Sampling an unrelated surface: the direct image serves.
+        CHECK(mrt_direct_serves(draw, 0x2099cc0000ull, /*is_storage_image=*/false, /*img_dim=*/1u,
+                                /*extent_compatible=*/true, /*has_persistent_target=*/true,
+                                format_defined));
+        // Sampling THIS pass's MRT2: it must not, or the descriptor and the colour attachment
+        // become the same image.
+        CHECK(!mrt_direct_serves(draw, kMrt2, false, 1u, true, true, format_defined));
+        // The non-feedback preconditions still gate it.
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, /*is_storage_image=*/true, 1u, true, true,
+                                 format_defined));
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, /*img_dim=*/5u, true, true,
+                                 format_defined));
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, 1u, /*extent_compatible=*/false,
+                                 true, format_defined));
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, 1u, true,
+                                 /*has_persistent_target=*/false, format_defined));
+
+        // The uniform fast path carries the same gate. It and mrt_direct_serves must agree: if this
+        // one said yes on a collision the CPU materialisation would be skipped, and the direct bind
+        // would then be refused with no snapshot left to fall back to.
+        CHECK(mrt_uniform_live_serves(draw, 0x2099cc0000ull, /*preconditions=*/true,
+                                      format_defined));
+        CHECK(!mrt_uniform_live_serves(draw, kMrt2, true, format_defined));
+        CHECK(!mrt_uniform_live_serves(draw, 0x2099cc0000ull, /*preconditions=*/false,
+                                       format_defined));
+
+        // A slot that is bound but MASKED OFF is not a target, so sampling it is not feedback and
+        // the direct path must remain available -- denying it would push a live surface onto a
+        // slower path, or onto guest bytes when no snapshot exists.
+        auto masked = make_draw();
+        masked.color_targets[2].base = kMrt2;
+        masked.ps.color_targets[2].format = 37u;
+        masked.ps.color_targets[2].write_mask = 0u;
+        CHECK(mrt_direct_serves(masked, kMrt2, false, 1u, true, true, format_defined));
     }
 
     if (failures == 0) std::printf("mrt_binding: OK\n");

--- a/prosper/frontends/shared/test_mrt_extent.cpp
+++ b/prosper/frontends/shared/test_mrt_extent.cpp
@@ -95,7 +95,6 @@ int main() {
     static_assert(mrt_extent_conflicts(1024, 32, 1920, 1080), "measured disagreement still truncates");
     static_assert(!mrt_extent_known(0, 0), "0x0 is the not-measured sentinel");
 
-    if (failures == 0) std::printf("mrt_extent: OK\n");
         // #2550 review: the sparse-MRT gate. Two live-renderer decisions key on this -- whether the
     // backend receives a BackendColorTarget at all, and whether colour pixels are asked for -- and
     // both were once "is colour-0 bound". A pass with MRT0 unbound and MRT2 bound is reachable by
@@ -142,5 +141,10 @@ int main() {
         CHECK(!prosper::frontend::mrt_target_feedback(bases, nullptr, 8, 0x2050000000ull));
     }
 
+    // Printed LAST, after every check above has run. It sat before the checks added in the
+    // #2550 review rounds, so a new failure exited non-zero while still reporting OK --
+    // the third instance in this branch of a success signal placed ahead of the work it
+    // claims to describe.
+    if (failures == 0) std::printf("mrt_extent: OK\n");
     return failures == 0 ? 0 : 1;
 }

--- a/prosper/frontends/shared/test_mrt_extent.cpp
+++ b/prosper/frontends/shared/test_mrt_extent.cpp
@@ -96,5 +96,51 @@ int main() {
     static_assert(!mrt_extent_known(0, 0), "0x0 is the not-measured sentinel");
 
     if (failures == 0) std::printf("mrt_extent: OK\n");
+        // #2550 review: the sparse-MRT gate. Two live-renderer decisions key on this -- whether the
+    // backend receives a BackendColorTarget at all, and whether colour pixels are asked for -- and
+    // both were once "is colour-0 bound". A pass with MRT0 unbound and MRT2 bound is reachable by
+    // construction, and on colour-0 alone it populated the per-slot persistence contract and then
+    // handed the backend a nullptr, leaving those slots transient and cleared by the next group.
+    {
+        const uint64_t none[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+        const uint64_t mrt0_only[8] = {0x2050000000ull, 0, 0, 0, 0, 0, 0, 0};
+        const uint64_t mrt2_without_mrt0[8] = {0, 0, 0x2083e00000ull, 0, 0, 0, 0, 0};
+        // A depth-only pass binds no colour slot -- the "skip the work" case the readback flag
+        // exists for, which must stay skipped.
+        CHECK(!prosper::frontend::mrt_any_slot_bound(none, 8));
+        CHECK(prosper::frontend::mrt_any_slot_bound(mrt0_only, 8));
+        // The case colour-0-alone got wrong.
+        CHECK(prosper::frontend::mrt_any_slot_bound(mrt2_without_mrt0, 8));
+        // Only the ACTIVE prefix counts: a base outside mrt_count is a stale register, not a bound
+        // attachment.
+        CHECK(!prosper::frontend::mrt_any_slot_bound(mrt2_without_mrt0, 1));
+        CHECK(prosper::frontend::mrt_any_slot_bound(mrt2_without_mrt0, 3));
+        CHECK(!prosper::frontend::mrt_any_slot_bound(nullptr, 8));
+        CHECK(!prosper::frontend::mrt_any_slot_bound(mrt0_only, 0));
+    }
+
+    // #2550 review round 3: same-pass render-target feedback. Both the backend's descriptor borrow
+    // and the frontend's direct-live sampling decision ask "is this sampled surface one I am
+    // writing", and both once asked it of slots 0 and 1 only. Now that a higher slot's image is
+    // persistent and sampled-capable, missing it means one VkImage is bound as shader-read and
+    // colour-attachment at once, bypassing the CPU fallback that exists for exactly this case.
+    {
+        const uint64_t bases[8] = {0x2050000000ull, 0, 0x2083e00000ull, 0, 0, 0, 0, 0};
+        const bool all_active[8] = {true, true, true, true, true, true, true, true};
+        CHECK(prosper::frontend::mrt_target_feedback(bases, all_active, 8, 0x2050000000ull));
+        // The case slots-0-and-1-only got wrong.
+        CHECK(prosper::frontend::mrt_target_feedback(bases, all_active, 8, 0x2083e00000ull));
+        CHECK(!prosper::frontend::mrt_target_feedback(bases, all_active, 8, 0x2099cc0000ull));
+        // Only the active prefix, and only ACTIVE slots: a stale base with a zero write mask is not
+        // a target and must not suppress a legitimate direct-live borrow.
+        CHECK(!prosper::frontend::mrt_target_feedback(bases, all_active, 2, 0x2083e00000ull));
+        const bool slot2_inactive[8] = {true, true, false, true, true, true, true, true};
+        CHECK(!prosper::frontend::mrt_target_feedback(bases, slot2_inactive, 8, 0x2083e00000ull));
+        // A zero sampled id never collides, and neither do null tables.
+        CHECK(!prosper::frontend::mrt_target_feedback(bases, all_active, 8, 0));
+        CHECK(!prosper::frontend::mrt_target_feedback(nullptr, all_active, 8, 0x2050000000ull));
+        CHECK(!prosper::frontend::mrt_target_feedback(bases, nullptr, 8, 0x2050000000ull));
+    }
+
     return failures == 0 ? 0 : 1;
 }

--- a/prosper/src/gpu/compute_tree_watch.cpp
+++ b/prosper/src/gpu/compute_tree_watch.cpp
@@ -1,0 +1,132 @@
+#include "compute_tree_watch.hpp"
+
+#include <cstdlib>
+#include <string>
+
+namespace prosper::gpu {
+namespace {
+
+// Shared strict field parser: rejects an empty field, trailing garbage, and a value wider than the
+// field. Returning the end pointer lets the caller demand the exact separator it expects rather
+// than accepting any punctuation.
+bool parse_field(const char*& cursor, uint64_t& out, uint64_t limit) {
+    if (!cursor || !*cursor) return false;
+    char* end = nullptr;
+    const unsigned long long value = std::strtoull(cursor, &end, 0);
+    if (end == cursor) return false;
+    if (value > limit) return false;
+    out = value;
+    cursor = end;
+    return true;
+}
+
+bool expect_separator(const char*& cursor) {
+    if (!cursor || *cursor != ':') return false;
+    ++cursor;
+    return true;
+}
+
+} // namespace
+
+std::optional<ComputeTreeWatchSelector> parse_compute_tree_watch_selector(const char* value) {
+    if (!value) return std::nullopt;
+    const char* cursor = value;
+    ComputeTreeWatchSelector selector;
+
+    uint64_t addr = 0;
+    if (!parse_field(cursor, addr, UINT64_MAX)) return std::nullopt;
+    if (!addr) return std::nullopt;
+    if (!expect_separator(cursor)) return std::nullopt;
+
+    uint64_t records = 0;
+    // A dword count, and one large enough to allocate blindly per dispatch is a mistake worth
+    // refusing at parse time rather than discovering as a stall in a routed run.
+    constexpr uint64_t kMaximumRecords = 1u << 20u;
+    if (!parse_field(cursor, records, kMaximumRecords)) return std::nullopt;
+    if (!records) return std::nullopt;
+
+    selector.addr = addr;
+    selector.records = static_cast<uint32_t>(records);
+
+    if (!*cursor) return selector;
+
+    // Shift and mask are optional but arrive together: a shift without a mask would silently keep
+    // the default mask, which is a different walk from the one the caller asked for.
+    if (!expect_separator(cursor)) return std::nullopt;
+    uint64_t shift = 0;
+    if (!parse_field(cursor, shift, 31u)) return std::nullopt;
+    if (!expect_separator(cursor)) return std::nullopt;
+    uint64_t mask = 0;
+    if (!parse_field(cursor, mask, UINT32_MAX)) return std::nullopt;
+    if (!mask) return std::nullopt;
+    if (*cursor) return std::nullopt;
+
+    selector.index_shift = static_cast<uint32_t>(shift);
+    selector.index_mask = static_cast<uint32_t>(mask);
+    return selector;
+}
+
+std::vector<ComputeTreeWatchDelta> compute_tree_watch_deltas(
+        std::span<const uint32_t> before, std::span<const uint32_t> after, uint32_t limit,
+        uint32_t* total_changed) {
+    std::vector<ComputeTreeWatchDelta> deltas;
+    uint32_t changed = 0;
+    // Comparing only the overlap keeps a resized observation from reporting every trailing slot as
+    // a change; the caller sees the size difference in the record counts it already prints.
+    const size_t common = std::min(before.size(), after.size());
+    for (size_t i = 0; i < common; ++i) {
+        if (before[i] == after[i]) continue;
+        ++changed;
+        if (deltas.size() < limit)
+            deltas.push_back({static_cast<uint32_t>(i), before[i], after[i]});
+    }
+    if (total_changed) *total_changed = changed;
+    return deltas;
+}
+
+const char* compute_tree_watch_transition_name(ComputeTreeWatchTransition transition) {
+    switch (transition) {
+        case ComputeTreeWatchTransition::Unchanged: return "unchanged";
+        case ComputeTreeWatchTransition::CleanToClean: return "clean->clean";
+        case ComputeTreeWatchTransition::CleanToCyclic: return "clean->cyclic";
+        case ComputeTreeWatchTransition::CyclicToClean: return "cyclic->clean";
+        case ComputeTreeWatchTransition::CyclicToCyclic: return "cyclic->cyclic";
+    }
+    return "unknown";
+}
+
+ComputeTreeWatchTransition classify_compute_tree_watch_transition(
+        const ComputeParentWalkReport& before, const ComputeParentWalkReport& after,
+        bool bytes_changed) {
+    if (!bytes_changed) return ComputeTreeWatchTransition::Unchanged;
+    const bool before_cyclic = before.distinct_cycles != 0u;
+    const bool after_cyclic = after.distinct_cycles != 0u;
+    if (!before_cyclic && !after_cyclic) return ComputeTreeWatchTransition::CleanToClean;
+    if (!before_cyclic) return ComputeTreeWatchTransition::CleanToCyclic;
+    if (!after_cyclic) return ComputeTreeWatchTransition::CyclicToClean;
+    return ComputeTreeWatchTransition::CyclicToCyclic;
+}
+
+ComputeTreeSiblingReport analyze_compute_tree_siblings(std::span<const uint32_t> words) {
+    ComputeTreeSiblingReport report;
+    report.records = static_cast<uint32_t>(std::min<size_t>(words.size(), UINT32_MAX));
+    for (size_t i = 0; i < words.size(); ++i) {
+        if ((words[i] & kComputeTreeSiblingSideBit) == 0u) continue;
+        ++report.side_bit_set;
+        // A side-bit record whose predecessor is its exact mate forms a pair. Index 0 can never
+        // pair (it has no predecessor), which is consistent with the root being the unpaired node.
+        //
+        // The head must NOT already carry the side bit. Without that clause two identical adjacent
+        // records both carrying it would satisfy `words[i] == (words[i-1] | bit)` trivially and be
+        // counted as a sibling pair -- inflating the metric with duplicates, which is the opposite
+        // of what an unpaired-record count is for.
+        if (i != 0 && (words[i - 1] & kComputeTreeSiblingSideBit) == 0u &&
+            words[i] == (words[i - 1] | kComputeTreeSiblingSideBit))
+            ++report.pairs;
+        else
+            ++report.unpaired_side;
+    }
+    return report;
+}
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/compute_tree_watch.hpp
+++ b/prosper/src/gpu/compute_tree_watch.hpp
@@ -1,0 +1,86 @@
+// Address-keyed watch over a guest binary-hierarchy parent table.
+//
+// Distinct from compute_parent_walk.hpp, which is PROGRAM-keyed: it evaluates one selected
+// program's own resource immediately before that program runs. This watch is keyed on a guest
+// ADDRESS and evaluated around EVERY realized dispatch, so a change is attributed to the dispatch
+// that made it rather than to "somewhere between two observations of one consumer".
+//
+// The distinction matters for the case it was built for: the consumer that hangs is not
+// necessarily the program that corrupted what it consumes, and a program that changes these bytes
+// without binding a range containing them is a finding in itself (an out-of-bounds write, or a
+// binding path the resource traversal does not model). Reporting whether the running program's
+// table contains the address alongside the change is what makes that visible instead of assumed.
+//
+// Pure analysis lives here so it is testable without a device; gpu_executor owns the guest reads.
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <span>
+#include <vector>
+
+#include "compute_parent_walk.hpp"
+
+namespace prosper::gpu {
+
+struct ComputeTreeWatchSelector {
+    uint64_t addr = 0;
+    uint32_t records = 0;
+    uint32_t index_shift = 3;
+    uint32_t index_mask = (1u << 27u) - 1u;
+};
+
+// Strict selector syntax:
+//   ADDR:RECORDS[:SHIFT:MASK]
+// All fields accept C integer syntax. Shift/mask default to the guest's own bfe(rec, 3, 27).
+// `records` is a dword count, not a byte count.
+std::optional<ComputeTreeWatchSelector> parse_compute_tree_watch_selector(const char* value);
+
+struct ComputeTreeWatchDelta {
+    uint32_t index = 0;
+    uint32_t before = 0;
+    uint32_t after = 0;
+};
+
+// Changed dword indices, ascending, capped at `limit` entries. `total_changed` receives the
+// uncapped count so a truncated report never reads as a complete one.
+std::vector<ComputeTreeWatchDelta> compute_tree_watch_deltas(
+    std::span<const uint32_t> before, std::span<const uint32_t> after, uint32_t limit,
+    uint32_t* total_changed);
+
+enum class ComputeTreeWatchTransition {
+    Unchanged,
+    CleanToClean,
+    CleanToCyclic,
+    CyclicToClean,
+    CyclicToCyclic,
+};
+
+const char* compute_tree_watch_transition_name(ComputeTreeWatchTransition transition);
+
+// Cyclicity is the only axis this classifies. Depth is reported separately by the walk report;
+// folding it in here would make "clean" mean two different things in two different runs.
+ComputeTreeWatchTransition classify_compute_tree_watch_transition(
+    const ComputeParentWalkReport& before, const ComputeParentWalkReport& after,
+    bool bytes_changed);
+
+// Sibling structure under the LBVH reading (#2542): a full binary tree over 1,032 leaves has
+// 1,031 internal nodes, adjacent records are siblings sharing a parent, and bit 30 identifies the
+// child side. `pairs` counts k where records[k+1] == records[k] | kSiblingSideBit; `unpaired_side`
+// counts records with the side bit set whose k-1 mate does not match.
+//
+// This is a QUANTITATIVE CORRELATION, not a correctness rule. Clean samples tolerate a nonzero
+// unpaired count and the slot-level causal test on it failed, so a nonzero value is a signal to
+// look, never on its own a defect.
+inline constexpr uint32_t kComputeTreeSiblingSideBit = 0x40000000u;
+
+struct ComputeTreeSiblingReport {
+    uint32_t records = 0;
+    uint32_t pairs = 0;
+    uint32_t side_bit_set = 0;
+    uint32_t unpaired_side = 0;
+};
+
+ComputeTreeSiblingReport analyze_compute_tree_siblings(std::span<const uint32_t> words);
+
+} // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -3524,6 +3524,11 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
     // the version is downgraded -- eleven legacy-reopen assertions failed that way when this field
     // was first placed next to the seed records.
     for (const auto& seed : c.ds_seeds) w.u32(seed.slice);
+    // Re-check the ceiling AFTER the final tail. The bound above was enforced before this tail
+    // existed, so a capture sitting just under the maximum could serialize successfully into a file
+    // that read_gpu_capture then rejects as oversized -- a write that reports success and produces
+    // an unreadable artifact. Any tail added after this point must move this check again.
+    if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
     bytes = std::move(w.data);
     return true;
 }

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -131,7 +131,7 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // source records, and carrier witnesses instead of being trusted as serialized authority.
 // v54: retain the explicit scalar S_BUFFER dword bound. The ordinary resource size remains the V#'s
 // independent vector footprint; replay cannot reconstruct one from the other when STRIDE < 4.
-constexpr uint32_t kVersion = 54;
+constexpr uint32_t kVersion = 55;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobDefaultBytes = 1ull << 30;
@@ -1154,7 +1154,7 @@ auto ds_seed_key(const GpuCaptureDsSeed& seed) {
     return std::tuple(seed.depth_read_base, seed.depth_write_base,
                       seed.stencil_read_base, seed.stencil_write_base,
                       seed.htile_data_base, seed.width, seed.height,
-                      static_cast<uint32_t>(seed.format));
+                      static_cast<uint32_t>(seed.format), seed.slice);
 }
 
 bool validate_ds_seed(const GpuCaptureDsSeed& seed, std::string& error) {
@@ -2705,6 +2705,7 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         w.u8(seed.depth_valid); w.u8(seed.stencil_valid);
         w.bytes(seed.depth); w.bytes(seed.stencil);
     }
+
     // v9 extends the resource contract with the base-level depth of 3D images. Keep the resource
     // record itself byte-compatible with v1-v8 and append depths in deterministic table order, so old
     // captures remain readable without duplicating every legacy table parser.
@@ -3513,6 +3514,16 @@ bool serialize_gpu_capture(const GpuCaptureFile& c, std::vector<uint8_t>& bytes,
         for (const auto& stage : diagnostic.stages)
             if (!write_scalar_buffer_bounds(stage.resource_table)) return false;
     if (w.data.size() > kMaxFileBytes) { error = "capture file exceeds 4 GiB"; return false; }
+    // v55: each DS seed's array slice, in the same order as the seed records. Written at the END of
+    // the stream, not beside the records it belongs to.
+    //
+    // That placement is the whole point. Every version-gated addition here is a trailing tail so a
+    // reader at version N can stop before it, and the test suite exercises exactly that by
+    // serializing at the current version, LOWERING THE VERSION BYTE IN PLACE, and reparsing. A tail
+    // written mid-stream survives its own round trip and desynchronises every later tail the moment
+    // the version is downgraded -- eleven legacy-reopen assertions failed that way when this field
+    // was first placed next to the seed records.
+    for (const auto& seed : c.ds_seeds) w.u32(seed.slice);
     bytes = std::move(w.data);
     return true;
 }
@@ -3737,7 +3748,6 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
         }
         c.ds_seeds.resize(seed_count);
         uint64_t seed_total = 0;
-        std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> keys;
         for (auto& seed : c.ds_seeds) {
             uint32_t format = 0;
             uint8_t depth_valid = 0, stencil_valid = 0;
@@ -3753,9 +3763,6 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
             seed.depth_valid = depth_valid != 0;
             seed.stencil_valid = stencil_valid != 0;
             if (!validate_ds_seed(seed, error)) return false;
-            if (!keys.insert(ds_seed_key(seed)).second) {
-                error = "duplicate DS seed identity"; return false;
-            }
             const uint64_t plane_bytes = seed.depth.size() + seed.stencil.size();
             if (plane_bytes > kMaxTotalDsSeedBytes ||
                 seed_total > kMaxTotalDsSeedBytes - plane_bytes) {
@@ -4905,6 +4912,21 @@ bool deserialize_gpu_capture(const std::vector<uint8_t>& bytes, GpuCaptureFile& 
                     error = "invalid scalar-buffer bound state";
                     return false;
                 }
+    }
+    // v55 trailing tail: each DS seed's array slice, in seed order. Pre-v55 captures leave every
+    // seed at slice 0, which is what every non-layered surface is.
+    if (version >= 55)
+        for (auto& seed : c.ds_seeds)
+            if (!r.u32(seed.slice)) return false;
+    // DS seed identity is checked HERE, not in the record loop, because the slice arrives in the
+    // tail above: a per-record check would compare incomplete identities and reject two faces of one
+    // cube that differ only in slice -- which is exactly the capture this version exists to allow.
+    {
+        std::set<decltype(ds_seed_key(GpuCaptureDsSeed{}))> identities;
+        for (const auto& seed : c.ds_seeds)
+            if (!identities.insert(ds_seed_key(seed)).second) {
+                error = "duplicate DS seed identity"; return false;
+            }
     }
     for (auto& draw : c.draws) restore_legacy_color_target_aliases(draw);
     for (auto& diagnostic : c.failure_diagnostics)

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -1610,6 +1610,31 @@ bool captured_compute_has_nullable_output_raw_buffer(
                     });
 }
 
+// PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 — accept a capture whose GPU-driven provenance cannot
+// be proven exactly, and say so.
+//
+// These validators refuse the WHOLE BUNDLE when one compute dispatch's packed-pointer or
+// indirect-pointer state is not exactly provable. That is right for a bundle meant to REPLAY: a
+// relocation replayed without provenance would fabricate a pointer. It is wrong for a bundle meant
+// to be READ -- `gpu_replay --inspect-only`, the draw list, the render targets -- and on GTA V it
+// makes the F9 frame grab unusable on the one title whose world is GPU-driven, which is exactly
+// where a draw-level view is needed. The charter calls that grab the fastest loop for a graphical
+// bug; on this title it could not be run at all.
+//
+// Opt-in and reported, because a bundle that silently claimed replay fidelity it does not have
+// would be worse than the refusal it replaces.
+inline bool capture_allow_unproven_provenance(const char* what, const char* detail) {
+    static const bool allowed = std::getenv("PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT") != nullptr;
+    if (!allowed) return false;
+    static std::atomic<int> reported{0};
+    if (reported.fetch_add(1) < 12)
+        std::fprintf(stderr,
+                     "[capture] ALLOW_UNPROVEN_INDIRECT: accepting %s (%s). "
+                     "THIS BUNDLE IS FOR INSPECTION, NOT FAITHFUL REPLAY.\n",
+                     what, detail);
+    return true;
+}
+
 bool validate_captured_nullable_output_raw_buffer(
         const GpuCaptureFile& capture, const GpuCapturedCompute& compute,
         std::string& error) {
@@ -1630,6 +1655,8 @@ bool validate_captured_nullable_output_raw_buffer(
         compute.launch.threads_y != 1u || compute.launch.threads_z != 1u ||
         compute.launch.groups_x != compute.recompile_config.user_sgprs[7] ||
         compute.launch.groups_y != 1u || compute.launch.groups_z != 1u) {
+        if (capture_allow_unproven_provenance("a nullable-output marker",
+                                              "stale captured launch provenance")) return true;
         error = "nullable-output marker has stale captured launch provenance";
         return false;
     }
@@ -1752,6 +1779,8 @@ bool validate_captured_gta5_packed_pointer(
     if (capture.format_version < 51u || candidates != 1u ||
         !compute.recompile_config_available ||
         compute.raw_shader_index >= capture.raw_shader_versions.size()) {
+        if (capture_allow_unproven_provenance("packed-pointer state",
+                                              "no exact compute provenance")) return true;
         error = "packed-pointer state lacks exact compute provenance";
         return false;
     }
@@ -1760,6 +1789,8 @@ bool validate_captured_gta5_packed_pointer(
         (static_cast<uint64_t>(config.threads_x) + config.local_x - 1u) / config.local_x;
     if (compute.launch.groups_x != groups_x || compute.launch.groups_y != 1u ||
         compute.launch.groups_z != 1u) {
+        if (capture_allow_unproven_provenance("packed-pointer state",
+                                              "stale captured launch provenance")) return true;
         error = "packed-pointer state has stale captured launch provenance";
         return false;
     }
@@ -1830,6 +1861,8 @@ bool validate_captured_indirect_pointer_relocations(
     if (capture.format_version < 53u || candidates != 1u ||
         !compute.recompile_config_available ||
         compute.raw_shader_index >= capture.raw_shader_versions.size()) {
+        if (capture_allow_unproven_provenance("an indirect-pointer relocation",
+                                              "no exact compute provenance")) return true;
         error = "indirect-pointer relocation lacks exact compute provenance";
         return false;
     }
@@ -1839,6 +1872,8 @@ bool validate_captured_indirect_pointer_relocations(
         config.local_x;
     if (compute.launch.groups_x != groups_x || compute.launch.groups_y != 1u ||
         compute.launch.groups_z != 1u) {
+        if (capture_allow_unproven_provenance("an indirect-pointer relocation",
+                                              "stale captured launch provenance")) return true;
         error = "indirect-pointer relocation has stale captured launch provenance";
         return false;
     }

--- a/prosper/src/gpu/gpu_capture.hpp
+++ b/prosper/src/gpu/gpu_capture.hpp
@@ -320,6 +320,12 @@ struct GpuCaptureDsSeed {
     uint32_t width = 0;
     uint32_t height = 0;
     GpuCaptureDsFormat format = GpuCaptureDsFormat::D32Float;
+    // Which array slice of the allocation this surface is. A cube shadow map is ONE six-layer guest
+    // allocation whose faces share every base above and differ only here, so without it two faces
+    // are the same identity: the writer rejects the second as a duplicate and a restore cannot
+    // replay them distinctly. Serialized in a v55 tail; captures below v55 read back as slice 0,
+    // which is exactly what every non-layered surface is.
+    uint32_t slice = 0;
     bool depth_valid = false;
     bool stencil_valid = false;
     std::vector<uint8_t> depth;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -1639,6 +1639,11 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // EXP.EN is the final per-component gate after CB_TARGET_MASK and CB_SHADER_MASK. Vulkan exposes
     // the same preservation semantics through colorWriteMask: disabled attachment components retain
     // their old values even though the fragment output itself is a full vec4.
+    // The fragment shell's output capacity and the render state's colour-target count are the same
+    // quantity seen from two sides; if they ever diverge the smaller one silently wins here, as a
+    // `&= 0` on every slot above it.
+    static_assert(kFragmentColorOutputs == kColorTargetCount,
+                  "fragment colour outputs must cover every render-state colour target");
     const uint32_t exp_mask = fragment_color_export_mask(
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)), max_shader_dwords);
     for (uint32_t slot = 0; slot < ps.color_targets.size(); ++slot)

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -582,6 +582,43 @@ struct ComputeAddressWatchHit {
 // unconditionally both fabricates matches against the descriptor table and double-reports an entry
 // whenever the parent and entry 0 happen to share an address. Branch, exactly as the graph does:
 // `table_index_count != 0` means the realized entries are the backing ranges and the parent is not.
+// Overlap of two ranges, ordered so it cannot wrap near UINT64_MAX.
+inline bool compute_address_ranges_overlap(uint64_t a_base, uint64_t a_size,
+                                           uint64_t b_base, uint64_t b_size) {
+    if (!a_size || !b_size) return false;
+    if (a_base >= b_base) return (a_base - b_base) < b_size;
+    return (b_base - a_base) < a_size;
+}
+
+// Windowed variant. The single-address form answers "does this program bind the exact byte", which
+// is the wrong question whenever the caller is watching a RANGE: a program binding
+// [window_base + 128, +160) touches the window and does not contain its first byte, so the
+// address form reports it as a non-toucher.
+//
+// That is not hypothetical. It produced a false "this program writes bytes it does not bind" on GTA
+// V -- reported as an out-of-bounds-write lead before the resource map showed the binding sitting
+// 128 bytes inside the window. An instrument whose two halves ask different questions manufactures
+// exactly the finding it was built to detect.
+inline std::vector<ComputeAddressWatchHit> compute_address_window_hits(
+        const ShaderResourceTable& table, uint64_t base, uint64_t bytes) {
+    std::vector<ComputeAddressWatchHit> hits;
+    for (const ShaderResource& r : table.resources) {
+        if (r.table_index_count) {
+            for (size_t e = 0; e < r.table_entries.size(); ++e) {
+                const ShaderBufferTableEntry& entry = r.table_entries[e];
+                if (!compute_address_ranges_overlap(entry.gpu_addr, entry.size, base, bytes))
+                    continue;
+                hits.push_back({r.binding, r.fetch_pc, static_cast<uint32_t>(e), entry.gpu_addr,
+                                entry.size, true});
+            }
+            continue;
+        }
+        if (compute_address_ranges_overlap(r.gpu_addr, r.size, base, bytes))
+            hits.push_back({r.binding, r.fetch_pc, 0xFFFFFFFFu, r.gpu_addr, r.size, false});
+    }
+    return hits;
+}
+
 inline std::vector<ComputeAddressWatchHit> compute_address_watch_hits(
         const ShaderResourceTable& table, uint64_t wanted) {
     std::vector<ComputeAddressWatchHit> hits;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include <cstring>
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <bitset>
 #include <condition_variable>
@@ -9619,7 +9620,25 @@ std::vector<uint32_t> observe_compute_tree_watch_pre(const ComputeItem& item, ui
     const auto& selected = compute_tree_watch_selector();
     if (!selected) return {};
     std::vector<uint32_t> current;
-    if (!read_compute_tree_watch_words(*selected, current)) return {};
+    if (!read_compute_tree_watch_words(*selected, current)) {
+        // An unreadable watch window produced NO output at all -- indistinguishable from "nothing
+        // writes this address", which is the conclusion it would have supported. Report it once.
+        // Measured need: watching GTA V's 0x2052ac0000 returned complete silence, and the silence
+        // meant the address is not guest-readable, not that no program writes it.
+        static std::mutex mutex;
+        static std::set<uint64_t> reported;
+        bool first = false;
+        {
+            std::lock_guard lock(mutex);
+            first = reported.insert(selected->addr).second;
+        }
+        if (first)
+            std::fprintf(stderr,
+                         "[compute-tree-watch] addr=0x%llx UNREADABLE (%u dwords) — this watch can "
+                         "report nothing about it; its silence is not evidence of no writer\n",
+                         static_cast<unsigned long long>(selected->addr), selected->records);
+        return {};
+    }
 
     LiveComputeTreeWatchState& state = compute_tree_watch_state();
     ++state.observations;
@@ -9988,6 +10007,81 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                 //
                 // Counted before the `render` early-out so a run without the live renderer still
                 // reports what the command stream contained. Printed at powers of two.
+                // PROSPER_TARGET_WATCH=0x…,0x… — EXACT and unsampled: is this address EVER a
+                // colour target, in any of the eight MRT slots?
+                //
+                // Separate from the census below because the census samples 1 in 32 draws, and a
+                // sampled zero cannot answer an "ever" question. A surface written by ten draws is
+                // missed with probability (31/32)^10 ≈ 73%; by one draw, 97%. The census's zero for
+                // GTA V's 0x2052ac0000 therefore only excludes a *frequent* writer, which is not
+                // what was asked of it.
+                //
+                // Cost is eight register lookups per draw with no lock (per-address atomics), which
+                // is what the 1-in-32 sampling was protecting against when it applied to a mutex and
+                // a map insert. Watch list is bounded so the per-draw cost stays fixed.
+                {
+                    struct TargetWatch {
+                        uint64_t addr;
+                        std::atomic<uint64_t> hits[8];
+                        std::atomic<uint64_t> total;
+                    };
+                    static constexpr size_t kMaxWatch = 8;
+                    static std::array<TargetWatch, kMaxWatch> watch{};
+                    static size_t watch_count = 0;
+                    static std::atomic<uint64_t> watch_draws{0};
+                    static const bool watch_enabled = [] {
+                        const char* spec = std::getenv("PROSPER_TARGET_WATCH");
+                        if (!spec || !*spec) return false;
+                        for (const char* p = spec; *p && watch_count < kMaxWatch;) {
+                            char* end = nullptr;
+                            const uint64_t v = std::strtoull(p, &end, 0);
+                            if (end == p) break;
+                            watch[watch_count++].addr = v;
+                            p = (*end == ',') ? end + 1 : end;
+                        }
+                        std::fprintf(stderr, "[target-watch] watching %zu address(es)\n",
+                                     watch_count);
+                        return watch_count != 0;
+                    }();
+                    if (watch_enabled) {
+                        namespace P = prosper::agc::Pm4;
+                        constexpr uint32_t kColorRegisterStride = 0xf;
+                        const uint64_t wn = watch_draws.fetch_add(1) + 1;
+                        if (const GpuState* snap = st.draws[operation.index].state.get()) {
+                            for (uint32_t slot = 0; slot < 8u; ++slot) {
+                                const auto lo = snap->cx.find(
+                                    P::CB_COLOR0_BASE + slot * kColorRegisterStride);
+                                if (lo == snap->cx.end() || !lo->second) continue;
+                                const auto hi = snap->cx.find(P::CB_COLOR0_BASE_EXT + slot);
+                                uint64_t base = static_cast<uint64_t>(lo->second) << 8;
+                                if (hi != snap->cx.end())
+                                    base |= static_cast<uint64_t>(hi->second & 0xffu) << 40;
+                                for (size_t w = 0; w < watch_count; ++w) {
+                                    if (watch[w].addr != base) continue;
+                                    watch[w].hits[slot].fetch_add(1, std::memory_order_relaxed);
+                                    watch[w].total.fetch_add(1, std::memory_order_relaxed);
+                                }
+                            }
+                        }
+                        if ((wn & (wn - 1)) == 0 && wn >= 4096u) {
+                            for (size_t w = 0; w < watch_count; ++w) {
+                                std::string slots;
+                                for (uint32_t s = 0; s < 8u; ++s) {
+                                    const uint64_t h = watch[w].hits[s].load();
+                                    if (!h) continue;
+                                    slots += " slot" + std::to_string(s) + "=" + std::to_string(h);
+                                }
+                                std::fprintf(stderr,
+                                             "[target-watch] addr=0x%llx draws=%llu of %llu%s\n",
+                                             (unsigned long long)watch[w].addr,
+                                             (unsigned long long)watch[w].total.load(),
+                                             (unsigned long long)wn,
+                                             slots.empty() ? "  NEVER A COLOUR TARGET" :
+                                                 slots.c_str());
+                            }
+                        }
+                    }
+                }
                 if (std::getenv("PROSPER_DRAW_CENSUS")) {
                     static std::atomic<uint64_t> seen{0}, indirect_seen{0};
                     const uint64_t n = seen.fetch_add(1) + 1;
@@ -10009,21 +10103,31 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         // Straight from the draw's own register snapshot, the same two registers
                         // render_state.cpp uses (CB_COLOR0_BASE + its _EXT high bits). Avoids
                         // building a RenderState per draw on a path that runs 131,072 times.
+                        // ALL EIGHT MRT slots, not just slot 0. The first version read only
+                        // CB_COLOR0_BASE, and its own control exposed that: two surfaces which
+                        // demonstrably HIT the RTT cache (0x2063380000, 0x2085de0000) never appeared
+                        // in the census at all. A deferred renderer writes a G-buffer across slots
+                        // 0..7 in one draw, so a slot-0-only census cannot see most of what a frame
+                        // renders into -- and "is address X ever a render target" was exactly the
+                        // question being asked of it.
+                        //
+                        // Register layout from render_state.cpp: stride 0xf per slot for BASE, and
+                        // CB_COLOR0_BASE_EXT + slot for the high bits.
                         namespace P = prosper::agc::Pm4;
-                        uint64_t base = 0;
-                        uint32_t view = 0;
+                        constexpr uint32_t kColorRegisterStride = 0xf;
                         if (const GpuState* snap = st.draws[operation.index].state.get()) {
-                            const auto lo = snap->cx.find(P::CB_COLOR0_BASE);
-                            const auto hi = snap->cx.find(P::CB_COLOR0_BASE_EXT);
-                            const auto vw = snap->cx.find(P::CB_COLOR0_VIEW);
-                            if (lo != snap->cx.end())
-                                base = static_cast<uint64_t>(lo->second) << 8;
-                            if (hi != snap->cx.end())
-                                base |= static_cast<uint64_t>(hi->second & 0xffu) << 40;
-                            if (vw != snap->cx.end()) view = vw->second;
+                            std::lock_guard lock(target_mutex);
+                            for (uint32_t slot = 0; slot < 8u; ++slot) {
+                                const auto lo = snap->cx.find(
+                                    P::CB_COLOR0_BASE + slot * kColorRegisterStride);
+                                if (lo == snap->cx.end() || !lo->second) continue;
+                                const auto hi = snap->cx.find(P::CB_COLOR0_BASE_EXT + slot);
+                                uint64_t base = static_cast<uint64_t>(lo->second) << 8;
+                                if (hi != snap->cx.end())
+                                    base |= static_cast<uint64_t>(hi->second & 0xffu) << 40;
+                                ++targets[{base, slot, 0u}];
+                            }
                         }
-                        std::lock_guard lock(target_mutex);
-                        ++targets[{base, view, 0u}];
                     }
                     if ((n & (n - 1)) == 0 && n >= 4096u) {
                         std::fprintf(stderr,
@@ -10047,11 +10151,15 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         for (const auto& r : ranked) {
                             const std::pair<const std::tuple<uint64_t, uint32_t, uint32_t>, uint64_t>
                                 entry{r.second, r.first};
-                            if (shown++ >= 12) { std::fprintf(stderr,
+                            // All of them at the final report. Twelve was enough to see whether one
+                            // target dominates; it is not enough to answer "is address X ever a
+                            // render target", which is the question a specific suspect raises.
+                            const size_t limit = n >= 65536u ? targets.size() : 12u;
+                            if (shown++ >= limit) { std::fprintf(stderr,
                                 "[draw-census]   ... %zu further targets\n",
-                                targets.size() - 12); break; }
+                                targets.size() - limit); break; }
                             std::fprintf(stderr,
-                                         "[draw-census]   color0=0x%llx view=0x%x draws=%llu\n",
+                                         "[draw-census]   target=0x%llx slot=%u draws=%llu\n",
                                          (unsigned long long)std::get<0>(entry.first),
                                          std::get<1>(entry.first),
                                          (unsigned long long)entry.second);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2037,6 +2037,40 @@ std::vector<uint32_t> recompile_compute_shader_cached(
     return *spirv;
 }
 
+// PROSPER_COMPUTE_DISPATCH_LOG=0xADDR[,0xADDR...]: one line per DISPATCH of the named programs,
+// with what actually happened to it. Every existing signal is once-per-program:
+// `[compute] skip unsupported program` fires once ever, and the subgroup, resource-map and
+// selected-sbuffer lines are all deduped. That is right for their purposes and wrong for this one,
+// and reading a once-per-program line as a per-dispatch property is exactly how a root-cause claim
+// in this investigation was published and had to be retracted -- the program it said "never runs"
+// ran 26 times.
+//
+// Answers "did THIS dispatch execute", which is what a frame-by-frame correlation between a decline
+// and a corrupted result needs.
+bool compute_dispatch_log_selected(uint64_t program) {
+    const char* spec = std::getenv("PROSPER_COMPUTE_DISPATCH_LOG");
+    if (!spec || !*spec || !program) return false;
+    for (const char* cursor = spec; cursor && *cursor;) {
+        char* end = nullptr;
+        const uint64_t one = std::strtoull(cursor, &end, 0);
+        if (end == cursor) return false;
+        if (one == program) return true;
+        if (*end != ',') return false;
+        cursor = end + 1;
+    }
+    return false;
+}
+
+void log_compute_dispatch(uint64_t program, uint64_t submit_no, size_t dispatch_index,
+                          uint64_t order, const char* outcome) {
+    if (!compute_dispatch_log_selected(program)) return;
+    std::fprintf(stderr,
+                 "[compute-dispatch] program=0x%llx submit=%llu dispatch=%zu order=%llu outcome=%s\n",
+                 static_cast<unsigned long long>(program),
+                 static_cast<unsigned long long>(submit_no), dispatch_index,
+                 static_cast<unsigned long long>(order), outcome);
+}
+
 bool report_compute_recompile_skip_once(RecompileDiagnosticContext diagnostic) {
     static std::mutex mutex;
     static std::set<uint64_t> logged;
@@ -7871,6 +7905,8 @@ std::vector<ComputeItem> realize_compute_dispatches(
         item.submit_no = submit_no;
         item.command_order = dispatch.command_order;
         if (item.spirv.empty()) {
+            log_compute_dispatch(code_addr, submit_no, dispatch_index, dispatch.command_order,
+                                 "recompile-empty");
             record_failure(RealizationFailureReason::ShaderRecompile, item.resources, item.spirv,
                            &config);
             // PROSPER_DYNTRACE_FAIL=1: replay the FAILED compute program's resource build with the
@@ -10060,6 +10096,9 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                                                        operation.command_order, tree_watch_touch);
                     const bool executed = capture_trace
                         ? compute({item}) : compute({std::move(item)});
+                    log_compute_dispatch(tree_watch_program, submit_no, operation.index,
+                                         operation.command_order,
+                                         executed ? "executed" : "backend-declined");
                     observe_compute_tree_watch_post(tree_watch_program, tree_watch_touch, submit_no,
                                                     operation.index, operation.command_order,
                                                     tree_watch_pre);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2928,8 +2928,17 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         // reach contradictory conclusions about the same chain. That happened: a Windows trace of s16
         // showed ZERO forget sites while the Linux fold attributed the loss of the descriptor-table
         // pointer to a v_cmp writing s16, and neither observation was wrong. (#2412)
+        // `program=` alongside `sh=`, because sh= IS NOT UNIQUE. It is the first code dword plus the
+        // span, and the first dword of a great many GTA V shaders is `bfa00003` -- `s_branch +3`, an
+        // ordinary prologue. Two different 276-dword programs therefore share `sh=bfa00003/276`, and
+        // filtering a watch by it silently mixes them: a trace filtered that way showed s106 being
+        // FORGOTTEN at a pc whose instruction words do not appear anywhere in the program being
+        // studied. The comment below claims this signature "identifies one cheaply and stably" -- it
+        // is cheap and stable, and it is not an identity. The code pointer is.
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] sh=%08x/%zu pc=%u s%d <- KNOWN 0x%08x\n",
+            fprintf(stderr,
+                    "[sgprwatch] program=0x%llx sh=%08x/%zu pc=%u s%d <- KNOWN 0x%08x\n",
+                    (unsigned long long)(uintptr_t)code,
                     dwords ? code[0] : 0u, dwords, watch_pc, r, v);
         if (valid_reg(r)) {
             val[(size_t)r] = v;
@@ -2947,7 +2956,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     };
     auto forget = [&](int r) {
         if (r == watch_sgpr)
-            fprintf(stderr, "[sgprwatch] sh=%08x/%zu pc=%u s%d <- FORGOTTEN words=%08x:%08x len=%u\n",
+            fprintf(stderr,
+                    "[sgprwatch] program=0x%llx sh=%08x/%zu pc=%u s%d <- FORGOTTEN "
+                    "words=%08x:%08x len=%u\n",
+                    (unsigned long long)(uintptr_t)code,
                     dwords ? code[0] : 0u, dwords, watch_pc, r, watch_w0, watch_w1, watch_len);
         if (valid_reg(r)) {
             val_known.reset((size_t)r);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9980,9 +9980,48 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
     for (const auto& operation : executable) {
         switch (operation.kind) {
             case RetainedSubmitKind::Draw: {
+                // PROSPER_DRAW_CENSUS=1 — the most basic number about a missing world, and nothing
+                // reported it: how many draws does prosper actually execute, and how many of them
+                // are indirect? An absent world with ten draws per frame and one with ten thousand
+                // are different problems, and every investigation of GTA V's missing world so far
+                // has proceeded without knowing which it is.
+                //
+                // Counted before the `render` early-out so a run without the live renderer still
+                // reports what the command stream contained. Printed at powers of two.
+                if (std::getenv("PROSPER_DRAW_CENSUS")) {
+                    static std::atomic<uint64_t> seen{0}, indirect_seen{0};
+                    const uint64_t n = seen.fetch_add(1) + 1;
+                    if (st.draws[operation.index].indirect)
+                        indirect_seen.fetch_add(1, std::memory_order_relaxed);
+                    if ((n & (n - 1)) == 0)
+                        std::fprintf(stderr,
+                                     "[draw-census] draws=%llu indirect=%llu submit=%llu\n",
+                                     (unsigned long long)n,
+                                     (unsigned long long)indirect_seen.load(),
+                                     (unsigned long long)submit_no);
+                }
                 if (!render) break;
                 if (st.draws[operation.index].indirect &&
                     (!indirect_dependencies_ok || !producer_epoch_ok)) {
+                    // The indirect latch drops this draw SILENTLY on an ordinary run -- the failure
+                    // is recorded only when a capture trace happens to be active. On a title whose
+                    // world is GPU-driven that is the difference between "the world is missing" and
+                    // "N indirect draws were dropped because a producer was declined", and nothing
+                    // reported it.
+                    //
+                    // Counted always, printed at powers of two so the volume stays bounded on a
+                    // title that does this every frame. The count is the point: an absent world with
+                    // zero dropped indirect draws and one with thousands are different problems.
+                    static std::atomic<uint64_t> latched_draws{0};
+                    const uint64_t dropped = latched_draws.fetch_add(1) + 1;
+                    if ((dropped & (dropped - 1)) == 0)
+                        std::fprintf(stderr,
+                                     "[agc] indirect DRAW dropped by the dependency latch "
+                                     "(count=%llu, submit=%llu, deps-ok=%u producer-ok=%u)\n",
+                                     (unsigned long long)dropped,
+                                     (unsigned long long)submit_no,
+                                     indirect_dependencies_ok ? 1u : 0u,
+                                     producer_epoch_ok ? 1u : 0u);
                     if (capture_trace) {
                         capture_trace->failures.push_back({
                             SubmitOperationKind::Draw, operation.index,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5278,6 +5278,37 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                         set_value(in.dst.value, (uint32_t)(int32_t)in.simm16);
                     break;
                 }
+                // s_mulk_i32: `D.i = D.i * signext(SIMM16)`, and it does NOT write SCC -- the comment
+                // below already says so while the code invalidated SCC for it anyway. Two costs, both
+                // paid on GTA V: the product is discarded, and every later s_cselect that depended on
+                // a live SCC loses it.
+                //
+                // The per-opcode evidence this widening requires, since the note below rightly refuses
+                // to take sibling opcodes for free: 0x413ce6000 pc149 is `s_mulk_i32 s106, 120`, where
+                // 120 is the descriptor array's exact record stride. It feeds
+                // `s_buffer_load_dwordx4 s[8:11], s[4:7], s106` at pc153, which selects one V# from
+                // that array, which is the descriptor for `buffer_load_dwordx3` at pc156 -- the
+                // instruction the program is rejected on, with mode=unresolved-operand. Forgetting
+                // s106 here is what makes that descriptor unresolvable.
+                //
+                // Multiplies a KNOWN destination only. An unknown destination still forgets, exactly
+                // as before; the change is that it no longer takes SCC with it.
+                if (in.opcode == kSopkOpcodeMulkI32) {
+                    if (in.dst.kind == OperandKind::SGPR) {
+                        uint32_t current = 0;
+                        if (known(in.dst.value, current))
+                            set_value(in.dst.value,
+                                      static_cast<uint32_t>(current *
+                                                            static_cast<uint32_t>(
+                                                                static_cast<int32_t>(in.simm16))));
+                        else
+                            forget(in.dst.value);
+                    }
+                    // A product is not an add-carry chain; the tracked origins cannot survive it.
+                    null_count_carry_origin = 0;
+                    bvh_count_carry_origin = 0;
+                    break;
+                }
                 // s_cmpk_* / s_addk_i32 write SCC (only s_movk/s_version/s_cmovk/s_mulk don't); this
                 // interpreter doesn't model the rest of SOPK, so they conservatively invalidate the
                 // tracked SCC — a stale SCC consumed by a later s_cselect would fabricate a

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -10249,6 +10249,52 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     // Pre/post around the dispatch, so a change to the watched table is
                     // attributed to the dispatch that made it. Captured before the move: the
                     // post observation needs the program address, and `item` is consumed below.
+                    // PROSPER_COMPUTE_ZERO_BEFORE=0xPROGRAM:0xADDR:DWORDS — zero a guest range
+                    // immediately before the named program dispatches. DIAGNOSTIC ONLY: it fixes
+                    // nothing, because on hardware something must be performing whatever
+                    // initialisation this stands in for, and identifying that is the actual work.
+                    //
+                    // It exists to test one specific prediction that no amount of reading the ISA
+                    // settles: GTA V's tree builder writes parent links only for children whose node
+                    // type is in {2,5}, so the slots it skips must already hold a value that
+                    // terminates the consumer's `while (i != 0) i = bfe(rec[i], 3, 27)` walk. Zero
+                    // terminates; a leftover index from an earlier generation of the same array does
+                    // not. If the array is simply never cleared, zeroing it here should turn a cyclic
+                    // tree into a legitimately sparse one -- pairs below 1030 and cycles at zero.
+                    // That outcome is not reachable by any other experiment available.
+                    if (const char* zero_spec = std::getenv("PROSPER_COMPUTE_ZERO_BEFORE")) {
+                        char* cursor = nullptr;
+                        const uint64_t want_program = std::strtoull(zero_spec, &cursor, 0);
+                        if (cursor && *cursor == ':' && want_program == item.code_addr) {
+                            const uint64_t zero_addr = std::strtoull(cursor + 1, &cursor, 0);
+                            uint64_t zero_dwords = 0;
+                            if (cursor && *cursor == ':')
+                                zero_dwords = std::strtoull(cursor + 1, &cursor, 0);
+                            const uint64_t zero_bytes = zero_dwords * sizeof(uint32_t);
+                            if (zero_addr && zero_dwords && zero_dwords <= (1u << 22u) &&
+                                guest_readable(zero_addr, zero_bytes)) {
+                                std::memset(
+                                    reinterpret_cast<void*>(static_cast<uintptr_t>(zero_addr)), 0,
+                                    static_cast<size_t>(zero_bytes));
+                                static std::mutex zero_mutex;
+                                static uint64_t zero_count = 0;
+                                uint64_t count = 0;
+                                {
+                                    std::lock_guard lock(zero_mutex);
+                                    count = ++zero_count;
+                                }
+                                if (count <= 3 || (count % 25) == 0)
+                                    std::fprintf(stderr,
+                                                 "[compute-zero-before] program=0x%llx addr=0x%llx "
+                                                 "dwords=%llu submit=%llu dispatch=%zu count=%llu\n",
+                                                 (unsigned long long)item.code_addr,
+                                                 (unsigned long long)zero_addr,
+                                                 (unsigned long long)zero_dwords,
+                                                 (unsigned long long)submit_no, operation.index,
+                                                 (unsigned long long)count);
+                            }
+                        }
+                    }
                     const uint64_t tree_watch_program = item.code_addr;
                     const ComputeLaunchDimensions tree_watch_launch = item.launch;
                     const std::string tree_watch_touch =

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9993,12 +9993,70 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     const uint64_t n = seen.fetch_add(1) + 1;
                     if (st.draws[operation.index].indirect)
                         indirect_seen.fetch_add(1, std::memory_order_relaxed);
-                    if ((n & (n - 1)) == 0)
+                    // WHERE the draws go, not just how many. 131,072 draws execute while the world
+                    // is absent, so the question is which surfaces they write and whether the one
+                    // that reaches the screen is among them. A count alone cannot answer that.
+                    //
+                    // Keyed on the colour-0 base and its extent, reported at teardown so the
+                    // per-draw path stays a map insert.
+                    // SAMPLED, 1 in 32. The first version took a mutex and inserted into a map on
+                    // every one of 131,072 draws and reported twelve lines at each power of two; the
+                    // routed run stalled at 1,024 draws and never reached gameplay. An instrument
+                    // that changes the subject's behaviour measures the instrument.
+                    static std::mutex target_mutex;
+                    static std::map<std::tuple<uint64_t, uint32_t, uint32_t>, uint64_t> targets;
+                    if ((n & 31u) == 0u) {
+                        // Straight from the draw's own register snapshot, the same two registers
+                        // render_state.cpp uses (CB_COLOR0_BASE + its _EXT high bits). Avoids
+                        // building a RenderState per draw on a path that runs 131,072 times.
+                        namespace P = prosper::agc::Pm4;
+                        uint64_t base = 0;
+                        uint32_t view = 0;
+                        if (const GpuState* snap = st.draws[operation.index].state.get()) {
+                            const auto lo = snap->cx.find(P::CB_COLOR0_BASE);
+                            const auto hi = snap->cx.find(P::CB_COLOR0_BASE_EXT);
+                            const auto vw = snap->cx.find(P::CB_COLOR0_VIEW);
+                            if (lo != snap->cx.end())
+                                base = static_cast<uint64_t>(lo->second) << 8;
+                            if (hi != snap->cx.end())
+                                base |= static_cast<uint64_t>(hi->second & 0xffu) << 40;
+                            if (vw != snap->cx.end()) view = vw->second;
+                        }
+                        std::lock_guard lock(target_mutex);
+                        ++targets[{base, view, 0u}];
+                    }
+                    if ((n & (n - 1)) == 0 && n >= 4096u) {
                         std::fprintf(stderr,
                                      "[draw-census] draws=%llu indirect=%llu submit=%llu\n",
                                      (unsigned long long)n,
                                      (unsigned long long)indirect_seen.load(),
                                      (unsigned long long)submit_no);
+                        std::lock_guard lock(target_mutex);
+                        // Busiest first. The numerically-lowest twelve addresses said nothing: the
+                        // question is whether one target dominates (a scene buffer) or the draws are
+                        // spread over hundreds of small ones.
+                        std::vector<std::pair<uint64_t, std::tuple<uint64_t, uint32_t, uint32_t>>>
+                            ranked;
+                        ranked.reserve(targets.size());
+                        for (const auto& e : targets) ranked.push_back({e.second, e.first});
+                        std::sort(ranked.begin(), ranked.end(),
+                                  [](const auto& a, const auto& b) { return a.first > b.first; });
+                        std::fprintf(stderr, "[draw-census]   distinct colour targets (sampled): %zu\n",
+                                     targets.size());
+                        size_t shown = 0;
+                        for (const auto& r : ranked) {
+                            const std::pair<const std::tuple<uint64_t, uint32_t, uint32_t>, uint64_t>
+                                entry{r.second, r.first};
+                            if (shown++ >= 12) { std::fprintf(stderr,
+                                "[draw-census]   ... %zu further targets\n",
+                                targets.size() - 12); break; }
+                            std::fprintf(stderr,
+                                         "[draw-census]   color0=0x%llx view=0x%x draws=%llu\n",
+                                         (unsigned long long)std::get<0>(entry.first),
+                                         std::get<1>(entry.first),
+                                         (unsigned long long)entry.second);
+                        }
+                    }
                 }
                 if (!render) break;
                 if (st.draws[operation.index].indirect &&

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2062,13 +2062,25 @@ bool compute_dispatch_log_selected(uint64_t program) {
 }
 
 void log_compute_dispatch(uint64_t program, uint64_t submit_no, size_t dispatch_index,
-                          uint64_t order, const char* outcome) {
+                          uint64_t order, const char* outcome,
+                          const ComputeLaunchDimensions* launch = nullptr) {
     if (!compute_dispatch_log_selected(program)) return;
+    // The launch travels with the outcome. GTA V's tree builder emits a PERFECT tree for five
+    // consecutive submits and then a cyclic one for the rest of the route, so the question is what
+    // differs between those two regimes -- and the guest's active-record count reaches the shader as
+    // the thread extent. A dispatch record without it cannot answer that.
+    char geometry[128] = "";
+    if (launch)
+        std::snprintf(geometry, sizeof(geometry),
+                      " groups=%ux%ux%u local=%ux%ux%u threads=%ux%ux%u",
+                      launch->groups_x, launch->groups_y, launch->groups_z,
+                      launch->local_x, launch->local_y, launch->local_z,
+                      launch->threads_x, launch->threads_y, launch->threads_z);
     std::fprintf(stderr,
-                 "[compute-dispatch] program=0x%llx submit=%llu dispatch=%zu order=%llu outcome=%s\n",
+                 "[compute-dispatch] program=0x%llx submit=%llu dispatch=%zu order=%llu outcome=%s%s\n",
                  static_cast<unsigned long long>(program),
                  static_cast<unsigned long long>(submit_no), dispatch_index,
-                 static_cast<unsigned long long>(order), outcome);
+                 static_cast<unsigned long long>(order), outcome, geometry);
 }
 
 bool report_compute_recompile_skip_once(RecompileDiagnosticContext diagnostic) {
@@ -9421,7 +9433,11 @@ void report_compute_tree_watch(const char* phase, const ComputeTreeWatchSelector
     //
     // Gated on the clean -> cyclic transition specifically. Dumping every change would write
     // hundreds of megabytes across a routed run and bury the two images that matter.
-    if (transition != ComputeTreeWatchTransition::CleanToCyclic) return;
+    // CleanToClean is dumped too when an aux range is configured: a cyclic sample with no clean
+    // counterpart from the same run cannot show what CHANGED, only what is present.
+    const bool want_clean_control = std::getenv("PROSPER_COMPUTE_TREE_WATCH_AUX") != nullptr &&
+                                    transition == ComputeTreeWatchTransition::CleanToClean;
+    if (transition != ComputeTreeWatchTransition::CleanToCyclic && !want_clean_control) return;
     const char* dump_root = std::getenv("PROSPER_COMPUTE_TREE_WATCH_DUMP");
     if (!dump_root || !*dump_root) return;
     auto write_image = [&](const char* which, const std::vector<uint32_t>& words) {
@@ -9444,6 +9460,42 @@ void report_compute_tree_watch(const char* phase, const ComputeTreeWatchSelector
     };
     write_image("pre", before);
     write_image("post", after);
+
+    // PROSPER_COMPUTE_TREE_WATCH_AUX=0xADDR:DWORDS — dump a SECOND guest range at the same moment.
+    //
+    // The watched table is the OUTPUT. Its input lives somewhere else, and the question that matters
+    // is what differs about that input between a dispatch that produces a correct tree and one that
+    // does not. GTA V's builder emits pairs=1030 unpaired=0 for eleven consecutive submits at an
+    // identical launch geometry and then never again, which rules its lowering correct and makes the
+    // input the only remaining variable -- but nothing was capturing the input.
+    const char* aux = std::getenv("PROSPER_COMPUTE_TREE_WATCH_AUX");
+    if (!aux || !*aux) return;
+    char* aux_end = nullptr;
+    const uint64_t aux_addr = std::strtoull(aux, &aux_end, 0);
+    if (!aux_addr || !aux_end || *aux_end != ':') return;
+    const uint64_t aux_dwords = std::strtoull(aux_end + 1, &aux_end, 0);
+    if (!aux_dwords || aux_dwords > (1u << 22u) || (aux_end && *aux_end)) return;
+    const uint64_t aux_bytes = aux_dwords * sizeof(uint32_t);
+    if (!guest_readable(aux_addr, aux_bytes)) {
+        std::fprintf(stderr, "[compute-tree-watch]   aux 0x%llx unreadable\n",
+                     static_cast<unsigned long long>(aux_addr));
+        return;
+    }
+    std::vector<uint32_t> aux_words(static_cast<size_t>(aux_dwords));
+    std::memcpy(aux_words.data(),
+                reinterpret_cast<const void*>(static_cast<uintptr_t>(aux_addr)),
+                static_cast<size_t>(aux_bytes));
+    char path[1024];
+    std::snprintf(path, sizeof(path), "%s/aux-%llx-s%llu-d%zu-o%llu.bin", dump_root,
+                  static_cast<unsigned long long>(aux_addr),
+                  static_cast<unsigned long long>(submit_no), dispatch_index,
+                  static_cast<unsigned long long>(order));
+    std::FILE* file = std::fopen(path, "wb");
+    if (!file) return;
+    const size_t written = std::fwrite(aux_words.data(), sizeof(uint32_t), aux_words.size(), file);
+    const int closed = std::fclose(file);
+    std::fprintf(stderr, "[compute-tree-watch]   dumped aux -> %s (%s)\n", path,
+                 (written == aux_words.size() && closed == 0) ? "ok" : "SHORT");
 }
 
 // Returns the pre-image so the caller can hand it back for the post comparison. Empty means the
@@ -10086,6 +10138,7 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     // attributed to the dispatch that made it. Captured before the move: the
                     // post observation needs the program address, and `item` is consumed below.
                     const uint64_t tree_watch_program = item.code_addr;
+                    const ComputeLaunchDimensions tree_watch_launch = item.launch;
                     const std::string tree_watch_touch =
                         compute_tree_watch_selector()
                             ? describe_compute_tree_watch_touch(item.resources.get(),
@@ -10098,7 +10151,8 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         ? compute({item}) : compute({std::move(item)});
                     log_compute_dispatch(tree_watch_program, submit_no, operation.index,
                                          operation.command_order,
-                                         executed ? "executed" : "backend-declined");
+                                         executed ? "executed" : "backend-declined",
+                                         &tree_watch_launch);
                     observe_compute_tree_watch_post(tree_watch_program, tree_watch_touch, submit_no,
                                                     operation.index, operation.command_order,
                                                     tree_watch_pre);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9340,6 +9340,38 @@ void report_compute_tree_watch(const char* phase, const ComputeTreeWatchSelector
     if (changed > kReportedSlots)
         std::fprintf(stderr, "[compute-tree-watch]   ... %u further changed slots not listed\n",
                      changed - kReportedSlots);
+
+    // PROSPER_COMPUTE_TREE_WATCH_DUMP=<dir>: write both images of a transition that INTRODUCES
+    // cycles. Twelve reported slots identify that something changed; they cannot answer what shape
+    // the damage has -- whether the wrong records cluster by workgroup, by wave, at the tail of the
+    // extent, or not at all. That question decides between a lane-activation defect and a
+    // value-computation defect, and it needs the whole array on disk.
+    //
+    // Gated on the clean -> cyclic transition specifically. Dumping every change would write
+    // hundreds of megabytes across a routed run and bury the two images that matter.
+    if (transition != ComputeTreeWatchTransition::CleanToCyclic) return;
+    const char* dump_root = std::getenv("PROSPER_COMPUTE_TREE_WATCH_DUMP");
+    if (!dump_root || !*dump_root) return;
+    auto write_image = [&](const char* which, const std::vector<uint32_t>& words) {
+        char path[1024];
+        std::snprintf(path, sizeof(path), "%s/tree-%s-s%llu-d%zu-o%llu-p%llx.bin", dump_root, which,
+                      static_cast<unsigned long long>(submit_no), dispatch_index,
+                      static_cast<unsigned long long>(order),
+                      static_cast<unsigned long long>(program));
+        std::FILE* file = std::fopen(path, "wb");
+        if (!file) {
+            std::fprintf(stderr, "[compute-tree-watch] dump open failed: %s\n", path);
+            return;
+        }
+        const size_t written = std::fwrite(words.data(), sizeof(uint32_t), words.size(), file);
+        const int closed = std::fclose(file);
+        if (written != words.size() || closed != 0)
+            std::fprintf(stderr, "[compute-tree-watch] dump write failed: %s\n", path);
+        else
+            std::fprintf(stderr, "[compute-tree-watch]   dumped %s -> %s\n", which, path);
+    };
+    write_image("pre", before);
+    write_image("post", after);
 }
 
 // Returns the pre-image so the caller can hand it back for the post comparison. Empty means the

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9933,6 +9933,64 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     // "nothing touches this buffer" -- which is the conclusion it would have
                     // supported, and it is false. Anchor a new watch to a line already proven to
                     // execute on the route being measured.
+                    // PROSPER_COMPUTE_RESOURCE_MAP=0xADDR[,0xADDR...]: print each named program's
+                    // realized resource table once, with binding, fetch pc, base and size. The
+                    // question it exists to answer is "do these two programs bind the same buffer",
+                    // which the address watch cannot express -- that one starts from an address and
+                    // finds programs, and here the address is precisely what is unknown.
+                    //
+                    // Deduped per (program, table shape) so a program dispatched forty times per
+                    // route prints once. Volume matters: the existing PROSPER_COMPUTELOG_RESOURCES
+                    // needs PROSPER_COMPUTELOG, which slows the subject enough that a routed run
+                    // stops reaching the phase being measured.
+                    if (const char* map = std::getenv("PROSPER_COMPUTE_RESOURCE_MAP")) {
+                        bool wanted_program = false;
+                        for (const char* cursor = map; cursor && *cursor;) {
+                            char* end = nullptr;
+                            const uint64_t one = std::strtoull(cursor, &end, 0);
+                            if (end == cursor) break;
+                            if (one == item.code_addr) { wanted_program = true; break; }
+                            cursor = (*end == ',') ? end + 1 : end;
+                            if (!*end) break;
+                        }
+                        if (wanted_program && item.resources) {
+                            uint64_t shape = item.resources->resources.size();
+                            for (const ShaderResource& r : item.resources->resources)
+                                shape = shape * 1000003ull + r.gpu_addr + r.size + r.binding;
+                            static std::mutex map_mutex;
+                            static std::set<std::pair<uint64_t, uint64_t>> map_logged;
+                            bool first = false;
+                            {
+                                std::lock_guard lock(map_mutex);
+                                first = map_logged.emplace(item.code_addr, shape).second;
+                            }
+                            if (first) {
+                                std::fprintf(stderr,
+                                             "[compute-resource-map] program=0x%llx submit=%llu "
+                                             "dispatch=%zu resources=%zu\n",
+                                             static_cast<unsigned long long>(item.code_addr),
+                                             static_cast<unsigned long long>(submit_no),
+                                             operation.index,
+                                             item.resources->resources.size());
+                                for (const ShaderResource& r : item.resources->resources) {
+                                    std::fprintf(stderr,
+                                                 "[compute-resource-map]   binding=%u fetch-pc=%u "
+                                                 "base=0x%llx size=%u stride=%u entries=%u\n",
+                                                 r.binding, r.fetch_pc,
+                                                 static_cast<unsigned long long>(r.gpu_addr),
+                                                 r.size, r.stride, r.table_index_count);
+                                    for (size_t e = 0; e < r.table_entries.size(); ++e)
+                                        std::fprintf(stderr,
+                                                     "[compute-resource-map]     entry=%zu "
+                                                     "base=0x%llx size=%u\n",
+                                                     e,
+                                                     static_cast<unsigned long long>(
+                                                         r.table_entries[e].gpu_addr),
+                                                     r.table_entries[e].size);
+                                }
+                            }
+                        }
+                    }
                     if (const char* watch = std::getenv("PROSPER_COMPUTE_ADDRESS_WATCH")) {
                         char* end = nullptr;
                         const uint64_t wanted = std::strtoull(watch, &end, 0);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2910,6 +2910,24 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
     // program-local and several of this title's shaders share a prologue, which makes that match
     // unreliable (#2412).
     uint32_t watch_w0 = 0, watch_w1 = 0; uint32_t watch_len = 0;
+
+    // PROSPER_DYNTRACE_SCC=1 — report every transition of the tracked SCC, with the pc and words that
+    // caused it. SCC is a single bit and it gates whole descriptors: GTA V's ray-tracing pass builds
+    // its BVH descriptor's dword3 with `s_addc_u32 s19, -1, 0`, whose operands are both inline
+    // constants, so the ONLY thing that can leave it unknown is an unknown SCC. Without this, "the
+    // descriptor did not resolve" gives no way to find which earlier instruction cost it.
+    //
+    // Deliberately mirrors the register watch, including printing the program identity rather than
+    // the sh= signature -- which is not unique (#2548).
+    const bool watch_scc = std::getenv("PROSPER_DYNTRACE_SCC") != nullptr;
+    int last_reported_scc = -2;
+    auto report_scc = [&](const char* why) {
+        if (!watch_scc || scc == last_reported_scc) return;
+        last_reported_scc = scc;
+        fprintf(stderr, "[sccwatch] program=0x%llx pc=%u scc=%s %s words=%08x:%08x len=%u\n",
+                (unsigned long long)(uintptr_t)code, watch_pc,
+                scc < 0 ? "UNKNOWN" : (scc ? "1" : "0"), why, watch_w0, watch_w1, watch_len);
+    };
     // Per-register record of the instruction that most recently made it UNKNOWN. Sized like the other
     // per-register fold state; `0xffffffff` means "never forgotten in this walk", which is a distinct
     // and useful answer from "forgotten by <instruction>" — a V# word that was never written at all
@@ -3661,6 +3679,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // tracked SCC, or a later s_cselect folds with a stale compare result.
                 if (in.opcode != kSop1OpcodeMovB32 && in.opcode != kSop1OpcodeMovB64) {
                     scc = -1;
+                    report_scc("invalidated");
                     null_count_carry_origin = 0;
                     bvh_count_carry_origin = 0;
                 }
@@ -3982,6 +4001,7 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                     case 0x0B: scc = (a <= c); break;                            // s_cmp_le_u32
                     default: scc = -1; break;
                 } else scc = -1;
+                report_scc("alu");
                 break;
             }
             case Rdna2Format::SMEM: {
@@ -5325,7 +5345,51 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                 // interpreter doesn't model the rest of SOPK, so they conservatively invalidate the
                 // tracked SCC — a stale SCC consumed by a later s_cselect would fabricate a
                 // confidently-wrong V# patch.
+                // Three SOPK encodings account for every conservative SCC loss measured on GTA V's
+                // ray-tracing pass (0x205b654a00, PROSPER_DYNTRACE_SCC), and TWO OF THEM DO NOT
+                // WRITE SCC AT ALL:
+                //
+                //   188x  s_setreg_b32     (0x13) -- writes a HARDWARE REGISTER, not SCC
+                //    43x  s_waitcnt_vscnt  (0x17, sdst=NULL) -- a wait; register-transparent
+                //    94x  s_addk_i32       (0x0f) -- genuinely writes SCC on overflow
+                //
+                // This matters because SCC gates whole descriptors here: the BVH descriptor's dword3
+                // is `s_addc_u32 s19, -1, 0`, whose operands are both inline constants, so an unknown
+                // SCC is the ONLY thing that can leave it unresolved -- and an unresolved dword3 is
+                // `mode=unresolved-operand` at the image_bvh_intersect_ray that consumes it.
+                //
+                // s_addk_i32 keeps invalidating SCC, because it really does write it. Its VALUE is
+                // now folded when the destination is known, for the same reason s_mulk_i32's is.
+                if (in.opcode == kSopkOpcodeSetregB32) {
+                    // Its encoded "dst" field is a hwreg id, not an SGPR, so nothing scalar is
+                    // written and nothing needs forgetting.
+                    break;
+                }
+                if (in.opcode == kSopkOpcodeWaitcntVscnt) {
+                    // The sibling case above already passes the sdst=NULL(125) form through. Any
+                    // other destination is unmodelled, so forget it -- but never SCC.
+                    if (in.dst.kind == OperandKind::SGPR && in.dst.value != 125)
+                        forget(in.dst.value);
+                    break;
+                }
+                if (in.opcode == kSopkOpcodeAddkI32) {
+                    if (in.dst.kind == OperandKind::SGPR) {
+                        uint32_t current = 0;
+                        if (known(in.dst.value, current))
+                            set_value(in.dst.value,
+                                      current + static_cast<uint32_t>(
+                                                    static_cast<int32_t>(in.simm16)));
+                        else
+                            forget(in.dst.value);
+                    }
+                    scc = -1;                    // s_addk_i32 writes SCC on signed overflow
+                    report_scc("sopk-addk");
+                    null_count_carry_origin = 0;
+                    bvh_count_carry_origin = 0;
+                    break;
+                }
                 scc = -1;
+                report_scc("sopk-conservative");
                 null_count_carry_origin = 0;
                 bvh_count_carry_origin = 0;
                 if (in.dst.kind == OperandKind::SGPR) forget(in.dst.value);

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -8120,7 +8120,14 @@ std::vector<ComputeItem> realize_compute_dispatches(
                 // matches a resource three ways: by fetch pc, by SRT offset, and by SGPR base; a
                 // resource carrying `srt=0xffffffff sgpr=0xffffffff` can be matched by none of them
                 // and is invisible to every lookup, however correct its address and size are.
-                if (std::getenv("PROSPER_DBG")) {
+                // Ungated. This block runs at most ONCE PER PROGRAM (it is inside
+                // report_compute_recompile_skip_once), so its cost is twelve programs' worth of
+                // lines on a routed GTA V boot -- while PROSPER_DBG, the gate it used to sit
+                // behind, produces a ~1.5 GB log and desyncs the pad script badly enough that the
+                // route never reaches the phase being diagnosed. A diagnostic reachable only by a
+                // switch that destroys the repro is not reachable. Same reasoning as the skip line
+                // itself, which was ungated for exactly this in an earlier commit.
+                {
                     if (!item.resources || item.resources->resources.empty()) {
                         std::fprintf(stderr,
                                      "[compute-table] program 0x%llx has NO resources at all\n",

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -2044,11 +2044,17 @@ bool report_compute_recompile_skip_once(RecompileDiagnosticContext diagnostic) {
         std::lock_guard lock(mutex);
         if (!logged.insert(diagnostic.program_address).second) return false;
     }
-    if (std::getenv("PROSPER_DBG"))
+    if (std::getenv("PROSPER_DBG")) {
         log_compute_recompile_skip_diagnostic(diagnostic);
-    else
-        std::fprintf(stderr, "[compute] skip unsupported program 0x%llx\n",
-                     static_cast<unsigned long long>(diagnostic.program_address));
+        return true;
+    }
+    // Name the reason, not only the address. Every skip is meant to be the next thing implemented,
+    // and until now the only way to learn why one happened was PROSPER_DBG -- which on a routed run
+    // desyncs the pad script badly enough that the route never reaches the phase being diagnosed.
+    const std::string reason = last_terminal_reject_reason(diagnostic.program_address);
+    std::fprintf(stderr, "[compute] skip unsupported program 0x%llx reason=%s\n",
+                 static_cast<unsigned long long>(diagnostic.program_address),
+                 reason.empty() ? "unrecorded" : reason.c_str());
     return true;
 }
 

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9,6 +9,7 @@
 #include "gpu_timeline.hpp"
 #include "capture_compute_policy.hpp"
 #include "compute_parent_walk.hpp"
+#include "compute_tree_watch.hpp"
 #include "videoout_present.hpp"   // present_write_frame
 #include "agc_shader_layout.hpp"  // AgcShaderHeader + build_shader_resources
 #include "pm4_registers.hpp"      // SPI_SHADER_USER_DATA_* offsets
@@ -9207,6 +9208,205 @@ RetainedComputeRealization realize_retained_compute(
     return RetainedComputeRealization::Realized;
 }
 
+// ---------------------------------------------------------------------------------------------
+// PROSPER_COMPUTE_TREE_WATCH=ADDR:RECORDS[:SHIFT:MASK]
+//
+// Address-keyed, evaluated around EVERY realized dispatch. The program-keyed parent walk above
+// answers "was the table cyclic when its consumer started"; this answers "which dispatch made it
+// cyclic", which is a different question and the one the consumer's hang depends on.
+//
+// Two comparisons per dispatch, and they are deliberately not the same comparison:
+//   pre  -- current bytes against the LAST observation, whenever that was. A change here was made
+//           by something that is not a dispatch (guest CPU, a copy, a graphics write).
+//   post -- current bytes against this dispatch's own pre-image. A change here is attributable to
+//           this dispatch, by construction.
+// Reporting them separately is what keeps "some dispatch between these two wrote it" from being
+// recorded as "this dispatch wrote it".
+//
+// The watch runs on every dispatch, not only on the programs already known to bind a range
+// containing the address, and reports `toucher=0/1` for each change. A change from a non-toucher
+// is a finding rather than noise: it means an out-of-bounds write, or a binding path the resource
+// traversal does not model. An instrument restricted to the suspects it already has cannot
+// discover that it is looking at the wrong set.
+struct LiveComputeTreeWatchState {
+    bool have_previous = false;
+    std::vector<uint32_t> previous;
+    ComputeParentWalkReport previous_report;
+    uint64_t previous_submit = 0;
+    uint64_t previous_order = 0;
+    uint64_t previous_program = 0;
+    uint64_t observations = 0;
+    uint64_t reported_changes = 0;
+};
+
+const std::optional<ComputeTreeWatchSelector>& compute_tree_watch_selector() {
+    static const auto selector = [] {
+        const char* value = std::getenv("PROSPER_COMPUTE_TREE_WATCH");
+        auto parsed = parse_compute_tree_watch_selector(value);
+        if (value && *value && !parsed)
+            std::fprintf(stderr,
+                         "[compute-tree-watch] invalid selector '%s'; expected "
+                         "ADDR:RECORDS[:SHIFT:MASK]\n",
+                         value);
+        return parsed;
+    }();
+    return selector;
+}
+
+LiveComputeTreeWatchState& compute_tree_watch_state() {
+    static LiveComputeTreeWatchState state;
+    return state;
+}
+
+// The guest allocation is the authority for what a later CPU-side read of this table sees. Reading
+// the running program's staged resource copy instead would make a pre/post pair compare two
+// different sources, which manufactures changes that nobody wrote.
+bool read_compute_tree_watch_words(const ComputeTreeWatchSelector& selector,
+                                   std::vector<uint32_t>& out) {
+    const uint64_t bytes = static_cast<uint64_t>(selector.records) * sizeof(uint32_t);
+    if (!guest_readable(selector.addr, bytes)) return false;
+    out.resize(selector.records);
+    std::memcpy(out.data(), reinterpret_cast<const void*>(static_cast<uintptr_t>(selector.addr)),
+                static_cast<size_t>(bytes));
+    return true;
+}
+
+// Name the binding and fetch pc when the running program's own table reaches the watched address.
+// A change reported with toucher=0 is the interesting case -- an out-of-bounds write, or a binding
+// path the traversal does not model -- so it must stay distinguishable from a change made by a
+// program that legitimately binds the range. Computed before the dispatch, because the ComputeItem
+// carrying the resource table is moved into the backend.
+std::string describe_compute_tree_watch_touch(const ShaderResourceTable* resources,
+                                              uint64_t wanted) {
+    if (!resources) return "toucher=0";
+    const std::vector<ComputeAddressWatchHit> hits = compute_address_watch_hits(*resources, wanted);
+    if (hits.empty()) return "toucher=0";
+    std::string touch = "toucher=1 at=";
+    for (size_t i = 0; i < hits.size(); ++i) {
+        char one[64];
+        std::snprintf(one, sizeof(one), "%s%u:%u", i ? "," : "", hits[i].binding, hits[i].fetch_pc);
+        touch += one;
+    }
+    return touch;
+}
+
+void report_compute_tree_watch(const char* phase, const ComputeTreeWatchSelector& selector,
+                               uint64_t program, const std::string& touch, uint64_t submit_no,
+                               size_t dispatch_index,
+                               uint64_t order, const std::vector<uint32_t>& before,
+                               const ComputeParentWalkReport& before_report,
+                               const std::vector<uint32_t>& after, uint64_t previous_submit,
+                               uint64_t previous_order, uint64_t previous_program,
+                               ComputeParentWalkReport& after_report) {
+    constexpr uint32_t kReportedSlots = 12;
+    uint32_t changed = 0;
+    const std::vector<ComputeTreeWatchDelta> deltas =
+        compute_tree_watch_deltas(before, after, kReportedSlots, &changed);
+    if (!changed) return;
+
+    LiveComputeTreeWatchState& state = compute_tree_watch_state();
+    ++state.reported_changes;
+
+    after_report = analyze_compute_parent_walk(after, selector.records, selector.index_shift,
+                                               selector.index_mask);
+    const ComputeTreeSiblingReport before_siblings = analyze_compute_tree_siblings(before);
+    const ComputeTreeSiblingReport after_siblings = analyze_compute_tree_siblings(after);
+    const ComputeTreeWatchTransition transition =
+        classify_compute_tree_watch_transition(before_report, after_report, true);
+
+    std::fprintf(stderr,
+                 "[compute-tree-watch] addr=0x%llx phase=%s transition=%s program=0x%llx "
+                 "submit=%llu dispatch=%zu order=%llu %s changed=%u records=%u "
+                 "pre{cycles=%u cyclic-roots=%u oob-roots=%u max-depth=%u pairs=%u unpaired=%u} "
+                 "post{cycles=%u cyclic-roots=%u oob-roots=%u max-depth=%u pairs=%u unpaired=%u} "
+                 "since{submit=%llu order=%llu program=0x%llx}\n",
+                 static_cast<unsigned long long>(selector.addr), phase,
+                 compute_tree_watch_transition_name(transition),
+                 static_cast<unsigned long long>(program),
+                 static_cast<unsigned long long>(submit_no), dispatch_index,
+                 static_cast<unsigned long long>(order), touch.c_str(), changed, selector.records,
+                 before_report.distinct_cycles, before_report.cyclic_roots,
+                 before_report.oob_roots, before_report.max_depth, before_siblings.pairs,
+                 before_siblings.unpaired_side, after_report.distinct_cycles,
+                 after_report.cyclic_roots, after_report.oob_roots, after_report.max_depth,
+                 after_siblings.pairs, after_siblings.unpaired_side,
+                 static_cast<unsigned long long>(previous_submit),
+                 static_cast<unsigned long long>(previous_order),
+                 static_cast<unsigned long long>(previous_program));
+
+    for (const ComputeTreeWatchDelta& delta : deltas)
+        std::fprintf(stderr, "[compute-tree-watch]   slot %u 0x%08x -> 0x%08x\n", delta.index,
+                     delta.before, delta.after);
+    if (changed > kReportedSlots)
+        std::fprintf(stderr, "[compute-tree-watch]   ... %u further changed slots not listed\n",
+                     changed - kReportedSlots);
+}
+
+// Returns the pre-image so the caller can hand it back for the post comparison. Empty means the
+// window was unreadable and no post comparison should be attempted -- comparing against an empty
+// pre-image would report every slot as changed.
+std::vector<uint32_t> observe_compute_tree_watch_pre(const ComputeItem& item, uint64_t submit_no,
+                                                     size_t dispatch_index, uint64_t order,
+                                                     const std::string& touch) {
+    const auto& selected = compute_tree_watch_selector();
+    if (!selected) return {};
+    std::vector<uint32_t> current;
+    if (!read_compute_tree_watch_words(*selected, current)) return {};
+
+    LiveComputeTreeWatchState& state = compute_tree_watch_state();
+    ++state.observations;
+    ComputeParentWalkReport current_report;
+    if (!state.have_previous) {
+        current_report = analyze_compute_parent_walk(current, selected->records,
+                                                     selected->index_shift, selected->index_mask);
+        const ComputeTreeSiblingReport siblings = analyze_compute_tree_siblings(current);
+        std::fprintf(stderr,
+                     "[compute-tree-watch] addr=0x%llx phase=first submit=%llu dispatch=%zu "
+                     "order=%llu records=%u cycles=%u cyclic-roots=%u oob-roots=%u max-depth=%u "
+                     "pairs=%u unpaired=%u\n",
+                     static_cast<unsigned long long>(selected->addr),
+                     static_cast<unsigned long long>(submit_no), dispatch_index,
+                     static_cast<unsigned long long>(order), selected->records,
+                     current_report.distinct_cycles, current_report.cyclic_roots,
+                     current_report.oob_roots, current_report.max_depth, siblings.pairs,
+                     siblings.unpaired_side);
+    } else {
+        current_report = state.previous_report;
+        report_compute_tree_watch("pre", *selected, item.code_addr, touch, submit_no,
+                                  dispatch_index, order,
+                                  state.previous, state.previous_report, current,
+                                  state.previous_submit, state.previous_order,
+                                  state.previous_program, current_report);
+    }
+    state.have_previous = true;
+    state.previous = current;
+    state.previous_report = current_report;
+    state.previous_submit = submit_no;
+    state.previous_order = order;
+    state.previous_program = item.code_addr;
+    return current;
+}
+
+void observe_compute_tree_watch_post(uint64_t program, const std::string& touch,
+                                     uint64_t submit_no, size_t dispatch_index, uint64_t order,
+                                     const std::vector<uint32_t>& pre_image) {
+    const auto& selected = compute_tree_watch_selector();
+    if (!selected || pre_image.empty()) return;
+    std::vector<uint32_t> current;
+    if (!read_compute_tree_watch_words(*selected, current)) return;
+
+    LiveComputeTreeWatchState& state = compute_tree_watch_state();
+    ComputeParentWalkReport after_report = state.previous_report;
+    report_compute_tree_watch("post", *selected, program, touch, submit_no, dispatch_index, order,
+                              pre_image, state.previous_report, current, submit_no, order, program,
+                              after_report);
+    state.previous = current;
+    state.previous_report = after_report;
+    state.previous_submit = submit_no;
+    state.previous_order = order;
+    state.previous_program = program;
+}
+
 struct LiveComputeParentWalkPreflight {
     bool selected = false;
     bool available = false;
@@ -9720,8 +9920,23 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                         previous_compute_executed = false;
                         break;
                     }
+                    // Pre/post around the dispatch, so a change to the watched table is
+                    // attributed to the dispatch that made it. Captured before the move: the
+                    // post observation needs the program address, and `item` is consumed below.
+                    const uint64_t tree_watch_program = item.code_addr;
+                    const std::string tree_watch_touch =
+                        compute_tree_watch_selector()
+                            ? describe_compute_tree_watch_touch(item.resources.get(),
+                                                                compute_tree_watch_selector()->addr)
+                            : std::string();
+                    const std::vector<uint32_t> tree_watch_pre =
+                        observe_compute_tree_watch_pre(item, submit_no, operation.index,
+                                                       operation.command_order, tree_watch_touch);
                     const bool executed = capture_trace
                         ? compute({item}) : compute({std::move(item)});
+                    observe_compute_tree_watch_post(tree_watch_program, tree_watch_touch, submit_no,
+                                                    operation.index, operation.command_order,
+                                                    tree_watch_pre);
                     if (capture_trace && executed)
                         capture_trace->computes.push_back(std::move(item));
                     if (capture_trace && !executed) {

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -9361,9 +9361,14 @@ bool read_compute_tree_watch_words(const ComputeTreeWatchSelector& selector,
 // program that legitimately binds the range. Computed before the dispatch, because the ComputeItem
 // carrying the resource table is moved into the backend.
 std::string describe_compute_tree_watch_touch(const ShaderResourceTable* resources,
-                                              uint64_t wanted) {
+                                              uint64_t wanted, uint64_t bytes) {
     if (!resources) return "toucher=0";
-    const std::vector<ComputeAddressWatchHit> hits = compute_address_watch_hits(*resources, wanted);
+    // WINDOW, not address. The watch detects changes anywhere in the window, so asking whether a
+    // program binds only the window's first byte makes the two halves of the instrument answer
+    // different questions -- which reported a program that binds window+128 as a non-toucher, i.e.
+    // as an out-of-bounds write that was not one.
+    const std::vector<ComputeAddressWatchHit> hits =
+        compute_address_window_hits(*resources, wanted, bytes);
     if (hits.empty()) return "toucher=0";
     std::string touch = "toucher=1 at=";
     for (size_t i = 0; i < hits.size(); ++i) {
@@ -10141,8 +10146,10 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     const ComputeLaunchDimensions tree_watch_launch = item.launch;
                     const std::string tree_watch_touch =
                         compute_tree_watch_selector()
-                            ? describe_compute_tree_watch_touch(item.resources.get(),
-                                                                compute_tree_watch_selector()->addr)
+                            ? describe_compute_tree_watch_touch(
+                                  item.resources.get(), compute_tree_watch_selector()->addr,
+                                  static_cast<uint64_t>(compute_tree_watch_selector()->records) *
+                                      sizeof(uint32_t))
                             : std::string();
                     const std::vector<uint32_t> tree_watch_pre =
                         observe_compute_tree_watch_pre(item, submit_no, operation.index,

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -7625,8 +7625,17 @@ std::vector<ComputeItem> realize_compute_dispatches(
         // preserving one native subgroup per guest wave. Keep the environment switch as an explicit
         // experiment for every other multi-wave shape; this automatic path is shader-address/title
         // independent and remains subject to all device and workgroup bounds below.
-        const bool native_multiwave_requested =
-            native_multiwave_wave_work || getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr;
+        // PROSPER_NO_NATIVE_COMPUTE_MULTIWAVE: refuse the multi-wave native contract while leaving
+        // the ordinary one-wave native path alone. The symmetric counterpart of the switch above,
+        // and it exists because the broad PROSPER_NO_NATIVE_COMPUTE_SUBGROUP is unusable as an A/B
+        // arm: on a routed GTA V run it additionally declines fifteen OTHER programs, so the program
+        // under test never dispatches and the arm returns a zero that means "never ran" rather than
+        // "ran clean". This switch changes only shaders whose workgroup spans several guest waves,
+        // which is exactly the population the multiwave lowering is responsible for.
+        const bool native_multiwave_disabled =
+            getenv("PROSPER_NO_NATIVE_COMPUTE_MULTIWAVE") != nullptr;
+        const bool native_multiwave_requested = !native_multiwave_disabled &&
+            (native_multiwave_wave_work || getenv("PROSPER_NATIVE_COMPUTE_MULTIWAVE") != nullptr);
         const bool native_subgroup_disabled =
             getenv("PROSPER_NO_NATIVE_COMPUTE_SUBGROUP") != nullptr;
         config.native_subgroup_size = select_native_compute_subgroup_size(
@@ -7649,6 +7658,27 @@ std::vector<ComputeItem> realize_compute_dispatches(
         if (getenv("PROSPER_SUBGROUP_LOG")) {
             const uint64_t local_invocations = static_cast<uint64_t>(config.local_x) *
                 config.local_y * config.local_z;
+            // Once per (program, resolved contract), not once per dispatch. Per-dispatch this line
+            // is emitted thousands of times on a routed run, and the volume is not merely untidy:
+            // it slows the subject enough to desync a timing-dependent pad script, so the route
+            // never reaches the phase you armed the diagnostic to observe. A run of this diagnostic
+            // on GTA V produced 1,464 lines and never dispatched the program under test, which made
+            // its zero read as a negative result when it was a run that never happened.
+            //
+            // Keyed on the resolved contract as well as the address, so a program whose contract
+            // legitimately changes between dispatches still reports every distinct outcome.
+            static std::mutex subgroup_log_mutex;
+            static std::set<std::pair<uint64_t, uint64_t>> subgroup_logged;
+            const uint64_t contract = (static_cast<uint64_t>(config.native_subgroup_size) << 32) |
+                                      (static_cast<uint64_t>(config.wave_size) << 8) |
+                                      (native_multiwave_requested ? 2u : 0u) |
+                                      (native_subgroup_disabled ? 1u : 0u);
+            bool first_report = false;
+            {
+                std::lock_guard lock(subgroup_log_mutex);
+                first_report = subgroup_logged.emplace(code_addr, contract).second;
+            }
+            if (first_report)
             std::fprintf(stderr,
                          "[subgroup] cs=0x%llx guest-wave=%u native=%u local=%ux%ux%u "
                          "invocations=%llu device-range=%u..%u max-wg-subgroups=%u "

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -2242,6 +2242,32 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
             }
         }
     }
+    // PROSPER_CAPTURE_MAX_SUBMITS=N — stop appending after N submits, keeping what was captured.
+    //
+    // The window is closed by a PRESENT, so it cannot end mid-burst. GTA V flips in bursts and emits
+    // its whole frame's work between two of them: with the window correctly waiting for content, one
+    // burst appended 3.3 GB and blew even the 3,072 MB maximum, so no budget setting can capture it.
+    // A submit cap bounds the bundle by CONTENT rather than by presents or bytes, which is the only
+    // one of the three the caller can reason about ("give me the first 40 submits of this frame").
+    //
+    // Stops appending rather than failing: the submits already captured are a valid, inspectable
+    // bundle, and discarding them because more arrived is the behaviour this is here to avoid.
+    static const uint64_t max_submits = [] {
+        const char* spec = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
+        if (!spec || !*spec) return uint64_t{0};
+        char* end = nullptr;
+        const unsigned long long parsed = std::strtoull(spec, &end, 0);
+        return (end && !*end && parsed) ? static_cast<uint64_t>(parsed) : uint64_t{0};
+    }();
+    if (max_submits && b.submits >= max_submits) {
+        static std::atomic<int> capped{0};
+        if (capped.fetch_add(1) < 2)
+            std::fprintf(stderr,
+                         "[grab] frame-bundle: submit cap %llu reached; further submits in this "
+                         "window are not appended\n",
+                         (unsigned long long)max_submits);
+        return;
+    }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
         b.pending_failure_error = error;
@@ -2268,7 +2294,32 @@ void interactive_frame_bundle_on_present() {
                              b.frames_seen,
                              static_cast<unsigned long long>(
                                  b.bundle.submits.back().submit_index));
-            if (b.failed || b.frames_seen >= b.frames_wanted) {   // window complete (or aborted)
+            // A window that closes having captured NOTHING is never what the caller wanted: it
+            // produces a failed grab and a message telling them to widen it by hand. Extend it
+            // until at least one submit has been captured, bounded by the same 240-present ceiling
+            // the env var accepts.
+            //
+            // This exists because the window is a PRESENT COUNT, and a present count is not a unit
+            // of time. GTA V flips in bursts -- 48 presents in 26 ms, 12 in 7 ms, against a 23/s
+            // average -- so the window's wall-clock duration is effectively random and usually far
+            // too short to contain a submit. Every frame count from 1 to 48 failed on that title
+            // while the run demonstrably rendered (#2549).
+            //
+            // Bounded, and it never SHORTENS a window: a capture that already has submits closes
+            // exactly where it did before, so titles whose present count already works are
+            // unaffected.
+            // OPT-IN. The default contract -- close after exactly `frames_wanted` presents,
+            // whatever was captured -- is deliberate and asserted by gpu_capture_bundle_roundtrip,
+            // including that an empty window reports failure promptly rather than hanging on. This
+            // does not change it.
+            constexpr uint32_t kNoSubmitPresentCeiling = 240u;
+            static const bool wait_for_submits =
+                std::getenv("PROSPER_CAPTURE_WAIT_FOR_SUBMITS") != nullptr;
+            const bool window_complete =
+                b.frames_seen >= b.frames_wanted &&
+                (!wait_for_submits || b.submits > 0 ||
+                 b.frames_seen >= kNoSubmitPresentCeiling);
+            if (b.failed || window_complete) {   // window complete (or aborted)
                 if (!b.failed && b.submits > 0) { write_path = b.current_path; write_bundle = std::move(b.bundle); }
                 else if (b.failed) {
                     std::fprintf(stderr, "[grab] frame-bundle aborted (see error above); not written\n");

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -2179,16 +2179,42 @@ std::atomic<uint64_t> g_grab_hook_not_capturing{0};
 // activity before F9 made a genuinely empty window look as though the hook had been reached during
 // it — defeating the single distinction this diagnostic exists to draw. Written and read under the
 // bundle mutex, on the same thread that opens and closes the window.
-uint64_t g_grab_hook_reached_at_open = 0;
-uint64_t g_grab_hook_inactive_at_open = 0;
-uint64_t g_grab_hook_not_capturing_at_open = 0;
-
-bool frame_bundle_submit_capped(uint64_t submits_appended, uint64_t max_submits) {
-    return max_submits != 0 && submits_appended >= max_submits;
+FrameBundleWindowCounters g_grab_hook_at_open{};
+FrameBundleWindowCounters grab_hook_totals_now() {
+    return {g_grab_hook_reached.load(std::memory_order_relaxed),
+            g_grab_hook_inactive.load(std::memory_order_relaxed),
+            g_grab_hook_not_capturing.load(std::memory_order_relaxed)};
 }
 
-uint64_t frame_bundle_window_delta(uint64_t total_now, uint64_t total_at_window_open) {
-    return total_now >= total_at_window_open ? total_now - total_at_window_open : 0;
+FrameBundleAppendOutcome frame_bundle_append_submit(
+    FrameBundleAppendState& state, const std::function<bool()>& capture_step) {
+    if (!state.capturing || state.failed) return FrameBundleAppendOutcome::NotCapturing;
+    // BEFORE the capture step, never after. Everything below this line costs a full submit capture,
+    // and a failure below it marks the whole bundle failed -- so a post-cap submit reaching it
+    // discards the very bundle the cap was asked to preserve.
+    if (state.max_submits != 0 && state.submits_appended >= state.max_submits)
+        return FrameBundleAppendOutcome::Capped;
+    if (!capture_step()) {
+        state.failed = true;
+        return FrameBundleAppendOutcome::Failed;
+    }
+    ++state.submits_appended;
+    return FrameBundleAppendOutcome::Appended;
+}
+
+void frame_bundle_open_window(FrameBundleWindowCounters& baseline,
+                              const FrameBundleWindowCounters& totals_now) {
+    baseline = totals_now;
+}
+
+FrameBundleWindowCounters frame_bundle_window_report(
+    const FrameBundleWindowCounters& totals_now, const FrameBundleWindowCounters& baseline) {
+    auto delta = [](uint64_t now, uint64_t at_open) {
+        return now >= at_open ? now - at_open : 0;
+    };
+    return {delta(totals_now.reached, baseline.reached),
+            delta(totals_now.inactive, baseline.inactive),
+            delta(totals_now.not_capturing, baseline.not_capturing)};
 }
 
 void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_no) {
@@ -2222,15 +2248,12 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
         const unsigned long long parsed = std::strtoull(spec, &end, 0);
         return (end && !*end && parsed) ? static_cast<uint64_t>(parsed) : uint64_t{0};
     }();
-    if (frame_bundle_submit_capped(b.submits, max_submits)) {
-        static std::atomic<int> capped{0};
-        if (capped.fetch_add(1) < 2)
-            std::fprintf(stderr,
-                         "[grab] frame-bundle: submit cap %llu reached; further submits in this "
-                         "window are not appended\n",
-                         (unsigned long long)max_submits);
-        return;
-    }
+    // The whole append policy runs through frame_bundle_append_submit(), with everything below
+    // supplied as the injected capture step. That is what makes the ORDERING regressable: a test
+    // hands in a step that records whether it ran, so moving the cap check below the capture inside
+    // the seam is observable rather than merely wrong.
+    FrameBundleAppendState append{b.capturing, b.failed, b.submits, max_submits};
+    const FrameBundleAppendOutcome outcome = frame_bundle_append_submit(append, [&]() -> bool {
     GpuCaptureFile capture;
     const GpuCaptureMetadata meta = runtime_capture_metadata(submit_no);
     std::string error;
@@ -2239,11 +2262,10 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     // that is still comfortably within its deduplicated frame budget.
     if (!capture_gpustate_submit(state, submit_no, meta.width, meta.height, meta, capture, error,
                                  b.max_unique_bytes)) {
-        b.failed = true;
         b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
-        return;
+        return false;
     }
     // A persistent shadow atlas may have been produced before the captured frame. Seed that
     // boundary state on the first submit only; later submits observe the replay cache updated by
@@ -2252,11 +2274,10 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     // mutated concurrently as it could from the independent present/flip thread.
     if (!b.submits && gpu_capture_ds_seed_snapshot_available() &&
         !read_all_gpu_capture_ds_seeds(capture.ds_seeds, error)) {
-        b.failed = true;
         b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: initial DS snapshot failed (%s); grab aborted\n",
                      error.c_str());
-        return;
+        return false;
     }
     // F9 is armed from a frame the user has already seen, then captures the next complete GPU frame.
     // With deferred target readback the selected scanout can have been produced before that boundary
@@ -2287,13 +2308,30 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
         }
     }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
-        b.failed = true;
         b.pending_failure_error = error;
         std::fprintf(stderr, "[grab] frame-bundle: submit %llu failed (%s); grab aborted\n",
                      static_cast<unsigned long long>(submit_no), error.c_str());
-        return;
+        return false;
     }
-    ++b.submits;
+    return true;
+    });
+    switch (outcome) {
+        case FrameBundleAppendOutcome::Capped: {
+            static std::atomic<int> capped{0};
+            if (capped.fetch_add(1) < 2)
+                std::fprintf(stderr,
+                             "[grab] frame-bundle: submit cap %llu reached; further submits in "
+                             "this window are not appended\n",
+                             (unsigned long long)max_submits);
+            break;
+        }
+        case FrameBundleAppendOutcome::NotCapturing:
+        case FrameBundleAppendOutcome::Appended:
+        case FrameBundleAppendOutcome::Failed:
+            break;
+    }
+    b.failed = append.failed;
+    b.submits = append.submits_appended;
 }
 
 // Called per present (flip): starts the frame on the first present after F9, writes it on the next.
@@ -2351,17 +2389,15 @@ void interactive_frame_bundle_on_present() {
                     // zero legitimately, and re-arming the same width is a coin flip (trap 101).
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; widen it with "
                                          "PROSPER_CAPTURE_FRAMES=N (1..240) or re-arm\n");
+                    const FrameBundleWindowCounters window =
+                        frame_bundle_window_report(grab_hook_totals_now(), g_grab_hook_at_open);
                     std::fprintf(stderr,
                                  "[grab] frame-bundle: during this window the submit hook was "
                                  "reached=%llu, %llu while inactive, %llu while not capturing; "
                                  "window was open %lld ms for %u presents\n",
-                                 (unsigned long long)frame_bundle_window_delta(
-                                     g_grab_hook_reached.load(), g_grab_hook_reached_at_open),
-                                 (unsigned long long)frame_bundle_window_delta(
-                                     g_grab_hook_inactive.load(), g_grab_hook_inactive_at_open),
-                                 (unsigned long long)frame_bundle_window_delta(
-                                     g_grab_hook_not_capturing.load(),
-                                     g_grab_hook_not_capturing_at_open),
+                                 (unsigned long long)window.reached,
+                                 (unsigned long long)window.inactive,
+                                 (unsigned long long)window.not_capturing,
                                  (long long)(std::chrono::duration_cast<std::chrono::milliseconds>(
                                      std::chrono::steady_clock::now().time_since_epoch()).count() -
                                      g_grab_window_open_ms),
@@ -2381,10 +2417,7 @@ void interactive_frame_bundle_on_present() {
             b.arm_delay_presents = 0;
             g_grab_window_open_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now().time_since_epoch()).count();
-            g_grab_hook_reached_at_open = g_grab_hook_reached.load(std::memory_order_relaxed);
-            g_grab_hook_inactive_at_open = g_grab_hook_inactive.load(std::memory_order_relaxed);
-            g_grab_hook_not_capturing_at_open =
-                g_grab_hook_not_capturing.load(std::memory_order_relaxed);
+            frame_bundle_open_window(g_grab_hook_at_open, grab_hook_totals_now());
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
             b.pending_failure_error.clear();
             // No arrow here, deliberately: " -> <path>" is reserved for a line emitted AFTER the

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -2174,6 +2174,22 @@ std::atomic<uint64_t> g_grab_hook_reached{0};
 long long g_grab_window_open_ms = 0;
 std::atomic<uint64_t> g_grab_hook_inactive{0};
 std::atomic<uint64_t> g_grab_hook_not_capturing{0};
+// Baselines taken when a capture window opens. The three counters above are process totals: they
+// accumulate from startup and were reported verbatim as evidence about one window, so ordinary
+// activity before F9 made a genuinely empty window look as though the hook had been reached during
+// it — defeating the single distinction this diagnostic exists to draw. Written and read under the
+// bundle mutex, on the same thread that opens and closes the window.
+uint64_t g_grab_hook_reached_at_open = 0;
+uint64_t g_grab_hook_inactive_at_open = 0;
+uint64_t g_grab_hook_not_capturing_at_open = 0;
+
+bool frame_bundle_submit_capped(uint64_t submits_appended, uint64_t max_submits) {
+    return max_submits != 0 && submits_appended >= max_submits;
+}
+
+uint64_t frame_bundle_window_delta(uint64_t total_now, uint64_t total_at_window_open) {
+    return total_now >= total_at_window_open ? total_now - total_at_window_open : 0;
+}
 
 void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_no) {
     g_grab_hook_reached.fetch_add(1, std::memory_order_relaxed);
@@ -2185,6 +2201,34 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     std::lock_guard<std::mutex> lk(b.mx);
     if (!b.capturing || b.failed) {
         g_grab_hook_not_capturing.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
+    // PROSPER_CAPTURE_MAX_SUBMITS=N — stop appending after N submits, keeping what was captured.
+    //
+    // The window is closed by a PRESENT, so it cannot end mid-burst. GTA V flips in bursts and emits
+    // its whole frame's work between two of them: with the window correctly waiting for content, one
+    // burst appended 3.3 GB and blew even the 3,072 MB maximum, so no budget setting can capture it.
+    // A submit cap bounds the bundle by CONTENT rather than by presents or bytes, which is the only
+    // one of the three the caller can reason about ("give me the first 40 submits of this frame").
+    //
+    // Tested BEFORE any capture work, not after. Capturing a submit and then discarding it paid the
+    // full cost of every post-cap submit, and — worse — a post-cap capture FAILURE set `b.failed`
+    // and threw away the already-valid capped bundle, which is precisely the outcome the cap exists
+    // to prevent.
+    static const uint64_t max_submits = [] {
+        const char* spec = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
+        if (!spec || !*spec) return uint64_t{0};
+        char* end = nullptr;
+        const unsigned long long parsed = std::strtoull(spec, &end, 0);
+        return (end && !*end && parsed) ? static_cast<uint64_t>(parsed) : uint64_t{0};
+    }();
+    if (frame_bundle_submit_capped(b.submits, max_submits)) {
+        static std::atomic<int> capped{0};
+        if (capped.fetch_add(1) < 2)
+            std::fprintf(stderr,
+                         "[grab] frame-bundle: submit cap %llu reached; further submits in this "
+                         "window are not appended\n",
+                         (unsigned long long)max_submits);
         return;
     }
     GpuCaptureFile capture;
@@ -2241,32 +2285,6 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
                              static_cast<unsigned long long>(scanout_addr), seed_error.c_str());
             }
         }
-    }
-    // PROSPER_CAPTURE_MAX_SUBMITS=N — stop appending after N submits, keeping what was captured.
-    //
-    // The window is closed by a PRESENT, so it cannot end mid-burst. GTA V flips in bursts and emits
-    // its whole frame's work between two of them: with the window correctly waiting for content, one
-    // burst appended 3.3 GB and blew even the 3,072 MB maximum, so no budget setting can capture it.
-    // A submit cap bounds the bundle by CONTENT rather than by presents or bytes, which is the only
-    // one of the three the caller can reason about ("give me the first 40 submits of this frame").
-    //
-    // Stops appending rather than failing: the submits already captured are a valid, inspectable
-    // bundle, and discarding them because more arrived is the behaviour this is here to avoid.
-    static const uint64_t max_submits = [] {
-        const char* spec = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
-        if (!spec || !*spec) return uint64_t{0};
-        char* end = nullptr;
-        const unsigned long long parsed = std::strtoull(spec, &end, 0);
-        return (end && !*end && parsed) ? static_cast<uint64_t>(parsed) : uint64_t{0};
-    }();
-    if (max_submits && b.submits >= max_submits) {
-        static std::atomic<int> capped{0};
-        if (capped.fetch_add(1) < 2)
-            std::fprintf(stderr,
-                         "[grab] frame-bundle: submit cap %llu reached; further submits in this "
-                         "window are not appended\n",
-                         (unsigned long long)max_submits);
-        return;
     }
     if (!append_capture_to_frame_bundle(b.bundle, capture, b.max_unique_bytes, error)) {
         b.failed = true;
@@ -2334,12 +2352,16 @@ void interactive_frame_bundle_on_present() {
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; widen it with "
                                          "PROSPER_CAPTURE_FRAMES=N (1..240) or re-arm\n");
                     std::fprintf(stderr,
-                                 "[grab] frame-bundle: submit hook reached=%llu, %llu while "
-                                 "inactive, %llu while not capturing; window was open %lld ms "
-                                 "for %u presents\n",
-                                 (unsigned long long)g_grab_hook_reached.load(),
-                                 (unsigned long long)g_grab_hook_inactive.load(),
-                                 (unsigned long long)g_grab_hook_not_capturing.load(),
+                                 "[grab] frame-bundle: during this window the submit hook was "
+                                 "reached=%llu, %llu while inactive, %llu while not capturing; "
+                                 "window was open %lld ms for %u presents\n",
+                                 (unsigned long long)frame_bundle_window_delta(
+                                     g_grab_hook_reached.load(), g_grab_hook_reached_at_open),
+                                 (unsigned long long)frame_bundle_window_delta(
+                                     g_grab_hook_inactive.load(), g_grab_hook_inactive_at_open),
+                                 (unsigned long long)frame_bundle_window_delta(
+                                     g_grab_hook_not_capturing.load(),
+                                     g_grab_hook_not_capturing_at_open),
                                  (long long)(std::chrono::duration_cast<std::chrono::milliseconds>(
                                      std::chrono::steady_clock::now().time_since_epoch()).count() -
                                      g_grab_window_open_ms),
@@ -2359,6 +2381,10 @@ void interactive_frame_bundle_on_present() {
             b.arm_delay_presents = 0;
             g_grab_window_open_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::steady_clock::now().time_since_epoch()).count();
+            g_grab_hook_reached_at_open = g_grab_hook_reached.load(std::memory_order_relaxed);
+            g_grab_hook_inactive_at_open = g_grab_hook_inactive.load(std::memory_order_relaxed);
+            g_grab_hook_not_capturing_at_open =
+                g_grab_hook_not_capturing.load(std::memory_order_relaxed);
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
             b.pending_failure_error.clear();
             // No arrow here, deliberately: " -> <path>" is reserved for a line emitted AFTER the

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -2165,11 +2165,28 @@ bool capture_bundle_trigger_file_enabled() {
 }
 
 // Called per submit: when a frame grab is in progress, append this submit's realized state to the bundle.
+// "the capture window contained no GPU submits" is reported identically whether the submit hook was
+// never reached, was reached before the window opened, or was reached and rejected -- three
+// different faults with three different fixes, and the message distinguishes none of them. On GTA V
+// the window reports zero at 1, 16 and 48 frames while the same run demonstrably renders. These
+// counters make the failure name itself.
+std::atomic<uint64_t> g_grab_hook_reached{0};
+long long g_grab_window_open_ms = 0;
+std::atomic<uint64_t> g_grab_hook_inactive{0};
+std::atomic<uint64_t> g_grab_hook_not_capturing{0};
+
 void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_no) {
-    if (!g_interactive_frame_active.load(std::memory_order_acquire)) return;
+    g_grab_hook_reached.fetch_add(1, std::memory_order_relaxed);
+    if (!g_interactive_frame_active.load(std::memory_order_acquire)) {
+        g_grab_hook_inactive.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
     InteractiveFrameBundle& b = interactive_frame_bundle();
     std::lock_guard<std::mutex> lk(b.mx);
-    if (!b.capturing || b.failed) return;
+    if (!b.capturing || b.failed) {
+        g_grab_hook_not_capturing.fetch_add(1, std::memory_order_relaxed);
+        return;
+    }
     GpuCaptureFile capture;
     const GpuCaptureMetadata meta = runtime_capture_metadata(submit_no);
     std::string error;
@@ -2265,6 +2282,17 @@ void interactive_frame_bundle_on_present() {
                     // zero legitimately, and re-arming the same width is a coin flip (trap 101).
                     std::fprintf(stderr, "[grab] frame-bundle: window had no submits; widen it with "
                                          "PROSPER_CAPTURE_FRAMES=N (1..240) or re-arm\n");
+                    std::fprintf(stderr,
+                                 "[grab] frame-bundle: submit hook reached=%llu, %llu while "
+                                 "inactive, %llu while not capturing; window was open %lld ms "
+                                 "for %u presents\n",
+                                 (unsigned long long)g_grab_hook_reached.load(),
+                                 (unsigned long long)g_grab_hook_inactive.load(),
+                                 (unsigned long long)g_grab_hook_not_capturing.load(),
+                                 (long long)(std::chrono::duration_cast<std::chrono::milliseconds>(
+                                     std::chrono::steady_clock::now().time_since_epoch()).count() -
+                                     g_grab_window_open_ms),
+                                 b.frames_seen);
                     b.outcome_pending = true; b.outcome_ok = false; b.outcome_path = b.current_path;
                     b.outcome_error = "the capture window contained no GPU submits";
                 }
@@ -2278,6 +2306,8 @@ void interactive_frame_bundle_on_present() {
         } else if (!b.armed_path.empty()) {
             b.capturing = true; b.current_path = std::move(b.armed_path); b.armed_path.clear();
             b.arm_delay_presents = 0;
+            g_grab_window_open_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now().time_since_epoch()).count();
             b.bundle = GpuCaptureBundle{}; b.submits = 0; b.frames_seen = 0; b.failed = false;
             b.pending_failure_error.clear();
             // No arrow here, deliberately: " -> <path>" is reserved for a line emitted AFTER the

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -337,6 +337,19 @@ void observe_guest_log_capture_gap();
 // the external controller moved its lever, while the one-shot state prevents a second arm.
 // Automatic trigger-file, fixed-present, and guest-log gates are mutually exclusive and fail closed
 // when more than one is configured, so one gate's completion cannot be attributed to another arm.
+// True when a submit must NOT be appended to the interactive frame bundle because the caller's
+// PROSPER_CAPTURE_MAX_SUBMITS cap is already met. Exported so the ORDERING can be regressed: the
+// submit hook must consult this before doing any capture work. Checking it afterwards meant every
+// post-cap submit paid the full capture cost, and a post-cap capture FAILURE discarded the
+// already-valid capped bundle -- the exact outcome the cap exists to prevent.
+bool frame_bundle_submit_capped(uint64_t submits_appended, uint64_t max_submits);
+
+// A hook counter scoped to ONE capture window. The underlying counters are process totals; the
+// empty-window report subtracts the value latched when the window opened. Saturating rather than
+// wrapping: if a baseline were ever missed or latched late, an unsigned wrap would print a count
+// near 2^64 and read as enormous activity, which is the opposite of the truth this line reports.
+uint64_t frame_bundle_window_delta(uint64_t total_now, uint64_t total_at_window_open);
+
 bool capture_bundle_trigger_file_enabled();
 
 } // namespace prosper::gpu

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -5,6 +5,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -337,18 +338,43 @@ void observe_guest_log_capture_gap();
 // the external controller moved its lever, while the one-shot state prevents a second arm.
 // Automatic trigger-file, fixed-present, and guest-log gates are mutually exclusive and fail closed
 // when more than one is configured, so one gate's completion cannot be attributed to another arm.
-// True when a submit must NOT be appended to the interactive frame bundle because the caller's
-// PROSPER_CAPTURE_MAX_SUBMITS cap is already met. Exported so the ORDERING can be regressed: the
-// submit hook must consult this before doing any capture work. Checking it afterwards meant every
-// post-cap submit paid the full capture cost, and a post-cap capture FAILURE discarded the
-// already-valid capped bundle -- the exact outcome the cap exists to prevent.
-bool frame_bundle_submit_capped(uint64_t submits_appended, uint64_t max_submits);
+// One submit's journey through the interactive frame bundle's append policy, with the capture step
+// INJECTED. The injection is the point: the property at stake is an ordering -- the cap must be
+// consulted before any capture work -- and an ordering cannot be regressed by a predicate that
+// merely returns the right answer. A test supplies a capture step that records whether it ran, so
+// moving the cap check below the capture inside this function makes the test fail.
+//
+// Checking the cap afterwards meant every post-cap submit paid the full capture cost, and a post-cap
+// capture FAILURE set `failed` and discarded the already-valid capped bundle -- the exact outcome
+// the cap exists to prevent.
+struct FrameBundleAppendState {
+    bool capturing = false;
+    bool failed = false;
+    uint64_t submits_appended = 0;
+    uint64_t max_submits = 0;      // 0 = uncapped
+};
+enum class FrameBundleAppendOutcome {
+    NotCapturing,   // the window is closed, or an earlier submit already failed
+    Capped,         // the cap is met: the capture step is NOT run and the bundle is left intact
+    Appended,       // the capture step ran and succeeded
+    Failed,         // the capture step ran and failed; the bundle is marked failed
+};
+FrameBundleAppendOutcome frame_bundle_append_submit(
+    FrameBundleAppendState& state, const std::function<bool()>& capture_step);
 
-// A hook counter scoped to ONE capture window. The underlying counters are process totals; the
-// empty-window report subtracts the value latched when the window opened. Saturating rather than
-// wrapping: if a baseline were ever missed or latched late, an unsigned wrap would print a count
-// near 2^64 and read as enormous activity, which is the opposite of the truth this line reports.
-uint64_t frame_bundle_window_delta(uint64_t total_now, uint64_t total_at_window_open);
+// Hook counters scoped to ONE capture window. The underlying counters are process totals, so the
+// empty-window report subtracts what was latched when the window opened.
+struct FrameBundleWindowCounters {
+    uint64_t reached = 0, inactive = 0, not_capturing = 0;
+};
+// Latches the baseline. Exported alongside the report so a mutation that drops the latch is
+// observable: the report then returns process totals instead of window activity.
+void frame_bundle_open_window(FrameBundleWindowCounters& baseline,
+                              const FrameBundleWindowCounters& totals_now);
+// Saturating: if a baseline were ever missed or latched late, an unsigned wrap would print a count
+// near 2^64 and read as enormous activity, the opposite of the truth this line reports.
+FrameBundleWindowCounters frame_bundle_window_report(
+    const FrameBundleWindowCounters& totals_now, const FrameBundleWindowCounters& baseline);
 
 bool capture_bundle_trigger_file_enabled();
 

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
@@ -796,6 +796,33 @@ bool discover_rdna2_gta5_selected_sbuffer(
     }
     DecodedBufferDescriptor selected{};
     if (!selected_sbuffer_target_descriptor(selected_words, selected)) {
+        // Dump ALL FIVE records, not only the one the contract reads. The decline says record 4 does
+        // not hold a V#; it cannot say whether that is because the SELECTOR is wrong (some other
+        // record does hold one) or because the whole outer array is stale (none does). Those need
+        // opposite fixes, and one printed record cannot distinguish them.
+        //
+        // The outer array's address changes every frame -- 0x203f2e9b38, 0x203e989b38, 0x20408c9b38
+        // across successive dispatches -- so it is a per-frame ring allocation, which makes "stale
+        // ring contents" a live possibility rather than a remote one.
+        if (report_selected_sbuffer_reject(code, "selected-vsharp-records")) {
+            for (uint32_t record = 0; record < kSelectedSbufferOuterRecords; ++record) {
+                const uint32_t offset = record * kSelectedSbufferOuterStride + 8u;
+                if (offset + sizeof(std::array<uint32_t, 4>) > outer->size) break;
+                std::array<uint32_t, 4> words{};
+                std::memcpy(words.data(), outer_bytes + offset, sizeof(words));
+                DecodedBufferDescriptor probe{};
+                const bool plausible = selected_sbuffer_target_descriptor(words, probe);
+                const DecodedBufferDescriptor raw = decode_buffer_descriptor(words.data());
+                std::fprintf(stderr,
+                             "[gta-selected-sbuffer]   record=%u@+%u words=%08x:%08x:%08x:%08x "
+                             "base=0x%llx stride=%u records=%u size=%u fmt=%u comp=%u %s\n",
+                             record, offset, words[0], words[1], words[2], words[3],
+                             static_cast<unsigned long long>(raw.base), raw.stride,
+                             raw.num_records, raw.size_bytes,
+                             static_cast<unsigned>(raw.format), raw.num_components,
+                             plausible ? "<-- MATCHES the expected target shape" : "");
+            }
+        }
         if (report_selected_sbuffer_reject(code, "selected-vsharp"))
             std::fprintf(stderr,
                          "[gta-selected-sbuffer] reject=selected-vsharp words=%08x:%08x:%08x:%08x "

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
@@ -1,4 +1,7 @@
 #include "rdna2_gta5_compute_contracts.hpp"
+#include <mutex>
+#include <set>
+#include <string>
 
 #include "agc_shader_layout.hpp"
 #include "rdna2_decode.hpp"
@@ -22,6 +25,24 @@ namespace {
 
 enum class NullableProgram : uint8_t { None, WorkgroupStore, WorkgroupProcess };
 enum class SelectedSbufferDomain : uint8_t { Reject, AllOob, Record4 };
+
+// The selected-sbuffer validator's six reject reasons were all behind PROSPER_DBG, which on a routed
+// run desyncs the pad script badly enough that the route never reaches the dispatch being validated.
+// So "this contract declined" was observable and WHY was not -- and on GTA V this contract is the
+// last thing standing between the title and its 3D world. PROSPER_GTA5_SBUFFER_REJECT=1 reports each
+// reason once per program instead, which is at most six lines for a whole run.
+//
+// The program identity is the code pointer: prosper maps guest memory directly, so it IS the guest
+// address the rest of the diagnostics print.
+inline bool report_selected_sbuffer_reject(const uint32_t* code, const char* reason) {
+    if (std::getenv("PROSPER_DBG")) return true;
+    if (!std::getenv("PROSPER_GTA5_SBUFFER_REJECT")) return false;
+    static std::mutex mutex;
+    static std::set<std::pair<uint64_t, std::string>> reported;
+    std::lock_guard lock(mutex);
+    return reported.emplace(static_cast<uint64_t>(reinterpret_cast<uintptr_t>(code)),
+                            std::string(reason)).second;
+}
 
 constexpr uint32_t kSelectedSbufferSourcePc = 70u;
 constexpr uint32_t kSelectedSbufferOuterPc = 153u;
@@ -622,7 +643,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
     }
     if (!rdna2_gta5_selected_sbuffer_launch(code, dwords, config)) {
         if (rdna2_gta5_selected_sbuffer_shader(code, dwords) &&
-            config.threads_x == kGtaSelectedSbufferThreads && std::getenv("PROSPER_DBG"))
+            config.threads_x == kGtaSelectedSbufferThreads && report_selected_sbuffer_reject(code, "launch"))
             std::fprintf(stderr,
                          "[gta-selected-sbuffer] reject=launch user=%zu local=%ux%ux%u "
                          "exact=%d threads=%ux%ux%u wave=%u tgid=%d/%d/%d tidig=%u\n",
@@ -662,7 +683,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
     }
     if (!source || !outer || !selected_sbuffer_source_shape(*source) ||
         !selected_sbuffer_outer_shape(*outer)) {
-        if (std::getenv("PROSPER_DBG"))
+        if (report_selected_sbuffer_reject(code, "resource-shape"))
             std::fprintf(stderr,
                          "[gta-selected-sbuffer] reject=resource-shape source=%p outer=%p "
                          "source-shape=%d outer-shape=%d resources=%zu "
@@ -683,7 +704,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
     }
     const SelectedSbufferDomain domain = selected_sbuffer_domain(*source);
     if (domain == SelectedSbufferDomain::Reject) {
-        if (std::getenv("PROSPER_DBG"))
+        if (report_selected_sbuffer_reject(code, "selector-domain"))
             std::fprintf(stderr, "[gta-selected-sbuffer] reject=selector-domain\n");
         return false;
     }
@@ -714,7 +735,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
 
     const uint8_t* outer_bytes = complete_resource_bytes(*outer, outer->size);
     if (!outer_bytes) {
-        if (std::getenv("PROSPER_DBG"))
+        if (report_selected_sbuffer_reject(code, "outer-unreadable"))
             std::fprintf(stderr, "[gta-selected-sbuffer] reject=outer-unreadable\n");
         return false;
     }
@@ -775,7 +796,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
     }
     DecodedBufferDescriptor selected{};
     if (!selected_sbuffer_target_descriptor(selected_words, selected)) {
-        if (std::getenv("PROSPER_DBG"))
+        if (report_selected_sbuffer_reject(code, "selected-vsharp"))
             std::fprintf(stderr,
                          "[gta-selected-sbuffer] reject=selected-vsharp words=%08x:%08x:%08x:%08x "
                          "base=0x%llx stride=%u records=%u size=%u format=%u components=%u\n",
@@ -793,7 +814,7 @@ bool discover_rdna2_gta5_selected_sbuffer(
         (target_x2 && !selected_sbuffer_target_resource(
                           *target_x2, kSelectedSbufferLoadX2Pc, selected)))
     {
-        if (std::getenv("PROSPER_DBG"))
+        if (report_selected_sbuffer_reject(code, "consumer-resource"))
             std::fprintf(stderr, "[gta-selected-sbuffer] reject=consumer-resource\n");
         return false;
     }

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
@@ -1,5 +1,6 @@
 #include "rdna2_gta5_compute_contracts.hpp"
 #include <mutex>
+#include <tuple>
 #include <map>
 #include <set>
 #include <string>
@@ -901,6 +902,35 @@ bool discover_rdna2_gta5_selected_sbuffer(
     if (!outer) return false;
     outer->selected_sbuffer_soffset = kGtaSelectedSbufferRecord4Soffset;
     outer->selected_sbuffer_words = selected_words;
+    // The ACCEPT side, which nothing reported. Every diagnostic on this contract described a
+    // DECLINE, so the descriptor it publishes on the ~93% of dispatches it accepts was invisible --
+    // and that descriptor is what the shader then reads its node records through.
+    //
+    // This matters because the proof behind it is weaker than its name: it reads the pc70 source and
+    // the 600-byte outer table through complete_resource_bytes(), i.e. the currently CPU-visible
+    // mapping, with no command-order snapshot coupling either to the bytes the GPU consumes (#2542).
+    // So an accepted descriptor can still be from the wrong epoch, and a wrong descriptor here means
+    // wrong node records downstream -- which is the measured defect.
+    //
+    // Deduped on the published descriptor, so a stable frame prints once and a CHANGE is what shows.
+    if (std::getenv("PROSPER_GTA5_SBUFFER_ACCEPT")) {
+        static std::mutex mutex;
+        static std::set<std::tuple<uint64_t, uint32_t, uint32_t>> reported;
+        bool first = false;
+        {
+            std::lock_guard lock(mutex);
+            first = reported.emplace(selected.base, selected.size_bytes, selected.stride).second;
+        }
+        if (first)
+            std::fprintf(stderr,
+                         "[gta-selected-sbuffer] ACCEPT record=4@+%u -> base=0x%llx size=%u "
+                         "stride=%u fmt=%u comps=%u words=%08x:%08x:%08x:%08x\n",
+                         kGtaSelectedSbufferRecord4Soffset + 8u,
+                         static_cast<unsigned long long>(selected.base), selected.size_bytes,
+                         selected.stride, static_cast<unsigned>(selected.format),
+                         selected.num_components, selected_words[0], selected_words[1],
+                         selected_words[2], selected_words[3]);
+    }
     return rdna2_gta5_selected_sbuffer_dispatch(code, dwords, config, resources);
 }
 

--- a/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
+++ b/prosper/src/gpu/rdna2_gta5_compute_contracts.cpp
@@ -1,5 +1,6 @@
 #include "rdna2_gta5_compute_contracts.hpp"
 #include <mutex>
+#include <map>
 #include <set>
 #include <string>
 
@@ -804,6 +805,41 @@ bool discover_rdna2_gta5_selected_sbuffer(
         // The outer array's address changes every frame -- 0x203f2e9b38, 0x203e989b38, 0x20408c9b38
         // across successive dispatches -- so it is a per-frame ring allocation, which makes "stale
         // ring contents" a live possibility rather than a remote one.
+        // The SELECTOR distribution, from the same source records the domain proof walks. The
+        // contract reads record 4 because its proof concluded every selector is 4-or-OOB; printing
+        // what the selectors actually are is what distinguishes "the proof is right and the array is
+        // something else" from "the proof is wrong".
+        if (report_selected_sbuffer_reject(code, "selector-histogram")) {
+            const uint8_t* source_bytes = source ? complete_resource_bytes(*source, source->size)
+                                                 : nullptr;
+            if (source_bytes) {
+                std::map<uint32_t, uint32_t> histogram;
+                for (uint32_t record = 0; record < kSelectedSbufferSourceRecords; ++record) {
+                    uint32_t first = 0;
+                    std::memcpy(&first, source_bytes + record * kSelectedSbufferSourceStride,
+                                sizeof(first));
+                    ++histogram[first >> 3u];
+                }
+                std::string text;
+                uint32_t shown = 0;
+                for (const auto& entry : histogram) {
+                    if (shown++ >= 12u) { text += " ..."; break; }
+                    char one[64];
+                    std::snprintf(one, sizeof(one), " %u:%u", entry.first, entry.second);
+                    text += one;
+                }
+                std::fprintf(stderr,
+                             "[gta-selected-sbuffer]   selectors distinct=%zu (selector:count)%s\n",
+                             histogram.size(), text.c_str());
+                std::fprintf(stderr,
+                             "[gta-selected-sbuffer]   record-4 selector would be %u; outer has %u "
+                             "records of %u bytes\n",
+                             kGtaSelectedSbufferRecord4Soffset / kSelectedSbufferOuterStride,
+                             kSelectedSbufferOuterRecords, kSelectedSbufferOuterStride);
+            } else {
+                std::fprintf(stderr, "[gta-selected-sbuffer]   selectors unavailable (source unreadable)\n");
+            }
+        }
         if (report_selected_sbuffer_reject(code, "selected-vsharp-records")) {
             for (uint32_t record = 0; record < kSelectedSbufferOuterRecords; ++record) {
                 const uint32_t offset = record * kSelectedSbufferOuterStride + 8u;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -3668,9 +3668,21 @@ struct SpirvCompute {
         emit_condbranch(within, active, invocation_guard_merge);
         emit_label(active);
     }
-    // --- Fragment-shader shell: vec4 outputs for the implemented MRT0/MRT1 exports. ---
+    // --- Fragment-shader shell: vec4 outputs for the MRT0..MRT7 exports. ---
+    //
+    // This array WAS sized 2, and that single number was the whole of GTA V's missing 3D world.
+    // Its G-buffer pass exports five render targets
+    // (c0=albedo c1=... c2=... c3=... c4=..., tmask=0x000fffff smask=0x0003ffff), and every part of
+    // the pipeline below the shader already carried eight: the render state decodes all eight slots,
+    // `active_color_count` scans all eight, and the backend's render pass, framebuffer and blend
+    // state are all generic over `color_count`. Only the fragment recompiler stopped at two -- so
+    // three of the five attachments were dropped, the deferred lighting pass sampled buffers nothing
+    // had written, and the world rendered into a G-buffer that was then lit by nothing.
+    //
+    // The rest of this shell was already written generically against `v_color.size()`; the size was
+    // the only thing holding it to two.
     uint32_t t_v4f = 0;
-    std::array<uint32_t, 2> v_color{};
+    std::array<uint32_t, kFragmentColorOutputs> v_color{};
     void begin_fragment(const ShaderResourceTable* rt = nullptr, uint32_t color_mask = 1u) {
         bool with_cbufs = rt != nullptr;
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
@@ -23875,7 +23887,10 @@ uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     uint32_t packed = 0;
-    std::array<bool, 2> realized{};
+    // One nibble per MRT, MRT0..MRT7. Sized 2 until 2026-08-15, which silently forced
+    // `write_mask &= 0` for slots 2..7 at gpu_execute.hpp's EXP.EN gate -- so a shader exporting to
+    // MRT2+ had those attachments dropped no matter what CB_TARGET_MASK and CB_SHADER_MASK said.
+    std::array<bool, kFragmentColorOutputs> realized{};
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::EXP || in.exp_target >= realized.size() ||
@@ -23923,7 +23938,7 @@ static std::vector<uint32_t> recompile_fragment_impl(
     for (const auto& in : ins) {
         if (in.is_end) break;
         if (in.fmt != Rdna2Format::EXP) continue;
-        if (in.exp_target < 2) color_mask |= 1u << in.exp_target;
+        if (in.exp_target < kFragmentColorOutputs) color_mask |= 1u << in.exp_target;
         else if (in.exp_target == 8 && !in.exp_compr) {
             has_depth_export |= (in.exp_en & kMrtzDepth) != 0;
             has_sample_mask_export |= (in.exp_en & kMrtzSampleMask) != 0;
@@ -24028,7 +24043,7 @@ static std::vector<uint32_t> recompile_fragment_impl(
     // skips it; the block's EXEC narrow + the export's OpKill do the per-invocation discard (#102). This is
     // NOT added for the vertex/compute shells (their scc branches are real uniform-ifs / NGG culling).
     for (uint32_t pc : mask_test_branches(ins, b.allow_b32_masks)) safe_branches.insert(pc);
-    std::array<bool, 2> exported{};
+    std::array<bool, kFragmentColorOutputs> exported{};
     auto exp_fn = [&](RegState& state, const Rdna2Inst& in) -> bool { // EXP MRT0/MRT1 -> matching output
         // An export while EXEC is narrowed (lanes killed by an alpha test / v_cmpx and not restored to
         // all-on) must not write the inactive lanes. Lower it to a real fragment discard: OpKill the lanes
@@ -24098,7 +24113,15 @@ static std::vector<uint32_t> recompile_fragment_impl(
                                      "pcrel target=%u body failed", pcrel_dispatch_target);
         return {};
     }
-    if (!exported[0] && !exported[1] && !has_null_export && !has_depth_export &&
+    // ANY colour slot counts, not just the first two. This tested `exported[0] || exported[1]` while
+    // the array was sized 2, which read as "did anything export"; once the shell carries eight
+    // outputs it silently became "did MRT0 or MRT1 export", and a shader whose only colour output is
+    // MRT2+ was rejected outright -- dropping its draws rather than its attachments. The guard's
+    // purpose is unchanged: a fragment program that emits no colour, no NULL, no depth and no sample
+    // mask is still fail-visible.
+    const bool exported_any_color =
+        std::any_of(exported.begin(), exported.end(), [](bool e) { return e; });
+    if (!exported_any_color && !has_null_export && !has_depth_export &&
         !has_sample_mask_export) {
         if (pcrel_dispatch_target != UINT32_MAX)
             log_recompile_diagnostic(diagnostic, "recompile-reject", "terminal",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -122,6 +122,12 @@ void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
 
 } // namespace
 
+void record_recompile_reject_reason_for_test(const RecompileDiagnosticContext& diagnostic,
+                                             const char* tag, const char* role,
+                                             const char* payload) {
+    log_recompile_diagnostic(diagnostic, tag, role, "%s", payload);
+}
+
 std::string last_terminal_reject_reason(uint64_t program_address) {
     std::lock_guard lock(terminal_reject_mutex());
     const auto& reasons = terminal_reject_reasons();
@@ -4685,6 +4691,17 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                     if (in.dst.value == R) continue;
                     break;
                 }
+                // Under MaskDomainOnly the whole read-modify-write SOPK family is admissible. Every
+                // SOPK operates on ONE dword: s_addk_i32/s_mulk_i32 read and rewrite their encoded
+                // destination, s_cmpk_* read it and write SCC, s_cmovk_i32 reads it and may rewrite
+                // it. All three are 32-bit scalar-DATA touches of the half; none can consume it as a
+                // 64-bit lane mask, which is the only thing this proof needs to exclude.
+                //
+                // Deliberately does NOT claim the half died, even for the forms that always write
+                // it: continuing the walk is the conservative direction, and a later genuine mask
+                // read still fails the proof. Being wrong about the kill would be unsound; being
+                // silent about it only costs acceptances.
+                if (data_read_ok && in.dst.kind == OperandKind::SGPR) break;
                 return block(in, "unmodelled-sopk");
             case Rdna2Format::SOPP:
                 // Hint/sync SOPPs read and write nothing — scan through them (s_waitcnt is ubiquitous

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -42,10 +42,44 @@ const char* recompile_diagnostic_stage_name(RecompileDiagnosticStage stage) {
 // Recompiles can run concurrently. Build the complete diagnostic on the stack and submit it through
 // one stdio call so one program's identity cannot be spliced onto another program's reject payload.
 // The context is an explicit per-call value; no global or thread-local attribution state is involved.
+// Last TERMINAL reject reason per program, recorded whether or not PROSPER_DBG is set.
+//
+// Every reject reason in this file sits behind PROSPER_DBG, and PROSPER_DBG is unusable on a routed
+// run: it produces a log large enough to desync a timing-dependent pad script, so the route never
+// reaches the phase whose rejects you wanted to read. The consequence is that
+// `[compute] skip unsupported program 0x...` has printed a bare address for the whole life of the
+// diagnostic, and the charter's rule that every skip is the next thing to implement cannot be
+// followed from it.
+//
+// Recording only the terminal role keeps this to one short string per rejected program (thirteen on
+// a 200 s GTA V route), so the map is bounded by the number of DISTINCT rejected programs rather
+// than by the number of dispatches.
+std::mutex& terminal_reject_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::map<uint64_t, std::string>& terminal_reject_reasons() {
+    static std::map<uint64_t, std::string> reasons;
+    return reasons;
+}
+
+void record_terminal_reject_reason(uint64_t program_address, const char* tag,
+                                   const char* payload) {
+    if (!program_address) return;
+    // A cap, because a pathological guest could present unboundedly many distinct programs. Losing
+    // late entries is strictly better than a diagnostic that grows without limit.
+    constexpr size_t kMaximumRecordedPrograms = 4096;
+    std::lock_guard lock(terminal_reject_mutex());
+    auto& reasons = terminal_reject_reasons();
+    if (reasons.size() >= kMaximumRecordedPrograms && !reasons.count(program_address)) return;
+    reasons[program_address] = std::string(tag) + " " + payload;
+}
+
 void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
                               const char* tag, const char* role, const char* format, ...) {
-    if (!std::getenv("PROSPER_DBG")) return;
-
+    // Formatted BEFORE the PROSPER_DBG gate: the terminal reason has to be recorded whether or not
+    // anyone is reading the verbose stream.
     char payload[1536];
     va_list args;
     va_start(args, format);
@@ -53,6 +87,15 @@ void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
     va_end(args);
     if (body < 0) return;
     payload[sizeof(payload) - 1] = '\0';
+    // Record every role EXCEPT "consequent". A consequent line only restates that an empty result
+    // was returned -- it names the effect, never the cause -- so letting it overwrite a terminal or
+    // route-decline reason would replace the answer with the question. Measured on a routed GTA V
+    // run: recording "terminal" alone left twelve of thirteen skips reading `reason=unrecorded`,
+    // because most reject sites use "route-decline".
+    if (role && std::strcmp(role, "consequent") != 0)
+        record_terminal_reject_reason(diagnostic.program_address, tag, payload);
+
+    if (!std::getenv("PROSPER_DBG")) return;
     size_t payload_size = std::strlen(payload);
     while (payload_size && (payload[payload_size - 1] == '\n' ||
                             payload[payload_size - 1] == '\r'))
@@ -78,6 +121,13 @@ void log_recompile_diagnostic(const RecompileDiagnosticContext& diagnostic,
 }
 
 } // namespace
+
+std::string last_terminal_reject_reason(uint64_t program_address) {
+    std::lock_guard lock(terminal_reject_mutex());
+    const auto& reasons = terminal_reject_reasons();
+    const auto found = reasons.find(program_address);
+    return found == reasons.end() ? std::string() : found->second;
+}
 
 void log_compute_recompile_skip_diagnostic(const RecompileDiagnosticContext& diagnostic) {
     log_recompile_diagnostic(diagnostic, "compute-recompile-reject", "consequent",

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -19620,7 +19620,11 @@ bool emit_cfg_state_machine(
                         state, in,
                         allows_compute_scalar_vcc_bridge(b));
                 if (!handled || !ok) {
-                    if (getenv("PROSPER_DBG"))
+                    // NOT gated on PROSPER_DBG. log_recompile_diagnostic gates its own PRINTING
+                    // on that variable and additionally RECORDS the reason for the unconditional
+                    // `[compute] skip unsupported program 0x… reason=…` line. An outer gate here
+                    // therefore suppressed the recording too, which is why five GTA V programs
+                    // reported reason=unrecorded while their cause existed and was formatted.
                         // The raw INSTRUCTION WORDS, because without them this line cannot be acted
                         // on. `fmt` and `op` are our decoder's own labels, so they identify the
                         // instruction only if you already trust the decode -- and a reject is
@@ -22011,7 +22015,11 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (!handled || !ok) {
                 // PROSPER_DBG (gated, off by default): report the instruction that fails recompilation —
                 // the first unsupported op / unresolved resource that makes a shader return empty.
-                if (getenv("PROSPER_DBG")) {
+                // NOT gated on PROSPER_DBG, for the reason at the CFG reject site above: the gate
+                // suppressed the RECORDING as well as the printing, and the recording is what the
+                // unconditional skip line reads. This site fires once per failing compile, so the
+                // formatting cost it now always pays is one string per rejected shader.
+                {
                     // `mode` separates the two rejections that used to print identically and want
                     // OPPOSITE work (#2412). `unknown-encoding` (handled=false) means no lowering
                     // exists — write the emitter. `unresolved-operand` (handled=true, ok=false)

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -4605,7 +4605,44 @@ uint32_t scalar_implicit_destination_read_width(const Rdna2Inst& in);
 uint32_t scalar_alu_source_words(const Rdna2Inst& in, uint32_t source);
 }
 
-inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t target, int R) {
+// What a surviving read of R is allowed to be.
+//
+// AnyRead     -- R must not be read at all before it is redefined. The original and default proof.
+// MaskDomainOnly -- R may be read as 32-bit scalar DATA, but not by a lane-mask consumer. Only
+//                meaningful for a VCC half, and only sound because prosper models a VCC half written
+//                by a B32 scalar op as scalar data with its own storage: a 32-bit read of that half
+//                reproduces the written dword exactly, while a MASK read would need the per-lane
+//                predicate the scalar model deliberately does not reconstruct.
+//
+// The distinction is 32-bit-ness, not explicitness, and that is the whole subtlety: a VOP3
+// `v_cndmask_b32 v0, v1, v2, vcc` names VCC explicitly and still reads the mask domain. Every
+// mask consumer reads the PAIR, so requiring `scalar_alu_source_words(...) == 1` excludes all of
+// them -- VOP3 cndmask, VOP3B carry-in, `s_mov_b64 exec, vcc`, and B64 mask logic alike -- without
+// enumerating them. The e32 implicit readers and the vccz/vccnz branches are rejected earlier and
+// unconditionally, so they are excluded on both paths.
+enum class ScalarMergeProof { AnyRead, MaskDomainOnly };
+
+// Why the proof failed, for the reject message. A liveness proof that reports only "failed" makes
+// every widening of it a guess: the first attempt at MaskDomainOnly did not accept the GTA V kernel
+// it was written for, and without the blocking pc there was no way to tell whether the walk stopped
+// at a mask read, a data read, or an unmodelled opcode -- three different follow-ups.
+struct ScalarMergeBlocker {
+    uint32_t pc = UINT32_MAX;
+    const char* kind = "none";
+};
+
+inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t target, int R,
+                               ScalarMergeProof proof = ScalarMergeProof::AnyRead,
+                               ScalarMergeBlocker* blocker = nullptr) {
+    const auto block = [&](const Rdna2Inst& at, const char* kind) {
+        if (blocker && blocker->pc == UINT32_MAX) { blocker->pc = at.pc; blocker->kind = kind; }
+        return false;
+    };
+    // MaskDomainOnly is a VCC-half question by construction: an ordinary SGPR has no mask domain,
+    // so the relaxation would silently become "reads are fine", which is not a proof of anything.
+    if (proof == ScalarMergeProof::MaskDomainOnly && R != 106 && R != 107)
+        return false;
+    const bool data_read_ok = proof == ScalarMergeProof::MaskDomainOnly;
     // Prove liveness over the actual scalar CFG, not just lexical order. UE4 commonly places another
     // forward EXECZ after an if/merge and only then overwrites the scratch SGPR/VCC value. A linear
     // scan used to reject that safe shape merely because it encountered the second branch. Explore
@@ -4630,8 +4667,10 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
         // SMEM carve-out needs — compilers love `s_buffer_load_dword vcc_lo, …` scratch loads).
         if (R == 106 || R == 107) {
             if (in.fmt == Rdna2Format::VOP2 &&
-                (in.opcode == 0x01 || (in.opcode >= 0x28 && in.opcode <= 0x2A))) return false;
-            if (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x06 || in.opcode == 0x07)) return false;
+                (in.opcode == 0x01 || (in.opcode >= 0x28 && in.opcode <= 0x2A)))
+                return block(in, "vop2-implicit-vcc");
+            if (in.fmt == Rdna2Format::SOPP && (in.opcode == 0x06 || in.opcode == 0x07))
+                return block(in, "vccz-branch");
         }
         switch (in.fmt) {
             // Most SOPK instructions remain fail-closed: s_addk/s_mulk/s_cmovk/s_cmpk read or
@@ -4646,7 +4685,7 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                     if (in.dst.value == R) continue;
                     break;
                 }
-                return false;
+                return block(in, "unmodelled-sopk");
             case Rdna2Format::SOPP:
                 // Hint/sync SOPPs read and write nothing — scan through them (s_waitcnt is ubiquitous
                 // after the merge). A barrier is also scalar-register-transparent; it changes only
@@ -4667,7 +4706,7 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                     }
                     continue;
                 }
-                return false;
+                return block(in, "unmodelled-sopp");
             case Rdna2Format::SMEM: {
                 // s_load/s_buffer_load: reads the SBASE pair (src[0], 2 regs) + SOFFSET (src[1]);
                 // redefines N consecutive dst SGPRs. Anything not a plain load -> bail.
@@ -4676,11 +4715,14 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                     case 0x0: case 0x8: n = 1;  break;   case 0x1: case 0x9: n = 2;  break;
                     case 0x2: case 0xA: n = 4;  break;   case 0x3: case 0xB: n = 8;  break;
                     case 0x4: case 0xC: n = 16; break;
-                    default: return false;
+                    default: return block(in, "unmodelled-smem");
                 }
-                if (in.src[0].value == R || in.src[0].value + 1 == R) return false;         // SBASE read
+                if (in.src[0].value == R || in.src[0].value + 1 == R)
+                    return block(in, "smem-sbase");                                          // SBASE read
+                // SOFFSET is one dword and is consumed as an address, never as a lane mask.
                 if ((in.src[1].kind == OperandKind::SGPR || in.src[1].kind == OperandKind::Special) &&
-                    in.src[1].value == R) return false;                                     // SOFFSET read
+                    in.src[1].value == R && !data_read_ok)
+                    return block(in, "smem-soffset");                                        // SOFFSET read
                 if (R >= in.dst.value && R < in.dst.value + (int)n) continue;  // redefined: this path is dead
                 break;
             }
@@ -4694,8 +4736,9 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                 const uint32_t implicit_read_width =
                     scalar_implicit_destination_read_width(in);
                 if (implicit_read_width && R >= in.dst.value &&
-                    R < in.dst.value + static_cast<int>(implicit_read_width))
-                    return false;
+                    R < in.dst.value + static_cast<int>(implicit_read_width) &&
+                    !(data_read_ok && implicit_read_width == 1))
+                    return block(in, "implicit-dst-rmw");
                 for (int k = 0; k < in.n_src; k++) {
                     if (in.src[k].kind != OperandKind::SGPR &&
                         in.src[k].kind != OperandKind::Special) continue;
@@ -4705,8 +4748,12 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                     const uint32_t words = scalar_alu_source_words(in, k);
                     if (words == UINT32_MAX) continue;
                     if (R >= in.src[k].value &&
-                        R < in.src[k].value + static_cast<int>(words))
-                        return false;
+                        R < in.src[k].value + static_cast<int>(words)) {
+                        // A one-dword source is a scalar-data read. Anything wider reads the pair,
+                        // which is exactly the set of lane-mask consumers.
+                        if (data_read_ok && words == 1) continue;
+                        return block(in, words == 1 ? "source-dword" : "source-pair");
+                    }
                 }
                 // A VOP3B carry-out (sdst) is a 64-bit mask write — reads none of R beyond its sources.
                 if (in.sdst.kind == OperandKind::SGPR &&
@@ -6052,11 +6099,28 @@ std::vector<ForwardIf> detect_forward_ifs(const std::vector<Rdna2Inst>& ins, boo
                     (r.dst.kind != OperandKind::SGPR && r.dst.kind != OperandKind::Special)) continue;
                 for (int vcc_half = 106; vcc_half <= 107; ++vcc_half) {
                     if (vcc_half < r.dst.value || vcc_half >= r.dst.value + (int)scalar_width) continue;
-                    if (!sgpr_dead_at_merge(ins, region_end, vcc_half)) {
+                    // PROSPER_VCC_SCALAR_DATA_MERGE=1 widens the proof from "not read" to "not read
+                    // as a lane mask". The guard this loop implements is about the MASK domain --
+                    // its own comment says so -- but the test it applies is total liveness, so a
+                    // half that survives the merge only to be read as a 32-bit scalar dword is
+                    // rejected even though the scalar model reproduces that dword exactly.
+                    //
+                    // Opt-in rather than default because the same physical pair being a mask on one
+                    // predecessor and data on another has no runtime type tag, and this file already
+                    // rejects that join deliberately. Keeping it behind a switch also makes the A/B
+                    // have a lever that can be shown to have moved, which a byte-identical module
+                    // has already cost this investigation once.
+                    static const bool relax_vcc_scalar_data =
+                        std::getenv("PROSPER_VCC_SCALAR_DATA_MERGE") != nullptr;
+                    const ScalarMergeProof proof = relax_vcc_scalar_data
+                        ? ScalarMergeProof::MaskDomainOnly : ScalarMergeProof::AnyRead;
+                    ScalarMergeBlocker blocker;
+                    if (!sgpr_dead_at_merge(ins, region_end, vcc_half, proof, &blocker)) {
                         log_recompile_diagnostic(
                             diagnostic, "compute-struct-reject", "route-decline",
-                            "execz pc=%u scalar write pc=%u leaves vcc-half s%d live at merge pc=%u",
-                            in.pc, r.pc, vcc_half, region_end);
+                            "execz pc=%u scalar write pc=%u leaves vcc-half s%d live at merge pc=%u "
+                            "blocked-by pc=%u kind=%s",
+                            in.pc, r.pc, vcc_half, region_end, blocker.pc, blocker.kind);
                         return reject();
                     }
                 }

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -455,6 +455,16 @@ bool fragment_spirv_uses_internal_gds(const std::vector<uint32_t>& spirv);
 // an attachment write mask, not a request to source disabled VGPRs; callers intersect this with the
 // fixed-function CB_TARGET_MASK/CB_SHADER_MASK before creating the Vulkan pipeline. This preserves
 // destination channels disabled by a partial export exactly as RDNA2 does.
+// Colour outputs a recompiled fragment shader can declare, MRT0..MRT7. Must equal
+// prosper::gpu::kColorTargetCount -- the render state, the pass-grouping in the live renderer and
+// the backend's render pass/blend state are all sized by that constant, and a fragment shell that
+// declares fewer silently drops the attachments above its own limit. gpu_execute.hpp static_asserts
+// the two together, since it is the translation unit that sees both.
+inline constexpr uint32_t kFragmentColorOutputs = 8;
+
+// One 4-bit EXP.EN nibble per MRT, MRT0..MRT7, from the shader's own colour exports. The live
+// executor intersects this with CB_TARGET_MASK & CB_SHADER_MASK to produce each attachment's Vulkan
+// colorWriteMask, so a slot missing here is a slot that cannot be written at all.
 uint32_t fragment_color_export_mask(const uint32_t* code, size_t dwords);
 
 // Recompile a vertex shader to a vertex SPIR-V module: v0 = gl_VertexIndex, run the VALU, and on EXP

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -118,6 +118,12 @@ void log_compute_recompile_skip_diagnostic(const RecompileDiagnosticContext& dia
 // address that nobody could act on.
 std::string last_terminal_reject_reason(uint64_t program_address);
 
+// Test-only hook: record a reject reason exactly as a compile site would, so the skip line's
+// reason plumbing can be exercised without driving a full recompile to a specific internal reject.
+void record_recompile_reject_reason_for_test(const RecompileDiagnosticContext& diagnostic,
+                                             const char* tag, const char* role,
+                                             const char* payload);
+
 // A narrowly-proven compiler-generated scalar jump table. The shader loads a uniform selector from a
 // direct constant buffer, bounds it, scales it by the 64-bit table-entry size, loads a PC-relative
 // target, and reaches it with s_setpc_b64. Arbitrary indirect control flow remains unsupported: this

--- a/prosper/src/gpu/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/rdna2_to_spirv.hpp
@@ -12,6 +12,7 @@
 // runs the translated ALU ops, then stores v[out_vgpr] to storage buffer 1 (b[gid]).
 #pragma once
 #include <array>
+#include <string>
 #include <cstdint>
 #include <cstddef>
 #include <vector>
@@ -110,6 +111,12 @@ struct RecompileDiagnosticContext {
 
 // Emit the canonical final live compute-skip diagnostic through the recompiler's atomic formatter.
 void log_compute_recompile_skip_diagnostic(const RecompileDiagnosticContext& diagnostic);
+
+// The last TERMINAL reject reason recorded for a program, or "" if none. Recorded whether or not
+// PROSPER_DBG is set, so the unconditional live skip line can name WHY a program was declined --
+// PROSPER_DBG is unusable on a routed run, which is why every skip has historically printed a bare
+// address that nobody could act on.
+std::string last_terminal_reject_reason(uint64_t program_address);
 
 // A narrowly-proven compiler-generated scalar jump table. The shader loads a uniform selector from a
 // direct constant buffer, bounds it, scales it by the 64-bit table-entry size, loads a PC-relative

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2544,6 +2544,27 @@ struct PersistentDsSampled {
     // plane (VUID-VkDescriptorImageInfo-imageView-01976).
     VkImageAspectFlagBits aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 };
+// Addresses that matched a live DS surface and were still declined, with why. Separate from the
+// counters because an aggregate names a volume, never a fix.
+inline std::unordered_map<uint64_t, std::pair<std::string, uint64_t>>& per_address_misses() {
+    static std::unordered_map<uint64_t, std::pair<std::string, uint64_t>> misses;
+    return misses;
+}
+// Is this address a depth or stencil plane of ANY retained DS surface, at any extent? Used to tell
+// "we hold nothing here" apart from "we hold it and something upstream never asked", which the
+// bridge's own counters cannot distinguish: a binding rejected by the caller's gate never reaches
+// the lookup and so is invisible to every statistic the lookup keeps.
+inline bool is_retained_ds_plane(uint64_t addr, uint32_t* w = nullptr, uint32_t* h = nullptr) {
+    if (!addr) return false;
+    for (const auto& [key, image] : persistent_ds_cache()) {
+        (void)image;
+        if (key.dr != addr && key.dw != addr && key.sr != addr && key.sw != addr) continue;
+        if (w) *w = key.w;
+        if (h) *h = key.h;
+        return true;
+    }
+    return false;
+}
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
                                                       uint32_t height,
                                                       uint32_t render_scale = 1,
@@ -2594,6 +2615,7 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
             // "the surface is here and we declined it" -- they call for opposite fixes.
             bool matched_plane = false, extent_bad = false, uninit = false;
             bool depth_req = false, stencil_req = false;
+            uint32_t cached_w = 0, cached_h = 0;
             for (const auto& [key, image] : persistent_ds_cache()) {
                 const bool d = key.dr == addr || key.dw == addr;
                 const bool st = key.sr == addr || key.sw == addr;
@@ -2602,18 +2624,47 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
                 if (!prosper::frontend::rtt_sampled_extent_compatible(
                         width, height, key.w, key.h, render_scale, normalized_sampling)) {
                     extent_bad = true;
+                    cached_w = key.w;
+                    cached_h = key.h;
                     continue;
                 }
                 if (!image.layout_initialized || !image.image) { uninit = true; continue; }
                 if (d && !image.depth_valid) depth_req = true;
                 if (st && !image.stencil_valid) stencil_req = true;
             }
-            if (!matched_plane) stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed);
-            else if (extent_bad) stats.miss_extent.fetch_add(1, std::memory_order_relaxed);
-            else if (uninit) stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed);
-            else if (stencil_req)
+            const char* why = nullptr;
+            if (!matched_plane) { stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed); }
+            else if (extent_bad) { stats.miss_extent.fetch_add(1, std::memory_order_relaxed);
+                                   why = "extent"; }
+            else if (uninit) { stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed);
+                               why = "uninitialized"; }
+            else if (stencil_req) {
                 stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed);
-            else if (depth_req) stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed);
+                why = "stencil-invalid"; }
+            else if (depth_req) { stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed);
+                                  why = "depth-invalid"; }
+            // Per-ADDRESS, because an aggregate cannot name the fix. A run reporting
+            // "depth-invalid=1089" says a thousand bindings declined; it does not say whether that
+            // is one surface declining a thousand times or a thousand surfaces declining once, and
+            // those are different defects. Only addresses that DID match a live surface are kept --
+            // the no-entry bucket is unbounded and is genuinely just "not ours".
+            if (why) {
+                static std::mutex reason_mutex;
+                std::lock_guard lock(reason_mutex);
+                auto& per = per_address_misses();
+                if (per.size() < 256 || per.count(addr)) {
+                    auto& row = per[addr];
+                    char detail[96];
+                    if (extent_bad)
+                        std::snprintf(detail, sizeof detail,
+                                      "extent (T# wants %ux%u, retained image is %ux%u)",
+                                      width, height, cached_w, cached_h);
+                    else
+                        std::snprintf(detail, sizeof detail, "%s", why);
+                    row.first = detail;
+                    ++row.second;
+                }
+            }
         }
         const uint64_t n = stats.calls.fetch_add(1) + 1;
         if ((n & (n - 1)) == 0 && n >= 1024) {
@@ -2629,6 +2680,32 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
                     (unsigned long long)stats.miss_stencil_invalid.load(),
                     (unsigned long long)stats.miss_extent.load(),
                     (unsigned long long)stats.miss_uninitialized.load());
+            std::vector<std::pair<uint64_t, std::pair<std::string, uint64_t>>> ranked;
+            {
+                static std::mutex reason_mutex_read;
+                std::lock_guard lock(reason_mutex_read);
+                for (const auto& e : per_address_misses()) ranked.push_back(e);
+            }
+            std::sort(ranked.begin(), ranked.end(),
+                      [](const auto& a, const auto& b) { return a.second.second > b.second.second; });
+            for (size_t i = 0; i < ranked.size() && i < 12; ++i)
+                fprintf(stderr, "[dsbridge]   declined addr=0x%llx reason=%s x%llu\n",
+                        (unsigned long long)ranked[i].first, ranked[i].second.first.c_str(),
+                        (unsigned long long)ranked[i].second.second);
+            // The whole retained set, because "no-entry" is the largest miss bucket and it is the
+            // one an address list cannot describe: it says an address is not a plane of anything we
+            // hold, and the useful question is then WHAT we hold. A surface the guest samples as
+            // depth that never appears here was never rendered into a retained DS image at all,
+            // which is a different defect from one we hold and decline.
+            fprintf(stderr, "[dsbridge]   retained DS surfaces: %zu\n",
+                    persistent_ds_cache().size());
+            for (const auto& [key, image] : persistent_ds_cache())
+                fprintf(stderr,
+                        "[dsbridge]     dr=0x%llx dw=0x%llx sr=0x%llx sw=0x%llx %ux%u fmt=%u "
+                        "dvalid=%d svalid=%d\n",
+                        (unsigned long long)key.dr, (unsigned long long)key.dw,
+                        (unsigned long long)key.sr, (unsigned long long)key.sw,
+                        key.w, key.h, key.fmt, (int)image.depth_valid, (int)image.stencil_valid);
         }
     }
     if (best.image) return best;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3,6 +3,7 @@
 // pixels. Used to verify recompiled shaders end-to-end (render -> readback -> pixel asserts). The
 // including test links Vulkan::Vulkan.
 #pragma once
+#include "../frontends/shared/mrt_extent.hpp"
 #include <vulkan/vulkan.h>
 #include "../src/gpu/gpu_capture.hpp"
 #include "../src/gpu/diagnostic_selectors.hpp"
@@ -273,6 +274,11 @@ struct BackendColorTarget {
     // across roughly sixteen pass groups per frame -- kept only the last group's slots 2..4.
     std::array<uint64_t, prosper::gpu::kColorTargetCount> persistent_id_slots{};
     std::array<bool, prosper::gpu::kColorTargetCount> load_existing_slots{};
+    // Per-slot twin of `readback`/`readback1`. Defaults to true so every existing caller keeps its
+    // pixels; the depth-feedback splitter turns it off for non-final segments, which otherwise pay a
+    // full-extent copy per slot per segment purely because `color_count > 2` forces a readback.
+    std::array<bool, prosper::gpu::kColorTargetCount> readback_slots{
+        true, true, true, true, true, true, true, true};
 };
 
 // Optional complete-MRT readback contract. `color_count` is the active Vulkan attachment prefix
@@ -5560,11 +5566,26 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             upload.borrowed_compute_lease = r.borrowed_compute_image_lease;
                         }
 
-                        const bool target_feedback =
-                            (persistent_color &&
-                             r.persistent_render_target_id == color_target->persistent_id) ||
-                            (persistent_color1 &&
-                             r.persistent_render_target_id == color_target->persistent_id1);
+                        // Every ACTIVE bound slot, not just 0 and 1. A higher slot's image is now
+                        // persistent and SAMPLED-capable, so without this a draw sampling an active
+                        // MRT2+ target borrows the very same VkImage as both descriptor and colour
+                        // attachment -- bypassing the established CPU fallback and using one image
+                        // as shader-read and colour-attachment simultaneously.
+                        const bool target_feedback = [&] {
+                            if (!color_target || !r.persistent_render_target_id) return false;
+                            uint64_t bases[prosper::gpu::kColorTargetCount]{};
+                            bool active[prosper::gpu::kColorTargetCount]{};
+                            bases[0] = color_target->persistent_id;
+                            active[0] = persistent_color;
+                            bases[1] = color_target->persistent_id1;
+                            active[1] = persistent_color1;
+                            for (uint32_t slot = 2; slot < color_count; ++slot) {
+                                bases[slot] = color_target->persistent_id_slots[slot];
+                                active[slot] = cached_extra[slot] != nullptr;
+                            }
+                            return prosper::frontend::mrt_target_feedback(
+                                bases, active, color_count, r.persistent_render_target_id);
+                        }();
                         if (!upload.borrowed_compute && !r.is_storage_image &&
                             persistent_color_targets_enabled && !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
@@ -6390,8 +6411,16 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // and there is no else). That is up to 8 MB copied and discarded per pass.
     const bool readback_color0 = want_color_readback && readback_color0_wanted;
     const bool readback_color1 = want_color_readback && readback_color1_wanted;
+    // Slots 2+ ask per slot, exactly as slots 0 and 1 do. `color_count > 2` alone would force a
+    // readback of every higher slot on every segment of a split pass, including the ones whose
+    // pixels are thrown away.
+    const bool readback_extra_wanted = [&] {
+        for (uint32_t slot = 2; slot < color_count; ++slot)
+            if (!color_target || color_target->readback_slots[slot]) return true;
+        return false;
+    }();
     const bool readback_requested = readback_color0 || readback_color1 ||
-                                    (want_color_readback && color_count > 2);
+                                    (want_color_readback && readback_extra_wanted);
     const bool storage_writeback_requested = std::any_of(
         texture_uploads.begin(), texture_uploads.end(),
         [](const SharedTextureUpload& upload) {
@@ -6965,6 +6994,16 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     };
     publish_persistent_color(persistent_color, readback_color0, img);
     publish_persistent_color(persistent_color1, readback_color1, img1);
+    // Retained higher slots need the same availability/visibility barrier when no readback copy
+    // performed it. Keyed on whether THIS slot's readback path actually ran, since the new public
+    // contract admits want_color_readback=false and per-slot readback_slots -- in those branches a
+    // persistent slot 2+ would otherwise reach SHADER_READ_ONLY_OPTIMAL with no barrier making its
+    // writes visible to a later command buffer that samples or LOADs it.
+    for (uint32_t slot = 2; slot < color_count; ++slot)
+        publish_persistent_color(
+            cached_extra[slot] != nullptr,
+            readback_requested && (!color_target || color_target->readback_slots[slot]),
+            extra_images[slot]);
     if (persistent_ds) {
         VkImageMemoryBarrier ds_ready{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         ds_ready.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -7074,7 +7113,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         transition_color_to_readback(persistent_color, readback_color0, img);
         transition_color_to_readback(persistent_color1, readback_color1, img1);
         for (uint32_t slot = 2; slot < color_count; ++slot)
-            transition_color_to_readback(cached_extra[slot] != nullptr, true, extra_images[slot]);
+            transition_color_to_readback(
+                cached_extra[slot] != nullptr,
+                !color_target || color_target->readback_slots[slot], extra_images[slot]);
         VkBufferImageCopy cp{};
         cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         cp.imageExtent = {W, H, 1};
@@ -7087,6 +7128,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 cmd, img1, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, rb, 1, &cp1);
         }
         for (uint32_t slot = 2; slot < color_count; ++slot) {
+            if (color_target && !color_target->readback_slots[slot]) continue;
             VkBufferImageCopy extra_copy = cp;
             extra_copy.bufferOffset = color_offsets[slot];
             vkCmdCopyImageToBuffer(cmd, extra_images[slot],
@@ -7113,7 +7155,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         restore_persistent_color(persistent_color, readback_color0, img);
         restore_persistent_color(persistent_color1, readback_color1, img1);
         for (uint32_t slot = 2; slot < color_count; ++slot)
-            restore_persistent_color(cached_extra[slot] != nullptr, true, extra_images[slot]);
+            restore_persistent_color(
+                cached_extra[slot] != nullptr,
+                !color_target || color_target->readback_slots[slot], extra_images[slot]);
     }
     if (timing_enabled && flush_now)
         active_submission.end_gpu_timestamp(cmd);
@@ -7463,10 +7507,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 readback + static_cast<size_t>(color_offsets[1]),
                 readback + static_cast<size_t>(color_offsets[1] + color_bytes[1]));
         if (mrt_outputs)
-            for (uint32_t slot = 2; slot < color_count; ++slot)
+            for (uint32_t slot = 2; slot < color_count; ++slot) {
+                if (color_target && !color_target->readback_slots[slot]) continue;
                 mrt_outputs->colors[slot].assign(
                     readback + static_cast<size_t>(color_offsets[slot]),
                     readback + static_cast<size_t>(color_offsets[slot] + color_bytes[slot]));
+            }
         vkUnmapMemory(dev, bmem);
         color_target_stats.readbacks = persistent_color ? 1 : 0;
     }
@@ -7976,6 +8022,47 @@ inline size_t depth_feedback_split_index(std::span<const BackendDraw> draws,
     return draws.size();
 }
 
+// The contract one SEGMENT of a depth-feedback-split pass renders under.
+//
+// Extracted so the segment decisions are testable at the site that makes them. Every field here was
+// once derived inline, and two of them were wrong in ways no end-to-end assertion caught: non-final
+// segments were handed `mrt_outputs == nullptr`, so their colour_count collapsed to one attachment
+// and every MRT1..7 export in them was discarded; and later segments never asked to LOAD the higher
+// slots, so a fresh slot cleared at the second segment.
+//
+// The invariant the tests pin: the SHAPE is identical across segments and only the pixel
+// destination and the load/readback flags differ.
+struct SplitSegmentContract {
+    BackendColorTarget target{};
+    uint32_t color_count = 1;
+    bool has_target = false;
+};
+inline SplitSegmentContract split_segment_contract(const BackendColorTarget* whole,
+                                                   const BackendMrtOutputs* whole_mrt,
+                                                   bool first, bool final) {
+    SplitSegmentContract out;
+    // The attachment shape never varies by segment. A pass is five-MRT for all of its segments or
+    // none of them; splitting is a synchronisation boundary, not a change of render target.
+    out.color_count = whole_mrt ? whole_mrt->color_count : 1u;
+    if (!whole) return out;
+    out.target = *whole;
+    out.has_target = true;
+    if (!first) {
+        // Every later segment LOADS everything, or it erases what its predecessors drew.
+        out.target.load_existing = true;
+        out.target.load_existing1 = true;
+        out.target.load_existing_slots.fill(true);
+    }
+    if (!final) {
+        // A non-final segment's pixels are discarded, so do not copy them out. Slots 2+ must say so
+        // per slot: `color_count > 2` alone forces a readback regardless of the slot-0/1 flags.
+        out.target.readback = false;
+        out.target.readback1 = false;
+        out.target.readback_slots.fill(false);
+    }
+    return out;
+}
+
 // Logical multi-draw entry. Most calls remain one Vulkan render pass. A depth feedback transition
 // becomes multiple ordered passes without copying the (often large) BackendDraw shader/resource
 // payloads. Intermediate color is retained on the GPU when possible and carried through CPU pixels
@@ -8120,29 +8207,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const size_t end = begin + relative_end;
         const bool final = end == all.size();
 
-        BackendColorTarget segment_target{};
-        const BackendColorTarget* segment_target_ptr = nullptr;
-        if (color_target) {
-            segment_target = *color_target;
-            if (begin) {
-                segment_target.load_existing = true;
-                segment_target.load_existing1 = true;
-            }
-            if (!final) {
-                segment_target.readback = false;
-                segment_target.readback1 = false;
-            }
-            segment_target_ptr = &segment_target;
-        }
+        const SplitSegmentContract segment =
+            split_segment_contract(color_target, mrt_outputs, begin == 0, final);
+        const BackendColorTarget* segment_target_ptr =
+            segment.has_target ? &segment.target : nullptr;
         std::vector<uint8_t> intermediate_color1;
         std::vector<uint8_t>* segment_out1 = out_rgba1
             ? (final ? out_rgba1 : &intermediate_color1) : nullptr;
+        // The shape travels with every segment; only the pixel destination differs.
+        BackendMrtOutputs intermediate_mrt;
+        intermediate_mrt.color_count = segment.color_count;
+        BackendMrtOutputs* segment_mrt = mrt_outputs
+            ? (final ? mrt_outputs : &intermediate_mrt) : nullptr;
         std::vector<uint8_t> rendered = render_draw_pass_rgba(
             all.subspan(begin, end - begin), W, H, next_seed0,
             begin ? nullptr : clear_rgba, true, segment_target_ptr, next_seed1,
             begin ? nullptr : clear_rgba1, segment_out1, submission_batch,
             final ? flush_submission_batch : false, all,
-            final ? mrt_outputs : nullptr, want_color_readback);
+            segment_mrt, want_color_readback);
         add_stats();
 
         if (final) {

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -8154,11 +8154,24 @@ inline SplitSegmentContract split_segment_contract(
         if (carried_slots[1]) out.target.seed_rgba1_slot = carried_slots[1];
     }
     if (!final) {
-        // A non-final segment's pixels are discarded, so do not copy them out. Slots 2+ must say so
-        // per slot: `color_count > 2` alone forces a readback regardless of the slot-0/1 flags.
+        // A non-final segment's slot-0 pixels are discarded, so do not copy them out.
         out.target.readback = false;
         out.target.readback1 = false;
         out.target.readback_slots.fill(false);
+        // ...but every slot this segment may have to CARRY must be copied out, or there is nothing
+        // to seed the next segment with. That is slot 1 (which the live renderer takes through
+        // BackendMrtOutputs) and every active slot 2+, unconditionally: whether a slot's image
+        // actually survives depends on persistent_color_targets_enabled and on a cache/budget
+        // allocation that can fall back to a transient image while leaving the identity non-zero,
+        // and none of that is visible from here.
+        //
+        // Decided HERE rather than by the caller amending the result. It was written as an
+        // override immediately after this function returned, which left the helper's own test
+        // asserting `non-final segments read back no slot` -- the exact opposite of the effective
+        // contract, in the test whose job is to document it.
+        for (uint32_t slot = 2; slot < out.color_count; ++slot)
+            out.target.readback_slots[slot] = true;
+        if (out.color_count > 1) out.target.readback1 = true;
     }
     return out;
 }
@@ -8309,31 +8322,13 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const size_t end = begin + relative_end;
         const bool final = end == all.size();
 
-        SplitSegmentContract segment = split_segment_contract(
+        const SplitSegmentContract segment = split_segment_contract(
             color_target, mrt_outputs, begin == 0, final, carried_slot_ptrs);
         const BackendColorTarget* segment_target_ptr =
             segment.has_target ? &segment.target : nullptr;
         std::vector<uint8_t> intermediate_color1;
         std::vector<uint8_t>* segment_out1 = out_rgba1
             ? (final ? out_rgba1 : &intermediate_color1) : nullptr;
-        // A non-final segment READS BACK every slot it may have to carry, unconditionally.
-        //
-        // Keying this on a non-zero persistent identity was wrong: persistence also requires
-        // persistent_color_targets_enabled and a successful cache/budget allocation, and the
-        // slot-creation path falls back to a transient image while leaving the identity non-zero.
-        // In any of those cases the identity says "retained" and the image is not, no bytes are
-        // captured, and the next segment starts from a cleared attachment. The wrapper cannot see
-        // those decisions, so it does not try to predict them -- it captures, which is correct when
-        // the image was transient and merely redundant when it survived. Split passes are rare;
-        // silently losing an attachment is not a price worth paying to avoid a copy on one.
-        if (!final && segment.has_target) {
-            for (uint32_t slot = 2; slot < segment.color_count; ++slot)
-                segment.target.readback_slots[slot] = true;
-            // Slot 1 travels through whichever output API the caller chose. `out_rgba1` is the
-            // legacy one; the live renderer takes slot 1 through BackendMrtOutputs, and on that
-            // path the readback landed in intermediate_mrt.colors[1] with nothing carrying it.
-            if (segment.color_count > 1) segment.target.readback1 = true;
-        }
         // The shape travels with every segment; only the pixel destination differs.
         BackendMrtOutputs intermediate_mrt;
         intermediate_mrt.color_count = segment.color_count;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2527,11 +2527,22 @@ persistent_ds_cache() {
 // memory. Resolve that address (read or write base — the guest aliases both at the same plane) to
 // the retained image so the consumer can bind it directly. Extent must match the T# exactly; only
 // a valid, initialized depth plane may be sampled.
+// The STENCIL plane is bridged on the same terms (2026-08-15). A combined depth/stencil surface has
+// two guest bases: the key's dr/dw name the depth plane and its sr/sw name the stencil plane, and a
+// guest T# addresses whichever plane it samples. Matching only dr/dw left every stencil sample
+// falling through to a guest-byte decode of memory the renderer never writes — zeros — which is
+// #1275's exact failure mode on the other plane. Grand Theft Auto V samples both planes of one
+// 3840x2160 D32_SFLOAT_S8_UINT surface (dr=dw=0x2052ac0000, sr=sw=0x2054aa0000), declaring the
+// depth plane Float32 and the stencil plane Uint8, which is what a deferred renderer's material and
+// light-volume classification reads.
 struct PersistentDsSampled {
     PersistentDsImage* image = nullptr;
     VkFormat format = VK_FORMAT_UNDEFINED;
     uint32_t width = 0;
     uint32_t height = 0;
+    // Exactly one of DEPTH/STENCIL: a sampled-image view of a combined format may expose only one
+    // plane (VUID-VkDescriptorImageInfo-imageView-01976).
+    VkImageAspectFlagBits aspect = VK_IMAGE_ASPECT_DEPTH_BIT;
 };
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
                                                       uint32_t height,
@@ -2547,34 +2558,80 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
         if (!prosper::frontend::rtt_sampled_extent_compatible(
                 width, height, key.w, key.h, render_scale, normalized_sampling))
             continue;
-        if (key.dr != addr && key.dw != addr) continue;
-        if (!image.depth_valid || !image.layout_initialized || !image.image) continue;
+        const bool is_depth_plane = key.dr == addr || key.dw == addr;
+        const bool is_stencil_plane = key.sr == addr || key.sw == addr;
+        // A surface whose depth and stencil bases coincide cannot be disambiguated by address, so
+        // resolve it as depth — the historical behaviour, and the only plane #1275 ever bridged.
+        if (!is_depth_plane && !is_stencil_plane) continue;
+        if (!image.layout_initialized || !image.image) continue;
+        if (is_depth_plane ? !image.depth_valid : !image.stencil_valid) continue;
         if (!best.image || image.last_depth_write > best_write) {
-            best = {&image, static_cast<VkFormat>(key.fmt), key.w, key.h};
+            best = {&image, static_cast<VkFormat>(key.fmt), key.w, key.h,
+                    is_depth_plane ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_STENCIL_BIT};
             best_write = image.last_depth_write;
         }
     }
-    if (best.image) {
-        if (bridge_log) {
-            static int hits = 0;
-            if (hits++ < 8)
-                fprintf(stderr, "[dsbridge] HIT addr=0x%llx requested=%ux%u image=%ux%u fmt=%u\n",
-                        (unsigned long long)addr, width, height, best.width, best.height,
-                        (unsigned)best.format);
-        }
-        return best;
-    }
+    // Counters, not first-N samples. The old logging printed the first eight hits and the first
+    // eight misses, which on a routed boot are all consumed by one plane during startup -- so it
+    // could not answer "how often does this miss, and why", which is the only question worth asking
+    // of a bridge. Reported at powers of two so a long run stays readable.
     if (bridge_log) {
-        static int misses = 0;
-        if (misses++ < 8) {
-            fprintf(stderr, "[dsbridge] miss addr=0x%llx %ux%u; cache:\n",
-                    (unsigned long long)addr, width, height);
-            for (const auto& [key, image] : persistent_ds_cache())
-                fprintf(stderr, "[dsbridge]   dr=0x%llx dw=0x%llx %ux%u fmt=%u dvalid=%d init=%d\n",
-                        (unsigned long long)key.dr, (unsigned long long)key.dw, key.w, key.h,
-                        key.fmt, (int)image.depth_valid, (int)image.layout_initialized);
+        struct DsBridgeStats {
+            std::atomic<uint64_t> calls{0};
+            std::atomic<uint64_t> hit_depth{0}, hit_stencil{0};
+            std::atomic<uint64_t> miss_no_entry{0};       // address is not a plane of any live DS
+            std::atomic<uint64_t> miss_depth_invalid{0};  // plane matched, aspect not valid
+            std::atomic<uint64_t> miss_stencil_invalid{0};
+            std::atomic<uint64_t> miss_extent{0};         // plane matched, extent incompatible
+            std::atomic<uint64_t> miss_uninitialized{0};
+        };
+        static DsBridgeStats stats;
+        if (best.image) {
+            (best.aspect == VK_IMAGE_ASPECT_STENCIL_BIT ? stats.hit_stencil : stats.hit_depth)
+                .fetch_add(1, std::memory_order_relaxed);
+        } else {
+            // Classify the miss against the cache, so "no such surface" is never confused with
+            // "the surface is here and we declined it" -- they call for opposite fixes.
+            bool matched_plane = false, extent_bad = false, uninit = false;
+            bool depth_req = false, stencil_req = false;
+            for (const auto& [key, image] : persistent_ds_cache()) {
+                const bool d = key.dr == addr || key.dw == addr;
+                const bool st = key.sr == addr || key.sw == addr;
+                if (!d && !st) continue;
+                matched_plane = true;
+                if (!prosper::frontend::rtt_sampled_extent_compatible(
+                        width, height, key.w, key.h, render_scale, normalized_sampling)) {
+                    extent_bad = true;
+                    continue;
+                }
+                if (!image.layout_initialized || !image.image) { uninit = true; continue; }
+                if (d && !image.depth_valid) depth_req = true;
+                if (st && !image.stencil_valid) stencil_req = true;
+            }
+            if (!matched_plane) stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed);
+            else if (extent_bad) stats.miss_extent.fetch_add(1, std::memory_order_relaxed);
+            else if (uninit) stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed);
+            else if (stencil_req)
+                stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed);
+            else if (depth_req) stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed);
+        }
+        const uint64_t n = stats.calls.fetch_add(1) + 1;
+        if ((n & (n - 1)) == 0 && n >= 1024) {
+            fprintf(stderr,
+                    "[dsbridge] calls=%llu hit(depth=%llu stencil=%llu) "
+                    "miss(no-entry=%llu depth-invalid=%llu stencil-invalid=%llu "
+                    "extent=%llu uninit=%llu)\n",
+                    (unsigned long long)n,
+                    (unsigned long long)stats.hit_depth.load(),
+                    (unsigned long long)stats.hit_stencil.load(),
+                    (unsigned long long)stats.miss_no_entry.load(),
+                    (unsigned long long)stats.miss_depth_invalid.load(),
+                    (unsigned long long)stats.miss_stencil_invalid.load(),
+                    (unsigned long long)stats.miss_extent.load(),
+                    (unsigned long long)stats.miss_uninitialized.load());
         }
     }
+    if (best.image) return best;
     return {};
 }
 
@@ -4099,6 +4156,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // the DEPTH aspect of ds_format, and the call transitions the image DS-attachment ->
         // shader-read around its passes.
         bool borrowed_ds = false;
+        bool borrowed_ds_stencil = false;   // sample the stencil plane rather than the depth plane
         bool borrowed_ds_feedback = false; // same image is this pass's read-only depth attachment
         VkFormat ds_format = VK_FORMAT_UNDEFINED;
         bool direct_memory = false;
@@ -5319,6 +5377,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 upload.borrowed_ds = true;
                                 upload.borrowed_ds_feedback = same_pass_feedback;
                                 upload.ds_format = sampled_ds.format;
+                                upload.borrowed_ds_stencil =
+                                    sampled_ds.aspect == VK_IMAGE_ASPECT_STENCIL_BIT;
                             }
                         }
                         upload.persistent_id =
@@ -5523,8 +5583,15 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                     // depth format's DEPTH aspect (one level — DS surfaces have no mip chains here);
                     // the sampled value arrives in R. The T# swizzle above still applies.
                     if (upload.borrowed_ds) {
+                        // The view format stays the image's combined DS format -- a depth/stencil
+                        // image admits no format reinterpretation -- and the aspect mask alone
+                        // selects the plane. Exactly one aspect, as a sampled view of a combined
+                        // format requires (VUID-VkDescriptorImageInfo-imageView-01976).
                         tvci.format = upload.ds_format;
-                        tvci.subresourceRange = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1};
+                        tvci.subresourceRange = {
+                            upload.borrowed_ds_stencil ? VK_IMAGE_ASPECT_STENCIL_BIT
+                                                       : VK_IMAGE_ASPECT_DEPTH_BIT,
+                            0, 1, 0, 1};
                     }
                     VkSamplerCreateInfo sci{VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO};
                     // Honor the game's decoded S# (r.mag/min/mip_filter, r.addr_uvw) instead of a fixed

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3333,7 +3333,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     if (mrt_outputs)
         for (auto& color : mrt_outputs->colors) color.clear();
     if (draws.empty()) return out;
-    for (const BackendDraw& draw : draws)
+    // PROSPER_RENDER_DROP_UNPROVEN_DRAW=1 — DIAGNOSTIC. Discard only the draw carrying an
+    // unproven resource instead of the whole batch.
+    //
+    // The default below returns an EMPTY batch: one resource failing its contract drops every draw
+    // submitted alongside it. That is deliberately conservative, and its blast radius has never been
+    // measured. On GTA V exactly one binding fails -- set=1 binding=46, a WRITABLE portable-uvec4
+    // storage image, with compression, arraying, multisampling and dimensions all fine -- and the
+    // question of whether that single unsupported resource is what removes the 3D world cannot be
+    // answered without separating "this resource is unusable" from "this frame renders nothing".
+    //
+    // Diagnostic, not a fix: dropping the draw still loses whatever it would have written, and the
+    // real work is supporting writable portable-uvec4 storage images. It exists to make the blast
+    // radius measurable.
+    const bool drop_only_unproven_draw =
+        getenv("PROSPER_RENDER_DROP_UNPROVEN_DRAW") != nullptr;
+    std::vector<const BackendDraw*> proven_draws;
+    proven_draws.reserve(draws.size());
+    for (const BackendDraw& draw : draws) {
+        bool draw_proven = true;
         for (const FrameResource& resource : draw.R)
             if (!backend_texture_plane_span_valid(resource) ||
                 !backend_storage_image_numeric_contract_valid(resource)) {
@@ -3349,8 +3367,26 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             static_cast<int>(backend_color_format(resource.texture_format)),
                             resource.storage_image_contract_valid ? 1u : 0u);
                 }
-                return out;
+                draw_proven = false;
+                break;
             }
+        if (draw_proven) proven_draws.push_back(&draw);
+        else if (!drop_only_unproven_draw) return out;
+    }
+    std::vector<BackendDraw> proven_storage;
+    if (drop_only_unproven_draw && proven_draws.size() != draws.size()) {
+        static uint32_t dropped_reports = 0;
+        if (dropped_reports++ < 16u)
+            std::fprintf(stderr,
+                         "[render] DROP_UNPROVEN_DRAW: kept %zu of %zu draws in this batch\n",
+                         proven_draws.size(), draws.size());
+        if (proven_draws.empty()) return out;
+        proven_storage.reserve(proven_draws.size());
+        for (const BackendDraw* draw : proven_draws) proven_storage.push_back(*draw);
+        // `draws` is a by-value span; rebinding it keeps every downstream use unchanged.
+        // proven_storage outlives that use because it is declared in this scope.
+        draws = std::span<const BackendDraw>(proven_storage);
+    }
     if (backend_has_unproven_submission()) return out;
     const RenderVkCtx& ctx = render_vk_ctx();
     if (!ctx.ok) return out;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2445,21 +2445,48 @@ inline RenderHostBufferPoolStats render_host_buffer_pool_stats() {
     return {pool.cached_bytes, pool.cached_buffers, pool.hits, pool.misses, pool.evictions};
 }
 
+// A depth/stencil surface's identity includes WHICH ARRAY SLICE the attachment view selects, not
+// only its allocation bases. A cube shadow map is ONE six-layer guest allocation: all six faces share
+// a base and the guest picks the face with DB_DEPTH_VIEW.SLICE_START/MAX, programming
+// 0x02000000, 0x02002001, 0x02004002 … 0x0200a005 for slices 0..5 against the same base (GTA V,
+// verified per-cube on a live route).
+//
+// Omitting the slice made every face of a cube collide on one key, so each face render REUSED and
+// overwrote the previous face's host image and only the last face survived. That is a corruption of
+// retained depth, independent of whether anything samples it: no consumer could recover a valid cube
+// from the cache however the sampling gate were relaxed.
+//
+// Non-layered surfaces program DB_DEPTH_VIEW=0 and therefore key at slice 0 exactly as before, so
+// this widens identity only where the guest actually used layers.
 struct PersistentDsKey {
     uint64_t dr = 0, dw = 0, sr = 0, sw = 0, htile = 0;
-    uint32_t w = 0, h = 0, fmt = 0;
+    uint32_t w = 0, h = 0, fmt = 0, slice = 0;
     bool operator==(const PersistentDsKey& o) const {
         return dr == o.dr && dw == o.dw && sr == o.sr && sw == o.sw && htile == o.htile &&
-               w == o.w && h == o.h && fmt == o.fmt;
+               w == o.w && h == o.h && fmt == o.fmt && slice == o.slice;
     }
 };
+
+// DB_DEPTH_VIEW.SLICE_START, including its two high bits (SLICE_START occupies bits 0..10 with
+// SLICE_START_HI at 11..12; SLICE_MAX is bits 13..23). A single-face attachment programs
+// START == MAX, which is what a cube face render does.
+inline uint32_t ds_depth_view_slice_start(uint32_t db_depth_view) {
+    return (db_depth_view & prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_MASK) |
+           (((db_depth_view >> prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_HI_SHIFT) &
+             prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_HI_MASK)
+            << prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_HI_SHIFT);
+}
+inline uint32_t ds_depth_view_slice_max(uint32_t db_depth_view) {
+    return (db_depth_view >> prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_MAX_SHIFT) &
+           prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_MAX_MASK;
+}
 
 struct PersistentDsKeyHash {
     size_t operator()(const PersistentDsKey& k) const {
         size_t hash = 1469598103934665603ull;
         auto mix = [&](uint64_t v) { hash ^= static_cast<size_t>(v); hash *= 1099511628211ull; };
         mix(k.dr); mix(k.dw); mix(k.sr); mix(k.sw); mix(k.htile);
-        mix(k.w); mix(k.h); mix(k.fmt);
+        mix(k.w); mix(k.h); mix(k.fmt); mix(k.slice);
         return hash;
     }
 };
@@ -2701,11 +2728,12 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
                     persistent_ds_cache().size());
             for (const auto& [key, image] : persistent_ds_cache())
                 fprintf(stderr,
-                        "[dsbridge]     dr=0x%llx dw=0x%llx sr=0x%llx sw=0x%llx %ux%u fmt=%u "
-                        "dvalid=%d svalid=%d\n",
+                        "[dsbridge]     dr=0x%llx dw=0x%llx sr=0x%llx sw=0x%llx slice=%u "
+                        "%ux%u fmt=%u dvalid=%d svalid=%d\n",
                         (unsigned long long)key.dr, (unsigned long long)key.dw,
                         (unsigned long long)key.sr, (unsigned long long)key.sw,
-                        key.w, key.h, key.fmt, (int)image.depth_valid, (int)image.stencil_valid);
+                        key.slice, key.w, key.h, key.fmt,
+                        (int)image.depth_valid, (int)image.stencil_valid);
         }
     }
     if (best.image) return best;
@@ -3322,10 +3350,13 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
         ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D32_SFLOAT_S8_UINT;
     const VkImageAspectFlags aspects = VK_IMAGE_ASPECT_DEPTH_BIT |
         (format == VK_FORMAT_D32_SFLOAT_S8_UINT ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
+    // Seeds carry no DB_DEPTH_VIEW, so a restored surface keys at slice 0. That matches every
+    // non-layered surface exactly and is the only slice a seed can honestly claim; a layered guest
+    // allocation restored from a seed will re-key correctly as soon as the guest programs its view.
     PersistentDsKey key{seed.depth_read_base, seed.depth_write_base,
                         seed.stencil_read_base, seed.stencil_write_base,
                         seed.htile_data_base, seed.width, seed.height,
-                        static_cast<uint32_t>(format)};
+                        static_cast<uint32_t>(format), 0u};
     PersistentDsImage& image = persistent_ds_cache()[key];
     if (!image.image) {
         VkImageCreateInfo info{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -3743,7 +3774,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             htile_identity = identity->stencil_read_base - 0x10000;
         ds_key = {identity->depth_read_base, identity->depth_write_base,
                   identity->stencil_read_base, identity->stencil_write_base,
-                  htile_identity, W, H, (uint32_t)DFMT};
+                  htile_identity, W, H, (uint32_t)DFMT,
+                  ds_depth_view_slice_start(identity->db_depth_view)};
         cached_ds = &persistent_ds_cache()[ds_key];
         dimg = cached_ds->image; dmem = cached_ds->memory; dview = cached_ds->view;
         ds_layout_initialized = cached_ds->layout_initialized;

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -263,6 +263,16 @@ struct BackendColorTarget {
     bool load_existing1 = true;
     bool readback1 = true;
     VkFormat format1 = VK_FORMAT_UNDEFINED;
+    // Slots 2..7. The named fields above predate the complete array and remain the contract for
+    // slots 0 and 1; these carry the same two properties for the rest.
+    //
+    // Without them every slot above 1 was a TRANSIENT image created per backend call and cleared
+    // with LOAD_OP_CLEAR, so returning to the same allocation in a later render group erased what an
+    // earlier group had drawn there. That was unreachable while the fragment recompiler could only
+    // export MRT0/MRT1; the moment it could export five, GTA V's G-buffer -- which accumulates
+    // across roughly sixteen pass groups per frame -- kept only the last group's slots 2..4.
+    std::array<uint64_t, prosper::gpu::kColorTargetCount> persistent_id_slots{};
+    std::array<bool, prosper::gpu::kColorTargetCount> load_existing_slots{};
 };
 
 // Optional complete-MRT readback contract. `color_count` is the active Vulkan attachment prefix
@@ -2476,6 +2486,13 @@ inline uint32_t ds_depth_view_slice_start(uint32_t db_depth_view) {
              prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_HI_MASK)
             << prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_START_HI_SHIFT);
 }
+// The production construction seam for a depth/stencil identity. Extracted so a test can exercise
+// the SAME derivation the backend uses: a regression that builds PersistentDsKey by hand asserts
+// only that the struct has a slice field, and stays green if the decode below is reverted.
+inline PersistentDsKey persistent_ds_key_for(const prosper::gpu::ResolvedPipelineState& ps,
+                                             uint64_t htile, uint32_t width, uint32_t height,
+                                             uint32_t format);
+
 inline uint32_t ds_depth_view_slice_max(uint32_t db_depth_view) {
     return (db_depth_view >> prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_MAX_SHIFT) &
            prosper::agc::Pm4::DB_DEPTH_VIEW_SLICE_MAX_MASK;
@@ -2541,6 +2558,13 @@ inline void note_persistent_ds_depth_write(PersistentDsImage& image, bool use_de
                                            bool depth_may_be_written) {
     if (use_depth && depth_may_be_written)
         image.last_depth_write = ++persistent_ds_write_generation();
+}
+
+inline PersistentDsKey persistent_ds_key_for(const prosper::gpu::ResolvedPipelineState& ps,
+                                             uint64_t htile, uint32_t width, uint32_t height,
+                                             uint32_t format) {
+    return {ps.depth_read_base, ps.depth_write_base, ps.stencil_read_base, ps.stencil_write_base,
+            htile, width, height, format, ds_depth_view_slice_start(ps.db_depth_view)};
 }
 
 inline std::unordered_map<PersistentDsKey, PersistentDsImage, PersistentDsKeyHash>&
@@ -3281,6 +3305,7 @@ inline bool snapshot_persistent_ds_images(std::vector<prosper::gpu::GpuCaptureDs
         seed.depth_read_base = key.dr; seed.depth_write_base = key.dw;
         seed.stencil_read_base = key.sr; seed.stencil_write_base = key.sw;
         seed.htile_data_base = key.htile; seed.width = key.w; seed.height = key.h;
+        seed.slice = key.slice;   // a cube's faces differ only here
         if (key.fmt == static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT))
             seed.format = prosper::gpu::GpuCaptureDsFormat::D32Float;
         else if (key.fmt == static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT_S8_UINT))
@@ -3350,13 +3375,12 @@ inline bool restore_persistent_ds_image(const prosper::gpu::GpuCaptureDsSeed& se
         ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D32_SFLOAT_S8_UINT;
     const VkImageAspectFlags aspects = VK_IMAGE_ASPECT_DEPTH_BIT |
         (format == VK_FORMAT_D32_SFLOAT_S8_UINT ? VK_IMAGE_ASPECT_STENCIL_BIT : 0u);
-    // Seeds carry no DB_DEPTH_VIEW, so a restored surface keys at slice 0. That matches every
-    // non-layered surface exactly and is the only slice a seed can honestly claim; a layered guest
-    // allocation restored from a seed will re-key correctly as soon as the guest programs its view.
+    // The seed carries its own slice (capture v55). Restoring every seed at slice 0 would collapse
+    // a cube's six faces onto one identity on replay, which is the same defect the live cache had.
     PersistentDsKey key{seed.depth_read_base, seed.depth_write_base,
                         seed.stencil_read_base, seed.stencil_write_base,
                         seed.htile_data_base, seed.width, seed.height,
-                        static_cast<uint32_t>(format), 0u};
+                        static_cast<uint32_t>(format), seed.slice};
     PersistentDsImage& image = persistent_ds_cache()[key];
     if (!image.image) {
         VkImageCreateInfo info{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -3772,10 +3796,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         if (!htile_identity && getenv("PROSPER_GPU_REPLAY_LEGACY_HTILE_BEFORE_STENCIL") &&
             identity->stencil_read_base >= 0x10000)
             htile_identity = identity->stencil_read_base - 0x10000;
-        ds_key = {identity->depth_read_base, identity->depth_write_base,
-                  identity->stencil_read_base, identity->stencil_write_base,
-                  htile_identity, W, H, (uint32_t)DFMT,
-                  ds_depth_view_slice_start(identity->db_depth_view)};
+        ds_key = persistent_ds_key_for(*identity, htile_identity, W, H, (uint32_t)DFMT);
         cached_ds = &persistent_ds_cache()[ds_key];
         dimg = cached_ds->image; dmem = cached_ds->memory; dview = cached_ds->view;
         ds_layout_initialized = cached_ds->layout_initialized;
@@ -3959,6 +3980,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     std::array<VkImage, prosper::gpu::kColorTargetCount> extra_images{};
     std::array<VkDeviceMemory, prosper::gpu::kColorTargetCount> extra_memories{};
     std::array<VkImageView, prosper::gpu::kColorTargetCount> extra_views{};
+    std::array<PersistentColorTargetImage*, prosper::gpu::kColorTargetCount> cached_extra{};
+    std::array<PersistentColorTargetKey, prosper::gpu::kColorTargetCount> extra_keys{};
     bool persistent_color1 = persistent_color1_enabled;
     PersistentColorTargetKey color_key1{};
     PersistentColorTargetImage* cached_color1 = nullptr;
@@ -4058,21 +4081,76 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         extra_memories[1] = imem1;
         extra_views[1] = view1;
     }
+    // Slots 2..7 retain their allocation across render groups when the caller names a persistent id,
+    // exactly as slots 0 and 1 do. Falls back to a transient image whenever the cache is unavailable
+    // or over its limits, which is the same fallback slot 1 takes -- a title that exceeds the budget
+    // loses accumulation on those slots rather than failing to render.
     for (uint32_t slot = 2; slot < color_count; ++slot) {
+        const uint64_t slot_id = color_target ? color_target->persistent_id_slots[slot] : 0;
+        const bool want_persistent = persistent_color_targets_enabled && slot_id;
+        if (want_persistent) {
+            extra_keys[slot] = {slot_id, W, H, color_formats[slot]};
+            auto [found, inserted] = persistent_color_target_cache().try_emplace(extra_keys[slot]);
+            (void)inserted;
+            cached_extra[slot] = &found->second;
+            cached_extra[slot]->last_use = color_target_generation;
+            extra_images[slot] = cached_extra[slot]->image;
+            extra_memories[slot] = cached_extra[slot]->memory;
+            extra_views[slot] = cached_extra[slot]->view;
+        }
+        if (extra_images[slot]) continue;   // retained from an earlier group
         VkImageCreateInfo ci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
         ci.imageType = VK_IMAGE_TYPE_2D; ci.format = color_formats[slot];
         ci.extent = {W, H, 1}; ci.mipLevels = 1; ci.arrayLayers = 1;
         ci.samples = VK_SAMPLE_COUNT_1_BIT; ci.tiling = VK_IMAGE_TILING_OPTIMAL;
-        ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                   (cached_extra[slot] ? (VK_IMAGE_USAGE_SAMPLED_BIT |
+                                          VK_IMAGE_USAGE_TRANSFER_DST_BIT) : 0u);
         vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
-        if (!extra_images[slot]) return out;
+        if (!extra_images[slot]) {
+            if (cached_extra[slot]) {
+                persistent_color_target_cache().erase(extra_keys[slot]);
+                cached_extra[slot] = nullptr;
+            }
+            return out;
+        }
         VkMemoryRequirements requirements{};
         vkGetImageMemoryRequirements(dev, extra_images[slot], &requirements);
         VkMemoryAllocateInfo allocation{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
         allocation.allocationSize = requirements.size;
         allocation.memoryTypeIndex = pick(requirements.memoryTypeBits, 0);
-        extra_memories[slot] = allocate_transient_render_memory(
-            dev, allocation.allocationSize, allocation.memoryTypeIndex);
+        if (cached_extra[slot]) {
+            const VkDeviceSize limit = persistent_color_target_limit();
+            while (!avoid_cache_eviction &&
+                   (persistent_color_target_cache().size() >
+                            persistent_color_target_count_limit() ||
+                    requirements.size > limit ||
+                    persistent_color_target_bytes() > limit - requirements.size) &&
+                   evict_persistent_color_target(ctx, color_target_generation)) {}
+            if (requirements.size <= limit &&
+                persistent_color_target_cache().size() <=
+                    persistent_color_target_count_limit() &&
+                persistent_color_target_bytes() <= limit - requirements.size &&
+                vkAllocateMemory(dev, &allocation, nullptr, &extra_memories[slot]) == VK_SUCCESS) {
+                cached_extra[slot]->bytes = requirements.size;
+                persistent_color_target_bytes() += requirements.size;
+            } else {
+                // Over budget: drop back to a transient image for this slot, exactly as slot 1 does.
+                vkDestroyImage(dev, extra_images[slot], nullptr);
+                extra_images[slot] = VK_NULL_HANDLE;
+                persistent_color_target_cache().erase(extra_keys[slot]);
+                cached_extra[slot] = nullptr;
+                ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+                vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
+                if (!extra_images[slot]) return out;
+                vkGetImageMemoryRequirements(dev, extra_images[slot], &requirements);
+                allocation.allocationSize = requirements.size;
+                allocation.memoryTypeIndex = pick(requirements.memoryTypeBits, 0);
+            }
+        }
+        if (!extra_memories[slot])
+            extra_memories[slot] = allocate_transient_render_memory(
+                dev, allocation.allocationSize, allocation.memoryTypeIndex);
         VkImageViewCreateInfo view_ci{VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO};
         view_ci.image = extra_images[slot]; view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         view_ci.format = color_formats[slot];
@@ -4081,7 +4159,27 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             vkBindImageMemory(dev, extra_images[slot], extra_memories[slot], 0) == VK_SUCCESS &&
             vkCreateImageView(dev, &view_ci, nullptr, &extra_views[slot]) == VK_SUCCESS &&
             extra_views[slot];
-        if (!ready) return out;
+        if (!ready) {
+            if (extra_views[slot]) vkDestroyImageView(dev, extra_views[slot], nullptr);
+            vkDestroyImage(dev, extra_images[slot], nullptr);
+            if (cached_extra[slot]) {
+                if (cached_extra[slot]->bytes)
+                    persistent_color_target_bytes() -= cached_extra[slot]->bytes;
+                if (extra_memories[slot]) vkFreeMemory(dev, extra_memories[slot], nullptr);
+                persistent_color_target_cache().erase(extra_keys[slot]);
+            } else if (extra_memories[slot]) {
+                release_transient_render_memory(dev, extra_memories[slot]);
+            }
+            extra_images[slot] = VK_NULL_HANDLE;
+            extra_memories[slot] = VK_NULL_HANDLE;
+            extra_views[slot] = VK_NULL_HANDLE;
+            return out;
+        }
+        if (cached_extra[slot]) {
+            cached_extra[slot]->image = extra_images[slot];
+            cached_extra[slot]->memory = extra_memories[slot];
+            cached_extra[slot]->view = extra_views[slot];
+        }
     }
 
     if (use_ds && !dimg) {
@@ -4131,13 +4229,18 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                                : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     }
     for (uint32_t slot = 2; slot < color_count; ++slot) {
+        // LOAD a retained slot whose contents are valid, so a G-buffer built across several render
+        // groups accumulates instead of each group clearing its predecessor's work.
+        const bool load_slot = cached_extra[slot] && cached_extra[slot]->valid &&
+                               color_target && color_target->load_existing_slots[slot];
         att[slot].format = color_formats[slot];
         att[slot].samples = VK_SAMPLE_COUNT_1_BIT;
-        att[slot].loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+        att[slot].loadOp = load_slot ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
         att[slot].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att[slot].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         att[slot].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        att[slot].initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        att[slot].initialLayout = load_slot ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
+                                            : VK_IMAGE_LAYOUT_UNDEFINED;
         att[slot].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     }
     att[ds_attachment].format = DFMT; att[ds_attachment].samples = VK_SAMPLE_COUNT_1_BIT;
@@ -7071,6 +7174,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         cached_color1->valid = true;
         cached_color1->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
+    for (uint32_t slot = 2; slot < color_count; ++slot) {
+        PersistentColorTargetImage* retained = cached_extra[slot];
+        if (!retained) continue;
+        active_submission.add_failure_cleanup([retained]() { retained->valid = false; });
+        retained->valid = true;
+        retained->layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    }
     BackendSubmissionBatchResult batch_result;
     if (flush_now)
         batch_result = active_submission.submit_and_wait(dev, queue, backend_trace);
@@ -7454,6 +7564,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         persistent_pipeline_layouts.size();
     const bool transient_color = cached_color == nullptr;
     const bool transient_color1 = use_color1 && cached_color1 == nullptr;
+    // Per-slot twin of the two flags above, so the teardown lambda can tell a retained slot from a
+    // transient one without capturing the cache pointers themselves.
+    std::array<bool, prosper::gpu::kColorTargetCount> transient_extra{};
+    for (uint32_t slot = 2; slot < color_count; ++slot)
+        transient_extra[slot] = cached_extra[slot] == nullptr;
     const bool transient_ds = use_ds && cached_ds == nullptr;
     const RenderVkCtx* ctx_ptr = &ctx;
     active_submission.add_cleanup(
@@ -7465,6 +7580,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
          shared_buffer_arenas = std::move(shared_buffer_arenas),
          texture_uploads = std::move(texture_uploads), seedbuf, seedmem, seedbuf1, seedmem1,
          rb, bmem, fb, rp, transient_color, view, img, imem, transient_color1, view1, img1,
+         transient_extra,
          imem1, color_count, extra_views, extra_images, extra_memories,
          transient_ds, dview, dimg, dmem, ds_stats_pool, ds_occ_pool,
          geom_buf, geom_mem, geom_counter, geom_counter_mem, ctx_ptr,
@@ -7547,6 +7663,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 release_transient_render_memory(dev, imem1);
             }
             for (uint32_t slot = 2; slot < color_count; ++slot) {
+                if (!transient_extra[slot]) continue;   // retained for the next render group
                 vkDestroyImageView(dev, extra_views[slot], nullptr);
                 vkDestroyImage(dev, extra_images[slot], nullptr);
                 release_transient_render_memory(dev, extra_memories[slot]);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -279,6 +279,13 @@ struct BackendColorTarget {
     // full-extent copy per slot per segment purely because `color_count > 2` forces a readback.
     std::array<bool, prosper::gpu::kColorTargetCount> readback_slots{
         true, true, true, true, true, true, true, true};
+    // Initial contents for slots 2..7, the per-slot twin of `seed_rgba`/`seed_rgba1`. A depth
+    // feedback split renders a logical pass in several physical passes; when the slots are not
+    // persistent (the caller passed no identities, e.g. every path that runs with live GPU targets
+    // disabled) the ONLY way a later segment sees an earlier one's pixels is to be seeded with them.
+    // Without it the final segment created fresh transient attachments and cleared away everything
+    // the earlier segments drew into MRT2+.
+    std::array<const uint8_t*, prosper::gpu::kColorTargetCount> seed_slots{};
 };
 
 // Optional complete-MRT readback contract. `color_count` is the active Vulkan attachment prefix
@@ -4113,9 +4120,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         ci.imageType = VK_IMAGE_TYPE_2D; ci.format = color_formats[slot];
         ci.extent = {W, H, 1}; ci.mipLevels = 1; ci.arrayLayers = 1;
         ci.samples = VK_SAMPLE_COUNT_1_BIT; ci.tiling = VK_IMAGE_TILING_OPTIMAL;
+        const bool slot_seeded = color_target && color_target->seed_slots[slot];
         ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                    (cached_extra[slot] ? (VK_IMAGE_USAGE_SAMPLED_BIT |
-                                          VK_IMAGE_USAGE_TRANSFER_DST_BIT) : 0u);
+                                          VK_IMAGE_USAGE_TRANSFER_DST_BIT) : 0u) |
+                   (slot_seeded ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
         vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
         if (!extra_images[slot]) {
             if (cached_extra[slot]) {
@@ -4150,7 +4159,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 extra_images[slot] = VK_NULL_HANDLE;
                 persistent_color_target_cache().erase(extra_keys[slot]);
                 cached_extra[slot] = nullptr;
-                ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+                ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                           (slot_seeded ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
                 vkCreateImage(dev, &ci, nullptr, &extra_images[slot]);
                 if (!extra_images[slot]) return out;
                 vkGetImageMemoryRequirements(dev, extra_images[slot], &requirements);
@@ -4244,7 +4254,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     for (uint32_t slot = 2; slot < color_count; ++slot) {
         // LOAD a retained slot whose contents are valid, so a G-buffer built across several render
         // groups accumulates instead of each group clearing its predecessor's work.
-        const bool load_slot = load_extra[slot];
+        const bool load_slot = load_extra[slot] ||
+                               (color_target && color_target->seed_slots[slot]);
         att[slot].format = color_formats[slot];
         att[slot].samples = VK_SAMPLE_COUNT_1_BIT;
         att[slot].loadOp = load_slot ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -6602,6 +6613,56 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &s1);
     }
+    // Slots 2..7 seed the same way slot 1 does. Split segments rely on this whenever the slots are
+    // not persistent: it is the only channel by which a later physical pass inherits an earlier
+    // one's pixels.
+    std::array<VkBuffer, prosper::gpu::kColorTargetCount> extra_seedbufs{};
+    std::array<VkDeviceMemory, prosper::gpu::kColorTargetCount> extra_seedmems{};
+    for (uint32_t slot = 2; slot < color_count; ++slot) {
+        if (!color_target || !color_target->seed_slots[slot]) continue;
+        const VkDeviceSize slot_bytes = color_bytes[slot];
+        if (!slot_bytes) continue;
+        VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+        sci.size = slot_bytes; sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
+        vkCreateBuffer(dev, &sci, nullptr, &extra_seedbufs[slot]);
+        if (!extra_seedbufs[slot]) continue;
+        VkMemoryRequirements sr; vkGetBufferMemoryRequirements(dev, extra_seedbufs[slot], &sr);
+        VkMemoryAllocateInfo sai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        sai.allocationSize = sr.size;
+        sai.memoryTypeIndex = pick(sr.memoryTypeBits,
+            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        extra_seedmems[slot] =
+            allocate_transient_render_memory(dev, sai.allocationSize, sai.memoryTypeIndex);
+        if (!extra_seedmems[slot]) { vkDestroyBuffer(dev, extra_seedbufs[slot], nullptr);
+                                     extra_seedbufs[slot] = VK_NULL_HANDLE; continue; }
+        vkBindBufferMemory(dev, extra_seedbufs[slot], extra_seedmems[slot], 0);
+        void* sp = nullptr; vkMapMemory(dev, extra_seedmems[slot], 0, slot_bytes, 0, &sp);
+        memcpy(sp, color_target->seed_slots[slot], static_cast<size_t>(slot_bytes));
+        vkUnmapMemory(dev, extra_seedmems[slot]);
+        VkImageMemoryBarrier s0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        s0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        s0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        s0.image = extra_images[slot];
+        s0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        s0.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &s0);
+        VkBufferImageCopy sc{}; sc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        sc.imageExtent = {W, H, 1};
+        vkCmdCopyBufferToImage(cmd, extra_seedbufs[slot], extra_images[slot],
+                               VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &sc);
+        VkImageMemoryBarrier s1{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        s1.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+        s1.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        s1.image = extra_images[slot];
+        s1.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        s1.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        s1.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                           VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &s1);
+    }
     // Upload each distinct texture once. Draw descriptors may use separate views/samplers over the
     // same image, preserving per-binding swizzle and sampler state without duplicating pixel storage.
     for (const auto& upload : texture_uploads) {
@@ -7663,6 +7724,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
          shared_buffers = std::move(shared_buffers),
          shared_buffer_arenas = std::move(shared_buffer_arenas),
          texture_uploads = std::move(texture_uploads), seedbuf, seedmem, seedbuf1, seedmem1,
+         extra_seedbufs, extra_seedmems,
          rb, bmem, fb, rp, transient_color, view, img, imem, transient_color1, view1, img1,
          transient_extra,
          imem1, color_count, extra_views, extra_images, extra_memories,
@@ -7732,6 +7794,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             if (seedmem) release_transient_render_memory(dev, seedmem);
             if (seedbuf1) vkDestroyBuffer(dev, seedbuf1, nullptr);
             if (seedmem1) release_transient_render_memory(dev, seedmem1);
+            for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot) {
+                if (extra_seedbufs[slot]) vkDestroyBuffer(dev, extra_seedbufs[slot], nullptr);
+                if (extra_seedmems[slot])
+                    release_transient_render_memory(dev, extra_seedmems[slot]);
+            }
             if (rb) vkDestroyBuffer(dev, rb, nullptr);
             if (bmem) release_transient_render_memory(dev, bmem);
             vkDestroyFramebuffer(dev, fb, nullptr);
@@ -8037,21 +8104,34 @@ struct SplitSegmentContract {
     uint32_t color_count = 1;
     bool has_target = false;
 };
-inline SplitSegmentContract split_segment_contract(const BackendColorTarget* whole,
-                                                   const BackendMrtOutputs* whole_mrt,
-                                                   bool first, bool final) {
+inline SplitSegmentContract split_segment_contract(
+    const BackendColorTarget* whole, const BackendMrtOutputs* whole_mrt, bool first, bool final,
+    const std::array<const uint8_t*, prosper::gpu::kColorTargetCount>& carried_slots = {}) {
     SplitSegmentContract out;
     // The attachment shape never varies by segment. A pass is five-MRT for all of its segments or
     // none of them; splitting is a synchronisation boundary, not a change of render target.
     out.color_count = whole_mrt ? whole_mrt->color_count : 1u;
-    if (!whole) return out;
-    out.target = *whole;
+    // A caller that named no persistent identities still needs a target when higher slots have to
+    // be carried between segments: the seed and readback flags live on it, and they are the only
+    // channel by which a non-persistent MRT2+ survives a physical pass boundary. A synthesised
+    // target is behaviourally identical to no target -- every identity is zero, so `persistent_color`
+    // and its siblings stay false and no cached image is consulted -- except that it can carry.
+    const bool carries_slots = out.color_count > 2u;
+    if (!whole && !carries_slots) return out;
+    if (whole) out.target = *whole;
     out.has_target = true;
     if (!first) {
         // Every later segment LOADS everything, or it erases what its predecessors drew.
         out.target.load_existing = true;
         out.target.load_existing1 = true;
         out.target.load_existing_slots.fill(true);
+        // LOADing is only sufficient when the slot is PERSISTENT. Where it is not -- the caller
+        // named no identity, which is every path running with live GPU targets disabled -- the
+        // later segment gets a fresh transient image, and the previous segment's pixels reach it
+        // only by being seeded in.
+        for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot)
+            if (!out.target.persistent_id_slots[slot]) out.target.seed_slots[slot] =
+                carried_slots[slot];
     }
     if (!final) {
         // A non-final segment's pixels are discarded, so do not copy them out. Slots 2+ must say so
@@ -8095,6 +8175,8 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
     BackendPipelineCacheStats aggregate_pipelines{};
     BackendRenderTimingStats aggregate_timing{};
     std::vector<uint8_t> carried_color0;
+    std::array<std::vector<uint8_t>, prosper::gpu::kColorTargetCount> carried_slots;
+    std::array<const uint8_t*, prosper::gpu::kColorTargetCount> carried_slot_ptrs{};
     std::vector<uint8_t> carried_color1;
     const uint8_t* next_seed0 = seed_rgba;
     const uint8_t* next_seed1 = seed_rgba1;
@@ -8207,13 +8289,20 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         const size_t end = begin + relative_end;
         const bool final = end == all.size();
 
-        const SplitSegmentContract segment =
-            split_segment_contract(color_target, mrt_outputs, begin == 0, final);
+        SplitSegmentContract segment = split_segment_contract(
+            color_target, mrt_outputs, begin == 0, final, carried_slot_ptrs);
         const BackendColorTarget* segment_target_ptr =
             segment.has_target ? &segment.target : nullptr;
         std::vector<uint8_t> intermediate_color1;
         std::vector<uint8_t>* segment_out1 = out_rgba1
             ? (final ? out_rgba1 : &intermediate_color1) : nullptr;
+        // A non-final segment must READ BACK any higher slot it has to carry forward by seed --
+        // otherwise there is nothing to seed the next segment with. Only when the slot is not
+        // persistent: a persistent slot is carried by the retained image and needs no copy.
+        for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot)
+            if (segment.has_target && !segment.target.persistent_id_slots[slot] &&
+                slot < segment.color_count)
+                segment.target.readback_slots[slot] = true;
         // The shape travels with every segment; only the pixel destination differs.
         BackendMrtOutputs intermediate_mrt;
         intermediate_mrt.color_count = segment.color_count;
@@ -8247,6 +8336,15 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             next_seed1 = carried_color1.empty() ? nullptr : carried_color1.data();
         } else {
             next_seed1 = nullptr;
+        }
+        // Carry each non-persistent higher slot's pixels into the next segment. Without this the
+        // final segment created fresh transient attachments and cleared away everything earlier
+        // segments drew into MRT2+ -- silently, since the shape and the flags were already right.
+        for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot) {
+            if (final) break;
+            carried_slots[slot] = std::move(intermediate_mrt.colors[slot]);
+            carried_slot_ptrs[slot] =
+                carried_slots[slot].empty() ? nullptr : carried_slots[slot].data();
         }
         begin = end;
     }

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -286,6 +286,12 @@ struct BackendColorTarget {
     // Without it the final segment created fresh transient attachments and cleared away everything
     // the earlier segments drew into MRT2+.
     std::array<const uint8_t*, prosper::gpu::kColorTargetCount> seed_slots{};
+    // Slot 1's seed when the caller receives it through BackendMrtOutputs instead of `out_rgba1`.
+    // The live renderer uses that API, so on a split its slot-1 readback landed in
+    // `mrt_outputs.colors[1]` while the wrapper only carried a seed forward inside `if (out_rgba1)`
+    // -- losing MRT1 on every non-final segment. The claim that "slots 0 and 1 already carry" was
+    // true only of the legacy explicit-out_rgba1 API.
+    const uint8_t* seed_rgba1_slot = nullptr;
 };
 
 // Optional complete-MRT readback contract. `color_count` is the active Vulkan attachment prefix
@@ -3645,6 +3651,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             backend_color_bytes_per_pixel(color_formats[slot]);
         readback_bytes += color_bytes[slot];
     }
+    // A slot-1 seed may arrive by either route; the explicit parameter wins when both are present,
+    // since an argument is the caller being specific.
+    const uint8_t* const effective_seed1 =
+        seed_rgba1 ? seed_rgba1
+                   : (color_target ? color_target->seed_rgba1_slot : nullptr);
     const VkFormat FMT1 = use_color1 ? color_formats[1] : VK_FORMAT_UNDEFINED;
     const bool persistent_color1_enabled = persistent_color_targets_enabled && use_color1 &&
                                            color_target && color_target->persistent_id1 &&
@@ -4019,7 +4030,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         color1_ci.samples = VK_SAMPLE_COUNT_1_BIT; color1_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
         color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
                           (persistent_color1 ? VK_IMAGE_USAGE_SAMPLED_BIT : 0u) |
-                          ((seed_rgba1 || persistent_color1)
+                          ((effective_seed1 || persistent_color1)
                                ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
         vkCreateImage(dev, &color1_ci, nullptr, &img1);
         if (!img1) {
@@ -4054,7 +4065,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 persistent_color1 = false;
                 color1_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT |
                                   VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
-                                  (seed_rgba1 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
+                                  (effective_seed1 ? VK_IMAGE_USAGE_TRANSFER_DST_BIT : 0u);
                 vkCreateImage(dev, &color1_ci, nullptr, &img1);
                 if (!img1) return out;
                 vkGetImageMemoryRequirements(dev, img1, &color1_requirements);
@@ -4092,7 +4103,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         }
     }
     const bool load_cached_color1 = cached_color1 && cached_color1->valid &&
-                                    color_target->load_existing1 && !seed_rgba1;
+                                    color_target->load_existing1 && !effective_seed1;
     if (use_color1) {
         extra_images[1] = img1;
         extra_memories[1] = imem1;
@@ -4241,12 +4252,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                           : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     if (use_color1) {
         att[1].format = FMT1; att[1].samples = VK_SAMPLE_COUNT_1_BIT;
-        att[1].loadOp = (seed_rgba1 || load_cached_color1)
+        att[1].loadOp = (effective_seed1 || load_cached_color1)
             ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
         att[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         att[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
         att[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        att[1].initialLayout = (seed_rgba1 || load_cached_color1)
+        att[1].initialLayout = (effective_seed1 || load_cached_color1)
             ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL : VK_IMAGE_LAYOUT_UNDEFINED;
         att[1].finalLayout = persistent_color1 ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
                                                : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -6581,7 +6592,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         vkCmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &s1);
     }
     VkBuffer seedbuf1 = VK_NULL_HANDLE; VkDeviceMemory seedmem1 = VK_NULL_HANDLE;
-    if (use_color1 && seed_rgba1) {
+    if (use_color1 && effective_seed1) {
         VkBufferCreateInfo sci{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
         sci.size = bytes1; sci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
         vkCreateBuffer(dev, &sci, nullptr, &seedbuf1);
@@ -6592,7 +6603,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         seedmem1 = allocate_transient_render_memory(dev, sai.allocationSize, sai.memoryTypeIndex);
         vkBindBufferMemory(dev, seedbuf1, seedmem1, 0);
         void* sp = nullptr; vkMapMemory(dev, seedmem1, 0, bytes1, 0, &sp);
-        memcpy(sp, seed_rgba1, static_cast<size_t>(bytes1)); vkUnmapMemory(dev, seedmem1);
+        memcpy(sp, effective_seed1, static_cast<size_t>(bytes1));
+        vkUnmapMemory(dev, seedmem1);
         VkImageMemoryBarrier s0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         s0.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED; s0.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         s0.image = extra_images[1]; s0.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -8116,7 +8128,10 @@ inline SplitSegmentContract split_segment_contract(
     // channel by which a non-persistent MRT2+ survives a physical pass boundary. A synthesised
     // target is behaviourally identical to no target -- every identity is zero, so `persistent_color`
     // and its siblings stay false and no cached image is consulted -- except that it can carry.
-    const bool carries_slots = out.color_count > 2u;
+    // > 1, not > 2: slot 1 needs carrying too when the caller takes it through BackendMrtOutputs.
+    // The threshold was 2 and a two-attachment split therefore synthesised no carrier at all, so
+    // MRT1 was cleared by the next segment even with every other part of the carry correct.
+    const bool carries_slots = out.color_count > 1u;
     if (!whole && !carries_slots) return out;
     if (whole) out.target = *whole;
     out.has_target = true;
@@ -8125,13 +8140,18 @@ inline SplitSegmentContract split_segment_contract(
         out.target.load_existing = true;
         out.target.load_existing1 = true;
         out.target.load_existing_slots.fill(true);
-        // LOADing is only sufficient when the slot is PERSISTENT. Where it is not -- the caller
-        // named no identity, which is every path running with live GPU targets disabled -- the
-        // later segment gets a fresh transient image, and the previous segment's pixels reach it
-        // only by being seeded in.
+        // LOADing is only sufficient when the slot's image actually SURVIVES, and a non-zero
+        // identity does not establish that: persistence also requires
+        // persistent_color_targets_enabled (an env switch) and a successful cache/budget
+        // allocation, and the slot-creation path explicitly falls back to a transient image while
+        // leaving the identity non-zero. Seeding whatever the previous segment produced is correct
+        // in every one of those cases and merely redundant when the image did survive, so the
+        // decision is made conservatively rather than from an identity that cannot answer it.
         for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot)
-            if (!out.target.persistent_id_slots[slot]) out.target.seed_slots[slot] =
-                carried_slots[slot];
+            out.target.seed_slots[slot] = carried_slots[slot];
+        // Slot 1 travels the same way when the caller takes it through BackendMrtOutputs rather
+        // than out_rgba1 -- see the carry below.
+        if (carried_slots[1]) out.target.seed_rgba1_slot = carried_slots[1];
     }
     if (!final) {
         // A non-final segment's pixels are discarded, so do not copy them out. Slots 2+ must say so
@@ -8296,13 +8316,24 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         std::vector<uint8_t> intermediate_color1;
         std::vector<uint8_t>* segment_out1 = out_rgba1
             ? (final ? out_rgba1 : &intermediate_color1) : nullptr;
-        // A non-final segment must READ BACK any higher slot it has to carry forward by seed --
-        // otherwise there is nothing to seed the next segment with. Only when the slot is not
-        // persistent: a persistent slot is carried by the retained image and needs no copy.
-        for (uint32_t slot = 2; slot < prosper::gpu::kColorTargetCount; ++slot)
-            if (segment.has_target && !segment.target.persistent_id_slots[slot] &&
-                slot < segment.color_count)
+        // A non-final segment READS BACK every slot it may have to carry, unconditionally.
+        //
+        // Keying this on a non-zero persistent identity was wrong: persistence also requires
+        // persistent_color_targets_enabled and a successful cache/budget allocation, and the
+        // slot-creation path falls back to a transient image while leaving the identity non-zero.
+        // In any of those cases the identity says "retained" and the image is not, no bytes are
+        // captured, and the next segment starts from a cleared attachment. The wrapper cannot see
+        // those decisions, so it does not try to predict them -- it captures, which is correct when
+        // the image was transient and merely redundant when it survived. Split passes are rare;
+        // silently losing an attachment is not a price worth paying to avoid a copy on one.
+        if (!final && segment.has_target) {
+            for (uint32_t slot = 2; slot < segment.color_count; ++slot)
                 segment.target.readback_slots[slot] = true;
+            // Slot 1 travels through whichever output API the caller chose. `out_rgba1` is the
+            // legacy one; the live renderer takes slot 1 through BackendMrtOutputs, and on that
+            // path the readback landed in intermediate_mrt.colors[1] with nothing carrying it.
+            if (segment.color_count > 1) segment.target.readback1 = true;
+        }
         // The shape travels with every segment; only the pixel destination differs.
         BackendMrtOutputs intermediate_mrt;
         intermediate_mrt.color_count = segment.color_count;
@@ -8331,12 +8362,17 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
         if (!rendered.empty()) carried_color0 = std::move(rendered);
         else carried_color0.clear();
         next_seed0 = carried_color0.empty() ? nullptr : carried_color0.data();
-        if (out_rgba1) {
+        // Slot 1 arrives in `intermediate_color1` under the out_rgba1 API and in
+        // `intermediate_mrt.colors[1]` under the BackendMrtOutputs API. Carry whichever is
+        // populated: keying on `out_rgba1` alone dropped MRT1 on every non-final segment of a live
+        // renderer split, because that caller uses the other API.
+        if (out_rgba1 && !intermediate_color1.empty())
             carried_color1 = std::move(intermediate_color1);
-            next_seed1 = carried_color1.empty() ? nullptr : carried_color1.data();
-        } else {
-            next_seed1 = nullptr;
-        }
+        else if (!intermediate_mrt.colors[1].empty())
+            carried_color1 = std::move(intermediate_mrt.colors[1]);
+        else
+            carried_color1.clear();
+        next_seed1 = carried_color1.empty() ? nullptr : carried_color1.data();
         // Carry each non-persistent higher slot's pixels into the next segment. Without this the
         // final segment created fresh transient attachments and cleared away everything earlier
         // segments drew into MRT2+ -- silently, since the shape and the flags were already right.
@@ -8346,6 +8382,9 @@ inline std::vector<uint8_t> render_draws_rgba(const std::vector<BackendDraw>& dr
             carried_slot_ptrs[slot] =
                 carried_slots[slot].empty() ? nullptr : carried_slots[slot].data();
         }
+        // Slot 1's pointer travels in the same table, so the contract can seed it without a second
+        // channel. `next_seed1` still serves the out_rgba1 API; both end at the same upload.
+        carried_slot_ptrs[1] = out_rgba1 ? nullptr : next_seed1;
         begin = end;
     }
     return {};

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -3982,6 +3982,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     std::array<VkImageView, prosper::gpu::kColorTargetCount> extra_views{};
     std::array<PersistentColorTargetImage*, prosper::gpu::kColorTargetCount> cached_extra{};
     std::array<PersistentColorTargetKey, prosper::gpu::kColorTargetCount> extra_keys{};
+    // One decision, consumed by the pre-pass barrier, the attachment's initialLayout and the LOAD op
+    // alike. Computed where all three can see it so they cannot disagree about whether this slot's
+    // contents are being carried forward.
+    std::array<bool, prosper::gpu::kColorTargetCount> load_extra{};
     bool persistent_color1 = persistent_color1_enabled;
     PersistentColorTargetKey color_key1{};
     PersistentColorTargetImage* cached_color1 = nullptr;
@@ -4181,6 +4185,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             cached_extra[slot]->view = extra_views[slot];
         }
     }
+    for (uint32_t slot = 2; slot < color_count; ++slot)
+        load_extra[slot] = cached_extra[slot] && cached_extra[slot]->valid &&
+                           color_target && color_target->load_existing_slots[slot];
 
     if (use_ds && !dimg) {
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -4231,8 +4238,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     for (uint32_t slot = 2; slot < color_count; ++slot) {
         // LOAD a retained slot whose contents are valid, so a G-buffer built across several render
         // groups accumulates instead of each group clearing its predecessor's work.
-        const bool load_slot = cached_extra[slot] && cached_extra[slot]->valid &&
-                               color_target && color_target->load_existing_slots[slot];
+        const bool load_slot = load_extra[slot];
         att[slot].format = color_formats[slot];
         att[slot].samples = VK_SAMPLE_COUNT_1_BIT;
         att[slot].loadOp = load_slot ? VK_ATTACHMENT_LOAD_OP_LOAD : VK_ATTACHMENT_LOAD_OP_CLEAR;
@@ -4241,7 +4247,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         att[slot].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
         att[slot].initialLayout = load_slot ? VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL
                                             : VK_IMAGE_LAYOUT_UNDEFINED;
-        att[slot].finalLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+        att[slot].finalLayout = cached_extra[slot] ? VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
+                                                   : VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
     }
     att[ds_attachment].format = DFMT; att[ds_attachment].samples = VK_SAMPLE_COUNT_1_BIT;
     // A guest-identified DS surface survives calls. New attachments get a defined initial value;
@@ -6463,6 +6470,29 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                              0, 0, nullptr, 0, nullptr, 1, &load);
     }
+    // Slots 2..7 take the same pre-pass transition as slots 0 and 1, from the layout the retained
+    // image is ACTUALLY in. Recording COLOR_ATTACHMENT_OPTIMAL as the attachment's initialLayout
+    // without this barrier is undefined: the image rests in SHADER_READ_ONLY_OPTIMAL after its
+    // previous group's readback restore.
+    for (uint32_t slot = 2; slot < color_count; ++slot) {
+        if (!load_extra[slot]) continue;
+        VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+        load.oldLayout = cached_extra[slot]->layout;
+        load.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        load.image = extra_images[slot];
+        load.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+        load.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                             VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_TRANSFER_READ_BIT;
+        load.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                             VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+        vkCmdPipelineBarrier(cmd,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                                 VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                                 VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                             0, 0, nullptr, 0, nullptr, 1, &load);
+    }
     if (load_cached_color1) {
         VkImageMemoryBarrier load{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         load.oldLayout = cached_color1->layout;
@@ -7043,6 +7073,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         };
         transition_color_to_readback(persistent_color, readback_color0, img);
         transition_color_to_readback(persistent_color1, readback_color1, img1);
+        for (uint32_t slot = 2; slot < color_count; ++slot)
+            transition_color_to_readback(cached_extra[slot] != nullptr, true, extra_images[slot]);
         VkBufferImageCopy cp{};
         cp.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         cp.imageExtent = {W, H, 1};
@@ -7080,6 +7112,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         };
         restore_persistent_color(persistent_color, readback_color0, img);
         restore_persistent_color(persistent_color1, readback_color1, img1);
+        for (uint32_t slot = 2; slot < color_count; ++slot)
+            restore_persistent_color(cached_extra[slot] != nullptr, true, extra_images[slot]);
     }
     if (timing_enabled && flush_now)
         active_submission.end_gpu_timestamp(cmd);
@@ -7179,7 +7213,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         if (!retained) continue;
         active_submission.add_failure_cleanup([retained]() { retained->valid = false; });
         retained->valid = true;
-        retained->layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+        // The layout the image is ACTUALLY left in: the pass ends it in SHADER_READ_ONLY_OPTIMAL and
+        // the readback restore returns it there. Recording COLOR_ATTACHMENT_OPTIMAL here while the
+        // image sat in TRANSFER_SRC_OPTIMAL is what made the next group's initialLayout a lie --
+        // VUID-vkCmdDraw-None-09600, invisible on RADV because the pixels happened to survive.
+        retained->layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     }
     BackendSubmissionBatchResult batch_result;
     if (flush_now)

--- a/prosper/tests/test_compute_address_watch.cpp
+++ b/prosper/tests/test_compute_address_watch.cpp
@@ -22,7 +22,75 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
+// The windowed form exists because the address form asked a different question from the change
+// detection that consumed it. These arms pin the difference.
+//
+// Worked example this comes from: a program binding [window + 128, +160) was reported as touching
+// NOTHING, because the address form asks only whether a resource contains the window's FIRST byte.
+// The tree watch detects changes anywhere in the window, so the two halves disagreed, and the
+// disagreement was published as "this program writes bytes it does not bind" -- an out-of-bounds
+// write that never existed. An instrument whose halves ask different questions manufactures exactly
+// the finding it was built to detect.
+static prosper::gpu::ShaderResource watch_scalar(uint32_t binding, uint32_t fetch_pc, uint64_t base,
+                                   uint32_t size) {
+    prosper::gpu::ShaderResource r;
+    r.binding = binding;
+    r.fetch_pc = fetch_pc;
+    r.gpu_addr = base;
+    r.size = size;
+    return r;
+}
+
+static void test_window_hits() {
+    using prosper::gpu::compute_address_ranges_overlap;
+    using prosper::gpu::compute_address_window_hits;
+    using prosper::gpu::compute_address_watch_hits;
+
+    constexpr uint64_t kWindowBase = 0x209cc76000ull;
+    constexpr uint64_t kWindowBytes = 2063ull * 4ull;
+
+    prosper::gpu::ShaderResourceTable table;
+    table.resources.push_back(watch_scalar(7, 43, kWindowBase + 128, 160));   // interior
+    table.resources.push_back(watch_scalar(8, 44, kWindowBase - 0x1000, 64)); // wholly below
+    table.resources.push_back(watch_scalar(9, 45, kWindowBase + 8200, 64));   // straddles the end (window is 8252 bytes)
+
+    CHECK(compute_address_watch_hits(table, kWindowBase).empty(),
+          "the ADDRESS form finds nothing: no resource contains the window's first byte");
+
+    const auto window = compute_address_window_hits(table, kWindowBase, kWindowBytes);
+    CHECK(window.size() == 2u,
+          "the WINDOW form finds the interior resource and the one straddling the end");
+    bool saw_interior = false, saw_below = false;
+    for (const auto& hit : window) {
+        if (hit.binding == 7u && hit.fetch_pc == 43u) saw_interior = true;
+        if (hit.binding == 8u) saw_below = true;
+    }
+    CHECK(saw_interior, "the interior resource is named with its binding and fetch pc");
+    CHECK(!saw_below,
+          "a resource wholly below the window is still not a toucher (no false positive traded in)");
+
+    prosper::gpu::ShaderResourceTable adjacent;
+    adjacent.resources.push_back(watch_scalar(1, 1, kWindowBase - 64, 64));
+    CHECK(compute_address_window_hits(adjacent, kWindowBase, kWindowBytes).empty(),
+          "a resource ending exactly where the window begins does not overlap it");
+
+    prosper::gpu::ShaderResourceTable touching;
+    touching.resources.push_back(watch_scalar(1, 1, kWindowBase - 64, 65));
+    CHECK(compute_address_window_hits(touching, kWindowBase, kWindowBytes).size() == 1u,
+          "one byte of overlap is overlap");
+
+    CHECK(!compute_address_ranges_overlap(kWindowBase, 0, kWindowBase, 16),
+          "a zero-size resource never overlaps");
+    CHECK(!compute_address_ranges_overlap(kWindowBase, 16, kWindowBase, 0),
+          "a zero-size window never overlaps");
+    CHECK(!compute_address_ranges_overlap(UINT64_MAX - 8, 16, 0x1000, 64),
+          "a range near UINT64_MAX does not wrap into a low window");
+    CHECK(!compute_address_ranges_overlap(0x1000, 64, UINT64_MAX - 8, 16),
+          "and does not wrap with the arguments the other way round");
+}
+
 int main() {
+    test_window_hits();
     printf("== test_compute_address_watch ==\n");
     constexpr uint64_t kBase = 0x20f848417cull;
     constexpr uint64_t kSize = 8252;

--- a/prosper/tests/test_compute_tree_watch.cpp
+++ b/prosper/tests/test_compute_tree_watch.cpp
@@ -1,0 +1,223 @@
+// Pure-analysis arms for the address-keyed tree watch (src/gpu/compute_tree_watch.hpp).
+//
+// Every arm here is written so that it FAILS if the property it names stops holding. That is not
+// a truism in this file's history: three earlier diagnostics in this investigation shipped with
+// assertions satisfied by something other than the mechanism under test (an inequality satisfied
+// by a counter variable, an arm passing through an earlier empty() exit, a wrap guard whose wrap
+// produced a value the comparison rejected anyway). Where an arm could pass for the wrong reason,
+// it carries a companion arm that must fail if the mechanism is removed.
+#include <cstdio>
+#include <cstdint>
+#include <span>
+#include <vector>
+
+#include "gpu/compute_tree_watch.hpp"
+
+using namespace prosper::gpu;
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const char* what) {
+    if (condition) return;
+    std::fprintf(stderr, "  %s -> FAILED\n", what);
+    ++g_failures;
+}
+
+void test_selector_parsing() {
+    const auto minimal = parse_compute_tree_watch_selector("0x20f848417c:2063");
+    check(minimal.has_value(), "minimal selector parses");
+    if (minimal) {
+        check(minimal->addr == 0x20f848417cull, "address parsed");
+        check(minimal->records == 2063u, "record count parsed");
+        check(minimal->index_shift == 3u, "shift defaults to the guest's bfe shift");
+        check(minimal->index_mask == (1u << 27u) - 1u, "mask defaults to the guest's bfe width");
+    }
+
+    const auto full = parse_compute_tree_watch_selector("0x1000:16:5:0xff");
+    check(full.has_value(), "full selector parses");
+    if (full) {
+        check(full->index_shift == 5u, "explicit shift overrides the default");
+        check(full->index_mask == 0xffu, "explicit mask overrides the default");
+    }
+
+    check(!parse_compute_tree_watch_selector(nullptr).has_value(), "null rejected");
+    check(!parse_compute_tree_watch_selector("").has_value(), "empty rejected");
+    check(!parse_compute_tree_watch_selector("0x1000").has_value(), "missing record count rejected");
+    check(!parse_compute_tree_watch_selector("0:16").has_value(), "zero address rejected");
+    check(!parse_compute_tree_watch_selector("0x1000:0").has_value(), "zero record count rejected");
+    check(!parse_compute_tree_watch_selector("0x1000:16:5").has_value(),
+          "a shift without a mask is rejected rather than silently keeping the default mask");
+    check(!parse_compute_tree_watch_selector("0x1000:16:32:0xff").has_value(),
+          "a shift of 32 is rejected");
+    check(!parse_compute_tree_watch_selector("0x1000:16:5:0").has_value(), "zero mask rejected");
+    check(!parse_compute_tree_watch_selector("0x1000:16:5:0xff:9").has_value(),
+          "trailing garbage rejected");
+    check(!parse_compute_tree_watch_selector("0x1000:99999999").has_value(),
+          "an absurd record count is refused at parse time, not discovered as a routed-run stall");
+}
+
+void test_deltas() {
+    const std::vector<uint32_t> before{1, 2, 3, 4, 5};
+    std::vector<uint32_t> after = before;
+    uint32_t total = 0xdeadbeefu;
+
+    auto none = compute_tree_watch_deltas(before, after, 8, &total);
+    check(none.empty(), "identical buffers report no deltas");
+    check(total == 0u, "identical buffers report zero total");
+
+    after[1] = 20;
+    after[4] = 50;
+    total = 0;
+    auto some = compute_tree_watch_deltas(before, after, 8, &total);
+    check(some.size() == 2u, "two changed slots reported");
+    check(total == 2u, "total matches the reported count when under the cap");
+    if (some.size() == 2u) {
+        check(some[0].index == 1u && some[0].before == 2u && some[0].after == 20u,
+              "first delta carries index and both values");
+        check(some[1].index == 4u && some[1].before == 5u && some[1].after == 50u,
+              "second delta carries index and both values");
+        check(some[0].index < some[1].index, "deltas ascend by index");
+    }
+
+    // The cap must truncate the LIST without truncating the COUNT -- a capped report that also
+    // capped its total would read as a complete small change.
+    total = 0;
+    auto capped = compute_tree_watch_deltas(before, after, 1, &total);
+    check(capped.size() == 1u, "the cap truncates the reported list");
+    check(total == 2u, "the uncapped total survives truncation");
+
+    // Sizes differing must compare only the overlap, or a resized observation reports every
+    // trailing slot as a change and buries the real one.
+    const std::vector<uint32_t> shorter{1, 2, 3};
+    total = 0;
+    auto overlap = compute_tree_watch_deltas(before, shorter, 8, &total);
+    check(total == 0u, "a shorter observation compares only the overlap");
+    check(overlap.empty(), "no deltas from a pure size difference");
+}
+
+ComputeParentWalkReport with_cycles(uint32_t cycles) {
+    ComputeParentWalkReport report;
+    report.distinct_cycles = cycles;
+    return report;
+}
+
+void test_transition_classification() {
+    const auto clean = with_cycles(0);
+    const auto cyclic = with_cycles(3);
+
+    check(classify_compute_tree_watch_transition(clean, cyclic, false) ==
+              ComputeTreeWatchTransition::Unchanged,
+          "unchanged bytes classify as unchanged even when the reports disagree");
+    check(classify_compute_tree_watch_transition(clean, cyclic, true) ==
+              ComputeTreeWatchTransition::CleanToCyclic,
+          "clean to cyclic is named");
+    check(classify_compute_tree_watch_transition(cyclic, clean, true) ==
+              ComputeTreeWatchTransition::CyclicToClean,
+          "cyclic to clean is named");
+    check(classify_compute_tree_watch_transition(cyclic, cyclic, true) ==
+              ComputeTreeWatchTransition::CyclicToCyclic,
+          "cyclic to cyclic is named");
+    check(classify_compute_tree_watch_transition(clean, clean, true) ==
+              ComputeTreeWatchTransition::CleanToClean,
+          "clean to clean is named");
+
+    // Cyclicity is the ONLY axis. A depth change must not masquerade as a cyclicity transition,
+    // or "clean" means one thing in a shallow run and another in a deep one.
+    ComputeParentWalkReport deep = clean;
+    deep.max_depth = 4096;
+    check(classify_compute_tree_watch_transition(clean, deep, true) ==
+              ComputeTreeWatchTransition::CleanToClean,
+          "a depth change alone is not a cyclicity transition");
+}
+
+void test_sibling_structure() {
+    // A full binary tree over N leaves has 2N-1 nodes. Build a small exact instance: pairs at
+    // (1,2), (3,4), (5,6) with index 0 as the unpaired root.
+    std::vector<uint32_t> words{0x00000010u,
+                                0x00000020u, 0x40000020u,
+                                0x00000030u, 0x40000030u,
+                                0x00000040u, 0x40000040u};
+    auto report = analyze_compute_tree_siblings(words);
+    check(report.records == 7u, "record count reported");
+    check(report.pairs == 3u, "three sibling pairs found");
+    check(report.side_bit_set == 3u, "three side-bit records");
+    check(report.unpaired_side == 0u, "a well-formed tree has no unpaired side records");
+
+    // Breaking one head must be visible as exactly one unpaired record, and must NOT change the
+    // side-bit population -- if it did, the metric would be counting the wrong thing.
+    words[3] = 0x00000031u;
+    auto broken = analyze_compute_tree_siblings(words);
+    check(broken.pairs == 2u, "breaking a head loses exactly one pair");
+    check(broken.unpaired_side == 1u, "breaking a head yields exactly one unpaired record");
+    check(broken.side_bit_set == 3u, "breaking a head does not change the side-bit population");
+
+    // Two identical adjacent records both carrying the side bit are duplicates, not siblings.
+    // Without the head-clear clause `words[i] == (words[i-1] | bit)` is trivially satisfied here,
+    // so this arm fails if that clause is removed.
+    const std::vector<uint32_t> duplicates{0x00000010u, 0x40000020u, 0x40000020u};
+    auto dup = analyze_compute_tree_siblings(duplicates);
+    check(dup.pairs == 0u,
+          "two identical side-bit records are duplicates, not a sibling pair");
+    check(dup.unpaired_side == 2u, "both duplicates count as unpaired");
+
+    // Index 0 carrying the side bit cannot pair: it has no predecessor.
+    const std::vector<uint32_t> leading{0x40000010u, 0x00000020u};
+    auto lead = analyze_compute_tree_siblings(leading);
+    check(lead.pairs == 0u, "index zero cannot form a pair");
+    check(lead.unpaired_side == 1u, "index zero with the side bit counts as unpaired");
+
+    check(analyze_compute_tree_siblings({}).records == 0u, "an empty span is handled");
+}
+
+// The watch's whole purpose is to separate "this dispatch made the table cyclic" from "the table
+// was already cyclic". That separation is only real if the underlying walk actually detects the
+// cycle in a table shaped like the guest's, so build one and confirm both halves.
+void test_walk_agrees_on_a_guest_shaped_table() {
+    constexpr uint32_t kRecords = 63;   // 2 * 32 - 1
+    constexpr uint32_t kShift = 3;
+    constexpr uint32_t kMask = (1u << 27u) - 1u;
+    auto make_record = [](uint32_t parent) { return parent << kShift; };
+
+    // A proper tree: every node points at floor(i/2), so every walk terminates at index 0.
+    std::vector<uint32_t> tree(kRecords, 0u);
+    for (uint32_t i = 1; i < kRecords; ++i) tree[i] = make_record(i / 2u);
+    auto clean = analyze_compute_parent_walk(tree, kRecords, kShift, kMask);
+    check(clean.distinct_cycles == 0u, "a proper parent tree walks clean");
+    check(clean.cyclic_roots == 0u, "a proper parent tree has no cyclic roots");
+    check(clean.max_depth > 0u, "a proper parent tree has nonzero depth");
+
+    // The observed corruption shape: a record's parent link points back down at its own child, so
+    // two nodes point at each other and every root below them never reaches zero.
+    std::vector<uint32_t> cyclic = tree;
+    cyclic[10] = make_record(21u);   // 21's parent is 10; now 10's parent is 21
+    auto broken = analyze_compute_parent_walk(cyclic, kRecords, kShift, kMask);
+    check(broken.distinct_cycles == 1u, "a mutual parent link is detected as one cycle");
+    check(broken.cyclic_roots > 0u, "the cycle traps at least one root");
+
+    uint32_t total = 0;
+    auto deltas = compute_tree_watch_deltas(tree, cyclic, 8, &total);
+    check(total == 1u, "exactly one dword separates the clean and cyclic tables");
+    if (!deltas.empty()) check(deltas[0].index == 10u, "the delta names the corrupted slot");
+    check(classify_compute_tree_watch_transition(clean, broken, total != 0u) ==
+              ComputeTreeWatchTransition::CleanToCyclic,
+          "the clean-to-cyclic transition is classified on a guest-shaped table");
+}
+
+} // namespace
+
+int main() {
+    std::printf("test_compute_tree_watch\n");
+    test_selector_parsing();
+    test_deltas();
+    test_transition_classification();
+    test_sibling_structure();
+    test_walk_agrees_on_a_guest_shaped_table();
+    if (g_failures) {
+        std::fprintf(stderr, "== FAILURES: %d ==\n", g_failures);
+        return 1;
+    }
+    std::printf("  all passed\n");
+    return 0;
+}

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -414,6 +414,11 @@ int main(int argc, char** argv) {
               GpuCaptureResourceInputVerdict::Mismatch,
           "FORMAT=INVALID V# still rejects a normalized byte-size disagreement");
 
+    // v55 appends one uint32 slice per DS seed at the very end of the stream. Legacy fixtures that
+    // downgrade the version byte in place must strip it first, like every tail before it.
+    auto v55_ds_slice_tail = [](const GpuCaptureFile& f) -> size_t {
+        return f.ds_seeds.size() * sizeof(uint32_t);
+    };
     auto resource_bool_tail = [](const GpuCaptureFile& f) -> size_t {
         size_t rc = 0;
         for (const auto& d : f.draws) rc += d.vrt.resources.size() + d.prt.resources.size();
@@ -591,6 +596,7 @@ int main(int argc, char** argv) {
         v45_provenance_bytes.resize(
             v45_provenance_bytes.size() -
             (4u + 100u * provenance_loaded.resource_provenance.size()));
+        v45_provenance_bytes.resize(v45_provenance_bytes.size() - v55_ds_slice_tail(provenance_loaded));  // v55 DS-seed slices
         v45_provenance_bytes[8] = 45;
         CHECK(deserialize_gpu_capture(v45_provenance_bytes, v45_provenance_loaded, error) &&
                   v45_provenance_loaded.format_version == 45 &&
@@ -826,7 +832,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame descriptor_array_replay;
     CHECK(serialize_gpu_capture(descriptor_array_capture, descriptor_array_bytes, error) &&
               deserialize_gpu_capture(descriptor_array_bytes, descriptor_array_loaded, error) &&
-              descriptor_array_loaded.format_version == 54 &&
+              descriptor_array_loaded.format_version == 55 &&
               materialize_gpu_replay(descriptor_array_loaded, descriptor_array_replay, error) &&
               descriptor_array_replay.computes.size() == 1 &&
               descriptor_array_replay.computes[0].resources &&
@@ -1085,6 +1091,7 @@ int main(int argc, char** argv) {
               v16_scissor_bytes.size() >= 25,
           "v17 capture serializes effective guest scissor state");
     if (v16_scissor_bytes.size() >= 25) {
+        v16_scissor_bytes.resize(v16_scissor_bytes.size() - v55_ds_slice_tail(v16_scissor_source));  // v55 DS-seed slices
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v50_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v49_tail(v16_scissor_source));
         v16_scissor_bytes.resize(v16_scissor_bytes.size() - v48_tail(v16_scissor_source));
@@ -1207,7 +1214,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 54 &&
+              msaa_loaded.format_version == 55 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1260,6 +1267,7 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> v43_msaa_bytes;
     CHECK(serialize_gpu_capture(v43_msaa_source, v43_msaa_bytes, error),
           "current writer prepares an uncompressed v43 MSAA compatibility fixture");
+    v43_msaa_bytes.resize(v43_msaa_bytes.size() - v55_ds_slice_tail(v43_msaa_source));  // v55 DS-seed slices
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v50_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v49_tail(v43_msaa_source));
     v43_msaa_bytes.resize(v43_msaa_bytes.size() - v48_tail(v43_msaa_source));
@@ -1321,7 +1329,7 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 54 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 55 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -1332,7 +1340,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 54 &&
+              video_loaded.format_version == 55 &&
               video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
@@ -1340,6 +1348,7 @@ int main(int argc, char** argv) {
               video_replay.items[0].prt->resources[0].host_data_size == video_memory.size(),
           "v28 replay round-trips and binds the complete pitch-padded source span");
     std::vector<uint8_t> v46_zero_mip_bytes = video_capture_bytes;
+    v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v55_ds_slice_tail(video_capture));  // v55 DS-seed slices
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v50_tail(video_capture));
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v49_tail(video_capture));
     v46_zero_mip_bytes.resize(v46_zero_mip_bytes.size() - v48_tail(video_capture));
@@ -1375,7 +1384,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 54 &&
+              upgraded_video.format_version == 55 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1457,7 +1466,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 54 &&
+              array_layout_loaded.format_version == 55 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1556,6 +1565,7 @@ int main(int argc, char** argv) {
           "writer rejects an out-of-bounds DCC metadata reference");
     CHECK(serialize_gpu_capture(volume_capture, volume_bytes, error),
           "recreated valid v12 DCC bytes after malformed-reference check");
+    volume_bytes.resize(volume_bytes.size() - v55_ds_slice_tail(volume_capture));  // v55 DS-seed slices
     volume_bytes.resize(volume_bytes.size() - v50_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v49_tail(volume_capture));
     volume_bytes.resize(volume_bytes.size() - v48_tail(volume_capture));
@@ -1624,6 +1634,44 @@ int main(int argc, char** argv) {
     GpuCaptureFile duplicate_ds = captured; duplicate_ds.ds_seeds.push_back(ds_seed);
     CHECK(!write_gpu_capture(path.string(), duplicate_ds, error) && error == "duplicate DS seed identity",
           "writer rejects duplicate persistent DS seed identities");
+    // Two faces of one cube: identical in every base, extent and format, differing ONLY in slice.
+    // Before slice joined the DS seed identity the writer rejected the second as a duplicate, so a
+    // capture taken once two cube faces were valid failed outright; and even a capture that had been
+    // written could not replay the faces distinctly, because restore keyed every seed at slice 0.
+    {
+        GpuCaptureFile two_faces = captured;
+        GpuCaptureDsSeed face1 = ds_seed;
+        face1.slice = 1;
+        two_faces.ds_seeds[0].slice = 0;
+        two_faces.ds_seeds.push_back(face1);
+        // Make the two faces' contents differ, so the round trip proves the payloads stay attached
+        // to the right slice rather than merely that two records survive.
+        two_faces.ds_seeds[1].depth.assign(16, 0x77);
+        std::vector<uint8_t> two_face_bytes;
+        GpuCaptureFile two_faces_loaded;
+        const bool round_tripped =
+            serialize_gpu_capture(two_faces, two_face_bytes, error) &&
+            deserialize_gpu_capture(two_face_bytes, two_faces_loaded, error);
+        CHECK(round_tripped,
+              "two cube faces differing only in slice are a valid capture, not a duplicate");
+        if (round_tripped) {
+            CHECK(two_faces_loaded.ds_seeds.size() == 2 &&
+                      two_faces_loaded.ds_seeds[0].slice == 0 &&
+                      two_faces_loaded.ds_seeds[1].slice == 1,
+                  "both cube faces survive the round trip with their slices");
+            CHECK(two_faces_loaded.ds_seeds.size() == 2 &&
+                      two_faces_loaded.ds_seeds[0].depth == two_faces.ds_seeds[0].depth &&
+                      two_faces_loaded.ds_seeds[1].depth == two_faces.ds_seeds[1].depth,
+                  "each face's depth payload stays attached to its own slice");
+        }
+        // The duplicate check must still fire on a genuine duplicate -- same slice included.
+        GpuCaptureFile same_slice = captured;
+        same_slice.ds_seeds.push_back(ds_seed);
+        CHECK(!write_gpu_capture(path.string(), same_slice, error) &&
+                  error == "duplicate DS seed identity",
+              "two seeds identical INCLUDING slice are still rejected as duplicates");
+    }
+
     GpuCaptureFile stencil_only = captured;
     stencil_only.ds_seeds[0].depth_valid = false; stencil_only.ds_seeds[0].depth.clear();
     std::vector<uint8_t> stencil_only_bytes;
@@ -1646,7 +1694,7 @@ int main(int argc, char** argv) {
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
-    CHECK(loaded.format_version == 54 &&
+    CHECK(loaded.format_version == 55 &&
               loaded.draws[0].vrt.resources[1].resource.size == 16u &&
               loaded.draws[0].vrt.resources[1].resource.scalar_buffer_dword_count == 4u &&
               shader_resource_buffer_binding_bytes(
@@ -1658,6 +1706,7 @@ int main(int argc, char** argv) {
               v53_scalar_bytes.size() >= v54_tail(captured) + 12u,
           "v54 scalar-buffer tail is removable for a v53 compatibility fixture");
     if (v53_scalar_bytes.size() >= v54_tail(captured) + 12u) {
+        v53_scalar_bytes.resize(v53_scalar_bytes.size() - v55_ds_slice_tail(captured));  // v55 DS-seed slices
         v53_scalar_bytes.resize(v53_scalar_bytes.size() - v54_tail(captured));
         v53_scalar_bytes[8] = 53u;
         v53_scalar_bytes[9] = v53_scalar_bytes[10] = v53_scalar_bytes[11] = 0u;
@@ -1733,7 +1782,9 @@ int main(int argc, char** argv) {
     std::vector<uint8_t> stale_bound_bytes;
     CHECK(serialize_gpu_capture(captured, stale_bound_bytes, error) && !stale_bound_bytes.empty(),
           "v54 stale scalar-buffer bound fixture serializes");
-    const size_t stale_tail = v54_tail(captured);
+    // v55 appends the DS-seed slices AFTER the v54 tail, so an offset measured from the end of the
+    // stream must skip them to land on the v54 records.
+    const size_t stale_tail = v54_tail(captured) + v55_ds_slice_tail(captured);
     bool stale_patched = false;
     if (stale_bound_bytes.size() >= stale_tail) {
         // The v54 tail is `count` followed by one dword per resource, in table order; resource 1 of
@@ -1758,6 +1809,11 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(captured, malformed_scalar_bytes, error) &&
               !malformed_scalar_bytes.empty(),
           "v54 scalar-buffer truncation fixture serializes");
+    // Drop the v55 DS-seed slice tail first, so popping a byte truncates the V54 tail this
+    // assertion is about rather than the newer one appended after it.
+    if (malformed_scalar_bytes.size() >= v55_ds_slice_tail(captured))
+        malformed_scalar_bytes.resize(malformed_scalar_bytes.size() -
+                                      v55_ds_slice_tail(captured));
     if (!malformed_scalar_bytes.empty()) malformed_scalar_bytes.pop_back();
     GpuCaptureFile malformed_scalar_loaded;
     CHECK(!deserialize_gpu_capture(malformed_scalar_bytes, malformed_scalar_loaded, error) &&
@@ -1781,6 +1837,7 @@ int main(int argc, char** argv) {
     CHECK(serialize_gpu_capture(pre_v31_source, v20_bytes, error) && v20_bytes.size() >= 21,
           "v21 capture serializes the logic-op extension");
     if (v20_bytes.size() >= 21) {
+        v20_bytes.resize(v20_bytes.size() - v55_ds_slice_tail(pre_v31_source));  // v55 DS-seed slices
         v20_bytes.resize(v20_bytes.size() - v50_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v49_tail(pre_v31_source));
         v20_bytes.resize(v20_bytes.size() - v48_tail(pre_v31_source));
@@ -1864,6 +1921,7 @@ int main(int argc, char** argv) {
         std::vector<uint8_t> v42_bytes;
         CHECK(serialize_gpu_capture(captured, v42_bytes, error),
               "v43 capture serializes before the color-state downgrade");
+        v42_bytes.resize(v42_bytes.size() - v55_ds_slice_tail(captured));  // v55 DS-seed slices
         v42_bytes.resize(v42_bytes.size() - v50_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v49_tail(captured));
         v42_bytes.resize(v42_bytes.size() - v48_tail(captured));
@@ -1894,6 +1952,7 @@ int main(int argc, char** argv) {
               v48_bvh_bytes.size() >=
                   v50_tail(captured) + v49_tail(captured) + v48_tail(captured),
           "v48 BVH sort state has a complete append-only tail");
+    v48_bvh_bytes.resize(v48_bvh_bytes.size() - v55_ds_slice_tail(captured));  // v55 DS-seed slices
     v48_bvh_bytes.resize(v48_bvh_bytes.size() - v50_tail(captured));
     v48_bvh_bytes.resize(v48_bvh_bytes.size() - v49_tail(captured));
     v48_bvh_bytes[8] = 48;
@@ -1926,6 +1985,7 @@ int main(int argc, char** argv) {
                   v50_tail(atomic_capture) + v49_tail(atomic_capture),
           "current capture has complete v49 and v50 append-only tails");
     v49_atomic_bytes = current_atomic_bytes;
+    v49_atomic_bytes.resize(v49_atomic_bytes.size() - v55_ds_slice_tail(atomic_capture));  // v55 DS-seed slices
     v49_atomic_bytes.resize(v49_atomic_bytes.size() - v50_tail(atomic_capture));
     v49_atomic_bytes[8] = 49;
     v49_atomic_bytes[9] = v49_atomic_bytes[10] = v49_atomic_bytes[11] = 0;
@@ -1990,6 +2050,7 @@ int main(int argc, char** argv) {
             v29_tail(pre_v31_source) + v28_tail(pre_v31_source) +
             v27_tail(pre_v31_source) + v26_tail(pre_v31_source) +
             v25_tail(pre_v31_source)) {
+        v24_resolve_bytes.resize(v24_resolve_bytes.size() - v55_ds_slice_tail(pre_v31_source));  // v55 DS-seed slices
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v50_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v49_tail(pre_v31_source));
         v24_resolve_bytes.resize(v24_resolve_bytes.size() - v48_tail(pre_v31_source));
@@ -2100,6 +2161,7 @@ int main(int argc, char** argv) {
         v44_tail(captured) + v43_tail(captured) +
             v42_tail(captured) + v41_tail(captured) +
             v40_tail(captured) + v39_tail(captured)) {
+        v37_compatible_bytes.resize(v37_compatible_bytes.size() - v55_ds_slice_tail(captured));  // v55 DS-seed slices
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v50_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v49_tail(captured));
         v37_compatible_bytes.resize(v37_compatible_bytes.size() - v48_tail(captured));
@@ -2624,6 +2686,7 @@ int main(int argc, char** argv) {
                   .atomic_x2_record_count == 25u,
           "v50 raw-compute replay preserves PGM_RSRC1, qword-atomic support, and record count");
     std::vector<uint8_t> v49_mixed_atomic = mixed_atomic_bytes;
+    v49_mixed_atomic.resize(v49_mixed_atomic.size() - v55_ds_slice_tail(mixed_atomic));  // v55 DS-seed slices
     v49_mixed_atomic.resize(v49_mixed_atomic.size() - v50_tail(mixed_atomic));
     v49_mixed_atomic[8] = 49;
     v49_mixed_atomic[9] = v49_mixed_atomic[10] = v49_mixed_atomic[11] = 0;
@@ -2705,6 +2768,7 @@ int main(int argc, char** argv) {
             v40_tail(v36_compute_source) +
             v39_tail(v36_compute_source) +
             v37_tail(v36_compute_source)) {
+        v36_compute_bytes.resize(v36_compute_bytes.size() - v55_ds_slice_tail(v36_compute_source));  // v55 DS-seed slices
         v36_compute_bytes.resize(v36_compute_bytes.size() - v50_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v49_tail(v36_compute_source));
         v36_compute_bytes.resize(v36_compute_bytes.size() - v48_tail(v36_compute_source));
@@ -3094,7 +3158,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 54 &&
+              failed_compute_loaded.format_version == 55 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -3333,7 +3397,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 54 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 55 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -3408,6 +3472,7 @@ int main(int argc, char** argv) {
             v44_tail(failed_capture) +
             v43_tail(failed_capture) +
             v42_tail(failed_capture) + v41_tail(failed_capture)) {
+        v40_failed_bytes.resize(v40_failed_bytes.size() - v55_ds_slice_tail(failed_capture));  // v55 DS-seed slices
         v40_failed_bytes.resize(v40_failed_bytes.size() - v50_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v49_tail(failed_capture));
         v40_failed_bytes.resize(v40_failed_bytes.size() - v48_tail(failed_capture));
@@ -3497,6 +3562,7 @@ int main(int argc, char** argv) {
     if (v13_bytes.size() >= 32) {
         const size_t legacy_resource_count = legacy_source.draws[0].vrt.resources.size() +
                                              legacy_source.draws[0].prt.resources.size();
+        v13_bytes.resize(v13_bytes.size() - v55_ds_slice_tail(legacy_source));  // v55 DS-seed slices
         v13_bytes.resize(v13_bytes.size() - v50_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v49_tail(legacy_source));
         v13_bytes.resize(v13_bytes.size() - v48_tail(legacy_source));
@@ -3619,9 +3685,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 55;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 56;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 55",
+          error == "unsupported capture version 56",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -823,28 +823,82 @@ int main(int argc, char** argv) {
     std::filesystem::remove(runtime, ec);
     std::filesystem::remove(runtime_capture, ec);
     std::filesystem::remove(predecessor_capture, ec);
-    // #2550 review: the submit cap is a decision the hook must make BEFORE capturing. A cap of zero
-    // means uncapped; below the cap appends; at or above it does not. The ordering itself lives at
-    // the call site, and this pins the predicate it calls.
-    CHECK(!prosper::gpu::frame_bundle_submit_capped(0, 0) &&
-              !prosper::gpu::frame_bundle_submit_capped(1000000, 0),
-          "a zero submit cap never caps");
-    CHECK(!prosper::gpu::frame_bundle_submit_capped(0, 40) &&
-              !prosper::gpu::frame_bundle_submit_capped(39, 40),
-          "submits below the cap are appended");
-    CHECK(prosper::gpu::frame_bundle_submit_capped(40, 40) &&
-              prosper::gpu::frame_bundle_submit_capped(41, 40),
-          "the submit at the cap, and every one after it, is not appended");
+    // #2550 review round 2: test the ORDERING and the BASELINE, not predicates that merely return
+    // the right answer. The previous version called two pure helpers directly, so moving the cap
+    // check back below the capture, or deleting the baseline latch, left every assertion green.
+    // These drive the production seams and observe whether the injected capture step ran.
+    {
+        using prosper::gpu::FrameBundleAppendOutcome;
+        using prosper::gpu::FrameBundleAppendState;
 
-    // Window-scoped counters. The saturating arm is the one that matters: the counters are process
-    // totals, so a missed or late baseline would otherwise wrap and print a number near 2^64 as
-    // evidence of activity during a window that had none.
-    CHECK(prosper::gpu::frame_bundle_window_delta(100, 90) == 10,
-          "a window counter reports activity since the window opened, not since process start");
-    CHECK(prosper::gpu::frame_bundle_window_delta(90, 90) == 0,
-          "a window with no hook activity reports zero");
-    CHECK(prosper::gpu::frame_bundle_window_delta(5, 90) == 0,
-          "a baseline above the total saturates to zero instead of wrapping");
+        // At the cap: the capture step must NOT run, and the already-appended submits and the
+        // failed flag must be untouched. This is the "a failing N+1 submit preserves the first N"
+        // property -- at the cap the N+1 capture never executes, so it cannot fail the bundle.
+        int ran = 0;
+        FrameBundleAppendState at_cap{true, false, 40, 40};
+        auto never_ok = [&]() { ++ran; return false; };
+        const auto capped = prosper::gpu::frame_bundle_append_submit(at_cap, never_ok);
+        CHECK(capped == FrameBundleAppendOutcome::Capped && ran == 0,
+              "at the submit cap the capture step does not run");
+        CHECK(!at_cap.failed && at_cap.submits_appended == 40,
+              "a capped submit preserves the bundle: not failed, count unchanged");
+
+        // Below the cap the step runs and the count advances.
+        ran = 0;
+        FrameBundleAppendState below{true, false, 39, 40};
+        auto ok = [&]() { ++ran; return true; };
+        CHECK(prosper::gpu::frame_bundle_append_submit(below, ok) ==
+                      FrameBundleAppendOutcome::Appended &&
+                  ran == 1 && below.submits_appended == 40 && !below.failed,
+              "below the cap the capture step runs and the submit is appended");
+
+        // A genuine capture failure below the cap does mark the bundle failed -- the cap changes
+        // WHEN the step runs, never whether a real failure is honoured.
+        ran = 0;
+        FrameBundleAppendState failing{true, false, 1, 40};
+        CHECK(prosper::gpu::frame_bundle_append_submit(failing, never_ok) ==
+                      FrameBundleAppendOutcome::Failed &&
+                  ran == 1 && failing.failed && failing.submits_appended == 1,
+              "a capture failure below the cap fails the bundle and appends nothing");
+
+        // Uncapped, and the closed-window cases.
+        ran = 0;
+        FrameBundleAppendState uncapped{true, false, 1000000, 0};
+        CHECK(prosper::gpu::frame_bundle_append_submit(uncapped, ok) ==
+                      FrameBundleAppendOutcome::Appended && ran == 1,
+              "a zero cap never caps, however many submits have been appended");
+        ran = 0;
+        FrameBundleAppendState closed{false, false, 0, 40};
+        FrameBundleAppendState already_failed{true, true, 0, 40};
+        CHECK(prosper::gpu::frame_bundle_append_submit(closed, ok) ==
+                      FrameBundleAppendOutcome::NotCapturing &&
+                  prosper::gpu::frame_bundle_append_submit(already_failed, ok) ==
+                      FrameBundleAppendOutcome::NotCapturing && ran == 0,
+              "a closed or already-failed window runs no capture step");
+    }
+    {
+        using prosper::gpu::FrameBundleWindowCounters;
+        // Two windows over one process. The counters are process totals, so the second window must
+        // report only its own activity -- deleting the latch in frame_bundle_open_window() makes
+        // this report the totals and fails here.
+        FrameBundleWindowCounters baseline{};
+        prosper::gpu::frame_bundle_open_window(baseline, {10, 3, 2});
+        const auto first = prosper::gpu::frame_bundle_window_report({14, 5, 2}, baseline);
+        CHECK(first.reached == 4 && first.inactive == 2 && first.not_capturing == 0,
+              "a window reports activity since it opened, not since process start");
+
+        prosper::gpu::frame_bundle_open_window(baseline, {14, 5, 2});
+        const auto second = prosper::gpu::frame_bundle_window_report({14, 5, 2}, baseline);
+        CHECK(second.reached == 0 && second.inactive == 0 && second.not_capturing == 0,
+              "a second window with no activity reports zero, not the first window's counts");
+
+        // Saturating: a missed or late latch must print 0, never a wrapped count near 2^64.
+        FrameBundleWindowCounters late{};
+        prosper::gpu::frame_bundle_open_window(late, {90, 90, 90});
+        const auto backwards = prosper::gpu::frame_bundle_window_report({5, 5, 5}, late);
+        CHECK(backwards.reached == 0 && backwards.inactive == 0 && backwards.not_capturing == 0,
+              "a baseline above the total saturates to zero instead of wrapping");
+    }
 
     std::filesystem::remove(bundle_capture, ec);
     std::filesystem::remove(compat_v2, ec);

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -828,5 +828,29 @@ int main(int argc, char** argv) {
     std::filesystem::remove(version1, ec);
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
     std::printf("== PASS ==\n");
+    
+    // #2550 review: the submit cap is a decision the hook must make BEFORE capturing. A cap of zero
+    // means uncapped; below the cap appends; at or above it does not. The ordering itself lives at
+    // the call site, and this pins the predicate it calls.
+    CHECK(!prosper::gpu::frame_bundle_submit_capped(0, 0) &&
+              !prosper::gpu::frame_bundle_submit_capped(1000000, 0),
+          "a zero submit cap never caps");
+    CHECK(!prosper::gpu::frame_bundle_submit_capped(0, 40) &&
+              !prosper::gpu::frame_bundle_submit_capped(39, 40),
+          "submits below the cap are appended");
+    CHECK(prosper::gpu::frame_bundle_submit_capped(40, 40) &&
+              prosper::gpu::frame_bundle_submit_capped(41, 40),
+          "the submit at the cap, and every one after it, is not appended");
+
+    // Window-scoped counters. The saturating arm is the one that matters: the counters are process
+    // totals, so a missed or late baseline would otherwise wrap and print a number near 2^64 as
+    // evidence of activity during a window that had none.
+    CHECK(prosper::gpu::frame_bundle_window_delta(100, 90) == 10,
+          "a window counter reports activity since the window opened, not since process start");
+    CHECK(prosper::gpu::frame_bundle_window_delta(90, 90) == 0,
+          "a window with no hook activity reports zero");
+    CHECK(prosper::gpu::frame_bundle_window_delta(5, 90) == 0,
+          "a baseline above the total saturates to zero instead of wrapping");
+
     return 0;
 }

--- a/prosper/tests/test_gpu_timeline.cpp
+++ b/prosper/tests/test_gpu_timeline.cpp
@@ -823,12 +823,6 @@ int main(int argc, char** argv) {
     std::filesystem::remove(runtime, ec);
     std::filesystem::remove(runtime_capture, ec);
     std::filesystem::remove(predecessor_capture, ec);
-    std::filesystem::remove(bundle_capture, ec);
-    std::filesystem::remove(compat_v2, ec);
-    std::filesystem::remove(version1, ec);
-    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
-    std::printf("== PASS ==\n");
-    
     // #2550 review: the submit cap is a decision the hook must make BEFORE capturing. A cap of zero
     // means uncapped; below the cap appends; at or above it does not. The ordering itself lives at
     // the call site, and this pins the predicate it calls.
@@ -851,6 +845,12 @@ int main(int argc, char** argv) {
           "a window with no hook activity reports zero");
     CHECK(prosper::gpu::frame_bundle_window_delta(5, 90) == 0,
           "a baseline above the total saturates to zero instead of wrapping");
+
+    std::filesystem::remove(bundle_capture, ec);
+    std::filesystem::remove(compat_v2, ec);
+    std::filesystem::remove(version1, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
 
     return 0;
 }

--- a/prosper/tests/test_indirect_pointer_descriptor_range.cpp
+++ b/prosper/tests/test_indirect_pointer_descriptor_range.cpp
@@ -430,7 +430,7 @@ void test_capture_roundtrip(const Shape& shape, const std::vector<uint32_t>& exa
     CHECK(capture_submit_items(
               {}, {compute}, {{SubmitOperationKind::Dispatch, 0u, 1u}},
               metadata, capture_reader, captured, error) &&
-              captured.format_version == 54u,
+              captured.format_version == 55u,
           "v53 capture stores a DescriptorRange dispatch without reading unused candidates");
     const GpuCapturedResource* captured_unused = captured_resource_at(
         captured, unused_large_pc);

--- a/prosper/tests/test_indirect_pointer_static_footprint.cpp
+++ b/prosper/tests/test_indirect_pointer_static_footprint.cpp
@@ -563,7 +563,7 @@ int main() {
               {}, {captured_compute},
               {{SubmitOperationKind::Dispatch, 0u, 1u}}, metadata,
               capture_reader, captured, capture_error) &&
-              captured.format_version == 54u && captured.computes.size() == 1u &&
+              captured.format_version == 55u && captured.computes.size() == 1u &&
               captured.computes[0].resources.resources[0].internal_bytes.size() ==
                   compiled_source->host_data_size,
           "capture stores the dispatch-owned relocation snapshot as v53 internal bytes");

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -1033,6 +1033,19 @@ int main() {
             }
         }
 
+        // The backend colour-format mapping that frontends/shared/mrt_binding.hpp's active-binding
+        // rule depends on. It is TOTAL: every unrecognised raw value, zero included, maps to
+        // R8G8B8A8_UNORM, so the format term in that rule never rejects a slot. Pinned here, in a
+        // test that actually links the backend, because mrt_binding's own test must model the
+        // predicate rather than call it -- and a silently narrowed mapping would invalidate that
+        // model instead of failing.
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_UNDEFINED) ==
+                  VK_FORMAT_R8G8B8A8_UNORM,
+              "#2550: an undefined colour format maps to the RGBA8 fallback, it is not rejected");
+        CHECK(prosper::test::backend_color_format(static_cast<VkFormat>(0x7fffffff)) ==
+                  VK_FORMAT_R8G8B8A8_UNORM,
+              "#2550: the backend colour-format mapping is total");
+
         // #2550 review round 3: the depth-feedback splitter's per-segment contract. A logical
         // five-MRT pass that splits at a depth write->sample transition handed every pre-final
         // segment `mrt_outputs == nullptr`, so those segments rendered with ONE attachment and

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -1076,11 +1076,20 @@ int main() {
             CHECK(mid_seg.target.load_existing_slots[2] && last_seg.target.load_existing_slots[2] &&
                       mid_seg.target.load_existing && mid_seg.target.load_existing1,
                   "#2550: every later segment loads every persistent slot");
-            // Non-final segments copy nothing out: their pixels are discarded, and `color_count > 2`
-            // alone would force a full-extent readback per slot per segment.
-            CHECK(!first_seg.target.readback_slots[2] && !mid_seg.target.readback_slots[2] &&
-                      !first_seg.target.readback && !first_seg.target.readback1,
-                  "#2550: non-final segments read back no slot");
+            // A non-final segment discards its own slot-0 pixels but must COPY OUT everything it
+            // may have to carry -- slot 1 and every active slot 2+ -- or the next segment has
+            // nothing to be seeded with. Asserted on the value the helper returns, which is the
+            // value the segment actually renders under: an earlier version left this decision to
+            // the caller, so this assertion read `non-final segments read back no slot` and
+            // documented the opposite of the effective contract.
+            CHECK(!first_seg.target.readback && !mid_seg.target.readback,
+                  "#2550: a non-final segment does not copy out slot 0");
+            CHECK(first_seg.target.readback_slots[2] && mid_seg.target.readback_slots[2] &&
+                      first_seg.target.readback1 && mid_seg.target.readback1,
+                  "#2550: a non-final segment copies out every slot it may have to carry");
+            // Slots outside the active prefix are not touched.
+            CHECK(!first_seg.target.readback_slots[5],
+                  "#2550: a slot beyond color_count is not read back");
             CHECK(last_seg.target.readback_slots[2] && last_seg.target.readback,
                   "#2550: the final segment keeps the caller's readback contract");
             // The persistent identities must survive unchanged, or later segments would retain a

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -936,6 +936,77 @@ int main() {
             }
         }
 
+        // Slots 2..7 must RETAIN across render groups (#2550 review). Before persistence they were
+        // transient images created per backend call with LOAD_OP_CLEAR, so a G-buffer assembled by
+        // several groups against one set of allocations kept only the last group's work. GTA V's
+        // G-buffer accumulates across roughly sixteen groups per frame, so this was the difference
+        // between three complete attachments and three attachments holding one group each.
+        //
+        // Two groups against ONE persistent slot-2 id: the first writes red to MRT2, the second
+        // writes only MRT0 and must leave MRT2 alone. The negative arm below re-runs the second
+        // group with load_existing off and requires MRT2 to come back cleared -- without it, a test
+        // that never loads would pass just as happily on a backend that never clears.
+        const uint32_t mrt0_and_mrt2[] = {
+            0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,   // v0..3 = GREEN
+            0xF800100Fu, 0x03020100u,                             // exp mrt0  (vm)
+            0x7E0802F2u, 0x7E0A0280u, 0x7E0C0280u, 0x7E0E02F2u,   // v4..7 = RED
+            0xF800182Fu, 0x07060504u,                             // exp mrt2  (vm, done)
+            0xBF810000u,
+        };
+        const uint32_t mrt0_only[] = {
+            0x7E000280u, 0x7E020280u, 0x7E0402F2u, 0x7E0602F2u,   // v0..3 = BLUE
+            0xF800180Fu, 0x03020100u,                             // exp mrt0  (vm, done)
+            0xBF810000u,
+        };
+        std::vector<uint32_t> frg_a = recompile_fragment(mrt0_and_mrt2, std::size(mrt0_and_mrt2));
+        std::vector<uint32_t> frg_b = recompile_fragment(mrt0_only, std::size(mrt0_only));
+        CHECK(!frg_a.empty() && !frg_b.empty(),
+              "#2550: MRT0+MRT2 and MRT0-only fragment shaders both recompile");
+        if (!frg_a.empty() && !frg_b.empty()) {
+            const float black[4] = {0, 0, 0, 1};
+            auto run_group = [&](const std::vector<uint32_t>& fs, uint64_t slot2_id,
+                                 bool load_existing, std::vector<uint8_t>& slot2_out) {
+                prosper::test::BackendDraw draw;
+                draw.vs = vert; draw.fs = fs;
+                prosper::test::BackendColorTarget target{};
+                target.persistent_id_slots[2] = slot2_id;
+                target.load_existing_slots[2] = load_existing;
+                prosper::test::BackendMrtOutputs outputs;
+                outputs.color_count = 3;
+                prosper::test::render_draws_rgba({draw}, W, H, nullptr, black, false, &target,
+                                                 nullptr, black, nullptr, nullptr, true, &outputs);
+                slot2_out = std::move(outputs.colors[2]);
+            };
+            constexpr uint64_t kSlot2Id = 0x20aa2200ull;
+            std::vector<uint8_t> first, second, cleared;
+            run_group(frg_a, kSlot2Id, true, first);
+            run_group(frg_b, kSlot2Id, true, second);
+            const size_t px = (size_t)W * H * 4;
+            CHECK(first.size() == px && second.size() == px,
+                  "#2550: slot 2 reads back at full extent from both render groups");
+            if (first.size() == px && second.size() == px) {
+                const uint8_t* f = &first[((size_t)(H / 2) * W + W / 2) * 4];
+                const uint8_t* g = &second[((size_t)(H / 2) * W + W / 2) * 4];
+                printf("  slot2 group1=(%u,%u,%u) group2=(%u,%u,%u)\n",
+                       f[0], f[1], f[2], g[0], g[1], g[2]);
+                CHECK(f[0] > 0xC0 && f[1] < 0x40 && f[2] < 0x40,
+                      "#2550: group 1 writes RED to the retained MRT2 attachment");
+                CHECK(g[0] > 0xC0 && g[1] < 0x40 && g[2] < 0x40,
+                      "#2550: group 2 does NOT clear MRT2 -- the first group's pixels survive");
+            }
+            // Negative arm: the same second group with load_existing off must come back cleared, so
+            // the assertion above is demonstrably sensitive to the LOAD and not to the backend
+            // simply never touching the attachment.
+            run_group(frg_a, kSlot2Id + 0x1000, true, first);
+            run_group(frg_b, kSlot2Id + 0x1000, false, cleared);
+            if (cleared.size() == px) {
+                const uint8_t* c = &cleared[((size_t)(H / 2) * W + W / 2) * 4];
+                printf("  slot2 no-load group2=(%u,%u,%u)\n", c[0], c[1], c[2]);
+                CHECK(c[0] < 0x40,
+                      "#2550: with load_existing off the second group DOES clear MRT2");
+            }
+        }
+
         // MRT3-only. This asserted `.empty()` until 2026-08-15, when the fragment shell's colour
         // outputs went from 2 to 8 -- MRT3 is now genuinely supported, so rejecting it would be the
         // defect rather than the guard. The original concern was never "MRT3 must fail"; it was that

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -260,6 +260,40 @@ int main() {
     CHECK(!recompile_fragment(astro_partial_ps, std::size(astro_partial_ps)).empty(),
           "#825: recompiled Astro Bot's partial-EN fragment shader");
 
+    // Five-MRT export (#GTA5 G-buffer). EXP encoding: EN in bits[3:0], TARGET in bits[9:4],
+    // COMPR bit10, DONE bit11, VM bit12; MRT0..MRT7 are targets 0..7. Each export names v0 for all
+    // four channels (second dword 0), so the shader is a legal minimal five-target G-buffer writer.
+    //
+    // This is the regression for the defect that hid GTA V's entire 3D world: the fragment shell's
+    // colour-output array, the export-mask decoder and the emit-side `exported` array were all sized
+    // 2, so exports to MRT2+ were discarded. The live executor then does
+    // `write_mask &= (exp_mask >> slot*4) & 0xf` per slot, which turned every slot above 1 into a
+    // zero write mask -- the attachment was dropped no matter what CB_TARGET_MASK said.
+    //
+    // The mask below is the arm that fails without the fix: the old two-slot decoder can only ever
+    // return 0x000000ff, so asserting the full five-nibble value cannot pass by coincidence.
+    const uint32_t five_mrt_ps[] = {
+        0x7E000280u,                 // v_mov_b32 v0, 0
+        0xF800100Fu, 0x00000000u,    // exp mrt0 v0,v0,v0,v0   EN=0xf vm
+        0xF800101Fu, 0x00000000u,    // exp mrt1
+        0xF800102Fu, 0x00000000u,    // exp mrt2
+        0xF800103Fu, 0x00000000u,    // exp mrt3
+        0xF800184Fu, 0x00000000u,    // exp mrt4 ... done
+        0xBF810000u,                 // s_endpgm
+    };
+    const uint32_t five_mrt_mask =
+        fragment_color_export_mask(five_mrt_ps, std::size(five_mrt_ps));
+    printf("  five-MRT export mask = 0x%08x (want 0x000fffff)\n", five_mrt_mask);
+    CHECK(five_mrt_mask == 0x000fffffu,
+          "five-MRT fragment reports EN for MRT0..MRT4");
+    // Slots 2..4 specifically -- the ones the old array size could not represent. Stated separately
+    // so a future change that widens the array but breaks the shift still fails on the right claim.
+    CHECK(((five_mrt_mask >> 8) & 0xfu) == 0xfu, "five-MRT fragment: MRT2 has a full write mask");
+    CHECK(((five_mrt_mask >> 12) & 0xfu) == 0xfu, "five-MRT fragment: MRT3 has a full write mask");
+    CHECK(((five_mrt_mask >> 16) & 0xfu) == 0xfu, "five-MRT fragment: MRT4 has a full write mask");
+    CHECK(!recompile_fragment(five_mrt_ps, std::size(five_mrt_ps)).empty(),
+          "five-MRT fragment recompiles to a module with five colour outputs");
+
     const uint32_t astro_ngg_vs[] = {
         0xBFA00001u, 0x93EAFF03u, 0x00080008u, 0x876BFF03u, 0x000000FFu,
         0x8F6A8C6Au, 0x887C6A6Bu, 0xBF800000u, 0xBF900009u, 0x906A8803u,
@@ -902,12 +936,21 @@ int main() {
             }
         }
 
+        // MRT3-only. This asserted `.empty()` until 2026-08-15, when the fragment shell's colour
+        // outputs went from 2 to 8 -- MRT3 is now genuinely supported, so rejecting it would be the
+        // defect rather than the guard. The original concern was never "MRT3 must fail"; it was that
+        // MRT3 must not be silently REMAPPED onto color0, which is what a naive widening would do
+        // and what the mask assertion below forbids directly: slot 3 set, slot 0 clear.
         const uint32_t mrt3_only[] = {
             0x7E0002F2u, 0x7E020280u, 0x7E040280u, 0x7E0602F2u,
             0xF800183Fu, 0x03020100u, 0xBF810000u,
         };
-        CHECK(recompile_fragment(mrt3_only, std::size(mrt3_only)).empty(),
-              "#635: unsupported MRT3-only export stays fail-visible instead of remapping to color0");
+        CHECK(!recompile_fragment(mrt3_only, std::size(mrt3_only)).empty(),
+              "#635: MRT3-only export recompiles now that the shell carries eight colour outputs");
+        const uint32_t mrt3_mask = fragment_color_export_mask(mrt3_only, std::size(mrt3_only));
+        printf("  MRT3-only export mask = 0x%08x (want 0x0000f000)\n", mrt3_mask);
+        CHECK(mrt3_mask == 0x0000f000u,
+              "#635: MRT3-only export lands on slot 3 and does NOT remap onto color0");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -1033,6 +1033,50 @@ int main() {
             }
         }
 
+        // #2550 review round 3: the depth-feedback splitter's per-segment contract. A logical
+        // five-MRT pass that splits at a depth write->sample transition handed every pre-final
+        // segment `mrt_outputs == nullptr`, so those segments rendered with ONE attachment and
+        // discarded their MRT1..4 exports -- the same accumulation loss this PR fixes at the
+        // frontend's pass groups, reappearing at the backend's own physical boundary.
+        {
+            prosper::test::BackendColorTarget whole{};
+            whole.persistent_id = 0x2050000000ull;
+            whole.persistent_id_slots[2] = 0x2083e00000ull;
+            prosper::test::BackendMrtOutputs whole_mrt;
+            whole_mrt.color_count = 5;
+
+            const auto first_seg = prosper::test::split_segment_contract(
+                &whole, &whole_mrt, /*first=*/true, /*final=*/false);
+            const auto mid_seg = prosper::test::split_segment_contract(
+                &whole, &whole_mrt, /*first=*/false, /*final=*/false);
+            const auto last_seg = prosper::test::split_segment_contract(
+                &whole, &whole_mrt, /*first=*/false, /*final=*/true);
+
+            // The shape is identical across segments. This is the blocker: it used to be 1 for
+            // every segment but the last.
+            CHECK(first_seg.color_count == 5 && mid_seg.color_count == 5 &&
+                      last_seg.color_count == 5,
+                  "#2550: every segment of a split pass renders the same MRT shape");
+            // Later segments LOAD every slot, or they erase their predecessors' work.
+            CHECK(!first_seg.target.load_existing_slots[2] || whole.load_existing_slots[2],
+                  "#2550: the first segment does not force a load it was not asked for");
+            CHECK(mid_seg.target.load_existing_slots[2] && last_seg.target.load_existing_slots[2] &&
+                      mid_seg.target.load_existing && mid_seg.target.load_existing1,
+                  "#2550: every later segment loads every persistent slot");
+            // Non-final segments copy nothing out: their pixels are discarded, and `color_count > 2`
+            // alone would force a full-extent readback per slot per segment.
+            CHECK(!first_seg.target.readback_slots[2] && !mid_seg.target.readback_slots[2] &&
+                      !first_seg.target.readback && !first_seg.target.readback1,
+                  "#2550: non-final segments read back no slot");
+            CHECK(last_seg.target.readback_slots[2] && last_seg.target.readback,
+                  "#2550: the final segment keeps the caller's readback contract");
+            // The persistent identities must survive unchanged, or later segments would retain a
+            // different image than the one they are accumulating into.
+            CHECK(mid_seg.target.persistent_id_slots[2] == 0x2083e00000ull &&
+                      mid_seg.target.persistent_id == 0x2050000000ull,
+                  "#2550: a segment keeps the whole pass's persistent identities");
+        }
+
         // MRT3-only. This asserted `.empty()` until 2026-08-15, when the fragment shell's colour
         // outputs went from 2 to 8 -- MRT3 is now genuinely supported, so rejecting it would be the
         // defect rather than the guard. The original concern was never "MRT3 must fail"; it was that

--- a/prosper/tests/test_recompiled_fragment.cpp
+++ b/prosper/tests/test_recompiled_fragment.cpp
@@ -889,17 +889,37 @@ int main() {
             0xF800180Fu, 0x07060504u,                             // exp mrt0 v4,v5,v6,v7
             0xBF810000u,                                          // s_endpgm
         };
+        // Rendered with FOUR attachments, which is what a shader exporting MRT3 is paired with in a
+        // real frame. It used to render into a single attachment, and that was only harmless while
+        // the recompiler silently dropped MRT3: once the shell carries eight outputs the module
+        // legitimately writes Location 3, and a one-attachment pass makes that write unused --
+        // caught by tools/vkval as `Undefined-Value-ShaderOutputNotConsumed`. Widening the pass is
+        // the faithful fix and strengthens the assertion: MRT0's blue must land on attachment 0 AND
+        // MRT3's red on attachment 3, which pins the mapping in both directions rather than only
+        // proving color0 is not red.
         std::vector<uint32_t> frg = recompile_fragment(ps, sizeof(ps)/sizeof(ps[0]));
         CHECK(!frg.empty(), "#566: recompiled descending-order 4-MRT (MRT3 then MRT0) PS -> SPIR-V");
         if (!frg.empty()) {
-            std::vector<uint8_t> px2 = prosper::test::render_triangle_rgba(vert, frg, W, H);
-            CHECK(px2.size() == (size_t)W*H*4, "rendered the MRT-order PS");
-            if (px2.size() == (size_t)W*H*4) {
+            prosper::test::BackendDraw draw;
+            draw.vs = vert; draw.fs = frg;
+            const float black[4] = {0, 0, 0, 1};
+            prosper::test::BackendMrtOutputs outputs;
+            outputs.color_count = 4;
+            std::vector<uint8_t> px2 = prosper::test::render_draws_rgba(
+                {draw}, W, H, nullptr, black, false, nullptr, nullptr, black, nullptr, nullptr,
+                true, &outputs);
+            const size_t want = (size_t)W * H * 4;
+            CHECK(px2.size() == want && outputs.colors[3].size() == want,
+                  "rendered the MRT-order PS into four attachments");
+            if (px2.size() == want && outputs.colors[3].size() == want) {
                 const uint8_t* cc = &px2[((size_t)(H/2) * W + W/2) * 4];
-                printf("  mrt-order center=(%u,%u,%u,%u) expect BLUE (MRT0), not RED (MRT3)\n",
-                       cc[0],cc[1],cc[2],cc[3]);
+                const uint8_t* c3 = &outputs.colors[3][((size_t)(H/2) * W + W/2) * 4];
+                printf("  mrt-order attachment0=(%u,%u,%u,%u) attachment3=(%u,%u,%u,%u)\n",
+                       cc[0],cc[1],cc[2],cc[3], c3[0],c3[1],c3[2],c3[3]);
                 CHECK(cc[2] > 0x80 && cc[0] < 0x40,
                       "#566: color0 receives MRT0 (BLUE), not the first-emitted MRT3 (RED)");
+                CHECK(c3[0] > 0x80 && c3[2] < 0x40,
+                      "#566: MRT3's RED lands on attachment 3, not discarded and not on color0");
             }
         }
     }
@@ -999,6 +1019,12 @@ int main() {
             // simply never touching the attachment.
             run_group(frg_a, kSlot2Id + 0x1000, true, first);
             run_group(frg_b, kSlot2Id + 0x1000, false, cleared);
+            // Assert the extent, do not merely gate on it. A regression that makes the no-load call
+            // fail and return an EMPTY buffer would otherwise skip the only assertion in this arm
+            // and take the negative control down with it, silently.
+            CHECK(cleared.size() == px,
+                  "#2550: the no-load arm reads back at full extent (its assertion cannot be "
+                  "skipped by an empty result)");
             if (cleared.size() == px) {
                 const uint8_t* c = &cleared[((size_t)(H / 2) * W + W / 2) * 4];
                 printf("  slot2 no-load group2=(%u,%u,%u)\n", c[0], c[1], c[2]);

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -827,9 +827,38 @@ int main() {
     });
     CHECK(count_occurrences(
               legacy_skip_capture.output,
-              "[compute] skip unsupported program 0x246813570000bb55\n") == 1 &&
+              "[compute] skip unsupported program 0x246813570000bb55 reason=unrecorded\n") == 1 &&
               legacy_skip_capture.output.find("role=consequent") == std::string::npos,
-          "non-debug live skips preserve the legacy once-per-address diagnostic");
+          "non-debug live skips stay once-per-address and say so when no reason was recorded");
+
+    // The point of the reason field: a program whose reject WAS recorded must name it on the
+    // non-debug line. Without this arm the change is indistinguishable from appending a constant --
+    // `reason=unrecorded` alone is satisfied by a version that never looks the reason up.
+    const uint64_t reasoned_program = 0x246813570000cc55ull;
+    const RecompileDiagnosticContext reasoned_diagnostic{
+        RecompileDiagnosticStage::Compute, reasoned_program};
+    (void)capture_stderr([&] {
+        record_recompile_reject_reason_for_test(reasoned_diagnostic, "compute-struct-reject",
+                                          "route-decline", "unclaimed execnz pc=428");
+    });
+    const CapturedStderr reasoned_skip_capture = capture_stderr([&] {
+        (void)report_compute_recompile_skip_once(reasoned_diagnostic);
+    });
+    CHECK(count_occurrences(
+              reasoned_skip_capture.output,
+              "[compute] skip unsupported program 0x246813570000cc55 "
+              "reason=compute-struct-reject unclaimed execnz pc=428\n") == 1,
+          "a recorded reject reason reaches the non-debug skip line");
+
+    // And a "consequent" line must NOT overwrite it. A consequent only restates that an empty result
+    // was returned; if it could win, the diagnostic would replace the answer with the question.
+    (void)capture_stderr([&] {
+        record_recompile_reject_reason_for_test(reasoned_diagnostic, "compute-recompile-reject",
+                                          "consequent", "reason=empty-result dispatch-skipped");
+    });
+    CHECK(last_terminal_reject_reason(reasoned_program) ==
+              "compute-struct-reject unclaimed execnz pc=428",
+          "a consequent line does not overwrite the recorded cause");
 
     // The unit-level reporter checks above deliberately keep cache-hit and legacy behavior focused,
     // but they cannot guard the executor's integration site: a live shader-recompile failure must

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -466,6 +466,66 @@ int main() {
         std::vector<uint8_t> via_bridge = prosper::test::render_draws_rgba({consumer}, W, H);
         CHECK(via_bridge.size() == (size_t)W * H * 4, "bridged consumer rendered");
 
+        // #2550 review round 4: a depth-feedback SPLIT must not lose MRT2's pixels when the slot
+        // is not persistent.
+        //
+        // Segment 1 writes depth and RED to MRT2. The consumer above samples that same depth, which
+        // is a write->sample transition, so depth_feedback_split_index() forces a physical pass
+        // boundary between them. `color_target` is null here -- the state every path with live GPU
+        // targets disabled runs in -- so MRT2 has no persistent identity and the second segment gets
+        // a fresh transient attachment. The earlier segment's pixels reach it only by being read
+        // back and seeded in.
+        //
+        // Before that carry existed, the final MRT2 came back cleared: the shape and the load flags
+        // were already correct, so nothing else in the suite could see it.
+        {
+            const uint32_t mrt0_and_mrt2[] = {
+                0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,   // v0..3 = GREEN
+                0xF800100Fu, 0x03020100u,                             // exp mrt0  (vm)
+                0x7E0802F2u, 0x7E0A0280u, 0x7E0C0280u, 0x7E0E02F2u,   // v4..7 = RED
+                0xF800182Fu, 0x07060504u,                             // exp mrt2  (vm, done)
+                0xBF810000u,
+            };
+            std::vector<uint32_t> split_fs =
+                recompile_fragment(mrt0_and_mrt2, std::size(mrt0_and_mrt2));
+            CHECK(!split_fs.empty(), "#2550: MRT0+MRT2 depth-writing producer recompiles");
+            if (!split_fs.empty()) {
+                // MRT2 needs its OWN write mask and format: `producer` sets only the named slot-0
+                // mask, and a zero per-slot mask masks the shader's MRT2 export straight out. The
+                // first version of this fixture missed that and read black for the right reason at
+                // the wrong layer.
+                ResolvedPipelineState split_producer = producer;
+                split_producer.color_targets[2].write_mask = 0xFu;
+                split_producer.color_targets[2].format =
+                    static_cast<uint32_t>(VK_FORMAT_R8G8B8A8_UNORM);
+                prosper::test::BackendDraw writer;
+                writer.vs = vert_z; writer.fs = split_fs; writer.ps = &split_producer;
+                writer.vcount = 3;
+                prosper::test::BackendMrtOutputs split_out;
+                split_out.color_count = 3;
+                // Deliberately NO BackendColorTarget: this is the non-persistent path.
+                std::vector<uint8_t> split_c0 = prosper::test::render_draws_rgba(
+                    {writer, consumer}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true,
+                    /*color_target=*/nullptr, nullptr, nullptr, nullptr, nullptr, true,
+                    &split_out);
+
+                // The split must actually have happened, or this proves nothing about carrying.
+                const std::vector<prosper::test::BackendDraw> split_draws{writer, consumer};
+                CHECK(prosper::test::depth_feedback_split_index(split_draws, W, H) == 1u,
+                      "#2550: the depth write->sample transition forces a physical pass split");
+                CHECK(split_c0.size() == (size_t)W * H * 4 &&
+                          split_out.colors[2].size() == (size_t)W * H * 4,
+                      "#2550: a split pass still reads back MRT2 at full extent");
+                if (split_out.colors[2].size() == (size_t)W * H * 4) {
+                    const uint8_t* m2 =
+                        &split_out.colors[2][(((size_t)H / 2) * W + W / 2) * 4];
+                    std::printf("  split MRT2 center=(%u,%u,%u)\n", m2[0], m2[1], m2[2]);
+                    CHECK(m2[0] > 0xC0 && m2[2] < 0x40,
+                          "#2550: segment 1's RED survives the split into the final MRT2");
+                }
+            }
+        }
+
         std::vector<uint8_t> zeros((size_t)W * H * 4, 0);
         prosper::test::FrameResource unbridged = bridged;
         unbridged.persistent_depth_target_id = 0;

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -303,6 +303,48 @@ int main() {
               false, true, true, VK_COMPARE_OP_NEVER),
           "a depth write masked by NEVER does not claim writer recency");
 
+    // DB_DEPTH_VIEW slice identity. A cube shadow map is ONE six-layer guest allocation: all six
+    // faces share a depth base and the guest selects the face with DB_DEPTH_VIEW.SLICE_START/MAX.
+    // GTA V programs exactly these values against one base, one per face.
+    {
+        struct { uint32_t view, start, max; } const faces[] = {
+            {0x02000000u, 0u, 0u}, {0x02002001u, 1u, 1u}, {0x02004002u, 2u, 2u},
+            {0x02006003u, 3u, 3u}, {0x02008004u, 4u, 4u}, {0x0200a005u, 5u, 5u},
+        };
+        bool decoded = true;
+        for (const auto& face : faces)
+            decoded = decoded &&
+                prosper::test::ds_depth_view_slice_start(face.view) == face.start &&
+                prosper::test::ds_depth_view_slice_max(face.view) == face.max;
+        CHECK(decoded, "DB_DEPTH_VIEW decodes SLICE_START/MAX for all six cube faces");
+
+        // The regression proper: two faces of one cube differ ONLY in slice, and must not collide.
+        // Before slice joined the key they shared one entry, so each face render reused and
+        // overwrote the previous face's host image and only the last face survived -- a corruption
+        // of retained depth that no consumer could recover a valid cube from.
+        constexpr uint64_t kCubeBase = 0x20d5cbe000ull;
+        constexpr uint32_t kFaceW = 512, kFaceH = 512;
+        auto face_key = [&](uint32_t slice) {
+            return prosper::test::PersistentDsKey{
+                kCubeBase, kCubeBase, 0, 0, 0, kFaceW, kFaceH,
+                static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT), slice};
+        };
+        CHECK(!(face_key(0) == face_key(1)),
+              "two cube faces of one allocation are distinct DS identities");
+        auto& cache = prosper::test::persistent_ds_cache();
+        const size_t before = cache.size();
+        auto& face0 = cache[face_key(0)];
+        auto& face5 = cache[face_key(5)];
+        face0.image = (VkImage)(uintptr_t)0x501; face0.layout_initialized = true;
+        face5.image = (VkImage)(uintptr_t)0x505; face5.layout_initialized = true;
+        CHECK(cache.size() == before + 2,
+              "six-layer cube retains one host image per face, not one for all six");
+        CHECK(face0.image != face5.image && cache[face_key(0)].image == face0.image,
+              "a later face render does not overwrite an earlier face's retained image");
+        cache.erase(face_key(0));
+        cache.erase(face_key(5));
+    }
+
     // Exercise the actual D32/D32S8 sibling selector, not just the predicate above. A read-only
     // touch of the older format must not steal recency from the surface that was really written.
     {

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -526,6 +526,116 @@ int main() {
             }
         }
 
+        // A NON-ZERO MRT2 identity with backend persistence DISABLED. This is the case a carry
+        // decision keyed on the identity gets wrong: the contract says "retained", the backend
+        // creates a transient image anyway, and the next segment starts from a cleared attachment.
+        // The same happens on an over-budget allocation fallback, which leaves the identity
+        // non-zero too -- so the wrapper does not predict residency, it captures unconditionally.
+        {
+            const uint32_t mrt0_and_mrt2_id[] = {
+                0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,
+                0xF800100Fu, 0x03020100u,
+                0x7E0802F2u, 0x7E0A0280u, 0x7E0C0280u, 0x7E0E02F2u,
+                0xF800182Fu, 0x07060504u,
+                0xBF810000u,
+            };
+            std::vector<uint32_t> id_fs =
+                recompile_fragment(mrt0_and_mrt2_id, std::size(mrt0_and_mrt2_id));
+            if (!id_fs.empty()) {
+                ResolvedPipelineState id_producer = producer;
+                id_producer.color_targets[2].write_mask = 0xFu;
+                id_producer.color_targets[2].format =
+                    static_cast<uint32_t>(VK_FORMAT_R8G8B8A8_UNORM);
+                prosper::test::BackendDraw id_writer;
+                id_writer.vs = vert_z; id_writer.fs = id_fs; id_writer.ps = &id_producer;
+                id_writer.vcount = 3;
+                prosper::test::BackendColorTarget id_target{};
+                id_target.persistent_id = 0x20aa0000ull;
+                id_target.persistent_id_slots[2] = 0x20aa2000ull;   // non-zero: "retained"
+                prosper::test::BackendMrtOutputs id_out;
+                id_out.color_count = 3;
+#ifdef _WIN32
+                _putenv_s("PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS", "1");
+#else
+                setenv("PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS", "1", 1);
+#endif
+                std::vector<uint8_t> id_c0 = prosper::test::render_draws_rgba(
+                    {id_writer, consumer}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true,
+                    &id_target, nullptr, nullptr, nullptr, nullptr, true, &id_out);
+#ifdef _WIN32
+                _putenv_s("PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS", "");
+#else
+                unsetenv("PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS");
+#endif
+                CHECK(id_c0.size() == (size_t)W * H * 4 &&
+                          id_out.colors[2].size() == (size_t)W * H * 4,
+                      "#2550: a split with a non-zero identity still reads back MRT2");
+                if (id_out.colors[2].size() == (size_t)W * H * 4) {
+                    const uint8_t* m2 = &id_out.colors[2][(((size_t)H / 2) * W + W / 2) * 4];
+                    std::printf("  split MRT2 (id set, persistence off) center=(%u,%u,%u)\n",
+                                m2[0], m2[1], m2[2]);
+                    CHECK(m2[0] > 0xC0 && m2[2] < 0x40,
+                          "#2550: a non-zero identity does not establish residency -- MRT2 still "
+                          "survives the split with backend persistence disabled");
+                }
+            }
+        }
+
+        // The same split, for MRT1, through the LIVE RENDERER's calling convention: `out_rgba1` is
+        // null and slot 1 arrives via BackendMrtOutputs. On that path the non-final segment's
+        // slot-1 readback landed in `intermediate_mrt.colors[1]` while the wrapper only carried a
+        // seed forward inside `if (out_rgba1)`, so MRT1 was lost on every split -- and the MRT2 test
+        // above cannot see it, because it deliberately jumps from MRT0 to MRT2.
+        {
+            const uint32_t mrt0_and_mrt1[] = {
+                0x7E000280u, 0x7E0202F2u, 0x7E040280u, 0x7E0602F2u,   // v0..3 = GREEN
+                0xF800100Fu, 0x03020100u,                             // exp mrt0  (vm)
+                0x7E0802F2u, 0x7E0A0280u, 0x7E0C0280u, 0x7E0E02F2u,   // v4..7 = RED
+                0xF800181Fu, 0x07060504u,                             // exp mrt1  (vm, done)
+                0xBF810000u,
+            };
+            std::vector<uint32_t> split1_fs =
+                recompile_fragment(mrt0_and_mrt1, std::size(mrt0_and_mrt1));
+            CHECK(!split1_fs.empty(), "#2550: MRT0+MRT1 depth-writing producer recompiles");
+            if (!split1_fs.empty()) {
+                // Slot 1's blend write mask comes from the NAMED color1_write_mask
+                // (render_runner.h:5161), not from the per-slot array -- the established slot-0/1
+                // convention. Setting only the array leaves attachment 1 masked off, and the test
+                // then reads the clear colour and blames the carry. Set both, as render_state.cpp
+                // does when it resolves a real draw.
+                ResolvedPipelineState split1_producer = producer;
+                split1_producer.color1_write_mask = 0xFu;
+                split1_producer.color_targets[1].write_mask = 0xFu;
+                split1_producer.color1_format =
+                    static_cast<uint32_t>(VK_FORMAT_R8G8B8A8_UNORM);
+                split1_producer.color_targets[1].format =
+                    static_cast<uint32_t>(VK_FORMAT_R8G8B8A8_UNORM);
+                prosper::test::BackendDraw writer1;
+                writer1.vs = vert_z; writer1.fs = split1_fs; writer1.ps = &split1_producer;
+                writer1.vcount = 3;
+                prosper::test::BackendMrtOutputs split1_out;
+                split1_out.color_count = 2;
+                // out_rgba1 = nullptr, exactly as the live renderer calls it.
+                std::vector<uint8_t> split1_c0 = prosper::test::render_draws_rgba(
+                    {writer1, consumer}, W, H, nullptr, nullptr, /*persist_depth_stencil=*/true,
+                    /*color_target=*/nullptr, nullptr, nullptr, /*out_rgba1=*/nullptr, nullptr,
+                    true, &split1_out);
+                const std::vector<prosper::test::BackendDraw> split1_draws{writer1, consumer};
+                CHECK(prosper::test::depth_feedback_split_index(split1_draws, W, H) == 1u,
+                      "#2550: the MRT1 fixture also splits at the depth write->sample transition");
+                CHECK(split1_c0.size() == (size_t)W * H * 4 &&
+                          split1_out.colors[1].size() == (size_t)W * H * 4,
+                      "#2550: a split pass reads back MRT1 through BackendMrtOutputs");
+                if (split1_out.colors[1].size() == (size_t)W * H * 4) {
+                    const uint8_t* m1 =
+                        &split1_out.colors[1][(((size_t)H / 2) * W + W / 2) * 4];
+                    std::printf("  split MRT1 center=(%u,%u,%u)\n", m1[0], m1[1], m1[2]);
+                    CHECK(m1[0] > 0xC0 && m1[2] < 0x40,
+                          "#2550: segment 1's RED survives the split into the final MRT1");
+                }
+            }
+        }
+
         std::vector<uint8_t> zeros((size_t)W * H * 4, 0);
         prosper::test::FrameResource unbridged = bridged;
         unbridged.persistent_depth_target_id = 0;

--- a/prosper/tests/test_shadow_compare_render.cpp
+++ b/prosper/tests/test_shadow_compare_render.cpp
@@ -318,6 +318,25 @@ int main() {
                 prosper::test::ds_depth_view_slice_max(face.view) == face.max;
         CHECK(decoded, "DB_DEPTH_VIEW decodes SLICE_START/MAX for all six cube faces");
 
+        // Exercise the PRODUCTION construction seam, not a hand-built key. Building PersistentDsKey
+        // directly asserts only that the struct has a slice field and stays green if the backend's
+        // decode is reverted; persistent_ds_key_for() is the function the backend actually calls.
+        {
+            prosper::gpu::ResolvedPipelineState face0{}, face1{};
+            face0.depth_read_base = face1.depth_read_base = 0x20d5cbe000ull;
+            face0.depth_write_base = face1.depth_write_base = 0x20d5cbe000ull;
+            face0.db_depth_view = 0x02000000u;   // SLICE_START=MAX=0
+            face1.db_depth_view = 0x02002001u;   // SLICE_START=MAX=1
+            const auto k0 = prosper::test::persistent_ds_key_for(
+                face0, 0, 512, 512, static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT));
+            const auto k1 = prosper::test::persistent_ds_key_for(
+                face1, 0, 512, 512, static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT));
+            CHECK(k0.slice == 0u && k1.slice == 1u,
+                  "the production DS identity derives its slice from DB_DEPTH_VIEW");
+            CHECK(!(k0 == k1),
+                  "two cube faces built through the production seam are distinct identities");
+        }
+
         // The regression proper: two faces of one cube differ ONLY in slice, and must not collide.
         // Before slice joined the key they shared one entry, so each face render reused and
         // overwrote the previous face's host image and only the last face survived -- a corruption

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -250,3 +250,37 @@ invoke Vulkan. The latch belongs to the process-local capture request and still 
 or causality between the phase dispatch and a later draw.
 `PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES=N` and
 `PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES=N` restrict the same checkpoint by semantic dispatch count.
+
+## `rtt_pass_graph.py` — one frame's render-pass graph from a `PROSPER_RTTLOG=1` log
+
+Answers "where does the picture stop being there". A title can render a complete world into an
+off-screen target and still present black, and neither a draw census nor a target census can see
+that: both count *work*, and the defect is in the *dataflow*. What separates the two is the pair
+(what a pass sampled, what its output then contained), which `PROSPER_RTTLOG` already prints and
+which nothing assembled.
+
+```bash
+PROSPER_RTTLOG=1 ./prosper-app <DUMP_ROOT>/<TITLE_ID>-app0 > run.log 2>&1
+python3 tools/gpu_timeline/rtt_pass_graph.py run.log --frames 1 --min-draws 4
+python3 tools/gpu_timeline/rtt_pass_graph.py run.log --only 0xADDR      # passes touching one surface
+```
+
+The log interleaves two line kinds and the ordering is the whole trick: every `[rtt] sample tex`
+line belongs to a draw of the **next** `[rtt] pass` line, so a pass's inputs are exactly the samples
+since the previous pass, and `SCANOUT` delimits frames. Each input is annotated with how it actually
+resolved — `depth-bridge`, `stencil-bridge`, `UNIFORM COLOUR`, or `MISS -- guest bytes`.
+
+Three traps in the numbers it prints, all of which produced a wrong conclusion before being fixed:
+
+- **`rgb_nonblack` comes from an RGBA8 conversion**, so an HDR f16 target whose values sit below
+  1/255 reports exactly ZERO while carrying a complete scene. Use `PROSPER_DUMP_PASS` and look.
+- **`px_nonzero` counts BYTES and includes alpha.** A 3840x2160 buffer reading
+  `px_nonzero=8294400 rgb_nonblack=3527` is alpha-only, not "nearly full".
+- **A pass whose readback was deferred has EMPTY cpu pixels**, so both numbers describe nothing.
+  `PROSPER_RTTLOG` itself forces the readback that materialises them, which means enabling this log
+  changes what the renderer does — any per-pass content number describes a run made differently from
+  a default one.
+
+`PROSPER_DUMP_PASS=0xADDR[,…]` (with `PROSPER_DUMP_PASS_EVERY=N`, default 60) writes what a pass
+actually produced as an image, for slot 0 and for MRT slots 1..7, and reports `src=…B` plus
+`NO CPU PIXELS (readback deferred)` rather than silently writing no file.

--- a/prosper/tools/gpu_timeline/rtt_pass_graph.py
+++ b/prosper/tools/gpu_timeline/rtt_pass_graph.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Reconstruct one frame's render-pass graph from a `PROSPER_RTTLOG=1` run log.
+
+The question this answers is "where does the picture stop being there". A title can render a complete
+world into an off-screen target and still present black, and neither a draw census nor a target census
+can see that: both are counts of *work*, and the defect is in the *dataflow*. What separates the two is
+the pair (what a pass sampled, what its output then contained), which `PROSPER_RTTLOG` already prints
+and which nothing assembled.
+
+The log interleaves two line kinds, and the ordering is the whole trick:
+
+    [rtt] sample tex addr=0x… WxH fmt=N -> HIT|miss (cache_size=…)     one per sampled binding
+    [rtt] pass target=0x… extent=WxH … (N draws) px_nonzero=… rgb_nonblack=…    one per pass group
+
+Every `sample` line belongs to a draw of the *next* `pass` line, so a pass's inputs are exactly the
+samples since the previous pass. Frames are delimited by the `SCANOUT` pass.
+
+`rgb_nonblack` is the number of pixels with a non-zero colour, so a pass whose inputs are populated and
+whose output is not is where content is lost. Note `px_nonzero` counts BYTES and includes alpha: a
+buffer reading `px_nonzero=8294400 rgb_nonblack=3527` at 3840x2160 is alpha-only, not "nearly full".
+That distinction is why both are printed here rather than a single "is it black" verdict.
+
+Usage:
+    rtt_pass_graph.py <run.log> [--frames N] [--min-draws N] [--only 0xADDR]
+"""
+import argparse
+import re
+import sys
+
+PASS_RE = re.compile(
+    r'\[rtt\] pass (?:target|c\d+)=(0x[0-9a-f]+) extent=(\d+)x(\d+).*?\((\d+) draws\) '
+    r'px_nonzero=(\d+)(?: rgb_nonblack=(\d+))?')
+SAMPLE_RE = re.compile(
+    r'\[rtt\] sample tex addr=(0x[0-9a-f]+) (\d+)x(\d+) fmt=(\d+) -> (HIT|miss|DS-DEPTH|DS-STENCIL)')
+
+# prosper::gpu::DataFormat, for reading a pass's role off its format rather than guessing from extent.
+FORMATS = {0: 'unknown', 1: 'f32', 2: 'u32', 3: 'i32', 4: 'f16', 5: 'un16', 6: 'sn16', 7: 'u16',
+           8: 'i16', 9: 'un8', 10: 'sn8', 11: 'u8', 12: 'i8', 13: 'bc1', 14: 'bc2', 15: 'bc3',
+           16: 'bc4', 17: 'bc5', 18: 'bc6', 19: 'bc7', 20: 'f11f11f10', 21: 'un2_10_10_10'}
+
+
+def fmt_name(n):
+    return FORMATS.get(n, 'fmt%d' % n)
+
+
+def parse(path):
+    """Yield frames, each a list of passes; a pass is (target, w, h, draws, nz, rgb, inputs, scanout)."""
+    frames, passes, pending = [], [], []
+    with open(path, 'r', errors='replace') as handle:
+        for line in handle:
+            if '[rtt] ' not in line:
+                continue
+            m = SAMPLE_RE.search(line)
+            if m:
+                pending.append((m.group(1), int(m.group(2)), int(m.group(3)),
+                                int(m.group(4)), m.group(5)))
+                continue
+            m = PASS_RE.search(line)
+            if not m:
+                continue
+            scanout = 'SCANOUT' in line
+            passes.append((m.group(1), int(m.group(2)), int(m.group(3)), int(m.group(4)),
+                           int(m.group(5)), int(m.group(6)) if m.group(6) else None,
+                           pending, scanout))
+            pending = []
+            if scanout:
+                frames.append(passes)
+                passes = []
+    if passes:
+        frames.append(passes)
+    return frames
+
+
+def summarize_inputs(inputs):
+    """Distinct sampled sources, in first-use order, with their hit state and sample count."""
+    order, seen = [], {}
+    for addr, w, h, fmt, state in inputs:
+        key = (addr, w, h, fmt)
+        if key not in seen:
+            seen[key] = [0, state]
+            order.append(key)
+        seen[key][0] += 1
+        if state == 'miss':
+            seen[key][1] = 'miss'
+    return [(k, seen[k][0], seen[k][1]) for k in order]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('log')
+    ap.add_argument('--frames', type=int, default=1, help='how many trailing frames to print')
+    ap.add_argument('--min-draws', type=int, default=0, help='hide passes below this draw count')
+    ap.add_argument('--only', help='print only passes writing or sampling this address')
+    args = ap.parse_args()
+
+    frames = parse(args.log)
+    if not frames:
+        print('no [rtt] pass lines found -- was the run made with PROSPER_RTTLOG=1?', file=sys.stderr)
+        return 1
+    print('%d frame(s) delimited by SCANOUT; showing the last %d\n' %
+          (len(frames), min(args.frames, len(frames))))
+
+    for frame in frames[-args.frames:]:
+        for target, w, h, draws, nz, rgb, inputs, scanout in frame:
+            if draws < args.min_draws:
+                continue
+            summarized = summarize_inputs(inputs)
+            if args.only and args.only not in (
+                    [target] + [k[0] for k, _, _ in summarized]):
+                continue
+            pixels = w * h
+            share = ('%5.1f%%' % (100.0 * rgb / pixels)) if rgb is not None and pixels else '    ?'
+            print('%s %-14s %9s draws=%-5d rgb_nonblack=%-9s (%s of %d px)  px_nonzero=%d' %
+                  ('SCANOUT' if scanout else '       ', target, '%dx%d' % (w, h), draws,
+                   rgb if rgb is not None else '?', share, pixels, nz))
+            for (addr, iw, ih, ifmt), count, state in summarized:
+                print('             <- %-14s %9s %-12s x%-4d %s' %
+                      (addr, '%dx%d' % (iw, ih), fmt_name(ifmt), count,
+                       {'HIT': '', 'DS-DEPTH': 'depth-bridge', 'DS-STENCIL': 'stencil-bridge'}
+                      .get(state, 'MISS -- guest bytes')))
+        print()
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/prosper/tools/gpu_timeline/rtt_pass_graph.py
+++ b/prosper/tools/gpu_timeline/rtt_pass_graph.py
@@ -31,7 +31,7 @@ PASS_RE = re.compile(
     r'\[rtt\] pass (?:target|c\d+)=(0x[0-9a-f]+) extent=(\d+)x(\d+).*?\((\d+) draws\) '
     r'px_nonzero=(\d+)(?: rgb_nonblack=(\d+))?')
 SAMPLE_RE = re.compile(
-    r'\[rtt\] sample tex addr=(0x[0-9a-f]+) (\d+)x(\d+) fmt=(\d+) -> (HIT|miss|DS-DEPTH|DS-STENCIL)')
+    r'\[rtt\] sample tex addr=(0x[0-9a-f]+) (\d+)x(\d+) fmt=(\d+) -> (HIT|HIT-GPU|HIT-CPU|HIT-UNIFORM|miss|DS-DEPTH|DS-STENCIL)')
 
 # prosper::gpu::DataFormat, for reading a pass's role off its format rather than guessing from extent.
 FORMATS = {0: 'unknown', 1: 'f32', 2: 'u32', 3: 'i32', 4: 'f16', 5: 'un16', 6: 'sn16', 7: 'u16',
@@ -116,7 +116,9 @@ def main():
             for (addr, iw, ih, ifmt), count, state in summarized:
                 print('             <- %-14s %9s %-12s x%-4d %s' %
                       (addr, '%dx%d' % (iw, ih), fmt_name(ifmt), count,
-                       {'HIT': '', 'DS-DEPTH': 'depth-bridge', 'DS-STENCIL': 'stencil-bridge'}
+                       {'HIT': '', 'HIT-GPU': '', 'HIT-CPU': 'cpu',
+                       'HIT-UNIFORM': 'UNIFORM COLOUR -- no texture detail',
+                       'DS-DEPTH': 'depth-bridge', 'DS-STENCIL': 'stencil-bridge'}
                       .get(state, 'MISS -- guest bytes')))
         print()
     return 0

--- a/prosper/tools/re/bvh_ref_simulator.py
+++ b/prosper/tools/re/bvh_ref_simulator.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Simulate 0x413dc3400's six-reference selection over a captured input, and diff it against what
+the dispatch actually wrote.
+
+Why six and not two. The builder does not read one pair of child references per node; it reads
+three pairs, chaining through the first two (retained ISA, #2542):
+
+    pc86   load the first pair from the compacted-node record        -> refs A, B
+    pc161  follow (A >> 3) - 4 and load another pair                 -> refs C, D
+    pc237  follow (B >> 3) - 4 and load another pair                 -> refs E, F
+    six predicate/store blocks, each accepting tag in {2, 5}
+
+A histogram over record dwords 0/1 therefore covers two of six candidates and CANNOT predict how
+many parent slots a dispatch writes. That is why `pairs == 1030` is only an empirical control for one
+route state and not a universal oracle: the active topology has to be derived per dispatch. What does
+survive as a hard oracle is acyclicity — a cycle among reachable references cannot be explained by
+legitimate non-materialised (tag != 2, 5) references.
+
+Inputs are the tree-watch dumps: the node records (`aux-*.bin`, 64-byte stride) plus the parent
+table's pre- and post-images from the same dispatch, so "what was written" is the changed set rather
+than a guess.
+"""
+import glob
+import os
+import struct
+import sys
+
+RECORD_BYTES = 64
+NODE_COUNT = 2063
+MATERIALISED_TAGS = (2, 5)
+
+
+def refs_of(records, index):
+    """The two references a node record carries, or None when the index is out of range."""
+    if not (0 <= index < len(records)):
+        return None
+    return records[index]
+
+
+def decode_index(ref):
+    """The builder's own decode: v_lshrrev_b32 3 then v_add_nc_u32 -4."""
+    return (ref >> 3) - 4
+
+
+def expected_destinations(records):
+    """Every slot the six-reference walk says should receive a parent link.
+
+    Returns (destinations, chased, dangling) where `chased` counts references followed to a second
+    pair and `dangling` counts follows that left the array — the latter matters because a dangling
+    follow is a reference the guest would also not be able to use.
+    """
+    destinations = []
+    chased = dangling = 0
+    for node in range(len(records)):
+        a, b = records[node]
+        for first in (a, b):
+            if (first & 7) in MATERIALISED_TAGS:
+                destinations.append(decode_index(first))
+            # The chain is followed regardless of the first pair's tag: pc161/pc237 address from the
+            # reference value, and the tag test gates the STORE, not the load.
+            nxt = refs_of(records, decode_index(first))
+            if nxt is None:
+                dangling += 1
+                continue
+            chased += 1
+            for second in nxt:
+                if (second & 7) in MATERIALISED_TAGS:
+                    destinations.append(decode_index(second))
+    return destinations, chased, dangling
+
+
+def reference_cycles(records):
+    """Cycles among reachable materialised references. Iterative, so a deep chain cannot blow the
+    Python stack and be mistaken for a structural result."""
+    n = len(records)
+    state = [0] * n
+    cycles = []
+    for start in range(n):
+        if state[start]:
+            continue
+        stack = [(start, 0)]
+        path = []
+        while stack:
+            node, edge = stack[-1]
+            if edge == 0:
+                if state[node] == 1:
+                    cycles.append(tuple(path[path.index(node):]) if node in path else (node,))
+                    stack.pop()
+                    continue
+                if state[node] == 2:
+                    stack.pop()
+                    continue
+                state[node] = 1
+                path.append(node)
+            kids = [decode_index(r) for r in records[node]
+                    if (r & 7) in MATERIALISED_TAGS and 0 <= decode_index(r) < n]
+            if edge < len(kids):
+                stack[-1] = (node, edge + 1)
+                stack.append((kids[edge], 0))
+            else:
+                state[node] = 2
+                if path and path[-1] == node:
+                    path.pop()
+                stack.pop()
+    return cycles
+
+
+def load_records(path):
+    data = open(path, 'rb').read()
+    count = min(NODE_COUNT, len(data) // RECORD_BYTES)
+    return [struct.unpack_from('<II', data, i * RECORD_BYTES) for i in range(count)]
+
+
+def load_words(path):
+    data = open(path, 'rb').read()
+    return list(struct.unpack('<%dI' % (len(data) // 4), data[:len(data) // 4 * 4]))
+
+
+def main(directory):
+    rows = []
+    for post in sorted(glob.glob(os.path.join(directory, 'tree-post-*p413dc3400.bin'))):
+        stem = os.path.basename(post)[len('tree-post-'):-len('-p413dc3400.bin')]
+        pre = os.path.join(directory, 'tree-pre-%s-p413dc3400.bin' % stem)
+        aux = glob.glob(os.path.join(directory, 'aux-*-%s.bin' % stem))
+        if not os.path.exists(pre) or not aux:
+            continue
+        records = load_records(aux[0])
+        if len(records) != NODE_COUNT:
+            continue
+        before, after = load_words(pre), load_words(post)
+        written = {i for i in range(min(len(before), len(after))) if before[i] != after[i]}
+
+        wanted, chased, dangling = expected_destinations(records)
+        in_range = {d for d in wanted if 0 <= d < NODE_COUNT}
+        cycles = reference_cycles(records)
+
+        missing = sorted(in_range - written)
+        unexpected = sorted(written - in_range)
+        rows.append((stem, len(in_range), len(written), len(missing), len(unexpected),
+                     len(cycles), dangling))
+        print("== %s" % stem)
+        print("   expected destinations (six-reference walk): %d distinct   chased=%d dangling=%d"
+              % (len(in_range), chased, dangling))
+        print("   actually written slots: %d" % len(written))
+        print("   expected but NOT written: %d %s" % (len(missing), missing[:10]))
+        print("   written but NOT expected: %d %s" % (len(unexpected), unexpected[:10]))
+        print("   reference cycles: %d" % len(cycles))
+        if cycles:
+            print("   first cycles: %s" % [c for c in cycles[:4]])
+        print()
+
+    if rows:
+        print("summary (stem, expected, written, missing, unexpected, cycles, dangling):")
+        for r in rows:
+            print("   %-28s %5d %5d %5d %5d %5d %6d" % r)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1] if len(sys.argv) > 1 else '.')

--- a/prosper/tools/re/bvh_table_anomaly.py
+++ b/prosper/tools/re/bvh_table_anomaly.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Name the single corrupted record in a cyclic capture, without needing a clean reference.
+
+The LBVH model plus the measurement makes this possible: a clean table has 1030 sibling pairs and
+ZERO unpaired side-bit records; a cyclic one has 1029 pairs and EXACTLY ONE unpaired record. So the
+unpaired record identifies itself, and the cycle it creates can be walked out and printed.
+
+This does not assume the unpaired record is the corrupted one -- it prints the cycle members
+independently, so the two identifications either agree (and confirm each other) or do not.
+"""
+import glob
+import struct
+import sys
+
+SIDE = 0x40000000
+SHIFT, MASK = 3, (1 << 27) - 1
+
+
+def load(path):
+    d = open(path, 'rb').read()
+    return list(struct.unpack('<%dI' % (len(d) // 4), d[:len(d) // 4 * 4]))
+
+
+def unpaired_records(w):
+    out = []
+    for i, v in enumerate(w):
+        if not (v & SIDE):
+            continue
+        if i and not (w[i - 1] & SIDE) and v == (w[i - 1] | SIDE):
+            continue
+        out.append(i)
+    return out
+
+
+def find_cycles(w):
+    n = len(w)
+    state = [0] * n          # 0 unvisited, 1 on current path, 2 done
+    cycles = []
+    for r in range(n):
+        if state[r]:
+            continue
+        path = []
+        idx = r
+        while idx != 0 and idx < n and state[idx] == 0:
+            state[idx] = 1
+            path.append(idx)
+            idx = (w[idx] >> SHIFT) & MASK
+        if idx != 0 and idx < n and state[idx] == 1:
+            cycles.append(path[path.index(idx):])
+        for p in path:
+            state[p] = 2
+    return cycles
+
+
+def parent(w, i):
+    return (w[i] >> SHIFT) & MASK
+
+
+for path in sorted(set(sum((glob.glob(p) for p in sys.argv[1:]), []))):
+    w = load(path)
+    if len(w) != 2063:
+        continue
+    unp = unpaired_records(w)
+    cycles = find_cycles(w)
+    print("== %s" % path.split('/')[-1])
+    print("   unpaired side-bit records: %s" % unp)
+    for c in cycles:
+        print("   cycle len=%d members=%s" % (len(c), c))
+        for m in c:
+            mate = m - 1 if (w[m] & SIDE) else m + 1
+            mate_ok = 0 <= mate < len(w)
+            print("      slot %4d = 0x%08x  parent=%4d  side=%d   mate slot %4d = %s" %
+                  (m, w[m], parent(w, m), 1 if w[m] & SIDE else 0, mate,
+                   ("0x%08x" % w[mate]) if mate_ok else "-"))
+    # Neighbourhood of each cycle member, so a hand check of the pairing is possible.
+    for c in cycles:
+        lo, hi = max(0, min(c) - 3), min(len(w), max(c) + 4)
+        print("   neighbourhood [%d,%d):" % (lo, hi))
+        for i in range(lo, hi):
+            print("      %4d 0x%08x parent=%4d side=%d %s" %
+                  (i, w[i], parent(w, i), 1 if w[i] & SIDE else 0,
+                   "<-- cycle" if i in c else ""))
+    print()

--- a/prosper/tools/re/bvh_table_audit.py
+++ b/prosper/tools/re/bvh_table_audit.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Test the LBVH model (#2542) against every captured 2063-dword parent table.
+
+Codex's prediction: 2063 = 2*1032-1 is a full binary tree over 1032 leaves with 1031 internal
+nodes, adjacent records are siblings sharing a parent, bit 30 identifies the child side, and the
+root is the single unpaired node. If that is right, a well-formed table should show a pair count
+at or very near 1031.
+
+The point of running it over the CLEAN captures is that they are the ones the model must fit. A
+model that only fits the corrupted ones explains nothing.
+"""
+import glob
+import struct
+import sys
+
+SIDE = 0x40000000
+SHIFT, MASK = 3, (1 << 27) - 1
+
+
+def load(path):
+    data = open(path, 'rb').read()
+    return list(struct.unpack('<%dI' % (len(data) // 4), data[:len(data) // 4 * 4]))
+
+
+def siblings(w):
+    pairs = unpaired = side = 0
+    for i, v in enumerate(w):
+        if not (v & SIDE):
+            continue
+        side += 1
+        if i and not (w[i - 1] & SIDE) and v == (w[i - 1] | SIDE):
+            pairs += 1
+        else:
+            unpaired += 1
+    return pairs, unpaired, side
+
+
+def walk(w, roots):
+    cyc = set()
+    cyclic_roots = oob = 0
+    maxd = 0
+    n = len(w)
+    for r in range(min(roots, n)):
+        gen, seen, idx, d = r + 1, {}, r, 0
+        while idx != 0:
+            if idx >= n:
+                oob += 1
+                d += 1
+                break
+            if seen.get(idx) == gen:
+                cyclic_roots += 1
+                clen = d - seen_depth[idx]
+                canon = member = idx
+                for _ in range(clen):
+                    canon = min(canon, member)
+                    member = (w[member] >> SHIFT) & MASK
+                cyc.add(canon)
+                break
+            seen[idx] = gen
+            seen_depth[idx] = d
+            idx = (w[idx] >> SHIFT) & MASK
+            d += 1
+        maxd = max(maxd, d)
+    return len(cyc), cyclic_roots, oob, maxd
+
+
+seen_depth = {}
+
+paths = sorted(set(sum((glob.glob(p) for p in sys.argv[1:]), [])))
+print("%-58s %6s %6s %6s %6s %7s %6s" %
+      ("capture", "pairs", "unpair", "side", "cycles", "cycroot", "depth"))
+clean_pairs, cyclic_pairs = [], []
+for p in paths:
+    w = load(p)
+    if len(w) != 2063:
+        continue
+    seen_depth = {}
+    pr, un, sd = siblings(w)
+    cy, cr, ob, md = walk(w, 2063)
+    print("%-58s %6d %6d %6d %6d %7d %6d" % (p.split('/')[-1][:58], pr, un, sd, cy, cr, md))
+    (cyclic_pairs if cy else clean_pairs).append(pr)
+
+def summary(name, xs):
+    if not xs:
+        print("%s: none" % name)
+        return
+    print("%s: n=%d pairs min=%d max=%d distinct=%s" %
+          (name, len(xs), min(xs), max(xs), sorted(set(xs))[:8]))
+
+print()
+summary("CLEAN  (no cycles)", clean_pairs)
+summary("CYCLIC (cycles>0) ", cyclic_pairs)
+print()
+print("LBVH prediction: a full binary tree over 1032 leaves has 1031 internal nodes,")
+print("so a well-formed parent table should show pairs at or near 1031.")


### PR DESCRIPTION
## What this is

The GTA V missing-world investigation, and the fixes it produced. The headline is a root-cause-class
defect: **prosper's fragment recompiler supported only MRT0 and MRT1, and GTA V's G-buffer exports
five render targets.**

The world is **not yet lit** on this branch. The G-buffer now reaches the deferred lighting pass
complete, which it did not before. That is necessary and not sufficient, and every claim below is
scoped accordingly.

## The root cause

GTA V's G-buffer pass, from the new `PROSPER_MRT_SHAPE_FOR`:

```
x1754  tmask=0x000fffff smask=0x0003ffff
       c0=0x207de60000 c1=0x207fe40000 c2=0x2083e00000 c3=0x2081e20000 c4=0x2085de0000
```

`tmask & smask = 0x0003ffff` — slots 0–3 at `0xf`, slot 4 at `0x3`. Five attachments, all enabled by
the guest.

Everything below the shader already carried eight: the render state decodes all eight slots,
`active_color_count` scans all eight, and the backend's render pass, framebuffer and blend state are
generic over `color_count`. **Five hard-coded `2`s in the fragment path were the entire limit** — the
shell's `v_color` array, `fragment_color_export_mask`'s `realized`, the colour-mask scan's
`exp_target < 2`, the emit-side `exported` array, and the "did anything export" guard's
`!exported[0] && !exported[1]`.

The blast radius is not confined to the shader. `gpu_execute.hpp` gates every slot's Vulkan write mask
by the shader's EXP.EN — `write_mask &= (exp_mask >> slot*4) & 0xf` — so a decoder that can never set
bits above nibble 1 forces **`write_mask = 0` for slots 2–7 regardless of CB_TARGET_MASK and
CB_SHADER_MASK**. Slots 0 and 1 survived only because `active_color` has named-field fallbacks for
exactly those two.

The last `2` was the worst: `!exported[0] && !exported[1]` read as "did anything export" while the
array was sized 2, and would silently have become "did MRT0 or MRT1 export" once widened — rejecting
outright any shader whose only colour output is MRT2+, dropping its *draws* rather than its
attachments.

`kFragmentColorOutputs` is now a named constant and `gpu_execute.hpp` static_asserts it equal to
`kColorTargetCount`, since it is the translation unit that sees both. They are the same quantity from
two sides, and if they diverge the smaller silently wins as a `&= 0` on every slot above it.

**Measured, same route, before → after:**

```
c2 ACTIVE=0 -> 2151      per-slot write_mask disagreements against the
c3 ACTIVE=0 -> 2083      draw's own mask registers: 5,318 -> 0
c4 ACTIVE=0 -> 1040
```

and the newly-live slots carry real content: `c2` rgb_nonblack=240,121, `c3` 407,957, `c4` 313,908.

## Second fix: a DS surface's identity includes its array slice

A cube shadow map is ONE six-layer allocation whose faces share a depth base and are selected by
`DB_DEPTH_VIEW.SLICE_START/MAX`. `PersistentDsKey` omitted the slice, so **every face render for a
base collided on one key and overwrote the previous face's host image** — only the last face survived.
No relaxation of the sampling gate could have recovered a valid cube from that cache.

Retained DS surfaces **29 → 55**; a cube base that held one entry now holds one per face. Non-layered
surfaces program `DB_DEPTH_VIEW=0` and key at slice 0 exactly as before.

Credit to Codex (#2542) for the layered-allocation model and for spotting this second defect beneath
the bridge gate.

## Third fix: the stencil plane was never bridged

`find_persistent_ds_sampled` matched only the depth bases `dr`/`dw`, so every sample of a combined
surface's stencil plane fell through to a guest-byte decode of memory the renderer never writes —
#1275's own failure mode, left unfixed on the other plane. Now `hit(depth=44121 stencil=3070)`, 0
validation errors. **A/B says it does not change the frame** (2.004% → 1.993% non-black, inside the
route's own 0.283–2.584% spread), so it is a verified gap fix and nothing more.

## Instruments — four that reported "black" when it was not

Each was acted on before being caught; they are fixed here and the corrections are recorded in
`docs/GTA5_STATUS.md` rather than only in this description.

1. **`rgb_nonblack` is computed from an RGBA8 conversion**, so an HDR f16 target whose values sit
   below 1/255 reports exactly ZERO while carrying a full scene. `0x20431c0000` reports 0 while the
   next pass extracts 47.5% non-black from it.
2. **`[rtt] sample tex … -> miss` spoke only for the colour cache**, so a correctly depth-bridged 4K
   buffer and a texture decoded from zeros printed the same word. Now reports the resolution path.
3. **A pass whose readback was deferred has EMPTY cpu pixels**, and `rgb_nonblack` is then computed
   over nothing — `0x207de60000` gives `src=0B` on 1,938 of 1,938 passes in a default run and 99.7%
   non-black under `PROSPER_RTTLOG=1`. The instrument's own readback is what materialises the pixels
   it measures, so `PROSPER_RTTLOG` changes the subject.
4. **A colour-target census must intersect the write mask.** `CB_COLORn_BASE` is sticky. This
   retracts my own earlier "0x2085de0000 is written by 130,290 of 131,072 draws, 96% in slot 4" —
   those were stale bindings.

Also retracted in-branch: the cube-shadow falsification. It read the final screenshot; re-run
cube-only at both poles reading the lighting output instead, `0x00` gives max=46/44.5% and `0xff`
gives **max=0** — the shadow term can zero the lighting output completely, so that verdict was void
rather than negative.

## New tooling

- `tools/gpu_timeline/rtt_pass_graph.py` — reassembles a frame's producer/consumer graph from a
  `PROSPER_RTTLOG=1` log. Every finding here came off it.
- `PROSPER_MRT_CENSUS` (per-slot base/format/mask/active, plus the carried-vs-implied disagreement
  that found the root cause), `PROSPER_MRT_SHAPE_FOR`, `PROSPER_DUMP_PASS`, `PROSPER_TARGET_WATCH`,
  `PROSPER_RTT_GUESTPEEK`, and per-plane/per-address `[dsbridge]` counters.

Neither of the two censuses that preceded it could have found the root cause: an activation census
says slots 2–4 never activate but not why, and its `mask=0` column is equally consistent with "the
guest disabled them" — which a mask histogram appeared to confirm. It only became visible when the
same quantity was computed **two ways from the same draw** and compared.

## Verification

```
ctest --no-tests=error -j4   ->  245/245 passed, exit 0
```

New regression tests: a five-MRT fragment program must report `0x000fffff` with MRT2/3/4 asserted
separately (the old two-slot decoder can only ever return `0x000000ff`, so it cannot pass by
coincidence); the `DB_DEPTH_VIEW` decode against all six values GTA V programs; and that retaining
face 5 does not overwrite face 0.

One existing test's contract is reversed deliberately: it asserted an MRT3-only export stays
`.empty()`. MRT3 is genuinely supported now, so rejecting it would be the defect rather than the
guard. The original concern was that MRT3 must not be silently *remapped* onto color0, which the
replacement asserts against directly (mask `0x0000f000`: slot 3 set, slot 0 clear).

## Risk

The MRT change is the broad one: any title whose fragment shader exports above MRT1 now gets those
attachments instead of having them dropped. That is the correct behaviour and it is new behaviour, so
it is the thing to review hardest. Snapshots were not run; per the charter they are a release-time
inventory, and this branch is mid-investigation.

Refs #2542, #1873.
