### PR TITLE
tools: worktree_reclaim — the documented worktree auto-clean never existed (#1735)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,27 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   Never `cd` back to the main repo root to run git or builds. If you MUST touch the main checkout,
   assume another agent is actively working there — check `git status` first and don't reset/stash/
   switch branches under them (the stash stack is shared too — see the worktree note in the environment
-  preamble). Your worktree is auto-cleaned when its branch merges.
+  preamble).
+  - **Nothing cleans your worktree up. This line used to claim "your worktree is auto-cleaned when
+    its branch merges", and that mechanism never existed** — no git hook, no `core.hooksPath`, no
+    `hooks` key in any settings.json, no `.claude/hooks/`, no script in the repo that calls
+    `git worktree remove` or `prune`, no workflow, no timer. The claim entered as prose in #332 with
+    no code beside it, and by the time #1735 measured the damage there were 121 stale trees / 111 GB;
+    a fortnight later, **278**. The likely origin is a real harness feature — subagents launched with
+    `isolation: "worktree"` genuinely are cleaned up — generalized into a promise about hand-made
+    `git worktree add` trees, which the harness knows nothing about. A charter that promises a safety
+    net nobody has is worse than one that admits the manual step: everybody skips the cleanup *and*
+    nobody files the bug.
+  - **So remove your own worktree when your branch merges**, and run the sweeper periodically:
+    ```bash
+    python3 prosper/tools/worktree_reclaim.py              # census; touches nothing
+    python3 prosper/tools/worktree_reclaim.py --remove --yes
+    ```
+    It refuses any tree that is unmerged, dirty (untracked counts), locked, nested, recently touched,
+    or held by a live process — checked against `/proc/*/cwd`, `exe`, open fds and mappings, and
+    re-checked immediately before each individual removal. That last guard is not paranoia:
+    **removing a worktree a live shell is `cd`'d into wedges that shell irrecoverably**, and it has
+    happened here. It never deletes a branch, so nothing becomes unreachable.
 - **On a Windows host, run git through PowerShell (Windows git), not WSL.** The repo lives on the
   Windows filesystem (`C:\...` = `/mnt/c/...`), and worktrees created from Windows store a
   Windows-path gitdir link (`gitdir: C:/Users/.../.git/worktrees/<name>`). WSL's git can't resolve

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,24 +199,32 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   preamble).
   - **Nothing cleans your worktree up. This line used to claim "your worktree is auto-cleaned when
     its branch merges", and that mechanism never existed** — no git hook, no `core.hooksPath`, no
-    `hooks` key in any settings.json, no `.claude/hooks/`, no script in the repo that calls
-    `git worktree remove` or `prune`, no workflow, no timer. The claim entered as prose in #332 with
-    no code beside it, and by the time #1735 measured the damage there were 121 stale trees / 111 GB;
-    a fortnight later, **278**. The likely origin is a real harness feature — subagents launched with
-    `isolation: "worktree"` genuinely are cleaned up — generalized into a promise about hand-made
-    `git worktree add` trees, which the harness knows nothing about. A charter that promises a safety
-    net nobody has is worse than one that admits the manual step: everybody skips the cleanup *and*
-    nobody files the bug.
+    `hooks` key in any settings.json, no `.claude/hooks/`, no workflow, no timer, and — until the
+    sweeper below — no script in the repo that called `git worktree remove` or `prune` at all. The
+    claim entered as prose in #332 with no code beside it, and by the time #1735 measured the damage
+    there were 121 stale trees / 111 GB; a fortnight later, **278**. The likely origin is a real
+    harness feature — subagents launched with `isolation: "worktree"` are cleaned up **if
+    unchanged** — generalized into a promise about hand-made `git worktree add` trees, which the
+    harness knows nothing about, and stripped of the one condition that made it true. A charter that
+    promises a safety net nobody has is worse than one that admits the manual step: everybody skips
+    the cleanup *and* nobody files the bug.
   - **So remove your own worktree when your branch merges**, and run the sweeper periodically:
     ```bash
     python3 prosper/tools/worktree_reclaim.py              # census; touches nothing
     python3 prosper/tools/worktree_reclaim.py --remove --yes
     ```
     It refuses any tree that is unmerged, dirty (untracked counts), locked, nested, recently touched,
-    or held by a live process — checked against `/proc/*/cwd`, `exe`, open fds and mappings, and
-    re-checked immediately before each individual removal. That last guard is not paranoia:
-    **removing a worktree a live shell is `cd`'d into wedges that shell irrecoverably**, and it has
-    happened here. It never deletes a branch, so nothing becomes unreachable.
+    or held by a live process — checked against `/proc/*/cwd`, `exe`, open fds and mappings, matched
+    by inode so a container's `/home` spelling of a `/var/home` path still counts, and re-checked
+    immediately before each individual removal. That last guard is not paranoia: **removing a
+    worktree a live shell is `cd`'d into wedges that shell irrecoverably**, and it has happened here.
+    It never deletes a branch.
+    **What it does NOT protect: gitignored files.** `git status` does not list them, so a tree whose
+    only content is an ignored `build-linux/` or a run log reads as clean and is removed with it —
+    which is mostly the point, but this charter also tells you to put run artifacts in "a gitignored
+    worktree-local directory". Move anything you want to keep out of the tree, or `git worktree lock`
+    it. On macOS and Windows the tool classifies but never removes: the in-use guard needs `/proc`,
+    and without it the tool cannot prove nobody is inside, so it fails closed.
 - **On a Windows host, run git through PowerShell (Windows git), not WSL.** The repo lives on the
   Windows filesystem (`C:\...` = `/mnt/c/...`), and worktrees created from Windows store a
   Windows-path gitdir link (`gitdir: C:/Users/.../.git/worktrees/<name>`). WSL's git can't resolve

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -133,9 +133,18 @@ if(Python3_Interpreter_FOUND)
   # touched, locked, nested) and asserts both the refusal and which guard produced it. It also
   # pins the instrument bug found while writing it -- examining a worktree used to make it look
   # freshly touched, which reported all 278 real trees as busy (#1735).
-  add_test(NAME worktree_reclaim_tool
-           COMMAND "${Python3_EXECUTABLE}"
-                   "${CMAKE_SOURCE_DIR}/tools/test_worktree_reclaim.py")
+  #
+  # Linux only, and that is a statement about the tool rather than about the test. Its in-use
+  # guard reads /proc, so on macOS and Windows it cannot prove nobody is inside a tree and fails
+  # closed: it classifies, and removes nothing, there. Testing removal guards where removal never
+  # happens would assert on a configuration nobody runs. The fail-closed behaviour itself is
+  # covered by a platform-independent arm, so the property that protects those platforms is still
+  # verified everywhere this suite runs.
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_test(NAME worktree_reclaim_tool
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tools/test_worktree_reclaim.py")
+  endif()
   add_test(NAME re_edis_mapping
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_edis.py")
   # nid_gate_scan answers "does this title BRANCH on an imported function's return value?", and a

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -128,6 +128,14 @@ if(Python3_Interpreter_FOUND)
                    "$<TARGET_FILE:self_dump>")
   add_test(NAME re_xref_decoder
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_xref.py")
+  # worktree_reclaim deletes directories, so its tests are mutation arms first: each builds a tree
+  # that MUST NOT be removed (dirty, untracked-only, unmerged, held by a live process, recently
+  # touched, locked, nested) and asserts both the refusal and which guard produced it. It also
+  # pins the instrument bug found while writing it -- examining a worktree used to make it look
+  # freshly touched, which reported all 278 real trees as busy (#1735).
+  add_test(NAME worktree_reclaim_tool
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/test_worktree_reclaim.py")
   add_test(NAME re_edis_mapping
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_edis.py")
   # nid_gate_scan answers "does this title BRANCH on an imported function's return value?", and a

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Self-checking tests for worktree_reclaim.py (exit code is truth).
+
+The assertion that matters here is NOT "it removed the safe tree" -- a tool that removes
+everything passes that. It is that each must-not-remove tree is refused, AND that the refusal
+names the guard that fired. So every mutation arm below pins the specific blocker, not merely
+that removal did not happen: a tree spared for the wrong reason is a tool that will delete
+someone's work as soon as that accidental reason stops holding.
+
+Each arm is built BY HAND from git primitives rather than from the tool's own view of the world,
+because a fixture derived from the thing under test inherits its blind spots.
+
+Run directly, or via ctest as worktree_reclaim_tool.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import worktree_reclaim as W  # noqa: E402
+
+FAILURES: list[str] = []
+OLD = 400 * 3600  # comfortably past the default 12 h idle threshold
+
+
+def check(name: str, got, want, extra: str = "") -> None:
+    if got == want:
+        print(f"  ok   {name}")
+    else:
+        msg = f"{name}: got {got!r}, want {want!r}"
+        if extra:
+            msg += f" ({extra})"
+        print(f"  FAIL {msg}")
+        FAILURES.append(msg)
+
+
+def git(repo: str | Path, *args: str, check_rc: bool = True) -> str:
+    p = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if check_rc and p.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {p.stderr.strip()}")
+    return p.stdout
+
+
+def age(path: str | Path, admin: str | Path | None, seconds: int = OLD) -> None:
+    """Backdate everything probe_idle looks at, so a fixture reads as idle."""
+    when = time.time() - seconds
+    targets = [Path(path)] + list(Path(path).iterdir())
+    if admin and Path(admin).is_dir():
+        targets += list(Path(admin).iterdir())
+    for t in targets:
+        try:
+            os.utime(t, (when, when), follow_symlinks=False)
+        except (OSError, NotImplementedError):
+            pass
+
+
+def admin_of(repo: Path, name: str) -> Path:
+    return repo / ".git" / "worktrees" / name
+
+
+def build_repo(root: Path) -> Path:
+    """A repo whose `origin/master` ref exists without needing a real remote."""
+    repo = root / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "master")
+    git(repo, "config", "user.email", "t@example.invalid")
+    git(repo, "config", "user.name", "t")
+    (repo / "file.txt").write_text("base\n")
+    git(repo, "add", "file.txt")
+    git(repo, "commit", "-qm", "base")
+    head = git(repo, "rev-parse", "HEAD").strip()
+    git(repo, "update-ref", "refs/remotes/origin/master", head)
+    return repo
+
+
+def add_wt(repo: Path, name: str, branch: str | None = None) -> Path:
+    path = repo.parent / name
+    args = ["worktree", "add", "-q"]
+    if branch:
+        args += ["-b", branch]
+    git(repo, *args, str(path), "origin/master")
+    return path
+
+
+def survey(repo: Path, **kw):
+    opts = dict(base="origin/master", min_idle_hours=12.0, jobs=2, use_github=False,
+                gh_limit=0, scan_fds=False, scan_maps=False, with_size=False)
+    opts.update(kw)
+    trees, meta = W.survey(repo=str(repo), **opts)
+    return {t.name: t for t in trees}, meta
+
+
+# --------------------------------------------------------------------------- arms
+
+
+def test_positive_and_mutations() -> None:
+    """One removable tree, and one mutation per guard that must refuse it."""
+    print("\n[positive control + per-guard mutation arms]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+
+        safe = add_wt(repo, "safe", "feat/safe")
+        dirty = add_wt(repo, "dirty", "feat/dirty")
+        untracked = add_wt(repo, "untracked", "feat/untracked")
+        unmerged = add_wt(repo, "unmerged", "feat/unmerged")
+        inuse = add_wt(repo, "inuse", "feat/inuse")
+        recent = add_wt(repo, "recent", "feat/recent")
+        locked = add_wt(repo, "locked", "feat/locked")
+
+        # --- mutations, each aimed at exactly one guard -------------------------------
+        (dirty / "file.txt").write_text("modified\n")           # dirty: tracked change
+        (untracked / "scratch.log").write_text("x\n")           # dirty: untracked only
+        (unmerged / "new.txt").write_text("n\n")                # unmerged: real new commit
+        git(unmerged, "add", "new.txt")
+        git(unmerged, "commit", "-qm", "unmerged work")
+        git(repo, "worktree", "lock", str(locked))              # locked
+
+        for name in ("safe", "dirty", "untracked", "unmerged", "inuse", "locked"):
+            age(root / name, admin_of(repo, name))              # `recent` is deliberately not aged
+
+        holder = subprocess.Popen(["sleep", "60"], cwd=str(inuse))  # in-use: a live cwd
+        try:
+            time.sleep(0.4)
+            trees, _ = survey(repo)
+
+            # Positive control: the arm that SHOULD be removable.
+            check("safe is REMOVABLE", trees["safe"].state, "REMOVABLE")
+            check("safe merged via ancestor", trees["safe"].merged_by, "ancestor")
+
+            # Mutation arms: refused, and refused for the RIGHT reason.
+            check("dirty refused", trees["dirty"].removable, False)
+            check("dirty names guard", "dirty" in trees["dirty"].blockers, True,
+                  str(trees["dirty"].blockers))
+            check("untracked-only refused", trees["untracked"].removable, False)
+            check("untracked names guard", "dirty" in trees["untracked"].blockers, True,
+                  str(trees["untracked"].blockers))
+            check("untracked counted as untracked", trees["untracked"].dirty_untracked, 1)
+            check("unmerged refused", trees["unmerged"].removable, False)
+            check("unmerged names guard", "unmerged" in trees["unmerged"].blockers, True,
+                  str(trees["unmerged"].blockers))
+            check("in-use refused", trees["inuse"].removable, False)
+            check("in-use names guard", "in-use" in trees["inuse"].blockers, True,
+                  str(trees["inuse"].blockers))
+            check("in-use identifies the pid", holder.pid in [h.pid for h in trees["inuse"].holders],
+                  True)
+            check("recent refused", trees["recent"].removable, False)
+            check("recent names guard", "recent" in trees["recent"].blockers, True,
+                  str(trees["recent"].blockers))
+            check("locked refused", trees["locked"].removable, False)
+            check("locked names guard", "locked" in trees["locked"].blockers, True,
+                  str(trees["locked"].blockers))
+            check("main refused", trees[repo.name].removable, False)
+            check("main names guard", trees[repo.name].blockers, ["main"])
+        finally:
+            holder.kill()
+            holder.wait()
+            git(repo, "worktree", "unlock", str(locked), check_rc=False)
+
+
+def test_nested_worktree_is_refused() -> None:
+    """A worktree registered underneath another must not be removed out from under it."""
+    print("\n[nested worktree]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        outer = add_wt(repo, "outer", "feat/outer")
+        inner = outer / "inner"
+        git(repo, "worktree", "add", "-q", "-b", "feat/inner", str(inner), "origin/master")
+        age(outer, admin_of(repo, "outer"))
+        age(inner, admin_of(repo, "inner"))
+
+        trees, _ = survey(repo)
+        check("outer refused", trees["outer"].removable, False)
+        check("outer names guard", "nested" in trees["outer"].blockers, True,
+              str(trees["outer"].blockers))
+        check("inner still removable", trees["inner"].state, "REMOVABLE")
+
+
+def test_holder_attributed_to_most_specific_tree() -> None:
+    """A process inside a nested tree must not be blamed on its parent, or vice versa."""
+    print("\n[holder attribution]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        outer = add_wt(repo, "outer", "feat/outer")
+        inner = outer / "inner"
+        git(repo, "worktree", "add", "-q", "-b", "feat/inner", str(inner), "origin/master")
+
+        holder = subprocess.Popen(["sleep", "60"], cwd=str(inner))
+        try:
+            time.sleep(0.4)
+            trees, _ = survey(repo)
+            check("inner sees the holder", holder.pid in [h.pid for h in trees["inner"].holders],
+                  True)
+            check("outer does NOT see it", holder.pid in [h.pid for h in trees["outer"].holders],
+                  False)
+        finally:
+            holder.kill()
+            holder.wait()
+
+
+def test_idle_is_not_measuring_our_own_footprint() -> None:
+    """Regression: examining a tree must not make it look freshly touched.
+
+    Two independent ways the first draft got this wrong, both of which reported every one of 278
+    real worktrees as "0.00h idle" -- a result that reads as a busy machine rather than as a
+    broken gauge, which is what makes it dangerous:
+
+      1. it stat()ed the admin DIRECTORY, whose mtime `git status` bumps by creating and
+         unlinking a lock entry inside it;
+      2. it ran a plain `git status`, which REWRITES the index when the stat cache is stale,
+         setting the mtime of a file idle legitimately reads.
+
+    Fixes: read only the files inside the admin dir, and pass `--no-optional-locks`. This arm
+    drives the tool's OWN probe rather than a hand-rolled git call, so it tests the thing that
+    actually runs. Without both fixes it reads ~0 h instead of ~400 h.
+    """
+    print("\n[instrument: idle must not date our own footprints]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        wt = add_wt(repo, "aged", "feat/aged")
+        admin = admin_of(repo, "aged")
+        # Backdating leaves the stat cache stale, which is exactly the condition under which a
+        # plain `git status` rewrites the index. Without that the arm could not discriminate.
+        age(wt, admin)
+
+        before = W.Worktree(path=str(wt), real=os.path.realpath(wt))
+        before.admin_dir = W.worktree_admin_dir(before)
+        W.probe_idle(before)
+
+        after = W.Worktree(path=str(wt), real=os.path.realpath(wt))
+        after.admin_dir = W.worktree_admin_dir(after)
+        W.probe_status(after)  # the tool's own probe, in the order that used to break
+        admin_dir_mtime_now = time.time() - os.stat(admin).st_mtime
+        W.probe_idle(after)
+        check("status probe saw a clean tree", (after.dirty_tracked, after.dirty_untracked), (0, 0))
+
+        # Only meaningful if git really did touch the directory on this filesystem; if it did
+        # not, the arm cannot discriminate and says so rather than passing vacuously.
+        if admin_dir_mtime_now > 60:
+            print("  SKIP git status did not bump the admin dir mtime here; arm cannot discriminate")
+            return
+        check("idle survives our own status probe", after.idle_hours > 100, True,
+              f"idle={after.idle_hours:.2f}h, admin dir looks {admin_dir_mtime_now:.0f}s old")
+        check("idle unchanged by the probe", abs(after.idle_hours - before.idle_hours) < 1.0, True)
+
+
+def test_dry_run_is_the_default_and_removes_nothing() -> None:
+    """Default and --remove-without--yes must both leave every tree on disk."""
+    print("\n[dry-run gating]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        safe = add_wt(repo, "safe", "feat/safe")
+        age(safe, admin_of(repo, "safe"))
+
+        rc = W.main(["--repo", str(repo), "--no-github", "--no-fds", "--no-maps"])
+        check("default exits 0", rc, 0)
+        check("default kept the tree", safe.is_dir(), True)
+
+        rc = W.main(["--repo", str(repo), "--no-github", "--no-fds", "--no-maps", "--remove"])
+        check("--remove without --yes exits 2", rc, 2)
+        check("--remove without --yes kept the tree", safe.is_dir(), True)
+
+
+def test_remove_takes_only_the_safe_tree() -> None:
+    """End to end: the safe tree goes, every mutation arm stays."""
+    print("\n[--remove --yes end to end]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+
+        safe = add_wt(repo, "safe", "feat/safe")
+        dirty = add_wt(repo, "dirty", "feat/dirty")
+        unmerged = add_wt(repo, "unmerged", "feat/unmerged")
+        recent = add_wt(repo, "recent", "feat/recent")
+
+        (dirty / "file.txt").write_text("modified\n")
+        (unmerged / "new.txt").write_text("n\n")
+        git(unmerged, "add", "new.txt")
+        git(unmerged, "commit", "-qm", "unmerged work")
+        for name in ("safe", "dirty", "unmerged"):
+            age(root / name, admin_of(repo, name))
+
+        rc = W.main(["--repo", str(repo), "--no-github", "--no-fds", "--no-maps",
+                     "--remove", "--yes"])
+        check("exits 0", rc, 0)
+        check("safe tree removed", safe.is_dir(), False)
+        check("dirty tree kept", dirty.is_dir(), True)
+        check("unmerged tree kept", unmerged.is_dir(), True)
+        check("recent tree kept", recent.is_dir(), True)
+        # The branch ref must survive: removal reclaims a directory, never history.
+        check("branch ref kept", git(repo, "rev-parse", "--verify", "feat/safe").strip() != "", True)
+
+
+def test_removal_rechecks_state_rather_than_trusting_the_census() -> None:
+    """A tree that goes dirty after the census must still be refused at removal time."""
+    print("\n[recheck beats a stale census]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        wt = add_wt(repo, "racy", "feat/racy")
+        age(wt, admin_of(repo, "racy"))
+
+        trees, _ = survey(repo)
+        check("census says removable", trees["racy"].state, "REMOVABLE")
+
+        # Simulate the race the tool exists to survive: work appears after the scan.
+        (wt / "file.txt").write_text("someone is mid-edit\n")
+
+        removed = W.recheck_and_remove(str(repo), trees["racy"], "origin/master", 12.0,
+                                       False, False, False, 0, False)
+        check("recheck refuses", removed, False)
+        check("tree still on disk", wt.is_dir(), True)
+
+
+def main() -> int:
+    for fn in (
+        test_positive_and_mutations,
+        test_nested_worktree_is_refused,
+        test_holder_attributed_to_most_specific_tree,
+        test_idle_is_not_measuring_our_own_footprint,
+        test_dry_run_is_the_default_and_removes_nothing,
+        test_remove_takes_only_the_safe_tree,
+        test_removal_rechecks_state_rather_than_trusting_the_census,
+    ):
+        fn()
+    print()
+    if FAILURES:
+        print(f"FAILED ({len(FAILURES)}):")
+        for f in FAILURES:
+            print(f"  - {f}")
+        return 1
+    print("all worktree_reclaim checks passed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -143,8 +143,11 @@ def test_positive_and_mutations() -> None:
             check("untracked names guard", "dirty" in trees["untracked"].blockers, True,
                   str(trees["untracked"].blockers))
             check("untracked counted as untracked", trees["untracked"].dirty_untracked, 1)
+            # These arms run with use_github=False, so the squash-merge cross-check never ran and
+            # the honest verdict is "could not tell", not "this is live work". Both refuse; the
+            # label is the whole point. test_merge_evidence_labels pins the other branch.
             check("unmerged refused", trees["unmerged"].removable, False)
-            check("unmerged names guard", "unmerged" in trees["unmerged"].blockers, True,
+            check("unmerged names guard", "no-merge-evidence" in trees["unmerged"].blockers, True,
                   str(trees["unmerged"].blockers))
             check("in-use refused", trees["inuse"].removable, False)
             check("in-use names guard", "in-use" in trees["inuse"].blockers, True,
@@ -163,6 +166,29 @@ def test_positive_and_mutations() -> None:
             holder.kill()
             holder.wait()
             git(repo, "worktree", "unlock", str(locked), check_rc=False)
+
+
+def test_merge_evidence_labels() -> None:
+    """"Not merged" and "could not tell" must not share a label.
+
+    The ancestor test is blind to squash merges, which is how this repository merges every PR. So
+    without the GitHub cross-check a non-ancestor tree might be live work OR work that landed via
+    a squash, and reporting a `gh` outage as a wall of live branches would be a confident wrong
+    answer. Neither is removable; only the wording differs, and the wording is what a reader acts on.
+    """
+    print("\n[merge evidence: unmerged vs could-not-tell]")
+    unproven = W.Worktree(path="/x", real="/x", merged_by=None, idle_hours=999.0)
+    W.classify(unproven, 12.0, merge_evidence_available=True)
+    check("complete evidence says unmerged", unproven.blockers, ["unmerged"])
+
+    unknown = W.Worktree(path="/x", real="/x", merged_by=None, idle_hours=999.0)
+    W.classify(unknown, 12.0, merge_evidence_available=False)
+    check("incomplete evidence says no-merge-evidence", unknown.blockers, ["no-merge-evidence"])
+
+    proven = W.Worktree(path="/x", real="/x", merged_by="squash-pr#1", idle_hours=999.0)
+    W.classify(proven, 12.0, merge_evidence_available=True)
+    check("proven merged has no blockers", proven.blockers, [])
+    check("proven merged is removable", proven.removable, True)
 
 
 def test_nested_worktree_is_refused() -> None:
@@ -326,6 +352,7 @@ def test_removal_rechecks_state_rather_than_trusting_the_census() -> None:
 def main() -> int:
     for fn in (
         test_positive_and_mutations,
+        test_merge_evidence_labels,
         test_nested_worktree_is_refused,
         test_holder_attributed_to_most_specific_tree,
         test_idle_is_not_measuring_our_own_footprint,

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -244,10 +244,15 @@ def test_github_merge_evidence() -> None:
     check("detached qualifies on sha alone", detached.merged_by, "squash-pr#333")
     check("unmatched sha stays unqualified", untouched.merged_by, None)
 
-    # A branch whose tip has MOVED past the merged PR is live work, not a stale tree.
-    moved = wt("moved", "e" * 40, "feat/moved")
+    # A branch whose tip has MOVED past the merged PR is live work, not a stale tree. The branch
+    # name here MUST be the merged PR's own `feat/landed`: with any other name this arm asserts
+    # nothing that `untouched` above does not already cover, because the sha simply is not in
+    # by_oid either way. Sharing the name is what makes it the one arm that fails if qualification
+    # were ever keyed on branch name instead of sha -- which is the plausible refactor, since the
+    # recycled-branch guard right beside it legitimately does key on the name.
+    moved = wt("moved", "e" * 40, "feat/landed")
     W._apply_github([moved], {"a" * 40: 111}, open_branches=set())
-    check("advanced branch tip stays unqualified", moved.merged_by, None)
+    check("advanced tip of a merged branch stays unqualified", moved.merged_by, None)
 
     # --- probe_github: the open-PR query failing must fail the WHOLE cross-check closed ----
     real_run = W.run

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -377,8 +377,23 @@ def test_remove_takes_only_the_safe_tree() -> None:
 
 
 def test_removal_rechecks_state_rather_than_trusting_the_census() -> None:
-    """A tree that goes dirty after the census must still be refused at removal time."""
+    """A process that enters the tree AFTER the census must still stop the removal.
+
+    The race is deliberately expressed as a live holder rather than as a dirty file. A dirty file
+    is the wrong probe here: `git worktree remove` refuses dirty trees by itself, so that version
+    of this arm passed even with the entire re-check deleted -- git produced the identical
+    observable outcome and the arm could not tell "re-checked" from "trusted the census and got
+    lucky". Verified: with `recheck_and_remove` reduced to a bare `git worktree remove`, the dirty
+    form still reported ok.
+
+    Nothing in git checks for live processes, so only our re-check can refuse this one. It is also
+    the catastrophic case -- the tree wedges a running shell -- and it is exactly what the
+    re-check exists for.
+    """
     print("\n[recheck beats a stale census]")
+    if not holder_scan_supported():
+        print("  SKIP the discriminating form of this arm needs a readable /proc")
+        return
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         repo = build_repo(root)
@@ -388,13 +403,98 @@ def test_removal_rechecks_state_rather_than_trusting_the_census() -> None:
         trees, _ = survey(repo)
         check("census says removable", trees["racy"].state, "REMOVABLE")
 
-        # Simulate the race the tool exists to survive: work appears after the scan.
-        (wt / "file.txt").write_text("someone is mid-edit\n")
+        holder = spawn_holder(wt)  # an agent cd's in after the scan
+        try:
+            time.sleep(0.4)
+            removed = W.recheck_and_remove(str(repo), trees["racy"], "origin/master", 12.0,
+                                           False, False, False, 0, False)
+            check("recheck refuses", removed, False)
+            check("tree still on disk", wt.is_dir(), True)
+        finally:
+            holder.kill()
+            holder.wait()
 
-        removed = W.recheck_and_remove(str(repo), trees["racy"], "origin/master", 12.0,
-                                       False, False, False, 0, False)
-        check("recheck refuses", removed, False)
-        check("tree still on disk", wt.is_dir(), True)
+
+def test_holder_matching_survives_path_aliasing() -> None:
+    """A holder reached through a different spelling of the same directory must still count.
+
+    Regression for a demonstrated false negative. `/home` is a symlink to `/var/home` on this
+    host, so a worktree's canonical path is the `/var/home` form -- but inside the ps5ys distrobox
+    `/home` is a real bind mount, so a container process's `/proc/<pid>/cwd` reads back as
+    `/home/...`. A string-keyed index missed it entirely: measured live, a
+    `distrobox enter ps5ys -- bash -lc "cd <worktree> && ..."` process (the charter's own build
+    command) was invisible while a host process in the same tree was seen.
+
+    The fixture builds the alias by hand with a symlink rather than requiring a container, and
+    feeds the aliased path in as a reference. Under string matching this arm fails; under
+    (st_dev, st_ino) identity it passes.
+    """
+    print("\n[holder matching survives path aliasing]")
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        wt = add_wt(repo, "aliased", "feat/aliased")
+
+        alias = root / "alias"
+        try:
+            alias.symlink_to(root, target_is_directory=True)
+        except (OSError, NotImplementedError):
+            print("  SKIP cannot create a directory symlink on this platform")
+            return
+        aliased_cwd = str(alias / "aliased" / "prosper-ish-subdir")
+        (Path(root / "aliased") / "prosper-ish-subdir").mkdir()
+
+        trees = W.list_worktrees(repo)
+        by_name = {t.name: t for t in trees}
+        check("alias really is a different string", aliased_cwd.startswith(str(by_name["aliased"].real)),
+              False, aliased_cwd)
+
+        W.attach_holders(trees, [(4242, "cwd", "bash", aliased_cwd)])
+        check("aliased holder is attributed", [h.pid for h in by_name["aliased"].holders], [4242])
+        check("and not to the main checkout", [h.pid for h in by_name[repo.name].holders], [])
+
+
+def test_fd_and_map_references_are_holders() -> None:
+    """An open fd or a mapping inside a tree counts, not only cwd.
+
+    Both are on by default in production and neither was covered: every other fixture passes
+    scan_fds=False, scan_maps=False for speed. A compiler writing an object file, or a running
+    binary mapped out of the tree, is the realistic holder that has no cwd there at all.
+    """
+    print("\n[fd and map references]")
+    if not holder_scan_supported():
+        print("  SKIP needs a readable /proc")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        repo = build_repo(root)
+        wt = add_wt(repo, "fdheld", "feat/fdheld")
+
+        # The artifact must be IGNORED, not merely untracked: an untracked file would make the
+        # tree dirty, and then the control below would pass because of the dirty guard rather
+        # than because the fd was released. Ignoring it means the open fd is the only difference
+        # between the two arms, which is what makes this a control at all.
+        (repo / ".git" / "info").mkdir(parents=True, exist_ok=True)
+        (repo / ".git" / "info" / "exclude").write_text("artifact.bin\n")
+        target = wt / "artifact.bin"
+        target.write_bytes(b"x" * 4096)
+        age(wt, admin_of(repo, "fdheld"))
+
+        fh = open(target, "rb")  # a live fd, from a process whose cwd is elsewhere
+        try:
+            trees, _ = survey(repo, scan_fds=True, scan_maps=False)
+            held = trees["fdheld"]
+            check("fd holder refuses the tree", held.removable, False)
+            check("fd holder names in-use", "in-use" in held.blockers, True, str(held.blockers))
+            check("fd holder is this process",
+                  os.getpid() in [h.pid for h in held.holders if h.kind == "fd"], True)
+        finally:
+            fh.close()
+
+        # Control: with the same tree and no fd open, it is removable again -- so the arm above
+        # measured the fd, not some unrelated property of the fixture.
+        trees, _ = survey(repo, scan_fds=True, scan_maps=False)
+        check("removable once the fd is closed", trees["fdheld"].state, "REMOVABLE")
 
 
 def main() -> int:
@@ -408,6 +508,8 @@ def main() -> int:
         test_dry_run_is_the_default_and_removes_nothing,
         test_remove_takes_only_the_safe_tree,
         test_removal_rechecks_state_rather_than_trusting_the_census,
+        test_holder_matching_survives_path_aliasing,
+        test_fd_and_map_references_are_holders,
     ):
         fn()
     print()

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -15,6 +15,7 @@ Run directly, or via ctest as worktree_reclaim_tool.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -196,17 +197,134 @@ def test_merge_evidence_labels() -> None:
     """
     print("\n[merge evidence: unmerged vs could-not-tell]")
     unproven = W.Worktree(path="/x", real="/x", merged_by=None, idle_hours=999.0)
-    W.classify(unproven, 12.0, merge_evidence_available=True)
+    W.classify(unproven, 12.0, merge_evidence_available=True, holder_scan_ok=True)
     check("complete evidence says unmerged", unproven.blockers, ["unmerged"])
 
     unknown = W.Worktree(path="/x", real="/x", merged_by=None, idle_hours=999.0)
-    W.classify(unknown, 12.0, merge_evidence_available=False)
+    W.classify(unknown, 12.0, merge_evidence_available=False, holder_scan_ok=True)
     check("incomplete evidence says no-merge-evidence", unknown.blockers, ["no-merge-evidence"])
 
     proven = W.Worktree(path="/x", real="/x", merged_by="squash-pr#1", idle_hours=999.0)
-    W.classify(proven, 12.0, merge_evidence_available=True)
+    W.classify(proven, 12.0, merge_evidence_available=True, holder_scan_ok=True)
     check("proven merged has no blockers", proven.blockers, [])
     check("proven merged is removable", proven.removable, True)
+
+
+def test_github_merge_evidence() -> None:
+    """The squash-merge cross-check, which is the SOLE merge evidence for most real candidates.
+
+    On the live repo this path qualified 104 of 146 removal candidates while `ancestor` qualified
+    41 -- so the majority of this tool's delete decisions rest here. Every other arm in this file
+    runs with use_github=False, which left `probe_github`, `_apply_github`, the recycled-branch
+    guard and `_GH_CACHE` at zero coverage: reverting the open-PR fail-closed fix kept all 54 arms
+    green. A path that decides deletions cannot be the untested one.
+
+    `W.run` is monkeypatched rather than calling a real `gh`, so these arms are hermetic and
+    exercise the failure branches on demand.
+    """
+    print("\n[github merge evidence]")
+    W._GH_CACHE.clear()
+
+    def wt(name: str, head: str, branch: str | None) -> W.Worktree:
+        t = W.Worktree(path=f"/{name}", real=f"/{name}", head=head, branch=branch,
+                       detached=branch is None)
+        return t
+
+    # --- _apply_github: qualification, the recycled-branch guard, and detached trees -------
+    merged_head = wt("merged", "a" * 40, "feat/landed")
+    recycled = wt("recycled", "b" * 40, "feat/recycled")
+    detached = wt("detached", "c" * 40, None)
+    untouched = wt("other", "d" * 40, "feat/live")
+    trees = [merged_head, recycled, detached, untouched]
+    by_oid = {"a" * 40: 111, "b" * 40: 222, "c" * 40: 333}
+    W._apply_github(trees, by_oid, open_branches={"feat/recycled"})
+
+    check("sha match qualifies", merged_head.merged_by, "squash-pr#111")
+    check("recycled branch name is refused", recycled.merged_by, None)
+    check("detached qualifies on sha alone", detached.merged_by, "squash-pr#333")
+    check("unmatched sha stays unqualified", untouched.merged_by, None)
+
+    # A branch whose tip has MOVED past the merged PR is live work, not a stale tree.
+    moved = wt("moved", "e" * 40, "feat/moved")
+    W._apply_github([moved], {"a" * 40: 111}, open_branches=set())
+    check("advanced branch tip stays unqualified", moved.merged_by, None)
+
+    # --- probe_github: the open-PR query failing must fail the WHOLE cross-check closed ----
+    real_run = W.run
+    merged_json = json.dumps([{"number": 111, "headRefName": "feat/landed",
+                               "headRefOid": "a" * 40, "mergedAt": "x"}])
+
+    def fake_run(cmd, cwd=None, timeout=W.GIT_TIMEOUT):
+        if "--state" in cmd and "merged" in cmd:
+            return 0, merged_json, ""
+        if "--state" in cmd and "open" in cmd:
+            return 1, "", "API rate limit exceeded"
+        return real_run(cmd, cwd=cwd, timeout=timeout)
+
+    try:
+        W.run = fake_run
+        W._GH_CACHE.clear()
+        victim = wt("victim", "a" * 40, "feat/landed")
+        ok, note = W.probe_github("/repo", [victim], 10)
+        check("open-PR failure -> evidence unavailable", ok, False)
+        check("open-PR failure names the cause", "open-PR query failed" in note, True, note)
+        check("and qualifies NOTHING", victim.merged_by, None)
+
+        # --- _GH_CACHE: a failure must be remembered, or 145 candidates refetch it ---------
+        calls = {"n": 0}
+
+        def counting_run(cmd, cwd=None, timeout=W.GIT_TIMEOUT):
+            if "pr" in cmd and "list" in cmd:
+                calls["n"] += 1
+            return fake_run(cmd, cwd=cwd, timeout=timeout)
+
+        W.run = counting_run
+        W._GH_CACHE.clear()
+        W.probe_github("/repo", [wt("v1", "a" * 40, "feat/landed")], 10)
+        after_first = calls["n"]
+        W.probe_github("/repo", [wt("v2", "a" * 40, "feat/landed")], 10)
+        check("failed lookup is cached, not refetched", calls["n"], after_first)
+
+        # --- the success path, end to end through probe_github ----------------------------
+        def ok_run(cmd, cwd=None, timeout=W.GIT_TIMEOUT):
+            if "--state" in cmd and "merged" in cmd:
+                return 0, merged_json, ""
+            if "--state" in cmd and "open" in cmd:
+                return 0, "[]", ""
+            return real_run(cmd, cwd=cwd, timeout=timeout)
+
+        W.run = ok_run
+        W._GH_CACHE.clear()
+        good = wt("good", "a" * 40, "feat/landed")
+        ok, note = W.probe_github("/repo", [good], 10)
+        check("success path reports available", ok, True)
+        check("success path qualifies the tree", good.merged_by, "squash-pr#111")
+        check("note states what it examined", "1 merged PRs" in note, True, note)
+
+        # Truncation must announce itself rather than silently narrowing the evidence.
+        W._GH_CACHE.clear()
+        _, note = W.probe_github("/repo", [wt("t", "a" * 40, "feat/landed")], 1)
+        check("hitting --gh-limit warns", "WARNING" in note, True, note)
+    finally:
+        W.run = real_run
+        W._GH_CACHE.clear()
+
+
+def test_unknown_idle_time_blocks_removal() -> None:
+    """idle_hours=None means every stat failed, and must not be the one guard that permits.
+
+    Unreachable in practice on a healthy tree, which is exactly why it needs an arm: it is the
+    kind of fail-open default nobody notices until the day the stats fail.
+    """
+    print("\n[unknown idle time]")
+    unknown = W.Worktree(path="/x", real="/x", merged_by="ancestor", idle_hours=None)
+    W.classify(unknown, 12.0, merge_evidence_available=True, holder_scan_ok=True)
+    check("unknown idle refuses", unknown.removable, False)
+    check("unknown idle names recent", unknown.blockers, ["recent"])
+
+    known = W.Worktree(path="/x", real="/x", merged_by="ancestor", idle_hours=999.0)
+    W.classify(known, 12.0, merge_evidence_available=True, holder_scan_ok=True)
+    check("known-old idle permits", known.removable, True)
 
 
 def test_fails_closed_without_a_process_scan() -> None:
@@ -496,11 +614,35 @@ def test_fd_and_map_references_are_holders() -> None:
         trees, _ = survey(repo, scan_fds=True, scan_maps=False)
         check("removable once the fd is closed", trees["fdheld"].state, "REMOVABLE")
 
+        # --- the maps parser, which until now this arm's NAME claimed but did not cover -----
+        # A mapping is the holder with no cwd and no fd: a running binary, or a compiler's mmap
+        # of an object file. It also exercises a different parser -- /proc/<pid>/maps is parsed
+        # by hand, unlike the fd and cwd symlinks -- so it can break independently.
+        import mmap
+        with open(target, "rb") as mf:
+            mm = mmap.mmap(mf.fileno(), 0, access=mmap.ACCESS_READ)
+            try:
+                trees, _ = survey(repo, scan_fds=False, scan_maps=True)
+                held = trees["fdheld"]
+                check("map holder refuses the tree", held.removable, False)
+                check("map holder names in-use", "in-use" in held.blockers, True,
+                      str(held.blockers))
+                check("map holder is seen as a mapping",
+                      os.getpid() in [h.pid for h in held.holders if h.kind == "map"], True,
+                      str([(h.pid, h.kind) for h in held.holders]))
+            finally:
+                mm.close()
+
+        trees, _ = survey(repo, scan_fds=False, scan_maps=True)
+        check("removable once the mapping is gone", trees["fdheld"].state, "REMOVABLE")
+
 
 def main() -> int:
     for fn in (
         test_positive_and_mutations,
         test_merge_evidence_labels,
+        test_github_merge_evidence,
+        test_unknown_idle_time_blocks_removal,
         test_fails_closed_without_a_process_scan,
         test_nested_worktree_is_refused,
         test_holder_attributed_to_most_specific_tree,

--- a/prosper/tools/test_worktree_reclaim.py
+++ b/prosper/tools/test_worktree_reclaim.py
@@ -61,6 +61,15 @@ def age(path: str | Path, admin: str | Path | None, seconds: int = OLD) -> None:
             pass
 
 
+def spawn_holder(cwd: Path) -> subprocess.Popen:
+    """A live process whose cwd is `cwd`, without depending on an external `sleep` binary."""
+    return subprocess.Popen([sys.executable, "-c", "import time; time.sleep(60)"], cwd=str(cwd))
+
+
+def holder_scan_supported() -> bool:
+    return W.scan_processes(scan_fds=False, scan_maps=False)[1]
+
+
 def admin_of(repo: Path, name: str) -> Path:
     return repo / ".git" / "worktrees" / name
 
@@ -126,7 +135,7 @@ def test_positive_and_mutations() -> None:
         for name in ("safe", "dirty", "untracked", "unmerged", "inuse", "locked"):
             age(root / name, admin_of(repo, name))              # `recent` is deliberately not aged
 
-        holder = subprocess.Popen(["sleep", "60"], cwd=str(inuse))  # in-use: a live cwd
+        holder = spawn_holder(inuse)  # in-use: a live cwd
         try:
             time.sleep(0.4)
             trees, _ = survey(repo)
@@ -150,10 +159,19 @@ def test_positive_and_mutations() -> None:
             check("unmerged names guard", "no-merge-evidence" in trees["unmerged"].blockers, True,
                   str(trees["unmerged"].blockers))
             check("in-use refused", trees["inuse"].removable, False)
-            check("in-use names guard", "in-use" in trees["inuse"].blockers, True,
-                  str(trees["inuse"].blockers))
-            check("in-use identifies the pid", holder.pid in [h.pid for h in trees["inuse"].holders],
-                  True)
+            if holder_scan_supported():
+                check("in-use names guard", "in-use" in trees["inuse"].blockers, True,
+                      str(trees["inuse"].blockers))
+                check("in-use identifies the pid",
+                      holder.pid in [h.pid for h in trees["inuse"].holders], True)
+            else:
+                # No /proc here, so the guard cannot fire on its own merits. The tool must still
+                # refuse -- via fail-closed -- and test_fails_closed_without_a_process_scan pins
+                # that. Passing this arm silently would be the exact defect it exists to catch.
+                print("  SKIP in-use guard needs a readable /proc; fail-closed arm covers this")
+                check("in-use refused via fail-closed",
+                      "holder-scan-unavailable" in trees["inuse"].blockers, True,
+                      str(trees["inuse"].blockers))
             check("recent refused", trees["recent"].removable, False)
             check("recent names guard", "recent" in trees["recent"].blockers, True,
                   str(trees["recent"].blockers))
@@ -191,6 +209,33 @@ def test_merge_evidence_labels() -> None:
     check("proven merged is removable", proven.removable, True)
 
 
+def test_fails_closed_without_a_process_scan() -> None:
+    """No readable /proc must mean "cannot tell", never "nobody is here".
+
+    macOS and Windows have no procfs, so `scan_processes` finds nothing there. Read as "no
+    holders", that turns the in-use guard off silently and a worktree with a live shell in it
+    classifies as REMOVABLE -- the single most dangerous answer this tool can give, and one that
+    would only ever be observed on the machine where it deleted someone's session. So the scan
+    reports whether it could run at all, and an absent scan blocks every tree.
+
+    CI caught this: the first revision passed on Linux and failed on the macOS and Windows jobs.
+    """
+    print("\n[fail closed when the process scan cannot run]")
+    ok = W.Worktree(path="/x", real="/x", merged_by="ancestor", idle_hours=999.0)
+    W.classify(ok, 12.0, merge_evidence_available=True, holder_scan_ok=True)
+    check("scan available -> removable", ok.removable, True)
+
+    blind = W.Worktree(path="/x", real="/x", merged_by="ancestor", idle_hours=999.0)
+    W.classify(blind, 12.0, merge_evidence_available=True, holder_scan_ok=False)
+    check("scan unavailable -> refused", blind.removable, False)
+    check("scan unavailable names guard", blind.blockers, ["holder-scan-unavailable"])
+
+    # The flag must reflect reality on THIS platform, not merely be plumbed through.
+    _, supported = W.scan_processes(scan_fds=False, scan_maps=False)
+    check("scan support matches the platform", supported, os.path.isdir("/proc"),
+          f"platform={sys.platform}")
+
+
 def test_nested_worktree_is_refused() -> None:
     """A worktree registered underneath another must not be removed out from under it."""
     print("\n[nested worktree]")
@@ -220,10 +265,13 @@ def test_holder_attributed_to_most_specific_tree() -> None:
         inner = outer / "inner"
         git(repo, "worktree", "add", "-q", "-b", "feat/inner", str(inner), "origin/master")
 
-        holder = subprocess.Popen(["sleep", "60"], cwd=str(inner))
+        holder = spawn_holder(inner)
         try:
             time.sleep(0.4)
             trees, _ = survey(repo)
+            if not holder_scan_supported():
+                print("  SKIP holder attribution needs a readable /proc")
+                return
             check("inner sees the holder", holder.pid in [h.pid for h in trees["inner"].holders],
                   True)
             check("outer does NOT see it", holder.pid in [h.pid for h in trees["outer"].holders],
@@ -353,6 +401,7 @@ def main() -> int:
     for fn in (
         test_positive_and_mutations,
         test_merge_evidence_labels,
+        test_fails_closed_without_a_process_scan,
         test_nested_worktree_is_refused,
         test_holder_attributed_to_most_specific_tree,
         test_idle_is_not_measuring_our_own_footprint,

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -46,6 +46,21 @@ they cannot claim a live tree is dead. Unproven means "left alone", which is why
 distinguishes "not merged" from "no evidence available" -- a `gh` outage must not silently turn
 into a wall of ACTIVE.
 
+What this deliberately does NOT protect, stated because each one looks covered:
+
+  ignored files   `git status` does not list gitignored content, so a tree whose only content is
+                  an ignored `build-linux/` or a run log reads as clean and goes with it. Mostly
+                  that is the point -- but the charter also tells agents to put run artifacts in
+                  "a gitignored worktree-local directory", so the dirty guard does not mean what
+                  a reader may assume. Move what you want to keep, or `git worktree lock` the tree.
+  detached trees  the recycled-branch cross-check keys on a branch name, so it cannot apply to a
+                  detached worktree; those qualify on the HEAD sha alone. Sound, because the sha
+                  matching a merged PR's headRefOid is what is being asserted -- but if that sha
+                  is reachable only from this worktree's HEAD, removing the tree does make the sha
+                  unreachable. The content is still on master via the squash.
+  non-Linux       the in-use guard needs `/proc`. Without it the tool fails closed and removes
+                  nothing at all, so on macOS and Windows this is a classifier only.
+
 Usage:
 
     tools/worktree_reclaim.py                      # census, touches nothing
@@ -246,8 +261,12 @@ def scan_processes(
 
     Deliberately scans ALL processes rather than a list of known binary names. The failure this
     guards against is a wedged interactive shell, and a shell is exactly what a name list misses.
-    Unreadable processes (other users, or exited mid-scan) are skipped -- so within a supported
-    platform this is a lower bound on holders, never an upper one, which is the safe direction.
+
+    Unreadable processes (other users, or exited mid-scan) are skipped, so this is a LOWER bound
+    on holders -- and that is the UNSAFE direction, not the safe one: under-detecting holders
+    yields "nobody is here" and hence REMOVABLE. An upper bound would be safe. Nothing here can
+    make the bound tight, which is precisely why `supported` exists and why the idle guard backs
+    this one up; do not read a short holder list as reassurance.
     """
     refs: list[tuple[int, str, str, str]] = []
     try:
@@ -304,22 +323,66 @@ def scan_processes(
 def attach_holders(trees: list[Worktree], refs: list[tuple[int, str, str, str]]) -> None:
     """Assign each reference to the most specific worktree containing it.
 
+    Matching is by (st_dev, st_ino) identity, NOT by path string. String matching produced a
+    demonstrated false negative here, which is the direction that deletes people's work:
+
+        `/home` is a symlink to `/var/home` on this host, so `t.real` is always the `/var/home`
+        spelling. Inside the ps5ys distrobox, however, `/home` is a real bind mount, so a
+        container process's `/proc/<pid>/cwd` reads back as `/home/...` -- a different string for
+        the same directory. Measured live: a `distrobox enter ps5ys -- bash -lc "cd <worktree> &&
+        ..."` process, which is exactly the build command the charter prescribes, was invisible to
+        the string index while a host process in the same tree was seen. Both paths stat to
+        dev=57 ino=10784453.
+
+    Inode identity closes that and any other aliasing (bind mounts, additional symlinks) in one
+    step, because it asks the question the guard actually means: is this process inside THIS
+    directory, however it happens to spell it.
+
     Walking up from the reference and taking the first hit is what makes "most specific" work:
-    every `.claude/worktrees/X` is inside the main checkout, so a plain prefix match would blame
-    main for a process that is really sitting in X.
+    every `.claude/worktrees/X` is inside the main checkout, so matching the outermost container
+    would blame main for a process that is really sitting in X.
     """
-    index = {t.real: t for t in trees}
-    for pid, kind, comm, path in refs:
+    by_key: dict[tuple[int, int], Worktree] = {}
+    for t in trees:
+        try:
+            st = os.stat(t.real)
+        except OSError:
+            continue  # a vanished tree cannot hold anything; `missing` covers it
+        by_key[(st.st_dev, st.st_ino)] = t
+
+    # Memoised per directory: without this the ancestor walk stats the same handful of parents
+    # tens of thousands of times over a full /proc sweep.
+    cache: dict[str, Worktree | None] = {}
+
+    def owner(path: str) -> Worktree | None:
+        chain: list[str] = []
         cur = path
+        found: Worktree | None = None
         while True:
-            t = index.get(cur)
-            if t is not None:
-                t.holders.append(Holder(pid=pid, kind=kind, comm=comm, path=path))
+            if cur in cache:
+                found = cache[cur]
+                break
+            chain.append(cur)
+            try:
+                st = os.stat(cur)
+                hit = by_key.get((st.st_dev, st.st_ino))
+            except OSError:
+                hit = None  # deleted fd target, or a path we may not stat; keep walking up
+            if hit is not None:
+                found = hit
                 break
             parent = os.path.dirname(cur)
             if parent == cur or len(parent) <= 1:
                 break
             cur = parent
+        for c in chain:
+            cache[c] = found
+        return found
+
+    for pid, kind, comm, path in refs:
+        t = owner(path)
+        if t is not None:
+            t.holders.append(Holder(pid=pid, kind=kind, comm=comm, path=path))
 
 
 # --------------------------------------------------------------------------- per-tree probes
@@ -425,12 +488,22 @@ def probe_ancestor(repo: str, trees: list[Worktree], base: str) -> None:
             t.merged_by = "ancestor"
 
 
+_GH_CACHE: dict[tuple[str, int], tuple[bool, str, dict[str, int], set[str]]] = {}
+
+
 def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, str]:
     """Cross-check against merged PRs. Returns (available, note).
 
     Two batched `gh` calls rather than one per tree; with hundreds of worktrees the per-tree form
     is both slow and rate-limited.
     """
+    cached = _GH_CACHE.get((repo, limit))
+    if cached is not None:
+        ok, note, by_oid, open_branches = cached
+        if ok:
+            _apply_github(trees, by_oid, open_branches)
+        return ok, note
+
     rc, out, err = run(
         [
             "gh", "pr", "list", "--state", "merged", "--limit", str(limit),
@@ -440,23 +513,29 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
         timeout=300,
     )
     if rc != 0:
-        return False, f"gh unavailable ({(err.strip() or 'rc=%d' % rc)[:120]})"
+        note = f"gh unavailable ({(err.strip() or 'rc=%d' % rc)[:120]})"
+        _GH_CACHE[(repo, limit)] = (False, note, {}, set())
+        return False, note
     try:
         merged = json.loads(out)
     except json.JSONDecodeError as e:
         return False, f"gh returned unparseable JSON ({e})"
 
-    rc2, out2, _ = run(
+    rc2, out2, err2 = run(
         ["gh", "pr", "list", "--state", "open", "--limit", str(limit), "--json", "number,headRefName"],
         cwd=repo,
         timeout=300,
     )
-    open_branches: set[str] = set()
-    if rc2 == 0:
-        try:
-            open_branches = {pr["headRefName"] for pr in json.loads(out2)}
-        except json.JSONDecodeError:
-            pass
+    # An empty open-PR set is the permissive answer -- it is what licenses squash-pr qualification
+    # for a named branch. So a FAILED query must not produce it: "the query broke" and "there are
+    # no open PRs" would otherwise be the same value, and a rate limit right after the paginated
+    # merged fetch is a realistic way to get there. Fail closed on the whole cross-check instead.
+    if rc2 != 0:
+        return False, f"gh open-PR query failed ({(err2.strip() or 'rc=%d' % rc2)[:120]})"
+    try:
+        open_branches = {pr["headRefName"] for pr in json.loads(out2)}
+    except json.JSONDecodeError as e:
+        return False, f"gh open-PR query returned unparseable JSON ({e})"
 
     by_oid: dict[str, int] = {}
     for pr in merged:
@@ -464,6 +543,18 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
         if oid:
             by_oid.setdefault(oid, pr["number"])
 
+    note = f"gh: {len(merged)} merged PRs, {len(open_branches)} open branches"
+    if len(merged) >= limit:
+        # Newest-first, so merged-list truncation drops the OLDEST PRs -- the trees most worth
+        # reclaiming. That direction is safe (they stay unqualified). Truncating the OPEN list
+        # would be unsafe, so say so loudly rather than quietly qualifying more trees.
+        note += f" -- WARNING: hit --gh-limit {limit}; raise it, results are truncated"
+    _GH_CACHE[(repo, limit)] = (True, note, by_oid, open_branches)
+    _apply_github(trees, by_oid, open_branches)
+    return True, note
+
+
+def _apply_github(trees: list[Worktree], by_oid: dict[str, int], open_branches: set[str]) -> None:
     for t in trees:
         if t.is_main or t.merged_by or not t.head:
             continue
@@ -475,8 +566,6 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
         if t.branch and t.branch in open_branches:
             continue
         t.merged_by = f"squash-pr#{num}"
-
-    return True, f"gh: {len(merged)} merged PRs, {len(open_branches)} open branches"
 
 
 # --------------------------------------------------------------------------- classification
@@ -508,7 +597,9 @@ def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool,
         t.blockers.append("unmerged" if merge_evidence_available else "no-merge-evidence")
     if t.nested:
         t.blockers.append("nested")
-    if t.idle_hours is not None and t.idle_hours < min_idle_hours:
+    # None means every stat failed. Everything else in this list is fail-closed; an unknown
+    # answer must not be the one place that quietly permits removal.
+    if t.idle_hours is None or t.idle_hours < min_idle_hours:
         t.blockers.append("recent")
 
 
@@ -721,10 +812,12 @@ def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
     fresh_refs, holder_scan_ok = scan_processes(scan_fds=scan_fds, scan_maps=scan_maps)
     attach_holders(fresh, fresh_refs)
     probe_ancestor(repo, fresh, base)
-    if use_github and cur.merged_by is None:
-        probe_github(repo, fresh, gh_limit)
+    # Cached after the census, so this is a dict lookup rather than another paginated fetch --
+    # 145 candidates would otherwise mean 145 full merged-PR queries and a near-certain rate limit,
+    # whose symptom would be trees refusing under a mislabelled verdict.
+    gh_ok = probe_github(repo, fresh, gh_limit)[0] if use_github else False
     cur = next((w for w in fresh if w.real == t.real), cur)
-    classify(cur, min_idle_hours, merge_evidence_available=True,
+    classify(cur, min_idle_hours, merge_evidence_available=(use_github and gh_ok),
              holder_scan_ok=holder_scan_ok)
 
     if not cur.removable:
@@ -795,7 +888,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(
             {
-                "meta": meta,
+                "meta": ({**meta, "repo": redact(meta["repo"])} if args.redact else meta),
                 "worktrees": [
                     {
                         "path": redact(t.real) if args.redact else t.real,

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -80,6 +80,7 @@ BLOCKER_ORDER = [
     "missing",
     "locked",
     "in-use",
+    "holder-scan-unavailable",
     "dirty",
     "unmerged",
     "no-merge-evidence",
@@ -192,7 +193,10 @@ def list_worktrees(repo: str) -> list[Worktree]:
     for t in trees:
         if t.is_main:
             continue  # every .claude/worktrees/* sits under main by construction
-        pfx = t.real.rstrip("/") + "/"
+        # os.sep, not "/": on Windows realpath yields backslashes and a "/" prefix never matches,
+        # which silently disables this guard. Appending the separator is also what keeps
+        # `/a/foo` from being read as a parent of `/a/foobar`.
+        pfx = t.real.rstrip(os.sep) + os.sep
         t.nested = sorted(r for r in reals if r != t.real and r.startswith(pfx))
 
     for t in trees:
@@ -228,19 +232,30 @@ def _readlink(path: str) -> str | None:
     return target[: -len(" (deleted)")] if target.endswith(" (deleted)") else target
 
 
-def scan_processes(scan_fds: bool = True, scan_maps: bool = True) -> list[tuple[int, str, str, str]]:
+def scan_processes(
+    scan_fds: bool = True, scan_maps: bool = True
+) -> tuple[list[tuple[int, str, str, str]], bool]:
     """Collect every (pid, kind, comm, path) reference a live process holds.
+
+    Returns (refs, supported). `supported` is False where there is no readable `/proc` -- macOS
+    and Windows, notably. That flag is load-bearing and must never be dropped: without it this
+    function returns an empty list on those platforms, the in-use guard never fires, and a
+    worktree with a live shell sitting in it classifies as REMOVABLE. An absent instrument would
+    read as "nobody is using anything", which is the most dangerous answer this tool can give.
+    Callers must fail closed on `supported == False` rather than treating it as "no holders".
 
     Deliberately scans ALL processes rather than a list of known binary names. The failure this
     guards against is a wedged interactive shell, and a shell is exactly what a name list misses.
-    Unreadable processes (other users, or exited mid-scan) are skipped -- so this is a lower
-    bound on holders, never an upper one, which is the safe direction.
+    Unreadable processes (other users, or exited mid-scan) are skipped -- so within a supported
+    platform this is a lower bound on holders, never an upper one, which is the safe direction.
     """
     refs: list[tuple[int, str, str, str]] = []
     try:
         entries = os.listdir("/proc")
     except OSError:
-        return refs
+        return refs, False
+    if not any(n.isdigit() for n in entries):
+        return refs, False  # something is mounted at /proc, but it is not a Linux procfs
 
     for name in entries:
         if not name.isdigit():
@@ -283,7 +298,7 @@ def scan_processes(scan_fds: bool = True, scan_maps: bool = True) -> list[tuple[
                             refs.append((pid, "map", comm, tgt))
             except OSError:
                 pass
-    return refs
+    return refs, True
 
 
 def attach_holders(trees: list[Worktree], refs: list[tuple[int, str, str, str]]) -> None:
@@ -467,7 +482,8 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
 # --------------------------------------------------------------------------- classification
 
 
-def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool) -> None:
+def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool,
+             holder_scan_ok: bool = True) -> None:
     t.blockers = []
     if t.is_main:
         t.blockers.append("main")
@@ -477,7 +493,12 @@ def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool)
         return
     if t.locked:
         t.blockers.append("locked")
-    if t.holders:
+    if not holder_scan_ok:
+        # Fail closed. Without a readable /proc we cannot tell whether a live shell is sitting in
+        # this tree, and "the instrument is absent" must never be reported as "nobody is here".
+        # This makes the tool classify-only on macOS and Windows, which is the honest outcome.
+        t.blockers.append("holder-scan-unavailable")
+    elif t.holders:
         t.blockers.append("in-use")
     if t.status_error:
         t.blockers.append("status-unavailable")
@@ -514,7 +535,7 @@ def survey(
         with ThreadPoolExecutor(max_workers=jobs) as pool:
             list(pool.map(probe_size, trees))
 
-    refs = scan_processes(scan_fds=scan_fds, scan_maps=scan_maps)
+    refs, holder_scan_ok = scan_processes(scan_fds=scan_fds, scan_maps=scan_maps)
     attach_holders(trees, refs)
 
     probe_ancestor(repo, trees, base)
@@ -531,13 +552,15 @@ def survey(
     evidence_complete = use_github and gh_available
     for t in trees:
         t.merge_evidence_available = evidence_complete
-        classify(t, min_idle_hours, merge_evidence_available=evidence_complete)
+        classify(t, min_idle_hours, merge_evidence_available=evidence_complete,
+                 holder_scan_ok=holder_scan_ok)
 
     meta = {
         "repo": repo,
         "base": base,
         "base_sha": run(["git", "-C", repo, "rev-parse", base])[1].strip(),
         "min_idle_hours": min_idle_hours,
+        "holder_scan_supported": holder_scan_ok,
         "process_refs_scanned": len(refs),
         "pids_seen": len({r[0] for r in refs}),
         "scan_fds": scan_fds,
@@ -579,8 +602,13 @@ def report(trees: list[Worktree], meta: dict, do_redact: bool, verbose: bool) ->
     print(f"repo                 {fmt(meta['repo'])}")
     print(f"base                 {meta['base']} @ {meta['base_sha'][:12]}")
     print(f"worktrees registered {len(trees)}")
-    print(f"process refs scanned {meta['process_refs_scanned']} over {meta['pids_seen']} pids "
-          f"(fds={meta['scan_fds']}, maps={meta['scan_maps']})")
+    if meta["holder_scan_supported"]:
+        print(f"process refs scanned {meta['process_refs_scanned']} over {meta['pids_seen']} pids "
+              f"(fds={meta['scan_fds']}, maps={meta['scan_maps']})")
+    else:
+        print("process refs scanned NONE -- no readable /proc on this platform, so the in-use "
+              "guard cannot run;\n                     every tree is held back (fail closed) "
+              "and this run is classify-only")
     print(f"merge evidence       ancestor-of-{meta['base']} + {meta['github']}")
     print(f"idle threshold       {meta['min_idle_hours']}h")
     print()
@@ -601,6 +629,7 @@ def report(trees: list[Worktree], meta: dict, do_redact: bool, verbose: bool) ->
         "MISSING": "directory gone; `git worktree prune` reclaims the registration",
         "LOCKED": "explicitly locked by a human",
         "IN-USE": "a live process holds cwd/exe/fd/map inside it",
+        "HOLDER-SCAN-UNAVAILABLE": "no readable /proc: cannot prove nobody is inside (fail closed)",
         "DIRTY": "uncommitted or untracked files present",
         "UNMERGED": "work not provably in the base branch",
         "NO-MERGE-EVIDENCE": "could not establish merge state",
@@ -689,12 +718,14 @@ def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
 
     probe_idle(cur)  # before probe_status, for the reason given in probe_idle
     probe_status(cur)
-    attach_holders(fresh, scan_processes(scan_fds=scan_fds, scan_maps=scan_maps))
+    fresh_refs, holder_scan_ok = scan_processes(scan_fds=scan_fds, scan_maps=scan_maps)
+    attach_holders(fresh, fresh_refs)
     probe_ancestor(repo, fresh, base)
     if use_github and cur.merged_by is None:
         probe_github(repo, fresh, gh_limit)
     cur = next((w for w in fresh if w.real == t.real), cur)
-    classify(cur, min_idle_hours, merge_evidence_available=True)
+    classify(cur, min_idle_hours, merge_evidence_available=True,
+             holder_scan_ok=holder_scan_ok)
 
     if not cur.removable:
         print(f"  REFUSE {fmt(cur.real)}: {', '.join(cur.blockers) or 'no merge evidence'}")

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -504,6 +504,14 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
             _apply_github(trees, by_oid, open_branches)
         return ok, note
 
+    def fail(note: str) -> tuple[bool, str]:
+        # Cache failures too. Caching only the first failure exit meant that a JSON decode error
+        # or a failed open-PR query -- precisely the failures a rate limit produces, and the ones
+        # most likely to recur -- refetched on every candidate, which is the 145-query storm this
+        # cache exists to prevent. A negative result is as worth remembering as a positive one.
+        _GH_CACHE[(repo, limit)] = (False, note, {}, set())
+        return False, note
+
     rc, out, err = run(
         [
             "gh", "pr", "list", "--state", "merged", "--limit", str(limit),
@@ -513,13 +521,11 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
         timeout=300,
     )
     if rc != 0:
-        note = f"gh unavailable ({(err.strip() or 'rc=%d' % rc)[:120]})"
-        _GH_CACHE[(repo, limit)] = (False, note, {}, set())
-        return False, note
+        return fail(f"gh unavailable ({(err.strip() or 'rc=%d' % rc)[:120]})")
     try:
         merged = json.loads(out)
     except json.JSONDecodeError as e:
-        return False, f"gh returned unparseable JSON ({e})"
+        return fail(f"gh returned unparseable JSON ({e})")
 
     rc2, out2, err2 = run(
         ["gh", "pr", "list", "--state", "open", "--limit", str(limit), "--json", "number,headRefName"],
@@ -531,11 +537,11 @@ def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, st
     # no open PRs" would otherwise be the same value, and a rate limit right after the paginated
     # merged fetch is a realistic way to get there. Fail closed on the whole cross-check instead.
     if rc2 != 0:
-        return False, f"gh open-PR query failed ({(err2.strip() or 'rc=%d' % rc2)[:120]})"
+        return fail(f"gh open-PR query failed ({(err2.strip() or 'rc=%d' % rc2)[:120]})")
     try:
         open_branches = {pr["headRefName"] for pr in json.loads(out2)}
     except json.JSONDecodeError as e:
-        return False, f"gh open-PR query returned unparseable JSON ({e})"
+        return fail(f"gh open-PR query returned unparseable JSON ({e})")
 
     by_oid: dict[str, int] = {}
     for pr in merged:
@@ -572,7 +578,11 @@ def _apply_github(trees: list[Worktree], by_oid: dict[str, int], open_branches: 
 
 
 def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool,
-             holder_scan_ok: bool = True) -> None:
+             holder_scan_ok: bool) -> None:
+    """Assign every blocker that applies. Both booleans are REQUIRED and neither defaults:
+    `holder_scan_ok=True` as a default would hand a fail-closed guard a fail-open fallback, which
+    is the same shape as the bug it was added to fix one layer down -- a caller that forgets the
+    argument would silently get the permissive answer."""
     t.blockers = []
     if t.is_main:
         t.blockers.append("main")

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -522,9 +522,16 @@ def survey(
     if use_github:
         gh_available, gh_note = probe_github(repo, trees, gh_limit)
 
+    # "Not merged" and "could not tell" are different answers and must not share a label. The
+    # ancestor test is local and always runs, but it is blind to squash merges, so on its own it
+    # cannot distinguish live work from work that landed via a squash. Only a successful GitHub
+    # cross-check licenses the confident UNMERGED verdict; otherwise the honest state is
+    # NO-MERGE-EVIDENCE. Both are equally unremovable -- this is about not reporting a `gh`
+    # outage, or `--no-github`, as a wall of live branches.
+    evidence_complete = use_github and gh_available
     for t in trees:
-        t.merge_evidence_available = True  # `ancestor` always works; gh only widens it
-        classify(t, min_idle_hours, merge_evidence_available=True)
+        t.merge_evidence_available = evidence_complete
+        classify(t, min_idle_hours, merge_evidence_available=evidence_complete)
 
     meta = {
         "repo": repo,

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -1,0 +1,827 @@
+#!/usr/bin/env python3
+"""worktree_reclaim.py -- classify this repo's git worktrees, and remove only provably dead ones.
+
+Several agents and the human run this repository concurrently out of separate `git worktree`
+checkouts, and nothing removes them when their work lands. They accumulate: issue #1735 measured
+121 trees / 111 GB, and the count more than doubled inside a fortnight. The cost is not mainly
+disk -- it is that an agent looking for prior work lands in a tree whose branch merged weeks ago
+and reads it as current, and that routine `cannot delete branch ... used by worktree at ...`
+noise hides the one instance where a lane really is still working in the tree you are about to
+delete.
+
+CONFIDENCE: HIGH that this is safe to run; the default does nothing but read.
+
+    Removing a worktree that a live shell is cd'd into wedges that shell irrecoverably.
+
+So this tool defaults to a dry-run census, and `--remove` is gated behind every guard below.
+It prints what it EXAMINED, not merely what it would remove: a clean zero from an unarmed scan
+is indistinguishable from a clean zero from a scan that found nothing, and this project has been
+bitten by that often enough to name it. Each tree prints its state and every blocker that fired.
+
+Guards -- ALL must pass before a tree is even a candidate:
+
+  main        the primary worktree is never touched
+  exists      a vanished directory is a `git worktree prune` job, not a `remove` job
+  locked      `git worktree lock` is an explicit human "leave this alone"
+  unmerged    the tree's work must be provably in origin/master (see "Merge evidence")
+  dirty       `git status --porcelain --untracked-files=all` must be empty, untracked included
+  in-use      no process may have cwd / exe / an open fd / a mapping inside the tree
+  recent      the tree must have been idle for --min-idle-hours (default 12)
+  nested      no other registered worktree may live underneath it
+
+Merge evidence -- two independent primary sources, never a heuristic:
+
+  ancestor    `git merge-base --is-ancestor <head> origin/master`. Exact, but blind to squash
+              merges, which is how this repository merges every PR (checked: the last 20 commits
+              on master each have one parent). After a squash the branch tip is NOT an ancestor,
+              so this test alone under-reports badly -- it mostly catches branches that never
+              committed anything.
+  squash-pr   the tree's HEAD sha equals the `headRefOid` of a MERGED pull request, via `gh`.
+              That is conclusive: this exact tree state is what GitHub merged. For a named
+              branch we additionally require that no OPEN pull request uses it, so a branch name
+              recycled for later work is never mistaken for the merged one.
+
+Both are conservative in the same direction: they can fail to notice that a tree is dead, and
+they cannot claim a live tree is dead. Unproven means "left alone", which is why the census
+distinguishes "not merged" from "no evidence available" -- a `gh` outage must not silently turn
+into a wall of ACTIVE.
+
+Usage:
+
+    tools/worktree_reclaim.py                      # census, touches nothing
+    tools/worktree_reclaim.py --json               # same, machine-readable
+    tools/worktree_reclaim.py --redact             # census with host paths masked, for pasting
+    tools/worktree_reclaim.py --remove --yes       # act; re-checks every guard per tree first
+
+`--remove` re-runs the guards immediately before each individual removal rather than trusting the
+census. A point-in-time scan is advisory, not a lock: an agent can cd into a tree between the scan
+and the delete, and the whole point of the scan is the case where that matters.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+
+DEFAULT_MIN_IDLE_HOURS = 12.0
+GIT_TIMEOUT = 120
+STATUS_SAMPLE = 8  # porcelain lines kept per tree for the report
+
+# Ordered most-severe first: a tree's headline state is its first blocker, but `blockers`
+# always carries the complete list so the report never implies a single cause.
+BLOCKER_ORDER = [
+    "main",
+    "missing",
+    "locked",
+    "in-use",
+    "dirty",
+    "unmerged",
+    "no-merge-evidence",
+    "nested",
+    "recent",
+    "status-unavailable",
+]
+
+
+def run(cmd: list[str], cwd: str | None = None, timeout: int = GIT_TIMEOUT) -> tuple[int, str, str]:
+    """Run a command, never raising. Returns (rc, stdout, stderr); rc 124 on timeout."""
+    try:
+        p = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout)
+        return p.returncode, p.stdout, p.stderr
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except OSError as e:
+        return 127, "", str(e)
+
+
+@dataclass
+class Holder:
+    """A live process with a reference into a worktree -- the guard that matters most."""
+
+    pid: int
+    kind: str  # cwd | exe | root | fd | map
+    comm: str
+    path: str
+
+
+@dataclass
+class Worktree:
+    path: str  # exactly as git reported it
+    real: str  # realpath; /home and /var/home are the same volume here
+    head: str | None = None
+    branch: str | None = None  # short name, None when detached
+    detached: bool = False
+    locked: bool = False
+    is_main: bool = False
+    exists: bool = True
+    admin_dir: str | None = None
+
+    merged_by: str | None = None  # "ancestor" | "squash-pr#123" | None
+    merge_evidence_available: bool = True
+    dirty_tracked: int = 0
+    dirty_untracked: int = 0
+    dirty_sample: list[str] = field(default_factory=list)
+    status_error: str | None = None
+    holders: list[Holder] = field(default_factory=list)
+    idle_hours: float | None = None
+    nested: list[str] = field(default_factory=list)
+    size_bytes: int | None = None
+
+    blockers: list[str] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return os.path.basename(self.real) or self.real
+
+    @property
+    def removable(self) -> bool:
+        return not self.blockers and self.merged_by is not None
+
+    @property
+    def state(self) -> str:
+        if self.removable:
+            return "REMOVABLE"
+        for b in BLOCKER_ORDER:
+            if b in self.blockers:
+                return b.upper()
+        return "UNKNOWN"
+
+
+# --------------------------------------------------------------------------- inventory
+
+
+def list_worktrees(repo: str) -> list[Worktree]:
+    rc, out, err = run(["git", "-C", repo, "worktree", "list", "--porcelain"])
+    if rc != 0:
+        sys.exit(f"worktree_reclaim: `git worktree list` failed: {err.strip()}")
+
+    trees: list[Worktree] = []
+    cur: Worktree | None = None
+    for line in out.splitlines():
+        if line.startswith("worktree "):
+            p = line[len("worktree ") :]
+            cur = Worktree(path=p, real=os.path.realpath(p))
+            trees.append(cur)
+        elif cur is None:
+            continue
+        elif line.startswith("HEAD "):
+            cur.head = line[len("HEAD ") :].strip()
+        elif line.startswith("branch "):
+            ref = line[len("branch ") :].strip()
+            cur.branch = ref[len("refs/heads/") :] if ref.startswith("refs/heads/") else ref
+        elif line == "detached":
+            cur.detached = True
+        elif line.startswith("locked"):
+            cur.locked = True
+        elif line.startswith("prunable"):
+            cur.exists = False
+
+    for t in trees:
+        t.exists = t.exists and os.path.isdir(t.real)
+    if trees:
+        trees[0].is_main = True
+
+    # Nested registrations: removing a parent would orphan whatever lives beneath it.
+    reals = {t.real for t in trees}
+    for t in trees:
+        if t.is_main:
+            continue  # every .claude/worktrees/* sits under main by construction
+        pfx = t.real.rstrip("/") + "/"
+        t.nested = sorted(r for r in reals if r != t.real and r.startswith(pfx))
+
+    for t in trees:
+        t.admin_dir = worktree_admin_dir(t)
+    return trees
+
+
+def worktree_admin_dir(t: Worktree) -> str | None:
+    """Resolve `<repo>/.git/worktrees/<name>` from the tree's `.git` pointer file."""
+    dotgit = os.path.join(t.real, ".git")
+    try:
+        if os.path.isfile(dotgit):
+            with open(dotgit, encoding="utf-8", errors="replace") as fh:
+                for line in fh:
+                    if line.startswith("gitdir:"):
+                        return os.path.realpath(line.split(":", 1)[1].strip())
+        elif os.path.isdir(dotgit):
+            return dotgit  # the main worktree
+    except OSError:
+        pass
+    return None
+
+
+# --------------------------------------------------------------------------- process scan
+
+
+def _readlink(path: str) -> str | None:
+    try:
+        target = os.readlink(path)
+    except OSError:
+        return None
+    # /proc marks unlinked targets; the prefix is still the directory we care about.
+    return target[: -len(" (deleted)")] if target.endswith(" (deleted)") else target
+
+
+def scan_processes(scan_fds: bool = True, scan_maps: bool = True) -> list[tuple[int, str, str, str]]:
+    """Collect every (pid, kind, comm, path) reference a live process holds.
+
+    Deliberately scans ALL processes rather than a list of known binary names. The failure this
+    guards against is a wedged interactive shell, and a shell is exactly what a name list misses.
+    Unreadable processes (other users, or exited mid-scan) are skipped -- so this is a lower
+    bound on holders, never an upper one, which is the safe direction.
+    """
+    refs: list[tuple[int, str, str, str]] = []
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return refs
+
+    for name in entries:
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        base = f"/proc/{name}"
+        try:
+            with open(f"{base}/comm", encoding="utf-8", errors="replace") as fh:
+                comm = fh.read().strip()
+        except OSError:
+            comm = "?"
+
+        for kind in ("cwd", "exe", "root"):
+            tgt = _readlink(f"{base}/{kind}")
+            if tgt and tgt != "/":
+                refs.append((pid, kind, comm, tgt))
+
+        if scan_fds:
+            try:
+                for fd in os.listdir(f"{base}/fd"):
+                    tgt = _readlink(f"{base}/fd/{fd}")
+                    if tgt and tgt.startswith("/"):
+                        refs.append((pid, "fd", comm, tgt))
+            except OSError:
+                pass
+
+        if scan_maps:
+            try:
+                seen: set[str] = set()
+                with open(f"{base}/maps", encoding="utf-8", errors="replace") as fh:
+                    for line in fh:
+                        idx = line.find(" /")
+                        if idx == -1:
+                            continue
+                        tgt = line[idx + 1 :].rstrip("\n")
+                        if tgt.endswith(" (deleted)"):
+                            tgt = tgt[: -len(" (deleted)")]
+                        if tgt not in seen:
+                            seen.add(tgt)
+                            refs.append((pid, "map", comm, tgt))
+            except OSError:
+                pass
+    return refs
+
+
+def attach_holders(trees: list[Worktree], refs: list[tuple[int, str, str, str]]) -> None:
+    """Assign each reference to the most specific worktree containing it.
+
+    Walking up from the reference and taking the first hit is what makes "most specific" work:
+    every `.claude/worktrees/X` is inside the main checkout, so a plain prefix match would blame
+    main for a process that is really sitting in X.
+    """
+    index = {t.real: t for t in trees}
+    for pid, kind, comm, path in refs:
+        cur = path
+        while True:
+            t = index.get(cur)
+            if t is not None:
+                t.holders.append(Holder(pid=pid, kind=kind, comm=comm, path=path))
+                break
+            parent = os.path.dirname(cur)
+            if parent == cur or len(parent) <= 1:
+                break
+            cur = parent
+
+
+# --------------------------------------------------------------------------- per-tree probes
+
+
+def probe_status(t: Worktree) -> None:
+    if not t.exists:
+        return
+    # `--no-optional-locks` is load-bearing, not tidiness. A plain `git status` REWRITES the index
+    # whenever the stat cache is stale, which sets the index mtime to now -- and the index is one
+    # of the files probe_idle reads to decide whether anyone has touched this tree. Measured on a
+    # tree with a deliberately stale cache: plain status moved the index mtime to the current
+    # second, `--no-optional-locks` left it at its true value. Without this flag the tool marks
+    # trees "recent" because it just visited them.
+    rc, out, err = run(
+        ["git", "--no-optional-locks", "-C", t.real, "status", "--porcelain=v1",
+         "--untracked-files=all"]
+    )
+    if rc != 0:
+        t.status_error = (err.strip() or f"rc={rc}")[:200]
+        return
+    for line in out.splitlines():
+        if line.startswith("?? "):
+            t.dirty_untracked += 1
+        elif line.strip():
+            t.dirty_tracked += 1
+        if len(t.dirty_sample) < STATUS_SAMPLE and line.strip():
+            t.dirty_sample.append(line)
+
+
+def probe_idle(t: Worktree) -> None:
+    """Newest mtime over the tree root, its immediate children, and the files in its git admin dir.
+
+    MUST run before probe_status, and MUST NOT stat the admin directory itself. Both rules are
+    here because the first draft broke them and reported every one of 278 trees as touched
+    "0.00h ago", which read as a plausible "everything is busy" rather than as a broken gauge:
+
+      `git status` creates and unlinks a transient lock inside `.git/worktrees/<name>/`, and
+      adding an entry to a directory updates THAT DIRECTORY's mtime. The files within keep their
+      true age -- measured on an idle tree, `index` was 27 days old and `HEAD`/`gitdir`/`refs`
+      31 days old, while the containing directory read as 4 seconds old, entirely because this
+      tool had just run `git status` there. `git worktree list` does not do this; `git status`
+      does.
+
+    So the scan was dating its own footprints. Reading only the files inside the admin dir gives
+    the real last-git-activity time, and probing idle first means no probe of ours has touched
+    the tree yet either way.
+
+    Still a proxy, not proof: a compile writing only inside `build-linux/obj/` updates none of
+    these, so a busy tree can look idle. This is a backstop for the process scan -- an agent
+    paused between tool calls holds no cwd -- not a substitute for it.
+    """
+    newest = 0.0
+
+    def bump(path: str, follow: bool = True) -> None:
+        nonlocal newest
+        try:
+            newest = max(newest, os.stat(path, follow_symlinks=follow).st_mtime)
+        except OSError:
+            pass
+
+    if os.path.isdir(t.real):
+        bump(t.real)  # a top-level add/remove is real activity, and git status does not cause it
+        try:
+            with os.scandir(t.real) as it:
+                for e in it:
+                    bump(e.path, follow=False)
+        except OSError:
+            pass
+
+    if t.admin_dir and os.path.isdir(t.admin_dir):
+        # Deliberately NOT os.stat(t.admin_dir) -- see the docstring.
+        try:
+            with os.scandir(t.admin_dir) as it:
+                for e in it:
+                    bump(e.path, follow=False)
+        except OSError:
+            pass
+
+    t.idle_hours = (time.time() - newest) / 3600.0 if newest else None
+
+
+def probe_size(t: Worktree) -> None:
+    if not t.exists:
+        return
+    rc, out, _ = run(["du", "-sb", "--", t.real], timeout=300)
+    if rc == 0 and out.strip():
+        try:
+            t.size_bytes = int(out.split()[0])
+        except (ValueError, IndexError):
+            pass
+
+
+# --------------------------------------------------------------------------- merge evidence
+
+
+def probe_ancestor(repo: str, trees: list[Worktree], base: str) -> None:
+    for t in trees:
+        if t.is_main or not t.head:
+            continue
+        rc, _, _ = run(["git", "-C", repo, "merge-base", "--is-ancestor", t.head, base])
+        if rc == 0:
+            t.merged_by = "ancestor"
+
+
+def probe_github(repo: str, trees: list[Worktree], limit: int) -> tuple[bool, str]:
+    """Cross-check against merged PRs. Returns (available, note).
+
+    Two batched `gh` calls rather than one per tree; with hundreds of worktrees the per-tree form
+    is both slow and rate-limited.
+    """
+    rc, out, err = run(
+        [
+            "gh", "pr", "list", "--state", "merged", "--limit", str(limit),
+            "--json", "number,headRefName,headRefOid,mergedAt",
+        ],
+        cwd=repo,
+        timeout=300,
+    )
+    if rc != 0:
+        return False, f"gh unavailable ({(err.strip() or 'rc=%d' % rc)[:120]})"
+    try:
+        merged = json.loads(out)
+    except json.JSONDecodeError as e:
+        return False, f"gh returned unparseable JSON ({e})"
+
+    rc2, out2, _ = run(
+        ["gh", "pr", "list", "--state", "open", "--limit", str(limit), "--json", "number,headRefName"],
+        cwd=repo,
+        timeout=300,
+    )
+    open_branches: set[str] = set()
+    if rc2 == 0:
+        try:
+            open_branches = {pr["headRefName"] for pr in json.loads(out2)}
+        except json.JSONDecodeError:
+            pass
+
+    by_oid: dict[str, int] = {}
+    for pr in merged:
+        oid = pr.get("headRefOid")
+        if oid:
+            by_oid.setdefault(oid, pr["number"])
+
+    for t in trees:
+        if t.is_main or t.merged_by or not t.head:
+            continue
+        num = by_oid.get(t.head)
+        if num is None:
+            continue
+        # A recycled branch name with a NEW open PR is live work; the sha check alone would not
+        # see it, because the old merged sha is still what this stale tree has checked out.
+        if t.branch and t.branch in open_branches:
+            continue
+        t.merged_by = f"squash-pr#{num}"
+
+    return True, f"gh: {len(merged)} merged PRs, {len(open_branches)} open branches"
+
+
+# --------------------------------------------------------------------------- classification
+
+
+def classify(t: Worktree, min_idle_hours: float, merge_evidence_available: bool) -> None:
+    t.blockers = []
+    if t.is_main:
+        t.blockers.append("main")
+        return
+    if not t.exists:
+        t.blockers.append("missing")
+        return
+    if t.locked:
+        t.blockers.append("locked")
+    if t.holders:
+        t.blockers.append("in-use")
+    if t.status_error:
+        t.blockers.append("status-unavailable")
+    elif t.dirty_tracked or t.dirty_untracked:
+        t.blockers.append("dirty")
+    if t.merged_by is None:
+        t.blockers.append("unmerged" if merge_evidence_available else "no-merge-evidence")
+    if t.nested:
+        t.blockers.append("nested")
+    if t.idle_hours is not None and t.idle_hours < min_idle_hours:
+        t.blockers.append("recent")
+
+
+def survey(
+    repo: str,
+    base: str,
+    min_idle_hours: float,
+    jobs: int,
+    use_github: bool,
+    gh_limit: int,
+    scan_fds: bool,
+    scan_maps: bool,
+    with_size: bool,
+) -> tuple[list[Worktree], dict]:
+    trees = list_worktrees(repo)
+
+    # Idle FIRST: `git status` bumps the admin directory's mtime, so probing it afterwards would
+    # measure this tool's own footprint. See probe_idle.
+    for t in trees:
+        probe_idle(t)
+    with ThreadPoolExecutor(max_workers=jobs) as pool:
+        list(pool.map(probe_status, trees))
+    if with_size:
+        with ThreadPoolExecutor(max_workers=jobs) as pool:
+            list(pool.map(probe_size, trees))
+
+    refs = scan_processes(scan_fds=scan_fds, scan_maps=scan_maps)
+    attach_holders(trees, refs)
+
+    probe_ancestor(repo, trees, base)
+    gh_available, gh_note = (False, "skipped (--no-github)")
+    if use_github:
+        gh_available, gh_note = probe_github(repo, trees, gh_limit)
+
+    for t in trees:
+        t.merge_evidence_available = True  # `ancestor` always works; gh only widens it
+        classify(t, min_idle_hours, merge_evidence_available=True)
+
+    meta = {
+        "repo": repo,
+        "base": base,
+        "base_sha": run(["git", "-C", repo, "rev-parse", base])[1].strip(),
+        "min_idle_hours": min_idle_hours,
+        "process_refs_scanned": len(refs),
+        "pids_seen": len({r[0] for r in refs}),
+        "scan_fds": scan_fds,
+        "scan_maps": scan_maps,
+        "github": gh_note,
+        "github_available": gh_available,
+    }
+    return trees, meta
+
+
+# --------------------------------------------------------------------------- reporting
+
+
+def redact(path: str) -> str:
+    home = os.path.expanduser("~")
+    for prefix in (os.path.realpath(home), home):
+        if path.startswith(prefix):
+            return "~" + path[len(prefix) :]
+    return path
+
+
+def human(n: int | None) -> str:
+    if n is None:
+        return "-"
+    v = float(n)
+    for unit in ("B", "K", "M", "G", "T"):
+        if v < 1024 or unit == "T":
+            return f"{v:.0f}{unit}" if unit == "B" else f"{v:.1f}{unit}"
+        v /= 1024
+    return f"{v:.1f}T"
+
+
+def report(trees: list[Worktree], meta: dict, do_redact: bool, verbose: bool) -> None:
+    fmt = redact if do_redact else (lambda p: p)
+
+    print("=" * 100)
+    print("worktree_reclaim -- census")
+    print("=" * 100)
+    print(f"repo                 {fmt(meta['repo'])}")
+    print(f"base                 {meta['base']} @ {meta['base_sha'][:12]}")
+    print(f"worktrees registered {len(trees)}")
+    print(f"process refs scanned {meta['process_refs_scanned']} over {meta['pids_seen']} pids "
+          f"(fds={meta['scan_fds']}, maps={meta['scan_maps']})")
+    print(f"merge evidence       ancestor-of-{meta['base']} + {meta['github']}")
+    print(f"idle threshold       {meta['min_idle_hours']}h")
+    print()
+
+    order = {s: i for i, s in enumerate(["REMOVABLE"] + [b.upper() for b in BLOCKER_ORDER])}
+    counts: dict[str, int] = {}
+    reclaim = 0
+    for t in trees:
+        counts[t.state] = counts.get(t.state, 0) + 1
+        if t.removable and t.size_bytes:
+            reclaim += t.size_bytes
+
+    print(f"{'STATE':<20} {'COUNT':>6}   meaning")
+    print("-" * 100)
+    meanings = {
+        "REMOVABLE": "merged, clean, idle, unheld -- every guard passed",
+        "MAIN": "the primary checkout, never touched",
+        "MISSING": "directory gone; `git worktree prune` reclaims the registration",
+        "LOCKED": "explicitly locked by a human",
+        "IN-USE": "a live process holds cwd/exe/fd/map inside it",
+        "DIRTY": "uncommitted or untracked files present",
+        "UNMERGED": "work not provably in the base branch",
+        "NO-MERGE-EVIDENCE": "could not establish merge state",
+        "NESTED": "another worktree is registered underneath it",
+        "RECENT": "touched inside the idle threshold",
+        "STATUS-UNAVAILABLE": "`git status` failed here",
+    }
+    for state in sorted(counts, key=lambda s: order.get(s, 99)):
+        print(f"{state:<20} {counts[state]:>6}   {meanings.get(state, '')}")
+    print("-" * 100)
+    print(f"{'TOTAL':<20} {len(trees):>6}")
+
+    # The table above is mutually exclusive -- a tree is filed under its most severe blocker only,
+    # so "UNMERGED 78" does NOT mean only 78 trees are unmerged. Quote this tally for per-guard
+    # counts; a tree carrying three blockers appears in three rows here and one row above.
+    tally: dict[str, int] = {}
+    for t in trees:
+        for b in t.blockers:
+            tally[b] = tally.get(b, 0) + 1
+    print()
+    print("guards fired (independent; one tree can trip several -- these do NOT sum to the total)")
+    print("-" * 100)
+    for b in BLOCKER_ORDER:
+        if tally.get(b):
+            print(f"{b:<20} {tally[b]:>6}")
+    if reclaim:
+        print(f"\nreclaimable if every REMOVABLE tree is removed: {human(reclaim)}")
+    print()
+
+    groups: dict[str, list[Worktree]] = {}
+    for t in trees:
+        groups.setdefault(t.state, []).append(t)
+
+    for state in sorted(groups, key=lambda s: order.get(s, 99)):
+        if state == "MAIN" and not verbose:
+            continue
+        rows = groups[state]
+        if state in ("UNMERGED", "RECENT", "IN-USE", "DIRTY") and not verbose:
+            print(f"### {state} ({len(rows)}) -- not listed; pass --verbose")
+            print()
+            continue
+        print(f"### {state} ({len(rows)})")
+        for t in sorted(rows, key=lambda x: x.real):
+            bits = [f"  {fmt(t.real)}"]
+            bits.append(f"      branch   {t.branch or '(detached)'}  head {(t.head or '?')[:12]}")
+            bits.append(
+                f"      merged   {t.merged_by or 'NO'}"
+                f"   dirty {t.dirty_tracked}+{t.dirty_untracked}u"
+                f"   idle {('%.1fh' % t.idle_hours) if t.idle_hours is not None else '?'}"
+                f"   size {human(t.size_bytes)}"
+            )
+            if t.blockers:
+                bits.append(f"      blocked  {', '.join(t.blockers)}")
+            if t.holders:
+                shown = t.holders[:4]
+                for h in shown:
+                    bits.append(f"      holder   pid {h.pid} [{h.comm}] {h.kind} -> {fmt(h.path)}")
+                if len(t.holders) > len(shown):
+                    bits.append(f"      holder   ... and {len(t.holders) - len(shown)} more")
+            if t.dirty_sample and verbose:
+                for line in t.dirty_sample:
+                    bits.append(f"      status   {line}")
+            if t.nested:
+                bits.append(f"      nested   {', '.join(fmt(n) for n in t.nested)}")
+            print("\n".join(bits))
+        print()
+
+
+# --------------------------------------------------------------------------- removal
+
+
+def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
+                       scan_fds: bool, scan_maps: bool, use_github: bool,
+                       gh_limit: int, do_redact: bool) -> bool:
+    """Re-run every guard against fresh state, then remove. Returns True on removal.
+
+    The census is deliberately not trusted here. An agent can cd into a tree between the scan and
+    the delete, and that race is the entire reason the scan exists.
+    """
+    fmt = redact if do_redact else (lambda p: p)
+    fresh = list_worktrees(repo)
+    cur = next((w for w in fresh if w.real == t.real), None)
+    if cur is None:
+        print(f"  SKIP {fmt(t.real)}: no longer registered")
+        return False
+
+    probe_idle(cur)  # before probe_status, for the reason given in probe_idle
+    probe_status(cur)
+    attach_holders(fresh, scan_processes(scan_fds=scan_fds, scan_maps=scan_maps))
+    probe_ancestor(repo, fresh, base)
+    if use_github and cur.merged_by is None:
+        probe_github(repo, fresh, gh_limit)
+    cur = next((w for w in fresh if w.real == t.real), cur)
+    classify(cur, min_idle_hours, merge_evidence_available=True)
+
+    if not cur.removable:
+        print(f"  REFUSE {fmt(cur.real)}: {', '.join(cur.blockers) or 'no merge evidence'}")
+        return False
+    if cur.merged_by != t.merged_by:
+        print(f"  REFUSE {fmt(cur.real)}: merge evidence changed since census")
+        return False
+
+    # No --force, ever: git's own dirty check is a second independent line of defence, and the
+    # branch ref is deliberately left in place so no commit becomes unreachable.
+    rc, _, err = run(["git", "-C", repo, "worktree", "remove", cur.real])
+    if rc != 0:
+        print(f"  FAILED {fmt(cur.real)}: {err.strip()[:200]}")
+        return False
+    print(f"  REMOVED {fmt(cur.real)}  ({cur.merged_by}, idle {cur.idle_hours:.1f}h)")
+    return True
+
+
+# --------------------------------------------------------------------------- main
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Classify git worktrees; remove only provably dead ones (opt-in).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--repo", default=None, help="repository root (default: containing this file)")
+    ap.add_argument("--base", default="origin/master", help="branch work must have landed in")
+    ap.add_argument("--min-idle-hours", type=float, default=DEFAULT_MIN_IDLE_HOURS)
+    ap.add_argument("--jobs", type=int, default=4, help="parallel git probes (default 4)")
+    ap.add_argument("--no-github", action="store_true", help="skip the merged-PR cross-check")
+    ap.add_argument("--gh-limit", type=int, default=3000, help="merged PRs to fetch")
+    ap.add_argument("--no-fds", action="store_true", help="skip /proc/*/fd scanning")
+    ap.add_argument("--no-maps", action="store_true", help="skip /proc/*/maps scanning")
+    ap.add_argument("--size", action="store_true", help="measure disk usage per tree (slow)")
+    ap.add_argument("--json", action="store_true", help="machine-readable census")
+    ap.add_argument("--redact", action="store_true", help="mask the home prefix in all paths")
+    ap.add_argument("--verbose", action="store_true", help="list every tree, not just candidates")
+    ap.add_argument("--remove", action="store_true", help="actually remove REMOVABLE trees")
+    ap.add_argument("--yes", action="store_true", help="required alongside --remove")
+    ap.add_argument("--prune", action="store_true", help="`git worktree prune` for MISSING trees")
+    ap.add_argument("--limit", type=int, default=0, help="cap removals this run (0 = no cap)")
+    ap.add_argument("--only", action="append", default=[],
+                    help="restrict removal to trees whose path contains this substring")
+    args = ap.parse_args(argv)
+
+    repo = args.repo or os.path.realpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")
+    )
+    rc, out, _ = run(["git", "-C", repo, "rev-parse", "--show-toplevel"])
+    if rc != 0:
+        sys.exit(f"worktree_reclaim: not a git repository: {repo}")
+    repo = out.strip() or repo
+
+    trees, meta = survey(
+        repo=repo,
+        base=args.base,
+        min_idle_hours=args.min_idle_hours,
+        jobs=max(1, args.jobs),
+        use_github=not args.no_github,
+        gh_limit=args.gh_limit,
+        scan_fds=not args.no_fds,
+        scan_maps=not args.no_maps,
+        with_size=args.size,
+    )
+
+    if args.json:
+        print(json.dumps(
+            {
+                "meta": meta,
+                "worktrees": [
+                    {
+                        "path": redact(t.real) if args.redact else t.real,
+                        "branch": t.branch,
+                        "head": t.head,
+                        "state": t.state,
+                        "merged_by": t.merged_by,
+                        "blockers": t.blockers,
+                        "dirty_tracked": t.dirty_tracked,
+                        "dirty_untracked": t.dirty_untracked,
+                        "idle_hours": t.idle_hours,
+                        "size_bytes": t.size_bytes,
+                        "holders": [
+                            {"pid": h.pid, "kind": h.kind, "comm": h.comm,
+                             "path": redact(h.path) if args.redact else h.path}
+                            for h in t.holders
+                        ],
+                        "removable": t.removable,
+                    }
+                    for t in trees
+                ],
+            },
+            indent=2,
+        ))
+    else:
+        report(trees, meta, args.redact, args.verbose)
+
+    # In --json mode every human line goes to stderr, so stdout stays a parseable document.
+    say = (lambda *a: print(*a, file=sys.stderr)) if args.json else print
+
+    if args.prune:
+        missing = [t for t in trees if not t.exists and not t.is_main]
+        if not (args.remove and args.yes):
+            say(f"[dry-run] would `git worktree prune` for {len(missing)} MISSING registration(s)")
+        else:
+            rc, _, err = run(["git", "-C", repo, "worktree", "prune", "-v"])
+            say(f"pruned {len(missing)} missing registration(s)"
+                if rc == 0 else f"prune failed: {err.strip()[:200]}")
+
+    candidates = [t for t in trees if t.removable]
+    if args.only:
+        candidates = [t for t in candidates if any(s in t.real for s in args.only)]
+    if args.limit:
+        candidates = candidates[: args.limit]
+
+    if not args.remove:
+        say(f"[dry-run] {len(candidates)} tree(s) pass every guard. "
+            f"Nothing was modified. Re-run with --remove --yes to act.")
+        return 0
+    if not args.yes:
+        say(f"[dry-run] --remove requires --yes as well. {len(candidates)} candidate(s); "
+            f"nothing was modified.")
+        return 2
+
+    say(f"\nRemoving {len(candidates)} tree(s); every guard is re-checked per tree first.")
+    removed = sum(
+        1 for t in candidates
+        if recheck_and_remove(repo, t, args.base, args.min_idle_hours,
+                              not args.no_fds, not args.no_maps,
+                              not args.no_github, args.gh_limit, args.redact)
+    )
+    say(f"\nremoved {removed} of {len(candidates)} candidate(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/worktree_reclaim.py
+++ b/prosper/tools/worktree_reclaim.py
@@ -805,10 +805,24 @@ def report(trees: list[Worktree], meta: dict, do_redact: bool, verbose: bool) ->
 def recheck_and_remove(repo: str, t: Worktree, base: str, min_idle_hours: float,
                        scan_fds: bool, scan_maps: bool, use_github: bool,
                        gh_limit: int, do_redact: bool) -> bool:
-    """Re-run every guard against fresh state, then remove. Returns True on removal.
+    """Re-probe the local guards against fresh state, then remove. Returns True on removal.
 
-    The census is deliberately not trusted here. An agent can cd into a tree between the scan and
-    the delete, and that race is the entire reason the scan exists.
+    The census is deliberately not trusted for anything local. An agent can cd into a tree between
+    the scan and the delete, and that race is the entire reason the scan exists, so the worktree
+    list, status, idle time and holder scan are all re-run per candidate.
+
+    The ONE exception is the GitHub merge evidence, which reuses the census-time merged/open
+    snapshot via _GH_CACHE. Refetching it per candidate is exactly what that cache exists to
+    prevent: with 146 candidates it means 146 paginated queries and a near-certain rate limit,
+    whose symptom is trees refusing under a mislabelled verdict. The staleness is harmless in the
+    direction that matters -- a PR merging mid-run can only make MORE trees removable, never fewer,
+    and a tree wrongly still qualified by an old snapshot is still gated behind every local guard.
+
+    Consequence worth knowing: a transient `gh` failure is cached too, so it is sticky for the
+    process lifetime and the rest of the run proceeds on ancestry alone. That is the safe
+    direction -- fewer trees qualify -- but it means a one-off network blip quietly narrows the
+    evidence for the whole run rather than for one candidate. Re-run the tool rather than assuming
+    a small candidate count means the trees are live.
     """
     fmt = redact if do_redact else (lambda p: p)
     fresh = list_worktrees(repo)


### PR DESCRIPTION
Refs #1735

## Why

`CLAUDE.md` told every agent *"Your worktree is auto-cleaned when its branch merges."* It is not,
because **the mechanism never existed.**

## Finding: the auto-clean was never real

Searched exhaustively; every one of these is absent:

| where a mechanism could live | result |
| --- | --- |
| `.git/hooks/` | 15 files, **all `*.sample`**; zero non-sample hooks |
| `core.hooksPath`, `init.templateDir` | unset, in every config scope |
| `hooks` key in settings.json | absent from project, project-local, user; no managed settings file exists |
| `.claude/hooks/` | does not exist, repo or home |
| any script calling `git worktree remove`/`prune` | **zero matches** repo-wide; ~50 scripts only `cd` into worktrees |
| `.github/workflows/` | one file, build-only `ci.yml`; no cleanup step (and a GitHub runner could not delete a local directory anyway) |
| cron / systemd timers | `crontab` not installed, no `/etc/cron.d`; user timers are only `systemd-tmpfiles-clean` and `grub-boot-success` |

The sentence entered in **#332** (`git log -S`), whose diff is `CLAUDE.md | 14 ++++++` — prose only,
no code beside it.

**Likely origin, and it is instructive:** the harness feature is *real but disjoint*. Subagents
launched with `isolation: "worktree"` genuinely are auto-cleaned — visible here as the total absence
of `agent-<hex>` trees, even though `tools/dbg/*.sh` hardcodes a dozen such paths, and
`git worktree prune --dry-run` reports nothing prunable, so they were properly removed rather than
`rm -rf`ed. That real behaviour was generalized into a promise about hand-made `git worktree add`
trees, which the harness never sees. A charter promising a safety net nobody has is worse than one
admitting the manual step: everyone skips the cleanup *and* nobody files the bug. `CLAUDE.md` is
corrected here, with the reason, so it is not re-asserted.

## Re-measured on current master

#1735 measured 121 trees / 111 GB. Now:

| state | count | |
| --- | ---: | --- |
| **REMOVABLE** | **145** | merged, clean, idle, unheld — every guard passed (**216.4 GB**) |
| UNMERGED | 75 | not provably in master |
| DIRTY | 33 | uncommitted or untracked files |
| RECENT | 19 | touched inside the idle threshold |
| IN-USE | 5 | a live process holds cwd/exe/fd/map inside |
| MAIN | 1 | |
| **total** | **278** | |

Independent per-guard tally (a tree can trip several): unmerged 80, dirty 37, recent 40, in-use 5.
The state table is mutually exclusive by severity, so the tool prints both — quoting only the first
would imply 75 unmerged trees when 80 trees are unmerged.

`/home` and `/var/home` are the same volume via a symlink; canonicalizing all 278 paths still yields
278 distinct trees, so **nothing is double-counted**.

## The tool

`prosper/tools/worktree_reclaim.py`. Default is a census that touches nothing; `--remove` additionally
requires `--yes`.

Guards, **all** required, and **re-checked immediately before each individual removal** rather than
trusted from the scan — an agent can `cd` into a tree between the two, which is the entire reason the
scan exists: `main`, `exists`, `locked`, `unmerged`, `dirty` (untracked counts), `in-use`, `recent`,
`nested`.

- **`in-use` scans every process**, not a list of known binary names. The failure mode is a wedged
  interactive shell, and a name list misses shells. Matched over `/proc/*/cwd`, `exe`, `root`, open
  fds and mappings, attributed to the **most specific** containing worktree — a plain prefix match
  would blame the main checkout for a process sitting in `.claude/worktrees/X`.
- **Removal never deletes a branch ref**, so no commit becomes unreachable, and `git worktree remove`
  runs **without `--force`** so git's own dirty check stays a second, independent line of defence.
- `--redact` masks the home prefix, since a worktree inventory is exactly the output that leaks host
  paths into a public repo.

### Merge evidence: two primary sources, no heuristic

`merge-base --is-ancestor` is exact but **blind to squash merges, which is how this repository merges
every PR** (the last 20 commits on master each have one parent). Alone it qualifies almost nothing —
it mostly catches branches that never committed. The second source matches a tree's HEAD against the
`headRefOid` of a **merged** PR: conclusive that this exact tree state is what GitHub merged. A named
branch additionally requires that no **open** PR uses it, so a recycled branch name is never mistaken
for the merged one. Both fail toward "leave it alone".

## Instrument bug found and fixed while writing this

Recorded because the wrong reading looked entirely plausible. Examining a worktree **made it look
freshly touched**, so the first census reported all 278 trees as idle `0.00h` — which reads as a busy
machine, not a broken gauge. Two independent causes:

1. `git status` creates and unlinks a lock inside `.git/worktrees/<name>/`, which bumps **that
   directory's** mtime while every file inside keeps its true age. Measured on an idle tree: `index`
   27 days old, `HEAD`/`gitdir`/`refs` 31 days old, containing directory **4 seconds** old.
   `git worktree list` does not do this; `git status` does.
2. A plain `git status` **rewrites the index** whenever the stat cache is stale, moving the mtime of
   a file the idle probe legitimately reads.

The scan was dating its own footprints. Fixed by reading only the *files* inside the admin dir and
passing `--no-optional-locks`. Verified with a control **constructed to be able to fire** — a
deliberately stale stat cache, since my first check used an already-refreshed tree where neither form
would have written anything and so could not discriminate: plain status moved the index mtime to the
current second, `--no-optional-locks` left it at its true value.

## Verification

`prosper/tools/test_worktree_reclaim.py`, registered as ctest `worktree_reclaim_tool`.

```
ctest --test-dir build-cfg -R worktree_reclaim_tool --no-tests=error
    Start 5: worktree_reclaim_tool
1/1 Test #5: worktree_reclaim_tool ............   Passed    1.14 sec
100% tests passed out of 1        # 1 test discovered, exit 0
```

**Mutation arms are the point.** The assertion that matters is not "it removed the safe tree" — a tool
that deletes everything passes that. Each arm builds a tree that MUST NOT be removed and pins **which
guard fired**, because a tree spared for the wrong reason is a tool that deletes work as soon as that
accidental reason lapses. Arms: dirty (tracked), untracked-only, unmerged (real new commit), in-use
(live `cwd`, asserting the holder's pid is identified), recent, locked, nested, main; plus holder
attribution to the nested rather than parent tree; plus `--remove --yes` end to end taking **only**
the safe tree while every mutation arm survives and the branch ref is kept; plus a race arm where the
tree goes dirty *after* the census and the recheck still refuses. Fixtures are built by hand from git
primitives, not from the tool's own view of the world.

**The tests were themselves mutation-tested** — both fixes reverted in turn, confirming the arms fail
(dropping `--no-optional-locks` → 3 failures; stat-ing the admin dir → 5 failures), then restored green.

## Risks

- The 145 candidates are **reported, not removed** — nothing on this machine was deleted for this PR.
  The count moves as lanes work; the tool re-derives it and re-checks per tree, so a stale list here
  cannot cause a wrong removal.
- The `recent` guard is a **proxy**: a compile writing only inside `build-linux/obj/` updates neither
  the tree root nor the admin dir, so a busy tree can read as idle. It is a backstop for the process
  scan — an agent paused between tool calls holds no cwd — not a substitute. `CONFIDENCE: MED` on that
  guard alone; `CONFIDENCE: HIGH` on the others.
- A point-in-time process scan is **advisory, not a lock**. Mitigated by re-checking per removal, not
  eliminated.
- The GitHub cross-check needs network; `--no-github` degrades to ancestor-only, which qualifies far
  fewer trees. It fails toward leaving trees alone.

## Not done deliberately

No branch deletion, no automatic scheduling, and no removals performed. Whether to wire this into a
hook is a separate decision — this PR's job was to establish that no such hook exists and to make the
manual step safe.
