### PR TITLE
feat(tools): hle_calls --out-bytes — see what a handler WROTE, not only what it returned (#2045 part 1)

### DIFF
--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -312,6 +312,12 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   **`--values`** additionally records each handler's RETURN value, which is what turns a census into
   evidence about *behaviour* rather than only traffic — the recurring bug shape here is a handler
   answering `SCE_OK` for work it never did, and a call count cannot see that.
+  **`--out-bytes N`** covers the half a return value cannot reach: it snapshots N bytes at whichever
+  of a0/a1 is a readable pointer, before the call and at its return, and reports what CHANGED. The
+  defect this codebase produces most is *success returned, out-struct never written* — every instance
+  returns `0`, so a value census is blind to all of them. Its counters keep "the handler wrote
+  nothing" (`same-zero`) apart from "this tool never read the bytes" (`null`/`small`/`unreadable`)
+  and from the one ambiguous case (`same-nonzero`: the bytes already held what would be written).
   **`--launch`** starts the process under gdb instead of attaching, so the window covers init: the
   handlers a title calls once, before anything could attach, are reachable only this way.
   Every `--values` run prints a `positive-control=` verdict on its own value capture — read it first,

--- a/prosper/tools/hle_calls/README.md
+++ b/prosper/tools/hle_calls/README.md
@@ -31,12 +31,17 @@ python3 tools/hle_calls/hle_calls.py --pid <pid> --filter '^s_'
 PROSPER_GUEST_ARGS=-force-gfx-direct \
 python3 tools/hle_calls/hle_calls.py --ticks 30 --values --filter '^s_' \
     --launch build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
+
+# ... and what each handler WROTE through its out-pointer, which a return value cannot say
+python3 tools/hle_calls/hle_calls.py --ticks 60 --values --out-bytes 16 --filter '^s_' \
+    --launch build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
 ```
 
 Flags: `--binary` (defaults to `/proc/<pid>/exe`, or the `--launch` program), `--ticks N` (window
 length), `--clock SYMBOL` (what advances the window, default `prosper::k_usleep` — one or more
 entries per frame on every title observed so far), `--filter REGEX`, `--order N`,
-`--inferior-log PATH` (`--launch` only — see below), `--gdb PATH`, `--timeout SECONDS`.
+`--out-bytes N` (sample the out-struct at a0/a1 — see below), `--inferior-log PATH` (`--launch`
+only — see below), `--gdb PATH`, `--timeout SECONDS`.
 
 Output:
 
@@ -173,8 +178,8 @@ Two independent reads answer "what did it return", and the header says which one
 Three limits before believing a number:
 
 - `--values` records the return **register**, never an out-struct. A handler that returns 0 while
-  writing wrong bytes through a pointer argument is invisible — and on this codebase that is a common
-  bug shape.
+  writing wrong bytes through a pointer argument is invisible to it — and on this codebase that is
+  the common bug shape, which is what [`--out-bytes`](#--out-bytes-what-the-handler-wrote) answers.
 - On a handler that longjmps back into its own caller, gdb's finish breakpoint sits at an address the
   landing pad reuses, so it can capture the *landing* value as if it were a return (measured on
   gdb 17.2). A `(captured N/M)` row's other values are therefore suspect, not merely fewer.
@@ -196,6 +201,62 @@ One behaviour change that also reaches `--pid`: the gdb side now passes SIGSEGV/
 straight through without stopping. prosper uses SIGSEGV as a working mechanism (write watches, the
 fault handler) and gdb's default is to stop, so an attach window previously truncated at the first
 guest fault.
+
+## `--out-bytes`: what the handler wrote
+
+A return value cannot see the defect this codebase produces most: **success returned, out-struct
+never written.** `sceSystemServiceGetStatus` aliased to the wrong handler,
+`sceSystemServiceGetDisplaySafeAreaInfo` leaving `ratio` at 0, `sceNpEntitlementAccessGetSkuFlag`
+unregistered with its out pointer untouched, `sceNpTrophy2GetTrophyInfoArray` handing back a garbage
+count that became a 34 GB allocation. Every one of them returns `0`; every one is invisible in a
+`--values` census. A 49-handler census that comes back with no implausible return value has bounded
+its candidate exactly as far as the return register reaches, and no further.
+
+`--out-bytes N` snapshots N bytes at whichever of a0/a1 is a readable pointer, **before the call and
+again at its return**, and reports what changed. Live on *Sonic Origins* (`PPSA05325`), `--out-bytes 16`:
+
+```
+       5  s_syss_getstatus   ret 0x0 x5
+            out a0[16] calls=5 read=5 changed=5 same-zero=0 same-nonzero=0 null=0 small=0 unreadable=0 lost=0
+              @2 70->00 @3 45->00 @6 07->01 @7 45->00 @10 70->00 @11 45->00  x4
+              @4 3f->00 @6 00->01 @7 80->00  x1
+```
+
+`src/hle/hle_service.cpp` says, before any run: `memset(st, 0, 12)` then `st[6] = 1`. The diff shows
+exactly that — byte 6 becomes 1, the other changed bytes are the memset clearing what was there, and
+**nothing at offsets 12–15 moved even though 16 bytes were sampled**, which re-derives the struct's
+width from the observation.
+
+### The five states, and why none of them collapse
+
+The counters are printed in full, zeros included, because the whole value of a before/after diff is
+that it can tell these apart:
+
+| counter | reading |
+|---|---|
+| `changed` | the handler wrote, and the diff shapes say what |
+| `same-zero` | the bytes were zero before and after: the unambiguous **nothing was written** |
+| `same-nonzero` | the bytes already held a value — a handler that wrote exactly that is indistinguishable from one that wrote nothing. The one state this method cannot resolve, and it is named rather than folded into `same-zero` |
+| `null` / `small` / `unreadable` | **nothing was read.** The argument was 0, or too small to be an address (a handle, a size), or pointed at memory gdb could not read. None of these is evidence about writing |
+| `lost` | sampled on entry, no second half (the frame left without returning, or the memory went away). Neither reading |
+
+A field that vanished when zero would let "nothing was read" pass for "nothing was written", which is
+the exact failure this tool exists to avoid. An argument that was NULL on *every* call gets one
+explicit line rather than silence.
+
+Its positive control is the same handler as `--values`', and derivable from the same source:
+`s_user_getevent` writes `{eventType=0, userId=1}` only on the call that delivers the LOGIN, so a
+`--launch` window must show `changed=1` for it, at `@4 …->01`, on the call that returned `0x0`. The
+run above does. In `--pid` mode, `changed=0` is the correct observation, for the same reason the
+value control shows no `0x0` there.
+
+**Scope: a0 and a1 only.** A handler whose out-pointer is a2 or later is not sampled, and no row
+claims otherwise — the absence of a line for such a handler means *this tool did not look*, never
+*the handler wrote nothing*. Widening it is a matter of adding registers to `OUT_ARGS`; the reason it
+is not already wide is cost, two reads per call per argument.
+
+Cost: two memory reads per call per argument, on top of `--values`' second trap. Pair it with
+`--filter`. Maximum width 256 bytes; a wider request is refused rather than clamped.
 
 ## Reading a zero — and the trap this tool was built around
 
@@ -237,6 +298,15 @@ Linux, `gdb` with Python support, `nm`/`c++filt`, and ptrace attach permitted
 (`kernel.yama.ptrace_scope=0`, `--pid` mode only — `--launch` runs its own child). The prosper
 binary must not be **stripped**: the driver enumerates handlers out of the symbol table with `nm`.
 Debug info is *not* required, including for `--values`.
+
+**The target must be non-PIE (`ET_EXEC`)**, which prosper's binaries are under the toolchains this
+project uses. Every breakpoint is armed at the raw link-time address `nm` reports; in a PIE those are
+offsets from a run-time load base, so each one lands in unmapped memory and gdb answers
+`Cannot insert breakpoint N / Cannot access memory at address 0x…` per handler. **The driver checks
+the ELF type and refuses with that explanation** rather than reporting a window that armed nothing.
+This is not hypothetical: Ubuntu's gcc defaults to `-pie` and Fedora's does not, so the same source
+builds differently on the two — measured when this tool's own test passed on Fedora and failed on a
+GitHub `ubuntu-24.04` runner. Rebuild with `-DCMAKE_EXE_LINKER_FLAGS=-no-pie`; the bias-aware fix is #2605.
 
 ## Cost
 

--- a/prosper/tools/hle_calls/hle_calls.py
+++ b/prosper/tools/hle_calls/hle_calls.py
@@ -115,14 +115,43 @@ carries no debug info, and that is precisely the configuration on which this
 feature used to record nothing at all (#2075). When both answer they must agree,
 and a disagreement prints a loud `value-source-MISMATCH:` line.
 
-Two limits to know before believing a number: `--values` records the return
-**register**, never an out-struct, so a handler that returns 0 while writing
-wrong bytes through a pointer is invisible; and on a handler that longjmps back
+One limit to know before believing a number: on a handler that longjmps back
 into its own caller, gdb's finish breakpoint can capture the *landing* value as
 if it were a return (measured on gdb 17.2), so a `(captured N/M)` row's other
 values are suspect rather than merely fewer.
 
 `--values` costs a second trap per call, so pair it with `--filter`.
+
+Out-structs — the half a return value cannot reach
+--------------------------------------------------
+`--values` records the return **register**. The recurring defect on this codebase
+is the one that register cannot see: *success returned, out-struct never
+written*. `sceSystemServiceGetStatus` aliased to the wrong handler,
+`sceSystemServiceGetDisplaySafeAreaInfo` leaving `ratio` at 0,
+`sceNpEntitlementAccessGetSkuFlag` unregistered with its out pointer untouched,
+`sceNpTrophy2GetTrophyInfoArray` handing back a garbage count — every one of them
+returns `0`, and every one is invisible in a value census.
+
+`--out-bytes N` snapshots N bytes at whichever of a0/a1 is a readable pointer,
+**before and after** each call, and reports what changed:
+
+    5  s_syss_getstatus   ret 0x0 x5
+            out a0[12] calls=5 read=5 changed=5 same-zero=0 same-nonzero=0 \\
+                null=0 small=0 unreadable=0 lost=0
+              @5 00->01 @6 00->01  x5
+
+The before/after form is what makes it self-validating, and every counter is
+printed including the zeros: `changed=0 same-zero=12` (the handler wrote nothing
+into a buffer that was zero) and `read=0 unreadable=12` (this tool never saw the
+bytes) are the two readings that must never be confused, and a field that
+disappeared when zero would let the second read as the first.
+
+`same-nonzero` is the one genuinely ambiguous state: the bytes already held a
+value, so a handler that wrote exactly that is indistinguishable from one that
+wrote nothing — a guest polling into a buffer it does not clear produces it.
+`lost` means the entry snapshot had no second half (the frame left without
+returning, or the memory went away): neither reading, and counted apart from
+both.
 
 The launched process's own output
 --------------------------------
@@ -156,6 +185,9 @@ import tempfile
 
 HLE_SIGNATURE = ("(unsigned long, unsigned long, unsigned long, "
                  "unsigned long, unsigned long, unsigned long)")
+# --out-bytes ceiling. Two reads of this width per call per argument, and the whole snapshot is held
+# per in-flight call; a struct worth inspecting here is tens of bytes, not kilobytes.
+OUT_BYTES_MAX = 256
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -199,6 +231,47 @@ def enumerate_handlers(binary, name_filter):
         seen.add(short)
         out.append((addr, short))
     return out
+
+
+def refuse_if_pie(binary):
+    """Stop with a reason on a position-independent executable, rather than letting gdb spew.
+
+    This tool arms breakpoints at the RAW addresses `nm` reports, which are link-time addresses. In a
+    non-PIE executable (`ET_EXEC`) they are the runtime addresses too, which is why this works at all
+    -- prosper's own binaries are `ET_EXEC` as built by the toolchains this project uses. Under a
+    toolchain that defaults to `-pie` (Ubuntu's gcc does; Fedora's does not) the same addresses are
+    offsets from a load base chosen at run time, so every breakpoint lands in unmapped memory:
+
+        Cannot insert breakpoint 3.
+        Cannot access memory at address 0x1149
+
+    gdb prints that per breakpoint and the run yields no result block -- loud, but three steps away
+    from naming its own cause. Measured on a GitHub `ubuntu-24.04` runner, where the same fixture
+    that passes here failed exactly this way.
+
+    Refusing rather than guessing a base is deliberate: in `--launch` mode the whole point is that
+    breakpoints are armed BEFORE the process exists, so there is no bias to read yet, and inferring
+    one from gdb's disabled-randomization default would produce a number that is right until it
+    silently is not. Making this work on a PIE build is a real feature (attach mode could read the
+    bias from `/proc/<pid>/maps`) and is tracked separately.
+    """
+    try:
+        with open(binary, "rb") as handle:
+            header = handle.read(18)
+    except OSError as exc:
+        sys.exit("hle_calls: cannot read %s: %s" % (binary, exc))
+    if len(header) < 18 or header[:4] != b"\x7fELF":
+        return                      # not an ELF; let the later steps produce their own message
+    little = header[5] == 1
+    e_type = int.from_bytes(header[16:18], "little" if little else "big")
+    if e_type == 3:                 # ET_DYN -- a PIE (or a shared object)
+        sys.exit(
+            "hle_calls: %s is a position-independent executable (ET_DYN), and this tool arms the "
+            "raw link-time addresses `nm` reports, so every breakpoint would land in unmapped "
+            "memory (gdb: 'Cannot insert breakpoint N / Cannot access memory at address 0x...'). "
+            "Build the target non-PIE -- e.g. cmake -DCMAKE_EXE_LINKER_FLAGS=-no-pie -- which is "
+            "what prosper's binaries already are under the toolchains this project uses. Refusing "
+            "here rather than reporting a window that armed nothing." % binary)
 
 
 def _prepare_inferior_log(path):
@@ -248,6 +321,12 @@ def main():
     ap.add_argument("--values", action="store_true",
                     help="also record each handler's return values (costs a second trap per "
                          "call — pair it with --filter)")
+    ap.add_argument("--out-bytes", type=int, default=0, metavar="N",
+                    help="also snapshot N bytes at whichever of a0/a1 is a readable pointer, "
+                         "before and after each call, and report what CHANGED. This is the half a "
+                         "return-value census cannot reach: the recurring bug shape here is "
+                         "'success returned, out-struct never written', which returns 0 every time. "
+                         "Costs two memory reads per call per argument — pair it with --filter.")
     ap.add_argument("--order", type=int, default=24,
                     help="how many leading calls to report in call order (default 24); this is "
                          "what shows whether the window covered init")
@@ -276,6 +355,11 @@ def main():
         sys.exit("hle_calls: pass exactly one of --pid <pid> or --launch <program> [args...]")
     # Refuse rather than silently ignore: in --pid mode the emulator is not this tool's child,
     # it already owns its stdout/stderr, and accepting the flag would imply we redirected them.
+    # A refusal rather than a clamp: a run that quietly sampled a different width than the one asked
+    # for would put an unfalsifiable number in front of a reader.
+    if args.out_bytes < 0 or args.out_bytes > OUT_BYTES_MAX:
+        sys.exit("hle_calls: --out-bytes must be between 0 (off) and %d; got %d"
+                 % (OUT_BYTES_MAX, args.out_bytes))
     if not args.launch and args.inferior_log is not None:
         sys.exit("hle_calls: --inferior-log applies to --launch only — a --pid target owns its "
                  "own output and this tool cannot redirect it")
@@ -286,6 +370,9 @@ def main():
         binary = args.binary or os.path.realpath("/proc/%d/exe" % args.pid)
     if not os.path.exists(binary):
         sys.exit("hle_calls: no such binary: %s" % binary)
+    # Before anything expensive: a PIE would arm hundreds of breakpoints at unmapped addresses and
+    # report a window that measured nothing. See refuse_if_pie().
+    refuse_if_pie(binary)
 
     handlers = enumerate_handlers(binary, args.filter)
     if not handlers:
@@ -311,6 +398,7 @@ def main():
     env["HLE_CALLS_MODE"] = "launch" if args.launch else "attach"
     env["HLE_CALLS_VALUES"] = "1" if args.values else "0"
     env["HLE_CALLS_ORDER"] = str(args.order)
+    env["HLE_CALLS_OUT_BYTES"] = str(args.out_bytes)
     script = os.path.join(HERE, "hle_calls_gdb.py")
     if args.launch:
         # `--args` must come last; the gdb script issues the `run` itself, after

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -10,6 +10,9 @@ environment so the driver can stay a plain subprocess call:
                       BEFORE the guest's entry point runs, so the window covers init
     HLE_CALLS_VALUES  "1" to record each handler's return values, not only its count
     HLE_CALLS_ORDER   how many leading calls to report in call order (default 24)
+    HLE_CALLS_OUT_BYTES  0 = off. Otherwise snapshot this many bytes at a0/a1 before
+                      and after each call, and report what CHANGED -- the half a
+                      return value cannot reach (#2045)
     HLE_CALLS_INFERIOR_TTY  launch mode only: where the INFERIOR's stdin/stdout/stderr
                       go. The driver holds gdb's own stdout on a pipe, and without this
                       the launched emulator's entire run log would inherit that pipe and
@@ -56,7 +59,9 @@ both are printed unconditionally:
 Two limits of `--values` worth knowing before believing a number:
 
   * It records the return **register**, never an out-struct. A handler that
-    returns 0 while writing wrong bytes through a pointer argument is invisible.
+    returns 0 while writing wrong bytes through a pointer argument is invisible
+    to it — that is what `--out-bytes` answers (see `_sample_out_args` below),
+    and it is a separate observation with its own five-state accounting.
   * On a handler that longjmps back into its own caller, gdb's finish breakpoint
     sits at an address the landing pad reuses, so it can capture the *landing*
     value as if it were a return. Measured on gdb 17.2. Non-returning paths are
@@ -102,6 +107,8 @@ TICKS = int(os.environ.get("HLE_CALLS_TICKS", "400"))
 MODE = os.environ.get("HLE_CALLS_MODE", "attach")
 VALUES = os.environ.get("HLE_CALLS_VALUES", "") == "1"
 ORDER_N = int(os.environ.get("HLE_CALLS_ORDER", "24"))
+# 0 = off. When non-zero, snapshot this many bytes at a0/a1 before and after every call (#2045).
+OUT_BYTES = int(os.environ.get("HLE_CALLS_OUT_BYTES", "0"))
 INFERIOR_TTY = os.environ.get("HLE_CALLS_INFERIOR_TTY", "")
 
 # The built-in control for the value-capture mechanism, and the two values it can answer.
@@ -153,15 +160,131 @@ def _note_reason(text):
         finish_failure_reasons[overflow] = finish_failure_reasons.get(overflow, 0) + 1
 
 
+# --- out-struct sampling (--out-bytes, #2045) ---------------------------------------------------
+# The recurring bug shape on this codebase is "success returned, out-struct never written":
+# sceSystemServiceGetStatus aliased to the wrong handler, sceSystemServiceGetDisplaySafeAreaInfo
+# leaving `ratio` 0, sceNpEntitlementAccessGetSkuFlag unregistered with the out pointer untouched,
+# sceNpTrophy2GetTrophyInfoArray handing back a garbage count. EVERY one of them returns 0, so a
+# return-value census cannot see any of them -- the bound a value census puts on a candidate reaches
+# exactly as far as the return register.
+#
+# So: snapshot N bytes at whichever of a0/a1 is a readable pointer, on entry and again at return,
+# and report the difference. The before/after form is what makes the result self-validating, which
+# is the property #2075 showed this tool otherwise lacked: "the handler wrote nothing" and "this
+# tool never looked" are DIFFERENT counters here, and both are printed.
+OUT_ARGS = (("a0", "rdi"), ("a1", "rsi"))       # SysV integer argument registers 0 and 1
+OUT_SHAPE_CAP = 32
+# A pointer is never in page 0. Anything below this is an ordinary small argument -- a handle, a
+# size, an enum -- and saying so is not the same statement as "the pointer could not be read".
+OUT_MIN_POINTER = 0x1000
+out_stats = {}                  # (handler, "a0"|"a1") -> counters + observed diff shapes
+
+
+def _out_stats(name, argname):
+    key = (name, argname)
+    if key not in out_stats:
+        out_stats[key] = {"calls": 0, "noreg": 0, "null": 0, "small": 0, "unreadable": 0,
+                          "read": 0, "changed": 0, "same_zero": 0, "same_nonzero": 0,
+                          "lost": 0, "shapes": {}}
+    return out_stats[key]
+
+
+def _out_shape(before, after):
+    """`@6 00->01` — the changed offsets only, which is what a reader compares against the source."""
+    diffs = [(i, before[i], after[i]) for i in range(len(before)) if before[i] != after[i]]
+    parts = ["@%d %02x->%02x" % d for d in diffs[:8]]
+    if len(diffs) > 8:
+        parts.append("+%d more bytes" % (len(diffs) - 8))
+    return " ".join(parts)
+
+
+def _sample_out_args(name):
+    """Entry half of the diff: returns [(stats, addr, before_bytes)] for each sampled argument."""
+    snaps = []
+    try:
+        frame = gdb.newest_frame()
+        inferior = gdb.selected_inferior()
+    except Exception:
+        return snaps
+    for argname, reg in OUT_ARGS:
+        st = _out_stats(name, argname)
+        st["calls"] += 1
+        try:
+            value = int(frame.read_register(reg)) & RET_MASK
+        except Exception:
+            st["noreg"] += 1
+            continue
+        if value == 0:
+            st["null"] += 1
+            continue
+        if value < OUT_MIN_POINTER:
+            st["small"] += 1
+            continue
+        try:
+            before = bytes(inferior.read_memory(value, OUT_BYTES))
+        except Exception:
+            # The distinction this whole feature turns on: nothing was READ here. It is NOT
+            # evidence that nothing was written.
+            st["unreadable"] += 1
+            continue
+        st["read"] += 1
+        snaps.append((st, value, before))
+    return snaps
+
+
 class _Finish(gdb.FinishBreakpoint):
-    """One-shot: record what the handler returned, then get out of the way."""
+    """One-shot: record what the handler returned and what it wrote, then get out of the way."""
 
     def __init__(self, frame, name):
         super().__init__(frame, internal=True)
         self.hle_name = name
         self.silent = True
+        self.out_snaps = []             # filled by _Counter.stop() right after construction
 
     def stop(self):
+        # Out-bytes first, and unconditionally: the return-value capture has a failure path that
+        # returns early, and an out-struct observation must not be lost to it.
+        self._capture_out_bytes()
+        if VALUES:
+            self._capture_return()
+        return False
+
+    def _capture_out_bytes(self):
+        try:
+            inferior = gdb.selected_inferior()
+        except Exception:
+            for st, _, _ in self.out_snaps:
+                st["lost"] += 1
+            return
+        for st, addr, before in self.out_snaps:
+            try:
+                after = bytes(inferior.read_memory(addr, len(before)))
+            except Exception:
+                # Readable on entry, unreadable now (the guest freed or unmapped it). Neither
+                # "wrote" nor "did not write" -- a third state, and it says so.
+                st["lost"] += 1
+                continue
+            if after != before:
+                st["changed"] += 1
+                shape = _out_shape(before, after)
+                if shape in st["shapes"] or len(st["shapes"]) < OUT_SHAPE_CAP:
+                    st["shapes"][shape] = st["shapes"].get(shape, 0) + 1
+                else:
+                    st["shapes"]["(+shapes beyond the first %d)" % OUT_SHAPE_CAP] = \
+                        st["shapes"].get("(+shapes beyond the first %d)" % OUT_SHAPE_CAP, 0) + 1
+            elif any(before):
+                # Ambiguous, and the ONE case this instrument cannot resolve: the bytes already held
+                # a value, so a handler that wrote exactly that is indistinguishable from one that
+                # wrote nothing. Kept apart from same-zero, where "nothing was written" is the far
+                # likelier reading.
+                st["same_nonzero"] += 1
+            else:
+                st["same_zero"] += 1
+        # Accounted for. Clearing them keeps a later out_of_scope() from counting the same samples
+        # a second time as lost.
+        self.out_snaps = []
+
+    def _capture_return(self):
         """Read the return value from TWO independent sources, because one of them is optional.
 
         `gdb.FinishBreakpoint.return_value` is derived from the function's **DWARF return type**, so
@@ -210,13 +333,12 @@ class _Finish(gdb.FinishBreakpoint):
             state["finish_failures"] += 1
             for text in why:
                 _note_reason(text)
-            return False
+            return
         if dwarf is not None and rax is not None and dwarf != rax:
             state["src_mismatch"] += 1
         state["src_dwarf" if dwarf is not None else "src_rax"] += 1
         values.setdefault(self.hle_name, {})
         values[self.hle_name][result] = values[self.hle_name].get(result, 0) + 1
-        return False
 
     def out_of_scope(self):
         # The handler's frame vanished without a normal return (longjmp, thread
@@ -224,7 +346,14 @@ class _Finish(gdb.FinishBreakpoint):
         # more than once per breakpoint on some versions, so it is not a reliable
         # counter. The per-row `captured N/M` below is what makes such a loss
         # visible, and it needs no cooperation from gdb at all.
-        pass
+        #
+        # An out-struct sample IS counted lost here, and for the opposite reason: nothing else can
+        # see it. `(captured N/M)` derives from the value histogram, so with `--values` off there is
+        # no other trace of a sample that never got its second half. gdb calling this twice would
+        # over-count `lost` -- an over-report of "this run could not tell", never of "it wrote".
+        for st, _, _ in self.out_snaps:
+            st["lost"] += 1
+        self.out_snaps = []
 
 
 class _Counter(gdb.Breakpoint):
@@ -250,15 +379,22 @@ class _Counter(gdb.Breakpoint):
                 pass
         if len(order) < ORDER_N:
             order.append((state["calls"], self.hle_name))
-        if VALUES:
+        # Sample BEFORE arming the finish breakpoint: the entry snapshot is a fact about this call
+        # whether or not the second half can be armed, and a dropped one is then counted as `lost`
+        # rather than silently vanishing.
+        snaps = _sample_out_args(self.hle_name) if OUT_BYTES else []
+        if VALUES or OUT_BYTES:
             try:
-                _Finish(gdb.newest_frame(), self.hle_name)
+                finish = _Finish(gdb.newest_frame(), self.hle_name)
+                finish.out_snaps = snaps
             except Exception as exc:
                 # The other half of #2075's diagnosis problem: this site and the decode site above
                 # increment ONE counter, so "finish-failures == calls" could not distinguish "never
                 # armed" from "armed and could not be decoded". Both now say which they were.
                 _note_reason(_reason("FinishBreakpoint()", exc))
                 state["finish_failures"] += 1
+                for st, _, _ in snaps:
+                    st["lost"] += 1
         return False
 
 
@@ -343,6 +479,8 @@ control, control_note = _positive_control()
 source = ""
 if VALUES:
     source = " value-source=dwarf:%d,rax:%d" % (state["src_dwarf"], state["src_rax"])
+if OUT_BYTES:
+    source += " out-bytes=%d" % OUT_BYTES
 print("clock=%s entries=%d/%d window=%s positive-control=%s armed=%d mode=%s calls=%d "
       "finish-failures=%d exited=%d%s"
       % (CLOCK, state["ticks"], TICKS, "complete" if state["ticks"] >= TICKS else "SHORT",
@@ -388,6 +526,30 @@ for count, name in rows:
         if captured != count:
             line += "   (captured %d/%d)" % (captured, count)
     print(line)
+    if OUT_BYTES:
+        # One line per sampled argument, then the diff shapes under it. Every counter is printed,
+        # including the zeros: "changed=0 same-zero=12" (the handler wrote nothing into a buffer
+        # that was zero) and "read=0 unreadable=12" (this tool never saw the bytes) are the two
+        # readings this feature exists to keep apart, and a field that vanishes when zero would
+        # make the second look like the first.
+        printed = False
+        for argname, _ in OUT_ARGS:
+            st = out_stats.get((name, argname))
+            if not st or (st["read"] + st["unreadable"] + st["small"] + st["noreg"]) == 0:
+                continue        # NULL on every call: reported by the fallback line below instead
+            printed = True
+            print("            out %s[%d] calls=%d read=%d changed=%d same-zero=%d same-nonzero=%d "
+                  "null=%d small=%d unreadable=%d lost=%d%s"
+                  % (argname, OUT_BYTES, st["calls"], st["read"], st["changed"], st["same_zero"],
+                     st["same_nonzero"], st["null"], st["small"], st["unreadable"], st["lost"],
+                     " noreg=%d" % st["noreg"] if st["noreg"] else ""))
+            ranked = sorted(st["shapes"].items(), key=lambda kv: -kv[1])
+            for shape, n in ranked[:3]:
+                print("              %s  x%d" % (shape, n))
+            if len(ranked) > 3:
+                print("              +%d more diff shapes" % (len(ranked) - 3))
+        if not printed and any((name, a) in out_stats for a, _ in OUT_ARGS):
+            print("            out: a0 and a1 were NULL on every call — nothing to sample")
 print("distinct=%d total=%d" % (len(rows), sum(c for c, _ in rows)))
 print("HLE_CALLS_END")
 

--- a/prosper/tools/hle_calls/test_hle_calls_values.py
+++ b/prosper/tools/hle_calls/test_hle_calls_values.py
@@ -90,36 +90,68 @@ def gdb_can_launch(gdb):
     return None
 
 
-def compile_fixture(cxx, out, debug):
-    cmd = [cxx, "-O0", "-g" if debug else "-g0", "-o", out, FIXTURE]
+def compile_fixture(cxx, out, debug, pie=False, optional=False):
+    """Build the fixture. `-no-pie` is load-bearing, not tidiness.
+
+    hle_calls arms breakpoints at the raw link-time addresses `nm` reports, so the target must be
+    `ET_EXEC` -- as prosper's own binaries are. Ubuntu's gcc defaults to `-pie` while Fedora's does
+    not, so a fixture built without this flag is a different program on the two, and the CI arm of
+    this very test failed that way (`Cannot access memory at address 0x1149`, no result block) while
+    passing locally. The `pie=True` arm below exists to pin the REFUSAL that now replaces that spew.
+    """
+    cmd = [cxx, "-O0", "-g" if debug else "-g0",
+           "-fPIE" if pie else "-fno-pie", "-pie" if pie else "-no-pie",
+           "-o", out, FIXTURE]
     done = subprocess.run(cmd, capture_output=True, text=True)
     if done.returncode != 0:
-        print("  [FAIL] could not compile the fixture (%s):\n%s" % (" ".join(cmd), done.stderr))
+        # A toolchain that cannot produce the requested linkage says nothing about the tool, so the
+        # PIE arm reports that as a skip. The two main arms still fail: without them there is no
+        # test at all.
+        prefix = "  [skip] " if optional else "  [FAIL] "
+        print("%scould not compile the fixture (%s):\n%s" % (prefix, " ".join(cmd), done.stderr))
         return False
     return True
 
 
-def run_arm(binary, ticks=12):
-    """Run the real driver over one fixture build; return (header_fields, rows, raw)."""
+def run_arm(binary, ticks=12, out_bytes=0):
+    """Run the real driver over one fixture build; return (header_fields, rows, outs, raw)."""
     cmd = [sys.executable, DRIVER, "--ticks", str(ticks), "--values", "--order", "8",
-           "--filter", "^s_", "--timeout", "180", "--launch", binary]
+           "--filter", "^s_", "--timeout", "180"]
+    if out_bytes:
+        cmd += ["--out-bytes", str(out_bytes)]
+    cmd += ["--launch", binary]
     done = subprocess.run(cmd, capture_output=True, text=True)
     raw = done.stdout + done.stderr
-    fields, rows = {}, {}
+    fields, rows, outs = {}, {}, {}
+    current, current_out = None, None
     for line in done.stdout.splitlines():
         if line.startswith("clock="):
             for token in line.split():
                 if "=" in token:
                     key, _, value = token.partition("=")
                     fields[key] = value
+            continue
+        out = re.match(r"\s+out (a\d)\[(\d+)\] (.*)$", line)
+        if out and current:
+            current_out = (current, out.group(1))
+            stats = {"width": int(out.group(2)), "shapes": {}}
+            for key, value in re.findall(r"([a-z-]+)=(\d+)", out.group(3)):
+                stats[key] = int(value)
+            outs[current_out] = stats
+            continue
+        shape = re.match(r"\s+(@\d+ .*?)\s+x(\d+)$", line)
+        if shape and current_out:
+            outs[current_out]["shapes"][shape.group(1)] = int(shape.group(2))
+            continue
         m = re.match(r"\s*(\d+)\s+(\S+)(.*)$", line)
-        if m and not line.startswith("clock="):
+        if m:
             name, tail = m.group(2), m.group(3)
             seen = {}
             for value, count in re.findall(r"(0x[0-9a-f]+) x(\d+)", tail):
                 seen[int(value, 16)] = int(count)
             rows[name] = {"calls": int(m.group(1)), "values": seen, "tail": tail}
-    return fields, rows, raw
+            current, current_out = name, None
+    return fields, rows, outs, raw
 
 
 def check_arm(label, fields, rows, raw, expect_source):
@@ -178,6 +210,76 @@ def check_arm(label, fields, rows, raw, expect_source):
           % (label, WIDE, [hex(v) for v in wide["values"]]))
 
 
+def check_out_arm(fields, rows, outs, raw):
+    """The --out-bytes arm (#2045): what the handler WROTE, which the return register cannot say.
+
+    Every expected value here comes from `test_values_fixture.cpp`, which in turn mirrors the real
+    handlers named in the issue — `s_syss_getstatus` writes 12 bytes with `st[6] = 1`, and
+    `s_user_getevent` writes `{0, 1}` on the one call that delivers the LOGIN. Both are known from
+    source before the run, which is the only kind of check worth having on an instrument.
+    """
+    label = "out-bytes"
+    check(fields.get("out-bytes") == "12", "%s: the header states the sampled width (out-bytes=%s)"
+          % (label, fields.get("out-bytes")))
+
+    wrote = outs.get(("s_fixture_writes12", "a0"), {})
+    check(wrote.get("read", 0) > 0 and wrote.get("read") == wrote.get("calls"),
+          "%s: the writer's out-pointer was sampled on every call (%s)" % (label, wrote))
+    check(wrote.get("changed", 0) == wrote.get("read", -1),
+          "%s: every sampled call showed a write (changed=%s read=%s)"
+          % (label, wrote.get("changed"), wrote.get("read")))
+    check(list(wrote.get("shapes", {})) == ["@6 00->01"],
+          "%s: the diff is exactly the byte the source writes, st[6]=1 (%s)"
+          % (label, list(wrote.get("shapes", {}))))
+
+    # THE distinction the feature exists for. Same width, same call count, both readable — one
+    # handler wrote and the other did not, and the counters say which without ambiguity.
+    quiet = outs.get(("s_fixture_nowrite", "a0"), {})
+    check(quiet.get("read", 0) > 0 and quiet.get("changed", -1) == 0,
+          "%s: a handler that writes nothing reads as changed=0, not as a failure (%s)"
+          % (label, quiet))
+    check(quiet.get("same-zero", 0) == quiet.get("read", -1),
+          "%s: its unwritten buffer is same-zero, the unambiguous 'nothing was written' (%s)"
+          % (label, quiet))
+
+    # ... and "nothing was READ" must never look like either of those.
+    bad = outs.get(("s_fixture_badptr", "a0"), {})
+    check(bad.get("unreadable", 0) > 0 and bad.get("read", -1) == 0 and bad.get("changed", -1) == 0,
+          "%s: an unmapped out-pointer is unreadable=N read=0 — nothing was READ (%s)" % (label, bad))
+    small = outs.get(("s_fixture_handlearg", "a0"), {})
+    check(small.get("small", 0) > 0 and small.get("read", -1) == 0,
+          "%s: a small handle argument is counted as small, not as unreadable (%s)" % (label, small))
+    check(("s_fixture_nullarg", "a0") not in outs
+          and "were NULL on every call" in raw,
+          "%s: an always-null argument gets the explicit null line, not a silent absence" % label)
+
+    # The out-struct positive control, from the same source contract as the value control: the LOGIN
+    # call is the only one that writes, so exactly one sample may differ.
+    control = outs.get((CONTROL, "a0"), {})
+    check(control.get("changed", -1) == 1,
+          "%s: %s wrote its event struct on exactly one call (%s)" % (label, CONTROL, control))
+    check(list(control.get("shapes", {})) == ["@4 00->01"],
+          "%s: and the write is userId=1 at offset 4 (%s)" % (label, list(control.get("shapes", {}))))
+    check(control.get("same-zero", 0) == control.get("read", 0) - 1,
+          "%s: every other %s call left the struct untouched (%s)" % (label, CONTROL, control))
+
+    # The ambiguous state, asserted rather than merely documented: a buffer the guest does not clear,
+    # rewritten with the same bytes every call. Exactly one call can show a diff; the rest ARE writes
+    # and are indistinguishable from silence, which is what `same-nonzero` says and `same-zero` must
+    # not. Collapsing the two would make this instrument claim more than it can see.
+    rewrite = outs.get(("s_fixture_rewrite", "a0"), {})
+    check(rewrite.get("changed", -1) == 1 and rewrite.get("same-nonzero", 0) == rewrite.get("read", 0) - 1,
+          "%s: a repeated identical write reads as same-nonzero, not as a write (%s)"
+          % (label, rewrite))
+    check(rewrite.get("same-zero", -1) == 0,
+          "%s: and never as same-zero, which would claim nothing was written (%s)" % (label, rewrite))
+    check(rows.get(CONTROL, {}).get("values", {}).get(LOGIN, 0) == 1,
+          "%s: the value capture still works alongside the out-byte sampling" % label)
+    check(fields.get("finish-failures") == "0" and "(captured " not in raw,
+          "%s: sampling out-bytes cost no return-value capture (finish-failures=%s)"
+          % (label, fields.get("finish-failures")))
+
+
 def main():
     print("== test_hle_calls_values ==")
     if sys.platform != "linux":
@@ -201,13 +303,47 @@ def main():
         # the configuration on which every value capture failed.
         arms = (("no-debug-info", os.path.join(work, "fixture_nodbg"), False, "rax"),
                 ("debug-info", os.path.join(work, "fixture_dbg"), True, "dwarf"))
+        built = {}
         for label, path, debug, expect in arms:
             if not compile_fixture(cxx, path, debug):
                 global fails
                 fails += 1
                 continue
-            fields, rows, raw = run_arm(path)
+            built[label] = path
+            fields, rows, outs, raw = run_arm(path)
             check_arm(label, fields, rows, raw, expect)
+        # Third arm: the same no-debug-info binary, now with --out-bytes. Run apart from the two
+        # above so the default path (out-bytes off) stays covered rather than only the new one.
+        if "no-debug-info" in built:
+            fields, rows, outs, raw = run_arm(built["no-debug-info"], out_bytes=12)
+            check_out_arm(fields, rows, outs, raw)
+
+        # Fourth arm: a PIE build must be REFUSED by name, not attempted. Every address this tool
+        # arms is a link-time address, so on a PIE they are offsets and each breakpoint lands in
+        # unmapped memory -- gdb then prints "Cannot insert breakpoint N" per handler and the run
+        # produces no result block, which is three steps from naming its own cause. This arm is here
+        # because that is exactly how the test failed on a GitHub ubuntu-24.04 runner while passing
+        # on Fedora: the two toolchains disagree on the -pie default, so the fixture was a different
+        # program on each.
+        pie_path = os.path.join(work, "fixture_pie")
+        if compile_fixture(cxx, pie_path, debug=False, pie=True, optional=True):
+            done = subprocess.run([sys.executable, DRIVER, "--ticks", "4", "--values",
+                                   "--filter", "^s_", "--timeout", "60", "--launch", pie_path],
+                                  capture_output=True, text=True)
+            message = done.stdout + done.stderr
+            check(done.returncode != 0,
+                  "pie: the driver refuses a PIE target (exit %d)" % done.returncode)
+            check("position-independent" in message and "-no-pie" in message,
+                  "pie: and the refusal names the cause and the fix (%s)"
+                  % message.strip().splitlines()[-1][:160] if message.strip() else "pie: no message")
+            # The refusal must come BEFORE any work, and the tell has to be a string only the
+            # not-taken path can print. Two earlier attempts here were void for exactly the reason
+            # this test exists to catch: "Cannot insert breakpoint" and "armed" both appear in the
+            # refusal itself, which QUOTES the gdb error it is preventing -- so each check would
+            # have passed or failed on the wording of the message rather than on the behaviour.
+            # `hle_calls: N handler symbols in ...` is printed only once enumeration has run.
+            check("handler symbols in" not in message,
+                  "pie: it refuses before enumerating handlers or starting gdb")
     finally:
         shutil.rmtree(work, ignore_errors=True)
 

--- a/prosper/tools/hle_calls/test_values_fixture.cpp
+++ b/prosper/tools/hle_calls/test_values_fixture.cpp
@@ -35,9 +35,63 @@ FIXTURE_HLE(s_user_getevent) {
     static int delivered = 0;
     if (a0 && !delivered) {
         delivered = 1;
+        // The real handler writes `{ int32 eventType = 0 (LOGIN), int32 userId = 1 }` here, and only
+        // on this one call. That makes it the out-struct control too: over a launch window, exactly
+        // ONE of this handler's calls may show a changed out-struct, and it is the call that
+        // returned 0.
+        int32_t* ev = (int32_t*)a0;
+        ev[0] = 0;
+        ev[1] = 1;
         return 0;
     }
     return 0x80960007ull;
+}
+
+// The out-struct control, mirroring hle_service.cpp's s_syss_getstatus: writes 12 bytes at a0 and
+// sets st[6] = 1. #2045 names exactly this handler, because its written bytes are known from the
+// source before any run.
+FIXTURE_HLE(s_fixture_writes12) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    auto* st = (uint8_t*)a0;
+    if (!st) return 0x80A10003ull;
+    for (int i = 0; i < 12; i++) st[i] = 0;
+    st[6] = 1;
+    return 0;
+}
+
+// Returns success and writes NOTHING through its out-pointer: the bug shape this feature exists to
+// find, and the arm that proves "nothing was written" is visibly distinct from "nothing was read".
+FIXTURE_HLE(s_fixture_nowrite) {
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0;
+}
+
+// Three ways an argument is not an out-pointer, each of which must be counted apart from the
+// others. None of these dereferences a0 -- the fixture only ever passes these values in.
+// The one state this method cannot resolve, made deterministic: the guest never clears this
+// buffer, and the handler writes the same bytes into it every call. Call 1 shows a diff; every
+// later call is byte-identical yet WAS written. `same-nonzero` is that reading, and it is why the
+// counter exists apart from `same-zero`.
+FIXTURE_HLE(s_fixture_rewrite) {
+    (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    auto* p = (uint8_t*)a0;
+    if (!p) return 0x80A10003ull;
+    p[0] = 0xAB;
+    p[3] = 0xCD;
+    return 0;
+}
+
+FIXTURE_HLE(s_fixture_nullarg) {   // a0 == 0
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0;
+}
+FIXTURE_HLE(s_fixture_handlearg) { // a0 is a small handle, not an address
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0;
+}
+FIXTURE_HLE(s_fixture_badptr) {    // a0 points at unmapped memory
+    (void)a0; (void)a1; (void)a2; (void)a3; (void)a4; (void)a5;
+    return 0;
 }
 
 // A value no accident produces, and one that needs all 64 bits: it pins both the capture and the
@@ -66,21 +120,46 @@ using hle_fn = uint64_t (*)(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, ui
 
 // Through volatile pointers so the calls survive any optimisation level: the test builds this at
 // -O0, but a fixture that can be inlined away would fail in a way that looks like a tool bug.
-static hle_fn volatile table[3] = {
+static hle_fn volatile table[9] = {
     &prosper::s_user_getevent,
     &prosper::s_fixture_wide,
     &prosper::s_fixture_ok,
+    &prosper::s_fixture_writes12,
+    &prosper::s_fixture_nowrite,
+    &prosper::s_fixture_rewrite,
+    &prosper::s_fixture_nullarg,
+    &prosper::s_fixture_handlearg,
+    &prosper::s_fixture_badptr,
 };
 static volatile uint64_t sink;
+// Deliberately NOT cleared between calls -- see s_fixture_rewrite.
+static uint8_t sticky[16];
 
 int main() {
     // Runs until the window closes and hle_calls kills it. A fixture that exited first would end
     // the window early (`window=SHORT exited=1`) and the test would be asserting on a truncated run.
     for (;;) {
-        uint64_t event = 0;
-        sink = table[0]((uint64_t)&event, 0, 0, 0, 0, 0);   // non-null a0: LOGIN-eligible
+        // Zeroed per iteration, the way a guest that declares its out-struct on the stack per call
+        // does. That matters for --out-bytes: the diff is between the bytes at entry and at return,
+        // so a guest REUSING a buffer that already holds what the handler writes produces
+        // `same-nonzero` rather than `changed` -- a real ambiguity of the method, kept out of this
+        // fixture deliberately so the assertions below mean one thing.
+        // 16 bytes and zeroed, so a sample WIDER than the 8-byte event struct still sees a
+        // known state: a window overlapping unrelated stack would report `same-nonzero` for
+        // reasons that have nothing to do with the handler.
+        uint8_t event[16] = {0};
+        uint8_t status[16] = {0};
+        uint8_t untouched[16] = {0};
+
+        sink = table[0]((uint64_t)event, 0, 0, 0, 0, 0);        // LOGIN-eligible; writes once
         sink = table[1](0, 0, 0, 0, 0, 0);
         sink = table[2](0, 0, 0, 0, 0, 0);
+        sink = table[3]((uint64_t)status, 0, 0, 0, 0, 0);       // writes 12 bytes, st[6] = 1
+        sink = table[4]((uint64_t)untouched, 0, 0, 0, 0, 0);    // writes nothing
+        sink = table[5]((uint64_t)sticky, 0, 0, 0, 0, 0);       // rewrites the same bytes
+        sink = table[6](0, 0, 0, 0, 0, 0);                      // a0 null
+        sink = table[7](0x2a, 0, 0, 0, 0, 0);                   // a0 a small handle
+        sink = table[8](0xdeadbeef000ull, 0, 0, 0, 0, 0);       // a0 unmapped (~15 TB, never mapped)
         prosper::k_usleep();
     }
 }


### PR DESCRIPTION
Refs #2045 — **part 1 only** (`--values` cannot see an out-struct). This does **not** close the issue:
part 2's predicate swaps landed in #2324, and the two stack-extent clamps it left open
(`hle_kernel_time`, `hle_agc`) are deliberately untouched here.

> **Stacked on #2590 (`Fixes #2075`), which is its base branch.** The two changes edit the same
> functions — #2590 rewrote `_Finish.stop()`, and this extends it — so basing on master would have
> guaranteed a conflict. Review/merge #2590 first; GitHub retargets this to `master` automatically
> when it lands. The diff shown here is this PR's own.

## Why a return-value census is not enough

`--values` records the return **register**. The recurring defect on this codebase is the one that
register cannot see: *success returned, out-struct never written*.

| defect | returned | what was wrong |
|---|---|---|
| `sceSystemServiceGetStatus` | `0` | aliased to the wrong handler |
| `sceSystemServiceGetDisplaySafeAreaInfo` | `0` | `ratio` left at 0 → a degenerate title-safe rect |
| `sceNpEntitlementAccessGetSkuFlag` | `0` | unregistered; the out pointer never touched |
| `sceNpTrophy2GetTrophyInfoArray` | `0` | garbage count → a 34 GB allocation |

Every one of them returns `0`. The 49-handler census on #1905 came back with no implausible return
value, and that bounds the candidate exactly as far as the return register reaches — no further.

## What this adds

`--out-bytes N` snapshots N bytes at whichever of a0/a1 is a readable pointer, **before the call and
again at its return**, and reports what changed:

```
       5  s_syss_getstatus   ret 0x0 x5
            out a0[16] calls=5 read=5 changed=5 same-zero=0 same-nonzero=0 null=0 small=0 unreadable=0 lost=0
              @2 70->00 @3 45->00 @6 07->01 @7 45->00 @10 70->00 @11 45->00  x4
              @4 3f->00 @6 00->01 @7 80->00  x1
```

**Five states, counted apart, all printed including the zeros:**

| counter | reading |
|---|---|
| `changed` | the handler wrote, and the shapes say which bytes |
| `same-zero` | zero before and after — the unambiguous *nothing was written* |
| `same-nonzero` | the bytes already held a value: a handler that wrote exactly that is indistinguishable from one that wrote nothing. The one state this method cannot resolve, named rather than folded into `same-zero` |
| `null` / `small` / `unreadable` | **nothing was read** — a null argument, a value too small to be an address (a handle, a size), or memory gdb could not read. None is evidence about writing |
| `lost` | sampled on entry, no second half (the frame left without returning, or the memory went away). Neither reading |

That separation is the whole design constraint the issue set — *"a way to tell 'nothing was written'
from 'nothing was read'"* — and it is why every field is printed even at zero: a counter that
disappeared when zero would let the second read as the first, which is the bug shape this feature
exists to find, relocated into the instrument. An argument that was NULL on every call gets its own
explicit line rather than silence.

## Known answer, derived from the source before the run

`src/hle/hle_service.cpp:2884-2893` says `memset(st, 0, 12)` then `st[6] = 1`. Live on *Sonic
Origins* (`PPSA05325`), current master's **default Release build**, `--out-bytes 16`:

- `s_syss_getstatus` → `changed=5/5`, every shape carrying `@6 …->01`. The other changed bytes are
  the `memset` clearing what was there.
- **Nothing at offsets 12–15 moved, although 16 bytes were sampled** — the struct's 12-byte width
  re-derived from the observation rather than assumed.

The out-struct positive control is the same handler as `--values`', from the same source contract:
`s_user_getevent` writes `{eventType=0, userId=1}` only on the call that delivers the LOGIN.

```
       7  s_user_getevent   ret 0x80960007 x6, 0x0 x1
            out a0[16] calls=7 read=7 changed=1 same-zero=0 same-nonzero=6 null=0 small=0 unreadable=0 lost=0
              @0 30->00 @1 ec->00 @2 df->00 @3 e2->00 @4 ff->01 @5 7f->00  x1
```

`changed=1` of 7, at `@4 …->01` (userId), on the one call that returned `0x0`. In `--pid` mode
`changed=0` is the correct observation, for the same reason the value control shows no `0x0` there.
Two more rows from the same run read as they should on inspection: `s_user_name` writes the ASCII
`Player` into a1, and `s_user_number` sets `@0 00->01`.

## Tests — three arms, still dump-free

`hle_calls_value_capture` (added by #2590) gains a third arm: the same no-debug-info fixture binary,
run with `--out-bytes 12`. The fixture grew one handler per state, each mirroring a real one:

- `s_fixture_writes12` — writes 12 bytes with `st[6] = 1`, exactly `s_syss_getstatus`;
- `s_fixture_nowrite` — returns success and writes nothing (**the bug shape**);
- `s_fixture_rewrite` — writes the same bytes every call into a buffer the guest never clears, which
  makes `same-nonzero` deterministic rather than an accident of stack layout;
- `s_fixture_nullarg` / `s_fixture_handlearg` / `s_fixture_badptr` — null, a small handle, and an
  unmapped address;
- `s_user_getevent` now writes its event struct on the LOGIN call, as the real one does.

40 checks, `all checks passed`, 0.74 s.

**Mutation arms**, both quoted verbatim:

*A — report an unreadable pointer as `same-zero`* (the exact confusion the feature must not make):
```
  [FAIL] out-bytes: an unmapped out-pointer is unreadable=N read=0 — nothing was READ ({})
== FAILURES: 1 ==
```

*B — never fire the after/before diff*:
```
  [FAIL] out-bytes: every sampled call showed a write (changed=0 read=12)
  [FAIL] out-bytes: the diff is exactly the byte the source writes, st[6]=1 ([])
  [FAIL] out-bytes: s_user_getevent wrote its event struct on exactly one call (…changed=0…)
  [FAIL] out-bytes: and the write is userId=1 at offset 4 ([])
  [FAIL] out-bytes: every other s_user_getevent call left the struct untouched (…)
  [FAIL] out-bytes: a repeated identical write reads as same-nonzero, not as a write (…)
  [FAIL] out-bytes: and never as same-zero, which would claim nothing was written (…)
== FAILURES: 7 ==
```

## Invariants and risks

- **The instrument never writes to the guest.** It reads twice and diffs; it does not poison the
  buffer to force a signal. The cost of that choice is `same-nonzero`, which is stated rather than
  hidden.
- Sampling happens **before** the finish breakpoint is armed, so an entry snapshot whose second half
  cannot be armed is counted `lost` rather than dropped silently.
- `--out-bytes` implies the same second trap `--values` uses, and works with `--values` off; pairing
  them is still recommended, since the positive-control verdict only exists with `--values`.
- A0/a1 only, by the issue's own suggestion. A handler whose out-pointer is a2+ is not covered — an
  honest gap, not a silent one: nothing claims to have looked.
- `read` does not prove the mapping is **writable**, so a read-only page reads as `same-*`. It cannot
  produce a false "wrote".
- Width is capped at 256 bytes and a larger request is refused rather than clamped — a run that
  quietly sampled a different width than the one asked for would put an unfalsifiable number in
  front of a reader.
- Cost: two memory reads per call per argument. Pair with `--filter`, as with `--values`.

## Commands and results

```bash
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 247`, ctest exit 0** on `78c4ea83`:

```
 12/247 Test   #8: hle_calls_value_capture ........................   Passed    0.74 sec
100/247 Test   #7: hle_calls_positive_control .....................   Passed    0.01 sec
```

Live arm (Linux, gdb 17.2 / Fedora 44, in the project's build container):

```bash
PROSPER_NO_COMPUTE=1 python3 prosper/tools/hle_calls/hle_calls.py \
    --ticks 60 --values --out-bytes 16 --order 8 --filter '^s_' \
    --inferior-log ~/hlecalls-boot.log \
    --launch prosper/build-linux/boot_trace <DUMP_ROOT>/PPSA05325-app0
```

`clock=prosper::k_usleep entries=60/60 window=complete positive-control=ok armed=157 mode=launch
calls=28 finish-failures=0 exited=0 value-source=dwarf:0,rax:28 out-bytes=16`, 11 handlers with
out-struct rows. Docs gate clean over every tracked `.md`; `git diff --check` clean. No emulator
code is touched.
