### PR TITLE
GTA V: capture-gate and DS-invalidation provenance diagnostics (no behavioural change)

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -925,9 +925,34 @@ trade for the question in this document — the bundle is wanted for its **resou
 descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
 about rendering, and must not be used as any.
 
-So the recipe that produces a GTA V bundle is both flags together; neither alone is enough. Until one
-exists, every conclusion in this section is from log statistics rather than from the frame's actual
-contents.
+**Gate 3 — the window that clears gate 1 then exceeds the 2 GiB bundle limit.**
+
+```
+[grab] frame-bundle: submit 42862 failed (frame bundle unique bytes 2155499889
+       exceeded limit 2147483648); grab aborted
+[grab] frame-bundle: frame 153 ended at submit 42861
+```
+
+So `PROSPER_CAPTURE_FRAMES=240` dies at frame **153**, having accumulated 2.15 GB. The useful number
+behind it: **42,861 submits across 153 frames ≈ 280 submits per frame, ≈ 14 MB of unique bytes per
+frame.** That is the sizing rule for this title — a window much above ~140 frames cannot complete,
+and nothing near that is needed, since one frame already carries ~280 submits.
+
+The three gates are **sequential and each masks the next**, which is why this took several runs to
+walk: widen the window and you meet provenance; clear provenance and you meet the size limit. The
+combination that gets through is a **small** window plus the override:
+
+```bash
+PROSPER_CAPTURE_FRAMES=8 PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 \
+PROSPER_GRAB_BUNDLE_AFTER_MS=380000 PROSPER_CAPTURE_DIR=~/<dir> \
+PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700 \
+PROSPER_PAD_SCRIPT=@scripts/gta5/reach-story-mode.pad \
+SDL_VIDEODRIVER=offscreen ./prosper-app <DUMP_ROOT>/PPSA04263-app0
+```
+
+Until a bundle exists, every conclusion in this section is from log statistics rather than from the
+frame's actual contents.
 
 ## The hang is NOT the only blocker — two more, measured (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -886,7 +886,7 @@ Three 4K DCC-compressed **sampled** images remain unsupported (fmt 1/4/9). That 
 resource from the storage image above — the storage image is not compressed. Whether the composite
 depends on those three has not been established.
 
-### The instrument that would answer this — TWO sequential gates, both now identified (2026-08-16)
+### The instrument that would answer this — THREE sequential gates, each masking the next (2026-08-16)
 
 `PROSPER_GRAB_BUNDLE_AFTER_MS` on `prosper-app` is the documented fastest loop for "why does this
 frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
@@ -3463,54 +3463,54 @@ exec_pristine=1 cfg_known=1` at pcs 16/18/21/25, so the mip level is proven and 
 descriptor, not the mip analysis. Then re-run this census and see whether the write-class binding
 becomes `outcome=executed`.
 
-### What invalidates the retained depth, now that the diagnostic can say (2026-08-17)
+### What invalidates the retained depth — 100% of it is prosper's own writeback (2026-08-17)
 
-`[ds] invalidate`'s `origin=` field was **structurally incapable of attribution** until the write
-origin was carried through the queue. It read a thread-local set around `notify_guest_gpu_write`, while
-DS/RTT invalidation runs at **drain** time on the draining thread — long after that thread-local is
-reset. So it printed `origin=gpu` for **30,458 of 30,458** invalidations, including ones made by
-writers that already tag themselves.
+**Read the retraction first.** An earlier revision of this section reported "~81% self-inflicted" and
+"1,678 **genuine guest** HTILE writes" for the main depth, and named the frontier as the semantics of
+those guest writes. **Both numbers were wrong and the frontier was misdirected.** The instrument had a
+second hole: `notify_guest_gpu_write_preserving_bytes` knew its own classification, printed it to the
+immediate watch, and then called the observer with only `(addr, size)` — so all four byte-preserving
+compute writeback paths arrived at the queue as the **default**, and the default was named `gpu`. A
+bucket that means "nobody said" was therefore reported as "genuinely the guest".
 
-**How that was found is worth keeping, because tagging looked like it should have been enough.** The
-remaining untagged writers were tagged first — the compute image writeback, its metadata reset, the
-renderer RTT writeback — and the re-run produced **30,458 × `origin=gpu` again, unchanged**. That null
-is what exposed the seam; the tags were correct and were being discarded between queue and drain. The
-queued record now captures the origin on the writing thread, and drain restores it around each range's
-invalidation.
-
-With attribution working, across every DS invalidation on a routed boot:
+With the origin carried as data across the notification/observer boundary, and the default renamed to
+`unknown` so it can never again be mistaken for a producer:
 
 | origin | count |
 | --- | --- |
-| `compute-writeback(image-guest-bytes)` | 15,777 |
-| `compute-writeback(cpu-fill)` | 11,267 |
-| `gpu` (genuinely the guest) | 6,316 |
+| `compute-writeback(image-guest-bytes)` | 15,017 |
+| `compute-writeback(cpu-fill)` | 10,234 |
+| `gpu-preserving` | 5,590 |
+| `unknown` (unattributed) | **0** |
 
-**About 81% of DS invalidation traffic is prosper invalidating its own caches from its own
-writebacks** (27,044 of 33,360). Recorded as a **measurement, not a verdict** — a writeback into guest
-memory can legitimately stale a detached cache — but it was invisible before and it is worth a
-decision.
+**30,841 of 30,841 DS invalidations are prosper invalidating its own caches from its own writebacks.
+Not 81% — all of them. There are no genuinely-guest DS invalidations on this route at all.**
 
-For the main depth `dr=0x2052ac0000`, which the failing 4K producer samples:
+For the main depth `dr=0x2052ac0000`, 2,276 invalidations, every one ours:
 
 | aspect hit | origin | count |
 | --- | --- | --- |
-| `htile_hit=1` | `gpu` | 1,678 |
-| `htile_hit=1` | `compute-writeback(cpu-fill)` | 407 |
-| `htile_hit=0` | `compute-writeback(cpu-fill)` | 407 |
+| `htile_hit=1` | `gpu-preserving` | 1,542 |
+| `htile_hit=1` | `compute-writeback(cpu-fill)` | 367 |
+| `htile_hit=0` | `compute-writeback(cpu-fill)` | 367 |
 
-**Its depth range is never directly written.** Every loss of the depth plane arrives through the
-conservative "an HTILE overlap may describe both aspects, so invalidate both" rule, and 1,678 of the
-2,492 are genuine guest HTILE writes of a repeated identical 640 KB at the HTILE base
-`0x2055310000`. The bridge consequence: `hit(depth=69965)` against
-`declined addr=0x2052ac0000 reason=depth-invalid x37751`, with the retained surface reporting
-`dvalid=0 svalid=1`.
+Its depth range is still never directly written — every loss of the plane arrives through the
+conservative "an HTILE overlap may describe both aspects" rule. But the writer is **us**, and 1,542 of
+those come from a path whose whole contract is that *the guest bytes were not modified*.
 
-**An aggregate over the wrong population reads as an answer.** A first pass over *all* surfaces showed
-24,922 depth invalidations with `htile_hit=0`, which says "HTILE is not involved at all". That
-population is dominated by **cube shadow maps** (`0x2094ec0000`, `0x20948c0000`, …). Filtering to the
-one surface under investigation inverts the conclusion completely. Filter to the subject before
-believing a count.
+**So the frontier is not the guest's HTILE semantics.** It is: why does prosper's own byte-preserving
+writeback overlap this depth surface's HTILE range at all, and should a write that provably preserves
+guest bytes invalidate a detached Vulkan depth image? The second half already has an answer on record
+and it is **yes, it must** — byte equality with guest memory says nothing about equality with a
+renderer-owned image the renderer has since drawn into, and *Dead Cells* #611 is the counterexample
+where sparing it makes gameplay geometry disappear. That is why no preservation policy is proposed
+here. The open question is the first half.
+
+**A default is not a measurement.** This is the third time on this title that a default or
+unattributed value was read as a positive finding — the others being a black frame compared against a
+mismatched trigger, and an `htile_hit=0` aggregate dominated by cube shadow maps. In all three the
+number was real and the population behind it was not what the label said. Name unattributed buckets
+`unknown`, and check what a "no origin" case actually means before counting it as evidence.
 
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -950,8 +950,25 @@ bundle and there is no frame count that fits under 2 GiB. (An earlier revision o
 divided 42,861 submits by 153 frames and published "≈ 14 MB per frame" as a sizing rule. That
 arithmetic is right and the inference from it is wrong: the 4-frame run falsifies it outright.)
 
-The lever is the budget, not the window: **`PROSPER_CAPTURE_BUNDLE_MAX_MB`** on `prosper-app`, which
-accepts 64..3072 MiB against a 2048 MiB default.
+The lever is the budget, not the window — **`PROSPER_CAPTURE_BUNDLE_MAX_MB`**, 64..3072 MiB against a
+2048 MiB default — **and on this title it is not enough at its maximum:**
+
+```
+FRAMES=240, limit 2048 MiB -> 2,155,499,889 bytes   (died at frame 153)
+FRAMES=4,   limit 2048 MiB -> 2,236,660,079 bytes
+FRAMES=4,   limit 3072 MiB -> 3,351,980,610 bytes
+FRAMES=1,   limit 3072 MiB -> 3,269,369,026 bytes   <- ONE frame, over the ceiling
+```
+
+A single frame costs 3.27 GB against a 3072 MiB (3.22 GB) hard clamp, so **there is currently no
+setting under which an F9 bundle of GTA V completes.** The last row is the one that matters: it is not
+a window-size problem and cannot be tuned away. (These are overshoot values at the point of abort,
+not totals, and they vary run to run, so the true working-set size is unknown and above 3.35 GB.)
+
+The fix worth building is not a bigger number. The question a bundle is wanted for here — *which
+compute program binds the empty composite tap* — needs **resource tables and descriptors, not pixel
+payloads**; a metadata-only capture would fit inside any budget and answer it directly. Tracked as
+#2554.
 
 The three gates are **sequential and each masks the next**, which is why this took several runs to
 walk: widen the window and you meet provenance; clear provenance and you meet the size limit; and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3386,6 +3386,43 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
+### The failing kernels bind 4K WRITE-capable storage images (2026-08-17)
+
+The section below draws the census boundary at "the unresolved operations inside the failing compute
+kernels remain outside the census". This looks *inside* that boundary for the first time, using a
+diagnostic that was already ungated and already in every routed log: `[compute-table]`, which dumps a
+program's whole resource table once per program that fails to recompile.
+
+**Two failing programs bind a storage image of exactly 33,177,600 bytes = 3840 × 2160 × 4** — the
+size of a 4K f11f11f10 surface, the very thing the composite's base tap is and does not contain:
+
+| program | binding | guest address | reject |
+| --- | --- | --- | --- |
+| `0x2042f49a00` | 6 | `0x204da00000`, **identical on all four runs** | `pc=16`, MIMG `op=0x1`, `mode=unresolved-operand` |
+| `0x205b557e00` | 13 | run-local (`0x2070f20000`, `0x2072f00000`) | `pc=314`, MIMG `op=0x0`, `srt_tag=0xa0`, `key_res=null pc_res=null` |
+
+`class=4` is `StorageImage` — read/written by `image_load`/`image_store` **without a sampler**, i.e.
+the class a compute producer writes through. `0x205b557e00` also samples a 3840×2160 renderer-owned
+RTT that reports *"has no readable snapshot -> dispatch skipped (#590)"*, so it reads a 4K surface and
+writes a 4K surface, and never runs.
+
+**This is the shape of the missing producer, and it is not proof.** What is established: failing
+kernels do bind 4K write-capable images, so the population the census excluded is not empty and is not
+irrelevant. What is *not* established: that either surface **is** the composite's base tap. Addresses
+are run-local, the tap was identified in an older run, and nothing here correlates the two — the
+honest statement is a size and class match on a population that was previously unexamined.
+
+**The failing population is also much larger than this document has been recording.** The reject
+census table above lists 13 programs; a routed boot has **30, 32, 36 and 35 distinct failing programs**
+across four runs on 2026-08-17. So "the seven failing kernels" understates it by roughly a factor of
+five, and any statement of the form "all the failing kernels were cleared" should be read against a
+count that was never that small.
+
+**Next step, and it is cheap:** re-run with `PROSPER_COMPUTE_BINDS=<tap address for that run>` — the
+instrument now reports the recompile-failure population as `outcome=partial-recompile-empty` instead
+of silently skipping it, which is exactly the population these two programs are in. Deriving the tap
+address for the *same* run is the only remaining piece.
+
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 
 Read the boundary in this heading before using the table. Every path that can write a surface **and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3463,6 +3463,55 @@ exec_pristine=1 cfg_known=1` at pcs 16/18/21/25, so the mip level is proven and 
 descriptor, not the mip analysis. Then re-run this census and see whether the write-class binding
 becomes `outcome=executed`.
 
+### What invalidates the retained depth, now that the diagnostic can say (2026-08-17)
+
+`[ds] invalidate`'s `origin=` field was **structurally incapable of attribution** until the write
+origin was carried through the queue. It read a thread-local set around `notify_guest_gpu_write`, while
+DS/RTT invalidation runs at **drain** time on the draining thread — long after that thread-local is
+reset. So it printed `origin=gpu` for **30,458 of 30,458** invalidations, including ones made by
+writers that already tag themselves.
+
+**How that was found is worth keeping, because tagging looked like it should have been enough.** The
+remaining untagged writers were tagged first — the compute image writeback, its metadata reset, the
+renderer RTT writeback — and the re-run produced **30,458 × `origin=gpu` again, unchanged**. That null
+is what exposed the seam; the tags were correct and were being discarded between queue and drain. The
+queued record now captures the origin on the writing thread, and drain restores it around each range's
+invalidation.
+
+With attribution working, across every DS invalidation on a routed boot:
+
+| origin | count |
+| --- | --- |
+| `compute-writeback(image-guest-bytes)` | 15,777 |
+| `compute-writeback(cpu-fill)` | 11,267 |
+| `gpu` (genuinely the guest) | 6,316 |
+
+**About 81% of DS invalidation traffic is prosper invalidating its own caches from its own
+writebacks** (27,044 of 33,360). Recorded as a **measurement, not a verdict** — a writeback into guest
+memory can legitimately stale a detached cache — but it was invisible before and it is worth a
+decision.
+
+For the main depth `dr=0x2052ac0000`, which the failing 4K producer samples:
+
+| aspect hit | origin | count |
+| --- | --- | --- |
+| `htile_hit=1` | `gpu` | 1,678 |
+| `htile_hit=1` | `compute-writeback(cpu-fill)` | 407 |
+| `htile_hit=0` | `compute-writeback(cpu-fill)` | 407 |
+
+**Its depth range is never directly written.** Every loss of the depth plane arrives through the
+conservative "an HTILE overlap may describe both aspects, so invalidate both" rule, and 1,678 of the
+2,492 are genuine guest HTILE writes of a repeated identical 640 KB at the HTILE base
+`0x2055310000`. The bridge consequence: `hit(depth=69965)` against
+`declined addr=0x2052ac0000 reason=depth-invalid x37751`, with the retained surface reporting
+`dvalid=0 svalid=1`.
+
+**An aggregate over the wrong population reads as an answer.** A first pass over *all* surfaces showed
+24,922 depth invalidations with `htile_hit=0`, which says "HTILE is not involved at all". That
+population is dominated by **cube shadow maps** (`0x2094ec0000`, `0x20948c0000`, …). Filtering to the
+one surface under investigation inverts the conclusion completely. Filter to the subject before
+believing a count.
+
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 
 Read the boundary in this heading before using the table. Every path that can write a surface **and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -889,8 +889,11 @@ depends on those three has not been established.
 ### The instrument that would answer this — THREE sequential gates, each masking the next (2026-08-16)
 
 `PROSPER_GRAB_BUNDLE_AFTER_MS` on `prosper-app` is the documented fastest loop for "why does this
-frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
-"frame capture does not work on GTA V", which is why the first one hid the second for a day.
+frame look wrong", and on this title it fails **three times, for unrelated reasons**. Each failure
+reads as "frame capture does not work on GTA V", and because they are **sequential** every fix reveals
+the next one rather than the bundle: clear the empty window and you meet the provenance abort, clear
+provenance and you meet the byte budget. That masking is why this took several runs to walk, and why
+the third gate — which no setting can clear — was the last to be seen.
 
 **Gate 1 — the capture window is a PRESENT COUNT, and a present count is not a unit of time.**
 Earlier attempts at 170 s with `PROSPER_CAPTURE_FRAMES=1` and 16 reported *"the capture window

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -886,15 +886,48 @@ Three 4K DCC-compressed **sampled** images remain unsupported (fmt 1/4/9). That 
 resource from the storage image above — the storage image is not compressed. Whether the composite
 depends on those three has not been established.
 
-### The instrument that would answer this, and why it has not yet
+### The instrument that would answer this — TWO sequential gates, both now identified (2026-08-16)
 
 `PROSPER_GRAB_BUNDLE_AFTER_MS` on `prosper-app` is the documented fastest loop for "why does this
-frame look wrong". It was tried at 170 s with `PROSPER_CAPTURE_FRAMES=1` and again with 16, and both
-report **"the capture window contained no GPU submits"** while the same run shows 271 `[agc]`, 60
-`[compute]` and 43 `[render]` lines and reaches 191 s of route. So the capture window and the
-submits are not lining up, and **that mismatch is itself the next thing to understand** — without a
-bundle there is no draw-level view of the frame, and every conclusion above is from log statistics
-rather than from the frame's actual contents.
+frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
+"frame capture does not work on GTA V", which is why the first one hid the second for a day.
+
+**Gate 1 — the capture window is one present wide, and this title does not submit on every present.**
+Earlier attempts at 170 s with `PROSPER_CAPTURE_FRAMES=1` and 16 reported *"the capture window
+contained no GPU submits"*, which read as a window/submit mismatch of unknown kind. The newer
+diagnostic names it exactly:
+
+```
+[grab] frame-bundle: window had no submits; widen it with PROSPER_CAPTURE_FRAMES=N (1..240)
+[grab] frame-bundle: during this window the submit hook was reached=0, 0 while inactive,
+       0 while not capturing; window was open 1 ms for 1 presents
+```
+
+`reached=0` with the window open **1 ms** settles it: the hook never fired, so nothing was
+mis-classified — the window simply closed between submits. **`PROSPER_CAPTURE_FRAMES=240` clears it**
+and the capture reaches real submits (observed: submit 34146).
+
+**Gate 2 — the bundle then aborts on indirect-pointer provenance.**
+
+```
+[grab] frame-bundle: submit 34146 failed (indirect-pointer relocation lacks exact compute
+       provenance); grab aborted
+```
+
+`validate_captured_indirect_pointer_relocations` requires capture format ≥ v53, a captured recompile
+config, an in-range raw shader index, **and exactly one** indirect-pointer carrier. GTA V fails one of
+these, and until 2026-08-16 the message was the same sentence for all four, so the log could not say
+which arm to pursue; it now names the failing precondition and prints the carrier/marker counts.
+
+**`PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1` accepts it and writes the bundle**, with the tool
+stating the limit itself: *"THIS BUNDLE IS FOR INSPECTION, NOT FAITHFUL REPLAY."* That is the right
+trade for the question in this document — the bundle is wanted for its **resource tables and
+descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
+about rendering, and must not be used as any.
+
+So the recipe that produces a GTA V bundle is both flags together; neither alone is enough. Until one
+exists, every conclusion in this section is from log statistics rather than from the frame's actual
+contents.
 
 ## The hang is NOT the only blocker — two more, measured (2026-08-15)
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -892,20 +892,29 @@ depends on those three has not been established.
 frame look wrong", and on this title it fails **twice, for unrelated reasons**. Each failure reads as
 "frame capture does not work on GTA V", which is why the first one hid the second for a day.
 
-**Gate 1 — the capture window is one present wide, and this title does not submit on every present.**
+**Gate 1 — the capture window is a PRESENT COUNT, and a present count is not a unit of time.**
 Earlier attempts at 170 s with `PROSPER_CAPTURE_FRAMES=1` and 16 reported *"the capture window
 contained no GPU submits"*, which read as a window/submit mismatch of unknown kind. The newer
 diagnostic names it exactly:
 
 ```
-[grab] frame-bundle: window had no submits; widen it with PROSPER_CAPTURE_FRAMES=N (1..240)
 [grab] frame-bundle: during this window the submit hook was reached=0, 0 while inactive,
-       0 while not capturing; window was open 1 ms for 1 presents
+       0 while not capturing; window was open 1 ms for 1 presents      # FRAMES=1
+       ... window was open  6 ms for   8 presents                      # FRAMES=8
+       ... window was open 38 ms for  64 presents                      # FRAMES=64
 ```
 
-`reached=0` with the window open **1 ms** settles it: the hook never fired, so nothing was
-mis-classified — the window simply closed between submits. **`PROSPER_CAPTURE_FRAMES=240` clears it**
-and the capture reaches real submits (observed: submit 34146).
+`reached=0` settles that nothing was mis-classified — the hook never fired. The rate is the finding:
+this title flips in **bursts**, ~0.6 ms per present against a ~23–25/s average, so a window's
+wall-clock duration is effectively random and usually far too short to contain a submit. Widening the
+count does not reliably help, because a burst consumes it: 64 presents elapsed in 38 ms and saw
+nothing.
+
+**The fix is `PROSPER_CAPTURE_WAIT_FOR_SUBMITS=1`** (`gpu_timeline.cpp`, opt-in), which extends the
+window until at least one submit is captured, bounded by the same 240-present ceiling, and never
+shortens a window that already worked. This was already diagnosed on this title under #2549 with the
+same burst measurements — recorded here because three separate frame counts were tried before that
+flag was found, and the failure message points at `PROSPER_CAPTURE_FRAMES` instead.
 
 **Gate 2 — the bundle then aborts on indirect-pointer provenance.**
 
@@ -925,25 +934,33 @@ trade for the question in this document — the bundle is wanted for its **resou
 descriptors**, not to reproduce the frame — but a replayed frame from such a bundle is not evidence
 about rendering, and must not be used as any.
 
-**Gate 3 — the window that clears gate 1 then exceeds the 2 GiB bundle limit.**
+**Gate 3 — GTA V's working set exceeds the F9 grab's 2 GiB default budget.**
 
 ```
 [grab] frame-bundle: submit 42862 failed (frame bundle unique bytes 2155499889
-       exceeded limit 2147483648); grab aborted
-[grab] frame-bundle: frame 153 ended at submit 42861
+       exceeded limit 2147483648); grab aborted        # FRAMES=240, died at frame 153
+[grab] frame-bundle: submit 35716 failed (frame bundle unique bytes 2236660079
+       exceeded limit 2147483648); grab aborted        # FRAMES=4 + WAIT_FOR_SUBMITS
 ```
 
-So `PROSPER_CAPTURE_FRAMES=240` dies at frame **153**, having accumulated 2.15 GB. The useful number
-behind it: **42,861 submits across 153 frames ≈ 280 submits per frame, ≈ 14 MB of unique bytes per
-frame.** That is the sizing rule for this title — a window much above ~140 frames cannot complete,
-and nothing near that is needed, since one frame already carries ~280 submits.
+**Read those two together, because the pair is the finding:** 153 frames cost 2.155 GB and *four*
+frames cost 2.237 GB. The bytes are therefore **not** per-frame deltas — they are dominated by the
+resident working set the first captured frame pulls in, so shrinking the window does not shrink the
+bundle and there is no frame count that fits under 2 GiB. (An earlier revision of this section
+divided 42,861 submits by 153 frames and published "≈ 14 MB per frame" as a sizing rule. That
+arithmetic is right and the inference from it is wrong: the 4-frame run falsifies it outright.)
+
+The lever is the budget, not the window: **`PROSPER_CAPTURE_BUNDLE_MAX_MB`** on `prosper-app`, which
+accepts 64..3072 MiB against a 2048 MiB default.
 
 The three gates are **sequential and each masks the next**, which is why this took several runs to
-walk: widen the window and you meet provenance; clear provenance and you meet the size limit. The
-combination that gets through is a **small** window plus the override:
+walk: widen the window and you meet provenance; clear provenance and you meet the size limit; and
+widening the window is the wrong lever for gate 1 anyway. The combination that gets through is a
+**small** window that waits for submits, plus the override:
 
 ```bash
-PROSPER_CAPTURE_FRAMES=8 PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 \
+PROSPER_CAPTURE_FRAMES=1 PROSPER_CAPTURE_WAIT_FOR_SUBMITS=1 \
+PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT=1 PROSPER_CAPTURE_BUNDLE_MAX_MB=3072 \
 PROSPER_GRAB_BUNDLE_AFTER_MS=380000 PROSPER_CAPTURE_DIR=~/<dir> \
 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
 PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700 \

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3418,10 +3418,50 @@ across four runs on 2026-08-17. So "the seven failing kernels" understates it by
 five, and any statement of the form "all the failing kernels were cleared" should be read against a
 count that was never that small.
 
-**Next step, and it is cheap:** re-run with `PROSPER_COMPUTE_BINDS=<tap address for that run>` — the
-instrument now reports the recompile-failure population as `outcome=partial-recompile-empty` instead
-of silently skipping it, which is exactly the population these two programs are in. Deriving the tap
-address for the *same* run is the only remaining piece.
+#### Watching that surface: the only WRITE-class binding of it came from a dispatch that did not run
+
+`PROSPER_COMPUTE_BINDS=204da00000` on a routed boot, 219 rows, 4 distinct programs. Two of them are
+the whole result:
+
+```
+[compute-binds] 0x204da00000 bound by program=0x2042f49a00 binding=6 class=4 fetch_pc=21
+                addr=0x204da00000 size=33177600 3840x2160 outcome=partial-recompile-empty
+[compute-binds] 0x204da00000 bound by program=0x205b557e00 binding=7 class=2 fetch_pc=19
+                addr=0x204da00000 size=33177600 3840x2160 outcome=executed
+```
+
+One 4K surface. `class=4` is `StorageImage`, the write-capable class; `class=2` is `Texture`,
+sampled-only. **The write-class binding is on a dispatch whose recompile failed — it did not run —
+while the sampled binding is on a dispatch that executed.** Across the whole run no executed dispatch
+was observed binding this surface write-class.
+
+Two qualifications, because both matter for how far this can be pushed:
+
+- **Recompile success is per-dispatch, not per-program.** Both programs also appear in the skip list
+  (`0x2042f49a00` at `pc=16` MIMG `op=0x1`; `0x205b557e00` at `pc=314` MIMG `op=0x0`), and a program's
+  resource table differs between dispatches, so the same code address can resolve in one invocation
+  and not in another. The claim is therefore about *observed bindings*, not about programs.
+- **This surface has not been shown to be the composite's base tap.** It is 4K, 33,177,600 bytes, and
+  written by nothing that ran — the right shape, on the right scale, in the population the census
+  excluded. That is a lead, not an identification.
+
+**The remaining 217 rows are instrument noise worth knowing about:** they come from two programs
+binding 256 MB constant buffers whose spans happen to *contain* the watched address. That is the
+documented "match the whole span, not the base" behaviour doing its job, but it means this instrument
+needs its output filtered by `class=` and by an exact `addr=` match before the signal is visible.
+
+**This row existed only because of the fix in `acaea037`.** Before it, `report_compute_binding_watch`
+returned from the `item.spirv.empty()` branch without reporting, so a recompile-failed dispatch
+produced no row at all — and this census would have shown the executed *consumer* and nothing else,
+i.e. exactly the false "no compute producer writes this surface" conclusion. The reviewer's finding
+that the instrument's null did not cover failing shaders is what made this visible.
+
+**Next step, now concrete:** make `0x2042f49a00` recompile. Its reject is a single named instruction —
+`pc=16`, MIMG `op=0x1` (`IMAGE_LOAD_MIP`), `mode=unresolved-operand`, `dmask=0x1 dim=1 glc=1` — and
+the `[mimg-mip-why]` lines for that program report `proven_at_use=1 mip_vgpr=v2 in_zero_set=1
+exec_pristine=1 cfg_known=1` at pcs 16/18/21/25, so the mip level is proven and the failure is the
+descriptor, not the mip analysis. Then re-run this census and see whether the write-class binding
+becomes `outcome=executed`.
 
 ### No OBSERVED DECODED path produces `0x2063380000` — which is not the same as "the guest never issues one"
 

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -8430,7 +8430,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             layout_ms += std::chrono::duration<double, std::milli>(layout_done - pack_done).count();
             if (trace) bi.after_hash = fnv1a(destination, bi.guest_bytes);
             const auto notify_start = ComputeClock::now();
+            // Name the writer. "a guest write covers this surface" and "prosper's own compute
+            // writeback covers this surface" are different facts, and only the second says the
+            // emulator is invalidating its own caches. Everything reaching the DS invalidation path
+            // used to report the default `gpu`, which cannot distinguish them.
+            set_guest_gpu_write_origin("compute-writeback(image-guest-bytes)");
             notify_guest_gpu_write(r->gpu_addr, bi.guest_bytes);
+            set_guest_gpu_write_origin(nullptr);
             if (!r->host_data && writer_provenance_enabled())
                 record_guest_write(GuestWriterKind::ComputeBuffer,
                                    r->gpu_addr, bi.guest_bytes,
@@ -8442,7 +8448,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         false, std::memory_order_acq_rel);
                 if (!leave_compressed_for_test) {
                     std::memset(bi.dcc_metadata, 0xff, bi.dcc_metadata_bytes);
+                    // This announcement lands on `metadata_addr`, which for a DEPTH surface is its
+                    // HTILE base -- and the DS cache treats an HTILE overlap as "may describe both
+                    // aspects" and invalidates depth as well as stencil. So this reset can discard a
+                    // retained depth image. Tagged so that consequence is attributable rather than
+                    // appearing as an anonymous `gpu` write; whether it SHOULD invalidate is a
+                    // separate question that needs the operation's real HTILE semantics proven.
+                    set_guest_gpu_write_origin("compute-writeback(metadata-reset)");
                     notify_guest_gpu_write(r->metadata_addr, bi.dcc_metadata_bytes);
+                    set_guest_gpu_write_origin(nullptr);
                     if (!r->dcc_metadata_host_data && writer_provenance_enabled())
                         record_guest_write(GuestWriterKind::ComputeBuffer,
                                            r->metadata_addr, bi.dcc_metadata_bytes,

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -154,7 +154,7 @@ using RttCache = std::unordered_map<uint64_t, RttSurf>;
 struct PendingGuestGpuWrite {
     uint64_t addr = 0;
     uint64_t size = 0;
-    const char* origin = "gpu";   // string literal or static storage; never an owned buffer
+    const char* origin = "unknown";   // string literal or static storage; never an owned buffer
 };
 
 struct PendingGuestGpuWrites {
@@ -168,10 +168,12 @@ PendingGuestGpuWrites& pending_guest_gpu_writes() {
     return pending;
 }
 
-void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
+void queue_guest_gpu_write(uint64_t addr, uint64_t size, const char* origin) {
     auto& pending = pending_guest_gpu_writes();
-    // Read the origin HERE, on the writing thread, while it is still the writer's.
-    const char* origin = prosper::gpu::guest_gpu_write_origin();
+    // The origin arrives AS DATA from the notifier. Reading the thread-local here instead would be
+    // correct for the plain notifier and wrong for the byte-preserving one, which knows a
+    // classification the thread-local never carried.
+    if (!origin) origin = "unknown";
     std::lock_guard<std::mutex> lock(pending.mutex);
     constexpr size_t kMaxPendingRanges = 65536;
     if (pending.ranges.size() < kMaxPendingRanges)
@@ -911,7 +913,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     const char* ds_invalidate = PROSPER_ENV_VALUE("PROSPER_DS_GUEST_WRITE_INVALIDATE");
     const bool invalidate_ds = !ds_invalidate || strcmp(ds_invalidate, "0");
     prosper::gpu::set_guest_gpu_write_observer(
-        [](uint64_t addr, uint64_t size) { queue_guest_gpu_write(addr, size); });
+        [](uint64_t addr, uint64_t size, const char* origin) {
+            queue_guest_gpu_write(addr, size, origin);
+        });
     // Resource tables are built before the submit reaches this callback. Publish the renderer's
     // default mode now so unmapped render-target descriptors remain available for RTT injection.
     // Outside a registered renderer, resource decoding retains its strict unknown-format policy.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -142,9 +142,24 @@ bool materialize_uniform_rtt(RttSurf& surface) {
 
 using RttCache = std::unordered_map<uint64_t, RttSurf>;
 
+// A queued guest write carries WHO made it. The origin is a thread-local set around
+// notify_guest_gpu_write, but DS/RTT invalidation runs later at drain time -- on whatever thread
+// drains, long after that thread-local was reset. So an invalidation diagnostic that reads the
+// thread-local reports a constant: measured on a routed GTA V boot, `[ds] invalidate` printed
+// `origin=gpu` for 30,458 of 30,458 invalidations, including ones made by writers that DO tag
+// themselves. The field looked like attribution and was structurally incapable of it.
+//
+// Capturing the origin at QUEUE time is what makes it real, and it is why the origin must live in
+// the record rather than be re-read at the far end of the seam.
+struct PendingGuestGpuWrite {
+    uint64_t addr = 0;
+    uint64_t size = 0;
+    const char* origin = "gpu";   // string literal or static storage; never an owned buffer
+};
+
 struct PendingGuestGpuWrites {
     std::mutex mutex;
-    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    std::vector<PendingGuestGpuWrite> ranges;
     bool overflowed = false;
 };
 
@@ -155,10 +170,12 @@ PendingGuestGpuWrites& pending_guest_gpu_writes() {
 
 void queue_guest_gpu_write(uint64_t addr, uint64_t size) {
     auto& pending = pending_guest_gpu_writes();
+    // Read the origin HERE, on the writing thread, while it is still the writer's.
+    const char* origin = prosper::gpu::guest_gpu_write_origin();
     std::lock_guard<std::mutex> lock(pending.mutex);
     constexpr size_t kMaxPendingRanges = 65536;
     if (pending.ranges.size() < kMaxPendingRanges)
-        pending.ranges.emplace_back(addr, size);
+        pending.ranges.push_back(PendingGuestGpuWrite{addr, size, origin});
     else
         pending.overflowed = true;
 }
@@ -234,7 +251,7 @@ void register_cpu_rtt_dcc_metadata(
 
 void drain_guest_gpu_writes(RttCache& cache, bool invalidate_ds) {
     auto& pending = pending_guest_gpu_writes();
-    std::vector<std::pair<uint64_t, uint64_t>> ranges;
+    std::vector<PendingGuestGpuWrite> ranges;
     bool overflowed = false;
     {
         std::lock_guard<std::mutex> lock(pending.mutex);
@@ -256,11 +273,16 @@ void drain_guest_gpu_writes(RttCache& cache, bool invalidate_ds) {
         cache.clear();
         return;
     }
-    for (const auto& [addr, size] : ranges) {
+    for (const auto& write : ranges) {
+        // Restore the writer's own origin for the duration of this range's invalidation, so the
+        // diagnostics inside report who actually wrote the bytes rather than the drain thread's
+        // default. Cleared afterwards so a queued origin never leaks into an unrelated later write.
+        prosper::gpu::set_guest_gpu_write_origin(write.origin);
         if (invalidate_ds)
-            prosper::test::invalidate_persistent_ds_guest_write(addr, size);
-        prosper::test::invalidate_persistent_color_target_guest_write(addr, size);
-        invalidate_cpu_rtt_guest_write(cache, addr, size);
+            prosper::test::invalidate_persistent_ds_guest_write(write.addr, write.size);
+        prosper::test::invalidate_persistent_color_target_guest_write(write.addr, write.size);
+        invalidate_cpu_rtt_guest_write(cache, write.addr, write.size);
+        prosper::gpu::set_guest_gpu_write_origin(nullptr);
     }
 }
 
@@ -5032,9 +5054,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 destination, pixels, tw, th, tile_mode,
                                                 writeback_pitch, 4u);
                                         }
-                                        if (guest_addr)
+                                        if (guest_addr) {
+                                            // Named for the same reason as the compute writebacks:
+                                            // a renderer writeback into guest memory is prosper's
+                                            // own store, and reads as an anonymous `gpu` write in
+                                            // every cache-invalidation diagnostic downstream.
+                                            prosper::gpu::set_guest_gpu_write_origin(
+                                                "renderer-writeback(rtt-guest-bytes)");
                                             prosper::gpu::notify_guest_gpu_write(
                                                 guest_addr, guest_bytes);
+                                            prosper::gpu::set_guest_gpu_write_origin(nullptr);
+                                        }
                                         // The same guest range can already have a sampled-image decode
                                         // under a different cache key/class. Its pixel representation
                                         // cannot be patched byte-for-byte from R32_UINT, so discard every

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <string>
 #include <bit>
 #include <cerrno>
 #include <cstdio>
@@ -1858,12 +1859,23 @@ bool validate_captured_indirect_pointer_relocations(
         error = "indirect-pointer relocation marker/carrier count mismatch";
         return false;
     }
-    if (capture.format_version < 53u || candidates != 1u ||
-        !compute.recompile_config_available ||
-        compute.raw_shader_index >= capture.raw_shader_versions.size()) {
-        if (capture_allow_unproven_provenance("an indirect-pointer relocation",
-                                              "no exact compute provenance")) return true;
-        error = "indirect-pointer relocation lacks exact compute provenance";
+    // Name WHICH precondition failed. These four are independent, they fail for unrelated reasons,
+    // and the one that fires decides whether the gap is a stale capture, a missing config, or a shape
+    // this validator was simply never written for -- but the message used to be the same sentence for
+    // all four, so the only way to tell them apart was to read this function. A whole title's F9
+    // bundles aborted on it (GTA V PPSA04263) with nothing in the log to say which arm to pursue.
+    const char* missing =
+        capture.format_version < 53u                                    ? "capture format older than v53"
+        : !compute.recompile_config_available                           ? "no captured recompile config"
+        : compute.raw_shader_index >= capture.raw_shader_versions.size() ? "raw shader index out of range"
+        : candidates != 1u                                              ? "carrier count is not exactly 1"
+                                                                        : nullptr;
+    if (missing) {
+        if (capture_allow_unproven_provenance("an indirect-pointer relocation", missing)) return true;
+        error = std::string("indirect-pointer relocation lacks exact compute provenance (") +
+                missing + ", carriers=" + std::to_string(candidates) +
+                " markers=" + std::to_string(marked) +
+                " format_version=" + std::to_string(capture.format_version) + ")";
         return false;
     }
     const auto& config = compute.recompile_config;

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -944,7 +944,14 @@ void notify_compute_authority_boundary(const ComputeAuthorityBoundary& boundary)
 // Guest GPU writes can change backing memory represented by a persistent host-side image. Backends
 // register one observer so guest-memory-producing backends can invalidate overlapping cached surfaces
 // without making prosper_core depend on Vulkan.
-using GuestGpuWriteObserver = std::function<void(uint64_t addr, uint64_t size)>;
+// The origin is passed AS DATA rather than read from the thread-local by the observer. The observer
+// may queue the write for a later drain on another thread, where the producer's thread-local is long
+// gone -- so a notifier that knows its own classification must hand it over here or the information
+// is lost. `notify_guest_gpu_write_preserving_bytes` knows it is "gpu-preserving" and used to drop
+// that on the floor at exactly this boundary, which silently filed every byte-preserving compute
+// writeback under the unattributed default.
+using GuestGpuWriteObserver =
+    std::function<void(uint64_t addr, uint64_t size, const char* origin)>;
 void set_guest_gpu_write_observer(GuestGpuWriteObserver observer);
 // Names the PM4 packet responsible for the next guest write, for PROSPER_GUEST_WRITE_WATCH. Thread
 // local and reset by the caller; a watch line that says only "a guest write covered this" cannot

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -11042,9 +11042,12 @@ void report_guest_write_watch(uint64_t addr, uint64_t size, const char* origin) 
 // packet that produced it. "a guest write covers this surface" and "a DMA_DATA fill of 512 KiB
 // covers this surface" are different facts, and only the second says whether the depth contents
 // were actually replaced.
-thread_local const char* g_guest_write_origin = "gpu";
+// "unknown", not "gpu". A default is not a measurement: naming it after a producer made an
+// unattributed bucket read as "genuinely the guest", and a published census then reported
+// prosper's own byte-preserving writebacks as guest HTILE writes.
+thread_local const char* g_guest_write_origin = "unknown";
 void set_guest_gpu_write_origin(const char* origin) {
-    g_guest_write_origin = origin ? origin : "gpu";
+    g_guest_write_origin = origin ? origin : "unknown";
 }
 const char* guest_gpu_write_origin() { return g_guest_write_origin; }
 
@@ -11063,7 +11066,7 @@ void notify_guest_gpu_write(uint64_t addr, uint64_t size) {
         else
             g_guest_gpu_writes.overflowed = true;
     }
-    if (g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size);
+    if (g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size, g_guest_write_origin);
 }
 void notify_guest_gpu_write_preserving_bytes(uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
@@ -11072,7 +11075,14 @@ void notify_guest_gpu_write_preserving_bytes(uint64_t addr, uint64_t size) {
     // which may differ from the exact guest bytes even when a compute result does not. Guest-memory
     // caches, page watches, and the submit journal remain valid because the caller proved that those
     // bytes were not modified.
-    if (g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size);
+    //
+    // Forward the classification this function already knows. Dropping it here is what made every
+    // byte-preserving compute writeback arrive at the queue as the unattributed default, so a census
+    // could not separate prosper's own writes from the guest's -- the exact distinction the origin
+    // field exists to draw. A caller-set origin wins, since it is more specific than this one.
+    const char* preserving_origin =
+        std::strcmp(g_guest_write_origin, "unknown") == 0 ? "gpu-preserving" : g_guest_write_origin;
+    if (g_guest_gpu_write_observer) g_guest_gpu_write_observer(addr, size, preserving_origin);
 }
 GuestGpuWriteSnapshot guest_gpu_write_snapshot() {
     if (!g_guest_gpu_writes.active || g_guest_gpu_writes.overflowed) return {};

--- a/prosper/tests/test_eop_write.cpp
+++ b/prosper/tests/test_eop_write.cpp
@@ -502,7 +502,7 @@ int main() {
         dma[6] = 0; // selectors are retained for diagnostics; both endpoints are mapped memory
 
         uint64_t observed_addr = 0, observed_size = 0;
-        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
             observed_addr = addr; observed_size = size;
         });
         GpuState st; run_cb(dma, 7, st);
@@ -558,7 +558,7 @@ int main() {
         dma[5] = sizeof(source);
         dma[6] = 1u | (3u << 8) | kDmaDataAddressSource;
         bool notified = false;
-        set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+        set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { notified = true; });
         GpuState st; run_cb(dma, 7, st);
         set_guest_gpu_write_observer({});
         CHECK(st.dma_copies.size() == 1 && st.dma_copies[0].dst == offset &&
@@ -801,7 +801,7 @@ int main() {
         stream[9] = (uint32_t)src; stream[10] = (uint32_t)(src >> 32);
         stream[11] = sizeof(source); stream[12] = 0;
         bool source_invalidated = false;
-        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t) {
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t, const char*) {
             if (addr == src) source_invalidated = true;
         });
         set_live_target_byte_range_reader(
@@ -1325,7 +1325,7 @@ int main() {
                 gpu_stream[5] = sizeof(gpu_source);
                 bool notified = false;
                 set_guest_gpu_write_observer(
-                    [&](uint64_t address, uint64_t size) {
+                    [&](uint64_t address, uint64_t size, const char*) {
                         notified |= address == gpu_dst && size == sizeof(gpu_source);
                     });
                 GpuState read_only_dma; run_cb(gpu_stream, 7, read_only_dma);
@@ -1344,7 +1344,7 @@ int main() {
                 gpu_stream[5] = sizeof(failed_gpu_source);
                 notified = false;
                 set_guest_gpu_write_observer(
-                    [&](uint64_t, uint64_t) { notified = true; });
+                    [&](uint64_t, uint64_t, const char*) { notified = true; });
                 const uint64_t trap_before_failed_write = prosper_gpu_write_trap_matches();
                 prosper_dma_backing_write_fail_once_for_test();
                 GpuState failed_backing_dma; run_cb(gpu_stream, 7, failed_backing_dma);
@@ -1361,7 +1361,7 @@ int main() {
                 gpu_stream[5] = 3 * sizeof(uint32_t);
                 notified = false;
                 set_guest_gpu_write_observer(
-                    [&](uint64_t address, uint64_t size) {
+                    [&](uint64_t address, uint64_t size, const char*) {
                         notified |= address == gpu_dst && size == 3 * sizeof(uint32_t);
                     });
                 GpuState read_only_fill; run_cb(gpu_stream, 7, read_only_fill);
@@ -1386,7 +1386,7 @@ int main() {
                 gpu_stream[5] = 16;
                 notified = false;
                 set_guest_gpu_write_observer(
-                    [&](uint64_t address, uint64_t size) {
+                    [&](uint64_t address, uint64_t size, const char*) {
                         notified |= address == overlap_dst && size == 16;
                     });
                 GpuState overlapping_dma; run_cb(gpu_stream, 7, overlapping_dma);
@@ -1403,7 +1403,7 @@ int main() {
                 gpu_stream[5] = sizeof(gpu_source);
                 notified = false;
                 set_guest_gpu_write_observer(
-                    [&](uint64_t, uint64_t) { notified = true; });
+                    [&](uint64_t, uint64_t, const char*) { notified = true; });
                 GpuState crossing_dma; run_cb(gpu_stream, 7, crossing_dma);
                 set_guest_gpu_write_observer({});
                 CHECK(*boundary_marker == 0x55667788u && !notified,
@@ -1448,7 +1448,7 @@ int main() {
         dma[3] = (uint32_t)bad_src; dma[4] = (uint32_t)(bad_src >> 32);
         dma[5] = 8;
         bool notified = false;
-        set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+        set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { notified = true; });
         GpuState st; run_cb(dma, 7, st);
         set_guest_gpu_write_observer({});
         CHECK(target == 0x8877665544332211ull,
@@ -1469,7 +1469,7 @@ int main() {
         dma[5] = sizeof(target);
         dma[6] = kDmaDataAddressSource;
         bool notified = false;
-        set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+        set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { notified = true; });
         GpuState st; run_cb(dma, 7, st);
         set_guest_gpu_write_observer({});
         CHECK(st.dma_copies.size() == 1 && target == 0x1122334455667788ull && !notified,
@@ -1510,7 +1510,7 @@ int main() {
                 dma[3] = (uint32_t)src; dma[4] = (uint32_t)(src >> 32);
                 dma[5] = sizeof(source);
                 bool notified = false;
-                set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+                set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { notified = true; });
                 GpuState st; run_cb(dma, 7, st);
                 set_guest_gpu_write_observer({});
                 CHECK(page[0] == 0x5A && page[sizeof(source) - 1] == 0x5A,
@@ -1521,7 +1521,7 @@ int main() {
                 dma[4] = 0;
                 dma[5] = 3 * sizeof(uint32_t);
                 notified = false;
-                set_guest_gpu_write_observer([&](uint64_t, uint64_t) { notified = true; });
+                set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { notified = true; });
                 GpuState fill; run_cb(dma, 7, fill);
                 set_guest_gpu_write_observer({});
                 CHECK(page[0] == 0x5A && page[3 * sizeof(uint32_t) - 1] == 0x5A,
@@ -2206,6 +2206,45 @@ int main() {
             }
         }
         CHECK(true, "label_hist_report keeps every entry whole across caps 40..400");
+    }
+
+    // The guest-write ORIGIN must cross the notification/observer boundary AS DATA. The observer may
+    // queue the write for a drain that happens later, on another thread, where the producer's
+    // thread-local is long gone -- so anything the notifier knows and does not hand over is lost.
+    //
+    // This is a regression for a defect that was invisible to the immediate view: the byte-preserving
+    // notifier printed `gpu-preserving` to the watch and then called the observer with only
+    // (addr, size), so every byte-preserving compute writeback reached the queue as the unattributed
+    // default. A census then reported those as genuine guest writes -- the exact distinction the field
+    // exists to draw.
+    {
+        struct Seen { uint64_t addr = 0, size = 0; std::string origin; };
+        std::vector<Seen> queued;
+        set_guest_gpu_write_observer(
+            [&](uint64_t addr, uint64_t size, const char* origin) {
+                // Model the delayed consumer: copy what was handed over, and never consult the
+                // thread-local. A drain reading the thread-local is precisely the bug.
+                queued.push_back(Seen{addr, size, origin ? origin : "<null>"});
+            });
+
+        set_guest_gpu_write_origin("test-tagged-writer");
+        notify_guest_gpu_write(0x1000, 64);
+        set_guest_gpu_write_origin(nullptr);          // producer's tag is gone before we read
+
+        notify_guest_gpu_write_preserving_bytes(0x2000, 128);
+        notify_guest_gpu_write(0x3000, 32);           // untagged: must be unattributed, not a producer
+
+        set_guest_gpu_write_observer({});
+
+        CHECK(queued.size() == 3, "every notification reaches the observer");
+        CHECK(queued.size() == 3 && queued[0].origin == "test-tagged-writer",
+              "a tagged write carries its producer's origin across the observer boundary");
+        CHECK(queued.size() == 3 && queued[1].origin == "gpu-preserving",
+              "the byte-preserving notifier forwards its own classification rather than dropping it");
+        CHECK(queued.size() == 3 && queued[2].origin == std::string("unknown"),
+              "an untagged write is UNATTRIBUTED, never named after a producer");
+        CHECK(queued.size() == 3 && queued[1].addr == 0x2000 && queued[1].size == 128,
+              "the preserving notification keeps its exact range");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_game_compute.cpp
+++ b/prosper/tests/test_game_compute.cpp
@@ -930,7 +930,7 @@ int main() {
     ComputeItem cpu_fill_item = item;
     cpu_fill_item.cpu_fast_path = ComputeCpuFastPath::FillSgprUvec4;
     uint32_t cpu_fill_write_notifications = 0;
-    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
         if (addr == buffer.gpu_addr && size == buffer.size)
             ++cpu_fill_write_notifications;
     });
@@ -1011,7 +1011,7 @@ int main() {
     }
 
     uint32_t unchanged_write_notifications = 0;
-    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
         if (addr == buffer.gpu_addr && size == buffer.size)
             unchanged_write_notifications++;
     });
@@ -1078,7 +1078,7 @@ int main() {
             atomic_item.code_addr = 0x500525200;
 
             uint64_t atomic_notified_bytes = 0;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t bytes) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t bytes, const char*) {
                 if (addr == atomic_image.gpu_addr) atomic_notified_bytes = bytes;
             });
             CHECK(prosper::frontend::execute_live_compute_items({atomic_item}),
@@ -1165,7 +1165,7 @@ int main() {
               "arm guest-byte watch around retained compute-buffer result");
 #endif
         uint32_t large_repeat_notifications = 0;
-        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
             if (addr == large_buffer.gpu_addr && size == large_buffer.size)
                 ++large_repeat_notifications;
         });
@@ -1186,7 +1186,7 @@ int main() {
 
         large_result[0] ^= 0xffffffffu;
         uint32_t large_repair_notifications = 0;
-        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+        set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
             if (addr == large_buffer.gpu_addr && size == large_buffer.size)
                 ++large_repair_notifications;
         });
@@ -1349,7 +1349,7 @@ int main() {
               gds_replay.computes[1].resources->resources[0].host_data,
           "capture v22 materializes one persistent GDS instance across ordered dispatches");
     uint32_t gds_notifications = 0;
-    set_guest_gpu_write_observer([&](uint64_t, uint64_t) { ++gds_notifications; });
+    set_guest_gpu_write_observer([&](uint64_t, uint64_t, const char*) { ++gds_notifications; });
     CHECK(prosper::frontend::execute_live_compute_items(gds_replay.computes),
           "production live backend executes captured GDS stores");
     set_guest_gpu_write_observer({});
@@ -3168,7 +3168,7 @@ int main() {
             return true;
         });
     bool writable_rtt_published = false;
-    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
         writable_rtt_published |= addr == writable_addr && size == writable_rtt_guest.size();
     });
     const std::vector<uint32_t> writable_spirv = recompile_valu(
@@ -3543,7 +3543,7 @@ int main() {
                 prosper::frontend::live_compute_storage_result_snapshot_bytes();
 #endif
             uint32_t repeated_write_notifications = 0;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                 if (addr == fdst.gpu_addr && size == fdst.size)
                     ++repeated_write_notifications;
             });
@@ -3899,7 +3899,7 @@ int main() {
                 CHECK(fill_equals(after_prove),
                       "failed storage readback does not publish newer image bytes to the guest");
                 uint32_t changed_write_notifications = 0;
-                set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+                set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                     if (addr == fdst.gpu_addr && size == fdst.size)
                         ++changed_write_notifications;
                 });
@@ -3931,7 +3931,7 @@ int main() {
                     prosper::frontend::live_compute_storage_result_snapshot_bytes();
 #endif
                 uint32_t recovered_repeat_notifications = 0;
-                set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+                set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                     if (addr == fdst.gpu_addr && size == fdst.size)
                         ++recovered_repeat_notifications;
                 });
@@ -3965,7 +3965,7 @@ int main() {
 #endif
             fill_guest[0] ^= 0xff;
             uint32_t repaired_write_notifications = 0;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                 if (addr == fdst.gpu_addr && size == fdst.size)
                     ++repaired_write_notifications;
             });
@@ -4221,7 +4221,7 @@ int main() {
                 reinterpret_cast<uint64_t>(raw_guest), raw_guest_bytes);
 #endif
             uint32_t raw_repeat_notifications = 0;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                 if (addr == raw_dst.gpu_addr && size == raw_guest_bytes)
                     ++raw_repeat_notifications;
             });
@@ -4240,7 +4240,7 @@ int main() {
 
             raw_guest[0] ^= 0xff;
             uint32_t raw_repair_notifications = 0;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                 if (addr == raw_dst.gpu_addr && size == raw_guest_bytes)
                     ++raw_repair_notifications;
             });

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -2865,7 +2865,7 @@ int main(int argc, char** argv) {
             output = current_render_target;
             return LiveTargetByteReadResult::Success;
         });
-    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
         invalidations.emplace_back(addr, size);
     });
     execute_ordered_items(
@@ -2944,7 +2944,7 @@ int main(int argc, char** argv) {
                                              operation.command_order});
     std::array<uint8_t, 4> gds_observed{};
     invalidations.clear();
-    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+    set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
         invalidations.emplace_back(addr, size);
     });
     execute_ordered_items(

--- a/prosper/tests/test_gpu_execute.cpp
+++ b/prosper/tests/test_gpu_execute.cpp
@@ -452,7 +452,7 @@ int main() {
                       watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged,
                   "arm cross-submit watch before GPU notification");
             bool preserving_write_observed = false;
-            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size) {
+            set_guest_gpu_write_observer([&](uint64_t addr, uint64_t size, const char*) {
                 preserving_write_observed =
                     addr == reinterpret_cast<uint64_t>(watched) + logical_offset + 8u &&
                     size == 16u;
@@ -630,7 +630,7 @@ int main() {
         auto& image = cache[scene];
         image.depth_valid = true;
         image.stencil_valid = true;
-        set_guest_gpu_write_observer([](uint64_t addr, uint64_t size) {
+        set_guest_gpu_write_observer([](uint64_t addr, uint64_t size, const char*) {
             prosper::test::invalidate_persistent_ds_guest_write(addr, size);
         });
         notify_guest_gpu_write(0x300000, 0x8000);


### PR DESCRIPTION
Refs #2542, #2554, tracker #1873. **Split out of #2555** after review rejected that PR's two
behavioural commits; this is the half with no rendering risk, so it can land while the compiler
relaxation is rebuilt properly.

## Why this is split

#2555 relaxed a shared compiler predicate (`compression_enabled` leaving the zero-mip proof) while
adding its bind-time safety guard to **compute only**. Review found the predicate is also called from
two graphics sites, and the graphics binding path merely *warns* before detiling compressed base bytes
— so that PR introduced a real hole, plus three further blockers. **None of that is here.** Those
commits stay on `work/gta5-world-render-3` (now draft) until the shared, metadata-kind-aware source
authority Codex described exists.

## What this changes

**A guest-write provenance contract, and it is not cosmetic.** `[ds] invalidate`'s `origin=` field was
*structurally incapable* of attribution, in two separate ways:

1. It read a thread-local set around `notify_guest_gpu_write`, while DS/RTT invalidation runs at
   **drain** time on the draining thread, long after that thread-local is reset.
2. `notify_guest_gpu_write_preserving_bytes` knew its own classification, printed `gpu-preserving` to
   the immediate watch, and then called the observer with only `(addr, size)` — so all four
   byte-preserving compute writeback paths arrived at the queue as the **default**, and that default
   was named `gpu`.

So a bucket meaning "nobody said" was being reported as "genuinely the guest".

Fixed by carrying the origin **as data** across the notification/observer boundary:

- `GuestGpuWriteObserver` takes `(addr, size, origin)` — **a shared contract change**; 20 observer
  lambdas across four test files were widened.
- the preserving notifier forwards its own classification (a caller-set origin still wins, being more
  specific).
- the default is **`unknown`**, not `gpu`. Naming an unattributed bucket after a producer is what made
  this misreport rather than merely under-report.
- the pending-write queue record carries the origin; drain restores it around each range's
  invalidation.

**Plus a capture diagnostic:** `validate_captured_indirect_pointer_relocations` has four independent
preconditions and reported all four with the same sentence, so a whole title's F9 bundles aborted with
nothing in the log to say which arm to pursue. It now names the failing precondition and prints
carrier/marker counts and format version.

## The measurement, and the retraction it replaces

**An earlier revision of this PR published numbers that this correction disproved.** It reported
`gpu = 6,316` as "genuinely the guest", "~81%" self-invalidation, and "1,678 of 2,492 main-depth
invalidations were genuine guest HTILE writes" — and named the frontier as the guest's HTILE semantics.
All of that came from the unattributed bucket described above. The corrected census:

| origin | count |
| --- | --- |
| `compute-writeback(image-guest-bytes)` | 15,017 |
| `compute-writeback(cpu-fill)` | 10,234 |
| `gpu-preserving` | 5,590 |
| `unknown` (unattributed) | **0** |

**30,841 of 30,841 DS invalidations are prosper invalidating its own caches from its own writebacks —
not 81%, all of them, with nothing left unattributed.** For the main depth `dr=0x2052ac0000`, 2,276
invalidations, every one ours:

| aspect hit | origin | count |
| --- | --- | --- |
| `htile_hit=1` | `gpu-preserving` | 1,542 |
| `htile_hit=1` | `compute-writeback(cpu-fill)` | 367 |
| `htile_hit=0` | `compute-writeback(cpu-fill)` | 367 |

**There are no genuine guest HTILE writes.** The frontier is therefore **why prosper's own
byte-preserving writeback overlaps this depth surface's HTILE range 1,542 times** — not the guest's
semantics. Whether such a write must still invalidate is already settled and the answer is **yes**:
byte equality with guest memory says nothing about equality with a renderer image drawn into since, and
*Dead Cells* #611 is the counterexample where sparing it makes gameplay geometry disappear. **No
preservation policy is proposed here.**

## Regression

`test_eop_write` covers the delayed seam: a tagged write must carry its producer across the boundary,
the preserving notifier must forward its classification, and an untagged write must read `unknown`. The
observer copies what it was handed and never consults the thread-local — the delayed-consumer shape.
Mutation-checked at the production site; dropping the forwarding fails exactly:

```
[FAIL] the byte-preserving notifier forwards its own classification rather than dropping it
```

## Also recorded in `GTA5_STATUS.md`

- **Three sequential capture gates**, each masking the next. The third is fatal: **one captured frame
  is 3.27 GB against a 3072 MiB hard clamp**, so no F9 bundle of this title completes at any
  `PROSPER_CAPTURE_FRAMES` or `PROSPER_CAPTURE_BUNDLE_MAX_MB` setting (#2554). The series is kept
  because 240 frames cost 2.16 GB and *one* costs 3.27 GB — bytes track the resident working set, not
  frame count, falsifying a per-frame sizing rule an earlier revision published.
- **30–36 distinct failing compute programs** per routed run, against the 13 in the census table and
  the "seven" the prose had been repeating.
- Two failing programs bind **4K write-capable storage images** (33,177,600 B = 3840×2160×4), and the
  only write-class binding of one such surface came from a dispatch that never ran — the observation
  that motivated #2555.
- **Three instrument traps, all the same shape: a default or unattributed value read as a positive
  finding.** A black frame that looked like a rendering regression until compared against a
  *matched-trigger* control; an `htile_hit=0` aggregate dominated by **cube shadow maps** that inverts
  once filtered to the surface under investigation; and the `gpu` bucket above. Each number was real
  and each population was not what the label claimed. The rule is written into the doc as *a default is
  not a measurement*.

## Risk

Nothing here alters rendering. It does change a **shared observer contract** (`GuestGpuWriteObserver`
gains a parameter) and the behaviour of `notify_guest_gpu_write_preserving_bytes` at that boundary, so
the blast radius is every registered observer — all of which are in this repo and all updated here. The
rest is diagnostics and documentation.

## Verification

```
cmake --build prosper/build-linux -j6                  # exit 0
ctest --no-tests=error -j4                             # 246/246 passed, exit 0
check_numbered_table.py --sequential (orchestration)   # exit 0
check_numbered_table.py over all tracked .md           # exit 0
git diff --check                                       # clean
```

No snapshots: no rendering behaviour changes.
