### PR TITLE
diag(agc): the [ud] shader-declaration line prints the CODE address

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -1294,9 +1294,20 @@ static void pipetrace_shader_user_data(const char* tag, const AgcShader* h) {
     const AgcShaderUserData* ud = h->user_data;
     if (!ud) { fprintf(stderr, "  [ud] %s shader=%p user_data=(null)\n", tag, (const void*)h); return; }
 
+    // `code=` is what makes this line joinable. The instruments that matter for a resource question
+    // key on the CODE address -- `[divloop-reject]`, `[structured-wave-reject]`,
+    // `log_recompile_diagnostic`, `[compute-table]`, the GPU capture's resource tables,
+    // `PROSPER_COMPUTE_SKIP_PROGRAM` -- while this line printed only the AgcShader header pointer. So
+    // a shader's declared `srt`/`eud` could not be tied to the program whose resources are in
+    // question. That is the join a GTA V investigation needed (#2704, #2705): a routed run emits
+    // ~96.5k of these LINES (not registrations -- this helper has three call sites), 1.11% of them
+    // declaring a non-zero SRT, and there was no way to ask whether a given compute program was
+    // among them.
     fprintf(stderr,
-            "  [ud] %s shader=%p user_data=%p eud=%u srt=%u direct_count=%u sharp_counts={%u,%u,%u,%u}\n",
-            tag, (const void*)h, (const void*)ud, ud->eud_size_dw, ud->srt_size_dw,
+            "  [ud] %s shader=%p code=0x%llx user_data=%p eud=%u srt=%u direct_count=%u "
+            "sharp_counts={%u,%u,%u,%u}\n",
+            tag, (const void*)h, (unsigned long long)(uintptr_t)h->code, (const void*)ud,
+            ud->eud_size_dw, ud->srt_size_dw,
             ud->direct_resource_count, ud->sharp_resource_count[0], ud->sharp_resource_count[1],
             ud->sharp_resource_count[2], ud->sharp_resource_count[3]);
 


### PR DESCRIPTION
Refs #2705, #2542, #2690, #2704.

## What was wrong

`pipetrace_shader_user_data()` reports what a shader **declares** — `eud_size_dw`, `srt_size_dw`,
the direct and sharp resource counts — keyed by the `AgcShader` **header pointer**.

The instruments that matter for a resource question identify a shader by its **code address**:
`[divloop-reject]`, `[structured-wave-reject]`, `log_recompile_diagnostic`, `[compute-table]`, the GPU
capture's resource tables, `PROSPER_COMPUTE_SKIP_PROGRAM`. (An earlier revision of this body listed
`[compute-cfg]` among them; it prints no code address — review caught it.)

So the one line saying what a shader **declares** could not be joined to any line saying what it
**got**.

## Why that is not hypothetical

A routed *Grand Theft Auto V* run emits **96,557** of these **lines** — lines, not registrations: the
helper has three call sites, so the line count strictly exceeds the number of shaders — **1,074** of
which (1.11%) declare a non-zero SRT. There was no way to ask whether a particular compute program was among them.

With `code=`, the join is one grep — and it immediately produced the finding now filed as **#2705**:
the three compute programs that hang this title (#2542, #2690) are **exactly** SRT-declaring ones,
with no sharp descriptors at all.

```
[ud] CreateShader shader=0x413cce110 code=0000000413dc6700 user_data=0x413cce1f0 eud=0 srt=2 direct_count=11 sharp_counts={0,0,0,0}
```

| program | srt | sharp_counts | eud |
| --- | ---: | --- | ---: |
| `0x413dc6700` | 2 | `{0,0,0,0}` | 0 |
| `0x413e14900` | 14 | `{0,0,0,0}` | 0 |
| `0x413e16400` | 15 | `{0,0,0,0}` | 0 |

`srt_size_dw` is parsed and printed and **never used to resolve anything** — all four value reads in
`src/` are `fprintf` arguments. That is #2705; this PR is only the join that made it visible.

**Scoped precisely, because an earlier revision of this body over-claimed it:** what these three
programs demonstrably lack is **sharps and an EUD**, not "everything prosper implements". A third
path — the direct-resource handling at `agc_shader_layout.cpp:1101` — runs, since all three declare
`direct_count=11`; it reads V#s from user-SGPR slots the guest never wrote, because only 2 dwords are
written (the SRT pointer). And #2704 records that `0x413dc6700` *does* get a 120-byte constant buffer
bound, which is **zero-filled** rather than absent.

## Scope

Diagnostic only.

- One field added to an existing line, already behind `PROSPER_PIPETRACE`.
- `h->code` is read from the guest-visible `AgcShader` header this function already dereferences and
  null-checks; no new dereference of guest memory is introduced.
- No behavioral change on any path.

## Verification — exact head `47b8acdb3b0cd75017f7d7dd70d1253af799aacf`

- Build: clean, **0 errors** (separate build tree).
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0.
- `tools/env/check_diag_gates.py`: `== all checks passed ==`, 104 findings / 104 baselined.
- Functional evidence: the two routed runs above, which cost **zero device losses** (all three hanging
  programs declined) and produced the census and the three-program table.

Note for re-running: pass no `TMPDIR`, or one whose path does not contain `build-`; `diag_gate_selftest`
fails spuriously otherwise, per trap 198.

