### PR TITLE
tools: self_dump --import-slots — print each import's relocation slot so "who calls this Sony function" stops being a hand-parse (#1625)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -117,6 +117,15 @@ add_test(NAME compute_authority_census_policy COMMAND test_compute_authority_cen
 
 find_package(Python3 COMPONENTS Interpreter QUIET)
 if(Python3_Interpreter_FOUND)
+  # self_dump --import-slots reads DT_JMPREL/DT_RELA to answer "which GOT slot does this Sony import
+  # land in" (#1625). The fixtures are PS5-shaped ELFs written byte by byte in the test, so they are
+  # an independent statement of the relocation layout rather than anything self_dump produced, and
+  # they run in CI with no game dump. Includes the zero-result arms: a tool that answers "nothing"
+  # when it means "I did not parse anything" is the defect class of #2399.
+  add_test(NAME self_dump_import_slots
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/self_dump/test_import_slots.py"
+                   "$<TARGET_FILE:self_dump>")
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
   add_test(NAME re_edis_mapping

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -266,7 +266,29 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   and the pixel-distinct/pixel-stale assertions when visible progression matters. Source publication
   counts alone do not prove that the image changed; see `screenshot/README.md`.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
-  export RVAs. Use `--find-symbol NID` for a focused import/export query.
+  export RVAs. Use `--find-symbol NID` for a focused import/export query, and **`--import-slots`**
+  to print the GOT/PLT relocation slot each import lands in — the step that starts every
+  "who calls this Sony function, and what does the guest do with the result?" investigation:
+
+  ```bash
+  ./build-linux/self_dump <DUMP_ROOT>/<TITLE>-app0/eboot.bin \
+      --import-slots --names ../PS5-3.20_Libs | grep scePadGetHandle
+  # 0x000007f9b18 u1GRHp+oWoY  libScePad   scePadGetHandle   JUMP_SLOT
+  ```
+
+  Then hand that slot to `re/xref.py` (see `re/README.md` for the full recipe, including the PLT
+  hop the slot's only direct reference is). `--names` points at the PS5 3.20 firmware stub dump
+  (`$PROSPER_PS5_LIBS` is the fallback); **the NID is printed either way**, so an import the dump
+  does not name is still actionable.
+
+  The output is deliberately self-describing rather than terse. Each run prints which relocation
+  tables it read and how many entries each held, how many symbols and imports it parsed, which name
+  table it used, and — when there are **no** rows — the reason, exiting **3** rather than 0. Imports
+  with no relocation are listed under `[IMPORTS WITHOUT A SLOT]` instead of being dropped, so a
+  `grep` that finds nothing means the module does not import that function, never "it has no slot".
+  A `JUMP_SLOT` row is the call path; `GLOB_DAT`/`64` rows are the same address stored elsewhere
+  (vtables, static initialisers), which is why a busy title reports several times more slots than
+  imports — filter with `grep JUMP_SLOT` when you want only the call site.
 - **`guest_bt/`** — symbolicated **guest**-thread backtraces for a live or frozen prosper process:
   "what is this thread doing / waiting for?". Answers it for **any** title, not just IL2CPP/Unity —
   the managed-symbol step is optional, and on a stripped native C++ UE4 title it still walks every

--- a/prosper/tools/common/nid_stub_names.hpp
+++ b/prosper/tools/common/nid_stub_names.hpp
@@ -1,0 +1,87 @@
+// nid_stub_names.hpp — read <NID> ↔ <funcName> pairs out of the PS5 3.20 firmware stub dump.
+//
+// Part of the `prosper` PS5->PC compatibility layer.
+//
+// The stub dump (CLAUDE.md: "PS5 3.20 firmware library reference", a gitignored sibling of the
+// repository) is one generated `libSceXxx.c` per system library, each carrying one loader line per
+// export:
+//
+//     if(sprx_dlsym(__handle, "PI7jIZj4pcE", &__ptr_sceRandomGetRandomNumber)) return;
+//
+// so the NID/name pair is read off the line directly — no hashing is involved in BUILDING the map,
+// which is what lets a caller check prosper's own `nid_hash` AGAINST the dump rather than using the
+// hash to produce it (nid_census --self-check does exactly that, through `on_pair`).
+//
+// Header-only and free of any prosper_core dependency on purpose: `self_dump` is a deliberately
+// standalone single-translation-unit tool, and this is the one piece it needs to share with
+// `nid_census` so the two cannot drift into two different readings of the same dump.
+#pragma once
+
+#include <cctype>
+#include <cstddef>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <string>
+
+namespace prosper_tools {
+
+// Extract the NID and function name from one generated `sprx_dlsym(...)` loader line.
+// Returns false for every other line in the file.
+inline bool parse_stub_line(const std::string& line, std::string* nid, std::string* name) {
+    const size_t call = line.find("sprx_dlsym(");
+    if (call == std::string::npos) return false;
+    const size_t q1 = line.find('"', call);
+    if (q1 == std::string::npos) return false;
+    const size_t q2 = line.find('"', q1 + 1);
+    if (q2 == std::string::npos) return false;
+    const size_t ptr = line.find("&__ptr_", q2);
+    if (ptr == std::string::npos) return false;
+    size_t end = ptr + 7;
+    while (end < line.size() && (isalnum((unsigned char)line[end]) || line[end] == '_')) ++end;
+    *nid = line.substr(q1 + 1, q2 - q1 - 1);
+    *name = line.substr(ptr + 7, end - (ptr + 7));
+    return !nid->empty() && !name->empty();
+}
+
+struct StubNames {
+    std::map<std::string, std::string> by_nid;   // nid -> function name
+    std::map<std::string, std::string> lib_of;   // nid -> library file stem
+    size_t pairs = 0;                            // parsed loader lines (duplicates included)
+    size_t files = 0;                            // .c files read
+    bool   dir_ok = false;                       // the directory itself was readable
+};
+
+// Read every `*.c` in `dir`. `on_pair`, when set, is invoked for each parsed pair in file order so a
+// caller can run its own control over the table (e.g. re-derive the NID from the name).
+//
+// A missing or unreadable directory yields `dir_ok == false` with an empty table rather than an
+// exception — callers report that state explicitly instead of presenting an empty table as "this
+// module imports nothing nameable".
+inline StubNames load_stub_names(
+    const std::string& dir,
+    const std::function<void(const std::string& nid, const std::string& name)>& on_pair = {}) {
+    namespace fs = std::filesystem;
+    StubNames t;
+    std::error_code ec;
+    fs::directory_iterator it(dir, ec);
+    if (ec) return t;
+    t.dir_ok = true;
+    for (const auto& e : it) {
+        if (!e.is_regular_file() || e.path().extension() != ".c") continue;
+        t.files++;
+        std::ifstream in(e.path());
+        std::string line, nid, name;
+        while (std::getline(in, line)) {
+            if (!parse_stub_line(line, &nid, &name)) continue;
+            t.pairs++;
+            t.by_nid[nid] = name;
+            t.lib_of[nid] = e.path().stem().string();
+            if (on_pair) on_pair(nid, name);
+        }
+    }
+    return t;
+}
+
+}  // namespace prosper_tools

--- a/prosper/tools/nid_census/nid_census.cpp
+++ b/prosper/tools/nid_census/nid_census.cpp
@@ -43,6 +43,7 @@
 // any disagreement: the name table is the instrument this tool reads the census through, so it
 // gets a control of its own rather than being trusted.
 #include "host/boot_program.hpp"
+#include "../common/nid_stub_names.hpp"
 #include "../../src/hle/dispatch.hpp"
 #include "../../src/hle/nid.hpp"
 #include "../../src/loader/linker.hpp"
@@ -76,53 +77,34 @@ struct Row {
 //     if(sprx_dlsym(__handle, "PI7jIZj4pcE", &__ptr_sceRandomGetRandomNumber)) return;
 // so the pair is read off directly. No hashing is required to build the map, which is what makes
 // --self-check meaningful: the hash is checked AGAINST the dump rather than used to produce it.
+//
+// The reading of the dump itself lives in tools/common/nid_stub_names.hpp so that self_dump
+// --import-slots names its imports from the identical parse; only the --self-check control and its
+// mismatch accounting are this tool's.
 struct NameTable {
     std::map<std::string, std::string> by_nid;   // nid -> function name
     std::map<std::string, std::string> lib_of;   // nid -> library file stem
     size_t pairs = 0, mismatches = 0;
 };
 
-bool parse_stub_line(const std::string& line, std::string* nid, std::string* name) {
-    const size_t call = line.find("sprx_dlsym(");
-    if (call == std::string::npos) return false;
-    const size_t q1 = line.find('"', call);
-    if (q1 == std::string::npos) return false;
-    const size_t q2 = line.find('"', q1 + 1);
-    if (q2 == std::string::npos) return false;
-    const size_t ptr = line.find("&__ptr_", q2);
-    if (ptr == std::string::npos) return false;
-    size_t end = ptr + 7;
-    while (end < line.size() && (isalnum((unsigned char)line[end]) || line[end] == '_')) ++end;
-    *nid = line.substr(q1 + 1, q2 - q1 - 1);
-    *name = line.substr(ptr + 7, end - (ptr + 7));
-    return !nid->empty() && !name->empty();
-}
-
 NameTable load_names(const std::string& dir, bool self_check) {
     NameTable t;
-    std::error_code ec;
-    for (const auto& e : fs::directory_iterator(dir, ec)) {
-        if (!e.is_regular_file() || e.path().extension() != ".c") continue;
-        std::ifstream in(e.path());
-        std::string line, nid, name;
-        while (std::getline(in, line)) {
-            if (!parse_stub_line(line, &nid, &name)) continue;
-            t.pairs++;
-            t.by_nid[nid] = name;
-            t.lib_of[nid] = e.path().stem().string();
+    auto stub = prosper_tools::load_stub_names(
+        dir, [&](const std::string& nid, const std::string& name) {
             // The dump states the NID; prosper computes it. They must agree, and a disagreement
             // means one of the two is wrong for that name — report it rather than silently
             // preferring either. This is the control on the name table itself.
-            if (self_check && nid_hash(name) != nid) {
-                t.mismatches++;
-                // stderr, not stdout: under --tsv these land above the header and corrupt the
-                // stream a consumer parses. The control's result belongs with the diagnostics,
-                // and its COUNT is reported in the scope block below in both modes.
-                fprintf(stderr, "  [name-mismatch] %s: dump says %s, nid_hash() says %s\n",
-                        name.c_str(), nid.c_str(), nid_hash(name).c_str());
-            }
-        }
-    }
+            if (!self_check || nid_hash(name) == nid) return;
+            t.mismatches++;
+            // stderr, not stdout: under --tsv these land above the header and corrupt the
+            // stream a consumer parses. The control's result belongs with the diagnostics,
+            // and its COUNT is reported in the scope block below in both modes.
+            fprintf(stderr, "  [name-mismatch] %s: dump says %s, nid_hash() says %s\n",
+                    name.c_str(), nid.c_str(), nid_hash(name).c_str());
+        });
+    t.by_nid = std::move(stub.by_nid);
+    t.lib_of = std::move(stub.lib_of);
+    t.pairs = stub.pairs;
     return t;
 }
 

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -15,6 +15,55 @@ PS5 dynamic symbols use NIDs rather than plaintext names. Once a name has been h
 The result distinguishes imports from exports and prints the export RVA. `--symbols` prints every import
 NID and every defined export with its RVA, size, module, and library context.
 
+## Find who calls an IMPORTED Sony function
+
+This is the question that starts most HLE contract work — "who calls this, and what does the guest do
+with the result?" — and it is how #1592 was root-caused: the guest's own `test eax,eax` / `jns` around
+`scePadGetHandle` proved the contract prosper was violating.
+
+A PS5 module never calls an import directly. The call goes to a PLT stub, the stub jumps through a GOT
+slot, and the loader fills that slot at bind time. `self_dump --import-slots` prints the slot
+(`DT_JMPREL`/`DT_RELA` `r_offset`), which used to be hand-parsed out of the relocation table:
+
+```bash
+./build-linux/self_dump <DUMP_ROOT>/PPSA20052-app0/eboot.bin \
+    --import-slots --names ../PS5-3.20_Libs | grep scePadGetHandle
+```
+
+```text
+0x000007f9b18 u1GRHp+oWoY  libScePad    scePadGetHandle    JUMP_SLOT
+```
+
+Then flatten the module and walk the two references out from that slot. **The slot's only direct
+reference is the PLT stub** — the callers reference the *stub*, so it is two `xref` queries, not one:
+
+```bash
+python3 tools/il2cpp/prx_to_elf.py <DUMP_ROOT>/PPSA20052-app0/eboot.bin ~/work/eboot.elf
+python3 tools/re/xref.py ~/work/eboot.elf to 0x7f9b18      # slot  -> PLT stub
+python3 tools/re/xref.py ~/work/eboot.elf to 0x60c8e0      # stub  -> the call sites
+```
+
+```text
+code references to 0x7f9b18: 1 (0 write, 0 read, 0 address-taken)
+   [x ] jmp*    at 0x60c8e0  (in func 0x60c3e0)            # the PLT stub
+
+code references to 0x60c8e0: 9 (0 write, 0 read, 0 address-taken)
+   [x ] call    at 0x7fc74  (in func 0x7fa30)
+   [x ] call    at 0x7fd5c  (in func 0x7fa30)              # the #1592 site
+   [x ] call    at 0x800d9  (in func 0x7fa30)
+   ...
+```
+
+`tools/re/edis.py` then disassembles a call site to read the guest's own test of the return value.
+This is the worked known answer for `--import-slots`: `0x7fd5c`, `0x800d9` and the containing function
+`0x7fa30` are exactly what #1592 recorded by hand.
+
+Two things to know before believing an answer here. **`--import-slots` reports `GLOB_DAT` and `64`
+relocations as well as `JUMP_SLOT`** — those are the same function address stored in a vtable or a
+static initialiser rather than the call path, so a busy title lists several times more slots than it has
+imports; `grep JUMP_SLOT` when you want the call site. And a **zero from `--import-slots` always states
+its own cause and exits 3**, so "no output" is never ambiguous between "no slots" and "nothing parsed".
+
 ## Find readers and writers of a slot
 
 Flatten the SELF/PRX first, then query the address with `xref.py`:

--- a/prosper/tools/self_dump/self_dump.cpp
+++ b/prosper/tools/self_dump/self_dump.cpp
@@ -8,12 +8,41 @@
 //   - dynamic tags
 //   - needed modules / import libraries / export libraries
 //   - imported & exported symbols (NID#lib#module), resolved to lib/module names
+//   - each import's relocation SLOT (--import-slots), which is where every
+//     "who calls this Sony function" investigation starts (#1625)
 //
 // This is the intelligence-gathering front end for the loader: the imported
 // module/function set defines the entire HLE surface we must implement.
 //
 // Build: g++ -O2 -std=c++20 self_dump.cpp -o self_dump
-// Usage: self_dump <file.self|eboot.bin|*.prx> [--symbols] [--find-symbol NID]
+// Usage: self_dump <file.self|eboot.bin|*.prx>
+//                  [--symbols] [--find-symbol NID]
+//                  [--import-slots] [--names <PS5-3.20_Libs dir>]
+//
+// --import-slots — "who calls this Sony function?"
+// ------------------------------------------------
+// A PS5 module never calls an imported function directly: the call goes through a
+// GOT slot that the loader fills with the resolved address. `DT_JMPREL` (and
+// `DT_RELA`) name that slot in each relocation's `r_offset`, so finding the slot
+// used to mean hand-parsing the relocation table — the one manual step in the
+// workflow that root-caused #1592. This flag prints it:
+//
+//     self_dump <DUMP_ROOT>/<TITLE>-app0/eboot.bin --import-slots | grep scePadGetHandle
+//     python3 tools/il2cpp/prx_to_elf.py <eboot.bin> <out.elf>       # flatten once
+//     python3 tools/re/xref.py <out.elf> to <slot>                   # -> the PLT stub
+//     python3 tools/re/xref.py <out.elf> to <stub>                   # -> the call sites
+//
+// Note the TWO xref queries: the slot's only direct reference is the PLT stub, and the
+// callers reference the stub, not the slot. tools/re/README.md works the whole recipe
+// through on PPSA20052. Every address here and in xref.py is image-relative, so they
+// compose directly.
+//
+// CONFIDENCE: HIGH that `r_offset` is the image-relative slot address — it is the
+// address prosper's own loader writes the resolved import into for R_X86_64_JUMP_SLOT
+// and R_X86_64_GLOB_DAT (src/self/module.cpp, `apply_relocations`), and the known-answer
+// check on PPSA20052's `scePadGetHandle` reproduces the call sites recorded on #1592.
+
+#include "../common/nid_stub_names.hpp"
 
 #include <cstdio>
 #include <cstdint>
@@ -80,6 +109,20 @@ struct Elf64_Sym {
     uint64_t st_value, st_size;
 };
 struct Elf64_Dyn { int64_t d_tag; uint64_t d_val; };
+struct Elf64_Rela { uint64_t r_offset, r_info; int64_t r_addend; };
+
+// x86-64 relocation types that place an ADDRESS in a slot. These are the ones whose
+// r_offset is the "who calls this import" answer; every other type against an import
+// symbol (TLS DTPMOD64/DTPOFF64/TPOFF64, …) is counted and reported separately rather
+// than dropped, so the census never quietly under-reports.
+static const char* addr_reloc_name(uint32_t t) {
+    switch (t) {
+        case 1: return "64";          // R_X86_64_64        S + A written into r_offset
+        case 6: return "GLOB_DAT";    // R_X86_64_GLOB_DAT  data/function GOT slot
+        case 7: return "JUMP_SLOT";   // R_X86_64_JUMP_SLOT PLT GOT slot — the call path
+        default: return nullptr;
+    }
+}
 
 // ELF program header types (standard + Sony)
 static const char* ptype_name(uint32_t t) {
@@ -116,9 +159,12 @@ static const char* etype_name(uint16_t t) {
 static const char* dtag_name(int64_t t) {
     switch ((uint64_t)t) {
         case 0:  return "DT_NULL";     case 1: return "DT_NEEDED";
+        case 2:  return "DT_PLTRELSZ";
         case 3:  return "DT_PLTGOT";   case 5: return "DT_STRTAB";
         case 6:  return "DT_SYMTAB";   case 0x1e: return "DT_FLAGS";
         case 4:  return "DT_HASH";     case 0xa: return "DT_STRSZ";
+        case 7:  return "DT_RELA";     case 8: return "DT_RELASZ";
+        case 9:  return "DT_RELAENT";
         case 0xb: return "DT_SYMENT";  case 0x14: return "DT_PLTREL";
         case 0x17: return "DT_JMPREL";
         case 0x61000005: return "DT_SCE_MODULE_INFO";
@@ -149,22 +195,41 @@ static const char* dtag_name(int64_t t) {
     }
 }
 
+static const char* kUsage =
+    "usage: %s <file> [--symbols] [--find-symbol NID] [--import-slots] [--names <dir>]\n"
+    "  --import-slots  print each import's relocation slot: <slot> <NID> <library> <name> <reloc>\n"
+    "  --names <dir>   PS5 3.20 firmware stub dump used to name the NIDs (or $PROSPER_PS5_LIBS)\n"
+    "exit: 0 ok | 1 usage/parse | 2 --find-symbol found nothing | 3 --import-slots found no slots\n";
+
 int main(int argc, char** argv) {
     if (argc < 2) {
-        fprintf(stderr, "usage: %s <file> [--symbols] [--find-symbol NID]\n", argv[0]);
+        fprintf(stderr, kUsage, argv[0]);
         return 1;
     }
-    bool dump_syms = false;
-    std::string find_symbol;
+    bool dump_syms = false, import_slots = false;
+    std::string find_symbol, names_dir;
+    bool names_dir_explicit = false;
     for (int i = 2; i < argc; ++i) {
         if (strcmp(argv[i], "--symbols") == 0) {
             dump_syms = true;
+        } else if (strcmp(argv[i], "--import-slots") == 0) {
+            import_slots = true;
+        } else if (strcmp(argv[i], "--names") == 0 && i + 1 < argc) {
+            names_dir = argv[++i];
+            names_dir_explicit = true;
         } else if (strcmp(argv[i], "--find-symbol") == 0 && i + 1 < argc) {
             find_symbol = argv[++i];
         } else {
-            fprintf(stderr, "usage: %s <file> [--symbols] [--find-symbol NID]\n", argv[0]);
+            fprintf(stderr, kUsage, argv[0]);
             return 1;
         }
+    }
+    // $PROSPER_PS5_LIBS is the fallback source for the name table. There is deliberately NO
+    // implicit path search: a name table that appeared from a directory the caller did not name
+    // would make the `name` column's provenance unknowable, and the flag's whole value is that a
+    // reader can tell a resolved name from an unresolved one. Every run prints which table it used.
+    if (names_dir.empty()) {
+        if (const char* env = getenv("PROSPER_PS5_LIBS")) names_dir = env;
     }
     auto b = read_file(argv[1]);
 
@@ -270,6 +335,15 @@ int main(int argc, char** argv) {
     // -- walk dynamic tags -- (DT_SCE_STRTAB/SYMTAB are byte offsets from the
     // image's dynlib string/symbol area; on this PS5 layout they resolve as VAs.)
     uint64_t strtab_va = 0, strsz = 0, symtab_va = 0, symtabsz = 0, syment = 24;
+    // Relocation tables. JMPREL is the PLT/GOT table (DT_JMPREL + DT_PLTRELSZ); RELA is the
+    // general one (DT_RELA + DT_RELASZ). PS5 modules have been observed carrying either the
+    // standard tags or Sony's DT_SCE_* aliases for the same tables, so both are read and the
+    // standard tag wins when a module declares both.
+    // CONFIDENCE: HIGH for the standard tags (every dump checked uses them);
+    // CONFIDENCE: MED for the DT_SCE_* aliases — no title in testdata/ exercises them, so they are
+    // a documented fallback rather than a verified path, and --import-slots names which tag it read.
+    uint64_t jmprel_va = 0, jmprel_sz = 0, rela_va = 0, rela_sz = 0, relaent = 24;
+    bool jmprel_sce = false, rela_sce = false;
     struct LibRec { std::string name; };
     std::map<int, LibRec> import_libs, export_libs, needed_mods;
     std::vector<Elf64_Dyn> dyns;
@@ -282,11 +356,21 @@ int main(int argc, char** argv) {
             case 0xa: strsz = d.d_val; break;                 // DT_STRSZ
             case 6:  symtab_va = d.d_val; break;              // DT_SYMTAB (VA)
             case 0xb: syment = d.d_val; break;                // DT_SYMENT
+            case 0x17: jmprel_va = d.d_val; jmprel_sce = false; break;   // DT_JMPREL (VA)
+            case 2:  jmprel_sz = d.d_val; break;              // DT_PLTRELSZ
+            case 7:  rela_va = d.d_val; rela_sce = false; break;         // DT_RELA (VA)
+            case 8:  rela_sz = d.d_val; break;                // DT_RELASZ
+            case 9:  if (d.d_val) relaent = d.d_val; break;   // DT_RELAENT
             case 0x61000035: if (!strtab_va) strtab_va = d.d_val; break;
             case 0x61000037: if (!strsz) strsz = d.d_val; break;
             case 0x61000039: if (!symtab_va) symtab_va = d.d_val; break;
             case 0x6100003f: symtabsz = d.d_val; break;       // DT_SCE_SYMTABSZ
             case 0x6100003b: if (!syment || syment==24) syment = d.d_val; break;
+            case 0x61000029: if (!jmprel_va) { jmprel_va = d.d_val; jmprel_sce = true; } break; // DT_SCE_JMPREL
+            case 0x6100002d: if (!jmprel_sz) jmprel_sz = d.d_val; break;                       // DT_SCE_PLTRELSZ
+            case 0x6100002f: if (!rela_va) { rela_va = d.d_val; rela_sce = true; } break;      // DT_SCE_RELA
+            case 0x61000031: if (!rela_sz) rela_sz = d.d_val; break;                           // DT_SCE_RELASZ
+            case 0x61000033: if (d.d_val) relaent = d.d_val; break;                            // DT_SCE_RELAENT
         }
     }
     // Resolve strtab: try as VA; if that fails, the value is an offset into the
@@ -339,7 +423,13 @@ int main(int argc, char** argv) {
         std::string nid, libname, modname;
         uint64_t value = 0, size = 0;
         bool is_import = false;
+        bool nid_encoded = false;   // the name parsed as NID#lib#mod
     };
+    // Index-aligned with the symbol table: a relocation's r_info>>32 indexes THIS vector directly.
+    // Non-NID entries (the null symbol, any plain name) are kept as placeholders with
+    // nid_encoded=false rather than skipped, because dropping them would shift every later index
+    // and silently mis-name every import slot. Consumers below filter on nid_encoded, so the
+    // existing [EXPORTS]/[SYMBOL QUERY]/[IMPORTS BY LIBRARY] output is unchanged.
     std::vector<SymbolRec> symbol_recs;
     std::map<std::string, std::set<std::string>> by_lib; // libname -> set of import NIDs
     size_t nsym = syment ? symtabsz / syment : 0, n_import = 0, n_export = 0;
@@ -348,7 +438,8 @@ int main(int argc, char** argv) {
         const char* raw = strtab_str(sym.st_name);
         std::string s = raw;
         // split nid#lib#mod
-        auto h1 = s.find('#'); if (h1 == std::string::npos) continue;
+        auto h1 = s.find('#');
+        if (h1 == std::string::npos) { symbol_recs.push_back({}); continue; }
         auto h2 = s.find('#', h1 + 1);
         std::string nid = s.substr(0, h1);
         std::string libid = (h2 == std::string::npos) ? "" : s.substr(h1 + 1, h2 - h1 - 1);
@@ -365,7 +456,7 @@ int main(int argc, char** argv) {
         std::string modname = !is_import && export_libs.count(lid) ? export_libs[lid].name
                               : needed_mods.count(mid) ? needed_mods[mid].name
                               : ("mod#" + modid);
-        symbol_recs.push_back({nid, libname, modname, sym.st_value, sym.st_size, is_import});
+        symbol_recs.push_back({nid, libname, modname, sym.st_value, sym.st_size, is_import, true});
         if (is_import) { n_import++; by_lib[libname].insert(nid); }
         else n_export++;
     }
@@ -379,10 +470,153 @@ int main(int argc, char** argv) {
     if (dump_syms) {
         printf("\n[EXPORTS]\n");
         for (const auto& sym : symbol_recs) {
-            if (sym.is_import) continue;
+            if (!sym.nid_encoded || sym.is_import) continue;
             printf("  0x%09llx size=0x%-8llx %-11s  %s::%s\n",
                    (unsigned long long)sym.value, (unsigned long long)sym.size,
                    sym.nid.c_str(), sym.modname.c_str(), sym.libname.c_str());
+        }
+    }
+
+    // ---- --import-slots ---------------------------------------------------
+    // One line per (relocation slot, imported symbol) pair:
+    //     <slot vaddr>  <NID>  <library>  <name>  <reloc>
+    // The slot is image-relative, which is what tools/re/xref.py takes, so
+    //     self_dump ... --import-slots | grep <name>   ->   xref.py <elf> to <slot>
+    // starts the "who calls this Sony function" walk without hand-parsing DT_JMPREL (#1625).
+    //
+    // Everything this section could get wrong is printed alongside the rows: which relocation
+    // tables were found and how many entries each held, how many symbols and imports were parsed,
+    // which name table (if any) was read, and — when the answer is zero — WHY it is zero. A tool
+    // that prints "nothing" when it means "I did not parse anything" is worse than one that
+    // refuses, so an empty result here always names its own cause and exits 3.
+    int slots_rc = 0;
+    if (import_slots) {
+        printf("\n[IMPORT SLOTS] file=%s\n", argv[1]);
+
+        struct Row { uint64_t slot; uint32_t sym; uint32_t type; };
+        std::vector<Row> rows;
+        std::map<uint32_t, size_t> other_types;      // reloc type -> count (references an import)
+        size_t reloc_total = 0, reloc_unmapped_tables = 0, reloc_bad_sym = 0;
+
+        auto scan = [&](const char* label, const char* tag, uint64_t va, uint64_t sz) {
+            // A table address of 0 is "absent", never "at vaddr 0". This matters: the first PT_LOAD
+            // of a PS5 executable IS mapped at vaddr 0, so resolving a zero address would succeed
+            // and parse the ELF header as relocations — a silent wrong answer rather than a gap.
+            if (!va) {
+                printf("[IMPORT SLOTS] %-6s absent (no %s)%s\n", label, tag,
+                       sz ? "  [but a size is declared for it — malformed dynamic table]" : "");
+                return;
+            }
+            int64_t fo = va2foff(va);
+            if (fo < 0) {
+                printf("[IMPORT SLOTS] %-6s va=0x%llx size=0x%llx (%s) -> UNMAPPED: no loaded "
+                       "segment covers it; its relocations were NOT read\n",
+                       label, (unsigned long long)va, (unsigned long long)sz, tag);
+                reloc_unmapped_tables++;
+                return;
+            }
+            // Bound the guest-declared size to the file: a table cannot run past EOF, and an
+            // over-large declared size would otherwise manufacture zero-filled "relocations".
+            uint64_t avail = (uint64_t)fo <= b.size() ? b.size() - (uint64_t)fo : 0;
+            uint64_t used = sz < avail ? sz : avail;
+            const uint64_t ent = relaent >= sizeof(Elf64_Rela) ? relaent : sizeof(Elf64_Rela);
+            size_t n = 0;
+            for (uint64_t o = 0; o + sizeof(Elf64_Rela) <= used; o += ent, ++n) {
+                auto r = rd<Elf64_Rela>(b, (size_t)fo + o);
+                uint32_t type = (uint32_t)(r.r_info & 0xffffffff);
+                uint32_t sym  = (uint32_t)(r.r_info >> 32);
+                reloc_total++;
+                if (sym == 0) continue;                       // no symbol (RELATIVE, …)
+                if (sym >= symbol_recs.size()) { reloc_bad_sym++; continue; }
+                const auto& s = symbol_recs[sym];
+                if (!s.nid_encoded || !s.is_import) continue; // internal definition, not an import
+                if (addr_reloc_name(type)) rows.push_back({ r.r_offset, sym, type });
+                else other_types[type]++;
+            }
+            printf("[IMPORT SLOTS] %-6s va=0x%llx size=0x%llx entries=%zu (%s, entsize=%llu)%s\n",
+                   label, (unsigned long long)va, (unsigned long long)sz, n, tag,
+                   (unsigned long long)ent,
+                   used < sz ? "  [TRUNCATED to the file's end]" : "");
+        };
+        scan("jmprel", jmprel_sce ? "DT_SCE_JMPREL/DT_SCE_PLTRELSZ" : "DT_JMPREL/DT_PLTRELSZ",
+             jmprel_va, jmprel_sz);
+        scan("rela",   rela_sce ? "DT_SCE_RELA/DT_SCE_RELASZ" : "DT_RELA/DT_RELASZ",
+             rela_va, rela_sz);
+        printf("[IMPORT SLOTS] symbols=%zu imports=%zu relocations-read=%zu\n",
+               symbol_recs.size(), n_import, reloc_total);
+        if (reloc_bad_sym)
+            printf("[IMPORT SLOTS] %zu relocation(s) named a symbol index past the symbol table "
+                   "and were skipped\n", reloc_bad_sym);
+
+        // Name table. Always reported, including when there is none — the NID column is the
+        // authoritative identity and stays actionable on its own.
+        prosper_tools::StubNames names;
+        if (!names_dir.empty()) {
+            names = prosper_tools::load_stub_names(names_dir);
+            if (!names.dir_ok)
+                printf("[IMPORT SLOTS] names: '%s' is not a readable directory%s — the name column "
+                       "will be '-'\n", names_dir.c_str(),
+                       names_dir_explicit ? "" : " (from $PROSPER_PS5_LIBS)");
+            else
+                printf("[IMPORT SLOTS] names: %s (%zu files, %zu pairs, %zu distinct NIDs)\n",
+                       names_dir.c_str(), names.files, names.pairs, names.by_nid.size());
+        } else {
+            printf("[IMPORT SLOTS] names: none — pass --names <PS5-3.20_Libs dir> or set "
+                   "$PROSPER_PS5_LIBS to fill the name column; the NID column is authoritative\n");
+        }
+        auto name_of = [&](const std::string& nid) -> const char* {
+            auto it = names.by_nid.find(nid);
+            return it == names.by_nid.end() ? "-" : it->second.c_str();
+        };
+
+        std::sort(rows.begin(), rows.end(), [](const Row& a, const Row& c) {
+            return a.slot != c.slot ? a.slot < c.slot : a.sym < c.sym;
+        });
+        std::set<uint32_t> with_slot;
+        for (auto& r : rows) with_slot.insert(r.sym);
+
+        if (rows.empty()) {
+            const char* why =
+                symbol_recs.empty()                ? "the symbol table could not be read at all "
+                                                     "(see the [DATA] symtab line above)" :
+                n_import == 0                      ? "this module imports nothing" :
+                (!jmprel_va && !rela_va)           ? "the dynamic table declares neither "
+                                                     "DT_JMPREL nor DT_RELA" :
+                reloc_unmapped_tables              ? "every declared relocation table is unmapped "
+                                                     "(see UNMAPPED above)" :
+                reloc_total == 0                   ? "the relocation tables are declared but empty" :
+                                                     "no relocation of type 64/GLOB_DAT/JUMP_SLOT "
+                                                     "references an imported symbol";
+            printf("[IMPORT SLOTS] 0 import slots — %s\n", why);
+            slots_rc = 3;
+        } else {
+            printf("#%-12s %-11s  %-32s %-40s %s\n", "slot", "NID", "library", "name", "reloc");
+            for (auto& r : rows) {
+                const auto& s = symbol_recs[r.sym];
+                printf("0x%011llx %-11s  %-32s %-40s %s\n",
+                       (unsigned long long)r.slot, s.nid.c_str(), s.libname.c_str(),
+                       name_of(s.nid), addr_reloc_name(r.type));
+            }
+            printf("[IMPORT SLOTS] %zu slots over %zu of %zu imports\n",
+                   rows.size(), with_slot.size(), n_import);
+        }
+        if (!other_types.empty()) {
+            printf("[IMPORT SLOTS] note: relocations of other types also reference imported "
+                   "symbols and are NOT address slots:");
+            for (auto& [t, c] : other_types) printf(" type%u x%zu", t, c);
+            printf("\n");
+        }
+        // An import with no relocation slot is listed rather than omitted: a `grep <name>` that
+        // returns nothing must mean "this module does not import it", never "it has no slot".
+        if (n_import > with_slot.size()) {
+            printf("[IMPORTS WITHOUT A SLOT] (%zu — imported but no address relocation targets "
+                   "them in this module)\n", n_import - with_slot.size());
+            for (size_t i = 0; i < symbol_recs.size(); i++) {
+                const auto& s = symbol_recs[i];
+                if (!s.nid_encoded || !s.is_import || with_slot.count((uint32_t)i)) continue;
+                printf("%-13s %-11s  %-32s %-40s %s\n",
+                       "-", s.nid.c_str(), s.libname.c_str(), name_of(s.nid), "none");
+            }
         }
     }
 
@@ -390,7 +624,7 @@ int main(int argc, char** argv) {
         size_t found = 0;
         printf("\n[SYMBOL QUERY] %s\n", find_symbol.c_str());
         for (const auto& sym : symbol_recs) {
-            if (sym.nid != find_symbol) continue;
+            if (!sym.nid_encoded || sym.nid != find_symbol) continue;
             ++found;
             printf("  %-6s value=0x%09llx size=0x%llx  %s::%s\n",
                    sym.is_import ? "IMPORT" : "EXPORT",
@@ -399,8 +633,8 @@ int main(int argc, char** argv) {
         }
         if (!found) {
             printf("  not found\n");
-            return 2;
+            return 2;   // unchanged: --find-symbol's "no such NID" exit code
         }
     }
-    return 0;
+    return slots_rc;   // 3 when --import-slots produced no rows, else 0
 }

--- a/prosper/tools/self_dump/self_dump.cpp
+++ b/prosper/tools/self_dump/self_dump.cpp
@@ -489,6 +489,15 @@ int main(int argc, char** argv) {
     // which name table (if any) was read, and — when the answer is zero — WHY it is zero. A tool
     // that prints "nothing" when it means "I did not parse anything" is worse than one that
     // refuses, so an empty result here always names its own cause and exits 3.
+    //
+    // EVERY BYTE PRINTED BELOW MUST BE ASCII. This output is designed to be grepped, and stdout
+    // carries bytes, not text: a UTF-8 punctuation mark leaves this process as its UTF-8 bytes and
+    // is then decoded by whatever reads it. On Windows that is the console/locale code page
+    // (cp1252/cp437), so a single em dash renders as mojibake in cmd.exe AND makes a `grep` for the
+    // line the tool itself printed fail to match. Five em dashes shipped here and cost a red
+    // `Windows MinGW` CI job on exactly the one check that matched across one. Comments in this
+    // file may use whatever punctuation reads best; printed literals may not.
+    // test_import_slots.py asserts this property directly, on every message path.
     int slots_rc = 0;
     if (import_slots) {
         printf("\n[IMPORT SLOTS] file=%s\n", argv[1]);
@@ -504,7 +513,7 @@ int main(int argc, char** argv) {
             // and parse the ELF header as relocations — a silent wrong answer rather than a gap.
             if (!va) {
                 printf("[IMPORT SLOTS] %-6s absent (no %s)%s\n", label, tag,
-                       sz ? "  [but a size is declared for it — malformed dynamic table]" : "");
+                       sz ? "  [but a size is declared for it -- malformed dynamic table]" : "");
                 return;
             }
             int64_t fo = va2foff(va);
@@ -554,14 +563,14 @@ int main(int argc, char** argv) {
         if (!names_dir.empty()) {
             names = prosper_tools::load_stub_names(names_dir);
             if (!names.dir_ok)
-                printf("[IMPORT SLOTS] names: '%s' is not a readable directory%s — the name column "
+                printf("[IMPORT SLOTS] names: '%s' is not a readable directory%s -- the name column "
                        "will be '-'\n", names_dir.c_str(),
                        names_dir_explicit ? "" : " (from $PROSPER_PS5_LIBS)");
             else
                 printf("[IMPORT SLOTS] names: %s (%zu files, %zu pairs, %zu distinct NIDs)\n",
                        names_dir.c_str(), names.files, names.pairs, names.by_nid.size());
         } else {
-            printf("[IMPORT SLOTS] names: none — pass --names <PS5-3.20_Libs dir> or set "
+            printf("[IMPORT SLOTS] names: none -- pass --names <PS5-3.20_Libs dir> or set "
                    "$PROSPER_PS5_LIBS to fill the name column; the NID column is authoritative\n");
         }
         auto name_of = [&](const std::string& nid) -> const char* {
@@ -587,7 +596,7 @@ int main(int argc, char** argv) {
                 reloc_total == 0                   ? "the relocation tables are declared but empty" :
                                                      "no relocation of type 64/GLOB_DAT/JUMP_SLOT "
                                                      "references an imported symbol";
-            printf("[IMPORT SLOTS] 0 import slots — %s\n", why);
+            printf("[IMPORT SLOTS] 0 import slots -- %s\n", why);
             slots_rc = 3;
         } else {
             printf("#%-12s %-11s  %-32s %-40s %s\n", "slot", "NID", "library", "name", "reloc");
@@ -609,7 +618,7 @@ int main(int argc, char** argv) {
         // An import with no relocation slot is listed rather than omitted: a `grep <name>` that
         // returns nothing must mean "this module does not import it", never "it has no slot".
         if (n_import > with_slot.size()) {
-            printf("[IMPORTS WITHOUT A SLOT] (%zu — imported but no address relocation targets "
+            printf("[IMPORTS WITHOUT A SLOT] (%zu -- imported but no address relocation targets "
                    "them in this module)\n", n_import - with_slot.size());
             for (size_t i = 0; i < symbol_recs.size(); i++) {
                 const auto& s = symbol_recs[i];

--- a/prosper/tools/self_dump/test_import_slots.py
+++ b/prosper/tools/self_dump/test_import_slots.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Regression test for `self_dump --import-slots` (#1625).
+
+The flag answers "which GOT slot does this Sony import land in", which is step 2 of the
+"who calls this Sony function" workflow and used to be hand-parsed out of `DT_JMPREL`.
+
+Every fixture here is a PS5-shaped ELF **built byte by byte in this file**, not extracted from a
+dump and not produced by any part of self_dump. That matters: a positive control drawn from the
+same machinery as the thing it validates only ever tests the discriminator. These bytes are an
+independent statement of what the relocation tables mean, so a wrong reading of them fails here.
+
+The cases are chosen so that each one fails for a different reason:
+
+  1. a JUMP_SLOT relocation against an imported symbol IS a slot   (the flag's whole purpose)
+  2. a GLOB_DAT relocation against an imported symbol IS a slot     (RELA, not just JMPREL)
+  3. a JUMP_SLOT against a DEFINED symbol is NOT an import slot     (index-aligned symbol lookup)
+  4. an import with no relocation is listed, never silently dropped (a grep miss must mean "absent")
+  5. a non-address relocation type against an import is counted, not reported as a slot
+  6. zero rows always names its own cause and exits 3               (#2399's class of defect)
+  7. an unmapped relocation table says UNMAPPED rather than "none"  (ditto)
+  7b. a table declared at address 0 is absent, not resolved against the vaddr-0 PT_LOAD
+  8. the name column is filled from the firmware stub dump, and its provenance is printed
+
+Usage: test_import_slots.py <path-to-self_dump>
+"""
+
+import struct
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# --- ELF / Sony dynamic constants used by the fixtures ---------------------------------------
+PT_LOAD, PT_DYNAMIC = 1, 2
+ET_SCE_DYNEXEC, EM_X86_64 = 0xFE10, 0x3E
+
+DT_NULL, DT_PLTRELSZ, DT_STRTAB, DT_SYMTAB, DT_RELA, DT_RELASZ = 0, 2, 5, 6, 7, 8
+DT_RELAENT, DT_STRSZ, DT_SYMENT, DT_PLTREL, DT_JMPREL = 9, 0xA, 0xB, 0x14, 0x17
+DT_SCE_NEEDED_MODULE, DT_SCE_IMPORT_LIB, DT_SCE_SYMTABSZ = 0x61000045, 0x61000049, 0x6100003F
+
+R_X86_64_GLOB_DAT, R_X86_64_JUMP_SLOT = 6, 7
+R_X86_64_RELATIVE, R_X86_64_DTPMOD64 = 8, 16
+
+# Where each table lives in the fixture's read-write segment (vaddr == file offset there).
+V_DYNAMIC, V_STRTAB, V_SYMTAB, V_JMPREL, V_RELA, V_GOT = 0x1000, 0x1200, 0x1300, 0x1400, 0x1500, 0x1F00
+SEG_RW, SEG_SIZE, FILE_SIZE = 0x1000, 0x1000, 0x2000
+
+B64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-"
+
+
+class StrTab:
+    """Sony's dynamic string table: NUL at 0, then NUL-terminated names."""
+
+    def __init__(self):
+        self.blob = bytearray(b"\0")
+        self.offs = {}
+
+    def add(self, s: str) -> int:
+        if s not in self.offs:
+            self.offs[s] = len(self.blob)
+            self.blob += s.encode() + b"\0"
+        return self.offs[s]
+
+
+def sym(name_off: int, shndx: int, value: int) -> bytes:
+    """Elf64_Sym. st_info = GLOBAL|FUNC, which self_dump does not read but a real one carries."""
+    return struct.pack("<IBBHQQ", name_off, 0x12, 0, shndx, value, 0)
+
+
+def rela(offset: int, symidx: int, rtype: int, addend: int = 0) -> bytes:
+    return struct.pack("<QQq", offset, (symidx << 32) | rtype, addend)
+
+
+def phdr(ptype: int, flags: int, off: int, vaddr: int, filesz: int) -> bytes:
+    return struct.pack("<IIQQQQQQ", ptype, flags, off, vaddr, vaddr, filesz, filesz, 0x4000)
+
+
+def build_fixture(*, jmprel=True, rela_table=True, unmapped_jmprel=False,
+                  zero_jmprel_va=False) -> bytes:
+    """A minimal PS5-shaped dynamic executable with three imports and one local definition.
+
+    `jmprel`/`rela_table` drop a whole relocation table; `unmapped_jmprel` keeps DT_JMPREL but
+    points it at a vaddr no segment covers; `zero_jmprel_va` declares a size for a table whose
+    address is 0 — the distinct ways an honest tool must report a zero differently from "I did not
+    parse anything", and differently from each other.
+    """
+    st = StrTab()
+    lib_one, lib_two = st.add("libSceTestOne"), st.add("libSceTestTwo")
+    module = st.add("testmodule")
+    # Symbol names are Sony's NID#libId#modId, the ids in Sony base64 ("A" == 0, "B" == 1).
+    n_import1 = st.add("TESTNIDONE1#%s#%s" % (B64[0], B64[1]))
+    n_local = st.add("LOCALSYMBOL#%s#%s" % (B64[0], B64[1]))
+    n_import2 = st.add("TESTNIDTWO2#%s#%s" % (B64[1], B64[1]))
+    n_noslot = st.add("NOSLOTNID12#%s#%s" % (B64[0], B64[1]))
+
+    symtab = b"".join([
+        sym(0, 0, 0),                    # 0: the null symbol — no NID, must not shift the indices
+        sym(n_import1, 0, 0),            # 1: import, libSceTestOne
+        sym(n_local, 1, 0x500),          # 2: DEFINED here — never an import slot
+        sym(n_import2, 0, 0),            # 3: import, libSceTestTwo
+        sym(n_noslot, 0, 0),             # 4: import with no relocation at all
+    ])
+    jmprel_tab = b"".join([
+        rela(V_GOT + 0x00, 1, R_X86_64_JUMP_SLOT),
+        rela(V_GOT + 0x08, 3, R_X86_64_JUMP_SLOT),
+        rela(V_GOT + 0x10, 2, R_X86_64_JUMP_SLOT),   # against the DEFINED symbol
+    ])
+    rela_tab = b"".join([
+        rela(V_GOT + 0x20, 1, R_X86_64_GLOB_DAT),
+        rela(V_GOT + 0x28, 0, R_X86_64_RELATIVE, 0x1234),      # no symbol -> skipped
+        rela(V_GOT + 0x30, 1, R_X86_64_DTPMOD64),              # TLS against an import -> counted
+    ])
+
+    dyn = [
+        (DT_SCE_IMPORT_LIB, (0 << 48) | lib_one),
+        (DT_SCE_IMPORT_LIB, (1 << 48) | lib_two),
+        (DT_SCE_NEEDED_MODULE, (1 << 48) | module),
+        (DT_STRTAB, V_STRTAB), (DT_STRSZ, len(st.blob)),
+        (DT_SYMTAB, V_SYMTAB), (DT_SYMENT, 24), (DT_SCE_SYMTABSZ, len(symtab)),
+        (DT_PLTREL, DT_RELA), (DT_RELAENT, 24),
+    ]
+    if jmprel:
+        jmprel_va = V_JMPREL
+        if unmapped_jmprel:
+            jmprel_va = 0xDEAD0000
+        elif zero_jmprel_va:
+            jmprel_va = 0
+        dyn += [(DT_JMPREL, jmprel_va), (DT_PLTRELSZ, len(jmprel_tab))]
+    if rela_table:
+        dyn += [(DT_RELA, V_RELA), (DT_RELASZ, len(rela_tab))]
+    dyn += [(DT_NULL, 0)]
+    dyn_blob = b"".join(struct.pack("<qQ", t, v) for t, v in dyn)
+
+    phdrs = b"".join([
+        phdr(PT_LOAD, 5, 0, 0, SEG_RW),                              # r-x
+        phdr(PT_LOAD, 6, SEG_RW, SEG_RW, SEG_SIZE),                  # rw-, holds every table
+        phdr(PT_DYNAMIC, 6, V_DYNAMIC, V_DYNAMIC, len(dyn_blob)),
+    ])
+    ehdr = struct.pack(
+        "<16sHHIQQQIHHHHHH",
+        b"\x7fELF\x02\x01\x01\x09" + b"\0" * 8, ET_SCE_DYNEXEC, EM_X86_64, 1,
+        0x100, 64, 0, 0, 64, 56, 3, 64, 0, 0)
+
+    buf = bytearray(b"\0" * FILE_SIZE)
+    buf[0:len(ehdr)] = ehdr
+    buf[64:64 + len(phdrs)] = phdrs
+    buf[V_DYNAMIC:V_DYNAMIC + len(dyn_blob)] = dyn_blob
+    buf[V_STRTAB:V_STRTAB + len(st.blob)] = st.blob
+    buf[V_SYMTAB:V_SYMTAB + len(symtab)] = symtab
+    buf[V_JMPREL:V_JMPREL + len(jmprel_tab)] = jmprel_tab
+    buf[V_RELA:V_RELA + len(rela_tab)] = rela_tab
+    return bytes(buf)
+
+
+def run(binary: str, blob: bytes, extra=(), names_dir=None):
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "fixture.elf"
+        path.write_bytes(blob)
+        cmd = [binary, str(path), "--import-slots"] + list(extra)
+        if names_dir:
+            cmd += ["--names", names_dir]
+        done = subprocess.run(cmd, capture_output=True, text=True)
+        return done.returncode, done.stdout
+
+
+def slot_rows(out: str):
+    """The `<slot> <NID> <library> <name> <reloc>` rows, keyed by slot."""
+    rows = {}
+    for line in out.splitlines():
+        if not line.startswith("0x"):
+            continue
+        f = line.split()
+        if len(f) == 5:
+            rows[f[0]] = f[1:]
+    return rows
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: test_import_slots.py <path-to-self_dump>", file=sys.stderr)
+        return 2
+    binary = sys.argv[1]
+    failures = []
+
+    def check(name, condition, detail=""):
+        if condition:
+            print("ok   - %s" % name)
+        else:
+            print("FAIL - %s %s" % (name, detail))
+            failures.append(name)
+
+    # --- Cases 1-5: the full fixture ----------------------------------------------------------
+    code, out = run(binary, build_fixture())
+    rows = slot_rows(out)
+
+    check("a JUMP_SLOT relocation reports the slot from r_offset",
+          rows.get("0x00000001f00", [None])[0] == "TESTNIDONE1", "\n" + out)
+    check("the slot row names the import's library",
+          rows.get("0x00000001f00", [None, None])[1:2] == ["libSceTestOne"], "\n" + out)
+    check("the second import resolves through its own library id",
+          rows.get("0x00000001f08", [None, None])[0:2] == ["TESTNIDTWO2", "libSceTestTwo"],
+          "\n" + out)
+    check("a GLOB_DAT relocation in DT_RELA is a slot too",
+          rows.get("0x00000001f20", [None] * 5)[3] == "GLOB_DAT", "\n" + out)
+    check("the JUMP_SLOT row is labelled JUMP_SLOT",
+          rows.get("0x00000001f00", [None] * 5)[3] == "JUMP_SLOT", "\n" + out)
+
+    # A relocation against a symbol this module DEFINES is not an import slot. This is the arm the
+    # index alignment protects: the null symbol carries no NID, so a parser that skipped it would
+    # shift every index by one and report symbol 2 (local) under symbol 1's identity.
+    check("a relocation against a defined symbol is not an import slot",
+          "0x00000001f10" not in rows, "\n" + out)
+    check("no row claims the local symbol's name",
+          "LOCALSYMBOL" not in out, "\n" + out)
+
+    check("the run reports three slots over two of three imports",
+          "3 slots over 2 of 3 imports" in out, "\n" + out)
+    check("an import with no relocation is listed rather than dropped",
+          "[IMPORTS WITHOUT A SLOT] (1" in out and "NOSLOTNID12" in out, "\n" + out)
+    check("a non-address relocation against an import is counted, not reported as a slot",
+          "type16 x1" in out, "\n" + out)
+    check("both relocation tables are named with their entry counts",
+          "entries=3 (DT_JMPREL/DT_PLTRELSZ" in out and "entries=3 (DT_RELA/DT_RELASZ" in out,
+          "\n" + out)
+    check("a run that found slots exits 0", code == 0, "got exit %d" % code)
+
+    # --- Case 6: no relocation tables at all --------------------------------------------------
+    code, out = run(binary, build_fixture(jmprel=False, rela_table=False))
+    check("a module with no relocation tables says so explicitly",
+          "0 import slots — the dynamic table declares neither DT_JMPREL nor DT_RELA" in out,
+          "\n" + out)
+    check("a zero result exits 3 rather than 0", code == 3, "got exit %d" % code)
+    check("a zero result still reports what was parsed",
+          "imports=3" in out and "jmprel absent" in out, "\n" + out)
+
+    # --- Case 7: a declared table that does not map -------------------------------------------
+    # The defect class #2399 is about: an unreadable table must never look like an empty one.
+    code, out = run(binary, build_fixture(rela_table=False, unmapped_jmprel=True))
+    check("an unmapped relocation table is reported as UNMAPPED", "UNMAPPED" in out, "\n" + out)
+    check("an unmapped table is not reported as 'no relocation references an import'",
+          "every declared relocation table is unmapped" in out, "\n" + out)
+    check("an unmapped table exits 3", code == 3, "got exit %d" % code)
+
+    # --- Case 7b: a table address of 0 is "absent", never "at vaddr 0" ------------------------
+    # A PS5 executable's first PT_LOAD IS mapped at vaddr 0, so resolving a zero table address
+    # succeeds and hands back the ELF header — which would be parsed as relocations and reported
+    # as slots. The wrong answer would look exactly like a right one, which is what makes it worth
+    # a case of its own rather than folding into the "no tables" arm.
+    code, out = run(binary, build_fixture(rela_table=False, zero_jmprel_va=True))
+    check("a zero table address is reported as absent, not resolved to vaddr 0",
+          "jmprel absent" in out and "malformed dynamic table" in out, "\n" + out)
+    check("a zero table address produces no rows", not slot_rows(out), "\n" + out)
+    check("a zero table address exits 3", code == 3, "got exit %d" % code)
+
+    # --- Case 8: the firmware stub dump fills the name column ---------------------------------
+    with tempfile.TemporaryDirectory() as names:
+        Path(names, "libSceTestOne.c").write_text(
+            'void __stub(void) {\n'
+            '  if(sprx_dlsym(__handle, "TESTNIDONE1", &__ptr_sceTestFunctionOne)) return;\n'
+            '}\n')
+        code, out = run(binary, build_fixture(), names_dir=names)
+        rows = slot_rows(out)
+        check("a named NID resolves to its function name",
+              rows.get("0x00000001f00", [None] * 5)[2] == "sceTestFunctionOne", "\n" + out)
+        check("an unnamed NID still prints its slot and NID",
+              rows.get("0x00000001f08", [None] * 5)[0:3] == ["TESTNIDTWO2", "libSceTestTwo", "-"],
+              "\n" + out)
+        check("the name table's provenance is printed",
+              "1 files, 1 pairs, 1 distinct NIDs" in out, "\n" + out)
+
+    code, out = run(binary, build_fixture(), names_dir="/nonexistent-name-table")
+    check("an unreadable name table says so instead of silently emptying the name column",
+          "is not a readable directory" in out, "\n" + out)
+    check("an unreadable name table does not suppress the slots", code == 0, "got exit %d" % code)
+
+    # --- the flag is opt-in: without it, the tool's existing output is unchanged ---------------
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "fixture.elf"
+        path.write_bytes(build_fixture())
+        done = subprocess.run([binary, str(path)], capture_output=True, text=True)
+        check("without --import-slots nothing is printed and the exit code stays 0",
+              done.returncode == 0 and "[IMPORT SLOTS]" not in done.stdout,
+              "exit %d\n%s" % (done.returncode, done.stdout))
+
+    print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/self_dump/test_import_slots.py
+++ b/prosper/tools/self_dump/test_import_slots.py
@@ -152,15 +152,25 @@ def build_fixture(*, jmprel=True, rela_table=True, unmapped_jmprel=False,
     return bytes(buf)
 
 
+ALL_OUTPUT = []   # every stdout this test has seen, for the ASCII invariant below
+
+
 def run(binary: str, blob: bytes, extra=(), names_dir=None):
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "fixture.elf"
-        path.write_bytes(blob)
+        path.write_bytes(blob)          # binary mode: the fixture must reach the tool byte-exact
         cmd = [binary, str(path), "--import-slots"] + list(extra)
         if names_dir:
             cmd += ["--names", names_dir]
-        done = subprocess.run(cmd, capture_output=True, text=True)
-        return done.returncode, done.stdout
+        # Decode explicitly, NOT with text=True. text=True uses
+        # locale.getpreferredencoding(), which is UTF-8 on Linux and cp1252 on Windows — so the
+        # same bytes would compare differently per platform and a Linux-green run could not see
+        # it. errors="replace" keeps a mis-decode visible (U+FFFD is non-ASCII, so the invariant
+        # check below fails) rather than raising something that reads as a crash.
+        done = subprocess.run(cmd, capture_output=True)
+        out = done.stdout.decode("utf-8", errors="replace")
+        ALL_OUTPUT.append((" ".join(cmd[1:]), out))
+        return done.returncode, out
 
 
 def slot_rows(out: str):
@@ -226,9 +236,13 @@ def main() -> int:
 
     # --- Case 6: no relocation tables at all --------------------------------------------------
     code, out = run(binary, build_fixture(jmprel=False, rela_table=False))
-    check("a module with no relocation tables says so explicitly",
-          "0 import slots — the dynamic table declares neither DT_JMPREL nor DT_RELA" in out,
-          "\n" + out)
+    # Asserted as two ASCII substrings rather than one quoted sentence: the zero, and the reason
+    # for it. Matching the whole sentence made this the only check in the file that spanned a
+    # non-ASCII character, and it was the only one that failed on Windows.
+    check("a module with no relocation tables reports zero slots",
+          "0 import slots" in out, "\n" + out)
+    check("a module with no relocation tables says WHY it is zero",
+          "the dynamic table declares neither DT_JMPREL nor DT_RELA" in out, "\n" + out)
     check("a zero result exits 3 rather than 0", code == 3, "got exit %d" % code)
     check("a zero result still reports what was parsed",
           "imports=3" in out and "jmprel absent" in out, "\n" + out)
@@ -281,6 +295,22 @@ def main() -> int:
         check("without --import-slots nothing is printed and the exit code stays 0",
               done.returncode == 0 and "[IMPORT SLOTS]" not in done.stdout,
               "exit %d\n%s" % (done.returncode, done.stdout))
+
+    # --- the output is ASCII on every message path -------------------------------------------
+    # The property, not a re-spelling of one message: stdout carries BYTES, and whoever reads them
+    # decodes by platform (UTF-8 on Linux, the cp1252/cp437 console code page on Windows). Any
+    # non-ASCII byte therefore renders as mojibake in cmd.exe and breaks a `grep` for the very
+    # line the tool printed. Checked over every run above — including the zero-result and
+    # name-table paths, which is where the five em dashes actually were.
+    offenders = []
+    for cmd, out in ALL_OUTPUT:
+        for lineno, line in enumerate(out.splitlines(), 1):
+            bad = {c for c in line if ord(c) > 127}
+            if bad:
+                offenders.append("%s: line %d: %s in %r"
+                                 % (cmd, lineno, sorted(hex(ord(c)) for c in bad), line[:90]))
+    check("every byte the tool prints is ASCII, on all %d runs" % len(ALL_OUTPUT),
+          not offenders, "\n" + "\n".join(offenders[:10]))
 
     print("\n%d checks failed" % len(failures) if failures else "\nall checks passed")
     return 1 if failures else 0


### PR DESCRIPTION
Fixes #1625.

## The gap

"Who calls this Sony function, and what does the guest do with the result?" is the question that starts
most HLE contract work. It is how #1592 was root-caused: the guest's own `test eax,eax` / `jns` around
`scePadGetHandle` proved the contract prosper was violating, and the fix took the title from a stuck
title screen to gameplay.

Reaching that disassembly took four steps, of which exactly one was manual — **find the import's GOT
slot by hand-parsing `DT_JMPREL`, because nothing printed it.** It was hand-parsed during #1592 and
would have been again on the next title.

## What the flag emits

```
self_dump <DUMP_ROOT>/<TITLE>-app0/eboot.bin --import-slots [--names <PS5-3.20_Libs dir>]
```

```text
[IMPORT SLOTS] file=<DUMP_ROOT>/PPSA20052-app0/eboot.bin
[IMPORT SLOTS] jmprel va=0xd1c900 size=0x3cd8 entries=649 (DT_JMPREL/DT_PLTRELSZ, entsize=24)
[IMPORT SLOTS] rela   va=0xd205d8 size=0x92088 entries=24923 (DT_RELA/DT_RELASZ, entsize=24)
[IMPORT SLOTS] symbols=683 imports=682 relocations-read=25572
[IMPORT SLOTS] names: ../PS5-3.20_Libs (275 files, 39158 pairs, 31275 distinct NIDs)
#slot         NID          library                          name                       reloc
...
0x000007f9b18 u1GRHp+oWoY  libScePad                        scePadGetHandle            JUMP_SLOT
0x000007f9b28 xk0AcarP3V4  libScePad                        scePadOpen                 JUMP_SLOT
...
[IMPORT SLOTS] 764 slots over 681 of 682 imports
[IMPORTS WITHOUT A SLOT] (1 — imported but no address relocation targets them in this module)
```

One row per (relocation slot, imported symbol) pair: `DT_JMPREL`/`DT_PLTRELSZ` and
`DT_RELA`/`DT_RELASZ` are read (with Sony's `DT_SCE_*` aliases as a fallback), and every relocation of
type `JUMP_SLOT`, `GLOB_DAT` or `64` whose symbol is an undefined NID-encoded import becomes a row.
`--names` points at the PS5 3.20 firmware stub dump (`$PROSPER_PS5_LIBS` is the fallback); **the NID is
printed either way**, so an import the dump does not name is still actionable.

## Known-answer verification — end to end, on the case #1592 recorded by hand

The issue names the check: `scePadGetHandle` in `PPSA20052` (*Worms Armageddon*), whose call sites are
already recorded on #1592. Reproduced on this branch, no hand-parsing anywhere:

```bash
# 1. the slot — this is the step that did not exist before
./build-linux/self_dump <DUMP_ROOT>/PPSA20052-app0/eboot.bin \
    --import-slots --names ../PS5-3.20_Libs | grep scePadGetHandle
#   0x000007f9b18 u1GRHp+oWoY  libScePad  scePadGetHandle  JUMP_SLOT

# 2. flatten, then walk out from the slot
python3 tools/il2cpp/prx_to_elf.py <DUMP_ROOT>/PPSA20052-app0/eboot.bin ~/work/eboot.elf
python3 tools/re/xref.py ~/work/eboot.elf to 0x7f9b18
python3 tools/re/xref.py ~/work/eboot.elf to 0x60c8e0
```

```text
module …/ppsa20052.elf: 5 PT_LOAD, 0x60ecdc bytes executable; decoded 94475 code reference
sites to 29057 distinct addresses, and 24808 data-pointer relocations to 11982 distinct addresses
query: to 0x7f9b18
data-pointer relocations targeting 0x7f9b18: 0
code references to 0x7f9b18: 1 (0 write, 0 read, 0 address-taken)
   [x ] jmp*    at 0x60c8e0  (in func 0x60c3e0)          # the PLT stub

query: to 0x60c8e0
code references to 0x60c8e0: 9 (0 write, 0 read, 0 address-taken)
   [x ] call    at 0x7fc74  (in func 0x7fa30)
   [x ] call    at 0x7fca4  (in func 0x7fa30)
   [x ] call    at 0x7fcd4  (in func 0x7fa30)
   [x ] call    at 0x7fd0b  (in func 0x7fa30)
   [x ] call    at 0x7fd5c  (in func 0x7fa30)            # <- #1592's site
   [x ] call    at 0x7fdac  (in func 0x7fa30)
   [x ] call    at 0x7fdfc  (in func 0x7fa30)
   [x ] call    at 0x7fe4c  (in func 0x7fa30)
   [x ] call    at 0x800d9  (in func 0x7fa30)            # <- #1592's second site
```

#1592 recorded `call scePadGetHandle ; eboot+0x7fd5c`, a second site at `+0x800d9`, a close path whose
`jle` is at `+0x7fc7b` (the `call` before it is `0x7fc74`), and "the whole pad manager is one function
at `eboot+0x7fa30`". All four match, including the containing function — which is an independent
confirmation, since nothing in this change knows about function boundaries.

**One correction to the issue's framing, and it is worth recording:** this is *not* a two-command
lookup. The GOT slot's only direct reference is the PLT stub; the callers reference the **stub**. So it
is one `self_dump` lookup and **two** `xref.py` queries. The manual relocation parse — the step this
PR removes — is gone either way. `tools/re/README.md` now documents the hop with this exact worked
example, so nobody rediscovers it by concluding a slot has one caller.

`xref.py` was **not edited here** — #2399 was fixed in parallel and landed as #2558, which this branch
is rebased onto. The transcript above is from the **post-#2558** `xref.py`, so both queries carry its
new provenance line (`decoded 94475 code reference sites …`): the run demonstrably executed, which is
exactly the assurance #2399 was about. The same two queries returned the same nine call sites before
that fix landed, so the known-answer result does not depend on it either way.

## Correctness: an empty result can never be confused with a failed parse

This is the defect class of #2399, and a tool that answers "nothing" when it means "I did not parse
anything" is worse than one that refuses. So:

* every run prints **which relocation tables it read and how many entries each held**, how many symbols
  and imports it parsed, and **which name table it used** (including "none", and including
  "'<path>' is not a readable directory");
* a relocation table whose vaddr maps into no segment is reported as **`UNMAPPED`, and its relocations
  are explicitly not read** — never silently treated as empty;
* a table longer than the file is **`[TRUNCATED to the file's end]`** rather than parsed into
  zero-filled entries;
* **zero rows names its own cause** — "this module imports nothing" / "the dynamic table declares
  neither DT_JMPREL nor DT_RELA" / "every declared relocation table is unmapped" / "the relocation
  tables are declared but empty" / "no relocation of type 64/GLOB_DAT/JUMP_SLOT references an imported
  symbol" — and **exits 3**;
* imports with no relocation are listed under `[IMPORTS WITHOUT A SLOT]`, so **a `grep` that finds
  nothing means the module does not import that function**, never "it has no slot";
* a relocation against an import whose type is *not* an address slot (TLS `DTPMOD64` and friends) is
  **counted and reported** rather than dropped.

## Invariants and other changes

* **The symbol vector is now index-aligned with the symbol table.** Non-NID entries (the null symbol)
  were skipped, so a relocation's `r_info >> 32` could not index it — an off-by-N that would have
  mis-named every slot. They are kept as placeholders with a new `nid_encoded` flag and the existing
  consumers filter on it. **Control:** `--symbols` and `--find-symbol` output is byte-identical to
  `origin/master` on all 44 local dumps apart from four dynamic tags that previously printed as `?`
  (`DT_PLTRELSZ`, `DT_RELA`, `DT_RELASZ`, `DT_RELAENT`, now named). Exit codes unchanged: `--find-symbol`
  still returns 2 when a NID is absent, including when combined with `--import-slots`.
* **`tools/common/nid_stub_names.hpp`** — the firmware stub dump's `<NID> ↔ <name>` parse, extracted so
  `self_dump` and `nid_census` cannot drift into two readings of the same dump. `nid_census` keeps its
  `--self-check` control through an `on_pair` callback; its behaviour is unchanged. Header-only and
  free of `prosper_core`, because `self_dump` is deliberately a standalone single translation unit.
* **No implicit path search for the name table.** A table that appeared from a directory the caller did
  not name would make the `name` column's provenance unknowable, which is the one thing this flag must
  not do. Explicit `--names`, else `$PROSPER_PS5_LIBS`, else none — and the run says which.
* Bounds: every table read is clamped to the file, and a declared entry size below `sizeof(Elf64_Rela)`
  is raised to it, so a malformed size can only under-read, never over-read.

## Confidence

* **`CONFIDENCE: HIGH`** that `r_offset` is the image-relative slot address. It is the address prosper's
  own loader writes the resolved import into for `R_X86_64_JUMP_SLOT`/`R_X86_64_GLOB_DAT`
  (`src/self/module.cpp`, `apply_relocations`), and the known-answer check above closes the loop against
  independently recorded evidence.
* **`CONFIDENCE: MED`** on the `DT_SCE_JMPREL`/`DT_SCE_PLTRELSZ`/`DT_SCE_RELA`/`DT_SCE_RELASZ` aliases.
  **All 44 local title dumps declare the standard tags** — I checked every one — so the alias path is a
  documented fallback with no local evidence behind it. It is marked as such in the source, and the run
  prints which tag it read, so a title that does use them will say so rather than answer silently.

## Deliberately not done

* **No PLT-stub scanner.** Mapping a slot back to its stub would mean scanning executable bytes for
  `ff 25` — a hand-rolled scan of the kind that produced the false positives retracted in #2396, and
  duplicating a decoder `xref.py` already owns and tests. The two-query recipe is documented instead.
* **`self_dump` still does not link `prosper_core`.** Its independent parser is a cross-check on
  `Module::load` rather than a duplicate of it, and the standalone build in its header comment still
  works.

## Risks

* `--import-slots` reports `GLOB_DAT`/`64` rows as well as `JUMP_SLOT`, so a busy title lists several
  times more slots than imports (8,265 over 1,664 imports on `PPSA01826`). That is correct — those are
  the same address stored in a vtable or static initialiser — but a reader after the *call* path wants
  `grep JUMP_SLOT`. Documented in both READMEs.
* New exit code 3 on an empty `--import-slots`. Nothing in the repo consumes `self_dump`'s exit code
  today; it will abort a `set -e` script that expects 0 from a module with no import slots, which is
  the intended fail-visible behaviour.

## Test

`prosper/tools/self_dump/test_import_slots.py`, registered as **`self_dump_import_slots`** (Python3
only, no game dump, runs in CI). Its fixtures are PS5-shaped ELFs **written byte by byte in the test**
rather than extracted from a dump or produced by any part of `self_dump` — an independent statement of
the relocation layout, so a wrong reading of it fails here. 27 checks: the `JUMP_SLOT` and `GLOB_DAT`
slot rows, library resolution through two different library ids, the negative arm (a relocation against
a *defined* symbol is not an import slot), the no-slot listing, the non-address-type count, the three
zero-result arms and their exit code 3 (no relocation tables, an `UNMAPPED` table, a zero table
address), name-table resolution and provenance, an unreadable name table, and that the flag is opt-in.

### Mutation arms — each was applied to a scratch copy, rebuilt, and the test re-run

| # | mutation | result |
| --- | --- | --- |
| 1 | slot column prints `r_addend` instead of `r_offset` | **7 checks failed** |
| 2 | the `is_import` filter is dropped | **4 checks failed** |
| 3 | non-NID symbols are skipped, breaking index alignment | **10 checks failed** |
| 4 | only `DT_JMPREL` is scanned, `DT_RELA` ignored | **4 checks failed** |
| 5 | a zero result exits 0 instead of 3 | **3 checks failed** |
| 6 | a zero table address is resolved instead of treated as absent | **2 checks failed** |
| 7 | an unmapped table is silently skipped instead of reported | **1 check failed** |

Verbatim, arms 1, 2 and 6:

```text
--- MUTATION: M1 slot column prints r_addend instead of r_offset ---
FAIL - a JUMP_SLOT relocation reports the slot from r_offset
FAIL - the slot row names the import's library
FAIL - the second import resolves through its own library id
FAIL - a GLOB_DAT relocation in DT_RELA is a slot too
FAIL - the JUMP_SLOT row is labelled JUMP_SLOT
FAIL - a named NID resolves to its function name
FAIL - an unnamed NID still prints its slot and NID
7 checks failed

--- MUTATION: M2 the is_import filter is dropped ---
FAIL - a relocation against a defined symbol is not an import slot
FAIL - no row claims the local symbol's name
FAIL - the run reports three slots over two of three imports
FAIL - an import with no relocation is listed rather than dropped
4 checks failed

--- MUTATION: M6 a zero table address is resolved instead of treated as absent ---
FAIL - a zero result still reports what was parsed
FAIL - a zero table address is reported as absent, not resolved to vaddr 0
2 checks failed
```

Arm 6 is the one worth reading: it is a **real defect this review found and fixed before landing**. A
relocation table whose declared address is 0 was being resolved rather than treated as absent — and
because a PS5 executable's first `PT_LOAD` is mapped at vaddr 0, that resolution *succeeded* and would
have parsed the ELF header as relocations. A wrong answer that looks exactly like a right one is the
worst thing this tool could do, so it now reports the table as absent and notes the orphaned size.

## Windows MinGW CI failure, and what it actually was

The first head was green on Linux and **red on `Windows MinGW`**, on exactly one check:
`a module with no relocation tables says so explicitly`. It is a genuine portability defect in the
tool, not a test artifact, and it was fixed rather than relaxed.

**Mechanism, established before changing anything.** Five of the messages this flag prints contained a
UTF-8 EM DASH (`U+2014` = `e2 80 94`). stdout carries *bytes*; whoever reads them decodes by platform.
Python's `subprocess.run(..., text=True)` decodes with `locale.getpreferredencoding()` — UTF-8 on
Linux, **cp1252 on Windows** — so the needle never matched there. Reproduced deterministically on
Linux by forcing the decode:

```text
raw bytes of the line: b'[IMPORT SLOTS] 0 import slots \xe2\x80\x94 the dynamic table declares' ...
utf-8    -> needle found: True
cp1252   -> needle found: False
cp437    -> needle found: False
```

Exactly one assertion in the file spanned a non-ASCII character, and exactly one check failed. Every
other check matched ASCII-only substrings and passed on Windows — including the ones using `%zu`, so
the format specifiers were never the problem.

**It was hurting the user, not only the test.** The same bytes are what a Windows console renders:

```text
cp1252 render: [IMPORT SLOTS] 0 import slots â€” the dynamic table declares neither DT_JMPREL
cp437  render: [IMPORT SLOTS] 0 import slots ΓÇö the dynamic table declares neither DT_JMPREL
```

So on Windows a `grep` for the line the tool itself printed would not match it. For a tool whose whole
purpose is `--import-slots | grep <name>`, that is the defect.

**Fix, in three parts.**
1. **The tool's stdout is now ASCII** — all five em dashes in printed literals became `--`. Comments
   and docs keep theirs; the rule is stated in the source next to the code it binds.
2. **The test decodes explicitly as UTF-8** instead of `text=True`, so the same bytes compare the same
   way on every platform. `errors="replace"` keeps a mis-decode visible rather than raising.
3. **The assertion is ASCII-stable by construction** — split into the zero (`0 import slots`) and the
   reason (`the dynamic table declares neither DT_JMPREL nor DT_RELA`), neither spanning punctuation.
   It is not weaker: both substrings must appear, and it still fails on every arm below.

**Plus the invariant that stops this recurring**, which is the property rather than a re-spelling of
one message: a check asserting **every byte the tool prints is ASCII**, over all 6 runs the test makes,
naming the offending code point and line when it fails.

### Verified against a real Windows artifact, not by reasoning alone

`x86_64-w64-mingw32-g++` (GCC 16.1.1) is available in the build container, so both binaries were
cross-compiled and the actual PE inspected — a firing control and its negative:

```text
self_dump_prefix.exe     size=396408   em-dash (e2 80 94) byte sequences: 5
self_dump_fixed.exe      size=396408   em-dash (e2 80 94) byte sequences: 0
```

`file` confirms `PE32+ executable for MS Windows ... x86-64`, so this really is the Windows target and
not a silently-native build. The fixed `.exe` still carries `0 import slots -- %s`,
`the dynamic table declares neither DT_JMPREL nor DT_RELA`, `[IMPORTS WITHOUT A SLOT] (%zu -- imported`
and `names: none -- pass --names`, so nothing was dropped.

`self_dump.cpp` contains **no preprocessor conditionals at all**, so the printed literals are identical
on both targets and the Linux ASCII-guard result transfers to Windows by construction. (I could not
*execute* the `.exe` — no wine on this host — which is why the byte-level check on the PE plus the
no-`#ifdef` argument is the evidence offered, rather than a claimed Windows run.)

### The new guard's own control

Run against the **pre-fix** binary, the guard fires and localises the defect:

```text
FAIL - every byte the tool prints is ASCII, on all 6 runs
  ...: line 50: ['0x2014'] in '[IMPORT SLOTS] 0 import slots — the dynamic table declares neither ...'
  ...: line 51: ['0x2014'] in '[IMPORTS WITHOUT A SLOT] (3 — imported but no address relocation ...'
1 checks failed
```

### Lesson recorded

A Linux-green run could not have caught this: **187 tests register on the Windows CI job against 247 on
Linux**, and the failing property was invisible to the platform I could run. The generalisable rule —
now written into the test — is to assert parsed fields and platform-invariant substrings rather than
rendered sentences, and to assert the portability property directly when output is the product.

## Build and test commands

Linux, inside the project's build container:

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4                       # exit 0
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

```text
 76/247 Test   #3: self_dump_import_slots .........................   Passed    0.04 sec
...
247/247 Test #112: file_binary_roundtrip ..........................   Passed  565.00 sec

100% tests passed out of 247

Total Test time (real) = 565.05 sec
```

**Build exit 0; `ctest` exit 0 with 247 tests discovered and 247 passed.** `--no-tests=error` was
passed, so the exit code is meaningful rather than the "nothing ran" 0. The new test is `#3`,
`self_dump_import_slots`. This run is on the **exact rebased head** — the rebase pulled in a
`prosper_core` change (#2557), so the whole tree was rebuilt (208 edges) and the suite re-run rather
than reusing the pre-rebase result. `nid_census` was re-run against the real
stub dump after the refactor and reports the same **39,158 pairs, 0 self-check mismatches** — the same
pair count `self_dump --import-slots` now prints, which is the check that the two tools read the dump
identically.

Sweep, as a robustness control rather than a test: `--import-slots` was run against **all 44 local
title dumps**; every one parsed, every one exited 0, and every one declared the standard
`DT_JMPREL`/`DT_PLTRELSZ`.

No snapshots were run: this change touches no renderer, GPU or HLE code path — only an offline
inspector, a header-only parser shared with another offline tool, and documentation.
