### PR TITLE
hle(agc): implement sceAgcQueueEndOfPipeActionPatchData — the DATA half of a patch pair

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -131,6 +131,20 @@ here and deliberately use a distinct heading so the two do not collide as anchor
   reading it. The **22,117-colour measurement recorded below** (§ *RESOLVED CHAIN*) **did** set
   `_PHASE=0` and stands; it was publicly doubted before that was checked, and the retraction is on
   #2542. (2026-08-18.)
+- **"Implementing the missing end-of-pipe data patch lights the world."** It does not.
+  `sceAgcQueueEndOfPipeActionPatchData` (#2708) is genuinely missing and now lands — 8,116 successful
+  writes, **zero** refused — but `0x413dc6700` still loses the device at `dispatch=40`, and after that
+  loss the composite freezes for the rest of the run (pixel CRC identical t=120s..600s). **This result
+  is not scoped to any particular theory of the black world**: it stands whatever the cause turns out
+  to be, so do not read it as bearing only on #2705's SRT question. An earlier version of this row
+  headlined it as "what leaves the resource table zero" — that premise is **withdrawn**: a live
+  memprobe shows 209 of 286 folds carrying non-zero data (#2704).
+  The pre-patch payload establishes something worse than "the value was stale": `data_sel=2` routes to
+  an 8-byte fence write, so before this change prosper was **writing `0xfffffffffffffffe` as the fence
+  value on every one of those packets that executed**. 8,116 is the count of successful patches and is
+  an upper bound on the writes, not a count of them: `honor_eop_write` returns early on `!rel_addr`,
+  misalignment and `!guest_readable`, only submitted-and-folded packets execute, and nothing shows the
+  packets target distinct addresses. (2026-08-18, #2708, #2704.)
 
 ## RESOLVED CHAIN: the world IS rendered, and then lit by nothing (2026-08-18)
 

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -3067,6 +3067,41 @@ HLE(agc_draw_index_auto_get_size)     { (void)a0; return kDwDrawIndexAuto * 4u; 
 HLE(agc_draw_index_offset_get_size)   { (void)a0; return kDwDrawIndexOffset * 4u; }
 HLE(agc_draw_index_indirect_get_size) { (void)a0; return kDwDrawIndexIndirect * 4u; }
 HLE(agc_dispatch_get_size)            { (void)a0; return kDwDispatch * 4u; }
+
+// sceAgcQueueEndOfPipeActionPatchData (MlEw1feXcjg) — the DATA half of the ReleaseMem patch pair.
+//
+// `sceAgcQueueEndOfPipeActionPatchAddress` was already implemented (agc_patch_release_mem_addr);
+// its sibling was not, so a packet built with a placeholder value got the right DESTINATION and kept
+// the wrong VALUE. GTA V calls this 9,126 times in 150 s of its story route, with a1 running 1, 2,
+// 3, … — an end-of-pipe fence sequence — and every one of them was discarded (#2707).
+//
+// Payload layout is prosper's own builder's, not an inferred PM4 one (agc_cb_release_mem above):
+//   cmd[1..2] address   cmd[3] data_sel   cmd[4..5] data   cmd[6] action   cmd[7] build_pre-hi
+// so this writes cmd[4..5] exactly as the address patch writes cmd[1..2].
+//
+// Deliberately does NOT touch the fence journal: `prosper_fence_journal_record` keys on the
+// destination ADDRESS, which the address patch already recorded. Recording again here with a DATA
+// value would enter a fence value where an address is expected.
+// CONFIDENCE: HIGH on the dword offsets (read from the builder in this file, and the packet is
+// re-validated as R_RELEASE_MEM before any write); MED on the argument order, which is taken from
+// the sibling's (cmd, value) shape and the observed call pattern rather than from a published
+// prototype.
+HLE(agc_patch_release_mem_data) {
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, 6 * sizeof(uint32_t), "ReleaseMemPatchData")) return 0;
+    if (!patch_check(cmd, R_RELEASE_MEM, "ReleaseMemPatchData")) return 0;
+    const uint32_t pre_lo = cmd[4], pre_hi = cmd[5];
+    cmd[4] = (uint32_t)(a1 & 0xffffffffu);
+    cmd[5] = (uint32_t)(a1 >> 32u);
+    if (getenv("PROSPER_GFXLOG"))
+        // Print data_sel and the PRE-patch payload as well as the new value, so the run proves the
+        // write landed AND that it changed something -- a success line that only echoes its own
+        // argument cannot distinguish "patched" from "patched with what was already there".
+        fprintf(stderr, "[agc] ReleaseMemPatchData cmd=%p data_sel=%u pre=0x%08x%08x data=0x%llx\n",
+                (const void*)cmd, cmd[3], pre_hi, pre_lo, (unsigned long long)a1);
+    return 0;
+}
+
 HLE(agc_dispatch_indirect_get_size)   { (void)a0; return kDwDispatchIndirect * 4u; }
 HLE(agc_dma_data_get_size)            { (void)a0; return kDwDmaData * 4u; }
 HLE(agc_event_write_get_size)         { (void)a0; return kDwEventWrite * 4u; }
@@ -3097,6 +3132,7 @@ void register_agc_hle() {
     RN("qMlfB1ZhMDc", agc_draw_index_offset_get_size);   // sceAgcDcbDrawIndexOffsetGetSize
     RN("mStuvI0zOtc", agc_draw_index_indirect_get_size); // sceAgcDcbDrawIndexIndirectGetSize
     RN("Abendgtz+3o", agc_dispatch_get_size);            // sceAgcCbDispatchGetSize
+    RN("MlEw1feXcjg", agc_patch_release_mem_data);       // ReleaseMem packet: set the data payload
     RN("w8HVkEeXPv8", agc_dispatch_indirect_get_size);   // sceAgcDcbDispatchIndirectGetSize
     RN("PxKWV2fVAps", agc_dispatch_indirect_get_size);   // sceAgcAcbDispatchIndirectGetSize
     RN("2ccJz9LQI+w", agc_dma_data_get_size);            // sceAgcDcbDmaDataGetSize


### PR DESCRIPTION
Refs #2707, #2542, #2705.

## What was wrong

The end-of-pipe action family is a **patch-after-build** pattern, and prosper implemented half of it:

| | |
| --- | --- |
| `sceAgcQueueEndOfPipeActionPatchAddress` | implemented (`agc_patch_release_mem_addr`) |
| **`sceAgcQueueEndOfPipeActionPatchData`** | **missing — NID unregistered, returned 0** |

So a ReleaseMem packet built with a placeholder got the right **destination** and kept the wrong
**value**.

## The patches land — the evidence, measured rather than inferred

Review's central objection was correct and is the reason this section exists: **a call count says
nothing about whether the writes are accepted.** An SDK-inline builder emitting a hardware
`IT_RELEASE_MEM` would have every patch refused by `patch_check`, *silently*, because the diagnostic
budget caps at 8 — and then this change would be inert.

So the success line now prints `data_sel` and the **pre-patch** payload:

```
8,116 successful writes, 0 refused

[agc] ReleaseMemPatchData cmd=0x203de027bc data_sel=2 pre=0xfffffffffffffffe data=0x1
[agc] ReleaseMemPatchData cmd=0x203de50620 data_sel=2 pre=0xfffffffffffffffe data=0x2
[agc] ReleaseMemPatchData cmd=0x203dea6294 data_sel=2 pre=0xfffffffffffffffe data=0x3
```

The pre-patch payload is `0xfffffffffffffffe` — **a placeholder sentinel, not random memory** — and it
is now the guest's fence sequence. A success line echoing only its own argument could not distinguish
"patched" from "patched with what was already there"; this one can.

## The fix

Offsets read from prosper's own builder in this file, not a PM4 document. `agc_cb_release_mem`:

```
cmd[1..2] address    cmd[3] data_sel    cmd[4..5] data    cmd[6] action
```

so this writes `cmd[4..5]` as the address patch writes `cmd[1..2]`, behind the same
`patch_target_writable` probe and `R_RELEASE_MEM` check.

It deliberately does **not** call `prosper_fence_journal_record`: that function **dereferences** its
address argument, so passing a fence value would read it as a pointer and clobber the packet's genuine
row. The address patch already records the destination, and the generation identity lives in
`cmd[7]`, which that patcher maintains.

## What this does NOT do

**It does not fix GTA V's world rendering and does not fix the hang.** `0x413dc6700` still loses the
device at dispatch 40, and after that loss the composite freezes for the rest of the run. Recorded as
a `## Ruled out` row in `docs/GTA5_STATUS.md` in this PR.

An earlier revision of this body carried a before/after table of frame colours and flip-stall
duration. **Both metrics were falsified by this project on the same day** — the flip stall by its own
control, and the colour pair recorded as loss timing with *"no dose conclusion may be drawn from the
pair"*. Quoting them as evidence for a different change was wrong; they are gone, and the landed-write
census above replaces them.

## Blast radius — measured, not assumed

`docs/AGC_PACKET_SIZES.md` already measured the caller set over **all 29 bootable dumps**: this NID is
called by `PPSA04263` only. An earlier revision of this body speculated "every title", which the repo
had already answered.

The `forges_freelist_ptr` guard (default ON) does **not** newly fire: it returns false for
`width >= 8`, and the observed packets carry `data_sel=2`, which the builder maps to an 8-byte write.

**Snapshots:** not proposed. The only measured caller is not a guarded title, and the charter makes
snapshots a release-time inventory rather than a merge gate — and a snapshot matrix could not have
answered the question that mattered here, which one `grep -c` did.

`CONFIDENCE: HIGH` on the dword offsets (builder + decoder agree, packet re-validated before any
write). `MED-HIGH` on the argument order — the 3.20 table exports a separate `…PatchType`, ruling out
the one alternative that fit the samples.

## Verification — exact head `cf186ec8ed544bca6038447b54c68c94393cca76`

- Build: clean, **0 errors** (separate build tree).
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0.
- Docs gate over every tracked `.md`: clean.
- Landed-write census above, from a routed run costing **zero device losses** (all three hanging
  programs declined).
