### PR TITLE
fix(capture): four provenance validators dereference payloads a bundle manifest strips by design

### DIFF
--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -759,29 +759,25 @@ bool capture_blob_payload_omitted(const GpuCaptureBlob& blob) {
            blob.content_hash == gpu_capture_hash(nullptr, 0);
 }
 
-// True when this compute's blob-backed resources reference payloads that were deliberately omitted,
-// i.e. we are validating a bundle MANIFEST rather than a capture.
+// True when EVERY blob in this capture had its payload deliberately omitted -- i.e. this is a bundle
+// MANIFEST, not a capture.
 //
-// The provenance proof still happens -- just not here. Every capture reaching
+// Capture-level and all_of, deliberately. make_capture_manifest() strips every blob, so that is the
+// manifest's signature; sampling a single resource instead would let one degenerate blob in a
+// hand-edited or corrupt .prgcap disable provenance validation for a whole compute -- including on
+// the materialize_gpu_replay() path, which is the gate standing between a bundle and a relocation
+// replayed without provenance.
+//
+// The proof still happens, just not against the projection. Every capture reaching
 // append_gpu_capture_bundle() is produced by capture_submit_items(), which runs
-// validate_failure_diagnostics() on the payload-BEARING object at capture time
-// (capture_failure_diagnostics -> validate_failure_diagnostics). The manifest is then a projection of
-// that already-validated capture with its payloads stripped, so re-running the deep proof against it
-// is duplication that cannot succeed: host_data would point into an empty vector.
-//
-// Getting this wrong is what made every GTA V F9 bundle abort. The version gates (`< 51`, `< 53`)
-// used to short-circuit two of these validators, so the blob dereference was never reached; fixing a
-// dropped format_version (#2718) removed that accidental shield and the real incompatibility
-// surfaced as "packed-pointer state references an invalid resource blob" on 3 of 4 gameplay grabs.
-bool captured_compute_payloads_omitted(const GpuCaptureFile& capture,
-                                       const GpuCapturedCompute& compute) {
-    if (!compute.resources.present) return false;
-    return std::any_of(compute.resources.resources.begin(), compute.resources.resources.end(),
-                       [&](const GpuCapturedResource& captured) {
-                           return captured.blob_index != UINT32_MAX &&
-                                  captured.blob_index < capture.blobs.size() &&
-                                  capture_blob_payload_omitted(capture.blobs[captured.blob_index]);
-                       });
+// validate_failure_diagnostics() on the payload-BEARING object at capture time. That is an invariant
+// of its two callers (gpu_timeline.cpp's append_runtime_capture_bundle and
+// append_capture_to_frame_bundle, both fed by capture_gpustate_submit /
+// capture_gpustate_target_submit) and is enforced nowhere else: a third caller must preserve it, or
+// restore validation by another route.
+bool capture_is_manifest(const GpuCaptureFile& capture) {
+    return !capture.blobs.empty() &&
+           std::all_of(capture.blobs.begin(), capture.blobs.end(), capture_blob_payload_omitted);
 }
 
 struct Interval {
@@ -1687,6 +1683,19 @@ bool validate_captured_nullable_output_raw_buffer(
         return false;
     }
 
+    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
+    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
+    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
+    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
+    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    if (capture_is_manifest(capture)) return true;
+
+    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
+    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
+    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
+    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
+    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());
     for (const GpuCapturedResource& captured : compute.resources.resources) {
@@ -1697,10 +1706,9 @@ bool validate_captured_nullable_output_raw_buffer(
                 return false;
             }
             if (captured.blob_index >= capture.blobs.size() ||
-                (!capture_blob_payload_omitted(capture.blobs[captured.blob_index]) &&
-                 (captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
-                  kGtaNullableOutputWitnessBytes >
-                      capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset))) {
+                captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
+                kGtaNullableOutputWitnessBytes >
+                    capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset) {
                 error = "nullable-output marker lacks its table witness";
                 return false;
             }
@@ -1742,6 +1750,13 @@ bool validate_captured_gta5_cf9200_no_backing(
         return false;
     }
 
+    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
+    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
+    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
+    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
+    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    if (capture_is_manifest(capture)) return true;
+
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());
     for (const GpuCapturedResource& captured : compute.resources.resources) {
@@ -1755,10 +1770,9 @@ bool validate_captured_gta5_cf9200_no_backing(
         }
         if (relevant) {
             if (captured.blob_index >= capture.blobs.size() ||
-                (!capture_blob_payload_omitted(capture.blobs[captured.blob_index]) &&
-                 (captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
-                  kGtaCf9200RootBytes >
-                      capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset))) {
+                captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
+                kGtaCf9200RootBytes >
+                    capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset) {
                 error = "GTA root-record marker lacks its 224-byte witness";
                 return false;
             }
@@ -1800,12 +1814,6 @@ bool validate_captured_gta5_packed_pointer(
         const GpuCaptureFile& capture, const GpuCapturedCompute& compute,
         std::string& error) {
     if (!compute.resources.present) return true;
-    // A payload-stripped MANIFEST cannot carry this proof: host_data would point into an empty
-    // vector, so the deep discover/validate below would fail for a capture whose provenance is
-    // sound. The proof already ran on the payload-bearing capture at capture time -- see
-    // captured_compute_payloads_omitted(). Skipping here loses nothing; failing here aborted every
-    // F9 bundle on GTA V.
-    if (captured_compute_payloads_omitted(capture, compute)) return true;
 
     const size_t candidates = static_cast<size_t>(std::count_if(
         compute.resources.resources.begin(), compute.resources.resources.end(),
@@ -1829,6 +1837,13 @@ bool validate_captured_gta5_packed_pointer(
         error = "packed-pointer state has stale captured launch provenance";
         return false;
     }
+
+    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
+    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
+    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
+    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
+    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    if (capture_is_manifest(capture)) return true;
 
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());
@@ -1876,12 +1891,6 @@ bool validate_captured_indirect_pointer_relocations(
         const GpuCaptureFile& capture, const GpuCapturedCompute& compute,
         std::string& error) {
     if (!compute.resources.present) return true;
-    // A payload-stripped MANIFEST cannot carry this proof: host_data would point into an empty
-    // vector, so the deep discover/validate below would fail for a capture whose provenance is
-    // sound. The proof already ran on the payload-bearing capture at capture time -- see
-    // captured_compute_payloads_omitted(). Skipping here loses nothing; failing here aborted every
-    // F9 bundle on GTA V.
-    if (captured_compute_payloads_omitted(capture, compute)) return true;
 
     const size_t marked = static_cast<size_t>(std::count_if(
         compute.resources.resources.begin(), compute.resources.resources.end(),
@@ -1930,6 +1939,13 @@ bool validate_captured_indirect_pointer_relocations(
         error = "indirect-pointer relocation has stale captured launch provenance";
         return false;
     }
+
+    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
+    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
+    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
+    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
+    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    if (capture_is_manifest(capture)) return true;
 
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -759,6 +759,31 @@ bool capture_blob_payload_omitted(const GpuCaptureBlob& blob) {
            blob.content_hash == gpu_capture_hash(nullptr, 0);
 }
 
+// True when this compute's blob-backed resources reference payloads that were deliberately omitted,
+// i.e. we are validating a bundle MANIFEST rather than a capture.
+//
+// The provenance proof still happens -- just not here. Every capture reaching
+// append_gpu_capture_bundle() is produced by capture_submit_items(), which runs
+// validate_failure_diagnostics() on the payload-BEARING object at capture time
+// (capture_failure_diagnostics -> validate_failure_diagnostics). The manifest is then a projection of
+// that already-validated capture with its payloads stripped, so re-running the deep proof against it
+// is duplication that cannot succeed: host_data would point into an empty vector.
+//
+// Getting this wrong is what made every GTA V F9 bundle abort. The version gates (`< 51`, `< 53`)
+// used to short-circuit two of these validators, so the blob dereference was never reached; fixing a
+// dropped format_version (#2718) removed that accidental shield and the real incompatibility
+// surfaced as "packed-pointer state references an invalid resource blob" on 3 of 4 gameplay grabs.
+bool captured_compute_payloads_omitted(const GpuCaptureFile& capture,
+                                       const GpuCapturedCompute& compute) {
+    if (!compute.resources.present) return false;
+    return std::any_of(compute.resources.resources.begin(), compute.resources.resources.end(),
+                       [&](const GpuCapturedResource& captured) {
+                           return captured.blob_index != UINT32_MAX &&
+                                  captured.blob_index < capture.blobs.size() &&
+                                  capture_blob_payload_omitted(capture.blobs[captured.blob_index]);
+                       });
+}
+
 struct Interval {
     uint64_t begin = 0;
     uint64_t end = 0;
@@ -1672,9 +1697,10 @@ bool validate_captured_nullable_output_raw_buffer(
                 return false;
             }
             if (captured.blob_index >= capture.blobs.size() ||
-                captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
-                kGtaNullableOutputWitnessBytes >
-                    capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset) {
+                (!capture_blob_payload_omitted(capture.blobs[captured.blob_index]) &&
+                 (captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
+                  kGtaNullableOutputWitnessBytes >
+                      capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset))) {
                 error = "nullable-output marker lacks its table witness";
                 return false;
             }
@@ -1729,9 +1755,10 @@ bool validate_captured_gta5_cf9200_no_backing(
         }
         if (relevant) {
             if (captured.blob_index >= capture.blobs.size() ||
-                captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
-                kGtaCf9200RootBytes >
-                    capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset) {
+                (!capture_blob_payload_omitted(capture.blobs[captured.blob_index]) &&
+                 (captured.blob_offset > capture.blobs[captured.blob_index].bytes.size() ||
+                  kGtaCf9200RootBytes >
+                      capture.blobs[captured.blob_index].bytes.size() - captured.blob_offset))) {
                 error = "GTA root-record marker lacks its 224-byte witness";
                 return false;
             }
@@ -1773,6 +1800,13 @@ bool validate_captured_gta5_packed_pointer(
         const GpuCaptureFile& capture, const GpuCapturedCompute& compute,
         std::string& error) {
     if (!compute.resources.present) return true;
+    // A payload-stripped MANIFEST cannot carry this proof: host_data would point into an empty
+    // vector, so the deep discover/validate below would fail for a capture whose provenance is
+    // sound. The proof already ran on the payload-bearing capture at capture time -- see
+    // captured_compute_payloads_omitted(). Skipping here loses nothing; failing here aborted every
+    // F9 bundle on GTA V.
+    if (captured_compute_payloads_omitted(capture, compute)) return true;
+
     const size_t candidates = static_cast<size_t>(std::count_if(
         compute.resources.resources.begin(), compute.resources.resources.end(),
         captured_resource_has_gta5_packed_pointer_candidate));
@@ -1842,6 +1876,13 @@ bool validate_captured_indirect_pointer_relocations(
         const GpuCaptureFile& capture, const GpuCapturedCompute& compute,
         std::string& error) {
     if (!compute.resources.present) return true;
+    // A payload-stripped MANIFEST cannot carry this proof: host_data would point into an empty
+    // vector, so the deep discover/validate below would fail for a capture whose provenance is
+    // sound. The proof already ran on the payload-bearing capture at capture time -- see
+    // captured_compute_payloads_omitted(). Skipping here loses nothing; failing here aborted every
+    // F9 bundle on GTA V.
+    if (captured_compute_payloads_omitted(capture, compute)) return true;
+
     const size_t marked = static_cast<size_t>(std::count_if(
         compute.resources.resources.begin(), compute.resources.resources.end(),
         [](const GpuCapturedResource& captured) {

--- a/prosper/src/gpu/gpu_capture.cpp
+++ b/prosper/src/gpu/gpu_capture.cpp
@@ -763,10 +763,12 @@ bool capture_blob_payload_omitted(const GpuCaptureBlob& blob) {
 // MANIFEST, not a capture.
 //
 // Capture-level and all_of, deliberately. make_capture_manifest() strips every blob, so that is the
-// manifest's signature; sampling a single resource instead would let one degenerate blob in a
+// manifest's signature; sampling a single resource instead would let ONE degenerate blob in a
 // hand-edited or corrupt .prgcap disable provenance validation for a whole compute -- including on
 // the materialize_gpu_replay() path, which is the gate standing between a bundle and a relocation
-// replayed without provenance.
+// replayed without provenance. Note the limit of that claim: a file in which EVERY blob is degenerate
+// is still accepted as a manifest. A .prgcap is a developer artifact rather than a trust boundary, so
+// that is a stated bound, not a defence.
 //
 // The proof still happens, just not against the projection. Every capture reaching
 // append_gpu_capture_bundle() is produced by capture_submit_items(), which runs
@@ -1685,16 +1687,12 @@ bool validate_captured_nullable_output_raw_buffer(
 
     // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
     // launch dimensions and recompile provenance in full, and on the deserialize side those are the
-    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
-    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
-    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    // only validation it ever receives. What it cannot carry is the witness BYTES. Not everything
+    // past this point needs them -- the sentinel and raw-shader checks below read descriptors and
+    // `internal_bytes`, which the manifest carries in full -- but the blob dereference does:
+    // `blob.bytes.data() + blob_offset` on an empty vector is `nullptr + offset`, declared as large
+    // as the witness, which the proof then reads through.
     if (capture_is_manifest(capture)) return true;
-
-    // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
-    // launch dimensions and recompile provenance in full, and on the deserialize side those are the
-    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
-    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
-    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
 
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());
@@ -1750,12 +1748,15 @@ bool validate_captured_gta5_cf9200_no_backing(
         return false;
     }
 
+    if (capture_is_manifest(capture)) return true;
+
     // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
     // launch dimensions and recompile provenance in full, and on the deserialize side those are the
-    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
-    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
-    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
-    if (capture_is_manifest(capture)) return true;
+    // only validation it ever receives. What it cannot carry is the witness BYTES. Not everything
+    // past this point needs them -- the sentinel and raw-shader checks below read descriptors and
+    // `internal_bytes`, which the manifest carries in full -- but the blob dereference does:
+    // `blob.bytes.data() + blob_offset` on an empty vector is `nullptr + offset`, declared as large
+    // as the witness, which the proof then reads through.
 
     ShaderResourceTable validated_resources;
     validated_resources.resources.reserve(compute.resources.resources.size());
@@ -1840,9 +1841,11 @@ bool validate_captured_gta5_packed_pointer(
 
     // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
     // launch dimensions and recompile provenance in full, and on the deserialize side those are the
-    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
-    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
-    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    // only validation it ever receives. What it cannot carry is the witness BYTES. Not everything
+    // past this point needs them -- the sentinel and raw-shader checks below read descriptors and
+    // `internal_bytes`, which the manifest carries in full -- but the blob dereference does:
+    // `blob.bytes.data() + blob_offset` on an empty vector is `nullptr + offset`, declared as large
+    // as the witness, which the proof then reads through.
     if (capture_is_manifest(capture)) return true;
 
     ShaderResourceTable validated_resources;
@@ -1942,9 +1945,11 @@ bool validate_captured_indirect_pointer_relocations(
 
     // Below the payload-INDEPENDENT checks above on purpose: a manifest carries markers, counts,
     // launch dimensions and recompile provenance in full, and on the deserialize side those are the
-    // only validation it ever receives. What it cannot carry is the witness BYTES, and everything
-    // past this point dereferences them -- `blob.bytes.data() + blob_offset` on an empty vector is
-    // `nullptr + offset`, declared as large as the witness, which the proof then reads through.
+    // only validation it ever receives. What it cannot carry is the witness BYTES. Not everything
+    // past this point needs them -- the sentinel and raw-shader checks below read descriptors and
+    // `internal_bytes`, which the manifest carries in full -- but the blob dereference does:
+    // `blob.bytes.data() + blob_offset` on an empty vector is `nullptr + offset`, declared as large
+    // as the witness, which the proof then reads through.
     if (capture_is_manifest(capture)) return true;
 
     ShaderResourceTable validated_resources;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -2548,9 +2548,13 @@ int main(int argc, char** argv) {
         GpuCaptureFile merged_capture;
         const bool merged_ok = capture_submit_items({}, {merged_compute}, nullable_operations, meta,
                                                     merged_reader, merged_capture, error);
-        const auto& marker_resource = merged_capture.computes[0].resources.resources.back();
-        CHECK(merged_ok && merged_capture.computes.size() == 1u &&
-                  marker_resource.blob_offset != 0u,
+        // Bind AFTER proving the vector is non-empty. Reading .back() first is an out-of-bounds read
+        // when capture_submit_items fails -- so the arm whose whole purpose is to turn a crash into a
+        // reported failure would crash instead of reporting it.
+        const bool fixture_ok = merged_ok && merged_capture.computes.size() == 1u &&
+                                !merged_capture.computes[0].resources.resources.empty();
+        CHECK(fixture_ok &&
+                  merged_capture.computes[0].resources.resources.back().blob_offset != 0u,
               "the merged-interval fixture really does give the marker a non-zero blob offset");
 
         GpuCaptureBundle witness_bundle;
@@ -2574,6 +2578,25 @@ int main(int argc, char** argv) {
                   !witness_restored.blobs.empty() && !witness_restored.blobs[0].bytes.empty(),
               "and materialization restores it from the dictionary");
     }
+
+    // The same guard at the OTHER site the crash review named. Site 1 above covers the
+    // nullable-output validator; without this the cf9200 root-record guard has no coverage at all,
+    // and "mutation-verified" would be true of one of the two sites the blocking finding named.
+    // Uses the cf9200 capture built below in this same file, so it costs a bundle round trip only.
+    struct Cf9200BundleProbe {
+        static void run(const GpuCaptureFile& capture) {
+            GpuCaptureBundle bundle;
+            std::string error;
+            const bool appended = append_gpu_capture_bundle(bundle, capture, error);
+            CHECK(appended,
+                  ("a cf9200 root-record capture appends to a bundle: " + error).c_str());
+            GpuCaptureFile manifest;
+            CHECK(appended &&
+                      materialize_gpu_capture_bundle_manifest(bundle, 0, manifest, error) &&
+                      !manifest.blobs.empty() && manifest.blobs[0].bytes.empty(),
+                  "the cf9200 manifest strips its payload -- otherwise the arm above is vacuous");
+        }
+    };
     std::vector<uint8_t> nullable_capture_bytes;
     GpuCaptureFile nullable_loaded;
     GpuReplayFrame nullable_replay;
@@ -2696,6 +2719,7 @@ int main(int argc, char** argv) {
               capture_submit_items({}, {cf9200_compute}, cf9200_operations, meta,
                                    cf9200_reader, cf9200_capture, error),
           "capture retains the exact root-record program, launch, sites, and shared witness");
+    Cf9200BundleProbe::run(cf9200_capture);
     std::vector<uint8_t> cf9200_capture_bytes;
     GpuCaptureFile cf9200_loaded;
     GpuReplayFrame cf9200_replay;

--- a/prosper/tests/test_gpu_capture.cpp
+++ b/prosper/tests/test_gpu_capture.cpp
@@ -1,4 +1,5 @@
 #include "../src/gpu/gpu_capture.hpp"
+#include "../src/gpu/gpu_capture_bundle.hpp"
 #include "../src/gpu/agc_shader_layout.hpp"
 #include "../src/gpu/guest_texture_layout.hpp"
 #include "../src/gpu/pm4_registers.hpp"
@@ -2504,6 +2505,75 @@ int main(int argc, char** argv) {
               nullable_capture.computes[0].resources.resources[0].captured_size ==
                   kGtaNullableOutputWitnessBytes,
           "capture retains the exact nullable-output shader, launch, marker, and table witness");
+
+    // A bundle MANIFEST must not be asked to re-prove provenance whose witness bytes it strips.
+    //
+    // make_capture_manifest() empties every blob deliberately (the bytes live in the bundle's dedup
+    // dictionary), while this validator bounds-checks the witness and then forms
+    // `blob.bytes.data() + blob_offset`, declaring it as large as the witness. On a manifest that is
+    // `nullptr + blob_offset`, and the downstream proof reads through it. Before this was guarded, a
+    // GTA V F9 grab either reported a misleading witness error or SEGFAULTED mid-capture.
+    //
+    // The filler resource below the marker is load-bearing: it makes the two intervals MERGE, so the
+    // marker's blob_offset is non-zero. At offset 0 the same defect only mis-reports; the crash needs
+    // a non-zero offset, which is the ordinary case in a real capture.
+    {
+        constexpr uint64_t filler_addr = nullable_table_addr - 64u;
+        std::array<uint8_t, 64> filler_bytes{};
+        ShaderResource filler;
+        filler.cls = ResourceClass::ConstantBuffer;
+        filler.format = DataFormat::Unknown;
+        filler.num_components = 0u;
+        filler.gpu_addr = filler_addr;
+        filler.size = static_cast<uint32_t>(filler_bytes.size());
+        filler.fetch_pc = 12u;
+        filler.host_data = filler_bytes.data();
+        filler.host_data_size = filler_bytes.size();
+
+        ComputeItem merged_compute = nullable_compute;
+        merged_compute.resources = std::make_shared<ShaderResourceTable>();
+        merged_compute.resources->resources.push_back(filler);
+        merged_compute.resources->resources.push_back(nullable_marker);
+
+        auto merged_reader = [&](uint64_t addr, uint8_t* dst, size_t n) -> size_t {
+            if (addr >= filler_addr && addr < filler_addr + filler_bytes.size()) {
+                const size_t offset = static_cast<size_t>(addr - filler_addr);
+                const size_t take = std::min(n, filler_bytes.size() - offset);
+                std::memcpy(dst, filler_bytes.data() + offset, take);
+                return take;
+            }
+            return nullable_reader(addr, dst, n);
+        };
+
+        GpuCaptureFile merged_capture;
+        const bool merged_ok = capture_submit_items({}, {merged_compute}, nullable_operations, meta,
+                                                    merged_reader, merged_capture, error);
+        const auto& marker_resource = merged_capture.computes[0].resources.resources.back();
+        CHECK(merged_ok && merged_capture.computes.size() == 1u &&
+                  marker_resource.blob_offset != 0u,
+              "the merged-interval fixture really does give the marker a non-zero blob offset");
+
+        GpuCaptureBundle witness_bundle;
+        std::string bundle_error;
+        const bool appended =
+            merged_ok && append_gpu_capture_bundle(witness_bundle, merged_capture, bundle_error);
+        CHECK(appended,
+              ("a capture whose witness is blob-backed at a non-zero offset appends to a bundle: " +
+               bundle_error).c_str());
+
+        GpuCaptureFile witness_manifest;
+        CHECK(appended &&
+                  materialize_gpu_capture_bundle_manifest(witness_bundle, 0, witness_manifest,
+                                                          bundle_error) &&
+                  !witness_manifest.blobs.empty() && witness_manifest.blobs[0].bytes.empty(),
+              "the manifest really did strip the payload -- otherwise the arm above is vacuous");
+        GpuCaptureFile witness_restored;
+        CHECK(appended &&
+                  materialize_gpu_capture_bundle_submit(witness_bundle, 0, witness_restored,
+                                                        bundle_error) &&
+                  !witness_restored.blobs.empty() && !witness_restored.blobs[0].bytes.empty(),
+              "and materialization restores it from the dictionary");
+    }
     std::vector<uint8_t> nullable_capture_bytes;
     GpuCaptureFile nullable_loaded;
     GpuReplayFrame nullable_replay;


### PR DESCRIPTION
Fixes #2729. Found by independent review of #2718.

## What was wrong

`make_capture_manifest()` strips every blob payload **by design** — the bytes live in the bundle's
deduplicated dictionary — while four validators reached from `validate_failure_diagnostics()`
bounds-check against `blob.bytes.size()`, which on a manifest is always 0:

| site | message |
| --- | --- |
| `gpu_capture.cpp:1678` | nullable-output marker lacks its table witness |
| `gpu_capture.cpp:1735` | GTA root-record marker lacks its 224-byte witness |
| `gpu_capture.cpp:1821` | packed-pointer state references an invalid resource blob |
| `gpu_capture.cpp:1907` | indirect-pointer relocation references an invalid resource blob |

## Why skipping them loses nothing

**The proof already happened, on the object that has the payloads.** Every capture reaching
`append_gpu_capture_bundle()` is produced by `capture_submit_items()`, which runs
`capture_failure_diagnostics()` → `validate_failure_diagnostics()` at capture time. I traced every
path rather than assuming:

- both `append_gpu_capture_bundle` callers (`gpu_timeline.cpp:989`, `:2157`)
- both `append_runtime_capture_bundle` callers (`:3326`, `:3619`)
- `capture_gpustate_submit` **and** `capture_gpustate_target_submit` — both end in
  `capture_submit_items`

So the manifest is a projection of an already-validated capture, and re-running the deep proof against
it is duplication that **cannot** succeed: `host_data` would point into an empty vector.

## The fix

- **Sites 1 and 2** use the house idiom `!capture_blob_payload_omitted(blob) && (bounds…)`. That
  helper exists for exactly this situation and is already consulted at six sites in this file
  (`:1245`, `:1280`, `:2795`, `:3473`, `:3906`, `:4841`) — none of these four consulted it. This is
  applying the established discriminator where it was missed, not inventing one.
- **Sites 3 and 4** need more than a bounds skip: they set `host_data` and run a deep
  discover/validate afterwards. They stand down entirely for a manifest, via a named helper that says
  why.

## Why it surfaced now

The `< 51` / `< 53` version gates used to short-circuit two of these validators, so the blob
dereference was never reached. Repairing a dropped `format_version` (#2718) removed that accidental
shield and the pre-existing incompatibility surfaced.

**This retracts the "fifth F9 gate" I reported on #2554.** I presented it as a title-side gate blocking
3 of 4 GTA V gameplay grabs. It was ours.

## Verification — end to end, on the actual failure

A grab armed at **500 s**, which aborted three times on
`packed-pointer state references an invalid resource blob`:

```
[grab] frame-bundle written (84 submits) -> frame_grab_PPSA04263_....prgbundle    (2,118 MB)
gpu_replay --bundle ... -> rc=0
  bundle v2 submits=84 logical=7619556845 unique=2220046838 ratio=0.291
  provenance errors: 0
```

- `ctest --no-tests=error -j6`: **281/281**, rc=0 — **unchanged**, so existing validation is not
  weakened.
- `check_ascii_output.py`: clean.

## Regression test — and a correction to what this PR first said

The first version of this PR claimed a test was disproportionate. **That was wrong, and instructively
so.** Both fixtures already exist in-tree — `tests/gta5_nullable_output_fixture.hpp` and
`tests/gta5_cf9200_fixture.hpp` — and are already driven through `capture_submit_items` in the same
file I was editing.

Worse: the wall I reported hitting, *"nullable-output marker has stale shader, launch, or table
provenance"*, was **the real post-fix failure mode at `blob_offset == 0`**. The test was reporting the
bug, and I read it as my fixture being wrong and wrote a section explaining why testing was not worth
it.

The arm now appends a real nullable-output capture to a bundle, with a **filler resource below the
marker** so the two intervals merge and `blob_offset` is non-zero. That matters: at offset 0 the defect
only mis-reports, and the crash needs a non-zero offset — which is the ordinary case in a real capture.
Two non-vacuity assertions guard it: the marker's offset really is non-zero, and the manifest really
does strip the payload.

**Mutation-verified, per site — and the scope of that claim matters.** An earlier revision of this
body said "mutation-verified" without qualification while only **one** of the four guards had
coverage; review proved by mutation that deleting the other three left every test binary green.

| guard | coverage |
| --- | --- |
| site 1 — nullable-output | unit arm; removing only this guard fails 3 arms with `nullable-output marker lacks its table witness` |
| site 2 — cf9200 root record | unit arm (uses the cf9200 fixture already in the same file); removing only this guard fails with `GTA root-record marker lacks its 224-byte witness`, while site 1's arm still passes |
| sites 3, 4 — packed / indirect pointer | **end-to-end evidence only** — the GTA V 500 s grab, which tripped site 3. No unit arm. |

Stated plainly because the previous revision of this claim was broader than the evidence.