### PR TITLE
fix(libkernel): the C11 _Mtx_*/_Cnd_* handlers must keep the libkernel BODY, not just its slot resolution

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1772,6 +1772,16 @@ if(TARGET prosper_core)
     add_test(NAME c11_thread_slots COMMAND test_c11_thread_slots)
     set_tests_properties(c11_thread_slots PROPERTIES TIMEOUT 120)
 
+    # #2619 / #2623: sharing the slot RESOLUTION was not the same as sharing the per-object
+    # BOOKKEEPING. Guards the claim-and-poison of a destroyed slot, the missed-wakeup generation,
+    # and the cond-destroy waiter count -- through BOTH spellings, since a divergence between them
+    # is the defect. Deliberately separate from c11_thread_slots: every arm there passes with the
+    # bookkeeping absent. Same generous TIMEOUT, same reason -- one arm parks a real thread.
+    add_executable(test_c11_sync_bookkeeping tests/test_c11_sync_bookkeeping.cpp)
+    target_link_libraries(test_c11_sync_bookkeeping PRIVATE prosper_core)
+    add_test(NAME c11_sync_bookkeeping COMMAND test_c11_sync_bookkeeping)
+    set_tests_properties(c11_sync_bookkeeping PROPERTIES TIMEOUT 120)
+
     # __tls_get_addr per-thread DTV is purged (blocks freed) on both thread-exit paths (#68), and
     # normal return leaves guest %fs before glibc resumes host pthread cleanup (#644).
     add_executable(test_tls_dtv_purge tests/test_tls_dtv_purge.cpp)

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -732,10 +732,21 @@ namespace { inline uint64_t fbsd_errno(int host) {
 // CONFIDENCE: HIGH on the table above (read out of libthr and libc, the guest's own platform);
 // CONFIDENCE: MED that Sony's libkernel did not re-write these bodies, which no evidence in the
 // corpus can currently settle either way — a title observed testing a Destroy result would.
-HLE(k_mutex_destroy) { auto* m = (pthread_mutex_t*)pt_claim_slot(a0);   // #2176: claim, then retire
-    if (m) { guest_mutex_unregister(m); retire_sync_object(m, SyncObjectKind::Mutex,
+//
+// The body lives in `guest_mutex_destroy_slot` so the C11 `_Mtx_destroy` spelling runs THIS code
+// rather than a second, weaker copy of it (#2619). The copy it used to run read the slot with a bare
+// truthiness test and never cleared it, which made a double `_Mtx_destroy` a double FREE ~30 s
+// later, left the slot naming quarantined storage a later `_Mtx_lock` would happily take, and
+// handed `kPtDestroyed` (0xDEA) to `pthread_mutex_destroy` and `free` if the object had already been
+// destroyed through the Sony spelling. `pt_claim_slot` closes all three at once, which is why it is
+// the shared primitive rather than three separate guards.
+uint64_t guest_mutex_destroy_slot(uint64_t slot_addr, SyncObjectKind kind) {
+    auto* m = (pthread_mutex_t*)pt_claim_slot(slot_addr);   // #2176: claim, then retire
+    if (m) { guest_mutex_unregister(m); retire_sync_object(m, kind,
                                     [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); }
-    return 0; }
+    return 0;
+}
+HLE(k_mutex_destroy) { return guest_mutex_destroy_slot(a0, SyncObjectKind::Mutex); }
 // PROSPER_MUTEX_FAILLOG: report any mutex op that returns a non-zero (EINVAL/EDEADLK/...) result,
 // with the guest slot address and the host object it resolved to. Diagnostic for the macOS
 // guest-side "std::mutex lock failed: Invalid argument" terminate — a host EINVAL(22) surfaces as
@@ -792,26 +803,38 @@ namespace {
     inline void mtx_waitlog_report_block(pthread_mutex_t*, uint64_t) {}
 }
 #endif
-HLE(k_mutex_lock)    {
-    auto* m = ensure_mutex(a0); if (!m) return 0x16;
-    if (guest_mutex_self_deadlock(m)) return mtx_report("lock", a0, m, EDEADLK);
-    mtx_waitlog_report_block(m, a0);
+// Lock and unlock are bodies rather than handlers for the same reason destroy is: the C11
+// `_Mtx_lock` / `_Mtx_unlock` forward to exactly these libkernel entry points on hardware, and
+// before #2623 they reached `interruptible_mutex_lock` / `pthread_mutex_unlock` DIRECTLY, skipping
+// `guest_mutex_self_deadlock` and the `guest_mutex_acquired` / `guest_mutex_released` ownership map.
+// That map is Windows-only, and so was the damage: `ensure_mutex` forces ERRORCHECK there, so a
+// static mutex first touched through the C11 spelling was registered with `owner == 0` and stayed
+// that way — a same-thread relock got winpthreads' raw EDEADLK instead of the clean refusal, and a
+// `_Mtx_unlock` of a Sony-locked mutex left `owner` stale, refusing the next legitimate
+// `scePthreadMutexLock` forever. Sharing the body removes the divergence rather than duplicating
+// the three calls that fix it.
+uint64_t guest_mutex_lock_slot(uint64_t slot_addr) {
+    auto* m = ensure_mutex(slot_addr); if (!m) return 0x16;
+    if (guest_mutex_self_deadlock(m)) return mtx_report("lock", slot_addr, m, EDEADLK);
+    mtx_waitlog_report_block(m, slot_addr);
     const int result = interruptible_mutex_lock(m);
     if (result == 0) { guest_mutex_acquired(m); mtx_waitlog_record(m); }
-    return mtx_report("lock", a0, m, result);
+    return mtx_report("lock", slot_addr, m, result);
 }
+uint64_t guest_mutex_unlock_slot(uint64_t slot_addr) {
+    auto* m = ensure_mutex(slot_addr); if (!m) return 0x16;
+    const int result = pthread_mutex_unlock(m);
+    if (result == 0) { guest_mutex_released(m); mtx_waitlog_clear(m); }
+    return mtx_report("unlock", slot_addr, m, result);
+}
+HLE(k_mutex_lock)    { return guest_mutex_lock_slot(a0); }
 HLE(k_mutex_trylock) {
     auto* m = ensure_mutex(a0); if (!m) return 0x16;
     const int result = pthread_mutex_trylock(m);
     if (result == 0) { guest_mutex_acquired(m); mtx_waitlog_record(m); }
     return mtx_report("trylock", a0, m, result);
 }
-HLE(k_mutex_unlock)  {
-    auto* m = ensure_mutex(a0); if (!m) return 0x16;
-    const int result = pthread_mutex_unlock(m);
-    if (result == 0) { guest_mutex_released(m); mtx_waitlog_clear(m); }
-    return mtx_report("unlock", a0, m, result);
-}
+HLE(k_mutex_unlock)  { return guest_mutex_unlock_slot(a0); }
 
 // --- Sony vs POSIX failure encoding for the shared pthread bodies (#1945, family of #1612) -------
 // The handler bodies above are registered under BOTH spellings. They are not the same contract:
@@ -1023,32 +1046,57 @@ SCE_PTHREAD_ALIAS(k_sce_condattr_setclock,     k_condattr_setclock)
 SCE_PTHREAD_ALIAS(k_sce_condattr_getclock,     k_condattr_getclock)
 SCE_PTHREAD_ALIAS(k_sce_condattr_setpshared,   k_condattr_setpshared)
 SCE_PTHREAD_ALIAS(k_sce_condattr_getpshared,   k_condattr_getpshared)
-HLE(k_cond_destroy) {
+// Shared with the C11 `_Cnd_destroy`, whose eleven-byte guest wrapper is a single call to THIS very
+// entry point (see the table in pthread_slot.hpp). What that establishes is the EFFECT, not a return
+// value: whatever this body does to the object is what happens on hardware through the C11 spelling
+// too, so the refusal below belongs to both. It does NOT establish that `_Cnd_destroy` forwards the
+// result — eleven bytes with no `xor eax,eax` is the shape of a void wrapper, and pthread_slot.hpp
+// works that reading through (#2636); the C11 handler encodes nothing and answers 0.
+// Its old private body retired unconditionally, so the EBUSY refusal below did not exist through that
+// spelling: a thread parked on the condvar had its object quarantined out from under it, which is
+// #2168's failure re-entered through a different door (#2619 / #2623).
+uint64_t guest_cond_destroy_slot(uint64_t slot_addr, SyncObjectKind kind) {
     // #2168: refuse a condvar that still has waiters, the way FreeBSD's _thr_cond_destroy does.
     // Checked BEFORE pt_claim_slot, because claiming retires the slot -- answering EBUSY after
     // clearing it would be the worst of both: the guest keeps a handle it is told is still live,
     // pointing at storage prosper has already quarantined.
-    if (auto* existing = (pthread_cond_t*)pt_peek_slot(a0)) {
+    if (auto* existing = (pthread_cond_t*)pt_peek_slot(slot_addr)) {
         if (guest_cond_has_waiters(existing))
-            // Bare errno here; the Sony spelling encodes it via SCE_PTHREAD_ALIAS below.
+            // Bare errno here; each spelling encodes it its own way at its own entry point.
             return static_cast<uint64_t>(prosper::hle::FreeBsdErrno::EBusy);
     }
-    if (auto* cond = (pthread_cond_t*)pt_claim_slot(a0)) {   // #2176: claim, then retire
+    if (auto* cond = (pthread_cond_t*)pt_claim_slot(slot_addr)) {   // #2176: claim, then retire
         // Quarantined, not freed, and the host `pthread_cond_destroy` runs at reclaim rather than
         // here — see the contract block above k_mutex_destroy and sync_retire.hpp (#2042). A thread
         // parked in interruptible_cond_wait is inside this very object.
         interruptible_cond_forget(cond);
         guest_cond_unregister(cond);
-        retire_sync_object(cond, SyncObjectKind::Cond,
+        retire_sync_object(cond, kind,
                            [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); });
     }
     return 0;
 }
+HLE(k_cond_destroy) { return guest_cond_destroy_slot(a0, SyncObjectKind::Cond); }
 // #2168 makes this body fallible, so the Sony spelling needs the encoding split -- previously it
 // was registered straight onto k_cond_destroy with the comment "always 0", which was true until now.
 SCE_PTHREAD_ALIAS(k_sce_cond_destroy, k_cond_destroy)
-HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_signal(c); } return 0; }
-HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); if (auto* c = ensure_cond(a0)) { guest_cond_advance(c); interruptible_cond_broadcast(c); } return 0; }
+// `guest_cond_advance` is the missed-wakeup guard: `interruptible_cond_clock_timedwait` converts a
+// non-realtime deadline by waiting in slices, and a signal that lands between two slices is
+// recovered ONLY by observing the generation change. The C11 `_Cnd_signal`/`_Cnd_broadcast` did not
+// bump it (#2623), so a guest signalling through the C11 spelling and waiting through the Sony one
+// — possible on the SAME object since #2596 made both resolve the same slot — could lose the wakeup
+// and time out instead. Sharing the body is what stops the pair drifting again.
+void guest_cond_signal_slot(uint64_t slot_addr) {
+    if (auto* c = ensure_cond(slot_addr)) { guest_cond_advance(c); interruptible_cond_signal(c); }
+}
+void guest_cond_broadcast_slot(uint64_t slot_addr) {
+    if (auto* c = ensure_cond(slot_addr)) { guest_cond_advance(c); interruptible_cond_broadcast(c); }
+}
+HLE(k_cond_signal)    { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.signal    cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); guest_cond_signal_slot(a0); return 0; }
+HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.broadcast cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); guest_cond_broadcast_slot(a0); return 0; }
+uint64_t guest_cond_generation_for_test(pthread_cond_t* cond) {
+    return guest_cond_snapshot(cond).generation;
+}
 // The two guest-slot resolvers, published for the C11 `_Mtx_*` / `_Cnd_*` handlers in
 // hle_kernel_time.cpp (#2596). They are thin by design: `ensure_mutex` / `ensure_cond` above hold
 // the whole contract -- FreeBSD's static-initialiser sentinels self-initialise (#793), a destroyed
@@ -1058,6 +1106,18 @@ HLE(k_cond_broadcast) { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu
 // initialised object as absent. On hardware it has no such guard: the shipped libc.prx's `_Cnd_wait`
 // is `call <scePthreadCondWait>; xor eax,eax; ret`, so the C11 spelling resolves its slots through
 // exactly this code. See pthread_slot.hpp.
+//
+// Sharing the RESOLVERS was only half of it, and #2619/#2623 are the other half: the C11 handlers
+// kept none of the per-object bookkeeping the Sony bodies keep, so they are now built on the WHOLE
+// operations published beside these two (`guest_mutex_lock_slot`, `guest_cond_destroy_slot`, …)
+// rather than on a resolver plus a private body.
+//
+// THESE TWO CONSEQUENTLY HAVE NO CALLERS LEFT, and that is stated rather than dressed up, because
+// the tempting justification ("_Mtx_init/_Cnd_init still need them") is simply false — those two
+// handlers allocate and initialise directly. They are kept for one checkable reason: the measured
+// mutation table in tests/test_c11_thread_slots.cpp names `guest_cond_from_slot` as the lever its
+// N4 arm pulls, so deleting them would silently retire a recorded, reproducible arm in a sibling
+// suite. If that table is ever re-derived against `ensure_cond` instead, delete these.
 pthread_mutex_t* guest_mutex_from_slot(uint64_t slot_addr) { return ensure_mutex(slot_addr); }
 pthread_cond_t*  guest_cond_from_slot(uint64_t slot_addr)  { return ensure_cond(slot_addr); }
 
@@ -1078,17 +1138,19 @@ pthread_cond_t*  guest_cond_from_slot(uint64_t slot_addr)  { return ensure_cond(
 // NOT changed, and deliberately: the C11 `_Cnd_wait` (hle_kernel_time.cpp `m_cnd_wait`) still
 // returns 0 unconditionally, because the SHIPPED guest libc.prx does exactly that -- its `_Cnd_wait`
 // is `call <scePthreadCondWait>; xor eax,eax; ret`. There the unconditional 0 is the contract
-// rather than a defect, and prosper reimplementing it faithfully is the point.
+// rather than a defect, and prosper reimplementing it faithfully is the point. What it now shares
+// with this spelling is the BODY below, including the #2168 waiter scope -- #2623: a thread parked
+// through the C11 spelling was invisible to `k_cond_destroy`'s busy check, so a destroy retired the
+// object out from under it. The RESULT is where the two spellings differ; the wait itself is not.
+uint64_t guest_cond_wait_slot(uint64_t cond_slot, uint64_t mutex_slot) {
+    auto* c = ensure_cond(cond_slot); auto* m = ensure_mutex(mutex_slot);
+    if (!c || !m) return 22;   // EINVAL — not a condition variable, or not a mutex. Bare; see the alias.
+    GuestCondWaiterScope waiting(c);   // #2168 -- covers every wait path in this body
+    return fbsd_errno(interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,
+                                              nullptr, kGuestMutexCondWaitBookkeeping));
+}
 HLE(k_cond_wait)      { if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.ent  cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0);
-    uint64_t result;
-    { auto* c = ensure_cond(a0); auto* m = ensure_mutex(a1);
-      if (!c || !m) {
-          result = 22;   // EINVAL — not a condition variable, or not a mutex. Bare; see the alias.
-      } else {
-          GuestCondWaiterScope waiting(c);   // #2168 -- covers every wait path in this body
-          result = fbsd_errno(interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,
-                                                      nullptr, kGuestMutexCondWaitBookkeeping));
-      } }
+    const uint64_t result = guest_cond_wait_slot(a0, a1);
     if (sclog_condition()) fprintf(stderr, "[sync2] T%" PRIu64 " COND.wait.exit cond=0x%llx\n", sctid(), a0 ? (unsigned long long)*(void**)a0 : 0); return result; }
 // The body above is registered under BOTH spellings, which is exactly why the fix could not live in
 // it alone: `pthread_cond_wait` must report the bare errno and `scePthreadCondWait` the encoded one,
@@ -1124,14 +1186,15 @@ HLE(k_cond_timedwait) {
     // branch added here cannot miss it; a future BODY still has to remember, which is why the
     // cond-wait bodies are the unit.
     //
-    // THREE bodies take this scope, and that is NOT the same as "all of them" -- the earlier
-    // wording here said "there are exactly three", and #2596 made it false while relying on it.
-    // The C11 `m_cnd_wait` (hle_kernel_time.cpp) is a fourth body that can park, because it now
-    // resolves a statically-initialised slot instead of skipping it, and it does NOT take the
-    // scope. So a thread parked through the C11 spelling is still invisible to the busy check
-    // below, and a destroy will retire the object out from under it -- #2168's exact failure
-    // through a different door. Tracked as #2623 with the file:line and the mechanism; recorded
-    // here rather than in the issue alone because a bare count is what the next reader trusts.
+    // DO NOT WRITE A COUNT HERE. The earlier wording said "the three cond-wait bodies are the unit
+    // and there are exactly three"; #2596 made that false while relying on it (the C11 `m_cnd_wait`
+    // became a fourth body that could park, and took no scope), and #2623 had to correct it. A bare
+    // count is exactly what the next reader trusts and nobody re-derives, so it is the wrong thing
+    // to record. What holds instead, and can be checked mechanically: every indefinite park now goes
+    // through `guest_cond_wait_slot`, which takes the scope itself, and the only bodies that call
+    // `interruptible_cond_*wait` outside it are the two TIMED ones -- this function and
+    // `k_sce_cond_timedwait`. `grep -n 'interruptible_cond_\(clock_\)\?timed\?wait' hle_kernel.cpp`
+    // is the check; anything it lists that is not scoped is a #2168 regression.
     GuestCondWaiterScope waiting(c);
     if (!a2) {
         int rc = interruptible_cond_wait(c, m, GuestWaitKind::ConditionSequence, 0,

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -785,8 +785,10 @@ HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthre
 //     segfault. Routing through the resolver fixes a use-after-destroy crash on this spelling as
 //     well as the missing operation.
 //
-// The guard is gone in favour of guest_mutex_from_slot / guest_cond_from_slot, which ARE
+// The guard is gone. #2596 replaced it with guest_mutex_from_slot / guest_cond_from_slot, which ARE
 // ensure_mutex / ensure_cond -- the same resolution scePthreadMutexLock and scePthreadCondWait use.
+// (#2619/#2623 then went further and took the whole libkernel BODY, so no handler below names those
+// two resolvers any more; the resolution they describe is still exactly what happens, one level in.)
 // That is where the guest itself answers the question: its C11 wrappers pass the slot pointer
 // STRAIGHT THROUGH to those entry points and inspect nothing (_Cnd_wait @0x5670 and _Mtx_lock
 // @0x5e80 in the shipped libc.prx, both re-derived through their JMPREL slots for #2596 -- see
@@ -797,29 +799,70 @@ HLE(m_mtx_init)   { if (a0) { auto* m = (pthread_mutex_t*)calloc(1, sizeof(pthre
 // The family moves TOGETHER on purpose. Fixing only the wait would leave `_Mtx_lock` no-opping on a
 // static mutex while `_Cnd_wait` self-initialised and waited on it, i.e. a wait on a mutex nothing
 // had locked -- one spelling of the #1873 shape, where the answer depends on which entry point the
-// guest happened to use. Destroy is NOT in this list: retiring an object the guest never
-// initialised would be a new defect, not a fix.
-HLE(m_mtx_lock)   { if (auto* m = guest_mutex_from_slot(a0)) interruptible_mutex_lock(m); return 0; }
-HLE(m_mtx_unlock) { if (auto* m = guest_mutex_from_slot(a0)) pthread_mutex_unlock(m); return 0; }
+// guest happened to use.
+//
+// SHARING THE RESOLUTION WAS ONLY HALF (#2619, #2623). Each handler below still carried a PRIVATE
+// BODY around the shared resolver, and four pieces of per-object bookkeeping the libkernel bodies
+// keep did not travel with it: the destroy pair never claimed or poisoned the slot (#2619, so a
+// double `_Mtx_destroy` was a double free and a slot already destroyed through the Sony spelling had
+// its 0xDEA poison dereferenced as a pointer); the C11 signal/broadcast never bumped the
+// missed-wakeup generation; the C11 wait was invisible to the cond-destroy busy check (#2168); and
+// the C11 lock/unlock bypassed the Windows guest-mutex ownership map. Each is the same #1873 shape
+// again, one level down. So every handler below is now the libkernel BODY -- `pthread_slot.hpp`'s
+// whole-operation family, which the scePthread* handlers call too -- and there is no private body
+// left to drift.
+//
+// DESTROY IS IN THE LIST NOW, and #2596's note that it is not is superseded rather than contradicted:
+// what that note ruled out was retiring an object the guest never initialised, and
+// `guest_mutex_destroy_slot` does not do that either. `pt_claim_slot` returns nullptr for every
+// sub-page value, so an untouched static slot is still a no-op.
+//
+// WHAT EACH HANDLER RETURNS is the one thing that stays per-spelling, and it is READ OUT of the
+// guest's own wrappers rather than chosen -- see the table in pthread_slot.hpp. `_Mtx_unlock`,
+// `_Cnd_signal`, `_Cnd_broadcast` and `_Cnd_wait` are 13 bytes ending `xor eax,eax; pop rbp; ret`,
+// so 0 is their CONTRACT. The destroy pair is 11 bytes and never touches eax after its call, which
+// does NOT establish that it forwards libkernel's answer -- eleven bytes with no `xor eax,eax` is
+// precisely what a VOID wrapper compiles to, `_Thrd_yield` is the byte-identical control, and 0 of
+// the pair's 30 call sites read the value (the reading is worked through in pthread_slot.hpp,
+// #2636). So both destroys answer 0, and #2168's refusal is expressed where it is actually
+// observable: in the object NOT being retired. `_Mtx_lock` maps its result onto a `_Thrd_*` code
+// (`0 -> 0, 0x8002000b -> 3, else 4`) and prosper still answers 0 unconditionally there -- a separate
+// false-success defect, filed as #2626 rather than folded in, because a `_Thrd_error` reaching
+// Dinkumware TERMINATES the guest (see the note above SCE_PTHREAD_ALIAS in hle_kernel.cpp), so it
+// needs its own evidence about which titles reach it. `guest_mutex_lock_slot` already computes the
+// value; the `(void)` below is where it is dropped, deliberately and visibly.
+HLE(m_mtx_lock)   { (void)guest_mutex_lock_slot(a0); return 0; }
+HLE(m_mtx_unlock) { (void)guest_mutex_unlock_slot(a0); return 0; }
 // _Mtx_destroy / _Cnd_destroy are the guest STL's own spelling of the same objects, so they carry
 // the same lifetime rule as scePthreadMutexDestroy / scePthreadCondDestroy: quarantine the storage
 // instead of freeing it here, and defer the host destroy to reclaim, because a thread may be parked
 // inside the object. See the contract block above k_mutex_destroy in hle_kernel.cpp, and
-// sync_retire.hpp (#2042).
-HLE(m_mtx_destroy){ if (a0 && *(void**)P(a0)) { retire_sync_object(*(void**)P(a0), SyncObjectKind::StlMutex,
-                                                          [](void* p) { pthread_mutex_destroy((pthread_mutex_t*)p); }); } return 0; }
+// sync_retire.hpp (#2042). The `SyncObjectKind` argument is the ONLY thing that differs from the
+// Sony spelling: it keeps the `_Mtx`/`_Cnd` census buckets #2619 used as its reachability evidence.
+HLE(m_mtx_destroy){ return guest_mutex_destroy_slot(a0, SyncObjectKind::StlMutex); }
 HLE(m_cnd_init)   { if (a0) { auto* c = (pthread_cond_t*)calloc(1, sizeof(pthread_cond_t)); pthread_cond_init(c, nullptr); *(void**)P(a0) = c; } return 0; }
-HLE(m_cnd_signal) { if (auto* c = guest_cond_from_slot(a0)) interruptible_cond_signal(c); return 0; }
-HLE(m_cnd_broadcast){ if (auto* c = guest_cond_from_slot(a0)) interruptible_cond_broadcast(c); return 0; }
+HLE(m_cnd_signal) { guest_cond_signal_slot(a0); return 0; }
+HLE(m_cnd_broadcast){ guest_cond_broadcast_slot(a0); return 0; }
 // The `return 0` here is NOT the defect and must stay. The shipped guest libc.prx's own `_Cnd_wait`
 // is `push rbp; mov rbp,rsp; call <plt scePthreadCondWait>; xor eax,eax; pop rbp; ret` -- it
 // discards the result on every path, so an unconditional 0 is the CONTRACT rather than an oversight
 // (#1983, recorded above k_cond_wait, which is where the reading was made). #2596 is only about the
-// wait not happening. Do not "fix" this line.
-HLE(m_cnd_wait)   { auto* c = guest_cond_from_slot(a0); auto* m = guest_mutex_from_slot(a1);
-                    if (c && m) interruptible_cond_wait(c, m); return 0; }
-HLE(m_cnd_destroy){ if (a0 && *(void**)P(a0)) { auto* c = (pthread_cond_t*)*(void**)P(a0); interruptible_cond_forget(c); retire_sync_object(c, SyncObjectKind::StlCond,
-                                                                       [](void* p) { pthread_cond_destroy((pthread_cond_t*)p); }); } return 0; }
+// wait not happening. Do not "fix" this line. What DID change is the body whose result it discards:
+// `guest_cond_wait_slot` takes the #2168 waiter scope, so a thread parked here is visible to every
+// cond-destroy busy check instead of having its condvar retired out from under it (#2623).
+HLE(m_cnd_wait)   { (void)guest_cond_wait_slot(a0, a1); return 0; }
+// Answers 0, exactly like its `_Mtx_destroy` sibling above. The guest's eleven-byte wrapper never
+// touches eax after its call to `scePthreadCondDestroy`, and that shape does NOT establish a
+// forwarded result -- it is what a void wrapper compiles to (pthread_slot.hpp works the reading
+// through against `_Thrd_yield`, its byte-identical void control, and against a call-site census in
+// which 0 of 30 destroy sites read the value; #2636).
+// What #2168 needs from this handler is a REFUSAL, not a number, and the refusal is in the shared
+// body: `guest_cond_destroy_slot` declines to claim or retire a condvar a thread is parked on, so
+// the guest keeps a handle that still works. Publishing `kSceKernelErrorEBUSY` here instead would
+// put a LIBKERNEL-encoded value through a C11-spelled door -- a third convention, neither the bare
+// errno the POSIX spelling answers nor a `_Thrd_*` code, and the one answer no reading of the bytes
+// supports. The `(void)` is where the shared body's result is dropped, deliberately and visibly.
+HLE(m_cnd_destroy){ (void)guest_cond_destroy_slot(a0, SyncObjectKind::StlCond); return 0; }
 
 // --- event queue (sceKernelEqueue): kqueue-like event mechanism the engine uses for vsync/flip
 // and async I/O completion. Headless: give a valid queue object; WaitEqueue yields briefly and

--- a/prosper/src/hle/pthread_slot.hpp
+++ b/prosper/src/hle/pthread_slot.hpp
@@ -25,7 +25,132 @@
 // sentinel" is answered inside libkernel. A private `if (*slot)` guard in prosper's C11 handler
 // answers a DIFFERENT question: it reads a statically initialised object as absent and skips the
 // operation entirely (#2596).
+//
+// SHARING THE RESOLUTION WAS NOT ENOUGH (#2619, #2623). #2596 gave the C11 handlers the same slot
+// RESOLUTION as their Sony counterparts and left each one keeping its own (absent) per-object
+// BOOKKEEPING: the destroy-busy waiter count (#2168), the missed-wakeup generation, the Windows
+// ownership map, and the claim-and-poison of a destroyed slot (#2176/#2170 -- the half #2619 is
+// about). Every one of those is the #1873 shape, the same question answered differently depending
+// on which spelling the guest happened to use, and the C11 spelling could reach them all the moment
+// its slots started resolving.
+//
+// So the family below publishes WHOLE OPERATIONS rather than resolvers, and both spellings call
+// them. That is not tidiness either: the guest's own wrappers ARE the Sony entry points. Read out
+// of the shipped libc.prx of PPSA24651, each PLT thunk taken to its import through the JMPREL slot
+// (`tools/re/stub_nid_map.py`) rather than by adjacency, and each body decoded with
+// `tools/re/edis.py`:
+//
+//   export         addr    size  forwards to                what it does with the result
+//   _Mtx_init      0x5dc0  0x73  scePthreadMutexattr{Init,Settype,Destroy}, scePthreadMutexInit
+//                                                           maps onto a _Thrd_* code
+//   _Mtx_lock      0x5e80  0x1d  scePthreadMutexLock        maps: 0->0, 0x8002000b->3, else 4
+//   _Mtx_unlock    0x5e70  0x0d  scePthreadMutexUnlock      xor eax,eax -- DISCARDS
+//   _Mtx_destroy   0x5e60  0x0b  scePthreadMutexDestroy     nothing after the call touches eax
+//   _Cnd_init      0x5560  0x9d  scePthreadCondInit         maps onto a _Thrd_* code
+//   _Cnd_signal    0x56d0  0x0d  scePthreadCondSignal       xor eax,eax -- DISCARDS
+//   _Cnd_broadcast 0x56e0  0x0d  scePthreadCondBroadcast    xor eax,eax -- DISCARDS
+//   _Cnd_wait      0x5670  0x0d  scePthreadCondWait         xor eax,eax -- DISCARDS
+//   _Cnd_destroy   0x5660  0x0b  scePthreadCondDestroy      nothing after the call touches eax
+//   _Thrd_yield    0x4ee0  0x0b  scePthreadYield            nothing after the call touches eax
+//                                                           (not a sync primitive -- it is here as
+//                                                            the CONTROL for the block below)
+//
+// Every wrapper is a single call with the guest's slot pointer passed straight through, and not one
+// of them inspects the slot. So a C11 handler whose BODY differs from the Sony handler's body is a
+// divergence by construction, whatever it returns.
+//
+// THE DESTROY PAIR IS THE ROW THAT SETTLES #2619's OPEN QUESTION, and the answer is that their
+// RESULT IS NOT A CONTRACT: prosper answers 0 through both spellings, and nothing in the lifetime
+// behaviour below depends on the question either way.
+//
+// An earlier revision of this block read the eleven bytes as "they FORWARD the libkernel result",
+// reasoning that the missing `xor eax,eax` had to mean the callee's value was being passed on. That
+// inference is VOID, and the counterexample is in the table above: an eleven-byte
+// `push rbp; mov rbp,rsp; call; pop rbp; ret` is exactly what a VOID-RETURNING wrapper compiles
+// to. The compiler emits no `xor eax,eax` for a function with no return value, so the absence --
+// which was the entire argument -- is equally well explained by there being nothing to return.
+// Recorded rather than quietly deleted because the shape is genuinely suggestive and the next
+// reader will re-derive it (#2636).
+//
+// THE ELEVEN-BYTE SHAPE CARRIES NO INFORMATION ABOUT THE RETURN TYPE AT ALL, and this module proves
+// it in BOTH directions with two functions sixteen bytes apart:
+//
+//     _Thrd_yield   @0x4ee0  554889e5 e8f7061100 5dc3  -> 0x1155e0  T72hz6ffq08  scePthreadYield
+//     _Thrd_equal   @0x4ef0  554889e5 e8f7061100 5dc3  -> 0x1155f0  3PtV6p3QNX4  scePthreadEqual
+//
+// BYTE-FOR-BYTE IDENTICAL bodies (the call displacements coincide because both the wrapper pair and
+// the stub pair are 0x10 apart, so both encode disp 0x1106f7). ISO C11 spells one
+// `void thrd_yield(void)` and the other `int thrd_equal(thrd_t, thrd_t)` -- and `_Thrd_equal` has no
+// way to return its value except by leaving `scePthreadEqual`'s result in eax. So one of these
+// eleven-byte bodies has nothing to forward and the other certainly does forward, and nothing in the
+// bytes distinguishes them. That is a complete proof rather than a counterexample, and it is why the
+// inference above is void.
+//
+// THE OBVIOUS COMPETING READING -- "the compiler just emits identical bytes for every eleven-byte
+// forwarder, so the identity means nothing" -- IS FALSIFIED BY THE NEXT PAIR DOWN, and the
+// arithmetic above predicts it. `_Thrd_current` @0x4f10 and `_Thrd_id` @0x4f20 are also 0x10 apart,
+// but they SHARE one stub (both call 0x115600 = `aI+OeCz8xrQ` scePthreadSelf), so their
+// displacements differ by exactly 0x10 and their bodies are NOT identical:
+//
+//     _Thrd_current 0x4f10  554889e5 e8e70611 00 5dc3   disp 0x1106e7  -> 0x115600
+//     _Thrd_id      0x4f20  554889e5 e8d70611 00 5dc3   disp 0x1106d7  -> 0x115600
+//
+// Same prologue, same shape, different bytes. So the yield/equal identity is not a compiler
+// signature that all these bodies share -- it is a consequence of the two wrappers and their two
+// distinct stubs being equally spaced, which is a prediction this module tests and confirms.
+//
+// It is not a lone oddity. Every eleven-byte forwarder in the module's C11 family, with its ISO
+// counterpart's return type -- these are the ones checked, listed so the claim is falsifiable rather
+// than asserted over a set someone assembled:
+//
+//     _Thrd_yield   0x4ee0 -> scePthreadYield         void          (nothing to forward)
+//     _Thrd_equal   0x4ef0 -> scePthreadEqual         int           FORWARDS
+//     _Thrd_current 0x4f10 -> scePthreadSelf          thrd_t        FORWARDS
+//     _Thrd_id      0x4f20 -> scePthreadSelf          (Dinkumware)  forwards
+//     _Mtx_destroy  0x5e60 -> scePthreadMutexDestroy  void
+//     _Cnd_destroy  0x5660 -> scePthreadCondDestroy   void
+//     _Tss_create  0x7f3a0 -> scePthreadKeyCreate     int           FORWARDS
+//     _Tss_delete  0x7f3b0 -> scePthreadKeyDelete     void          (nothing to forward)
+//     _Tss_set     0x7f3c0 -> scePthreadSetspecific   int           FORWARDS
+//     _Tss_get     0x7f3d0 -> scePthreadGetspecific   void*         FORWARDS
+//
+// THE `_Tss_*` HALF WAS ALREADY IN THIS REPOSITORY. `hle_kernel.cpp` (above
+// `SCE_PTHREAD_ALIAS(k_sce_key_delete, ...)`) records that `_Tss_create`, `_Tss_delete` and
+// `_Tss_set` are "11-byte, five-instruction forwarders ... returning eax unexamined", verified by
+// PLT relocation for PPSA24651. Two of those return `int` in ISO C11. The counterexample never
+// required leaving the tree, and an earlier revision of THIS block nevertheless asserted a universal
+// that the same source file contradicts 1,600 lines away (#2636).
+//
+// WHAT DOES SURVIVE, and it is the load-bearing line: NO CALLER READS THE DESTROY PAIR'S RESULT.
+// Over every direct `E8` in `.text` (0..0x115bf0) of the flattened module, `_Cnd_destroy` has 14
+// call sites and `_Mtx_destroy` 16, and NOT ONE of those 30 is followed by `test eax,eax`; the
+// first, at 0x504f, does `mov rax,[rip+0x18d1ad]` and clobbers eax before any use. The wrappers
+// whose result IS a contract are read at most of theirs -- `_Cnd_wait` 7 of 8, `_Mtx_unlock` 12 of
+// 25. That is an absence rather than a proof, and it is labelled as one below.
+//
+// WHAT THE ELEVEN BYTES DO ESTABLISH is the half #2168 needs, and it is not about a return value at
+// all: the wrapper's single call is to `scePthreadCondDestroy`, so whatever that entry point does
+// TO THE OBJECT is what happens on hardware through the C11 spelling. The EBUSY refusal is
+// therefore part of `_Cnd_destroy`'s behaviour too, and a C11 destroy that retires an object a
+// thread is parked in is wrong for the same reason the Sony one was. That is what
+// `guest_cond_destroy_slot` enforces and what the tests assert -- on the OBJECT, not on a number.
+//
+// CONFIDENCE: HIGH that the eleven-byte shape does not establish forwarding. This is now a PROOF,
+// not a counterexample: `_Thrd_yield` and `_Thrd_equal` are byte-identical with opposite ISO return
+// types, so the shape is demonstrably ambiguous in both directions inside one module. Also HIGH on
+// every byte, address, NID and count quoted above -- all re-derived from the shipped `libc.prx` with
+// the tools named at the head of this block.
+// CONFIDENCE: MED that the destroy pair is declared `void`, and the grounds are narrower than an
+// earlier revision claimed. What supports it is exactly two things: the ISO C11 signatures of
+// `mtx_destroy` and `cnd_destroy` themselves, which are `void`; and the call-site census above,
+// which is an ABSENCE over one module rather than a proof. A partition over the module's C11 exports
+// is NOT among the grounds -- that argument was asserted over a set assembled alongside the
+// conclusion and is refuted by the table above. Nothing prosper does needs it settled: both readings
+// permit the 0 both handlers answer, because a void result may be anything and a forwarded one is
+// read by no caller here.
 #pragma once
+
+#include "sync_retire.hpp"   // SyncObjectKind — the destroy pair keeps its own census bucket
 
 #include <cstdint>
 #include <pthread.h>
@@ -38,5 +163,32 @@ namespace prosper {
 // names a host object or is a static initialiser, and both come back as a usable object.
 pthread_mutex_t* guest_mutex_from_slot(uint64_t slot_addr);
 pthread_cond_t*  guest_cond_from_slot(uint64_t slot_addr);
+
+// --- whole operations, shared by the Sony spelling and the C11 spelling (#2619 / #2623) ----------
+// Each is the ENTIRE body of the scePthread* / pthread_* handler of the same name, bookkeeping
+// included, so the two spellings cannot drift again. Results are the BARE FreeBSD errno; the
+// libkernel encoding is applied by SCE_PTHREAD_ALIAS at the Sony spelling, and by the C11 wrapper's
+// own result transform (the table above) at the C11 one.
+uint64_t guest_mutex_lock_slot(uint64_t slot_addr);
+uint64_t guest_mutex_unlock_slot(uint64_t slot_addr);
+// `kind` selects the retirement CENSUS bucket only (`_Mtx` vs `mutex`); the lifetime policy is
+// identical. Keeping the buckets apart is what let #2619 establish that no title on this machine
+// reaches the C11 spelling at all.
+uint64_t guest_mutex_destroy_slot(uint64_t slot_addr, SyncObjectKind kind);
+void     guest_cond_signal_slot(uint64_t slot_addr);
+void     guest_cond_broadcast_slot(uint64_t slot_addr);
+// The ONE body that parks on a condition variable without a deadline, so `GuestCondWaiterScope`
+// (#2168) is taken here rather than remembered by each caller. EINVAL(22) if either slot is unusable.
+uint64_t guest_cond_wait_slot(uint64_t cond_slot, uint64_t mutex_slot);
+// EBUSY(16) when the condvar still has waiters — checked BEFORE the slot is claimed, so a refusal
+// leaves the guest a handle that still works (#2168).
+uint64_t guest_cond_destroy_slot(uint64_t slot_addr, SyncObjectKind kind);
+
+// Test-only. The missed-wakeup generation counter is bumped by exactly one function
+// (`guest_cond_advance`, hle_kernel.cpp) whose only callers are the signal/broadcast bodies, and its
+// only PRODUCTION reader is the retry loop in `interruptible_cond_clock_timedwait` — a
+// slice-boundary race no test can schedule. Reading the counter is therefore the only way to assert
+// that a signal was ACCOUNTED FOR, which is the first divergence #2623 records.
+uint64_t guest_cond_generation_for_test(pthread_cond_t* cond);
 
 }  // namespace prosper

--- a/prosper/tests/test_c11_sync_bookkeeping.cpp
+++ b/prosper/tests/test_c11_sync_bookkeeping.cpp
@@ -1,0 +1,401 @@
+// test_c11_sync_bookkeeping — the C11 `_Mtx_*` / `_Cnd_*` handlers must keep the SAME PER-OBJECT
+// BOOKKEEPING their libkernel counterparts keep, not merely share their slot resolution
+// (#2619, #2623).
+//
+// WHY THIS IS A SEPARATE FILE FROM test_c11_thread_slots. That file guards #2596: the handlers must
+// RESOLVE a statically-initialised slot instead of skipping it. This one guards what #2596 did not
+// give them — the state each libkernel body maintains ALONGSIDE the operation. Every arm here passes
+// on the #2596 code and fails on the bookkeeping being absent, which is exactly why the two must not
+// be merged: a suite that resolves slots correctly can be completely blind to the accounting.
+//
+// THE PRIMARY EVIDENCE, because it is what decided the return values below and it settles the one
+// question #2619 left open. The shipped guest `libc.prx` of PPSA24651 was flattened
+// (`tools/il2cpp/prx_to_elf.py`), each C11 export located by NID in its dynsym, each body decoded
+// (`tools/re/edis.py`), and each PLT thunk taken to its import through the JMPREL slot
+// (`tools/re/stub_nid_map.py`) rather than by adjacency:
+//
+//   _Mtx_destroy   @0x5e60, 11 bytes:  push rbp; mov rbp,rsp; call -> scePthreadMutexDestroy;
+//                                      pop rbp; ret
+//   _Cnd_destroy   @0x5660, 11 bytes:  push rbp; mov rbp,rsp; call -> scePthreadCondDestroy;
+//                                      pop rbp; ret
+//   _Cnd_wait      @0x5670, 13 bytes:  … call -> scePthreadCondWait; XOR EAX,EAX; pop rbp; ret
+//   _Thrd_yield    @0x4ee0, 11 bytes:  push rbp; mov rbp,rsp; call -> scePthreadYield; pop rbp; ret
+//
+// The `_Cnd_wait` line is the recorded #2596 reading, re-derived here byte for byte, and it is this
+// method's positive control: a decode that reproduces a result someone else measured independently
+// is a decode that resolved the right symbol.
+//
+// THE DESTROY PAIR'S RETURN VALUE IS NOT A CONTRACT, and this file used to say the opposite. The
+// two are ELEVEN bytes, not thirteen — there is no `xor eax,eax` — and an earlier revision read
+// that absence as "THE DESTROY PAIR FORWARDS libkernel's answer". It does not follow, and the module
+// settles it in BOTH directions with two functions sixteen bytes apart:
+//
+//   _Thrd_yield  @0x4ee0  554889e5 e8f7061100 5dc3  ->  scePthreadYield   ISO: void thrd_yield(void)
+//   _Thrd_equal  @0x4ef0  554889e5 e8f7061100 5dc3  ->  scePthreadEqual   ISO: int  thrd_equal(...)
+//
+// Byte-for-byte identical bodies, opposite ISO C11 return types — and `_Thrd_equal` can only return
+// its value by leaving `scePthreadEqual`'s result in eax, so one of these forwards and the other has
+// nothing to forward, with nothing in the bytes to tell them apart. `_Tss_create` / `_Tss_set` /
+// `_Tss_get` are the same shape and also forward (already recorded in hle_kernel.cpp, above the
+// `k_sce_key_delete` alias). pthread_slot.hpp carries the full table (#2636).
+//
+// A SECOND EARLIER REVISION claimed the byte shape tracked the published C11 return type across
+// "all thirteen" of the module's C11 exports. That is withdrawn too: the thirteen were the twelve
+// mutex/condvar primitives plus the one control that supported the conclusion, and the exports left
+// outside the set contain at least six counterexamples. It is recorded rather than deleted because
+// it is the failure mode worth remembering — a universal asserted over a set assembled alongside the
+// conclusion tests the discriminator, not the domain.
+//
+// What survives is narrower and is labelled as such: the ISO C11 signatures of `mtx_destroy` and
+// `cnd_destroy`, plus the fact that 0 of the destroy pair's 30 call sites in `.text` read the value.
+//
+// So both destroy handlers answer 0, and what #2619 asked to be established is established on the
+// OBJECT rather than on a number: the guest wrapper's single call is to `scePthreadCondDestroy`, so
+// #2168's EBUSY refusal is part of `_Cnd_destroy`'s behaviour too, and §4 asserts it — as a
+// non-retirement, which is the form in which it is observable at all.
+//
+// WHAT EACH ARM KILLS. Every row below was MEASURED — mutation applied, rebuilt, re-run — and the
+// counts are what the run printed, not what the author expected:
+//   M1  restore the old private `m_mtx_destroy` body (bare `if (a0 && *(void**)P(a0))` +
+//       `retire_sync_object`, no `pt_claim_slot`)
+//                                    -> FAIL (4): all four discriminating arms of §1. §2/§3/§4 pass.
+//   M2  restore the old private `m_cnd_destroy` body (no claim, no busy check)
+//                                    -> FAIL (4): §2's three, plus §4's "none of the three retired
+//                                       anything" arm. §4's Sony and POSIX refusals still PASS —
+//                                       only the C11 body lost the check, which is the divergence,
+//                                       and a suite that could not show that would not be testing
+//                                       parity. §4's `_Cnd_destroy` VALUE arm also passes, because
+//                                       the old body returned 0 as well; that arm is M2b's, not
+//                                       M2's, and the pair is what separates the two questions.
+//   M2b make `m_cnd_destroy` publish `kSceKernelErrorEBUSY` on a refusal instead of 0 — the
+//       pre-correction #2636 behaviour, and the "right number, wrong convention" failure this area
+//       keeps producing
+//                                    -> FAIL (1): §4's `_Cnd_destroy` value arm, and ONLY that one.
+//                                       So the value arm and the retirement arm are measurably
+//                                       independent: M2 moves one and not the other, M2b the
+//                                       reverse. Neither is a second spelling of the other, and a
+//                                       suite asserting only "the object survived" would accept a
+//                                       libkernel-encoded value through a C11-spelled door.
+//   M3  drop `guest_cond_advance` from `guest_cond_signal_slot`/`guest_cond_broadcast_slot` (the
+//       SHARED bodies, so both spellings lose it)
+//                                    -> FAIL (3): all three of §3, the Sony parity arm included.
+//   M4  route `m_cnd_signal`/`m_cnd_broadcast` back through the bare resolver — advance kept for the
+//       Sony spelling only, i.e. the exact #2623(1) divergence
+//                                    -> FAIL (2): §3's two C11 arms. The Sony parity arm PASSES.
+//   M5  drop `GuestCondWaiterScope` from the shared `guest_cond_wait_slot`
+//                                    -> FAIL (4): §4's Sony and POSIX refusals, the "none of the
+//                                       three retired anything" arm, and the wake control — with no
+//                                       waiter counted the condvar is retired out from under the
+//                                       parked thread, so the later broadcast resolves a poisoned
+//                                       slot and nobody is ever woken. That cascade IS the bug,
+//                                       expressed as a failed assertion instead of a hang. The
+//                                       `_Cnd_destroy` value arm passes here BY DESIGN: 0 is the
+//                                       answer whether the destroy refused or retired, which is
+//                                       precisely why the refusal is asserted on the object.
+//   M6  give `m_cnd_wait` back its own body (resolve + `interruptible_cond_wait`, no scope) — the
+//       exact #2623(2) divergence
+//                                    -> FAIL (4): the same four. §1, §2 and §3 pass.
+//   M7  make `guest_cond_waiter_leave` a no-op, so the count leaks
+//                                    -> FAIL (1): §4's last arm, and only that one.
+//
+// M3/M4 are a deliberate pair, and the pair is the evidence: the first breaks the shared body so
+// BOTH spellings lose the behaviour, the second breaks only the C11 one. §3 separates them, so §3
+// is testing cross-spelling parity rather than merely that the feature exists.
+//
+// M5/M6 ARE NOT SEPARATED BY THIS FILE, and saying so is the honest form of the same claim: §4's
+// only waiter parks through the C11 spelling, so both mutations produce the identical four
+// failures. What separates them is the pre-existing `cond_destroy_busy` suite, which parks a SONY
+// waiter — measured: it fails 3 arms under M5 and passes completely under M6. So the shared-body
+// regression is caught there and the C11-only one is caught here, and neither file is redundant.
+//
+// M7 exists because every other arm in §4 survives it: without it, §4's closing arm would be a row
+// no mutation kills, which is a row that has never been shown to test anything.
+//
+// HANG SAFETY. §4 parks a real thread on a condvar. It is DETACHED and every wait is bounded: a
+// regression in this area is a thread that never wakes, and expressing that as a hang burns ctest's
+// timeout and gets misread as machine load on a box that routinely runs at load 30+.
+
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/hle/pthread_slot.hpp"
+#include "../src/hle/sce_errno.hpp"
+#include "../src/hle/sync_retire.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <pthread.h>
+#include <thread>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+
+HleFn mtx_init = nullptr, mtx_lock = nullptr, mtx_unlock = nullptr, mtx_destroy = nullptr;
+HleFn cnd_init = nullptr, cnd_signal = nullptr, cnd_broadcast = nullptr, cnd_wait = nullptr,
+      cnd_destroy = nullptr;
+HleFn sce_mtx_lock = nullptr, sce_mtx_destroy = nullptr;
+HleFn sce_cnd_signal = nullptr, sce_cnd_destroy = nullptr, posix_cnd_destroy = nullptr;
+
+uint64_t call1(HleFn fn, void* slot) { return fn((uint64_t)(uintptr_t)slot, 0, 0, 0, 0, 0); }
+uint64_t call2(HleFn fn, void* a, void* b) {
+    return fn((uint64_t)(uintptr_t)a, (uint64_t)(uintptr_t)b, 0, 0, 0, 0);
+}
+
+// §4's parked waiter. File-scope storage so a detached worker can never outlive it.
+void* g_park_cnd = nullptr;
+void* g_park_mtx = nullptr;
+std::atomic<int> g_parked{0};
+std::atomic<int> g_woke{0};
+
+void* park_in_c11_wait(void*) {
+    mtx_lock((uint64_t)(uintptr_t)&g_park_mtx, 0, 0, 0, 0, 0);
+    g_parked.store(1, std::memory_order_release);
+    cnd_wait((uint64_t)(uintptr_t)&g_park_cnd, (uint64_t)(uintptr_t)&g_park_mtx, 0, 0, 0, 0);
+    g_woke.store(1, std::memory_order_release);
+    mtx_unlock((uint64_t)(uintptr_t)&g_park_mtx, 0, 0, 0, 0, 0);
+    return nullptr;
+}
+
+// Generous, and only ever used for CONTROLS ("did the worker reach its wait"). Not a timing
+// assertion — a tight bound would only turn machine load into a red build.
+bool spin_until(const std::atomic<int>& flag, int seconds) {
+    for (int i = 0; i < seconds * 1000 && !flag.load(std::memory_order_acquire); ++i)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return flag.load(std::memory_order_acquire) != 0;
+}
+
+bool broadcast_until_awake(void* cnd_slot, void* mtx_slot, const std::atomic<int>& flag) {
+    for (int i = 0; i < 300 && !flag.load(std::memory_order_acquire); ++i) {
+        mtx_lock((uint64_t)(uintptr_t)mtx_slot, 0, 0, 0, 0, 0);
+        cnd_broadcast((uint64_t)(uintptr_t)cnd_slot, 0, 0, 0, 0, 0);
+        mtx_unlock((uint64_t)(uintptr_t)mtx_slot, 0, 0, 0, 0, 0);
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return flag.load(std::memory_order_acquire) != 0;
+}
+
+}  // namespace
+
+int main() {
+    printf("== test_c11_sync_bookkeeping ==\n");
+    register_builtin_hle();
+
+    const auto by_name = [](const char* n) { return Hle::lookup(nid_hash(n)); };
+    mtx_init          = by_name("_Mtx_init");
+    mtx_lock          = by_name("_Mtx_lock");
+    mtx_unlock        = by_name("_Mtx_unlock");
+    mtx_destroy       = by_name("_Mtx_destroy");
+    cnd_init          = by_name("_Cnd_init");
+    cnd_signal        = by_name("_Cnd_signal");
+    cnd_broadcast     = by_name("_Cnd_broadcast");
+    cnd_wait          = by_name("_Cnd_wait");
+    cnd_destroy       = by_name("_Cnd_destroy");
+    sce_mtx_lock      = by_name("scePthreadMutexLock");
+    sce_mtx_destroy   = by_name("scePthreadMutexDestroy");
+    sce_cnd_signal    = by_name("scePthreadCondSignal");
+    sce_cnd_destroy   = by_name("scePthreadCondDestroy");
+    posix_cnd_destroy = by_name("pthread_cond_destroy");
+    const bool all = mtx_init && mtx_lock && mtx_unlock && mtx_destroy && cnd_init && cnd_signal &&
+                     cnd_broadcast && cnd_wait && cnd_destroy && sce_mtx_lock && sce_mtx_destroy &&
+                     sce_cnd_signal && sce_cnd_destroy && posix_cnd_destroy;
+    CHECK(all, "control: both spellings of every handler under test are registered");
+    if (!all) { printf("== FAIL (%d) ==\n", fails); return 1; }
+
+    // ===== 1. _Mtx_destroy CLAIMS and POISONS the slot (#2619) ================================
+    // The old body read the slot with a bare truthiness test and never wrote to it, so the slot went
+    // on naming quarantined storage. Three consequences, all asserted here: a second destroy retired
+    // the SAME block again (a double free ~30 s later, from an unrelated call), a later lock through
+    // either spelling resolved a destroyed object, and a slot already carrying the destroyed poison
+    // 0xDEA passed the truthiness test and had 0xDEA itself handed to `free`.
+    printf("-- _Mtx_destroy claims the slot, so a repeat destroy retires nothing --\n");
+    {
+        void* slot = nullptr;
+        CHECK(mtx_init((uint64_t)(uintptr_t)&slot, 0, 0, 0, 0, 0) == 0 && slot != nullptr,
+              "control: _Mtx_init produces an object");
+        void* const object = slot;
+
+        const uint64_t before = retired_sync_object_count();
+        call1(mtx_destroy, &slot);
+        CHECK(retired_sync_object_count() == before + 1,
+              "control: the first _Mtx_destroy retires the object exactly once (true before this "
+              "change too -- it is the positive control the arms below are measured against)");
+        CHECK(slot != object && slot != nullptr,
+              "the slot NO LONGER NAMES the retired storage, and was not merely cleared to NULL -- "
+              "it holds the destroyed poison, so a later use is refused rather than self-initialised");
+
+        // #2619 scenario 2, in its cross-spelling form, and it must come BEFORE any Sony destroy
+        // touches this slot. An earlier revision put it last, where `scePthreadMutexDestroy` had
+        // already claimed and poisoned the slot itself — so the refusal was produced by the arm
+        // above it rather than by the handler under test, and it passed under the mutation. Order
+        // is load-bearing here, not stylistic.
+        CHECK(call1(sce_mtx_lock, &slot) == prosper::hle::kSceKernelErrorEINVAL,
+              "scePthreadMutexLock REFUSES a slot the C11 spelling destroyed -- the use-after-destroy "
+              "#2170 closed for the Sony spelling was still open through _Mtx_destroy");
+
+        const uint64_t after_first = retired_sync_object_count();
+        call1(mtx_destroy, &slot);
+        CHECK(retired_sync_object_count() == after_first,
+              "a SECOND _Mtx_destroy on the same slot retires NOTHING -- it used to hand the same "
+              "block to the quarantine twice, which frees it twice ~30 s apart (#2619 scenario 1)");
+
+        call1(sce_mtx_destroy, &slot);
+        CHECK(retired_sync_object_count() == after_first,
+              "...and a scePthreadMutexDestroy after it retires nothing either, so the two spellings "
+              "agree about a slot that is already destroyed");
+    }
+
+    // ===== 2. _Cnd_destroy does the same ======================================================
+    // Same defect, same shape, separate arm: the two handlers had separate private bodies, so a fix
+    // to one proves nothing about the other. (Measured: M1 leaves every arm of §2 green.)
+    printf("-- _Cnd_destroy claims the slot too --\n");
+    {
+        void* slot = nullptr;
+        CHECK(cnd_init((uint64_t)(uintptr_t)&slot, 0, 0, 0, 0, 0) == 0 && slot != nullptr,
+              "control: _Cnd_init produces an object");
+        void* const object = slot;
+
+        const uint64_t before = retired_sync_object_count();
+        CHECK(call1(cnd_destroy, &slot) == 0, "control: destroying an idle condvar succeeds");
+        CHECK(retired_sync_object_count() == before + 1 && slot != object && slot != nullptr,
+              "the slot no longer names the retired condvar");
+
+        const uint64_t after_first = retired_sync_object_count();
+        call1(cnd_destroy, &slot);
+        CHECK(retired_sync_object_count() == after_first,
+              "a second _Cnd_destroy retires NOTHING (it used to double-retire the same block)");
+        call1(sce_cnd_destroy, &slot);
+        CHECK(retired_sync_object_count() == after_first,
+              "...and neither does a scePthreadCondDestroy behind it");
+    }
+
+    // ===== 3. the missed-wakeup generation, through BOTH spellings (#2623 divergence 1) =========
+    // `guest_cond_advance` is the guard that lets `interruptible_cond_clock_timedwait` recover a
+    // signal that lands between two slices of a converted non-realtime deadline. Its only production
+    // reader is that slice-boundary race, which no test can schedule — so the counter is read
+    // directly. That is not a weaker assertion than a behavioural one: the counter is written by
+    // exactly one function, whose only callers are the two bodies under test, so nothing else in
+    // this process can move it.
+    printf("-- _Cnd_signal / _Cnd_broadcast bump the missed-wakeup generation --\n");
+    {
+        void* slot = nullptr;   // a static sentinel: self-initialises on first use, like the guest's
+        call1(cnd_signal, &slot);
+        CHECK(slot != nullptr, "control: the static cnd_t slot self-initialised (#2596)");
+        auto* cond = (pthread_cond_t*)slot;
+
+        const uint64_t g0 = guest_cond_generation_for_test(cond);
+        call1(cnd_signal, &slot);
+        CHECK(guest_cond_generation_for_test(cond) == g0 + 1,
+              "_Cnd_signal ADVANCES the generation -- a guest signalling through the C11 spelling and "
+              "waiting through the Sony one saw a stale generation and could lose the wakeup");
+        const uint64_t g1 = guest_cond_generation_for_test(cond);
+        call1(cnd_broadcast, &slot);
+        CHECK(guest_cond_generation_for_test(cond) == g1 + 1,
+              "_Cnd_broadcast advances it too");
+        // The parity arm, and the reason M3 and M4 are separable: it asserts the answer does not
+        // depend on which spelling asked (#1873). It passes under M4 and fails under M3.
+        const uint64_t g2 = guest_cond_generation_for_test(cond);
+        call1(sce_cnd_signal, &slot);
+        CHECK(guest_cond_generation_for_test(cond) == g2 + 1,
+              "...and scePthreadCondSignal advances it by exactly the same amount on the same object");
+    }
+
+    // ===== 4. a thread parked in _Cnd_wait blocks EVERY spelling of cond destroy (#2623 div. 2) ==
+    // #2168 made cond-destroy refuse a condvar with waiters, and #2596 opened a new route to a
+    // waiter the check could not see: a null cond slot could not park at all before it, and can
+    // after. So a destroy retired the object out from under a parked thread — #2168's exact failure
+    // through a different door. All three destroy spellings are asserted, because the whole thesis
+    // is that they agree.
+    printf("-- a C11 waiter is visible to the cond-destroy busy check, through every spelling --\n");
+    {
+        pthread_t t{};
+        CHECK(pthread_create(&t, nullptr, park_in_c11_wait, nullptr) == 0,
+              "control: the C11 waiter thread starts");
+        pthread_detach(t);
+        CHECK(spin_until(g_parked, 5), "control: the waiter reached its _Cnd_wait");
+        // The waiter has published `g_parked` before entering the wait, so give it a moment to get
+        // inside. `GuestCondWaiterScope` is entered before `interruptible_cond_wait`, so this is a
+        // bound on the scope being taken, not on the park completing.
+        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+        // `before` and `object` are captured BEFORE the first destroy attempt, deliberately. An
+        // earlier revision took the count just above the `_Cnd_destroy` arm, and when the two
+        // preceding destroys were the ones that failed they had already retired the condvar and
+        // poisoned the slot — so `_Cnd_destroy` found nothing to retire and the "retired NOTHING"
+        // arm PASSED, in the exact run where the behaviour it names was broken. A count that can be
+        // satisfied by the object having already gone is not a count of anything.
+        const uint64_t before = retired_sync_object_count();
+        void* const object = g_park_cnd;
+        CHECK(object != nullptr, "control: the waiter self-initialised the static cnd_t slot");
+
+        CHECK(call1(sce_cnd_destroy, &g_park_cnd) == prosper::hle::kSceKernelErrorEBUSY,
+              "scePthreadCondDestroy refuses with the encoded EBUSY while a C11 wait is parked on it");
+        CHECK(call1(posix_cnd_destroy, &g_park_cnd) ==
+                  static_cast<uint64_t>(prosper::hle::FreeBsdErrno::EBusy),
+              "...pthread_cond_destroy refuses with the bare EBUSY, same object, same instant");
+        // The C11 spelling answers 0 — and this arm pins the CONVENTION rather than the refusal.
+        // Its guest wrapper's eleven bytes do not establish a forwarded result (see the block at the
+        // head of this file and pthread_slot.hpp, #2636), so there is no value here with which to
+        // express a refusal; publishing the encoded EBUSY instead would put a libkernel-encoded
+        // value through a C11-spelled door, which is what this arm fails on. It is NOT the arm that
+        // catches a missing busy check — the old private body returned 0 too — and saying so is the
+        // point: the refusal is observable only on the OBJECT, which is the next arm's job.
+        CHECK(call1(cnd_destroy, &g_park_cnd) == 0,
+              "...and _Cnd_destroy answers 0, the same as its _Mtx_destroy sibling and not a "
+              "libkernel-encoded EBUSY");
+        // THE load-bearing arm of the section, for all three spellings and for the C11 one in
+        // particular: a destroy that refused must not have retired the condvar or cleared the slot.
+        CHECK(retired_sync_object_count() == before && g_park_cnd == object,
+              "...and NONE of the three retired anything: the slot still names the same live condvar "
+              "the thread is parked in, rather than storage sitting in the quarantine with its "
+              "clock started");
+
+        CHECK(broadcast_until_awake(&g_park_cnd, &g_park_mtx, g_woke),
+              "control: the waiter still wakes on a broadcast (a wait that never returns would be a "
+              "worse defect than the one being fixed)");
+        // Once the waiter has left, the refusal must clear — otherwise the fix would be a permanent
+        // EBUSY, which is the leak `GuestCondWaiterScope`'s RAII exists to prevent.
+        for (int i = 0; i < 500 && call1(sce_cnd_destroy, &g_park_cnd) != 0; ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        CHECK(retired_sync_object_count() > before,
+              "...and the destroy SUCCEEDS once the waiter has left: the refusal is a live waiter "
+              "count, not a one-way latch");
+    }
+
+    // ===== 5. the Windows guest-mutex ownership map (#2623 divergence 3) ========================
+    // NOT EXECUTED ON THIS HOST, and said plainly rather than skipped silently. The ownership map is
+    // `#ifdef _WIN32` (native POSIX implements the ERRORCHECK contract in pthreads, and routing every
+    // guest lock through one process-global map there throttles synchronisation-heavy titles —
+    // #719/#793). The C11 lock/unlock reached `interruptible_mutex_lock` / `pthread_mutex_unlock`
+    // directly and never touched `guest_mutex_acquired` / `guest_mutex_released`, so on Windows a
+    // static mutex first locked through the C11 spelling stayed registered with `owner == 0`. The fix
+    // is structural — `m_mtx_lock`/`m_mtx_unlock` now call the same body `scePthreadMutexLock`/
+    // `Unlock` call — and this arm confirms it on the platform where it is observable.
+    printf("-- the C11 lock records ownership in the Windows guest-mutex map --\n");
+#ifdef _WIN32
+    {
+        void* slot = nullptr;
+        call1(mtx_lock, &slot);
+        CHECK(slot != nullptr, "control: the static mtx_t slot self-initialised");
+        CHECK(win_guest_mutex_owned_by_current_thread_for_test(slot),
+              "_Mtx_lock records this thread as the owner, so a same-thread relock is refused by "
+              "prosper's own check rather than by winpthreads' raw EDEADLK");
+        call1(mtx_unlock, &slot);
+        CHECK(!win_guest_mutex_owned_by_current_thread_for_test(slot),
+              "_Mtx_unlock clears it, so a later scePthreadMutexLock is not refused against a stale "
+              "owner");
+    }
+#else
+    printf("  [skip] Windows-only: the guest-mutex ownership map does not exist on this host, and "
+           "an arm that cannot fail is not an arm\n");
+#endif
+
+    if (fails) printf("== FAIL (%d) ==\n", fails);
+    else       printf("== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #2619
Fixes #2623
Refs #2626

## The failure scenario

#2596 gave the C11 `_Mtx_*` / `_Cnd_*` handlers the same slot **resolution** their Sony
counterparts use. Each one still carried a private body around that resolver, and four pieces of
per-object **bookkeeping** did not travel with it. Every one is the #1873 shape — the same question
answered differently depending on which spelling the guest used — and three of the four became
reachable the moment the slots started resolving.

1. **The destroy pair never claimed or poisoned the slot (#2619).** `m_mtx_destroy` /
   `m_cnd_destroy` read it with a bare truthiness test and never wrote to it, so: a second
   `_Mtx_destroy` handed the SAME block to the quarantine twice and it was freed twice ~30 s apart
   from an unrelated later call; the slot went on naming quarantined storage that a later lock
   through either spelling resolved and locked; and a slot already destroyed through the Sony
   spelling held `kPtDestroyed` (`0xDEA`), which passed the truthiness test and was handed to
   `pthread_mutex_destroy` and `free` as a pointer.
2. **`m_cnd_signal` / `m_cnd_broadcast` never bumped `guest_cond_advance`** — the missed-wakeup
   generation `interruptible_cond_clock_timedwait` uses to recover a signal landing between two
   slices of a converted non-realtime deadline (#2623 §1).
3. **`m_cnd_wait` took no `GuestCondWaiterScope`**, so a thread parked through the C11 spelling was
   invisible to every cond-destroy busy check — #2168's exact failure, re-entered through a door
   #2596 opened (#2623 §2).
4. **`m_mtx_lock` / `m_mtx_unlock` bypassed the Windows guest-mutex ownership map**, so a static
   mutex first touched through the C11 spelling was registered ERRORCHECK with `owner == 0` and
   stayed that way (#2623 §3).

## Behavioral contract and the approach

The fix is **structural rather than four patches**: `src/hle/pthread_slot.hpp` now publishes whole
OPERATIONS (`guest_mutex_lock_slot`, `guest_mutex_unlock_slot`, `guest_mutex_destroy_slot`,
`guest_cond_signal_slot`, `guest_cond_broadcast_slot`, `guest_cond_wait_slot`,
`guest_cond_destroy_slot`) and BOTH spellings call them. The `scePthread*` / `pthread_*` handlers
become one-liners over the same bodies, so there is no private body left to drift.

**The invariant that makes this hold:** only the RESULT stays per-spelling, and only because the
guest's own wrappers differ there. Everything observable about the object — slot claim/poison,
generation advance, waiter accounting, ownership registration — is now single-sourced.

## Primary evidence, and it settles the question #2619 left open

The shipped guest `libc.prx` of `PPSA24651` was flattened (`tools/il2cpp/prx_to_elf.py`), each C11
export located by NID in its dynsym, each body decoded (`tools/re/edis.py`), and each PLT thunk
taken to its import through the JMPREL slot (`tools/re/stub_nid_map.py`) rather than by adjacency.
Every wrapper is a single call passing the guest's slot pointer STRAIGHT THROUGH; not one inspects
the slot:

| export | addr | size | forwards to | result mapping |
| --- | --- | --- | --- | --- |
| `_Mtx_init` | 0x5dc0 | 0x73 | `scePthreadMutexattr{Init,Settype,Destroy}`, `scePthreadMutexInit` | |
| `_Mtx_lock` | 0x5e80 | 0x1d | `scePthreadMutexLock` | maps 0 to 0, 0x8002000b to 3, else 4 |
| `_Mtx_unlock` | 0x5e70 | 0x0d | `scePthreadMutexUnlock` | `xor eax,eax` — discards |
| `_Mtx_destroy` | 0x5e60 | 0x0b | `scePthreadMutexDestroy` | nothing after the call touches eax |
| `_Cnd_init` | 0x5560 | 0x9d | `scePthreadCondInit` | maps onto a `_Thrd_*` code |
| `_Cnd_signal` | 0x56d0 | 0x0d | `scePthreadCondSignal` | `xor eax,eax` — discards |
| `_Cnd_broadcast` | 0x56e0 | 0x0d | `scePthreadCondBroadcast` | `xor eax,eax` — discards |
| `_Cnd_wait` | 0x5670 | 0x0d | `scePthreadCondWait` | `xor eax,eax` — discards |
| `_Cnd_destroy` | 0x5660 | 0x0b | `scePthreadCondDestroy` | nothing after the call touches eax |
| `_Thrd_yield` | 0x4ee0 | 0x0b | `scePthreadYield` | nothing after the call touches eax — the CONTROL, see below |

`_Cnd_wait`'s row reproduces #2596's independently recorded reading byte for byte, which is this
method's positive control.

### The destroy pair's RETURN VALUE is not a contract — corrected after review

An earlier revision of this PR read the two 11-byte bodies as *"there is no `xor eax,eax`, so those
two FORWARD libkernel's answer"*, and made `_Cnd_destroy` publish the encoded EBUSY on that basis.
**The inference is invalid and has been removed.** An 11-byte `push rbp; mov rbp,rsp; call; pop rbp;
ret` is exactly what a **void-returning** wrapper compiles to — the compiler emits no `xor eax,eax`
for a function with no return value, so the absence, which was the entire argument, is equally well
explained by there being nothing to return.

Three independent lines settle it the other way. All three were re-derived from the dump for this
correction:

1. **A void counterexample in the same module, byte for byte.** `_Thrd_yield` (`exNzzCAQuWM`) @0x4ee0
   is `55 4889e5 e8f7061100 5d c3` — eleven bytes, no `xor eax,eax` — calling 0x1155e0 →
   `T72hz6ffq08` `scePthreadYield`. ISO C11 spells its counterpart `void thrd_yield(void)`. The shape
   this PR read as "forwards" is produced here by a function with nothing to forward.
2. ~~The byte shape tracks the published C11 return type across all thirteen of the module's C11
   exports, with no exception.~~ **WITHDRAWN — this claim was false, and it is the second dead
   argument this PR has recorded.** See "The partition that was not one" below.
3. **No caller reads it.** Scanning every direct `E8` in `.text` (0..0x115bf0) of the flattened
   module: `_Cnd_destroy` has **14** call sites and `_Mtx_destroy` **16**, and **not one of those 30**
   is followed by `test eax,eax` — the first, at 0x504f, does `mov rax,[rip+0x18d1ad]` and clobbers
   eax before any use. The wrappers whose result IS a contract are read at most of theirs:
   `_Cnd_wait` 7 of 8, `_Mtx_unlock` 12 of 25.

### The partition that was not one — withdrawn after a second review

The thirteen-export partition above was offered as the external positive instance that justified
raising confidence, and **it does not hold.** The module's C11 family is far larger than thirteen, and
the exports left outside the set contain **at least six counterexamples**. The decisive one sits
**sixteen bytes** from the control the whole argument rested on:

```
_Thrd_yield  @0x4ee0  554889e5 e8f7061100 5dc3  -> 0x1155e0  T72hz6ffq08  scePthreadYield
_Thrd_equal  @0x4ef0  554889e5 e8f7061100 5dc3  -> 0x1155f0  3PtV6p3QNX4  scePthreadEqual
```

**Byte-for-byte identical bodies** (the displacements coincide because both the wrapper pair and the
stub pair are 0x10 apart). ISO C11 spells one `void thrd_yield(void)` and the other
`int thrd_equal(thrd_t, thrd_t)` — and `_Thrd_equal` has no way to return its value except by leaving
`scePthreadEqual`'s result in eax. Every eleven-byte C11 forwarder in the module, re-derived here:

| export | target | ISO return | forwards? |
| --- | --- | --- | --- |
| `_Thrd_yield` 0x4ee0 | `scePthreadYield` | `void` | nothing to forward |
| `_Thrd_equal` 0x4ef0 | `scePthreadEqual` | **`int`** | **yes** |
| `_Thrd_current` 0x4f10 | `scePthreadSelf` | **`thrd_t`** | **yes** |
| `_Thrd_id` 0x4f20 | `scePthreadSelf` | (Dinkumware) | yes |
| `_Mtx_destroy` 0x5e60 | `scePthreadMutexDestroy` | `void` | — |
| `_Cnd_destroy` 0x5660 | `scePthreadCondDestroy` | `void` | — |
| `_Tss_create` 0x7f3a0 | `scePthreadKeyCreate` | **`int`** | **yes** |
| `_Tss_delete` 0x7f3b0 | `scePthreadKeyDelete` | `void` | nothing to forward |
| `_Tss_set` 0x7f3c0 | `scePthreadSetspecific` | **`int`** | **yes** |
| `_Tss_get` 0x7f3d0 | `scePthreadGetspecific` | **`void*`** | **yes** |

**The competing reading — "the compiler just emits identical bytes for every eleven-byte forwarder"
— is falsified by the next pair down, and the arithmetic predicts it.** `_Thrd_current` @0x4f10 and
`_Thrd_id` @0x4f20 are *also* 0x10 apart, but they **share one stub** (both call 0x115600 =
`scePthreadSelf`), so their displacements differ by exactly 0x10 and their bodies are **not**
identical — `554889e5 e8e7061100 5dc3` against `554889e5 e8d7061100 5dc3`. Same prologue, same shape,
different bytes. The yield/equal identity is therefore a consequence of two wrappers and two
**distinct** stubs being equally spaced, not a compiler signature these bodies all share. That turns
the byte-identity from a striking observation into a **tested prediction**.

**The `_Tss_*` half was already in this repository** — `hle_kernel.cpp`, above the
`k_sce_key_delete` alias, records those as "11-byte, five-instruction forwarders … returning eax
unexamined", verified by PLT relocation for PPSA24651. Two of them return `int`. The counterexample
never required leaving the tree, and this PR asserted the universal anyway.

**Why it happened, recorded because it is the more useful half:** the "thirteen" were the twelve
mutex/condvar primitives **plus the single control that supported the conclusion** — `_Thrd_yield`,
which the table itself flags as *not* a sync primitive. A universal asserted over a set assembled
alongside the conclusion tests the **discriminator, not the domain**; it is instrument-trap 122 with
set membership doing the selecting rather than the generator. And because it *raised* a confidence
label, it was the argument least likely to be re-derived — exactly the asymmetry the charter warns
about.

**The net effect on the two labels is one up and one down:**

- `CONFIDENCE: HIGH` that eleven bytes do not establish forwarding — **kept, and now stronger than
  before.** It was a counterexample in one direction; `_Thrd_equal` supplies the other, so the shape
  is demonstrably ambiguous **in both directions inside one module**. That is a proof, and it is a
  better argument than the partition ever was.
- `CONFIDENCE: MED` that the destroy pair is declared `void` — **restated on narrower grounds.** It
  now rests on exactly two things, both labelled: the ISO C11 signatures of `mtx_destroy` and
  `cnd_destroy` themselves, and the call-site census, which is an **absence** over one module.

**So `m_cnd_destroy` returns 0**, matching its `m_mtx_destroy` sibling. Publishing
`kSceKernelErrorEBUSY` would have put a libkernel-encoded value through a C11-spelled entry point — a
third convention, neither the bare errno the POSIX spelling answers nor a `_Thrd_*` code.

**What the eleven bytes DO establish is the half #2168 needs, and it is not about a return value at
all:** the wrapper's single call is to `scePthreadCondDestroy`, so whatever that entry point does *to
the object* is what happens on hardware through the C11 spelling. The refusal-to-retire is therefore
part of `_Cnd_destroy`'s behaviour, it is unchanged by this correction, and the test now asserts it
as a **non-retirement** — the form in which it is observable at all. `_Cnd_wait`'s own `return 0` is
untouched.

`CONFIDENCE: HIGH` that the eleven-byte shape does not establish forwarding (proven by the
`_Thrd_yield` counterexample) and on every byte, address, NID and count above. `CONFIDENCE: MED` that
the pair is declared `void`: lines 2 and 3 are strong and agree, but line 2 maps a published ISO C11
signature onto Dinkumware's internal `_Xxx_yyy` primitive and line 3 is an absence over one module.
**Nothing here needs it settled** — both readings permit the 0 both handlers now answer.

## Regression test, with the mutation arms that make it discriminating

`prosper/tests/test_c11_sync_bookkeeping.cpp`, deliberately separate from `test_c11_thread_slots` —
every arm there passes with the bookkeeping absent, which is what made this class invisible. Seven
mutations were APPLIED, REBUILT and RE-RUN; the counts are what the runs printed:

| arm | mutation | result |
| --- | --- | --- |
| M1 | old `m_mtx_destroy` body | FAIL 4 (all of §1) |
| M2 | old `m_cnd_destroy` body | FAIL 4 (§2 x3, §4's retirement arm; §4's Sony and POSIX refusals still PASS — the divergence) |
| **M2b** | **publish the encoded EBUSY on a refusal (the pre-correction behaviour)** | **FAIL 1 (§4's `_Cnd_destroy` VALUE arm, and only that one)** |
| M3 | drop advance from the SHARED bodies | FAIL 3 (all of §3, parity arm included) |
| M4 | drop advance from the C11 spelling only | FAIL 2 (§3's C11 arms; parity arm PASSES) |
| M5 | drop the scope from the shared wait | FAIL 4 |
| M6 | drop the scope from `m_cnd_wait` only | FAIL 4 |
| M7 | leak the waiter count | FAIL 1 (§4's closing arm, and only that) |

**M2/M2b are the pair that separates the two questions §4 asks**, and they are why the correction did
not just weaken an assertion. M2 moves the retirement arm and not the value arm; M2b the exact
reverse. So neither is a second spelling of the other: a suite asserting only "the object survived"
would accept a libkernel-encoded value through a C11-spelled door, and one asserting only the value
would miss a missing busy check. Under M5/M6 the value arm passes **by design** — 0 is the answer
whether the destroy refused or retired, which is precisely why the refusal is asserted on the object.

M3/M4 separate a shared-body regression from a C11-only one, which is what makes §3 a parity test
rather than an existence test. **M5/M6 are NOT separated by this file, and that is recorded rather
than papered over:** the pre-existing `cond_destroy_busy` suite parks a SONY waiter and was measured
failing 3 arms under M5 while passing completely under M6, so each file catches the half the other
cannot.

M2, M2b, M5, M6 and M7 were **re-measured after the correction** (M1/M3/M4 touch only §1/§3, which
this correction does not change). Each arm was applied, rebuilt and re-run, and the test binary's
md5 was checked changing between arms and returning to `ffcb9a2ef76998dac084c5c1d22f3943` at
baseline — the mtime trap below is exactly why.

## Two instrument faults caught during this work

- The first full mutation batch was **VOID and looked fine**. The harness restored files with
  `shutil.copy2`, which preserves the BACKUP's mtime — so a restored file was OLDER than the object
  built from the mutated one, ninja skipped the rebuild, and the previous arm's mutation stayed
  compiled in. Arms cross-contaminated, and the tell was only that two arms killed sections they
  have no mechanism to touch. A mutation harness must stamp mtimes forward, and an arm whose failure
  set is not explicable by its mechanism should be disbelieved before it is recorded.
- §4 originally captured its retirement count AFTER two destroy attempts. In the runs where those
  two were the ones that failed, they had already retired the condvar, so the "`_Cnd_destroy`
  retired NOTHING" arm PASSED — vacuously, in exactly the run where the behaviour it names was
  broken. The count is now taken before the first attempt and paired with an identity check on the
  slot. Same for §1's use-after-destroy arm, which sat after a `scePthreadMutexDestroy` that poisons
  the slot itself and so passed under M1.

## Affected and deliberately unaffected

- **Affected:** both spellings of mutex lock/unlock/destroy and cond signal/broadcast/wait/destroy.
  The Sony/POSIX handlers now call the shared bodies, so their behavior is what it was — the shared
  body was extracted from them.
- **Deliberately unaffected:** `_Cnd_wait`'s unconditional `return 0` (the guest wrapper discards
  it, established above), and both destroy handlers' `return 0`. The `_Mtx_lock` result: `guest_mutex_lock_slot` now computes it and the
  handler drops it with an explicit `(void)`.
- **Deliberately not folded in, filed as #2626:** `_Mtx_lock` still returns 0 unconditionally while
  the guest wrapper maps the result onto a `_Thrd_*` code. Not done here because a `_Thrd_error`
  reaching Dinkumware terminates the guest, so it needs its own blast-radius evidence.

## Risks

- **Reachability is low today and that is recorded on both issues:** all 44 dumps on this machine
  ship `sce_module/libc.prx`, which exports the whole `_Mtx_*` / `_Cnd_*` family, and the loader
  resolves imports by NID with "cross-module export beats a stub slot", so the guest's own
  implementation wins and prosper's C11 handlers are not bound on those titles. This is a
  correctness fix on a path a future dump can reach, not a title unblock.
- **No guest-visible return-value change on the C11 spelling.** An earlier revision of this PR made
  `_Cnd_destroy` return the encoded EBUSY; that is withdrawn (see the corrected evidence above) and
  both destroy handlers answer 0 exactly as before this branch. The behavioural change on that
  spelling is the lifetime half only: the slot is claimed and poisoned, and a condvar with a parked
  waiter is not retired.
- The refactor moves live Sony/POSIX bodies into a shared header. The risk is a behavior change
  smuggled into the extraction; the mutation arms above are what bound it, and every extracted body
  is exercised through both spellings.

## Verification (local; author-run)

Linux, distrobox `ps5ys`, `prosper/build-linux`, `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`:

```
cmake --build prosper/build-linux -j4        -> clean, exit 0
ctest --no-tests=error -j4                   -> 266/266 passed, exit 0
```

Re-run at the corrected head `988964a5`, rebased onto master `a67f9452` (dump configured):
**273/273 passed, exit 0**. The registered count is re-established with `ctest -N` on every rebase
rather than carried forward — it has moved 266 -> 270 -> 273 as master's own gates landed
(`ascii_output_literals` among them), and none of those are this branch's. The focused suite `c11_sync_bookkeeping` passes with the `_Cnd_destroy` value arm now
reading `== 0`.

**ASCII output gate (#2588/#2614).** That gate merged onto master while this PR was open and fails
the build on non-ASCII inside a **string literal**. This branch's new test introduced **12**; all are
swept (em dash -> `--`, ellipsis -> `...`), `tools/output/check_ascii_output.py` passes, and **no
ledger number was raised**. Comments keep their non-ASCII by the gate's own design — 25 remain in
this file untouched.

Baseline on the branch point (`origin/master` `ec2c0c22`): **265/265 passed, exit 0**. The delta is
this commit's new test.

**No CI evidence is quoted: CI has not run on this branch.** GitHub was mid-incident when the work
was done, which is also why the PR is being opened after the fact.

## Merge order — PR #2634 is stacked on this branch

**PR #2634 (`fix/issue-2626-mtx-lock`) targets this PR's branch as its base**, not `master`. It
implements the `#2626` follow-up deferred above (`_Mtx_lock` reporting a failed lock instead of
`_Thrd_success`). **This PR must merge first**; GitHub will then retarget #2634 onto `master`.
Merging them out of order, or merging #2634 into this branch before this PR is reviewed, changes
what is being reviewed here.