### PR TITLE
GTA V: one typed sampled-source decision, shared by both backends (design check; nothing wired yet)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1168,6 +1168,10 @@ if(TARGET prosper_core)
   add_test(NAME shader_recompile_cache COMMAND test_shader_recompile_cache)
 
   # RDNA2 shader instruction-stream walker (first stage of the RDNA2->SPIR-V recompiler).
+  add_executable(test_compressed_source_authority tests/test_compressed_source_authority.cpp)
+  target_link_libraries(test_compressed_source_authority PRIVATE prosper_core)
+  add_test(NAME compressed_source_authority COMMAND test_compressed_source_authority)
+
   add_executable(test_rdna2_decode tests/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)
   add_test(NAME rdna2_decode_walk COMMAND test_rdna2_decode)

--- a/prosper/src/gpu/compressed_source_authority.cpp
+++ b/prosper/src/gpu/compressed_source_authority.cpp
@@ -9,72 +9,154 @@ namespace {
 
 // DCC's "nothing in this block is compressed" code is 0xff per byte. Taken from the predicate this
 // replaces (the former `dcc_cache_safe` scan in the live compute backend), not newly invented — what
-// changed is that it now selects the SOURCE rather than only cache eligibility, and that it is applied
-// only when the metadata is known to BE DCC.
-bool dcc_metadata_proves_plain(const uint8_t* metadata, size_t metadata_bytes,
-                               size_t expected_bytes) {
-    if (!metadata || !expected_bytes || metadata_bytes != expected_bytes) return false;
-    return std::all_of(metadata, metadata + metadata_bytes,
-                       [](uint8_t value) { return value == 0xffu; });
+// changed is that it now selects the SOURCE rather than only cache eligibility, that it is applied only
+// when the metadata is known to BE DCC, and that its span is derived rather than supplied.
+bool dcc_plane_proves_plain(const uint8_t* plane, size_t span) {
+    return std::all_of(plane, plane + span, [](uint8_t value) { return value == 0xffu; });
+}
+
+uint32_t texel_bytes(DataFormat format, uint32_t num_components) {
+    const uint32_t components = num_components ? num_components : 1u;
+    const uint32_t bytes = data_format_bytes(format) * components;
+    if (bytes) return bytes;
+    // Packed formats report no per-component width but occupy one dword.
+    if (format == DataFormat::Float10_11_11 || format == DataFormat::Unorm2_10_10_10) return 4u;
+    return 0u;
+}
+
+// The exact span of this shape's metadata plane, or 0 when no exact footprint is derivable.
+//
+// Deriving it here is the whole point: an adapter that reached for the colour-DCC helper on a depth
+// resource is exactly the original defect, and it cannot express that mistake through this interface.
+size_t exact_metadata_span(const MetadataPlaneShape& shape) {
+    switch (shape.kind) {
+        case CompressionMetadataKind::Htile:
+            // Only the 2D_MSAA Z_X shape has a published exact span in this tree. Single-sample HTILE
+            // — GTA V's main depth — deliberately has none, so its metadata cannot authorize its base.
+            if (shape.img_dim == 6u && shape.format == DataFormat::Float32 &&
+                shape.num_components == 1u && shape.sample_count > 1u)
+                return gfx10_htile_msaa_metadata_bytes(shape.width, shape.height, shape.tile_mode,
+                                                       shape.sample_count, shape.meta_pipe_aligned);
+            return 0;
+        case CompressionMetadataKind::Dcc: {
+            const uint32_t bytes_per_texel = texel_bytes(shape.format, shape.num_components);
+            if (!bytes_per_texel) return 0;
+            const uint32_t layers =
+                shape.img_dim == 3u ? 6u : (shape.img_dim == 2u ? std::max(shape.depth, 1u) : 1u);
+            return gfx10_dcc_metadata_bytes(shape.width, shape.height, layers, shape.tile_mode,
+                                            bytes_per_texel, shape.meta_pipe_aligned);
+        }
+        case CompressionMetadataKind::Unknown:
+            return 0;
+    }
+    return 0;
 }
 
 }  // namespace
 
-SampledSourceDecision sampled_source_decision(const SampledSourceFacts& facts) {
-    // An import that the caller will consume selects THE IMAGE. Checked before compression, because it
-    // makes the base allocation's encoding irrelevant: those bytes are not the source.
-    if (facts.import_selected)
-        return {SampledSourceRepresentation::ImportedImage, SampledSourceReason::RendererImageImport};
+MetadataProof resolve_metadata_proof(const MetadataPlaneShape& shape, const uint8_t* plane,
+                                    size_t readable_bytes) {
+    if (shape.kind == CompressionMetadataKind::Unknown) return MetadataProof::UnknownKind;
 
-    // An import exists and the caller has chosen NOT to consume it. This is a decline, not a fallback:
-    // the recovery switch that bypasses an imported image is expressing that the image should not be
-    // used, which is the opposite of permission to read guest bytes in its place. The old guard
-    // exempted exactly this case because it only asked whether an import existed.
-    if (facts.import_available)
-        return {SampledSourceRepresentation::None, SampledSourceReason::DeclinedImportBypassed};
+    const size_t span = exact_metadata_span(shape);
+    if (!span) return MetadataProof::NoExactFootprint;
+    // `readable_bytes` bounds what may be touched; it never defines the span. A plane the caller can
+    // only partly read cannot be proven uniform over the whole thing.
+    if (!plane || readable_bytes < span) return MetadataProof::Absent;
+
+    switch (shape.kind) {
+        case CompressionMetadataKind::Dcc:
+            return dcc_plane_proves_plain(plane, span) ? MetadataProof::ProvesPlain
+                                                       : MetadataProof::NotDecompressed;
+        case CompressionMetadataKind::Htile:
+            return gfx10_htile_metadata_is_decompressed(plane, span, span, nullptr)
+                       ? MetadataProof::ProvesPlain
+                       : MetadataProof::NotDecompressed;
+        case CompressionMetadataKind::Unknown:
+            break;
+    }
+    return MetadataProof::UnknownKind;
+}
+
+bool producer_writeback_covers_read(const ProducerWritebackRecord& record,
+                                   const ConsumerReadRequest& read) {
+    if (!record.present) return false;
+    // Same allocation, same version of its contents.
+    if (record.base_addr != read.base_addr) return false;
+    if (record.content_version != read.content_version) return false;
+    // The producer's written range must COVER the consumer's read range.
+    if (read.byte_offset < record.byte_offset) return false;
+    const uint64_t record_end = record.byte_offset + record.byte_size;
+    const uint64_t read_end = read.byte_offset + read.byte_size;
+    if (!record.byte_size || !read.byte_size || read_end > record_end) return false;
+    // The layout must interpret those bytes the same way. Identical addresses with a different tile
+    // mode, pitch, extent or texel width are a different image over the same memory.
+    if (record.width != read.width || record.height != read.height || record.depth != read.depth)
+        return false;
+    if (record.tile_mode != read.tile_mode || record.row_pitch != read.row_pitch) return false;
+    if (texel_bytes(record.format, record.num_components) !=
+        texel_bytes(read.format, read.num_components))
+        return false;
+    // Ordering: the consumer must come after the producer on the same submit timeline.
+    if (record.submit_no != read.submit_no) return false;
+    return record.command_order < read.command_order;
+}
+
+SampledSourceDecision sampled_source_decision(const SampledSourceFacts& facts) {
+    // A selected import selects THE IMAGE. Checked first because it makes the base allocation's
+    // encoding irrelevant: those bytes are not the source.
+    if (facts.import_state == ImportState::Selected)
+        return {SampledSourceRepresentation::ImportedImage, SampledSourceReason::RendererImageImport};
 
     // Not a compressed source: the base carries ordinary texels by construction.
     if (!facts.compression_enabled)
-        return {SampledSourceRepresentation::GuestBase,
-                SampledSourceReason::UncompressedDescriptor};
+        return {SampledSourceRepresentation::GuestBase, SampledSourceReason::UncompressedDescriptor};
 
-    // An exactly supported compressed decode produces its own pixels; the compressed bytes are
-    // interpreted rather than read as though they were plain.
-    if (facts.exact_materialization)
+    // An exact materialization produces its own pixels, named by the materializer that made them.
+    if (facts.materialized == MaterializedSource::ExactDcc)
         return {SampledSourceRepresentation::MaterializedPixels,
                 SampledSourceReason::ExactDccMaterialization};
+    if (facts.materialized == MaterializedSource::ExactHtile)
+        return {SampledSourceRepresentation::MaterializedPixels,
+                SampledSourceReason::ExactHtileMaterialization};
 
-    // prosper's own ordered writeback put plain texels in the base. The guest's metadata may still read
-    // "compressed" — that is the documented shape of the ordered storage-writeback round trip, where
-    // the base IS authoritative because we wrote it. Requires exact provenance; see the field comment.
-    if (facts.ordered_producer_writeback)
+    // prosper's own writeback put plain texels in the base — verified against the consumer's read
+    // rather than asserted, so a stale record, a different layout over the same address, or a consumer
+    // that precedes the producer cannot license raw bytes.
+    if (producer_writeback_covers_read(facts.producer, facts.read))
         return {SampledSourceRepresentation::GuestBase,
                 SampledSourceReason::OrderedProducerWriteback};
 
-    // Metadata may prove the base holds ordinary texels — but ONLY through the proof belonging to its
-    // own kind. Applying DCC's all-0xff scan to an HTILE plane is how a DCC-sized window over depth
-    // metadata came to look like permission, so the kinds do not share a path and Unknown has none.
-    switch (facts.kind) {
-        case CompressionMetadataKind::Dcc:
-            if (dcc_metadata_proves_plain(facts.metadata, facts.metadata_bytes,
-                                          facts.expected_metadata_bytes))
-                return {SampledSourceRepresentation::GuestBase,
-                        SampledSourceReason::DccUncompressedBase};
-            return {SampledSourceRepresentation::None,
-                    SampledSourceReason::DeclinedUnsupportedMetadataState};
-        case CompressionMetadataKind::Htile:
-            // PAL's decompressed initial values, checked uniformly across the exact expected span.
-            if (gfx10_htile_metadata_is_decompressed(facts.metadata, facts.metadata_bytes,
-                                                     facts.expected_metadata_bytes, nullptr))
-                return {SampledSourceRepresentation::GuestBase,
-                        SampledSourceReason::HtileUncompressedBase};
-            return {SampledSourceRepresentation::None,
-                    SampledSourceReason::DeclinedUnsupportedMetadataState};
-        case CompressionMetadataKind::Unknown:
-            // Deliberately no proof. An aspect-unknown plane cannot be shown decompressed, because
-            // which bit pattern means "decompressed" depends on the kind.
+    // Metadata may prove the base holds ordinary texels, through the proof belonging to its own kind
+    // over a span derived here from the resource shape.
+    const MetadataProof proof = resolve_metadata_proof(facts.metadata_shape, facts.metadata_plane,
+                                                       facts.metadata_readable_bytes);
+    if (proof == MetadataProof::ProvesPlain) {
+        return {SampledSourceRepresentation::GuestBase,
+                facts.metadata_shape.kind == CompressionMetadataKind::Htile
+                    ? SampledSourceReason::HtileUncompressedBase
+                    : SampledSourceReason::DccUncompressedBase};
+    }
+
+    // Only now may a bypassed import determine the outcome. It is not evidence AGAINST any of the
+    // independent proofs above — an earlier draft declined here first, which let a bypassed import veto
+    // an uncompressed base and every separately proven compressed source.
+    if (facts.import_state == ImportState::BypassedCompatible)
+        return {SampledSourceRepresentation::None, SampledSourceReason::DeclinedImportBypassed};
+
+    switch (proof) {
+        case MetadataProof::UnknownKind:
             return {SampledSourceRepresentation::None,
                     SampledSourceReason::DeclinedUnknownMetadataKind};
+        case MetadataProof::NoExactFootprint:
+            return {SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedNoExactMetadataFootprint};
+        case MetadataProof::Absent:
+        case MetadataProof::NotDecompressed:
+            return {SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnsupportedMetadataState};
+        case MetadataProof::ProvesPlain:
+            break;
     }
     return {SampledSourceRepresentation::None, SampledSourceReason::DeclinedNoAuthority};
 }
@@ -91,18 +173,34 @@ const char* sampled_source_representation_name(SampledSourceRepresentation repre
 
 const char* sampled_source_reason_name(SampledSourceReason reason) {
     switch (reason) {
-        case SampledSourceReason::UncompressedDescriptor:           return "uncompressed-descriptor";
-        case SampledSourceReason::RendererImageImport:              return "renderer-image-import";
-        case SampledSourceReason::ExactDccMaterialization:          return "exact-dcc-materialization";
-        case SampledSourceReason::DccUncompressedBase:              return "dcc-uncompressed-base";
-        case SampledSourceReason::HtileUncompressedBase:            return "htile-uncompressed-base";
-        case SampledSourceReason::OrderedProducerWriteback:         return "ordered-producer-writeback";
-        case SampledSourceReason::DeclinedUnknownMetadataKind:      return "declined-unknown-metadata-kind";
-        case SampledSourceReason::DeclinedUnsupportedMetadataState: return "declined-unsupported-metadata-state";
-        case SampledSourceReason::DeclinedImportBypassed:           return "declined-import-bypassed";
-        case SampledSourceReason::DeclinedNoAuthority:              return "declined-no-authority";
+        case SampledSourceReason::UncompressedDescriptor:   return "uncompressed-descriptor";
+        case SampledSourceReason::RendererImageImport:       return "renderer-image-import";
+        case SampledSourceReason::ExactDccMaterialization:   return "exact-dcc-materialization";
+        case SampledSourceReason::ExactHtileMaterialization: return "exact-htile-materialization";
+        case SampledSourceReason::DccUncompressedBase:       return "dcc-uncompressed-base";
+        case SampledSourceReason::HtileUncompressedBase:     return "htile-uncompressed-base";
+        case SampledSourceReason::OrderedProducerWriteback:  return "ordered-producer-writeback";
+        case SampledSourceReason::DeclinedUnknownMetadataKind:
+            return "declined-unknown-metadata-kind";
+        case SampledSourceReason::DeclinedNoExactMetadataFootprint:
+            return "declined-no-exact-metadata-footprint";
+        case SampledSourceReason::DeclinedUnsupportedMetadataState:
+            return "declined-unsupported-metadata-state";
+        case SampledSourceReason::DeclinedImportBypassed:    return "declined-import-bypassed";
+        case SampledSourceReason::DeclinedNoAuthority:       return "declined-no-authority";
     }
     return "declined-no-authority";
+}
+
+const char* metadata_proof_name(MetadataProof proof) {
+    switch (proof) {
+        case MetadataProof::Absent:           return "absent";
+        case MetadataProof::UnknownKind:      return "unknown-kind";
+        case MetadataProof::NoExactFootprint: return "no-exact-footprint";
+        case MetadataProof::NotDecompressed:  return "not-decompressed";
+        case MetadataProof::ProvesPlain:      return "proves-plain";
+    }
+    return "absent";
 }
 
 }  // namespace prosper::gpu

--- a/prosper/src/gpu/compressed_source_authority.cpp
+++ b/prosper/src/gpu/compressed_source_authority.cpp
@@ -39,6 +39,13 @@ size_t exact_metadata_span(const MetadataPlaneShape& shape) {
                                                        shape.sample_count, shape.meta_pipe_aligned);
             return 0;
         case CompressionMetadataKind::Dcc: {
+            // The DCC helper's published contract is SINGLE-SAMPLE base-level SW_64KB_R_X. It takes no
+            // sample count, so it cannot reject a multisample shape -- this caller must, or a 4xAA
+            // colour surface receives the single-sample span and an all-0xff prefix over that wrong
+            // window authorizes the base. That is the same self-consistent wrong footprint this whole
+            // resolver exists to make inexpressible.
+            if (shape.sample_count != 1u) return 0;
+            if (shape.img_dim == 6u) return 0;   // 2D_MSAA is not a single-sample colour shape
             const uint32_t bytes_per_texel = texel_bytes(shape.format, shape.num_components);
             if (!bytes_per_texel) return 0;
             const uint32_t layers =
@@ -81,22 +88,27 @@ MetadataProof resolve_metadata_proof(const MetadataPlaneShape& shape, const uint
 bool producer_writeback_covers_read(const ProducerWritebackRecord& record,
                                    const ConsumerReadRequest& read) {
     if (!record.present) return false;
-    // Same allocation, same version of its contents.
-    if (record.base_addr != read.base_addr) return false;
+
+    // EXACT physical identity. Anything else and the same bytes are a different image -- a 3D versus
+    // arrayed view, a shifted mip, a different mip-tail placement, or a different owned backing.
+    if (!(record.layout == read.layout)) return false;
+
+    // The layout must actually establish how wide a texel is. Two unknown formats both report 0, and
+    // comparing 0 == 0 would accept them as compatible -- zero means "cannot establish", not "matches".
+    if (!texel_bytes(read.layout.format, read.layout.num_components)) return false;
+
+    // Same version of the contents.
     if (record.content_version != read.content_version) return false;
-    // The producer's written range must COVER the consumer's read range.
+
+    // Overflow-checked containment. `offset + size` wraps on a hostile or buggy input, and a wrapped
+    // end compares as CONTAINED -- a record covering [0,64) would admit a read at UINT64_MAX-3 of 8
+    // bytes, whose end computes as 4.
+    if (!record.byte_size || !read.byte_size) return false;
+    if (record.byte_size > UINT64_MAX - record.byte_offset) return false;
+    if (read.byte_size > UINT64_MAX - read.byte_offset) return false;
     if (read.byte_offset < record.byte_offset) return false;
-    const uint64_t record_end = record.byte_offset + record.byte_size;
-    const uint64_t read_end = read.byte_offset + read.byte_size;
-    if (!record.byte_size || !read.byte_size || read_end > record_end) return false;
-    // The layout must interpret those bytes the same way. Identical addresses with a different tile
-    // mode, pitch, extent or texel width are a different image over the same memory.
-    if (record.width != read.width || record.height != read.height || record.depth != read.depth)
-        return false;
-    if (record.tile_mode != read.tile_mode || record.row_pitch != read.row_pitch) return false;
-    if (texel_bytes(record.format, record.num_components) !=
-        texel_bytes(read.format, read.num_components))
-        return false;
+    if (read.byte_offset + read.byte_size > record.byte_offset + record.byte_size) return false;
+
     // Ordering: the consumer must come after the producer on the same submit timeline.
     if (record.submit_no != read.submit_no) return false;
     return record.command_order < read.command_order;

--- a/prosper/src/gpu/compressed_source_authority.cpp
+++ b/prosper/src/gpu/compressed_source_authority.cpp
@@ -109,6 +109,23 @@ bool producer_writeback_covers_read(const ProducerWritebackRecord& record,
     if (read.byte_offset < record.byte_offset) return false;
     if (read.byte_offset + read.byte_size > record.byte_offset + record.byte_size) return false;
 
+    // BOUND BOTH RANGES BY THE LAYOUT THEY CLAIM TO DESCRIBE. Containment alone only relates the two
+    // ranges to each other, so two matching oversized claims authorized bytes outside the resource: an
+    // identical layout with a 64-byte extent, a record of [0,128) and a read of [0,128) satisfied every
+    // other check here. Overflow checking does not help -- that range does not wrap, it is simply out
+    // of bounds.
+    const uint64_t extent =
+        std::min<uint64_t>(record.layout.guest_bytes, record.layout.resource_bytes);
+    if (!extent) return false;
+
+    // Current policy is deliberately the STRICTEST one that covers the real case: an exact FULL-extent
+    // writeback, which is what the ordered storage-writeback round trip already produces and what the
+    // storage cache key already represents. Partial coverage is representable by the containment logic
+    // above and stays unauthorized until some real shape needs it and can be evaluated on its own
+    // evidence -- a narrower authority cannot be wrong in a way that shows up as plausible pixels.
+    if (record.byte_offset != 0 || record.byte_size != extent) return false;
+    if (read.byte_offset != 0 || read.byte_size != extent) return false;
+
     // Ordering: the consumer must come after the producer on the same submit timeline.
     if (record.submit_no != read.submit_no) return false;
     return record.command_order < read.command_order;

--- a/prosper/src/gpu/compressed_source_authority.cpp
+++ b/prosper/src/gpu/compressed_source_authority.cpp
@@ -1,0 +1,108 @@
+#include "compressed_source_authority.hpp"
+
+#include <algorithm>
+
+#include "tile.hpp"
+
+namespace prosper::gpu {
+namespace {
+
+// DCC's "nothing in this block is compressed" code is 0xff per byte. Taken from the predicate this
+// replaces (the former `dcc_cache_safe` scan in the live compute backend), not newly invented — what
+// changed is that it now selects the SOURCE rather than only cache eligibility, and that it is applied
+// only when the metadata is known to BE DCC.
+bool dcc_metadata_proves_plain(const uint8_t* metadata, size_t metadata_bytes,
+                               size_t expected_bytes) {
+    if (!metadata || !expected_bytes || metadata_bytes != expected_bytes) return false;
+    return std::all_of(metadata, metadata + metadata_bytes,
+                       [](uint8_t value) { return value == 0xffu; });
+}
+
+}  // namespace
+
+SampledSourceDecision sampled_source_decision(const SampledSourceFacts& facts) {
+    // An import that the caller will consume selects THE IMAGE. Checked before compression, because it
+    // makes the base allocation's encoding irrelevant: those bytes are not the source.
+    if (facts.import_selected)
+        return {SampledSourceRepresentation::ImportedImage, SampledSourceReason::RendererImageImport};
+
+    // An import exists and the caller has chosen NOT to consume it. This is a decline, not a fallback:
+    // the recovery switch that bypasses an imported image is expressing that the image should not be
+    // used, which is the opposite of permission to read guest bytes in its place. The old guard
+    // exempted exactly this case because it only asked whether an import existed.
+    if (facts.import_available)
+        return {SampledSourceRepresentation::None, SampledSourceReason::DeclinedImportBypassed};
+
+    // Not a compressed source: the base carries ordinary texels by construction.
+    if (!facts.compression_enabled)
+        return {SampledSourceRepresentation::GuestBase,
+                SampledSourceReason::UncompressedDescriptor};
+
+    // An exactly supported compressed decode produces its own pixels; the compressed bytes are
+    // interpreted rather than read as though they were plain.
+    if (facts.exact_materialization)
+        return {SampledSourceRepresentation::MaterializedPixels,
+                SampledSourceReason::ExactDccMaterialization};
+
+    // prosper's own ordered writeback put plain texels in the base. The guest's metadata may still read
+    // "compressed" — that is the documented shape of the ordered storage-writeback round trip, where
+    // the base IS authoritative because we wrote it. Requires exact provenance; see the field comment.
+    if (facts.ordered_producer_writeback)
+        return {SampledSourceRepresentation::GuestBase,
+                SampledSourceReason::OrderedProducerWriteback};
+
+    // Metadata may prove the base holds ordinary texels — but ONLY through the proof belonging to its
+    // own kind. Applying DCC's all-0xff scan to an HTILE plane is how a DCC-sized window over depth
+    // metadata came to look like permission, so the kinds do not share a path and Unknown has none.
+    switch (facts.kind) {
+        case CompressionMetadataKind::Dcc:
+            if (dcc_metadata_proves_plain(facts.metadata, facts.metadata_bytes,
+                                          facts.expected_metadata_bytes))
+                return {SampledSourceRepresentation::GuestBase,
+                        SampledSourceReason::DccUncompressedBase};
+            return {SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnsupportedMetadataState};
+        case CompressionMetadataKind::Htile:
+            // PAL's decompressed initial values, checked uniformly across the exact expected span.
+            if (gfx10_htile_metadata_is_decompressed(facts.metadata, facts.metadata_bytes,
+                                                     facts.expected_metadata_bytes, nullptr))
+                return {SampledSourceRepresentation::GuestBase,
+                        SampledSourceReason::HtileUncompressedBase};
+            return {SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnsupportedMetadataState};
+        case CompressionMetadataKind::Unknown:
+            // Deliberately no proof. An aspect-unknown plane cannot be shown decompressed, because
+            // which bit pattern means "decompressed" depends on the kind.
+            return {SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnknownMetadataKind};
+    }
+    return {SampledSourceRepresentation::None, SampledSourceReason::DeclinedNoAuthority};
+}
+
+const char* sampled_source_representation_name(SampledSourceRepresentation representation) {
+    switch (representation) {
+        case SampledSourceRepresentation::None:               return "none";
+        case SampledSourceRepresentation::ImportedImage:      return "imported-image";
+        case SampledSourceRepresentation::MaterializedPixels: return "materialized-pixels";
+        case SampledSourceRepresentation::GuestBase:          return "guest-base";
+    }
+    return "none";
+}
+
+const char* sampled_source_reason_name(SampledSourceReason reason) {
+    switch (reason) {
+        case SampledSourceReason::UncompressedDescriptor:           return "uncompressed-descriptor";
+        case SampledSourceReason::RendererImageImport:              return "renderer-image-import";
+        case SampledSourceReason::ExactDccMaterialization:          return "exact-dcc-materialization";
+        case SampledSourceReason::DccUncompressedBase:              return "dcc-uncompressed-base";
+        case SampledSourceReason::HtileUncompressedBase:            return "htile-uncompressed-base";
+        case SampledSourceReason::OrderedProducerWriteback:         return "ordered-producer-writeback";
+        case SampledSourceReason::DeclinedUnknownMetadataKind:      return "declined-unknown-metadata-kind";
+        case SampledSourceReason::DeclinedUnsupportedMetadataState: return "declined-unsupported-metadata-state";
+        case SampledSourceReason::DeclinedImportBypassed:           return "declined-import-bypassed";
+        case SampledSourceReason::DeclinedNoAuthority:              return "declined-no-authority";
+    }
+    return "declined-no-authority";
+}
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/compressed_source_authority.hpp
+++ b/prosper/src/gpu/compressed_source_authority.hpp
@@ -127,6 +127,9 @@ struct ProducerWritebackRecord {
     bool present = false;
     SampledSourceLayout layout;
     uint64_t content_version = 0;
+    // Relative to `layout.base_addr`, and bounded by the layout's own extent — a range is only
+    // meaningful against the allocation it claims to describe. Two ranges that agree with each other
+    // and exceed that extent used to authorize bytes outside the resource.
     uint64_t byte_offset = 0;
     uint64_t byte_size = 0;
     // Ordering: the consumer must come after the producer in the same submit timeline.
@@ -138,6 +141,7 @@ struct ProducerWritebackRecord {
 struct ConsumerReadRequest {
     SampledSourceLayout layout;
     uint64_t content_version = 0;
+    // Relative to `layout.base_addr`, as above.
     uint64_t byte_offset = 0;
     uint64_t byte_size = 0;
     uint64_t submit_no = 0;

--- a/prosper/src/gpu/compressed_source_authority.hpp
+++ b/prosper/src/gpu/compressed_source_authority.hpp
@@ -1,26 +1,30 @@
 // WHICH representation of a sampled source is authoritative — and, as a consequence, whether the
 // guest base allocation may be read as ordinary texels.
 //
-// One pure decision over explicit facts, shared by both backends, because getting it wrong in either
-// is a silent-wrong-pixels defect. The compute backend asks before guest preparation; the graphics
-// backend asks before decode/detile. Previously neither asked explicitly: compute checked only that
-// the base was *readable*, and graphics merely warned. A mapped base allocation whose texels actually
-// live in DCC or HTILE decodes to plausible garbage, which is strictly worse than declining — it
-// arrives as wrong pixels instead of a visible skip.
+// One pure decision over facts the CALLER CANNOT SELF-CERTIFY, shared by both backends, because
+// getting it wrong in either is a silent-wrong-pixels defect. The compute backend asks before guest
+// preparation; the graphics backend asks before decode/detile. Previously neither asked explicitly:
+// compute checked only that the base was *readable*, and graphics merely warned. A mapped base
+// allocation whose texels live in DCC or HTILE decodes to plausible garbage, which is strictly worse
+// than declining — it arrives as wrong pixels instead of a visible skip.
 //
-// THE DISTINCTION THAT MATTERS, and an earlier draft of this file got it wrong: an imported image is
-// authority to consume THAT IMAGE. It is not permission to read the guest base. Those are different
-// selected sources, so the decision names the source rather than answering a single "may I read"
-// boolean — which would have licensed exactly the wrong thing for an imported binding.
+// WHY THE INPUT TYPES LOOK PARANOID. An earlier draft took `metadata_bytes` and
+// `expected_metadata_bytes` and proved only that the two were equal — both supplied by the adapter. The
+// original defect survived that unchanged: call the colour-DCC footprint helper for an HTILE resource,
+// read exactly that wrong-sized window, pass the same number twice, and a uniform prefix authorizes the
+// base. A shared decision exists so the adapters are NOT trusted; every authority below is therefore
+// either derived here from the resource shape, or minted by the verifier that can actually establish
+// it. A plain `bool` authority is a way for one careless adapter assignment to license raw bytes.
 //
 // This is deliberately NOT part of the zero-mip proof. Compression describes how bytes are ENCODED;
 // that proof is about which LOD is ADDRESSED. Conflating them turned "we cannot decode these bytes"
-// into "this whole program is unsupported", dropping every other thing the program did. Compile on the
-// semantic proof; select the source here, at bind time.
+// into "this whole program is unsupported", dropping every other thing the program did.
 #pragma once
 
 #include <cstddef>
 #include <cstdint>
+
+#include "shader_resources.hpp"   // DataFormat
 
 namespace prosper::gpu {
 
@@ -31,37 +35,133 @@ namespace prosper::gpu {
 // `meta_data_address` for a depth parent and the DCC address there otherwise — the SAME field. So the
 // bit is not an aspect tag, and the T# format alone is not enough either (a Float32x1 view is not
 // necessarily depth). The kind is established by correlating the metadata address with retained
-// depth/HTILE state, which is why it is an INPUT here rather than something this function derives.
+// depth/HTILE state, which is why it is an input rather than something derived from the descriptor.
 enum class CompressionMetadataKind : uint8_t { Unknown, Dcc, Htile };
+
+// The physical shape a metadata plane belongs to. The resolver derives the plane's exact span from
+// this, so no caller can assert a span of its own choosing.
+struct MetadataPlaneShape {
+    CompressionMetadataKind kind = CompressionMetadataKind::Unknown;
+    uint32_t width = 0;
+    uint32_t height = 0;
+    uint32_t depth = 1;
+    uint32_t img_dim = 0;
+    uint32_t sample_count = 1;
+    uint32_t tile_mode = 0;
+    DataFormat format = DataFormat::Float32;
+    uint32_t num_components = 1;
+    bool meta_pipe_aligned = false;
+};
+
+// What the metadata plane establishes. Only `ProvesPlain` can contribute authority, and only the
+// resolver below can produce it.
+enum class MetadataProof : uint8_t {
+    Absent,             // no plane supplied, or fewer bytes readable than the exact span needs
+    UnknownKind,        // aspect unknown: which pattern means "decompressed" is undefined
+    NoExactFootprint,   // kind known, but no exact span is derivable for THIS shape
+    NotDecompressed,    // exact span read; the state is not provably decompressed
+    ProvesPlain,        // exact span read; the kind's OWN proof is satisfied
+};
+
+// Derive the exact plane span from `shape` and apply the proof belonging to `shape.kind`.
+//
+// `readable_bytes` says how much of the plane the caller can actually read — it is a bound, never the
+// span. If the derived span exceeds it, the answer is `Absent`, not a proof over a short window.
+//
+// `NoExactFootprint` is a real and load-bearing answer, not an omission: single-sample HTILE has no
+// exact footprint in this tree today, and GTA V's main depth is exactly that shape. Such a surface may
+// still be imported or exactly materialized — but its metadata must never authorize its base.
+MetadataProof resolve_metadata_proof(const MetadataPlaneShape& shape, const uint8_t* plane,
+                                     size_t readable_bytes);
+
+// Whether an import exists for this binding and whether it will be consumed.
+//
+// A tri-state rather than two bools: the pair permitted `selected && !available`, and "available"
+// conflated an exactly compatible import with a renderer lookup that was later rejected for
+// device/format/extent. Only an exactly compatible import can meaningfully be *bypassed*.
+enum class ImportState : uint8_t {
+    Unavailable,          // no compatible import for this binding
+    Selected,             // an exactly compatible import that the backend WILL consume
+    BypassedCompatible,   // an exactly compatible import the caller has chosen not to consume
+};
+
+// Pixels produced by an exact compressed materialization, named by the materializer that produced
+// them. Untyped, this was a boolean that reported `ExactDccMaterialization` for an HTILE plane and made
+// "Unknown authorizes nothing" false through a fact claiming DCC without proving DCC. Graphics already
+// has exact HTILE materialization, so this was never going to stay DCC-only.
+enum class MaterializedSource : uint8_t { None, ExactDcc, ExactHtile };
+
+// Exact producer provenance for "prosper's own writeback established these bytes".
+//
+// The most dangerous positive authority there is: one mistaken assignment licenses raw bytes while the
+// metadata says they are encoded. So it is verified in this seam from a record, not asserted by a
+// caller — and identity is more than submit ordering. The bytes are only authoritative if the
+// allocation, its version, the byte range AND the layout used to interpret it all match.
+struct ProducerWritebackRecord {
+    bool present = false;
+    uint64_t base_addr = 0;
+    uint64_t byte_offset = 0;
+    uint64_t byte_size = 0;
+    uint64_t content_version = 0;
+    uint32_t width = 0, height = 0, depth = 1;
+    uint32_t tile_mode = 0;
+    uint32_t row_pitch = 0;
+    DataFormat format = DataFormat::Float32;
+    uint32_t num_components = 1;
+    // Ordering: the consumer must come after the producer in the same submit timeline.
+    uint64_t submit_no = 0;
+    uint64_t command_order = 0;
+};
+
+// What the consumer is about to read, in the same terms, so the seam can compare rather than trust.
+struct ConsumerReadRequest {
+    uint64_t base_addr = 0;
+    uint64_t byte_offset = 0;
+    uint64_t byte_size = 0;
+    uint64_t content_version = 0;
+    uint32_t width = 0, height = 0, depth = 1;
+    uint32_t tile_mode = 0;
+    uint32_t row_pitch = 0;
+    DataFormat format = DataFormat::Float32;
+    uint32_t num_components = 1;
+    uint64_t submit_no = 0;
+    uint64_t command_order = 0;
+};
+
+// True only when the record covers this exact read, in order, with a layout that interprets the same
+// bytes the same way.
+bool producer_writeback_covers_read(const ProducerWritebackRecord& record,
+                                   const ConsumerReadRequest& read);
 
 // The source the backend is authorized to consume.
 enum class SampledSourceRepresentation : uint8_t {
     None,               // declined; consume nothing
     ImportedImage,      // a retained renderer-owned image — NOT permission to read the base
-    MaterializedPixels, // pixels produced by an exactly supported compressed decode
+    MaterializedPixels, // pixels produced by an exact compressed materialization
     GuestBase,          // the guest base allocation, read as ordinary texels
 };
 
-// Why that source was selected. Stable and typed so tests assert the decision rather than log text,
-// and so a decline is attributable instead of sharing an anonymous skip with unrelated reasons.
+// Why that source was selected. Typed so tests assert the decision rather than log text, and so a
+// decline is attributable instead of sharing an anonymous skip with unrelated reasons.
 enum class SampledSourceReason : uint8_t {
-    UncompressedDescriptor,             // no metadata compression declared
-    RendererImageImport,                // the import is the representation actually selected
-    ExactDccMaterialization,            // uniform DCC fast clear, materialized exactly
-    DccUncompressedBase,                // DCC metadata proves the base holds ordinary texels
-    HtileUncompressedBase,              // HTILE metadata proves the same, by ITS OWN proof
-    OrderedProducerWriteback,           // prosper's own ordered writeback established these bytes
-    DeclinedUnknownMetadataKind,        // aspect unknown: no proof exists to apply
-    DeclinedUnsupportedMetadataState,   // kind known, state not provably decompressed
-    DeclinedImportBypassed,             // an import exists but the caller will not consume it
-    DeclinedNoAuthority,                // compressed, and nothing establishes any source
+    UncompressedDescriptor,
+    RendererImageImport,
+    ExactDccMaterialization,
+    ExactHtileMaterialization,
+    DccUncompressedBase,
+    HtileUncompressedBase,
+    OrderedProducerWriteback,
+    DeclinedUnknownMetadataKind,
+    DeclinedNoExactMetadataFootprint,
+    DeclinedUnsupportedMetadataState,
+    DeclinedImportBypassed,
+    DeclinedNoAuthority,
 };
 
 struct SampledSourceDecision {
     SampledSourceRepresentation representation = SampledSourceRepresentation::None;
     SampledSourceReason reason = SampledSourceReason::DeclinedNoAuthority;
 
-    // Only one representation licenses interpreting the guest allocation as plain texels.
     bool may_read_guest_base() const {
         return representation == SampledSourceRepresentation::GuestBase;
     }
@@ -70,31 +170,22 @@ struct SampledSourceDecision {
 struct SampledSourceFacts {
     bool compression_enabled = false;
 
-    // The metadata plane, and how many bytes this surface's kind says it should be. A window that is
-    // not exactly the expected size proves nothing: a short read can be uniform by accident, and a
-    // wrong-kind footprint is precisely the case where the caller's sizing is not to be trusted.
-    CompressionMetadataKind kind = CompressionMetadataKind::Unknown;
-    const uint8_t* metadata = nullptr;
-    size_t metadata_bytes = 0;
-    size_t expected_metadata_bytes = 0;
+    ImportState import_state = ImportState::Unavailable;
+    MaterializedSource materialized = MaterializedSource::None;
 
-    // An import exists for this binding at all.
-    bool import_available = false;
-    // ...and the caller will actually consume it. A recovery switch that has chosen to bypass the
-    // imported image leaves this false, and that is a DECLINE rather than a fallback to guest bytes.
-    bool import_selected = false;
+    // The metadata plane's shape and readable extent. The proof is resolved HERE, from the shape.
+    MetadataPlaneShape metadata_shape;
+    const uint8_t* metadata_plane = nullptr;
+    size_t metadata_readable_bytes = 0;
 
-    bool exact_materialization = false;
-
-    // prosper's own ordered writeback established the base bytes. This must be EXACT provenance —
-    // same base identity, range and version, in order — not "prosper wrote this address at some
-    // earlier time". The ordered-submit journal is the intended input.
-    bool ordered_producer_writeback = false;
+    ProducerWritebackRecord producer;
+    ConsumerReadRequest read;
 };
 
 SampledSourceDecision sampled_source_decision(const SampledSourceFacts& facts);
 
 const char* sampled_source_representation_name(SampledSourceRepresentation representation);
 const char* sampled_source_reason_name(SampledSourceReason reason);
+const char* metadata_proof_name(MetadataProof proof);
 
 }  // namespace prosper::gpu

--- a/prosper/src/gpu/compressed_source_authority.hpp
+++ b/prosper/src/gpu/compressed_source_authority.hpp
@@ -1,0 +1,100 @@
+// WHICH representation of a sampled source is authoritative — and, as a consequence, whether the
+// guest base allocation may be read as ordinary texels.
+//
+// One pure decision over explicit facts, shared by both backends, because getting it wrong in either
+// is a silent-wrong-pixels defect. The compute backend asks before guest preparation; the graphics
+// backend asks before decode/detile. Previously neither asked explicitly: compute checked only that
+// the base was *readable*, and graphics merely warned. A mapped base allocation whose texels actually
+// live in DCC or HTILE decodes to plausible garbage, which is strictly worse than declining — it
+// arrives as wrong pixels instead of a visible skip.
+//
+// THE DISTINCTION THAT MATTERS, and an earlier draft of this file got it wrong: an imported image is
+// authority to consume THAT IMAGE. It is not permission to read the guest base. Those are different
+// selected sources, so the decision names the source rather than answering a single "may I read"
+// boolean — which would have licensed exactly the wrong thing for an imported binding.
+//
+// This is deliberately NOT part of the zero-mip proof. Compression describes how bytes are ENCODED;
+// that proof is about which LOD is ADDRESSED. Conflating them turned "we cannot decode these bytes"
+// into "this whole program is unsupported", dropping every other thing the program did. Compile on the
+// semantic proof; select the source here, at bind time.
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::gpu {
+
+// Which kind of compression metadata a descriptor's `metadata_addr` points at.
+//
+// T# WORD6[21] means "metadata texture fetch is enabled". It does NOT say which kind: AMD PAL's GFX10
+// SRD builder sets it for depth/stencil and colour alike, putting `GetHtile256BAddr()` in
+// `meta_data_address` for a depth parent and the DCC address there otherwise — the SAME field. So the
+// bit is not an aspect tag, and the T# format alone is not enough either (a Float32x1 view is not
+// necessarily depth). The kind is established by correlating the metadata address with retained
+// depth/HTILE state, which is why it is an INPUT here rather than something this function derives.
+enum class CompressionMetadataKind : uint8_t { Unknown, Dcc, Htile };
+
+// The source the backend is authorized to consume.
+enum class SampledSourceRepresentation : uint8_t {
+    None,               // declined; consume nothing
+    ImportedImage,      // a retained renderer-owned image — NOT permission to read the base
+    MaterializedPixels, // pixels produced by an exactly supported compressed decode
+    GuestBase,          // the guest base allocation, read as ordinary texels
+};
+
+// Why that source was selected. Stable and typed so tests assert the decision rather than log text,
+// and so a decline is attributable instead of sharing an anonymous skip with unrelated reasons.
+enum class SampledSourceReason : uint8_t {
+    UncompressedDescriptor,             // no metadata compression declared
+    RendererImageImport,                // the import is the representation actually selected
+    ExactDccMaterialization,            // uniform DCC fast clear, materialized exactly
+    DccUncompressedBase,                // DCC metadata proves the base holds ordinary texels
+    HtileUncompressedBase,              // HTILE metadata proves the same, by ITS OWN proof
+    OrderedProducerWriteback,           // prosper's own ordered writeback established these bytes
+    DeclinedUnknownMetadataKind,        // aspect unknown: no proof exists to apply
+    DeclinedUnsupportedMetadataState,   // kind known, state not provably decompressed
+    DeclinedImportBypassed,             // an import exists but the caller will not consume it
+    DeclinedNoAuthority,                // compressed, and nothing establishes any source
+};
+
+struct SampledSourceDecision {
+    SampledSourceRepresentation representation = SampledSourceRepresentation::None;
+    SampledSourceReason reason = SampledSourceReason::DeclinedNoAuthority;
+
+    // Only one representation licenses interpreting the guest allocation as plain texels.
+    bool may_read_guest_base() const {
+        return representation == SampledSourceRepresentation::GuestBase;
+    }
+};
+
+struct SampledSourceFacts {
+    bool compression_enabled = false;
+
+    // The metadata plane, and how many bytes this surface's kind says it should be. A window that is
+    // not exactly the expected size proves nothing: a short read can be uniform by accident, and a
+    // wrong-kind footprint is precisely the case where the caller's sizing is not to be trusted.
+    CompressionMetadataKind kind = CompressionMetadataKind::Unknown;
+    const uint8_t* metadata = nullptr;
+    size_t metadata_bytes = 0;
+    size_t expected_metadata_bytes = 0;
+
+    // An import exists for this binding at all.
+    bool import_available = false;
+    // ...and the caller will actually consume it. A recovery switch that has chosen to bypass the
+    // imported image leaves this false, and that is a DECLINE rather than a fallback to guest bytes.
+    bool import_selected = false;
+
+    bool exact_materialization = false;
+
+    // prosper's own ordered writeback established the base bytes. This must be EXACT provenance —
+    // same base identity, range and version, in order — not "prosper wrote this address at some
+    // earlier time". The ordered-submit journal is the intended input.
+    bool ordered_producer_writeback = false;
+};
+
+SampledSourceDecision sampled_source_decision(const SampledSourceFacts& facts);
+
+const char* sampled_source_representation_name(SampledSourceRepresentation representation);
+const char* sampled_source_reason_name(SampledSourceReason reason);
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/compressed_source_authority.hpp
+++ b/prosper/src/gpu/compressed_source_authority.hpp
@@ -91,23 +91,44 @@ enum class ImportState : uint8_t {
 // has exact HTILE materialization, so this was never going to stay DCC-only.
 enum class MaterializedSource : uint8_t { None, ExactDcc, ExactHtile };
 
+// The COMPLETE physical identity of an image over a byte range — every field that changes how those
+// bytes are interpreted.
+//
+// It mirrors the existing exact storage cache key (`ComputeImageCacheKey` in the live compute backend)
+// field for field rather than keeping a convenient subset, because a partial identity is what makes
+// "same bytes" mean "same image" when it does not: equal extent, tile mode and pitch still leave a 3D
+// versus arrayed view, a shifted mip, a mip-tail placement, or a different replay-owned backing
+// interpreting the same range differently. Adapters derive this from that key; comparison here is
+// EXACT, and stays exact until some broader alias is independently proved safe.
+struct SampledSourceLayout {
+    uint64_t base_addr = 0;
+    uintptr_t host_data = 0;          // owned-backing identity: two captures may share a guest address
+    uint32_t guest_bytes = 0;
+    uint32_t resource_bytes = 0;
+    uint32_t width = 0, height = 0, depth = 0;
+    uint32_t img_dim = 0;
+    uint32_t tile_mode = 0;
+    uint32_t linear_row_pitch = 0;
+    uint32_t layer_stride = 0, layer_mip_offset = 0;
+    uint32_t mip_tail_offset = 0, mip_tail_bytes = 0, mip_tail_x = 0, mip_tail_y = 0;
+    bool in_mip_tail = false;
+    DataFormat format = DataFormat::Float32;
+    uint32_t num_components = 1;
+
+    bool operator==(const SampledSourceLayout& other) const = default;
+};
+
 // Exact producer provenance for "prosper's own writeback established these bytes".
 //
 // The most dangerous positive authority there is: one mistaken assignment licenses raw bytes while the
 // metadata says they are encoded. So it is verified in this seam from a record, not asserted by a
-// caller — and identity is more than submit ordering. The bytes are only authoritative if the
-// allocation, its version, the byte range AND the layout used to interpret it all match.
+// caller — and identity is more than submit ordering.
 struct ProducerWritebackRecord {
     bool present = false;
-    uint64_t base_addr = 0;
+    SampledSourceLayout layout;
+    uint64_t content_version = 0;
     uint64_t byte_offset = 0;
     uint64_t byte_size = 0;
-    uint64_t content_version = 0;
-    uint32_t width = 0, height = 0, depth = 1;
-    uint32_t tile_mode = 0;
-    uint32_t row_pitch = 0;
-    DataFormat format = DataFormat::Float32;
-    uint32_t num_components = 1;
     // Ordering: the consumer must come after the producer in the same submit timeline.
     uint64_t submit_no = 0;
     uint64_t command_order = 0;
@@ -115,21 +136,17 @@ struct ProducerWritebackRecord {
 
 // What the consumer is about to read, in the same terms, so the seam can compare rather than trust.
 struct ConsumerReadRequest {
-    uint64_t base_addr = 0;
+    SampledSourceLayout layout;
+    uint64_t content_version = 0;
     uint64_t byte_offset = 0;
     uint64_t byte_size = 0;
-    uint64_t content_version = 0;
-    uint32_t width = 0, height = 0, depth = 1;
-    uint32_t tile_mode = 0;
-    uint32_t row_pitch = 0;
-    DataFormat format = DataFormat::Float32;
-    uint32_t num_components = 1;
     uint64_t submit_no = 0;
     uint64_t command_order = 0;
 };
 
-// True only when the record covers this exact read, in order, with a layout that interprets the same
-// bytes the same way.
+// True only when the record covers this exact read, in order, over an identical physical layout whose
+// texel width is actually establishable. Range arithmetic is overflow-checked: an unchecked
+// offset + size wraps, and a wrapped end compares as CONTAINED, which authorizes an arbitrary read.
 bool producer_writeback_covers_read(const ProducerWritebackRecord& record,
                                    const ConsumerReadRequest& read);
 

--- a/prosper/tests/test_compressed_source_authority.cpp
+++ b/prosper/tests/test_compressed_source_authority.cpp
@@ -11,6 +11,8 @@
 //     recovery switch has chosen to bypass is the opposite of permission to read guest bytes.
 #include "gpu/compressed_source_authority.hpp"
 
+#include "gpu/tile.hpp"
+
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -36,14 +38,45 @@ std::vector<uint8_t> uniform_dwords(uint32_t value, size_t dwords) {
     return bytes;
 }
 
-SampledSourceFacts compressed_with(CompressionMetadataKind kind,
-                                   const std::vector<uint8_t>& metadata) {
+// GTA V's main depth: 4K, single-sample, Float32x1, img_dim==1. The shape with NO exact HTILE
+// footprint in this tree -- which is precisely the shape whose metadata must never authorize its base.
+MetadataPlaneShape gta_main_depth_shape() {
+    MetadataPlaneShape s;
+    s.kind = CompressionMetadataKind::Htile;
+    s.width = 3840; s.height = 2160; s.depth = 1;
+    s.img_dim = 1; s.sample_count = 1; s.tile_mode = 24;
+    s.format = DataFormat::Float32; s.num_components = 1;
+    return s;
+}
+
+// The one HTILE shape with a published exact span: 2D_MSAA Z_X, 4xAA, pipe-aligned, mode 24. The
+// footprint helper is deliberately fail-closed outside that envelope, so a shape just outside it
+// (2xAA, mode 27) yields NoExactFootprint -- which is how the first draft of this fixture was wrong.
+MetadataPlaneShape msaa_depth_shape() {
+    MetadataPlaneShape s;
+    s.kind = CompressionMetadataKind::Htile;
+    s.width = 1920; s.height = 1080; s.depth = 1;
+    s.img_dim = 6; s.sample_count = 4; s.tile_mode = 24;
+    s.format = DataFormat::Float32; s.num_components = 1;
+    s.meta_pipe_aligned = true;
+    return s;
+}
+
+MetadataPlaneShape colour_dcc_shape() {
+    MetadataPlaneShape s;
+    s.kind = CompressionMetadataKind::Dcc;
+    s.width = 256; s.height = 128; s.depth = 1;
+    s.img_dim = 1; s.sample_count = 1; s.tile_mode = 27;
+    s.format = DataFormat::Unorm8; s.num_components = 4;
+    return s;
+}
+
+SampledSourceFacts compressed(const MetadataPlaneShape& shape, const std::vector<uint8_t>& plane) {
     SampledSourceFacts f;
     f.compression_enabled = true;
-    f.kind = kind;
-    f.metadata = metadata.data();
-    f.metadata_bytes = metadata.size();
-    f.expected_metadata_bytes = metadata.size();
+    f.metadata_shape = shape;
+    f.metadata_plane = plane.data();
+    f.metadata_readable_bytes = plane.size();
     return f;
 }
 
@@ -56,159 +89,215 @@ bool is(const SampledSourceDecision& d, SampledSourceRepresentation r, SampledSo
 int main() {
     printf("== test_compressed_source_authority ==\n");
 
-    // THE DISTINCTION AN EARLIER DRAFT GOT WRONG. An imported image is authority to consume THAT
-    // IMAGE; it is not permission to read the guest base. A single "may I read the base" boolean
-    // answered true here and would have licensed reading a stale/encoded allocation for an imported
-    // binding. The representation must be named, and it must not be GuestBase.
+    // THE CONCRETE WRONG ROUTE the old code took, and the arm that proves the interface forbids it.
+    // GTA V's main depth is single-sample HTILE, for which this tree has no exact footprint. An adapter
+    // previously reached for the COLOUR-DCC footprint helper, read exactly that wrong-sized window, and
+    // a uniform prefix authorized the base. Here the span is derived from the shape, so the wrong-sized
+    // window is not expressible -- and the plane is filled with VALID uniform HTILE dwords so this
+    // cannot pass merely because the bytes were wrong.
     {
-        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
-        auto imported = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
-        imported.import_available = true;
-        imported.import_selected = true;
-        const auto d = sampled_source_decision(imported);
-        CHECK(is(d, SampledSourceRepresentation::ImportedImage,
+        const auto valid_htile = uniform_dwords(kHtileDepthOnlyDecompressed, 4096);
+        const auto shape = gta_main_depth_shape();
+        CHECK(resolve_metadata_proof(shape, valid_htile.data(), valid_htile.size()) ==
+                  MetadataProof::NoExactFootprint,
+              "single-sample HTILE has no exact footprint, so its plane proves nothing");
+        const auto d = sampled_source_decision(compressed(shape, valid_htile));
+        CHECK(is(d, SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedNoExactMetadataFootprint) &&
+              !d.may_read_guest_base(),
+              "the GTA-shaped depth declines on footprint even with valid uniform HTILE dwords");
+    }
+
+    // The same shape may still be imported or exactly materialized -- the footprint gap forbids the
+    // BASE, not the surface.
+    {
+        const auto valid_htile = uniform_dwords(kHtileDepthOnlyDecompressed, 4096);
+        auto imported = compressed(gta_main_depth_shape(), valid_htile);
+        imported.import_state = ImportState::Selected;
+        CHECK(is(sampled_source_decision(imported), SampledSourceRepresentation::ImportedImage,
                  SampledSourceReason::RendererImageImport),
-              "a selected import selects the IMAGE, whatever the metadata says");
-        CHECK(!d.may_read_guest_base(),
+              "a footprint gap does not prevent consuming an imported image");
+
+        auto materialized = compressed(gta_main_depth_shape(), valid_htile);
+        materialized.materialized = MaterializedSource::ExactHtile;
+        CHECK(is(sampled_source_decision(materialized),
+                 SampledSourceRepresentation::MaterializedPixels,
+                 SampledSourceReason::ExactHtileMaterialization),
+              "exact HTILE materialization is reported as HTILE, not as DCC");
+    }
+
+    // An imported image is authority to consume THAT IMAGE, never permission to read the base.
+    {
+        auto f = compressed(colour_dcc_shape(), uniform_dwords(0x40404040u, 64));
+        f.import_state = ImportState::Selected;
+        const auto d = sampled_source_decision(f);
+        CHECK(d.representation == SampledSourceRepresentation::ImportedImage &&
+              !d.may_read_guest_base(),
               "a selected import is NOT permission to read the guest base");
     }
 
-    // An import the caller will not consume is a DECLINE, not a fallback to guest bytes. This is the
-    // PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS shape: the old guard exempted the case precisely because
-    // it only asked whether an import existed.
+    // A BYPASSED import must not veto an independent proof. This was a global decline before all other
+    // authorities, so a bypassed import rejected even an uncompressed base.
     {
-        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
-        auto bypassed = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
-        bypassed.import_available = true;
-        bypassed.import_selected = false;
-        const auto d = sampled_source_decision(bypassed);
-        CHECK(is(d, SampledSourceRepresentation::None, SampledSourceReason::DeclinedImportBypassed),
-              "an import the caller bypasses declines, naming the bypass");
-        CHECK(!d.may_read_guest_base(),
-              "a bypassed import does not fall back to reading guest bytes");
+        SampledSourceFacts uncompressed;
+        uncompressed.compression_enabled = false;
+        uncompressed.import_state = ImportState::BypassedCompatible;
+        CHECK(is(sampled_source_decision(uncompressed), SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::UncompressedDescriptor),
+              "a bypassed import does not veto an uncompressed base");
+
+        const auto plain_dcc = uniform_dwords(0xffffffffu, 4096);
+        auto proven = compressed(colour_dcc_shape(), plain_dcc);
+        proven.import_state = ImportState::BypassedCompatible;
+        CHECK(is(sampled_source_decision(proven), SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::DccUncompressedBase),
+              "a bypassed import does not veto a proven-plain DCC base");
+
+        auto unproven = compressed(colour_dcc_shape(), uniform_dwords(0x40404040u, 4096));
+        unproven.import_state = ImportState::BypassedCompatible;
+        CHECK(is(sampled_source_decision(unproven), SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedImportBypassed),
+              "with no independent proof, a bypassed import names the decline");
     }
 
-    // An uncompressed source reads the base by construction, and says so as its own reason.
+    // Kind-specific proofs over a DERIVED span, and the cross-kind arms.
     {
-        SampledSourceFacts f;
-        f.compression_enabled = false;
-        const auto d = sampled_source_decision(f);
-        CHECK(is(d, SampledSourceRepresentation::GuestBase,
-                 SampledSourceReason::UncompressedDescriptor) && d.may_read_guest_base(),
-              "an uncompressed descriptor selects the guest base, with nothing to prove");
-    }
+        const auto msaa = msaa_depth_shape();
+        const size_t span = gfx10_htile_msaa_metadata_bytes(
+            msaa.width, msaa.height, msaa.tile_mode, msaa.sample_count, msaa.meta_pipe_aligned);
+        CHECK(span > 0, "the MSAA HTILE shape has a derivable exact span");
+        // And the resolver agrees the span exists: with no plane it is Absent (span known, unreadable)
+        // rather than NoExactFootprint (span unknown). Distinguishing those is the whole point.
+        CHECK(resolve_metadata_proof(msaa, nullptr, 0) == MetadataProof::Absent,
+              "a known span with no readable plane is absent, not a missing footprint");
 
-    // FAIL CLOSED for a compressed source with nothing behind it. The production code lacked this: it
-    // checked only that the base was READABLE, and readable is not authority.
-    {
-        SampledSourceFacts f;
-        f.compression_enabled = true;   // kind Unknown, no metadata, no import, no producer
-        const auto d = sampled_source_decision(f);
-        CHECK(d.representation == SampledSourceRepresentation::None && !d.may_read_guest_base(),
-              "a compressed source with no authority declines and forbids the base");
-    }
+        std::vector<uint8_t> htile_plain(span);
+        for (size_t o = 0; o + 4 <= span; o += 4)
+            std::memcpy(htile_plain.data() + o, &kHtileDepthStencilDecompressed, 4);
+        CHECK(is(sampled_source_decision(compressed(msaa, htile_plain)),
+                 SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::HtileUncompressedBase),
+              "MSAA HTILE proves plain on PAL's decompressed value over the derived span");
 
-    // An UNKNOWN kind authorizes nothing, however uniform its bytes happen to be -- tried with BOTH
-    // kind-specific patterns, so this cannot pass merely because the bytes were wrong.
-    {
-        bool all_declined = true;
-        for (uint32_t pattern : {0xffffffffu, kHtileDepthOnlyDecompressed,
-                                 kHtileDepthStencilDecompressed}) {
-            const auto metadata = uniform_dwords(pattern, 64);
-            const auto d = sampled_source_decision(
-                compressed_with(CompressionMetadataKind::Unknown, metadata));
-            if (!is(d, SampledSourceRepresentation::None,
-                    SampledSourceReason::DeclinedUnknownMetadataKind))
-                all_declined = false;
-        }
-        CHECK(all_declined,
-              "an aspect-unknown plane declines as unknown-kind, whatever it contains");
-    }
-
-    // DCC: all-0xff selects the base. One compressed block withdraws it, with the state reason.
-    {
-        const auto plain = uniform_dwords(0xffffffffu, 64);
-        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, plain)),
-                 SampledSourceRepresentation::GuestBase, SampledSourceReason::DccUncompressedBase),
-              "all-0xff DCC metadata selects the guest base");
-
-        auto one_block = plain;
-        one_block[17] = 0x40;
-        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, one_block)),
-                 SampledSourceRepresentation::None,
-                 SampledSourceReason::DeclinedUnsupportedMetadataState),
-              "one compressed DCC block declines on metadata state");
-    }
-
-    // HTILE: only PAL's decompressed values select the base -- and the CROSS-KIND arms are the point.
-    // Without them, sharing one proof between kinds would pass.
-    {
-        bool both = true;
-        for (uint32_t v : {kHtileDepthOnlyDecompressed, kHtileDepthStencilDecompressed}) {
-            const auto metadata = uniform_dwords(v, 64);
-            if (!is(sampled_source_decision(compressed_with(CompressionMetadataKind::Htile, metadata)),
-                    SampledSourceRepresentation::GuestBase,
-                    SampledSourceReason::HtileUncompressedBase))
-                both = false;
-        }
-        CHECK(both, "HTILE selects the base only on PAL's decompressed initial values");
-
-        const auto dcc_pattern = uniform_dwords(0xffffffffu, 64);
-        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Htile, dcc_pattern)),
-                 SampledSourceRepresentation::None,
-                 SampledSourceReason::DeclinedUnsupportedMetadataState),
+        std::vector<uint8_t> dcc_pattern_over_htile(span, 0xff);
+        CHECK(!sampled_source_decision(compressed(msaa, dcc_pattern_over_htile)).may_read_guest_base(),
               "DCC's all-0xff does NOT prove an HTILE plane decompressed");
 
-        const auto htile_pattern = uniform_dwords(kHtileDepthOnlyDecompressed, 64);
-        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, htile_pattern)),
-                 SampledSourceRepresentation::None,
-                 SampledSourceReason::DeclinedUnsupportedMetadataState),
+        const auto dcc = colour_dcc_shape();
+        std::vector<uint8_t> htile_pattern_over_dcc(8192);
+        for (size_t o = 0; o + 4 <= htile_pattern_over_dcc.size(); o += 4)
+            std::memcpy(htile_pattern_over_dcc.data() + o, &kHtileDepthOnlyDecompressed, 4);
+        CHECK(!sampled_source_decision(compressed(dcc, htile_pattern_over_dcc)).may_read_guest_base(),
               "HTILE's decompressed value does NOT prove a DCC plane plain");
     }
 
-    // A window that is not exactly the expected span proves nothing. The GTA V shape got DCC sizing for
-    // an HTILE plane, so a mismatched length is precisely where the caller's sizing is not trustworthy.
+    // A plane the caller can only partly read cannot be proven uniform over the whole span.
     {
-        const auto metadata = uniform_dwords(0xffffffffu, 64);
-        auto short_window = compressed_with(CompressionMetadataKind::Dcc, metadata);
-        short_window.expected_metadata_bytes = metadata.size() * 2;
-        CHECK(!sampled_source_decision(short_window).may_read_guest_base(),
-              "a metadata window shorter than expected proves nothing");
-
-        auto absent = compressed_with(CompressionMetadataKind::Dcc, metadata);
-        absent.metadata = nullptr;
-        CHECK(!sampled_source_decision(absent).may_read_guest_base(),
-              "absent metadata proves nothing");
+        const auto dcc = colour_dcc_shape();
+        const auto plain = uniform_dwords(0xffffffffu, 4096);
+        auto f = compressed(dcc, plain);
+        f.metadata_readable_bytes = 8;   // far less than the derived span
+        CHECK(!sampled_source_decision(f).may_read_guest_base(),
+              "a plane shorter than the derived span proves nothing");
+        CHECK(resolve_metadata_proof(dcc, plain.data(), 8) == MetadataProof::Absent,
+              "a short readable window resolves as absent, not as a proof");
     }
 
-    // The two remaining positive sources, each on metadata that proves nothing, so each arm can only
-    // pass through the authority it names.
+    // Unknown kind authorizes nothing, whatever the bytes are.
     {
-        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
+        MetadataPlaneShape unknown = colour_dcc_shape();
+        unknown.kind = CompressionMetadataKind::Unknown;
+        bool all_declined = true;
+        for (uint32_t pattern : {0xffffffffu, kHtileDepthOnlyDecompressed,
+                                 kHtileDepthStencilDecompressed}) {
+            const auto plane = uniform_dwords(pattern, 4096);
+            if (!is(sampled_source_decision(compressed(unknown, plane)),
+                    SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnknownMetadataKind))
+                all_declined = false;
+        }
+        CHECK(all_declined, "an aspect-unknown plane declines as unknown-kind, whatever it contains");
 
-        auto materialized = compressed_with(CompressionMetadataKind::Dcc, compressed_metadata);
-        materialized.exact_materialization = true;
-        const auto md = sampled_source_decision(materialized);
-        CHECK(is(md, SampledSourceRepresentation::MaterializedPixels,
-                 SampledSourceReason::ExactDccMaterialization) && !md.may_read_guest_base(),
-              "an exact materialization selects its own pixels, not the base");
+        // ...and materialization must not launder an unknown kind into a DCC claim.
+        auto claimed = compressed(unknown, uniform_dwords(0x40404040u, 64));
+        claimed.materialized = MaterializedSource::ExactHtile;
+        CHECK(sampled_source_decision(claimed).reason ==
+                  SampledSourceReason::ExactHtileMaterialization,
+              "materialization reports the materializer that ran, not a DCC default");
+    }
 
-        auto produced = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
-        produced.ordered_producer_writeback = true;
-        const auto pd = sampled_source_decision(produced);
-        CHECK(is(pd, SampledSourceRepresentation::GuestBase,
-                 SampledSourceReason::OrderedProducerWriteback) && pd.may_read_guest_base(),
-              "an ordered producer writeback makes the base authoritative despite stale metadata");
+    // Producer authority is VERIFIED against the consumer's read, not asserted.
+    {
+        const auto compressed_plane = uniform_dwords(0x40404040u, 4096);
+        ProducerWritebackRecord rec;
+        rec.present = true;
+        rec.base_addr = 0x2000000000ull; rec.byte_offset = 0; rec.byte_size = 65536;
+        rec.content_version = 7;
+        rec.width = 256; rec.height = 64; rec.depth = 1;
+        rec.tile_mode = 27; rec.row_pitch = 1024;
+        rec.format = DataFormat::Unorm8; rec.num_components = 4;
+        rec.submit_no = 11; rec.command_order = 3;
+
+        ConsumerReadRequest read;
+        read.base_addr = rec.base_addr; read.byte_offset = 0; read.byte_size = 65536;
+        read.content_version = 7;
+        read.width = 256; read.height = 64; read.depth = 1;
+        read.tile_mode = 27; read.row_pitch = 1024;
+        read.format = DataFormat::Unorm8; read.num_components = 4;
+        read.submit_no = 11; read.command_order = 9;
+
+        auto with = [&](ProducerWritebackRecord r, ConsumerReadRequest c) {
+            auto f = compressed(colour_dcc_shape(), compressed_plane);
+            f.producer = r; f.read = c;
+            return sampled_source_decision(f);
+        };
+
+        CHECK(is(with(rec, read), SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::OrderedProducerWriteback),
+              "an exactly matching ordered producer writeback makes the base authoritative");
+
+        auto stale = read; stale.content_version = 8;
+        CHECK(!with(rec, stale).may_read_guest_base(),
+              "a different content version withdraws producer authority");
+        auto other_layout = read; other_layout.tile_mode = 24;
+        CHECK(!with(rec, other_layout).may_read_guest_base(),
+              "a different tile mode over the same bytes is a different image");
+        auto other_pitch = read; other_pitch.row_pitch = 2048;
+        CHECK(!with(rec, other_pitch).may_read_guest_base(),
+              "a different row pitch withdraws producer authority");
+        auto wider_texel = read; wider_texel.format = DataFormat::Float32;
+        CHECK(!with(rec, wider_texel).may_read_guest_base(),
+              "a different texel width withdraws producer authority");
+        auto beyond = read; beyond.byte_size = 65536 * 2;
+        CHECK(!with(rec, beyond).may_read_guest_base(),
+              "a read past the written range is not covered");
+        auto before = read; before.command_order = 1;
+        CHECK(!with(rec, before).may_read_guest_base(),
+              "a consumer that precedes the producer is not covered");
+        auto other_submit = read; other_submit.submit_no = 12;
+        CHECK(!with(rec, other_submit).may_read_guest_base(),
+              "a different submit timeline is not covered");
+        ProducerWritebackRecord absent = rec; absent.present = false;
+        CHECK(!with(absent, read).may_read_guest_base(),
+              "no producer record means no producer authority");
+    }
+
+    // Compressed with nothing behind it fails closed.
+    {
+        SampledSourceFacts f;
+        f.compression_enabled = true;
+        CHECK(!sampled_source_decision(f).may_read_guest_base(),
+              "a compressed source with no authority forbids the base");
     }
 
     // Names are part of the contract: a decline must be attributable in a log.
     {
         CHECK(std::string(sampled_source_reason_name(
-                  SampledSourceReason::DeclinedUnknownMetadataKind)) ==
-                  "declined-unknown-metadata-kind" &&
-              std::string(sampled_source_representation_name(
-                  SampledSourceRepresentation::ImportedImage)) == "imported-image",
-              "representations and reasons report distinct stable names");
+                  SampledSourceReason::DeclinedNoExactMetadataFootprint)) ==
+                  "declined-no-exact-metadata-footprint" &&
+              std::string(metadata_proof_name(MetadataProof::NoExactFootprint)) ==
+                  "no-exact-footprint",
+              "representations, reasons and proofs report distinct stable names");
     }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_compressed_source_authority.cpp
+++ b/prosper/tests/test_compressed_source_authority.cpp
@@ -291,6 +291,42 @@ int main() {
                   "a record whose own range overflows covers nothing");
         }
 
+        // JOINTLY OVERSIZED RANGES. The two ranges agree with each other perfectly, so containment is
+        // satisfied and nothing wraps -- but both exceed the extent the layout claims, so they describe
+        // bytes outside the resource. The arm keeps record and read IDENTICAL: enlarging only the
+        // producer would leave the consumer failing containment instead, and the arm would then pass
+        // for a reason unrelated to the bound it is meant to test.
+        {
+            SampledSourceLayout small = layout;
+            small.guest_bytes = 64; small.resource_bytes = 64;      // claims only 64 bytes
+
+            ProducerWritebackRecord over = rec;
+            ConsumerReadRequest over_read = read;
+            over.layout = small;       over_read.layout = small;
+            over.byte_offset = 0;      over.byte_size = 128;        // both exceed the claimed extent
+            over_read.byte_offset = 0; over_read.byte_size = 128;
+            CHECK(!decide(over, over_read).may_read_guest_base(),
+                  "two mutually consistent ranges that exceed the layout extent authorize nothing");
+
+            ProducerWritebackRecord past = rec;
+            ConsumerReadRequest past_read = read;
+            past.layout = small;       past_read.layout = small;
+            past.byte_offset = 64;      past.byte_size = 1;         // starts at the extent boundary
+            past_read.byte_offset = 64; past_read.byte_size = 1;
+            CHECK(!decide(past, past_read).may_read_guest_base(),
+                  "a matching pair starting at the extent boundary authorizes nothing");
+
+            // ...and the in-bounds full-extent pair over that SAME small layout still works, so the two
+            // arms above are about the bound rather than about the small layout itself.
+            ProducerWritebackRecord exact = rec;
+            ConsumerReadRequest exact_read = read;
+            exact.layout = small;       exact_read.layout = small;
+            exact.byte_offset = 0;      exact.byte_size = 64;
+            exact_read.byte_offset = 0; exact_read.byte_size = 64;
+            CHECK(decide(exact, exact_read).may_read_guest_base(),
+                  "an exact full-extent pair over the same layout still authorizes the base");
+        }
+
         // TWO UNKNOWN TEXEL WIDTHS must not compare equal. Zero means "cannot establish", not "matches".
         {
             SampledSourceLayout unknown_width = layout;

--- a/prosper/tests/test_compressed_source_authority.cpp
+++ b/prosper/tests/test_compressed_source_authority.cpp
@@ -1,0 +1,217 @@
+// May a compressed sampled source's base allocation be read as ordinary texels?
+//
+// Every arm here exists because the predicate this replaces got that question wrong in a way that
+// produced plausible pixels rather than a visible failure. The two that matter most:
+//
+//   * the metadata proof must belong to the metadata's OWN KIND. A DCC all-0xff scan applied to an
+//     HTILE plane is not a weaker proof, it is a different question -- and it authorized reading GTA V's
+//     main depth because `gpu_capture_dcc_metadata_footprint()` hands an img_dim==1 Float32x1 shape
+//     colour-DCC sizing.
+//   * an imported image only counts when it is the representation ACTUALLY SELECTED. An import a
+//     recovery switch has chosen to bypass is the opposite of permission to read guest bytes.
+#include "gpu/compressed_source_authority.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+// PAL's decompressed HTILE initial values (gfx9MaskRam.cpp): depth-only and depth+stencil.
+constexpr uint32_t kHtileDepthOnlyDecompressed = 0xfffc000fu;
+constexpr uint32_t kHtileDepthStencilDecompressed = 0xfffff3ffu;
+
+std::vector<uint8_t> uniform_dwords(uint32_t value, size_t dwords) {
+    std::vector<uint8_t> bytes(dwords * sizeof(uint32_t));
+    for (size_t i = 0; i < dwords; ++i)
+        std::memcpy(bytes.data() + i * sizeof(uint32_t), &value, sizeof(value));
+    return bytes;
+}
+
+SampledSourceFacts compressed_with(CompressionMetadataKind kind,
+                                   const std::vector<uint8_t>& metadata) {
+    SampledSourceFacts f;
+    f.compression_enabled = true;
+    f.kind = kind;
+    f.metadata = metadata.data();
+    f.metadata_bytes = metadata.size();
+    f.expected_metadata_bytes = metadata.size();
+    return f;
+}
+
+bool is(const SampledSourceDecision& d, SampledSourceRepresentation r, SampledSourceReason why) {
+    return d.representation == r && d.reason == why;
+}
+
+}  // namespace
+
+int main() {
+    printf("== test_compressed_source_authority ==\n");
+
+    // THE DISTINCTION AN EARLIER DRAFT GOT WRONG. An imported image is authority to consume THAT
+    // IMAGE; it is not permission to read the guest base. A single "may I read the base" boolean
+    // answered true here and would have licensed reading a stale/encoded allocation for an imported
+    // binding. The representation must be named, and it must not be GuestBase.
+    {
+        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
+        auto imported = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
+        imported.import_available = true;
+        imported.import_selected = true;
+        const auto d = sampled_source_decision(imported);
+        CHECK(is(d, SampledSourceRepresentation::ImportedImage,
+                 SampledSourceReason::RendererImageImport),
+              "a selected import selects the IMAGE, whatever the metadata says");
+        CHECK(!d.may_read_guest_base(),
+              "a selected import is NOT permission to read the guest base");
+    }
+
+    // An import the caller will not consume is a DECLINE, not a fallback to guest bytes. This is the
+    // PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS shape: the old guard exempted the case precisely because
+    // it only asked whether an import existed.
+    {
+        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
+        auto bypassed = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
+        bypassed.import_available = true;
+        bypassed.import_selected = false;
+        const auto d = sampled_source_decision(bypassed);
+        CHECK(is(d, SampledSourceRepresentation::None, SampledSourceReason::DeclinedImportBypassed),
+              "an import the caller bypasses declines, naming the bypass");
+        CHECK(!d.may_read_guest_base(),
+              "a bypassed import does not fall back to reading guest bytes");
+    }
+
+    // An uncompressed source reads the base by construction, and says so as its own reason.
+    {
+        SampledSourceFacts f;
+        f.compression_enabled = false;
+        const auto d = sampled_source_decision(f);
+        CHECK(is(d, SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::UncompressedDescriptor) && d.may_read_guest_base(),
+              "an uncompressed descriptor selects the guest base, with nothing to prove");
+    }
+
+    // FAIL CLOSED for a compressed source with nothing behind it. The production code lacked this: it
+    // checked only that the base was READABLE, and readable is not authority.
+    {
+        SampledSourceFacts f;
+        f.compression_enabled = true;   // kind Unknown, no metadata, no import, no producer
+        const auto d = sampled_source_decision(f);
+        CHECK(d.representation == SampledSourceRepresentation::None && !d.may_read_guest_base(),
+              "a compressed source with no authority declines and forbids the base");
+    }
+
+    // An UNKNOWN kind authorizes nothing, however uniform its bytes happen to be -- tried with BOTH
+    // kind-specific patterns, so this cannot pass merely because the bytes were wrong.
+    {
+        bool all_declined = true;
+        for (uint32_t pattern : {0xffffffffu, kHtileDepthOnlyDecompressed,
+                                 kHtileDepthStencilDecompressed}) {
+            const auto metadata = uniform_dwords(pattern, 64);
+            const auto d = sampled_source_decision(
+                compressed_with(CompressionMetadataKind::Unknown, metadata));
+            if (!is(d, SampledSourceRepresentation::None,
+                    SampledSourceReason::DeclinedUnknownMetadataKind))
+                all_declined = false;
+        }
+        CHECK(all_declined,
+              "an aspect-unknown plane declines as unknown-kind, whatever it contains");
+    }
+
+    // DCC: all-0xff selects the base. One compressed block withdraws it, with the state reason.
+    {
+        const auto plain = uniform_dwords(0xffffffffu, 64);
+        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, plain)),
+                 SampledSourceRepresentation::GuestBase, SampledSourceReason::DccUncompressedBase),
+              "all-0xff DCC metadata selects the guest base");
+
+        auto one_block = plain;
+        one_block[17] = 0x40;
+        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, one_block)),
+                 SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedUnsupportedMetadataState),
+              "one compressed DCC block declines on metadata state");
+    }
+
+    // HTILE: only PAL's decompressed values select the base -- and the CROSS-KIND arms are the point.
+    // Without them, sharing one proof between kinds would pass.
+    {
+        bool both = true;
+        for (uint32_t v : {kHtileDepthOnlyDecompressed, kHtileDepthStencilDecompressed}) {
+            const auto metadata = uniform_dwords(v, 64);
+            if (!is(sampled_source_decision(compressed_with(CompressionMetadataKind::Htile, metadata)),
+                    SampledSourceRepresentation::GuestBase,
+                    SampledSourceReason::HtileUncompressedBase))
+                both = false;
+        }
+        CHECK(both, "HTILE selects the base only on PAL's decompressed initial values");
+
+        const auto dcc_pattern = uniform_dwords(0xffffffffu, 64);
+        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Htile, dcc_pattern)),
+                 SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedUnsupportedMetadataState),
+              "DCC's all-0xff does NOT prove an HTILE plane decompressed");
+
+        const auto htile_pattern = uniform_dwords(kHtileDepthOnlyDecompressed, 64);
+        CHECK(is(sampled_source_decision(compressed_with(CompressionMetadataKind::Dcc, htile_pattern)),
+                 SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedUnsupportedMetadataState),
+              "HTILE's decompressed value does NOT prove a DCC plane plain");
+    }
+
+    // A window that is not exactly the expected span proves nothing. The GTA V shape got DCC sizing for
+    // an HTILE plane, so a mismatched length is precisely where the caller's sizing is not trustworthy.
+    {
+        const auto metadata = uniform_dwords(0xffffffffu, 64);
+        auto short_window = compressed_with(CompressionMetadataKind::Dcc, metadata);
+        short_window.expected_metadata_bytes = metadata.size() * 2;
+        CHECK(!sampled_source_decision(short_window).may_read_guest_base(),
+              "a metadata window shorter than expected proves nothing");
+
+        auto absent = compressed_with(CompressionMetadataKind::Dcc, metadata);
+        absent.metadata = nullptr;
+        CHECK(!sampled_source_decision(absent).may_read_guest_base(),
+              "absent metadata proves nothing");
+    }
+
+    // The two remaining positive sources, each on metadata that proves nothing, so each arm can only
+    // pass through the authority it names.
+    {
+        const auto compressed_metadata = uniform_dwords(0x40404040u, 64);
+
+        auto materialized = compressed_with(CompressionMetadataKind::Dcc, compressed_metadata);
+        materialized.exact_materialization = true;
+        const auto md = sampled_source_decision(materialized);
+        CHECK(is(md, SampledSourceRepresentation::MaterializedPixels,
+                 SampledSourceReason::ExactDccMaterialization) && !md.may_read_guest_base(),
+              "an exact materialization selects its own pixels, not the base");
+
+        auto produced = compressed_with(CompressionMetadataKind::Htile, compressed_metadata);
+        produced.ordered_producer_writeback = true;
+        const auto pd = sampled_source_decision(produced);
+        CHECK(is(pd, SampledSourceRepresentation::GuestBase,
+                 SampledSourceReason::OrderedProducerWriteback) && pd.may_read_guest_base(),
+              "an ordered producer writeback makes the base authoritative despite stale metadata");
+    }
+
+    // Names are part of the contract: a decline must be attributable in a log.
+    {
+        CHECK(std::string(sampled_source_reason_name(
+                  SampledSourceReason::DeclinedUnknownMetadataKind)) ==
+                  "declined-unknown-metadata-kind" &&
+              std::string(sampled_source_representation_name(
+                  SampledSourceRepresentation::ImportedImage)) == "imported-image",
+              "representations and reasons report distinct stable names");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_compressed_source_authority.cpp
+++ b/prosper/tests/test_compressed_source_authority.cpp
@@ -71,14 +71,27 @@ MetadataPlaneShape colour_dcc_shape() {
     return s;
 }
 
-SampledSourceFacts compressed(const MetadataPlaneShape& shape, const std::vector<uint8_t>& plane) {
-    SampledSourceFacts f;
-    f.compression_enabled = true;
-    f.metadata_shape = shape;
-    f.metadata_plane = plane.data();
-    f.metadata_readable_bytes = plane.size();
-    return f;
-}
+// The fixture OWNS its metadata plane.
+//
+// The previous helper took a `const std::vector<uint8_t>&` and stored `plane.data()` in the returned
+// facts. Every call site that passed a temporary -- `compressed(shape, uniform_dwords(...))` -- left a
+// dangling pointer that the decision then scanned, and the arms "passed" only because the freed storage
+// happened to be unchanged. Owning the bytes makes that mistake inexpressible rather than merely fixed.
+struct Compressed {
+    std::vector<uint8_t> plane;
+    SampledSourceFacts facts;
+
+    Compressed(const MetadataPlaneShape& shape, std::vector<uint8_t> bytes)
+        : plane(std::move(bytes)) {
+        facts.compression_enabled = true;
+        facts.metadata_shape = shape;
+        facts.metadata_plane = plane.data();
+        facts.metadata_readable_bytes = plane.size();
+    }
+    // Non-copyable: a copy would leave `facts.metadata_plane` pointing into the original's vector.
+    Compressed(const Compressed&) = delete;
+    Compressed& operator=(const Compressed&) = delete;
+};
 
 bool is(const SampledSourceDecision& d, SampledSourceRepresentation r, SampledSourceReason why) {
     return d.representation == r && d.reason == why;
@@ -101,7 +114,8 @@ int main() {
         CHECK(resolve_metadata_proof(shape, valid_htile.data(), valid_htile.size()) ==
                   MetadataProof::NoExactFootprint,
               "single-sample HTILE has no exact footprint, so its plane proves nothing");
-        const auto d = sampled_source_decision(compressed(shape, valid_htile));
+        Compressed gta(shape, valid_htile);
+        const auto d = sampled_source_decision(gta.facts);
         CHECK(is(d, SampledSourceRepresentation::None,
                  SampledSourceReason::DeclinedNoExactMetadataFootprint) &&
               !d.may_read_guest_base(),
@@ -112,15 +126,15 @@ int main() {
     // BASE, not the surface.
     {
         const auto valid_htile = uniform_dwords(kHtileDepthOnlyDecompressed, 4096);
-        auto imported = compressed(gta_main_depth_shape(), valid_htile);
-        imported.import_state = ImportState::Selected;
-        CHECK(is(sampled_source_decision(imported), SampledSourceRepresentation::ImportedImage,
+        Compressed imported(gta_main_depth_shape(), valid_htile);
+        imported.facts.import_state = ImportState::Selected;
+        CHECK(is(sampled_source_decision(imported.facts), SampledSourceRepresentation::ImportedImage,
                  SampledSourceReason::RendererImageImport),
               "a footprint gap does not prevent consuming an imported image");
 
-        auto materialized = compressed(gta_main_depth_shape(), valid_htile);
-        materialized.materialized = MaterializedSource::ExactHtile;
-        CHECK(is(sampled_source_decision(materialized),
+        Compressed materialized(gta_main_depth_shape(), valid_htile);
+        materialized.facts.materialized = MaterializedSource::ExactHtile;
+        CHECK(is(sampled_source_decision(materialized.facts),
                  SampledSourceRepresentation::MaterializedPixels,
                  SampledSourceReason::ExactHtileMaterialization),
               "exact HTILE materialization is reported as HTILE, not as DCC");
@@ -128,9 +142,9 @@ int main() {
 
     // An imported image is authority to consume THAT IMAGE, never permission to read the base.
     {
-        auto f = compressed(colour_dcc_shape(), uniform_dwords(0x40404040u, 64));
-        f.import_state = ImportState::Selected;
-        const auto d = sampled_source_decision(f);
+        Compressed f(colour_dcc_shape(), uniform_dwords(0x40404040u, 64));
+        f.facts.import_state = ImportState::Selected;
+        const auto d = sampled_source_decision(f.facts);
         CHECK(d.representation == SampledSourceRepresentation::ImportedImage &&
               !d.may_read_guest_base(),
               "a selected import is NOT permission to read the guest base");
@@ -146,16 +160,15 @@ int main() {
                  SampledSourceReason::UncompressedDescriptor),
               "a bypassed import does not veto an uncompressed base");
 
-        const auto plain_dcc = uniform_dwords(0xffffffffu, 4096);
-        auto proven = compressed(colour_dcc_shape(), plain_dcc);
-        proven.import_state = ImportState::BypassedCompatible;
-        CHECK(is(sampled_source_decision(proven), SampledSourceRepresentation::GuestBase,
+        Compressed proven(colour_dcc_shape(), uniform_dwords(0xffffffffu, 4096));
+        proven.facts.import_state = ImportState::BypassedCompatible;
+        CHECK(is(sampled_source_decision(proven.facts), SampledSourceRepresentation::GuestBase,
                  SampledSourceReason::DccUncompressedBase),
               "a bypassed import does not veto a proven-plain DCC base");
 
-        auto unproven = compressed(colour_dcc_shape(), uniform_dwords(0x40404040u, 4096));
-        unproven.import_state = ImportState::BypassedCompatible;
-        CHECK(is(sampled_source_decision(unproven), SampledSourceRepresentation::None,
+        Compressed unproven(colour_dcc_shape(), uniform_dwords(0x40404040u, 4096));
+        unproven.facts.import_state = ImportState::BypassedCompatible;
+        CHECK(is(sampled_source_decision(unproven.facts), SampledSourceRepresentation::None,
                  SampledSourceReason::DeclinedImportBypassed),
               "with no independent proof, a bypassed import names the decline");
     }
@@ -174,20 +187,22 @@ int main() {
         std::vector<uint8_t> htile_plain(span);
         for (size_t o = 0; o + 4 <= span; o += 4)
             std::memcpy(htile_plain.data() + o, &kHtileDepthStencilDecompressed, 4);
-        CHECK(is(sampled_source_decision(compressed(msaa, htile_plain)),
+        Compressed msaa_ok(msaa, htile_plain);
+        CHECK(is(sampled_source_decision(msaa_ok.facts),
                  SampledSourceRepresentation::GuestBase,
                  SampledSourceReason::HtileUncompressedBase),
               "MSAA HTILE proves plain on PAL's decompressed value over the derived span");
 
-        std::vector<uint8_t> dcc_pattern_over_htile(span, 0xff);
-        CHECK(!sampled_source_decision(compressed(msaa, dcc_pattern_over_htile)).may_read_guest_base(),
+        Compressed dcc_over_htile(msaa, std::vector<uint8_t>(span, 0xff));
+        CHECK(!sampled_source_decision(dcc_over_htile.facts).may_read_guest_base(),
               "DCC's all-0xff does NOT prove an HTILE plane decompressed");
 
         const auto dcc = colour_dcc_shape();
         std::vector<uint8_t> htile_pattern_over_dcc(8192);
         for (size_t o = 0; o + 4 <= htile_pattern_over_dcc.size(); o += 4)
             std::memcpy(htile_pattern_over_dcc.data() + o, &kHtileDepthOnlyDecompressed, 4);
-        CHECK(!sampled_source_decision(compressed(dcc, htile_pattern_over_dcc)).may_read_guest_base(),
+        Compressed htile_over_dcc(dcc, htile_pattern_over_dcc);
+        CHECK(!sampled_source_decision(htile_over_dcc.facts).may_read_guest_base(),
               "HTILE's decompressed value does NOT prove a DCC plane plain");
     }
 
@@ -195,9 +210,9 @@ int main() {
     {
         const auto dcc = colour_dcc_shape();
         const auto plain = uniform_dwords(0xffffffffu, 4096);
-        auto f = compressed(dcc, plain);
-        f.metadata_readable_bytes = 8;   // far less than the derived span
-        CHECK(!sampled_source_decision(f).may_read_guest_base(),
+        Compressed f(dcc, plain);
+        f.facts.metadata_readable_bytes = 8;   // far less than the derived span
+        CHECK(!sampled_source_decision(f.facts).may_read_guest_base(),
               "a plane shorter than the derived span proves nothing");
         CHECK(resolve_metadata_proof(dcc, plain.data(), 8) == MetadataProof::Absent,
               "a short readable window resolves as absent, not as a proof");
@@ -210,8 +225,8 @@ int main() {
         bool all_declined = true;
         for (uint32_t pattern : {0xffffffffu, kHtileDepthOnlyDecompressed,
                                  kHtileDepthStencilDecompressed}) {
-            const auto plane = uniform_dwords(pattern, 4096);
-            if (!is(sampled_source_decision(compressed(unknown, plane)),
+            Compressed u(unknown, uniform_dwords(pattern, 4096));
+            if (!is(sampled_source_decision(u.facts),
                     SampledSourceRepresentation::None,
                     SampledSourceReason::DeclinedUnknownMetadataKind))
                 all_declined = false;
@@ -219,67 +234,147 @@ int main() {
         CHECK(all_declined, "an aspect-unknown plane declines as unknown-kind, whatever it contains");
 
         // ...and materialization must not launder an unknown kind into a DCC claim.
-        auto claimed = compressed(unknown, uniform_dwords(0x40404040u, 64));
-        claimed.materialized = MaterializedSource::ExactHtile;
-        CHECK(sampled_source_decision(claimed).reason ==
+        Compressed claimed(unknown, uniform_dwords(0x40404040u, 64));
+        claimed.facts.materialized = MaterializedSource::ExactHtile;
+        CHECK(sampled_source_decision(claimed.facts).reason ==
                   SampledSourceReason::ExactHtileMaterialization,
               "materialization reports the materializer that ran, not a DCC default");
     }
 
-    // Producer authority is VERIFIED against the consumer's read, not asserted.
+    // Producer authority is VERIFIED against the consumer's read, not asserted -- over the COMPLETE
+    // physical identity, with overflow-checked ranges.
     {
-        const auto compressed_plane = uniform_dwords(0x40404040u, 4096);
+        SampledSourceLayout layout;
+        layout.base_addr = 0x2000000000ull;
+        layout.host_data = 0;
+        layout.guest_bytes = 65536; layout.resource_bytes = 65536;
+        layout.width = 256; layout.height = 64; layout.depth = 1;
+        layout.img_dim = 1; layout.tile_mode = 27; layout.linear_row_pitch = 1024;
+        layout.format = DataFormat::Unorm8; layout.num_components = 4;
+
         ProducerWritebackRecord rec;
         rec.present = true;
-        rec.base_addr = 0x2000000000ull; rec.byte_offset = 0; rec.byte_size = 65536;
+        rec.layout = layout;
         rec.content_version = 7;
-        rec.width = 256; rec.height = 64; rec.depth = 1;
-        rec.tile_mode = 27; rec.row_pitch = 1024;
-        rec.format = DataFormat::Unorm8; rec.num_components = 4;
+        rec.byte_offset = 0; rec.byte_size = 65536;
         rec.submit_no = 11; rec.command_order = 3;
 
         ConsumerReadRequest read;
-        read.base_addr = rec.base_addr; read.byte_offset = 0; read.byte_size = 65536;
+        read.layout = layout;
         read.content_version = 7;
-        read.width = 256; read.height = 64; read.depth = 1;
-        read.tile_mode = 27; read.row_pitch = 1024;
-        read.format = DataFormat::Unorm8; read.num_components = 4;
+        read.byte_offset = 0; read.byte_size = 65536;
         read.submit_no = 11; read.command_order = 9;
 
-        auto with = [&](ProducerWritebackRecord r, ConsumerReadRequest c) {
-            auto f = compressed(colour_dcc_shape(), compressed_plane);
+        Compressed fixture(colour_dcc_shape(), uniform_dwords(0x40404040u, 4096));
+        auto decide = [&](const ProducerWritebackRecord& r, const ConsumerReadRequest& c) {
+            SampledSourceFacts f = fixture.facts;   // plane owned by `fixture`, outlives every call
             f.producer = r; f.read = c;
             return sampled_source_decision(f);
         };
 
-        CHECK(is(with(rec, read), SampledSourceRepresentation::GuestBase,
+        CHECK(is(decide(rec, read), SampledSourceRepresentation::GuestBase,
                  SampledSourceReason::OrderedProducerWriteback),
               "an exactly matching ordered producer writeback makes the base authoritative");
 
-        auto stale = read; stale.content_version = 8;
-        CHECK(!with(rec, stale).may_read_guest_base(),
+        // OVERFLOW. A record covering [0,64) must not admit a read whose offset+size WRAPS: the wrapped
+        // end computes as 4 and compares as contained, which would authorize an arbitrary range.
+        {
+            ProducerWritebackRecord small = rec;
+            small.byte_offset = 0; small.byte_size = 64;
+            ConsumerReadRequest wrapping = read;
+            wrapping.byte_offset = UINT64_MAX - 3; wrapping.byte_size = 8;
+            CHECK(!decide(small, wrapping).may_read_guest_base(),
+                  "a read whose offset+size overflows is not contained by any record");
+            ProducerWritebackRecord wrapping_record = rec;
+            wrapping_record.byte_offset = UINT64_MAX - 3; wrapping_record.byte_size = 8;
+            CHECK(!decide(wrapping_record, read).may_read_guest_base(),
+                  "a record whose own range overflows covers nothing");
+        }
+
+        // TWO UNKNOWN TEXEL WIDTHS must not compare equal. Zero means "cannot establish", not "matches".
+        {
+            SampledSourceLayout unknown_width = layout;
+            unknown_width.format = static_cast<DataFormat>(0xfeedu);
+            unknown_width.num_components = 0;
+            ProducerWritebackRecord r = rec; r.layout = unknown_width;
+            ConsumerReadRequest c = read;   c.layout = unknown_width;
+            CHECK(!decide(r, c).may_read_guest_base(),
+                  "two unestablishable texel widths are not a compatible layout");
+        }
+
+        // One field of the COMPLETE identity at a time. Each must withdraw authority on its own.
+        struct Arm { const char* what; SampledSourceLayout layout; };
+        std::vector<Arm> arms;
+        auto arm = [&](const char* what, auto mutate) {
+            SampledSourceLayout m = layout; mutate(m); arms.push_back({what, m});
+        };
+        arm("base address",   [](SampledSourceLayout& l){ l.base_addr += 0x1000; });
+        arm("owned backing",  [](SampledSourceLayout& l){ l.host_data = 0xdead; });
+        arm("guest bytes",    [](SampledSourceLayout& l){ l.guest_bytes /= 2; });
+        arm("resource bytes", [](SampledSourceLayout& l){ l.resource_bytes /= 2; });
+        arm("width",          [](SampledSourceLayout& l){ l.width /= 2; });
+        arm("height",         [](SampledSourceLayout& l){ l.height /= 2; });
+        arm("depth",          [](SampledSourceLayout& l){ l.depth += 1; });
+        arm("img_dim",        [](SampledSourceLayout& l){ l.img_dim = 2; });
+        arm("tile mode",      [](SampledSourceLayout& l){ l.tile_mode = 24; });
+        arm("row pitch",      [](SampledSourceLayout& l){ l.linear_row_pitch *= 2; });
+        arm("layer stride",   [](SampledSourceLayout& l){ l.layer_stride = 4096; });
+        arm("layer mip off",  [](SampledSourceLayout& l){ l.layer_mip_offset = 256; });
+        arm("mip tail off",   [](SampledSourceLayout& l){ l.mip_tail_offset = 512; });
+        arm("mip tail bytes", [](SampledSourceLayout& l){ l.mip_tail_bytes = 512; });
+        arm("mip tail x",     [](SampledSourceLayout& l){ l.mip_tail_x = 8; });
+        arm("mip tail y",     [](SampledSourceLayout& l){ l.mip_tail_y = 8; });
+        arm("in mip tail",    [](SampledSourceLayout& l){ l.in_mip_tail = true; });
+        arm("format",         [](SampledSourceLayout& l){ l.format = DataFormat::Float32; });
+        arm("components",     [](SampledSourceLayout& l){ l.num_components = 2; });
+
+        bool every_field_matters = true;
+        for (const auto& a : arms) {
+            ConsumerReadRequest c = read; c.layout = a.layout;
+            if (decide(rec, c).may_read_guest_base()) {
+                printf("  [FAIL] producer authority survived a changed %s\n", a.what);
+                every_field_matters = false;
+            }
+        }
+        CHECK(every_field_matters,
+              "every field of the physical identity withdraws producer authority on its own");
+
+        ConsumerReadRequest stale = read; stale.content_version = 8;
+        CHECK(!decide(rec, stale).may_read_guest_base(),
               "a different content version withdraws producer authority");
-        auto other_layout = read; other_layout.tile_mode = 24;
-        CHECK(!with(rec, other_layout).may_read_guest_base(),
-              "a different tile mode over the same bytes is a different image");
-        auto other_pitch = read; other_pitch.row_pitch = 2048;
-        CHECK(!with(rec, other_pitch).may_read_guest_base(),
-              "a different row pitch withdraws producer authority");
-        auto wider_texel = read; wider_texel.format = DataFormat::Float32;
-        CHECK(!with(rec, wider_texel).may_read_guest_base(),
-              "a different texel width withdraws producer authority");
-        auto beyond = read; beyond.byte_size = 65536 * 2;
-        CHECK(!with(rec, beyond).may_read_guest_base(),
+        ConsumerReadRequest beyond = read; beyond.byte_size = 65536 * 2;
+        CHECK(!decide(rec, beyond).may_read_guest_base(),
               "a read past the written range is not covered");
-        auto before = read; before.command_order = 1;
-        CHECK(!with(rec, before).may_read_guest_base(),
+        ConsumerReadRequest before = read; before.command_order = 1;
+        CHECK(!decide(rec, before).may_read_guest_base(),
               "a consumer that precedes the producer is not covered");
-        auto other_submit = read; other_submit.submit_no = 12;
-        CHECK(!with(rec, other_submit).may_read_guest_base(),
+        ConsumerReadRequest other_submit = read; other_submit.submit_no = 12;
+        CHECK(!decide(rec, other_submit).may_read_guest_base(),
               "a different submit timeline is not covered");
         ProducerWritebackRecord absent = rec; absent.present = false;
-        CHECK(!with(absent, read).may_read_guest_base(),
+        CHECK(!decide(absent, read).may_read_guest_base(),
               "no producer record means no producer authority");
+    }
+
+    // A MULTISAMPLE DCC shape has no derivable span: the helper's contract is single-sample, and it
+    // takes no sample count, so it cannot reject one itself. Only the sample count differs from the
+    // known-good shape above.
+    {
+        MetadataPlaneShape msaa_colour = colour_dcc_shape();
+        msaa_colour.sample_count = 4;
+        const auto plain = uniform_dwords(0xffffffffu, 8192);
+        CHECK(resolve_metadata_proof(msaa_colour, plain.data(), plain.size()) ==
+                  MetadataProof::NoExactFootprint,
+              "a multisample DCC shape has no derivable span");
+        Compressed f(msaa_colour, plain);
+        CHECK(is(sampled_source_decision(f.facts), SampledSourceRepresentation::None,
+                 SampledSourceReason::DeclinedNoExactMetadataFootprint),
+              "a multisample DCC shape declines on footprint, not on an all-0xff prefix");
+
+        // ...and the single-sample sibling still proves plain, so this is the sample count alone.
+        Compressed ok(colour_dcc_shape(), uniform_dwords(0xffffffffu, 8192));
+        CHECK(sampled_source_decision(ok.facts).may_read_guest_base(),
+              "the same shape at one sample still proves plain");
     }
 
     // Compressed with nothing behind it fails closed.


### PR DESCRIPTION
## Design check on the decision itself, before three adapters depend on it — `2f655123`

Branch `work/gta5-source-authority`, one commit, **nothing wired yet**. That is deliberate: the compute
adapter, the graphics adapter and the zero-mip relaxation all assume this shape, so being wrong here
costs three times over. I would rather spend a review round now than rework all three.

I implemented your model: `SampledSourceRepresentation { None, ImportedImage, MaterializedPixels,
GuestBase }` plus a typed `SampledSourceReason` with distinct declines, `may_read_guest_base()` true
only for `GuestBase`, kind-specific metadata proofs, and `Unknown` authorizing nothing. Fifteen arms,
mutation-checked at the production site — sharing one proof across kinds fails three named arms, and
letting `Unknown` fall through to the DCC scan fails the arm that names the pattern.

**Your correction landed on something I had already got wrong**, which is why I want the shape checked
rather than assumed: my first version answered a single `may_read_base()` boolean and returned **true**
for an imported binding. It would have licensed reading a stale or encoded allocation for exactly the
bindings that have a better source available.

### The one interpretive choice you did not specify, and I think it is load-bearing

I evaluate the import facts **before** `compression_enabled`:

```
if (import_selected)   -> ImportedImage
if (import_available)  -> None / DeclinedImportBypassed
if (!compression_enabled) -> GuestBase / UncompressedDescriptor
...
```

That ordering means **an UNCOMPRESSED source with an available-but-bypassed import now declines**, where
today it would simply read the base — and reading it is perfectly safe, since there is no metadata to
misinterpret. So my ordering may be over-strict for the uncompressed case.

The argument for the current order is that a bypassed import expresses "do not consume this
representation", and silently substituting a different one is how the old guard went wrong. The argument
against is that `PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS` exists precisely to fall back, and for an
uncompressed source that fallback is sound.

**Which do you want?** If the bypass should only decline for *compressed* sources, the fix is to move the
`import_available` test below the `compression_enabled` check, and I would add an arm pinning that an
uncompressed bypassed import reads the base.

### Two smaller ones

- I folded "not compressed" into `GuestBase` + `UncompressedDescriptor` rather than giving it its own
  representation. It seemed right — the selected source genuinely *is* the guest base — but it does mean
  `may_read_guest_base()` is true for two quite different situations (nothing to prove vs. proved).
- `ordered_producer_writeback` is currently a plain input `bool` with a comment demanding exact
  provenance. I have not yet wired it to the ordered-submit journal. Would you rather the type made that
  impossible to get wrong — a submit/dispatch/order identity passed in rather than a bool the adapter
  can set carelessly?

Next steps unless you redirect: the Float32x1 sibling arm in `test_gpu_capture_render.cpp`'s
`run_depth_bits_copy` fixture (thank you — that saved authoring a third DCC scenario), then the compute
adapter, then the graphics adapter with its own raw-read-path test, then the relaxation.

`ctest --no-tests=error -j4` → **260/260**, exit 0.
