### PR TITLE
fix(app): size the library descriptor pool from the library, and never allocate a set out of a full pool

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -603,6 +603,16 @@ if(TARGET prosper_core)
   target_include_directories(test_prosper_app_library_nav PRIVATE frontends/prosper-app)
   add_test(NAME prosper_app_library_nav COMMAND test_prosper_app_library_nav)
 
+  # Library descriptor-pool sizing and the exhaustion rule (#1649): the pool must follow the title count
+  # instead of a fixed 256, and a set must never be allocated out of a full pool — ImGui's backend writes
+  # to whatever vkAllocateDescriptorSets returned without checking it. Pure arithmetic plus a fake
+  # allocator that records whether it ran, so no Vulkan, no ImGui and no window.
+  add_executable(test_prosper_app_library_descriptor_budget
+                 frontends/prosper-app/test_library_descriptor_budget.cpp)
+  target_include_directories(test_prosper_app_library_descriptor_budget PRIVATE frontends/prosper-app)
+  add_test(NAME prosper_app_library_descriptor_budget
+           COMMAND test_prosper_app_library_descriptor_budget)
+
   # Library background art and focus music (#1630): DDS/BC7 and RIFF/ATRAC9 container validation plus
   # the debounce, two-stage fade and LRU policy. Pure byte and arithmetic work — the containers are
   # synthesized in the test, so no dump, no GPU and no audio device is involved.

--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -165,6 +165,25 @@ command-line path keeps working.
 Selection movement lives in `library_nav.hpp`, which is pure and unit-tested, so the grid's behaviour is
 covered in ordinary CI rather than only by someone pressing arrow keys.
 
+#### Descriptor capacity
+
+Covers and background art are Dear ImGui textures, and every one of them costs a descriptor set out of
+the library's single pool. The pool is sized from the library — one set per title, plus an allowance for
+the background cache and ImGui's own font atlas — and is **grown** when a rescan finds more titles than
+it holds, so pointing the app at a bigger folder does not cost the extra titles their art. The sizing and
+the accounting are pure and unit-tested in `library_descriptor_budget.hpp`.
+
+When the pool genuinely cannot fit everything, the shortfall costs one image per title and nothing more:
+prosper checks the budget *before* asking ImGui for a set, because `ImGui_ImplVulkan_AddTexture` writes to
+whatever `vkAllocateDescriptorSets` returned without checking it, and on a full pool that is
+`VK_NULL_HANDLE`. Titles past the limit fall back to the same labelled button a title with an undecodable
+`icon0.png` gets, and one line is logged.
+
+`PROSPER_LIBRARY_POOL_SETS=<n>` caps the pool at `n` sets and stops it from growing. It exists to make
+that exhaustion path reachable without owning hundreds of games — set it below your library's title count
+and the titles past the cap should lose their covers, and nothing else. It is a reproduction knob, not a
+tuning one; leave it unset for normal use.
+
 ## Options
 
 - `--dump <app0>` — boot and display the PS5 title at this app0 directory (positional path also works).

--- a/prosper/frontends/prosper-app/library_descriptor_budget.hpp
+++ b/prosper/frontends/prosper-app/library_descriptor_budget.hpp
@@ -1,0 +1,132 @@
+#pragma once
+// library_descriptor_budget.hpp — how big the library view's ONE Vulkan descriptor pool has to be, and
+// the accounting that keeps a set from being allocated out of a pool that has no room left (#1649).
+//
+// Pure: no Vulkan, no SDL, no ImGui. That is deliberate — the sizing arithmetic and the exhaustion rule
+// are the parts that can be wrong in a way nobody notices until someone owns 250 games, and they are the
+// parts a unit test can actually pin down. library_ui.cpp and library_media.cpp own the handles.
+//
+// WHY A BUDGET AND NOT A RETURN-VALUE CHECK
+//
+// The obvious guard — call ImGui_ImplVulkan_AddTexture() and check what it returned — is too late. That
+// function allocates a descriptor set, ignores the VkResult beyond a diagnostic hook, and then passes the
+// set straight into vkUpdateDescriptorSets(). vkAllocateDescriptorSets() is required to write
+// VK_NULL_HANDLE into every output slot when it fails, so on an exhausted pool the update is issued with
+// dstSet == VK_NULL_HANDLE: a validation error and undefined behaviour that has already happened by the
+// time the caller sees the return value. third_party/imgui is vendored verbatim and must not be patched,
+// so the only correct place to stop is BEFORE the call — hence acquire_texture_set() below, which never
+// invokes the allocator once the pool's sets are spoken for.
+//
+// THREADING: a DescriptorBudget is not synchronized. Both users are on the UI thread — the media layer's
+// threading contract (library_media.hpp) already puts every Vulkan call there.
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+namespace prosper::frontend {
+
+// ImGui's Vulkan backend allocates ONE combined-image-sampler set from the same pool for its font atlas,
+// and rebuilds it destroy-then-create (imgui_impl_vulkan.cpp's ImGui_ImplVulkan_CreateFontsTexture), so
+// exactly one is live at a time. The backend's own IMGUI_IMPL_VULKAN_MINIMUM_IMAGE_SAMPLER_POOL_SIZE is
+// 1 for the same reason. prosper never allocates this one, so it is reserved out of the budget rather
+// than counted in it.
+inline constexpr uint32_t kLibraryImGuiReservedSets = 1;
+
+// Upper bound for the background-art layer (#1630), which shares the pool with the covers:
+//   kBackgroundCacheCapacity (3) resident
+// + 1 inserted before the LRU evicts, in insert_background()
+// + kRetireFrames (3) evicted-but-not-yet-collected, held so an in-flight frame can still sample them
+// + 1 slack
+// At most one background is evicted per frame (one upload is in flight at a time and it is published in
+// poll_upload), and collect_retired() runs at the top of every update(), so the live peak is nearer 6;
+// the two spare sets cost nothing and leave room for a change in that cadence. Stated as a literal
+// rather than derived from launcher_media.hpp's constants so this header stays free of every other
+// dependency; the arithmetic is written out so a change there is checkable by eye.
+inline constexpr uint32_t kLibraryBackgroundSets = 8;
+
+// A floor, so a run that starts on an empty or tiny games folder still has room for the font atlas, the
+// backgrounds and a handful of covers before the first grow.
+inline constexpr uint32_t kLibraryMinPoolSets = 32;
+
+// A ceiling, so a directory full of junk cannot ask the driver for an absurd pool. Past this the covers
+// degrade one image at a time through the budget below, which is the same graceful path a title with an
+// undecodable icon0.png already takes. 8192 covers would need far more VRAM than any of them can have.
+inline constexpr uint32_t kLibraryMaxPoolSets = 8192;
+
+// maxSets (and the matching descriptorCount) for a library of `title_count` titles: one set per cover,
+// plus the background allowance, plus ImGui's own, clamped to [kLibraryMinPoolSets, kLibraryMaxPoolSets].
+// Saturating, so a nonsense count cannot wrap into a tiny pool.
+inline constexpr uint32_t library_descriptor_pool_sets(size_t title_count) {
+    const size_t overhead = static_cast<size_t>(kLibraryBackgroundSets) + kLibraryImGuiReservedSets;
+    size_t want = title_count > SIZE_MAX - overhead ? SIZE_MAX : title_count + overhead;
+    if (want < kLibraryMinPoolSets) want = kLibraryMinPoolSets;
+    if (want > kLibraryMaxPoolSets) want = kLibraryMaxPoolSets;
+    return static_cast<uint32_t>(want);
+}
+
+// How many sets of a pool of `pool_sets` prosper itself may allocate — everything except ImGui's own.
+inline constexpr uint32_t library_texture_budget(uint32_t pool_sets) {
+    return pool_sets > kLibraryImGuiReservedSets ? pool_sets - kLibraryImGuiReservedSets : 0;
+}
+
+// Counts the descriptor sets prosper has taken out of the library's pool. Covers and backgrounds draw
+// from the same allowance, which is the whole point: they share one pool, so only one number can tell
+// either of them that the next allocation would fail.
+class DescriptorBudget {
+public:
+    // Start over with a new capacity. Used at init and after the pool is regrown; `used` returns to 0
+    // because a regrow releases every set prosper held.
+    void reset(uint32_t capacity) {
+        capacity_ = capacity;
+        used_ = 0;
+    }
+
+    // Take one slot. False means the pool is full and the caller MUST NOT allocate.
+    bool acquire() {
+        if (used_ >= capacity_) return false;
+        ++used_;
+        return true;
+    }
+
+    // Give one back. Clamped rather than wrapping: an unbalanced release is a bug, and a wrapped `used_`
+    // would turn it into a silently over-allocating pool instead of a merely wrong counter.
+    void release() {
+        if (used_ > 0) --used_;
+    }
+
+    uint32_t capacity() const { return capacity_; }
+    uint32_t used() const { return used_; }
+    uint32_t available() const { return capacity_ > used_ ? capacity_ - used_ : 0; }
+
+private:
+    uint32_t capacity_ = 0;
+    uint32_t used_ = 0;
+};
+
+// Allocate a descriptor set through `add`, but ONLY if the budget has room — see the header comment for
+// why checking `add`'s result instead is too late. Returns `none` without calling `add` on an exhausted
+// budget. Templated on the handle type so this header stays Vulkan-free and the rule is testable with a
+// fake allocator that records whether it ran.
+//
+// `add` failing for some other reason (out of device memory, say) still returns `none`; the slot is given
+// straight back, so a transient failure does not permanently shrink the pool's usable capacity.
+template <class Set, class AddFn>
+Set acquire_texture_set(DescriptorBudget& budget, Set none, AddFn&& add) {
+    if (!budget.acquire()) return none;
+    Set set = std::forward<AddFn>(add)();
+    if (set == none) budget.release();
+    return set;
+}
+
+// The mirror of acquire_texture_set: hand `set` to `remove`, clear it, and return its slot. A null handle
+// is a no-op, so this is safe on a half-built resource and safe to call twice.
+template <class Set, class RemoveFn>
+void release_texture_set(DescriptorBudget& budget, Set& set, Set none, RemoveFn&& remove) {
+    if (set == none) return;
+    std::forward<RemoveFn>(remove)(set);
+    set = none;
+    budget.release();
+}
+
+} // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/library_media.cpp
+++ b/prosper/frontends/prosper-app/library_media.cpp
@@ -77,8 +77,10 @@ std::string read_file_bytes(const std::string& path) {
 LibraryMedia::~LibraryMedia() { shutdown(); }
 
 bool LibraryMedia::init(VkPhysicalDevice phys, VkDevice device, VkQueue queue, uint32_t queue_family,
-                        VkSampler sampler, bool music_enabled, float music_gain) {
+                        VkSampler sampler, DescriptorBudget* budget, bool music_enabled,
+                        float music_gain) {
     phys_ = phys; device_ = device; queue_ = queue; qfamily_ = queue_family; sampler_ = sampler;
+    budget_ = budget;
     musicGain_ = music_gain;
 
     // BC7 needs both the device feature and the format itself usable as a sampled image. Checking only
@@ -198,22 +200,50 @@ void LibraryMedia::shutdown() {
     recent_.reset();
 
     if (device_) {
-        // An upload may still be in flight; its images and staging memory cannot be freed under it.
-        if (pending_.active && uploadFence_)
-            vkWaitForFences(device_, 1, &uploadFence_, VK_TRUE, UINT64_MAX);
-        vkDeviceWaitIdle(device_);
-        if (pending_.active) {
-            if (pending_.staging)    vkDestroyBuffer(device_, pending_.staging, nullptr);
-            if (pending_.stagingMem) vkFreeMemory(device_, pending_.stagingMem, nullptr);
-            destroy_background(pending_.bg);
-            pending_ = PendingUpload{};
-        }
-        collect_retired(true);   // the device is idle here, so anything still retired can go now
-        destroy_all_backgrounds();
+        release_backgrounds();
         if (uploadFence_) { vkDestroyFence(device_, uploadFence_, nullptr); uploadFence_ = VK_NULL_HANDLE; }
         if (cmdPool_) { vkDestroyCommandPool(device_, cmdPool_, nullptr); cmdPool_ = VK_NULL_HANDLE; cmd_ = VK_NULL_HANDLE; }
     }
     ready_ = false;
+}
+
+// Every GPU object this layer holds, released; the worker, the audio stream and the music state are
+// deliberately untouched. shutdown() calls this and then tears down the fence and command pool as well;
+// LibraryUi calls it on its own when the descriptor pool is replaced by a larger one, which invalidates
+// every set allocated from the old pool (#1649).
+void LibraryMedia::release_backgrounds() {
+    if (!device_) return;
+    // An upload may still be in flight; its images and staging memory cannot be freed under it.
+    if (pending_.active && uploadFence_)
+        vkWaitForFences(device_, 1, &uploadFence_, VK_TRUE, UINT64_MAX);
+    vkDeviceWaitIdle(device_);
+    if (pending_.active) {
+        if (pending_.staging)    vkDestroyBuffer(device_, pending_.staging, nullptr);
+        if (pending_.stagingMem) vkFreeMemory(device_, pending_.stagingMem, nullptr);
+        destroy_background(pending_.bg);
+    }
+    pending_ = PendingUpload{};
+    collect_retired(true);   // the device is idle here, so anything still retired can go now
+    destroy_all_backgrounds();
+
+    // Forget what was on screen. backdrop() looks the displayed root up in cache_, which is now empty, so
+    // it already reports "nothing" — but leaving focusRoot_ set would make the next set_focus() with the
+    // same title a no-op and that title would never get its art back. Clearing it makes the very next
+    // update() re-request the art that was just dropped. The MUSIC state is not touched: the track is
+    // host memory, has nothing to do with the descriptor pool, and stopping it here would make the user
+    // hear a folder rescan.
+    focusRoot_.clear();
+    focusPending_ = false;
+    shownRoot_.clear();
+    outgoingRoot_.clear();
+    transitionActive_ = false;
+    incomingReady_ = true;
+    lastDrawn_.clear();
+    deferred_.reset();   // decoded bytes for an upload that would land in the pool that is going away
+    // Everything the worker is still carrying belongs to the state just dropped, so retire the
+    // generation: claim_result() then discards it instead of installing a track for a title that is no
+    // longer focused and uploading art nothing will draw. The next set_focus() asks for both again.
+    ++generation_;
 }
 
 // --- worker ---------------------------------------------------------------------------------------
@@ -677,10 +707,16 @@ void LibraryMedia::poll_upload(uint64_t now_ms) {
     ivi.format = pending_.format;
     ivi.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     bool ok = vkCreateImageView(device_, &ivi, nullptr, &bg.view) == VK_SUCCESS;
-    if (ok) {
-        bg.set = ImGui_ImplVulkan_AddTexture(sampler_, bg.view, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
-        ok = bg.set != VK_NULL_HANDLE;
+    if (ok && budget_) {
+        // Budget first: covers and backgrounds share one pool, and ImGui_ImplVulkan_AddTexture writes to
+        // whatever vkAllocateDescriptorSets returned without checking it, so an exhausted pool must be
+        // detected BEFORE the call rather than from its result (#1649).
+        bg.set = acquire_texture_set(*budget_, VkDescriptorSet(VK_NULL_HANDLE), [&] {
+            return ImGui_ImplVulkan_AddTexture(sampler_, bg.view,
+                                               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        });
     }
+    ok = ok && bg.set != VK_NULL_HANDLE;
     if (!ok) {
         fprintf(stderr, "[library] could not publish the background for %s\n", pending_.root.c_str());
         destroy_background(bg);
@@ -731,7 +767,16 @@ void LibraryMedia::collect_retired(bool force) {
 }
 
 void LibraryMedia::destroy_background(Background& bg) {
-    if (bg.set)    ImGui_ImplVulkan_RemoveTexture(bg.set);
+    // The set goes back to the SHARED pool budget, so a released background makes room for a cover.
+    if (budget_) {
+        release_texture_set(*budget_, bg.set, VkDescriptorSet(VK_NULL_HANDLE),
+                            [](VkDescriptorSet s) { ImGui_ImplVulkan_RemoveTexture(s); });
+    } else if (bg.set) {
+        // Unreachable today — without a budget no set is ever taken — but freeing it unconditionally
+        // means a future caller that skips the budget cannot leak a descriptor here.
+        ImGui_ImplVulkan_RemoveTexture(bg.set);
+        bg.set = VK_NULL_HANDLE;
+    }
     if (bg.view)   vkDestroyImageView(device_, bg.view, nullptr);
     if (bg.image)  vkDestroyImage(device_, bg.image, nullptr);
     if (bg.memory) vkFreeMemory(device_, bg.memory, nullptr);

--- a/prosper/frontends/prosper-app/library_media.hpp
+++ b/prosper/frontends/prosper-app/library_media.hpp
@@ -24,6 +24,7 @@
 // in-flight load plus one queued one, and no GPU work at all for titles passed over.
 
 #include "launcher_media.hpp"
+#include "library_descriptor_budget.hpp"
 
 #include <SDL3/SDL.h>
 #include <vulkan/vulkan.h>
@@ -53,16 +54,28 @@ public:
 
     // Call once per instance; a second call without an intervening shutdown() leaks this layer's pool
     // and fence and reassigns the still-joinable worker thread, which terminates the process.
-    // `sampler` is borrowed from the library UI (same filtering as the covers). Returns false only if
-    // the Vulkan objects this layer owns could not be created. A machine with no audio device is NOT a
-    // failure — it yields a silent library, the same outcome as a title with no snd0.at9 — so check
-    // music_enabled() afterwards for the effective audio state rather than this return value.
+    // `sampler` is borrowed from the library UI (same filtering as the covers). `budget` is the library's
+    // descriptor accounting, also borrowed and non-owning: backgrounds and covers come out of ONE pool,
+    // so only a shared counter can tell either of them that the next allocation would fail (#1649). It
+    // must outlive this object — LibraryUi owns both — and is only touched on the UI thread. A null
+    // budget means no background may be registered at all, which is a silent library, not a crash.
+    // Returns false only if the Vulkan objects this layer owns could not be created. A machine with no
+    // audio device is NOT a failure — it yields a silent library, the same outcome as a title with no
+    // snd0.at9 — so check music_enabled() afterwards for the effective audio state rather than this
+    // return value.
     bool init(VkPhysicalDevice phys, VkDevice device, VkQueue queue, uint32_t queue_family,
-              VkSampler sampler, bool music_enabled, float music_gain);
+              VkSampler sampler, DescriptorBudget* budget, bool music_enabled, float music_gain);
 
     // Stop the worker, close the audio stream, destroy every image. Safe without a successful init and
     // safe to call twice. Called before a guest boots, so nothing here outlives the library view.
     void shutdown();
+
+    // Give up every descriptor set, image and staging allocation this layer holds, but keep running: the
+    // worker, the audio stream and the music state are untouched. Used when the library's descriptor
+    // pool is replaced by a larger one, which invalidates every set allocated from the old pool. The
+    // focus is cleared too, so the next set_focus() re-requests the art that was just dropped rather
+    // than seeing the same root and doing nothing. The caller must have waited for the device.
+    void release_backgrounds();
 
     bool ready() const { return ready_; }
 
@@ -177,6 +190,7 @@ private:
     VkQueue          queue_   = VK_NULL_HANDLE;
     uint32_t         qfamily_ = 0;
     VkSampler        sampler_ = VK_NULL_HANDLE;
+    DescriptorBudget* budget_ = nullptr;          // borrowed from LibraryUi; shared with the covers
     VkCommandPool    cmdPool_ = VK_NULL_HANDLE;   // this layer's own, never the UI's
     VkCommandBuffer  cmd_     = VK_NULL_HANDLE;
     VkFence          uploadFence_ = VK_NULL_HANDLE;

--- a/prosper/frontends/prosper-app/library_ui.cpp
+++ b/prosper/frontends/prosper-app/library_ui.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 
 namespace prosper::frontend {
@@ -59,29 +60,68 @@ void imgui_vk_result(VkResult r) {
 
 LibraryUi::~LibraryUi() { shutdown(); }
 
+// One combined-image-sampler set per texture, and FREE_DESCRIPTOR_SET because covers and backgrounds are
+// individually released (ImGui_ImplVulkan_RemoveTexture calls vkFreeDescriptorSets).
+VkDescriptorPool LibraryUi::create_descriptor_pool(uint32_t sets) const {
+    VkDescriptorPoolSize size{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, sets};
+    VkDescriptorPoolCreateInfo dpi{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
+    dpi.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+    dpi.maxSets = sets;
+    dpi.poolSizeCount = 1;
+    dpi.pPoolSizes = &size;
+    VkDescriptorPool pool = VK_NULL_HANDLE;
+    if (vkCreateDescriptorPool(device_, &dpi, nullptr, &pool) != VK_SUCCESS) return VK_NULL_HANDLE;
+    return pool;
+}
+
+bool LibraryUi::init_imgui_vulkan() {
+    ImGui_ImplVulkan_InitInfo vi{};
+    vi.Instance = instance_;
+    vi.PhysicalDevice = phys_;
+    vi.Device = device_;
+    vi.QueueFamily = qfamily_;
+    vi.Queue = queue_;
+    vi.DescriptorPool = pool_;
+    vi.RenderPass = renderPass_;
+    vi.MinImageCount = imageCount_;
+    vi.ImageCount = imageCount_;
+    vi.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
+    vi.CheckVkResultFn = imgui_vk_result;
+    return ImGui_ImplVulkan_Init(&vi);
+}
+
 bool LibraryUi::init(SDL_Window* window, VkInstance instance, VkPhysicalDevice phys, VkDevice device,
                      uint32_t queue_family, VkQueue queue, VkSwapchainKHR swapchain,
                      VkFormat swapchain_format, const std::vector<VkImage>& swapchain_images,
                      VkExtent2D extent) {
-    window_ = window; device_ = device; phys_ = phys; queue_ = queue; qfamily_ = queue_family;
+    window_ = window; instance_ = instance; device_ = device; phys_ = phys; queue_ = queue;
+    qfamily_ = queue_family;
     swapchain_ = swapchain;
+    imageCount_ = static_cast<uint32_t>(swapchain_images.size());
 
-    // A pool large enough for ImGui's font atlas plus one descriptor per cover. Sized from the grid,
-    // not guessed: exceeding it would silently drop covers.
-    const uint32_t kMaxTextures = 256;
-    VkDescriptorPoolSize sizes[] = {
-        { VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, kMaxTextures },
-    };
-    VkDescriptorPoolCreateInfo dpi{VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO};
-    dpi.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    dpi.maxSets = kMaxTextures;
-    dpi.poolSizeCount = 1;
-    dpi.pPoolSizes = sizes;
-    if (vkCreateDescriptorPool(device_, &dpi, nullptr, &pool_) != VK_SUCCESS) {
+    // PROSPER_LIBRARY_POOL_SETS forces a small pool so #1649's exhaustion can be reproduced without
+    // owning 250 games. Deliberately a HARD cap that a grow cannot lift: the point of the knob is to
+    // reach the path where a cover has no descriptor left, and see that it costs that cover and nothing
+    // else. Unset (the normal case) leaves the sizing entirely to the library's title count.
+    if (const char* cap = SDL_getenv("PROSPER_LIBRARY_POOL_SETS")) {
+        const long v = std::strtol(cap, nullptr, 10);
+        if (v > 0) {
+            poolCap_ = static_cast<uint32_t>(v);
+            fprintf(stderr, "[library] PROSPER_LIBRARY_POOL_SETS=%u: descriptor pool capped\n", poolCap_);
+        }
+    }
+
+    // Sized from the library, not fixed (#1649). The games are not scanned yet at this point, so this is
+    // the floor; the first set_games() grows it to fit the real title count.
+    poolSets_ = library_descriptor_pool_sets(0);
+    if (poolCap_ && poolSets_ > poolCap_) poolSets_ = poolCap_;
+    pool_ = create_descriptor_pool(poolSets_);
+    if (pool_ == VK_NULL_HANDLE) {
         fprintf(stderr, "[library] descriptor pool creation failed\n");
         shutdown();
         return false;
     }
+    budget_.reset(library_texture_budget(poolSets_));
 
     VkCommandPoolCreateInfo cpi{VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO};
     cpi.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
@@ -130,19 +170,7 @@ bool LibraryUi::init(SDL_Window* window, VkInstance instance, VkPhysicalDevice p
 
     if (!ImGui_ImplSDL3_InitForVulkan(window_)) { fprintf(stderr, "[library] SDL3 backend init failed\n"); shutdown(); return false; }
     sdlInit_ = true;
-    ImGui_ImplVulkan_InitInfo vi{};
-    vi.Instance = instance;
-    vi.PhysicalDevice = phys_;
-    vi.Device = device_;
-    vi.QueueFamily = qfamily_;
-    vi.Queue = queue_;
-    vi.DescriptorPool = pool_;
-    vi.RenderPass = renderPass_;
-    vi.MinImageCount = static_cast<uint32_t>(swapchain_images.size());
-    vi.ImageCount = static_cast<uint32_t>(swapchain_images.size());
-    vi.MSAASamples = VK_SAMPLE_COUNT_1_BIT;
-    vi.CheckVkResultFn = imgui_vk_result;
-    if (!ImGui_ImplVulkan_Init(&vi)) { fprintf(stderr, "[library] Vulkan backend init failed\n"); shutdown(); return false; }
+    if (!init_imgui_vulkan()) { fprintf(stderr, "[library] Vulkan backend init failed\n"); shutdown(); return false; }
     vulkanInit_ = true;
     ready_ = true;
 
@@ -159,7 +187,7 @@ bool LibraryUi::init(SDL_Window* window, VkInstance instance, VkPhysicalDevice p
     const char* musicEnv = SDL_getenv("PROSPER_LAUNCHER_MUSIC");
     musicToggle_ = resolve_launcher_music(musicEnv, musicToggle_, /*automated=*/stats_);
     const float gain = resolve_launcher_music_gain(SDL_getenv("PROSPER_LAUNCHER_MUSIC_VOLUME"));
-    if (!media_.init(phys_, device_, queue_, qfamily_, sampler_, musicToggle_, gain))
+    if (!media_.init(phys_, device_, queue_, qfamily_, sampler_, &budget_, musicToggle_, gain))
         fprintf(stderr, "[library] background art and music unavailable\n");
     // Mirror the EFFECTIVE state, not the request: if the audio device could not be opened the checkbox
     // must show unticked, or set_music_enabled() sees no change on the first click and swallows it.
@@ -233,6 +261,7 @@ bool LibraryUi::recreate_swapchain(VkSwapchainKHR swapchain, VkFormat format,
     vkDeviceWaitIdle(device_);
     destroy_render_target();
     swapchain_ = swapchain;
+    imageCount_ = static_cast<uint32_t>(images.size());
     if (!create_render_target(format, images, extent)) { ready_ = false; return false; }
     return true;
 }
@@ -274,17 +303,64 @@ void LibraryUi::shutdown() {
     if (renderSem_)  { vkDestroySemaphore(device_, renderSem_, nullptr);   renderSem_ = VK_NULL_HANDLE; }
     if (cmdPool_)    { vkDestroyCommandPool(device_, cmdPool_, nullptr);   cmdPool_ = VK_NULL_HANDLE; cmd_ = VK_NULL_HANDLE; }
     if (pool_)       { vkDestroyDescriptorPool(device_, pool_, nullptr);   pool_ = VK_NULL_HANDLE; }
+    poolSets_ = 0;
+    budget_.reset(0);   // nothing may be allocated until a later init() creates a pool again
     ready_ = false;
 }
 
 void LibraryUi::destroy_covers() {
     for (Cover& c : covers_) {
-        if (c.set)    ImGui_ImplVulkan_RemoveTexture(c.set);
+        release_texture_set(budget_, c.set, VkDescriptorSet(VK_NULL_HANDLE),
+                            [](VkDescriptorSet s) { ImGui_ImplVulkan_RemoveTexture(s); });
         if (c.view)   vkDestroyImageView(device_, c.view, nullptr);
         if (c.image)  vkDestroyImage(device_, c.image, nullptr);
         if (c.memory) vkFreeMemory(device_, c.memory, nullptr);
     }
     covers_.clear();
+}
+
+// Grow the descriptor pool to fit `title_count` covers. The pool handle is baked into ImGui's Vulkan
+// backend at init time and the vendored backend offers no way to swap it, so growing means creating the
+// new pool, releasing every set prosper holds out of the old one, and re-running
+// ImGui_ImplVulkan_Init — which rebuilds the font atlas and the UI pipeline against the new pool. That
+// is affordable here because this only runs when the library actually got bigger: once at startup for a
+// library above the floor, and again if the user points the app at a larger folder.
+//
+// Never shrinks. A rescan that finds FEWER games would otherwise churn the backend for nothing, and the
+// spare sets cost a few hundred bytes.
+bool LibraryUi::ensure_descriptor_capacity(size_t title_count) {
+    if (!ready_ || device_ == VK_NULL_HANDLE) return false;
+    uint32_t want = library_descriptor_pool_sets(title_count);
+    if (poolCap_ && want > poolCap_) want = poolCap_;
+    if (want <= poolSets_) return true;
+
+    // Create first, swap second: if the driver refuses the bigger pool we still have a working one, and
+    // the budget below simply keeps costing an image per title past capacity.
+    VkDescriptorPool fresh = create_descriptor_pool(want);
+    if (fresh == VK_NULL_HANDLE) {
+        fprintf(stderr, "[library] could not grow the descriptor pool to %u sets; %zu titles share %u\n",
+                want, title_count, poolSets_);
+        return false;
+    }
+
+    // Both holders of sets from the old pool must let go before it is destroyed. The caller already
+    // destroyed the covers; the backgrounds are released here, and are reloaded on the next focus change.
+    media_.release_backgrounds();
+    if (vulkanInit_) { ImGui_ImplVulkan_Shutdown(); vulkanInit_ = false; }
+    vkDestroyDescriptorPool(device_, pool_, nullptr);
+    pool_ = fresh;
+    poolSets_ = want;
+    poolFullWarned_ = false;   // a bigger pool may well hold everything; let it say so again if not
+    budget_.reset(library_texture_budget(poolSets_));
+    if (!init_imgui_vulkan()) {
+        // Nothing can draw without the backend, and the pool it would have used is already gone. Same
+        // outcome as a failed init(): the app falls back to the flat idle colour.
+        fprintf(stderr, "[library] Vulkan backend re-init failed after growing the descriptor pool\n");
+        ready_ = false;
+        return false;
+    }
+    vulkanInit_ = true;
+    return true;
 }
 
 void LibraryUi::set_games(std::vector<GameEntry> games, const std::string& games_dir) {
@@ -296,6 +372,9 @@ void LibraryUi::set_games(std::vector<GameEntry> games, const std::string& games
 
     if (device_) vkDeviceWaitIdle(device_);   // covers may still be referenced by an in-flight frame
     destroy_covers();
+    // After destroy_covers() and the device wait, so the grow finds the old pool free of cover sets and
+    // no frame in flight that could still be sampling one.
+    ensure_descriptor_capacity(games.size());
     games_ = std::move(games);
     gamesDir_ = games_dir;
     covers_.resize(games_.size());
@@ -441,13 +520,31 @@ VkDescriptorSet LibraryUi::cover_for(const GameEntry& game) {
         ivi.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
         ok = vkCreateImageView(device_, &ivi, nullptr, &cover.view) == VK_SUCCESS;
     }
+    bool poolFull = false;
     if (ok) {
-        cover.set = ImGui_ImplVulkan_AddTexture(sampler_, cover.view,
-                                                VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        // Through the budget, NOT straight to AddTexture: on a full pool that helper hands the
+        // VK_NULL_HANDLE from vkAllocateDescriptorSets to vkUpdateDescriptorSets, so checking its return
+        // value would be checking after the undefined behaviour (#1649).
+        poolFull = budget_.available() == 0;
+        cover.set = acquire_texture_set(budget_, VkDescriptorSet(VK_NULL_HANDLE), [&] {
+            return ImGui_ImplVulkan_AddTexture(sampler_, cover.view,
+                                               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+        });
     }
     if (!ok || !cover.set) {
         // Leave the entry usable without art rather than dropping a bootable title from the list.
-        fprintf(stderr, "[library] could not upload cover for %s\n", game.title_name.c_str());
+        // Said once for an exhausted pool: every remaining title would repeat it, and the cause is a
+        // property of the pool rather than of this icon.
+        if (poolFull) {
+            if (!poolFullWarned_) {
+                poolFullWarned_ = true;
+                fprintf(stderr,
+                        "[library] descriptor pool full at %u sets; titles past this show no cover art\n",
+                        poolSets_);
+            }
+        } else {
+            fprintf(stderr, "[library] could not upload cover for %s\n", game.title_name.c_str());
+        }
         if (cover.view)   { vkDestroyImageView(device_, cover.view, nullptr); cover.view = VK_NULL_HANDLE; }
         if (cover.image)  { vkDestroyImage(device_, cover.image, nullptr);    cover.image = VK_NULL_HANDLE; }
         if (cover.memory) { vkFreeMemory(device_, cover.memory, nullptr);     cover.memory = VK_NULL_HANDLE; }

--- a/prosper/frontends/prosper-app/library_ui.cpp
+++ b/prosper/frontends/prosper-app/library_ui.cpp
@@ -360,6 +360,9 @@ bool LibraryUi::ensure_descriptor_capacity(size_t title_count) {
         return false;
     }
     vulkanInit_ = true;
+    // Worth a line: it is the only place the pool changes size, and it says out loud how many covers the
+    // run can actually hold — which is exactly the number #1649 was silently wrong about.
+    fprintf(stderr, "[library] descriptor pool grown to %u sets for %zu titles\n", poolSets_, title_count);
     return true;
 }
 

--- a/prosper/frontends/prosper-app/library_ui.hpp
+++ b/prosper/frontends/prosper-app/library_ui.hpp
@@ -13,11 +13,13 @@
 // resources, and event translation.
 
 #include "game_library.hpp"
+#include "library_descriptor_budget.hpp"
 #include "library_media.hpp"
 
 #include <SDL3/SDL.h>
 #include <vulkan/vulkan.h>
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -101,6 +103,19 @@ private:
 
     bool create_render_target(VkFormat format, const std::vector<VkImage>& images, VkExtent2D extent);
     void destroy_render_target();
+
+    // The library's single descriptor pool, shared by ImGui's font atlas, one set per cover, and the
+    // background art (#1630). Sized from the library rather than fixed at 256 (#1649).
+    VkDescriptorPool create_descriptor_pool(uint32_t sets) const;
+    // Make sure the pool can hold `title_count` covers plus the background allowance, growing it if not.
+    // A grow releases every set prosper holds and re-initialises ImGui's Vulkan backend, which is the
+    // only way to point it at a different pool without patching the vendored backend — so the caller
+    // must have destroyed the covers and waited for the device first. Returns false when the pool could
+    // not be grown; the view keeps working at its current capacity and the budget absorbs the shortfall.
+    bool ensure_descriptor_capacity(size_t title_count);
+    // Everything ImGui_ImplVulkan_Init needs, rebuilt from the members so init() and a grow agree.
+    bool init_imgui_vulkan();
+
     // Decode icon0.png and upload it. Returns VK_NULL_HANDLE on any failure; the grid then draws a
     // placeholder, because a missing or corrupt icon must not remove a bootable title from the list.
     VkDescriptorSet cover_for(const GameEntry& game);
@@ -115,14 +130,25 @@ private:
     };
 
     SDL_Window*      window_   = nullptr;
+    VkInstance       instance_ = VK_NULL_HANDLE;   // kept only so a pool grow can re-init ImGui's backend
     VkDevice         device_   = VK_NULL_HANDLE;
     VkPhysicalDevice phys_     = VK_NULL_HANDLE;
     VkQueue          queue_    = VK_NULL_HANDLE;
     uint32_t         qfamily_  = 0;
     VkFormat         format_   = VK_FORMAT_B8G8R8A8_UNORM;
     VkExtent2D       extent_   {};
+    uint32_t         imageCount_ = 2;              // swapchain image count, for ImGui's init info
 
     VkDescriptorPool pool_       = VK_NULL_HANDLE;
+    uint32_t         poolSets_   = 0;              // maxSets the live pool was created with
+    // How many of pool_'s sets prosper itself may allocate — covers here, backgrounds in LibraryMedia.
+    // Consulted BEFORE ImGui_ImplVulkan_AddTexture, which would otherwise write to a VK_NULL_HANDLE set
+    // when the pool is full (#1649); see library_descriptor_budget.hpp.
+    DescriptorBudget budget_;
+    // PROSPER_LIBRARY_POOL_SETS caps the pool, so #1649's exhaustion path is reproducible on a small
+    // library. 0 = unset. Not a tuning knob: capping it below the library deliberately costs covers.
+    uint32_t         poolCap_    = 0;
+    bool             poolFullWarned_ = false;   // the exhaustion notice is per run, not per title
     VkRenderPass     renderPass_ = VK_NULL_HANDLE;
     VkCommandPool    cmdPool_    = VK_NULL_HANDLE;
     VkCommandBuffer  cmd_        = VK_NULL_HANDLE;

--- a/prosper/frontends/prosper-app/library_ui.hpp
+++ b/prosper/frontends/prosper-app/library_ui.hpp
@@ -144,6 +144,9 @@ private:
     // How many of pool_'s sets prosper itself may allocate — covers here, backgrounds in LibraryMedia.
     // Consulted BEFORE ImGui_ImplVulkan_AddTexture, which would otherwise write to a VK_NULL_HANDLE set
     // when the pool is full (#1649); see library_descriptor_budget.hpp.
+    //
+    // MUST stay declared ABOVE media_: media_ holds a pointer to this and gives its sets back from
+    // ~LibraryMedia, and members are destroyed in reverse declaration order.
     DescriptorBudget budget_;
     // PROSPER_LIBRARY_POOL_SETS caps the pool, so #1649's exhaustion path is reproducible on a small
     // library. 0 = unset. Not a tuning knob: capping it below the library deliberately costs covers.

--- a/prosper/frontends/prosper-app/test_library_descriptor_budget.cpp
+++ b/prosper/frontends/prosper-app/test_library_descriptor_budget.cpp
@@ -1,0 +1,174 @@
+// test_library_descriptor_budget — the library view's descriptor-pool sizing and the exhaustion rule
+// that keeps a failed allocation from ever being written to (#1649). Pure arithmetic and a fake
+// allocator, so this runs in the default core build with no Vulkan, no ImGui and no window.
+//
+// The interesting assertion is the LAST group: acquire_texture_set() must not merely return a null
+// handle once the budget is spent, it must not CALL the allocator at all. ImGui's backend passes the set
+// vkAllocateDescriptorSets() produced into vkUpdateDescriptorSets() without checking it, so a guard that
+// only inspects the return value inspects it after the undefined behaviour. The fake allocator below
+// records whether it ran, which is the only way to tell those two guards apart.
+#include "library_descriptor_budget.hpp"
+
+#include <cstdio>
+#include <limits>
+
+using prosper::frontend::DescriptorBudget;
+using prosper::frontend::acquire_texture_set;
+using prosper::frontend::kLibraryBackgroundSets;
+using prosper::frontend::kLibraryImGuiReservedSets;
+using prosper::frontend::kLibraryMaxPoolSets;
+using prosper::frontend::kLibraryMinPoolSets;
+using prosper::frontend::library_descriptor_pool_sets;
+using prosper::frontend::library_texture_budget;
+using prosper::frontend::release_texture_set;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+// Stands in for a VkDescriptorSet. A plain int keeps the header Vulkan-free and lets the test count
+// allocations, which a real handle could not.
+using FakeSet = int;
+static constexpr FakeSet kNone = 0;
+
+struct FakeAllocator {
+    int calls = 0;
+    int next = 100;
+    bool fail = false;      // simulate a driver-side failure that is NOT pool exhaustion
+    FakeSet operator()() {
+        ++calls;
+        if (fail) return kNone;
+        return next++;
+    }
+};
+
+int main() {
+    std::printf("== test_prosper_app_library_descriptor_budget ==\n");
+
+    // --- pool sizing follows the library, not a fixed guess ---------------------------------------
+    // The defect: a constant 256 sets shared by the covers and the backgrounds, so a library of about
+    // 250 titles exhausted the pool. The size must move with the title count.
+    CHECK(library_descriptor_pool_sets(1000) == 1000 + kLibraryBackgroundSets + kLibraryImGuiReservedSets,
+          "a 1000-title library gets a set per cover plus the background and ImGui allowance");
+    CHECK(library_descriptor_pool_sets(250) > 256,
+          "250 titles now ask for MORE than the old fixed 256 (the exact case in #1649)");
+    CHECK(library_descriptor_pool_sets(300) > library_descriptor_pool_sets(299),
+          "one more title asks for one more set");
+    // The allowance is what the background layer can hold at once (cache + insert + retired + slack); a
+    // pool sized for covers alone would starve it on the very first focus change.
+    CHECK(library_descriptor_pool_sets(40) - 40 == kLibraryBackgroundSets + kLibraryImGuiReservedSets,
+          "the overhead above the cover count is exactly the background plus ImGui allowance");
+
+    // --- clamped at both ends ---------------------------------------------------------------------
+    CHECK(library_descriptor_pool_sets(0) == kLibraryMinPoolSets,
+          "an empty library still gets the floor, so the font atlas and backgrounds have room");
+    CHECK(library_descriptor_pool_sets(1) == kLibraryMinPoolSets,
+          "a one-title library is still floored rather than given a 10-set pool");
+    CHECK(library_descriptor_pool_sets(kLibraryMaxPoolSets + 5000) == kLibraryMaxPoolSets,
+          "an absurd library is capped rather than asking the driver for an absurd pool");
+    CHECK(library_descriptor_pool_sets(std::numeric_limits<size_t>::max()) == kLibraryMaxPoolSets,
+          "a saturating count clamps to the ceiling instead of wrapping to a tiny pool");
+    CHECK(kLibraryMinPoolSets > kLibraryBackgroundSets + kLibraryImGuiReservedSets,
+          "the floor leaves room for at least one cover after the fixed overhead");
+
+    // --- the budget reserves ImGui's own set -------------------------------------------------------
+    // prosper never allocates the font atlas set, so it must be held back rather than counted; handing
+    // the whole pool out would put the LAST cover exactly where the atlas lives.
+    CHECK(library_texture_budget(64) == 64 - kLibraryImGuiReservedSets,
+          "the budget is the pool minus ImGui's own reserved set");
+    CHECK(library_texture_budget(0) == 0, "a zero-set pool yields no budget rather than underflowing");
+    CHECK(library_texture_budget(kLibraryImGuiReservedSets) == 0,
+          "a pool with only ImGui's set leaves nothing for covers");
+
+    // --- accounting -------------------------------------------------------------------------------
+    {
+        DescriptorBudget b;
+        b.reset(3);
+        CHECK(b.capacity() == 3 && b.used() == 0 && b.available() == 3, "reset starts empty");
+        CHECK(b.acquire() && b.acquire() && b.acquire(), "the first three acquisitions succeed");
+        CHECK(b.used() == 3 && b.available() == 0, "the budget is now spent");
+        CHECK(!b.acquire(), "the fourth acquisition is refused");
+        CHECK(b.used() == 3, "a refused acquisition does not consume a slot");
+        b.release();
+        CHECK(b.used() == 2 && b.available() == 1, "a release returns a slot");
+        CHECK(b.acquire(), "the returned slot can be taken again");
+        b.release(); b.release(); b.release();
+        CHECK(b.used() == 0, "releasing everything empties the budget");
+        b.release();
+        CHECK(b.used() == 0, "an unbalanced release clamps at zero instead of wrapping to 4 billion");
+        b.reset(1);
+        CHECK(b.capacity() == 1 && b.used() == 0, "reset re-arms with the new capacity");
+    }
+    {
+        DescriptorBudget b;   // never reset: capacity 0
+        CHECK(!b.acquire(), "a default-constructed budget refuses everything");
+    }
+
+    // --- the guard runs BEFORE the allocator, not after it -----------------------------------------
+    // This is the correctness half of #1649. With the guard removed, every CHECK in this block that
+    // counts `alloc.calls` fails, because the allocator is reached on an exhausted pool — which is
+    // exactly the path that hands VK_NULL_HANDLE to vkUpdateDescriptorSets.
+    {
+        DescriptorBudget b;
+        b.reset(2);
+        FakeAllocator alloc;
+        const FakeSet a = acquire_texture_set(b, kNone, [&] { return alloc(); });
+        const FakeSet c = acquire_texture_set(b, kNone, [&] { return alloc(); });
+        CHECK(a != kNone && c != kNone && a != c, "two allocations inside the budget both succeed");
+        CHECK(alloc.calls == 2, "the allocator ran once per successful acquisition");
+
+        const FakeSet over = acquire_texture_set(b, kNone, [&] { return alloc(); });
+        CHECK(over == kNone, "an allocation past the budget yields a null handle");
+        CHECK(alloc.calls == 2,
+              "the allocator was NOT called past the budget (a return-value check would have run it)");
+        CHECK(b.used() == 2, "the refused allocation did not consume a slot");
+
+        // Freeing one must make room again, and must make room only once.
+        FakeSet freed = a;
+        int removed = 0;
+        release_texture_set(b, freed, kNone, [&](FakeSet) { ++removed; });
+        CHECK(removed == 1 && freed == kNone, "release hands the set to the remover and clears it");
+        CHECK(b.used() == 1, "release returns the slot");
+        release_texture_set(b, freed, kNone, [&](FakeSet) { ++removed; });
+        CHECK(removed == 1 && b.used() == 1,
+              "releasing an already-cleared handle is a no-op, so the budget cannot drift");
+
+        const FakeSet again = acquire_texture_set(b, kNone, [&] { return alloc(); });
+        CHECK(again != kNone && alloc.calls == 3, "the freed slot can be allocated again");
+    }
+    {
+        // An allocator that fails for a reason other than exhaustion must give its slot straight back,
+        // or a run of transient failures would permanently shrink the usable pool.
+        DescriptorBudget b;
+        b.reset(2);
+        FakeAllocator alloc;
+        alloc.fail = true;
+        const FakeSet s = acquire_texture_set(b, kNone, [&] { return alloc(); });
+        CHECK(s == kNone && alloc.calls == 1, "a failing allocator is still called while there is room");
+        CHECK(b.used() == 0, "its slot is returned rather than leaked");
+        alloc.fail = false;
+        CHECK(acquire_texture_set(b, kNone, [&] { return alloc(); }) != kNone,
+              "the budget is undamaged by the failure");
+    }
+
+    // --- a pool sized for a library can hold that library's covers ---------------------------------
+    // Ties the two halves together: the sizing must satisfy the accounting, which is the property that
+    // actually failed at 250 titles.
+    for (size_t titles : {size_t(0), size_t(1), size_t(30), size_t(250), size_t(255), size_t(1000)}) {
+        DescriptorBudget b;
+        b.reset(library_texture_budget(library_descriptor_pool_sets(titles)));
+        size_t got = 0;
+        for (size_t i = 0; i < titles; i++) if (b.acquire()) ++got;
+        const bool all = got == titles;
+        const bool backgrounds = b.available() >= kLibraryBackgroundSets;
+        char msg[160];
+        std::snprintf(msg, sizeof msg,
+                      "%zu titles: every cover fits (%zu) and %u background sets remain", titles, got,
+                      b.available());
+        CHECK(all && backgrounds, msg);
+    }
+
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #1649.

## The failure

`prosper-app`'s library view creates **one** `VkDescriptorPool` and shares it between three consumers:

- Dear ImGui's own font atlas (one combined-image-sampler set),
- one set per title's cover art, allocated for the whole library at scan time,
- the per-title background art added by #1630 — up to 3 cached, plus one being inserted before the LRU
  evicts, plus retired-but-not-yet-collected entries.

That pool was a fixed **256 sets** (`library_ui.cpp`, `kMaxTextures = 256`), so a library of roughly 250
titles exhausted it. Re-verified as still the shape on master before starting.

**The sharper half is what exhaustion did.** `ImGui_ImplVulkan_AddTexture`
(`third_party/imgui/backends/imgui_impl_vulkan.cpp:1221`) allocates the set, passes the `VkResult` to a
diagnostic hook that only prints, and then hands the set straight to `vkUpdateDescriptorSets` at `:1251`.
`vkAllocateDescriptorSets` is required to write `VK_NULL_HANDLE` into every output slot when it fails, so
on a full pool the update ran with `dstSet == VK_NULL_HANDLE`: a validation error and undefined
behaviour, not a missing cover.

The issue suggested "check the returned set before use". **That is not sufficient, and it is the one
finding here worth reading carefully: the undefined behaviour happens inside `AddTexture`, before it
returns.** `cover_for()` on master already checks the returned set (`if (!ok || !cover.set)`), and it does
not help at all. `third_party/imgui` is vendored verbatim and must not be patched, so the guard has to sit
on prosper's side of the call — prosper must decline to *make* the call.

## Behavioural contract

1. The pool is sized from the library: one set per title, plus the background allowance, plus ImGui's
   own, clamped to a floor and a ceiling. It is **grown** when a rescan finds more titles than it holds,
   so pointing the app at a bigger folder does not cost the extra titles their art.
2. A descriptor set is **never** requested from a pool with no room. When the budget is spent the
   allocator is not invoked at all, so `VK_NULL_HANDLE` cannot reach `vkUpdateDescriptorSets`.
3. Exhaustion a grow cannot fix costs **one image**, logged once, with the title still launchable — the
   same degradation an undecodable `icon0.png` already produces.

## Approach

**`frontends/prosper-app/library_descriptor_budget.hpp` (new; pure — no Vulkan, no SDL, no ImGui)**

- `library_descriptor_pool_sets(title_count)` — `maxSets` for a library of that size. Saturating, clamped
  to `[32, 8192]`.
- `library_texture_budget(pool_sets)` — the pool minus ImGui's reserved atlas set; what prosper itself may
  allocate.
- `DescriptorBudget` — the shared count. Covers and backgrounds come out of one pool, so only one counter
  can tell either of them that the next allocation would fail.
- `acquire_texture_set(budget, none, add)` / `release_texture_set(budget, set, none, remove)` — the seam
  both call sites go through. `acquire` consults the budget **before** invoking `add`, and returns the slot
  when `add` fails for some other reason, so a transient failure cannot permanently shrink capacity.

**`library_ui.cpp` / `.hpp`**

- `create_descriptor_pool(sets)` and `init_imgui_vulkan()` factored out so `init()` and a grow build the
  pool and the ImGui init info identically.
- `set_games()` calls `ensure_descriptor_capacity(games.size())` after its existing `vkDeviceWaitIdle` and
  `destroy_covers()`. A grow creates the new pool **first** (so a driver refusal leaves the working one in
  place), then releases every set from the old pool, re-runs `ImGui_ImplVulkan_Init` against the new one,
  and destroys the old pool. It never shrinks.
- `cover_for()` allocates through `acquire_texture_set`. Exhaustion logs one line per run, not per title.

**`library_media.cpp` / `.hpp`**

- `init()` takes the borrowed `DescriptorBudget*`; `poll_upload()` allocates through `acquire_texture_set`
  and `destroy_background()` releases through `release_texture_set`.
- New `release_backgrounds()`, factored out of `shutdown()`: drops every image, staging allocation and
  descriptor set but leaves the worker, the audio stream and the music state running. It also clears the
  focus and retires the load generation, so the next `set_focus()` re-requests the art that was dropped
  instead of seeing the same root and doing nothing, and an in-flight worker result for the dropped state
  is discarded rather than installing a track for a title that is no longer focused.

**`PROSPER_LIBRARY_POOL_SETS=<n>`** caps the pool and stops it growing, so the exhaustion path is reachable
without owning hundreds of games. Documented in the app README as a reproduction knob, not a tuning one.

## Invariants

- Every `ImGui_ImplVulkan_AddTexture` call site in prosper is behind `acquire_texture_set`; every
  `ImGui_ImplVulkan_RemoveTexture` returns its slot. `grep -rn ImGui_ImplVulkan_AddTexture
  prosper/frontends` shows the two call sites, both guarded.
- `budget_` is declared above `media_` in `LibraryUi` because `media_` holds a pointer to it and returns
  sets from `~LibraryMedia`; members are destroyed in reverse declaration order. Noted in the header.
- A grow releases the old pool's sets **before** `ImGui_ImplVulkan_Shutdown`, because `RemoveTexture`
  needs the backend alive.
- If `ImGui_ImplVulkan_Init` fails after a grow, `ready_` goes false and the app falls back to the flat
  idle colour — the same outcome a failed `init()` already produces.

## Affected / deliberately unaffected

- Affected: `prosper-app`'s library view only. No `prosper_core` file is touched; ImGui's own drawing, the
  grid layout, navigation, music and the fade policy are unchanged.
- `third_party/` is untouched.
- Not touched: GTA V (`PPSA04263`), compute shaders, the recompiler, or any renderer path.

## Risks

- **The grow path re-initialises ImGui's Vulkan backend**, destroying and rebuilding the font atlas and
  the UI pipeline. It is the standard teardown/setup pair, runs only outside a frame (`set_games` is never
  called between `NewFrame` and `Render`) and after a `vkDeviceWaitIdle` — but it is new behaviour and is
  not reachable from ctest. Exercised live instead; see below.
- The initial pool is the floor (32 sets), so any library above ~23 titles takes the grow path once at
  startup, before the first frame is presented. That is deliberate: it puts the new path on the common
  route rather than only on a rare folder change, so it cannot rot unnoticed.
- The background allowance is a literal (8) rather than derived from `launcher_media.hpp`'s constants. The
  derivation is written out in the header so a change there is checkable by eye; the computed live peak is
  6.

## Verification

### Unit test — `prosper_app_library_descriptor_budget` (new, 41 assertions)

Pure arithmetic plus a fake allocator that **records whether it ran**, which is the only way to
distinguish "returns null past capacity" from "does not allocate past capacity".

Both mutation arms were run on this branch with the change reverted in place, then reverted back.

**Arm 1 — the guard removed** (`if (!budget.acquire()) return none;` → `budget.acquire();`, i.e. the
allocator is reached on a full pool, which is the pre-fix behaviour):

```
  [FAIL] an allocation past the budget yields a null handle
  [FAIL] the allocator was NOT called past the budget (a return-value check would have run it)
  [FAIL] the freed slot can be allocated again
== FAIL: 3 ==
rc=1
```

**Arm 2 — the sizing reverted to the fixed 256:**

```
  [FAIL] a 1000-title library gets a set per cover plus the background and ImGui allowance
  [FAIL] 250 titles now ask for MORE than the old fixed 256 (the exact case in #1649)
  [FAIL] one more title asks for one more set
  [FAIL] the overhead above the cover count is exactly the background plus ImGui allowance
  [FAIL] an empty library still gets the floor, so the font atlas and backgrounds have room
  [FAIL] a one-title library is still floored rather than given a 10-set pool
  [FAIL] an absurd library is capped rather than asking the driver for an absurd pool
  [FAIL] a saturating count clamps to the ceiling instead of wrapping to a tiny pool
  [FAIL] 250 titles: every cover fits (250) and 5 background sets remain
  [FAIL] 255 titles: every cover fits (255) and 0 background sets remain
  [FAIL] 1000 titles: every cover fits (255) and 0 background sets remain
== FAIL: 11 ==
rc=1
```

The last three lines of arm 2 are the reported defect reproduced exactly: at 1000 titles only 255 covers
fit and **zero** background sets remain.

**What the unit test does not cover, stated plainly:** it pins the sizing and the ordering rule, and that
both shipping call sites go through the tested seam is visible by inspection — but nothing in ctest
constructs a Vulkan device for the library view, so the wiring, the grow and `release_backgrounds()` are
covered by the live runs below rather than by a test. (#1651 asks for exactly such a seam for this layer.)

### Builds and tests

Core config (no `-DPROSPER_APP`), Linux:

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
ctest --no-tests=error -j4 --output-on-failure
```

```
100% tests passed out of 247
```

`ctest` exit code **0**, **247 of 247** discovered tests passed (`--no-tests=error`, so an empty
directory would have exited 8, not 0).

App config, Linux:

```
cmake -S prosper -B build-app -G Ninja -DPROSPER_APP=ON -DPROSPER_AUDIO_SDL3=ON -DPROSPER_PAD_SDL3=ON \
      -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build build-app -j4
ctest --no-tests=error -j4 --output-on-failure
```

```
100% tests passed out of 249
```

`ctest` exit code **0**, **249 of 249** discovered tests passed. The two extra over the core config are
the SDL3 frontend self-tests that only exist in this configuration; the new
`prosper_app_library_descriptor_budget` runs in both.

### Live runs

Linux, RADV (AMD Radeon 8060S, STRIX_HALO), `SDL_VIDEODRIVER=offscreen`, Vulkan validation layer
enabled (`VK_LAYER_KHRONOS_validation` 1.4.341), 44 real dumps in the games directory, 25 s per run.
This is the launcher's own view — no guest, no title progression, so no gameplay screenshots apply.

**Arm A — default, 44 titles.** The pool is created at the floor and grown to fit the library:

```
[library] descriptor pool grown to 53 sets for 44 titles
```

53 = 44 covers + 8 background allowance + 1 for ImGui's atlas. `dstSet is VK_NULL_HANDLE`: **0**.
Core dumps: **0**.

**Arm B — `PROSPER_LIBRARY_POOL_SETS=12`, forcing the exhaustion #1649 describes:**

```
[library] PROSPER_LIBRARY_POOL_SETS=12: descriptor pool capped
[library] descriptor pool full at 12 sets; titles past this show no cover art
[library] could not publish the background for <DUMP_ROOT>/PPSA02664-app0
```

Both consumers declined cleanly. `dstSet is VK_NULL_HANDLE`: **0**. Core dumps: **0**. The remaining
titles render as labelled buttons and stay launchable.

**Arm C — the live mutation arm.** Same Arm B command, with `acquire_texture_set`'s guard removed
(`if (!budget.acquire()) return none;` → `budget.acquire();`) and `prosper-app` rebuilt, i.e. the
allocator reached on a full pool exactly as before this PR:

```
[library] imgui vulkan error: -1000069000
Validation Error: [ UNASSIGNED-GeneralParameterError-RequiredHandle ] | MessageID = 0x8fdcb17b
vkUpdateDescriptorSets(): pDescriptorWrites[0].dstSet is VK_NULL_HANDLE.

timeout: the monitored command dumped core
```

`-1000069000` is `VK_ERROR_OUT_OF_POOL_MEMORY`, and **the process dumped core** — the crash #1649
predicted, reproduced. The guard is what removes it, and note again that the set was already written to
by the time `AddTexture` returned. The guard was restored from `HEAD` and the binary rebuilt before Arms
A and B above were re-run; `git status` is clean at `HEAD`.

**One leftover validation message, A/B'd as pre-existing.** Every run reports
`VUID-vkQueueSubmit-pSignalSemaphores-00067` 8 times. That is the library's own acquire/present loop
under the `offscreen` driver and has nothing to do with descriptors — checked rather than assumed: the
four library sources were checked out from `origin/master`, `prosper-app` rebuilt, and the same run
produced the **identical 8 occurrences and no others**. Unchanged by this PR in either direction.

### Snapshots

None run. This changes no renderer path and no guest-facing behaviour — it touches the launcher's own
descriptor allocation only, and the guarded titles' routes never reach the library view's grid.
