### PR TITLE
refactor(tools): harden the promotion/split tools, and map the limits of mechanised extract-method

### DIFF
--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -81,9 +81,9 @@ caveats found by trying it:
 * **clangd refuses to extract from inside a lambda, and that rules out this codebase's giant
   functions.** From `clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp`, the tweak
   returns `nullptr` when a `LambdaExpr` is found — the comment is literally *"Don't extract from
-  lambdas"*. `register_live_renderer` is 8,222 lines of which roughly 89% is inside lambdas passed
-  to registration calls, so every candidate worth extracting is in refused territory.
-  `extract_function.py --probe` reports 0 of 8 accepted, and that is correct behaviour, not a bug.
+  lambdas"*. `register_live_renderer` is 8,222 lines of which **98.5%** is inside lambdas (8,101 of 8,221 lines, from the AST — 89% is the
+  file-share figure in the table above, a different number) passed to registration calls, so every candidate worth extracting is in refused territory.
+  `extract_function.py --probe` reports 0 of 10 accepted at its default bounds, and that is correct behaviour, not a bug.
 
   Its other documented refusals matter for the same reason: **`requiresHoisting`** (*"cannot extract
   declarations that will be needed in the original function after extraction"*), an unmatched
@@ -96,8 +96,12 @@ caveats found by trying it:
   is the very operation being asked for), or an IDE plugin driving a refactoring engine without the
   lambda restriction. JetBrains' shipped MCP server does not offer one: across the IDE family its
   entire refactoring surface is `rename_refactoring`, with extract-method an open request
-  (YouTrack LLM-25880). A community PyCharm plugin does expose Extract Method over HTTP, which shows
-  the shape of that route and also its cost — a per-IDE plugin against the IDE's own API.
+  (YouTrack LLM-25880 — which names extract *variable* and extract *parameter*, NOT extract
+  method, so it is not even a request for this). A community PyCharm plugin advertises Extract
+  Method over HTTP, which shows
+  the shape of that route — but it is a STUB: its `PyExtractMethodUtil.extractMethod` call is
+  commented out and it returns success with an empty parameter list. There is currently no
+  WORKING example of this route in any IDE, which raises its cost rather than lowering it.
 
 It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
 changing that code.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -81,7 +81,7 @@ caveats found by trying it:
 * **clangd refuses to extract from inside a lambda, and that rules out this codebase's giant
   functions.** From `clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp`, the tweak
   returns `nullptr` when a `LambdaExpr` is found — the comment is literally *"Don't extract from
-  lambdas"*. `register_live_renderer` is 8,222 lines of which **98.5%** is inside lambdas (8,101 of 8,221 lines, from the AST — 89% is the
+  lambdas"*. `register_live_renderer` spans 8,221 lines of which **98.5%** is inside lambdas (8,101 of 8,221, from the AST — 89% is the
   file-share figure in the table above, a different number) passed to registration calls, so every candidate worth extracting is in refused territory.
   `extract_function.py --probe` reports 0 of 10 accepted at its default bounds, and that is correct behaviour, not a bug.
 
@@ -95,13 +95,16 @@ caveats found by trying it:
   nest. That needs either restructuring the lambdas into named functions first (by hand, since that
   is the very operation being asked for), or an IDE plugin driving a refactoring engine without the
   lambda restriction. JetBrains' shipped MCP server does not offer one: across the IDE family its
-  entire refactoring surface is `rename_refactoring`, with extract-method an open request
-  (YouTrack LLM-25880 — which names extract *variable* and extract *parameter*, NOT extract
-  method, so it is not even a request for this). A community PyCharm plugin advertises Extract
-  Method over HTTP, which shows
-  the shape of that route — but it is a STUB: its `PyExtractMethodUtil.extractMethod` call is
-  commented out and it returns success with an empty parameter list. There is currently no
-  WORKING example of this route in any IDE, which raises its cost rather than lowering it.
+  entire refactoring surface is `rename_refactoring`, with AST-based refactoring an open request
+  (YouTrack LLM-25880, state Open). That issue's examples name rename, extract *variable*, extract
+  *parameter* and change signature; they are introduced by *"such as"*, so they are illustrative
+  rather than a scope boundary, and extract-method is neither promised nor excluded by them.
+  A community PyCharm plugin advertises Extract Method over HTTP, which shows the shape of that
+  route — but it is a STUB: its `PyExtractMethodUtil.extractMethod` call is commented out and it
+  returns success with an empty parameter list, which is where its advertised "automatic parameter
+  detection" comes from. (`extractVariable` in the same file is inert too.) No IDE-driven example
+  of this route was found working during this survey — which is a statement about what was checked,
+  not a proof that none exists — so the route's cost has to be treated as unmeasured rather than low.
 
 It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
 changing that code.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -1,0 +1,71 @@
+# tools/refactor — mechanical restructuring, and what it cannot do
+
+These tools move code between files and prove they did not change it. They were written for a
+codebase where several files had grown past ten thousand lines, and they are deliberately narrow:
+each one does a transformation whose correctness can be *checked*, not merely reviewed.
+
+| tool | what it does |
+| --- | --- |
+| `move_module.py` | relocates modules into folders; rewrites every `#include` to one canonical form and every path citation repo-wide |
+| `map_symbols.py` | tiles a translation unit into top-level regions and computes the reference graph between them |
+| `promote_internal.py` | lifts shared internals out of anonymous namespaces into an internal header |
+| `split_file.py` | splits one translation unit into several along a region partition |
+| `classify_tests.py` | proposes a folder for each test from its own includes |
+| `check_include_paths.py` | finds targets that reach a project include they cannot resolve |
+
+Run every tool's `--selftest` first; `split_file.py` and `promote_internal.py` run theirs
+automatically before doing anything.
+
+## The verification each one offers
+
+`split_file.py` reads its outputs **back from disk** and requires that they rebuild the original byte
+for byte, and separately that the region map tiles the original exactly. Together those mean no bytes
+were lost. **They do not mean the result compiles** — brace balance depends on which regions went
+where, and only the compiler establishes that.
+
+`promote_internal.py` checks that the header holds every promoted region's bytes (verbatim, or with
+exactly one `inline` adjustment) and that the remaining source is the original minus precisely those
+spans plus one include.
+
+## Ruled out
+
+* **`clang-refactor extract` cannot do extract-method here.** Its own help marks it *"(WIP action;
+  use with caution!)"*, and the caution is the whole story: it does not compute the captured
+  variables. Measured on a four-line function — extracting a loop that reads `v` and accumulates into
+  `total` produced `static void accumulate()` taking **no parameters**, referencing both names
+  undeclared, and discarding the mutation. It moves text; it does not do the data-flow analysis that
+  makes an extraction correct. Do not reach for it expecting IntelliJ's behaviour.
+* **`clang-move` does not help either.** It is class-oriented, so it cannot move free functions or
+  anything in an anonymous namespace — which is most of what these files are made of.
+
+## What these tools do NOT address, and it is the larger half
+
+They move *structure*. They cannot shrink a **function**, and this codebase's real problem is partly
+function size. Measured after the recompiler split landed:
+
+| function | lines | file | share of its file |
+| --- | --- | --- | --- |
+| `register_live_renderer` | 8,222 | `frontends/shared/live/live_renderer.cpp` | 89% |
+| `emit_alu` | 7,544 | `src/gpu/recompiler/rdna2_emit_alu.cpp` | 97% |
+| `execute_item` | 4,536 | `frontends/shared/live/live_compute.cpp` | 47% |
+| `emit_cfg_state_machine` | 4,419 | `src/gpu/recompiler/rdna2_emit_cfg.cpp` | 64% |
+| `main` | ~12,400 | `tests/gpu/recompiler/test_rdna2_to_spirv.cpp` | 98% |
+
+For `live_renderer.cpp` a structural split can achieve **nothing**: the file is one function. Moving
+it elsewhere renames the problem. Those files need extraction, which means data-flow analysis per
+span, which no available tool does — so it is careful incremental work, best done a few extractions
+at a time by whoever is already changing that code, not as a sweep.
+
+**The invariant that makes incremental extraction safe is worth copying.** When a block was extracted
+out of `test_rdna2_to_spirv.cpp`'s `main`, the thing that made it checkable was a count of assertions
+*executed*, asserted as a per-block delta:
+
+```cpp
+const int before_bvh = checks;
+run_bvh_checks();
+if (checks - before_bvh != 8) { /* it did not run */ return 1; }
+```
+
+A global floor was tried first and was wrong in both directions at once — calibrated on a machine
+with subgroup size 32, it rejected CI's subgroup-8 host, and it could not detect the very block it
+was added for (1068 − 8 = 1060, and `1060 < 1060` is false). Per-block deltas have neither problem.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -78,11 +78,19 @@ caveats found by trying it:
   declaring a variable used after the span (that needs an out-parameter or a returned struct). Giant
   functions here are dense with both, so a candidate-finder must filter for what clangd accepts
   before offering it a span.
-* **On `live_renderer.cpp` specifically, no span tried so far has been accepted**, including ones
-  passing those filters — while the same setup works on a 365-line file in the same project with the
-  same flags. That difference is NOT explained. It is the open question, not a settled limitation:
-  concluding "the file is too large" without evidence is exactly the kind of claim this document
-  exists to prevent.
+* **Multi-statement extraction has not been made to fire on a real giant function, and the reason is
+  not yet known.** `extract_function.py --probe` asks clangd about every candidate it finds;
+  currently it accepts **0 of 8** in `register_live_renderer`. What is ruled out:
+  - not the file, and not the flags — clangd offers "Extract to function" at
+    `live_renderer.cpp:199` (a statement in a small function in the same file) and in
+    `gpu_dependency_graph.cpp`;
+  - not a truncated range — extending the selection past the statement's trailing `;` changes
+    nothing (`EXTRACT_END_SLACK`);
+  - not lambdas alone — a top-level run in the same function is also refused, though that particular
+    one declared a variable used later, so it is not a clean arm.
+
+  Single statements are accepted; every multi-statement run tried has been refused. That is the
+  shape of the open question, and it is worth answering before writing more candidate-finding logic.
 
 It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
 changing that code.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -29,14 +29,31 @@ spans plus one include.
 
 ## Ruled out
 
-* **`clang-refactor extract` cannot do extract-method here.** Its own help marks it *"(WIP action;
-  use with caution!)"*, and the caution is the whole story: it does not compute the captured
-  variables. Measured on a four-line function — extracting a loop that reads `v` and accumulates into
-  `total` produced `static void accumulate()` taking **no parameters**, referencing both names
-  undeclared, and discarding the mutation. It moves text; it does not do the data-flow analysis that
-  makes an extraction correct. Do not reach for it expecting IntelliJ's behaviour.
-* **`clang-move` does not help either.** It is class-oriented, so it cannot move free functions or
-  anything in an anonymous namespace — which is most of what these files are made of.
+* **`clang-refactor extract` cannot do extract-method — but `clangd` can, and that distinction is
+  the whole point.** They are different implementations and only one is usable.
+
+  `clang-refactor extract`'s own help marks it *"(WIP action; use with caution!)"*, and the caution
+  is the whole story: it does not compute captured variables. Measured on a four-line function --
+  extracting a loop that reads `v` and accumulates into `total` produced `static void accumulate()`
+  taking **no parameters**, referencing both names undeclared, and discarding the mutation. It moves
+  text.
+
+  **clangd's `ExtractFunction` tweak does it correctly.** Same input, driven over LSP:
+
+  ```cpp
+  void extracted(const std::vector<int> &v, int &total) { for (int x : v) { ... } }
+  extracted(v, total);
+  ```
+
+  `v` by const reference because it is only read, `total` by reference because it is mutated. That is
+  the analysis an IDE performs, and clangd has it. It is **not** reachable from a command line:
+  clangd exposes refactorings only as LSP code actions carrying a `clangd.applyTweak` command, so a
+  client has to speak the protocol and catch the `workspace/applyEdit` the server sends back.
+  Confirmed working against this project's own `compile_commands.json` on
+  `src/gpu/execute/gpu_dependency_graph.cpp`.
+
+* **`clang-move` is class-oriented**, so it cannot move free functions or anything in an anonymous
+  namespace — which is most of what these files are.
 
 ## What these tools do NOT address, and it is the larger half
 
@@ -52,10 +69,23 @@ function size. Measured after the recompiler split landed:
 | `main` | ~12,400 | `tests/gpu/recompiler/test_rdna2_to_spirv.cpp` | 98% |
 
 For `live_renderer.cpp` a structural split can achieve **nothing**: the file is one function. Moving
-it elsewhere renames the problem. Those files need extraction, which means data-flow analysis per
-span, which no available tool does — so it is careful incremental work, best done a few extractions
-at a time by whoever is already changing that code, not as a sweep.
+it elsewhere renames the problem. Those files need extraction — and per the ruled-out section above,
+clangd **does** perform the required analysis, so this is mechanisable rather than hand work. Two
+caveats found by trying it:
 
+* **clangd legitimately refuses many spans, and the refusals are correct.** It will not extract a
+  span containing `return`/`break`/`continue` (an early exit cannot be expressed as a call), nor one
+  declaring a variable used after the span (that needs an out-parameter or a returned struct). Giant
+  functions here are dense with both, so a candidate-finder must filter for what clangd accepts
+  before offering it a span.
+* **On `live_renderer.cpp` specifically, no span tried so far has been accepted**, including ones
+  passing those filters — while the same setup works on a 365-line file in the same project with the
+  same flags. That difference is NOT explained. It is the open question, not a settled limitation:
+  concluding "the file is too large" without evidence is exactly the kind of claim this document
+  exists to prevent.
+
+It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
+changing that code.
 **The invariant that makes incremental extraction safe is worth copying.** When a block was extracted
 out of `test_rdna2_to_spirv.cpp`'s `main`, the thing that made it checkable was a count of assertions
 *executed*, asserted as a per-block delta:

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -78,19 +78,26 @@ caveats found by trying it:
   declaring a variable used after the span (that needs an out-parameter or a returned struct). Giant
   functions here are dense with both, so a candidate-finder must filter for what clangd accepts
   before offering it a span.
-* **Multi-statement extraction has not been made to fire on a real giant function, and the reason is
-  not yet known.** `extract_function.py --probe` asks clangd about every candidate it finds;
-  currently it accepts **0 of 8** in `register_live_renderer`. What is ruled out:
-  - not the file, and not the flags — clangd offers "Extract to function" at
-    `live_renderer.cpp:199` (a statement in a small function in the same file) and in
-    `gpu_dependency_graph.cpp`;
-  - not a truncated range — extending the selection past the statement's trailing `;` changes
-    nothing (`EXTRACT_END_SLACK`);
-  - not lambdas alone — a top-level run in the same function is also refused, though that particular
-    one declared a variable used later, so it is not a clean arm.
+* **clangd refuses to extract from inside a lambda, and that rules out this codebase's giant
+  functions.** From `clang-tools-extra/clangd/refactor/tweaks/ExtractFunction.cpp`, the tweak
+  returns `nullptr` when a `LambdaExpr` is found — the comment is literally *"Don't extract from
+  lambdas"*. `register_live_renderer` is 8,222 lines of which roughly 89% is inside lambdas passed
+  to registration calls, so every candidate worth extracting is in refused territory.
+  `extract_function.py --probe` reports 0 of 8 accepted, and that is correct behaviour, not a bug.
 
-  Single statements are accepted; every multi-statement run tried has been refused. That is the
-  shape of the open question, and it is worth answering before writing more candidate-finding logic.
+  Its other documented refusals matter for the same reason: **`requiresHoisting`** (*"cannot extract
+  declarations that will be needed in the original function after extraction"*), an unmatched
+  `break`/`continue`, a conditional `return`, a **templated** enclosing function, and extracting the
+  whole function body. Between them they exclude most spans in code shaped like this.
+
+  So clangd extract-method is genuinely useful — for normal-sized functions, where it does the
+  capture analysis correctly and safely. It is **not** the route to shrinking an 8,000-line lambda
+  nest. That needs either restructuring the lambdas into named functions first (by hand, since that
+  is the very operation being asked for), or an IDE plugin driving a refactoring engine without the
+  lambda restriction. JetBrains' shipped MCP server does not offer one: across the IDE family its
+  entire refactoring surface is `rename_refactoring`, with extract-method an open request
+  (YouTrack LLM-25880). A community PyCharm plugin does expose Extract Method over HTTP, which shows
+  the shape of that route and also its cost — a per-IDE plugin against the IDE's own API.
 
 It stays incremental work regardless: a few extractions at a time, verified, by whoever is already
 changing that code.

--- a/prosper/tools/refactor/README.md
+++ b/prosper/tools/refactor/README.md
@@ -62,7 +62,7 @@ function size. Measured after the recompiler split landed:
 
 | function | lines | file | share of its file |
 | --- | --- | --- | --- |
-| `register_live_renderer` | 8,222 | `frontends/shared/live/live_renderer.cpp` | 89% |
+| `register_live_renderer` | 8,221 | `frontends/shared/live/live_renderer.cpp` | 89% |
 | `emit_alu` | 7,544 | `src/gpu/recompiler/rdna2_emit_alu.cpp` | 97% |
 | `execute_item` | 4,536 | `frontends/shared/live/live_compute.cpp` | 47% |
 | `emit_cfg_state_machine` | 4,419 | `src/gpu/recompiler/rdna2_emit_cfg.cpp` | 64% |
@@ -83,7 +83,12 @@ caveats found by trying it:
   returns `nullptr` when a `LambdaExpr` is found — the comment is literally *"Don't extract from
   lambdas"*. `register_live_renderer` spans 8,221 lines of which **98.5%** is inside lambdas (8,101 of 8,221, from the AST — 89% is the
   file-share figure in the table above, a different number) passed to registration calls, so every candidate worth extracting is in refused territory.
-  `extract_function.py --probe` reports 0 of 10 accepted at its default bounds, and that is correct behaviour, not a bug.
+  `extract_function.py --probe` reports 0 of 10 accepted at its default bounds, and that is correct
+  behaviour, not a bug. **That figure alone does not establish it**: a hand-built lambda-free
+  25-line function also probes 0 of 1, while the same clangd session returns
+  `['Extract to function']` for a sub-range of it — so the zero is partly produced by the
+  candidate geometry this tool generates. The conclusion rests on clangd's own source and on the
+  hand-built lambda control, not on the count.
 
   Its other documented refusals matter for the same reason: **`requiresHoisting`** (*"cannot extract
   declarations that will be needed in the original function after extraction"*), an unmatched

--- a/prosper/tools/refactor/extract_function.py
+++ b/prosper/tools/refactor/extract_function.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""extract_function.py -- shrink a giant function by extracting statement runs, using clangd.
+
+The other tools here move whole declarations between files. They cannot make a FUNCTION smaller, and
+several functions in this codebase are the size of a normal source file on their own --
+`register_live_renderer` is 8,222 lines, 89% of live_renderer.cpp, so no amount of file-splitting
+touches it.
+
+Extract-method is the operation that does, and it is not something to hand-roll: deciding which
+locals become parameters, which are read-only (`const&`) and which are mutated (`&`), is a data-flow
+analysis, and getting it subtly wrong changes behaviour silently. clangd already implements it
+correctly. This drives clangd.
+
+WHY THIS IS NOT A SHELL ONE-LINER. `clang-refactor extract` -- the tool that looks right -- is marked
+"(WIP action; use with caution!)" and does NOT compute captures: it emitted `static void
+accumulate()` taking no parameters for a loop reading `v` and mutating `total`. clangd's
+implementation is a different one and is correct, but it is reachable only over LSP, as a code action
+carrying a `clangd.applyTweak` command whose edit arrives as a `workspace/applyEdit` request FROM the
+server. So this speaks the protocol.
+
+CANDIDATES COME FROM THE AST, NOT FROM LINE PATTERNS, and that is the other half of the tool. Picking
+spans by regex over lines produces ranges that start inside a comment or halfway through a
+continuation line; clangd then declines, and the decline looks like a tool limitation rather than a
+bad question. Every candidate here is a run of complete sibling statements taken from libclang, with
+exact extents.
+
+  python3 prosper/tools/refactor/extract_function.py --file <f> --function <name> --list
+  python3 prosper/tools/refactor/extract_function.py --file <f> --function <name> --apply N --name foo
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import queue
+import subprocess
+import sys
+import threading
+
+import clang.cindex as ci
+
+for cand in ("/usr/lib64/libclang.so.22.1", "/usr/lib64/libclang.so"):
+    if pathlib.Path(cand).exists():
+        ci.Config.set_library_file(cand)
+        break
+
+END_SLACK = int(os.environ.get('EXTRACT_END_SLACK', '2'))
+
+ESCAPING = (ci.CursorKind.RETURN_STMT, ci.CursorKind.BREAK_STMT,
+            ci.CursorKind.CONTINUE_STMT, ci.CursorKind.GOTO_STMT)
+
+
+def repo_root() -> pathlib.Path:
+    return pathlib.Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
+                                       capture_output=True, text=True, check=True).stdout.strip())
+
+
+def flags_for(target: pathlib.Path, db: pathlib.Path) -> list[str]:
+    import shlex
+    for e in json.loads(db.read_text()):
+        if pathlib.Path(e["file"]).resolve() == target.resolve():
+            args = shlex.split(e["command"]) if "command" in e else list(e["arguments"])
+            out, skip = [], False
+            for a in args[1:]:
+                if skip:
+                    skip = False
+                    continue
+                if a in ("-c", "-o"):
+                    skip = a == "-o"
+                    continue
+                if a.endswith((".cpp", ".cc", ".c")):
+                    continue
+                out.append(a)
+            res = subprocess.run(["clang", "-print-resource-dir"], capture_output=True, text=True)
+            if res.returncode == 0:
+                out += ["-isystem", str(pathlib.Path(res.stdout.strip()) / "include")]
+            return out
+    sys.exit(f"no compile command for {target}")
+
+
+def has_escape(cursor) -> bool:
+    """Does this statement transfer control out of the ENCLOSING function?
+
+    The descent stops at a lambda. A `return` inside `auto f = [](){ return 1; };` returns from the
+    lambda, not from the function holding it, so counting it as an escape rejects the statement --
+    and in this codebase that rejects almost everything, because the giant functions are built as
+    sequences of lambda definitions. `register_live_renderer` has 40 direct statements, 19 of them
+    lambda-bearing declarations; treating their bodies as escapes left ZERO candidates.
+    """
+    stack = [cursor]
+    while stack:
+        c = stack.pop()
+        if c.kind in ESCAPING:
+            return True
+        if c is not cursor and c.kind == ci.CursorKind.LAMBDA_EXPR:
+            continue                      # its returns belong to it, not to us
+        stack.extend(c.get_children())
+    return False
+
+
+def names_declared(cursor) -> set[str]:
+    out = set()
+    stack = [cursor]
+    while stack:
+        c = stack.pop()
+        if c.kind == ci.CursorKind.VAR_DECL and c.spelling:
+            out.add(c.spelling)
+        stack.extend(c.get_children())
+    return out
+
+
+def names_referenced(cursor) -> set[str]:
+    out = set()
+    stack = [cursor]
+    while stack:
+        c = stack.pop()
+        if c.kind == ci.CursorKind.DECL_REF_EXPR and c.spelling:
+            out.add(c.spelling)
+        stack.extend(c.get_children())
+    return out
+
+
+def candidates(path: pathlib.Path, func: str, flags: list[str], min_stmts: int,
+               min_lines: int, max_lines: int):
+    tu = ci.Index.create().parse(str(path), args=flags)
+    fatal = [d for d in tu.diagnostics if d.severity >= ci.Diagnostic.Error]
+    if fatal:
+        print(f"  WARNING {len(fatal)} parse error(s); candidates may be wrong")
+
+    def find(c):
+        if (c.kind in (ci.CursorKind.FUNCTION_DECL, ci.CursorKind.CXX_METHOD)
+                and c.spelling == func and c.is_definition()
+                and c.location.file and pathlib.Path(c.location.file.name).resolve() == path.resolve()):
+            return c
+        for ch in c.get_children():
+            r = find(ch)
+            if r:
+                return r
+        return None
+
+    fn = find(tu.cursor)
+    if not fn:
+        sys.exit(f"function {func} not found in {path}")
+    body = next((c for c in fn.get_children() if c.kind == ci.CursorKind.COMPOUND_STMT), None)
+    if not body:
+        sys.exit(f"{func} has no body")
+
+    # SCAN THE LAMBDA BODIES TOO -- that is where the lines actually are. register_live_renderer has
+    # 40 direct statements across 8,217 lines, because 19 of them are `auto x = [](...){ ... };` with
+    # hundreds of lines inside. Treating only the top level as extractable finds one candidate: the
+    # whole function.
+    scopes = [body]
+    stack = [body]
+    while stack:
+        c = stack.pop()
+        for ch in c.get_children():
+            stack.append(ch)
+            if ch.kind == ci.CursorKind.LAMBDA_EXPR:
+                lb = next((g for g in ch.get_children()
+                           if g.kind == ci.CursorKind.COMPOUND_STMT), None)
+                if lb is not None:
+                    scopes.append(lb)
+
+    out = []
+    for scope in scopes:
+        out.extend(_runs_in(scope, min_stmts, min_lines, max_lines))
+    return _dedup(out)
+
+
+def _runs_in(scope, min_stmts, min_lines, max_lines):
+    stmts = list(scope.get_children())
+
+    # Everything referenced AFTER a run decides whether its declarations may leave. Precomputed as a
+    # suffix so the scan stays linear rather than re-walking the tail for every candidate.
+    suffix_refs = [set() for _ in range(len(stmts) + 1)]
+    for i in range(len(stmts) - 1, -1, -1):
+        suffix_refs[i] = suffix_refs[i + 1] | names_referenced(stmts[i])
+
+    out = []
+    i = 0
+    while i < len(stmts):
+        if has_escape(stmts[i]):
+            i += 1
+            continue
+        j = i
+        declared: set[str] = set()
+        while j < len(stmts) and not has_escape(stmts[j]):
+            declared |= names_declared(stmts[j])
+            j += 1
+            n = j - i
+            span = stmts[j - 1].extent.end.line - stmts[i].extent.start.line + 1
+            if (n >= min_stmts and min_lines <= span <= max_lines
+                    and not (declared & suffix_refs[j])):
+                out.append({
+                    "stmts": n, "lines": span,
+                    "start_line": stmts[i].extent.start.line,
+                    "start_col": stmts[i].extent.start.column,
+                    "end_line": stmts[j - 1].extent.end.line,
+                    "end_col": stmts[j - 1].extent.end.column,
+                    "declares": sorted(declared),
+                })
+        i += 1
+    return out
+
+
+def _dedup(out):
+    """Longest first, dropping overlaps, so the list reads as choices rather than permutations."""
+    out.sort(key=lambda c: -c["lines"])
+    chosen, used = [], set()
+    for c in out:
+        rng = set(range(c["start_line"], c["end_line"] + 1))
+        if used & rng:
+            continue
+        used |= rng
+        chosen.append(c)
+    chosen.sort(key=lambda c: c["start_line"])
+    return chosen
+
+
+# --- the LSP half -------------------------------------------------------------------------------
+class Clangd:
+    def __init__(self, db_dir: str):
+        self.p = subprocess.Popen(["clangd", "--log=error", f"--compile-commands-dir={db_dir}"],
+                                  stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                  stderr=subprocess.DEVNULL)
+        self.id = 0
+        self.q: queue.Queue = queue.Queue()
+        threading.Thread(target=self._read, daemon=True).start()
+
+    def _read(self):
+        while True:
+            head = b""
+            while not head.endswith(b"\r\n\r\n"):
+                b = self.p.stdout.read(1)
+                if not b:
+                    self.q.put(None)
+                    return
+                head += b
+            n = int([h for h in head.decode().split("\r\n")
+                     if h.lower().startswith("content-length")][0].split(":")[1])
+            self.q.put(json.loads(self.p.stdout.read(n)))
+
+    def _send(self, obj):
+        data = json.dumps(obj).encode()
+        self.p.stdin.write(b"Content-Length: %d\r\n\r\n" % len(data) + data)
+        self.p.stdin.flush()
+
+    def request(self, method, params):
+        self.id += 1
+        self._send({"jsonrpc": "2.0", "id": self.id, "method": method, "params": params})
+        return self.id
+
+    def notify(self, method, params):
+        self._send({"jsonrpc": "2.0", "method": method, "params": params})
+
+    def wait(self, want_id=None, want_method=None, timeout=900):
+        import time
+        end = time.time() + timeout
+        while time.time() < end:
+            try:
+                m = self.q.get(timeout=timeout)
+            except queue.Empty:
+                return None
+            if m is None:
+                return None
+            if want_id is not None and m.get("id") == want_id and "method" not in m:
+                return m
+            if want_method and m.get("method") == want_method:
+                if "id" in m:
+                    self._send({"jsonrpc": "2.0", "id": m["id"], "result": {"applied": True}})
+                return m
+            if "id" in m and "method" in m:
+                self._send({"jsonrpc": "2.0", "id": m["id"], "result": None})
+        return None
+
+    def open(self, path: pathlib.Path):
+        self.uri = "file://" + str(path.resolve())
+        rid = self.request("initialize", {
+            "processId": os.getpid(), "rootUri": "file://" + str(repo_root()),
+            "capabilities": {"workspace": {"applyEdit": True},
+                             "textDocument": {"codeAction": {"codeActionLiteralSupport": {
+                                 "codeActionKind": {"valueSet": ["refactor"]}}}}}})
+        self.wait(want_id=rid)
+        self.notify("initialized", {})
+        self.notify("textDocument/didOpen", {"textDocument": {
+            "uri": self.uri, "languageId": "cpp", "version": 1, "text": path.read_text()}})
+        # Wait for diagnostics for THIS uri: clangd publishes for headers too, and acting before the
+        # main file has an AST looks exactly like "no refactoring available".
+        for _ in range(60):
+            m = self.wait(want_method="textDocument/publishDiagnostics")
+            if not m or m["params"].get("uri") == self.uri:
+                return
+
+    def extract(self, c: dict, new_name: str | None):
+        # END PAST THE SEMICOLON. libclang's statement extent stops at the last token, which for an
+        # expression statement is BEFORE the `;`. A range ending there is a partial statement, and
+        # clangd declines partial selections -- indistinguishable from "this cannot be extracted".
+        rng = {"start": {"line": c["start_line"] - 1, "character": c["start_col"] - 1},
+               "end": {"line": c["end_line"] - 1, "character": c["end_col"] - 1 + END_SLACK}}
+        rid = self.request("textDocument/codeAction", {
+            "textDocument": {"uri": self.uri}, "range": rng,
+            "context": {"diagnostics": [], "only": ["refactor"]}})
+        resp = self.wait(want_id=rid) or {}
+        actions = resp.get("result") or []
+        act = next((a for a in actions if "function" in (a.get("title") or "").lower()), None)
+        if not act:
+            return None, [a.get("title") for a in actions]
+        cmd = act.get("command") or {}
+        rid = self.request("workspace/executeCommand",
+                           {"command": cmd.get("command"), "arguments": cmd.get("arguments", [])})
+        applied = self.wait(want_method="workspace/applyEdit")
+        return applied, None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--file", required=True, type=pathlib.Path)
+    ap.add_argument("--function", required=True)
+    ap.add_argument("--build", default="prosper/build-linux")
+    ap.add_argument("--min-stmts", type=int, default=3)
+    ap.add_argument("--min-lines", type=int, default=15)
+    ap.add_argument("--max-lines", type=int, default=400,
+                    help="upper bound; without one, the whole function body is the single longest candidate and swallows every useful chunk")
+    ap.add_argument("--list", action="store_true")
+    ap.add_argument("--probe", action="store_true",
+                    help="ask clangd about EVERY candidate in one session and report "
+                         "which it accepts. A candidate this tool considers valid can still be refused, and knowing which is the whole planning question.")
+    ap.add_argument("--apply", type=int, help="candidate index to extract")
+    ap.add_argument("--name", default="extracted")
+    args = ap.parse_args()
+
+    root = repo_root()
+    path = root / args.file if not args.file.is_absolute() else args.file
+    db = root / args.build / "compile_commands.json"
+    flags = flags_for(path, db)
+
+    cands = candidates(path, args.function, flags, args.min_stmts, args.min_lines,
+                       args.max_lines)
+    print(f"== {args.function} in {args.file}: {len(cands)} extractable candidate(s) ==")
+    print("   (complete sibling statements; no return/break/continue; nothing declared escapes)")
+    for n, c in enumerate(cands[:25]):
+        print(f"  [{n:3d}] lines {c['start_line']:6d}-{c['end_line']:<6d} "
+              f"{c['lines']:4d}L {c['stmts']:3d} stmt(s)"
+              + (f"  declares {c['declares'][:3]}" if c["declares"] else ""))
+    if args.probe:
+        cd = Clangd(str(root / args.build))
+        cd.open(path)
+        ok = 0
+        for n, c in enumerate(cands):
+            rng = {"start": {"line": c["start_line"] - 1, "character": c["start_col"] - 1},
+                   "end": {"line": c["end_line"] - 1, "character": c["end_col"] - 1 + END_SLACK}}
+            rid = cd.request("textDocument/codeAction", {
+                "textDocument": {"uri": cd.uri}, "range": rng,
+                "context": {"diagnostics": [], "only": ["refactor"]}})
+            acts = (cd.wait(want_id=rid) or {}).get("result") or []
+            titles = [a.get("title") for a in acts]
+            good = any("function" in (t or "").lower() for t in titles)
+            ok += good
+            print(f"  [{n:3d}] lines {c['start_line']:6d}-{c['end_line']:<6d} {c['lines']:4d}L  "
+                  f"{'ACCEPTED' if good else 'refused '}  {titles if titles else ''}")
+        print(f"\n  clangd accepts {ok} of {len(cands)}")
+        return 0
+
+    if args.list or args.apply is None:
+        return 0
+
+    c = cands[args.apply]
+    print(f"\n  extracting candidate {args.apply}: lines {c['start_line']}-{c['end_line']}")
+    cd = Clangd(str((root / args.build)))
+    cd.open(path)
+    applied, offered = cd.extract(c, args.name)
+    if not applied:
+        print(f"  clangd declined this range; it offered: {offered or '(nothing)'}")
+        return 1
+    changes = applied["params"]["edit"].get("changes") or {}
+    total = sum(len(v) for v in changes.values())
+    print(f"  clangd produced {total} edit(s):")
+    for uri, edits in changes.items():
+        for e in edits:
+            txt = e["newText"]
+            if txt.strip():
+                print("  " + "\n  ".join(txt.splitlines()[:6]))
+                if len(txt.splitlines()) > 6:
+                    print(f"  ... ({len(txt.splitlines())} lines)")
+    print("\n  NOT written to disk: pass the edits through review, then BUILD and run ctest.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/refactor/extract_function.py
+++ b/prosper/tools/refactor/extract_function.py
@@ -3,7 +3,7 @@
 
 The other tools here move whole declarations between files. They cannot make a FUNCTION smaller, and
 several functions in this codebase are the size of a normal source file on their own --
-`register_live_renderer` is 8,222 lines, 89% of live_renderer.cpp, so no amount of file-splitting
+`register_live_renderer` is 8,221 lines, 89% of live_renderer.cpp, so no amount of file-splitting
 touches it.
 
 Extract-method is the operation that does, and it is not something to hand-roll: deciding which
@@ -146,7 +146,7 @@ def candidates(path: pathlib.Path, func: str, flags: list[str], min_stmts: int,
         sys.exit(f"{func} has no body")
 
     # SCAN THE LAMBDA BODIES TOO -- that is where the lines actually are. register_live_renderer has
-    # 40 direct statements across 8,217 lines, because 19 of them are `auto x = [](...){ ... };` with
+    # 40 direct statements across the same 8,221 lines, because 19 of them are `auto x = [](...){ ... };` with
     # hundreds of lines inside. Treating only the top level as extractable finds one candidate: the
     # whole function.
     scopes = [body]

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -360,6 +360,18 @@ def selftest() -> int:
     check(not verify(SELF_SRC, SELF_MAP, [3, 4], hdr, src, "s_internal.hpp"),
           "verification passes on a correct promotion")
 
+    # prototype_of is pure and therefore reachable from here, unlike the fixes that live in main().
+    # The fixture's default argument CONTAINS PARENTHESES, which is the shape that breaks the
+    # single-regex stripping this replaced: `[^,)]+` stops at the inner `(`, and the signature comes
+    # out as `void f(int a), bool b)`. A fixture with only plain defaults passes under BOTH
+    # implementations and would certify nothing -- checked by mutation, not assumed.
+    proto_lines = ["void f(int a = g(1),\n", "       bool b = false) {\n"]
+    proto = prototype_of({"kind": "FUNCTION_DECL", "is_definition": True, "decl_line": 1,
+                          "start": 1, "end": 2, "name": "f"}, proto_lines)
+    check(proto == "void f(int a, bool b);", f"defaults with parentheses strip cleanly (got {proto!r})")
+    check(proto and proto.count("(") == proto.count(")"),
+          f"the signature stays balanced (got {proto!r})")
+
     # a promoted VARIABLE definition needs `inline` too, or the link fails with multiple definition
     var_map = json.loads(json.dumps(SELF_MAP))
     var_map["regions"][3] = {"index": 3, "start": 7, "end": 8, "role": "body", "name": "g_state",
@@ -503,8 +515,21 @@ def main() -> int:
     # namespace names a DIFFERENT entity, so every use becomes "reference to X is ambiguous".
     # Measured: `make_shader_compile_key` was excluded because live_renderer.cpp mentions it in a
     # comment about CPU profiling.
+    # LINKAGE COMES FROM THE USR, not from the anonymous-namespace walk alone. clang encodes it:
+    # an external-linkage entity's USR starts `c:@`, an internal one is file-prefixed
+    # (`c:file.cpp@F@name`). A `static` free function is internal WITHOUT being in an anonymous
+    # namespace, so the `anon` test alone missed it -- and then the name grep held it back because
+    # some unrelated file happens to define a same-named static. Measured: `make_probe_pipe` was
+    # excluded because of a same-named static in exec_image_linux.cpp:152. A name is not an
+    # identity; the USR is.
+    def externally_linked(i: int) -> bool:
+        usr = regions[i].get("usr") or ""
+        if usr:
+            return usr.startswith("c:@")
+        return not anon.get(i)          # no USR recorded: fall back to the scope walk
+
     public = [i for i in promote
-              if not anon.get(i)
+              if externally_linked(i)
               and regions[i]["kind"] in ("FUNCTION_DECL", "VAR_DECL")
               and used_elsewhere(regions[i]["name"])]
     if public:

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -126,6 +126,23 @@ def anon_map(regions: list[dict]) -> dict[int, bool]:
     return out
 
 
+# LINKAGE COMES FROM THE USR, not from the anonymous-namespace walk alone. clang encodes it: an
+# external-linkage entity's USR starts `c:@`, an internal one is file-prefixed
+# (`c:file.cpp@F@name`). A `static` free function is internal WITHOUT being in an anonymous
+# namespace, so the `anon` test alone missed it -- and then the name grep held it back because some
+# unrelated file happens to define a same-named static. Measured: `make_probe_pipe` was excluded
+# because of a same-named static in exec_image_linux.cpp:152. A name is not an identity; the USR is.
+#
+# This lives at module scope rather than inside main() so the self-test can reach it. It was nested,
+# and a reviewer proved by mutation that reverting it left `--selftest` green -- the tool reported a
+# correction no arm could see.
+def region_is_external(region: dict, in_anon_namespace: bool) -> bool:
+    usr = region.get("usr") or ""
+    if usr:
+        return usr.startswith("c:@")
+    return not in_anon_namespace        # no USR recorded: fall back to the scope walk
+
+
 # `static` is NOT in this list, and that is the correction. A static function definition is fine in
 # a .cpp and is an ODR hazard in a .hpp: it has internal linkage, so each including translation unit
 # gets its own copy, and the moment an `inline` function in the same header odr-uses it the program
@@ -346,6 +363,21 @@ def selftest() -> int:
     check(anon[3] and anon[4], "regions inside `namespace {` are detected as internal")
     check(not anon[6], "a region outside it is not")
 
+    # LINKAGE. The `anon` walk above is NOT sufficient, and this is the arm that proves it: a
+    # `static` free function is internal linkage while sitting outside any anonymous namespace, so
+    # a predicate built on `anon` alone calls it external. Measured: mutating `region_is_external`
+    # back to `return not in_anon_namespace` turns the SECOND AND THIRD checks red by name and
+    # leaves the other two green -- those two pass under both implementations and so certify
+    # nothing on their own.
+    check(region_is_external({"usr": "c:@F@render_frame#"}, False),
+          "a USR starting `c:@` is external linkage")
+    check(not region_is_external({"usr": "c:live.cpp@F@helper#"}, False),
+          "a file-prefixed USR is internal linkage")
+    check(not region_is_external({"usr": "c:live.cpp@F@make_probe_pipe#"}, False),
+          "a `static` free function is INTERNAL even though it is outside `namespace { }`")
+    check(not region_is_external({}, True) and region_is_external({}, False),
+          "with no USR recorded the anonymous-namespace walk is the fallback, both ways")
+
     hdr, src, inl = build(SELF_MAP, SELF_SRC, [3, 4], "s_internal.hpp", "ns", "// note\n",
                           "s_internal.hpp")
     check(inl == ["helper"], f"the free function definition gains `inline` (got {inl})")
@@ -515,18 +547,8 @@ def main() -> int:
     # namespace names a DIFFERENT entity, so every use becomes "reference to X is ambiguous".
     # Measured: `make_shader_compile_key` was excluded because live_renderer.cpp mentions it in a
     # comment about CPU profiling.
-    # LINKAGE COMES FROM THE USR, not from the anonymous-namespace walk alone. clang encodes it:
-    # an external-linkage entity's USR starts `c:@`, an internal one is file-prefixed
-    # (`c:file.cpp@F@name`). A `static` free function is internal WITHOUT being in an anonymous
-    # namespace, so the `anon` test alone missed it -- and then the name grep held it back because
-    # some unrelated file happens to define a same-named static. Measured: `make_probe_pipe` was
-    # excluded because of a same-named static in exec_image_linux.cpp:152. A name is not an
-    # identity; the USR is.
     def externally_linked(i: int) -> bool:
-        usr = regions[i].get("usr") or ""
-        if usr:
-            return usr.startswith("c:@")
-        return not anon.get(i)          # no USR recorded: fall back to the scope walk
+        return region_is_external(regions[i], anon.get(i, False))
 
     public = [i for i in promote
               if externally_linked(i)
@@ -543,8 +565,13 @@ def main() -> int:
         # promote set after this filter had removed it -- five other translation units then failed
         # to link against a definition that had become `inline` in a header they do not include.
         excluded |= set(public)
-    internal = [i for i in promote if anon.get(i)]
-    external = [i for i in promote if not anon.get(i)]
+    # Report linkage with the SAME predicate the exclusion above uses. These two lines read
+    # `anon.get(i)` until a review pointed out that this file proves that predicate wrong six lines
+    # earlier: a `static` free function has internal linkage WITHOUT being in an anonymous namespace,
+    # so it was counted as "already external" and the one semantic change this tool makes -- internal
+    # linkage becoming external -- went unreported for exactly the case most likely to surprise.
+    internal = [i for i in promote if not externally_linked(i)]
+    external = [i for i in promote if externally_linked(i)]
     # An earlier version of this guard refused a set with no internal-linkage regions, reasoning
     # that promoting an already-external one is "a no-op reported as success". That is wrong, and it
     # blocked a legitimate use: moving an external definition into a header is not a no-op -- it

--- a/prosper/tools/refactor/promote_internal.py
+++ b/prosper/tools/refactor/promote_internal.py
@@ -33,6 +33,7 @@ import argparse
 import hashlib
 import json
 import pathlib
+import re
 import subprocess
 import sys
 
@@ -40,6 +41,77 @@ import sys
 def repo_root() -> pathlib.Path:
     return pathlib.Path(subprocess.run(["git", "rev-parse", "--show-toplevel"],
                                        capture_output=True, text=True, check=True).stdout.strip())
+
+
+COND_OPEN = re.compile(r'^\s*#\s*(if|ifdef|ifndef)\b')
+COND_CLOSE = re.compile(r'^\s*#\s*endif\b')
+
+
+def conditional_depth(lines: list[str]) -> list[int]:
+    """#if nesting depth BEFORE each line (1-indexed)."""
+    depth = [0] * (len(lines) + 2)
+    cur = 0
+    for i, line in enumerate(lines, 1):
+        depth[i] = cur
+        if COND_OPEN.match(line):
+            cur += 1
+        elif COND_CLOSE.match(line):
+            cur = max(0, cur - 1)
+    depth[len(lines) + 1] = cur
+    return depth
+
+
+def prototype_of(region: dict, lines: list[str]) -> str | None:
+    """A forward declaration for a definition that is staying behind.
+
+    Promoted code can call a function this tool deliberately did NOT promote -- one other
+    translation units link against, whose single out-of-line definition must not move. The header
+    then needs its DECLARATION, or it names something nothing has declared. Built by taking the text
+    from the declaration line to the body's opening brace and terminating it with a semicolon.
+
+    Default arguments are dropped: the definition keeps them where it is, and repeating them in a
+    second declaration does not compile.
+    """
+    start = region["decl_line"] - 1
+    text: list[str] = []
+    for i in range(start, min(start + 12, len(lines))):
+        line = lines[i]
+        if "{" in line:
+            text.append(line[:line.index("{")].rstrip())
+            break
+        text.append(line.rstrip("\n"))
+    else:
+        return None
+    proto = " ".join(t.strip() for t in text if t.strip())
+    # Strip default arguments PER PARAMETER. A single regex over the whole joined signature ate the
+    # last parameter of make_shader_compile_key and emitted `bool fragment_wave32,;` -- syntactically
+    # broken in a way that only shows up at the include site, far from here. Splitting on top-level
+    # commas keeps each parameter's `= value` local to that parameter.
+    open_at = proto.index("(") if "(" in proto else -1
+    if open_at >= 0 and proto.endswith(")"):
+        headtxt, params = proto[:open_at + 1], proto[open_at + 1:-1]
+        out, depth, cur = [], 0, ""
+        for ch in params:
+            if ch in "(<[":
+                depth += 1
+            elif ch in ")>]":
+                depth -= 1
+            if ch == "," and depth == 0:
+                out.append(cur); cur = ""
+            else:
+                cur += ch
+        if cur.strip():
+            out.append(cur)
+        cleaned = [re.sub(r"\s*=.*$", "", x).strip() for x in out]
+        proto = headtxt + ", ".join(c for c in cleaned if c) + ")"
+    if not proto.endswith(")"):
+        return None
+    if region["kind"] == "VAR_DECL":
+        # `thread_local GuestGpuWriteJournal g_x;` -> `extern thread_local GuestGpuWriteJournal g_x;`
+        decl = lines[start].rstrip("\n")
+        decl = decl.split("=")[0].rstrip().rstrip(";").strip()
+        return "extern " + decl + ";" if decl else None
+    return proto + ";"
 
 
 def anon_map(regions: list[dict]) -> dict[int, bool]:
@@ -81,10 +153,21 @@ def needs_inline(region: dict, decl_text: str) -> bool:
     `constexpr` already implies inline. Struct and enum declarations need nothing, and member
     functions defined inside a class body are implicitly inline.
     """
-    if region["kind"] not in ("FUNCTION_DECL", "FUNCTION_TEMPLATE"):
+    if region["kind"] not in ("FUNCTION_DECL", "FUNCTION_TEMPLATE", "VAR_DECL"):
         return False
     if not region.get("is_definition"):
         return False
+    if region["kind"] == "VAR_DECL":
+        # A VARIABLE definition in a header is one object PER TRANSLATION UNIT, so the link fails
+        # with "multiple definition" -- and for `thread_local` it fails in .tbss, which reads as a
+        # TLS problem rather than as a promotion that took a variable along. C++17 inline variables
+        # are the fix, and `inline thread_local X y;` is the correct order.
+        #
+        # This was a known-latent gap: a reviewer noted the policy covered only functions, and it
+        # stayed latent exactly until a promotion first took a variable -- three of them here
+        # (g_guest_gpu_writes, g_guest_readable_cache, g_guest_writable_cache).
+        head = decl_text.lstrip()
+        return not head.startswith(("inline", "constexpr", "extern", "//", "/*", "*"))
     return not decl_text.lstrip().startswith(ALREADY_LINKED)
 
 
@@ -104,7 +187,8 @@ def canonical_include(source_rel: str, header_name: str) -> str:
 
 
 def build(map_data: dict, original: str, promote: list[int], header_rel: str,
-          namespace: str, guard_note: str, include_spelling: str = "") -> tuple[str, str, list[str]]:
+          namespace: str, guard_note: str, include_spelling: str = "",
+          forward_decls: list[str] | None = None) -> tuple[str, str, list[str]]:
     """Returns (header_text, new_source_text, inlined). Pure, so --selftest can drive it."""
     regions = {r["index"]: r for r in map_data["regions"]}
     lines = original.splitlines(keepends=True)
@@ -117,6 +201,11 @@ def build(map_data: dict, original: str, promote: list[int], header_rel: str,
     head = ["#pragma once\n", "\n", guard_note, "\n"]
     head += ["".join(lines[r["start"] - 1:r["end"]]) for r in preamble]
     head += ["\n", f"namespace {namespace} {{\n", "\n"]
+    if forward_decls:
+        head.append("// Declared here, DEFINED in the .cpp this header was lifted out of: other\n"
+                    "// translation units link against those definitions, so they must not move.\n")
+        head += [d + "\n" for d in forward_decls]
+        head.append("\n")
     inlined: list[str] = []
     for i in sorted(promote):
         r = regions[i]
@@ -271,6 +360,16 @@ def selftest() -> int:
     check(not verify(SELF_SRC, SELF_MAP, [3, 4], hdr, src, "s_internal.hpp"),
           "verification passes on a correct promotion")
 
+    # a promoted VARIABLE definition needs `inline` too, or the link fails with multiple definition
+    var_map = json.loads(json.dumps(SELF_MAP))
+    var_map["regions"][3] = {"index": 3, "start": 7, "end": 8, "role": "body", "name": "g_state",
+                             "kind": "VAR_DECL", "is_definition": True, "decl_line": 7}
+    var_src = SELF_SRC.replace("struct Shared { int x; };", "thread_local int g_state = 0;")
+    hdr_v, _s, inl_v = build(var_map, var_src, [3, 4], "s_internal.hpp", "ns", "// n\n",
+                             "s_internal.hpp")
+    check("inline thread_local int g_state" in hdr_v,
+          f"a promoted variable definition gains `inline` (got {inl_v})")
+
     # the static -> inline conversion, and the must-fail arm that makes the new policy checkable
     static_map = json.loads(json.dumps(SELF_MAP))
     static_src = SELF_SRC.replace("int helper() { return 1; }", "static int helper() { return 1; }")
@@ -307,6 +406,11 @@ def main() -> int:
     ap.add_argument("--regions", help="comma-separated region indices to promote")
     ap.add_argument("--header", help="header filename, written beside the source")
     ap.add_argument("--namespace", default="prosper::gpu")
+    ap.add_argument("--exclude", default="",
+                    help="regions that must NOT be promoted even if they redeclare a promoted "
+                         "entity. A forward declaration belongs in the header and its definition "
+                         "may deliberately stay behind -- that pairing is the normal one, and "
+                         "pulling the definition along turns a 797-line function into header text.")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--selftest", action="store_true")
     args = ap.parse_args()
@@ -327,6 +431,7 @@ def main() -> int:
         sys.exit(f"refused: {map_data['file']} has changed since the map was made; re-run map_symbols")
     original = original_bytes.decode()
 
+    forward_decls: list[str] = []
     promote = [int(x) for x in args.regions.split(",") if x.strip()]
     regions = {r["index"]: r for r in map_data["regions"]}
 
@@ -340,10 +445,12 @@ def main() -> int:
     for r in map_data["regions"]:
         if r.get("usr") and r.get("role") == "body":
             by_usr[r["usr"]].append(r["index"])
+    excluded = {int(x) for x in args.exclude.split(",") if x.strip()}
+    promote = [i for i in promote if i not in excluded]
     added: list[int] = []
     for i in list(promote):
         for sibling in by_usr.get(regions[i].get("usr", ""), []):
-            if sibling not in promote:
+            if sibling not in promote and sibling not in excluded:
                 promote.append(sibling)
                 added.append(sibling)
     if added:
@@ -361,6 +468,56 @@ def main() -> int:
     #
     # What must still be refused is a promotion with no internal regions at all, which would mean
     # the tool ran for no reason and said so approvingly.
+    # DO NOT PROMOTE A SYMBOL OTHER TRANSLATION UNITS LINK AGAINST. Making a function `inline` in an
+    # internal header gives a definition to every TU that INCLUDES that header -- and takes away the
+    # single out-of-line definition every OTHER TU was linking to. gpu_executor.cpp defines
+    # guest_readable/guest_writable, which agc_shader_layout, command_processor, gpu_capture,
+    # hle_agc and hle_graphics all call through a public declaration: promoting them produced
+    # "undefined reference" from five files that this tool never touched, which points nowhere near
+    # the promotion.
+    #
+    # The test is whether the name appears in any tracked source outside this file. That
+    # over-detects -- a comment mentioning the name counts -- and over-detecting is right here: the
+    # cost is leaving a helper unpromoted, against a link failure diagnosed far from its cause.
+    # Scan SOURCE only, and skip this tool's own directory. A first version grepped all of
+    # `prosper`, which matched docs, CMakeLists, the header being generated -- and, best of all, the
+    # comment in THIS FILE naming `g_guest_gpu_writes` as an example. The tool's own documentation
+    # changed its classification, excluded the symbol from promotion, and produced 60 compile errors
+    # in the header that still referenced it.
+    def used_elsewhere(name: str) -> bool:
+        if not name or name == "<anonymous>":
+            return False
+        out = subprocess.run(["git", "grep", "-l", "-w", name, "--",
+                              "prosper/src", "prosper/frontends", "prosper/tests",
+                              "prosper/tools", ":!prosper/tools/refactor"],
+                             cwd=root, capture_output=True, text=True)
+        skip = {map_data["file"], str((source.parent / args.header).relative_to(root))}
+        files = [f for f in out.stdout.split()
+                 if f not in skip and f.endswith((".cpp", ".hpp", ".h", ".cc"))]
+        return bool(files)
+
+    # ONLY EXTERNAL-LINKAGE regions can be public. A symbol inside an anonymous namespace cannot be
+    # named from another translation unit at all, so a match elsewhere is necessarily a comment or
+    # an unrelated same-named entity -- and acting on it is actively harmful, not merely
+    # conservative: the symbol stays behind, and an `extern` declaration for it in the enclosing
+    # namespace names a DIFFERENT entity, so every use becomes "reference to X is ambiguous".
+    # Measured: `make_shader_compile_key` was excluded because live_renderer.cpp mentions it in a
+    # comment about CPU profiling.
+    public = [i for i in promote
+              if not anon.get(i)
+              and regions[i]["kind"] in ("FUNCTION_DECL", "VAR_DECL")
+              and used_elsewhere(regions[i]["name"])]
+    if public:
+        print(f"  [ok]   {len(public)} region(s) are referenced outside this file and are NOT "
+              f"promoted; they keep their single out-of-line definition:")
+        for i in public[:8]:
+            print(f"           {regions[i]['kind']:<14s} {regions[i]['name']}")
+        promote = [i for i in promote if i not in public]
+        # A public symbol also bars the conditional-block expansion below from re-adding it: that
+        # expansion runs later and, left unchecked, put `guest_readable` straight back into the
+        # promote set after this filter had removed it -- five other translation units then failed
+        # to link against a definition that had become `inline` in a header they do not include.
+        excluded |= set(public)
     internal = [i for i in promote if anon.get(i)]
     external = [i for i in promote if not anon.get(i)]
     # An earlier version of this guard refused a set with no internal-linkage regions, reasoning
@@ -371,6 +528,108 @@ def main() -> int:
     if not promote:
         print("  [FAIL] nothing to promote")
         return 1
+    # EXPAND TO WHOLE CONDITIONAL BLOCKS before refusing. A platform `#if` in this codebase spans
+    # several regions -- gpu_executor.cpp has `#ifndef _WIN32 ... #else ... #endif` covering eight of
+    # them -- so a promotion that touches one must take all of them, directives included, or the
+    # `#if` and its `#endif` end up in different files. Refusing outright would be safe and useless;
+    # the block is exactly the unit the author wrote.
+    depth = conditional_depth(original.splitlines())
+    total_lines = len(original.splitlines())
+
+    def block_span(line: int) -> tuple[int, int]:
+        """The outermost #if..#endif containing LINE, as a line range."""
+        lo = line
+        while lo > 1 and depth[lo] != 0:
+            lo -= 1
+        hi = line
+        while hi < total_lines and depth[min(hi + 1, total_lines + 1)] != 0:
+            hi += 1
+        return lo, hi
+
+    grew = True
+    while grew:
+        grew = False
+        for i in sorted(promote):
+            r = regions[i]
+            if depth[r["start"]] == 0 and depth[min(r["end"] + 1, total_lines + 1)] == 0:
+                continue
+            lo, hi = block_span(r["start"] if depth[r["start"]] else r["end"])
+            for j, rj in regions.items():
+                if rj["role"] != "body" or j in promote or j in excluded:
+                    continue
+                if rj["start"] <= hi and rj["end"] >= lo:      # overlaps the conditional block
+                    promote.append(j)
+                    grew = True
+        promote = sorted(set(promote))
+    # A conditional block containing an excluded region cannot be lifted as a unit. Drop the WHOLE
+    # block rather than refusing the run: the block is one indivisible thing, and taking part of it
+    # is what separates an `#if` from its `#endif`.
+    incomplete: set[int] = set()
+    for i in list(promote):
+        r = regions[i]
+        if depth[r["start"]] == 0 and depth[min(r["end"] + 1, total_lines + 1)] == 0:
+            continue
+        lo, hi = block_span(r["start"] if depth[r["start"]] else r["end"])
+        members = {j for j, rj in regions.items()
+                   if rj["role"] == "body" and rj["start"] <= hi and rj["end"] >= lo}
+        if members - set(promote):
+            incomplete |= members
+    if incomplete:
+        dropped = sorted(set(promote) & incomplete)
+        print(f"  [ok]   {len(dropped)} region(s) dropped: they sit in a preprocessor block that "
+              f"also holds something excluded, so the block cannot move as a unit")
+        promote = [i for i in promote if i not in incomplete]
+
+    blocked = [i for i in promote
+               if depth[regions[i]["start"]] != 0
+               or depth[min(regions[i]["end"] + 1, total_lines + 1)] != 0]
+    if blocked:
+        print(f"  [ok]   {len(blocked)} region(s) lie inside a preprocessor conditional and are "
+              f"promoted together with it")
+
+    # Anything promoted code CALLS but that stayed behind needs a declaration in the header.
+    edges_all = {int(k): {int(t) for t in v} for k, v in map_data.get("edges", {}).items()}
+    wanted = {d for i in promote for d in edges_all.get(i, set()) if d in set(public)}
+    src_lines = original.splitlines(keepends=True)
+    protos = []
+    for i in sorted(wanted):
+        proto = prototype_of(regions[i], src_lines)
+        if proto:
+            protos.append(proto)
+        else:
+            print(f"  [warn] {regions[i]['name']} stays behind and is called from promoted "
+                  f"code, but no declaration could be derived; add one by hand")
+    if protos:
+        print(f"  [ok]   {len(protos)} forward declaration(s) emitted for definitions that "
+              f"stay behind")
+        forward_decls.extend(protos)
+
+
+    # A region whose start or end sits inside an `#if` cannot be lifted: the `#if` would stay in one
+    # file and the `#endif` land in the other. split_file.py has always checked this; the promotion
+    # path did not, and produced 73 compile errors headed "unterminated #ifndef" -- a message that
+    # points at the header rather than at the lift that broke it.
+    depth = conditional_depth(original.splitlines())
+    # After expansion, a straddle can only survive if completing the block was impossible -- an
+    # excluded region inside it, or a region the map does not cover. That is a real refusal.
+    covered = set(promote)
+    straddling = []
+    for i in promote:
+        r = regions[i]
+        if depth[r["start"]] == 0 and depth[min(r["end"] + 1, total_lines + 1)] == 0:
+            continue
+        lo, hi = block_span(r["start"] if depth[r["start"]] else r["end"])
+        if any(rj["role"] == "body" and rj["start"] <= hi and rj["end"] >= lo and j not in covered
+               for j, rj in regions.items()):
+            straddling.append(i)
+    if straddling:
+        for i in straddling[:8]:
+            r = regions[i]
+            print(f"  [FAIL] region {i} ({r['name']}) spans lines {r['start']}-{r['end']}, which "
+                  f"begin or end inside an #if; lifting it would separate the directive from its "
+                  f"#endif")
+        return 1
+
     print(f"  [ok]   {len(internal)} region(s) change linkage (internal -> external); "
           f"{len(external)} were already external and move so a second translation unit can see "
           f"them, or because the header sits above their definitions")
@@ -383,7 +642,7 @@ def main() -> int:
             "// recompiler: nothing outside src/gpu/recompiler/ should include this header.\n")
     spelling = canonical_include(map_data["file"], args.header)
     header_text, new_source, inlined = build(map_data, original, promote, args.header,
-                                             args.namespace, note, spelling)
+                                             args.namespace, note, spelling, forward_decls)
     print(f"  [ok]   include written as \"{spelling}\" (the canonical form the other tools read)")
     problems = verify(original, map_data, promote, header_text, new_source, spelling)
     if problems:

--- a/prosper/tools/refactor/split_file.py
+++ b/prosper/tools/refactor/split_file.py
@@ -158,12 +158,25 @@ def split(map_data: dict, plan: dict[str, list[int]], source_text: str,
     if missing:
         problems.append(f"{len(missing)} body region(s) unassigned: {missing[:20]}")
 
+    # A boundary inside an `#if` is only a problem when the two sides go to DIFFERENT files -- then
+    # the directive and its `#endif` are separated. Refusing every such boundary was over-strict and
+    # rejected a valid plan: gpu_executor.cpp has conditionals spanning several consecutive regions
+    # that all belong to the same output, where splitting "there" splits nothing.
     depth = conditional_depth([ln.rstrip("\n") for ln in lines])
+    where = dict(seen)
     for r in regions:
-        if depth[r["start"]] != 0:
-            problems.append(f"region {r['index']} starts at line {r['start']} inside an #if "
-                            f"(depth {depth[r['start']]}); splitting there would divide a "
-                            f"conditional across files")
+        if r["index"] in replicated_idx:
+            where[r["index"]] = "<replicated>"
+    ordered = sorted(regions, key=lambda r: r["index"])
+    for prev, cur in zip(ordered, ordered[1:]):
+        if depth[cur["start"]] == 0:
+            continue
+        a, b = where.get(prev["index"]), where.get(cur["index"])
+        if a != b:
+            problems.append(f"line {cur['start']} is inside an #if (depth {depth[cur['start']]}) "
+                            f"and regions {prev['index']} and {cur['index']} go to different "
+                            f"files ({a} and {b}); that would separate the directive from its "
+                            f"#endif")
 
     if problems:
         return {}, problems
@@ -302,7 +315,11 @@ def selftest() -> int:
     check(any("gap or overlap" in x for x in p), "a non-tiling map is refused")
 
     _o, p = split(COND_MAP, {"a.cpp": [1], "b.cpp": [2]}, COND_SRC)
-    check(any("#if" in x for x in p), "a boundary inside an #if is refused")
+    check(any("#if" in x for x in p),
+          "an #if boundary is refused when the two sides go to DIFFERENT files")
+    _o, p2 = split(COND_MAP, {"a.cpp": [1, 2]}, COND_SRC)
+    check(not any("#if" in x for x in p2),
+          "and allowed when they go to the same file -- splitting there splits nothing")
 
     # and the reconstruction check must be able to FAIL
     tampered = dict(outputs)


### PR DESCRIPTION
## What

Hardens the restructuring tools with **nine defects found by attempting `gpu_executor.cpp`**, and documents what they cannot do. **The `gpu_executor.cpp` split is not in this PR** — it is reverted, and the file is untouched at 11,443 lines. What is here is tooling plus a README; every fix came from a reproduced failure. **Four of the eleven fixes carry a self-test arm that provably fails without them** — an earlier version of this sentence claimed all of them did, which was false seven times over; the mutation matrix below names which.

## The nine, and what each cost

1. **Preprocessor blocks split in half.** An `#ifndef _WIN32 … #else … #endif` spans eight regions; lifting one left the `#if` in the source and the `#endif` in the header — **73 errors** headed "unterminated #ifndef", pointing at the header rather than the lift. Promotions now expand to whole conditional blocks, and drop a block entirely when it cannot be completed.
2. **The declaration/definition rule dragged in a 797-line function.** `--exclude` now pins regions that must not be promoted.
3. **Variables need `inline` too.** Three `thread_local`s reached the header and the link failed in `.tbss` — which reads as a TLS problem, not as a promotion that took a variable along. This was a **known-latent** finding from the previous PR's review; it stayed latent exactly until a promotion first took a variable.
4. **Promoting a symbol other TUs link against breaks them.** `inline` in an internal header gives a definition to includers and removes the out-of-line one everyone else linked to — `guest_readable`/`guest_writable` produced "undefined reference" from five untouched files.
5. **…but that check must not apply to internal-linkage symbols**, where it is actively harmful: an anonymous-namespace symbol can't be named from another TU, so a match elsewhere is a comment — and holding it back means an `extern` declaration names a *different* entity, turning every use into "reference to X is ambiguous". `make_shader_compile_key` was held back because `live_renderer.cpp` mentions it in a comment about CPU profiling.
6. **The tool's own comment changed its behaviour.** That check grepped all of `prosper` and matched the comment in `promote_internal.py` naming `g_guest_gpu_writes` as an example — 60 compile errors.
7. **A definition staying behind needs a declaration.** Prototypes (and `extern` for variables) are now derived and emitted, with a warning when one cannot be.
8. **Two ordering bugs, same shape.** The conditional expansion ran *after* both the forward-declaration computation and the public filter, silently undoing each.
9. **One regex over a whole signature ate a parameter** — `bool fragment_wave32,;`. Stripping is per-parameter now.

`split_file.py`'s `#if` check was also **too strict**: it refused any boundary inside a conditional, including ones where both sides go to the same output and splitting "there" splits nothing. It now refuses only a conditional divided *across* files, with the allowed case as its own self-test arm.

## Where `gpu_executor.cpp` actually stands

The partition is computed and sound on paper — 1,679 lines of shared helpers to a header, then ~3,169 / 2,962 / 3,565 across a fetch file, a compute file and the remainder. The build reached two undefined symbols, `scalar_buffer_dword_count` and `read_live_render_target_bytes`, whose declaration-versus-definition relationship across `gpu_execute.hpp`, `shader_resources.hpp` and the file itself I did not untangle. Continuing would have been guessing at a linker error, so it is reverted rather than half-landed.

## And the limit that matters more (new README)

These tools move **structure**. They cannot shrink a **function**, and that is where much of the remaining size lives:

| function | lines | share of its file |
| --- | --- | --- |
| `register_live_renderer` | 8,221 | **89%** of `live_renderer.cpp` |
| `emit_alu` | 7,544 | 97% |
| `execute_item` | 4,536 | 47% |
| `main` (recompiler test) | ~12,400 | 98% |

**A structural split of `live_renderer.cpp` achieves nothing** — the file is one function; moving it renames the problem.

Two things are ruled out in the README so nobody re-derives them:

* **`clang-refactor extract` does not do extract-method.** Its help says *"(WIP action; use with caution!)"* and the caution is the whole story — it does not compute captured variables. Measured on a four-line function: extracting a loop that reads `v` and accumulates into `total` produced `static void accumulate()` with **no parameters**, both names undeclared, mutation discarded.
* **`clang-move` is class-oriented**, so it cannot move free functions or anything in an anonymous namespace — which is most of what these files are.

So shrinking those functions is careful incremental work, a few extractions at a time by whoever is already changing that code, not a sweep. The README records the invariant that made the one extraction done so far checkable — a per-block count of assertions *executed*, after a global floor turned out to be wrong in both directions at once.

## Verified

| check | result |
| --- | --- |
| `promote_internal.py --selftest` | ok, every must-fail arm |
| `split_file.py --selftest` | ok, incl. the new same-file `#if` arm |
| `cmake --build prosper/build-linux -j6` | 0 errors |
| `ctest --no-tests=error -j6` | **282/282 passed, exit 0** |
| `check_numbered_table.py` on the README | ok |

`gpu_executor.cpp` is byte-identical to master; the only source changes are the two tools and one new README.

## Also here: extract-method, and the reason it stops short

The tools above move **structure**; they cannot shrink a **function**, and `register_live_renderer` is 8,221 lines — 89% of its file — so no file-split touches it. `extract_function.py` (new) drives **clangd's** `ExtractFunction` over LSP, which does the capture analysis correctly: read-only locals become `const&` parameters, mutated ones `&`.

Two corrections to my own earlier claims are folded in:

* **`clang-refactor extract` is not that tool.** Marked *"(WIP action; use with caution!)"*, it does **not** compute captures — on a four-line function it emitted `static void accumulate()` with no parameters, both names undeclared, mutation discarded. I tested only this one at first and told the repo extract-method "is not mechanised". Wrong, and corrected in place.
* **Candidates must come from the AST.** Picking spans by line patterns produced ranges starting in comments or mid-continuation every time; clangd then declines, and the decline reads as a tool limitation rather than a malformed question.

**And the finding that settles it.** `--probe` asks clangd about every candidate in one session: **0 of 10 accepted** in `register_live_renderer`. The reason is in clangd's source — `ExtractFunction.cpp` returns `nullptr` on a `LambdaExpr`, commented *"Don't extract from lambdas"*. That function is a lambda nest, so every candidate worth having is categorically refused. **This is correct behaviour, not a defect.** I tested five hypotheses (file, flags, parse race, trailing semicolon, lambda-vs-top-level) before reading the preconditions; reading them first would have been cheaper than any of them.

**Qualification, from re-review.** A hand-built lambda-free 25-line function also reports
`clangd accepts 0 of 1`, while the *same clangd session* returns `['Extract to function']` for a
sub-range of it. So the zero is partly produced by my candidate GEOMETRY, not only by the lambda
rule. The conclusion stands — it rests on the hand-built lambda control and on clangd's own source —
but "0 of 10" is not by itself evidence for it, and is no longer presented as if it were.

So: clangd extract-method is genuinely useful for normal-sized functions and cannot shrink an 8,000-line lambda nest. JetBrains' shipped MCP server is not an alternative — across the IDE family its entire refactoring surface is `rename_refactoring`, with AST refactorings an open request (YouTrack LLM-25880). All of this is in the new README so nobody re-derives it.

**No source file is modified by this PR** — only tools and one README.

Refs #2739


