### PR TITLE
docs(compat): Blue Prince claims gameplay and shows only a title screen

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -243,6 +243,7 @@ The main menu and attract-mode gameplay are verified. See the [tracker](https://
 ## Blue Prince — `PPSA25009`
 
 <p align="center"><img src="assets/screenshots/blue-prince-title.png" alt="Blue Prince — title screen"></p>
+<p align="center"><img src="assets/screenshots/blue-prince-hall.png" alt="Blue Prince — Mount Holly entrance-hall gameplay"></p>
 
 The manor entrance hall renders with real 3D gameplay content. See the [tracker](https://github.com/mattias800/prosper/issues/1808).
 


### PR DESCRIPTION
docs(compat): Blue Prince's section claims gameplay and shows only a title screen

The prose reads "The manor entrance hall renders with real 3D gameplay content",
directly under a single image of the title screen. assets/screenshots/blue-prince-hall.png
has been on master all along and tracker #1808 already embeds it -- only COMPATIBILITY.md
was left showing the wrong milestone.

A rung-3 row whose only image is a title screen is indistinguishable from a rung-2 row
to a reader, which is the one person who cannot check it against anything else.

Found by auditing all 21 gameplay titles against the standing rule that a title at
rung 3+ carries a gameplay screenshot in both its tracker and COMPATIBILITY.md.
Trackers were 21/21 compliant. COMPATIBILITY.md had two gaps: this one, and Grand
Theft Auto V, which has no gameplay capture anywhere -- accepted, since its gameplay
entry renders HUD and radar over an absent 3D world, so a capture would show nothing
worth showing.

Gates: all tracked .md files unbroken; git diff --check clean. Image already on master,
so no new bytes.

Refs #1808