### PR TITLE
fix(dsbridge): the miss classifier reported a sibling's reason, not the rejected entry's

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -2042,6 +2042,12 @@ if(TARGET prosper_core)
       target_link_libraries(test_textured_interp_render PRIVATE prosper_core Vulkan::Vulkan)
       add_test(NAME textured_interp_render COMMAND test_textured_interp_render)
 
+      # The sampled-depth bridge's miss classifier must name the reason belonging to the entry it
+      # rejected, not the first failing reason across every sibling at that address.
+      add_executable(test_dsbridge_miss_classifier tests/test_dsbridge_miss_classifier.cpp)
+      target_link_libraries(test_dsbridge_miss_classifier PRIVATE prosper_core Vulkan::Vulkan)
+      add_test(NAME dsbridge_miss_classifier COMMAND test_dsbridge_miss_classifier)
+
       # IMAGE_SAMPLE_C_LZ 2D (shadow-map compare, #1271): manual-dref lowering, end-to-end.
       add_executable(test_shadow_compare_render tests/test_shadow_compare_render.cpp)
       target_link_libraries(test_shadow_compare_render PRIVATE prosper_core Vulkan::Vulkan)

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2799,11 +2799,29 @@ inline bool is_retained_ds_plane(uint64_t addr, uint32_t* w = nullptr, uint32_t*
 // bridge earlier in the process. Keeping the classification separate makes the reasoning testable
 // without either hazard, and the log becomes a thin consumer.
 struct DsBridgeMiss {
+    // An enum rather than a string, so a consumer cannot compare against a literal that no longer
+    // exists and cannot construct a string_view from a null reason. `None` is a real state: the
+    // address matched a plane and nothing disqualified it, which is what a SERVABLE address
+    // classifies as.
+    enum class Reason { None, NoEntry, Extent, Uninitialized, StencilInvalid, DepthInvalid };
+    Reason reason = Reason::NoEntry;
     bool matched_plane = false;      // the address is a plane of SOME retained surface
     bool extent_is_reason = false;   // ...and nothing at that address was the right size
-    const char* why = nullptr;       // nullptr when the address matched nothing at all
     uint32_t cached_w = 0, cached_h = 0;  // a mismatching sibling's extent, for the detail string
 };
+// The reason word the bridge log prints; empty for NoEntry (that bucket is unbounded and genuinely
+// "not ours") and for None.
+inline const char* ds_bridge_miss_reason_name(DsBridgeMiss::Reason reason) {
+    switch (reason) {
+        case DsBridgeMiss::Reason::Extent:         return "extent";
+        case DsBridgeMiss::Reason::Uninitialized:  return "uninitialized";
+        case DsBridgeMiss::Reason::StencilInvalid: return "stencil-invalid";
+        case DsBridgeMiss::Reason::DepthInvalid:   return "depth-invalid";
+        case DsBridgeMiss::Reason::NoEntry:
+        case DsBridgeMiss::Reason::None:           break;
+    }
+    return "";
+}
 inline DsBridgeMiss classify_ds_bridge_miss(uint64_t addr, uint32_t width, uint32_t height,
                                             uint32_t render_scale = 1,
                                             bool normalized_sampling = true) {
@@ -2840,11 +2858,12 @@ inline DsBridgeMiss classify_ds_bridge_miss(uint64_t addr, uint32_t width, uint3
     // "extent (T# wants 1024x1536, retained image is 3840x2160)" 1403 times on one route while the
     // cache simultaneously held a 1024x1536 D32_SFLOAT entry at that very address.
     out.extent_is_reason = extent_bad && !extent_ok_exists;
-    if (!out.matched_plane)          out.why = nullptr;
-    else if (out.extent_is_reason)   out.why = "extent";
-    else if (uninit)                 out.why = "uninitialized";
-    else if (stencil_req)            out.why = "stencil-invalid";
-    else if (depth_req)              out.why = "depth-invalid";
+    if (!out.matched_plane)          out.reason = DsBridgeMiss::Reason::NoEntry;
+    else if (out.extent_is_reason)   out.reason = DsBridgeMiss::Reason::Extent;
+    else if (uninit)                 out.reason = DsBridgeMiss::Reason::Uninitialized;
+    else if (stencil_req)            out.reason = DsBridgeMiss::Reason::StencilInvalid;
+    else if (depth_req)              out.reason = DsBridgeMiss::Reason::DepthInvalid;
+    else                             out.reason = DsBridgeMiss::Reason::None;
     return out;
 }
 // The reason text the bridge log prints. Keyed off the CLASSIFIED reason, never off "some sibling
@@ -2852,13 +2871,14 @@ inline DsBridgeMiss classify_ds_bridge_miss(uint64_t addr, uint32_t width, uint3
 // extent sentence describing a stale sibling — text that contradicted the counter it was filed
 // under and described a mismatch that was not the reason for anything.
 inline std::string ds_bridge_miss_detail(const DsBridgeMiss& miss, uint32_t width, uint32_t height) {
-    if (!miss.why) return {};
+    if (miss.reason == DsBridgeMiss::Reason::None ||
+        miss.reason == DsBridgeMiss::Reason::NoEntry) return {};
     char detail[96];
     if (miss.extent_is_reason)
         std::snprintf(detail, sizeof detail, "extent (T# wants %ux%u, retained image is %ux%u)",
                       width, height, miss.cached_w, miss.cached_h);
     else
-        std::snprintf(detail, sizeof detail, "%s", miss.why);
+        std::snprintf(detail, sizeof detail, "%s", ds_bridge_miss_reason_name(miss.reason));
     return detail;
 }
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
@@ -2940,20 +2960,25 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
             // "the surface is here and we declined it" -- they call for opposite fixes.
             const DsBridgeMiss miss = classify_ds_bridge_miss(
                 addr, width, height, render_scale, normalized_sampling);
-            if (!miss.matched_plane) { stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed); }
-            else if (miss.extent_is_reason) { stats.miss_extent.fetch_add(1, std::memory_order_relaxed); }
-            else if (miss.why == std::string_view("uninitialized")) {
-                stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed); }
-            else if (miss.why == std::string_view("stencil-invalid")) {
-                stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed); }
-            else if (miss.why == std::string_view("depth-invalid")) {
-                stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed); }
+            switch (miss.reason) {
+                case DsBridgeMiss::Reason::NoEntry:
+                    stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed); break;
+                case DsBridgeMiss::Reason::Extent:
+                    stats.miss_extent.fetch_add(1, std::memory_order_relaxed); break;
+                case DsBridgeMiss::Reason::Uninitialized:
+                    stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed); break;
+                case DsBridgeMiss::Reason::StencilInvalid:
+                    stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed); break;
+                case DsBridgeMiss::Reason::DepthInvalid:
+                    stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed); break;
+                case DsBridgeMiss::Reason::None: break;  // servable; the selector, not this, decides
+            }
             // Per-ADDRESS, because an aggregate cannot name the fix. A run reporting
             // "depth-invalid=1089" says a thousand bindings declined; it does not say whether that
             // is one surface declining a thousand times or a thousand surfaces declining once, and
             // those are different defects. Only addresses that DID match a live surface are kept --
             // the no-entry bucket is unbounded and is genuinely just "not ours".
-            if (miss.why) {
+            if (!ds_bridge_miss_detail(miss, width, height).empty()) {
                 static std::mutex reason_mutex;
                 std::lock_guard lock(reason_mutex);
                 auto& per = per_address_misses();

--- a/prosper/tests/render_runner.h
+++ b/prosper/tests/render_runner.h
@@ -2791,6 +2791,76 @@ inline bool is_retained_ds_plane(uint64_t addr, uint32_t* w = nullptr, uint32_t*
     }
     return false;
 }
+// Why a sampled-depth lookup missed, classified against the retained-DS cache.
+//
+// Pure and environment-free on purpose. The logging path that consumes it is gated on
+// PROSPER_DSBRIDGE_LOG, which is read into a function-local static — so a test that armed that
+// variable would both trip the cached-env-arming guard and depend on nothing having called the
+// bridge earlier in the process. Keeping the classification separate makes the reasoning testable
+// without either hazard, and the log becomes a thin consumer.
+struct DsBridgeMiss {
+    bool matched_plane = false;      // the address is a plane of SOME retained surface
+    bool extent_is_reason = false;   // ...and nothing at that address was the right size
+    const char* why = nullptr;       // nullptr when the address matched nothing at all
+    uint32_t cached_w = 0, cached_h = 0;  // a mismatching sibling's extent, for the detail string
+};
+inline DsBridgeMiss classify_ds_bridge_miss(uint64_t addr, uint32_t width, uint32_t height,
+                                            uint32_t render_scale = 1,
+                                            bool normalized_sampling = true) {
+    DsBridgeMiss out;
+    bool extent_bad = false, uninit = false, depth_req = false, stencil_req = false;
+    // Did ANY entry at this address have a usable extent? One address can hold several cache
+    // entries — a live surface plus a stale sibling retained at a different size — and only this
+    // flag separates "nothing here is the right size" from "the right size is here and failed for
+    // another reason". Without it a stale sibling sets extent_bad and, being tested first, masks
+    // the real reason permanently.
+    bool extent_ok_exists = false;
+    for (const auto& [key, image] : persistent_ds_cache()) {
+        const bool d = key.dr == addr || key.dw == addr;
+        const bool st = key.sr == addr || key.sw == addr;
+        if (!d && !st) continue;
+        out.matched_plane = true;
+        if (!prosper::frontend::rtt_sampled_extent_compatible(
+                width, height, key.w, key.h, render_scale, normalized_sampling)) {
+            extent_bad = true;
+            out.cached_w = key.w;
+            out.cached_h = key.h;
+            continue;
+        }
+        extent_ok_exists = true;
+        if (!image.layout_initialized || !image.image) { uninit = true; continue; }
+        if (d && !image.depth_valid) depth_req = true;
+        if (st && !image.stencil_valid) stencil_req = true;
+    }
+    // Extent is the reason ONLY when nothing at this address was the right size. Previously any
+    // single wrong-sized sibling won this branch outright, so a surface prosper held at exactly the
+    // requested size and declined for depth-invalid was reported as an extent mismatch against the
+    // sibling's dimensions — naming the wrong entry, the wrong problem, and a fix that does not
+    // exist. Measured on Grand Theft Auto V (PPSA04263): 0x20945c0000 reported
+    // "extent (T# wants 1024x1536, retained image is 3840x2160)" 1403 times on one route while the
+    // cache simultaneously held a 1024x1536 D32_SFLOAT entry at that very address.
+    out.extent_is_reason = extent_bad && !extent_ok_exists;
+    if (!out.matched_plane)          out.why = nullptr;
+    else if (out.extent_is_reason)   out.why = "extent";
+    else if (uninit)                 out.why = "uninitialized";
+    else if (stencil_req)            out.why = "stencil-invalid";
+    else if (depth_req)              out.why = "depth-invalid";
+    return out;
+}
+// The reason text the bridge log prints. Keyed off the CLASSIFIED reason, never off "some sibling
+// mismatched": those had drifted apart, so a surface declined for depth-invalid still printed the
+// extent sentence describing a stale sibling — text that contradicted the counter it was filed
+// under and described a mismatch that was not the reason for anything.
+inline std::string ds_bridge_miss_detail(const DsBridgeMiss& miss, uint32_t width, uint32_t height) {
+    if (!miss.why) return {};
+    char detail[96];
+    if (miss.extent_is_reason)
+        std::snprintf(detail, sizeof detail, "extent (T# wants %ux%u, retained image is %ux%u)",
+                      width, height, miss.cached_w, miss.cached_h);
+    else
+        std::snprintf(detail, sizeof detail, "%s", miss.why);
+    return detail;
+}
 inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t width,
                                                       uint32_t height,
                                                       uint32_t render_scale = 1,
@@ -2868,55 +2938,28 @@ inline PersistentDsSampled find_persistent_ds_sampled(uint64_t addr, uint32_t wi
         } else {
             // Classify the miss against the cache, so "no such surface" is never confused with
             // "the surface is here and we declined it" -- they call for opposite fixes.
-            bool matched_plane = false, extent_bad = false, uninit = false;
-            bool depth_req = false, stencil_req = false;
-            uint32_t cached_w = 0, cached_h = 0;
-            for (const auto& [key, image] : persistent_ds_cache()) {
-                const bool d = key.dr == addr || key.dw == addr;
-                const bool st = key.sr == addr || key.sw == addr;
-                if (!d && !st) continue;
-                matched_plane = true;
-                if (!prosper::frontend::rtt_sampled_extent_compatible(
-                        width, height, key.w, key.h, render_scale, normalized_sampling)) {
-                    extent_bad = true;
-                    cached_w = key.w;
-                    cached_h = key.h;
-                    continue;
-                }
-                if (!image.layout_initialized || !image.image) { uninit = true; continue; }
-                if (d && !image.depth_valid) depth_req = true;
-                if (st && !image.stencil_valid) stencil_req = true;
-            }
-            const char* why = nullptr;
-            if (!matched_plane) { stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed); }
-            else if (extent_bad) { stats.miss_extent.fetch_add(1, std::memory_order_relaxed);
-                                   why = "extent"; }
-            else if (uninit) { stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed);
-                               why = "uninitialized"; }
-            else if (stencil_req) {
-                stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed);
-                why = "stencil-invalid"; }
-            else if (depth_req) { stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed);
-                                  why = "depth-invalid"; }
+            const DsBridgeMiss miss = classify_ds_bridge_miss(
+                addr, width, height, render_scale, normalized_sampling);
+            if (!miss.matched_plane) { stats.miss_no_entry.fetch_add(1, std::memory_order_relaxed); }
+            else if (miss.extent_is_reason) { stats.miss_extent.fetch_add(1, std::memory_order_relaxed); }
+            else if (miss.why == std::string_view("uninitialized")) {
+                stats.miss_uninitialized.fetch_add(1, std::memory_order_relaxed); }
+            else if (miss.why == std::string_view("stencil-invalid")) {
+                stats.miss_stencil_invalid.fetch_add(1, std::memory_order_relaxed); }
+            else if (miss.why == std::string_view("depth-invalid")) {
+                stats.miss_depth_invalid.fetch_add(1, std::memory_order_relaxed); }
             // Per-ADDRESS, because an aggregate cannot name the fix. A run reporting
             // "depth-invalid=1089" says a thousand bindings declined; it does not say whether that
             // is one surface declining a thousand times or a thousand surfaces declining once, and
             // those are different defects. Only addresses that DID match a live surface are kept --
             // the no-entry bucket is unbounded and is genuinely just "not ours".
-            if (why) {
+            if (miss.why) {
                 static std::mutex reason_mutex;
                 std::lock_guard lock(reason_mutex);
                 auto& per = per_address_misses();
                 if (per.size() < 256 || per.count(addr)) {
                     auto& row = per[addr];
-                    char detail[96];
-                    if (extent_bad)
-                        std::snprintf(detail, sizeof detail,
-                                      "extent (T# wants %ux%u, retained image is %ux%u)",
-                                      width, height, cached_w, cached_h);
-                    else
-                        std::snprintf(detail, sizeof detail, "%s", why);
-                    row.first = detail;
+                    row.first = ds_bridge_miss_detail(miss, width, height);
                     ++row.second;
                 }
             }

--- a/prosper/tests/test_dsbridge_miss_classifier.cpp
+++ b/prosper/tests/test_dsbridge_miss_classifier.cpp
@@ -1,0 +1,148 @@
+// test_dsbridge_miss_classifier — the sampled-depth bridge must name the reason belonging to the
+// entry it actually rejected, not the first failing reason found across every sibling at that
+// address.
+//
+// One address can hold several persistent-DS cache entries: a live surface plus a stale sibling
+// retained at a different size. The miss classifier set `extent_bad` from ANY mismatching sibling
+// and tested it before every validity reason, so an address holding a correctly-sized entry that
+// failed for depth-invalid was filed under `extent` and printed a sentence describing the sibling's
+// dimensions. The detail string had the same defect independently — it keyed off `extent_bad` even
+// when the classified reason was something else, so the text contradicted the counter it was filed
+// under.
+//
+// Measured on Grand Theft Auto V (PPSA04263): 0x20945c0000 reported
+// `extent (T# wants 1024x1536, retained image is 3840x2160)` 1403 times on one route while the cache
+// held a 1024x1536 D32_SFLOAT entry at that very address. That mislabel sent an investigation after
+// a non-existent extent bug; the true reason is depth-invalid, which is separately falsified ground.
+//
+// This exercises `classify_ds_bridge_miss` directly rather than through the log. The log path is
+// gated on PROSPER_DSBRIDGE_LOG, which is read into a function-local static — arming it from a test
+// would trip the cached-env-arming guard AND make the result depend on nothing having called the
+// bridge earlier in the process.
+
+#include "render_runner.h"
+
+#include <cstdio>
+#include <cstdint>
+#include <string>
+
+static int failures = 0;
+#define CHECK(condition, message) do { \
+    if (!(condition)) { std::fprintf(stderr, "FAIL: %s\n", message); ++failures; } \
+} while (0)
+
+namespace {
+
+constexpr uint64_t kAddr = 0x20945c0000ull;   // the address the routed run reported
+constexpr uint32_t kWantW = 1024, kWantH = 1536;
+constexpr uint32_t kStaleW = 3840, kStaleH = 2160;
+
+prosper::test::PersistentDsKey key_for(uint32_t w, uint32_t h) {
+    return prosper::test::PersistentDsKey{
+        kAddr, kAddr, 0, 0, 0, w, h, static_cast<uint32_t>(VK_FORMAT_D32_SFLOAT)};
+}
+
+std::string reason_of(const prosper::test::DsBridgeMiss& miss) {
+    return prosper::test::ds_bridge_miss_detail(miss, kWantW, kWantH);
+}
+
+}  // namespace
+
+int main() {
+    auto& cache = prosper::test::persistent_ds_cache();
+
+    // --- Arm 1: a right-sized entry failing for depth-invalid, beside a wrong-sized sibling ------
+    {
+        const auto stale = key_for(kStaleW, kStaleH);
+        const auto live = key_for(kWantW, kWantH);
+        auto& stale_image = cache[stale];
+        auto& live_image = cache[live];
+        stale_image.image = (VkImage)(uintptr_t)1;
+        stale_image.layout_initialized = true;
+        stale_image.depth_valid = true;      // valid, but the wrong size for this request
+        live_image.image = (VkImage)(uintptr_t)2;
+        live_image.layout_initialized = true;
+        live_image.depth_valid = false;      // right size, invalid depth — the REAL reason
+
+        const auto miss = prosper::test::classify_ds_bridge_miss(kAddr, kWantW, kWantH);
+        CHECK(miss.matched_plane, "the address is recognised as a plane of a retained surface");
+        CHECK(!miss.extent_is_reason,
+              "extent is not the reason when the right size is present and failed otherwise");
+        const std::string why = reason_of(miss);
+        CHECK(why == "depth-invalid",
+              ("the reason names the rejected entry, not a wrong-sized sibling (got \"" + why +
+               "\")").c_str());
+        CHECK(why.find("extent") == std::string::npos,
+              "the detail string does not describe an extent mismatch that is not the reason");
+        CHECK(!prosper::test::find_persistent_ds_sampled(kAddr, kWantW, kWantH).image,
+              "the lookup itself still declines - this fixes the REASON, not the outcome");
+
+        cache.erase(stale);
+        cache.erase(live);
+    }
+
+    // --- Arm 2 (positive control): nothing at this address is the right size -> extent IS the ----
+    // reason. Without this arm the fix is indistinguishable from deleting the extent branch.
+    {
+        const auto stale = key_for(kStaleW, kStaleH);
+        auto& stale_image = cache[stale];
+        stale_image.image = (VkImage)(uintptr_t)1;
+        stale_image.layout_initialized = true;
+        stale_image.depth_valid = true;
+
+        const auto miss = prosper::test::classify_ds_bridge_miss(kAddr, kWantW, kWantH);
+        CHECK(miss.matched_plane && miss.extent_is_reason,
+              "extent remains the reason when NOTHING at the address is the right size");
+        const std::string why = reason_of(miss);
+        CHECK(why.rfind("extent", 0) == 0,
+              ("the extent reason is reported (got \"" + why + "\")").c_str());
+        CHECK(why.find("1024x1536") != std::string::npos &&
+                  why.find("3840x2160") != std::string::npos,
+              "the extent detail reports both the requested and the retained dimensions");
+
+        cache.erase(stale);
+    }
+
+    // --- Arm 3: a right-sized VALID entry is served, so the arms above are not passing merely -----
+    // because everything declines.
+    {
+        const auto stale = key_for(kStaleW, kStaleH);
+        const auto live = key_for(kWantW, kWantH);
+        auto& stale_image = cache[stale];
+        auto& live_image = cache[live];
+        stale_image.image = (VkImage)(uintptr_t)1;
+        stale_image.layout_initialized = true;
+        stale_image.depth_valid = true;
+        live_image.image = (VkImage)(uintptr_t)2;
+        live_image.layout_initialized = true;
+        live_image.depth_valid = true;
+        prosper::test::note_persistent_ds_depth_write(live_image, true, true);
+
+        const auto found = prosper::test::find_persistent_ds_sampled(kAddr, kWantW, kWantH);
+        CHECK(found.image == &live_image,
+              "the right-sized valid entry is selected over the wrong-sized sibling");
+        CHECK(found.width == kWantW && found.height == kWantH,
+              "the served view reports the retained entry's own extent");
+        const auto miss = prosper::test::classify_ds_bridge_miss(kAddr, kWantW, kWantH);
+        CHECK(miss.why == nullptr || std::string(miss.why).empty(),
+              "a servable address classifies with no miss reason");
+
+        cache.erase(stale);
+        cache.erase(live);
+    }
+
+    // --- Arm 4: an address the cache has never heard of stays "no entry", not a fabricated -------
+    // reason.
+    {
+        const auto miss = prosper::test::classify_ds_bridge_miss(0x20dead0000ull, kWantW, kWantH);
+        CHECK(!miss.matched_plane && miss.why == nullptr,
+              "an unknown address matches no plane and is given no reason");
+    }
+
+    if (failures) {
+        std::fprintf(stderr, "test_dsbridge_miss_classifier: %d failure(s)\n", failures);
+        return 1;
+    }
+    std::printf("test_dsbridge_miss_classifier: all checks passed\n");
+    return 0;
+}

--- a/prosper/tests/test_dsbridge_miss_classifier.cpp
+++ b/prosper/tests/test_dsbridge_miss_classifier.cpp
@@ -124,7 +124,7 @@ int main() {
         CHECK(found.width == kWantW && found.height == kWantH,
               "the served view reports the retained entry's own extent");
         const auto miss = prosper::test::classify_ds_bridge_miss(kAddr, kWantW, kWantH);
-        CHECK(miss.why == nullptr || std::string(miss.why).empty(),
+        CHECK(miss.reason == prosper::test::DsBridgeMiss::Reason::None,
               "a servable address classifies with no miss reason");
 
         cache.erase(stale);
@@ -135,8 +135,11 @@ int main() {
     // reason.
     {
         const auto miss = prosper::test::classify_ds_bridge_miss(0x20dead0000ull, kWantW, kWantH);
-        CHECK(!miss.matched_plane && miss.why == nullptr,
-              "an unknown address matches no plane and is given no reason");
+        CHECK(!miss.matched_plane &&
+                  miss.reason == prosper::test::DsBridgeMiss::Reason::NoEntry,
+              "an unknown address matches no plane and is classified as no-entry");
+        CHECK(reason_of(miss).empty(),
+              "no-entry prints no reason text: that bucket is unbounded and genuinely not ours");
     }
 
     if (failures) {


### PR DESCRIPTION
Independent of #2718 (different file, different subsystem); both came out of the same GTA V session.
Refs #2723.

## What was wrong

One address can hold several persistent-DS cache entries — a live surface plus a stale sibling
retained at a different size. The miss classifier set `extent_bad` from **any** mismatching sibling
and tested it **before** every validity reason:

```cpp
else if (extent_bad) { ... why = "extent"; }
else if (uninit) ...
else if (stencil_req) ...
else if (depth_req) ...
```

So an address holding a correctly-sized entry that failed for `depth-invalid` was filed under
`extent`, and the sentence it printed described the *sibling's* dimensions.

The detail string carried the same defect independently — it keyed off `extent_bad` rather than the
classified reason, so the text could contradict the counter it was filed under.

## The failure scenario, measured

*Grand Theft Auto V* (`PPSA04263`), `scripts/gta5/reach-story-mode.pad`, Linux/RADV,
`PROSPER_DSBRIDGE_LOG=1`:

```
[dsbridge] declined addr=0x20945c0000 reason=extent (T# wants 1024x1536, retained image is 3840x2160) x1403
```

and, from `PROSPER_DSLOG=1` on the same run, the cache simultaneously holds:

```
dr=0x20945c0000 slice=0 1024x1536 fmt=126 dvalid=0 svalid=0
```

A 1024x1536 `D32_SFLOAT` entry **at that very address**, exactly the size the T# asked for. The true
reason is `depth-invalid`.

**This is not cosmetic.** The reported reason named a mismatch that was not the reason for anything
and pointed at a fix that does not exist. It cost this session a full investigation into a
non-existent extent bug — I filed it, chased it, and only found the classifier when I went to add a
per-lookup diagnostic. `depth-invalid` is separately falsified ground in `docs/GTA5_STATUS.md`, so the
mislabel routed effort away from the record that would have stopped it.

## The fix

Extent is the reason **only when nothing at the address was the right size**, and the detail string
follows the classified reason rather than `extent_bad`.

## Why the classification moved into its own function

`classify_ds_bridge_miss()` is pure and environment-free. The log path that consumes it is gated on
`PROSPER_DSBRIDGE_LOG`, which is read into a **function-local static** — so a test that armed that
variable would both trip the `cached_env_arming_logic` guard (it did, on my first attempt) and depend
on nothing having called the bridge earlier in the process. Separating the reasoning from the
reporting removes both hazards, and the log becomes a thin consumer.

## What this deliberately does NOT change

**Whether anything is declined, and therefore what any title renders.** This changes the *reason a
decline is filed under*, never the decline. `find_persistent_ds_sampled()`'s selection logic is
untouched — arm 1 asserts the lookup still declines.

## Verification

- `ctest --no-tests=error -j6`: **281/281 passed**, rc=0 (280 before; this PR adds one).
- `tools/output/check_ascii_output.py`: `== all checks passed ==`.
- Clean full build, 0 errors.

**Mutation-verified.** With `extent_is_reason` reverted to the old `extent_bad` and nothing else
changed, 4 assertions fail and the reason string reproduces the production text character for
character:

```
FAIL: extent is not the reason when the right size is present and failed otherwise
FAIL: the reason names the rejected entry, not a wrong-sized sibling
      (got "extent (T# wants 1024x1536, retained image is 3840x2160)")
FAIL: the detail string does not describe an extent mismatch that is not the reason
FAIL: a servable address classifies with no miss reason
```

Four arms, including two controls chosen so the fix cannot pass by weakening the branch:

- **arm 2 (positive control)** — with only a wrong-sized entry present, `extent` is still the reason
  and still reports both dimensions. Without this, deleting the extent branch outright would pass.
- **arm 3** — a right-sized *valid* entry is still served, so arms 1 and 2 are not passing merely
  because everything declines.
- **arm 4** — an unknown address stays "no entry" and is given no fabricated reason.
