### PR TITLE
videodec2: sceVideodec2Reset discards the decoder's state instead of destroying the decoder, and the two-pass decode test can see which path it ran

### DIFF
--- a/prosper/docs/VIDEODEC2.md
+++ b/prosper/docs/VIDEODEC2.md
@@ -11,7 +11,7 @@ it (`src/hle/video_backend.hpp`):
 | shape | entry points | used by |
 | --- | --- | --- |
 | stream | `open` / `open_memory` / `info` / `next_video` / `seek` / `close` | `sceAvPlayer` |
-| access unit | `open_decoder` / `decode_au` / `close_decoder` | `sceVideodec2` |
+| access unit | `open_decoder` / `decode_au` / `reset_decoder` / `close_decoder` | `sceVideodec2` |
 
 The Linux implementation is `frontends/video_vaapi/vaapi_backend.cpp`. `decode_au` is
 `avcodec_send_packet` / `avcodec_receive_frame`, which is natively access-unit shaped — so this is a
@@ -78,6 +78,58 @@ the copy path was rewritten to write straight into the guest's buffer. The regre
 `test_video_vaapi` runs the same comparison offline against a committed 128×96 Annex-B asset whose
 per-frame hashes came from a host `ffmpeg` decode, over **both** the hardware and software paths.
 
+## Three lifecycle verbs, three contracts
+
+`libSceVideodec2` exports eighteen functions (PS5 3.20 firmware symbol database), among them
+`CreateDecoder`, `Decode`, `Flush`, `Reset` and `DeleteDecoder` as five separate entry points with no
+re-initialise call between them. Three of them dispose of decoder state and
+they are **not** interchangeable — implementing one as another is #2585, and it is the kind of defect
+that shows up as a hang rather than as an error:
+
+| call | what it disposes of | carries a `VdecFrame`/`VdecOutput` |
+| --- | --- | --- |
+| `sceVideodec2Flush` | **drains** — hands the buffered pictures back | yes |
+| `sceVideodec2Reset` | **discards** — throws the buffered state away | no |
+| `sceVideodec2DeleteDecoder` | **destroys** — the decoder and the handle are gone | no |
+
+**The warrant for flushing is the dominance argument below — read that first.** Whether the Sony
+contract keeps or drops the parsed sequence headers is *not* established (`CONFIDENCE: MED`), and it
+does not need to be, because `avcodec_flush_buffers` dominates:
+
+| if the true contract is... | close and reopen (what prosper did) | flush in place (what it does) |
+| --- | --- | --- |
+| drop the DPB, **keep** the parameter sets | **broken** — the decoder cannot decode until the next in-band SPS | correct |
+| drop the DPB **and** the parameter sets | works only if the stream repeats its parameter sets | **no worse either way, and strictly better under row 1**: a stream that repeats them replaces the retained ones in-band by id, and a stream that does not repeat them is one where retaining is the only thing that decodes at all. Under this row retention can make prosper decode where a faithful implementation would not — the decision is unaffected, but the claim is "no worse", not "correct" |
+
+There is no reading of the contract under which closing wins, so the fix does not depend on resolving
+the open half.
+
+A weaker supporting claim, deliberately **not** the reason: **Reset must leave the decoder usable**,
+derivable from the export list rather than assumed — the library has no re-initialise entry point
+between `CreateDecoder` and `DeleteDecoder`, so a Reset that destroyed the decoder would leave the
+guest no way to rebuild it except Delete + Create with the whole `VdecConfig`, which is what Delete
+is already for. `CONFIDENCE: HIGH` — **but it is not load-bearing**, because the pre-fix code already
+satisfied it in the guest-visible sense: the handle stayed valid and the next `Decode` reopened. Cite
+the dominance argument as the warrant, not this.
+
+Both halves of what `avcodec_flush_buffers` actually does were **measured against this
+build's libavcodec**, not read off its documentation, using the committed asset and a hand-built
+positive instance of each case (`test_video_vaapi`, and `VaapiBackend::reset_decoder`'s comment):
+
+- **parameter sets are kept** — a flushed context fed access units 6–11 with every SPS and PPS NAL
+  stripped out decodes **6** pictures; a **fresh** context fed the same bytes decodes **0**.
+- **the DPB is dropped** — a flushed context fed access units 7–11 (non-IDR slices, no IDR among
+  them) decodes **0** pictures; an **unflushed** one decodes against the stale pre-reset references.
+  **That control's margin is one picture, not five** (the decoder errors out on the rest once the
+  references diverge), independently reproduced against libavcodec 8.1.2 with a separate access-unit
+  splitter. The test therefore asserts `> 0` rather than a fixed count — **do not "tighten" it to 5**;
+  a fixed count is brittle across libavcodec versions and would fail for a reason unrelated to Reset.
+
+A backend with no in-place reset falls back to close-and-reopen and **says so once**. That forgets too
+much rather than too little, which is the right direction to fail: leaving the DPB live would decode
+the guest's next access units against references it just asked us to forget, and that is a corrupt
+picture rather than an error.
+
 **The decoder writes into the CALLER's buffer, not into its own.** `decode_au` takes a destination
 and copies under its own lock, and `AuPicture` carries no plane pointers at all. That is deliberate:
 the earlier shape handed back pointers into the decoder's staging buffer that stayed valid only
@@ -112,6 +164,23 @@ Every executable image in the local corpus scanned for `sceVideodec2Decode`'s NI
 A title that never reaches `Decode` cannot be affected: the decode path is entered only from inside
 `sceVideodec2Decode` on a live decoder handle.
 
+**All six also import `sceVideodec2Reset` (`wJXikG6QFN8`), and `sceVideodec2Flush` (`l1hXwscLuCY`).**
+Re-measured over the same 44 dumps / 589 executable images, with `sceVideodec2Decode`'s own NID as
+the positive control — it returns exactly the six titles above, so the method reproduces a known
+answer before being trusted on a new one. Note what this does and does not say: **an import is a
+linked symbol, not a call.** CRI's player links the surface it may use. But it does replace #2585's
+original framing — "no title is recorded calling `sceVideodec2Reset` at all", which was a fact about
+a handler that had no logging rather than about any title — with a measured one: every affected title
+links it, and three of the six are recorded reaching `Decode` live.
+
+Seven of `libSceVideodec2`'s eighteen exports are still unregistered: `CreateDecoderBid`,
+`CreateHevcDecoder`, `QueryHevcDecoderMemoryInfo`, `GetHevcPictureInfo`, `GetVp9PictureInfo`,
+`MapMemory`, `MapDirectMemory`. **Zero titles in the local corpus import any of them** (same scan,
+same control), which is why this is recorded rather than urgent — but an unregistered NID answers
+`SCE_OK` without writing its out-parameter, so an HEVC title would receive a successful-looking
+decoder handle that was never written. It is loud (`prosper_on_unimpl` prints once per NID), so the
+gap is recorded rather than silent; it is the return *value* that is wrong. #2630.
+
 **Decoding a movie does not make prosper render it.** On `PPSA05325` every presented sample is
 `source=guest_scanout` and **68 of 68** `[rtt] GUEST SCANOUT` lines still report *"no present source
 and no renderer target"* — the same figure #2267 measured before any of this. The renderer authors
@@ -138,16 +207,50 @@ that its rendering works.
   behaviour. `PROSPER_VDEC2_FORMAT` sweeps candidates without a rebuild, and a ctest arm pins that
   the value it names reaches the guest's struct, so a sweep's null is about the guest rather than
   about the instrument.
-- **`sceVideodec2Flush` does not drain the decoder** — #2562.
-- **`sceVideodec2Reset` closes and reopens instead of `avcodec_flush_buffers`**, which discards the
-  parsed SPS/PPS as well as the DPB — #2585. `CONFIDENCE: MED` on the current mechanism.
+- **`sceVideodec2Flush` does not drain the decoder** — #2562. Note it is also still **unlogged**, so
+  "no title calls it" remains a statement about the instrument rather than about any title.
 - **`sceVideodec2GetAvcPictureInfo`'s structure** is unestablished — #1658.
-- **The two-pass decode test cannot prove it ran two different paths** — #2586.
+- **Which sequence-header disposition Sony specifies for `sceVideodec2Reset`** — `CONFIDENCE: MED`,
+  and the fix does not depend on it (see the dominance table above). Resolving it wants a title that
+  actually resets; `sceVideodec2Reset` now `svc_log`s, so the next boot that makes one will say so.
 - **Windows.** `frontends/video_mf` implements the stream shape only, so Videodec2 titles get the
   honest no-decoder announcement there rather than a picture. #2563.
 
 ## Ruled out
 
+- **"Closing the backend decoder is an acceptable way to express `sceVideodec2Reset`, because
+  forgetting more than a reset needs to is a safe direction to err."** Falsified by measurement
+  against this build's libavcodec: a **fresh** `AVCodecContext` — exactly what close-and-reopen
+  produces — decodes **0** pictures from access units whose SPS/PPS have been stripped, while a
+  **flushed** one decodes all 6. Over-forgetting is not safe here, because the parsed sequence
+  headers are the one piece of state a mid-stream reset may be unable to re-supply: Videodec2's
+  caller demuxes itself, so whether parameter sets are repeated in-band is title-dependent. #2585,
+  and both arms plus their controls are in `test_video_vaapi`.
+- **"No title in this repository's history calls `sceVideodec2Reset`, so the mechanism is bounded."**
+  **Void, not false** — and *unfalsifiable in principle*, not merely unobserved. `wJXikG6QFN8` has
+  been a **registered** NID since #1368, and `prosper_on_unimpl` fires only for imports with **no**
+  registered handler, so a registered handler with no `svc_log` leaves no trace in *any* instrument on
+  *any* boot. The claim was about the instrument, not about any title, and it was used as a reason the
+  defect was not urgent. `sceVideodec2Reset` now `svc_log`s. #2585.
+  **It is not true that the other entry points already did.** Of the eleven registered Videodec2
+  handlers, **six log and five do not** — `Flush`, `DeleteDecoder`, `ReleaseComputeQueue`, and both
+  `GetPictureInfo` forms are still silent. Said explicitly because an earlier draft of this row
+  claimed Reset "now logs like every other Videodec2 entry point", which contradicted this document's
+  own open-issues entry for `Flush` (#2562) — and a `## Ruled out` row asserting Flush already logs is
+  exactly the sentence that stops the next reader checking.
+- **"The two-pass access-unit decode test covers the hardware and the software path."** True as a
+  *request* and unverified as an *outcome*: both passes are software on a host with no usable VA-API
+  device, which is precisely the headless CI where the claim was being relied on. `AuPicture` now
+  carries `hardware`, set from the pixel format a frame actually came back in, and the run states its
+  own coverage. #2586.
+  **The guarantee is deliberately one-sided, and this was measured, not reasoned about.** On a host
+  with VA-API (12 of 12 pictures in the hardware format), forcing `hardware` **true** fails two
+  assertions, and forcing it **false** *passes* while printing "this host negotiated NO VA-API
+  hardware decode". So the test can prove a pass ran in software and that two passes differed; it
+  **cannot** prove a host's hardware path went unexercised — "the flag is stuck false" and "this host
+  has no VA-API" are the same observation, and the second is a supported state. A created device does
+  not settle it either: libavcodec may negotiate a software format behind an attached VA-API device,
+  which is why `open_decoder` logs *"requested"*.
 - **"The output `format` enum must be established before decoding can be enabled."** This kept the
   decode path opt-in behind `PROSPER_VDEC2_DECODE` (#2281). **Falsified by measurement, and the
   measurement is what carries it**: on `PPSA19991` decode-off freezes the composite at one CRC for

--- a/prosper/frontends/video_vaapi/test_video_vaapi.cpp
+++ b/prosper/frontends/video_vaapi/test_video_vaapi.cpp
@@ -257,6 +257,10 @@ int main(int argc, char** argv) {
             // — the hardware path transfers an NV12 surface, the software path interleaves YUV420P
             // chroma on the CPU — so one set of hashes covering only whichever the host happened to
             // pick would leave the other completely unchecked.
+            //
+            // #2586. Which path each pass ACTUALLY took, as opposed to which it requested. Recorded
+            // per pass so the run can state its own coverage instead of claiming it.
+            bool pass_hardware[2] = {false, false};
             for (int pass = 0; pass < 2 && !stream.empty(); ++pass) {
                 const bool force_software = pass == 1;
                 if (force_software)
@@ -278,6 +282,7 @@ int main(int argc, char** argv) {
                 std::vector<uint8_t> dst(kNv12 + 256, 0xC3);
                 std::vector<uint64_t> got;
                 bool geometry_ok = true, guard_ok = true;
+                int hardware_pictures = 0, software_pictures = 0;
                 for (const auto& u : units) {
                     VideoBackend::AuPicture pic{};
                     std::fill(dst.begin(), dst.end(), 0xC3);
@@ -287,14 +292,23 @@ int main(int argc, char** argv) {
                     if (pic.width != kW || pic.height != kH || pic.y_stride < kW ||
                         pic.nv12_bytes != kNv12)
                         geometry_ok = false;
+                    if (pic.hardware) ++hardware_pictures; else ++software_pictures;
                     for (size_t i = kNv12; i < dst.size(); ++i)
                         if (dst[i] != 0xC3) { guard_ok = false; break; }
                     uint64_t hv = 0xcbf29ce484222325ull;
                     for (size_t i = 0; i < kNv12; ++i) { hv ^= dst[i]; hv *= 0x100000001b3ull; }
                     got.push_back(hv);
                 }
-                std::printf("  [info] %s pass: %zu pictures from %zu access units\n", what,
-                            got.size(), units.size());
+                pass_hardware[pass] = hardware_pictures > 0;
+                std::printf("  [info] %s pass: %zu pictures from %zu access units, decoded in %s "
+                            "(%d hardware / %d software)\n", what, got.size(), units.size(),
+                            hardware_pictures ? "HARDWARE (VA-API)" : "SOFTWARE",
+                            hardware_pictures, software_pictures);
+                // One decoder must not silently change path mid-stream in EITHER direction: the two
+                // conversions differ (surface transfer vs CPU chroma interleave), so a pass that did
+                // both would be reporting one hash set produced by two code paths.
+                CHECK(hardware_pictures == 0 || software_pictures == 0,
+                      "a single decoder stays on ONE decode path for the whole stream");
                 CHECK(got.size() == 12,
                       force_software ? "12 access units yield 12 pictures (software)"
                                      : "12 access units yield 12 pictures");
@@ -315,6 +329,179 @@ int main(int argc, char** argv) {
                 backend()->close_decoder(dec);
             }
             unsetenv("PROSPER_AVP_VAAPI_DEVICE");
+
+            // WHAT THE TWO PASSES ACTUALLY COVERED (#2586). The passes above REQUEST different
+            // paths; a request is not an outcome. On a host with no usable VA-API device both are
+            // software, and until AuPicture::hardware existed nothing here could say so -- the claim
+            // "covered both the hardware and software paths" was then true as a request and
+            // unverified as a result, on exactly the headless CI where it matters.
+            //
+            // A host without VA-API is a SUPPORTED configuration, so this must not become "hardware
+            // is required" -- that would turn a diagnostic gap into a broken build. What is asserted
+            // is only what is verifiable on any host; the rest is reported.
+            //
+            // THE RESIDUAL LIMIT, measured rather than reasoned about, because "what else could
+            // satisfy this assertion" is the question #2586 exists to ask. Two mutation arms were run
+            // against a host that HAS VA-API (12 of 12 pictures in the hardware format):
+            //
+            //   AuPicture::hardware forced TRUE  -> both assertions below FAIL. Detected.
+            //   AuPicture::hardware forced FALSE -> this test PASSES, and prints "this host
+            //                                       negotiated NO VA-API hardware decode" on a host
+            //                                       that plainly has it. NOT detected.
+            //
+            // That asymmetry is not fixable from inside a single run, and it is worth stating rather
+            // than hiding: "the flag is stuck false" and "this host has no VA-API" are the same
+            // observation, and the second is a legitimate supported state. A device having been
+            // CREATED does not settle it either -- libavcodec may negotiate a software format behind
+            // an attached VA-API device, which is exactly why open_decoder's log says "requested".
+            // So the honest guarantee is one-sided: this can prove a pass ran in software, and it can
+            // prove two passes differed; it cannot prove a host's hardware path went unexercised.
+            CHECK(!pass_hardware[1],
+                  "the forced-software pass really did decode in software, not merely ask to");
+            if (pass_hardware[0]) {
+                CHECK(pass_hardware[0] != pass_hardware[1],
+                      "the two passes exercised DIFFERENT decode paths: hardware and software");
+                std::puts("  [info] coverage: BOTH decode paths exercised (hardware and software).");
+            } else {
+                // Stated rather than asserted, and stated plainly: this run is the one-path case.
+                std::puts("  [info] coverage: this host negotiated NO VA-API hardware decode, so "
+                          "BOTH passes ran the SOFTWARE path and the hardware surface-transfer path "
+                          "is NOT covered by this run (#2586). Not a failure: a host without VA-API "
+                          "is supported.");
+            }
+
+            // ---- sceVideodec2Reset: discard the buffered state, keep the decoder (#2585) --------
+            //
+            // Two halves of one contract, each with a hand-built positive instance and a control
+            // that must come out the OTHER way. A control drawn from the same setup as the claim
+            // would only show the machinery runs; these two show the case is expressible and that
+            // the fix is what decides it.
+            //
+            // The asset is what makes this testable: it carries an IDR with its own SPS+PPS at
+            // access unit 0 AND at access unit 6, so the second half can be re-fed with the
+            // parameter sets stripped -- which is exactly a stream that supplies them once.
+            {
+                // Strip every SPS(7)/PPS(8) NAL out of one access unit. Annex-B start codes are 3 or
+                // 4 bytes and this asset uses both, so both are walked.
+                auto strip_parameter_sets = [](const uint8_t* p, size_t len) {
+                    std::vector<std::pair<size_t, int>> starts;
+                    for (size_t i = 0; i + 3 <= len;) {
+                        if (p[i] == 0 && p[i + 1] == 0) {
+                            if (i + 4 <= len && p[i + 2] == 0 && p[i + 3] == 1) {
+                                starts.emplace_back(i, 4); i += 4; continue;
+                            }
+                            if (p[i + 2] == 1) { starts.emplace_back(i, 3); i += 3; continue; }
+                        }
+                        ++i;
+                    }
+                    std::vector<uint8_t> out;
+                    for (size_t k = 0; k < starts.size(); ++k) {
+                        const size_t s = starts[k].first;
+                        const size_t e = (k + 1 < starts.size()) ? starts[k + 1].first : len;
+                        const int nal = p[s + starts[k].second] & 0x1F;
+                        if (nal == 7 || nal == 8) continue;
+                        out.insert(out.end(), p + s, p + e);
+                    }
+                    return out;
+                };
+                constexpr size_t kNv12 = static_cast<size_t>(kW) * kH * 3 / 2;
+                std::vector<uint8_t> dst(kNv12, 0);
+                // Confirm the fixture really is the case under test before drawing conclusions from
+                // it: if the asset ever stopped repeating its parameter sets at unit 6, the stripped
+                // units below would be trivially undecodable and both arms would "pass" for the
+                // wrong reason.
+                const auto stripped_head =
+                    strip_parameter_sets(stream.data() + units[6].first, units[6].second);
+                CHECK(stripped_head.size() < units[6].second,
+                      "access unit 6 really does carry parameter sets for the strip arm to remove");
+
+                auto feed = [&](int dec, size_t from, size_t to, bool strip) {
+                    int pictures = 0;
+                    for (size_t i = from; i < to; ++i) {
+                        VideoBackend::AuPicture pic{};
+                        const std::vector<uint8_t> tmp =
+                            strip ? strip_parameter_sets(stream.data() + units[i].first,
+                                                         units[i].second)
+                                  : std::vector<uint8_t>();
+                        const uint8_t* p = strip ? tmp.data() : stream.data() + units[i].first;
+                        const size_t n = strip ? tmp.size() : units[i].second;
+                        if (backend()->decode_au(dec, p, n, dst.data(), kNv12, pic) ==
+                            VideoBackend::AuResult::Decoded)
+                            ++pictures;
+                    }
+                    return pictures;
+                };
+
+                // ARM 1 -- the parameter sets SURVIVE a Reset. This is #2585 itself: closing the
+                // decoder and reopening (what this used to do) throws the parsed SPS/PPS away, and a
+                // title whose stream carries them once then cannot decode again at all.
+                {
+                    const int dec = backend()->open_decoder(1);
+                    CHECK(dec >= 0, "a decoder opens for the Reset arms");
+                    if (dec >= 0) {
+                        const int before = feed(dec, 0, 6, false);
+                        CHECK(before == 6, "6 access units decode before the Reset");
+                        CHECK(backend()->reset_decoder(dec),
+                              "the backend performs an in-place Reset");
+                        const int after = feed(dec, 6, 12, true);
+                        CHECK(after == 6,
+                              "after a Reset the decoder still decodes access units whose SPS/PPS "
+                              "have been STRIPPED -- the parameter sets survived (#2585)");
+                        backend()->close_decoder(dec);
+                    }
+                }
+                // ARM 1's CONTROL, built by hand and outside the arm: a FRESH decoder is exactly
+                // what close-and-reopen produced, and it must fail on the same bytes. Without this
+                // the arm above would also pass if `reset_decoder` did nothing at all.
+                {
+                    const int dec = backend()->open_decoder(1);
+                    if (dec >= 0) {
+                        const int after = feed(dec, 6, 12, true);
+                        CHECK(after == 0,
+                              "CONTROL: a FRESH decoder -- what close-and-reopen gives -- decodes "
+                              "NOTHING from the same stripped access units (#2585)");
+                        backend()->close_decoder(dec);
+                    }
+                }
+
+                // ARM 2 -- the DPB really is DROPPED. Reset's other half, and it must not be lost
+                // while fixing the first: units 7..11 are non-IDR slices with no IDR among them, so
+                // a decoder that still holds the pre-reset references decodes them and one that
+                // forgot them cannot.
+                {
+                    const int dec = backend()->open_decoder(1);
+                    if (dec >= 0) {
+                        CHECK(feed(dec, 0, 6, false) == 6, "6 access units decode before the Reset");
+                        CHECK(backend()->reset_decoder(dec), "the backend performs an in-place Reset");
+                        CHECK(feed(dec, 7, 12, false) == 0,
+                              "after a Reset, non-IDR access units decode to NOTHING -- every "
+                              "decoded reference was forgotten (#2585)");
+                        backend()->close_decoder(dec);
+                    }
+                }
+                // ARM 2's CONTROL: the same units WITHOUT a Reset must decode, or the arm above
+                // proves only that non-IDR units never decode.
+                {
+                    const int dec = backend()->open_decoder(1);
+                    if (dec >= 0) {
+                        CHECK(feed(dec, 0, 6, false) == 6, "6 access units decode before the control");
+                        // `> 0` AND NOT A FIXED COUNT, deliberately. The real margin here is ONE
+                        // picture, not five: the decoder errors out on the rest once the references
+                        // diverge. Measured, and independently reproduced against libavcodec 8.1.2
+                        // with a separate access-unit splitter. Do NOT "tighten" this to 5 -- a
+                        // fixed count is brittle across libavcodec versions and would then fail for
+                        // a reason that has nothing to do with Reset.
+                        CHECK(feed(dec, 7, 12, false) > 0,
+                              "CONTROL: without a Reset the same non-IDR units DO decode, against "
+                              "the references the Reset is what discards (#2585)");
+                        backend()->close_decoder(dec);
+                    }
+                }
+
+                // Reset on an id the backend does not know must say so rather than report success.
+                CHECK(!backend()->reset_decoder(0x5EED),
+                      "Reset on an unknown decoder id is refused, not silently reported as done");
+            }
 
             // A frame buffer smaller than the picture reports its OWN outcome, distinct from "no
             // picture yet". Collapsed into one bool these are indistinguishable, and the benign one

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -1095,7 +1095,12 @@ VideoBackend::AuResult VaapiBackend::decode_au(int id, const uint8_t* au, size_t
     // planes as they are -- no colour conversion, no chroma interleave, nothing per-pixel on the CPU
     // beyond the transfer the guest's own buffer requires anyway.
     const AVFrame* pic = d.frame;
-    if (d.hw_pix_fmt != AV_PIX_FMT_NONE && d.frame->format == d.hw_pix_fmt) {
+    // THE ONLY MOMENT HARDWARE DECODE IS KNOWABLE (#2586). `hw_device` merely says a VA-API device
+    // was created and attached; libavcodec can still negotiate a software format behind it, which is
+    // why open_decoder's log says "requested". The frame arriving in the hardware pixel format is
+    // the outcome, so it is what gets reported.
+    const bool hardware = d.hw_pix_fmt != AV_PIX_FMT_NONE && d.frame->format == d.hw_pix_fmt;
+    if (hardware) {
         av_frame_unref(d.sw_frame);
         d.sw_frame->format = AV_PIX_FMT_NV12;          // ask for NV12 directly from the surface
         if (av_hwframe_transfer_data(d.sw_frame, d.frame, 0) < 0) return AuResult::NoPicture;
@@ -1120,6 +1125,9 @@ VideoBackend::AuResult VaapiBackend::decode_au(int id, const uint8_t* au, size_t
     out.y_stride = out.width;
     out.uv_stride = out.width;
     out.nv12_bytes = nv12_bytes(out.width, out.height);
+    // Reported alongside the geometry rather than only on success, so a FrameTooSmall refusal still
+    // says which path produced the picture it is refusing to copy.
+    out.hardware = hardware;
 
     // Report the size mismatch as its OWN outcome. Collapsed into "no picture" it would read as a
     // decoder warming up, which is the benign case it most resembles and the one that hides it.
@@ -1144,6 +1152,35 @@ VideoBackend::AuResult VaapiBackend::decode_au(int id, const uint8_t* au, size_t
         return AuResult::NoPicture;
     }
     return AuResult::Decoded;
+}
+
+// sceVideodec2Reset: discard the buffered state, keep the decoder (#2585).
+//
+// `avcodec_flush_buffers` is exactly this operation, and the two halves of what it does were
+// MEASURED against this build's libavcodec rather than read off its documentation, using the
+// committed Annex-B asset and a hand-built positive instance of each case:
+//
+//   parameter sets are KEPT   -- a flushed context fed AU6..11 with every SPS and PPS NAL stripped
+//                               out decodes 6 pictures; a FRESH context fed the same bytes decodes
+//                               0. That is #2585: close-and-reopen produces the second decoder, so
+//                               a title whose stream carries its parameter sets once cannot decode
+//                               after a reset until the next in-band SPS.
+//   the DPB is DROPPED        -- a flushed context fed AU7..11 (non-IDR slices, no IDR among them)
+//                               decodes 0 pictures because it has no references and waits for a
+//                               recovery point; an UNFLUSHED one decodes against the stale
+//                               pre-reset references. So this really does forget them. The control's
+//                               margin is ONE picture, not five -- the decoder errors out on the
+//                               rest once the references diverge -- which is why the test asserts
+//                               "> 0" rather than a fixed count.
+//
+// `checked_first_au` is deliberately NOT re-armed: it gates a once-per-decoder codec/bitstream
+// sanity warning, and a guest that resets per seek would otherwise reprint it on every cycle.
+bool VaapiBackend::reset_decoder(int id) {
+    std::lock_guard<std::mutex> lk(g_au_mutex);
+    auto it = g_au_decoders.find(id);
+    if (it == g_au_decoders.end() || !it->second.ctx) return false;
+    avcodec_flush_buffers(it->second.ctx);
+    return true;
 }
 
 void VaapiBackend::close_decoder(int id) {

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -28,14 +28,19 @@ public:
     bool seek(int id, uint64_t position_us) override;
     void close(int id) override;
 
-    // sceVideodec2's access-unit path (#2270). Software decode: the guest submits one compressed
-    // access unit and expects at most one picture, so there is no stream to bind a hardware surface
-    // pool to at open time, and a 1080p H.264 software decode is well inside budget for the movie
-    // playback these titles use it for. Hardware acceleration can be layered on later without
-    // changing this interface.
+    // sceVideodec2's access-unit path (#2270). The guest submits one compressed access unit and
+    // expects at most one picture back, which is libavcodec's send_packet/receive_frame contract --
+    // so this is a second entry point onto the same decoder, not a second decoder.
+    //
+    // VA-API is REQUESTED first and software is the fallback. (This comment used to say the path was
+    // software-only with "hardware acceleration can be layered on later"; it was layered on, and the
+    // comment was not updated. A stale claim about which path runs is the exact confusion #2586 is
+    // about, so note that neither this comment nor open_decoder's log establishes the outcome --
+    // only AuPicture::hardware does, because it is set from the pixel format a frame came back in.)
     int open_decoder(uint32_t codec) override;
     AuResult decode_au(int id, const uint8_t* au, size_t bytes,
                        uint8_t* dst, uint64_t dst_bytes, AuPicture& out) override;
+    bool reset_decoder(int id) override;
     void close_decoder(int id) override;
 
 private:

--- a/prosper/src/hle/hle_service.cpp
+++ b/prosper/src/hle/hle_service.cpp
@@ -869,23 +869,43 @@ HLE(s_videodec2_flush) {
     return 0;
 }
 HLE(s_videodec2_reset) {
-    // Reset means "forget every decoded reference", and once a real decoder is attached that is no
-    // longer free (#2270). Continuing to feed a libavcodec context that still holds the pre-reset
-    // DPB decodes the guest's new access units against references it has just discarded, which
-    // yields a corrupt picture rather than an error -- silent, and exactly the failure class this
-    // path was filed for. Dropping the backend decoder makes the next Decode open a fresh one, which
-    // is the same forgetting expressed through the lifecycle we already have.
+    // sceVideodec2Reset DISCARDS the decoder's buffered state and leaves the decoder usable. It is
+    // neither of its two neighbours, and #2585 was implementing it as the third:
     //
-    // CONFIDENCE: MED, and the uncertainty is in the MECHANISM, not the meaning. Close-and-reopen is
-    // strictly stronger than a reset needs to be: `avcodec_flush_buffers` drops the DPB and KEEPS the
-    // parsed SPS/PPS, while a fresh AVCodecContext drops both. Videodec2's caller demuxes itself, so
-    // whether parameter sets are repeated in-band is title-dependent -- PPSA19991's first access unit
-    // carries an SPS and nothing establishes that its later ones do. A title that sends them once and
-    // resets mid-stream would get a decoder that cannot decode until the next in-band SPS: #2270's
-    // own hang shape in a new place. Two things bound that today -- no title in this repository's
-    // history is recorded calling sceVideodec2Reset at all, and the 64-unit alarm above makes the
-    // failure loud rather than silent. The clean fix is a reset_decoder(id) backend entry point over
-    // avcodec_flush_buffers: #2585. (#2571 review N4.)
+    //   Flush  -- DRAIN.   Carries a VdecFrame/VdecOutput, so it hands buffered pictures back.
+    //   Reset  -- DISCARD. Carries neither, so it returns nothing; it throws the state away.
+    //   Delete -- DESTROY. The decoder is gone and the handle with it.
+    //
+    // THE WARRANT IS THE DOMINANCE ARGUMENT BELOW, not the confidence label. A weaker supporting
+    // claim -- that Reset must leave the decoder usable, derivable from the export list because
+    // libSceVideodec2 has NO re-initialise entry point between Create and Delete -- is CONFIDENCE:
+    // HIGH but is NOT load-bearing: the pre-fix code already satisfied it in the guest-visible sense,
+    // since the handle stayed valid and the next Decode reopened. Cite the dominance argument.
+    //
+    // THIS USED TO CLOSE THE BACKEND DECODER and let the next Decode open a fresh one. That forgets
+    // the parsed SPS/PPS along with the DPB, and the two are not equally re-suppliable: Videodec2's
+    // caller demuxes itself, so whether parameter sets are repeated in-band is title-dependent, and
+    // a title that sends them once and resets mid-stream got a decoder that could not decode until
+    // the next in-band SPS -- #2270's own hang shape in a new place. Measured on this build's
+    // libavcodec with the committed Annex-B asset: a FLUSHED context fed access units with every
+    // SPS/PPS stripped decodes 6 pictures, a FRESH one decodes 0. See VaapiBackend::reset_decoder.
+    //
+    // Which disposition the Sony contract actually specifies for the sequence headers is NOT
+    // established (CONFIDENCE: MED) -- and it does not have to be, because flushing DOMINATES. If
+    // the contract keeps them, close-and-reopen is broken and flushing is right. If the contract
+    // drops them, flushing is NO WORSE: a stream that repeats its parameter sets replaces the
+    // retained ones in-band by id, and a stream that does not repeat them is one where retaining is
+    // the only thing that decodes at all. (Stated as "no worse" rather than "correct" on purpose --
+    // under that reading, retention can make prosper decode where a faithful implementation would
+    // not. It does not change the decision.) There is no reading under which closing wins.
+    //
+    // LOGGED, and that is not incidental. #2585's own text argued the defect was bounded because
+    // "no title in this repository's history is recorded calling sceVideodec2Reset at all" -- but
+    // this handler had no svc_log call, so no boot could ever have recorded one. That was a fact
+    // about the instrument being used as a fact about the titles. `dump_words = 0`: the only
+    // argument is a decoder handle, and a handle is >= 0x10000, which svc_ptrish would otherwise
+    // mistake for a pointer and try to dump.
+    svc_log("sceVideodec2Reset", a0, a1, a2, a3, a4, a5, 0);
     int au_id = -1;
     {
         std::lock_guard<std::mutex> lk(g_vdec_mx);
@@ -893,17 +913,43 @@ HLE(s_videodec2_reset) {
         auto it = g_vdec_au.find(a0);
         if (it != g_vdec_au.end()) {
             au_id = it->second.id;
-            // Re-arm the OPEN but keep `announced`: a refused codec must not re-print its banner on
-            // every reset cycle. Mutating rather than erasing is what preserves that (#2571 N3).
-            it->second.id = -1;
-            it->second.opened = false;
             it->second.no_picture_run = 0;
+            // A handle with NO live backend decoder re-arms the open so the next Decode retries.
+            // That is the refused-codec path, and `announced` is deliberately kept so the refusal
+            // does not re-print its banner on every reset cycle (#2571 N3). A LIVE decoder must NOT
+            // re-arm: it is about to be flushed in place and never closes, so re-arming would open a
+            // second decoder and strand the first.
+            if (au_id < 0) it->second.opened = false;
         }
     }
-    // Outside the lock: close_decoder calls into the backend, and holding an HLE lock across a
-    // backend call is how lock-order problems get built (same rule as DeleteDecoder above).
-    if (au_id >= 0)
-        if (auto* vb = prosper::video::backend()) vb->close_decoder(au_id);
+    if (au_id < 0) return 0;
+    // Outside the lock: these call into the backend, and holding an HLE lock across a backend call
+    // is how lock-order problems get built (same rule as DeleteDecoder above).
+    auto* vb = prosper::video::backend();
+    if (vb && vb->reset_decoder(au_id)) return 0;   // flushed in place; the decoder stays open
+    // FALLBACK -- a backend with no in-place reset (or none registered any more). Close and re-arm,
+    // which is what this function used to do unconditionally. It forgets too much rather than too
+    // little, which is the right direction to fail: leaving the DPB live would decode the guest's
+    // next access units against references it just asked us to forget, and that is a corrupt picture
+    // rather than an error. Said once, because a fail-visible backstop nobody can see is not one.
+    if (vb) {
+        static std::atomic<bool> said{false};
+        if (!said.exchange(true))
+            fprintf(stderr,
+                    "[vdec2] sceVideodec2Reset: this backend has no in-place reset, so the decoder "
+                    "is being CLOSED and reopened. That discards the parsed sequence headers as well "
+                    "as the DPB, so a title whose stream carries its parameter sets only once cannot "
+                    "decode again until its next in-band SPS (#2585)\n");
+    }
+    {
+        std::lock_guard<std::mutex> lk(g_vdec_mx);
+        auto it = g_vdec_au.find(a0);
+        if (it != g_vdec_au.end() && it->second.id == au_id) {
+            it->second.id = -1;
+            it->second.opened = false;
+        }
+    }
+    if (vb) vb->close_decoder(au_id);
     return 0;
 }
 // sceVideodec2GetPictureInfo / ...GetAvcPictureInfo. `which` names the entry point so a size mismatch

--- a/prosper/src/hle/video_backend.hpp
+++ b/prosper/src/hle/video_backend.hpp
@@ -137,6 +137,13 @@ public:
         // this project writes the exact form. The guest sizes its frame buffer from that same
         // expression, so any other one here disagrees with the buffer it is copying into.
         uint64_t nv12_bytes = 0;
+        // The OUTCOME of the hardware request, not the request (#2586). True only when the frame
+        // came back in the backend's hardware pixel format, which is the only moment hardware decode
+        // is actually knowable -- the backend's own open log says "requested" for exactly this
+        // reason. Without it a two-pass test that asks for hardware and then forces software cannot
+        // tell a host that gave it both paths from a host that quietly gave it the same path twice,
+        // which is the coverage claim the test exists to make.
+        bool hardware = false;
     };
 
     // Submit one access unit and, if it completes a picture, write the packed NV12 into `dst`.
@@ -146,6 +153,26 @@ public:
                                uint8_t* /*dst*/, uint64_t /*dst_bytes*/, AuPicture& /*out*/) {
         return AuResult::NoPicture;
     }
+
+    // Discard the decoder's buffered state IN PLACE, keeping the decoder itself (#2585,
+    // sceVideodec2Reset). Returns false if this backend has no such operation.
+    //
+    // Three lifecycle verbs, three different contracts, and the whole of #2585 was implementing one
+    // as another: `sceVideodec2Flush` DRAINS (it carries a VdecFrame/VdecOutput, so it hands
+    // pictures back), `sceVideodec2Reset` DISCARDS (it carries neither), and
+    // `sceVideodec2DeleteDecoder` DESTROYS. They are three separate exports of libSceVideodec2, and
+    // the library has no re-initialise entry point between Create and Delete -- so a Reset that
+    // destroyed the decoder would leave the guest no way to rebuild it except Delete + Create with
+    // the full VdecConfig, which is what DeleteDecoder is already for. Reset therefore has to leave
+    // the decoder usable. CONFIDENCE: HIGH on that, from the export list alone.
+    //
+    // Defaulted to `false` rather than to an empty body, because an empty body is the one answer
+    // that is wrong under EVERY reading of the contract: it would leave the pre-reset DPB live and
+    // decode the guest's next access units against references it just asked us to forget -- a
+    // corrupt picture rather than an error, which is silent. `false` lets the caller fall back to
+    // close-and-reopen and SAY it did, which forgets too much rather than too little.
+    virtual bool reset_decoder(int /*id*/) { return false; }
+
     virtual void close_decoder(int /*id*/) {}
 };
 

--- a/prosper/tests/test_videodec2_decode.cpp
+++ b/prosper/tests/test_videodec2_decode.cpp
@@ -113,14 +113,19 @@ public:
             dst[y_bytes + i] = static_cast<uint8_t>((last_au_first * 3u + i * 7u) & 0xFF);
         return AuResult::Decoded;
     }
+    // #2585. Reset must reach THIS, not close_decoder. `support_reset` models a backend that has no
+    // in-place reset, which is the fallback the HLE must still take -- and the only way to prove the
+    // fallback is a live path rather than dead code.
+    bool reset_decoder(int id) override { ++resets; last_reset = id; return support_reset; }
     void close_decoder(int id) override { ++closes; last_closed = id; }
 
     bool refuse_open = false;
     bool starve = false;
     bool zero_size = false;
+    bool support_reset = true;
     int  next_id = 7;
-    int  opens = 0, decodes = 0, closes = 0;
-    int  last_id = -1, last_closed = -1;
+    int  opens = 0, decodes = 0, closes = 0, resets = 0;
+    int  last_id = -1, last_closed = -1, last_reset = -1;
     uint32_t last_codec = 0;
     size_t last_au_bytes = 0;
     uint8_t last_au_first = 0;
@@ -142,6 +147,11 @@ private:
 // half: the value the variable names is what lands in the guest's struct. It says nothing about
 // whether a guest reads it, which is the open question.
 constexpr uint32_t kFormatProbe = 0x2a;
+
+// SCE_VIDEODEC2_ERROR_DECODER_INSTANCE, mirrored from the handler's own VDEC_ERR_DECODER. Written
+// out rather than included so a change to the handler's constant fails this test loudly instead of
+// following it silently -- the value is what the guest sees, so it is part of the ABI.
+constexpr uint64_t kVdecErrDecoder = 0x811d0103ull;
 
 // _putenv rather than _putenv_s on Windows: MinGW-w64 declares the _s form only for a new enough
 // CRT, and this test builds on every platform in CI.
@@ -355,18 +365,89 @@ int main(int argc, char** argv) {
             fake.zero_size = false;
         }
 
-        // Reset means "forget every decoded reference". Continuing to feed the same libavcodec
-        // context would decode the guest's next access units against references it just discarded,
-        // which yields a corrupt picture rather than an error.
-        const int before = fake.closes;
+        // ---- Reset DISCARDS the buffered state and KEEPS the decoder (#2585) -------------------
+        //
+        // These four assertions used to say the opposite -- that Reset closes the backend decoder
+        // and the next access unit goes to a fresh one. That was the defect: closing forgets the
+        // parsed SPS/PPS along with the DPB, and a title whose stream carries its parameter sets
+        // once then cannot decode at all. What is pinned here is the ROUTING (Reset reaches
+        // reset_decoder, and the decoder survives it); that the flush really keeps the sequence
+        // headers and really drops the DPB is measured against a real bitstream in test_video_vaapi,
+        // because a fake backend cannot establish a codec's semantics.
+        const int closes_before = fake.closes, opens_before_reset = fake.opens;
+        const int live_id = fake.last_id;
         CHECK(reset(handle, 0, 0, 0, 0, 0) == 0, "Reset succeeds");
-        CHECK(fake.closes == before + 1, "Reset drops the backend decoder rather than reusing it");
+        CHECK(fake.resets == 1 && fake.last_reset == live_id,
+              "Reset flushes the LIVE backend decoder in place (#2585)");
+        CHECK(fake.closes == closes_before,
+              "Reset does NOT close the backend decoder -- closing would discard the parsed "
+              "sequence headers along with the DPB (#2585)");
         VdecFrame again{sizeof(VdecFrame), (uint64_t)(uintptr_t)guest_frame.data(), nv12_bytes, 0, {}};
         VdecOutput again_out{}; again_out.size = sizeof again_out;
         CHECK(decode(handle, (uint64_t)(uintptr_t)&input, (uint64_t)(uintptr_t)&again,
                      (uint64_t)(uintptr_t)&again_out, 0, 0) == 0 && again_out.pictures == 1,
               "decoding resumes after Reset");
-        CHECK(fake.opens == 2, "the access unit after a Reset goes to a FRESH backend decoder");
+        CHECK(fake.opens == opens_before_reset && fake.last_id == live_id,
+              "the access unit after a Reset goes to the SAME decoder, not a fresh one");
+
+        // THE FALLBACK, as a live path. A backend with no in-place reset must still forget the DPB,
+        // and the only lifecycle left for that is close-and-reopen -- which is the old behaviour,
+        // now reached only where it is the best available answer rather than always. Without this
+        // arm the fallback is unexecuted code that reads as covered.
+        {
+            fake.support_reset = false;
+            const int closes_b = fake.closes, opens_b = fake.opens, resets_b = fake.resets;
+            // The fallback announces itself once, and the announcement is the whole reason the
+            // fallback is acceptable rather than a silent downgrade -- so it is asserted, not
+            // assumed. Captured the same way the NO DECODER banner is, and a FAILED capture fails
+            // the test rather than skipping the assertion (#2571 review D2).
+#if !defined(_WIN32)
+            const std::string warn_path =
+                prosper_test::test_scratch_file("vdec2-reset-fallback.log");
+            std::fflush(stderr);
+            const int saved = dup(fileno(stderr));
+            const bool redirected = saved >= 0 && std::freopen(warn_path.c_str(), "w", stderr);
+            const uint64_t frc = reset(handle, 0, 0, 0, 0, 0);
+            if (redirected) { std::fflush(stderr); dup2(saved, fileno(stderr)); clearerr(stderr); }
+            if (saved >= 0) close(saved);
+            CHECK(redirected, "the fallback-warning arm could capture stderr (a failed capture is a "
+                              "FAILURE, never a silent skip)");
+            if (redirected) {
+                int warnings = 0;
+                if (std::FILE* f = std::fopen(warn_path.c_str(), "rb")) {
+                    char line[512];
+                    while (std::fgets(line, sizeof line, f))
+                        if (std::strstr(line, "no in-place reset")) ++warnings;
+                    std::fclose(f);
+                } else {
+                    CHECK(false, "the captured fallback-warning log could be re-opened for reading");
+                }
+                std::remove(warn_path.c_str());
+                CHECK(warnings == 1,
+                      "the close-and-reopen fallback ANNOUNCES itself, exactly once (#2585)");
+            }
+            CHECK(frc == 0, "Reset succeeds against a backend with no in-place reset");
+#else
+            CHECK(reset(handle, 0, 0, 0, 0, 0) == 0, "Reset succeeds against a backend with no "
+                                                     "in-place reset");
+#endif
+            CHECK(fake.resets == resets_b + 1, "the HLE still ASKS the backend to reset first");
+            CHECK(fake.closes == closes_b + 1 && fake.last_closed == live_id,
+                  "a backend that refuses the in-place reset falls back to closing the decoder");
+            VdecFrame f3{sizeof(VdecFrame), (uint64_t)(uintptr_t)guest_frame.data(), nv12_bytes, 0, {}};
+            VdecOutput o3{}; o3.size = sizeof o3;
+            CHECK(decode(handle, (uint64_t)(uintptr_t)&input, (uint64_t)(uintptr_t)&f3,
+                         (uint64_t)(uintptr_t)&o3, 0, 0) == 0 && o3.pictures == 1,
+                  "decoding resumes after the fallback Reset");
+            CHECK(fake.opens == opens_b + 1 && fake.last_id != live_id,
+                  "the fallback re-arms the open, so the next unit gets a FRESH decoder");
+            fake.support_reset = true;
+        }
+
+        // An unknown handle is rejected rather than silently succeeding: Reset is a void-returning
+        // discard, so a wrong handle answering SCE_OK would look exactly like a completed reset.
+        CHECK(reset(handle + 0x99999, 0, 0, 0, 0, 0) == kVdecErrDecoder,
+              "Reset on an unknown decoder handle reports VDEC_ERR_DECODER");
     }
 
     // A backend that refuses the codec must not be mistaken for one that is warming up. The


### PR DESCRIPTION
Fixes #2585. Fixes #2586. Refs #2270, #2571, #2562, #2630.

## The contract question, and which evidence carries which half

`Reset`, `Flush` and `Close` are three different Sony contracts, and the whole of #2585 is that one
was implemented as another. `s_videodec2_reset` **closed the backend decoder** and let the next
`Decode` open a fresh one.

**Evidence 1 -- the PS5 3.20 firmware library reference (`libSceVideodec2`), authoritative for the
API surface.** It exports **eighteen** functions, among them `CreateDecoder`, `Decode`, `Flush`,
`Reset` and `DeleteDecoder` as five separate entry points, with **no re-initialise call anywhere
between Create and Delete**. Two things follow structurally, from the export list alone:

| call | disposes of | carries a `VdecFrame`/`VdecOutput` |
| --- | --- | --- |
| `sceVideodec2Flush` | **drains** -- hands the buffered pictures back | yes |
| `sceVideodec2Reset` | **discards** -- throws the buffered state away | no |
| `sceVideodec2DeleteDecoder` | **destroys** -- decoder and handle are gone | no |

- **Reset must leave the decoder usable.** If it destroyed the decoder the guest would have no way
  to rebuild it except `Delete` + `Create` with the whole `VdecConfig` -- which is what `Delete` is
  already for, and would leave no reason for both exports to exist. `CONFIDENCE: HIGH` -- **but this
  is NOT the warrant for the fix.** The pre-fix code already satisfied it in the guest-visible sense
  (the handle stayed valid, the next `Decode` reopened). The warrant is the dominance argument below;
  cite that, not this.
- **Reset is not Flush.** Flush carries an out-frame and an out-struct, so it *returns pictures*;
  Reset carries neither. Drain versus discard. `CONFIDENCE: MED` on the argument lists themselves
  (they are prosper's live-derived handler shapes from #1658/#2270, not firmware prototypes -- the
  database gives names and NIDs and never bodies).

**Evidence 2 -- prosper's live evidence: there is none, and that is itself a finding.** #2585 argued
the defect was bounded because *"no title in this repository's history is recorded calling
`sceVideodec2Reset` at all."* **The handler had no `svc_log` call**, and `wJXikG6QFN8` has been a
**registered** NID since #1368 -- `prosper_on_unimpl` fires only for imports with *no* registered
handler, so a registered handler with no `svc_log` leaves no trace in **any** instrument on **any**
boot. The premise was **unfalsifiable in principle**, not merely unobserved. `sceVideodec2Reset` now
`svc_log`s.

**It is NOT true that the other entry points already did**, and an earlier draft of this PR said so.
Of the eleven registered Videodec2 handlers, **six log and five do not** -- `Flush`, `DeleteDecoder`,
`ReleaseComputeQueue` and both `GetPictureInfo` forms are still silent. `Flush`'s gap is **#2562** and
stays open; a `## Ruled out` row claiming it already logs is exactly the sentence that would stop the
next reader checking, which is why the doc now states the 6/5 split explicitly.

Re-measured over **44 dumps / 589 executable images**, with `sceVideodec2Decode`'s NID
`852F5+q6+iM` as the positive control -- it returns exactly the six titles #2571 recorded, so the
scan reproduces a known answer before being trusted on a new one:

**all six Videodec2 titles also import `wJXikG6QFN8` (`sceVideodec2Reset`)** -- `PPSA02058`,
`PPSA05325`, `PPSA07809`, `PPSA08804`, `PPSA17942`, `PPSA19991`. An import is a linked symbol, not
a call; but it replaces "no title" with "every affected title links it, and calls are now
observable".

**Evidence 3 -- what the mechanism actually costs, measured against this build's libavcodec** (not
read off its documentation), using the committed Annex-B asset and a hand-built positive instance of
each case:

| | flushed context | control |
| --- | --- | --- |
| access units 6-11 with every SPS/PPS NAL **stripped** | **6 pictures** | **fresh** context: **0** |
| access units 7-11 (non-IDR, no IDR among them) | **0 pictures** | **unflushed** context: decodes against stale refs |

The fresh context is exactly what close-and-reopen produced. So over-forgetting was **not** the safe
direction it looked like: the parsed sequence headers are the one piece of state a mid-stream reset
may be unable to re-supply, because Videodec2's caller demuxes itself and whether parameter sets are
repeated in-band is title-dependent.

### The half that stays open, and why the fix does not wait on it

Whether the Sony contract **keeps or drops** the sequence headers is **not established --
`CONFIDENCE: MED`**. It does not need to be, because flushing **dominates**:

| if the true contract is... | close and reopen (what prosper did) | flush in place (this PR) |
| --- | --- | --- |
| drop the DPB, **keep** the parameter sets | **broken** -- cannot decode until the next in-band SPS | correct |
| drop the DPB **and** the parameter sets | works only if the stream repeats its parameter sets | **no worse either way, strictly better under row 1** -- a stream that repeats them replaces the retained ones in-band by id; a stream that does not is one where retaining is the only thing that decodes at all. Under this row retention can make prosper decode where a faithful implementation would not, so the claim is "no worse", not "correct" |

There is no reading under which closing wins.

## The change

- `VideoBackend::reset_decoder(int) -> bool`, defaulted to **`false`**, not to an empty body. An
  empty body is the one answer wrong under *every* reading: it would leave the pre-reset DPB live and
  decode against references the guest just asked us to forget -- a corrupt picture rather than an
  error, which is silent. `false` lets the caller fall back and **say so**.
- `VaapiBackend::reset_decoder` is `avcodec_flush_buffers`.
- `s_videodec2_reset` calls it and keeps the decoder open. A backend that refuses falls back to
  close-and-reopen -- the old behaviour, now reached only where it is the best available answer --
  and announces it once. The refused-codec path still re-arms the open, and the `NO DECODER` banner
  stays suppressed (#2571 N3).
- `sceVideodec2Reset` now `svc_log`s.

## #2586 -- the test can now detect that it ran one path twice

`AuPicture::hardware` is set from the pixel format a frame **actually came back in** -- the only
moment hardware decode is knowable, which is why the backend's own open log says *"requested"*.
`test_video_vaapi` prints which path each pass took and **states its own coverage**.

It deliberately does **not** become "hardware is required" -- a host without VA-API is supported:

- **always-live assertion:** the forced-software pass really decoded in software. Fails if the flag
  is stuck true.
- **conditional assertion:** if the default pass negotiated hardware, the two passes differ.
- **the one-path case is printed in full** rather than passed over silently.

`vaapi_backend.hpp`'s comment claiming this path was software-only ("hardware acceleration can be
layered on later") was stale -- it *was* layered on and the comment was never updated. A stale claim
about which path runs is the same confusion #2586 is about, so it is corrected here.

## Tests

Split deliberately: a fake backend cannot establish a codec's semantics, and a real decoder cannot
exercise a backend that has no in-place reset.

- **`test_video_vaapi`** -- real decoder, real bitstream. Two arms for #2585, each with a hand-built
  control that must come out the other way, plus a fixture check that access unit 6 really carries
  parameter sets so the arms cannot pass for the wrong reason.
- **`test_videodec2_decode`** -- HLE routing against a fake backend: Reset reaches `reset_decoder`
  and the decoder survives it; the close-and-reopen fallback is exercised as a **live** path and its
  announcement is **counted from captured stderr**; an unknown handle reports `VDEC_ERR_DECODER`.

## Deliberately out of scope

#2562 (`Flush` does not drain), #2563 / the Windows access-unit decoder, and the seven unregistered
`libSceVideodec2` exports found while doing this -- filed as **#2630** with a corpus measurement
(zero local titles import any of them; same scan, same positive control).

## Also recorded

`docs/VIDEODEC2.md` gains the three-verb contract section, the dominance table, the corpus
measurement, and three `## Ruled out` rows: that closing was a safe over-forgetting (falsified by
measurement), that "no title calls Reset" bounded the defect (**void, not false** -- the handler had
no logging), and that the two-pass test covered both paths (true as a request, unverified as an
outcome).

## Verification (exact head `377653b9`, rebased on `398cfa46`)

Built in the `ps5ys` distrobox (a host build silently drops gpu_replay and the Vulkan execution
tests). Environment: **Linux, `GAME_DUMP` configured, `PROSPER_DIAGNOSTICS` unset.**

**The denominator was pinned with `ctest -N` BEFORE the run**, so a partial run could not hand back a
plausible count:

```
ctest -N                       -> Total Tests: 265        (REGISTERED=265)
ctest --no-tests=error -j4     -> 100% tests passed out of 265
                                  CTEST_EXIT=0
```

**265 registered in this configuration**, established here rather than assumed — every test master
added during the outage is present and ran (`apr_equeue_completion`, `metadata_kind_correlation`,
`watch_list`, `videoout_queries`, `runtime_prx_load`, `ascii_output_literals`).

Gates: `git diff --check` clean, `check_ascii_output.py` passes (#2614's new gate), the numbered-table
docs gate passes, and `git log origin/master..HEAD --format=%B | grep -c '^Claude-Session:'` is 0.

### What this host actually exercised (#2586)

```
[info] default (VA-API if present) pass: 12 pictures from 12 access units,
       decoded in HARDWARE (VA-API) (12 hardware / 0 software)
[info] software pass: 12 pictures from 12 access units,
       decoded in SOFTWARE (0 hardware / 12 software)
[ok]   the two passes exercised DIFFERENT decode paths: hardware and software
[info] coverage: BOTH decode paths exercised (hardware and software).
```

### Mutation arms

Every arm reverts one property, rebuilds, and must fail. The binary md5 is recorded before and after
each rebuild and **returns to the baseline exactly** on every restore, so no arm can be a skipped
rebuild measuring nothing. Baseline: `test_videodec2_decode` `39c8aa6a…`, `test_video_vaapi`
`1c6881ba…`.

| arm | mutation | md5 moved | result |
| --- | --- | --- | --- |
| **M1** | HLE never calls `reset_decoder` (master's close-and-reopen) | `39c8aa6a` -> `d5457bc7` | `test_videodec2_decode` **FAILED (6)** |
| **M2** | `reset_decoder` implements close-and-reopen behind the entry point | `1c6881ba` -> `d39ee02b` | `test_video_vaapi` **FAIL**, exactly 1 arm |
| **M3** | `avcodec_flush_buffers` removed (the DPB survives) | `1c6881ba` -> `4d919ecc` | `test_video_vaapi` **FAIL**, exactly 1 arm |
| **M4** | `out.hardware` hardcoded **true** | `1c6881ba` -> `42139f85` | `test_video_vaapi` **FAIL**, 2 arms |

Verbatim:

```
=== M1 ===  TEST_EXIT=1
  [FAIL] Reset flushes the LIVE backend decoder in place (#2585)
  [FAIL] Reset does NOT close the backend decoder -- closing would discard the parsed
         sequence headers along with the DPB (#2585)
  [FAIL] the access unit after a Reset goes to the SAME decoder, not a fresh one
  [FAIL] the close-and-reopen fallback ANNOUNCES itself, exactly once (#2585)
  [FAIL] the HLE still ASKS the backend to reset first
  [FAIL] a backend that refuses the in-place reset falls back to closing the decoder
FAILED (6)

=== M2 ===  TEST_EXIT=1
  [FAIL] after a Reset the decoder still decodes access units whose SPS/PPS have been
         STRIPPED -- the parameter sets survived (#2585)

=== M3 ===  TEST_EXIT=1
  [FAIL] after a Reset, non-IDR access units decode to NOTHING -- every decoded reference
         was forgotten (#2585)

=== M4 ===  TEST_EXIT=1
  [FAIL] the forced-software pass really did decode in software, not merely ask to
  [FAIL] the two passes exercised DIFFERENT decode paths: hardware and software
```

M2 and M3 each fail **exactly one** arm and leave the other and both controls green — the two halves
of the contract are pinned separately rather than by one arm that would pass either way.

### The residual limit, measured rather than reasoned about (M5)

A fifth arm forced `out.hardware` **false** on this VA-API-capable host. **The test PASSED** and
printed *"this host negotiated NO VA-API hardware decode"*. That is not fixable from inside a single
run: "the flag is stuck false" and "this host has no VA-API" are the same observation, and the second
is a supported state. A created device does not settle it either — libavcodec can negotiate a
software format behind an attached VA-API device, which is why `open_decoder` logs *"requested"*.

So the guarantee is deliberately **one-sided**: this can prove a pass ran in software and that two
passes differed; it cannot prove a host's hardware path went unexercised. Recorded in the test
comment and in `docs/VIDEODEC2.md` § Ruled out rather than left for the next reader to discover.

**No PR-side snapshot run**: this changes no rendering path. `sceVideodec2Reset` is entered only from
a live Videodec2 decoder handle, and no snapshot route drives one.

---

## Update at `0697fb54` (was `377653b9`)

Review correction. **The delta is comments and documentation only** — verifiable with:

```
git diff 377653b9..HEAD -- '*.cpp' '*.hpp' | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | grep -vE '^[+-][[:space:]]*(//|/\*|\*)' | grep -vE '^[+-][[:space:]]*$'
```

which prints nothing — every C++ change is inside a comment.

1. **Fixed a factually wrong `## Ruled out` row.** It claimed Reset "now logs like every other
   Videodec2 entry point". **6 of the 11 registered handlers log; 5 do not** (`Flush`,
   `DeleteDecoder`, `ReleaseComputeQueue`, both `GetPictureInfo` forms) — verified by inspecting each
   handler body. It also contradicted this document's own open-issues entry for `Flush`, and the
   wrong half was the one in the cited row, where it would have stopped the next reader re-checking
   **#2562**. The row now states the 6/5 split and names the five.
2. **Lead with the dominance argument, not the `HIGH` label** — in the doc, the handler comment and
   this body. The `HIGH` on "Reset leaves the decoder usable" is defensible but not load-bearing:
   master already satisfied it in the guest-visible sense.
3. **Row 2 now reads "no worse either way, strictly better under row 1"** rather than "correct either
   way", which overreached.
4. **The DPB control's margin is 1 picture, not 5** — recorded at the assertion and in the backend,
   with an explicit "do not tighten this to a fixed count".

The commit message carried the same wrong sentence, so this was an **amend** rather than a follow-up
commit: a squash merge concatenates commit bodies, and the incorrect claim would otherwise have
landed in master's history.

### Re-verified on `0697fb54`, from scratch

```
ctest -N                       -> Total Tests: 265        (REGISTERED=265, pinned before the run)
ctest --no-tests=error -j4     -> 100% tests passed out of 265
                                  CTEST_EXIT=0
```

Linux, `GAME_DUMP` configured, `PROSPER_DIAGNOSTICS` unset, built in the distrobox. Gates re-run on
this head: `git diff --check` clean, `check_ascii_output.py` passes, docs gate passes, session-trailer
count 0. Mutation arms were run at `377653b9` and are unaffected — the delta cannot change behaviour.
