### PR TITLE
diag(gpu): PROSPER_SRTDUMP — what is behind an SRT-declaring shader's user-data pointers (#2705)

### DIFF
--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -8510,12 +8510,25 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
             table = build_shader_resources(*hdr, sgprs, kUserSgprs, 0);
             assign_convention_bindings(table, 2);
 
-            // SRT CONTENTS. `srt_size_dw` is the one user-data field prosper parses and never
-            // resolves: build_shader_resources reads sharps and the EUD and has no
-            // shader-resource-table path at all (#2705). The GTA V compute programs that hang the
-            // GPU each declare an SRT while declaring NO sharps and no EUD, so both implemented
-            // paths have nothing to resolve for them -- everything they need is described by a field
-            // that is only ever printed.
+            // SRT CONTENTS. `build_shader_resources` reads sharps and the EUD and has no
+            // shader-resource-table path, and every SRT-declaring header in a routed GTA V gameplay
+            // run declares neither -- `sharps={0,0,0,0} eud=0` on 138,034 of 138,034 headers across
+            // 88 of 88 programs (#2705). So the AGC-header path resolves nothing for them and the
+            // table's own bytes are the only way to see what they describe. Nothing dumps them; this
+            // does.
+            //
+            // WHAT THIS DOES NOT MEAN, because an earlier version of this comment said it and it is
+            // false: prosper is NOT blind to this channel. `add_compute_buffer_resources` (:5665,
+            // called :7570) const-folds descriptors loaded with `s_load_dwordx4/x8 sN, s[ptr:ptr+1],
+            // <imm>` from a user-data table -- see the SrtUse contract in gpu_execute.hpp -- and it
+            // fires on these very programs, e.g. `[compute-table] program 0x205b657200 …
+            // addr=0x20037cf620 stride=32 srt=0x10`. The gap is narrower and stranger than "no path
+            // exists": the recovered key set starts at 0x10 and byte offset 0 never appears in it,
+            // while the shaders do load descriptors there (#2757).
+            //
+            // Recorded at this length because the false version travelled: it was written here, then
+            // into a PR body, and would have been the wording the next agent inherited -- from code,
+            // which outlives the PR that a correction lives in.
             //
             // Deciding that needs the table's own bytes, and nothing dumps them. This does, and
             // deliberately dumps CANDIDATES rather than naming one pointer as the SRT: its position

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -8451,7 +8451,13 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     const char* enabled = getenv("PROSPER_COMPUTELOG");
     const char* dim_env = getenv("PROSPER_COMPUTELOG_DIM");
-    if ((!enabled || !*enabled) && (!dim_env || !*dim_env)) return;
+    // PROSPER_SRTDUMP arms only the shader-resource-table dump below. It needs the same per-dispatch
+    // walk, but not COMPUTELOG's per-dispatch prose: COMPUTELOG on this title's gameplay route
+    // produces a log measured in gigabytes, and the SRT question needs 1,074 lines of the 96,557
+    // registrations. Separating the switches keeps the run small enough to read.
+    const char* srt_env = getenv("PROSPER_SRTDUMP");
+    const bool srt_only = srt_env && *srt_env;
+    if ((!enabled || !*enabled) && (!dim_env || !*dim_env) && !srt_only) return;
 
     uint32_t want_w = 0, want_h = 0;
     if (dim_env && *dim_env && sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2) {
@@ -8489,6 +8495,53 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
             read_user_sgprs(ds.sh, P::COMPUTE_USER_DATA_0 + range_start, sgprs);
             table = build_shader_resources(*hdr, sgprs, kUserSgprs, 0);
             assign_convention_bindings(table, 2);
+
+            // SRT CONTENTS. `srt_size_dw` is the one user-data field prosper parses and never
+            // resolves: build_shader_resources reads sharps and the EUD and has no
+            // shader-resource-table path at all (#2705). The GTA V compute programs that hang the
+            // GPU each declare an SRT while declaring NO sharps and no EUD, so both implemented
+            // paths have nothing to resolve for them -- everything they need is described by a field
+            // that is only ever printed.
+            //
+            // Deciding that needs the table's own bytes, and nothing dumps them. This does, and
+            // deliberately dumps CANDIDATES rather than naming one pointer as the SRT: its position
+            // in the user-data block is not established, and a diagnostic that picks one and labels
+            // it "the SRT" would manufacture the fact it exists to measure. Every readable dword
+            // pair in the window is shown with the first `srt_size_dw` dwords behind it. Whichever
+            // holds descriptors will be evident; if none does, that is equally the answer.
+            if (const AgcShaderUserData* ud = hdr->user_data;
+                    srt_env && *srt_env && ud && ud->srt_size_dw) {
+                const uint32_t want = ud->srt_size_dw;
+                const uint32_t shown = want < 64 ? want : 64;   // srt_size_dw is a uint16
+                fprintf(stderr, "[srtdump] code=0x%llx srt_size_dw=%u (showing %u) "
+                                "sharps={%u,%u,%u,%u} eud=%u\n",
+                        (unsigned long long)code_addr, want, shown,
+                        ud->sharp_resource_count[0], ud->sharp_resource_count[1],
+                        ud->sharp_resource_count[2], ud->sharp_resource_count[3], ud->eud_size_dw);
+                bool any = false;
+                for (uint32_t k = 0; k + 1 < kUserSgprs; k++) {
+                    const uint64_t raw = (uint64_t)sgprs[k] | ((uint64_t)sgprs[k + 1] << 32);
+                    if (raw <= 0x10000) continue;
+                    uint64_t addr = 0;
+                    for (uint64_t mask : {~uint64_t{0}, uint64_t{0xFFFFFFFFFFFF},
+                                          uint64_t{0xFFFFFFFFFF}}) {
+                        const uint64_t cand = raw & mask;
+                        if (cand > 0x10000 && guest_readable(cand, shown * 4u)) { addr = cand; break; }
+                    }
+                    if (!addr) continue;
+                    any = true;
+                    fprintf(stderr, "[srtdump]   dw%u -> 0x%llx:", k, (unsigned long long)addr);
+                    const uint32_t* words = reinterpret_cast<const uint32_t*>(addr);
+                    uint32_t nonzero = 0;
+                    for (uint32_t w = 0; w < shown; w++) {
+                        fprintf(stderr, " %08x", words[w]);
+                        nonzero += words[w] != 0;
+                    }
+                    fprintf(stderr, "  (nz=%u/%u)\n", nonzero, shown);
+                }
+                if (!any)
+                    fprintf(stderr, "[srtdump]   no readable pointer in the user-data window\n");
+            }
         }
 
         // A compute shader can carry only an inline direct type-1 V# and no sharp descriptors. Dump

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -8451,13 +8451,20 @@ bool execute_nonrender_submit_work(const GpuState& st, uint64_t submit_no) {
 void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
     const char* enabled = getenv("PROSPER_COMPUTELOG");
     const char* dim_env = getenv("PROSPER_COMPUTELOG_DIM");
-    // PROSPER_SRTDUMP arms only the shader-resource-table dump below. It needs the same per-dispatch
-    // walk, but not COMPUTELOG's per-dispatch prose: COMPUTELOG on this title's gameplay route
-    // produces a log measured in gigabytes, and the SRT question needs 1,074 lines of the 96,557
-    // registrations. Separating the switches keeps the run small enough to read.
+    // PROSPER_SRTDUMP arms the shader-resource-table dump below and NOTHING else. It needs the same
+    // per-dispatch walk as COMPUTELOG, which is why it enters this function, but it must not turn on
+    // COMPUTELOG's per-dispatch prose -- that prose is what makes a COMPUTELOG run on this title's
+    // gameplay route unreadable, and it carries a 4 KiB FNV hash of the shader code per dispatch.
+    //
+    // `prose` is what the two PRE-EXISTING switches ask for, and it gates the tail exactly as they
+    // did before this diagnostic existed. Getting this wrong is not cosmetic: the first version of
+    // this switch let `srt_only` un-gate the tail, so an "SRTDUMP-only" run emitted 352,940
+    // `[compute]` lines it never claimed to, and the resulting log was read as if it were the small
+    // targeted one the comment promised.
     const char* srt_env = getenv("PROSPER_SRTDUMP");
     const bool srt_only = srt_env && *srt_env;
-    if ((!enabled || !*enabled) && (!dim_env || !*dim_env) && !srt_only) return;
+    const bool prose = (enabled && *enabled) || (dim_env && *dim_env);
+    if (!prose && !srt_only) return;
 
     uint32_t want_w = 0, want_h = 0;
     if (dim_env && *dim_env && sscanf(dim_env, "%ux%u", &want_w, &want_h) != 2) {
@@ -8491,6 +8498,13 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
 
         ShaderResourceTable table;
         uint32_t sgprs[kUserSgprs] = {};
+        // `user_data` can be NON-NULL yet point at unmapped guest memory -- build_shader_resources
+        // probes for exactly this and documents the observed case (#713, PPSA02664), returning an
+        // empty table rather than faulting. TWO readers below dereference it, in sibling scopes, so
+        // the probe is hoisted here and shared: a diagnostic that SIGSEGVs where the renderer does
+        // not turns an investigation into a crash report about the instrument.
+        const AgcShaderUserData* ud = hdr ? hdr->user_data : nullptr;
+        const bool ud_ok = ud && guest_readable((uint64_t)(uintptr_t)ud, sizeof(AgcShaderUserData));
         if (hdr) {
             read_user_sgprs(ds.sh, P::COMPUTE_USER_DATA_0 + range_start, sgprs);
             table = build_shader_resources(*hdr, sgprs, kUserSgprs, 0);
@@ -8509,8 +8523,7 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
             // it "the SRT" would manufacture the fact it exists to measure. Every readable dword
             // pair in the window is shown with the first `srt_size_dw` dwords behind it. Whichever
             // holds descriptors will be evident; if none does, that is equally the answer.
-            if (const AgcShaderUserData* ud = hdr->user_data;
-                    srt_env && *srt_env && ud && ud->srt_size_dw) {
+            if (srt_only && ud_ok && ud->srt_size_dw) {
                 const uint32_t want = ud->srt_size_dw;
                 const uint32_t shown = want < 64 ? want : 64;   // srt_size_dw is a uint16
                 fprintf(stderr, "[srtdump] code=0x%llx srt_size_dw=%u (showing %u) "
@@ -8551,10 +8564,10 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
         if (hdr && table.resources.empty() && enabled && *enabled) {
             static std::set<uint64_t> logged_empty;
             if (logged_empty.insert(code_addr).second) {
-                const AgcShaderUserData* ud = hdr->user_data;
-                fprintf(stderr, "[compute] empty-resource metadata code=0x%llx type=%u ud=%p",
-                        (unsigned long long)code_addr, hdr->type, (const void*)ud);
-                if (ud) {
+                fprintf(stderr, "[compute] empty-resource metadata code=0x%llx type=%u ud=%p%s",
+                        (unsigned long long)code_addr, hdr->type, (const void*)ud,
+                        ud && !ud_ok ? " (UNMAPPED)" : "");
+                if (ud_ok) {
                     fprintf(stderr, " eud=%u srt=%u direct_count=%u sharp={%u,%u,%u,%u}",
                             ud->eud_size_dw, ud->srt_size_dw, ud->direct_resource_count,
                             ud->sharp_resource_count[0], ud->sharp_resource_count[1],
@@ -8564,7 +8577,7 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
                 for (uint32_t s = 0; s < kUserSgprs; ++s) fprintf(stderr, " %08x", sgprs[s]);
                 fprintf(stderr, "\n");
 
-                if (ud && ud->direct_resource_offset && ud->direct_resource_count) {
+                if (ud_ok && ud->direct_resource_offset && ud->direct_resource_count) {
                     fprintf(stderr, "[compute]   direct offsets:");
                     for (uint16_t t = 0; t < ud->direct_resource_count && t < 16; ++t)
                         fprintf(stderr, " [%u]=%u", t, ud->direct_resource_offset[t]);
@@ -8588,6 +8601,9 @@ void diagnose_compute_dispatches(const GpuState& st, uint64_t submit_no) {
         }
         if (!dim_match) continue;
         matched++;
+        // Everything past here is COMPUTELOG/COMPUTELOG_DIM's output, including the 4 KiB code hash.
+        // An SRTDUMP-only run has already printed what it came for.
+        if (!prose) continue;
 
         uint64_t code_hash = 1469598103934665603ull;
         if (code_addr && guest_readable(code_addr, 4096)) {


### PR DESCRIPTION
## What this adds

`PROSPER_SRTDUMP=1` prints, for every compute dispatch whose shader header declares a non-zero
`srt_size_dw`, the bytes behind every readable 64-bit pointer in its user-data window. It dumps
**candidates, not a conclusion**: the SRT's position in the user-data block is not established, so a
diagnostic that picked one pointer and labelled it "the SRT" would manufacture the fact it exists to
measure.

Measured on *Grand Theft Auto V* `PPSA04263`, Linux/RADV, routed gameplay entry, 890,722-line log.

## Corrected census — the first version of this PR was wrong

The original body reported **740** SRT-declaring dispatches, **1,487** candidate pointers and **3**
programs. Those were `head` slices of the log, of two *different* lengths, so they did not even
describe the same sample. Recounted over the whole run:

| | first reported | actual | factor |
| --- | ---: | ---: | ---: |
| SRT-declaring dispatches | 740 | **138,034** | 186x |
| candidate pointers | 1,487 | **398,475** | 268x |
| distinct programs | 3 | **88** | 29x |

Instrument trap 46. Produced by review and independently re-derived here.

## The one result this run supports cleanly

**Every SRT-declaring header in the run declares no sharps and no EUD — 138,034 of 138,034, across
88 of 88 programs** (a single `uniq -c` row: `sharps={0,0,0,0} eud=0`). That settles #2705's second
experiment — a program with `srt>0` **and** non-zero sharps — as **not occurring in this title**,
rather than as "not yet found".

## Three claims withdrawn from the previous revision

**1. "None of the candidates is descriptor-shaped."** False. It was made after examining three
payloads out of thousands. Decoding them all finds programs whose SRT bytes are valid RDNA2 V#s.

**2. "A descriptor described only by the channel prosper does not read."** False, and this log
disproves it. `add_compute_buffer_resources` (`gpu_executor.cpp:5665`, called `:7570`) const-folds
exactly this channel; `gpu_execute.hpp:201-217` describes it and defines `SrtUse::key` as the
`s_load` immediate. It fires on these very programs —
`[compute-table] … program 0x205b657200 … addr=0x20037cf620 stride=32 srt=0x10` is prosper reading
SRT byte offset 0x10.

**3. "All 6,655 of their dispatches report `resources=0`."** True of the number, wrong about what it
means. That count comes from `diagnose_compute_dispatches` building its own table with
`build_shader_resources` **alone**, which cannot see the const-fold's resources. The executor's real
tables for those same programs carry **75, 82, 34 and 149** resources, each *"0 with no lookup key"*.
The figure measured my instrument, not the renderer.

**"7 of 88" is also a floor, not a total**, because the decoder only inspected payload dword 0.
Review found more at other aligned offsets, including `0x413ced900`, whose payload is
`2 count dwords + two 4-dword descriptors = exactly 10 = srt_size_dw` — a cleaner example than any
in the previous body.

## The decode, controlled from an independent source

Field extraction matches `decode_buffer_descriptor` (`agc_shader_layout.cpp:190-193`) field for
field, and review established the null properly (odd-offset payloads: 3/2/1/0 hits against 144 at
dword 0; within-payload shuffle mean 25.8; 0 of 2,000 permutations concentrate the hits in ≤7
programs).

The control worth keeping is the one drawn from a *different program and a different table* than the
claim: `0x201bb77d00 stride=4 records=36864 → 147,456 bytes`, decoded from `0x205b5e8600`'s payload,
against prosper's own `addr=0x201bb77d00 size=147456 stride=4 srt=0x30` reported on `0x205b654a00`.
Three fields agreeing across two programs.

## Review fixes in this revision

- **Memory safety.** `hdr->user_data` was dereferenced behind a null check alone; it can be non-null
  and unmapped (#713, PPSA02664). `ud_ok` now matches `build_shader_resources`' probe character for
  character and is shared by both readers. The adjacent **pre-existing** `[compute] empty-resource
  metadata` reader had the same defect and prints `(UNMAPPED)` instead of faulting; that line is not
  this feature's defect and is called out rather than folded in silently.
- **The switch did not do what its comment said.** `srt_only` un-gated the whole function tail, so an
  SRTDUMP-only run emitted **352,940** `[compute]` lines plus a 4 KiB FNV hash per dispatch. Now
  gated on `prose`, the disjunction the two pre-existing switches already required —
  deliberately **not** on `enabled` alone, which would have broken `PROSPER_COMPUTELOG_DIM`-only mode.
- Known and accepted: an SRTDUMP-only run still calls `build_shader_resources` per dispatch and
  discards the result. "Additive only" is a claim about stderr, not about cost.

## Verification

| arm (Messenger `PPSA24651`, 90 s) | `[compute]` lines |
| --- | ---: |
| no switches | **5** |
| `PROSPER_SRTDUMP=1` | **5** |
| `PROSPER_SRTDUMP=1 PROSPER_COMPUTELOG=1` | **368,958** |

The third arm is the positive control: without it, deleting the tail outright would look identical.
All three are the same binary, route and duration, so the comparison is like-for-like.

GTA V, 150 s, default route, SRTDUMP-only: **2,170** `[srtdump]` lines and **6** `[compute]` lines.
That arm exists to show the dump still emits on the real title while the tail stays quiet; it is
**not** an A/B, and no ratio is quoted against the census run. An earlier revision said
"256 KB log (was ~100 MB)", comparing a 150 s run against a ~540 s `reach-story-mode` run whose
`[srtdump]` volume is 247x larger — a mismatched-sample comparison, which is precisely the defect
this PR exists to correct. Withdrawn rather than restated with a normalisation.

```
cmake --build prosper/build-linux -j6                       BUILD_RC=0   (status captured, not piped)
ctest --test-dir prosper/build-linux --no-tests=error -j6   CTEST_RC=0   282/282, 4 skipped
python3 prosper/tools/env/check_diag_gates.py               exit 0, 104/104 baselined
git diff --check origin/master...HEAD                       clean
Claude-Session trailers                                     0
```

`check_diag_gates.py` passing is reported as a fact, not as certification: it documents that it
treats disjunctive gates as ungated, so it cannot see the defect this revision repairs.

Refs #2705, #2709, #2757.

