### PR TITLE
test(infra): a dump-parameterized test that wants ANOTHER title now skips visibly instead of failing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,11 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   cmake --build . -j8
   ctest --no-tests=error              # report the discovered count and exit code
   ```
+  **Configuring `-DGAME_DUMP` at a title other than `PPSA24651` reports three cases as `(Skipped)`,
+  not as failures** (#1573): `module_loads_eboot`, `boot_reaches_first_syscall` and
+  `real_shader_render` assert against *The Messenger's* own bytes. CMake derives the dump's title id
+  and names both ids in the skip. So a bring-up agent's first `ctest` on a new title is green with a
+  smaller executed set — read the skip count, not just the exit code. `docs/VERIFICATION.md` § CI.
 - **Write run artifacts and build temporaries to the real disk, never `/tmp`.** On the Linux box `/tmp`
   is a **RAM-backed tmpfs sized at 50% of RAM, with a per-user quota shared by every concurrent agent**.
   A single `.prgcap` is 200 MB–2.7 GB, a 4K `.bmp` is 24 MB, and a `PROSPER_GFXLOG`/`PROSPER_DBG` run log

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -219,6 +219,72 @@ else()
   message(STATUS "Game dump not found at ${GAME_DUMP} — skipping dump-backed tests")
 endif()
 
+# Which title `GAME_DUMP` actually points at (#1573). A handful of ctest cases assert against ONE
+# title's bytes — import counts, an IL2CPP module layout, that title's embedded shader blobs — so
+# pointing GAME_DUMP at a different game turns them red for a reason nothing in the ctest output
+# names. A bring-up agent's first action on a new title is exactly that configure, so the red run is
+# the first thing they see, and every plausible reading of it (master is broken / this dump is
+# corrupt / bisect) is wrong.
+#
+# `sce_sys/param.json`'s `titleId` is authoritative; the `PPSAxxxxx-app0` directory name is a second,
+# independent source for a dump laid out without `sce_sys/`. If NEITHER yields an id the title-gated
+# cases are registered and RUN as before — a detection failure must stay fail-visible rather than
+# converting three real guards into silent skips, which is the defect this whole area is about.
+# CONFIDENCE: HIGH (both sources read directly from every dump on the dev box).
+set(GAME_DUMP_TITLE_ID "")
+if(HAVE_GAME_DUMP)
+  if(EXISTS "${GAME_DUMP}/sce_sys/param.json")
+    file(READ "${GAME_DUMP}/sce_sys/param.json" prosper_param_json)
+    string(JSON prosper_param_title_id ERROR_VARIABLE prosper_param_error
+           GET "${prosper_param_json}" "titleId")
+    if(NOT prosper_param_error)
+      set(GAME_DUMP_TITLE_ID "${prosper_param_title_id}")
+    endif()
+    unset(prosper_param_json)
+  endif()
+  if(GAME_DUMP_TITLE_ID STREQUAL "")
+    get_filename_component(prosper_dump_dir_name "${GAME_DUMP}" NAME)
+    if(prosper_dump_dir_name MATCHES "^([A-Z]+[0-9]+)")
+      set(GAME_DUMP_TITLE_ID "${CMAKE_MATCH_1}")
+    endif()
+  endif()
+  if(GAME_DUMP_TITLE_ID STREQUAL "")
+    message(STATUS "Game dump title id could not be determined from ${GAME_DUMP} — "
+                   "title-specific tests will run against it")
+  else()
+    message(STATUS "Game dump title id: ${GAME_DUMP_TITLE_ID}")
+  endif()
+endif()
+
+# Register `name` as a ctest case that is SKIPPED with `reason`, rather than not registered at all.
+# `cmake -E echo` prints the reason and exits 0; SKIP_REGULAR_EXPRESSION is what turns that into a
+# `(Skipped)` result. The point is that the case still occupies a line in the ctest summary: a test
+# that silently disappears from the registered set costs coverage with no line to read and no count
+# to compare against (the failure mode `docs/VERIFICATION.md` § CI records for the Vulkan flag).
+function(prosper_add_skipped_test name reason)
+  add_test(NAME ${name} COMMAND ${CMAKE_COMMAND} -E echo "SKIPPED: ${reason}")
+  set_tests_properties(${name} PROPERTIES SKIP_REGULAR_EXPRESSION "SKIPPED: ")
+endfunction()
+
+# Register a ctest case that asserts against ONE title's content. Runs normally when GAME_DUMP is
+# that title (or when no title id could be derived); otherwise registers a visible skip naming both
+# the required title and the configured one, so the reason is in the run instead of in a doc.
+function(prosper_add_title_gated_test name title)
+  if(GAME_DUMP_TITLE_ID STREQUAL "${title}" OR GAME_DUMP_TITLE_ID STREQUAL "")
+    add_test(NAME ${name} COMMAND ${ARGN})
+  else()
+    prosper_add_skipped_test(${name}
+      "${name} asserts against ${title}'s own content; GAME_DUMP is configured with \
+${GAME_DUMP_TITLE_ID}. Re-run cmake with -DGAME_DUMP=<dump root>/${title}-app0 to exercise it.")
+    # Also say it here. ctest prints `(Skipped)` but not the reason unless it is run with `-V`, and
+    # configure is the moment the reader chose the dump — so this is where the explanation lands in
+    # front of them without their having to know to ask for it.
+    message(STATUS
+      "ctest case '${name}' will be SKIPPED: it asserts against ${title}'s own content, "
+      "GAME_DUMP is ${GAME_DUMP_TITLE_ID}")
+  endif()
+endfunction()
+
 if(TARGET prosper_core)
   # nid_census: every guest import that falls to the dispatcher's return-0 default (#2081).
   # Links prosper_core because both of its inputs must be the real ones — `Module::load` for the
@@ -231,8 +297,9 @@ if(TARGET prosper_core)
   add_executable(test_module tests/test_module.cpp)
   target_link_libraries(test_module PRIVATE prosper_core)
   if(HAVE_GAME_DUMP)
-    add_test(NAME module_loads_eboot
-             COMMAND test_module "${GAME_DUMP}/eboot.bin")
+    # Messenger-specific: the assertions pin PPSA24651's import/segment/relocation counts (#1573).
+    prosper_add_title_gated_test(module_loads_eboot PPSA24651
+             test_module "${GAME_DUMP}/eboot.bin")
   endif()
 
   add_executable(test_nid tests/test_nid.cpp)
@@ -1387,8 +1454,9 @@ if(TARGET prosper_core)
     add_executable(test_boot_linux tests/test_boot_linux.cpp)
     target_link_libraries(test_boot_linux PRIVATE prosper_core)
     if(HAVE_GAME_DUMP)
-      add_test(NAME boot_reaches_first_syscall
-               COMMAND test_boot_linux "${GAME_DUMP}")
+      # Messenger-specific: links THIS title's own Il2cppUserAssemblies.prx / PS5Util.prx (#1573).
+      prosper_add_title_gated_test(boot_reaches_first_syscall PPSA24651
+               test_boot_linux "${GAME_DUMP}")
     endif()
 
     if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
@@ -1702,7 +1770,10 @@ if(TARGET prosper_core)
       if(HAVE_GAME_DUMP)
         add_executable(test_real_shader_render tests/test_real_shader_render.cpp)
         target_link_libraries(test_real_shader_render PRIVATE prosper_core Vulkan::Vulkan)
-        add_test(NAME real_shader_render COMMAND test_real_shader_render "${GAME_DUMP}/eboot.bin")
+        # Messenger-specific: it recompiles and renders the RDNA2 blobs embedded in THIS title's
+        # eboot, so a dump whose eboot carries none (or none that fully translate) fails (#1573).
+        prosper_add_title_gated_test(real_shader_render PPSA24651
+                 test_real_shader_render "${GAME_DUMP}/eboot.bin")
       endif()
       message(STATUS "Vulkan found (${Vulkan_LIBRARY}) — offscreen graphics harness enabled")
     else()

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -141,21 +141,32 @@ rasteriser; they are listed in `ci.yml` with a reproduction command and tracked 
 tests cannot run in CI at all — dumps are copyrighted and gitignored — and now report `(Skipped)` rather
 than passing.
 
-**Two dump-backed tests are pinned to *The Messenger* specifically, not to "some dump".** If you
-configure with `-DGAME_DUMP=` pointing at any other title, `module_loads_eboot` and
-`boot_reaches_first_syscall` fail locally while everything else passes, and the failure looks like a
-regression in the loader:
+**Three dump-backed tests are pinned to *The Messenger* specifically, not to "some dump" — and they
+now report `(Skipped)` instead of failing (#1573).** `module_loads_eboot` pins `PPSA24651-app0`'s
+import, segment and relocation counts (`tests/test_module.cpp`); `boot_reaches_first_syscall` links
+that title's own `Media/Modules/Il2cppUserAssemblies.prx` and `PS5Util.prx`; `real_shader_render`
+recompiles and renders the RDNA2 blobs embedded in its eboot. Configure with `-DGAME_DUMP=` pointing
+at another title and all three used to go red for a reason nothing in the ctest output named —
+measured on `PPSA01826-app0` (The Pathless), **243/246 with these three failed**:
 
 ```text
-module_loads_eboot        imports=610 expected 612 / distinct import libs=34 expected 35
+module_loads_eboot          imports=1665 expected 612 / distinct import libs=50 expected 35
 boot_reaches_first_syscall  link: load .../Media/Modules/Il2cppUserAssemblies.prx: cannot open file
+real_shader_render          [FAIL] found the game's embedded RDNA2 shader blobs
 ```
 
-`612` imports and `35` import libraries are `PPSA24651-app0`'s numbers (`tests/test_module.cpp`), and
-that dump is the `GAME_DUMP` default in `CMakeLists.txt`. The second test wants The Messenger's IL2CPP
-module layout. So a build configured against, say, Blue Prince for renderer work reports **171/173
-with those two red**, and that result is expected rather than a regression — confirm it by running the
-same two tests on unmodified master with the same `-DGAME_DUMP`, which is the cheap discriminator.
+Every plausible reading of that — master is broken, this dump is corrupt, bisect — is wrong, and it is
+exactly the run a bring-up agent makes first on a new title.
+
+CMake now derives the configured dump's title id (`sce_sys/param.json`'s `titleId`, falling back to the
+`PPSAxxxxx-app0` directory name) and registers those three as **visible ctest skips** naming both the
+required and the configured id when it is not `PPSA24651`. The same run is now **243 passed, 3 skipped
+out of 246, exit 0**; the reason is printed at configure time and is in the test's own output under
+`ctest -V`. Point `-DGAME_DUMP=` back at `PPSA24651-app0`, re-run cmake, and they execute again.
+
+If **neither** source yields a title id the three are registered and run exactly as before. A detection
+failure has to stay fail-visible: silently converting three real guards into permanent skips would be
+the same defect this section is about, pointed the other way.
 
 ## Rule of thumb
 


### PR DESCRIPTION
Fixes #1573.

## Failure scenario

`module_loads_eboot`, `boot_reaches_first_syscall` and `real_shader_render` assert against **The
Messenger's own bytes** — `PPSA24651`'s import/segment/relocation counts, its IL2CPP module layout,
and the RDNA2 blobs embedded in its eboot. Configure with `-DGAME_DUMP=` pointing at any other title
and all three go red, with nothing in the ctest output naming the cause.

That is exactly the run a bring-up agent makes first on a new title: configure against that title's
dump, run ctest to confirm the tree is healthy before trusting any boot evidence. Every plausible
reading of the result — master is broken, this dump is corrupt, go bisect — is wrong. It also erodes
the project's "ctest exit code is truth" rule: if a green run silently requires one specific
undocumented dump, the exit code is not self-describing.

Measured on `origin/master` `20153833`, `-DGAME_DUMP=<DUMP_ROOT>/PPSA01826-app0` (*The Pathless*):

```text
99% tests passed, 3 tests failed out of 246          # ctest --no-tests=error -> exit 8

module_loads_eboot          imports=1665 expected 612 / distinct import libs=50 expected 35
                            plt reloc count=1636 out of expected range
boot_reaches_first_syscall  link: load .../Media/Modules/Il2cppUserAssemblies.prx: cannot open file
real_shader_render          [FAIL] found the game's embedded RDNA2 shader blobs
```

## Behavioural contract

A ctest case that asserts against one title's content must, when `GAME_DUMP` points somewhere else:

1. **still be registered** — the count must not silently shrink (an unregistered test is invisible by
   construction: no line to read, no count to compare against);
2. report **`(Skipped)`**, not `Failed` and not `Passed`;
3. name **both** the required title id and the configured one, at a moment the reader is looking;
4. and when the title genuinely matches, **execute exactly as before**.

A fifth rule falls out of the project's own instrument discipline: if the title id cannot be
determined at all, the case must **run**, not skip. A detection bug that silently converts three real
guards into permanent green skips is the same defect pointed the other way.

## Approach

`prosper/CMakeLists.txt` derives `GAME_DUMP_TITLE_ID` at configure time — the natural moment, since
`GAME_DUMP` is a cache variable and can only change there:

* `sce_sys/param.json`'s `titleId` is authoritative (`string(JSON ...)`, CMake ≥ 3.19; the project
  requires 3.20);
* the `PPSAxxxxx-app0` **directory name** is an independent fallback for a dump laid out without
  `sce_sys/`;
* if neither yields an id, the title-gated cases are registered and **run**, and configure says so.

Two small functions:

* `prosper_add_skipped_test(name reason)` — registers `cmake -E echo "SKIPPED: <reason>"` with
  `SKIP_REGULAR_EXPRESSION`, so ctest reports `(Skipped)` and the case keeps its line in the summary.
  No new binary, no exit-code plumbing, works on every platform CMake runs on.
* `prosper_add_title_gated_test(name title <command...>)` — `add_test` when the title matches (or is
  undeterminable), the skip otherwise, **plus** a `message(STATUS ...)` at configure time. That last
  part matters: ctest prints `(Skipped)` but *not* the reason unless run with `-V`, and configure is
  the moment the reader chose the dump.

The three registrations change; **no test source is touched**, including the GPU one.

## Affected / deliberately unaffected

* **Affected:** the registration of `module_loads_eboot`, `boot_reaches_first_syscall` and
  `real_shader_render` only.
* **Unaffected:** every test binary (zero source changes); the other three dump-gated cases
  (`nid_hash_matches_imports`, `trap_identifies_imports`, `plugin_autolink` — they are not
  title-pinned and pass on other dumps); the `HAVE_GAME_DUMP` gate itself; CI, which sets no
  `GAME_DUMP` and so does not reach any of this. **#1675 is a different gap** (dump *absent* rather
  than dump *wrong*) and is not addressed here.

## Risks

* A dump with neither `param.json` nor a `PPSAxxxxx` directory name reverts to today's behaviour
  (red on a non-Messenger dump). Deliberate — see the fifth rule above. `CONFIDENCE: HIGH` that this
  is unreachable in practice: both sources are present on all ~30 local dumps, and they are
  independent.
* If the detection itself broke, the tests would run rather than skip — the failure direction is the
  loud one.
* `test_real_shader_render` is still *built* on a title mismatch (it sits inside the existing
  `if(HAVE_GAME_DUMP)` block). Build time only.

## Verification

Linux, in the `ps5ys` distrobox (a host build silently omits gpu_replay and every Vulkan execution
test, so a host ctest would not be evidence). Counts are quoted next to every exit code.

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/<TITLE>-app0
cmake --build prosper/build-linux -j4
ctest --test-dir prosper/build-linux --no-tests=error -j4 --output-on-failure
```

| arm | `GAME_DUMP` | before | after |
| --- | --- | --- | --- |
| baseline | `PPSA24651-app0` (The Messenger) | **246/246 passed, exit 0** | **246/246 passed, exit 0** |
| the bug | `PPSA01826-app0` (The Pathless) | **243 passed / 3 FAILED / 246, exit 8** | **243 passed / 3 skipped / 246, exit 0** |

After, on the Pathless arm, configure prints:

```text
-- Game dump title id: PPSA01826
-- ctest case 'module_loads_eboot' will be SKIPPED: it asserts against PPSA24651's own content, GAME_DUMP is PPSA01826
-- ctest case 'boot_reaches_first_syscall' will be SKIPPED: it asserts against PPSA24651's own content, GAME_DUMP is PPSA01826
-- ctest case 'real_shader_render' will be SKIPPED: it asserts against PPSA24651's own content, GAME_DUMP is PPSA01826
```

and ctest ends:

```text
The following tests did not run:
	 18 - module_loads_eboot (Skipped)
	118 - plugin_autolink (Skipped)          # pre-existing: this dump ships no Media/Plugins/PSN.prx
	195 - boot_reaches_first_syscall (Skipped)
	241 - real_shader_render (Skipped)
```

`ctest -V` carries the full reason into the test's own output.

### Mutation arms

The pass above is not enough on its own: a skip that fires unconditionally would produce the same
green. Four arms, each a **hand-built** dump layout, run against this branch's real build:

| arm | constructed input | expected | observed |
| --- | --- | --- | --- |
| **positive control** | `PPSA24651-app0` | the three **execute** | `246/246 passed`, all three `Passed`, no `SKIPPED` line at configure |
| **C — content, not name** | The Messenger dump reached through a directory named `some-other-name` | `param.json` decides → **execute** | `title id: PPSA24651`; `3/3 Passed` |
| **F — name lies, content wins** | directory *named* `PPSA24651-app0` carrying `PPSA01826`'s `param.json` | `param.json` overrides the name → **skip** | `title id: PPSA01826`; all three `***Skipped` |
| **E — undeterminable** | directory `mystery-dump`, no `sce_sys/`, Messenger `eboot.bin` + `Media` | no id → **run anyway** | `title id could not be determined ... will run against it`; `3/3 Passed` |

Arms C and F are the ones that matter: C fails if detection is really reading the directory name, F
fails if it is really trusting the name over the content. Both were also reproduced in a standalone
5-line CMake project before being run here, so the mechanism was checked outside the thing it gates.

`diff --check` clean. No `Claude-Session:` trailer (`git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` → 0).

## Docs

* `prosper/docs/VERIFICATION.md` § CI — the existing paragraph said **two** tests and predates
  `real_shader_render`; rewritten for three, with the real measured before/after numbers.
* root `CLAUDE.md` build block — one paragraph, because a bring-up agent's first `ctest` on a new
  title is now green with a *smaller executed set*: read the skip count, not just the exit code.
