### PR TITLE
tools(env): check_diag_gates.py — model polarity, defaulted aliases, stored lambdas and clause implication

### DIFF
--- a/prosper/docs/DIAGNOSTIC_GATE_AUDIT.md
+++ b/prosper/docs/DIAGNOSTIC_GATE_AUDIT.md
@@ -57,25 +57,30 @@ each derived from a **measured** instance rather than invented:
 | `TWO-GATE` | one report statement requiring **two** distinct `PROSPER_*` variables | `[udtail]` (#2146); the unimplemented-NID table (#2149) |
 | `SPLIT-CALL` | a callee reached only under env gates whose call sites **disagree** on which gate | `record_guest_write(ColorTarget, …)` (#2111) |
 
-### Headline numbers (master, 2026-08-17)
+### Headline numbers (master, 2026-08-17, after #2628)
 
 | | count |
 | --- | --- |
-| `PROSPER_*` variables read anywhere in the tree | **651** |
-| read sites for them | **1,055** |
-| variables read at more than one site | **155** |
-| env predicate functions resolved (`udprov_enabled()` and friends) | **61** |
-| **findings** (`SPLIT-CALL` 4, `SPLIT-LOCAL` 22, `TWO-GATE` 151) | **177** |
-| distinct baseline keys for those findings | **93** |
+| `PROSPER_*` variables read anywhere in the tree | **658** |
+| read sites for them | **1,067** |
+| variables read at more than one site | **158** |
+| env predicate functions resolved (`udprov_enabled()` and friends) | **43** |
+| **findings** (`SPLIT-CALL` 3, `SPLIT-LOCAL` 19, `TWO-GATE` 81) | **103** |
+| distinct baseline keys for those findings | **54** |
 
-Classification of the 93 keys, from `tools/env/diag_gate_baseline.txt`:
+Classification of the 54 keys, from `tools/env/diag_gate_baseline.txt`:
 
 | class | keys | meaning |
 | --- | --- | --- |
 | `defect` | 2 | a confirmed instance; the note names the issue |
 | `config-echo` | 10 | the field echoes **configuration**, so `0` truthfully means "unconstrained" — the shape rule 1 recommends |
-| `benign` | 2 | read and judged sound, with the reason in the note: two deliberate entry points into one arming helper, and a behaviour predicate that prints nothing |
-| `unreviewed` | 79 | found by the sweep and **not judged**; honest debt, tracked by #2572 |
+| `benign` | 2 | read and judged sound, with the reason in the note: two deliberate entry points into one arming helper, and a pure clock read whose call sites disagree |
+| `unreviewed` | 40 | found by the sweep and **not judged**; honest debt, tracked by #2572 |
+
+Before #2628 the same tree read **177 findings / 93 keys** against **61** predicates. The drop is the
+scanner getting *narrower*, not the tree getting cleaner — nothing in `src/` changed. The predicate
+count falls furthest because most of what it lost were `PROSPER_NO_*` opt-outs, which were being
+recorded as requirements exactly backwards.
 
 **There is deliberately no class meaning "the variables share a name family, so it is probably
 fine".** An earlier revision had one, and it was the single most misreadable thing in this document:
@@ -84,6 +89,59 @@ recorded in the **note** of an `unreviewed` row and is triage only — because #
 was `PROSPER_PROGRESS` + `PROSPER_PROGRESS_UNIMPL`, which **is** a name family, and the family is
 exactly what made the coupling invisible: the name promised what only the pair delivered. A shared
 family cannot be the end of an argument, so it does not get to be a class.
+
+### What #2628 sharpened, and how the shrink was kept honest
+
+Four lexical limits accounted for most of the difference between "the scanner's second clause" and
+"a requirement a run has to satisfy". Each is now modelled:
+
+| limit | before | after |
+| --- | --- | --- |
+| **polarity inside an `if`** | `if (!getenv("X"))` and `getenv("PROSPER_NO_X") == nullptr` both recorded `X` as *required* — while the same negation *was* pushed through for `if (!getenv("X")) return;`, so the two spellings of one idea disagreed | a negated env test imposes nothing; a disjunct satisfiable with nothing set leaves the whole disjunction unconstrained (`positive_env_literals`) |
+| **a defaulted alias** | `const char* out = getenv("X"); if (!out) out = "…";` left `out` standing for `X`, so every later use read as gated | assigning a **literal** to an alias widens it to "the declaration's gate **or** the assignment site's" — which collapses to nothing when the assignment is reachable by default |
+| **a stored lambda** | a helper lambda aliased every `PROSPER_*` in its body and exported it to each *call*, invisibly at the call site | only an **immediately invoked** lambda aliases; `[&]{…}` held in a variable does not (`alias_is_a_gate`) |
+| **`SPLIT-CALL` by identity** | `{A}` versus `{A\|B}` — an *implication* — read as a disagreement | neither-implies-the-other, alongside the existing disjointness test (`implies`) |
+
+Polarity forced a fifth change: `collect_predicates()` used to read a predicate body as a flat bag
+of literals, which was survivable only *because* negation was ignored. With polarity that reading is
+wrong in both directions at once, and `dyntrace_failed_shader_enabled` shows both — a guard
+(`if (!getenv("PROSPER_DYNTRACE_FAIL")) return false;`) that **is** required and a filter
+(`if (!filter) return true;`) that is not. A flat polarity read would have kept the optional one and
+dropped the required one, silently weakening a `defect` row's key. A predicate body is now read as a
+function body: guards impose their negation, an early truthy return ends the accumulation, and a
+predicate with two truthy exits requires their **disjunction**.
+
+**Every one of those changes reports fewer findings, which is the direction that silently disables a
+rule** — the `SPLIT-LOCAL` row in [Ruled out](#ruled-out) is this scanner having already done it
+once. So:
+
+- each fix ships as a **pair of self-test arms** differing only in the property under test — `==`
+  against `!=`, `: 60` against `: 0`, one repair line present against absent, a stored lambda
+  against an invoked one, an implied second gate against a disjoint one. 24 arms, 12 of them
+  must-match;
+- **every must-not-match half was checked to be a finding on the pre-#2628 scanner**, so none of
+  them passes by having been outside the rule's reach all along;
+- **both `defect` rows still reproduce.** `[udtail]`'s key moved — `PROSPER_DYNTRACE_FAIL_ADDR` left
+  the alternation, correctly, because it is an optional address filter — and the row was carried
+  across by hand rather than regenerated;
+- the baseline was rebuilt by matching each surviving finding to its predecessor at the same
+  `file:line`, not by `--emit-baseline`. 53 of the 54 rows resolve to a predecessor; 15 re-keyed and
+  say so in the note.
+
+**One row is new, and it is the rule working rather than decaying.** `diagnostic_elapsed_ms`
+(`live_renderer.cpp:534`) is called under `PROSPER_PASS_LOG` and under `PROSPER_DUMP_PERSISTENT`.
+Those two sites always disagreed; the spurious `PROSPER_RTT_PERTARGET|…` clause they used to share
+was hiding it. So sharpening a rule can *add* findings as well as remove them.
+
+**What was deliberately not silenced:** the convention's own **rule 1**. An armed-state banner is
+conditioned on both switches by construction — `command_processor.cpp:1572` prints *"INIT-TRIP NOT A
+CONTROL — `PROSPER_MB3_FREELIST_GUARD` is on"* — and both `command_processor.cpp` rows are still in
+the baseline. A rule that recognised the shape would have to distinguish "this banner explains the
+other switch" from "this report silently needs it", and no lexical test does; a plausible one ("the
+report's own text names a variable from its other clause") would silence any diagnostic that happens
+to print a variable name. Rule **2**'s shapes did go, but for the polarity reason rather than by
+recognising them: `guest_write_watch.cpp:1372` and `gpu_timeline.cpp:2288`/`:2742` all test a
+*negated* env read.
 
 ### Confirmed instances
 
@@ -154,6 +212,19 @@ thing is the exact failure this document exists to prevent.
 - A **disjunction imposes no requirement**: `if (getenv("A") || flag)` and
   `if (getenv("A") || getenv("B"))` both yield nothing. That understates deliberately — the
   direction that makes no false accusation.
+- A **negated env test imposes nothing**, for the same reason: `if (!getenv("X"))` and the opt-out
+  `getenv("PROSPER_NO_X") == nullptr` both run on a default boot. The corollary is a real gap:
+  `if (getenv("X")) return;` genuinely makes the remainder require `X` to be *unset*, and this tool
+  has no way to express that, so it does not report it.
+- An **argument list is one conjunct**, so `f(getenv("A") != nullptr, limit_derived_from_B)` yields
+  the any-of clause `{A|B}` rather than two independent parameters. That widens a clause, which
+  understates `TWO-GATE`. The `live_renderer.cpp` texture-cache rows carry a clause of this shape.
+- A **braceless `if` body is not scoped**: in `if (a) if (b) x = c;` the write to `x` is attributed
+  to the enclosing block. This is why the defaulted-alias rule only fires on a *literal* right-hand
+  side — a computed one may sit under a condition the scanner never saw.
+- A **statement split across lines after its `if`** is outside that `if`'s gate: the scanner handles
+  one condition per line, so `if (getenv("A"))\n    fprintf(...)` is read as ungated. Braces avoid
+  it.
 - `#if`-gated code is scanned as if it were live.
 - A diagnostic gated by something that is **not an environment variable** — a build flag, a member
   field, a runtime setting — is out of scope by construction. The most consequential example is in
@@ -184,6 +255,23 @@ this tree can print an unmeasured field"*.
 - **"`PROSPER_UD_TAIL_ALIGN=off` gives you the `[udtail]` report without the mutation."** It does
   not: the gate is `getenv() != nullptr`, so `0`, `off` and the empty string all enter the block and
   apply `range_start = prefix`. #2146.
+- **"A `TWO-GATE` finding means arming the obviously-named switch leaves you in silence."** Not on
+  its own, and #2628 removed 38 baseline keys where it was false by construction: the second clause
+  was a negated test, an opt-out that is on by default, an alias holding a compiled-in default, or a
+  lambda's body leaking into its call sites. The finding is a *candidate*; the check is to open each
+  name's declaration and read its polarity and its default. #2572 / #2628.
+- **"A rising `TWO-GATE` count means the convention is decaying."** Rules 1 and 2 both *create*
+  findings — an armed-state banner (`command_processor.cpp:1572`) and a refusal that names the
+  missing switch (`guest_write_watch.cpp:1372`) are each conditioned on two variables by
+  construction. Read the notes, not the total. #2572.
+- **"Sharpening a rule can only remove findings."** `SPLIT-CALL` gained one at
+  `live_renderer.cpp:534` when the spurious clause its three call sites shared went away: the
+  disagreement had been there all along and the extra clause was masking it. #2628.
+- **"A flat bag of literals is good enough for a predicate body."** It was, only because negation
+  was ignored — the two errors cancelled. `dyntrace_failed_shader_enabled` (`gpu_executor.cpp:401`)
+  has a guard on `PROSPER_DYNTRACE_FAIL` that *is* required and a filter on
+  `PROSPER_DYNTRACE_FAIL_ADDR` that is not; a flat polarity read keeps the wrong one of the two.
+  Predicate bodies are read as function bodies (`predicate_clauses`). #2628.
 
 ## See also
 

--- a/prosper/docs/DIAGNOSTIC_GATE_AUDIT.md
+++ b/prosper/docs/DIAGNOSTIC_GATE_AUDIT.md
@@ -78,9 +78,33 @@ Classification of the 54 keys, from `tools/env/diag_gate_baseline.txt`:
 | `unreviewed` | 40 | found by the sweep and **not judged**; honest debt, tracked by #2572 |
 
 Before #2628 the same tree read **177 findings / 93 keys** against **61** predicates. The drop is the
-scanner getting *narrower*, not the tree getting cleaner — nothing in `src/` changed. The predicate
-count falls furthest because most of what it lost were `PROSPER_NO_*` opt-outs, which were being
-recorded as requirements exactly backwards.
+scanner getting *narrower*, not the tree getting cleaner — nothing in `src/` changed.
+
+**18 predicates stopped resolving, and "they were `PROSPER_NO_*` opt-outs" covers only 13 of them.**
+The other five are worth naming, because a predicate that resolves to nothing is invisible
+afterwards and the summary is where anyone would look for it:
+
+- **13** are `PROSPER_NO_*` / `PROSPER_TEST_DISABLE_*` opt-outs (`compute_memory_pool_enabled`,
+  `descriptor_pool_reuse_enabled`, `native_2d_transfer_enabled`, `udprov_collection_enabled`, …),
+  which were being recorded as requirements exactly backwards. Dropping them is the fix.
+- **`time_compute_address_matches`** (`live_compute.cpp:2983`) returns `true` when
+  `PROSPER_COMPUTE_TIMING_CODE` is unset. Dropping it is also a fix — `master` recorded a
+  requirement that does not exist.
+- **`sclog_condition` / `sclog_semaphore` / `sclog`** (`hle_kernel.cpp:117`, `:122`, `:127`) is the
+  one case where the *understating* direction bites. What they lost was inverted and wrong — `master`
+  recorded `sclog_condition` as requiring `{PROSPER_SYNCLOG_SEMA_ONLY}` when the body is
+  `thread_enabled && !semaphore_only` — but their real requirement is `PROSPER_SYNCLOG`, and that is
+  now recorded nowhere. It arrives transitively through `sclog_thread_enabled()` →
+  `sclog_time_enabled()` (`:102`, `getenv("PROSPER_SYNCLOG") != nullptr; if (!enabled) return
+  false;`), and `predicate_clauses()` does not expand *other* predicates. Measured rather than
+  inferred: `sclog_thread_enabled` resolves on **neither** scanner, so the chain was already broken
+  one level below this change — no baseline row depended on it and nothing regressed, but "the
+  predicate count fell because of opt-outs" is not the whole story.
+- **`software_decode_allowed`** stopped resolving because its two definitions now genuinely
+  **disagree**: `vaapi_backend.cpp:52` defaults to *true* and reads `=0` as "hardware only", while
+  `media_foundation_backend.cpp:43` defaults to *false* and reads `=0` as *enabling*. Same switch,
+  opposite meaning per platform. Filed as **#2648**; the scanner found it, which is the tool paying
+  for itself in a direction it was not built for.
 
 **There is deliberately no class meaning "the variables share a name family, so it is probably
 fine".** An earlier revision had one, and it was the single most misreadable thing in this document:
@@ -111,6 +135,23 @@ dropped the required one, silently weakening a `defect` row's key. A predicate b
 function body: guards impose their negation, an early truthy return ends the accumulation, and a
 predicate with two truthy exits requires their **disjunction**.
 
+**That fifth limit was invisible to every total, and that is the most useful thing in this
+section.** Both readings — the flat one and the structured one — produce the identical **103
+findings / 54 keys**. Only the *content* of one key differs:
+
+```
+structured   TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN
+flat         TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL_ADDR|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN
+```
+
+`gpu_executor.cpp:402` is `if (!std::getenv("PROSPER_DYNTRACE_FAIL")) return false;` — required —
+and `:403-404` reads `PROSPER_DYNTRACE_FAIL_ADDR` into an optional filter. The flat read keeps
+exactly the wrong one, so a reader following that `defect` row would arm the filter and get silence:
+the defect this document is about, committed by the tool that detects it. **No count could have
+caught it** — not the finding total, not the key total, not a diff of "the numbers went down as
+expected". Only reading the key did. Treat "the totals moved the way I predicted" as evidence about
+volume and never about content.
+
 **Every one of those changes reports fewer findings, which is the direction that silently disables a
 rule** — the `SPLIT-LOCAL` row in [Ruled out](#ruled-out) is this scanner having already done it
 once. So:
@@ -125,8 +166,34 @@ once. So:
   the alternation, correctly, because it is an optional address filter — and the row was carried
   across by hand rather than regenerated;
 - the baseline was rebuilt by matching each surviving finding to its predecessor at the same
-  `file:line`, not by `--emit-baseline`. 53 of the 54 rows resolve to a predecessor; 15 re-keyed and
-  say so in the note.
+  `file:line`, not by `--emit-baseline`. 53 of the 54 rows resolve to a predecessor; **14** re-keyed
+  and say so in the note.
+
+The counts, and the convention they are counted under — stated because the obvious alternative gives
+different numbers, and an earlier revision of this section mixed the two:
+
+| | rows in the new baseline | keys in the old one |
+| --- | --- | --- |
+| unchanged | 39 | 39 |
+| re-keyed (carry `[#2628 re-keyed; was …]`) | 14 | 14 named as a predecessor |
+| new | 1 | — |
+| no successor recorded | — | 40 |
+| **total** | **54** | **93** |
+
+Count **rows** in the new file, and account for the old file's keys by whether a marker names them.
+Both are then reproducible with `grep`, which is the only property that matters here: these counts
+tell whoever merges the sibling branch how many rows to expect, so a count they cannot re-derive
+sends them hunting for a row nobody lost. Two footnotes, both of which have already misled a reader:
+
+- `grep -c '\[#2628 re-keyed; was'` over the baseline returns **15**. The fifteenth hit is the
+  header prose that names the marker. Filter comments first.
+- The rejected alternative counts the *old* keys by which surviving row absorbed them, and gives
+  39 + 16 + 38 **or** 39 + 17 + 37 depending on whether a `SPLIT-LOCAL` and a `TWO-GATE` sharing one
+  source line count as the same absorption. Having two defensible answers is precisely why it is not
+  the convention. It is not wrong, though, and it is what explains the apparent gap between 14
+  markers and 54 departed keys: one surviving row absorbs **three** old keys
+  (`…|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT`), and its note records the one predecessor
+  whose argument still applies while naming the other two.
 
 **One row is new, and it is the rule working rather than decaying.** `diagnostic_elapsed_ms`
 (`live_renderer.cpp:534`) is called under `PROSPER_PASS_LOG` and under `PROSPER_DUMP_PERSISTENT`.
@@ -198,6 +265,32 @@ classification and an issue link. A baseline row that no longer reproduces **als
 landed, so delete the row. The second half matters as much as the first — a baseline nobody is
 forced to update stops describing the tree, which is this document's whole subject.
 
+### The baseline's own integrity — what guards the NOTES
+
+Both halves above are about **keys**. Until #2628 nothing in the tool looked at a **note**:
+`load_baseline()` kept it only so `--list` could echo it, and the header's class counts were skipped
+as comments. So a row could keep a current key and lose the judgement that is the only reason the
+row is worth having, and every check stayed green. `baseline_integrity()` closes that, with three
+rules:
+
+1. every row carries a class from `BASELINE_CLASSES`;
+2. the header's class counts match the rows, for all four classes;
+3. the `unreviewed` count equals `UNREVIEWED_BUDGET` **exactly** — asserted, not bounded, so that
+   *paying* debt also demands an edit and the ratchet tightens instead of drifting.
+
+Rule 3 is the one with teeth. `--emit-baseline` classifies **every** row `unreviewed`, so "just
+regenerate the baseline" — the repair everyone reaches for, and the one the header has warned
+against in prose since #2149 — now fails loudly instead of laundering a `defect` row into an
+unjudged one. Measured: with the three rules neutered in `main()` and nothing else changed, a
+baseline holding the current 54 keys with all 14 judgements replaced by `unreviewed` reports
+`== all checks passed ==`, exit 0.
+
+**What it cannot see, stated so nobody quotes it as more:** a baseline copied *whole* from one
+branch over another is internally consistent by construction and passes all three rules. Nothing
+inside one file can detect that. Only merge **order** protects against it — land the branch that
+rebuilds the keys first, so the second merger's "keep mine" resolution is the one that fails loudly
+rather than the one that passes silently.
+
 ## What the scanner cannot see
 
 Stated here rather than left implied, because a clean run of an instrument that cannot observe the
@@ -222,6 +315,10 @@ thing is the exact failure this document exists to prevent.
 - A **braceless `if` body is not scoped**: in `if (a) if (b) x = c;` the write to `x` is attributed
   to the enclosing block. This is why the defaulted-alias rule only fires on a *literal* right-hand
   side — a computed one may sit under a condition the scanner never saw.
+- **`-1` counts as a falsy default**, because `DEFAULT_RHS_RE` lists it. So `X ? atoi(X) : -1` keeps
+  its alias and stays a gate although `-1` is truthy in C. That over-reports rather than
+  under-reports, and it is consistent with the one place the tool states which literals mean
+  "unset", so it is left alone — but a finding resting on such a ternary is a candidate to re-read.
 - A **statement split across lines after its `if`** is outside that `if`'s gate: the scanner handles
   one condition per line, so `if (getenv("A"))\n    fprintf(...)` is read as ungated. Braces avoid
   it.
@@ -256,10 +353,11 @@ this tree can print an unmeasured field"*.
   not: the gate is `getenv() != nullptr`, so `0`, `off` and the empty string all enter the block and
   apply `range_start = prefix`. #2146.
 - **"A `TWO-GATE` finding means arming the obviously-named switch leaves you in silence."** Not on
-  its own, and #2628 removed 38 baseline keys where it was false by construction: the second clause
-  was a negated test, an opt-out that is on by default, an alias holding a compiled-in default, or a
-  lambda's body leaking into its call sites. The finding is a *candidate*; the check is to open each
-  name's declaration and read its polarity and its default. #2572 / #2628.
+  its own, and #2628 removed 40 baseline keys — 35 of them `TWO-GATE` — where it was false by
+  construction: the second clause was a negated test, an opt-out that is on by default, an alias
+  holding a compiled-in default, or a lambda's body leaking into its call sites. The finding is a
+  *candidate*; the check is to open each name's declaration and read its polarity and its default.
+  #2572 / #2628.
 - **"A rising `TWO-GATE` count means the convention is decaying."** Rules 1 and 2 both *create*
   findings — an armed-state banner (`command_processor.cpp:1572`) and a refusal that names the
   missing switch (`guest_write_watch.cpp:1372`) are each conditioned on two variables by

--- a/prosper/tools/env/check_diag_gates.py
+++ b/prosper/tools/env/check_diag_gates.py
@@ -97,6 +97,25 @@ from pathlib import Path
 SCAN_DIRS = ("src", "frontends", "tools", "tests")
 SCAN_EXT = (".c", ".cc", ".cpp", ".h", ".hpp")
 
+# The four classifications a baseline row may carry. `unreviewed` is honest debt; the other three
+# are judgements, and the JUDGEMENT is the expensive artifact in that file -- each cost a human
+# reading a diagnostic and deciding whether its zero can lie. See baseline_integrity().
+BASELINE_CLASSES = ("defect", "config-echo", "benign", "unreviewed")
+
+# How many `unreviewed` rows the baseline is allowed to carry -- asserted EXACTLY, not as a ceiling.
+#
+# Exactly, because the two directions are different events and both want a human:
+#   more than this -> debt was ADDED. `--emit-baseline` writes EVERY row as `unreviewed`, so this
+#     is precisely what "just regenerate the baseline" looks like after it has laundered a `defect`
+#     row into an unjudged one. That is the failure this whole file exists to prevent, and until
+#     now nothing in the tool could see it: load_baseline() kept the note only so `--list` could
+#     echo it, and the header's class counts were skipped as comments.
+#   fewer than this -> debt was PAID. Tightening the number is then a one-line, visible, reviewable
+#     edit, and the ratchet is self-arming: it can only be loosened deliberately and in the diff.
+# #2572 is annotating the remaining rows; when it lands this becomes 0 and no unjudged row can
+# enter the baseline again.
+UNREVIEWED_BUDGET = 40
+
 ENV_NAME = r"PROSPER_[A-Z0-9_]+"
 # Every way this tree asks for a PROSPER_* variable. `env_enabled("X")` and friends pass the name
 # as an argument, so anchor on the LITERAL rather than on a fixed list of callee names -- the same
@@ -1686,6 +1705,140 @@ def load_baseline(path: Path) -> dict[str, str]:
     return entries
 
 
+def _header_class_counts(text: str) -> dict[str, int]:
+    """The `#   benign: 2` block. Only the four known class names are read, so a typo in the header
+    surfaces as "no count declared for <class>" rather than as a silently accepted new class."""
+    declared: dict[str, int] = {}
+    for line in text.split("\n"):
+        m = re.match(r"^#\s+([a-z][a-z-]*):\s*(\d+)\s*$", line)
+        if m and m.group(1) in BASELINE_CLASSES:
+            declared[m.group(1)] = int(m.group(2))
+    return declared
+
+
+def baseline_integrity(text: str, budget: int = UNREVIEWED_BUDGET) -> list[str]:
+    """Check the baseline against ITSELF. Returns one message per failure; empty means sound.
+
+    The gate above this one gets half the job. It fails on a stale KEY and on a missing KEY, and it
+    is completely indifferent to a NOTE -- so a row can keep its key and lose the judgement that is
+    the only reason the row is worth having, with nothing in CI able to tell. That asymmetry is not
+    hypothetical: two branches rewrote this file at once (#2628 and #2572), and the resolution
+    everyone reaches for -- "keep my side of the conflict" -- passes every check while discarding
+    the other lane's 79 notes, with no conflict left over and a diff that reads as your own edit
+    (the trap-41 / #1701 shape).
+
+    Three rules, each cheap and each falsifiable:
+
+      1. every row carries a class from BASELINE_CLASSES;
+      2. the header's own class counts match the rows, for all four classes -- a summary nobody
+         checks is the same silent-drift door one level up, and this file's header is quoted
+         verbatim in docs/DIAGNOSTIC_GATE_AUDIT.md;
+      3. the `unreviewed` count equals UNREVIEWED_BUDGET exactly (see that constant).
+
+    Rule 3 is the one with teeth, because `unreviewed` is what a regeneration turns every judgement
+    into. What none of the three can see, stated so nobody quotes this as more than it is: a
+    baseline copied WHOLE from one branch over another is internally consistent by construction and
+    passes all three. Only merge ORDER protects against that -- land the branch that rebuilds the
+    keys first, so the second merger's "keep mine" resolution is the one that fails loudly.
+    """
+    rows: list[tuple[str, str]] = []
+    for line in text.split("\n"):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, _sep, note = line.partition("  #")
+        rows.append((key.strip(), note.strip()))
+
+    failures: list[str] = []
+    counts = {cls: 0 for cls in BASELINE_CLASSES}
+    for key, note in rows:
+        cls = note.split(":", 1)[0].strip()
+        if cls in counts:
+            counts[cls] += 1
+        else:
+            failures.append(
+                f"row carries no recognised classification (want one of "
+                f"{', '.join(BASELINE_CLASSES)}): {key}")
+
+    declared = _header_class_counts(text)
+    for cls in BASELINE_CLASSES:
+        if cls not in declared:
+            failures.append(f"the header declares no count for `{cls}` -- add `#   {cls}: "
+                            f"{counts[cls]}` to the class-count block")
+        elif declared[cls] != counts[cls]:
+            failures.append(f"the header says `{cls}: {declared[cls]}` and the rows say "
+                            f"{counts[cls]} -- one of the two was edited without the other")
+
+    if counts["unreviewed"] > budget:
+        failures.append(
+            f"{counts['unreviewed']} `unreviewed` row(s) against a budget of {budget} -- unjudged "
+            f"debt was ADDED. If this came from `--emit-baseline`, it has overwritten judgements: "
+            f"that command classifies every row `unreviewed`, so a `defect` row is laundered into "
+            f"an unjudged one by a command that looks like housekeeping. Re-apply the notes.")
+    elif counts["unreviewed"] < budget:
+        failures.append(
+            f"{counts['unreviewed']} `unreviewed` row(s) against a budget of {budget} -- debt was "
+            f"PAID. Tighten UNREVIEWED_BUDGET in check_diag_gates.py to {counts['unreviewed']} so "
+            f"the ratchet holds; leaving it slack lets the same number of rows silently return.")
+    return failures
+
+
+# Arms for baseline_integrity(). Each pair differs ONLY in the property under test, and every
+# must-fail half is a mutation of the must-pass one -- a rule that cannot be shown to fire is not a
+# rule, and this file's own `## Ruled out` records a check of exactly that kind sitting inert.
+_SOUND_BASELINE = """\
+# A baseline.
+#   defect: 1
+#   config-echo: 0
+#   benign: 1
+#   unreviewed: 2
+#
+TWO-GATE|src/a.cpp|report|PROSPER_A+PROSPER_B  # defect: the printer needs both. #2149
+SPLIT-LOCAL|src/b.cpp|hits|PROSPER_C  # benign: structural, not a count of things observed. #2572
+TWO-GATE|src/c.cpp|report|PROSPER_D+PROSPER_E  # unreviewed: not judged
+TWO-GATE|src/d.cpp|report|PROSPER_F+PROSPER_G  # unreviewed: not judged
+"""
+
+BASELINE_INTEGRITY_TESTS = (
+    ("a sound baseline passes", _SOUND_BASELINE, 2, ""),
+    ("an unclassified row is caught",
+     _SOUND_BASELINE.replace("# defect: the printer needs both. #2149", "# ok, looks fine"),
+     2, "no recognised classification"),
+    ("a header count that disagrees with the rows is caught",
+     _SOUND_BASELINE.replace("#   benign: 1", "#   benign: 2"), 2, "was edited without the other"),
+    ("a class missing from the header is caught",
+     _SOUND_BASELINE.replace("#   config-echo: 0\n", ""), 2, "declares no count for `config-echo`"),
+    # The two rule-3 arms. Both mutate the SAME file in the same place; only the direction differs,
+    # and the messages have to differ too -- "debt was added" and "debt was paid" call for opposite
+    # actions from whoever reads them.
+    ("a judgement downgraded to `unreviewed` is caught",
+     _SOUND_BASELINE.replace("# benign: structural, not a count of things observed. #2572",
+                             "# unreviewed: not judged").replace("#   benign: 1", "#   benign: 0")
+                    .replace("#   unreviewed: 2", "#   unreviewed: 3"),
+     2, "debt was ADDED"),
+    ("debt paid without tightening the ratchet is caught", _SOUND_BASELINE, 3, "debt was PAID"),
+)
+
+
+def run_baseline_integrity_test(verbose: bool = False) -> int:
+    bad = 0
+    for label, text, budget, want in BASELINE_INTEGRITY_TESTS:
+        got = baseline_integrity(text, budget)
+        ok = (not got) if not want else any(want in g for g in got)
+        if not ok:
+            bad += 1
+            print(f"  [FAIL] baseline-integrity: {label}")
+            print(f"         want={want or '<no failures>'}")
+            print(f"         got ={got or '<no failures>'}")
+        elif verbose:
+            print(f"  [ok]   baseline-integrity: {label}")
+    if not bad:
+        print(f"  [ok]   baseline integrity: {len(BASELINE_INTEGRITY_TESTS)} arms "
+              f"({sum(1 for _l, _t, _b, w in BASELINE_INTEGRITY_TESTS if not w)} positive, "
+              f"{sum(1 for _l, _t, _b, w in BASELINE_INTEGRITY_TESTS if w)} must-fail)")
+    return bad
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
     ap.add_argument("root", nargs="?", help="checkout root containing src/ frontends/ tools/ tests/")
@@ -1698,7 +1851,8 @@ def main() -> int:
     args = ap.parse_args()
 
     print("== check_diag_gates ==")
-    if run_self_test(args.verbose) or run_key_stability_test(args.verbose):
+    if (run_self_test(args.verbose) or run_key_stability_test(args.verbose)
+            or run_baseline_integrity_test(args.verbose)):
         return 1
     if args.selftest:
         print("== all checks passed ==")
@@ -1730,7 +1884,10 @@ def main() -> int:
             print(f"{key}  # unreviewed")
         return 0
 
-    baseline = load_baseline(here.parent / "diag_gate_baseline.txt")
+    baseline_path = here.parent / "diag_gate_baseline.txt"
+    baseline = load_baseline(baseline_path)
+    integrity = (baseline_integrity(baseline_path.read_text(encoding="utf-8"))
+                 if baseline_path.is_file() else [])
     by_key = {f.key(): f for f in findings}
     new = [f for k, f in sorted(by_key.items()) if k not in baseline]
     stale = [k for k in sorted(baseline) if k not in by_key]
@@ -1747,10 +1904,19 @@ def main() -> int:
             if k in baseline and baseline[k]:
                 print(f"      {baseline[k]}")
 
-    if not new and not stale:
+    if not integrity:
+        print(f"  [ok]   baseline notes: {len(baseline)} row(s) classified, header counts agree, "
+              f"{UNREVIEWED_BUDGET} unreviewed as budgeted")
+
+    if not new and not stale and not integrity:
         print("== all checks passed ==")
         return 0
 
+    if integrity:
+        print(f"  [FAIL] {len(integrity)} baseline integrity problem(s) -- the KEYS may be current "
+              f"while the JUDGEMENTS are not:")
+        for msg in integrity:
+            print(f"    {msg}")
     if new:
         print(f"  [FAIL] {len(new)} finding(s) not in the baseline:")
         for f in new:
@@ -1761,7 +1927,7 @@ def main() -> int:
         print(f"  [FAIL] {len(stale)} baseline entry(ies) no longer reproduce -- delete the row:")
         for k in stale:
             print(f"    {k}")
-    print(f"== {len(new) + len(stale)} failure(s) ==")
+    print(f"== {len(new) + len(stale) + len(integrity)} failure(s) ==")
     return 1
 
 

--- a/prosper/tools/env/check_diag_gates.py
+++ b/prosper/tools/env/check_diag_gates.py
@@ -69,6 +69,15 @@ silently stops describing the tree, which is the same failure class this tool ex
   - A disjunction is treated as ungated: `if (getenv("A") || flag)` imposes no requirement, and
     `if (getenv("A") || getenv("B"))` imposes none either. That understates deliberately -- it is
     the direction that produces no false accusation.
+  - A NEGATED env test imposes nothing, for the same reason: `if (!getenv("X"))` and the opt-out
+    `getenv("PROSPER_NO_X") == nullptr` both run on a default boot. Corollary, and a real gap:
+    `if (getenv("X")) return;` genuinely does make the remainder require X to be UNSET, which is a
+    coupling this tool has no way to express and therefore does not report.
+  - An argument list is read as one conjunct, so `f(getenv("A") != nullptr, limit_from_B)` yields
+    the any-of clause `{A|B}` rather than the two independent parameters it is. That widens a
+    clause, which is the understating direction for TWO-GATE.
+  - A braceless `if` body is not scoped: `if (a) if (b) x = c;` attributes `x` to the enclosing
+    block. LITERAL_RHS_RE exists because of this -- see the defaulted-alias rule in run().
   - `#if`-gated code is scanned as if it were live.
   - A diagnostic gated by something other than an environment variable (a build flag, a member
     field, a runtime setting) is out of scope by construction.
@@ -146,6 +155,27 @@ ASSIGN_RE = re.compile(
 NEGATIVE_TEST_RE = re.compile(r"(?:^\s*!|!\s*[A-Za-z_(]|==\s*(?:nullptr|NULL|0)\b|<=\s*0\b|"
                               r"==\s*0\b|\.empty\(\)|!\*)")
 
+# A comparison that follows an env read and INVERTS it. `getenv("X") == nullptr` is this tree's
+# opt-OUT idiom -- it is TRUE when X is unset -- and `<= 0` is the same thing for a numeric read.
+INVERTING_TAIL_RE = re.compile(r"^\s*(?:==\s*(?:nullptr|NULL|0)\b|<=\s*0\b|<\s*1\b)")
+
+# A lambda introducer at the head of an initialiser: `[&](args) {`, `[] {`, `[=]() -> bool {`.
+LAMBDA_INTRO_RE = re.compile(r"^\s*\[[^\]\[]*\]\s*(?:\(|\{|mutable\b|constexpr\b|noexcept\b|->)")
+
+# `name =` with the compound and comparison forms excluded: `+=`/`!=`/`<=`/`==` all fail to match
+# because the character before `=` is then not part of the identifier and not whitespace.
+ASSIGN_TO_NAME_RE = re.compile(r"\b([A-Za-z_]\w*)\s*=(?!=)")
+
+# A COMPILED-IN CONSTANT -- the thing a "supply a default" statement assigns. Deliberately narrower
+# than "any value not derived from the environment": a computed RHS (`resdump = strtoull(fa, ...) ==
+# code_addr;`, gpu_executor.cpp:6417) sits under a braceless `if` whose condition this scanner does
+# not scope, so treating it as a default would retire the alias on a path that is not actually
+# reachable by default -- and that row is a live two-gate finding. A literal cannot be conditional
+# on anything the scanner missed. (`""` is what strip_comments() leaves of any non-PROSPER_ string.)
+LITERAL_RHS_RE = re.compile(
+    r"^\s*-?(?:\d+(?:\.\d*)?[uUlLfF]*|0[xX][0-9a-fA-F]+[uUlL]*"
+    r"|true|false|nullptr|NULL|\"\"|''|\{\s*\})\s*$")
+
 
 # --------------------------------------------------------------------------------------------
 # Lexing
@@ -202,6 +232,124 @@ def strip_comments(text: str) -> list[str]:
 
 def env_literals(expr: str) -> set[str]:
     return set(ENV_LITERAL_RE.findall(expr))
+
+
+# --------------------------------------------------------------------------------------------
+# Polarity
+#
+# A gate is "X must be SET". An env test that is NEGATED says the opposite, and this tree writes
+# far more of the negated form than the plain one -- `PROSPER_NO_*` is the standard opt-OUT idiom,
+# so `getenv("PROSPER_NO_RESOLVE") == nullptr` is TRUE on a default run and imposes nothing.
+# Reading those as requirements was the single commonest reason a finding was not a real coupling
+# (#2572 measured 47 of 79 reviewed rows, with this as the largest cluster; #2628).
+#
+# The negation was ALREADY pushed through for the early-return form (guard_gates()), so before this
+# the two spellings of one idea disagreed with each other:
+#
+#     if (!getenv("X")) return;        -- the remainder requires X    (correct)
+#     if (!getenv("X")) { ... }        -- the block required X        (backwards)
+#
+# It is done per LITERAL rather than per operand on purpose. A whole-operand test (the shape
+# NEGATIVE_TEST_RE encodes for guard_gates) is applied to text that is sometimes an entire function
+# body -- collect_predicates() calls clauses_of() on one -- where a single `.empty()` or `== 0`
+# anywhere would retire every gate in it. Per-literal, `getenv("A") && !getenv("B")` correctly
+# yields just {A}.
+# --------------------------------------------------------------------------------------------
+def _matching_close(expr: str, open_pos: int) -> int:
+    depth = 0
+    for pos in range(open_pos, len(expr)):
+        if expr[pos] == "(":
+            depth += 1
+        elif expr[pos] == ")":
+            depth -= 1
+            if depth == 0:
+                return pos
+    return -1
+
+
+def _enclosing_open(expr: str, idx: int) -> int:
+    """Position of the nearest `(` to the left of idx that is still open at idx, or -1."""
+    depth, j = 0, idx - 1
+    while j >= 0:
+        ch = expr[j]
+        if ch == ")":
+            depth += 1
+        elif ch == "(":
+            if depth == 0:
+                return j
+            depth -= 1
+        j -= 1
+    return -1
+
+
+_MAX_PAREN_LEVELS = 8
+
+
+def _is_negated(expr: str, idx: int) -> bool:
+    """Does an ODD number of inversions apply to the env literal at `idx`?
+
+    Walks outward through the paren groups that enclose the literal. At each level two inversions
+    are recognised, and both must be, because expand() rewrites an alias into a nested paren group:
+    `!profile_fold` becomes `!((getenv("PROSPER_STAGE_FOLD_PROFILE")))`, where the `!` is three
+    levels out from the literal.
+
+      - a `!` before the callee that opens the group -- `!getenv(`, `!*getenv(`, `!(`;
+      - an inverting comparison after the group closes -- `getenv("X") == nullptr`.
+    """
+    negated, i, levels = False, idx, 0
+    while levels < _MAX_PAREN_LEVELS:
+        open_pos = _enclosing_open(expr, i)
+        if open_pos < 0:
+            break
+        levels += 1
+        k = open_pos - 1
+        while k >= 0 and expr[k].isspace():
+            k -= 1
+        while k >= 0 and (expr[k].isalnum() or expr[k] in "_:"):   # the callee name
+            k -= 1
+        while k >= 0 and (expr[k].isspace() or expr[k] == "*"):    # `!*getenv(...)`
+            k -= 1
+        # `expr[k-1] not in "!=<>"` keeps `a != getenv(...)` and `!!x` from reading as one negation.
+        if k >= 0 and expr[k] == "!" and (k == 0 or expr[k - 1] not in "!=<>"):
+            negated = not negated
+        close = _matching_close(expr, open_pos)
+        if close >= 0 and INVERTING_TAIL_RE.match(expr[close + 1:]):
+            negated = not negated
+        i = open_pos
+    return negated
+
+
+def positive_env_literals(expr: str) -> set[str]:
+    """The PROSPER_* names this expression requires to be SET for it to be true."""
+    return {m.group(1) for m in ENV_LITERAL_RE.finditer(expr)
+            if not _is_negated(expr, m.start())}
+
+
+def split_ternary(expr: str) -> tuple[str, str, str] | None:
+    """`cond ? then : else` split at nesting depth 0, or None.
+
+    Brackets and braces count as well as parens, so the `return e ? atol(e) : 0;` inside an
+    immediately-invoked lambda is NOT seen as the initialiser's own ternary.
+    """
+    expr = unwrap(expr)
+    depth, q = 0, -1
+    i = 0
+    while i < len(expr):
+        ch = expr[i]
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif depth == 0 and ch == "?":
+            if q < 0:
+                q = i
+        elif depth == 0 and ch == ":" and q >= 0:
+            if expr[i:i + 2] == "::" or (i and expr[i - 1] == ":"):
+                i += 2
+                continue
+            return expr[:q], expr[q + 1:i], expr[i + 1:]
+        i += 1
+    return None
 
 
 def unwrap(expr: str) -> str:
@@ -271,17 +419,23 @@ def clauses_of(expr: str) -> frozenset:
         getenv(A) && getenv(B)   -- BOTH needed          -> two clauses {A}, {B}
         getenv(A) || getenv(B)   -- EITHER suffices      -> one clause {A, B}
         getenv(A) || flag        -- neither is required  -> no clause
+        getenv(A) && !getenv(B)  -- only A is required   -> one clause {A}
+        getenv(A) || !getenv(B)  -- neither is required  -> no clause
 
     Read flat, the second reads as "both required" and manufactures a two-gate finding that does
     not exist -- 133 of the first tree run's findings came from that, including one predicate the
     scanner claimed required all sixteen of its alternatives.
+
+    The last two lines are polarity (#2628): a negated env test is satisfied by the DEFAULT run, so
+    it constrains nothing, and a disjunct that is satisfiable with nothing set leaves the whole
+    disjunction unconstrained. See positive_env_literals().
     """
     disjuncts = split_top_level(expr, "||")
-    per: list[set[str]] = [env_literals(d) for d in disjuncts]
+    per: list[set[str]] = [positive_env_literals(d) for d in disjuncts]
     if len(disjuncts) == 1:
         out = set()
         for operand in split_top_level(disjuncts[0], "&&"):
-            names = env_literals(operand)
+            names = positive_env_literals(operand)
             if names:
                 out.add(frozenset(names))
         return frozenset(out)
@@ -310,6 +464,154 @@ def simplify(ctx) -> frozenset:
             continue
         out.append(c)
     return frozenset(out)
+
+
+def expand_with(aliases: dict[str, frozenset], expr: str) -> str:
+    """Splice each alias back in as an explicit `(A || B) && (C)` so clauses_of() can read it."""
+    def sub(m):
+        ctx = aliases.get(m.group(0))
+        if not ctx:
+            return m.group(0)
+        return "(" + " && ".join(
+            "(" + " || ".join(f'getenv("{n}")' for n in sorted(cl)) + ")"
+            for cl in sorted(ctx, key=lambda c: sorted(c))) + ")"
+    return re.sub(r"\b[A-Za-z_]\w*\b", sub, expr)
+
+
+def guard_clauses(cond: str, expand) -> frozenset:
+    """For `if (COND) return;` -- what the REST requires, i.e. the gates of !COND.
+
+    The negation has to be pushed through, and getting that backwards inverts the answer:
+
+        if (!a || !b) return;      remainder needs a AND b   -> two clauses
+        if (a <= 0 && !b) return;  remainder needs a OR b    -> one any-of clause
+
+    The second form is the one that mattered: reading it as "both" made the scanner keep reporting
+    the very instance #2149's fix had just repaired, because the repaired function opens with
+    exactly `if (interval <= 0 && !dump_unimpl) return;`. A checker that cannot see its own fix
+    land is worse than none -- it teaches people to regenerate past it.
+
+    Only NEGATIVE tests contribute. The negation of a positive test (`if (GATE) return;`) says the
+    remainder needs GATE unset, which is not a gate; and any operand whose negation is not an env
+    fact leaves its whole disjunct unconstrained.
+    """
+    out: set = set()
+    for disjunct in split_top_level(cond, "||"):
+        clause: set = set()
+        unconstrained = False
+        for operand in split_top_level(disjunct, "&&"):
+            if not NEGATIVE_TEST_RE.search(operand):
+                unconstrained = True
+                break
+            names = env_literals(expand(operand))
+            if not names:
+                unconstrained = True
+                break
+            clause |= names
+        if not unconstrained and clause:
+            out.add(frozenset(clause))
+    return frozenset(out)
+
+
+def split_statements(text: str) -> list[str]:
+    """Split on `;` at nesting depth 0."""
+    out, buf, depth = [], [], 0
+    for ch in text:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        elif ch == ";" and depth <= 0:
+            out.append("".join(buf))
+            buf = []
+            continue
+        buf.append(ch)
+    if "".join(buf).strip():
+        out.append("".join(buf))
+    return out
+
+
+IF_RETURN_RE = re.compile(r"^\s*if\s*\((.*)\)\s*\{?\s*return\b(.*)$", re.S)
+RETURN_RE = re.compile(r"^\s*return\b(.*)$", re.S)
+
+
+def predicate_clauses(body_text: str) -> frozenset:
+    """The requirement that calling a short bool/int predicate imposes.
+
+    This used to be `clauses_of()` over the whole joined body, which happened to work only because
+    polarity was ignored: every `PROSPER_*` literal anywhere in the body became an alternative of
+    one any-of clause. Once negation is modelled (#2628) that reading is actively wrong in BOTH
+    directions at once, and `dyntrace_failed_shader_enabled` (gpu_executor.cpp:401) shows both:
+
+        if (!std::getenv("PROSPER_DYNTRACE_FAIL")) return false;   // a GUARD -- FAIL is required
+        const char* filter = std::getenv("PROSPER_DYNTRACE_FAIL_ADDR");
+        if (!filter) return true;                                  // early SUCCESS -- optional
+
+    A flat any-of read said `FAIL|FAIL_ADDR`; a flat polarity read would have said `FAIL_ADDR` and
+    dropped the one variable that IS required, silently weakening a `defect` row's key. A predicate
+    body is a function body, so it is read as one: guards impose their negation (the same rule
+    guard_clauses() already applied to early returns in ordinary code), an early truthy return ends
+    the accumulation, and a declaration is an alias rather than a requirement of its own.
+
+    A body in which NO statement is recognised falls back to the flat reading, so a `static int v =
+    -1; if (v < 0) { ... }` memo (`audiolog_level`, hle_audio.cpp:327) keeps its gate instead of
+    quietly resolving to nothing -- the direction that disables a rule.
+
+    Statements this does not recognise contribute nothing -- the understating direction, which is
+    the one that makes no false accusation.
+    """
+    body = body_text[body_text.find("{") + 1:] if "{" in body_text else body_text
+    aliases: dict[str, frozenset] = {}
+    ctx: set = set()            # required on every path that can return true
+    alts: list[frozenset] = []  # one per `if (COND) return <truthy>;` early exit
+    tail: set = set()           # what the path falling through all of them requires
+    recognised = False
+
+    def exp(expr: str) -> str:
+        return expand_with(aliases, expr)
+
+    for stmt in split_statements(body):
+        m = IF_RETURN_RE.match(stmt)
+        if m:
+            recognised = True
+            cond = unwrap(m.group(1))
+            value = m.group(2).strip().split(";")[0].strip()
+            if value and not DEFAULT_RHS_RE.match(value):
+                alt = clauses_of(exp(cond))
+                if not alt:
+                    # `if (!filter) return true;` -- true with nothing further armed, so the guards
+                    # already collected are the whole necessary condition.
+                    return simplify(ctx)
+                alts.append(alt)
+            else:
+                (tail if alts else ctx).update(guard_clauses(cond, exp))
+            continue
+        m = RETURN_RE.match(stmt)
+        if m:
+            recognised = True
+            (tail if alts else ctx).update(clauses_of(exp(m.group(1))))
+            continue
+        dm = DECL_RE.match(stmt.strip())
+        if dm:
+            got = clauses_of(exp(dm.group(2)))
+            if got:
+                aliases[dm.group(1)] = got
+
+    if not recognised:
+        return simplify(set(clauses_of(body)))
+    if alts:
+        # Several exits can return true, so what is NECESSARY is the disjunction of their
+        # requirements -- `report_selected_sbuffer_reject` (rdna2_gta5_compute_contracts.cpp:39)
+        # returns early under PROSPER_DBG and otherwise needs PROSPER_GTA5_SBUFFER_REJECT, so
+        # either one alone reaches the report. Expressible only when every branch is a single
+        # clause; otherwise the disjunction is dropped, which understates.
+        branches = alts + [frozenset(tail)]
+        if all(len(b) == 1 for b in branches):
+            names: set[str] = set()
+            for b in branches:
+                names |= set(next(iter(b)))
+            ctx.add(frozenset(names))
+    return simplify(ctx)
 
 
 def collect_predicates(files: dict[Path, list[str]]) -> dict[str, frozenset]:
@@ -345,7 +647,7 @@ def collect_predicates(files: dict[Path, list[str]]) -> dict[str, frozenset]:
             text = " ".join(body)
             if not env_literals(text):
                 continue
-            seen.setdefault(m.group(1), []).append(clauses_of(text))
+            seen.setdefault(m.group(1), []).append(predicate_clauses(text))
     return {name: variants[0] for name, variants in seen.items()
             if variants[0] and all(v == variants[0] for v in variants)}
 
@@ -483,43 +785,45 @@ class FileScanner:
                 for cl in sorted(ctx, key=lambda c: sorted(c))) + ")"
         return re.sub(r"\b[A-Za-z_]\w*\b", sub, expr)
 
+    @staticmethod
+    def alias_is_a_gate(rhs: str) -> bool:
+        """Is this initialiser's VALUE the thing an env switch decides? Two shapes say no. #2628.
+
+        1. A STORED LAMBDA. `auto readable = [&](uint64_t a, uint32_t n) { ... }` holds a callable,
+           not a value, so the `PROSPER_*` names in its body belong to the branch inside it -- but
+           the block-scope alias path resolved them anyway and exported the requirement to every
+           later `readable(...)` CALL, invisibly at the call site. `readable`
+           (gpu_executor.cpp:2854) and `build_bds` (live_renderer.cpp:5602) are the measured
+           instances; collect_predicates() already declines to alias a whole function for exactly
+           this reason and the lambda path applied no such restriction.
+           An IMMEDIATELY-INVOKED lambda is the opposite case and stays: `static const long
+           interval = [] { ... getenv("PROSPER_PROGRESS") ...; }();` really does hold a value the
+           environment decides, and #2149's fourth measured instance depends on it resolving.
+           The two are told apart by the trailing `()`.
+
+        2. A TERNARY WITH A LIVE DEFAULT. `X ? atoi(X) : 60` yields 60 when X is unset, so the
+           value exists either way and testing it later is not an env gate. `X ? atol(X) : 0` is
+           NOT that: DEFAULT_RHS_RE is the tool's existing statement of which literals mean
+           "unset", and a falsy default keeps the alias -- which is what makes `if (interval <= 0)
+           return;` still impose PROSPER_PROGRESS.
+        """
+        body = rhs.strip().rstrip(";").strip()
+        if LAMBDA_INTRO_RE.match(body):
+            return body.endswith(")")          # invoked -> a value; stored -> a callable
+        parts = split_ternary(body)
+        if parts is not None:
+            fallback = parts[2].strip()
+            if fallback and not DEFAULT_RHS_RE.match(fallback) and "PROSPER_" not in fallback:
+                return False
+        return True
+
     def required(self, cond: str) -> frozenset:
         """The gate context a condition imposes on the block it opens."""
         return clauses_of(self.expand(cond))
 
     def guard_gates(self, cond: str) -> frozenset:
-        """For `if (COND) return;` -- what the REST of the block requires, i.e. the gates of !COND.
-
-        The negation has to be pushed through, and getting that backwards inverts the answer:
-
-            if (!a || !b) return;    remainder needs a AND b   -> two clauses
-            if (a <= 0 && !b) return;  remainder needs a OR b  -> one any-of clause
-
-        The second form is the one that mattered: reading it as "both" made the scanner keep
-        reporting the very instance this issue's fix had just repaired, because the repaired
-        function opens with exactly `if (interval <= 0 && !dump_unimpl) return;`. A checker that
-        cannot see its own fix land is worse than none -- it teaches people to regenerate past it.
-
-        Only NEGATIVE tests contribute. The negation of a positive test (`if (GATE) return;`)
-        says the remainder needs GATE unset, which is not a gate; and any operand whose negation
-        is not an env fact leaves its whole disjunct unconstrained.
-        """
-        out: set = set()
-        for disjunct in split_top_level(cond, "||"):
-            clause: set = set()
-            unconstrained = False
-            for operand in split_top_level(disjunct, "&&"):
-                if not NEGATIVE_TEST_RE.search(operand):
-                    unconstrained = True
-                    break
-                names = env_literals(self.expand(operand))
-                if not names:
-                    unconstrained = True
-                    break
-                clause |= names
-            if not unconstrained and clause:
-                out.add(frozenset(clause))
-        return frozenset(out)
+        """For `if (COND) return;` -- what the REST of the block requires. See guard_clauses()."""
+        return guard_clauses(cond, self.expand)
 
     # -- the walk ----------------------------------------------------------------------------
     def note_local(self, var: str, line_no: int, gates: frozenset, is_write: bool):
@@ -663,6 +967,38 @@ class FileScanner:
                     for ident in IDENT_RE.findall(args):
                         self.note_local(ident, i + 1, here, False)
 
+            # ---- a DEFAULTED alias stops being (only) its own gate -------------------------
+            # `const char* out = getenv("X"); if (!out || !*out) out = "shader0.bin";` leaves `out`
+            # holding a compiled-in default on exactly the path where X is unset, so every later
+            # `if (...out...)` is not gated on X at all (hle_graphics.cpp:1249). The repair sits
+            # inside an `if`, so the SPLIT-LOCAL write path never saw it. #2628.
+            #
+            # The alias is WIDENED rather than dropped, because the second value may itself be
+            # reachable only under a different switch -- `if (g_dyntrace_force) resdump = true;`
+            # (gpu_executor.cpp:6418) means `resdump` is true under PROSPER_RESDUMP *or* under the
+            # dyntrace-failure replay, which is a real any-of requirement and not "no requirement".
+            # Dropping it there would have retired a live coupling; widening keeps it and still
+            # collapses the `out` case, because the default is assigned inside the alias's own gate
+            # so simplify() absorbs the widened clause into it.
+            for am2 in ASSIGN_TO_NAME_RE.finditer(line):
+                name = am2.group(1)
+                value = line[am2.end():].split(";")[0]
+                if not LITERAL_RHS_RE.match(value):
+                    continue
+                for s in reversed(self.stack):
+                    if name not in s.aliases:
+                        continue
+                    at = simplify(set(here) | set(cond_gates))
+                    have = s.aliases[name]
+                    if len(at) == 1 and len(have) == 1:
+                        s.aliases[name] = frozenset(
+                            {frozenset(next(iter(have)) | next(iter(at)))})
+                    else:
+                        # Reachable with nothing armed, or a requirement no single clause can
+                        # express: the alias no longer stands for an env switch.
+                        del s.aliases[name]
+                    break
+
             # ---- scoped alias declaration --------------------------------------------------
             if cond is None:
                 dm2 = DECL_RE.match(line)
@@ -671,7 +1007,7 @@ class FileScanner:
                     rhs, used = self.gather_statement(i, eq + 1) if eq >= 0 else (dm2.group(2), 1)
                     consumed = max(consumed, used)
                     ctx = clauses_of(self.expand(rhs))
-                    if ctx:
+                    if ctx and self.alias_is_a_gate(rhs):
                         self.stack[-1].aliases[dm2.group(1)] = ctx
 
             # ---- brace bookkeeping ---------------------------------------------------------
@@ -708,6 +1044,18 @@ class FileScanner:
         return self.findings
 
 
+def implies(a: frozenset, b: frozenset) -> bool:
+    """Does satisfying gate context `a` also satisfy `b`? (CNF absorption, one direction.)
+
+    `{A}` implies `{A|B}`: arming A satisfies both. simplify() already collapses that pair inside a
+    single context; two SEPARATE contexts were compared by clause-set IDENTITY, so an implication
+    read as a disagreement -- `hle_audio.cpp` `audio2log`, called under {AUDIO2LOG} at :1698 and
+    under {AUDIO2LOG|AUDIO2_PROBE} at :1901, where the first site's arming satisfies the second.
+    #2628.
+    """
+    return all(any(ca <= cb for ca in a) for cb in b)
+
+
 def split_call_findings(call_sites: dict[str, list[tuple[str, frozenset]]],
                         defined: set[str]) -> list[Finding]:
     """SPLIT-CALL: a callee reached only under gates whose call sites do not agree.
@@ -728,7 +1076,7 @@ def split_call_findings(call_sites: dict[str, list[tuple[str, frozenset]]],
         pair = None
         for a in distinct:
             for b in distinct:
-                if a != b and not (a & b):
+                if a != b and not (a & b) and not implies(a, b) and not implies(b, a):
                     pair = (a, b)
                     break
             if pair:
@@ -861,9 +1209,98 @@ def inventory(files: dict[Path, list[str]]) -> dict[str, list[str]]:
 
 
 # --------------------------------------------------------------------------------------------
+# Paired arms for the four lexical limits closed in #2628.
+#
+# Every one of those fixes makes the scanner report FEWER findings, which is the direction that can
+# silently disable a rule -- this scanner has already done it once (`SPLIT-LOCAL` reporting 0 across
+# `src/` while structurally blind, in the audit's `## Ruled out`). So each is written as a PAIR that
+# differs only in the property under test, and the must-match half is what stops "fewer findings"
+# from becoming "no findings":
+#
+#   1 polarity        `== nullptr` vs `!= nullptr` -- ONE character apart
+#                     `if (!getenv(X)) { ... }` vs `if (!getenv(X)) return;` -- the two spellings
+#                     that used to disagree with each other
+#   2 defaulted alias the same function with and without its `if (!out) out = "...";` repair line
+#                     `? atoi(e) : 60` vs `? atoi(e) : 0` -- one character, and the difference
+#                     between an optional parameter and an off-by-default switch
+#   3 lambda alias    the same body STORED (`auto g = [&]{...};`, called later) vs IMMEDIATELY
+#                     INVOKED (`const bool g = [&]{...}();`). The use site differs -- `g(...)` vs
+#                     `g` -- because it must: that IS the property under test, and no C++ spells
+#                     both the same way. The assertion is on the exact rendered requirement, which
+#                     only the alias branch can produce.
+#   4 split-call      a second call site whose gate is IMPLIED by the first (`{A}` vs `{A|B}`)
+#                     versus one that is DISJOINT from it (`{A}` vs `{B}`)
+#
+# Each must-not-match half was checked to be a FINDING on the pre-#2628 scanner, so none of them is
+# passing because it was never in the rule's reach.
+#
+# Two further arms cover predicate_clauses(), which polarity forced to be rewritten: a predicate
+# whose body is `guard; optional filter; early success` must impose the GUARD's variable and not
+# the filter's, and one with two truthy exits must impose their disjunction. Both assert the exact
+# requirement string, so dropping a variable and adding one fail differently.
+# --------------------------------------------------------------------------------------------
+_OPT_OUT = """
+void report(const State& st) {
+    static const bool resolve_on = std::getenv("PROSPER_ZZ_NO_RESOLVE") %s nullptr;
+    if (resolve_on) {
+        if (getenv("PROSPER_ZZ_RESOLVE_LOG")) fprintf(stderr, "[zz] %%u\\n", st.id);
+    }
+}
+"""
+
+_DEFAULTED_ALIAS = """
+void dump_shader(const char* nid) {
+    if (getenv("PROSPER_ZZ_AGCSHADER")) {
+        const char* out = getenv("PROSPER_ZZ_AGCSHADER_OUT");
+%s        if (FILE* f = fopen(out, "wb")) { fprintf(stderr, "  [wrote %%s]\\n", out); }
+    }
+}
+"""
+
+_TERNARY_DEFAULT = """
+void dump_pass(uint64_t frame) {
+    if (getenv("PROSPER_ZZ_DUMP_PASS")) {
+        const char* e = getenv("PROSPER_ZZ_DUMP_PASS_EVERY");
+        const int every = e ? atoi(e) : %s;
+        if (every) { fprintf(stderr, "  [pass every=%%d]\\n", every); }
+    }
+}
+"""
+
+_LAMBDA_ALIAS = """
+void fold(const Stage& s) {
+    %s
+    if (getenv("PROSPER_ZZ_DYNTRACE")) {
+        if (%s) fprintf(stderr, "[zz] %%llu\\n", s.addr);
+    }
+}
+"""
+
+_SPLIT_CALL_GATES = """
+bool audio2log() {
+    static const bool on = std::getenv("PROSPER_ZZ_AUDIO2LOG") != nullptr;
+    return on;
+}
+void probe_dump(uint64_t p) {
+    g_history.insert(p);
+}
+void trace_call(uint64_t p) {
+    if (audio2log()) {
+        probe_dump(p);
+    }
+}
+void trace_probe(uint64_t p) {
+    if (%s) {
+        probe_dump(p);
+    }
+}
+"""
+
+
+# --------------------------------------------------------------------------------------------
 # Self-test. Every case is a shape MEASURED in this tree, reduced to the smallest form that keeps
-# the signature. Five of the nine assert on what must NOT match: a checker that fires on sound
-# code gets skipped, not heeded.
+# the signature. More than half assert on what must NOT match: a checker that fires on sound code
+# gets skipped, not heeded.
 #
 # This is also the positive control the charter demands, and it is deliberately NOT drawn from the
 # tree scan: a control built by the same machinery as the null inherits the null's blind spots and
@@ -1019,6 +1456,101 @@ void diagnose_resource_provenance(const State& st) {
     }
 }
 """, []),
+
+    # ---- #2628 limit 1: polarity ------------------------------------------------------------
+    # The opt-OUT idiom is this tree's standard default-ON switch, so PROSPER_ZZ_NO_RESOLVE being
+    # in the requirement was backwards: the block runs when it is UNSET. Its partner differs by
+    # one character and must still be a two-gate report.
+    ("opt-out (`== nullptr`) is satisfied by a DEFAULT run, so it gates nothing",
+     _OPT_OUT % "==", []),
+    ("opt-in (`!= nullptr`) is a real gate -- one character from the arm above",
+     _OPT_OUT % "!=", ["TWO-GATE:PROSPER_ZZ_NO_RESOLVE+PROSPER_ZZ_RESOLVE_LOG"]),
+    # These two spellings of one idea used to DISAGREE: the negation was pushed through for the
+    # early-return form and not for the block form, so the same code flagged or not depending on
+    # how the author wrote it. Now the block imposes nothing and the remainder still imposes ALPHA.
+    ("`if (!getenv(X)) { ... }` runs when X is UNSET -- the block requires nothing", """
+void report(const State& st) {
+    if (!getenv("PROSPER_ZZ_ALPHA")) {
+        if (getenv("PROSPER_ZZ_BETA")) fprintf(stderr, "[zz] %u\\n", st.id);
+    }
+}
+""", []),
+    ("`if (!getenv(X)) return;` still makes the REMAINDER require X", """
+void report(const State& st) {
+    if (!getenv("PROSPER_ZZ_ALPHA")) return;
+    if (getenv("PROSPER_ZZ_BETA")) fprintf(stderr, "[zz] %u\\n", st.id);
+}
+""", ["TWO-GATE:PROSPER_ZZ_ALPHA+PROSPER_ZZ_BETA"]),
+
+    # ---- #2628 limit 2: a defaulted alias -----------------------------------------------------
+    # hle_graphics.cpp:1249 reduced. The mutation arm is the SAME function with the one repair line
+    # deleted, so nothing else in the fixture can account for the difference.
+    ("a defaulted alias is not a gate (`if (!out) out = \"shader0.bin\";`)",
+     _DEFAULTED_ALIAS % '        if (!out || !*out) out = "shader0.bin";\n', []),
+    ("...and WITHOUT that one repair line the coupling is real",
+     _DEFAULTED_ALIAS % "", ["TWO-GATE:PROSPER_ZZ_AGCSHADER+PROSPER_ZZ_AGCSHADER_OUT"]),
+    # `: 60` is an optional parameter; `: 0` is a switch that is off by default. One character, and
+    # DEFAULT_RHS_RE -- the tool's existing statement of which literals mean "unset" -- decides.
+    ("a ternary with a LIVE default (`: 60`) is a parameter, not a gate",
+     _TERNARY_DEFAULT % "60", []),
+    ("a ternary with a FALSY default (`: 0`) is a gate",
+     _TERNARY_DEFAULT % "0", ["TWO-GATE:PROSPER_ZZ_DUMP_PASS+PROSPER_ZZ_DUMP_PASS_EVERY"]),
+
+    # ---- #2628 limit 3: a lambda is not an alias for its body ---------------------------------
+    # `readable` (gpu_executor.cpp:2854) reduced: a helper whose body carries an env branch used to
+    # export that requirement to every CALL of it, invisibly at the call site. An immediately
+    # invoked lambda is the opposite case -- it yields a value the environment decides -- and
+    # #2149's fourth measured instance depends on that one still resolving.
+    ("a STORED lambda does not export its body's switches to its call sites",
+     _LAMBDA_ALIAS % ('auto readable = [&](uint64_t a) { const bool gfxlog = '
+                      'getenv("PROSPER_ZZ_GFXLOG") != nullptr; return gfxlog && guest_readable(a); };',
+                      "readable(s.addr)"), []),
+    ("an IMMEDIATELY INVOKED lambda holds a value the environment decides, and still aliases",
+     _LAMBDA_ALIAS % ('const bool readable = [&] { const bool gfxlog = '
+                      'getenv("PROSPER_ZZ_GFXLOG") != nullptr; return gfxlog && guest_readable(0); }();',
+                      "readable"), ["TWO-GATE:PROSPER_ZZ_DYNTRACE+PROSPER_ZZ_GFXLOG"]),
+
+    # ---- #2628 limit 4: SPLIT-CALL compared clause sets by identity ---------------------------
+    # hle_audio.cpp reduced: {AUDIO2LOG} at one site and {AUDIO2LOG|AUDIO2_PROBE} at another are
+    # not a disagreement -- arming the first satisfies both. A DISJOINT second gate still is.
+    ("call sites whose gates IMPLY one another do not disagree",
+     _SPLIT_CALL_GATES % 'audio2log() || getenv("PROSPER_ZZ_AUDIO2_PROBE")', []),
+    ("call sites whose gates are DISJOINT still disagree",
+     _SPLIT_CALL_GATES % 'getenv("PROSPER_ZZ_AUDIO2_PROBE")', ["SPLIT-CALL:probe_dump"]),
+
+    # ---- predicate bodies, which polarity forced to be modelled ------------------------------
+    # dyntrace_failed_shader_enabled (gpu_executor.cpp:401) reduced. The flat reading joined both
+    # variables into one any-of clause; a flat POLARITY reading would have kept only the optional
+    # one and dropped the required one, quietly weakening a `defect` row's key. The assertion is
+    # the exact requirement, so either error fails it.
+    ("a predicate's guard is required and its optional filter is not", """
+bool dynfail_enabled(uint64_t code_addr) {
+    if (!std::getenv("PROSPER_ZZ_DYNFAIL")) return false;
+    const char* filter = std::getenv("PROSPER_ZZ_DYNFAIL_ADDR");
+    if (!filter) return true;
+    return strtoull(filter, nullptr, 16) == code_addr;
+}
+void replay(const Draw& d) {
+    if (dynfail_enabled(d.vs)) {
+        if (getenv("PROSPER_ZZ_DYNFAIL_LOG")) fprintf(stderr, "[zz] 0x%llx\\n", d.vs);
+    }
+}
+""", ["TWO-GATE:PROSPER_ZZ_DYNFAIL+PROSPER_ZZ_DYNFAIL_LOG"]),
+    # Two exits can return true, so EITHER variable reaches the report -- one any-of clause, not
+    # two requirements and not nothing. report_selected_sbuffer_reject
+    # (rdna2_gta5_compute_contracts.cpp:39) reduced.
+    ("a predicate with two truthy exits requires their DISJUNCTION", """
+bool report_reject(const uint32_t* code) {
+    if (std::getenv("PROSPER_ZZ_DBG")) return true;
+    if (!std::getenv("PROSPER_ZZ_REJECT")) return false;
+    return code != nullptr;
+}
+void reject(const uint32_t* code, const State& st) {
+    if (report_reject(code)) {
+        if (getenv("PROSPER_ZZ_REJECT_LOG")) fprintf(stderr, "[zz] %u\\n", st.id);
+    }
+}
+""", ["TWO-GATE:PROSPER_ZZ_DBG|PROSPER_ZZ_REJECT+PROSPER_ZZ_REJECT_LOG"]),
 ]
 
 

--- a/prosper/tools/env/diag_gate_baseline.txt
+++ b/prosper/tools/env/diag_gate_baseline.txt
@@ -28,12 +28,33 @@
 # the pair delivered. A shared family cannot be the end of an argument, so it does not get to be a
 # class that reads like a clearance.
 #
-# #2628 SHARPENED THE SCANNER, so this file shrank from 93 keys to 54 and 15 of the survivors
-# re-keyed. That is the direction which can silently disable a rule, so the rows were NOT
-# regenerated: every surviving row was matched to its predecessor by the finding's own file:line,
-# and 38 removals and 15 re-keys were read one at a time. Rows that re-keyed carry
-# `[#2628 re-keyed; was ...]` so the previous requirement stays greppable. What went away, by the
-# mechanism that produced it:
+# #2628 SHARPENED THE SCANNER, so this file shrank from 93 keys to 54. That is the direction which
+# can silently disable a rule, so the rows were NOT regenerated: every surviving row was matched to
+# its predecessor by the finding's own file:line, and every removal and re-key was read one at a
+# time. Rows that re-keyed carry `[#2628 re-keyed; was ...]` so the previous requirement stays
+# greppable.
+#
+# THE COUNTS, AND THE CONVENTION THEY ARE COUNTED UNDER -- stated because the obvious alternative
+# gives different numbers and the two were mixed in an earlier revision of this header:
+#
+#   ROWS IN THIS FILE          39 unchanged  + 14 re-keyed + 1 new = 54
+#   KEYS ON THE PREVIOUS FILE  39 unchanged  + 14 named as a predecessor by a marker
+#                                            + 40 with no successor recorded = 93
+#
+# The convention is: count ROWS here, and account for the previous file's keys by whether a marker
+# names them. Both numbers are then things a merger can GREP, which is the only property that
+# matters -- these counts exist to tell whoever merges the sibling branch how many rows to expect,
+# so a count they cannot reproduce with `grep` sends them hunting for a row nobody lost.
+#   * `grep -c '\[#2628 re-keyed; was'` over this file returns 15, not 14. The fifteenth hit is the
+#     mention four lines above this one. `grep -v '^#'` first.
+#   * The rejected alternative counts the PREVIOUS file's keys by which surviving row absorbed
+#     them, giving 39 + 16 + 38 or 39 + 17 + 37 depending on whether a SPLIT-LOCAL and a TWO-GATE
+#     sharing one line count as the same absorption. That it has two defensible answers is the
+#     reason it is not used: a number nobody can re-derive identically is worse than a coarser one.
+#     It is not wrong, and it is why 14 markers do not account for 54 departed keys -- see the
+#     PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT row below.
+#
+# What went away, by the mechanism that produced it:
 #   * a negated env test read as a requirement -- the `PROSPER_NO_*` opt-out idiom, the default-on
 #     PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET mode, and BOTH of the convention's own rule-2
 #     shapes (guest_write_watch.cpp:1372's refusal, gpu_timeline.cpp:2288/:2742's half-a-pair
@@ -51,7 +72,11 @@
 # Regenerate the key list with:
 #     python3 tools/env/check_diag_gates.py <root> --emit-baseline
 # then re-apply the classifications. Never let a regeneration silently downgrade a `defect` row to
-# `unreviewed` -- that is the laundering this tool exists to prevent, performed by hand.
+# `unreviewed` -- that is the laundering this tool exists to prevent, performed by hand. Since #2628
+# that sentence is also ENFORCED: the class counts below must match the rows, and the `unreviewed`
+# count must equal UNREVIEWED_BUDGET in check_diag_gates.py exactly, in both directions. So a
+# regeneration fails the gate, and paying debt down requires tightening the budget in the same
+# commit. (Note that --emit-baseline currently writes its banner to stdout as well -- #2649.)
 #   benign: 2
 #   config-echo: 10
 #   defect: 2
@@ -82,7 +107,7 @@ SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_target_width|PROSPER_GPU_TIMELINE_CA
 TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DETILE+PROSPER_DUMP_RAWTILE  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_DETILE+PROSPER_DUMP_RAWTILE+PROSPER_NODETILE`]
 TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_MRT_CENSUS+PROSPER_MRT_SHAPE_FOR  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_MRT_CENSUS+PROSPER_MRT_SHAPE_FOR+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
 TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RENDER_TIMING+PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_GFXLOG|PROSPER_RENDER_REFVS|PROSPER_SKIP_DRAW+PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT`] -- THIS ROW ABSORBED THREE predecessor keys, and only the one recorded here carries a note that still applies. The other two are `PROSPER_GFXLOG|PROSPER_RENDER_REFVS|PROSPER_SKIP_DRAW+PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET` and `PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`. DO NOT carry the first one's note across when merging #2572: it opens `benign: LAMBDA ALIAS plus defaults. The {GFXLOG|RENDER_REFVS|SKIP_DRAW} clause comes from build_bds (live_renderer.cpp:5602)`, and that clause is exactly what #2628 removed -- the argument is about a requirement this row no longer has. The recorded predecessor's note transfers whole, and was re-checked against the source: MIN/MAX are an optional submit WINDOW defaulting to 0..INT_MAX (:1415-1416 falls back to 0, :1417-1418 to INT_MAX, which is why alias_is_a_gate() retires only MAX), and the arming switch is PROSPER_RTTLOG alone (:1422). #2572
 TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_GUESTPEEK  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_RTTLOG|PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_GUESTPEEK+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
 TWO-GATE|src/gpu/command_processor.cpp|report|PROSPER_GENERATION_GUARD+PROSPER_MB3_FREELIST_GUARD  # unreviewed: not judged
 TWO-GATE|src/gpu/command_processor.cpp|report|PROSPER_INIT_TRIP+PROSPER_MB3_FREELIST_GUARD  # unreviewed: not judged

--- a/prosper/tools/env/diag_gate_baseline.txt
+++ b/prosper/tools/env/diag_gate_baseline.txt
@@ -28,6 +28,26 @@
 # the pair delivered. A shared family cannot be the end of an argument, so it does not get to be a
 # class that reads like a clearance.
 #
+# #2628 SHARPENED THE SCANNER, so this file shrank from 93 keys to 54 and 15 of the survivors
+# re-keyed. That is the direction which can silently disable a rule, so the rows were NOT
+# regenerated: every surviving row was matched to its predecessor by the finding's own file:line,
+# and 38 removals and 15 re-keys were read one at a time. Rows that re-keyed carry
+# `[#2628 re-keyed; was ...]` so the previous requirement stays greppable. What went away, by the
+# mechanism that produced it:
+#   * a negated env test read as a requirement -- the `PROSPER_NO_*` opt-out idiom, the default-on
+#     PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET mode, and BOTH of the convention's own rule-2
+#     shapes (guest_write_watch.cpp:1372's refusal, gpu_timeline.cpp:2288/:2742's half-a-pair
+#     complaints), which were flagged for complying with #2149;
+#   * an alias holding a compiled-in default (PROSPER_AGCSHADER_OUT);
+#   * a stored lambda exporting its body's switches to its call sites (PROSPER_STAGE_FOLD_PROFILE);
+#   * two call-site gates where one IMPLIES the other rather than disagreeing (hle_audio audio2log).
+# Rule ONE's shape still produces findings and deliberately so: command_processor.cpp:1572's
+# armed-state banner is conditioned on both switches by construction, and no lexical test separates
+# "this banner explains the other switch" from "this report silently needs it". Both
+# command_processor rows are still here.
+# One row is NEW and is the rule working rather than decaying: with the spurious shared clause gone,
+# SPLIT-CALL can see that diagnostic_elapsed_ms's three sites disagree.
+#
 # Regenerate the key list with:
 #     python3 tools/env/check_diag_gates.py <root> --emit-baseline
 # then re-apply the classifications. Never let a regeneration silently downgrade a `defect` row to
@@ -35,22 +55,19 @@
 #   benign: 2
 #   config-echo: 10
 #   defect: 2
-#   unreviewed: 79
+#   unreviewed: 40
 #
-SPLIT-CALL|src/gpu/command_processor.cpp|generation_guard|PROSPER_GENERATION_GUARD+PROSPER_MB3_FREELIST_GUARD  # benign: the callee is a BEHAVIOUR predicate, not a producer of printed state -- there is no field it could leave unmeasured. The rule's shape matches; its subject does not.
+SPLIT-CALL|frontends/shared/live_renderer.cpp|diagnostic_elapsed_ms|PROSPER_DUMP_PERSISTENT+PROSPER_PASS_LOG  # benign: the callee is a pure clock read (live_renderer.cpp:534-538 returns steady_clock::now() minus a function-local static origin) -- it holds no counter and prints nothing, so no call site can leave a producer unarmed. Its own comment (:530-533) states the shared origin is deliberate, so `ms:` windows in PROSPER_PASS_LOG and PROSPER_DUMP_PERSISTENT aim at one instant. Surfaced by #2628: the spurious clause the three sites used to share is gone, so the rule can now see they disagree. #2628
 SPLIT-CALL|src/gpu/gpu_timeline.cpp|automatic_capture_bundle_gate_conflicts|PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG+PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-SPLIT-CALL|src/hle/hle_audio.cpp|audio2log|PROSPER_AUDIO2LOG+PROSPER_AUDIO2LOG|PROSPER_AUDIO2_PROBE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 SPLIT-CALL|src/host/exec_image_linux.cpp|arm_hwwatch|PROSPER_HWBP|PROSPER_HWWATCH+PROSPER_HWWATCH_ABS  # benign: two DELIBERATE entry points into one arming helper (absolute watch vs register-relative on the first exec-bp hit). Neither switch is a producer for the other's printer, and nothing prints a field either could have measured.
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_compute_image_hit|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_submit_query|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_validated_bytes|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_validation_ms|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_active|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_disabled|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_only|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_query|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_stability|(any)  # unreviewed: not judged
-SPLIT-LOCAL|frontends/shared/live_renderer.cpp|seed|PROSPER_RTT_NOSEED  # unreviewed: not judged
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_submit_query|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_validated_bytes|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_validation_ms|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_active|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_disabled|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_only|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_query|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB+PROSPER_TEXTURE_WRITE_WATCH_MIN_KB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
+SPLIT-LOCAL|frontends/shared/live_renderer.cpp|resource_texture_watch_stability|PROSPER_NO_TEXTURE_DECODE_CACHE|PROSPER_TEXTURE_DECODE_CACHE_MB  # unreviewed: not judged [#2628 re-keyed; was `(any)`]
 SPLIT-LOCAL|src/gpu/gpu_executor.cpp|fresh|PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE|PROSPER_UDPROV  # defect: #2569 fresh_extent: prints 0, which reads as 'the bind programmed nothing'
 SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_after_compute_program|PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM  # config-echo: selector value echoed by [timeline]; 0 truthfully means UNCONSTRAINED
 SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_compute_program|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM  # config-echo: selector value echoed by [timeline]; 0 truthfully means UNCONSTRAINED
@@ -62,50 +79,17 @@ SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_min_draws|PROSPER_GPU_TIMELINE_CAPTU
 SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_target_height|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM  # config-echo: selector value echoed by [timeline]; 0 truthfully means UNCONSTRAINED
 SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_target_min_index|PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRAW_INDEX  # config-echo: selector value echoed by [timeline]; 0 truthfully means UNCONSTRAINED
 SPLIT-LOCAL|src/gpu/gpu_timeline.cpp|select_target_width|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM  # config-echo: selector value echoed by [timeline]; 0 truthfully means UNCONSTRAINED
-SPLIT-LOCAL|tests/render_runner.h|cached_color|PROSPER_NO_BACKEND_PERSISTENT_COLOR_TARGETS  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_compute.cpp|report|PROSPER_COMPUTE_PHASE_TIMING+PROSPER_COMPUTE_TIMING_TRACE_ONLY  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|frontends/shared/live_compute.cpp|report|PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION+PROSPER_NO_IMPORTED_IMAGE_GUEST_BYPASS+PROSPER_NO_NATIVE_2D_COMPUTE_TRANSFER|PROSPER_NO_NATIVE_3D_COMPUTE_TRANSFER  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|frontends/shared/live_compute.cpp|report|PROSPER_NO_NORMALIZED_UNORM_RTT_BIND|PROSPER_NO_UNORM_RTT_VALUE_REUSE+PROSPER_RENDER_SCALE  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|(any)+PROSPER_DETILE_STATS  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|(any)+PROSPER_DSBRIDGE_LOG  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|(any)+PROSPER_DS_UNBRIDGED_FAR  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|(any)+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DETILE+PROSPER_DUMP_RAWTILE+PROSPER_NODETILE  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DSLOG+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_DRAWSTEPS+PROSPER_GFXLOG|PROSPER_RENDER_REFVS|PROSPER_SKIP_DRAW+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_PASS+PROSPER_DUMP_PASS_EVERY+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_PASS+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_PERSISTENT+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_RAWTILE+PROSPER_NODETILE  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_RTGROUPS+PROSPER_DUMP_RTGROUPS_ADDR+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_RTGROUPS_ADDR+PROSPER_DUMP_RTGROUPS_RGBA+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_SAMPLED_RTT+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_EAGER_RESOLVE_READBACK+PROSPER_NO_RESOLVE+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_GFXLOG|PROSPER_RENDER_REFVS|PROSPER_SKIP_DRAW+PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_MRT_CENSUS+PROSPER_MRT_SHAPE_FOR+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_MRT_CENSUS+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_NO_RESOLVE+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_PASS_LOG+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_PASS_LOG|PROSPER_PASS_LOG_NODEFER+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_READBACK_WHY+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DETILE+PROSPER_DUMP_RAWTILE  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_DETILE+PROSPER_DUMP_RAWTILE+PROSPER_NODETILE`]
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_MRT_CENSUS+PROSPER_MRT_SHAPE_FOR  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_MRT_CENSUS+PROSPER_MRT_SHAPE_FOR+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
 TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RENDER_TIMING+PROSPER_RENDER_TIMING_DETAIL_MIN_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RESOLVE_CENSUS+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG|PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_GUESTPEEK+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG|PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_NOSEED+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG|PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET  # unreviewed: not judged
-TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET+PROSPER_TARGET_STEP_HASH_MIN_DRAWS  # unreviewed: not judged
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_GFXLOG|PROSPER_RENDER_REFVS|PROSPER_SKIP_DRAW+PROSPER_RTTLOG+PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_GUESTPEEK  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_RTTLOG|PROSPER_RTTLOG_MAX_SUBMIT|PROSPER_RTTLOG_MIN_SUBMIT+PROSPER_RTT_GUESTPEEK+PROSPER_RTT|PROSPER_RTT_PERTARGET|PROSPER_RTT_SINGLE_TARGET`]
 TWO-GATE|src/gpu/command_processor.cpp|report|PROSPER_GENERATION_GUARD+PROSPER_MB3_FREELIST_GUARD  # unreviewed: not judged
 TWO-GATE|src/gpu/command_processor.cpp|report|PROSPER_INIT_TRIP+PROSPER_MB3_FREELIST_GUARD  # unreviewed: not judged
 TWO-GATE|src/gpu/gpu_execute.hpp|report|PROSPER_CAPTION_DIAG+PROSPER_FRAME_DIR  # unreviewed: not judged
-TWO-GATE|src/gpu/gpu_execute.hpp|report|PROSPER_FORCE_COLORWRITE+PROSPER_NO_EARLY_NO_EFFECT  # unreviewed: not judged
 TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_COMPUTE_TREE_WATCH_AUX+PROSPER_COMPUTE_TREE_WATCH_DUMP  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL|PROSPER_DYNTRACE_FAIL_ADDR|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN  # defect: #2146 [udtail]: the one report answering #305 also needs PROSPER_UD_TAIL_ALIGN, which the charter requires stay OFF
-TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE|PROSPER_DYNTRACE_FAIL|PROSPER_DYNTRACE_FAIL_ADDR+PROSPER_STAGE_FOLD_PROFILE  # unreviewed: not judged
-TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE|PROSPER_UDPROV+PROSPER_RESDUMP  # unreviewed: not judged
-TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_CAPTURE_BUNDLE+PROSPER_CAPTURE_BUNDLE_AFTER_GUEST_LOG  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_CAPTURE_BUNDLE+PROSPER_CAPTURE_BUNDLE_TRIGGER_FILE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
+TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN  # defect: #2146 [udtail]: the one report answering #305 also needs PROSPER_UD_TAIL_ALIGN, which the charter requires stay OFF [#2628 re-keyed; was `PROSPER_DYNTRACE_FAIL|PROSPER_DYNTRACE_FAIL_ADDR|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN`]
+TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL|PROSPER_RESDUMP+PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE|PROSPER_UDPROV  # unreviewed: not judged [#2628 re-keyed; was `PROSPER_GPU_CAPTURE_RESOURCE_PROVENANCE|PROSPER_UDPROV+PROSPER_RESDUMP`]
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_AFTER_COMPUTE_PROGRAM+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE+PROSPER_GPU_TIMELINE_CAPTURE_CHECKPOINT_EVERY+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_BUNDLE+PROSPER_GPU_TIMELINE_CAPTURE_DEPTH+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
@@ -121,12 +105,9 @@ TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_TARGET_DRA
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_COMPUTE_PROGRAM+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_DISPATCH_DIM+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/gpu/gpu_timeline.cpp|report|PROSPER_GPU_TIMELINE_CAPTURE_WHEN_TARGET_DIM+PROSPER_GPU_TIMELINE_CAPTURE|PROSPER_GPU_TIMELINE_CAPTURE_SUBMIT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|src/hle/hle_graphics.cpp|report|PROSPER_AGCSHADER+PROSPER_AGCSHADER_OUT  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/hle/hle_pad.cpp|report|PROSPER_PAD_SCRIPT+PROSPER_PAD_SCRIPT_RELOAD  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|src/host/exec_image_win.cpp|report|PROSPER_NULL_PAGE+PROSPER_NULL_PAGE_LOG  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
-TWO-GATE|src/host/guest_write_watch.cpp|report|PROSPER_DMEM_CALLER+PROSPER_DMEM_WRITE_TRACE  # unreviewed: not judged; every gate shares a name family (TRIAGE ONLY -- see the header)
 TWO-GATE|tests/render_runner.h|report|PROSPER_BACKEND_TIMING_WINDOWS+PROSPER_RENDER_TIMING  # unreviewed: not judged
 TWO-GATE|tests/render_runner.h|report|PROSPER_DRAW_ISO+PROSPER_ISO_AT  # unreviewed: not judged
-TWO-GATE|tests/render_runner.h|report|PROSPER_NO_BACKEND_PIPELINE_CACHE+PROSPER_PIPEKEY_LOG  # unreviewed: not judged
 TWO-GATE|tools/boot_trace/boot_trace.cpp|report|PROSPER_CRASHPEEK+PROSPER_PEEK_CLASS  # unreviewed: not judged
 TWO-GATE|tools/boot_trace/boot_trace.cpp|report|PROSPER_CRASHPEEK+PROSPER_PEEK_CODE  # unreviewed: not judged


### PR DESCRIPTION
Fixes #2628
Refs #2572
Refs #2149

> ### MERGE COLLISION — read before merging this or PR #2643
>
> **Merge THIS PR first, #2643 second.** That order was established by running all four combinations
> of "which merges second" × "which file the merger keeps" (recorded in the review on both PRs).
> Exactly one combination fails *silently*: **#2644 merging second and keeping its own baseline
> passes CI green with all 79 of #2643's notes gone.** Landing this PR first removes that cell from
> the board — every wrong resolution then either fails CI or is self-evidently an author deleting
> their own diff. A second reason points the same way: this baseline says 40 rows are *"tracked by
> #2572"*, which is true only while #2572 is open, and #2643 closes it.
>
> **This PR and PR #2643 (`fix/issue-2572-diag-baseline-triage`) conflict with each other by
> construction.** Each merges cleanly onto `master` alone; together they rewrite the same two files:
> `prosper/tools/env/diag_gate_baseline.txt` and `prosper/docs/DIAGNOSTIC_GATE_AUDIT.md`. #2643
> annotates all 79 `unreviewed` rows; this PR sharpens the scanner so the key set shrinks from 93 to
> 54. `git merge-tree` on the two heads reports `CONFLICT (content)` in **both** files, so the
> conflict is real and will be presented — the danger is resolving it by picking a side.
>
> **Whoever merges second must re-apply #2643's notes onto this PR's keys, and must NOT take either
> baseline file whole.** Taking a file whole is the trap-41 / #1701 failure mode: it reverts the
> other lane's edits with no conflict, no failing check, and a diff that reads as your own edit.
>
> **The counts a merger should expect, and the convention they are counted under:**
>
> | | rows in the new baseline | keys in the old one |
> | --- | --- | --- |
> | unchanged | 39 | 39 |
> | re-keyed (carry `[#2628 re-keyed; was …]`) | 14 | 14 named as a predecessor |
> | new | 1 | — |
> | no successor recorded | — | 40 |
> | **total** | **54** | **93** |
>
> Count **rows** here, and account for the old keys by whether a marker names them: 39 + 14 + 1 = 54
> and 39 + 14 + 40 = 93. Both are reproducible with `grep`, which is the only property that matters,
> since these counts exist to tell the second merger how many rows to expect. Two traps:
> `grep -c '\[#2628 re-keyed; was'` returns **15** — the fifteenth hit is the baseline header prose
> that names the marker, so filter comments first. And one surviving row absorbs **three** old keys,
> which is why 14 markers do not account for 54 departed keys; its note now names all three and says
> which one's argument still applies.

## What changed since the review that rejected this

The rejection was for a bounded accounting error, with the engineering verified. Both blocking items
are fixed, plus the three non-blocking ones.

**1. The row accounting now sums, in all three places.** The PR body, the baseline header and
`DIAGNOSTIC_GATE_AUDIT.md` said `39 + 38 + 15 = 92` against a 93-key `master`. Corrected to
**39 / 14 / 1 → 54** and **39 / 14 / 40 → 93**, with the convention stated in the baseline header and
the doc so the next reader does not have to reconstruct it.

*Which convention, and why.* The alternative — counting old keys by which surviving row **absorbed**
them — is the one that produces the "38 removals" figure, and it is not wrong. It is not
*reproducible*, which is worse for this purpose: derived mechanically by intersecting each finding's
own `@file:line` across the two scanners it gives **39 + 17 + 37**, while the reviewer's hand
derivation gives **39 + 16 + 38**. The single key of difference is
`TWO-GATE|…|report|(any)+PROSPER_DETILE_STATS`, which shares a source line with the
`resource_texture_*` `SPLIT-LOCAL` rows — so whether it counts as "the same absorption" is a
judgement call, and two careful derivations already answered it differently. A count that two people
cannot reproduce identically is exactly what got this PR rejected, so the shipped convention is the
one a merger can `grep`. The alternative is recorded in both durable places rather than deleted,
because it is what explains the apparent 14-vs-54 gap.

**2. The three-predecessor row now records the predecessor whose note transfers.**
`TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_RTTLOG+PROSPER_RTTLOG_MIN_SUBMIT`
absorbed three `master` keys. Its marker named the one whose #2643 note **does not** survive — that
note opens *"benign: LAMBDA ALIAS plus defaults. The {GFXLOG|RENDER_REFVS|SKIP_DRAW} clause comes
from `build_bds` (live_renderer.cpp:5602)"*, and that clause is precisely what this PR removed. The
marker now names the predecessor whose note *does* transfer, so the merge procedure's mechanical step
("rebuild the predecessor key, take its note") yields the right one by construction; the other two
are named in the same note, with an explicit **do not carry this one across** on the `build_bds` one.
Re-verified against source rather than restated: `build_bds` is at `live_renderer.cpp:5602`, the
submit window's fallbacks are `:1415-1416` (`0`, so `alias_is_a_gate()` keeps MIN) and `:1417-1418`
(`INT_MAX`, so it retires MAX), and the arming switch is `PROSPER_RTTLOG` alone at `:1422`.

**3. The stale CI line is gone** — CI is green on this branch (10 checks SUCCESS, `Publish Release`
skipped).

**4. The predicate-drop attribution is corrected.** The doc credited the drop from 61 to 43 resolved
predicates to `PROSPER_NO_*` opt-outs. Measured: **13 of the 18** are opt-outs;
`time_compute_address_matches` is a default-true behaviour predicate whose removal is also a fix; and
`sclog_condition` / `sclog_semaphore` / `sclog` (`hle_kernel.cpp:117`, `:122`, `:127`) lost an
*inverted* clause while their real requirement — `PROSPER_SYNCLOG`, arriving transitively via
`sclog_thread_enabled()` → `sclog_time_enabled()` (`:102`) — is now recorded nowhere, because
`predicate_clauses()` does not expand other predicates. Measured rather than inferred:
`sclog_thread_enabled` resolves on **neither** scanner, so that chain was already broken one level
below this change and no baseline row depended on it. It is the understating direction, and it is now
in the residuals instead of inside "opt-outs".

**5. Two issues filed, neither fixed here.** **#2648** — `software_decode_allowed()` means opposite
things on the two video backends: `vaapi_backend.cpp:52` defaults true and reads
`PROSPER_AVP_ALLOW_SOFTWARE=0` as "hardware only", `media_foundation_backend.cpp:43` defaults false
and reads `=0` as *enabling*. It surfaced as the fifth non-opt-out predicate above: the two bodies
used to collapse to the same clause and now genuinely disagree. **#2649** — `--emit-baseline` writes
its status banner to stdout along with the key list, so the documented regeneration recipe produces a
corrupt file when redirected (pre-existing on `master`).

## New: the baseline's own integrity is now checked

This is the part worth landing beyond the correction, and the observation behind it is the reviewer's:
the gate was **half blind**. It fails on a stale or missing **key** and was completely indifferent to
a **note** — `load_baseline()` kept the note only so `--list` could echo it, and the header's class
counts were parsed as comments. The notes are the expensive artifact (each is a human deciding
whether a diagnostic's zero can lie) and they were the unguarded half.

`baseline_integrity()` adds three rules:

1. every row carries a class from `BASELINE_CLASSES`;
2. the header's class counts match the rows, for all four classes;
3. the `unreviewed` count equals `UNREVIEWED_BUDGET` **exactly**.

Rule 3 is asserted rather than bounded, which makes it self-arming: *paying* debt also fails, with a
message telling you to tighten the constant. So when #2643 lands and the merged baseline reaches
`benign: 42, config-echo: 10, defect: 2, unreviewed: 0`, that merge is **forced** to set
`UNREVIEWED_BUDGET = 0` — and from then on no unjudged row can enter the baseline again. It also
catches the failure the file's header has warned about in prose since #2149: `--emit-baseline`
classifies **every** row `unreviewed`, so "just regenerate the baseline" now fails loudly instead of
laundering a `defect` row into an unjudged one.

**What it cannot see, stated so nobody quotes it as more than it is:** a baseline copied *whole* from
one branch over another is internally consistent by construction and passes all three rules. No check
inside one file can detect that. Only merge **order** protects against it, which is why the order
above is a decision and not a preference.

### Mutation arms — each rule shown FAILING on the real baseline

Run from a scratch copy of the tool + baseline, so the worktree was never left mutated; the control
arm (unmutated copy) is `== all checks passed ==`, exit 0.

**A `defect` row laundered to `unreviewed`, with the header kept self-consistent** — the case that
survives a header/row cross-check:

```
  [FAIL] 1 baseline integrity problem(s) -- the KEYS may be current while the JUDGEMENTS are not:
    41 `unreviewed` row(s) against a budget of 40 -- unjudged debt was ADDED. If this came from
    `--emit-baseline`, it has overwritten judgements: that command classifies every row `unreviewed`,
    so a `defect` row is laundered into an unjudged one by a command that looks like housekeeping.
    Re-apply the notes.
== 1 failure(s) ==
rc=1
```

**A note replaced by a classless stub** (`# ok`) — the hurried-rebase shape:

```
  [FAIL] 2 baseline integrity problem(s) -- the KEYS may be current while the JUDGEMENTS are not:
    row carries no recognised classification (want one of defect, config-echo, benign, unreviewed): TWO-GATE|src/gpu/gpu_executor.cpp|report|PROSPER_DYNTRACE_FAIL|PROSPER_GFXLOG+PROSPER_UD_TAIL_ALIGN
    the header says `defect: 2` and the rows say 1 -- one of the two was edited without the other
== 2 failure(s) ==
rc=1
```

**The header edited without the rows:**

```
  [FAIL] 1 baseline integrity problem(s) -- the KEYS may be current while the JUDGEMENTS are not:
    the header says `config-echo: 9` and the rows say 10 -- one of the two was edited without the other
== 1 failure(s) ==
rc=1
```

**Debt PAID without tightening the ratchet** — the arm that makes rule 3 self-arming, and the one
#2643's merger will hit:

```
  [FAIL] 1 baseline integrity problem(s) -- the KEYS may be current while the JUDGEMENTS are not:
    39 `unreviewed` row(s) against a budget of 40 -- debt was PAID. Tighten UNREVIEWED_BUDGET in
    check_diag_gates.py to 39 so the ratchet holds; leaving it slack lets the same number of rows
    silently return.
== 1 failure(s) ==
rc=1
```

**The whole key list regenerated with `--emit-baseline`, real header carried over** — 54 current
keys, every judgement gone:

```
  [FAIL] 5 baseline integrity problem(s) -- the KEYS may be current while the JUDGEMENTS are not:
    the header says `defect: 2` and the rows say 0 -- one of the two was edited without the other
    the header says `config-echo: 10` and the rows say 0 -- one of the two was edited without the other
    the header says `benign: 2` and the rows say 0 -- one of the two was edited without the other
    the header says `unreviewed: 40` and the rows say 54 -- one of the two was edited without the other
    54 `unreviewed` row(s) against a budget of 40 -- unjudged debt was ADDED. ...
== 5 failure(s) ==
rc=1
```

**The counterfactual that shows the gate could not see any of this before.** Same file as the last
arm, with `baseline_integrity()`'s result neutered in `main()` only (so the keys and every other
check are identical):

```
  [ok]   scanned 489 file(s) under prosper: 658 PROSPER_* variable(s) read at 1067 site(s), ...
  [ok]   findings: SPLIT-CALL=3, SPLIT-LOCAL=19, TWO-GATE=81 (total 103, baselined 103)
== all checks passed ==
rc=0
```

Green, exit 0, with all 14 judgements destroyed. That is the state this rule now makes impossible.

**Six permanent self-test arms** ship alongside (`BASELINE_INTEGRITY_TESTS`), 1 positive and 5
must-fail, each must-fail half a mutation of the positive one differing only in the property under
test — including both directions of rule 3, whose messages differ because they call for opposite
actions. They run under `--selftest`, so ctest covers them.

**The optional third rule was declined.** Requiring a `file:line` plus an issue reference in every
non-`unreviewed` note would fail **12 of the 14** such rows today (all ten `config-echo` rows, one
`benign`, both `defect` rows carry an issue but no `file:line`). Landing it would mean rewriting 12
notes in a PR that exists to correct an accounting error, and — worse — it would pressure whoever
writes the next `config-echo` note into manufacturing a citation to satisfy a regex. The rule the
notes actually need is "name the mechanism", which no regex expresses.

## The original change (unchanged by this revision)

### The failure scenario

Four lexical limits made `check_diag_gates.py` report a second clause that **no run has to satisfy**.
#2572's review of the 79 `unreviewed` baseline rows found **47 of them** settled that way. A gate
whose findings are mostly artefacts is one nobody reads — and the repair everyone reaches for
(regenerate the baseline) silently downgrades every classification in it.

### The approach — each limit modelled, not suppressed

1. **POLARITY inside an `if`.** `if (!getenv("X"))` and the opt-out `getenv("PROSPER_NO_X") ==
   nullptr` both recorded X as REQUIRED — while the same negation *was* pushed through for the
   early-return form, so the two spellings of one idea disagreed with each other. Polarity is decided
   per **LITERAL** (`positive_env_literals`), not per operand, because `clauses_of()` is also handed
   whole function bodies where one stray `== 0` would retire every gate in them.
2. **A DEFAULTED ALIAS.** `const char* out = getenv("X"); if (!out) out = "shader0.bin";` left `out`
   standing for X, so every later use read as gated on it. Assigning a LITERAL to an alias now widens
   it to "the declaration's gate OR the assignment site's" — which collapses to nothing when the
   assignment is reachable by default, and correctly **keeps** the coupling when it is not
   (`if (g_dyntrace_force) resdump = true;` is `PROSPER_RESDUMP` *or* the dyntrace replay, not
   "unconditional"). Restricted to a literal because a braceless `if` body is not scoped here, so a
   computed value may sit under a condition the scanner never saw. `X ? atoi(X) : 60` is likewise an
   optional parameter; `X ? atol(X) : 0` is still a gate.
3. **A STORED LAMBDA is not an alias for its body.** `readable` (`gpu_executor.cpp:2854`) and
   `build_bds` (`live_renderer.cpp:5602`) exported their bodies' switches to every CALL of them,
   invisibly at the call site. An **immediately invoked** lambda holds a value the environment
   decides and still aliases — #2149's fourth measured instance depends on that.
4. **SPLIT-CALL compared clause SETS BY IDENTITY**, so `{A}` versus `{A|B}` — an implication — read
   as a disagreement (`hle_audio.cpp` `audio2log`). It now tests that neither side implies the other.

**Polarity forced a fifth change.** `collect_predicates()` read a predicate body as a flat bag of
literals, which survived only BECAUSE negation was ignored; with polarity it is wrong in both
directions at once. `dyntrace_failed_shader_enabled` (`gpu_executor.cpp:401`) has a guard on
`PROSPER_DYNTRACE_FAIL` that IS required and a filter on `PROSPER_DYNTRACE_FAIL_ADDR` that is not,
and a flat polarity read keeps the wrong one — **silently weakening a `defect` row's key.** Predicate
bodies are now read as function bodies (`predicate_clauses`): guards impose their negation, an early
truthy return ends the accumulation, two truthy exits require their disjunction, and a body no
statement of which is recognised falls back to the flat reading rather than to nothing.

**That fifth limit was invisible to every total, and the doc now says so.** Both readings produce the
identical **103 findings / 54 keys** — only the *content* of one key differs. No count, no diff of
totals, and no "the numbers went down as expected" check could have caught it; only reading the key
did. That is now recorded in `DIAGNOSTIC_GATE_AUDIT.md`, because it is the sharpest instance of the
failure mode this scanner exists to defend against.

### Verification of the rules themselves — the direction that can silently disable a rule

Every one of these changes reports **FEWER** findings, which is exactly how a rule dies unnoticed.
This scanner has already done it once (SPLIT-LOCAL returning 0 across `src/` while structurally
blind). So each ships as a **PAIR of self-test arms differing only in the property under test**:
`==` against `!=`, one repair line present against absent, `: 60` against `: 0`, a stored lambda
against an invoked one, an implied second gate against a disjoint one.

**24 arms, 12 must-match.** Every must-not-match half was checked to be a FINDING on the pre-change
scanner, so none passes by having been outside the rule's reach. **Both `defect` rows still
reproduce.**

### The baseline was NOT regenerated

**177 findings / 93 keys → 103 findings / 54 keys, with nothing in `src/` changed.** Each surviving
finding was matched to its predecessor by its own `file:line`, and every removal and re-key was read
one at a time. Re-keyed rows carry `[#2628 re-keyed; was ...]`. `[udtail]`'s key moved because
`PROSPER_DYNTRACE_FAIL_ADDR` correctly left its alternation; the row was carried across by hand.

**One row is NEW, and it is the rule working rather than decaying:** with the spurious clause its
three call sites shared now gone, SPLIT-CALL can see that `diagnostic_elapsed_ms`
(`live_renderer.cpp:534`) disagrees — classified benign, it is a pure clock read.

## Affected and deliberately unaffected

- **Affected:** `prosper/tools/env/check_diag_gates.py` (the four rules, `predicate_clauses`, and now
  `baseline_integrity` + its six arms), its baseline, and `prosper/docs/DIAGNOSTIC_GATE_AUDIT.md`.
- **Deliberately unaffected: nothing in `src/` changed.** No runtime behavior, no diagnostic output.
- **NOT silenced — the convention's own rule 1.** An armed-state banner is conditioned on both
  switches by construction (`command_processor.cpp:1572`), and no lexical test separates "this
  banner explains the other switch" from "this report silently needs it". **Both
  `command_processor` rows remain.** Rule 2's shapes did go, but as a *consequence* of polarity
  rather than by recognising them.

## Risks

- **The whole change moves in the under-reporting direction.** A rule that stops firing is
  indistinguishable from a rule that has nothing to find, and this scanner has already failed that
  way once. The 12 must-match arms and the two still-reproducing `defect` rows are the guard; they
  are a bound on the failure, not a proof of its absence.
- The polarity decision is per-literal, which is deliberate but means a compound condition mixing
  polarities on the *same* literal is resolved by the positive-literal set rather than by evaluating
  the expression.
- The alias-widening rule is restricted to literal assignments precisely because braceless `if`
  bodies are not scoped here; a computed default therefore still reads as a gate. Understating in the
  safe direction, stated rather than hidden. Related residual now documented: `-1` is in
  `DEFAULT_RHS_RE`, so `X ? atoi(X) : -1` keeps its alias although `-1` is truthy in C — over-reporting,
  and consistent with the one place the tool states which literals mean "unset".
- `UNREVIEWED_BUDGET` is a hand-maintained constant. That is the point (it must be moved
  deliberately and visibly in a diff), but it means a legitimate new unjudged row costs a two-line
  edit rather than one.
- The merge collision described at the top is the operational risk.

## Verification (local; author-run, exact head)

```
cmake --build prosper/build-linux -j4                        -> clean, exit 0
ctest --no-tests=error -j4                                   -> 265/265 passed, exit 0 (dump configured;
                                                                diag_gate_selftest #22 among them)
python3 prosper/tools/env/check_diag_gates.py --selftest      -> pass (24 scanner + 2 key-stability
                                                                + 6 baseline-integrity arms), exit 0
python3 prosper/tools/env/check_diag_gates.py prosper         -> 103 findings / 54 keys, all
                                                                baselined, header counts agree,
                                                                40 unreviewed as budgeted, exit 0
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py  -> pass, exit 0
git diff --check                                              -> clean, exit 0
```

CI on this branch: **10 checks SUCCESS**, `Publish Release` skipped, `mergeable=MERGEABLE`.
