### PR TITLE
tools(docs): check_merge_result.py — validate the MERGE RESULT before merging, against a freshly fetched base

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -511,7 +511,7 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     unique and ascending, and requires that **no row present in the base is missing** (`--baseline`).
     Note the local baseline is `origin/master`, while **CI passes `HEAD^1`** — the base *as of when the
     event fired*. `origin/master` is the fresher and therefore stricter of the two, which is why it is
-    the right one to check by hand; the gap between them is the subject of instrument trap 188.
+    the right one to check by hand; the gap between them is the subject of instrument trap 189.
     **Gaps are legal** — `--sequential` and its gapless rule were removed on 2026-08-17 (#2089) because a
     gap is usually another lane's unmerged number, which no edit of *your* branch can supply, so the check
     served only to serialize independent lanes; the flag now errors and names its replacement. So if you
@@ -519,6 +519,12 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     wait for the number below yours. Before writing a row, allocate with
     `python3 prosper/tools/docs/trap_number.py`, which scans master **and every open PR** (#1729);
     reading master alone is what produced the #2574/#2581 collision.
+    **On a PR that touches a numbered table, run the gate against the MERGE RESULT immediately before
+    merging** — `python3 prosper/tools/docs/check_merge_result.py` fetches, merges into
+    `origin/master` in the object database (no checkout, no index), and runs the gate on the result.
+    A green `Docs` job is a statement about a merge that may no longer exist, and unlike a red one
+    nobody re-derives it (#2211, instrument trap 189); this is the only check that sees a concurrent
+    append, and it is stale the moment another lane lands, so run it last and merge promptly.
     Confirm the diff really is `.md`-only — `git diff --name-only origin/master...HEAD | grep -v '\.md$'`
     should be empty. The exception is about the *diff*, not the intent; one stray file makes it an
     ordinary PR again.

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -216,6 +216,13 @@ if(Python3_Interpreter_FOUND)
   # divergence would hand out a number the gate then rejects, on somebody else's PR, hours later.
   add_test(NAME trap_number
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/docs/test_trap_number.py")
+  # The pre-merge merge-result check (#2211). Its cases build real throwaway git repositories and
+  # run real merges: the git plumbing IS the tool, so a mocked merge would test nothing. The case
+  # that earns its keep is the clean merge whose RESULT holds a duplicate -- the state no head-time
+  # check can observe, because at head time the other branch's row did not exist.
+  add_test(NAME doc_merge_result_checker
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/docs/test_check_merge_result.py")
   # Parsing/gating logic of the Vulkan validation guard (#1704). Pure — it does not create a Vulkan
   # instance, so it runs everywhere. A parser that stops matching the layer's message framing would
   # report a clean suite forever, which is the one way this guard can fail silently.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -470,6 +470,25 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   citation at all, losing 22 of 118 references (5 of them in `.cpp`/`.hpp`/test comments) **with the
   gate still green and the success line still saying "all resolving"**. Run by the CI `Docs` job;
   `ctest -R trap_citation_checker` covers it.
+- **`docs/check_merge_result.py`** — run the numbered-table gate against the **merge result**, against
+  a freshly fetched base, as the last step before merging (#2211). A `pull_request` job validates
+  `refs/pull/N/merge`, which GitHub computes when the event fires and never recomputes as the base
+  moves, so a **green** required check is a statement about a merge that may no longer exist — and
+  unlike a red one, nobody re-derives it (instrument trap 189). Uses `git merge-tree --write-tree`,
+  so it touches neither your working tree nor the index and cannot collide with another agent in the
+  same repository. Reports a textual conflict as a conflict rather than as a table defect, and a
+  checker failure as a checker failure. **`--base` defaults to `origin/master`, which is wrong for a
+  stacked PR** — pass the branch it will actually merge into, or the green run describes a merge that
+  will never happen.
+  **Measured boundary, so its value is not overstated:** for two same-numbered rows inserted at a row
+  boundary in an otherwise identical file, separation 0 lines (both appending at the tail) makes git
+  *conflict*, and separation ≥ 1 leaves the offending branch **already red on its own head** —
+  because inserting a duplicate-numbered row above the tail puts that branch's *own* column out of
+  ascending order, which is an artifact of how those cases were generated rather than a general
+  property of separated insertions. So in that family `--ordered` alone closes the hole. What it does
+  **not** close, and this tool does, is the artifact a *human* produces: resolving that separation-0
+  conflict by keeping both rows gives a duplicate on master while **both heads were green**, which is
+  how `33, 34, 35, 32` reached master in #1696. `ctest -R doc_merge_result_checker` covers it.
 - **`docs/trap_number.py`** — allocate the next instrument-trap row number against `origin/master`
   **and every open PR** (#1729). Prints each claimant so you can see whether you are in a race, not
   just a bare number. An **advisor, not a gate**: two lanes running it in the same minute both see the

--- a/prosper/tools/docs/check_merge_result.py
+++ b/prosper/tools/docs/check_merge_result.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Run the numbered-table gate against the MERGE RESULT, against a freshly fetched base.
+
+WHY. A `pull_request` CI job validates `refs/pull/N/merge`, which GitHub computes **when the event
+fires** and never recomputes as the base moves. So a green required check is a statement about a
+merge that may no longer exist, and unlike a red one nobody re-derives it -- a red check gets
+investigated, a green check is *acted on*. That is instrument trap 189, and #2581 merged on exactly
+it: its `Docs` job was green against a base predating #2574, so nothing warned either author that
+both had written instrument-trap row 182 (#2211).
+
+The residual hole is not fixable in the workflow file -- the remedies are repository settings
+(branch protection's "require branches to be up to date", or a merge queue) that only the owner can
+apply. This is the part a checkout CAN do: compute the merge yourself, immediately before merging,
+and run the gate on the result. It is the manual procedure that caught the 182 collision, made into
+one command.
+
+HOW, and why it does not touch your tree. `git merge-tree --write-tree` performs the merge entirely
+in the object database: no checkout, no index, no `MERGE_HEAD` to clean up, and nothing that can
+collide with another agent working in the same repository. It reports conflicts by exit status and
+names the conflicted paths, so a textual conflict is distinguished from a clean merge that is
+nevertheless invalid -- which is the case the gate exists for, since two rows claiming one number on
+lines a few apart merge CLEANLY (#1701, #2211).
+
+`--base` DEFAULTS TO `origin/master`, WHICH IS WRONG FOR A STACKED PR. The honest pre-merge check is
+against the branch this one will actually merge into, so pass `--base <that branch>` when your PR is
+stacked. A green run against the wrong base is not a weaker signal -- it is a confident statement
+about a merge that will never happen.
+
+WHAT IT CANNOT TELL YOU. It answers about the base as of the moment it runs. Another lane can merge
+in the second after it prints, so this shrinks the window exactly the way `trap_number.py` does and
+closes it no more than that -- run it as the last step before merging, not as the first step of a
+review. It also checks only the numbered-table classes: a semantically wrong row, a reverted
+paragraph, or a stale by-number reference in prose all merge clean and pass here (that boundary is
+the same one `check_numbered_table.py`'s own WHAT THIS CANNOT SEE section draws).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+DEFAULT_FILE = "prosper/docs/GAME_COMPAT_ORCHESTRATION.md"
+DEFAULT_HEADER = "Instrument"
+CHECKER = Path(__file__).resolve().parent / "check_numbered_table.py"
+
+
+def git(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    proc = subprocess.run(["git", *args], capture_output=True, text=True)
+    if check and proc.returncode != 0:
+        print(f"error: git {' '.join(args[:3])}... failed: {proc.stderr.strip()}", file=sys.stderr)
+        raise SystemExit(2)
+    return proc
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--base", default="origin/master", help="branch to merge into (default origin/master)")
+    ap.add_argument("--head", default="HEAD", help="what to merge (default HEAD)")
+    ap.add_argument("--file", default=DEFAULT_FILE, help=f"file to check (default {DEFAULT_FILE})")
+    ap.add_argument("--table-header", default=DEFAULT_HEADER,
+                    help=f"select the table whose header contains this (default {DEFAULT_HEADER!r})")
+    ap.add_argument("--no-fetch", action="store_true",
+                    help="skip `git fetch` -- ONLY for a scripted caller that just fetched; a stale "
+                         "base is the exact defect this tool exists to catch")
+    args = ap.parse_args()
+
+    if not args.no_fetch:
+        git("fetch", "--quiet", "origin")
+
+    base = git("rev-parse", args.base).stdout.strip()
+    head = git("rev-parse", args.head).stdout.strip()
+    print(f"merging {args.head} ({head[:8]}) into {args.base} ({base[:8]})")
+
+    if git("merge-base", "--is-ancestor", head, base, check=False).returncode == 0:
+        print("nothing to check: this head is already contained in the base.")
+        return 0
+
+    # --write-tree leaves the working tree and index untouched, which matters in a repository
+    # several agents share. Exit 1 means conflicts; the tree oid is still the first stdout line and
+    # the conflicted paths follow, so the message can name them.
+    merged = git("merge-tree", "--write-tree", base, head, check=False)
+    if merged.returncode not in (0, 1):
+        print(f"error: git merge-tree failed: {merged.stderr.strip()}", file=sys.stderr)
+        if "--write-tree" in merged.stderr or "usage:" in merged.stderr.lower():
+            # git 2.38 introduced this mode. Named explicitly because the fallback (`git merge` in a
+            # scratch worktree) is the thing this tool deliberately avoids, so "just use git merge"
+            # is the wrong lesson to draw from a usage message.
+            print("`git merge-tree --write-tree` needs git >= 2.38; this git is "
+                  f"{git('--version').stdout.strip()}", file=sys.stderr)
+        return 2
+    lines = merged.stdout.split("\n")
+    tree = lines[0].strip()
+    if merged.returncode == 1:
+        conflicts = [l for l in lines[1:] if l.strip()]
+        print("MERGE CONFLICT -- resolve it before merging. Conflicted paths / messages:")
+        for line in conflicts[:20]:
+            print(f"  {line}")
+        print()
+        print("Re-apply your own hunks onto the base's version rather than taking the file whole")
+        print("(instrument trap 41 / #1701): `git checkout <branch> -- <file>` reverts every OTHER")
+        print("lane's edit to that file, with no conflict and no failing check.")
+        return 1
+
+    with tempfile.TemporaryDirectory() as d:
+        merged_copy = Path(d) / "merged.md"
+        base_copy = Path(d) / "base.md"
+        show = git("show", f"{tree}:{args.file}", check=False)
+        if show.returncode != 0:
+            print(f"error: {args.file} is not in the merge result: {show.stderr.strip()}", file=sys.stderr)
+            return 2
+        merged_copy.write_text(show.stdout, encoding="utf-8")
+        base_copy.write_text(git("show", f"{base}:{args.file}").stdout, encoding="utf-8")
+
+        proc = subprocess.run(
+            [sys.executable, str(CHECKER), "--ordered", "--table-header", args.table_header,
+             "--baseline", str(base_copy), str(merged_copy)],
+            capture_output=True, text=True,
+        )
+    # Rewrite the temporary path back to the real one: an error naming a file in /tmp that no longer
+    # exists reads as a tooling failure rather than as a finding about your change.
+    for stream, out in ((proc.stdout, sys.stdout), (proc.stderr, sys.stderr)):
+        if stream:
+            text = stream.replace(str(merged_copy), f"{args.file} (merged)")
+            print(text.replace(str(base_copy), f"{args.base}:{args.file}").rstrip(), file=out)
+
+    if proc.returncode == 0:
+        print(f"\nclean merge, and the merge RESULT passes the gate against {args.base} as of now.")
+        print("Merge promptly: another lane landing after this point invalidates it.")
+    elif "problem(s) found" not in proc.stdout + proc.stderr:
+        # Classified on the checker's own summary marker rather than on its exit STATUS, and the
+        # difference matters: argparse exits 2, but an unhandled exception exits **1** -- the same
+        # status as a real finding. So a crash in the checker would otherwise be announced as "your
+        # table is invalid", sending the author into their own diff for a fault that is not theirs.
+        # That is the same mis-attribution this file already avoids for a textual conflict (#2616
+        # review). Only a run that reported problems is treated as a finding.
+        print(f"\nThe checker itself failed (rc={proc.returncode}) without reporting any table",
+              file=sys.stderr)
+        print("problem, so this says NOTHING about the merge result. Fix the invocation above,",
+              file=sys.stderr)
+        print("then re-run.", file=sys.stderr)
+    else:
+        print("\nThe merge is textually clean but the RESULT is invalid -- this is the case CI",
+              file=sys.stderr)
+        print("cannot see, because at head time the other row did not exist. Fix on your branch,",
+              file=sys.stderr)
+        print("then re-run. Gaps are legal (#2089), so a duplicate is repaired by renumbering YOUR",
+              file=sys.stderr)
+        print("row to any number above the current highest -- nothing waits on anything.", file=sys.stderr)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/docs/test_check_merge_result.py
+++ b/prosper/tools/docs/test_check_merge_result.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Self-checking tests for check_merge_result.py (exit code is truth).
+
+Each case builds a throwaway git repository with two branches and asks the tool about the merge, so
+the git plumbing is exercised for real rather than mocked -- the plumbing IS the tool, and a mocked
+`merge-tree` would test nothing.
+
+The case that matters most is `clean merge, duplicate in the result`: BOTH inputs merge without a
+textual conflict, and the invalid table exists only in the merge. That is the state CI cannot
+observe, because at the time each head was validated the other row did not exist (#2211).
+
+Run directly, or via ctest as doc_merge_result_checker.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+TOOL = HERE / "check_merge_result.py"
+DOC = "prosper/docs/GAME_COMPAT_ORCHESTRATION.md"
+
+FAILURES: list[str] = []
+
+
+def table(*rows: str) -> str:
+    body = "".join(f"| {n} | {what} | evidence |\n" for n, what in (r.split(":", 1) for r in rows))
+    return "| # | Instrument | How it lied |\n|---|---|---|\n" + body + "\n### Next\n\nprose\n"
+
+
+def git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+
+
+def write(repo: Path, text: str) -> None:
+    p = repo / DOC
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text, encoding="utf-8")
+
+
+def scenario(base: str, ours: str, theirs: str, d: str) -> Path:
+    """A repo whose `master` holds `ours` and whose `lane` holds `theirs`, both from `base`."""
+    repo = Path(d) / "repo"
+    repo.mkdir()
+    git(repo, "init", "-q", "-b", "master")
+    git(repo, "config", "user.email", "t@example.invalid")
+    git(repo, "config", "user.name", "t")
+    # Windows runners default core.autocrlf=true, which would put CRLF in the worktree and LF in the
+    # index. Nothing here would fail on that today, and pinning it costs one line versus a Windows-
+    # only surprise later -- this suite's harness has already had exactly one of those (the
+    # line-number extractor that vanished on `C:\...` paths, green on Linux, red only on MinGW).
+    git(repo, "config", "core.autocrlf", "false")
+    write(repo, base)
+    git(repo, "add", "-A")
+    git(repo, "commit", "-q", "-m", "base")
+    git(repo, "branch", "lane")
+    write(repo, ours)
+    git(repo, "commit", "-qam", "master moves")
+    git(repo, "checkout", "-q", "lane")
+    write(repo, theirs)
+    git(repo, "commit", "-qam", "lane appends")
+    return repo
+
+
+def case(name: str, base: str, ours: str, theirs: str, *, want_rc: int,
+         expect_text: str | None = None) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        repo = scenario(base, ours, theirs, d)
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--no-fetch", "--base", "master", "--head", "lane"],
+            cwd=repo, capture_output=True, text=True,
+        )
+    out = proc.stdout + proc.stderr
+    if proc.returncode != want_rc:
+        FAILURES.append(f"{name}: expected rc={want_rc}, got {proc.returncode}. out={out[:400]!r}")
+        return
+    if expect_text and expect_text not in out:
+        FAILURES.append(f"{name}: expected {expect_text!r} in output, got {out[:400]!r}")
+        return
+    print(f"  ok  {name}")
+
+
+BASE = table("1:a", "2:b", "3:c")
+
+print("what the merge result says:")
+
+# Ordinary: master gained nothing this branch collides with.
+case("a clean merge with a valid result passes",
+     BASE, BASE, table("1:a", "2:b", "3:c", "4:lane's row"),
+     want_rc=0, expect_text="the merge RESULT passes the gate")
+
+# THE case. Master took 4; the lane took 4 too and placed it a few lines away, so the merge is
+# textually CLEAN and the duplicate exists only in the result. Neither head-time check could have
+# seen it. This is what #2581 was, and what a green Docs job did not warn about.
+case("a clean merge whose RESULT holds a duplicate is caught",
+     BASE,
+     table("1:a", "2:b", "3:c", "4:master's row"),
+     table("1:a", "4:the lane's row", "2:b", "3:c"),
+     want_rc=1, expect_text="duplicate row number 4")
+
+# ...and the message must say what to do, since the whole point is that the author is otherwise
+# looking at a green check.
+case("the duplicate message names the repair",
+     BASE,
+     table("1:a", "2:b", "3:c", "4:master's row"),
+     table("1:a", "4:the lane's row", "2:b", "3:c"),
+     want_rc=1, expect_text="renumbering YOUR")
+
+# A textual conflict is a different outcome from an invalid clean merge, and must not be reported as
+# a table defect -- the file in the merge result is not a table at that point, it is conflict
+# markers, and telling the author their numbering is broken would send them to the wrong place.
+case("a textual conflict is reported as a conflict",
+     BASE,
+     table("1:a", "2:b", "3:c", "4:master's row"),
+     table("1:a", "2:b", "3:c", "4:the lane's row"),
+     want_rc=1, expect_text="MERGE CONFLICT")
+
+# The --baseline wiring is what catches a row that VANISHES in the merge. Without this case, the
+# tool could be passing no baseline at all and every case above would still pass.
+case("a row deleted by the merge is caught",
+     table("1:a", "2:b", "3:c", "4:d"),
+     table("1:a", "2:b", "3:c", "4:d"),
+     table("1:a", "2:b", "3:c"),
+     want_rc=1, expect_text="GONE from this table: 4")
+
+# The checker-failure branch, reachable through the ENVIRONMENT rather than the arguments. My first
+# claim was that no arm was possible without a test-only injection point in production code; the
+# #2616 review rejected that and was right. Copy the tool ALONE into a tempdir and its sibling
+# `check_numbered_table.py` is absent, so the subprocess exits non-zero without ever reporting a
+# table problem -- which is exactly the state the branch classifies. Six lines, no injection point.
+#
+# Worth keeping as a lesson as well as a test: "this path is untestable" is a claim like any other,
+# and it was wrong because I had only considered the argument surface.
+def cli_missing_checker(name: str) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        repo = scenario(BASE, BASE, table("1:a", "2:b", "3:c", "4:lane"), d)
+        lone = Path(d) / "lone"
+        lone.mkdir()
+        (lone / TOOL.name).write_text(TOOL.read_text(encoding="utf-8"), encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(lone / TOOL.name), "--no-fetch", "--base", "master",
+             "--head", "lane"],
+            cwd=repo, capture_output=True, text=True,
+        )
+    out = proc.stdout + proc.stderr
+    if proc.returncode == 0:
+        FAILURES.append(f"{name}: expected a non-zero exit, got 0: {out[:250]!r}")
+    elif "RESULT is invalid" in out:
+        FAILURES.append(f"{name}: a tooling failure was reported as a table finding: {out[:250]!r}")
+    elif "checker itself failed" not in out:
+        FAILURES.append(f"{name}: expected the checker-failure message, got {out[:250]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+cli_missing_checker("a missing checker is reported as a tooling failure, not a table defect")
+
+
+# Nothing to check is not a pass-by-accident: it is stated, so a caller cannot mistake "already
+# merged" for "validated".
+case("a head already in the base says so",
+     BASE, table("1:a", "2:b", "3:c", "4:d"), BASE,
+     want_rc=0, expect_text="already contained in the base")
+
+print()
+if FAILURES:
+    for f in FAILURES:
+        print(f"FAIL: {f}", file=sys.stderr)
+    print(f"\n{len(FAILURES)} case(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("all cases passed")


### PR DESCRIPTION
**Stacked on #2610** (base is `fix/issue-2089-trap-numbering`, not `master`). It calls `check_numbered_table.py --ordered --baseline`, which #2610 introduces. Rebase this onto master once that lands.

## The problem, after the falsifications

#2211's body says the `Docs` gate validates the PR head and that nothing ever checks the merged table. **Both are false and were falsified on the issue with run logs** — the `docs` job checks out `refs/pull/N/merge` (no `ref:`) and runs on every push to master. I re-read the workflow before writing this and agree; nothing there needs changing.

What is real is the title: the merge commit is computed **when the event fires** and is never recomputed as the base moves. So a green required check is a statement about a merge that may no longer exist.

**And the direction that matters is the green one.** A red check gets investigated, so its staleness surfaces within minutes — that is instrument trap 187, for `gh run rerun`. A green check is *acted on*: it is the thing that authorises the merge, and an author who has just been told they may proceed has no reason to ask what tree the answer was about. #2581 merged on exactly that — its `Docs` job was green against a base predating #2574, so nothing warned either author that both had written instrument-trap row **182**. The collision was found by simulating the merge by hand, never by CI. (Recorded as instrument trap 188 in #2610.)

The remedies for the staleness itself are repository settings only the owner can apply — branch protection's *"Require branches to be up to date before merging"*, or a merge queue. **This PR does not close that**, and #2211 stays open. What it adds is the part a checkout *can* do: the manual procedure that actually caught the 182 collision, as one command.

## What it does

`prosper/tools/docs/check_merge_result.py` fetches, merges `HEAD` into `origin/master`, and runs the numbered-table gate on the result with `origin/master`'s copy as `--baseline`.

- **`git merge-tree --write-tree`**, so the merge happens entirely in the object database: no checkout, no index, no `MERGE_HEAD` to clean up, nothing that can collide with another agent in this shared repository.
- **A textual conflict is reported as a conflict**, not as a table defect. In the merge result the file at that point is conflict markers, and telling the author their *numbering* is broken sends them to the wrong place. The conflict message points at instrument trap 41 instead, because the tempting resolution (`git checkout <branch> -- <file>`) silently reverts every other lane's edit.
- Live on this branch:

```
$ python3 prosper/tools/docs/check_merge_result.py
merging HEAD (8f124852) into origin/master (7413647a)
prosper/docs/GAME_COMPAT_ORCHESTRATION.md (merged): numbered column 1..188, 188 rows,
  unique and ascending, no unused numbers; no row present in origin/master:... has been deleted

clean merge, and the merge RESULT passes the gate against origin/master as of now.
Merge promptly: another lane landing after this point invalidates it.
```

## The measured boundary — how much this is actually worth

I tried to establish *when* a duplicate-numbered merge is textually clean, rather than assuming it. Two same-numbered rows inserted at a row boundary in an otherwise identical file, insertion points `k` lines apart:

| separation | git merge | offending branch's own head | merge result |
|---|---|---|---|
| 0 lines (both append at the tail) | **CONFLICT** | green | red |
| 1 line | clean | **RED already** | red |
| 2–5 lines | clean | **RED already** | red |

So within that family, `--ordered` alone closes the hole: either git conflicts and a human is involved, or the offending branch is already failing its own check. Uniqueness plus ascent turn out to do more work than they look like, because a duplicate number forces both insertions to the same sorted position, which is where git conflicts.

**That table is not the whole story, and the reason is the charter's own rule about positive controls: it tests the discriminator, not the domain.** Every row of it came from one generator — insert-at-a-row-boundary — so it can only speak about cases that generator can express. Constructing an instance **by hand, outside it**:

```
lane A's head alone:  rc=0   (…| 8 | r8 |, | 9 | A's row |)
lane B's head alone:  rc=0   (…| 8 | r8 |, | 9 | B's row |)
the human's conflict resolution -- keep both rows -- which is what LANDS:
  error: resolved.md:6: duplicate row number 9 (first used at line 5). …
  rc=1
```

That is the realistic outcome of meeting the separation-0 conflict above, and it is how `33, 34, 35, 32` reached master in #1696. **Both heads were green and no head-time check could ever have seen it**, because the resolution did not exist on either branch. That is the case this tool covers and nothing else does.

## What it cannot tell you

- It answers about the base as of the moment it runs. Another lane can merge a second later — it shrinks the window exactly as `trap_number.py` does and closes it no more than that. Run it **last**, then merge.
- It checks only the numbered-table classes. A semantically wrong row, a reverted paragraph, or a stale by-number reference in prose all merge clean and pass here — the same boundary `check_numbered_table.py`'s own *WHAT THIS CANNOT SEE* section draws.
- It says nothing about any file other than the one named (`--file`, defaulting to the orchestration doc).

## Verification (exact head of this branch)

```
python3 prosper/tools/docs/test_check_merge_result.py                        rc=0, 6 cases
ctest --test-dir <build> -R '^(doc_table_checker|trap_number|doc_merge_result_checker)$' \
      --no-tests=error                                                       rc=0, 3/3 passed
python3 prosper/tools/docs/check_merge_result.py                             rc=0 (output above)
git diff --check <base>..HEAD                                                rc=0
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'         0
```

Every test case builds a real throwaway git repository and runs a real merge. The git plumbing *is* the tool, so a mocked `merge-tree` would test nothing. No C++ touched; no build beyond the CMake configure needed to register and run the tests.

## Review

Worth a read for one thing in particular: whether the measured-boundary table above is being over-read. I claim `--ordered` closes the machine-generated family and that only the human-resolution case survives — a reviewer should try to construct a third shape that escapes both, since if one exists my "what this is worth" framing is too generous rather than too harsh.

Refs #2211, #2089, #1729
