### PR TITLE
diag(gpu): name why a selected descriptor table is declined, and stop declining one for a record that cannot be a descriptor

### DIFF
--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5845,6 +5845,15 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
         }
         if (u.kind != 1) continue;
         if (u.table_record_count) {
+            // PROSPER_SRTTABLE_LOG=1 -- report why a runtime-selected descriptor table was declined.
+            // The three decline paths below already logged, but only under PROSPER_DBG, which this
+            // project records as producing a ~1.5 GB log and desyncing the pad script badly enough
+            // that the route never reaches the phase being diagnosed. A diagnostic reachable only by
+            // a switch that destroys the repro is not reachable -- the same reasoning that ungated
+            // the `[compute-table]` block in this file. This switch costs nothing when unset and is
+            // bounded by the table count, not by the dispatch count.
+            const bool table_log =
+                std::getenv("PROSPER_SRTTABLE_LOG") || std::getenv("PROSPER_DBG");
             // #2481: a runtime-selected descriptor table. The element is chosen on the GPU, so the
             // binding declares every entry and the emitter indexes it. Re-derive the whole contract
             // from guest memory here rather than trusting the use: a forged SrtUse must not be able
@@ -5856,8 +5865,19 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 u.table_record_count > kMaxSelectedTableRecords ||
                 static_cast<uint64_t>(u.table_element_offset) + 16u > u.table_entry_stride ||
                 (u.table_element_offset % 4u) != 0u || u.table_base <= 0x10000u ||
-                u.table_load_pc == 0xFFFFFFFFu || u.table_load_pc >= dwords)
+                u.table_load_pc == 0xFFFFFFFFu || u.table_load_pc >= dwords) {
+                // Previously a silent `continue`, which is indistinguishable from the table never
+                // having been published at all -- the two have completely different causes and the
+                // log could not tell them apart.
+                if (table_log)
+                    std::fprintf(stderr,
+                                 "[srt] selected-table pc=%u REJECTED shape fmt=%u zero_record=%d "
+                                 "stride=%u records=%u element=%u base=0x%llx load_pc=%u dwords=%zu\n",
+                                 u.use_pc, u.instruction_format, (int)u.zero_record_raw,
+                                 u.table_entry_stride, u.table_record_count, u.table_element_offset,
+                                 (unsigned long long)u.table_base, u.table_load_pc, dwords);
                 continue;
+            }
             // Every element must be a readable, individually valid V#. One malformed entry rejects
             // the whole table: binding a partially populated descriptor array would let the guest's
             // own index select a slot prosper never resolved, which renders confidently wrong
@@ -5893,7 +5913,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 // inversion as the unsupported case below, one category over, so it declines the
                 // whole table exactly as it did before this change.
                 if (!guest_readable(entry_addr, static_cast<uint32_t>(sizeof(words)))) {
-                    if (std::getenv("PROSPER_DBG"))
+                    if (table_log)
                         std::fprintf(stderr,
                                      "[srt] selected-table pc=%u REJECTED unreadable-record "
                                      "index=%u addr=0x%llx\n",
@@ -5907,14 +5927,28 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 entry = decode_buffer_descriptor(words.data());
                 // Only a record we READ and that does not look like a descriptor at all may be
                 // nulled: a stale arena slot the guest never indexes.
-                const bool not_a_descriptor = entry.base <= 0x10000u || entry.size_bytes == 0u;
+                // A record whose BASE IS NOT MAPPED cannot be a descriptor the guest would select:
+                // selecting it would fault on first access. It is a stale arena slot, which is
+                // exactly the case this classification exists to null. Without this test the
+                // heuristic is `base > 0x10000 && size != 0`, which ordinary float data passes
+                // trivially -- measured on PPSA04263, `0x413ce6000` pc=156 declines its whole table
+                // on records like `base=0x4d0cbd9054e2 size=4294967295`, an 85 TiB address that is
+                // plainly not a descriptor. Declining the table there converts a nullable stale slot
+                // into a rejected program (#2481).
+                //
+                // Only the FIRST dword pair is probed, not the whole span: a descriptor's declared
+                // size may legitimately exceed what is currently resident, and requiring the entire
+                // range to be mapped would decline real tables.
+                const bool base_mapped = guest_readable(entry.base, 4u);
+                const bool not_a_descriptor =
+                    entry.base <= 0x10000u || entry.size_bytes == 0u || !base_mapped;
                 const bool unsupported_descriptor = !not_a_descriptor &&
                     (entry.size_bytes > 0x10000000u || entry.forbid_unknown_fallback);
                 if (unsupported_descriptor) {
                     // Decline the WHOLE table, as before this change. A >256 MiB buffer or an
                     // unrepresentable DST_SEL / USCALED-SSCALED 2_10_10_10 is a descriptor the guest
                     // may well select.
-                    if (std::getenv("PROSPER_DBG"))
+                    if (table_log)
                         std::fprintf(stderr,
                                      "[srt] selected-table pc=%u REJECTED unsupported-record "
                                      "index=%u base=0x%llx size=%u fallback=%d\n",
@@ -5924,11 +5958,14 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                     break;
                 }
                 const bool usable = !not_a_descriptor;
-                if (!usable && std::getenv("PROSPER_DBG"))
+                if (!usable && table_log)
                     std::fprintf(stderr,
-                                 "[srt] selected-table pc=%u NULL-SLOT index=%u "
+                                 "[srt] selected-table pc=%u NULL-SLOT index=%u why=%s "
                                  "words=%08x:%08x:%08x:%08x\n",
-                                 u.use_pc, index, words[0], words[1], words[2], words[3]);
+                                 u.use_pc, index,
+                                 entry.base <= 0x10000u ? "low-base"
+                                     : entry.size_bytes == 0u ? "zero-size" : "base-unmapped",
+                                 words[0], words[1], words[2], words[3]);
                 ShaderBufferTableEntry slot;
                 if (usable) {
                     slot.vsharp = words;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5857,6 +5857,11 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             // of distinct tables. Measured on a 500 s routed GTA V route: 138 lines. That is small
             // because few programs use the path, not because anything bounds it -- a title that used
             // it widely would produce far more.
+            //
+            // EVERY report in this block is routed through it, including the SUCCESS line -- not
+            // only the declines. A switch that speaks solely on failure cannot distinguish "this
+            // table was accepted" from "this table was never published", which is the same
+            // silent-`continue` ambiguity that motivated the switch in the first place.
             const bool table_log =
                 std::getenv("PROSPER_SRTTABLE_LOG") || std::getenv("PROSPER_DBG");
             // #2481: a runtime-selected descriptor table. The element is chosen on the GPU, so the
@@ -5986,7 +5991,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             }
             if (unsupported_record) continue;
             if (resolved == 0u) {
-                if (std::getenv("PROSPER_DBG"))
+                if (table_log)
                     std::fprintf(stderr,
                                  "[srt] selected-table pc=%u REJECTED base=0x%llx stride=%u "
                                  "records=%u resolved=%u\n",
@@ -6017,7 +6022,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             }
             homogeneous &= have_first;
             if (!homogeneous) {
-                if (std::getenv("PROSPER_DBG"))
+                if (table_log)
                     std::fprintf(stderr,
                                  "[srt] selected-table pc=%u REJECTED heterogeneous entries\n",
                                  u.use_pc);
@@ -6047,14 +6052,14 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             // Failing to publish costs exactly what the previous behaviour cost: an unresolved
             // descriptor at the consumer, fail-visible.
             if (!valid_shader_buffer_table_contract(r)) {
-                if (std::getenv("PROSPER_DBG"))
+                if (table_log)
                     std::fprintf(stderr,
                                  "[srt] selected-table pc=%u REJECTED contract stride=%u fmt=%u "
                                  "comps=%u\n",
                                  u.use_pc, r.stride, (unsigned)r.format, r.num_components);
                 continue;
             }
-            if (std::getenv("PROSPER_DBG"))
+            if (table_log)
                 std::fprintf(stderr,
                              "[srt] selected-table pc=%u producer=%u base=0x%llx stride=%u "
                              "records=%u resolved=%u element=+0x%x\n",

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5850,8 +5850,13 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
             // project records as producing a ~1.5 GB log and desyncing the pad script badly enough
             // that the route never reaches the phase being diagnosed. A diagnostic reachable only by
             // a switch that destroys the repro is not reachable -- the same reasoning that ungated
-            // the `[compute-table]` block in this file. This switch costs nothing when unset and is
-            // bounded by the table count, not by the dispatch count.
+            // the `[compute-table]` block in this file.
+            //
+            // Volume, stated correctly: `realize_compute_dispatches` reaches this PER DISPATCH, so
+            // the output scales with dispatches that publish a selected table, not with the number
+            // of distinct tables. Measured on a 500 s routed GTA V route: 138 lines. That is small
+            // because few programs use the path, not because anything bounds it -- a title that used
+            // it widely would produce far more.
             const bool table_log =
                 std::getenv("PROSPER_SRTTABLE_LOG") || std::getenv("PROSPER_DBG");
             // #2481: a runtime-selected descriptor table. The element is chosen on the GPU, so the
@@ -5927,21 +5932,25 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 entry = decode_buffer_descriptor(words.data());
                 // Only a record we READ and that does not look like a descriptor at all may be
                 // nulled: a stale arena slot the guest never indexes.
-                // A record whose BASE IS NOT MAPPED cannot be a descriptor the guest would select:
-                // selecting it would fault on first access. It is a stale arena slot, which is
-                // exactly the case this classification exists to null. Without this test the
-                // heuristic is `base > 0x10000 && size != 0`, which ordinary float data passes
-                // trivially -- measured on PPSA04263, `0x413ce6000` pc=156 declines its whole table
-                // on records like `base=0x4d0cbd9054e2 size=4294967295`, an 85 TiB address that is
-                // plainly not a descriptor. Declining the table there converts a nullable stale slot
-                // into a rejected program (#2481).
+                // DO NOT add a `guest_readable(entry.base, …)` term here. It looks obviously right
+                // -- a record whose base is unmapped cannot be a descriptor, because selecting it
+                // would fault -- and it is WRONG on this platform, in two independent ways:
                 //
-                // Only the FIRST dword pair is probed, not the whole span: a descriptor's declared
-                // size may legitimately exceed what is currently resident, and requiring the entire
-                // range to be mapped would decline real tables.
-                const bool base_mapped = guest_readable(entry.base, 4u);
-                const bool not_a_descriptor =
-                    entry.base <= 0x10000u || entry.size_bytes == 0u || !base_mapped;
+                //  * `exec_image_linux.cpp`'s SIGSEGV handler maps a fresh RW page for ANY unmapped
+                //    SEGV_MAPERR in [GPU_VA_LO, GPU_VA_HI) = [4 GiB, 64 GiB), unconditionally and
+                //    not env-gated. Faulting is the TRIGGER FOR LAZY BACKING, not evidence of
+                //    invalidity -- and `0x413ce6000`, the program that motivated the idea, sits
+                //    inside that window at ~16.3 GiB.
+                //  * `guest_readable` cannot see through that anyway: its Linux arm probes with a
+                //    `write()` to a pipe, so the kernel returns EFAULT via copy_from_user and no
+                //    SIGSEGV is ever delivered to the process. The probe reports "unmapped" for an
+                //    address the guest can legitimately touch.
+                //
+                // Page RESIDENCY is not the oracle; region IDENTITY is. `prosper_reserved_range_state`
+                // exists on both platforms for that. Whatever replaces this needs a mutation arm too:
+                // the existing coverage in `test_dynfetch_fold.cpp` builds its garbage with `base = 0`,
+                // so a residency term can be deleted with the whole suite still green (#2481).
+                const bool not_a_descriptor = entry.base <= 0x10000u || entry.size_bytes == 0u;
                 const bool unsupported_descriptor = !not_a_descriptor &&
                     (entry.size_bytes > 0x10000000u || entry.forbid_unknown_fallback);
                 if (unsupported_descriptor) {
@@ -5963,8 +5972,7 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                                  "[srt] selected-table pc=%u NULL-SLOT index=%u why=%s "
                                  "words=%08x:%08x:%08x:%08x\n",
                                  u.use_pc, index,
-                                 entry.base <= 0x10000u ? "low-base"
-                                     : entry.size_bytes == 0u ? "zero-size" : "base-unmapped",
+                                 entry.base <= 0x10000u ? "low-base" : "zero-size",
                                  words[0], words[1], words[2], words[3]);
                 ShaderBufferTableEntry slot;
                 if (usable) {


### PR DESCRIPTION
**Scope reduced to the diagnostic.** The classification change is reverted — review refuted its
soundness argument using prosper's own source, and was right.

*(The branch name is stale: it says `x16-descriptor-keys`, from a hypothesis withdrawn on #2757
before any code was written. This has nothing to do with x16 keying.)*

## What lands: `PROSPER_SRTTABLE_LOG`

Reports why a runtime-selected descriptor table (#2481) was declined.

The three decline paths already logged, but only under `PROSPER_DBG` — which this project records as
producing a ~1.5 GB log and desyncing the pad script so badly *the route never reaches the phase
being diagnosed*. That is the same "a diagnostic reachable only by a switch that destroys the repro
is not reachable" problem that got the `[compute-table]` block ungated in this file.

The early shape guard previously `continue`d **silently** — indistinguishable in a log from the table
never having been published at all, two entirely different causes. It now reports its fields.

**No behaviour is gated behind the switch**; it guards printers only.

It already earned its keep: it is what produced the measurement below, and what made the reverted
change's premise checkable in the first place.

```
[srt] selected-table pc=156 REJECTED unsupported-record index=0 base=0x4d0cbd9054e2 size=4294967295
[srt] selected-table pc=156 NULL-SLOT index=2 why=zero-size words=...
```

## What is reverted, and why — worth reading before anyone retries it

I classified a record whose base fails `guest_readable` as not-a-descriptor, arguing that selecting
it would fault. **That is backwards on this platform:**

- `exec_image_linux.cpp`'s SIGSEGV handler maps a fresh RW page for **any** unmapped `SEGV_MAPERR` in
  `[GPU_VA_LO, GPU_VA_HI)` = **[4 GiB, 64 GiB)**, unconditionally and not env-gated. Faulting is the
  *trigger for lazy backing*, not evidence of invalidity — and `0x413ce6000`, the program that
  motivated the change, sits **inside** that window at ~16.3 GiB.
- `guest_readable` could not see through it regardless: its Linux arm probes with `write()` to a pipe,
  so the kernel returns `EFAULT` from `copy_from_user` and **no SIGSEGV is ever delivered**. It
  reports "unmapped" for addresses the guest can legitimately touch.

Two further findings I accept without argument: the change gave `guest_readable` **opposite epistemic
weight thirty lines apart**, and it removed the fail-visible decline for the >256 MiB / bad-`DST_SEL`
case whenever a base merely was not resident — which the adjacent comment explicitly calls dangerous.

**And the test point is the one that should not have needed a reviewer.** There was none.
`test_dynfetch_fold.cpp` builds its garbage with `base = 0`, so **deleting the predicate leaves all
284 tests passing** — I reported that green run as verification when it was blind to the change.

The refutation is recorded **in the code where the wrong idea was**, so the next reader meets it
rather than the idea, together with the path forward: region **identity** via
`prosper_reserved_range_state`, not page residency, plus a mutation arm.

## Also corrected

The comment claimed the switch is "bounded by the table count, not by the dispatch count". False —
`realize_compute_dispatches` reaches it per dispatch. The 138 lines measured on a 500 s route are
small because few programs use the path, not because anything bounds it.

## Verification

```
cmake --build prosper/build-linux -j6                        BUILD=0
ctest --test-dir prosper/build-linux --no-tests=error -j6    CTEST=0, 284/284 passed
python3 prosper/tools/env/check_diag_gates.py                104 findings / 104 baselined
```

Four skips (`module_loads_eboot`, `plugin_autolink`, `boot_reaches_first_syscall`,
`real_shader_render`) for a non-`PPSA24651` `GAME_DUMP` — note that is four, where the charter
documents three.

**This does not fix GTA V's missing world and is not offered as doing so.**

Refs #2481, #2412, #2757.
