### PR TITLE
docs(compat): Bendy and the Dark Revival reaches gameplay — chart row, gameplay image, regeneration

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -57,7 +57,7 @@ Last updated: 2026-08-17
 | *Little Nightmares III* | `PPSA05143` | Unreal Engine 4 | 🚧 Boot splash sequence and title screen; most title frames carry a yellow tint | [#1893](https://github.com/mattias800/prosper/issues/1893) |
 | *Crisis Core –Final Fantasy VII– Reunion* | `PPSA07809` | Unreal Engine 4 | 🚧 Title screen, on a throttled route — a default run still dies in the guest allocator within seconds | [#1894](https://github.com/mattias800/prosper/issues/1894) |
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
-| *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Health warning and title screen; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
+| *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Chapter 1 gameplay; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Title screen | [#1898](https://github.com/mattias800/prosper/issues/1898) |
 
 ## At a glance
@@ -495,10 +495,17 @@ The route reaches Training 1 with a live rail-shooter camera, HUD, crosshair, an
 
 ## Bendy and the Dark Revival — `PPSA27624`
 
+<p align="center"><img src="assets/screenshots/bendy-dark-revival-gameplay.png" alt="Bendy and the Dark Revival — Chapter 1 gameplay with the NEW OBJECTIVE HUD"></p>
 <p align="center"><img src="assets/screenshots/bendy-dark-revival-title.png" alt="Bendy and the Dark Revival — title screen"></p>
 
-A default launch reaches the multi-language photosensitivity warning and then the title screen and its BEGIN menu at
-native 3840×2160. The menu's background video is not composited, so the menu sits on a flat grey background. See the
+The route [`prosper/scripts/bendy-dark-revival-PPSA27624/reach-gameplay.pad`](prosper/scripts/bendy-dark-revival-PPSA27624/reach-gameplay.pad)
+crosses the multi-language photosensitivity warning, the title screen and the BEGIN menu into **Chapter 1** at native
+3840×2160 — Audrey's opening dialogue, the hold-to-interact prompt, a first-person reticle and the `NEW OBJECTIVE`
+banner. **No prosper code change was required**; the title was one input route away. Reproduced across five bounded
+runs, two of which share 5 of 8 byte-identical frame CRCs.
+
+The menu's background video is still not composited, so the BEGIN menu sits on a flat grey background. See
+[`prosper/docs/BENDY_DARK_REVIVAL_STATUS.md`](prosper/docs/BENDY_DARK_REVIVAL_STATUS.md) and the
 [tracker](https://github.com/mattias800/prosper/issues/1897).
 
 ## Beneath — `PPSA27640`

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -73,13 +73,13 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | Tales of Graces f Remastered | `PPSA19991` | 4 | `1234--` | - | none | [#1688](https://github.com/mattias800/prosper/issues/1688), [#1673](https://github.com/mattias800/prosper/issues/1673), [#2731](https://github.com/mattias800/prosper/issues/2731) | [#1889](https://github.com/mattias800/prosper/issues/1889) | - |
 | Terminator 2D: NO FATE | `PPSA25872` | 4 | `1234--` | `terminator-boot` | none | - | [#1872](https://github.com/mattias800/prosper/issues/1872) | - |
 | Asterix & Obelix - Babylon Mission | `PPSA30490` | 3 | `123---` | - | none | [#1599](https://github.com/mattias800/prosper/issues/1599), [#2743](https://github.com/mattias800/prosper/issues/2743), [#2738](https://github.com/mattias800/prosper/issues/2738) | [#1884](https://github.com/mattias800/prosper/issues/1884) | [`ASTERIX_BABYLON_STATUS.md`](prosper/docs/ASTERIX_BABYLON_STATUS.md) |
+| Bendy and the Dark Revival | `PPSA27624` | 3 | `123---` | - | none | [#1979](https://github.com/mattias800/prosper/issues/1979), [#1955](https://github.com/mattias800/prosper/issues/1955) | [#1897](https://github.com/mattias800/prosper/issues/1897) | - |
 | Bendy and the Ink Machine | `PPSA27616` | 3 | `123---` | - | none | [#1178](https://github.com/mattias800/prosper/issues/1178), [#1177](https://github.com/mattias800/prosper/issues/1177) | [#1881](https://github.com/mattias800/prosper/issues/1881) | - |
 | Grand Theft Auto V | `PPSA04263` | 3 | `123---` | - | none | [#2429](https://github.com/mattias800/prosper/issues/2429) | [#1873](https://github.com/mattias800/prosper/issues/1873) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Syberia: Remastered | `PPSA30140` | 3 | `123---` | - | none | [#1790](https://github.com/mattias800/prosper/issues/1790), [#1627](https://github.com/mattias800/prosper/issues/1627), [#1737](https://github.com/mattias800/prosper/issues/1737), [#1628](https://github.com/mattias800/prosper/issues/1628) | [#1811](https://github.com/mattias800/prosper/issues/1811) | [`SYBERIA_STATUS.md`](prosper/docs/SYBERIA_STATUS.md) |
 | Tactics Ogre: Reborn | `PPSA03839` | 3 | `123---` | - | none | [#1913](https://github.com/mattias800/prosper/issues/1913), [#1784](https://github.com/mattias800/prosper/issues/1784) | [#1892](https://github.com/mattias800/prosper/issues/1892) | - |
 | The House of the Dead 2: Remake | `PPSA24203` | 3 | `123---` | - | none | [#1907](https://github.com/mattias800/prosper/issues/1907) | [#1896](https://github.com/mattias800/prosper/issues/1896) | - |
 | Astro Bot | `PPSA21564` | 2 | `12----` | - | none | [#1732](https://github.com/mattias800/prosper/issues/1732), [#1459](https://github.com/mattias800/prosper/issues/1459), [#1730](https://github.com/mattias800/prosper/issues/1730), [#1731](https://github.com/mattias800/prosper/issues/1731) | [#1809](https://github.com/mattias800/prosper/issues/1809) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
-| Bendy and the Dark Revival | `PPSA27624` | 2 | `12----` | - | none | [#1979](https://github.com/mattias800/prosper/issues/1979), [#1955](https://github.com/mattias800/prosper/issues/1955) | [#1897](https://github.com/mattias800/prosper/issues/1897) | - |
 | Beneath | `PPSA27640` | 2 | `12----` | - | none | - | [#1898](https://github.com/mattias800/prosper/issues/1898) | - |
 | Crisis Core –Final Fantasy VII– Reunion | `PPSA07809` | 2 | `12----` | - | none | [#1945](https://github.com/mattias800/prosper/issues/1945), [#2057](https://github.com/mattias800/prosper/issues/2057), [#2058](https://github.com/mattias800/prosper/issues/2058), [#2027](https://github.com/mattias800/prosper/issues/2027) | [#1894](https://github.com/mattias800/prosper/issues/1894) | [`CRISIS_CORE_STATUS.md`](prosper/docs/CRISIS_CORE_STATUS.md) |
 | Dragon Quest VII Reimagined | `PPSA17942` | 2 | `12----` | - | none | [#1486](https://github.com/mattias800/prosper/issues/1486) | [#1874](https://github.com/mattias800/prosper/issues/1874) | [`DRAGON_QUEST_STATUS.md`](prosper/docs/DRAGON_QUEST_STATUS.md) |
@@ -102,8 +102,8 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | --- | --- |
 | 6 -- reviewed automatic gameplay snapshot guard | 14 |
 | 4 -- manual visual verification | 2 |
-| 3 -- gameplay with real GPU draws | 6 |
-| 2 -- title screen | 15 |
+| 3 -- gameplay with real GPU draws | 7 |
+| 2 -- title screen | 14 |
 | 1 -- any real graphics | 1 |
 | 0 -- not started | 1 |
 


### PR DESCRIPTION
docs(compat): Bendy and the Dark Revival reaches gameplay -- chart row, gameplay image, regeneration

#2769 landed the route, status doc and capture; this lands the user-facing half, per the
standing rule that a title at rung 3+ carries a gameplay screenshot in BOTH its tracker
and COMPATIBILITY.md.

  - summary row: "Health warning and title screen" -> "Chapter 1 gameplay". The old row
    described a menu for a title that now reaches a level.
  - the per-title gallery now LEADS with bendy-dark-revival-gameplay.png. A rung-3 section
    whose images stop at a title screen is indistinguishable from a rung-2 section.
  - the prose states the milestone and that NO prosper code change was required -- this
    title was one input route away, which is the third such result today.
  - the uncomposited menu background video is retained as a known defect rather than
    dropped, since it is still true.

Tracker #1897 was updated separately (rung 3 ticked, gameplay frame leading its visual
section, milestone rewritten with the derived scene-index discriminator, the save-state
dependence, and the green cast recorded as an unclaimed rung-5 question) -- deliberately
AFTER #2769 merged, because a body pinned to raw.githubusercontent/master renders broken
while its image is still only on a branch.

PROGRESS_TRACKER.md regenerated with the tool: rung 3 goes 6 -> 7, rung 2 goes 15 -> 14.
Without it the --check gate goes red on the next unrelated PR.

Checked before touching either shared doc that no open PR touches COMPATIBILITY.md or
PROGRESS_TRACKER.md -- landing into a contended file while someone else's PR is in review
cost #2759 a rebase earlier today.

Gates: all tracked .md files unbroken; git diff --check clean; --check exits 0 against the
live trackers, 39 trackers / 39 parsed. Image already on master, so no new bytes.

Refs #1897, #2769