### PR TITLE
fix(screenshot): stop sampling once the guest is dead and the present layer has gone quiet

### DIFF
--- a/prosper/docs/R_TYPE_DELTA_STATUS.md
+++ b/prosper/docs/R_TYPE_DELTA_STATUS.md
@@ -541,6 +541,12 @@ Two apparatus notes for whoever picks that up:
   race**: on `20153833` with a warm page cache and `PROSPER_RENDER=1`, three attempts split two
   boots to one fault, so retry the launch to get either arm. A route that *intends* to sample this
   crash passes `--allow-guest-fault`.
+  A follow-up (#2584) also stops the run at the fault: the sampler used to keep going for the
+  remaining ~24 s and write 24 more byte-identical PNGs. Measured here on the same route, same
+  binary, `rip=0x410024055` on both arms — default **1.5 s / 1 PNG**, `--no-stop-after-guest-fault`
+  **25.3 s / 25 PNGs**, all 26 files one md5 (`c65064cd…`), identical `status=GUEST-FAULT` and
+  exit 1. So a fault-arm boot of this title now costs seconds rather than the whole route, and the
+  short PNG set says why: `stop=guest-fault` on the summary line, `stop_reason` in the manifest.
 - The flat post-movie colour is *not* the same value as the pre-fault black (`crc=064567f8`); the two
   are distinguishable by CRC, which makes them separable in a route manifest.
 

--- a/prosper/tests/test_capture_manifest.cpp
+++ b/prosper/tests/test_capture_manifest.cpp
@@ -308,7 +308,7 @@ int main() {
               early.find("\"requested\":25") != std::string::npos &&
               early.find("\"stop_reason\":\"guest-fault\"") != std::string::npos &&
               early.find("\"timed_out\":false") != std::string::npos,
-              "a short run states saved, requested and why it is short — and is not a timeout");
+              "a short run states saved, requested and why it is short, and is not a timeout");
 
         CHECK(std::string(sampling_stop_name(SamplingStop::RequestSatisfied)) ==
                   "request-satisfied" &&
@@ -325,6 +325,57 @@ int main() {
         CHECK(stopped_run.find("\"stop_after_guest_fault\":false") != std::string::npos &&
               stopped_run.find("\"guest_fault_settle_seconds\":2.500000") != std::string::npos,
               "the run header records the early-stop policy that produced the artifact set");
+
+        // #2639 review B1. The finding was not the wording: ONE assertion family moves in the
+        // PASSING direction under a shortened run, and the live A/B could not have seen it, because
+        // neither arm set a `--max-*` flag and both therefore had the assertion off. So construct
+        // the hazard by hand, outside whatever produced that null -- the same route, sampled to the
+        // end of the request versus cut at the stop.
+        {
+            std::vector<uint8_t> frame(16 * 8 * 4, 0x44);
+            const CaptureObservation shot{CaptureSource::Rendered, 7, 7, 70, 0, 16, 8,
+                                          0xdeadbeef, 1.0};
+            CaptureTracker full, cut;
+            full.observe(shot, frame);
+            cut.observe(shot, frame);   // the single sample an early-stopped run takes
+            // The 24 byte-identical samples a full-length run goes on to take, one per second, from
+            // a guest that died at 0.4 s: same source identity, same pixels, advancing clock.
+            for (int second = 2; second <= 25; ++second) {
+                CaptureObservation later = shot;
+                later.elapsed_seconds = static_cast<double>(second);
+                full.observe(later, frame);
+            }
+            CHECK(full.max_stale_seconds() == 24.0 && full.max_pixel_stale_seconds() == 24.0,
+                  "a full-length run measures the whole quiet interval after the guest dies");
+            CHECK(cut.max_stale_seconds() == 0.0 && cut.max_pixel_stale_seconds() == 0.0,
+                  "an early-stopped run measures NO staleness: the tail it drops IS the evidence "
+                  "the staleness bounds are computed from");
+            // Which is the flip in full: one bound, two verdicts, same route.
+            const double bound = 5.0;
+            CHECK(full.max_pixel_stale_seconds() > bound &&
+                  !(cut.max_pixel_stale_seconds() > bound),
+                  "--max-pixel-stale-seconds 5 FAILS the full run and PASSES the shortened one");
+        }
+
+        // So the bound disarms the stop rather than being documented around it.
+        CHECK(early_stop_armed(true, -1.0, -1.0),
+              "with no staleness bound armed, the early stop is armed");
+        CHECK(!early_stop_armed(true, 5.0, -1.0),
+              "--max-stale-seconds disarms the early stop");
+        CHECK(!early_stop_armed(true, -1.0, 5.0),
+              "--max-pixel-stale-seconds disarms the early stop");
+        CHECK(!early_stop_armed(true, 0.0, -1.0),
+              "a ZERO staleness bound counts as armed: the assertions guard on >= 0, so reading "
+              "zero as absent would silently drop the strictest bound of all");
+        CHECK(!early_stop_armed(false, -1.0, -1.0),
+              "--no-stop-after-guest-fault stays off whatever the assertions ask for");
+
+        // The struct's own default is the policy an archived manifest reports for a producer that
+        // does not set it, so it must be the tool's default and not the "stop on the first poll
+        // after the fault" that zero means (#2639 review N1).
+        CHECK(CaptureRunConfig{}.guest_fault_settle_seconds == 1.0,
+              "the settle-window default matches the tool's, so a direct producer gets the same "
+              "policy the command line gives");
     }
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tests/test_capture_manifest.cpp
+++ b/prosper/tests/test_capture_manifest.cpp
@@ -188,8 +188,10 @@ int main() {
     GuestOutcome running_guest;
     const RunVerdict failed_verdict = decide_run_verdict(true, running_guest, false);
     const std::string summary =
-        manifest_summary_json(3, 5, true, tracker, failed_verdict, running_guest, false);
+        manifest_summary_json(3, 5, SamplingStop::Timeout, tracker, failed_verdict, running_guest,
+                              false);
     CHECK(summary.find("\"timed_out\":true") != std::string::npos &&
+          summary.find("\"stop_reason\":\"timeout\"") != std::string::npos &&
           summary.find("\"pixel_distinct_frames\":2") != std::string::npos &&
           summary.find("\"max_pixel_stale_seconds\":2.500000") != std::string::npos &&
           summary.find("\"exit_code\":1") != std::string::npos,
@@ -234,7 +236,8 @@ int main() {
               "--allow-guest-fault does not disarm the capture assertions");
 
         const std::string fault_summary =
-            manifest_summary_json(25, 25, false, tracker, fault_verdict, faulted, false);
+            manifest_summary_json(25, 25, SamplingStop::RequestSatisfied, tracker, fault_verdict,
+                                  faulted, false);
         CHECK(fault_summary.find("\"guest_state\":\"faulted\"") != std::string::npos &&
               fault_summary.find("\"guest_kind\":2") != std::string::npos &&
               fault_summary.find("\"guest_fault_rip\":\"0x410024055\"") != std::string::npos &&
@@ -251,10 +254,77 @@ int main() {
               std::string(returned_verdict.status) == "ok" && returned_verdict.exit_code == 0,
               "a guest that exits normally is recorded but does not fail the run");
         const std::string returned_summary =
-            manifest_summary_json(5, 5, false, tracker, returned_verdict, returned, false);
+            manifest_summary_json(5, 5, SamplingStop::RequestSatisfied, tracker, returned_verdict,
+                                  returned, false);
         CHECK(returned_summary.find("\"guest_state\":\"returned\"") != std::string::npos &&
               returned_summary.find("\"guest_fault_rip\":null") != std::string::npos,
               "a normal guest exit is still visible in the manifest, with no fault address");
+    }
+
+    // #2584: the verdict was right and the LOOP was not — a run whose guest died at 0.4 s went on
+    // sampling for 24 more seconds and wrote 24 byte-identical PNGs. The stop condition is the unit
+    // under test here; the live arm (a routed PPSA26414 boot with and without
+    // --no-stop-after-guest-fault) is what proves the sampler is actually wired to it.
+    {
+        GuestOutcome running;
+        GuestOutcome returned;  returned.state = GuestRunState::Returned;
+        GuestOutcome faulted;   faulted.state = GuestRunState::Faulted; faulted.kind = 2;
+        const double settle = 1.0;
+
+        CHECK(should_stop_after_guest_fault(faulted, true, 2.0, 2.0, settle),
+              "a dead guest and a present layer that has gone quiet stops the sampler");
+
+        // The two arms that separate this from "stop as soon as the guest thread dies". A primary
+        // thread's death says nothing about other guest threads or a renderer backlog, so a stop
+        // keyed on the fault alone would silently truncate a run that is still producing frames —
+        // and the truncation would be indistinguishable from a satisfied request.
+        CHECK(!should_stop_after_guest_fault(faulted, true, 2.0, 0.2, settle),
+              "a present layer still publishing keeps the sampler running after the fault");
+        CHECK(!should_stop_after_guest_fault(faulted, true, 0.2, 2.0, settle),
+              "work already in flight gets the settle window before the sampler gives up");
+
+        // Neither non-terminal nor voluntary exit is a stop. `Returned` is the load-bearing one: a
+        // title exiting normally must keep tripping the saved/requested assertion (#2007), which
+        // stopping here would silence.
+        CHECK(!should_stop_after_guest_fault(running, true, 2.0, 2.0, settle),
+              "a live guest never stops the sampler, however quiet the present layer is");
+        CHECK(!should_stop_after_guest_fault(returned, true, 2.0, 2.0, settle),
+              "a guest that exits on its own is not a fault and does not stop the sampler");
+
+        CHECK(!should_stop_after_guest_fault(faulted, /*enabled=*/false, 30.0, 30.0, settle),
+              "--no-stop-after-guest-fault samples the full request even from a dead guest");
+
+        // Boundary: the windows are inclusive, so a zero settle stops on the first poll after the
+        // fault. Nothing in the tool sets that, but the comparison must not be strict.
+        CHECK(should_stop_after_guest_fault(faulted, true, 0.0, 0.0, 0.0),
+              "a zero settle window stops as soon as the fault is observed");
+
+        // The stop must be legible in the artifact, or a 3-PNG run reads as a crashed harness.
+        const RunVerdict fault_verdict = decide_run_verdict(false, faulted, false);
+        const std::string early =
+            manifest_summary_json(3, 25, SamplingStop::GuestFault, tracker, fault_verdict, faulted,
+                                  false);
+        CHECK(early.find("\"saved\":3") != std::string::npos &&
+              early.find("\"requested\":25") != std::string::npos &&
+              early.find("\"stop_reason\":\"guest-fault\"") != std::string::npos &&
+              early.find("\"timed_out\":false") != std::string::npos,
+              "a short run states saved, requested and why it is short — and is not a timeout");
+
+        CHECK(std::string(sampling_stop_name(SamplingStop::RequestSatisfied)) ==
+                  "request-satisfied" &&
+              std::string(sampling_stop_name(SamplingStop::Timeout)) == "timeout" &&
+              std::string(sampling_stop_name(SamplingStop::GuestFault)) == "guest-fault",
+              "every stop reason has its own name, so the three are distinguishable");
+
+        // The run header records the policy, so an archived manifest says whether the tail was
+        // dropped by this stop or was never produced.
+        CaptureRunConfig stopped_config;
+        stopped_config.stop_after_guest_fault = false;
+        stopped_config.guest_fault_settle_seconds = 2.5;
+        const std::string stopped_run = manifest_run_json(stopped_config);
+        CHECK(stopped_run.find("\"stop_after_guest_fault\":false") != std::string::npos &&
+              stopped_run.find("\"guest_fault_settle_seconds\":2.500000") != std::string::npos,
+              "the run header records the early-stop policy that produced the artifact set");
     }
 
     if (fails) { std::printf("== FAIL: %d ==\n", fails); return 1; }

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -269,6 +269,13 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   non-zero instead of `status=ok` (#2007), and the manifest summary carries `guest_state` and the
   fault address. Pass `--allow-guest-fault` only when the route deliberately samples a crashing
   title; it yields `status=GUEST-FAULT-ALLOWED`, never `ok`.
+  Sampling also **stops** once the guest is dead *and* the present layer has published nothing for
+  `--guest-fault-settle-seconds` (1 s), so the run no longer spends its remaining `--seconds` /
+  `--timeout` re-photographing one frame (#2584: 24 of 25 PNGs were byte-identical). Every sample
+  already taken is kept and the verdict is unchanged; the summary reads `saved/requested` with
+  `stop=guest-fault` beside it, and the manifest summary carries `stop_reason`, so **a short PNG set
+  is not evidence of a crashed harness — read `stop_reason` before assuming a run was truncated**.
+  `--no-stop-after-guest-fault` restores full-length sampling.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
   export RVAs. Use `--find-symbol NID` for a focused import/export query, and **`--import-slots`**
   to print the GOT/PLT relocation slot each import lands in — the step that starts every

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -272,10 +272,14 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   Sampling also **stops** once the guest is dead *and* the present layer has published nothing for
   `--guest-fault-settle-seconds` (1 s), so the run no longer spends its remaining `--seconds` /
   `--timeout` re-photographing one frame (#2584: 24 of 25 PNGs were byte-identical). Every sample
-  already taken is kept and the verdict is unchanged; the summary reads `saved/requested` with
-  `stop=guest-fault` beside it, and the manifest summary carries `stop_reason`, so **a short PNG set
-  is not evidence of a crashed harness — read `stop_reason` before assuming a run was truncated**.
-  `--no-stop-after-guest-fault` restores full-length sampling.
+  already taken is kept; the summary reads `saved/requested` with `stop=guest-fault` beside it, and
+  the manifest summary carries `stop_reason`, so **a short PNG set is not evidence of a crashed
+  harness — read `stop_reason` before assuming a run was truncated**.
+  `--no-stop-after-guest-fault` restores full-length sampling. The stop cannot make a failing run
+  pass: the saved/requested assertion is excused only in `--seconds` mode with a sample taken,
+  **`--max-stale-seconds` / `--max-pixel-stale-seconds` disarm the stop outright** (they are maxima
+  over the samples taken, so a shortened run would report a smaller one), and every other flag
+  assertion is a floor that fewer samples can only push further from being met.
 - **`self_dump/`** — parse a SELF/ELF and print its segment/program-header map, import NIDs, and
   export RVAs. Use `--find-symbol NID` for a focused import/export query, and **`--import-slots`**
   to print the GOT/PLT relocation slot each import lands in — the step that starts every

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -101,7 +101,8 @@ that (#2007: a title that crashed 0.4 s into boot produced 25 identical PNGs and
   so a batch consumer can filter without re-reading the run log.
 - `--allow-guest-fault` is for routes that *intend* to sample a crashing title. It restores exit 0
   and reports `status=GUEST-FAULT-ALLOWED` — never `ok` — so the fault stays visible in the record,
-  and it does not disarm the `--min-*` / `--require-*` assertions.
+  and it does not disarm the `--min-*` / `--require-*` / `--max-*` assertions. (It is the flag that
+  makes the early stop below observable at all: without it a fault is exit 1 either way.)
 - A guest whose entry **returns** (a title exiting normally) is reported as `guest=returned` and is
   not a failure on its own; a run cut short by it still trips the saved/requested assertion.
 
@@ -123,7 +124,9 @@ sampling them, so the stop cannot silently truncate evidence; it can only remove
 already known-identical.
 
 - **Every sample already taken is kept**, and the run finishes normally: same verdict, same
-  assertions, same manifest, same exit status.
+  manifest, same exit status. The assertions are *not* untouched, and three bullets below state
+  exactly which: one assertion is excused, two disarm the stop outright, and the rest cannot be
+  affected in either direction.
 - **The short artifact set explains itself.** The summary line reads
   `done: 3/25 screenshot(s) … stop=guest-fault … status=GUEST-FAULT`, and the manifest summary
   carries `stop_reason` (`request-satisfied` | `timeout` | `guest-fault`) beside the `saved` and
@@ -134,6 +137,21 @@ already known-identical.
   is due again regardless of the guest and the remainder are guaranteed duplicates. In frame
   (`--every`) mode a dead, quiet guest produces no new frame for `due` to fire on, so nothing more
   would have been written and the shortfall still fails.
+- **`--max-stale-seconds` and `--max-pixel-stale-seconds` disarm the stop entirely.** Both are
+  *maxima over the samples that were taken* — `CaptureTracker::observe` accumulates them, and only at
+  a sample — so cutting the tail deletes precisely the quiet interval they exist to catch. A run with
+  `--allow-guest-fault --max-pixel-stale-seconds 5` that fails over the full window (25 samples,
+  ~24 s stale, exit 1 `FAILED`) would, if the stop were left armed, take one sample, report 0 s and
+  exit 0. So arming either bound keeps the full-length loop, and the manifest run header records
+  `"stop_after_guest_fault": false` — the policy the run actually used, not the one requested — with
+  the bounds themselves in the same `assertions` object next to it. The run log says so too.
+- **Nothing else the tool asserts can be affected.** Every remaining flag assertion is a floor —
+  `--min-distinct-frames`, `--min-pixel-distinct-frames`, `--min-present-count`, `--min-frame-seq`,
+  `--require-composited-frame`, `--require-crc32` — and fewer samples can only push a floor further
+  from being satisfied. The one assertion that is not a flag, *manifest could not be written
+  completely*, is an I/O check on the tool itself: a shortened run makes fewer sample writes, but the
+  summary write and the `fclose` still happen, so an unwritable manifest is still caught. The stop
+  can shorten a run; it cannot turn a failing run into a passing one.
 - **A guest that *returns* does not trigger this.** A title exiting on its own is not a dead guest,
   and a run cut short by it must keep tripping the saved/requested assertion, as above.
 - `--no-stop-after-guest-fault` restores the old full-length sampling, and both the flag and the

--- a/prosper/tools/screenshot/README.md
+++ b/prosper/tools/screenshot/README.md
@@ -35,6 +35,7 @@ screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
            [--min-pixel-distinct-frames N] [--max-pixel-stale-seconds S]
            [--require-composited-frame] [--min-present-count N]
            [--min-frame-seq N] [--require-crc32 N] [--allow-guest-fault]
+           [--no-stop-after-guest-fault] [--guest-fault-settle-seconds S]
 ```
 
 | Option | Default | Meaning |
@@ -60,6 +61,8 @@ screenshot <app0-dir> [--every N] [--count M] [--out DIR] [--timeout SECS]
 | `--min-frame-seq N` | 0 | Fail unless a captured sample reaches rendered-frame N |
 | `--require-crc32 N` | unset | Fail unless a sample has this RGBA CRC32 (decimal or `0xHEX`) |
 | `--allow-guest-fault` | off | Do not fail the run when the guest's primary thread dies (deliberate fault-reproduction routes) |
+| `--no-stop-after-guest-fault` | off | Keep sampling the full request after the guest's primary thread dies |
+| `--guest-fault-settle-seconds S` | 1 | Quiescence required before that early stop: the guest must be dead **and** the present layer silent this long |
 
 Only the game is required; everything else has a sane default.
 Directory-creation and PNG write failures include the failing path and operating-system error.
@@ -105,6 +108,37 @@ that (#2007: a title that crashed 0.4 s into boot produced 25 identical PNGs and
 Scope: this observes the thread `run_entry` entered. A *worker* thread's fatal fault already
 `_exit(90)`s the whole process on Linux, which every caller that checks an exit status can see; the
 primary thread was the one that could die silently.
+
+### Sampling stops once nothing new can arrive
+
+The verdict was only half of it: the loop used to keep running to the full `--seconds`/`--count`/
+`--timeout` after the guest had died, writing one identical PNG per interval. On the `PPSA26414`
+reproduction that was 24 byte-identical PNGs over 24 s (#2584).
+
+Sampling now stops when **both** hold: the guest's primary thread is dead, *and* the present layer
+has published nothing for `--guest-fault-settle-seconds` (1 s by default). The second condition is
+not redundant — `GuestOutcome` covers only the thread `run_entry` entered, so other guest threads and
+a renderer backlog can still publish frames after it dies. A run that keeps producing frames keeps
+sampling them, so the stop cannot silently truncate evidence; it can only remove a tail that is
+already known-identical.
+
+- **Every sample already taken is kept**, and the run finishes normally: same verdict, same
+  assertions, same manifest, same exit status.
+- **The short artifact set explains itself.** The summary line reads
+  `done: 3/25 screenshot(s) … stop=guest-fault … status=GUEST-FAULT`, and the manifest summary
+  carries `stop_reason` (`request-satisfied` | `timeout` | `guest-fault`) beside the `saved` and
+  `requested` it already had. Three PNGs where 25 were asked for must never read as a crashed
+  harness.
+- **The saved/requested assertion is excused only where the skipped samples would otherwise have
+  been written** — wall-clock (`--seconds`) mode with at least one sample taken, where the sampler
+  is due again regardless of the guest and the remainder are guaranteed duplicates. In frame
+  (`--every`) mode a dead, quiet guest produces no new frame for `due` to fire on, so nothing more
+  would have been written and the shortfall still fails.
+- **A guest that *returns* does not trigger this.** A title exiting on its own is not a dead guest,
+  and a run cut short by it must keep tripping the saved/requested assertion, as above.
+- `--no-stop-after-guest-fault` restores the old full-length sampling, and both the flag and the
+  settle window are recorded in the manifest's run header, so an archived artifact set says whether
+  its tail was dropped or never produced.
 
 Warmup is useful when llvmpipe makes a frame-counted startup take minutes. The guest and GPU command
 decoder continue at native speed while Vulkan work is skipped; normal screenshots begin once warmup

--- a/prosper/tools/screenshot/capture_manifest.cpp
+++ b/prosper/tools/screenshot/capture_manifest.cpp
@@ -62,6 +62,27 @@ RunVerdict decide_run_verdict(bool assertions_failed, const GuestOutcome& guest,
     return {"ok", 0};
 }
 
+const char* sampling_stop_name(SamplingStop stop) {
+    switch (stop) {
+        case SamplingStop::Timeout:    return "timeout";
+        case SamplingStop::GuestFault: return "guest-fault";
+        case SamplingStop::RequestSatisfied: break;
+    }
+    return "request-satisfied";
+}
+
+bool should_stop_after_guest_fault(const GuestOutcome& guest, bool enabled,
+                                   double seconds_since_fault_observed,
+                                   double seconds_since_present_advanced,
+                                   double settle_seconds) {
+    if (!enabled) return false;
+    if (guest.state != GuestRunState::Faulted) return false;
+    // Both windows, not either: the first proves in-flight work had its chance, the second proves
+    // nothing is still arriving. See the header for why the fault alone is not enough.
+    return seconds_since_fault_observed >= settle_seconds &&
+           seconds_since_present_advanced >= settle_seconds;
+}
+
 void normalize_capture_rgba(CaptureSource source, std::vector<uint8_t>& pixels) {
     // A republished guest scanout is normalized like a composited frame and for the same reason:
     // both reach the desktop through the OPAQUE swapchain, so neither one's alpha attenuates the
@@ -259,6 +280,11 @@ std::string manifest_run_json(const CaptureRunConfig& c) {
          << ",\"min_present_count\":" << c.min_present_count
          << ",\"min_frame_seq\":" << c.min_frame_seq
          << ",\"allow_guest_fault\":" << (c.allow_guest_fault ? "true" : "false")
+         // Sampling policy rather than an assertion, but recorded in the same object so one line
+         // still reproduces the whole invocation.
+         << ",\"stop_after_guest_fault\":" << (c.stop_after_guest_fault ? "true" : "false")
+         << ",\"guest_fault_settle_seconds\":" << std::fixed << std::setprecision(6)
+         << c.guest_fault_settle_seconds
          << ",\"required_crc32\":";
     if (c.required_crc32_set)
         line << "\"" << std::hex << std::setw(8) << std::setfill('0') << c.required_crc32
@@ -303,13 +329,17 @@ std::string manifest_sample_json(int index, const std::string& png_path,
     return line.str();
 }
 
-std::string manifest_summary_json(int saved, int requested, bool timed_out,
+std::string manifest_summary_json(int saved, int requested, SamplingStop stop,
                                   const CaptureTracker& tracker, const RunVerdict& verdict,
                                   const GuestOutcome& guest, bool allow_guest_fault) {
     std::ostringstream line;
     line << "{\"type\":\"summary\",\"schema\":1,\"saved\":" << saved
          << ",\"requested\":" << requested
-         << ",\"timed_out\":" << (timed_out ? "true" : "false")
+         // `saved` < `requested` alone cannot tell a truncated harness from a run that stopped
+         // because nothing new could arrive. `stop_reason` is what separates them; `timed_out` is
+         // derived from the same value so an existing consumer keeps reading the same field.
+         << ",\"timed_out\":" << (stop == SamplingStop::Timeout ? "true" : "false")
+         << ",\"stop_reason\":\"" << sampling_stop_name(stop) << "\""
          << ",\"distinct_source_frames\":" << tracker.distinct_source_frames()
          << ",\"pixel_distinct_frames\":" << tracker.pixel_distinct_frames()
          << ",\"rendered_samples\":" << tracker.rendered_samples()

--- a/prosper/tools/screenshot/capture_manifest.cpp
+++ b/prosper/tools/screenshot/capture_manifest.cpp
@@ -83,6 +83,11 @@ bool should_stop_after_guest_fault(const GuestOutcome& guest, bool enabled,
            seconds_since_present_advanced >= settle_seconds;
 }
 
+bool early_stop_armed(bool requested, double max_stale_seconds, double max_pixel_stale_seconds) {
+    // See the header for why a staleness bound vetoes the stop rather than merely being documented.
+    return requested && max_stale_seconds < 0 && max_pixel_stale_seconds < 0;
+}
+
 void normalize_capture_rgba(CaptureSource source, std::vector<uint8_t>& pixels) {
     // A republished guest scanout is normalized like a composited frame and for the same reason:
     // both reach the desktop through the OPAQUE swapchain, so neither one's alpha attenuates the

--- a/prosper/tools/screenshot/capture_manifest.hpp
+++ b/prosper/tools/screenshot/capture_manifest.hpp
@@ -148,6 +148,23 @@ bool should_stop_after_guest_fault(const GuestOutcome& guest, bool enabled,
                                    double seconds_since_present_advanced,
                                    double settle_seconds);
 
+// Is the early stop actually armed for this run? `requested` is what the command line asked for
+// (`--no-stop-after-guest-fault` clears it); the two staleness bounds VETO it.
+//
+// That veto is load-bearing, not defensive. `--max-stale-seconds` and `--max-pixel-stale-seconds`
+// are the only assertions in this tool derived from a MAXIMUM over the samples that were taken
+// (`CaptureTracker::observe` accumulates both, and only at a sample). Every other capture assertion
+// is a floor -- `--min-*`, `--require-*` -- and fewer samples can only push a floor further from
+// being satisfied, so a shortened run can only fail those. A maximum moves the other way: cutting
+// the tail deletes the quiet interval the bound exists to catch. Concretely, an `--allow-guest-fault`
+// run that fails today with ~24 s of measured pixel staleness would take one sample, report 0 s and
+// exit 0 -- a silently weakened assertion, which is the failure mode this project treats as the most
+// expensive. Documenting it would not undo it, so the bound disarms the stop and the run measures
+// the window it was asked to measure.
+//
+// A negative bound means "not armed", matching the `>= 0` guards on the assertions themselves.
+bool early_stop_armed(bool requested, double max_stale_seconds, double max_pixel_stale_seconds);
+
 struct CaptureRunConfig {
     std::string title;
     std::string timestamp;
@@ -175,7 +192,11 @@ struct CaptureRunConfig {
     uint32_t required_crc32 = 0;
     bool allow_guest_fault = false;
     bool stop_after_guest_fault = true;
-    double guest_fault_settle_seconds = 0;
+    // Tracks the tool's own default (`screenshot.cpp`). This field records the POLICY a run used, so
+    // a zero here is not inert: zero is "stop on the first poll after the fault", the opposite of
+    // the conservatism the settle window exists for. A producer that constructs this struct directly
+    // must not silently get a different policy than the command line gives (#2639 review N1).
+    double guest_fault_settle_seconds = 1.0;
 };
 
 class CaptureTracker {

--- a/prosper/tools/screenshot/capture_manifest.hpp
+++ b/prosper/tools/screenshot/capture_manifest.hpp
@@ -121,6 +121,33 @@ struct RunVerdict {
 RunVerdict decide_run_verdict(bool assertions_failed, const GuestOutcome& guest,
                               bool allow_guest_fault);
 
+// Why the sampling loop ended. `RequestSatisfied` and `Timeout` are the two reasons the loop always
+// had; `GuestFault` is the early stop (#2584).
+enum class SamplingStop : uint8_t { RequestSatisfied, Timeout, GuestFault };
+
+const char* sampling_stop_name(SamplingStop stop);   // request-satisfied | timeout | guest-fault
+
+// Should the sampler stop before its request is satisfied, because nothing new can arrive?
+//
+// This deliberately does NOT stop at the fault itself, and that is the whole design. `GuestOutcome`
+// describes only the thread `run_entry` entered (see the scope note above): other guest threads and
+// a renderer backlog can still publish frames after the primary thread dies, and a stop keyed on the
+// fault alone would discard those silently — the truncated run would look exactly like a satisfied
+// one. So the stop also requires the present layer to have gone quiet, which makes the condition
+// detect its own invalidity: a run that keeps producing frames keeps sampling them.
+//
+// Both windows are measured against the same settle duration. The one measured from the fault is
+// what gives work already in flight a chance to land; the one measured from the last publication is
+// what establishes that nothing is still arriving.
+//
+// `Returned` is deliberately NOT a stop. A title exiting on its own is not a dead guest, the tool
+// already reports it, and a run cut short by it must keep tripping the saved/requested assertion —
+// the contract `README.md` states and #2007 relied on.
+bool should_stop_after_guest_fault(const GuestOutcome& guest, bool enabled,
+                                   double seconds_since_fault_observed,
+                                   double seconds_since_present_advanced,
+                                   double settle_seconds);
+
 struct CaptureRunConfig {
     std::string title;
     std::string timestamp;
@@ -147,6 +174,8 @@ struct CaptureRunConfig {
     bool required_crc32_set = false;
     uint32_t required_crc32 = 0;
     bool allow_guest_fault = false;
+    bool stop_after_guest_fault = true;
+    double guest_fault_settle_seconds = 0;
 };
 
 class CaptureTracker {
@@ -187,8 +216,10 @@ std::string manifest_sample_json(int index, const std::string& png_path,
                                  const std::string& input_route);
 // The verdict, the guest's terminal state and the opt-out are all required parameters: a caller that
 // forgets to wire the guest state must fail to compile rather than emit a summary that quietly omits
-// it, which is the shape of the defect this signature exists to prevent (#2007).
-std::string manifest_summary_json(int saved, int requested, bool timed_out,
+// it, which is the shape of the defect this signature exists to prevent (#2007). `stop` is required
+// for the same reason: a short artifact set that does not say why it is short is the same legibility
+// defect one level down (#2584). It also supplies the `timed_out` field, so the two cannot disagree.
+std::string manifest_summary_json(int saved, int requested, SamplingStop stop,
                                   const CaptureTracker& tracker, const RunVerdict& verdict,
                                   const GuestOutcome& guest, bool allow_guest_fault);
 

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -26,9 +26,19 @@
 //
 // It also stops sampling once that is established: the primary thread is dead AND the present layer
 // has published nothing for the settle window, so nothing new can arrive (#2584). Samples already
-// taken are kept, and the run finishes normally — same verdict, same manifest, same exit status,
-// without the redundant tail. The summary line reports `saved/requested` with `stop=guest-fault`
-// beside it so a short artifact set explains itself instead of reading as a truncated harness.
+// taken are kept and the run finishes normally, without the redundant tail. The summary line reports
+// `saved/requested` with `stop=guest-fault` beside it so a short artifact set explains itself
+// instead of reading as a truncated harness.
+//
+// What the stop can and cannot change, stated exactly, because "same assertions" is NOT true and
+// used to be claimed here (#2639 review B1):
+//   - the saved/requested assertion is EXCUSED, and only in wall-clock mode with a sample taken;
+//   - `--max-stale-seconds` / `--max-pixel-stale-seconds` DISARM the stop, because they are maxima
+//     over the samples taken and a shortened run would report a smaller one (`early_stop_armed`);
+//   - every other FLAG assertion is a floor (`--min-*`, `--require-*`) that fewer samples can only
+//     push further from being met, and the one non-flag assertion (an unwritable manifest) is still
+//     caught by the summary write and the fclose below. So the stop cannot make a run pass.
+// The verdict, the manifest and the exit status are otherwise the ones the full-length run produces.
 //
 // Reaching a rendering frame loop needs the guest switches the render frontier documents; this tool
 // defaults PROSPER_GUEST_ARGS=-force-gfx-direct (Unity/Messenger recipe) if it isn't already set,
@@ -399,6 +409,23 @@ int main(int argc, char** argv) {
     if (every < 1) every = 1;
     if (count < 1) count = 1;
 
+    // A staleness bound disarms the early stop, because both bounds are maxima over the samples that
+    // were TAKEN and the stop deletes the very interval they exist to catch (#2639 review B1; the
+    // reasoning is on `early_stop_armed`). From here on this variable is the EFFECTIVE policy: it is
+    // what the loop obeys and what the manifest run header records, so an archived artifact set
+    // states the policy it ran under rather than the one that was asked for.
+    {
+        const bool requested_stop = stop_after_guest_fault;
+        stop_after_guest_fault = screenshot::early_stop_armed(stop_after_guest_fault,
+                                                             max_stale_seconds,
+                                                             max_pixel_stale_seconds);
+        if (requested_stop && !stop_after_guest_fault)
+            fprintf(stderr, "[shot] early stop after a guest fault is DISARMED for this run: "
+                            "--max-stale-seconds / --max-pixel-stale-seconds measure the maximum "
+                            "gap across the samples taken, so stopping early would delete the "
+                            "interval they exist to catch. Sampling runs the full request.\n");
+    }
+
     // Title code = dump basename with a trailing "-app0" removed (e.g. PPSA24651-app0 -> PPSA24651).
     std::string code = dump;
     if (auto sl = code.find_last_of("/\\"); sl != std::string::npos) code = code.substr(sl + 1);
@@ -767,9 +794,11 @@ int main(int argc, char** argv) {
     if (saved != count && !short_run_explained)
         assertion_failed("saved %d/%d requested screenshots", saved, count);
     else if (saved != count)
+        // ASCII only: this is program output, and a UTF-8 punctuation mark in a printf literal is
+        // cp1252/cp437 mojibake on Windows and stops matching the grep a reader types (#2588).
         fprintf(stderr, "[shot] note: %d of %d requested samples were taken. The %d not taken were "
-                        "skipped because sampling stopped at the guest's death — each would have "
-                        "been a byte-for-byte copy of sample %d — not because the run was cut "
+                        "skipped because sampling stopped at the guest's death (each would have "
+                        "been a byte-for-byte copy of sample %d), not because the run was cut "
                         "short. This is not counted as a failure.\n",
                 saved, count, count - saved, saved - 1);
     if (manifest_failed)

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -17,10 +17,18 @@
 //     --warmup-seconds S  skip Vulkan rendering for S seconds before capture
 //     --warmup-submits N  skip Vulkan rendering before submit N
 //     --allow-guest-fault the guest's primary thread dying is not a failure (fault-repro routes)
+//     --no-stop-after-guest-fault  keep sampling the full request after the guest dies
+//     --guest-fault-settle-seconds S  quiescence required before that early stop (default 1)
 //
 // A run whose guest died still writes every PNG it managed to sample — frames from a crashing boot
 // are real evidence — but it reports `status=GUEST-FAULT` and exits non-zero, because every sample
 // after the fault is the same stale frame and no exit status used to say so (#2007).
+//
+// It also stops sampling once that is established: the primary thread is dead AND the present layer
+// has published nothing for the settle window, so nothing new can arrive (#2584). Samples already
+// taken are kept, and the run finishes normally — same verdict, same manifest, same exit status,
+// without the redundant tail. The summary line reports `saved/requested` with `stop=guest-fault`
+// beside it so a short artifact set explains itself instead of reading as a truncated harness.
 //
 // Reaching a rendering frame loop needs the guest switches the render frontier documents; this tool
 // defaults PROSPER_GUEST_ARGS=-force-gfx-direct (Unity/Messenger recipe) if it isn't already set,
@@ -277,6 +285,12 @@ int main(int argc, char** argv) {
     uint64_t min_present_count = 0, min_frame_seq = 0, required_crc32 = 0;
     bool manifest_disabled = false, require_composited_frame = false, required_crc32_set = false;
     bool warmup_seconds_set = false, warmup_submits_set = false, allow_guest_fault = false;
+    // Once the guest's primary thread is dead AND the present layer has been quiet this long, no
+    // further sample can carry new information, so sampling stops (#2584). One second is long
+    // enough for a renderer backlog or a surviving guest thread to publish one more frame at any
+    // rate the tool has ever sampled, and short enough that the redundant tail disappears.
+    double guest_fault_settle_seconds = 1.0;
+    bool stop_after_guest_fault = true;
     for (int i = 1; i < argc; i++) {
         std::string a = argv[i];
         if      (a == "--every"   && i + 1 < argc) every = atoi(argv[++i]);
@@ -345,6 +359,14 @@ int main(int argc, char** argv) {
         }
         else if (a == "--require-composited-frame") require_composited_frame = true;
         else if (a == "--allow-guest-fault") allow_guest_fault = true;
+        else if (a == "--no-stop-after-guest-fault") stop_after_guest_fault = false;
+        else if (a == "--guest-fault-settle-seconds" && i + 1 < argc) {
+            if (!parse_nonnegative_double(argv[++i], guest_fault_settle_seconds)) {
+                fprintf(stderr,
+                        "screenshot: --guest-fault-settle-seconds requires a non-negative number\n");
+                return 2;
+            }
+        }
         else if (a == "--warmup-seconds" && i + 1 < argc) {
             warmup_seconds_set = true;
             if (!parse_nonnegative_double(argv[++i], warmup_seconds)) {
@@ -370,7 +392,8 @@ int main(int argc, char** argv) {
                         "[--max-stale-seconds S] [--min-pixel-distinct-frames N] "
                         "[--max-pixel-stale-seconds S] [--require-composited-frame] "
                         "[--min-present-count N] [--min-frame-seq N] [--require-crc32 N] "
-                        "[--allow-guest-fault]\n");
+                        "[--allow-guest-fault] [--no-stop-after-guest-fault] "
+                        "[--guest-fault-settle-seconds S]\n");
         return 2;
     }
     if (every < 1) every = 1;
@@ -499,6 +522,8 @@ int main(int argc, char** argv) {
         run_config.required_crc32_set = required_crc32_set;
         run_config.required_crc32 = static_cast<uint32_t>(required_crc32);
         run_config.allow_guest_fault = allow_guest_fault;
+        run_config.stop_after_guest_fault = stop_after_guest_fault;
+        run_config.guest_fault_settle_seconds = guest_fault_settle_seconds;
         const std::string run_line = screenshot::manifest_run_json(run_config);
         if (fprintf(manifest, "%s\n", run_line.c_str()) < 0 || fflush(manifest) != 0) {
             fprintf(stderr, "screenshot: cannot write manifest header '%s': %s\n",
@@ -573,18 +598,67 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[shot] manifest: %s\n", manifest_path.c_str());
 
     int saved = 0;
-    bool timed_out = false, manifest_failed = false, required_crc32_seen = false;
+    bool manifest_failed = false, required_crc32_seen = false;
+    screenshot::SamplingStop stop = screenshot::SamplingStop::RequestSatisfied;
     screenshot::CaptureTracker tracker;
     uint64_t next = (uint64_t)every;   // frame-mode: rendered-frame # for the next shot
     auto t0 = std::chrono::steady_clock::now();
     auto last_cap = t0;                // time-mode: wall-clock of the previous shot
+    // Early-stop state. `sampling_guest` is the terminal state observed WHILE sampling, which is a
+    // different observation from the one the verdict is folded from after the loop: this one has to
+    // be polled, that one has to be read exactly once.
+    screenshot::GuestOutcome sampling_guest;
+    auto guest_fault_at = t0;          // when the fault was first observed
+    auto present_advanced_at = t0;     // when the present layer last published anything
+    uint64_t seen_frame_seq = gpu::present_frame_seq();
+    uint64_t seen_present_count = gpu::present_count();
     while (saved < count) {
         auto now = std::chrono::steady_clock::now();
         double el = std::chrono::duration<double>(now - t0).count();
         if (timeout > 0 && el > timeout) {
             fprintf(stderr, "[shot] timeout after %.0fs with %d/%d saved — game not rendering enough "
                             "(wrong guest env for this title? see the README)\n", el, saved, count);
-            timed_out = true;
+            stop = screenshot::SamplingStop::Timeout;
+            break;
+        }
+        // Present-layer liveness, polled every iteration rather than at capture time: the quiescence
+        // window has to be measured from the last real publication, not from the last thing this
+        // tool happened to photograph. Either counter advancing is new content — renderer frames and
+        // guest flips are independent, and a title can advance one without the other.
+        {
+            const uint64_t frame_seq_now = gpu::present_frame_seq();
+            const uint64_t present_count_now = gpu::present_count();
+            if (frame_seq_now != seen_frame_seq || present_count_now != seen_present_count) {
+                seen_frame_seq = frame_seq_now;
+                seen_present_count = present_count_now;
+                present_advanced_at = now;
+            }
+        }
+        if (stop_after_guest_fault &&
+            sampling_guest.state != screenshot::GuestRunState::Faulted) {
+            const screenshot::GuestOutcome polled = screenshot::read_guest_outcome();
+            if (polled.state == screenshot::GuestRunState::Faulted) {
+                sampling_guest = polled;
+                guest_fault_at = now;
+                fprintf(stderr, "[shot] guest fault observed at %.1fs with %d/%d saved; sampling "
+                                "continues while the present layer is still publishing\n",
+                        el, saved, count);
+            }
+        }
+        if (screenshot::should_stop_after_guest_fault(
+                sampling_guest, stop_after_guest_fault,
+                std::chrono::duration<double>(now - guest_fault_at).count(),
+                std::chrono::duration<double>(now - present_advanced_at).count(),
+                guest_fault_settle_seconds)) {
+            fprintf(stderr,
+                    "[shot] stopping early at %.1fs: the guest's primary thread is dead and the "
+                    "present layer has published nothing for %.1fs, so every further sample would "
+                    "copy the same frame. %d of %d requested samples were taken and ALL are kept; "
+                    "the run finishes normally. Use --no-stop-after-guest-fault to sample the full "
+                    "request anyway.\n",
+                    el, std::chrono::duration<double>(now - present_advanced_at).count(),
+                    saved, count);
+            stop = screenshot::SamplingStop::GuestFault;
             break;
         }
         bool due = time_mode ? (std::chrono::duration<double>(now - last_cap).count() >= seconds)
@@ -677,8 +751,27 @@ int main(int argc, char** argv) {
         fputc('\n', stderr);
         exit_code = 1;
     };
-    if (saved != count)
+    // A short run is EXCUSED only where the samples it skipped would otherwise have been written.
+    //
+    // In wall-clock mode the sampler is due again every `--seconds` no matter what the guest is
+    // doing, and the present layer keeps handing back its last frame, so once one sample exists the
+    // remainder are guaranteed duplicates: their absence is this stop's doing, not the route's, and
+    // failing on it would flip an `--allow-guest-fault` run that passes today into FAILED.
+    //
+    // In frame mode `due` needs a NEW rendered frame, which a dead and quiet guest will never
+    // produce. The sampler would have written nothing more and would have failed on the timeout, so
+    // the shortfall is real and still fails — the contract README.md states for a run cut short by
+    // the guest. Excusing it there would turn a failing run into a passing one.
+    const bool short_run_explained =
+        stop == screenshot::SamplingStop::GuestFault && time_mode && saved > 0;
+    if (saved != count && !short_run_explained)
         assertion_failed("saved %d/%d requested screenshots", saved, count);
+    else if (saved != count)
+        fprintf(stderr, "[shot] note: %d of %d requested samples were taken. The %d not taken were "
+                        "skipped because sampling stopped at the guest's death — each would have "
+                        "been a byte-for-byte copy of sample %d — not because the run was cut "
+                        "short. This is not counted as a failure.\n",
+                saved, count, count - saved, saved - 1);
     if (manifest_failed)
         assertion_failed("%s", "manifest could not be written completely");
     if (tracker.distinct_source_frames() < static_cast<uint64_t>(min_distinct_frames))
@@ -734,7 +827,7 @@ int main(int argc, char** argv) {
         screenshot::decide_run_verdict(exit_code != 0, guest_outcome, allow_guest_fault);
     if (manifest) {
         const std::string summary = screenshot::manifest_summary_json(
-            saved, count, timed_out, tracker, verdict, guest_outcome, allow_guest_fault);
+            saved, count, stop, tracker, verdict, guest_outcome, allow_guest_fault);
         if (fprintf(manifest, "%s\n", summary.c_str()) < 0 || fclose(manifest) != 0) {
             fprintf(stderr, "[shot] manifest close failed: %s: %s\n",
                     manifest_path.c_str(), strerror(errno));
@@ -743,10 +836,14 @@ int main(int argc, char** argv) {
             verdict = screenshot::decide_run_verdict(true, guest_outcome, allow_guest_fault);
         }
     }
-    fprintf(stderr, "[shot] done: %d screenshot(s) in %s; source-distinct=%llu "
+    // `saved/requested` and `stop=` travel together: a reader who sees fewer PNGs than requested
+    // must be able to tell a truncated harness from a run that stopped because nothing new could
+    // arrive, on this one line, without opening the manifest.
+    fprintf(stderr, "[shot] done: %d/%d screenshot(s) in %s; stop=%s source-distinct=%llu "
                     "pixel-distinct=%llu max-source-stale=%.1fs max-pixel-stale=%.1fs guest=%s "
                     "status=%s\n",
-            saved, out.c_str(), (unsigned long long)tracker.distinct_source_frames(),
+            saved, count, out.c_str(), screenshot::sampling_stop_name(stop),
+            (unsigned long long)tracker.distinct_source_frames(),
             (unsigned long long)tracker.pixel_distinct_frames(), tracker.max_stale_seconds(),
             tracker.max_pixel_stale_seconds(),
             screenshot::guest_run_state_name(guest_outcome.state), verdict.status);


### PR DESCRIPTION
Fixes #2584
Refs #2007

## The failure scenario

#2007/#2577 made a dead guest visible in the verdict but left the LOOP alone: the run kept going to
its full `--seconds` / `--count` / `--timeout`, writing one PNG per interval, every one a copy of the
same stale frame.

Measured on the `PPSA26414` (R-Type Delta) reproduction: **guest dead at 0.4 s, run continued ~24 s,
25 PNGs of which 24 were byte-identical.** Across a snapshot matrix, or a batch of routed boots on a
contended box, that is a lot of wall clock spent producing bytes that are known-redundant at the
moment they are written — and 25 files in an artifact directory reads as 25 observations.

## Behavioral contract and the approach

Sampling now stops when **BOTH** hold:

1. the guest's primary thread is dead, **and**
2. the present layer has published nothing for `--guest-fault-settle-seconds` (default 1 s).

**The second condition is the design, not a safety margin.** `GuestOutcome` describes only the
thread `run_entry` entered — other guest threads and a renderer backlog can still publish after it
dies — so a stop keyed on the fault alone would silently truncate a run that is still producing
frames, and the truncation would be indistinguishable from a satisfied request. Requiring quiescence
makes the condition **detect its own invalidity**: a run that keeps producing frames keeps sampling
them, and the stop can only remove a tail that is already known-identical.

**A guest that RETURNS is deliberately not a stop.** A title exiting on its own is not a dead guest,
and a run cut short by it must keep tripping the saved/requested assertion — the contract
`README.md` states and #2007 relied on.

### The saved-vs-requested narrowing, and why it is narrow

The assertion is excused **ONLY** in wall-clock mode with at least one sample taken — the case where
the sampler is due again regardless of the guest and the remainder are guaranteed duplicates. In
frame mode `due` needs a new rendered frame a dead quiet guest never produces, so nothing more would
have been written and the shortfall still fails. Without that narrowing, an `--allow-guest-fault`
run that passes today would flip to FAILED.

### Legibility — a short artifact set must not read as a crashed harness

- summary line: `done: 1/25 screenshot(s) ... stop=guest-fault ... status=GUEST-FAULT`
- manifest summary: new `stop_reason` (`request-satisfied` | `timeout` | `guest-fault`) beside the
  `saved`/`requested` it already carried, so `--count` needs no new field; **`timed_out` is now
  derived from the same value and cannot disagree with it**
- manifest run header records the policy (`stop_after_guest_fault`, `guest_fault_settle_seconds`), so
  an archived set says whether its tail was dropped or never produced
- an explicit note names the skipped samples and states they are not a failure

## Caller audit

`tools/snapshot/snapshot.py` is the only in-repo consumer. It invokes screenshot in exactly one
place, always in time mode, never with `--allow-guest-fault`, and rejects a non-zero exit **BEFORE**
it reaches its own `saved != requested` check — so a faulted run is rejected as it is today, just
sooner, and an exit-0 short run is unreachable for it. Nothing counts PNG files on disk
(`analyze_content_manifest` works from manifest sample records; the `frame_*.bmp` globs are
`boot_trace`'s). **No guard changes behavior.**

## Affected and deliberately unaffected

- **Affected:** `tools/screenshot`'s sampling loop, its summary line, and the manifest's summary and
  run header. `--no-stop-after-guest-fault` restores the previous loop exactly.
- **Deliberately unaffected:** the verdict, the exit status, and the pre-fault PNGs. #2007's point
  was that evidence and verdict are separate concerns, and the A/B below shows both directions
  produce the same verdict and the same exit status.
- **Deliberately unaffected:** a guest that exits normally, and frame mode's saved/requested
  assertion.

## Risks

- `CONFIDENCE: MED` on the **1 s default settle window.** It is bounded by what this box observed
  (the layer went quiet immediately at the fault), not by a survey of titles whose worker threads
  outlive the primary thread. `--guest-fault-settle-seconds` exists for that case, and the quiescence
  requirement means the failure mode of a too-short window is a dropped tail of *further frames*,
  not a dropped verdict.
- `CONFIDENCE: HIGH` on the stop condition and the exit-status equivalence — both measured live on
  the reproduction, in both directions.
- The manifest gains a field. `timed_out` is now derived from `stop_reason`, so any external consumer
  reading `timed_out` sees a value that can no longer disagree with `stop_reason`; no in-repo
  consumer reads either (audited above).

## Verification (local; author-run)

Linux, distrobox, worktree build.

**Build and tests**

```
cmake --build <build dir> -j4     -> clean
ctest --no-tests=error -j4        -> 265/265 passed, exit 0
```

Baseline on `origin/master` `ec2c0c22`: **265/265 passed, exit 0**.

**Live A/B, one binary, same route, same fault `rip=0x410024055`**

| arm | wall | PNGs | stop_reason | status | exit |
| --- | --- | --- | --- | --- | --- |
| default | 1.52 s | 1 | `guest-fault` | GUEST-FAULT | 1 |
| `--no-stop-after-guest-fault` | 25.30 s | 25 | `request-satisfied` | GUEST-FAULT | 1 |

All 26 PNGs share one md5 (`c65064cd11e8f46215e9a89c34f35cd3`) — 24 exact copies dropped, no evidence
lost, verdict and exit status unchanged.

**Exit-status preservation**

- time mode + `--allow-guest-fault` stays exit 0 `GUEST-FAULT-ALLOWED` (1.46 s)
- frame mode + `--allow-guest-fault` still fails `saved 0/5` exit 1 FAILED (1.43 s, vs burning the
  40 s timeout)

**Positive control, healthy title (`PPSA24651`)**: 6/6, `stop=request-satisfied`, `guest=running`,
ok, exit 0 — the stop never arms.

**Mutation arms on `test_capture_manifest`**, each with a distinct binary md5 and a verified
byte-identical restore:

- **A** stop at the fault, no quiescence → FAIL *"a present layer still publishing keeps the sampler
  running after the fault"*, FAIL *"work already in flight gets the settle window before the sampler
  gives up"*
- **B** any terminal state stops → FAIL *"a guest that exits on its own is not a fault and does not
  stop the sampler"*
- **C** summary omits `stop_reason` → FAIL *"summary records incomplete failure"*, FAIL *"a short run
  states saved, requested and why it is short — and is not a timeout"*

**No CI evidence is quoted: CI has not run on this branch.**

## Note on the commit trailer

The commit body carries `Refs #2007` (the parent issue this was split out of). The work closes
**#2584**, which is why this PR body states `Fixes #2584` explicitly.


---

## Update at `3f7af6ab` — review B1 fixed by mechanism, N1/N2 fixed, N4 answered

The review of `4fce5ff9` was **REJECTED** on one blocking finding, and it was right: the contract text
above claimed the stop preserves the assertions, and `--max-stale-seconds` /
`--max-pixel-stale-seconds` were genuinely weakened by it. Full response in the PR comment; the
substance:

**Fix (resolution (a)).** Both staleness bounds now **disarm the early stop**. They are the only
capture assertions derived from a maximum over the samples *taken* (`CaptureTracker::observe`), so
cutting the tail deletes exactly the interval they exist to catch; every other flag assertion is a
floor that fewer samples can only push further from being met. `early_stop_armed()` folds the request
and the two bounds into one effective policy before anything reads it, so the loop and the manifest
run header agree. **The suggested fold-the-quiet-interval mechanism does not close it** — it makes the
number honest for the window that happened, but the full-length window is longer, so the bound still
flips (0.3 s vs. 24.0 s against a bound of 5).

**No in-repo route is affected.** `tools/snapshot/snapshot.py:948-950` passes neither `--max-*` nor
`--allow-guest-fault`, so every snapshot route keeps #2584's early stop unchanged.

**Contract text** corrected in `README.md` (`:104` and `:125`), `screenshot.cpp`'s header block and
`tools/AGENTS.md`: one assertion excused, two disarm the stop, the rest cannot be affected, plus the
one non-flag assertion (an unwritable manifest) which is still caught by the summary write and the
`fclose`.

**Also:** `CaptureRunConfig::guest_fault_settle_seconds` `0` -> `1.0` (N1); three new non-ASCII printed
literals removed, including one in `test_capture_manifest.cpp` the review did not catch (N2, #2588).

### Live A/B for the fix, `PPSA26414`, same fault `rip=0x410024055`, one binary per arm

| arm | binary md5 | args added | wall | PNGs | `stop_reason` | max-pixel-stale | status | exit |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| **A** pre-fix | `d6a21e37` | `--max-pixel-stale-seconds 5` | 2 s | 1 | `guest-fault` | **0.0 s** | GUEST-FAULT-ALLOWED | **0** |
| **B** fixed | `446e70ab` | `--max-pixel-stale-seconds 5` | 25 s | 25 | `request-satisfied` | **24.066 s** | FAILED | **1** |
| **C** fixed, control | `446e70ab` | none | 1 s | 1 | `guest-fault` | 0.0 s | GUEST-FAULT-ALLOWED | 0 |

All 27 PNGs share one md5 (`c65064cd11e8f46215e9a89c34f35cd3`): no evidence differs between arms, only
the measurement window. Arm B's manifest run header records `"stop_after_guest_fault": false` — the
policy the run used, not the one requested.

### What the arms cover, and what they do not

Stated explicitly as the review asked. The unit arms cover **the stop predicate**
(`should_stop_after_guest_fault`) and **the arming policy** (`early_stop_armed`), plus a hand-built
tracker pair showing one bound producing two verdicts. The **loop bookkeeping** —
`present_advanced_at` refreshed from `gpu::present_frame_seq()` / `gpu::present_count()`,
`guest_fault_at` stamped at observation, the poll skipped once `Faulted` is latched — is covered by
the **live route only**, because it needs a guest. Mutations: reverting `early_stop_armed` to
`return requested;` fails three arms; reverting the settle default to `0` fails one. Both md5 round
trips are exact.

### Verification at `3f7af6ab`

```
cmake --build <build dir> -j4     -> clean, exit 0
ctest --no-tests=error -j4        -> 265/265 passed, exit 0
```

265 is the dump-configured count; CI Linux sees 262. `git diff --check` clean; docs gate clean.
No snapshot run: the diff is `tools/screenshot` and its docs, and the one in-repo snapshot caller is
unaffected.
