### PR TITLE
fix(hle): APR completions on a shared equeue stop coalescing when the tag is not a counter

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -509,6 +509,12 @@ if(TARGET prosper_core)
   target_link_libraries(test_equeue_events PRIVATE prosper_core)
   add_test(NAME equeue_events COMMAND test_equeue_events)
 
+  # APR completion delivery on a shared equeue (#1673): the constant-tag (CRI) dialect must not be
+  # coalesced away, while the counter dialect (#208) and genuine level sources must still coalesce.
+  add_executable(test_apr_equeue_completion tests/test_apr_equeue_completion.cpp)
+  target_link_libraries(test_apr_equeue_completion PRIVATE prosper_core)
+  add_test(NAME apr_equeue_completion COMMAND test_apr_equeue_completion)
+
   # Variadic libc formatters (issue #122): real va_list capture so %f/XMM + stack + %s-past-4th
   # args format correctly (was a 3-integer-register forward). Cross-platform (host libc printf).
   add_executable(test_printf tests/test_printf.cpp)

--- a/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
+++ b/prosper/docs/UE4_APR_IOSTORE_BRINGUP.md
@@ -11,6 +11,32 @@ default since #825 and needs no switch; `PROSPER_NO_GUEST_FS=1` turns it off for
 
 ## Ruled out
 
+- **The shared-equeue completion coalescing is what blocks Tales of Graces f's opening movie —
+  false, and the tempting inference to avoid is "the bug is real, therefore it is THIS title's
+  blocker".** The drop itself *is* real and is fixed by
+  [#1673](https://github.com/mattias800/prosper/issues/1673): CRI ADX2 binds through the `id != 0`
+  branch with a literal zero tag, so its high-water mark never advances, every completion posted an
+  identical `(ident, filter, data=0)` event, and `eq_post`'s level coalescing collapsed N discrete
+  completions into one delivery. A by-hand instance in `tests/test_apr_equeue_completion.cpp`
+  reproduces it on the pre-fix code. **But it never fires on the measured PPSA19991 route.** Two
+  independent 150–180 s headless `boot_trace` runs with `PROSPER_EVLOG=1`: **0** coalesce-replace
+  events on the APR filter (`-24`), and the CRI equeue's waits and deliveries balance exactly
+  (480 ↔ 480 pre-fix, 452 ↔ 452 post-fix), each wait preceded by `WAIT.empty (infinite)` — i.e. the
+  CRI waiter is strictly serialized, one request in flight at a time, so two completions are never
+  pending together. The zero is trustworthy rather than an unarmed instrument: the *same* counter
+  reports 5 APR-filter replacements on PPSA17942 and ~170k on the vblank filter in the same runs.
+  So this is a latent hazard of the same character as #2560's binding-aliasing window — reachable,
+  worth closing, and **not** the movie blocker. Do not close the movie investigation on it.
+
+- **The fix perturbs the #208 / #180 UE4 listener channel — false, and the token census is the
+  proof.** The predicate is `cnt != 0`, and the two dialects partition across it with no overlap:
+  PPSA17942 posts **198** completions on this branch with **0** zero-counter tokens (rings 3/4, ids
+  29953/29954 — exactly the documented `0x74fe+ring` listener channel), so every one of them takes
+  the pre-existing `coalesce=true` path with bit-identical behaviour, including the 5 genuine
+  coalesces observed. PPSA19991 posts **32** with **0** nonzero tokens. A zero counter cannot be
+  legitimate in the counter dialect anyway: the guest's listener ctor seeds the per-ring counters at
+  `0x3e8` (1000) with last-processed `0x3e7`, and #180 already forbids posting `cnt < 1000` there.
+
 - **Two registered containers sharing a total byte size makes either normal APR read ambiguous —
   false after #78.** `sceAmprAprCommandBufferReadFile` resolves the real `a3` file id first; total
   byte size is only a legacy fallback when that id is unknown. A collision can therefore refuse

--- a/prosper/src/hle/hle_kernel_time.cpp
+++ b/prosper/src/hle/hle_kernel_time.cpp
@@ -899,6 +899,18 @@ namespace {
                     // the delivered event carries expirations-since-last-read (kqueue EVFILT_TIMER). Other
                     // filters keep replace-in-place (vblank/flip: the newest event wins).
                     int64_t data = (e.filter == -7 || e.filter == -15) ? q.data + e.data : e.data;
+                    // DIAGNOSTIC (PROSPER_EVLOG=1): a replace-in-place is a DELIVERY THAT WILL NOT HAPPEN.
+                    // For a level source (vblank/flip) that is the intended semantics and the line is
+                    // noise; for a COUNTED completion source it is a lost wakeup, and this is the only
+                    // place that can see it — by the time a consumer notices, the evidence is a thread
+                    // blocked in WaitEqueue with nothing to say why. Printed with ident/filter so the
+                    // APR completion filter (-24) is separable from the 60 Hz pump. Same gate as every
+                    // other producer here, so the count can never be an unarmed zero.
+                    if (evlog() && e.filter != -7 && e.filter != -15)
+                        fprintf(stderr, "[ev] coalesce-replace eq=0x%llx ident=%lld filter=%d "
+                                        "(dropped data=%lld, new data=%lld)\n",
+                                (unsigned long long)eq, (long long)e.ident, (int)e.filter,
+                                (long long)q.data, (long long)data);
                     q = e; q.data = data; s->cv.notify_all(); return;
                 }
             }
@@ -1267,6 +1279,10 @@ HLE(k_eq_getcount){
 // eq_post coalesces on (ident,filter), so ident carries the ring to keep concurrent rings'
 // completions from replacing each other; the per-ring coalescing to the HIGHEST counter is exactly
 // the kqueue "completed up to" semantics the listener's range walk implements.
+// SCOPE (#1673): everything in this block describes the COUNTER dialect, and the coalescing above
+// is conditional on it. A third consumer — CRI ADX2 — binds through the same id != 0 branch with a
+// constant ZERO tag and no range walk, so its completions are counted, not levelled, and are posted
+// individually. See the discrimination comment in prosper_eq_post_apr_token below.
 // CONFIDENCE: HIGH — ctor seeding, walk bounds, unconditional last:=cnt store, handler match/hash/
 // null-entry paths all from static disassembly; tag-echo event consumption live-verified (#180).
 namespace {
@@ -1290,10 +1306,10 @@ namespace {
         return (eq_identity << 6) | (ring & 0x3f);
     }
     void apr_post(uint64_t eq, uint64_t eq_identity, int64_t id,
-                  unsigned ring, uint64_t token) {   // no APR lock held
+                  unsigned ring, uint64_t token, bool coalesce) {   // no APR lock held
         SceKEvent e{}; e.ident = id + (int64_t)ring; e.filter = EVFILT_AMPR_MODELED;
         e.data = (int64_t)token; e.udata = 0;
-        eq_post(eq, e, /*coalesce=*/true, eq_identity);
+        eq_post(eq, e, coalesce, eq_identity);
     }
 }
 // Post an EXACT guest-chosen completion token (the H896Pt-yB4I binding tag) to the binding's own
@@ -1365,15 +1381,54 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
     }
     unsigned ring = (unsigned)(token >> 58) & 0x3f;
     uint64_t cnt = token & ((1ull << 58) - 1);
+    // A THIRD consumer shares this id != 0 branch, and level coalescing is wrong for it (#1673).
+    //
+    // The branch's coalescing is justified by the #208 listener's range walk: it consumes
+    // `last+1 ..= cnt` and stores `last := cnt`, so one knote carrying the HIGHEST counter retires
+    // every batch below it — genuine kqueue "completed up to" level semantics. That justification
+    // rests entirely on the tag BEING a counter.
+    //
+    // CRI ADX2 (cri_ware_unity.prx; Tales of Graces f Remastered PPSA19991, Sonic Origins
+    // PPSA05325) binds through the same NID with a tag that is a literal ZERO (`xor ecx,ecx` at
+    // cri+0x11b88f) and waits with sceKernelWaitEqueue(..., NULL timeout), retrying until
+    // sceKernelGetEventId matches its id (cri+0x11ba65). Its "counter" therefore never advances:
+    // the high-water mark stays 0, every completion posts an IDENTICAL (ident, filter, data=0)
+    // event, and level coalescing collapses N discrete completions into ONE delivery. A CRI waiter
+    // that does not receive one blocks forever — there is no timeout to rescue it and no range walk
+    // to make the lost event redundant.
+    //
+    // So coalesce only when the tag really is a counter, and use the counter itself as the test.
+    // cnt == 0 cannot be a legitimate value in the #208 dialect: the guest's listener ctor seeds the
+    // per-ring counters at 0x3e8 (1000) with last-processed 0x3e7, counters are dense upward from
+    // there, and #180 already forbids posting cnt < 1000 on that channel because the listener's
+    // unconditional `last := cnt` store would REGRESS the seed. Every token with a nonzero counter
+    // therefore takes the pre-existing path with bit-identical behaviour — this cannot perturb the
+    // UE4/IoStore channel, which is the one #180 and #208 constrain.
+    //
+    // Live shape (PPSA19991, headless boot_trace, PROSPER_AMPRLOG=1 PROSPER_EVLOG=1): one shared
+    // equeue, 471 bound submits — 437 on the id == 0 pointer dialect (already non-coalescing since
+    // #210) and 34 on this branch, every one of them `token=0x0 (ring=0)`, with 22 sharing id=1 and
+    // so sharing one coalescing key.
+    //
+    // This restores the rule the other two completion sources already follow: a completion is a
+    // discrete COUNT, never a level (EOP #234, APR pointer-tag #210). The counter dialect is the
+    // single genuine exception, because there the counter value itself carries "completed up to".
+    // CONFIDENCE: HIGH on the CRI half (guest disassembly for the zero tag and the ident-only
+    // waiter, plus the live token census above); HIGH that the counter dialect is untouched (the
+    // predicate is false for every token it can produce).
+    const bool counter_dialect = cnt != 0;
     const uint64_t hwm_key = apr_hwm_key(eq_identity, ring);
     {
         AprTokenState& state = apr_token_state();
         std::lock_guard lk(state.mx);
         if (cnt > state.tag_hwm[hwm_key]) state.tag_hwm[hwm_key] = cnt;
     }
-    if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u) -> eq=0x%llx scheduled\n",
-                         (unsigned long long)token, ring, (unsigned long long)eq);
-    std::thread([eq, eq_identity, id, ring, hwm_key] {
+    // `id` is on this line because it is the COALESCING KEY (apr_post posts ident = id + ring) and
+    // was previously unprintable: joining a completion back to its binding meant guessing from the
+    // interleaving of a multi-threaded log, which silently mis-attributes every post.
+    if (evlog()) fprintf(stderr, "[ev] AprTagComplete token=0x%llx (ring=%u id=%lld) -> eq=0x%llx scheduled\n",
+                         (unsigned long long)token, ring, (long long)id, (unsigned long long)eq);
+    std::thread([eq, eq_identity, id, ring, hwm_key, counter_dialect] {
         struct timespec ts{ 0, 2000000 };   // 2 ms
         nanosleep(&ts, nullptr);
         uint64_t hwm;
@@ -1382,7 +1437,7 @@ void prosper_eq_post_apr_token(uint64_t eq, uint64_t eq_identity,
             std::lock_guard lk(state.mx);
             hwm = state.tag_hwm[hwm_key];
         }
-        apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm);
+        apr_post(eq, eq_identity, id, ring, ((uint64_t)ring << 58) | hwm, counter_dialect);
     }).detach();
 }
 // Assign the next completion token for `ring` (0-based, 6 bits) — for UNBOUND submits only, whose

--- a/prosper/tests/test_apr_equeue_completion.cpp
+++ b/prosper/tests/test_apr_equeue_completion.cpp
@@ -1,0 +1,175 @@
+// test_apr_equeue_completion — APR completion events on a SHARED equeue must not be coalesced
+// away when the binding tag is not a counter (#1673).
+//
+// Two tag dialects share the H896Pt-yB4I binding call, discriminated by the binding's id:
+//
+//   id == 0  IoDispatcher direct channel (#210): tag is an opaque per-request POINTER. Already
+//            posted with coalesce=false — every completion is delivered. Not the subject here.
+//   id != 0  FAPREventQueueListener channel (#208): tag is (ring<<58)|counter, ctor-seeded dense
+//            from 1000. prosper posts the per-(eq,ring) HIGH-WATER MARK and coalesces, which is
+//            exactly the kqueue "completed up to" level the listener's last+1..cnt range walk
+//            implements. Correct for that consumer, and this test pins it.
+//
+// CRI ADX2 (cri_ware_unity.prx) uses the id != 0 branch with a tag that is a literal ZERO
+// (`xor ecx,ecx` at cri+0x11b88f) and a waiter that tests only the event IDENT
+// (sceKernelWaitEqueue + sceKernelGetEventId at cri+0x11ba65, NULL timeout, retry until match).
+// So its "counter" never advances, every completion posts an IDENTICAL (ident, filter) event, and
+// the level-style coalescing collapses N discrete completions into one delivery. The waiter that
+// does not get an event blocks forever on a NULL timeout.
+//
+// This is the same rule prosper already applies to the two other completion sources: a completion
+// is a discrete COUNT, never a level (EOP #234, APR pointer-tag #210). The counter dialect is the
+// one genuine exception, because there the counter itself carries "completed up to".
+//
+// Live shape this reproduces (PPSA19991 Tales of Graces f Remastered, headless boot_trace,
+// PROSPER_AMPRLOG=1 PROSPER_EVLOG=1): ONE equeue 0x318b75c0, 471 bound submits, of which 437 bind
+// id=0 (pointer dialect) and 34 bind a nonzero id — 22 of those on id=1 alone — every one of the
+// 34 posting `AprTagComplete token=0x0 (ring=0)`. Same equeue, same ident, constant zero tag.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+// SceKernelEvent (FreeBSD kevent layout, 0x20 bytes) — must match the backend's struct exactly.
+struct KEvent { int64_t ident; int16_t filter; uint16_t flags; uint32_t fflags; int64_t data; uint64_t udata; };
+static_assert(sizeof(KEvent) == 0x20, "SceKernelEvent must be 0x20 bytes");
+
+// The APR completion filter the backend posts (EVFILT_AMPR_MODELED). The guest never reads it;
+// asserting it here is what proves the counted entries are APR completions and not some other
+// source that merely happened to raise the queue depth.
+static constexpr int16_t kAprFilter = -24;
+
+// Drain whatever is queued so each scenario starts from an empty queue.
+static void drain(HleFn wait, uint64_t eq) {
+    std::vector<KEvent> ev(128);
+    int32_t out = -1; uint32_t cap = 1000;   // 1 ms
+    wait(eq, (uint64_t)(uintptr_t)ev.data(), ev.size(), (uint64_t)(uintptr_t)&out,
+         (uint64_t)(uintptr_t)&cap, 0);
+}
+
+int main() {
+    printf("== test_apr_equeue_completion ==\n");
+    register_builtin_hle();
+
+    auto create   = Hle::lookup(nid_hash("sceKernelCreateEqueue"));
+    auto addampr  = Hle::lookup(nid_hash("sceKernelAddAmprEvent"));
+    auto adduser  = Hle::lookup(nid_hash("sceKernelAddUserEvent"));
+    auto trigger  = Hle::lookup(nid_hash("sceKernelTriggerUserEvent"));
+    auto wait     = Hle::lookup(nid_hash("sceKernelWaitEqueue"));
+    auto getcount = Hle::lookup(nid_hash("sceKernelGetEventCount"));
+    auto bind     = Hle::lookup("H896Pt-yB4I");   // AprCbSetEventQueue (legacy binding NID)
+    auto submit   = Hle::lookup("eE4Szl8sil8");   // sceKernelAprSubmitCommandBuffer (plain, CRI's)
+    CHECK(create && addampr && adduser && trigger && wait && getcount && bind && submit,
+          "all APR + equeue entry points registered");
+    if (!(create && addampr && adduser && trigger && wait && getcount && bind && submit)) {
+        printf("== FAIL ==\n"); return 1;
+    }
+
+    uint64_t eq = 0;
+    create((uint64_t)(uintptr_t)&eq, 0, 0, 0, 0, 0);
+    CHECK(eq != 0, "CreateEqueue produced a handle");
+
+    // The posts are deferred ~2 ms on a detached thread (modeled DMA latency). Wait generously so a
+    // slow machine cannot turn "not yet delivered" into a false pass on the count assertions below.
+    const auto settle = [] { std::this_thread::sleep_for(std::chrono::milliseconds(120)); };
+
+    // --- Subject: the constant-tag (CRI) dialect on a SHARED equeue. -------------------------
+    // Two command buffers, ONE equeue, the SAME nonzero id, tag = 0 for both — exactly the live
+    // PPSA19991 shape. Two discrete completions, so two deliveries are owed.
+    {
+        const int64_t kId = 1;
+        const uint64_t cb1 = 0x205df94000ull, cb2 = 0x205df94028ull;   // live cb addresses
+        addampr(eq, (uint64_t)kId, 0, 0, 0, 0);
+        bind(cb1, eq, (uint64_t)kId, /*tag=*/0, 0, 0);
+        bind(cb2, eq, (uint64_t)kId, /*tag=*/0, 0, 0);
+        submit(cb1, /*ring_1based=*/1, 0, 0, 0, 0);
+        submit(cb2, /*ring_1based=*/1, 0, 0, 0, 0);
+        settle();
+
+        const uint64_t n = getcount(eq, 0, 0, 0, 0, 0);
+        CHECK(n == 2, "two constant-tag APR completions on a shared equeue are both retained");
+
+        // A bare count of 2 would also be satisfied by two events that never shared a coalescing
+        // key at all, which is the failure this assertion exists to exclude: read them back and
+        // require that both really are APR completions carrying the SAME (ident, filter). Only a
+        // non-coalescing post can leave two same-key entries queued.
+        std::vector<KEvent> ev(8);
+        int32_t out = -1; uint32_t cap = 50000;
+        wait(eq, (uint64_t)(uintptr_t)ev.data(), ev.size(), (uint64_t)(uintptr_t)&out,
+             (uint64_t)(uintptr_t)&cap, 0);
+        CHECK(out == 2, "WaitEqueue returns both completions");
+        const bool same_key = out == 2 &&
+                              ev[0].ident == kId && ev[1].ident == kId &&
+                              ev[0].filter == kAprFilter && ev[1].filter == kAprFilter;
+        CHECK(same_key, "both retained entries are APR completions sharing one (ident, filter)");
+        drain(wait, eq);
+    }
+
+    // --- Control 1: the counter dialect must STILL coalesce to the high-water mark. -----------
+    // This is the #208 listener's "completed up to" level. A fix that simply switched the whole
+    // id != 0 branch to coalesce=false would break this arm, which is why it is here: it bounds
+    // the change to the dialect that actually needs it.
+    {
+        const int64_t kId = 0x74fe;
+        const uint64_t cb3 = 0x205df95000ull, cb4 = 0x205df95028ull;
+        addampr(eq, (uint64_t)kId, 0, 0, 0, 0);
+        // Dense ascending per-ring counters, ring 0, ctor-seeded at 1000 — the real guest shape.
+        bind(cb3, eq, (uint64_t)kId, /*tag=*/1000, 0, 0);
+        submit(cb3, 1, 0, 0, 0, 0);
+        bind(cb4, eq, (uint64_t)kId, /*tag=*/1001, 0, 0);
+        submit(cb4, 1, 0, 0, 0, 0);
+        settle();
+
+        const uint64_t n = getcount(eq, 0, 0, 0, 0, 0);
+        CHECK(n == 1, "advancing counter-tag completions still coalesce to one level event");
+
+        std::vector<KEvent> ev(8);
+        int32_t out = -1; uint32_t cap = 50000;
+        wait(eq, (uint64_t)(uintptr_t)ev.data(), ev.size(), (uint64_t)(uintptr_t)&out,
+             (uint64_t)(uintptr_t)&cap, 0);
+        CHECK(out == 1 && ev[0].data == 1001,
+              "the coalesced level carries the HIGHEST counter (completed-up-to)");
+        drain(wait, eq);
+    }
+
+    // --- Control 2: a genuine LEVEL source must keep coalescing. ------------------------------
+    // Guards against an over-broad fix that disables coalescing in eq_post generally. The 60 Hz
+    // vblank pump depends on this; without it the queue fills with stale ticks.
+    {
+        const int64_t kUserId = 4242;
+        adduser(eq, (uint64_t)kUserId, 0xFEEDu, 0, 0, 0);
+        trigger(eq, (uint64_t)kUserId, 0, 0, 0, 0);
+        trigger(eq, (uint64_t)kUserId, 0, 0, 0, 0);
+        trigger(eq, (uint64_t)kUserId, 0, 0, 0, 0);
+        const uint64_t n = getcount(eq, 0, 0, 0, 0, 0);
+        CHECK(n == 1, "repeated level-source (user event) triggers still coalesce to one");
+        drain(wait, eq);
+    }
+
+    // --- Control 3: the pointer dialect (id == 0) is unchanged and still never coalesces. -----
+    {
+        const uint64_t cb5 = 0x205df96000ull, cb6 = 0x205df96028ull;
+        addampr(eq, 0, 0, 0, 0, 0);
+        bind(cb5, eq, /*id=*/0, /*tag=*/0xAAAA0000ull, 0, 0);
+        bind(cb6, eq, /*id=*/0, /*tag=*/0xBBBB0000ull, 0, 0);
+        submit(cb5, 1, 0, 0, 0, 0);
+        submit(cb6, 1, 0, 0, 0, 0);
+        settle();
+        const uint64_t n = getcount(eq, 0, 0, 0, 0, 0);
+        CHECK(n == 2, "pointer-dialect (id==0) completions remain individually delivered");
+        drain(wait, eq);
+    }
+
+    printf(fails ? "== FAIL ==\n" : "== PASS ==\n");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Refs #1673

Closes hazard 2 of the three the issue enumerates. Hazards 1 and 3 remain open — see
*Affected and deliberately unaffected*, which is why this is `Refs` and not `Fixes`.

## The failure scenario

`prosper_eq_post_apr_token`'s `id != 0` branch posted every completion with `coalesce=true`. That is
right for the one consumer it was written for — UE4's `FAPREventQueueListener` (#208) range-walks
`last+1 ..= cnt` and stores `last := cnt`, so a single knote carrying the highest counter retires
every batch below it, which is genuine kqueue "completed up to" level semantics.

**A third consumer shares the branch and is not levelled.** CRI ADX2 (`cri_ware_unity.prx`) binds
with a literal zero tag (`xor ecx,ecx` at `cri+0x11b88f`) and waits in `sceKernelWaitEqueue` with a
NULL timeout, retrying until `sceKernelGetEventId` matches its id (`cri+0x11ba65`). Its high-water
mark therefore never advances, every completion posts an identical `(ident, filter, data=0)` event,
and `eq_post`'s replace-in-place collapses N discrete completions into one delivery. A waiter that
misses one **blocks forever**: no timeout to rescue it, and no range walk to make the lost event
redundant.

## Behavioral contract and the approach

Coalesce only when the tag really is a counter (`cnt != 0`).

**The invariant that makes this safe:** a zero counter cannot be legitimate in the #208 dialect —
the guest's listener ctor seeds the per-ring counters at `0x3e8` with last-processed `0x3e7`, and
#180 already forbids posting `cnt < 1000` there, because the listener's unconditional `last := cnt`
store would regress the seed. So every token the UE4 channel can produce takes the pre-existing path
**bit-identically**.

This restores the rule the other two completion sources already follow: a completion is a discrete
count, never a level (EOP #234, APR pointer-tag #210). The counter dialect is the single genuine
exception, because there the counter value itself carries "completed up to".

## Evidence

Headless `boot_trace`, `PROSPER_EVLOG=1`, this box. The two dialects partition across the predicate
with **no overlap**:

| title | posts on the `id != 0` branch | zero-counter tokens |
| --- | --- | --- |
| `PPSA19991` (Tales of Graces f, CRI) | 32 | 32 (all) |
| `PPSA17942` (DOLL, UE4 counter) | 198 | 0 — rings 3/4, ids 29953/29954 = `0x74fe+ring` exactly |
| `PPSA05325` (Sonic Origins) | 0 in a 150 s window | — |

`CONFIDENCE: HIGH` on the CRI half (guest disassembly for the zero tag and the ident-only waiter,
plus the live token census) and HIGH that the counter dialect is untouched (the predicate is false
for every token it can produce).

## IMPORTANT — the drop is REAL but LATENT on the measured route

Recorded in `docs/UE4_APR_IOSTORE_BRINGUP.md` § *Ruled out* so it is not re-derived, and stated here
because the tempting inference to avoid is *"the bug is real, therefore it is THIS title's
blocker"*:

- Two independent 150–180 s runs show **0** coalesce-replace events on the APR filter (`-24`), and
  the CRI equeue's waits and deliveries balance exactly — **480/480 pre-fix, 452/452 post-fix** —
  with each wait preceded by `WAIT.empty (infinite)`. The waiter is strictly serialized, one request
  in flight, so two completions are never pending together.
- That zero is trustworthy rather than an unarmed instrument: the *same* counter reports 5
  APR-filter replacements on `PPSA17942` and ~170k on the vblank filter in the same runs.
- **So this is not the opening-movie blocker.** Same character as #2560's aliasing window:
  reachable, worth closing, not currently firing. Do not close the movie investigation on it.

## Two instruments this investigation needed and did not have

- `[ev] coalesce-replace ...` under `PROSPER_EVLOG` — a replace-in-place is a delivery that will not
  happen, and `eq_post` is the only place that can see it. Producer and printer share one gate, so
  its count cannot be an unarmed zero. Suppressed for the level filters (`-7`, `-15`), where
  replace-in-place is the intended semantics and the line would be noise.
- The binding `id` on the `AprTagComplete` line. It is the coalescing key and was unprintable, so
  joining a completion to its binding meant guessing from a multi-threaded log's interleaving —
  which mis-attributed every post when first tried.

## Tests

`prosper/tests/test_apr_equeue_completion.cpp` — the subject arm plus three controls (counter
dialect still coalesces to the highest counter; a genuine level source still coalesces; the `id==0`
pointer dialect still never coalesces). **The subject arm asserts both entries are APR completions
sharing one `(ident, filter)`**, so a bare count of 2 arising some other way cannot satisfy it.

Mutation arms: forcing the predicate to `true` fails exactly the 3 subject assertions with all
controls green; forcing it to `false` fails exactly the 2 counter-dialect control assertions.

## Affected and deliberately unaffected

- **Affected:** the zero-tag (CRI) dialect on the `id != 0` branch — its completions are now posted
  individually instead of replaced in place.
- **Deliberately unaffected:** the #208/#180 UE4 counter channel (predicate false for every token it
  can produce, and the 198-post census shows zero overlap); the `id == 0` pointer dialect, which has
  posted through a single ordered FIFO worker with `coalesce=false` since #210; and the level filters
  `-7`/`-15`, whose replace-in-place is correct and untouched.
- **Still open on #1673, which is why this is `Refs`:**
  - **Hazard 1** — the guest's own waiter dequeues and *discards* an event that is not its own
    (`cri+0x11ba7b`), so a completion can still be destroyed by another thread's wait. That is a
    guest-side property this change does not and cannot address.
  - **Hazard 3** — all 9 `id == 0` bindings share ident 0, so a posted event carries nothing that
    distinguishes which command buffer finished. Benign today only because reads complete in
    submission order; nothing enforces that, and this PR does not change it.

## Risks

- The predicate keys off the counter value rather than off the binding, so a hypothetical
  counter-dialect consumer that legitimately posts `cnt == 0` would lose level semantics. #180's
  existing floor (`cnt < 1000` is refused on that channel) is what rules this out, and it is a
  documented constraint rather than an enforced type.
- Posting individually instead of replacing raises the event count on the CRI equeue. The post-fix
  balance measurement (452/452, each wait preceded by `WAIT.empty`) is the evidence that the queue
  does not now overflow or reorder, but it is one route on one title.
- The new `[ev] coalesce-replace` line is gated behind `PROSPER_EVLOG` and shares its gate with the
  producer, so it cannot report an unarmed zero — but it is off by default and therefore unexercised
  in ordinary runs.

## Verification (local; author-run)

Linux, distrobox `ps5ys`:

```
cmake --build prosper/build-linux -j4    -> exit 0
ctest --no-tests=error -j4               -> 266/266 passed, exit 0
```

265 baseline on `origin/master` `ec2c0c22` (**265/265 passed, exit 0**) plus this PR's one new test.

**No CI evidence is quoted: CI has not run on this branch.** GitHub was degraded during this work,
which is why the PR is being opened after the fact.
