### PR TITLE
docs(compat): Tales of Graces f reaches gameplay — chart row, gameplay image, regeneration

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -50,7 +50,7 @@ Last updated: 2026-08-17
 | *Greak: Memories of Azur* | `PPSA02849` | Unity / IL2CPP | ✅ First-level gameplay | [#1887](https://github.com/mattias800/prosper/issues/1887) |
 | *Rugrats: Adventure in Gameland* | `PPSA23396` | Unity / IL2CPP | ✅ First nursery level | [#1888](https://github.com/mattias800/prosper/issues/1888) |
 | *Syberia: Remastered* | `PPSA30140` | Unity / IL2CPP | 🚧 First playable scene | [#1811](https://github.com/mattias800/prosper/issues/1811) |
-| *Tales of Graces f Remastered* | `PPSA19991` | Unity / IL2CPP | 🚧 Opening movie, title screen, EULA, menu, and options; the title screen needs no input, and movie frames render with collapsed chroma ([#2731](https://github.com/mattias800/prosper/issues/2731)) | [#1889](https://github.com/mattias800/prosper/issues/1889) |
+| *Tales of Graces f Remastered* | `PPSA19991` | Unity / IL2CPP | 🚧 Lhant Hill prologue gameplay; movie frames render with collapsed chroma ([#2731](https://github.com/mattias800/prosper/issues/2731)) | [#1889](https://github.com/mattias800/prosper/issues/1889) |
 | *Astro Bot* | `PPSA21564` | ASOBI (in-house) | 🚧 Opening sequence and title screen | [#1809](https://github.com/mattias800/prosper/issues/1809) |
 | *The Forgotten City* | `PPSA03026` | Unreal Engine | 🚧 Title screen | [#1890](https://github.com/mattias800/prosper/issues/1890) |
 | *Tactics Ogre: Reborn* | `PPSA03839` | — | 🚧 First tutorial battle | [#1892](https://github.com/mattias800/prosper/issues/1892) |
@@ -402,6 +402,7 @@ The validated route reaches the title screen and first playable scene with real 
 
 ## Tales of Graces f Remastered — `PPSA19991`
 
+<p align="center"><img src="assets/screenshots/tales-graces-f-gameplay.png" alt="Tales of Graces f Remastered — Lhant Hill prologue gameplay"></p>
 <p align="center"><img src="assets/screenshots/tales-graces-f-publisher.png" alt="Tales of Graces f Remastered — publisher logo"></p>
 <p align="center"><img src="assets/screenshots/tales-graces-f-criware.png" alt="Tales of Graces f Remastered — CRIWARE logo"></p>
 <p align="center"><img src="assets/screenshots/tales-graces-f-title-no-input.png" alt="Tales of Graces f Remastered — title screen reached with no input"></p>
@@ -414,7 +415,9 @@ The validated route reaches the title screen and first playable scene with real 
 master; this one carries the `Press ✕` prompt and, more importantly, was reached with the pad
 unplugged.*
 
-A default launch with no input route renders the opening movie, then reaches the **title screen** on its own at roughly 220 s, and continues into the EULA, main menu and new-game Options screen at native 1920×1080. Movie frames composite with their chroma collapsed ([#2731](https://github.com/mattias800/prosper/issues/2731)). See the [tracker](https://github.com/mattias800/prosper/issues/1889).
+The route [`prosper/scripts/talesgraces/reach-gameplay.pad`](prosper/scripts/talesgraces/reach-gameplay.pad) reaches the **Lhant Hill prologue** — Asbel in a live 3D field at native 1920×1080 — reproduced 2 of 2, with no rejected shader or skipped dispatch in any run. A default launch with no input route still reaches the **title screen** on its own at roughly 220 s, then the EULA, main menu and new-game Options screen.
+
+**What held this title at a menu was input, not the renderer.** Two new-game screens bind their confirm action to the **OPTIONS** button and each raises a Yes/No dialog defaulting to **No**, so a Cross-only route loops forever and an OPTIONS+Cross route answers *No*. Movie frames composite with their chroma collapsed ([#2731](https://github.com/mattias800/prosper/issues/2731)). See [`prosper/docs/TALES_GRACES_STATUS.md`](prosper/docs/TALES_GRACES_STATUS.md) and the [tracker](https://github.com/mattias800/prosper/issues/1889).
 
 ## Astro Bot — `PPSA21564`
 

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -76,6 +76,7 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | Grand Theft Auto V | `PPSA04263` | 3 | `123---` | - | none | [#2429](https://github.com/mattias800/prosper/issues/2429) | [#1873](https://github.com/mattias800/prosper/issues/1873) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Syberia: Remastered | `PPSA30140` | 3 | `123---` | - | none | [#1790](https://github.com/mattias800/prosper/issues/1790), [#1627](https://github.com/mattias800/prosper/issues/1627), [#1737](https://github.com/mattias800/prosper/issues/1737), [#1628](https://github.com/mattias800/prosper/issues/1628) | [#1811](https://github.com/mattias800/prosper/issues/1811) | [`SYBERIA_STATUS.md`](prosper/docs/SYBERIA_STATUS.md) |
 | Tactics Ogre: Reborn | `PPSA03839` | 3 | `123---` | - | none | [#1913](https://github.com/mattias800/prosper/issues/1913), [#1784](https://github.com/mattias800/prosper/issues/1784) | [#1892](https://github.com/mattias800/prosper/issues/1892) | - |
+| Tales of Graces f Remastered | `PPSA19991` | 3 | `123---` | - | none | [#1688](https://github.com/mattias800/prosper/issues/1688), [#1673](https://github.com/mattias800/prosper/issues/1673), [#2731](https://github.com/mattias800/prosper/issues/2731) | [#1889](https://github.com/mattias800/prosper/issues/1889) | - |
 | The House of the Dead 2: Remake | `PPSA24203` | 3 | `123---` | - | none | [#1907](https://github.com/mattias800/prosper/issues/1907) | [#1896](https://github.com/mattias800/prosper/issues/1896) | - |
 | Astro Bot | `PPSA21564` | 2 | `12----` | - | none | [#1732](https://github.com/mattias800/prosper/issues/1732), [#1459](https://github.com/mattias800/prosper/issues/1459), [#1730](https://github.com/mattias800/prosper/issues/1730), [#1731](https://github.com/mattias800/prosper/issues/1731) | [#1809](https://github.com/mattias800/prosper/issues/1809) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Bendy and the Dark Revival | `PPSA27624` | 2 | `12----` | - | none | [#1979](https://github.com/mattias800/prosper/issues/1979), [#1955](https://github.com/mattias800/prosper/issues/1955) | [#1897](https://github.com/mattias800/prosper/issues/1897) | - |
@@ -88,7 +89,6 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | R-Type Delta: HD Boosted | `PPSA26414` | 2 | `12----` | - | none | [#1746](https://github.com/mattias800/prosper/issues/1746), [#1591](https://github.com/mattias800/prosper/issues/1591) | [#1810](https://github.com/mattias800/prosper/issues/1810) | [`R_TYPE_DELTA_STATUS.md`](prosper/docs/R_TYPE_DELTA_STATUS.md) |
 | Sonic Frontiers | `PPSA03831` | 2 | `12----` | - | none | [#2206](https://github.com/mattias800/prosper/issues/2206), [#657](https://github.com/mattias800/prosper/issues/657) | [#1891](https://github.com/mattias800/prosper/issues/1891) | [`SONIC_FRONTIERS_STATUS.md`](prosper/docs/SONIC_FRONTIERS_STATUS.md) |
 | Sonic Racing: CrossWorlds | `PPSA08804` | 2 | `12----` | - | none | [#2361](https://github.com/mattias800/prosper/issues/2361), [#2362](https://github.com/mattias800/prosper/issues/2362), [#2363](https://github.com/mattias800/prosper/issues/2363), [#2309](https://github.com/mattias800/prosper/issues/2309), [#2303](https://github.com/mattias800/prosper/issues/2303) | [#1895](https://github.com/mattias800/prosper/issues/1895) | [`SONIC_CROSSWORLDS_STATUS.md`](prosper/docs/SONIC_CROSSWORLDS_STATUS.md) |
-| Tales of Graces f Remastered | `PPSA19991` | 2 | `12----` | - | none | [#1688](https://github.com/mattias800/prosper/issues/1688), [#1673](https://github.com/mattias800/prosper/issues/1673), [#2731](https://github.com/mattias800/prosper/issues/2731) | [#1889](https://github.com/mattias800/prosper/issues/1889) | - |
 | The Forgotten City | `PPSA03026` | 2 | `12----` | - | none | [#1961](https://github.com/mattias800/prosper/issues/1961), [#1945](https://github.com/mattias800/prosper/issues/1945), [#1226](https://github.com/mattias800/prosper/issues/1226) | [#1890](https://github.com/mattias800/prosper/issues/1890) | - |
 | The Oregon Trail | `PPSA19244` | 2 | `12----` | - | none | [#1945](https://github.com/mattias800/prosper/issues/1945), [#1606](https://github.com/mattias800/prosper/issues/1606), [#1641](https://github.com/mattias800/prosper/issues/1641), [#1634](https://github.com/mattias800/prosper/issues/1634) | [#1886](https://github.com/mattias800/prosper/issues/1886) | [`OREGON_TRAIL_STATUS.md`](prosper/docs/OREGON_TRAIL_STATUS.md) |
 | The Pathless | `PPSA01826` | 2 | `12----` | - | none | [#1570](https://github.com/mattias800/prosper/issues/1570), [#1213](https://github.com/mattias800/prosper/issues/1213) | [#1883](https://github.com/mattias800/prosper/issues/1883) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
@@ -102,8 +102,8 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | --- | --- |
 | 6 -- reviewed automatic gameplay snapshot guard | 14 |
 | 4 -- manual visual verification | 1 |
-| 3 -- gameplay with real GPU draws | 6 |
-| 2 -- title screen | 16 |
+| 3 -- gameplay with real GPU draws | 7 |
+| 2 -- title screen | 15 |
 | 1 -- any real graphics | 1 |
 | 0 -- not started | 1 |
 


### PR DESCRIPTION
docs(compat): Tales of Graces f reaches gameplay -- chart row, gameplay image, regeneration

#2763 landed the route, the status doc and the captures; this lands the user-facing half,
per the standing rule that a title at rung 3+ carries a gameplay screenshot in BOTH its
tracker and COMPATIBILITY.md.

  - summary row: "Opening movie, title screen, EULA, menu, and options" -> "Lhant Hill
    prologue gameplay". The old row described a menu for a title that now reaches a level.
  - the per-title gallery now LEADS with tales-graces-f-gameplay.png rather than opening on
    a publisher logo. A rung-3 section whose images stop at a menu is indistinguishable
    from a rung-2 section to a reader.
  - the prose states the milestone and, more usefully, why it was not reached earlier: two
    new-game screens bind their confirm action to the OPTIONS button and each raises a
    Yes/No dialog defaulting to No, so a Cross-only route loops forever.

Tracker #1889 was updated separately (rung 3 ticked, gameplay frame leading its visual
section, milestone rewritten) -- deliberately AFTER #2763 merged, because a body pinned to
raw.githubusercontent/master renders broken while its image is still only on a branch.

PROGRESS_TRACKER.md regenerated with the tool, not hand-edited: the rung change moves Tales
from `12----` to `123---`, and without the regeneration the --check gate goes red on the
next unrelated PR. `--check` now exits 0 against the live trackers; 39 trackers, 39 parsed.

Gates: all tracked .md files unbroken; git diff --check clean. Images already on master, so
no new bytes.

Refs #1889, #2763