### PR TITLE
GTA V: the composite tap is renderer-owned with no observed notified refresh; positive metadata-kind correlation

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1172,6 +1172,14 @@ if(TARGET prosper_core)
   target_link_libraries(test_compressed_source_authority PRIVATE prosper_core)
   add_test(NAME compressed_source_authority COMMAND test_compressed_source_authority)
 
+  add_executable(test_metadata_kind_correlation tests/test_metadata_kind_correlation.cpp)
+  target_link_libraries(test_metadata_kind_correlation PRIVATE prosper_core)
+  add_test(NAME metadata_kind_correlation COMMAND test_metadata_kind_correlation)
+
+  add_executable(test_watch_list tests/test_watch_list.cpp)
+  target_link_libraries(test_watch_list PRIVATE prosper_core)
+  add_test(NAME watch_list COMMAND test_watch_list)
+
   add_executable(test_rdna2_decode tests/test_rdna2_decode.cpp)
   target_link_libraries(test_rdna2_decode PRIVATE prosper_core)
   add_test(NAME rdna2_decode_walk COMMAND test_rdna2_decode)

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3389,7 +3389,53 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
-### The failing kernels bind 4K WRITE-capable storage images (2026-08-17)
+### THE FAILING KERNEL'S 4K WRITE IS NOT THE COMPOSITE'S TAP — measured, same run (2026-08-17)
+
+**Read this before the section below it.** That section reports that two failing compute programs bind
+4K write-capable storage images, and that the only write-class binding of `0x204da00000` came from a
+dispatch that never ran. Both facts hold. The *inference* everyone then drew from them — that unblocking
+that program feeds the composite — is **false**, and a single run with `PROSPER_RTT_GUESTPEEK`
+distinguishes them because it prints each sampled surface's FORMAT:
+
+| surface | format | role | resolved |
+| --- | --- | --- | --- |
+| `0x2063380000` | **`Float10_11_11`** (fmt 20) | the composite's base tap, sampled 11x | **`HIT-CPU`**, all 11 |
+| `0x20471e0000` | **`Float16`** (fmt 4) | the presumed HDR source | `HIT-CPU` |
+| `0x204da00000` | **`Float32`** (fmt 1) | what `0x2042f49a00` writes, sampled **once** at pc=75 | `miss` |
+
+`0x204da00000` is a different address AND a different format from the tap. `0x2042f49a00` reads main
+depth and stencil and writes two **Float32** images — a depth-derived pass, not the f16 → f11f11f10
+conversion the composite is missing. **So the compute source-authority work does not lead to the
+composite's missing input.** It is worth having on its own terms (it closed real paths that read
+compressed bytes as plain texels, in both backends), but it is not the route to the world.
+
+**And the tap resolves `HIT-CPU` on every sample**, which changes the question entirely. The composite
+does not read empty *guest* memory — the renderer owns that surface and serves its own CPU snapshot. So
+a compute dispatch writing guest bytes is not even the mechanism that would fill it. What is empty is
+the **renderer's snapshot**, and what fills that is a renderer/draw question.
+
+**`PROSPER_RTT_GUESTPEEK`'s 0% distinguishes nothing here, and this is an instrument trap worth naming.**
+All **twenty** distinct `Float10_11_11` surfaces in the run report 0% non-zero guest bytes, and most
+resolve `HIT-CPU` — including `0x205f1a0000`, the bloom source this document elsewhere credits with 44%
+content. Empty guest memory is the *normal* state of a renderer-owned surface, so "guest bytes are zero"
+is not evidence that a surface is unproduced. The claim that the tap is effectively empty stands on the
+**aliasing A/B** (SCANOUT 13.5% → 55.6% with real geometry), which is a rendering measurement; it does
+not stand on guestpeek.
+
+**One assumption corrected in the other direction:** these addresses are **stable across runs**.
+`0x2063380000`, `0x20471e0000`, `0x2052ac0000`, `0x204da00000` and `0x205f1a0000` all appear at the
+addresses this document recorded hours earlier, in a fresh boot. Earlier notes here cautioned that
+addresses are run-local and re-derivation is required. That is true of *some* allocations — the storage
+image `0x205b557e00` binds did move between runs — but not of these, so a cross-run comparison of the
+named surfaces is legitimate.
+
+**Where the work actually goes next.** The tap is renderer-owned and its snapshot is empty, and the
+earlier colour-target census found **1 draw in 65,536** ever binding `0x2063380000` as a colour target.
+So either that single draw is the producer and it renders nothing, or the producer writes it by some
+path the resolved-table census cannot see. That is the next thing to establish, and it is a graphics
+question rather than a compute one.
+
+### The failing kernels bind 4K write-capable storage images (2026-08-17)
 
 The section below draws the census boundary at "the unresolved operations inside the failing compute
 kernels remain outside the census". This looks *inside* that boundary for the first time, using a

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3389,6 +3389,38 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
+### The composite's tap is renderer-owned, written by ONE draw, and never invalidated (2026-08-17)
+
+Three measurements on the same routed boot, each with its denominator, narrow the tap
+`0x2063380000` (`Float10_11_11`, 4K) to a single remaining question.
+
+**One draw ever binds it as a colour target.** `PROSPER_TARGET_WATCH=0x2063380000` — exact, unsampled,
+all eight MRT slots, no dimension filter — reports `draws=1` at every power-of-two checkpoint from
+4,096 through **262,144**. One draw, slot 0, and the count never grows.
+
+**No guest write ever touches it.** The new `PROSPER_RTT_INVALIDATE_WATCH` reports **131,072 queued
+guest writes examined, 0 touching either the tap or the f16 source `0x20471e0000`.** The snapshot is
+therefore never invalidated by a guest write — and this is a measurement rather than a silence, because
+the instrument prints its own denominator. It also reports that `0x2063380000` is at some drains **not
+in the RTT cache at all**, which is a different state from "cached and never refreshed" and is stated
+separately so the two are not conflated.
+
+**It is served from the renderer's own snapshot.** Every one of its 11 `PROSPER_RTT_GUESTPEEK` samples
+resolves `HIT-CPU`.
+
+So the composite reads a renderer-owned snapshot that one draw established and nothing ever refreshes.
+**The remaining question is what that single draw does** — whether it is the intended producer rendering
+nothing (culled, zero-area, colour writes masked, shader rejected), or merely an initial clear whose
+per-frame counterpart is absent. That is one draw out of 262,144, which is a small enough target to
+identify directly, and it is the next step.
+
+**On the boundary this does and does not move.** The write watch observes writes that reach
+`notify_guest_gpu_write`; a producer writing guest memory without notifying would be invisible here too.
+So this remains *no observed path*, not *the guest never issues one* — the same boundary #2542 already
+records, now with a denominator of 131,072 rather than an argument. What is genuinely new is that the
+surface is renderer-owned and served from a snapshot, which means a guest-memory producer is not even
+the mechanism that would fill it.
+
 ### THE FAILING KERNEL'S 4K WRITE IS NOT THE COMPOSITE'S TAP — measured, same run (2026-08-17)
 
 **Read this before the section below it.** That section reports that two failing compute programs bind

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3389,7 +3389,7 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
-### The composite's tap is renderer-owned, bound by ONE observed draw, and never refreshed (2026-08-17)
+### The composite's tap is renderer-owned, bound by ONE observed draw, with no observed notified refresh (2026-08-17)
 
 Three measurements on the same routed boot, each with its denominator, narrow the tap
 `0x2063380000` (`Float10_11_11`, 4K) to a single remaining question.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3389,17 +3389,20 @@ question, not a GPU one. It shares the frontier with one unfinished measurement:
 the failing compute kernels that no instrument has resolved (see the section below for exactly which,
 and why their null does not count yet).
 
-### The composite's tap is renderer-owned, written by ONE draw, and never invalidated (2026-08-17)
+### The composite's tap is renderer-owned, bound by ONE observed draw, and never refreshed (2026-08-17)
 
 Three measurements on the same routed boot, each with its denominator, narrow the tap
 `0x2063380000` (`Float10_11_11`, 4K) to a single remaining question.
 
-**One draw ever binds it as a colour target.** `PROSPER_TARGET_WATCH=0x2063380000` — exact, unsampled,
-all eight MRT slots, no dimension filter — reports `draws=1` at every power-of-two checkpoint from
-4,096 through **262,144**. One draw, slot 0, and the count never grows.
+**One observed draw BINDS it as a colour target — binding is not writing.**
+`PROSPER_TARGET_WATCH=0x2063380000` — exact, unsampled, all eight MRT slots, no dimension filter —
+reports `draws=1` at every power-of-two checkpoint from 4,096 through **262,144**. One draw, slot 0, and
+the count never grows. Whether that draw wrote useful pixels is **not** established here — the open
+question below is exactly that, and "bound by one draw" and "written by one draw" are different claims.
 
-**No guest write ever touches it.** The new `PROSPER_RTT_INVALIDATE_WATCH` reports **131,072 queued
-guest writes examined, 0 touching either the tap or the f16 source `0x20471e0000`.** The snapshot is
+**No OBSERVED queued write touches it.** The new `PROSPER_RTT_INVALIDATE_WATCH` reports **131,072
+queued guest writes examined, 0 touching either the tap or the f16 source `0x20471e0000`.** That counts
+writes reaching `notify_guest_gpu_write`, so it is a statement about notified writes, not about the guest. The snapshot is
 therefore never invalidated by a guest write — and this is a measurement rather than a silence, because
 the instrument prints its own denominator. It also reports that `0x2063380000` is at some drains **not
 in the RTT cache at all**, which is a different state from "cached and never refreshed" and is stated
@@ -3408,7 +3411,8 @@ separately so the two are not conflated.
 **It is served from the renderer's own snapshot.** Every one of its 11 `PROSPER_RTT_GUESTPEEK` samples
 resolves `HIT-CPU`.
 
-So the composite reads a renderer-owned snapshot that one draw established and nothing ever refreshes.
+So the composite reads a renderer-owned snapshot associated with one observed binding draw, which no
+observed notified write ever refreshes.
 **The remaining question is what that single draw does** — whether it is the intended producer rendering
 nothing (culled, zero-area, colour writes masked, shader rejected), or merely an initial clear whose
 per-frame counterpart is absent. That is one draw out of 262,144, which is a small enough target to
@@ -3437,9 +3441,15 @@ distinguishes them because it prints each sampled surface's FORMAT:
 
 `0x204da00000` is a different address AND a different format from the tap. `0x2042f49a00` reads main
 depth and stencil and writes two **Float32** images — a depth-derived pass, not the f16 → f11f11f10
-conversion the composite is missing. **So the compute source-authority work does not lead to the
-composite's missing input.** It is worth having on its own terms (it closed real paths that read
-compressed bytes as plain texels, in both backends), but it is not the route to the world.
+conversion the composite is missing. **So this failing kernel is not the DIRECT producer of the tap, nor
+of the f16 → f11f11f10 conversion.** That is exactly what the format mismatch establishes and no more:
+it does not rule out compute as an *upstream* input to the one graphics draw that binds the tap, so
+"the compute path is not the route" would overstate it.
+
+The source-authority work is worth having on its own terms — it **defines** the decision that must be
+made before compressed bytes are read as plain texels. But note what is not yet true: **neither runtime
+consumer is wired.** The compute adapter is parked and the graphics adapter is unwritten, so the policy
+exists and no path is closed by it yet.
 
 **And the tap resolves `HIT-CPU` on every sample**, which changes the question entirely. The composite
 does not read empty *guest* memory — the renderer owns that surface and serves its own CPU snapshot. So

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -2,6 +2,8 @@
 // (behavior-preserving); Vulkan-backed, so this unit links Vulkan::Vulkan.
 #include "live_renderer.hpp"
 #include "hle/dispatch.hpp"   // PROSPER_ENV_ON / _VALUE: cached reads on per-draw paths
+#include "gpu/metadata_kind_correlation.hpp"  // positive metadata-kind correlation (pure, tested)
+#include "gpu/watch_list.hpp"                 // strict 0x-only watch parsing
 #include "rtt_authority.hpp"
 #include "rtt_injection.hpp"
 #include "rtt_scale.hpp"
@@ -231,12 +233,14 @@ std::vector<uint64_t> parse_rtt_invalidate_watch_addrs() {
     std::vector<uint64_t> addrs;
     const char* spec = getenv("PROSPER_RTT_INVALIDATE_WATCH");
     if (!spec || !*spec) return addrs;
-    for (const char* p = spec; *p;) {
-        char* end = nullptr;
-        const uint64_t v = strtoull(p, &end, 0);
-        if (end == p) break;
-        addrs.push_back(v);
-        p = (*end == ',') ? end + 1 : end;
+    // Strict: an explicit 0x prefix, full consumption, no overflow, no zero address. A rejected spec
+    // arms NOTHING and says so, rather than watching a decimal-parsed address and reporting success.
+    if (!prosper::gpu::parse_hex_watch_list(spec, addrs)) {
+        fprintf(stderr,
+                "[rtt-inval] ignoring malformed PROSPER_RTT_INVALIDATE_WATCH=\"%s\" "
+                "(expected 0x-prefixed hex addresses, comma separated) -- NOT armed\n", spec);
+        addrs.clear();
+        return addrs;
     }
     fprintf(stderr, "[rtt-inval] watching %zu address(es)\n", addrs.size());
     return addrs;
@@ -265,6 +269,7 @@ void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t siz
     auto& watch = rtt_invalidate_watch();
     if (!watch.addrs.empty()) {
         watch.writes_examined.fetch_add(1, std::memory_order_relaxed);
+        bool write_touched_a_watched_surface = false;
         for (const uint64_t wanted : watch.addrs) {
             const auto entry = cache.find(wanted);
             if (entry == cache.end()) {
@@ -288,7 +293,13 @@ void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t siz
             const auto effect = prosper::frontend::live_rtt_guest_write_effect(
                 wanted, bytes, surface.dcc_metadata_addr, surface.dcc_metadata_bytes, addr, size);
             if (effect == prosper::frontend::LiveRttGuestWriteEffect::none) continue;
-            watch.writes_hitting.fetch_add(1, std::memory_order_relaxed);
+            // Counted ONCE per queued write, not once per matching address: with several watched
+            // addresses a per-address counter can exceed writes_examined, which makes the ratio
+            // nonsense in exactly the summary line that exists to make a zero trustworthy.
+            if (!write_touched_a_watched_surface) {
+                write_touched_a_watched_surface = true;
+                watch.writes_hitting.fetch_add(1, std::memory_order_relaxed);
+            }
             static std::atomic<int> logged{0};
             if (logged.fetch_add(1) < 64)
                 fprintf(stderr,
@@ -1133,31 +1144,24 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
     // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
     // exact-match identity and immutable CPU snapshot used by live compute (#590).
-    // Establish WHICH kind of compression metadata an address is, by correlation with retained state.
-    // The descriptor cannot say: WORD6[21] is set for depth and colour alike and shares one metadata
-    // address field, and a Float32x1 view is not necessarily depth. Only the renderer holds the retained
-    // depth surfaces, so the correlation lives here.
+    // Establish WHICH kind of compression metadata an address is. The decision is a pure function over
+    // retained state (metadata_kind_correlation.hpp); this lambda only GATHERS that state, so the rule
+    // itself is mutation-testable at the site that ships rather than through this registration.
+    //
+    // Both answers are positive correlations over metadata AND resource identity. An earlier version
+    // answered DCC by elimination -- "not Float32x1, therefore colour" -- which classified an
+    // uncorrelated Uint32x1 raw alias as DCC and let its all-0xff bytes authorize reading the base.
     prosper::gpu::set_metadata_kind_query(
         [](const prosper::gpu::MetadataKindRequest& request) {
-            // HTILE is POSITIVELY identified: some retained depth/stencil surface names this exact
-            // address as its HTILE base. That is the evidence the review asked for, rather than
-            // inferring depth from the T# format.
+            std::vector<prosper::gpu::RetainedDepthCorrelation> depth;
             for (const auto& [key, image] : prosper::test::persistent_ds_cache()) {
                 (void)image;
-                if (key.htile && key.htile == request.metadata_addr)
-                    return prosper::gpu::CompressionMetadataKind::Htile;
+                depth.push_back({key.dr, key.dw, key.sr, key.sw, key.htile});
             }
-            // No HTILE correlation. A DEPTH-SHAPED view then stays Unknown rather than being assumed to
-            // be colour DCC: single-component Float32 is exactly the shape whose metadata was previously
-            // read with colour-DCC sizing, and guessing here is how that happened. Unknown authorizes
-            // nothing, so this is a safe answer rather than a missing one.
-            const bool depth_shaped = request.format == prosper::gpu::DataFormat::Float32 &&
-                                      (request.num_components ? request.num_components : 1u) == 1u;
-            if (depth_shaped) return prosper::gpu::CompressionMetadataKind::Unknown;
-            // An ordinary multi-component colour view with compression declared is DCC by elimination:
-            // the depth registry did not claim it, and colour is the only other kind GFX10 puts in this
-            // field.
-            return prosper::gpu::CompressionMetadataKind::Dcc;
+            std::vector<prosper::gpu::RetainedColorCorrelation> color;
+            for (const auto& [addr, surface] : g_rtt)
+                color.push_back({addr, surface.dcc_metadata_addr});
+            return prosper::gpu::correlate_compression_metadata_kind(request, depth, color);
         });
 
     prosper::gpu::set_live_target_query([invalidate_ds](uint64_t addr) {

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -218,9 +218,11 @@ bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr) 
 // ran", and a watched address absent from the cache says so explicitly rather than looking like a
 // silent zero.
 //
-// `strtoull(..., 0)` is used deliberately, so `0x` is required: a bare `2063380000` would parse as
-// DECIMAL and watch an unrelated address while reporting success. That exact base-0 mistake is
-// recorded as an instrument trap for PROSPER_TARGET_WATCH.
+// Addresses are parsed by the shared STRICT parser (`watch_list.hpp`), which requires an explicit `0x`,
+// full token consumption, no overflow and no zero address, and arms NOTHING on a malformed spec. An
+// earlier revision of this comment claimed `strtoull(..., 0)` was deliberate "so `0x` is required" —
+// that was simply false, since base 0 falls back to DECIMAL, and the comment made the bug read as
+// checked. The same trap is recorded for PROSPER_TARGET_WATCH, which now uses the same parser.
 struct RttInvalidateWatch {
     std::vector<uint64_t> addrs;
     std::atomic<uint64_t> writes_examined{0};

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -1030,6 +1030,33 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     // The compute backend must not sample a surface whose CURRENT pixels live in this renderer's
     // RTT cache (raw guest memory is then empty/stale — the Dead Cells 642x362 lesson): publish the
     // exact-match identity and immutable CPU snapshot used by live compute (#590).
+    // Establish WHICH kind of compression metadata an address is, by correlation with retained state.
+    // The descriptor cannot say: WORD6[21] is set for depth and colour alike and shares one metadata
+    // address field, and a Float32x1 view is not necessarily depth. Only the renderer holds the retained
+    // depth surfaces, so the correlation lives here.
+    prosper::gpu::set_metadata_kind_query(
+        [](const prosper::gpu::MetadataKindRequest& request) {
+            // HTILE is POSITIVELY identified: some retained depth/stencil surface names this exact
+            // address as its HTILE base. That is the evidence the review asked for, rather than
+            // inferring depth from the T# format.
+            for (const auto& [key, image] : prosper::test::persistent_ds_cache()) {
+                (void)image;
+                if (key.htile && key.htile == request.metadata_addr)
+                    return prosper::gpu::CompressionMetadataKind::Htile;
+            }
+            // No HTILE correlation. A DEPTH-SHAPED view then stays Unknown rather than being assumed to
+            // be colour DCC: single-component Float32 is exactly the shape whose metadata was previously
+            // read with colour-DCC sizing, and guessing here is how that happened. Unknown authorizes
+            // nothing, so this is a safe answer rather than a missing one.
+            const bool depth_shaped = request.format == prosper::gpu::DataFormat::Float32 &&
+                                      (request.num_components ? request.num_components : 1u) == 1u;
+            if (depth_shaped) return prosper::gpu::CompressionMetadataKind::Unknown;
+            // An ordinary multi-component colour view with compression declared is DCC by elimination:
+            // the depth registry did not claim it, and colour is the only other kind GFX10 puts in this
+            // field.
+            return prosper::gpu::CompressionMetadataKind::Dcc;
+        });
+
     prosper::gpu::set_live_target_query([invalidate_ds](uint64_t addr) {
         drain_guest_gpu_writes(g_rtt, invalidate_ds);
         auto it = g_rtt.find(addr);

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -201,8 +201,111 @@ bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr) 
     return prosper::frontend::mrt_draw_binds_target(draw, addr, mrt_format_defined);
 }
 
+// PROSPER_RTT_INVALIDATE_WATCH=<0xaddr>[,<0xaddr>…] — why a renderer-owned surface's CPU snapshot is,
+// or is not, being invalidated.
+//
+// The question it answers is the one left when a composite input is empty and the renderer serves its
+// own snapshot for it. `PROSPER_RTT_GUESTPEEK` cannot answer it: every renderer-owned surface reports
+// 0% non-zero GUEST bytes whether it renders correctly or not, because the renderer owns the pixels.
+// So "the guest memory is empty" is not evidence about production, and the live question becomes
+// whether the cached copy is ever refreshed.
+//
+// It reports both directions, which is the point. A write that OVERLAPS prints its effect and its
+// origin; a write that misses prints nothing, but the periodic line states how many writes were
+// examined and how many hit — so "never invalidated" is distinguishable from "the instrument never
+// ran", and a watched address absent from the cache says so explicitly rather than looking like a
+// silent zero.
+//
+// `strtoull(..., 0)` is used deliberately, so `0x` is required: a bare `2063380000` would parse as
+// DECIMAL and watch an unrelated address while reporting success. That exact base-0 mistake is
+// recorded as an instrument trap for PROSPER_TARGET_WATCH.
+struct RttInvalidateWatch {
+    std::vector<uint64_t> addrs;
+    std::atomic<uint64_t> writes_examined{0};
+    std::atomic<uint64_t> writes_hitting{0};
+};
+
+// The counters are atomics, so the watch is populated IN PLACE rather than returned from an
+// initializer lambda -- an atomic is neither copyable nor movable.
+std::vector<uint64_t> parse_rtt_invalidate_watch_addrs() {
+    std::vector<uint64_t> addrs;
+    const char* spec = getenv("PROSPER_RTT_INVALIDATE_WATCH");
+    if (!spec || !*spec) return addrs;
+    for (const char* p = spec; *p;) {
+        char* end = nullptr;
+        const uint64_t v = strtoull(p, &end, 0);
+        if (end == p) break;
+        addrs.push_back(v);
+        p = (*end == ',') ? end + 1 : end;
+    }
+    fprintf(stderr, "[rtt-inval] watching %zu address(es)\n", addrs.size());
+    return addrs;
+}
+
+RttInvalidateWatch& rtt_invalidate_watch() {
+    static RttInvalidateWatch watch;
+    static const bool once = [] {
+        watch.addrs = parse_rtt_invalidate_watch_addrs();
+        return true;
+    }();
+    (void)once;
+    return watch;
+}
+
+const char* rtt_guest_write_effect_name(prosper::frontend::LiveRttGuestWriteEffect effect) {
+    switch (effect) {
+        case prosper::frontend::LiveRttGuestWriteEffect::color_plane:   return "color-plane";
+        case prosper::frontend::LiveRttGuestWriteEffect::dcc_metadata:  return "dcc-metadata";
+        default:                                                       return "none";
+    }
+}
+
 void invalidate_cpu_rtt_guest_write(RttCache& cache, uint64_t addr, uint64_t size) {
     if (!addr || !size) return;
+    auto& watch = rtt_invalidate_watch();
+    if (!watch.addrs.empty()) {
+        watch.writes_examined.fetch_add(1, std::memory_order_relaxed);
+        for (const uint64_t wanted : watch.addrs) {
+            const auto entry = cache.find(wanted);
+            if (entry == cache.end()) {
+                // A watched address that is not a cached RTT surface at all. Reported once so an
+                // absence of invalidations is not read as "nothing ever wrote it".
+                static std::mutex absent_mutex;
+                static std::set<uint64_t> absent_reported;
+                bool first = false;
+                { std::lock_guard<std::mutex> lock(absent_mutex);
+                  first = absent_reported.insert(wanted).second; }
+                if (first)
+                    fprintf(stderr,
+                            "[rtt-inval] 0x%llx is NOT in the RTT cache at this drain — no snapshot "
+                            "to invalidate\n", (unsigned long long)wanted);
+                continue;
+            }
+            const RttSurf& surface = entry->second;
+            const uint64_t bpp = prosper::test::backend_color_bytes_per_pixel(surface.format);
+            const uint64_t pixels = static_cast<uint64_t>(surface.w) * surface.h;
+            const uint64_t bytes = pixels > UINT64_MAX / bpp ? UINT64_MAX : pixels * bpp;
+            const auto effect = prosper::frontend::live_rtt_guest_write_effect(
+                wanted, bytes, surface.dcc_metadata_addr, surface.dcc_metadata_bytes, addr, size);
+            if (effect == prosper::frontend::LiveRttGuestWriteEffect::none) continue;
+            watch.writes_hitting.fetch_add(1, std::memory_order_relaxed);
+            static std::atomic<int> logged{0};
+            if (logged.fetch_add(1) < 64)
+                fprintf(stderr,
+                        "[rtt-inval] 0x%llx %ux%u snapshot invalidated: effect=%s by write "
+                        "addr=0x%llx size=%llu origin=%s\n",
+                        (unsigned long long)wanted, surface.w, surface.h,
+                        rtt_guest_write_effect_name(effect),
+                        (unsigned long long)addr, (unsigned long long)size,
+                        prosper::gpu::guest_gpu_write_origin());
+        }
+        // Periodic totals, so a zero is a measurement rather than a silence.
+        const uint64_t examined = watch.writes_examined.load(std::memory_order_relaxed);
+        if (examined && (examined & (examined - 1)) == 0 && examined >= 1024)
+            fprintf(stderr, "[rtt-inval] examined=%llu writes, %llu touched a watched surface\n",
+                    (unsigned long long)examined,
+                    (unsigned long long)watch.writes_hitting.load(std::memory_order_relaxed));
+    }
     for (auto it = cache.begin(); it != cache.end();) {
         const RttSurf& surface = it->second;
         const uint64_t bpp = prosper::test::backend_color_bytes_per_pixel(surface.format);

--- a/prosper/src/gpu/gpu_execute.hpp
+++ b/prosper/src/gpu/gpu_execute.hpp
@@ -17,6 +17,7 @@
 #include <cstring>                 // memcpy: aliasing-safe index-buffer fingerprint loads
 #include "rdna2_to_spirv.hpp"      // recompile_vertex / recompile_fragment
 #include "shader_resources.hpp"    // ShaderResourceTable
+#include "compressed_source_authority.hpp"  // CompressionMetadataKind
 #include "agc_shader_layout.hpp"   // DecodedBufferDescriptor (DynFetch)
 #include "videoout_present.hpp"    // PresentFrameOrigin: a rendered frame carries its provenance
 #include <algorithm>
@@ -1008,6 +1009,31 @@ bool have_submit_compute();
 // backend imports an immutable CPU snapshot for sampled bindings. Writable bindings seed from the
 // snapshot, publish their result to guest backing, and notify the renderer to invalidate its copy.
 using LiveTargetQueryFn = std::function<bool(uint64_t gpu_addr)>;
+
+// WHICH kind of compression metadata a descriptor's metadata address points at (#2606).
+//
+// The descriptor cannot say. T# WORD6[21] is set for depth/stencil and colour alike, with PAL putting
+// HTILE's address in the same `meta_data_address` field it puts DCC's — and the T# format is not enough
+// either, because a Float32x1 view is not necessarily depth. The reliable evidence is correlation with
+// RETAINED depth/HTILE state, which only the renderer holds, so it registers this the same way it
+// registers the live-target query above.
+//
+// The sampled-source decision takes the kind as an input and refuses to guess: an aspect-unknown plane
+// authorizes nothing, because which bit pattern means "decompressed" depends on the kind. Answering
+// Unknown is therefore always safe and never silently wrong.
+struct MetadataKindRequest {
+    uint64_t metadata_addr = 0;
+    uint64_t resource_addr = 0;
+    DataFormat format = DataFormat::Float32;
+    uint32_t num_components = 1;
+    uint32_t img_dim = 0;
+};
+using MetadataKindQueryFn = std::function<CompressionMetadataKind(const MetadataKindRequest&)>;
+void set_metadata_kind_query(MetadataKindQueryFn fn);
+
+// Unknown when no renderer is registered, so a backend running without one cannot accidentally
+// authorize a base allocation through a kind nobody established.
+CompressionMetadataKind classify_compression_metadata_kind(const MetadataKindRequest& request);
 void set_live_target_query(LiveTargetQueryFn fn);
 bool is_live_render_target(uint64_t gpu_addr);
 enum class LiveTargetPixelFormat : uint8_t { Rgba8Unorm, Rgba16Float, R11G11B10Float };

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -5,6 +5,7 @@
 // pure. No Vulkan here — the backend is a std::function injected by whoever owns a device (the runtime
 // binary at startup, or a test via render_runner.h), so prosper_core links this without Vulkan.
 #include "gpu_execute.hpp"
+#include "watch_list.hpp"   // strict 0x-only watch parsing (shared with the RTT watch)
 #include "gpu_capture.hpp"
 #include "gpu_timeline.hpp"
 #include "capture_compute_policy.hpp"
@@ -10192,16 +10193,36 @@ static OrderedSubmitResult execute_ordered_gpustate(const GpuState& st, uint32_t
                     static std::array<TargetWatch, kMaxWatch> watch{};
                     static size_t watch_count = 0;
                     static std::atomic<uint64_t> watch_draws{0};
+                    // Parsed by the shared STRICT parser, which is the whole reason it exists. This
+                    // site was the original occurrence of the base-0 trap: `strtoull(..., 0)` accepts a
+                    // bare decimal, so `PROSPER_TARGET_WATCH=2063380000` armed a watch on
+                    // 2,063,380,000, printed "watching 1 address(es)", and produced a confident zero
+                    // for an address nobody asked about. A watch whose null is meaningless is worse
+                    // than no watch, and this one's nulls are quoted as evidence.
+                    //
+                    // A malformed list arms NOTHING. An oversized list is REJECTED rather than
+                    // truncated: silently dropping the ninth address would answer "never a target" for
+                    // a surface that was never examined.
                     static const bool watch_enabled = [] {
                         const char* spec = std::getenv("PROSPER_TARGET_WATCH");
                         if (!spec || !*spec) return false;
-                        for (const char* p = spec; *p && watch_count < kMaxWatch;) {
-                            char* end = nullptr;
-                            const uint64_t v = std::strtoull(p, &end, 0);
-                            if (end == p) break;
-                            watch[watch_count++].addr = v;
-                            p = (*end == ',') ? end + 1 : end;
+                        std::vector<uint64_t> addrs;
+                        if (!prosper::gpu::parse_hex_watch_list(spec, addrs)) {
+                            std::fprintf(stderr,
+                                         "[target-watch] ignoring malformed PROSPER_TARGET_WATCH=\"%s\" "
+                                         "(expected 0x-prefixed hex addresses, comma separated) "
+                                         "-- NOT armed\n", spec);
+                            return false;
                         }
+                        if (addrs.size() > kMaxWatch) {
+                            std::fprintf(stderr,
+                                         "[target-watch] PROSPER_TARGET_WATCH lists %zu addresses, "
+                                         "more than the %zu-address bound -- NOT armed (truncating "
+                                         "would report 'never a target' for addresses never examined)\n",
+                                         addrs.size(), kMaxWatch);
+                            return false;
+                        }
+                        for (const uint64_t v : addrs) watch[watch_count++].addr = v;
                         std::fprintf(stderr, "[target-watch] watching %zu address(es)\n",
                                      watch_count);
                         return watch_count != 0;

--- a/prosper/src/gpu/gpu_executor.cpp
+++ b/prosper/src/gpu/gpu_executor.cpp
@@ -10893,6 +10893,16 @@ void set_live_target_image_importer(LiveTargetImageImportFn import_fn,
 void set_live_target_image_written_notifier(LiveTargetImageWrittenFn written_fn) {
     g_live_target_image_written = std::move(written_fn);
 }
+
+static MetadataKindQueryFn g_metadata_kind_query;
+void set_metadata_kind_query(MetadataKindQueryFn fn) { g_metadata_kind_query = std::move(fn); }
+
+CompressionMetadataKind classify_compression_metadata_kind(const MetadataKindRequest& request) {
+    // No renderer, no correlation, no kind. Unknown authorizes nothing downstream, so a backend running
+    // without a registered renderer fails closed rather than inheriting a guess.
+    if (!request.metadata_addr || !g_metadata_kind_query) return CompressionMetadataKind::Unknown;
+    return g_metadata_kind_query(request);
+}
 bool import_live_render_target_image(uint64_t gpu_addr, const LiveTargetImageRequest& request,
                                      LiveTargetImageImport& import) {
     import = LiveTargetImageImport{};

--- a/prosper/src/gpu/metadata_kind_correlation.cpp
+++ b/prosper/src/gpu/metadata_kind_correlation.cpp
@@ -1,0 +1,39 @@
+#include "metadata_kind_correlation.hpp"
+
+namespace prosper::gpu {
+
+CompressionMetadataKind correlate_compression_metadata_kind(
+    const MetadataKindRequest& request,
+    const std::vector<RetainedDepthCorrelation>& depth,
+    const std::vector<RetainedColorCorrelation>& color) {
+    // Nothing to correlate. Not an error, and not an invitation to guess from the format.
+    if (!request.metadata_addr || !request.resource_addr) return CompressionMetadataKind::Unknown;
+
+    // HTILE: a retained depth surface names this metadata plane, AND one of its aspect bases is the
+    // resource being asked about. The second half is what makes a reused metadata address safe: without
+    // it, a stale entry whose HTILE address had been recycled would identify an unrelated resource.
+    for (const RetainedDepthCorrelation& ds : depth) {
+        if (!ds.htile || ds.htile != request.metadata_addr) continue;
+        const bool resource_is_an_aspect_of_this_surface =
+            (ds.depth_read && ds.depth_read == request.resource_addr) ||
+            (ds.depth_write && ds.depth_write == request.resource_addr) ||
+            (ds.stencil_read && ds.stencil_read == request.resource_addr) ||
+            (ds.stencil_write && ds.stencil_write == request.resource_addr);
+        if (resource_is_an_aspect_of_this_surface) return CompressionMetadataKind::Htile;
+    }
+
+    // DCC: a retained colour surface AT THIS RESOURCE ADDRESS registered this metadata plane. Also a
+    // positive correlation on both halves -- never "it is not depth, therefore it is colour".
+    for (const RetainedColorCorrelation& rt : color) {
+        if (!rt.resource_addr || rt.resource_addr != request.resource_addr) continue;
+        if (rt.dcc_metadata_addr && rt.dcc_metadata_addr == request.metadata_addr)
+            return CompressionMetadataKind::Dcc;
+    }
+
+    // Uncorrelated. The format is deliberately NOT consulted here: a Float32x1 view is not necessarily
+    // depth and a Uint32x1 alias is not necessarily colour, so any format-based fallback is a guess
+    // wearing evidence's clothes. Unknown authorizes nothing downstream.
+    return CompressionMetadataKind::Unknown;
+}
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/metadata_kind_correlation.hpp
+++ b/prosper/src/gpu/metadata_kind_correlation.hpp
@@ -1,0 +1,57 @@
+// Establish WHICH kind of compression metadata an address is, by POSITIVE correlation with retained
+// renderer state — never by elimination.
+//
+// The descriptor cannot answer it. T# WORD6[21] is set for depth/stencil and colour alike, with AMD PAL
+// putting HTILE's address in the same `meta_data_address` field it puts DCC's, and the T# format is not
+// enough either: a Float32x1 view is not necessarily depth, and a Uint32x1 raw alias is not necessarily
+// colour.
+//
+// WHY THIS IS A PURE FUNCTION OVER EXPLICIT STATE. An earlier version lived inside the renderer's
+// registration lambda and answered by elimination — HTILE on a metadata-address match, `Unknown` for
+// Float32x1, and **DCC for everything else**. Two defects followed, and both are the same mistake:
+//   * inventing DCC identity from an absence. An uncorrelated Uint32x1 raw/depth alias was classified
+//     DCC, and its all-0xff bytes then authorized reading the base — while the whole point of the
+//     source-authority policy is that the kind must be KNOWN before those bytes mean anything.
+//   * ignoring resource identity. A stale retained entry whose metadata address had been reused
+//     identified HTILE without proving the metadata belonged to THIS resource.
+// Both answers are now positive correlations over metadata AND resource identity, and anything
+// uncorrelated is `Unknown` — which authorizes nothing downstream, so it is a safe answer.
+//
+// It is pure so it can be mutation-tested at the site that ships. Testing the renderer's lambda through
+// a synthetic callback proved only that the plumbing forwards: mutating the real lambda to answer DCC
+// unconditionally left that test green.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "compressed_source_authority.hpp"   // CompressionMetadataKind
+#include "gpu_execute.hpp"                   // MetadataKindRequest
+
+namespace prosper::gpu {
+
+// A retained depth/stencil surface, as the renderer holds it: the aspect bases it renders through and
+// the HTILE plane that describes them.
+struct RetainedDepthCorrelation {
+    uint64_t depth_read = 0;
+    uint64_t depth_write = 0;
+    uint64_t stencil_read = 0;
+    uint64_t stencil_write = 0;
+    uint64_t htile = 0;
+};
+
+// A retained colour surface and the DCC control plane registered for it.
+struct RetainedColorCorrelation {
+    uint64_t resource_addr = 0;
+    uint64_t dcc_metadata_addr = 0;
+};
+
+// `Htile` only when a retained depth surface names this metadata address as its HTILE base AND one of
+// its aspect bases is this resource. `Dcc` only when a retained colour surface at this resource address
+// registered this metadata address. Otherwise `Unknown`.
+CompressionMetadataKind correlate_compression_metadata_kind(
+    const MetadataKindRequest& request,
+    const std::vector<RetainedDepthCorrelation>& depth,
+    const std::vector<RetainedColorCorrelation>& color);
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/watch_list.cpp
+++ b/prosper/src/gpu/watch_list.cpp
@@ -1,0 +1,59 @@
+#include "watch_list.hpp"
+
+#include <cctype>
+#include <cstdlib>
+
+namespace prosper::gpu {
+namespace {
+
+bool hex_digit(char c, uint64_t& value) {
+    if (c >= '0' && c <= '9') { value = static_cast<uint64_t>(c - '0'); return true; }
+    if (c >= 'a' && c <= 'f') { value = static_cast<uint64_t>(c - 'a') + 10u; return true; }
+    if (c >= 'A' && c <= 'F') { value = static_cast<uint64_t>(c - 'A') + 10u; return true; }
+    return false;
+}
+
+}  // namespace
+
+bool parse_hex_watch_list(const char* spec, std::vector<uint64_t>& out) {
+    out.clear();
+    if (!spec || !*spec) return false;
+
+    const char* p = spec;
+    while (true) {
+        // Leading spaces are tolerated so a shell-quoted list stays usable; everything else is not.
+        while (*p == ' ' || *p == '\t') ++p;
+
+        // An explicit 0x/0X prefix is REQUIRED. This is the whole point: without it a decimal token
+        // parses silently into an unrelated address.
+        if (p[0] != '0' || (p[1] != 'x' && p[1] != 'X')) { out.clear(); return false; }
+        p += 2;
+
+        // At least one hex digit, accumulated with an overflow check rather than trusting strtoull's
+        // errno dance.
+        uint64_t value = 0;
+        uint64_t digit = 0;
+        size_t digits = 0;
+        while (hex_digit(*p, digit)) {
+            if (value > (UINT64_MAX >> 4)) { out.clear(); return false; }   // would shift out the top
+            value = (value << 4) | digit;
+            ++digits;
+            ++p;
+        }
+        if (!digits) { out.clear(); return false; }
+
+        while (*p == ' ' || *p == '\t') ++p;
+
+        // A zero address is never a guest surface; accepting it arms a watch that matches nothing while
+        // reporting itself armed.
+        if (!value) { out.clear(); return false; }
+        out.push_back(value);
+
+        if (*p == '\0') return true;                 // whole spec consumed
+        if (*p != ',') { out.clear(); return false; } // trailing junk after a valid token
+        ++p;
+        if (*p == '\0') { out.clear(); return false; } // trailing comma: an empty final token
+    }
+}
+
+}  // namespace prosper::gpu

--- a/prosper/src/gpu/watch_list.hpp
+++ b/prosper/src/gpu/watch_list.hpp
@@ -1,0 +1,30 @@
+// Parse a comma-separated list of HEX guest addresses for a `PROSPER_*_WATCH` diagnostic.
+//
+// It exists because `strtoull(spec, &end, 0)` is the wrong tool and reads as the right one. Base 0 means
+// "0x prefix selects hex, otherwise DECIMAL" — so a bare `2063380000` parses happily as decimal
+// 2,063,380,000, the watch reports itself armed, and the routed run produces a confident zero-hit result
+// about an address nobody asked about. A watch whose null is meaningless is worse than no watch.
+//
+// This was recorded as an instrument trap for `PROSPER_TARGET_WATCH`, and then reproduced verbatim by a
+// later diagnostic whose own comment claimed `0x` was required. It was not: nothing checked the prefix.
+// Hence one strict parser, used and tested rather than restated.
+//
+// Strict means every one of these is a REJECTION, not a best-effort parse:
+//   * a token without an explicit `0x` / `0X` prefix
+//   * trailing or embedded text that is not consumed
+//   * an empty token, including from a stray or doubled comma
+//   * a value that overflows 64 bits
+//   * a zero address, which is never a guest surface and silently matches nothing
+// A rejected spec yields NO addresses and returns false, so the caller reports "not armed" instead of
+// arming a lie.
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+namespace prosper::gpu {
+
+// True only when the whole spec parsed and produced at least one address. On false, `out` is empty.
+bool parse_hex_watch_list(const char* spec, std::vector<uint64_t>& out);
+
+}  // namespace prosper::gpu

--- a/prosper/tests/test_compressed_source_authority.cpp
+++ b/prosper/tests/test_compressed_source_authority.cpp
@@ -12,6 +12,7 @@
 #include "gpu/compressed_source_authority.hpp"
 
 #include "gpu/tile.hpp"
+#include "gpu/gpu_execute.hpp"
 
 #include <cstdint>
 #include <cstdio>
@@ -419,6 +420,44 @@ int main() {
         f.compression_enabled = true;
         CHECK(!sampled_source_decision(f).may_read_guest_base(),
               "a compressed source with no authority forbids the base");
+    }
+
+    // THE KIND HOOK FAILS CLOSED. The decision refuses to guess the metadata kind, so the hook that
+    // supplies it must answer Unknown whenever nothing established one -- no registered renderer, or no
+    // metadata address at all. A backend running without a renderer then cannot inherit a guess.
+    {
+        set_metadata_kind_query({});   // no renderer registered
+        MetadataKindRequest request;
+        request.metadata_addr = 0x2055310000ull;
+        request.resource_addr = 0x2052ac0000ull;
+        request.format = DataFormat::Float32;
+        request.num_components = 1;
+        request.img_dim = 1;
+        CHECK(classify_compression_metadata_kind(request) == CompressionMetadataKind::Unknown,
+              "with no registered renderer the metadata kind is Unknown, never assumed");
+
+        // Installed, it forwards -- so the Unknown above is the absence of a correlator, not a stub.
+        set_metadata_kind_query([](const MetadataKindRequest& r) {
+            return r.metadata_addr == 0x2055310000ull ? CompressionMetadataKind::Htile
+                                                      : CompressionMetadataKind::Dcc;
+        });
+        CHECK(classify_compression_metadata_kind(request) == CompressionMetadataKind::Htile,
+              "a registered correlator's answer is forwarded");
+        MetadataKindRequest other = request;
+        other.metadata_addr = 0x2099990000ull;
+        CHECK(classify_compression_metadata_kind(other) == CompressionMetadataKind::Dcc,
+              "and it is asked per address rather than cached across them");
+
+        // A descriptor with no metadata address has nothing to correlate, even with a correlator that
+        // would answer for anything.
+        set_metadata_kind_query([](const MetadataKindRequest&) {
+            return CompressionMetadataKind::Htile;
+        });
+        MetadataKindRequest none = request;
+        none.metadata_addr = 0;
+        CHECK(classify_compression_metadata_kind(none) == CompressionMetadataKind::Unknown,
+              "no metadata address means Unknown, whatever a correlator would say");
+        set_metadata_kind_query({});
     }
 
     // Names are part of the contract: a decline must be attributable in a log.

--- a/prosper/tests/test_metadata_kind_correlation.cpp
+++ b/prosper/tests/test_metadata_kind_correlation.cpp
@@ -1,0 +1,129 @@
+// Which kind of compression metadata is at an address — established by POSITIVE correlation only.
+//
+// These arms exist because the version they replace answered by elimination, inside a renderer lambda
+// that no test reached. Two consequences, and both are pinned here:
+//   * "not Float32x1, therefore DCC" classified an uncorrelated Uint32x1 raw alias as colour DCC, after
+//     which its all-0xff plane authorized reading the base — the exact interpretation the
+//     source-authority policy exists to withhold until the kind is KNOWN.
+//   * a metadata-address match alone identified HTILE without proving the plane belonged to THIS
+//     resource, so a stale retained entry whose address had been recycled answered for an unrelated one.
+//
+// The rule is tested here rather than through the renderer's registration, because mutating that lambda
+// to answer DCC unconditionally left the forwarding test green — plumbing coverage, not rule coverage.
+#include "gpu/metadata_kind_correlation.hpp"
+
+#include <cstdio>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+// GTA V's main depth and its HTILE, as the renderer retains them.
+constexpr uint64_t kDepthRead = 0x2052ac0000ull;
+constexpr uint64_t kStencilRead = 0x2054aa0000ull;
+constexpr uint64_t kHtile = 0x2055310000ull;
+// An ordinary colour target and its DCC plane.
+constexpr uint64_t kColorAddr = 0x2063380000ull;
+constexpr uint64_t kColorDcc = 0x2064000000ull;
+
+std::vector<RetainedDepthCorrelation> retained_depth() {
+    return {{kDepthRead, kDepthRead, kStencilRead, kStencilRead, kHtile}};
+}
+std::vector<RetainedColorCorrelation> retained_color() {
+    return {{kColorAddr, kColorDcc}};
+}
+
+MetadataKindRequest ask(uint64_t metadata_addr, uint64_t resource_addr,
+                        DataFormat format = DataFormat::Float32, uint32_t components = 1,
+                        uint32_t img_dim = 1) {
+    MetadataKindRequest r;
+    r.metadata_addr = metadata_addr;
+    r.resource_addr = resource_addr;
+    r.format = format;
+    r.num_components = components;
+    r.img_dim = img_dim;
+    return r;
+}
+
+CompressionMetadataKind kind(const MetadataKindRequest& r) {
+    return correlate_compression_metadata_kind(r, retained_depth(), retained_color());
+}
+
+}  // namespace
+
+int main() {
+    printf("== test_metadata_kind_correlation ==\n");
+
+    // POSITIVE HTILE: the retained surface names this plane AND this resource is one of its aspects.
+    CHECK(kind(ask(kHtile, kDepthRead)) == CompressionMetadataKind::Htile,
+          "a retained depth surface's HTILE plane correlates for its depth base");
+    CHECK(kind(ask(kHtile, kStencilRead)) == CompressionMetadataKind::Htile,
+          "...and for its stencil base, which shares the same HTILE plane");
+
+    // POSITIVE DCC: this resource registered this plane.
+    CHECK(kind(ask(kColorDcc, kColorAddr, DataFormat::Unorm8, 4)) == CompressionMetadataKind::Dcc,
+          "a retained colour surface's registered DCC plane correlates for that resource");
+
+    // RESOURCE IDENTITY IS REQUIRED, both ways. A correct metadata address paired with a resource the
+    // retained entry does not describe is the recycled-address case, and must not answer.
+    CHECK(kind(ask(kHtile, 0x20aaaa0000ull)) == CompressionMetadataKind::Unknown,
+          "an HTILE plane does not identify a resource the retained surface never names");
+    CHECK(kind(ask(kColorDcc, 0x20bbbb0000ull)) == CompressionMetadataKind::Unknown,
+          "a DCC plane does not identify a resource that did not register it");
+
+    // METADATA IDENTITY IS REQUIRED. The right resource with the wrong plane proves nothing.
+    CHECK(kind(ask(0x20cccc0000ull, kDepthRead)) == CompressionMetadataKind::Unknown,
+          "a depth resource with an unrelated metadata address is Unknown");
+    CHECK(kind(ask(0x20cccc0000ull, kColorAddr, DataFormat::Unorm8, 4)) ==
+              CompressionMetadataKind::Unknown,
+          "a colour resource with an unrelated metadata address is Unknown");
+
+    // CROSS-PAIRING must not correlate: depth's plane against the colour resource and vice versa.
+    CHECK(kind(ask(kHtile, kColorAddr, DataFormat::Unorm8, 4)) == CompressionMetadataKind::Unknown,
+          "depth's HTILE plane does not become DCC by being asked about a colour resource");
+    CHECK(kind(ask(kColorDcc, kDepthRead)) == CompressionMetadataKind::Unknown,
+          "a colour DCC plane does not become HTILE by being asked about a depth resource");
+
+    // NO ELIMINATION. This is the arm the previous implementation failed: an uncorrelated resource must
+    // be Unknown WHATEVER its format, and Uint32x1 is the case that was silently classified DCC.
+    {
+        const DataFormat formats[] = {DataFormat::Float32, DataFormat::Uint32, DataFormat::Unorm8,
+                                      DataFormat::Float16, DataFormat::Uint8};
+        const uint32_t component_counts[] = {1u, 2u, 4u};
+        bool all_unknown = true;
+        for (DataFormat f : formats)
+            for (uint32_t c : component_counts)
+                if (kind(ask(0x20dddd0000ull, 0x20eeee0000ull, f, c)) !=
+                    CompressionMetadataKind::Unknown)
+                    all_unknown = false;
+        CHECK(all_unknown,
+              "an uncorrelated resource is Unknown for EVERY format/component shape, never DCC by "
+              "elimination");
+    }
+
+    // Degenerate inputs correlate with nothing.
+    CHECK(kind(ask(0, kDepthRead)) == CompressionMetadataKind::Unknown,
+          "no metadata address correlates with nothing");
+    CHECK(kind(ask(kHtile, 0)) == CompressionMetadataKind::Unknown,
+          "no resource address correlates with nothing");
+    CHECK(correlate_compression_metadata_kind(ask(kHtile, kDepthRead), {}, {}) ==
+              CompressionMetadataKind::Unknown,
+          "with no retained state at all, nothing correlates");
+
+    // A retained entry with a zero HTILE base must not match a zero metadata address by accident.
+    {
+        std::vector<RetainedDepthCorrelation> no_htile = {{kDepthRead, kDepthRead, 0, 0, 0}};
+        CHECK(correlate_compression_metadata_kind(ask(kHtile, kDepthRead), no_htile, {}) ==
+                  CompressionMetadataKind::Unknown,
+              "a retained surface with no HTILE plane correlates nothing");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}

--- a/prosper/tests/test_watch_list.cpp
+++ b/prosper/tests/test_watch_list.cpp
@@ -1,0 +1,89 @@
+// Strict hex parsing for PROSPER_*_WATCH address lists.
+//
+// The defect this pins: `strtoull(spec, &end, 0)` accepts a bare DECIMAL token, so
+// `PROSPER_RTT_INVALIDATE_WATCH=2063380000` armed a watch on 2,063,380,000 — reported success, matched
+// nothing, and produced a confident zero-hit result about an address nobody asked about. It was already
+// an instrument trap for PROSPER_TARGET_WATCH, then reproduced by a diagnostic whose own comment claimed
+// `0x` was required. Nothing checked the prefix. So the rule is tested, not restated.
+#include "gpu/watch_list.hpp"
+
+#include <cstdio>
+#include <vector>
+
+using namespace prosper::gpu;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+bool rejects(const char* spec) {
+    std::vector<uint64_t> out{0xdeadu};   // seeded, so a rejection must also CLEAR it
+    const bool ok = parse_hex_watch_list(spec, out);
+    return !ok && out.empty();
+}
+}  // namespace
+
+int main() {
+    printf("== test_watch_list ==\n");
+
+    // Accepted: 0x-prefixed, single and comma-separated, either case, with tolerated spaces.
+    {
+        std::vector<uint64_t> out;
+        CHECK(parse_hex_watch_list("0x2063380000", out) && out.size() == 1 &&
+                  out[0] == 0x2063380000ull,
+              "a single 0x-prefixed address parses to its hex value");
+
+        CHECK(parse_hex_watch_list("0x2063380000,0x20471e0000", out) && out.size() == 2 &&
+                  out[0] == 0x2063380000ull && out[1] == 0x20471e0000ull,
+              "a comma list parses in order");
+
+        CHECK(parse_hex_watch_list("0X2063380000", out) && out.size() == 1 &&
+                  out[0] == 0x2063380000ull,
+              "an uppercase 0X prefix is accepted");
+
+        CHECK(parse_hex_watch_list(" 0xAbCd , 0x10 ", out) && out.size() == 2 &&
+                  out[0] == 0xabcdull && out[1] == 0x10ull,
+              "surrounding spaces are tolerated and hex digits are case-insensitive");
+
+        CHECK(parse_hex_watch_list("0xffffffffffffffff", out) && out.size() == 1 &&
+                  out[0] == UINT64_MAX,
+              "the largest 64-bit address parses exactly");
+    }
+
+    // THE DEFECT ITSELF: a bare decimal token must be REJECTED, not silently reinterpreted. This is the
+    // arm whose absence let a watch arm on the wrong address and report success.
+    CHECK(rejects("2063380000"),
+          "a bare decimal token is rejected, never parsed as decimal");
+    CHECK(rejects("0x2063380000,2063380000"),
+          "one bad token in a list rejects the WHOLE list rather than arming a partial watch");
+
+    // Malformed shapes.
+    CHECK(rejects("0x"),          "a prefix with no digits is rejected");
+    CHECK(rejects("0xzz"),        "non-hex digits after the prefix are rejected");
+    CHECK(rejects("0x10junk"),    "trailing text after a valid token is rejected");
+    CHECK(rejects("0x10 0x20"),   "a space-separated list without commas is rejected");
+    CHECK(rejects("0x10,"),       "a trailing comma is rejected");
+    CHECK(rejects("0x10,,0x20"),  "a doubled comma is rejected");
+    CHECK(rejects(","),           "a lone comma is rejected");
+    CHECK(rejects("x10"),         "a prefix without its leading zero is rejected");
+    CHECK(rejects("10"),          "a bare hex-looking token without 0x is rejected");
+    CHECK(rejects("0x1ffffffffffffffff"), "a value wider than 64 bits is rejected, not truncated");
+
+    // A zero address is never a guest surface: accepting it arms a watch that matches nothing while
+    // reporting itself armed, which is the same class of lie as the decimal parse.
+    CHECK(rejects("0x0"),        "a zero address is rejected");
+    CHECK(rejects("0x00000000"), "a long-form zero address is rejected");
+    CHECK(rejects("0x10,0x0"),   "a zero anywhere in the list rejects the list");
+
+    // Empty and absent specs are rejections, not empty successes.
+    {
+        std::vector<uint64_t> out{0xdeadu};
+        CHECK(!parse_hex_watch_list(nullptr, out) && out.empty(), "a null spec is rejected");
+        CHECK(!parse_hex_watch_list("", out) && out.empty(), "an empty spec is rejected");
+    }
+
+    if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
+    printf("== PASS ==\n");
+    return 0;
+}


### PR DESCRIPTION
Refs #2542, #2481, #2554, tracker #1873. Continues the source-authority series merged as #2589 and
#2606, and **narrows what that series was assumed to be for**.

> **This body is the current state, rewritten after two review rounds.** Earlier revisions claimed the
> compute path was ruled out, that `strtoull(..., 0)` required a `0x` prefix, and that the correlator
> answered DCC by elimination. All three were wrong and none survives below — the history is in the
> commits, not stacked in contradictory sections here.

## The measurement: this failing kernel is not the direct producer of the tap

The source-authority series rested on one unverified inference — that `0x204da00000`, the 4K storage
image a failing compute program writes, is the composite's empty base tap. One run with
`PROSPER_RTT_GUESTPEEK` settles it, because that instrument prints each surface's **format**:

| surface | format | role | resolved |
| --- | --- | --- | --- |
| `0x2063380000` | **`Float10_11_11`** (fmt 20) | the composite's base tap, 11 samples | **`HIT-CPU`**, all 11 |
| `0x20471e0000` | **`Float16`** (fmt 4) | the presumed HDR source | `HIT-CPU` |
| `0x204da00000` | **`Float32`** (fmt 1) | what `0x2042f49a00` writes, **1** sample | `miss` |

Different address **and** different format. `0x2042f49a00` reads main depth and stencil and writes two
`Float32` images — a depth-derived pass, not the f16 → f11f11f10 conversion the composite is missing.

**What that establishes, precisely:** this kernel is not the *direct* producer of the tap or of the
conversion. It does **not** rule out compute as an *upstream* input to the one graphics draw that binds
the tap, so "the compute path is not the route" would overstate it.

The facts recorded earlier still hold — two failing programs do bind 4K write-capable storage images,
and the only write-class binding of `0x204da00000` did come from a dispatch that never ran. The
**inference** drawn from them does not; the status doc flagged it as "a lead, not an identification" at
the time, so the correction is to the inference and not the evidence.

The source-authority work keeps its own justification: it **defines** the decision that must be made
before compressed bytes are read as plain texels. But note what is not yet true — **neither runtime
consumer is wired.** The compute adapter is parked and the graphics adapter unwritten, so the policy
exists and closes no path yet.

## What the tap is, with denominators

```
PROSPER_TARGET_WATCH=0x2063380000    draws=1 of 262,144 BIND it as a colour target (slot 0)
PROSPER_RTT_INVALIDATE_WATCH         131,072 notified queued writes examined, 0 touched it
PROSPER_RTT_GUESTPEEK                11 samples, HIT-CPU every time
PROSPER_DROPPED_DRAW_CENSUS          its draw is NOT dropped (all 256 drops are on two other targets)
```

So the composite reads a **renderer-owned snapshot associated with one observed binding draw, refreshed
by no observed notified write, whose draw prosper does not drop.** Binding is not writing — whether that
draw wrote useful pixels is **not** established here, and that is the open question. One draw in 262,144
is a findable target; identifying it wants the frame bundle, which is unusable on this title at any
setting (#2554).

## `PROSPER_RTT_INVALIDATE_WATCH`

Is a renderer-owned surface's CPU snapshot ever refreshed, and by whom?

`PROSPER_RTT_GUESTPEEK` cannot answer that, and **that is itself a trap this PR records**: every
renderer-owned surface reports 0% non-zero *guest* bytes whether it renders correctly or not, because
the renderer owns the pixels. All **twenty** `Float10_11_11` surfaces on this route report 0% —
including `0x205f1a0000`, which the status doc elsewhere credits with 44% content. Empty guest memory is
the normal state of a renderer-owned surface, so guestpeek's 0% is not evidence about production. The
tap's emptiness stands on the aliasing A/B (SCANOUT 13.5% → 55.6% with real geometry), a *rendering*
measurement.

The watch reports **both directions on purpose**: an overlapping write prints its effect and the origin
carried through the queue (from #2589); a miss prints nothing, but the periodic line gives writes
examined vs writes hitting, so a zero is a measurement rather than a silence; and a watched address that
is **not in the RTT cache at all** says so once, because that is a different state from "cached and never
refreshed". `writes_hitting` counts once per queued write, so it cannot exceed `writes_examined`.

## Strict watch-list parsing, now governing both diagnostics

`strtoull(spec, &end, 0)` is base 0, which means "`0x` selects hex, **otherwise decimal**". So
`PROSPER_TARGET_WATCH=2063380000` armed a watch on 2,063,380,000, printed `watching 1 address(es)`, and
produced a confident zero for an address nobody asked about. That was recorded as an instrument trap —
and then reproduced by this PR's own new diagnostic, whose comment *claimed* `0x` was required while
nothing checked it.

`parse_hex_watch_list()` requires an explicit `0x`/`0X`, full token consumption, at least one digit, no
64-bit overflow, no zero address, and no empty token from a stray or doubled comma. A rejected spec arms
**nothing** and says so. **Both** `PROSPER_TARGET_WATCH` and `PROSPER_RTT_INVALIDATE_WATCH` use it — the
former matters directly here, because the one-draw result above is central evidence and came from it. An
oversized list is **rejected rather than truncated**, since silently dropping the ninth address would
report "never a target" for a surface never examined. 23 arms.

## Positive metadata-kind correlation

The sampled-source decision merged in #2606 takes `CompressionMetadataKind` as an input and refuses to
guess. This supplies it by **positive correlation over metadata AND resource identity**:

- **HTILE** only when a retained depth surface names this plane *and* one of its aspect bases is this
  resource;
- **DCC** only when a retained colour surface *at this resource address* registered this plane;
- otherwise **`Unknown`** — and the format is deliberately **not** consulted, because a Float32x1 view is
  not necessarily depth and a Uint32x1 alias is not necessarily colour.

`Unknown` when no correlator is registered, so a backend without a renderer fails closed. The rule is a
pure function (`metadata_kind_correlation.hpp`) tested at the site that ships: an earlier version lived
in the renderer's lambda and answered *by elimination*, which classified an uncorrelated `Uint32x1` raw
alias as DCC and would have let its all-`0xff` plane authorize reading the base.

## Mutation coverage, at each production site

```
DCC by elimination                        -> 3 arms fail (incl. every-format/component shape)
HTILE without resource identity           -> 2 arms fail
0x prefix made optional                   -> 3 arms fail (incl. the bare-decimal arm)
```

## Boundary, stated rather than widened

The write watch sees writes reaching `notify_guest_gpu_write`; a producer writing guest memory without
notifying is invisible to it. So this remains **"no observed notified path"**, not "the guest never
writes it" — the same boundary #2542 records, now with a denominator of 131,072 instead of an argument.
What is genuinely new is that the surface is renderer-owned and served from a snapshot, so a guest-memory
producer is not even the mechanism that would fill it.

## Not in this PR

The compute adapter that consumes the decision is **parked**, not forgotten. Wiring it makes
`game_compute_exec`'s ordered writeback round trip decline, because producer authority is a prerequisite
rather than a follow-up — and the journal suggested for it (`writer_provenance.hpp`) is **opt-in and off
by default**, so authority built on it would exist only when a diagnostic switch is set. Open questions
are on #2542.

## Verification

```
cmake --build prosper/build-linux -j6                  # exit 0
ctest --no-tests=error -j4                             # 263/263 passed, exit 0
check_numbered_table.py over all tracked .md           # exit 0
git diff --check                                       # clean
```

No snapshots: the behavioural surface is two opt-in diagnostics and a query that answers `Unknown` until
a renderer registers it.

Windows MinGW failed during **Set up job**, before checkout, unable to download `setup-msys2` (HTTP
429/503) during the GitHub incident — infrastructure rather than code. It needs a rerun before merge.
