### PR TITLE
hle(agc): implement the Jump-packet target patcher (Ikfdt-rIqCE) — GTA V's jump packets were folded with target=0

### DIFF
--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -3102,6 +3102,64 @@ HLE(agc_patch_release_mem_data) {
     return 0;
 }
 
+// libSceAgc::Ikfdt-rIqCE — the jump-target patcher: fill in a Jump packet's target and length.
+//
+//   Ikfdt-rIqCE(packet, cache_policy, target_addr, target_size_dwords)
+//
+// Argument roles come from the guest's own disassembly — five direct call sites reached through the
+// adapter at eboot+0x1df090, each forming rdi=packet, esi=cache policy (observed 0 and 2), rdx=target
+// command-buffer address, ecx=size in dwords — and are confirmed by the live values below.
+//
+// THE PACKET IS OURS, AND THAT MATTERS MORE THAN THE NAME. A public catalogue labels this NID
+// `sceAgcJumpPatchSetTarget`, but that literal string hashes to `2BS4EtAaF28` (the separate
+// three-argument 3.20 export), so this is documented under its NID as the extended/cache-policy form
+// until a matching SDK header settles the spelling.
+//
+// Kyty's handler for this same NID validates IT_INDIRECT_BUFFER and writes cmd[1] address-low
+// preserving low control bits, cmd[2] address-high, and cmd[3] as cache policy in bits 28..29 with
+// size in bits 0..19. **Copying that here would corrupt the stream.** prosper's sceAgcDcbJump does not
+// emit IT_INDIRECT_BUFFER; it emits this project's custom IT_NOP/R_JUMP, whose payload the decoder
+// reads as [1..2]=target lo/hi, [3]=dword COUNT, [4]=predicated flag (pm4_decode.cpp R_JUMP). Kyty's
+// cmd[3] store would therefore land a policy-packed value on top of the segment's dword count.
+//
+// So the shape was measured before anything was written. A routed run with a probe that reported the
+// header and patched nothing (PPSA04263, Linux) gave the same answer at every call site:
+//
+//   [agc] JumpPatchTarget PROBE #0 cmd=0x203dfc5eb0 hdr=0xc0031078 op=0x10 r=0x1e count=3
+//         shape=IT_NOP/R_JUMP(ours) payload=00000000,00000000,00000000,00000000
+//         | policy=0x2 target=0x203dfe0080 ndw=0x23c7 -- NOT patched
+//
+// Two things that log settles. The packet is **ours** (`op=0x10 IT_NOP`, `r=0x1e R_JUMP`), so the
+// layout below is the right one; and its payload arrives **all zero**, so the guest creates the Jump
+// empty and relies on this call to fill it. Without this handler prosper folded an R_JUMP with
+// target=0 and dword count=0 — a jump to nothing — which is exactly the "prosper can fold a command
+// graph different from the one the guest built" confounder (#2711 Q5).
+//
+// cmd[4] is deliberately NOT touched: predication is owned by sceAgcSetPacketPredication on this same
+// packet, and the composite segments this title jumps to are predicated (#319). Cache policy has no
+// field in the R_JUMP representation and prosper's own sceAgcDcbJump likewise records no policy, so it
+// is logged rather than stored — a slot invented for it here would be read by nothing.
+// CONFIDENCE: HIGH on the argument roles and the packet shape (both measured); MED on cache policy
+// being safely ignorable, which holds only while the decoder has no policy semantics.
+HLE(agc_jump_patch_target) {
+    auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
+    if (!patch_target_writable(a0, kDwJump * sizeof(uint32_t), "JumpPatchTarget")) return 0;
+    if (!patch_check(cmd, R_JUMP, "JumpPatchTarget")) return 0;
+    const uint32_t pre_lo = cmd[1], pre_hi = cmd[2], pre_ndw = cmd[3];
+    cmd[1] = (uint32_t)(a2 & 0xffffffffu);
+    cmd[2] = (uint32_t)(a2 >> 32u);
+    cmd[3] = (uint32_t)a3;
+    if (getenv("PROSPER_GFXLOG"))
+        // Print the PRE-patch payload next to the new one: a success line that only echoes its own
+        // argument cannot distinguish "patched" from "patched with what was already there", and here
+        // the pre-state is the evidence that the guest really did leave the packet empty.
+        fprintf(stderr, "[agc] JumpPatchTarget cmd=%p pre=(0x%08x%08x,ndw=%u) "
+                        "target=0x%llx ndw=%u policy=0x%llx\n",
+                (const void*)cmd, pre_hi, pre_lo, pre_ndw,
+                (unsigned long long)a2, (uint32_t)a3, (unsigned long long)a1);
+    return 0;
+}
+
 HLE(agc_dispatch_indirect_get_size)   { (void)a0; return kDwDispatchIndirect * 4u; }
 HLE(agc_dma_data_get_size)            { (void)a0; return kDwDmaData * 4u; }
 HLE(agc_event_write_get_size)         { (void)a0; return kDwEventWrite * 4u; }
@@ -3132,7 +3190,8 @@ void register_agc_hle() {
     RN("qMlfB1ZhMDc", agc_draw_index_offset_get_size);   // sceAgcDcbDrawIndexOffsetGetSize
     RN("mStuvI0zOtc", agc_draw_index_indirect_get_size); // sceAgcDcbDrawIndexIndirectGetSize
     RN("Abendgtz+3o", agc_dispatch_get_size);            // sceAgcCbDispatchGetSize
-    RN("MlEw1feXcjg", agc_patch_release_mem_data);       // ReleaseMem packet: set the data payload
+    RN("MlEw1feXcjg", agc_patch_release_mem_data);
+    RN("Ikfdt-rIqCE", agc_jump_patch_target);            // Jump packet: fill in target + dword count (#2711 Q5)       // ReleaseMem packet: set the data payload
     RN("w8HVkEeXPv8", agc_dispatch_indirect_get_size);   // sceAgcDcbDispatchIndirectGetSize
     RN("PxKWV2fVAps", agc_dispatch_indirect_get_size);   // sceAgcAcbDispatchIndirectGetSize
     RN("2ccJz9LQI+w", agc_dma_data_get_size);            // sceAgcDcbDmaDataGetSize

--- a/prosper/src/hle/hle_agc.cpp
+++ b/prosper/src/hle/hle_agc.cpp
@@ -3123,7 +3123,9 @@ HLE(agc_patch_release_mem_data) {
 // cmd[3] store would therefore land a policy-packed value on top of the segment's dword count.
 //
 // So the shape was measured before anything was written. A routed run with a probe that reported the
-// header and patched nothing (PPSA04263, Linux) gave the same answer at every call site:
+// header and patched nothing (PPSA04263, Linux) answered identically at 402 of 403 call sites. The
+// residual is one stable non-Jump header per run, refused rather than patched (#2715), so the
+// malformed-command-graph confounder is removed for the recognised 402 and NOT for that one:
 //
 //   [agc] JumpPatchTarget PROBE #0 cmd=0x203dfc5eb0 hdr=0xc0031078 op=0x10 r=0x1e count=3
 //         shape=IT_NOP/R_JUMP(ours) payload=00000000,00000000,00000000,00000000
@@ -3143,7 +3145,10 @@ HLE(agc_patch_release_mem_data) {
 // being safely ignorable, which holds only while the decoder has no policy semantics.
 HLE(agc_jump_patch_target) {
     auto* cmd = (uint32_t*)(uintptr_t)a0; if (!cmd) return 0;
-    if (!patch_target_writable(a0, kDwJump * sizeof(uint32_t), "JumpPatchTarget")) return 0;
+    // FOUR dwords, not kDwJump: this handler reads cmd[0] and writes cmd[1..3], and the span contract
+    // above is the dwords each handler actually TOUCHES rather than the packet's nominal length.
+    // cmd[4] is deliberately outside it -- predication belongs to sceAgcSetPacketPredication.
+    if (!patch_target_writable(a0, 4u * sizeof(uint32_t), "JumpPatchTarget")) return 0;
     if (!patch_check(cmd, R_JUMP, "JumpPatchTarget")) return 0;
     const uint32_t pre_lo = cmd[1], pre_hi = cmd[2], pre_ndw = cmd[3];
     cmd[1] = (uint32_t)(a2 & 0xffffffffu);
@@ -3190,8 +3195,8 @@ void register_agc_hle() {
     RN("qMlfB1ZhMDc", agc_draw_index_offset_get_size);   // sceAgcDcbDrawIndexOffsetGetSize
     RN("mStuvI0zOtc", agc_draw_index_indirect_get_size); // sceAgcDcbDrawIndexIndirectGetSize
     RN("Abendgtz+3o", agc_dispatch_get_size);            // sceAgcCbDispatchGetSize
-    RN("MlEw1feXcjg", agc_patch_release_mem_data);
-    RN("Ikfdt-rIqCE", agc_jump_patch_target);            // Jump packet: fill in target + dword count (#2711 Q5)       // ReleaseMem packet: set the data payload
+    RN("MlEw1feXcjg", agc_patch_release_mem_data);      // ReleaseMem packet: set the data payload
+    RN("Ikfdt-rIqCE", agc_jump_patch_target);            // Jump packet: fill in target + dword count (#2711 Q5)
     RN("w8HVkEeXPv8", agc_dispatch_indirect_get_size);   // sceAgcDcbDispatchIndirectGetSize
     RN("PxKWV2fVAps", agc_dispatch_indirect_get_size);   // sceAgcAcbDispatchIndirectGetSize
     RN("2ccJz9LQI+w", agc_dma_data_get_size);            // sceAgcDcbDmaDataGetSize

--- a/prosper/tests/test_agc_dcb.cpp
+++ b/prosper/tests/test_agc_dcb.cpp
@@ -34,7 +34,7 @@ constexpr uint32_t IT_NOP = 0x10, IT_NUM_INSTANCES = 0x2F, IT_SET_CONTEXT_REG = 
                    IT_SET_SH_REG = 0x76, IT_SET_UCONFIG_REG = 0x79,
                    R_DRAW_RESET = 0x05, R_PUSH_MARKER = 0x0b, R_POP_MARKER = 0x0c,
                    R_SH_REGS_INDIRECT = 0x11, R_CX_REGS_INDIRECT = 0x12,
-                   R_UC_REGS_INDIRECT = 0x13, R_DMA_DATA = 0x19;
+                   R_UC_REGS_INDIRECT = 0x13, R_DMA_DATA = 0x19, R_JUMP = 0x1e;
 
 struct ShaderRegister { uint32_t offset, value; };
 
@@ -735,6 +735,50 @@ int main() {
     }
     CHECK(identity_mapping,
           "Gen5 interpolant helper initializes all 32 virtual-offset/value pairs");
+
+
+    // ---- Ikfdt-rIqCE: the Jump-packet target patcher (#2711 Q5) -------------------------------
+    // GTA V builds Jump packets EMPTY and fills them in through this call, so an unregistered
+    // handler left every one of them reaching the command processor with target=0 and count=0.
+    // The pairing is what matters and is what this locks: sceAgcDcbJump BUILDS the packet, this
+    // patches it, and cmd[4] belongs to sceAgcSetPacketPredication and must survive untouched.
+    {
+        auto jump  = Hle::lookup("xSAR0LTcRKM");   // sceAgcDcbJump
+        auto jpatch = Hle::lookup("Ikfdt-rIqCE");  // the target patcher under test
+        CHECK(jump && jpatch, "DcbJump and JumpPatchTarget are both registered");
+        if (jump && jpatch) {
+            // Build it the way the guest does: through the real builder, with a null target.
+            uint32_t* const jpkt = dcb.cursor_up;
+            const uint64_t jr = jump(D, 0, 0, /*target=*/0, /*ndw=*/0, 0);
+            CHECK(jr == (uint64_t)(uintptr_t)jpkt, "DcbJump returned the packet it built");
+            CHECK(jpkt[1] == 0 && jpkt[2] == 0 && jpkt[3] == 0,
+                  "the built Jump packet starts EMPTY (target=0, count=0) -- the state the guest patches");
+            jpkt[4] = 0xA5A5A5A5u;   // stand in for sceAgcSetPacketPredication's flag
+
+            const uint32_t header_before = jpkt[0];
+            jpatch((uint64_t)(uintptr_t)jpkt, /*cache policy=*/2,
+                   /*target=*/0x0000002040290080ull, /*dwords=*/359, 0, 0);
+
+            CHECK(jpkt[1] == 0x40290080u, "JumpPatchTarget wrote cmd[1] = target low");
+            CHECK(jpkt[2] == 0x00000020u, "JumpPatchTarget wrote cmd[2] = target high");
+            CHECK(jpkt[3] == 359u,        "JumpPatchTarget wrote cmd[3] = dword COUNT (not a packed policy)");
+            CHECK(jpkt[4] == 0xA5A5A5A5u, "JumpPatchTarget left cmd[4] (predication) untouched");
+            CHECK(jpkt[0] == header_before, "JumpPatchTarget left the header untouched");
+
+            // Wrong packet class must be refused byte-for-byte. patch_check is the only thing standing
+            // between a mis-typed pointer and five clobbered dwords, and a live run does hand this
+            // handler a non-Jump header once per run (#2715).
+            uint32_t decoy[6];
+            memset(decoy, 0, sizeof decoy);
+            decoy[0] = PM4(6, IT_NOP, R_DMA_DATA);
+            for (uint32_t i = 1; i < 6; ++i) decoy[i] = 0xDEADBE00u + i;
+            uint32_t decoy_before[6];
+            memcpy(decoy_before, decoy, sizeof decoy);
+            jpatch((uint64_t)(uintptr_t)decoy, 2, 0x0000002040290080ull, 359, 0, 0);
+            CHECK(memcmp(decoy, decoy_before, sizeof decoy) == 0,
+                  "JumpPatchTarget refuses a non-Jump packet without modifying a single dword");
+        }
+    }
 
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");


### PR DESCRIPTION
Refs #2711 (Q5), #319.

## What was wrong

GTA V creates AGC **Jump** packets empty and fills them in afterwards through
`libSceAgc::Ikfdt-rIqCE`, which was **unregistered**. Every such packet therefore reached the command
processor with `target=0` and `dword count=0` — a jump to nothing — so prosper folded a command graph
that was not the one the guest built, and whatever those segments draw never executed.

This is measured, not inferred. On a routed run, **402 patches, and every one reports the packet
arriving empty**:

```
[agc] JumpPatchTarget cmd=0x203dfc6074 pre=(0x0000000000000000,ndw=0) target=0x203dfe0080 ndw=9046 policy=0x2
[agc] JumpPatchTarget cmd=0x2040105aa8 pre=(0x0000000000000000,ndw=0) target=0x2040290080 ndw=359  policy=0x2
[agc] JumpPatchTarget cmd=0x20401fdf1c pre=(0x0000000000000000,ndw=0) target=0x2040380080 ndw=552  policy=0x2
```

The pre-state is in the line deliberately: a success line that only echoes its own argument cannot
distinguish "patched" from "patched with what was already there", and here the pre-state *is* the
evidence that the guest left the packet empty.

## Why the packet shape had to be measured before anything was written

Two independent traps here, and either would have corrupted a command buffer silently.

**The name.** A public catalogue labels this NID `sceAgcJumpPatchSetTarget`, but that literal string
hashes to `2BS4EtAaF28` — a separate three-argument 3.20 export. So this is documented under its NID as
the extended/cache-policy form until a matching SDK header settles the spelling.

**The layout.** Kyty's handler for this same NID validates `IT_INDIRECT_BUFFER` and writes `cmd[1]`
address-low preserving low control bits, `cmd[2]` address-high, and `cmd[3]` as **cache policy in bits
28..29 with size in bits 0..19**. prosper's `sceAgcDcbJump` does **not** emit `IT_INDIRECT_BUFFER`; it
emits this project's custom `IT_NOP`/`R_JUMP`, whose payload the decoder reads as `[1..2]`=target lo/hi,
**`[3]`=dword COUNT**, `[4]`=predicated flag (`pm4_decode.cpp`, `R_JUMP`). Kyty's `cmd[3]` store would
have put a policy-packed value on top of the segment's dword count.

So the NID was first registered as a **probe** that validated writability, decoded and reported the
header, and patched nothing. It answered identically at **402 of 403** call sites — the residual is
covered below:

```
[agc] JumpPatchTarget PROBE #0 cmd=0x203dfc5eb0 hdr=0xc0031078 op=0x10 r=0x1e count=3
      shape=IT_NOP/R_JUMP(ours) payload=00000000,00000000,00000000,00000000
      | policy=0x2 target=0x203dfe0080 ndw=0x23c7 -- NOT patched
```

`op=0x10` (`IT_NOP`), `r=0x1e` (`R_JUMP`) — **the packet is ours**, so the layout in this PR is the
right one and Kyty's is not. Argument roles (`a0`=packet, `a1`=cache policy, `a2`=target, `a3`=size in
dwords) come from the guest's own disassembly — five direct call sites through the adapter at
`eboot+0x1df090` — and the live values above agree with them.

## Deliberate non-changes

- **`cmd[4]` is not touched.** Predication is owned by `sceAgcSetPacketPredication` on this same packet,
  and this title's jump segments are predicated (#319). Writing it here would clobber that.
- **Cache policy is logged, not stored.** `R_JUMP` has no policy field and `sceAgcDcbJump` records none
  either, so a slot invented for it would be read by nothing. `CONFIDENCE: MED` on it being safely
  ignorable — that holds only while the decoder has no policy semantics.

## `patch_check` earned its place on the first run

1 of 403 calls arrived with header `0x3e718000` — **PM4 type 0, not a type-3 packet at all** — and was
refused rather than overwriting five dwords of something else:

```
[agc] JumpPatchTarget: header 0x3e718000 is not the expected packet (op=0x80 r=0x0 want r=0x1e) -- patch refused
```

## This does NOT fix the device loss, and the A/B says so

With jump targets patched and `0x413dc6700` left **enabled**, the loss still occurs:
`submit=4878 dispatch=40`. Unchanged in kind from every prior run.

That is the point of landing it now rather than later. #2711's Q5 recommended exactly this order: remove
the malformed-command-graph confounder *before* spending more effort attributing the hang to a shader,
because until the jump targets are real, any capture is faithful to what prosper executed but not to
what GTA intended to execute. No visual progression is claimed here and none is attached — this is a
command-stream correctness fix whose observable effect is that 402 previously-dead segments now have
real targets.

## Build and test

- Build: clean, **0 errors**.
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0.
- Routed `PPSA04263` run, `scripts/gta5/reach-story-mode.pad`, 4K, 7 screenshots: 402 patches applied,
  1 refused (above), no new failure mode.

### Visual A/B — matched skip set, and it confirms no visible change

Both arms decline all three hanging programs, so both cost **zero device losses** and their frames are
comparable. Arm A is the pre-patcher build; arm B is this one.

At the gameplay checkpoint arm B renders the state already documented in `GTA5_STATUS.md` and nothing
more: complete radar (player arrow, three blips, compass rose with `N`, green/blue/gold legend bar), the
caption *"The Radar shows your position within the world."*, one point light with a lens-flare streak,
faint blue structure to the right, and **no geometry**. Identical in kind to arm A.

So this fix has **no visible effect yet**, and that is the honest result rather than an unexamined
assumption — I looked at the frames instead of asserting it from the absence of a claim. Two caveats on
how far the A/B goes: screenshots are sampled on a 30 s timer over a route that is not frame
deterministic, so the arms are not matched *frames* and per-file size deltas between them (2.70 MB vs
2.52 MB) are timing jitter, not signal. What the comparison does support is the negative — nothing new
appears — not a pixel-level equivalence.

## Verification

Exact head `abb31122`, Linux, in-distrobox build.

### Regression test

`prosper/tests/test_agc_dcb.cpp` drives the real pairing through `Hle::lookup`: `sceAgcDcbJump` **builds**
the packet (an assertion confirms it starts empty — the state the guest actually patches), the patcher
fills it, and the arms check `cmd[1..2]` target, `cmd[3]` as a dword **count** rather than a packed
policy, `cmd[4]` preserved, and the header untouched. A second arm hands it an `R_DMA_DATA` packet and
requires byte-for-byte no change.

Mutation-checked, because a test that cannot fail proves nothing:

```
swap a2/a3 (target vs dword count) -> 3 assertions fail
clobber cmd[4] (predication)       -> 1 assertion fails: "left cmd[4] (predication) untouched"
```

### The residual, stated precisely

The probe did **not** answer identically everywhere: **402 of 403**, with one stable non-Jump header
(`0x3e718000`, PM4 type 0) refused each run. So the malformed-command-graph confounder is removed **for
the recognised 402 and not for that one**; it is filed as #2715 and the source comment says so rather
than implying the confounder is gone.

### Writable span

Four dwords, not `kDwJump`. This handler reads `cmd[0]` and writes `cmd[1..3]`, and line 730 of this file
states the spans are the dwords each handler actually **touches**, not the packet's nominal length. An
earlier revision justified the wider span by citing `agc_patch_release_mem_data` as precedent for
nominal-length probing — that was a misreading: it touches `cmd[0]`, `cmd[3]`, `cmd[4]` and `cmd[5]`,
exactly the six dwords it requests. There was no precedent.
