### PR TITLE
fix(libkernel): scePthreadCondWait must report its wait; the TLS-key pair must encode (#1983)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2167,7 +2167,13 @@ HLE(k_pthread_create) {
     // The trampoline enters guest code on an explicit Sony stack. The host pthread itself retains a
     // glibc-owned stack large enough for static TLS and native start/exit bookkeeping.
     int attr_rc = pthread_attr_setstacksize(&la, supplied_stack ? kStackFloor : ssz);
-    if (attr_rc) { pthread_attr_destroy(&la); return (uint64_t)(unsigned)attr_rc; }
+    // fbsd_errno, not the raw host number (#1612): the sibling failure paths below already map, and
+    // this one is the last of #2178's three "raw host errno" rows. It matters more here than at the
+    // other two because this body is ALREADY aliased -- `scePthreadCreate` was therefore reporting
+    // `0x80020000 | <host errno>` on this path, the exact "worse than the bare value it replaces"
+    // outcome #2178 warns about. Benign today (pthread_attr_setstacksize reports EINVAL, which is 22
+    // on FreeBSD and on every host prosper builds for), which is also why no test arm can see it.
+    if (attr_rc) { pthread_attr_destroy(&la); return fbsd_errno(attr_rc); }
     pthread_attr_setdetachstate(&la, detach);
     auto* ts = new (std::nothrow) ThreadStart{};
     if (!ts) { pthread_attr_destroy(&la); return 12; }         // ENOMEM (FreeBSD and host agree)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1011,10 +1011,11 @@ HLE(k_cond_init) {
     *(void**)a0 = cond;
     return 0;
 }
-// The Sony spellings of the fallible condition-variable entry points (#2178). Destroy, Signal,
-// Broadcast and Wait are deliberately absent: each returns 0 unconditionally, so an alias would
-// change nothing today and misstate the contract tomorrow. scePthreadCondTimedwait encodes in
-// place instead — it has no POSIX spelling registered on its body.
+// The Sony spellings of the fallible condition-variable entry points (#2178). Signal and Broadcast
+// are deliberately absent: each returns 0 unconditionally, so an alias would change nothing today
+// and misstate the contract tomorrow. Destroy joined them when #2168 made it EBUSY-capable, and
+// Wait when #1983 made it report its wait; both aliases are below their own bodies.
+// scePthreadCondTimedwait encodes in place instead — it has no POSIX spelling on its body.
 SCE_PTHREAD_ALIAS(k_sce_cond_init,             k_cond_init)
 SCE_PTHREAD_ALIAS(k_sce_condattr_init,         k_condattr_init)
 SCE_PTHREAD_ALIAS(k_sce_condattr_setclock,     k_condattr_setclock)
@@ -1047,14 +1048,49 @@ HLE(k_cond_destroy) {
 SCE_PTHREAD_ALIAS(k_sce_cond_destroy, k_cond_destroy)
 HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_signal(c); } return 0; }
 HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_broadcast(c); } return 0; }
+// #1983: this reported SUCCESS for a wait that failed, and for a wait that never happened, through
+// two separate paths:
+//   1. the result was DISCARDED -- `(void)interruptible_cond_wait(...)` followed by an
+//      unconditional `return 0`, so a failed wait was reported to the guest as "signalled";
+//   2. a null cond or mutex slot skipped the `if (c && m)` body entirely, so NO wait was attempted
+//      at all -- and it still returned 0. That is the worse of the two: a predicate loop is told a
+//      condition fired when nothing was ever waited on, and either spins or proceeds on unsatisfied
+//      state. Path 1 at least performed the wait.
+// This is strictly worse than the bare-errno defect #1983 tracks, because a guest that only tests
+// `rc == 0` is misled too, not just one comparing against a named constant.
+// The k_cond_timedwait sibling just below already captured both -- same helper, same argument
+// shape, adjacent handler, opposite treatment of the return value. It is the model followed here,
+// down to the bare EINVAL(22) for an unusable pair.
+//
+// NOT changed, and deliberately: the C11 `_Cnd_wait` (hle_kernel_time.cpp `m_cnd_wait`) still
+// returns 0 unconditionally, because the SHIPPED guest libc.prx does exactly that -- its `_Cnd_wait`
+// is `call <scePthreadCondWait>; xor eax,eax; ret`. There the unconditional 0 is the contract
+// rather than a defect, and prosper reimplementing it faithfully is the point.
 HLE(k_cond_wait)      { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
+    uint64_t result;
     { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
-      if (c && m) {
+      if (!c || !m) {
+          result = 22;   // EINVAL — not a condition variable, or not a mutex. Bare; see the alias.
+      } else {
           GuestCondWaiterScope waiting(c);   // #2168 -- covers every wait path in this body
-          (void)interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,
-                                        nullptr, kGuestMutexCondWaitBookkeeping);
+          result = fbsd_errno(interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,
+                                                      nullptr, kGuestMutexCondWaitBookkeeping));
       } }
-    if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return 0; }
+    if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return result; }
+// The body above is registered under BOTH spellings, which is exactly why the fix could not live in
+// it alone: `pthread_cond_wait` must report the bare errno and `scePthreadCondWait` the encoded one,
+// so the two consumers of this one body want opposite answers (#1983, the shape #2296 also hit).
+//
+// CONFIDENCE: MED on the encoded form for THIS entry point, and the evidence is worth stating
+// precisely because it is weaker here than for its siblings. The shipped guest libc.prx's C11
+// `_Cnd_timedwait` compares `scePthreadCondTimedwait`'s result against 0x8002003c and 0x80020001,
+// and `_Mtx_lock` compares `scePthreadMutexLock`'s against 0x8002000b -- both were re-read for
+// #1983 and both reproduce. But `_Cnd_wait` (the C11 wrapper that calls scePthreadCondWait) is
+// `push rbp; mov rbp,rsp; call <plt>; xor eax,eax; pop rbp; ret`: it DISCARDS the result. So the
+// C11 layer neither confirms nor contradicts the encoding for this one, and the encoded form is an
+// extrapolation from the libkernel-wide convention (#2178), not a measurement. Do not raise this
+// label without a direct caller that compares.
+SCE_PTHREAD_ALIAS(k_sce_cond_wait, k_cond_wait)
 // POSIX pthread_cond_timedwait(cond_slot, mutex_slot, const timespec* abstime) — abstime is an
 // absolute deadline in the condition attribute's selected clock ({i64 sec, i64 nsec}, FreeBSD ==
 // Linux x86-64 layout), and the
@@ -1796,6 +1832,13 @@ HLE(k_log_attr_setschedparam) { // scePthreadAttrSetschedparam(attr, SchedParam*
     return 0;
 }
 
+// DELIBERATELY NOT ALIASED, and this is a recorded decision rather than an omission (#2178, #2365).
+// `scePthreadGetname` is dual-registered with `pthread_getname_np` and IS fallible, so the family
+// rule would sweep it — but the only guest call site found (PPSA17942 `0x5fac7c3`) does `test eax,
+// eax`, where 3 and 0x80020003 are indistinguishable, so nothing observed can settle it. Its Set
+// counterpart WAS swept in #2382 because a caller there does discriminate. #1983 re-examined this
+// and found no new evidence either way, so the bare form stands until a caller that branches on the
+// value turns up; `tests/test_pthread_names.cpp` pins it with the same reasoning.
 HLE(k_pthread_getname) {
     if (!a0) return 3;    // ESRCH
     if (!a1) return 14;   // EFAULT
@@ -2422,8 +2465,17 @@ HLE(k_key_delete)    {
 #else
     const int result = pthread_key_delete(key);
 #endif
-    return (uint64_t)(int64_t)result;
+    // fbsd_errno, not the raw host number: k_key_create above already routes its EAGAIN through the
+    // table (#1612) and this half did not, so one of the pair could hand the guest a host errno.
+    // Bare on purpose -- `pthread_key_delete` keeps it; `scePthreadKeyDelete` encodes below (#1983).
+    return fbsd_errno(result);
 }
+// The C11 layer makes this concrete: in the shipped guest libc.prx, `_Tss_create`, `_Tss_delete` and
+// `_Tss_set` are three-instruction forwarders onto scePthreadKeyCreate / KeyDelete / Setspecific
+// respectively (verified by PLT relocation for PPSA24651). KeyCreate already encoded via
+// k_sce_key_create, so one C11 family was forwarding an encoded value from one member and a bare
+// errno from the other two -- the #1873 shape, inside a single guest header's worth of API.
+SCE_PTHREAD_ALIAS(k_sce_key_delete, k_key_delete)
 HLE(k_getspecific)   {
     uint64_t rv = (uint64_t)(uintptr_t)pthread_getspecific((pthread_key_t)a0);
     // #312: learn the non-trapping MB3 pool-array address even when the hardware-watch diagnostic
@@ -2441,8 +2493,9 @@ HLE(k_setspecific)   {
     if (g_mb3_arm_hook && a1) g_mb3_arm_hook(a1);
     int r = pthread_setspecific((pthread_key_t)a0, (void*)(uintptr_t)a1);
     if (!r && gpu::mb3_tls_tracking_enabled()) gpu::mb3_note_tls_pool_candidate(a1);
-    return (uint64_t)(int64_t)r;
+    return fbsd_errno(r);   // #1612: never a raw host errno. Bare here; the Sony spelling encodes.
 }
+SCE_PTHREAD_ALIAS(k_sce_setspecific, k_setspecific)
 
 // --- event flags (SceKernelEventFlag): a bit pattern with wait/set/clear ---
 namespace {
@@ -4478,7 +4531,7 @@ void register_kernel_hle() {
     R("scePthreadCondDestroy", k_sce_cond_destroy);                 // EBUSY-capable since #2168
     R("scePthreadCondSignal", k_cond_signal);
     R("scePthreadCondBroadcast", k_cond_broadcast);
-    R("scePthreadCondWait", k_cond_wait);
+    R("scePthreadCondWait", k_sce_cond_wait);   // reports its wait since #1983 (was always 0)
     R("scePthreadCondTimedwait", k_cond_timedwait_sce);   // Sony: relative µs, NOT the POSIX abstime form
     // read/write locks + once (Sony + POSIX names) — real host primitives (thread-safety fix).
     R("scePthreadRwlockInit", k_sce_rwlock_init);    R("pthread_rwlock_init", k_rwlock_init);
@@ -4541,7 +4594,7 @@ void register_kernel_hle() {
     R("scePthreadGetschedparam", k_getschedparam);  R("pthread_getschedparam", k_getschedparam);
     R("scePthreadSetschedparam", k_log_setschedparam);  R("scePthreadSetprio", k_log_setprio);
     R("scePthreadGetprio", k_getprio);
-    R("scePthreadGetname", k_pthread_getname);
+    R("scePthreadGetname", k_pthread_getname);   // bare ON PURPOSE — see the block above the body
     R("scePthreadRename", k_sce_pthread_rename);
     R("scePthreadSetName", k_sce_pthread_rename);
     R("pthread_getname_np", k_pthread_getname);
@@ -4550,9 +4603,11 @@ void register_kernel_hle() {
     R("scePthreadGetstack", k_attr_getstackaddr);
     // TLS keys (POSIX + Sony names -> host pthread keys)
     R("pthread_key_create", k_key_create);   R("scePthreadKeyCreate", k_sce_key_create);
-    R("pthread_key_delete", k_key_delete);   R("scePthreadKeyDelete", k_key_delete);
+    R("pthread_key_delete", k_key_delete);   R("scePthreadKeyDelete", k_sce_key_delete);   // #1983
+    // Getspecific returns the stored VALUE, not an error code, so it must NEVER be aliased —
+    // sce_pthread_rc would rewrite a small guest pointer into 0x800200xx.
     R("pthread_getspecific", k_getspecific); R("scePthreadGetspecific", k_getspecific);
-    R("pthread_setspecific", k_setspecific); R("scePthreadSetspecific", k_setspecific);
+    R("pthread_setspecific", k_setspecific); R("scePthreadSetspecific", k_sce_setspecific); // #1983
     R("pthread_self", k_pthread_self);
     // POSIX pthread_equal — the GC compares thread ids with this while searching its
     // thread table; unimplemented (always "not equal") made every thread look unknown.

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1858,13 +1858,22 @@ HLE(k_log_attr_setschedparam) { // scePthreadAttrSetschedparam(attr, SchedParam*
 // re-derive it as support for encoding. Rename was swept on the FAMILY RULE at CONFIDENCE: MED, not
 // on its call site, and any sweep of Getname stands on identical footing.
 //
-// WHAT IT DOES ESTABLISH is narrower and cuts the other way from the older rationale: this caller is
-// a byte-for-byte structural twin of the Rename caller 0x30 bytes above it — same prologue, same
-// test/je, same movsxd, same tail-jump into the same helper, same format specifier. So #2365's
-// reason for holding Getname back ("its contract is different: lookup failures on a call whose
-// success path writes through a buffer") is NOT VISIBLE at the only call site anyone has found. That
-// is not proof the contracts match; it is the removal of the one asymmetry that was cited for them
-// differing.
+// WHAT IT DOES ESTABLISH is narrower and cuts the other way from the older rationale: this caller
+// runs the SAME INSTRUCTION SEQUENCE as the Rename caller 0x30 bytes above it — same prologue, same
+// test/je, same movsxd, same tail-jump into the same helper, same format specifier — differing only
+// in the call/lea/jump displacements, as two calls to different imports must. (An earlier wording
+// said "byte-for-byte", which is literally false and was retracted by the reviewer who coined it;
+// the claim doing the work is that the SHAPE matches, not the bytes.) So the argument for holding
+// Getname back — "its contract is different: lookup failures on a call whose success path writes
+// through a buffer" — is NOT VISIBLE at the only call site anyone has found. That is not proof the
+// contracts match; it is the removal of the one asymmetry that was cited for them differing.
+//
+// Attribution, checked rather than assumed: that contract argument is stated in the Rename block
+// later in this file (#2382). **#2365's PR body gives a DIFFERENT reason** — that applying the rule
+// makes `test_pthread_names` fail, because the test asserts the bare values. So the blocker #2365
+// actually recorded is the test pins, which is precisely what #2595 is scoped to move. I have read
+// #2365's body, not its review thread, so do not read this as ruling out that the contract argument
+// was also made there.
 //
 // So the bare form here is the older default surviving, at CONFIDENCE: MED — not a measurement, and
 // not "unsettleable". It is not swept in #2573 because doing so moves `tests/test_pthread_names.cpp`'s
@@ -2829,7 +2838,7 @@ SCE_PTHREAD_ALIAS(k_sce_key_create,            k_key_create)
 // An earlier version of this comment read `0x%08x` as the guest naming the space it expects. It is
 // not: %08x ZERO-PADS to eight columns, so a bare 22 prints as 0x00000016 and an encoded one as
 // 0x80020016, and both render fine. `test eax,eax` above it is nonzero in either space too. So the
-// disassembly rules nothing out -- exactly the reason Getname below is not swept, applied one
+// disassembly rules nothing out -- exactly the reason Getname ABOVE is not swept, applied one
 // paragraph higher up. (Caught in review by Marlow, who checked it precisely because it was a
 // citation raising certainty in a direction already believed.)
 //

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1835,9 +1835,9 @@ HLE(k_log_attr_setschedparam) { // scePthreadAttrSetschedparam(attr, SchedParam*
 // DELIBERATELY NOT ALIASED — a DEFERRED decision (#2595), not an evidentially settled one. The
 // distinction is the whole point of this block: an earlier draft of it claimed "nothing observed can
 // settle it" and cited `0x5fac7c3` for the claim, which is not a Getname address at all — it is the
-// `lea rsi` inside the *Rename* caller, quoted 950 lines below above SCE_PTHREAD_ALIAS(
-// k_sce_pthread_rename). Anyone opening it would have landed in the wrong listing and drawn the
-// opposite conclusion. Caught in review of #2573.
+// `lea rsi` inside the *Rename* caller, quoted in the block above
+// SCE_PTHREAD_ALIAS(k_sce_pthread_rename) later in this file. Anyone opening it would have landed in
+// the wrong listing and drawn the opposite conclusion. Caught in review of #2573.
 //
 // `scePthreadGetname` is dual-registered with `pthread_getname_np` and IS fallible, so the family
 // rule that swept the rest of #2178 would take it. Re-derived from PPSA17942 for #2573 rather than

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1832,13 +1832,45 @@ HLE(k_log_attr_setschedparam) { // scePthreadAttrSetschedparam(attr, SchedParam*
     return 0;
 }
 
-// DELIBERATELY NOT ALIASED, and this is a recorded decision rather than an omission (#2178, #2365).
+// DELIBERATELY NOT ALIASED — a DEFERRED decision (#2595), not an evidentially settled one. The
+// distinction is the whole point of this block: an earlier draft of it claimed "nothing observed can
+// settle it" and cited `0x5fac7c3` for the claim, which is not a Getname address at all — it is the
+// `lea rsi` inside the *Rename* caller, quoted 950 lines below above SCE_PTHREAD_ALIAS(
+// k_sce_pthread_rename). Anyone opening it would have landed in the wrong listing and drawn the
+// opposite conclusion. Caught in review of #2573.
+//
 // `scePthreadGetname` is dual-registered with `pthread_getname_np` and IS fallible, so the family
-// rule would sweep it — but the only guest call site found (PPSA17942 `0x5fac7c3`) does `test eax,
-// eax`, where 3 and 0x80020003 are indistinguishable, so nothing observed can settle it. Its Set
-// counterpart WAS swept in #2382 because a caller there does discriminate. #1983 re-examined this
-// and found no new evidence either way, so the bare form stands until a caller that branches on the
-// value turns up; `tests/test_pthread_names.cpp` pins it with the same reasoning.
+// rule that swept the rest of #2178 would take it. Re-derived from PPSA17942 for #2573 rather than
+// inherited: How7B8Oet6k -> JMPREL[1984] -> GOT 0x94909f0 -> PLT thunk 0x669b580, whose single
+// caller is the function at 0x5fac7e0:
+//
+//   5fac7e7:  call   0x669b580              ; scePthreadGetname
+//   5fac7ec:  test   eax,eax
+//   5fac7ee:  je     0x5fac802              ; success early-out
+//   5fac7f0:  movsxd rdx,eax
+//   5fac7f3:  lea    rsi,[rip+0x223d9d1]    ; "…Failed in scePthreadGetname(), 0x%08x"
+//   5fac7fd:  jmp    0x5fa9670              ; shared log helper
+//
+// WHAT THIS DOES NOT ESTABLISH, and the trap is live because the listing looks like evidence: `%08x`
+// ZERO-PADS, so a bare 3 prints as 0x00000003 and an encoded one as 0x80020003 — both render, and
+// the `test eax,eax` is nonzero in either space. That exact reading was made once, about the Rename
+// caller, and FALSIFIED in review; the correction is recorded in the Rename block below. Do not
+// re-derive it as support for encoding. Rename was swept on the FAMILY RULE at CONFIDENCE: MED, not
+// on its call site, and any sweep of Getname stands on identical footing.
+//
+// WHAT IT DOES ESTABLISH is narrower and cuts the other way from the older rationale: this caller is
+// a byte-for-byte structural twin of the Rename caller 0x30 bytes above it — same prologue, same
+// test/je, same movsxd, same tail-jump into the same helper, same format specifier. So #2365's
+// reason for holding Getname back ("its contract is different: lookup failures on a call whose
+// success path writes through a buffer") is NOT VISIBLE at the only call site anyone has found. That
+// is not proof the contracts match; it is the removal of the one asymmetry that was cited for them
+// differing.
+//
+// So the bare form here is the older default surviving, at CONFIDENCE: MED — not a measurement, and
+// not "unsettleable". It is not swept in #2573 because doing so moves `tests/test_pthread_names.cpp`'s
+// `== 3` / `== 14` pins, and editing a passing test so it agrees with a change is exactly what #2365
+// declined to do; that edit needs a reviewer looking at it as the primary artefact. #2595 carries it,
+// with the disassembly above and what would actually settle it.
 HLE(k_pthread_getname) {
     if (!a0) return 3;    // ESRCH
     if (!a1) return 14;   // EFAULT
@@ -2477,8 +2509,11 @@ HLE(k_key_delete)    {
     return fbsd_errno(result);
 }
 // The C11 layer makes this concrete: in the shipped guest libc.prx, `_Tss_create`, `_Tss_delete` and
-// `_Tss_set` are three-instruction forwarders onto scePthreadKeyCreate / KeyDelete / Setspecific
-// respectively (verified by PLT relocation for PPSA24651). KeyCreate already encoded via
+// `_Tss_set` are 11-byte, five-instruction forwarders onto scePthreadKeyCreate / KeyDelete /
+// Setspecific respectively -- `push rbp; mov rbp,rsp; call <plt>; pop rbp; ret`, so a CALL and a
+// RET rather than a tail-jump, returning eax unexamined (verified by PLT relocation for PPSA24651;
+// an earlier wording said "three-instruction tail-call", which was wrong on both counts and is
+// corrected here because the number was checkable). KeyCreate already encoded via
 // k_sce_key_create, so one C11 family was forwarding an encoded value from one member and a bare
 // errno from the other two -- the #1873 shape, inside a single guest header's worth of API.
 SCE_PTHREAD_ALIAS(k_sce_key_delete, k_key_delete)

--- a/prosper/tests/test_kernel_signal_time.cpp
+++ b/prosper/tests/test_kernel_signal_time.cpp
@@ -71,10 +71,15 @@ int main() {
     CHECK(c2b == 0, "setcancelstate with NULL old_state -> OK (no write)");
     uint64_t c3 = setcancel(7 /*invalid*/, 0, 0, 0, 0, 0);
     // Plain errno 22, not the 0x80020016 SCE encoding (#1612). This handler is registered ONLY as the
-    // POSIX `pthread_setcancelstate`, whose contract returns an errno directly — and every other
-    // pthread entry point in the emulator (mutex, rwlock, key, cond, sem) already returns a bare
-    // FreeBSD errno from the same shared handlers. A guest comparing the result against EINVAL could
-    // never match the encoded form.
+    // POSIX `pthread_setcancelstate`, whose contract returns an errno directly. A guest comparing
+    // the result against EINVAL could never match the encoded form.
+    //
+    // This comment used to add "and every other pthread entry point in the emulator (mutex, rwlock,
+    // key, cond, sem) already returns a bare FreeBSD errno from the same shared handlers". That was
+    // true when written and is now false: #1984, #2015, #2158, #2189 and #1983 gave every FALLIBLE
+    // Sony spelling an SCE_PTHREAD_ALIAS, so the shared handlers are reached bare through the POSIX
+    // name and encoded through the Sony one. What still holds — and is the only part this assertion
+    // depends on — is that a POSIX-only spelling reports the bare errno. (#2178)
     CHECK(c3 == 22ull, "setcancelstate(invalid) -> EINVAL (POSIX contract: a plain errno)");
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -22,6 +22,10 @@
 //   M3  return the host errno instead of the FreeBSD one (#1612)         -> the EAGAIN row fails on both
 //   M4  apply the encoding to a non-error return                         -> the barrier serial-thread arm fails
 //
+//   M5  make a fallible body report 0 again (discard its result)          -> the CondWait row and
+//                                                                             its positive control
+//                                                                             fail together (#1983)
+//
 // The M3 and M4 arms matter most. M1/M2 are provoked with a null object, which yields EINVAL — and
 // EINVAL is 22 on FreeBSD, on Linux, on Darwin and on MinGW, so a null-slot arm alone cannot tell a
 // FreeBSD number from a host number. The EAGAIN row can: FreeBSD EAGAIN is 35 while the host's is
@@ -32,9 +36,11 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/sce_errno.hpp"
+#include <cerrno>
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <thread>
 
 using namespace prosper;
 
@@ -101,6 +107,12 @@ const Row kRows[] = {
     // --- condition variables ---
     {"scePthreadCondInit",           "pthread_cond_init",           "#2178"},
     {"scePthreadCondTimedwait",      nullptr,                       "#2178, in place"},
+    // Moved OUT of kInfallible by #1983. It was correctly listed there when this file was written:
+    // the body discarded its wait result and returned 0 on every path, including the path where a
+    // null slot meant no wait was attempted at all. That is a silent success, strictly worse than
+    // the bare-errno defect this file sweeps for, because a guest testing `rc == 0` is misled too.
+    // Now the body reports the wait and refuses an unusable pair, so the alias rule applies to it.
+    {"scePthreadCondWait",           "pthread_cond_wait",           "#1983, was infallible"},
     // --- read/write locks (already correct: #1984 / #2158 — these are regression guards) ---
     {"scePthreadRwlockInit",         "pthread_rwlock_init",         "#1984"},
     {"scePthreadRwlockRdlock",       "pthread_rwlock_rdlock",       "#2158"},
@@ -134,7 +146,7 @@ const Row kRows[] = {
 const char* const kInfallible[] = {
     "scePthreadMutexattrSetprotocol", "scePthreadMutexattrSetpshared", "scePthreadMutexattrDestroy",
     "scePthreadMutexDestroy", "scePthreadCondattrDestroy", "scePthreadCondDestroy",
-    "scePthreadCondSignal", "scePthreadCondBroadcast", "scePthreadCondWait",
+    "scePthreadCondSignal", "scePthreadCondBroadcast",
     "scePthreadRwlockDestroy", "scePthreadSemDestroy", "scePthreadBarrierDestroy",
     "scePthreadBarrierattrInit", "scePthreadBarrierattrDestroy", "scePthreadBarrierattrSetpshared",
 };
@@ -304,7 +316,129 @@ int main() {
         }
     }
 
-    // ===== 6. the other side of "iff": handlers that correctly have no alias ==================
+    // ===== 6. #1983: the TLS-key pair, which cannot use the null-object row convention ==========
+    // kRows provokes EINVAL with an all-zero call. That is unsafe here: a key argument of 0 is a
+    // plausible LIVE key in this process (the C++ runtime allocates keys before main), so a null-arg
+    // row could delete somebody else's key and pass by accident. Use an index far above any
+    // implementation's table instead — every host range-checks before touching anything, so the
+    // refusal is defined behaviour rather than a lucky read.
+    //
+    // These two were #2178's "raw host errno first" rows: the body returned the HOST number through
+    // BOTH spellings, so aliasing alone would have produced `0x80020000 | wrong_errno`. The
+    // fbsd_errno mapping and the alias therefore land together, as #2189 did for k_mutexattr_init.
+    //
+    // The C11 layer is what makes the pairing concrete rather than merely symmetric: in the shipped
+    // guest libc.prx (PPSA24651), `_Tss_create`, `_Tss_delete` and `_Tss_set` are three-instruction
+    // tail-call forwarders onto scePthreadKeyCreate / KeyDelete / Setspecific (resolved through the
+    // PLT relocations, NIDs geDaqgH9lTg / PrdHuuDekhY / +BzXYkqYeLE). KeyCreate already encoded, so
+    // one C11 family forwarded an encoded value from one member and a bare errno from the other two.
+    // CONFIDENCE: MED on the encoded form itself — the forwarders do not COMPARE, so no guest has
+    // been observed testing an encoded result from any of the three.
+    printf("-- TLS keys: encoded on the Sony spelling, bare on the POSIX one (#1983) --\n");
+    {
+        HleFn sce_kcreate = Hle::lookup(nid_hash("scePthreadKeyCreate"));
+        HleFn sce_kdelete = Hle::lookup(nid_hash("scePthreadKeyDelete"));
+        HleFn pos_kdelete = Hle::lookup(nid_hash("pthread_key_delete"));
+        HleFn sce_setspec = Hle::lookup(nid_hash("scePthreadSetspecific"));
+        HleFn pos_setspec = Hle::lookup(nid_hash("pthread_setspecific"));
+        HleFn pos_getspec = Hle::lookup(nid_hash("pthread_getspecific"));
+        HleFn sce_getspec = Hle::lookup(nid_hash("scePthreadGetspecific"));
+        CHECK(sce_kcreate && sce_kdelete && pos_kdelete && sce_setspec && pos_setspec &&
+                  pos_getspec && sce_getspec,
+              "the TLS-key entry points are registered under both spellings");
+        if (sce_kcreate && sce_kdelete && pos_kdelete && sce_setspec && pos_setspec &&
+            pos_getspec && sce_getspec) {
+            const uint64_t bogus = 0x7ffffffful;
+            const uint64_t posix_del = pos_kdelete(bogus, 0, 0, 0, 0, 0);
+            // Stated as a precondition rather than assumed: if a host ever accepted this, both arms
+            // below would be vacuously satisfied and would read as coverage.
+            CHECK(posix_del != 0,
+                  "precondition: this host refuses an out-of-range TLS key at all");
+            CHECK(posix_del == kBareEINVAL,
+                  "pthread_key_delete on a bogus key keeps the bare FreeBSD EINVAL (22)");
+            CHECK(sce_kdelete(bogus, 0, 0, 0, 0, 0) == kEncodedEINVAL,
+                  "scePthreadKeyDelete on a bogus key reports encoded EINVAL (0x80020016)");
+            CHECK(pos_setspec(bogus, 0x1234, 0, 0, 0, 0) == kBareEINVAL,
+                  "pthread_setspecific on a bogus key keeps the bare EINVAL (22)");
+            CHECK(sce_setspec(bogus, 0x1234, 0, 0, 0, 0) == kEncodedEINVAL,
+                  "scePthreadSetspecific on a bogus key reports encoded EINVAL");
+
+            // POSITIVE CONTROL. Without it, a body broken into "refuse everything" satisfies all
+            // four arms above.
+            //
+            // The stored value is deliberately 0x2a, BELOW 256. sce_pthread_rc passes anything with
+            // bits outside the low byte through untouched, so a large value would be identical
+            // whether or not Getspecific were aliased — and section 5's arms cannot see this either,
+            // because they never store a value. 0x2a is the only shape that discriminates: aliasing
+            // scePthreadGetspecific turns it into 0x8002002a, i.e. a guest's TLS pointer delivered
+            // as an errno. Read through BOTH spellings, since only the Sony one can be aliased.
+            uint32_t key = 0xffffffffu;
+            CHECK(sce_kcreate((uint64_t)(uintptr_t)&key, 0, 0, 0, 0, 0) == 0 && key != 0xffffffffu,
+                  "control: scePthreadKeyCreate produces a key");
+            CHECK(sce_setspec(key, 0x2a, 0, 0, 0, 0) == 0,
+                  "control: scePthreadSetspecific stores a value and reports 0");
+            CHECK(pos_getspec(key, 0, 0, 0, 0, 0) == 0x2a,
+                  "control: pthread_getspecific reads the small value back unencoded");
+            CHECK(sce_getspec && sce_getspec(key, 0, 0, 0, 0, 0) == 0x2a,
+                  "control: scePthreadGetspecific reads back 0x2a, NOT 0x8002002a — the arm that "
+                  "catches a mechanical sweep reaching a value-returning handler");
+            CHECK(sce_kdelete(key, 0, 0, 0, 0, 0) == 0,
+                  "control: scePthreadKeyDelete of a real key reports 0");
+        }
+    }
+
+    // ===== 7. #1983: scePthreadCondWait must still report SUCCESS for a real signalled wait =====
+    // The kRows row above provokes the refusal; this is its positive control, and it is the arm that
+    // separates "the handler reports its wait" from "the handler was broken into rejecting". It also
+    // covers the second defect the row cannot see: before #1983 the body returned 0 for a wait that
+    // FAILED as well as for one that succeeded, so only a success arm plus a failure arm together
+    // establish that the result is now the wait's own.
+    //
+    // No lost-wakeup race: the signaller can only take the mutex once the wait has released it.
+    printf("-- a real signalled condition wait still reports 0 through both spellings --\n");
+    {
+        HleFn sce_wait   = Hle::lookup(nid_hash("scePthreadCondWait"));
+        HleFn posix_wait = Hle::lookup(nid_hash("pthread_cond_wait"));
+        HleFn cond_init  = Hle::lookup(nid_hash("scePthreadCondInit"));
+        HleFn cond_sig   = Hle::lookup(nid_hash("scePthreadCondSignal"));
+        HleFn cond_del   = Hle::lookup(nid_hash("scePthreadCondDestroy"));
+        HleFn mtx_init   = Hle::lookup(nid_hash("scePthreadMutexInit"));
+        HleFn mtx_lock   = Hle::lookup(nid_hash("scePthreadMutexLock"));
+        HleFn mtx_unlock = Hle::lookup(nid_hash("scePthreadMutexUnlock"));
+        HleFn mtx_del    = Hle::lookup(nid_hash("scePthreadMutexDestroy"));
+        CHECK(sce_wait && posix_wait && cond_init && cond_sig && cond_del && mtx_init && mtx_lock &&
+                  mtx_unlock && mtx_del,
+              "the condition-variable family is registered under both spellings");
+        if (sce_wait && posix_wait && cond_init && cond_sig && cond_del && mtx_init && mtx_lock &&
+            mtx_unlock && mtx_del) {
+            void* cond = nullptr;
+            void* mutex = nullptr;
+            const uint64_t c = (uint64_t)(uintptr_t)&cond;
+            const uint64_t m = (uint64_t)(uintptr_t)&mutex;
+            CHECK(cond_init(c, 0, 0, 0, 0, 0) == 0 && cond, "control: a condition variable initializes");
+            CHECK(mtx_init(m, 0, 0, 0, 0, 0) == 0 && mutex, "control: a mutex initializes");
+            for (int arm = 0; arm < 2; ++arm) {
+                HleFn wait_fn = arm == 0 ? sce_wait : posix_wait;
+                CHECK(mtx_lock(m, 0, 0, 0, 0, 0) == 0, "control: the waiter takes the mutex first");
+                std::thread signaller([&] {
+                    mtx_lock(m, 0, 0, 0, 0, 0);
+                    cond_sig(c, 0, 0, 0, 0, 0);
+                    mtx_unlock(m, 0, 0, 0, 0, 0);
+                });
+                const uint64_t rc = wait_fn(c, m, 0, 0, 0, 0);
+                signaller.join();
+                CHECK(rc == 0, arm == 0
+                          ? "scePthreadCondWait reports 0 for a wait that was really signalled"
+                          : "pthread_cond_wait reports 0 for a wait that was really signalled");
+                CHECK(mtx_unlock(m, 0, 0, 0, 0, 0) == 0,
+                      "control: the wait reacquired the mutex before returning");
+            }
+            cond_del(c, 0, 0, 0, 0, 0);
+            mtx_del(m, 0, 0, 0, 0, 0);
+        }
+    }
+
+    // ===== 8. the other side of "iff": handlers that correctly have no alias ==================
     // HONEST LABEL: these arms document the contract, they do NOT discriminate. Each body returns 0
     // on every path, and `sce_pthread_rc(0)` is 0, so a speculatively added alias would be
     // invisible here. They are kept because they pin the *observable* half — that these entry

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -22,9 +22,18 @@
 //   M3  return the host errno instead of the FreeBSD one (#1612)         -> the EAGAIN row fails on both
 //   M4  apply the encoding to a non-error return                         -> the barrier serial-thread arm fails
 //
-//   M5  make a fallible body report 0 again (discard its result)          -> the CondWait row and
-//                                                                             its positive control
-//                                                                             fail together (#1983)
+//   M5  make the CondWait body report 0 again (discard its result)       -> its kRows row fails on
+//                                                                           BOTH spellings (#1983)
+//   M6  make the CondWait body REFUSE unconditionally                    -> §7's signalled-wait
+//                                                                           control fails (#1983)
+//
+// M5 and M6 are COMPLEMENTARY, and an earlier revision of this header got it wrong in the way that
+// matters most here: it claimed M5 kills §7's positive control too. It cannot. M5 makes the body
+// return 0 and §7 asserts 0, so §7 passes under M5 — the measured `FAIL (2)` is the kRows row's two
+// halves, Sony and POSIX, not §7. Conversely no kRows row can see M6: they all provoke a refusal, so
+// a body that refuses unconditionally satisfies every one of them. Neither arm covers the other, and
+// a row here claiming otherwise is worse than no row at all, because this header is exactly where a
+// future reader checks whether an arm still bites — and a false claim of coverage stops them looking.
 //
 // The M3 and M4 arms matter most. M1/M2 are provoked with a null object, which yields EINVAL — and
 // EINVAL is 22 on FreeBSD, on Linux, on Darwin and on MinGW, so a null-slot arm alone cannot tell a

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -328,9 +328,10 @@ int main() {
     // fbsd_errno mapping and the alias therefore land together, as #2189 did for k_mutexattr_init.
     //
     // The C11 layer is what makes the pairing concrete rather than merely symmetric: in the shipped
-    // guest libc.prx (PPSA24651), `_Tss_create`, `_Tss_delete` and `_Tss_set` are three-instruction
-    // tail-call forwarders onto scePthreadKeyCreate / KeyDelete / Setspecific (resolved through the
-    // PLT relocations, NIDs geDaqgH9lTg / PrdHuuDekhY / +BzXYkqYeLE). KeyCreate already encoded, so
+    // guest libc.prx (PPSA24651), `_Tss_create`, `_Tss_delete` and `_Tss_set` are 11-byte,
+    // five-instruction forwarders onto scePthreadKeyCreate / KeyDelete / Setspecific --
+    // `push rbp; mov rbp,rsp; call <plt>; pop rbp; ret`, returning eax unexamined (resolved through
+    // the PLT relocations, NIDs geDaqgH9lTg / PrdHuuDekhY / +BzXYkqYeLE). KeyCreate already encoded, so
     // one C11 family forwarded an encoded value from one member and a bare errno from the other two.
     // CONFIDENCE: MED on the encoded form itself — the forwarders do not COMPARE, so no guest has
     // been observed testing an encoded result from any of the three.
@@ -426,12 +427,19 @@ int main() {
                     mtx_unlock(m, 0, 0, 0, 0, 0);
                 });
                 const uint64_t rc = wait_fn(c, m, 0, 0, 0, 0);
+                // Release BEFORE joining, and the order is load-bearing rather than stylistic. The
+                // wait returns holding the mutex. On a SPURIOUS wake it can re-acquire before the
+                // signaller's blocked lock is ever granted, so joining first would strand the
+                // signaller inside mtx_lock while this thread holds the mutex it is waiting for --
+                // the test would HANG rather than fail. Under ctest that burns the timeout and
+                // reports as an infrastructure problem, so a real regression would be attributed to
+                // machine load instead of to this assertion.
+                CHECK(mtx_unlock(m, 0, 0, 0, 0, 0) == 0,
+                      "control: the wait reacquired the mutex before returning");
                 signaller.join();
                 CHECK(rc == 0, arm == 0
                           ? "scePthreadCondWait reports 0 for a wait that was really signalled"
                           : "pthread_cond_wait reports 0 for a wait that was really signalled");
-                CHECK(mtx_unlock(m, 0, 0, 0, 0, 0) == 0,
-                      "control: the wait reacquired the mutex before returning");
             }
             cond_del(c, 0, 0, 0, 0, 0);
             mtx_del(m, 0, 0, 0, 0, 0);


### PR DESCRIPTION
Fixes #1983
Refs #2178

## Summary

Three fallible `scePthread*` entry points still handed the guest a **bare** FreeBSD errno — or, in
one case, no error at all — where every other libkernel entry point hands it
`0x8002_0000 | errno`. One of them, `scePthreadCondWait`, was worse than the encoding defect the
issue tracks: it reported **success for a wait that failed, and for a wait that never happened**.

This also closes the last two rows of #2178's remaining group. After it, every handler in that
issue's table is either aliased or deliberately, and now visibly, not.

## The failure scenario

`k_cond_wait` was:

```cpp
{ auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
  if (c && m) { (void)interruptible_cond_wait(...); } }
return 0;
```

Two distinct ways that reports success wrongly:

1. **The result was discarded.** A wait that failed was reported to the guest as *signalled*.
2. **A null cond or mutex slot skipped the wait entirely** and still returned 0 — no wait was ever
   attempted. A predicate loop is then told a condition fired when nothing was waited on, so it
   either spins or proceeds on unsatisfied state.

Path 2 is the worse of the two, and neither is visible to a guest that only tests `rc == 0` —
unlike the bare-errno defect, this one misleads that guest as well.

**The equivalence with `k_cond_timedwait` is mechanical, not adjacency**, and that is worth stating
precisely because "the sibling already does this" would otherwise be the weakest sentence in the
argument. Its null-deadline branch makes the *same call*: same helper, same
`GuestWaitKind::ConditionSequence`, same `source = 0`, same `nullptr` mutex_state, same
`kGuestMutexCondWaitBookkeeping` — and returns `fbsd_errno(rc)`. The two are identical **by
construction**, not merely similar. One of them discarded that value and the other did not.

`scePthreadKeyDelete` and `scePthreadSetspecific` returned the **raw host errno**, unmapped,
through *both* spellings — #2178's finding 1, the #1612 shape rather than the #1984 one. Their
sibling `scePthreadKeyCreate` already routed through `fbsd_errno` and already encoded.

## Behavioural contract

* A Sony spelling on a **fallible** body reports `0x8002_0000 | <FreeBSD errno>`.
* The POSIX spelling registered on that same body reports the **bare** FreeBSD errno.
* A handler that returns a **value** (`Self`, `Equal`, `Getspecific`) is never aliased.
* Where a body returns a host errno, the `fbsd_errno` mapping lands in the **same commit** as the
  alias — encoding a host number yields `0x80020000 | wrong_errno`, which is worse than the bare
  value it replaces (#2178's explicit instruction, and what #2189 did for `k_mutexattr_init`).

## Handler table

Every changed and deliberately-unchanged entry point, with the NID from the 3.20 firmware dump
(`libkernel.c`) and whether a POSIX spelling shares the body.

| Sony spelling | NID | POSIX spelling on the same body | before | after |
| --- | --- | --- | --- | --- |
| `scePthreadCondWait` | `WKAXJ4XBPQ4` | `pthread_cond_wait` (`Op8TBGY5KHg`) | **always `0`** — failed wait and no-wait-at-all alike | Sony: `0x8002_0000\|errno`, `0x80020016` for a null cond/mutex slot. POSIX: bare errno, `22` for the same |
| `scePthreadKeyDelete` | `PrdHuuDekhY` | `pthread_key_delete` (`6BpEZuDT7YI`) | raw **host** errno through both spellings | Sony: encoded FreeBSD errno. POSIX: bare FreeBSD errno |
| `scePthreadSetspecific` | `+BzXYkqYeLE` | `pthread_setspecific` (`WrOLvHU0yQM`) | raw **host** errno through both spellings | Sony: encoded FreeBSD errno. POSIX: bare FreeBSD errno |
| `scePthreadGetname` | `How7B8Oet6k` | `pthread_getname_np` | bare `3` / `14` | **unchanged** — see below |
| `scePthreadGetspecific` | `eoht7mQOCmo` | `pthread_getspecific` (`0-KXaS70xy4`) | value return, no alias | **unchanged**, and now has a discriminating arm |

### `scePthreadGetname` is deliberately NOT swept — and this section was WRONG in the first revision

**Review rejected this PR on exactly this paragraph, correctly.** It cited `0x5fac7c3` as the Getname
call site. That is not a Getname address: it is the `lea rsi` **inside the `scePthreadRename`
caller**, quoted verbatim 950 lines lower in the same file where #2382 recorded it. Anyone opening it
to check would have landed in the Rename listing and drawn the opposite conclusion — the #2049 → #2052
shape, shipping *inside a code comment*, which is where the next reader stops looking.

Re-derived from `PPSA17942` rather than taking the correction on trust —
`How7B8Oet6k` → `JMPREL[1984]` → GOT `0x94909f0` → PLT thunk `0x669b580` → its single caller at
`0x5fac7e0`:

```asm
5fac7e7:  call   0x669b580              ; scePthreadGetname
5fac7ec:  test   eax,eax
5fac7ee:  je     0x5fac802              ; success early-out
5fac7f0:  movsxd rdx,eax
5fac7f3:  lea    rsi,[rip+0x223d9d1]    ; "E2016102603B:Failed in scePthreadGetname(), 0x%08x"
5fac7fd:  jmp    0x5fa9670              ; shared log helper
```

The **same instruction sequence** as the Rename caller `0x30` bytes above it — differing only in the
call/lea/jump displacements, as two calls to different imports must. *(An earlier revision of this
body, and of the code comment, said "byte-for-byte structural twin". Literally false; retracted by
the reviewer who coined it, and corrected in both places. The claim doing the work is that the SHAPE
matches, not the bytes.)*

**One thing the review asked for is deliberately NOT in the new comment, and this is the one point I
am pushing back on.** The suggested wording was that the caller printing `0x%08x` is *"the same signal
that settled Rename"*. That is false in this repository's own record: the `%08x` reading was made
once, about the Rename caller, and **falsified in review** — `%08x` zero-pads, so a bare `3` prints
`0x00000003` and an encoded one `0x80020003`, and `test eax,eax` is nonzero in either space. The
correction is recorded in `hle_kernel.cpp` above `SCE_PTHREAD_ALIAS(k_sce_pthread_rename, …)`, which
also states that **Rename was swept on the FAMILY RULE at `CONFIDENCE: MED`**, explicitly "not on any
evidence specific to these two". Writing the `%08x` argument into the code would have re-introduced an
error already caught once here — the same failure the finding is about, pointed the other way.

What the listing *does* establish is narrower and does go in: the one known consumer treats Getname's
result **exactly** as it treats Rename's, so #2365's stated reason for holding Getname back — "its
contract is different: lookup failures on a call whose success path writes through a buffer" — is not
visible at the only call site anyone has found. Not proof the contracts match; the removal of the one
asymmetry that was cited.

**Attribution, checked rather than assumed:** that contract argument is stated in the **Rename code
block (#2382)**, not in #2365. **#2365's PR body gives a different reason** — applying the rule makes
`test_pthread_names` fail, because the test asserts the bare values. So the blocker #2365 actually
recorded is the test pins, which is exactly what #2595 is scoped to move. (Body read, not the review
thread — so this does not rule out the contract argument also appearing there.)

So: **deferred, `CONFIDENCE: MED` on the bare form, not "unsettleable"**. Sweeping it moves
`test_pthread_names.cpp`'s `== 3` / `== 14` pins, and editing a passing test so it agrees with a
change is what #2365 declined to do — that edit needs a reviewer looking at it as the primary
artefact. Filed as **#2595** with the disassembly and what would actually settle it.

## Evidence, and what it does and does not establish

I re-derived the contract rather than inheriting it, and ran a **positive control first**:
`prosper/tools/il2cpp/prx_to_elf.py` on `PPSA24651`'s `sce_module/libc.prx`, `self_dump
--find-symbol` for the export, `tools/re/edis.py` to disassemble, plus a JMPREL walk to resolve each
PLT stub to its imported NID.

Control — the two comparisons this project already records both reproduce exactly:

```
_Mtx_lock  @0x5e80  ->  call <plt scePthreadMutexLock 9UK1vLZQft4>
                        cmp  eax,0x8002000b            ; encoded EDEADLK
_Cnd_timedwait @0x5680 -> call <plt scePthreadCondTimedwait BmMjYxmew1w>
                        cmp  eax,0x8002003c            ; encoded ETIMEDOUT
                        cmp  ecx,0x80020001            ; encoded EPERM
```

**The new finding, and it cuts against the change rather than for it:**

```
_Cnd_wait  @0x5670  ->  push rbp; mov rbp,rsp
                        call <plt scePthreadCondWait WKAXJ4XBPQ4>
                        xor  eax,eax                   ; DISCARDS the result
                        pop  rbp; ret
```

So the C11 layer neither confirms nor contradicts the encoding for `scePthreadCondWait`. The
encoded form is an extrapolation from the libkernel-wide convention, not a measurement.
**`CONFIDENCE: MED`,** recorded in the code above the alias, with instructions not to raise it
without a caller that compares. Two consequences worth stating:

* The C11 path **cannot regress** from this change, because it ignores the value.
* Prosper's own `_Cnd_wait` (`m_cnd_wait`, `hle_kernel_time.cpp`) returning `0` unconditionally is
  therefore **correct and is left alone** — there the unconditional 0 is the shipped contract, not
  a defect. That distinction is now a comment in `k_cond_wait`.

For the TLS keys the evidence is structural rather than a comparison: `_Tss_create`, `_Tss_delete`
and `_Tss_set` are **11-byte, five-instruction** forwarders onto `scePthreadKeyCreate` / `KeyDelete` /
`Setspecific` — `push rbp; mov rbp,rsp; call <plt>; pop rbp; ret`, so a CALL and a RET rather than a
tail-jump, returning `eax` unexamined (PLT indices `0x54`/`0x55`/`0x56`, NIDs `geDaqgH9lTg` /
`PrdHuuDekhY` / `+BzXYkqYeLE`). *An earlier revision of this body said "three-instruction tail-call",
wrong on both counts; the conclusion it supports is unaffected.* KeyCreate already encoded, so one C11 family was forwarding an encoded value from
one member and a bare errno from the other two — the #1873 shape inside a single guest header's
worth of API. They do not *compare*, so this too is `CONFIDENCE: MED`.

## Pinned expectations changed — named explicitly

**`prosper/tests/test_pthread_error_encoding.cpp`: `scePthreadCondWait` moves from `kInfallible`
into `kRows`.** It was correctly in `kInfallible` when written — the body genuinely returned 0 on
every path. It is fallible now, so the alias rule applies and the row asserts the Sony/POSIX pair.
No other existing expectation is changed anywhere. In particular `test_sce_errno.cpp`'s
`scePthreadSemTrywait` pin is **already** the encoded `0x80020023` (it was updated by #2189); the
issue text describing it as a bare `35` is stale.

`prosper/tests/test_kernel_signal_time.cpp` gets a comment-only correction (#2178's "also, a stale
comment" item): its claim that "every other pthread entry point ... returns a bare FreeBSD errno"
was true when written and has been false since #1984.

## Tests, and the mutation arm for each

All in `test_pthread_error_encoding.cpp`, the table-driven harness #2178's handoff names.
Each failure arm is paired with a **positive control**, because every arm here is satisfied just as
well by a handler broken into "refuse everything".

**A test that could HANG rather than fail, fixed in review.** The signalled-wait control joined the
signaller thread while the main thread still held the re-acquired mutex. On a *spurious* wake the
wait can re-acquire before the signaller's blocked `mtx_lock` is ever granted, stranding it — the
test would hang, not fail. Under ctest that burns the timeout and reports as an infrastructure
problem, so on a box that regularly runs at load 30+ a real regression would have been attributed to
contention. The unlock now happens **before** the join; the ordering is load-bearing and says so in
the code. All mutation arms were re-run after the reorder, since reordering control flow around
assertions can silently stop them discriminating.

Mutation arms — each run by reverting exactly one piece of the fix, rebuilding, and re-running:

| # | mutation | result |
| --- | --- | --- |
| M1 | `R("scePthreadCondWait", k_cond_wait)` — alias dropped, body fix kept | **FAIL (1)** `scePthreadCondWait -> encoded EINVAL 0x80020016 (got 0x16)` |
| M2 | `R("pthread_cond_wait", k_sce_cond_wait)` — POSIX spelling wrongly aliased too | **FAIL (1)** `pthread_cond_wait -> bare EINVAL 22 (got 2147614742)` |
| M3 | both TLS-key aliases dropped | **FAIL (2)** `scePthreadKeyDelete` / `scePthreadSetspecific` encoded-EINVAL arms |
| M4 | `scePthreadGetspecific` wrongly aliased (a VALUE return) | **FAIL (1)** `scePthreadGetspecific reads back 0x2a, NOT 0x8002002a` |
| M5 | `k_cond_wait` body reports 0 again (discards its result) | **FAIL (2)** — the kRows row's two halves: `got 0x0` (Sony) / `got 0` (POSIX) |
| M6 | `k_cond_wait` body **refuses unconditionally** | **FAIL (2)** — §7's signalled-wait control, both spellings |
| baseline / restored | — | **PASS** |

**M5 and M6 are complementary, and the first revision of this PR claimed otherwise.** The test file's
`WHAT EACH ARM KILLS` header said M5 kills §7's positive control as well. It cannot: M5 makes the body
return 0 and §7 asserts 0, so §7 passes under M5 — the measured `FAIL (2)` was always the kRows row's
two halves. M6 is the arm that actually kills §7, and no kRows row can see it, since they all provoke a
refusal. Both rows are now measured, not asserted. Flagged in review as this session's exact defect
family: **an artifact telling a reader that coverage exists where it does not**, which is worse than no
row at all because it stops the next person looking.

M4 needed the control to store `0x2a`, **below 256**: `sce_pthread_rc` passes anything with bits
outside the low byte through untouched, so a larger stored value is identical whether or not
Getspecific is aliased. The first draft used `0xabcd` and M4 passed — the arm was void. Recorded
because it is exactly the "a discriminator that cannot show its lever moved" trap.

**One change has no discriminating arm, and I am not going to claim otherwise.** Routing
`k_key_delete` / `k_setspecific` through `fbsd_errno` is unobservable on this host: the only errno
either can produce is `EINVAL`, which is 22 on FreeBSD *and* on Linux *and* on MinGW. Reverting just
that hunk (M6) leaves the suite green. It is kept because #2178 requires the mapping to land with
the alias and because leaking a raw host number is the #1612 defect — but it is correctness by
construction, not by measurement.

### The fix makes #2170's own diagnostic honest

`pt_report_destroyed` prints *"[pthread] use-after-destroy on a %s: refused with EINVAL"*
(`hle_kernel.cpp:383`). `ensure_cond` / `ensure_mutex` call it and then return `nullptr`. Until this
change, `k_cond_wait` responded to that `nullptr` with **0** — so for this one entry point the log
line was **false**: the diagnostic announced a refusal while the guest was told its condition had
been signalled. Anyone debugging a use-after-destroy through `scePthreadCondWait` was reading a
message that contradicted the return value. The fix makes the instrument tell the truth.

## Deliberately unaffected

* Every POSIX spelling keeps its bare errno; the pair arms are what prove it.
* `scePthreadCondSignal` / `Broadcast` remain unaliased — still 0 on every path.
* `scePthreadGetname`, `Self`, `Equal`, `Getspecific` — unchanged, for the reasons above.
* No GPU, renderer, compute or shader code is touched.

## Risks

1. **`scePthreadCondWait` can now return non-zero to a guest that never saw one — but on Linux/macOS
   the reachable non-zero set is very nearly empty.** `kGuestMutexCondWaitBookkeeping` is `nullptr`
   off Windows (`hle_kernel.cpp:522`), so the body reduces to `pthread_cond_wait`: a spurious wake
   returns 0, POSIX forbids `EINTR`, there is no deadline, and the interruption/quarantine paths are
   all `#ifdef _WIN32`. The only non-zero arrives **through the mutex** — `EPERM` for a non-owner,
   reachable because `k_mutex_init` forces `PTHREAD_MUTEX_ERRORCHECK` **on every host, unguarded**
   (`:668`). So on a correct guest this is inert; on an incorrect one it now says so.
   *(Established by the reviewer and verified against source here.)*
2. **Windows adds one member of that set which is prosper's condition, not the guest's.** If
   `cond_slot_for` returns null — the 4096-entry table full (`sync_futex.cpp:131`), or 64 contended
   attempts exhausted (`:172`) — `interruptible_cond_wait` returns `ENOMEM`, which now reaches the
   guest as `0x8002000c`. Previously it was swallowed into a silent 0, i.e. a spin. **Converting an
   emulator capacity limit into a guest-visible error is a real behaviour change**, and it is stated
   here rather than left to be discovered. Arguably the honest direction — a spin is not better — but
   it is a change, and it is Windows-only.
3. **`CONFIDENCE: MED` on all three encodings**, unchanged from #2178's label and not raised by this
   PR. The `_Cnd_wait` disassembly above is the reason it cannot be raised. The reviewer went looking
   for grounds to raise it and found none — which is a stronger position than never having been
   challenged, given that the failure mode this project keeps hitting is an author being talked *up*
   from a correct label.
4. The null-slot EINVAL is new behaviour for `pthread_cond_wait` as well as for the Sony spelling.
   That is the same answer `k_cond_timedwait` already gives for the same input.

## Build / test

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4                     # exit 0
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 246`, exit 0** (Linux, in the `ps5ys` distrobox).

Note on the order of work: with the source fix applied and the test file still at master's version,
`pthread_error_encoding` fails on its own — `scePthreadCondWait -> 0 (no failure path, so no alias)
got 0x80020016`. That is master's own assertion going red for exactly the right reason, and it is
what identified the pinned expectation that had to move.
