### PR TITLE
fix(hle,host): guest threads can fault at process exit -- make the registries the trampoline tail touches immortal

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1804,6 +1804,17 @@ if(TARGET prosper_core)
     target_link_libraries(test_tls_dtv_purge PRIVATE prosper_core)
     add_test(NAME tls_dtv_purge_on_thread_exit COMMAND test_tls_dtv_purge)
 
+    # #2613: nothing joins guest threads at shutdown, so thread_trampoline's tail runs while the
+    # process is already inside __run_exit_handlers and touches the thread-name / thread-stack / DTV
+    # registries. They must be process-lifetime (src/host/immortal.hpp), i.e. register no static
+    # destructor. The test parks a guest worker and drives the whole tail from an exit-time probe, so
+    # the post-destruction access happens on EVERY run instead of 1-in-300 — and the probe checks the
+    # two library canaries first, so a broken ordering assumption fails instead of passing vacuously.
+    add_executable(test_exit_registry_lifetime tests/test_exit_registry_lifetime.cpp)
+    target_link_libraries(test_exit_registry_lifetime PRIVATE prosper_core)
+    add_test(NAME exit_registry_lifetime COMMAND test_exit_registry_lifetime)
+    set_tests_properties(exit_registry_lifetime PROPERTIES TIMEOUT 120)
+
     add_executable(test_agc_dcb tests/test_agc_dcb.cpp)
     target_link_libraries(test_agc_dcb PRIVATE prosper_core)
     add_test(NAME agc_dcb_pm4 COMMAND test_agc_dcb)

--- a/prosper/src/hle/dispatch.hpp
+++ b/prosper/src/hle/dispatch.hpp
@@ -270,6 +270,10 @@ void tls_dtv_purge_current_thread();
 // Number of threads currently holding live DTV entries (test/diagnostic introspection: lets the
 // regression test assert that thread exit really purged — i.e. no per-thread-churn leak).
 size_t tls_dtv_thread_count();
+// #2613 test hook: true once hle_kernel.cpp's static-storage objects have been destroyed. A canary
+// declared before every registry in that file flips it, so an exit-time probe can prove it really
+// ran after static destruction instead of passing vacuously. Always false while main() runs.
+bool hle_kernel_statics_destroyed();
 
 // Guest initial-exec TLS. Enabled by default on Linux/Windows (PROSPER_NO_GUEST_FS opts out); macOS
 // trap emulation is opt-in with PROSPER_GUEST_FS. Backs guest %fs-relative static thread-locals with a

--- a/prosper/src/hle/hle_kernel.cpp
+++ b/prosper/src/hle/hle_kernel.cpp
@@ -17,6 +17,7 @@
 #include "sce_errno.hpp"
 #include "../host/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "../host/exec_image.hpp"      // describe_code_address (host frame naming)
+#include "../host/immortal.hpp"        // #2613: registries a guest thread can reach after exit()
 #include "pthread_slot.hpp"   // #2596: the two guest-slot resolvers are defined here
 #include "sync_futex.hpp"
 #include "sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
@@ -72,6 +73,29 @@
 #endif
 
 namespace prosper {
+
+// #2613 static-destruction ordering canary. Declared BEFORE every registry in this file, so the
+// reverse-order static destruction pass destroys it AFTER all of them: once this flag reads true,
+// every object in this translation unit that still had a static destructor has already run it.
+// tests/test_exit_registry_lifetime.cpp reads it to prove its own exit-time probe really ran after
+// this TU's destruction — without that check a probe that ran too early would pass vacuously.
+// The flag itself is a constant-initialized atomic, so it has neither dynamic initialization nor a
+// destructor and stays readable for the whole process lifetime.
+namespace {
+std::atomic<bool> g_hle_kernel_statics_destroyed{false};
+struct HleKernelDestructionCanary {
+    HleKernelDestructionCanary() noexcept {
+        g_hle_kernel_statics_destroyed.store(false, std::memory_order_relaxed);
+    }
+    ~HleKernelDestructionCanary() {
+        g_hle_kernel_statics_destroyed.store(true, std::memory_order_release);
+    }
+};
+HleKernelDestructionCanary g_hle_kernel_destruction_canary;
+}   // namespace
+bool hle_kernel_statics_destroyed() {
+    return g_hle_kernel_statics_destroyed.load(std::memory_order_acquire);
+}
 
 // #2215: is this OS thread inside a live submit-render callback right now? Defined weakly so
 // prosper_core keeps linking for every consumer that does not pull in the live renderer
@@ -145,8 +169,14 @@ namespace {
 #endif
     }
 #ifdef _WIN32
-    std::mutex g_thread_handle_mx;
-    std::unordered_map<uint64_t, HANDLE> g_thread_handles;
+    // #2613: immortal — win_thread_trampoline's tail calls unregister_current_thread_handle() while
+    // the process may already be running its exit handlers. See host/immortal.hpp.
+    Immortal<std::mutex> g_thread_handle_mx;
+    Immortal<std::unordered_map<uint64_t, HANDLE>> g_thread_handles;
+    static_assert(std::is_trivially_destructible_v<decltype(g_thread_handle_mx)> &&
+                  std::is_trivially_destructible_v<decltype(g_thread_handles)>,
+                  "#2613: the Windows guest-thread handle registry must register no static "
+                  "destructor -- the trampoline tail reaches it while the process is exiting");
     void register_current_thread_handle(uint64_t guest_thread) {
         HANDLE duplicate = nullptr;
         if (!DuplicateHandle(GetCurrentProcess(), GetCurrentThread(), GetCurrentProcess(), &duplicate,
@@ -162,16 +192,16 @@ namespace {
                          (unsigned long long)guest_thread, (unsigned long)GetLastError());
             return;
         }
-        std::lock_guard<std::mutex> lk(g_thread_handle_mx);
-        auto [it, inserted] = g_thread_handles.emplace(guest_thread, duplicate);
+        std::lock_guard<std::mutex> lk(*g_thread_handle_mx);
+        auto [it, inserted] = g_thread_handles->emplace(guest_thread, duplicate);
         if (!inserted) { CloseHandle(it->second); it->second = duplicate; }
     }
     void unregister_current_thread_handle(uint64_t guest_thread) {
         HANDLE handle = nullptr;
         {
-            std::lock_guard<std::mutex> lk(g_thread_handle_mx);
-            auto it = g_thread_handles.find(guest_thread);
-            if (it != g_thread_handles.end()) { handle = it->second; g_thread_handles.erase(it); }
+            std::lock_guard<std::mutex> lk(*g_thread_handle_mx);
+            auto it = g_thread_handles->find(guest_thread);
+            if (it != g_thread_handles->end()) { handle = it->second; g_thread_handles->erase(it); }
         }
         if (handle) CloseHandle(handle);
     }
@@ -192,9 +222,9 @@ namespace {
     // name a foreign thread -- that was measured false. The registry no longer depends on it.
     HANDLE duplicate_registered_thread_handle(uint64_t guest_thread) {
         HANDLE duplicate = nullptr;
-        std::lock_guard<std::mutex> lk(g_thread_handle_mx);
-        auto it = g_thread_handles.find(guest_thread);
-        if (it != g_thread_handles.end())
+        std::lock_guard<std::mutex> lk(*g_thread_handle_mx);
+        auto it = g_thread_handles->find(guest_thread);
+        if (it != g_thread_handles->end())
             DuplicateHandle(GetCurrentProcess(), it->second, GetCurrentProcess(), &duplicate,
                             0, FALSE, DUPLICATE_SAME_ACCESS);
         return duplicate;
@@ -1783,8 +1813,15 @@ struct GuestThreadName {
     uint64_t generation = 0;
     std::array<char, kGuestThreadNameSize> value{};
 };
-std::mutex g_guest_thread_name_mutex;
-std::unordered_map<uint64_t, GuestThreadName> g_guest_thread_names;
+// #2613: immortal. retire_guest_thread_name() below is the LAST call in thread_trampoline's tail,
+// and nothing joins guest threads at shutdown, so it can run after this registry's static destructor
+// would have. See host/immortal.hpp.
+Immortal<std::mutex> g_guest_thread_name_mutex;
+Immortal<std::unordered_map<uint64_t, GuestThreadName>> g_guest_thread_names;
+static_assert(std::is_trivially_destructible_v<decltype(g_guest_thread_name_mutex)> &&
+              std::is_trivially_destructible_v<decltype(g_guest_thread_names)>,
+              "#2613: the guest thread-name registry must register no static destructor -- a guest "
+              "thread reaches it from the trampoline tail while the process is exiting");
 std::atomic<uint64_t> g_guest_thread_name_generation{1};
 
 uint64_t next_guest_thread_name_generation() {
@@ -1804,9 +1841,9 @@ std::array<char, kGuestThreadNameSize> bounded_guest_thread_name(const char* nam
 }
 
 bool publish_guest_thread_name(uint64_t thread, uint64_t generation, const char* name) noexcept {
-    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
+    std::lock_guard<std::mutex> lock(*g_guest_thread_name_mutex);
     try {
-        g_guest_thread_names[thread] = GuestThreadName{generation, bounded_guest_thread_name(name)};
+        (*g_guest_thread_names)[thread] = GuestThreadName{generation, bounded_guest_thread_name(name)};
         return true;
     } catch (...) {
         return false;
@@ -1814,16 +1851,16 @@ bool publish_guest_thread_name(uint64_t thread, uint64_t generation, const char*
 }
 
 void retire_guest_thread_name(uint64_t thread, uint64_t generation) {
-    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
-    const auto it = g_guest_thread_names.find(thread);
-    if (it != g_guest_thread_names.end() && (!generation || it->second.generation == generation))
-        g_guest_thread_names.erase(it);
+    std::lock_guard<std::mutex> lock(*g_guest_thread_name_mutex);
+    const auto it = g_guest_thread_names->find(thread);
+    if (it != g_guest_thread_names->end() && (!generation || it->second.generation == generation))
+        g_guest_thread_names->erase(it);
 }
 
 bool get_guest_thread_name(uint64_t thread, std::array<char, kGuestThreadNameSize>& name) {
-    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
-    const auto it = g_guest_thread_names.find(thread);
-    if (it != g_guest_thread_names.end()) {
+    std::lock_guard<std::mutex> lock(*g_guest_thread_name_mutex);
+    const auto it = g_guest_thread_names->find(thread);
+    if (it != g_guest_thread_names->end()) {
         name = it->second.value;
         return true;
     }
@@ -1852,12 +1889,12 @@ void set_host_thread_name(uint64_t thread, const char* name) {
 }
 
 bool set_guest_thread_name(uint64_t thread, const char* name) {
-    std::lock_guard<std::mutex> lock(g_guest_thread_name_mutex);
-    auto it = g_guest_thread_names.find(thread);
-    if (it == g_guest_thread_names.end()) {
+    std::lock_guard<std::mutex> lock(*g_guest_thread_name_mutex);
+    auto it = g_guest_thread_names->find(thread);
+    if (it == g_guest_thread_names->end()) {
         if (thread != (uint64_t)(uintptr_t)pthread_self()) return false;
         try {
-            it = g_guest_thread_names.emplace(thread, GuestThreadName{}).first;
+            it = g_guest_thread_names->emplace(thread, GuestThreadName{}).first;
         } catch (...) {
             return false;
         }
@@ -4694,9 +4731,12 @@ HLE(k_dlsym) {   // sceKernelDlsym(SceKernelModule handle, const char* name, voi
 // the init image, tbss zeroed). This is the general-dynamic model — no %fs needed (that's only for
 // the main exe's initial-exec TLS, which the current boot already tolerates).
 namespace {
-std::vector<TlsModuleDesc> g_tls_mods;
-std::mutex g_tls_mods_mx;   // guards g_tls_mods: a runtime sceKernelLoadStartModule re-runs set_tls_modules
-                            // (assign, may realloc) while a worker is in k_tls_get_addr (#344).
+// #2613: immortal. k_tls_get_addr runs on guest threads that are still live at exit(), and
+// tls_dtv_purge_current_thread() below is called from thread_trampoline's tail — both reach these
+// after the static destructors that used to own them had run. See host/immortal.hpp.
+Immortal<std::vector<TlsModuleDesc>> g_tls_mods;
+Immortal<std::mutex> g_tls_mods_mx;   // guards g_tls_mods: a runtime sceKernelLoadStartModule re-runs
+                            // set_tls_modules (assign, may realloc) while a worker is in k_tls_get_addr (#344).
 // Per-thread DTV (thread -> module id -> TLS block). MUST NOT use a host `thread_local`: guest threads
 // run under the GUEST %fs, and host thread_local storage is %fs-relative, so it ALIASES guest memory —
 // reads come back as garbage (an unordered_map whose bucket_count reads 0 → `hash % 0` → SIGFPE).
@@ -4707,25 +4747,31 @@ std::mutex g_tls_mods_mx;   // guards g_tls_mods: a runtime sceKernelLoadStartMo
 // scePthreadExit/pthread_exit) via tls_dtv_purge_current_thread(): glibc recycles pthread ids, so a
 // stale entry would hand a NEW thread the dead thread's dirty TLS blocks instead of the fresh
 // zero/tdata-initialized state the ABI guarantees — and the blocks would leak per thread churn (#68).
-std::mutex g_dtv_mx;
-std::unordered_map<std::thread::id, std::unordered_map<uint64_t, void*>> g_dtv;
+Immortal<std::mutex> g_dtv_mx;
+Immortal<std::unordered_map<std::thread::id, std::unordered_map<uint64_t, void*>>> g_dtv;
+static_assert(std::is_trivially_destructible_v<decltype(g_tls_mods)> &&
+              std::is_trivially_destructible_v<decltype(g_tls_mods_mx)> &&
+              std::is_trivially_destructible_v<decltype(g_dtv_mx)> &&
+              std::is_trivially_destructible_v<decltype(g_dtv)>,
+              "#2613: the TLS module list and per-thread DTV must register no static destructor -- "
+              "guest threads reach both while the process is exiting");
 }
 void tls_dtv_purge_current_thread() {
     std::unordered_map<uint64_t, void*> mine;
-    { std::lock_guard<std::mutex> lk(g_dtv_mx);
-      auto it = g_dtv.find(std::this_thread::get_id());
-      if (it == g_dtv.end()) return;   // main/host threads may never have touched __tls_get_addr
+    { std::lock_guard<std::mutex> lk(*g_dtv_mx);
+      auto it = g_dtv->find(std::this_thread::get_id());
+      if (it == g_dtv->end()) return;   // main/host threads may never have touched __tls_get_addr
       mine = std::move(it->second);
-      g_dtv.erase(it);
+      g_dtv->erase(it);
     }
     for (auto& kv : mine) free(kv.second);   // free the blocks outside the lock
 }
 size_t tls_dtv_thread_count() {   // test/diagnostic introspection: threads with live DTV entries
-    std::lock_guard<std::mutex> lk(g_dtv_mx);
-    return g_dtv.size();
+    std::lock_guard<std::mutex> lk(*g_dtv_mx);
+    return g_dtv->size();
 }
 void set_tls_modules(const TlsModuleDesc* descs, size_t count) {
-    { std::lock_guard<std::mutex> lk(g_tls_mods_mx); g_tls_mods.assign(descs, descs + count); }
+    { std::lock_guard<std::mutex> lk(*g_tls_mods_mx); g_tls_mods->assign(descs, descs + count); }
     if (getenv("PROSPER_TLSLOG"))
         for (size_t i = 0; i < count; i++)
             fprintf(stderr, "[tls] module %zu: init_va=0x%llx filesz=0x%llx memsz=0x%llx\n", i,
@@ -4737,21 +4783,21 @@ HLE(k_tls_get_addr) {   // __tls_get_addr(tls_index* ti): ti[0]=module id, ti[1]
     if (!ti) return 0;
     uint64_t modid = ti[0], off = ti[1];
     std::thread::id tid = std::this_thread::get_id();   // portable per-OS-thread key (no %fs, no syscall)
-    { std::lock_guard<std::mutex> lk(g_dtv_mx);
-      auto& dtv = g_dtv[tid];
+    { std::lock_guard<std::mutex> lk(*g_dtv_mx);
+      auto& dtv = (*g_dtv)[tid];
       auto it = dtv.find(modid);
       if (it != dtv.end()) return (uint64_t)(uintptr_t)it->second + off;
     }
     size_t memsz = 64, filesz = 0; uint64_t init_va = 0;
-    { std::lock_guard<std::mutex> lk(g_tls_mods_mx);   // #344: safe vs a concurrent set_tls_modules realloc
-      if (modid < g_tls_mods.size()) {
-          memsz  = g_tls_mods[modid].memsz ? g_tls_mods[modid].memsz : 64;
-          filesz = g_tls_mods[modid].filesz;
-          init_va = g_tls_mods[modid].init_va;
+    { std::lock_guard<std::mutex> lk(*g_tls_mods_mx);   // #344: safe vs a concurrent set_tls_modules realloc
+      if (modid < g_tls_mods->size()) {
+          memsz  = (*g_tls_mods)[modid].memsz ? (*g_tls_mods)[modid].memsz : 64;
+          filesz = (*g_tls_mods)[modid].filesz;
+          init_va = (*g_tls_mods)[modid].init_va;
       } }
     void* blk = calloc(1, memsz);   // zero-init (tbss), then copy the tdata image
     if (init_va && filesz) memcpy(blk, (const void*)(uintptr_t)init_va, filesz);
-    { std::lock_guard<std::mutex> lk(g_dtv_mx); g_dtv[tid][modid] = blk; }
+    { std::lock_guard<std::mutex> lk(*g_dtv_mx); (*g_dtv)[tid][modid] = blk; }
     return (uint64_t)(uintptr_t)blk + off;
 }
 

--- a/prosper/src/host/exec_image.hpp
+++ b/prosper/src/host/exec_image.hpp
@@ -91,7 +91,13 @@ std::string describe_code_address(uint64_t address);
 void register_thread_stack(uint64_t tid, void* base, uint64_t size);
 // Remove a dead thread's entry. pthread ids are RECYCLED — a stale entry would serve the next
 // thread on the same id the old thread's bounds (#138). Called on every HLE thread-exit path.
+// The registry is process-lifetime (host/immortal.hpp): a guest thread reaches this from the
+// trampoline tail while the process is already running its exit handlers (#2613).
 void unregister_thread_stack(uint64_t tid);
+// #2613 test hook: true once this translation unit's static-storage objects have been destroyed.
+// A canary declared before every registry here flips it, so an exit-time probe can prove it really
+// ran after static destruction instead of passing vacuously. Always false while main() runs.
+bool exec_image_statics_destroyed();
 // Mark the calling host thread as about to execute guest code. Primary entry paths
 // (module init + run_entry) always arm PROSPER_HWBP; worker entry paths do so only when
 // PROSPER_HWBP_ALLTHREADS is set. Call while host TLS is active, before guest TLS/entry.

--- a/prosper/src/host/exec_image_linux.cpp
+++ b/prosper/src/host/exec_image_linux.cpp
@@ -1,6 +1,7 @@
 // exec_image_linux.cpp — Linux host backing + HLE stubs (M2/M3). Compiles to nothing
 // on non-Linux so the shared (mingw) build is unaffected.
 #include "exec_image.hpp"
+#include "immortal.hpp"   // #2613: registries a guest thread can reach after exit()
 #include "sse4a.hpp"
 #include "x86_read_decode.hpp"
 #include "guest_write_watch.hpp"
@@ -63,6 +64,23 @@ struct f_owner_ex { int type; pid_t pid; };
 namespace prosper {
 
 namespace {
+    // #2613 static-destruction ordering canary. Declared BEFORE every registry in this file, so the
+    // reverse-order static destruction pass destroys it AFTER all of them: once this flag reads
+    // true, every object in this translation unit that still had a static destructor has already run
+    // it. tests/test_exit_registry_lifetime.cpp reads it to prove its own exit-time probe really ran
+    // after this TU's destruction — without that check a probe that ran too early would pass
+    // vacuously. The flag is a constant-initialized atomic: no dynamic initialization, no destructor.
+    std::atomic<bool> g_exec_image_statics_destroyed{false};
+    struct ExecImageDestructionCanary {
+        ExecImageDestructionCanary() noexcept {
+            g_exec_image_statics_destroyed.store(false, std::memory_order_relaxed);
+        }
+        ~ExecImageDestructionCanary() {
+            g_exec_image_statics_destroyed.store(true, std::memory_order_release);
+        }
+    };
+    ExecImageDestructionCanary g_exec_image_destruction_canary;
+
     uint64_t g_base = 0, g_stub_base = 0, g_stub_size = 0, g_nstubs = 0;
     // #1659: label guest addresses through the shared, module-aware helpers instead of subtracting a
     // literal base. These sites hard-coded 0x400000000 — the eboot's address BEFORE #825 relocated it
@@ -75,8 +93,16 @@ namespace {
     // stack we allocate (the main thread's mmap'd stack; workers' stacks from
     // k_pthread_create), so the GC/thread code gets accurate bounds without the fragile
     // pthread_getattr_np.
-    std::map<uint64_t, std::pair<uint64_t, uint64_t>> g_stacks;   // tid -> (base, size)
-    std::mutex g_smx;
+    // #2613: immortal. thread_trampoline's tail calls unregister_thread_stack() and nothing joins
+    // guest threads at shutdown, so this registry is reached while the process is running its exit
+    // handlers — after a plain namespace-scope container's destructor would have run.
+    // See host/immortal.hpp.
+    Immortal<std::map<uint64_t, std::pair<uint64_t, uint64_t>>> g_stacks;   // tid -> (base, size)
+    Immortal<std::mutex> g_smx;
+    static_assert(std::is_trivially_destructible_v<decltype(g_stacks)> &&
+                  std::is_trivially_destructible_v<decltype(g_smx)>,
+                  "#2613: the guest thread-stack registry must register no static destructor -- a "
+                  "guest thread reaches it from the trampoline tail while the process is exiting");
     // Recovery point. Only the (single) thread that armed it — always the main thread running
     // run_entry/run_guest_inits — can be longjmp'd back; guest worker faults have no armed point and
     // terminate the process cleanly. We key "who armed" on the real kernel tid (SYS_gettid, a syscall
@@ -3549,18 +3575,22 @@ std::string describe_code_address(uint64_t address) {
     return text;
 }
 
+bool exec_image_statics_destroyed() {   // #2613, see the canary at the top of this file
+    return g_exec_image_statics_destroyed.load(std::memory_order_acquire);
+}
+
 void register_thread_stack(uint64_t tid, void* base, uint64_t size) {
-    std::lock_guard<std::mutex> lk(g_smx);
-    g_stacks[tid] = { (uint64_t)base, size };
+    std::lock_guard<std::mutex> lk(*g_smx);
+    (*g_stacks)[tid] = { (uint64_t)base, size };
 }
 void unregister_thread_stack(uint64_t tid) {
-    std::lock_guard<std::mutex> lk(g_smx);
-    g_stacks.erase(tid);
+    std::lock_guard<std::mutex> lk(*g_smx);
+    g_stacks->erase(tid);
 }
 bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
-    std::lock_guard<std::mutex> lk(g_smx);
-    auto it = g_stacks.find(tid);
-    if (it == g_stacks.end()) return false;
+    std::lock_guard<std::mutex> lk(*g_smx);
+    auto it = g_stacks->find(tid);
+    if (it == g_stacks->end()) return false;
     *base = (void*)it->second.first; *size = (size_t)it->second.second;
     return true;
 }

--- a/prosper/src/host/exec_image_win.cpp
+++ b/prosper/src/host/exec_image_win.cpp
@@ -18,6 +18,7 @@
 #endif
 
 #include "exec_image.hpp"
+#include "immortal.hpp"   // #2613: registries a guest thread can reach after exit()
 #include "guest_write_watch.hpp"
 #include "sse4a.hpp"
 #include "x86_read_decode.hpp"
@@ -148,6 +149,22 @@ __asm__(
 namespace prosper {
 
 namespace {
+// #2613 static-destruction ordering canary. Declared BEFORE every registry in this file, so the
+// reverse-order static destruction pass destroys it AFTER all of them: once this flag reads true,
+// every object in this translation unit that still had a static destructor has already run it.
+// tests/test_exit_registry_lifetime.cpp reads it to prove its own exit-time probe really ran after
+// this TU's destruction. Constant-initialized atomic: no dynamic init, no destructor.
+std::atomic<bool> g_exec_image_statics_destroyed{false};
+struct ExecImageDestructionCanary {
+    ExecImageDestructionCanary() noexcept {
+        g_exec_image_statics_destroyed.store(false, std::memory_order_relaxed);
+    }
+    ~ExecImageDestructionCanary() {
+        g_exec_image_statics_destroyed.store(true, std::memory_order_release);
+    }
+};
+ExecImageDestructionCanary g_exec_image_destruction_canary;
+
 std::atomic<GuestExecutionThreadEnterTestHook> g_guest_execution_enter_test_hook{nullptr};
 std::atomic<void*> g_guest_execution_enter_test_opaque{nullptr};
 }
@@ -249,8 +266,14 @@ namespace {
     };
 
     // Thread-stack registry (portable; mirrors the Linux one) so GC/thread code gets real bounds.
-    std::map<uint64_t, std::pair<uint64_t, uint64_t>> g_stacks;
-    std::mutex g_smx;
+    // #2613: immortal — win_thread_trampoline's tail calls unregister_thread_stack() while the
+    // process may already be running its exit handlers. See host/immortal.hpp.
+    Immortal<std::map<uint64_t, std::pair<uint64_t, uint64_t>>> g_stacks;
+    Immortal<std::mutex> g_smx;
+    static_assert(std::is_trivially_destructible_v<decltype(g_stacks)> &&
+                  std::is_trivially_destructible_v<decltype(g_smx)>,
+                  "#2613: the guest thread-stack registry must register no static destructor -- a "
+                  "guest thread reaches it from the trampoline tail while the process is exiting");
 
     // Module initialization may attach a frontend-owned thread to IL2CPP before run_entry switches
     // to its dedicated guest stack. Keep the init thread's native stack registered for that
@@ -259,8 +282,8 @@ namespace {
         uint64_t native_tid = 0;
         ~InitThreadStackRegistration() {
             if (!native_tid) return;
-            std::lock_guard<std::mutex> lk(g_smx);
-            g_stacks.erase(native_tid);
+            std::lock_guard<std::mutex> lk(*g_smx);
+            g_stacks->erase(native_tid);
         }
     };
     thread_local InitThreadStackRegistration t_init_stack_registration;
@@ -1371,17 +1394,21 @@ std::string describe_code_address(uint64_t address) {
     return text;
 }
 
+bool exec_image_statics_destroyed() {   // #2613, see the canary at the top of this file
+    return g_exec_image_statics_destroyed.load(std::memory_order_acquire);
+}
+
 void register_thread_stack(uint64_t tid, void* base, uint64_t size) {
-    std::lock_guard<std::mutex> lk(g_smx); g_stacks[tid] = { (uint64_t)base, size };
+    std::lock_guard<std::mutex> lk(*g_smx); (*g_stacks)[tid] = { (uint64_t)base, size };
 }
 void unregister_thread_stack(uint64_t tid) {
-    std::lock_guard<std::mutex> lk(g_smx); g_stacks.erase(tid);
+    std::lock_guard<std::mutex> lk(*g_smx); g_stacks->erase(tid);
 }
 bool guest_stack_for_thread(uint64_t tid, void** base, size_t* size) {
     auto lookup = [&](uint64_t key) {
-        std::lock_guard<std::mutex> lk(g_smx);
-        auto it = g_stacks.find(key);
-        if (it == g_stacks.end()) return false;
+        std::lock_guard<std::mutex> lk(*g_smx);
+        auto it = g_stacks->find(key);
+        if (it == g_stacks->end()) return false;
         if (base) *base = (void*)(uintptr_t)it->second.first;
         if (size) *size = (size_t)it->second.second;
         return true;

--- a/prosper/src/host/immortal.hpp
+++ b/prosper/src/host/immortal.hpp
@@ -1,0 +1,84 @@
+// immortal.hpp — process-lifetime state that must remain usable during and after static destruction.
+//
+// #2613. prosper never joins guest threads: k_pthread_create spawns them and nothing quiesces them
+// at shutdown, so every prosper process reaches exit() with live guest threads. thread_trampoline's
+// tail (tls_dtv_purge_current_thread / unregister_thread_stack / retire_guest_thread_name) then runs
+// concurrently with __run_exit_handlers, and it touches namespace-scope registries whose static
+// destructors that handler chain has already executed. Observed as a real core dump: the main thread
+// inside _dl_fini, a guest thread inside std::unordered_map lookup on a destroyed map.
+//
+// Immortal<T> removes the ordering question rather than narrowing the window. The contained object is
+// constructed during its translation unit's dynamic initialization exactly where the plain object was,
+// and is NEVER destroyed: the holder's only member is a byte array, so the holder is trivially
+// destructible and the compiler emits no __cxa_atexit registration for it. Storage is
+// process-lifetime, so a thread that reaches the registry at any point — including after every exit
+// handler has run — finds a live object. There is no window to widen and no ordering to get right.
+//
+// The cost is that T's destructor never runs. For a process-lifetime registry that is the intent:
+// the OS reclaims the memory at exit, and declining to destroy it is what makes the shutdown race
+// unrepresentable. Do NOT use Immortal for anything whose destructor has a side effect the process
+// actually needs (flushing a stream, releasing a lock visible outside this process, joining a
+// thread) — those still need an explicit, ordered shutdown.
+//
+// Pair every declaration with
+//     static_assert(std::is_trivially_destructible_v<decltype(the_object)>, "...");
+// at the declaration site. That assert is the guard against the regression this file exists to
+// prevent: it fires if the holder is ever simplified back to a bare container.
+//
+// TWO PROPERTIES THAT ARE NOT VISIBLE AT A CALL SITE, both measured on this tree's toolchain
+// (Fedora gcc 16, libstdc++). Neither is a problem for anything converted in #2613; both are the
+// kind of thing that bites whoever applies this header somewhere new.
+//
+//  1. THE static_assert IS VACUOUS FOR SOME T. libstdc++'s bare std::mutex already measures
+//     trivially-destructible = 1, so an assert naming only mutex operands proves nothing. Every
+//     assert in this tree is a conjunction that also names the CONTAINER beside the mutex, and the
+//     containers measure 0 -- that operand is what makes the guard fire. Keep the container in the
+//     conjunction; do not write an Immortal<std::mutex> assert on its own and read it as coverage.
+//
+//  2. WRAPPING CONVERTS CONSTANT INITIALIZATION INTO DYNAMIC INITIALIZATION. A bare namespace-scope
+//     std::mutex has a constexpr constructor and emits no _GLOBAL__sub_I_ at all; wrapped in
+//     Immortal it acquires one, because this class has a user-provided constructor. That trades a
+//     zero-cost object for one with static-initialization-order exposure -- a net loss if the
+//     object had no destructor to begin with. It is harmless as applied here only because every
+//     converted mutex is taken alongside a container in the same TU that already required dynamic
+//     initialization. Before wrapping a constant-initialized T, check that it is not the only
+//     reason its TU gains a static initializer.
+#pragma once
+
+#include <new>
+#include <type_traits>
+#include <utility>
+
+namespace prosper {
+
+template <class T>
+class Immortal {
+public:
+    template <class... Args>
+    explicit Immortal(Args&&... args) {
+        ::new (static_cast<void*>(storage_)) T(std::forward<Args>(args)...);
+    }
+    Immortal(const Immortal&) = delete;
+    Immortal& operator=(const Immortal&) = delete;
+    // No destructor is declared, on purpose. Declaring one — even `= default` — would still be
+    // trivial here, but writing it invites someone to "complete" it later with a call to T's.
+
+    // std::launder is REQUIRED, not decoration. An array and its first element are not
+    // pointer-interconvertible, so the reinterpret_cast alone yields a pointer to the byte array
+    // rather than to the T constructed into it -- formally UB since C++17. No shipping compiler
+    // exploits it for this pattern today, and with the launder the generated assembly for this
+    // tree differs only in .file directives and local label numbering; it is here so the next T
+    // this header is applied to (a type with a const or reference member, where the aliasing
+    // question has teeth) does not inherit a latent defect.
+    T& get() noexcept { return *std::launder(reinterpret_cast<T*>(storage_)); }
+    const T& get() const noexcept { return *std::launder(reinterpret_cast<const T*>(storage_)); }
+    T& operator*() noexcept { return get(); }
+    const T& operator*() const noexcept { return get(); }
+    T* operator->() noexcept { return &get(); }
+    const T* operator->() const noexcept { return &get(); }
+
+private:
+    alignas(T) unsigned char storage_[sizeof(T)];
+};
+
+}   // namespace prosper

--- a/prosper/tests/test_exit_registry_lifetime.cpp
+++ b/prosper/tests/test_exit_registry_lifetime.cpp
@@ -1,0 +1,260 @@
+// test_exit_registry_lifetime — regression guard for #2613.
+//
+// prosper never joins guest threads: k_pthread_create spawns them and nothing quiesces them at
+// shutdown, so every process reaches exit() with live guest threads. thread_trampoline's tail —
+// tls_dtv_purge_current_thread(), unregister_thread_stack(), retire_guest_thread_name() — then runs
+// while __run_exit_handlers is already tearing the process down, and it touches namespace-scope
+// registries whose static destructors that teardown has already executed. #2613 has the core dump:
+// main inside _dl_fini, a guest thread inside an unordered_map lookup on a destroyed map.
+//
+// THE HARD PART OF TESTING THIS IS DETERMINISM. Reproducing the original crash needs a thread to be
+// in the tail during teardown — 1 fault in 300 runs pinned to one CPU. A test that "passes N times"
+// would be evidence of nothing, and #2617 removed the accidental trigger precisely because a random
+// SEGFAULT with no diagnosis is worse than an issue. So this test does not race: it PARKS a guest
+// worker inside its entry, lets main return, and drives the whole thing from an exit-time probe that
+// is guaranteed to run after the library's static destruction. Post-destruction registry access is
+// then a certainty on every run, not a 1-in-300 accident.
+//
+// The ordering that makes that true, and how the test proves it rather than assuming it:
+//   * ExitProbe is declared FIRST in this translation unit, and this TU's object file precedes
+//     libprosper_core.a on the link line. ELF runs .init_array in link order, so this TU's dynamic
+//     initialization happens before the library's; __cxa_atexit handlers run in reverse registration
+//     order, so this probe's destructor runs after every static destructor in the library.
+//   * That is a property of this toolchain and link, not of the standard — so the probe DOES NOT
+//     TRUST IT. hle_kernel.cpp and exec_image_linux.cpp each carry a canary object declared before
+//     their registries, which flips a flag when destroyed. If either flag is still false when the
+//     probe runs, the probe fails the test loudly instead of passing vacuously: "the ordering
+//     assumption broke" and "the fix works" must never look alike.
+//   * main() asserts the same two flags read FALSE while it runs, so the flags are shown to move.
+//
+// What each phase covers: the read side of all three registries after destruction (thread names,
+// thread stacks, the __tls_get_addr DTV), then the real trampoline tail itself — the parked worker
+// is released and joined from inside the probe, so retire_guest_thread_name / unregister_thread_stack
+// / tls_dtv_purge_current_thread all execute post-destruction and their effects are asserted.
+//
+// Without the fix the map/vector destructors have run by then, so every one of those touches is a
+// use-after-destruction: the observed failures are a SIGSEGV or a registry that reports its live
+// rows as missing. Either way the test fails; it cannot pass.
+#include "../src/hle/dispatch.hpp"
+#include "../src/hle/nid.hpp"
+#include "../src/host/exec_image.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <thread>
+
+using namespace prosper;
+
+namespace {
+
+// ---------------------------------------------------------------------------------------------
+// The exit-time probe. MUST stay the first object with a non-trivial constructor/destructor in this
+// file: everything else here is constant-initialized (atomics, plain function pointers, PODs), so
+// this is unambiguously the first registration and therefore the last destructor in this TU.
+// ---------------------------------------------------------------------------------------------
+struct ExitProbe {
+    ExitProbe() noexcept;
+    ~ExitProbe();
+};
+ExitProbe g_exit_probe;
+
+// Everything below is constant-initialized: no dynamic initialization, no destructors.
+HleFn g_create = nullptr, g_join = nullptr, g_getname = nullptr, g_tlsget = nullptr;
+
+std::atomic<uint64_t> g_parked_thread{0};
+std::atomic<bool> g_parked_running{false};
+std::atomic<bool> g_release_parked{false};
+std::atomic<bool> g_main_phase_ok{false};
+std::atomic<bool> g_probe_constructed{false};
+
+constexpr uint64_t kSyntheticTid  = 0x2613cafe;      // a stack row no thread exit ever removes
+constexpr uint64_t kSyntheticBase = 0x7f2613000000ull;
+constexpr uint64_t kSyntheticSize = 0x40000;
+constexpr uint64_t kWorkerResult  = 0x2613;
+
+const char kParkedName[] = "exit-probe-worker";
+
+// One TLS module template so the parked worker can take a real DTV entry through __tls_get_addr.
+unsigned char g_tdata[8] = {0x26, 0x13, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+enum { kMemsz = 32, kFilesz = 8 };
+
+int g_fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); g_fails++; } \
+                         else      { std::printf("  [ok]   %s\n", m); } } while (0)
+
+// Probe-side reporting: stdio is still alive inside __run_exit_handlers (_IO_cleanup runs after
+// them), but flush every line so nothing is lost if a later phase faults.
+int g_probe_fails = 0;
+void probe_check(bool ok, const char* what) {
+    std::fprintf(stderr, "  %s %s\n", ok ? "[ok]  " : "[FAIL]", what);
+    std::fflush(stderr);
+    if (!ok) g_probe_fails++;
+}
+
+// The parked guest worker. Takes a DTV entry, announces itself, then blocks inside its guest entry
+// so its name/stack/DTV rows are all live when the process starts exiting. Body kept out of the
+// sysv_abi shim for the MinGW assembler reason documented in test_pthread_names.cpp.
+__attribute__((noinline)) void* parked_worker_body() {
+    uint64_t ti[2] = {0, 0};                       // module 0, offset 0
+    (void)g_tlsget((uint64_t)(uintptr_t)ti, 0, 0, 0, 0, 0);
+    g_parked_running.store(true, std::memory_order_release);
+    while (!g_release_parked.load(std::memory_order_acquire))
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    return (void*)(uintptr_t)kWorkerResult;
+}
+#ifdef _WIN32
+extern "C" __attribute__((sysv_abi)) void* parked_worker(void*) {
+#else
+void* parked_worker(void*) {
+#endif
+    return parked_worker_body();
+}
+
+ExitProbe::ExitProbe() noexcept { g_probe_constructed.store(true, std::memory_order_release); }
+
+ExitProbe::~ExitProbe() {
+    std::fprintf(stderr, "== exit probe (static destruction is under way) ==\n");
+    std::fflush(stderr);
+
+    // ---- validity gate. Everything below is only meaningful AFTER the library's static
+    // destruction; if the link order that guarantees it ever changes, fail rather than pass.
+    const bool hle_done  = hle_kernel_statics_destroyed();
+    const bool exec_done = exec_image_statics_destroyed();
+    if (!hle_done || !exec_done) {
+        std::fprintf(stderr,
+                     "  [FAIL] probe ran BEFORE the library's static destruction "
+                     "(hle_kernel=%d exec_image=%d). This test's ordering assumption is broken -- "
+                     "the result says nothing about #2613 either way.\n",
+                     (int)hle_done, (int)exec_done);
+        std::fflush(stderr);
+        std::_Exit(1);
+    }
+    probe_check(true, "probe runs after the library's static destructors (both canaries flipped)");
+
+    if (!g_main_phase_ok.load(std::memory_order_acquire)) {
+        std::fprintf(stderr, "  [FAIL] main phase did not complete; probe has nothing to check\n");
+        std::fflush(stderr);
+        std::_Exit(1);
+    }
+
+    const uint64_t parked = g_parked_thread.load(std::memory_order_acquire);
+
+    // ---- (1) read side, post-destruction: the thread-stack registry (exec_image_linux.cpp).
+    void* base = nullptr; size_t size = 0;
+    const bool stack_found = guest_stack_for_thread(kSyntheticTid, &base, &size);
+    probe_check(stack_found && (uint64_t)(uintptr_t)base == kSyntheticBase && size == kSyntheticSize,
+                "thread-stack registry still serves its row after static destruction");
+
+    // ---- (2) read side, post-destruction: the guest thread-name registry (hle_kernel.cpp).
+    unsigned char name_out[40];
+    std::memset(name_out, 0xa5, sizeof name_out);
+    const uint64_t name_rc = g_getname(parked, (uint64_t)(uintptr_t)name_out, 0, 0, 0, 0);
+    probe_check(name_rc == 0 && std::strcmp((const char*)name_out, kParkedName) == 0,
+                "thread-name registry still serves the parked worker's name after static destruction");
+
+    // ---- (3) read side, post-destruction: the __tls_get_addr DTV (hle_kernel.cpp).
+    probe_check(tls_dtv_thread_count() == 1,
+                "DTV still reports the parked worker's entry after static destruction");
+
+    // ---- (4) the real thing: release the parked worker so thread_trampoline's tail runs NOW,
+    // with the process already inside its exit handlers. This is the exact interleaving #2613's
+    // core dump caught, made deterministic.
+    g_release_parked.store(true, std::memory_order_release);
+    uint64_t worker_rv = 0;
+    const uint64_t join_rc = g_join(parked, (uint64_t)(uintptr_t)&worker_rv, 0, 0, 0, 0);
+    probe_check(join_rc == 0 && worker_rv == kWorkerResult,
+                "parked guest worker ran its trampoline tail during exit and joined cleanly");
+
+    // ---- (5) and the tail's effects landed in the still-live registries.
+    std::memset(name_out, 0xa5, sizeof name_out);
+    probe_check(g_getname(parked, (uint64_t)(uintptr_t)name_out, 0, 0, 0, 0) == 3,
+                "retire_guest_thread_name erased the row from the post-destruction registry");
+    probe_check(!guest_stack_for_thread(parked, &base, &size),
+                "unregister_thread_stack erased the worker's row from the post-destruction registry");
+    probe_check(tls_dtv_thread_count() == 0,
+                "tls_dtv_purge_current_thread purged the DTV from the post-destruction registry");
+
+    // ---- (6) write side, post-destruction: mutate the stack registry and read the mutation back.
+    unregister_thread_stack(kSyntheticTid);
+    probe_check(!guest_stack_for_thread(kSyntheticTid, &base, &size),
+                "thread-stack registry accepts a write after static destruction");
+
+    if (g_probe_fails) {
+        std::fprintf(stderr, "== FAIL: %d exit-probe check(s) ==\n", g_probe_fails);
+        std::fflush(stderr);
+        std::_Exit(1);
+    }
+    std::fprintf(stderr, "== PASS (exit probe) ==\n");
+    std::fflush(stderr);
+}
+
+}   // namespace
+
+int main() {
+    std::printf("== test_exit_registry_lifetime ==\n");
+    register_builtin_hle();
+
+    g_create  = Hle::lookup(nid_hash("scePthreadCreate"));
+    g_join    = Hle::lookup(nid_hash("scePthreadJoin"));
+    g_getname = Hle::lookup(nid_hash("scePthreadGetname"));
+    g_tlsget  = Hle::lookup(nid_hash("__tls_get_addr"));
+    CHECK(g_create && g_join && g_getname && g_tlsget,
+          "scePthreadCreate/Join/Getname and __tls_get_addr are registered");
+    if (!(g_create && g_join && g_getname && g_tlsget)) { std::printf("== FAIL ==\n"); return 1; }
+
+    // The canaries must read LIVE here. Without this arm the probe's validity gate could be passing
+    // on a flag that is simply always true.
+    CHECK(!hle_kernel_statics_destroyed() && !exec_image_statics_destroyed(),
+          "both static-destruction canaries read LIVE while main() runs");
+    CHECK(g_probe_constructed.load(std::memory_order_acquire),
+          "the exit probe was constructed during static initialization");
+
+    TlsModuleDesc desc{};
+    desc.init_va = (uint64_t)(uintptr_t)g_tdata;
+    desc.filesz  = kFilesz;
+    desc.memsz   = kMemsz;
+    set_tls_modules(&desc, 1);
+    CHECK(tls_dtv_thread_count() == 0, "no thread holds a DTV entry yet");
+
+    // A stack row keyed by an id no thread owns, so nothing but the probe ever removes it.
+    register_thread_stack(kSyntheticTid, (void*)(uintptr_t)kSyntheticBase, kSyntheticSize);
+    void* base = nullptr; size_t size = 0;
+    CHECK(guest_stack_for_thread(kSyntheticTid, &base, &size) &&
+          (uint64_t)(uintptr_t)base == kSyntheticBase && size == kSyntheticSize,
+          "synthetic stack row is registered before exit");
+
+    uint64_t tid = 0;
+    const uint64_t rc = g_create((uint64_t)(uintptr_t)&tid, 0,
+                                 (uint64_t)(uintptr_t)&parked_worker, 0,
+                                 (uint64_t)(uintptr_t)kParkedName, 0);
+    CHECK(rc == 0 && tid != 0, "parked guest worker created through scePthreadCreate");
+    if (rc != 0 || tid == 0) { std::printf("== FAIL ==\n"); return 1; }
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    while (!g_parked_running.load(std::memory_order_acquire) &&
+           std::chrono::steady_clock::now() < deadline)
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    CHECK(g_parked_running.load(std::memory_order_acquire),
+          "parked worker reached its guest entry and is blocked there");
+
+    unsigned char name_out[40];
+    std::memset(name_out, 0xa5, sizeof name_out);
+    CHECK(g_getname(tid, (uint64_t)(uintptr_t)name_out, 0, 0, 0, 0) == 0 &&
+          std::strcmp((const char*)name_out, kParkedName) == 0,
+          "parked worker's name is registered before exit");
+    CHECK(tls_dtv_thread_count() == 1, "parked worker holds exactly one DTV entry before exit");
+
+    g_parked_thread.store(tid, std::memory_order_release);
+
+    if (g_fails) {
+        std::printf("== FAIL: %d ==\n", g_fails);
+        return 1;   // the probe still runs and will report its own gate failure
+    }
+    g_main_phase_ok.store(true, std::memory_order_release);
+    std::printf("== main phase ok -- the verdict is the exit probe's ==\n");
+    return 0;   // return, do NOT _Exit: static destruction is the thing under test
+}


### PR DESCRIPTION
Fixes #2613.

## The failure

Nothing joins guest threads at shutdown. `k_pthread_create` spawns them and prosper has no barrier
that quiesces them, so **every** prosper process -- `prosper-app`, every boot test -- reaches
`exit()` with live guest threads. `thread_trampoline`'s tail then runs concurrently with
`__run_exit_handlers` and touches namespace-scope registries whose static destructors that handler
chain has already executed.

#2613 has the core dump, not a reading of the source: main thread in `_dl_fini`, a guest thread in
`std::unordered_map` lookup on `g_guest_thread_names` after it was destroyed. Reproduced on Linux at
about **1 fault in 300 runs** pinned to one CPU; materially wider under Rosetta 2, which is where
#2427 was observed 15 times in 502 job attempts.

## The contract

A registry the trampoline tail touches must be **usable for the whole process lifetime**, including
during and after static destruction. This PR makes that structural rather than probabilistic.

`prosper/src/host/immortal.hpp` adds `Immortal<T>`: the contained object is constructed during its
TU's dynamic initialization exactly where the plain object was, and is **never destroyed** -- the
holder's only member is a byte array, so the holder is trivially destructible and the compiler emits
no `__cxa_atexit` registration for it. There is no window to widen and no ordering to get right.
Every declaration is paired with

```cpp
static_assert(std::is_trivially_destructible_v<decltype(the_object)>, "...");
```

at the declaration site, so simplifying the holder back to a bare container fails to compile.

## What changed

Everything the tail reaches, on both platforms -- fixing one alone just moves the fault to the next:

| file | objects | reached from |
| --- | --- | --- |
| `src/hle/hle_kernel.cpp` | `g_guest_thread_name_mutex`, `g_guest_thread_names` | `retire_guest_thread_name` |
| `src/hle/hle_kernel.cpp` | `g_tls_mods`, `g_tls_mods_mx`, `g_dtv_mx`, `g_dtv` | `tls_dtv_purge_current_thread`, `k_tls_get_addr` |
| `src/hle/hle_kernel.cpp` (`_WIN32`) | `g_thread_handle_mx`, `g_thread_handles` | `unregister_current_thread_handle` |
| `src/host/exec_image_linux.cpp` | `g_stacks`, `g_smx` | `unregister_thread_stack` |
| `src/host/exec_image_win.cpp` | `g_stacks`, `g_smx` | `unregister_thread_stack` |

The mutexes are included for symmetry and for macOS/libc++, but they are **not** the load-bearing
half on this Linux toolchain, where `std::is_trivially_destructible<std::mutex>` is 1 -- the
containers are, and the dump faults inside the map. That distinction is #2613's second comment and
it is why the table above lists the containers first.

## Deliberately unaffected

Same construction point, same contents, same locking, same call sites -- only the spelling of the
access changed (`x` -> `*x` / `x->`). Nothing else in the shutdown path is touched, and no shutdown
barrier is introduced (that would be a much larger change and risks hanging on a guest thread that
never returns).

**Out of scope, filed as #2673:** the same shape survives in seven registries a live guest thread can
reach through *ordinary* HLE calls during exit (guest cond/mutex/barrier state, the Windows key
thunks, the unwind module list, the module export tables). Those are not on the trampoline tail, no
dump exists for any of them, and this PR's test does not exercise them -- so widening the diff would
have shipped seven untested conversions.

## Regression test, and why it is deterministic

`prosper/tests/test_exit_registry_lifetime.cpp`. **This is the part that needed care.** Racing a
thread against teardown reproduces 1-in-300, and a detector whose failure mode is a random SEGFAULT
with no diagnosis is exactly what #2617 correctly deleted. A test that "passes N times" would be
evidence of nothing.

So the test does not race. It parks a guest worker inside its guest entry, returns from `main`, and
drives the entire trampoline tail from an **exit-time probe** that runs after the library's static
destruction -- so the post-destruction access happens on **every** run.

The ordering that makes that work is a property of this toolchain and link (`ExitProbe` is declared
first in the test TU; the test's object file precedes `libprosper_core.a` on the link line; ELF runs
`.init_array` in link order and `__cxa_atexit` handlers in reverse registration order). **The test
does not trust it.** `hle_kernel.cpp` and `exec_image_linux.cpp` each carry a canary object declared
before their registries which flips a flag when destroyed; the probe checks both flags first and
fails loudly if either is still false. "The ordering assumption broke" and "the fix works" cannot
look alike. `main()` asserts the same two flags read *live* while it runs, so the flags are shown to
move in both directions.

Phases: the read side of all three registries post-destruction, then the real tail (release the
parked worker, join it, assert `retire_guest_thread_name` / `unregister_thread_stack` /
`tls_dtv_purge_current_thread` all landed), then a post-destruction *write* to the stack registry.

### Mutation arm

Registries reverted to plain namespace-scope containers, canaries and test kept so it still builds.
Binary md5 confirmed to change and to return:

```
fixed     test_exit_registry_lifetime  a7675d39beca6507334a4fba0e19f5d4
mutated   test_exit_registry_lifetime  d513c4ca351a5cb31554a28b26f550a3
restored  test_exit_registry_lifetime  a7675d39beca6507334a4fba0e19f5d4   (exact return)
```

Mutation arm, 20 runs: **0 passed, 20 exited 139 (SIGSEGV)**. First run verbatim:

```
== exit probe (static destruction is under way) ==
  [ok]   probe runs after the library's static destructors (both canaries flipped)
  [FAIL] thread-stack registry still serves its row after static destruction
  [FAIL] thread-name registry still serves the parked worker's name after static destruction
  [ok]   DTV still reports the parked worker's entry after static destruction
Segmentation fault (core dumped)
EXIT=139
```

Note the two `[FAIL]` lines **before** the crash: the verdict does not rest on the SIGSEGV alone,
which matters because `exit 139` with no output has been misread as success here before (#1738). The
`[ok]` on the canary line is the validity gate confirming the probe really was past static
destruction. The crash then arrives in the join phase -- the trampoline tail touching destroyed
registries, i.e. #2613's mechanism reproduced deterministically.

Fixed arm, same 20 runs: **20/20 exit 0.**

## Verification

Built in the `ps5ys` distrobox (a host build silently drops `gpu_replay` and every Vulkan execution
test). Base `0588464b`, head `8e1b7c0b`.

```
cmake --build prosper/build-linux -j4                    -> rc=0
ctest -N                                                 -> Total Tests: 271
ctest --no-tests=error -j2                               -> 100% tests passed out of 271, exit 0
```

Denominator moved during this work as master merged; 271 = master's 270 + the one test added here.
Baseline measured on this machine before the change (master `ec2c0c22`, same environment -- no dump
configured, `PROSPER_DIAGNOSTICS` unset): **260/260, exit 0**.

Gates:

```
python3 prosper/tools/output/check_ascii_output.py prosper -> all checks passed
python3 prosper/tools/env/check_diag_gates.py             -> all checks passed
git diff origin/master --check                            -> clean
```

The ASCII gate (#2614) caught 7 em dashes in `static_assert` and `fprintf` literals in the first
draft; they are `--` now.

Windows and macOS are converted by inspection and compile-guarded by the same `static_assert`s, but
were **not** built or run here -- this box is Linux only. `exec_image_win.cpp` and the `_WIN32`
`g_thread_handles` block need the Windows CI job.

## Risks

- These destructors no longer run at exit. For a process-lifetime registry that is the intent -- the
  OS reclaims the memory, and declining to destroy it is what makes the race unrepresentable.
  `immortal.hpp`'s header comment records the cases where the trade is **not** acceptable (a
  destructor with a side effect the process needs: flushing a stream, releasing a lock visible
  outside this process, joining a thread). Nothing converted here has one.
- `Immortal<T>` uses placement `new` into an aligned byte array; `get()` type-puns through
  `reinterpret_cast`. Standard for this idiom, and the alternative (a function-local `static T*`)
  costs a guard-variable check on `k_tls_get_addr`, which is hot.
- The canary objects and their two exported predicates exist only so the test can prove its own
  ordering. They are 10 lines each and cost one relaxed atomic store at exit.

## Review

Requesting independent review: this is a lifetime/ABI-adjacent change to shared infrastructure, and
the verification itself is the kind that is easy to get wrong -- an exit-ordering test can pass for
the wrong reason. The canary gate is the specific thing to challenge.
