### PR TITLE
fix(tools): xref.py's --help printed "None", and an unknown mode answered nothing with exit 0

### DIFF
--- a/prosper/tools/il2cpp/resolve.py
+++ b/prosper/tools/il2cpp/resolve.py
@@ -1,4 +1,23 @@
 #!/usr/bin/env python3
+"""resolve.py — map runtime addresses / btrace frames to C# method names.
+
+Uses the Il2CppDumper output (script.json). Companion to prx_to_elf.py; see README.md.
+
+usage:
+  python3 resolve.py <script.json> 0x16b981 0x11e63c ...      # bare RVAs
+  python3 resolve.py <script.json> il+0x16b981,eb+0xada254    # a btrace chain
+  echo '[btrace] ... chain=il+0x1e23b8,il+0xde92e9' | python3 resolve.py <script.json> -
+  python3 resolve.py <script.json> --base 0x440000000 0x4402140d0   # absolute runtime addr
+
+The IL2CPP PRX loads at a fixed guest base (0x440000000 for both PPSA24651 and PPSA02664), so a
+method's runtime address = base + RVA, and script.json's "Address" field == RVA (the flattened ELF
+has p_offset == p_vaddr). A prosper [btrace] chain prints frames as "il+0x<offset>", where <offset>
+is already the RVA — feed those straight in.
+"""
+# The usage block above is the module DOCSTRING, not a comment, because `main()` prints `__doc__` on
+# a bad invocation — and a header made only of `#` comments makes that print the literal string
+# `None` (#2399, where the same arrangement in xref.py sent a caller to invented syntax).
+#
 # resolve.py — map runtime addresses / btrace frames to C# method names using the
 # Il2CppDumper output (script.json). Companion to prx_to_elf.py; see README.md.
 #

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -40,6 +40,36 @@ python3 tools/re/xref.py /tmp/eboot.elf to 0x20698a5
 `from ADDRESS` lists references made by the function window containing that address; `reloc ADDRESS`
 restricts output to relative data relocations.
 
+### How to read a zero — and the CLI contract that makes a zero readable
+
+`xref.py`'s arguments are **positional**: `xref.py <module.elf> {to|from|reloc|imm} <argument>`.
+There are no option flags. `xref.py --help` prints that usage; anything that is not one of the four
+modes is **refused**, loudly and with a non-zero exit.
+
+That is a contract, not a nicety, because the one answer this tool must never give by accident is a
+confident zero. `xref.py <elf> --addr 0x…` used to clear the argument-count check, parse the module,
+decode half a million reference sites, then fall off the end of the mode chain and exit **0 with no
+output at all** — indistinguishable from "nothing references this address", which is a conclusion
+strong enough to redirect an investigation (#2399; the reporter fell back to a hand-rolled byte scan
+and had to retract its false positives, #2396).
+
+So the exit status means exactly one of two things:
+
+| exit | meaning |
+| --- | --- |
+| `0` | the query ran; the printed counts **are** the answer, zero included |
+| `2` | refused — nothing was searched, and no number printed is a result |
+
+Every query prints, before its answer, how many references the decoder found **across the whole
+module**. That number is what separates "this address has no references" from "this run found
+nothing at all", and it is printed on hits and misses alike so a saved transcript carries its own
+validity check. A zero result says so on its own line, and an address lying outside every `PT_LOAD`
+(checked against `p_memsz`, so a `.bss` flag byte is *inside*) is called out as the likeliest cause —
+usually a runtime address nobody rebased to an image-relative one (#1659).
+
+Two zeros are still worth nothing until you have done one more thing: a string of 22 bytes or fewer
+needs `imm` (see below), and an address you cannot find at all needs the load base subtracted.
+
 ## Find who builds a SHORT string — `to` cannot, and its zero is misleading
 
 A short string may have **no address to reference**. Clang materialises a `std::string` built from a

--- a/prosper/tools/re/gstr.py
+++ b/prosper/tools/re/gstr.py
@@ -18,9 +18,17 @@ auto-detecting UTF-16LE (UE4's TCHAR) as well as ASCII.
 The intended pipeline is to feed it every data reference of a frame's function at once:
 
     python3 tools/re/xref.py <flat.elf> from 0x2121d9e \
-      | awk '/^   (lea|load) /{print $3}' \
-      | xargs python3 tools/re/gstr.py <flat.elf> \
-      | grep '"'
+      | awk '/ (lea|load) +-> /{print $NF}' \
+      | xargs python3 tools/re/gstr.py <flat.elf> --strings-only
+
+The awk matches on the arrow and takes the LAST field, deliberately. `xref.py from` prints an
+access-class column (`[& ]`, `[rw]`) ahead of the kind, added in #2025, and that column tokenises
+differently per class -- `[& ]` splits into two awk fields where `[rw]` is one -- so a fixed field
+index is right for some lines and wrong for others. The recipe here used to be
+`awk '/^   (lea|load) /{print $3}'`, written before that column existed; against the current output
+it matches nothing at all, `xargs` then runs gstr with no addresses, gstr reads an empty stdin, and
+the whole pipeline prints nothing and exits 0. That is the same silent-empty failure #2399 records
+one tool upstream: a documented invocation that answers "nothing" when it means "I did not run".
 
 Flatten a module first with `python3 tools/il2cpp/prx_to_elf.py <eboot.bin> <flat.elf>`, or reuse
 the images `tools/guest_bt/guest_bt.py` already caches under `tools/guest_bt/.cache/`.

--- a/prosper/tools/re/test_xref.py
+++ b/prosper/tools/re/test_xref.py
@@ -3,7 +3,9 @@
 
 import importlib.util
 import os
+import shutil
 import struct
+import subprocess
 import sys
 import tempfile
 
@@ -345,7 +347,148 @@ def refusal():
     print("xref refusal: PASS")
 
 
+def cli():
+    """#2399: the command line must never answer a question it did not ask.
+
+    Two symptoms, and they were cause and effect. `xref.py --help` printed the literal string
+    `None` -- `main()` did `print(__doc__)` on a bad invocation, and every line of the module header
+    was a `#` comment, so there was no docstring to print. Told nothing, the caller guessed
+    `xref.py <elf> --addr 0x…`; that is four argv entries, so it cleared the arity check, parsed a
+    real 27 MB module, decoded half a million reference sites -- and then fell off the end of an
+    if/elif chain with no `else`, printing NOTHING and exiting 0. For an address with two real
+    references. An empty exit-0 run is byte-identical to "no references found", and "nobody
+    references this address" is a conclusion strong enough to redirect an investigation; the
+    reporter hand-rolled a byte scan instead and had to retract its false positives (#2396).
+
+    Every arm here is CLI-level, through a subprocess, because that is the layer that failed: the
+    decoder was never wrong. The fixture is built in-process rather than taken from a dump, so the
+    arms cannot silently skip in CI (#1675).
+    """
+    xref = os.path.join(HERE, "xref.py")
+
+    def run(*args):
+        p = subprocess.run([sys.executable, xref, *args], capture_output=True, text=True)
+        return p.returncode, p.stdout, p.stderr
+
+    # One executable PT_LOAD whose memsz reaches well past its filesz -- the .bss tail. Guest flag
+    # bytes live there, and on PPSA24651 the `storeb` target 0x1f4f3f0 is 0x13288 past the last
+    # segment's filesz with two real references, so the tail is not a corner case.
+    raw = bytearray(0x200)
+    raw[:4] = b"\x7fELF"
+    struct.pack_into("<Q", raw, 0x20, 0x40)
+    struct.pack_into("<HH", raw, 0x36, 56, 1)
+    struct.pack_into("<IIQQQQQQ", raw, 0x40,
+                     1, 5, 0x100, 0x1000, 0, 0x100, 0x2000, 0x1000)   # filesz 0x100, memsz 0x2000
+    called = 0x1080          # in the file-backed part
+    bss_flag = 0x2000        # in the memsz tail only
+    unreferenced = 0x1090    # mapped, file-backed, and referenced by nothing
+    outside = 0x900000       # in no segment at all -- an un-rebased runtime address
+    code = bytearray(b"\x90" * 0x100)
+    code[0x00:0x05] = b"\xe8" + rel32(0x1000, 5, called)
+    code[0x05:0x0c] = b"\xc6\x05" + rel32(0x1005, 7, bss_flag) + b"\x01"
+    raw[0x100:0x200] = code
+
+    tmp = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmp, "fixture.elf")
+        with open(path, "wb") as f:
+            f.write(raw)
+
+        # --- the root cause, asserted directly. `print(__doc__)` is only a usage message if there
+        # --- is a docstring; a header made of `#` comments leaves __doc__ None.
+        assert XREF.__doc__ is not None, "xref.py has no module docstring; --help would print None"
+
+        # --- symptom 1: help must be usage, and an explicit help request is a SUCCESS.
+        for flag in ("--help", "-h"):
+            rc, out, err = run(flag)
+            assert rc == 0, (flag, rc, out, err)
+            assert out.strip() != "None" and "None" != out.strip(), (flag, out)
+            # Naming every mode is the specific thing whose absence sent the reporter to `--addr`.
+            for mode in ("to", "from", "reloc", "imm"):
+                assert mode in out, (flag, mode, out)
+            assert "POSITIONAL" in out, out
+
+        # Too few arguments is a refusal, not a help request: it must be non-zero and say why.
+        rc, out, err = run(path)
+        assert rc != 0, (rc, out, err)
+        assert (out + err).strip() != "None", (out, err)
+        assert "expected 3 arguments" in err, err
+
+        # --- the answer the tool must give, so the arm below has something to be measured against.
+        rc, out, err = run(path, "to", hex(called))
+        assert rc == 0, (rc, out, err)
+        assert "code references to 0x%x: 1" % called in out, out
+        assert "call" in out, out
+
+        # --- symptom 2, the whole point: the reporter's invocation, on an address that DOES have a
+        # --- reference (the arm above proves it). Before the fix this printed zero bytes and exited
+        # --- 0. The assertion is written as "must not be a silent success" rather than as an exact
+        # --- message, because any loud failure is acceptable and silence never is.
+        rc, out, err = run(path, "--addr", hex(called))
+        assert not (rc == 0 and not out.strip() and not err.strip()), (
+            "an invented flag produced a silent exit-0 run: this is #2399")
+        assert rc != 0, (rc, out, err)
+        assert "--addr" in err and "not a mode" in err, err
+        # ...and the hint that closes the loop, since guessing the syntax is what started it.
+        assert "positional" in err.lower(), err
+
+        # A mode that is merely misspelled -- not flag-shaped -- must be refused on the same path.
+        rc, out, err = run(path, "too", hex(called))
+        assert rc != 0 and "not a mode" in err, (rc, out, err)
+
+        # A non-numeric address for a numeric mode is refused, not tracebacked past.
+        rc, out, err = run(path, "to", "not_an_address")
+        assert rc != 0 and "is not an address" in err, (rc, out, err)
+        assert "Traceback" not in err, err
+
+        # --- a genuine zero must announce itself AS a zero, and carry the evidence that the run
+        # --- happened: the module-wide decoded count. That number is what distinguishes "this
+        # --- address has no references" from "this run found nothing at all".
+        rc, out, err = run(path, "to", hex(unreferenced))
+        assert rc == 0, (rc, out, err)
+        assert "0 references of any decoded kind" in out, out
+        assert "real answer, not a failed run" in out, out
+        assert "decoded 2 code reference sites" in out, out
+
+        # --- the unmapped warning, and BOTH of its arms. An address in no segment is the commonest
+        # --- cause of an honest-looking zero (a runtime address nobody rebased, #1659)...
+        rc, out, err = run(path, "to", hex(outside))
+        assert rc == 0 and "WARNING" in out and "outside every PT_LOAD" in out, (rc, out)
+
+        # ...and this is the arm that keeps the warning honest: a .bss address, past filesz and
+        # inside memsz, with a real `storeb` writing it. It must be ANSWERED and NOT warned about.
+        # Checking the range against p_filesz instead of p_memsz passes every other arm here and
+        # fails this one -- which is how that mistake was caught on a live PPSA24651 query.
+        rc, out, err = run(path, "to", hex(bss_flag))
+        assert rc == 0, (rc, out, err)
+        assert "code references to 0x%x: 1 (1 write" % bss_flag in out, out
+        assert "WARNING" not in out, ("a referenced .bss address must not be flagged unmapped", out)
+
+        # `from` printed a bare header and nothing else on an empty window, which reads as a
+        # truncated run rather than as an answer.
+        rc, out, err = run(path, "from", hex(outside))
+        assert rc == 0 and "0 distinct targets" in out, (rc, out)
+
+        # `imm` takes an arbitrary needle, so a help flag in the ARGUMENT slot is a search term.
+        # Treating it as a help request would make `imm` unable to ask about its own flag strings.
+        rc, out, err = run(path, "imm", "--help")
+        assert rc == 0, (rc, out, err)
+        assert "inline-immediate constructions of '--help'" in out, out
+        assert "usage:" not in out, out
+
+        # --- the mutation arm for the whole file, run against the tool exactly as shipped: with
+        # --- master's xref.py in place of this one, the `--addr` arm above is a silent exit 0.
+        # --- Reproduce by copying this test next to the old xref.py:
+        # ---     git show <base>:prosper/tools/re/xref.py > <scratch>/xref.py
+        # ---     cp prosper/tools/re/test_xref.py <scratch>/ && python3 <scratch>/test_xref.py
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    print("xref cli: PASS")
+
+
 if __name__ == "__main__":
     main()
     imm()
     refusal()
+    cli()

--- a/prosper/tools/re/waitgraph.py
+++ b/prosper/tools/re/waitgraph.py
@@ -1,5 +1,29 @@
 #!/usr/bin/env python3
+"""waitgraph.py — build a wait-for graph for a TOTALLY deadlocked guest.
+
+usage:
+    tools/re/waitgraph.py <dump-file> [<dump-file> ...]
+
+Produce the input with:
+    PROSPER_SYNC_RING=4000000 PROSPER_APP_GUEST_DUMP_MS=110000 \\
+    PROSPER_APP_GUEST_DUMP_PATH=<dump.txt>  prosper-app <game>
+
+Both inputs may be the same file: `prosper-app`'s timed dump appends the thread snapshot and the
+sync ring together, which is the intended way to use this.
+
+For each parked thread T waiting on object O it draws an edge to the thread that most recently woke
+O. A ROOT is a parked thread whose object nothing has ever woken — usually the real defect. A CYCLE
+is a lock-ordering deadlock. Roots with no cycle mean starvation or a lost wakeup, not lock ordering.
+
+Caveat: only the CONDITION-slot paths record wake events, so a thread parked in an `address` (raw
+futex) wait ALWAYS looks like a root — because no producer was ever recorded for its object, not
+because none exists. Those are reported separately; do not read them as findings.
+"""
 # waitgraph.py — build a wait-for graph for a TOTALLY deadlocked guest.
+#
+# The usage block above is the module DOCSTRING, not a comment, because the bad-invocation path
+# below prints `__doc__` — and a header made only of `#` comments makes that print the literal
+# string `None` (#2399, where the same arrangement in xref.py sent a caller to invented syntax).
 #
 # When every guest thread is parked, `PROSPER_APP_GUEST_DUMP_PATH` tells you WHERE each thread
 # stopped and `PROSPER_SYNC_RING` tells you what happened before they stopped. Neither, alone, tells

--- a/prosper/tools/re/xref.py
+++ b/prosper/tools/re/xref.py
@@ -1,4 +1,37 @@
 #!/usr/bin/env python3
+"""xref.py — cross-reference finder for an (unsymbolicated) PS5 module.
+
+Answers "who references address X" over direct calls, rip-relative loads/stores/leas, and Sony
+(DT_SCE_*) relocations — none of which objdump or readelf can decode on a PS5 module.
+
+usage:
+    xref.py <module.elf> to    <hexaddr>    who references this address
+    xref.py <module.elf> from  <hexaddr>    what the function at this address references
+    xref.py <module.elf> reloc <hexaddr>    data-pointer relocations targeting this address only
+    xref.py <module.elf> imm   <string>     who BUILDS this string from inline immediates
+    xref.py --help
+
+The arguments are POSITIONAL. There are no option flags, and a mode that is not one of the four
+above is refused rather than answered (#2399).
+
+Three things a caller must know before believing an answer:
+
+  * The input is a FLATTENED ELF (p_offset == p_vaddr), not the SELF as it ships. Flatten first:
+        python3 tools/il2cpp/prx_to_elf.py <DUMP>/eboot.bin <out.elf>
+    Handing this tool an `eboot.bin` is refused, not answered (#2346).
+  * Addresses are IMAGE-RELATIVE. A runtime address is module_load_base + VA (the eboot base is
+    0x410000000 — see prosper/src/host/boot_program.hpp for the authoritative set), so subtract the
+    base before querying an address taken from a live backtrace or a diagnostic (#1659).
+  * `to` returning 0 for a string of 22 bytes or fewer is VOID until `imm` has been run: clang
+    materialises a short std::string from immediates, leaving the .rodata copy with no reference of
+    any kind (#1905).
+
+exit status is a contract, because the failure this tool must never have is a zero that means
+"I did not run":
+    0   the query ran; the printed counts ARE the answer, including when they are zero
+    2   refused — nothing was searched, and no count below is a result
+"""
+#
 # xref.py — cross-reference finder for an (unsymbolicated) PS5 module.
 #
 # PS5 eboot/PRX code is position-independent: internal references appear as
@@ -42,11 +75,14 @@
 # `ui/ui_startup` has zero references AND is requested on every boot -- #1905). `imm` closes that hole
 # by searching the executable segments for the string's own bytes appearing as instruction operands.
 #
-# Usage:
-#   xref.py <module.elf> to   <hexaddr>     # who references this address
-#   xref.py <module.elf> from <hexaddr>     # what this function references (rip-lea/call, ~2KB window)
-#   xref.py <module.elf> reloc <hexaddr>    # data-pointer relocations targeting this address only
-#   xref.py <module.elf> imm  <string>      # who BUILDS this string from inline immediates
+# The usage block lives in the module DOCSTRING above and nowhere else, deliberately. It used to be
+# here, as a comment, while `main()` printed `__doc__` on a bad invocation -- and a module whose
+# header is all `#` comments has `__doc__ == None`, so `xref.py --help` printed the literal string
+# `None` (#2399). The comment was correct and unreachable at the same time, which is the worst
+# arrangement available: the tool could not tell a caller how to invoke it, so the caller guessed
+# `--addr`, and the guess produced an empty result they read as "no references".
+#
+# `from` scans a ~2KB window forward from the given address.
 
 import struct, sys
 from collections import defaultdict
@@ -117,12 +153,19 @@ class Module:
         if not phnum or e_phoff + phnum * phentsize > len(raw):
             raise BadModule(f"{path}: program header table (phoff=0x{e_phoff:x}, phnum={phnum}) "
                             f"does not fit in {len(raw)} bytes")
-        self.segs = []          # (va, foff, filesz, flags)
+        self.segs = []          # (va, foff, filesz, flags) -- FILE-backed bytes, what we can decode
+        # p_memsz, separately, because it is a different question. `segs` bounds what can be READ;
+        # `va_ranges` bounds what the module OCCUPIES, and the .bss tail (memsz > filesz) is in the
+        # second and not the first. Guest flag bytes live there: on PPSA24651 the `storeb` target
+        # 0x1f4f3f0 is 0x13288 past the last segment's filesz and is written by real code, so a
+        # "not in this module" check built on filesz calls a correct answer suspect.
+        self.va_ranges = []     # (va, memsz)
         self.dyn_va = 0
         for i in range(phnum):
             t, fl, off, va, pa, fs, ms, al = struct.unpack_from('<IIQQQQQQ', raw, e_phoff + i * phentsize)
             if t == 1:
                 self.segs.append((va, off, fs, fl))
+                self.va_ranges.append((va, max(fs, ms)))
             elif t == 2:
                 self.dyn_va = va
         if not self.segs:
@@ -387,26 +430,123 @@ def find_immediate_builds(m, needle, span=0x60):
     return out
 
 
+MODES = ('to', 'from', 'reloc', 'imm')
+HELP_FLAGS = ('-h', '--help', 'help')
+
+# The exit codes are a contract, not a formality. This tool's characteristic failure is a zero that
+# means "I did not run", so REFUSED and ANSWERED must never share a status.
+EXIT_OK = 0        # the query ran; the printed counts are the answer, zero included
+EXIT_REFUSED = 2   # nothing was searched
+
+
+def usage(stream=sys.stdout):
+    print(__doc__.rstrip(), file=stream)
+
+
+def refuse(message):
+    """Print usage plus a specific reason on stderr, and hand back the refusal status."""
+    usage(sys.stderr)
+    print(f"\nxref.py: refused: {message}", file=sys.stderr)
+    return EXIT_REFUSED
+
+
+def describe_module(path, m):
+    """Print what was decoded, before any answer.
+
+    A count of what the decoder found ACROSS THE MODULE is the number that separates "this address
+    has no references" from "this run found nothing at all" — the two readings of a bare zero that
+    #2399 and #2346 are both about. It is printed on every query, not only on empty ones, so that a
+    zero and a hit are framed identically and a saved transcript carries its own validity check.
+    """
+    exec_bytes = sum(fs for _, _, fs, fl in m.segs if fl & 1)
+    code_sites = sum(len(v) for v in m.code_xref.values())
+    data_sites = sum(len(v) for v in m.data_xref.values())
+    print(f"module {path}: {len(m.segs)} PT_LOAD, 0x{exec_bytes:x} bytes executable; decoded "
+          f"{code_sites} code reference sites to {len(m.code_xref)} distinct addresses, and "
+          f"{data_sites} data-pointer relocations to {len(m.data_xref)} distinct addresses")
+    return code_sites + data_sites
+
+
+def warn_unmapped(m, addr):
+    """Warn when the queried address lies outside the module's address space entirely.
+
+    This is the commonest cause of an honest-looking 0: a runtime address that was never rebased to
+    an image-relative one (#1659) is not in this module at all, so of course nothing references it.
+
+    Measured against p_memsz, NOT p_filesz. `foff()` is filesz-based because it maps to file bytes,
+    but a module occupies its .bss tail too, and that tail is where guest flag bytes live — on
+    PPSA24651 the address 0x1f4f3f0 is past every segment's filesz and has two real references. A
+    filesz test would flag that correct answer as suspect, which is worse than not warning at all.
+
+    A warning and never a refusal, and only when the answer is empty: a non-empty result proves the
+    address is meaningful, and an alarm printed over a correct answer is noise that teaches readers
+    to ignore the alarm.  CONFIDENCE: HIGH
+    """
+    if any(va <= addr < va + size for va, size in m.va_ranges):
+        return
+    print(f"   WARNING: 0x{addr:x} is outside every PT_LOAD segment of this module (checked against "
+          f"p_memsz, so the .bss tail is included). If this address came from a live backtrace or a "
+          f"diagnostic, subtract the module load base first (#1659) — as it stands the 0 above is an "
+          f"answer about an address this module does not have.")
+
+
+def show_truncated(shown, total, what):
+    """Say so when a listing was cut short, instead of letting it read as the whole answer."""
+    if total > shown:
+        print(f"   ... {total - shown} more {what} not shown (listing is capped at {shown})")
+
+
 def main():
-    if len(sys.argv) < 4:
-        print(__doc__)
-        return 1
+    argv = sys.argv[1:]
+    # A help flag counts only in the module or mode slot. `imm` takes an arbitrary needle, so
+    # `xref.py f.elf imm --help` must search for the string "--help", not print this text.
+    if any(a in HELP_FLAGS for a in argv[:2]):
+        usage()
+        return EXIT_OK
+    if len(argv) < 3:
+        return refuse(f"expected 3 arguments (module, mode, argument), got {len(argv)}")
+
+    # Validate the mode BEFORE parsing the module: it is the argv-level mistake, it costs nothing to
+    # check, and leaving it until after the if/elif chain is exactly how #2399 happened. There was no
+    # `else` at the bottom of that chain, so an unrecognised mode fell through to `return 0` having
+    # printed nothing -- and `xref.py <elf> --addr 0x…` is four argv entries, so it cleared the arity
+    # check, parsed a real module, decoded half a million reference sites, and then reported none of
+    # them. Zero bytes of output and exit 0, for an address that provably had two references.
+    mode = argv[1]
+    if mode not in MODES:
+        hint = ""
+        if mode.startswith('-'):
+            hint = (" This CLI is positional and has no option flags — there is no `--addr`; the "
+                    "query is written `to 0x…`.")
+        return refuse(f"{mode!r} is not a mode. Expected one of: {', '.join(MODES)}.{hint}")
+
+    # Likewise the address: argv-level, free to check, and doing it here keeps a typo from costing a
+    # 27 MB module parse and from interleaving its stderr with buffered stdout.
+    addr = None
+    if mode != 'imm':
+        try:
+            addr = int(argv[2], 0)
+        except ValueError:
+            return refuse(f"{argv[2]!r} is not an address. `{mode}` takes a number (0x… or "
+                          f"decimal); only `imm` takes text.")
+
+    path = argv[0]
     try:
-        m = Module(sys.argv[1])
+        m = Module(path)
     except BadModule as exc:
         # Non-zero exit as well as the message: a caller that pipes this into a report must not be
         # able to mistake a refusal for an empty result set (#2346).
         print(f"refused: {exc}", file=sys.stderr)
-        return 2
-    mode = sys.argv[2]
+        return EXIT_REFUSED
+    decoded = describe_module(path, m)
     if mode == 'imm':
-        text = sys.argv[3]
+        text = argv[2]
         needle = text.encode('utf-8')
+        print(f"query: imm {text!r}")
         try:
             builds = find_immediate_builds(m, needle)
         except ValueError as exc:
-            print(f"refused: {exc}")
-            return 1
+            return refuse(str(exc))
         print(f"inline-immediate constructions of {text!r} ({len(needle)} bytes): {len(builds)}")
         for first, last, parts in builds:
             where = ", ".join(f"0x{va:x}[{lo}:{hi}]" for va, lo, hi in parts)
@@ -429,13 +569,19 @@ def main():
         for va in lits[:16]:
             print(f"   0x{va:x}: {len(m.code_xref.get(va, []))} code refs, "
                   f"{len(m.data_xref.get(va, []))} data relocations")
-        return 0
-    addr = int(sys.argv[3], 0)
+        show_truncated(16, len(lits), "literal copies")
+        if not builds and not lits:
+            print(f"   0 constructions and 0 literal copies — a real answer, not a failed run: this "
+                  f"module decoded {decoded} references in total. {text!r} is not in this image.")
+        return EXIT_OK
+    print(f"query: {mode} 0x{addr:x}")
     if mode in ('to', 'reloc'):
         drefs = m.data_xref.get(addr, [])
         print(f"data-pointer relocations targeting 0x{addr:x}: {len(drefs)}")
         for s in drefs[:32]:
             print(f"   ptr stored at 0x{s:x}")
+        show_truncated(32, len(drefs), "relocations")
+        crefs = []
         if mode == 'to':
             crefs = m.code_xref.get(addr, [])
             # Summarise by access class first. "who WRITES this" is the usual question, and an
@@ -451,17 +597,37 @@ def main():
                       "decoder does not know, or it is genuinely read-only (#2025).")
             for s, k in crefs[:32]:
                 print(f"   [{access(k):2s}] {k:7s} at 0x{s:x}  (in func 0x{m.func_start(s):x})")
+            show_truncated(32, len(crefs), "code references")
+        # The line this whole change exists for. A zero must state that it IS the answer and name
+        # the evidence that the run happened, because the alternative reading -- "the tool did not
+        # run" -- is the one that has twice sent an investigation somewhere worse (#2346, #2399).
+        if not drefs and not crefs:
+            ran = (f"This is a real answer, not a failed run: the decoder found {decoded} "
+                   f"references elsewhere in this module.")
+            if mode == 'to':
+                print(f"   0 references of any decoded kind. {ran} If 0x{addr:x} is a string of 22 "
+                      f"bytes or fewer, this zero is void until `imm` has been run (#1905).")
+            else:
+                print(f"   0 data-pointer relocations. {ran} Note that `reloc` does not consult "
+                      f"code references at all — run `to 0x{addr:x}` for those.")
+            warn_unmapped(m, addr)
     elif mode == 'from':
         start = m.func_start(addr)
         print(f"references made by func 0x{start:x} (window from 0x{addr:x}):")
-        fo = m.foff(addr)
         seen = set()
         for tgt, sites in m.code_xref.items():
             for s, k in sites:
                 if addr <= s < addr + 0x800 and tgt not in seen:
                     seen.add(tgt)
                     print(f"   [{access(k):2s}] {k:7s} -> 0x{tgt:x}")
-    return 0
+        # `from` printed a header and then nothing at all on an empty result, which reads as a
+        # truncated run rather than as a function that references nothing.
+        print(f"   {len(seen)} distinct targets in the 0x800-byte window from 0x{addr:x}"
+              + ("" if seen else f" — a real answer: the decoder found {decoded} references "
+                                 f"elsewhere in this module."))
+        if not seen:
+            warn_unmapped(m, addr)
+    return EXIT_OK
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #2399

## The failure scenario

Two symptoms, and the issue is right that they were cause and effect — but the second one is a real
defect in the tool, not only in the caller.

```
$ python3 prosper/tools/re/xref.py --help
None                                      # exit 1

$ python3 prosper/tools/re/xref.py <flat.elf> --addr 0x1f4f3f0
                                          # exit 0, ZERO bytes of output
$ python3 prosper/tools/re/xref.py <flat.elf> to 0x1f4f3f0
code references to 0x1f4f3f0: 2 (1 write, 1 read, 0 address-taken)
```

Both reproduce on current master (`20153833`), verified against a flattened *The Messenger*
(`PPSA24651`) eboot — not the GTA V dump the issue used.

## The mechanism behind the silent-empty result, established by construction

`main()` did `print(__doc__)` when `len(sys.argv) < 4`. Every line of `xref.py`'s header was a `#`
comment, so the module had **no docstring**, `__doc__` was `None`, and `print(None)` wrote the
literal string. There was no `-h`/`--help` handling at all; `--help` merely happened to be a
too-few-arguments invocation.

Told nothing, the caller guessed `--addr`. That guess is **four** argv entries, so:

1. it cleared the `len(sys.argv) < 4` arity check;
2. `mode = sys.argv[2]` became the literal string `'--addr'`;
3. `addr = int(sys.argv[3], 0)` parsed fine;
4. the `if mode == 'imm' / elif mode in ('to','reloc') / elif mode == 'from'` chain had **no
   `else`**, so `main()` fell straight through to `return 0`.

Zero bytes of output, exit 0 — for an address with two real references.

**The #2350 backstop is not implicated, and it did not fail.** It guards the *module*, not the
*query*, and the module parsed perfectly. Measured on the run that produced the silent zero:

```
exec_bytes = 0x19b4c7c (26,954,876)          # backstop threshold is 0x10000
code reference sites decoded  = 527,707      to 131,188 distinct addresses
data relocations decoded      =  49,664      to  32,893 distinct addresses
```

So: not the gate, not the decoding, not the address parse. It was argv dispatch falling off the end
of a chain with no `else`.

## The hand-constructed positive instance

Per the charter rule about a null validated by its own machinery, the referenced address was derived
**outside xref.py entirely** — GNU `objdump` in raw-binary mode (the flattened ELF has no section
header table, so `objdump -d` rejects it; binary mode with `--adjust-vma` does not depend on the ELF
structure *or* on this tool):

```
$ objdump -D -b binary -m i386:x86-64 -M intel --adjust-vma=0x300000 <slice>
  31487f:  c6 05 6a ab c3 01 01   mov  BYTE PTR [rip+0x1c3ab6a],0x1   # 0x1f4f3f0
```

By hand: `0x31487f + 7 + 0x1c3ab6a = 0x1f4f3f0`. This is exactly the shape the issue used. The tool
finds it (a `storeb` writer plus a `cmpb` reader) when asked correctly, and reported nothing at all
when asked with the invented flag.

That instance also caught a bug in my own first fix. `0x1f4f3f0` is **past every segment's
`p_filesz`** — it is in the `.bss` tail — so an "is this address in the module?" warning built on
`foff()` fired on a correct answer. It is now measured against `p_memsz`, and only printed when the
answer is empty. Both directions are pinned by test arms.

## Behavioural contract for a zero result

Exit status now means exactly one of two things, and this is the contract the change exists to
create:

| exit | meaning |
| --- | --- |
| `0` | the query ran; the printed counts **are** the answer, zero included |
| `2` | refused — nothing was searched, and no number printed is a result |

Every query prints, *before* its answer, how many references the decoder found across the whole
module — on hits and misses alike, so a saved transcript carries its own validity check and a zero
is framed identically to a hit. An empty result says so on its own line and names that evidence:

```
module <flat.elf>: 5 PT_LOAD, 0x19b4c7c bytes executable; decoded 527707 code reference sites to
131188 distinct addresses, and 49664 data-pointer relocations to 32893 distinct addresses
query: to 0x19b8004
data-pointer relocations targeting 0x19b8004: 0
code references to 0x19b8004: 0 (0 write, 0 read, 0 address-taken)
   0 references of any decoded kind. This is a real answer, not a failed run: the decoder found
   577371 references elsewhere in this module. If 0x19b8004 is a string of 22 bytes or fewer, this
   zero is void until `imm` has been run (#1905).
```

## Approach and invariants

- **`xref.py` keeps hand-rolled argv parsing rather than moving to `argparse`.** `argparse` would
  reject an `imm` needle beginning with `-` (the tool must be able to ask about flag-shaped strings),
  and would reword the refusal paths that #2346 and #2099 pin. The fix is a real module docstring
  plus explicit validation, not a framework swap.
- A help flag is honoured **only in the module or mode slot**. `xref.py <elf> imm --help` searches
  for the string `--help`; it does not print usage. Pinned by an arm.
- Mode and address are validated **before** the module is parsed — argv-level mistakes cost nothing
  to catch, and doing it there also stops a typo from paying for a 27 MB parse and from interleaving
  unbuffered stderr with buffered stdout.
- `Module` gained `va_ranges` (`p_memsz`-based) alongside `segs` (`p_filesz`-based). `foff()` is
  unchanged and still filesz-based, because it maps to file bytes; the two answer different
  questions and conflating them is what produced the false warning above.
- **No existing output line changed.** The new lines are additive, and the one documented consumer
  (`gstr.py`'s pipeline) was verified end-to-end.

## Also fixed — same defect class, found by sweeping for the shape

`print(__doc__)` with no module docstring was not unique to `xref.py`. Swept every Python tool:

| tool | before | now |
| --- | --- | --- |
| `re/waitgraph.py` | printed `None` | prints usage |
| `il2cpp/resolve.py` | printed `None` | prints usage |
| `re/edis.py`, `snapshot/snapshot.py` | already had docstrings | unchanged |

And one downstream instance of the *silent-empty* half: `re/gstr.py`'s documented pipeline is
`awk '/^   (lea|load) /{print $3}'`, written before #2025 added the access-class column to
`xref.py from`. Against the current output it matches **nothing**; `xargs` then runs `gstr` with no
addresses, `gstr` reads an empty stdin, and the whole pipeline prints nothing and exits 0 — the same
"answers nothing when it means I did not run" failure, one tool downstream. Corrected to match on
the arrow and take the last field (the class column tokenises differently per class, so a fixed
field index is right for some lines and wrong for others), and verified end-to-end:

```
$ xref.py <flat.elf> from 0x314870 | awk '/ (lea|load) +-> /{print $NF}' \
    | xargs gstr.py <flat.elf> --strings-only
0x1c37efe      A"<TypeName Unknown>"
0x1c37ee2      A".\nvcloth/src/SwFactory.cpp"
```

## Tests, and the mutation arms

`test_xref.py` gains `cli()` — 11 arms, driven through `subprocess` because the CLI is the layer
that failed (the decoder was never wrong), against an ELF fixture **built in-process**, so nothing
can silently skip in CI on a missing dump (#1675).

**Mutation evidence.** Master's `xref.py` copied next to the new test, arm by arm:

```
FAIL  --help prints usage                        exit 1, expected 0
FAIL  too-few-args refuses loudly                no arity message on stderr (stderr='')
pass  positive control: to 0x1080 answers
FAIL  invented --addr flag is refused            SILENT exit-0 run for an address with a real reference
FAIL  misspelled mode is refused                 a misspelled mode was accepted silently
FAIL  unparseable address is refused             raw traceback instead of a refusal
FAIL  a zero states that it is a zero            a zero does not say it is a zero
FAIL  unmapped address is warned about           an address in no segment answers 0 with no warning
pass  referenced .bss address is NOT warned
FAIL  `from` prints a target count               `from` printed a bare header and no count
pass  `imm` treats --help as a needle

8 of 11 arms FAILED against the pre-fix xref.py
0 of 11 arms FAILED against the fixed xref.py
```

The three that pass on both sides are accounted for rather than glossed: **`to 0x1080` answers** is
the positive control, and it must pass on both sides — it is what proves the fixture address really
is referenced, so the `--addr` silence is not merely an address with no references. The other two
(`.bss` not warned, `imm --help` is a needle) guard *new* behaviour and are structurally incapable
of failing on a tool that has neither; they exist so the warning cannot become unconditional noise
and the help handling cannot swallow an `imm` needle.

Note the `--addr` arm is written as "must not be a silent exit-0 run" rather than as an exact
message: any loud failure is acceptable, and silence never is.

## Exact commands and results

```
$ python3 prosper/tools/re/test_xref.py
xref decoder: PASS
xref imm: PASS
xref refusal: PASS
xref cli: PASS                                                    exit 0

$ ctest -N --no-tests=error                                       246 tests registered
$ ctest --no-tests=error -R 'xref|edis|nid_gate|prx_to_elf|il2cpp' --output-on-failure
    re_xref_decoder ......... Passed
    re_edis_mapping ......... Passed
    re_nid_gate_classifier .. Passed
    il2cpp_prx_to_elf_header  Passed
100% tests passed out of 4                                        exit 0

$ python3 prosper/tools/docs/check_numbered_table.py prosper/tools/re/README.md
prosper/tools/re/README.md: 2 table(s), 9 rows, unbroken                     exit 0
$ git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
                                                                             exit 0
$ git diff --check                                                           exit 0
```

**What I did not run, and why.** Not the full 246-test build. The diff is Python and Markdown only
(`git diff --name-only origin/master...HEAD | grep -vE '\.(py|md)$'` is empty), no C++ target
consumes any of these files, and the box is running ~8 concurrent builds. The 4 registered tests
that cover the changed tools were run and pass; CI covers the rest.

No snapshots were run: this change cannot reach the renderer.

## Risks

- **Output format changed additively** for `to`/`from`/`reloc`/`imm`: a module header line, a
  `query:` line, an explicit zero line, a truncation notice, and a `from` target count. Any consumer
  matching on the *existing* lines is unaffected (none of them changed); a consumer matching
  positionally on the first line of output would be. The only such consumer in the repo is
  `gstr.py`'s awk, which was already broken by #2025 and is fixed here.
- **Exit codes changed on failure paths**: the arity error and the short-`imm`-needle refusal were
  `1`, now `2`; `--help` was `1`, now `0`. Nothing in the repo scripts these. The uniform "2 means
  refused" is the point of the change.
- **`p_memsz` is now read** for the unmapped check. `max(p_filesz, p_memsz)` guards a malformed
  header where memsz < filesz. `CONFIDENCE: HIGH` — the warning is advisory, never a refusal, so
  the worst case of a wrong range is a missing or spurious hint next to a correct answer.
- The unmapped warning could still fire on a legitimate query into a region this tool models as
  unoccupied. It is printed only alongside an empty result, and it names the remedy (#1659).

## Deliberately unaffected

The decoder is untouched: no reference form was added, removed or reclassified, and every existing
assertion in `test_xref.py` is unchanged and still passing. Nothing in `src/` is touched, and this
goes nowhere near the shader recompiler or compute work.
