### PR TITLE
ci: install gdb on the Linux job so hle_calls_value_capture stops skipping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,19 @@ jobs:
       # strictly spirv-val-gated. #1711 is what shipped through the gap. spv_validate now fails
       # when the validator is absent, so removing this line breaks the job instead of silently
       # switching the gate off again.
+      # gdb is the same shape of gap, measured rather than assumed: the Ubuntu 24.04 runner image
+      # ships gcc/g++/cmake but NOT gdb, so `hle_calls_value_capture` — the only guard on the #2075
+      # class, a value capture that silently records nothing — reported
+      # `10/250 Test #10: hle_calls_value_capture ***Skipped` on every CI run since it landed. That
+      # skip is legible by design (SKIP_RETURN_CODE 77 names it in the summary) rather than silent,
+      # which is why this is a one-line install and not a redesign: the test drives a real gdb over a
+      # real no-debug-info binary because nothing else reproduces the defect.
       - name: Install dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y ninja-build pkg-config libavformat-dev libavcodec-dev \
             libavutil-dev libswresample-dev libswscale-dev libva-dev \
-            libvulkan-dev mesa-vulkan-drivers vulkan-validationlayers spirv-tools
+            libvulkan-dev mesa-vulkan-drivers vulkan-validationlayers spirv-tools gdb
 
       # #1675: Vulkan was disabled here because it was never installed, not by choice — and that
       # silently removed 27 tests (~1,700 assertions) from every "green" CI run, including every


### PR DESCRIPTION
One line: `gdb` added to the Linux job's apt install. Deliberately separate from #2593, so a CI
regression cannot be bisected to a tool change.

## What it fixes

`hle_calls_value_capture` (landed in #2590) is the only guard on the #2075 class — a `--values` run
that records nothing at all while looking armed. It has **skipped on every CI run since it landed**:

```
 10/250 Test  #10: hle_calls_value_capture ........................***Skipped   0.03 sec
100% tests passed, 0 tests failed out of 250
The following tests did not run:
	 10 - hle_calls_value_capture (Skipped)
	123 - plugin_autolink (Skipped)
```

(from the Linux job of the run on #2590's merged head, `99bfea84`)

## Why gdb, measured rather than assumed

The test's preflight needs `gdb` (with Python), a C++ compiler, `nm` and `c++filt`. The Ubuntu 24.04
runner image ships `gcc 13.2`, `g++ 13.2` and `CMake 3.31.6` but **no `gdb` package** — checked
against `actions/runner-images`' `Ubuntu2404-Readme.md`, whose apt-package and tools lists have no
entry for it. `nm`/`c++filt` come with binutils, which is present (the build links). So gdb is the
missing piece.

**And the change is self-checking**: if the case still skips after this lands, the cause was not gdb
and the summary line says so in exactly the same place. That is no worse than today.

## Why the test cannot avoid gdb

#2075 was not a logic bug. It lived in the interaction between gdb, an ELF carrying no DWARF, and the
tool's decode: `FinishBreakpoint.return_value` is derived from the DWARF return type, and prosper's
default `CMAKE_BUILD_TYPE` is `Release` (`-O3 -DNDEBUG`, no `-g`), so the attribute was `None`,
`int(None)` raised once per call, and `finish-failures` equalled the call count exactly. A
recorded-output test would have been green throughout. The test therefore compiles its fixture twice —
`-g0` (the exact defect condition) and `-g` — and asserts the two arms produce the same histogram.

The repository's sibling case (`stack_profile_logic`) is deliberately gdb-free with a comment saying a
silently skipped test is indistinguishable from a passing one. This one cannot be, so it skips
**loudly** instead: `SKIP_RETURN_CODE 77` puts it in the summary by name. That is what made this
findable at all.

## Risk

One extra apt package (~4 MB) on the Linux job only. No other job, no build flag, no source change.
`git diff --check` clean.
