### PR TITLE
diag(recompiler): report each buffer op's disposition — a legal NUM_RECORDS=0 fold and a silent drop leave identical evidence

### DIFF
--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13720,6 +13720,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.indirect_pointer_source_root_lo_var &&
                         b.indirect_pointer_source_root_hi_var;
                     if (!exact_source) {
+                        buf_op.how = "reject-indirect-pointer-source";
                         ok = false;
                         return true;
                     }
@@ -13852,6 +13853,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         in.src[1].kind == OperandKind::SGPR && in.src[1].value == 8 &&
                         in.src[2].kind == OperandKind::InlineInt && in.src[2].value == 0;
                     if (!exact_operands) {
+                        buf_op.how = "reject-selected-sbuffer-operands";
                         ok = false;
                         return true;
                     }

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13403,6 +13403,39 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     atomic_op = Op_AtomicOr; break;
                 default: ok = false; return true;           // remaining typed/atomic opcodes deferred
             }
+            // Per-instruction buffer-op disposition (PROSPER_DBG). A buffer op whose V# decodes to
+            // NUM_RECORDS=0 — or that matches one of the no-backing markers below — is folded away:
+            // loads become a constant, stores are dropped, and no backing buffer is declared. That is
+            // architecturally correct for an empty descriptor. It is also, in the emitted SPIR-V,
+            // INDISTINGUISHABLE from an instruction that never reached the emitter at all: both leave
+            // no access chain, no load, no trace of any kind. Those two have completely different
+            // causes, and offline dissection of a program whose buffer traffic has vanished cannot
+            // separate them without this line (#2709 built an argument for a whole new memory model
+            // on exactly that ambiguity, and was wrong).
+            //
+            // Reported from a scope guard rather than at each decision site so EVERY exit path emits
+            // exactly one line. A path nobody classified prints `unclassified` rather than printing
+            // nothing — so a census can detect its own incompleteness instead of silently
+            // under-counting, which a per-site call cannot do. The three pre-switch rejects above are
+            // deliberately outside it: they set ok=false, and a rejected program is already reported
+            // by the recompile-reject census.
+            struct BufOpDisposition {
+                bool on;
+                const SpirvCompute& b;
+                const Rdna2Inst& in;
+                const uint32_t& n;
+                const bool& is_store;
+                const bool& is_atomic;
+                const char* how = "unclassified";
+                ~BufOpDisposition() {
+                    if (!on) return;
+                    std::fprintf(stderr,
+                                 "[buf-op] program=0x%llx pc=%u %s op=0x%x n=%u store=%d atomic=%d %s\n",
+                                 (unsigned long long)b.diagnostic.program_address, in.pc,
+                                 in.fmt == Rdna2Format::MUBUF ? "MUBUF" : "MTBUF", in.opcode, n,
+                                 (int)is_store, (int)is_atomic, how);
+                }
+            } buf_op{std::getenv("PROSPER_DBG") != nullptr, b, in, n, is_store, is_atomic};
             uint32_t offset = in.literal & 0xFFFu;
             bool offen = (in.literal >> 12) & 1u, idxen = (in.literal >> 13) & 1u;
             const bool indirect_pointer_descriptor_source_candidate =
@@ -13463,6 +13496,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rs.vreg[d] = acc;
                         predicate_write(b, rs, d, old);
                     }
+                    buf_op.how = "pcrel-table";
                     return true;
                 }
             }
@@ -13483,21 +13517,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             bool instance_vfetch = false;
             bool folded_vfetch = false; // by-fetch V# base already includes OFFSET/SOFFSET
             const ShaderResource* resolved_buffer = nullptr;
-            // Per-site buffer-op disposition (PROSPER_DBG). A buffer op that resolves a
-            // NUM_RECORDS=0 descriptor folds to zero (loads) or drops (stores) and emits NO memory
-            // access at all. That is architecturally correct for an empty descriptor, but in the
-            // emitted module it is INDISTINGUISHABLE from an op that was never decoded — both leave
-            // no trace. Offline dissection of a program whose buffer traffic has vanished therefore
-            // cannot tell "folded because the descriptor is empty" from "never reached the emitter",
-            // and those two have completely different causes. This line separates them.
-            const auto buf_op_disposition = [&](const char* how) {
-                if (!std::getenv("PROSPER_DBG")) return;
-                std::fprintf(stderr,
-                             "[buf-op] program=0x%llx pc=%u %s op=0x%x n=%u store=%d atomic=%d %s\n",
-                             (unsigned long long)b.diagnostic.program_address, in.pc,
-                             in.fmt == Rdna2Format::MUBUF ? "MUBUF" : "MTBUF",
-                             in.opcode, n, (int)is_store, (int)is_atomic, how);
-            };
             bool gta5_selected_sbuffer_consumer = false;
             bool indirect_pointer_descriptor_source = false;
             if (is_format) {
@@ -13591,23 +13610,23 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     ok = false; return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
-                    buf_op_disposition("zero-record");
                     // The exact live V# is empty. The producer admitted only selectors whose OOB
                     // result is zero; re-check that contract so a malformed table cannot silently
                     // turn SQ_SEL_1 into zero. Apply the result only to active EXEC lanes, preserving
                     // the old destination in masked lanes, and never declare a backing buffer.
-                    if (is_store) { ok = false; return true; }
+                    if (is_store) { buf_op.how = "reject-zero-record-format-store"; ok = false; return true; }
                     for (uint32_t k = 0; k < n; ++k) {
                         const uint32_t selector = res->swizzle[k];
-                        if (selector != 0u && selector < 4u) { ok = false; return true; }
+                        if (selector != 0u && selector < 4u) { buf_op.how = "reject-zero-record-selector"; ok = false; return true; }
                         const int d = in.dst.value + static_cast<int>(k);
                         const uint32_t old = vreg_old(b, rs, d);
                         rs.vreg[d] = b.uconst(0);
                         predicate_write(b, rs, d, old);
                     }
+                    buf_op.how = "zero-record";
                     return true;
                 }
-                buf_op_disposition("emitted");
+                buf_op.how = "resolved";
                 resolved_buffer = res;
                 binding = res->binding;
                 stride = res->stride;
@@ -13697,6 +13716,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         access == GtaCf9200NoBackingAccess::None ||
                         (access == GtaCf9200NoBackingAccess::LoadZero && is_store) ||
                         (access == GtaCf9200NoBackingAccess::DropStore && !is_store)) {
+                        buf_op.how = "reject-cf9200";
                         ok = false;
                         return true;
                     }
@@ -13706,6 +13726,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rs.vreg[destination] = b.uconst(0u);
                         predicate_write(b, rs, destination, old);
                     }
+                    buf_op.how = "cf9200-no-backing";
                     return true;
                 }
                 if (is_proven_null_nullable_raw_buffer(*res)) {
@@ -13719,6 +13740,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         access == Gta5NullableOutputAccess::None ||
                         (access == Gta5NullableOutputAccess::LoadDword && is_store) ||
                         (access == Gta5NullableOutputAccess::StoreDword && !is_store)) {
+                        buf_op.how = "reject-proven-null-nullable";
                         ok = false;
                         return true;
                     }
@@ -13728,6 +13750,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         rs.vreg[d] = b.uconst(0);
                         predicate_write(b, rs, d, old);
                     }
+                    buf_op.how = "proven-null-nullable";
                     return true;
                 }
                 if (is_optional_null_raw_load_buffer(*res)) {
@@ -13736,6 +13759,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     // dword load may consume it; stores, atomics, wider loads, and packet variants
                     // stay fail-visible rather than inheriting drop-write behavior.
                     if (!rdna2_optional_null_raw_load_shape(in)) {
+                        buf_op.how = "reject-optional-null-load";
                         ok = false;
                         return true;
                     }
@@ -13743,6 +13767,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     const uint32_t old = vreg_old(b, rs, d);
                     rs.vreg[d] = b.uconst(0);
                     predicate_write(b, rs, d, old);
+                    buf_op.how = "optional-null-load";
                     return true;
                 }
                 if (is_proven_null_guarded_raw_store(*res)) {
@@ -13758,13 +13783,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                          in.opcode == kMubufOpcodeStoreDwordX3) &&
                         rdna2_gta5_null_guarded_raw_store_site(in);
                     if (!supported_store || res->fetch_pc != in.pc) {
+                        buf_op.how = "reject-null-guarded-store";
                         ok = false;
                         return true;
                     }
+                    buf_op.how = "null-guarded-store";
                     return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
-                    buf_op_disposition("zero-record");
+                    buf_op.how = "zero-record";
                     // The front half proved all four live V# words at this exact instruction and
                     // decoded NUM_RECORDS=0. RDNA2's OOB contract returns zero for every raw load
                     // component, drops raw stores, and performs no memory operation for an atomic.
@@ -13809,7 +13836,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     gta5_selected_sbuffer_consumer = true;
                 }
-                buf_op_disposition("emitted");
+                buf_op.how = "resolved";
                 resolved_buffer = res;
                 binding = res->binding;
                 stride  = res->stride;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13483,6 +13483,21 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             bool instance_vfetch = false;
             bool folded_vfetch = false; // by-fetch V# base already includes OFFSET/SOFFSET
             const ShaderResource* resolved_buffer = nullptr;
+            // Per-site buffer-op disposition (PROSPER_DBG). A buffer op that resolves a
+            // NUM_RECORDS=0 descriptor folds to zero (loads) or drops (stores) and emits NO memory
+            // access at all. That is architecturally correct for an empty descriptor, but in the
+            // emitted module it is INDISTINGUISHABLE from an op that was never decoded — both leave
+            // no trace. Offline dissection of a program whose buffer traffic has vanished therefore
+            // cannot tell "folded because the descriptor is empty" from "never reached the emitter",
+            // and those two have completely different causes. This line separates them.
+            const auto buf_op_disposition = [&](const char* how) {
+                if (!std::getenv("PROSPER_DBG")) return;
+                std::fprintf(stderr,
+                             "[buf-op] program=0x%llx pc=%u %s op=0x%x n=%u store=%d atomic=%d %s\n",
+                             (unsigned long long)b.diagnostic.program_address, in.pc,
+                             in.fmt == Rdna2Format::MUBUF ? "MUBUF" : "MTBUF",
+                             in.opcode, n, (int)is_store, (int)is_atomic, how);
+            };
             bool gta5_selected_sbuffer_consumer = false;
             bool indirect_pointer_descriptor_source = false;
             if (is_format) {
@@ -13576,6 +13591,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     ok = false; return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
+                    buf_op_disposition("zero-record");
                     // The exact live V# is empty. The producer admitted only selectors whose OOB
                     // result is zero; re-check that contract so a malformed table cannot silently
                     // turn SQ_SEL_1 into zero. Apply the result only to active EXEC lanes, preserving
@@ -13591,6 +13607,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     return true;
                 }
+                buf_op_disposition("emitted");
                 resolved_buffer = res;
                 binding = res->binding;
                 stride = res->stride;
@@ -13747,6 +13764,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
+                    buf_op_disposition("zero-record");
                     // The front half proved all four live V# words at this exact instruction and
                     // decoded NUM_RECORDS=0. RDNA2's OOB contract returns zero for every raw load
                     // component, drops raw stores, and performs no memory operation for an atomic.
@@ -13791,6 +13809,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                     gta5_selected_sbuffer_consumer = true;
                 }
+                buf_op_disposition("emitted");
                 resolved_buffer = res;
                 binding = res->binding;
                 stride  = res->stride;

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13458,12 +13458,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     b.indirect_buffer_atomic_binding == UINT32_MAX ||
                     b.indirect_buffer_atomic_byte_offset != offset ||
                     (offset & 7u) != 0u) {
+                    buf_op.how = "reject-packed-pointer-atomic";
                     ok = false;
                     return true;
                 }
                 const auto lo = rs.vreg.find(in.dst.value);
                 const auto hi = rs.vreg.find(in.dst.value + 1);
                 if (lo == rs.vreg.end() || hi == rs.vreg.end()) {
+                    buf_op.how = "reject-packed-pointer-atomic";
                     ok = false;
                     return true;
                 }
@@ -13472,6 +13474,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 (void)b.cbuf_atomic_x2_rtn(
                     Op_AtomicOr, b.uconst(offset / 8u), value,
                     b.indirect_buffer_atomic_binding, access, b.uconst64(0u));
+                buf_op.how = "packed-pointer-atomic";
                 return true;
             }
             // PC-relative EMBEDDED TABLE (#273): this load's V# was built from s_getpc_b64 and the

--- a/prosper/src/gpu/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/rdna2_to_spirv.cpp
@@ -13418,7 +13418,19 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // nothing — so a census can detect its own incompleteness instead of silently
             // under-counting, which a per-site call cannot do. The three pre-switch rejects above are
             // deliberately outside it: they set ok=false, and a rejected program is already reported
-            // by the recompile-reject census.
+            // by the recompile-reject census -- as is the switch's own `default:` arm, which is
+            // also above this point. That is FOUR uncovered rejects, not three, and the `default:`
+            // one matters most to a census: an unmodelled buffer opcode is literally the "never
+            // reached the emitter" case this line exists to identify. So the tempting identity
+            // "instructions in the stream == lines emitted" holds only for a program with none of
+            // the four; it happened to hold for 0x413dc6700 (41 == 41) and that is not a guarantee.
+            // Hoisting the guard above the switch is not the fix: n/is_store/is_atomic are unset
+            // there, so it would print `n=0 store=0 atomic=0`, which is less honest than no line.
+            //
+            // `rt=` is on the line because `unclassified` alone does not mean "instrument hole".
+            // recompile_coverage() translates on a table-less compute shell, so every buffer op it
+            // sees takes a no-table path and prints `unclassified` for a reason that has nothing to
+            // do with coverage. `rt=0` marks those. A hole is `rt=1 ... unclassified`.
             struct BufOpDisposition {
                 bool on;
                 const SpirvCompute& b;
@@ -13426,16 +13438,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const uint32_t& n;
                 const bool& is_store;
                 const bool& is_atomic;
+                const ShaderResourceTable* rt;
                 const char* how = "unclassified";
                 ~BufOpDisposition() {
                     if (!on) return;
                     std::fprintf(stderr,
-                                 "[buf-op] program=0x%llx pc=%u %s op=0x%x n=%u store=%d atomic=%d %s\n",
+                                 "[buf-op] program=0x%llx pc=%u %s op=0x%x n=%u store=%d atomic=%d rt=%d %s\n",
                                  (unsigned long long)b.diagnostic.program_address, in.pc,
                                  in.fmt == Rdna2Format::MUBUF ? "MUBUF" : "MTBUF", in.opcode, n,
-                                 (int)is_store, (int)is_atomic, how);
+                                 (int)is_store, (int)is_atomic, (int)(rt != nullptr), how);
                 }
-            } buf_op{std::getenv("PROSPER_DBG") != nullptr, b, in, n, is_store, is_atomic};
+            } buf_op{std::getenv("PROSPER_DBG") != nullptr, b, in, n, is_store, is_atomic, rt};
             uint32_t offset = in.literal & 0xFFFu;
             bool offen = (in.literal >> 12) & 1u, idxen = (in.literal >> 13) & 1u;
             const bool indirect_pointer_descriptor_source_candidate =
@@ -13507,7 +13520,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // bindings. Only external buffer accesses require the stage's SMEM/MUBUF resource gate.
             // Keep this check after the fold so resource-free graphics shaders (Astro Bot's loading VS)
             // can consume their embedded lookup table without making unresolved V# accesses permissive.
-            if (!allow_smem) { ok = false; return true; }
+            if (!allow_smem) { buf_op.how = "reject-no-smem"; ok = false; return true; }
             uint32_t binding = 2, stride = 0;   // overwritten by SRSRC resolution below whenever a resource
                                                 // table is present (format AND raw ops); the binding-2 default
                                                 // survives only on the table-less offline path (see below)
@@ -13610,6 +13623,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                 !rt ? "no-table" : (tagged_res ? "yes" : "null"),
                                 rt ? rt->resources.size() : 0u);
                     }
+                    buf_op.how = "reject-unresolved";
                     ok = false; return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
@@ -13671,6 +13685,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                                 pp ? "yes" : "null",
                                 sreg_range_written(rs, in.src[1].value, 4), rt->resources.size());
                     }
+                    buf_op.how = "reject-raw-unresolved";
                     ok = false; return true;   // unresolvable V# -> reject; NEVER default to binding 2
                 }
                 if (indirect_pointer_descriptor_source_candidate) {
@@ -13794,6 +13809,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     return true;
                 }
                 if (is_zero_record_raw_buffer(*res)) {
+                    // Safe at the TOP here, unlike the format path: none of this block's three arms
+                    // (atomic, store-drop, load-fold) sets ok=false, so no later outcome can
+                    // contradict the label. A fail-visible guard added below must move this down.
                     buf_op.how = "zero-record";
                     // The front half proved all four live V# words at this exact instruction and
                     // decoded NUM_RECORDS=0. RDNA2's OOB contract returns zero for every raw load


### PR DESCRIPTION
## What this adds

A `PROSPER_DBG`-gated line reporting the disposition of every buffer op the MUBUF/MTBUF handler sees:

```
[buf-op] program=0x413dc6700 pc=91 MUBUF op=0xc n=1 store=0 atomic=0 zero-record
```

## Why

A buffer op whose V# decodes to `NUM_RECORDS=0` — or that matches one of the no-backing markers in
the same handler — is folded away: loads become a constant, stores are dropped, and the path
deliberately **never declares a backing buffer**. That is correct for an empty descriptor.

It is also, in the emitted SPIR-V, **indistinguishable from an instruction that never reached the
emitter**. Both leave no `OpAccessChain`, no `OpLoad`, no trace. One is a resource-state question and
the other a translation bug, and nothing offline could tell them apart.

That ambiguity produced a wrong conclusion and nearly a wrong roadmap. Investigating GTA V's
`0x413dc6700` (#2709), the emitted module has exactly **one** storage-buffer access chain for **41**
MUBUF sites — verified exhaustively, since across every op in the module only `OpVariable` and one
`OpAccessChain` yield a `StorageBuffer` pointer. That was read as evidence the recompiler could not
express the loads, and an argument for adding `VK_KHR_buffer_device_address` / `PhysicalStorageBuffer`
("substantial, touches every compute shader") was built on it. One offline run with this line says
which case it is — all 41 fold — and a live census then showed **75% of that program's 14,432 folds
resolve concrete descriptors with real extents**. The front half was working the whole time.

## Reported from a scope guard, and why that matters

Not a call at each decision site. A guard whose destructor reports means **every exit path emits
exactly one line**, and a path nobody classified prints `unclassified` instead of printing nothing.

That is the property a per-site call cannot have, and it is not hypothetical — it is what the first
version of this PR got wrong. Review found five further sites that decide a disposition, emit no
memory access, and return with no line: the PC-relative table fold, and the `cf9200-no-backing`,
`proven-null-nullable`, `optional-null-load` and `null-guarded-store` markers. Four are GTA V paths,
i.e. the exact title the instrument was built for. A census would have under-counted in silence.

Every site now names its outcome, **rejects included** — the first version printed `zero-record` at
the top of the format-path block, *above* two terminal rejects, so a format store against an empty V#
was labelled a legal fold when nothing was folded.

`emitted` is renamed `resolved`: it means a descriptor was resolved, not that a memory access survived
the ten later reject sites in the handler.

## Scope

Diagnostic only: gated on `PROSPER_DBG` (nothing on a default run), reads no lowering decision, and
changes none. Not on a hot path — this is `emit_alu` at recompile time behind `shader_cache()`, not
the per-draw pattern #2214/#2228 addressed.

Deliberately outside the guard: the three pre-switch rejects (`lds`, `tfe`, MTBUF D16). They set
`ok = false`, and a rejected program is already reported by the recompile-reject census.

Not de-duplicated: the useful form is a per-dispatch census, and collapsing repeats would destroy the
multiplicity that showed all 7 dispatch tables in the captured submit agreed.

## Verification

Exact head `03fe0c79`, Linux, in-distrobox build.

- Build: clean, **0 errors**.
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0 (`Total Test time (real) = 18.51 sec`).
- Instrument audit, old version vs this one, over the same captured submit:

```
old: 14304 lines
new: 14321 lines   = 9045 zero-record + 5259 resolved + 14 optional-null-load + 3 proven-null-nullable
unclassified: 0
```

The 17-line difference is exactly the `optional-null-load` and `proven-null-nullable` dispositions
that were previously invisible — so review finding 2 is confirmed by measurement, not just accepted.
`0x413dc6700` still reports 41 distinct pcs, all `zero-record`; the finding reproduces unchanged.

No unit test accompanies this. The change is one `fprintf` behind a `getenv`; what would matter — that
a fold is reported as a fold and an unclassified path is visibly unclassified — is the audit above,
taken on a real captured submit through `gpu_replay --recompile-raw --inspect-only`, where every count
is falsifiable and was cross-checked independently against the guest instruction stream and the
emitted SPIR-V.

A second captured submit — one taken **past** the startup boundary, so all 41 sites resolve real
descriptors — audits as `743 resolved, 105 zero-record, 30 cf9200-no-backing, 3 null-guarded-store,
1 packed-pointer-atomic`, every line `rt=1`, `unclassified` **0**.

## Review history

Two rounds.

**Round 1 — REJECTED**, two blocking findings, both real, both verified against the source before
acting: the format-path line printed *above* two terminal rejects (so a format store against an empty
V# was labelled a legal fold), and five further sites decided a disposition and returned with no line
at all. Rather than patch the two sites, reporting moved to a scope guard — which is what gives the
instrument the property that it can detect its own incompleteness.

That paid immediately: the guard's own `unclassified` flagged the GTA V packed-pointer atomic on a
capture the reviewer had not seen — the one site a per-site call could never have covered, because the
old lambda was defined below it.

**Round 2 — APPROVED**, with non-blocking findings, all of which are now fixed:

- `unclassified` conflated three populations. `recompile_coverage()` translates on a table-less
  compute shell and runs on the failed-draw path and at F9 capture, so on a live `PROSPER_DBG` run
  `unclassified` would be non-zero for reasons unrelated to coverage — meaning `unclassified: 0` was a
  property of the offline route, not of the instrument. The line now carries `rt=`, which separates
  the two in one field, and the five deliberate in-handler rejects now name themselves.
- The comment said **three** pre-switch rejects escape the guard. There are **four** — the switch's
  `default:` arm is above it too, and it is the most census-relevant of them. So "instructions in the
  stream == lines emitted" held for `0x413dc6700` (41 == 41) by luck rather than by construction, and
  the comment now says so.
- Recorded why the raw path's `zero-record` is safe at the top of its block while the format path's
  had to move to the bottom.

The reviewer also verified capture/lifetime, format-string types, aggregate-init validity under C++20,
unwinding behavior and cost, and confirmed no path downstream of `resolved` returns without emitting
memory — which saved re-deriving them.

Refs #2709.
