### PR TITLE
GTA V: the 4K scene producer executes — split compression out of the zero-mip proof, behind a fail-closed bind-time guard

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -925,9 +925,34 @@ trade for the question in this document — the bundle is wanted for its **resou
 descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
 about rendering, and must not be used as any.
 
-So the recipe that produces a GTA V bundle is both flags together; neither alone is enough. Until one
-exists, every conclusion in this section is from log statistics rather than from the frame's actual
-contents.
+**Gate 3 — the window that clears gate 1 then exceeds the 2 GiB bundle limit.**
+
+```
+[grab] frame-bundle: submit 42862 failed (frame bundle unique bytes 2155499889
+       exceeded limit 2147483648); grab aborted
+[grab] frame-bundle: frame 153 ended at submit 42861
+```
+
+So `PROSPER_CAPTURE_FRAMES=240` dies at frame **153**, having accumulated 2.15 GB. The useful number
+behind it: **42,861 submits across 153 frames ≈ 280 submits per frame, ≈ 14 MB of unique bytes per
+frame.** That is the sizing rule for this title — a window much above ~140 frames cannot complete,
+and nothing near that is needed, since one frame already carries ~280 submits.
+
+The three gates are **sequential and each masks the next**, which is why this took several runs to
+walk: widen the window and you meet provenance; clear provenance and you meet the size limit. The
+combination that gets through is a **small** window plus the override:
+
+```bash
+PROSPER_CAPTURE_FRAMES=8 PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 \
+PROSPER_GRAB_BUNDLE_AFTER_MS=380000 PROSPER_CAPTURE_DIR=~/<dir> \
+PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700 \
+PROSPER_PAD_SCRIPT=@scripts/gta5/reach-story-mode.pad \
+SDL_VIDEODRIVER=offscreen ./prosper-app <DUMP_ROOT>/PPSA04263-app0
+```
+
+Until a bundle exists, every conclusion in this section is from log statistics rather than from the
+frame's actual contents.
 
 ## The hang is NOT the only blocker — two more, measured (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -950,8 +950,25 @@ bundle and there is no frame count that fits under 2 GiB. (An earlier revision o
 divided 42,861 submits by 153 frames and published "≈ 14 MB per frame" as a sizing rule. That
 arithmetic is right and the inference from it is wrong: the 4-frame run falsifies it outright.)
 
-The lever is the budget, not the window: **`PROSPER_CAPTURE_BUNDLE_MAX_MB`** on `prosper-app`, which
-accepts 64..3072 MiB against a 2048 MiB default.
+The lever is the budget, not the window — **`PROSPER_CAPTURE_BUNDLE_MAX_MB`**, 64..3072 MiB against a
+2048 MiB default — **and on this title it is not enough at its maximum:**
+
+```
+FRAMES=240, limit 2048 MiB -> 2,155,499,889 bytes   (died at frame 153)
+FRAMES=4,   limit 2048 MiB -> 2,236,660,079 bytes
+FRAMES=4,   limit 3072 MiB -> 3,351,980,610 bytes
+FRAMES=1,   limit 3072 MiB -> 3,269,369,026 bytes   <- ONE frame, over the ceiling
+```
+
+A single frame costs 3.27 GB against a 3072 MiB (3.22 GB) hard clamp, so **there is currently no
+setting under which an F9 bundle of GTA V completes.** The last row is the one that matters: it is not
+a window-size problem and cannot be tuned away. (These are overshoot values at the point of abort,
+not totals, and they vary run to run, so the true working-set size is unknown and above 3.35 GB.)
+
+The fix worth building is not a bigger number. The question a bundle is wanted for here — *which
+compute program binds the empty composite tap* — needs **resource tables and descriptors, not pixel
+payloads**; a metadata-only capture would fit inside any budget and answer it directly. Tracked as
+#2554.
 
 The three gates are **sequential and each masks the next**, which is why this took several runs to
 walk: widen the window and you meet provenance; clear provenance and you meet the size limit; and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3456,12 +3456,48 @@ produced no row at all — and this census would have shown the executed *consum
 i.e. exactly the false "no compute producer writes this surface" conclusion. The reviewer's finding
 that the instrument's null did not cover failing shaders is what made this visible.
 
-**Next step, now concrete:** make `0x2042f49a00` recompile. Its reject is a single named instruction —
-`pc=16`, MIMG `op=0x1` (`IMAGE_LOAD_MIP`), `mode=unresolved-operand`, `dmask=0x1 dim=1 glc=1` — and
-the `[mimg-mip-why]` lines for that program report `proven_at_use=1 mip_vgpr=v2 in_zero_set=1
-exec_pristine=1 cfg_known=1` at pcs 16/18/21/25, so the mip level is proven and the failure is the
-descriptor, not the mip analysis. Then re-run this census and see whether the write-class binding
-becomes `outcome=executed`.
+#### Done: the producer executes now, and the world is still absent (2026-08-17)
+
+`0x2042f49a00`'s reject was one term. `shader_resource_allows_zero_mip_specialization` ANDed
+`!compression_enabled`, clearing a proof the per-use fold had already established — hence the apparent
+contradiction between `[mimg-mip-why] proven_at_use=1` and `[mimg-mip] proven_zero_mip=0`. Compression
+describes how bytes are **encoded**; the predicate is about which LOD is **addressed**. Split in
+`a8637c31`, after the bind-time guard it depends on landed in `1fbd77a7`.
+
+```
+before:  program=0x2042f49a00 binding=6 class=4  outcome=partial-recompile-empty
+after:   program=0x2042f49a00 binding=6 class=4  outcome=executed
+```
+
+**The guard fires on the same program in the same run**, exactly as designed:
+
+```
+[compute] program 0x2042f49a00 image 0x2052ac0000 ... compressed sampled source without authority
+          (no imported image, no fast clear, metadata does not prove the base allocation
+          uncompressed) -> dispatch skipped (#590)
+```
+
+That is binding 4 — the depth read at pc=16 — on a dispatch whose retained-depth import missed. It
+declined instead of reading compressed guest bytes. Both outcomes occur in one run because the import
+is available *sometimes*: `hit(depth=69965)` against `declined addr=0x2052ac0000 reason=depth-invalid
+x37751`, with the retained surface reporting `dvalid=0 svalid=1`.
+
+**The world is still black.** Radar and status bars render as before; no 3D. A necessary step, not the
+fix.
+
+**A regression was nearly reported here and was not.** The first post-change screenshot at
+`PROSPER_CAPTURE_SCREENSHOT_AT_FRAME=4200` was fully black including the HUD — worse than the known
+baseline. The pre-change run at the **same trigger** is equally black: host frame 4200 is an
+early/transition moment, while the HUD-visible baseline comes from the 380 s grab at guest present
+~4137. Different sample point, not different behaviour. **Compare frames only against a control taken
+with the identical trigger** — on this route an unmatched pair looks exactly like a regression.
+
+**The frontier is now depth validity, not the recompiler.** This dispatch reads the main depth and
+needs the retained image to be *valid* when it runs; `dvalid=0` says it frequently is not, and one
+address accounts for 37,751 of the run's 40,826 `depth-invalid` declines. That is HTILE
+materialization/retention work, and it connects to the DS-invalidation changes split into #2553. Also
+open from review: the import-hit/import-miss regression at the production binding site, and making
+`PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS` fail closed for the compressed case.
 
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3386,6 +3386,43 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
+### The failing kernels bind 4K WRITE-capable storage images (2026-08-17)
+
+The section below draws the census boundary at "the unresolved operations inside the failing compute
+kernels remain outside the census". This looks *inside* that boundary for the first time, using a
+diagnostic that was already ungated and already in every routed log: `[compute-table]`, which dumps a
+program's whole resource table once per program that fails to recompile.
+
+**Two failing programs bind a storage image of exactly 33,177,600 bytes = 3840 × 2160 × 4** — the
+size of a 4K f11f11f10 surface, the very thing the composite's base tap is and does not contain:
+
+| program | binding | guest address | reject |
+| --- | --- | --- | --- |
+| `0x2042f49a00` | 6 | `0x204da00000`, **identical on all four runs** | `pc=16`, MIMG `op=0x1`, `mode=unresolved-operand` |
+| `0x205b557e00` | 13 | run-local (`0x2070f20000`, `0x2072f00000`) | `pc=314`, MIMG `op=0x0`, `srt_tag=0xa0`, `key_res=null pc_res=null` |
+
+`class=4` is `StorageImage` — read/written by `image_load`/`image_store` **without a sampler**, i.e.
+the class a compute producer writes through. `0x205b557e00` also samples a 3840×2160 renderer-owned
+RTT that reports *"has no readable snapshot -> dispatch skipped (#590)"*, so it reads a 4K surface and
+writes a 4K surface, and never runs.
+
+**This is the shape of the missing producer, and it is not proof.** What is established: failing
+kernels do bind 4K write-capable images, so the population the census excluded is not empty and is not
+irrelevant. What is *not* established: that either surface **is** the composite's base tap. Addresses
+are run-local, the tap was identified in an older run, and nothing here correlates the two — the
+honest statement is a size and class match on a population that was previously unexamined.
+
+**The failing population is also much larger than this document has been recording.** The reject
+census table above lists 13 programs; a routed boot has **30, 32, 36 and 35 distinct failing programs**
+across four runs on 2026-08-17. So "the seven failing kernels" understates it by roughly a factor of
+five, and any statement of the form "all the failing kernels were cleared" should be read against a
+count that was never that small.
+
+**Next step, and it is cheap:** re-run with `PROSPER_COMPUTE_BINDS=<tap address for that run>` — the
+instrument now reports the recompile-failure population as `outcome=partial-recompile-empty` instead
+of silently skipping it, which is exactly the population these two programs are in. Deriving the tap
+address for the *same* run is the only remaining piece.
+
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 
 Read the boundary in this heading before using the table. Every path that can write a surface **and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -886,15 +886,48 @@ Three 4K DCC-compressed **sampled** images remain unsupported (fmt 1/4/9). That 
 resource from the storage image above — the storage image is not compressed. Whether the composite
 depends on those three has not been established.
 
-### The instrument that would answer this, and why it has not yet
+### The instrument that would answer this — TWO sequential gates, both now identified (2026-08-16)
 
 `PROSPER_GRAB_BUNDLE_AFTER_MS` on `prosper-app` is the documented fastest loop for "why does this
-frame look wrong". It was tried at 170 s with `PROSPER_CAPTURE_FRAMES=1` and again with 16, and both
-report **"the capture window contained no GPU submits"** while the same run shows 271 `[agc]`, 60
-`[compute]` and 43 `[render]` lines and reaches 191 s of route. So the capture window and the
-submits are not lining up, and **that mismatch is itself the next thing to understand** — without a
-bundle there is no draw-level view of the frame, and every conclusion above is from log statistics
-rather than from the frame's actual contents.
+frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
+"frame capture does not work on GTA V", which is why the first one hid the second for a day.
+
+**Gate 1 — the capture window is one present wide, and this title does not submit on every present.**
+Earlier attempts at 170 s with `PROSPER_CAPTURE_FRAMES=1` and 16 reported *"the capture window
+contained no GPU submits"*, which read as a window/submit mismatch of unknown kind. The newer
+diagnostic names it exactly:
+
+```
+[grab] frame-bundle: window had no submits; widen it with PROSPER_CAPTURE_FRAMES=N (1..240)
+[grab] frame-bundle: during this window the submit hook was reached=0, 0 while inactive,
+       0 while not capturing; window was open 1 ms for 1 presents
+```
+
+`reached=0` with the window open **1 ms** settles it: the hook never fired, so nothing was
+mis-classified — the window simply closed between submits. **`PROSPER_CAPTURE_FRAMES=240` clears it**
+and the capture reaches real submits (observed: submit 34146).
+
+**Gate 2 — the bundle then aborts on indirect-pointer provenance.**
+
+```
+[grab] frame-bundle: submit 34146 failed (indirect-pointer relocation lacks exact compute
+       provenance); grab aborted
+```
+
+`validate_captured_indirect_pointer_relocations` requires capture format ≥ v53, a captured recompile
+config, an in-range raw shader index, **and exactly one** indirect-pointer carrier. GTA V fails one of
+these, and until 2026-08-16 the message was the same sentence for all four, so the log could not say
+which arm to pursue; it now names the failing precondition and prints the carrier/marker counts.
+
+**`PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1` accepts it and writes the bundle**, with the tool
+stating the limit itself: *"THIS BUNDLE IS FOR INSPECTION, NOT FAITHFUL REPLAY."* That is the right
+trade for the question in this document — the bundle is wanted for its **resource tables and
+descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
+about rendering, and must not be used as any.
+
+So the recipe that produces a GTA V bundle is both flags together; neither alone is enough. Until one
+exists, every conclusion in this section is from log statistics rather than from the frame's actual
+contents.
 
 ## The hang is NOT the only blocker — two more, measured (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -892,20 +892,29 @@ depends on those three has not been established.
 frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
 "frame capture does not work on GTA V", which is why the first one hid the second for a day.
 
-**Gate 1 — the capture window is one present wide, and this title does not submit on every present.**
+**Gate 1 — the capture window is a PRESENT COUNT, and a present count is not a unit of time.**
 Earlier attempts at 170 s with `PROSPER_CAPTURE_FRAMES=1` and 16 reported *"the capture window
 contained no GPU submits"*, which read as a window/submit mismatch of unknown kind. The newer
 diagnostic names it exactly:
 
 ```
-[grab] frame-bundle: window had no submits; widen it with PROSPER_CAPTURE_FRAMES=N (1..240)
 [grab] frame-bundle: during this window the submit hook was reached=0, 0 while inactive,
-       0 while not capturing; window was open 1 ms for 1 presents
+       0 while not capturing; window was open 1 ms for 1 presents      # FRAMES=1
+       ... window was open  6 ms for   8 presents                      # FRAMES=8
+       ... window was open 38 ms for  64 presents                      # FRAMES=64
 ```
 
-`reached=0` with the window open **1 ms** settles it: the hook never fired, so nothing was
-mis-classified — the window simply closed between submits. **`PROSPER_CAPTURE_FRAMES=240` clears it**
-and the capture reaches real submits (observed: submit 34146).
+`reached=0` settles that nothing was mis-classified — the hook never fired. The rate is the finding:
+this title flips in **bursts**, ~0.6 ms per present against a ~23–25/s average, so a window's
+wall-clock duration is effectively random and usually far too short to contain a submit. Widening the
+count does not reliably help, because a burst consumes it: 64 presents elapsed in 38 ms and saw
+nothing.
+
+**The fix is `PROSPER_CAPTURE_WAIT_FOR_SUBMITS=1`** (`gpu_timeline.cpp`, opt-in), which extends the
+window until at least one submit is captured, bounded by the same 240-present ceiling, and never
+shortens a window that already worked. This was already diagnosed on this title under #2549 with the
+same burst measurements — recorded here because three separate frame counts were tried before that
+flag was found, and the failure message points at `PROSPER_CAPTURE_FRAMES` instead.
 
 **Gate 2 — the bundle then aborts on indirect-pointer provenance.**
 
@@ -925,25 +934,33 @@ trade for the question in this document — the bundle is wanted for its **resou
 descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
 about rendering, and must not be used as any.
 
-**Gate 3 — the window that clears gate 1 then exceeds the 2 GiB bundle limit.**
+**Gate 3 — GTA V's working set exceeds the F9 grab's 2 GiB default budget.**
 
 ```
 [grab] frame-bundle: submit 42862 failed (frame bundle unique bytes 2155499889
-       exceeded limit 2147483648); grab aborted
-[grab] frame-bundle: frame 153 ended at submit 42861
+       exceeded limit 2147483648); grab aborted        # FRAMES=240, died at frame 153
+[grab] frame-bundle: submit 35716 failed (frame bundle unique bytes 2236660079
+       exceeded limit 2147483648); grab aborted        # FRAMES=4 + WAIT_FOR_SUBMITS
 ```
 
-So `PROSPER_CAPTURE_FRAMES=240` dies at frame **153**, having accumulated 2.15 GB. The useful number
-behind it: **42,861 submits across 153 frames ≈ 280 submits per frame, ≈ 14 MB of unique bytes per
-frame.** That is the sizing rule for this title — a window much above ~140 frames cannot complete,
-and nothing near that is needed, since one frame already carries ~280 submits.
+**Read those two together, because the pair is the finding:** 153 frames cost 2.155 GB and *four*
+frames cost 2.237 GB. The bytes are therefore **not** per-frame deltas — they are dominated by the
+resident working set the first captured frame pulls in, so shrinking the window does not shrink the
+bundle and there is no frame count that fits under 2 GiB. (An earlier revision of this section
+divided 42,861 submits by 153 frames and published "≈ 14 MB per frame" as a sizing rule. That
+arithmetic is right and the inference from it is wrong: the 4-frame run falsifies it outright.)
+
+The lever is the budget, not the window: **`PROSPER_CAPTURE_BUNDLE_MAX_MB`** on `prosper-app`, which
+accepts 64..3072 MiB against a 2048 MiB default.
 
 The three gates are **sequential and each masks the next**, which is why this took several runs to
-walk: widen the window and you meet provenance; clear provenance and you meet the size limit. The
-combination that gets through is a **small** window plus the override:
+walk: widen the window and you meet provenance; clear provenance and you meet the size limit; and
+widening the window is the wrong lever for gate 1 anyway. The combination that gets through is a
+**small** window that waits for submits, plus the override:
 
 ```bash
-PROSPER_CAPTURE_FRAMES=8 PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 \
+PROSPER_CAPTURE_FRAMES=1 PROSPER_CAPTURE_WAIT_FOR_SUBMITS=1 \
+PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 PROSPER_CAPTURE_BUNDLE_MAX_MB=3072 \
 PROSPER_GRAB_BUNDLE_AFTER_MS=380000 PROSPER_CAPTURE_DIR=~/<dir> \
 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700 \

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3418,10 +3418,50 @@ across four runs on 2026-08-17. So "the seven failing kernels" understates it by
 five, and any statement of the form "all the failing kernels were cleared" should be read against a
 count that was never that small.
 
-**Next step, and it is cheap:** re-run with `PROSPER_COMPUTE_BINDS=<tap address for that run>` — the
-instrument now reports the recompile-failure population as `outcome=partial-recompile-empty` instead
-of silently skipping it, which is exactly the population these two programs are in. Deriving the tap
-address for the *same* run is the only remaining piece.
+#### Watching that surface: the only WRITE-class binding of it came from a dispatch that did not run
+
+`PROSPER_COMPUTE_BINDS=204da00000` on a routed boot, 219 rows, 4 distinct programs. Two of them are
+the whole result:
+
+```
+[compute-binds] 0x204da00000 bound by program=0x2042f49a00 binding=6 class=4 fetch_pc=21
+                addr=0x204da00000 size=33177600 3840x2160 outcome=partial-recompile-empty
+[compute-binds] 0x204da00000 bound by program=0x205b557e00 binding=7 class=2 fetch_pc=19
+                addr=0x204da00000 size=33177600 3840x2160 outcome=executed
+```
+
+One 4K surface. `class=4` is `StorageImage`, the write-capable class; `class=2` is `Texture`,
+sampled-only. **The write-class binding is on a dispatch whose recompile failed — it did not run —
+while the sampled binding is on a dispatch that executed.** Across the whole run no executed dispatch
+was observed binding this surface write-class.
+
+Two qualifications, because both matter for how far this can be pushed:
+
+- **Recompile success is per-dispatch, not per-program.** Both programs also appear in the skip list
+  (`0x2042f49a00` at `pc=16` MIMG `op=0x1`; `0x205b557e00` at `pc=314` MIMG `op=0x0`), and a program's
+  resource table differs between dispatches, so the same code address can resolve in one invocation
+  and not in another. The claim is therefore about *observed bindings*, not about programs.
+- **This surface has not been shown to be the composite's base tap.** It is 4K, 33,177,600 bytes, and
+  written by nothing that ran — the right shape, on the right scale, in the population the census
+  excluded. That is a lead, not an identification.
+
+**The remaining 217 rows are instrument noise worth knowing about:** they come from two programs
+binding 256 MB constant buffers whose spans happen to *contain* the watched address. That is the
+documented "match the whole span, not the base" behaviour doing its job, but it means this instrument
+needs its output filtered by `class=` and by an exact `addr=` match before the signal is visible.
+
+**This row existed only because of the fix in `acaea037`.** Before it, `report_compute_binding_watch`
+returned from the `item.spirv.empty()` branch without reporting, so a recompile-failed dispatch
+produced no row at all — and this census would have shown the executed *consumer* and nothing else,
+i.e. exactly the false "no compute producer writes this surface" conclusion. The reviewer's finding
+that the instrument's null did not cover failing shaders is what made this visible.
+
+**Next step, now concrete:** make `0x2042f49a00` recompile. Its reject is a single named instruction —
+`pc=16`, MIMG `op=0x1` (`IMAGE_LOAD_MIP`), `mode=unresolved-operand`, `dmask=0x1 dim=1 glc=1` — and
+the `[mimg-mip-why]` lines for that program report `proven_at_use=1 mip_vgpr=v2 in_zero_set=1
+exec_pristine=1 cfg_known=1` at pcs 16/18/21/25, so the mip level is proven and the failure is the
+descriptor, not the mip analysis. Then re-run this census and see whether the write-class binding
+becomes `outcome=executed`.
 
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3492,6 +3492,46 @@ early/transition moment, while the HUD-visible baseline comes from the 380 s gra
 ~4137. Different sample point, not different behaviour. **Compare frames only against a control taken
 with the identical trigger** — on this route an unmatched pair looks exactly like a regression.
 
+#### What actually invalidates that depth, now that the diagnostic can say (2026-08-17)
+
+`[ds] invalidate`'s `origin=` field was **structurally incapable of attribution** until `1818b996`.
+It reads a thread-local set around `notify_guest_gpu_write`, while DS/RTT invalidation runs at
+**drain** time on the draining thread, long after that thread-local is reset — so it printed
+`origin=gpu` for **30,458 of 30,458** invalidations, including ones from writers that tag themselves.
+The queued record now carries the origin, captured on the writing thread.
+
+**Read the aggregate and the per-surface breakdown as two different questions**, because taking the
+aggregate for an answer inverted this one. Across every DS invalidation:
+
+| origin | count |
+| --- | --- |
+| `compute-writeback(image-guest-bytes)` | 15,777 |
+| `compute-writeback(cpu-fill)` | 11,267 |
+| `gpu` (genuinely the guest) | 6,316 |
+
+About **81%** of DS invalidation traffic is prosper invalidating its own caches from its own
+writebacks. That is a measurement, not a verdict — a writeback into guest memory can legitimately
+stale a detached cache — but it was invisible before and it is worth a decision.
+
+For the surface `0x2042f49a00` actually samples, `dr=0x2052ac0000`:
+
+| aspect hit | origin | count |
+| --- | --- | --- |
+| `htile_hit=1` | `gpu` | 1,678 |
+| `htile_hit=1` | `compute-writeback(cpu-fill)` | 407 |
+| `htile_hit=0` | `compute-writeback(cpu-fill)` | 407 |
+
+**Its depth range is never directly written.** Every loss of the depth plane comes through the
+conservative "an HTILE overlap may describe both aspects, so invalidate both" rule, and 1,678 of the
+2,492 are genuine guest HTILE writes of a repeated identical 640 KB at the HTILE base
+`0x2055310000`. So the frontier is the HTILE semantics, exactly as framed — not a writeback bug.
+
+**An aggregate over the wrong population reads as an answer.** A first pass over *all* surfaces showed
+24,922 depth invalidations with `htile_hit=0`, which says "HTILE is not involved at all". That
+population is dominated by **cube shadow maps** (`0x2094ec0000`, `0x20948c0000`, …). Isolating the one
+surface under investigation inverts the conclusion completely. Same shape as the matched-trigger
+screenshot trap above: filter to the subject before believing a count.
+
 **The frontier is now depth validity, not the recompiler.** This dispatch reads the main depth and
 needs the retained image to be *valid* when it runs; `dvalid=0` says it frequently is not, and one
 address accounts for 37,751 of the run's 40,826 `depth-invalid` declines. That is HTILE

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -6046,7 +6046,62 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  (unsigned long long)r->metadata_addr,
                                  sampled_dcc_clear_code);
 
+                // Does the metadata itself prove the base allocation carries ordinary texels? An
+                // all-0xff DCC plane is "nothing is compressed", so the base bytes ARE the image.
+                // Computed here rather than after the read below, because it is an authority for
+                // reading, not merely a cache-eligibility fact -- which is all it used to be.
+                const bool sampled_metadata_proves_uncompressed =
+                    sampled_dcc_metadata && sampled_dcc_metadata_bytes &&
+                    std::all_of(sampled_dcc_metadata,
+                                sampled_dcc_metadata + sampled_dcc_metadata_bytes,
+                                [](uint8_t value) { return value == 0xff; });
+
                 if (!sampled_dcc_fast_clear) {
+                    // FAIL CLOSED: a COMPRESSED sampled source may not enter guest preparation
+                    // without an authoritative representation. `readable` below is not one -- a
+                    // mapped base allocation whose texels live in DCC/HTILE decodes to plausible
+                    // garbage, which is strictly worse than declining, because it arrives as wrong
+                    // pixels instead of a visible skip.
+                    //
+                    // The three admissible authorities are: an imported retained Vulkan image
+                    // (`bi.imported`), the exact supported fast-clear materialization
+                    // (`sampled_dcc_fast_clear`, handled in the other arm), and metadata that
+                    // proves the base is uncompressed. Anything else declines.
+                    //
+                    // This exists because the compression term in the recompiler's zero-mip gate is
+                    // about to stop standing in for it. That term is not part of the zero-mip proof
+                    // -- compression describes byte ENCODING, the proof is about which LOD is
+                    // addressed -- but while it is there it is the only thing keeping a compressed
+                    // compute sampled binding away from this raw read. Removing it first would turn
+                    // GTA V's `0x2042f49a00` from "recompile-empty" into "reads compressed bytes".
+                    // The guard lands first, deliberately, so no routed A/B can consume garbage.
+                    //
+                    // SCOPED TO SURFACES WHOSE PIXELS LIVE SOMEWHERE ELSE, and the scope is the
+                    // whole correctness of this guard. `renderer_owned || depth_import_eligible` is
+                    // exactly the set that ATTEMPTED the import above, so reaching here with one of
+                    // them means the import MISSED -- the live pixels are in a Vulkan image or in
+                    // HTILE, and the base allocation is stale or encoded.
+                    //
+                    // An ordinary guest-backed surface is deliberately NOT covered. prosper's own
+                    // compute writeback puts plain texels in the base and can leave the guest's
+                    // metadata reading "compressed"; the base is then authoritative because we wrote
+                    // it, and `game_compute_exec` pins exactly that round-trip
+                    // ("unresolved DCC promotion keeps the ordinary sampled guest fallback
+                    // correct"). A guard without this scope fails that test, which is how the scope
+                    // was found rather than reasoned.
+                    //
+                    // `!bi.imported` is stated rather than assumed. An imported binding is expected
+                    // to bypass guest preparation entirely, but this is a safety interlock and must
+                    // not depend on an invariant proven elsewhere in a 6,000-line function.
+                    // CONFIDENCE: HIGH (declining is safe here; the risk is over-declining).
+                    if (r->compression_enabled && !bi.imported &&
+                        (renderer_owned || depth_import_eligible) &&
+                        !sampled_metadata_proves_uncompressed) {
+                        skip_image(r, "compressed sampled source without authority "
+                                      "(no imported image, no fast clear, metadata does not prove "
+                                      "the base allocation uncompressed)");
+                        break;
+                    }
                     sampled_guest_source = resource_bytes_for(r, sampled_guest_need);
                     const bool readable =
                         (r->host_data && r->host_data_size >= sampled_guest_need) ||
@@ -6054,13 +6109,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (!readable) { skip_image(r, "sampled surface unreadable"); break; }
                 }
 
-                bool dcc_cache_safe = !r->compression_enabled;
-                if (r->compression_enabled) {
-                    dcc_cache_safe = sampled_dcc_metadata && sampled_dcc_metadata_bytes &&
-                        std::all_of(sampled_dcc_metadata,
-                                    sampled_dcc_metadata + sampled_dcc_metadata_bytes,
-                                    [](uint8_t value) { return value == 0xff; });
-                }
+                const bool dcc_cache_safe =
+                    !r->compression_enabled || sampled_metadata_proves_uncompressed;
                 // Fast clears are keyed by metadata, not by the inactive base allocation. Keep
                 // this first narrow path uncached rather than teaching the existing base-byte key
                 // an unsafe partial identity; staging materialization is still far cheaper than

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -8480,7 +8480,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
             if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
             const auto notify_start = ComputeClock::now();
+            // Name the writer. "a guest write covers this surface" and "prosper's own compute
+            // writeback covers this surface" are different facts, and only the second says the
+            // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+            // used to report the default `gpu`, which cannot distinguish them.
+            set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
             notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+            set_guest_gpu_write_origin(nullptr);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    r->gpu_addr, bi.guest_bytes,
@@ -8492,7 +8498,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         false, std::memory_order_acq_rel);
                 if (!leave_compressed_for_test) {
                     std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                    // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                    // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                    // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                    // retained depth image. Tagged so that consequence is attributable rather than
+                    // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                    // separate question that needs the operation's real HTILE semantics proven.
+                    set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
                     notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                    set_guest_gpu_write_origin(nullptr);
                     if (!r->dcc_metadata_host_data && writer_provenance_enabled())
                         record_guest_write(GuestWriterKind::ComputeBuffer,
                                            r->metadata_addr, bi.dcc_metadata_bytes,

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -2453,6 +2453,12 @@ struct VulkanComputeContext {
 
 VulkanComputeContext* g_live_compute_context = nullptr;
 std::atomic<uint64_t> g_sampled_image_upload_skips{0};
+// Declines from the compressed-source authority guard specifically. A dedicated counter, not a
+// shared one, because the guard shares its decline path (skip_image) with several unrelated
+// reasons -- so a test asserting "the dispatch declined" cannot tell whether THIS guard fired.
+// Measured: without this counter, removing the guard's compression term left the regression green,
+// because a renderer-owned binding with no import declines for another reason anyway.
+std::atomic<uint64_t> g_compressed_source_authority_declines{0};
 std::atomic<uint64_t> g_cpu_fill_dispatches{0};
 
 struct BorrowedComputeImageLease {
@@ -6097,6 +6103,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (r->compression_enabled && !bi.imported &&
                         (renderer_owned || depth_import_eligible) &&
                         !sampled_metadata_proves_uncompressed) {
+                        g_compressed_source_authority_declines.fetch_add(
+                            1, std::memory_order_relaxed);
                         skip_image(r, "compressed sampled source without authority "
                                       "(no imported image, no fast clear, metadata does not prove "
                                       "the base allocation uncompressed)");
@@ -8950,6 +8958,10 @@ uint64_t live_compute_buffer_gpu_result_skips() {
 
 uint64_t live_compute_sampled_image_upload_skips() {
     return g_sampled_image_upload_skips.load(std::memory_order_relaxed);
+}
+
+uint64_t live_compute_compressed_source_authority_declines() {
+    return g_compressed_source_authority_declines.load(std::memory_order_relaxed);
 }
 
 uint64_t live_compute_storage_transfer_seeds() {

--- a/prosper/frontends/shared/live_compute.hpp
+++ b/prosper/frontends/shared/live_compute.hpp
@@ -208,6 +208,11 @@ uint64_t live_compute_buffer_gpu_result_skips();
 // Monotonic diagnostic count of retained sampled-image hits whose validated source omitted upload.
 // Capture/replay tests use this to prove residency without relying on timing-sensitive assertions.
 uint64_t live_compute_sampled_image_upload_skips();
+
+// How many bindings the compressed-source authority guard declined. Separate from the skip counters
+// above because the guard shares skip_image with unrelated reasons, so only a dedicated counter can
+// prove THIS guard fired rather than some other decline.
+uint64_t live_compute_compressed_source_authority_declines();
 // True only when an ordinary guest-backed 2D sampled image uses the same native Vulkan texel
 // representation as its typed storage counterpart. This is the format half of the retained-image
 // transfer contract; resource identity and write authority are checked separately at runtime.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -142,9 +142,24 @@ bool materialize_uniform_rtt(RttSurf& surface) {
 
 using RttCache = std::unordered_map<uint64_t, RttSurf>;
 
+// A queued guest write carries WHO made it. The origin is a thread-local set around
+// notify_guest_gpu_write, but DS/RTT invalidation runs later at drain time -- on whatever thread
+// drains, long after that thread-local was reset. So an invalidation diagnostic that reads the
+// thread-local reports a constant: measured on a routed GTA V boot, `[ds] invalidate` printed
+// `origin=gpu` for 30,458 of 30,458 invalidations, including ones made by writers that DO tag
+// themselves. The field looked like attribution and was structurally incapable of it.
+//
+// Capturing the origin at QUEUE time is what makes it real, and it is why the origin must live in
+// the record rather than be re-read at the far end of the seam.
+struct PendingGuestGpuWrite {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    const char* origin = "gpu";   // string literal or static storage; never an owned buffer
+};
+
 struct PendingGuestGpuWrites {
     std::mutex mutex;
-    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    std::vector<PendingGuestGpuWrite> ranges;
     bool overflowed = false;
 };
 
@@ -155,10 +170,12 @@ PendingGuestGpuWrites& pending_guest_gpu_writes() {
 
 void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
     auto& pending = pending_guest_gpu_writes();
+    // Read the origin HERE, on the writing thread, while it is still the writer's.
+    const char* origin = prosper::gpu::guest_gpu_write_origin();
     std::lock_guard<std::mutex> lock(pending.mutex);
     constexpr size_t kMaxPendingRanges = 65536;
     if (pending.ranges.size() < kMaxPendingRanges)
-        pending.ranges.emplace_back(addr, size);
+        pending.ranges.push_back(PendingGuestGpuWrite{addr, size, origin});
     else
         pending.overflowed = true;
 }
@@ -234,7 +251,7 @@ void register_cpu_rtt_dcc_metadata(
 
 void drain_guest_gpu_writes(RttCache& cache, bool invalidate_ds) {
     auto& pending = pending_guest_gpu_writes();
-    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    std::vector<PendingGuestGpuWrite> ranges;
     bool overflowed = false;
     {
         std::lock_guard<std::mutex> lock(pending.mutex);
@@ -256,11 +273,16 @@ void drain_guest_gpu_writes(RttCache& cache, bool invalidate_ds) {
         cache.clear();
         return;
     }
-    for (const auto& [addr, size] : ranges) {
+    for (const auto& write : ranges) {
+        // Restore the writer's own origin for the duration of this range's invalidation, so the
+        // diagnostics inside report who actually wrote the bytes rather than the drain thread's
+        // default. Cleared afterwards so a queued origin never leaks into an unrelated later write.
+        prosper::gpu::set_guest_gpu_write_origin(write.origin);
         if (invalidate_ds)
-            prosper::test::invalidate_persistent_ds_guest_write(addr, size);
-        prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
-        invalidate_cpu_rtt_guest_write(cache, addr, size);
+            prosper::test::invalidate_persistent_ds_guest_write(write.addr, write.size);
+        prosper::test::invalidate_persistent_color_target_guest_write(write.addr, write.size);
+        invalidate_cpu_rtt_guest_write(cache, write.addr, write.size);
+        prosper::gpu::set_guest_gpu_write_origin(nullptr);
     }
 }
 
@@ -5032,9 +5054,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 destination, pixels, tw, th, tile_mode,
                                                 writeback_pitch, 4u);
                                         }
-                                        if (guest_addr)
+                                        if (guest_addr) {
+                                            // Named for the same reason as the compute writebacks:
+                                            // a renderer writeback into guest memory is prosper's
+                                            // own store, and reads as an anonymous `gpu` write in
+                                            // every cache-invalidation diagnostic downstream.
+                                            prosper::gpu::set_guest_gpu_write_origin(
+                                                "renderer-writeback(rtt-guest-bytes)");
                                             prosper::gpu::notify_guest_gpu_write(
                                                 guest_addr, guest_bytes);
+                                            prosper::gpu::set_guest_gpu_write_origin(nullptr);
+                                        }
                                         // The same guest range can already have a sampled-image decode
                                         // under a different cache key/class. Its pixel representation
                                         // cannot be patched byte-for-byte from R32_UINT, so discard every

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <string>
 #include <bit>
 #include <cerrno>
 #include <cstdio>
@@ -1858,12 +1859,23 @@ bool validate_captured_indirect_pointer_relocations(
         error = "indirect-pointer relocation marker/carrier count mismatch";
         return false;
     }
-    if (capture.format_version < 53u || candidates != 1u ||
-        !compute.recompile_config_available ||
-        compute.raw_shader_index >= capture.raw_shader_versions.size()) {
-        if (capture_allow_unproven_provenance("an indirect-pointer relocation",
-                                              "no exact compute provenance")) return true;
-        error = "indirect-pointer relocation lacks exact compute provenance";
+    // Name WHICH precondition failed. These four are independent, they fail for unrelated reasons,
+    // and the one that fires decides whether the gap is a stale capture, a missing config, or a shape
+    // this validator was simply never written for -- but the message used to be the same sentence for
+    // all four, so the only way to tell them apart was to read this function. A whole title's F9
+    // bundles aborted on it (GTA V PPSA04263) with nothing in the log to say which arm to pursue.
+    const char* missing =
+        capture.format_version < 53u                                    ? "capture format older than v53"
+        : !compute.recompile_config_available                           ? "no captured recompile config"
+        : compute.raw_shader_index >= capture.raw_shader_versions.size() ? "raw shader index out of range"
+        : candidates != 1u                                              ? "carrier count is not exactly 1"
+                                                                        : nullptr;
+    if (missing) {
+        if (capture_allow_unproven_provenance("an indirect-pointer relocation", missing)) return true;
+        error = std::string("indirect-pointer relocation lacks exact compute provenance (") +
+                missing + ", carriers=" + std::to_string(candidates) +
+                " markers=" + std::to_string(marked) +
+                " format_version=" + std::to_string(capture.format_version) + ")";
         return false;
     }
     const auto& config = compute.recompile_config;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5652,13 +5652,27 @@ static bool gta_optional_null_linear_load_launch(
     return true;
 }
 
+// Whether the MIP OPERAND can be specialized away. Every term below is about mip addressing: the use
+// proved the operand zero, and the descriptor exposes exactly one base level outside a tail.
+//
+// `compression_enabled` is deliberately NOT a term. Compression describes how the base allocation's
+// bytes are ENCODED; this predicate is about which LOD is ADDRESSED, and the two are orthogonal. It
+// used to be here, where it silently cleared a proof the per-use fold had already established --
+// GTA V's 0x2042f49a00 reports `proven_at_use=1` at pc=16 and `proven_zero_mip=0` downstream, which
+// looks like a contradiction and is really this one line.
+//
+// Removing it does NOT authorize reading a compressed base allocation. That is a question about the
+// physical source, it is answered where the answer is knowable -- at bind time in the live compute
+// backend, which fails closed without an imported image, an exact fast-clear materialization, or
+// metadata proving the base uncompressed -- and that guard landed first, on purpose. Keeping the term
+// here conflated "we cannot decode these bytes" with "this whole program is unsupported", and the
+// cost was every other thing the program does: for 0x2042f49a00, two 4K storage-image writes.
 bool shader_resource_allows_zero_mip_specialization(
     const SrtUse& use, const DecodedImageDescriptor& descriptor,
     const DecodedImageView& view) {
     return use.proven_zero_mip && descriptor.sample_count == 1u &&
         descriptor.base_level == 0u && descriptor.last_level == 0u &&
-        descriptor.max_mip == 0u && !view.in_mip_tail &&
-        !descriptor.compression_enabled;
+        descriptor.max_mip == 0u && !view.in_mip_tail;
 }
 
 std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -14788,11 +14788,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // IMAGE_LOAD_MIP's final address is a real guest mip selector. Specialize it away only
             // after the per-use fold and the materialized-resource checks agree. The 2D_ARRAY form
             // retains its slice coordinate; only the separately proven mip operand is discarded.
+            // `res->compression_enabled` is deliberately absent from this LOAD gate; see
+            // shader_resource_allows_zero_mip_specialization for why it is not a mip term. The
+            // physical-source question it used to stand in for is answered at bind time by the live
+            // compute backend, which fails closed for a compressed sampled source with no authority.
+            // The STORE gate below keeps its compression term: a store is a different risk and
+            // nothing in the evidence for this change bears on it.
             if (is_zero_mip_load &&
                 (!rdna2_mimg_zero_mip_shape(in) || !res->proven_zero_mip ||
                  res->img_dim != in.mimg_dim || res->sample_count != 1u ||
                  res->declared_mip_levels != 1u || res->in_mip_tail ||
-                 res->compression_enabled || (in.mimg_dim == 5u && !b.is_compute))) {
+                 (in.mimg_dim == 5u && !b.is_compute))) {
                 // Name the sub-condition. Seven terms collapse into one
                 // `mode=unresolved-operand`, and an investigation cannot act on that: "the mip is
                 // not proven zero" and "the resource declares compression" are different pieces of

--- a/prosper/tests/test_agc_shader.cpp
+++ b/prosper/tests/test_agc_shader.cpp
@@ -556,9 +556,12 @@ int main() {
         reinterpret_cast<uint64_t>(zero_mip_texture_shader), true, 3);
     const prosper::gpu::ShaderResource* dcc_zero_mip_texture =
         realized_dcc_zero_mip ? realized_dcc_zero_mip->by_fetch_pc(1) : nullptr;
+    // The descriptor still decodes as compressed, and the mip proof now survives it: compression
+    // describes byte encoding, the proof is about which LOD is addressed. Reading those bytes is a
+    // bind-time question the live compute backend answers fail-closed.
     CHECK(dcc_zero_mip_texture && dcc_zero_mip_texture->compression_enabled &&
-              !dcc_zero_mip_texture->proven_zero_mip,
-          "build_stage_table leaves DCC-backed IMAGE_LOAD_MIP fail-visible");
+              dcc_zero_mip_texture->proven_zero_mip,
+          "build_stage_table keeps the zero-mip proof on a DCC-backed IMAGE_LOAD_MIP");
 
     const uint32_t direct_seed_fetch[] = {
         0xE0002000u, 0x80020100u,   // pc=0: buffer_load_format_x v1, v0, s[8:11], 0 idxen

--- a/prosper/tests/test_dynfetch_fold.cpp
+++ b/prosper/tests/test_dynfetch_fold.cpp
@@ -2177,10 +2177,27 @@ int main() {
     dcc_zero_mip_t8[7] = 0x20553100u;       // nonzero metadata address payload
     const DecodedImageDescriptor dcc_zero_mip_descriptor =
         decode_image_descriptor(dcc_zero_mip_t8);
+    // The descriptor still decodes as compressed -- WORD6[21] is set for depth and colour alike, with
+    // the metadata address carrying HTILE in the depth case (here 0x20553100 << 8 = 0x2055310000,
+    // this surface's real HTILE base on a routed boot). That decode is correct and unchanged.
+    //
+    // What changed is that compression no longer VETOES the mip proof. It describes byte encoding;
+    // this predicate is about which LOD is addressed. Whether those bytes may actually be read is a
+    // physical-source question answered at bind time, where the live compute backend fails closed
+    // without an imported image, an exact fast-clear materialization, or metadata proving the base
+    // uncompressed. Keeping the veto here cost the whole program: GTA V's 0x2042f49a00 also writes
+    // two 4K storage images, and none of that work reached the GPU.
     CHECK(dcc_zero_mip_descriptor.compression_enabled &&
-              !shader_resource_allows_zero_mip_specialization(
+              shader_resource_allows_zero_mip_specialization(
                   materialized_zero_mip_use, dcc_zero_mip_descriptor, zero_mip_view),
-          "GTA V's DCC-backed IMAGE_LOAD_MIP remains fail-visible at materialization");
+          "GTA V's DCC-backed IMAGE_LOAD_MIP specializes on the mip proof (source authority is a "
+          "bind-time question)");
+    // Compression must not become a back door into the proof: the mip still has to be proven.
+    SrtUse unproven_dcc_zero_mip_use = materialized_zero_mip_use;
+    unproven_dcc_zero_mip_use.proven_zero_mip = false;
+    CHECK(!shader_resource_allows_zero_mip_specialization(
+                  unproven_dcc_zero_mip_use, dcc_zero_mip_descriptor, zero_mip_view),
+          "a compressed resource still requires the zero-mip proof");
 
     // The same live Astro visibility kernel assembles a sampled T# in s[44:51] from four
     // consecutive entry-user-data pairs before image_load. Preserve both lanes of s_mov_b64 and

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -361,8 +361,23 @@ int main() {
         };
         CHECK(unsafe_realization_fails(multilevel_tsharp, false, 2),
               "compute realization keeps a multilevel IMAGE_LOAD_MIP fail-visible");
-        CHECK(unsafe_realization_fails(dcc_tsharp, true, 1),
-              "compute realization keeps GTA-shaped DCC IMAGE_LOAD_MIP fail-visible");
+        // The GTA-shaped DCC descriptor now REALIZES. Compression describes byte encoding and this
+        // stage is about mip addressing; whether those bytes may be read is decided at bind time,
+        // where the live compute backend fails closed for a compressed sampled source with no
+        // imported image, no exact fast-clear materialization, and no metadata proving the base
+        // uncompressed. The resource must still carry `compression_enabled` -- the decode is correct
+        // and unchanged, it simply no longer vetoes the proof.
+        auto compressed_realization_succeeds = [&](const uint32_t* descriptor) {
+            std::vector<OperationRealizationFailure> failures;
+            const std::vector<ComputeItem> items = realize_compute_dispatches(
+                make_zero_mip_submit(descriptor), 2482, &failures);
+            if (items.size() != 1 || !failures.empty() || !items[0].resources) return false;
+            const ShaderResource* texture = items[0].resources->by_fetch_pc(4);
+            return texture && texture->compression_enabled && texture->proven_zero_mip &&
+                texture->declared_mip_levels == 1u;
+        };
+        CHECK(compressed_realization_succeeds(dcc_tsharp),
+              "compute realization admits GTA-shaped DCC IMAGE_LOAD_MIP on the mip proof");
     }
 
     // #584: graphics and compute are one PM4 timeline. The planner must retain the asymmetric

--- a/prosper/tests/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/test_rdna2_spirv_struct.cpp
@@ -4920,20 +4920,46 @@ int main() {
     }
     ShaderResourceTable unproven_load_mip = rt_zero_mip_2d;
     unproven_load_mip.resources[0].proven_zero_mip = false;
-    ShaderResourceTable compressed_load_mip = rt_zero_mip_2d;
-    compressed_load_mip.resources[0].compression_enabled = true;
     ShaderResourceTable multilevel_load_mip = rt_zero_mip_2d;
     multilevel_load_mip.resources[0].declared_mip_levels = 2;
     if (!recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
                         &unproven_load_mip).empty() ||
         !recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
-                        &compressed_load_mip).empty() ||
-        !recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
                         &multilevel_load_mip).empty()) {
-        printf("  [FAIL] IMAGE_LOAD_MIP accepted an unproven, DCC, or multilevel resource\n");
+        printf("  [FAIL] IMAGE_LOAD_MIP accepted an unproven or multilevel resource\n");
         return 1;
     }
-    printf("  [ok]   IMAGE_LOAD_MIP 2D requires the exact one-level uncompressed proof\n");
+    printf("  [ok]   IMAGE_LOAD_MIP 2D requires the exact one-level mip proof\n");
+
+    // COMPRESSION IS NOT A MIP TERM, and this arm moved rather than disappeared. It used to sit in
+    // the negative list above, asserting that a DCC-marked resource fails to RECOMPILE. That
+    // conflated two questions: "is the mip operand zero" (a shader-semantic fact, proven by the
+    // per-use fold) and "can the base allocation's bytes be read" (a physical-source fact, knowable
+    // only once the binding resolves). The second question now lives where it can be answered -- the
+    // live compute backend fails closed for a compressed sampled source with no imported image, no
+    // exact fast-clear materialization, and no metadata proving the base uncompressed.
+    //
+    // So the compressed resource must now COMPILE, on exactly the same proof as the uncompressed one.
+    ShaderResourceTable compressed_load_mip = rt_zero_mip_2d;
+    compressed_load_mip.resources[0].compression_enabled = true;
+    const std::vector<uint32_t> compressed_load_mip_spv = recompile_valu(
+        gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0, &compressed_load_mip);
+    if (compressed_load_mip_spv.empty() || !has_opcode(compressed_load_mip_spv, OpImageFetch)) {
+        printf("  [FAIL] compressed IMAGE_LOAD_MIP did not compile on the zero-mip proof "
+               "(compression is a source-authority question, not a mip question)\n");
+        return 1;
+    }
+    // And the move must not have leaked into the mip proof itself: compression still must not rescue
+    // a resource whose mip is unproven. Without this arm the change above is indistinguishable from
+    // deleting the gate.
+    ShaderResourceTable compressed_unproven_load_mip = compressed_load_mip;
+    compressed_unproven_load_mip.resources[0].proven_zero_mip = false;
+    if (!recompile_valu(gta_load_mip_2d, std::size(gta_load_mip_2d), 1, 0,
+                        &compressed_unproven_load_mip).empty()) {
+        printf("  [FAIL] compressed IMAGE_LOAD_MIP compiled without the zero-mip proof\n");
+        return 1;
+    }
+    printf("  [ok]   compressed IMAGE_LOAD_MIP compiles on the mip proof, and still needs it\n");
 
     const uint32_t gta_load_mip_2da[] = {
         0x7e060206u,                         // v_mov_b32 v3, s6; v2 remains the slice

--- a/prosper/tests/test_shader_recompile_cache.cpp
+++ b/prosper/tests/test_shader_recompile_cache.cpp
@@ -1035,10 +1035,11 @@ int main() {
     stats = shader_recompile_cache_stats();
     CHECK(!cached_proven_zero_mip.empty() && cached_unproven_zero_mip.empty() &&
               repeated_proven_zero_mip == cached_proven_zero_mip &&
-              cached_multilevel_zero_mip.empty() && cached_dcc_zero_mip.empty() &&
+              cached_multilevel_zero_mip.empty() && !cached_dcc_zero_mip.empty() &&
               cached_tail_zero_mip.empty() &&
               stats.misses == 5 && stats.hits == 1 && stats.entries == 5,
-          "compute cache partitions zero-mip proof, levels, DCC, and texture-tail safety");
+          "compute cache partitions zero-mip proof, levels, and texture-tail safety, and "
+          "compiles the DCC case (source authority is decided at bind time)");
 
     clear_shader_recompile_cache();
     static const uint32_t kZeroStoreMipCompute[] = {


### PR DESCRIPTION
Refs #2542, #2481, tracker #1873. Reviewed in design by Codex on #2542 before any code was written;
this PR is the implementation of that plan plus the investigation that produced it.

## Result

**GTA V's 4K scene producer now executes.** `0x2042f49a00` holds the only write-class binding of the
4K surface `0x204da00000` (3840x2160, 33,177,600 B) seen anywhere in a routed run, and it used to fail
recompilation:

```
before:  program=0x2042f49a00 binding=6 class=4 StorageImage  outcome=partial-recompile-empty
after:   program=0x2042f49a00 binding=6 class=4 StorageImage  outcome=executed
```

**The world is still black.** Radar, status bars and tutorial text render as before; no 3D. This is a
necessary step and not the fix, and the PR does not claim otherwise.

## The defect

`shader_resource_allows_zero_mip_specialization` ANDed `!compression_enabled`, and the LOAD emitter
gate re-checked the same field. That produced a diagnostic pair that reads as a contradiction:

```
[mimg-mip-why] program=0x2042f49a00 pc=16 proven_at_use=1 in_zero_set=1 exec_pristine=1 cfg_known=1
[mimg-mip]     program=0x2042f49a00 image_load_mip declined pc=16 proven_zero_mip=0 compressed=1
```

The per-use fold proves the mip operand is zero; one term then clears that proof. **Compression
describes how bytes are ENCODED; these predicates are about which LOD is ADDRESSED.** Conflating them
turned "we cannot decode these bytes" into "this whole program is unsupported", and the cost was
everything else the program does — including the 4K write above.

## Why the two commits are ordered, and why the order is load-bearing

`compression_enabled` was **not** redundant. Codex established that on #2542: this is a *compute*
dispatch, so it never reaches the graphics DCC guard I had cited, and the compute path does not fail
closed — if `import_live_render_target_image` misses, it falls through to
`sampled_guest_source = resource_bytes_for(...)` and reads the base allocation, with only a
*readability* check. Removing the compiler term alone would have turned a decline into reading
compressed/stale bytes: **wrong pixels instead of a visible skip.**

So:

1. **`1fbd77a7` — the runtime guard first.** A compressed sampled source may not enter guest
   preparation without authority: an imported retained image, the exact fast-clear materialization, or
   metadata proving the base uncompressed (an all-`0xff` scan that already existed but was computed
   *after* the read and used only for cache eligibility).
2. **`a8637c31` — then the compiler path.** Compression leaves the zero-mip proof and the LOAD gate.
   **The STORE gate is untouched** — a store is a different risk and nothing here bears on it.

Verified on a routed boot that both outcomes occur, on the same program, in one run: dispatches whose
import resolves execute, and one whose import missed declined with
`compressed sampled source without authority ... -> dispatch skipped`, never touching guest base bytes.
That is the safe negative Codex predicted, and it happens because the retained depth is valid only
sometimes (`hit(depth=69965)` against `declined ... reason=depth-invalid x37751`).

## Test boundaries moved, not deleted

Five pinned assertions each re-assert the same fact on the correct side of the compile/bind split:
`rdna2_spirv_struct`, `dynfetch_fold` (which already encodes the live descriptor — metadata
`0x20553100 << 8` is this surface's real HTILE base), `gpu_execute`, `agc_shader_create`,
`shader_recompile_cache`. Every one still asserts `compression_enabled` is decoded and set: per AMD
PAL's GFX10 SRD builder it is set for depth and colour alike, with HTILE vs DCC differing only in what
the shared metadata address points at. **The decode was never wrong; the inference from it was.**

Two counter-arms were added so the change cannot be mistaken for deleting the gate: a compressed
resource with an unproven mip must still fail, at both the emitter and the materialization predicate.

## Diagnostic fix with a measured payoff

`1818b996`: `[ds] invalidate`'s `origin=` field was **structurally incapable of attribution**. It read
a thread-local set around `notify_guest_gpu_write`, while DS/RTT invalidation runs at *drain* time on
the draining thread — so it printed `origin=gpu` for **30,458 of 30,458** invalidations, including
ones from writers that tag themselves. The queued record now carries the origin, captured on the
writing thread. First run with it working:

| origin | count |
| --- | --- |
| `compute-writeback(image-guest-bytes)` | 15,777 |
| `compute-writeback(cpu-fill)` | 11,267 |
| `gpu` (genuinely the guest) | 6,316 |

**~81% of DS invalidation traffic is prosper invalidating its own caches from its own writebacks.**
Recorded as a measurement, not a verdict — a writeback into guest memory can legitimately stale a
detached cache — but it was invisible before.

`bfbc4589`: the indirect-pointer capture abort named one of four independent preconditions with the
same sentence; it now names which one failed, with carrier/marker counts.

## KNOWN GAP — the decisive regression is not written yet

Codex specified: *"an import-hit/import-miss pair at the production binding site: hit executes while
never resolving guest base bytes; mutating the import/extent/device match at that same site makes the
compressed dispatch decline."* **It is not in this PR.**

This matters more than usual: the guard's scope — `renderer_owned || depth_import_eligible` — was
found by *accidentally breaking* `game_compute_exec`'s pinned contract ("unresolved DCC promotion
keeps the ordinary sampled guest fallback correct"), not by reasoning. My first version declined every
compressed sampled source, including the case where prosper's own writeback put plain texels in the
base and the base is therefore authoritative. So the predicate that makes the interlock correct is
currently untested.

**Update — I attempted it, and the attempt produced a better result than the test would have.**

I wrote the pair (guest-backed falls back / renderer-owned with no import declines). Both arms passed.
Then I mutated the guard at the production site by deleting its compression term outright, and the
renderer-owned arm **stayed green** — so it never tested the guard. The log says why:

```
[compute] ... renderer-owned RTT has no readable snapshot -> dispatch skipped (#590)
```

That binding declines *earlier*, for an unrelated reason, and `skip_image` is shared — so "the
dispatch declined" is true with or without the guard. **The arm was vacuous and I did not commit it.**

`38360ff0` commits what makes a real one possible instead: a dedicated counter,
`live_compute_compressed_source_authority_declines()`, incremented only where this guard fires, so a
test can assert *this* guard acted rather than that something declined. The discriminator lives in the
production path, not in the test.

Why the real test still isn't written: the guard's live path on GTA V is `depth_import_eligible`,
which needs a **2D Float32 single-component** sampled view. The existing DCC fixture is RGBA8x4 and so
takes the `renderer_owned` half, where the earlier snapshot guard always wins. A faithful regression
needs a new fixture. The gap is now understood exactly rather than merely known.

Also outstanding from review: `PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS` is not yet fail-closed for the
compressed case.

## Investigation recorded in `GTA5_STATUS.md`

- Three sequential capture gates on this title, each masking the next; **one captured frame is 3.27 GB
  against a 3072 MiB hard ceiling**, so no F9 bundle of GTA V completes at any setting (#2554).
- **30–36 distinct failing compute programs** per routed run, against the 13 in the census table and
  the "seven" the prose had been repeating.
- Two traps, both the same shape — a number computed over the wrong population:
  a black frame that read as a regression until the *matched-trigger* control proved the pre-change run
  equally black; and "24,922 depth invalidations have `htile_hit=0`, so HTILE is not involved", which
  was dominated by cube shadow maps and inverts entirely once filtered to the surface under
  investigation.

## Verification

```
cmake --build prosper/build-linux -j6                  # exit 0
ctest --no-tests=error -j4                             # 246/246 passed, exit 0
check_numbered_table.py --sequential (orchestration)   # exit 0
check_numbered_table.py over all tracked .md           # exit 0
git diff --check                                       # clean
```

No snapshots run: the behavioural surface is one compute admission guard and one recompiler predicate,
both covered by the focused tests above and by the routed A/B.
