### PR TITLE
fix(recompiler): S_CSELECT_B32 recycling VCC_LO as scalar scratch accepts non-constant sources — the stock UE volumetric-fog kernel recompiles (#2741)

### DIFF
--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -536,7 +536,8 @@ invariants. A change in frames, draws or wave64 skips is **not** evidence of any
   `120x68x32` grid at 4 and 32 B/cell, under a 3-D dispatch whose Z group count is 32. It rejects on
   `pc=646 words=856a0f0e` = **`s_cselect_b32 vcc_lo, s14, s15`** (llvm-mc, gfx1030), the
   `VCC_LO`-as-scalar-scratch shape `is_gtav_wave64_vcc_lo_scalar_cselect`
-  (`rdna2_to_spirv.cpp:4888`) declined because it required inline-constant sources. The same class
+  (then `rdna2_to_spirv.cpp:4888`; that file was split by #2752) declined because it required
+  inline-constant sources. The same class
   stops the same pass in *Plucky Squire*, *The Pathless* and *Little Nightmares III*. #2747, #2741.
   **That predicate now admits scalar-data sources** (renamed `is_wave64_vcc_lo_scalar_cselect`,
   `rdna2_alu_support.hpp`), so this program is expected to recompile — **not re-measured on this

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -537,11 +537,15 @@ invariants. A change in frames, draws or wave64 skips is **not** evidence of any
   `pc=646 words=856a0f0e` = **`s_cselect_b32 vcc_lo, s14, s15`** (llvm-mc, gfx1030), the
   `VCC_LO`-as-scalar-scratch shape `is_gtav_wave64_vcc_lo_scalar_cselect`
   (then `rdna2_to_spirv.cpp:4888`; that file was split by #2752) declined because it required
-  inline-constant sources. The same class
-  stops the same pass in *Plucky Squire*, *The Pathless* and *Little Nightmares III*. #2747, #2741.
+  inline-constant sources. The same **`s_cselect_b32`** class stops the same pass in *Plucky Squire*
+  (`0x3015fd0000`) and *The Pathless* (`0x200ea80000`, `0x200ead0000`). *Little Nightmares III* loses
+  its froxel program `0x30114c0000` to the **M0** reject `s_mov_b32 s14, m0` instead, which is a
+  different gap. #2747, #2741.
   **That predicate now admits scalar-data sources** (renamed `is_wave64_vcc_lo_scalar_cselect`,
-  `rdna2_alu_support.hpp`), so this program is expected to recompile — **not re-measured on this
-  title**, and #2747's prediction is explicitly that restoring the pass moves no title off its rung.
+  `rdna2_alu_support.hpp`), so **this** program — `0x3017400000`, whose reject is the
+  `s_cselect_b32` — is expected to recompile; the M0-blocked programs are **not** affected.
+  **Not re-measured on this title**, and #2747's prediction is explicitly that restoring the pass
+  moves no title off its rung.
 - **"That missing fog is why this title has not reached gameplay."** **Not supported, and stated so
   it is not assumed.** Volumetric fog is a lighting pass, not a progression gate; the title screen and
   the first-run setup render with it absent, and the run above is clean end to end. The only other

--- a/prosper/docs/DRAGON_QUEST_STATUS.md
+++ b/prosper/docs/DRAGON_QUEST_STATUS.md
@@ -536,8 +536,11 @@ invariants. A change in frames, draws or wave64 skips is **not** evidence of any
   `120x68x32` grid at 4 and 32 B/cell, under a 3-D dispatch whose Z group count is 32. It rejects on
   `pc=646 words=856a0f0e` = **`s_cselect_b32 vcc_lo, s14, s15`** (llvm-mc, gfx1030), the
   `VCC_LO`-as-scalar-scratch shape `is_gtav_wave64_vcc_lo_scalar_cselect`
-  (`rdna2_to_spirv.cpp:4888`) declines because it requires inline-constant sources. The same class
+  (`rdna2_to_spirv.cpp:4888`) declined because it required inline-constant sources. The same class
   stops the same pass in *Plucky Squire*, *The Pathless* and *Little Nightmares III*. #2747, #2741.
+  **That predicate now admits scalar-data sources** (renamed `is_wave64_vcc_lo_scalar_cselect`,
+  `rdna2_alu_support.hpp`), so this program is expected to recompile — **not re-measured on this
+  title**, and #2747's prediction is explicitly that restoring the pass moves no title off its rung.
 - **"That missing fog is why this title has not reached gameplay."** **Not supported, and stated so
   it is not assumed.** Volumetric fog is a lighting pass, not a progression gate; the title screen and
   the first-run setup render with it absent, and the run above is clean end to end. The only other

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -694,7 +694,8 @@ the three routes (fetch pc, SRT offset, SGPR base).
 as an ordinary scalar register** — GTA V's compiler recycles it, which this file already documents
 elsewhere. prosper's VCC-as-scalar recognition is
 `is_wave64_vcc_lo_scalar_b32_candidate`, and it covers exactly two shapes: `s_cselect_b32` with
-inline operands, and SOP2 B32 logicals. **`s_mulk_i32` is SOPK and is in neither set**, so the write
+scalar-data operands (inline constants, SGPRs, or VCC_LO itself since #2741 — it was inline-only when
+this was written), and SOP2 B32 logicals. **`s_mulk_i32` is SOPK and is in neither set**, so the write
 at pc149 is not recognised as a scalar-scratch definition. That matches the failure exactly, but the
 alternative — that the const-fold breaks somewhere else along `s106`'s chain — has not been
 separately excluded, so this is a lead and not a conclusion. Verify before building on it.
@@ -913,12 +914,12 @@ That is the same obstacle as everywhere else in this title:
 | `0x205b654a00` pc1174/1177 | the BVH descriptor's dword3 | `image_bvh_intersect_ray` rejects, the ray-tracing pass never compiles |
 | `0x413ce6000` pc149 | `s_mulk_i32 s106, 120`, the descriptor-array selector | `buffer_load_dwordx3` at pc156 rejects |
 | `0x413ce6000` pc84/90 | integer scratch inside an execz arm | the structurizer's VCC-half liveness guard rejects (cleared on this branch) |
-| GTA V generally | `is_gtav_wave64_vcc_lo_scalar_cselect` exists precisely for this | already a known pattern in the code |
+| GTA V generally | `is_wave64_vcc_lo_scalar_cselect` exists precisely for this | already a known pattern in the code |
 
 **prosper models VCC specially in each place independently — the liveness proof, the scalar-scratch
 recogniser, the descriptor const-fold — and each place has its own, narrower notion of which VCC
 writes count as data.** `is_wave64_vcc_lo_scalar_b32_candidate` admits exactly `s_cselect_b32` with
-inline operands and SOP2 B32 logicals. `s_mulk_i32` (SOPK) is not in it. Neither is the
+scalar-data operands and SOP2 B32 logicals. `s_mulk_i32` (SOPK) is not in it. Neither is the
 `s_and_b32`/`s_or_b32` pair above being tracked *through* to a descriptor.
 
 **This is the frontier.** Not the tree builder, whose lowering is proven correct by eleven perfect

--- a/prosper/docs/PLUCKY_SQUIRE_STATUS.md
+++ b/prosper/docs/PLUCKY_SQUIRE_STATUS.md
@@ -88,6 +88,11 @@ title fails to advance, the correct statement is "the guest read the input and d
 - [#2741](https://github.com/mattias800/prosper/issues/2741) — two UE4 volumetric-fog compute programs
   never execute (`0x3015ab0000` 0/72, `0x3015fd0000` 0/6). Exact rejects: an entry `s_mov_b32 s14, m0`
   and an `s_cselect_b32 vcc_lo, s37, s36` where LLVM has recycled both VCC words as scalar data.
+  **The VCC half is fixed** — a live env-gated A/B moved `0x3015fd0000` from `executed=0 skipped=6` to
+  `executed=6 skipped=0` with nothing rejecting behind it, and the widened predicate has landed. The
+  **M0** half (`0x3015ab0000`, pc151, this title's *main-view* 240x135x64 volume) is untouched and
+  still blocked on the narrower liveness-proved form, so this title's main froxel pass remains absent
+  and **no image change is claimed here**.
 - [#1581](https://github.com/mattias800/prosper/issues/1581) — the rare self-recovering descriptor
   transient; measured here at 1 skip in 46,667 and 2 in 4,488.
 - The world renders very dark with large fully-black regions, and one sampled frame shows blown-out

--- a/prosper/docs/RECOMPILER_REMAINING.md
+++ b/prosper/docs/RECOMPILER_REMAINING.md
@@ -223,6 +223,40 @@ earlier revision excluded it so an identity result could not be mistaken for a d
 excluding it does not fail visibly either — it falls through to the generic reject and names a
 defined control as unsupported, which is the worse signal of the two.
 
+## VCC_LO as scalar scratch: `S_CSELECT_B32` with non-constant sources — **LANDED** (2026-08-20)
+
+`is_wave64_vcc_lo_scalar_cselect` (`rdna2_alu_support.hpp`) used to require **both** sources to be
+inline constants, because an inline operand is an exact dword independent of its value. LLVM also
+emits the same recycling with ordinary SGPR sources, and chains it through VCC_LO itself, so the
+predicate now admits any **scalar-DATA operand kind**: `InlineInt`, `InlineFloat`, `SGPR`, and
+`Special` **only for value 106 (VCC_LO)**.
+
+Three facts make that narrower than it reads, and all three are load-bearing:
+
+* **`Special` is admitted for 106 alone.** The stock Unreal froxel kernel rejects as a *four-wide
+  cascade* — `s_cselect_b32 vcc_lo, s37, s36` at pc217, then `s_cselect_b32 vcc_lo, s38, vcc_lo` at
+  pc220/223, whose second source decodes as `Special` 106. An SGPR-only widening fixes the first
+  reject and re-rejects at the second, which looks like success in a log. Admitting `Special`
+  106..125 wholesale instead breaks two VCC_HI packet-drift guards
+  (`test_rdna2_to_spirv.cpp`, "rejects packet drift and a live high-half mask" and "rejects pc232
+  packet drift into the killed VCC_HI word"); 106 alone restores both.
+* **The predicate decides SHAPE, never whether a source HOLDS scalar data.** That stays with the
+  whole-stream pre-pass (`source_is_scalar_word`) and `operand_bits`, which rejects any source whose
+  dword is not representable in the per-invocation model.
+* **Acceptance still needs the separate per-PC proof** — `complete_scalar_pair` *or*
+  `vcc_b32_low_only_pcs`. For the Unreal kernel it is `complete_scalar_pair`: the dead-high proof
+  does **not** apply, since VCC_HI is that shader's loop counter and stays live past the select.
+  `complete_scalar_pair` proves strictly more (it reconstructs the architectural predicate from both
+  physical words rather than discarding the high one).
+
+**What this established and what it did not.** Measured by a live env-gated A/B on *The Plucky
+Squire* `0x3015fd0000` (control vs arm in one binary, same route, back to back): `executed=0
+skipped=6` → `executed=6 skipped=0`, with no further reject behind it. That is a claim about
+**programs executing**, which is the contract. It is **not** a claim that any image changed — see the
+#2481 row in *Ruled out*, where widening this same family for GTA V left the terminal byte-identical.
+#2747's own prediction is that this restores a lighting pass in four titles and moves **none** of
+them off its rung. #2741, #2747.
+
 ## Ruled out
 
 Cross-title falsifications where the **recompiler was blamed and exonerated**. One line per dead
@@ -231,7 +265,7 @@ without contradictory new evidence.
 
 | Hypothesis | Verdict and evidence | Source |
 |---|---|---|
-| GTA V's `unresolved-operand` rejects at **VCC reads** (`v_mov_b32 v1, vcc_lo`, `v_add_nc_u32 v0, vcc_lo, v0`) mean prosper's **VCC-as-scalar-scratch model is too narrow** — it admits VCC_LO scalar writes only through an enumerated packet list (`is_gtav_wave64_vcc_lo_scalar_cselect`, `is_wave64_vcc_lo_scalar_b32_candidate`, `b32_vcc_scalar_write`), and GTA V also writes VCC_LO with `s_lshl_b32`, `s_mulk_i32`, `s_add_i32`, `s_min_i32` and `v_readfirstlane_b32` | **Falsified — the reject is a symptom three instructions downstream of an unrelated cause.** Widening the write predicate to admit `s_lshl_b32`, extending it in the wave64 MUST dataflow, and adding a dual-domain admission all leave the terminal byte-identical, tested one at a time and then together. `operand_bits` was never the gap either: its `Special` case already reads `rs.sreg[106]` for 106..124. Instrumenting the dataflow gave the actual chain for `0x413d88400`: pc47 `s_mov_b32 s6, s14` makes s6 a MUST scalar word; pc337 **`s_bcnt1_i32_b64 s6, exec`** erases that fact, because `wave64_mask_reduction_source` deliberately returned −1 for architectural EXEC ("already resolved from architectural state by emit_alu"); pc351 `s_lshl_b32 vcc_lo, s6, 2` therefore has a non-scalar source, so VCC_LO's own scalar lifetime is dropped at the pc353 block boundary, and the failure finally surfaces at pc354 in a different register file. emit_alu *can* materialize the reduction, which is why the same packets compile fine inside one block — the coverage arm proving that had passed throughout. **A reject PC names where a fact was consumed, not where it was lost; instrument the MUST dataflow before widening any predicate at the reject site.** | #2481 |
+| GTA V's `unresolved-operand` rejects at **VCC reads** (`v_mov_b32 v1, vcc_lo`, `v_add_nc_u32 v0, vcc_lo, v0`) mean prosper's **VCC-as-scalar-scratch model is too narrow** — it admits VCC_LO scalar writes only through an enumerated packet list (`is_wave64_vcc_lo_scalar_cselect` (then named `is_gtav_…`), `is_wave64_vcc_lo_scalar_b32_candidate`, `b32_vcc_scalar_write`), and GTA V also writes VCC_LO with `s_lshl_b32`, `s_mulk_i32`, `s_add_i32`, `s_min_i32` and `v_readfirstlane_b32` | **Falsified — the reject is a symptom three instructions downstream of an unrelated cause.** Widening the write predicate to admit `s_lshl_b32`, extending it in the wave64 MUST dataflow, and adding a dual-domain admission all leave the terminal byte-identical, tested one at a time and then together. `operand_bits` was never the gap either: its `Special` case already reads `rs.sreg[106]` for 106..124. Instrumenting the dataflow gave the actual chain for `0x413d88400`: pc47 `s_mov_b32 s6, s14` makes s6 a MUST scalar word; pc337 **`s_bcnt1_i32_b64 s6, exec`** erases that fact, because `wave64_mask_reduction_source` deliberately returned −1 for architectural EXEC ("already resolved from architectural state by emit_alu"); pc351 `s_lshl_b32 vcc_lo, s6, 2` therefore has a non-scalar source, so VCC_LO's own scalar lifetime is dropped at the pc353 block boundary, and the failure finally surfaces at pc354 in a different register file. emit_alu *can* materialize the reduction, which is why the same packets compile fine inside one block — the coverage arm proving that had passed throughout. **A reject PC names where a fact was consumed, not where it was lost; instrument the MUST dataflow before widening any predicate at the reject site.** | #2481 |
 | A synthetic kernel reproducing that shape (EXEC popcount, a guard, a consume past the merge) is enough to regression-test it | **Falsified.** Three synthetic shapes were built, including one whose guarded block contains an unpredicated scalar write live at the merge specifically to defeat `safe_execz_branches`. All three compiled on **both** sides of the fix: the structured/linearizing routes claim them before the CFG dispatcher — whose block-entry filter is the defect — ever runs. The exact production kernel plus its exact routed resource table **does** discriminate, and that is what `test_exec_population_count` pins; whether some smaller synthetic could also discriminate was not established, so read this row as "three attempts failed" rather than as a proof of minimality. | #2481 |
 | GTA V's counted **`structured emission stopped` sites are an independent CFG family** that needs 28 separate structurizer fixes | **Falsified by program-tagged terminals and offline retries.** The message is a wrapper emitted after compact structured emission has already stopped at an earlier instruction/resource rejection. In the phase-anchored 28-tuple census every wrapper's `next-pc` matched the same invocation's earlier terminal PC; later exact fixes at `0x413cf6100`, `0x413cf5400`, `0x413e19200`, `0x413e1ac00`, and `0x413cf9200` removed the wrapper without any structurizer change. `0x413ce2a00` is the complementary positive control: compact route selection declines on a bottom-tested EXEC loop, but the generic dispatcher compiles it successfully, so its `backward else` line is route-selection noise rather than a skip. Attribute only program-tagged terminal records; stderr from concurrent shader compilations interleaves. | #2481 |
 | GTA V `0x413dc6700` should receive a **fixed traversal-loop cap** to prevent the recurring RADV device loss | **Falsified as guest semantics.** Its sole backedge is the pc88..97 parent-link traversal and exits when `(parent_word >> 3) & 0x07ffffff` becomes zero; the shader contains no intrinsic numeric trip bound. Captured healthy `0x413ce6000 -> 0x413dc3400 -> 11 x 0x413dc6700` chains replay with an acyclic parent graph (observed maximum depth 6). The live guilty recovery follows a skipped/rejected `0x413ce6000` producer state, so a cap would conceal bad upstream data and truncate a valid deeper graph rather than implement RDNA2. Repair the producer/resource gap; keep the consumer loop exact. | #2481 |

--- a/prosper/docs/RECOMPILER_REMAINING.md
+++ b/prosper/docs/RECOMPILER_REMAINING.md
@@ -254,8 +254,15 @@ Squire* `0x3015fd0000` (control vs arm in one binary, same route, back to back):
 skipped=6` → `executed=6 skipped=0`, with no further reject behind it. That is a claim about
 **programs executing**, which is the contract. It is **not** a claim that any image changed — see the
 #2481 row in *Ruled out*, where widening this same family for GTA V left the terminal byte-identical.
-#2747's own prediction is that this restores a lighting pass in four titles and moves **none** of
-them off its rung. #2741, #2747.
+#2747's own prediction is that this restores a lighting pass and moves **no** title off its rung.
+
+Scope, precisely: of the six froxel programs #2747 names, this predicate unblocks **four, across three
+titles** — `PPSA15319` `0x3015fd0000`, `PPSA17942` `0x3017400000`, `PPSA01826` `0x200ea80000` and
+`0x200ead0000`. The other two, `PPSA15319` `0x3015ab0000` and `PPSA05143` `0x30114c0000`, reject on the
+byte-identical `s_mov_b32 s14, m0` (`be8e037c`) and are **not** touched: that half of #2741 needs a
+narrower liveness-proved form, and #134's `kernel X2 … is REJECTED` must not be reverted wholesale.
+Both of those are their titles' *main-view* volumes, so *Plucky Squire* and *Little Nightmares III*
+keep their main froxel pass absent. #2741, #2747.
 
 ## Ruled out
 

--- a/prosper/src/gpu/recompiler/rdna2_alu_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_alu_support.hpp
@@ -104,16 +104,33 @@ inline uint32_t mbcnt_source_bit(SpirvCompute& b, const RegState& rs, const Oper
     return found == rs.sreg_bool.end() ? 0 : found->second;
 }
 
-// GTA V uses S_CSELECT_B32 to recycle VCC_LO as ordinary scalar scratch. Inline integer and float
-// operands are exact dword constants, independent of their values. Whether the untouched VCC_HI
-// word may be discarded or must form a complete scalar pair is proved separately at each PC.
-inline bool is_gtav_wave64_vcc_lo_scalar_cselect(const Rdna2Inst& in) {
+// S_CSELECT_B32 recycling VCC_LO as ordinary scalar scratch. GTA V selects inline constants; the
+// stock Unreal volumetric-fog kernel selects tracked SGPRs and then CHAINS through VCC_LO itself
+// (#2741: The Plucky Squire 0x3015fd0000 pc217/220/223 is a four-wide cascade -- an SGPR-only
+// widening fixes pc217 and re-rejects at pc220, whose second source decodes as Special 106).
+//
+// This is a SHAPE predicate over operand KINDS only. Whether a non-constant source actually HOLDS
+// scalar data is decided elsewhere and deliberately not duplicated here: the whole-stream pre-pass
+// answers it with source_is_scalar_word(), and emit_alu's operand_bits() rejects any source whose
+// dword is not representable in the per-invocation model. Acceptance additionally requires the
+// separate complete_scalar_pair / vcc_b32_low_only_pcs proof at each PC -- whether the untouched
+// VCC_HI word may be discarded or must form a complete scalar pair is never a property of the
+// select itself.
+//
+// VCC_HI (Special 107) is deliberately NOT admitted as a source. Where the low-only proof applies
+// it has just declared that word dead, and reading it back as data at native subgroup 64 would
+// materialize a ballot half the proof said nobody can observe. Two packet-drift guards in
+// test_rdna2_to_spirv.cpp exist to keep that fail-visible, and admitting Special 106..125 wholesale
+// breaks both.
+inline bool is_wave64_vcc_lo_scalar_cselect(const Rdna2Inst& in) {
+    const auto scalar_source_kind = [](const Operand& o) {
+        return o.kind == OperandKind::InlineInt || o.kind == OperandKind::InlineFloat ||
+               o.kind == OperandKind::SGPR ||
+               (o.kind == OperandKind::Special && o.value == 106);
+    };
     return in.fmt == Rdna2Format::SOP2 && in.opcode == kSop2OpcodeCselectB32 &&
         in.dst.kind == OperandKind::SGPR && in.dst.value == 106 &&
-        (in.src[0].kind == OperandKind::InlineInt ||
-         in.src[0].kind == OperandKind::InlineFloat) &&
-        (in.src[1].kind == OperandKind::InlineInt ||
-         in.src[1].kind == OperandKind::InlineFloat);
+        scalar_source_kind(in.src[0]) && scalar_source_kind(in.src[1]);
 }
 
 // IMAGE_GET_LOD currently models only the ordinary FP32 sampled-image form. Keep the unsupported

--- a/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
@@ -310,7 +310,7 @@ inline std::unordered_set<uint32_t> proven_cselect_b64_low_only_pcs(
 // word. The scalar-data-vs-mask decision remains path-local in emit_alu; this predicate only names
 // B32 packets for which a dead-high proof can make that scalar path discard the old predicate.
 inline bool is_wave64_vcc_lo_scalar_b32_candidate(const Rdna2Inst& in) {
-    return is_gtav_wave64_vcc_lo_scalar_cselect(in) ||
+    return is_wave64_vcc_lo_scalar_cselect(in) ||
         (in.fmt == Rdna2Format::SOP2 && sop2_is_b32_logical(in.opcode) &&
          in.dst.kind == OperandKind::SGPR && in.dst.value == 106);
 }
@@ -322,7 +322,7 @@ inline std::unordered_set<uint32_t> proven_wave64_vcc_b32_low_only_pcs(
         if (in.is_end) break;
         const bool candidate = include_logical
             ? is_wave64_vcc_lo_scalar_b32_candidate(in)
-            : is_gtav_wave64_vcc_lo_scalar_cselect(in);
+            : is_wave64_vcc_lo_scalar_cselect(in);
         if (candidate &&
             sgpr_dead_at_merge(ins, in.pc + in.len_dwords, 107))
             result.insert(in.pc);

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -1273,7 +1273,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.scalar_presence_has_no_placeholders && rs.sreg.contains(107);
                 const bool complete_scalar_pair =
                     path_local_scalar_pair || b.vcc_b32_scalar_pair_pcs.contains(in.pc);
-                if (!is_gtav_wave64_vcc_lo_scalar_cselect(in) ||
+                if (!is_wave64_vcc_lo_scalar_cselect(in) ||
                     (!complete_scalar_pair &&
                      !b.vcc_b32_low_only_pcs.contains(in.pc)) || !rs.scc) {
                     ok = false; return true;

--- a/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
@@ -2266,7 +2266,7 @@ bool emit_cfg_state_machine(
             };
             const bool valid_scc_read = !reads_scc(in) || scalar_scc;
             const bool b32_vcc_scalar_write =
-                is_gtav_wave64_vcc_lo_scalar_cselect(in) ||
+                is_wave64_vcc_lo_scalar_cselect(in) ||
                 (in.fmt == Rdna2Format::SOP2 &&
                  (in.dst.value == 106 || in.dst.value == 107) &&
                  in.opcode >= 0x0e && in.opcode <= 0x1c &&

--- a/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
@@ -9516,6 +9516,67 @@ int main() {
     printf("  kernelX4(vcc scratch) mismatches=%u\n", badX4);
     CHECK(gotX4.size()==N && badX4==0, "kernel X4 computes bits(a0) + vcc_lo(5) via the tracked scalar write");
 
+    // Kernels X4b/X4c/X4d: the same VCC-as-scalar-scratch model reached through S_CSELECT_B32 with
+    // NON-CONSTANT scalar sources (#2741). The stock Unreal volumetric-fog kernel
+    // (The Plucky Squire 0x3015fd0000, byte-identical in Little Nightmares III and The Pathless)
+    // loads four floats with s_buffer_load_dwordx4, keeps its loop counter in VCC_HI, and selects
+    // one of them into VCC_LO with a four-wide cascade whose later members chain through VCC_LO
+    // itself. Every word below is llvm-mc gfx1030 verified; the pc217 select is the title's exact
+    // dword 0x856a2425. VCC_HI is written as ordinary scalar data first, so acceptance runs through
+    // the complete_scalar_pair reconstruction (the dead-high proof does NOT apply to this shape —
+    // in the real shader VCC_HI stays live as the loop counter past the select).
+    //   X4b: s_mov s36,7 ; s_mov s37,9 ; s_mov vcc_hi,0 ; s_cmp_eq_u32 vcc_hi,0 (SCC=1)
+    //        s_cselect_b32 vcc_lo, s37, s36 ; v_add_nc_u32 v1, vcc_lo, v0   => bits(a0) + 9
+    const uint32_t codeX4b[] = {
+        0xBEA40387u, 0xBEA50389u, 0xBEEB0380u, 0xBF06806Bu,
+        0x856A2425u, 0x4A02006Au, 0xBF810000u };
+    std::vector<uint32_t> spvX4b = recompile_valu(codeX4b, std::size(codeX4b), 1, /*out_vgpr*/1);
+    CHECK(!spvX4b.empty(), "kernel X4b (s_cselect_b32 vcc_lo from two SGPRs) recompiles");
+    // Guard the execution arm: with the widening absent this module is empty, and the
+    // CHECK above is the finding — running an empty module would abort the suite instead.
+    std::vector<float> gotX4b = spvX4b.empty()
+        ? std::vector<float>() : prosper::test::run_compute(spvX4b, inX, N, N);
+    uint32_t badX4b = 0;
+    for (uint32_t i = 0; i < N && gotX4b.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotX4b[i], 4);
+        if (gb != bits_of(inX[i]) + 9u) badX4b++;
+    }
+    printf("  kernelX4b(vcc cselect sgpr) mismatches=%u\n", badX4b);
+    CHECK(gotX4b.size()==N && badX4b==0,
+          "kernel X4b selects the SCC-true SGPR source (9, not 7) into vcc_lo and reads it as data");
+
+    //   X4c: the cascade's chained member, whose src1 is VCC_LO itself (decodes as Special 106).
+    //        ... s_cmp_eq_u32 vcc_hi,1 (SCC=0) ; s_cselect_b32 vcc_lo, s38, vcc_lo
+    //        The SCC-false arm is the chained VCC_LO, so the answer stays 9: reading s38 would give
+    //        11 and dropping the chained read would give 0. An SGPR-only widening rejects here.
+    const uint32_t codeX4c[] = {
+        0xBEA40387u, 0xBEA50389u, 0xBEA6038Bu, 0xBEEB0380u, 0xBF06806Bu,
+        0x856A2425u, 0xBF06816Bu, 0x856A6A26u, 0x4A02006Au, 0xBF810000u };
+    std::vector<uint32_t> spvX4c = recompile_valu(codeX4c, std::size(codeX4c), 1, /*out_vgpr*/1);
+    CHECK(!spvX4c.empty(), "kernel X4c (s_cselect_b32 vcc_lo chaining through vcc_lo) recompiles");
+    // Guard the execution arm: with the widening absent this module is empty, and the
+    // CHECK above is the finding — running an empty module would abort the suite instead.
+    std::vector<float> gotX4c = spvX4c.empty()
+        ? std::vector<float>() : prosper::test::run_compute(spvX4c, inX, N, N);
+    uint32_t badX4c = 0;
+    for (uint32_t i = 0; i < N && gotX4c.size() == N; i++) {
+        uint32_t gb; std::memcpy(&gb, &gotX4c[i], 4);
+        if (gb != bits_of(inX[i]) + 9u) badX4c++;
+    }
+    printf("  kernelX4c(vcc cselect chain) mismatches=%u\n", badX4c);
+    CHECK(gotX4c.size()==N && badX4c==0,
+          "kernel X4c round-trips the chained vcc_lo source (9, not 11 and not 0)");
+
+    //   X4d: same-site source mutation to VCC_HI (Special 107) stays REJECTED. This is a real
+    //        discriminator at this shape: VCC_HI holds tracked scalar data here, so operand_bits
+    //        would resolve it and a Special 106..125 widening would ACCEPT. The narrow
+    //        Special == 106 form is what keeps the two GTA packet-drift guards above passing.
+    const uint32_t codeX4d[] = {
+        0xBEA40387u, 0xBEA50389u, 0xBEEB0380u, 0xBF06806Bu,
+        0x856A6B25u, 0x4A02006Au, 0xBF810000u };
+    CHECK(recompile_valu(codeX4d, std::size(codeX4d), 1, /*out_vgpr*/1).empty(),
+          "kernel X4d (same-site vcc_hi source) remains REJECTED");
+
     // Kernel O: VOP2 v_mul_f32 in SDWA form with OMOD ×2 output modifier. This was a #121 blocker —
     // PPSA02664's pixel shaders emit `v_mul_f32 v,v,v mul:2` (full-DWORD selects, omod=×2), which the
     // decoder rejected as an unhandled modifier, failing the whole PS. Now the ×2 is applied.


### PR DESCRIPTION
Fixes the **VCC half** of #2741. Refs #2747.

## The gap

`is_gtav_wave64_vcc_lo_scalar_cselect` (`rdna2_alu_support.hpp`) recognised `S_CSELECT_B32` recycling
VCC_LO as ordinary scalar scratch, but required **both sources to be inline constants** — an inline
operand is an exact dword independent of its value, so no reasoning about what a source holds was
needed. LLVM emits the same recycling with ordinary **SGPR** sources in any high-register-pressure
GFX10 shader, so the stock Unreal volumetric-fog compute program is rejected outright and **every one
of its dispatches is skipped**. It is not one title's bug.

**Exactly what this unblocks — stated precisely, because the neighbouring reject is easy to credit to
it by mistake.** #2747 names six froxel programs across four titles. This predicate unblocks **four of
them, across three titles**: `PPSA15319` `0x3015fd0000`, `PPSA17942` `0x3017400000`, `PPSA01826`
`0x200ea80000` and `0x200ead0000`. The other two — `PPSA15319` `0x3015ab0000` and `PPSA05143`
`0x30114c0000` — reject on the **byte-identical reject word** `s_mov_b32 s14, m0` (`be8e037c`), each
bind a `240 x 135 x 64 x 8` = 16,588,800 B volume, and are **not** touched here. Both are their
titles' *main-view* volumes, so *The Plucky Squire* and *Little Nightmares III* keep their main froxel
pass absent after this change.

An earlier revision of this body called those two "byte-identical **programs**". They are not, and the
evidence **falsifies** it rather than merely failing to support it: they reject at **different PCs** —
`0x3015ab0000` at `pc=151`, `0x30114c0000` at `pc=297`, on the same dword `be8e037c` (#2741). The
recompiler is deterministic over the program bytes, so two byte-identical images reject at the same
position; different positions therefore rule identity out. (Their `[compute-table]` binding counts also
differ — two `class=2` sampled inputs versus three — but those figures come from different runs on
different routes and a `[compute-table]` reflects what one dispatch offered, so treat that as
**corroboration**, not as the falsifier. The PC is the falsifier.)

What #2747 does establish is narrower, and stronger than this PR needs: the same *stock UE pass*,
compiled by the same compiler into two unrelated titles, hitting one reject. **Three** facts back it —
the identical blocking dword `be8e037c`, the identical `240 x 135 x 64 x 8` = 16,588,800 B volume, and
identical dispatch geometry `groups=30x17x64 local=8x8 threads=240x136`. The third comes from #2747
**comment `5347427037`**, which supersedes that issue's instrument note 2: a second `PPSA05143` arm ran
past the boundary the first died before and put `0x30114c0000` in the census with that geometry, taking
the identification from `MED-HIGH` to `HIGH`. An earlier revision of this body said no dispatch geometry
was quoted for `0x30114c0000` at all — that was true of #2747's **body** and false of **#2747**, which
is a distinction this project pays for repeatedly.

**One qualification that #2747's comment does not carry, and it belongs with the third fact.** (The
caveat does appear once in the issue thread — #2741 comment `5347312824`, on the positive control — but
not in #2747's comments, which is where fact 3 comes from, and not in the review.)
`PLUCKY_SQUIRE_STATUS.md` § Ruled out records that this geometry is **not run-to-run stable**: an
independent 1,152 s arm of the same Plucky route on the same binary reports `groups=27x15x64 local=8x8
threads=216x120` for `0x3015ab0000`, a 3456x1920 view, because UE dynamic resolution moves the froxel
grid's XY between runs. So the geometry match is between *those two arms*, both at 3840x2160 — real
evidence, and not a run-to-run selector. What does not move across arms is `gz=64`, `local=8x8` and the
16,588,800 B binding, and those are the parts the identification actually rests on.

(For completeness: #2747's emphasised "byte-identical **volumes**" sentence is about the *other* pair,
`0x200ead0000` / `0x3015fd0000` at 131,072 B. The 16,588,800 B figure for this pair comes from its
froxel table.)

## The change

Widen the predicate from *"both sources are inline constants"* to *"both sources have a scalar-DATA
operand kind"*, and rename it `is_wave64_vcc_lo_scalar_cselect` — it is no longer GTA-V-specific:

```cpp
const auto scalar_source_kind = [](const Operand& o) {
    return o.kind == OperandKind::InlineInt || o.kind == OperandKind::InlineFloat ||
           o.kind == OperandKind::SGPR ||
           (o.kind == OperandKind::Special && o.value == 106);
};
```

Three things keep that narrower than it reads. **Each has a mutation arm below, and each arm fires.**

1. **`Special` is admitted for 106 alone.** The real reject is a **four-wide cascade** — pc217 is
   `s_cselect_b32 vcc_lo, s37, s36`, but pc220/223 are `s_cselect_b32 vcc_lo, s38, vcc_lo`, whose
   second source decodes as `Special` 106. An SGPR-only widening fixes pc217 and **re-rejects at
   pc220**, which reads as success in a log. Admitting `Special` 106..125 wholesale instead breaks
   both VCC_HI packet-drift guards.
2. **The predicate decides SHAPE, never whether a source HOLDS scalar data.** That stays with the
   whole-stream pre-pass (`source_is_scalar_word`, `rdna2_emit_cfg.cpp`) and with `operand_bits`,
   which rejects any source whose dword is not representable per invocation.
3. **Acceptance still requires the separate per-PC proof** — `complete_scalar_pair` **or**
   `vcc_b32_low_only_pcs` (`rdna2_emit_alu.cpp`). For this shader it is `complete_scalar_pair`; the
   dead-high proof does **not** apply, because VCC_HI is the kernel's loop counter and stays live
   past the select (`dead_high = 0` at all three PCs). `complete_scalar_pair` proves strictly more —
   it reconstructs the architectural predicate from both physical words instead of discarding the
   high one.

Nothing else changes: no change to `sgpr_dead_at_merge`, `proven_wave64_vcc_b32_low_only_pcs`, the
`complete_scalar_pair` reconstruction, or the **M0** half of #2741.

## Behavioral contract

* **Changed:** a Wave64 compute `S_CSELECT_B32` writing VCC_LO whose sources are SGPRs, inline
  constants, or VCC_LO itself is now recognised as a scalar-scratch definition. It is *accepted* only
  where the pre-existing per-PC proof already licensed a scalar VCC_LO lifetime.
* **Deliberately unchanged:** VCC_HI as a source stays rejected everywhere; the M0 entry-read reject
  (`kernel X2 (m0 read as ALU data) is REJECTED`, #134) stays; Wave32 and vertex paths are untouched;
  the B64 sibling `proven_cselect_b64_low_only_pcs` is untouched.
* **One stage is not simply "untouched", and review caught it.** The *emitter's* acceptance branch is
  `b.is_compute && b.wave_size == 64` (`rdna2_emit_alu.cpp:1266`), so no fragment shader can take the
  new acceptance path. But the *whole-stream pre-pass* is guarded
  `(b.is_compute || b.is_fragment) && b.wave_size == 64` (`rdna2_emit_cfg.cpp:2175`), so for a Wave64
  **fragment** the widened predicate now makes `b32_vcc_scalar_write` true where it previously was
  not, and 106 enters `masks`. The emit side then falls to the generic `case 0x0A`
  (`rdna2_emit_alu.cpp:2175`) and never establishes the Bool domain — the two models of one
  instruction disagree by stage. **This mismatch is pre-existing** (master reaches it with
  inline-constant sources); the widening makes it *more reachable* without introducing it, and no
  captured Wave64 fragment shader is known to contain the shape. Filed as **#2761** rather than fixed
  here, because fixing it needs a fragment-shaped regression and #2429's void-discriminator hazard
  applies to building one.

## Tests and what each arm proves

New kernels beside **X4** ("VCC as plain scalar SCRATCH"), matching its shape. Every word verified
with `llvm-mc -arch=amdgcn -mcpu=gfx1030`; X4b/X4c use the title's exact reject dword `0x856a2425`.

| Kernel | Shape | Asserts |
|---|---|---|
| **X4b** | `s_mov s36,7 ; s_mov s37,9 ; s_mov vcc_hi,0 ; s_cmp_eq_u32 vcc_hi,0 ; s_cselect_b32 vcc_lo,s37,s36 ; v_add_nc_u32 v1,vcc_lo,v0` | recompiles **and executes** to `bits(a0) + 9` — the SCC-true SGPR source, not 7 |
| **X4c** | X4b plus `s_cmp_eq_u32 vcc_hi,1 ; s_cselect_b32 vcc_lo,s38,vcc_lo` | recompiles and executes to `bits(a0) + 9`; reading `s38` instead of the chained `vcc_lo` would give 11 |
| **X4d** | X4b with the same-site source mutated to VCC_HI | stays **REJECTED** |

Counter-arms — the predicate body was mutated in place, `test_rdna2_to_spirv` rebuilt and re-run each
time (1,073 checks in every arm):

| Arm | Predicate | Result |
|---|---|---|
| **A — master's form** | inline constants only | **4 FAIL**: X4b and X4c, both checks each. Nothing else in 1,073 checks moves — the widening is load-bearing for exactly the new assertions and for nothing else. |
| **B — the naive fix** | `+ SGPR`, no `Special` | **2 FAIL**: X4c only. X4b **passes**. This is trap 1 reproduced exactly: the first reject vanishes and the program still does not recompile. |
| **C — the over-wide fix** | `+ Special 106..125` | **3 FAIL**: both GTA packet-drift guards *and* X4d. Confirms X4d is an independent discriminator for the 106-only restriction, at a configuration (`complete_scalar_pair`, `native_subgroup_size=0`) the GTA guards do not cover. |

**One honest limit on X4c, from review.** Its second select is an *identity* — the SCC-false arm
selects the value VCC_LO already holds — so the **value** arm discriminates a wrong-arm selection (11)
but cannot discriminate a *dropped* chained read: dropping it makes `operand_bits` reject, which
yields an empty module and fails X4c's **compile** arm instead. The compile arm plus counter-arm B is
what carries this kernel; the value arm is a bonus. An earlier revision of this body claimed "0 a
dropped chained read", which describes an outcome that cannot occur.

**Instrument note carried forward from #2741:** an untracked `VCC_LO` read is a **void** mutation arm
here — when the native subgroup equals the guest wave it resolves through `native_wave_ballot_half`
before reaching the reject. X4d mutates to **VCC_HI**, which is the discriminating operand, and arm C
demonstrates it firing rather than asserting that it would.

## What this establishes, and what it does NOT

**Established:** the programs recompile. The live A/B recorded on #2741 (one binary, env-gated so
control and arm differed by nothing else, same route, back to back) moved *The Plucky Squire*'s
`0x3015fd0000` from `executed=0 skipped=6` to `executed=6 skipped=0 groups=2x2x64 local=8x8
threads=16x16`, with no further reject behind it. That measurement is **not repeated in this PR** —
what this PR adds is the offline proof that the widened predicate is the thing that moves it, and the
three counter-arms that bound it.

**NOT established: that any image changes.** `RECOMPILER_REMAINING.md` § Ruled out records that
widening this same predicate family for GTA V left the terminal **byte-identical** (#2481), and the
B64 sibling with SGPR sources is *already* admitted on the `sgpr_dead_at_merge` proof — so "the
programs now execute" and "the composite changed" are different claims and only the first is made
here. #2747's own prediction is explicitly that this restores a lighting pass in four titles and
moves **none of them off its rung**. For *Plucky Squire* specifically a composite change should not
even be expected: its **main-view** 240x135x64 volume is `0x3015ab0000`, which is blocked by the
**M0** half and is deliberately untouched — only the 16x16x64 secondary view is unblocked here.
An unchanged image is therefore not evidence the fix failed.

`CONFIDENCE: HIGH` that the predicate was the whole blocker for `0x3015fd0000` (live A/B, no reject
behind it, three counter-arms). `CONFIDENCE: MED` that admitting a `Special` VCC_LO source is sound
at a **low-only** PC as opposed to a complete-pair PC — Plucky exercises only the complete-pair path,
so the live evidence does not cover the other. That is the reviewable question, and it is why this is
flagged for independent review.

## Docs

* `RECOMPILER_REMAINING.md` — new LANDED section recording the widening, the three narrowing
  constraints, and the explicit *executes ≠ image changes* separation against the #2481 row. The
  #2481 row's symbol citation is updated to the new name (name only; its prose is unchanged).
* `PLUCKY_SQUIRE_STATUS.md`, `DRAGON_QUEST_STATUS.md`, `GTA5_STATUS.md` — current-state sentences that
  said the predicate "requires inline-constant sources" are now false and are corrected.

## Verification

Linux, `ps5ys` distrobox (Fedora 44, gcc 16.1.1), own worktree off `origin/master` `f79afdb1`, built
`-j4` with `TMPDIR` on real disk outside `/tmp` and outside any `build-*` path. Build: **0 errors**,
reached `[100%]`.

**The Vulkan check comes first, because without it the rest of this section proves nothing.**
`add_test(NAME rdna2_to_spirv_exec COMMAND test_rdna2_to_spirv)` is at
`prosper/CMakeLists.txt:2095` **as of this branch's base `f79afdb1`** (the file is byte-identical on
the PR head — this PR touches no build file — while `origin/master` has since drifted **+8 lines** in
this region, where the same `add_test` is at `:2103`), inside the `if(Vulkan_FOUND)` opened at `:1978`
(itself inside
`if(UNIX)` at `:1811` and `if(TARGET prosper_core)` at `:424` — verified by matching `if`/`endif`
depth to line 2095, not by reading the nearest `if` above it). A configure without Vulkan therefore
**drops all five new CHECKs and still exits 0** — the `--no-tests=error` failure mode by another
mechanism. So the count below is only meaningful together with the two lines that show the test was
actually registered and actually ran:

```text
$ grep -E '^Vulkan_LIBRARY:' CMakeCache.txt
Vulkan_LIBRARY:FILEPATH=/usr/lib64/libvulkan.so          # configure log: "Vulkan found … offscreen graphics harness enabled"

$ ctest -N | tail -2                                     # denominator pinned BEFORE the run
Total Tests: 282
$ ctest -N | grep rdna2_to_spirv_exec
  Test #254: rdna2_to_spirv_exec                         # registered, i.e. Vulkan_FOUND was true

$ ctest --no-tests=error -j4
281/282 Test #254: rdna2_to_spirv_exec ............................   Passed    9.70 sec
282/282 Test #133: file_binary_roundtrip ..........................   Passed   42.01 sec

100% tests passed out of 282

Total Test time (real) =  52.77 sec
CTEST_EXIT=0

$ ./test_rdna2_to_spirv | tail -1                        # closes the STALE-BINARY case
== PASS: 1073 checks ==
```

**`282` registered, `282` passed, exit `0`**, with `rdna2_to_spirv_exec` present in the `-N` listing
and `Passed` in the run — so "the suite was empty" and "the new kernels were skipped" are both
falsified by the evidence rather than assumed away.

**Why the last line is in the block rather than in prose.** All five lines above can hold while the new
CHECKs are absent, in exactly one way: a **stale test binary**, if the `.cpp` were not recompiled.
`== PASS: 1073 checks ==` is what rules that out, because the counter-arm table establishes 1,073 as the
*with-new-kernels* total — arm A reports `FAIL: 2 of 1073`, so failing checks still count toward it,
making 1,068 the without-kernels number. A stale binary would report 1,068. It reports 1,073, and that
total includes the five new CHECKs, `kernel X2 (m0 read as ALU data) is REJECTED`, and both GTA
packet-drift guards. (The execution arms cannot silently no-op into a pass either: the assertion is
`gotX4b.size()==N && badX4b==0`, so an empty result fails on the size.) The three counter-arms are in a
separate comment on this PR.

