### PR TITLE
fix(libkernel): the C11 _Mtx_lock reports a failed lock instead of _Thrd_success (#2626)

### DIFF
--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -850,14 +850,12 @@ HLE(k_mutex_unlock)  { return guest_mutex_unlock_slot(a0); }
 // std::system_error("invalid argument") that terminates the process. A perfectly ordinary
 // "the mutex was busy" therefore killed the guest.
 // CONFIDENCE: HIGH (guest disassembly of the shipped libc.prx is the primary evidence).
-namespace {
-    inline uint64_t sce_pthread_rc(uint64_t posix_rc) {
-        // Pass through success, and anything a body already encoded or that is not an errno.
-        if (posix_rc == 0 || (posix_rc & ~0xffull) != 0) return posix_rc;
-        return prosper::hle::sce_kernel_error(
-            static_cast<prosper::hle::FreeBsdErrno>(static_cast<uint32_t>(posix_rc)));
-    }
-}
+//
+// `sce_pthread_rc` USED TO LIVE HERE, in a file-local anonymous namespace. #2626 moved it to
+// pthread_slot.hpp, beside the C11 `_Mtx_lock` transform that is defined in terms of it — because
+// the guest's own `_Mtx_lock` compares the ENCODED result against an encoded constant, a second
+// copy of this rule would be a copy of the thing the comparison depends on. One definition, both
+// conventions, and the #1873 divergence cannot reopen by drift.
 // One Sony-spelling alias per shared body: same behaviour, libkernel error encoding.
 #define SCE_PTHREAD_ALIAS(sce_name, posix_body) \
     HLE(sce_name) { return sce_pthread_rc(posix_body(a0, a1, a2, a3, a4, a5)); }

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -826,12 +826,23 @@ HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthre
 // the pair's 30 call sites read the value (the reading is worked through in pthread_slot.hpp,
 // #2636). So both destroys answer 0, and #2168's refusal is expressed where it is actually
 // observable: in the object NOT being retired. `_Mtx_lock` maps its result onto a `_Thrd_*` code
-// (`0 -> 0, 0x8002000b -> 3, else 4`) and prosper still answers 0 unconditionally there -- a separate
-// false-success defect, filed as #2626 rather than folded in, because a `_Thrd_error` reaching
-// Dinkumware TERMINATES the guest (see the note above SCE_PTHREAD_ALIAS in hle_kernel.cpp), so it
-// needs its own evidence about which titles reach it. `guest_mutex_lock_slot` already computes the
-// value; the `(void)` below is where it is dropped, deliberately and visibly.
-HLE(m_mtx_lock)   { (void)guest_mutex_lock_slot(a0); return 0; }
+// (`0 -> 0, 0x8002000b -> 3, else 4`), and #2626 is where prosper stopped answering 0 unconditionally
+// there. It was the widest false success left in the family: `std::mutex::lock()` was told it holds a
+// lock it does not, on the two paths `guest_mutex_lock_slot` can refuse — a slot carrying the
+// destroyed poison, and a same-thread relock of an ERRORCHECK mutex.
+//
+// WHY THIS IS A DIVERGENCE AND NOT A STYLE QUESTION, in this repository's own terms: the linker
+// resolves an import against sibling guest modules FIRST ("Cross-module export beats a stub slot",
+// linker.cpp pass 2). So a title that ships `sce_module/libc.prx` runs the wrapper disassembled in
+// pthread_slot.hpp and gets the `_Thrd_*` mapping; a title that does not ships that import to THIS
+// handler instead. Before #2626 the two answered a failing lock differently — the #1873 shape, with
+// the door chosen by the title's packaging rather than by anything it does.
+//
+// The blast radius is bounded on the side that matters: the SUCCESS path is untouched, and a
+// `_Thrd_error` can only reach Dinkumware (where it terminates the guest — see the note above
+// SCE_PTHREAD_ALIAS in hle_kernel.cpp) on a lock prosper REFUSED, which is a lock the guest does not
+// hold. Terminating there is the shipped wrapper's own contract; returning 0 was a corruption.
+HLE(m_mtx_lock)   { return thrd_rc_from_mutex_lock(guest_mutex_lock_slot(a0)); }
 HLE(m_mtx_unlock) { (void)guest_mutex_unlock_slot(a0); return 0; }
 // _Mtx_destroy / _Cnd_destroy are the guest STL's own spelling of the same objects, so they carry
 // the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: quarantine the storage

--- a/prosper/src/hle/pthread_slot.hpp
+++ b/prosper/src/hle/pthread_slot.hpp
@@ -19,7 +19,9 @@
 //                                  0x115510 -> GOT 0x1922e0 -> 9UK1vLZQft4 (scePthreadMutexLock)
 //
 // The two differ in what they do with the RESULT — `_Cnd_wait` discards it, `_Mtx_lock` maps it
-// onto a `_Thrd_*` code — and that difference is not the point here. The point is what neither of
+// onto a `_Thrd_*` code (that mapping is `thrd_rc_from_mutex_lock` below, landed by #2626; it was
+// still a discard when this paragraph was written) — and that difference is not the point here,
+// which is why #2596 deferred it. The point is what neither of
 // them does: **inspect the slot**. Each is a single call with the guest's slot pointer passed
 // straight through, so every question about "is this object initialised, destroyed, or a static
 // sentinel" is answered inside libkernel. A private `if (*slot)` guard in prosper's C11 handler
@@ -150,6 +152,7 @@
 // read by no caller here.
 #pragma once
 
+#include "sce_errno.hpp"     // the libkernel encoding the Sony spelling and the C11 wrapper both use
 #include "sync_retire.hpp"   // SyncObjectKind — the destroy pair keeps its own census bucket
 
 #include <cstdint>
@@ -183,6 +186,105 @@ uint64_t guest_cond_wait_slot(uint64_t cond_slot, uint64_t mutex_slot);
 // EBUSY(16) when the condvar still has waiters — checked BEFORE the slot is claimed, so a refusal
 // leaves the guest a handle that still works (#2168).
 uint64_t guest_cond_destroy_slot(uint64_t slot_addr, SyncObjectKind kind);
+
+// --- the three result conventions those bodies feed (#2626) --------------------------------------
+// THREE spellings reach the identical body and each reports its failure differently. Getting this
+// wrong is the #1612/#1945 family, and it has cost this project a title:
+//
+//   POSIX  `pthread_mutex_lock`   -> the BARE FreeBSD errno, exactly what the bodies above return.
+//   Sony   `scePthreadMutexLock`  -> `sce_pthread_rc` below: 0x8002_0000 | that errno.
+//   C11    `_Mtx_lock`            -> a Dinkumware `_Thrd_*` code, `thrd_rc_from_mutex_lock` below.
+//
+// The C11 transform is DEFINED IN TERMS OF the Sony one rather than beside it, because that is how
+// the guest's own wrapper computes it: it compares `scePthreadMutexLock`'s ENCODED result against
+// the encoded constant. Re-derived independently for #2626 from the shipped `libc.prx` of
+// PPSA24651 — flattened with `tools/il2cpp/prx_to_elf.py`, the export located by NID
+// (`_Mtx_lock` = `iS4aWbUonl0`) in the dynsym at 0x5e80 with st_size 29, the body decoded with
+// `tools/re/edis.py`, and the call taken to its import through the JMPREL slot with
+// `tools/re/stub_nid_map.py` (0x115510 -> `9UK1vLZQft4` scePthreadMutexLock, libkernel):
+//
+//     push rbp; mov rbp,rsp
+//     call   0x115510            ; scePthreadMutexLock
+//     xor    ecx,ecx
+//     cmp    eax,0x8002000b      ; SCE_KERNEL_ERROR_EDEADLK — the ENCODED form, not a bare 11
+//     setne  cl
+//     add    ecx,0x3             ; ecx = 3 if EDEADLK, 4 otherwise
+//     test   eax,eax
+//     cmovne eax,ecx             ; success passes through untouched
+//     pop rbp; ret
+//
+// Two independent controls came with that decode and both fired: `_Mtx_unlock` (0x5e70, 13 bytes)
+// reproduced its recorded `xor eax,eax` DISCARD byte for byte, so this method resolves the right
+// symbol; and `_Mtx_trylock` (0x5ea0, 29 bytes) carries the SAME transform against 0x80020010
+// (encoded EBUSY). That second one is what settles the NAME rather than only the number: two
+// different libkernel refusals — "would deadlock" and "already held" — both land on 3, which is
+// what `_Thrd_busy` means and nothing else in the enum does.
+// CONFIDENCE: HIGH on the numbers (they are the guest's own bytes, quoted above) and on the names
+// (Dinkumware's `_Thrd_*` ordering, already relied on by the `_Thrd_error`(4) reading recorded
+// above SCE_PTHREAD_ALIAS in hle_kernel.cpp).
+inline uint64_t sce_pthread_rc(uint64_t posix_rc) {
+    // Pass through success, and anything a body already encoded or that is not an errno.
+    if (posix_rc == 0 || (posix_rc & ~0xffull) != 0) return posix_rc;
+    return hle::sce_kernel_error(static_cast<hle::FreeBsdErrno>(static_cast<uint32_t>(posix_rc)));
+}
+
+// Dinkumware's C11 result enum, in its declaration order. Only the three the mutex-lock transform
+// can produce are reachable from here; the other two are spelled out so a future `_Mtx_timedlock`
+// transform does not have to re-guess the ordering. Every value below is PINNED BY THE GUEST'S OWN
+// BYTES rather than by analogy to a published header — each is the constant a decoded wrapper in the
+// shipped `libc.prx` of PPSA24651 actually produces (#2626):
+//
+//   0 success   every wrapper: `test eax,eax` then `cmove`/`je` — success passes through untouched
+//   1 nomem     `_Cnd_init`      0x5560: cmp ecx,0x8002000c (ENOMEM)    -> lea eax,[rax+rax*2+1]
+//   2 timedout  `_Mtx_timedlock` 0x5ec0: cmp eax,0x8002003c (ETIMEDOUT) -> lea ecx,[rcx+rcx*1+2]
+//   3 busy      `_Mtx_trylock`   0x5ea0: cmp eax,0x80020010 (EBUSY)     -> add ecx,3
+//   4 error     all four: the failure none of them discriminates
+//
+// THIS ENUM IS NOT THE WHOLE RANGE, and the promise above is deliberately narrower than it once was.
+// An earlier revision offered these values to a future `_Cnd_timedwait` transform as well, and that
+// reader would have been one value short: `_Cnd_timedwait` (0x5680, 73 bytes, its call taken through
+// the JMPREL slot to 0x115650 -> `BmMjYxmew1w` scePthreadCondTimedwait) produces a value outside
+// {0..4}.
+//
+//     56a2: cmp eax,0x8002003c   ; ETIMEDOUT -> mov eax,2
+//     56ad: test ecx,ecx         ; success   -> 0
+//     56b1: cmp ecx,0x80020001   ; EPERM
+//     56b7: sete al
+//     56ba: or   eax,0x4         ; EPERM -> 5, anything else -> 4
+//
+// So its full transform is `0->0, ETIMEDOUT->2, EPERM->5, else->4`. That it discriminates EPERM at
+// all agrees with the #2327 note above `guest_mutex_not_owned_by_self` in hle_kernel.cpp, which
+// records Sony's own `_Cnd_timedwait` testing for it — two independent readings of the same
+// behaviour. The 5 is recorded here so the follow-up does not re-derive it, and deliberately NOT
+// added to the enum below: the bytes give the NUMBER, and Dinkumware's spelling for it has not been
+// traced in this repository. Naming it would be the same unforced guess the block above
+// `thrd_rc_from_mutex_lock` declines to make about which exception `_Thrd_busy` raises.
+// CONFIDENCE: HIGH on every number, address and byte in this block (the guest's own bytes,
+// re-derived with prx_to_elf.py / edis.py / stub_nid_map.py). The names carry the confidence stated
+// above `sce_pthread_rc`, which is where they come from.
+enum : uint64_t {
+    kThrdSuccess  = 0,
+    kThrdNomem    = 1,
+    kThrdTimedout = 2,
+    kThrdBusy     = 3,
+    kThrdError    = 4,
+};
+
+// `_Mtx_lock`'s result transform, applied to a BARE body result. Note what it is NOT: "zero stays
+// zero, non-zero becomes an error". The guest's wrapper spends four instructions singling EDEADLK
+// out, so the two refusals are meant to be distinguishable and collapsing them is a defect even
+// though both are non-zero. What the difference costs is recorded rather than inferred: the
+// `_Thrd_error`(4) path is the one this repository has already traced to
+// `std::_Throw_C_error(4)` -> an uncaught `std::system_error("invalid argument")` that terminates
+// the guest (see the note above SCE_PTHREAD_ALIAS in hle_kernel.cpp, and #1945 where it killed
+// *The Oregon Trail*). The exact exception Dinkumware raises for `_Thrd_busy` has NOT been traced
+// here and is deliberately not stated — what is established is that it is a different path from the
+// one that terminates.
+inline uint64_t thrd_rc_from_mutex_lock(uint64_t posix_rc) {
+    const uint64_t sce = sce_pthread_rc(posix_rc);
+    if (sce == 0) return kThrdSuccess;
+    return sce == hle::kSceKernelErrorEDEADLK ? kThrdBusy : kThrdError;
+}
 
 // Test-only. The missed-wakeup generation counter is bumped by exactly one function
 // (`guest_cond_advance`, hle_kernel.cpp) whose only callers are the signal/broadcast bodies, and its

--- a/prosper/tests/test_c11_sync_bookkeeping.cpp
+++ b/prosper/tests/test_c11_sync_bookkeeping.cpp
@@ -97,6 +97,27 @@
 //                                    -> FAIL (4): the same four. §1, §2 and §3 pass.
 //   M7  make `guest_cond_waiter_leave` a no-op, so the count leaks
 //                                    -> FAIL (1): §4's last arm, and only that one.
+//   M8  restore the pre-#2626 `m_mtx_lock` body, `(void)guest_mutex_lock_slot(a0); return 0;`
+//                                    -> FAIL (2): §6's destroyed-slot arm and its EDEADLK arm.
+//                                       §1-§5 pass, which is the point of putting §6 here rather
+//                                       than folding it into an existing section.
+//   M9  `return guest_mutex_lock_slot(a0) ? 4 : 0` — every refusal becomes `_Thrd_error`
+//                                    -> FAIL (1): the EDEADLK arm ONLY.
+//   M10 `return guest_mutex_lock_slot(a0) ? 3 : 0` — every refusal becomes `_Thrd_busy`
+//                                    -> FAIL (1): the destroyed-slot arm ONLY.
+//   M11 give `m_mtx_unlock` the same transform, i.e. break the #1983/#2596 discard fence
+//                                    -> FAIL (1): §6's `_Mtx_unlock` arm, and only that one.
+//   M12 `(void)guest_mutex_lock_slot(a0); return 4;` — report an error on EVERY lock
+//                                    -> FAIL (3): §6's success control, the ERRORCHECK setup
+//                                       control, and the EDEADLK arm.
+//
+// M9/M10 ARE THE PAIR THAT MATTERS in §6, for the reason M3/M4 matter in §3: `_Mtx_lock`'s contract
+// is a two-way mapping, not "zero or error", and each of those mutations satisfies one half of it.
+// A suite asserting only that a failed lock is non-zero would pass under both. M8 fails both arms,
+// M9 and M10 fail exactly one each, and the arms they fail are different — so the two arms are
+// measurably independent rather than two spellings of one assertion. M11 and M12 exist for the M7
+// reason: without them §6's `_Mtx_unlock` arm and its success control would be rows no mutation
+// kills, and a row nothing kills has never been shown to test anything.
 //
 // M3/M4 are a deliberate pair, and the pair is the evidence: the first breaks the shared body so
 // BOTH spellings lose the behaviour, the second breaks only the C11 one. §3 separates them, so §3
@@ -111,6 +132,11 @@
 // M7 exists because every other arm in §4 survives it: without it, §4's closing arm would be a row
 // no mutation kills, which is a row that has never been shown to test anything.
 //
+// §6 IS A RETURN-VALUE SECTION, and it is in this file rather than in a new one because #2626 is
+// the same divergence as everything above it, one level further out: the C11 spelling and the Sony
+// spelling reach one shared body and must describe its refusals identically, each in its own
+// convention. See pthread_slot.hpp for the three conventions and the guest bytes that fix them.
+//
 // HANG SAFETY. §4 parks a real thread on a condvar. It is DETACHED and every wait is bounded: a
 // regression in this area is a thread that never wakes, and expressing that as a hang burns ctest's
 // timeout and gets misread as machine load on a box that routinely runs at load 30+.
@@ -122,6 +148,7 @@
 #include "../src/hle/sync_retire.hpp"
 
 #include <atomic>
+#include <cerrno>       // §6's construction control asserts EBUSY from a real trylock
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
@@ -393,6 +420,113 @@ int main() {
 #else
     printf("  [skip] Windows-only: the guest-mutex ownership map does not exist on this host, and "
            "an arm that cannot fail is not an arm\n");
+#endif
+
+    // ===== 6. _Mtx_lock REPORTS a failed lock, in the C11 convention (#2626) ====================
+    // The handler used to be `(void)guest_mutex_lock_slot(a0); return 0;` — every refusal the shared
+    // body computes was discarded and the guest's `std::mutex::lock()` was told it holds a lock it
+    // does not. The shipped wrapper does not discard: `_Mtx_lock` (0x5e80, 29 bytes) compares
+    // scePthreadMutexLock's ENCODED result against 0x8002000b and maps 0->0, EDEADLK->3, else->4.
+    // See pthread_slot.hpp for the decode and its two controls.
+    //
+    // THIS IS A DIVERGENCE ARM, not merely a return-value arm. linker.cpp resolves an import against
+    // sibling guest modules before falling to an HLE stub, so a title shipping `sce_module/libc.prx`
+    // got the mapping from its own wrapper and a title without one got the unconditional 0 — the
+    // same question answered differently depending on the title's packaging (#1873).
+    //
+    // THE TWO ARMS BELOW PUSH IN OPPOSITE DIRECTIONS ON PURPOSE, because "non-zero" is not the
+    // contract and an implementation that collapsed the two codes would pass a suite that only
+    // checked one of them:
+    //   * an implementation returning `_Thrd_error`(4) for every refusal fails the EDEADLK arm;
+    //   * an implementation returning `_Thrd_busy`(3) for every refusal fails the destroyed arm;
+    //   * the original unconditional 0 fails both;
+    //   * returning the Sony encoding (0x80020016) or the bare errno (22) fails both.
+    printf("-- _Mtx_lock maps a failed lock onto a _Thrd_* code instead of reporting success --\n");
+    {
+        void* slot = nullptr;
+        CHECK(mtx_init((uint64_t)(uintptr_t)&slot, 0, 0, 0, 0, 0) == 0 && slot != nullptr,
+              "control: _Mtx_init produces an object");
+        CHECK(call1(mtx_lock, &slot) == 0,
+              "control: a lock that SUCCEEDS still reports _Thrd_success(0) -- the fix must not turn "
+              "the ordinary path into an error, and this is the arm that would catch it");
+        call1(mtx_unlock, &slot);
+
+        call1(mtx_destroy, &slot);
+        // `ensure_mutex` refuses the destroyed poison, so the shared body answers EINVAL(22) and
+        // nothing is locked. 4, not 0: the guest is entitled to find out.
+        CHECK(call1(mtx_lock, &slot) == 4,
+              "_Mtx_lock on a DESTROYED slot reports _Thrd_error(4) -- it used to report success for "
+              "a lock that never happened, which is the #2626 false success");
+        // The parity half: the identical refusal, through the Sony door, in the Sony convention.
+        // Both spellings must describe the SAME condition — only the encoding differs.
+        CHECK(call1(sce_mtx_lock, &slot) == prosper::hle::kSceKernelErrorEINVAL,
+              "...and scePthreadMutexLock reports the encoded EINVAL for the same slot at the same "
+              "instant, so the two conventions disagree about the ENCODING and nothing else");
+        // The #1983/#2596 fence, asserted rather than assumed: `_Mtx_unlock` is 13 bytes ending
+        // `xor eax,eax`, so its unconditional 0 is the shipped contract and #2626 must not "fix" it
+        // by symmetry. This arm fails if someone gives unlock the same treatment.
+        CHECK(call1(mtx_unlock, &slot) == 0,
+              "...while _Mtx_unlock STILL returns 0 for the same destroyed slot -- its wrapper discards "
+              "the result, so an unconditional 0 is its contract and not an oversight");
+    }
+
+    // The EDEADLK -> _Thrd_busy(3) arm. It needs a mutex that actually answers EDEADLK, and the two
+    // hosts reach that condition through different code, so it is constructed twice rather than
+    // skipped on one of them — a mapping asserted in only one direction has never been shown to be
+    // a mapping. Both constructions assert the same thing: 3, and specifically NOT 4.
+    printf("-- ...and EDEADLK maps to _Thrd_busy(3), not to _Thrd_error(4) --\n");
+#ifdef _WIN32
+    {
+        // Windows: `ensure_mutex` forces ERRORCHECK and registers the object, so the shared body's
+        // own `guest_mutex_self_deadlock` fires BEFORE `interruptible_mutex_lock`. Taking that route
+        // is not an implementation detail here, it is hang safety: winpthreads' cooperative poller
+        // spins on trylock, and a same-thread relock that reached it would never return.
+        void* slot = nullptr;
+        CHECK(call1(mtx_lock, &slot) == 0, "control: the first _Mtx_lock on a static slot succeeds");
+        CHECK(call1(mtx_lock, &slot) == 3,
+              "a same-thread relock reports _Thrd_busy(3) -- the guest can distinguish 'would "
+              "deadlock' from 'invalid', and only 3 lets it");
+        CHECK(call1(sce_mtx_lock, &slot) == prosper::hle::kSceKernelErrorEDEADLK,
+              "...and the Sony spelling reports the encoded EDEADLK for the same relock");
+        call1(mtx_unlock, &slot);
+    }
+#else
+    {
+        // POSIX: `guest_mutex_self_deadlock` is a no-op here (#719/#793 — routing every guest lock
+        // through one process-global map throttles synchronisation-heavy titles), so the natural
+        // path above cannot produce EDEADLK on this host and an arm written that way would silently
+        // assert nothing. Construct the condition BY HAND instead: an ERRORCHECK mutex installed
+        // straight into the slot. `ensure_mutex` returns any non-sentinel value untouched, so the
+        // shared body reaches `pthread_mutex_lock`, which owes EDEADLK to the owner on relock.
+        pthread_mutex_t errorcheck;
+        pthread_mutexattr_t attr;
+        pthread_mutexattr_init(&attr);
+        pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_ERRORCHECK);
+        CHECK(pthread_mutex_init(&errorcheck, &attr) == 0,
+              "control: an ERRORCHECK mutex is constructible on this host");
+        pthread_mutexattr_destroy(&attr);
+
+        void* slot = &errorcheck;   // above 0x1000, so not a static sentinel — used as-is
+        CHECK(call1(mtx_lock, &slot) == 0,
+              "control: the first _Mtx_lock takes the hand-built ERRORCHECK mutex");
+        // The positive control for the CONSTRUCTION, not for the mapping: if this host's pthreads
+        // did not answer EDEADLK the arm below would be asserting against a condition that never
+        // occurred, and it would fail rather than pass vacuously.
+        CHECK(pthread_mutex_trylock(&errorcheck) == EBUSY,
+              "control: the mutex is genuinely held, so the relock below is a real self-deadlock");
+        CHECK(call1(mtx_lock, &slot) == 3,
+              "a same-thread relock of an ERRORCHECK mutex reports _Thrd_busy(3) -- an implementation "
+              "that answered _Thrd_error(4) for every refusal would turn a recoverable condition "
+              "into an uncaught std::system_error");
+        CHECK(call1(sce_mtx_lock, &slot) == prosper::hle::kSceKernelErrorEDEADLK,
+              "...and the Sony spelling reports the encoded EDEADLK for the same relock, which is the "
+              "constant the guest's own wrapper compares against");
+        CHECK(slot == (void*)&errorcheck,
+              "control: the slot still names the hand-built object, so every arm above operated on "
+              "it rather than on something ensure_mutex manufactured");
+        pthread_mutex_unlock(&errorcheck);
+        pthread_mutex_destroy(&errorcheck);
+    }
 #endif
 
     if (fails) printf("== FAIL (%d) ==\n", fails);


### PR DESCRIPTION
Fixes #2626.

**Stacked on `fix/issue-2619-c11-destroy`** — the base of this PR is that branch, not `master`. It
touches the same C11 handlers (#2619/#2623), and this change builds directly on its shared-body
refactor: `guest_mutex_lock_slot` already computes the value that was being discarded. At the time
of writing, no open PR was listed for that branch yet (checked via the REST listing); the branch
itself is pushed and is this PR's base.

## The defect

`HLE(m_mtx_lock)` (`prosper/src/hle/hle_kernel_time.cpp`) was:

```cpp
HLE(m_mtx_lock)   { (void)guest_mutex_lock_slot(a0); return 0; }
```

The shared libkernel body computes a refusal and the handler discarded it, so a guest
`std::mutex::lock()` was told it holds a lock it does not. Two refusals are reachable: a slot
carrying the destroyed poison (`ensure_mutex` refuses it, EINVAL) and a same-thread relock of an
ERRORCHECK mutex (EDEADLK).

## Which convention, and how that was established

Three conventions meet at these bodies and the wrong one is the #1612/#1945 family:

| spelling | result |
| --- | --- |
| POSIX `pthread_mutex_lock` | the bare FreeBSD errno the shared bodies return |
| Sony `scePthreadMutexLock` | `sce_pthread_rc`: `0x8002_0000 \| errno` |
| C11 `_Mtx_lock` | a Dinkumware `_Thrd_*` code |

**The evidence is the guest's own disassembly, re-derived for this PR rather than taken from the
issue.** The shipped `libc.prx` of PPSA24651 was flattened with `tools/il2cpp/prx_to_elf.py`, the
export located by NID (`_Mtx_lock` = `iS4aWbUonl0`) in the dynsym at **0x5e80 with st_size 29**, the
body decoded with `tools/re/edis.py`, and the call taken to its import through the JMPREL slot with
`tools/re/stub_nid_map.py`:

```
0x115510  9UK1vLZQft4  scePthreadMutexLock  libkernel

_Mtx_lock @0x5e80 (29 bytes)  554889e5e887f6100031c93d0b0002800f95c183c10385c00f45c15dc3
    push   rbp
    mov    rbp,rsp
    call   0x115510            ; scePthreadMutexLock
    xor    ecx,ecx
    cmp    eax,0x8002000b      ; SCE_KERNEL_ERROR_EDEADLK - the ENCODED form, not a bare 11
    setne  cl
    add    ecx,0x3             ; ecx = 3 if EDEADLK, 4 otherwise
    test   eax,eax
    cmovne eax,ecx             ; success passes through untouched
    pop    rbp
    ret
```

So: `0 -> 0`, `0x8002000b -> 3`, anything else non-zero `-> 4`. Note the comparison is against the
**encoded** constant, which is why the C11 transform below is defined in terms of the Sony one.

**Two controls came with the decode and both fired.**

1. `_Mtx_unlock` (0x5e70, **13** bytes, `554889e5e8a7f6100031c05dc3`) reproduced its recorded
   `xor eax,eax` DISCARD byte for byte. That is the recorded #1983/#2596 reading, so this method
   resolved the right symbol — and that discard is the fence that must stay. This PR does not touch
   it, and asserts it.
2. `_Mtx_trylock` (0x5ea0, 29 bytes) carries the **same** transform against `0x80020010` (encoded
   EBUSY). This is the control that settles the *name* rather than only the number: two different
   libkernel refusals — "would deadlock" and "already held" — both land on `3`, which is what
   `_Thrd_busy` means and nothing else in Dinkumware's enum does.

## Why this is a divergence, not a style question

`linker.cpp` pass 2 resolves an import against sibling guest modules before falling to an HLE stub
("Cross-module export beats a stub slot"), and `sce_module/libc.prx` is in `boot_link_inputs`. So a
title shipping that PRX ran the wrapper above and got the mapping, while a title without one reached
this handler and got the unconditional 0. **The answer depended on the title's packaging** — the
#1873 shape, one level further out than #2619/#2623.

## Approach

- `sce_pthread_rc` moves from `hle_kernel.cpp`'s anonymous namespace into `pthread_slot.hpp`, and
  `thrd_rc_from_mutex_lock` is defined **in terms of it**. The guest compares an encoded result
  against an encoded constant, so a second copy of the encoding rule would be a copy of the thing
  the comparison depends on. Sony-spelling behaviour is unchanged: same function, one definition.
- `HLE(m_mtx_lock)` becomes `return thrd_rc_from_mutex_lock(guest_mutex_lock_slot(a0));`.

## Deliberately unaffected

`_Mtx_unlock`, `_Cnd_signal`, `_Cnd_broadcast`, `_Cnd_wait` keep their unconditional 0 — their
wrappers are 13 bytes ending `xor eax,eax`, so that IS their contract (#1983 / #2596). The destroy
pair keeps forwarding. Every Sony and POSIX spelling is byte-for-byte unchanged in behaviour.

## Risk

The success path is untouched. A `_Thrd_error` can only reach Dinkumware — where it terminates the
guest — on a lock prosper **refused**, i.e. one the guest does not hold. Terminating there is the
shipped wrapper's own contract; returning 0 was a silent corruption. Titles that ship
`sce_module/libc.prx` never call this handler at all, so their behaviour cannot change.

## Tests, and the mutation table

§6 of `prosper/tests/test_c11_sync_bookkeeping.cpp`. Each mutation was applied, rebuilt and re-run;
the binary's md5 changed on every arm and returned **exactly** to the fixed baseline
(`8a514e99dfa2035969c7b03f81b1fd52`) on restore, so no arm measured a stale binary.

| # | mutation | measured result |
| --- | --- | --- |
| M8 | restore the pre-fix body, `(void)guest_mutex_lock_slot(a0); return 0;` | **FAIL (2)** — the destroyed-slot arm and the EDEADLK arm |
| M9 | `return guest_mutex_lock_slot(a0) ? 4 : 0` — every refusal becomes `_Thrd_error` | **FAIL (1)** — the EDEADLK arm only |
| M10 | `return guest_mutex_lock_slot(a0) ? 3 : 0` — every refusal becomes `_Thrd_busy` | **FAIL (1)** — the destroyed-slot arm only |
| M11 | give `m_mtx_unlock` the same transform, breaking the #1983 discard fence | **FAIL (1)** — the `_Mtx_unlock` arm only |
| M12 | `(void)guest_mutex_lock_slot(a0); return 4;` — error on every lock | **FAIL (3)** — the success control, the ERRORCHECK setup control, the EDEADLK arm |

M9/M10 are the pair that matters: `_Mtx_lock`'s contract is a **two-way mapping**, not "zero or
error", and each of those mutations satisfies one half of it. A suite asserting only that a failed
lock is non-zero would pass under both. M11 and M12 exist so that no arm in §6 is a row nothing
kills.

M8 verbatim:

```
== test_c11_sync_bookkeeping ==
  [FAIL] _Mtx_lock on a DESTROYED slot reports _Thrd_error(4) - it used to report success for a lock that never happened, which is the #2626 false success
  [FAIL] a same-thread relock of an ERRORCHECK mutex reports _Thrd_busy(3) - an implementation that answered _Thrd_error(4) for every refusal would turn a recoverable condition into an uncaught std::system_error
== FAIL (2) ==
```

M9 verbatim:

```
  [FAIL] a same-thread relock of an ERRORCHECK mutex reports _Thrd_busy(3) - an implementation that answered _Thrd_error(4) for every refusal would turn a recoverable condition into an uncaught std::system_error
== FAIL (1) ==
```

M10 verbatim:

```
  [FAIL] _Mtx_lock on a DESTROYED slot reports _Thrd_error(4) - it used to report success for a lock that never happened, which is the #2626 false success
== FAIL (1) ==
```

M11 verbatim:

```
  [FAIL] ...while _Mtx_unlock STILL returns 0 for the same destroyed slot - its wrapper discards the result, so an unconditional 0 is its contract and not an oversight
== FAIL (1) ==
```

M12 verbatim:

```
  [FAIL] control: a lock that SUCCEEDS still reports _Thrd_success(0) - the fix must not turn the ordinary path into an error, and this is the arm that would catch it
  [FAIL] control: the first _Mtx_lock takes the hand-built ERRORCHECK mutex
  [FAIL] a same-thread relock of an ERRORCHECK mutex reports _Thrd_busy(3) - an implementation that answered _Thrd_error(4) for every refusal would turn a recoverable condition into an uncaught std::system_error
== FAIL (3) ==
```

### The EDEADLK arm is constructed twice, not skipped

The issue suggested asserting `_Thrd_busy` on Windows, where `guest_mutex_self_deadlock` fires.
That helper is a no-op on POSIX (#719/#793), so an arm written the natural way would have asserted
nothing on this host and the mapping would have been guarded in one direction only. On POSIX the arm
therefore builds an **ERRORCHECK mutex by hand** and installs it in the slot: `ensure_mutex` returns
any non-sentinel value untouched, so the shared body reaches `pthread_mutex_lock`, which owes
EDEADLK to its owner on relock. A `pthread_mutex_trylock(...) == EBUSY` control proves the mutex is
genuinely held, so the relock is a real self-deadlock rather than a vacuous pass. Windows keeps the
`guest_mutex_self_deadlock` route deliberately — winpthreads' cooperative poller spins on trylock,
so a same-thread relock reaching it would never return, and this file's HANG SAFETY note applies.

Both hosts additionally assert the Sony spelling reports the encoded `EDEADLK` for the same relock,
so the two conventions are shown to disagree about the **encoding and nothing else**.

## Verification

Linux, inside the project distrobox (a host build silently drops gpu_replay and the Vulkan
execution tests, so it is a weaker fact):

```
cmake --build prosper/build-linux -j4          -> exit 0, 0 errors
ctest --no-tests=error -j4                     -> 100% tests passed, 266 of 266, exit code 0
```

Baseline on the parent branch before any edit was also **266/266, exit code 0** — the count is
unchanged because the new arms extend an existing test binary rather than adding one, so the count
is not itself evidence of a new test; the mutation table above is.

Directly relevant suites, all green: `c11_sync_bookkeeping` (#223), `pthread_error_encoding` (#221),
`mutex_types` (#119), `sce_errno_freebsd` (#74).

## The `_Thrd_*` enum, now pinned by the guest's own bytes — and one value short of the range

Raised in review and addressed here. Every value in the enum is the constant a decoded wrapper
actually produces, not an analogy to a published header:

| value | wrapper | discriminating compare |
| --- | --- | --- |
| 0 success | all of them | `test eax,eax` then `cmove`/`je` — success passes through untouched |
| 1 nomem | `_Cnd_init` 0x5560 | `cmp ecx,0x8002000c` (ENOMEM) → `lea eax,[rax+rax*2+1]` |
| 2 timedout | `_Mtx_timedlock` 0x5ec0 | `cmp eax,0x8002003c` (ETIMEDOUT) → `lea ecx,[rcx+rcx*1+2]` |
| 3 busy | `_Mtx_trylock` 0x5ea0 | `cmp eax,0x80020010` (EBUSY) → `add ecx,3` |
| 4 error | all four | the failure none of them discriminates |

**The enum comment used to promise more than it carries, and that is corrected.** It offered these
values to a future `_Cnd_timedwait` transform as well; that reader would have been one value short.
`_Cnd_timedwait` (0x5680, 73 bytes, its call taken through the JMPREL slot to 0x115650 →
`BmMjYxmew1w` `scePthreadCondTimedwait`) produces a value outside `{0..4}`:

```
56a2: cmp eax,0x8002003c   ; ETIMEDOUT -> mov eax,2
56ad: test ecx,ecx         ; success   -> 0
56b1: cmp ecx,0x80020001   ; EPERM
56b7: sete al
56ba: or   eax,0x4         ; EPERM -> 5, anything else -> 4
```

So its full transform is `0->0, ETIMEDOUT->2, EPERM->5, else->4`. That it discriminates EPERM at all
agrees with the #2327 note above `guest_mutex_not_owned_by_self` in `hle_kernel.cpp`, which records
Sony's own `_Cnd_timedwait` testing for it — two independent readings of the same behaviour.

**The 5 is recorded so the follow-up does not re-derive it, and deliberately NOT added to the enum.**
The bytes give the *number*; Dinkumware's spelling for it has not been traced in this repository, and
naming it would be the same unforced guess this PR already declines to make about which exception
`_Thrd_busy` raises.

## Follow-up filed separately

`_Mtx_trylock`, `_Mtx_timedlock` and `_Cnd_timedwait` are **not registered at all**, so they fall to
the dispatcher's default 0 — which for a trylock means "you own the lock". Same false-success class,
not folded in here. Decoded transforms, free for whoever takes it: trylock `0->0, EBUSY->3, else 4`;
timedlock `0->0, ETIMEDOUT->2, else 4`; timedwait `0->0, ETIMEDOUT->2, EPERM->5, else 4`.


**ASCII output gate (#2588/#2614).** That gate merged onto master while this PR was open and fails
the build on non-ASCII inside a **string literal**. This branch's new test arms introduced **10**; all
are swept (em dash -> `--`, ellipsis -> `...`), `tools/output/check_ascii_output.py` passes, and **no
ledger number was raised**. Comments keep their non-ASCII by the gate's own design.


**Verification at head `f1c3cad7`** (rebased onto master `a67f9452`): build exit 0; `ctest -N` -> 273; `ctest --no-tests=error -j4` -> **273/273 passed, exit 0**.