### PR TITLE
fix(apr): a resolve batch that fails mid-way stamps its whole remaining range, not just the failing entry

### DIFF
--- a/prosper/src/hle/hle_file.cpp
+++ b/prosper/src/hle/hle_file.cpp
@@ -2161,6 +2161,10 @@ static std::string apr_miss_callsite() {
 // makes APR proceed on garbage ids and wild-write over the allocator, so every successful entry
 // writes its id and size. `error_index` is one scalar, not an output array; a missing path records
 // its index and fails the batch so callers do not construct a zero-length reader (#1226).
+//
+// The "populate the outputs" half of that reasoning covers the WHOLE array, not just the entries the
+// loop reaches: on a miss the batch stops, but all `count` output slots still belong to this call
+// (#1951). See the miss branch below for why the untouched tail is stamped rather than left.
 static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int count,
                                  uint32_t* out_ids, uint64_t* out_sizes, uint32_t* error_index) {
     if (!paths || count <= 0) return 0x80020016ull;   // EINVAL
@@ -2205,8 +2209,30 @@ static uint64_t apr_resolve_impl(const char* prefix, const char** paths, int cou
         }
         if (found) size = (uint64_t)st.st_size;
         else {
-            if (out_ids) out_ids[i] = 0xffffffffu;
-            if (out_sizes) out_sizes[i] = 0;
+            // Stamp the failing entry AND everything after it (#1951). The batch stops here, so
+            // entries i+1..count-1 are never stat'd — and leaving them untouched hands the guest
+            // back whatever its own array already held. That is the same "APR proceeds on garbage
+            // ids" hazard this function's header comment was written against, displaced one index:
+            // a stale word that happens to be a live 1-based registry index resolves through
+            // prosper_apr_path_for_id() to the WRONG container, so the read path serves the wrong
+            // file's bytes instead of failing. 0xffffffff cannot be a valid APR id (ids are 1-based
+            // indices into g_apr_files), so both f_apr_get_file_stat and the Ampr read path reject
+            // it with ENOENT — a definite, diagnosable error instead of a silent wrong-data read.
+            // The written RANGE is exactly the range an all-success batch already writes, so this
+            // assumes no output-array bound the success path does not already assume.
+            //
+            // The scalar `error_index` and the ENOENT batch-failure return are deliberately
+            // unchanged: that contract was recovered from live ArcRunner evidence (#1226).
+            //
+            // CONFIDENCE: MED — no title has yet been observed making a multi-entry resolve whose
+            // miss is not the final entry (Sonic Origins' two startup misses are each single-entry
+            // calls), so firmware's exact treatment of the tail is unevidenced. The sentinel VALUE
+            // is the one the failing entry already used; stamping can only turn an unspecified read
+            // into a rejected id, and no evidenced behaviour is weakened.
+            for (int j = i; j < count; j++) {
+                if (out_ids)   out_ids[j]   = 0xffffffffu;
+                if (out_sizes) out_sizes[j] = 0;
+            }
             if (error_index) *error_index = (uint32_t)i;
             if (filelog())
                 fprintf(stderr, "[apr] resolve MISS %s%s\n",

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -524,6 +524,46 @@ int main() {
                   miss_error_guard[2] == 0x22222222u,
               "APR resolver reports the scalar failure index without an array overrun");
 
+        // #1951: the batch stops at the miss, but every one of the `count` output slots still
+        // belongs to the call. The 2-entry case above cannot see this — its miss IS the last entry,
+        // so there is no tail. Resolve [present, present, MISSING, present] instead and prove the
+        // untouched tail is stamped rather than left holding the caller's own prior contents.
+        //
+        // The poison is deliberately a LIVE 1-based registry id, not an obviously-bogus word: a
+        // decoy container is registered first so that id 1 names a DIFFERENT file than the tail
+        // entry's own path. That reproduces the exact hazard — a stale id resolving to the wrong
+        // container — instead of merely showing that some bytes changed. Entry 3 also names a file
+        // that genuinely EXISTS, so the tail sentinel additionally distinguishes "stamped" from
+        // "resolved anyway" (which would mean the batch did not stop).
+        prosper_apr_reset_for_test();
+        const char* decoy_path = "prosper-test-apr-decoy-container.tmp";   // registry-only, never opened
+        const uint32_t decoy_id = prosper_apr_register(decoy_path, 4096);
+        CHECK(decoy_id == 1 && prosper_apr_path_for_id(1) == decoy_path,
+              "#1951 setup: a live id 1 names the decoy container");
+        const char* tail_paths[4] = { wp_full, wp_full,
+                                      "prosper-test-apr-does-not-exist.tmp", wp_full };
+        uint32_t tail_ids[4] = { decoy_id, decoy_id, decoy_id, decoy_id };
+        uint64_t tail_sizes[4] = { 0x5a5a, 0x5a5a, 0x5a5a, 0x5a5a };
+        uint32_t tail_error_guard[3] = { 0x11111111u, 0xDEADBEEFu, 0x22222222u };
+        uint64_t rt = resolve_plain((uint64_t)(uintptr_t)tail_paths, 4,
+                                    (uint64_t)(uintptr_t)tail_ids,
+                                    (uint64_t)(uintptr_t)tail_sizes,
+                                    (uint64_t)(uintptr_t)&tail_error_guard[1], 0);
+        CHECK((uint32_t)rt == 0x80020002u && tail_error_guard[1] == 2,
+              "#1951: a mid-batch miss still fails the batch at its own scalar index");
+        CHECK(tail_ids[0] >= 1 && tail_ids[0] != decoy_id && tail_sizes[0] == wp_bytes.size() &&
+                  tail_ids[1] == tail_ids[0] && tail_sizes[1] == wp_bytes.size(),
+              "#1951: entries before the miss keep their real resolved ids and sizes");
+        CHECK(tail_ids[2] == 0xffffffffu && tail_sizes[2] == 0,
+              "#1951: the failing entry itself is stamped (unchanged behaviour)");
+        CHECK(tail_ids[3] == 0xffffffffu && tail_sizes[3] == 0,
+              "#1951: the entry AFTER the miss is stamped, not left holding the caller's value");
+        CHECK(prosper_apr_path_for_id(tail_ids[3]).empty(),
+              "#1951: the stamped tail id resolves to no container (no silent wrong-file read)");
+        CHECK(tail_error_guard[0] == 0x11111111u && tail_error_guard[2] == 0x22222222u,
+              "#1951: stamping the tail does not write past the scalar error index");
+        prosper_apr_reset_for_test();
+
         // A null paths pointer / non-positive count is rejected without touching memory.
         CHECK((uint32_t)resolve_prefix((uint64_t)(uintptr_t)"", 0, 1, 0, 0, 0) == 0x80020016u,
               "WithPrefix resolve rejects a null paths array");


### PR DESCRIPTION
Fixes #1951

## Failure scenario

`apr_resolve_impl` (`prosper/src/hle/hle_file.cpp`) walks a batch of guest paths and aborts on the
first missing one. Before this change, the miss branch wrote **only the failing entry's** outputs and
returned:

```c
if (out_ids) out_ids[i] = 0xffffffffu;
if (out_sizes) out_sizes[i] = 0;
if (error_index) *error_index = (uint32_t)i;
return 0x80020002ull;   // ENOENT
```

Entries `i+1 .. count-1` are never stat'd, never registered and never written, so the guest reads back
whatever its own `out_ids` / `out_sizes` array already held.

Concretely, with `count = 4` where entries 0-1 exist and entry 2 does not:

1. entries 0-1 get real ids/sizes and are registered;
2. entry 2 gets `id = 0xffffffff`, `size = 0`, `*error_index = 2`, return `ENOENT`;
3. **entry 3 keeps the caller's prior array contents.**

That is the same hazard the function's own header comment was written against ("Returning without
populating the id/size outputs … makes APR proceed on garbage ids"), displaced one index. The reasoning
had been applied to the successful entries and to the failing entry, but not to the untouched tail.

The dangerous case is not a random word — it is a stale word that happens to be a **live 1-based
registry index**. `prosper_apr_path_for_id()` resolves that to a *real but wrong* container, so
`sceAmprAprCommandBufferReadFile` / `sceKernelAprGetFileStat` serve another file's bytes instead of
failing. That is a silent wrong-data read rather than a clean error.

Verified still present on current master (`20153833`) before fixing.

## Behavioural contract

A batch resolve owns all `count` output slots. On a mid-batch miss the batch still fails at that entry
(unchanged), and every slot from the failing entry to the end reads back a **definite sentinel** that
cannot name a container:

- `out_ids[j] = 0xffffffff` for all `j >= i` — never a valid APR id, since ids are 1-based indices into
  the registry vector, so `prosper_apr_path_for_id()` returns empty and both the Ampr read path and
  `sceKernelAprGetFileStat` reject it with `ENOENT`.
- `out_sizes[j] = 0` for all `j >= i`.

Explicitly **unchanged**: the scalar `error_index` still records the failing index only, and the batch
still returns `ENOENT` at the first miss rather than continuing. That contract was recovered from live
ArcRunner evidence (#1226) and this PR does not touch it.

## Approach and invariants

The two single-slot writes become one loop over `j = i .. count-1`, placed before the existing
`error_index` write and `ENOENT` return.

Invariants worth naming:

- **No new memory bound is assumed.** The written range is exactly the range an all-success batch
  already writes. If the guest's arrays were shorter than `count`, the success path would already
  overrun them; the tail stamp relies on the identical `count`-elements-per-array invariant and nothing
  more.
- **The sentinel value is not new** — it is the one the failing entry already received, and the same
  value GTA V's RAGE was observed pre-filling its id array with (recorded in the existing test comment
  at `test_apr_registry.cpp`). Both `0` and `0xffffffff` are rejected by our read paths; `0xffffffff` is
  chosen for consistency with the failing entry and because it is not a plausible index.
- All three entry points sharing the helper get the fix: `f_apr_resolve`, `f_apr_resolve_ids`,
  `f_apr_resolve_with_prefix`. (The issue text says "four entry points" but lists three; three is
  correct — `grep -n "f_apr_resolve" prosper/src/hle/hle_file.cpp` shows exactly three definitions and
  three registrations, and `apr_resolve_impl` is the only APR resolve implementation in the tree.)

`CONFIDENCE: MED` on firmware's exact treatment of the tail, and the code comment says so. No title has
yet been observed making a multi-entry resolve whose miss is not the final entry — Sonic Origins' two
startup misses (`raw/ui/ui_startup.pac`, `raw/ui/rpl_texture/ui_title_nocopy.dds`) are each their own
single-entry call, so index 0 fails and there is no tail. This is therefore defensive hardening against
a latent robustness defect, not an evidenced behaviour correction. It cannot weaken anything evidenced:
it only converts an unspecified read into a rejected id.

## Deliberately unaffected

- **The `EINVAL` early return** (`!paths || count <= 0`) still touches no memory. The existing test
  asserts that ("rejects a null paths array"), and a malformed call is a different contract from a
  well-formed batch that hits a missing file. Not changed.
- **Successful batches** — byte-identical behaviour; the loop is only reachable from the miss branch.
- **The registry** — a failed batch still registers exactly the entries that resolved before the miss.
- **`error_index` semantics, the `ENOENT` return value, the content-root `/app0/raw` fallback, and the
  `apr_miss_callsite()` diagnostic** — untouched.

## Risks

- A guest that pre-filled its id array with previously-valid ids and expected untouched slots to survive
  a partial failure would now see them replaced. This is exotic (it would be relying on error-path
  behaviour), and such a guest is already having its pre-miss slots rewritten with fresh ids today.
- If some title's real ABI for one variant passed an output array **shorter** than `count`, the stamp
  would write further than the old miss path did. Ruled acceptable because the all-success path already
  writes the full `count` range, so no title can be relying on a shorter array.

## Build and test

Linux, distrobox `ps5ys`, worktree-local build dir, dump `<DUMP_ROOT>/PPSA24651-app0` (The Messenger):

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4                       # exit 0
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 246`, ctest exit code 0** (`--no-tests=error`, so the count is real and not
an empty directory).

New checks in `test_apr_registry` (exit 0):

```
[ok]   #1951 setup: a live id 1 names the decoy container
[ok]   #1951: a mid-batch miss still fails the batch at its own scalar index
[ok]   #1951: entries before the miss keep their real resolved ids and sizes
[ok]   #1951: the failing entry itself is stamped (unchanged behaviour)
[ok]   #1951: the entry AFTER the miss is stamped, not left holding the caller's value
[ok]   #1951: the stamped tail id resolves to no container (no silent wrong-file read)
[ok]   #1951: stamping the tail does not write past the scalar error index
```

### Mutation arm — the test fails with the fix reverted

The existing 2-entry miss test **cannot** see this defect: its miss *is* the last entry, so there is no
tail. The new case resolves `[present, present, MISSING, present]`.

The poison is deliberately not an obviously-bogus word. A decoy container is registered first so that
**id 1 is live and names a different file** than the tail entry's own path, and the arrays are poisoned
with that id — reproducing the actual hazard (a stale id resolving to the wrong container) rather than
merely showing that some bytes changed. Entry 3 also names a file that genuinely **exists**, so the
sentinel assertion additionally distinguishes "stamped" from "resolved anyway" (which would mean the
batch failed to stop).

Reverting only the `hle_file.cpp` loop back to the two single-slot writes, keeping the test, and
rebuilding:

```
mutation_rc=1
  [ok]   #1951 setup: a live id 1 names the decoy container
  [ok]   #1951: a mid-batch miss still fails the batch at its own scalar index
  [ok]   #1951: entries before the miss keep their real resolved ids and sizes
  [ok]   #1951: the failing entry itself is stamped (unchanged behaviour)
  [FAIL] #1951: the entry AFTER the miss is stamped, not left holding the caller's value
  [FAIL] #1951: the stamped tail id resolves to no container (no silent wrong-file read)
  [ok]   #1951: stamping the tail does not write past the scalar error index
== FAIL: 2 ==
```

Exactly the two intended assertions fail and nothing else — including the second one, which is the
one that proves the *consequence* (the leftover value names a real container that is not the file the
guest asked for), not merely that a slot was unwritten. Every pre-existing check in the file still
passes under the mutation, so the new arm is not masking an unrelated change.

### Snapshots

None run. This path is guest file-resolution, not renderer state, and no snapshot route exercises a
multi-entry APR resolve with a mid-batch miss.

## Review

Worth an independent read: it is a reverse-engineered Sony ABI error path where the exact firmware
behaviour is unevidenced, which is the category the charter asks to review even for a small diff. The
specific things to challenge are (a) whether `0xffffffff` rather than `0` is the right tail sentinel,
and (b) whether stamping the tail at all is preferable to leaving it, given no live title reproduces it.
