### PR TITLE
diag(recompiler): name which conjunct denies structured wave emission

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -22765,8 +22765,7 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                        (in.opcode == 0x365 || in.opcode == 0x366) &&
                        !(in.src[0].kind == OperandKind::InlineInt && in.src[0].value == -1);
             });
-        const bool structured_compute_wave_cfg = exact_compute_wave_cfg && !cf_rejected &&
-            barriers_are_top_level && !structured_has_cross_lane_mbcnt &&
+        const bool structured_wave_forward_ifs_ok =
             std::all_of(Fs.begin(), Fs.end(), [&](const ForwardIf& branch) {
                 // An exact native guest-size subgroup performs the vote without synthesized
                 // workgroup barriers, so nested wave branches are safe. Portable scratch votes
@@ -22774,6 +22773,71 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 return (!branch.on_exec && !branch.on_vcc) || b.native_subgroup_size ||
                        top_level_pc(branch.branch_pc);
             });
+        const bool structured_compute_wave_cfg = exact_compute_wave_cfg && !cf_rejected &&
+            barriers_are_top_level && !structured_has_cross_lane_mbcnt &&
+            structured_wave_forward_ifs_ok;
+        // PROSPER_DBG: name WHICH conjunct denied structured wave emission, and what that
+        // actually costs THIS stream.
+        //
+        // When `exact_compute_wave_cfg` holds and this conjunction does not, the stream loses
+        // structured wave emission. What happens instead is NOT one outcome, and an earlier revision
+        // of this reporter asserted the loop-emulating one unconditionally. That was wrong in a way
+        // worth recording, because the wrong case is not a corner:
+        //
+        //   `barriers_are_top_level == false` requires a barrier inside a ForwardIf/DivLoop region.
+        //   Any barrier before `is_end` also clears `cfg_dispatch_safe`, so the gate below always
+        //   takes its `!cfg_dispatch_safe` arm -- and `analyze_barrier_phased_compute` marks a
+        //   branch that crosses a barrier invalid, so the phased retry does not fire either and the
+        //   shader is REJECTED OUTRIGHT. A line claiming "emulates loops" would then describe loop
+        //   emulation for a program that emitted no SPIR-V at all.
+        //
+        // The census that accompanied that revision could not have caught it: the conjuncts it
+        // measured were the two that leave `cfg_dispatch_safe` alone, so every sampled line landed
+        // in the one arm where the sentence happened to be true. A control drawn from the arm that
+        // works cannot test the arm that does not.
+        //
+        // So the outcome is computed rather than assumed, and it is in the KEY as well as the
+        // message. `emit_body` reaches this point for one program address from the whole stream, the
+        // counted-loop prelude (dispatcher deliberately withheld), the post-loop suffix and per-phase
+        // sub-streams; keying on (program, conjunct) alone lets whichever ran first suppress the
+        // rest, so the line with the wrong consequence would win. That is the same shared-key
+        // suppression fixed on `divloop_reject` (#2684) and not inherited here until review.
+        //
+        // The neighbouring `[compute-cfg]` line prints `structured_wave=` as a single bool, which
+        // cannot name a conjunct at all.
+        if (b.is_compute && exact_compute_wave_cfg && !structured_compute_wave_cfg &&
+            getenv("PROSPER_DBG") && b.diagnostic.program_address != 0) {
+            const char* outcome =
+                !allow_cfg_dispatcher
+                    ? "dispatcher withheld for this sub-stream; emission continues here"
+                    : (!cfg_dispatch_safe
+                           ? "dispatcher unsafe (guest barrier): phased retry, else the whole "
+                             "program is rejected and emits nothing"
+                           : "stream goes to the CFG dispatcher, which emulates loops");
+            const std::pair<const char*, bool> conjuncts[] = {
+                {"cf-rejected",                  !cf_rejected},
+                {"barrier-not-top-level",        barriers_are_top_level},
+                {"cross-lane-mbcnt",             !structured_has_cross_lane_mbcnt},
+                {"nested-wave-forward-if",       structured_wave_forward_ifs_ok},
+            };
+            static std::mutex swr_mu;
+            static std::set<std::tuple<uint64_t, std::string, std::string>> swr_seen;
+            std::lock_guard<std::mutex> lk(swr_mu);
+            // Clearing, not refusing: past the cap the reporter degrades into REPEATING lines rather
+            // than dropping them. For a diagnostic, losing tidiness beats losing findings.
+            if (swr_seen.size() >= 4096u) swr_seen.clear();
+            for (const auto& c : conjuncts) {
+                // EVERY false conjunct is named, not just the first. They are independent, so
+                // fixing the first one reported can leave the decision unchanged -- a report that
+                // stopped at one would send a reader to widen a guard that changes nothing.
+                if (c.second) continue;
+                if (!swr_seen.emplace(b.diagnostic.program_address, c.first, outcome).second)
+                    continue;
+                std::fprintf(stderr,
+                             "[structured-wave-reject] program=0x%llx %s (%s)\n",
+                             (unsigned long long)b.diagnostic.program_address, c.first, outcome);
+            }
+        }
         if (b.is_compute && cfg_branches && getenv("PROSPER_DBG"))
             std::fprintf(stderr,
                          "[compute-cfg] branches=%zu backedge=%d dispatch_safe=%d complex=%d "


### PR DESCRIPTION
Refs #2542, #2690.

## What was wrong

`structured_compute_wave_cfg` is a **five-term conjunction**. When it is false while
`exact_compute_wave_cfg` is true, the stream loses structured wave emission — and what it gets instead
is one of three outcomes, decided by `allow_cfg_dispatcher` and `cfg_dispatch_safe`: the loop-emulating
CFG dispatcher, an outright rejection that emits nothing, or falling through to the structurizer in a
sub-stream where the dispatcher was deliberately withheld.

Emulated loops are how GTA V's compute programs hang the GPU (#2542, #2690, three programs and
counting), so *"which of these five terms was false"* is a question with a device loss behind it.

The neighbouring `[compute-cfg]` line already prints `structured_wave=` as a **single bool**, which
cannot answer it. This is the same gap `[divloop-reject]` closed one level down (#2684), and the same
fix.

```
[structured-wave-reject] program=0x413d88400 cross-lane-mbcnt (stream goes to the CFG dispatcher, which emulates loops)
```

**Every false conjunct is named, not just the first.** They are independent, so fixing the one that
happened to be reported first can leave the decision unchanged — a report that stopped at one would
send a reader to widen a guard that changes nothing.

**The outcome is computed, not assumed, and it is in the de-dup key as well as the message.** The
first revision of this PR asserted the loop-emulating outcome unconditionally. Review showed that is
false on two reachable paths, and the worse one is an *implication* rather than a corner case:

> `barriers_are_top_level == false` requires a barrier inside a ForwardIf/DivLoop region. Any barrier
> before `is_end` also clears `cfg_dispatch_safe`, so the gate always takes its `!cfg_dispatch_safe`
> arm — and a branch crossing a barrier makes the phased retry invalid too, so the shader is
> **rejected outright and emits nothing**. Every `barrier-not-top-level` line would have described
> loop emulation for a program that produced no SPIR-V.

**The census below could not have caught that**, and that is the part worth keeping. The conjuncts it
measured are precisely the two that leave `cfg_dispatch_safe` alone, so every sampled line landed in
the one arm where the sentence happens to be true. A control drawn from the arm that works cannot
test the arm that does not — the instrument looked validated because the population could not express
the failing case.

Keying on `(program, conjunct)` alone was the second half of the same finding. `emit_body` reaches
this point for one program address from the whole stream, the counted-loop prelude (dispatcher
deliberately withheld), the post-loop suffix and per-phase sub-streams; whichever ran first would
suppress the rest, so the line with the **wrong** consequence would win. That is the same shared-key
suppression fixed on `divloop_reject` in #2684, not inherited here until review pointed at it.

## Measured

Routed *Grand Theft Auto V* (`PPSA04263`), Linux/RADV, 4K, `scripts/gta5/reach-story-mode.pad`,
20 samples, `tools/screenshot`. All three known hanging programs declined, so the run costs **zero
device losses**. Over **1,366 `[compute-cfg]` lines** — not distinct programs: that line excludes
branch-free and counted-loop shaders and counts sub-stream invocations separately:

| classification | count | meaning |
| --- | ---: | --- |
| `exact_wave=0` | 906 | gate not taken |
| `exact_wave=1 structured_wave=0` | **23** | dispatcher — the cases this names |
| `exact_wave=1 structured_wave=1` | 437 | structured |

The 23 resolve to **five distinct `(program, conjunct)` pairs**:

| conjunct | distinct programs |
| --- | ---: |
| `nested-wave-forward-if` | 4 |
| `cross-lane-mbcnt` | 1 |

### The order is the point

I predicted `cross-lane-mbcnt` would dominate — a light-list compaction shader uses `mbcnt`, and it is
the one conjunct with no `native_subgroup_size` escape hatch. **It is the rarer of the two.**

I had recorded that as a hypothesis rather than a finding, precisely because static reading cannot
pick between five conjuncts. That is the entire reason this reporter exists, and it immediately
corrected the person who wrote it.

## What this census does NOT cover

Stated explicitly because the omission is invisible in the numbers: **none of the three programs known
to hang appear in it.** Two were declined before they recompiled.

**Whether `0x413dc6700` can reach this decision at all is not established.** An earlier revision of
this PR claimed as a structural finding that it could not — that barrier-phased programs always return
before the conjunction. That is wrong. The phased branch is taken only when
`phased.guarded || initial_dispatch_active || force_barrier_phases`, so an **unguarded** phased program
falls through and does reach here; the gate's own `!cfg_dispatch_safe` arm exists precisely to catch
that case, and would be unreachable otherwise.

The available evidence points the other way from my earlier claim: this program's
`[compute-phase] begin=0` implies it is **not** guarded (a guarded stream starts at `guard_index + 1`),
which would mean it *does* reach this decision and this reporter should fire for it in an undeclined
run. I have not run that, because an undeclined run loses the device.

## Scope

Diagnostic only.

- No behavioral change on any path. The conjunction is unchanged; its fifth term was hoisted into a
  named `const bool` so it can be tested individually, and the value is identical by construction.
- Gated on `getenv("PROSPER_DBG")` **and** a non-zero program address, so unattributed lines cannot
  merge distinct shaders under one de-dup key — the failure mode found in review on #2684.
- De-dup set bounded at 4096; past the cap it **clears**, so the reporter degrades into repeating
  lines rather than dropping them.

## Review

Rejected on the first round with three blocking findings, all of them mine and all fixed above: the
consequence clause was false on two reachable paths, the de-dup key omitted the context that decides
the consequence (repeating a defect fixed one PR earlier), and the "structural finding" about
barrier-phased programs was not licensed by the code.

## Verification

- Build: clean, **0 errors**, separate build tree.
- `ctest --no-tests=error -j4`: **279/279 passed**, exit 0.
- `tools/env/check_diag_gates.py`: `== all checks passed ==` — 104 findings, 104 baselined. The new
  `getenv` adds no finding (site count 1073 → 1074, findings unchanged).
- Functional evidence is the census above: the reporter fires, names distinct conjuncts, attributes
  them to distinct programs, and de-duplicates on a live routed run.

Note on running ctest here: pass no `TMPDIR`, or one whose path does not contain `build-`. See
**#2692** — `diag_gate_selftest` fails spuriously otherwise, because the scanner filters out its own
temporary fixtures.

No unit test accompanies this. It is an `fprintf` behind an env gate on a decision the existing
recompiler tests already reach; a test asserting "this string was printed" would pin the string, not
the behavior.
