### PR TITLE
tools(re): nid_gate_scan reads the error arm; #1640 re-bounded on what it then shows, and the *Destroy split's justification corrected

### DIFF
--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -729,19 +729,22 @@ split, and it is deliberately a **three**-way one, not two:
 same 24,308 windows, same 536 called imports:
 
 ```text
-#   254 gated, 202 ignored-only (cannot matter), 80 neither (no gate, and >=1 site not cleared)
-#   180 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable)
-#   site buckets: alu-gate=522 const=1 forward=1817 gate-open=897 ignored=18462 nonzero=2287
-#                 other-cmp=313 undecodable=9
+#   254 gated, 192 ignored-only (cannot matter), 90 neither (no gate, and >=1 site not cleared)
+#   241 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable)
+#   site buckets: alu-gate=517 const=1 forward=2013 gate-open=1053 ignored=18270 nonzero=2133
+#                 other-cmp=313 undecodable=8
 ```
 
-`undecodable` fell from **2,699 windows to 9**: the old figure was almost entirely the *last*
+`undecodable` fell from **2,699 windows to 8**: the old figure was almost entirely the *last*
 instruction of each fixed-size window being cut in half and decoding as `(bad)`/`.byte`, so the
-"11.1% of all windows are a void sample" line below was reading a truncation artifact as a finding.
-`ignored`-only rows rose 157 → 202 and the same "neither" count fell 132 → 80, because following the
+11.1%-of-all-windows void share this section originally reported was a truncation artifact read as a
+finding.
+`ignored`-only rows rose 157 → 192 and the same "neither" count fell 132 → 90, because following the
 branches resolves sites that used to end at the first one. The new `gate-open` bucket is the honest
-residue: a row can gate on the result and still be unresolved, which is why **180** — not 80 — is the
-number of rows that need a hand read.
+residue, and it cuts the other way: a row can gate on the result and still be unresolved, and a value
+handed to a callee in an argument register is not dead either — so **241** rows, not 90, need a hand
+read. That is more than the 132 this section originally reported, and it is the more accurate number:
+the old walk was clearing sites it had not established anything about.
 
 **Not-gated is not the same as cleared.** Only the `ignored`-only rows are struck off; an unresolved
 row carries at least one `forward`/`gate-open` site (the result left the scan's reach still live —

--- a/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
+++ b/prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md
@@ -724,13 +724,31 @@ split, and it is deliberately a **three**-way one, not two:
 #                 undecodable=2699
 ```
 
-**Not-gated is not the same as cleared.** Only the **157** `ignored`-only rows are struck off; the
-**132** unresolved rows carry at least one `forward` window (the result left the window still live —
-returned, spilled or tail-jumped, so the gate is in a caller) or at least one `undecodable` one, and
-**2,699 of the 24,308 windows — 11.1% — are undecodable**, which is a void sample rather than a
-negative. Anyone narrowing the candidate list from this table must work through those 132 by hand
-rather than treat the 247 as the whole search space. Two further properties matter more than the
-numbers:
+**Re-measured 2026-08-17 (PR #2637): the scan now reads the error arm, and most of that
+`undecodable` share was an artifact of the instrument, not a property of the module.** Same module,
+same 24,308 windows, same 536 called imports:
+
+```text
+#   254 gated, 202 ignored-only (cannot matter), 80 neither (no gate, and >=1 site not cleared)
+#   180 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable)
+#   site buckets: alu-gate=522 const=1 forward=1817 gate-open=897 ignored=18462 nonzero=2287
+#                 other-cmp=313 undecodable=9
+```
+
+`undecodable` fell from **2,699 windows to 9**: the old figure was almost entirely the *last*
+instruction of each fixed-size window being cut in half and decoding as `(bad)`/`.byte`, so the
+"11.1% of all windows are a void sample" line below was reading a truncation artifact as a finding.
+`ignored`-only rows rose 157 → 202 and the same "neither" count fell 132 → 80, because following the
+branches resolves sites that used to end at the first one. The new `gate-open` bucket is the honest
+residue: a row can gate on the result and still be unresolved, which is why **180** — not 80 — is the
+number of rows that need a hand read.
+
+**Not-gated is not the same as cleared.** Only the `ignored`-only rows are struck off; an unresolved
+row carries at least one `forward`/`gate-open` site (the result left the scan's reach still live —
+returned, spilled or tail-jumped, so the gate is in a caller) or at least one `undecodable` one,
+which is a void sample rather than a negative. Anyone narrowing the candidate list from this table
+must work through those by hand rather than treat the gated rows as the whole search space. Two
+further properties matter more than the numbers:
 
 - It is a **static upper bound on what can matter**, not a list of what runs. Cross it with the boot
   census (`hle_calls --launch --values`) before treating any row as live: the

--- a/prosper/docs/SONIC_FRONTIERS_STATUS.md
+++ b/prosper/docs/SONIC_FRONTIERS_STATUS.md
@@ -89,8 +89,10 @@ it. But the corpus says something about the *precise* code that nobody should ha
 **Two independent titles have a dedicated arm for `0x809F000F` and none for `0x809F0008`.** Of the
 five local titles that call `sceSaveDataTransferringMountPs4`, three const-compare the result —
 PPSA03839 against `0x809F0003` (a retry loop), and **PPSA07809 and PPSA08804 against `0x809F000F`**.
-PPSA08804's compare is inside its error arm *past* the branch, which is why a `nid_gate_scan` bucket
-reports it as a plain non-zero test.
+PPSA08804's compare is inside its error arm *past* the branch, at `+0x4e41a32`. When this was
+written that made it invisible to `nid_gate_scan`, which stopped at the first branch and bucketed the
+site as a plain non-zero test; the scan now follows both arms and reports it as `const` (PR #2637),
+so it no longer has to be taken on the hand-read. `--no-follow-arms` reproduces the older reading.
 
 `0x809F000F` appears nowhere in prosper, and the PS5 3.20 library dump carries names and NIDs only —
 no constants — so what it means is unresolved. Start from this rather than from

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -3173,6 +3173,39 @@ HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n
     if (sclog_semaphore() || sclog_focused_semaphore(a0))
         fprintf(stderr, "[sync2] T%" PRIu64 " SEMA.signal   sema=0x%llx n=%lld\n", sctid(), (unsigned long long)a0, (long long)n);
     interruptible_mutex_lock(&s->m); s->count += n; interruptible_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
+// #1640: PollSema's "not available" value is 0x80020023 (FreeBSD EAGAIN) where its sibling
+// `k_ef_poll` above answers 0x80020010 (EBUSY). EBUSY is the obvious guess by symmetry. IT IS NOT
+// TAKEN, because a static census of the whole 44-dump corpus shows the corpus CANNOT tell the two
+// apart, so changing it would be a guess dressed as a fix:
+//
+//   python3 tools/re/nid_gate_scan.py <DUMP_ROOT>/PPSA*-app0 --nid 12wOHk8ywb0 --const 0x80020010 -v
+//
+// Four titles import `sceKernelPollSema` (PPSA02801, PPSA04263, PPSA08576, PPSA13579 — confirmed
+// independently by `nid_census --registered --names`, which agrees on exactly that set). Across
+// their 49 call sites: **0 compare the result against any constant.** 29 are `ignored` (the result
+// is dead before any read), 17 are `test eax,eax`, and the 3 `forward` windows were read by hand
+// with `edis.py` — all three are the same `call PollSema; jmp <back>` into a shared
+// `xor r15d,r15d; test eax,eax; je <success>`, i.e. `nonzero` as well. 0 undecodable windows.
+//
+// That is a BOUND, not merely an absence, and this is the part worth keeping: both candidate values
+// are non-zero AND both are negative as int32 (0x80020010, 0x80020023). So a `test eax,eax` gate —
+// and equally a `js`/`jns` on it — is *structurally* incapable of distinguishing them. Every one of
+// the 49 sites is therefore provably insensitive to the choice, which is why no amount of re-running
+// this scan will settle it.
+//
+// The instrument is not silently broken: the same tool, same corpus, same classifier finds
+// `sceKernelPollEventFlag` (9lvj5DjHZiA) compared against `cmp eax,0x80020010` at **9 sites** in
+// PPSA05325 — independently re-deriving, from static disassembly, the live-trace evidence recorded
+// in `k_ef_poll` above. So the class "a poll import const-compared against a libkernel errno" is
+// expressible and does get found; it simply does not occur for this NID.
+//
+// WHAT WOULD SETTLE IT: a caller that compares the result against a named constant (the way
+// `_Mtx_trylock` compares 0x80020010), or a live `[sync2] SEMA.*` trace of a title branching on the
+// value. Site discovery follows one stub level and one call deep, so the 49 is a lower bound —
+// an indirect call through a function pointer would not appear.
+// CONFIDENCE: LOW on 0x80020023 being what Sony's libkernel reports. It is a legitimate FreeBSD
+// EAGAIN and NOT an instance of #1612 (a host errno leaking into a FreeBSD-numbered field), so it is
+// left as it is rather than swapped on symmetry alone.
 HLE(k_sema_poll)   { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t need = a1 ? (int64_t)a1 : 1;
     interruptible_mutex_lock(&s->m); bool ok = s->count >= need; if (ok) s->count -= need; pthread_mutex_unlock(&s->m); return ok ? 0 : 0x80020023; }
 

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -3175,34 +3175,49 @@ HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n
     interruptible_mutex_lock(&s->m); s->count += n; interruptible_cond_broadcast(&s->c); pthread_mutex_unlock(&s->m); return 0; }
 // #1640: PollSema's "not available" value is 0x80020023 (FreeBSD EAGAIN) where its sibling
 // `k_ef_poll` above answers 0x80020010 (EBUSY). EBUSY is the obvious guess by symmetry. IT IS NOT
-// TAKEN, because a static census of the whole 44-dump corpus shows the corpus CANNOT tell the two
-// apart, so changing it would be a guess dressed as a fix:
+// TAKEN, because a static census of the whole 44-dump corpus finds nothing in it that can tell the
+// two apart, so changing it would be a guess dressed as a fix:
 //
-//   python3 tools/re/nid_gate_scan.py <DUMP_ROOT>/PPSA*-app0 --nid 12wOHk8ywb0 --const 0x80020010 -v
+//   python3 tools/re/nid_gate_scan.py <DUMP_ROOT> --nid 12wOHk8ywb0 --const 0x80020010 -v
 //
 // Four titles import `sceKernelPollSema` (PPSA02801, PPSA04263, PPSA08576, PPSA13579 — confirmed
 // independently by `nid_census --registered --names`, which agrees on exactly that set). Across
 // their 49 call sites: **0 compare the result against any constant.** 29 are `ignored` (the result
-// is dead before any read), 17 are `test eax,eax`, and the 3 `forward` windows were read by hand
-// with `edis.py` — all three are the same `call PollSema; jmp <back>` into a shared
-// `xor r15d,r15d; test eax,eax; je <success>`, i.e. `nonzero` as well. 0 undecodable windows.
+// is dead before any read); 18 are `nonzero` (gated on zero/non-zero, and the value is then dead on
+// every reachable path, so the site cannot tell one non-zero answer from another); the remaining 2
+// the tool declines to clear, and both were read BY HAND:
+//   * PPSA04263+0x2b1e081, `gate-open`. Its ERROR arm — `test eax,eax; je`, not taken — never reads
+//     eax at all, and `call 0x33911f0` at +0x2b1e09b clobbers it. The site is unresolved only
+//     because the SUCCESS arm spills eax at +0x2b1e0e4, where the value is provably zero.
+//   * PPSA04263+0x310cd21, `undecodable`. Both consumers reduce the result to one bit — `sete sil`
+//     at +0x310cd30 and `test ebx,ebx; jne` at +0x310cd48 — and no decodable path reaches a compare
+//     against any constant. The bucket comes from one path running into inter-function NOP padding.
 //
-// That is a BOUND, not merely an absence, and this is the part worth keeping: both candidate values
-// are non-zero AND both are negative as int32 (0x80020010, 0x80020023). So a `test eax,eax` gate —
-// and equally a `js`/`jns` on it — is *structurally* incapable of distinguishing them. Every one of
-// the 49 sites is therefore provably insensitive to the choice, which is why no amount of re-running
-// this scan will settle it.
+// READING THE ERROR ARM IS THE WHOLE POINT, and an earlier version of this comment claimed a bound
+// it had not earned. `nid_gate_scan` used to stop at the first branch, so a site that gates
+// generically and const-compares INSIDE its error arm was bucketed `nonzero` — indistinguishable
+// from one that cannot care. That is precisely `k_ef_poll`'s own evidence above (Sonic Origins'
+// `RsdxWaitEvent` gates first and discriminates second), so a census run that way could not have
+// found the case it was looking for. The tool now forks at every branch the value survives, and
+// `--no-follow-arms` restores the old walk — diffed against the pre-change census, byte for byte.
 //
-// The instrument is not silently broken: the same tool, same corpus, same classifier finds
-// `sceKernelPollEventFlag` (9lvj5DjHZiA) compared against `cmp eax,0x80020010` at **9 sites** in
-// PPSA05325 — independently re-deriving, from static disassembly, the live-trace evidence recorded
-// in `k_ef_poll` above. So the class "a poll import const-compared against a libkernel errno" is
-// expressible and does get found; it simply does not occur for this NID.
+// The positive control is drawn from OUTSIDE this NID and outside this scan, because a control
+// sharing the null's instrument only shows the instrument runs: PPSA08804 const-compares
+// `sceSaveDataTransferringMountPs4` against 0x809F000F inside an error arm at +0x4e41a32 — found by
+// hand in review of #2208 — and the same bytes report `nonzero` under the old walk and `const` under
+// the new one. PPSA07809's site answers `const` for 0x809F000F but `other-cmp` for 0x809F0003, so
+// the finder discriminates rather than agreeing with whatever constant it is handed; and Sonic
+// Frontiers' five sites stay `nonzero` under both, matching the independently recorded finding that
+// it gates on the sign alone (docs/SONIC_FRONTIERS_STATUS.md).
+//
+// WHAT THIS DOES NOT ESTABLISH: it bounds the CORPUS, not Sony's libkernel. Site discovery follows
+// one stub level and one call deep, so 49 is a lower bound — an indirect call through a function
+// pointer does not appear at all. The walk is intra-module and does not follow the value into a
+// caller; a site that returns it is reported `gate-open`, never cleared.
 //
 // WHAT WOULD SETTLE IT: a caller that compares the result against a named constant (the way
 // `_Mtx_trylock` compares 0x80020010), or a live `[sync2] SEMA.*` trace of a title branching on the
-// value. Site discovery follows one stub level and one call deep, so the 49 is a lower bound —
-// an indirect call through a function pointer would not appear.
+// value.
 // CONFIDENCE: LOW on 0x80020023 being what Sony's libkernel reports. It is a legitimate FreeBSD
 // EAGAIN and NOT an instance of #1612 (a host errno leaking into a FreeBSD-numbered field), so it is
 // left as it is rather than swapped on symmetry alone.

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -3188,10 +3188,20 @@ HLE(k_sema_signal) { auto* s = (Sema*)(uintptr_t)a0; if (!s) return 0; int64_t n
 // the tool declines to clear, and both were read BY HAND:
 //   * PPSA04263+0x2b1e081, `gate-open`. Its ERROR arm — `test eax,eax; je`, not taken — never reads
 //     eax at all, and `call 0x33911f0` at +0x2b1e09b clobbers it. The site is unresolved only
-//     because the SUCCESS arm spills eax at +0x2b1e0e4, where the value is provably zero.
+//     because the SUCCESS arm spills eax at +0x2b1e0e4, where the value is zero. Do not look for a
+//     zeroing instruction — there is none, and the proof is BRANCH DOMINANCE: the only route to
+//     that spill still carrying the poll result runs through the `je` at +0x2b1e088, and the `je`
+//     being taken IS `eax == 0`. Every other route overwrites eax first (`mov eax,ecx` at
+//     +0x2b1e0ca, `mov eax,[rbx+rdx*4+0x80c]` at +0x2b1e0d3, and the error arm's `call`). Note the
+//     claim is about the tracked value, not the stack slot: [rbp-0x5c] does receive non-zero values
+//     on the routes where eax was overwritten.
 //   * PPSA04263+0x310cd21, `undecodable`. Both consumers reduce the result to one bit — `sete sil`
 //     at +0x310cd30 and `test ebx,ebx; jne` at +0x310cd48 — and no decodable path reaches a compare
-//     against any constant. The bucket comes from one path running into inter-function NOP padding.
+//     against any constant. The bucket comes from one path reaching the 14-byte alignment pad at
+//     +0x310cc92 (`66 66 66 66 66 2e 0f 1f 84 00 …`), which the classifier rejects on its `data16`
+//     prefix (#2653). That pad is INTRA-function — it aligns +0x310cca0, the target of the `jne` at
+//     +0x310cc73 in the same code stream — so this is padding before a branch target, not a walk
+//     that ran off the end of a function.
 //
 // READING THE ERROR ARM IS THE WHOLE POINT, and an earlier version of this comment claimed a bound
 // it had not earned. `nid_gate_scan` used to stop at the first branch, so a site that gates

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -542,9 +542,9 @@ HLE(k_ok)              { return 0; }                       // generic success no
 // RE-MEASURED 2026-08-17 (PR #2637), and it moved in the direction that strengthens this: the scan
 // used to stop at the first branch, so a site that tested generically and compared the errno inside
 // its ERROR ARM was counted in the `test eax,eax` half. Reading the arms, the same 445 sites across
-// the same 66 modules split const=307 / nonzero=82 / gate-open=43 / undecodable=13, against
+// the same 66 modules split const=307 / nonzero=78 / gate-open=47 / undecodable=13, against
 // const=237 / nonzero=208 with `--no-follow-arms`. So **70 more sites name 0x805A1001 than this
-// paragraph could see**, and the 43 `gate-open` + 13 `undecodable` are honestly unresolved rather
+// paragraph could see**, and the 47 `gate-open` + 13 `undecodable` are honestly unresolved rather
 // than counted as insensitive. (The 441/204 recorded above is the older reading; the site total has
 // since drifted by four, which was not investigated.)
 //

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -538,15 +538,23 @@ HLE(k_ok)              { return 0; }                       // generic success no
 // the COMPARE, not the branch target, so it says which titles *can* change behaviour under a
 // different answer, not which ones do, and "441 sites" is a lower bound on reach (it follows one
 // stub level and one call deep). The `test eax,eax` half matters as much as the errno half — it is
-// the plain defensive form of the same gate and never mentions 0x805A1001.
+// the plain defensive form of the same gate. It was recorded here as one that "never mentions
+// 0x805A1001"; that is FALSE for 70 of those sites, which name the constant inside their error arm
+// where the scan of the day could not see it. The claim is quoted rather than deleted so this stays
+// a dated record of what was believed, and the re-measure directly below is what corrects it.
 // RE-MEASURED 2026-08-17 (PR #2637), and it moved in the direction that strengthens this: the scan
 // used to stop at the first branch, so a site that tested generically and compared the errno inside
 // its ERROR ARM was counted in the `test eax,eax` half. Reading the arms, the same 445 sites across
 // the same 66 modules split const=307 / nonzero=78 / gate-open=47 / undecodable=13, against
 // const=237 / nonzero=208 with `--no-follow-arms`. So **70 more sites name 0x805A1001 than this
 // paragraph could see**, and the 47 `gate-open` + 13 `undecodable` are honestly unresolved rather
-// than counted as insensitive. (The 441/204 recorded above is the older reading; the site total has
-// since drifted by four, which was not investigated.)
+// than counted as insensitive.
+// The 441 -> 445 drift against the older reading is resolved, and it is apparatus rather than
+// corpus: PPSA08804-app0 carries a second copy of its eboot at `_DUPLEX_/Original eboot/eboot.bin`
+// (a release-group leftover, and NOT byte-identical to the shipped one -- a different build). The
+// scanner walks it as its own module, and it contributes exactly 4 sites and 1 module: 445 - 4 =
+// 441 and 66 - 1 = 65, reproducing the historical figures. Any sweep quoting a site total over the
+// local dumps double-counts that one title's eboot.
 //
 // What prosper can honestly answer is which ids the guest asked it to load. The sysmodule id space
 // is the set of *optional* modules an application must request; the always-resident libraries

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -539,6 +539,14 @@ HLE(k_ok)              { return 0; }                       // generic success no
 // different answer, not which ones do, and "441 sites" is a lower bound on reach (it follows one
 // stub level and one call deep). The `test eax,eax` half matters as much as the errno half — it is
 // the plain defensive form of the same gate and never mentions 0x805A1001.
+// RE-MEASURED 2026-08-17 (PR #2637), and it moved in the direction that strengthens this: the scan
+// used to stop at the first branch, so a site that tested generically and compared the errno inside
+// its ERROR ARM was counted in the `test eax,eax` half. Reading the arms, the same 445 sites across
+// the same 66 modules split const=307 / nonzero=82 / gate-open=43 / undecodable=13, against
+// const=237 / nonzero=208 with `--no-follow-arms`. So **70 more sites name 0x805A1001 than this
+// paragraph could see**, and the 43 `gate-open` + 13 `undecodable` are honestly unresolved rather
+// than counted as insensitive. (The 441/204 recorded above is the older reading; the site total has
+// since drifted by four, which was not investigated.)
 //
 // What prosper can honestly answer is which ids the guest asked it to load. The sysmodule id space
 // is the set of *optional* modules an application must request; the always-resident libraries

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -237,22 +237,32 @@ const char* const kInfallible[] = {
 //
 // They were listed as infallible when this file was written, and that was true then. #2359 (condvar)
 // and #2379 (barrier) landed #2168's busy-destroy contract: each now refuses an object that still
-// has waiters with an ENCODED `SCE_KERNEL_ERROR_EBUSY` (0x80020010), returned in place because
-// neither body has a POSIX spelling registered on it. The `kInfallible` ARM still passed unchanged
-// after both, because a null slot never reaches the busy check — so nothing failed, and the list's
-// stated rationale ("returns 0 on every path") silently went false while the assertion stayed green.
-// That is the failure this split exists to prevent: a passing arm is not evidence that the sentence
-// justifying it is still true.
+// has waiters, and the guest sees `SCE_KERNEL_ERROR_EBUSY` (0x80020010) from BOTH Sony spellings.
+// They get there by opposite routes, and the difference is the axis #2182 polices, so do not
+// collapse it:
+//   * `k_barrier_destroy` encodes IN PLACE (hle_kernel.cpp:3045). It is Sony-only — nothing
+//     registers `pthread_barrier_destroy` onto that body — so there is no POSIX caller to mislead.
+//   * `k_cond_destroy` returns the BARE FreeBSD errno (hle_kernel.cpp:1033-1034) precisely BECAUSE
+//     `pthread_cond_destroy` is registered onto the same body (:4810). The Sony spelling gets its
+//     0x8002xxxx from the `SCE_PTHREAD_ALIAS` at :1049. Making this one encode in place would hand
+//     every `pthread_cond_destroy` caller a Sony-encoded value — #1984's shape — and
+//     `test_cond_destroy_busy.cpp` asserts the bare 16 for exactly that reason.
+// The `kInfallible` ARM still passed unchanged after both landings, because a null slot never
+// reaches the busy check — so nothing failed, and the list's stated rationale ("returns 0 on every
+// path") silently went false while the assertion stayed green. That is the failure this split
+// exists to prevent: a passing arm is not evidence that the sentence justifying it is still true.
 //
 // The busy path itself is covered where it can actually be constructed — a thread must really be
 // parked in the object — by `test_cond_destroy_busy.cpp` and `test_barrier_destroy_busy.cpp`. What
 // is pinned HERE is only the null-slot half: these report success for an absent object rather than
-// inventing a failure. Neither arm discriminates an added alias (`sce_pthread_rc(0)` is 0).
+// inventing a failure. That is all this arm can see: `sce_pthread_rc(0)` is 0, so it reads the same
+// through the condvar's existing alias as it would through the barrier's direct registration, and
+// it would not notice an alias being added to or removed from either.
 // #2168's remaining third, `scePthreadMutexDestroy`, is still genuinely infallible above: it needs
 // owner tracking that deliberately does not exist on POSIX hosts (#719/#793).
 const char* const kFallibleButNullSucceeds[] = {
-    "scePthreadCondDestroy",      // #2359: encoded EBUSY when the condvar still has waiters
-    "scePthreadBarrierDestroy",   // #2379: encoded EBUSY when threads are parked in the barrier
+    "scePthreadCondDestroy",      // #2359: EBUSY with waiters — bare from the body, encoded by the alias
+    "scePthreadBarrierDestroy",   // #2379: EBUSY with threads parked — encoded in the body itself
 };
 
 }  // namespace

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -243,10 +243,16 @@ const char* const kInfallible[] = {
 //   * `k_barrier_destroy` encodes IN PLACE (hle_kernel.cpp:3045). It is Sony-only — nothing
 //     registers `pthread_barrier_destroy` onto that body — so there is no POSIX caller to mislead.
 //   * `k_cond_destroy` returns the BARE FreeBSD errno (hle_kernel.cpp:1033-1034) precisely BECAUSE
-//     `pthread_cond_destroy` is registered onto the same body (:4810). The Sony spelling gets its
-//     0x8002xxxx from the `SCE_PTHREAD_ALIAS` at :1049. Making this one encode in place would hand
-//     every `pthread_cond_destroy` caller a Sony-encoded value — #1984's shape — and
+//     the POSIX spelling is registered onto the same body -- grep
+//     `R("pthread_cond_destroy", k_cond_destroy)`, hle_kernel.cpp:4825 at the time of writing. The
+//     Sony spelling gets its 0x8002xxxx from the `SCE_PTHREAD_ALIAS` at :1049. Making this one
+//     encode in place would hand every POSIX caller a Sony-encoded value -- #1984's shape -- and
 //     `test_cond_destroy_busy.cpp` asserts the bare 16 for exactly that reason.
+//     (The line number is given with the symbol on purpose. This citation was already wrong once:
+//     it read :4810, correct when the reviewer wrote it and stale one rebase later, because a line
+//     number is a fact about a revision and a comment outlives revisions. That is #2665's class,
+//     and it bites hardest exactly here -- a reader who opens the cited line, finds an unrelated
+//     registration and concludes the claim is unsupported ends up believing the opposite of it.)
 // The `kInfallible` ARM still passed unchanged after both landings, because a null slot never
 // reaches the busy check -- so nothing failed, and the list's stated rationale ("returns 0 on every
 // path") silently went false while the assertion stayed green. That is the failure this split

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -248,7 +248,7 @@ const char* const kInfallible[] = {
 //     every `pthread_cond_destroy` caller a Sony-encoded value — #1984's shape — and
 //     `test_cond_destroy_busy.cpp` asserts the bare 16 for exactly that reason.
 // The `kInfallible` ARM still passed unchanged after both landings, because a null slot never
-// reaches the busy check — so nothing failed, and the list's stated rationale ("returns 0 on every
+// reaches the busy check -- so nothing failed, and the list's stated rationale ("returns 0 on every
 // path") silently went false while the assertion stayed green. That is the failure this split
 // exists to prevent: a passing arm is not evidence that the sentence justifying it is still true.
 //
@@ -261,8 +261,8 @@ const char* const kInfallible[] = {
 // #2168's remaining third, `scePthreadMutexDestroy`, is still genuinely infallible above: it needs
 // owner tracking that deliberately does not exist on POSIX hosts (#719/#793).
 const char* const kFallibleButNullSucceeds[] = {
-    "scePthreadCondDestroy",      // #2359: EBUSY with waiters — bare from the body, encoded by the alias
-    "scePthreadBarrierDestroy",   // #2379: EBUSY with threads parked — encoded in the body itself
+    "scePthreadCondDestroy",      // #2359: EBUSY with waiters -- bare from the body, encoded by the alias
+    "scePthreadBarrierDestroy",   // #2379: EBUSY with threads parked -- encoded in the body itself
 };
 
 }  // namespace

--- a/prosper/tests/test_pthread_error_encoding.cpp
+++ b/prosper/tests/test_pthread_error_encoding.cpp
@@ -226,10 +226,33 @@ bool wait_for(const std::atomic<int>& counter, int target) {
 // established that its absence is the right answer rather than an oversight.
 const char* const kInfallible[] = {
     "scePthreadMutexattrSetprotocol", "scePthreadMutexattrSetpshared", "scePthreadMutexattrDestroy",
-    "scePthreadMutexDestroy", "scePthreadCondattrDestroy", "scePthreadCondDestroy",
+    "scePthreadMutexDestroy", "scePthreadCondattrDestroy",
     "scePthreadCondSignal", "scePthreadCondBroadcast",
-    "scePthreadRwlockDestroy", "scePthreadSemDestroy", "scePthreadBarrierDestroy",
+    "scePthreadRwlockDestroy", "scePthreadSemDestroy",
     "scePthreadBarrierattrInit", "scePthreadBarrierattrDestroy", "scePthreadBarrierattrSetpshared",
+};
+
+// Bodies that CAN fail, but answer 0 for a NULL slot — so the sweep's null probe cannot reach their
+// failure path and they do not belong in either list above.
+//
+// They were listed as infallible when this file was written, and that was true then. #2359 (condvar)
+// and #2379 (barrier) landed #2168's busy-destroy contract: each now refuses an object that still
+// has waiters with an ENCODED `SCE_KERNEL_ERROR_EBUSY` (0x80020010), returned in place because
+// neither body has a POSIX spelling registered on it. The `kInfallible` ARM still passed unchanged
+// after both, because a null slot never reaches the busy check — so nothing failed, and the list's
+// stated rationale ("returns 0 on every path") silently went false while the assertion stayed green.
+// That is the failure this split exists to prevent: a passing arm is not evidence that the sentence
+// justifying it is still true.
+//
+// The busy path itself is covered where it can actually be constructed — a thread must really be
+// parked in the object — by `test_cond_destroy_busy.cpp` and `test_barrier_destroy_busy.cpp`. What
+// is pinned HERE is only the null-slot half: these report success for an absent object rather than
+// inventing a failure. Neither arm discriminates an added alias (`sce_pthread_rc(0)` is 0).
+// #2168's remaining third, `scePthreadMutexDestroy`, is still genuinely infallible above: it needs
+// owner tracking that deliberately does not exist on POSIX hosts (#719/#793).
+const char* const kFallibleButNullSucceeds[] = {
+    "scePthreadCondDestroy",      // #2359: encoded EBUSY when the condvar still has waiters
+    "scePthreadBarrierDestroy",   // #2379: encoded EBUSY when threads are parked in the barrier
 };
 
 }  // namespace
@@ -540,6 +563,22 @@ int main() {
         if (!f) { snprintf(msg, sizeof msg, "%s is registered", name); CHECK(false, msg); continue; }
         const uint64_t got = call0(f);
         snprintf(msg, sizeof msg, "%-32s -> 0 (no failure path, so no alias)  got 0x%llx",
+                 name, (unsigned long long)got);
+        CHECK(got == 0, msg);
+    }
+
+    // The #2168 busy-destroy pair. Same observable assertion, deliberately a separate group and a
+    // separate label: these bodies DO have a failure path, it is simply unreachable through a null
+    // slot. Keeping them in kInfallible would keep asserting the right thing for a reason that
+    // stopped being true when #2359 and #2379 landed. See kFallibleButNullSucceeds.
+    printf("-- #2168 busy-destroy bodies: a NULL slot still reports success (the busy path is in "
+           "test_cond_destroy_busy / test_barrier_destroy_busy) --\n");
+    for (const char* name : kFallibleButNullSucceeds) {
+        char msg[192];
+        HleFn f = Hle::lookup(nid_hash(name));
+        if (!f) { snprintf(msg, sizeof msg, "%s is registered", name); CHECK(false, msg); continue; }
+        const uint64_t got = call0(f);
+        snprintf(msg, sizeof msg, "%-32s -> 0 for a null slot (fallible, but not here)  got 0x%llx",
                  name, (unsigned long long)got);
         CHECK(got == 0, msg);
     }

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -215,18 +215,28 @@ Flattening happens in memory, so there is no `prx_to_elf.py` step.
 
 | bucket | meaning |
 |---|---|
-| `const` | compares the result against `--const` |
-| `nonzero` | `test eax,eax` / `cmp eax,0` → conditional branch |
+| `const` | some reachable path compares the result against `--const` |
+| `nonzero` | gated on zero/non-zero, and the value is then dead on **every** reachable path — the only bucket that says this site cannot tell one non-zero answer from another |
+| `gate-open` | gated, but an arm left the scan's reach (returned, spilled, indirect branch, unmapped, budget) — **not** cleared; read it by hand |
 | `alu-gate` | folds the result into flags (`and eax,mask` …) and branches on that |
 | `other-cmp` | compares against some other immediate |
-| `forward` | still live when the window ends — returned, spilled, or tail-jumped; read it by hand |
+| `forward` | never gated here and still live — returned, spilled, or tail-jumped; read it by hand |
 | `ignored` | dead before any read: this call site cannot be affected |
 | `undecodable` | objdump could not decode the window — a **void** sample, not a negative one |
 
+**The error arm is read.** The scan forks at every branch the value survives and explores both
+successors, so a site that tests the result generically and *then* const-compares it inside its error
+arm lands in `const`. That case used to land in `nonzero` — indistinguishable from a site that cannot
+care — which is why `nonzero` now carries the stronger meaning above and `gate-open` exists to hold
+everything the walk could not finish. `--no-follow-arms` restores the old single-window walk, and is
+there only to reproduce numbers published before this existed; it under-reports `const`, measurably
+(PPSA08804's `sceSaveDataTransferringMountPs4` site: `nonzero` without, `const` with).
+
 **Read the output as a bound, not a census.** It classifies the *compare*, never the branch target,
-so it tells you which titles *can* change behaviour, not which do; and site discovery follows one
-stub level and one call deep, so a count is a lower bound. `forward=0` across a corpus is worth
-quoting for the opposite reason — together with `undecodable=0` it shows every window decoded.
+so it tells you which titles *can* change behaviour, not which do; site discovery follows one stub
+level and one call deep, so a count is a lower bound; and the walk is intra-module, so a value handed
+to a caller is `gate-open` rather than cleared. `gate-open=0 forward=0 undecodable=0` across a corpus
+is worth quoting for the opposite reason — together they say every site was resolved.
 
 The classifier tracks the result as a small register taint set rather than watching `eax` alone,
 because the ordinary compiler output is `mov ecx,eax; xor eax,eax; test ecx,ecx` — the `xor` is the
@@ -260,23 +270,25 @@ Rows sort by gated call sites descending, so the head of the table is libc, and 
 block is the part to read first:
 
 ```text
-Ovb2dSJOAuE  strcmp                libSceLibcInternal  sites=981 gated=973 forward=7 nonzero=972 …
+Ovb2dSJOAuE  strcmp                libSceLibcInternal  sites=981 gated=979 gate-open=65 nonzero=912 …
 …
-fMP5NHUOaMk  sceSysmoduleIsLoaded  libSceSysmodule     sites=5   gated=5   const=1 nonzero=4
+fMP5NHUOaMk  sceSysmoduleIsLoaded  libSceSysmodule     sites=5   gated=5   const=1 gate-open=1 nonzero=3
 …
-# <path>: 536 imported NIDs are called; 247 shown at --min-gated=1
-#   247 gated, 157 ignored-only (cannot matter), 132 unresolved (>=1 forward/undecodable window
-#   — NOT cleared, read by hand)
-#   site buckets: alu-gate=125 const=1 forward=3445 ignored=14432 nonzero=3440 other-cmp=166
-#                 undecodable=2699
+# <path>: 536 imported NIDs are called; 254 shown at --min-gated=1
+#   254 gated, 202 ignored-only (cannot matter), 80 neither (no gate, and >=1 site not cleared)
+#   180 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable) — read
+#   those by hand
+#   site buckets: alu-gate=522 const=1 forward=1817 gate-open=897 ignored=18462 nonzero=2287
+#                 other-cmp=313 undecodable=9
 ```
 
-**Not-gated is not the same as cleared, and the summary says so on purpose.** `ignored` is the only
-bucket that means an answer cannot matter at that site; `forward` explicitly needs a look by hand and
-`undecodable` is a void sample. A two-way "called / gated" split invites the reading that everything
-below the cut is struck off — here that would wrongly retire 132 rows, and 11.1% of all windows are
-undecodable. The three-way split plus the site-bucket totals make it impossible to mistake the table
-for a clean partition.
+**Not-gated is not the same as cleared, and neither is gated.** `ignored` is the only bucket that
+means an answer cannot matter at that site, and `nonzero` the only one that means it cannot matter
+*which* non-zero answer; `forward` and `gate-open` explicitly need a look by hand and `undecodable`
+is a void sample. A two-way "called / gated" split invites the reading that everything below the cut
+is struck off — and the `gate-open` rows show the same trap above the cut, since a row can gate on
+the result and still be unresolved. That is why the summary prints the not-resolved row count
+separately from the not-gated one, and the site-bucket totals underneath both.
 
 `--names` points at the gitignored PS5 firmware `genstub.py` library dump and is **symbolication
 only** — an unlabelled NID is still scanned and still reported, so a missing dump costs names, never

--- a/prosper/tools/re/README.md
+++ b/prosper/tools/re/README.md
@@ -270,16 +270,16 @@ Rows sort by gated call sites descending, so the head of the table is libc, and 
 block is the part to read first:
 
 ```text
-Ovb2dSJOAuE  strcmp                libSceLibcInternal  sites=981 gated=979 gate-open=65 nonzero=912 …
+Ovb2dSJOAuE  strcmp                libSceLibcInternal  sites=981 gated=979 gate-open=66 nonzero=911 …
 …
 fMP5NHUOaMk  sceSysmoduleIsLoaded  libSceSysmodule     sites=5   gated=5   const=1 gate-open=1 nonzero=3
 …
 # <path>: 536 imported NIDs are called; 254 shown at --min-gated=1
-#   254 gated, 202 ignored-only (cannot matter), 80 neither (no gate, and >=1 site not cleared)
-#   180 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable) — read
+#   254 gated, 192 ignored-only (cannot matter), 90 neither (no gate, and >=1 site not cleared)
+#   241 rows carry >=1 site the scan could not resolve (gate-open/forward/undecodable) -- read
 #   those by hand
-#   site buckets: alu-gate=522 const=1 forward=1817 gate-open=897 ignored=18462 nonzero=2287
-#                 other-cmp=313 undecodable=9
+#   site buckets: alu-gate=517 const=1 forward=2013 gate-open=1053 ignored=18270 nonzero=2133
+#                 other-cmp=313 undecodable=8
 ```
 
 **Not-gated is not the same as cleared, and neither is gated.** `ignored` is the only bucket that

--- a/prosper/tools/re/nid_gate_scan.py
+++ b/prosper/tools/re/nid_gate_scan.py
@@ -12,21 +12,31 @@ This resolves that statically, with no boot and no GPU:
       -> every `call rel32` that reaches the stub (plus any `call *[rip+d]` straight to the slot)
       -> objdump the bytes right after each call and classify what happens to eax.
 
-CAVEAT — this tool UNDER-REPORTS const-sensitivity, and the limit is structural.
-`classify_window` stops at the first branch, so a site that tests the result generically and THEN
-const-compares it *inside its error arm* is bucketed as a plain non-zero test. Measured: PPSA08804
-compares against 0x809F000F at 0x4e41a32, past the branch, and this scan reports it as `nonzero`
-(#2023 review). So a `nonzero` verdict means "no const compare before the first branch", NOT "this
-title does not care which error code it gets". Read the error arm before concluding an errno is
-inert.
+THE ERROR ARM IS READ. This used to carry a caveat saying it was not: `classify_window` stopped at
+the first branch, so a site that tests the result generically and THEN const-compares it *inside its
+error arm* was bucketed as a plain non-zero test, and a `nonzero` verdict meant only "no const
+compare before the first branch". Measured then: PPSA08804 compares against 0x809F000F at 0x4e41a32,
+past the branch, reported as `nonzero` (#2023 review). That under-reporting is now fixed —
+`classify_site_following` forks the walk at every branch the value survives and explores both
+successors — and PPSA08804's site is reported as `const`.
 
-Buckets (see `classify_window`):
-    const        the window compares eax against --const (the gate idiom this was written for)
-    nonzero      `test eax,eax` / `cmp eax,0` / sign test -> conditional branch (any error gates)
+What remains, and it is a different claim: a site whose arms leave this scan's reach is reported
+`gate-open` or `forward`, NEVER `nonzero`. So the bucket that says "this site cannot tell one error
+code from another" now earns that meaning, and the buckets that cannot say it are loud. Pass
+`--no-follow-arms` to reproduce the pre-2026-08 numbers.
+
+Buckets (see `classify_site_following` for the default walk, `classify_window` for the legacy one):
+    const        some reachable path compares eax against --const (the idiom this was written for)
+    nonzero      gated on zero/non-zero, and the value is then dead on EVERY reachable path — the
+                 one bucket that means "this site cannot be affected by WHICH non-zero answer"
+    gate-open    gated, but at least one arm left the scan's reach (returned, spilled, indirect
+                 branch, unmapped, or the block budget ran out) — NOT cleared, read by hand
     other-cmp    compares eax against some *other* immediate
-    forward      eax is moved/returned/stored without a local branch — the gate, if any, is in a
+    alu-gate     flags derive from an ALU transform of the result (`and eax,mask; jne`)
+    forward      eax is moved/returned/stored and never gated here — the gate, if any, is in a
                  caller or behind a spilled value; needs a look by hand
     ignored      eax is dead before it is read — this call site cannot be affected
+    undecodable  objdump could not decode the window: a VOID sample, not a negative one
 
 Usage:
     nid_gate_scan.py <module|app0-dir> --nid <NID> [--const 0x805a1001] [--window 48] [-v]
@@ -321,6 +331,15 @@ def disasm(blob, base):
     Raises on an objdump failure rather than returning an empty list: a silent empty decode would
     be classified as an ordinary window and drain into a bucket, turning a broken toolchain into a
     plausible-looking measurement.
+
+    `--no-show-raw-insn` is load-bearing, not cosmetic. objdump wraps the raw-byte column after
+    seven bytes, and the continuation line carries the SAME `<addr>:\\t<hex bytes>` shape as a real
+    instruction — so the parse below read ` 310d73a:\\t03 00 00 00` as an instruction `00` at a VA
+    that is *inside* the 11-byte `mov DWORD PTR [rdi+rax*4+0x6e0],0x3` starting at 0x310d733
+    (PPSA04263). A phantom mnemonic is inert in the taint walk, but a phantom VA is not: the walk
+    uses instruction addresses to continue a block past the end of a window, and continuing from
+    the middle of an instruction decodes garbage. Suppressing the byte column removes the wrap and
+    with it the whole class.
     """
     od = objdump_binary()
     if od is None:
@@ -331,7 +350,7 @@ def disasm(blob, base):
     with open(tmp, "wb") as f:
         f.write(blob)
     r = subprocess.run(
-        [od, "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "intel",
+        [od, "-D", "-b", "binary", "-m", "i386:x86-64", "-M", "intel", "--no-show-raw-insn",
          "--adjust-vma=%#x" % base, tmp],
         capture_output=True, text=True)
     if r.returncode != 0:
@@ -339,9 +358,9 @@ def disasm(blob, base):
     out = r.stdout
     insns = []
     for line in out.splitlines():
-        m = re.match(r"\s*([0-9a-f]+):\s+((?:[0-9a-f]{2} )+)\s*(\S+)\s*(.*)", line)
+        m = re.match(r"\s*([0-9a-f]+):\s+(\S+)\s*(.*)", line)
         if m:
-            insns.append((int(m.group(1), 16), m.group(3), m.group(4).split("#")[0].strip()))
+            insns.append((int(m.group(1), 16), m.group(2), m.group(3).split("#")[0].strip()))
     return insns
 
 
@@ -389,40 +408,69 @@ def canon(operand):
 ALU_RMW = {"and", "or", "xor", "add", "sub", "shl", "shr", "sar", "not", "neg", "inc", "dec", "imul"}
 
 
-def classify_window(insns, const):
-    """Classify what the code right after the call does with the returned eax.
+def _direct_target(ops):
+    """The VA a direct branch goes to, or None when the operand is not a bare absolute address.
+
+    objdump's raw-binary Intel output prints a direct jump's destination as a plain `0x...`
+    (already shifted by --adjust-vma, so it is a VA in the flat image). An indirect branch prints
+    a register or a memory operand instead, and there is nothing static to follow.
+    """
+    op = ops.strip()
+    return int(op, 16) if re.fullmatch(r"0x[0-9a-f]+", op) else None
+
+
+def _is_cond_jump(mn):
+    """Any conditional jump. Every x86 mnemonic starting with `j` is a jump, and `jmp` is the only
+    unconditional one, so this is exact rather than an enumeration that can miss `jp`/`jrcxz`."""
+    return mn.startswith("j") and mn != "jmp"
+
+
+def _walk_block(insns, const, live, spilled, follow=False, fall_va=None):
+    """One block of the taint walk. Returns (bucket, evidence, state).
 
     Tracks the result as a small taint set of registers rather than looking only at eax: the
     common compiler output moves eax into another register and *then* zeroes eax as the enclosing
     function's own return value, so an eax-only reader calls a live gate "ignored" (measured on
     GTA V eboot+0x2d850cc: `mov ecx,eax; xor eax,eax; test ecx,ecx`).
 
-    Buckets: const / nonzero / other-cmp / alu-gate all mean "branches on the result"; `forward`
-    means the result left the window still live (returned, spilled, or tail-jumped) and needs a
-    look by hand; `ignored` means it was dead before any read; `undecodable` means objdump could
-    not decode the window, which is a VOID sample, not a negative one.
+    `follow=False` is the legacy single-window walk: it STOPS at the first branch, which is the
+    under-reporting this file's header caveat is about. `follow=True` instead reports the block's
+    successors in `state["edges"]` — a zero-gate no longer terminates the walk, it forks it — so
+    `classify_site_following` can read the ERROR ARM. `fall_va` is where the block continues if the
+    walk runs off the end of the decoded window; None means "the window is the end of what I have".
     """
     const_forms = {"0x%x" % const, str(const)}
-    live = {"a"}
-    spilled = False
-    for va, mn, ops in insns:
+    live = set(live)
+    gated = None                                          # the gate's own (va, mn, ops), once seen
+
+    def st(edges=()):
+        return {"live": live, "spilled": spilled, "edges": list(edges), "gated": gated}
+
+    for i, (va, mn, ops) in enumerate(insns):
+        ev = (va, mn, ops)
         if mn.startswith("(bad)") or mn.startswith(".byte") or mn in ("data16", "rex.W", "rex.RB"):
             # The decode ran into data or a prefix objdump could not attach. Say so instead of
             # letting a broken window fall into `forward`, where it is indistinguishable from a
             # real forward and quietly weakens every count in the table.
-            return "undecodable", (va, mn, ops)
+            return "undecodable", ev, st()
         parts = [p.strip() for p in ops.split(",")] if ops else []
         dst = canon(parts[0]) if parts else None
         src = canon(parts[-1]) if len(parts) > 1 else None
         if mn == "cmp" and dst in live:
             imm = parts[-1]
             if imm in const_forms:
-                return "const", (va, mn, ops)
+                return "const", ev, st()
             if imm in ("0x0", "0"):
-                return "nonzero", (va, mn, ops)
-            return "other-cmp", (va, mn, ops)
+                if not follow:
+                    return "nonzero", ev, st()
+                gated = gated or ev                       # the gate is real; keep reading past it
+                continue
+            return "other-cmp", ev, st()
         if mn == "test" and dst in live and src in live:
-            return "nonzero", (va, mn, ops)
+            if not follow:
+                return "nonzero", ev, st()
+            gated = gated or ev
+            continue
         if mn in ("mov", "movsxd", "movzx", "movsx") and src in live:
             if dst:
                 live.add(dst)
@@ -435,26 +483,159 @@ def classify_window(insns, const):
             if src == dst and mn in ("xor", "sub"):
                 live.discard(dst)                         # self-xor / self-sub: the zeroing idiom
                 if not live:
-                    return ("forward" if spilled else "ignored"), (va, mn, ops)
+                    return ("forward" if spilled else "ignored"), ev, st()
                 continue
-            return "alu-gate", (va, mn, ops)              # flags now derive from the result
+            return "alu-gate", ev, st()                   # flags now derive from the result
         if mn == "ret":
-            return ("forward" if ("a" in live or spilled) else "ignored"), (va, mn, ops)
+            return ("forward" if ("a" in live or spilled) else "ignored"), ev, st()
         if mn == "jmp":
             # An unconditional jump ends this basic block; anything after it belongs to unrelated
             # code. Without this the scan walked straight on and could pick up a `cmp` from the
             # NEXT block, over-reporting a gate that the result never reaches.
-            return ("forward" if (live or spilled) else "ignored"), (va, mn, ops)
+            if not (live or spilled):
+                return "ignored", ev, st()
+            tgt = _direct_target(ops) if follow else None
+            if tgt is None:
+                return "forward", ev, st()                # legacy mode, or an indirect tail-call
+            return "edges", ev, st([tgt])
+        if _is_cond_jump(mn):
+            if not follow:
+                continue                                  # legacy: walked straight through
+            # Both successors are reachable with the value in the same state, so BOTH are queued —
+            # including when the branch tests flags this walk did not set. Exploring only the
+            # fall-through is what let a const compare hide in the taken arm.
+            tgt = _direct_target(ops)
+            nxt = insns[i + 1][0] if i + 1 < len(insns) else fall_va
+            if tgt is None or nxt is None:
+                return "forward", ev, st()                # indirect, or the window ran out
+            return "edges", ev, st([tgt, nxt])
         if mn == "call":
             live -= CALLER_SAVED
             if not live:
-                return ("forward" if spilled else "ignored"), (va, mn, ops)
+                return ("forward" if spilled else "ignored"), ev, st()
             continue
         if dst in live and mn not in ("cmp", "test", "push"):
             live.discard(dst)                             # overwritten from a non-result source
             if not live:
-                return ("forward" if spilled else "ignored"), (va, mn, ops)
-    return ("forward" if (live or spilled) else "ignored"), (insns[0] if insns else (0, "", ""))
+                return ("forward" if spilled else "ignored"), ev, st()
+    last = insns[-1] if insns else (0, "", "")
+    if not (live or spilled):
+        return "ignored", (insns[0] if insns else last), st()
+    if follow and fall_va is not None:
+        return "edges", last, st([fall_va])               # the block simply continues past the window
+    return "forward", (insns[0] if insns else last), st()
+
+
+def classify_window(insns, const):
+    """Classify what the code right after the call does with the returned eax — ONE window, no
+    branch following. This is the legacy classifier, kept so `--no-follow-arms` reproduces every
+    number this tool published before arm following existed.
+
+    Buckets: const / nonzero / other-cmp / alu-gate all mean "branches on the result"; `forward`
+    means the result left the window still live (returned, spilled, or tail-jumped) and needs a
+    look by hand; `ignored` means it was dead before any read; `undecodable` means objdump could
+    not decode the window, which is a VOID sample, not a negative one.
+    """
+    bucket, ev, _state = _walk_block(insns, const, {"a"}, False)
+    return bucket, ev
+
+
+# Decoded blocks per call site. A site that needs more than this is reported UNRESOLVED
+# (`gate-open` / `forward`), never quietly cleared — running out of budget must not look like a
+# clean negative, which is the whole failure mode arm following exists to remove.
+ARM_BLOCK_LIMIT = 192
+
+# Worst-to-best. The site's verdict is the strongest thing found on ANY reachable path, so one arm
+# that const-compares makes the whole site `const` no matter how many arms drop the value.
+_SITE_RANK = ("ignored", "nonzero", "gate-open", "forward", "undecodable",
+              "alu-gate", "other-cmp", "const")
+
+
+MAX_X86_INSN = 16          # an x86-64 instruction is at most 15 bytes; 16 is the safe round number
+
+
+def block_fetcher(img, window):
+    """`va -> (instructions strictly inside [va, va+window), next_va)`, memoised.
+
+    The over-read by one maximum instruction length is what makes both halves exact, and neither is
+    optional once the walk follows branches:
+      * every returned instruction is COMPLETE. objdump decodes whatever bytes it is handed, so the
+        last instruction in a blob cut at a fixed size decodes as `(bad)`/`.byte` junk — which is
+        the `undecodable` bucket, i.e. a truncation artifact wearing the name of a real finding.
+        Reading 16 bytes past the boundary and then discarding everything that starts at or after
+        it leaves only instructions whose bytes were all present.
+      * `next_va` is EXACT, with no instruction-length table anywhere: it is simply the first
+        instruction that starts at or after the boundary, which is where the block continues if the
+        walk runs off the end of the window.
+    Junk in the MIDDLE of a window is still reported `undecodable`, because there it is data rather
+    than truncation — which is the distinction the bucket is supposed to carry.
+    """
+    cache = {}
+
+    def fetch(va):
+        if va not in cache:
+            fo = img.foff(va)
+            if fo is None:
+                cache[va] = (None, None)                 # unmapped: honestly unresolvable
+            else:
+                end = va + window
+                ins = disasm(img.raw[fo:fo + window + MAX_X86_INSN], va)
+                body = [i for i in ins if i[0] < end]
+                tail = [i for i in ins if i[0] >= end]
+                cache[va] = (body, tail[0][0] if tail else None) if body else (None, None)
+        return cache[va]
+
+    return fetch
+
+
+def classify_site_following(fetch, start, const, limit=ARM_BLOCK_LIMIT):
+    """Classify a call site by exploring EVERY reachable path the result stays live on.
+
+    This is the fix for the caveat at the top of this file. The legacy walk stops at the first
+    branch, so `test eax,eax; je .ok; cmp eax,<errno>; ...` — a site that gates generically and
+    discriminates inside its error arm — was reported as a plain `nonzero`, i.e. as if it could not
+    tell two error codes apart. Here the gate forks the walk and both arms are read.
+
+    Buckets are the legacy ones plus **`gate-open`**: the site does gate on the value, and at least
+    one reachable arm left this scan's reach (returned it, spilled it, jumped indirectly, or ran the
+    block budget out). `nonzero` is correspondingly STRONGER than in the legacy walk — it now means
+    the value is gated and then provably dead on every reachable path, so that site cannot tell one
+    non-zero answer from another. `gate-open` and `forward` are the not-cleared buckets.
+    """
+    outcomes, gate_ev, other_ev = set(), None, None
+    work = [(start, frozenset({"a"}), False)]
+    seen, blocks = set(), 0
+    while work:
+        key = work.pop()
+        if key in seen:
+            continue
+        seen.add(key)
+        va, live, spilled = key
+        blocks += 1
+        if blocks > limit:
+            outcomes.add("forward")                      # budget: unresolved, not cleared
+            break
+        insns, fall = fetch(va)
+        if not insns:
+            outcomes.add("forward")                      # unmapped, or nothing decodable: not cleared
+            continue
+        bucket, ev, state = _walk_block(insns, const, set(live), spilled, True, fall)
+        gate_ev = gate_ev or state["gated"]
+        if bucket == "edges":
+            nlive, nspill = frozenset(state["live"]), state["spilled"]
+            work += [(tgt, nlive, nspill) for tgt in state["edges"]]
+            continue
+        if bucket == "const":
+            return "const", ev                           # one positive instance settles the site
+        outcomes.add(bucket)
+        if bucket in ("other-cmp", "alu-gate", "undecodable"):
+            other_ev = other_ev or ev
+    if gate_ev:
+        if "forward" in outcomes:
+            outcomes = (outcomes - {"forward"}) | {"gate-open"}
+        outcomes = (outcomes - {"ignored"}) | {"nonzero"}
+    verdict = max(outcomes or {"ignored"}, key=_SITE_RANK.index)
+    return verdict, (other_ev or gate_ev or (start, "", ""))
 
 
 ENDBR64 = b"\xf3\x0f\x1e\xfa"
@@ -491,21 +672,25 @@ def call_sites(img, xref, sym_index):
     return sorted(set(sites))
 
 
-def classify_sites(img, sites, const, window):
+def classify_sites(img, sites, const, window, follow=True):
     """(census, details) for a set of call sites. `details` rows are (site, bucket, ev, arg0)."""
     census, details = {}, []
+    fetch = block_fetcher(img, window)
     for site, kind in sites:
         after = site + (6 if kind == "call*" else 5)
         fo = img.foff(after)
         if fo is None:
             continue
-        bucket, ev = classify_window(disasm(img.raw[fo:fo + window], after), const)
+        if follow:
+            bucket, ev = classify_site_following(fetch, after, const)
+        else:
+            bucket, ev = classify_window(disasm(img.raw[fo:fo + window], after), const)
         census[bucket] = census.get(bucket, 0) + 1
         details.append((site, bucket, ev, arg0_before(img.raw, img.foff(site))))
     return census, details
 
 
-def scan_module(path, nid, const, window, verbose=False):
+def scan_module(path, nid, const, window, verbose=False, follow=True):
     """Returns (status, detail) where status is 'no-import', 'no-slot', or a bucket census dict."""
     try:
         img = Image(flatten(path))
@@ -516,7 +701,7 @@ def scan_module(path, nid, const, window, verbose=False):
         return "no-import", {}
     if not img.jump_slots(idx):
         return "import-no-slot", {}
-    census, details = classify_sites(img, call_sites(img, scan_code(img), idx), const, window)
+    census, details = classify_sites(img, call_sites(img, scan_code(img), idx), const, window, follow)
     if verbose:
         for site, bucket, ev, arg in details:
             argtxt = ("id=%#x%s" % (arg[0], "" if arg[1] else "?")) if arg else "id=?"
@@ -524,7 +709,9 @@ def scan_module(path, nid, const, window, verbose=False):
     return "ok", census
 
 
-GATED = ("const", "nonzero", "other-cmp", "alu-gate")
+GATED = ("const", "nonzero", "other-cmp", "alu-gate", "gate-open")
+# Buckets that say "this site was not resolved", as opposed to "resolved, and it does not care".
+UNRESOLVED = ("gate-open", "forward", "undecodable")
 
 
 def load_nid_names(libs_dir):
@@ -556,7 +743,7 @@ def load_nid_names(libs_dir):
     return names
 
 
-def sweep_module(path, const, window, names, min_gated, verbose):
+def sweep_module(path, const, window, names, min_gated, verbose, follow=True):
     """Classify EVERY imported NID of one module. Prints a row per import that has call sites."""
     img = Image(flatten(path))
     if img.dynsym() is None:
@@ -570,7 +757,7 @@ def sweep_module(path, const, window, names, min_gated, verbose):
         sites = call_sites(img, xref, idx)
         if not sites:
             continue                                         # imported, never called: no gate here
-        census, details = classify_sites(img, sites, const, window)
+        census, details = classify_sites(img, sites, const, window, follow)
         gated = sum(census.get(b, 0) for b in GATED)
         rows.append((gated, len(sites), nid, census, details))
     rows.sort(key=lambda r: (-r[0], -r[1], r[2]))
@@ -596,24 +783,30 @@ def sweep_summary(label, rows, shown, min_gated):
     """The trailing `#` block: what was hidden, and why the table is not a clean partition.
 
     A row that is not gated is NOT automatically a row that cannot matter. `forward` means the
-    result left the window still live and needs a look by hand, and `undecodable` is a void sample.
-    Reporting only "N called, M shown" invites exactly the wrong reading — that everything below the
-    cut is cleared — which is the expensive direction in a document whose whole purpose is to stop
-    the next reader re-deriving a dead answer. So state the three-way split explicitly, and print
-    the site-level bucket totals so the undecodable share is impossible to miss.
+    result left the scan's reach still live and needs a look by hand, `gate-open` means the same of
+    an arm, and `undecodable` is a void sample. Reporting only "N called, M shown" invites exactly
+    the wrong reading — that everything below the cut is cleared — which is the expensive direction
+    in a document whose whole purpose is to stop the next reader re-deriving a dead answer. So state
+    the split explicitly, count the rows that are not resolved SEPARATELY from the ones that are not
+    gated (a `gate-open` row is both gated and unresolved), and print the site-level bucket totals.
     """
     gated_rows = sum(1 for g, _n, _i, _c, _d in rows if g)
     ignored_only = sum(1 for g, _n, _i, c, _d in rows if not g and set(c) <= {"ignored"})
     unresolved = len(rows) - gated_rows - ignored_only
+    open_rows = sum(1 for _g, _n, _i, c, _d in rows if set(c) & set(UNRESOLVED))
     totals = {}
     for _g, _n, _i, c, _d in rows:
         for k, v in c.items():
             totals[k] = totals.get(k, 0) + v
     print("# %s: %d imported NIDs are called; %d shown at --min-gated=%d"
           % (label, len(rows), shown, min_gated))
-    print("#   %d gated, %d ignored-only (cannot matter), %d unresolved "
-          "(>=1 forward/undecodable window — NOT cleared, read by hand)"
-          % (gated_rows, ignored_only, unresolved))
+    print("#   %d gated, %d ignored-only (cannot matter), %d neither "
+          "(no gate, and >=1 site not cleared)" % (gated_rows, ignored_only, unresolved))
+    # A `gate-open` row IS gated — it branches on the result — so it is counted above and is still
+    # not cleared. Reporting only the "neither" column would hide exactly those rows, which is the
+    # expensive direction: they read as answered.
+    print("#   %d rows carry >=1 site the scan could not resolve (%s) — read those by hand"
+          % (open_rows, "/".join(UNRESOLVED)))
     print("#   site buckets: %s" % " ".join("%s=%d" % kv for kv in sorted(totals.items())))
 
 
@@ -629,6 +822,10 @@ def main():
                     help="with --all-nids, hide imports with fewer than N gated call sites (default 1)")
     ap.add_argument("--const", default="0x805a1001")
     ap.add_argument("--window", type=lambda s: int(s, 0), default=48)
+    ap.add_argument("--no-follow-arms", action="store_true",
+                    help="legacy single-window walk: stop at the first branch and never read the "
+                         "error arm. UNDER-REPORTS const-sensitivity (see this file's header); it "
+                         "exists to reproduce numbers published before arm following")
     ap.add_argument("-v", "--verbose", action="store_true")
     a = ap.parse_args()
     if bool(a.nid) == bool(a.all_nids):
@@ -645,12 +842,13 @@ def main():
         targets = [a.target]
 
     names = load_nid_names(a.names) if a.names else {}
+    follow = not a.no_follow_arms
 
     if a.all_nids:
         for t in sorted(targets):
             label = os.path.relpath(t, a.target) if os.path.isdir(a.target) else t
             try:
-                rows, shown = sweep_module(t, const, a.window, names, a.min_gated, a.verbose)
+                rows, shown = sweep_module(t, const, a.window, names, a.min_gated, a.verbose, follow)
             except Exception as e:                           # noqa: BLE001 — report, keep going
                 # Loud and per module: a directory sweep must not lose one module's failure in the
                 # noise of the others', and this is where dynsym()'s deliberate raises surface.
@@ -661,7 +859,7 @@ def main():
 
     total = {}
     for t in sorted(targets):
-        status, census = scan_module(t, a.nid, const, a.window, a.verbose)
+        status, census = scan_module(t, a.nid, const, a.window, a.verbose, follow)
         if status == "no-import" and not a.verbose:
             continue
         label = os.path.relpath(t, a.target) if os.path.isdir(a.target) else t

--- a/prosper/tools/re/nid_gate_scan.py
+++ b/prosper/tools/re/nid_gate_scan.py
@@ -391,6 +391,12 @@ for _wide, _key in (("si", "si"), ("di", "di"), ("bp", "bp"), ("sp", "sp")):
 # survive one — but rbx/rbp/r12-r15 do.
 CALLER_SAVED = {"a", "c", "d", "si", "di", "r8", "r9", "r10", "r11"}
 
+# The SysV integer argument registers, in order. A tainted value sitting in one of these AT a call is
+# not dead — it is the callee's argument, and the compare may be one frame down. Clearing the site
+# there would be the same mistake as stopping at the first branch, one level out: `ignored` and
+# `nonzero` both mean "cannot be affected", and neither is established by a value being handed away.
+ARG_REGS = {"di", "si", "d", "c", "r8", "r9"}
+
 
 def canon(operand):
     """Canonical register name for an operand, or None if it is not a bare register."""
@@ -510,6 +516,10 @@ def _walk_block(insns, const, live, spilled, follow=False, fall_va=None):
                 return "forward", ev, st()                # indirect, or the window ran out
             return "edges", ev, st([tgt, nxt])
         if mn == "call":
+            if follow and live & ARG_REGS:
+                # Not applied in legacy mode: `--no-follow-arms` is a reproduction path, so it stays
+                # bug-for-bug identical to the walk whose numbers are quoted in the tree.
+                return "forward", ev, st()                # handed to the callee: not dead, not here
             live -= CALLER_SAVED
             if not live:
                 return ("forward" if spilled else "ignored"), ev, st()
@@ -805,7 +815,7 @@ def sweep_summary(label, rows, shown, min_gated):
     # A `gate-open` row IS gated — it branches on the result — so it is counted above and is still
     # not cleared. Reporting only the "neither" column would hide exactly those rows, which is the
     # expensive direction: they read as answered.
-    print("#   %d rows carry >=1 site the scan could not resolve (%s) — read those by hand"
+    print("#   %d rows carry >=1 site the scan could not resolve (%s) -- read those by hand"
           % (open_rows, "/".join(UNRESOLVED)))
     print("#   site buckets: %s" % " ".join("%s=%d" % kv for kv in sorted(totals.items())))
 

--- a/prosper/tools/re/test_nid_gate_scan.py
+++ b/prosper/tools/re/test_nid_gate_scan.py
@@ -105,6 +105,16 @@ def objdump_free_checks():
     check("t-alu-mask-is-a-gate", tbucket(("and", "eax,0x80000000")), "alu-gate")
     check("t-self-xor-is-ignored", tbucket(("xor", "eax,eax"), ("ret", "")), "ignored")
     check("t-call-clobbers", tbucket(("call", "0x2000"), ("ret", "")), "ignored")
+    #  …but a result MOVED INTO an argument register before the call is the callee's argument, not a
+    #  dead value. `ignored` there would claim "cannot be affected" about a value handed one frame
+    #  down — the same error as stopping at the first branch, one level out.
+    #  Follow mode only — the legacy walk stays bug-for-bug identical, because its whole remaining
+    #  job is reproducing numbers already quoted in the tree.
+    check("t-arg-register-at-a-call-is-not-dead",
+          twalk(("mov", "edi,eax"), ("xor", "eax,eax"), ("call", "0x2000"), ("ret", "")),
+          ("forward", [], False))
+    check("t-legacy-keeps-clearing-an-arg-register-at-a-call",
+          tbucket(("mov", "edi,eax"), ("xor", "eax,eax"), ("call", "0x2000"), ("ret", "")), "ignored")
     check("t-ret-forwards", tbucket(("ret", "")), "forward")
     check("t-callee-saved-survives-call",
           tbucket(("mov", "r14d,eax"), ("call", "0x2000"), ("test", "r14d,r14d")), "nonzero")

--- a/prosper/tools/re/test_nid_gate_scan.py
+++ b/prosper/tools/re/test_nid_gate_scan.py
@@ -13,6 +13,14 @@ for bugs an independent review found after the first table had already been publ
   * `and eax,mask; jne` used to land in `ignored`, i.e. in the one bucket whose whole meaning is
     "this site cannot be affected by the answer".
 
+The arm-following cases at the bottom are the same idea one level up. A walk that stops at the first
+branch reports a site that gates generically and const-compares *inside its error arm* as a plain
+`nonzero` — as insensitive — and re-running it at greater effort cannot change that, because the
+case is structurally inexpressible for that walk. So the positive instance is CONSTRUCTED BY HAND
+here, outside any corpus, and each one is paired with the LEGACY verdict on the very same bytes:
+`const` with arms followed, `nonzero` without. A control drawn from the same instrument as the null
+it validates can only ever test the discriminator.
+
 Run directly, or via ctest as `re_nid_gate_classifier`.
 """
 import os
@@ -39,6 +47,30 @@ def check(name, got, want):
 def bucket(asm_bytes, base=0x1000):
     """Classify a literal byte string as the window after the call. Needs GNU objdump."""
     return G.classify_window(G.disasm(asm_bytes, base), UNLOADED)[0]
+
+
+class FakeImg:
+    """The minimum `block_fetcher` and `stub_entry_points` need: a flat blob at a base VA."""
+
+    def __init__(self, base, blob):
+        self.base, self.raw = base, blob
+
+    def foff(self, va):
+        off = va - self.base
+        return off if 0 <= off < len(self.raw) else None
+
+
+def follow(asm_bytes, base=0x1000, window=48):
+    """Classify literal bytes as a call site WITH arms followed. Needs GNU objdump."""
+    fetch = G.block_fetcher(FakeImg(base, asm_bytes), window)
+    return G.classify_site_following(fetch, base, UNLOADED)[0]
+
+
+def twalk(*insns):
+    """One follow-mode block over pre-decoded instructions: (bucket, edges, saw_gate)."""
+    ins = [(0x1000 + i * 4, m, o) for i, (m, o) in enumerate(insns)]
+    bucket, _ev, st = G._walk_block(ins, UNLOADED, {"a"}, False, True, None)
+    return bucket, st["edges"], bool(st["gated"])
 
 
 def tbucket(*insns):
@@ -78,18 +110,35 @@ def objdump_free_checks():
           tbucket(("mov", "r14d,eax"), ("call", "0x2000"), ("test", "r14d,r14d")), "nonzero")
     check("t-undecodable", tbucket(("(bad)", "")), "undecodable")
 
+    # --- classify_window() must NOT follow anything: the legacy walk is the reproducibility path --
+    # `--no-follow-arms` exists so every number this tool published before arm following can be
+    # re-derived. If the legacy walk quietly gained the new behaviour, that guarantee is gone and
+    # nothing above would notice, because the follow-mode answers are the ones people now want.
+    check("legacy-stops-at-the-gate",
+          tbucket(("test", "eax,eax"), ("jne", "0x2000"), ("cmp", "eax,0x805a1001")), "nonzero")
+    check("legacy-stops-at-jmp",
+          tbucket(("jmp", "0x2000"), ("cmp", "eax,0x805a1001")), "forward")
+
+    # --- _walk_block(follow=True): the block reports its SUCCESSORS instead of stopping ----------
+    check("follow-gate-forks-into-both-arms",
+          twalk(("test", "eax,eax"), ("jne", "0x2000"), ("ret", "")), ("edges", [0x2000, 0x1008], True))
+    check("follow-cmp-zero-forks-too",
+          twalk(("cmp", "eax,0x0"), ("je", "0x2000"), ("ret", "")), ("edges", [0x2000, 0x1008], True))
+    check("follow-jmp-is-an-edge", twalk(("jmp", "0x2000")), ("edges", [0x2000], False))
+    check("follow-indirect-jmp-is-unresolved", twalk(("jmp", "rax")), ("forward", [], False))
+    #  A branch whose fall-through fell off the end of the window with no `fall_va` to continue from
+    #  is UNRESOLVED, never a silent "the arm held nothing".
+    check("follow-truncated-branch-is-unresolved",
+          twalk(("test", "eax,eax"), ("jne", "0x2000")), ("forward", [], True))
+    #  A conditional branch on flags this walk did not set still forks: the value is live in both
+    #  successors, and exploring only the fall-through is how a const compare hides in the taken arm.
+    check("follow-forks-on-an-unrelated-branch",
+          twalk(("cmp", "ecx,0x4"), ("jne", "0x2000"), ("ret", "")), ("edges", [0x2000, 0x1008], False))
+
     # --- stub_entry_points(): the CET prologue case ----------------------------------------------
     # No dump in the local corpus uses a CET-enabled stub, so the re-sweep that left every other
     # number unchanged does NOT constrain this path — it only ever adds call sites, and it never
     # fired. These assertions are the only thing testing it.
-    class FakeImg:
-        def __init__(self, base, blob):
-            self.base, self.raw = base, blob
-
-        def foff(self, va):
-            off = va - self.base
-            return off if 0 <= off < len(self.raw) else None
-
     #  stub at 0x1000: f3 0f 1e fa (endbr64) then ff 25 ... at 0x1004
     cet = FakeImg(0x1000, b"\xf3\x0f\x1e\xfa" + b"\xff\x25\x00\x00\x00\x00")
     check("stub-entry-cet-adds-prologue", sorted(G.stub_entry_points(cet, 0x1004)), [0x1000, 0x1004])
@@ -196,6 +245,71 @@ def objdump_checks():
 
     # --- a window that cannot be decoded is VOID, not negative ------------------------------------
     check("undecodable-is-its-own-bucket", bucket(b"\x06\x07\x0e\x16"), "undecodable")
+
+    # --- THE POSITIVE INSTANCE, built by hand --------------------------------------------------
+    # A site that gates generically and const-compares INSIDE ITS ERROR ARM. This is the class the
+    # legacy walk cannot express at all, so it is written out here rather than sampled from a dump:
+    # a control drawn from the instrument under test can only confirm that the instrument runs.
+    # Each case asserts BOTH verdicts on the same bytes, which is what makes it a discriminator.
+    #  1000: 85 c0             test eax,eax
+    #  1002: 74 05             je   0x1009          <- success arm
+    #  1004: 3d 01 10 5a 80    cmp  eax,0x805a1001  <- ERROR ARM, past the branch
+    #  1009: 31 c0             xor  eax,eax
+    #  100b: c3                ret
+    ARM_CONST = b"\x85\xc0\x74\x05\x3d\x01\x10\x5a\x80\x31\xc0\xc3"
+    check("arm-const-found-when-followed", follow(ARM_CONST), "const")
+    check("arm-const-INVISIBLE-to-the-legacy-walk", bucket(ARM_CONST), "nonzero")
+    #  the same shape comparing a DIFFERENT immediate must not answer `const` — otherwise the case
+    #  above would pass for any compare at all, and prove nothing about the value being searched for
+    ARM_OTHER = b"\x85\xc0\x74\x05\x3d\x05\x00\x00\x00\x31\xc0\xc3"
+    check("arm-other-immediate-is-not-const", follow(ARM_OTHER), "other-cmp")
+    #  a `jmp` into a shared tail that const-compares: the 3 hand-read windows of #1640's census had
+    #  exactly this shape (`call <import>; jmp <back>`), and the legacy walk stopped at the jmp
+    #  1000: eb 02             jmp 0x1004
+    #  1002: 90 90             (padding)
+    #  1004: 3d 01 10 5a 80    cmp eax,0x805a1001
+    TAIL_CONST = b"\xeb\x02\x90\x90\x3d\x01\x10\x5a\x80"
+    check("jmp-tail-const-found-when-followed", follow(TAIL_CONST), "const")
+    check("jmp-tail-const-INVISIBLE-to-the-legacy-walk", bucket(TAIL_CONST), "forward")
+
+    # --- and the negatives, so `nonzero` is not simply what the follow walk always says ----------
+    #  both arms drop the value -> gated and provably insensitive to WHICH non-zero answer
+    #  1000: 85 c0  test eax,eax / 1002: 74 03  je 0x1007 / 1004: 31 c0 c3 / 1007: 31 c0 c3
+    check("both-arms-dead-is-nonzero", follow(b"\x85\xc0\x74\x03\x31\xc0\xc3\x31\xc0\xc3"), "nonzero")
+    #  one arm hands the value back to the caller: NOT cleared, and it must not read as `nonzero`
+    #  1000: 85 c0  test eax,eax / 1002: 74 01  je 0x1005 / 1004: c3 (eax live) / 1005: 31 c0 c3
+    check("an-arm-that-returns-the-value-is-gate-open",
+          follow(b"\x85\xc0\x74\x01\xc3\x31\xc0\xc3"), "gate-open")
+    #  an indirect tail-jump cannot be followed at all
+    check("indirect-jmp-site-is-forward", follow(b"\xff\xe0"), "forward")
+    #  a backward branch must not walk forever — the visited set is the only thing stopping it
+    #  1000: 85 c0  test eax,eax / 1002: 75 fc  jne 0x1000 / 1004: c3
+    check("self-loop-terminates", follow(b"\x85\xc0\x75\xfc\xc3"), "gate-open")
+
+    # --- disasm(): objdump's wrapped byte column is not an instruction ---------------------------
+    # objdump breaks the raw-byte listing after seven bytes and the continuation line carries the
+    # same `<addr>:` shape, so an 11-byte instruction used to yield a phantom second "instruction"
+    # at a VA INSIDE it. Inert as a mnemonic, poisonous as an address: the walk continues a block
+    # from an instruction VA, and continuing from mid-instruction decodes garbage.
+    #  c7 84 87 e0 06 00 00 03 00 00 00   mov DWORD PTR [rdi+rax*4+0x6e0],0x3   (11 bytes)
+    #  90                                 nop
+    long_insn = b"\xc7\x84\x87\xe0\x06\x00\x00\x03\x00\x00\x00\x90"
+    check("disasm-no-phantom-from-a-wrapped-byte-column",
+          [va for va, _m, _o in G.disasm(long_insn, 0x1000)], [0x1000, 0x100B])
+
+    # --- block_fetcher(): every returned instruction is whole, and next_va is exact ---------------
+    # Cutting the blob at the window instead would hand the walk a truncated final instruction,
+    # which decodes as `(bad)`/`.byte` — a truncation artifact reported as the `undecodable` bucket,
+    # i.e. as a finding. Over-reading one instruction length and discarding what starts past the
+    # boundary removes the whole class and yields the continuation VA for free.
+    #  1000: 90 90 90                      nop nop nop
+    #  1003: 3d 01 10 5a 80                cmp eax,0x805a1001   (straddles a 4-byte window)
+    #  1008: 90                            nop
+    fetched, nxt = G.block_fetcher(FakeImg(0x1000, b"\x90\x90\x90\x3d\x01\x10\x5a\x80\x90"), 4)(0x1000)
+    check("fetch-keeps-only-whole-instructions",
+          [(va, mn) for va, mn, _o in fetched],
+          [(0x1000, "nop"), (0x1001, "nop"), (0x1002, "nop"), (0x1003, "cmp")])
+    check("fetch-next-va-is-the-first-instruction-past-the-window", nxt, 0x1008)
 
     # --- disasm() itself: addresses, mnemonics, and the output regex ------------------------------
     # Asserting only "it did not raise" is tautological once the capability probe has passed — the


### PR DESCRIPTION
Refs #1640
Refs #2168

**Evidence work, plus the instrument that earns it.** No runtime value changes. The product is a
comment, a test reclassification, and the `nid_gate_scan` extension without which neither claim would
be established — so "is it true?" *is* the review question here.

This PR was rejected at `8a34fb1` on two blocking findings. Both are addressed; the sections below
are the current state, and the reply comment carries the point-by-point diff against that review.

## Finding 1 → the scan reads the error arm now, and #1640's bound is re-derived from that

`nid_gate_scan.py` used to stop at the first branch, so a site that gated generically and
const-compared the errno **inside its error arm** was bucketed `nonzero` — indistinguishable from a
site that cannot care. Its own docstring documented that and prescribed the fix. The first version of
this PR quoted the bound anyway ("provably insensitive", "no amount of re-running this scan will
settle it") when 20 of the 49 sites sat in that blind spot.

### What landed in the tool

`classify_site_following` forks the walk at **every** branch the value survives and explores both
successors, bounded by a visited set (loops) and a 192-block budget that reports **unresolved**, never
cleared, when exhausted. Two buckets change meaning as a result:

- **`nonzero`** now means gated *and* provably dead on every reachable path — the only bucket that
  says a site cannot tell one non-zero answer from another.
- **`gate-open`** is new: gated, but an arm left the scan's reach (returned, spilled, indirect,
  unmapped, budget). Not cleared.

`--no-follow-arms` restores the legacy walk and reproduces the previous census byte for byte.

Three further instrument defects surfaced and are fixed:

1. objdump wraps its raw-byte column after seven bytes and the continuation line carries the same
   `<addr>:` shape, so an 11-byte instruction yielded a phantom instruction at a VA *inside* it —
   inert as a mnemonic, poisonous as an address once a walk continues a block from one.
   `--no-show-raw-insn` removes the wrap.
2. Cutting a decode blob at a fixed size half-decodes its final instruction as `(bad)`/`.byte` — a
   truncation artifact reported as `undecodable`, the bucket that means "void sample, go read it by
   hand". `block_fetcher` over-reads one maximum instruction length and drops whatever starts past the
   boundary, which also yields the exact continuation VA. On `PPSA05325`'s eboot, `--all-nids`
   `undecodable` falls **2,699 → 8** windows out of the same 24,308.
3. A result **moved into a SysV argument register before a `call`** was reaching `ignored` — the
   bucket that means "cannot be affected" — because the `call` clobbers the caller-saved set and
   emptied the taint. It is not dead there; it is the callee's argument, and the compare may be one
   frame down. That is the same error as stopping at the first branch, one level out. Follow mode now
   reports `forward` for it (so the site lands in `gate-open`); legacy stays bug-for-bug identical,
   because its only remaining job is reproducing numbers already quoted in the tree, and both halves
   are asserted so neither can drift.

### The census, re-derived — all 44 dumps, 49 sites

```
python3 tools/re/nid_gate_scan.py <DUMP_ROOT> --nid 12wOHk8ywb0 --const 0x80020010 -v
```

| bucket | legacy walk | arms followed |
| --- | --- | --- |
| `ignored` | 29 | 29 |
| `nonzero` | 17 | **18** |
| `forward` | 3 | 0 |
| `gate-open` | — | 1 |
| `undecodable` | 0 | 1 |
| `const` / `other-cmp` | **0** | **0** |

Four titles import `sceKernelPollSema` (`PPSA02801`, `PPSA04263`, `PPSA08576`, `PPSA13579`), agreeing
with `nid_census --registered --names`. **47 of 49 sites are cleared by the tool; the other two were
read by hand** and both are insensitive:

- `PPSA04263+0x2b1e081` `gate-open` — its **error arm** never reads `eax` (`call 0x33911f0` at
  `+0x2b1e09b` clobbers it). The site is unresolved only because the **success** arm spills `eax` at
  `+0x2b1e0e4`, where the value is provably zero.
- `PPSA04263+0x310cd21` `undecodable` — both consumers reduce the result to one bit (`sete sil` at
  `+0x310cd30`, `test ebx,ebx; jne` at `+0x310cd48`) and no decodable path reaches a constant compare.
  The bucket comes from one path running into inter-function NOP padding (#2653).

### The positive control, from outside the null's instrument

The old PollEventFlag control validated the `const` bucket while the null rested on `nonzero` — same
instrument, so it tested the discriminator. The new one is the class the old walk **could not
express**, from a different NID, a different title, and someone else's hand-read:

- `PPSA08804` const-compares `sceSaveDataTransferringMountPs4` against `0x809F000F` inside an error
  arm at `+0x4e41a32` (review of #2208, recorded in `SONIC_FRONTIERS_STATUS.md`). Same bytes:
  `nonzero` with `--no-follow-arms`, **`const`** without.
- It **discriminates**: `PPSA07809`'s site answers `const` for `0x809F000F` and `other-cmp` for
  `0x809F0003`.
- It does **not** manufacture positives: Sonic Frontiers' five sites stay `nonzero=5` under both,
  matching the independently recorded "gates on the sign alone".
- The instance is also written out as literal bytes in `test_nid_gate_scan.py`, each paired with the
  legacy verdict on the same bytes, so the discriminator is a standing assertion.

### What the comment now says it does NOT establish

It bounds the **corpus**, not Sony's libkernel. Site discovery follows one stub level and one call
deep, so 49 is a lower bound. The walk is intra-module, so a value handed to a caller is `gate-open`
rather than cleared. The value stays `0x80020023` at `CONFIDENCE: LOW`.

### Records re-measured, because they came from the walk this PR changed

- **`hle_kernel_time.cpp`** (`sceSysmoduleIsLoaded`), same 445 sites across the same 66 modules:
  `const=237 / nonzero=208` legacy versus **`const=307`** `/ nonzero=78 / gate-open=47 /
  undecodable=13` with arms read. **70 more sites name `0x805A1001`** than that paragraph could see —
  it strengthens the existing conclusion.
- **`GRIS_SONIC_COBRA_BRINGUP.md`** — its "11.1% of all windows are undecodable" was the truncation
  artifact. Re-measured block added; `ignored`-only rows 157 -> 192, and the honest hand-read residue
  is 241 rows, because a `gate-open` row is gated *and* unresolved. The sweep summary now prints the
  not-resolved count separately from the not-gated one.
- **`SONIC_FRONTIERS_STATUS.md`** — the sentence saying the scan cannot see PPSA08804's compare is no
  longer true; corrected, with `--no-follow-arms` named for the older reading.
- Two records stale the same way are **filed rather than edited**, to keep this bounded: #2653 (a
  multi-byte NOP classified `undecodable`) and #2654 (`test_false_success_nids`' census parenthetical,
  whose numbers no longer reproduce even in legacy mode).

## Finding 2 → the condvar sentence was wrong, and it inverted the rule the file polices

`test_pthread_error_encoding.cpp` said both busy-destroy bodies return an encoded EBUSY "in place
because neither body has a POSIX spelling registered on it". True of the barrier; false of the condvar
on both halves. Verified against the source: `k_cond_destroy` returns the **bare** FreeBSD errno
(`hle_kernel.cpp:1033-1034`) *because* `pthread_cond_destroy` is registered onto the same body
(`:4810`), and the alias at `:1049` encodes it; no `pthread_barrier_destroy` registration exists
anywhere; `test_cond_destroy_busy.cpp:105` asserts the bare `16`.

This matters beyond wording — #2182's axis is "a body with a POSIX spelling must **not** encode in
place", so a future author trusting that sentence and making `k_cond_destroy` encode reproduces
#1984's shape. The comment now states the contrast with a `file:line` per route, and the knock-on
"neither arm discriminates an added alias" is reworded as a property of the arm (it cannot see an
alias in either direction, because `sce_pthread_rc(0)` is 0) rather than a claim about which entry
points have one.

## Finding 2's other half — the #2168 split itself (unchanged, and reviewed clean)

`kInfallible` is documented as *"entry points whose body returns 0 on every path"* and still listed
`scePthreadCondDestroy` and `scePthreadBarrierDestroy` after #2359 and #2379 made both refuse a busy
object. **The arm kept passing throughout both landings**, because a null slot never reaches the busy
check — so the assertion stayed green while the sentence justifying it went false. Split into
`kFallibleButNullSucceeds`, which pins the same observable half under an honest label and names
`test_cond_destroy_busy` / `test_barrier_destroy_busy` as where the busy path is actually covered.

Mutation arm, verbatim (barrier busy check reverted to pre-#2379 unconditional success):

```
===== MUTATED: test_barrier_destroy_busy =====
FAIL: scePthreadBarrierDestroy with a thread parked returns ENCODED EBUSY (0x80020010)
FAIL: the waiter did not wake within 5 s -- the barrier was destroyed out from
      under a parked thread, so arriving reached nothing (#2168 regressed)
== FAIL ==  exit=1

===== MUTATED: test_pthread_error_encoding =====
[ok]   scePthreadCondDestroy      -> 0 for a null slot (fallible, but not here)
[ok]   scePthreadBarrierDestroy   -> 0 for a null slot (fallible, but not here)
encoding exit=0
```

Both halves at once: the bodies really are fallible today, **and** no arm in the encoding sweep can
see that contract in either direction — which is exactly how the stale label survived.

## Corrections applied after approval (comment-only, `dec9167f`)

Four factual errors the reviewer found at `db173e5f`, each re-derived from the bytes on this head
rather than accepted on the review's word:

1. **A stale citation.** `pthread_cond_destroy` is registered at `hle_kernel.cpp:4825` here, not
   `:4810` — correct when the reviewer wrote it against `8a34fb1`, aged out at the rebase, and
   re-checked by neither of us. `:4810` now lands on `R("pthread_self", ...)`. It is fixed by naming
   the **symbol** to grep for and recording *why* a bare line number cannot be trusted (#2665's
   class), because this is the comment whose whole job is stopping the #2182 mistake: a reader who
   opens the cited line, finds an unrelated registration and concludes the claim is unsupported
   arrives at exactly the wrong answer. The five other citations in that comment were re-checked on
   this head and hold.
2. **"inter-function NOP padding" was intra-function.** The 14-byte pad at `+0x310cc92` aligns
   `+0x310cca0`, the target of the `jne` at `+0x310cc73` in the same code stream.
3. **"provably zero" needed its mechanism named.** There is no zeroing instruction; the proof is
   **branch dominance** — the only route to the spill still carrying the poll result runs through
   the `je` at `+0x2b1e088`, and that `je` being taken *is* `eax == 0`. Now stated, along with the
   caveat that it is true of the tracked value and not of the stack slot.
4. **A false sentence left standing above its own correction.** `hle_kernel_time.cpp`'s "never
   mentions `0x805A1001`" is false for 70 sites by this PR's own re-measure eight lines below it.
   Qualified in place, with the false claim quoted rather than deleted so the paragraph stays a
   dated record of what was believed.

**And the 441 → 445 drift is no longer uninvestigated.** It is apparatus: `PPSA08804-app0` carries a
second eboot at `_DUPLEX_/Original eboot/eboot.bin` (a release-group leftover, and *not*
byte-identical to the shipped one — a different build). Measured, it contributes exactly **4 sites
and 1 module**: 445 − 4 = 441 and 66 − 1 = 65, reproducing the historical figures. Recorded in place,
because any sweep quoting a site total over the local dumps double-counts that title's eboot.

## Affected and deliberately unaffected

- **Affected at runtime:** nothing. `hle_kernel.cpp` and `hle_kernel_time.cpp` change comments only;
  the test change is a reclassification asserting the same observable values under an honest label.
- **Affected as tooling:** `nid_gate_scan`'s default verdicts. `nonzero` is stricter and `gate-open`
  is new, so a census taken before this is not comparable to one taken after — `--no-follow-arms`
  exists for exactly that and is byte-for-byte identical to the old walk.
- **Deliberately unaffected:** `k_sema_poll`'s return value. Changing it on symmetry alone is the
  class of guess that already cost Sonic Origins once, and the census still shows the corpus cannot
  adjudicate it. `scePthreadMutexDestroy` stays in `kInfallible` and is genuinely still infallible
  (#719/#793).

## Risks

The tool change carries the real risk, and it is a resolving-power one rather than a safety one: the
walk can only ever find *more* compares than before, and everything it cannot finish lands in a bucket
that says so. The failure mode to review for is the opposite — a path wrongly reported `nonzero`
(cleared) when the value is still live. The taint model treats a spill as permanently unresolved, a
`ret` as unresolved, and an indirect branch as unresolved, so the "cleared" verdict requires the
register taint to die on every reachable path.

## Why `Refs` and not `Fixes`

- **#1640 is not settled.** The corpus still cannot answer which errno the real `sceKernelPollSema`
  reports; what changed is that the bound is now earned rather than asserted. The issue stays open
  until a title branching on the value, or a live `[sync2] SEMA.*` trace of one, turns up.
- **#2168's mutex third remains.** It needs owner tracking deliberately absent on POSIX hosts.

## Verification (local; author-run; exact head)

Linux, distrobox `ps5ys`, `prosper/build-linux`, dump configured at `PPSA24651-app0`:

```
cmake --build prosper/build-linux -j4              -> clean, exit 0
ctest --no-tests=error -j4                         -> 269/269 passed, exit 0 (153 s)
python3 prosper/tools/re/test_nid_gate_scan.py     -> ALL CHECKS PASSED, exit 0 (46 checks)
python3 prosper/tools/output/check_ascii_output.py -> all checks passed, exit 0  (#2614's gate)
python3 prosper/tools/docs/check_numbered_table.py --ordered --table-header Instrument \
    prosper/docs/GAME_COMPAT_ORCHESTRATION.md      -> clean
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py -> clean
git diff --check                                   -> clean
git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'   -> 0
```

269, not 265: the denominator is taken from `ctest -N` on the build under test rather than from any
remembered figure. Master gained `apr_equeue_completion` (#2638), moved `videoout_queries`
cross-platform (#2641) and landed #2614's own `ascii_output_literals` gate while this branch was
open; it is rebased onto `398cfa46`.

The ctest above is a run whose **start and finish I recorded**, after two earlier runs were killed:

```
START 2026-08-17T20:39:24Z  head=dec9167f  clean=0  registered=Total Tests: 269   (ctest -N)
END   2026-08-17T20:42:01Z  exit=0                   100% tests passed out of 269  (152.96 s)
```


**Two apparatus notes, because both produced results that looked like defects in this branch.**

1. *A red `diag_gate_selftest`.* The first ctest here put `TMPDIR` inside `prosper/build-linux/`, and
   the test failed reporting *"the scanner's own signatures are broken -- a tree scan would report a
   false CLEAN"*. It is the apparatus: `check_diag_gates.py`'s self-test writes its fixtures under
   `TMPDIR`, and `collect_files` filters on the **absolute** path containing `build-`, so every
   fixture is skipped and all four positive arms report `got=[]`. Reproduces on master's
   byte-identical copy; vanishes with `TMPDIR=/var/tmp`. Tracked as **#2658** (three lanes filed it
   independently within five minutes; my #2660 is closed into it). To be exact about the trigger,
   since I got this wrong when I filed: the charter's literal recipe, `TMPDIR=$PWD/build/tmpdir`, is
   **safe** — `build/tmpdir` has no hyphen. What trips it is putting the tmpdir inside the *primary*
   build directory the charter names elsewhere, `prosper/build-linux`, which is what I did.
2. *Two killed ctest runs.* A concurrent lane's broad `pkill -f "ctest --no-tests=error"` over-matched
   and terminated two of my runs — one at 16/266 with exit **143** (SIGTERM), one before it wrote a
   single line. Neither is quoted. The result below is from a run whose start and finish I recorded,
   with `TMPDIR` outside any `build-*` directory.

Mutation arms for the instrument fixes (reverted in a scratch copy, tests re-run):

```
revert --no-show-raw-insn      -> FAIL disasm-no-phantom-from-a-wrapped-byte-column
                                  got=[0x1000, 0x1007, 0x100b]  (0x1007 is inside the 11-byte insn)
revert block_fetcher over-read -> FAIL jmp-tail-const-found-when-followed        got=forward
                                  FAIL fetch-keeps-only-whole-instructions
                                  FAIL fetch-next-va-is-the-first-instruction-past-the-window
```

The arm-following and argument-register discriminators need no scratch mutation: each follow-mode
assertion is paired with the legacy verdict on the same bytes, and the pair differs
(`arm-const-found-when-followed` = `const` / `arm-const-INVISIBLE-to-the-legacy-walk` = `nonzero`;
`t-arg-register-at-a-call-is-not-dead` = `forward` /
`t-legacy-keeps-clearing-an-arg-register-at-a-call` = `ignored`).

Also re-verified after every tool change: the four-title #1640 census under `--no-follow-arms` diffs
**clean** against the pre-change baseline, site by site.

No snapshots were run: no renderer code is touched.
