### PR TITLE
docs: audit COMPATIBILITY.md against the trackers, and add an aggregate view

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,7 +8,7 @@ bugs. Different title revisions may behave differently.
 Detailed investigation notes, measurements, known defects, and next steps live in the linked
 [game-tracker issues](https://github.com/mattias800/prosper/issues?q=is%3Aissue+%22%5BGame+tracker%5D%22).
 
-Last updated: 2026-08-11
+Last updated: 2026-08-17
 
 ## Summary
 
@@ -20,7 +20,7 @@ Last updated: 2026-08-11
 | *Evergate* | `PPSA01885` | Unity | ✅ First tutorial-room gameplay | [#1868](https://github.com/mattias800/prosper/issues/1868) |
 | *GRIS* | `PPSA09804` | Unity / IL2CPP | ✅ Opening gameplay | [#1869](https://github.com/mattias800/prosper/issues/1869) |
 | *Space Adventure Cobra — The Awakening* | `PPSA17337` | Unity / IL2CPP | ✅ Tutorial combat | [#1870](https://github.com/mattias800/prosper/issues/1870) |
-| *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 4K SEGA logo; the boot sequence then holds on a white screen before a title screen | [#1871](https://github.com/mattias800/prosper/issues/1871) |
+| *Sonic Origins* | `PPSA05325` | Hedgehog Engine | 🔬 4K SEGA logo, then decoded 4K movie frames; no title screen observed | [#1871](https://github.com/mattias800/prosper/issues/1871) |
 | *Sonic Frontiers* | `PPSA03831` | Hedgehog Engine 2 (Needle) | 🚧 Full 4K opening sequence, title screen and main menu; the menu heading draws the wrong string | [#1891](https://github.com/mattias800/prosper/issues/1891) |
 | *Sonic Racing: CrossWorlds* | `PPSA08804` | Unreal Engine 5 | 🔬 4K title screen and menus with a pad route; needs input to advance past the logos | [#1895](https://github.com/mattias800/prosper/issues/1895) |
 | *Terminator 2D: NO FATE* | `PPSA25872` | Unity / IL2CPP | ✅ Main menu and attract-mode gameplay | [#1872](https://github.com/mattias800/prosper/issues/1872) |
@@ -53,6 +53,47 @@ Last updated: 2026-08-11
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Health warning and title screen; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
+
+## At a glance
+
+Derived from the table above by reading each row's **milestone text** against the six-rung bring-up
+ladder in `CLAUDE.md`. It is *not* derived from the ✅/🚧/🔬 markers, which are not a rung scale:
+six of the twenty titles that reach gameplay are marked 🚧 rather than ✅, and the two 🔬 rows sit
+at two different rungs. Counting markers gives a different — and wrong — answer.
+
+| Where the title stops | Titles |
+| --- | --- |
+| **Gameplay reached** with real GPU draws (rung 3 or better) | 20 |
+| **Title screen or menu** reached, gameplay not yet reached (rung 2) | 18 |
+| **Below a title screen** — logo or splash only (rung 1) | 1 |
+| Total tracked | 39 |
+
+"Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
+It includes *Grand Theft Auto V*, which enters Story Mode with a correct HUD and radar over an absent
+3D world, and *Syberia: Remastered*, whose gameplay composite is degraded.
+
+### Where the titles accumulate
+
+The 18 titles that stop at a title screen or menu, by the engine recorded in the table:
+
+| Engine | Titles |
+| --- | --- |
+| Unreal Engine — 8 × UE4, 1 × UE5, 1 unversioned | 10 |
+| Unity / IL2CPP, including Unity 6 | 4 |
+| Hedgehog Engine 2, Custom, Custom (Ancient), ASOBI — one each | 4 |
+
+**Every Unreal title in the table is in this group.** Ten of the 39 rows are Unreal; all ten reach a
+title screen and none has reached gameplay. The distribution is the mirror image on the other side:
+15 of the 20 titles at gameplay are Unity-family, as are 12 of the 14 ✅ rows.
+
+**This is an observation about where titles accumulate, not a claim that the ten Unreal titles share
+one root cause.** A common cause is an untested hypothesis, and the per-title records currently cut
+against it: what bounds *Nikoderiko*, *ArcRunner*, *Crisis Core*, *Little Nightmares III* and
+*The Oregon Trail* is recorded separately for each in the sections below and in their tracker issues,
+and no cross-title experiment has been run. What the grouping does say is that the shared UE
+bring-up surface — [`prosper/docs/UE4_APR_IOSTORE_BRINGUP.md`](prosper/docs/UE4_APR_IOSTORE_BRINGUP.md)
+and [`prosper/docs/CROSS_ENGINE_UE4.md`](prosper/docs/CROSS_ENGINE_UE4.md) — carries the largest
+single block of titles waiting to reach gameplay.
 
 ## Screenshots and short descriptions
 
@@ -111,9 +152,19 @@ live renderer at 3840×2160. The title had previously produced nothing but black
 machine waits for a save-data job that could never finish, because
 `sceSaveDataCreateTransactionResource` returned 0 when it must return the id of the transaction
 resource it creates. With a real id the boot advances,
-the frontend loads its menu resource set and opens its logo movie, and the SEGA logo renders. **No
-title screen is reached:** after the logo fades the composite holds on white. See
-[`prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) and the
+the frontend loads its menu resource set and opens its logo movie, and the SEGA logo renders.
+
+**No title screen is reached.** After the logo fades the composite goes to a flat white frame. That
+white state used to be terminal — one colour, static to the end of the run. It no longer is: since
+`sceVideodec2Decode` began decoding by default ([#2571](https://github.com/mattias800/prosper/pull/2571)),
+a default launch still shows the pure-white frame at 80 s and then continues, producing distinct
+multi-thousand-colour 4K frames to the end of a 180 s window. The white is **passed through, not
+eliminated**, and what follows the movie is unmeasured — no title screen has been observed. prosper
+authors none of these frames either way: 68 of 68 guest scanouts report no present source and no
+renderer target, so every presented frame is raw guest memory published directly, and only its
+contents changed. See
+[`prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md),
+[#2267](https://github.com/mattias800/prosper/issues/2267) for the measured run, and the
 [tracker](https://github.com/mattias800/prosper/issues/1871).
 
 ## Sonic Frontiers — `PPSA03831`


### PR DESCRIPTION
Docs-only. Two things: an evidence-backed staleness audit of every row in `COMPATIBILITY.md`, and a new `## At a glance` aggregate section so the shape of the effort is visible without counting rows by eye.

**Do not merge on my say-so — the requester will merge.** A docs PR may skip the CI wait, but this one rewrites a user-facing milestone claim, which no CI job can check.

## Part 1 — the audit

The file said `Last updated: 2026-08-11`. I re-checked all **39** rows against three independent sources: each title's `tracker:game` issue (last comments, via REST — GraphQL is still throwing 503s), its `docs/*_STATUS.md`, and every PR merged since 2026-08-11.

**Exactly one row was stale, and it is corrected without promoting the milestone.**

### *Sonic Origins* `PPSA05325`

The row said the boot *"holds on a white screen before a title screen"*. That clause is falsified on current master.

[#2571](https://github.com/mattias800/prosper/pull/2571) (merged 2026-08-17, `687d2b70`) made `sceVideodec2Decode` decode by default. A direct, unmodified default-launch `tools/screenshot` run on that head — recorded in [#2267's 2026-08-17 comment](https://github.com/mattias800/prosper/issues/2267#issuecomment-5313765004) — shows the pure-white frame **still occurring at 80 s and then being passed through**:

| elapsed | distinct colours |
| --- | ---: |
| 60 s | 7,018 (the SEGA logo — matches this issue's own figure) |
| **80 s** | **1** (Y=255 U=V=128, pure white) |
| 100–180 s | 14,871 / 8,978 / 13,351 / 9,294 / 9,372 |

Against the previous master measurement — *"70 s → end: 1 colour, pure white, static to the end"* — the run now continues.

**The milestone is deliberately NOT promoted.** That evidence record is explicit about its own limits, and I took them at face value:

- it does **not** establish a title screen — *"I did not observe one and did not look for one"*;
- prosper still authors nothing on this title — **68 of 68** guest scanouts report `no present source and no renderer target`, identical to the pre-fix figure. Only the contents of the flipped buffer changed.

So the row stays at rung 1 (below a title screen) and keeps its 🔬 marker. Only the falsified clause is rewritten, and the prose section now records what was measured, what it does not establish, and where the evidence lives.

### Rows deliberately left alone

The five titles flagged to me as possibly lagging **all turned out to be already landed** by the 2026-08-06 / 08-08 / 08-11 refreshes:

| Title | Flagged because | Table already says |
| --- | --- | --- |
| *Sonic Racing: CrossWorlds* | `999bab0d` recompiles half its skipped compute programs | "4K title screen and menus with a pad route" (set by #2360, 2026-08-08). `SONIC_CROSSWORLDS_STATUS.md` says **rung 2**, gameplay not reached |
| *Sonic Frontiers* | #2206 | "…title screen and main menu; the menu heading draws the wrong string" |
| *The Oregon Trail* | #1987, #1946 | "Title screen reached and rendered"; prose already records the RT0 blend fix |
| *Little Nightmares III* | #2014, #1987 | "Boot splash sequence and title screen; most title frames carry a yellow tint" |
| *Asterix & Obelix: Babylon Mission* | #1949 | "Logo movies, intro cutscene, and title menu" |

Everything merged since 2026-08-11 is GTA V compute internals, tooling and infrastructure. `GTA5_STATUS.md` still opens with **rung 3, world black**, so the GTA V row ("Gameplay entry: HUD and radar render; 3D world absent") is current. I also re-read #1890, whose last comment *opens* with "the title screen did NOT reproduce on current master" — it closes with "Rung **2** confirmed on `b8898a18` + #1960", so *The Forgotten City*'s row is right too.

## Part 2 — `## At a glance`

Counts are **derived from each row's milestone text against the six-rung ladder**, not from the ✅/🚧/🔬 markers, and the section says so — because reading the markers gives a different and wrong answer:

- six of the twenty titles at gameplay are marked 🚧, not ✅ (*Blue Prince*, *GTA V*, *Bendy and the Ink Machine*, *Syberia*, *Tactics Ogre*, *House of the Dead 2*);
- the two 🔬 rows sit at **two different rungs** — *Sonic Origins* below a title screen, *CrossWorlds* at one.

The markers have never had a legend anywhere in the repo (🔬 appears in no other file). **This PR does not invent one** — it states the factual mismatch and warns the reader off the miscount.

| Where the title stops | Titles |
| --- | --- |
| Gameplay reached, rung 3+ | **20** |
| Title screen or menu, rung 2 | **18** |
| Below a title screen, rung 1 | **1** |

Engine breakdown of the 18 stuck at title/menu: **10 Unreal** (8 UE4, 1 UE5, 1 unversioned), 4 Unity-family, 4 one-offs.

**Every Unreal title in the table is in that group** — ten of 39 rows, none at gameplay — while 15 of the 20 at gameplay are Unity-family, as are 12 of the 14 ✅ rows.

This is framed in the file as **an observation about where titles accumulate, explicitly not a claim that the ten share one root cause**, with that labelled as an untested hypothesis: the per-title records currently cut against it and no cross-title experiment has been run. What it does say is that the shared UE bring-up surface carries the largest block of titles waiting on gameplay.

## Verification

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py     # rc=0, 100 files
python3 prosper/tools/docs/check_numbered_table.py --ordered --table-header Instrument \
    --baseline <origin/master copy> prosper/docs/GAME_COMPAT_ORCHESTRATION.md            # rc=0, 189 rows, none deleted
git diff --check                                                                          # rc=0
git diff --name-only origin/master...HEAD | grep -v '\.md$'                               # empty
```

Note for anyone copying the gate from `CLAUDE.md`: `--sequential` no longer exists — #2610 replaced it with `--ordered` on 2026-08-17 and the old flag now errors.

Counts were re-derived programmatically from the committed file after the edit, not by eye. Trap-41 check: the diff deletes exactly 5 lines, all of them the ones I intended (the date, the Sonic Origins row, and three lines of its prose paragraph) — no collateral loss from another lane.

`GAME_COMPAT_ORCHESTRATION.md` is untouched, as requested.

## Risk

Low, and bounded to one row's prose. The one judgement call is the *Sonic Origins* rewrite: it is a correction of a measured-false negative claim, not a promotion, and it is sourced to a run on merged code rather than to the code change itself. If a reviewer disagrees that a PR-adjacent evidence comment is sufficient to retire the "holds on white" wording, reverting that hunk leaves the aggregate section standing on its own.

Refs #1871
