### PR TITLE
diag(compute): PROSPER_COMPUTE_PARENTSCAN — CPU-side cyclicity census of a link array, because a capture changes which dispatches run away

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4136,26 +4136,20 @@ One line per falsified hypothesis, the evidence that killed it, and where. **Rea
 a new one** — and note which entries are *solid* versus *void*, because a void result is not a
 falsification.
 
-- **The eight `OpControlBarrier` in `0x413dc6700` are the guest's own `s_barrier`s rather than
-  emulation scaffolding.** *Solid.* They are not: the guest contains **zero** `s_barrier` (SOPP `0x0a`,
-  `kSoppOpcodeBarrier`), its loop exit is per-wave (`s_cbranch_execz`), and the emitted module votes
-  workgroup-wide — a 256-way OR of a per-lane pending bit into `LDS[260]`, with eight barriers around
-  it. Wave 64, workgroup 256, so four waves; the LDS array is 261 entries (256 lane slots + 4 wave
-  slots + the result) and the wave index is `%92 >> 6`. So the barriers are emulation scaffolding and
-  the scope is wider than the guest's. This falsifies the speculation recorded under "Void, not
-  falsified" below; it does **not** establish that the barriers cause anything. #2717.
-- **Whether that scope difference causes the corruption — still VOID, and for a known reason.** The
-  obvious A/B (`PROSPER_NATIVE_COMPUTE_MULTIWAVE=1`, two runs identical in every column: 11 trip HITs,
-  21 cyclic inputs, 22 cyclic outputs, same loss at `0x413d85e00` d55) **proves nothing**, because the
-  lever cannot move for this program. `PROSPER_NATIVE_COMPUTE_MULTIWAVE` sets only
-  `config.native_subgroup_size`; `rdna2_to_spirv.cpp:23668` then forces `b.native_subgroup_size = 0`
-  whenever `partial_barrier_phases || exact_partial_dispatcher`, and this dispatch is both
-  (`threads=2063`, `local=256`). Every wave-width lowering gates on `b.`, not `config.`. The
-  `[subgroup] … native=0 multiwave=0` line reports the **config**, not the emitted lowering, so it
-  cannot witness the arm either. This is instrument trap **164** — the same switch, the same program,
-  the same byte-identical module `d04fd09b13408f9b4da7287fae34f692` in both arms — and its rule
-  applies: hash the artefact the switch is supposed to change, **before** reading the outcome. A real
-  test needs a lever that reaches `b.native_subgroup_size`. #2717.
+- **`0x413dc6700` contains no guest barriers, so all eight emitted `OpControlBarrier` are emulation
+  scaffolding.** *Falsified — and it was a grep artifact, not a measurement.* The program contains
+  **two** `s_barrier` (SOPP `0x0a`, encoded `0xbf8a0000`), at **pc 116 and pc 129** — which are exactly
+  the phase boundaries this file already records (phase 0 = `pc 0..<116`, phase 1 = `117..129`). The
+  program is barrier-phased, as `:83` and `:4767` say. The "zero" came from a `grep` whose pattern had
+  three spaces after `fmt=SOPP` where `shader_inspect` prints four; the tool had reported the two
+  barriers all along. Counted from the raw dwords by encoding (`(w >> 23) == 0x17F`, op `0x0a`) rather
+  than from formatted text: 2. #2717.
+- **What the scope comparison actually shows.** *Solid, and narrower than the retracted version.* The
+  guest's loop exit is **per-wave** (`s_cbranch_execz`), while the emitted module votes
+  **workgroup-wide** — a 256-way OR of a per-lane pending bit into `LDS[260]`, four waves of 64 in a
+  261-entry array, wave index `%92 >> 6`. The module carries **eight** `OpControlBarrier` against the
+  guest's **two**, so six are the vote's and two correspond to the guest's own phase boundaries.
+  Whether that scope difference causes anything is untested — see the next row. #2717.
 - **`0x413dc6700` never corrupts a clean input.** *Falsified.* Eight consecutive submits do show 88
   dispatches running `0 -> 0` on all four link arrays, which is what suggested it — but with coverage
   widened to nine submits, **one dispatch with a clean input turns a clean 2063-entry array into 537

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4148,8 +4148,11 @@ falsification.
   guest's loop exit is **per-wave** (`s_cbranch_execz`), while the emitted module votes
   **workgroup-wide** — a 256-way OR of a per-lane pending bit into `LDS[260]`, four waves of 64 in a
   261-entry array, wave index `%92 >> 6`. The module carries **eight** `OpControlBarrier` against the
-  guest's **two**, so six are the vote's and two correspond to the guest's own phase boundaries.
-  Whether that scope difference causes anything is untested — see the next row. #2717.
+  guest's **two**. Of the eight, **three** immediately follow a store to the vote word — one per
+  dispatcher phase, the write→barrier→read the vote needs. The remaining five are **not attributed**:
+  saying "six are the vote's and two are the guest's" would be arithmetic, not a measurement, and the
+  mapping from the guest's two `s_barrier` onto specific emitted ones has not been established.
+  Whether the scope difference causes anything is untested — see the next row. #2717.
 - **`0x413dc6700` never corrupts a clean input.** *Falsified.* Eight consecutive submits do show 88
   dispatches running `0 -> 0` on all four link arrays, which is what suggested it — but with coverage
   widened to nine submits, **one dispatch with a clean input turns a clean 2063-entry array into 537

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4136,23 +4136,36 @@ One line per falsified hypothesis, the evidence that killed it, and where. **Rea
 a new one** — and note which entries are *solid* versus *void*, because a void result is not a
 falsification.
 
-- **`0x413dc6700` runs away because prosper's portable wave vote adds workgroup barriers the guest does
-  not have.** *Solid.* The scope difference is real and was worth testing: the guest contains **zero**
-  `s_barrier` (SOPP `0x0a`), its exit is per-wave (`s_cbranch_execz`, 64 lanes), and prosper emulates it
-  with a 256-way LDS OR plus eight `OpControlBarrier`, because the program's 256-thread workgroup is four
-  waves and the conservative multi-wave default refuses it a native contract
-  (`[subgroup] cs=0x413dc6700 guest-wave=64 native=0 multiwave=0`, against `native=64` for a single-wave
-  program beside it). `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1` grants the exact subgroup shell, which
-  removes those workgroup barriers while keeping one native subgroup per guest wave. Two runs, identical
-  but for that switch, with `PROSPER_COMPUTE_PARENTSCAN`: **identical in every column** — 11 trip-bound
-  HITs, 21 cyclic inputs, 22 cyclic outputs, and the same device loss at `0x413d85e00` dispatch 55. The
-  barriers are not the mechanism. #2711, #2717.
-- **The corruption is produced by whatever consumes it / by prosper's own declines.** *Solid, both
-  halves.* `0x413dc6700` does **not** corrupt a clean input: eight consecutive submits show 88 dispatches
-  running `0 -> 0` on all four link arrays. It corrupts only after being handed a cyclic array, and a
-  single dispatch — clean input, terminating normally, not a runaway — turns a clean 2063-entry array
-  into 537 cyclic entries. Declining the other runaway programs is not the cause either: a run declining
-  **nothing** shows the same `0 -> 84` corruption. #2711, #2717.
+- **The eight `OpControlBarrier` in `0x413dc6700` are the guest's own `s_barrier`s rather than
+  emulation scaffolding.** *Solid.* They are not: the guest contains **zero** `s_barrier` (SOPP `0x0a`,
+  `kSoppOpcodeBarrier`), its loop exit is per-wave (`s_cbranch_execz`), and the emitted module votes
+  workgroup-wide — a 256-way OR of a per-lane pending bit into `LDS[260]`, with eight barriers around
+  it. Wave 64, workgroup 256, so four waves; the LDS array is 261 entries (256 lane slots + 4 wave
+  slots + the result) and the wave index is `%92 >> 6`. So the barriers are emulation scaffolding and
+  the scope is wider than the guest's. This falsifies the speculation recorded under "Void, not
+  falsified" below; it does **not** establish that the barriers cause anything. #2717.
+- **Whether that scope difference causes the corruption — still VOID, and for a known reason.** The
+  obvious A/B (`PROSPER_NATIVE_COMPUTE_MULTIWAVE=1`, two runs identical in every column: 11 trip HITs,
+  21 cyclic inputs, 22 cyclic outputs, same loss at `0x413d85e00` d55) **proves nothing**, because the
+  lever cannot move for this program. `PROSPER_NATIVE_COMPUTE_MULTIWAVE` sets only
+  `config.native_subgroup_size`; `rdna2_to_spirv.cpp:23668` then forces `b.native_subgroup_size = 0`
+  whenever `partial_barrier_phases || exact_partial_dispatcher`, and this dispatch is both
+  (`threads=2063`, `local=256`). Every wave-width lowering gates on `b.`, not `config.`. The
+  `[subgroup] … native=0 multiwave=0` line reports the **config**, not the emitted lowering, so it
+  cannot witness the arm either. This is instrument trap **164** — the same switch, the same program,
+  the same byte-identical module `d04fd09b13408f9b4da7287fae34f692` in both arms — and its rule
+  applies: hash the artefact the switch is supposed to change, **before** reading the outcome. A real
+  test needs a lever that reaches `b.native_subgroup_size`. #2717.
+- **`0x413dc6700` never corrupts a clean input.** *Falsified.* Eight consecutive submits do show 88
+  dispatches running `0 -> 0` on all four link arrays, which is what suggested it — but with coverage
+  widened to nine submits, **one dispatch with a clean input turns a clean 2063-entry array into 537
+  cyclic entries while terminating normally**, and is not a runaway. So the consumer does corrupt clean
+  input, on one dispatch in nine submits. That also restores this file's own
+  `### The writer is the CONSUMER ITSELF` finding, which an earlier revision of this row contradicted.
+  #2711, #2717.
+- **Our own `PROSPER_COMPUTE_SKIP_PROGRAM` declines leave stale arrays that read as cyclic.** *Solid.*
+  A run declining **nothing** shows the same corruption (`0 -> 84` at the first runaway submit) before
+  dying at `0x413e14900`. The workaround is not manufacturing the defect. #2711, #2717.
 
 - **`0x413dc6700` computes on zeros because prosper cannot express its pointer-chase load, so GTA V's
   world needs `PhysicalStorageBuffer` / `VK_KHR_buffer_device_address`.** *Solid.* Filed as #2709 and

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -4136,6 +4136,24 @@ One line per falsified hypothesis, the evidence that killed it, and where. **Rea
 a new one** — and note which entries are *solid* versus *void*, because a void result is not a
 falsification.
 
+- **`0x413dc6700` runs away because prosper's portable wave vote adds workgroup barriers the guest does
+  not have.** *Solid.* The scope difference is real and was worth testing: the guest contains **zero**
+  `s_barrier` (SOPP `0x0a`), its exit is per-wave (`s_cbranch_execz`, 64 lanes), and prosper emulates it
+  with a 256-way LDS OR plus eight `OpControlBarrier`, because the program's 256-thread workgroup is four
+  waves and the conservative multi-wave default refuses it a native contract
+  (`[subgroup] cs=0x413dc6700 guest-wave=64 native=0 multiwave=0`, against `native=64` for a single-wave
+  program beside it). `PROSPER_NATIVE_COMPUTE_MULTIWAVE=1` grants the exact subgroup shell, which
+  removes those workgroup barriers while keeping one native subgroup per guest wave. Two runs, identical
+  but for that switch, with `PROSPER_COMPUTE_PARENTSCAN`: **identical in every column** — 11 trip-bound
+  HITs, 21 cyclic inputs, 22 cyclic outputs, and the same device loss at `0x413d85e00` dispatch 55. The
+  barriers are not the mechanism. #2711, #2717.
+- **The corruption is produced by whatever consumes it / by prosper's own declines.** *Solid, both
+  halves.* `0x413dc6700` does **not** corrupt a clean input: eight consecutive submits show 88 dispatches
+  running `0 -> 0` on all four link arrays. It corrupts only after being handed a cyclic array, and a
+  single dispatch — clean input, terminating normally, not a runaway — turns a clean 2063-entry array
+  into 537 cyclic entries. Declining the other runaway programs is not the cause either: a run declining
+  **nothing** shows the same `0 -> 84` corruption. #2711, #2717.
+
 - **`0x413dc6700` computes on zeros because prosper cannot express its pointer-chase load, so GTA V's
   world needs `PhysicalStorageBuffer` / `VK_KHR_buffer_device_address`.** *Solid.* Filed as #2709 and
   argued further in its comments; also carried into #2711's Q1/Q2 answers as a premise. The emitted

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4283,6 +4283,67 @@ const std::set<uint64_t>& compute_skip_programs() {
     return programs;
 }
 
+// PROSPER_COMPUTE_PARENTSCAN=0xADDR — CPU-side cyclicity census of a link/parent array, taken
+// PRE-dispatch from the exact bytes the dispatch is about to read.
+//
+// This exists because the obvious instrument does not work. Deciding whether a runaway dispatch's INPUT
+// is ALREADY cyclic needs the array and the runaway record from the SAME run, and arming
+// PROSPER_GPU_CAPTURE to obtain the array changes which dispatches run away — measured on GTA V's
+// 0x413dc6700: 11 dispatches of both parities without a capture, reproducibly, versus 5 odd-only
+// ordinals with one armed. An instrument that alters the phenomenon cannot establish its cause.
+//
+// A walk of bytes the front half has already materialized touches no GPU state, issues no submit and
+// cannot reorder one, so this can run alongside PROSPER_CFG_TRIP_BOUND's witness and be read against it.
+//
+// The link encoding is the title's own: next = (word >> 3) & 0x7FFFFFF, terminating on 0 or on an index
+// at/after the record count — an out-of-range RDNA2 buffer load returns zero, which is exactly what
+// exits the guest's pc88..97 walk. The line reports `records` and the encoding's shift/mask so a wrong
+// guess is visible rather than silent. CONFIDENCE: HIGH on the encoding (it is the guest's own
+// `v_bfe_u32 v1, v1, 3, 27` with NUM_RECORDS as the bound).
+struct ParentScanResult {
+    uint32_t records = 0, terminating = 0, cyclic = 0, cycle_nodes = 0, longest = 0;
+};
+
+ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
+    ParentScanResult out;
+    if (!bytes || byte_count < 4) return out;
+    const uint32_t records = static_cast<uint32_t>(byte_count / 4);
+    out.records = records;
+    const uint32_t* words = reinterpret_cast<const uint32_t*>(bytes);
+    // 0 = unclassified, 1 = reaches a terminator, 2 = enters a cycle. Memoized so the whole array is
+    // classified in O(records) rather than O(records * path length).
+    std::vector<uint8_t> state(records, 0);
+    std::vector<uint32_t> path;
+    std::vector<uint32_t> seen_at(records, UINT32_MAX);
+    std::set<uint32_t> cycle_nodes;
+    for (uint32_t start = 0; start < records; ++start) {
+        if (state[start]) continue;
+        path.clear();
+        uint32_t i = start;
+        uint8_t verdict = 1;
+        while (true) {
+            if (i == 0 || i >= records) { verdict = 1; break; }         // terminator / OOB read -> 0
+            if (state[i]) { verdict = state[i]; break; }                // already classified
+            if (seen_at[i] != UINT32_MAX) {                             // revisited on THIS walk
+                for (size_t k = seen_at[i]; k < path.size(); ++k) cycle_nodes.insert(path[k]);
+                verdict = 2;
+                break;
+            }
+            seen_at[i] = static_cast<uint32_t>(path.size());
+            path.push_back(i);
+            i = (words[i] >> 3) & 0x7FFFFFFu;
+        }
+        if (path.size() > out.longest) out.longest = static_cast<uint32_t>(path.size());
+        for (uint32_t node : path) { state[node] = verdict; seen_at[node] = UINT32_MAX; }
+    }
+    for (uint32_t k = 0; k < records; ++k) {
+        if (state[k] == 1) ++out.terminating;
+        else if (state[k] == 2) ++out.cyclic;
+    }
+    out.cycle_nodes = static_cast<uint32_t>(cycle_nodes.size());
+    return out;
+}
+
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
@@ -4965,6 +5026,25 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     source = buffers[i].linear_seed.data();
                 }
                 if (trace) buffers[i].before_hash = fnv1a(source, buffers[i].bytes);
+                if (const char* pscan = std::getenv("PROSPER_COMPUTE_PARENTSCAN")) {
+                    // Stride 4 restricts this to the per-entity u32 arrays; the 64-byte record buffer
+                    // is not a link array and scanning it would report noise as structure.
+                    if (std::strtoull(pscan, nullptr, 16) ==
+                            static_cast<uint64_t>(item.code_addr) && resource->stride == 4u) {
+                        const ParentScanResult ps = scan_parent_array(source, buffers[i].bytes);
+                        std::fprintf(stderr,
+                                     "[parentscan] program=0x%llx submit=%llu dispatch=%llu "
+                                     "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
+                                     "cycle-nodes=%u longest=%u enc=(w>>3)&0x7ffffff\n",
+                                     (unsigned long long)item.code_addr,
+                                     (unsigned long long)item.submit_no,
+                                     (unsigned long long)item.dispatch_index,
+                                     resource->binding,
+                                     (unsigned long long)resource->gpu_addr,
+                                     ps.records, ps.terminating, ps.cyclic, ps.cycle_nodes,
+                                     ps.longest);
+                    }
+                }
                 buffers[i].cache_key = {
                     resource->gpu_addr, reinterpret_cast<uintptr_t>(resource->host_data),
                     static_cast<uint32_t>(buffers[i].bytes),

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -8751,6 +8751,27 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (const auto& buffer : buffers) {
             if (!buffer.resource || buffer.alias_of != SIZE_MAX) continue;
             const uint8_t* bytes = resource_bytes(buffer.resource);
+            // POST-dispatch half of PROSPER_COMPUTE_PARENTSCAN. The pre-dispatch scan says whether a
+            // dispatch's INPUT was cyclic; this says whether its OUTPUT is. A dispatch whose input was
+            // clean and whose output is cyclic is the one that INTRODUCED the cycle -- which is the
+            // whole question, and neither half answers it alone.
+            if (const char* pscan_after = std::getenv("PROSPER_COMPUTE_PARENTSCAN")) {
+                if (std::strtoull(pscan_after, nullptr, 16) ==
+                        static_cast<uint64_t>(item.code_addr) && buffer.resource->stride == 4u) {
+                    const ParentScanResult pa = scan_parent_array(bytes, buffer.resource->size);
+                    std::fprintf(stderr,
+                                 "[parentscan-after] program=0x%llx submit=%llu dispatch=%llu "
+                                 "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
+                                 "cycle-nodes=%u longest=%u changed=%llu\n",
+                                 (unsigned long long)item.code_addr,
+                                 (unsigned long long)item.submit_no,
+                                 (unsigned long long)item.dispatch_index,
+                                 buffer.resource->binding,
+                                 (unsigned long long)buffer.resource->gpu_addr,
+                                 pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
+                                 (unsigned long long)buffer.changed_bytes);
+                }
+            }
             std::fprintf(stderr,
                          "[compute]   writeback binding=%u addr=0x%llx size=%u changed=%llu "
                          "hash=%016llx->%016llx first=%08x,%08x,%08x,%08x,%08x,%08x,%08x,%08x\n",

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4301,7 +4301,15 @@ const std::set<uint64_t>& compute_skip_programs() {
 // guess is visible rather than silent. CONFIDENCE: HIGH on the encoding (it is the guest's own
 // `v_bfe_u32 v1, v1, 3, 27` with NUM_RECORDS as the bound).
 struct ParentScanResult {
-    uint32_t records = 0, terminating = 0, cyclic = 0, cycle_nodes = 0, longest = 0;
+    // `terminating + cyclic == records` -- index 0 is the terminator and is classified as
+    // terminating, not skipped. An earlier revision broke out of the walk before pushing it, so the
+    // two columns silently summed to records-1 on EVERY array (measured 400/400), which is the kind of
+    // off-by-one that reads as a rounding difference rather than a bug.
+    uint32_t records = 0, terminating = 0, cyclic = 0, cycle_nodes = 0;
+    // Longest terminating CHAIN, computed as a depth, not the longest walk this scan happened to take.
+    // The walk length depends on the order starts are visited -- memoisation truncates later walks --
+    // so a single 2047-link chain reports 1 or 2047 purely by link direction.
+    uint32_t longest = 0;
     uint32_t sample_count = 0;
     uint32_t sample_idx[6]{}, sample_word[6]{}, sample_next[6]{};
 };
@@ -4335,8 +4343,23 @@ ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
             path.push_back(i);
             i = (words[i] >> 3) & 0x7FFFFFFu;
         }
-        if (path.size() > out.longest) out.longest = static_cast<uint32_t>(path.size());
         for (uint32_t node : path) { state[node] = verdict; seen_at[node] = UINT32_MAX; }
+    }
+    state[0] = 1;   // the terminator itself terminates
+    // Depth of each terminating node, memoised: depth(i) = 1 + depth(next(i)), 0 for a cyclic node.
+    // Independent of visit order, unlike the walk length it replaces.
+    std::vector<uint32_t> depth(records, 0);
+    for (uint32_t start = 0; start < records; ++start) {
+        if (state[start] != 1 || depth[start]) continue;
+        std::vector<uint32_t> chain;
+        uint32_t i = start;
+        while (i != 0 && i < records && state[i] == 1 && !depth[i]) {
+            chain.push_back(i);
+            i = (words[i] >> 3) & 0x7FFFFFFu;
+        }
+        uint32_t d = (i < records) ? depth[i] : 0u;
+        for (auto it = chain.rbegin(); it != chain.rend(); ++it) { d += 1u; depth[*it] = d; }
+        if (d > out.longest) out.longest = d;
     }
     for (uint32_t k = 0; k < records; ++k) {
         if (state[k] == 1) ++out.terminating;
@@ -4358,48 +4381,75 @@ ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
 
 // Retained pre-dispatch copies for PROSPER_COMPUTE_PARENTSCAN, keyed by guest address. Small and
 // bounded: one 8 KiB array per link buffer, overwritten each dispatch.
-std::map<uint64_t, std::vector<uint8_t>>& parent_scan_stash_map() {
-    static std::map<uint64_t, std::vector<uint8_t>> m;
+struct ParentScanStash {
+    std::vector<uint8_t> bytes;
+    uint64_t submit = 0, dispatch = 0;
+    uint32_t cyclic = 0;          // the pre-dispatch verdict, so the post half can prove a TRANSITION
+    bool valid = false;
+};
+std::map<uint64_t, ParentScanStash>& parent_scan_stash_map() {
+    static std::map<uint64_t, ParentScanStash> m;
     return m;
 }
 std::mutex& parent_scan_stash_mutex() { static std::mutex m; return m; }
 
-void parent_scan_stash(uint64_t addr, const uint8_t* bytes, size_t count) {
+void parent_scan_stash(uint64_t addr, const uint8_t* bytes, size_t count,
+                       uint64_t submit, uint64_t dispatch, uint32_t cyclic) {
     if (!bytes || !count || count > (1u << 20)) return;
     std::lock_guard<std::mutex> lk(parent_scan_stash_mutex());
-    auto& v = parent_scan_stash_map()[addr];
-    v.assign(bytes, bytes + count);
+    auto& s = parent_scan_stash_map()[addr];
+    s.bytes.assign(bytes, bytes + count);
+    s.submit = submit; s.dispatch = dispatch; s.cyclic = cyclic; s.valid = true;
 }
 
 // Write the input and output of a dispatch that turned a clean link array cyclic. This is the artifact
 // the whole investigation has lacked: the exact bytes that provoke the defect, captured at the moment it
 // happens rather than sampled afterwards.
 void parent_scan_dump_pair(uint64_t addr, const uint8_t* after, size_t count,
-                           uint64_t code, uint64_t submit, uint64_t dispatch) {
+                           uint64_t code, uint64_t submit, uint64_t dispatch, uint32_t after_cyclic) {
     const char* dir = std::getenv("PROSPER_COMPUTE_PARENTSCAN_DUMP");
     if (!dir || !*dir) return;
-    std::vector<uint8_t> before;
+    ParentScanStash before;
     {
         std::lock_guard<std::mutex> lk(parent_scan_stash_mutex());
         auto it = parent_scan_stash_map().find(addr);
         if (it != parent_scan_stash_map().end()) before = it->second;
     }
+    // Only a genuine CLEAN -> CYCLIC transition, and only when the retained input belongs to THIS
+    // dispatch. Firing on "the output is cyclic" instead would dump every dispatch downstream of the
+    // real writer, and pairing an output with whatever input was last stashed for that address would
+    // put two different dispatches in one filename that asserts a single one.
+    if (!before.valid || before.cyclic != 0 || after_cyclic == 0) return;
+    if (before.submit != submit || before.dispatch != dispatch) return;
     char path[512];
     for (int half = 0; half < 2; ++half) {
-        const std::vector<uint8_t>* src = nullptr;
-        std::vector<uint8_t> tail;
-        if (half == 0) { src = &before; }
-        else { tail.assign(after, after + count); src = &tail; }
-        if (src->empty()) continue;
-        std::snprintf(path, sizeof(path), "%s/parent_%llx_s%llu_d%llu_%s.bin", dir,
-                      (unsigned long long)addr, (unsigned long long)submit,
-                      (unsigned long long)dispatch, half == 0 ? "in" : "out");
-        if (FILE* f = std::fopen(path, "wb")) {
-            std::fwrite(src->data(), 1, src->size(), f);
-            std::fclose(f);
-            std::fprintf(stderr, "[parentscan-dump] program=0x%llx wrote %s (%zu bytes)\n",
-                         (unsigned long long)code, path, src->size());
+        const uint8_t* data = half == 0 ? before.bytes.data() : after;
+        const size_t   size = half == 0 ? before.bytes.size() : count;
+        if (!data || !size) continue;
+        const int n = std::snprintf(path, sizeof(path), "%s/parent_%llx_s%llu_d%llu_%s.bin", dir,
+                                    (unsigned long long)addr, (unsigned long long)submit,
+                                    (unsigned long long)dispatch, half == 0 ? "in" : "out");
+        if (n < 0 || static_cast<size_t>(n) >= sizeof(path)) {
+            std::fprintf(stderr, "[parentscan-dump] path too long for %s -- not written\n", dir);
+            continue;
         }
+        FILE* f = std::fopen(path, "wb");
+        if (!f) {
+            std::fprintf(stderr, "[parentscan-dump] could not open %s -- not written\n", path);
+            continue;
+        }
+        const size_t wrote = std::fwrite(data, 1, size, f);
+        const bool closed = std::fclose(f) == 0;
+        // Report what actually reached the file. An earlier revision printed the intended size
+        // unconditionally, so a short or failed write announced itself as a success.
+        if (wrote == size && closed)
+            std::fprintf(stderr, "[parentscan-dump] program=0x%llx wrote %s (%zu bytes)\n",
+                         (unsigned long long)code, path, wrote);
+        else
+            std::fprintf(stderr,
+                         "[parentscan-dump] program=0x%llx INCOMPLETE %s (%zu of %zu bytes%s)\n",
+                         (unsigned long long)code, path, wrote, size,
+                         closed ? "" : ", close failed");
     }
 }
 
@@ -5085,18 +5135,42 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     source = buffers[i].linear_seed.data();
                 }
                 if (trace) buffers[i].before_hash = fnv1a(source, buffers[i].bytes);
-                if (const char* pscan = std::getenv("PROSPER_COMPUTE_PARENTSCAN")) {
+                // getenv is read ONCE, not per buffer per dispatch: this half sits on the default
+                // (non-trace) path, which is exactly the pattern #2214/#2228 removed from the live
+                // renderer. `tools/getenv_probe` exists to catch its reappearance.
+                static const uint64_t pscan_addr = []() -> uint64_t {
+                    const char* e = std::getenv("PROSPER_COMPUTE_PARENTSCAN");
+                    if (!e || !*e) return 0u;
+                    const uint64_t v = static_cast<uint64_t>(std::strtoull(e, nullptr, 16));
+                    // This switch takes a PROGRAM ADDRESS, not the =1 that arms every other
+                    // PROSPER_* variable. Left silent, `=1` parses to 1, matches no program, and
+                    // reports nothing -- indistinguishable from "the program never ran".
+                    if (v && v < 0x1000u)
+                        std::fprintf(stderr,
+                                     "[parentscan] PROSPER_COMPUTE_PARENTSCAN=%s is not a program "
+                                     "address; this switch expects one (e.g. 413dc6700). Nothing "
+                                     "will be scanned.\n", e);
+                    return v;
+                }();
+                static const bool pscan_dump_armed =
+                    std::getenv("PROSPER_COMPUTE_PARENTSCAN_DUMP") != nullptr;
+                if (pscan_addr) {
                     // Stride 4 restricts this to the per-entity u32 arrays; the 64-byte record buffer
                     // is not a link array and scanning it would report noise as structure.
-                    if (std::strtoull(pscan, nullptr, 16) ==
-                            static_cast<uint64_t>(item.code_addr) && resource->stride == 4u) {
+                    if (pscan_addr == static_cast<uint64_t>(item.code_addr) &&
+                        resource->stride == 4u) {
                         const ParentScanResult ps = scan_parent_array(source, buffers[i].bytes);
                         // Stash the input so the post-dispatch half can dump BOTH halves the instant it
                         // sees a clean->cyclic transition. Without this the corrupting dispatch is only
                         // ever observable through six sampled ring members: the array that produced it is
                         // gone by the time we know it mattered, and a capture cannot be aimed at it
                         // (arming one changes which dispatches corrupt).
-                        parent_scan_stash(resource->gpu_addr, source, buffers[i].bytes);
+                        // Only retain the input when a dump can consume it. Stashing unconditionally
+                        // grew a process-wide map on the very runs this instrument claims not to
+                        // perturb.
+                        if (pscan_dump_armed)
+                            parent_scan_stash(resource->gpu_addr, source, buffers[i].bytes,
+                                              item.submit_no, item.dispatch_index, ps.cyclic);
                         std::fprintf(stderr,
                                      "[parentscan] program=0x%llx submit=%llu dispatch=%llu "
                                      "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
@@ -8835,10 +8909,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
                                  (unsigned long long)buffer.changed_bytes);
-                    if (pa.cyclic > 0)
-                        parent_scan_dump_pair(buffer.resource->gpu_addr, bytes,
-                                              buffer.resource->size, item.code_addr,
-                                              item.submit_no, item.dispatch_index);
+                    parent_scan_dump_pair(buffer.resource->gpu_addr, bytes,
+                                          buffer.resource->size, item.code_addr,
+                                          item.submit_no, item.dispatch_index, pa.cyclic);
                     for (uint32_t s = 0; s < pa.sample_count; ++s)
                         std::fprintf(stderr,
                                      "[parentscan-ring]   idx=%u word=0x%08x -> next=%u%s\n",

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4356,6 +4356,53 @@ ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
     return out;
 }
 
+// Retained pre-dispatch copies for PROSPER_COMPUTE_PARENTSCAN, keyed by guest address. Small and
+// bounded: one 8 KiB array per link buffer, overwritten each dispatch.
+std::map<uint64_t, std::vector<uint8_t>>& parent_scan_stash_map() {
+    static std::map<uint64_t, std::vector<uint8_t>> m;
+    return m;
+}
+std::mutex& parent_scan_stash_mutex() { static std::mutex m; return m; }
+
+void parent_scan_stash(uint64_t addr, const uint8_t* bytes, size_t count) {
+    if (!bytes || !count || count > (1u << 20)) return;
+    std::lock_guard<std::mutex> lk(parent_scan_stash_mutex());
+    auto& v = parent_scan_stash_map()[addr];
+    v.assign(bytes, bytes + count);
+}
+
+// Write the input and output of a dispatch that turned a clean link array cyclic. This is the artifact
+// the whole investigation has lacked: the exact bytes that provoke the defect, captured at the moment it
+// happens rather than sampled afterwards.
+void parent_scan_dump_pair(uint64_t addr, const uint8_t* after, size_t count,
+                           uint64_t code, uint64_t submit, uint64_t dispatch) {
+    const char* dir = std::getenv("PROSPER_COMPUTE_PARENTSCAN_DUMP");
+    if (!dir || !*dir) return;
+    std::vector<uint8_t> before;
+    {
+        std::lock_guard<std::mutex> lk(parent_scan_stash_mutex());
+        auto it = parent_scan_stash_map().find(addr);
+        if (it != parent_scan_stash_map().end()) before = it->second;
+    }
+    char path[512];
+    for (int half = 0; half < 2; ++half) {
+        const std::vector<uint8_t>* src = nullptr;
+        std::vector<uint8_t> tail;
+        if (half == 0) { src = &before; }
+        else { tail.assign(after, after + count); src = &tail; }
+        if (src->empty()) continue;
+        std::snprintf(path, sizeof(path), "%s/parent_%llx_s%llu_d%llu_%s.bin", dir,
+                      (unsigned long long)addr, (unsigned long long)submit,
+                      (unsigned long long)dispatch, half == 0 ? "in" : "out");
+        if (FILE* f = std::fopen(path, "wb")) {
+            std::fwrite(src->data(), 1, src->size(), f);
+            std::fclose(f);
+            std::fprintf(stderr, "[parentscan-dump] program=0x%llx wrote %s (%zu bytes)\n",
+                         (unsigned long long)code, path, src->size());
+        }
+    }
+}
+
 bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& item) {
     using namespace prosper::gpu;
     using ComputeClock = std::chrono::steady_clock;
@@ -5044,6 +5091,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (std::strtoull(pscan, nullptr, 16) ==
                             static_cast<uint64_t>(item.code_addr) && resource->stride == 4u) {
                         const ParentScanResult ps = scan_parent_array(source, buffers[i].bytes);
+                        // Stash the input so the post-dispatch half can dump BOTH halves the instant it
+                        // sees a clean->cyclic transition. Without this the corrupting dispatch is only
+                        // ever observable through six sampled ring members: the array that produced it is
+                        // gone by the time we know it mattered, and a capture cannot be aimed at it
+                        // (arming one changes which dispatches corrupt).
+                        parent_scan_stash(resource->gpu_addr, source, buffers[i].bytes);
                         std::fprintf(stderr,
                                      "[parentscan] program=0x%llx submit=%llu dispatch=%llu "
                                      "binding=%u addr=0x%llx records=%u terminating=%u cyclic=%u "
@@ -8782,6 +8835,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
                                  (unsigned long long)buffer.changed_bytes);
+                    if (pa.cyclic > 0)
+                        parent_scan_dump_pair(buffer.resource->gpu_addr, bytes,
+                                              buffer.resource->size, item.code_addr,
+                                              item.submit_no, item.dispatch_index);
                     for (uint32_t s = 0; s < pa.sample_count; ++s)
                         std::fprintf(stderr,
                                      "[parentscan-ring]   idx=%u word=0x%08x -> next=%u%s\n",

--- a/prosper/frontends/shared/live_compute.cpp
+++ b/prosper/frontends/shared/live_compute.cpp
@@ -4302,6 +4302,8 @@ const std::set<uint64_t>& compute_skip_programs() {
 // `v_bfe_u32 v1, v1, 3, 27` with NUM_RECORDS as the bound).
 struct ParentScanResult {
     uint32_t records = 0, terminating = 0, cyclic = 0, cycle_nodes = 0, longest = 0;
+    uint32_t sample_count = 0;
+    uint32_t sample_idx[6]{}, sample_word[6]{}, sample_next[6]{};
 };
 
 ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
@@ -4341,6 +4343,16 @@ ParentScanResult scan_parent_array(const uint8_t* bytes, size_t byte_count) {
         else if (state[k] == 2) ++out.cyclic;
     }
     out.cycle_nodes = static_cast<uint32_t>(cycle_nodes.size());
+    // Keep a few actual ring members. A count says corruption happened; the entries say what SHAPE it
+    // is, and the shape is usually the mechanism -- a self-loop (parent[i]==i), a 2-cycle, or a ring of
+    // stale generation are three different bugs and the count cannot tell them apart.
+    for (uint32_t node : cycle_nodes) {
+        if (out.sample_count >= 6u) break;
+        out.sample_idx[out.sample_count] = node;
+        out.sample_word[out.sample_count] = words[node];
+        out.sample_next[out.sample_count] = (words[node] >> 3) & 0x7FFFFFFu;
+        ++out.sample_count;
+    }
     return out;
 }
 
@@ -8770,6 +8782,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  (unsigned long long)buffer.resource->gpu_addr,
                                  pa.records, pa.terminating, pa.cyclic, pa.cycle_nodes, pa.longest,
                                  (unsigned long long)buffer.changed_bytes);
+                    for (uint32_t s = 0; s < pa.sample_count; ++s)
+                        std::fprintf(stderr,
+                                     "[parentscan-ring]   idx=%u word=0x%08x -> next=%u%s\n",
+                                     pa.sample_idx[s], pa.sample_word[s], pa.sample_next[s],
+                                     pa.sample_next[s] == pa.sample_idx[s] ? "  SELF-LOOP" : "");
                 }
             }
             std::fprintf(stderr,

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1086,6 +1086,27 @@ A refusal also clears `producer_epoch_ok`, which the next `ParserStall` latches 
 later **indirect** draw and dispatch untried. A single named decline can therefore account for a
 frame's worth of missing geometry.
 
+**`PROSPER_COMPUTE_PARENTSCAN=0xADDR` — CPU-side cyclicity census of a compute program's link arrays.**
+For a kernel that walks a per-item successor array (GTA V's `0x413dc6700` is the motivating case), this
+classifies every entry of each **stride-4** bound buffer as terminating or cyclic, **before** the
+dispatch reads it and again **after** it writes, and prints `records / terminating / cyclic /
+cycle-nodes / longest` plus a few ring members. `terminating + cyclic == records` always; the link
+encoding it assumes is printed on every line so a wrong guess is visible rather than silent.
+
+It exists because the obvious instrument does not work: arming `PROSPER_GPU_CAPTURE` to obtain the array
+**changes which dispatches misbehave** (measured on this title: 11 runaway dispatches of both parities
+without a capture, reproducibly, versus 5 odd-only with one armed). This walks bytes the front half has
+already materialised — no submit, no GPU state, no reordering — so it can be read against
+`PROSPER_CFG_TRIP_BOUND`'s witness in the same run. That pairing is what established the causal
+direction (22/22: every runaway read an already-cyclic array).
+
+`PROSPER_COMPUTE_PARENTSCAN_DUMP=DIR` additionally writes the input and output arrays of a dispatch that
+turns a **clean** array cyclic — the transition only, with the retained input required to belong to that
+same dispatch, so the pair in one filename is genuinely one dispatch. Two caveats: the switch takes a
+**program address**, not `=1` (it says so if given something that cannot be one), and coverage depends on
+how often a buffer is materialised — `PROSPER_COMPUTE_BUFFER_CACHE_MB=0` raised it from 3 submits to 9
+on a routed run, though the mechanism for that is not established.
+
 **`PROSPER_COMPUTE_SKIP_PROGRAM=0xADDR[,0xADDR...]` — decline named compute programs.** A bisection
 instrument: one dispatch can take down everything after it (a GPU hang costs the process its compute
 backend), so "which dispatch is responsible?" is worth asking directly instead of by rebuilding. It

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1100,12 +1100,17 @@ already materialised — no submit, no GPU state, no reordering — so it can be
 `PROSPER_CFG_TRIP_BOUND`'s witness in the same run. That pairing is what established the causal
 direction (22/22: every runaway read an already-cyclic array).
 
+**The post-dispatch half and the dump additionally require the compute trace** — they live inside the
+writeback loop, so `PROSPER_COMPUTELOG_CODE=0xADDR` (or `PROSPER_COMPUTELOG`) must be set as well.
+Arming only `PROSPER_COMPUTE_PARENTSCAN` gives the pre-dispatch census and an empty dump directory,
+which looks like "nothing corrupted" rather than "the second half never ran".
+
 `PROSPER_COMPUTE_PARENTSCAN_DUMP=DIR` additionally writes the input and output arrays of a dispatch that
 turns a **clean** array cyclic — the transition only, with the retained input required to belong to that
 same dispatch, so the pair in one filename is genuinely one dispatch. Two caveats: the switch takes a
-**program address**, not `=1` (it says so if given something that cannot be one), and coverage depends on
-how often a buffer is materialised — `PROSPER_COMPUTE_BUFFER_CACHE_MB=0` raised it from 3 submits to 9
-on a routed run, though the mechanism for that is not established.
+**program address**, not `=1` (it says so if given something that cannot be one), and coverage varies: `PROSPER_COMPUTE_BUFFER_CACHE_MB=0` raised it
+from 3 submits to 9 on a routed run, and **why is not established** — the scan runs before
+`acquire_cached_buffer`, so the obvious "a cache hit skips the hook" explanation is wrong.
 
 **`PROSPER_COMPUTE_SKIP_PROGRAM=0xADDR[,0xADDR...]` — decline named compute programs.** A bisection
 instrument: one dispatch can take down everything after it (a GPU hang costs the process its compute


### PR DESCRIPTION
## What this adds

`PROSPER_COMPUTE_PARENTSCAN=0xADDR` — a **CPU-side** cyclicity census of a compute program's stride-4
link arrays, taken from the exact bytes a dispatch reads (pre) and writes (post), plus a dump of both
halves when a dispatch turns a clean array cyclic.

```
[parentscan]       … dispatch=38 binding=4 addr=0x20f848a240 records=2063 terminating=2063 cyclic=0   cycle-nodes=0   longest=11 enc=(w>>3)&0x7ffffff
[parentscan]       … dispatch=38 binding=7 addr=0x20f849233c records=2063 terminating=1700 cyclic=363 cycle-nodes=3   longest=5
[parentscan]       … dispatch=38 binding=8 addr=0x20f848417c records=2063 terminating=1877 cyclic=186 cycle-nodes=124 longest=58
[parentscan-after] … dispatch=38 binding=4 addr=0x20f848a240 records=2063 terminating=2033 cyclic=30  cycle-nodes=20  longest=11 changed=…
[parentscan-dump]  program=0x413dc6700 wrote …/parent_20f848a240_s4983_d38_in.bin  (8252 bytes)
[parentscan-dump]  program=0x413dc6700 wrote …/parent_20f848a240_s4983_d38_out.bin (8252 bytes)
```

Those lines are consecutive in one run's log, **elided** — the address/program prefix and the trailing
`enc=` field are trimmed for width, and `[compute]` trace lines interleave in the real file. What is not
elided is the relationship: binding 4 goes in **clean**
(`cyclic=0`) and comes out **cyclic=30**, which is the transition, and only then do the two dump lines
fire. `terminating + cyclic == records` on every line. This run's transition is `0 -> 30`; the `537` quoted
elsewhere in this description is a *different* run's culprit dispatch, and the two are not the same
event — the dump fires on whichever dispatch first makes the transition in that process.

The previous two revisions of this block were hand-assembled across runs and did not satisfy the
arithmetic — the second still had ring lines under `cycle-nodes=0` and a dump under `cyclic=0`, both
structurally impossible. Third attempt. It is worth noting plainly that the *code* here was checked by
fuzzing against an independent reference twice, while the pasted evidence needed three rounds.

`terminating + cyclic == records` on every line — an earlier revision of this PR pasted sample output
that was hand-assembled across runs and did not satisfy that, which is exactly the "transcript does not
match the command above it" failure the project keeps recording. These lines are copied from one run.

## Why a CPU-side instrument, and not a capture

The question it answers is *"does this dispatch fail because its input was already cyclic, or does it
make its input cyclic?"* — and that needs the array **and** the runaway record from the same run.
Obtaining the array with `PROSPER_GPU_CAPTURE` does not work, because arming a capture **changes which
dispatches run away**:

| arm | dispatches of `0x413dc6700` hitting the trip cap |
| --- | --- |
| no capture (two runs) | 38,39,40,41,42,43,44,45,46,47,48 — 11, both parities, identical |
| capture armed | 39,41,43,45,47 — 5, odd ordinals only |

An instrument that alters the phenomenon cannot establish its cause. A walk of bytes the front half has
already materialised issues no submit, touches no GPU state and cannot reorder one, so it runs alongside
`PROSPER_CFG_TRIP_BOUND`'s witness and is read against it.

## What it established

**The causal direction, 22/22, one unperturbed run:**

| | input cyclic | input acyclic |
| --- | ---: | ---: |
| ran away (trip HIT) | **11** | **0** |
| terminated | **0** | **11** |

The cycle comes first; the non-termination follows. That retired a hypothesis I had been pursuing (that
the loop lowering fails and corrupts while spinning) and confirmed `GTA5_STATUS.md`'s existing causal
chain with same-run evidence.

**Then the culprit**, once the post-dispatch half was added and coverage widened with
`PROSPER_COMPUTE_BUFFER_CACHE_MB=0`, which raised it from 3 submits to 9 (**the mechanism for that is
not established** — the scan precedes `acquire_cached_buffer`, so "a cache hit skips the hook" does not
explain it and should not be repeated until someone derives the real reason): eight consecutive submits entirely clean — 88 dispatches,
`0->0` throughout — then **one dispatch turns a clean 2063-entry array into 537 cyclic entries while
terminating normally**. Subsequent odd dispatches read it and run away; even ones read the still-clean
partner and terminate, which is what the parity alternation in earlier runs had been.

**And the write set**, from the dump: 501 words changed, 192 link updates, 309 flags-only, every touched
word going low-bits `0 -> 2`, link deltas median 7 / max 260 — legitimate-looking path-compression work,
of which only 12 writes lie on a resulting cycle.

## Design notes

- **Restricted to `stride == 4`**, so it targets the per-item u32 arrays; the 64-byte record buffer is
  not a link array and scanning it would report noise as structure.
- **The line prints `records` and the encoding's shift/mask**, so a wrong encoding guess is visible
  rather than silent. The encoding is the guest's own `v_bfe_u32 v1, v1, 3, 27` with `NUM_RECORDS` as the
  bound; an out-of-range RDNA2 buffer load returns zero, which is what exits the guest's walk.
- **O(records)**, memoised — each array is classified in one pass rather than per-start.
- **The dump is bounded**: one retained input copy per link buffer (8 KiB here), overwritten each
  dispatch, and nothing is written unless `PROSPER_COMPUTE_PARENTSCAN_DUMP` names a directory **and** a
  clean→cyclic transition is seen.
- Diagnostic only: gated on the env var, emits nothing by default, changes no dispatch behaviour.

## Verification

Exact head `40e7110d`, Linux, in-distrobox build.

- Build: clean, **0 errors**.
- `ctest --no-tests=error -j4`: **280/280 passed**, exit 0.
- Exercised across ~10 routed runs; the tables above are its output.

No unit test accompanies this. It is a read-only census behind a `getenv`, and what would matter — that
it classifies a real link array correctly — is the routed evidence above, where its verdicts correlate
22/22 with an independent instrument (the trip-bound witness) that shares none of its code.

Refs #2711, #2542, #2716.
