### PR TITLE
diag(recompiler): divloop-reject must not assert a fallback it cannot see

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -5697,9 +5697,10 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
                                             const char* caller_role = "emit") {
     std::vector<DivLoop> out;
     // PROSPER_DBG: name WHICH rejection discards the loops. Every `return {}` here throws away
-    // EVERY loop in the shader, not just the one that failed, and the caller then falls back to the
-    // whole-stream CFG dispatcher, which EMULATES the loop instead of emitting a real SPIR-V one.
-    // So one unhandled shape silently changes how an entire program executes. Static reading can
+    // EVERY loop in the shader, not just the one that failed. What the caller then does with an
+    // empty list is NOT fixed -- see the note on `caller_role` below -- but one of the outcomes is
+    // the whole-stream CFG dispatcher, which EMULATES the loop instead of emitting a real SPIR-V
+    // one. So one unhandled shape silently changes how an entire program executes. Static reading can
     // narrow a symptom to this function in minutes and then stall, because the sites are
     // indistinguishable from outside; this makes them distinguishable.
     //
@@ -5721,12 +5722,37 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
     // different shaders rejecting at the same cause and pc into one line, making a count of
     // distinct programs read LOW. An unattributed line is not a weaker finding, it is a wrong one.
     //
+    // The message states ONLY what is certain at this point, and deliberately says nothing about
+    // what happens next. It is tempting to add "and the stream then falls back to the CFG
+    // dispatcher" -- an earlier version did, and so did the first attempt at THIS comment, which
+    // asserted the opposite outcome just as confidently and was equally wrong.
+    //
+    // The honest statement is that the outcome is not determined here, and this comment will not
+    // enumerate the ways it can go -- deliberately, because two drafts already got an enumeration
+    // wrong in opposite directions.
+    //
+    // What is checkable and sufficient: an empty list is ONE input among several to a decision taken
+    // in `emit_body`, whose branches carry predicates over values not visible here (whether the
+    // dispatcher is permitted at all for this sub-stream, whether a guest barrier made it unsafe,
+    // the branch count, the presence of particular ops). At least one caller withholds the
+    // dispatcher outright, so "refused loop" and "loop emulated" are not the same claim. That is as
+    // far as this function can see, and it is far enough to know the consequence is not its to
+    // state. Plumbing those values in purely to keep a sentence would be the wrong trade: the
+    // sentence is what should go.
+    //
+    // (Found reviewing #2695, which fixed the same over-assertion one level up. Counting both
+    // earlier drafts of this comment -- one asserting the dispatcher, one asserting outright
+    // rejection, one asserting a false universal over the entries -- the shared shape is that the
+    // clause gets written where the CAUSE is detected rather than where the EFFECT is decided, and
+    // those are different functions. Writing a *narrower* claim is not a fix if it is still a claim
+    // about the other function.)
+    //
     // `caller_role` is in the message AND in the de-dup key, and both halves are load-bearing.
     // Two callers reach this function with the same `safe` set and the same program, and their
     // consequences are NOT the same:
     //
-    //   emit            -- the recompile. Every loop in the shader is discarded and the stream
-    //                      falls back to the CFG dispatcher, which emulates the loop.
+    //   emit            -- the recompile. Every loop in the shader is discarded; what the stream
+    //                      does next is decided by the caller, not here (see the note above).
     //   multiwave-probe -- `compute_shader_prefers_native_multiwave`, which only tests
     //                      `loops.empty()`. Nothing is discarded and no fallback happens; the
     //                      preference analysis simply proceeds as though the shader were loop-free.
@@ -5755,7 +5781,7 @@ std::vector<DivLoop> detect_divergent_loops(const std::vector<Rdna2Inst>& ins,
                              "[divloop-reject] program=0x%llx role=%s %s at pc=%u (%s)\n",
                              (unsigned long long)diagnostic.program_address, caller_role, why, pc,
                              std::strcmp(caller_role, "emit") == 0
-                                 ? "all loops discarded; stream falls back to the CFG dispatcher"
+                                 ? "all loops discarded; what the stream does next is the caller's"
                                  : "probe only: nothing discarded, analysis proceeds as loop-free");
         }
         return {};


### PR DESCRIPTION
Refs #2684, #2695.

## What was wrong

`divloop_reject`'s `role=emit` line printed:

```
(all loops discarded; stream falls back to the CFG dispatcher)
```

The first clause is this function's to state. **The second is not, and it is false on reachable
paths.** `emit_body` decides what happens to a stream with no loops through several branches, over
values `detect_divergent_loops` cannot see; at least one caller withholds the dispatcher outright, so
"refused loop" and "loop emulated" are different claims. A line asserting the second describes loop
emulation for programs that never reached a dispatcher — the most misleading thing a diagnostic can
do, because it reads as an explanation of behaviour that did not occur.

## The fix, and the three wrong versions of it

The tempting fix is to plumb the caller's flags in so the sentence survives. **The sentence is what
should go.** Getting there took three drafts, each wrong in a different direction, and the comment now
records that instead of a fourth enumeration:

1. the original asserted the CFG dispatcher;
2. the first replacement asserted the **opposite** — "a shader with two branches and a refused loop is
   rejected outright and emits nothing". False: `portable_compute_dpp_ror8` reaches a dispatcher
   before `complex_compute_cfg` is consulted.

   An earlier revision of this body listed `exact_compute_wave_cfg` as a second route here. **It is
   not one**, and the way that sentence travelled is the reason it is called out rather than quietly
   deleted: review round 1 derived that a divloop reject leaves `Fs` empty — the unclaimed backward
   branch makes `detect_forward_ifs` reject — so `exact_compute_wave_cfg` is identically false and
   its gate is unreachable after any reject. Round 2 contradicted that in passing, and I copied
   round 2's sentence into a commit message and this body without tracing it against the code or the
   earlier round. A claim inside a review reads as already verified, which is exactly why it has to
   be traced;
3. the second replacement asserted a **false universal** — that the compute dispatcher entries are
   three and that every one requires `allow_cfg_dispatcher`. Neither holds: `emit_phase` and the
   LDS fminmax path are two more compute entries that never consult the flag, and the prelude
   recursion's withholding does not propagate, because `emit_phase` re-enters `emit_body` with the
   flag hard-coded true.

Draft 3 is the interesting failure. It was written *specifically* to fix draft 2's overclaim, cited
the reviewer's own stronger argument, and was narrower — and still asserted something false about
another function. **Writing a narrower claim is not a fix if it is still a claim about the other
function.** The comment now states only what is checkable and sufficient: an empty list is one input
among several to a decision taken elsewhere, and at least one caller withholds the dispatcher.

## Also fixed: the claim survived twice in its own documentation

Removing it from the message left it standing in the comment header that explains the message — the
opening paragraph, and the `caller_role` table's gloss on `emit`, which is precisely where a reader
who sees `role=emit` goes to find out what it means. Both rewritten.

## Why this is a separate PR from #2695

#2695 fixed the identical over-assertion one level up, in code that had not merged. This is in code
that **has** merged (#2684), so it gets its own commit.

The shared shape, across both PRs and all three drafts here: the consequence clause gets written where
the **cause** is detected rather than where the **effect** is decided, and those are different
functions. Whoever names a cause has just finished reasoning about the effect, so attaching it feels
free.

## Verification — measured at `3b857b7fc794ff0b71b8f1694f05f9e54a4a199d`, and the tree has not moved since

Every revision after that head changed only this PR body and the commit message; `git diff --stat 3b857b7fc794ff0b71b8f1694f05f9e54a4a199d 31874428` is empty, so the results below apply unchanged to the current head `31874428`.

- Build: clean, **0 errors** (separate build tree).
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0.
- `tools/env/check_diag_gates.py`: `== all checks passed ==` — 104 findings, 104 baselined.

Note for re-running: pass no `TMPDIR`, or one whose path does not contain `build-` —
`diag_gate_selftest` fails spuriously otherwise (**#2692**).

Diagnostic only: comment content plus one string literal, both behind an existing `PROSPER_DBG`
gate. No behavioral change on any path; the de-dup key still carries `caller_role`, so the probe
cannot suppress the recompile.
