### PR TITLE
tools(hle_calls): resolve the load bias so a PIE target measures instead of refusing

### DIFF
--- a/prosper/tools/hle_calls/README.md
+++ b/prosper/tools/hle_calls/README.md
@@ -48,7 +48,8 @@ Output:
 ```
 clock=prosper::k_usleep entries=400/400 window=complete \
     positive-control=absent(attach:login-consumed-pre-window) \
-    armed=151 mode=attach calls=72 finish-failures=0 exited=0
+    armed=151 mode=attach calls=72 finish-failures=0 exited=0 \
+    elf=ET_EXEC load-bias=0x0 symbol-check=8/8
 positive-control-note: expected in attach mode and NOT a defect: init consumed the …
 first-calls: 1:pad_read_state  2:s_user_getevent  3:s_syss_getstatus  …
       36  s_user_getevent
@@ -299,14 +300,36 @@ Linux, `gdb` with Python support, `nm`/`c++filt`, and ptrace attach permitted
 binary must not be **stripped**: the driver enumerates handlers out of the symbol table with `nm`.
 Debug info is *not* required, including for `--values`.
 
-**The target must be non-PIE (`ET_EXEC`)**, which prosper's binaries are under the toolchains this
-project uses. Every breakpoint is armed at the raw link-time address `nm` reports; in a PIE those are
-offsets from a run-time load base, so each one lands in unmapped memory and gdb answers
-`Cannot insert breakpoint N / Cannot access memory at address 0x…` per handler. **The driver checks
-the ELF type and refuses with that explanation** rather than reporting a window that armed nothing.
-This is not hypothetical: Ubuntu's gcc defaults to `-pie` and Fedora's does not, so the same source
-builds differently on the two — measured when this tool's own test passed on Fedora and failed on a
-GitHub `ubuntu-24.04` runner. Rebuild with `-DCMAKE_EXE_LINKER_FLAGS=-no-pie`; the bias-aware fix is #2605.
+**PIE and non-PIE targets both work** (#2605). Every breakpoint is armed at the raw link-time address
+`nm` reports, which on an `ET_EXEC` binary is already the runtime address; on a PIE it is an offset
+from a base the kernel picks per run, so the tool reads that base out of the live process and adds it
+before arming. This matters because the toolchains disagree — Ubuntu's gcc defaults to `-pie` and
+Fedora's does not, so the same source builds differently on the two, and this tool's own test once
+passed on Fedora while failing on a GitHub `ubuntu-24.04` runner with
+`Cannot insert breakpoint N / Cannot access memory at address 0x…` per handler.
+
+The result block says where the breakpoints went, and you should read it:
+
+```
+… elf=ET_DYN load-bias=0x555555554000 symbol-check=8/8
+```
+
+- `load-bias` is `running entry − link-time entry`, the running one from `/proc/<pid>/auxv`'s
+  `AT_ENTRY` and cross-checked against gdb's own `info files`. It is **read, never assumed** — under
+  gdb the base is `0x555555554000` every time because gdb disables randomization, but an ordinary
+  `--pid` attach measured `0x5634df2d1000`, so a constant would be right until it silently was not.
+- `symbol-check=N/N` is the observation behind it: gdb was asked what lives at a sample of the
+  addresses about to be armed, and every one named a function *start*. A wrong bias (or a `--binary`
+  that is not the image the process is running) fails this and the run is **refused by name** —
+  `HLE_CALLS_ABORT: … do not land on a function start …` — before a single breakpoint is inserted.
+
+`--launch` on a PIE stops the process at its first instruction (`starti`, i.e. the dynamic loader's
+first instruction, before anything of the program has run) purely to read the base, then arms and
+continues. **No init coverage is lost**: the window still opens where it did on a non-PIE target, and
+the built-in `positive-control=ok` — the once-per-process LOGIN — is what says so.
+
+Requires gdb 8.1 or newer for `starti` on a PIE `--launch`; an older gdb is refused with that
+explanation, and `-DCMAKE_EXE_LINKER_FLAGS=-no-pie` remains a way out.
 
 ## Cost
 

--- a/prosper/tools/hle_calls/hle_calls.py
+++ b/prosper/tools/hle_calls/hle_calls.py
@@ -39,7 +39,7 @@ The header line reports the window actually observed:
 
     clock=prosper::k_usleep entries=400/400 window=complete \\
         positive-control=absent(attach:login-consumed-pre-window) armed=750 mode=attach \\
-        calls=21362 finish-failures=0 exited=0
+        calls=21362 finish-failures=0 exited=0 elf=ET_EXEC load-bias=0x0 symbol-check=8/8
 
 An **empty histogram with a non-zero `entries`** is a real measurement: the
 guest entered no HLE handler while the clock advanced 400 times. An empty
@@ -169,6 +169,26 @@ redirected too, so a launched program that reads stdin sees EOF. `--inferior-log
 applies to `--launch` only; passing it with `--pid` is an error, because there is
 no inferior whose output this tool controls.
 
+PIE targets, and where the breakpoints went
+-------------------------------------------
+`nm` reports link-time addresses. On an `ET_EXEC` binary those are the runtime
+addresses; on a PIE they are offsets from a base the kernel picks per run, so the
+tool reads that base out of the live process and adds it before arming — under
+`--pid` from the attached process, and under `--launch` after a `starti` that
+stops at the first instruction, before anything of the program has run, so no
+init coverage is lost. Ubuntu's gcc defaults to `-pie` and Fedora's does not, so
+both shapes occur for the same source (#2605).
+
+The header reports the outcome — `elf=ET_DYN load-bias=0x555555554000
+symbol-check=8/8`. The bias is `running entry - link-time entry`, read from
+`/proc/<pid>/auxv` and cross-checked against gdb's own `info files`; it is never
+assumed, because gdb disables randomization and its `0x555555554000` is right
+until a plain `--pid` attach (measured: `0x5634df2d1000`) makes it silently
+wrong. `symbol-check` is the observation behind it: gdb was asked what lives at a
+sample of the addresses about to be armed, and each named a function *start*. A
+wrong bias — or a `--binary` that is not the image the process is running —
+fails that and the run is refused by name rather than measuring nothing.
+
 Requirements: Linux, `gdb` with Python, `nm`, and ptrace attach permitted
 (`kernel.yama.ptrace_scope=0`, for `--pid`; `--launch` runs its own child). The
 prosper binary must not be stripped — the handler enumeration below reads the
@@ -188,6 +208,10 @@ HLE_SIGNATURE = ("(unsigned long, unsigned long, unsigned long, "
 # --out-bytes ceiling. Two reads of this width per call per argument, and the whole snapshot is held
 # per in-flight call; a struct worth inspecting here is tens of bytes, not kilobytes.
 OUT_BYTES_MAX = 256
+# ELF `e_type`. ET_EXEC's link-time addresses are its runtime addresses; ET_DYN's are offsets from a
+# base the kernel picks per run, which is the whole of #2605.
+ET_EXEC = 2
+ET_DYN = 3
 HERE = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -233,45 +257,44 @@ def enumerate_handlers(binary, name_filter):
     return out
 
 
-def refuse_if_pie(binary):
-    """Stop with a reason on a position-independent executable, rather than letting gdb spew.
+def read_elf_geometry(binary):
+    """`(e_type, e_entry)` -- what decides whether a link-time address is a runtime address (#2605).
 
     This tool arms breakpoints at the RAW addresses `nm` reports, which are link-time addresses. In a
-    non-PIE executable (`ET_EXEC`) they are the runtime addresses too, which is why this works at all
-    -- prosper's own binaries are `ET_EXEC` as built by the toolchains this project uses. Under a
-    toolchain that defaults to `-pie` (Ubuntu's gcc does; Fedora's does not) the same addresses are
-    offsets from a load base chosen at run time, so every breakpoint lands in unmapped memory:
+    non-PIE executable (`ET_EXEC`) they are the runtime addresses too. Under a toolchain that
+    defaults to `-pie` (Ubuntu's gcc does; Fedora's does not) the same addresses are offsets from a
+    load base chosen at run time, and arming them unrelocated puts every breakpoint in unmapped
+    memory:
 
         Cannot insert breakpoint 3.
         Cannot access memory at address 0x1149
 
-    gdb prints that per breakpoint and the run yields no result block -- loud, but three steps away
-    from naming its own cause. Measured on a GitHub `ubuntu-24.04` runner, where the same fixture
-    that passes here failed exactly this way.
+    That is what a GitHub `ubuntu-24.04` runner produced from the same fixture that passes on Fedora.
+    #2593 replaced the spew with a refusal; this function replaces the refusal with the load bias,
+    which the gdb side derives from the LIVE process (`hle_calls_gdb.py`, `_resolve_load_bias`) --
+    `e_entry` here is one of the two halves of that subtraction, the other being the kernel's own
+    `AT_ENTRY`. Nothing is guessed: in particular the base gdb picks with randomization disabled is
+    never assumed, because it is right until it silently is not (a real attach measured
+    `0x5634df2d1000`, nowhere near gdb's `0x555555554000`).
 
-    Refusing rather than guessing a base is deliberate: in `--launch` mode the whole point is that
-    breakpoints are armed BEFORE the process exists, so there is no bias to read yet, and inferring
-    one from gdb's disabled-randomization default would produce a number that is right until it
-    silently is not. Making this work on a PIE build is a real feature (attach mode could read the
-    bias from `/proc/<pid>/maps`) and is tracked separately.
+    Returns `(None, None)` for anything that is not an ELF, and lets the later steps produce their
+    own message -- `nm` is next and says so plainly.
     """
     try:
         with open(binary, "rb") as handle:
-            header = handle.read(18)
+            header = handle.read(64)
     except OSError as exc:
         sys.exit("hle_calls: cannot read %s: %s" % (binary, exc))
-    if len(header) < 18 or header[:4] != b"\x7fELF":
-        return                      # not an ELF; let the later steps produce their own message
-    little = header[5] == 1
-    e_type = int.from_bytes(header[16:18], "little" if little else "big")
-    if e_type == 3:                 # ET_DYN -- a PIE (or a shared object)
-        sys.exit(
-            "hle_calls: %s is a position-independent executable (ET_DYN), and this tool arms the "
-            "raw link-time addresses `nm` reports, so every breakpoint would land in unmapped "
-            "memory (gdb: 'Cannot insert breakpoint N / Cannot access memory at address 0x...'). "
-            "Build the target non-PIE -- e.g. cmake -DCMAKE_EXE_LINKER_FLAGS=-no-pie -- which is "
-            "what prosper's binaries already are under the toolchains this project uses. Refusing "
-            "here rather than reporting a window that armed nothing." % binary)
+    if len(header) < 32 or header[:4] != b"\x7fELF":
+        return (None, None)
+    order = "little" if header[5] == 1 else "big"
+    e_type = int.from_bytes(header[16:18], order)
+    # e_entry sits at 0x18 in both classes; only its width differs (ELF32 4 bytes, ELF64 8).
+    width = 8 if header[4] == 2 else 4
+    if len(header) < 0x18 + width:
+        return (e_type, None)
+    e_entry = int.from_bytes(header[0x18:0x18 + width], order)
+    return (e_type, e_entry)
 
 
 def _prepare_inferior_log(path):
@@ -370,15 +393,25 @@ def main():
         binary = args.binary or os.path.realpath("/proc/%d/exe" % args.pid)
     if not os.path.exists(binary):
         sys.exit("hle_calls: no such binary: %s" % binary)
-    # Before anything expensive: a PIE would arm hundreds of breakpoints at unmapped addresses and
-    # report a window that measured nothing. See refuse_if_pie().
-    refuse_if_pie(binary)
+    # Whether `nm`'s addresses are runtime addresses, and what the gdb side needs to find out if they
+    # are not. See read_elf_geometry().
+    elf_type, elf_entry = read_elf_geometry(binary)
+    if elf_type == ET_DYN and elf_entry is None:
+        sys.exit("hle_calls: %s is ET_DYN but its ELF header carries no entry point, so the load "
+                 "bias cannot be derived. Build the target non-PIE "
+                 "(cmake -DCMAKE_EXE_LINKER_FLAGS=-no-pie) and re-run." % binary)
 
     handlers = enumerate_handlers(binary, args.filter)
     if not handlers:
         sys.exit("hle_calls: found no HLE handlers in %s "
                  "(wrong binary, stripped build, or too narrow a --filter)" % binary)
-    print("hle_calls: %d handler symbols in %s" % (len(handlers), binary), file=sys.stderr)
+    print("hle_calls: %d handler symbols in %s (%s)"
+          % (len(handlers), binary,
+             "ET_DYN -- the load bias is read from the live process before arming"
+             if elf_type == ET_DYN else
+             "ET_EXEC -- link-time addresses are runtime addresses" if elf_type == ET_EXEC else
+             "not an ELF header this tool recognises"),
+          file=sys.stderr)
 
     with tempfile.NamedTemporaryFile("w", suffix=".syms", delete=False) as table:
         for addr, name in handlers:
@@ -399,6 +432,10 @@ def main():
     env["HLE_CALLS_VALUES"] = "1" if args.values else "0"
     env["HLE_CALLS_ORDER"] = str(args.order)
     env["HLE_CALLS_OUT_BYTES"] = str(args.out_bytes)
+    # The gdb side needs both halves of the bias subtraction: this file's link-time entry point, and
+    # the running process's real one. It reads the second itself; only the first is knowable here.
+    env["HLE_CALLS_ELF_TYPE"] = str(elf_type if elf_type is not None else 0)
+    env["HLE_CALLS_ELF_ENTRY"] = str(elf_entry if elf_entry is not None else 0)
     script = os.path.join(HERE, "hle_calls_gdb.py")
     if args.launch:
         # `--args` must come last; the gdb script issues the `run` itself, after
@@ -449,7 +486,7 @@ def main():
     run = subprocess.CompletedProcess(cmd, proc.returncode, out, err)
     os.unlink(syms_path)
 
-    body, keep = [], False
+    body, keep, notes, aborts = [], False, [], []
     for line in run.stdout.splitlines():
         if line == "HLE_CALLS_BEGIN":
             keep = True
@@ -459,7 +496,23 @@ def main():
             continue
         if keep:
             body.append(line)
+        elif line.startswith("HLE_CALLS_ABORT:"):
+            aborts.append(line)
+        elif line.startswith("hle_calls:"):
+            # What the gdb side resolved and armed, forwarded rather than swallowed. Only the
+            # result block reaches stdout, so before this these lines — the load bias it derived,
+            # the symbols it could not arm — were visible ONLY when the run produced nothing at all,
+            # i.e. exactly when it was too late to be diagnostic.
+            notes.append(line)
+    for line in notes:
+        print(line, file=sys.stderr)
     if not body:
+        # An abort names its own cause, so print it INSTEAD of the raw gdb transcript: the transcript
+        # is what a reader had to search before, and "VOID, not a negative" is true but not useful
+        # when the tool already knows precisely what was wrong.
+        if aborts:
+            sys.stderr.write(run.stderr)
+            sys.exit("\n".join(aborts))
         sys.stderr.write(run.stdout)
         sys.stderr.write(run.stderr)
         sys.exit("hle_calls: gdb produced no result block — VOID, not a negative")

--- a/prosper/tools/hle_calls/hle_calls_gdb.py
+++ b/prosper/tools/hle_calls/hle_calls_gdb.py
@@ -18,6 +18,9 @@ environment so the driver can stay a plain subprocess call:
                       the launched emulator's entire run log would inherit that pipe and
                       accumulate in the driver's memory. gdb opens the path; it does not
                       create it, so the driver does that first.
+    HLE_CALLS_ELF_TYPE   the target's ELF `e_type` (2 = ET_EXEC, 3 = ET_DYN/PIE)
+    HLE_CALLS_ELF_ENTRY  its link-time entry point -- one half of the load-bias
+                      subtraction below (#2605)
 
 Every handler gets a Python breakpoint whose `stop()` counts the hit and returns
 False, so the inferior is never actually stopped for the user. The count is kept
@@ -50,6 +53,12 @@ both are printed unconditionally:
   * `window=complete|SHORT` says whether the clock really reached `--ticks`.
     `run`/`continue` also return on a signal gdb stops for, which would
     otherwise print a truncated histogram that reads as a finished window.
+  * `elf=`, `load-bias=` and `symbol-check=` say where the breakpoints actually
+    went. On an `ET_EXEC` target the bias is `0x0` and the check is a formality;
+    on a PIE it is the whole difference between a measurement and a window that
+    armed nothing, so it is derived from the live process and then verified
+    against gdb's own symbol table before a single breakpoint is inserted
+    (`_resolve_load_bias` / `_symbol_landing`, #2605).
   * `positive-control=` states the verdict on the value-capture mechanism
     itself, so the reader never has to derive it — and, critically, so the rule
     is applied **per mode**. See `_positive_control()` below for the whole state
@@ -90,6 +99,18 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import hle_calls_control as _control
 
 
+def _abort(text):
+    """Stop the run with a named cause, rather than letting it produce a window that armed nothing.
+
+    The driver prints an `HLE_CALLS_ABORT:` line INSTEAD of the raw gdb transcript, so whatever is
+    said here is what a reader sees. Exit code 3 so a caller can tell "this tool refused" from "gdb
+    died" (1) -- both differ from a clean run's 0.
+    """
+    print("HLE_CALLS_ABORT: " + text)
+    sys.stdout.flush()
+    gdb.execute("quit 3")
+
+
 def _load_syms(path):
     out = []
     with open(path) as handle:
@@ -110,6 +131,17 @@ ORDER_N = int(os.environ.get("HLE_CALLS_ORDER", "24"))
 # 0 = off. When non-zero, snapshot this many bytes at a0/a1 before and after every call (#2045).
 OUT_BYTES = int(os.environ.get("HLE_CALLS_OUT_BYTES", "0"))
 INFERIOR_TTY = os.environ.get("HLE_CALLS_INFERIOR_TTY", "")
+# The target's linkage, from the driver's own read of the ELF header. ET_EXEC (2) means `nm`'s
+# addresses are already runtime addresses; ET_DYN (3) means they are offsets and the bias below has
+# to come from the live process. 0 = the driver did not recognise the file as an ELF.
+ELF_TYPE = int(os.environ.get("HLE_CALLS_ELF_TYPE", "2"))
+ELF_ENTRY = int(os.environ.get("HLE_CALLS_ELF_ENTRY", "0"))
+ET_EXEC = 2
+ET_DYN = 3
+AT_ENTRY = 9                    # auxv key: the entry point the kernel actually jumped to
+# How many enumerated symbols to verify land exactly on a function start before arming anything.
+# A sample, not the whole table: this is one gdb command per symbol and the table reaches ~750.
+SYMBOL_CHECK_N = 8
 
 # The built-in control for the value-capture mechanism, and the two values it can answer.
 # src/hle/hle_service.cpp `HLE(s_user_getevent)`: a function-local `static` flag makes the
@@ -412,6 +444,163 @@ def _on_exited(event):
     state["exited"] = True
 
 
+# --- load bias (#2605) --------------------------------------------------------------------------
+# Every address in SYMS is a LINK-TIME address, because that is what `nm` reports. On an ET_EXEC
+# target those are the runtime addresses and there is nothing to do. On a PIE (`ET_DYN`) they are
+# offsets from a base the kernel picks per run, and arming them unrelocated puts every breakpoint in
+# unmapped memory -- which is not a wrong measurement, it is no measurement, and it reads like one
+# (#2593 refused such a target outright; this replaces the refusal).
+#
+# The base is NOT guessed. gdb disables randomization by default, so `0x555555554000` is what a
+# launch under gdb happens to produce on x86-64 Linux today -- and an ordinary attach to a running
+# process measured `0x5634df2d1000`. A constant that is right until it silently is not is worse than
+# a refusal, so the bias is read from the process and then checked against a second, independent
+# source before anything is armed.
+
+
+def _auxv_entry(pid):
+    """The entry point the KERNEL jumped to, from `/proc/<pid>/auxv` -- or None.
+
+    `AT_ENTRY` is the runtime address of the ELF's `e_entry`, so their difference is the load bias by
+    definition, for a PIE and a non-PIE alike. This is the same quantity gdb derives for itself
+    (see `_gdb_entry_point`), obtained a different way, which is what makes the two a cross-check
+    rather than one value read twice.
+
+    Deliberately NOT "the first mapping in `/proc/<pid>/maps`", which is the obvious reading and is
+    wrong on the very target this tool exists for: prosper maps the GUEST image low, so a live
+    `boot_trace`'s first three map lines are `410000000-...` and the executable's own text does not
+    appear until far down the file (measured 2026-08-17 on a PIE build; the real bias that run was
+    `0x55b927796000`). A maps-based derivation therefore has to match the executable by path -- with
+    `(deleted)` suffixes, symlinks and containers to get right -- while `AT_ENTRY` is one unambiguous
+    word the kernel wrote.
+    """
+    try:
+        with open("/proc/%d/auxv" % pid, "rb") as handle:
+            data = handle.read()
+    except OSError:
+        return None
+    width = 8                   # x86-64: two 8-byte words per auxv entry
+    for off in range(0, len(data) - 2 * width + 1, 2 * width):
+        key = int.from_bytes(data[off:off + width], "little")
+        if key == AT_ENTRY:
+            return int.from_bytes(data[off + width:off + 2 * width], "little")
+    return None
+
+
+def _gdb_entry_point():
+    """gdb's own view of the running entry point, from `info files` -- or None.
+
+    Measured on gdb 17.2: before the inferior exists this reports the file's link-time entry, and
+    once the main executable has been relocated it reports the runtime one. So it answers the same
+    question as `AT_ENTRY` through gdb's displacement logic instead of the kernel's auxv.
+    """
+    try:
+        text = gdb.execute("info files", to_string=True)
+    except gdb.error:
+        return None
+    match = re.search(r"Entry point:\s*(0x[0-9a-fA-F]+)", text)
+    return int(match.group(1), 16) if match else None
+
+
+def _symbol_landing(bias, sample_n=SYMBOL_CHECK_N):
+    """Do the biased addresses actually land on the functions they name? `(exact, named, total, misses)`
+
+    This is the check that makes a wrong bias fail LOUDLY instead of producing an empty histogram.
+    It asks gdb -- whose symbol table is relocated independently of the arithmetic above -- what
+    lives at each address this run is about to arm. A correct bias yields `<name> in section .text`;
+    a wrong one yields `No symbol matches` (unmapped) or `<other> + 19` (mid-function). Both are
+    caught, and the caller refuses the run.
+
+    `exact` (the address is a function START) is the criterion, not the name: identical-code folding
+    can put two handlers at one address, so gdb naming the other one there is not an error. `named`
+    is reported alongside it for the reader, never used to refuse.
+    """
+    total = min(sample_n, len(SYMS))
+    if not total:
+        return (0, 0, 0, [])
+    # Spread across the table rather than taking the first N: a bias that is wrong only for part of
+    # the image (a mismatched --binary, a rebuilt target) shows up at the far end.
+    picks = [i * len(SYMS) // total for i in range(total)]
+    exact = named = 0
+    misses = []
+    for i in picks:
+        addr, name = SYMS[i]
+        try:
+            text = gdb.execute("info symbol %#x" % (addr + bias), to_string=True).strip()
+        except gdb.error as exc:
+            text = "info symbol failed: %s" % exc
+        head = text.split(" in section ")[0]
+        if " in section " in text and not re.search(r"\+ \d+$", head):
+            exact += 1
+            if name in text:
+                named += 1
+        else:
+            misses.append("%s -> %#x -> %s" % (name, addr + bias, text.splitlines()[0][:120]))
+    return (exact, named, total, misses)
+
+
+def _resolve_load_bias():
+    """`(bias, note)` -- and in launch mode this is what first brings the process into existence.
+
+    The hard half of #2605 is that `--launch` arms every breakpoint BEFORE the process runs, which is
+    the entire point of the mode (it is the only way to cover init), so there is no base to read yet.
+    `starti` resolves that without giving anything up: it stops at the FIRST instruction of the
+    process, which on a dynamically linked binary is the loader's `_start` -- measured on gdb 17.2,
+    the stop is at `_start () from /lib64/ld-linux-x86-64.so.2` with the executable already mapped
+    (`/proc/<pid>/maps` shows it) and gdb's symbols already relocated. Nothing of the program has run,
+    so the window still opens where it did before: no instruction of init is lost.
+
+    Rejected alternatives, so they are not re-derived:
+      * assuming gdb's disabled-randomization base -- see the block comment above;
+      * arming at the entry point, stopping there, then arming the rest -- that DOES lose the
+        instructions before the entry point, and `starti` makes it unnecessary;
+      * letting gdb relocate symbol-spec breakpoints (`break 'prosper::s_user_getevent'`) instead of
+        addresses -- gdb would handle the bias, but the specs are ambiguous for exactly the symbols
+        this tool arms: every handler is `static` (nm reports `t`), anonymous-namespace names are
+        not unique across translation units under GCC's `_GLOBAL__N_1` mangling, and a name matching
+        several locations silently changes what a row counts. Addresses select one function; the
+        enumeration already picked which one.
+    """
+    if ELF_TYPE != ET_DYN:
+        return (0, "ET_EXEC: link-time addresses are runtime addresses")
+    if MODE == "launch":
+        try:
+            gdb.execute("starti")
+        except gdb.error as exc:
+            _abort("this target is a PIE (ET_DYN), so its load bias can only be read from the "
+                   "running process, and `starti` -- which stops at the first instruction, before "
+                   "anything of the program has run -- failed: %s. `starti` needs gdb 8.1 or newer. "
+                   "Either use a newer gdb, or build the target non-PIE "
+                   "(cmake -DCMAKE_EXE_LINKER_FLAGS=-no-pie)." % exc)
+    try:
+        pid = gdb.selected_inferior().pid
+    except Exception:
+        pid = 0
+    if not pid:
+        _abort("this target is a PIE (ET_DYN) and there is no live inferior to read a load bias "
+               "from, so every breakpoint would land in unmapped memory. Refusing rather than "
+               "reporting a window that armed nothing.")
+    kernel = _auxv_entry(pid)
+    debugger = _gdb_entry_point()
+    if kernel is None and debugger is None:
+        _abort("this target is a PIE (ET_DYN) and neither /proc/%d/auxv nor gdb's own `info files` "
+               "would give the running entry point, so the load bias cannot be derived. Refusing "
+               "rather than reporting a window that armed nothing." % pid)
+    if kernel is not None and debugger is not None and kernel != debugger:
+        # Two independent readings of one quantity. If they disagree, one of them is about a
+        # different image than the other, and picking either would be a guess.
+        _abort("the running entry point disagrees between its two sources: /proc/%d/auxv AT_ENTRY "
+               "is %#x and gdb's `info files` says %#x. One of them is describing a different image "
+               "(a mismatched --binary, or an exec this tool did not follow). Refusing rather than "
+               "picking one." % (pid, kernel, debugger))
+    entry = kernel if kernel is not None else debugger
+    bias = entry - ELF_ENTRY
+    return (bias, "ET_DYN: %#x = running entry %#x - link-time entry %#x, from %s"
+            % (bias, entry, ELF_ENTRY,
+               "/proc/<pid>/auxv AT_ENTRY (gdb agrees)" if kernel is not None and debugger is not None
+               else "/proc/<pid>/auxv AT_ENTRY" if kernel is not None else "gdb `info files`"))
+
+
 def _positive_control():
     """Forwards to the lifted, gdb-free verdict machine (#2053).
 
@@ -432,10 +621,41 @@ gdb.execute("set confirm off")
 gdb.execute("handle SIGSEGV SIGBUS SIGILL SIGFPE nostop noprint pass")
 gdb.events.exited.connect(_on_exited)
 
+if MODE == "launch" and INFERIOR_TTY:
+    # Before `starti`/`run`, because it takes effect when the inferior is created. Without it the
+    # inferior inherits gdb's stdout/stderr, which the driver holds on a pipe until the window
+    # closes: the emulator's ENTIRE run log would then sit in the driver's memory (a
+    # PROSPER_GFXLOG/PROSPER_DBG log reaches 1.5 GB, and exhausting memory on this box takes every
+    # concurrent lane's shell down with it). gdb's own stdout stays on the pipe — the result block
+    # is a few hundred bytes.
+    # `set inferior-tty` OPENS this path and does not create it, so the driver creates and truncates
+    # it first — otherwise gdb aborts at `run` with "No such file or directory" before a single
+    # breakpoint fires. It also redirects the inferior's stdin. The path is interpolated unquoted,
+    # so the driver refuses whitespace (gdb itself handles spaces fine — see the note there; the
+    # restriction is this driver's, not gdb's).
+    gdb.execute("set inferior-tty %s" % INFERIOR_TTY)
+
+# On a PIE this starts the inferior (stopped at its first instruction) so the base can be read; on
+# an ET_EXEC target it costs nothing and returns 0.
+LOAD_BIAS, bias_note = _resolve_load_bias()
+LAUNCH_STARTED = MODE == "launch" and ELF_TYPE == ET_DYN
+exact, named, checked, misses = _symbol_landing(LOAD_BIAS)
+print("hle_calls: load bias %#x — %s" % (LOAD_BIAS, bias_note))
+if checked and exact != checked:
+    # The bias is arithmetic; this is the observation. gdb's symbol table is relocated by gdb's own
+    # logic, so it is an independent answer to "is this address the function we think it is" — and
+    # it is the check that turns a wrong bias into a named refusal instead of a silent empty window.
+    _abort("%d of %d sampled handler addresses do not land on a function start at load bias %#x, so "
+           "arming them would measure nothing. The binary passed to --binary is not the one this "
+           "process is running, or its load bias could not be derived. Misses: %s"
+           % (checked - exact, checked, LOAD_BIAS, "; ".join(misses[:4])))
+print("hle_calls: symbol check %d/%d sampled addresses land exactly on a function start "
+      "(%d also match by name)" % (exact, checked, named))
+
 armed = 0
 for addr, name in SYMS:
     try:
-        _Counter(addr, name)
+        _Counter(addr + LOAD_BIAS, name)
         armed += 1
     except gdb.error as exc:  # a symbol the running binary does not actually have
         print("hle_calls: skip %s (%s)" % (name, exc))
@@ -445,25 +665,15 @@ try:
 except gdb.error as exc:
     raise SystemExit("hle_calls: cannot set the clock breakpoint on %s: %s" % (CLOCK, exc))
 
-print("hle_calls: armed %d handler breakpoints; window = %d entries of %s (mode=%s values=%s)"
-      % (armed, TICKS, CLOCK, MODE, "on" if VALUES else "off"))
+print("hle_calls: armed %d handler breakpoints at load bias %#x; window = %d entries of %s "
+      "(mode=%s values=%s)" % (armed, LOAD_BIAS, TICKS, CLOCK, MODE, "on" if VALUES else "off"))
 
 if MODE == "launch":
-    if INFERIOR_TTY:
-        # Without this the inferior inherits gdb's stdout/stderr, which the driver holds on a
-        # pipe until the window closes: the emulator's ENTIRE run log would then sit in the
-        # driver's memory (a PROSPER_GFXLOG/PROSPER_DBG log reaches 1.5 GB, and exhausting
-        # memory on this box takes every concurrent lane's shell down with it). gdb's own
-        # stdout stays on the pipe — the result block is a few hundred bytes.
-        # `set inferior-tty` OPENS this path and does not create it, so the driver creates and
-        # truncates it first — otherwise gdb aborts at `run` with "No such file or directory"
-        # before a single breakpoint fires. It also redirects the inferior's stdin. The path is
-        # interpolated unquoted, so the driver refuses whitespace (gdb itself handles spaces
-        # fine — see the note there; the restriction is this driver's, not gdb's).
-        gdb.execute("set inferior-tty %s" % INFERIOR_TTY)
-    # Every breakpoint above is already in place, so the window opens at the
-    # process's first instruction — which is the whole point of this mode.
-    gdb.execute("run")
+    # Every breakpoint above is already in place, so the window opens at the process's first
+    # instruction — which is the whole point of this mode. On a PIE the process is already stopped
+    # AT that first instruction (see _resolve_load_bias), so `continue` opens the same window `run`
+    # does; nothing of init has executed either way.
+    gdb.execute("continue" if LAUNCH_STARTED else "run")
 else:
     gdb.execute("continue")
 
@@ -481,11 +691,17 @@ if VALUES:
     source = " value-source=dwarf:%d,rax:%d" % (state["src_dwarf"], state["src_rax"])
 if OUT_BYTES:
     source += " out-bytes=%d" % OUT_BYTES
+# `elf=`/`load-bias=`/`symbol-check=` are in the header rather than only in the arming line above
+# because the driver forwards only this block to stdout. A reader must be able to tell WHERE the
+# breakpoints went from the result itself: on a PIE that is the difference between a histogram and a
+# window that armed nothing, and the pair of them is also what says the tool ran at all (#2605).
 print("clock=%s entries=%d/%d window=%s positive-control=%s armed=%d mode=%s calls=%d "
-      "finish-failures=%d exited=%d%s"
+      "finish-failures=%d exited=%d elf=%s load-bias=%#x symbol-check=%d/%d%s"
       % (CLOCK, state["ticks"], TICKS, "complete" if state["ticks"] >= TICKS else "SHORT",
          control, armed, MODE, state["calls"], state["finish_failures"],
-         1 if state["exited"] else 0, source))
+         1 if state["exited"] else 0,
+         "ET_DYN" if ELF_TYPE == ET_DYN else "ET_EXEC" if ELF_TYPE == ET_EXEC else "unknown",
+         LOAD_BIAS, exact, checked, source))
 # Only a verdict of `ok` needs no explanation. Every other state carries the one sentence that
 # says whether the run is usable, so the reader does not have to have the README open to know.
 if control_note:

--- a/prosper/tools/hle_calls/test_hle_calls_values.py
+++ b/prosper/tools/hle_calls/test_hle_calls_values.py
@@ -18,6 +18,18 @@ condition) and once with `-g` -- and runs the real driver over each. The two arm
 result more than self-agreement: the debug arm's values come from gdb's own ABI-aware decode, the
 stripped arm's from this tool's `%rax` read, and the test asserts they produce the SAME histogram.
 
+Three further arms guard the load-bias handling (#2605), and they are not interchangeable:
+
+  * `pie` — the same fixture built `-pie` must yield the SAME histogram as its `-no-pie` twin.
+  * `mismatched-binary` — a run whose `--binary` names a different image must be REFUSED by name.
+    This is the mutation arm for the landing check: without it the run also fails, but as an
+    unexplained `VOID` three steps from its cause.
+  * `attach-pie` — the only arm that can tell a *derived* bias from a hardcoded one. Under `--launch`
+    gdb disables randomization, so `0x555555554000` satisfies every launch-mode assertion above
+    (measured: a build with the bias replaced by that constant passes the `pie` arm in full and
+    fails only here). This arm reads the real base out of `/proc/<pid>/maps` itself and requires the
+    tool to have reported that number. It skips loudly where ptrace forbids attaching to a sibling.
+
 The price is a dependency on gdb, a C++ compiler, `nm` and `c++filt`. A missing one exits **77**,
 which CMake registers as `SKIP_RETURN_CODE`, so ctest reports the run as `(Skipped)` by name rather
 than as a pass. That distinction matters here more than usual: this repository already carries a
@@ -30,6 +42,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 DRIVER = os.path.join(HERE, "hle_calls.py")
@@ -90,14 +103,65 @@ def gdb_can_launch(gdb):
     return None
 
 
-def compile_fixture(cxx, out, debug, pie=False, optional=False):
-    """Build the fixture. `-no-pie` is load-bearing, not tidiness.
+def attach_is_permitted(gdb):
+    """Can this gdb ptrace-attach to a SIBLING process here? `None` if it can, a reason if not.
 
-    hle_calls arms breakpoints at the raw link-time addresses `nm` reports, so the target must be
-    `ET_EXEC` -- as prosper's own binaries are. Ubuntu's gcc defaults to `-pie` while Fedora's does
-    not, so a fixture built without this flag is a different program on the two, and the CI arm of
-    this very test failed that way (`Cannot access memory at address 0x1149`, no result block) while
-    passing locally. The `pie=True` arm below exists to pin the REFUSAL that now replaces that spew.
+    Asked rather than inferred from a failed run. `kernel.yama.ptrace_scope=1` -- Ubuntu's default,
+    and therefore CI's -- permits attaching only to descendants, and gdb is a child of the driver
+    while the fixture is a child of this test, so they are siblings and the attach is refused. That
+    is an environment fact, not a regression in the tool, and it must not read as one.
+    """
+    child = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"],
+                             stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    try:
+        probe = subprocess.run([gdb, "-p", str(child.pid), "-batch", "-ex", "quit"],
+                               capture_output=True, text=True, timeout=60)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "gdb could not be run for an attach probe: %s" % exc
+    finally:
+        child.kill()
+        child.wait()
+    text = (probe.stderr + probe.stdout).strip()
+    if probe.returncode != 0 or "ptrace" in text or "not permitted" in text:
+        return ("this gdb cannot attach to a sibling process here (kernel.yama.ptrace_scope?): %s"
+                % (text.splitlines()[-1][:160] if text else "gdb said nothing, exit %d"
+                   % probe.returncode))
+    return None
+
+
+def executable_base(pid, path):
+    """The load address of `path` in `pid`, read straight out of `/proc/<pid>/maps` -- or None.
+
+    Deliberately a SECOND, independent derivation of the number the tool reports: the tool reads
+    `AT_ENTRY` out of auxv and subtracts the ELF's link-time entry, while this matches the mapping by
+    pathname and takes its lowest start. Both must land on the same address. (The tool does not use
+    this method itself because prosper maps the guest image low, so the first line of a live
+    `boot_trace`'s maps is a guest mapping, not the executable.)
+    """
+    lowest = None
+    try:
+        with open("/proc/%d/maps" % pid) as handle:
+            for line in handle:
+                parts = line.split()
+                if len(parts) >= 6 and os.path.realpath(parts[-1]) == os.path.realpath(path):
+                    start = int(parts[0].split("-")[0], 16)
+                    lowest = start if lowest is None else min(lowest, start)
+    except OSError:
+        return None
+    return lowest
+
+
+def compile_fixture(cxx, out, debug, pie=False, optional=False):
+    """Build the fixture. The linkage is stated explicitly because BOTH shapes have to be covered.
+
+    hle_calls arms breakpoints at the raw link-time addresses `nm` reports. On an `ET_EXEC` target
+    those are the runtime addresses; on a PIE they are offsets from a base the kernel picks per run,
+    and the tool has to read that base out of the live process (#2605). Ubuntu's gcc defaults to
+    `-pie` while Fedora's does not, so a fixture built without an explicit flag is a DIFFERENT
+    program on the two -- which is how the CI arm of this very test once failed
+    (`Cannot access memory at address 0x1149`, no result block) while passing locally. Pinning the
+    flag makes each arm mean one thing, and the `pie=True` arms below cover the shape this box does
+    not produce by default.
     """
     cmd = [cxx, "-O0", "-g" if debug else "-g0",
            "-fPIE" if pie else "-fno-pie", "-pie" if pie else "-no-pie",
@@ -113,13 +177,19 @@ def compile_fixture(cxx, out, debug, pie=False, optional=False):
     return True
 
 
-def run_arm(binary, ticks=12, out_bytes=0):
-    """Run the real driver over one fixture build; return (header_fields, rows, outs, raw)."""
+def run_arm(binary, ticks=12, out_bytes=0, pid=None, symbols=None):
+    """Run the real driver over one fixture build; return (header_fields, rows, outs, raw).
+
+    `pid` attaches to an already-running process instead of launching one; `symbols` overrides
+    `--binary`, which is how the mismatched-binary arm below builds a wrong address by hand.
+    """
     cmd = [sys.executable, DRIVER, "--ticks", str(ticks), "--values", "--order", "8",
            "--filter", "^s_", "--timeout", "180"]
     if out_bytes:
         cmd += ["--out-bytes", str(out_bytes)]
-    cmd += ["--launch", binary]
+    if symbols:
+        cmd += ["--binary", symbols]
+    cmd += ["--pid", str(pid)] if pid else ["--launch", binary]
     done = subprocess.run(cmd, capture_output=True, text=True)
     raw = done.stdout + done.stderr
     fields, rows, outs = {}, {}, {}
@@ -154,13 +224,33 @@ def run_arm(binary, ticks=12, out_bytes=0):
     return fields, rows, outs, raw
 
 
-def check_arm(label, fields, rows, raw, expect_source):
+def check_arm(label, fields, rows, raw, expect_source, expect_elf="ET_EXEC", expect_mode="launch"):
     if not fields:
         check(False, "%s: the driver produced a result block\n%s" % (label, raw[-2000:]))
         return
     check(fields.get("window") == "complete" and fields.get("exited") == "0",
           "%s: the window closed on the clock, not on an exit (window=%s exited=%s)"
           % (label, fields.get("window"), fields.get("exited")))
+    # WHERE the breakpoints went. On an ET_EXEC target the bias must be exactly zero -- a non-zero
+    # one there would mean the tool relocated addresses that were already runtime addresses -- and on
+    # a PIE it must not be, because every link-time address is an offset (#2605). The symbol check
+    # is the observation behind both: gdb was asked what lives at each sampled armed address.
+    check(fields.get("elf") == expect_elf,
+          "%s: the header states the target's linkage (elf=%s, expected %s)"
+          % (label, fields.get("elf"), expect_elf))
+    bias = fields.get("load-bias", "")
+    if expect_elf == "ET_DYN":
+        check(bias.startswith("0x") and int(bias, 16) != 0,
+              "%s: a PIE run reports the load bias it resolved (load-bias=%s)" % (label, bias))
+    else:
+        check(bias == "0x0", "%s: an ET_EXEC run relocates nothing (load-bias=%s)" % (label, bias))
+    checked = fields.get("symbol-check", "")
+    match = re.fullmatch(r"(\d+)/(\d+)", checked)
+    check(bool(match) and match.group(1) == match.group(2) and int(match.group(2)) > 0,
+          "%s: every sampled armed address landed on a function start (symbol-check=%s)"
+          % (label, checked))
+    check(fields.get("mode") == expect_mode,
+          "%s: the run used the mode asked for (mode=%s)" % (label, fields.get("mode")))
     # THE regression. On master this reads finish-failures=<calls>, and every row (captured 0/N).
     check(fields.get("finish-failures") == "0",
           "%s: no capture failed (finish-failures=%s of calls=%s)"
@@ -303,7 +393,7 @@ def main():
         # the configuration on which every value capture failed.
         arms = (("no-debug-info", os.path.join(work, "fixture_nodbg"), False, "rax"),
                 ("debug-info", os.path.join(work, "fixture_dbg"), True, "dwarf"))
-        built = {}
+        built, measured = {}, {}
         for label, path, debug, expect in arms:
             if not compile_fixture(cxx, path, debug):
                 global fails
@@ -311,6 +401,7 @@ def main():
                 continue
             built[label] = path
             fields, rows, outs, raw = run_arm(path)
+            measured[label] = (fields, rows)
             check_arm(label, fields, rows, raw, expect)
         # Third arm: the same no-debug-info binary, now with --out-bytes. Run apart from the two
         # above so the default path (out-bytes off) stays covered rather than only the new one.
@@ -318,32 +409,95 @@ def main():
             fields, rows, outs, raw = run_arm(built["no-debug-info"], out_bytes=12)
             check_out_arm(fields, rows, outs, raw)
 
-        # Fourth arm: a PIE build must be REFUSED by name, not attempted. Every address this tool
-        # arms is a link-time address, so on a PIE they are offsets and each breakpoint lands in
-        # unmapped memory -- gdb then prints "Cannot insert breakpoint N" per handler and the run
-        # produces no result block, which is three steps from naming its own cause. This arm is here
-        # because that is exactly how the test failed on a GitHub ubuntu-24.04 runner while passing
-        # on Fedora: the two toolchains disagree on the -pie default, so the fixture was a different
-        # program on each.
+        # Fourth arm: a PIE build must produce the SAME measurement as its -no-pie twin (#2605).
+        # Every address this tool arms is a link-time address, so on a PIE they are offsets from a
+        # base the kernel picks per run; unrelocated, each breakpoint lands in unmapped memory and
+        # gdb prints "Cannot insert breakpoint N" per handler with no result block at the end --
+        # which is exactly how this test failed on a GitHub ubuntu-24.04 runner while passing on
+        # Fedora, the two toolchains disagreeing on the -pie default. #2593 replaced that with a
+        # refusal; this arm is the refusal's replacement, and the histogram equality below is what
+        # makes it a measurement rather than merely a non-crash.
         pie_path = os.path.join(work, "fixture_pie")
-        if compile_fixture(cxx, pie_path, debug=False, pie=True, optional=True):
+        have_pie = compile_fixture(cxx, pie_path, debug=False, pie=True, optional=True)
+        if have_pie:
+            fields, rows, _, raw = run_arm(pie_path)
+            check_arm("pie", fields, rows, raw, "rax", expect_elf="ET_DYN")
+            if "no-debug-info" in measured:
+                twin_fields, twin_rows = measured["no-debug-info"]
+                # The fixture calls each handler exactly once per loop and the clock closes the
+                # window at the end of the 12th, so the histogram is a fixed number -- and the two
+                # linkages must agree on all of it, name for name and count for count. A bias that
+                # is wrong by any amount cannot produce this: it produces no result block at all.
+                check(rows and {n: r["calls"] for n, r in rows.items()}
+                      == {n: r["calls"] for n, r in twin_rows.items()},
+                      "pie: the PIE histogram equals its -no-pie twin's, handler for handler (%s vs %s)"
+                      % (sorted((n, r["calls"]) for n, r in rows.items()),
+                         sorted((n, r["calls"]) for n, r in twin_rows.items())))
+                check(twin_fields.get("load-bias") == "0x0" and fields.get("load-bias", "0x0") != "0x0",
+                      "pie: and it got there through a non-zero bias its twin did not need "
+                      "(pie=%s no-pie=%s)" % (fields.get("load-bias"), twin_fields.get("load-bias")))
+
+        # Fifth arm: the check that makes a WRONG address refuse instead of measuring nothing.
+        # Constructed by hand rather than by disabling the fix: launch the PIE fixture while naming
+        # its -no-pie twin as the symbol source. The addresses are then real, well-formed, and about
+        # a different image -- the shape a stale --binary or a rebuilt target produces -- and every
+        # one of them lands in unmapped memory. Without this arm, "the PIE arm passed" would say
+        # nothing about whether a wrong bias is detectable at all.
+        if have_pie and "no-debug-info" in built:
             done = subprocess.run([sys.executable, DRIVER, "--ticks", "4", "--values",
-                                   "--filter", "^s_", "--timeout", "60", "--launch", pie_path],
+                                   "--filter", "^s_", "--timeout", "60",
+                                   "--binary", built["no-debug-info"], "--launch", pie_path],
                                   capture_output=True, text=True)
             message = done.stdout + done.stderr
+            # Note which of these three is load-bearing. A run with the landing check REMOVED also
+            # exits non-zero and also emits no result block -- gdb fails to insert the breakpoints
+            # and the driver reports VOID -- so those two pass either way and prove nothing on their
+            # own (measured: with `_symbol_landing` neutered, only the second check below fails).
+            # The two that discriminate are the abort line, which only the check can print, and the
+            # absence of gdb's insertion error, which only reaching the arming step can produce.
             check(done.returncode != 0,
-                  "pie: the driver refuses a PIE target (exit %d)" % done.returncode)
-            check("position-independent" in message and "-no-pie" in message,
-                  "pie: and the refusal names the cause and the fix (%s)"
-                  % message.strip().splitlines()[-1][:160] if message.strip() else "pie: no message")
-            # The refusal must come BEFORE any work, and the tell has to be a string only the
-            # not-taken path can print. Two earlier attempts here were void for exactly the reason
-            # this test exists to catch: "Cannot insert breakpoint" and "armed" both appear in the
-            # refusal itself, which QUOTES the gdb error it is preventing -- so each check would
-            # have passed or failed on the wording of the message rather than on the behaviour.
-            # `hle_calls: N handler symbols in ...` is printed only once enumeration has run.
-            check("handler symbols in" not in message,
-                  "pie: it refuses before enumerating handlers or starting gdb")
+                  "mismatched-binary: the run is refused (exit %d)" % done.returncode)
+            check("HLE_CALLS_ABORT:" in message and "do not land on a function start" in message,
+                  "mismatched-binary: and it says which check failed (%s)"
+                  % next((l for l in message.splitlines() if "ABORT" in l), "no abort line")[:200])
+            check("Cannot insert breakpoint" not in message,
+                  "mismatched-binary: it refused BEFORE arming — gdb never tried to insert a "
+                  "breakpoint into unmapped memory")
+            check("clock=" not in done.stdout,
+                  "mismatched-binary: no result block was produced — nothing was measured")
+
+        # Sixth arm: --pid against a PIE with the kernel's own randomization in play. This is the
+        # arm that separates a DERIVED bias from a hardcoded one: under gdb the base is
+        # 0x555555554000 every time (gdb disables randomization), so a constant would satisfy every
+        # launch-mode assertion above. Here the test reads the real base out of /proc itself and
+        # requires the tool to have reported that number.
+        if have_pie:
+            reason = attach_is_permitted(gdb)
+            if reason:
+                print("  [skip] attach-pie: %s" % reason)
+                print("         Nothing else in this test can tell a derived load bias from a "
+                      "hardcoded one, so that distinction is UNCHECKED on this machine.")
+            else:
+                child = subprocess.Popen([pie_path], stdout=subprocess.DEVNULL,
+                                         stderr=subprocess.DEVNULL)
+                try:
+                    time.sleep(1.0)
+                    base = executable_base(child.pid, pie_path)
+                    fields, rows, _, raw = run_arm(pie_path, pid=child.pid)
+                    check(base is not None and fields.get("load-bias") == "%#x" % base,
+                          "attach-pie: the reported bias is the base this process actually got "
+                          "(reported=%s /proc says=%s)"
+                          % (fields.get("load-bias"), None if base is None else "%#x" % base))
+                    check(sum(r["calls"] for r in rows.values()) > 0
+                          and fields.get("window") == "complete",
+                          "attach-pie: and the window measured real calls (window=%s calls=%s)"
+                          % (fields.get("window"), fields.get("calls")))
+                    check(fields.get("elf") == "ET_DYN" and fields.get("mode") == "attach",
+                          "attach-pie: on a PIE target, in attach mode (elf=%s mode=%s)"
+                          % (fields.get("elf"), fields.get("mode")))
+                finally:
+                    child.kill()
+                    child.wait()
     finally:
         shutil.rmtree(work, ignore_errors=True)
 


### PR DESCRIPTION
Fixes #2605
Refs #2593

## The failure scenario

`hle_calls` armed every breakpoint at the raw link-time address `nm` reports, which is the runtime
address **only on an `ET_EXEC` binary**. Ubuntu's gcc defaults to `-pie` and Fedora's does not, so
the same source produces a target this tool could not touch on one of the two — and before #2593 it
did not say so, it produced `Cannot insert breakpoint N` per handler and no result block. #2593
replaced that with a refusal by name. **This replaces the refusal with the bias.**

## Behavioral contract and the approach

Both modes now work, on both linkages:

- **`--pid`** reads the base from the attached process.
- **`--launch`** — the half the issue called hard, because breakpoints are armed BEFORE the process
  exists — issues `starti` first. That stops at the FIRST instruction of the process (the dynamic
  loader's `_start`), with the executable already mapped and gdb's symbols already relocated, so the
  base is readable and **no init coverage is lost**: nothing of the program has run. The window opens
  exactly where it did before, and the built-in once-per-process LOGIN control
  (`positive-control=ok`) is what says so.

### The base is read, never assumed

It is `AT_ENTRY` from `/proc/<pid>/auxv` minus the ELF's own `e_entry`, cross-checked against gdb's
independent `info files` entry point; **the two must agree or the run is refused.**

`AT_ENTRY` rather than "the first mapping in `/proc/<pid>/maps`" because that obvious reading is
wrong on the very target this tool exists for: prosper maps the guest image low, so a live
`boot_trace`'s first map lines are `410000000-...` and the executable's own text appears far down the
file.

### The arithmetic is checked against an observation before anything is armed

gdb is asked what lives at a sample of the addresses about to be armed, and **each must name a
function *start***. A wrong bias — or a `--binary` that is not the image the process is running —
fails that and the run aborts with
`HLE_CALLS_ABORT: ... do not land on a function start ...` instead of measuring nothing.

The header carries the outcome, so a reader can tell where the breakpoints went from the result
alone:

```
... exited=0 elf=ET_DYN load-bias=0x555555554000 symbol-check=8/8
```

The driver also forwards gdb's own `hle_calls:` lines to stderr; they were previously visible only
when a run produced nothing at all, i.e. exactly when it was too late.

## Rejected alternatives, recorded in `_resolve_load_bias` so they are not re-derived

- **Assuming gdb's disabled-randomization base** — right until it silently is not; a plain attach
  measured `0x5634df2d1000`.
- **Arming at the entry point and stopping there** — loses the instructions before it, and `starti`
  makes it unnecessary.
- **Letting gdb relocate symbol-spec breakpoints** — would handle the bias but is ambiguous for
  exactly these symbols: every handler is `static`, and GCC's `_GLOBAL__N_1` anonymous-namespace
  mangling is not unique across translation units, so a spec matching several locations would
  silently change what a row counts.

## Evidence

On a PIE `boot_trace` built for this (`-DCMAKE_POSITION_INDEPENDENT_CODE=ON
-DCMAKE_EXE_LINKER_FLAGS=-pie`), against `PPSA24651`:

- **`--launch`**: 157 handlers armed at bias `0x555555554000` (= running entry `0x55555557e8b0`
  minus link-time entry `0x2a8b0`), and the whole result block is **byte-identical to the `ET_EXEC`
  twin's** apart from the two new fields — same 11 rows, same counts, same first-calls, same return
  values. Master refuses this binary outright.
- **`--pid`** against the same binary running with real ASLR: bias `0x5616694a4000`, matching the
  base read independently out of `/proc/<pid>/maps`.

## Tests, and why the arms are not interchangeable

Added to `hle_calls_value_capture`:

- **`pie`** — the `-pie` fixture must yield the same histogram as its `-no-pie` twin. (This is the
  arm #2605 named as the acceptance criterion: the refusal arm becomes the positive arm.)
- **`mismatched-binary`** — naming a different image as `--binary` must be refused **by name, before
  arming**. Two of its four checks pass either way (the run fails regardless); the two that
  discriminate are the abort line and the absence of gdb's insertion error, and the comment says
  which.
- **`attach-pie`** — the only arm that separates a **DERIVED** bias from a hardcoded one. Under
  `--launch` gdb disables randomization, so a constant satisfies every launch assertion; this arm
  reads the real base out of `/proc/<pid>/maps` itself and requires the tool to have reported that
  number. It **skips loudly** where ptrace forbids a sibling attach.

**Mutation arms, run against the committed test:**

| mutation | result |
| --- | --- |
| bias forced to 0 (master's behaviour) | 6 failures — the whole `pie` and `attach-pie` arms |
| bias replaced by gdb's `0x555555554000`, rest of the flow intact | `pie` passes **IN FULL**, including the histogram equality and `positive-control=ok`; only `attach-pie` fails (3) |
| landing check neutered | 2 failures, both in `mismatched-binary` — the abort line and the "refused before arming" check |

The second row is `attach-pie`'s whole reason for existing: a hardcoded constant is indistinguishable
from a derived bias under `--launch`, and only an attach against real ASLR separates them.

## Affected and deliberately unaffected

- **Affected:** `tools/hle_calls` only — a developer instrument. Both `--launch` and `--pid` now
  resolve and apply a load bias, and `--launch` now issues `starti`.
- **Deliberately unaffected:** the `ET_EXEC` path's output, which the byte-identical result-block
  comparison above pins; nothing in `prosper/src` is touched, so no emulator behavior changes.

## Risks

- **`--launch` now issues `starti`.** The claim that this loses no init coverage rests on `starti`
  stopping at the loader's `_start` before any program instruction runs; the built-in LOGIN
  positive control (`positive-control=ok`) is the standing check that the window still opens where it
  did.
- `attach-pie` depends on ptrace permitting a sibling attach. It skips loudly rather than passing
  vacuously where it does not, but on such a box the derived-vs-hardcoded discrimination is not
  exercised.
- The bias derivation reads `/proc/<pid>/auxv`, so it is Linux-specific — as the tool already was
  (it drives gdb).

## Verification (local; author-run)

```
ctest --no-tests=error -j4       -> 265/265 passed, exit 0
hle_calls_value_capture          -> 73 checks, all pass, 2.7 s
```

Baseline on `origin/master` `ec2c0c22`: **265/265 passed, exit 0** — this PR adds arms to an existing
case rather than a new binary, so the count is unchanged.

**No CI evidence is quoted: CI has not run on this branch.**
