### PR TITLE
fix(capture): a frame bundle's manifest drops format_version, so every GTA V F9 bundle aborts

### DIFF
--- a/prosper/src/gpu/gpu_capture_bundle.cpp
+++ b/prosper/src/gpu/gpu_capture_bundle.cpp
@@ -158,6 +158,15 @@ uint64_t resource_hash(const GpuCaptureBundle& bundle,
 
 GpuCaptureFile make_capture_manifest(const GpuCaptureFile& capture) {
     GpuCaptureFile manifest;
+    // Carry the source capture's format version. This is a field-by-field copy, and omitting this
+    // one field did NOT produce a wrong file -- serialize_gpu_capture() always writes kVersion --
+    // it produced a wrong VALIDATION: serialize validates `c.format_version`, which for a manifest
+    // stayed at GpuCaptureFile's default of 0. validate_captured_indirect_pointer_relocations()
+    // then read that 0 as "capture format older than v53" and refused a capture whose provenance was
+    // complete, aborting the whole frame bundle. Every Grand Theft Auto V (PPSA04263) F9 bundle died
+    // here (#2554 gate 2). Copying rather than forcing kVersion keeps the fail-safe direction: a
+    // genuinely old capture re-bundled still validates as the version it actually is.
+    manifest.format_version = capture.format_version;
     manifest.metadata = capture.metadata;
     manifest.expected_output_hash = capture.expected_output_hash;
     manifest.expected_output_bytes = capture.expected_output_bytes;

--- a/prosper/tests/test_indirect_pointer_descriptor_range.cpp
+++ b/prosper/tests/test_indirect_pointer_descriptor_range.cpp
@@ -1,4 +1,5 @@
 #include "gpu/gpu_capture.hpp"
+#include "gpu/gpu_capture_bundle.hpp"
 #include "gpu/rdna2_decode.hpp"
 #include "gpu/rdna2_indirect_pointer_analysis.hpp"
 #include "gpu/rdna2_to_spirv.hpp"
@@ -522,6 +523,25 @@ void test_capture_roundtrip(const Shape& shape, const std::vector<uint32_t>& exa
                   compute.spirv, used_oversized.spirv,
                   replay.computes[0].resources.get()),
           "raw replay rejects a newly-live binding whose capture backing was omitted");
+
+    // #2554 gate 2. A frame bundle does not serialize the capture it is handed: it serializes a
+    // MANIFEST built by a field-by-field copy, and that copy validates before it is written. The
+    // copy used to drop format_version, so the manifest presented itself as version 0 and the
+    // provenance validator refused it as "older than v53" -- a capture built moments earlier by
+    // capture_submit_items(), whose provenance is complete and which replays correctly two CHECKs
+    // above. The refusal aborted the entire grab, which is why this title has never produced an F9
+    // bundle. `captured` is the same object those CHECKs just proved sound, so a failure here is
+    // about the bundle path alone.
+    {
+        GpuCaptureBundle bundle;
+        std::string bundle_error;
+        const bool appended = append_gpu_capture_bundle(bundle, captured, bundle_error);
+        CHECK(appended,
+              ("a complete v53 indirect-pointer capture appends to a frame bundle: " +
+               bundle_error).c_str());
+        CHECK(appended && bundle.submits.size() == 1u,
+              "the appended bundle holds exactly the one captured submit");
+    }
 
     GpuCaptureFile q_mutation = loaded;
     GpuCapturedResource* q_source = captured_resource_at(q_mutation, shape.source_pc);


### PR DESCRIPTION
Refs #2554 (gate 2).

## What was wrong

`append_gpu_capture_bundle()` does not serialize the capture it is handed. It serializes a
**manifest** built by `make_capture_manifest()` — a field-by-field copy — and that copy omitted
`format_version`, so the manifest kept `GpuCaptureFile`'s default of `0`.

`serialize_gpu_capture()` then **writes** `kVersion` but **validates** `c.format_version`. For a
manifest those two disagree — 0 against 55 — and `validate_captured_indirect_pointer_relocations()`
reads the 0 as *"capture format older than v53"*, refusing a capture whose provenance is complete and
aborting the entire grab.

No byte difference has been observed on disk — but the original claim that "nothing wrong reached
disk" is stronger than the evidence. `serialize_gpu_capture()` also **branches** on
`c.format_version`: `gpu_capture.cpp:3013`/`:3027` apply the pre-v28 legacy upgrade. With the field
at 0, **every bundle manifest ever written was serialized under pre-v28 legacy rules**. It comes out
byte-identical only because the capture path always fills `linear_row_pitch_bytes` for that shape and
`captured_size == 0` occurs only for buffers, where the legacy and current footprints coincide. That
is a contingency, not a guarantee.

That branch is also the **real** argument for copying rather than forcing `kVersion`: serialize's
legacy upgrade keys on the source version, so forcing the current one would write a re-bundled
pre-v28 capture as v55 *without* the upgrade `write_gpu_capture()` applies. Copying makes the bundle
path byte-consistent with the standalone path. (Reviewer's finding; my "fail-safe" framing was
weaker than the truth.)

## Why it matters

The F9 frame grab is the documented fastest loop for a rendered-frame bug, and it has **never**
produced a bundle for *Grand Theft Auto V* (`PPSA04263`) — the one title in the tracker whose world
does not render, and therefore the title that most needs it. #2554 recorded four sequential gates and
left gate 2's question open: *"which precondition actually fails here, now that the message can say
so."* This is the answer. The provenance was present; the field describing it was not copied.

## The failure scenario, exactly

Route `scripts/gta5/reach-story-mode.pad`, Linux/RADV, 4K, gameplay reached, grab armed with
`PROSPER_GRAB_BUNDLE_AFTER_MS=420000`:

```
[grab] frame-bundle: submit 38110 failed (indirect-pointer relocation lacks exact compute
       provenance (capture format older than v53, carriers=1 markers=1 format_version=0));
       grab aborted
[grab] frame-bundle aborted (see error above); not written
```

`carriers=1 markers=1` is a *well-formed* carrier. Only the version was wrong.

## The fix

Copy the source capture's `format_version` in `make_capture_manifest()`.

Copying rather than forcing `kVersion` is deliberate and is the fail-safe direction: a genuinely old
capture that is re-bundled still validates as the version it actually is, instead of being handed a
current version number and asked to prove provenance the format did not yet carry.

## Verification

**The regression arm is mutation-verified, and it reproduces the production failure string exactly.**
With the one-line fix neutralized and nothing else changed:

```
FAIL: a complete v53 indirect-pointer capture appends to a frame bundle: indirect-pointer
      relocation lacks exact compute provenance (capture format older than v53,
      carriers=1 markers=1 format_version=0)
FAIL: the appended bundle holds exactly the one captured submit
```

That is the live GTA V abort, character for character, including both counts — so the test is
demonstrably exercising the production path and not merely a lookalike.

The arm reuses `test_indirect_pointer_descriptor_range`'s existing `captured` object, which two
CHECKs earlier is already proven to serialize, deserialize and replay correctly. So a failure there
is attributable to the bundle path alone.

- `ctest --no-tests=error -j6`: **280/280 passed**, rc=0 (count quoted alongside the code per
  `CLAUDE.md`).
- Clean full build, 0 errors.

### End-to-end, on the title this is about

Same route and arming, **no `PROSPER_CAPTURE_ALLOW_UNPROVEN_INDIRECT`**, four runaway compute
programs declined so the run costs zero device losses:

```
[grab] frame-bundle: seeded boundary scanout 0x215ed10000 (3840x2160)
[grab] frame-bundle written (39 submits) -> frame_grab_PPSA04263_....prgbundle   (896 MB)
```

and that bundle **replays**:

```
gpu_replay --bundle frame_grab_PPSA04263_....prgbundle out.bmp
[gpureplay] bundle v2 submits=39 logical=3669480613 unique=895575273 ratio=0.244
rc=0
```

For contrast, a bundle captured from the same route *with* `ALLOW_UNPROVEN_INDIRECT` writes, but
then cannot be reconstructed. **Qualified after review:** this is plausibly the *same* stripped-manifest
artifact on the read path rather than evidence the override yields an unfaithful bundle — see the
note below.

```
gpu_replay: cannot reconstruct bundle submit 1: indirect-pointer relocation has stale shader,
            launch, source, or proof state
```

So the override was not an equivalent workaround: it produced an unreplayable bundle, exactly as its
own `NOT FAITHFUL REPLAY` warning says. This PR produces a replayable one.

## What this deliberately does NOT change

**Nothing any title renders.** This is the capture/replay path only. It does not touch what is
authorized, decoded, or drawn, and it does not by itself advance GTA V — it makes the instrument that
investigates GTA V work.

It also does not address #2554's other gates: gate 1 (present-count window), gate 3 (bundle byte
budget) and the withdrawn gate 4 are untouched. Note for that issue: gate 3 did **not** bite in these
runs — one gameplay frame came to 896 MB, well under the 2 GiB default — so the 3.27 GB measured
there is scene- and configuration-dependent rather than a fixed property of the title.

## Risk

Low. One field added to a field-by-field copy, in the direction that makes a manifest describe
itself accurately. The class of bug it belongs to — a hand-maintained copy that silently omits a
field — is worth noting for review: nothing in the type system or the tests caught a dropped field,
and the symptom surfaced far away, as a provenance refusal.



## Post-review note: this makes a pre-existing incompatibility reachable

Independent review established that `make_capture_manifest()` strips every blob payload **by design**
(the bytes live in the bundle's dedup dictionary), while four validators reached from
`validate_failure_diagnostics()` dereference those payloads and bound-check against `bytes.size()`:
`gpu_capture.cpp:1673`, `:1730`, `:1818`, `:1904`. On a manifest that size is always 0.

Before this fix, the `< 51` / `< 53` version gates short-circuited two of them, so the blob
dereference was never reached. This patch removes that accidental shield — so the "fifth F9 gate" I
reported on #2554 (`packed-pointer state references an invalid resource blob`) is character-for-character
the failure at `gpu_capture.cpp:1820`, reached on a manifest whose blobs are empty by construction.

**Not a regression**: those submits aborted before this PR too, with the version message instead. But
it means gate 5 is most likely an instrument artifact rather than a title-side gate, and I have
corrected #2554 accordingly. The underlying design question — where provenance should be proven when
the manifest deliberately lacks payloads — is filed separately, together with a second dropped field
(`resource_provenance`) that the same review found.

Note `capture_blob_payload_omitted()` (`gpu_capture.cpp:757`) already exists for exactly this
situation and is used at six sites; none of these four validators consults it.