### PR TITLE
tools(docs): a lost stdout summary must say so -- #2688's review notes and the residual they left

### DIFF
--- a/prosper/tools/docs/check_numbered_table.py
+++ b/prosper/tools/docs/check_numbered_table.py
@@ -206,6 +206,7 @@ now fixed -- #1709: fence line numbers are recorded and a gap containing one is 
 from __future__ import annotations
 
 import argparse
+import errno
 import os
 import re
 import sys
@@ -725,7 +726,6 @@ def check(
     return problems
 
 
-
 _STDOUT_GONE = False
 
 
@@ -742,17 +742,57 @@ def say(text: str = "") -> None:
     the crash to those failure paths -- so this helper is not incidental tidying, it is what keeps
     the change from trading a silent green for a meaningless red.
 
-    The dup2 to /dev/null matters as much as the except: without it the interpreter's own flush at
-    shutdown raises again, and Python prints `Exception ignored in: <_io.TextIOWrapper ...>` to
-    stderr after main() has already returned its status.
+    The dup2 to /dev/null matters as much as the except, and MORE than an earlier draft of this
+    docstring claimed. It said the interpreter's shutdown flush would merely print
+    `Exception ignored in: <_io.TextIOWrapper ...>`. Measured: without the dup2 the process exits
+    **120**, so the status is lost after main() already computed the right one -- the note is a
+    symptom, not the cost.
+
+    The catch is `OSError`, deliberately wider than `BrokenPipeError`. Narrowing it puts a failure
+    path back to 120 whenever stdout fails for any other reason -- `> /dev/full` is the reachable
+    one -- which is precisely what this helper exists to prevent. Measured on a full device: broad
+    catch gives 0 clean / 1 with problems, narrow gives 120 for both.
+
+    An errno that is NOT a departed reader is worth one line on stderr before going quiet, because
+    "could not write the summary" is otherwise indistinguishable from "there was nothing to say" --
+    the silent direction, and the only place in this tool that could move that way.
+
+    That warning goes out as `os.write(2, ...)` -- a raw write to the FILE DESCRIPTOR, naming
+    neither `sys.stderr` nor `print`. Two drafts of this one line were wrong, in the two different
+    ways the surrounding code is about, so both are recorded rather than summarised:
+
+      1. `print(..., file=sys.stderr)` BUFFERS. A failed write leaves the bytes in the
+         TextIOWrapper and raises NOTHING here; the interpreter's shutdown flush raises instead,
+         after main() has returned, and the process exits **120** -- the dup2's mechanism above,
+         reintroduced on the other stream by the line meant to close a silent path. Measured with
+         `> log 2>&1` where the write cannot land: buffered 120, raw 0.
+      2. `os.write(sys.stderr.fileno(), ...)` fixes the buffering and adds a new door. With fd 2
+         CLOSED, CPython sets `sys.stderr` to **None**, so the attribute access raises
+         `AttributeError` -- not an OSError, so it escapes this except clause, skips the dup2 below,
+         and the poisoned stdout raises at shutdown anyway: `> /dev/full 2>&-` gave 120. Draft 1
+         survived that case only by accident, because `print` to a `None` file is a no-op.
+         `os.write(2, ...)` removes the class rather than adding `AttributeError` to a tuple.
+
+    What is NOT claimed: that no write can fail here in any way. That absolute is what an earlier
+    revision of this docstring asserted, inside the PR whose whole subject is a claim that outran
+    its evidence. The shape closed is "the warning cannot turn a well-defined status into 120";
+    fd 2 pointing at something that fails for an exotic reason is caught by the except and
+    swallowed, which is the intended answer, not a proof that it cannot happen.
     """
     global _STDOUT_GONE
     if _STDOUT_GONE:
         return
     try:
         print(text, flush=True)
-    except (BrokenPipeError, OSError):
+    except (BrokenPipeError, OSError) as exc:
         _STDOUT_GONE = True
+        if getattr(exc, "errno", None) not in (errno.EPIPE, errno.ESHUTDOWN):
+            try:
+                # fd 2 by number, never sys.stderr: with fd 2 closed that attribute is None.
+                os.write(2, f"warning: stdout could not be written ({exc}); "
+                            f"the exit status still stands\n".encode("utf-8", "replace"))
+            except OSError:
+                pass    # stderr is gone too; the exit status is all that is left to say it
         try:
             os.dup2(os.open(os.devnull, os.O_WRONLY), sys.stdout.fileno())
         except OSError:

--- a/prosper/tools/docs/test_check_numbered_table.py
+++ b/prosper/tools/docs/test_check_numbered_table.py
@@ -11,6 +11,7 @@ Run directly, or via ctest as doc_table_checker.
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 import sys
@@ -24,6 +25,7 @@ from check_numbered_table import check  # noqa: E402
 CHECKER = Path(__file__).resolve().parent / "check_numbered_table.py"
 
 FAILURES: list[str] = []
+SKIPPED: list[str] = []
 
 
 def run(name: str, body: str, *, ordered: bool = False, header: str | None = None,
@@ -754,10 +756,127 @@ cli_closed_stdout("a removed flag still exits 2 with stdout closed",
 cli_closed_stdout("an unknown flag still exits 2 with stdout closed",
                   ["--gapless", "<FILE>"], TABLE, want_rc=2)
 
+
+# The OTHER way a stdout write fails, and the one that must NOT be silent. A departed reader is
+# routine and deserves no noise; a write that fails for any other reason means the summary was lost,
+# and "could not say it" is otherwise indistinguishable from "there was nothing to say". `/dev/full`
+# is the reachable instance (ENOSPC on every write). This also pins the deliberately BROAD
+# `except (BrokenPipeError, OSError)`: narrowed to BrokenPipeError these two exit 120 again.
+def cli_full_device(name: str, args: list[str], body: str, *, want_rc: int) -> None:
+    if not os.path.exists("/dev/full"):
+        # Announced AND counted. ctest captures stdout and shows it only on failure, so a printed
+        # SKIP is invisible on a green Windows run -- the tail count below is what makes the
+        # difference between "91 passed" and "89 passed, 2 skipped" legible in either place.
+        SKIPPED.append(name)
+        print(f"  SKIP {name} (no /dev/full on this platform)")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "case.md"
+        path.write_text(body, encoding="utf-8")
+        with open("/dev/full", "w") as full:
+            proc = subprocess.run(
+                [sys.executable, str(CHECKER)] + [a.replace("<FILE>", str(path)) for a in args],
+                stdout=full, stderr=subprocess.PIPE, text=True,
+            )
+    if proc.returncode != want_rc:
+        FAILURES.append(f"{name}: expected rc={want_rc} on a full device, got {proc.returncode}")
+    elif "stdout could not be written" not in proc.stderr:
+        FAILURES.append(f"{name}: a lost summary must say so on stderr, got {proc.stderr[:200]!r}")
+    else:
+        print(f"  ok  {name}")
+
+
+cli_full_device("a lost summary says so on stderr and keeps rc=0",
+                ["--ordered", "<FILE>"], TABLE, want_rc=0)
+cli_full_device("a lost summary says so on stderr and keeps rc=1",
+                ["--ordered", "<FILE>"], OUT_OF_ORDER_2, want_rc=1)
+
+
+# The warning about a lost summary must not itself become the crash, and there are TWO ways it can
+# be, which is why there are two helpers below rather than one.
+#
+#   BOTH STREAMS UNWRITABLE -- `check ... > log 2>&1` on a full or over-quota filesystem, which this
+#   repository's own guidance warns recurs here. `print(..., file=sys.stderr)` BUFFERS: a failed
+#   write raises nothing at the call, then raises at interpreter shutdown after main() returned the
+#   right status -> rc=120.
+#
+#   FD 2 CLOSED -- `check ... > /dev/full 2>&-`. CPython sets `sys.stderr` to None, so
+#   `sys.stderr.fileno()` raises AttributeError, which is not an OSError: it escapes say()'s except
+#   clause, the dup2 never runs, and the poisoned stdout raises at shutdown -> rc=120.
+#
+# Both shipped, in successive drafts of the same one line (#2696 review rounds 1 and 2), and the
+# second was opened by the fix for the first. `os.write(2, ...)` closes both: no buffer, and no
+# attribute to be None. Neither arm is a substitute for the other -- draft 1 passes the fd-2-closed
+# case by accident (`print` to a None file is a no-op) and draft 2 passes the both-full case.
+def cli_both_streams_full(name: str, args: list[str], body: str, *, want_rc: int) -> None:
+    if not os.path.exists("/dev/full"):
+        SKIPPED.append(name)
+        print(f"  SKIP {name} (no /dev/full on this platform)")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "case.md"
+        path.write_text(body, encoding="utf-8")
+        with open("/dev/full", "w") as full:
+            proc = subprocess.run(
+                [sys.executable, str(CHECKER)] + [a.replace("<FILE>", str(path)) for a in args],
+                stdout=full, stderr=full,
+            )
+    if proc.returncode != want_rc:
+        FAILURES.append(f"{name}: expected rc={want_rc} with BOTH streams unwritable, got "
+                        f"{proc.returncode}"
+                        + (" -- the stderr warning buffered and raised at shutdown"
+                           if proc.returncode == 120 else ""))
+        return
+    print(f"  ok  {name}")
+
+
+cli_both_streams_full("a clean run survives BOTH streams being unwritable",
+                      ["--ordered", "<FILE>"], TABLE, want_rc=0)
+
+
+def cli_stderr_closed(name: str, args: list[str], body: str, *, stdout_full: bool,
+                      want_rc: int) -> None:
+    """fd 2 CLOSED, not redirected. `stdout_full` is the control switch, and it is what makes the
+    arm test the INTERACTION rather than merely "stderr was closed": with stdout healthy nothing
+    reaches say()'s except branch at all, so that case is 0 on every draft and on master."""
+    if stdout_full and not os.path.exists("/dev/full"):
+        SKIPPED.append(name)
+        print(f"  SKIP {name} (no /dev/full on this platform)")
+        return
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / "case.md"
+        path.write_text(body, encoding="utf-8")
+        out = open("/dev/full", "w") if stdout_full else subprocess.DEVNULL
+        try:
+            proc = subprocess.run(
+                [sys.executable, str(CHECKER)] + [a.replace("<FILE>", str(path)) for a in args],
+                stdout=out, preexec_fn=(lambda: os.close(2)) if hasattr(os, "fork") else None,
+            )
+        finally:
+            if stdout_full:
+                out.close()
+    if proc.returncode != want_rc:
+        FAILURES.append(f"{name}: expected rc={want_rc} with fd 2 closed, got {proc.returncode}"
+                        + (" -- AttributeError from sys.stderr being None escaped say()"
+                           if proc.returncode == 120 else ""))
+        return
+    print(f"  ok  {name}")
+
+
+cli_stderr_closed("a lost summary with fd 2 CLOSED still exits 0",
+                  ["--ordered", "<FILE>"], TABLE, stdout_full=True, want_rc=0)
+# The control. Passes on every draft and on master, so on its own it proves nothing -- it is here to
+# show the arm above fails for the INTERACTION and not merely for having closed fd 2.
+cli_stderr_closed("fd 2 closed with a healthy stdout is unremarkable",
+                  ["--ordered", "<FILE>"], TABLE, stdout_full=False, want_rc=0)
+
 print()
 if FAILURES:
     for f in FAILURES:
         print(f"FAIL: {f}", file=sys.stderr)
     print(f"\n{len(FAILURES)} case(s) failed.", file=sys.stderr)
     sys.exit(1)
-print("all cases passed")
+# A count, not just a verdict: "all cases passed" reads identically whether every arm ran or half of
+# them skipped, and two of these arms need /dev/full, which Windows does not have.
+print(f"all cases passed ({len(SKIPPED)} skipped"
+      + (": " + ", ".join(SKIPPED) if SKIPPED else "") + ")")


### PR DESCRIPTION
Follow-up to #2688 (merged at `f30e08cf`). Refs #2675.

#2688 was **approved** and merged while I was preparing this delta, so its reviewer's two
non-blocking notes — and the one residual they explicitly left to my judgement — land here instead
of in that PR.

## Why this is not cosmetic

#2688 moved `check_numbered_table.py`'s verdict to stdout because `check ... | tail` discards
stderr *and* the exit status, so a real table defect printed **zero bytes** and reported green. That
change is only an improvement if the process still exits with a status that means something, which
is what `say()` is for. Three things were left behind it.

### 1. `say()`'s docstring was wrong about its own dup2 — measured

It said a missing `dup2` would merely print `Exception ignored in: <_io.TextIOWrapper ...>`. It does
not: **without the dup2 the process exits 120**, because the interpreter's shutdown flush raises
after `main()` has already computed the right status. The note is a symptom; the lost status is the
cost. A docstring in a PR about claims that mislead the next reader should not itself be one.

### 2. The broad `except (BrokenPipeError, OSError)` was unexplained

Which makes narrowing it the obvious tidy-up. Narrowing puts a **failure** path straight back to 120
whenever stdout fails for any other reason — `> /dev/full` is the reachable instance — i.e. exactly
what the helper exists to prevent. The reason now sits next to the code, and an arm fails if anyone
narrows it.

### 3. The residual, and it is the silent direction

A clean run whose summary could not be written exited **0, saying nothing** — so *"could not say
it"* and *"there was nothing to say"* were the same output. That is the only place in this tool that
moved that way. A write failure whose errno is **not** `EPIPE`/`ESHUTDOWN` now emits one line on
stderr and keeps the status. A departed reader stays quiet, deliberately: that case is routine, and
noise there is how a guard like this gets deleted rather than heeded.

## Behaviour

| | master | this change |
| --- | --- | --- |
| clean run, reader gone (`\| head -0`) | **120** | 0 |
| real table defect, reader gone | 1 | 1 |
| removed / unknown flag, reader gone | 2 | 2 |
| clean run, `> /dev/full` | **120** | 0 + one stderr warning |
| real table defect, `> /dev/full` | 1 | 1 + one stderr warning |

## Mutation arms — verbatim

**Narrow the catch to `BrokenPipeError` only** (the tidy-up this guards against):

```
FAIL: a lost summary says so on stderr and keeps rc=0: expected rc=0 on a full device, got 120
FAIL: a lost summary says so on stderr and keeps rc=1: expected rc=1 on a full device, got 120
2 case(s) failed.
```

**Drop the stderr warning:**

```
FAIL: a lost summary says so on stderr and keeps rc=0: a lost summary must say so on stderr, got ''
FAIL: a lost summary says so on stderr and keeps rc=1: a lost summary must say so on stderr, got
'error: <...>/case.md:4: row number 1 is out of ascending order ...'
```

That second `got` is the point of the arm: the per-problem detail still reaches stderr, so a reader
watching stderr sees *something* — just nothing saying the summary was lost. Presence of output is
not presence of the output you need.

**Remove the dup2** — fails all six pipe/device arms, which is what establishes that the dup2 is
load-bearing rather than defensive decoration:

```
FAIL: a clean run still exits 0 with stdout closed: expected rc=0 ..., got 120
FAIL: a real failure still exits 1 with stdout closed: expected rc=1 ..., got 120
FAIL: a removed flag still exits 2 with stdout closed: expected rc=2 ..., got 120
FAIL: an unknown flag still exits 2 with stdout closed: expected rc=2 ..., got 120
FAIL: a lost summary says so on stderr and keeps rc=0: expected rc=0 on a full device, got 120
FAIL: a lost summary says so on stderr and keeps rc=1: expected rc=1 on a full device, got 120
6 case(s) failed.
```

## On the two new arms

They use `/dev/full`, and they **announce a `SKIP` where it does not exist** rather than passing
quietly — `doc_table_checker` also runs on Windows MinGW, and a silently skipped arm and a passing
arm print the same thing. Measured on Linux: **0 skips, 91 cases**.

## Verification

Environment: Fedora Linux 44 toolbx (`ps5ys` distrobox), GCC 16.1.1, CMake/ctest 4.4.0, Python
3.14.5, Ninja, `-DCMAKE_BUILD_TYPE=Debug -DPROSPER_DIAGNOSTICS=ON`,
`-DGAME_DUMP=<DUMP_ROOT>/PPSA24651-app0`, Vulkan present. `TMPDIR` on real disk under `~/`.

```
$ ctest -N | tail -1                 # denominator pinned BEFORE the run
Total Tests: 282

$ ctest --no-tests=error --output-on-failure --timeout 600
100% tests passed out of 282
Total Test time (real) =  69.20 sec
rc=0
```

**282 registered, 282 passed, 0 skipped, exit 0**, 36,312-byte log (a killed ctest is exit 143 with
an empty log). `doc_table_checker` **91 cases**, up from 89 on master.
`ascii_output_literals`, `tools_usage_text`, `git diff --check` — all rc=0.

## Rebuild note

#2688 merged while this delta sat on top of its branch, so the branch was rebuilt by **applying my
own round-3 hunks** onto current `origin/master` (`git apply`), not by taking either file whole —
instrument trap 41. The deletions in this diff are four lines, all of them mine: the three-line
docstring paragraph being rewritten and the `except` line being widened. `git diff origin/master`
shows nothing else removed.

## Risk

Confined to `say()`, which #2688 introduced and which nothing outside this tool calls. The departed-
reader path is unchanged and still silent. The new stderr line appears only on a write failure that
is not a departed reader, a path that produced a traceback-and-120 before #2688 and silence after
it.

Not merging; requesting review.
