### PR TITLE
fix(diag): re-key the arm_hwwatch baseline row — master's Docs job is red from a clean-merge collision

### DIFF
--- a/prosper/tools/env/diag_gate_baseline.txt
+++ b/prosper/tools/env/diag_gate_baseline.txt
@@ -40,7 +40,7 @@
 SPLIT-CALL|src/gpu/command_processor.cpp|generation_guard|PROSPER_GENERATION_GUARD+PROSPER_MB3_FREELIST_GUARD  # benign: the callee is a BEHAVIOUR predicate, not a producer of printed state -- there is no field it could leave unmeasured. The rule's shape matches; its subject does not.
 SPLIT-CALL|src/gpu/gpu_timeline.cpp|automatic_capture_bundle_gate_conflicts|PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG+PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 SPLIT-CALL|src/hle/hle_audio.cpp|audio2log|PROSPER_AUDIO2LOG+PROSPER_AUDIO2LOG|PROSPER_AUDIO2_PROBE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-SPLIT-CALL|src/host/exec_image_linux.cpp|arm_hwwatch|PROSPER_HWBP+PROSPER_HWWATCH_ABS  # benign: two DELIBERATE entry points into one arming helper (absolute watch vs register-relative on the first exec-bp hit). Neither switch is a producer for the other's printer, and nothing prints a field either could have measured.
+SPLIT-CALL|src/host/exec_image_linux.cpp|arm_hwwatch|PROSPER_HWBP|PROSPER_HWWATCH+PROSPER_HWWATCH_ABS  # benign: two DELIBERATE entry points into one arming helper (absolute watch vs register-relative on the first exec-bp hit). Neither switch is a producer for the other's printer, and nothing prints a field either could have measured.
 SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_compute_image_hit|(any)  # unreviewed: not judged
 SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_submit_query|(any)  # unreviewed: not judged
 SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_validated_bytes|(any)  # unreviewed: not judged


### PR DESCRIPTION
Master's `Docs` job is red, and has been since #2579 landed. Every open PR shows the failure, so this
unblocks the queue.

## The failure

```
[FAIL] 1 finding(s) not in the baseline:
  SPLIT-CALL|src/host/exec_image_linux.cpp|arm_hwwatch|PROSPER_HWBP|PROSPER_HWWATCH+PROSPER_HWWATCH_ABS
    @src/host/exec_image_linux.cpp:3248  2 call sites, gates disagree:
    PROSPER_HWWATCH_ABS vs PROSPER_HWBP|PROSPER_HWWATCH
[FAIL] 1 baseline entry(ies) no longer reproduce -- delete the row:
  SPLIT-CALL|src/host/exec_image_linux.cpp|arm_hwwatch|PROSPER_HWBP+PROSPER_HWWATCH_ABS
```

Two failures, one drift, counted from both ends — the checker fails on a finding missing from the
baseline **and** on a baseline row that no longer reproduces, which is the correct design and is why
one key change reads as two problems.

## Why it happened, and why neither PR is at fault

* **#2576** (issue #1932) reworked the SIGTRAP dispatch in `exec_image_linux.cpp`. That widened the
  gate on `arm_hwwatch`'s first call site from `PROSPER_HWBP` to `PROSPER_HWBP|PROSPER_HWWATCH`.
  The baseline key is `KIND|file|subject|requirement`, so a changed requirement is a changed key.
* **#2574** (issue #2149) introduced the checker and shipped a baseline generated *before* that
  change existed.

Each was green on its own head. They touch no common line, merged cleanly in sequence, and the
result is broken — the clean-merge semantic collision `CLAUDE.md` warns about, where `mergeable:
CLEAN` plus green CI on each branch cannot see the problem. Worth noting the checker caught it
immediately and named it precisely, which is the behaviour it was added for.

## The change

One line. The finding is unchanged in substance — still two deliberate entry points into one arming
helper — so the existing row is **re-keyed**, keeping its `benign` classification and its note
verbatim. Nothing is added, removed or reclassified: **177 findings, 177 baselined**, before and
after.

## Verification

```
python3 prosper/tools/env/check_diag_gates.py --selftest   ->  rc 0
python3 prosper/tools/env/check_diag_gates.py prosper      ->  == all checks passed ==
                                                               scanned 479 files, 653 PROSPER_*
                                                               variables at 1058 sites
                                                               SPLIT-CALL=4 SPLIT-LOCAL=22
                                                               TWO-GATE=151, 177 baselined
```

Both run on this exact tree. No mutation arm is offered and none is meaningful: this is a data
correction to a baseline, and its own gate failing before and passing after **is** the arm — the
before state is reproducible at `ba0ced87` on master.

## Risk

Low, and bounded by what the file is. The only way this could hide a real defect is if the new key
described a *different* coupling than the old one; it does not — same file, same subject
(`arm_hwwatch`), same two call sites, same reason it is benign. A reviewer wanting to confirm that
independently can diff the two keys: only the requirement clause differs, and it differs by the
alternation #2576 added.

Fixes #2594
