### PR TITLE
fix(gpu): an all-ones NUM_RECORDS is a stale arena slot, not a 4 GiB buffer — null the slot, keep the table

### DIFF
--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5955,7 +5955,21 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 // exists on both platforms for that. Whatever replaces this needs a mutation arm too:
                 // the existing coverage in `test_dynfetch_fold.cpp` builds its garbage with `base = 0`,
                 // so a residency term can be deleted with the whole suite still green (#2481).
-                const bool not_a_descriptor = entry.base <= 0x10000u || entry.size_bytes == 0u;
+                // `size_bytes == 0xFFFFFFFF` is the all-ones word, not an allocation. It is what
+                // random data reads as, and it cannot be a buffer the guest selects: measured over a
+                // routed PPSA04263 route, the 359 descriptors prosper actually resolved and bound
+                // top out at 66,355,200 bytes -- 24.7% of the 256 MiB cap below -- while every
+                // offending record was either this exact pattern or ~996 MiB. So this is nulled as a
+                // stale slot rather than declining the whole table (#2481).
+                //
+                // Deliberately the EXACT pattern, not a threshold. The >256 MiB case below keeps
+                // declining, because "large" really can be a descriptor the guest selects and the
+                // fail-visible path must survive for it; 0xFFFFFFFF cannot, being 4 GiB - 1 exactly.
+                // This tests the BYTES, which is why it works identically live, offline and in a
+                // fixture -- unlike page residency and region identity, both falsified on #2481.
+                const bool all_ones_record = entry.size_bytes == 0xFFFFFFFFu;
+                const bool not_a_descriptor =
+                    entry.base <= 0x10000u || entry.size_bytes == 0u || all_ones_record;
                 const bool unsupported_descriptor = !not_a_descriptor &&
                     (entry.size_bytes > 0x10000000u || entry.forbid_unknown_fallback);
                 if (unsupported_descriptor) {
@@ -5977,7 +5991,8 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                                  "[srt] selected-table pc=%u NULL-SLOT index=%u why=%s "
                                  "words=%08x:%08x:%08x:%08x\n",
                                  u.use_pc, index,
-                                 entry.base <= 0x10000u ? "low-base" : "zero-size",
+                                 entry.base <= 0x10000u ? "low-base"
+                                     : entry.size_bytes == 0u ? "zero-size" : "all-ones-size",
                                  words[0], words[1], words[2], words[3]);
                 ShaderBufferTableEntry slot;
                 if (usable) {

--- a/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
+++ b/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
@@ -2738,6 +2738,81 @@ int main() {
               !selected_table_xyz1_spirv.empty(),
           "a three-component DST_SEL still binds its descriptor table for untyped loads");
 
+    // #2481: ONE stale record must null its own slot, not decline the whole table. GTA V reuses a
+    // 600-byte arena allocation for these tables, so a slot the dispatch never indexes routinely
+    // holds ordinary float data -- which reads as `num_records = 0xFFFFFFFF`, i.e. size 4 GiB - 1.
+    // That is the all-ones word, not an allocation, and it cannot be a buffer the guest selects:
+    // over a routed PPSA04263 route the 359 descriptors prosper resolved and bound top out at
+    // 66,355,200 bytes, 24.7% of the >256 MiB cap that still declines.
+    //
+    // Only record 2 is spoiled. The table must still bind with its arity intact -- five entries, so
+    // a runtime index cannot land on a slot that was silently dropped -- with entry 2 nulled and
+    // every other entry byte-identical to the clean case.
+    //
+    // MUTATION: delete `all_ones_record` from `not_a_descriptor` in gpu_executor.cpp and this arm
+    // goes red, because the record then reaches the `size_bytes > 0x10000000` branch and declines the
+    // entire table, leaving `selected_table_stale_resource` null. The pre-existing arms above cannot
+    // detect that -- they build every record well-formed -- which is why this one is here.
+    alignas(16) static uint32_t selected_table_stale[5][30]{};
+    std::memcpy(selected_table_stale, selected_table_records, sizeof(selected_table_records));
+    selected_table_stale[2][4] = 0xffffffffu;          // NUM_RECORDS all ones -> stale arena slot
+    const uint64_t selected_table_stale_base = reinterpret_cast<uint64_t>(selected_table_stale);
+    uint32_t selected_table_stale_seed[16]{};
+    std::memcpy(selected_table_stale_seed, selected_table_seed, sizeof(selected_table_seed));
+    selected_table_stale_seed[0] = static_cast<uint32_t>(selected_table_stale_base);
+    selected_table_stale_seed[1] =
+        (static_cast<uint32_t>(selected_table_stale_base >> 32) & 0xffffu) | (120u << 16);
+    ShaderResourceTable selected_table_stale_rt;
+    add_compute_buffer_resources(
+        selected_table_stale_rt, selected_table_shader.data(), selected_table_shader.size(),
+        selected_table_stale_seed, std::size(selected_table_stale_seed));
+    assign_convention_bindings(selected_table_stale_rt, 2);
+    const ShaderResource* selected_table_stale_resource =
+        selected_table_stale_rt.by_fetch_pc(5u);
+    bool stale_slot_nulled = false, stale_others_intact = false;
+    if (selected_table_stale_resource &&
+        selected_table_stale_resource->table_entries.size() == 5u) {
+        const auto& e = selected_table_stale_resource->table_entries;
+        stale_slot_nulled = e[2].gpu_addr == 0u && e[2].size == 0u;
+        stale_others_intact = true;
+        for (uint32_t entry = 0; entry < 5u; ++entry) {
+            if (entry == 2u) continue;
+            stale_others_intact &=
+                e[entry].gpu_addr == reinterpret_cast<uint64_t>(selected_table_payload[entry]) &&
+                e[entry].size == 64u && e[entry].stride == 16u;
+        }
+    }
+    CHECK(selected_table_stale_resource &&
+              selected_table_stale_resource->table_index_count == 5u &&
+              stale_slot_nulled && stale_others_intact,
+          "one all-ones record nulls its own slot and the table still binds with exact arity");
+
+    // NEGATIVE ARM, and this is the one that stops the change from being "delete the decline". A
+    // record that is genuinely LARGE rather than all-ones must still decline the WHOLE table: a
+    // >256 MiB buffer can be a descriptor the guest selects, so it has to stay fail-visible rather
+    // than becoming a silent null. Same fixture, same shader, one word different from the arm above.
+    alignas(16) static uint32_t selected_table_big[5][30]{};
+    std::memcpy(selected_table_big, selected_table_records, sizeof(selected_table_records));
+    // 0x2000000 records x 16-byte stride = 512 MiB, comfortably over the 256 MiB cap and WITHOUT
+    // overflowing the uint32 size. The first version of this arm used 0x20000000, whose product is
+    // 8 GiB and truncates to exactly 0 in 32 bits -- so the record was nulled as zero-size and the
+    // arm failed. Worth keeping in the comment: a negative arm that constructs an impossible value
+    // tests nothing, and this one caught its own fixture bug.
+    selected_table_big[2][4] = 0x2000000u;
+    const uint64_t selected_table_big_base = reinterpret_cast<uint64_t>(selected_table_big);
+    uint32_t selected_table_big_seed[16]{};
+    std::memcpy(selected_table_big_seed, selected_table_seed, sizeof(selected_table_seed));
+    selected_table_big_seed[0] = static_cast<uint32_t>(selected_table_big_base);
+    selected_table_big_seed[1] =
+        (static_cast<uint32_t>(selected_table_big_base >> 32) & 0xffffu) | (120u << 16);
+    ShaderResourceTable selected_table_big_rt;
+    add_compute_buffer_resources(
+        selected_table_big_rt, selected_table_shader.data(), selected_table_shader.size(),
+        selected_table_big_seed, std::size(selected_table_big_seed));
+    assign_convention_bindings(selected_table_big_rt, 2);
+    CHECK(selected_table_big_rt.by_fetch_pc(5u) == nullptr,
+          "a genuinely oversized record still declines the whole table, fail-visible");
+
     // Same-site mutation: shrink the outer V# so the element at +8 no longer fits inside one
     // record. The selection is then not expressible as an array index and must fail visibly rather
     // than binding a differently-shaped table.


### PR DESCRIPTION
## The defect

*Grand Theft Auto V* reuses a 600-byte arena allocation for its runtime-selected descriptor tables
(#2481), so a slot the dispatch never indexes routinely holds ordinary float data. Decoded as a V#
that yields `num_records = 0xFFFFFFFF` — size 4 GiB − 1 — which trips the `size_bytes > 256 MiB`
branch and **declines the whole table**, turning a nullable stale slot into a rejected program.

The surrounding code already anticipates the shape: *"a stale arena slot the guest never indexes …
GTA V's arena reuses the same 600-byte allocation, so unselected slots have been observed holding
ordinary float data."* It just classifies this particular reading on the wrong side of the line.

## Why `0xFFFFFFFF` is safe to reclassify

Measured over a routed `PPSA04263` route: the **359 descriptors prosper actually resolved and bound
top out at 66,355,200 bytes — 24.7% of the cap.** Nothing legitimate is close to it, and every
offending record was either this exact pattern or ~996 MiB.

**Deliberately the exact pattern, not a lowered threshold.** A genuinely large buffer really can be a
descriptor the guest selects, so `>256 MiB` keeps declining and stays fail-visible. Only 4 GiB − 1
exactly is reclassified.

## Why this oracle, when two others failed

It tests the **bytes**, so it behaves identically live, offline and in a fixture. Both earlier
candidates asked about the emulator instead, and are falsified with evidence on #2481:

| oracle | why it failed |
| --- | --- |
| page residency (`guest_readable`) | `exec_image_linux.cpp` lazily maps any unmapped fault in [4 GiB, 64 GiB), so faulting is the *trigger for backing*, not evidence of invalidity — and the probe uses `write()` to a pipe, which never delivers SIGSEGV anyway (#2780) |
| region identity (`prosper_reserved_range_state`) | depends on live HLE mapping state; applying it turns **this very test** red, because the fixture builds its records in host memory |

## Tests — and this time they can see the change

- **Positive arm**: spoil one record of five. The table must still bind with **arity intact** (so a
  runtime index cannot land on a silently dropped slot), that slot nulled, every other entry
  byte-identical to the clean case.
- **Negative arm**: a genuinely oversized record must still decline the whole table. Without it this
  change is indistinguishable from deleting the decline.
- **Mutation at the production site**: removing `all_ones_record` from `not_a_descriptor` turns
  **exactly one named check** red — the positive arm — while the negative arm stays green under both,
  which is what proves it does not depend on the term.

```
=== MUTANT: all_ones_record term deleted ===
  [FAIL] one all-ones record nulls its own slot and the table still binds with exact arity
== FAIL: 1 ==
=== RESTORED ===
== PASS ==
```

The negative arm caught its own fixture bug on first run: `0x20000000` records × 16-byte stride is
8 GiB, which truncates to exactly **0** in `uint32` and got nulled as zero-size. Recorded in the
test, because an arm that constructs an impossible value tests nothing.

## Measured effect, same binary/route/duration

| | before | after |
| --- | ---: | ---: |
| tables declined `unsupported-record` | 16 | **4** |
| tables publishing | — | **88** |
| `recompile-reject` lines | 10 | **10** |

**Recompile-rejects are unchanged. This admits no previously-rejected program and does not fix the
missing world.** What it does is stop one stale slot from discarding four good descriptors alongside
it.

One number I am deliberately *not* quoting as a delta: the "before" log shows 0 published tables, but
that is an instrument artifact — the success line was only routed through `PROSPER_SRTTABLE_LOG` in
#2780's second commit, after that log was made. The 88 is an absolute for the new build; the 16 → 4
is the like-for-like comparison.

## Verification

```
cmake --build prosper/build-linux -j6                        BUILD=0
ctest --test-dir prosper/build-linux --no-tests=error -j6    CTEST=0, 285/285 passed
python3 prosper/tools/env/check_diag_gates.py                all checks passed
```

Refs #2481, #2412, #2757, #2774.
