### PR TITLE
fix(pad): scePadGetHandle names the lowest handle sharing a triple, not an arbitrary one

### DIFF
--- a/prosper/src/hle/hle_pad.cpp
+++ b/prosper/src/hle/hle_pad.cpp
@@ -477,6 +477,21 @@ HLE(pad_close) {
 // (its close path at eboot+0x7fc7b takes `jle` -- 0 and below are "nothing to close"), and negative
 // means "no handle".
 //
+// Several open handles can share one triple: nothing stops a guest from calling scePadOpen twice
+// with the same (userId, portType, index), and prosper mints a fresh handle each time, so every one
+// of them matches this lookup.  Answering with the first match the container iterates makes the
+// reply depend on std::unordered_map's unspecified order -- it moves with insertion history, with
+// rehashes, and with the standard-library version -- so one route could answer differently across
+// runs, and a guest that closes what it was handed and keeps reading the other loses input for the
+// rest of the run, intermittently (#1624).  Answer with the LOWEST matching handle instead: since
+// scePadOpen mints from a monotonically increasing counter, that is the oldest still-open pad for
+// the triple, which is the one a caller asking "did I already open this?" is asking about.
+// CONFIDENCE: HIGH that a shared triple must resolve deterministically (a nondeterministic reply is
+// wrong under any semantics).  MED on picking the oldest: prosper has no primary evidence for what
+// hardware does with a repeated open -- rejecting the second open is at least as plausible, and the
+// PS5 3.20 export list names scePadOpen without a body or an error code, so nothing local settles
+// it.  Both are unobserved so far: no local dump double-opens a triple today.
+//
 // CONFIDENCE: HIGH on the lookup semantics and the sign convention (both read directly off the
 // guest's own use above, and Sony pad handles are positive with 0x8092xxxx errors).  MED on the
 // exact errno: prosper cannot establish SCE_PAD_ERROR_NO_HANDLE's value from primary evidence, so
@@ -485,11 +500,16 @@ HLE(pad_close) {
 HLE(pad_get_handle) {
     const PadOpenKey key{(int32_t)a0, (int32_t)a1, (int32_t)a2};
     std::lock_guard<std::mutex> lock(g_pad_handle_mx);
+    int32_t found = 0;
+    bool have = false;
     for (const auto& [handle, opened] : g_pad_handles) {
         if (!(opened == key)) continue;
+        if (!have || handle < found) { found = handle; have = true; }
+    }
+    if (have) {
         if (padlog()) fprintf(stderr, "[pad] GETHANDLE userId=%d type=%d index=%d -> handle=%d\n",
-                              key.user_id, key.type, key.index, handle);
-        return (uint64_t)(int64_t)handle;
+                              key.user_id, key.type, key.index, found);
+        return (uint64_t)(int64_t)found;
     }
     if (padlog()) fprintf(stderr, "[pad] GETHANDLE userId=%d type=%d index=%d -> no open handle\n",
                           key.user_id, key.type, key.index);

--- a/prosper/tests/test_pad.cpp
+++ b/prosper/tests/test_pad.cpp
@@ -331,6 +331,78 @@ int main() {
         set_test_env("PROSPER_PAD_SCRIPT", "");
     }
 
+    // (6b) scePadGetHandle must be DETERMINISTIC when several open handles share one
+    // (userId, portType, index) triple (#1624). Nothing stops a guest from opening the same triple
+    // twice — prosper mints a fresh handle for every scePadOpen — and each of those handles matches
+    // the lookup equally. Resolving by iterating the handle map answered with whichever entry the
+    // container happened to reach first, and std::unordered_map leaves that order unspecified: it
+    // moves with insertion history, with rehashes, and with the standard-library version. A guest
+    // that closes the handle it was handed and keeps reading the other then loses input for the
+    // rest of the run, intermittently. The contract asserted here is the LOWEST matching handle —
+    // the oldest still-open pad for the triple, since scePadOpen mints from a monotonic counter.
+    //
+    // The arms are built so a "first match in iteration order" implementation cannot satisfy them
+    // by luck: 24 duplicates make one specific handle the answer out of 24 candidates, the query is
+    // repeated after enough unrelated opens to rehash the container several times, and again after
+    // the current answer is closed.
+    {
+        HleFn open       = Hle::lookup(nid_hash("scePadOpen"));
+        HleFn close      = Hle::lookup(nid_hash("scePadClose"));
+        HleFn get_handle = Hle::lookup(nid_hash("scePadGetHandle"));
+        constexpr uint64_t invalid_handle = 0xffffffff80920003ull;
+        CHECK(open && close && get_handle, "duplicate-triple arm: scePadOpen/Close/GetHandle found");
+        if (open && close && get_handle) {
+            constexpr int kDup = 24;
+            uint64_t dup[kDup];
+            for (int i = 0; i < kDup; ++i) dup[i] = open(7, 0, 3, 0, 0, 0);
+            uint64_t lowest = dup[0];
+            uint64_t highest = dup[0];
+            bool ascending = true;
+            bool all_distinct = true;
+            for (int i = 1; i < kDup; ++i) {
+                if (dup[i] < lowest)  lowest = dup[i];
+                if (dup[i] > highest) highest = dup[i];
+                ascending &= dup[i] > dup[i - 1];
+            }
+            for (int i = 0; i < kDup && all_distinct; ++i)
+                for (int j = i + 1; j < kDup; ++j)
+                    if (dup[i] == dup[j]) { all_distinct = false; break; }
+            // The ambiguity has to EXIST before any assertion about resolving it means anything: if
+            // a repeated triple handed back one shared handle there would be nothing to choose
+            // between and every arm below would pass vacuously.
+            CHECK(all_distinct && ascending && highest != lowest,
+                  "duplicate triple: 24 opens of (user 7, type 0, index 3) mint 24 distinct "
+                  "ascending handles, so 23 of the matches are NOT the lowest");
+
+            CHECK(get_handle(7, 0, 3, 0, 0, 0) == lowest,
+                  "scePadGetHandle names the LOWEST handle sharing a triple, not whichever the "
+                  "handle map iterates first");
+
+            // Unrelated opens grow the container past several rehash points — the exact event that
+            // reorders unordered_map iteration — so the same query must still answer the same way.
+            constexpr int kNoise = 96;
+            uint64_t noise[kNoise];
+            for (int i = 0; i < kNoise; ++i) noise[i] = open(100 + i, 0, 0, 0, 0, 0);
+            CHECK(get_handle(7, 0, 3, 0, 0, 0) == lowest,
+                  "the named handle does not move when unrelated opens rehash the handle map");
+
+            // Closing the named handle promotes the next-lowest still-open one: a guest that closes
+            // what it was handed must be given another live pad, never a retired handle.
+            uint64_t second = 0;
+            for (int i = 0; i < kDup; ++i)
+                if (dup[i] != lowest && (second == 0 || dup[i] < second)) second = dup[i];
+            CHECK(close(lowest, 0, 0, 0, 0, 0) == 0, "scePadClose retires the named duplicate");
+            CHECK(get_handle(7, 0, 3, 0, 0, 0) == second,
+                  "after the lowest duplicate is closed the next-lowest open handle is named");
+
+            for (int i = 0; i < kDup; ++i)
+                if (dup[i] != lowest) close(dup[i], 0, 0, 0, 0, 0);
+            for (int i = 0; i < kNoise; ++i) close(noise[i], 0, 0, 0, 0, 0);
+            CHECK(get_handle(7, 0, 3, 0, 0, 0) == invalid_handle,
+                  "closing every duplicate leaves the triple with no handle");
+        }
+    }
+
     // (7) PROSPER_PAD_SCRIPT pure helpers — parse + time-eval (drives menus headless, issue #163).
     {
         CHECK(pad_button_by_name("start")   == SCE_PAD_BUTTON_OPTIONS, "name: start -> OPTIONS");


### PR DESCRIPTION
Fixes #1624.

## Failure scenario

`prosper/src/hle/hle_pad.cpp` keys open pads on the `(userId, portType, index)` triple
(`std::unordered_map<int32_t, PadOpenKey> g_pad_handles`), and `scePadGetHandle` resolved a triple by
**iterating** that map and returning the first match.

Nothing stops a guest from calling `scePadOpen` twice with the same triple — prosper mints a fresh
handle for every open — so several entries can match one lookup, and which handle came back was
whichever entry the container happened to reach first. `std::unordered_map` leaves that order
unspecified: it moves with insertion history, with rehashes, and with the standard-library version.

1. `scePadOpen(userId=1, type=0, index=0)` -> handle 1
2. `scePadOpen(userId=1, type=0, index=0)` again -> handle 2
3. `scePadGetHandle(1, 0, 0)` -> **1 or 2**, unspecified

If the guest closes the one it was handed and keeps reading the other, input silently stops for the
rest of the run, and it reproduces only intermittently. Determinism is load-bearing on this project:
snapshot guards and capture replay both assume one route produces one behaviour, so this presents as
"the guard is flaky" rather than as a bug.

**Measured on the old resolver** (libstdc++, Linux, via `PROSPER_PADLOG=1`): after 24 opens of one
triple minting handles 3..26, it answered **26** on every query — and kept answering 26 after handle
3 was closed. Not a coin flip on this toolchain, just the wrong end of an order nobody chose.

## Behavioural contract

`scePadGetHandle(userId, portType, index)` returns the **lowest** still-open handle opened for that
triple, or the existing negative "no handle" error when none is open. Since `scePadOpen` mints from a
monotonically increasing counter, the lowest is the **oldest still-open pad** for that triple — the
one a caller asking "did I already open this?" is asking about — and it is stable under any container
order, insertion history or rehash.

Unchanged: the lookup semantics, the sign convention, and the error value, all of which came from the
Worms Armageddon disassembly recorded in the function's comment (#1592/#1623).

## Approach and invariants

Two lines of resolver change: track the minimum matching handle across the scan instead of returning
on the first match. The scan already runs under `g_pad_handle_mx`, so the answer is a consistent
snapshot; the map holds a handful of pads, so scanning it fully rather than short-circuiting is not a
measurable cost.

Invariants the tests pin:
- the answer is the lowest matching handle, not an arbitrary one;
- the answer does not move when unrelated opens rehash the container;
- closing the named handle promotes the next-lowest still-open one, never a retired handle;
- with every duplicate closed, the triple reports no handle.

`CONFIDENCE: HIGH` that a shared triple must resolve deterministically — a nondeterministic reply is
wrong under any semantics. `CONFIDENCE: MED` on picking the **oldest** specifically: prosper has no
primary evidence for what hardware does with a repeated open. Rejecting the second `scePadOpen` is at
least as plausible and is what the issue floats as the more faithful alternative, but the PS5 3.20
export list names `scePadOpen` with no body and no error code, so nothing local settles it and
inventing an error constant would be worse than the deterministic lookup. **No local dump double-opens
a triple today**, so both readings remain unobserved; the reject variant stays open for whenever
primary evidence for its error code turns up. That reasoning is recorded in the source comment, not
only here.

## Affected / deliberately unaffected

- **Affected:** `scePadGetHandle` only, and only when two or more open handles share one triple. With
  at most one match — every case any local dump exercises today — the returned handle is identical.
- **Deliberately unaffected:** `scePadOpen` still accepts a duplicate triple and still mints a new
  handle (changing that needs the evidence above). `scePadClose`, `scePadIsValidHandle`, and every
  read/effector path are untouched. No other caller exists in `src/`, `frontends/` or `tools/`.

## Risks

- The lookup now always scans the whole handle map instead of stopping at the first match. The map is
  a handful of entries, it is already under the same lock, and no hot path calls this.
- Choosing "oldest" could be wrong if hardware in fact names the newest — but any fixed choice beats
  an unspecified one, and the `CONFIDENCE: MED` note in the source says exactly what would settle it.

## Verification

Configure and build (Linux, in the project's container, worktree-local build dir):

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
```
Build: exit 0, 478/478 targets linked.

```bash
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```
**`100% tests passed out of 246`, exit code 0** (152.48 s). `--no-tests=error` was passed, so the
count is real rather than an empty directory reporting green.

Focused: `./test_pad` -> exit 0, `== FAIL: 0 ==`.

### Mutation arm — the new arms fail without the fix

Same worktree, same test, resolver reverted to the first-match loop, built and run at `-j4`:

```
  [ok]   duplicate triple: 24 opens of (user 7, type 0, index 3) mint 24 distinct ascending handles, so 23 of the matches are NOT the lowest
  [FAIL] scePadGetHandle names the LOWEST handle sharing a triple, not whichever the handle map iterates first
  [FAIL] the named handle does not move when unrelated opens rehash the handle map
  [ok]   scePadClose retires the named duplicate
  [FAIL] after the lowest duplicate is closed the next-lowest open handle is named
  [ok]   closing every duplicate leaves the triple with no handle
== FAIL: 3 ==
```
`test_pad` exit code 1. With the fix, all six are `[ok]` and the exit code is 0.

`PROSPER_PADLOG=1` on both arms shows what actually moved:

| query | without the fix | with the fix |
| --- | --- | --- |
| after 24 opens (handles 3..26) | `-> handle=26` | `-> handle=3` |
| after 96 unrelated opens rehash the map | `-> handle=26` | `-> handle=3` |
| after the lowest (3) is closed | `-> handle=26` | `-> handle=4` |
| after all duplicates are closed | `no open handle` | `no open handle` |

### Why the test discriminates rather than passing by luck

- It **constructs the ambiguity by hand and asserts it exists** before asserting anything about
  resolving it: 24 opens of one triple must mint 24 distinct, ascending handles, so 23 of the matches
  are not the answer. Had `scePadOpen` handed back one shared handle, there would be nothing to choose
  between and every later arm would pass vacuously — that arm is there to make the vacuous case
  visible instead of green.
- With 24 candidates, "first in iteration order" has one chance in 24 of being the lowest by accident;
  it was not — the measured pre-fix answer was the *highest*, on every query.
- Honest limit on one arm: the rehash arm fails pre-fix for the same reason the first does (it asserts
  the value, and the value is wrong), and on **this** libstdc++ the pre-fix answer did *not* visibly
  move across the rehash — it was 26 before and after. So that arm demonstrates the fixed answer is
  stable across rehashing; it does not independently prove the old order moved here. The
  cross-toolchain movement is a property of the standard, not something this run measured.

Snapshots: none run. This changes no renderer or GPU code, and touches only a libScePad lookup that
no snapshot route double-opens.
