### PR TITLE
docs: regenerate SCREENSHOTS.md after the Dragon Quest VII merge

### DIFF
--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -9,7 +9,7 @@
 
 **Every screenshot checked into this repository, most recent first.** Read down from the top and stop when you reach one you have already seen.
 
-**136 images**, most recent **2026-08-20**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
+**137 images**, most recent **2026-08-20**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
 
 This file is generated from git history by [`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) and is regenerated and diffed in CI, so it cannot drift from the tree. [`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a reverse-chronological index of the images themselves.
 
@@ -19,6 +19,14 @@ This file is generated from git history by [`prosper/tools/docs/gen_screenshot_f
 > a record of *when* things happened.
 
 ## 2026-08-20
+
+### dragon-quest-vii-opening-chapter.png
+
+<p align="center"><img src="assets/screenshots/dragon-quest-vii-opening-chapter.png" alt="dragon quest vii opening chapter"></p>
+
+feat(dq7): the route reaches the opening chapter in Estard, and Unreal titles get an IoStore package oracle (#2779)
+
+`0ea7868c` · [`assets/screenshots/dragon-quest-vii-opening-chapter.png`](assets/screenshots/dragon-quest-vii-opening-chapter.png)
 
 ### bendy-dark-revival-gameplay.png
 


### PR DESCRIPTION
docs: regenerate SCREENSHOTS.md after the Dragon Quest VII merge

#2779 added assets/screenshots/dragon-quest-vii-opening-chapter.png, so the generated feed
went stale the moment it merged: 136 -> 137 images.

This is the designed workflow, not an oversight. A PR cannot correctly include its own feed
entry, because the caption and hash come from the commit that ADDS the image and squash-merge
creates that commit -- anything generated on the branch would be wrong by the time it landed.
So the feed is regenerated after a merge. The check exits 1 beforehand and 0 after, which is
the gate doing its job rather than a failure.

Verified in both directions rather than assumed:
  --check before regeneration -> exit 1
  --check after               -> exit 0, 137 images

The new entry sits at the top under 2026-08-20, captioned with #2779's subject, which states
what the change was: the route reaches the opening chapter in Estard and Unreal titles get an
IoStore package oracle. The image shows the Estard coast rendering from the guest's own
command stream -- real engine output with a severely degraded composite, not gameplay. The
chart row and the tracker carry that distinction; the feed is only a chronological index.