### PR TITLE
fix(libkernel): the C11 _Cnd_wait/_Mtx_lock must resolve a guest slot the way libkernel does (#2596)

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1624,6 +1624,10 @@ if(TARGET prosper_core)
     # #2178: every fallible scePthread* spelling reports the libkernel-encoded error while the POSIX
     # spelling on the same body keeps the bare FreeBSD errno. Asserts both halves per entry point —
     # a single-spelling arm cannot see a missing (or a wrongly added) SCE_PTHREAD_ALIAS.
+    add_executable(test_pthread_error_encoding tests/test_pthread_error_encoding.cpp)
+    target_link_libraries(test_pthread_error_encoding PRIVATE prosper_core)
+    add_test(NAME pthread_error_encoding COMMAND test_pthread_error_encoding)
+
     # #2596: the C11 _Mtx_* / _Cnd_* handlers must resolve a guest sync slot the way the libkernel
     # entry point they forward to on hardware resolves it. Asserts what the handler DID (blocked,
     # excluded a second thread, self-initialised the slot), never what it returned -- _Cnd_wait's
@@ -1633,10 +1637,6 @@ if(TARGET prosper_core)
     target_link_libraries(test_c11_thread_slots PRIVATE prosper_core)
     add_test(NAME c11_thread_slots COMMAND test_c11_thread_slots)
     set_tests_properties(c11_thread_slots PROPERTIES TIMEOUT 120)
-
-    add_executable(test_pthread_error_encoding tests/test_pthread_error_encoding.cpp)
-    target_link_libraries(test_pthread_error_encoding PRIVATE prosper_core)
-    add_test(NAME pthread_error_encoding COMMAND test_pthread_error_encoding)
 
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1624,6 +1624,16 @@ if(TARGET prosper_core)
     # #2178: every fallible scePthread* spelling reports the libkernel-encoded error while the POSIX
     # spelling on the same body keeps the bare FreeBSD errno. Asserts both halves per entry point —
     # a single-spelling arm cannot see a missing (or a wrongly added) SCE_PTHREAD_ALIAS.
+    # #2596: the C11 _Mtx_* / _Cnd_* handlers must resolve a guest sync slot the way the libkernel
+    # entry point they forward to on hardware resolves it. Asserts what the handler DID (blocked,
+    # excluded a second thread, self-initialised the slot), never what it returned -- _Cnd_wait's
+    # unconditional 0 is the shipped contract. TIMEOUT is generous because every arm is a bounded
+    # spin: a regression here is a thread that never wakes, and each arm reports it as a failure.
+    add_executable(test_c11_thread_slots tests/test_c11_thread_slots.cpp)
+    target_link_libraries(test_c11_thread_slots PRIVATE prosper_core)
+    add_test(NAME c11_thread_slots COMMAND test_c11_thread_slots)
+    set_tests_properties(c11_thread_slots PROPERTIES TIMEOUT 120)
+
     add_executable(test_pthread_error_encoding tests/test_pthread_error_encoding.cpp)
     target_link_libraries(test_pthread_error_encoding PRIVATE prosper_core)
     add_test(NAME pthread_error_encoding COMMAND test_pthread_error_encoding)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -17,6 +17,7 @@
 #include "sce_errno.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "../host/exec_image.hpp"      // describe_code_address (host frame naming)
+#include "pthread_slot.hpp"   // #2596: the two guest-slot resolvers are defined here
 #include "sync_futex.hpp"
 #include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "../gpu/mb3_freelist.hpp"
@@ -1048,6 +1049,18 @@ HLE(k_cond_destroy) {
 SCE_PTHREAD_ALIAS(k_sce_cond_destroy, k_cond_destroy)
 HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_signal(c); } return 0; }
 HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_broadcast(c); } return 0; }
+// The two guest-slot resolvers, published for the C11 `_Mtx_*` / `_Cnd_*` handlers in
+// hle_kernel_time.cpp (#2596). They are thin by design: `ensure_mutex` / `ensure_cond` above hold
+// the whole contract -- FreeBSD's static-initialiser sentinels self-initialise (#793), a destroyed
+// slot is refused loudly instead of manufacturing a fresh unheld object (#2170), and the created
+// object is installed with a compare-exchange so racing first uses share one object (#2176). The
+// C11 spelling had a PRIVATE `if (*slot)` guard that answered none of that, and read a statically
+// initialised object as absent. On hardware it has no such guard: the shipped libc.prx's `_Cnd_wait`
+// is `call <scePthreadCondWait>; xor eax,eax; ret`, so the C11 spelling resolves its slots through
+// exactly this code. See pthread_slot.hpp.
+pthread_mutex_t* guest_mutex_from_slot(uint64_t slot_addr) { return ensure_mutex(slot_addr); }
+pthread_cond_t*  guest_cond_from_slot(uint64_t slot_addr)  { return ensure_cond(slot_addr); }
+
 // #1983: this reported SUCCESS for a wait that failed, and for a wait that never happened, through
 // two separate paths:
 //   1. the result was DISCARDED -- `(void)interruptible_cond_wait(...)` followed by an

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -1121,8 +1121,17 @@ HLE(k_cond_timedwait) {
     // k_cond_wait alone, which left this function's null-deadline branch -- an INDEFINITE park
     // through the identical call -- invisible to the busy check, so a destroy retired the slot out
     // from under a thread parked forever. Scoping the body rather than the call means a future
-    // branch added here cannot miss it; a future BODY still has to remember, which is why the three
-    // cond-wait bodies are the unit and there are exactly three.
+    // branch added here cannot miss it; a future BODY still has to remember, which is why the
+    // cond-wait bodies are the unit.
+    //
+    // THREE bodies take this scope, and that is NOT the same as "all of them" -- the earlier
+    // wording here said "there are exactly three", and #2596 made it false while relying on it.
+    // The C11 `m_cnd_wait` (hle_kernel_time.cpp) is a fourth body that can park, because it now
+    // resolves a statically-initialised slot instead of skipping it, and it does NOT take the
+    // scope. So a thread parked through the C11 spelling is still invisible to the busy check
+    // below, and a destroy will retire the object out from under it -- #2168's exact failure
+    // through a different door. Tracked as #2623 with the file:line and the mechanism; recorded
+    // here rather than in the issue alone because a bare count is what the next reader trusts.
     GuestCondWaiterScope waiting(c);
     if (!a2) {
         int rc = interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -752,12 +752,22 @@ HLE(k_uuid_create) {                                       // fill 16 non-zero b
 
 // --- C11 threads (used by MSVC STL std::mutex/std::condition_variable) ---
 HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t)); pthread_mutexattr_t at; pthread_mutexattr_init(&at); pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE); pthread_mutex_init(m, &at); pthread_mutexattr_destroy(&at); *(void**)P(a0) = m; } return 0; }
-// #2596: every one of these used a PRIVATE `if (a0 && *(void**)P(a0))` guard, so a slot holding a
-// STATIC INITIALISER -- NULL for PTHREAD_MUTEX_INITIALIZER, and the other sub-page sentinels FreeBSD
-// uses -- read as "there is no object here" and the operation was SKIPPED ENTIRELY. `_Mtx_lock` then
-// reported success without taking the lock, which is precisely the bdwgc GC_allocate_ml
-// static-mutex shape that was the ROOT CAUSE of the level-1 heap corruption (#793), reached through
-// the other spelling; `_Cnd_wait` reported success for a wait that never happened.
+// #2596: every one of these used a PRIVATE `if (a0 && *(void**)P(a0))` guard, and it was wrong in
+// TWO different ways depending on which sentinel the slot held -- a distinction worth stating,
+// because the first revision of this comment claimed the whole class was merely "skipped" and a
+// reviewer falsified that in one grep. The guard tests the slot's VALUE for non-zero, while
+// `pt_static_sentinel` (hle_kernel.cpp) treats EVERYTHING below 0x1000 as a static initialiser:
+//
+//   * NULL (PTHREAD_MUTEX_INITIALIZER) -- the guard is false, so the operation was SKIPPED
+//     ENTIRELY. `_Mtx_lock` reported success without taking the lock, which is precisely the bdwgc
+//     GC_allocate_ml static-mutex shape that was the ROOT CAUSE of the level-1 heap corruption
+//     (#793), reached through the other spelling; `_Cnd_wait` reported success for a wait that
+//     never happened.
+//   * ANY OTHER SENTINEL -- 1 (PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP) and the destroyed poison
+//     kPtDestroyed (0xDEA) -- the guard is TRUE, so the value was DEREFERENCED AS AN OBJECT
+//     POINTER: `interruptible_mutex_lock((pthread_mutex_t*)0xDEA)`. Not a silent skip at all, a
+//     segfault. Routing through the resolver fixes a use-after-destroy crash on this spelling as
+//     well as the missing operation.
 //
 // The guard is gone in favour of guest_mutex_from_slot / guest_cond_from_slot, which ARE
 // ensure_mutex / ensure_cond -- the same resolution scePthreadMutexLock and scePthreadCondWait use.

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -10,6 +10,7 @@
 #include "callback_fs.hpp"            // recover the caller's guest %fs from the import-stub frame
 #include "sce_errno.hpp"    // #1612: the guest reads FreeBSD errnos, not this host's
 #include "heap_mutex.hpp"   // #707: keep hot equeue/APR mutexes off macOS __DATA
+#include "pthread_slot.hpp"   // #2596: resolve a guest sync slot the way libkernel does
 #include "sync_futex.hpp"
 #include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include <pthread.h>
@@ -751,8 +752,29 @@ HLE(k_uuid_create) {                                       // fill 16 non-zero b
 
 // --- C11 threads (used by MSVC STL std::mutex/std::condition_variable) ---
 HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthread_mutex_t)); pthread_mutexattr_t at; pthread_mutexattr_init(&at); pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE); pthread_mutex_init(m, &at); pthread_mutexattr_destroy(&at); *(void**)P(a0) = m; } return 0; }
-HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) interruptible_mutex_lock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
-HLE(m_mtx_unlock) { if (a0 && *(void**)P(a0)) pthread_mutex_unlock((pthread_mutex_t*)*(void**)P(a0)); return 0; }
+// #2596: every one of these used a PRIVATE `if (a0 && *(void**)P(a0))` guard, so a slot holding a
+// STATIC INITIALISER -- NULL for PTHREAD_MUTEX_INITIALIZER, and the other sub-page sentinels FreeBSD
+// uses -- read as "there is no object here" and the operation was SKIPPED ENTIRELY. `_Mtx_lock` then
+// reported success without taking the lock, which is precisely the bdwgc GC_allocate_ml
+// static-mutex shape that was the ROOT CAUSE of the level-1 heap corruption (#793), reached through
+// the other spelling; `_Cnd_wait` reported success for a wait that never happened.
+//
+// The guard is gone in favour of guest_mutex_from_slot / guest_cond_from_slot, which ARE
+// ensure_mutex / ensure_cond -- the same resolution scePthreadMutexLock and scePthreadCondWait use.
+// That is where the guest itself answers the question: its C11 wrappers pass the slot pointer
+// STRAIGHT THROUGH to those entry points and inspect nothing (_Cnd_wait @0x5670 and _Mtx_lock
+// @0x5e80 in the shipped libc.prx, both re-derived through their JMPREL slots for #2596 -- see
+// pthread_slot.hpp), so a private guard here answers a different question from the one libkernel
+// answers. A null slot ADDRESS, and a slot holding the destroyed sentinel, still resolve to nullptr
+// and still skip -- there genuinely is no object.
+//
+// The family moves TOGETHER on purpose. Fixing only the wait would leave `_Mtx_lock` no-opping on a
+// static mutex while `_Cnd_wait` self-initialised and waited on it, i.e. a wait on a mutex nothing
+// had locked -- one spelling of the #1873 shape, where the answer depends on which entry point the
+// guest happened to use. Destroy is NOT in this list: retiring an object the guest never
+// initialised would be a new defect, not a fix.
+HLE(m_mtx_lock)   { if (auto* m = guest_mutex_from_slot(a0)) interruptible_mutex_lock(m); return 0; }
+HLE(m_mtx_unlock) { if (auto* m = guest_mutex_from_slot(a0)) pthread_mutex_unlock(m); return 0; }
 // _Mtx_destroy / _Cnd_destroy are the guest STL's own spelling of the same objects, so they carry
 // the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: quarantine the storage
 // instead of freeing it here, and defer the host destroy to reclaim, because a thread may be parked
@@ -761,9 +783,15 @@ HLE(m_mtx_unlock) { if (a0 && *(void**)P(a0)) pthread_mutex_unlock((pthread_mute
 HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { retire_sync_object(*(void**)P(a0), SyncObjectKind::StlMutex,
                                                           [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } return 0; }
 HLE(m_cnd_init)   { if (a0) { auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)P(a0) = c; } return 0; }
-HLE(m_cnd_signal) { if (a0 && *(void**)P(a0)) interruptible_cond_signal((pthread_cond_t*)*(void**)P(a0)); return 0; }
-HLE(m_cnd_broadcast){ if (a0 && *(void**)P(a0)) interruptible_cond_broadcast((pthread_cond_t*)*(void**)P(a0)); return 0; }
-HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) interruptible_cond_wait((pthread_cond_t*)*(void**)P(a0), (pthread_mutex_t*)*(void**)P(a1)); return 0; }
+HLE(m_cnd_signal) { if (auto* c = guest_cond_from_slot(a0)) interruptible_cond_signal(c); return 0; }
+HLE(m_cnd_broadcast){ if (auto* c = guest_cond_from_slot(a0)) interruptible_cond_broadcast(c); return 0; }
+// The `return 0` here is NOT the defect and must stay. The shipped guest libc.prx's own `_Cnd_wait`
+// is `push rbp; mov rbp,rsp; call <plt scePthreadCondWait>; xor eax,eax; pop rbp; ret` -- it
+// discards the result on every path, so an unconditional 0 is the CONTRACT rather than an oversight
+// (#1983, recorded above k_cond_wait, which is where the reading was made). #2596 is only about the
+// wait not happening. Do not "fix" this line.
+HLE(m_cnd_wait)   { auto* c = guest_cond_from_slot(a0); auto* m = guest_mutex_from_slot(a1);
+                    if (c && m) interruptible_cond_wait(c, m); return 0; }
 HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); interruptible_cond_forget(c); retire_sync_object(c, SyncObjectKind::StlCond,
                                                                        [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); }); } return 0; }
 

--- a/prosper/src/hle/pthread_slot.hpp
+++ b/prosper/src/hle/pthread_slot.hpp
@@ -1,0 +1,42 @@
+// pthread_slot.hpp — resolving a GUEST pthread object slot to the host object it names.
+//
+// A FreeBSD/PS5 pthread object is a POINTER held in guest storage, and a STATICALLY INITIALISED one
+// is a small sentinel (`PTHREAD_MUTEX_INITIALIZER` == NULL, adaptive == 1, …). Real libthr
+// SELF-INITIALISES such an object on first use. prosper does the same in `ensure_mutex` /
+// `ensure_cond` (hle_kernel.cpp), which also REFUSE a destroyed slot (#2170) instead of
+// manufacturing a fresh unheld object, and which install the created object atomically so two
+// threads racing the first use share one host object (#793, #2176).
+//
+// These two declarations exist so the C11 `_Mtx_*` / `_Cnd_*` handlers in hle_kernel_time.cpp reach
+// the SAME resolution rather than carrying a second, weaker copy of it. That is not tidiness: on
+// hardware the C11 spelling resolves its slots through exactly this code, because the guest's own
+// wrappers do not resolve anything themselves. Read out of the shipped libc.prx of PPSA24651 for
+// #2596, each PLT thunk taken to its import through the JMPREL slot rather than by adjacency:
+//
+//   _Cnd_wait  @0x5670 (13 bytes)  push rbp; mov rbp,rsp; call 0x115640; xor eax,eax; pop rbp; ret
+//                                  0x115640 -> GOT 0x192378 -> WKAXJ4XBPQ4 (scePthreadCondWait)
+//   _Mtx_lock  @0x5e80 (29 bytes)  … call 0x115510; cmp eax,0x8002000b; setne cl; add ecx,3; …
+//                                  0x115510 -> GOT 0x1922e0 -> 9UK1vLZQft4 (scePthreadMutexLock)
+//
+// The two differ in what they do with the RESULT — `_Cnd_wait` discards it, `_Mtx_lock` maps it
+// onto a `_Thrd_*` code — and that difference is not the point here. The point is what neither of
+// them does: **inspect the slot**. Each is a single call with the guest's slot pointer passed
+// straight through, so every question about "is this object initialised, destroyed, or a static
+// sentinel" is answered inside libkernel. A private `if (*slot)` guard in prosper's C11 handler
+// answers a DIFFERENT question: it reads a statically initialised object as absent and skips the
+// operation entirely (#2596).
+#pragma once
+
+#include <cstdint>
+#include <pthread.h>
+
+namespace prosper {
+
+// `slot_addr` is the GUEST address of the pointer-sized slot, not the object. Returns nullptr when
+// there is nothing to operate on: a null slot address, or a slot holding the destroyed sentinel
+// (which also logs, once per prefix — see pt_report_destroyed). Any other value either already
+// names a host object or is a static initialiser, and both come back as a usable object.
+pthread_mutex_t* guest_mutex_from_slot(uint64_t slot_addr);
+pthread_cond_t*  guest_cond_from_slot(uint64_t slot_addr);
+
+}  // namespace prosper

--- a/prosper/tests/test_c11_thread_slots.cpp
+++ b/prosper/tests/test_c11_thread_slots.cpp
@@ -1,0 +1,216 @@
+// test_c11_thread_slots — the C11 `_Mtx_*` / `_Cnd_*` handlers must resolve a guest sync slot the
+// same way the libkernel entry point they forward to on hardware resolves it (#2596).
+//
+// THE DEFECT. Each of these handlers opened with a private `if (a0 && *(void**)a0)` guard, so a slot
+// holding a STATIC INITIALISER — NULL for `PTHREAD_MUTEX_INITIALIZER`, and every other sub-page
+// sentinel FreeBSD uses — read as "there is no object here" and the operation was SKIPPED. For
+// `_Cnd_wait` that means the handler reported success for a wait that never happened: a predicate
+// loop is told its condition fired when nothing was ever waited on, so it spins or proceeds on
+// unsatisfied state. For `_Mtx_lock` it means the critical section ran unguarded — the same shape as
+// the bdwgc `GC_allocate_ml` static-mutex bug that was the ROOT CAUSE of the level-1 heap
+// corruption (#793), reached through the other spelling.
+//
+// WHAT IS NOT THE DEFECT, and this test must not be "fixed" into asserting it: `_Cnd_wait` returning
+// 0 unconditionally is CORRECT. The shipped guest libc.prx's own `_Cnd_wait` is
+// `push rbp; mov rbp,rsp; call <plt scePthreadCondWait>; xor eax,eax; pop rbp; ret` — it discards
+// the result on every path, so an unconditional 0 is the contract rather than a defect (#1983,
+// recorded in the code above `k_cond_wait`). Every arm below therefore asserts what the handler DID,
+// never what it returned.
+//
+// WHAT EACH ARM KILLS. Every row below was MEASURED — the mutation applied, rebuilt, re-run — not
+// predicted, so a future reader can check they still bite:
+//   N1  restore `if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1))` on m_cnd_wait
+//                                          -> FAIL (2): §1's "still WAITING 200 ms later" arm and
+//                                             its "both slots SELF-INITIALISED" companion. §1's
+//                                             wake arm PASSES under N1, because a wait that never
+//                                             happened has already "returned".
+//   N2  restore the guard on m_mtx_lock    -> FAIL (2): §2's "self-initialised into a real host
+//                                             mutex" and "a second thread BLOCKS"
+//   N3  make m_cnd_broadcast skip again    -> FAIL (2): the wake arm of §1 AND of §3 — nobody is
+//                                             ever woken, and the bounded retry reports it as a
+//                                             failure rather than hanging
+//   N4  make guest_cond_from_slot refuse an ALREADY-INITIALISED slot (sentinels only)
+//                                          -> FAIL (2): §1's wake arm and §3's "an initialised
+//                                             _Cnd_wait waits too". This is the arm §3 exists for:
+//                                             §1 and §2 both pass under it, so without §3 a change
+//                                             that fixed the sentinel path by breaking the ordinary
+//                                             one would land green.
+//
+// No single arm covers another: N1/N2 are blind to N3 and N4 (both leave the wait blocking, which
+// is what they assert), and N3/N4 are blind to N1/N2 (a skipped wait "returns" immediately, which
+// satisfies every wake arm).
+//
+// HANG SAFETY. Every worker here is DETACHED and every wait is bounded, deliberately: a regression
+// in this area is a thread that never wakes, and a test that expresses that as a hang burns ctest's
+// timeout and gets reported as an infrastructure problem — on a box that regularly runs at load 30+
+// a real regression would then be blamed on machine load. Each arm fails and the process exits.
+
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <pthread.h>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+HleFn mtx_lock = nullptr, mtx_unlock = nullptr, mtx_init = nullptr;
+HleFn cnd_wait = nullptr, cnd_broadcast = nullptr, cnd_init = nullptr;
+
+// A statically-initialised guest cnd_t / mtx_t pair: the slot holds NULL, which is exactly what
+// `PTHREAD_MUTEX_INITIALIZER` puts there on the guest's platform. File-scope so a detached worker
+// can never outlive the storage (the hazard §9 of test_pthread_error_encoding records).
+void* g_static_cnd = nullptr;
+void* g_static_mtx = nullptr;
+std::atomic<int> g_waiter_entered{0};
+std::atomic<int> g_wait_returned{0};
+
+void* static_waiter(void*) {
+    mtx_lock((uint64_t)(uintptr_t)&g_static_mtx, 0, 0, 0, 0, 0);
+    g_waiter_entered.store(1, std::memory_order_release);
+    cnd_wait((uint64_t)(uintptr_t)&g_static_cnd, (uint64_t)(uintptr_t)&g_static_mtx, 0, 0, 0, 0);
+    g_wait_returned.store(1, std::memory_order_release);
+    mtx_unlock((uint64_t)(uintptr_t)&g_static_mtx, 0, 0, 0, 0, 0);
+    return nullptr;
+}
+
+void* g_contended_mtx = nullptr;
+std::atomic<int> g_second_locked{0};
+
+void* second_locker(void*) {
+    mtx_lock((uint64_t)(uintptr_t)&g_contended_mtx, 0, 0, 0, 0, 0);
+    g_second_locked.store(1, std::memory_order_release);
+    mtx_unlock((uint64_t)(uintptr_t)&g_contended_mtx, 0, 0, 0, 0, 0);
+    return nullptr;
+}
+
+void* g_init_cnd = nullptr;
+void* g_init_mtx = nullptr;
+std::atomic<int> g_init_entered{0};
+std::atomic<int> g_init_returned{0};
+
+void* initialised_waiter(void*) {
+    mtx_lock((uint64_t)(uintptr_t)&g_init_mtx, 0, 0, 0, 0, 0);
+    g_init_entered.store(1, std::memory_order_release);
+    cnd_wait((uint64_t)(uintptr_t)&g_init_cnd, (uint64_t)(uintptr_t)&g_init_mtx, 0, 0, 0, 0);
+    g_init_returned.store(1, std::memory_order_release);
+    mtx_unlock((uint64_t)(uintptr_t)&g_init_mtx, 0, 0, 0, 0, 0);
+    return nullptr;
+}
+
+bool spin_until(const std::atomic<int>& flag, int deciseconds) {
+    for (int i = 0; i < deciseconds * 100 && !flag.load(std::memory_order_acquire); ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return flag.load(std::memory_order_acquire) != 0;
+}
+
+// Broadcast in a bounded retry loop rather than once. A single broadcast races the waiter's own
+// entry into the wait, and a lost wakeup would express itself as a HANG — which is the one failure
+// mode this file must not have. The retry turns it into a failed assertion.
+bool broadcast_until_awake(void* cnd_slot, void* mtx_slot, const std::atomic<int>& flag) {
+    for (int i = 0; i < 300 && !flag.load(std::memory_order_acquire); ++i) {
+        mtx_lock((uint64_t)(uintptr_t)mtx_slot, 0, 0, 0, 0, 0);
+        cnd_broadcast((uint64_t)(uintptr_t)cnd_slot, 0, 0, 0, 0, 0);
+        mtx_unlock((uint64_t)(uintptr_t)mtx_slot, 0, 0, 0, 0, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return flag.load(std::memory_order_acquire) != 0;
+}
+
+bool spawn_detached(void* (*body)(void*)) {
+    pthread_t t{};
+    if (pthread_create(&t, nullptr, body, nullptr) != 0) return false;
+    pthread_detach(t);
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    printf("== test_c11_thread_slots ==\n");
+    register_builtin_hle();
+
+    mtx_init      = Hle::lookup(nid_hash("_Mtx_init"));
+    mtx_lock      = Hle::lookup(nid_hash("_Mtx_lock"));
+    mtx_unlock    = Hle::lookup(nid_hash("_Mtx_unlock"));
+    cnd_init      = Hle::lookup(nid_hash("_Cnd_init"));
+    cnd_wait      = Hle::lookup(nid_hash("_Cnd_wait"));
+    cnd_broadcast = Hle::lookup(nid_hash("_Cnd_broadcast"));
+    CHECK(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast,
+          "the C11 _Mtx_* / _Cnd_* handlers are registered");
+    if (!(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast)) {
+        printf("== FAIL (%d) ==\n", ++fails);
+        return 1;
+    }
+
+    // ===== 1. a _Cnd_wait on a STATICALLY INITIALISED cnd_t must actually wait ==================
+    // The arm is "did it block", not "what did it return", because the return is 0 either way and
+    // always will be — see the header. Before #2596 the null slot short-circuited the whole body,
+    // so the wait returned within microseconds of being entered.
+    printf("-- _Cnd_wait on a static cnd_t waits instead of returning immediately --\n");
+    {
+        CHECK(spawn_detached(static_waiter), "control: the waiter thread starts");
+        CHECK(spin_until(g_waiter_entered, 5), "control: the waiter reached its _Cnd_wait");
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        CHECK(g_wait_returned.load(std::memory_order_acquire) == 0,
+              "_Cnd_wait on a statically-initialised cnd_t is still WAITING 200 ms later — it used "
+              "to skip the wait entirely and report success for a wait that never happened");
+        CHECK(g_static_cnd != nullptr && g_static_mtx != nullptr,
+              "…and both slots SELF-INITIALISED: each now names a real host object, the same way "
+              "scePthreadCondWait resolves them (#793 / #2170), which is the mechanism the arm "
+              "above observes rather than a second assertion of it");
+        CHECK(broadcast_until_awake(&g_static_cnd, &g_static_mtx, g_wait_returned),
+              "…and the wait RETURNS once the condition is broadcast (a wait that blocks forever "
+              "would be a worse defect than the one being fixed)");
+    }
+
+    // ===== 2. _Mtx_lock on a static mtx_t must really take the lock ============================
+    // The same guard, on the handler where skipping it is the #793 heap-corruption shape: a guest
+    // whose lock silently does nothing runs its critical section unguarded and reports success.
+    printf("-- _Mtx_lock on a static mtx_t really excludes a second thread --\n");
+    {
+        mtx_lock((uint64_t)(uintptr_t)&g_contended_mtx, 0, 0, 0, 0, 0);
+        CHECK(g_contended_mtx != nullptr,
+              "control: the static slot self-initialised into a real host mutex");
+        CHECK(spawn_detached(second_locker), "control: a second locker thread starts");
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        CHECK(g_second_locked.load(std::memory_order_acquire) == 0,
+              "a second thread's _Mtx_lock BLOCKS while this one holds it — it used to no-op and "
+              "let both threads into the critical section");
+        mtx_unlock((uint64_t)(uintptr_t)&g_contended_mtx, 0, 0, 0, 0, 0);
+        CHECK(spin_until(g_second_locked, 5),
+              "…and it acquires as soon as the holder releases");
+    }
+
+    // ===== 3. the ORDINARY initialised path is unchanged =======================================
+    // A regression guard rather than a discriminator for #2596: these slots never hold a sentinel,
+    // so they exercise the branch the change does not touch. It is here because the obvious way to
+    // get §1 and §2 green is to make the handlers unconditional, and that would break nothing
+    // visible without this section.
+    printf("-- _Mtx_init / _Cnd_init objects still lock, wait and wake --\n");
+    {
+        CHECK(mtx_init((uint64_t)(uintptr_t)&g_init_mtx, 0, 0, 0, 0, 0) == 0 && g_init_mtx,
+              "control: _Mtx_init produces an object");
+        CHECK(cnd_init((uint64_t)(uintptr_t)&g_init_cnd, 0, 0, 0, 0, 0) == 0 && g_init_cnd,
+              "control: _Cnd_init produces an object");
+        CHECK(spawn_detached(initialised_waiter), "control: the waiter thread starts");
+        CHECK(spin_until(g_init_entered, 5), "control: the waiter reached its _Cnd_wait");
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        CHECK(g_init_returned.load(std::memory_order_acquire) == 0,
+              "an initialised _Cnd_wait waits too");
+        CHECK(broadcast_until_awake(&g_init_cnd, &g_init_mtx, g_init_returned),
+              "…and wakes on _Cnd_broadcast");
+    }
+
+    if (fails) printf("== FAIL (%d) ==\n", fails);
+    else       printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/test_c11_thread_slots.cpp
+++ b/prosper/tests/test_c11_thread_slots.cpp
@@ -246,8 +246,8 @@ int main() {
     // signal/broadcast half of the change at all, however the mutation is phrased. A positive
     // control that has already resolved the thing under test is not a control.
     //
-    // WHAT THESE TWO ARMS ARE FOR, stated carefully because the first revision of this block gave a
-    // reason that CANNOT HAPPEN. It said a skipped signal "would be signalling an object no waiter
+    // WHAT THESE THREE ARMS ARE FOR, stated carefully because the first revision of this block gave
+    // a reason that CANNOT HAPPEN. It said a skipped signal "would be signalling an object no waiter
     // will ever use". There is no such waiter: `ensure_cond` installs the object with a CAS before
     // returning it, and `m_cnd_wait` can only park on what it returns, so a slot still holding a
     // sentinel has nobody parked on it by construction. On a NULL sentinel a skipped broadcast
@@ -255,15 +255,22 @@ int main() {
     // replaced because a plausible-but-impossible failure mode in a test's rationale is exactly what
     // stops the next reader questioning the arm.
     //
-    // The two things these arms really establish:
-    //   1. CROSS-SPELLING PARITY, which is this PR's whole thesis (#1873). `k_cond_broadcast` and
-    //      `k_mutex_unlock` resolve the identical guest slot for the identical input. §4 is the only
-    //      place in the suite that asserts the C11 spelling agrees, and the only place the resolver
-    //      is exercised on the signal side at all.
-    //   2. THE CRASH PATH. The old guard tested the slot's VALUE, so it was TRUE for every sentinel
-    //      except NULL: sentinel 1 and the destroyed poison kPtDestroyed (0xDEA) were dereferenced
-    //      as object pointers. Routing through the resolver is what turns
-    //      `interruptible_cond_broadcast((pthread_cond_t*)0xDEA)` into a refusal.
+    // WHAT THE THREE ARMS ESTABLISH -- one thing, not two:
+    //   CROSS-SPELLING PARITY, which is this PR's whole thesis (#1873). `k_cond_signal`,
+    //   `k_cond_broadcast` and `k_mutex_unlock` resolve the identical guest slot for the identical
+    //   input. §4 is the only place in the suite that asserts the C11 spelling agrees, and the only
+    //   place the resolver is exercised on the signal side at all.
+    //
+    // WHAT THEY DO NOT ESTABLISH, though the change fixes it: THE CRASH PATH. The old guard tested
+    // the slot's VALUE, so it was TRUE for every sentinel except NULL -- sentinel 1 and the destroyed
+    // poison kPtDestroyed (0xDEA) were dereferenced as object pointers, and routing through the
+    // resolver turns `interruptible_cond_broadcast((pthread_cond_t*)0xDEA)` into a refusal. Every
+    // clause of that is true and NO ARM BELOW SHOWS IT: all three slots here hold nullptr, so nothing
+    // in this file exercises a non-NULL sentinel. Correctness by construction, not by measurement.
+    // An arm that stored `(void*)1` would not fix that -- under the mutation it would SIGSEGV rather
+    // than fail an assertion, which is a worse instrument than none. The third reviewer caught this
+    // attribution, and it is the SAME class as the retraction three paragraphs up: a true statement
+    // filed under an arm that cannot support it.
     // The observable is the resolution itself, because a broadcast to a condvar with no waiters has
     // no other effect to assert.
     printf("-- _Cnd_signal / _Cnd_broadcast / _Mtx_unlock resolve a slot no wait has touched --\n");

--- a/prosper/tests/test_c11_thread_slots.cpp
+++ b/prosper/tests/test_c11_thread_slots.cpp
@@ -26,7 +26,8 @@
 //                                             happened has already "returned".
 //   N2  restore the guard on m_mtx_lock    -> FAIL (2): §2's "self-initialised into a real host
 //                                             mutex" and "a second thread BLOCKS"
-//   N3  make m_cnd_broadcast skip again    -> FAIL (2): the wake arm of §1 AND of §3 — nobody is
+//   N3  make m_cnd_broadcast never broadcast AT ALL (`if (false && a0)`)
+//                                          -> FAIL (2): the wake arm of §1 AND of §3 — nobody is
 //                                             ever woken, and the bounded retry reports it as a
 //                                             failure rather than hanging
 //   N4  make guest_cond_from_slot refuse an ALREADY-INITIALISED slot (sentinels only)
@@ -35,10 +36,24 @@
 //                                             §1 and §2 both pass under it, so without §3 a change
 //                                             that fixed the sentinel path by breaking the ordinary
 //                                             one would land green.
+//   N5  restore the OLD GUARD on m_cnd_broadcast (`if (a0 && *(void**)P(a0))`)
+//                                          -> FAIL (1): §4's `_Cnd_broadcast` arm, and ONLY that
+//                                             one. §1, §2 and §3 all pass under it — see §4.
+//   N6  restore the OLD GUARD on m_mtx_unlock
+//                                          -> FAIL (1): §4's `_Mtx_unlock` arm, and only that one.
 //
-// No single arm covers another: N1/N2 are blind to N3 and N4 (both leave the wait blocking, which
-// is what they assert), and N3/N4 are blind to N1/N2 (a skipped wait "returns" immediately, which
-// satisfies every wake arm).
+// N3 AND N5 ARE DIFFERENT MUTATIONS, and an earlier revision of this header ran N3 while describing
+// N5. A reviewer caught the mismatch by reading, and measuring the arm they described produced
+// something worse than either of us predicted: with the old guard genuinely restored the suite
+// passed COMPLETELY. §4 exists because of that, and the header now names the exact lever each row
+// pulls rather than a paraphrase of it — a row describing a mutation nobody ran is how coverage
+// that does not exist gets believed (the shape #2573 corrected in its own M5 row).
+//
+// No single arm covers another: N1/N2 are blind to N3-N6 (all of those leave the wait blocking,
+// which is what N1/N2 assert), N3/N4 are blind to N1/N2 (a skipped wait "returns" immediately,
+// satisfying every wake arm), and N5/N6 are invisible to every section except §4. N3 kills §4's
+// broadcast arm as well as the two wake arms, which is why its count is 3 — a broadcast that never
+// fires also never resolves.
 //
 // HANG SAFETY. Every worker here is DETACHED and every wait is bounded, deliberately: a regression
 // in this area is a thread that never wakes, and a test that expresses that as a hang burns ctest's
@@ -212,6 +227,37 @@ int main() {
               "an initialised _Cnd_wait waits too");
         CHECK(broadcast_until_awake(&g_init_cnd, &g_init_mtx, g_init_returned),
               "…and wakes on _Cnd_broadcast");
+    }
+
+    // ===== 4. the SIGNAL side, on a slot no wait has resolved yet ==============================
+    // THIS SECTION EXISTS BECAUSE ITS ABSENCE WAS INVISIBLE, and the way that came out is worth
+    // recording. A reviewer questioned the N3 row and derived that restoring the old guard on
+    // `m_cnd_broadcast` should fail only §1's wake arm, not §3's. Measuring it produced something
+    // worse than either reading: restoring the guard made the suite pass **completely**.
+    //
+    // The reason is structural, not a fluke. §1 and §3 both WAIT before they broadcast, and the
+    // wait self-initialises the slot — so by the time any broadcast runs, every slot in this file
+    // already holds a real pointer and the old guard is satisfied. Those sections therefore cannot
+    // see the signal/broadcast half of the change AT ALL, however the mutation is phrased. A
+    // positive control that has already resolved the thing under test is not a control.
+    //
+    // The only observable that discriminates is the resolution itself, on a slot NOTHING has waited
+    // on: after the call the slot must NAME AN OBJECT. That is not an implementation detail — it is
+    // the whole mechanism, because a later waiter resolves the same slot, so a signal that skipped
+    // it would be signalling an object no waiter will ever use. Nothing weaker works here: a
+    // broadcast to an empty condvar has no other effect to assert.
+    printf("-- _Cnd_broadcast / _Mtx_unlock resolve a slot no wait has touched --\n");
+    {
+        static void* untouched_cnd = nullptr;   // a static sentinel, never waited on
+        static void* untouched_mtx = nullptr;
+        cnd_broadcast((uint64_t)(uintptr_t)&untouched_cnd, 0, 0, 0, 0, 0);
+        CHECK(untouched_cnd != nullptr,
+              "_Cnd_broadcast RESOLVES a statically-initialised cnd_t rather than skipping it — the "
+              "slot now names the same object a later _Cnd_wait will resolve");
+        mtx_unlock((uint64_t)(uintptr_t)&untouched_mtx, 0, 0, 0, 0, 0);
+        CHECK(untouched_mtx != nullptr,
+              "_Mtx_unlock likewise resolves rather than skipping, so the C11 family agrees with "
+              "itself about what a static sentinel means");
     }
 
     if (fails) printf("== FAIL (%d) ==\n", fails);

--- a/prosper/tests/test_c11_thread_slots.cpp
+++ b/prosper/tests/test_c11_thread_slots.cpp
@@ -106,8 +106,12 @@ void* initialised_waiter(void*) {
     return nullptr;
 }
 
-bool spin_until(const std::atomic<int>& flag, int deciseconds) {
-    for (int i = 0; i < deciseconds * 100 && !flag.load(std::memory_order_acquire); ++i)
+// Deliberately GENEROUS, and only ever used for CONTROLS — "did the worker start", "did it acquire
+// after the release". None of them is a timing assertion, so a tight bound here would only turn
+// machine load into a red build on a box that routinely runs at load 30+. The one assertion in this
+// file that IS about timing — "still waiting 200 ms later" — does not go through this helper.
+bool spin_until(const std::atomic<int>& flag, int seconds) {
+    for (int i = 0; i < seconds * 1000 && !flag.load(std::memory_order_acquire); ++i)
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     return flag.load(std::memory_order_acquire) != 0;
 }

--- a/prosper/tests/test_c11_thread_slots.cpp
+++ b/prosper/tests/test_c11_thread_slots.cpp
@@ -27,9 +27,10 @@
 //   N2  restore the guard on m_mtx_lock    -> FAIL (2): §2's "self-initialised into a real host
 //                                             mutex" and "a second thread BLOCKS"
 //   N3  make m_cnd_broadcast never broadcast AT ALL (`if (false && a0)`)
-//                                          -> FAIL (2): the wake arm of §1 AND of §3 — nobody is
+//                                          -> FAIL (3): the wake arm of §1 AND of §3 — nobody is
 //                                             ever woken, and the bounded retry reports it as a
-//                                             failure rather than hanging
+//                                             failure rather than hanging — PLUS §4's broadcast arm,
+//                                             because a broadcast that never fires never resolves
 //   N4  make guest_cond_from_slot refuse an ALREADY-INITIALISED slot (sentinels only)
 //                                          -> FAIL (2): §1's wake arm and §3's "an initialised
 //                                             _Cnd_wait waits too". This is the arm §3 exists for:
@@ -41,6 +42,11 @@
 //                                             one. §1, §2 and §3 all pass under it — see §4.
 //   N6  restore the OLD GUARD on m_mtx_unlock
 //                                          -> FAIL (1): §4's `_Mtx_unlock` arm, and only that one.
+//   N7  restore the OLD GUARD on m_cnd_signal
+//                                          -> FAIL (1): §4's `_Cnd_signal` arm, and only that one.
+//                                             `_Cnd_signal` is one of the five handlers this change
+//                                             moves and had NO arm at all until a reviewer pointed
+//                                             out that restoring its guard failed nothing.
 //
 // N3 AND N5 ARE DIFFERENT MUTATIONS, and an earlier revision of this header ran N3 while describing
 // N5. A reviewer caught the mismatch by reading, and measuring the arm they described produced
@@ -78,7 +84,7 @@ static int fails = 0;
 namespace {
 
 HleFn mtx_lock = nullptr, mtx_unlock = nullptr, mtx_init = nullptr;
-HleFn cnd_wait = nullptr, cnd_broadcast = nullptr, cnd_init = nullptr;
+HleFn cnd_wait = nullptr, cnd_broadcast = nullptr, cnd_init = nullptr, cnd_signal = nullptr;
 
 // A statically-initialised guest cnd_t / mtx_t pair: the slot holds NULL, which is exactly what
 // `PTHREAD_MUTEX_INITIALIZER` puts there on the guest's platform. File-scope so a detached worker
@@ -163,9 +169,10 @@ int main() {
     cnd_init      = Hle::lookup(nid_hash("_Cnd_init"));
     cnd_wait      = Hle::lookup(nid_hash("_Cnd_wait"));
     cnd_broadcast = Hle::lookup(nid_hash("_Cnd_broadcast"));
-    CHECK(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast,
+    cnd_signal    = Hle::lookup(nid_hash("_Cnd_signal"));
+    CHECK(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast && cnd_signal,
           "the C11 _Mtx_* / _Cnd_* handlers are registered");
-    if (!(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast)) {
+    if (!(mtx_init && mtx_lock && mtx_unlock && cnd_init && cnd_wait && cnd_broadcast && cnd_signal)) {
         printf("== FAIL (%d) ==\n", ++fails);
         return 1;
     }
@@ -230,30 +237,55 @@ int main() {
     }
 
     // ===== 4. the SIGNAL side, on a slot no wait has resolved yet ==============================
-    // THIS SECTION EXISTS BECAUSE ITS ABSENCE WAS INVISIBLE, and the way that came out is worth
-    // recording. A reviewer questioned the N3 row and derived that restoring the old guard on
-    // `m_cnd_broadcast` should fail only §1's wake arm, not §3's. Measuring it produced something
-    // worse than either reading: restoring the guard made the suite pass **completely**.
+    // THIS SECTION EXISTS BECAUSE ITS ABSENCE WAS INVISIBLE. A reviewer questioned the N3 row and
+    // derived that restoring the old guard on `m_cnd_broadcast` should fail only §1's wake arm.
+    // Measuring it produced something worse than either reading: restoring the guard made the suite
+    // pass COMPLETELY. The reason is structural — §1 and §3 both WAIT before they broadcast, and the
+    // wait self-initialises the slot, so by the time any broadcast runs every slot in this file
+    // already holds a real pointer and the old guard is satisfied. Those sections cannot see the
+    // signal/broadcast half of the change at all, however the mutation is phrased. A positive
+    // control that has already resolved the thing under test is not a control.
     //
-    // The reason is structural, not a fluke. §1 and §3 both WAIT before they broadcast, and the
-    // wait self-initialises the slot — so by the time any broadcast runs, every slot in this file
-    // already holds a real pointer and the old guard is satisfied. Those sections therefore cannot
-    // see the signal/broadcast half of the change AT ALL, however the mutation is phrased. A
-    // positive control that has already resolved the thing under test is not a control.
+    // WHAT THESE TWO ARMS ARE FOR, stated carefully because the first revision of this block gave a
+    // reason that CANNOT HAPPEN. It said a skipped signal "would be signalling an object no waiter
+    // will ever use". There is no such waiter: `ensure_cond` installs the object with a CAS before
+    // returning it, and `m_cnd_wait` can only park on what it returns, so a slot still holding a
+    // sentinel has nobody parked on it by construction. On a NULL sentinel a skipped broadcast
+    // therefore loses NOTHING. A second reviewer caught that, and it is recorded rather than quietly
+    // replaced because a plausible-but-impossible failure mode in a test's rationale is exactly what
+    // stops the next reader questioning the arm.
     //
-    // The only observable that discriminates is the resolution itself, on a slot NOTHING has waited
-    // on: after the call the slot must NAME AN OBJECT. That is not an implementation detail — it is
-    // the whole mechanism, because a later waiter resolves the same slot, so a signal that skipped
-    // it would be signalling an object no waiter will ever use. Nothing weaker works here: a
-    // broadcast to an empty condvar has no other effect to assert.
-    printf("-- _Cnd_broadcast / _Mtx_unlock resolve a slot no wait has touched --\n");
+    // The two things these arms really establish:
+    //   1. CROSS-SPELLING PARITY, which is this PR's whole thesis (#1873). `k_cond_broadcast` and
+    //      `k_mutex_unlock` resolve the identical guest slot for the identical input. §4 is the only
+    //      place in the suite that asserts the C11 spelling agrees, and the only place the resolver
+    //      is exercised on the signal side at all.
+    //   2. THE CRASH PATH. The old guard tested the slot's VALUE, so it was TRUE for every sentinel
+    //      except NULL: sentinel 1 and the destroyed poison kPtDestroyed (0xDEA) were dereferenced
+    //      as object pointers. Routing through the resolver is what turns
+    //      `interruptible_cond_broadcast((pthread_cond_t*)0xDEA)` into a refusal.
+    // The observable is the resolution itself, because a broadcast to a condvar with no waiters has
+    // no other effect to assert.
+    printf("-- _Cnd_signal / _Cnd_broadcast / _Mtx_unlock resolve a slot no wait has touched --\n");
     {
-        static void* untouched_cnd = nullptr;   // a static sentinel, never waited on
+        static void* untouched_signal_cnd = nullptr;   // static sentinels, never waited on
+        static void* untouched_bcast_cnd = nullptr;
         static void* untouched_mtx = nullptr;
-        cnd_broadcast((uint64_t)(uintptr_t)&untouched_cnd, 0, 0, 0, 0, 0);
-        CHECK(untouched_cnd != nullptr,
-              "_Cnd_broadcast RESOLVES a statically-initialised cnd_t rather than skipping it — the "
-              "slot now names the same object a later _Cnd_wait will resolve");
+        // `_Cnd_signal` gets its own slot rather than sharing the broadcast one: it is one of the
+        // five handlers this change moves, and without an arm of its own restoring its old guard
+        // would fail nothing in this file.
+        cnd_signal((uint64_t)(uintptr_t)&untouched_signal_cnd, 0, 0, 0, 0, 0);
+        CHECK(untouched_signal_cnd != nullptr,
+              "_Cnd_signal RESOLVES a statically-initialised cnd_t rather than skipping it — the "
+              "same slot, and the same answer, scePthreadCondSignal gives for this input");
+        cnd_broadcast((uint64_t)(uintptr_t)&untouched_bcast_cnd, 0, 0, 0, 0, 0);
+        CHECK(untouched_bcast_cnd != nullptr,
+              "_Cnd_broadcast likewise resolves rather than skipping");
+        // NOTE for anyone reading this arm as evidence of more than it shows: unlocking a mutex this
+        // thread never locked is UNDEFINED under POSIX for a non-ERRORCHECK mutex. It is benign on
+        // glibc, and it is exactly what k_mutex_unlock already does for the same input, which is why
+        // it is acceptable here — but the arm asserts that the slot was RESOLVED, not that the
+        // unlock is defined.
         mtx_unlock((uint64_t)(uintptr_t)&untouched_mtx, 0, 0, 0, 0, 0);
         CHECK(untouched_mtx != nullptr,
               "_Mtx_unlock likewise resolves rather than skipping, so the C11 family agrees with "


### PR DESCRIPTION
Fixes #2596
Refs #2619

## Summary

The C11 `_Mtx_*` / `_Cnd_*` handlers each opened with a **private** `if (a0 && *(void**)P(a0))`
guard, so a slot holding a **static initialiser** — `NULL` for `PTHREAD_MUTEX_INITIALIZER`, and the
other sub-page sentinels FreeBSD uses — read as *"there is no object here"* and the operation was
**skipped entirely**:

```cpp
HLE(m_cnd_wait)   { if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1)) interruptible_cond_wait(…); return 0; }
HLE(m_mtx_lock)   { if (a0 && *(void**)P(a0)) interruptible_mutex_lock(…); return 0; }
```

`_Cnd_wait` then reported success for a wait that never happened — a predicate loop is told its
condition fired when nothing was ever waited on. `_Mtx_lock` reported success without taking the
lock, which is precisely the bdwgc `GC_allocate_ml` static-mutex shape that was the **root cause**
of the level-1 heap corruption (#793), reached through the other spelling.

## The scope boundary, which is the load-bearing part of this PR

**`_Cnd_wait` returning `0` unconditionally is CORRECT and stays.** #2573 established it and said so
in a code comment above `k_cond_wait`, and this PR re-derived it rather than inheriting it: the
shipped guest `libc.prx` of `PPSA24651` exports `_Cnd_wait` at `0x5670`, **13 bytes**:

```
5670: push rbp; mov rbp,rsp
5674: call 0x115640          ; -> GOT 0x192378 -> WKAXJ4XBPQ4 (scePthreadCondWait)
5679: xor  eax,eax           ; DISCARDS the result, on every path
567b: pop  rbp; ret
```

So an unconditional `0` is the **contract**, not an oversight, and the fix is not "capture the
result" — it is to stop short-circuiting the call. **Every arm in the new test asserts what the
handler DID (blocked, excluded a second thread, self-initialised the slot), never what it
returned**, and the code says the same above `m_cnd_wait` so the next reader does not "fix" it.

## Why the whole family moves, not just the wait

Because the C11 wrappers **do not resolve anything themselves** — the guest's own answer to "is this
object initialised, destroyed, or a static sentinel" is given inside libkernel, in the code prosper
already has. Re-derived for this PR, each PLT thunk taken to its import through the JMPREL slot:

| guest export | size | shape | resolves to |
| --- | --- | --- | --- |
| `_Cnd_wait` `@0x5670` | 13 B | `call`, `xor eax,eax` — discards | `WKAXJ4XBPQ4` `scePthreadCondWait` |
| `_Mtx_lock` `@0x5e80` | 29 B | `call`, `cmp eax,0x8002000b`, `setne cl`, `add ecx,3` — maps onto `_Thrd_*` | `9UK1vLZQft4` `scePthreadMutexLock` |
| `_Mtx_unlock` `@0x5e70` | 13 B | bare forwarder | *(same family)* |

They differ in what they do with the **result**; what none of them does is **inspect the slot**.
Each passes the guest's slot pointer straight through. So a private guard in prosper's C11 handler
answers a different question from the one libkernel answers — and fixing only the wait would leave
`_Mtx_lock` no-opping on a static mutex while `_Cnd_wait` self-initialised the same mutex and waited
on it, i.e. **a wait on a mutex nothing had locked**. That is the #1873 shape (one question, two
spellings, two answers) introduced by a partial fix, so the five non-destroy handlers move together.

**Destroy is deliberately NOT in this change.** It needs claim-and-poison semantics
(`pt_claim_slot`), not self-initialising resolution — retiring an object the guest never initialised
would be a new defect. `_Mtx_destroy` / `_Cnd_destroy` have their own defects of the same family
(a double-destroy is a **double free**, and a slot already destroyed through the Sony spelling is
dereferenced as a pointer); filed separately as **#2619** with the file:line and the mechanism.

## Approach

A new `src/hle/pthread_slot.hpp` publishes the two resolvers that already exist —
`guest_mutex_from_slot` / `guest_cond_from_slot` are one-line wrappers over `ensure_mutex` /
`ensure_cond` in `hle_kernel.cpp`. Those hold the whole contract: FreeBSD static sentinels
self-initialise (#793), a destroyed slot is refused loudly rather than replaced with a fresh unheld
object (#2170), and the created object is installed with a compare-exchange so racing first uses
share one host object (#2176). One place, both spellings — the rule the charter states for #1873.

A null slot **address**, and a slot holding the destroyed sentinel, still resolve to `nullptr` and
still skip: there genuinely is no object, and libkernel refuses those too.

## Blast radius — measured, because widening the family deserves it

**Every one of the 44 dumps on this machine ships `sce_module/libc.prx`**, which *exports* the whole
`_Mtx_*` / `_Cnd_*` family (`self_dump --find-symbol`: `_Cnd_wait` `vEaqE-7IZYc` @`0x5670`,
`_Mtx_lock` `iS4aWbUonl0` @`0x5e80`, …), and the loader resolves imports by NID with *"cross-module
export beats a stub slot"* (`src/loader/linker.cpp:109-119`). So on those titles the guest's own
implementation wins and **prosper's C11 handlers are never bound** — the guest routes the C11
spelling into the `scePthread*` path #2573 already fixed.

Corroborated dynamically, with its own positive control in the same line. A 90 s headless
`boot_trace`, both titles:

```
PPSA24651  [sync] … destroyed so far: mutex=65530 cond=6     rwlock=0 … _Mtx=0 _Cnd=0
PPSA25009  [sync] … destroyed so far: mutex=52874 cond=12662 rwlock=0 … _Mtx=0 _Cnd=0
```

The `_Mtx` / `_Cnd` columns stay at zero while the same counter records tens of thousands of
Sony-spelling destroys, which is what shows the counter works rather than being dead. **The honest
limit:** that is a *destroy* census, so it does not by itself prove no `_Mtx_lock` ran — the linker
argument is what carries "never bound", and the census is corroboration.

So the change is correct-by-contract and inert on every title available here. It is worth landing
anyway for the reason #2596 gives: a title that does not ship `libc.prx`, or that imports one of
these under a spelling `libc.prx` does not export, binds prosper's handler and gets the defect.

## Tests

New `tests/test_c11_thread_slots.cpp` (ctest `c11_thread_slots`). Every arm asserts behaviour, not a
return value:

1. **`_Cnd_wait` on a static `cnd_t` blocks** — the waiter is still inside the wait 200 ms later,
   both slots now name real host objects, and the wait **returns** once broadcast.
2. **`_Mtx_lock` on a static `mtx_t` really excludes** — a second thread's `_Mtx_lock` does not
   complete while this one holds it, and acquires as soon as it is released.
3. **The ordinary `_Mtx_init` / `_Cnd_init` path is unchanged** — a regression guard, because the
   obvious way to make (1) and (2) green is to make the handlers unconditional.
4. **`_Cnd_signal` / `_Cnd_broadcast` / `_Mtx_unlock` resolve a slot nothing has waited on.** The
   only arms that can see the signal side at all — §1 and §3 both *wait* before they broadcast, so
   by then the slot is already resolved and the old guard is satisfied. Added in review; see the
   section below for what these arms do and do not establish.

**Hang safety is designed in, not incidental.** A regression here is a thread that never wakes, and
a test that expresses that as a hang burns ctest's timeout and gets reported as infrastructure — on
a shared box that becomes "machine load" rather than a real regression (the hazard #2573's review
caught in its own §7). Every worker is detached, every wait is bounded, and the wake path
broadcasts in a bounded retry loop so a lost wakeup fails an assertion instead of hanging.

### Mutation arms — each measured by reverting exactly one piece, rebuilding, re-running

| # | mutation | result |
| --- | --- | --- |
| N1 | restore `if (a0 && *(void**)P(a0) && a1 && *(void**)P(a1))` on `m_cnd_wait` | **FAIL (2)** §1's "still WAITING 200 ms later" and "both slots SELF-INITIALISED" |
| N2 | restore the guard on `m_mtx_lock` | **FAIL (2)** §2's "self-initialised into a real host mutex" and "a second thread BLOCKS" |
| N3 | make `m_cnd_broadcast` never broadcast at all (`if (false && a0)`) | **FAIL (3)** the wake arm of §1 and of §3, **and** §4's broadcast arm |
| N4 | make `guest_cond_from_slot` refuse an already-initialised slot (sentinels only) | **FAIL (2)** §1's wake arm and §3's "an initialised `_Cnd_wait` waits too" |
| N5 | restore the **old guard** on `m_cnd_broadcast` | **FAIL (1)** §4's `_Cnd_broadcast` arm, and only that one |
| N6 | restore the **old guard** on `m_mtx_unlock` | **FAIL (1)** §4's `_Mtx_unlock` arm, and only that one |
| N7 | restore the **old guard** on `m_cnd_signal` | **FAIL (1)** §4's `_Cnd_signal` arm, and only that one |
| baseline / restored | — | **PASS** |

All seven re-measured at the current head after §4 was rewritten.

### §4 exists because the review found a row that had never been run — and the gap behind it was bigger

The first revision of this table had an N3 that **described one mutation and measured another**. The
row said *"make `m_cnd_broadcast` skip a self-initialised slot again"*, i.e. restore the old guard;
the harness actually ran `if (false && a0)`, disabling broadcast outright. A reviewer caught the
mismatch **by reading**, and derived that the described mutation should fail only §1's wake arm.

Measuring the arm as described produced something worse than either reading: **with the old guard
genuinely restored, the whole suite passed.** The reason is structural rather than a fluke — §1 and
§3 both *wait* before they broadcast, and the wait self-initialises the slot, so by the time any
broadcast ran, every slot in the file already held a real pointer and the old guard was satisfied.
Those sections could not see the signal/broadcast half of this change **at all**, however the
mutation was phrased.

§4 is the arm that can: `_Cnd_signal`, `_Cnd_broadcast` and `_Mtx_unlock` on a slot **nothing has
waited on**, with the observable being that the slot afterwards *names an object*.

**The first version of §4's rationale gave a reason that cannot happen**, and the re-review caught
it: it said a skipped signal "would be signalling an object no waiter will ever use". There is no
such waiter — `ensure_cond` installs the object with a CAS *before* returning it, and `m_cnd_wait`
can only park on what it returns, so a slot still holding a sentinel has nobody parked on it by
construction. On a NULL sentinel a skipped broadcast loses **nothing**. Demonstrated rather than
argued: under N5 (old guard restored) §1 and §3 still wake.

What §4 actually establishes is narrower and true:

1. **Cross-spelling parity** — `k_cond_broadcast` / `k_mutex_unlock` resolve the identical guest slot
   for the identical input. This is the PR's own #1873 thesis, and §4 is the only place in the suite
   that asserts the C11 spelling agrees.
2. **The crash path** — the old guard tested the slot's *value*, so it was true for every sentinel
   except NULL: sentinel `1` and `kPtDestroyed` (`0xDEA`) were dereferenced as object pointers.

Nothing weaker discriminates, because a broadcast to a condvar with no waiters has no other effect to
assert. `_Cnd_signal` got its own slot and its own arm after the re-review pointed out it is one of
the five handlers this change moves and had no arm at all — restoring its guard failed nothing.

Recorded at length because a row claiming coverage that does not exist is worse than no row: it is
where the next reader checks whether an arm still bites, and it stops them looking. #2573 corrected
the identical shape in its own M5 row.

### The two divergences the review found inside the widened family

The review's second blocking finding was that this PR invokes #1873 to justify moving five handlers
together and then leaves two #1873 divergences inside them: `guest_cond_advance` missing from the C11
signal/broadcast, and no `GuestCondWaiterScope` on `m_cnd_wait` — which **this change newly widens**,
because a null cond slot can park for the first time. Both are pre-existing; both are real.

Filed as **#2623** with the `file:line`s and the mechanism, together with a Windows-only third the
reviewer found (`m_mtx_lock` / `m_mtx_unlock` bypass the guest-mutex ownership map, so a static mutex
first touched through the C11 spelling is ERRORCHECK with `owner == 0`).

**One thing is fixed here rather than deferred:** the comment above `k_cond_timedwait` said *"the
three cond-wait bodies are the unit and there are exactly three"*. This change makes that false — the
C11 `m_cnd_wait` is a fourth body that can park — and a bare count is what the next reader trusts, so
it is corrected in place and points at #2623.

### And the change fixes more than the body claimed

Also from review, and it cuts in the PR's favour: the old guard tested the slot's **value** for
non-zero, while `pt_static_sentinel` treats everything below `0x1000` as a static initialiser. So
only **NULL** was skipped. Sentinel `1` (`PTHREAD_ADAPTIVE_MUTEX_INITIALIZER_NP`) and the destroyed
poison `kPtDestroyed` (`0xDEA`) both *passed* the guard and were **dereferenced as object pointers** —
`interruptible_mutex_lock((pthread_mutex_t*)0xDEA)`. Not a silent skip: a segfault. Routing through
the resolver therefore also fixes a use-after-destroy crash on this spelling. The comment said the
whole class was "skipped entirely"; corrected, because it was falsifiable in one grep.

## Risks

1. **A statically-initialised `mtx_t` self-initialised through `_Mtx_lock` is non-recursive**, where
   one created by `_Mtx_init` is `PTHREAD_MUTEX_RECURSIVE`. That divergence is confined to exactly
   the case that is broken today (a slot never passed to `_Mtx_init`), and **on native POSIX** it
   matches what the Sony spelling does for the same input, which is the behaviour being
   reimplemented. **The first revision of this line said that without the qualifier and a reviewer
   showed it is false on Windows**: `ensure_mutex` forces `PTHREAD_MUTEX_ERRORCHECK` there and
   registers the object, but ownership is recorded only by `guest_mutex_acquired` /
   `guest_mutex_released`, whose callers are the Sony/POSIX bodies alone — so a static mutex first
   touched through the C11 spelling is ERRORCHECK with `owner == 0`. Tracked in #2623 rather than
   fixed here.
2. **`_Cnd_wait` can now block where it used to return immediately.** If the matching signal is
   lost, that is a deadlock rather than a spin. Both are hangs; the new one is the semantic the
   guest asked for. Reachable only on a title that binds these handlers at all — see the blast
   radius above.
3. **A `_Cnd_wait` waiter is still not counted by #2168's waiter accounting**, so
   `scePthreadCondDestroy` on the same object would not answer EBUSY for it. That gap is
   **pre-existing, not introduced**: `m_cnd_wait` never took `GuestCondWaiterScope` on the
   already-initialised path either, and this change only extends the same uncounted wait to a
   statically-initialised slot. Not folded in because the scope lives in `hle_kernel.cpp`'s
   anonymous namespace and exporting it is more surface than #2596 needs; stated here so it is on
   the record rather than discovered later.
4. `m_mtx_init` still overwrites its slot unconditionally, so `_Mtx_lock` before `_Mtx_init` on the
   same slot now leaks the self-initialised object. Pre-existing, and only reachable through a guest
   bug; noted rather than folded in.
5. No GPU, renderer, compute or shader code is touched.

## Deliberately unaffected

* `m_cnd_wait`'s unconditional `return 0` — the shipped contract, see above.
* `m_mtx_destroy` / `m_cnd_destroy` — #2619.
* `m_mtx_init` / `m_cnd_init` — they create the object rather than resolving one.
* Every `scePthread*` / `pthread_*` spelling: unchanged, and now the single source of the semantics.

## Build / test

```
cmake -S prosper -B prosper/build-linux -G Ninja -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
cmake --build prosper/build-linux -j4
cd prosper/build-linux && ctest --no-tests=error -j4 --output-on-failure
```

**`100% tests passed out of 261`, exit 0** (Linux, in the `ps5ys` distrobox) — 260 on master plus
the new `c11_thread_slots`.