### PR TITLE
diag(capture): a timeline selector that never matches, and a malformed capture tunable, now say so — a PROSPER_CAPTURE_MAX_SUBMITS typo meant UNCAPPED

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1325,6 +1325,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_guest_log_capture_miss PRIVATE prosper_core)
   add_test(NAME guest_log_capture_miss COMMAND test_guest_log_capture_miss)
 
+  # The same silence, two selector families over: a malformed capture tunable substituting a
+  # different policy (#2565) and a detailed timeline selector that never matched (#2564). Separate
+  # binary because both the detailed-capture request and the tunable refusal are process-wide
+  # one-shots, and one of its arms deliberately ends a CHILD process during static initialization.
+  add_executable(test_capture_tunables tests/test_capture_tunables.cpp)
+  target_link_libraries(test_capture_tunables PRIVATE prosper_core)
+  add_test(NAME capture_tunables COMMAND test_capture_tunables)
+
   # Remote/headless F9 equivalent: an external regular-file witness arms the existing seeded
   # whole-frame capture on the next present. Pure/cross-platform; no game dump or Vulkan device.
   add_executable(test_capture_trigger_file tests/test_capture_trigger_file.cpp)

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -3080,6 +3080,9 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     // Latched before every early return, so the exit report can separate "the run produced no GPU
     // submits at all" from "it submitted plenty and the timeline was never recording" (#2564). Those
     // have opposite fixes and used to produce the identical observation: a missing .prgcap.
+    // Unconditional on purpose: gating it on the selector's environment would make the count itself
+    // depend on the thing being diagnosed. The very next line already pays an identical relaxed
+    // increment for the grab hook, so the marginal cost of this one is not measurable.
     g_timeline_submit_hook_reached.fetch_add(1, std::memory_order_relaxed);
     interactive_frame_bundle_on_submit(state, submit_no);
     if (!gpu_timeline_requested()) return;

--- a/prosper/src/gpu/gpu_timeline.cpp
+++ b/prosper/src/gpu/gpu_timeline.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <atomic>
 #include <bit>
+#include <cctype>
 #include <cerrno>
 #include <chrono>
 #include <cstdio>
@@ -240,6 +241,24 @@ RuntimeRecorder& runtime_recorder() {
     return recorder;
 }
 
+// Mirrors of the detailed-capture selector's state, at namespace scope (#2564).
+//
+// The exit report may NOT read RuntimeDetailRequest itself. It is a function-local static built
+// lazily on the first submit that reaches the recorder, so a run that never submits — or one whose
+// timeline was never requested — has no such object at all; and an atexit handler registered at load
+// runs AFTER every static destructor, so even a constructed one has ended its lifetime by then.
+// #1684 hit exactly this and leaked its singleton for the same reason. These cost one relaxed store
+// each on paths that already build a whole submit record.
+std::atomic<bool> g_timeline_request_built{false};
+std::atomic<bool> g_timeline_request_valid{false};
+std::atomic<bool> g_timeline_selector_semantic{false};
+std::atomic<uint64_t> g_timeline_submit_hook_reached{0};
+std::atomic<uint64_t> g_timeline_selector_submits_examined{0};
+std::atomic<uint64_t> g_timeline_selector_last_submit_examined{0};
+std::atomic<uint64_t> g_timeline_detail_submits_captured{0};
+std::atomic<bool> g_timeline_after_compute_armed{false};
+std::atomic<uint64_t> g_timeline_phase_submits_observed{0};
+
 struct RuntimeDetailRequest {
     std::string path;
     std::string predecessor_path;
@@ -291,6 +310,10 @@ struct RuntimeDetailRequest {
     std::atomic<bool> history_phase_bounded{false};
 
     RuntimeDetailRequest() {
+        // Latched before the first early return: "the request was never built at all" and "it was
+        // built and rejected" are different faults with different fixes, and the exit report has to
+        // tell them apart without being able to look at this object (#2564).
+        g_timeline_request_built.store(true, std::memory_order_release);
         const char* path_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
         const char* submit_env = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
         if ((!path_env || !*path_env) && (!submit_env || !*submit_env)) return;
@@ -524,6 +547,8 @@ struct RuntimeDetailRequest {
             exit_after_capture = *value && std::strcmp(value, "0") && std::strcmp(value, "off");
         submit_no = parsed;
         valid = true;
+        g_timeline_request_valid.store(true, std::memory_order_release);
+        g_timeline_selector_semantic.store(semantic_selector, std::memory_order_release);
         if (semantic_selector)
             std::fprintf(stderr, "[timeline] semantic capture endpoint submit>=%llu "
                                  "target=%ux%u target-index=%u..%u draws=%u..%u "
@@ -791,12 +816,14 @@ RuntimeCapturePhaseObservation observe_runtime_capture_phase(RuntimeDetailReques
         request.after_compute_seen.load(std::memory_order_acquire))
         return RuntimeCapturePhaseObservation::Ready;
     request.phase_observation_submits.fetch_add(1, std::memory_order_relaxed);
+    g_timeline_phase_submits_observed.fetch_add(1, std::memory_order_relaxed);
     for (const auto& dispatch : state.dispatches) {
         request.phase_dispatches_scanned.fetch_add(1, std::memory_order_relaxed);
         if (compute_dispatch_code_addr(state, dispatch) != request.select_after_compute_program)
             continue;
         request.after_compute_submit_no = submit_no;
         request.after_compute_seen.store(true, std::memory_order_release);
+        g_timeline_after_compute_armed.store(true, std::memory_order_release);
         std::fprintf(stderr,
                      "[timeline] capture after-compute gate armed submit=%llu program=0x%llx "
                      "observed-submits=%llu dispatches-scanned=%llu history-submits-skipped=%llu "
@@ -1854,6 +1881,232 @@ bool begin_gpu_timeline_submit(uint64_t submit_no) {
     return requested;
 }
 
+namespace {
+// Renders a log line or an environment value unambiguously. An exact-match failure — or a rejected
+// tunable — is very often caused by a byte the operator cannot see: a trailing tab, a stray CR, a
+// BOM, a trailing space. Printing raw would reproduce the very invisibility these reports exist to
+// remove. Shared by the guest-log miss report (#1684) and the tunable notices (#2565).
+std::string escape_log_line(const std::string& text) {
+    std::string out;
+    out.reserve(text.size() + 8);
+    for (const unsigned char ch : text) {
+        if (ch == '\\') {
+            out += "\\\\";
+        } else if (ch >= 0x20 && ch < 0x7f) {
+            out.push_back(static_cast<char>(ch));
+        } else {
+            char buf[5];
+            std::snprintf(buf, sizeof(buf), "\\x%02x", ch);
+            out += buf;
+        }
+    }
+    return out;
+}
+
+// A tunable's value is a number, never prose, so a SPACE inside one is always a typo — and
+// `PROSPER_CAPTURE_MAX_SUBMITS=40 ` is one of the two typos this whole change exists for.
+// escape_log_line deliberately leaves 0x20 alone (correct for a guest log line, which is mostly
+// spaces; wrong here, where the invisible byte IS the bug), so spaces are escaped on top of it.
+std::string escape_tunable_value(const std::string& raw) {
+    std::string out = escape_log_line(raw);
+    std::string escaped;
+    escaped.reserve(out.size());
+    for (const char ch : out) {
+        if (ch == ' ') escaped += "\\x20";
+        else escaped.push_back(ch);
+    }
+    return escaped;
+}
+}  // namespace
+
+// ---- Capture tunables: strict parse, and never a silent substitution (#2565) -----------------
+// Four capture tunables accepted a malformed or out-of-range value and quietly substituted a
+// different policy. None printed anything, so the run still completed and still produced *a* result
+// — just not the one that was asked for. The fallbacks are unchanged here; only the silence is.
+CaptureTunableParse parse_capture_tunable(const char* raw, uint64_t lo, uint64_t hi) {
+    CaptureTunableParse out;
+    if (!raw || !*raw) return out;   // Unset
+    char* end = nullptr;
+    errno = 0;
+    const unsigned long long parsed = std::strtoull(raw, &end, 0);
+    // Every one of these is deliberate. `end == raw` rejects a value with no digits at all; `*end`
+    // rejects trailing bytes, which is what makes `40 ` a rejection rather than a 40; `errno`
+    // rejects an overflow that strtoull would otherwise saturate to ULLONG_MAX; a leading '-' is
+    // rejected explicitly because strtoull silently NEGATES it into a huge positive number, turning
+    // `-1` into an accepted 18446744073709551615; and LEADING whitespace is rejected because
+    // strtoull skips it, so ` 40` would otherwise be accepted while `40 ` is not — an asymmetry with
+    // no defensible meaning in a value that is supposed to be a number and nothing else.
+    if (errno || end == raw || !end || *end || *raw == '-' ||
+        std::isspace(static_cast<unsigned char>(*raw))) {
+        out.status = CaptureTunableStatus::Malformed;
+        return out;
+    }
+    out.value = static_cast<uint64_t>(parsed);
+    out.status = out.value < lo   ? CaptureTunableStatus::BelowRange
+                 : out.value > hi ? CaptureTunableStatus::AboveRange
+                                  : CaptureTunableStatus::Accepted;
+    return out;
+}
+
+namespace {
+// The shared body of a substitution notice. `in_force` is the load-bearing half: a message that only
+// says "rejected" still leaves the operator to guess what the run is actually doing.
+std::string capture_tunable_notice(const char* name, const char* raw,
+                                   const CaptureTunableParse& parse, uint64_t lo, uint64_t hi,
+                                   const std::string& in_force) {
+    if (parse.status == CaptureTunableStatus::Unset ||
+        parse.status == CaptureTunableStatus::Accepted)
+        return {};
+    std::string out = "[grab] ";
+    out += name;
+    out += "=\"" + escape_tunable_value(raw ? raw : "") + "\" ";
+    out += parse.status == CaptureTunableStatus::Malformed
+               ? "is not a whole number (the entire value must be one, with no trailing bytes — "
+                 "not even a space)"
+               : "is outside " + std::to_string(lo) + ".." + std::to_string(hi);
+    out += "; " + in_force + "\n";
+    return out;
+}
+}  // namespace
+
+std::string format_capture_bundle_max_mb_notice(const char* raw) {
+    const CaptureTunableParse parse =
+        parse_capture_tunable(raw, kInteractiveBundleMinMb, kInteractiveBundleMaxMb);
+    // 0 is this variable's existing sentinel for "keep the built-in default" — every call site has
+    // always encoded it that way, and prosper-app's own parse says so in a comment. Honouring it is
+    // not a substitution, so it draws no notice.
+    if (parse.status == CaptureTunableStatus::BelowRange && parse.value == 0) return {};
+    std::string in_force;
+    switch (parse.status) {
+        case CaptureTunableStatus::BelowRange:
+            in_force = "the budget is raised to the " + std::to_string(kInteractiveBundleMinMb) +
+                       " MiB minimum";
+            break;
+        case CaptureTunableStatus::AboveRange:
+            in_force = "the budget is capped at the " + std::to_string(kInteractiveBundleMaxMb) +
+                       " MiB maximum";
+            break;
+        default:
+            in_force = "the built-in default of " + std::to_string(kInteractiveBundleDefaultMb) +
+                       " MiB is in force, so a raise asked for here was DISCARDED and a capture "
+                       "that aborted on the budget will abort again";
+            break;
+    }
+    return capture_tunable_notice("PROSPER_CAPTURE_BUNDLE_MAX_MB", raw, parse,
+                                  kInteractiveBundleMinMb, kInteractiveBundleMaxMb, in_force);
+}
+
+std::string format_capture_frames_notice(const char* raw) {
+    const CaptureTunableParse parse =
+        parse_capture_tunable(raw, kCaptureFramesMin, kCaptureFramesMax);
+    std::string in_force;
+    switch (parse.status) {
+        case CaptureTunableStatus::BelowRange:
+            in_force = "the window is " + std::to_string(kCaptureFramesMin) + " present";
+            break;
+        case CaptureTunableStatus::AboveRange:
+            in_force = "the window is clamped to " + std::to_string(kCaptureFramesMax) +
+                       " presents";
+            break;
+        default:
+            in_force = "the window is the default " + std::to_string(kCaptureFramesDefault) +
+                       " present — which is the very width the 'window had no submits' message "
+                       "tells you to widen, so a mistyped remedy reproduces the original failure "
+                       "exactly";
+            break;
+    }
+    return capture_tunable_notice("PROSPER_CAPTURE_FRAMES", raw, parse, kCaptureFramesMin,
+                                  kCaptureFramesMax, in_force);
+}
+
+std::string format_capture_max_submits_refusal(const char* raw) {
+    // 1 is the minimum: a cap of zero submits captures nothing, and "uncapped" is expressible only
+    // by leaving the variable unset. Accepting `=0` as "uncapped" would preserve exactly the
+    // ambiguity this refusal exists to remove.
+    const CaptureTunableParse parse = parse_capture_tunable(raw, 1, UINT64_MAX);
+    if (parse.status == CaptureTunableStatus::Unset ||
+        parse.status == CaptureTunableStatus::Accepted)
+        return {};
+    std::string out = "[grab] PROSPER_CAPTURE_MAX_SUBMITS=\"" + escape_tunable_value(raw ? raw : "") +
+                      "\" is not a submit count; REFUSING TO RUN.\n";
+    out += "[grab]   This variable does not fall back to a default: its fallback is UNCAPPED, which "
+           "is the opposite of what a cap is for.\n";
+    out += "[grab]   The cap exists because one flip burst appended 3.3 GB in a single window and "
+           "blew even the " + std::to_string(kInteractiveBundleMaxMb) +
+           " MiB maximum, so proceeding with a typo would remove the only content bound on exactly "
+           "the run that needs it.\n";
+    out += "[grab]   Give a whole number of submits (1 or more), or unset the variable for an "
+           "uncapped capture. The entire value must be a number — `40 ` with a trailing space and "
+           "`4O` with a letter O are both rejected here.\n";
+    return out;
+}
+
+namespace {
+// Reported at most once per process. The environment does not change during a run, so a second
+// notice would only be noise in a log the first one is competing for attention in.
+// Atomic rather than a plain bool: the three gate constructors that resolve the budget are built
+// lazily and can be reached from the guest-log, present and render threads.
+void report_tunable_once(std::atomic<bool>& reported, const std::string& text) {
+    if (text.empty() || reported.exchange(true, std::memory_order_acq_rel)) return;
+    std::fputs(text.c_str(), stderr);
+}
+}  // namespace
+
+uint32_t resolve_capture_bundle_max_mb() {
+    const char* raw = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB");
+    static std::atomic<bool> reported{false};
+    report_tunable_once(reported, format_capture_bundle_max_mb_notice(raw));
+    const CaptureTunableParse parse =
+        parse_capture_tunable(raw, kInteractiveBundleMinMb, kInteractiveBundleMaxMb);
+    switch (parse.status) {
+        // 0 has always meant "keep the built-in default" at every call site, and a malformed value
+        // has always landed there. That fallback is deliberately unchanged: the defect was silence.
+        case CaptureTunableStatus::Unset:
+        case CaptureTunableStatus::Malformed: return 0;
+        // 0 keeps the built-in default, exactly as it always has; anything else under the minimum is
+        // raised to it, exactly as request_interactive_capture_bundle's clamp always has.
+        case CaptureTunableStatus::BelowRange:
+            return parse.value ? kInteractiveBundleMinMb : 0;
+        case CaptureTunableStatus::AboveRange: return kInteractiveBundleMaxMb;
+        case CaptureTunableStatus::Accepted: return static_cast<uint32_t>(parse.value);
+    }
+    return 0;
+}
+
+uint32_t resolve_capture_frames() {
+    const char* raw = std::getenv("PROSPER_CAPTURE_FRAMES");
+    static std::atomic<bool> reported{false};
+    report_tunable_once(reported, format_capture_frames_notice(raw));
+    const CaptureTunableParse parse =
+        parse_capture_tunable(raw, kCaptureFramesMin, kCaptureFramesMax);
+    switch (parse.status) {
+        case CaptureTunableStatus::Unset:
+        case CaptureTunableStatus::Malformed: return kCaptureFramesDefault;
+        case CaptureTunableStatus::BelowRange: return kCaptureFramesMin;
+        case CaptureTunableStatus::AboveRange: return kCaptureFramesMax;
+        case CaptureTunableStatus::Accepted: return static_cast<uint32_t>(parse.value);
+    }
+    return kCaptureFramesDefault;
+}
+
+uint64_t capture_max_submits() {
+    // Resolved once, and the resolution can END THE PROCESS. This is the one tunable that refuses
+    // rather than substituting, and it refuses at LOAD (the initializer below calls this), so the
+    // operator learns before the route runs rather than after a multi-gigabyte capture is underway.
+    static const uint64_t value = [] {
+        const char* raw = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
+        const std::string refusal = format_capture_max_submits_refusal(raw);
+        if (!refusal.empty()) {
+            std::fputs(refusal.c_str(), stderr);
+            std::fflush(nullptr);
+            std::exit(3);
+        }
+        const CaptureTunableParse parse = parse_capture_tunable(raw, 1, UINT64_MAX);
+        return parse.status == CaptureTunableStatus::Accepted ? parse.value : uint64_t{0};
+    }();
+    return value;
+}
+
 // ---- Interactive frame-bundle capture (prosper-app F9) ---------------------------------------------
 // Capture ONE complete displayed frame — every submit between two presents — on demand, so the produced
 // .prgbundle replays faithfully (the producer submits re-run and regenerate renderer-owned RTTs a single
@@ -1869,7 +2122,7 @@ struct InteractiveFrameBundle {
     std::string current_path;    // path for the window currently being captured
     bool capturing = false;
     bool failed = false;
-    uint64_t max_unique_bytes = 2048ull << 20;
+    uint64_t max_unique_bytes = static_cast<uint64_t>(kInteractiveBundleDefaultMb) << 20;
     // Why the CURRENT grab aborted, recorded as it happens. Distinct from the published outcome
     // below: sharing one field let a completed grab's {ok, path} be collected next to a LATER grab's
     // error string, because this one is written while that one is still awaiting collection.
@@ -1890,6 +2143,10 @@ struct InteractiveFrameBundle {
 };
 InteractiveFrameBundle& interactive_frame_bundle() { static InteractiveFrameBundle b; return b; }
 std::atomic<bool> g_interactive_frame_active{false};   // armed OR capturing
+// Latched, never cleared. `g_interactive_frame_active` goes back to false when a window closes, so
+// it cannot answer "did anything ever arm?" — which is exactly the question the exit report needs in
+// order to say that PROSPER_CAPTURE_BUNDLE was set and nothing ever used it (#2565).
+std::atomic<bool> g_interactive_capture_ever_armed{false};
 
 // Append one capture to `bundle` with content dedup, rolling back if it would exceed the byte budget.
 bool append_capture_to_frame_bundle(GpuCaptureBundle& bundle, const GpuCaptureFile& capture,
@@ -1924,10 +2181,17 @@ std::string request_interactive_capture_bundle(const std::string& path, uint32_t
     std::string replaced = std::move(b.armed_path);
     b.armed_path = path;
     b.arm_delay_presents = delay_presents;
-    if (max_mb) b.max_unique_bytes = static_cast<uint64_t>(std::clamp<uint32_t>(max_mb, 64u, 3072u)) << 20;
-    if (const char* frames = std::getenv("PROSPER_CAPTURE_FRAMES"))
-        b.frames_wanted = std::clamp<uint32_t>(static_cast<uint32_t>(std::strtoul(frames, nullptr, 0)), 1u, 240u);
+    if (max_mb)
+        b.max_unique_bytes = static_cast<uint64_t>(std::clamp<uint32_t>(
+                                 max_mb, kInteractiveBundleMinMb, kInteractiveBundleMaxMb))
+                             << 20;
+    // Strict, and it says what it did (#2565). An unparseable value used to become 0 and then be
+    // clamped straight back to the 1-present default, which is precisely the width the empty-window
+    // message tells the operator to widen — so a mistyped remedy reproduced the original failure and
+    // read as the remedy not working. The value in force is unchanged; the silence is not.
+    if (std::getenv("PROSPER_CAPTURE_FRAMES")) b.frames_wanted = resolve_capture_frames();
     g_interactive_frame_active.store(true, std::memory_order_release);
+    g_interactive_capture_ever_armed.store(true, std::memory_order_release);
     return replaced;
 }
 bool interactive_capture_bundle_active() {
@@ -1970,26 +2234,6 @@ size_t common_prefix_bytes(const std::string& a, const std::string& b) {
     size_t i = 0;
     while (i < n && a[i] == b[i]) ++i;
     return i;
-}
-
-// Renders a guest log line unambiguously. An exact-match failure is very often caused by a byte the
-// operator cannot see — a trailing tab, a stray CR, a BOM — so printing the line raw would reproduce
-// the very invisibility this report exists to remove.
-std::string escape_log_line(const std::string& text) {
-    std::string out;
-    out.reserve(text.size() + 8);
-    for (const unsigned char ch : text) {
-        if (ch == '\\') {
-            out += "\\\\";
-        } else if (ch >= 0x20 && ch < 0x7f) {
-            out.push_back(static_cast<char>(ch));
-        } else {
-            char buf[5];
-            std::snprintf(buf, sizeof(buf), "\\x%02x", ch);
-            out += buf;
-        }
-    }
-    return out;
 }
 
 bool automatic_capture_bundle_gate_conflicts(const char* selected_gate) {
@@ -2056,13 +2300,7 @@ struct GuestLogCaptureBundleState {
                          kGuestLogCaptureMaxLineBytes);
             return;
         }
-        if (const char* limit = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
-            char* end = nullptr;
-            errno = 0;
-            const unsigned long parsed = std::strtoul(limit, &end, 0);
-            if (!errno && end != limit && end && !*end && parsed <= UINT32_MAX)
-                max_mb = static_cast<uint32_t>(parsed);
-        }
+        max_mb = resolve_capture_bundle_max_mb();
         line.reserve(std::min<size_t>(marker.size() + 16, kGuestLogCaptureMaxLineBytes));
         enabled = true;
     }
@@ -2247,7 +2485,28 @@ void report_unfired_automatic_capture_gates() {
             only_value = value;
         }
     }
-    if (!configured) return;   // nothing was asked for; silence is the correct answer
+    if (!configured) {
+        // PROSPER_CAPTURE_BUNDLE alone is a COMPLETE no-op (#2565): it is only ever read as the
+        // destination of one of the three gates above, and F9 derives its own path from
+        // PROSPER_CAPTURE_DIR. "I set the capture path, why is there no bundle?" is a plausible
+        // first attempt, and until now it produced no message anywhere. Say nothing when something
+        // did arm — an interactive or scheduled grab that used the path is not a misconfiguration.
+        const char* only_path = std::getenv("PROSPER_CAPTURE_BUNDLE");
+        if (only_path && *only_path &&
+            !g_interactive_capture_ever_armed.load(std::memory_order_acquire))
+            std::fprintf(stderr,
+                         "[grab] PROSPER_CAPTURE_BUNDLE=\"%s\" was set but nothing ever armed a "
+                         "capture, and NO BUNDLE WAS WRITTEN. On its own this variable only names a "
+                         "DESTINATION; it arms nothing. Add one gate: "
+                         "PROSPER_CAPTURE_BUNDLE_AT_PRESENT=N, "
+                         "PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG=<exact guest line>, or "
+                         "PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=<path>; or press F9 in prosper-app "
+                         "(or schedule it with PROSPER_GRAB_BUNDLE_AT_FRAME / "
+                         "PROSPER_GRAB_BUNDLE_AFTER_MS), which name their output through "
+                         "PROSPER_CAPTURE_DIR rather than through this variable\n",
+                         only_path);
+        return;   // nothing else was asked for; silence is the correct answer
+    }
 
     // Reported here as well as at arm time, because a configuration rejected at startup is easy to
     // miss in a route's log and its only other symptom is the same missing file.
@@ -2314,13 +2573,154 @@ void report_unfired_automatic_capture_gates() {
 }
 
 namespace {
+// The semantic selectors, in the order the request parses them. Read at exit purely to quote back
+// what was configured: every one of these is RUN-LOCAL (extents and program addresses both), which
+// is exactly why a selector carried over from an earlier run silently matches nothing.
+constexpr const char* kTimelineSemanticSelectors[] = {
+    "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM",
+    "PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX",
+    "PROSPER_GPU_TIMELINE_CAPTURE_MIN_DRAWS",
+    "PROSPER_GPU_TIMELINE_CAPTURE_MAX_DRAWS",
+    "PROSPER_GPU_TIMELINE_CAPTURE_MIN_DISPATCHES",
+    "PROSPER_GPU_TIMELINE_CAPTURE_MAX_DISPATCHES",
+    "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_VERTEX_PROGRAM",
+    "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_FRAGMENT_PROGRAM",
+    "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM",
+    "PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM",
+    "PROSPER_GPU_TIMELINE_CAPTURE_WHEN_DISPATCH_DIM",
+};
+}  // namespace
+
+std::string format_timeline_capture_selector_miss(const TimelineCaptureSelectorMiss& miss) {
+    std::string out =
+        "[timeline] the detailed capture selector never matched a submit; NO .prgcap WAS WRITTEN.\n";
+    out += "[timeline]   PROSPER_GPU_TIMELINE_CAPTURE=\"" + escape_log_line(miss.capture_path) +
+           "\" PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT=\"" + escape_log_line(miss.submit_spec) + "\"\n";
+    for (const auto& [name, value] : miss.semantic)
+        out += "[timeline]   " + name + "=\"" + escape_log_line(value) + "\"\n";
+
+    // Ordered by which fault makes the others unobservable: a timeline that was never recording
+    // means no submit was judged no matter what else is set, and no submits at all means the same.
+    if (!miss.timeline_requested) {
+        out += "[timeline]   PROSPER_GPU_TIMELINE is NOT set, so the recorder never ran and NO "
+               "submit was ever judged against this selector. The detailed capture requires it: "
+               "record_gpu_timeline_submit returns before reaching the selector when it is absent. "
+               "The submit hook itself was reached " +
+               std::to_string(miss.submit_hook_reached) + " time(s).\n";
+        return out;
+    }
+    if (!miss.submit_hook_reached) {
+        out += "[timeline]   the run produced no GPU submits at all, so the selector was never "
+               "tested. That is a routing or boot fault, not a selector fault.\n";
+        return out;
+    }
+    if (!miss.request_built) {
+        out += "[timeline]   the capture request was never built: " +
+               std::to_string(miss.submit_hook_reached) +
+               " submit(s) reached the hook but none reached the recorder, so the timeline writer "
+               "was never opened (an unwritable PROSPER_GPU_TIMELINE path reports its own error "
+               "above).\n";
+        return out;
+    }
+    if (!miss.request_valid) {
+        out += "[timeline]   the capture request was REJECTED when it was built; the [timeline] "
+               "line naming the rejected value appears earlier in this log. Nothing was ever armed, "
+               "so no submit could match.\n";
+        return out;
+    }
+    if (miss.after_compute_gated && !miss.after_compute_armed) {
+        out += "[timeline]   the AFTER_COMPUTE_PROGRAM phase gate never armed, so the endpoint "
+               "predicate was never reached: " +
+               std::to_string(miss.phase_submits_observed) +
+               " submit(s) were scanned for that compute program and none contained it. Program "
+               "addresses are RUN-LOCAL — re-derive this one from THIS run before re-using it.\n";
+        return out;
+    }
+    out += "[timeline]   " + std::to_string(miss.submits_examined) +
+           " submit(s) were judged against the selector; the last one judged was submit " +
+           std::to_string(miss.last_submit_examined) + ".\n";
+    if (!miss.submits_examined) {
+        out += "[timeline]   none was judged at all, so the selector was never exercised.\n";
+        return out;
+    }
+    if (!miss.semantic_selector) {
+        // A bare ordinal selector: the only way to miss is to stop short of it. Note that some of
+        // the variables quoted above do NOT make the selector semantic on their own (a program
+        // address of 0, or a draw-index range with no target extent), which is why this reads the
+        // request's own verdict rather than inferring it from the environment.
+        out += "[timeline]   this is an ORDINAL selector, and the run never reached that submit "
+               "number. Run the route longer, or pick an ordinal at or below " +
+               std::to_string(miss.last_submit_examined) +
+               ". Submit ordinals are RUN-LOCAL: re-derive it from this run's own timeline with "
+               "`gpu_timeline <file> --records`.\n";
+        return out;
+    }
+    out += "[timeline]   every judged submit satisfied the ordinal floor and none satisfied every "
+           "semantic predicate above. Extents, draw indices and program addresses are all "
+           "RUN-LOCAL: re-derive the selector against THIS run's timeline with "
+           "`gpu_timeline <file> --signatures` / `--select` rather than re-using one from an "
+           "earlier run. `--select` exits nonzero when nothing matches, so it answers this "
+           "offline in seconds.\n";
+    return out;
+}
+
+bool timeline_capture_selector_miss_snapshot(TimelineCaptureSelectorMiss& out) {
+    const char* path = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE");
+    const char* submit = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
+    // Either variable alone is already a configuration the operator meant; the request rejects that
+    // pairing and this report has to cover it too, not only the complete one.
+    if ((!path || !*path) && (!submit || !*submit)) return false;
+    if (g_timeline_detail_submits_captured.load(std::memory_order_acquire)) return false;
+    out.capture_path = path ? path : "";
+    out.submit_spec = submit ? submit : "";
+    out.semantic.clear();
+    for (const char* name : kTimelineSemanticSelectors)
+        if (const char* value = std::getenv(name))
+            if (*value) out.semantic.emplace_back(name, value);
+    const char* timeline = std::getenv("PROSPER_GPU_TIMELINE");
+    out.timeline_requested = timeline && *timeline;
+    out.request_built = g_timeline_request_built.load(std::memory_order_acquire);
+    out.request_valid = g_timeline_request_valid.load(std::memory_order_acquire);
+    out.semantic_selector = g_timeline_selector_semantic.load(std::memory_order_acquire);
+    const char* after_compute = std::getenv("PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM");
+    // "0" is the documented way to spell "no phase gate", and the request treats it as such.
+    out.after_compute_gated = after_compute && *after_compute &&
+                              std::strcmp(after_compute, "0") && std::strcmp(after_compute, "0x0");
+    out.after_compute_armed = g_timeline_after_compute_armed.load(std::memory_order_acquire);
+    out.submit_hook_reached = g_timeline_submit_hook_reached.load(std::memory_order_relaxed);
+    out.phase_submits_observed = g_timeline_phase_submits_observed.load(std::memory_order_relaxed);
+    out.submits_examined = g_timeline_selector_submits_examined.load(std::memory_order_relaxed);
+    out.last_submit_examined =
+        g_timeline_selector_last_submit_examined.load(std::memory_order_relaxed);
+    out.detail_submits_captured =
+        g_timeline_detail_submits_captured.load(std::memory_order_relaxed);
+    return true;
+}
+
+void report_unfired_timeline_capture_selector() {
+    TimelineCaptureSelectorMiss miss;
+    if (!timeline_capture_selector_miss_snapshot(miss)) return;
+    std::fputs(format_timeline_capture_selector_miss(miss).c_str(), stderr);
+}
+
+namespace {
 // Registered at load rather than from a gate's constructor: two of the three gate states are built
 // lazily on the first present, so a run that never presents would register nothing — and that is
 // exactly the run whose silence is hardest to explain. The handler reads only the environment,
 // namespace-scope atomics, and the deliberately leaked guest-log state, so it stays valid after
 // every static destructor has run.
 [[maybe_unused]] const int g_automatic_capture_gate_exit_report = [] {
+    // FIRST, and before anything is registered: a malformed PROSPER_CAPTURE_MAX_SUBMITS ends the
+    // process here (#2565). Its fallback is "uncapped", so continuing would remove the only content
+    // bound on the run, and doing it at load means the operator learns before the route starts
+    // rather than after a multi-gigabyte capture is already underway.
+    capture_max_submits();
     std::atexit(&report_unfired_automatic_capture_gates);
+    // The detailed timeline selector is a separate family with its own state, so it gets its own
+    // handler rather than being folded into the gate report (#2564). Registered at load for the
+    // same reason: its request object is built lazily on the first recorded submit, and a run that
+    // never records one is exactly the run whose silence is hardest to explain.
+    std::atexit(&report_unfired_timeline_capture_selector);
     return 0;
 }();
 
@@ -2346,13 +2746,7 @@ struct CaptureBundleTriggerFileState {
         }
         trigger_path = trigger_env;
         bundle_path = bundle_env;
-        if (const char* limit = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
-            char* end = nullptr;
-            errno = 0;
-            const unsigned long parsed = std::strtoul(limit, &end, 0);
-            if (!errno && end != limit && end && !*end && parsed <= UINT32_MAX)
-                max_mb = static_cast<uint32_t>(parsed);
-        }
+        max_mb = resolve_capture_bundle_max_mb();
         enabled = true;
     }
 };
@@ -2466,13 +2860,13 @@ void interactive_frame_bundle_on_submit(const GpuState& state, uint64_t submit_n
     // full cost of every post-cap submit, and — worse — a post-cap capture FAILURE set `b.failed`
     // and threw away the already-valid capped bundle, which is precisely the outcome the cap exists
     // to prevent.
-    static const uint64_t max_submits = [] {
-        const char* spec = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
-        if (!spec || !*spec) return uint64_t{0};
-        char* end = nullptr;
-        const unsigned long long parsed = std::strtoull(spec, &end, 0);
-        return (end && !*end && parsed) ? static_cast<uint64_t>(parsed) : uint64_t{0};
-    }();
+    //
+    // The parse is strict and REFUSES rather than substituting (#2565): `4O` (letter O) and `40 `
+    // (trailing space) used to yield 0, and 0 means UNCAPPED — so a typo silently removed the cap on
+    // exactly the run the cap exists for, and the symptom was an aborted multi-gigabyte capture
+    // rather than a message. capture_max_submits() has already ended the process at load if the
+    // value was not a submit count, so by here it is either a real cap or genuinely unset.
+    const uint64_t max_submits = capture_max_submits();
     // The whole append policy runs through frame_bundle_append_submit(), with everything below
     // supplied as the injected capture step. That is what makes the ORDERING regressable: a test
     // hands in a step that records whether it ran, so moving the cap check below the capture inside
@@ -2683,6 +3077,10 @@ bool take_interactive_grab_outcome(InteractiveGrabOutcome& out) {
 }
 
 void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
+    // Latched before every early return, so the exit report can separate "the run produced no GPU
+    // submits at all" from "it submitted plenty and the timeline was never recording" (#2564). Those
+    // have opposite fixes and used to produce the identical observation: a missing .prgcap.
+    g_timeline_submit_hook_reached.fetch_add(1, std::memory_order_relaxed);
     interactive_frame_bundle_on_submit(state, submit_no);
     if (!gpu_timeline_requested()) return;
     GpuTimelineWriter* writer = runtime_recorder().get();
@@ -2866,6 +3264,13 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
                      request.bundle_start_target_min_index,
                      request.bundle_start_target_max_index);
     }
+    // Counted here rather than at the top of the function: this is the submit set the endpoint
+    // predicate actually judged, which is what separates "nothing matched" from "the predicate was
+    // never reached" — the after-compute phase gate returns above without ever getting here (#2564).
+    if (request.valid) {
+        g_timeline_selector_submits_examined.fetch_add(1, std::memory_order_relaxed);
+        g_timeline_selector_last_submit_examined.store(submit_no, std::memory_order_relaxed);
+    }
     const bool capture_endpoint = request.valid &&
         runtime_capture_endpoint_matches(request, submit, state);
     const uint64_t bundle_first = request.bundle_depth > request.submit_no
@@ -2985,6 +3390,7 @@ void record_gpu_timeline_submit(const GpuState& state, uint64_t submit_no) {
     GpuCaptureFile capture;
     if (!request.bundle_path.empty()) begin_runtime_capture_bundle();
     request.detail_submits_captured.fetch_add(1, std::memory_order_relaxed);
+    g_timeline_detail_submits_captured.fetch_add(1, std::memory_order_relaxed);
     const auto capture_started = std::chrono::steady_clock::now();
     std::fprintf(stderr, "[timeline] submit %llu detailed capture starting: semantic-draws=%zu "
                          "semantic-dispatches=%zu metadata-only=%s\n",
@@ -3301,14 +3707,7 @@ void record_gpu_timeline_present(uint64_t present_count, int buffer_index, int64
                 config.path = path;
                 config.present = wanted;
                 config.valid = true;
-                if (const char* limit = std::getenv("PROSPER_CAPTURE_BUNDLE_MAX_MB")) {
-                    char* limit_end = nullptr;
-                    errno = 0;
-                    const unsigned long parsed = std::strtoul(limit, &limit_end, 0);
-                    if (!errno && limit_end != limit && limit_end && !*limit_end &&
-                        parsed <= UINT32_MAX)
-                        config.max_mb = static_cast<uint32_t>(parsed);
-                }
+                config.max_mb = resolve_capture_bundle_max_mb();
             }
         }
         return config;

--- a/prosper/src/gpu/gpu_timeline.hpp
+++ b/prosper/src/gpu/gpu_timeline.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace prosper::gpu {
@@ -354,6 +355,96 @@ bool guest_log_capture_miss_snapshot(GuestLogCaptureMiss& out);
 // capture. Registered with std::atexit at load time, so a run that silently produced no bundle now
 // says so; exported so the same text can be asserted by a test.
 void report_unfired_automatic_capture_gates();
+
+// ---- capture tunables (#2565) ----------------------------------------------------------------
+// A malformed capture tunable used to substitute a DIFFERENT policy in silence. That is the milder
+// relative of #1684 — not "armed and never fired" but "configured and quietly ignored" — and it is
+// invisible the same way, because the run still completes and still produces *a* result.
+//
+// The parse is STRICT: the whole value must be a number with nothing around it, not even a space.
+// `PROSPER_CAPTURE_MAX_SUBMITS=40 ` and `=4O` (letter O) are rejected rather than accepted-as-zero.
+enum class CaptureTunableStatus {
+    Unset,        // absent or empty: the variable was not asked for at all
+    Accepted,     // a whole number inside the accepted range
+    Malformed,    // not a whole number, or trailing bytes (including whitespace)
+    BelowRange,   // parsed, below the minimum this tunable accepts
+    AboveRange,   // parsed, above the maximum this tunable accepts
+};
+struct CaptureTunableParse {
+    CaptureTunableStatus status = CaptureTunableStatus::Unset;
+    uint64_t value = 0;   // what parsed; meaningful for Accepted, BelowRange and AboveRange
+};
+CaptureTunableParse parse_capture_tunable(const char* raw, uint64_t lo, uint64_t hi);
+
+// The interactive/automatic whole-frame bundle budget, in MiB. `request_interactive_capture_bundle`
+// reads 0 as "keep the built-in default" and clamps anything else into [min, max]; both constants
+// live here so a message can never claim a bound the code does not enforce.
+inline constexpr uint32_t kInteractiveBundleDefaultMb = 2048;
+inline constexpr uint32_t kInteractiveBundleMinMb = 64;
+inline constexpr uint32_t kInteractiveBundleMaxMb = 3072;
+// The capture window width, in presents.
+inline constexpr uint32_t kCaptureFramesDefault = 1;
+inline constexpr uint32_t kCaptureFramesMin = 1;
+inline constexpr uint32_t kCaptureFramesMax = 240;
+
+// Pure: the exact `[grab]` text for a rejected value of each substituting tunable, empty when the
+// value is acceptable or unset. Each one names the variable, the rejected value with non-printable
+// bytes escaped (a trailing space is precisely the typo nobody can see), the accepted range, and —
+// the part that matters — the value ACTUALLY IN FORCE, so the run can never be described as
+// "configured" when it is not.
+std::string format_capture_bundle_max_mb_notice(const char* raw);
+std::string format_capture_frames_notice(const char* raw);
+// PROSPER_CAPTURE_MAX_SUBMITS REFUSES instead of substituting, because its fallback inverts the
+// caller's intent: 0 means UNCAPPED, so a typo removes the only content bound on a capture that has
+// reached multiple gigabytes — on exactly the runs the cap exists for. Empty when acceptable.
+std::string format_capture_max_submits_refusal(const char* raw);
+
+// The values actually in force. Both report their substitution on stderr the first time they are
+// resolved, and are otherwise silent. `resolve_capture_bundle_max_mb` returns 0 for "keep the
+// built-in default", exactly as the three gate constructors previously encoded it.
+uint32_t resolve_capture_bundle_max_mb();
+uint32_t resolve_capture_frames();
+// The submit cap in force; 0 means uncapped, which is expressible ONLY by leaving the variable
+// unset. A malformed or zero value has already ended the process at load with a nonzero status.
+uint64_t capture_max_submits();
+
+// ---- detailed timeline capture selector (#2564) -----------------------------------------------
+// `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT` and the semantic selectors around it had the same silent
+// shape #1684 fixed for the bundle gates, one selector family over: if the run never reached the
+// ordinal, or no submit ever satisfied the semantic predicates, nothing was printed. The run exited
+// 0 and the only evidence was a missing `.prgcap`. The `detail_submits_captured` counter that does
+// exist reaches the timeline FILE and never stderr.
+//
+// Every field is either read from the environment at exit or mirrored into a namespace-scope atomic,
+// never taken from the lazily built request object: two of the paths that build it may never run,
+// and an atexit handler registered first runs after every static destructor.
+struct TimelineCaptureSelectorMiss {
+    std::string capture_path;      // PROSPER_GPU_TIMELINE_CAPTURE, as configured
+    std::string submit_spec;       // PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT, as configured
+    // Semantic selectors in force, as name -> raw value. Printed verbatim so the operator sees the
+    // extents and addresses they actually asked for; both are RUN-LOCAL and must be re-derived.
+    std::vector<std::pair<std::string, std::string>> semantic;
+    bool timeline_requested = false;   // PROSPER_GPU_TIMELINE — without it no submit is ever judged
+    bool request_built = false;        // the request object was constructed at least once
+    bool request_valid = false;        // ... and its configuration parsed
+    bool semantic_selector = false;    // matching is by CONTENT, not by the submit ordinal alone
+    bool after_compute_gated = false;  // an AFTER_COMPUTE_PROGRAM phase gate stands in front
+    bool after_compute_armed = false;  // ... and it armed
+    uint64_t submit_hook_reached = 0;  // record_gpu_timeline_submit entries, before any early return
+    uint64_t phase_submits_observed = 0;  // submits examined for the phase program while unarmed
+    uint64_t submits_examined = 0;     // submits the endpoint predicate actually judged
+    uint64_t last_submit_examined = 0; // the ordinal of the last one it judged
+    uint64_t detail_submits_captured = 0;  // >0 means the selector matched; no report is then due
+};
+// Pure: the exact stderr text for a selector that never captured. Reports "the ordinal was never
+// reached" and "nothing matched the semantic predicates" DISTINCTLY, because the fixes differ — run
+// longer versus re-derive the selector against this run's own timeline.
+std::string format_timeline_capture_selector_miss(const TimelineCaptureSelectorMiss& miss);
+// Snapshot of the live selector. True when a report is due: a selector was configured and no
+// detailed capture was ever taken.
+bool timeline_capture_selector_miss_snapshot(TimelineCaptureSelectorMiss& out);
+// Registered with std::atexit at load, next to report_unfired_automatic_capture_gates().
+void report_unfired_timeline_capture_selector();
 // Marks bytes omitted by a bounded stdout adapter. It deliberately discards through the next observed
 // line ending so an unobserved suffix can cause only a missed match, never a false exact-line match.
 void observe_guest_log_capture_gap();

--- a/prosper/tests/test_capture_tunables.cpp
+++ b/prosper/tests/test_capture_tunables.cpp
@@ -1,0 +1,526 @@
+// Capture tunables and the detailed timeline selector must never fail in silence (#2564, #2565).
+// Pure/offline: no guest, no Vulkan device.
+//
+// Two defects with one shape, both siblings of #1684. A malformed tunable used to substitute a
+// DIFFERENT policy without a word — and for PROSPER_CAPTURE_MAX_SUBMITS the substitute is UNCAPPED,
+// the exact inverse of what a cap is for, on precisely the runs that need it. A detailed timeline
+// selector that never matched used to say nothing at all: the run exited 0 and the only evidence was
+// a missing .prgcap.
+//
+// Two kinds of arm here, and the split is the point:
+//   * in-process checks call the formatters and resolvers directly. They can assert the TEXT and the
+//     VALUE IN FORCE, and they are structurally unable to see whether anything is registered with
+//     std::atexit or validated at load — the reporter is being called by hand.
+//   * child-process arms spawn this same binary and let it merely return from main (or, for
+//     PROSPER_CAPTURE_MAX_SUBMITS, never reach main at all). Only these can see a missing
+//     registration or a missing load-time refusal, which is what #1684's arm C proved the hard way.
+#include "../src/gpu/gpu_timeline.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include "test_scratch.h"
+#ifdef _WIN32
+#include <io.h>
+#else
+#include <unistd.h>
+#endif
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+static void set_test_env(const char* name, const std::string& value) {
+#ifdef _WIN32
+    _putenv_s(name, value.c_str());
+#else
+    setenv(name, value.c_str(), 1);
+#endif
+}
+
+static void clear_test_env(const char* name) {
+#ifdef _WIN32
+    _putenv_s(name, "");
+#else
+    unsetenv(name);
+#endif
+}
+
+static bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+static std::string slurp(const std::filesystem::path& path) {
+    std::string text;
+    if (FILE* in = std::fopen(path.string().c_str(), "rb")) {
+        char buf[4096];
+        size_t got = 0;
+        while ((got = std::fread(buf, 1, sizeof(buf), in)) > 0) text.append(buf, got);
+        std::fclose(in);
+    }
+    return text;
+}
+
+// Runs `body` with stderr redirected to a scratch file and returns everything it wrote. Asserting on
+// a returned string alone would leave the DELIVERY untested, and an undelivered report is exactly
+// the defect: from the caller's side an empty report and an unreachable one look identical.
+static int stream_fd(FILE* stream) {
+#ifdef _WIN32
+    return _fileno(stream);
+#else
+    return fileno(stream);
+#endif
+}
+
+template <typename Body>
+static std::string capture_stderr(const std::filesystem::path& path, Body body) {
+    // dup/dup2 rather than freopen: there is no portable name to reopen the original stderr with,
+    // and under ctest it is a pipe rather than a terminal.
+#ifdef _WIN32
+    const int saved = _dup(stream_fd(stderr));
+#else
+    const int saved = dup(stream_fd(stderr));
+#endif
+    FILE* sink = std::fopen(path.string().c_str(), "w");
+    if (!sink || saved < 0) { if (sink) std::fclose(sink); return "<redirect failed>"; }
+    std::fflush(stderr);
+#ifdef _WIN32
+    _dup2(stream_fd(sink), stream_fd(stderr));
+#else
+    dup2(stream_fd(sink), stream_fd(stderr));
+#endif
+    body();
+    std::fflush(stderr);
+#ifdef _WIN32
+    _dup2(saved, stream_fd(stderr));
+    _close(saved);
+#else
+    dup2(saved, stream_fd(stderr));
+    close(saved);
+#endif
+    std::fclose(sink);
+    return slurp(path);
+}
+
+// Spawns this same binary in `mode`, redirecting the child's stderr to a BARE filename in the
+// current directory. ctest runs a test in the directory the binary was built into, and neither a
+// CMake target name nor this filename contains a space or a separator, so the whole command line
+// needs no quoting at all — which is the question two Windows CI runs were lost to on #1684.
+struct ChildRun {
+    int rc = -1;
+    std::string stderr_text;
+    std::string command;
+};
+static ChildRun run_child(const char* argv0, const std::string& mode, const std::string& err_name) {
+    ChildRun out;
+    const std::string prefix =
+#ifdef _WIN32
+        ".\\";
+#else
+        "./";
+#endif
+    const std::string self = std::filesystem::path(argv0).filename().string();
+    out.command = prefix + self + " " + mode + " 2>" + err_name;
+    if (!std::system(nullptr)) std::printf("  [note] no command processor available\n");
+    out.rc = std::system(out.command.c_str());
+    out.stderr_text = slurp(err_name);
+    std::error_code ec;
+    std::filesystem::remove(err_name, ec);
+    return out;
+}
+
+int main(int argc, char** argv) {
+    // ---- child modes ---------------------------------------------------------------------------
+    // Neither of these calls a reporter. Anything on the child's stderr can only have come from an
+    // exit handler registered at load, or from the load-time refusal — the halves an in-process
+    // assertion cannot distinguish from their absence.
+    if (argc > 1 && std::strcmp(argv[1], "--child-submits") == 0) {
+        std::printf("  [child] started (submits)\n");
+        std::fflush(stdout);
+        for (uint64_t n = 1; n <= 12; ++n) {
+            begin_gpu_timeline_submit(n);
+            record_gpu_timeline_submit(GpuState{}, n);
+        }
+        return 0;
+    }
+    if (argc > 1 && std::strcmp(argv[1], "--child-bare") == 0) {
+        // Reaching this line is itself an observation, so it is witnessed on BOTH streams: stdout
+        // lands inline in the ctest log ("did the spawn happen at all?", which a failed spawn and a
+        // missing exit report otherwise answer identically), and stderr lands in the captured file,
+        // where the PROSPER_CAPTURE_MAX_SUBMITS arm asserts its ABSENCE — the refusal is supposed to
+        // end the process during static initialization, before main runs a single line.
+        std::printf("  [child] started (bare)\n");
+        std::fflush(stdout);
+        std::fprintf(stderr, "[child] reached main\n");
+        std::fflush(stderr);
+        return 0;
+    }
+
+    std::printf("== test_capture_tunables ==\n");
+    const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto scratch = prosper_test::test_scratch_dir();
+    const auto stderr_path = scratch / ("prosper-capture-tunables-" + std::to_string(nonce) + ".err");
+    const std::string child_err = "captun-child-" + std::to_string(nonce) + ".stderr";
+    const auto bundle_path =
+        scratch / ("prosper-capture-tunables-" + std::to_string(nonce) + ".prgbundle");
+
+    // A stale gate in the ambient environment would arm something and silence the reports below.
+    clear_test_env("PROSPER_CAPTURE_BUNDLE");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AT_PRESENT");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE");
+    clear_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB");
+    clear_test_env("PROSPER_CAPTURE_FRAMES");
+    clear_test_env("PROSPER_CAPTURE_MAX_SUBMITS");
+    clear_test_env("PROSPER_GPU_TIMELINE");
+    clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE");
+    clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
+
+    // ---- the strict parse (#2565) --------------------------------------------------------------
+    {
+        CHECK(parse_capture_tunable(nullptr, 1, 100).status == CaptureTunableStatus::Unset &&
+                  parse_capture_tunable("", 1, 100).status == CaptureTunableStatus::Unset,
+              "an absent or empty value is Unset, not a rejection");
+        const auto ok = parse_capture_tunable("40", 1, 100);
+        CHECK(ok.status == CaptureTunableStatus::Accepted && ok.value == 40,
+              "a whole decimal number is accepted at its own value");
+        CHECK(parse_capture_tunable("0x28", 1, 100).value == 40,
+              "hexadecimal is accepted, as every other capture tunable already spells addresses");
+        CHECK(parse_capture_tunable("4O", 1, 100).status == CaptureTunableStatus::Malformed,
+              "a letter O in place of a zero is REJECTED, not read as 4");
+        CHECK(parse_capture_tunable("40 ", 1, 100).status == CaptureTunableStatus::Malformed,
+              "a trailing space is rejected: the whole value must be the number");
+        CHECK(parse_capture_tunable(" 40", 1, 100).status == CaptureTunableStatus::Malformed,
+              "a leading space is rejected too, so the two spellings cannot disagree");
+        // strtoull NEGATES a leading '-' into a huge positive number. Left unchecked, `-1` would be
+        // accepted as 18446744073709551615 — a cap so large it is indistinguishable from uncapped,
+        // which is the very substitution this change exists to prevent.
+        CHECK(parse_capture_tunable("-1", 1, UINT64_MAX).status == CaptureTunableStatus::Malformed,
+              "a negative value is rejected rather than wrapping to an enormous positive cap");
+        CHECK(parse_capture_tunable("10", 64, 3072).status == CaptureTunableStatus::BelowRange &&
+                  parse_capture_tunable("10", 64, 3072).value == 10,
+              "a value under the minimum is BelowRange and still reports what was asked for");
+        CHECK(parse_capture_tunable("5000", 64, 3072).status == CaptureTunableStatus::AboveRange,
+              "a value over the maximum is AboveRange");
+    }
+
+    // ---- PROSPER_CAPTURE_MAX_SUBMITS refuses; it does not substitute ---------------------------
+    {
+        CHECK(format_capture_max_submits_refusal(nullptr).empty() &&
+                  format_capture_max_submits_refusal("40").empty(),
+              "an unset or valid cap produces no refusal");
+        const std::string typo = format_capture_max_submits_refusal("4O");
+        CHECK(contains(typo, "PROSPER_CAPTURE_MAX_SUBMITS=\"4O\""),
+              "the refusal quotes the exact rejected value");
+        CHECK(contains(typo, "REFUSING TO RUN") && contains(typo, "UNCAPPED"),
+              "the refusal states both that it refuses and WHY the fallback is unacceptable");
+        // The whole point of refusing rather than defaulting: there is no honest substitute here,
+        // so the refusal must not borrow the phrasing of the tunables that DO fall back. "<x> is in
+        // force" is the substituting notices' contract; a refusal that used it would be describing
+        // a run that is not going to happen.
+        CHECK(!contains(typo, "in force"),
+              "the refusal names no value in force, because it substitutes none");
+        CHECK(!format_capture_max_submits_refusal("0").empty(),
+              "zero is refused too: 'uncapped' is expressible only by leaving the variable unset");
+        CHECK(contains(format_capture_max_submits_refusal("40 "), "40\\x20"),
+              "an invisible trailing space is ESCAPED, not reproduced invisibly");
+    }
+
+    // ---- PROSPER_CAPTURE_BUNDLE_MAX_MB reports and falls back ----------------------------------
+    {
+        CHECK(format_capture_bundle_max_mb_notice(nullptr).empty() &&
+                  format_capture_bundle_max_mb_notice("512").empty(),
+              "an unset or in-range budget produces no notice");
+        const std::string typo = format_capture_bundle_max_mb_notice("2O48");
+        CHECK(contains(typo, "PROSPER_CAPTURE_BUNDLE_MAX_MB=\"2O48\""),
+              "the notice names the variable and quotes the rejected value");
+        CHECK(contains(typo, std::to_string(kInteractiveBundleDefaultMb) + " MiB") &&
+                  contains(typo, "DISCARDED"),
+              "the notice states the budget actually in force and that the raise was discarded");
+        CHECK(contains(format_capture_bundle_max_mb_notice("10"),
+                       std::to_string(kInteractiveBundleMinMb) + " MiB minimum"),
+              "a below-range budget reports the minimum it was raised to");
+        CHECK(contains(format_capture_bundle_max_mb_notice("5000"),
+                       std::to_string(kInteractiveBundleMaxMb) + " MiB maximum"),
+              "an above-range budget reports the maximum it was capped at");
+        // 0 is this variable's long-standing sentinel for "keep the built-in default" — honouring
+        // it is not a substitution, so it must draw neither a notice nor a changed budget.
+        CHECK(format_capture_bundle_max_mb_notice("0").empty(),
+              "zero is the documented 'keep the default' sentinel and is not reported as a fault");
+    }
+
+    // ---- PROSPER_CAPTURE_FRAMES reports and falls back ------------------------------------------
+    {
+        CHECK(format_capture_frames_notice(nullptr).empty() &&
+                  format_capture_frames_notice("16").empty(),
+              "an unset or in-range window produces no notice");
+        const std::string typo = format_capture_frames_notice("abc");
+        CHECK(contains(typo, "PROSPER_CAPTURE_FRAMES=\"abc\""),
+              "the notice names the variable and quotes the rejected value");
+        // This is the sharpest case of the family: widening the window is the remedy the empty-window
+        // message itself prints, so a mistyped remedy silently reproduced the original failure.
+        CHECK(contains(typo, "window had no submits"),
+              "the notice connects the discarded value to the failure it was meant to fix");
+        CHECK(contains(format_capture_frames_notice("300"),
+                       "clamped to " + std::to_string(kCaptureFramesMax)),
+              "an above-range window reports the width it was clamped to");
+    }
+
+    // ---- PROSPER_CAPTURE_BUNDLE alone is a complete no-op, and now says so ----------------------
+    // Deliberately BEFORE anything arms a capture: a run that did arm one is not misconfigured, and
+    // the suppression is checked immediately afterwards.
+    {
+        set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+        const std::string alone =
+            capture_stderr(stderr_path, [] { report_unfired_automatic_capture_gates(); });
+        CHECK(contains(alone, "PROSPER_CAPTURE_BUNDLE") && contains(alone, "arms nothing"),
+              "PROSPER_CAPTURE_BUNDLE set with no gate is reported instead of doing nothing");
+        CHECK(contains(alone, "PROSPER_CAPTURE_BUNDLE_AT_PRESENT") &&
+                  contains(alone, "PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG") &&
+                  contains(alone, "PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE"),
+              "the report names every gate that would actually arm one");
+        clear_test_env("PROSPER_CAPTURE_BUNDLE");
+        const std::string quiet =
+            capture_stderr(stderr_path, [] { report_unfired_automatic_capture_gates(); });
+        CHECK(quiet.empty(), "with nothing configured at all the report stays silent");
+    }
+
+    // ---- the frames notice reaches stderr through the REAL arm path -----------------------------
+    // First call of resolve_capture_frames() in this process, so it also proves the notice is
+    // delivered rather than merely formatted. It latches "something armed", which is why the
+    // PROSPER_CAPTURE_BUNDLE-alone arm above had to run first.
+    {
+        set_test_env("PROSPER_CAPTURE_FRAMES", "abc");
+        const std::string armed = capture_stderr(stderr_path, [&] {
+            (void)request_interactive_capture_bundle(bundle_path.string());
+        });
+        CHECK(contains(armed, "PROSPER_CAPTURE_FRAMES=\"abc\""),
+              "arming a capture with a malformed window width says so on stderr");
+        const std::string again = capture_stderr(stderr_path, [&] {
+            (void)request_interactive_capture_bundle(bundle_path.string());
+        });
+        CHECK(again.empty(), "the notice is printed once, not once per arm");
+        clear_test_env("PROSPER_CAPTURE_FRAMES");
+        CHECK(resolve_capture_frames() == kCaptureFramesDefault,
+              "an unset window resolves to the default");
+        set_test_env("PROSPER_CAPTURE_FRAMES", "300");
+        CHECK(resolve_capture_frames() == kCaptureFramesMax,
+              "an above-range window resolves to the clamped value, unchanged from before");
+        set_test_env("PROSPER_CAPTURE_FRAMES", "abc");
+        CHECK(resolve_capture_frames() == kCaptureFramesDefault,
+              "a malformed window still falls back to the default: only the silence changed");
+        clear_test_env("PROSPER_CAPTURE_FRAMES");
+    }
+    // With a capture armed, PROSPER_CAPTURE_BUNDLE is no longer a no-op and must NOT be reported.
+    {
+        set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+        const std::string after_arm =
+            capture_stderr(stderr_path, [] { report_unfired_automatic_capture_gates(); });
+        CHECK(after_arm.empty(),
+              "once something has armed, a set PROSPER_CAPTURE_BUNDLE is not called a no-op");
+        clear_test_env("PROSPER_CAPTURE_BUNDLE");
+    }
+
+    // ---- the budget resolver: value in force, and one notice ------------------------------------
+    {
+        set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "2O48");
+        uint32_t resolved = 0;
+        const std::string notice =
+            capture_stderr(stderr_path, [&] { resolved = resolve_capture_bundle_max_mb(); });
+        CHECK(contains(notice, "PROSPER_CAPTURE_BUNDLE_MAX_MB=\"2O48\""),
+              "resolving a malformed budget says so on stderr");
+        CHECK(resolved == 0,
+              "a malformed budget still resolves to 0 = keep the built-in default, as before");
+        set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "5000");
+        CHECK(resolve_capture_bundle_max_mb() == kInteractiveBundleMaxMb,
+              "an above-range budget resolves to the maximum");
+        set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "10");
+        CHECK(resolve_capture_bundle_max_mb() == kInteractiveBundleMinMb,
+              "a below-range budget resolves to the minimum");
+        set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "512");
+        CHECK(resolve_capture_bundle_max_mb() == 512, "an in-range budget resolves unchanged");
+        set_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB", "0");
+        CHECK(resolve_capture_bundle_max_mb() == 0,
+              "zero still resolves to 0 = keep the built-in default, not to the 64 MiB minimum");
+        clear_test_env("PROSPER_CAPTURE_BUNDLE_MAX_MB");
+    }
+
+    // ---- the cap is resolved ONCE, at load ------------------------------------------------------
+    {
+        CHECK(capture_max_submits() == 0, "an unset cap is uncapped");
+        // Setting it now must not change the answer, and must not end this process: the refusal is a
+        // load-time decision, so a value that appears mid-run is neither honoured nor fatal. The
+        // child arm below is what proves the load-time half.
+        set_test_env("PROSPER_CAPTURE_MAX_SUBMITS", "4O");
+        CHECK(capture_max_submits() == 0,
+              "the cap is resolved once at load; a later environment change does not re-open it");
+        clear_test_env("PROSPER_CAPTURE_MAX_SUBMITS");
+    }
+
+    // ---- the detailed timeline selector (#2564) -------------------------------------------------
+    {
+        TimelineCaptureSelectorMiss none;
+        CHECK(!timeline_capture_selector_miss_snapshot(none),
+              "with no selector configured there is nothing to report");
+    }
+    {
+        // The pure formatter, over the outcomes that have DIFFERENT fixes. Conflating them is what
+        // sends the next run at the wrong problem.
+        TimelineCaptureSelectorMiss miss;
+        miss.capture_path = "/w/out.prgcap";
+        miss.submit_spec = "41000";
+        miss.request_built = miss.request_valid = true;
+        miss.submit_hook_reached = 12800;
+        const std::string no_timeline = format_timeline_capture_selector_miss(miss);
+        CHECK(contains(no_timeline, "PROSPER_GPU_TIMELINE is NOT set"),
+              "a selector without PROSPER_GPU_TIMELINE is diagnosed as exactly that");
+
+        miss.timeline_requested = true;
+        miss.submits_examined = 12800;
+        miss.last_submit_examined = 12800;
+        const std::string ordinal = format_timeline_capture_selector_miss(miss);
+        CHECK(contains(ordinal, "ORDINAL selector") && contains(ordinal, "at or below 12800"),
+              "an unreached ordinal names what the run DID reach, not only what was asked for");
+        CHECK(contains(ordinal, "41000"), "the report quotes the ordinal that was demanded");
+
+        miss.semantic_selector = true;
+        miss.semantic.emplace_back("PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM", "3840x2160");
+        const std::string semantic = format_timeline_capture_selector_miss(miss);
+        CHECK(contains(semantic, "3840x2160") && contains(semantic, "RUN-LOCAL") &&
+                  contains(semantic, "--select"),
+              "a semantic miss quotes the predicate and points at re-deriving it, not at running "
+              "longer");
+        CHECK(!contains(semantic, "ORDINAL selector"),
+              "the two outcomes are reported distinctly, because their fixes differ");
+
+        TimelineCaptureSelectorMiss quiet_run;
+        quiet_run.capture_path = "/w/out.prgcap";
+        quiet_run.submit_spec = "1";
+        quiet_run.timeline_requested = true;
+        const std::string no_submits = format_timeline_capture_selector_miss(quiet_run);
+        CHECK(contains(no_submits, "no GPU submits at all"),
+              "a run that never submitted is a routing fault, and is named as one");
+
+        TimelineCaptureSelectorMiss phase;
+        phase.capture_path = "/w/out.prgcap";
+        phase.submit_spec = "1";
+        phase.timeline_requested = true;
+        phase.request_built = phase.request_valid = true;
+        phase.submit_hook_reached = 900;
+        phase.after_compute_gated = true;
+        phase.phase_submits_observed = 900;
+        const std::string unarmed = format_timeline_capture_selector_miss(phase);
+        CHECK(contains(unarmed, "phase gate never armed") && contains(unarmed, "900"),
+              "an unarmed after-compute phase gate is separated from an unmatched endpoint");
+    }
+    {
+        // The live selector, against the real submit path. One shot per process: the request object
+        // is a singleton, so this is the only configuration this process can exercise.
+        const auto timeline_path =
+            scratch / ("prosper-capture-tunables-" + std::to_string(nonce) + ".prgtl");
+        const auto capture_path =
+            scratch / ("prosper-capture-tunables-" + std::to_string(nonce) + ".prgcap");
+        set_test_env("PROSPER_GPU_TIMELINE", timeline_path.string());
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path.string());
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "41000");
+        for (uint64_t n = 1; n <= 5; ++n) {
+            begin_gpu_timeline_submit(n);
+            record_gpu_timeline_submit(GpuState{}, n);
+        }
+        TimelineCaptureSelectorMiss live;
+        CHECK(timeline_capture_selector_miss_snapshot(live),
+              "a configured selector that captured nothing is reportable");
+        CHECK(live.submit_spec == "41000" && live.request_valid,
+              "the snapshot carries the configured ordinal and the request's own verdict");
+        CHECK(live.submits_examined == 5 && live.last_submit_examined == 5,
+              "the snapshot counts the submits the selector actually judged");
+        CHECK(live.detail_submits_captured == 0, "nothing was captured, which is why a report is due");
+        const std::string delivered =
+            capture_stderr(stderr_path, [] { report_unfired_timeline_capture_selector(); });
+        CHECK(contains(delivered, "never matched a submit") && contains(delivered, "41000"),
+              "the selector report reaches stderr and names the ordinal that was demanded");
+        CHECK(contains(delivered, "at or below 5"),
+              "the delivered report states the ordinal the run actually reached");
+
+        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE");
+        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
+        const std::string silent =
+            capture_stderr(stderr_path, [] { report_unfired_timeline_capture_selector(); });
+        CHECK(silent.empty(), "with no selector configured the report says nothing at all");
+        clear_test_env("PROSPER_GPU_TIMELINE");
+        close_gpu_timeline();
+    }
+
+    // ---- the wiring: real processes that never call a reporter ----------------------------------
+    // Everything above calls the reporters by hand and therefore cannot tell a registered exit
+    // handler from an unregistered one, nor a load-time refusal from its absence.
+    {
+        const auto timeline_path =
+            scratch / ("prosper-capture-tunables-child-" + std::to_string(nonce) + ".prgtl");
+        const auto capture_path =
+            scratch / ("prosper-capture-tunables-child-" + std::to_string(nonce) + ".prgcap");
+        set_test_env("PROSPER_GPU_TIMELINE", timeline_path.string());
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path.string());
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "41000");
+        const ChildRun child = run_child(argv[0], "--child-submits", child_err);
+        // A spawn or redirection fault leaves the same empty file the defect does. Name the
+        // apparatus so the two can never be confused.
+        if (child.rc != 0 || child.stderr_text.empty())
+            std::printf("  [note] child rc=%d, stderr bytes=%zu, command was: %s\n", child.rc,
+                        child.stderr_text.size(), child.command.c_str());
+        CHECK(child.rc == 0, "the child exits cleanly, exactly as a real unmatched run does");
+        CHECK(contains(child.stderr_text, "never matched a submit"),
+              "a process that only returns from main still reports its unmatched selector at exit");
+        CHECK(contains(child.stderr_text, "at or below 12"),
+              "the exit report states the submit ordinal the child actually reached");
+        CHECK(!std::filesystem::exists(capture_path),
+              "no capture was written, which is the outcome the report exists to explain");
+        clear_test_env("PROSPER_GPU_TIMELINE");
+        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE");
+        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
+        std::error_code ec;
+        std::filesystem::remove(timeline_path, ec);
+    }
+    {
+        set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
+        const ChildRun child = run_child(argv[0], "--child-bare", child_err);
+        if (child.rc != 0 || child.stderr_text.empty())
+            std::printf("  [note] child rc=%d, stderr bytes=%zu, command was: %s\n", child.rc,
+                        child.stderr_text.size(), child.command.c_str());
+        CHECK(child.rc == 0 && contains(child.stderr_text, "arms nothing"),
+              "a process that sets only PROSPER_CAPTURE_BUNDLE explains itself at exit");
+        clear_test_env("PROSPER_CAPTURE_BUNDLE");
+    }
+    {
+        // The load-time refusal. This child never reaches main, so its exit status is the assertion:
+        // without the refusal it would return 0 and run UNCAPPED, which is the defect.
+        set_test_env("PROSPER_CAPTURE_MAX_SUBMITS", "4O");
+        const ChildRun child = run_child(argv[0], "--child-bare", child_err);
+        clear_test_env("PROSPER_CAPTURE_MAX_SUBMITS");
+        if (child.rc == 0 || child.stderr_text.empty())
+            std::printf("  [note] child rc=%d, stderr bytes=%zu, command was: %s\n", child.rc,
+                        child.stderr_text.size(), child.command.c_str());
+        CHECK(child.rc != 0,
+              "a malformed submit cap ends the process with a nonzero status instead of running "
+              "uncapped");
+        CHECK(contains(child.stderr_text, "REFUSING TO RUN") &&
+                  contains(child.stderr_text, "PROSPER_CAPTURE_MAX_SUBMITS=\"4O\""),
+              "the refusal reaches stderr of a process that never reached main");
+        CHECK(!contains(child.stderr_text, "[child] reached main"),
+              "the refusal happens at LOAD: the child never ran a line of its own");
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(stderr_path, ec);
+    std::filesystem::remove(bundle_path, ec);
+    if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }
+    std::printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_capture_tunables.cpp
+++ b/prosper/tests/test_capture_tunables.cpp
@@ -111,23 +111,37 @@ static std::string capture_stderr(const std::filesystem::path& path, Body body) 
 
 // Spawns this same binary in `mode`, redirecting the child's stderr to a BARE filename in the
 // current directory. ctest runs a test in the directory the binary was built into, and neither a
-// CMake target name nor this filename contains a space or a separator, so the whole command line
-// needs no quoting at all — which is the question two Windows CI runs were lost to on #1684.
+// CMake target name nor this filename contains a space or a separator, so the program and the
+// redirect need no quoting at all — which is the question two Windows CI runs were lost to on #1684.
+//
+// `shell_env_*` is a shell-level assignment applied to the child, used ONLY where the child needs
+// the variable before its own `main` could set one. Nothing here relies on the parent's
+// `setenv`/`_putenv_s` reaching the spawned process: whether a CRT environment write lands in the
+// Win32 environment block a child inherits is exactly the kind of platform question that costs a CI
+// cycle, and no existing test in this repository answers it — both cross-process tests here have
+// their children set their own environment from argv, which is what the other modes do too.
 struct ChildRun {
     int rc = -1;
     std::string stderr_text;
     std::string command;
 };
-static ChildRun run_child(const char* argv0, const std::string& mode, const std::string& err_name) {
+static ChildRun run_child(const char* argv0, const std::string& mode, const std::string& err_name,
+                          const std::string& shell_env_name = {},
+                          const std::string& shell_env_value = {}) {
     ChildRun out;
-    const std::string prefix =
-#ifdef _WIN32
-        ".\\";
-#else
-        "./";
-#endif
     const std::string self = std::filesystem::path(argv0).filename().string();
-    out.command = prefix + self + " " + mode + " 2>" + err_name;
+#ifdef _WIN32
+    const std::string prefix = ".\\";
+    const std::string env = shell_env_name.empty()
+                                ? std::string()
+                                : "set \"" + shell_env_name + "=" + shell_env_value + "\" && ";
+#else
+    const std::string prefix = "./";
+    const std::string env = shell_env_name.empty()
+                                ? std::string()
+                                : shell_env_name + "='" + shell_env_value + "' ";
+#endif
+    out.command = env + prefix + self + " " + mode + " 2>" + err_name;
     if (!std::system(nullptr)) std::printf("  [note] no command processor available\n");
     out.rc = std::system(out.command.c_str());
     out.stderr_text = slurp(err_name);
@@ -136,18 +150,33 @@ static ChildRun run_child(const char* argv0, const std::string& mode, const std:
     return out;
 }
 
+// Command-line spelling for a path handed to a child. Quoted, which is the form #1684's Windows CI
+// runs proved works for an ARGUMENT (the program path was the part that could not be quoted).
+static std::string quoted(const std::filesystem::path& p) { return "\"" + p.string() + "\""; }
+
 int main(int argc, char** argv) {
     // ---- child modes ---------------------------------------------------------------------------
     // Neither of these calls a reporter. Anything on the child's stderr can only have come from an
     // exit handler registered at load, or from the load-time refusal — the halves an in-process
     // assertion cannot distinguish from their absence.
-    if (argc > 1 && std::strcmp(argv[1], "--child-submits") == 0) {
+    if (argc > 4 && std::strcmp(argv[1], "--child-submits") == 0) {
         std::printf("  [child] started (submits)\n");
         std::fflush(stdout);
+        // The child sets its own environment from argv rather than inheriting it: see run_child.
+        // It happens before the first submit, which is where the capture request is built.
+        set_test_env("PROSPER_GPU_TIMELINE", argv[2]);
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", argv[3]);
+        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", argv[4]);
         for (uint64_t n = 1; n <= 12; ++n) {
             begin_gpu_timeline_submit(n);
             record_gpu_timeline_submit(GpuState{}, n);
         }
+        return 0;
+    }
+    if (argc > 2 && std::strcmp(argv[1], "--child-bundle") == 0) {
+        std::printf("  [child] started (bundle)\n");
+        std::fflush(stdout);
+        set_test_env("PROSPER_CAPTURE_BUNDLE", argv[2]);
         return 0;
     }
     if (argc > 1 && std::strcmp(argv[1], "--child-bare") == 0) {
@@ -155,10 +184,14 @@ int main(int argc, char** argv) {
         // lands inline in the ctest log ("did the spawn happen at all?", which a failed spawn and a
         // missing exit report otherwise answer identically), and stderr lands in the captured file,
         // where the PROSPER_CAPTURE_MAX_SUBMITS arm asserts its ABSENCE — the refusal is supposed to
-        // end the process during static initialization, before main runs a single line.
+        // end the process during static initialization, before main runs a single line. The
+        // variable's visibility is reported too, so a shell assignment that failed to reach the
+        // child is separable from a refusal that failed to fire; those produce the same exit status.
+        const char* cap = std::getenv("PROSPER_CAPTURE_MAX_SUBMITS");
         std::printf("  [child] started (bare)\n");
         std::fflush(stdout);
-        std::fprintf(stderr, "[child] reached main\n");
+        std::fprintf(stderr, "[child] reached main; PROSPER_CAPTURE_MAX_SUBMITS=%s\n",
+                     cap ? cap : "<unset>");
         std::fflush(stderr);
         return 0;
     }
@@ -466,10 +499,11 @@ int main(int argc, char** argv) {
             scratch / ("prosper-capture-tunables-child-" + std::to_string(nonce) + ".prgtl");
         const auto capture_path =
             scratch / ("prosper-capture-tunables-child-" + std::to_string(nonce) + ".prgcap");
-        set_test_env("PROSPER_GPU_TIMELINE", timeline_path.string());
-        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE", capture_path.string());
-        set_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT", "41000");
-        const ChildRun child = run_child(argv[0], "--child-submits", child_err);
+        // Passed as arguments, not inherited: the child sets them itself before its first submit.
+        const ChildRun child = run_child(
+            argv[0],
+            "--child-submits " + quoted(timeline_path) + " " + quoted(capture_path) + " 41000",
+            child_err);
         // A spawn or redirection fault leaves the same empty file the defect does. Name the
         // apparatus so the two can never be confused.
         if (child.rc != 0 || child.stderr_text.empty())
@@ -482,28 +516,24 @@ int main(int argc, char** argv) {
               "the exit report states the submit ordinal the child actually reached");
         CHECK(!std::filesystem::exists(capture_path),
               "no capture was written, which is the outcome the report exists to explain");
-        clear_test_env("PROSPER_GPU_TIMELINE");
-        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE");
-        clear_test_env("PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT");
         std::error_code ec;
         std::filesystem::remove(timeline_path, ec);
     }
     {
-        set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
-        const ChildRun child = run_child(argv[0], "--child-bare", child_err);
+        const ChildRun child =
+            run_child(argv[0], "--child-bundle " + quoted(bundle_path), child_err);
         if (child.rc != 0 || child.stderr_text.empty())
             std::printf("  [note] child rc=%d, stderr bytes=%zu, command was: %s\n", child.rc,
                         child.stderr_text.size(), child.command.c_str());
         CHECK(child.rc == 0 && contains(child.stderr_text, "arms nothing"),
               "a process that sets only PROSPER_CAPTURE_BUNDLE explains itself at exit");
-        clear_test_env("PROSPER_CAPTURE_BUNDLE");
     }
     {
         // The load-time refusal. This child never reaches main, so its exit status is the assertion:
-        // without the refusal it would return 0 and run UNCAPPED, which is the defect.
-        set_test_env("PROSPER_CAPTURE_MAX_SUBMITS", "4O");
-        const ChildRun child = run_child(argv[0], "--child-bare", child_err);
-        clear_test_env("PROSPER_CAPTURE_MAX_SUBMITS");
+        // without the refusal it would return 0 and run UNCAPPED, which is the defect. The value has
+        // to exist before main, so it is the one thing set through the shell rather than from argv.
+        const ChildRun child =
+            run_child(argv[0], "--child-bare", child_err, "PROSPER_CAPTURE_MAX_SUBMITS", "4O");
         if (child.rc == 0 || child.stderr_text.empty())
             std::printf("  [note] child rc=%d, stderr bytes=%zu, command was: %s\n", child.rc,
                         child.stderr_text.size(), child.command.c_str());

--- a/prosper/tests/test_guest_log_capture_miss.cpp
+++ b/prosper/tests/test_guest_log_capture_miss.cpp
@@ -204,9 +204,16 @@ int main(int argc, char** argv) {
 
     // --- delivery: the report actually reaches stderr, and only when a gate is armed ------------
     clear_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG");
+    // PROSPER_CAPTURE_BUNDLE has to go with it. Since #2565 that variable ON ITS OWN is itself
+    // reported — it names a destination and arms nothing — so leaving it set would turn this check
+    // into one about that report instead of the gate report it exists to pin. Clearing both makes
+    // the premise ("nothing configured at all") match the claim, and additionally proves the new
+    // report is not spurious.
+    clear_test_env("PROSPER_CAPTURE_BUNDLE");
     const std::string quiet = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
-    CHECK(quiet.empty(), "with no gate configured the exit report says nothing at all");
+    CHECK(quiet.empty(), "with nothing configured at all the exit report says nothing at all");
 
+    set_test_env("PROSPER_CAPTURE_BUNDLE", bundle_path.string());
     set_test_env("PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG", "phase-ready");
     const std::string loud = capture_stderr(stderr_path, &report_unfired_automatic_capture_gates);
     CHECK(contains(loud, "never matched") && contains(loud, "phase-ready"),

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -739,6 +739,20 @@ covers the other two automatic gates: an unreached `PROSPER_CAPTURE_BUNDLE_AT_PR
 count the run actually reached, and an unobserved `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE` states how many
 presents looked for it. **Absence of a bundle is no longer evidence of anything on its own — read the
 exit report.**
+Since #2565 the same exit report also covers **`PROSPER_CAPTURE_BUNDLE` set on its own**, which is a
+complete no-op: the variable only names a DESTINATION, and nothing but one of the three gates above
+(or F9, which uses `PROSPER_CAPTURE_DIR` instead) ever arms a capture into it.
+
+**Malformed capture tunables no longer substitute a policy in silence** (#2565). The parse is strict —
+the whole value must be a number, with nothing around it, not even a space — and every rejection now
+names the variable, quotes the value with invisible bytes escaped, and states what is actually in
+force:
+
+| variable | a bad value used to mean | now |
+| --- | --- | --- |
+| `PROSPER_CAPTURE_MAX_SUBMITS` | **uncapped** — the inverse of the request | **the process refuses to start**, exit status 3. There is no honest default: `0` means uncapped, so a typo removed the only content bound on exactly the run that needed it. Express "uncapped" by leaving the variable unset. |
+| `PROSPER_CAPTURE_BUNDLE_MAX_MB` | the default budget, so a raise was discarded | same value in force, plus one `[grab]` line saying the raise was discarded (or naming the 64/3072 MiB bound it was clamped to) |
+| `PROSPER_CAPTURE_FRAMES` | 1 — the very width the `window had no submits` message tells you to widen | same value in force, plus one `[grab]` line; a mistyped remedy no longer reproduces the original failure in silence |
 If present counts vary and the title emits no honest guest-stdout marker, use the headless F9 control:
 set `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` together with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`, keep the trigger absent at process start, and create it

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -60,6 +60,22 @@ tested. The same report covers an unreached `PROSPER_CAPTURE_BUNDLE_AT_PRESENT` 
 count the run reached), an unobserved `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE`, a gate configured without
 `PROSPER_CAPTURE_BUNDLE`, and a conflicting multi-gate configuration.
 
+`PROSPER_CAPTURE_BUNDLE` **set on its own arms nothing** — it names only a destination — and since
+#2565 that too is reported at exit rather than leaving a missing file as the whole story.
+
+The capture tunables parse strictly, and a rejected value is never substituted in silence (#2565).
+The entire value must be a number, with nothing around it: `PROSPER_CAPTURE_MAX_SUBMITS=40 ` (trailing
+space) and `=4O` (letter O) are rejections, not forties.
+
+* **`PROSPER_CAPTURE_MAX_SUBMITS`** is the one that **refuses**: a bad value ends the process at load
+  with exit status 3 and a `[grab]` explanation. It cannot fall back, because its fallback is
+  *uncapped* — the inverse of the request, on exactly the run the cap exists for. Leave the variable
+  unset for an uncapped capture; `0` is refused because it would mean both things at once.
+* **`PROSPER_CAPTURE_BUNDLE_MAX_MB`** (64..3072) and **`PROSPER_CAPTURE_FRAMES`** (1..240) keep their
+  existing fallbacks and now print one `[grab]` line naming the variable, the rejected value with
+  invisible bytes escaped, and the value actually in force. Reading "the budget default is in force"
+  is how you learn that a raise you made after an aborted capture was discarded.
+
 When neither a fixed present nor guest stdout is phase-stable, set
 `PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE=/path/capture.ready` with
 `PROSPER_CAPTURE_BUNDLE=/path/frame.prgbundle`. Keep the trigger path absent at startup, watch

--- a/prosper/tools/gpu_timeline/README.md
+++ b/prosper/tools/gpu_timeline/README.md
@@ -69,6 +69,28 @@ PROSPER_GPU_TIMELINE_EXIT_AFTER_CAPTURE=1 \
   --bundle-intermediate-through-target 642x362 /tmp/closure.bmp
 ```
 
+**A selector that never matches now says so at process exit, on stderr** (#2564). Before that fix the
+run simply completed, exited 0 and wrote no `.prgcap` — an outcome indistinguishable from a route that
+crashed early or a mistyped output path, and the `detail_submits_captured` counter that does exist
+reaches only the timeline file. The report quotes what was configured and what the run actually
+reached, and it separates the outcomes because their fixes differ:
+
+* `this is an ORDINAL selector, and the run never reached that submit number` — run the route longer,
+  or pick an ordinal at or below the one named. **Submit ordinals are run-local**; re-derive with
+  `gpu_timeline <file> --records`.
+* `none satisfied every semantic predicate` — the predicates are quoted back verbatim. Extents, draw
+  indices and program addresses are **all run-local**, so re-derive them against *this* run with
+  `--signatures` / `--select` rather than re-using a selector from an earlier one. `--select` exits
+  nonzero when nothing matches, which answers the same question offline in seconds.
+* `PROSPER_GPU_TIMELINE is NOT set` — the detailed capture requires it. Setting only
+  `PROSPER_GPU_TIMELINE_CAPTURE` and `PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT` is a complete no-op,
+  because the submit hook returns before reaching the selector when the recorder is not running.
+* `the run produced no GPU submits at all` — a routing or boot fault, not a selector fault.
+* `the AFTER_COMPUTE_PROGRAM phase gate never armed` — the endpoint predicate was never even reached;
+  the compute program address is run-local too.
+
+So **the absence of a `.prgcap` is not evidence on its own**: read the exit report first.
+
 See [`../gpu_replay/README.md`](../gpu_replay/README.md) for graph interpretation, pixel-oracle
 semantics, draw isolation, resource/shader extraction, and the distinction between draw and operation indices.
 


### PR DESCRIPTION
Fixes #2564
Fixes #2565

## Why one PR

Both issues are the same defect class in the same file, filed together out of #1684 (merged as #2566), and they collide mechanically: they share the load-time initializer that registers the exit handlers, the same header block, the same new test binary, and the same `report_unfired_automatic_capture_gates()` function. Splitting them would mean two sequential PRs racing on `gpu_timeline.cpp`, which several lanes touch. The contract for each variable is stated separately below so they can still be reviewed separately.

## Failure scenario, re-verified on `origin/master` @ `56f83a11`

A standalone program linking `prosper_core` (not committed) armed each selector/tunable and reported how many bytes of stderr mentioned it. Every arm reproduced:

```
[2564 ordinal]      child rc=0, stderr bytes=88   mentions CAPTURE_SUBMIT: NO
[timeline] recording native submit/present index -> ...prgtl      <- the only line
[2564 ordinal]      .prgcap exists: 0
[2564 semantic]     child rc=0, mentions 'never'/'no match': NO
[2565 MAX_SUBMITS]  child rc=0, stderr bytes=0, mentions var: NO
[2565 FRAMES]       stderr bytes=0, mentions var: NO
[2565 MAX_MB]       stderr bytes=0, mentions var: NO
[2565 BUNDLE alone] stderr bytes=0, mentions var: NO
```

The ordinal child asked for submit 41000, reached submit 12, exited 0, wrote no `.prgcap` and said nothing. The **semantic** arm is worse than silent: it prints its arming banner (`[timeline] semantic capture endpoint submit>=1 target=3840x2160 ...`) and then never mentions the selector again, so the log positively asserts that the selector is live.

## The contract, per variable

**A malformed value must never leave the run describable as "configured" when it is not.** Two policies, chosen per variable by what the fallback *means*:

| variable | fallback used to be | policy now | why |
| --- | --- | --- | --- |
| `PROSPER_CAPTURE_MAX_SUBMITS` | **uncapped** | **refuse**: one `[grab]` block, `exit(3)`, at load | There is no honest default. Its fallback inverts the request, and it does so on exactly the run the cap exists for — one flip burst appended 3.3 GB and blew even the 3,072 MiB maximum. `0` is refused too, because it would have to mean both "no cap" and "cap at nothing"; uncapped is expressed by leaving the variable unset. |
| `PROSPER_CAPTURE_BUNDLE_MAX_MB` | the default budget / a silent clamp | **report and fall back**, value in force named | The misparse is unhelpful, not dangerous: you get the default budget instead of the raise. The fallback is deliberately unchanged. |
| `PROSPER_CAPTURE_FRAMES` | 1, or a silent clamp to 240 | **report and fall back**, value in force named | Same, and it is the sharpest: widening the window is the remedy the `window had no submits` message itself prints, so a mistyped remedy silently reproduced the original failure and read as the remedy not working. |
| `PROSPER_CAPTURE_BUNDLE` alone | complete no-op | reported by the existing exit handler | It names a destination and arms nothing. Suppressed when anything did arm. |

Refusing at **load** rather than at first use is deliberate: the operator learns before the route runs, not after a multi-gigabyte capture is already underway.

```
$ PROSPER_CAPTURE_MAX_SUBMITS='40 ' <any prosper binary>
[grab] PROSPER_CAPTURE_MAX_SUBMITS="40\x20" is not a submit count; REFUSING TO RUN.
[grab]   This variable does not fall back to a default: its fallback is UNCAPPED, which is the opposite of what a cap is for.
[grab]   The cap exists because one flip burst appended 3.3 GB in a single window and blew even the 3072 MiB maximum, so proceeding with a typo would remove the only content bound on exactly the run that needs it.
[grab]   Give a whole number of submits (1 or more), or unset the variable for an uncapped capture. The entire value must be a number — `40 ` with a trailing space and `4O` with a letter O are both rejected here.
$ echo $?
3
```

The parse is **strict, not permissive**: the entire value must be a number with nothing around it. Four rejections that used to be silent acceptances or silent zeroes:

* `4O` (letter O) — was `0`, i.e. uncapped
* `40 ` / ` 40` — trailing bytes; leading whitespace is rejected too, so the two spellings cannot disagree
* `-1` — `strtoull` **negates** it into an accepted `18446744073709551615`, a cap indistinguishable from uncapped
* overflow — `strtoull` saturates to `ULLONG_MAX`; `errno` is checked

Invisible bytes are escaped, and unlike the guest-log report a **space is escaped too** (`40\x20`): a log line is mostly spaces, but in a numeric tunable an invisible space *is* the bug.

## #2564: what the selector report says

```
[timeline] the detailed capture selector never matched a submit; NO .prgcap WAS WRITTEN.
[timeline]   PROSPER_GPU_TIMELINE_CAPTURE="...prgcap" PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT="41000"
[timeline]   12 submit(s) were judged against the selector; the last one judged was submit 12.
[timeline]   this is an ORDINAL selector, and the run never reached that submit number. Run the route
             longer, or pick an ordinal at or below 12. Submit ordinals are RUN-LOCAL: re-derive it
             from this run's own timeline with `gpu_timeline <file> --records`.
```

and for a semantic selector, quoting each predicate back:

```
[timeline]   PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM="3840x2160"
[timeline]   every judged submit satisfied the ordinal floor and none satisfied every semantic
             predicate above. Extents, draw indices and program addresses are all RUN-LOCAL:
             re-derive the selector against THIS run's timeline with `gpu_timeline <file>
             --signatures` / `--select` ... `--select` exits nonzero when nothing matches.
```

Five outcomes are reported **distinctly**, because their fixes differ and conflating them sends the next run at the wrong problem: unreached ordinal (run longer) · unmatched semantic predicate (re-derive) · `PROSPER_GPU_TIMELINE is NOT set` (the detailed selector is then a **complete no-op** — `record_gpu_timeline_submit` returns before reaching it) · no GPU submits at all (a routing fault) · an `AFTER_COMPUTE_PROGRAM` phase gate that never armed (the endpoint predicate was never reached).

Whether the selector is semantic is read from **the request's own verdict**, not inferred from the environment: several of those variables do not make a selector semantic on their own (a program address of `0`, a draw-index range with no target extent), so inferring would have mislabelled the outcome.

## Invariants

* **Both handlers are registered at load, not from a gate or request constructor** — the same reason as #2566, one level worse here: `RuntimeDetailRequest` is a function-local static built lazily on the *first recorded submit*, so a run that never records one has no such object at all, and that is exactly the run whose silence is hardest to explain.
* **The exit report never reads `RuntimeDetailRequest`.** An `atexit` handler registered first runs after every static destructor. It reads the environment plus nine namespace-scope atomics instead. Eager construction was considered and rejected: `test_gpu_timeline`'s child modes set the selector environment *inside* `main`, so constructing at load would silently disable every one of those cases.
* **No fallback changed.** `PROSPER_CAPTURE_BUNDLE_MAX_MB=5000` still yields 3072 MiB, `=10` still yields 64, `=0` still means "keep the built-in default" (its long-standing sentinel — honouring it is not a substitution, so it draws no notice), a malformed value still yields the default, and `PROSPER_CAPTURE_FRAMES` still clamps to 1..240. Only the silence changed. `PROSPER_CAPTURE_MAX_SUBMITS` is the single deliberate behavioural change, and it is a refusal, not a different value.
* The default budget and both bounds are now named constants (`kInteractiveBundleDefaultMb/MinMb/MaxMb`, `kCaptureFrames*`) used by both the code and the messages, so a message cannot drift into claiming a bound the code does not enforce.
* `escape_log_line` moved earlier in the file, unchanged, so the tunable notices can share it.

## Affected / deliberately unaffected

Affected: what a malformed capture tunable and an unmatched timeline selector print; one `getenv` at load; nine relaxed atomics on paths that already build a whole submit record; one extra `atexit` slot.

Deliberately unaffected: every capture's selection semantics, every existing `[grab]`/`[timeline]` message, the F9 path, `gpu_replay`, and any run that sets none of these variables. `report_unfired_automatic_capture_gates`'s existing three-gate behaviour is untouched apart from the new no-gate branch.

## Risks

* `std::exit(3)` from a load-time initializer is legal and runs only what has been registered so far — the refusal is deliberately validated **before** either `atexit` registration, so nothing half-initialized runs on that path. It fires only when the variable is set *and* malformed.
* A process that mutates its own environment mid-run could be described by the post-mutation value at exit, as with #2566. Nothing in prosper calls `setenv` at runtime; the test exercises this deliberately.
* The cap is now resolved **once, at load**, where it was previously resolved on first use. Nothing sets it mid-run, no test sets it at all, and the ordering seam (`frame_bundle_append_submit`) still takes an injected cap so its regression is unaffected.

## Build and test

Linux, in the project container, worktree-local build dir, at this exact head:

```bash
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 255`, ctest exit `0`** (254 registered on master at `8c6a1287`, plus the new `capture_tunables`). The new test's own **65 checks** all pass. Re-run at the exact head after the rebase; see the verification comment.

## Mutation arms

Each reverts one part of the fix, rebuilds, and runs the test. Failures quoted verbatim.

**A — the `std::atexit` registration for the selector report removed.** This is the arm that matters, and it is the one #1684 warned about: **every in-process check still passes**, because they call the reporter by hand. Only the child-process arm can see it.

```
== A-no-atexit-registration ==
  rc=1, 2 failing check(s)
  [FAIL] a process that only returns from main still reports its unmatched selector at exit
  [FAIL] the exit report states the submit ordinal the child actually reached
```

**B — the load-time `capture_max_submits()` call removed** (so the refusal never happens):

```
== B-no-load-time-refusal ==
  rc=1, 3 failing check(s)
  [FAIL] a malformed submit cap ends the process with a nonzero status instead of running uncapped
  [FAIL] the refusal reaches stderr of a process that never reached main
  [FAIL] the refusal happens at LOAD: the child never ran a line of its own
```

**C — the strict parse reverted to permissive** (`if (errno || end == raw || !end)`):

```
== C-permissive-parse ==
  rc=1, 12 failing check(s)
  [FAIL] a letter O in place of a zero is REJECTED, not read as 4
  [FAIL] a trailing space is rejected: the whole value must be the number
  [FAIL] a leading space is rejected too, so the two spellings cannot disagree
  [FAIL] a negative value is rejected rather than wrapping to an enormous positive cap
  [FAIL] the refusal quotes the exact rejected value
  [FAIL] the refusal states both that it refuses and WHY the fallback is unacceptable
  [FAIL] an invisible trailing space is ESCAPED, not reproduced invisibly
  [FAIL] the notice states the budget actually in force and that the raise was discarded
  [FAIL] a malformed budget still resolves to 0 = keep the built-in default, as before
  [FAIL] a malformed submit cap ends the process with a nonzero status instead of running uncapped
  [FAIL] the refusal reaches stderr of a process that never reached main
  [FAIL] the refusal happens at LOAD: the child never ran a line of its own
```

**D — the `PROSPER_CAPTURE_BUNDLE`-alone branch reverted to `if (!configured) return;`:**

```
== D-no-bundle-alone-report ==
  rc=1, 3 failing check(s)
  [FAIL] PROSPER_CAPTURE_BUNDLE set with no gate is reported instead of doing nothing
  [FAIL] the report names every gate that would actually arm one
  [FAIL] a process that sets only PROSPER_CAPTURE_BUNDLE explains itself at exit
```

**E — the `submits_examined` / `last_submit_examined` counters removed** (so the report can still say "never matched" but not what the run reached):

```
== E-no-examined-counters ==
  rc=1, 3 failing check(s)
  [FAIL] the snapshot counts the submits the selector actually judged
  [FAIL] the delivered report states the ordinal the run actually reached
  [FAIL] the exit report states the submit ordinal the child actually reached
```

Restored: `rc=0, ok=65, fail=0`.

### On the child-process arms

The `PROSPER_CAPTURE_MAX_SUBMITS` child **never reaches `main`**, so it cannot redirect its own stderr the way #2566's child does. The parent redirects it with a bare `2><name>` filename in the working directory — no separator, no space, no quoting, which removes the question two Windows CI runs were lost to. The program is still `./<name>`, relative and unquoted.

**Nothing relies on the parent's environment being inherited.** No existing test here establishes that a CRT `_putenv_s` reaches the Win32 environment block a spawned child inherits — both cross-process tests in this repository have their children set their own environment from `argv` — so `--child-submits` and `--child-bundle` do the same, taking their paths as quoted *arguments* (the form #1684's Windows runs proved works; the program path was the part that could not be quoted). Only `PROSPER_CAPTURE_MAX_SUBMITS` cannot, because it is read at load before `main`; that one two-character literal is assigned by the shell.

The `--child-bare` mode witnesses itself on *both* streams: stdout so a failed spawn is separable from a missing report in the ctest log, and stderr so the refusal arm can assert its **absence** — the refusal is supposed to end the process before `main` runs a line. It also names the value it saw (`PROSPER_CAPTURE_MAX_SUBMITS=<unset>`), so a shell assignment that failed to reach the child cannot masquerade as a refusal that failed to fire; and the refusal's own text quotes the value it read, so a passing arm *proves* the variable arrived rather than assuming it.

## One pre-existing assertion adjusted, and it was strengthened

`test_guest_log_capture_miss`'s `with no gate configured the exit report says nothing at all` ran with `PROSPER_CAPTURE_BUNDLE` still set, so the new no-gate report correctly fired and it failed. The premise, not the claim, was incomplete: the check now clears `PROSPER_CAPTURE_BUNDLE` as well, which makes it match its own wording and additionally proves the new report is not spurious. Nothing was weakened; every other check in that file is untouched and passing.

## Docs

`tools/AGENTS.md` (a table of the three tunables and what a bad value used to mean), `tools/gpu_replay/README.md` (the strict-parse contract and the refuse-vs-fall-back split), and `tools/gpu_timeline/README.md` (the five selector-miss outcomes and how to read them apart) all now state that **the absence of a capture file is not evidence on its own — read the exit report**.

No snapshots were run: the diff is diagnostic plumbing with no rendering path.
