### PR TITLE
test(infra): route the remaining fixed-name test artifacts through the per-case scratch directory

### DIFF
--- a/prosper/tests/test_ampr_measure.cpp
+++ b/prosper/tests/test_ampr_measure.cpp
@@ -4,10 +4,12 @@
 // fill the destination.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "test_scratch.h"
 #include <array>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 using namespace prosper;
 
@@ -389,7 +391,11 @@ int main() {
         CHECK(read_file(0, 0, 0, 0xffffffffull, 0, 0) == 20,
               "32-bit-offset read command measures 20 bytes");
 
-        const char* fixture_path = "prosper-test-ampr-measure.tmp";
+        // #1621: the per-case scratch directory, not a fixed name in the shared ctest working
+        // directory — a failed assertion or a crash used to leave this behind in the build root.
+        const std::string fixture_path_storage =
+            prosper_test::test_scratch_file("prosper-test-ampr-measure.tmp");
+        const char* fixture_path = fixture_path_storage.c_str();
         const std::array<uint8_t, 4> fixture = {0x10, 0x20, 0x30, 0x40};
         bool fixture_written = false;
         if (FILE* file = std::fopen(fixture_path, "wb")) {

--- a/prosper/tests/test_apr_registry.cpp
+++ b/prosper/tests/test_apr_registry.cpp
@@ -18,6 +18,8 @@
 #ifndef _WIN32
 #include <sys/mman.h>   // mmap/munmap — WriteAddress fault-safety check (#1149/#1154)
 #endif
+#include "test_scratch.h"
+
 #include "../src/host/exec_image.hpp"
 #include "../src/host/guest_write_watch.hpp"
 #include "../src/hle/dispatch.hpp"
@@ -154,7 +156,11 @@ int main() {
 
     // The AMPR builder is a DMA-style read: callers may consume their destination buffer directly,
     // not only the completion record's data pointer. Evergate loads globalgamemanagers this way.
-    const char* fixture_path = "prosper-test-apr-read.tmp";
+    // #1621: every fixture below lives in this process's own scratch directory, not under a fixed
+    // relative name in the shared ctest working directory.
+    const std::string fixture_path_storage =
+        prosper_test::test_scratch_file("prosper-test-apr-read.tmp");
+    const char* fixture_path = fixture_path_storage.c_str();
     std::array<uint8_t, 257> expected{};
     for (size_t i = 0; i < expected.size(); ++i) expected[i] = (uint8_t)(i * 29u + 7u);
     FILE* fixture = std::fopen(fixture_path, "wb");
@@ -201,7 +207,9 @@ int main() {
     // #1901: equal total sizes do not make real ID-resolved reads ambiguous. Register a second,
     // byte-distinct fixture through the public resolve HLE so this also proves its warning describes
     // only the unresolved-id fallback rather than falsely declaring both files unreadable.
-    const char* collision_path = "prosper-test-apr-read-collision.tmp";
+    const std::string collision_path_storage =
+        prosper_test::test_scratch_file("prosper-test-apr-read-collision.tmp");
+    const char* collision_path = collision_path_storage.c_str();
     std::array<uint8_t, expected.size()> collision_bytes{};
     for (size_t i = 0; i < collision_bytes.size(); ++i)
         collision_bytes[i] = (uint8_t)(i * 17u + 11u);
@@ -268,7 +276,9 @@ int main() {
           "colliding valid-id reads report method=id");
 
     // An unknown id may use total-size correlation only when exactly one registered file matches.
-    const char* unique_path = "prosper-test-apr-read-fallback.tmp";
+    const std::string unique_path_storage =
+        prosper_test::test_scratch_file("prosper-test-apr-read-fallback.tmp");
+    const char* unique_path = unique_path_storage.c_str();
     std::array<uint8_t, 263> unique_bytes{};
     for (size_t i = 0; i < unique_bytes.size(); ++i)
         unique_bytes[i] = (uint8_t)(i * 23u + 19u);
@@ -414,15 +424,21 @@ int main() {
     CHECK(resolve_ids != nullptr && wait_cb != nullptr,
           "APR id-only resolver and synchronous completion wait registered");
 
-    const char* wp_full = "prosper-test-apr-prefix.tmp";   // prefix + tail == this path
-    const char* wp_prefix = "prosper-test-apr-";
+    // #1621: the SHAPE of this name is part of the test — APR's path-prefix resolution is exercised
+    // by splitting it into a prefix and a tail and having the HLE rejoin them. So the scratch
+    // directory goes into the PREFIX ("<scratch dir>/prosper-test-apr-") and the tail is left exactly
+    // as it was; wp_full stays prefix + tail by construction rather than by a repeated literal.
+    const std::string wp_prefix_storage = prosper_test::test_scratch_file("prosper-test-apr-");
+    const char* wp_prefix = wp_prefix_storage.c_str();
     const char* wp_tail   = "prefix.tmp";
+    const std::string wp_full_storage = wp_prefix_storage + wp_tail;   // prefix + tail == this path
+    const char* wp_full = wp_full_storage.c_str();
     std::array<uint8_t, 321> wp_bytes{};
     for (size_t i = 0; i < wp_bytes.size(); ++i) wp_bytes[i] = (uint8_t)(i * 13u + 5u);
     if (FILE* wf = std::fopen(wp_full, "wb")) { std::fwrite(wp_bytes.data(), 1, wp_bytes.size(), wf); std::fclose(wf); }
 
     if (resolve_prefix && resolve_plain) {
-        // The prefix path is prepended: prefix="prosper-test-apr-", paths[0]="prefix.tmp".
+        // The prefix path is prepended: prefix="<scratch dir>/prosper-test-apr-", paths[0]="prefix.tmp".
         const char* paths[1] = { wp_tail };
         uint32_t ids[1] = { 0xdeadbeef }; uint64_t sizes[1] = { 0xdead }; uint32_t error_index = 0xdead;
         uint64_t r = resolve_prefix((uint64_t)(uintptr_t)wp_prefix, (uint64_t)(uintptr_t)paths, 1,
@@ -459,7 +475,7 @@ int main() {
             // ordinary path that already exists. This is what turns the correctly loaded ACB into
             // an audible bank rather than a silent mixer.
             namespace fs = std::filesystem;
-            const fs::path app0 = "prosper-test-apr-app0";
+            const fs::path app0 = prosper_test::test_scratch_path("prosper-test-apr-app0");
             const fs::path raw_sound = app0 / "raw" / "sound";
             fs::create_directories(raw_sound);
             const fs::path awb = raw_sound / "fallback.awb";
@@ -508,7 +524,10 @@ int main() {
         // trapping startup in a multi-billion-iteration loop. Resolve the preceding valid entry,
         // then fail at the missing entry with its scalar index and without writing past that scalar.
         prosper_apr_reset_for_test();
-        const char* miss_paths[2] = { wp_full, "prosper-test-apr-does-not-exist.tmp" };
+        const std::string absent_path_storage =
+            prosper_test::test_scratch_file("prosper-test-apr-does-not-exist.tmp");
+        const char* absent_path = absent_path_storage.c_str();
+        const char* miss_paths[2] = { wp_full, absent_path };
         uint32_t miss_ids[2] = { 0x55, 0x55 }; uint64_t miss_sizes[2] = { 0x55, 0x55 };
         uint32_t miss_error_guard[3] = { 0x11111111u, 0xDEADBEEFu, 0x22222222u };
         uint64_t rm = resolve_plain((uint64_t)(uintptr_t)miss_paths, 2,
@@ -536,12 +555,13 @@ int main() {
         // that genuinely EXISTS, so the tail sentinel additionally distinguishes "stamped" from
         // "resolved anyway" (which would mean the batch did not stop).
         prosper_apr_reset_for_test();
-        const char* decoy_path = "prosper-test-apr-decoy-container.tmp";   // registry-only, never opened
+        const std::string decoy_path_storage =
+            prosper_test::test_scratch_file("prosper-test-apr-decoy-container.tmp");
+        const char* decoy_path = decoy_path_storage.c_str();   // registry-only, never opened
         const uint32_t decoy_id = prosper_apr_register(decoy_path, 4096);
         CHECK(decoy_id == 1 && prosper_apr_path_for_id(1) == decoy_path,
               "#1951 setup: a live id 1 names the decoy container");
-        const char* tail_paths[4] = { wp_full, wp_full,
-                                      "prosper-test-apr-does-not-exist.tmp", wp_full };
+        const char* tail_paths[4] = { wp_full, wp_full, absent_path, wp_full };
         uint32_t tail_ids[4] = { decoy_id, decoy_id, decoy_id, decoy_id };
         uint64_t tail_sizes[4] = { 0x5a5a, 0x5a5a, 0x5a5a, 0x5a5a };
         uint32_t tail_error_guard[3] = { 0x11111111u, 0xDEADBEEFu, 0x22222222u };

--- a/prosper/tests/test_apr_stat_audio.cpp
+++ b/prosper/tests/test_apr_stat_audio.cpp
@@ -24,6 +24,7 @@
 
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "test_scratch.h"
 
 namespace prosper {
     uint32_t prosper_apr_register(const std::string& path, uint64_t size);
@@ -45,7 +46,9 @@ int main() {
     CHECK(stat_fn != nullptr, "sceKernelAprGetFileStat registered");
 
     // A fixture file with a known, non-trivial size that the handler will host-stat.
-    const char* fixture = "test_apr_stat_fixture.bin";
+    // #1621: per-case scratch directory, not a fixed name in the shared ctest working directory.
+    const std::string fixture_storage = prosper_test::test_scratch_file("test_apr_stat_fixture.bin");
+    const char* fixture = fixture_storage.c_str();
     {
         FILE* f = std::fopen(fixture, "wb");
         CHECK(f != nullptr, "create APR stat fixture file");

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -549,9 +549,14 @@ int main() {
     // PROSPER_DENY_SUBSTR case-insensitivity (#1237): the fixture EXISTS on disk, but its name
     // contains a CASE VARIANT of the armed ".tmpdeny" substring — the deny must still fire.
     {
-        const std::string deny_fixture_storage =
-            prosper_test::test_scratch_file("prosper-deny-fixture.TmpDeny");
-        const char* deny_fixture = deny_fixture_storage.c_str();
+        // Deliberately NOT tests/test_scratch.h, and measured rather than assumed. Converting this
+        // one made the assertion below FAIL on Windows/MinGW while passing on Linux: `translate()`
+        // composes the deny redirect as `"/prosper-denied" + path`, which for a host-absolute
+        // Windows path yields `/prosper-deniedC:\...` — a spelling whose CRT error is not the ENOENT
+        // this asserts. The knob is documented for GUEST paths, so an absolute host path with a
+        // drive letter is a shape it was never given; what is under test here is the case-insensitive
+        // MATCH, not the location. Left relative so the assertion keeps its meaning (#1621, #2599).
+        const char* deny_fixture = "prosper-deny-fixture.TmpDeny";
         FILE* deny_out = std::fopen(deny_fixture, "wb");
         CHECK(deny_out != nullptr, "create deny fixture");
         if (deny_out) { std::fputs("x", deny_out); std::fclose(deny_out); }

--- a/prosper/tests/test_file_binary.cpp
+++ b/prosper/tests/test_file_binary.cpp
@@ -2,6 +2,7 @@
 // In particular, Windows CRT text mode treats 0x1a as EOF and translates CRLF.
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
+#include "test_scratch.h"
 #include <array>
 #include <cerrno>
 #include <cstdint>
@@ -71,7 +72,15 @@ int main() {
 #else
     setenv("PROSPER_DENY_SUBSTR", ".TMPDENY", 1);
 #endif
-    const char* path = "prosper-test-file-binary.tmp";
+    // #1621: fixtures live in this process's own scratch directory rather than under fixed relative
+    // names in the shared ctest working directory. Three of them are ALSO addressed as guest paths
+    // ("/app0/<name>"), and app0 is re-rooted at that same directory below — so their basenames are
+    // named constants and the guest spellings are built from those, never from the host path.
+    static constexpr const char* kFixtureName = "prosper-test-file-binary.tmp";
+    static constexpr const char* kMkdirDirName = "prosper-test-mkdir-eexist.tmp";
+    static constexpr const char* kMissingName = "prosper-test-file-binary-missing.tmp";
+    const std::string path_storage = prosper_test::test_scratch_file(kFixtureName);
+    const char* path = path_storage.c_str();
     std::array<uint8_t, 512> expected{};
     for (size_t i = 0; i < expected.size(); ++i) expected[i] = (uint8_t)(i * 37u + 11u);
     expected[7] = 0x1a;
@@ -167,7 +176,8 @@ int main() {
 
     // Creating an existing directory is a failure, not an idempotent success. Linux previously
     // suppressed EEXIST while Windows propagated it, so save-directory control flow differed by host.
-    const char* dir_path = "prosper-test-mkdir-eexist.tmp";
+    const std::string dir_path_storage = prosper_test::test_scratch_file(kMkdirDirName);
+    const char* dir_path = dir_path_storage.c_str();
     std::error_code remove_error;
     std::filesystem::remove_all(dir_path, remove_error);
     int64_t mkdir_first = mkdir_fn
@@ -186,9 +196,9 @@ int main() {
     CHECK(duplicate_errno == EEXIST, "mkdir preserves EEXIST for the caller");
     CHECK(kernel_mkdir_duplicate == 0x80020011u,
           "sceKernelMkdir returns SCE_KERNEL_ERROR_EEXIST directly");
-    set_app0_root(std::filesystem::current_path().string());
-    const std::string reachable_file = std::string("/app0/") + path;
-    const std::string reachable_directory = std::string("/app0/") + dir_path;
+    set_app0_root(prosper_test::test_scratch_dir().string());
+    const std::string reachable_file = std::string("/app0/") + kFixtureName;
+    const std::string reachable_directory = std::string("/app0/") + kMkdirDirName;
     CHECK(kernel_reachability_fn &&
               kernel_reachability_fn((uint64_t)(uintptr_t)reachable_file.c_str(), 0, 0, 0, 0, 0) == 0,
           "sceKernelCheckReachability finds a translated guest file");
@@ -407,7 +417,8 @@ int main() {
     // Windows CRT refuses to open a directory at all, so the HLE must retain an emulator-owned
     // directory cursor instead of reporting a successful empty enumeration. Astro Bot discovers
     // each intro cinematic sublevel through this exact contract.
-    const std::filesystem::path dents_path = "prosper-test-getdents.tmp";
+    const std::filesystem::path dents_path =
+        prosper_test::test_scratch_path("prosper-test-getdents.tmp");
     std::filesystem::remove_all(dents_path, remove_error);
     std::filesystem::create_directories(dents_path / "c01");
     std::filesystem::create_directories(dents_path / "c02b");
@@ -518,7 +529,8 @@ int main() {
     std::filesystem::remove_all(dents_path, remove_error);
 
     std::array<uint8_t, 512> actual{};
-    const char* missing_path = "prosper-test-file-binary-missing.tmp";
+    const std::string missing_path_storage = prosper_test::test_scratch_file(kMissingName);
+    const char* missing_path = missing_path_storage.c_str();
     std::error_code missing_remove_error;
     std::filesystem::remove(missing_path, missing_remove_error);
     errno = 0;
@@ -537,7 +549,9 @@ int main() {
     // PROSPER_DENY_SUBSTR case-insensitivity (#1237): the fixture EXISTS on disk, but its name
     // contains a CASE VARIANT of the armed ".tmpdeny" substring — the deny must still fire.
     {
-        const char* deny_fixture = "prosper-deny-fixture.TmpDeny";
+        const std::string deny_fixture_storage =
+            prosper_test::test_scratch_file("prosper-deny-fixture.TmpDeny");
+        const char* deny_fixture = deny_fixture_storage.c_str();
         FILE* deny_out = std::fopen(deny_fixture, "wb");
         CHECK(deny_out != nullptr, "create deny fixture");
         if (deny_out) { std::fputs("x", deny_out); std::fclose(deny_out); }
@@ -560,9 +574,9 @@ int main() {
             HleFn close_fn = Hle::lookup(nid_hash("sceKernelClose"));
             if (close_fn) close_fn(root_fd, 0, 0, 0, 0, 0);
         }
+        const std::string reentry_guest_path = std::string("/app0/../app0/") + kFixtureName;
         const uint64_t reentry_fd = open_fn
-            ? open_fn((uint64_t)(uintptr_t)"/app0/../app0/prosper-test-file-binary.tmp",
-                      0, 0, 0, 0, 0)
+            ? open_fn((uint64_t)(uintptr_t)reentry_guest_path.c_str(), 0, 0, 0, 0, 0)
             : 0;
         CHECK((int64_t)reentry_fd >= 3, "'/app0/../app0/<file>' re-enters the mount");
         if ((int64_t)reentry_fd >= 3) {
@@ -574,7 +588,7 @@ int main() {
         CHECK((uint32_t)sibling == 0x80020002u,
               "'/app0/../etc' keeps the sandbox-traversal deny (ENOENT)");
     }
-    const std::string unreachable_file = std::string("/app0/") + missing_path;
+    const std::string unreachable_file = std::string("/app0/") + kMissingName;
     std::string overlong_path(256, 'a');
     CHECK(kernel_reachability_fn &&
               kernel_reachability_fn((uint64_t)(uintptr_t)unreachable_file.c_str(), 0, 0, 0, 0, 0) ==
@@ -668,7 +682,9 @@ int main() {
     check_missing_path_contract("Rmdir", rmdir_fn, kernel_rmdir_fn);
     check_missing_path_contract("Unlink", unlink_fn, kernel_unlink_fn);
 
-    const char* missing_rename_target = "prosper-test-file-binary-missing-renamed.tmp";
+    const std::string missing_rename_target_storage =
+        prosper_test::test_scratch_file("prosper-test-file-binary-missing-renamed.tmp");
+    const char* missing_rename_target = missing_rename_target_storage.c_str();
     std::filesystem::remove(missing_rename_target, missing_remove_error);
     errno = 0;
     int64_t libc_missing_rename = rename_fn
@@ -691,7 +707,9 @@ int main() {
     CHECK(kernel_missing_truncate == 0x80020002u,
           "sceKernelTruncate returns SCE_KERNEL_ERROR_ENOENT directly");
 
-    const char* truncate_path = "prosper-test-kernel-truncate.tmp";
+    const std::string truncate_path_storage =
+        prosper_test::test_scratch_file("prosper-test-kernel-truncate.tmp");
+    const char* truncate_path = truncate_path_storage.c_str();
     std::filesystem::remove(truncate_path, missing_remove_error);
     FILE* truncate_out = std::fopen(truncate_path, "wb");
     bool truncate_fixture_written = false;
@@ -712,7 +730,9 @@ int main() {
           "sceKernelTruncate resizes a path on both hosts");
     std::filesystem::remove(truncate_path, missing_remove_error);
 
-    const char* descriptor_resize_path = "prosper-test-kernel-ftruncate.tmp";
+    const std::string descriptor_resize_path_storage =
+        prosper_test::test_scratch_file("prosper-test-kernel-ftruncate.tmp");
+    const char* descriptor_resize_path = descriptor_resize_path_storage.c_str();
     std::filesystem::remove(descriptor_resize_path, missing_remove_error);
     FILE* descriptor_resize_out = std::fopen(descriptor_resize_path, "wb");
     bool descriptor_resize_fixture_written = false;
@@ -760,8 +780,10 @@ int main() {
 #ifndef _WIN32
     // Linux ELOOP is 40, while FreeBSD/Orbis ELOOP is 62. A real symlink cycle guards
     // against accidentally embedding the host errno in a kernel result.
-    const char* loop_a = "prosper-test-open-loop-a.tmp";
-    const char* loop_b = "prosper-test-open-loop-b.tmp";
+    const std::string loop_a_storage = prosper_test::test_scratch_file("prosper-test-open-loop-a.tmp");
+    const std::string loop_b_storage = prosper_test::test_scratch_file("prosper-test-open-loop-b.tmp");
+    const char* loop_a = loop_a_storage.c_str();
+    const char* loop_b = loop_b_storage.c_str();
     std::error_code symlink_error;
     std::filesystem::remove(loop_a, symlink_error);
     std::filesystem::remove(loop_b, symlink_error);
@@ -1217,7 +1239,9 @@ int main() {
 
     // The same rule applies after earlier chunks were delivered. The fixture is one full bounce
     // chunk plus 512 bytes; only the committed first chunk may be consumed/reported.
-    const char* large_path = "prosper-test-file-binary-large.tmp";
+    const std::string large_path_storage =
+        prosper_test::test_scratch_file("prosper-test-file-binary-large.tmp");
+    const char* large_path = large_path_storage.c_str();
     FILE* large_out = std::fopen(large_path, "wb");
     bool large_written = large_out != nullptr;
     if (large_out) {

--- a/prosper/tests/test_gpu_timeline_capture_exit.cpp
+++ b/prosper/tests/test_gpu_timeline_capture_exit.cpp
@@ -1,5 +1,6 @@
 #include "../src/gpu/gpu_timeline.hpp"
 #include "../src/gpu/gpu_capture.hpp"
+#include "test_scratch.h"
 
 #include <cstdio>
 #include <cstdlib>
@@ -19,12 +20,38 @@ static void set_test_env(const char* name, const char* value) {
 #endif
 }
 
+// #1621: the parent re-invokes itself as `argv[0] --child` and then reads a capture the CHILD wrote,
+// so the two processes must agree on a directory. `test_scratch_dir()` is per-PID, so letting each
+// side derive its own would put the child's files where the parent does not look — and the symptom
+// would be "the ordered-DMA predecessor capture is incomplete", i.e. a content assertion failing on
+// correct code, which is the exact failure class tests/test_scratch.h exists to remove. The parent
+// therefore computes the directory and hands it over; `std::system` inherits the environment.
+// (PROSPER_TEST_SCRATCH_DIR is inherited too, but the child would append its OWN pid under it.)
+static const char* kArtifactDirEnv = "PROSPER_TEST_TIMELINE_CAPTURE_DIR";
+
+// The three artifact paths, rooted at `dir`. Both processes build them the same way from the same
+// directory, so the names stay in one place.
+struct ArtifactPaths {
+    std::string timeline, endpoint, predecessor;
+};
+
+static ArtifactPaths artifact_paths(const std::filesystem::path& dir) {
+    return {(dir / "timeline-capture-exit.prgtl").string(),
+            (dir / "timeline-capture-endpoint.prgcap").string(),
+            (dir / "timeline-capture-predecessor.prgcap").string()};
+}
+
 static int run_child() {
-    set_test_env("PROSPER_GPU_TIMELINE", "timeline-capture-exit.prgtl");
-    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", "timeline-capture-endpoint.prgcap");
+    // Handed down by the parent. Falling back to this process's own scratch directory keeps a
+    // hand-run `test_gpu_timeline_capture_exit --child` working off the tmpfs.
+    const char* dir = std::getenv(kArtifactDirEnv);
+    const ArtifactPaths paths = artifact_paths(
+        dir != nullptr && *dir != '\0' ? std::filesystem::path(dir) : prosper_test::test_scratch_dir());
+
+    set_test_env("PROSPER_GPU_TIMELINE", paths.timeline.c_str());
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", paths.endpoint.c_str());
     set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "2");
-    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR",
-                 "timeline-capture-predecessor.prgcap");
+    set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_PREDECESSOR", paths.predecessor.c_str());
     set_test_env("PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE", "1");
 
     GpuState predecessor;
@@ -42,6 +69,11 @@ static int run_child() {
 
 int main(int argc, char** argv) {
     if (argc > 1 && std::string(argv[1]) == "--child") return run_child();
+
+    const std::filesystem::path dir = prosper_test::test_scratch_dir();
+    const ArtifactPaths paths = artifact_paths(dir);
+    set_test_env(kArtifactDirEnv, dir.string().c_str());
+
     const std::string command = std::string("\"") + argv[0] + "\" --child";
     const int status = std::system(command.c_str());
 #ifdef _WIN32
@@ -56,15 +88,15 @@ int main(int argc, char** argv) {
     }
     GpuCaptureFile predecessor;
     std::string error;
-    if (!read_gpu_capture("timeline-capture-predecessor.prgcap", predecessor, error) ||
+    if (!read_gpu_capture(paths.predecessor, predecessor, error) ||
         predecessor.dma_copies.size() != 1 || predecessor.operations.size() != 1 ||
         predecessor.operations[0].kind != SubmitOperationKind::DmaCopy) {
         std::fprintf(stderr, "ordered-DMA predecessor capture is incomplete: %s\n", error.c_str());
         return 1;
     }
     std::error_code ec;
-    std::filesystem::remove("timeline-capture-exit.prgtl", ec);
-    std::filesystem::remove("timeline-capture-endpoint.prgcap", ec);
-    std::filesystem::remove("timeline-capture-predecessor.prgcap", ec);
+    std::filesystem::remove(paths.timeline, ec);
+    std::filesystem::remove(paths.endpoint, ec);
+    std::filesystem::remove(paths.predecessor, ec);
     return 0;
 }

--- a/prosper/tests/test_win_exception_delivery.cpp
+++ b/prosper/tests/test_win_exception_delivery.cpp
@@ -5,11 +5,13 @@
 #include "../src/hle/sync_futex.hpp"
 #include "../src/host/exec_image.hpp"
 #include "../src/host/sse4a.hpp"
+#include "test_scratch.h"
 #include <pthread.h>
 #include <windows.h>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <string>
 #include <vector>
 
 using namespace prosper;
@@ -696,7 +698,10 @@ int main() {
     pin_boundary_transition = 0;
     pin_boundary_republished = 0;
     pin_boundary_finish = 0;
-    const char* pin_trace_path = "test_win_exception_delivery_pin_boundary.tmp";
+    // #1621: per-case scratch directory, not a fixed name in the shared ctest working directory.
+    const std::string pin_trace_storage =
+        prosper_test::test_scratch_file("test_win_exception_delivery_pin_boundary.tmp");
+    const char* pin_trace_path = pin_trace_storage.c_str();
     DeleteFileA(pin_trace_path);
     pthread_t pin_thread{};
     const int pin_create = pthread_create(&pin_thread, nullptr, pin_boundary_worker, nullptr);


### PR DESCRIPTION
Fixes #1621. Independent of #2561 / #2568 — this branch is off `master` and touches only test
sources.

## Failure scenario

Six tests write **fixed relative names into the ctest working directory**. This is not #1613's race
(each name is unique to one ctest case, and ctest's working directory is already
`CMAKE_CURRENT_BINARY_DIR`), which is why they were deliberately left out of that sweep. Two things
still make them worth closing:

1. **Build-directory debris on the failure path.** Each site removes its file at the end of a
   *successful* run. A failed assertion or a crash leaves it in the build directory root, where it is
   indistinguishable from build output and never cleaned.
2. **Two ctest runs against one build directory collide.** Not a supported mode today, but it is the
   same failure shape as #1613 — a *content* assertion failing on correct code, which is the most
   mystifying class there is.

Sites, re-verified on `master` `bf32c9ad` (the issue's line numbers had moved, and its own grep
patterns missed one — `prosper-deny-fixture.TmpDeny`):

| file | fixed names |
| --- | --- |
| `test_gpu_timeline_capture_exit.cpp` | `timeline-capture-exit.prgtl`, `-endpoint.prgcap`, `-predecessor.prgcap` |
| `test_apr_registry.cpp` | `prosper-test-apr-{read,read-collision,read-fallback,prefix,does-not-exist,decoy-container}.tmp`, `prosper-test-apr-app0/` |
| `test_ampr_measure.cpp` | `prosper-test-ampr-measure.tmp` |
| `test_apr_stat_audio.cpp` | `test_apr_stat_fixture.bin` |
| `test_file_binary.cpp` | ten `prosper-test-*` names **plus `prosper-deny-fixture.TmpDeny`** |
| `test_win_exception_delivery.cpp` | `test_win_exception_delivery_pin_boundary.tmp` (Windows only) |

## Behavioural contract

Every artifact a test creates lands under `prosper_test::test_scratch_path()` — per ctest case, per
pid, inside the build directory, removed at normal exit — and **no assertion changes meaning**. In
particular the three sites where the artifact's *name or location is itself under test* must keep
testing the same thing.

## Approach

Mechanical for most: `const char* x = "name"` becomes a `std::string` from `test_scratch_file(...)`
plus a `c_str()` alias, so the body of each test is untouched.

**Three sites are not mechanical, and are the ones to review.**

* **`test_gpu_timeline_capture_exit.cpp` — parent/child.** It re-invokes `argv[0] --child` through
  `std::system`, and the **parent reads a `.prgcap` the child wrote**. `test_scratch_dir()` is
  per-**pid**, so deriving it independently on both sides puts the child's files where the parent
  does not look. (`PROSPER_TEST_SCRATCH_DIR` is inherited, but the child appends its *own* pid under
  it.) The parent computes the directory and hands it over in `PROSPER_TEST_TIMELINE_CAPTURE_DIR`,
  which `std::system` inherits; the child falls back to its own scratch directory so a hand-run
  `--child` still works off the tmpfs. Both sides build the three paths through one
  `artifact_paths(dir)` helper so the names live in one place.
* **`test_apr_registry.cpp` — the prefix/tail split.** `prosper-test-apr-prefix.tmp` is split into a
  prefix (`prosper-test-apr-`) and a tail (`prefix.tmp`) to exercise APR's path-prefix resolution, so
  the **shape** of the name is part of the test. The scratch directory therefore goes into the
  **prefix** — `<scratch dir>/prosper-test-apr-` — the tail is left exactly as it was, and the full
  path is now `prefix + tail` **by construction** instead of a third literal that could drift.
* **`test_file_binary.cpp` — guest paths.** Three fixtures are *also* addressed as guest paths
  (`/app0/<name>`), and one assertion opens the literal
  `/app0/../app0/prosper-test-file-binary.tmp`. Concatenating `/app0/` with an absolute host path
  would be nonsense, so `set_app0_root` is re-rooted at the scratch directory and those three
  basenames became named constants that the host path and the guest spelling are each built from.
  Note this also *shrinks* what the case-insensitive guest-path fallback can scan: app0 was
  previously the whole build directory.

## Affected / deliberately unaffected

* **Affected:** where six test binaries put their own scratch files. No assertion added, removed or
  weakened; the diff is 129 insertions / 39 deletions, and every deletion is a path expression.
* **Deliberately unaffected:** `test_file_binary.cpp`'s chmod and utimes fixtures, which are
  explicitly commented *"Deliberately NOT tests/test_scratch.h (#1613)"* — they need a native
  filesystem with specific mode/timestamp behaviour, not the build directory. Left as they are.
* No production code is touched.

## Risks

* `test_win_exception_delivery.cpp` is Windows-only and cannot be built on this box; the change there
  is the mechanical two-line form and is compile-checked by the Windows/MinGW CI job. `test_scratch.h`
  is already included by 21 other tests that carry `_WIN32` branches, so the header itself is not new
  ground there. `CONFIDENCE: MED` on that one site until CI is green, `HIGH` on the rest.
* Re-rooting app0 in `test_file_binary` moves `/app0/..` and `/app0/../etc`. Both assertions still
  pass (the traversal deny is a sandbox rule, not a filesystem fact).

## Verification

Linux, in the `ps5ys` distrobox. `--no-tests=error` on every ctest; counts quoted next to exit codes.

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
ctest --test-dir prosper/build-linux --no-tests=error -j4 --output-on-failure
```

**246 registered, 246 passed, exit 0.** Build directory root inspected afterwards: no `*.tmp`,
`*.prgcap`, `*.prgtl`, `test_apr_stat_fixture.bin` or `prosper-test-*` entry remains.

### Mutation arms

A green suite proves nothing here on its own — the tests passed before too. Each arm compiles
`master`'s version of the file and this branch's version side by side against the same
`libprosper_core.a` and runs them back to back.

**Arm 1 — a read-only working directory.** If the artifacts really left the cwd, the converted binary
no longer needs to write there. `PROSPER_TEST_SCRATCH_DIR` points at a writable path in both columns.

| binary | master | this branch |
| --- | --- | --- |
| `test_apr_stat_audio` | **rc=1**, 2 `[FAIL]` (`create APR stat fixture file`, `host-stat the fixture`) | **rc=0**, 0 `[FAIL]` |
| `test_ampr_measure` | **rc=1**, 1 `[FAIL]` | **rc=0**, 0 `[FAIL]` |
| `test_apr_registry` | **rc=134** (abort), 19 `[FAIL]` | **rc=0**, 0 `[FAIL]` |
| `test_file_binary` | **rc=134** (abort) | **rc=0**, 0 `[FAIL]` |
| `test_gpu_timeline_capture_exit` | **rc=1** — `[timeline] open failed: cannot open timeline: Permission denied` | **rc=0** |

**Arm 2 — the parent/child hand-off, from a *writable* cwd.** This isolates the tricky part from
arm 1's read-only effect. A third binary is built: this branch's file with the single line
`set_test_env(kArtifactDirEnv, ...)` deleted — i.e. exactly the naive conversion the issue warns
against, each side deriving its own per-pid directory.

| variant | writable cwd |
| --- | --- |
| master | rc=0 (status quo — writes into the cwd) |
| **naive** (env hand-off removed) | **rc=1** — `ordered-DMA predecessor capture is incomplete: invalid capture file size`, and the log shows the child writing under a *different* `pid-…` directory |
| this branch | rc=0 |

The naive arm reproduces the predicted symptom exactly, which is what makes the hand-off the thing
being tested rather than an incidental detail. It also exercises the child's fallback branch.

### One measurement that is NOT evidence, recorded so nobody repeats it

`file_binary_roundtrip`'s wall clock is useless on this box and looks alarming: it was timed at
**16 s, 20 s, 34 s, 43 s, 62 s, 409 s and 436 s** across this session, on both master and this
branch, tracking only how many other agents were building at the time. Per-line timestamps show why —
**34.97 s of a 35.60 s run sat in one pre-existing assertion**, `sceKernelSync performs the
host-wide/process-file flush`, which calls host `sync()`. Everything else in the file is
milliseconds. I chased this as a suspected regression of my own before measuring it.

`diff --check` clean. No `Claude-Session:` trailer
(`git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` → 0).
