### PR TITLE
docs: structure mirrors architecture, every folder gets an AGENTS.md, and teardown is part of finishing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,8 +303,9 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     Why this is spelled out rather than left to the sweeper: measured 2026-08-20, **49 registered
     worktrees**, from which `worktree_reclaim.py` could reclaim exactly **one** — blocked on **35
     trees classified DIRTY**, i.e. holding uncommitted or untracked files. Disk, and note the
-    scoping: **101 GB under `.claude/worktrees/`**, plus **13 registered trees living outside that
-    subtree** carrying roughly 33 GB more, so about **141 GB** in total. Automation cannot
+    scoping: `du` reports **101 GiB under `.claude/worktrees/`**, and **13 registered trees live
+    outside that subtree** carrying roughly 33 GB more — so the total is well over 100 GB either way,
+    which is the point. (Do not add the two figures as printed: one is binary and one decimal.) Automation cannot
     fix that and never will, because refusing a dirty tree is the guard that stops it destroying
     someone's work. **So commit, stash or discard before you leave a tree**, or you are the only one
     who will ever be able to clean it up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,9 +234,11 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   here is stale the first time somebody edits it, and a stale map is worse than none because it is
   believed. Write about what the folder is *for*.
 
-  Measured 2026-08-20: **2 `AGENTS.md` files against 89 source directories** under `src/`,
-  `frontends/` and `tools/`. Write one when you work in a folder that lacks it; correct the existing
-  one when you change what the folder means.
+  Measured 2026-08-20 on the commit before this rule landed: **2 `AGENTS.md` files against 89 source
+  directories** under `src/`, `frontends/` and `tools/`. The commit that added this rule also seeded
+  all of `src/gpu`, taking it to 16 — so treat the ratio as the starting point it described, not as a
+  current figure, and re-measure rather than quoting it. Write one when you work in a folder that
+  lacks it; correct the existing one when you change what the folder means.
 
   *"Within reason"* is part of the rule: a folder holding a single file, or a leaf whose name already
   says everything, does not need one. If you cannot write a sentence the reader would not have
@@ -298,9 +300,11 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     `isolation: "worktree"` tree only when it is **unchanged** — so a subagent that did any real work
     leaves its tree behind permanently, and the agent that spawned it is the only one who knows it is
     finished.
-    Why this is spelled out rather than left to the sweeper: measured 2026-08-20, **48 registered
-    worktrees occupying 101 GB**, from which `worktree_reclaim.py` could reclaim exactly **one**. It
-    was blocked on **35 trees classified DIRTY** — uncommitted or untracked files. Automation cannot
+    Why this is spelled out rather than left to the sweeper: measured 2026-08-20, **49 registered
+    worktrees**, from which `worktree_reclaim.py` could reclaim exactly **one** — blocked on **35
+    trees classified DIRTY**, i.e. holding uncommitted or untracked files. Disk, and note the
+    scoping: **101 GB under `.claude/worktrees/`**, plus **13 registered trees living outside that
+    subtree** carrying roughly 33 GB more, so about **141 GB** in total. Automation cannot
     fix that and never will, because refusing a dirty tree is the guard that stops it destroying
     someone's work. **So commit, stash or discard before you leave a tree**, or you are the only one
     who will ever be able to clean it up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,9 +303,10 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     Why this is spelled out rather than left to the sweeper: measured 2026-08-20, **49 registered
     worktrees**, from which `worktree_reclaim.py` could reclaim exactly **one** — blocked on **35
     trees classified DIRTY**, i.e. holding uncommitted or untracked files. Disk, and note the
-    scoping: `du` reports **101 GiB under `.claude/worktrees/`**, and **13 registered trees live
-    outside that subtree** carrying roughly 33 GB more — so the total is well over 100 GB either way,
-    which is the point. (Do not add the two figures as printed: one is binary and one decimal.) Automation cannot
+    scoping: `du` reported **101 GiB under `.claude/worktrees/`** and **13 registered trees living
+    outside that subtree** carrying ~31 GiB more. Re-measure rather than quoting those: the first
+    figure read 89 GiB a few hours later on the same day, because this churns constantly. The
+    conclusion is what is stable — well over 100 GB, and the sweeper can reclaim almost none of it. Automation cannot
     fix that and never will, because refusing a dirty tree is the guard that stops it destroying
     someone's work. **So commit, stash or discard before you leave a tree**, or you are the only one
     who will ever be able to clean it up.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,47 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   lane reports an A/B to you, land it in the doc or the issue before the session ends. Read the
   `## Ruled out` section of every doc you are about to work in **before** forming a hypothesis.
 
+- **File and folder structure mirrors the logical architecture, and you are expected to refactor
+  toward that as you go.** A directory is a claim about what belongs together. When the claim is
+  false the tree actively misleads, because "where does this live?" gets answered by the wrong
+  place — and the cost lands on whoever arrives next, not on whoever left it. So put new code in the
+  folder its architecture implies rather than beside whatever file you happened to open, split a file
+  that has grown a second responsibility, and move a module that sits in the wrong folder.
+
+  **You do not need permission or a dedicated task for this.** An incidental, mechanical restructure
+  alongside the work you are already doing is welcome, and is how the tree stays honest between the
+  occasional large passes. Two limits keep it from becoming a hazard:
+  - **Move with tools, never by retyping.** `prosper/tools/refactor/` exists for exactly this:
+    `move_module.py` (relocate a module and rewrite every include and path citation repo-wide),
+    `split_file.py` (a split that proves it was a pure move), `promote_internal.py` (lift
+    internal-linkage declarations into a header). Hand-editing a restructure is how this project's
+    recorded traps happen — a whole-file `git checkout` that silently reverted another lane's edits
+    (trap 41), and a clean merge into a broken file.
+  - **Keep the move separable from the behaviour change.** Put it in its own commit so a reviewer
+    reads `git mv` plus include rewrites instead of a diff that mixes relocation with logic. If the
+    restructure is big enough to conflict with other lanes, it is its own PR.
+
+  `CMakeLists.txt:71` is `file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)`, so a new
+  subfolder under `src/` needs no source-list edit. Other roots are listed explicitly; check before
+  assuming.
+
+- **Every folder holding real content carries an `AGENTS.md` saying what lives there and what
+  belongs there.** The point is navigation: an agent should be able to understand a folder's job
+  without opening a source file. A paragraph or two — the folder's responsibility, its boundary
+  against its siblings, and anything a newcomer would otherwise learn only by getting it wrong.
+
+  It is a **map, not documentation of the code**. The code documents itself; a per-function summary
+  here is stale the first time somebody edits it, and a stale map is worse than none because it is
+  believed. Write about what the folder is *for*.
+
+  Measured 2026-08-20: **2 `AGENTS.md` files against 89 source directories** under `src/`,
+  `frontends/` and `tools/`. Write one when you work in a folder that lacks it; correct the existing
+  one when you change what the folder means.
+
+  *"Within reason"* is part of the rule: a folder holding a single file, or a leaf whose name already
+  says everything, does not need one. If you cannot write a sentence the reader would not have
+  guessed, skip it.
+
 - **Work in your OWN git worktree — the main checkout is shared.** Several agents (and the human)
   run this repo concurrently, so the main working directory and its build dir are contended:
   branch-switching, staging, or `cmake --build` there collides with whatever someone else is
@@ -243,6 +284,26 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     worktree-local directory". Move anything you want to keep out of the tree, or `git worktree lock`
     it. On macOS and Windows the tool classifies but never removes: the in-use guard needs `/proc`,
     and without it the tool cannot prove nobody is inside, so it fails closed.
+  - **Teardown is part of finishing a PR, and neither half happens by itself.** When your PR merges,
+    delete the remote branch and remove your worktree:
+    ```bash
+    gh pr merge <N> --squash --delete-branch   # the LOCAL half fails if master is checked out
+    git ls-remote origin refs/heads/<branch>   # ...so verify; empty output means it really went
+    git push origin --delete <branch>          # and do it explicitly if it did not
+    cd <anywhere outside the tree>             # removing the tree your shell sits in wedges it
+    git worktree remove <path>
+    git branch -d <branch>
+    ```
+    **A subagent's worktree is yours to remove too.** The harness auto-cleans an
+    `isolation: "worktree"` tree only when it is **unchanged** — so a subagent that did any real work
+    leaves its tree behind permanently, and the agent that spawned it is the only one who knows it is
+    finished.
+    Why this is spelled out rather than left to the sweeper: measured 2026-08-20, **48 registered
+    worktrees occupying 101 GB**, from which `worktree_reclaim.py` could reclaim exactly **one**. It
+    was blocked on **35 trees classified DIRTY** — uncommitted or untracked files. Automation cannot
+    fix that and never will, because refusing a dirty tree is the guard that stops it destroying
+    someone's work. **So commit, stash or discard before you leave a tree**, or you are the only one
+    who will ever be able to clean it up.
 - **On a Windows host, run git through PowerShell (Windows git), not WSL.** The repo lives on the
   Windows filesystem (`C:\...` = `/mnt/c/...`), and worktrees created from Windows store a
   Windows-path gitdir link (`gitdir: C:/Users/.../.git/worktrees/<name>`). WSL's git can't resolve

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -50,7 +50,7 @@ the string's only occurrence, which is the exact failure a grep-able citation wa
 It happened to this very paragraph's flagship example. `tools/AGENTS.md` records the same class
 from the other direction: a doc that prettifies a literal defeats a grep for the line the tool
 actually printed.
-The two `CMakeLists.txt` line numbers below are the deliberate exception, and even those should be
+The `CMakeLists.txt` line numbers below are the deliberate exception, and even those should be
 confirmed by grepping the construct rather than trusted.
 
 **Do not confuse `src/gpu/diagnostics/` with `src/diagnostics/`.** They are different folders with

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -30,12 +30,20 @@ does this frame look wrong", the split matters: a wrong *descriptor* is usually 
 Build note: `CMakeLists.txt:71` globs `src/*.cpp` recursively with `CONFIGURE_DEPENDS`, so a new
 subfolder here needs no source-list edit.
 
-**Line citations in these files are as-of-a-commit, not invariants.** They were correct when
-written and this tree gets restructured; re-derive with `grep` rather than trusting one that does
-not resolve. Recorded because it has already happened here: three citations in
-`resources/AGENTS.md` pointed past EOF within a day, because they named line numbers in
-`rdna2_to_spirv.cpp` from before it was split from 25,448 lines to 4,070 — the author verified
-them in a worktree that was 13 commits behind master.
+**These files cite SYMBOLS AND UNIQUE STRINGS, never `file:line`.** That is a deliberate policy,
+not an oversight, and it was bought expensively during the review of the commit that added them:
+
+- Three citations named line numbers in `rdna2_to_spirv.cpp` taken from before #2752 split it from
+  25,448 lines to 4,070, so they pointed **past EOF within a day**. The author had verified them
+  in a worktree 13 commits behind master, where they were true.
+- A replacement citation into `gpu_executor.cpp` was **correct when written** and was displaced by
+  an unrelated merge hours later. It then still *resolved* — into an unrelated block — which is
+  worse, because it fails silently instead of visibly.
+
+A folder map is exactly the document that outlives the line numbers in it. A symbol survives a
+restructure, a `grep -rn` finds it in a second, and a wrong one is obvious rather than plausible.
+The two `CMakeLists.txt` line numbers below are the deliberate exception, and even those should be
+confirmed by grepping the construct rather than trusted.
 
 **Do not confuse `src/gpu/diagnostics/` with `src/diagnostics/`.** They are different folders with
 opposite build treatment: `CMakeLists.txt:75-77` excludes `src/diagnostics/` unless

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -30,6 +30,13 @@ does this frame look wrong", the split matters: a wrong *descriptor* is usually 
 Build note: `CMakeLists.txt:71` globs `src/*.cpp` recursively with `CONFIGURE_DEPENDS`, so a new
 subfolder here needs no source-list edit.
 
+**Line citations in these files are as-of-a-commit, not invariants.** They were correct when
+written and this tree gets restructured; re-derive with `grep` rather than trusting one that does
+not resolve. Recorded because it has already happened here: three citations in
+`resources/AGENTS.md` pointed past EOF within a day, because they named line numbers in
+`rdna2_to_spirv.cpp` from before it was split from 25,448 lines to 4,070 — the author verified
+them in a worktree that was 13 commits behind master.
+
 **Do not confuse `src/gpu/diagnostics/` with `src/diagnostics/`.** They are different folders with
 opposite build treatment: `CMakeLists.txt:75-77` excludes `src/diagnostics/` unless
 `PROSPER_DIAGNOSTICS` is on (default OFF at `:21`), and that exclusion's pattern does **not** match

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -42,6 +42,14 @@ not an oversight, and it was bought expensively during the review of the commit 
 
 A folder map is exactly the document that outlives the line numbers in it. A symbol survives a
 restructure, a `grep -rn` finds it in a second, and a wrong one is obvious rather than plausible.
+
+**When the citation is a log string rather than a symbol, quote only as much as fits on ONE source
+line.** C++ literals are wrapped by the formatter, so a message that reads as one sentence in the
+output does not exist as one token in the source — cite the longer form and the document becomes
+the string's only occurrence, which is the exact failure a grep-able citation was meant to avoid.
+It happened to this very paragraph's flagship example. `tools/AGENTS.md` records the same class
+from the other direction: a doc that prettifies a literal defeats a grep for the line the tool
+actually printed.
 The two `CMakeLists.txt` line numbers below are the deliberate exception, and even those should be
 confirmed by grepping the construct rather than trusted.
 

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -29,3 +29,8 @@ does this frame look wrong", the split matters: a wrong *descriptor* is usually 
 
 Build note: `CMakeLists.txt:71` globs `src/*.cpp` recursively with `CONFIGURE_DEPENDS`, so a new
 subfolder here needs no source-list edit.
+
+**Do not confuse `src/gpu/diagnostics/` with `src/diagnostics/`.** They are different folders with
+opposite build treatment: `CMakeLists.txt:75-77` excludes `src/diagnostics/` unless
+`PROSPER_DIAGNOSTICS` is on (default OFF at `:21`), and that exclusion's pattern does **not** match
+this one, which always builds.

--- a/prosper/src/gpu/AGENTS.md
+++ b/prosper/src/gpu/AGENTS.md
@@ -1,0 +1,31 @@
+# `src/gpu` — the AGC → Vulkan translation stack
+
+Everything that turns a PS5 guest's GPU work into Vulkan work lives here. The folders are ordered by
+**the direction data flows through the stack**, and that ordering is the fastest way to guess where
+something belongs:
+
+| folder | what it owns |
+| --- | --- |
+| `pm4/` | decoding the guest's command buffer |
+| `agc/` | Sony AGC / Gen5 descriptor formats — reading a shader's declared resources |
+| `recompiler/` | RDNA2 machine code → SPIR-V |
+| `resources/` | resolving what a shader binds to real memory and images |
+| `state/` | fixed-function render state, and its translation to Vulkan |
+| `texture/` | guest texture memory: tiling, block compression, layout |
+| `execute/` | building and submitting the actual GPU work |
+| `present/` | scanout |
+| `capture/` | serializing a frame for offline replay |
+| `timeline/` | frame timelines and bundles |
+| `diagnostics/` | observation only — nothing here is on a rendering path |
+
+A folder is a **claim about coupling**: things in one folder are expected to change together. Where
+that turns out to be false, the seam is worth recording on the structure issue rather than smoothing
+over by dropping a file into whichever folder is convenient.
+
+**The renderer itself is not here.** `src/gpu` is the translation and decode layer; the live Vulkan
+renderer and its per-frame orchestration live under `frontends/shared/live/`. If you are chasing "why
+does this frame look wrong", the split matters: a wrong *descriptor* is usually this tree, a wrong
+*draw order or barrier* is usually that one.
+
+Build note: `CMakeLists.txt:71` globs `src/*.cpp` recursively with `CONFIGURE_DEPENDS`, so a new
+subfolder here needs no source-list edit.

--- a/prosper/src/gpu/agc/AGENTS.md
+++ b/prosper/src/gpu/agc/AGENTS.md
@@ -4,8 +4,9 @@ Reads the PS5-specific shader header and turns a stage's *declared* resources in
 `ShaderResourceTable`.
 
 `agc_shader_layout` is the whole folder. It parses `AgcShaderUserData` — the sharp arrays, the
-Extended User Data (EUD), the direct-resource offsets — and decodes individual descriptors
-(`decode_buffer_descriptor` for a V#, and the T#/S#/BVH equivalents).
+Extended User Data (EUD), the direct-resource offsets — and decodes individual descriptors —
+`decode_buffer_descriptor` for a V#, with named decoders for the T# and BVH forms. There is no
+`decode_sampler_descriptor`: an S# is decoded inline.
 
 Two things to know before working here:
 

--- a/prosper/src/gpu/agc/AGENTS.md
+++ b/prosper/src/gpu/agc/AGENTS.md
@@ -1,0 +1,20 @@
+# `agc` — Sony AGC / Gen5 shader descriptor formats
+
+Reads the PS5-specific shader header and turns a stage's *declared* resources into a
+`ShaderResourceTable`.
+
+`agc_shader_layout` is the whole folder. It parses `AgcShaderUserData` — the sharp arrays, the
+Extended User Data (EUD), the direct-resource offsets — and decodes individual descriptors
+(`decode_buffer_descriptor` for a V#, and the T#/S#/BVH equivalents).
+
+Two things to know before working here:
+
+- **A declared resource is not the only kind.** Some titles describe resources through a
+  shader-resource table the header only sizes (`srt_size_dw`), or load descriptors with SMEM from a
+  user-data pointer. Those are recovered by a const-fold in `execute/`, not here — so "this function
+  returned an empty table" does not mean the dispatch has no resources.
+- **`user_data` can be non-null and point at unmapped guest memory.** `build_shader_resources` probes
+  it with `guest_readable` before dereferencing, and documents the observed case. Anything new that
+  reads it needs the same probe.
+
+PS5-specific formats need direct title evidence; PS4-era layouts are a hypothesis, not a source.

--- a/prosper/src/gpu/capture/AGENTS.md
+++ b/prosper/src/gpu/capture/AGENTS.md
@@ -5,7 +5,7 @@ into a `.prgbundle` / `.prgcap` that `tools/gpu_replay` can reproduce offline an
 
 - `gpu_capture` — the capture itself.
 - `gpu_capture_bundle` — bundle format and manifest.
-- `capture_compute_policy` — what compute state a capture retains.
+- `capture_compute_policy` — the policy governing compute capture.
 - `writer_provenance` — which pass wrote a given range, so a replay can attribute a pixel.
 
 This is the highest-leverage debugging path in the project: press **F9** in `prosper-app` (or use the

--- a/prosper/src/gpu/capture/AGENTS.md
+++ b/prosper/src/gpu/capture/AGENTS.md
@@ -1,0 +1,16 @@
+# `capture` — frame capture and replay serialization
+
+Serializes a live frame — commands, shaders, resources, and the renderer-owned targets it samples —
+into a `.prgbundle` / `.prgcap` that `tools/gpu_replay` can reproduce offline and deterministically.
+
+- `gpu_capture` — the capture itself.
+- `gpu_capture_bundle` — bundle format and manifest.
+- `capture_compute_policy` — what compute state a capture retains.
+- `writer_provenance` — which pass wrote a given range, so a replay can attribute a pixel.
+
+This is the highest-leverage debugging path in the project: press **F9** in `prosper-app` (or use the
+`PROSPER_GRAB_BUNDLE_AFTER_MS` / `_AT_FRAME` triggers for a headless run), then iterate on the frozen
+frame instead of re-routing to catch the moment live.
+
+**A manifest strips payloads by design.** Validators and consumers must not assume a referenced
+payload is present; several were fixed for dereferencing exactly what the manifest omits.

--- a/prosper/src/gpu/diagnostics/AGENTS.md
+++ b/prosper/src/gpu/diagnostics/AGENTS.md
@@ -1,0 +1,19 @@
+# `diagnostics` — observation only
+
+**Nothing in this folder is on a rendering path.** That is the folder's defining property: code here
+may be removed, gated off or rate-limited without changing a single rendered pixel. If something here
+starts affecting output, it belongs somewhere else.
+
+- `diagnostic_selectors` — choosing what to observe.
+- `diag_ratelimit` — rate limiting. **Check a diagnostic's rate limit before quoting its volume as a
+  frequency**; several phantom findings came from reading a capped count as a real one.
+- `watch_list`, `compute_tree_watch`, `compute_parent_walk` — watching addresses and walking compute
+  parentage.
+
+Two standing cautions, both learned expensively:
+
+- **Prefer instruments that detect their own invalidity.** A diagnostic that can fail silently will,
+  and its silence reads as evidence.
+- **A count is only as good as its population.** Know whether a diagnostic fires per dispatch, once
+  per program, or only on some sub-population — several published figures were off by two orders of
+  magnitude because the answer was assumed rather than read.

--- a/prosper/src/gpu/diagnostics/AGENTS.md
+++ b/prosper/src/gpu/diagnostics/AGENTS.md
@@ -1,8 +1,15 @@
 # `diagnostics` — observation only
 
-**Nothing in this folder is on a rendering path.** That is the folder's defining property: code here
-may be removed, gated off or rate-limited without changing a single rendered pixel. If something here
-starts affecting output, it belongs somewhere else.
+**Nothing here is on a rendering path AT DEFAULT SETTINGS**, and that is the intended property:
+with nothing armed, code in this folder can be removed or rate-limited without changing a single
+rendered pixel.
+
+**One entry breaks the stronger form of that rule and you must know about it.**
+`compute_parent_walk_suspicious()` (`compute_parent_walk.cpp:117`) reaches `gpu_executor.cpp:10613`,
+which **skips a live compute dispatch** — it prints `DIAGNOSTIC-ONLY skip suspicious dispatch` and
+then does not run it. It is env-gated, so a default boot is unaffected, but an armed run is not
+merely observing. `compute_parent_walk.hpp` states this boundary; do not read the folder name as a
+guarantee.
 
 - `diagnostic_selectors` — choosing what to observe.
 - `diag_ratelimit` — rate limiting. **Check a diagnostic's rate limit before quoting its volume as a

--- a/prosper/src/gpu/diagnostics/AGENTS.md
+++ b/prosper/src/gpu/diagnostics/AGENTS.md
@@ -5,9 +5,9 @@ with nothing armed, code in this folder can be removed or rate-limited without c
 rendered pixel.
 
 **One entry breaks the stronger form of that rule and you must know about it.**
-`compute_parent_walk_suspicious()` (`compute_parent_walk.cpp:117`) reaches `gpu_executor.cpp:10613`,
-which **skips a live compute dispatch** — it prints `DIAGNOSTIC-ONLY skip suspicious dispatch` and
-then does not run it. It is env-gated, so a default boot is unaffected, but an armed run is not
+`compute_parent_walk_suspicious()` in `compute_parent_walk.cpp` reaches the site in
+`execute/gpu_executor.cpp` that prints `DIAGNOSTIC-ONLY skip suspicious dispatch` and then
+**does not run the dispatch** — grep that string; it is unique. It is env-gated, so a default boot is unaffected, but an armed run is not
 merely observing. `compute_parent_walk.hpp` states this boundary; do not read the folder name as a
 guarantee.
 

--- a/prosper/src/gpu/diagnostics/AGENTS.md
+++ b/prosper/src/gpu/diagnostics/AGENTS.md
@@ -6,8 +6,10 @@ rendered pixel.
 
 **One entry breaks the stronger form of that rule and you must know about it.**
 `compute_parent_walk_suspicious()` in `compute_parent_walk.cpp` reaches the site in
-`execute/gpu_executor.cpp` that prints `DIAGNOSTIC-ONLY skip suspicious dispatch` and then
-**does not run the dispatch** — grep that string; it is unique. It is env-gated, so a default boot is unaffected, but an armed run is not
+`execute/gpu_executor.cpp` that prints `[compute-parent-walk] DIAGNOSTIC-ONLY skip suspicious`
+and then **does not run the dispatch** — grep `DIAGNOSTIC-ONLY skip suspicious`, which is unique
+in source. Do not extend it with the next word: the C++ literal is wrapped across two lines
+there, so the longer form matches nothing. It is env-gated, so a default boot is unaffected, but an armed run is not
 merely observing. `compute_parent_walk.hpp` states this boundary; do not read the folder name as a
 guarantee.
 

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -1,0 +1,18 @@
+# `execute` — submission and execution
+
+Where a decoded draw or dispatch becomes real GPU work.
+
+- `gpu_executor` — the executor: builds each stage's resource table, runs the scalar const-fold that
+  recovers descriptors the shader header does not declare, and issues the work. The largest file in
+  the tree.
+- `gpu_execute.hpp` — the shared contracts, including **`SrtUse`**: a descriptor use recovered by the
+  const-fold, keyed by the `s_load` immediate byte offset. Read this before assuming prosper cannot
+  see a descriptor channel.
+- `gpu_dependency_graph` — ordering and dependencies between submitted work.
+- `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block", which the executor asks
+  before trusting a pointer. Here rather than in `resources/` because it is a question about
+  *trusting* an address, not about binding one.
+
+The const-fold is the part most often mistaken for absent. It resolves descriptors loaded with
+`s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a user-data table and publishes them with
+`srt_offset` = that immediate.

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -3,15 +3,16 @@
 Where a decoded draw or dispatch becomes real GPU work.
 
 - `gpu_executor` — the executor: builds each stage's resource table, runs the scalar const-fold that
-  recovers descriptors the shader header does not declare, and issues the work. The largest file in
-  the tree.
+  recovers descriptors the shader header does not declare, and issues the work. Large; navigate it by
+  symbol rather than by reading it.
 - `gpu_execute.hpp` — the shared contracts, including **`SrtUse`**: a descriptor use recovered by the
   const-fold, keyed by the `s_load` immediate byte offset. Read this before assuming prosper cannot
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
-- `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block", which the executor asks
-  before trusting a pointer. Here rather than in `resources/` because it is a question about
-  *trusting* an address, not about binding one.
+- `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Its callers are
+  elsewhere**: `pm4/command_processor.cpp`, `hle/hle_kernel.cpp`, `hle/hle_agc.cpp`,
+  `hle/dispatch.cpp`, `host/exec_image_linux.cpp` — `gpu_executor.cpp` does not reference it. So
+  its placement here is historical rather than a coupling claim, and it is a candidate for moving.
 
 The const-fold is the part most often mistaken for absent. It resolves descriptors loaded with
 `s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a user-data table and publishes them with

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -10,8 +10,11 @@ Where a decoded draw or dispatch becomes real GPU work.
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
 - `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Its callers are
-  elsewhere**: `pm4/command_processor.cpp`, `hle/hle_kernel.cpp`, `hle/hle_agc.cpp`,
-  `hle/dispatch.cpp`, `host/exec_image_linux.cpp` — `gpu_executor.cpp` does not reference it. So
+  elsewhere**: `pm4/command_processor.cpp`, `hle/hle_kernel.cpp`, `hle/hle_agc.cpp` and
+  `host/exec_image_linux.cpp` (the last through the weak `prosper_mb3_is_pool_candidate`) —
+  `gpu_executor.cpp` does not reference it. Note `hle/dispatch.cpp` is **not** a caller: its only
+  `mb3` token is `g_mb3_arm_hook`, the `PROSPER_MB3WATCH` write-watch hook, which is a different
+  mechanism and catches a loose `mb3_` grep. So
   its placement here is historical rather than a coupling claim, and it is a candidate for moving.
 
 The const-fold is the part most often mistaken for absent. It resolves descriptors loaded with

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -10,9 +10,17 @@ Where a decoded draw or dispatch becomes real GPU work.
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
 - `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Its callers are
-  elsewhere**: `src/gpu/pm4/command_processor.cpp` (21 references), `src/hle/graphics/hle_agc.cpp`
-  (4), `src/hle/kernel/hle_kernel.cpp` (3) and `src/host/image/exec_image_linux.cpp` (1, through
-  the weak `prosper_mb3_is_pool_candidate`) —
+  elsewhere** — `src/gpu/pm4/command_processor.cpp`, `src/hle/graphics/hle_agc.cpp`,
+  `src/hle/kernel/hle_kernel.cpp` and `src/host/image/exec_image_linux.cpp` (the last through the
+  weak `prosper_mb3_is_pool_candidate`). Re-derive rather than trusting this list, and grep the
+  module's declared symbols rather than the substring `mb3_`:
+  ```bash
+  grep -rlE "$(grep -oE '\b(prosper_)?mb3[a-z0-9_]*' src/gpu/execute/mb3_freelist.hpp \
+               | sort -u | paste -sd'|')" --include='*.cpp' src/ | grep -v mb3_freelist
+  ```
+  A count is deliberately not quoted: `command_processor.cpp` also defines its own
+  `mb3_freelist_guard` / `mb3_freelist_report` statics, so a substring count says 21 where module
+  references number 8, and three plausible counting rules give three different answers. —
   `gpu_executor.cpp` does not reference it. Note `src/hle/dispatch/dispatch.cpp` is **not** a caller: its only
   `mb3` token is `g_mb3_arm_hook`, the `PROSPER_MB3WATCH` write-watch hook, which is a different
   mechanism and catches a loose `mb3_` grep. So

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -10,9 +10,10 @@ Where a decoded draw or dispatch becomes real GPU work.
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
 - `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Its callers are
-  elsewhere**: `pm4/command_processor.cpp`, `hle/hle_kernel.cpp`, `hle/hle_agc.cpp` and
-  `host/exec_image_linux.cpp` (the last through the weak `prosper_mb3_is_pool_candidate`) —
-  `gpu_executor.cpp` does not reference it. Note `hle/dispatch.cpp` is **not** a caller: its only
+  elsewhere**: `src/gpu/pm4/command_processor.cpp` (21 references), `src/hle/graphics/hle_agc.cpp`
+  (4), `src/hle/kernel/hle_kernel.cpp` (3) and `src/host/image/exec_image_linux.cpp` (1, through
+  the weak `prosper_mb3_is_pool_candidate`) —
+  `gpu_executor.cpp` does not reference it. Note `src/hle/dispatch/dispatch.cpp` is **not** a caller: its only
   `mb3` token is `g_mb3_arm_hook`, the `PROSPER_MB3WATCH` write-watch hook, which is a different
   mechanism and catches a loose `mb3_` grep. So
   its placement here is historical rather than a coupling claim, and it is a candidate for moving.

--- a/prosper/src/gpu/execute/AGENTS.md
+++ b/prosper/src/gpu/execute/AGENTS.md
@@ -9,22 +9,25 @@ Where a decoded draw or dispatch becomes real GPU work.
   const-fold, keyed by the `s_load` immediate byte offset. Read this before assuming prosper cannot
   see a descriptor channel.
 - `gpu_dependency_graph` — ordering and dependencies between submitted work.
-- `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Its callers are
-  elsewhere** — `src/gpu/pm4/command_processor.cpp`, `src/hle/graphics/hle_agc.cpp`,
-  `src/hle/kernel/hle_kernel.cpp` and `src/host/image/exec_image_linux.cpp` (the last through the
-  weak `prosper_mb3_is_pool_candidate`). Re-derive rather than trusting this list, and grep the
-  module's declared symbols rather than the substring `mb3_`:
+- `mb3_freelist` — answers "is this guest pointer a free MallocBinned3 block". **Nothing in this
+  folder calls it**: `gpu_executor.cpp` has no reference, and the callers are
+  `src/gpu/pm4/command_processor.cpp`, `src/hle/graphics/hle_agc.cpp`,
+  `src/hle/kernel/hle_kernel.cpp` and `src/host/image/exec_image_linux.cpp` — the last through the
+  weak `prosper_mb3_is_pool_candidate`. Its placement here is therefore historical rather than a
+  coupling claim, and it is a candidate for moving.
+
+  Re-derive that list rather than trusting it, and grep the module's declared symbols rather than the
+  substring `mb3_`:
   ```bash
   grep -rlE "$(grep -oE '\b(prosper_)?mb3[a-z0-9_]*' src/gpu/execute/mb3_freelist.hpp \
                | sort -u | paste -sd'|')" --include='*.cpp' src/ | grep -v mb3_freelist
   ```
-  A count is deliberately not quoted: `command_processor.cpp` also defines its own
-  `mb3_freelist_guard` / `mb3_freelist_report` statics, so a substring count says 21 where module
-  references number 8, and three plausible counting rules give three different answers. —
-  `gpu_executor.cpp` does not reference it. Note `src/hle/dispatch/dispatch.cpp` is **not** a caller: its only
-  `mb3` token is `g_mb3_arm_hook`, the `PROSPER_MB3WATCH` write-watch hook, which is a different
-  mechanism and catches a loose `mb3_` grep. So
-  its placement here is historical rather than a coupling claim, and it is a candidate for moving.
+  Two traps that grep avoids. `src/hle/dispatch/dispatch.cpp` looks like a caller under a loose
+  `mb3_` pattern but is not one — its only token is `g_mb3_arm_hook`, the `PROSPER_MB3WATCH`
+  write-watch hook, a different mechanism. And no reference COUNT is quoted here, because
+  `command_processor.cpp` defines its own `mb3_freelist_guard` / `mb3_freelist_report` statics: a
+  substring count says 21 where module references number 8, and three defensible counting rules give
+  three different answers.
 
 The const-fold is the part most often mistaken for absent. It resolves descriptors loaded with
 `s_load_dwordx4/x8 sN, s[ptr:ptr+1], <imm>` from a user-data table and publishes them with

--- a/prosper/src/gpu/pm4/AGENTS.md
+++ b/prosper/src/gpu/pm4/AGENTS.md
@@ -1,0 +1,16 @@
+# `pm4` — the guest command stream
+
+Decodes the PM4 packet stream the guest submits, and maintains the register state it writes.
+
+- `pm4_decode` — packet-level decode: types, opcodes, payload extents.
+- `pm4_registers` — the register namespace and offsets the packets address.
+- `command_processor` — walks a submission, applies register writes, and emits the draws and
+  dispatches the rest of the stack consumes.
+
+This is the **entry point of the whole stack**: everything downstream is a consequence of what is
+decoded here, so a decode error does not look like a decode error — it looks like a missing draw, a
+wrong extent, or a resource bound from the wrong address.
+
+**A builder's dword count is an ABI contract with the guest's own reservations.** See
+`docs/AGC_PACKET_SIZES.md` before changing any packet's size; getting it wrong desynchronises the
+stream rather than failing locally.

--- a/prosper/src/gpu/present/AGENTS.md
+++ b/prosper/src/gpu/present/AGENTS.md
@@ -1,0 +1,7 @@
+# `present` — scanout
+
+`videoout_present` — taking a finished frame to the display path.
+
+The last stage, and therefore the one where an upstream failure is *observed* rather than caused. A
+black or stale frame here is almost never a bug here. Check that something was drawn, and that the
+target being presented is the target that was drawn to, before looking for a defect in this folder.

--- a/prosper/src/gpu/recompiler/AGENTS.md
+++ b/prosper/src/gpu/recompiler/AGENTS.md
@@ -1,0 +1,21 @@
+# `recompiler` — RDNA2 machine code → SPIR-V
+
+Takes a guest shader's instruction bytes and emits a SPIR-V module.
+
+- `rdna2_decode` — instruction decode: formats, opcodes, operands. Pure and side-effect free, which
+  makes it the cheapest thing in the stack to unit-test.
+- `rdna2_to_spirv` (+ `_internal`, `emit_alu`, `emit_cfg`, `alu_support`, `cfg_support`) — the
+  translator: register state, control-flow structurization, and per-instruction lowering.
+- `spirv_builder` — small hand-built SPIR-V modules used as test fixtures, **not** a general emitter.
+- `gta5/`, `indirect/` — see their own AGENTS.md.
+
+**An unsupported op is a FATAL gap, not an acceptable skip.** Reject paths exist as a fail-visible
+backstop for genuinely unknown encodings — mark `CONFIDENCE: LOW`, log loudly, file an issue with the
+exact opcode — but every one hit on a live boot is the next thing to implement. A silently skipped
+instruction drops real rendered content and reads as "handled".
+
+Every SPIR-V emitter path is `spirv-val`-gated in CI (`tools/spv_validate`) with one representative
+module per path, not one per game shader.
+
+Primary reference: *"RDNA 2" Instruction Set Architecture Reference Guide* (AMD doc 70648). PS5
+extensions and AGC behaviour still require live title evidence.

--- a/prosper/src/gpu/recompiler/AGENTS.md
+++ b/prosper/src/gpu/recompiler/AGENTS.md
@@ -6,7 +6,8 @@ Takes a guest shader's instruction bytes and emits a SPIR-V module.
   makes it the cheapest thing in the stack to unit-test.
 - `rdna2_to_spirv` (+ `_internal`, `emit_alu`, `emit_cfg`, `alu_support`, `cfg_support`) — the
   translator: register state, control-flow structurization, and per-instruction lowering.
-- `spirv_builder` — small hand-built SPIR-V modules. **One of them SHIPS**: `live_compute.cpp:2155` feeds
+- `spirv_builder` — small hand-built SPIR-V modules. **One of them SHIPS**:
+  `frontends/shared/live/live_compute.cpp`'s `prepare_compare_pipeline()` feeds
   `build_compute_compare_uvec4()` straight to `vkCreateShaderModule` on the live path. Treating
   them as test fixtures is what let an invalid `OpAccessChain` reach real devices (#1711), and
   `tools/spv_validate` exists to stop exactly that — so a change here is a change to shipped

--- a/prosper/src/gpu/recompiler/AGENTS.md
+++ b/prosper/src/gpu/recompiler/AGENTS.md
@@ -6,7 +6,11 @@ Takes a guest shader's instruction bytes and emits a SPIR-V module.
   makes it the cheapest thing in the stack to unit-test.
 - `rdna2_to_spirv` (+ `_internal`, `emit_alu`, `emit_cfg`, `alu_support`, `cfg_support`) — the
   translator: register state, control-flow structurization, and per-instruction lowering.
-- `spirv_builder` — small hand-built SPIR-V modules used as test fixtures, **not** a general emitter.
+- `spirv_builder` — small hand-built SPIR-V modules. **These SHIP**: `live_compute.cpp:2155` feeds
+  `build_compute_compare_uvec4()` straight to `vkCreateShaderModule` on the live path. Treating
+  them as test fixtures is what let an invalid `OpAccessChain` reach real devices (#1711), and
+  `tools/spv_validate` exists to stop exactly that — so a change here is a change to shipped
+  shader code, not to a fixture. It is not a general emitter either.
 - `gta5/`, `indirect/` — see their own AGENTS.md.
 
 **An unsupported op is a FATAL gap, not an acceptable skip.** Reject paths exist as a fail-visible

--- a/prosper/src/gpu/recompiler/AGENTS.md
+++ b/prosper/src/gpu/recompiler/AGENTS.md
@@ -6,7 +6,7 @@ Takes a guest shader's instruction bytes and emits a SPIR-V module.
   makes it the cheapest thing in the stack to unit-test.
 - `rdna2_to_spirv` (+ `_internal`, `emit_alu`, `emit_cfg`, `alu_support`, `cfg_support`) — the
   translator: register state, control-flow structurization, and per-instruction lowering.
-- `spirv_builder` — small hand-built SPIR-V modules. **These SHIP**: `live_compute.cpp:2155` feeds
+- `spirv_builder` — small hand-built SPIR-V modules. **One of them SHIPS**: `live_compute.cpp:2155` feeds
   `build_compute_compare_uvec4()` straight to `vkCreateShaderModule` on the live path. Treating
   them as test fixtures is what let an invalid `OpAccessChain` reach real devices (#1711), and
   `tools/spv_validate` exists to stop exactly that — so a change here is a change to shipped

--- a/prosper/src/gpu/recompiler/gta5/AGENTS.md
+++ b/prosper/src/gpu/recompiler/gta5/AGENTS.md
@@ -1,0 +1,12 @@
+# `recompiler/gta5` — title-specific compute contracts
+
+Evidence-driven lowerings for *Grand Theft Auto V* (`PPSA04263`) compute programs whose behaviour was
+established from live captures rather than from a published contract.
+
+Kept apart from the translator on purpose: these churn on a different cadence, they are justified by
+one title's measurements, and mixing them into `rdna2_to_spirv` would make it impossible to see which
+rules are general and which are a specific game's.
+
+**Adding something here is an admission that the general path could not express it.** Prefer
+generalising into the translator when the evidence supports it; when it does not, land it here with
+the measurement that justifies it and a `CONFIDENCE:` marker.

--- a/prosper/src/gpu/recompiler/indirect/AGENTS.md
+++ b/prosper/src/gpu/recompiler/indirect/AGENTS.md
@@ -11,7 +11,7 @@ per invocation, and derives one bounded record per real invocation.
 
 **This is not the descriptor-table path.** A descriptor loaded with `s_load`/`s_buffer_load` from a
 user-data pointer at a constant immediate is a *scalar*, compile-time-constant offset, and is
-const-folded in `execute/` (see the `SrtUse` contract in `execute/gpu_execute.hpp`). This folder
+const-folded in `execute/` (see the `SrtUse` contract in `src/gpu/execute/gpu_execute.hpp`). This folder
 exists for the harder case where the address is not known until the wave runs.
 
 It deliberately does **not** grant arbitrary FLAT access: every relocated consumer keeps its exact PC,

--- a/prosper/src/gpu/recompiler/indirect/AGENTS.md
+++ b/prosper/src/gpu/recompiler/indirect/AGENTS.md
@@ -1,0 +1,18 @@
+# `recompiler/indirect` — bounded guest pointers loaded at runtime
+
+Proves producer/guard/consumer structure for pointers a shader loads **into VGPRs** and dereferences
+per invocation, and derives one bounded record per real invocation.
+
+- `rdna2_indirect_pointer_analysis` — the proof: which fetch produced the pointer, what guards it,
+  which consumers use it, and at what widths.
+- `rdna2_indirect_pointer_relocation` / `_descriptor_range` — turning that proof into something
+  bindable.
+- `rdna2_indirect_buffer_shadow` — the carrier that owns snapshot layout and lifetime.
+
+**This is not the descriptor-table path.** A descriptor loaded with `s_load`/`s_buffer_load` from a
+user-data pointer at a constant immediate is a *scalar*, compile-time-constant offset, and is
+const-folded in `execute/` (see the `SrtUse` contract in `execute/gpu_execute.hpp`). This folder
+exists for the harder case where the address is not known until the wave runs.
+
+It deliberately does **not** grant arbitrary FLAT access: every relocated consumer keeps its exact PC,
+packet, address pair, width and immediate in the proof.

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -3,7 +3,8 @@
 Turns descriptors into resolved, bindable resources, and answers questions about their provenance.
 
 - `shader_resources` — `ShaderResource` / `ShaderResourceTable`. The table exposes **five** lookups
-  (`shader_resources.hpp:705,708,713,716,718`); the recompiler uses four of them — by fetch PC, by
+  (`by_srt_offset`, `by_sgpr_base`, `by_sgpr_base_cls`, `by_fetch_pc`, `by_binding`, all declared
+  together in `shader_resources.hpp`); the recompiler uses four of them — by fetch PC, by
   SRT byte offset (`by_srt_offset`), and by SGPR base in both the class-qualified
   (`by_sgpr_base_cls`) and bare (`by_sgpr_base`) forms.
   A resource carrying `srt=0xffffffff sgpr=0xffffffff` is unreachable by the three **key-based**
@@ -12,8 +13,9 @@ Turns descriptors into resolved, bindable resources, and answers questions about
   It is **not** unreachable in general, and getting that wrong sends you hunting a binding that is
   in fact resolving: `by_fetch_pc` consults neither field, so a resource with both sentinels plus a
   valid fetch PC still resolves — the header defines four such shapes, and the recompiler retrieves
-  them live (`rdna2_to_spirv.cpp:2153`'s `by_fetch_pc(153u)`, and `rdna2_emit_alu.cpp:4949`).
-  `by_binding` matches anything in the table at all.
+  them live — `grep -rn by_fetch_pc src/gpu/recompiler/` finds the call sites, including the
+  `by_fetch_pc(153u)` selected-descriptor lookup. `by_binding` matches anything in the table at
+  all.
 - `gpu_resources` — the resolved resource layer over guest memory.
 - `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
 - `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -12,8 +12,8 @@ Turns descriptors into resolved, bindable resources, and answers questions about
   It is **not** unreachable in general, and getting that wrong sends you hunting a binding that is
   in fact resolving: `by_fetch_pc` consults neither field, so a resource with both sentinels plus a
   valid fetch PC still resolves — the header defines four such shapes, and the recompiler retrieves
-  them live (`rdna2_to_spirv.cpp:6639`, `:7161`, `:12817`). `by_binding` matches anything in the
-  table at all.
+  them live (`rdna2_to_spirv.cpp:2153`'s `by_fetch_pc(153u)`, and `rdna2_emit_alu.cpp:4949`).
+  `by_binding` matches anything in the table at all.
 - `gpu_resources` — the resolved resource layer over guest memory.
 - `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
 - `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -2,10 +2,14 @@
 
 Turns descriptors into resolved, bindable resources, and answers questions about their provenance.
 
-- `shader_resources` — `ShaderResource` / `ShaderResourceTable` and the three lookups the recompiler
-  matches against: by fetch PC, by SRT byte offset (`by_srt_offset`), and by SGPR base
-  (`by_sgpr_base_cls`). A resource matched by none of them is invisible to every lookup however
-  correct its address and size are.
+- `shader_resources` — `ShaderResource` / `ShaderResourceTable`. The table exposes **five** lookups
+  (`shader_resources.hpp:705,708,713,716,718`); the recompiler uses four of them — by fetch PC, by
+  SRT byte offset (`by_srt_offset`), and by SGPR base in both the class-qualified
+  (`by_sgpr_base_cls`) and bare (`by_sgpr_base`) forms.
+  A resource carrying `srt=0xffffffff sgpr=0xffffffff` cannot be reached by any of those four
+  however correct its address and size are — which is the usual ending of a "the descriptor is
+  right but nothing binds" investigation. It is still reachable by `by_binding`, which matches
+  anything in the table, so "invisible to every lookup" would be too strong.
 - `gpu_resources` — the resolved resource layer over guest memory.
 - `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
 - `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -1,0 +1,14 @@
+# `resources` — what a shader actually binds
+
+Turns descriptors into resolved, bindable resources, and answers questions about their provenance.
+
+- `shader_resources` — `ShaderResource` / `ShaderResourceTable` and the three lookups the recompiler
+  matches against: by fetch PC, by SRT byte offset (`by_srt_offset`), and by SGPR base
+  (`by_sgpr_base_cls`). A resource matched by none of them is invisible to every lookup however
+  correct its address and size are.
+- `gpu_resources` — the resolved resource layer over guest memory.
+- `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
+- `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.
+
+The three-lookup contract is the thing to understand first: most "the descriptor is right but nothing
+binds" investigations end at a resource whose key does not match the key its consumer looks up.

--- a/prosper/src/gpu/resources/AGENTS.md
+++ b/prosper/src/gpu/resources/AGENTS.md
@@ -6,13 +6,17 @@ Turns descriptors into resolved, bindable resources, and answers questions about
   (`shader_resources.hpp:705,708,713,716,718`); the recompiler uses four of them — by fetch PC, by
   SRT byte offset (`by_srt_offset`), and by SGPR base in both the class-qualified
   (`by_sgpr_base_cls`) and bare (`by_sgpr_base`) forms.
-  A resource carrying `srt=0xffffffff sgpr=0xffffffff` cannot be reached by any of those four
-  however correct its address and size are — which is the usual ending of a "the descriptor is
-  right but nothing binds" investigation. It is still reachable by `by_binding`, which matches
-  anything in the table, so "invisible to every lookup" would be too strong.
+  A resource carrying `srt=0xffffffff sgpr=0xffffffff` is unreachable by the three **key-based**
+  lookups however correct its address and size are — which is the usual ending of a "the
+  descriptor is right but nothing binds" investigation.
+  It is **not** unreachable in general, and getting that wrong sends you hunting a binding that is
+  in fact resolving: `by_fetch_pc` consults neither field, so a resource with both sentinels plus a
+  valid fetch PC still resolves — the header defines four such shapes, and the recompiler retrieves
+  them live (`rdna2_to_spirv.cpp:6639`, `:7161`, `:12817`). `by_binding` matches anything in the
+  table at all.
 - `gpu_resources` — the resolved resource layer over guest memory.
 - `compressed_source_authority` — who is authoritative for a compressed surface's bytes.
 - `metadata_kind_correlation` — correlating a surface's metadata kind with how it is used.
 
-The three-lookup contract is the thing to understand first: most "the descriptor is right but nothing
+The lookup contract is the thing to understand first: most "the descriptor is right but nothing
 binds" investigations end at a resource whose key does not match the key its consumer looks up.

--- a/prosper/src/gpu/state/AGENTS.md
+++ b/prosper/src/gpu/state/AGENTS.md
@@ -1,0 +1,12 @@
+# `state` — fixed-function render state
+
+- `render_state` — the guest's render state as decoded from its register writes: blend, depth,
+  raster, target formats and extents.
+- `vk_translate` — mapping that state onto Vulkan enums, formats and pipeline structures.
+
+Small folder, outsized blast radius: state that never reaches the GPU produces output that looks like
+a *shading* bug. One recorded case had solid-block glyphs, a black logo panel and a flat sky that were
+all one defect — the RT0 blend state was never submitted.
+
+When adding a translation, prefer failing visibly on an unknown enum over mapping it to a plausible
+default.

--- a/prosper/src/gpu/texture/AGENTS.md
+++ b/prosper/src/gpu/texture/AGENTS.md
@@ -10,6 +10,7 @@ Tiling bugs are **visually distinctive and diagnostically misleading**: the cont
 correctly coloured but spatially scrambled, which reads as a geometry or UV problem. If a surface
 looks like the right image cut into blocks, start here.
 
-Layouts are generic where possible. A title-specific tiling special case is a strong signal the
-general rule is wrong — one recorded fix replaced a per-title hack with generic 4 KiB mip-tail tiling
-and resolved a whole title at once.
+Layouts are generic where possible, and a title-specific tiling special case is a strong signal the
+general rule is wrong. Worked example: #1578 (`336ea104`) fixed a wrong block-to-element multiplier
+in the **shared generic** path and resolved a whole title at once — the defect was in the rule
+everyone used, not in a per-title hack.

--- a/prosper/src/gpu/texture/AGENTS.md
+++ b/prosper/src/gpu/texture/AGENTS.md
@@ -1,0 +1,15 @@
+# `texture` — guest texture memory
+
+How pixels are actually laid out in guest memory, and how to get them into a linear Vulkan image.
+
+- `tile` — the tiling/swizzle modes, including mip-tail handling.
+- `guest_texture_layout` — per-level offsets, pitches and sizes.
+- `bc_decode` — block-compressed format decode.
+
+Tiling bugs are **visually distinctive and diagnostically misleading**: the content is present and
+correctly coloured but spatially scrambled, which reads as a geometry or UV problem. If a surface
+looks like the right image cut into blocks, start here.
+
+Layouts are generic where possible. A title-specific tiling special case is a strong signal the
+general rule is wrong — one recorded fix replaced a per-title hack with generic 4 KiB mip-tail tiling
+and resolved a whole title at once.

--- a/prosper/src/gpu/timeline/AGENTS.md
+++ b/prosper/src/gpu/timeline/AGENTS.md
@@ -1,0 +1,9 @@
+# `timeline` — frame timelines and bundle selection
+
+`gpu_timeline` — the frame's operation sequence, and the signatures used to select an operation
+across runs.
+
+**Addresses and operation ordinals are run-local.** A historical capture hash is not a current
+renderer oracle, and neither is a target extent or a raw draw count on its own. Re-derive the selector
+with `gpu_timeline --signatures` / `--select` before recording a new bundle; a selector that silently
+matches nothing produces an empty result that reads exactly like a negative finding.


### PR DESCRIPTION
Three standing instructions requested by the project owner, plus the first tranche of the second.

## 1. File and folder structure mirrors the logical architecture

A directory is a claim about what belongs together; when the claim is false the tree actively
misleads, because *"where does this live?"* gets answered by the wrong place. New rule: put code in
the folder its architecture implies, split a file that has grown a second responsibility, move a
module that sits in the wrong folder — **and do it incidentally, without needing a dedicated task**.

Two limits keep that from becoming a hazard, both drawn from recorded traps:

- **Move with `tools/refactor/`, never by retyping.** Hand-editing a restructure is how trap 41
  happened (a whole-file `git checkout` that silently reverted another lane's edits) and how "clean
  merge, broken file" happened.
- **Keep the move separable from the behaviour change**, so a reviewer reads `git mv` plus include
  rewrites rather than a diff mixing relocation with logic.

## 2. Every folder holding real content carries an `AGENTS.md`

So an agent can understand a folder's job **without opening a source file**. Explicitly a *map, not
documentation of the code*: the code documents itself, a per-function summary is stale on the first
edit, and a stale map is worse than none because it is believed.

Measured 2026-08-20: **2 `AGENTS.md` files against 89 source directories** under `src/`, `frontends/`
and `tools/`.

`"within reason"` is part of the rule — a single-file folder, or a leaf whose name already says
everything, does not need one.

### Seeded across all of `src/gpu` (14 files)

A root map ordered by **the direction data flows through the stack** (`pm4` → `agc` → `recompiler` →
`resources` → `state` → `texture` → `execute` → `present`, with `capture`/`timeline`/`diagnostics`
observing rather than participating), plus one per folder. Each gives the folder's responsibility, its
boundary against its siblings, and the one caution a newcomer would otherwise learn by getting it
wrong:

- `pm4` — a builder's dword count is an ABI contract with the guest's own reservations.
- `agc` — `user_data` can be non-null and point at **unmapped** guest memory; an empty table does not
  mean the dispatch has no resources.
- `recompiler/indirect` — this is the **VGPR**-addressed case; a descriptor at a constant immediate is
  const-folded in `execute/` instead. That distinction cost me an afternoon today, so it is written
  down.
- `resources` — the three-lookup contract (by PC, by SRT offset, by SGPR base); a resource matched by
  none is invisible however correct its address is.
- `texture` — tiling bugs read as geometry bugs.
- `present` — a symptom here is almost never a defect here.
- `diagnostics` — nothing in the folder may touch a rendering path; that is its defining property.

## 3. Teardown is part of finishing a PR

Delete the remote branch, then remove the worktree — **including a subagent's**, because the harness
auto-cleans an `isolation: "worktree"` tree only when it is *unchanged*, so any tree where work
actually happened survives forever.

The measurement that motivates it, taken today:

| | |
| --- | ---: |
| registered worktrees | **48** |
| disk under `.claude/worktrees` | **101 GB** |
| reclaimable by `worktree_reclaim.py` | **1** |
| blocked as DIRTY (uncommitted/untracked) | **35** |

**Automation cannot fix this and never will**, because refusing a dirty tree is exactly the guard
that stops the sweeper destroying someone's work. So the actionable half of the instruction is
*commit, stash or discard before you leave a tree* — otherwise you are the only one who will ever be
able to clean it up.

## Verification

Docs-only: `git diff --name-only origin/master...HEAD | grep -v '\.md$'` is empty (15 files, +289).

```
python3 prosper/tools/docs/check_numbered_table.py   clean on every tracked .md
git diff --check                                    clean
Claude-Session trailers                             0
```

One claim was checked rather than assumed before writing it into the charter: `CMakeLists.txt:71` is
`file(GLOB_RECURSE PROSPER_SRC CONFIGURE_DEPENDS src/*.cpp)`, so the statement that a new subfolder
needs no source-list edit is **scoped to `src/`** and verified. Other roots list sources explicitly.
