### PR TITLE
docs(gta5): the first 88 folds see an empty SRT — and the capture trap that produced a wrong root cause

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4919,8 +4919,9 @@ resolved folds split into two orientations, and only `s4` is fixed:
 | `s16` | 4 | 8252 | `0x20f8482140` | `0x20f849233c` |
 | `s12` | 4 | 8252 | `0x20f849233c` | `0x20f8482140` |
 
-The two input/output pairs **swap** between orientations, and they do so in strict alternation — the
-resolved folds read ABABAB... in a period-11 pattern of 6 A to 5 B, i.e. exactly 24 x (6,5) = 144 / 120.
+The two input/output pairs **swap** between orientations, and they do so in a fixed repeating pattern —
+the resolved folds are one 11-fold block of 6 A and 5 B repeated 24 times, i.e. exactly 24 x (6,5) =
+144 / 120. It is not a strict A-B alternation: each period carries one A-A seam.
 That is the double-buffering `### The writer is the CONSUMER ITSELF` (above) documents, seen from the
 register side. Reading either column as "the" mapping is exactly the cross-dispatch attribution error
 that produced the retracted cyclic-table root cause.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4144,9 +4144,11 @@ falsification.
   `StorageBuffer` pointer. The inference from that was wrong, because **a legal `NUM_RECORDS=0` fold
   and a never-decoded instruction leave identical evidence**: both leave no access chain, no load, no
   trace at all. This was the fold. The `[buf-op]` disposition line (#2712) says which — all 41 sites,
-  `zero-record` — and a live `[dyntrace]` census over 14,432 folds then showed **10,824 (75%) resolve
-  concrete descriptors with real extents**, the five bases matching the five SRT pointer slots exactly.
-  `pc91` itself resolves a real V# in **264 of 352** folds. Nothing about this program requires
+  `zero-record` — and a live `[dyntrace]` census over **352 program folds** (14,432 buffer-op *site*
+  observations: 352 folds x 41 MUBUF sites) then showed **10,824 of those site observations resolve
+  concrete descriptors with real extents against 3,608 zero-record**. Per fold the split is clean:
+  `pc91` resolves a real V# in **264 of 352** folds and is zero-record in the other 88. Quoting 14,432
+  as a fold count conflates the two units and does not survive comparison with any dispatch count. Nothing about this program requires
   address-based memory access; the translated-guest-address work in #2711 Q3 stands on its own merits
   and must not be justified by this program. #2709, #2712.
 
@@ -4869,14 +4871,19 @@ out of that table at `+0x18/+0x20/+0x28/+0x30/+0x50` and builds all five of its 
 
 For the program's first **88** folds those five slots read zero, so every V# decodes
 `{base=0, stride=<immediate>, NUM_RECORDS=0}` and all 41 of its buffer ops fold: 18 loads (49 dwords)
-to a constant zero, 23 stores (41 dwords) dropped, **no memory access emitted at all**. After fold 88
+to a constant zero, 23 stores (41 dwords) dropped — **none of the 41 MUBUF sites emits a memory
+access**. (The module is not access-free: it retains exactly one `StorageBuffer` access chain, from a
+non-MUBUF path.) After fold 88
 every fold resolves real descriptors. Measured in two runs whose submit numbering otherwise differs,
 and the boundary is **deterministic** in both: 3,608 zero-record folds (= 88 folds x 41 sites),
 contiguous at the very start, then none.
 
 `PROSPER_COMPUTE_MEMPROBE=413dc6700:0:0:40` dumps that table and confirms both states are genuine: the
 bytes are **unchanged between its two sample points** for the empty ones too, so those dispatches are
-really handed an empty table rather than read too early. This is startup, not a defect.
+really handed an empty table rather than read too early — a genuine empty-SRT input state, not a
+fold-time staleness artifact. That is what refutes the emitter-drop reading; it is **not** by itself
+proof that no producer is missing, so the supported claim is "a startup phase, and not evidence of a
+recompiler defect", not "not a defect".
 
 **The capture trap this creates, which cost this investigation a night.**
 `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires on the *first* submit containing the program — inside the
@@ -4900,18 +4907,26 @@ result.
 ### What the program is, from its resolved descriptors
 
 Every one of the five buffers carries **2063 records**, and the dispatch is `groups=9x1x1
-local=256x1x1` = 2304 threads:
+local=256x1x1` = 2304 threads. **The register→base assignment is NOT stable across folds** — the 264
+resolved folds split into two orientations, and only `s4` is fixed:
 
-| SGPR | base | stride | size | role |
-| --- | --- | ---: | ---: | --- |
-| `s4` | `0x209cc76000` | 64 | 132032 | the entity records — read (13 loads) **and** written (10 stores) |
-| `s0` | `0x20f848417c` | 4 | 8252 | per-entity u32, read-only |
-| `s16` | `0x20f8482140` | 4 | 8252 | per-entity u32, read-only |
-| `s8` | `0x20f848a240` | 4 | 8252 | per-entity u32, write-only |
-| `s12` | `0x20f849233c` | 4 | 8252 | per-entity u32, write-only |
+| SGPR | stride | size | 144 folds | 120 folds |
+| --- | ---: | ---: | --- | --- |
+| `s4` | 64 | 132032 | `0x209cc76000` | `0x209cc76000` (stable) |
+| `s0` | 4 | 8252 | `0x20f848417c` | `0x20f848a240` |
+| `s8` | 4 | 8252 | `0x20f848a240` | `0x20f848417c` |
+| `s16` | 4 | 8252 | `0x20f8482140` | `0x20f849233c` |
+| `s12` | 4 | 8252 | `0x20f849233c` | `0x20f8482140` |
 
-2063 entities with a 64-byte record each, two per-entity input arrays and two output arrays: a scene
-traversal / visibility pass, consistent with this program gating world content.
+The two input/output pairs **swap** between orientations — which is the double-buffering the retraction
+below describes, seen from the register side. Reading either column as "the" mapping is exactly the
+cross-dispatch attribution error that produced the retracted cyclic-table root cause.
+
+What the shape establishes: a **2063-record, per-item read/modify/write or traversal-shaped pass** — one
+64-byte record per item read and written, plus two u32 inputs and two u32 outputs per item. It is
+*consistent with* a scene traversal / visibility pass, and that is a **hypothesis, not a finding**: the
+descriptor shape does not identify the records as entities, does not identify the shader as visibility,
+and does not establish that it gates world content.
 
 **Read the cyclic-table retraction below before using any base address in that table.** Those are the
 bases resolved across a *whole run*, not one dispatch's. This program runs many times per submit with

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4136,6 +4136,20 @@ One line per falsified hypothesis, the evidence that killed it, and where. **Rea
 a new one** — and note which entries are *solid* versus *void*, because a void result is not a
 falsification.
 
+- **`0x413dc6700` computes on zeros because prosper cannot express its pointer-chase load, so GTA V's
+  world needs `PhysicalStorageBuffer` / `VK_KHR_buffer_device_address`.** *Solid.* Filed as #2709 and
+  argued further in its comments; also carried into #2711's Q1/Q2 answers as a premise. The emitted
+  SPIR-V really does contain **one** storage-buffer access chain for **41** MUBUF sites — verified
+  exhaustively, since across every op in the module only `OpVariable` and one `OpAccessChain` yield a
+  `StorageBuffer` pointer. The inference from that was wrong, because **a legal `NUM_RECORDS=0` fold
+  and a never-decoded instruction leave identical evidence**: both leave no access chain, no load, no
+  trace at all. This was the fold. The `[buf-op]` disposition line (#2712) says which — all 41 sites,
+  `zero-record` — and a live `[dyntrace]` census over 14,432 folds then showed **10,824 (75%) resolve
+  concrete descriptors with real extents**, the five bases matching the five SRT pointer slots exactly.
+  `pc91` itself resolves a real V# in **264 of 352** folds. Nothing about this program requires
+  address-based memory access; the translated-guest-address work in #2711 Q3 stands on its own merits
+  and must not be justified by this program. #2709, #2712.
+
 - **Sampled-depth invalidation is starving the deferred-lighting pass.** *Solid.* The lighting pass
   does read the scene depth `0x2052ac0000` through the bridge, and that bridge did decline — 826 times
   on `depth-invalid` — so the hypothesis was well-founded. It is still wrong. 730 of the 900
@@ -4848,6 +4862,63 @@ The pointer-chase loop is now *less* likely to be the hang: it is one of three d
 module, and it is the one just shown to be bounded at 11 iterations on the hanging dispatch's own
 data. The other two are unexamined.
 
+## The first 88 folds see an EMPTY SRT — and a capture taken during them is unrepresentative
+
+`0x413dc6700` declares **2 user SGPRs**: one SRT pointer, nothing else. It loads five 64-bit pointers
+out of that table at `+0x18/+0x20/+0x28/+0x30/+0x50` and builds all five of its V#s from them.
+
+For the program's first **88** folds those five slots read zero, so every V# decodes
+`{base=0, stride=<immediate>, NUM_RECORDS=0}` and all 41 of its buffer ops fold: 18 loads (49 dwords)
+to a constant zero, 23 stores (41 dwords) dropped, **no memory access emitted at all**. After fold 88
+every fold resolves real descriptors. Measured in two runs whose submit numbering otherwise differs,
+and the boundary is **deterministic** in both: 3,608 zero-record folds (= 88 folds x 41 sites),
+contiguous at the very start, then none.
+
+`PROSPER_COMPUTE_MEMPROBE=413dc6700:0:0:40` dumps that table and confirms both states are genuine: the
+bytes are **unchanged between its two sample points** for the empty ones too, so those dispatches are
+really handed an empty table rather than read too early. This is startup, not a defect.
+
+**The capture trap this creates, which cost this investigation a night.**
+`PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires on the *first* submit containing the program — inside the
+startup window. A capture taken that way has all-empty descriptors, emits almost no memory traffic,
+replays with **zero** device losses, and reads as a program that does nothing on purpose. Which is
+exactly how the "prosper drops this program's entire memory interface" claim in the Ruled-out section
+above was reached. To get a representative submit, enumerate first:
+
+```
+PROSPER_GPU_CAPTURE=<path> PROSPER_GPU_CAPTURE_COMPUTE_ADDR=0x413dc6700 \
+PROSPER_GPU_CAPTURE_AT=99999 PROSPER_GPU_CAPTURE_LOG=1
+```
+
+`AT` beyond every candidate prints `[gpucap] candidate at=N submit=M ...` for each match and captures
+none; pick a later `at=` on the next run. **The at->submit mapping is not stable across runs** —
+capture overhead shifts it, so the index that coincided with the losing submit in one run will not in
+the next (measured: the loss landed on `at=2`'s submit in one run and ~400 submits past the captured
+one in the next). The capture is also pre-submit, so it holds the *inputs* to the submit, not its
+result.
+
+### What the program is, from its resolved descriptors
+
+Every one of the five buffers carries **2063 records**, and the dispatch is `groups=9x1x1
+local=256x1x1` = 2304 threads:
+
+| SGPR | base | stride | size | role |
+| --- | --- | ---: | ---: | --- |
+| `s4` | `0x209cc76000` | 64 | 132032 | the entity records — read (13 loads) **and** written (10 stores) |
+| `s0` | `0x20f848417c` | 4 | 8252 | per-entity u32, read-only |
+| `s16` | `0x20f8482140` | 4 | 8252 | per-entity u32, read-only |
+| `s8` | `0x20f848a240` | 4 | 8252 | per-entity u32, write-only |
+| `s12` | `0x20f849233c` | 4 | 8252 | per-entity u32, write-only |
+
+2063 entities with a 64-byte record each, two per-entity input arrays and two output arrays: a scene
+traversal / visibility pass, consistent with this program gating world content.
+
+**Read the cyclic-table retraction below before using any base address in that table.** Those are the
+bases resolved across a *whole run*, not one dispatch's. This program runs many times per submit with
+**different tables**, and attributing one dispatch's buffer to another is precisely the error that
+produced the retracted cyclic-table root cause. Re-deriving the link graph from `0x20f848417c` and
+finding it acyclic reproduces the *succeeding* dispatch's measurement, not the hanging one's.
+
 ## Other open defects
 
 - **#2445** — specific lowercase glyphs (`r`, `s`, `m`) dropped from UI text: "Ente ing Sto y Mode".
@@ -4861,6 +4932,24 @@ data. The other two are unexamined.
 
 ## Instruments worth knowing about here
 
+- **`[buf-op]` (`PROSPER_DBG`)** — the disposition of every buffer op the MUBUF/MTBUF handler sees:
+  `[buf-op] program=0x... pc=91 MUBUF op=0xc n=1 store=0 atomic=0 rt=1 zero-record`. It exists because
+  a **legal `NUM_RECORDS=0` fold and an instruction that never reached the emitter leave identical
+  evidence** in emitted SPIR-V — no access chain, no load, no trace — and telling them apart decides
+  whether a program with no memory traffic is a resource-state question or a translation bug. Reported
+  from a scope guard, so **every** exit path emits exactly one line and an unlabelled path prints
+  `unclassified` rather than nothing; that is what lets a census detect its own incompleteness. `rt=0`
+  marks `recompile_coverage()`'s table-less shell (it runs on the failed-draw path and at F9 capture),
+  so a genuine hole is `rt=1 ... unclassified`. Four rejects sit above the guard by design — `lds`,
+  `tfe`, MTBUF D16, and the opcode switch's `default:` — so "instructions in the stream == lines
+  emitted" is not an identity; it happened to hold for `0x413dc6700` (41 == 41). #2712.
+- **`[dyntrace]` + `PROSPER_DYNTRACE_ADDR` / `_ONCE`** — the live V# each MUBUF resolves, at fold time.
+  This is the only way to see what the front half actually built: the fold is **not** re-run during
+  offline replay (the resource table is replayed from the capture, so markers are baked in), so a
+  question about descriptor resolution cannot be answered from a `.prgcap` alone. Use `_ONCE` for one
+  fold, and **drop it when the question is about variation across dispatches** — a single traced fold
+  told this investigation all five pointers were null, which was true of that fold and false of 75% of
+  the run.
 - **`PROSPER_COMPUTE_SKIP_PROGRAM=0xADDR[,...]`** — decline named compute programs. A bisection tool,
   not a workaround. It announces itself at parse time and reports each skip through the decline census
   as `reason=skipped-by-selector`, so a diagnostic run can never be mistaken for a default one later.

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4875,8 +4875,9 @@ to a constant zero, 23 stores (41 dwords) dropped — **none of the 41 MUBUF sit
 access**. (The module is not access-free: it retains exactly one `StorageBuffer` access chain, from a
 non-MUBUF path.) After fold 88
 every fold resolves real descriptors. Measured in two runs whose submit numbering otherwise differs,
-and the boundary is **deterministic** in both: 3,608 zero-record folds (= 88 folds x 41 sites),
-contiguous at the very start, then none.
+and the boundary is **deterministic** in both: **88 zero-record folds** (3,608 buffer-op site
+observations = 88 folds x 41 sites), contiguous from fold 0, then none. No fold mixes the two states —
+0 of 352 are mixed — which is what makes 88 x 41 and 264 x 41 identities rather than coincidences.
 
 `PROSPER_COMPUTE_MEMPROBE=413dc6700:0:0:40` dumps that table and confirms both states are genuine: the
 bytes are **unchanged between its two sample points** for the empty ones too, so those dispatches are
@@ -4904,7 +4905,7 @@ the next (measured: the loss landed on `at=2`'s submit in one run and ~400 submi
 one in the next). The capture is also pre-submit, so it holds the *inputs* to the submit, not its
 result.
 
-### What the program is, from its resolved descriptors
+### What the descriptor shape establishes — and what it does not
 
 Every one of the five buffers carries **2063 records**, and the dispatch is `groups=9x1x1
 local=256x1x1` = 2304 threads. **The register→base assignment is NOT stable across folds** — the 264
@@ -4918,9 +4919,11 @@ resolved folds split into two orientations, and only `s4` is fixed:
 | `s16` | 4 | 8252 | `0x20f8482140` | `0x20f849233c` |
 | `s12` | 4 | 8252 | `0x20f849233c` | `0x20f8482140` |
 
-The two input/output pairs **swap** between orientations — which is the double-buffering the retraction
-below describes, seen from the register side. Reading either column as "the" mapping is exactly the
-cross-dispatch attribution error that produced the retracted cyclic-table root cause.
+The two input/output pairs **swap** between orientations, and they do so in strict alternation — the
+resolved folds read ABABAB... in a period-11 pattern of 6 A to 5 B, i.e. exactly 24 x (6,5) = 144 / 120.
+That is the double-buffering `### The writer is the CONSUMER ITSELF` (above) documents, seen from the
+register side. Reading either column as "the" mapping is exactly the cross-dispatch attribution error
+that produced the retracted cyclic-table root cause.
 
 What the shape establishes: a **2063-record, per-item read/modify/write or traversal-shaped pass** — one
 64-byte record per item read and written, plus two u32 inputs and two u32 outputs per item. It is
@@ -4928,7 +4931,8 @@ What the shape establishes: a **2063-record, per-item read/modify/write or trave
 descriptor shape does not identify the records as entities, does not identify the shader as visibility,
 and does not establish that it gates world content.
 
-**Read the cyclic-table retraction below before using any base address in that table.** Those are the
+**Read `## RETRACTED: the cyclic-table root cause` (above) before using any base address in that
+table.** Those are the
 bases resolved across a *whole run*, not one dispatch's. This program runs many times per submit with
 **different tables**, and attributing one dispatch's buffer to another is precisely the error that
 produced the retracted cyclic-table root cause. Re-deriving the link graph from `0x20f848417c` and


### PR DESCRIPTION
Docs-only. `git diff --name-only origin/master...HEAD | grep -v '\.md$'` is empty.

## What this records

Three measurements, plus the trap that produced a wrong root cause along the way.

**1. The startup boundary.** `0x413dc6700` declares **2 user SGPRs** — one SRT pointer — and builds all
five of its V#s from five 64-bit pointers in that table (`+0x18/+0x20/+0x28/+0x30/+0x50`). For the
program's first **88 folds** those slots read zero, so every V# decodes `NUM_RECORDS=0` and all 41 of its
MUBUF sites fold: 18 loads (49 dwords) to a constant, 23 stores (41 dwords) dropped. After fold 88 every
fold resolves real descriptors.

Units matter here and the first revision of this PR got them wrong: the census is **352 program folds**,
i.e. **14,432 buffer-op site observations** (352 x 41 MUBUF sites). 10,824 resolved and 3,608
zero-record are likewise *site* observations; the per-fold split is 264 resolved / 88 zero-record for
`pc91`. Deterministic across two runs, and **0 of 352 folds mix the two states**, which is what makes
88 x 41 and 264 x 41 identities rather than coincidences.

`PROSPER_COMPUTE_MEMPROBE` confirms both states are genuine: the bytes are unchanged between its two
sample points for the empty ones too. That rules out **fold-time staleness** specifically — which is
what refutes the emitter-drop reading. It is *not* proof that no producer is missing, so the supported
claim is "a startup phase, and not evidence of a recompiler defect".

**2. The capture trap, which is the load-bearing part.** `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` fires on the
*first* submit containing the program — inside that window. Such a capture has all-empty descriptors,
emits almost no memory traffic, replays with **zero** device losses, and reads as a program that
deliberately does nothing.

That is how "prosper drops this program's entire memory interface, so GTA V's world needs
`PhysicalStorageBuffer`" (#2709) was reached. It is wrong: **75% of the site observations resolve
concrete descriptors with real extents**, and `pc91` — the pointer-chase load that issue was filed about
— resolves a real V# in **264 of 352 folds**. Recorded as a `## Ruled out` entry with the enumeration
recipe (`PROSPER_GPU_CAPTURE_AT=99999` + `_LOG=1` lists candidates and captures none), including the
warning that the `at`→submit mapping is **not stable across runs**.

**3. What the descriptor shape establishes — and what it does not.** All five buffers carry **2063
records**; the dispatch is `9x1x1 x 256x1x1` = 2304 threads. The register→base assignment is **not
stable**: the 264 resolved folds split **144 / 120** between two orientations in which the input and
output pairs swap (`s0`↔`s8`, `s16`↔`s12`), with only `s4` fixed — and they alternate strictly, in a
period-11 6:5 pattern that is exactly 24 x (6,5). Both columns are shown with their counts, because
reading either as "the" mapping is the cross-dispatch attribution error that produced the retracted
cyclic-table root cause.

The shape establishes a **2063-record per-item read/modify/write or traversal-shaped pass**. It is
*consistent with* a scene traversal / visibility pass — stated as a **hypothesis**, since the descriptor
shape does not identify the records as entities, does not identify the shader as visibility, and does
not establish that it gates world content.

## Instruments documented

- **`[buf-op]`** (#2712) — why it exists (a legal `NUM_RECORDS=0` fold and a never-decoded instruction
  leave identical evidence in emitted SPIR-V), what `rt=` separates, and that four rejects sit above the
  scope guard so "instructions in the stream == lines emitted" is not an identity.
- **`[dyntrace]`** — that the fold is **not** re-run during offline replay (the table is replayed from
  the capture), so a descriptor-resolution question cannot be answered from a `.prgcap` alone; and that
  `_ONCE` is the wrong tool when the question is about variation across dispatches.

## Review history

Two rounds, both **changes requested**, and both correct.

- **Round 1** — four findings: 14,432 used as a fold count when it is 352 folds x 41 sites; the
  SGPR→base table showing one of two orientations while calling it run-wide (the hazard that section
  exists to warn about); "no memory access emitted at all" contradicting the Ruled-out paragraph's
  exhaustively-verified surviving `StorageBuffer` access chain; and "startup, not a defect" claiming
  more than two deterministic phases establish.
- **Round 2** — three: the unit conflation survived in one sentence six lines from its corrected
  neighbour; **this PR body still carried all four original claims** (and becomes the squash-merge
  commit message); and both "below" cross-references pointed the wrong way, with the double-buffering
  evidence cited to the retraction rather than to `### The writer is the CONSUMER ITSELF`.

The second reviewer also re-derived every number from the retained logs rather than trusting the
recount, and found the support **stronger** than the section claimed: the 41-site fold chunking is
self-proving (one distinct pc-sequence over all 352 folds; `[dyntrace] SMEM` lines = 352 x 7), no fold
mixes dispositions, and the orientation alternation is exact.

## Verification

- `check_numbered_table.py` over the head file: **58 tables, 242 rows**, unbroken, exit 0.
- `git diff --check`: clean. No absolute host paths in any added line.
- Docs-only, so per the charter's docs exception this needs no CI wait; the numbering gate is the one
  check that could fail on this diff and it was run locally.

Refs #2542, #2709, #2711, #2712.
