### PR TITLE
fix(apr): a command-buffer destructor must prune LEGACY bindings too, on both platform halves

### DIFF
--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -18,6 +18,22 @@ default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for
   #1895 to treat registration warnings as read failures is corrected and regression-tested by
   [#1901](https://github.com/mattias800/prosper/issues/1901).
 
+- **A generation/identity stamp on the APR completion binding would close the reused-address
+  aliasing window — false, and it cannot work at the seam that needs it.**
+  [#1674](https://github.com/mattias800/prosper/issues/1674) suggested one, by analogy with the
+  `eq_identity` equeue-lifetime guard. The analogy does not carry: `eq_identity` works because the
+  *producer* retains the value it must later re-present. Here the only key the submit path has is
+  the command buffer's guest **address** — `apr_cb_submit_state(cb, …)` receives nothing else — so
+  a generation stamped on the entry has nothing to be compared against and can never reject a
+  stale match. Making it work would require pruning at **construct** time instead, and
+  `ampr_cb_construct` is explicitly documented as also serving as a *refresh* of a live object
+  ("several SDK flows refresh a live object through a constructor-shaped call whose size slots are
+  all zero/pointers"), so pruning there would drop bindings that are still awaiting a completion —
+  reintroducing the #180/#2139 class of stall to fix a leak. The destructor is the only call that
+  states the object is gone, so pruning there (both flavors, both platform halves) is the whole
+  fix. Bounding the binding vector by capacity was rejected for the same reason: evicting the
+  oldest entry drops a live completion.
+
 ## Frame loop reached; 0 draws = early-load present loop (issue #213, 2026-07-09)
 
 DOLL now boots fully and runs a **stable frame loop**. Two blockers cleared this session:

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -34,6 +34,22 @@ default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for
   fix. Bounding the binding vector by capacity was rejected for the same reason: evicting the
   oldest entry drops a live completion.
 
+- **"The APR binding leak is bounded in practice — no live title is known to grow the list" — false,
+  measured 2026-08-17.** [#1674](https://github.com/mattias800/prosper/issues/1674) recorded this on
+  the reasoning that CRI reuses a fixed array of 20 command buffers and the UE4 flows reuse pooled
+  ones. A probe over 43 local dumps (`boot_trace`, 40 s each, 29 exercised APR) found the opposite:
+  **8 titles leak legacy bindings, 13,822 entries in 40 s each** — 5,885 on `PPSA02101`, 4,335 on
+  *Nikoderiko* `PPSA23760`, 1,076 on *Little Nightmares III* `PPSA05143` — and every entry is
+  rescanned under `state.mx` by every later submit. The leak was live on roughly a third of the
+  titles that touch APR, and it grew with session length. Fixed by
+  [#2560](https://github.com/mattias800/prosper/pull/2560).
+  The *aliasing* half of the same issue is the part that really was unhit: over the same sweep, the
+  divergent case (a legacy binding destructed, not re-bound, then submitted) occurred **0 times**,
+  while the looser "submit for an address that had any destructor called on it" occurred **13,486
+  times across 15 titles** — so the pattern is reachable and the guests simply keep their legacy-bound
+  and destruct-reused buffer pools disjoint. **Do not re-run this sweep to re-establish either half**;
+  re-run it only to test a *new* binding-lifetime change.
+
 ## Frame loop reached; 0 draws = early-load present loop (issue #213, 2026-07-09)
 
 DOLL now boots fully and runs a **stable frame loop**. Two blockers cleared this session:

--- a/prosper/src/hle/hle_kernel_mem.cpp
+++ b/prosper/src/hle/hle_kernel_mem.cpp
@@ -338,13 +338,30 @@ namespace {
             }
         return false;
     }
-    void apr_cb_destroy_320_binding(uint64_t cb) {
+    // Drop every binding for a command buffer the guest has destructed (#1674). Deliberately NOT
+    // filtered on `deduplicate_completion`: that flag says the binding came through the PS5 3.20
+    // eager NID (o67gODLFpls), and the legacy NID (H896Pt-yB4I) leaves it false. Filtering on it
+    // made the destructor a no-op for every legacy binding, which is two defects rather than one:
+    //   - the vector never shrank, and apr_cb_submit_state linear-scans it under `state.mx` on
+    //     EVERY submit, so a title that constructs a fresh cb per read pays an unbounded scan;
+    //   - the correctness half: entries are keyed by the command buffer's guest ADDRESS. A buffer
+    //     that is freed and whose address is later reused by an UNRELATED allocation matched the
+    //     dead entry, so submitting the new buffer echoed the dead binding's tag to the dead
+    //     binding's equeue instead of handing the caller a fresh token through the result slots.
+    //     The `eq_identity` guard does not cover this — it only suppresses the post if the OLD
+    //     equeue has since been destroyed, and engines keep one long-lived APR equeue.
+    // Erasing by predicate rather than by first match is defence-in-depth: apr_cb_set_equeue
+    // updates in place, so a duplicate should be unreachable, and a destructor is exactly the
+    // wrong place to leave one behind if it ever becomes reachable.
+    // CONFIDENCE: HIGH — a destructor call is the guest stating the object is gone, and the two
+    // NIDs that reach here (Qs1xtplKo0U / GuchCTefuZw) are destructors for both binding flavors.
+    void apr_cb_destroy_binding(uint64_t cb) {
+        if (!cb) return;
         AprBoundState& state = apr_bound_state();
         std::lock_guard<std::mutex> lk(state.mx);
-        auto it = std::find_if(state.cbs.begin(), state.cbs.end(), [&](const AprBoundCb& b) {
-            return b.cb == cb && b.deduplicate_completion;
-        });
-        if (it != state.cbs.end()) state.cbs.erase(it);
+        state.cbs.erase(std::remove_if(state.cbs.begin(), state.cbs.end(),
+                                       [&](const AprBoundCb& b) { return b.cb == cb; }),
+                        state.cbs.end());
     }
     // Per-request "eventful" marks for UNBOUND one-shot cbs (issue #180). The engine drives two
     // flavors of sceAmprAprCommandBufferReadFile through ONE wrapper (identical guest-RA chains):
@@ -366,6 +383,16 @@ namespace {
     // positive crashes the listener).
     std::mutex g_apr_eventful_mx;
     std::unordered_map<uint64_t, bool> g_apr_eventful;   // req/cb ptr -> eventful (updated per ReadFile)
+}
+// Test seam for #1674: how many bindings the registry currently holds for one command-buffer
+// address. 0 after a destructor, 1 while bound. Reading it is the direct observable for the
+// leak half; the aliasing half is observed through the submit path's result slots.
+size_t prosper_apr_binding_count_for_test(uint64_t cb) {
+    AprBoundState& state = apr_bound_state();
+    std::lock_guard<std::mutex> lk(state.mx);
+    size_t n = 0;
+    for (const auto& b : state.cbs) if (b.cb == cb) ++n;
+    return n;
 }
 void prosper_apr_mark_eventful(uint64_t req, bool eventful) {
     std::lock_guard<std::mutex> lk(g_apr_eventful_mx);
@@ -2063,7 +2090,7 @@ HLE(k_ampr_measure_write_equeue) { // sSAUCCU1dv4 = sceAmprMeasureCommandSizeWri
 }
 HLE(k_ampr_destruct_320) {
     ampr_arglog("AmprCommandBufferDestructor", a0, a1, a2, a3, a4, a5);
-    apr_cb_destroy_320_binding(a0);
+    apr_cb_destroy_binding(a0);
     ampr_cb_destroy_320(a0);
     return 0;
 }
@@ -5783,7 +5810,13 @@ HLE(k_ampr_apr_cb_construct_stub) {
 HLE(k_ampr_set_buffer_stub) {
     return ampr_arglog("N-FSPA4S3nI(SetBuffer, WINDOWS STUB)", a0, a1, a2, a3, a4, a5);
 }
-HLE(k_ampr_destruct) { ampr_cb_destroy_320(a0); return 0; }
+// #1674: this half destroyed the capacity/offset record but never the completion BINDING, so on
+// Windows no binding of either flavor was ever pruned — strictly worse than the POSIX bug, which
+// at least pruned the 3.20 ones. The binding registry has been shared by both halves since #2139
+// (`k_ampr_append_equeue_legacy`/`_320` call the same `apr_cb_set_equeue`), so the teardown must be
+// shared too: a registry one half fills and the other never empties is the divergence #2139 and
+// #1970 both existed to remove.
+HLE(k_ampr_destruct) { apr_cb_destroy_binding(a0); ampr_cb_destroy_320(a0); return 0; }
 HLE(k_ampr_getsize) {
     if (uint64_t capacity = ampr_cb_capacity(a0)) return capacity;
     // Byte-for-byte the POSIX arm's contract (#1970). The `a0 == g_apr_last_cb` test is NOT

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -28,6 +28,8 @@ namespace prosper {
     void        prosper_apr_reset_for_test();
     int         prosper_apr_match_by_size(uint64_t size, std::string* out_path);
     std::string prosper_apr_path_for_id(uint32_t id);
+    // #1674 test seam: live APR completion bindings recorded for one command-buffer address.
+    size_t      prosper_apr_binding_count_for_test(uint64_t cb);
 }
 using namespace prosper;
 
@@ -644,6 +646,100 @@ int main() {
             // guarded: POSIX suppresses the writes deliberately, Windows never had them.
             CHECK(out1 == kResidue && out2 == kResidue,
                   "#1629: the plain submit writes NO result slots — a2/a3 are residue, not outputs");
+        }
+    }
+
+    // #1674: a command-buffer destructor must drop the completion binding for EVERY flavor.
+    //
+    // The registry is keyed by the command buffer's guest ADDRESS. The destructor used to erase
+    // only entries with `deduplicate_completion` set — true only for the PS5 3.20 eager NID
+    // (o67gODLFpls) — so a binding made through the legacy NID (H896Pt-yB4I) survived the
+    // destructor forever. Two harms, and this block asserts both:
+    //   - the registry grows without bound, and every submit linear-scans it under a lock;
+    //   - a later, unrelated allocation that lands on the same address inherits the dead
+    //     binding's equeue/id/tag, so its submit echoes the dead tag to the dead queue instead of
+    //     handing the caller a fresh token through the result slots.
+    //
+    // The observable for the second harm is the submit path's own branch: a BOUND cb (nonzero
+    // equeue) suppresses the result slots and posts the tag; an UNBOUND cb writes a fresh token
+    // into both slots and posts nothing. So "the slots were written" IS "no binding was found",
+    // which is exactly the property under test — no equeue, no worker thread, no timing.
+    //
+    // The equeue used here is a plain nonzero sentinel, never a real SceKernelEqueue: that keeps
+    // the binding on the `tag_echo` branch (which is what suppresses the slots) while
+    // prosper_eq_post_apr_token's identity guard rejects the post, so the test cannot deliver an
+    // event to anything. The point being tested is which BRANCH submit takes, not what the queue
+    // receives.
+    {
+        HleFn bind_legacy  = Hle::lookup("H896Pt-yB4I");    // legacy: deduplicate_completion=false
+        HleFn bind_320     = Hle::lookup("o67gODLFpls");    // PS5 3.20: deduplicate_completion=true
+        HleFn destruct_apr = Hle::lookup("Qs1xtplKo0U");    // sceAmprAprCommandBufferDestructor
+        HleFn destruct_cb  = Hle::lookup("GuchCTefuZw");    // sceAmprCommandBufferDestructor
+        HleFn submit       = Hle::lookup("ASoW5WE-UPo");    // ...AndGetResult (writes result slots)
+        CHECK(bind_legacy && bind_320 && destruct_apr && destruct_cb && submit,
+              "#1674: both bind NIDs, both destructor NIDs and AndGetResult all resolve");
+
+        if (bind_legacy && bind_320 && destruct_apr && destruct_cb && submit) {
+            constexpr uint64_t kResidue = 0xdeadbeefcafef00dull;
+            // Nonzero so the binding is "bound" (submit's test is the EQUEUE, not the tag), and
+            // deliberately not a live queue so prosper_eq_identity() answers 0 and the post is
+            // dropped by its own lifetime guard.
+            constexpr uint64_t kFakeEq  = 0x5ec0ffee0000ull;
+            alignas(64) uint8_t cb_x_storage[256] = {};
+            alignas(64) uint8_t cb_y_storage[256] = {};
+            const uint64_t cb_x = (uint64_t)(uintptr_t)cb_x_storage;
+            const uint64_t cb_y = (uint64_t)(uintptr_t)cb_y_storage;
+            alignas(8) uint64_t s1 = kResidue, s2 = kResidue;
+            const uint64_t p1 = (uint64_t)(uintptr_t)&s1, p2 = (uint64_t)(uintptr_t)&s2;
+
+            // --- legacy binding: recorded, then honoured by submit (the discriminator's other pole)
+            bind_legacy(cb_x, kFakeEq, /*id=*/0x7501, /*tag=*/0x10000000000003e8ull, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_x) == 1,
+                  "#1674: a legacy H896Pt-yB4I bind records exactly one binding for the cb");
+            s1 = s2 = kResidue;
+            submit(cb_x, 1, p1, p2, 0, 0);
+            CHECK(s1 == kResidue && s2 == kResidue,
+                  "#1674 control: while the legacy binding is LIVE, submit suppresses both result "
+                  "slots (so a later write to them is a real state change, not a no-op)");
+
+            // --- the destructor must prune it. Before the fix this erased nothing.
+            destruct_apr(cb_x, 0, 0, 0, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_x) == 0,
+                  "#1674: sceAmprAprCommandBufferDestructor prunes a LEGACY binding");
+
+            // --- the aliasing half: the address is reused by an unrelated buffer that never
+            //     bound anything, and its submit must behave as unbound.
+            s1 = s2 = kResidue;
+            submit(cb_x, 1, p1, p2, 0, 0);
+            CHECK(s1 != kResidue && s2 != kResidue && s1 == s2,
+                  "#1674: a cb reusing the destructed address does NOT inherit the dead binding — "
+                  "submit hands it a fresh token instead of echoing the dead tag/equeue");
+
+            // --- the 3.20 flavor keeps being pruned (the behaviour the old predicate did have),
+            //     and the other destructor NID prunes too.
+            bind_320(cb_x, kFakeEq, /*id=*/0x7501, /*tag=*/0x10000000000003e9ull, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_x) == 1,
+                  "#1674: a PS5 3.20 o67gODLFpls bind records one binding for the cb");
+            destruct_cb(cb_x, 0, 0, 0, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_x) == 0,
+                  "#1674: sceAmprCommandBufferDestructor prunes a 3.20 binding (unchanged)");
+
+            // --- and it prunes ONLY the destructed buffer: a live binding on another address
+            //     must survive, or the fix would have traded a leak for a lost completion.
+            bind_legacy(cb_x, kFakeEq, 0x7501, 0x10000000000003eaull, 0, 0);
+            bind_legacy(cb_y, kFakeEq, 0x7501, 0x10000000000003ebull, 0, 0);
+            destruct_apr(cb_x, 0, 0, 0, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_x) == 0 &&
+                  prosper_apr_binding_count_for_test(cb_y) == 1,
+                  "#1674: destroying one cb leaves an unrelated cb's binding intact");
+            s1 = s2 = kResidue;
+            submit(cb_y, 1, p1, p2, 0, 0);
+            CHECK(s1 == kResidue && s2 == kResidue,
+                  "#1674: the surviving binding is still HONOURED — cb_y's submit stays on the "
+                  "bound path and writes no result slots");
+            destruct_apr(cb_y, 0, 0, 0, 0, 0);
+            CHECK(prosper_apr_binding_count_for_test(cb_y) == 0,
+                  "#1674: the registry is empty for both buffers once both are destructed");
         }
     }
 


### PR DESCRIPTION
Fixes #1674

## Failure scenario

`apr_cb_destroy_320_binding` erased a binding only when `b.cb == cb && b.deduplicate_completion`.
`deduplicate_completion` is set **only** for the PS5 3.20 eager bind NID (`o67gODLFpls`); the legacy
NID (`H896Pt-yB4I`) leaves it `false`. So for every legacy binding the destructor ran, matched
nothing, and left the entry in `AprBoundState::cbs` for the life of the process.

Two consequences, and this PR fixes both:

1. **Unbounded growth under a lock.** Nothing else ever erases from that vector, and
   `apr_cb_submit_state` linear-scans it while holding `state.mx` on **every** submit. A title that
   constructs a fresh command buffer per read pays a scan that only ever gets longer.

2. **Stale-binding aliasing — the correctness half.** Entries are keyed by the command buffer's
   guest **address**. A buffer that is freed and whose address is later reused by an unrelated
   allocation matched the dead entry, so `apr_submit_common` took the *bound* path for it: it
   suppressed the caller's result slots and echoed the **dead** binding's tag to the **dead**
   binding's equeue, instead of handing the new caller a fresh token.
   The existing `eq_identity` lifetime guard does not cover this — it only suppresses a post whose
   equeue has since been *destroyed*, and engines keep one long-lived APR equeue, so the wrong post
   goes through.

### A second defect found while fixing it: Windows never pruned *anything*

`k_ampr_destruct` (the Windows registration for both `Qs1xtplKo0U` and `GuchCTefuZw`) destroyed the
capacity/offset record but **never called the binding teardown at all** — so on Windows no binding
of either flavor was ever pruned. That is strictly worse than the POSIX bug, which at least pruned
the 3.20 ones. The binding registry has been shared by both halves since #2139
(`k_ampr_append_equeue_legacy` / `_320` both call the shared `apr_cb_set_equeue`), so a registry one
half fills and the other never empties is exactly the divergence #2139 and #1970 existed to remove.

## Behavioural contract

**A command-buffer destructor drops every completion binding recorded for that command buffer,
regardless of which bind NID created it, on every platform.** After the destructor returns, the
address is unbound: a later, unrelated buffer at the same address is treated as unbound by submit
(fresh token through the result slots, no equeue post), and a live binding on any *other* address
is untouched.

## Approach and invariants

- `apr_cb_destroy_320_binding` → **`apr_cb_destroy_binding`** (it is no longer 3.20-specific), with
  the `deduplicate_completion` term dropped.
- Erases by predicate (`remove_if`) rather than by first match. `apr_cb_set_equeue` updates in
  place, so a duplicate should be unreachable — but a destructor is the wrong place to leave one
  behind if it ever becomes reachable. Defence-in-depth, not a behaviour change.
- Windows `k_ampr_destruct` now calls the same helper before `ampr_cb_destroy_320`, matching POSIX.
- New test seam `prosper_apr_binding_count_for_test(cb)` — live bindings for one address.

Invariants preserved: the 3.20 pruning that *did* work is unchanged; `apr_cb_set_equeue`'s in-place
rebind is untouched; the `fallback_pending` tail worker and the `#180` bound/unbound submit
discrimination are untouched.

## Deliberately NOT done — and why (recorded in `docs/UE4_APR_IOSTORE_BRINGUP.md` § Ruled out)

The issue suggested "an explicit generation/identity on the entry so a reused address cannot inherit
a dead binding — the same shape as the existing `eq_identity` guard". **That cannot work at the seam
that needs it, so it is not implemented, and the reasoning is landed in the doc rather than left in
this PR body.**

`eq_identity` works because the *producer* retains the value it must later re-present. Here the only
key the submit path has is the command buffer's address — `apr_cb_submit_state(cb, …)` receives
nothing else — so a generation stamped on the entry has nothing to be compared against and can never
reject a stale match. Making it discriminate would require pruning at **construct** time instead,
and `ampr_cb_construct` is explicitly documented as *also* serving as a refresh of a live object
("several SDK flows refresh a live object through a constructor-shaped call whose size slots are all
zero/pointers") — so pruning there could drop a binding still awaiting a completion, reintroducing
the #180/#2139 class of stall in order to fix a leak. Bounding the vector by capacity was rejected
for the same reason: evicting the oldest entry drops a live completion.

The destructor is the only call that states the object is gone, so pruning there — both flavors,
both platform halves — is the whole fix.

Also not done: `k_ampr_destruct_320` keeps its name, because the other function it calls
(`ampr_cb_destroy_320`) really is 3.20-conditional (`tracks_offset`). Only the binding helper was
renamed.

## Affected / unaffected behaviour

**Affected:** any title that binds an APR command buffer through the legacy `H896Pt-yB4I` NID and
then destructs it (POSIX), and any title that binds through *either* NID and destructs it
(Windows) — the binding is now removed.

**The issue's "bounded in practice today … no live title is known to grow this list" note is wrong,
and the measurement below corrects it.** In a 40 s headless boot, **8 titles leak legacy bindings and
13,822 entries accumulate across the corpus** — 5,885 on `PPSA02101` and 4,335 on *Nikoderiko*
`PPSA23760` alone, in 40 seconds each. Every one of those entries is scanned under `state.mx` by
every subsequent submit (6,195 and 4,655 submits respectively over the same window), and the vector
only ever grows. So the leak half is not a latent tidiness issue — it is live on a third of the
titles that touch APR, and it scales with session length. The *aliasing* half remains unobserved
(0 divergent submits corpus-wide), which is the part that was correctly described as not yet hit.

**Deliberately unaffected:** 3.20 bindings on POSIX (already pruned); rebinding an address (still
updates in place); the submit path's bound/unbound token contract; the deferred tail worker; the
capacity/offset map (`g_ampr_cb_state`), which is separately bounded and refreshed by construct.

## Risks

- The change makes a destructor *drop* state it previously kept. If a title destructed a command
  buffer and then submitted it expecting its old completion binding to still apply, it would now
  get the unbound path — a #180/#2139-class stall. This was the main open risk; it is now
  **measured rather than argued**: across 43 local dumps the changed line executes 13,822 times and
  the divergent case occurs **0 times**, while the looser "submit after any destruct on the same
  address" pattern occurs 13,486 times, proving the class is reachable. Full numbers below. Also
  guarded by the "unrelated cb's binding survives" and "the surviving binding is still honoured"
  test arms.
- **No deferred completion can be lost by this change, and that is structural rather than
  observed.** The only deferred post is the `apr_tail_worker` fallback, and `fallback_pending` is
  set only when `eager_completion` is true — i.e. only for 3.20 bindings, which the *old* predicate
  already erased on destruct. Legacy bindings have `eager_completion == false`, so they have no
  pending deferred post for the destructor to cancel. The newly-pruned set is therefore exactly the
  set with nothing in flight.
- Concurrency shape is unchanged: the old erase took the same `state.mx`, and `apr_tail_worker`
  copies the entries it will post into a local vector *before* unlocking, so widening the erase
  introduces no iterator hazard.
- The Windows call site is **compile-verified but not run-verified locally** (no Windows host here).
  Evidence for the compile half is below and includes its own positive control.

## Build and test — exact commands and results

Linux (in the project distrobox, `-j4`):

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4                      # exit 0
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

```
100% tests passed out of 246
Total Test time (real) =  68.48 sec
ctest_rc=0
```

**246 tests discovered, 246 passed, exit code 0.**

Docs gates:

```
prosper/docs/GAME_COMPAT_ORCHESTRATION.md: 14 table(s), 243 rows, contiguous and unbroken   -> rc 0
git ls-files '*.md' | check_numbered_table.py                                               -> rc 0
git diff --check                                                                            -> rc 0
```

### Mutation arm — the new checks fail with the fix reverted

Restoring only the `&& b.deduplicate_completion` term in the destroy predicate, rebuilding
`test_apr_registry`, and running it (verbatim):

```
  [ok]   #1674: both bind NIDs, both destructor NIDs and AndGetResult all resolve
  [ok]   #1674: a legacy H896Pt-yB4I bind records exactly one binding for the cb
  [ok]   #1674 control: while the legacy binding is LIVE, submit suppresses both result slots (so a later write to them is a real state change, not a no-op)
  [FAIL] #1674: sceAmprAprCommandBufferDestructor prunes a LEGACY binding
  [FAIL] #1674: a cb reusing the destructed address does NOT inherit the dead binding — submit hands it a fresh token instead of echoing the dead tag/equeue
  [ok]   #1674: a PS5 3.20 o67gODLFpls bind records one binding for the cb
  [ok]   #1674: sceAmprCommandBufferDestructor prunes a 3.20 binding (unchanged)
  [FAIL] #1674: destroying one cb leaves an unrelated cb's binding intact
  [ok]   #1674: the surviving binding is still HONOURED — cb_y's submit stays on the bound path and writes no result slots
  [FAIL] #1674: the registry is empty for both buffers once both are destructed
== FAIL: 4 ==
```

Process exit **1**. With the fix in place all nine are `[ok]` and the file ends `== PASS ==`.

Note which checks *did not* move: the two "3.20" arms and the two "live binding is honoured" arms
pass in **both** arms by design. They are the controls — they show the discriminator can express
both outcomes, so a `[FAIL]` above is a real state change and not a check that could only ever have
failed. The aliasing arm's observable is submit's own bound/unbound branch (bound ⇒ result slots
suppressed and the tag posted; unbound ⇒ fresh token written to both slots), so "the slots were
written" *is* "no binding was found" — which is the property under test, with no equeue, no worker
thread and no timing involved. The equeue handle used is a nonzero non-queue sentinel, so
`prosper_eq_identity()` answers 0 and `prosper_eq_post_apr_token` drops the post by its own guard;
the test therefore cannot deliver an event anywhere.

### Windows arm — compile-verified, with a positive control for the instrument

The Linux build cannot see the Windows call site at all, so it was checked with the MinGW compiler
available in the project container:

```bash
x86_64-w64-mingw32-g++ -std=c++20 -fsyntax-only <the TU's own -I/-D flags> \
    prosper/src/hle/hle_kernel_mem.cpp        # exit 0
```

Because a syntax check that silently compiled the *POSIX* arm would produce exactly the same exit 0,
the instrument was validated by deliberately mistyping the new call **in the Windows arm only**:

```
prosper/src/hle/hle_kernel_mem.cpp:5819:24: error: 'apr_cb_destroy_binding_SENTINEL_TYPO' was not declared in this scope
 5819 | HLE(k_ampr_destruct) { apr_cb_destroy_binding_SENTINEL_TYPO(a0); ampr_cb_destroy_320(a0); return 0; }
```

…while the host `g++ -fsyntax-only` on the **same mistyped file** still exited **0**. So the MinGW
check demonstrably reaches the changed line and the Linux build demonstrably cannot — which is why
the check was run. The sentinel was reverted and the clean check re-run (exit 0) before committing.

Snapshots: not run. This is an HLE bookkeeping change with no renderer path; per the charter's
release-time-inventory policy, no snapshot is a meaningful gate here.

## Live-boot evidence: the change prunes 13,822 real legacy bindings and diverges 0 times

Review raised the sharpest objection: the *only* bindings whose behaviour changes here are the
**legacy** (`H896Pt-yB4I`) ones, since the old predicate already erased 3.20 ones — and #1672 records
that CRI uses exactly the legacy path, so the affected population is precisely the one that pools and
reuses command buffers. If such a title destructs and then reuses a buffer *without* re-binding, this
change turns a working completion into a silently unbound submit: a #180/#2139-class stall, in the
direction the charter forbids.

That is an empirical question, so it was measured. A **temporary, local-only** probe (not in this
diff — see below) counted the exact event this change makes behave differently: **a submit arriving
for a cb address whose LEGACY binding was erased by a destructor and not re-bound since.** Before the
fix that submit found the stale entry and took the bound path; after it, it takes the unbound path.
Everything else is unchanged by construction.

**Route:** `boot_trace <DUMP_ROOT>/<ID>-app0`, 40 s wall-clock, every dump in the local corpus except
`PPSA04263` (another lane owns it). 43 dumps: **29 exercised APR**, 14 never touched it. The three
titles review named were additionally run at 150 s with the same verdict.

### Corpus totals (29 titles that exercised APR)

| counter | total |
| --- | --- |
| legacy (`H896Pt-yB4I`) binds | 30,659 |
| 3.20 (`o67gODLFpls`) binds | 42,310 |
| destructor calls | 95,120 |
| **legacy bindings erased — the entries this change newly prunes** | **13,822** |
| 3.20 bindings erased (pruned before this change too) | 19,245 |
| submits | 52,124 |
| submits that found a binding | 34,707 |
| submits arriving for an address that had ANY destructor called on it | 13,486 |
| **DIVERGENT submits (legacy binding destructed, not re-bound, then submitted)** | **0** |

### The 8 titles in the exact risk configuration

These bind through the legacy path **and** call destructors that really erase those bindings — i.e.
the code this change alters runs, thousands of times, on each of them.

| Title | legacy binds | destructs | **legacy erased** | submits | submits after a destruct | **DIVERGENT** |
| --- | --- | --- | --- | --- | --- | --- |
| `PPSA02101` | 13,790 | 12,390 | 5,885 | 6,195 | 255 | **0** |
| *Nikoderiko* `PPSA23760` | 9,993 | 9,310 | 4,335 | 4,655 | 255 | **0** |
| *Little Nightmares III* `PPSA05143` | 1,665 | 2,824 | 1,076 | 1,412 | 268 | **0** |
| *ArcRunner* `PPSA21406` | 1,096 | 2,570 | 992 | 1,285 | 236 | **0** |
| *The Oregon Trail* `PPSA19244` | 1,525 | 6,186 | 965 | 3,093 | 2,057 | **0** |
| *Dragon Quest VII* `PPSA17942` | 1,298 | 1,196 | 245 | 1,441 | 287 | **0** |
| `PPSA15319` | 368 | 10,744 | 170 | 5,372 | 5,131 | **0** |
| `PPSA07809` | 607 | 1,032 | 154 | 789 | 298 | **0** |

The three titles review named land as follows, and are worth stating because they are *not* the
interesting ones: *Tales of Graces f* `PPSA19991` (CRI) binds the legacy path heavily and calls **no
destructor at all** during a run — CRI constructs its pool once and reuses it, exactly as #1674
predicted — so the widened erase never fires for it (150 s: 446 legacy binds, 446 submits, all bound,
0 destructs). *Sonic Origins* `PPSA05325` is the same shape, lightly exercised (6 binds, 46 submits,
0 destructs). *The Pathless* `PPSA01826` destructs heavily but is **100% 3.20** (21,197 3.20 binds,
21,110 destructs, 9,930 erased, **0 legacy**), so its entries were already pruned before this change.

**Had the evidence stopped at those three it would have supported a weaker and partly wrong
conclusion** — "the change is inert" — because none of them can show the widened erase firing. The
corpus sweep is what establishes the real result: the change is **active** on 8 titles and 13,822
bindings, and still diverges zero times.

### Why the zero is not an unarmed instrument

- **Arming:** 30,659 legacy binds, 95,120 destructs, 13,822 real legacy erases, 52,124 submits. The
  altered line executes 13,822 times.
- **The class is expressible, not merely the discriminator live.** The looser counter — submits
  arriving for an address that had *any* destructor called on it — is **13,486 across 15 titles**
  (5,131 on `PPSA15319` alone). So "destruct, then submit the same address" genuinely happens live,
  in volume, and the probe sees it. The divergent subclass is 0 because none of those addresses
  carried a *legacy* binding — the guests keep the two pools disjoint — not because the pattern
  cannot occur.
- **A hand-built positive instance, outside the live-boot source.** The new `test_apr_registry` block
  performs legacy-bind → destruct → submit, and on that same instrumented binary the probe reports
  `DIVERGENT_SUBMITS=1` (`binds_legacy=3 binds_320=1 destructs=4 submits=5`). A live 0 is therefore a
  measured absence, not a counter that could never increment.

### Limits, stated plainly

- `boot_trace` is a headless CPU-side boot, not a routed gameplay session. It exercises the APR path
  hard (the counts above) but later-game streaming regimes are unmeasured.
- Every process was **killed** at the time limit, so shutdown-time destructor sequences are never
  observed. That is not the risk case — no submit can follow one — but it is genuinely unmeasured.
- 43 local dumps is not a proof over all software. The claim supported is "no route measured locally
  reaches the divergent case, while the changed line executes 13,822 times", which is what makes this
  safe to land.

### The probe is not shipped

It existed only in the working tree for these runs and was reverted before the final build. This
PR's diff contains none of it; the tree was rebuilt and the full suite re-run after reverting.

## Review

Requesting independent review: this is reverse-engineered Sony API lifetime semantics and touches a
shared cross-platform registry, both of which the charter routes to review even for a small diff.
The specific things worth challenging are (a) whether a destructor may legitimately be followed by a
submit that still expects the old binding, and (b) whether the "Ruled out" argument against a
generation stamp is actually right.