### PR TITLE
renderer: classify a declined compressed sampled surface, and print the gates it actually failed

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -127,11 +127,17 @@ What survives is the narrower claim, and it is the one that matters: `has_ds_liv
 helper** and that helper returned zero.
 
 **Which helper, and therefore which gate, is still undetermined.** `dcc_metadata_footprint`
-(`gpu_capture.cpp`) routes to the HTILE sizer only for `img_dim == 6 && Float32 && 1 component`, and
-otherwise to the DCC sizer — which fail-closes on tile mode and **never looks at `sample_count`**. So
-"the 4xAA gate blocked it" and "it was never routed to the HTILE sizer at all" are both consistent
-with everything measured so far, and `img_dim` was the one field not printed. #2679 now prints
-`dim=`. Until that is read, no gate conclusion should be quoted from this section.
+(`gpu_capture.cpp`) reaches the HTILE sizer only when **all three** of `img_dim == 6`,
+`format == Float32` and `num_components == 1` hold, and otherwise uses the DCC sizer — which
+fail-closes on tile mode and **never looks at `sample_count`**. So "the 4xAA gate blocked it" and "it
+was never routed to the HTILE sizer at all" are both consistent with everything measured so far.
+
+Two of those three conjuncts were unprinted, not one. #2679 adds `dim=` **and `ncomp=`**, because
+`fmt=` cannot stand in for the component count: it prints the `DataFormat` enum, and `Float32` is
+reached from raw IMG_FMT 22/64/74/77 with one, two, three or four components
+(`agc_shader_layout.cpp`). Note the asymmetry that remains even so — `dim != 6` is **decisive** (the
+HTILE sizer cannot have run), while `dim == 6` alone is not. Until all three are read, no gate
+conclusion should be quoted from this section.
 
 That is the second withdrawal on this surface, and the pattern is worth naming: each time, a
 measurement narrowed the question without settling it, and each time the tempting move was to treat
@@ -139,10 +145,12 @@ the surviving hypothesis as confirmed because it was the last one standing. It w
 there was simply no instrument pointed at its rival.
 
 What is measured, in full: `kind=HTILE` (the correlator classifies it correctly on this path),
-`tile=24` matching `TileMode::Sw64KbZX`, `pipe_aligned=1`, `ds_live=0`, and `samples=1`. Note that
-these two readings of them are **mutually exclusive and not yet separated**: if `img_dim == 6` the
-HTILE sizer ran and the sample count is the failing gate; if not, the DCC sizer ran, fail-closed on
-tile mode, and the sample count was never consulted. `dim=` decides it and is printed as of #2679. The function's own comment records that the sample-count gate is conservatism rather than
+`tile=24` matching `TileMode::Sw64KbZX`, `pipe_aligned=1`, `ds_live=0`, and `samples=1`.
+
+Two readings of that set remain **mutually exclusive and not yet separated**. If the routing predicate
+held, the HTILE sizer ran and the sample count is the failing gate; if it did not, the DCC sizer ran,
+fail-closed on tile mode, and the sample count was never consulted at all. `dim=` and `ncomp=` are
+printed as of #2679 so the next routed run separates them. The function's own comment records that the sample-count gate is conservatism rather than
 arithmetic:
 
 > HTILE sizing is independent of the depth sample count, but this API deliberately retains the

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -94,8 +94,11 @@ Two caveats, both load-bearing:
 ```
 
 `0x2052ac0000` is this title's main depth and `0x2055310000` its HTILE — neither is DCC. The renderer's
-sampled-image path never consults `sampled_source_decision()`; the metadata-kind correlator is
-registered only for the compute hook. Filed as **#2674**.
+sampled-image path never consults `sampled_source_decision()`, and — corrected in review — the
+metadata-kind correlator had **no production caller anywhere in the tree**. A query is registered for
+it in `live_renderer.cpp`, which made it natural to assume the compute path used it; registering a
+query is not calling one, and on master every reference to `classify_compression_metadata_kind`
+outside its own definition is a test. Filed as **#2674**.
 
 **A correction, kept because the reasoning error is the instructive part.** The first analysis
 concluded that gate 2 (the metadata footprint) is what blocks this surface, and attributed it to
@@ -113,26 +116,42 @@ hypothesis already held was the one chosen; `ds_live=` was added to the diagnost
 answers it as a measurement. `first=0x00` was likewise the *unread default*, not a reading of the
 plane.
 
-**Measured, 2026-08-18: `ds_live=0`.** No retained DS image exists for this surface, so the size
-expression does call the footprint helper and the helper returns zero. The original conclusion was
-therefore correct — but it is only now *established*, and it was not established when first written.
-The distinction matters here more than the answer: the same claim reached by the same route would
-have been wrong on any surface the renderer does own.
+**Measured, 2026-08-18: `ds_live=0`** — and this needs reading precisely, because the obvious reading
+is wrong. It does **not** mean "no retained DS image exists for this surface". The lookup that sets
+it is itself gated on `!has_live_rtt && !is_storage_image && img_dim == 1 && cls == Texture`
+(`live_renderer.cpp:2899`), so a binding the gate rejects never reaches the lookup and reads 0 for a
+reason unrelated to residency — on an `img_dim == 6` surface it is *structurally* 0.
+
+What survives is the narrower claim, and it is the one that matters: `has_ds_live` is false, therefore
+`!has_ds_live && r.compression_enabled` holds, therefore the size expression **did call a sizing
+helper** and that helper returned zero.
+
+**Which helper, and therefore which gate, is still undetermined.** `dcc_metadata_footprint`
+(`gpu_capture.cpp`) routes to the HTILE sizer only for `img_dim == 6 && Float32 && 1 component`, and
+otherwise to the DCC sizer — which fail-closes on tile mode and **never looks at `sample_count`**. So
+"the 4xAA gate blocked it" and "it was never routed to the HTILE sizer at all" are both consistent
+with everything measured so far, and `img_dim` was the one field not printed. #2679 now prints
+`dim=`. Until that is read, no gate conclusion should be quoted from this section.
+
+That is the second withdrawal on this surface, and the pattern is worth naming: each time, a
+measurement narrowed the question without settling it, and each time the tempting move was to treat
+the surviving hypothesis as confirmed because it was the last one standing. It was not confirmed;
+there was simply no instrument pointed at its rival.
 
 What is measured, in full: `kind=HTILE` (the correlator classifies it correctly on this path),
-`tile=24` matching `TileMode::Sw64KbZX`, `pipe_aligned=1`, `ds_live=0`, and `samples=1` against a
-required 4. **Every gate condition passes except the sample count**, and the surface is never routed
-to the HTILE helper in the first place — it is sized by the DCC one, which fail-closes on a tile mode
-that is not `SW_64KB_R_X`. The function's own comment records that the sample-count gate is conservatism rather than
+`tile=24` matching `TileMode::Sw64KbZX`, `pipe_aligned=1`, `ds_live=0`, and `samples=1`. Note that
+these two readings of them are **mutually exclusive and not yet separated**: if `img_dim == 6` the
+HTILE sizer ran and the sample count is the failing gate; if not, the DCC sizer ran, fail-closed on
+tile mode, and the sample count was never consulted. `dim=` decides it and is printed as of #2679. The function's own comment records that the sample-count gate is conservatism rather than
 arithmetic:
 
 > HTILE sizing is independent of the depth sample count, but this API deliberately retains the
 > observed 4xaa gate rather than claiming broader support.
 
-`meta_pipe_aligned` (T# word6 bit 19, `agc_shader_layout.cpp:386`) is the third condition and is **not
-printed by the decline line**, so today the log cannot say which gate failed. Making the gate legible
-is the prerequisite for deciding whether the 4xAA gate can widen with evidence rather than by
-inference from a comment.
+`meta_pipe_aligned` (T# word6 bit 19, `agc_shader_layout.cpp:386`) is the third condition. It, the
+sample count, `ds_live` and `img_dim` were all absent from the decline line, so the log could not say
+which gate failed; #2679 prints them. Making the gate legible is the prerequisite for deciding
+whether the 4xAA gate can widen with evidence rather than by inference from a comment.
 
 ### Also observed
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -3,12 +3,142 @@
 **Rung 3** on the bring-up ladder: routed gameplay entry with real GPU draws. The HUD, radar and
 tutorial text render; the 3D world does not.
 
-Tracker: **#1873**. Active frontier: **#2481**. Route: `scripts/gta5/reach-story-mode.pad`
+Tracker: **#1873**. Active frontier: **#2542** (#2481 is CLOSED and superseded by it; the
+pointer here and in `CLAUDE.md` said #2481 long after it closed). Route: `scripts/gta5/reach-story-mode.pad`
 (read its header — the flip timing is measured, not estimated, and the tab navigation needs four R1
 presses for a reason).
 
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
+
+## Gameplay frame characterised end to end, with the hang declined (2026-08-18)
+
+Two routed runs, Linux/RADV, `scripts/gta5/reach-story-mode.pad`, 4K, `tools/screenshot`, with
+`PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700`. **Zero device losses in both**, guest still running at the
+end of the first; the second ended on its own 520 s timeout. 40 and 69 samples respectively.
+
+**What renders, and what does not.** At gameplay the composite contains:
+
+- the **radar/minimap** — complete: player arrow, three blips, compass rose with `N`, and the
+  green/blue/gold legend bar;
+- the **tutorial caption** — `The Radar shows your position within the world.`, every glyph present;
+- **three point lights with lens-flare streaks**, plus very faint blue structure toward the right;
+- **no geometry at all.**
+
+So the lighting and post path reaches the scanout while the geometry it illuminates does not. The 2D
+and UI composite is in good shape — the 4K loading screen (Michael, skyline, logo, and
+`Entering Story Mode: (90%)`) renders essentially correctly.
+
+**Route note.** This route enters the **prologue** (`Ludendorff, North Yankton, nine years ago.`
+renders correctly over black), not the free-roam resume the route README describes. The prologue
+legitimately opens on black before fading in, so a capture that stops around 200 s will read as "black
+world" for a reason that has nothing to do with the renderer. The first run did exactly that; the
+second is why the state above is stated at all. **Capture past 400 s on this route** before concluding
+anything about the world.
+
+### Skipping is not fixing — a correction worth keeping
+
+It is tempting to read "world still absent with `0x413dc6700` declined" as evidence against #2542's
+framing. **It is not.** A declined dispatch produces nothing, so an absent world is exactly what that
+route predicts if the program is a world producer. The SKIP route can show that the *rest* of the
+frame survives without a device loss; it cannot demonstrate a correct world, and no run under it
+should be quoted as if it could.
+
+### Compute rejects on this frame: one shared mode, and it is not a missing emitter
+
+Nine distinct compute programs are declined, **every one `mode=unresolved-operand`**, across five
+instruction families (MUBUF, DS, MIMG, SOP1, VOP3). Per `rdna2_to_spirv.cpp` that mode means the
+lowering ran and could not resolve an operand or a resource-table descriptor — so these are descriptor
+failures, not absent lowerings.
+
+The ungated `[compute-table]` dump answers the next question directly: **does the rejecting
+instruction's own fetch pc appear as a key in the table that program was handed?**
+
+| program | reject pc | keys | pc is a key | min key |
+| --- | ---: | ---: | :---: | ---: |
+| `0x2042f49a00` | 16 | 4 | **YES** | 16 |
+| `0x205b5e8600` | 314 | 75 | NO | 6 |
+| `0x205b654a00` | 1180 | 82 | NO | 16 |
+| `0x205b657200` | 313 | 34 | NO | 16 |
+| `0x205b658800` | 82 | 150 | NO | 6 |
+| `0x413cf9200` | 5 | 9 | NO | 64 |
+| `0x413cf9a00` | 39 | 5 | NO | 11 |
+| `0x413cf9d00` | 70 | 16 | NO | 26 |
+| `0x413d14100` | 6 | 10 | NO | 41 |
+
+**8 of 9 reject at a pc for which no resource was offered.** Two — `0x413cf9200` at pc 5 and
+`0x413d14100` at pc 6 — reject *before the first key in their own table*, at the top of the program
+where a root pointer is loaded. `0x413cf9200` pc 5 decodes as
+`buffer_load_dword v17, v0, s[4:7], 0`: an SGPR-based descriptor, and every resource in that table
+carries `sgpr=0xffffffff`, so nothing is keyed by SGPR base either.
+
+**This rules out the framing in `gpu_executor.cpp`** that a resource with
+`srt=0xffffffff sgpr=0xffffffff` is "invisible to every lookup": the same diagnostic reports
+`0 with no lookup key` for all nine, because those entries are still keyed by fetch pc. The failure is
+not "the resource has no key" but "no resource was offered for the site that needs one".
+
+Two caveats, both load-bearing:
+
+- **No comparison population.** `[compute-table]` prints only for *rejected* programs (it sits inside
+  `report_compute_recompile_skip_once`), so every row above is a reject by construction. This cannot
+  show the pattern discriminates rejected from accepted programs; that needs the table dumped for
+  accepted ones, which no switch does today.
+- **`0x2042f49a00` is the internal positive control** — its rejecting pc *is* a key, so the analysis
+  can print YES, and the eight NOs are not a matcher that always misses.
+
+### The sampled depth is declined, and the reason printed is the wrong one
+
+```
+[render] DCC-compressed sampled image addr=0x2052ac0000 meta=0x2055310000
+         3840x2160x1 fmt=1 tile=24 is unsupported; metadata=0/0 first=0x00
+```
+
+`0x2052ac0000` is this title's main depth and `0x2055310000` its HTILE — neither is DCC. The renderer's
+sampled-image path never consults `sampled_source_decision()`; the metadata-kind correlator is
+registered only for the compute hook. Filed as **#2674**.
+
+**A correction, kept because the reasoning error is the instructive part.** The first analysis
+concluded that gate 2 (the metadata footprint) is what blocks this surface, and attributed it to
+`gfx10_htile_msaa_metadata_bytes()` fail-closing on `sample_count != 4`. That conclusion is not
+established by the evidence, because the size expression is
+
+```cpp
+!has_ds_live && r.compression_enabled ? gpu_capture_dcc_metadata_footprint(r) : 0u
+```
+
+so `metadata=0/0` is *equally* consistent with `has_ds_live` being true — in which case no footprint
+helper is consulted at all and the gate discussion is irrelevant. For a title's main depth buffer,
+which the renderer demonstrably renders into, that branch is not exotic. The branch that fitted the
+hypothesis already held was the one chosen; `ds_live=` was added to the diagnostic so the next run
+answers it as a measurement. `first=0x00` was likewise the *unread default*, not a reading of the
+plane.
+
+**Measured, 2026-08-18: `ds_live=0`.** No retained DS image exists for this surface, so the size
+expression does call the footprint helper and the helper returns zero. The original conclusion was
+therefore correct — but it is only now *established*, and it was not established when first written.
+The distinction matters here more than the answer: the same claim reached by the same route would
+have been wrong on any surface the renderer does own.
+
+What is measured, in full: `kind=HTILE` (the correlator classifies it correctly on this path),
+`tile=24` matching `TileMode::Sw64KbZX`, `pipe_aligned=1`, `ds_live=0`, and `samples=1` against a
+required 4. **Every gate condition passes except the sample count**, and the surface is never routed
+to the HTILE helper in the first place — it is sized by the DCC one, which fail-closes on a tile mode
+that is not `SW_64KB_R_X`. The function's own comment records that the sample-count gate is conservatism rather than
+arithmetic:
+
+> HTILE sizing is independent of the depth sample count, but this API deliberately retains the
+> observed 4xaa gate rather than claiming broader support.
+
+`meta_pipe_aligned` (T# word6 bit 19, `agc_shader_layout.cpp:386`) is the third condition and is **not
+printed by the decline line**, so today the log cannot say which gate failed. Making the gate legible
+is the prerequisite for deciding whether the 4xAA gate can widen with evidence rather than by
+inference from a comment.
+
+### Also observed
+
+- **#2445 (dropped `r`/`s`/`m` glyphs) does not reproduce on Linux/RADV.** Both strings the issue
+  names render complete here. That is not a falsification — the issue is Windows/NVIDIA — but it
+  suggests a platform asymmetry, which is a much smaller search than a general text defect.
 
 ## THE CORRUPTING PROGRAM IS `0x413dc3400` (2026-08-15)
 

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4236,17 +4236,79 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             metadata.size());
                             } else if (!dcc_uncompressed) {
                                 static std::set<std::pair<uint64_t, uint64_t>> warned_dcc_images;
-                                if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second)
+                                if (warned_dcc_images.emplace(r.gpu_addr, r.metadata_addr).second) {
+                                    // WHICH KIND this metadata is, by positive correlation with
+                                    // retained renderer state -- never inferred from the descriptor.
+                                    // T# WORD6[21] (`compression_enabled`) is set for depth/stencil
+                                    // and colour alike, and AMD PAL puts GetHtile256BAddr() in the
+                                    // same `meta_data_address` field it uses for DCC, so the
+                                    // descriptor cannot separate them. This branch assumed DCC,
+                                    // which is how GTA V's main depth (0x2052ac0000, HTILE at
+                                    // 0x2055310000) came to be reported as "DCC-compressed" (#2674).
+                                    //
+                                    // Classified HERE, inside the first-sighting guard, rather than
+                                    // beside the footprint: the query walks the retained DS cache and
+                                    // the RTT map, which is O(surfaces) and this path runs per
+                                    // sampled texture. Behind the guard it runs at most once per
+                                    // (base, metadata) pair for the process, so the hot path is
+                                    // unchanged.
+                                    //
+                                    // Used ONLY TO REPORT. It deliberately does not change which
+                                    // footprint is taken or what is authorized: the HTILE helper is
+                                    // fail-closed on sample_count != 4 and this surface is
+                                    // single-sample, so routing it there today returns 0 exactly as
+                                    // the DCC helper does, while changing the path every other title
+                                    // takes. Widening that gate needs its own evidence (#2674).
+                                    const prosper::gpu::CompressionMetadataKind kind =
+                                        prosper::gpu::classify_compression_metadata_kind(
+                                            prosper::gpu::MetadataKindRequest{
+                                                r.metadata_addr, r.gpu_addr, r.format,
+                                                r.num_components, r.img_dim});
+                                    // Name the KIND, and print the inputs the footprint helpers
+                                    // actually gate on. The previous line called every declined
+                                    // surface "DCC-compressed" and omitted `samples` and
+                                    // `pipe_aligned`, which are two of the three conditions in
+                                    // gfx10_htile_msaa_metadata_bytes() and one in the DCC helper --
+                                    // so it could not say WHICH gate failed, and a reader chasing a
+                                    // depth surface was sent looking for a DCC defect (#2674).
+                                    //
+                                    // `first=` is printed only when bytes were actually read.
+                                    // metadata=0/0 means the footprint was zero, so nothing was
+                                    // fetched and the first byte is an unread default, not a
+                                    // measurement of the plane -- reporting 0x00 there stated a fact
+                                    // about our own buffer as though it were one about the guest.
+                                    //
+                                    // `ds_live=` disambiguates the TWO independent reasons the
+                                    // footprint can be zero, which the old line could not separate:
+                                    // a retained DS image exists for this surface (the size
+                                    // expression is gated on `!has_ds_live` outright), or the DCC
+                                    // helper fail-closed on the shape. Without it, "metadata=0/0" is
+                                    // compatible with both and a reader is free to pick the one that
+                                    // suits their hypothesis -- which is how a gate analysis gets
+                                    // written against the wrong gate.
+                                    const char* kind_name =
+                                        kind == prosper::gpu::CompressionMetadataKind::Htile
+                                            ? "HTILE"
+                                            : kind == prosper::gpu::CompressionMetadataKind::Dcc
+                                                  ? "DCC"
+                                                  : "UNCORRELATED";
+                                    char first_text[24] = "(unread)";
+                                    if (metadata_got)
+                                        std::snprintf(first_text, sizeof first_text, "0x%02x",
+                                                      metadata[0]);
                                     fprintf(stderr,
-                                            "[render] DCC-compressed sampled image addr=0x%llx "
-                                            "meta=0x%llx %ux%ux%u fmt=%u tile=%u is unsupported; "
-                                            "metadata=%zu/%llu first=0x%02x\n",
+                                            "[render] compressed sampled image kind=%s addr=0x%llx "
+                                            "meta=0x%llx %ux%ux%u fmt=%u tile=%u samples=%u "
+                                            "pipe_aligned=%u ds_live=%u is unsupported; "
+                                            "metadata=%zu/%llu first=%s\n",
+                                            kind_name,
                                             (unsigned long long)r.gpu_addr,
                                             (unsigned long long)r.metadata_addr,
                                             tw, th, r.depth, (unsigned)r.format, r.tile_mode,
-                                            metadata_got,
-                                            (unsigned long long)metadata_bytes,
-                                            metadata_got ? metadata[0] : 0u);
+                                            r.sample_count, r.meta_pipe_aligned ? 1u : 0u,
+                                            has_ds_live ? 1u : 0u, metadata_got,
+                                            (unsigned long long)metadata_bytes, first_text);
+                                }
                             }
                         }
                         // PROSPER_DS_UNBRIDGED_FAR=1 — DIAGNOSTIC ONLY, never a shipped default.

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4246,6 +4246,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     // which is how GTA V's main depth (0x2052ac0000, HTILE at
                                     // 0x2055310000) came to be reported as "DCC-compressed" (#2674).
                                     //
+                                    // This is the FIRST production caller of the correlator anywhere
+                                    // in the tree. It was easy to assume the compute path already
+                                    // used it -- a query is registered for it in this file -- but
+                                    // registering a query is not calling one, and on master every
+                                    // reference to `classify_compression_metadata_kind` outside its
+                                    // own definition is a test.
+                                    //
                                     // Classified HERE, inside the first-sighting guard, rather than
                                     // beside the footprint: the query walks the retained DS cache and
                                     // the RTT map, which is O(surfaces) and this path runs per
@@ -4264,13 +4271,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             prosper::gpu::MetadataKindRequest{
                                                 r.metadata_addr, r.gpu_addr, r.format,
                                                 r.num_components, r.img_dim});
-                                    // Name the KIND, and print the inputs the footprint helpers
+                                    // Name the KIND, and print the inputs the sizing helpers
                                     // actually gate on. The previous line called every declined
                                     // surface "DCC-compressed" and omitted `samples` and
-                                    // `pipe_aligned`, which are two of the three conditions in
-                                    // gfx10_htile_msaa_metadata_bytes() and one in the DCC helper --
-                                    // so it could not say WHICH gate failed, and a reader chasing a
-                                    // depth surface was sent looking for a DCC defect (#2674).
+                                    // `pipe_aligned` -- two of the three conditions in
+                                    // gfx10_htile_msaa_metadata_bytes(). The DCC sizer gates only on
+                                    // tile mode and bytes-per-texel; it takes `pipe_aligned` and
+                                    // explicitly discards it (`(void)pipe_aligned` in tile.cpp), so
+                                    // that field is diagnostic for the HTILE route only. Either way
+                                    // the old line could not say WHICH gate failed, and a reader
+                                    // chasing a depth surface was sent looking for a DCC defect.
                                     //
                                     // `first=` is printed only when bytes were actually read.
                                     // metadata=0/0 means the footprint was zero, so nothing was
@@ -4280,12 +4290,26 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     //
                                     // `ds_live=` disambiguates the TWO independent reasons the
                                     // footprint can be zero, which the old line could not separate:
-                                    // a retained DS image exists for this surface (the size
-                                    // expression is gated on `!has_ds_live` outright), or the DCC
-                                    // helper fail-closed on the shape. Without it, "metadata=0/0" is
-                                    // compatible with both and a reader is free to pick the one that
-                                    // suits their hypothesis -- which is how a gate analysis gets
-                                    // written against the wrong gate.
+                                    // the size expression is gated on `!has_ds_live` outright, or the
+                                    // sizing helper fail-closed on the shape. Without it,
+                                    // "metadata=0/0" is compatible with both and a reader is free to
+                                    // pick the one that suits their hypothesis -- which is how a gate
+                                    // analysis gets written against the wrong gate. One was.
+                                    //
+                                    // Read `ds_live=0` as "the size expression called a helper", NOT
+                                    // as "no retained DS image exists". The lookup above is itself
+                                    // gated on `!has_live_rtt && !is_storage_image && img_dim == 1 &&
+                                    // cls == Texture`, so a binding the gate rejects never reaches it
+                                    // and reads 0 for a reason that has nothing to do with residency
+                                    // -- on an `img_dim == 6` surface it is structurally 0.
+                                    //
+                                    // `dim=` is printed because it, not the sample count, selects
+                                    // which helper runs: `dcc_metadata_footprint` routes to the HTILE
+                                    // sizer ONLY for `img_dim == 6 && Float32 && 1 component`, and
+                                    // otherwise to the DCC sizer, which fail-closes on tile mode and
+                                    // never looks at `sample_count`. Without `dim=` the two gate
+                                    // stories -- "the sample count blocked it" and "it was never
+                                    // routed to the HTILE sizer at all" -- are indistinguishable.
                                     const char* kind_name =
                                         kind == prosper::gpu::CompressionMetadataKind::Htile
                                             ? "HTILE"
@@ -4298,14 +4322,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                       metadata[0]);
                                     fprintf(stderr,
                                             "[render] compressed sampled image kind=%s addr=0x%llx "
-                                            "meta=0x%llx %ux%ux%u fmt=%u tile=%u samples=%u "
-                                            "pipe_aligned=%u ds_live=%u is unsupported; "
+                                            "meta=0x%llx %ux%ux%u fmt=%u dim=%u tile=%u "
+                                            "samples=%u pipe_aligned=%u ds_live=%u is unsupported; "
                                             "metadata=%zu/%llu first=%s\n",
                                             kind_name,
                                             (unsigned long long)r.gpu_addr,
                                             (unsigned long long)r.metadata_addr,
-                                            tw, th, r.depth, (unsigned)r.format, r.tile_mode,
-                                            r.sample_count, r.meta_pipe_aligned ? 1u : 0u,
+                                            tw, th, r.depth, (unsigned)r.format, r.img_dim,
+                                            r.tile_mode, r.sample_count,
+                                            r.meta_pipe_aligned ? 1u : 0u,
                                             has_ds_live ? 1u : 0u, metadata_got,
                                             (unsigned long long)metadata_bytes, first_text);
                                 }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4303,13 +4303,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     // and reads 0 for a reason that has nothing to do with residency
                                     // -- on an `img_dim == 6` surface it is structurally 0.
                                     //
-                                    // `dim=` is printed because it, not the sample count, selects
-                                    // which helper runs: `dcc_metadata_footprint` routes to the HTILE
-                                    // sizer ONLY for `img_dim == 6 && Float32 && 1 component`, and
-                                    // otherwise to the DCC sizer, which fail-closes on tile mode and
-                                    // never looks at `sample_count`. Without `dim=` the two gate
-                                    // stories -- "the sample count blocked it" and "it was never
-                                    // routed to the HTILE sizer at all" -- are indistinguishable.
+                                    // `dim=` and `ncomp=` are printed because the ROUTING, not the
+                                    // sample count, decides which gate applies:
+                                    // `dcc_metadata_footprint` reaches the HTILE sizer only for
+                                    // `img_dim == 6 && Float32 && num_components == 1`, and
+                                    // otherwise uses the DCC sizer, which fail-closes on tile mode
+                                    // and never looks at `sample_count`. All three conjuncts must be
+                                    // visible: `fmt=` cannot stand in for `ncomp=`, because it
+                                    // prints the DataFormat enum and `Float32` is reached from raw
+                                    // IMG_FMT 22/64/74/77 with one, two, three or four components.
+                                    // With any conjunct missing, "the sample count blocked it" and
+                                    // "it was never routed to the HTILE sizer at all" stay
+                                    // indistinguishable -- which they were, and a gate analysis was
+                                    // written against the wrong gate because of it.
                                     const char* kind_name =
                                         kind == prosper::gpu::CompressionMetadataKind::Htile
                                             ? "HTILE"
@@ -4322,14 +4328,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                       metadata[0]);
                                     fprintf(stderr,
                                             "[render] compressed sampled image kind=%s addr=0x%llx "
-                                            "meta=0x%llx %ux%ux%u fmt=%u dim=%u tile=%u "
+                                            "meta=0x%llx %ux%ux%u fmt=%u ncomp=%u dim=%u tile=%u "
                                             "samples=%u pipe_aligned=%u ds_live=%u is unsupported; "
                                             "metadata=%zu/%llu first=%s\n",
                                             kind_name,
                                             (unsigned long long)r.gpu_addr,
                                             (unsigned long long)r.metadata_addr,
-                                            tw, th, r.depth, (unsigned)r.format, r.img_dim,
-                                            r.tile_mode, r.sample_count,
+                                            tw, th, r.depth, (unsigned)r.format, r.num_components,
+                                            r.img_dim, r.tile_mode, r.sample_count,
                                             r.meta_pipe_aligned ? 1u : 0u,
                                             has_ds_live ? 1u : 0u, metadata_got,
                                             (unsigned long long)metadata_bytes, first_text);


### PR DESCRIPTION
Fixes #2674.

## What was wrong

The live renderer's sampled-image path decides what to do with a compressed guest surface using its
own ad-hoc DCC branch. It never consults the metadata-kind correlator that exists on master, so an
HTILE-compressed **depth** surface is processed and reported as though it were DCC colour.

Observed on a routed *Grand Theft Auto V* (`PPSA04263`) gameplay frame, Linux/RADV:

```
[render] DCC-compressed sampled image addr=0x2052ac0000 meta=0x2055310000
         3840x2160x1 fmt=1 tile=24 is unsupported; metadata=0/0 first=0x00
```

`0x2052ac0000` is that title's main depth and `0x2055310000` its HTILE plane. Neither is DCC.

The descriptor genuinely cannot tell them apart: T# WORD6[21] (`compression_enabled`) is set for
depth/stencil and colour alike, and AMD PAL puts `GetHtile256BAddr()` in the same
`meta_data_address` field it uses for DCC. That ambiguity is exactly what
`src/gpu/metadata_kind_correlation.{hpp,cpp}` resolves by positive correlation against retained
renderer state — and, corrected in review, it had **no production caller anywhere in the tree**. A
query is registered for it in this file, which made it natural to assume the compute path used it;
registering a query is not calling one. On master every reference to
`classify_compression_metadata_kind` outside its own definition is a test, so **this is the first
production caller**.

Two further problems with the line itself, both of which cost an investigation real time:

- it printed **neither `sample_count` nor `meta_pipe_aligned`**, two of the three conditions
  `gfx10_htile_msaa_metadata_bytes()` gates on. Neither is a DCC-sizer condition: that helper gates
  on tile mode and bytes-per-texel, and takes `pipe_aligned` only to discard it
  (`(void)pipe_aligned;`, `tile.cpp`). So the log could not say *which* gate failed;
- it printed `first=0x00` even when **zero bytes were read**. `metadata=0/0` means the footprint was
  zero and nothing was fetched, so that `0x00` is our own zero-filled buffer being reported as
  though it were a measurement of the guest's plane. A default is not a measurement.

## What this changes

The decline now classifies the metadata by correlation and reports the inputs the footprint helpers
actually gate on:

```
[render] compressed sampled image kind=HTILE addr=0x… meta=0x… 3840x2160x1 fmt=1
         ncomp=1 dim=… tile=24 samples=1 pipe_aligned=1 ds_live=0 is unsupported;
         metadata=0/0 first=(unread)
```

`first=` reads `(unread)` when nothing was fetched, rather than inventing a byte.

## What this deliberately does NOT change

**Nothing about what is authorized, and therefore nothing any title renders.** The classification is
used only to report. Routing this surface to the HTILE footprint helper today would return 0 exactly
as the DCC helper does — that helper is fail-closed on `sample_count != 4` and this surface is
single-sample — while changing the path every other title takes. Widening that gate is a separate
question that needs its own evidence, and this PR is what makes that evidence obtainable.

I am stating this plainly because the failure mode is attractive: land a classification fix, observe
that no pixel changed, and conclude the depth path is irrelevant. It is not — it is gated two steps
earlier.

## Cost

The correlator query walks the retained DS cache and the RTT map, which is O(surfaces), and this path
runs per sampled texture. The call is therefore made **inside the first-sighting guard**, so it
executes at most once per `(base, metadata)` pair for the process. The hot path is unchanged.

## The three gates, for whoever picks up #2674

| gate | GTA V's main depth | |
| --- | --- | :---: |
| 1. kind | classified by correlation — **this PR** | fixed |
| 2. footprint | a sizing helper is called and returns 0. **Which helper, and therefore which gate, is undetermined** — see below | **blocking** |
| 3. uniform-value proof | unreachable — gate 2 returns 0, so **the plane has never been read** and nothing is known about whether this surface is decompressed | unreachable |

`gfx10_htile_msaa_metadata_bytes()`'s own comment records that gate 2 is conservatism rather than
arithmetic: *"HTILE sizing is independent of the depth sample count, but this API deliberately
retains the observed 4xaa gate rather than claiming broader support."* That is a statement that
single-sample was never checked — not evidence that it is unsupported.

## Measured on a routed gameplay frame

Linux/RADV, 4K, `scripts/gta5/reach-story-mode.pad`, `PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700`
(so the run costs **zero device losses**). The new line, for the surface this issue was filed about:

```
[render] compressed sampled image kind=HTILE addr=0x2052ac0000 meta=0x2055310000
         3840x2160x1 fmt=1 tile=24 samples=1 pipe_aligned=1 ds_live=0
         is unsupported; metadata=0/0 first=(unread)
```

Three things this immediately settles, none of which the old line could express:

- **the correlator classifies correctly on this path** — `kind=HTILE`, not DCC;
- **`ds_live=0`**, which must be read narrowly: it means the size expression called a sizing helper,
  **not** that no retained DS image exists. The lookup that sets it is itself gated on
  `!has_live_rtt && !is_storage_image && img_dim == 1 && cls == Texture`, so a binding the gate
  rejects reads 0 for a reason unrelated to residency, and on an `img_dim == 6` surface it is
  *structurally* 0;
- **which gate blocks it is still undetermined, and the PR no longer claims otherwise.**
  `dcc_metadata_footprint()` reaches the HTILE sizer only when **all three** of `img_dim == 6`,
  `format == Float32` and `num_components == 1` hold; otherwise the DCC sizer runs, fail-closes on
  tile mode, and **never looks at `sample_count`**. So "the 4xAA gate blocked it" and "it was never
  routed to the HTILE sizer at all" are both consistent with everything measured.

  **Two** of those conjuncts were unprinted, not one — round 2 adds `dim=` *and* `ncomp=`. `fmt=`
  cannot stand in for the component count: it prints the `DataFormat` enum, and `Float32` is reached
  from raw IMG_FMT 22/64/74/77 with one, two, three or four components. One asymmetry survives even
  with both fields: `dim != 6` is **decisive** (the HTILE sizer cannot have run), while `dim == 6`
  alone is not. The next routed run settles it.

A second HTILE depth surface (`0x20c0c80000`, 2992x1496) shows the identical profile, so the pattern
is systematic rather than one surface's quirk. Two `tile=27` colour surfaces in the same run *do* get
footprints (81920 and 49152 bytes, fully read) — the positive control that the DCC helper works when
the shape suits it, and the observation behind **#2677**.

## Verification

- Build: clean, 0 errors.
- `tools/output/check_ascii_output.py`: `== all checks passed ==`.
- `tools/docs/check_numbered_table.py` over every tracked `.md`: clean.
- ctest: recorded below at the exact head.

No unit test accompanies this. The change is a diagnostic string plus one classification call, and
the production site is an `fprintf` inside a renderer lambda that no test reaches; the classification
rule itself is already covered by `test_metadata_kind_correlation`. The evidence is the routed run
above, which is the only thing that could have demonstrated it.

## Review history

Three rounds, and worth stating plainly because the pattern is the useful part: **the code was found
sound in every round; every blocking finding was in the prose.** Always in the same direction — a
claim slightly stronger than the measurement licensed.

- **Round 1** — four findings: a false "the correlator is registered only for the compute hook" (it
  had *no* production caller; this PR adds the first), an underdetermined gate conclusion, a doc
  paragraph this PR itself falsified, and `ds_live=0` over-read as "no retained DS image exists".
- **Round 2** — two findings: the *replacement* gate claim over-claimed by one conjunct (`ncomp` was
  unprinted too), and both withdrawn conclusions were still standing on **#2674**, stated more
  strongly there than they ever were here. Correcting the PR and the doc while leaving the issue
  thread was the wrong half of the job — the thread is the durable record.

Also corrected out-of-band: an earlier #2674 comment pasted a `git grep` transcript showing two hits
under a command that returns four. The conclusion held, but a transcript that does not match the
command above it is not evidence.
