### PR TITLE
fix(videoout): build test_videoout on Windows, and stop WaitVblank inheriting the Win32 timer tick

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1502,6 +1502,18 @@ if(TARGET prosper_core)
   target_link_libraries(test_agc_submit PRIVATE prosper_core)
   add_test(NAME agc_submit_to_gpustate COMMAND test_agc_submit)
 
+  # libSceVideoOut: query/config functions return real 1080p60 values + swapchain-scaffolding
+  # display-buffer registry records the game's registered framebuffers.
+  #
+  # CROSS-PLATFORM on purpose (#1765). This sat inside the if(UNIX) block below, so the one platform
+  # whose display pacing is at risk was the one platform that did not build it: sceVideoOutWaitVblank
+  # waits on a deadline, and on Windows that wait is quantized by the process timer period. Nothing
+  # here is POSIX-specific -- it drives the HLE registry and asserts returned values -- so the gate
+  # was incidental rather than a statement about the test.
+  add_executable(test_videoout tests/test_videoout.cpp)
+  target_link_libraries(test_videoout PRIVATE prosper_core)
+  add_test(NAME videoout_queries COMMAND test_videoout)
+
   # Windows guest-execution substrate (exec_image_win.cpp): build boot_trace so the whole boot path
   # links (proves the substrate + SysV-ABI HLE boundary resolve). No evdev/Vulkan here. The guest boot
   # itself is not yet verified on Windows — see docs/PORTING.md "Windows".
@@ -1691,12 +1703,6 @@ if(TARGET prosper_core)
     add_executable(test_agc_epilogue_window tests/test_agc_epilogue_window.cpp)
     target_link_libraries(test_agc_epilogue_window PRIVATE prosper_core)
     add_test(NAME agc_epilogue_window COMMAND test_agc_epilogue_window)
-
-    # libSceVideoOut: query/config functions return real 1080p60 values + swapchain-scaffolding
-    # display-buffer registry records the game's registered framebuffers.
-    add_executable(test_videoout tests/test_videoout.cpp)
-    target_link_libraries(test_videoout PRIVATE prosper_core)
-    add_test(NAME videoout_queries COMMAND test_videoout)
 
     # libSceVideoOut flip->present: SubmitFlip scans out the registered buffer; present_readback
     # returns the presented frame's real pixels. The surface the renderer presents frames to.

--- a/prosper/src/hle/hle_graphics.cpp
+++ b/prosper/src/hle/hle_graphics.cpp
@@ -18,6 +18,7 @@
 #include "gpu/gpu_execute.hpp"      // guest_readable (safe pointer probe for the diagnostic dumps)
 #include "gpu/tile.hpp"             // de-swizzle a TILE-mode scanout into a linear image
 #include "host/guest_memory_map.hpp" // guest_readable_mapping_containing (real over-read proof)
+#include "host/precise_sleep.hpp"   // #1765: a vblank wait whose resolution is not the Win32 tick
 #include <cstdlib>
 #include <cstring>
 #include <cerrno>
@@ -755,9 +756,11 @@ void vblank_sleep_until_ns(uint64_t deadline_ns) {
         g_vblank_test_now_ns.store(deadline_ns, std::memory_order_relaxed);
         return;
     }
-    std::this_thread::sleep_until(std::chrono::steady_clock::time_point(
-        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-            std::chrono::nanoseconds(deadline_ns))));
+    // NOT std::this_thread::sleep_until: on Windows that is one ::Sleep(ms), which the system timer
+    // period quantizes to ~15.6 ms steps, so this ~16.68 ms wait cost ~31 ms and paced a title's
+    // display thread at ~32 Hz (#1765). host::sleep_until_steady_ns keeps the deadline semantics and
+    // picks a primitive that does not inherit that period; on POSIX it still is sleep_until.
+    host::sleep_until_steady_ns(deadline_ns);
 }
 }  // namespace
 
@@ -827,9 +830,9 @@ HLE(g_vo_wait_vblank) {
     // Next strictly-future boundary: a caller that is already exactly on one still waits a full
     // period, which is what "wait for the NEXT vblank" means.
     const uint64_t next = t0 + ((now - t0) / kVblankNs + 1) * kVblankNs;
-    // F5: vblank_sleep_until_ns uses duration_cast rather than a nanoseconds->time_point
-    // construction, which only compiles because steady_clock::duration happens to be nanoseconds
-    // on every toolchain we build with.
+    // F5: the deadline crosses into host::sleep_until_steady_ns as a plain nanosecond count, and the
+    // duration_cast back to a steady_clock::time_point happens there — see precise_sleep.cpp, which
+    // also records why this is not a bare std::this_thread::sleep_until on Windows (#1765).
     vblank_sleep_until_ns(next);
     return 0;
 }

--- a/prosper/src/host/precise_sleep.cpp
+++ b/prosper/src/host/precise_sleep.cpp
@@ -1,0 +1,150 @@
+// precise_sleep — block until a steady-clock deadline with a wait primitive whose resolution does
+// not depend on the process's Win32 timer period (#1765).
+//
+// WHY THIS IS NOT `std::this_thread::sleep_until`, on Windows only. Three facts compose:
+//
+//  1. libstdc++'s `sleep_until` on a STEADY clock forwards to `sleep_for(deadline - now)` and
+//     returns — it does not re-check the clock (`bits/this_thread_sleep.h`).
+//  2. On mingw-w64 libstdc++ is configured with `_GLIBCXX_USE_NANOSLEEP`, `_GLIBCXX_HAVE_SLEEP` and
+//     `_GLIBCXX_HAVE_USLEEP` all UNdefined and `_GLIBCXX_USE_WIN32_SLEEP` defined, so `sleep_for`
+//     ends in exactly one `::Sleep(DWORD milliseconds)`. Read from `bits/c++config.h`, and
+//     confirmed against the shipped library: `libstdc++.a(thread.o)` names exactly one sleep-ish
+//     import, `__imp_Sleep`, and `__sleep_for` tail-calls it.
+//  3. Windows quantizes `::Sleep` to the system timer period, and nothing in this tree raises it
+//     (`timeBeginPeriod` / `NtSetTimerResolution` appear nowhere outside `third_party/`). prosper's
+//     own measurement on a Windows host — recorded in `tests/test_win_exception_delivery.cpp` for
+//     #2242 — is `Sleep(1)` = 15.554 ms by default against 1.930 ms after `timeBeginPeriod(1)`.
+//
+// So a ~16.68 ms display-pacing wait became `::Sleep(17)`, which cannot complete before the second
+// ~15.6 ms tick: roughly 31 ms, i.e. a display thread paced at ~32 Hz instead of ~60. The waitable
+// timer below is scheduled off the high-resolution timer wheel instead, so its expiry does not wait
+// for the coarse tick and the process-wide timer period is left alone (raising it globally costs
+// power and perturbs every other timer in the process).
+//
+// CONFIDENCE: HIGH on the mechanism — (1) and (2) are read from the toolchain's own headers,
+// generated config and compiled library, (3) from a measurement already in this repository.
+// CONFIDENCE: MED on the resulting numbers for any particular Windows host: the author could not
+// execute on Windows, so the improvement from ~31 ms to ~16.7 ms per wait is derived rather than
+// observed. The fallback keeps the previous behaviour if the timer cannot be created, so the worst
+// case is what master already does.
+#ifdef _WIN32
+// Must precede EVERY header, including <chrono>/<thread>: those pull in MinGW's _mingw.h, which
+// defaults _WIN32_WINNT to 0x0601, after which a later `#ifndef _WIN32_WINNT` is a silent no-op and
+// CreateWaitableTimerExW goes undeclared. Same placement rule as hle_kernel.cpp, hle_kernel_mem.cpp
+// and exec_image_win.cpp.
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+// Windows 10 1803+. Defined defensively: an older mingw-w64 header set declares
+// CreateWaitableTimerExW without this flag, and the value is part of the published contract.
+#ifndef CREATE_WAITABLE_TIMER_HIGH_RESOLUTION
+#define CREATE_WAITABLE_TIMER_HIGH_RESOLUTION 0x00000002
+#endif
+#endif  // _WIN32
+
+#include "precise_sleep.hpp"
+
+#include <chrono>
+#include <thread>
+
+namespace prosper::host {
+namespace {
+
+thread_local SleepBackend g_backend = SleepBackend::None;
+
+uint64_t steady_now_ns() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+void sleep_until_with_std(uint64_t deadline_ns) {
+    std::this_thread::sleep_until(std::chrono::steady_clock::time_point(
+        std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+            std::chrono::nanoseconds(deadline_ns))));
+}
+
+#ifdef _WIN32
+// One auto-reset timer per waiting thread. Auto-reset so the wait itself consumes the signal and no
+// stale signalled state can make the NEXT wait return instantly.
+struct ThreadTimer {
+    HANDLE handle = nullptr;
+    ThreadTimer() {
+        handle = CreateWaitableTimerExW(nullptr, nullptr,
+                                        CREATE_WAITABLE_TIMER_HIGH_RESOLUTION,
+                                        TIMER_ALL_ACCESS);
+    }
+    ~ThreadTimer() { if (handle) CloseHandle(handle); }
+    ThreadTimer(const ThreadTimer&) = delete;
+    ThreadTimer& operator=(const ThreadTimer&) = delete;
+};
+thread_local ThreadTimer g_timer;
+#endif
+
+}  // namespace
+
+void sleep_until_steady_ns(uint64_t deadline_ns) {
+#ifdef _WIN32
+    for (;;) {
+        const uint64_t now = steady_now_ns();
+        if (now >= deadline_ns) return;
+        const uint64_t remaining_ns = deadline_ns - now;
+        if (!g_timer.handle) break;   // no high-resolution timer on this system
+
+        LARGE_INTEGER due;
+        // NEGATIVE is a relative interval in 100 ns units; a positive value would be an absolute
+        // FILETIME, i.e. a wait until the year 1601 — which returns instantly and would silently
+        // turn this into a spin. Round the division UP so the timer can never expire early.
+        due.QuadPart = -(LONGLONG)((remaining_ns + 99) / 100);
+        if (due.QuadPart == 0) due.QuadPart = -1;
+        // The timeout is a safety net, not the pacing mechanism: the timer object signals first on
+        // every healthy wait, so this only bounds a wait that would otherwise hang. It is itself
+        // tick-quantized, hence the generous slack.
+        const uint64_t timeout_ms = remaining_ns / 1000000ull + 100ull;
+        if (!SetWaitableTimer(g_timer.handle, &due, 0, nullptr, nullptr, FALSE)) break;
+        // Only a real signal counts as the high-resolution path. WAIT_TIMEOUT means the safety net
+        // fired instead, which is a tick-quantized wake and must not be labelled as the timer's --
+        // it also means the deadline is long past, so the re-check below returns without sleeping
+        // again.
+        if (WaitForSingleObject(g_timer.handle,
+                                timeout_ms > 0xFFFFFFFEull ? INFINITE : (DWORD)timeout_ms)
+                != WAIT_OBJECT_0)
+            break;
+        g_backend = SleepBackend::Win32HighResolutionTimer;
+        // Loop rather than return: a waitable timer may be released marginally early, and the
+        // contract here is "do not come back before the deadline". The re-read of the clock makes
+        // that true without trusting the primitive's own precision.
+    }
+    // Anything above that did not work out lands here — no worse than master's behaviour, and
+    // reported distinctly so a test can tell the two apart rather than silently pacing at ~32 Hz.
+    if (steady_now_ns() >= deadline_ns) return;
+    sleep_until_with_std(deadline_ns);
+    g_backend = SleepBackend::Win32SleepFallback;
+#else
+    // glibc: sleep_until -> sleep_for -> a nanosleep loop that also restarts on EINTR, which matters
+    // because prosper delivers its own signals. Deliberately a single call, identical to what this
+    // path did before precise_sleep existed.
+    sleep_until_with_std(deadline_ns);
+    g_backend = SleepBackend::PosixSleepUntil;
+#endif
+}
+
+SleepBackend sleep_backend() { return g_backend; }
+
+const char* sleep_backend_name() {
+    switch (g_backend) {
+        case SleepBackend::PosixSleepUntil:          return "posix-sleep-until";
+        case SleepBackend::Win32HighResolutionTimer: return "win32-high-resolution-timer";
+        case SleepBackend::Win32SleepFallback:       return "win32-sleep-fallback";
+        case SleepBackend::None:                     break;
+    }
+    return "none";
+}
+
+}  // namespace prosper::host

--- a/prosper/src/host/precise_sleep.hpp
+++ b/prosper/src/host/precise_sleep.hpp
@@ -1,0 +1,30 @@
+// precise_sleep — block until a deadline on std::chrono::steady_clock, without inheriting the
+// Win32 process timer period. See precise_sleep.cpp for why this exists rather than a bare
+// std::this_thread::sleep_until (#1765).
+#pragma once
+#include <cstdint>
+
+namespace prosper::host {
+
+// Which primitive the calling thread's most recently completed sleep_until_steady_ns() used.
+// Thread-local and diagnostic: a thread that has not slept yet reports None. It exists so a test
+// can assert the MECHANISM — that the high-resolution path is actually in force — instead of
+// asserting a wall-clock duration, which on a loaded host is a future flake (see the note in
+// test_videoout.cpp about #1770/#1793).
+enum class SleepBackend {
+    None,                       // this thread has not completed a wait yet
+    PosixSleepUntil,            // std::this_thread::sleep_until (glibc: a nanosleep loop)
+    Win32HighResolutionTimer,   // CREATE_WAITABLE_TIMER_HIGH_RESOLUTION waitable timer
+    Win32SleepFallback,         // the timer was unavailable; ::Sleep(ms) quantization is in force
+};
+
+// Block until `deadline_ns`, measured on std::chrono::steady_clock's epoch in nanoseconds. Returns
+// immediately if the deadline has already passed.
+void sleep_until_steady_ns(uint64_t deadline_ns);
+
+SleepBackend sleep_backend();
+
+// A stable spelling of sleep_backend() for assertions and logs. Never null.
+const char* sleep_backend_name();
+
+}  // namespace prosper::host

--- a/prosper/tests/test_videoout.cpp
+++ b/prosper/tests/test_videoout.cpp
@@ -6,6 +6,7 @@
 #include "../src/gpu/videoout_present.hpp"
 #include "../src/gpu/tile.hpp"              // tile/detile round trip for the flipped-buffer image
 #include "../src/host/guest_memory_map.hpp" // the registered-mapping proof for the padded read
+#include "../src/host/precise_sleep.hpp"    // #1765: which primitive WaitVblank actually waited on
 #include <algorithm>
 #include <vector>
 #include <cstdio>
@@ -267,6 +268,12 @@ int main() {
     if (waitvbl) {
         CHECK((uint32_t)waitvbl(invalid_handle, 0, 0, 0, 0, 0) == kInvalidHandle,
               "WaitVblank rejects an invalid handle");
+        // #1765: the wait PRIMITIVE, asserted before and after so the report tracks real use.
+        // "none" here proves the accessor is not a compiled-in constant that would satisfy the
+        // post-wait arm no matter what the sleeper did.
+        CHECK(strcmp(host::sleep_backend_name(), "none") == 0,
+              "no vblank wait has been performed yet on this thread");
+
         // Five waits must consume at least four full vblank periods of real time. A stub that
         // returns immediately finishes in microseconds and fails this outright.
         vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0);
@@ -283,6 +290,34 @@ int main() {
               "five WaitVblank calls block for at least four vblank periods");
         CHECK(wait_c1 >= wait_c0 + 4,
               "WaitVblank advances GetVblankStatus's counter by one tick per wait");
+        // Reported, deliberately NOT asserted. The upper half of this measurement is what #1765 is
+        // about, and a wall-clock ceiling is exactly the assertion this file has already been burned
+        // by twice: #1770's minimum-residue sampler wrapped after long overshoots and #1793 found
+        // its replacement's admission rule invalid, both because host scheduling is in the number.
+        // A machine running several builds at once will overshoot five 16.68 ms waits by more than
+        // any threshold that could still catch a 2x pacing regression. So the ceiling is asserted
+        // deterministically further down, and the mechanism -- which is not a statistic -- here.
+        // Reported in PERIODS, not ms/wait: the first of the five starts at an arbitrary phase, so
+        // the healthy total is 4..5 periods and a per-wait mean reads misleadingly below one.
+        // ~15.6 ms Sleep quantization would put this near 9.2.
+        printf("  [note] five WaitVblank calls took %lld us = %.2f vblank periods "
+               "(healthy 4..5), backend '%s'\n",
+               (long long)elapsed_us, (double)elapsed_us * 1000.0 / 16683350.0,
+               host::sleep_backend_name());
+
+        // The mechanism. On Windows std::this_thread::sleep_until compiles to a single ::Sleep(ms),
+        // whose resolution is the process timer period -- ~15.6 ms by default, measured on a Windows
+        // host in test_win_exception_delivery.cpp -- so a 16.68 ms wait could only complete on the
+        // second tick, ~31 ms, pacing a title's display thread at ~32 Hz. This arm goes red exactly
+        // when that quantizing path is back in force, which a lower bound on elapsed time cannot
+        // see: oversleeping by 2x passes every assertion above.
+#ifdef _WIN32
+        CHECK(strcmp(host::sleep_backend_name(), "win32-high-resolution-timer") == 0,
+              "WaitVblank waited on a high-resolution timer, not ::Sleep's ~15.6 ms tick");
+#else
+        CHECK(strcmp(host::sleep_backend_name(), "posix-sleep-until") == 0,
+              "WaitVblank waited on sleep_until (glibc: a nanosleep loop honouring the deadline)");
+#endif
 
         // PHASE, which the counter assertion above does NOT test. A WaitVblank with its own epoch
         // shifted half a period — same period, different phase — advances the counter by exactly
@@ -330,6 +365,29 @@ int main() {
         CHECK(phase_distance_ns < 1000,
               "WaitVblank shares GetVblankStatus's PHASE, not just its period "
               "(wakes land on a boundary of the same grid)");
+
+        // The UPPER bound #1765 asks for, taken where it costs nothing to be exact. Every arm on
+        // the live clock above is one-sided, and a one-sided assertion cannot tell "paced at 59.94
+        // Hz" from "paced at half that" -- the second is longer, and longer passes a lower bound.
+        // Deterministic time removes the host scheduler from the measurement entirely, so the
+        // ceiling can be the exact value rather than a tolerance somebody has to tune: the previous
+        // wait landed ON a boundary, so N further waits must advance the clock by EXACTLY N periods
+        // and the status counter by EXACTLY N. This does not see the host sleep quantization -- no
+        // deterministic arm can, which is why the backend arm above exists -- but it does pin
+        // prosper's own boundary arithmetic from both sides.
+        constexpr int kRepeatedWaits = 5;
+        const uint64_t repeat_start_ns = fake_end_ns;
+        const uint64_t repeat_c0 = *(uint64_t*)vb;
+        bool repeat_ok = true;
+        for (int i = 0; i < kRepeatedWaits; ++i)
+            repeat_ok &= waitvbl(handle, 0, 0, 0, 0, 0) == 0;
+        vbl(handle, (uint64_t)(uintptr_t)vb, 0, 0, 0, 0);
+        CHECK(repeat_ok && *(uint64_t*)(vb + 0x10) ==
+                  repeat_start_ns + (uint64_t)kRepeatedWaits * kPeriodNs &&
+                  *(uint64_t*)vb == repeat_c0 + kRepeatedWaits,
+              "consecutive WaitVblanks from a boundary advance by exactly one period each, "
+              "neither short nor double");
+
         prosper_vo_set_vblank_now_for_test(0);
     }
 


### PR DESCRIPTION
Fixes #1765

Two halves. The first is a build-registration bug; the second is a timing path whose **mechanism is
established from primary evidence** but whose **runtime effect the author could not execute**. Read
the risk section before merging. **Updated after review:** CI has since run the `Windows MinGW`
job on this head and `videoout_queries` passes there, so the code is now *observed* executing on
Windows and selecting the high-resolution backend. The per-wait timing *magnitude* remains derived.

## A. `test_videoout` was not built on Windows

`test_videoout` / `videoout_queries` sat inside the `if(UNIX)` block, so **the one platform whose
display pacing is at risk was the one platform that did not build the guard.** Nothing in the test is
POSIX-specific — it drives the HLE registry and asserts returned values — so the gate was incidental.
Moved up to the cross-platform `if(TARGET prosper_core)` level.

Measured by configuring both `CMakeLists` under a MinGW cross toolchain:

| | Total tests in the **Windows** configuration | `videoout_queries` |
| --- | --- | --- |
| `origin/master` | 200 | 0 occurrences |
| this branch | 201 | `Test #200: videoout_queries` |

## B. `sceVideoOutWaitVblank` waited on `::Sleep`, whose resolution is the process timer period

Three facts compose, each **read rather than assumed**:

1. libstdc++'s `sleep_until` on a **steady** clock forwards to `sleep_for(deadline - now)` and
   returns without re-checking (`bits/this_thread_sleep.h`).
2. On mingw-w64, `bits/c++config.h` leaves `_GLIBCXX_USE_NANOSLEEP`, `_GLIBCXX_HAVE_SLEEP` and
   `_GLIBCXX_HAVE_USLEEP` **undefined** and defines `_GLIBCXX_USE_WIN32_SLEEP`, so `sleep_for` ends in
   exactly one `::Sleep(DWORD ms)`. Confirmed against the **shipped library**, not only the headers:
   `libstdc++.a(thread.o)` names exactly one sleep-ish import, `__imp_Sleep`, and `__sleep_for`
   tail-calls it after rounding ns→ms **UP**. (This resolves the issue's own caveat that "libstdc++'s
   MinGW backend is not guaranteed to take the `::Sleep` path": it does take it.)
3. Windows quantizes `::Sleep` to the system timer period and nothing in this tree raises it.
   **prosper's OWN measurement on a Windows host is already in the repository** from #2242
   (`tests/test_win_exception_delivery.cpp`): `Sleep(1)` = **15.554 ms** by default against
   **1.930 ms** after `timeBeginPeriod(1)`.

So a ~16.68 ms pacing wait became `::Sleep(17)`, which cannot complete before the second ~15.6 ms
tick — roughly **31 ms**, i.e. a display thread paced at **~32 Hz instead of ~60**.

### The fix

New `src/host/precise_sleep.{hpp,cpp}` keeps the deadline semantics and, on Windows, waits on a
`CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` waitable timer instead — scheduled off the high-resolution
timer wheel, leaving the **process-wide timer period alone** (raising that globally costs power and
perturbs every other timer in the process, which is why `timeBeginPeriod(1)` was not the chosen
remedy). If the timer cannot be created it falls back to the previous `sleep_until`, so **the worst
case is what master already does.**

**POSIX is deliberately byte-for-byte the previous behaviour**: a single `sleep_until`, i.e. glibc's
nanosleep loop, which already honours the deadline and restarts on `EINTR` — which matters here
because prosper delivers its own signals.

## C. The guard is two-sided now, but not by way of a wall-clock ceiling

The issue asked for an upper bound on the pacing assertion. **A wall-clock ceiling is exactly the
assertion this file has already been burned by twice** — #1770's minimum-residue sampler wrapped
after long overshoots, and #1793 found its replacement's admission rule invalid — because host
scheduling is inside the number. So:

- the **MECHANISM** is asserted on the live clock (`sleep_backend_name()`), which is not a statistic
  and goes red exactly when the quantizing primitive is back in force;
- the **CEILING** is asserted on the deterministic test clock, where it can be EXACT rather than a
  tolerance somebody has to tune: N waits from a boundary must advance the clock by exactly N periods
  and the status counter by exactly N;
- the elapsed time is **PRINTED, not asserted**.

**Mutation arm C is the point of the whole exercise.** Simulating half-rate pacing
(`(now - t0) / kVblankNs + 2`) leaves BOTH pre-existing arms green — *"five WaitVblank calls block for
at least four vblank periods"* and *"advances the counter by one tick per wait"* — while the new exact
arm fails. A one-sided assertion cannot tell correct pacing from half pacing, **demonstrated rather
than argued**.

## Affected and deliberately unaffected

- **Affected:** `sceVideoOutWaitVblank`'s wait primitive on Windows, and the Windows test
  registration.
- **Deliberately unaffected:** POSIX, byte-for-byte — the same single `sleep_until` call it made
  before.
- **Deliberately unaffected:** `test_present` / `videoout_present` is still inside the `if(UNIX)`
  gate and looks like the same incidental restriction, but it was left alone to keep this change to
  one subject.

## Risks

- **`CONFIDENCE: MED` on the resulting numbers for any given Windows host.** The improvement from
  ~31 ms to ~16.7 ms per wait is *derived*, not observed: CI executes the test on Windows but does
  not measure per-wait latency, and the magnitude depends on the host's current timer resolution.
  `CONFIDENCE: HIGH` on the mechanism — (1) and (2) are read from the toolchain's own headers,
  generated config and compiled library, and (3) from a measurement already in this repository.
- **What would settle it:** running `test_videoout.exe` on real Windows and reading the `[note]` line
  it now prints, which reports the five-wait total in vblank periods (healthy 4..5; ~9.2 under
  ~15.6 ms quantization) alongside the selected backend.
- **Execution on Windows: verified by CI, not by the author's box.** The `Windows MinGW` job runs
  `ctest` and reports `videoout_queries ... Passed`, exercising the `#ifdef _WIN32` arm that requires
  the `win32-high-resolution-timer` backend — so the timer is created and selected on a real Windows
  host. What remains unmeasured is the latency improvement itself. Locally, wine is installed in this
  container but non-functional — a static hello-world hangs identically to the prosper binaries — so
  it produced no evidence either way, and a wine timing number would not have been evidence about
  Windows regardless.
- A new host-side source file (`precise_sleep.cpp`) enters the build on all platforms. The Windows
  path is behind `#ifdef`; the POSIX path is the previous code.

## Verification (local; author-run)

**Linux**, distrobox `ps5ys`, `-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`:

```
baseline (origin/master ec2c0c22):  ctest --no-tests=error  -> exit 0, 100% of 265 (265/265)
this branch:                        ctest --no-tests=error  -> exit 0, 100% of 265 (265/265)
```

**Windows cross-compile** (Fedora MinGW GCC 16.1.1, throwaway toolchain):

- `test_videoout.cpp` → object built clean
- `precise_sleep.cpp` → object built clean
- `test_videoout.exe` → **LINKED** (imports `CreateWaitableTimerExW`, `SetWaitableTimer`,
  `WaitForSingleObject`), so the high-resolution path is really in the Windows binary rather than
  compiled out.

**The cross-compile check is proven non-vacuous.** Mistyping ONE Windows-only line makes MinGW fail
while host g++ on the identical file still passes, for both files:

```
precise_sleep.cpp  SetWaitableTimer_DELIBERATE_TYPO  -> mingw rc=1, host g++ rc=0
test_videoout.cpp  WIN32_ONLY_DELIBERATE_TYPO        -> mingw rc=1, host g++ rc=0
```

**Mutation arms** (distinct md5 per arm; restored binary md5 matches baseline exactly):

| arm | mutation | result |
| --- | --- | --- |
| A | backend reports the quantizing fallback | mechanism arm FAILS (others green) |
| B | accessor hardcoded to a constant | only the pre-wait "none" arm FAILS |
| C | half-rate pacing | only the new exact arm FAILS |

**No CI evidence is quoted: CI has not run on this branch.**

