### PR TITLE
diag(ds/rt): fix four ways these GPU diagnostics produced confidently wrong answers

### DIFF
--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -4371,26 +4371,70 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             ? static_cast<uint8_t>(strtoul(
                                   getenv("PROSPER_DS_UNBRIDGED_FILL"), nullptr, 0))
                             : 0xffu;
+                        // PROSPER_DS_UNBRIDGED_FILL_F32=<float> — fill FLOAT TEXELS, not bytes.
+                        //
+                        // The byte fill above is correct for a UNORM depth, where 0xff really is 1.0.
+                        // It is NOT correct for a Float32 depth (`fmt=1`), where 0xffffffff is
+                        // **NaN**: every comparison against it is false, so the "far" pole is not far,
+                        // it is a third failure mode. A two-pole run over {0x00, 0xff} on a Float32
+                        // surface therefore tests {0.0f, NaN} and never tests 1.0f at all -- which
+                        // silently voids the discriminator this lever exists to be. One such run was
+                        // published as a falsification before the arithmetic was checked.
+                        static const bool have_f32_fill =
+                            PROSPER_ENV_VALUE("PROSPER_DS_UNBRIDGED_FILL_F32") != nullptr;
+                        static const float f32_fill = have_f32_fill
+                            ? strtof(PROSPER_ENV_VALUE("PROSPER_DS_UNBRIDGED_FILL_F32"), nullptr)
+                            : 1.0f;
                         if (!rtt_hit && !has_ds_live && !fr.is_storage_image &&
                             !far_mode.empty() && far_mode != "0" &&
                             (far_mode != "cube" || r.img_dim == 3u) &&
                             prosper::test::is_retained_ds_plane(r.gpu_addr)) {
-                            std::fill(texture_pixels.begin(), texture_pixels.end(), far_fill);
+                            const bool f32_path = have_f32_fill &&
+                                r.format == prosper::gpu::DataFormat::Float32 &&
+                                texture_pixels.size() % sizeof(float) == 0;
+                            if (f32_path) {
+                                float* texels = reinterpret_cast<float*>(texture_pixels.data());
+                                std::fill(texels, texels + texture_pixels.size() / sizeof(float),
+                                          f32_fill);
+                            } else {
+                                std::fill(texture_pixels.begin(), texture_pixels.end(), far_fill);
+                            }
+                            // PER-ADDRESS count, not just a global one. The report prints once per
+                            // address, so a global running total cannot say how many of a given
+                            // surface's missed samples the fill actually reached -- and that is
+                            // exactly the number a reader needs: this lever only fires when
+                            // `is_retained_ds_plane` holds, so it can cover an arbitrary fraction of
+                            // the misses a run observes. Without it, "filled, and nothing changed"
+                            // is not a falsification, because the fill may have reached 2 of 161.
                             static std::mutex far_mutex;
-                            static std::set<uint64_t> far_seen;
+                            static std::map<uint64_t, uint64_t> far_hits;
                             static std::atomic<uint64_t> far_count{0};
                             const uint64_t n = far_count.fetch_add(1) + 1;
                             bool first = false;
+                            uint64_t per_addr = 0;
                             {
                                 std::lock_guard lock(far_mutex);
-                                first = far_seen.insert(r.gpu_addr).second;
+                                per_addr = ++far_hits[r.gpu_addr];
+                                first = per_addr == 1;
                             }
+                            // Re-report on a power-of-two schedule so coverage is visible without
+                            // flooding: 1, 2, 4, 8 ... fills per address.
+                            first = first || (per_addr & (per_addr - 1)) == 0;
+                            char fill_text[32];
+                            if (f32_path)
+                                std::snprintf(fill_text, sizeof fill_text, "%gf", f32_fill);
+                            else
+                                std::snprintf(fill_text, sizeof fill_text, "0x%02x",
+                                              (unsigned)far_fill);
                             if (first)
                                 fprintf(stderr,
-                                        "[ds-far] addr=0x%llx %ux%ux%u dim=%u filled 0x%02x "
-                                        "(unbridged retained DS plane; total=%llu)\n",
+                                        "[ds-far] addr=0x%llx %ux%ux%u dim=%u fmt=%u path=%s "
+                                        "filled=%s (unbridged retained DS plane; "
+                                        "fills-this-addr=%llu total=%llu)\n",
                                         (unsigned long long)r.gpu_addr, tw, th, r.depth, r.img_dim,
-                                        (unsigned)far_fill, (unsigned long long)n);
+                                        (unsigned)r.format, f32_path ? "f32" : "byte",
+                                        fill_text, (unsigned long long)per_addr,
+                                        (unsigned long long)n);
                             rtt_hit = true;   // do not overwrite it with a guest-byte decode below
                             resource_rtt_hit = true;
                         }

--- a/prosper/frontends/shared/live_renderer.cpp
+++ b/prosper/frontends/shared/live_renderer.cpp
@@ -7504,12 +7504,37 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         const char* address_filter = PROSPER_ENV_VALUE("PROSPER_DUMP_RTGROUPS_ADDR");
                         const uint64_t wanted_base = address_filter && *address_filter
                             ? strtoull(address_filter, nullptr, 0) : 0;
+                        // Match the address against EVERY MRT slot, not just slot 0.
+                        //
+                        // `base` is the pass's slot-0 attachment. A G-buffer names different
+                        // surfaces per slot, so filtering by a slot-2 address matched ONE pass in a
+                        // full routed run for a target the draw census credits with 6,672 draws --
+                        // and a near-empty result reads as "that target is empty" rather than as
+                        // "the filter asked the wrong question". The dumped pixels are still slot
+                        // 0's; what this fixes is WHICH PASSES are selected, so naming any slot of a
+                        // G-buffer selects that G-buffer's passes.
+                        bool slot_match = !wanted_base || base == wanted_base;
+                        uint32_t matched_slot = 0;
+                        if (wanted_base && !slot_match)
+                            for (uint32_t slot = 1; slot < pass_bases.size(); ++slot)
+                                if (pass_bases[slot] == wanted_base) {
+                                    slot_match = true; matched_slot = slot; break;
+                                }
                         const char* dd = getenv("PROSPER_FRAME_DIR");
                         // Identify the pass by its first..last draw index so multiple passes to the same
                         // target VA in one frame do not silently overwrite each other.
                         const uint64_t pass_d0 = render_pass.empty() ? 0u : render_pass.front()->draw_index;
                         const uint64_t pass_d1 = render_pass.empty() ? 0u : render_pass.back()->draw_index;
-                        if (!wanted_base || base == wanted_base) {
+                        if (slot_match) {
+                            if (wanted_base && matched_slot) {
+                                static std::set<std::pair<uint64_t, uint32_t>> slot_seen;
+                                if (slot_seen.emplace(wanted_base, matched_slot).second)
+                                    fprintf(stderr,
+                                            "[rtt] rtgroup filter 0x%llx matched slot %u of a pass "
+                                            "whose slot-0 base is 0x%llx; dumped pixels are SLOT 0\n",
+                                            (unsigned long long)wanted_base, matched_slot,
+                                            (unsigned long long)base);
+                            }
                             if (const char* rg = PROSPER_ENV_VALUE("PROSPER_DUMP_RTGROUPS"); rg && nz >= (size_t)atol(rg)) {
                                 const std::vector<uint8_t> inspected = inspection_rgba8(
                                     rendered_pixels, gw, gh, pass_format);

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2811,7 +2811,36 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
         // resolve it as depth — the historical behaviour, and the only plane #1275 ever bridged.
         if (!is_depth_plane && !is_stencil_plane) continue;
         if (!image.layout_initialized || !image.image) continue;
-        if (is_depth_plane ? !image.depth_valid : !image.stencil_valid) continue;
+        // PROSPER_DS_BRIDGE_IGNORE_VALID=1 -- DIAGNOSTIC ONLY, never a shipped default.
+        //
+        // GTA V's deferred lighting pass samples the main depth 0x2052ac0000, and the bridge
+        // declines it here with dvalid=0 while svalid=1 on the SAME surface -- prosper holds the
+        // image, the extent matches, and only the depth aspect is marked invalid. The sample then
+        // falls back to guest memory, which is black for a surface prosper rendered into.
+        //
+        // Serving a stale depth is wrong as output. It is decisive as a DISCRIMINATOR: if the world
+        // appears, the aspect-validity state is what withholds it and the fix is upstream in what
+        // clears depth_valid; if nothing changes, the bridge is not the gate and this hypothesis
+        // dies with it. Reports whether it actually overrode anything, so a null cannot be read as a
+        // negative when the lever never fired.
+        static const bool ignore_valid = getenv("PROSPER_DS_BRIDGE_IGNORE_VALID") != nullptr;
+        const bool aspect_valid = is_depth_plane ? image.depth_valid : image.stencil_valid;
+        if (!aspect_valid && !ignore_valid) continue;
+        if (!aspect_valid && ignore_valid) {
+            static std::mutex override_mutex;
+            static std::map<uint64_t, uint64_t> overrides;
+            uint64_t n = 0;
+            {
+                std::lock_guard lock(override_mutex);
+                n = ++overrides[addr];
+            }
+            if ((n & (n - 1)) == 0)
+                std::fprintf(stderr,
+                             "[dsbridge] OVERRIDE addr=0x%llx %ux%u aspect=%s served despite "
+                             "invalid (count=%llu)\n",
+                             (unsigned long long)addr, key.w, key.h,
+                             is_depth_plane ? "depth" : "stencil", (unsigned long long)n);
+        }
         if (!best.image || image.last_depth_write > best_write) {
             best = {&image, static_cast<VkFormat>(key.fmt), key.w, key.h,
                     is_depth_plane ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_STENCIL_BIT};

--- a/prosper/tools/env/diag_gate_baseline.txt
+++ b/prosper/tools/env/diag_gate_baseline.txt
@@ -105,7 +105,7 @@
 # count must equal UNREVIEWED_BUDGET in check_diag_gates.py exactly, in both directions. So a
 # regeneration fails the gate, and paying debt down requires tightening the budget in the same
 # commit. (Note that --emit-baseline currently writes its banner to stdout as well -- #2649.)
-#   benign: 42
+#   benign: 43
 #   config-echo: 10
 #   defect: 2
 #   unreviewed: 0
@@ -164,3 +164,4 @@ TWO-GATE|tests/render_runner.h|report|PROSPER_BACKEND_TIMING_WINDOWS+PROSPER_REN
 TWO-GATE|tests/render_runner.h|report|PROSPER_DRAW_ISO+PROSPER_ISO_AT  # benign: MODE + its required argument -- PROSPER_ISO_AT is the pixel coordinate the isolation pass cannot run without (render_runner.h:7746-7748), not a producer. Every printed field (per-draw blend/mask/viewport, the per-kill results) is computed inside the same block. #2572
 TWO-GATE|tools/boot_trace/boot_trace.cpp|report|PROSPER_CRASHPEEK+PROSPER_PEEK_CLASS  # benign: MODE + its required argument. PROSPER_PEEK_CLASS is a sub-selector of the PROSPER_CRASHPEEK post-fault dump (boot_trace.cpp:350) and supplies the addresses to peek; every printed value is read from guest memory in the same loop (:427), so there is no producer whose arming differs from the printer's. Unarmed -> no output at all. #2572
 TWO-GATE|tools/boot_trace/boot_trace.cpp|report|PROSPER_CRASHPEEK+PROSPER_PEEK_CODE  # benign: MODE + its required argument. PROSPER_PEEK_CODE is a sub-selector of the PROSPER_CRASHPEEK post-fault dump (boot_trace.cpp:350) and supplies the addresses to peek; every printed value is read from guest memory in the same loop (:457), so there is no producer whose arming differs from the printer's. Unarmed -> no output at all. #2572
+TWO-GATE|frontends/shared/live_renderer.cpp|report|PROSPER_DUMP_RTGROUPS_ADDR+PROSPER_DUMP_RTGROUPS|PROSPER_DUMP_RTGROUPS_RGBA  # benign: BOTH gates are load-bearing, not a split producer/printer. The dump arms at live_renderer.cpp:7501 and the address filter is read at :7504; the report at :7533 names which MRT SLOT that filter matched. With no ADDR filter there is no match to report, and with no dump variant armed nothing is written for the match to describe. Every field it prints -- the wanted address, the matched slot, the pass's slot-0 base -- is computed at :7504-:7512 under the same condition that prints it, so it cannot report unarmed state as a measurement. #2542


### PR DESCRIPTION
## What was wrong

`PROSPER_DS_UNBRIDGED_FAR` exists to be a **decisive discriminator**: fill a depth plane prosper could
not bridge with the opposite of what it currently reads, and see whether the scene lights up. Its own
comment reasons carefully about needing two poles, because on a reversed-Z buffer `0xff` asserts the
*same* claim as the zeros it is meant to contradict.

The fill is byte-wise:

```cpp
std::fill(texture_pixels.begin(), texture_pixels.end(), far_fill);   // far_fill is a uint8_t
```

Correct for a **UNORM** depth, where `0xff` really is 1.0. **Wrong for a Float32 depth** (`fmt=1`),
where `0xffffffff` reinterpreted as IEEE-754 is **NaN** — and every comparison against NaN is false.

So on *Grand Theft Auto V*'s 3840×2160 Float32 main depth, a "both poles" run tests `{0.0f, NaN}` and
**never tests 1.0f at all**. The discriminator is silently void, and it reads as a clean negative.

I know it reads that way because I published one. The result was posted as a falsification of the
depth hypothesis on #2542 and has been **retracted** there.

## Commit 1 — three fixes, all diagnostic-only

1. **`PROSPER_DS_UNBRIDGED_FILL_F32=<float>`** fills float texels when the surface is `Float32`,
   falling back to the byte fill otherwise. `1.0f` is now reachable.
2. **The report names the path and the value actually written** — `path=f32|byte filled=1f|0xff`. It
   previously printed the byte parameter unconditionally, so a run could not show which branch
   executed. A discriminator that cannot show its lever moved is **void, not negative**; the second
   attempt at this experiment was voided by exactly that, and I only noticed because the frame and
   the log disagreed about what should have happened.
3. **Fills are counted PER ADDRESS**, on a power-of-two schedule, not only as a global total. This
   lever fires only where `is_retained_ds_plane` holds, so it can cover an arbitrary fraction of the
   misses a run observes. Without the per-address count, *"filled, and nothing changed"* is not a
   falsification — the fill may have reached 2 of the 161 misses that run recorded. That number is
   currently unknown for GTA V's main depth, which is precisely the gap this closes.

## Verified

```
[ds-far] addr=0x2052ac0000 3840x2160x1 dim=1 fmt=1 path=f32 filled=1f (unbridged retained DS plane; ...)
[ds-far] addr=0x2093cc0000  512x512x6 dim=3 fmt=5 path=byte filled=0xff (...)
```

Routed GTA V gameplay, Linux/RADV, zero device losses: the Float32 main depth takes the **f32** path
with an actual `1.0f`, while the `Unorm16` shadow cubes correctly keep the **byte** path. That is the
lever demonstrating its own action, which is the whole point of change 2.

## Behaviour

None outside the diagnostic. The byte path is unchanged whenever `PROSPER_DS_UNBRIDGED_FILL_F32` is
unset, which is every default run — and `PROSPER_DS_UNBRIDGED_FAR` is itself opt-in and documented as
never a shipped default.

## Why it is worth landing on its own

The instrument was producing *confident wrong answers* on any Float32 depth surface, and nothing about
its output revealed that. Every future investigator reaching for it on a float depth would have got
the same void negative I did.

Refs #2542.

## Commit 2 — let the bridge serve an invalid aspect

The DS bridge declines a sampled aspect whose validity flag is clear:

```cpp
if (is_depth_plane ? !image.depth_valid : !image.stencil_valid) continue;
```

On GTA V's routed gameplay the per-address dump shows the main depth in exactly that state — and
**only** the depth aspect:

```
dr=0x2052ac0000 dw=0x2052ac0000 sr=0x2054aa0000 sw=0x2054aa0000
slice=0 3840x2160 fmt=130 dvalid=0 svalid=1
```

prosper holds the image, the extent matches, stencil is fine, and depth alone is refused — so the
deferred lighting pass that samples it falls back to guest memory, black for a surface prosper
rendered into.

Whether that withholds the world was **untestable**: nothing could serve the depth anyway to find
out. `PROSPER_DS_BRIDGE_IGNORE_VALID=1` does, and reports each override per address on a
power-of-two schedule so a null cannot be read as a negative when the lever never fired — which is
how the two previous attempts at this experiment were voided.

It already produced a result: **73 overrides on `0x2052ac0000`, no world**, which retires the depth
hypothesis alongside the `0.0f` and confirmed-`1.0f` fills. The `dvalid=0`/`svalid=1` asymmetry is
still a real defect worth its own investigation — it is simply not what hides the world.

Serving a stale depth is wrong as *output*; this is never a shipped default, and the default path is
byte-identical when the variable is unset.

## Commit 3 — the rtgroup address filter matched only slot 0

`PROSPER_DUMP_RTGROUPS_ADDR` compared the requested address against the pass's **base**, i.e. the
slot-0 attachment. A G-buffer names a different surface per MRT slot, so filtering by a slot-2 or
slot-4 address selected essentially nothing: **one pass in a full routed run** for a target the draw
census credits with 6,672 draws.

A near-empty result reads as *"that target is empty"*. On GTA V it is the exact opposite of the
truth. With the filter matching any slot, the same address dumps **521 passes, 474 with content, the
richest 99.66% non-zero** — the prologue bank heist rendered in full at 3840×2160, fully textured,
with legible signage.

That single comparison hid the most important fact about this title's rendering: **the world IS drawn
correctly**, and the defect is downstream in the lighting stage. The investigation had been looking
upstream for weeks.

The filter now checks every slot in `pass_bases` and, on a non-zero slot, says so once per
`(address, slot)` — including that the dumped pixels are still slot 0's. What changes is **which
passes are selected**, not which pixels are shown, and saying so plainly is what stops the next
reader over-reading it.

Commit 4 baselines the resulting `check_diag_gates.py` finding: the report needs the ADDR filter
*and* a dump variant, which is the #2149 two-gate shape, and here both gates are load-bearing.

## Why they belong together

Each closes a different way these DS diagnostics could produce an answer that is confidently wrong:
one wrote a value it never computed, one could not show it had acted, one could not show how much it
had covered, and one made a question untestable by having no lever at all. Between them they took the
depth hypothesis from *"falsified"* (wrongly, twice) to genuinely falsified.
