### PR TITLE
fix(libkernel): scePthreadJoin/scePthreadDetach must report their result (#2575)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2383,13 +2383,7 @@ HLE(k_pthread_detach) { return fbsd_errno(pthread_detach((pthread_t)a0)); }
 // FreeBSD numbering. EDEADLK is the case that proves the mapping runs — 11 on FreeBSD, 35 on Linux —
 // and 35 is FreeBSD's EAGAIN, i.e. a retry hint. A guest told "retry" instead of "you just tried to
 // join yourself" loops on a condition that will never change (#1612).
-//
-// ONE CASE IS NOT CHECKED AND IS NOT CLAIMED: what a join reports when ANOTHER thread is already
-// joining the target. `fbsd_errno` forwards whatever the host decides, which is EINVAL on glibc; a
-// reviewer raised that FreeBSD's libthr may answer ENOTSUP(45) there instead, and neither of us has
-// read that source. If it does, the mapping needs a case of its own, because no host produces 45 for
-// this. Recorded as an open question rather than as a mapping — do not restate either answer as
-// settled without opening libthr's join_common.
+
 SCE_PTHREAD_ALIAS(k_sce_pthread_join,   k_pthread_join)
 SCE_PTHREAD_ALIAS(k_sce_pthread_detach, k_pthread_detach)
 HLE(k_pthread_exit)   {

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2360,9 +2360,14 @@ HLE(k_pthread_detach) { return fbsd_errno(pthread_detach((pthread_t)a0)); }
 // TWO SEPARATE READINGS COME OUT OF THAT, and they land at different strengths:
 //
 //   * The guest DOES consume these results — unlike `_Cnd_wait`, which discards
-//     scePthreadCondWait's (#1983). `std::thread::join()` on a failed join therefore reported
-//     _Thrd_success under the old always-0 body, and then copied a stack slot prosper had just
-//     zeroed into the caller's `res`. CONFIDENCE: HIGH that the result must be reported at all.
+//     scePthreadCondWait's (#1983). Under the old always-0 body a FAILED join was reported to the
+//     C11 layer as `_Thrd_success`, so `std::thread::join()` returned normally from a join that
+//     never happened. TWO DIFFERENT CALLERS, and an earlier wording here ran them together: a
+//     caller that passes a `res` pointer (C11 `thrd_join(thr, &res)`) additionally read the slot
+//     prosper had just zeroed, whereas `std::thread::join()` passes `res == nullptr`, so
+//     `4d92: test rbx,rbx` / `4d95: je` skips the copy for it. Both are wrong; only the first
+//     involves the value. Caught in review of #2575.
+//     CONFIDENCE: HIGH that the result must be reported at all.
 //     The listing also shows the value_ptr rule above is safe for this consumer: it reads its own
 //     slot ONLY after the `test` says success, so leaving it untouched on a refusal is never read.
 //   * It does NOT settle the ENCODING. `test eax,eax` is nonzero in both spaces, exactly like the
@@ -2378,6 +2383,13 @@ HLE(k_pthread_detach) { return fbsd_errno(pthread_detach((pthread_t)a0)); }
 // FreeBSD numbering. EDEADLK is the case that proves the mapping runs — 11 on FreeBSD, 35 on Linux —
 // and 35 is FreeBSD's EAGAIN, i.e. a retry hint. A guest told "retry" instead of "you just tried to
 // join yourself" loops on a condition that will never change (#1612).
+//
+// ONE CASE IS NOT CHECKED AND IS NOT CLAIMED: what a join reports when ANOTHER thread is already
+// joining the target. `fbsd_errno` forwards whatever the host decides, which is EINVAL on glibc; a
+// reviewer raised that FreeBSD's libthr may answer ENOTSUP(45) there instead, and neither of us has
+// read that source. If it does, the mapping needs a case of its own, because no host produces 45 for
+// this. Recorded as an open question rather than as a mapping — do not restate either answer as
+// settled without opening libthr's join_common.
 SCE_PTHREAD_ALIAS(k_sce_pthread_join,   k_pthread_join)
 SCE_PTHREAD_ALIAS(k_sce_pthread_detach, k_pthread_detach)
 HLE(k_pthread_exit)   {

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -2307,8 +2307,79 @@ int guest_thread_spawn(uint64_t entry, uint64_t arg, const char* name,
 // a wild/unmapped address -> intermittent SIGSEGV (IL2CPP bdwgc's GC_pthread_create calls the 4-arg form).
 // Force name=null for the 4-arg entry point.
 HLE(k_pthread_create_noname) { return k_pthread_create(a0, a1, a2, a3, 0, 0); }
-HLE(k_pthread_join)   { void* rv = nullptr; pthread_join((pthread_t)a0, a1 ? &rv : nullptr); if (a1) *(void**)(uintptr_t)a1 = rv; return 0; }
-HLE(k_pthread_detach) { pthread_detach((pthread_t)a0); return 0; }
+// #2575: both of these DISCARDED the host result and returned 0 unconditionally — the SILENT
+// SUCCESS class #1983 fixed in `k_cond_wait`, and the sharper half of it. `pthread_join` reports
+// ESRCH (no such thread), EINVAL (the target is detached, or another thread is already joining it)
+// and EDEADLK (joining yourself); `pthread_detach` reports ESRCH and EINVAL. Every one of them
+// reached the guest as `0` = "the thread was joined, and here is its result".
+//
+// THE `value_ptr` WRITE IS THE SECOND HALF, and it is what makes this worse than an ignored return
+// code. The old body wrote `rv` through the guest's pointer whether or not the join happened, and
+// on every failure path `rv` is still the `nullptr` it was initialised to. So a guest joining a
+// worker to read its exit value could not distinguish "the worker returned NULL" from "there was no
+// such thread": both arrived as rc 0 with a NULL result. A SELF-join (EDEADLK) was reported as a
+// successful join returning NULL, and the caller proceeded as if its worker had finished.
+// FreeBSD's pthread_join writes through `value_ptr` only when it really joined, and so does this now.
+HLE(k_pthread_join)   {
+    void* rv = nullptr;
+    const int rc = pthread_join((pthread_t)a0, &rv);
+    if (rc == 0 && a1) *(void**)(uintptr_t)a1 = rv;   // only a real join produces an exit value
+    return fbsd_errno(rc);   // bare here (#1612); scePthreadJoin encodes through the alias below
+}
+HLE(k_pthread_detach) { return fbsd_errno(pthread_detach((pthread_t)a0)); }
+// Both bodies are registered under BOTH spellings, which is why the fix cannot live in the body
+// alone: `pthread_join` / `pthread_detach` must report the bare FreeBSD errno and `scePthreadJoin`
+// (onNY9Byn-W8) / `scePthreadDetach` (4qGrR6eoP9Y) the libkernel-encoded `0x8002_0000 | errno`, so
+// the two consumers of one body want opposite answers. Same split as #1983 needed for
+// scePthreadCondWait. (NIDs read out of the 3.20 firmware dump, libkernel.c:8764 and :8753 — the
+// issue's first revision had them swapped and corrected itself, so they are quoted from the dump
+// rather than carried over.)
+//
+// EVIDENCE, from the shipped guest libc.prx of PPSA24651, re-derived for #2575 rather than assumed.
+// Its C11 `_Thrd_join` (export YvmY5Jf0VYU @0x4d60) and `_Thrd_detach` (L7f7zYwBvZA @0x4dc0) are the
+// known consumers. Each PLT thunk was resolved to its import through the JMPREL slot, so the pairing
+// is read out of the relocation rather than inferred from adjacency:
+//
+//   _Thrd_join   -> 0x1155a0 -> GOT 0x192328 -> onNY9Byn-W8 (scePthreadJoin)
+//     4d80: call   0x1155a0
+//     4d85: mov    ecx,eax
+//     4d87: mov    eax,0x4          ; _Thrd_error
+//     4d8c: test   ecx,ecx          ; <-- a TEST, not a compare against a named constant
+//     4d8e: jne    0x4d9c           ; nonzero -> return _Thrd_error, and the res slot is NOT read
+//     4d90: xor    eax,eax          ; _Thrd_success
+//     4d92: test   rbx,rbx          ; caller passed a res pointer?
+//     4d97: mov    ecx,[rbp-0x20]   ; the slot it handed scePthreadJoin as value_ptr
+//     4d9a: mov    [rbx],ecx
+//
+//   _Thrd_detach -> 0x1155b0 -> GOT 0x192330 -> 4qGrR6eoP9Y (scePthreadDetach)
+//     4dc4: call   0x1155b0
+//     4dc9: xor    ecx,ecx
+//     4dcb: test   eax,eax
+//     4dcd: setne  cl                ; nonzero -> 4 (_Thrd_error), zero -> 0 (_Thrd_success)
+//
+// TWO SEPARATE READINGS COME OUT OF THAT, and they land at different strengths:
+//
+//   * The guest DOES consume these results — unlike `_Cnd_wait`, which discards
+//     scePthreadCondWait's (#1983). `std::thread::join()` on a failed join therefore reported
+//     _Thrd_success under the old always-0 body, and then copied a stack slot prosper had just
+//     zeroed into the caller's `res`. CONFIDENCE: HIGH that the result must be reported at all.
+//     The listing also shows the value_ptr rule above is safe for this consumer: it reads its own
+//     slot ONLY after the `test` says success, so leaving it untouched on a refusal is never read.
+//   * It does NOT settle the ENCODING. `test eax,eax` is nonzero in both spaces, exactly like the
+//     `scePthreadGetname` caller quoted above `k_pthread_getname` — so this rules nothing out in
+//     either direction, and pointing at it as support for the encoded form would repeat the reading
+//     that was already falsified once here (the `%08x` argument, recorded in the Rename block).
+//     CONFIDENCE: MED on the encoded form, at the same strength and for the same reason as
+//     scePthreadRename (#2382) and the TLS-key pair (#1983): the libkernel-wide convention (#2178)
+//     applied to a fallible entry point. Do not raise it without a caller that COMPARES against a
+//     named constant, the way `_Mtx_lock` compares 0x8002000b.
+//
+// The BARE half is settled independently of the encoding: the failure must reach the guest in
+// FreeBSD numbering. EDEADLK is the case that proves the mapping runs — 11 on FreeBSD, 35 on Linux —
+// and 35 is FreeBSD's EAGAIN, i.e. a retry hint. A guest told "retry" instead of "you just tried to
+// join yourself" loops on a condition that will never change (#1612).
+SCE_PTHREAD_ALIAS(k_sce_pthread_join,   k_pthread_join)
+SCE_PTHREAD_ALIAS(k_sce_pthread_detach, k_pthread_detach)
 HLE(k_pthread_exit)   {
     // Host pthread_exit unwinds without ever returning through thread_trampoline, so this is its own
     // thread-exit path: purge the exiting thread's __tls_get_addr DTV first (#68) and drop its stack
@@ -4621,8 +4692,8 @@ void register_kernel_hle() {
     R("scePthreadYield", k_pthread_yield);
     R("__stack_chk_fail", k_stack_chk_fail);   // diagnostic: log the guest canary on a canary-check failure
     R("scePthreadCreate", k_sce_pthread_create);
-    R("scePthreadJoin", k_pthread_join);
-    R("scePthreadDetach", k_pthread_detach);
+    R("scePthreadJoin", k_sce_pthread_join);       // reports its join since #2575 (was always 0)
+    R("scePthreadDetach", k_sce_pthread_detach);   // reports its detach since #2575 (was always 0)
     R("scePthreadExit", k_pthread_exit);
     R("scePthreadAttrInit", k_sce_attr_init);
     R("scePthreadAttrDestroy", k_attr_destroy);

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -27,6 +27,30 @@
 //   M6  make the CondWait body REFUSE unconditionally                    -> §7's signalled-wait
 //                                                                           control fails (#1983)
 //
+//   M7  drop SCE_PTHREAD_ALIAS(k_sce_pthread_join, …)                    -> §9's Sony self-join arm
+//   M8  alias `pthread_join` as well                                     -> §9's POSIX self-join arm
+//   M9  make k_pthread_join report 0 again (discard its result)          -> §9's self-join arms, both
+//   M10 write value_ptr on `if (a1)` rather than `if (rc == 0 && a1)`    -> §9's untouched arm ONLY
+//   M11 return the raw HOST errno from k_pthread_join instead of mapping -> §9's POSIX self-join arm
+//   M12 drop the value_ptr write entirely                                -> §9's exit-value control ONLY
+//   M13 drop SCE_PTHREAD_ALIAS(k_sce_pthread_detach, …)                  -> §9's Sony detach arm
+//   M14 make k_pthread_detach report 0 again                             -> §9's detach arms
+//
+// M7-M14 are the #2575 set and they are NOT interchangeable, for the same reason M5 and M6 are not.
+// M10 and M12 are invisible to every return-value arm in the file — a body that reports EDEADLK
+// correctly and still nulls (or never writes) the guest's `value_ptr` satisfies all of them — and
+// conversely the value_ptr arms cannot see M7/M8/M11/M13, which are all about the number. M11 is the
+// only one that can tell a FreeBSD errno from a host one, because EDEADLK is the ONLY errno reachable
+// in §9 where the two numberings disagree (11 on FreeBSD, 35 on Linux, and 35 is FreeBSD's EAGAIN).
+//
+// M9 AND M14 ARE THE ARMS THAT REVERT THE DEFECT ITSELF, and the first draft of §9 could not see
+// either. Its skip guards asked the HANDLER whether the host refuses a self-join / a second detach;
+// under M9 and M14 the handler answers 0, the guard read that as "this host permits it" and skipped,
+// and the section passed under the exact bug it exists to catch. Both guards now come from a direct
+// host call on a thread the handler never touches. Recorded because the failure was silent and
+// green: the same "a positive control drawn from the same source as the null tests the
+// DISCRIMINATOR, never the DOMAIN" shape the charter records, inside a mutation harness.
+//
 // M5 and M6 are COMPLEMENTARY, and an earlier revision of this header got it wrong in the way that
 // matters most here: it claimed M5 kills §7's positive control too. It cannot. M5 makes the body
 // return 0 and §7 asserts 0, so §7 passes under M5 — the measured `FAIL (2)` is the kRows row's two
@@ -45,10 +69,13 @@
 #include "../src/hle/dispatch.hpp"
 #include "../src/hle/nid.hpp"
 #include "../src/hle/sce_errno.hpp"
+#include <atomic>
 #include <cerrno>
+#include <chrono>
 #include <cstdio>
 #include <cstdint>
 #include <cstring>
+#include <pthread.h>
 #include <thread>
 
 using namespace prosper;
@@ -148,7 +175,43 @@ const Row kRows[] = {
     // --- barriers (no POSIX spelling registered on either body) ---
     {"scePthreadBarrierInit",        nullptr,                       "#2178, in place"},
     {"scePthreadBarrierWait",        nullptr,                       "#2178, in place"},
+    // scePthreadJoin / scePthreadDetach became fallible in #2575 and so now need the alias, but they
+    // deliberately have NO row here and that is not an oversight: kRows provokes its refusal with an
+    // all-zero call, and `pthread_join(0, …)` is not a defined refusal. A `pthread_t` is an opaque
+    // descriptor POINTER on both hosts prosper builds for, so a null one is dereferenced before any
+    // validity check — the sweep would segfault rather than report EINVAL. Their arms are §9, where
+    // the failure comes from a real thread.
 };
+
+// --- §9 thread bodies. Plain HOST pthreads on purpose: these arms are about what k_pthread_join and
+// k_pthread_detach do with the host result, so nothing about prosper's own create trampoline is
+// under test and routing through it would only add failure modes the arms cannot attribute.
+void* join_worker(void* arg) { return arg; }        // hands its own argument back as the exit value
+
+// The park gate and its counters are FILE-SCOPE STATICS, not locals of main, and that is a
+// correctness requirement rather than a style choice. §9's workers are detached, so nothing joins
+// them; a gate living in main's frame would be touched by a worker still inside pthread_mutex_lock
+// after that frame had gone away. It reproduced: the first mutation run aborted with SIGABRT in one
+// arm out of eight, which is exactly how this presents — intermittently, in whichever arm happens to
+// lose the race, and attributable to anything. §9 also waits for every worker to finish below, so
+// the statics are belt and braces.
+pthread_mutex_t g_park_gate = PTHREAD_MUTEX_INITIALIZER;
+std::atomic<int> g_park_running{0};
+std::atomic<int> g_park_done{0};
+void* park_worker(void*) {
+    g_park_running.fetch_add(1, std::memory_order_release);
+    pthread_mutex_lock(&g_park_gate);      // main holds this for the whole of §9's detach block
+    pthread_mutex_unlock(&g_park_gate);
+    g_park_done.fetch_add(1, std::memory_order_release);
+    return nullptr;
+}
+// Bounded spin so a lost wake fails the run instead of burning ctest's timeout, which reports as an
+// infrastructure problem and gets blamed on machine load (the hazard #1983's review caught in §7).
+bool wait_for(const std::atomic<int>& counter, int target) {
+    for (int i = 0; i < 20000 && counter.load(std::memory_order_acquire) < target; ++i)
+        std::this_thread::sleep_for(std::chrono::microseconds(100));
+    return counter.load(std::memory_order_acquire) >= target;
+}
 
 // Entry points whose body returns 0 on every path. They correctly have NO alias, and #2158
 // established that its absence is the right answer rather than an oversight.
@@ -470,6 +533,133 @@ int main() {
         snprintf(msg, sizeof msg, "%-32s -> 0 (no failure path, so no alias)  got 0x%llx",
                  name, (unsigned long long)got);
         CHECK(got == 0, msg);
+    }
+
+    // ===== 9. #2575: join and detach must report their result, and only a real join writes back ===
+    // Both bodies DISCARDED the host result and returned 0 on every path, so ESRCH, EINVAL and
+    // EDEADLK all reached the guest as "the thread was joined, and here is its result" — with
+    // `*value_ptr` overwritten by the `nullptr` the discarded call left behind. That second half is
+    // what makes this worse than an ignored return code: "the worker returned NULL" and "there was
+    // no such thread" became the same observation, and a SELF-join read as a worker that finished.
+    //
+    // The self-join arm carries the #1612 half as well, and it is the only join failure in this file
+    // that can: EDEADLK is 11 on FreeBSD and 35 on Linux, and 35 is FreeBSD's EAGAIN — so a
+    // passed-through host number would tell the guest "would block, retry" where the truth is "you
+    // just tried to join yourself", which is a loop that never ends. Every other errno these two
+    // produce is EINVAL(22), which every platform agrees on and proves nothing about the mapping.
+    //
+    // EVERY SKIP BELOW IS DECIDED BY A DIRECT HOST CALL, NEVER BY THE HANDLER UNDER TEST, and that
+    // is the whole design of this section rather than a detail. The first draft asked the handler
+    // itself whether the host refuses a self-join — and the mutation that reverts the fix (make the
+    // body report 0 again) then produced `0`, which the draft read as "this host permits a
+    // self-join" and SKIPPED. The arm passed under the exact defect it exists to catch, in both the
+    // join and the detach block. A guard drawn from the same source as the null it is validating
+    // tests nothing; the host probes here are the "construct a positive instance BY HAND, outside
+    // whatever produced the null" rule applied literally.
+    printf("-- join/detach report their result; only a real join writes value_ptr (#2575) --\n");
+    {
+        HleFn sce_join     = Hle::lookup(nid_hash("scePthreadJoin"));     // onNY9Byn-W8
+        HleFn posix_join   = Hle::lookup(nid_hash("pthread_join"));
+        HleFn sce_detach   = Hle::lookup(nid_hash("scePthreadDetach"));   // 4qGrR6eoP9Y
+        HleFn posix_detach = Hle::lookup(nid_hash("pthread_detach"));
+        CHECK(sce_join && posix_join && sce_detach && posix_detach,
+              "scePthreadJoin/Detach and pthread_join/detach are registered under both spellings");
+        if (sce_join && posix_join && sce_detach && posix_detach) {
+            // --- POSITIVE CONTROL. Without it, a body broken into "refuse everything" satisfies
+            // every failure arm below, and a body that never joins at all satisfies the rc == 0 half.
+            // The exit-value readback separates them: 0x5eed can only reach `out` through a join
+            // that really completed and really read the worker's return.
+            pthread_t worker{};
+            const int created = pthread_create(&worker, nullptr, join_worker, (void*)0x5eed);
+            CHECK(created == 0, "control: a worker thread starts");
+            if (created == 0) {
+                void* out = (void*)0xC0FFEE;   // a sentinel a real join MUST overwrite
+                const uint64_t rc = sce_join((uint64_t)worker, (uint64_t)(uintptr_t)&out, 0, 0, 0, 0);
+                CHECK(rc == 0, "control: scePthreadJoin of a real worker reports 0");
+                CHECK(out == (void*)0x5eed,
+                      "control: the worker's own exit value (0x5eed) reaches value_ptr — an arm that "
+                      "only checked rc == 0 would pass under the old always-0 body too");
+            }
+
+            // --- the join failure arm: a self-join, through both spellings.
+            // POSIX specifies EDEADLK here ("a deadlock was detected, or the value of thread
+            // specifies the calling thread"), so the host probe is a precondition rather than a
+            // capability test — but it is still taken from the host, for the reason in the header.
+            char msg[224];
+            const int host_self_join = pthread_join(pthread_self(), nullptr);
+            if (host_self_join == 0) {
+                printf("  [SKIP] this host's own pthread_join permits a thread to join itself — the "
+                       "#2575 EDEADLK arms cannot run here\n");
+            } else {
+                snprintf(msg, sizeof msg,
+                         "precondition: this HOST refuses a self-join with EDEADLK (host EDEADLK is "
+                         "%d here; got %d) — established by a direct host call, so no handler can "
+                         "manufacture the skip", EDEADLK, host_self_join);
+                CHECK(host_self_join == EDEADLK, msg);
+
+                void* untouched = (void*)0xC0FFEE;
+                const uint64_t sony_rc =
+                    sce_join((uint64_t)pthread_self(), (uint64_t)(uintptr_t)&untouched, 0, 0, 0, 0);
+                const uint64_t posix_rc = posix_join((uint64_t)pthread_self(), 0, 0, 0, 0, 0);
+                snprintf(msg, sizeof msg,
+                         "pthread_join(self) reports bare FreeBSD EDEADLK (11), not this host's %d "
+                         "— %d is FreeBSD's EAGAIN and would arrive as a retry hint (got %llu)",
+                         EDEADLK, EDEADLK, (unsigned long long)posix_rc);
+                CHECK(posix_rc == 11, msg);
+                snprintf(msg, sizeof msg,
+                         "scePthreadJoin(self) reports encoded FreeBSD EDEADLK 0x8002000b (got 0x%llx)",
+                         (unsigned long long)sony_rc);
+                CHECK(sony_rc == 0x8002000bull, msg);
+                CHECK(untouched == (void*)0xC0FFEE,
+                      "a REFUSED join leaves value_ptr untouched — it used to be overwritten with "
+                      "NULL, which a guest reads as a legitimate NULL exit value");
+            }
+
+            // --- detach. Its only reachable refusal is EINVAL, so it cannot carry the mapping half;
+            // what it carries is the alias split, which is the defect it actually had.
+            //
+            // Both workers park on g_park_gate, which main holds for this whole block, so their
+            // descriptors stay valid throughout — a detached thread that had already exited would be
+            // a wild pointer, not a defined EINVAL. The PROBE thread is detached by direct host
+            // calls only, so the host's answer to a second detach is ground truth; the SUBJECT
+            // thread is the handler's.
+            pthread_mutex_lock(&g_park_gate);
+            pthread_t probe{}, subject{};
+            const int probe_created   = pthread_create(&probe, nullptr, park_worker, nullptr);
+            const int subject_created = pthread_create(&subject, nullptr, park_worker, nullptr);
+            CHECK(probe_created == 0 && subject_created == 0, "control: two parked workers start");
+            if (probe_created == 0 && subject_created == 0) {
+                CHECK(wait_for(g_park_running, 2), "control: both parked workers reached the gate");
+                CHECK(pthread_detach(probe) == 0, "control: the HOST detaches a live joinable thread");
+                const int host_double = pthread_detach(probe);
+                if (host_double == 0) {
+                    printf("  [SKIP] this host's own pthread_detach accepts a second detach of the "
+                           "same thread — the #2575 detach refusal arms cannot run here\n");
+                } else {
+                    snprintf(msg, sizeof msg,
+                             "precondition: this HOST refuses a second detach with EINVAL (got %d)",
+                             host_double);
+                    CHECK(host_double == EINVAL, msg);
+
+                    CHECK(sce_detach((uint64_t)subject, 0, 0, 0, 0, 0) == 0,
+                          "control: scePthreadDetach of a live joinable thread reports 0");
+                    CHECK(pthread_detach(subject) == EINVAL,
+                          "control: …and it REALLY detached — the host now refuses a second detach. "
+                          "A body that reported 0 without calling through passes the line above and "
+                          "fails this one");
+                    CHECK(sce_detach((uint64_t)subject, 0, 0, 0, 0, 0) == kEncodedEINVAL,
+                          "scePthreadDetach of an already-detached thread reports encoded EINVAL "
+                          "(0x80020016)");
+                    CHECK(posix_detach((uint64_t)subject, 0, 0, 0, 0, 0) == kBareEINVAL,
+                          "pthread_detach of the same thread keeps the bare FreeBSD EINVAL (22)");
+                }
+            }
+            pthread_mutex_unlock(&g_park_gate);
+            // Both workers are detached, so nothing joins them; wait for them to leave the gate
+            // before returning from main rather than racing process teardown against a live thread.
+            if (probe_created == 0 && subject_created == 0)
+                CHECK(wait_for(g_park_done, 2), "control: both parked workers finished");
+        }
     }
 
     if (fails) printf("== FAIL (%d) ==\n", fails);

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -31,12 +31,21 @@
 //   M8  alias `pthread_join` as well                                     -> §9's POSIX self-join arm
 //   M9  make k_pthread_join report 0 again (discard its result)          -> §9's self-join arms, both
 //   M10 write value_ptr on `if (a1)` rather than `if (rc == 0 && a1)`    -> §9's untouched arm ONLY
-//   M11 return the raw HOST errno from k_pthread_join instead of mapping -> §9's POSIX self-join arm
+//   M11 return the raw HOST errno from k_pthread_join instead of mapping -> §9's self-join arms, BOTH
 //   M12 drop the value_ptr write entirely                                -> §9's exit-value control ONLY
 //   M13 drop SCE_PTHREAD_ALIAS(k_sce_pthread_detach, …)                  -> §9's Sony detach arm
 //   M14 make k_pthread_detach report 0 again                             -> §9's detach arms
+//   M15 make k_pthread_detach report 0 WITHOUT calling through           -> §9's "it REALLY detached"
+//                                                                           control, plus both detach
+//                                                                           arms
 //
-// M7-M14 are the #2575 set and they are NOT interchangeable, for the same reason M5 and M6 are not.
+// M11 kills BOTH self-join arms, not just the POSIX one, and an earlier revision of this table said
+// otherwise while the PR body's measured row said `FAIL (2)`. The reason it must: an unmapped host
+// EDEADLK is 35, and `sce_pthread_rc(35)` is 0x80020023 — encoded FreeBSD EAGAIN — so the Sony arm
+// sees a wrong-but-encoded value and fails too. Caught in review; the same class this file corrects
+// five lines above for M5/M6, which is why it is stated rather than quietly fixed.
+//
+// M7-M15 are the #2575 set and they are NOT interchangeable, for the same reason M5 and M6 are not.
 // M10 and M12 are invisible to every return-value arm in the file — a body that reports EDEADLK
 // correctly and still nulls (or never writes) the guest's `value_ptr` satisfies all of them — and
 // conversely the value_ptr arms cannot see M7/M8/M11/M13, which are all about the number. M11 is the


### PR DESCRIPTION
Fixes #2575
Refs #2178

## Summary

`scePthreadJoin` and `scePthreadDetach` **discarded the host result and returned 0 on every path**.
`pthread_join` reports `ESRCH`, `EINVAL` and `EDEADLK`; `pthread_detach` reports `ESRCH` and
`EINVAL`. All of them reached the guest as **`0` = "the thread was joined, and here is its result"**.

This is the *silent success* class #2573 fixed in `k_cond_wait` — strictly worse than the bare-errno
defect #2178 tracks, because a guest that only tests `rc == 0` is misled too.

## The failure scenario, and the half that is not the return value

```cpp
HLE(k_pthread_join)   { void* rv = nullptr; pthread_join((pthread_t)a0, a1 ? &rv : nullptr);
                        if (a1) *(void**)(uintptr_t)a1 = rv; return 0; }
HLE(k_pthread_detach) { pthread_detach((pthread_t)a0); return 0; }
```

The `value_ptr` write is the sharper half. The old body wrote `rv` through the guest's pointer
**whether or not the join happened**, and on every failure path `rv` is still the `nullptr` it was
initialised to. So a guest joining a worker to read its exit value could not distinguish *"the
worker returned NULL"* from *"there was no such thread"* — both arrived as `rc 0` with a NULL
result. A **self-join (`EDEADLK`) was reported as a successful join that returned NULL**, and the
caller proceeded as if its worker had finished.

FreeBSD's `pthread_join` writes through `value_ptr` only when it really joined. So does this now.

## Behavioural contract

* A Sony spelling on a **fallible** body reports `0x8002_0000 | <FreeBSD errno>`.
* The POSIX spelling registered on that same body reports the **bare** FreeBSD errno.
* `value_ptr` is written **only on a successful join**; a refusal leaves the guest's slot untouched.
* The `fbsd_errno` mapping lands in the same commit as the alias (#2178's rule): encoding a host
  number yields `0x80020000 | wrong_errno`, which is worse than the bare value it replaces.

## Handler table

NIDs read out of the 3.20 firmware dump (`libkernel.c:8764` and `:8753`) rather than carried over —
the issue's first revision had the pair swapped and corrected itself, which is exactly the kind of
citation that survives casual checking.

| Sony spelling | NID | POSIX spelling on the same body | failure | before | after (Sony / POSIX) |
| --- | --- | --- | --- | --- | --- |
| `scePthreadJoin` | `onNY9Byn-W8` | `pthread_join` | `EDEADLK` (self-join) | **`0`**, and `*value_ptr` **nulled** | `0x8002000b` / `11`, `*value_ptr` untouched |
| `scePthreadJoin` | `onNY9Byn-W8` | `pthread_join` | `EINVAL` (the target is detached) | **`0`**, `*value_ptr` nulled | `0x80020016` / `22`, untouched |
| `scePthreadJoin` | `onNY9Byn-W8` | `pthread_join` | `ESRCH` | **`0`**, `*value_ptr` nulled | `0x80020003` / `3`, untouched |
| `scePthreadJoin` | `onNY9Byn-W8` | `pthread_join` | *success* | `0`, value written | **unchanged** — `0`, value written |
| `scePthreadDetach` | `4qGrR6eoP9Y` | `pthread_detach` | `EINVAL` (already detached) | **`0`** | `0x80020016` / `22` |
| `scePthreadDetach` | `4qGrR6eoP9Y` | `pthread_detach` | `ESRCH` | **`0`** | `0x80020003` / `3` |
| `scePthreadDetach` | `4qGrR6eoP9Y` | `pthread_detach` | *success* | `0` | **unchanged** — `0` |

`ESRCH` is listed for completeness. It is **not** asserted by a test arm and cannot be: reaching it
needs a `pthread_t` that is structurally valid but terminated, and every way to build one from a
test is undefined behaviour on both hosts prosper builds for. Recorded as derived-by-construction,
not measured.

The **multiple-joiner** case is deliberately absent from the table. `fbsd_errno` forwards whatever
the host decides, and nobody on this change has read FreeBSD's `join_common` to establish what
hardware answers there — so naming a number for it would be a claim reached by a route that does not
establish it, which is the failure this PR family spent the day correcting. Left unstated rather than
stated with a hedge.

## Evidence — re-derived from the guest, and it changes what can be claimed

Method as #2573: `tools/il2cpp/prx_to_elf.py --sections` on `PPSA24651`'s `sce_module/libc.prx`,
`self_dump --find-symbol` for the export, `objdump -d`, and a `self_dump --import-slots` walk to
resolve each PLT thunk to its imported NID. The NID hash was reproduced independently first and
checked against the firmware dump (`scePthreadJoin` → `onNY9Byn-W8`, `scePthreadDetach` →
`4qGrR6eoP9Y`) before anything was read out of the listing.

`_Cnd_wait @0x5670` reproduced #2573's reading exactly (13 bytes, `call` + `xor eax,eax`), which is
the positive control for the whole method.

**The consumers.** `_Thrd_join` (`YvmY5Jf0VYU` @`0x4d60`) and `_Thrd_detach` (`L7f7zYwBvZA`
@`0x4dc0`), each resolved through its JMPREL slot rather than by adjacency:

```
_Thrd_join   -> plt 0x1155a0 -> GOT 0x192328 -> onNY9Byn-W8   (scePthreadJoin)
  4d80: call   0x1155a0
  4d85: mov    ecx,eax
  4d87: mov    eax,0x4          ; _Thrd_error
  4d8c: test   ecx,ecx          ; <-- a TEST, not a compare against a named constant
  4d8e: jne    0x4d9c           ; nonzero -> return _Thrd_error, and the res slot is NOT read
  4d90: xor    eax,eax          ; _Thrd_success
  4d92: test   rbx,rbx
  4d97: mov    ecx,[rbp-0x20]   ; the slot it handed scePthreadJoin as value_ptr
  4d9a: mov    [rbx],ecx

_Thrd_detach -> plt 0x1155b0 -> GOT 0x192330 -> 4qGrR6eoP9Y   (scePthreadDetach)
  4dc4: call   0x1155b0
  4dc9: xor    ecx,ecx
  4dcb: test   eax,eax
  4dcd: setne  cl                ; nonzero -> 4 (_Thrd_error), zero -> 0 (_Thrd_success)
```

Two readings come out of that, at **different strengths**, and separating them is the point:

* **The guest DOES consume these results** — unlike `_Cnd_wait`, which discards
  `scePthreadCondWait`'s. So `std::thread::join()` on a failed join reported `_Thrd_success` under
  the old body and then copied a stack slot prosper had just zeroed into the caller's `res`.
  `CONFIDENCE: HIGH` that the result must be reported at all. The listing also shows the
  *write-only-on-success* rule is safe for this consumer: it reads its own slot **only after** the
  `test` says success, so leaving it untouched on a refusal is never observed.
* **It does NOT settle the encoding.** `test eax,eax` is nonzero in both spaces — the identical
  situation to the `scePthreadGetname` caller quoted above `k_pthread_getname`. Pointing at this
  listing as support for the encoded form would repeat a reading this repository already falsified
  once (the `%08x` argument, recorded in the Rename block). **`CONFIDENCE: MED` on the encoded
  form**, at the same strength and for the same reason as `scePthreadRename` (#2382) and the TLS-key
  pair (#1983): the libkernel-wide convention (#2178) applied to a fallible entry point. Do not
  raise it without a caller that *compares* against a named constant, as `_Mtx_lock` compares
  `0x8002000b`.

The **bare** half is settled independently of the encoding: the failure must reach the guest in
FreeBSD numbering. `EDEADLK` is 11 on FreeBSD and **35 on Linux**, and 35 is FreeBSD's `EAGAIN` —
a retry hint. A guest told "retry" instead of "you just tried to join yourself" loops on a condition
that will never change (#1612).

## Tests

New `§9` in `tests/test_pthread_error_encoding.cpp`, the table-driven harness #2573 extended.

**Join and Detach deliberately have no `kRows` row**, and the table says so: `kRows` provokes its
refusal with an all-zero call, and `pthread_join(0, …)` is not a defined refusal — a `pthread_t` is
an opaque descriptor *pointer* on both hosts, so a null one is dereferenced before any validity
check and the sweep would segfault rather than report EINVAL.

Arms, all measured on Linux/glibc in the `ps5ys` distrobox:

* positive control — join a real worker, `rc == 0` **and the worker's own exit value `0x5eed`
  reaches `value_ptr`**. The second half is what separates "reports 0" from "actually joined".
* self-join through both spellings — Sony `0x8002000b`, POSIX `11` **where this host's `EDEADLK` is
  35** (the test prints both numbers), and `value_ptr` still holding its `0xC0FFEE` sentinel.
* detach — a live joinable thread detaches (`0`), **the host then refuses a second detach**, which
  proves the handler called through; then the already-detached refusal through both spellings,
  `0x80020016` / `22`.

### The skip guards were laundering the two most important arms, and the mutation run caught it

The first draft asked **the handler under test** whether this host refuses a self-join / a second
detach, and skipped if the answer was `0`. Under the mutation that reverts the fix — make the body
report `0` again — the handler answered `0`, the guard read that as *"this host permits it"*, and
**§9 passed green under the exact defect it exists to catch**, in both the join and the detach
block (measured: M9 and M14 both `== PASS ==`). Every skip is now decided by a **direct host call**,
in the detach case on a separate thread the handler never touches. This is the charter's "construct
a positive instance BY HAND, outside whatever produced the null" applied literally, and it is
recorded in the test header because a green mutation arm is invisible.

The same run also aborted one arm with `SIGABRT`: the park gate was a local of `main`, and §9's
workers are detached, so a worker could still be inside `pthread_mutex_lock` after that frame had
gone. The gate and its counters are file-scope statics now, and §9 waits for both workers to finish.
Intermittent, in whichever arm loses the race, attributable to anything — worth stating rather than
quietly fixing.

### Mutation arms — each measured by reverting exactly one piece, rebuilding, re-running

| # | mutation | result |
| --- | --- | --- |
| M7 | drop `SCE_PTHREAD_ALIAS(k_sce_pthread_join, …)` | **FAIL (1)** `scePthreadJoin(self) … (got 0xb)` |
| M8 | alias `pthread_join` as well | **FAIL (1)** `pthread_join(self) … (got 2147614731)` |
| M9 | `k_pthread_join` reports 0 again (discards its result) | **FAIL (2)** both self-join halves, `got 0` / `got 0x0` |
| M10 | write `value_ptr` on `if (a1)` instead of `if (rc == 0 && a1)` | **FAIL (1)** the untouched arm, **and nothing else** |
| M11 | return the raw **host** errno instead of `fbsd_errno` | **FAIL (2)** `got 35` / `got 0x80020023` — i.e. encoded FreeBSD **EAGAIN** |
| M12 | drop the `value_ptr` write entirely | **FAIL (1)** the exit-value control, **and nothing else** |
| M13 | drop `SCE_PTHREAD_ALIAS(k_sce_pthread_detach, …)` | **FAIL (1)** the Sony detach arm |
| M14 | `k_pthread_detach` reports 0 again | **FAIL (2)** both detach halves |
| M15 | `k_pthread_detach` never calls through at all | **FAIL (3)** including "…and it REALLY detached" |
| baseline / restored | — | **PASS** |

M10/M12 and M7/M8/M11/M13 are complementary and neither set covers the other: a body that reports
`EDEADLK` correctly and still nulls (or never writes) `value_ptr` satisfies every return-value arm,
and the `value_ptr` arms are blind to every wrong number. M11 is the only arm that can tell a
FreeBSD errno from a host one, because `EDEADLK` is the only errno reachable in §9 where the two
numberings disagree.

## Cross-title evidence

`scePthreadJoin` / `scePthreadDetach` are **live on every title** — no dump ships `libkernel`, so
both bind to prosper's HLE — which is why this needed a cross-title arm and not only a unit test.
The risk being tested is narrow and specific: *a guest that previously ignored a `0` now sees a
non-zero.*

**Arm A — what do these handlers actually return during a real boot?** `tools/hle_calls` with
`--values`, launched over `boot_trace` so the window covers init, filtered to the join/detach/create
family, on `PPSA24651` and `PPSA25009`:

```
k_pthread_create          ret 0x0 x14
k_sce_pthread_create      ret 0x0 x13
k_pthread_detach          ret 0x0 x1
k_pthread_create_noname   ret 0x0 x1
```

Every observed return is `0`, and **no `k_pthread_join` call occurs at all** in the window. **The
honest limit on this arm, stated because the tool itself flags it:** the run reports
`entries=0/120 window=SHORT` (the default `--clock prosper::k_usleep` never advanced), and *both
titles produced byte-identical histograms* — which is itself the tell that the window covered only
the title-independent init prefix. So arm A establishes that no failure occurs **during init**, and
nothing beyond that. It is reported with its limit rather than as a clean result.

**Arm B — before/after checkpoint on the same two titles**, 90 s headless `boot_trace`
(`PROSPER_GUEST_ARGS=-force-gfx-direct`, no renderer), master's `hle_kernel.cpp` against this
branch, everything else identical:

| title | build | exit | log lines | faulted (`RUN ENDED`) | `[sync]` census at the 65,536-object quarantine milestone |
| --- | --- | --- | --- | --- | --- |
| `PPSA24651` | master | 137 (SIGKILL at 90 s — i.e. still running) | 136 | no | `mutex=65557 cond=6 rwlock=0 sem=0 barrier=0` |
| `PPSA24651` | this branch | 137 | 136 | no | `mutex=65530 cond=6 rwlock=0 sem=0 barrier=0` |
| `PPSA25009` | master | 137 | 41 | no | `mutex=52871 cond=12665 rwlock=0 sem=0 barrier=0` |
| `PPSA25009` | this branch | 137 | 40 | no | `mutex=52874 cond=12662 rwlock=0 sem=0 barrier=0` |

Same reached checkpoint on both titles: no run died early, no run faulted, and both builds reached
the same 65,536-object quarantine milestone with a work mix differing by **0.04%** on `PPSA24651`
(65,557 vs 65,530 mutex destroys) and **0.006%** on `PPSA25009` — ordinary run-to-run variance, not
a behaviour change. `PPSA24651`'s last progress line is byte-identical across builds
(`…/Media/sharedassets3.resource`).

**The one difference, stated rather than smoothed over:** `PPSA25009`'s master run ends on one extra
line (41 vs 40) — a trailing `[agc] WaitRegMem #0 q=D NOT satisfied at fold time` diagnostic that the
branch run had not yet emitted when the 90 s window closed. It is a timing artifact of where the
SIGKILL lands in an unbounded diagnostic stream, not a progression difference: both runs are inside
the same post-`seed-skip-verify` steady state and both reach the same quarantine milestone.

The window bounds the claim: 90 s of a headless boot, two titles. It does not cover late gameplay,
and no arm here can exclude a title that joins a thread only after an hour. What the two arms
together establish is that the change is inert across everything these titles exercise in that
window — the strongest statement the available instruments support.

## Risks

1. **A guest that ignored a `0` can now see a non-zero.** That is the intended change and the whole
   point of the issue, but it is a real behaviour change on every title. Bounded by arm A above for
   the init window and by arm B for the first 90 s of two titles; not bounded beyond that.
2. **`value_ptr` is no longer written on a refusal.** A guest that never initialises its own
   `value_ptr` and reads it after a *failed* join now reads its own uninitialised storage instead of
   the `NULL` prosper used to put there. The one known consumer does not do this — `_Thrd_join`
   reads its slot only on the success path (listing above) — and FreeBSD behaves the same way, so
   the guest cannot have been relying on prosper's extra write. `CONFIDENCE: HIGH`, from the
   disassembly rather than from the contract alone.
3. **`CONFIDENCE: MED` on the encoding**, unchanged from #2178's label and not raised by this PR.
   The `_Thrd_*` listings are the reason it *cannot* be raised, and they are quoted above so the
   next reader does not have to re-derive that.
4. No GPU, renderer, compute or shader code is touched.

## Deliberately unaffected

* Every POSIX spelling keeps its bare errno; the paired arms are what prove it.
* The success paths of both entry points are byte-for-byte the same contract as before: `0`, and for
  join the worker's exit value written through `value_ptr`.
* `scePthreadGetname` stays bare (#2595), `scePthreadCondSignal` / `Broadcast` stay unaliased.
* The five existing tests that join a real worker through `scePthreadJoin` (`test_pthread_names`,
  `test_stack_registry`, `test_tls_dtv_purge`, `test_win_pthread_key_destructor`,
  `test_win_kernel_is_stack`) all assert success, which is unchanged. One of them gets strictly
  *stronger*, and the first revision of this line quoted its predicate backwards — it is
  `worker_result == nullptr` (`test_win_pthread_key_destructor.cpp:123`), seeded from `(void*)1` at
  `:93`, not `!= nullptr`. The strengthening is not in that predicate at all: under the old body a
  FAILED join satisfied **both** halves of `join_result == 0 && worker_result == nullptr`, because
  the body returned 0 *and* wrote the `nullptr` the check looks for. Now a failed join makes
  `join_result != 0`, so the conjunction goes red. Corrected rather than quietly fixed, because a
  quoted predicate reads as a checked one.

## Build / test

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4                       # exit 0
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 260`, exit 0** (Linux, in the `ps5ys` distrobox).