### PR TITLE
test(infra): a dump-gated ctest case reports a skip instead of vanishing from the registered set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
           echo "Vulkan-gated suite present; total registered: \
             $(ctest --test-dir prosper/build-ci -N | tail -1 | grep -oE '[0-9]+$')"
 
+      # The same guard for the DUMP-gated set (#1675). CI never has a dump, so these five cannot run
+      # here — but they must still be REGISTERED, as skips, so the gap has a line in the summary. On
+      # master before this they were simply absent: 241 registered here against 246 locally, with
+      # nothing in either run naming the five that vanished or the 48 assertions behind them.
+      # Registration is exactly what a future edit could silently undo, so it is what this checks.
+      - name: Verify the dump-gated tests are registered as skips
+        run: |
+          for t in module_loads_eboot nid_hash_matches_imports trap_identifies_imports \
+                   boot_reaches_first_syscall real_shader_render plugin_autolink; do
+            if ! ctest --test-dir prosper/build-ci -N -R "^${t}$" | grep -q "Test *#"; then
+              echo "::error::${t} is not registered — a dump-gated case vanished instead of reporting a skip (see #1675)"
+              exit 1
+            fi
+          done
+
       - name: Build
         run: cmake --build prosper/build-ci
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -266,6 +266,21 @@ function(prosper_add_skipped_test name reason)
   set_tests_properties(${name} PROPERTIES SKIP_REGULAR_EXPRESSION "SKIPPED: ")
 endfunction()
 
+# The no-dump half of the same rule (#1675). Dumps are copyrighted and gitignored, so CI will never
+# have one — but a case that needs one must still REPORT that rather than vanishing. Measured before
+# this existed: a local configure registered 246 cases and a dumpless one 241, and the five that
+# disappeared carried 48 executed assertions plus test_boot_linux's two depth gates. Nothing in
+# either run named the difference; an unregistered test has no line to read and no count to compare
+# against, so the smaller suite was indistinguishable from full coverage.
+#
+# Use this in the `else()` of an `if(HAVE_GAME_DUMP)`, inside whatever platform/Vulkan block already
+# guards the case, so the skip appears exactly where the real case would have.
+function(prosper_add_dumpless_skipped_test name)
+  prosper_add_skipped_test(${name}
+    "${name} needs a local PS5 game dump and none is configured (-DGAME_DUMP=<dump root>). \
+Dumps are gitignored and cannot be committed, so this case never executes in CI.")
+endfunction()
+
 # Register a ctest case that asserts against ONE title's content. Runs normally when GAME_DUMP is
 # that title (or when no title id could be derived); otherwise registers a visible skip naming both
 # the required title and the configured one, so the reason is in the run instead of in a doc.
@@ -300,6 +315,8 @@ if(TARGET prosper_core)
     # Messenger-specific: the assertions pin PPSA24651's import/segment/relocation counts (#1573).
     prosper_add_title_gated_test(module_loads_eboot PPSA24651
              test_module "${GAME_DUMP}/eboot.bin")
+  else()
+    prosper_add_dumpless_skipped_test(module_loads_eboot)   # 25 assertions (#1675)
   endif()
 
   add_executable(test_nid tests/test_nid.cpp)
@@ -307,6 +324,8 @@ if(TARGET prosper_core)
   if(HAVE_GAME_DUMP)
     add_test(NAME nid_hash_matches_imports
              COMMAND test_nid "${GAME_DUMP}/eboot.bin")
+  else()
+    prosper_add_dumpless_skipped_test(nid_hash_matches_imports)   # 4 assertions (#1675)
   endif()
 
   add_executable(test_hle_registered tests/test_hle_registered.cpp)
@@ -1449,6 +1468,8 @@ if(TARGET prosper_core)
     if(HAVE_GAME_DUMP)
       add_test(NAME trap_identifies_imports
                COMMAND test_trap_linux "${GAME_DUMP}")
+    else()
+      prosper_add_dumpless_skipped_test(trap_identifies_imports)   # 15 assertions (#1675)
     endif()
 
     add_executable(test_boot_linux tests/test_boot_linux.cpp)
@@ -1457,6 +1478,8 @@ if(TARGET prosper_core)
       # Messenger-specific: links THIS title's own Il2cppUserAssemblies.prx / PS5Util.prx (#1573).
       prosper_add_title_gated_test(boot_reaches_first_syscall PPSA24651
                test_boot_linux "${GAME_DUMP}")
+    else()
+      prosper_add_dumpless_skipped_test(boot_reaches_first_syscall)   # 2 depth gates (#1675)
     endif()
 
     if(NOT APPLE AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|amd64|AMD64)$")
@@ -1774,6 +1797,8 @@ if(TARGET prosper_core)
         # eboot, so a dump whose eboot carries none (or none that fully translate) fails (#1573).
         prosper_add_title_gated_test(real_shader_render PPSA24651
                  test_real_shader_render "${GAME_DUMP}/eboot.bin")
+      else()
+        prosper_add_dumpless_skipped_test(real_shader_render)   # 4 assertions (#1675)
       endif()
       message(STATUS "Vulkan found (${Vulkan_LIBRARY}) — offscreen graphics harness enabled")
     else()

--- a/prosper/docs/VERIFICATION.md
+++ b/prosper/docs/VERIFICATION.md
@@ -137,9 +137,42 @@ Two guards keep that from recurring, and both matter more than the flag itself:
 **Windows/MinGW and macOS still disable Vulkan**, so layers 2–4 are Linux-and-local only there.
 
 Four tests are excluded by name on lavapipe because they pass on real hardware and fail on the software
-rasteriser; they are listed in `ci.yml` with a reproduction command and tracked in #1681. Dump-backed
-tests cannot run in CI at all — dumps are copyrighted and gitignored — and now report `(Skipped)` rather
-than passing.
+rasteriser; they are listed in `ci.yml` with a reproduction command and tracked in #1681.
+
+### Dump-gated tests — the census, and how the gap is reported (#1675)
+
+Dump-backed tests cannot run in CI at all: dumps are copyrighted and gitignored. **Six registered ctest
+cases are gated on a local game dump**, and this is the complete list, with the assertions each one
+actually executes (measured against `PPSA24651-app0`, not counted from the source):
+
+| ctest case | binary | assertions with a dump |
+| --- | --- | --- |
+| `module_loads_eboot` | `test_module` | 25 |
+| `nid_hash_matches_imports` | `test_nid` | 4 |
+| `trap_identifies_imports` | `test_trap_linux` | 15 |
+| `boot_reaches_first_syscall` | `test_boot_linux` | 2 depth gates (no `CHECK` macro) |
+| `real_shader_render` | `test_real_shader_render` | 4 |
+| `plugin_autolink` | `test_plugin_autolink` | 34, of which **14** are behind the dump branch |
+
+All six now report **`(Skipped)`** when there is no dump, by two different mechanisms, and the
+difference between them is the point:
+
+* `plugin_autolink` **runs** and returns `SKIP_RETURN_CODE` (77) from inside the binary, because 20 of
+  its 34 assertions do not need a dump and must still execute. Same for `mb3_poison_scan`, which skips
+  on a failed fixed mapping rather than on a dump.
+* the other five are registered by CMake as **skip cases** when `HAVE_GAME_DUMP` is off. Before that
+  they were not registered at all: `origin/master` `20153833` registered **241** cases without a dump
+  against **246** with one, and nothing in either run named the five that vanished or the 48 assertions
+  behind them. An unregistered test is invisible by construction — no line to read, no count to compare
+  against — which is the same failure the Vulkan flag caused above. Both configurations now register
+  246, and `ci.yml` asserts all six by name so a future edit cannot quietly drop back to 241.
+
+**A `(Skipped)` line is a legible gap, not a closed one.** These assertions still do not run anywhere
+except on a machine with the dump. Closing it for the loader assertions specifically means synthesizing
+fixture modules (a pair of tiny generated SELF/PRX files exporting one shared NID would exercise
+`link_program`'s export table, collision guard and alias recording with no dump) — tracked in #2567.
+The other five are pinned to one real title's bytes and cannot be synthesized without becoming
+different tests.
 
 **Three dump-backed tests are pinned to *The Messenger* specifically, not to "some dump" — and they
 now report `(Skipped)` instead of failing (#1573).** `module_loads_eboot` pins `PPSA24651-app0`'s


### PR DESCRIPTION
Fixes #1675. **Stacked on #2561** (`fix/issue-1573-ctest-dump-skip`), which introduces the
`prosper_add_skipped_test` helper this reuses — base is that branch, and GitHub will retarget to
`master` once it merges. Review the second commit only.

## Scope check first — the census the issue asked for

The issue said to measure before choosing a fix, and put `CONFIDENCE: LOW` on the breadth. Measured,
by **running each binary** against `PPSA24651-app0` rather than counting `CHECK(` sites:

| ctest case | binary | assertions with a dump | without a dump, on master |
| --- | --- | --- | --- |
| `module_loads_eboot` | `test_module` | 25 | **case not registered** |
| `nid_hash_matches_imports` | `test_nid` | 4 | **not registered** |
| `trap_identifies_imports` | `test_trap_linux` | 15 | **not registered** |
| `boot_reaches_first_syscall` | `test_boot_linux` | 2 depth gates (no `CHECK` macro) | **not registered** |
| `real_shader_render` | `test_real_shader_render` | 4 | **not registered** |
| `plugin_autolink` | `test_plugin_autolink` | 34, of which **14** are behind the dump branch | registered, `(Skipped)` since #1678 |

**Six registered ctest cases are dump-gated; 62 assertions plus two depth gates sit behind those
gates.** So this is neither a one-file annotation nor a fixture-building exercise: it is five
registrations.

Measured directly on `origin/master` `20153833`:

```text
cmake -S prosper -B build -DGAME_DUMP=/nonexistent-dump  ;  ctest -N | tail -1  ->  Total Tests: 241
cmake -S prosper -B build -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0 ; ctest -N     ->  Total Tests: 246
```

### Two corrections to the record

1. **The triage comment on #1675 said `real_shader_render` "is registered with `${GAME_DUMP}` and has
   no `SKIP_RETURN_CODE`, so whatever it declines to exercise is still counted as a pass" in CI. That
   is not what happens** — it sits inside `if(HAVE_GAME_DUMP)` (its *executable* is too), so with no
   dump it is not registered and not built. The defect is real but it is the *other* shape: silent
   absence, not a silent pass. The comment's census also found only 2 dump-gated cases because it
   grepped `add_test` lines containing `GAME_DUMP` **on the same line**; four of the six spread the
   `COMMAND` onto a continuation line.
2. The issue also asked whether any test takes a dump path from the environment or a default location
   instead of the CMake argument. `grep -rn 'getenv' prosper/tests/` finds no dump-path environment
   variable; four tests do default an argv-absent path to `../../PPSA24651-app0`, but every one of
   them is invoked by CMake with an explicit argument, so the default is unreachable from ctest.

## Failure scenario

CI never sets `GAME_DUMP` (dumps are copyrighted and gitignored). Five cases therefore do not exist
there — no line in the summary, no entry in `ctest -N`, no count to compare against. A reader of a
green CI run cannot discover that the loader's real-module coverage, the NID hash check, the stub
dispatch chain, the boot depth gates and the real-shader render did not run. That is the failure mode
`docs/VERIFICATION.md` § CI already records for the Vulkan flag (27 tests / ~1,800 assertions gone,
"138/138 looked exactly like full coverage"), reproduced in the dump-gated set.

## Behavioural contract

* the registered case count must be **the same with and without a dump** — the gap is reported, never
  expressed as an absence;
* a case that cannot run reports **`(Skipped)`**, never `Passed`;
* platform coverage is **unchanged**: a skip appears exactly where the real case would have, never on
  a platform where the case never existed;
* a case that *can* partly run still **runs** — `plugin_autolink`'s 20 dump-free assertions must not
  be converted into a skip.

## Approach

* `prosper_add_dumpless_skipped_test(name)` — a thin wrapper over #2561's `prosper_add_skipped_test`,
  used in the `else()` of the five existing `if(HAVE_GAME_DUMP)` blocks, **inside** whatever
  platform/Vulkan block already guards each one. `trap_identifies_imports` and
  `boot_reaches_first_syscall` stay UNIX-only; `real_shader_render` stays inside the Vulkan-found
  block. No new cases appear anywhere they did not exist before.
* `plugin_autolink` and `mb3_poison_scan` are **left alone**: their in-binary `SKIP_RETURN_CODE` is
  the right mechanism, because they have substantive assertions that do not need the gated resource.
  Converting them to CMake-side skips would delete 20 executing assertions.
* `.github/workflows/ci.yml` gains a second registration guard, by name, for all six dump-gated
  cases — the mirror of the Vulkan one two steps above it, and for the same stated reason. Without it
  a future edit that drops an `else()` silently returns to 241 and nothing fails.
* `docs/VERIFICATION.md` gains the census table and states plainly that a `(Skipped)` line is a
  legible gap, not a closed one.

## Affected / deliberately unaffected

* **Affected:** registration of five ctest cases when `HAVE_GAME_DUMP` is off; one new CI step.
* **Unaffected:** every test binary (zero source changes); all behaviour when a dump *is* configured;
  `plugin_autolink`; `mb3_poison_scan`; platform coverage.
* **Not changed, having checked:** all four CI `ctest` invocations already pass `--no-tests=error`,
  including the folded-scalar Windows-app one. I had this down as a gap from a stale read of the
  main checkout and confirmed against `git show origin/master:.github/workflows/ci.yml` before
  writing anything.

## Risks

* CI's Linux test count rises by 5 (all skips). Any external tooling asserting a fixed count would
  need updating; the only in-repo count assertion is the informational `echo` in the guard step.
* The new CI guard fails if a dump-gated case stops being registered — intended, and it is the only
  way this fix can be silently undone.

## Verification

Linux, in the `ps5ys` distrobox (a host build silently omits gpu_replay and every Vulkan execution
test). Counts quoted next to every exit code; `--no-tests=error` on every ctest.

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<either>
cmake --build prosper/build-linux -j4
ctest --test-dir prosper/build-linux --no-tests=error -j4 --output-on-failure
```

| arm | `GAME_DUMP` | registered | result |
| --- | --- | --- | --- |
| master, no dump | `/nonexistent-dump` | **241** | 5 cases absent |
| master, dump | `PPSA24651-app0` | **246** | — |
| **this branch**, no dump | `/nonexistent-dump` | **246** | **240 passed, 6 skipped, exit 0** |
| **this branch**, dump | `PPSA24651-app0` | **246** | **246/246 passed, exit 0** |

The name sets of the two 246s are **identical** — `diff` of the two `ctest -N` listings is empty,
which is the assertion that matters more than the equal totals.

No-dump run, tail:

```text
100% tests passed out of 246

The following tests did not run:
	 18 - module_loads_eboot (Skipped)
	 19 - nid_hash_matches_imports (Skipped)
	118 - plugin_autolink (Skipped)
	194 - trap_identifies_imports (Skipped)
	195 - boot_reaches_first_syscall (Skipped)
	241 - real_shader_render (Skipped)
```

### Mutation arm

The relevant mutation is the pre-fix state itself, measured on unmodified `origin/master`
`20153833`: **241 vs 246**, with the five missing names listed by `diff`. Nothing was made to pass by
weakening an assertion — no test source is touched in this PR at all, and the two tests that skip
from inside their own binaries were left exactly as they are so their dump-free assertions keep
running.

`diff --check` clean. Docs gate clean
(`check_numbered_table.py prosper/docs/VERIFICATION.md` → *2 tables, 11 rows, unbroken*).
No `Claude-Session:` trailer (`git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'`
→ 0).

## Is synthesizing fixtures worth a follow-up?

**Yes, for exactly one of the six — filed as #2567.** `plugin_autolink`'s 14 dump-gated assertions
cover `link_program`'s export table, its duplicate-export collision guard and #1670's alias
recording: *structural* loader behaviour, reproducible with two tiny generated PRX modules sharing one
NID. The machinery already exists (`tests/test_runtime_prx_load.cpp` writes and maps its own synthetic
PRX).

**No, for the other five.** They are pinned to one real title's bytes — `PPSA24651`'s import counts,
its IL2CPP module layout, the RDNA2 blobs in its eboot. A synthetic fixture cannot reproduce those; it
would be a different test wearing the same name, which is worse than an honest skip.
