### PR TITLE
fix(tools): hle_calls --values recorded nothing on prosper's own default build (#2075)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -149,6 +149,16 @@ if(Python3_Interpreter_FOUND)
   # actually runs rather than on a copy.
   add_test(NAME hle_calls_positive_control
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/hle_calls/test_hle_calls.py")
+  # The sibling above is pure; this one cannot be. #2075 was not a logic bug: `--values` recorded
+  # NOTHING on prosper's own default build, because gdb's FinishBreakpoint.return_value comes from
+  # the DWARF return type and `Release` carries no `-g`. Only a real gdb over a real no-debug-info
+  # binary reproduces that, so this compiles test_values_fixture.cpp twice (-g0 and -g) and runs the
+  # real driver over each. A missing gdb/compiler exits 77 -> reported as `(Skipped)` by name, which
+  # is the one thing a silently-skipped end-to-end test cannot do.
+  add_test(NAME hle_calls_value_capture
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/hle_calls/test_hle_calls_values.py")
+  set_tests_properties(hle_calls_value_capture PROPERTIES SKIP_RETURN_CODE 77 TIMEOUT 600)
   add_test(NAME snapshot_guard_logic
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/snapshot/test_snapshot.py")
   add_test(NAME gpu_replay_regress_logic

--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -844,14 +844,22 @@ on this path are offline-consistent (`sceNetCtlGetState` -> DISCONNECTED, `sceNp
   formed and then falsified against the `DELIVERED` lines above. Any `hle_calls` zero for a
   trampoline-registered handler is **void**. Recorded as instrument trap 105 in
   `GAME_COMPAT_ORCHESTRATION.md`.
-- **`hle_calls --values` is currently void on this machine** (#2075), and its own positive control says so.
-  Three independent arms (60 ticks / 1500 ticks / a single-handler 40-tick arm) report
-  `finish-failures` exactly equal to the call count — 20/20, 543/543, 4/4 — with
-  `positive-control=VOID(0-returns-for-N-calls)` and every row `(captured 0/N)`. gdb is 17.2, the
-  version the tool documents. The counting path is healthy — the same 1500-tick arm with `--values`
-  off reports `calls=257 finish-failures=0`. So no value census can be taken here until #2075 is
-  fixed, and any value figure quoted for this title comes from an earlier arm, not from current
-  master.
+- **`hle_calls --values` was void on this machine** (#2075) — **fixed**, and the cause was not the
+  one this bullet originally suspected. Three independent arms (60 ticks / 1500 ticks / a
+  single-handler 40-tick arm) reported `finish-failures` exactly equal to the call count — 20/20,
+  543/543, 4/4 — with `positive-control=VOID(0-returns-for-N-calls)` and every row `(captured 0/N)`,
+  while the counting path stayed healthy (the same 1500-tick arm with `--values` off reported
+  `calls=257 finish-failures=0`). **gdb 17.2 was innocent, and so was the missing caller frame.**
+  The value came from `FinishBreakpoint.return_value`, which gdb derives from the **DWARF return
+  type** — and `boot_trace` had none, because prosper's default `CMAKE_BUILD_TYPE` is `Release`
+  (`-O3 -DNDEBUG`, no `-g`). One-variable A/B on a single binary (`objcopy --strip-debug` of a
+  RelWithDebInfo build, same gdb, same title, same window): debug sections present →
+  `finish-failures=0` and `positive-control=ok`; removed → `4 calls / 4 failures /
+  VOID(0-returns-for-4-calls)`. The tool now reads `%rax` when DWARF is absent and reports
+  `value-source=dwarf:N,rax:M`, so a value census can be taken here on an ordinary default build:
+  the repro arm gives `s_user_getevent ret 0x0 x1, 0x80960007 x3  positive-control=ok`. Value
+  figures quoted for this title *before* that fix still come from an earlier arm, not from a
+  measurement on the revision they were quoted against.
 
 ### The resource-phase model, the `ui_startup` insertion site, and what boot actually completes (2026-08-06, master `f080fc23`)
 

--- a/prosper/tools/hle_calls/README.md
+++ b/prosper/tools/hle_calls/README.md
@@ -151,9 +151,26 @@ a null event pointer, which answers `NO_EVENT` without consuming the LOGIN; the 
 not be *armed or decoded*, and it does not see the more common loss: a handler that leaves its frame
 without returning normally (longjmp, thread teardown) loses its value silently. Each row therefore
 prints `(captured N/M)` whenever fewer values were recorded than calls counted, and that is the field
-to read before calling a value set complete.
+to read before calling a value set complete. **Every failure now names itself** on a
+`finish-failure-reasons:` line (`4x return_value: TypeError: …`) — a bare count is what let #2075
+stay undiagnosed while the feature recorded nothing at all.
 
-Two limits before believing a number:
+### Where a value comes from — `value-source=dwarf:N,rax:M`
+
+Two independent reads answer "what did it return", and the header says which one did:
+
+- **`dwarf`** — gdb's `FinishBreakpoint.return_value`, decoded from the function's DWARF return
+  type. ABI-aware for any return type, and available only on a build that carries debug info.
+- **`rax`** — the SysV integer return register, read at the return address before the caller has
+  executed an instruction. Needs no debug info, and is exactly right for what this tool arms: the
+  driver enumerates only the six-`unsigned long` HLE signature, whose `HLE(…)` macro returns
+  `uint64_t`.
+
+`dwarf:0,rax:N` is the **normal** shape, not a degraded one: prosper's default `CMAKE_BUILD_TYPE` is
+`Release` (`-O3 -DNDEBUG`, no `-g`). When both answer they must agree; a disagreement prints a loud
+`value-source-MISMATCH:` line, and it would mean a handler whose return does not live in `%rax`.
+
+Three limits before believing a number:
 
 - `--values` records the return **register**, never an out-struct. A handler that returns 0 while
   writing wrong bytes through a pointer argument is invisible — and on this codebase that is a common
@@ -165,6 +182,9 @@ Two limits before believing a number:
   control on one call in three, the row read `ret 0x80960007 x13, 0x0 x7` with a complete-looking
   20-of-20 capture, because the seven landing values were *recorded* rather than lost.
   `positive-control=VIOLATED(login-x7)` was the only field in the run that said so.
+- A `rax`-sourced value rests on one assumption — that the handler returns an integer — which holds
+  by construction for everything this tool arms, and which only a `dwarf` run can independently
+  check. On a debug build the two are compared on every call; on a `Release` build nothing else can.
 
 `window=complete|SHORT` in the header is the matching check for the run as a whole: `run`/`continue`
 also return on a signal gdb stops for (`SIGABRT` is not passed through, and these titles do abort),
@@ -194,10 +214,29 @@ own state, and the positive control is what caught it. The same shape of mistake
 line always prints `entries` and `armed`: a result you cannot sanity-check against a known-live
 number is not a result.
 
+## Ruled out
+
+One line per hypothesis this tool's own investigations have killed, so nobody re-derives a dead
+answer at full cost.
+
+- **"`--values` is broken by gdb 17.2 / by the missing caller CFI."** Falsified while fixing #2075.
+  The `gdb.FinishBreakpoint` construction succeeds on every call — measured directly, `ctor-ok` for
+  4 of 4 — even though `gdb.Frame.older()` on a handler entered from guest code returns `None`, so
+  the absent caller frame is real and harmless. The cause was the *decode*: `return_value` comes
+  from the DWARF return type, and the binary had none. One-variable A/B on **one** binary
+  (`objcopy --strip-debug`, same gdb 17.2, same title, same window): `.debug_*` present →
+  `finish-failures=0`, `positive-control=ok`; removed → `4 calls / 4 failures /
+  VOID(0-returns-for-4-calls)`.
+- **"`--values` needs a debug build."** True before #2075's fix, and no longer: a `Release` binary
+  is captured through `%rax` (`value-source=dwarf:0,rax:N`). Do not reintroduce a `-g` requirement
+  in the docs — it would send readers to rebuild the emulator to work around a fixed defect.
+
 ## Requirements
 
 Linux, `gdb` with Python support, `nm`/`c++filt`, and ptrace attach permitted
-(`kernel.yama.ptrace_scope=0`). The prosper binary must not be stripped.
+(`kernel.yama.ptrace_scope=0`, `--pid` mode only — `--launch` runs its own child). The prosper
+binary must not be **stripped**: the driver enumerates handlers out of the symbol table with `nm`.
+Debug info is *not* required, including for `--values`.
 
 ## Cost
 

--- a/prosper/tools/hle_calls/hle_calls.py
+++ b/prosper/tools/hle_calls/hle_calls.py
@@ -105,7 +105,15 @@ captures that could not be **armed or decoded**, and it does not see the more
 common loss: a handler that leaves its frame without returning normally (longjmp,
 thread teardown) loses its value silently. So each row prints `(captured N/M)`
 whenever fewer values were recorded than calls counted — that is the field to
-read before calling a value set complete.
+read before calling a value set complete. Every failure also names itself on a
+`finish-failure-reasons:` line; a bare count is what let #2075 stay undiagnosed.
+
+`value-source=dwarf:N,rax:M` says which of the two reads answered: gdb's
+DWARF-typed `return_value`, or the SysV integer return register. `dwarf:0` is
+normal rather than degraded — prosper's default build type is `Release`, which
+carries no debug info, and that is precisely the configuration on which this
+feature used to record nothing at all (#2075). When both answer they must agree,
+and a disagreement prints a loud `value-source-MISMATCH:` line.
 
 Two limits to know before believing a number: `--values` records the return
 **register**, never an out-struct, so a handler that returns 0 while writing
@@ -133,7 +141,9 @@ applies to `--launch` only; passing it with `--pid` is an error, because there i
 no inferior whose output this tool controls.
 
 Requirements: Linux, `gdb` with Python, `nm`, and ptrace attach permitted
-(`kernel.yama.ptrace_scope=0`). The prosper binary must not be stripped.
+(`kernel.yama.ptrace_scope=0`, for `--pid`; `--launch` runs its own child). The
+prosper binary must not be stripped — the handler enumeration below reads the
+symbol table. Debug info is not required, `--values` included.
 """
 
 import argparse

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -32,11 +32,18 @@ both are printed unconditionally:
     "init made no interesting call" from "this run never saw init" — the two read
     identically in a histogram.
   * `finish-failures` counts return-value captures that could not be armed or
-    decoded — but it is NOT the whole story, so each row also prints
+    decoded, and every one of them now names its own reason on the
+    `finish-failure-reasons:` line — a bare count is what let #2075 stay
+    undiagnosed. It is still NOT the whole story, so each row also prints
     `(captured N/M)` whenever fewer values were recorded than calls counted.
     That second form is the one to trust: a handler that leaves its frame
     without returning normally (longjmp, thread teardown) loses its capture
     without incrementing `finish-failures`.
+  * `value-source=dwarf:N,rax:M` says which read answered. Both are the same
+    number when both are available; only DWARF is independent of this tool's
+    "the HLE ABI returns in %rax" assumption, and a disagreement between them
+    is reported loudly on its own line. `dwarf:0` is normal, not degraded:
+    prosper's default build type is Release, which carries no debug info.
   * `window=complete|SHORT` says whether the clock really reached `--ticks`.
     `run`/`continue` also return on a signal gdb stops for, which would
     otherwise print a truncated histogram that reads as a finished window.
@@ -68,6 +75,7 @@ here is a tool bug, not a new emulator defect.
 """
 
 import os
+import re
 import sys
 import gdb
 
@@ -104,6 +112,8 @@ CONTROL = "s_user_getevent"
 CONTROL_LOGIN = 0
 CONTROL_NO_EVENT = 0x80960007
 
+RET_MASK = 0xFFFFFFFFFFFFFFFF
+
 counts = {}
 # How many of CONTROL's calls passed a NON-NULL out-pointer (#2054). The LOGIN is delivered only
 # `if (a0 && ...)`, so a guest polling with nullptr consumes none and gets NO_EVENT forever with no
@@ -112,7 +122,35 @@ counts = {}
 control_eligible = 0
 values = {}                     # name -> {return value: count}
 order = []                      # leading calls, in call order
-state = {"ticks": 0, "calls": 0, "finish_failures": 0, "exited": False}
+state = {"ticks": 0, "calls": 0, "finish_failures": 0, "exited": False,
+         # Where each captured value came from, and whether the two sources ever disagreed.
+         # `rax` is not a degraded mode -- see _Finish.stop() -- but a reader is entitled to know
+         # which one answered, because only `dwarf` is independent of this tool's ABI assumption.
+         "src_dwarf": 0, "src_rax": 0, "src_mismatch": 0}
+# Distinct reasons a capture produced NO value at all, with counts. `finish-failures=N` on its own
+# cost this feature four days of being void with nobody able to say why (#2075): the header said how
+# many captures failed and nothing said what the failure WAS. One line of text is the whole fix.
+finish_failure_reasons = {}
+
+
+REASON_CAP = 32
+
+
+def _reason(kind, exc):
+    # gdb's messages carry the failing ADDRESS ("Cannot access memory at address 0x…"), which differs
+    # per call: left alone, every failure would be its own "distinct" reason and this table would grow
+    # once per call over a window of thousands. Fold the address out, and cap the table below.
+    return re.sub(r"0x[0-9a-fA-F]+", "0x<addr>", "%s: %s: %s" % (kind, type(exc).__name__, exc))[:200]
+
+
+def _note_reason(text):
+    if text in finish_failure_reasons:
+        finish_failure_reasons[text] += 1
+    elif len(finish_failure_reasons) < REASON_CAP:
+        finish_failure_reasons[text] = 1
+    else:
+        overflow = "(+reasons beyond the first %d distinct)" % REASON_CAP
+        finish_failure_reasons[overflow] = finish_failure_reasons.get(overflow, 0) + 1
 
 
 class _Finish(gdb.FinishBreakpoint):
@@ -124,11 +162,58 @@ class _Finish(gdb.FinishBreakpoint):
         self.silent = True
 
     def stop(self):
+        """Read the return value from TWO independent sources, because one of them is optional.
+
+        `gdb.FinishBreakpoint.return_value` is derived from the function's **DWARF return type**, so
+        it exists only on a build that carries debug info. prosper's default build type is `Release`
+        (`-O3 -DNDEBUG`, no `-g`, see prosper/CMakeLists.txt) -- on such a binary gdb has no type for
+        the handler, `return_value` is `None`, and `int(None)` raised once per call: that is #2075,
+        where `finish-failures` equalled the call count exactly and every row read `(captured 0/N)`.
+        Measured one-variable A/B on ONE binary (`objcopy --strip-debug` of a RelWithDebInfo
+        `boot_trace`, same gdb 17.2, same title, same window): with `.debug_*` present
+        `finish-failures=0` and the control reported `ok`; with it removed, 4 calls / 4 failures /
+        `VOID(0-returns-for-4-calls)`. The FinishBreakpoint itself constructed fine in both arms, so
+        the "gdb cannot unwind to the guest caller" hypothesis in #2075 is falsified, not fixed.
+
+        `%rax` needs no debug info and is exactly right for what this tool arms: the driver
+        enumerates only functions with the six-`unsigned long` HLE signature, and every one of those
+        is written through an `HLE(...)` macro that returns `uint64_t` -- an integer return, i.e.
+        `%rax` under SysV. The finish breakpoint stops at the return address in the caller, before
+        any instruction there has executed, so `%rax` still holds the value the handler returned.
+        `CONFIDENCE: HIGH` -- and it is checked rather than asserted: when both sources answer, a
+        disagreement is counted and reported, which is what would fire if a handler ever returned
+        something the ABI does not put in `%rax` (a struct, a float).
+
+        DWARF is preferred when present because it is ABI-aware for ANY return type, so a debug build
+        keeps behaving exactly as it did before this change.
+        """
+        why = []
+        dwarf = None
         try:
-            result = int(self.return_value) & 0xFFFFFFFFFFFFFFFF
-        except Exception:                       # no debug info for the return type
+            rv = self.return_value
+            if rv is None:
+                why.append("return_value: None (this binary has no DWARF return type for the "
+                           "handler -- a Release build; %rax below is the answer)")
+            else:
+                dwarf = int(rv) & RET_MASK
+        except Exception as exc:
+            why.append(_reason("return_value", exc))
+        rax = None
+        try:
+            rax = int(gdb.newest_frame().read_register("rax")) & RET_MASK
+        except Exception as exc:
+            why.append(_reason("rax", exc))
+
+        result = dwarf if dwarf is not None else rax
+        if result is None:
+            # Only now is the capture lost -- and the reader gets to see why, per distinct reason.
             state["finish_failures"] += 1
+            for text in why:
+                _note_reason(text)
             return False
+        if dwarf is not None and rax is not None and dwarf != rax:
+            state["src_mismatch"] += 1
+        state["src_dwarf" if dwarf is not None else "src_rax"] += 1
         values.setdefault(self.hle_name, {})
         values[self.hle_name][result] = values[self.hle_name].get(result, 0) + 1
         return False
@@ -168,7 +253,11 @@ class _Counter(gdb.Breakpoint):
         if VALUES:
             try:
                 _Finish(gdb.newest_frame(), self.hle_name)
-            except Exception:
+            except Exception as exc:
+                # The other half of #2075's diagnosis problem: this site and the decode site above
+                # increment ONE counter, so "finish-failures == calls" could not distinguish "never
+                # armed" from "armed and could not be decoded". Both now say which they were.
+                _note_reason(_reason("FinishBreakpoint()", exc))
                 state["finish_failures"] += 1
         return False
 
@@ -248,15 +337,37 @@ print("HLE_CALLS_BEGIN")
 # `run`/`continue` also return on a signal gdb stops for (SIGABRT is not in the pass list above,
 # and these titles do abort), which otherwise prints a truncated histogram that looks complete.
 control, control_note = _positive_control()
+# `value-source=` says which of the two reads answered (see _Finish.stop()). It is printed only with
+# --values, where it is never noise: `dwarf:0,rax:N` is the normal shape on prosper's default Release
+# build, and it is the field that would have named #2075's cause on sight.
+source = ""
+if VALUES:
+    source = " value-source=dwarf:%d,rax:%d" % (state["src_dwarf"], state["src_rax"])
 print("clock=%s entries=%d/%d window=%s positive-control=%s armed=%d mode=%s calls=%d "
-      "finish-failures=%d exited=%d"
+      "finish-failures=%d exited=%d%s"
       % (CLOCK, state["ticks"], TICKS, "complete" if state["ticks"] >= TICKS else "SHORT",
          control, armed, MODE, state["calls"], state["finish_failures"],
-         1 if state["exited"] else 0))
+         1 if state["exited"] else 0, source))
 # Only a verdict of `ok` needs no explanation. Every other state carries the one sentence that
 # says whether the run is usable, so the reader does not have to have the README open to know.
 if control_note:
     print("positive-control-note: " + control_note)
+# A failure count with no reason is what made #2075 a four-day investigation instead of a one-line
+# diagnosis. Distinct reasons, most frequent first, capped so a pathological run cannot flood.
+if finish_failure_reasons:
+    ranked = sorted(finish_failure_reasons.items(), key=lambda kv: -kv[1])
+    shown = ranked[:4]
+    line = "finish-failure-reasons: " + "; ".join("%dx %s" % (n, t) for t, n in shown)
+    if len(ranked) > len(shown):
+        line += "; +%d more distinct" % (len(ranked) - len(shown))
+    print(line)
+# The check on this tool's own ABI assumption: both sources read the same call, so they can only
+# disagree if the handler's real return does not live in %rax. Loud, because every %rax-sourced value
+# in the run would then be suspect -- including on builds where DWARF is absent and nothing can check.
+if state["src_mismatch"]:
+    print("value-source-MISMATCH: %d captures where the DWARF return value and %%rax disagreed. "
+          "Every rax-sourced value in this run is suspect: a handler whose return does not live in "
+          "%%rax (a struct or float return) breaks this tool's ABI assumption." % state["src_mismatch"])
 if order:
     print("first-calls: " + "  ".join("%d:%s" % (n, name) for n, name in order))
 for count, name in rows:

--- a/prosper/tools/hle_calls/test_hle_calls_values.py
+++ b/prosper/tools/hle_calls/test_hle_calls_values.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""End-to-end regression for `hle_calls --values`: it must capture returns with NO debug info (#2075).
+
+Why this one is end-to-end when its sibling `test_hle_calls.py` is pure
+------------------------------------------------------------------------
+#2075 was not a logic bug. Every value capture failed on current master because
+`gdb.FinishBreakpoint.return_value` is derived from the function's **DWARF return type**, and
+prosper's default build type is `Release` (`-O3 -DNDEBUG`, no `-g`) -- so gdb had no type, the
+attribute was `None`, and `int(None)` raised once per call. `finish-failures` then equalled the call
+count exactly and every row read `(captured 0/N)`.
+
+Nothing short of a real gdb driving a real process over real symbols can reproduce that: the
+defect lives in the interaction between gdb, the ELF's debug sections, and this tool's decode. A
+recorded-output test would have been green throughout the four days the feature was void.
+
+So this test compiles `test_values_fixture.cpp` **twice** -- once with `-g0` (the exact #2075
+condition) and once with `-g` -- and runs the real driver over each. The two arms are what make the
+result more than self-agreement: the debug arm's values come from gdb's own ABI-aware decode, the
+stripped arm's from this tool's `%rax` read, and the test asserts they produce the SAME histogram.
+
+The price is a dependency on gdb, a C++ compiler, `nm` and `c++filt`. A missing one exits **77**,
+which CMake registers as `SKIP_RETURN_CODE`, so ctest reports the run as `(Skipped)` by name rather
+than as a pass. That distinction matters here more than usual: this repository already carries a
+test (`stack_profile_logic`) written to avoid gdb precisely because a silently skipped test reads
+exactly like a passing one. This one cannot avoid gdb, so it says so out loud instead.
+"""
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DRIVER = os.path.join(HERE, "hle_calls.py")
+FIXTURE = os.path.join(HERE, "test_values_fixture.cpp")
+SKIP = 77
+
+CONTROL = "s_user_getevent"
+LOGIN = 0x0
+NO_EVENT = 0x80960007
+WIDE = "s_fixture_wide"
+WIDE_VALUE = 0xDEADBEEF12345678
+
+fails = 0
+
+
+def check(cond, label):
+    global fails
+    if cond:
+        print("  [ok]   %s" % label)
+    else:
+        print("  [FAIL] %s" % label)
+        fails += 1
+
+
+def skip(reason):
+    print("== test_hle_calls_values: SKIPPED ==")
+    print("   %s" % reason)
+    print("   This test needs a real gdb (with Python), a C++ compiler, nm and c++filt on Linux.")
+    print("   It is the only guard on the #2075 class -- a value capture that silently records")
+    print("   nothing -- so a skip here leaves that class UNCHECKED on this machine.")
+    sys.exit(SKIP)
+
+
+def find_compiler():
+    for name in (os.environ.get("CXX"), "g++", "c++", "clang++"):
+        if name and shutil.which(name):
+            return shutil.which(name)
+    return None
+
+
+def gdb_can_launch(gdb):
+    """Can this gdb actually start an inferior here? Containers and hardened kernels say no.
+
+    Asked explicitly rather than inferred from a failed run, so an environment that forbids ptrace
+    is reported as a skip instead of as a regression in the tool.
+    """
+    try:
+        probe = subprocess.run([gdb, "-batch", "-ex", "python print('py-ok')", "-ex", "run",
+                                "--args", "/bin/true"],
+                               capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "gdb could not be executed: %s" % exc
+    if "py-ok" not in probe.stdout:
+        return "this gdb has no Python support (the tool is a gdb Python script)"
+    blocked = ("ptrace", "Operation not permitted", "not permitted")
+    if probe.returncode != 0 and any(b in (probe.stderr + probe.stdout) for b in blocked):
+        return "this gdb cannot start an inferior here: %s" % probe.stderr.strip()[:200]
+    return None
+
+
+def compile_fixture(cxx, out, debug):
+    cmd = [cxx, "-O0", "-g" if debug else "-g0", "-o", out, FIXTURE]
+    done = subprocess.run(cmd, capture_output=True, text=True)
+    if done.returncode != 0:
+        print("  [FAIL] could not compile the fixture (%s):\n%s" % (" ".join(cmd), done.stderr))
+        return False
+    return True
+
+
+def run_arm(binary, ticks=12):
+    """Run the real driver over one fixture build; return (header_fields, rows, raw)."""
+    cmd = [sys.executable, DRIVER, "--ticks", str(ticks), "--values", "--order", "8",
+           "--filter", "^s_", "--timeout", "180", "--launch", binary]
+    done = subprocess.run(cmd, capture_output=True, text=True)
+    raw = done.stdout + done.stderr
+    fields, rows = {}, {}
+    for line in done.stdout.splitlines():
+        if line.startswith("clock="):
+            for token in line.split():
+                if "=" in token:
+                    key, _, value = token.partition("=")
+                    fields[key] = value
+        m = re.match(r"\s*(\d+)\s+(\S+)(.*)$", line)
+        if m and not line.startswith("clock="):
+            name, tail = m.group(2), m.group(3)
+            seen = {}
+            for value, count in re.findall(r"(0x[0-9a-f]+) x(\d+)", tail):
+                seen[int(value, 16)] = int(count)
+            rows[name] = {"calls": int(m.group(1)), "values": seen, "tail": tail}
+    return fields, rows, raw
+
+
+def check_arm(label, fields, rows, raw, expect_source):
+    if not fields:
+        check(False, "%s: the driver produced a result block\n%s" % (label, raw[-2000:]))
+        return
+    check(fields.get("window") == "complete" and fields.get("exited") == "0",
+          "%s: the window closed on the clock, not on an exit (window=%s exited=%s)"
+          % (label, fields.get("window"), fields.get("exited")))
+    # THE regression. On master this reads finish-failures=<calls>, and every row (captured 0/N).
+    check(fields.get("finish-failures") == "0",
+          "%s: no capture failed (finish-failures=%s of calls=%s)"
+          % (label, fields.get("finish-failures"), fields.get("calls")))
+    check("(captured " not in raw,
+          "%s: every call's return was recorded (no `(captured N/M)` row)" % label)
+    check(fields.get("positive-control") == "ok",
+          "%s: the built-in positive control passed (positive-control=%s)"
+          % (label, fields.get("positive-control")))
+    check("value-source-MISMATCH" not in raw,
+          "%s: the DWARF value and %%rax never disagreed" % label)
+
+    # Which read answered. This is what separates the two arms, and it is the field that would have
+    # named #2075 on sight: `dwarf:0,rax:0` with a non-zero call count IS the bug.
+    source = fields.get("value-source", "")
+    m = re.fullmatch(r"dwarf:(\d+),rax:(\d+)", source)
+    check(bool(m), "%s: value-source is reported (%s)" % (label, source))
+    if m:
+        dwarf, rax = int(m.group(1)), int(m.group(2))
+        calls = int(fields.get("calls", "0"))
+        check(dwarf + rax == calls and calls > 0,
+              "%s: every one of the %d calls yielded a value (dwarf=%d rax=%d)"
+              % (label, calls, dwarf, rax))
+        if expect_source == "rax":
+            check(dwarf == 0 and rax > 0,
+                  "%s: with no debug info every value came from %%rax (dwarf=%d rax=%d)"
+                  % (label, dwarf, rax))
+        else:
+            check(rax == 0 and dwarf > 0,
+                  "%s: with debug info gdb's own decode answered (dwarf=%d rax=%d)"
+                  % (label, dwarf, rax))
+
+    control = rows.get(CONTROL, {"values": {}, "calls": 0})
+    check(control["values"].get(LOGIN, 0) == 1,
+          "%s: exactly one LOGIN captured for %s (%s)" % (label, CONTROL, control["values"]))
+    check(control["values"].get(NO_EVENT, 0) >= 1,
+          "%s: the later %s calls answered NO_EVENT (%s)" % (label, CONTROL, control["values"]))
+    check(sum(control["values"].values()) == control["calls"],
+          "%s: %s's captured values account for all %d of its calls"
+          % (label, CONTROL, control["calls"]))
+
+    # A 64-bit value no accident produces: it pins the register read and the mask together. A
+    # capture that truncated to 32 bits, or read the wrong register, cannot print this.
+    wide = rows.get(WIDE, {"values": {}})
+    check(list(wide["values"]) == [WIDE_VALUE],
+          "%s: %s's full 64-bit return survived (%s)"
+          % (label, WIDE, [hex(v) for v in wide["values"]]))
+
+
+def main():
+    print("== test_hle_calls_values ==")
+    if sys.platform != "linux":
+        skip("this platform is %s; hle_calls is Linux-only" % sys.platform)
+    for tool in ("nm", "c++filt"):
+        if not shutil.which(tool):
+            skip("%s is not on PATH (the driver enumerates handlers with it)" % tool)
+    gdb = os.environ.get("HLE_CALLS_TEST_GDB") or shutil.which("gdb")
+    if not gdb:
+        skip("gdb is not on PATH")
+    reason = gdb_can_launch(gdb)
+    if reason:
+        skip(reason)
+    cxx = find_compiler()
+    if not cxx:
+        skip("no C++ compiler found (set CXX)")
+
+    work = tempfile.mkdtemp(prefix="hle_calls_values_")
+    try:
+        # Arm A is the whole point: `-g0` is the shape of prosper's own default Release build, and
+        # the configuration on which every value capture failed.
+        arms = (("no-debug-info", os.path.join(work, "fixture_nodbg"), False, "rax"),
+                ("debug-info", os.path.join(work, "fixture_dbg"), True, "dwarf"))
+        for label, path, debug, expect in arms:
+            if not compile_fixture(cxx, path, debug):
+                global fails
+                fails += 1
+                continue
+            fields, rows, raw = run_arm(path)
+            check_arm(label, fields, rows, raw, expect)
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    print("== FAILURES: %d ==" % fails if fails else "== all checks passed ==")
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/hle_calls/test_values_fixture.cpp
+++ b/prosper/tools/hle_calls/test_values_fixture.cpp
@@ -1,0 +1,86 @@
+// Fixture for test_hle_calls_values.py -- a stand-in guest+emulator for `hle_calls --values`.
+//
+// This is NOT part of prosper. It exists because #2075 could only be reproduced end-to-end: the
+// failure was that gdb's `FinishBreakpoint.return_value` is `None` on a binary with no DWARF, so
+// every value capture raised and the feature recorded nothing. No recorded-output test can see
+// that -- it needs a real gdb, driving a real process, over real symbols.
+//
+// What it has to reproduce from the emulator, and why each part matters:
+//
+//   * functions in namespace `prosper` with the six-`unsigned long` signature, because that is
+//     exactly what the driver's `nm`+`c++filt` enumeration keys on;
+//   * `static` linkage, as the real `HLE(name)` macro emits (nm reports them as 't', not 'T');
+//   * `prosper::k_usleep`, the default `--clock` symbol whose entries bound the window;
+//   * `s_user_getevent`'s once-per-process LOGIN contract, including the `a0 &&` gate, because the
+//     tool's built-in positive control and its `control_eligible` count both read it.
+//
+// Build it BOTH with and without `-g`: the no-debug-info build is the #2075 condition, and the
+// debug build is what proves the two value sources agree rather than one merely being plausible.
+
+#include <cstdint>
+#include <unistd.h>
+
+namespace prosper {
+
+// The same shape as src/hle/*.cpp's `HLE(name)` macro: static, six uint64_t, returns uint64_t.
+#define FIXTURE_HLE(name)                                                        \
+    static uint64_t name(uint64_t a0, uint64_t a1, uint64_t a2, uint64_t a3,     \
+                         uint64_t a4, uint64_t a5)
+
+// Mirrors hle_service.cpp's s_user_getevent closely enough for the tool's control to apply: the
+// initial LOGIN (return 0) is delivered at most once per PROCESS and only when the guest passed a
+// non-null out-pointer; every other call answers SCE_USER_SERVICE_ERROR_NO_EVENT.
+FIXTURE_HLE(s_user_getevent) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    static int delivered = 0;
+    if (a0 && !delivered) {
+        delivered = 1;
+        return 0;
+    }
+    return 0x80960007ull;
+}
+
+// A value no accident produces, and one that needs all 64 bits: it pins both the capture and the
+// mask. A tool that truncated to 32 bits, or read the wrong register, cannot print this.
+FIXTURE_HLE(s_fixture_wide) {
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0xDEADBEEF12345678ull;
+}
+
+// A plain success, so the histogram has a row whose value is the one this codebase returns most.
+FIXTURE_HLE(s_fixture_ok) {
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0;
+}
+
+// The clock. Deliberately NOT `s_`-prefixed, so a `--filter '^s_'` run arms it as the window's
+// clock only and never as a handler -- exactly how the real k_usleep is used. External linkage so
+// the `break prosper::k_usleep` spec resolves from the symbol table alone, with or without DWARF.
+void k_usleep() {
+    usleep(2000);
+}
+
+}  // namespace prosper
+
+using hle_fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+
+// Through volatile pointers so the calls survive any optimisation level: the test builds this at
+// -O0, but a fixture that can be inlined away would fail in a way that looks like a tool bug.
+static hle_fn volatile table[3] = {
+    &prosper::s_user_getevent,
+    &prosper::s_fixture_wide,
+    &prosper::s_fixture_ok,
+};
+static volatile uint64_t sink;
+
+int main() {
+    // Runs until the window closes and hle_calls kills it. A fixture that exited first would end
+    // the window early (`window=SHORT exited=1`) and the test would be asserting on a truncated run.
+    for (;;) {
+        uint64_t event = 0;
+        sink = table[0]((uint64_t)&event, 0, 0, 0, 0, 0);   // non-null a0: LOGIN-eligible
+        sink = table[1](0, 0, 0, 0, 0, 0);
+        sink = table[2](0, 0, 0, 0, 0, 0);
+        prosper::k_usleep();
+    }
+}


### PR DESCRIPTION
Fixes #2075.

## The failure

`tools/hle_calls/hle_calls.py --values` recorded **no return value at all**: `finish-failures`
equalled the total call count and every row printed `(captured 0/N)`. The only instrument prosper
has for the "registered-but-mismodelled return value" class was therefore unusable — the class named
as the residue of #1905's init audit.

## The mechanism — and what it is *not*

The issue's hypothesis was that `gdb.FinishBreakpoint(frame)` could not be constructed because a
handler is entered from **guest** code, which carries no CFI for gdb to unwind to. That is
**falsified**. Instrumenting both increment sites separately (the two share one counter, which is
why the count alone could not tell them apart):

```
probe      4  ctor-ok
probe      4  frame:prosper::s_user_getevent(unsigned long, ... )
probe      4  older:None
probe      4  ret:TypeError("int() argument must be a string, a bytes-like object or a real
                             number, not 'NoneType'")
```

The construction succeeds every time. `Frame.older()` really is `None` — the absent guest caller
frame is real — and it is harmless. The failure is in the **decode**: gdb derives
`FinishBreakpoint.return_value` from the function's **DWARF return type**, and there was none,
because prosper's default `CMAKE_BUILD_TYPE` is `Release` (`-O3 -DNDEBUG`, no `-g`, see
`prosper/CMakeLists.txt`). `return_value` was `None`, and `int(None)` raised once per call — exactly
`finish-failures == calls`.

**One-variable A/B, on one binary.** A RelWithDebInfo `boot_trace`, copied, and the copy passed
through `objcopy --strip-debug` (symbol table intact, so the `nm` enumeration is unchanged). Same
gdb 17.2, same title, same window, same command:

| binary | result |
|---|---|
| `.debug_*` present | `calls=3 finish-failures=0`, `ret 0x80960007 x2, 0x0 x1`, `positive-control=ok` |
| `.debug_*` removed | `calls=4 finish-failures=4`, `ret (none captured)`, `positive-control=VOID(0-returns-for-4-calls)` |

The second row is the issue's report, token for token. gdb 17.2 is innocent; so is the missing
caller frame. Both falsifications are recorded in `tools/hle_calls/README.md` § Ruled out and in
`docs/GRIS_SONIC_COBRA_BRINGUP.md`, whose bullet had recorded the census as void "on this machine
with gdb 17.2".

## The fix

`_Finish.stop()` now reads the return value from **two** independent sources:

- **DWARF** (`FinishBreakpoint.return_value`) — preferred when present, because it is ABI-aware for
  any return type, so a debug build behaves exactly as before;
- **`%rax`** — the SysV integer return register, read at the return address before the caller has
  executed an instruction. Needs no debug info, and is exact for what this tool arms: the driver
  enumerates only the six-`unsigned long` HLE signature, and every such handler is written through
  an `HLE(...)` macro that returns `uint64_t`. `CONFIDENCE: HIGH`.

The ABI assumption is **checked, not asserted**: when both sources answer they must agree, and a
disagreement prints a loud `value-source-MISMATCH:` line. That is what would fire if a handler ever
returned something the ABI does not put in `%rax`.

Two diagnosis fixes ride along, both of which would have turned this into a one-line finding:

- `finish-failure-reasons:` — every failure now names itself (`4x return_value: TypeError: …`).
  A bare count is what let this stay undiagnosed.
- `value-source=dwarf:N,rax:M` in the header — `dwarf:0` is the normal shape on a Release build,
  and `dwarf:0,rax:0` with a non-zero call count **is** the bug, on sight.

## Known-answer reproduction

The issue states the expected output, derived from `src/hle/hle_service.cpp` (the LOGIN event is a
once-per-process `static`), before any run. The issue's own repro command, on **current master's
default build** (`Release`, no debug info) with the Sonic Origins dump:

```
clock=prosper::k_usleep entries=40/40 window=complete positive-control=ok armed=1 mode=launch \
    calls=4 finish-failures=0 exited=0 value-source=dwarf:0,rax:4
first-calls: 1:s_user_getevent  2:s_user_getevent  3:s_user_getevent  4:s_user_getevent
       4  s_user_getevent   ret 0x80960007 x3, 0x0 x1
```

`ret 0x0 x1, 0x80960007 x3`, `positive-control=ok` — the predicted answer, computed outside the
tool. A wider arm on the same build (`--ticks 60 --filter '^s_'`, the issue's arm 1, which reported
20 calls / 20 failures) now returns a complete census: `calls=28 finish-failures=0`,
`value-source=dwarf:0,rax:28`, 11 distinct handlers, every row with values, `positive-control=ok`,
and `first-calls` leading with init handlers rather than frame-loop pollers.

The debug-info build of the same binary answers identically with `value-source=dwarf:4,rax:0`, so
the two sources agree on live data as well as in the fixture.

## The regression test, and why this one is end-to-end

`test_hle_calls.py` (the verdict machine) is pure and stays pure. This defect is not reachable that
way: it lives in the interaction between gdb, the ELF's debug sections and this tool's decode, and a
recorded-output test would have been green throughout. So `hle_calls_value_capture` compiles
`tools/hle_calls/test_values_fixture.cpp` **twice** — `-g0` (the exact defect condition) and `-g` —
and runs the real driver over each. The fixture reproduces what the enumeration keys on: namespace
`prosper`, the six-`unsigned long` signature, `static` linkage, a `prosper::k_usleep` clock, and
`s_user_getevent`'s once-per-process LOGIN including its `a0 &&` gate. `s_fixture_wide` returns
`0xDEADBEEF12345678`, which pins the register read and the 64-bit mask together.

It needs a real gdb, so a missing gdb/compiler exits **77** and CMake registers
`SKIP_RETURN_CODE 77`: ctest then reports it as `(Skipped)` **by name**. This repository already
carries a test written to avoid gdb for exactly this reason (`stack_profile_logic`, whose comment
says a silently skipped test is indistinguishable from a passing one) — this one cannot avoid gdb,
so it says so out loud instead.

**Mutation arm.** With only the `%rax` fallback removed (`rax = None`) and everything else intact:

```
  [FAIL] no-debug-info: no capture failed (finish-failures=36 of calls=36)
  [FAIL] no-debug-info: every call's return was recorded (no `(captured N/M)` row)
  [FAIL] no-debug-info: the built-in positive control passed (positive-control=VOID(0-returns-for-12-calls))
  [FAIL] no-debug-info: every one of the 36 calls yielded a value (dwarf=0 rax=0)
  [FAIL] no-debug-info: with no debug info every value came from %rax (dwarf=0 rax=0)
  [FAIL] no-debug-info: exactly one LOGIN captured for s_user_getevent ({})
  [FAIL] no-debug-info: s_fixture_wide's full 64-bit return survived ([])
== FAILURES: 9 ==   (exit 1)
```

The `debug-info` arm still passes there, which is the point: the test's discrimination is aimed at
the defect condition, and the two arms are what make the result more than self-agreement.

## Affected / deliberately unaffected

- Affected: `--values` only. On a build **with** debug info the recorded values are unchanged
  (`value-source=dwarf:N,rax:0`), so no historical value figure is invalidated by this change.
- Unaffected: the call-counting path, the window/clock logic, `--pid`/`--launch` modes, and the
  nine-state positive-control verdict machine (`hle_calls_control.py` is untouched).
- No emulator code is touched. The diff is the tool, its tests, its README, and one status-doc
  bullet that recorded the wrong cause.

## Risks

- `%rax` is right by the ABI for everything this tool arms; a handler with a non-integer return
  would break it, which is why the mismatch check exists and why it is loud. It can only be checked
  on a debug build — stated in the README's limits list rather than left implicit.
- Reading a register inside `FinishBreakpoint.stop()` assumes the selected thread is the one that
  stopped, the same assumption the existing `$rdi` eligibility read already makes.
- The new test depends on gdb + a C++ compiler. It skips visibly rather than failing where they are
  absent; a skip means the #2075 class is unchecked on that machine, and the skip message says so.

## Commands and results

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**Result: `100% tests passed out of 247`, ctest exit 0** (build exit 0), on
`a08984ca`. The two tool tests in that run:

```
  4/247 Test   #7: hle_calls_positive_control .....................   Passed    0.01 sec
 14/247 Test   #8: hle_calls_value_capture ........................   Passed    0.82 sec
```

Docs gate: `check_numbered_table.py --sequential --table-header Instrument` on
`GAME_COMPAT_ORCHESTRATION.md` (14 tables, 243 rows) and over every tracked `.md`, both clean.
`git diff --check` clean.

Live arms (Linux, gdb 17.2 on Fedora 44, inside the project's build container):

```bash
PROSPER_NO_COMPUTE=1 python3 prosper/tools/hle_calls/hle_calls.py \
    --ticks 40 --values --order 6 --filter s_user_getevent \
    --inferior-log ~/hlecalls-boot.log \
    --launch prosper/build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
```
