### PR TITLE
diag(capture): an armed automatic capture gate that never fires now says so at exit — a prefix marker cost a full routed run and reported nothing

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1184,6 +1184,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_guest_log_capture PRIVATE prosper_core)
   add_test(NAME guest_log_capture COMMAND test_guest_log_capture)
 
+  # The same gate's SILENT failure: an armed marker that never matches must diagnose itself instead
+  # of leaving a missing file as the only evidence (#1684). Separate binary because the gate is a
+  # process-wide one-shot and guest_log_capture's marker deliberately fires.
+  add_executable(test_guest_log_capture_miss tests/test_guest_log_capture_miss.cpp)
+  target_link_libraries(test_guest_log_capture_miss PRIVATE prosper_core)
+  add_test(NAME guest_log_capture_miss COMMAND test_guest_log_capture_miss)
+
   # Remote/headless F9 equivalent: an external regular-file witness arms the existing seeded
   # whole-frame capture on the next present. Pure/cross-platform; no game dump or Vulkan device.
   add_executable(test_capture_trigger_file tests/test_capture_trigger_file.cpp)

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -1941,6 +1941,57 @@ constexpr const char* kAutomaticCaptureBundleGates[] = {
     "PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE",
 };
 
+// Every automatic whole-frame capture gate is armed by an environment variable and fires at most
+// once. Until #1684 a gate that never fired said NOTHING: the run completed, exited 0, and simply
+// wrote no bundle — an outcome indistinguishable from a run that was never configured, and the only
+// way to tell them apart was to notice the absence of a file. These flags live at namespace scope
+// rather than inside the gate states because the exit report must stay readable after every static
+// destructor has run, and because two of the three states are built lazily on the first present and
+// so do not exist at all in a run that never presents.
+enum AutomaticCaptureGateIndex : size_t {
+    kGateAtPresent = 0,
+    kGateGuestLog = 1,
+    kGateTriggerFile = 2,
+    kGateCount = 3,
+};
+static_assert(sizeof(kAutomaticCaptureBundleGates) / sizeof(kAutomaticCaptureBundleGates[0]) ==
+                  kGateCount,
+              "gate indices must line up with kAutomaticCaptureBundleGates");
+std::atomic<bool> g_automatic_capture_gate_fired[kGateCount] = {};
+
+// Latched per flip so a gate that never fired can state what the run actually reached, instead of
+// only repeating what was asked for. Two relaxed atomics against a whole present.
+std::atomic<uint64_t> g_presents_observed{0};
+std::atomic<uint64_t> g_last_present_count{0};
+
+// Longest shared prefix, in bytes. Used to pick the observed line closest to an unmatched marker.
+size_t common_prefix_bytes(const std::string& a, const std::string& b) {
+    const size_t n = std::min(a.size(), b.size());
+    size_t i = 0;
+    while (i < n && a[i] == b[i]) ++i;
+    return i;
+}
+
+// Renders a guest log line unambiguously. An exact-match failure is very often caused by a byte the
+// operator cannot see — a trailing tab, a stray CR, a BOM — so printing the line raw would reproduce
+// the very invisibility this report exists to remove.
+std::string escape_log_line(const std::string& text) {
+    std::string out;
+    out.reserve(text.size() + 8);
+    for (const unsigned char ch : text) {
+        if (ch == '\\') {
+            out += "\\\\";
+        } else if (ch >= 0x20 && ch < 0x7f) {
+            out.push_back(static_cast<char>(ch));
+        } else {
+            char buf[5];
+            std::snprintf(buf, sizeof(buf), "\\x%02x", ch);
+            out += buf;
+        }
+    }
+    return out;
+}
+
 bool automatic_capture_bundle_gate_conflicts(const char* selected_gate) {
     uint32_t configured = 0;
     for (const char* gate : kAutomaticCaptureBundleGates) {
@@ -1972,6 +2023,15 @@ struct GuestLogCaptureBundleState {
     uint32_t line_sources = 0;
     bool discard_line = false;
     bool suppress_lf_after_cr = false;
+    // Miss bookkeeping (#1684). Only ever read when the marker never matched, and only written on a
+    // completed line while the gate is armed, so it costs one prefix compare per guest log line and
+    // nothing at all in a run with no marker configured.
+    uint64_t lines_observed = 0;
+    uint64_t lines_discarded = 0;
+    std::string closest_line;
+    size_t closest_prefix_bytes = 0;
+    bool has_closest = false;
+    bool marker_too_long = false;
 
     GuestLogCaptureBundleState() {
         const char* marker_env = std::getenv("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
@@ -1989,6 +2049,7 @@ struct GuestLogCaptureBundleState {
         marker = marker_env;
         path = path_env;
         if (marker.size() > kGuestLogCaptureMaxLineBytes) {
+            marker_too_long = true;
             std::fprintf(stderr,
                          "[grab] PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG exceeds the %zu-byte "
                          "line limit\n",
@@ -2008,8 +2069,12 @@ struct GuestLogCaptureBundleState {
 };
 
 GuestLogCaptureBundleState& guest_log_capture_bundle_state() {
-    static GuestLogCaptureBundleState state;
-    return state;
+    // Deliberately never destroyed. The exit report is registered with std::atexit at load time,
+    // and atexit handlers share one LIFO list with static destructors — so a handler registered
+    // FIRST runs LAST, after this object's destructor would have ended its lifetime. Leaking a
+    // singleton reachable from a static pointer keeps the report legal instead of merely lucky.
+    static GuestLogCaptureBundleState* state = new GuestLogCaptureBundleState();
+    return *state;
 }
 } // namespace
 
@@ -2029,10 +2094,24 @@ void observe_guest_log_for_capture(const char* bytes, size_t size,
         std::lock_guard<std::mutex> lock(state.mx);
         if (state.fired.load(std::memory_order_relaxed)) return;
         auto complete_line = [&] {
-            if (!state.discard_line && state.line == state.marker) {
+            ++state.lines_observed;
+            if (state.discard_line) {
+                ++state.lines_discarded;
+            } else if (state.line == state.marker) {
                 state.fired.store(true, std::memory_order_release);
                 matched = true;
                 matched_sources = state.line_sources;
+            } else {
+                // Remember the near-miss (#1684). The longest shared prefix is what separates "the
+                // marker is wrong" — a line the report can print verbatim for the operator to copy —
+                // from "the guest log never reached this code path", where nothing shares anything.
+                // Ties keep the FIRST such line, so the answer is deterministic and does not churn.
+                const size_t shared = common_prefix_bytes(state.line, state.marker);
+                if (!state.has_closest || shared > state.closest_prefix_bytes) {
+                    state.closest_line = state.line;
+                    state.closest_prefix_bytes = shared;
+                    state.has_closest = true;
+                }
             }
             state.line.clear();
             state.line_sources = 0;
@@ -2061,6 +2140,7 @@ void observe_guest_log_for_capture(const char* bytes, size_t size,
         }
     }
     if (!matched) return;
+    g_automatic_capture_gate_fired[kGateGuestLog].store(true, std::memory_order_release);
 
     // The marker is a phase gate, not a frame oracle. Skip exactly one completed present so the
     // transition boundary cannot be mistaken for the scene it announced, then use the established
@@ -2099,7 +2179,151 @@ void observe_guest_log_capture_gap() {
     state.suppress_lf_after_cr = false;
 }
 
+std::string format_guest_log_capture_miss(const GuestLogCaptureMiss& miss) {
+    std::string out =
+        "[grab] PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG never matched; NO BUNDLE WAS WRITTEN.\n"
+        "[grab]   The gate requires the COMPLETE guest-stdout line to EQUAL the marker; it is not "
+        "a substring match.\n";
+    out += "[grab]   marker: \"" + escape_log_line(miss.marker) + "\" (" +
+           std::to_string(miss.marker.size()) + " bytes)\n";
+    if (miss.marker_too_long) {
+        out += "[grab]   the marker exceeds the " + std::to_string(kGuestLogCaptureMaxLineBytes) +
+               "-byte line limit, so the gate was never enabled and could never have matched.\n";
+        return out;
+    }
+    out += "[grab]   observed " + std::to_string(miss.lines_observed) +
+           " completed guest-stdout line(s), of which " + std::to_string(miss.lines_discarded) +
+           " were discarded (over the " + std::to_string(kGuestLogCaptureMaxLineBytes) +
+           "-byte limit, or truncated by a stdout gap).\n";
+    if (miss.lines_observed == 0) {
+        out += "[grab]   no completed line reached the observer at all, so the marker was never "
+               "compared against anything: the route did not reach guest stdout output. That is a "
+               "different fault from a wrong marker.\n";
+        return out;
+    }
+    if (miss.lines_observed == miss.lines_discarded) {
+        out += "[grab]   every observed line was discarded, so no comparison was ever made.\n";
+        return out;
+    }
+    out += "[grab]   closest observed line: \"" + escape_log_line(miss.closest_line) + "\" (" +
+           std::to_string(miss.closest_line.size()) + " bytes, sharing the first " +
+           std::to_string(miss.closest_prefix_bytes) + " byte(s) with the marker)\n";
+    if (miss.closest_prefix_bytes == miss.marker.size() &&
+        miss.closest_line.size() > miss.marker.size()) {
+        out += "[grab]   that line BEGINS with the marker and continues past it: the marker is a "
+               "PREFIX of the real line. Re-run with the closest line above as the marker, "
+               "verbatim.\n";
+    } else if (miss.closest_prefix_bytes == 0) {
+        out += "[grab]   nothing observed shares even one leading byte with the marker.\n";
+    }
+    return out;
+}
+
+bool guest_log_capture_miss_snapshot(GuestLogCaptureMiss& out) {
+    GuestLogCaptureBundleState& state = guest_log_capture_bundle_state();
+    // An empty marker means the gate was rejected before the marker was ever parsed (no
+    // PROSPER_CAPTURE_BUNDLE, or a gate conflict). Both already printed their own reason, and
+    // report_unfired_automatic_capture_gates() handles them ahead of this call.
+    if (state.marker.empty()) return false;
+    if (state.fired.load(std::memory_order_acquire)) return false;
+    std::lock_guard<std::mutex> lock(state.mx);
+    out.marker = state.marker;
+    out.lines_observed = state.lines_observed;
+    out.lines_discarded = state.lines_discarded;
+    out.closest_line = state.closest_line;
+    out.closest_prefix_bytes = state.closest_prefix_bytes;
+    out.marker_too_long = state.marker_too_long;
+    return true;
+}
+
+void report_unfired_automatic_capture_gates() {
+    size_t configured = 0, only = 0;
+    const char* only_value = nullptr;
+    for (size_t i = 0; i < kGateCount; ++i) {
+        const char* value = std::getenv(kAutomaticCaptureBundleGates[i]);
+        if (value && *value) {
+            ++configured;
+            only = i;
+            only_value = value;
+        }
+    }
+    if (!configured) return;   // nothing was asked for; silence is the correct answer
+
+    // Reported here as well as at arm time, because a configuration rejected at startup is easy to
+    // miss in a route's log and its only other symptom is the same missing file.
+    const char* bundle = std::getenv("PROSPER_CAPTURE_BUNDLE");
+    if (!bundle || !*bundle) {
+        std::fprintf(stderr,
+                     "[grab] an automatic whole-frame capture gate was configured without "
+                     "PROSPER_CAPTURE_BUNDLE; nothing was ever armed and no bundle was written\n");
+        return;
+    }
+    if (configured > 1) {
+        std::fprintf(stderr,
+                     "[grab] automatic whole-frame capture gates are mutually exclusive; more than "
+                     "one was configured, so none was armed and no bundle was written\n");
+        return;
+    }
+    if (g_automatic_capture_gate_fired[only].load(std::memory_order_acquire)) return;
+
+    const unsigned long long presents = g_presents_observed.load(std::memory_order_relaxed);
+    const unsigned long long last_present = g_last_present_count.load(std::memory_order_relaxed);
+    switch (only) {
+        case kGateGuestLog: {
+            GuestLogCaptureMiss miss;
+            if (guest_log_capture_miss_snapshot(miss))
+                std::fputs(format_guest_log_capture_miss(miss).c_str(), stderr);
+            break;
+        }
+        case kGateAtPresent: {
+            char* end = nullptr;
+            errno = 0;
+            const unsigned long long wanted = std::strtoull(only_value, &end, 0);
+            const bool parsed = !errno && end != only_value && end && !*end;
+            if (!parsed) {
+                std::fprintf(stderr,
+                             "[grab] PROSPER_CAPTURE_BUNDLE_AT_PRESENT=\"%s\" is not a number, so "
+                             "the gate was never armed and no bundle was written\n",
+                             only_value);
+                break;
+            }
+            if (!presents)
+                std::fprintf(stderr,
+                             "[grab] PROSPER_CAPTURE_BUNDLE_AT_PRESENT=%llu never fired; NO BUNDLE "
+                             "WAS WRITTEN. The run never presented at all, so no present ordinal "
+                             "could be reached\n",
+                             wanted);
+            else
+                std::fprintf(stderr,
+                             "[grab] PROSPER_CAPTURE_BUNDLE_AT_PRESENT=%llu never fired; NO BUNDLE "
+                             "WAS WRITTEN. The run observed %llu present(s) and its last present "
+                             "count was %llu\n",
+                             wanted, presents, last_present);
+            break;
+        }
+        case kGateTriggerFile:
+            std::fprintf(stderr,
+                         "[grab] PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=\"%s\" never fired; NO BUNDLE "
+                         "WAS WRITTEN. That path was not a regular file at any of the %llu "
+                         "present(s) this run observed\n",
+                         only_value, presents);
+            break;
+        default:
+            break;
+    }
+}
+
 namespace {
+// Registered at load rather than from a gate's constructor: two of the three gate states are built
+// lazily on the first present, so a run that never presents would register nothing — and that is
+// exactly the run whose silence is hardest to explain. The handler reads only the environment,
+// namespace-scope atomics, and the deliberately leaked guest-log state, so it stays valid after
+// every static destructor has run.
+[[maybe_unused]] const int g_automatic_capture_gate_exit_report = [] {
+    std::atexit(&report_unfired_automatic_capture_gates);
+    return 0;
+}();
+
 struct CaptureBundleTriggerFileState {
     bool enabled = false;
     std::string trigger_path;
@@ -2144,6 +2368,7 @@ void capture_bundle_trigger_file_on_present(uint64_t present_count) {
     std::error_code ec;
     if (!std::filesystem::is_regular_file(state.trigger_path, ec) || ec) return;
     if (state.fired.exchange(true, std::memory_order_acq_rel)) return;
+    g_automatic_capture_gate_fired[kGateTriggerFile].store(true, std::memory_order_release);
 
     const std::string replaced =
         request_interactive_capture_bundle(state.bundle_path, state.max_mb);
@@ -3040,6 +3265,11 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
 
 void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64_t flip_arg,
                                  uint32_t width, uint32_t height) {
+    // Latched so an automatic gate that never fired can report what the run actually reached rather
+    // than only what was asked for ("you asked for present 5000; the run reached 812"). Two relaxed
+    // atomics against the cost of a whole flip.
+    g_presents_observed.fetch_add(1, std::memory_order_relaxed);
+    g_last_present_count.store(present_count, std::memory_order_relaxed);
     // A remote controller can create this file only after a lightweight screenshot proves the title
     // is in the desired phase. Polling stays entirely absent from normal runs; when configured, the
     // file and this log line independently prove the lever moved before the existing F9 state machine
@@ -3086,6 +3316,7 @@ void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64
     static std::atomic<bool> scheduled_fired{false};
     if (scheduled.valid && present_count >= scheduled.present &&
         !scheduled_fired.exchange(true, std::memory_order_acq_rel)) {
+        g_automatic_capture_gate_fired[kGateAtPresent].store(true, std::memory_order_release);
         const std::string replaced =
             request_interactive_capture_bundle(scheduled.path, scheduled.max_mb);
         std::fprintf(stderr,

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -327,6 +327,33 @@ bool guest_log_capture_bundle_enabled();
 void observe_guest_log_for_capture(
     const char* bytes, size_t size,
     GuestLogCaptureSource source = GuestLogCaptureSource::Unknown);
+
+// What an armed guest-log gate actually observed, so "the marker never matched" can say WHY rather
+// than leaving the operator to infer it from a missing file (#1684). The match is EXACT and stays
+// exact: a marker that is a prefix of the real line — `LevelDocument Loaded: worldmap` against
+// `LevelDocument Loaded: worldmap [worldmap]` — cost a full ~7-minute routed run that exited 0 and
+// wrote nothing. `closest_line` is the observed line sharing the longest prefix with the marker, so
+// the report can print the exact string the operator should have asked for.
+struct GuestLogCaptureMiss {
+    std::string marker;             // the exact line that was demanded
+    uint64_t lines_observed = 0;    // completed guest-stdout lines the observer saw
+    uint64_t lines_discarded = 0;   // of those, lines dropped for exceeding the byte limit or a gap
+    std::string closest_line;       // observed line sharing the longest prefix with the marker
+    size_t closest_prefix_bytes = 0;   // length of that shared prefix
+    bool marker_too_long = false;   // the marker itself exceeds kGuestLogCaptureMaxLineBytes
+};
+// Pure: the exact stderr text for an armed marker that never matched. Exported so the diagnosis is
+// regressable without booting a title, and so the near-miss reasoning can be asserted directly.
+// Non-printable bytes are escaped in both the marker and the observed line, because an invisible
+// difference (a trailing tab, a stray CR) is precisely the failure this report has to make visible.
+std::string format_guest_log_capture_miss(const GuestLogCaptureMiss& miss);
+// Snapshot of the live gate. Returns true when a miss report is due — i.e. a marker was configured
+// and never matched. Returns false when no marker was configured or the marker matched.
+bool guest_log_capture_miss_snapshot(GuestLogCaptureMiss& out);
+// Prints one report for the configured automatic whole-frame capture gate when it never armed a
+// capture. Registered with std::atexit at load time, so a run that silently produced no bundle now
+// says so; exported so the same text can be asserted by a test.
+void report_unfired_automatic_capture_gates();
 // Marks bytes omitted by a bounded stdout adapter. It deliberately discards through the next observed
 // line ending so an unobserved suffix can cause only a missed match, never a false exact-line match.
 void observe_guest_log_capture_gap();

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -1,0 +1,271 @@
+// An ARMED guest-log capture marker that never matches must say so (#1684). Pure/offline: no guest
+// and no Vulkan device.
+//
+// The failure this guards is not a wrong bundle, it is silence. A marker that is a PREFIX of the
+// real guest line — `LevelDocument Loaded: worldmap` against the printed
+// `LevelDocument Loaded: worldmap [worldmap]` — never matches, and before this change nothing at all
+// was reported: the run completed, exited 0, wrote no bundle, and the only evidence was a missing
+// file. A ~7-minute routed Astro Bot capture was lost that way.
+//
+// This test lives apart from test_guest_log_capture because the gate is a process-wide one-shot:
+// that test's marker MATCHES, and a fired gate has nothing to report by construction.
+#include "../src/gpu/gpu_timeline.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include "test_scratch.h"
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_test_env(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+static void clear_test_env(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+static int stream_fd(FILE* stream) {
+#ifdef _WIN32
+    return _fileno(stream);
+#else
+    return fileno(stream);
+#endif
+}
+
+// Runs `body` with stderr redirected to a scratch file and returns everything it wrote. The exit
+// report's whole job is to put text on stderr, so asserting on a returned string alone would leave
+// the delivery untested — an empty report and an unreachable report look identical from the caller.
+static std::string capture_stderr(const std::filesystem::path& path, void (*body)()) {
+#ifdef _WIN32
+    const int saved = _dup(stream_fd(stderr));
+#else
+    const int saved = dup(stream_fd(stderr));
+#endif
+    FILE* sink = std::fopen(path.string().c_str(), "w");
+    if (!sink || saved < 0) { if (sink) std::fclose(sink); return "<redirect failed>"; }
+    std::fflush(stderr);
+#ifdef _WIN32
+    _dup2(stream_fd(sink), stream_fd(stderr));
+#else
+    dup2(stream_fd(sink), stream_fd(stderr));
+#endif
+    body();
+    std::fflush(stderr);
+#ifdef _WIN32
+    _dup2(saved, stream_fd(stderr));
+    _close(saved);
+#else
+    dup2(saved, stream_fd(stderr));
+    close(saved);
+#endif
+    std::fclose(sink);
+
+    std::string text;
+    if (FILE* in = std::fopen(path.string().c_str(), "rb")) {
+        char buf[4096];
+        size_t got = 0;
+        while ((got = std::fread(buf, 1, sizeof(buf), in)) > 0) text.append(buf, got);
+        std::fclose(in);
+    }
+    return text;
+}
+
+static bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+int main(int argc, char** argv) {
+    // Child mode. It arms the gate, feeds a line the marker is only a PREFIX of, and returns from
+    // main. Nothing here calls the reporter, so any text on this process's stderr can only come from
+    // the std::atexit registration — which is the half of the fix that an in-process assertion is
+    // structurally unable to see. Removing that one registration leaves every direct-call check
+    // below passing while a real run goes silent again, which is precisely the original defect.
+    if (argc > 2 && std::string(argv[1]) == "--unfired-child") {
+        set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "LevelDocument Loaded: worldmap");
+        set_test_env("PROSPER_CAPTURE_BUNDLE", argv[2]);
+        const char guest[] = "LevelDocument Loaded: worldmap [worldmap]\n";
+        observe_guest_log_for_capture(guest, sizeof(guest) - 1);
+        return 0;
+    }
+
+    std::printf("== test_guest_log_capture_miss ==\n");
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto scratch = prosper_test::test_scratch_dir();
+    const auto bundle_path = scratch / ("prosper-guest-log-miss-" + std::to_string(nonce) + ".prgbundle");
+    const auto stderr_path = scratch / ("prosper-guest-log-miss-" + std::to_string(nonce) + ".stderr");
+
+    // --- the pure formatter: the diagnosis, without needing a title ---------------------------
+    {
+        GuestLogCaptureMiss miss;
+        miss.marker = "LevelDocument Loaded: worldmap";
+        miss.lines_observed = 812;
+        miss.closest_line = "LevelDocument Loaded: worldmap [worldmap]";
+        miss.closest_prefix_bytes = miss.marker.size();
+        const std::string text = format_guest_log_capture_miss(miss);
+        CHECK(contains(text, "never matched") && contains(text, "NO BUNDLE WAS WRITTEN"),
+              "a never-matched marker is named as such, and the missing bundle is stated");
+        CHECK(contains(text, "\"LevelDocument Loaded: worldmap\""),
+              "the report quotes the marker that was demanded");
+        CHECK(contains(text, "LevelDocument Loaded: worldmap [worldmap]"),
+              "the report quotes the closest observed line verbatim, so it can be copied");
+        CHECK(contains(text, "PREFIX"),
+              "a marker that is a prefix of the real line is diagnosed as exactly that");
+        CHECK(contains(text, "812"), "the report states how many lines were compared");
+    }
+    {
+        // Zero observed lines is a DIFFERENT fault from a wrong marker, and conflating them is what
+        // sent the original investigation looking at the marker text.
+        GuestLogCaptureMiss miss;
+        miss.marker = "phase-ready";
+        const std::string text = format_guest_log_capture_miss(miss);
+        CHECK(contains(text, "no completed line reached the observer"),
+              "an unreached guest-log path is distinguished from a wrong marker");
+        CHECK(!contains(text, "closest observed line"),
+              "with nothing observed there is no closest line to claim");
+    }
+    {
+        GuestLogCaptureMiss miss;
+        miss.marker = std::string(kGuestLogCaptureMaxLineBytes + 1, 'x');
+        miss.marker_too_long = true;
+        CHECK(contains(format_guest_log_capture_miss(miss), "never been enabled") ||
+              contains(format_guest_log_capture_miss(miss), "never enabled"),
+              "an over-long marker reports that the gate was never enabled");
+    }
+
+    // --- the live gate: a prefix marker against the real observer ------------------------------
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE");
+    clear_test_env("PROSPER_GPU_TIMELINE");
+    set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "phase-ready");
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+    CHECK(guest_log_capture_bundle_enabled(), "the gate arms from a marker plus a bundle path");
+
+    // A trailing tab is invisible when printed raw, and it is exactly the kind of byte that breaks
+    // an exact match while the two strings look identical in a terminal.
+    observe_guest_log_for_capture("phase-ready\t\n", 13);
+    observe_guest_log_for_capture("phase-ready-suffix\n", 19);
+    observe_guest_log_for_capture("unrelated\n", 10);
+    CHECK(!interactive_capture_bundle_active(),
+          "none of the near-miss lines arms a capture: the match stays EXACT");
+
+    GuestLogCaptureMiss live;
+    CHECK(guest_log_capture_miss_snapshot(live),
+          "an armed marker that never matched is reportable");
+    CHECK(live.marker == "phase-ready", "the snapshot carries the configured marker");
+    CHECK(live.lines_observed == 3 && live.lines_discarded == 0,
+          "every completed line is counted, so 'marker wrong' and 'never reached' stay separable");
+    CHECK(live.closest_line == "phase-ready\t" && live.closest_prefix_bytes == 11,
+          "the closest observed line is the first sharing the longest prefix with the marker");
+
+    const std::string live_text = format_guest_log_capture_miss(live);
+    CHECK(contains(live_text, "\\x09"),
+          "an invisible trailing byte in the closest line is escaped, not reproduced invisibly");
+    CHECK(contains(live_text, "PREFIX"),
+          "the live near-miss is diagnosed as a prefix marker");
+
+    // --- delivery: the report actually reaches stderr, and only when a gate is armed ------------
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    const std::string quiet = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(quiet.empty(), "with no gate configured the exit report says nothing at all");
+
+    set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "phase-ready");
+    const std::string loud = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(contains(loud, "never matched") && contains(loud, "phase-ready"),
+          "with the gate armed and unmatched the exit report names the marker on stderr");
+    CHECK(contains(loud, "phase-ready\\x09"),
+          "the delivered report carries the escaped closest line");
+
+    // A gate configured without an output path produced no message anywhere before #1684.
+    clear_test_env("PROSPER_CAPTURE_BUNDLE");
+    const std::string no_path = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(contains(no_path, "without PROSPER_CAPTURE_BUNDLE"),
+          "a gate configured without an output path is reported rather than ignored");
+
+    // Mutually exclusive gates: rejected at startup, and the rejection is restated at exit because
+    // its only other symptom is the same missing file.
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+    set_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT", "500");
+    const std::string conflict = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(contains(conflict, "mutually exclusive"),
+          "a conflicting gate configuration is restated at exit");
+
+    // A present-ordinal gate that the run never reached names what the run DID reach.
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    record_gpu_timeline_present(7, 0, 0, 4, 4);
+    record_gpu_timeline_present(8, 0, 0, 4, 4);
+    const std::string at_present = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(contains(at_present, "PROSPER_CAPTURE_BUNDLE_AT_PRESENT=500") &&
+          contains(at_present, "never fired"),
+          "an unreached present ordinal is reported by name");
+    CHECK(contains(at_present, "2 present(s)") && contains(at_present, "last present count was 8"),
+          "the report states what the run reached, not only what was asked for");
+
+    set_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT", "not-a-number");
+    const std::string malformed = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
+    CHECK(contains(malformed, "is not a number"),
+          "a malformed present ordinal is reported instead of silently disabling the gate");
+
+    // Leave nothing armed, so this test's own process exit stays quiet and its ctest log cannot be
+    // misread as a failure. Done before the child spawn so the child inherits a clean environment.
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE");
+
+    // --- the wiring: a real process that merely RETURNS FROM MAIN must still explain itself -----
+    // The defect was silence at exit, so the guard has to cross a process boundary. Every check
+    // above calls the reporter directly and therefore cannot distinguish a registered exit handler
+    // from an unregistered one.
+    {
+        std::string self = argv[0];
+        if (self.find('/') == std::string::npos && self.find('\\') == std::string::npos)
+            self = "./" + self;
+        const auto child_err = scratch / ("prosper-guest-log-miss-child-" + std::to_string(nonce) + ".stderr");
+        const std::string command = "\"" + self + "\" --unfired-child \"" + bundle_path.string() +
+                                    "\" 2> \"" + child_err.string() + "\"";
+        const int rc = std::system(command.c_str());
+        std::string child_text;
+        if (FILE* in = std::fopen(child_err.string().c_str(), "rb")) {
+            char buf[4096];
+            size_t got = 0;
+            while ((got = std::fread(buf, 1, sizeof(buf), in)) > 0) child_text.append(buf, got);
+            std::fclose(in);
+        }
+        CHECK(rc == 0, "the child process exits cleanly, exactly as the lost Astro Bot run did");
+        CHECK(contains(child_text, "never matched") && contains(child_text, "PREFIX"),
+              "a process that only returns from main still reports its unfired marker at exit");
+        CHECK(contains(child_text, "LevelDocument Loaded: worldmap [worldmap]"),
+              "the exit report names the exact line the guest actually printed");
+        std::error_code child_ec;
+        std::filesystem::remove(child_err, child_ec);
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(stderr_path, ec);
+    std::filesystem::remove(bundle_path, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -103,11 +103,21 @@ int main(int argc, char** argv) {
     // structurally unable to see. Removing that one registration leaves every direct-call check
     // below passing while a real run goes silent again, which is precisely the original defect.
     if (argc > 3 && std::string(argv[1]) == "--unfired-child") {
+        // These two lines go to the inherited STDOUT, so they land inline in the ctest log and
+        // answer "did the child run at all?" without any extra plumbing. A spawn that never starts
+        // and an exit report that never fires both leave the stderr file empty, and only this
+        // witness separates them.
+        std::printf("  [child] started, redirecting stderr to %s\n", argv[3]);
+        std::fflush(stdout);
         // The child redirects its OWN stderr rather than having the parent append a `2>` clause.
         // Shell redirection would put a third quoted path into a command line that cmd.exe already
         // parses awkwardly, and the reopened stream is still what the atexit handler writes to:
         // stdio teardown runs after the exit handlers, so the report lands in this file.
-        if (!std::freopen(argv[3], "w", stderr)) return 2;
+        if (!std::freopen(argv[3], "w", stderr)) {
+            std::printf("  [child] freopen failed\n");
+            std::fflush(stdout);
+            return 2;
+        }
         set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "LevelDocument Loaded: worldmap");
         set_test_env("PROSPER_CAPTURE_BUNDLE", argv[2]);
         const char guest[] = "LevelDocument Loaded: worldmap [worldmap]\n";
@@ -246,17 +256,27 @@ int main(int argc, char** argv) {
     // above calls the reporter directly and therefore cannot distinguish a registered exit handler
     // from an unregistered one.
     {
-        // make_preferred() is load-bearing on Windows and a no-op elsewhere: CMake and
-        // std::filesystem hand back forward slashes, and cmd.exe will not run a program path
-        // spelled that way — it reads the leading `/` components as switches. The first Windows
-        // CI run failed on exactly that, and only because the note below printed the command.
-        std::filesystem::path self = std::filesystem::path(argv[0]).make_preferred();
-        if (!self.has_parent_path()) self = std::filesystem::path(".") / self;
+        // The program is named RELATIVE to the working directory and left unquoted. ctest runs a
+        // test in the directory the binary was built into (CMake's default WORKING_DIRECTORY), and
+        // a CMake target name can contain no spaces, so this needs no quoting at all — which
+        // removes the leading-quote question from the command line entirely. Two Windows CI runs
+        // were lost to that question with an absolute path, first with forward slashes and then
+        // with native ones.
+        const std::filesystem::path self =
+            std::filesystem::path(argv[0]).filename();   // no directory, no spaces, no quotes
+        const std::string prefix =
+#ifdef _WIN32
+            ".\\";
+#else
+            "./";
+#endif
         const auto child_err =
             (scratch / ("prosper-guest-log-miss-child-" + std::to_string(nonce) + ".stderr"))
                 .make_preferred();
-        const std::string command = "\"" + self.string() + "\" --unfired-child \"" +
+        const std::string command = prefix + self.string() + " --unfired-child \"" +
                                     bundle_path.string() + "\" \"" + child_err.string() + "\"";
+        if (!std::system(nullptr))
+            std::printf("  [note] no command processor is available to std::system\n");
         const int rc = std::system(command.c_str());
         std::string child_text;
         if (FILE* in = std::fopen(child_err.string().c_str(), "rb")) {
@@ -268,8 +288,14 @@ int main(int argc, char** argv) {
         // A spawn, quoting, or redirection problem is indistinguishable from the missing exit
         // report itself — both leave this file empty. Name the apparatus so the two never get
         // confused, which is the failure mode the instrument-trap list keeps recording.
-        if (rc != 0 || child_text.empty())
+        if (rc != 0 || child_text.empty()) {
+            std::error_code note_ec;
+            std::printf("  [note] child rc=%d, stderr file exists=%d size=%lld, cwd=%s\n", rc,
+                        std::filesystem::exists(child_err, note_ec) ? 1 : 0,
+                        static_cast<long long>(std::filesystem::file_size(child_err, note_ec)),
+                        std::filesystem::current_path(note_ec).string().c_str());
             std::printf("  [note] child command was: %s\n", command.c_str());
+        }
         CHECK(rc == 0, "the child process exits cleanly, exactly as the lost Astro Bot run did");
         CHECK(contains(child_text, "never matched") && contains(child_text, "PREFIX"),
               "a process that only returns from main still reports its unfired marker at exit");

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -243,9 +243,15 @@ int main(int argc, char** argv) {
         if (self.find('/') == std::string::npos && self.find('\\') == std::string::npos)
             self = "./" + self;
         const auto child_err = scratch / ("prosper-guest-log-miss-child-" + std::to_string(nonce) + ".stderr");
+        // More than two quote characters, so cmd.exe does not strip the outermost pair and the
+        // string is used as written; /bin/sh treats it the same way. Paths here are the test
+        // binary and its own scratch directory.
         const std::string command = "\"" + self + "\" --unfired-child \"" + bundle_path.string() +
                                     "\" 2> \"" + child_err.string() + "\"";
         const int rc = std::system(command.c_str());
+        // Printed on any failure so a spawn or quoting problem is never mistaken for the defect
+        // this arm exists to catch — the two look identical from the assertions alone.
+        if (rc != 0) std::printf("  [note] child command was: %s\n", command.c_str());
         std::string child_text;
         if (FILE* in = std::fopen(child_err.string().c_str(), "rb")) {
             char buf[4096];

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -102,7 +102,12 @@ int main(int argc, char** argv) {
     // the std::atexit registration — which is the half of the fix that an in-process assertion is
     // structurally unable to see. Removing that one registration leaves every direct-call check
     // below passing while a real run goes silent again, which is precisely the original defect.
-    if (argc > 2 && std::string(argv[1]) == "--unfired-child") {
+    if (argc > 3 && std::string(argv[1]) == "--unfired-child") {
+        // The child redirects its OWN stderr rather than having the parent append a `2>` clause.
+        // Shell redirection would put a third quoted path into a command line that cmd.exe already
+        // parses awkwardly, and the reopened stream is still what the atexit handler writes to:
+        // stdio teardown runs after the exit handlers, so the report lands in this file.
+        if (!std::freopen(argv[3], "w", stderr)) return 2;
         set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "LevelDocument Loaded: worldmap");
         set_test_env("PROSPER_CAPTURE_BUNDLE", argv[2]);
         const char guest[] = "LevelDocument Loaded: worldmap [worldmap]\n";
@@ -241,15 +246,17 @@ int main(int argc, char** argv) {
     // above calls the reporter directly and therefore cannot distinguish a registered exit handler
     // from an unregistered one.
     {
-        std::string self = argv[0];
-        if (self.find('/') == std::string::npos && self.find('\\') == std::string::npos)
-            self = "./" + self;
-        const auto child_err = scratch / ("prosper-guest-log-miss-child-" + std::to_string(nonce) + ".stderr");
-        // More than two quote characters, so cmd.exe does not strip the outermost pair and the
-        // string is used as written; /bin/sh treats it the same way. Paths here are the test
-        // binary and its own scratch directory.
-        const std::string command = "\"" + self + "\" --unfired-child \"" + bundle_path.string() +
-                                    "\" 2> \"" + child_err.string() + "\"";
+        // make_preferred() is load-bearing on Windows and a no-op elsewhere: CMake and
+        // std::filesystem hand back forward slashes, and cmd.exe will not run a program path
+        // spelled that way — it reads the leading `/` components as switches. The first Windows
+        // CI run failed on exactly that, and only because the note below printed the command.
+        std::filesystem::path self = std::filesystem::path(argv[0]).make_preferred();
+        if (!self.has_parent_path()) self = std::filesystem::path(".") / self;
+        const auto child_err =
+            (scratch / ("prosper-guest-log-miss-child-" + std::to_string(nonce) + ".stderr"))
+                .make_preferred();
+        const std::string command = "\"" + self.string() + "\" --unfired-child \"" +
+                                    bundle_path.string() + "\" \"" + child_err.string() + "\"";
         const int rc = std::system(command.c_str());
         std::string child_text;
         if (FILE* in = std::fopen(child_err.string().c_str(), "rb")) {

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -149,9 +149,11 @@ int main(int argc, char** argv) {
         GuestLogCaptureMiss miss;
         miss.marker = std::string(kGuestLogCaptureMaxLineBytes + 1, 'x');
         miss.marker_too_long = true;
-        CHECK(contains(format_guest_log_capture_miss(miss), "never been enabled") ||
-              contains(format_guest_log_capture_miss(miss), "never enabled"),
+        const std::string text = format_guest_log_capture_miss(miss);
+        CHECK(contains(text, "never enabled"),
               "an over-long marker reports that the gate was never enabled");
+        CHECK(!contains(text, "closest observed line"),
+              "a gate that was never enabled makes no claim about what it observed");
     }
 
     // --- the live gate: a prefix marker against the real observer ------------------------------
@@ -249,9 +251,6 @@ int main(int argc, char** argv) {
         const std::string command = "\"" + self + "\" --unfired-child \"" + bundle_path.string() +
                                     "\" 2> \"" + child_err.string() + "\"";
         const int rc = std::system(command.c_str());
-        // Printed on any failure so a spawn or quoting problem is never mistaken for the defect
-        // this arm exists to catch — the two look identical from the assertions alone.
-        if (rc != 0) std::printf("  [note] child command was: %s\n", command.c_str());
         std::string child_text;
         if (FILE* in = std::fopen(child_err.string().c_str(), "rb")) {
             char buf[4096];
@@ -259,6 +258,11 @@ int main(int argc, char** argv) {
             while ((got = std::fread(buf, 1, sizeof(buf), in)) > 0) child_text.append(buf, got);
             std::fclose(in);
         }
+        // A spawn, quoting, or redirection problem is indistinguishable from the missing exit
+        // report itself — both leave this file empty. Name the apparatus so the two never get
+        // confused, which is the failure mode the instrument-trap list keeps recording.
+        if (rc != 0 || child_text.empty())
+            std::printf("  [note] child command was: %s\n", command.c_str());
         CHECK(rc == 0, "the child process exits cleanly, exactly as the lost Astro Bot run did");
         CHECK(contains(child_text, "never matched") && contains(child_text, "PREFIX"),
               "a process that only returns from main still reports its unfired marker at exit");

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -679,6 +679,19 @@ overlong lines; non-stdout streams and descriptors are ignored. The one match di
 adapter that contributed to the line. Do not use a substring or a program address as a substitute for a
 real phase marker. Persistent color/depth targets must remain enabled so the bundle can seed the frame
 boundary it is intended to preserve.
+**Equality means the WHOLE line, and a marker that is merely a prefix of it never fires.** This cost a
+full ~7-minute routed Astro Bot world-map capture (#1684): the guest printed
+`LevelDocument Loaded: worldmap [worldmap]`, the marker was `LevelDocument Loaded: worldmap`, and the run
+reached the checkpoint, exited 0, and wrote nothing at all. Since #1684 an armed gate that never fired
+says so **at process exit**, on stderr, naming the marker, how many guest-stdout lines were compared, and
+the observed line sharing the longest prefix with the marker — escaped, so an invisible trailing byte is
+visible. Copy that line verbatim as the next run's marker. Two distinct outcomes to read carefully:
+`no completed line reached the observer` means the route never produced guest stdout (a wrong route, not
+a wrong marker), whereas a quoted closest line means the marker itself is wrong. The same exit report
+covers the other two automatic gates: an unreached `PROSPER_CAPTURE_BUNDLE_AT_PRESENT` states the present
+count the run actually reached, and an unobserved `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE` states how many
+presents looked for it. **Absence of a bundle is no longer evidence of anything on its own — read the
+exit report.**
 If present counts vary and the title emits no honest guest-stdout marker, use the headless F9 control:
 set `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` together with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`, keep the trigger absent at process start, and create it

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -50,6 +50,16 @@ does not accept substrings; CR, LF, and CRLF differ only as line terminators. Fr
 `printf`, `puts`, `putchar`, `fputs`, `fwrite`, or fd writes is observed, and the match diagnostic names the
 contributing adapter(s). Non-stdout output is ignored. Keep persistent targets enabled.
 
+A marker that is only a *prefix* of the real line therefore never fires, and that is the common way to
+lose a long route (#1684). Since that fix the process reports an armed-but-unfired gate on stderr **at
+exit**: it names the marker, how many completed guest-stdout lines were compared, and the observed line
+sharing the longest prefix with the marker, with non-printable bytes escaped so an invisible difference
+is visible. Re-run with that quoted line verbatim. `no completed line reached the observer` is the other
+outcome and means something different — the route never reached guest stdout, so the marker was never
+tested. The same report covers an unreached `PROSPER_CAPTURE_BUNDLE_AT_PRESENT` (it states the present
+count the run reached), an unobserved `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE`, a gate configured without
+`PROSPER_CAPTURE_BUNDLE`, and a conflicting multi-gate configuration.
+
 When neither a fixed present nor guest stdout is phase-stable, set
 `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`. Keep the trigger path absent at startup, watch


### PR DESCRIPTION
Fixes #1684

## Failure scenario

`PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG` compares the accumulated guest log line with `==` (`gpu_timeline.cpp`, `complete_line`: `state.line == state.marker`). A marker that is a **prefix** of the real line never matches — and when it never matched, **nothing at all was reported**. The run completed, exited 0, and wrote no bundle.

An Astro Bot world-map capture ran the full ~7 minutes, reached the checkpoint (the marker text is in the log), exited 0 and produced no bundle and no explanation: the guest printed `LevelDocument Loaded: worldmap [worldmap]` and the marker was `LevelDocument Loaded: worldmap`. The existing `[grab]` messages fire only on **configuration** errors; there was none for the far more likely runtime outcome.

**Re-verified on `origin/master` @ `20153833`** with a standalone program linking `prosper_core` (not committed), which arms the gate with that exact marker, feeds that exact guest line, and returns from `main`:

```
exit=0
--- stdout ---
armed=0 bundle_exists=0
--- stderr (byte count) ---
0
```

Zero bytes on stderr. That is the defect.

## Behavioural contract

**The match stays EXACT.** There is no substring mode, silent or otherwise. An unmarked substring match could arm on an unintended earlier line and capture the wrong frame, which is worse than failing. What changes is that failing is no longer silent.

A `std::atexit` handler now reports the single configured automatic capture gate when it never armed a capture. Same program, built against this branch:

```
[grab] PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG never matched; NO BUNDLE WAS WRITTEN.
[grab]   The gate requires the COMPLETE guest-stdout line to EQUAL the marker; it is not a substring match.
[grab]   marker: "LevelDocument Loaded: worldmap" (30 bytes)
[grab]   observed 1 completed guest-stdout line(s), of which 0 were discarded (over the 4096-byte limit, or truncated by a stdout gap).
[grab]   closest observed line: "LevelDocument Loaded: worldmap [worldmap]" (41 bytes, sharing the first 30 byte(s) with the marker)
[grab]   that line BEGINS with the marker and continues past it: the marker is a PREFIX of the real line. Re-run with the closest line above as the marker, verbatim.
```

The quoted closest line is the exact string to use on the next run.

Two outcomes are reported **distinctly**, because they have different fixes: a quoted closest line means the marker is wrong; `no completed line reached the observer` means the route never produced guest stdout, so the marker was never tested at all. Conflating those is what would send the next investigation back to the marker text.

The same handler covers the sibling gates in the same file, which share the shape exactly:

| gate | previously | now |
| --- | --- | --- |
| `AFTER_GUEST_LOG` never matched | silent | marker, lines compared, escaped closest line, prefix diagnosis |
| `AT_PRESENT` ordinal never reached | silent | names the ordinal and the present count the run actually reached |
| `AT_PRESENT` malformed value | silently inert | reported as not a number |
| `TRIGGER_FILE` never appeared | silent | names the path and how many presents looked for it |
| any gate without `PROSPER_CAPTURE_BUNDLE` | silent for `AT_PRESENT` | reported |
| conflicting multi-gate configuration | reported at startup only | restated at exit |

## Approach and invariants

- **Near-miss tracking.** Each completed non-matching line is compared for longest shared prefix with the marker; the first line holding the maximum wins, so the answer is deterministic. One prefix compare per guest log line, paid only while a marker is configured.
- **Escaping.** The marker and the closest line are printed with non-printable bytes as `\xNN`. An invisible trailing byte is precisely the failure this report exists to make visible; printing raw would reproduce the invisibility. Verified end-to-end by a `\t` case.
- **Registration at load, not from a gate constructor.** Two of the three gate states are built lazily on the first present, so a run that never presents would otherwise register nothing — exactly the run whose silence is hardest to explain. The handler instead reads the environment plus namespace-scope atomics, so it works whether or not any gate state was ever constructed.
- **The guest-log state singleton is now deliberately leaked.** `atexit` handlers share one LIFO list with static destructors, so a handler registered *first* runs *last* — after that function-local static's destructor would have ended its lifetime. Leaking a singleton reachable from a static pointer makes the read legal rather than merely lucky. (It stays reachable, so it is not a leak to a leak checker.)
- The fired flags are namespace-scope atomics rather than reusing each state's existing `fired` member, for the same lifetime and lazy-construction reasons.

## Affected / deliberately unaffected

Affected: what an armed-but-unfired automatic capture gate prints at process exit; two new relaxed atomics per present; the guest-log state's lifetime.

Deliberately unaffected: **the matching semantics.** Exact line equality, CR/LF/CRLF terminator handling, the overlong-line discard, the stdout-gap discard, the one-shot arm, the one-present skip, non-stdout exclusion, and every existing `[grab]` message are untouched. `test_guest_log_capture`'s existing assertion that `phase-ready-suffix` does **not** match is intact and still passing — that assertion is the guard against exactly the fuzzy-match change #1684 warns against, and it was not weakened.

Also unaffected: the F9 interactive path, `gpu_replay`, and every non-capture run (one `atexit` slot, two relaxed atomics per flip, three `getenv` calls at exit).

## Risks

- The handler runs during exit and writes to `stderr`. Verified empirically that glibc runs `atexit` handlers before stdio teardown (the sample output above comes from a process that only returns from `main`).
- `getenv` at exit would race a concurrent `setenv`; nothing in prosper calls `setenv` at runtime.
- The report reads the environment rather than each gate's parsed state, so a process that *mutates* its own environment mid-run could be described by the post-mutation value. Real runs set these once before start; the unit test exercises this deliberately and it is the only way it can arise.

## Build and test

Linux, in the project container, worktree-local build dir:

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 247`, ctest exit `0`** (246 registered on master, plus the new `guest_log_capture_miss` case). The new test's own 27 checks all pass.

## Mutation arms

Each arm reverts one part of the fix and rebuilds; the quoted failures are verbatim.

**A — near-miss tracking removed** (the `else` branch in `complete_line`):

```
== test_guest_log_capture_miss ==
  [FAIL] the closest observed line is the first sharing the longest prefix with the marker
  [FAIL] an invisible trailing byte in the closest line is escaped, not reproduced invisibly
  [FAIL] the live near-miss is diagnosed as a prefix marker
  [FAIL] the delivered report carries the escaped closest line
== FAIL: 4 ==
```

**B — `guest_log_capture_miss_snapshot` never reports** (`return false` at the top):

```
== test_guest_log_capture_miss ==
  [FAIL] an armed marker that never matched is reportable
  [FAIL] the snapshot carries the configured marker
  [FAIL] every completed line is counted, so 'marker wrong' and 'never reached' stay separable
  [FAIL] the closest observed line is the first sharing the longest prefix with the marker
  [FAIL] an invisible trailing byte in the closest line is escaped, not reproduced invisibly
  [FAIL] the live near-miss is diagnosed as a prefix marker
  [FAIL] with the gate armed and unmatched the exit report names the marker on stderr
  [FAIL] the delivered report carries the escaped closest line
== FAIL: 8 ==
```

**C — the `std::atexit` registration removed.** This one is the reason the test spawns a child process, and it is worth reading carefully. With the registration removed the standalone repro goes silent again — `exit=0`, **0 bytes on stderr**, the original defect exactly — while *every in-process check still passed*, because they call the reporter directly:

```
--- stderr bytes ---
0
--- in-process test ---
test_rc=0
```

An in-process assertion is structurally unable to distinguish a registered exit handler from an unregistered one, so it would have been a green test over a live bug. After adding a child-process arm that only arms the gate and returns from `main`, the same mutation fails:

```
== test_guest_log_capture_miss ==
  [FAIL] a process that only returns from main still reports its unfired marker at exit
  [FAIL] the exit report names the exact line the guest actually printed
== FAIL: 2 ==
```

## Also filed, not fixed here

Two siblings sharing the shape, found while surveying the same file and left out to keep this PR to the never-fired report:

- **#2564** — `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT` and the semantic selectors are silent when they never match (`gpu_timeline.cpp:2979`); the `detail_submits_captured` counter that exists only reaches the timeline file, never stderr.
- **#2565** — malformed capture tunables silently substitute a different policy. `PROSPER_CAPTURE_MAX_SUBMITS` is the sharp one: a typo means **uncapped**, on the exact runs the cap exists for. Also `PROSPER_CAPTURE_BUNDLE` set alone, which is a complete no-op.

## Docs

`prosper/tools/AGENTS.md` and `prosper/tools/gpu_replay/README.md` now state that equality means the whole line, that a prefix marker never fires, what the exit report says, and how to read the two outcomes apart — with the standing note that **absence of a bundle is no longer evidence of anything on its own**.

No snapshots were run: the diff is diagnostic plumbing with no rendering path.
