### PR TITLE
audio: measure whether the guest WRITES a silent port's grain, and measure the bed fold end to end

### DIFF
--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -378,9 +378,10 @@ Note that the first two fall silent in cases 1 **and** 2, which is why `PROSPER_
 - **"The mix loop might not be applying the fold table it documents."** Falsified end to end, not by
   inspection: `test_audio`'s `test_bed_routing_matrix` pushes one unit impulse per source channel
   through the real `sceAudioOut2*` entrypoints for **every** width 1..16 and reads the gain that
-  arrives at the host sink. All 96 placed gains match the table, and every channel at index ≥ 8
-  measures exactly `{0, 0}` at every width above 8 — the "unplaced" contract, measured rather than
-  asserted. Note precisely what this does and does not establish: it pins the **application** of the
+  arrives at the host sink. That is **136 channel measurements** across the sixteen widths: the
+  **100** placed ones all match the table's gains, and the **36** unplaced ones — every channel at
+  index ≥ 8, at every width above 8 — measure exactly `{0, 0}`, so the "unplaced contributes
+  nothing" contract is measured rather than asserted. Note precisely what this does and does not establish: it pins the **application** of the
   table, and the orientation question below is untouched by it (#1720).
 - **Which titles could ever settle the left/right orientation — surveyed, so nobody re-searches.**
   Only **5 of 44** dumps import `sceAudioOut2GetSpeakerInfo` (`DImz2Ft9E2g`), the one call through

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -172,8 +172,9 @@ guest's own PCM instead of assuming an enumeration, reporting every five seconds
 
 ```text
 [audio-layout] port1 ctx0 type=0x0 fmt=0xc00 channels=12 grain=256 frames=6856704 \
-               stride=n/a (single grain buffer 0x301e393a88, 26784 publications)
-[audio-layout]   ch0  rms=0.028960 peak=0.389781 nonzero= 89.8% hf=0.1210 corr= +1.00 +0.46 …
+               stride=n/a (single grain buffer 0x301e393a88, 26784 publications) fold=7.1 + 4 UNPLACED
+[audio-layout]   ch0  rms=0.028960 peak=0.389781 nonzero= 89.8% hf=0.1210 fold=L1.000/R0.000 \
+               corr= +1.00 +0.46 …
 ```
 
 - **`rms` / `peak` / `nonzero%`** — which channels carry the bed *at all*. A height channel a title
@@ -192,6 +193,13 @@ guest's own PCM instead of assuming an enumeration, reporting every five seconds
   double-buffering title makes this one grain's byte size, an **independent** measure of the channel
   count rather than a restatement of the `data_format` decode. A single-buffer title reports
   `stride=n/a` with the pointer and publication count, which is a finding, not a missing value.
+- **`fold`** — where prosper actually *sent* that channel: the `{left, right}` gain pair the mix
+  loop applied, or `UNPLACED` for a channel it has no position for. This is the other half of the
+  question and it used to be readable only by opening `hle_audio.cpp` and working the table by hand,
+  which is exactly the step nobody takes while reading a log. A channel that measures as a surround
+  feed and folds to `UNPLACED`, or one that measures centre-like and folds hard to one side, is now
+  visible in two adjacent lines. Non-MAIN ports print `fold=n/a`: they are not mixed to the host
+  bed at all, so claiming a placement for them would be a straight falsehood.
 
 `PROSPER_AUDIO_LAYOUT_DUMP=PATH` additionally appends each measured port's raw interleaved grain to
 `PATH.portN.<channels>ch.f32` as float32 (both sample types converted), so the measurement can be re-derived,
@@ -296,16 +304,107 @@ with this probe; it settles orientation in one run. That is
 the experiment #1720 asks for, and it is why a plausible-sounding wrong order is more dangerous than
 a reported gap.
 
+## Is the grain prosper READS the grain the guest WRITES? — `PROSPER_AUDIO_STAMP`
+
+Everything above is computed from one read of the guest's buffer, so none of it can separate the
+two causes of a port that measures exactly zero:
+
+- **(a)** the guest holds the bus open and mixes silence into it — a non-defect, and
+- **(b)** prosper is reading a buffer the guest never fills: a pointer published once at setup and
+  thereafter stale, one buffer of a pair we never see, or a read taken at the wrong point in the
+  guest's fill cycle. Real audio is being lost, silently.
+
+**A wrong address is exactly as zero as a silent mix.** `nonzero=0/55175168` is a statement about an
+instrument until something outside that instrument says otherwise, and no additional statistic
+derived from the same read can be that something — it would inherit the assumption under test.
+
+`PROSPER_AUDIO_STAMP` settles it by **writing**. After the mix has consumed a grain it stamps the
+guest's own grain buffer with a per-channel-distinct pattern, and on the next push classifies what
+comes back:
+
+| verdict | meaning |
+|---|---|
+| `CLEARED` | the stamp is gone and the grain is exactly zero — the guest **actively writes** this buffer and writes silence into it. Case (a), measured rather than assumed. |
+| `INTACT` | the stamp survived byte-for-byte — the guest never touched this buffer between two pushes. Case (b): prosper is reading dead memory, and this port's zero says nothing about the guest's mix. |
+| `OVERWRITTEN` | the stamp is gone and the grain carries something else — the guest fills this buffer with content the push-time read is not seeing. Case (b), timing rather than address. |
+| `POINTER-MOVED` | the guest republished a different address before the stamp could be read back. Itself a finding: the port is double-buffered, so a zero read of either buffer alone proves nothing. |
+
+```sh
+PROSPER_AUDIO_STAMP=<port>[:<pushes>[:<after>]]
+#   port    1-based, as printed by [audio-flow] / [audio-layout]
+#   pushes  how many pushes to stamp (default 8, max 64)
+#   after   how many of that port's pushes to let past first (default 0)
+```
+
+Three properties make a verdict from it worth quoting:
+
+- **It is self-validating.** The stamp is read back *immediately* after being written, through the
+  same `audio_read_bytes_partial()` the mix loop uses, and the per-channel non-zero counts of that
+  read-back are printed. A probe whose own read-back does not return what it wrote prints
+  `PROBE-INVALID` and draws **no verdict**. That read-back is a positive instance of "this exact
+  port can report a non-zero sample", constructed by hand and **outside** whatever produced the
+  null — a control drawn from the same silent guest could only ever have re-confirmed the silence.
+- **`after` is not a convenience, and skipping it will fake a result.** A title's first pushes are
+  routinely silent while it boots. Measured on *Dragon Quest VII* (150 s route): its 12-channel MAIN
+  port — the one carrying the whole soundtrack — is **exactly zero for the first ~43 seconds**. A
+  probe armed at push 0 therefore classifies the *known-good* port as `CLEARED` and "validates" an
+  instrument that was pointed at silence. Calibrate against a port measured to carry content, at a
+  moment it is measured to be carrying it.
+- **Guest memory is left byte-identical.** An `INTACT` stamp is rolled back to the bytes that were
+  there before it; in the other cases the guest has already replaced them itself.
+
+It is opt-in, names **one** port, and stops after a bounded number of pushes — the pushes it stamps
+do carry the stamp into the *following* push's flow/layout statistics, so an unbounded version would
+corrupt the very totals the investigation is reading. A malformed value disables the probe loudly
+rather than stamping some other port: a typo must cost a measurement, never produce a wrong one.
+
 Related, narrower probes: `PROSPER_AUDIOLOG=1` (legacy `sceAudioOut` path: per-port calls, bytes,
 peak and RMS), `PROSPER_AUDIO_DUMP=PATH` (raw `PATH.portN.raw` PCM for offline inspection),
 `PROSPER_AUDIO2LOG=1` (full AudioOut2 call trace with hexdumps), `PROSPER_AUDIO2_PROBE=1` (per-port
 PCM sampling, signal-bearing ports only) and `PROSPER_AUDIO2_CONTROL_PROBE=1` (control surface).
 Note that the first two fall silent in cases 1 **and** 2, which is why `PROSPER_AUDIO_FLOW` exists.
 
+## Ruled out — do not re-derive these
+
+- **"A silent AudioOut2 port might be pushing its PCM through `sceAudioOut2ContextBedWrite`, which
+  prosper stubs."** The stub is real — `audio2_ctx_bed_write` in `hle_audio.cpp` validates the
+  context handle and returns 0, mixing nothing — so the hypothesis is well formed and would explain
+  a port that reads as zero while the title is audible on hardware. It is nonetheless dead for the
+  whole local corpus: **0 of 44 dumps import the NID `DxGyV8dtOR8`**, scanned across every
+  `eboot.bin` and `.prx` in each dump. *Dragon Quest VII* imports exactly **14** AudioOut2
+  entrypoints, and `PortSetAttributes(id=0) + ContextPush` — the pair prosper reads — is the only
+  PCM path any of them offer. Re-run the scan before assuming it for a *new* dump; do not re-run it
+  for one already in the corpus (#1721).
+- **"The mix loop might not be applying the fold table it documents."** Falsified end to end, not by
+  inspection: `test_audio`'s `test_bed_routing_matrix` pushes one unit impulse per source channel
+  through the real `sceAudioOut2*` entrypoints for **every** width 1..16 and reads the gain that
+  arrives at the host sink. All 96 placed gains match the table, and every channel at index ≥ 8
+  measures exactly `{0, 0}` at every width above 8 — the "unplaced" contract, measured rather than
+  asserted. Note precisely what this does and does not establish: it pins the **application** of the
+  table, and the orientation question below is untouched by it (#1720).
+- **Which titles could ever settle the left/right orientation — surveyed, so nobody re-searches.**
+  Only **5 of 44** dumps import `sceAudioOut2GetSpeakerInfo` (`DImz2Ft9E2g`), the one call through
+  which a guest could learn the platform's own speaker positions: `PPSA04263` (GTA V, eboot),
+  `PPSA05143` (Little Nightmares III, eboot), `PPSA09804` (GRIS, via `AkSoundEngine.prx`),
+  `PPSA21564` (Astro Bot, eboot) and `PPSA26414` (R-Type Delta, eboot). GTA V alone additionally
+  imports `SpeakerArrayCreate` and `GetSpeakerArrayAmbisonicsCoefficients`. Every other title in the
+  corpus — *Dragon Quest VII* included — never asks, so for those the bed's order is something
+  prosper must infer and cannot negotiate. Start the orientation experiment from one of those five.
+
 ## Tests (`ctest`)
 - **`audio_hle`** (`tests/test_audio.cpp`) — always built. Drives the real HLE entrypoints through the
   dispatch table with a capturing sink: format decode (all 8 formats + unknown), port open/close,
   byte-exact PCM forwarding, `Output`/`Outputs`, volume, port state, exhaustion, and error paths.
+  It also carries **`test_bed_routing_matrix`**, which measures the fold end to end: one unit impulse
+  per source channel, for every width 1..16, pushed through the real `sceAudioOut2*` entrypoints, with
+  the resulting host `{L, R}` gain read back off the sink and printed as a routing matrix. That report
+  is the answer to "which guest channel landed in which host channel, and at what gain", and it is a
+  different claim from `test_stereo_downmix`'s: the latter pins the fold **table** against literals,
+  this pins the mix loop's **application** of it. A correct table applied through a wrong stride, tap
+  list or side produces exactly the output a wrong table would, and no assertion on the pure function
+  can see it. Its bulk oracle is `audio_stereo_downmix` itself, deliberately — so a handful of
+  placements are additionally asserted against literals at widths 3, 5, 6 and 7, the ones no other
+  end-to-end arm exercises.
 - **`audio_sdl3`** (`frontends/audio_sdl3/test_audio_sdl3.cpp`) — built with `-DPROSPER_AUDIO_SDL3=ON`.
   End-to-end through the real SDL3 backend under the SDL **dummy** audio driver, so it runs on
   headless CI with no sound hardware.

--- a/prosper/docs/AUDIO.md
+++ b/prosper/docs/AUDIO.md
@@ -390,6 +390,27 @@ Note that the first two fall silent in cases 1 **and** 2, which is why `PROSPER_
   imports `SpeakerArrayCreate` and `GetSpeakerArrayAmbisonicsCoefficients`. Every other title in the
   corpus — *Dragon Quest VII* included — never asks, so for those the bed's order is something
   prosper must infer and cannot negotiate. Start the orientation experiment from one of those five.
+  Their MAIN port widths, measured with `PROSPER_AUDIO_FLOW=1` on a short default boot:
+
+  | title | MAIN `data_format` | channels | note |
+  |---|---|---|---|
+  | `PPSA26414` R-Type Delta | `0xc00` (two MAIN ports; port38 has `flags=0x2`) | 12 | **the best candidate**: a wide bed AND it queries `GetSpeakerInfo` |
+  | `PPSA21564` Astro Bot | `0x800` | 8 | |
+  | `PPSA05143` Little Nightmares III | `0x880` | 8 | **bit 7 set** — see below |
+  | `PPSA09804` GRIS (Wwise) | `0x880` | 8 | **bit 7 set** |
+
+- **`data_format` bit 7 is set by two titles and prosper drops it. Whether it names the channel
+  order is UNVERIFIED — do not repeat the code comment as fact.** `hle_audio.cpp:630` says the bit
+  "selects the standard 8-channel order", which if true would mean the format word carries ordering
+  information and the order is not purely an inference. Two things are established and one is not:
+  **measured**, two titles set it (`0x880` above) and two do not; **established by reading the
+  code**, nothing in prosper consumes it — it is masked off at `hle_audio.cpp:1023` and `:1999`
+  (`& 0x7fu`) and `audio2_format_channels` uses only bits 8..15. **Not established**: what the bit
+  means. The comment entered in #1347, a GTA V *decode* change, with no evidence recorded for it,
+  and it is exactly the shape of claim this project has been burned by — a plausible sentence with a
+  `file:line` that everyone downstream treats as checked. Treat it as a lead for #1720, not as a
+  premise, and re-derive it from a title's own disassembly or from an A/B before building on it.
+  `CONFIDENCE: LOW`.
 
 ## Tests (`ctest`)
 - **`audio_hle`** (`tests/test_audio.cpp`) — always built. Drives the real HLE entrypoints through the

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -365,8 +365,22 @@ current build.
   without resting on the mapping it is used to support. Within the residue, ch4/ch6 correlate +0.96 and ch5/ch7 +0.95 while ch4/ch5 is -0.04, so
   the surround tier pairs even=left / odd=right; ch2 correlates near-equally with both groups
   (centre-like). Reproduced identically on a second independent 150 s run.
-  **The 8-channel port (ctx1/port2) remains exactly zero** — 0 non-zero of 55,175,168 samples —
-  even though prosper forwards it. That is a separate open question (#1721), not this fix.
+  **The 8-channel port (ctx1/port2) is exactly zero — and that is the GUEST's silence, not
+  prosper's blindness (#1721, settled).** 0 non-zero of 55,175,168 samples, and prosper forwards it
+  anyway. The reading is now measured rather than inferred, because an exact zero from a read cannot
+  by itself distinguish "the guest mixes silence here" from "prosper is reading a buffer the guest
+  never fills" — a wrong address is exactly as zero as a silent mix. `PROSPER_AUDIO_STAMP=2:8:13000`
+  (see `AUDIO.md`) writes a per-channel-distinct pattern into that port's own grain after consuming
+  it and reports what comes back on the next push: **`CLEARED` on every arm** — the stamp is gone
+  and the grain is exactly zero, so the guest *actively writes* the buffer at `0x250101e000` and
+  writes silence into it. A live bus carrying nothing. The control that makes this worth quoting ran
+  on the same port in the same run: the probe's own read-back reported **256 non-zero samples on
+  each of the 8 channels**, so the reader demonstrably can report a non-zero sample here. Calibrated
+  against port1 in an identical run at the same offset, which returns `OVERWRITTEN` — the guest
+  filling it with content. Two further hypotheses are dead: this title imports exactly **14**
+  AudioOut2 entrypoints and `sceAudioOut2ContextBedWrite` is not among them (nor in any of the 44
+  local dumps), so there is no second PCM path prosper could be missing; and it never imports
+  `sceAudioOut2GetSpeakerInfo`, so nothing in its own setup names the bed order.
   **Rung 4 for audio: the project owner confirmed by ear that the music plays and sounds right.**
   That establishes real audio reaching the device at sane levels through the guest's own path. It
   establishes **nothing about the channel order** — with ten of the twelve channels empty, every

--- a/prosper/src/hle/audio.hpp
+++ b/prosper/src/hle/audio.hpp
@@ -8,6 +8,7 @@
 // itself via audio_set_sink(), keeping prosper_core dependency-free and unit-testable.
 #pragma once
 #include <cmath>
+#include <cstddef>   // std::size_t — a header must carry its own includes, not inherit its includer's
 #include <cstdint>
 
 namespace prosper {
@@ -124,7 +125,7 @@ AudioGrainVerdict audio_classify_stamped_grain(bool same_address, bool matches_s
 // byte-wise count — the obvious way to ask "is this buffer empty" — reports a buffer the guest
 // legitimately cleared with negative zero as non-zero, and the probe then answers `Overwritten`
 // for exactly the case it exists to identify.
-uint64_t audio_count_nonzero_samples(const void* pcm, size_t bytes, bool s16);
+uint64_t audio_count_nonzero_samples(const void* pcm, std::size_t bytes, bool s16);
 
 // Pluggable audio backend. All calls arrive on the guest's audio thread; output() MAY block to
 // pace it (as real hardware does — sceAudioOutOutput blocks until the ring has room).

--- a/prosper/src/hle/audio.hpp
+++ b/prosper/src/hle/audio.hpp
@@ -101,6 +101,31 @@ struct AudioSignalStats {
     void reset() { peak = 0.0; sumsq = 0.0; samples = 0; nonzero = 0; }
 };
 
+// --- PROSPER_AUDIO_STAMP: does the guest WRITE the grain prosper reads? ------------------------
+// A port measuring exactly zero is either a live bus carrying silence or a buffer prosper reads and
+// the guest never fills, and every statistic derived from that same read is blind to the
+// difference. The probe (hle_audio.cpp) writes a pattern into the guest's grain after consuming it
+// and classifies what comes back on the next push. The decision itself is a pure function so the
+// rule can be unit-tested: getting `Intact` and `Overwritten` the wrong way round inverts the whole
+// conclusion (the stamp is deliberately non-zero, so a surviving stamp looks like guest content),
+// and that mistake is invisible in a live log.
+enum class AudioGrainVerdict {
+    PointerMoved,   // the guest republished a different address; this port is double-buffered
+    Intact,         // the stamp survived -> the guest never wrote this buffer between two pushes
+    Cleared,        // the stamp is gone and the grain is exactly zero -> live bus, silent content
+    Overwritten,    // the stamp is gone and content is in its place -> live bus carrying signal
+};
+AudioGrainVerdict audio_classify_stamped_grain(bool same_address, bool matches_stamp,
+                                               uint64_t nonzero_samples);
+
+// Samples differing from exactly zero, under the SAME rule AudioSignalStats::nonzero uses, so a
+// stamp verdict and a PROSPER_AUDIO_FLOW total can never disagree about what "silent" means.
+// The subtlety that forces a shared helper: **-0.0f is zero here and its bytes are not**. A
+// byte-wise count — the obvious way to ask "is this buffer empty" — reports a buffer the guest
+// legitimately cleared with negative zero as non-zero, and the probe then answers `Overwritten`
+// for exactly the case it exists to identify.
+uint64_t audio_count_nonzero_samples(const void* pcm, size_t bytes, bool s16);
+
 // Pluggable audio backend. All calls arrive on the guest's audio thread; output() MAY block to
 // pace it (as real hardware does — sceAudioOutOutput blocks until the ring has room).
 struct AudioSink {

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -161,6 +161,45 @@ bool audio2_reserve_queue_slot(uint32_t& queued, uint32_t queue_depth) {
     return true;
 }
 
+uint64_t audio_count_nonzero_samples(const void* pcm, size_t bytes, bool s16) {
+    if (!pcm) return 0;
+    uint64_t n = 0;
+    if (s16) {
+        const auto* s = static_cast<const int16_t*>(pcm);
+        for (size_t i = 0, m = bytes / sizeof(int16_t); i < m; ++i)
+            if (s[i] != 0) ++n;
+    } else {
+        const auto* s = static_cast<const float*>(pcm);
+        // `!= 0.0f`, never a byte test: -0.0f compares equal to zero and has a non-zero bit
+        // pattern, and NaN compares unequal to zero, which is the same treatment
+        // AudioSignalStats gives both.
+        for (size_t i = 0, m = bytes / sizeof(float); i < m; ++i)
+            if (s[i] != 0.0f) ++n;
+    }
+    return n;
+}
+
+AudioGrainVerdict audio_classify_stamped_grain(bool same_address, bool matches_stamp,
+                                               uint64_t nonzero_samples) {
+    // Two properties are load-bearing, and a third that looks like it is, is not. Recorded because
+    // the difference was established by mutation rather than by reading, and reading had it wrong:
+    //   1. The address check must precede both content tests. A stamp read back from a DIFFERENT
+    //      buffer says nothing about either one, and the double-buffered case is otherwise reported
+    //      as a clean verdict about a buffer nobody looked at.
+    //   2. The identity test must EXIST. The stamp is deliberately non-zero in every sample, so a
+    //      surviving stamp carries a large non-zero count; drop this line and "prosper is reading
+    //      memory the guest never writes" is reported as "the port is healthy" — the exact inversion
+    //      the probe exists to prevent.
+    //   3. Whether identity is tested BEFORE or AFTER emptiness is immaterial, and the first version
+    //      of this comment claimed otherwise. Swapping them is behaviour-preserving for as long as
+    //      property 2's invariant holds, because the two conditions are then mutually exclusive: a
+    //      surviving stamp is never empty. The swap arm PASSED, which is what corrected the comment.
+    if (!same_address) return AudioGrainVerdict::PointerMoved;
+    if (matches_stamp) return AudioGrainVerdict::Intact;
+    if (nonzero_samples == 0) return AudioGrainVerdict::Cleared;
+    return AudioGrainVerdict::Overwritten;
+}
+
 // Stereo fold-down for a MAIN speaker bed. See audio.hpp for the contract.
 //
 // The bed order for 1..8 channels is FL, FR, FC, LFE, then surround pairs, with the small layouts
@@ -995,14 +1034,41 @@ void audio_layout_report() {
                      (unsigned long long)lp.last_ptr, (unsigned long long)lp.ptr_updates);
         else
             snprintf(stride_note, sizeof stride_note, "stride=n/a (no PCM pointer observed)");
+        // What prosper DID with each channel, printed beside what the channel measured as. The two
+        // halves of the layout question are "what role does this channel play in the guest's mix"
+        // (rms/hf/corr, above) and "where did prosper send it" — and until now the second half was
+        // only ever readable by opening hle_audio.cpp and applying the table by hand, which is
+        // exactly the step nobody takes while reading a log. A channel that measures as a surround
+        // feed and folds to `UNPLACED`, or one that measures centre-like and folds hard to one
+        // side, is then visible in the same two lines instead of in an offline derivation.
+        // Only a MAIN port is folded at all; anything else is not mixed to the host bed, so
+        // claiming a placement for it would be a straight falsehood.
+        AudioStereoGain fold[kA2MaxChannels]{};
+        const bool      folded = lp.type == 0;
+        const unsigned  unplaced =
+            folded ? audio_stereo_downmix(lp.channels, fold, kA2MaxChannels) : lp.channels;
+        char fold_note[96];
+        if (!folded)
+            snprintf(fold_note, sizeof fold_note, "fold=n/a (non-MAIN: not mixed to the host bed)");
+        else if (unplaced)
+            snprintf(fold_note, sizeof fold_note, "fold=7.1 + %u UNPLACED", unplaced);
+        else
+            snprintf(fold_note, sizeof fold_note, "fold=all %u placed", lp.channels);
         fprintf(stderr,
-                "[audio-layout] port%u ctx%u type=0x%x fmt=0x%x channels=%u grain=%u frames=%llu %s\n",
+                "[audio-layout] port%u ctx%u type=0x%x fmt=0x%x channels=%u grain=%u frames=%llu %s %s\n",
                 i + 1, lp.ctx_slot, lp.type, lp.data_format, lp.channels, lp.grain,
-                (unsigned long long)lp.frames, stride_note);
+                (unsigned long long)lp.frames, stride_note, fold_note);
         for (uint32_t c = 0; c < lp.channels; ++c) {
             const double hf = rms[c] > 0.0 ? std::sqrt(lp.diff_sumsq[c] / n) / rms[c] : 0.0;
-            fprintf(stderr, "[audio-layout]   ch%-2u rms=%.6f peak=%.6f nonzero=%5.1f%% hf=%.4f corr=",
+            fprintf(stderr, "[audio-layout]   ch%-2u rms=%.6f peak=%.6f nonzero=%5.1f%% hf=%.4f",
                     c, rms[c], lp.peak[c], 100.0 * (double)lp.nonzero[c] / n, hf);
+            if (!folded)
+                fprintf(stderr, " fold=n/a  ");
+            else if (fold[c].left == 0.0f && fold[c].right == 0.0f)
+                fprintf(stderr, " fold=UNPLACED");
+            else
+                fprintf(stderr, " fold=L%.3f/R%.3f", (double)fold[c].left, (double)fold[c].right);
+            fprintf(stderr, " corr=");
             for (uint32_t e = 0; e < lp.channels; ++e) {
                 const uint32_t lo = c < e ? c : e, hi = c < e ? e : c;
                 const double denom = rms[lo] * rms[hi] * n;
@@ -1166,6 +1232,291 @@ bool a2_store_zeros(uint64_t dst, size_t n) {
     std::vector<uint8_t> z(n, 0);
     return audio_store_bytes(dst, z.data(), n);
 }
+
+// The AudioOut2 grain write-back probe. It lives here, after the fault-safe guest memory
+// helpers it is built on, and is used by the mix loop further down.
+namespace {
+
+// --- PROSPER_AUDIO_STAMP: is the grain prosper READS the grain the guest WRITES? ---------------
+//
+// A port whose PCM reads as exactly zero for a whole run has two causes that need opposite fixes,
+// and NOTHING in PROSPER_AUDIO_FLOW or PROSPER_AUDIO_LAYOUT can separate them, because every
+// statistic those probes publish is computed from the same read:
+//   (a) the guest holds the bus open and mixes silence into it — a non-defect, and
+//   (b) prosper is reading a buffer the guest never fills — a pointer published once at setup and
+//       thereafter stale, a second buffer of a pair we never see, a read taken at the wrong point
+//       in the guest's fill cycle. Real audio is being lost, silently and invisibly.
+// A wrong address is exactly as zero as a silent mix, so "nonzero=0/55175168" is a statement about
+// an instrument until something outside that instrument says otherwise. This is that something.
+//
+// It settles the question by WRITING. Once the mix has consumed a grain, the probe stamps the
+// guest's own grain buffer with a per-channel-distinct pattern, and on the NEXT push classifies
+// what came back. The single fact it establishes is whether the guest WRITES this buffer between
+// two pushes, which is exactly the fact no amount of reading can supply:
+//   OVERWRITTEN  the stamp is gone and non-zero content is in its place -> the guest actively fills
+//                this buffer with signal. A live bus carrying audio: the HEALTHY signature, and the
+//                one to calibrate the probe against on a port already measured to carry content.
+//   CLEARED      the stamp is gone and the grain is exactly zero -> the guest actively writes this
+//                buffer and writes SILENCE into it. Case (a), now measured rather than assumed:
+//                the port is a live bus with nothing on it, and not prosper's defect.
+//   INTACT       the stamp survived byte-for-byte -> the guest did not touch this buffer at all
+//                between two pushes. Case (b): prosper is reading memory the guest does not fill,
+//                and the port's zero says nothing whatever about the guest's mix.
+//   POINTER-MOVED the guest republished a different address before we could read the stamp back —
+//                itself a finding (this port is double-buffered), and the reason the probe keys its
+//                classification on the address it actually stamped rather than on the port slot.
+// Note which way OVERWRITTEN cuts, because the name invites the opposite reading: prosper's own
+// push-time read is of the SAME buffer a few microseconds earlier, so content found here is content
+// the mix loop got. OVERWRITTEN is a report that the path works, not that something was missed.
+//
+// The probe is SELF-VALIDATING, which is the whole reason it is trustworthy: the stamp is read back
+// IMMEDIATELY after being written, through the same audio_read_bytes_partial() the mix loop uses,
+// and a probe whose own read-back does not return the stamp prints PROBE-INVALID and NO verdict.
+// That read-back is a positive instance of "this exact port can report a non-zero sample",
+// constructed by hand and outside whatever produced the null — a control drawn from the same
+// silent guest would only ever have re-confirmed the silence.
+//
+// Guest memory is left byte-identical: an INTACT stamp is rolled back to the bytes that were there
+// before it, and in every other case the guest has already replaced them itself. The probe is
+// opt-in, names ONE port, and stops after a bounded number of pushes — the pushes it stamps do
+// carry the stamp into the following push's flow/layout statistics, so an unbounded version would
+// corrupt the very totals the investigation is reading.
+//
+//   PROSPER_AUDIO_STAMP=<port>[:<pushes>[:<after>]]
+//       port    1-based, as printed by [audio-flow] / [audio-layout].
+//       pushes  how many pushes to stamp. Default 8, maximum 64.
+//       after   how many of the port's pushes to let past FIRST. Default 0.
+// `after` is not a convenience. The probe has to be calibrated against a port whose answer is
+// already known, and the only such port is one measured to carry content — but a title's first
+// pushes are routinely silent while it boots, so a probe armed at push 0 would classify the
+// KNOWN-GOOD port as CLEARED and "confirm" an instrument that was reading the wrong thing. At
+// 188 pushes/s, `after` is the port's own clock: 9400 lands the stamp about fifty seconds in.
+// A malformed value DISABLES the probe loudly rather than stamping some other port: a typo must
+// cost a measurement, never produce a wrong one.
+struct StampState {
+    uint64_t             addr = 0;        // the address the outstanding stamp was written to
+    std::vector<uint8_t> pattern;         // exactly what was written there
+    std::vector<uint8_t> original;        // what was there before, for the INTACT rollback
+    bool                 pending = false;
+    uint32_t             done = 0;        // pushes stamped so far, against the budget
+    uint64_t             seen = 0;        // pushes of this port observed, against `after`
+    bool                 disabled = false;
+};
+
+bool audio_stamp_config(uint32_t& port, uint32_t& pushes, uint64_t& after) {
+    static int      parsed = -1;
+    static uint32_t cfg_port = 0, cfg_pushes = 8;
+    static uint64_t cfg_after = 0;
+    if (parsed < 0) {
+        parsed = 0;
+        if (const char* e = getenv("PROSPER_AUDIO_STAMP"); e && *e) {
+            char*               end = nullptr;
+            const unsigned long v = strtoul(e, &end, 0);
+            bool                ok = end != e && v >= 1 && v <= kA2MaxPorts;
+            if (ok && *end == ':') {
+                char*               end2 = nullptr;
+                const unsigned long n = strtoul(end + 1, &end2, 0);
+                if (end2 == end + 1 || n < 1 || n > 64) ok = false;
+                else {
+                    cfg_pushes = (uint32_t)n;
+                    if (*end2 == ':') {
+                        char*               end3 = nullptr;
+                        const unsigned long a = strtoull(end2 + 1, &end3, 0);
+                        if (end3 == end2 + 1 || *end3 != '\0') ok = false;
+                        else cfg_after = (uint64_t)a;
+                    } else if (*end2 != '\0') {
+                        ok = false;
+                    }
+                }
+            } else if (ok && *end != '\0') {
+                ok = false;
+            }
+            if (ok) { cfg_port = (uint32_t)v; parsed = 1; }
+            else
+                fprintf(stderr, "[audio-stamp] PROSPER_AUDIO_STAMP=\"%s\" is malformed (expected "
+                                "<port 1..%u>[:<pushes 1..64>[:<after>]]); probe DISABLED\n",
+                        e, (unsigned)kA2MaxPorts);
+        }
+    }
+    port = cfg_port;
+    pushes = cfg_pushes;
+    after = cfg_after;
+    return parsed == 1;
+}
+
+// Non-zero SAMPLES per channel, and the run peak, for one interleaved grain. Reported rather than a
+// raw non-zero byte count: bytes are not comparable with anything else in this subsystem, whereas
+// per-channel sample counts line up directly with the `nonzero%` column of PROSPER_AUDIO_LAYOUT and
+// say WHICH channels the guest fills — which is the interesting half of an OVERWRITTEN verdict.
+// Returns the TOTAL, which must equal audio_count_nonzero_samples() over the same buffer: the
+// verdict is drawn from that shared rule, and this per-channel breakdown only says where the
+// samples sit.
+uint64_t audio_stamp_channel_stats(const std::vector<uint8_t>& buf, uint32_t channels,
+                                   uint32_t data_type, uint64_t* nonzero_out, double& peak_out) {
+    for (uint32_t c = 0; c < channels && c < kA2MaxChannels; ++c) nonzero_out[c] = 0;
+    peak_out = 0.0;
+    uint64_t     total = 0;
+    const size_t sample_bytes = data_type == 0 ? sizeof(float) : sizeof(int16_t);
+    for (size_t i = 0, n = buf.size() / sample_bytes; i < n; ++i) {
+        const float v = data_type == 0 ? reinterpret_cast<const float*>(buf.data())[i]
+                                       : (float)reinterpret_cast<const int16_t*>(buf.data())[i] *
+                                             (1.0f / 32768.0f);
+        if (v != 0.0f) {
+            ++total;
+            if ((i % channels) < kA2MaxChannels) ++nonzero_out[i % channels];
+        }
+        const double a = v < 0 ? -(double)v : (double)v;
+        if (v == v && a > peak_out) peak_out = a;   // NaN never raises the peak, as elsewhere here
+    }
+    return total;
+}
+
+void audio_stamp_print_channels(const char* label, const uint64_t* nonzero, uint32_t channels,
+                                double peak) {
+    fprintf(stderr, "               %s peak=%.6f non-zero samples:", label, peak);
+    for (uint32_t c = 0; c < channels && c < kA2MaxChannels; ++c)
+        fprintf(stderr, " ch%u=%llu", c, (unsigned long long)nonzero[c]);
+    fprintf(stderr, "\n");
+}
+
+// Per-channel-distinct and every sample non-zero, so the read-back doubles as a channel-identity
+// check: whichever channel index a value comes back on is the index prosper's stride arithmetic
+// put it at. Magnitudes stay under 0.5 at the widest bed so a stamp that does reach a device is
+// not a full-scale bang.
+void audio_stamp_fill(std::vector<uint8_t>& out, size_t n, uint32_t channels, uint32_t data_type) {
+    out.assign(n, 0);
+    if (data_type == 0) {
+        auto* s = reinterpret_cast<float*>(out.data());
+        for (size_t i = 0, m = n / sizeof(float); i < m; ++i)
+            s[i] = (float)((i % channels) + 1) / 32.0f;
+    } else {
+        auto* s = reinterpret_cast<int16_t*>(out.data());
+        for (size_t i = 0, m = n / sizeof(int16_t); i < m; ++i)
+            s[i] = (int16_t)(((i % channels) + 1) * 1024);
+    }
+}
+
+// Called from the mix loop with g_a2_mx held, once per push, for the one selected port, AFTER that
+// push's grain has been read and measured — so the probe never perturbs the reading it explains.
+void audio_stamp_step(uint32_t port_index, uint64_t pcm, uint32_t channels, uint32_t data_type,
+                      uint32_t grain) {
+    uint32_t want_port = 0, budget = 0;
+    uint64_t after = 0;
+    if (!audio_stamp_config(want_port, budget, after)) return;
+    if (port_index + 1 != want_port) return;
+
+    static StampState st;
+    if (st.disabled || st.done >= budget) return;
+    if (st.seen++ < after) {
+        if (st.seen == 1)
+            fprintf(stderr, "[audio-stamp] port%u: armed, waiting %llu pushes before the first "
+                            "stamp\n", port_index + 1, (unsigned long long)after);
+        return;
+    }
+    const size_t sample_bytes = data_type == 0 ? sizeof(float) : sizeof(int16_t);
+    const size_t want = sample_bytes * (size_t)channels * grain;
+    if (!pcm || !want || !channels) return;
+
+    // An INDEPENDENT read of the same range: the classification must not inherit whatever the mix
+    // loop's read did, or a broken read would validate itself.
+    std::vector<uint8_t> now(want);
+    const size_t got = audio_read_bytes_partial(pcm, now.data(), want);
+    if (got != want) {
+        fprintf(stderr, "[audio-stamp] port%u: read 0x%llx +%zu returned %zu bytes; "
+                        "probe DISABLED (a partial grain cannot be classified)\n",
+                port_index + 1, (unsigned long long)pcm, want, got);
+        st.disabled = true;
+        return;
+    }
+
+    if (st.pending) {
+        uint64_t ch_now[kA2MaxChannels]{};
+        double   peak_now = 0.0;
+        const uint64_t total_now =
+            audio_stamp_channel_stats(now, channels, data_type, ch_now, peak_now);
+        const bool matches_stamp = st.pattern.size() == now.size() &&
+                                   std::memcmp(st.pattern.data(), now.data(), now.size()) == 0;
+        switch (audio_classify_stamped_grain(st.addr == pcm, matches_stamp, total_now)) {
+        case AudioGrainVerdict::PointerMoved:
+            fprintf(stderr, "[audio-stamp] port%u POINTER-MOVED: stamped 0x%llx, this push "
+                            "published 0x%llx — the port is double-buffered, so a zero read of "
+                            "either buffer alone proves nothing\n",
+                    port_index + 1, (unsigned long long)st.addr, (unsigned long long)pcm);
+            break;
+        case AudioGrainVerdict::Intact:
+            fprintf(stderr, "[audio-stamp] port%u INTACT: the stamp written to 0x%llx last push "
+                            "survived byte-for-byte — the guest did NOT write this buffer between "
+                            "pushes, so prosper is reading memory the guest does not fill and this "
+                            "port's zero says nothing about the guest's mix\n",
+                    port_index + 1, (unsigned long long)st.addr);
+            // Leave guest memory exactly as it was found.
+            if (!audio_store_bytes(pcm, st.original.data(), st.original.size()))
+                fprintf(stderr, "[audio-stamp] port%u: rollback of the intact stamp FAILED; the "
+                                "buffer still holds the probe pattern\n", port_index + 1);
+            break;
+        case AudioGrainVerdict::Cleared:
+            fprintf(stderr, "[audio-stamp] port%u CLEARED: the stamp written to 0x%llx last push "
+                            "is gone and the grain is exactly zero — the guest ACTIVELY writes "
+                            "this buffer and writes silence into it. The port is a live bus "
+                            "carrying no signal, not a buffer prosper is failing to read\n",
+                    port_index + 1, (unsigned long long)st.addr);
+            break;
+        case AudioGrainVerdict::Overwritten:
+            // The HEALTHY signature. prosper's own push-time read is of this same buffer a few
+            // microseconds earlier, so content found here is content the mix loop received — this
+            // says the path works, not that something was missed.
+            fprintf(stderr, "[audio-stamp] port%u OVERWRITTEN: the stamp written to 0x%llx last "
+                            "push is gone and the guest has filled the buffer with %llu non-zero "
+                            "samples — a live bus carrying signal, which is what a working port "
+                            "looks like\n",
+                    port_index + 1, (unsigned long long)st.addr, (unsigned long long)total_now);
+            audio_stamp_print_channels("guest content:", ch_now, channels, peak_now);
+            break;
+        }
+        st.pending = false;
+    }
+
+    audio_stamp_fill(st.pattern, want, channels, data_type);
+    st.original = now;
+    if (!audio_store_bytes(pcm, st.pattern.data(), st.pattern.size())) {
+        fprintf(stderr, "[audio-stamp] port%u: writing the stamp to 0x%llx FAILED; probe DISABLED "
+                        "(guest memory untouched)\n", port_index + 1, (unsigned long long)pcm);
+        st.disabled = true;
+        return;
+    }
+    // THE POSITIVE CONTROL, and the reason a verdict from this probe is worth anything: read the
+    // stamp back through the very call the mix loop uses. If a non-zero grain written by hand to
+    // this port's own buffer does not come back non-zero, the probe cannot distinguish silence
+    // from blindness and must not pretend to.
+    std::vector<uint8_t> back(want);
+    const size_t back_got = audio_read_bytes_partial(pcm, back.data(), want);
+    if (back_got != want || std::memcmp(back.data(), st.pattern.data(), want) != 0) {
+        fprintf(stderr, "[audio-stamp] port%u PROBE-INVALID: read back %zu of %zu stamped bytes "
+                        "and they do not match what was written — this port's read path cannot be "
+                        "shown to report a non-zero sample, so NO verdict is drawn from it\n",
+                port_index + 1, back_got, want);
+        st.disabled = true;
+        st.pending = false;
+        return;
+    }
+    // Report the control quantitatively, per channel, so "the reader could have seen it" is a
+    // number in the log rather than an assertion in a PR.
+    uint64_t ch_back[kA2MaxChannels]{};
+    double   peak_back = 0.0;
+    audio_stamp_channel_stats(back, channels, data_type, ch_back, peak_back);
+    fprintf(stderr, "[audio-stamp] port%u stamp %u/%u written to 0x%llx (%zu bytes, %u ch); "
+                    "read-back OK — this port CAN report a non-zero sample\n",
+            port_index + 1, st.done + 1, budget, (unsigned long long)pcm, want, channels);
+    audio_stamp_print_channels("positive control:", ch_back, channels, peak_back);
+    st.addr = pcm;
+    st.pending = true;
+    ++st.done;
+    if (st.done >= budget)
+        fprintf(stderr, "[audio-stamp] port%u: stamp budget (%u) spent; the verdict above is the "
+                        "probe's whole output\n", port_index + 1, budget);
+}
+
+} // namespace
 
 // ---- libSceAudioIn: headless, silent, real-time paced ----------------------------------
 //
@@ -1770,6 +2121,10 @@ HLE(audio2_ctx_push) {
                 }
                 if (ps.type != 0) ++fp.skip_not_main; else ++fp.mixed;
             }
+            // AFTER this push's grain has been read and measured, and before the mix (which works
+            // from the host-side copy in `tmp`, so it is unaffected): ask whether the guest writes
+            // the buffer we just read. Opt-in, one port, bounded. See PROSPER_AUDIO_STAMP above.
+            audio_stamp_step((uint32_t)this_pidx, ps.pcm_ptr, channels, data_type, grain);
             if (probe) {
                 static uint64_t call_ct[kA2MaxPorts] = {0};
                 const size_t nf = frames_got * channels;

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -1406,8 +1406,15 @@ void audio_stamp_step(uint32_t port_index, uint64_t pcm, uint32_t channels, uint
     if (port_index + 1 != want_port) return;
 
     static StampState st;
-    if (st.disabled || st.done >= budget) return;
-    if (st.seen++ < after) {
+    if (st.disabled) return;
+    // The budget gates writing a NEW stamp, never resolving an outstanding one. Returning here on
+    // `done >= budget` alone would leave the last stamp unclassified — costing a verdict, and worse,
+    // leaving the pattern in the guest's buffer in exactly the INTACT case, which is the one where
+    // nothing else ever overwrites it. That would quietly break the byte-identical guarantee at the
+    // one address the probe was pointed at.
+    const bool budget_spent = st.done >= budget;
+    if (budget_spent && !st.pending) return;
+    if (!budget_spent && st.seen++ < after) {
         if (st.seen == 1)
             fprintf(stderr, "[audio-stamp] port%u: armed, waiting %llu pushes before the first "
                             "stamp\n", port_index + 1, (unsigned long long)after);
@@ -1475,6 +1482,9 @@ void audio_stamp_step(uint32_t port_index, uint64_t pcm, uint32_t channels, uint
         }
         st.pending = false;
     }
+    // The last stamp has now been classified and, if it survived, rolled back. Stop before writing
+    // another one.
+    if (budget_spent) return;
 
     audio_stamp_fill(st.pattern, want, channels, data_type);
     st.original = now;
@@ -1512,8 +1522,8 @@ void audio_stamp_step(uint32_t port_index, uint64_t pcm, uint32_t channels, uint
     st.pending = true;
     ++st.done;
     if (st.done >= budget)
-        fprintf(stderr, "[audio-stamp] port%u: stamp budget (%u) spent; the verdict above is the "
-                        "probe's whole output\n", port_index + 1, budget);
+        fprintf(stderr, "[audio-stamp] port%u: stamp budget (%u) spent; one more verdict follows on "
+                        "the next push, then the probe is done\n", port_index + 1, budget);
 }
 
 } // namespace

--- a/prosper/src/hle/hle_audio.cpp
+++ b/prosper/src/hle/hle_audio.cpp
@@ -161,7 +161,7 @@ bool audio2_reserve_queue_slot(uint32_t& queued, uint32_t queue_depth) {
     return true;
 }
 
-uint64_t audio_count_nonzero_samples(const void* pcm, size_t bytes, bool s16) {
+uint64_t audio_count_nonzero_samples(const void* pcm, std::size_t bytes, bool s16) {
     if (!pcm) return 0;
     uint64_t n = 0;
     if (s16) {

--- a/prosper/tests/test_audio.cpp
+++ b/prosper/tests/test_audio.cpp
@@ -286,11 +286,228 @@ static void test_stereo_downmix() {
     for (auto& e : guard) CHECK(e.left == 7.0f && e.right == 7.0f);   // untouched by every refusal
 }
 
+// The decision rule behind PROSPER_AUDIO_STAMP (hle_audio.cpp). The probe answers the one question
+// no amount of reading a guest buffer can: does the guest WRITE the grain prosper reads? Its whole
+// output is a four-way verdict, and two of the four are inversions of each other — so the ordering
+// of the tests inside the classifier is the entire correctness surface, and a live log looks
+// perfectly plausible with them swapped.
+static void test_stamped_grain_verdicts() {
+    using V = AudioGrainVerdict;
+
+    // The stamp is deliberately non-zero in every sample, so a SURVIVING stamp carries a large
+    // non-zero count. A classifier that decided emptiness without consulting identity therefore
+    // reports `Overwritten` — "the guest is filling this buffer with signal" — for the case that
+    // actually means "prosper is reading memory the guest never touches", inverting the probe's
+    // whole answer. This arm is what fails when the identity test is dropped.
+    //
+    // What it does NOT pin, stated because the comment here first claimed it did: the ORDER of the
+    // identity and emptiness tests. Swapping them is behaviour-preserving, since a surviving stamp
+    // is never empty, and the mutation arm that swapped them passed. The order that IS pinned is
+    // the address check coming first, by the two `false` arms below.
+    CHECK(audio_classify_stamped_grain(true, true, 2048) == V::Intact);
+    CHECK(audio_classify_stamped_grain(true, false, 0) == V::Cleared);
+    CHECK(audio_classify_stamped_grain(true, false, 2048) == V::Overwritten);
+    // A stamp read back from a DIFFERENT buffer says nothing about either buffer, so the address
+    // check must come first — including in the case that would otherwise look like a clean verdict.
+    CHECK(audio_classify_stamped_grain(false, true, 2048) == V::PointerMoved);
+    CHECK(audio_classify_stamped_grain(false, false, 0) == V::PointerMoved);
+
+    // The counting rule the verdict is drawn from. It must agree with AudioSignalStats::nonzero,
+    // because a disagreement would let the stamp probe and PROSPER_AUDIO_FLOW report different
+    // answers about the same buffer.
+    float zeros[64]{};
+    CHECK(audio_count_nonzero_samples(zeros, sizeof zeros, false) == 0);
+
+    // -0.0f is THE boundary case, and it is not academic: a guest mixer that clears with a negated
+    // accumulator leaves negative zeros, whose BYTES are not zero. A byte-wise emptiness test — the
+    // obvious implementation — calls that buffer non-empty, and the probe then answers
+    // `Overwritten` for precisely the cleared buffer it exists to identify.
+    float negzeros[64];
+    for (float& v : negzeros) v = -0.0f;
+    CHECK(audio_count_nonzero_samples(negzeros, sizeof negzeros, false) == 0);
+    bool any_byte_set = false;
+    for (const uint8_t* b = (const uint8_t*)negzeros; b < (const uint8_t*)(negzeros + 64); ++b)
+        if (*b) any_byte_set = true;
+    CHECK(any_byte_set);            // the trap is real: these bytes are NOT zero
+    AudioSignalStats negstats;
+    for (float v : negzeros) negstats.add(v);
+    CHECK(negstats.nonzero == 0);   // and the flow probe agrees with the count above
+
+    float mixed[8] = {0.0f, 0.25f, 0.0f, -0.5f, 0.0f, 0.0f, 1.0f, -0.0f};
+    CHECK(audio_count_nonzero_samples(mixed, sizeof mixed, false) == 3);
+    int16_t s16[8] = {0, 1, 0, -1, 0, 0, 32767, 0};
+    CHECK(audio_count_nonzero_samples(s16, sizeof s16, true) == 3);
+    CHECK(audio_count_nonzero_samples(nullptr, 64, false) == 0);
+    CHECK(audio_count_nonzero_samples(mixed, 0, false) == 0);
+}
+
+// --- END-TO-END bed routing: which GUEST channel reaches which HOST channel, at what gain ------
+//
+// test_stereo_downmix above pins the fold TABLE against literal values. This measures what the mix
+// loop actually DOES with that table, by pushing one unit impulse per source channel through the
+// real sceAudioOut2 entrypoints and reading the stereo grain the host sink receives. The two are
+// different claims and neither implies the other: a correct table applied through a wrong stride,
+// a wrong tap list, or a wrong side produces exactly the output a wrong table would, and no
+// assertion on the pure function can see it.
+//
+// It also reports the result, because that report is the answer to the question #1720 asks — "which
+// guest channel landed in which host channel, and with what orientation" — for every width the fold
+// accepts, rather than for the two widths (8 and 12) the existing arms happen to exercise.
+//
+// The oracle for the bulk of the comparison is audio_stereo_downmix() itself, which is DELIBERATE
+// and is the point: it tests the application, not the table. So that this cannot degenerate into a
+// tautology if both ever drift together, a handful of placements are additionally asserted against
+// LITERALS below, chosen at widths the rest of the file never pushes end-to-end.
+static void test_bed_routing_matrix() {
+    audio_reset();
+    CapturingSink sink;
+    audio_set_sink(&sink);
+
+    constexpr uint32_t kGrain = 64;
+    uint8_t ctx_param[0x40]{};
+    CHECK(call("sceAudioOut2ContextResetParam", PTR(ctx_param)) == 0);
+    *(uint32_t*)(ctx_param + 0x10) = kGrain;
+    uint64_t ctx = 0;
+    CHECK(call("sceAudioOut2ContextCreate", PTR(ctx_param), 0, 0, PTR(&ctx)) == 0);
+
+    struct PortParam {
+        uint16_t type, pad;
+        uint32_t data_format, rate, flags;
+        uint64_t user;
+        uint32_t reserved[10];
+    } pp{};
+    static_assert(sizeof(PortParam) == 0x40);
+    pp.type = 0;                       // MAIN: the only type folded into the host bed
+    pp.rate = 48000;
+
+    uint64_t pcm_ptr = 0;
+    struct Attribute { uint32_t id, reserved; uint64_t value, value_size; } attr{
+        0, 0, PTR(&pcm_ptr), sizeof(pcm_ptr)
+    };
+
+    printf("  [bed-routing] measured guest channel -> host L/R, through the real AudioOut2 mix loop\n");
+    for (uint32_t w = 1; w <= kAudioMaxBedChannels; ++w) {
+        AudioStereoGain declared[kAudioMaxBedChannels];
+        const unsigned  unplaced = audio_stereo_downmix(w, declared, kAudioMaxBedChannels);
+        CHECK(unplaced == (w > 8 ? w - 8 : 0));
+
+        pp.data_format = (w << 8);     // f32, w channels
+        uint64_t port = 0;
+        CHECK(call("sceAudioOut2PortCreate", ctx, PTR(&pp), PTR(&port)) == 0);
+
+        printf("  [bed-routing] width=%-2u", w);
+        std::vector<float> grain((size_t)kGrain * w);
+        for (uint32_t c = 0; c < w; ++c) {
+            // One channel at unit level, every other channel exactly zero. Isolation is what makes
+            // the reading a per-channel GAIN rather than a sum that several wrong matrices share.
+            std::fill(grain.begin(), grain.end(), 0.0f);
+            for (uint32_t f = 0; f < kGrain; ++f) grain[(size_t)f * w + c] = 1.0f;
+            pcm_ptr = PTR(grain.data());
+            sink.outs.clear();
+            CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+            CHECK(call("sceAudioOut2ContextPush", ctx, 1) == 0);
+            CHECK(sink.outs.size() == 1);
+            if (sink.outs.size() != 1) continue;
+            CHECK(sink.outs[0].frames == (int)kGrain);
+            const float* out = reinterpret_cast<const float*>(sink.outs[0].pcm.data());
+            const float measured_l = out[0], measured_r = out[1];
+            // A steady input must give a steady output: a per-frame drift would mean the fold is
+            // reading across frame boundaries, which a single-frame check cannot see.
+            for (uint32_t f = 1; f < kGrain; ++f) {
+                CHECK(out[f * 2 + 0] == measured_l);
+                CHECK(out[f * 2 + 1] == measured_r);
+            }
+            CHECK(std::abs(measured_l - declared[c].left) < 1e-6f);
+            CHECK(std::abs(measured_r - declared[c].right) < 1e-6f);
+            printf(" | ch%u L%.3f R%.3f%s", c, measured_l, measured_r,
+                   (declared[c].left == 0.0f && declared[c].right == 0.0f) ? " UNPLACED" : "");
+            // The unplaced tier measured end to end, for EVERY width above 8 rather than only the
+            // one Dragon Quest VII happens to use: a channel with no known position must contribute
+            // exactly nothing to either side, not merely something small.
+            if (c >= 8) {
+                CHECK(measured_l == 0.0f);
+                CHECK(measured_r == 0.0f);
+            }
+        }
+        printf("\n");
+        CHECK(call("sceAudioOut2PortDestroy", port) == 0);
+        sink.outs.clear();
+    }
+
+    // Literal anchors, so the loop above cannot pass by agreeing with a table that has itself
+    // drifted. These are deliberately at widths 3, 5, 6 and 7 — the ones no other end-to-end arm in
+    // this file pushes, which is exactly where an application bug could live undetected.
+    struct { uint32_t width, channel; float left, right; } anchors[] = {
+        {3, 2, 0.70710678f, 0.70710678f},   // 3ch centre: -3 dB into BOTH sides
+        {5, 3, 0.70710678f, 0.0f},          // 5ch surround left: left ONLY
+        {5, 4, 0.0f, 0.70710678f},          // 5ch surround right: right ONLY
+        {6, 3, 0.5f, 0.5f},                 // 5.1 LFE: -6 dB into both
+        {7, 6, 0.35355339f, 0.35355339f},   // 6.1 rear centre: -3 dB halved across the pair
+    };
+    for (auto& a : anchors) {
+        pp.data_format = (a.width << 8);
+        uint64_t port = 0;
+        CHECK(call("sceAudioOut2PortCreate", ctx, PTR(&pp), PTR(&port)) == 0);
+        std::vector<float> grain((size_t)kGrain * a.width, 0.0f);
+        for (uint32_t f = 0; f < kGrain; ++f) grain[(size_t)f * a.width + a.channel] = 1.0f;
+        pcm_ptr = PTR(grain.data());
+        sink.outs.clear();
+        CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+        CHECK(call("sceAudioOut2ContextPush", ctx, 1) == 0);
+        CHECK(sink.outs.size() == 1);
+        if (!sink.outs.empty()) {
+            const float* out = reinterpret_cast<const float*>(sink.outs[0].pcm.data());
+            CHECK(std::abs(out[0] - a.left) < 1e-6f);
+            CHECK(std::abs(out[1] - a.right) < 1e-6f);
+        }
+        CHECK(call("sceAudioOut2PortDestroy", port) == 0);
+        sink.outs.clear();
+    }
+
+    // The same measurement over an S16 bed. Not symmetry for its own sake: every other end-to-end
+    // AudioOut2 arm in this file that uses S16 is STEREO, so before this the multichannel fold had
+    // no S16 coverage at all — `sample_at`'s integer branch, the `tmp_s16` sizing and the
+    // conversion were only ever exercised through the 2-channel identity fold, where a stride or
+    // scale error cannot show. Full-scale-half (16384 -> exactly 0.5) keeps the expected products
+    // exact in binary floating point, so a 1e-6 tolerance is measuring the fold and not the codec.
+    for (uint32_t w : {(uint32_t)6, (uint32_t)12}) {
+        AudioStereoGain declared[kAudioMaxBedChannels];
+        audio_stereo_downmix(w, declared, kAudioMaxBedChannels);
+        pp.data_format = (w << 8) | 1u;                 // s16, w channels
+        uint64_t port = 0;
+        CHECK(call("sceAudioOut2PortCreate", ctx, PTR(&pp), PTR(&port)) == 0);
+        printf("  [bed-routing] width=%-2u s16", w);
+        std::vector<int16_t> grain((size_t)kGrain * w);
+        for (uint32_t c = 0; c < w; ++c) {
+            std::fill(grain.begin(), grain.end(), (int16_t)0);
+            for (uint32_t f = 0; f < kGrain; ++f) grain[(size_t)f * w + c] = 16384;
+            pcm_ptr = PTR(grain.data());
+            sink.outs.clear();
+            CHECK(call("sceAudioOut2PortSetAttributes", port, PTR(&attr), 1) == 0);
+            CHECK(call("sceAudioOut2ContextPush", ctx, 1) == 0);
+            CHECK(sink.outs.size() == 1);
+            if (sink.outs.size() != 1) continue;
+            const float* out = reinterpret_cast<const float*>(sink.outs[0].pcm.data());
+            CHECK(std::abs(out[0] - declared[c].left * 0.5f) < 1e-6f);
+            CHECK(std::abs(out[1] - declared[c].right * 0.5f) < 1e-6f);
+            printf(" | ch%u L%.3f R%.3f", c, out[0], out[1]);
+        }
+        printf("\n");
+        CHECK(call("sceAudioOut2PortDestroy", port) == 0);
+        sink.outs.clear();
+    }
+
+    CHECK(call("sceAudioOut2ContextDestroy", ctx) == 0);
+    audio_reset();
+}
+
 int main() {
     printf("== test_audio ==\n");
     register_builtin_hle();
     test_signal_stats();
     test_stereo_downmix();
+    test_stamped_grain_verdicts();
+    test_bed_routing_matrix();
 
     // --- 1. format decoding (all 8 SceAudioOutParamFormat values + an unknown) ---------------
     struct { uint32_t param; int ch; AudioFmt fmt; } fmts[] = {


### PR DESCRIPTION
## What this is

Two linked AudioOut2 issues, one investigation. **#1721 is resolved as a non-defect, measured.**
**#1720 stays open**, with its remaining gap narrowed and the instrument that would read the answer
now committed.

Both reproduce on the pre-change master (`20153833`) and were re-measured there before anything was
edited — the evidence below is from a 150 s `reach-title-screen.pad` route on *Dragon Quest VII
Reimagined* (`PPSA17942`).

## The failure scenario the new instrument addresses

An AudioOut2 port that reads as exactly zero has two causes needing opposite fixes:

- **(a)** the guest holds the bus open and mixes silence into it — a non-defect, and
- **(b)** prosper reads a buffer the guest never fills — a pointer published once at setup and then
  stale, one buffer of a pair we never see, a read taken at the wrong point in the fill cycle. Real
  audio is being lost, silently.

Every statistic in `PROSPER_AUDIO_FLOW` and `PROSPER_AUDIO_LAYOUT` is computed from that same read,
so **none of them can tell (a) from (b)**: a wrong address is exactly as zero as a silent mix. That
is the whole content of #1721 — "0 non-zero of 55,175,168 samples" was a statement about an
instrument, and no further statistic derived from the same read could have settled it, because it
would inherit the assumption under test.

## Behavioural contract — `PROSPER_AUDIO_STAMP=<port>[:<pushes>[:<after>]]`

Off by default and inert unless set. When set it settles the question by **writing**: after the mix
has consumed a grain it stamps the guest's own grain buffer with a per-channel-distinct pattern and
classifies what comes back on the next push.

| verdict | meaning |
|---|---|
| `CLEARED` | stamp gone, grain exactly zero — the guest **actively writes** this buffer and writes silence. Case (a). |
| `INTACT` | stamp survived byte-for-byte — the guest never touched it. Case (b). |
| `OVERWRITTEN` | stamp gone, content in its place — a live bus carrying signal. The **healthy** signature. |
| `POINTER-MOVED` | the guest republished a different address first — the port is double-buffered, so a zero read of either buffer alone proves nothing. |

Invariants:

- **Self-validating.** The stamp is read back immediately through the same
  `audio_read_bytes_partial()` the mix loop uses. A probe whose own read-back does not return what
  it wrote prints `PROBE-INVALID` and draws **no verdict**.
- **Guest memory is left byte-identical.** An `INTACT` stamp is rolled back to the bytes that
  preceded it; in every other case the guest has already replaced them.
- **Bounded and single-port.** The stamped pushes carry the stamp into the *following* push's
  flow/layout totals, so an unbounded version would corrupt the totals the investigation is reading.
- **A malformed value disables the probe loudly** rather than stamping some other port.

## #1721 — what the 8-channel zero actually is

**The guest's own silence, not prosper's blindness.** `PROSPER_AUDIO_STAMP=2:6:13000`:

```
[audio-stamp] port2 stamp 1/6 written to 0x25011ae000 (8192 bytes, 8 ch); read-back OK — this port CAN report a non-zero sample
               positive control: peak=0.250000 non-zero samples: ch0=256 ch1=256 ch2=256 ch3=256 ch4=256 ch5=256 ch6=256 ch7=256
[audio-stamp] port2 CLEARED: the stamp written to 0x25011ae000 last push is gone and the grain is exactly zero — the guest ACTIVELY writes this buffer and writes silence into it. The port is a live bus carrying no signal, not a buffer prosper is failing to read
```

`CLEARED` on every arm. The guest wipes that buffer to exact zero each push, so it is a live bus
with nothing on it. prosper is not failing to read it.

### How I proved the instrument could have seen a non-zero

Three independent ways, because "exactly zero" is the class of claim this project keeps a trap list
about:

1. **A positive instance constructed by hand, on the same port, outside whatever produced the null.**
   The read-back above reports **256 non-zero samples on each of the 8 channels** of port2 itself.
   The reader demonstrably can report non-zero here.
2. **Calibration against a port with a known answer**, same route, same offset, everything else
   equal — `PROSPER_AUDIO_STAMP=1:6:13000` on the 12-channel port that carries the soundtrack:
   ```
   [audio-stamp] port1 OVERWRITTEN: ... the guest has filled the buffer with 512 non-zero samples — a live bus carrying signal
                  guest content: peak=0.075005 non-zero samples: ch0=256 ch1=256 ch2=0 ch3=0 ch4=0 ch5=0 ch6=0 ch7=0 ch8=0 ch9=0 ch10=0 ch11=0
   ```
   Different verdict, same probe, same run shape. And note the cross-check this hands over for free:
   a *write-and-observe* instrument independently reproduces what the *read-and-accumulate* layout
   probe reported — all content in ch0/ch1 — which is agreement between two mechanisms rather than
   one mechanism restating itself.
3. **The producer and the printer are armed by the same switch** (the #2149 class). Both
   `flow_add_sample` and `audio_flow_report` are gated on the single `audio_flow()` static reading
   `PROSPER_AUDIO_FLOW`; likewise `layout_add_grain`/`audio_layout_report` on `audio_layout()`. There
   is no second gate that could report unarmed state as a confident zero.

**`after` is load-bearing, and skipping it fakes a result.** Dragon Quest VII's *good* port is
exactly zero for the first ~43 s of the route while the title boots (measured: 43 consecutive
`[audio-flow]` interval lines with `nonzero=0/577536`). A probe armed at push 0 classifies the
known-good port as `CLEARED` and "validates" an instrument pointed at silence. That is why the
offset exists and why the calibration uses it.

### Two further #1721 hypotheses, killed statically

- **`sceAudioOut2ContextBedWrite` as a second PCM path prosper stubs.** Well formed — the stub is
  real (`audio2_ctx_bed_write` validates the handle and returns 0, mixing nothing). Dead anyway:
  **0 of 44 local dumps import NID `DxGyV8dtOR8`**, scanned over every `eboot.bin` and `.prx`.
  Dragon Quest VII imports exactly **14** AudioOut2 entrypoints, and `PortSetAttributes(id=0)` +
  `ContextPush` — the pair prosper reads — is the only PCM path any of them offer.
- **The guest declaring the layout.** It never imports `sceAudioOut2GetSpeakerInfo`.

## #1720 — what moved, and what deliberately did not

**Not fixed, and not guessed at.** No channel map was changed. Channels 9..16 still have no measured
position and no pair's orientation is measured, because nothing in the corpus can currently supply
either. What this PR adds is the ability to *read* the answer when a title does, plus a narrowing of
where to look:

- **`PROSPER_AUDIO_LAYOUT` now prints the fold gains it APPLIED** beside each channel's measured
  role (`fold=L0.707/R0.000`, or `fold=UNPLACED`). Until now the second half of the question was
  readable only by opening `hle_audio.cpp` and working the table by hand — the step nobody takes
  while reading a log. Non-MAIN ports print `fold=n/a`; they are not mixed, so claiming a placement
  would be a falsehood.
- **`test_bed_routing_matrix` measures the fold end to end** — one unit impulse per source channel,
  every width 1..16, through the real `sceAudioOut2*` entrypoints, reading the gain that arrives at
  the host sink. It prints the matrix, which *is* the answer to "which guest channel landed in which
  host channel, and at what gain".
- **Corpus survey, recorded so nobody re-searches it:** only **5 of 44** dumps import
  `sceAudioOut2GetSpeakerInfo` — `PPSA04263`, `PPSA05143`, `PPSA09804` (via `AkSoundEngine.prx`),
  `PPSA21564`, `PPSA26414`. Every other title, Dragon Quest VII included, never asks, so for those
  the bed order is something prosper must infer and cannot negotiate. Start the orientation
  experiment from one of those five.
- **Stronger evidence that DQ7 cannot settle the height tier**: the stamp probe shows its writer
  *does* touch the whole 12-channel buffer every push (it clears ch2..ch11) and puts nothing in
  ch8..ch11. That is a stronger statement than "reads as zero".

## Measured vs derived

- **Measured**: that DQ7's 8-channel MAIN port is actively cleared by the guest each push; that its
  12-channel port is actively filled on ch0/ch1 only; that the reader reports non-zero on both ports
  when handed non-zero; that prosper's mix loop applies the documented fold table exactly, for every
  width 1..16, in both F32 and S16; that 0/44 dumps import `ContextBedWrite` and 5/44 import
  `GetSpeakerInfo`.
- **Derived / unchanged**: every left/right orientation in the fold table remains `CONFIDENCE: MED`
  on the index-0 = FrontLeft convention, exactly as before. **What would settle it** is unchanged
  and now has an address: content with distinct per-channel placement in one of the five titles
  above, measured with `PROSPER_AUDIO_LAYOUT`.

## What the tests prove, and the mutation arms

`test_bed_routing_matrix`'s bulk oracle is `audio_stereo_downmix` itself — deliberately, because it
tests the **application**, not the table. Five placements are additionally asserted against literals
at widths 3, 5, 6 and 7, the ones no other end-to-end arm exercises.

Mutation arms, each applied to the real source, rebuilt, and run:

| # | mutation | result |
|---|---|---|
| M1 | classifier tests emptiness **before** identity | **PASSED**, 0 failing checks — see below |
| M1' | classifier's identity test **deleted** | **FAILED**, 1 check: `test_audio.cpp:307  audio_classify_stamped_grain(true, true, 2048) == V::Intact` |
| M2 | address check moved **after** the content tests | **FAILED**, 2 checks: `:312` and `:313`, both `PointerMoved` arms |
| M3 | non-zero counted **byte-wise** instead of per sample | **FAILED**, 2 checks: `:327` (the `-0.0f` arm) and `:337` |
| M4 | mix loop swaps the two sides while **applying** a correct table | **FAILED**, 941 checks, of which **147 are the new matrix** — `:420` x73 and `:421` x74, spread across widths 1..16 |

Every arm above was applied to the real source, rebuilt, and run **at this PR's head**; the source
was restored and `git diff` confirmed empty between arms.

**M1 passing is reported because it corrected me, not despite that.** I had commented that the
identity/emptiness ordering was load-bearing; the swap is in fact behaviour-preserving, because a
surviving stamp is never empty, so the two conditions are mutually exclusive. The comment in
`hle_audio.cpp` and the note in the test now say so explicitly, and record that the swap arm passed.
Reading had it wrong and mutation had it right.

**Honest limit on M4**: it is caught by my new test *and* by several pre-existing arms (the 8- and
12-channel end-to-end cases). I could not construct a single-point mutation caught **only** by
`test_bed_routing_matrix` — `test_stereo_downmix` covers the table exhaustively and the mix loop is
shared code the existing arms already exercise. Its contribution is therefore per-(width, channel)
isolation, coverage of widths 1..7 and 9..16 which had **no** end-to-end coverage at all, and the
printed report — not a new detection. The one genuine coverage gap it does close is measured: every
pre-existing S16 AudioOut2 end-to-end arm is **stereo**, so the multichannel fold had no S16
coverage; the new S16 arms at widths 6 and 12 are the first.

## Affected / deliberately unaffected

- **Unaffected on a default run.** `PROSPER_AUDIO_STAMP` is inert unless set; the layout `fold=`
  column only prints under `PROSPER_AUDIO_LAYOUT=1`. No mixing, routing or fold behaviour changes —
  `audio_stereo_downmix` is byte-for-byte the same function.
- The probe writes to guest memory **only** when explicitly enabled, for one named port, for a
  bounded number of pushes, through the existing fault-safe `audio_store_bytes`.

## Risks

- The probe deliberately writes into the guest's grain buffer. Mitigated by: opt-in, one port,
  bounded pushes, byte-identical rollback on `INTACT`, fault-safe store, and self-disabling on any
  failed write or mismatched read-back. It is a debugging instrument in the same family as
  `PROSPER_HWBP`/`HWWATCH`/`PEEK`.
- The stamped pushes perturb the *following* push's flow/layout statistics. Documented in
  `AUDIO.md` and in the header comment; it is why the budget is bounded.

## Build / test

```sh
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

Results are in a comment below, at the exact head.

Live measurement route (all three arms):

```sh
cd prosper
PROSPER_NULL_PAGE=1 PROSPER_GUEST_ARGS= PROSPER_AUDIO_FLOW=1 PROSPER_AUDIO_LAYOUT=1 \
PROSPER_AUDIO_STAMP=2:6:13000 \
PROSPER_SAVE0=<FRESH>/save0 PROSPER_SAVEDATA_DIR=<FRESH>/savedata \
PROSPER_PAD_SCRIPT=@scripts/dragon-quest-vii/reach-title-screen.pad \
timeout 190 ./build-linux/boot_trace <DUMP_ROOT>/PPSA17942-app0
```

No snapshots were run: this changes no rendering behaviour and no default-run behaviour.

Refs #1720
Fixes #1721
