### PR TITLE
loader: a PT_LOAD that cannot be mapped in full refuses the module instead of mapping it all-zero and reporting success (#2631)

### DIFF
--- a/prosper/docs/ARCHITECTURE.md
+++ b/prosper/docs/ARCHITECTURE.md
@@ -43,6 +43,39 @@
 - Load dependent `*.prx` modules, build the module graph.
 - Resolve imports: each undefined NID symbol → address of our HLE stub (below).
 - Set up TLS blocks, `sce_process_param`, stack, and jump to entry.
+- **A `PT_LOAD` maps in full, or the module is refused (#2631).** A segment whose declared `p_filesz`
+  runs past the end of the file used to be skipped *silently* while `build_image` still returned
+  success, so the module mapped a zero-filled hole exactly where its bytes belonged and the loader
+  said nothing; the first symptom was the guest executing a page of zeros inside a module that looked
+  correctly loaded. (The sibling case — a segment that does not fit the image its own extent just
+  sized — was worse than skipped: an overflowing `p_memsz` was left out of the extent computation and
+  then **copied anyway**, pushing an `img.prot` record spanning the whole address space. Same
+  invariant, same refusal.) Refusing, rather than mapping the surviving prefix and zero-filling the
+  rest, is the format's own reading: the gABI defines `p_filesz` as the bytes of the segment *present
+  in the file image*, so a short file does not contain the segment at all.
+- **Ruled out — "some real dump depends on the lenient reading":** it does not. Measured across the 44
+  local dumps (589 modules, 2,945 `PT_LOAD` segments — **exactly five per module**, with no spread):
+  **0** whose file bytes run past EOF (none even *ends* at EOF), **0** that do not fit their own mapped
+  image, **0** with `filesz > memsz`, **0** excluded from the extent by an overflowing `memsz`, and
+  **2,945 of 2,945** SELF data segments whose own `file_size` equals the phdr's `p_filesz` exactly.
+  Independently re-derived from the format by a second parser sharing no code with prosper (review of
+  #2689): every figure identical.
+- **Two traps around that measurement, both of which cost time to find.**
+  1. The SELF *header's* `file_size` (container offset `0x10`) is **not** a truncation oracle, and it
+     fails in **both** directions. It differs from the physical file in 517 of 589 modules: **452
+     smaller** (signature/metadata follow it), **65 larger** — over-declaring by 4 bytes (25 modules),
+     8 (32), 12 (6) and 64 (2) — and only **72 equal**. Hand-verified outside the scanner:
+     `PPSA01826-app0/prx/akaudioinput.prx` is 10,172 bytes physically and declares `0x27c0` = 10,176.
+     An oracle built on this field would flag 65 working modules as truncated and be blind on 72 more.
+     *The 517 was first recorded here as "smaller in 517", which is a `!=` count reported as `<` — the
+     kind of error this section exists to stop, so it is left visible rather than quietly corrected.*
+  2. **"No dump does this" is true of `PT_LOAD`, not of segments generally.** The corpus does contain
+     trailing-trimmed content: besides the 65 over-declaring headers, two copies of
+     `sce_sys/about/right.sprx` (12,448 bytes, in `PPSA15552` and `PPSA02101`) carry a SELF data
+     segment declaring 64 bytes at a file offset *equal to* EOF — zero bytes present. It keys program
+     header 10, whose `p_type` is `0x6fffff00` (`SCE_COMMENT`, per `tools/self_dump`), so it is
+     neither a `PT_LOAD` nor in `m.loads` and nothing reads it. Extending this refusal past `PT_LOAD`
+     — the natural follow-on, and what #2686 gestures at — would reject those two modules on day one.
 
 ### 2. NID resolution & HLE dispatch (`src/hle`)
 - A registry maps `(libraryName, NID)` → host function pointer.

--- a/prosper/src/self/module.cpp
+++ b/prosper/src/self/module.cpp
@@ -259,7 +259,13 @@ bool build_image(const Module& m, uint64_t base, LoadedImage& out, std::string* 
     auto align_up = [](uint64_t v, uint64_t a){ return (v + a - 1) & ~(a-1); };
     img.min_vaddr = align_dn(lo, 0x4000);
     img.max_vaddr = align_up(hi, 0x4000);
-    if (img.max_vaddr < img.min_vaddr) img.max_vaddr = img.min_vaddr;  // degenerate (align_up wrap) -> empty
+    if (img.max_vaddr < img.min_vaddr) {
+        // align_up wrapped, so the declared PT_LOAD extent runs off the end of the 64-bit address
+        // space. Clamping it to an empty image (the pre-#2631 behaviour) reported SUCCESS for a
+        // module of which nothing at all was mapped - see the refusal rationale below.
+        if (err) *err = "PT_LOAD image extent overflows the 64-bit address space";
+        return false;
+    }
     const uint64_t image_size = img.max_vaddr - img.min_vaddr;
     if (image_size > kMaxLoadedImageBytes) {
         if (err) *err = "PT_LOAD image extent exceeds prosper's 1 GiB loader limit";
@@ -278,13 +284,76 @@ bool build_image(const Module& m, uint64_t base, LoadedImage& out, std::string* 
         if (err) *err = "PT_LOAD image extent exceeds the host vector limit";
         return false;
     }
-    for (auto& s : m.segments) {
-        if (s.type != PT_LOAD || s.vaddr < img.min_vaddr) continue;   // outside the mapped window
-        uint64_t dst = s.vaddr - img.min_vaddr;
-        // Overflow-safe on BOTH the dest (img.mem) and source (m.file) — a malformed near-2^64
-        // filesz/file_off wraps the naive `a + b <= size` check and drives a huge OOB memcpy.
-        if (self_read_ok(dst, s.filesz, img.mem.size()) && self_read_ok(s.file_off, s.filesz, m.file.size()))
+    // Every PT_LOAD maps IN FULL or the load FAILS (#2631). A segment the copy below could not
+    // perform used to be skipped silently while build_image still returned `true`, so the image kept
+    // a zero-filled hole exactly where the file's own bytes belonged and the caller was told the load
+    // had succeeded. The first symptom was the guest executing a page of zeros at an address the
+    // fault handler attributes to a module that looks correctly loaded, arbitrarily far from the
+    // cause. Measured on a 0x1000-byte synthetic PRX physically cut to 0x400: Module::load accepted
+    // it, two symbols parsed, and the resulting 16 KiB image held ZERO nonzero bytes against a
+    // control of 79.
+    //
+    // Why refuse rather than map the surviving prefix and zero-fill the rest:
+    //   * the format says so. The gABI defines p_filesz as the number of bytes of the segment present
+    //     in the FILE image, so a file shorter than p_offset + p_filesz does not contain the segment;
+    //     there is no partial-segment reading to fall back on. A PS5 SELF states the same length a
+    //     second time in its own segment table, and the two agree in every module we hold.
+    //   * it costs nothing measurable. Across the 44 local dumps - 589 modules, 2,945 PT_LOAD
+    //     segments - every segment satisfies both conditions with room to spare: 0 whose file bytes
+    //     run past EOF (none even END at EOF), 0 that do not fit their own mapped image, 0 with
+    //     filesz > memsz, 0 excluded from the extent by an overflowing memsz, and 2,945 of 2,945 SELF
+    //     data segments whose own file_size equals the phdr's p_filesz exactly. No real module needs
+    //     the lenient reading, so refusing cannot reject content that exists.
+    //   * the refusal reaches the guest as a code it can act on: runtime_module_load turns a false
+    //     return into ENOEXEC out of sceKernelLoadStartModule, and link_program fails the boot naming
+    //     the path. A "successfully loaded" module of zeros offers neither.
+    // CONFIDENCE: HIGH.
+    char msg[256];
+    for (size_t i = 0; i < m.segments.size(); i++) {
+        const Segment& s = m.segments[i];
+        if (s.type != PT_LOAD) continue;
+        // `i` is the program header index: m.segments is filled in phdr order, one entry per header.
+        // Unsigned, so it wraps when vaddr is below the window - harmless, because the condition
+        // below rejects that case before the value is used for anything.
+        const uint64_t dst = s.vaddr - img.min_vaddr;
+        // (1) The segment must lie entirely inside the image the extent computation above sized. For
+        // a well-formed module this is free - the image IS max(vaddr+memsz) aligned up. It fails only
+        // for a segment the extent loop had to exclude (an overflowing vaddr+memsz) or one declaring
+        // filesz > memsz beyond the alignment slack; both are malformed. Note the overflowing-memsz
+        // case was NOT merely skipped before: the extent loop left it out of the sizing and the copy
+        // loop then took it anyway, pushing an img.prot record with size = 0xffffffffffffffff - a
+        // protection span covering the whole address space. Its one and only consumer
+        // (executable_end_for, host/exec_image_win.cpp:844 - the sole reader of LoadedImage::prot in
+        // the tree) clamps an oversized span against img.max_vaddr, so the practical damage was
+        // bounded, but the record was wrong and is a refusal now. Raised in review of #2689.
+        if (s.vaddr < img.min_vaddr || !self_read_ok(dst, s.memsz, image_size) ||
+            !self_read_ok(dst, s.filesz, image_size)) {
+            snprintf(msg, sizeof msg,
+                     "PT_LOAD (program header %zu) vaddr 0x%llx filesz 0x%llx memsz 0x%llx does not "
+                     "fit the mapped image [0x%llx, 0x%llx)",
+                     i, (unsigned long long)s.vaddr, (unsigned long long)s.filesz,
+                     (unsigned long long)s.memsz, (unsigned long long)img.min_vaddr,
+                     (unsigned long long)img.max_vaddr);
+            if (err) *err = msg;
+            return false;
+        }
+        // (2) The file must actually hold the bytes the segment declares. self_read_ok is
+        // overflow-safe, which the naive `file_off + filesz <= size` is not: a malformed near-2^64
+        // filesz wraps it, passes, and drives a huge OOB memcpy. A filesz of 0 is a pure-.bss
+        // PT_LOAD - it claims no file bytes, so a short file takes nothing from it and it is not a
+        // truncation.
+        if (s.filesz) {
+            if (!self_read_ok(s.file_off, s.filesz, m.file.size())) {
+                snprintf(msg, sizeof msg,
+                         "PT_LOAD (program header %zu) declares 0x%llx bytes at file offset 0x%llx "
+                         "but the file holds only 0x%llx bytes",
+                         i, (unsigned long long)s.filesz, (unsigned long long)s.file_off,
+                         (unsigned long long)m.file.size());
+                if (err) *err = msg;
+                return false;
+            }
             memcpy(img.mem.data() + dst, m.file.data() + s.file_off, s.filesz);
+        }
         img.prot.push_back({ s.vaddr, s.memsz, (s.flags & 4) != 0, (s.flags & 2) != 0, (s.flags & 1) != 0 });
     }
     img.entry = base + m.e_entry;

--- a/prosper/tests/synth_prx.h
+++ b/prosper/tests/synth_prx.h
@@ -93,13 +93,14 @@ struct SynthModuleSpec {
     bool     omit_dynamic_phdr = false;              // no PT_DYNAMIC -> the module must be rejected
     bool     zero_value_exports = false;             // st_value == 0: defined, but NOT an export
     uint64_t relative_reloc_offset = kSynthInitArray;// where DT_INIT_ARRAY[0] is patched
-    // 0 = whole file; else write only N bytes. Cutting inside the program header table is refused
-    // (test_loader_synth_reject). Cutting LATER is not: #2631 — a PT_LOAD whose declared p_filesz
-    // exceeds the file is skipped ENTIRELY, so the segment maps all-zero, the bytes that do exist
-    // are discarded, and build_image still returns true with no diagnostic. Measured with this knob:
-    // truncate_to = 0x400 parses 2 symbols and yields a 16 KiB image with 0 nonzero bytes. That path
-    // is deliberately left unpinned by any arm — an assertion today would bless silent corruption as
-    // correct, and the fix changes loader acceptance for every title.
+    // 0 = whole file; else write only N bytes. Two different refusals, both pinned in
+    // test_loader_synth_reject: cutting INSIDE the program header table removes PT_DYNAMIC, so
+    // `Module::load` refuses the module; cutting LATER removes nothing the parser reads, so the
+    // module parses in full and `build_image` is the only stage that can see it (#2631, fixed).
+    // Before that fix the later cut was silent: a PT_LOAD whose declared p_filesz exceeded the file
+    // was skipped ENTIRELY, the segment mapped all-zero, the bytes that did exist were discarded, and
+    // build_image still returned true. Measured with this knob at the time: truncate_to = 0x400
+    // parsed 2 symbols and yielded a 16 KiB image with 0 nonzero bytes, against a control of 79.
     uint64_t truncate_to = 0;
 };
 

--- a/prosper/tests/test_loader_synth_reject.cpp
+++ b/prosper/tests/test_loader_synth_reject.cpp
@@ -10,6 +10,10 @@
 // The arms are grouped by what the loader must do, because "reject" is not one behaviour:
 //   * REFUSE the module — `Module::load` fails and `link_program` returns false with the path in the
 //     message (a wrong machine, a missing PT_DYNAMIC, a file truncated before its program headers);
+//   * REFUSE the module at IMAGE-BUILD time — everything parses, and only the PT_LOAD copy can see
+//     that the file is shorter than the segment claims (#2631). These are the arms whose control is
+//     doing the most work: the corrupted module is byte-identical to the control up to the cut, so
+//     an arm that "passes" by refusing broadly would take the control down with it;
 //   * REFUSE the relocation but keep the module — a relocation whose target is outside the mapped
 //     image, or straddles its end, must not be applied and must not write past the buffer. The
 //     straddle pair is four bytes apart and lands on opposite sides of module.cpp's `p + 8 > end`
@@ -115,6 +119,69 @@ int main() {
         const std::string p = emit("reject_truncated_all.prx", s);
         const std::string e = link_error(p);
         CHECK(!e.empty(), "a four-byte file is refused");
+    }
+
+    // ---- truncated modules: the FILE is shorter than a PT_LOAD says it is (#2631) ---------------
+    // These are the quiet ones. A cut inside the program header table (above) removes PT_DYNAMIC and
+    // is refused by `Module::load`; a cut AFTER the tables removes nothing the parser reads, so every
+    // earlier stage reports success and only the segment copy in `build_image` can see it. Before
+    // #2631 that copy was skipped in full - the segment mapped all-zero, the bytes that DO exist were
+    // discarded, and build_image returned true. Each arm differs from `good_spec` in `truncate_to`
+    // alone, and the "control" line above (an unmodified fixture links) is that field at its default.
+    {
+        // The measurement recorded in #2631: 0x1000 declared, 0x400 present.
+        SynthModuleSpec s = good_spec; s.truncate_to = 0x400;
+        const std::string path = emit("reject_truncated_load.prx", s);
+
+        std::string err;
+        auto mod = Module::load(path, &err);
+        CHECK(mod.has_value(),
+              "truncated PT_LOAD: the module still PARSES - no earlier stage can see the cut");
+        if (mod) {
+            CHECK(mod->symbols.size() == 2,
+                  "truncated PT_LOAD: its symbol table still reads back (null symbol + the export)");
+            LoadedImage img;
+            CHECK(!build_image(*mod, kBase1, img, &err),
+                  "truncated PT_LOAD: build_image refuses instead of mapping the segment all-zero");
+            CHECK(contains(err, "declares 0x1000 bytes"),
+                  "truncated PT_LOAD: the refusal quotes the length the segment declared");
+            CHECK(contains(err, "the file holds only 0x400 bytes"),
+                  "truncated PT_LOAD: the refusal quotes what the file actually holds");
+        }
+        const std::string e = link_error(path);
+        CHECK(!e.empty() && contains(e, path) && contains(e, "the file holds only"),
+              "truncated PT_LOAD: link_program fails and the message names the path");
+    }
+    {
+        // The razor: one 0x100 block short of the declared 0x1000, so EVERY table the loader reads -
+        // dynamic, symtab, strtab, RELA, JMPREL, DT_INIT_ARRAY, DT_INIT - survives intact and the
+        // module is fully parseable. Deliberately strict: the missing tail happens to be the
+        // fixture's zero padding, and prosper still refuses it, because a file that does not contain
+        // a segment cannot be shown to contain zeros there. Measured to cost nothing on real content
+        // - across the 44 local dumps no PT_LOAD even ENDS at EOF, let alone runs past it.
+        SynthModuleSpec s = good_spec; s.truncate_to = prosper_test::kSynthFileSize - 0x100;
+        const std::string path = emit("reject_truncated_tail.prx", s);
+
+        std::string err;
+        auto mod = Module::load(path, &err);
+        CHECK(mod.has_value(), "one-block-short PT_LOAD: the module still parses");
+        if (mod) {
+            CHECK(mod->symbols.size() == 2 && mod->symbols[1].nid == kExport,
+                  "one-block-short PT_LOAD: its export still resolves by NID - nothing else notices");
+            LoadedImage img;
+            CHECK(!build_image(*mod, kBase1, img, &err),
+                  "one-block-short PT_LOAD: build_image refuses");
+            CHECK(contains(err, "the file holds only 0xf00 bytes"),
+                  "one-block-short PT_LOAD: the refusal quotes the short length");
+        }
+    }
+    {
+        // ... and the same knob set to the file's own size truncates nothing, so the arms above
+        // cannot be passing by refusing every module that carries a `truncate_to` at all.
+        SynthModuleSpec s = good_spec; s.truncate_to = prosper_test::kSynthFileSize;
+        const std::string path = emit("truncate_noop.prx", s);
+        CHECK(link_error(path).empty(),
+              "truncate control: a cut at exactly the declared size removes nothing and links");
     }
 
     // ---- relocation-level rejections ------------------------------------------------------------
@@ -228,6 +295,50 @@ int main() {
         const std::string e = link_error(hand_bad);
         CHECK(!e.empty() && contains(e, "no PT_DYNAMIC"),
               "hand-built: retyping the PT_DYNAMIC header to PT_NULL is refused");
+
+        // (c) The truncation arm, in a geometry the generator cannot express (#2631). The hand-laid
+        // module has TWO PT_LOADs - text at file 0x0000 and data at file 0x1000 - so cutting the file
+        // at 0x1800 leaves program header 0 complete and takes 0x800 bytes off program header 1. Every
+        // dynamic table lives below 0x1800, so the module parses in full and both exports and the
+        // import still resolve: the ONLY stage that can see the damage is the segment copy. A
+        // single-PT_LOAD fixture cannot pose this question at all - there, a short file always cuts
+        // the one segment there is - which is the whole reason this file exists.
+        std::vector<uint8_t> cut = prosper_test::handmade_prx_bytes(kHandA, kHandB, kHandI);
+        cut.resize(0x1800);
+        const std::string hand_cut = dir + "/handmade_truncated.prx";
+        CHECK(prosper_test::write_module_bytes(hand_cut, cut, &err),
+              "hand-built: the truncated fixture is written");
+
+        auto cut_mod = Module::load(hand_cut, &err);
+        CHECK(cut_mod.has_value(), "hand-built truncated: the module still parses");
+        if (cut_mod) {
+            CHECK(cut_mod->symbols.size() == 4, "hand-built truncated: all four symbols still read back");
+            CHECK(cut_mod->symbols[1].nid == kHandA && cut_mod->symbols[2].nid == kHandB,
+                  "hand-built truncated: both exports still resolve by NID");
+            CHECK(cut_mod->imports.size() == 1, "hand-built truncated: the import still resolves");
+            LoadedImage img;
+            CHECK(!build_image(*cut_mod, kBase1, img, &err),
+                  "hand-built truncated: build_image refuses the short data segment");
+            CHECK(contains(err, "program header 1"),
+                  "hand-built truncated: the refusal names the SHORT segment, not the intact one");
+            CHECK(contains(err, "declares 0x1000 bytes at file offset 0x1000") &&
+                      contains(err, "the file holds only 0x1800 bytes"),
+                  "hand-built truncated: the refusal quotes the declared span and the file length");
+        }
+        // The control for that arm: the same module uncut maps its data segment's bytes, so the
+        // refusal above is about the truncation and not about the second PT_LOAD existing.
+        {
+            auto ok_mod = Module::load(hand_good, &err);
+            CHECK(ok_mod.has_value(), "hand-built control: the uncut module parses");
+            if (ok_mod) {
+                LoadedImage img;
+                CHECK(build_image(*ok_mod, kBase1, img, &err),
+                      "hand-built control: the uncut module's image builds");
+                const uint8_t* strtab = img.at(kBase1 + prosper_test::kHandStrtabVa + 1);
+                CHECK(strtab != nullptr && memcmp(strtab, kHandA.c_str(), kHandA.size()) == 0,
+                      "hand-built control: the DATA segment's own bytes reach the image");
+            }
+        }
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);

--- a/prosper/tests/test_self_bounds.cpp
+++ b/prosper/tests/test_self_bounds.cpp
@@ -13,11 +13,18 @@
 //      reads past the buffer. Now requires an in-range NUL. Guarded by test_str_at().
 //   D) build_image() allowed a huge non-wrapping PT_LOAD span to reach vector::assign; the uncaught
 //      length_error/bad_alloc terminated linking. Image construction is now fallible and reports it.
+//   E) build_image() SKIPPED any PT_LOAD it could not copy in full - a filesz past EOF, a segment
+//      outside the image it had just sized - and returned true anyway, so the module mapped a
+//      zero-filled hole where its own bytes belonged and the caller was told it had loaded (#2631).
+//      Every such segment is now a refusal with a message naming the program header and the
+//      shortfall. The arms below are the malformed-input half; tests/test_loader_synth_reject.cpp
+//      carries the truncated-module half, where the module otherwise parses perfectly.
 // No game dump needed: pure in-memory construction.
 #include "../src/self/module.hpp"
 #include <cstdio>
 #include <cstring>
 #include <cstdint>
+#include <string>
 #include <vector>
 
 using namespace prosper;
@@ -106,28 +113,71 @@ static void test_build_image_bounds() {
         const uint8_t* p = img.at(0x100000000ull + 0x4000);
         CHECK(p && p[0] == 1 && p[7] == 8, "valid PT_LOAD maps its filesz bytes");
     }
+    {   // E) the razor for #2631: the SAME segment as the control above, differing in p_filesz alone
+        // (9 rather than 8), against the same 8-byte file. One byte of the segment does not exist.
+        // Pre-fix, the copy was skipped in full and build_image returned true, so the eight bytes
+        // that DO exist were replaced by zeros and the caller was told the module had loaded.
+        Module m;
+        m.file = {1,2,3,4,5,6,7,8};
+        Segment s; s.type = PT_LOAD; s.vaddr = 0x4000; s.filesz = 9; s.memsz = 0x4000; s.file_off = 0; s.flags = 4;
+        m.segments.push_back(s);
+        LoadedImage img;
+        std::string err;
+        CHECK(!build_image(m, 0x100000000ull, img, &err),
+              "a PT_LOAD one byte longer than its file is refused");
+        CHECK(err.find("declares 0x9 bytes at file offset 0x0") != std::string::npos,
+              "the refusal quotes the declared length and offset");
+        CHECK(err.find("the file holds only 0x8 bytes") != std::string::npos,
+              "the refusal quotes what the file actually holds");
+    }
     {   // malformed huge filesz that WRAPS BOTH naive checks (dest and source) so they pass -> a huge
-        // OOB memcpy (hard segfault). The overflow-safe check must skip it. vaddr=0x4001 -> dst=1;
+        // OOB memcpy (hard segfault). The overflow-safe check must catch it. vaddr=0x4001 -> dst=1;
         // with filesz=UINT64_MAX and file_off=1, both `1 + (2^64-1)` wrap to 0, which the OLD
         // `a + b <= size` accepts; the memcpy size itself stays 2^64-1.
+        //
+        // Reaching this line at all IS the memory-safety assertion - the pre-fix code segfaults here
+        // and never returns, whatever the return value. What changed with #2631 is only the verdict:
+        // the segment used to be dropped and the load called successful, which mapped nothing of a
+        // module the caller then linked. A segment this malformed is unloadable, so the honest answer
+        // is a refusal that says which header and why.
         Module m;
         m.file.assign(64, 0xAB);
         Segment bad; bad.type = PT_LOAD; bad.vaddr = 0x4001; bad.filesz = UINT64_MAX; bad.memsz = 0x4000; bad.file_off = 1; bad.flags = 4;
         m.segments.push_back(bad);
         LoadedImage img;
-        CHECK(build_image(m, 0x100000000ull, img), "wrapping filesz image still builds safely");
-        CHECK(img.mem.size() > 0, "wrapping huge filesz skipped, no OOB memcpy (image still sized)");
+        std::string err;
+        CHECK(!build_image(m, 0x100000000ull, img, &err),
+              "wrapping filesz is refused, not silently skipped (no OOB memcpy either way)");
+        CHECK(err.find("does not fit the mapped image") != std::string::npos,
+              "wrapping filesz names the image it could not fit");
+        CHECK(err.find("program header 0") != std::string::npos,
+              "wrapping filesz names the offending program header");
+        // Restores what the pre-#2631 `img.mem.size() > 0` carried: the extent computation still
+        // sized the window correctly (vaddr 0x4001 + memsz 0x4000, aligned out to [0x4000, 0xc000))
+        // in the presence of the malformed filesz. The refusal message quotes those bounds, so
+        // asserting them here keeps the fact pinned without a second build_image call.
+        CHECK(err.find("[0x4000, 0xc000)") != std::string::npos,
+              "wrapping filesz still sized the image correctly before refusing");
     }
     {   // malformed huge memsz: vaddr+memsz does not overflow (passes the extent-skip guard) but
-        // align_up(hi) wraps to 0, giving max_vaddr(0) < min_vaddr(0x8000). Without the clamp,
-        // mem.assign(0 - 0x8000) requests ~2^64 bytes -> bad_alloc/terminate. The clamp keeps it empty.
+        // align_up(hi) wraps to 0, giving max_vaddr(0) < min_vaddr(0x8000). Unguarded,
+        // mem.assign(0 - 0x8000) requests ~2^64 bytes -> bad_alloc/terminate; the wrap is detected
+        // before the allocation, which is what keeps this arm from being a crash.
+        //
+        // It used to be detected and then CLAMPED to an empty image with a `true` return - a module
+        // declaring a 16-exabyte span "loaded" with nothing mapped (#2631). The wrap is now the
+        // refusal it always was, and it is reported before any allocation is attempted.
         Module m;
         m.file = {1,2,3,4};
         Segment s; s.type = PT_LOAD; s.vaddr = 0x8000; s.filesz = 4; s.memsz = UINT64_MAX - 0x8000; s.file_off = 0; s.flags = 4;
         m.segments.push_back(s);
         LoadedImage img;
-        CHECK(build_image(m, 0x100000000ull, img), "align-up-wrapped extent returns an empty image");
-        CHECK(img.mem.size() == 0, "align_up-wrapped extent clamped to empty (no giant allocation)");
+        std::string err;
+        CHECK(!build_image(m, 0x100000000ull, img, &err),
+              "align-up-wrapped extent is refused (no giant allocation, no empty-image success)");
+        CHECK(err.find("overflows the 64-bit address space") != std::string::npos,
+              "align-up-wrapped extent reports the address-space overflow by name");
+        CHECK(img.mem.size() == 0, "a refused image leaves the caller's LoadedImage untouched");
     }
     {   // A huge but non-wrapping extent passes the arithmetic guards above and is still far below a
         // 64-bit vector::max_size(). Before #1299 it reached vector::assign; Linux overcommit could


### PR DESCRIPTION
Fixes #2631. Refs #2685, #2686, #2687.

## The failure scenario

`build_image` skipped any `PT_LOAD` it could not copy and returned `true` anyway. The three ways a
copy could be skipped were all silent:

* the declared `p_filesz` runs past the end of the file (#2631's case),
* the segment does not fit the image the extent computation had just sized,
* the whole extent's `align_up` wrapped, so the image was clamped to zero bytes.

In each case `build_image` returned `true` with declared content unmapped, the loader reported
success, and the first symptom arrived arbitrarily far away: the guest executing a page of zeros at an
address the fault handler attributes to a module that looks correctly loaded. An optional plugin
flagged `skip_on_export_collision` could never collide either, because it exported nothing.

One sub-case is **worse than skipped**, and an earlier draft of this description got it wrong (caught
in review): a `PT_LOAD` with an overflowing `p_memsz` was left out of the *extent* computation and
then **copied anyway** by the loop below it, pushing an `img.prot` record with
`size = 0xffffffffffffffff` — a protection span covering the whole address space. Its one and only
consumer, `executable_end_for` at `src/host/exec_image_win.cpp:844` (the sole reader of
`LoadedImage::prot` in the tree), clamps an oversized span against `img.max_vaddr`, so the practical
damage was bounded; the record was still wrong, and it is a refusal now. This matters for the fold:
the `memsz` half of check (1) is the part a reader is most likely to wave through as redundant.

Measured on a `tests/synth_prx.h` module (0x1000 bytes, one `PT_LOAD` declaring `p_filesz = 0x1000`)
physically cut to 0x400: `Module::load` accepted it, two symbols parsed, and the 16 KiB image held
**zero** nonzero bytes against a control of 79.

## The behavioural contract now

Every `PT_LOAD` maps **in full**, or `build_image` fails with a message naming the program header and
the shortfall:

```
PT_LOAD (program header 1) declares 0x1000 bytes at file offset 0x1000 but the file holds only 0x1800 bytes
PT_LOAD (program header 0) vaddr 0x4001 filesz 0xffffffffffffffff memsz 0x4000 does not fit the mapped image [0x4000, 0xc000)
PT_LOAD image extent overflows the 64-bit address space
```

`link_program` turns that into a boot failure naming the path; `runtime_module_load` turns it into
**ENOEXEC** out of `sceKernelLoadStartModule`.

## Which policy, and the evidence for it

The issue left the policy open between refusing and mapping the surviving prefix with a warning. This
takes **refuse**, on three grounds.

**1. The format's own reading (published contract).** The gABI defines `p_filesz` as the number of
bytes of the segment present in the *file image*, so a file shorter than `p_offset + p_filesz` does
not contain the segment; there is no partial-segment reading defined to fall back on. A PS5 SELF
states the same length a **second** time, in its own segment table, and prosper reads the segment
through that table — so a short file contradicts two independent statements of the same length.

*Honest counterweight, offered as analogy rather than evidence:* an `mmap`-based loader (Linux
`binfmt_elf`) does neither of the two options — it maps the pages the file has, zero-fills only to the
end of the last page that exists, and faults (SIGBUS) beyond it. It never fabricates whole absent
pages. prosper reads the file into a buffer rather than mapping it, so reproducing that would mean
carrying the absent tail through `img.prot` and marking those pages non-present in the host mapping
stage. That is *possible* — an earlier draft of this paragraph claimed an architectural constraint and
was wrong, corrected in review — so the argument against it is cost/benefit, not impossibility:
machinery, a new `LoadedImage` concept and a host-mapping path, for **0 of 2,945** segments, to make a
malformed module fault later instead of refusing now. The cost/benefit argument is the stronger one.

**2. It is measured to cost nothing (primary evidence, prosper's own loader).** Across the 44 dumps
present locally — 589 modules, 2,945 `PT_LOAD` segments:

| measurement | result |
| --- | --- |
| `PT_LOAD`s whose file bytes run past EOF | **0** (none even *ends* at EOF) |
| `PT_LOAD`s that do not fit their own mapped image | **0** |
| `PT_LOAD`s with `filesz > memsz` | **0** |
| `PT_LOAD`s excluded from the extent by an overflowing `memsz` | **0** |
| `PT_LOAD`s resolved through a SELF data segment | **2,945 of 2,945** (0 use the `elf_base + p_offset` fallback) |
| SELF data segments whose own `file_size` equals the phdr's `p_filesz` | **2,945 of 2,945**, exactly |
| modules whose image still builds on this branch (`imgdump <module> /dev/null`) | **589 of 589**, 0 refusals |

The last row is the acceptance-surface check run through prosper's own patched loader rather than a
model of it. A structural fact that falls out and is worth having in the record: **every one of the
589 modules carries exactly five `PT_LOAD`s** — 589 x 5 = 2,945, with no spread at all. Every figure
in this table was **re-derived independently in review**, by a second format-driven parser sharing no
code with prosper; all identical. **Ruled out: "some real dump depends on the lenient reading."** It does not — recorded in
`docs/ARCHITECTURE.md` under the loader component so the next agent does not re-derive it.

**Two traps recorded alongside it**, both in `ARCHITECTURE.md`:

1. The SELF **header's** `file_size` (container offset `0x10`) is *not* a truncation oracle, and it
   fails in **both** directions. Over the same 589 modules it is **smaller in 452**, **larger in 65**
   (over-declaring by 4 bytes in 25 modules, 8 in 32, 12 in 6 and 64 in 2) and **equal in only 72**.
   Hand-verified outside the scanner: `PPSA01826-app0/prx/akaudioinput.prx` is 10,172 bytes physically
   and its header declares `0x27c0` = 10,176. An oracle built on this field would flag 65 working
   modules as truncated and be blind on 72 more.
   *This PR first recorded that as "smaller in 517 of 589" — a `!=` count reported as `<`
   (452 + 65 = 517). Caught in review. Left visible in the doc rather than quietly corrected, because
   the wrong version asserted `file_size <= physical`, which is precisely the inference that makes the
   field look usable as a lower bound: a trap planted inside a paragraph warning about a trap.*
2. **"No dump does this" is true of `PT_LOAD`, not of segments generally.** Besides the 65
   over-declaring headers, two copies of `sce_sys/about/right.sprx` (12,448 bytes, in `PPSA15552` and
   `PPSA02101`) carry a SELF data segment declaring 64 bytes at a file offset *equal to* EOF — zero
   bytes present. It keys program header 10, whose `p_type` is `0x6fffff00` (`SCE_COMMENT`, per
   `tools/self_dump`; the review called it `PT_SCE_DYNLIBDATA`, which is `0x61000000`), so it is
   neither a `PT_LOAD` nor in `m.loads` and nothing reads it. Extending this refusal past `PT_LOAD` —
   what #2686 gestures at — would reject those two modules on day one.

**3. The refusal is actionable.** A `false` return reaches the guest as ENOEXEC from
`sceKernelLoadStartModule`, which is the documented answer for a file that is not a valid executable
image. A "successfully loaded" module of zeros gives the guest nothing to act on.

`CONFIDENCE: HIGH` for the refusal policy (published gABI definition + 2,945/2,945 corpus agreement +
589/589 post-change re-verification). No check was weakened anywhere to make a title load; the change
only makes acceptance stricter.

## Regression arms — every one fails without the fix

`tests/test_loader_synth_reject.cpp` (+23 assertions), built on the #2645 fixtures as the issue asks:

* **the generator's module cut to 0x400** — the issue's own measurement. Asserts `Module::load` still
  *succeeds* and its symbol table still reads back, so the arm pins that no earlier stage can see the
  cut and only `build_image` can; then that `build_image` refuses, quoting both the declared length
  and what the file holds; then that `link_program` fails with the path in the message.
* **cut one 0x100 block short of the declared size** — the razor. Every table (dynamic, symtab,
  strtab, RELA, JMPREL, `DT_INIT_ARRAY`, `DT_INIT`) survives and the export still resolves by NID, so
  the module is fully parseable and still refused. Deliberately strict: the missing tail happens to be
  the fixture's zero padding, and prosper still refuses, because a file that does not contain a
  segment cannot be shown to contain zeros there.
* **`truncate_to` set to exactly the file size** — truncates nothing and links. Without this the arms
  above could pass by refusing any module carrying the knob at all.
* **the hand-laid two-`PT_LOAD` fixture cut at 0x1800** — a geometry `synth_prx.h` *structurally
  cannot express*, which is the reason `handmade_prx.h` exists. Program header 0 (text, file
  0x0-0x1000) stays complete while program header 1 (data, file 0x1000-0x2000) loses 0x800 bytes; all
  four symbols, both exports and the import still resolve; and the refusal must name **header 1**, not
  header 0. Its control asserts the uncut module's *data* segment bytes reach the image, so the arm
  cannot be passing because the second `PT_LOAD` merely exists.

`tests/test_self_bounds.cpp` (43 assertions, up from 34 on master): a new arm differing from the
file's existing valid-`PT_LOAD` control in `p_filesz` alone (9 against 8, over an 8-byte file), plus
the bounds assertion that restores what the removed `img.mem.size() > 0` carried — that the extent
computation still sized the window to `[0x4000, 0xc000)` correctly *in the presence of* the malformed
segment (raised in review; the refusal message already quotes the bounds, so it costs nothing).

**Two existing assertions in `test_self_bounds.cpp` change verdict**, and that is a deliberate,
reviewable acceptance-surface change:

| arm | before | now |
| --- | --- | --- |
| `filesz = UINT64_MAX` wrapping both naive checks | "wrapping filesz image still builds safely" (`true`) | refused, naming the header and the image it could not fit |
| `memsz` whose `align_up` wraps the address space | "returns an empty image" (`true`) | refused, naming the address-space overflow |

Both were written to pin *memory safety* — no OOB `memcpy`, no giant allocation — and both still
assert exactly that: reaching the assertion at all is the safety property (the pre-guard code
segfaults and never returns), and the allocation is still rejected before `vector::assign`. What
changed is only that an unmappable segment is now *reported* rather than dropped.

`tests/synth_prx.h`'s `truncate_to` comment is updated: it recorded this path as deliberately unpinned
pending #2631, and it is now pinned.

### Mutation arm (fix reverted, tests unchanged)

`git show origin/master:prosper/src/self/module.cpp > prosper/src/self/module.cpp`, rebuild both test
targets, run:

```
== test_self_bounds (SELF/ELF/loader malformed-input hardening) ==
  [FAIL] prosper/tests/test_self_bounds.cpp:126  a PT_LOAD one byte longer than its file is refused
  [FAIL] prosper/tests/test_self_bounds.cpp:128  the refusal quotes the declared length and offset
  [FAIL] prosper/tests/test_self_bounds.cpp:130  the refusal quotes what the file actually holds
  [FAIL] prosper/tests/test_self_bounds.cpp:149  wrapping filesz is refused, not silently skipped (no OOB memcpy either way)
  [FAIL] prosper/tests/test_self_bounds.cpp:151  wrapping filesz names the image it could not fit
  [FAIL] prosper/tests/test_self_bounds.cpp:153  wrapping filesz names the offending program header
  [FAIL] prosper/tests/test_self_bounds.cpp:159  wrapping filesz still sized the image correctly before refusing
  [FAIL] prosper/tests/test_self_bounds.cpp:176  align-up-wrapped extent is refused (no giant allocation, no empty-image success)
  [FAIL] prosper/tests/test_self_bounds.cpp:178  align-up-wrapped extent reports the address-space overflow by name
FAILED  (34 passed, 9 failed)
SB_RC=1
  [FAIL] truncated PT_LOAD: build_image refuses instead of mapping the segment all-zero
  [FAIL] truncated PT_LOAD: the refusal quotes the length the segment declared
  [FAIL] truncated PT_LOAD: the refusal quotes what the file actually holds
  [FAIL] truncated PT_LOAD: link_program fails and the message names the path
  [FAIL] one-block-short PT_LOAD: build_image refuses
  [FAIL] one-block-short PT_LOAD: the refusal quotes the short length
  [FAIL] hand-built truncated: build_image refuses the short data segment
  [FAIL] hand-built truncated: the refusal names the SHORT segment, not the intact one
  [FAIL] hand-built truncated: the refusal quotes the declared span and the file length
FAILED (9)
rc=1
```

Every control passed throughout (34 of 43 in `test_self_bounds`, and every non-truncation arm of the
reject test). Restoring the file from `HEAD` and rebuilding returns both binaries to their exact
baseline md5 (`580f8f81a03d5c555a0c4a5af632929e` / `c174746d853ebb4f7d492c7f27015f28`) and both back to
green (43 and 64 assertions).

## Affected and deliberately unaffected

* **Affected:** every caller of `build_image` — `link_program` (boot fails naming the path),
  `runtime_module_load` (ENOEXEC), `tools/imgdump`. The loader acceptance surface is strictly
  narrower; measured to reject nothing in the local corpus (589/589).
* **Unaffected:** `Module::load` and every parsing stage. A truncated module still *parses*; that is
  the point of the arms above. The `p_filesz == 0` case (a pure-`.bss` `PT_LOAD`) is explicitly
  exempted from the file check — it claims no file bytes, so a short file takes nothing from it.
  Non-`PT_LOAD` program headers are untouched, which matters: 2,915 of them in the corpus have a
  logical `p_offset` landing outside the physical file, which is exactly why `va2foff`'s two-pass
  "LOAD wins" rule (#113) and `dyn_run_ok`'s recovery exist.

## Risks

* A dump we do not hold could contain a module whose last `PT_LOAD` was written with trailing zeros
  trimmed. It would now fail to load rather than limp. That is the intended direction, the message
  says exactly what happened, and 0 of 2,945 local segments do it (none even *ends* at EOF).
* A short *optional* plugin fails the whole link rather than being skipped.
  `skip_on_export_collision` is about export collisions specifically and was deliberately not
  extended; if a real title ever hits this, the error names the file and the decision can be revisited
  with a case in hand.

## Found but not fixed (filed, per the charter)

Three further silent-acceptance paths in the same area, each with `file:line`, a concrete failure
scenario and a suggested fix:

* **#2685** — `build_image` accepts a module with *no* `PT_LOAD` at all and returns an empty image as
  success. Same class; left out to keep this PR to one question. 589 of 589 real modules carry at
  least one `PT_LOAD`.
* **#2686** — in a SELF, a `PT_LOAD` with no matching data segment silently falls back to
  `elf_base + p_offset` and maps unrelated bytes. This PR mitigates the sub-case where that offset
  lands outside the file; the in-file case is still silent.
* **#2687** — `Module::load` uses `ftell`'s `-1` as a size, so `resize(SIZE_MAX)` throws an uncaught
  `length_error` and terminates the process on an unseekable file.

## Verification

Environment: Fedora toolbox distrobox `ps5ys`, GCC 16.1.1, CMake 4.4.0, `RelWithDebInfo`,
`Vulkan_FOUND` (offscreen graphics harness enabled), `PROSPER_AUDIO_FFMPEG` and `PROSPER_VIDEO_VAAPI`
both on (both backends built), `GAME_DUMP` -> `PPSA24651`. All 279 registered tests are therefore
enabled; a host build or a configuration without Vulkan/FFmpeg/VA-API yields a smaller denominator.

```
cmake -S prosper -B prosper/build-linux -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0
TMPDIR=<WORKTREE>/tmpdir cmake --build prosper/build-linux -j6          # 0 errors
ctest -N                                                                # Total Tests: 279   <- denominator pinned BEFORE the run
ctest --no-tests=error -j4 --output-on-failure                          # 100% tests passed out of 279, exit 0
```

Corpus sweep through the patched loader (44 dumps): `images_built=589 build_image_failed=0`.

ASCII gate (#2614): `python3 prosper/tools/output/check_ascii_output.py prosper` -> all checks passed.
Docs gate: `check_numbered_table.py` clean on `ARCHITECTURE.md`. `git diff --check` clean.
No snapshots were run: this PR touches no renderer, shader or GPU code.

## Review corrections applied (see the registered review on this PR)

Amended, not appended, so a squash cannot resurrect the wrong figure from a superseded commit body:

* **the blocker** — the SELF-header `file_size` figure was a `!=` count reported as `<`. Re-measured
  independently before amending: 452 smaller / 72 equal / 65 larger, 452 + 65 = 517, hand-verified on
  `akaudioinput.prx`. Fixed in `ARCHITECTURE.md`, the commit message and this description. One
  correction *to* the correction: the review put the over-declarations at "4-8 bytes each"; the
  measured histogram is 4 (25 modules), 8 (32), 12 (6) and **64** (2), so the range is 4-64.
* the overflowing-`memsz` sub-case was **copied**, not skipped — corrected in the `module.cpp` comment,
  the commit message and this description. The review cited the clamp at `exec_image_win.cpp:820-829`;
  it is `executable_end_for` at **`:844`** (`:820` is BCrypt hashing). Mechanism confirmed, and it is
  genuinely the only reader of `LoadedImage::prot` in the tree.
* the `mmap` counterweight overstated a constraint as architectural; reworded to cost/benefit.
* arm C's lost "extent still sized correctly" fact restored as the reviewer suggested.
* the trailing-trimmed caveat added to the doc. Verified before recording: exactly two SELF data
  segments in the corpus declare bytes that are not present, both `right.sprx`, both program header
  10, `p_type 0x6fffff00` — which `tools/self_dump` names `SCE_COMMENT`, not `PT_SCE_DYNLIBDATA`
  (`0x61000000`) as the review had it. Neither is a `PT_LOAD` and neither enters `m.loads`.
* the structural cross-check (**exactly five `PT_LOAD`s in every one of the 589 modules**) and the
  independent re-derivation of the sweep are now in the doc and the commit message.
* **#2685** line citation fixed (`:292` on master / `:354` on this head; `:353` is
  `out = std::move(img);`). **#2686** now states the predicate behind its 2,915 explicitly, with the
  two neighbouring definitions (3,052 and 3,038) that produce different counts in the same direction.

Re-verified at the amended head: build 0 errors; `ctest -N` -> 279; `ctest --no-tests=error -j4` ->
100% of 279, exit 0; corpus sweep `images_built=589 build_image_failed=0`; ASCII and docs gates clean;
mutation arm re-run (9 + 9 failures, verbatim above) with both binaries returning to their exact
baseline md5.