### PR TITLE
test(docs): arms for seven trap_number.py promises that had none (#2624)

### DIFF
--- a/prosper/tools/docs/test_trap_number.py
+++ b/prosper/tools/docs/test_trap_number.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 """Self-checking tests for trap_number.py (exit code is truth).
 
-The network half of that tool (`gh pr list`, the contents API) is not exercised here -- a test that
-needs authentication is a test that gets disabled. What IS exercised is the half that can be wrong
-silently: which rows it reads out of a document, and whether its answer agrees with the gate that
-will judge the row it helps you write.
+Nothing here needs the network or authentication -- a test that needs either is a test that gets
+disabled. `gh` is a stub on PATH, and the arms that exercise `git fetch` push to an `origin` that is
+a directory in the same temporary tree. What IS exercised is every half that can be wrong silently:
+which rows it reads out of a document, which base it reads them from, and whether its answer agrees
+with the gate that will judge the row it helps you write.
 
 That agreement is the point of the last section, and it is not decoration. The allocator and
 `check_numbered_table.py` parse the same table with DIFFERENT code -- the checker builds table runs
@@ -34,6 +35,18 @@ expensively by a mutation run instead:
 The question is cheaper than a mutation run and catches the same class while you are writing, which
 is where it is worth having. It is not a replacement for mutating -- an arm can name a unique string
 and still test the wrong branch -- but nothing that fails this question is worth mutating.
+
+AND THE OTHER HALF, WHICH THAT QUESTION CANNOT REACH (#2624). Hardening every arm you wrote says
+nothing about a promise you never wrote one for, and the two failures are orthogonal: #2610 repaired
+the selectivity of all twelve arms above and STILL left three advertised promises with no arm --
+the fail-closed `gh pr diff`, `git fetch`, and the `no claim` state. So before adding arms, ask
+
+    "WHAT SENTENCE DOES THIS TOOL'S DOCSTRING LEAD WITH, AND WHICH ARM GOES RED IF IT BECOMES FALSE?"
+
+enumerated from the tool's own --help, docstrings and README claims, and only then compared against
+the arms that exist. Starting from the existing arms cannot find this class, because a missing arm
+leaves nothing to start from. It is the advertised faculty -- the thing everyone reasons about --
+that nobody points an arm at.
 
 Run directly, or via ctest as trap_number.
 """
@@ -146,6 +159,12 @@ DOC = "prosper/docs/GAME_COMPAT_ORCHESTRATION.md"
 HDR = "| # | Instrument | How it lied |\\n|---|---|---|\\n"
 def table(rows):
     return HDR + "".join("| %d | r%d | e |\\n" % (n, n) for n in rows) + "\\n### Next\\n"
+def pr(n, title, oid, paths, draft=False):
+    return {"number": n, "title": title, "headRefOid": oid, "isDraft": draft,
+            "files": [{"path": p} for p in paths]}
+def patch(path, lines):
+    head = "diff --git a/%s b/%s\\n--- a/%s\\n+++ b/%s\\n@@\\n" % (path, path, path, path)
+    return head + "".join(l + "\\n" for l in lines)
 import os
 if os.environ.get("STUB_MODE") == "unauth":
     sys.stderr.write("gh: not authenticated" + chr(10))
@@ -172,6 +191,25 @@ elif a[:2] == ["pr", "list"]:
              "files": [{"path": "f%d.txt" % i} for i in range(100)]},
         ]))
         sys.exit(0)
+    m = os.environ.get("STUB_MODE")
+    if m == "diffail":
+        print(json.dumps([pr(66, "unreadable patch lane", "eee", [DOC])]))
+        sys.exit(0)
+    if m == "noclaim":
+        print(json.dumps([pr(77, "older base lane", "fff", [DOC])]))
+        sys.exit(0)
+    if m == "notable":
+        print(json.dumps([pr(88, "rewrote the table lane", "ggg", [DOC])]))
+        sys.exit(0)
+    if m == "draft":
+        print(json.dumps([pr(99, "draft lane", "hhh", [DOC], True)]))
+        sys.exit(0)
+    if m == "untouched":
+        # One PR touches the document, one does not and is NOT at the files cap -- so the absent
+        # path is real information rather than an unknown, and the tool must not fetch its copy.
+        print(json.dumps([pr(11, "lane A", "aaa", [DOC]),
+                          pr(55, "unrelated lane", "iii", ["prosper/src/foo.cpp"])]))
+        sys.exit(0)
     print(json.dumps([
         {"number": 11, "title": "lane A", "headRefOid": "aaa", "isDraft": False,
          "files": [{"path": DOC}]},
@@ -184,11 +222,22 @@ elif a[0] == "api":
         print(table([1, 2, 900]))
     elif m == "dupmaster":
         print(table([1, 2]))
+    elif m == "noclaim":
+        # Exactly the base's rows: an older base that adds nothing.
+        print(table([1, 2]))
+    elif m == "notable":
+        print("Just prose in this copy. No numbered table at all." + chr(10))
     else:
         print(table([1, 2, 3]))
 elif a[:2] == ["pr", "diff"]:
     import os
     m = os.environ.get("STUB_MODE")
+    if m == "diffail":
+        sys.stderr.write("gh: could not read that pull request" + chr(10))
+        sys.exit(3)
+    if m in ("noclaim", "notable"):
+        print(patch("other.txt", ["+unrelated"]))
+        sys.exit(0)
     if m == "wild":
         print("diff --git a/%s b/%s" % (DOC, DOC))
         print("--- a/%s" % DOC); print("+++ b/%s" % DOC)
@@ -208,13 +257,34 @@ else:
 '''
 
 DOC_REL = Path("prosper/docs/GAME_COMPAT_ORCHESTRATION.md")
-SEED = ("| # | Instrument | How it lied |\n|---|---|---|\n"
-        "| 1 | r1 | e |\n| 2 | r2 | e |\n\n### Next\n")
+
+
+def doc_text(rows: list[int]) -> str:
+    """The seeded document, so an arm can say which rows a commit holds rather than paste a table."""
+    return ("| # | Instrument | How it lied |\n|---|---|---|\n"
+            + "".join(f"| {n} | r{n} | e |\n" for n in rows) + "\n### Next\n")
+
+
+SEED = doc_text([1, 2])
+
+
+def git(repo: Path, *args: str) -> str:
+    """git in `repo`, FAILING LOUDLY -- the setup loop below can ignore rc, this cannot.
+
+    The origin arms build the state their assertion reads: a push that silently failed would leave
+    an upstream holding nothing, `git fetch` would still succeed against it, and the arm would then
+    be measuring the seed it started from while looking like it had measured a fetch.
+    """
+    proc = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise AssertionError(f"git {' '.join(args)} failed (rc={proc.returncode}): {proc.stderr.strip()}")
+    return proc.stdout.strip()
 
 
 def run_main(name: str, *, want_rc: int, expect: str | None = None, absent: str | None = None,
              exact: str | None = None, extra: list[str] | None = None,
-             stub_env: dict[str, str] | None = None, no_gh: bool = False) -> None:
+             stub_env: dict[str, str] | None = None, no_gh: bool = False,
+             origin_rows: list[int] | None = None, origin_missing: bool = False) -> None:
     with tempfile.TemporaryDirectory() as d:
         root = Path(d)
         bin_dir = root / "bin"
@@ -244,8 +314,37 @@ def run_main(name: str, *, want_rc: int, expect: str | None = None, absent: str 
         (repo / DOC_REL).write_text(SEED, encoding="utf-8")
         for cmd in (["init", "-q", "-b", "master"],
                     ["config", "user.email", "t@example.invalid"],
+                    # A developer with commit.gpgsign on globally would otherwise get a fixture
+                    # whose commits fail, and every arm here reads a commit.
+                    ["config", "commit.gpgsign", "false"],
                     ["config", "user.name", "t"], ["add", "-A"], ["commit", "-qm", "base"]):
             subprocess.run(["git", "-C", str(repo), *cmd], capture_output=True)
+
+        # `--no-fetch --base master` unless an arm asks for a real remote, in which case it runs the
+        # DEFAULT path: fetch, then read origin/master. Every other arm skips the fetch, which is
+        # how the fetch went unexercised (#2624).
+        base_args = ["--no-fetch", "--base", "master"]
+        if origin_missing:
+            base_args = ["--base", "origin/master"]
+            git(repo, "remote", "add", "origin", str(root / "no-such-upstream"))
+        elif origin_rows is not None:
+            base_args = ["--base", "origin/master"]
+            upstream = root / "upstream"
+            init = subprocess.run(["git", "init", "--bare", "-q", str(upstream)],
+                                  capture_output=True, text=True)
+            assert init.returncode == 0, f"git init --bare failed: {init.stderr}"
+            git(repo, "remote", "add", "origin", str(upstream))
+            git(repo, "push", "-q", "origin", "master")
+            seeded = git(repo, "rev-parse", "HEAD")
+            # Another lane's push, landing on the shared origin after this checkout was made.
+            (repo / DOC_REL).write_text(doc_text(origin_rows), encoding="utf-8")
+            git(repo, "commit", "-qam", "another lane's row")
+            git(repo, "push", "-q", "origin", "master")
+            # Rewind the remote-tracking ref by hand rather than trusting push not to have moved it:
+            # this is exactly the state of a checkout that has not fetched since that push, and it is
+            # what makes the arm discriminate. Without a fetch the tool reads `seeded` and answers
+            # from rows that are two commits stale.
+            git(repo, "update-ref", "refs/remotes/origin/master", seeded)
 
         if no_gh:
             # PATH with NO gh at all -- not even the stub. `git` still has to resolve, so keep the
@@ -267,8 +366,7 @@ def run_main(name: str, *, want_rc: int, expect: str | None = None, absent: str 
             env = dict(os.environ, PATH=str(bin_dir) + os.pathsep + os.environ["PATH"])
         env.update(stub_env or {})
         proc = subprocess.run(
-            [sys.executable, str(HERE / "trap_number.py"), "--no-fetch", "--base", "master",
-             *(extra or [])],
+            [sys.executable, str(HERE / "trap_number.py"), *base_args, *(extra or [])],
             cwd=repo, capture_output=True, text=True, env=env,
         )
     out = proc.stdout + proc.stderr
@@ -375,6 +473,81 @@ run_main("an absent gh is a refusal with a message, not a traceback",
 # cannot distinguish "there are 2" from "we stopped at 2".
 run_main("a truncated PR list is an error, not a smaller answer",
          want_rc=1, expect="TRUNCATED", extra=["--limit", "2"])
+
+# ---------------------------------------------------------------------------------------------
+# Promises that had NO arm at all (#2624), found by listing what the tool's docstring and --help
+# advertise and then asking which arm goes red if each sentence becomes false. That is a different
+# question from "does the arm I wrote discriminate?", and #2610 proved the two are orthogonal:
+# every existing arm's selectivity was repaired and these were still unguarded afterwards.
+# ---------------------------------------------------------------------------------------------
+
+# "RAISES rather than returning None on a failed `gh pr diff`, and that is the whole point."
+# Returning None made the caller fall through to the set-difference branch -- the logic that
+# function REPLACED -- so an unreadable patch silently restored the defect while the run looked
+# successful. Nothing ran that path: the stub's `pr diff` always succeeded.
+# The assertion names the failing call, and that is load-bearing. rc=1 alone is VOID here for the
+# same reason it was void for the unauthenticated arm: a fallback would carry on and die at a later
+# `gh` call, so the run exits 1 under either implementation. A traceback also exits 1 -- hence
+# `absent="Traceback"`, since the tool promises a refusal with a message, not a crash.
+run_main("an unreadable `gh pr diff` is a refusal that names that call, not a silent fallback",
+         want_rc=1, expect="gh pr diff 66", absent="Traceback", stub_env={"STUB_MODE": "diffail"})
+
+# "Without this the base is whatever the last fetch left behind, which is the stale-read half of the
+# very defect being prevented." Every other arm passes --no-fetch, so the DEFAULT path -- the one a
+# human actually runs -- was never executed. A wrong remote, a wrong ref, or a fetch failure treated
+# as benign would be invisible to the suite and visible only as a stale answer.
+#
+# So: a real `origin` on the filesystem (no network, no authentication). Origin holds rows 1, 2 and
+# 5; the checkout's remote-tracking ref is rewound to the commit holding 1 and 2. Reading the FETCHED
+# base gives 5 and answers 6; reading the stale ref gives 2, and the two stubbed PRs' row 3 makes it
+# answer 4. --quiet asserted whole-output, so nothing but the fetched read can satisfy it.
+run_main("the default path fetches, so the base is the pushed one and not a stale local ref",
+         want_rc=0, exact="6", extra=["--quiet"], origin_rows=[1, 2, 5])
+
+# ...and the failure direction of the same promise: a fetch that CANNOT run must stop the tool. If
+# it were swallowed, the answer would come from whatever the last fetch left behind and would look
+# exactly like a successful run. Asserting the message names `git fetch` is what discriminates: the
+# subsequent `git show origin/master:...` would fail too, so rc=1 alone proves nothing.
+run_main("a fetch that fails is a hard error naming that call, not a fall back to the stale ref",
+         want_rc=1, expect="git fetch", absent="next free number", origin_missing=True)
+
+# "Every open PR is listed, including those whose highest row is at or below master's -- because
+# that is NOT a claim, it is a branch on an older base that adds no row." Of the report's states,
+# CLAIMS, DUPLICATES and `inherits` had arms and this one did not, so a change collapsing it into
+# either would have passed. It is the branch that tells an author "this PR is not in your race".
+# PR #77's copy holds exactly the base's rows and its patch touches another file entirely.
+run_main("a PR on an older base that adds no row is reported as no claim, not as a claim",
+         want_rc=0, expect="no claim (older base, adds no row)", absent="CLAIMS",
+         stub_env={"STUB_MODE": "noclaim"})
+
+# The fourth report state, likewise unguarded: a PR whose copy of the file has no numbered table at
+# all (renamed header, table moved, file rewritten). It must be listed and excluded from the
+# arithmetic rather than crash `max()` or be silently counted as a claim on nothing.
+run_main("a PR whose copy has no numbered table is listed as that, not as a claim",
+         want_rc=0, expect="no numbered table in its copy", absent="CLAIMS",
+         stub_env={"STUB_MODE": "notable"})
+
+# "The scan asks GitHub which files each PR changes and only fetches the ones that do." The cap arm
+# above pins the other side -- a PR AT the 100-file cap is scanned because its file list proves
+# nothing -- but nothing pinned that a PR below the cap which does not touch the file is skipped.
+# Fetching every open PR would still produce a correct number, so only the counts and the absent
+# row can see it. PR #55 changes one unrelated source file.
+run_main("a PR that does not touch the file is not fetched or reported",
+         want_rc=0, expect="scanned 2 open PR(s), 1 touching this file", absent="#55",
+         stub_env={"STUB_MODE": "untouched"})
+
+# Drafts are scanned like any other open PR -- a draft's row is on a branch and collides exactly as
+# hard -- and are flagged so a reader can weigh the claim. The flag is the only thing distinguishing
+# them in the report, and nothing asserted it.
+run_main("a draft PR is scanned and flagged rather than dropped",
+         want_rc=0, expect="[draft]", stub_env={"STUB_MODE": "draft"})
+
+# "no numbered table whose header contains ... -- wrong path, or the table format changed". The
+# same not-found condition on the BASE rather than on a PR, and the one that must stop the run:
+# every number after it would be derived from an empty base.
+run_main("no matching table in the base is an error, not an allocation from nothing",
+         want_rc=1, expect="no numbered table whose header contains 'Nonexistent'",
+         absent="next free number", extra=["--table-header", "Nonexistent"])
 
 print("agreement with the gate, on the repository's real table:")
 


### PR DESCRIPTION
Fixes #2624.

## What was wrong

`prosper/tools/docs/trap_number.py` advertises a set of promises in its docstring and `--help`.
Seven of them had **no test arm at all** -- not a weak arm, none. #2610 had just finished repairing
the *selectivity* of every arm the suite did have (each now asserts on a string only the branch
under test can produce) and these were still unguarded afterwards, which is the point: the two
failures are orthogonal. "What else could satisfy this assertion?" hardens an arm you already
wrote; it cannot tell you about a promise you never tested.

So this started from the tool rather than from the suite: enumerate every sentence
`trap_number.py`'s module docstring, function docstrings and `--help` promise, then ask which arm
goes red if each becomes false.

## Enumerated promises and their arms before this PR

| # | Promise (from the tool's own text) | Arm before |
| --- | --- | --- |
| 1 | Reads the table from the base AND from every open PR's head; highest of all + 1 | yes |
| 2 | A truncated `--limit` list is a hard error | yes |
| 3 | An unauthenticated `gh` is a hard error at the FIRST call, not a fallback | yes |
| 4 | An absent `gh` is a refusal with a message, not a traceback | yes |
| 5 | A PR at the 100-file cap is scanned rather than trusted | yes |
| 6 | A patch-derived claim, so an amended row is not a new claim | yes |
| 7 | A claim more than `MAX_JUMP` above the base is a typo, reported and excluded | yes |
| 8 | A duplicate of a number the base already holds is reported | yes |
| 9 | A stacked PR `inherits` rather than `CLAIMS` | yes |
| 10 | `--quiet` prints only the number | yes |
| 11 | The allocator and `check_numbered_table.py` agree on what a numbered row is | yes (real table) |
| 12 | `added_rows_from_diff` RAISES on a failed `gh pr diff` | **none** |
| 13 | The default path fetches before reading the base | **none** |
| 14 | `no claim (older base, adds no row)` is a distinct report state | **none** |
| 15 | `no numbered table in its copy` is a distinct report state | **none** |
| 16 | Only PRs whose file list contains the path are fetched | **none** |
| 17 | A draft is scanned and flagged | **none** |
| 18 | A base with no matching table is an error, not an allocation | **none** |

Rows 12, 13 and 14 are the three #2624 names. Rows 15-18 came out of the same enumeration.

## What this adds

Eight arms (the fetch promise needs both directions), taking the suite from 29 cases to 37.
`trap_number.py` itself is **unchanged** -- this PR is test-only.

The fetch arms need a remote, and get one without the network: `origin` is a bare repository in the
same temporary tree. It holds rows 1, 2 and 5; the checkout's remote-tracking ref is rewound by hand
to the commit holding 1 and 2. The fetched read answers 6, the stale read answers 4.

## Mutations

Each arm was verified by breaking the promise in `trap_number.py`, running the suite, and restoring
the file byte-for-byte. Every arm is red only under its own mutation. Verbatim first lines:

```
=== M1a  gh pr diff failure returns [] (the silent fallback)
  FAIL: an unreadable `gh pr diff` is a refusal that names that call, not a silent fallback:
        expected rc=1, got 0: "... PR #66  highest row 3   inherits 3 from its base branch,
        claims nothing of its own ... next free number: 4"
=== M1b  it still raises, but the message does not name `gh pr diff`
  FAIL: an unreadable `gh pr diff` is a refusal that names that call, not a silent fallback:
        expected 'gh pr diff 66' in output, got "error: the patch could not be read (rc=3) ..."
=== M2a  the git fetch is a no-op (the stale read)
  FAIL: the default path fetches, so the base is the pushed one and not a stale local ref:
        expected the whole output to be '6', got '4'
  FAIL: a fetch that fails is a hard error naming that call, not a fall back to the stale ref:
        expected 'git fetch' in output, got "error: git show origin/master:... failed (rc=128)"
=== M2b  a fetch failure is swallowed as benign
  FAIL: a fetch that fails is a hard error naming that call, not a fall back to the stale ref:
        expected 'git fetch' in output, got "error: git show origin/master:... failed (rc=128)"
=== M3   the `no claim` state is collapsed into `inherits`
  FAIL: a PR on an older base that adds no row is reported as no claim, not as a claim:
        expected 'no claim (older base, adds no row)' in output, got "... PR #77  highest row 2
        inherits  from its base branch, claims nothing of its own ..."
=== M4   the `no numbered table in its copy` state is dropped
  FAIL: a PR whose copy has no numbered table is listed as that, not as a claim:
        expected 'no numbered table in its copy' in output, got "... PR #88  highest row None
        no claim (older base, adds no row) ..."
=== M5   every open PR is fetched, not only those touching the file
  FAIL: a PR that does not touch the file is not fetched or reported:
        expected 'scanned 2 open PR(s), 1 touching this file' in output, got "... PR #55  highest
        row 3   CLAIMS 3 ... scanned 2 open PR(s), 2 touching this file ... COLLISION: 3 claimed
        by more than one open PR (#11, #55)."
=== M6   the [draft] flag is dropped
  FAIL: a draft PR is scanned and flagged rather than dropped:
        expected '[draft]' in output, got "... PR #99  highest row 3   CLAIMS 3 ..."
=== M7   a base with no matching table allocates from nothing instead of erroring
  FAIL: no matching table in the base is an error, not an allocation from nothing:
        expected rc=1, got 0: "... master  highest row 0 ... COLLISION: 3 claimed by ..."
```

M1a is the one worth reading twice: under the silent fallback the run **succeeds**, and PR #66's
real claim on row 3 is reported as "inherits 3 from its base branch, claims nothing of its own".
That is a wrong answer wearing a successful run, which is what the docstring says the raise exists
to prevent. M1b is there because rc=1 alone would be a void arm: a fallback dies at a later `gh`
call and a traceback also exits 1, so the arm names the failing call and asserts no traceback.

M2a reddens both fetch arms, as it should: a fetch that never runs breaks the promise in both
directions.

## Selectivity of each new arm

Every assertion names a string only its branch can produce -- `gh pr diff 66`, `git fetch`,
`no claim (older base, adds no row)`, `no numbered table in its copy`,
`scanned 2 open PR(s), 1 touching this file`, `[draft]`,
`no numbered table whose header contains 'Nonexistent'` -- and the fetch arm asserts `--quiet`'s
**whole output**, the strongest form available here. `absent=` closes the other side where a
collapse would otherwise satisfy the arm (`CLAIMS` for the two report states, `Traceback` for the
diff failure, `next free number` for both error arms).

## Found on the way, filed rather than fixed here

* **#2629** -- a live defect: `table_numbers` requires a row to begin at column 0, while
  `check_numbered_table` accepts 1-3 columns of indentation. One stray leading space therefore hides
  that row **and every row after it** from the allocator while the gate still counts them, so the
  tool advises a number that is already taken. The existing agreement arm cannot see it, because it
  reads the repository's real table, which has no such row -- a control drawn from the same source
  as the null it validates. Not fixed here: this PR is deliberately test-only.
* **#2658** -- `check_diag_gates.py` excludes build files by substring on the ABSOLUTE path, so a
  `TMPDIR` containing `build-` makes its own `--selftest` fail. Found because my first `ctest` run
  used `TMPDIR=<WORKTREE>/build-tmpdir` and reported `diag_gate_selftest` failed; it passes with any
  other scratch directory. Unrelated to this diff.

## Cross-platform

Nothing new is platform-specific. The `gh` stub keeps its existing per-platform launcher (`gh.cmd`
on Windows, so `PATHEXT` resolution still works); the new git setup uses plain paths and no shell,
so a Windows temp path works unchanged; every added literal is ASCII (checked byte-wise); the
fixture now pins `commit.gpgsign false` so a developer with signing on globally still gets a usable
repository.

## Verification, at the exact head

```
cmake --build prosper/build-linux -j4                 -> rc=0
ctest --no-tests=error                                -> 260 tests, 100% passed, exit code 0
                                                         (1 not run: plugin_autolink (Skipped))
python3 prosper/tools/docs/test_trap_number.py        -> 37 cases, exit 0 (was 29)
python3 prosper/tools/docs/test_check_numbered_table.py  -> exit 0
python3 prosper/tools/docs/test_check_trap_citations.py  -> exit 0

check_numbered_table.py --ordered --table-header Instrument --baseline <base> \
    prosper/docs/GAME_COMPAT_ORCHESTRATION.md
  -> numbered column 1..189, 189 rows, unique and ascending, no unused numbers;
     none of the 189 rows in the baseline has been deleted            exit 0
git ls-files '*.md' -z | xargs -0 check_numbered_table.py             exit 0
git diff --check                                                     exit 0
```

`ctest` was run with a scratch `TMPDIR` that does not contain `build-`; see #2658 for why that
matters and why it is not this diff.

## Risk

Test-only. The tool is untouched, so nothing a title or the renderer does can change. The new arms
add roughly 4.5 s to the `trap_number` ctest case (1.5 s -> 6.0 s), from the git fixtures. No
numbered table was edited and no instrument-trap number was claimed.
