### PR TITLE
tools(docs): check that every by-number trap reference resolves — the half of the numbering contract nobody checked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,21 @@ jobs:
         run: |
           git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github
 
+      # The other half of the numbering contract, and until now nobody checked it. The table's value
+      # is that other files point AT it by number -- 118 references on 110 lines in 46 files as of
+      # 2026-08-17, and 50 of those are .cpp/.hpp/.py COMMENTS, not prose. `check_numbered_table.py`
+      # validates the table and has no idea anything cites it, so a reference to a row that never
+      # existed reads as perfectly correct: a plausible number in a plausible sentence, findable only
+      # by opening the table and counting, which nobody does for a number in a code comment.
+      #
+      # It scans every tracked file, so it is deliberately narrow about what counts as a reference --
+      # `s_trap 1` in the shader tests is an RDNA2 mnemonic and is excluded by an identifier-character
+      # lookbehind, measured rather than assumed (without it the corpus reports 3 spurious hits).
+      - name: Verify every by-number trap reference resolves
+        run: |
+          git ls-files -z | xargs -0 python3 prosper/tools/docs/check_trap_citations.py --github \
+            --table prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+
       # Lives here, in the job that needs nothing built, for the same reason the checks above do:
       # it is a repository-wide text scan that finishes in a second. It gates the flag that keeps
       # the OTHER jobs' ctest steps honest -- plain ctest exits 0 on an empty suite, so a job

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,9 @@ jobs:
       # It scans every tracked file, so it is deliberately narrow about what counts as a reference --
       # `s_trap 1` in the shader tests is an RDNA2 mnemonic and is excluded by a leading boundary,
       # measured rather than assumed: without it the corpus admits 4 extra matches, 3 of which cite
-      # row 0 and would turn this gate red on correct code.
+      # row 0 and would turn this gate red on correct code. The TRAILING boundary is `(?!\w|\.\d)`
+      # rather than the obvious `(?![\w.])`, which also rejects a full stop and so silently stopped
+      # seeing every sentence-final citation -- 22 of 118, while still reporting "all resolving".
       - name: Verify every by-number trap reference resolves
         run: |
           git ls-files -z | xargs -0 python3 prosper/tools/docs/check_trap_citations.py --github \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,15 +228,17 @@ jobs:
           git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py --github
 
       # The other half of the numbering contract, and until now nobody checked it. The table's value
-      # is that other files point AT it by number -- 118 references on 110 lines in 46 files as of
-      # 2026-08-17, and 50 of those are .cpp/.hpp/.py COMMENTS, not prose. `check_numbered_table.py`
+      # is that other files point AT it by number, and roughly half of those references are
+      # .cpp/.hpp/.py COMMENTS rather than prose -- the step prints the live counts, so no figure is
+      # frozen here to go stale. `check_numbered_table.py`
       # validates the table and has no idea anything cites it, so a reference to a row that never
       # existed reads as perfectly correct: a plausible number in a plausible sentence, findable only
       # by opening the table and counting, which nobody does for a number in a code comment.
       #
       # It scans every tracked file, so it is deliberately narrow about what counts as a reference --
-      # `s_trap 1` in the shader tests is an RDNA2 mnemonic and is excluded by an identifier-character
-      # lookbehind, measured rather than assumed (without it the corpus reports 3 spurious hits).
+      # `s_trap 1` in the shader tests is an RDNA2 mnemonic and is excluded by a leading boundary,
+      # measured rather than assumed: without it the corpus admits 4 extra matches, 3 of which cite
+      # row 0 and would turn this gate red on correct code.
       - name: Verify every by-number trap reference resolves
         run: |
           git ls-files -z | xargs -0 python3 prosper/tools/docs/check_trap_citations.py --github \

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -187,6 +187,12 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME doc_table_checker
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/docs/test_check_numbered_table.py")
+  # Every `trap NNN` reference in the repository must name a row that exists. Half this suite is
+  # FALSE-POSITIVE cases (`s_trap 1`, a bare number, "trapdoor"), because this checker scans every
+  # tracked file and one that fires on ordinary prose or on an RDNA2 mnemonic gets disabled.
+  add_test(NAME trap_citation_checker
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/docs/test_check_trap_citations.py")
   # Parsing/gating logic of the Vulkan validation guard (#1704). Pure — it does not create a Vulkan
   # instance, so it runs everywhere. A parser that stops matching the layer's message framing would
   # report a clean suite forever, which is the one way this guard can fail silently.

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -442,7 +442,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   `traps 1234` and `entry 99` do not. Each exclusion is measured: removing the leading boundary
   admits 4 extra matches, **3 of which cite row 0** and would turn this repo-wide gate red on correct
   code; removing the trailing boundary makes `\|d{1,3}` bite a prefix out of `0x40` and `1234`, the
-  second resolving **silently** to an unrelated row. Run by the CI `Docs` job;
+  second resolving **silently** to an unrelated row. That boundary is `(?!\|w\|\|.\|d)` and **not** the
+  obvious `(?![\|w.])`, which rejects a full stop — so `See instrument trap 41.` stopped being a
+  citation at all, losing 22 of 118 references (5 of them in `.cpp`/`.hpp`/test comments) **with the
+  gate still green and the success line still saying "all resolving"**. Run by the CI `Docs` job;
   `ctest -R trap_citation_checker` covers it.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 - **`PROSPER_MB3_POISON`, `PROSPER_PEND_AGE`, `PROSPER_SUBMIT_STALL_US`** — the three in-emulator

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -433,13 +433,16 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   existed read as perfectly correct — a plausible number in a plausible sentence, findable only by
   opening the table and counting, which nobody does for a number in a code comment. **That is the
   more expensive half:** a duplicate row is visible the moment you look at the table, while a stale
-  by-number reference quietly sends the next agent to an unrelated entry. Measured on `origin/master`
-  2026-08-17: **118 references on 110 lines in 46 files, naming 63 distinct rows, all resolving —
-  and 50 of those references are `.cpp`/`.hpp`/`.py` comments**, so this is a contract compiled files
-  depend on. Deliberately narrow about what counts as a reference, because it scans every tracked
-  file and one that fires on ordinary prose gets disabled: `s_trap 1` in the shader tests is an RDNA2
-  mnemonic, excluded by an identifier-character lookbehind that is measured rather than assumed
-  (without it the corpus reports 3 spurious hits). Run by the CI `Docs` job;
+  by-number reference quietly sends the next agent to an unrelated entry. Roughly half the references
+  are `.cpp`/`.hpp`/`.py` comments rather than prose, so this is a contract compiled files depend on;
+  the tool prints the live counts on every run, so no figure is quoted here to go stale. Deliberately
+  narrow about what counts as a reference, because it scans every tracked file and one that fires on
+  ordinary prose gets disabled — `trap 41`, `traps 55 and 56`, `instrument-trap 43` and `trap #13`
+  count, while `s_trap 1` (an RDNA2 mnemonic), `WRITE-TRAP #1` (a pasted log line), `trap 0x40`,
+  `traps 1234` and `entry 99` do not. Each exclusion is measured: removing the leading boundary
+  admits 4 extra matches, **3 of which cite row 0** and would turn this repo-wide gate red on correct
+  code; removing the trailing boundary makes `\|d{1,3}` bite a prefix out of `0x40` and `1234`, the
+  second resolving **silently** to an unrelated row. Run by the CI `Docs` job;
   `ctest -R trap_citation_checker` covers it.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 - **`PROSPER_MB3_POISON`, `PROSPER_PEND_AGE`, `PROSPER_SUBMIT_STALL_US`** — the three in-emulator

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -427,6 +427,20 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   the file `unbroken` (#2108). What it does **not** cover, stated so silence is not read as
   coverage: HTML tables, delimiter-less pipe blocks (no header to measure against), whether an
   escaped pipe was what the author meant, and fenced regions, which are skipped deliberately.
+- **`docs/check_trap_citations.py`** — the other half of the numbering contract: every `trap NNN`
+  reference in the repository must name a row that exists. `check_numbered_table.py` validates the
+  TABLE and has no idea anything cites it, so until this existed a reference to a row that never
+  existed read as perfectly correct — a plausible number in a plausible sentence, findable only by
+  opening the table and counting, which nobody does for a number in a code comment. **That is the
+  more expensive half:** a duplicate row is visible the moment you look at the table, while a stale
+  by-number reference quietly sends the next agent to an unrelated entry. Measured on `origin/master`
+  2026-08-17: **118 references on 110 lines in 46 files, naming 63 distinct rows, all resolving —
+  and 50 of those references are `.cpp`/`.hpp`/`.py` comments**, so this is a contract compiled files
+  depend on. Deliberately narrow about what counts as a reference, because it scans every tracked
+  file and one that fires on ordinary prose gets disabled: `s_trap 1` in the shader tests is an RDNA2
+  mnemonic, excluded by an identifier-character lookbehind that is measured rather than assumed
+  (without it the corpus reports 3 spurious hits). Run by the CI `Docs` job;
+  `ctest -R trap_citation_checker` covers it.
 - **`niddiag/`, `fetch_niddb.sh`** — NID (Sony symbol hash) resolution helpers.
 - **`PROSPER_MB3_POISON`, `PROSPER_PEND_AGE`, `PROSPER_SUBMIT_STALL_US`** — the three in-emulator
   diagnostics for the MallocBinned3 free-list corruption family (#1945/#1226). `MB3_POISON` walks the

--- a/prosper/tools/docs/check_trap_citations.py
+++ b/prosper/tools/docs/check_trap_citations.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Every `trap NNN` reference in the repository must name a row that exists.
+
+WHY. The instrument-trap table's whole value is that other documents, source comments and tests
+point AT it by number -- `// instrument trap 104 records that a read-only probe's DURATION can
+decide...` in `src/gpu/command_processor.cpp`, `See instrument-trap 41` in `CLAUDE.md`,
+`Recorded as instrument trap 114` in a status doc. Measured on `origin/master` 2026-08-17: **95
+lines across 50 files, naming 91 distinct rows** -- and roughly half are `.cpp`/`.hpp`/test comments
+rather than prose, so this is a contract compiled files depend on, not a documentation nicety.
+
+Nothing checked that those references resolve. `check_numbered_table.py` validates the TABLE --
+structure, arity, uniqueness, ascent, and (with `--baseline`) that no row was deleted. It has no
+idea anything cites it. So a reference to a row that never existed, or to one whose number was
+mistyped, reads as perfectly correct: it is a plausible number in a plausible sentence, and the only
+way to find out is to open the table and count. Nobody does that for a number in a code comment.
+
+That is the failure this catches, and it is the more expensive half of the numbering problem: a
+duplicate row is visible the moment you look at the table, while a stale by-number reference **reads
+as correct** and quietly sends the next agent to an unrelated entry -- or to nothing at all.
+
+WHAT COUNTS AS A REFERENCE. `trap 41`, `traps 55 and 56`, `instrument trap 104`, `instrument-trap
+43`, `orchestration trap 68`, and comma lists like `traps 64, 116 and 121`. The word must not be
+preceded by an identifier character, which is what keeps the RDNA2 shader tests' `s_trap 1` and
+`v_trap` out -- those are instruction mnemonics and have nothing to do with this table. That
+exclusion is measured rather than assumed: without it the corpus reports 4 spurious references, all
+in `tests/test_recompile_coverage.cpp` and its neighbours.
+
+WHAT IT CANNOT SEE, stated so silence is not read as coverage:
+  * A reference that names a row which EXISTS but is the wrong one. Only a reader can tell that; a
+    number that resolves is all this can check. This is the same boundary check_numbered_table draws
+    between "the table is well formed" and "the table is true".
+  * A reference written in a form this does not recognise -- "the trap about rate limits", "entry
+    49", a bare "#49". Deliberately narrow: a citation checker that fires on prose gets deleted.
+  * References in files git does not track, and in binary files, which are skipped.
+  * A row that is cited and then DELETED is reported here as a dangling reference, but the deletion
+    itself belongs to `check_numbered_table.py --baseline`. The two are complements: that one asks
+    "did a row leave?", this one asks "does every pointer still land?".
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_numbered_table import parse_tables  # noqa: E402
+
+# `(?<![A-Za-z0-9_])` is what excludes `s_trap 1` / `v_trap 3`: an RDNA2 mnemonic, not a citation.
+# The separator after the word may be a space or a hyphen ("instrument-trap 43" appears in CLAUDE.md).
+# The tail captures comma/and lists so "traps 64, 116 and 121" yields three references, not one.
+CITATION = re.compile(
+    r"(?<![A-Za-z0-9_])(?:instrument[- ]|orchestration )?traps?[- ]"
+    r"(\d{1,3}(?:\s*,\s*\d{1,3})*(?:\s*(?:,\s*)?and\s+\d{1,3})?)",
+    re.IGNORECASE,
+)
+NUMBER = re.compile(r"\d{1,3}")
+
+
+def table_numbers(doc: Path, table_header: str) -> set[int] | None:
+    try:
+        text = doc.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    tables, _, _ = parse_tables(text.split("\n"))
+    matching = [t for t in tables if t.proper and t.all_rows_numbered and table_header in t.header]
+    if len(matching) != 1:
+        return None
+    return {n for _, n in matching[0].numbered_rows()}
+
+
+def citations(path: Path) -> list[tuple[int, int, str]]:
+    """(line_no, number, the matched text) for every trap reference in `path`."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []  # binary or unreadable: not a citation site
+    out: list[tuple[int, int, str]] = []
+    for line_no, line in enumerate(text.split("\n"), start=1):
+        for m in CITATION.finditer(line):
+            for num in NUMBER.findall(m.group(1)):
+                out.append((line_no, int(num), m.group(0).strip()))
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("paths", nargs="+", type=Path, help="files to scan for references")
+    ap.add_argument("--table", type=Path, required=True, help="the document holding the table")
+    ap.add_argument("--table-header", default="Instrument",
+                    help="select the table whose header contains this (default 'Instrument')")
+    ap.add_argument("--github", action="store_true",
+                    help="emit ::error:: annotations so failures surface on the Actions summary")
+    args = ap.parse_args()
+
+    have = table_numbers(args.table, args.table_header)
+    if have is None:
+        # Fails closed. If the table cannot be found, every reference would trivially "not resolve"
+        # or trivially resolve depending on the bug -- either way the run means nothing, so say so
+        # instead of printing a number.
+        print(f"error: no single numbered table whose header contains {args.table_header!r} in "
+              f"{args.table} -- wrong path, or the table format changed", file=sys.stderr)
+        return 2
+
+    problems: list[str] = []
+    scanned = cited = 0
+    seen_numbers: set[int] = set()
+    citing_files: set[Path] = set()
+    citing_lines: set[tuple[Path, int]] = set()
+    for path in args.paths:
+        if path.resolve() == args.table.resolve():
+            continue  # the table cites itself in row text; those are not pointers into it
+        scanned += 1
+        for line_no, num, text in citations(path):
+            cited += 1
+            seen_numbers.add(num)
+            citing_files.add(path)
+            citing_lines.add((path, line_no))
+            if num not in have:
+                problems.append(
+                    f"{path}:{line_no}: cites row {num}, which is not in {args.table} "
+                    f"(the table runs {min(have)}..{max(have)}). A by-number reference that does "
+                    f"not resolve READS AS CORRECT -- it is a plausible number in a plausible "
+                    f"sentence -- so nothing else will ever report it. Either the row was deleted "
+                    f"or renumbered (which `check_numbered_table.py --baseline` forbids), or this "
+                    f"is a typo. Reference reads: {text!r}"
+                )
+
+    for problem in problems:
+        if args.github:
+            escaped = problem.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+            print(f"::error::{escaped}")
+        else:
+            print(f"error: {problem}", file=sys.stderr)
+    if problems:
+        print(f"\n{len(problems)} dangling reference(s) found.", file=sys.stderr)
+        return 1
+
+    # Quote the counts, not just the exit status: a scan that matched nothing at all -- a broken
+    # regex, a wrong file list -- exits 0 exactly like a clean one, and the counts are the only way
+    # to tell those apart.
+    print(
+        f"{args.table}: {len(have)} rows ({min(have)}..{max(have)}); "
+        f"{cited} reference(s) on {len(citing_lines)} line(s) in {len(citing_files)} file(s) "
+        f"(of {scanned} scanned), naming {len(seen_numbers)} distinct row(s), all resolving"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/docs/check_trap_citations.py
+++ b/prosper/tools/docs/check_trap_citations.py
@@ -4,9 +4,12 @@
 WHY. The instrument-trap table's whole value is that other documents, source comments and tests
 point AT it by number -- `// instrument trap 104 records that a read-only probe's DURATION can
 decide...` in `src/gpu/command_processor.cpp`, `See instrument-trap 41` in `CLAUDE.md`,
-`Recorded as instrument trap 114` in a status doc. Measured on `origin/master` 2026-08-17: **95
-lines across 50 files, naming 91 distinct rows** -- and roughly half are `.cpp`/`.hpp`/test comments
-rather than prose, so this is a contract compiled files depend on, not a documentation nicety.
+`Recorded as instrument trap 114` in a status doc. Roughly half of them are `.cpp`/`.hpp`/test
+comments rather than prose, so this is a contract compiled files depend on, not a documentation
+nicety. **This file deliberately quotes no total**: it PRINTS the live figure on every run, and an
+earlier draft froze a number here that had already been corrected twice elsewhere (#2621 review) --
+citing a stale count inside the tool that measures it is the exact failure the tool exists to
+prevent. Run it if you want the number.
 
 Nothing checked that those references resolve. `check_numbered_table.py` validates the TABLE --
 structure, arity, uniqueness, ascent, and (with `--baseline`) that no row was deleted. It has no
@@ -22,8 +25,11 @@ WHAT COUNTS AS A REFERENCE. `trap 41`, `traps 55 and 56`, `instrument trap 104`,
 43`, `orchestration trap 68`, and comma lists like `traps 64, 116 and 121`. The word must not be
 preceded by an identifier character, which is what keeps the RDNA2 shader tests' `s_trap 1` and
 `v_trap` out -- those are instruction mnemonics and have nothing to do with this table. That
-exclusion is measured rather than assumed: without it the corpus reports 4 spurious references, all
-in `tests/test_recompile_coverage.cpp` and its neighbours.
+exclusion is measured rather than assumed: on `origin/master` `7413647a`, removing the leading
+boundary admits exactly **4** extra matches -- `s_trap 0` in `test_dynfetch_fold.cpp`,
+`test_indirect_pointer_static_footprint.cpp` and `test_rdna2_to_spirv.cpp`, and `s_trap 1` in
+`test_recompile_coverage.cpp`. **Three of them cite row 0**, which does not exist, so they would not
+merely be noise: they would turn this repo-wide required gate red on correct code.
 
 WHAT IT CANNOT SEE, stated so silence is not read as coverage:
   * A reference that names a row which EXISTS but is the wrong one. Only a reader can tell that; a
@@ -48,12 +54,30 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from check_numbered_table import parse_tables  # noqa: E402
 
-# `(?<![A-Za-z0-9_])` is what excludes `s_trap 1` / `v_trap 3`: an RDNA2 mnemonic, not a citation.
-# The separator after the word may be a space or a hyphen ("instrument-trap 43" appears in CLAUDE.md).
+# Three things this regex has to get right, each measured against the real corpus rather than
+# reasoned about (#2621 review):
+#
+#  1. A LEADING boundary, so `s_trap 1` / `v_trap 3` -- RDNA2 mnemonics -- are not citations. Two
+#     forms, because the prefix decides which: an explicitly prefixed citation ("instrument-trap 43")
+#     legitimately follows a hyphen, while a BARE `trap` after a hyphen is part of a compound word.
+#     Without that split, `prosper/tools/AGENTS.md:100`'s pasted log line `[agc] WRITE-TRAP #1[...]`
+#     would count as a reference to row 1.
+#  2. A TRAILING boundary on the number. Without it `\d{1,3}` bites a prefix out of anything longer
+#     and the result is a citation to a row that was never written:
+#         `trap 0x40`   -> row 0     (turns this repo-wide gate RED on correct code)
+#         `traps 1234`  -> row 123   (silently WRONG -- resolves today, points at an unrelated row)
+#         `trap 41.5ms` -> row 41    (spurious, resolves)
+#     `(?![\w.])` rejects all three: the match fails outright rather than truncating.
+#  3. An optional `#`. `trap #16`, `trap #35` and `instrument trap #13` are live in-repo citation
+#     forms (DRAGON_QUEST_STATUS.md, OREGON_TRAIL_STATUS.md, SYBERIA_STATUS.md); missing them while
+#     the success line says "all resolving" would be a completeness claim the tool does not have.
+#
 # The tail captures comma/and lists so "traps 64, 116 and 121" yields three references, not one.
 CITATION = re.compile(
-    r"(?<![A-Za-z0-9_])(?:instrument[- ]|orchestration )?traps?[- ]"
-    r"(\d{1,3}(?:\s*,\s*\d{1,3})*(?:\s*(?:,\s*)?and\s+\d{1,3})?)",
+    r"(?:(?<![A-Za-z0-9_])(?:instrument[- ]|orchestration )|(?<![A-Za-z0-9_-]))"
+    r"traps?[- ]#?"
+    r"(\d{1,3}(?:\s*,\s*#?\d{1,3})*(?:\s*(?:,\s*)?and\s+#?\d{1,3})?)"
+    r"(?![\w.])",
     re.IGNORECASE,
 )
 NUMBER = re.compile(r"\d{1,3}")

--- a/prosper/tools/docs/check_trap_citations.py
+++ b/prosper/tools/docs/check_trap_citations.py
@@ -67,7 +67,14 @@ from check_numbered_table import parse_tables  # noqa: E402
 #         `trap 0x40`   -> row 0     (turns this repo-wide gate RED on correct code)
 #         `traps 1234`  -> row 123   (silently WRONG -- resolves today, points at an unrelated row)
 #         `trap 41.5ms` -> row 41    (spurious, resolves)
-#     `(?![\w.])` rejects all three: the match fails outright rather than truncating.
+#     The boundary is `(?!\w|\.\d)` and NOT `(?![\w.])`, which is the obvious form and is wrong:
+#     a full stop is also how a sentence ends, so `See instrument trap 41.` stopped being a citation
+#     at all. That cost 22 of 118 references on this corpus, 5 of them in .cpp/.hpp/test comments --
+#     the half this tool exists for -- and it did so SILENTLY, because the gate stays green while the
+#     success line still says "all resolving". A citation auditor that quietly stops seeing
+#     sentence-final citations and then reports full coverage is the exact shape it was built to
+#     police (#2621 review). Excluding only a digit AFTER the stop keeps `41.5` out and `41.` in.
+#     It also restored list members: `See traps 55 and 56.` had been yielding only 55.
 #  3. An optional `#`. `trap #16`, `trap #35` and `instrument trap #13` are live in-repo citation
 #     forms (DRAGON_QUEST_STATUS.md, OREGON_TRAIL_STATUS.md, SYBERIA_STATUS.md); missing them while
 #     the success line says "all resolving" would be a completeness claim the tool does not have.
@@ -77,7 +84,7 @@ CITATION = re.compile(
     r"(?:(?<![A-Za-z0-9_])(?:instrument[- ]|orchestration )|(?<![A-Za-z0-9_-]))"
     r"traps?[- ]#?"
     r"(\d{1,3}(?:\s*,\s*#?\d{1,3})*(?:\s*(?:,\s*)?and\s+#?\d{1,3})?)"
-    r"(?![\w.])",
+    r"(?!\w|\.\d)",
     re.IGNORECASE,
 )
 NUMBER = re.compile(r"\d{1,3}")

--- a/prosper/tools/docs/test_check_trap_citations.py
+++ b/prosper/tools/docs/test_check_trap_citations.py
@@ -85,10 +85,34 @@ case("a plain list of resolving numbers passes", "// traps 1, 2 and 3\n", want_r
 # inside each string still matched. Only a citation that must be REPORTED proves it was parsed.
 case("the hyphenated form is recognised (asserted by failing)",
      "// see instrument-trap 99\n", want_rc=1, expect_text="cites row 99")
-case("the spaced instrument form is recognised (asserted by failing)",
+# These two are NOT alternation tests and are named for what they actually establish: deleting the
+# `(?:instrument[- ]|orchestration )` group leaves both green, because the bare `trap 99` inside each
+# string still matches through the other branch. They pin that a prefixed citation is found at all,
+# which is worth having; only the HYPHENATED case above can discriminate the alternation, because a
+# hyphen is the one separator the bare branch refuses (#2621 review).
+case("a prefixed citation is found (does not discriminate the alternation)",
      "// see instrument trap 99\n", want_rc=1, expect_text="cites row 99")
-case("the orchestration form is recognised (asserted by failing)",
+case("an orchestration-prefixed citation is found (does not discriminate the alternation)",
      "// per orchestration trap 99\n", want_rc=1, expect_text="cites row 99")
+
+# THE ARM THAT WOULD HAVE CAUGHT THE REGRESSION. The obvious trailing boundary, `(?![\w.])`, also
+# rejects a full stop -- which is how a sentence ends -- so `See instrument trap 41.` stopped being a
+# citation at all. 22 of 118 references vanished from the corpus, 5 of them in .cpp/.hpp/test
+# comments, and NOTHING went red: the gate stays green while the success line still claims "all
+# resolving". A citation auditor that silently stops seeing sentence-final citations and then reports
+# full coverage is precisely the shape it exists to police.
+case("a sentence-final citation is still a citation",
+     "See instrument trap 99.\n", want_rc=1, expect_text="cites row 99")
+
+# ...and the same at the end of a LIST, which the broken form also truncated: `traps 55 and 56.`
+# was yielding only 55, so the loss was not confined to single references.
+case("the last member of a sentence-final list is still a citation",
+     "See traps 1, 2 and 99.\n", want_rc=1, expect_text="cites row 99")
+
+# The counter-arm that keeps both honest: a DECIMAL must still be rejected, which is the entire
+# reason the boundary exists. `(?!\w|\.\d)` excludes only a digit after the stop.
+case("a decimal is still not a citation, with the looser boundary",
+     "// trap 99.5 ms of overhead\n", want_rc=0)
 
 # `trap #NN` is live in this repository — DRAGON_QUEST_STATUS.md, OREGON_TRAIL_STATUS.md and
 # SYBERIA_STATUS.md all use it. Missing it while the success line says "all resolving" would be a

--- a/prosper/tools/docs/test_check_trap_citations.py
+++ b/prosper/tools/docs/test_check_trap_citations.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Self-checking tests for check_trap_citations.py (exit code is truth).
+
+Two halves, and the second is the one that keeps the check alive. A citation checker that fires on
+correct prose gets disabled within a day, and this one scans every tracked file in the repository --
+including a thousand source files whose comments mention all sorts of things. So the false-positive
+cases here (`s_trap 1`, a bare number, a word that merely contains "trap") carry as much weight as
+the true positives.
+
+Run directly, or via ctest as trap_citation_checker.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+TOOL = HERE / "check_trap_citations.py"
+
+FAILURES: list[str] = []
+
+TABLE = (
+    "# doc\n\n| # | Instrument | How it lied |\n|---|---|---|\n"
+    + "".join(f"| {n} | thing {n} | evidence |\n" for n in (1, 2, 3, 7))
+    + "\n### Next\n"
+)
+
+
+def case(name: str, citing: str, *, want_rc: int, expect_text: str | None = None,
+         table: str = TABLE) -> None:
+    with tempfile.TemporaryDirectory() as d:
+        t = Path(d) / "table.md"
+        c = Path(d) / "citing.cpp"
+        t.write_text(table, encoding="utf-8")
+        c.write_text(citing, encoding="utf-8")
+        proc = subprocess.run(
+            [sys.executable, str(TOOL), "--table", str(t), str(c), str(t)],
+            capture_output=True, text=True,
+        )
+    out = proc.stdout + proc.stderr
+    if proc.returncode != want_rc:
+        FAILURES.append(f"{name}: expected rc={want_rc}, got {proc.returncode}: {out[:300]!r}")
+        return
+    if expect_text and expect_text not in out:
+        FAILURES.append(f"{name}: expected {expect_text!r}, got {out[:300]!r}")
+        return
+    print(f"  ok  {name}")
+
+
+print("references that do not resolve:")
+
+case("a reference above the table's range",
+     "// see instrument trap 99 for why\n",
+     want_rc=1, expect_text="cites row 99")
+
+# A gap is legal in the table (#2089), so a number INSIDE the range can still be absent -- and this
+# is the case a "is it <= max?" check would miss entirely.
+case("a reference INTO A GAP, inside the range but absent",
+     "// see instrument trap 5 for why\n",
+     want_rc=1, expect_text="cites row 5")
+
+# Every reference on the line must be checked, not just the first. "traps 64, 116 and 121" is a real
+# shape from CLAUDE.md, and a checker that took only the first number would pass two thirds of it.
+case("a comma-and list is expanded, and the bad member is named",
+     "// traps 1, 2 and 99 all apply\n",
+     want_rc=1, expect_text="cites row 99")
+
+case("every dangling reference is reported, not just the first",
+     "// trap 88 here\n// and trap 99 there\n",
+     want_rc=1, expect_text="2 dangling reference(s) found")
+
+print("correct shapes that must NOT fire:")
+
+case("a resolving reference passes", "// instrument trap 7 explains it\n", want_rc=0)
+case("the hyphenated form resolves", "// see instrument-trap 3\n", want_rc=0)
+case("the orchestration form resolves", "// per orchestration trap 2\n", want_rc=0)
+case("a plain list of resolving numbers passes", "// traps 1, 2 and 3\n", want_rc=0)
+
+# THE discriminating false positive. `s_trap` is an RDNA2 instruction mnemonic and appears in the
+# shader recompiler's tests; without the identifier-character lookbehind the real corpus reports
+# three spurious references (`prosper/tests/test_rdna2_to_spirv.cpp` among them), and both of these
+# cases fail. Mutation-checked: deleting `(?<![A-Za-z0-9_])` makes exactly these two go red.
+#
+# The operand here is deliberately a number the table does NOT hold. The repository's actual text is
+# `// s_trap 1`, and a fixture using 1 would be VOID: 1 is a valid row, so the case passes whether
+# the mnemonic was excluded or matched-and-resolved, and it cannot tell the two apart. That was the
+# first draft of this case, and the mutation arm is what exposed it.
+case("s_trap is an RDNA2 mnemonic, not a citation",
+     "        0xBF920063u, // s_trap 99\n", want_rc=0)
+case("v_trap is not a citation either", "// v_trap 99 is an encoding\n", want_rc=0)
+
+# Narrowness is deliberate: an unrecognised phrasing must be silently ignored rather than guessed
+# at, because a checker that fires on prose gets deleted rather than heeded.
+case("a bare number is not a citation", "// see entry 99\n", want_rc=0)
+case("a word merely containing 'trap' is not a citation", "// the trapdoor 99 opens\n", want_rc=0)
+
+print("fails closed:")
+
+# If the table cannot be found the run means nothing either way, so it must say so rather than
+# report a count. rc=2 separates "the instrument is broken" from "your references are broken".
+case("a table that cannot be found is an error, not a clean run",
+     "// trap 1\n", want_rc=2, expect_text="no single numbered table",
+     table="# doc\n\nno table here at all\n")
+
+# The success line quotes the counts. A scan that matched nothing -- a broken regex, a wrong file
+# list -- exits 0 exactly like a clean one, and the counts are the only way to tell them apart.
+case("the success line quotes the reference and row counts",
+     "// trap 1 and trap 7\n", want_rc=0, expect_text="naming 2 distinct row(s), all resolving")
+
+print()
+if FAILURES:
+    for f in FAILURES:
+        print(f"FAIL: {f}", file=sys.stderr)
+    print(f"\n{len(FAILURES)} case(s) failed.", file=sys.stderr)
+    sys.exit(1)
+print("all cases passed")

--- a/prosper/tools/docs/test_check_trap_citations.py
+++ b/prosper/tools/docs/test_check_trap_citations.py
@@ -75,9 +75,48 @@ case("every dangling reference is reported, not just the first",
 print("correct shapes that must NOT fire:")
 
 case("a resolving reference passes", "// instrument trap 7 explains it\n", want_rc=0)
-case("the hyphenated form resolves", "// see instrument-trap 3\n", want_rc=0)
-case("the orchestration form resolves", "// per orchestration trap 2\n", want_rc=0)
 case("a plain list of resolving numbers passes", "// traps 1, 2 and 3\n", want_rc=0)
+
+# THE PREFIX FORMS ARE ASSERTED IN THE FAILING DIRECTION, and that is not stylistic. An arm that
+# says "`instrument-trap 3` passes" is VOID: if the parser stopped recognising the form entirely it
+# would find no reference at all and still exit 0, so rc=0 cannot distinguish "recognised and
+# resolved" from "never seen". The #2621 review caught exactly this — deleting the whole
+# `(?:instrument[- ]|orchestration )` group left three such arms green, because the bare `trap N`
+# inside each string still matched. Only a citation that must be REPORTED proves it was parsed.
+case("the hyphenated form is recognised (asserted by failing)",
+     "// see instrument-trap 99\n", want_rc=1, expect_text="cites row 99")
+case("the spaced instrument form is recognised (asserted by failing)",
+     "// see instrument trap 99\n", want_rc=1, expect_text="cites row 99")
+case("the orchestration form is recognised (asserted by failing)",
+     "// per orchestration trap 99\n", want_rc=1, expect_text="cites row 99")
+
+# `trap #NN` is live in this repository — DRAGON_QUEST_STATUS.md, OREGON_TRAIL_STATUS.md and
+# SYBERIA_STATUS.md all use it. Missing it while the success line says "all resolving" would be a
+# completeness claim the tool does not have (#2621 review).
+case("the hash form is recognised (asserted by failing)",
+     "// see instrument trap #99\n", want_rc=1, expect_text="cites row 99")
+case("...and a resolving hash reference passes", "// see trap #7\n", want_rc=0)
+
+# ...but a hash after a COMPOUND WORD is not a citation. `[agc] WRITE-TRAP #1[val=…]` is a pasted
+# diagnostic line in tools/AGENTS.md, and accepting `#` naively turns it into a reference to row 1.
+# This is why the leading boundary is split: an explicitly prefixed citation may follow a hyphen
+# ("instrument-trap 43"), a bare one may not.
+# NOTE the operand: the real log line reads `WRITE-TRAP #1`, and a fixture using 1 would be the
+# THIRD void arm in this file — 1 is a valid row, so the case passes whether the compound word was
+# excluded or matched-and-resolved. Every "must not fire" arm here uses a number the fixture table
+# does not hold, which is the only thing that makes rc=0 mean "not matched".
+case("a hyphenated compound word with a hash is not a citation",
+     "    [agc] WRITE-TRAP #99[val=0x5a]\n", want_rc=0)
+
+# B1 (#2621 review) — the number needs a TRAILING boundary or `\d{1,3}` bites a prefix out of
+# anything longer. Each of these was a real defect: the first turns a repo-wide required gate RED on
+# correct code, the second is worse because it SILENTLY resolves to an unrelated row.
+case("a hex vector is not a citation to row 0",
+     "// trap 0x40 is the debug vector\n", want_rc=0)
+case("a longer number is not truncated into a valid row",
+     "// the guest traps 1234 times per frame\n", want_rc=0)
+case("a decimal measurement is not a citation",
+     "// trap 41.5 ms of overhead\n", want_rc=0)
 
 # THE discriminating false positive. `s_trap` is an RDNA2 instruction mnemonic and appears in the
 # shader recompiler's tests; without the identifier-character lookbehind the real corpus reports


### PR DESCRIPTION
**Independent of #2610 and #2616** — base is `master`, and it changes no existing check. Land in any order.

## The gap

The instrument-trap table's whole value is that other files point **at** it by number. Measured on `origin/master` (`7413647a`):

```
$ git ls-files -z | xargs -0 python3 prosper/tools/docs/check_trap_citations.py \
    --table prosper/docs/GAME_COMPAT_ORCHESTRATION.md

prosper/docs/GAME_COMPAT_ORCHESTRATION.md: 187 rows (1..187); 118 reference(s) on 110 line(s)
  in 46 file(s) (of 1044 scanned), naming 63 distinct row(s), all resolving
```

**50 of those 118 are `.cpp` / `.hpp` / `.py` comments**, not prose — `src/gpu/command_processor.cpp:496`, `src/hle/hle_service.cpp:462`, `src/host/raw_syscall.hpp:77`, `frontends/shared/live_renderer.cpp:4915`, and more. This is a contract compiled files depend on.

**Nothing checked that any of it resolves.** `check_numbered_table.py` validates the *table* — structure, arity, uniqueness, ascent, and (with #2610's `--baseline`) that no row was deleted. It has no idea anything cites it. So a reference to a row that never existed reads as perfectly correct: a plausible number in a plausible sentence, findable only by opening the table and counting, which nobody does for a number in a code comment.

**That is the more expensive half of the numbering problem.** A duplicate row is visible the moment you look at the table. A stale by-number reference quietly sends the next agent to an unrelated entry — or to nothing — and it does so wearing the authority of a citation, which `CLAUDE.md` already records as the most contagious kind of error this project produces.

## Why it is narrow on purpose

It scans all 1,044 tracked files, so a checker that fires on ordinary prose gets disabled rather than heeded. Counted: `trap 41`, `traps 55 and 56`, `instrument trap 104`, `instrument-trap 43`, `orchestration trap 68`, and comma-and lists (`traps 64, 116 and 121` → three references). Not counted: a bare number, `entry 99`, `trapdoor 99`, and anything whose `trap` is preceded by an identifier character.

That last exclusion is what keeps the RDNA2 shader tests' `s_trap 1` out, and it is **measured, not assumed** — deleting the `(?<![A-Za-z0-9_])` lookbehind makes the real corpus report 3 spurious hits:

```
error: prosper/tests/test_rdna2_to_spirv.cpp:12328: cites row 0, which is not in
  prosper/docs/GAME_COMPAT_ORCHESTRATION.md (the table runs 1..187) ... Reference reads: 'trap 0'
3 dangling reference(s) found.
```

## Fails closed

- A table that cannot be found → **rc=2** with a message, not a clean run. `rc=2` separates "the instrument is broken" from "your references are broken".
- The success line quotes the reference and row counts, because a scan that matched **nothing** — a broken regex, a wrong file list — exits 0 exactly like a clean one, and the counts are the only way to tell those apart.

## What it cannot see, stated so silence is not read as coverage

- A reference naming a row that **exists but is the wrong one**. Only a reader can tell that; a number that resolves is all this can check — the same boundary `check_numbered_table.py` draws between "the table is well formed" and "the table is true".
- A reference in a phrasing it does not recognise ("the trap about rate limits", "entry 49", a bare `#49`).
- Untracked and binary files.
- The *deletion* that made a reference dangle — that belongs to `check_numbered_table.py --baseline` (#2610). The two are complements: that one asks "did a row leave?", this one asks "does every pointer still land?".

## Mutation-arm evidence

| mutation | result |
|---|---|
| remove the identifier lookbehind | 2 test arms red; real corpus reports 3 spurious references |
| (clean) | 14/14 arms pass; corpus reports 118 references, all resolving |

**One arm was VOID in its first draft, and the mutation is what exposed it.** The `s_trap` case used the repository's real text, `// s_trap 1` — and `1` is a valid row, so the case passed whether the mnemonic was *excluded* or *matched and happened to resolve*. It could not distinguish the two implementations. It now uses an operand the table does not hold. Recorded in the test file rather than quietly fixed, since it is the exact shape `CLAUDE.md` warns about: an assertion whose inputs cannot exercise the property being asserted.

Half the suite is false-positive shapes, for the reason above.

## Verification (exact head of this branch)

```
python3 prosper/tools/docs/test_check_trap_citations.py                     rc=0, 14 cases
ctest --test-dir <build> -R '^(doc_table_checker|trap_citation_checker)$' \
      --no-tests=error                                                      rc=0, 2/2 passed
git ls-files -z | xargs -0 python3 prosper/tools/docs/check_trap_citations.py \
      --table prosper/docs/GAME_COMPAT_ORCHESTRATION.md                     rc=0 (output above)
git diff --check origin/master..HEAD                                        rc=0
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'        0
```

All 118 references resolve on current master, so this lands green and locks the property in rather than starting with a cleanup.

## Note for whoever reruns CI

This edits `.github/workflows/ci.yml`, so `gh run rerun` on runs created before it will refuse with *"its workflow file may be broken"* — push or rebase for a fresh run.

## Review

The thing to attack is the regex. It runs over every tracked file on every PR, so a false positive blocks unrelated work — try to find a real phrase in this repository that it misreads, and a real citation form it misses. The `s_trap` exclusion in particular: is an identifier-character lookbehind the right rule, or is there a legitimate citation somewhere preceded by one?

Refs #2089, #1729
