### PR TITLE
docs: the bridge-override arm covered >=32,768 samples, not 73 -- an under-claim

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -46,6 +46,21 @@ unbounded it hangs at dispatch 40, bounded it truncates its own output. Fixing t
 the direct route to a lit world, and this is the first evidence tying the hang to the darkness by
 mechanism rather than by coincidence of timing.
 
+### A correction that understated its own evidence
+
+The bridge-override arm was first reported as **"73 overrides"**. That was the number of *log lines*
+across **7** addresses — and the instrument emits on a **power-of-two schedule**, so lines are not
+events. The main depth's own last line reads `count=32768`.
+
+So the arm covered **at least 32,768 samples on `0x2052ac0000`**, not 73: the depth falsification is
+roughly **450x better supported** than it was written up as. Recorded because the error ran in the
+unusual direction — an under-claim, which nobody is motivated to check, and which would have left the
+next reader thinking the strongest negative result in this document rested on a few dozen samples.
+
+Two separate mistakes produced it: counting emitted lines as if they were events, and quoting a
+sampled counter without reading its own schedule. Both are cheap to avoid — the schedule is three
+lines above the print.
+
 ### Choose instruments by census, and beware what they perturb
 
 Two rules this pass paid for repeatedly:
@@ -98,7 +113,7 @@ So the break is in one of the first two stages, and everything after them is exo
 ### Eliminated, each with a controlled experiment
 
 - **depth** — three levers, every one confirmed to have fired: `0.0f`, a confirmed `1.0f`
-  (`path=f32 filled=1f`), and serving the real retained depth despite `dvalid=0` (**73 overrides**).
+  (`path=f32 filled=1f`), and serving the real retained depth despite `dvalid=0` (**>= 32,768 overrides on the main depth alone**).
   No world at any. Note the earlier "both poles" falsification was **void** — the byte fill made the
   far pole NaN on a Float32 depth (#2680).
 - **draw rejection** — zero `[render] skip draw` lines across six routed runs (unconditional

--- a/prosper/tools/gpu_replay/README.md
+++ b/prosper/tools/gpu_replay/README.md
@@ -590,7 +590,7 @@ is the `guest_addr` printed by `--inspect-only`. This exposes the input to opera
 the selected submit executes, and the inspection conversion is not a pixel oracle for HDR values.
 
 Live runs can narrow intermediate-target dumps with
-`PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes> PROSPER_DUMP_RTGROUPS_ADDR=0x...`; only a target whose guest base
+`PROSPER_DUMP_RTGROUPS=<min-nonzero-bytes> PROSPER_DUMP_RTGROUPS_ADDR=0x...`; since #2680 the address is matched against **every MRT slot**, not only slot 0 (the report names which slot matched, and the dumped pixels remain slot 0's). Only a target whose guest base
 matches the optional address filter is written. A sampled-texture filter A/B uses
 `PROSPER_TESTTEX_FILTER=linear|point` together with `PROSPER_TESTTEX_DRAW=N` and/or
 `PROSPER_TESTTEX_BINDING=B`. It changes only the matching descriptor's minification and magnification filters.


### PR DESCRIPTION
Docs-only. Two corrections raised in review of #2680, both about text that would mislead the next reader.

## 1. The bridge-override arm was under-claimed by ~450×

The depth falsification quoted **"73 overrides"** as the strength of its strongest arm. That was the
number of **log lines** across **7** addresses — and the instrument emits on a **power-of-two
schedule**, so lines are not events. The main depth's own last line reads `count=32768`.

So the arm covered **at least 32,768 samples on `0x2052ac0000`**, not 73.

The conclusion is unchanged and was never at risk. What was wrong is that the evidence for it was
described as far weaker than it is — the strongest negative result in that document looked like it
rested on a few dozen samples.

**Recorded rather than quietly fixed, because the error ran in the direction nobody checks.** An
over-claim invites scrutiny; an under-claim reads as conservatism and passes. Two mistakes produced
it, both cheap to avoid: counting emitted lines as if they were events, and quoting a sampled counter
without reading its own schedule — which sits three lines above the print.

## 2. `gpu_replay/README.md` still described the pre-#2680 filter

It said `PROSPER_DUMP_RTGROUPS_ADDR` matches a target's guest base — i.e. slot 0 only. Since #2680 it
matches **every MRT slot** and names which one matched (the dumped pixels remain slot 0's).

That stale sentence is not incidental: **it is exactly what cost this investigation the discovery
that the G-buffer was full.** Filtering a slot-4 G-buffer address selected one pass in a whole run,
and the near-empty result read as "that target is empty" when the target in fact held a complete,
fully-textured 4K image of the world.

Gates run locally: `check_numbered_table.py` on `GTA5_STATUS.md` (56 tables / 234 rows) and over every
tracked `.md`, both clean; `diff --check` clean; diff is `.md`-only.

Refs #2542, #2680.
