### PR TITLE
docs: SCREENSHOTS.md — every screenshot, newest first, generated from git history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,31 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: python3 prosper/tools/docs/gen_progress_tracker.py --check
 
+      # SCREENSHOTS.md is GENERATED from git history -- the reverse-chronological index of every
+      # checked-in screenshot, so "what is new since I last looked" is answerable by reading down
+      # from the top instead of diffing a 500-line chart against memory.
+      #
+      # --selftest first and SEPARATELY (not piped -- a pipeline's exit status is its last stage's).
+      # Its two arms assert BOTH verdicts: a complete input renders, and an image with no
+      # add-commit ABORTS. That second arm is the whole point. A feed that silently drops entries
+      # reads as "nothing new happened", which is the one wrong answer indistinguishable from the
+      # truth, and it is exactly what `git log --diff-filter=A --follow` would have produced --
+      # measured returning EMPTY for two images added the same day the tool was written.
+      - name: Verify the screenshot-feed generator still discriminates
+        run: python3 prosper/tools/docs/gen_screenshot_feed.py --selftest
+
+      # The feed describes MASTER, and is regenerated after a screenshot merge -- so the check
+      # regenerates from `origin/master` too, and both sides agree on a PR branch that has not
+      # merged yet. This job checks out at fetch-depth 2 (load-bearing for the numbering gate
+      # above), which is far too shallow for a history scan, so deepen here rather than widening
+      # the whole job: --filter=blob:none fetches commit metadata without file contents, which is
+      # all this tool reads (log metadata plus ls-tree NAMES).
+      - name: Verify SCREENSHOTS.md still matches the tree
+        run: |
+          git fetch --unshallow --filter=blob:none origin master 2>/dev/null \
+            || git fetch --deepen=2147483647 --filter=blob:none origin master
+          python3 prosper/tools/docs/gen_screenshot_feed.py --check --ref origin/master
+
   linux-app:
     name: Linux App
     runs-on: ubuntu-latest

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -8,6 +8,10 @@ bugs. Different title revisions may behave differently.
 Detailed investigation notes, measurements, known defects, and next steps live in the linked
 [game-tracker issues](https://github.com/mattias800/prosper/issues?q=is%3Aissue+%22%5BGame+tracker%5D%22).
 
+**Looking for what is new?** [`SCREENSHOTS.md`](SCREENSHOTS.md) is every checked-in screenshot in
+reverse-chronological order — read down from the top and stop at one you have seen. This file is
+organised by title instead, so it answers "how far does X get" rather than "what changed lately".
+
 This page is the **user-facing overview** and is written by hand. For the same titles as a
 machine-readable index — rung, ladder, snapshot guard, hardware-oracle record, open blockers —
 see [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md), which is **generated from the tracker issues**

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ console's OS, ABI, and GPU stack on the host — **not** by emulating a CPU.
 > ⚠️ **Experimental research project.** It is not a general-purpose game runner yet. Tested retail
 > titles currently reach different milestones and still expose substantial compatibility gaps. See
 > [Game compatibility](COMPATIBILITY.md) for title-by-title results and known blockers.
+Newest screenshots first: [`SCREENSHOTS.md`](SCREENSHOTS.md).
 
 ## Screenshots
 

--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -1,0 +1,1145 @@
+# Screenshots — newest first
+
+<!--
+    GENERATED FILE -- DO NOT EDIT BY HAND.
+    Produced by prosper/tools/docs/gen_screenshot_feed.py from git history.
+    Regenerate with:  python3 prosper/tools/docs/gen_screenshot_feed.py
+    CI regenerates this file and fails if it differs from the committed copy.
+-->
+
+**Every screenshot checked into this repository, most recent first.** Read down from the top and stop when you reach one you have already seen.
+
+**136 images**, most recent **2026-08-20**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
+
+This file is generated from git history by [`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) and is regenerated and diffed in CI, so it cannot drift from the tree. [`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a reverse-chronological index of the images themselves.
+
+> A screenshot here is evidence of what rendered on the day its commit landed. It is not
+> a claim about the title's current state — for that, read the tracker. An image is never
+> removed from this feed when a title moves on, because the point of a feed is that it is
+> a record of *when* things happened.
+
+## 2026-08-20
+
+### bendy-dark-revival-gameplay.png
+
+<p align="center"><img src="assets/screenshots/bendy-dark-revival-gameplay.png" alt="bendy dark revival gameplay"></p>
+
+feat(bendy-dark-revival): rung 2 -> rung 3 — a route reaches the PPSA27624 Chapter 1 sections (#2769)
+
+`5501dd45` · [`assets/screenshots/bendy-dark-revival-gameplay.png`](assets/screenshots/bendy-dark-revival-gameplay.png)
+
+### tales-graces-f-gameplay-dialogue.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-gameplay-dialogue.png" alt="tales graces f gameplay dialogue"></p>
+
+feat(route): Tales of Graces f Remastered reaches gameplay -- the wall was two OPTIONS-button gates, not the renderer (#2763)
+
+`f249929d` · [`assets/screenshots/tales-graces-f-gameplay-dialogue.png`](assets/screenshots/tales-graces-f-gameplay-dialogue.png)
+
+### tales-graces-f-gameplay.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-gameplay.png" alt="tales graces f gameplay"></p>
+
+feat(route): Tales of Graces f Remastered reaches gameplay -- the wall was two OPTIONS-button gates, not the renderer (#2763)
+
+`f249929d` · [`assets/screenshots/tales-graces-f-gameplay.png`](assets/screenshots/tales-graces-f-gameplay.png)
+
+### sonic-origins-sonic-team-logo.png
+
+<p align="center"><img src="assets/screenshots/sonic-origins-sonic-team-logo.png" alt="sonic origins sonic team logo"></p>
+
+docs(compat): refresh the checked-in visual evidence, and repair two trackers that deny screenshots already on master (#2737)
+
+`29f4db65` · [`assets/screenshots/sonic-origins-sonic-team-logo.png`](assets/screenshots/sonic-origins-sonic-team-logo.png)
+
+### tales-graces-f-title-no-input.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-title-no-input.png" alt="tales graces f title no input"></p>
+
+docs(compat): refresh the checked-in visual evidence, and repair two trackers that deny screenshots already on master (#2737)
+
+`29f4db65` · [`assets/screenshots/tales-graces-f-title-no-input.png`](assets/screenshots/tales-graces-f-title-no-input.png)
+
+### issue-2731-tales-graces-f-movie-chroma.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-2731-tales-graces-f-movie-chroma.png" alt="issue 2731 tales graces f movie chroma"></p>
+
+docs(compat): refresh the checked-in visual evidence, and repair two trackers that deny screenshots already on master (#2737)
+
+`29f4db65` · [`prosper/docs/screenshots/issue-2731-tales-graces-f-movie-chroma.png`](prosper/docs/screenshots/issue-2731-tales-graces-f-movie-chroma.png)
+
+### issue-2734-little-nightmares-3-corrupt-save-modal.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-2734-little-nightmares-3-corrupt-save-modal.png" alt="issue 2734 little nightmares 3 corrupt save modal"></p>
+
+docs(compat): refresh the checked-in visual evidence, and repair two trackers that deny screenshots already on master (#2737)
+
+`29f4db65` · [`prosper/docs/screenshots/issue-2734-little-nightmares-3-corrupt-save-modal.png`](prosper/docs/screenshots/issue-2734-little-nightmares-3-corrupt-save-modal.png)
+
+### asterix-babylon-gameplay.png
+
+<p align="center"><img src="assets/screenshots/asterix-babylon-gameplay.png" alt="asterix babylon gameplay"></p>
+
+bringup(asterix-babylon): a Triangle-aware input route reaches GAMEPLAY (rung 2 -> 3) (#2736)
+
+`5404e173` · [`assets/screenshots/asterix-babylon-gameplay.png`](assets/screenshots/asterix-babylon-gameplay.png)
+
+## 2026-08-19
+
+### plucky-squire-chapter1-intro.png
+
+<p align="center"><img src="assets/screenshots/plucky-squire-chapter1-intro.png" alt="plucky squire chapter1 intro"></p>
+
+docs(plucky): status doc — the chapter-one world renders, plus five falsified hypotheses (#2742)
+
+`675ff2f6` · [`assets/screenshots/plucky-squire-chapter1-intro.png`](assets/screenshots/plucky-squire-chapter1-intro.png)
+
+## 2026-08-08
+
+### sonic-crossworlds-title.png
+
+<p align="center"><img src="assets/screenshots/sonic-crossworlds-title.png" alt="sonic crossworlds title"></p>
+
+docs(crossworlds): rung 2 — the title screen renders completely, reproduced across two runs (#2360)
+
+`a3a88356` · [`assets/screenshots/sonic-crossworlds-title.png`](assets/screenshots/sonic-crossworlds-title.png)
+
+## 2026-08-07
+
+### arcrunner-title-screen-default-route.png
+
+<p align="center"><img src="assets/screenshots/arcrunner-title-screen-default-route.png" alt="arcrunner title screen default route"></p>
+
+ArcRunner: the per-fold account — the guest's builder is released mid-fold, and the contract that forbids it is version-gated off (#2219)
+
+`a22cf8de` · [`assets/screenshots/arcrunner-title-screen-default-route.png`](assets/screenshots/arcrunner-title-screen-default-route.png)
+
+## 2026-08-06
+
+### sonic-frontiers-autosave-notice.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-autosave-notice.png" alt="sonic frontiers autosave notice"></p>
+
+fix(hle): sceSaveDataTransferringMountPs4 must report "no PS4 save", not SCE_OK — Sonic Frontiers reaches its title screen (#2208)
+
+`7801a5bc` · [`assets/screenshots/sonic-frontiers-autosave-notice.png`](assets/screenshots/sonic-frontiers-autosave-notice.png)
+
+### sonic-frontiers-main-menu.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-main-menu.png" alt="sonic frontiers main menu"></p>
+
+fix(hle): sceSaveDataTransferringMountPs4 must report "no PS4 save", not SCE_OK — Sonic Frontiers reaches its title screen (#2208)
+
+`7801a5bc` · [`assets/screenshots/sonic-frontiers-main-menu.png`](assets/screenshots/sonic-frontiers-main-menu.png)
+
+### sonic-frontiers-title-screen.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-title-screen.png" alt="sonic frontiers title screen"></p>
+
+fix(hle): sceSaveDataTransferringMountPs4 must report "no PS4 save", not SCE_OK — Sonic Frontiers reaches its title screen (#2208)
+
+`7801a5bc` · [`assets/screenshots/sonic-frontiers-title-screen.png`](assets/screenshots/sonic-frontiers-title-screen.png)
+
+### arcrunner-title-screen.png
+
+<p align="center"><img src="assets/screenshots/arcrunner-title-screen.png" alt="arcrunner title screen"></p>
+
+docs(arcrunner): the title screen is behind the movie, and the throttle rescues by DELAY not by lock hold (#2205)
+
+`40129122` · [`assets/screenshots/arcrunner-title-screen.png`](assets/screenshots/arcrunner-title-screen.png)
+
+### sonic-origins-sega-logo.png
+
+<p align="center"><img src="assets/screenshots/sonic-origins-sega-logo.png" alt="sonic origins sega logo"></p>
+
+fix(savedata): sceSaveDataCreateTransactionResource must return a positive resource id (#2121)
+
+`e404841c` · [`assets/screenshots/sonic-origins-sega-logo.png`](assets/screenshots/sonic-origins-sega-logo.png)
+
+### arcrunner-default-route-logos.png
+
+<p align="center"><img src="assets/screenshots/arcrunner-default-route-logos.png" alt="arcrunner default route logos"></p>
+
+ArcRunner: the init-side generation census — the #1756 question answered, four falsifications, and real graphics off the throttle (#1226) (#2122)
+
+`8c8e74f5` · [`assets/screenshots/arcrunner-default-route-logos.png`](assets/screenshots/arcrunner-default-route-logos.png)
+
+### arcrunner-intro-city.png
+
+<p align="center"><img src="assets/screenshots/arcrunner-intro-city.png" alt="arcrunner intro city"></p>
+
+ArcRunner renders its intro cinematic — the #1226 fault is a submit-timing race (follow-up to #2077) (#2086)
+
+`0a6f82a8` · [`assets/screenshots/arcrunner-intro-city.png`](assets/screenshots/arcrunner-intro-city.png)
+
+### arcrunner-intro-space-station.png
+
+<p align="center"><img src="assets/screenshots/arcrunner-intro-space-station.png" alt="arcrunner intro space station"></p>
+
+ArcRunner renders its intro cinematic — the #1226 fault is a submit-timing race (follow-up to #2077) (#2086)
+
+`0a6f82a8` · [`assets/screenshots/arcrunner-intro-space-station.png`](assets/screenshots/arcrunner-intro-space-station.png)
+
+### rtype-delta-force-select.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-force-select.png" alt="rtype delta force select"></p>
+
+fix(gpu): a saved-EXEC wave mask must survive the NGG fetch-index fold — R-Type Delta reaches its title screen (#2061)
+
+`83e3383a` · [`assets/screenshots/rtype-delta-force-select.png`](assets/screenshots/rtype-delta-force-select.png)
+
+### rtype-delta-title.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-title.png" alt="rtype delta title"></p>
+
+fix(gpu): a saved-EXEC wave mask must survive the NGG fetch-index fold — R-Type Delta reaches its title screen (#2061)
+
+`83e3383a` · [`assets/screenshots/rtype-delta-title.png`](assets/screenshots/rtype-delta-title.png)
+
+### crisis-core-main-menu.png
+
+<p align="center"><img src="assets/screenshots/crisis-core-main-menu.png" alt="crisis core main menu"></p>
+
+Crisis Core (PPSA07809) reaches rung 2 — and its #1945 fault is a race the guest wins, not a late write (#2060)
+
+`e311e6cd` · [`assets/screenshots/crisis-core-main-menu.png`](assets/screenshots/crisis-core-main-menu.png)
+
+### crisis-core-title.png
+
+<p align="center"><img src="assets/screenshots/crisis-core-title.png" alt="crisis core title"></p>
+
+Crisis Core (PPSA07809) reaches rung 2 — and its #1945 fault is a race the guest wins, not a late write (#2060)
+
+`e311e6cd` · [`assets/screenshots/crisis-core-title.png`](assets/screenshots/crisis-core-title.png)
+
+### crisis-core-voice-language.png
+
+<p align="center"><img src="assets/screenshots/crisis-core-voice-language.png" alt="crisis core voice language"></p>
+
+Crisis Core (PPSA07809) reaches rung 2 — and its #1945 fault is a race the guest wins, not a late write (#2060)
+
+`e311e6cd` · [`assets/screenshots/crisis-core-voice-language.png`](assets/screenshots/crisis-core-voice-language.png)
+
+### sonic-frontiers-middleware-credits.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-middleware-credits.png" alt="sonic frontiers middleware credits"></p>
+
+fix(present): publish the flipped VideoOut buffer when no pass ever targets it — with a real guest-authorship test and the composited-frame gate intact (#2068)
+
+`33dac763` · [`assets/screenshots/sonic-frontiers-middleware-credits.png`](assets/screenshots/sonic-frontiers-middleware-credits.png)
+
+### sonic-frontiers-sega-logo.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-sega-logo.png" alt="sonic frontiers sega logo"></p>
+
+fix(present): publish the flipped VideoOut buffer when no pass ever targets it — with a real guest-authorship test and the composited-frame gate intact (#2068)
+
+`33dac763` · [`assets/screenshots/sonic-frontiers-sega-logo.png`](assets/screenshots/sonic-frontiers-sega-logo.png)
+
+### rtype-delta-opening-movie-colour.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-opening-movie-colour.png" alt="rtype delta opening movie colour"></p>
+
+fix(gpu): recognise an AvPlayer chroma plane declared as a one-layer 2D array (#2037)
+
+`08d75128` · [`assets/screenshots/rtype-delta-opening-movie-colour.png`](assets/screenshots/rtype-delta-opening-movie-colour.png)
+
+### issue-1946-health-warning-before-after.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1946-health-warning-before-after.png" alt="issue 1946 health warning before after"></p>
+
+fix(agc): offer the render-target-0 blend key on every SDK version — The Oregon Trail's whole UI layer was unblended (#1946) (#2031)
+
+`beeff2ab` · [`prosper/docs/screenshots/issue-1946-health-warning-before-after.png`](prosper/docs/screenshots/issue-1946-health-warning-before-after.png)
+
+### issue-1946-slate-blend-before-after.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1946-slate-blend-before-after.png" alt="issue 1946 slate blend before after"></p>
+
+fix(agc): offer the render-target-0 blend key on every SDK version — The Oregon Trail's whole UI layer was unblended (#1946) (#2031)
+
+`beeff2ab` · [`prosper/docs/screenshots/issue-1946-slate-blend-before-after.png`](prosper/docs/screenshots/issue-1946-slate-blend-before-after.png)
+
+### sonic-crossworlds-sega-logo.png
+
+<p align="center"><img src="assets/screenshots/sonic-crossworlds-sega-logo.png" alt="sonic crossworlds sega logo"></p>
+
+docs(crossworlds): Sonic Racing: CrossWorlds reaches rung 1 — the SEGA logo renders (#2039)
+
+`f8b0f040` · [`assets/screenshots/sonic-crossworlds-sega-logo.png`](assets/screenshots/sonic-crossworlds-sega-logo.png)
+
+### little-nightmares-3-eula.png
+
+<p align="center"><img src="assets/screenshots/little-nightmares-3-eula.png" alt="little nightmares 3 eula"></p>
+
+docs(little-nightmares-3): #2014 is a wrong background clear, not a channel map — plus the first input route (#2041)
+
+`f811615a` · [`assets/screenshots/little-nightmares-3-eula.png`](assets/screenshots/little-nightmares-3-eula.png)
+
+## 2026-08-05
+
+### little-nightmares-3-title-screen.png
+
+<p align="center"><img src="assets/screenshots/little-nightmares-3-title-screen.png" alt="little nightmares 3 title screen"></p>
+
+docs(little-nightmares-3): rung 2 — the title screen renders; land the ruled-out record (#2017)
+
+`080263cf` · [`assets/screenshots/little-nightmares-3-title-screen.png`](assets/screenshots/little-nightmares-3-title-screen.png)
+
+### rtype-delta-rung1-logo-and-opening-movie.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-rung1-logo-and-opening-movie.png" alt="rtype delta rung1 logo and opening movie"></p>
+
+docs(rtype): R-Type Delta reaches rung 1 — the #1746 startup race is host CPU speed, not a prosper defect (#2009)
+
+`c3614f51` · [`assets/screenshots/rtype-delta-rung1-logo-and-opening-movie.png`](assets/screenshots/rtype-delta-rung1-logo-and-opening-movie.png)
+
+### oregon-trail-title-screen.png
+
+<p align="center"><img src="assets/screenshots/oregon-trail-title-screen.png" alt="oregon trail title screen"></p>
+
+diag(fault): probe every guest-pointer register at a worker fault, not just rdx/rax (#1992)
+
+`034f959a` · [`assets/screenshots/oregon-trail-title-screen.png`](assets/screenshots/oregon-trail-title-screen.png)
+
+### oregon-trail-gameloft-splash.png
+
+<p align="center"><img src="assets/screenshots/oregon-trail-gameloft-splash.png" alt="oregon trail gameloft splash"></p>
+
+fix(hle): scePthread* must return libkernel-encoded errors — Oregon Trail advances three checkpoints (#1984)
+
+`38619f29` · [`assets/screenshots/oregon-trail-gameloft-splash.png`](assets/screenshots/oregon-trail-gameloft-splash.png)
+
+### oregon-trail-health-warning.png
+
+<p align="center"><img src="assets/screenshots/oregon-trail-health-warning.png" alt="oregon trail health warning"></p>
+
+fix(hle): scePthread* must return libkernel-encoded errors — Oregon Trail advances three checkpoints (#1984)
+
+`38619f29` · [`assets/screenshots/oregon-trail-health-warning.png`](assets/screenshots/oregon-trail-health-warning.png)
+
+### bendy-dark-revival-title.png
+
+<p align="center"><img src="assets/screenshots/bendy-dark-revival-title.png" alt="bendy dark revival title"></p>
+
+fix(avplayer): end a source nobody consumes on its own media clock (#1981)
+
+`afe4a2b0` · [`assets/screenshots/bendy-dark-revival-title.png`](assets/screenshots/bendy-dark-revival-title.png)
+
+### asterix-babylon-intro-cutscene.png
+
+<p align="center"><img src="assets/screenshots/asterix-babylon-intro-cutscene.png" alt="asterix babylon intro cutscene"></p>
+
+feat(avplayer): implement sceAvPlayerJumpToTime and honour the guest file-replacement reader (#1974)
+
+`ff72e77c` · [`assets/screenshots/asterix-babylon-intro-cutscene.png`](assets/screenshots/asterix-babylon-intro-cutscene.png)
+
+### asterix-babylon-title.png
+
+<p align="center"><img src="assets/screenshots/asterix-babylon-title.png" alt="asterix babylon title"></p>
+
+feat(avplayer): implement sceAvPlayerJumpToTime and honour the guest file-replacement reader (#1974)
+
+`ff72e77c` · [`assets/screenshots/asterix-babylon-title.png`](assets/screenshots/asterix-babylon-title.png)
+
+### little-nightmares-3-boot-splash.png
+
+<p align="center"><img src="assets/screenshots/little-nightmares-3-boot-splash.png" alt="little nightmares 3 boot splash"></p>
+
+fix(ajm): accept the config revision — Little Nightmares III reaches rung 1 (#1966)
+
+`1fc8ece9` · [`assets/screenshots/little-nightmares-3-boot-splash.png`](assets/screenshots/little-nightmares-3-boot-splash.png)
+
+### sonic-frontiers-opening-sequence.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-opening-sequence.png" alt="sonic frontiers opening sequence"></p>
+
+docs(sonic-frontiers): rung 1 — it renders; the rung-0 reading was a failure-only diagnostic (#1969)
+
+`440d84d2` · [`assets/screenshots/sonic-frontiers-opening-sequence.png`](assets/screenshots/sonic-frontiers-opening-sequence.png)
+
+### sonic-frontiers-sonic-team-logo.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-sonic-team-logo.png" alt="sonic frontiers sonic team logo"></p>
+
+docs(sonic-frontiers): rung 1 — it renders; the rung-0 reading was a failure-only diagnostic (#1969)
+
+`440d84d2` · [`assets/screenshots/sonic-frontiers-sonic-team-logo.png`](assets/screenshots/sonic-frontiers-sonic-team-logo.png)
+
+## 2026-08-04
+
+### oregon-trail-legal-popup.png
+
+<p align="center"><img src="assets/screenshots/oregon-trail-legal-popup.png" alt="oregon trail legal popup"></p>
+
+feat(oregon): reach rung 1 — the startup legal popup renders on a default launch (#1950)
+
+`e92d2f7f` · [`assets/screenshots/oregon-trail-legal-popup.png`](assets/screenshots/oregon-trail-legal-popup.png)
+
+### beneath-title.png
+
+<p align="center"><img src="assets/screenshots/beneath-title.png" alt="beneath title"></p>
+
+docs: record Beneath title screen
+
+`0dafd22d` · [`assets/screenshots/beneath-title.png`](assets/screenshots/beneath-title.png)
+
+### forgotten-city-title.png
+
+<p align="center"><img src="assets/screenshots/forgotten-city-title.png" alt="forgotten city title"></p>
+
+docs: record first-run compatibility baselines
+
+`1640bb30` · [`assets/screenshots/forgotten-city-title.png`](assets/screenshots/forgotten-city-title.png)
+
+### tactics-ogre-hevc-movie.png
+
+<p align="center"><img src="assets/screenshots/tactics-ogre-hevc-movie.png" alt="tactics ogre hevc movie"></p>
+
+docs(tactics-ogre): record restored HEVC presentation
+
+`0d2f9a9f` · [`assets/screenshots/tactics-ogre-hevc-movie.png`](assets/screenshots/tactics-ogre-hevc-movie.png)
+
+### tactics-ogre-reborn-gameplay.png
+
+<p align="center"><img src="assets/screenshots/tactics-ogre-reborn-gameplay.png" alt="tactics ogre reborn gameplay"></p>
+
+Document Tactics Ogre tutorial battle
+
+`038c166d` · [`assets/screenshots/tactics-ogre-reborn-gameplay.png`](assets/screenshots/tactics-ogre-reborn-gameplay.png)
+
+## 2026-08-03
+
+### tactics-ogre-reborn-opening-scene.png
+
+<p align="center"><img src="assets/screenshots/tactics-ogre-reborn-opening-scene.png" alt="tactics ogre reborn opening scene"></p>
+
+Document Tactics Ogre opening scene
+
+`4c8e3997` · [`assets/screenshots/tactics-ogre-reborn-opening-scene.png`](assets/screenshots/tactics-ogre-reborn-opening-scene.png)
+
+### house-of-the-dead-2-remake-gameplay.png
+
+<p align="center"><img src="assets/screenshots/house-of-the-dead-2-remake-gameplay.png" alt="house of the dead 2 remake gameplay"></p>
+
+Document House of the Dead 2 gameplay
+
+`b01e057c` · [`assets/screenshots/house-of-the-dead-2-remake-gameplay.png`](assets/screenshots/house-of-the-dead-2-remake-gameplay.png)
+
+### tactics-ogre-title.png
+
+<p align="center"><img src="assets/screenshots/tactics-ogre-title.png" alt="tactics ogre title"></p>
+
+Add Tactics Ogre title milestone
+
+`4d192dc1` · [`assets/screenshots/tactics-ogre-title.png`](assets/screenshots/tactics-ogre-title.png)
+
+### house-of-the-dead-2-remake-title.png
+
+<p align="center"><img src="assets/screenshots/house-of-the-dead-2-remake-title.png" alt="house of the dead 2 remake title"></p>
+
+Document newly tested game compatibility
+
+`fbde2b4c` · [`assets/screenshots/house-of-the-dead-2-remake-title.png`](assets/screenshots/house-of-the-dead-2-remake-title.png)
+
+### rtype-delta-movie-coordinate-progress.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-movie-coordinate-progress.png" alt="rtype delta movie coordinate progress"></p>
+
+fix(gpu): honor unnormalized sample coordinates
+
+`d4fa07a8` · [`assets/screenshots/rtype-delta-movie-coordinate-progress.png`](assets/screenshots/rtype-delta-movie-coordinate-progress.png)
+
+### blue-prince-hall.png
+
+<p align="center"><img src="assets/screenshots/blue-prince-hall.png" alt="blue prince hall"></p>
+
+Fix Blue Prince hall snapshot guard (#1813)
+
+`730d434e` · [`assets/screenshots/blue-prince-hall.png`](assets/screenshots/blue-prince-hall.png)
+
+## 2026-08-02
+
+### earthion-title-menu.png
+
+<p align="center"><img src="assets/screenshots/earthion-title-menu.png" alt="earthion title menu"></p>
+
+feat(earthion): route past the intro — the "missing picture" was a black text page (#1590) (#1775)
+
+`3d1a7480` · [`assets/screenshots/earthion-title-menu.png`](assets/screenshots/earthion-title-menu.png)
+
+### tales-graces-f-options.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-options.png" alt="tales graces f options"></p>
+
+feat(talesgraces): routes to the title screen and the new-game Options screen (PPSA19991 rung 2) (#1759)
+
+`30477a2d` · [`assets/screenshots/tales-graces-f-options.png`](assets/screenshots/tales-graces-f-options.png)
+
+### tales-graces-f-title.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-title.png" alt="tales graces f title"></p>
+
+feat(talesgraces): routes to the title screen and the new-game Options screen (PPSA19991 rung 2) (#1759)
+
+`30477a2d` · [`assets/screenshots/tales-graces-f-title.png`](assets/screenshots/tales-graces-f-title.png)
+
+### bendy-gameplay.png
+
+<p align="center"><img src="assets/screenshots/bendy-gameplay.png" alt="bendy gameplay"></p>
+
+docs(compat): boot sweep of fourteen titles on 3a473bca — corrected rungs, four new rows, and a frame-rate census (#1740)
+
+`8fc79ca0` · [`assets/screenshots/bendy-gameplay.png`](assets/screenshots/bendy-gameplay.png)
+
+### bendy-title.png
+
+<p align="center"><img src="assets/screenshots/bendy-title.png" alt="bendy title"></p>
+
+docs(compat): boot sweep of fourteen titles on 3a473bca — corrected rungs, four new rows, and a frame-rate census (#1740)
+
+`8fc79ca0` · [`assets/screenshots/bendy-title.png`](assets/screenshots/bendy-title.png)
+
+### pathless-title.png
+
+<p align="center"><img src="assets/screenshots/pathless-title.png" alt="pathless title"></p>
+
+docs(compat): boot sweep of fourteen titles on 3a473bca — corrected rungs, four new rows, and a frame-rate census (#1740)
+
+`8fc79ca0` · [`assets/screenshots/pathless-title.png`](assets/screenshots/pathless-title.png)
+
+### plucky-squire-title.png
+
+<p align="center"><img src="assets/screenshots/plucky-squire-title.png" alt="plucky squire title"></p>
+
+docs(compat): boot sweep of fourteen titles on 3a473bca — corrected rungs, four new rows, and a frame-rate census (#1740)
+
+`8fc79ca0` · [`assets/screenshots/plucky-squire-title.png`](assets/screenshots/plucky-squire-title.png)
+
+### astro-bot-opening-cinematic.png
+
+<p align="center"><img src="assets/screenshots/astro-bot-opening-cinematic.png" alt="astro bot opening cinematic"></p>
+
+docs(astro): Astro Bot enters COMPATIBILITY.md at rung 2 — the title screen renders (#1736)
+
+`6d7b69e9` · [`assets/screenshots/astro-bot-opening-cinematic.png`](assets/screenshots/astro-bot-opening-cinematic.png)
+
+### astro-bot-title.png
+
+<p align="center"><img src="assets/screenshots/astro-bot-title.png" alt="astro bot title"></p>
+
+docs(astro): Astro Bot enters COMPATIBILITY.md at rung 2 — the title screen renders (#1736)
+
+`6d7b69e9` · [`assets/screenshots/astro-bot-title.png`](assets/screenshots/astro-bot-title.png)
+
+### astro-bot-worldmap-background.png
+
+<p align="center"><img src="assets/screenshots/astro-bot-worldmap-background.png" alt="astro bot worldmap background"></p>
+
+fix(gpu): CB_COLOR_CONTROL.MODE must not override the guest's colour write mask (#1728)
+
+`c8fe4afd` · [`assets/screenshots/astro-bot-worldmap-background.png`](assets/screenshots/astro-bot-worldmap-background.png)
+
+## 2026-08-01
+
+### tales-graces-f-criware.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-criware.png" alt="tales graces f criware"></p>
+
+fix(hle): deliver the APR completion event for a zero-tag binding (#1666) (#1667)
+
+`fa1f07b3` · [`assets/screenshots/tales-graces-f-criware.png`](assets/screenshots/tales-graces-f-criware.png)
+
+### tales-graces-f-publisher.png
+
+<p align="center"><img src="assets/screenshots/tales-graces-f-publisher.png" alt="tales graces f publisher"></p>
+
+fix(hle): deliver the APR completion event for a zero-tag binding (#1666) (#1667)
+
+`fa1f07b3` · [`assets/screenshots/tales-graces-f-publisher.png`](assets/screenshots/tales-graces-f-publisher.png)
+
+### issue-1630-grid-after.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1630-grid-after.png" alt="issue 1630 grid after"></p>
+
+feat(app): per-title background art and focus music in the library (#1647)
+
+`7da42075` · [`prosper/docs/screenshots/issue-1630-grid-after.png`](prosper/docs/screenshots/issue-1630-grid-after.png)
+
+### issue-1630-grid-before.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1630-grid-before.png" alt="issue 1630 grid before"></p>
+
+feat(app): per-title background art and focus music in the library (#1647)
+
+`7da42075` · [`prosper/docs/screenshots/issue-1630-grid-before.png`](prosper/docs/screenshots/issue-1630-grid-before.png)
+
+### issue-1630-library-background-1.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1630-library-background-1.png" alt="issue 1630 library background 1"></p>
+
+feat(app): per-title background art and focus music in the library (#1647)
+
+`7da42075` · [`prosper/docs/screenshots/issue-1630-library-background-1.png`](prosper/docs/screenshots/issue-1630-library-background-1.png)
+
+### issue-1630-library-background-2.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1630-library-background-2.png" alt="issue 1630 library background 2"></p>
+
+feat(app): per-title background art and focus music in the library (#1647)
+
+`7da42075` · [`prosper/docs/screenshots/issue-1630-library-background-2.png`](prosper/docs/screenshots/issue-1630-library-background-2.png)
+
+### issue-1630-library-background-3.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1630-library-background-3.png" alt="issue 1630 library background 3"></p>
+
+feat(app): per-title background art and focus music in the library (#1647)
+
+`7da42075` · [`prosper/docs/screenshots/issue-1630-library-background-3.png`](prosper/docs/screenshots/issue-1630-library-background-3.png)
+
+### syberia-gameplay.png
+
+<p align="center"><img src="assets/screenshots/syberia-gameplay.png" alt="syberia gameplay"></p>
+
+docs(syberia): validated route to gameplay, and localize the black scene to one format gap (#1622)
+
+`5ee5e785` · [`assets/screenshots/syberia-gameplay.png`](assets/screenshots/syberia-gameplay.png)
+
+### syberia-title.png
+
+<p align="center"><img src="assets/screenshots/syberia-title.png" alt="syberia title"></p>
+
+docs(syberia): validated route to gameplay, and localize the black scene to one format gap (#1622)
+
+`5ee5e785` · [`assets/screenshots/syberia-title.png`](assets/screenshots/syberia-title.png)
+
+### worms-armageddon-gameplay.png
+
+<p align="center"><img src="assets/screenshots/worms-armageddon-gameplay.png" alt="worms armageddon gameplay"></p>
+
+fix(pad): scePadGetHandle looks up an open handle instead of fabricating one (#1623)
+
+`823c9670` · [`assets/screenshots/worms-armageddon-gameplay.png`](assets/screenshots/worms-armageddon-gameplay.png)
+
+## 2026-07-31
+
+### syberia-profile.png
+
+<p align="center"><img src="assets/screenshots/syberia-profile.png" alt="syberia profile"></p>
+
+fix(agc): register sceAgcAcbWriteData — Syberia goes from hard hang to its profile menu (#1610)
+
+`961a6cdd` · [`assets/screenshots/syberia-profile.png`](assets/screenshots/syberia-profile.png)
+
+### nikoderiko-title.png
+
+<p align="center"><img src="assets/screenshots/nikoderiko-title.png" alt="nikoderiko title"></p>
+
+docs(compat): add Nikoderiko at title screen and The Oregon Trail at research tier (#1608)
+
+`a933091d` · [`assets/screenshots/nikoderiko-title.png`](assets/screenshots/nikoderiko-title.png)
+
+### greak-title.png
+
+<p align="center"><img src="assets/screenshots/greak-title.png" alt="greak title"></p>
+
+feat(recompiler): lower s_ttracedata — Greak and Rugrats reach gameplay (#1600)
+
+`5a0eb7b6` · [`assets/screenshots/greak-title.png`](assets/screenshots/greak-title.png)
+
+### greak.png
+
+<p align="center"><img src="assets/screenshots/greak.png" alt="greak"></p>
+
+feat(recompiler): lower s_ttracedata — Greak and Rugrats reach gameplay (#1600)
+
+`5a0eb7b6` · [`assets/screenshots/greak.png`](assets/screenshots/greak.png)
+
+### rugrats-title.png
+
+<p align="center"><img src="assets/screenshots/rugrats-title.png" alt="rugrats title"></p>
+
+feat(recompiler): lower s_ttracedata — Greak and Rugrats reach gameplay (#1600)
+
+`5a0eb7b6` · [`assets/screenshots/rugrats-title.png`](assets/screenshots/rugrats-title.png)
+
+### rugrats.png
+
+<p align="center"><img src="assets/screenshots/rugrats.png" alt="rugrats"></p>
+
+feat(recompiler): lower s_ttracedata — Greak and Rugrats reach gameplay (#1600)
+
+`5a0eb7b6` · [`assets/screenshots/rugrats.png`](assets/screenshots/rugrats.png)
+
+### asterix-slap-them-all.png
+
+<p align="center"><img src="assets/screenshots/asterix-slap-them-all.png" alt="asterix slap them all"></p>
+
+docs(compat): add Asterix Slap Them All and Summer Sports Games at gameplay (#1604)
+
+`2421d503` · [`assets/screenshots/asterix-slap-them-all.png`](assets/screenshots/asterix-slap-them-all.png)
+
+### summer-sports-games.png
+
+<p align="center"><img src="assets/screenshots/summer-sports-games.png" alt="summer sports games"></p>
+
+docs(compat): add Asterix Slap Them All and Summer Sports Games at gameplay (#1604)
+
+`2421d503` · [`assets/screenshots/summer-sports-games.png`](assets/screenshots/summer-sports-games.png)
+
+### joe-mac-menu.png
+
+<p align="center"><img src="assets/screenshots/joe-mac-menu.png" alt="joe mac menu"></p>
+
+docs(compat): record five newly triaged titles, two of them rendering (#1596)
+
+`bb5a11a2` · [`assets/screenshots/joe-mac-menu.png`](assets/screenshots/joe-mac-menu.png)
+
+### joe-mac.png
+
+<p align="center"><img src="assets/screenshots/joe-mac.png" alt="joe mac"></p>
+
+docs(compat): record five newly triaged titles, two of them rendering (#1596)
+
+`bb5a11a2` · [`assets/screenshots/joe-mac.png`](assets/screenshots/joe-mac.png)
+
+### worms-armageddon-title.png
+
+<p align="center"><img src="assets/screenshots/worms-armageddon-title.png" alt="worms armageddon title"></p>
+
+docs(compat): record five newly triaged titles, two of them rendering (#1596)
+
+`bb5a11a2` · [`assets/screenshots/worms-armageddon-title.png`](assets/screenshots/worms-armageddon-title.png)
+
+### alex-kidd.png
+
+<p align="center"><img src="assets/screenshots/alex-kidd.png" alt="alex kidd"></p>
+
+test(snapshot): reviewed alexkidd-gameplay content guard — PPSA02664 reaches ladder rung 6 (#1582)
+
+`a6d995fa` · [`assets/screenshots/alex-kidd.png`](assets/screenshots/alex-kidd.png)
+
+### dragon-quest-vii-onboarding.png
+
+<p align="center"><img src="assets/screenshots/dragon-quest-vii-onboarding.png" alt="dragon quest vii onboarding"></p>
+
+docs: record Dragon Quest VII onboarding
+
+`aeee4d48` · [`assets/screenshots/dragon-quest-vii-onboarding.png`](assets/screenshots/dragon-quest-vii-onboarding.png)
+
+### dragon-quest-vii-name-confirmation.png
+
+<p align="center"><img src="assets/screenshots/dragon-quest-vii-name-confirmation.png" alt="dragon quest vii name confirmation"></p>
+
+Document DQ7 name confirmation milestone
+
+`d2fe1c66` · [`assets/screenshots/dragon-quest-vii-name-confirmation.png`](assets/screenshots/dragon-quest-vii-name-confirmation.png)
+
+### dragon-quest-vii-name-entry.png
+
+<p align="center"><img src="assets/screenshots/dragon-quest-vii-name-entry.png" alt="dragon quest vii name entry"></p>
+
+Document Dragon Quest name entry
+
+`297ec493` · [`assets/screenshots/dragon-quest-vii-name-entry.png`](assets/screenshots/dragon-quest-vii-name-entry.png)
+
+### space-adventure-cobra.png
+
+<p align="center"><img src="assets/screenshots/space-adventure-cobra.png" alt="space adventure cobra"></p>
+
+fix(runtime): preserve guest TLS across write-watch faults
+
+`82eadf58` · [`assets/screenshots/space-adventure-cobra.png`](assets/screenshots/space-adventure-cobra.png)
+
+### gris.png
+
+<p align="center"><img src="assets/screenshots/gris.png" alt="gris"></p>
+
+docs: record GRIS opening gameplay
+
+`b08f0a94` · [`assets/screenshots/gris.png`](assets/screenshots/gris.png)
+
+### issue-1459-astrobot-blue-fmv-gpu-present.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1459-astrobot-blue-fmv-gpu-present.png" alt="issue 1459 astrobot blue fmv gpu present"></p>
+
+docs: capture Astro Bot blue intro
+
+`3f72a8ce` · [`prosper/docs/screenshots/issue-1459-astrobot-blue-fmv-gpu-present.png`](prosper/docs/screenshots/issue-1459-astrobot-blue-fmv-gpu-present.png)
+
+## 2026-07-30
+
+### issue-1471-library-empty.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1471-library-empty.png" alt="issue 1471 library empty"></p>
+
+fix(app): address review findings on the library view
+
+`44d1689d` · [`prosper/docs/screenshots/issue-1471-library-empty.png`](prosper/docs/screenshots/issue-1471-library-empty.png)
+
+### issue-1471-library-scrolled.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1471-library-scrolled.png" alt="issue 1471 library scrolled"></p>
+
+fix(app): address review findings on the library view
+
+`44d1689d` · [`prosper/docs/screenshots/issue-1471-library-scrolled.png`](prosper/docs/screenshots/issue-1471-library-scrolled.png)
+
+### issue-1471-library-grid.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1471-library-grid.png" alt="issue 1471 library grid"></p>
+
+feat(app): draw the game library with Dear ImGui
+
+`7cf767fe` · [`prosper/docs/screenshots/issue-1471-library-grid.png`](prosper/docs/screenshots/issue-1471-library-grid.png)
+
+### issue-1459-astrobot-linux-indirect-title.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1459-astrobot-linux-indirect-title.png" alt="issue 1459 astrobot linux indirect title"></p>
+
+gpu: execute AGC indirect work after producers
+
+`e85c527c` · [`prosper/docs/screenshots/issue-1459-astrobot-linux-indirect-title.png`](prosper/docs/screenshots/issue-1459-astrobot-linux-indirect-title.png)
+
+## 2026-07-29
+
+### issue-1469-drop-messenger.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1469-drop-messenger.png" alt="issue 1469 drop messenger"></p>
+
+docs(app): interactive-open evidence screenshots (#1469)
+
+`3f7f9929` · [`prosper/docs/screenshots/issue-1469-drop-messenger.png`](prosper/docs/screenshots/issue-1469-drop-messenger.png)
+
+### issue-1469-picker-messenger.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1469-picker-messenger.png" alt="issue 1469 picker messenger"></p>
+
+docs(app): interactive-open evidence screenshots (#1469)
+
+`3f7f9929` · [`prosper/docs/screenshots/issue-1469-picker-messenger.png`](prosper/docs/screenshots/issue-1469-picker-messenger.png)
+
+### issue-1469-reject-not-a-title.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1469-reject-not-a-title.png" alt="issue 1469 reject not a title"></p>
+
+docs(app): interactive-open evidence screenshots (#1469)
+
+`3f7f9929` · [`prosper/docs/screenshots/issue-1469-reject-not-a-title.png`](prosper/docs/screenshots/issue-1469-reject-not-a-title.png)
+
+### issue-1469-relaunch-blasphemous2.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1469-relaunch-blasphemous2.png" alt="issue 1469 relaunch blasphemous2"></p>
+
+docs(app): interactive-open evidence screenshots (#1469)
+
+`3f7f9929` · [`prosper/docs/screenshots/issue-1469-relaunch-blasphemous2.png`](prosper/docs/screenshots/issue-1469-relaunch-blasphemous2.png)
+
+### issue-1459-astrobot-worldmap-current.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1459-astrobot-worldmap-current.png" alt="issue 1459 astrobot worldmap current"></p>
+
+docs: capture current Astro Bot world map
+
+`2e83d1ea` · [`prosper/docs/screenshots/issue-1459-astrobot-worldmap-current.png`](prosper/docs/screenshots/issue-1459-astrobot-worldmap-current.png)
+
+### issue-1466-astrobot-direct-tile.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1466-astrobot-direct-tile.png" alt="issue 1466 astrobot direct tile"></p>
+
+perf(gpu): tile mapped storage images directly
+
+`1b8eeed6` · [`prosper/docs/screenshots/issue-1466-astrobot-direct-tile.png`](prosper/docs/screenshots/issue-1466-astrobot-direct-tile.png)
+
+## 2026-07-26
+
+### issue-1287-hall-live-fixed.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-live-fixed.png" alt="issue 1287 hall live fixed"></p>
+
+docs: live Blue Prince gameplay at oracle parity (#1287 rung-5 evidence) (#1438)
+
+`ffbb7d74` · [`prosper/docs/screenshots/issue-1287-hall-live-fixed.png`](prosper/docs/screenshots/issue-1287-hall-live-fixed.png)
+
+### issue-1287-hall-live-vs-oracle.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-live-vs-oracle.png" alt="issue 1287 hall live vs oracle"></p>
+
+docs: live Blue Prince gameplay at oracle parity (#1287 rung-5 evidence) (#1438)
+
+`ffbb7d74` · [`prosper/docs/screenshots/issue-1287-hall-live-vs-oracle.png`](prosper/docs/screenshots/issue-1287-hall-live-vs-oracle.png)
+
+### issue-1287-manor-approach-live.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-manor-approach-live.png" alt="issue 1287 manor approach live"></p>
+
+docs: live Blue Prince gameplay at oracle parity (#1287 rung-5 evidence) (#1438)
+
+`ffbb7d74` · [`prosper/docs/screenshots/issue-1287-manor-approach-live.png`](prosper/docs/screenshots/issue-1287-manor-approach-live.png)
+
+### issue-1427-hall-geometry-restored.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1427-hall-geometry-restored.png" alt="issue 1427 hall geometry restored"></p>
+
+fix(render): upload a buffer binding's whole declared range, not the first 1 MiB (#1429)
+
+`ad5a840a` · [`prosper/docs/screenshots/issue-1427-hall-geometry-restored.png`](prosper/docs/screenshots/issue-1427-hall-geometry-restored.png)
+
+### issue-1427-oracle-before-after.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1427-oracle-before-after.png" alt="issue 1427 oracle before after"></p>
+
+fix(render): upload a buffer binding's whole declared range, not the first 1 MiB (#1429)
+
+`ad5a840a` · [`prosper/docs/screenshots/issue-1427-oracle-before-after.png`](prosper/docs/screenshots/issue-1427-oracle-before-after.png)
+
+### issue-1287-hall-materials-fixed.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-materials-fixed.png" alt="issue 1287 hall materials fixed"></p>
+
+docs: Blue Prince hall with correct materials (#1287 milestone frame) (#1418)
+
+`0f7d9310` · [`prosper/docs/screenshots/issue-1287-hall-materials-fixed.png`](prosper/docs/screenshots/issue-1287-hall-materials-fixed.png)
+
+## 2026-07-25
+
+### issue-1334-hall-default-tonemapped.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1334-hall-default-tonemapped.png" alt="issue 1334 hall default tonemapped"></p>
+
+fix(gpu): GPU-copy the MSAA resolve into the destination persistent image (#1382)
+
+`6479cd5f` · [`prosper/docs/screenshots/issue-1334-hall-default-tonemapped.png`](prosper/docs/screenshots/issue-1334-hall-default-tonemapped.png)
+
+### issue-1287-hall-bundle-tonemapped.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-bundle-tonemapped.png" alt="issue 1287 hall bundle tonemapped"></p>
+
+docs: current Blue Prince hall frames for the #1287 oracle request (#1375)
+
+`a3613436` · [`prosper/docs/screenshots/issue-1287-hall-bundle-tonemapped.png`](prosper/docs/screenshots/issue-1287-hall-bundle-tonemapped.png)
+
+### issue-1287-hall-magenta-prosper.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-magenta-prosper.png" alt="issue 1287 hall magenta prosper"></p>
+
+docs: current Blue Prince hall frames for the #1287 oracle request (#1375)
+
+`a3613436` · [`prosper/docs/screenshots/issue-1287-hall-magenta-prosper.png`](prosper/docs/screenshots/issue-1287-hall-magenta-prosper.png)
+
+### issue-1287-hall-night-prosper.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-night-prosper.png" alt="issue 1287 hall night prosper"></p>
+
+docs: current Blue Prince hall frames for the #1287 oracle request (#1375)
+
+`a3613436` · [`prosper/docs/screenshots/issue-1287-hall-night-prosper.png`](prosper/docs/screenshots/issue-1287-hall-night-prosper.png)
+
+### issue-1287-hall-nobatch-live.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-hall-nobatch-live.png" alt="issue 1287 hall nobatch live"></p>
+
+docs: current Blue Prince hall frames for the #1287 oracle request (#1375)
+
+`a3613436` · [`prosper/docs/screenshots/issue-1287-hall-nobatch-live.png`](prosper/docs/screenshots/issue-1287-hall-nobatch-live.png)
+
+### issue-1287-vestibule-prosper.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1287-vestibule-prosper.png" alt="issue 1287 vestibule prosper"></p>
+
+docs: current Blue Prince hall frames for the #1287 oracle request (#1375)
+
+`a3613436` · [`prosper/docs/screenshots/issue-1287-vestibule-prosper.png`](prosper/docs/screenshots/issue-1287-vestibule-prosper.png)
+
+### issue-1356-gris-title.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1356-gris-title.png" alt="issue 1356 gris title"></p>
+
+feat: bring GRIS and Cobra to title with audio (#1368)
+
+`8b37be95` · [`prosper/docs/screenshots/issue-1356-gris-title.png`](prosper/docs/screenshots/issue-1356-gris-title.png)
+
+### issue-1356-space-adventure-cobra-title.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1356-space-adventure-cobra-title.png" alt="issue 1356 space adventure cobra title"></p>
+
+feat: bring GRIS and Cobra to title with audio (#1368)
+
+`8b37be95` · [`prosper/docs/screenshots/issue-1356-space-adventure-cobra-title.png`](prosper/docs/screenshots/issue-1356-space-adventure-cobra-title.png)
+
+### dragon-quest-vii-title.png
+
+<p align="center"><img src="assets/screenshots/dragon-quest-vii-title.png" alt="dragon quest vii title"></p>
+
+docs: publish Dragon Quest VII title capture
+
+`18abdf28` · [`assets/screenshots/dragon-quest-vii-title.png`](assets/screenshots/dragon-quest-vii-title.png)
+
+### issue-1352-wall-shading-after.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1352-wall-shading-after.png" alt="issue 1352 wall shading after"></p>
+
+fix(gpu): DEPTH_CLEAR_ENABLE acts only through the enabled depth-write path (#1354)
+
+`feb5822d` · [`prosper/docs/screenshots/issue-1352-wall-shading-after.png`](prosper/docs/screenshots/issue-1352-wall-shading-after.png)
+
+### issue-1352-wall-shading-before.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-1352-wall-shading-before.png" alt="issue 1352 wall shading before"></p>
+
+fix(gpu): DEPTH_CLEAR_ENABLE acts only through the enabled depth-write path (#1354)
+
+`feb5822d` · [`prosper/docs/screenshots/issue-1352-wall-shading-before.png`](prosper/docs/screenshots/issue-1352-wall-shading-before.png)
+
+## 2026-07-24
+
+### blue-prince-title.png
+
+<p align="center"><img src="assets/screenshots/blue-prince-title.png" alt="blue prince title"></p>
+
+Add Blue Prince and Terminator docs screenshots (#1342)
+
+`5e11d900` · [`assets/screenshots/blue-prince-title.png`](assets/screenshots/blue-prince-title.png)
+
+### terminator-title.png
+
+<p align="center"><img src="assets/screenshots/terminator-title.png" alt="terminator title"></p>
+
+Add Blue Prince and Terminator docs screenshots (#1342)
+
+`5e11d900` · [`assets/screenshots/terminator-title.png`](assets/screenshots/terminator-title.png)
+
+### terminator.png
+
+<p align="center"><img src="assets/screenshots/terminator.png" alt="terminator"></p>
+
+Add Blue Prince and Terminator docs screenshots (#1342)
+
+`5e11d900` · [`assets/screenshots/terminator.png`](assets/screenshots/terminator.png)
+
+### gta5-main-menu.png
+
+<p align="center"><img src="assets/screenshots/gta5-main-menu.png" alt="gta5 main menu"></p>
+
+docs: show GTA V current renderer state (#1339)
+
+`e6b8fb06` · [`assets/screenshots/gta5-main-menu.png`](assets/screenshots/gta5-main-menu.png)
+
+### gta5-title.png
+
+<p align="center"><img src="assets/screenshots/gta5-title.png" alt="gta5 title"></p>
+
+docs: show GTA V current renderer state (#1339)
+
+`e6b8fb06` · [`assets/screenshots/gta5-title.png`](assets/screenshots/gta5-title.png)
+
+### blasphemous2-title.png
+
+<p align="center"><img src="assets/screenshots/blasphemous2-title.png" alt="blasphemous2 title"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/blasphemous2-title.png`](assets/screenshots/blasphemous2-title.png)
+
+### blasphemous2.png
+
+<p align="center"><img src="assets/screenshots/blasphemous2.png" alt="blasphemous2"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/blasphemous2.png`](assets/screenshots/blasphemous2.png)
+
+### dead-cells-title.png
+
+<p align="center"><img src="assets/screenshots/dead-cells-title.png" alt="dead cells title"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/dead-cells-title.png`](assets/screenshots/dead-cells-title.png)
+
+### dead-cells.png
+
+<p align="center"><img src="assets/screenshots/dead-cells.png" alt="dead cells"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/dead-cells.png`](assets/screenshots/dead-cells.png)
+
+### evergate-title.png
+
+<p align="center"><img src="assets/screenshots/evergate-title.png" alt="evergate title"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/evergate-title.png`](assets/screenshots/evergate-title.png)
+
+### evergate.png
+
+<p align="center"><img src="assets/screenshots/evergate.png" alt="evergate"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/evergate.png`](assets/screenshots/evergate.png)
+
+### messenger-title.png
+
+<p align="center"><img src="assets/screenshots/messenger-title.png" alt="messenger title"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/messenger-title.png`](assets/screenshots/messenger-title.png)
+
+### messenger.png
+
+<p align="center"><img src="assets/screenshots/messenger.png" alt="messenger"></p>
+
+docs: refresh public README + COMPATIBILITY with screenshots and current status
+
+`958979f6` · [`assets/screenshots/messenger.png`](assets/screenshots/messenger.png)
+
+## 2026-07-19
+
+### issue-897-astrobot-linux-natural-opening-midfade.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-midfade.png" alt="issue 897 astrobot linux natural opening midfade"></p>
+
+docs(astrobot): attach natural Linux graphics captures
+
+`2a09b44d` · [`prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-midfade.png`](prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-midfade.png)
+
+### issue-897-astrobot-linux-natural-opening-visible.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-visible.png" alt="issue 897 astrobot linux natural opening visible"></p>
+
+docs(astrobot): attach natural Linux graphics captures
+
+`2a09b44d` · [`prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-visible.png`](prosper/docs/screenshots/issue-897-astrobot-linux-natural-opening-visible.png)
+
+## 2026-07-18
+
+### issue-825-astrobot-windows-sony-presents.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-825-astrobot-windows-sony-presents.png" alt="issue 825 astrobot windows sony presents"></p>
+
+docs(astrobot): attach Windows progress captures
+
+`815a84b2` · [`prosper/docs/screenshots/issue-825-astrobot-windows-sony-presents.png`](prosper/docs/screenshots/issue-825-astrobot-windows-sony-presents.png)
+
+### issue-825-astrobot-windows-title.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-825-astrobot-windows-title.png" alt="issue 825 astrobot windows title"></p>
+
+docs(astrobot): attach Windows progress captures
+
+`815a84b2` · [`prosper/docs/screenshots/issue-825-astrobot-windows-title.png`](prosper/docs/screenshots/issue-825-astrobot-windows-title.png)
+
+## 2026-07-17
+
+### issue-825-astrobot-linux-sony-presents.png
+
+<p align="center"><img src="prosper/docs/screenshots/issue-825-astrobot-linux-sony-presents.png" alt="issue 825 astrobot linux sony presents"></p>
+
+docs(astrobot): attach Linux loading screenshot
+
+`a1395e75` · [`prosper/docs/screenshots/issue-825-astrobot-linux-sony-presents.png`](prosper/docs/screenshots/issue-825-astrobot-linux-sony-presents.png)

--- a/prosper/tools/docs/gen_screenshot_feed.py
+++ b/prosper/tools/docs/gen_screenshot_feed.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""gen_screenshot_feed.py -- build SCREENSHOTS.md, every checked-in screenshot newest-first.
+
+WHY THIS EXISTS. Progress on this project is visual, and the visual record was spread across
+COMPATIBILITY.md's per-title sections and 39 tracker issues. Finding "what is new since I last
+looked" meant scrolling a 500-line chart and diffing it against memory. This file answers that
+question directly: open it, read down from the top, stop when you reach something you have seen.
+
+IT IS GENERATED. Do not hand-edit it -- edits are overwritten. There is nothing to maintain and
+therefore nothing to forget: the ordering and the captions come from git history, so an image is
+in the feed the moment its commit lands and it can never disagree with the tree.
+
+    python3 prosper/tools/docs/gen_screenshot_feed.py           # rewrite SCREENSHOTS.md
+    python3 prosper/tools/docs/gen_screenshot_feed.py --check   # fail if it is stale
+    python3 prosper/tools/docs/gen_screenshot_feed.py --selftest # prove the generator discriminates
+
+FAILURE MODE THIS IS BUILT AGAINST, because it is the one that would make the file worse than
+useless: an image that is present in the tree but missing from the feed. A feed that silently
+drops entries is read as "nothing new happened", which is exactly the wrong conclusion and is
+indistinguishable from the truth. So every image in the tree MUST resolve to an add-commit, and
+the tool ABORTS naming the offenders rather than emitting a partial file.
+
+That is not hypothetical. The obvious implementation --
+
+    git log --diff-filter=A --follow -- <path>          # WRONG
+
+-- returns EMPTY for recently added files (measured 2026-08-20 on two images added that day, both
+of which the non-follow query dates correctly). `--follow` is for tracking a path across renames
+and does not compose reliably with `--diff-filter=A`. Using it would have silently omitted the
+NEWEST entries -- the only ones anybody opens this file to see. The scan below is a single
+`--diff-filter=A --name-only` pass over the whole history instead: no per-file queries, no
+`--follow`, and O(1) git invocations rather than O(images).
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import subprocess
+import sys
+from collections import defaultdict
+
+OUT = "SCREENSHOTS.md"
+# Directories scanned, in the order their images are attributed. `assets/screenshots` is the
+# user-facing compatibility gallery; `prosper/docs/screenshots` is issue-specific evidence.
+DIRS = ("assets/screenshots", "prosper/docs/screenshots")
+EXTS = (".png", ".jpg", ".jpeg")
+
+BANNER = """<!--
+    GENERATED FILE -- DO NOT EDIT BY HAND.
+    Produced by prosper/tools/docs/gen_screenshot_feed.py from git history.
+    Regenerate with:  python3 prosper/tools/docs/gen_screenshot_feed.py
+    CI regenerates this file and fails if it differs from the committed copy.
+-->"""
+
+
+def run(args: list[str], repo: pathlib.Path) -> str:
+    out = subprocess.run(
+        ["git", "-C", str(repo)] + args,
+        capture_output=True, text=True, check=True,
+    )
+    return out.stdout
+
+
+def tracked_images(repo: pathlib.Path, ref: str) -> set[str]:
+    listing = run(["ls-tree", "-r", "--name-only", ref] + list(DIRS), repo)
+    return {
+        line for line in listing.splitlines()
+        if line.lower().endswith(EXTS)
+    }
+
+
+def add_events(repo: pathlib.Path, ref: str) -> dict[str, tuple[int, str, str, str]]:
+    """path -> (unix_time, iso_date, short_sha, subject) for the commit that ADDED it.
+
+    One pass over history. A path can legitimately appear more than once (added, deleted,
+    re-added); the LATEST addition wins, because that is the event a reader is looking for.
+    """
+    log = run([
+        "log", ref, "--diff-filter=A", "--name-only", "--date=short",
+        "--format=%x00%at%x00%ad%x00%h%x00%s", "--"] + list(DIRS), repo)
+
+    found: dict[str, tuple[int, str, str, str]] = {}
+    meta: tuple[int, str, str, str] | None = None
+    for line in log.splitlines():
+        if line.startswith("\x00"):
+            _, at, ad, sha, subject = line.split("\x00", 4)
+            meta = (int(at), ad, sha, subject)
+            continue
+        if not line or meta is None:
+            continue
+        if line.lower().endswith(EXTS):
+            # `git log` walks newest-first, so the first sighting is the latest addition.
+            found.setdefault(line, meta)
+    return found
+
+
+def build(repo: pathlib.Path, ref: str) -> str:
+    images = tracked_images(repo, ref)
+    events = add_events(repo, ref)
+
+    # The load-bearing check. An image in the tree with no add-commit would be silently dropped,
+    # and a feed that drops entries reads as "nothing new" -- the one wrong answer that looks fine.
+    undated = sorted(images - events.keys())
+    if undated:
+        raise SystemExit(
+            "error: {} image(s) in the tree have no add-commit, so the feed would be "
+            "INCOMPLETE:\n  {}\nRefusing to write a partial file.".format(
+                len(undated), "\n  ".join(undated)))
+
+    by_date: dict[str, list[tuple[int, str, str, str, str]]] = defaultdict(list)
+    for path in sorted(images):
+        at, ad, sha, subject = events[path]
+        by_date[ad].append((at, path, sha, subject, ad))
+
+    total = len(images)
+    dates = sorted(by_date, reverse=True)
+    newest = dates[0] if dates else "never"
+
+    out: list[str] = [
+        "# Screenshots — newest first",
+        "",
+        BANNER,
+        "",
+        "**Every screenshot checked into this repository, most recent first.** Read down from the "
+        "top and stop when you reach one you have already seen.",
+        "",
+        f"**{total} images**, most recent **{newest}**. Captions are the subject line of the commit "
+        "that added each image, so they say what the change was rather than what the picture is.",
+        "",
+        "This file is generated from git history by "
+        "[`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) "
+        "and is regenerated and diffed in CI, so it cannot drift from the tree. "
+        "[`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and "
+        "[`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a "
+        "reverse-chronological index of the images themselves.",
+        "",
+        "> A screenshot here is evidence of what rendered on the day its commit landed. It is not",
+        "> a claim about the title's current state — for that, read the tracker. An image is never",
+        "> removed from this feed when a title moves on, because the point of a feed is that it is",
+        "> a record of *when* things happened.",
+        "",
+    ]
+
+    for date in dates:
+        entries = sorted(by_date[date], key=lambda e: (-e[0], e[1]))
+        out.append(f"## {date}")
+        out.append("")
+        for _at, path, sha, subject, _ad in entries:
+            name = pathlib.PurePosixPath(path).name
+            out.append(f"### {name}")
+            out.append("")
+            label = pathlib.PurePosixPath(path).stem.replace("-", " ").replace("_", " ")
+            out.append(f'<p align="center"><img src="{path}" alt="{label}"></p>')
+            out.append("")
+            # Two-space Markdown hard breaks are trailing whitespace, which `git diff --check`
+            # rejects repo-wide. Separate paragraphs instead -- same rendering, no whitespace.
+            out.append(subject)
+            out.append("")
+            out.append(f"`{sha}` · [`{path}`]({path})")
+            out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def selftest() -> int:
+    """Prove the tool discriminates, rather than merely running.
+
+    The property that matters is the abort on an undated image. A generator that emitted a
+    partial file on missing metadata would fail exactly the way this feed must never fail, so
+    the selftest asserts BOTH verdicts: a complete input builds, an incomplete one raises.
+    """
+    import types
+
+    def fake(images, events):
+        mod = types.SimpleNamespace()
+        mod.tracked = lambda *a: images
+        mod.evts = lambda *a: events
+        return mod
+
+    ok_images = {"assets/screenshots/a.png"}
+    ok_events = {"assets/screenshots/a.png": (1, "2026-01-01", "abc1234", "feat: a")}
+
+    g_tracked, g_add = globals()["tracked_images"], globals()["add_events"]
+    failures = []
+    try:
+        globals()["tracked_images"] = lambda *a: ok_images
+        globals()["add_events"] = lambda *a: ok_events
+        text = build(pathlib.Path("."), "HEAD")
+        if "a.png" not in text:
+            failures.append("complete input did not render its image")
+
+        # The violating arm: an image with no add-commit must ABORT, not emit a partial file.
+        globals()["tracked_images"] = lambda *a: ok_images | {"assets/screenshots/orphan.png"}
+        try:
+            build(pathlib.Path("."), "HEAD")
+            failures.append("an undated image did NOT abort -- the feed would silently omit it")
+        except SystemExit as exc:
+            if "orphan.png" not in str(exc):
+                failures.append("abort message does not name the offending image")
+    finally:
+        globals()["tracked_images"], globals()["add_events"] = g_tracked, g_add
+
+    for f in failures:
+        print(f"selftest FAIL: {f}", file=sys.stderr)
+    print(f"selftest: 2 arms, {len(failures)} failure(s)")
+    return 1 if failures else 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--repo", default=None, help="repository root (default: infer from this file)")
+    ap.add_argument("--ref", default="HEAD", help="git ref to read the tree and history from")
+    ap.add_argument("--check", action="store_true", help="exit non-zero if the file is stale")
+    ap.add_argument("--selftest", action="store_true", help="assert the generator still discriminates")
+    args = ap.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    repo = pathlib.Path(args.repo) if args.repo else pathlib.Path(__file__).resolve().parents[3]
+    text = build(repo, args.ref)
+    target = repo / OUT
+
+    n = text.count("\n### ")
+    if args.check:
+        current = target.read_text() if target.exists() else ""
+        if current != text:
+            print(
+                f"error: {OUT} is STALE -- it does not match the images in the tree.\n"
+                f"       Fix: python3 prosper/tools/docs/gen_screenshot_feed.py\n"
+                f"       then commit the result.", file=sys.stderr)
+            print(f"{n} image(s) scanned", file=sys.stderr)
+            return 1
+        print(f"{OUT} is up to date with the tree ({n} images).")
+        return 0
+
+    target.write_text(text)
+    print(f"{n} image(s) scanned")
+    print(f"wrote {target}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
docs: SCREENSHOTS.md — every screenshot, newest first, generated from git history

Progress on this project is visual, but the visual record was spread across
COMPATIBILITY.md's per-title sections and 39 tracker issues. Answering "what is new
since I last looked" meant scrolling a 500-line chart and diffing it against memory.
This file answers it directly: open it, read down from the top, stop at one you have
already seen. 136 images today.

GENERATED, not hand-maintained, and that is the point. Ordering and captions come from
git history, so an image is in the feed the moment its commit lands and the file cannot
disagree with the tree. There is nothing to remember to update. CI regenerates and diffs
it, so it cannot drift.

  prosper/tools/docs/gen_screenshot_feed.py            # rewrite
  prosper/tools/docs/gen_screenshot_feed.py --check    # fail if stale
  prosper/tools/docs/gen_screenshot_feed.py --selftest # prove it discriminates

The failure mode this is built against, because it would make the file worse than
useless: an image present in the tree but missing from the feed. A feed that silently
drops entries reads as "nothing new happened" -- the one wrong answer indistinguishable
from the truth. So every tracked image MUST resolve to an add-commit and the tool aborts
naming the offenders rather than emitting a partial file.

That is not hypothetical. The obvious implementation is

    git log --diff-filter=A --follow -- <path>

and it returns EMPTY for recently added files -- measured on the two gameplay images
added the same day this was written, both of which the non-follow query dates correctly.
--follow is for tracking a path across renames and does not compose reliably with
--diff-filter=A. It would have silently omitted the NEWEST entries: the only ones anyone
opens this file to see. The scan is a single --diff-filter=A --name-only pass instead,
O(1) git invocations rather than O(images).

CI wiring, two steps in the Docs job:
  - --selftest, run separately (a pipeline's exit status is its last stage's). Two arms,
    both verdicts asserted: a complete input renders, an undated image ABORTS.
  - --check against origin/master. The feed describes master and is regenerated after a
    screenshot merge, so checking against master makes both sides agree on an unmerged PR
    branch. The Docs job checks out at fetch-depth 2 (load-bearing for the numbering
    gate), far too shallow for a history scan, so the step deepens with --filter=blob:none
    -- commit metadata without file contents, which is all this tool reads.

Verified the gate can actually fail: injecting one line into SCREENSHOTS.md makes --check
exit 1 naming the fix; restoring it returns 0. A gate that cannot fail is void.

Also fixed while building it: the caption used Markdown's two-trailing-space hard break,
which git diff --check rejects repo-wide. Paragraphs instead -- same rendering, no
whitespace. Pointers added from COMPATIBILITY.md and README.md so the file is findable.

Gates: selftest 2 arms / 0 failures; --check exits 0 against origin/master; all tracked
.md files unbroken; git diff --check clean; ASCII gate passes; ci.yml parses as YAML.