### PR TITLE
diag(gpu): report every selected-table record, accepted included — the two-population control three refuted predicates lacked

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -110,6 +110,36 @@ conclusion; it sharpens what "essentially all black" looks like.
 
 ## Ruled out (2026-08-19)
 
+- **Any predicate over `num_records` or `size_bytes` is UNFALSIFIABLE on the `reach-story-mode`
+  route — the run cannot contain a counterexample.** Four successive attempts to classify a
+  runtime-selected descriptor-table record as "not a descriptor" were refuted (#2481): page
+  residency, region identity, saturated size, and a `num_records` threshold drawn from a census.
+  The fourth is the instructive one, because the census *looked* like the two-population control the
+  first three lacked.
+
+  It was not, and the arithmetic shows why. `size_bytes = num_records × stride` with a **14-bit**
+  stride field, and a record is declined at `size_bytes > 256 MiB`. So a size-declined record must
+  carry `num_records ≥ 16,386`, and an accepted one `num_records ≤ 268,435,456` — the only window
+  where **either** label is attainable is `[16386, 268435456]`. Measured over 382 accepted and 54
+  declined records, accepts top out at **668** and declines start at **973 million**: every single
+  record fell *outside* that window. Consequently every threshold in `(668, 973M)` scores an
+  identical `54/54` with `0/382` false positives — 10,000, 65,535, 1 M, 200 M all tie. The scorecard
+  was measuring the decline filter, not the descriptors.
+
+  A `size > 256 MiB` row in the same table is worse still: ACCEPT is only reachable *past* that
+  exact test, so `0/382` there is forced by the source and could never have printed anything else.
+
+  And the threshold dies on a hand-built instance without needing a second title: with `stride == 0`
+  **`NUM_RECORDS` is a BYTE count** (RDNA3 §8.4.1, #2528), so any raw buffer ≥ 64 KiB carries
+  `num_records ≥ 65536` by definition of the field.
+
+  **So: the next proposal must use a field the decline filter does not, or a route that produces
+  records inside `[16386, 268435456]`.** What survives from the census as genuinely empirical is only
+  the accept-side observation that no accepted record exceeded 65535 — accepts were free to, since
+  `stride=16, num_records=1M` is 16 MiB and would be accepted — and that **two** accepted records are
+  legitimately formatless (`stride=112 records=267`), so `fmt == 0` is not a descriptor test either:
+  untyped loads move raw dwords regardless of declared format.
+
 - **`0x205b658800` is NOT the lighting pass.** It is a rejected full-screen 1080p compute in the
   submit whose 4K output is black, which made it an attractive candidate. Its 149 resources reference
   **none** of the surfaces the resolved-chain table names — not `0x20431c0000`, not `0x207de60000`,

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5965,9 +5965,13 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                     if (table_log)
                         std::fprintf(stderr,
                                      "[srt] selected-table pc=%u REJECTED unsupported-record "
-                                     "index=%u base=0x%llx size=%u fallback=%d\n",
+                                     "index=%u base=0x%llx size=%u stride=%u records=%u fmt=%u "
+                                     "comps=%u fallback=%d words=%08x:%08x:%08x:%08x\n",
                                      u.use_pc, index, (unsigned long long)entry.base,
-                                     entry.size_bytes, (int)entry.forbid_unknown_fallback);
+                                     entry.size_bytes, entry.stride, entry.num_records,
+                                     static_cast<unsigned>(entry.format), entry.num_components,
+                                     (int)entry.forbid_unknown_fallback,
+                                     words[0], words[1], words[2], words[3]);
                     unsupported_record = true;
                     break;
                 }
@@ -5975,9 +5979,28 @@ std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
                 if (!usable && table_log)
                     std::fprintf(stderr,
                                  "[srt] selected-table pc=%u NULL-SLOT index=%u why=%s "
+                                 "base=0x%llx size=%u stride=%u records=%u fmt=%u comps=%u "
                                  "words=%08x:%08x:%08x:%08x\n",
                                  u.use_pc, index,
                                  entry.base <= 0x10000u ? "low-base" : "zero-size",
+                                 (unsigned long long)entry.base, entry.size_bytes, entry.stride,
+                                 entry.num_records, static_cast<unsigned>(entry.format),
+                                 entry.num_components,
+                                 words[0], words[1], words[2], words[3]);
+                // The ACCEPTED population. Without it this report has only records that already
+                // FAILED some filter, and comparing two post-filter populations cannot produce a
+                // counterexample -- which is precisely how three successive predicates for "is this
+                // record a descriptor" were proposed and refuted on #2481. Every record inspected is
+                // now reported with the same decoded fields, from one run, with no filter between
+                // them.
+                if (usable && table_log)
+                    std::fprintf(stderr,
+                                 "[srt] selected-table pc=%u ACCEPT-SLOT index=%u "
+                                 "base=0x%llx size=%u stride=%u records=%u fmt=%u comps=%u "
+                                 "words=%08x:%08x:%08x:%08x\n",
+                                 u.use_pc, index, (unsigned long long)entry.base, entry.size_bytes,
+                                 entry.stride, entry.num_records,
+                                 static_cast<unsigned>(entry.format), entry.num_components,
                                  words[0], words[1], words[2], words[3]);
                 ShaderBufferTableEntry slot;
                 if (usable) {


### PR DESCRIPTION
## Why

Three successive predicates for *"is this table record a descriptor"* were proposed and refuted on
#2481 — page residency, region identity, saturated size. They failed for different reasons, but they
shared one defect that is **not** about the oracle chosen: **none had a two-population control drawn
from the same source.** Each compared records that had already *failed* a filter against descriptors
that had already *passed* one, which cannot produce a counterexample by construction. That is the
same-source-control trap the charter describes, and I walked into it three times.

The report could not have supplied that control:

- **accepted** records printed nothing at all;
- the **declined** path printed no descriptor words — so the population that matters was exactly the
  one whose bytes were invisible;
- the **nulled** path printed words but no decoded fields.

## What changes

All three paths now print the same fields — `base`, `size`, `stride`, `num_records`, `format`,
`components` and the four raw words — from one run, with no filter between them. Pure `fprintf`
additions behind the existing `PROSPER_SRTTABLE_LOG`; no behaviour is gated on it.

## What it immediately yields — and why the scorecard is NOT evidence

480 s routed `PPSA04263` route (`reach-story-mode.pad`, `0x413dc6700` skipped): **382 accepted,
52 nulled, 54 declined.**

| predicate | catches | false positives |
| --- | ---: | ---: |
| `num_records > 65535` | 54/54 rejects | 0/382 accepts |
| `size > 256 MiB` | 54/54 | 0/382 |
| `fmt == 0` | 54/54 | **2**/382 |

**I published that table believing I had finally built a two-population control. Review showed it is
still circular, and the arithmetic is decisive:**

- `size_bytes = num_records × stride` with a **14-bit** stride field, and a record is declined at
  `size_bytes > 256 MiB`. So a declined record must carry `num_records ≥ 16,386`; an accepted one
  `≤ 268,435,456`. **The only window where either label is attainable is `[16386, 268435456]` — and
  every one of the 436 records fell outside it** (accepts ≤ 668, declines ≥ 973 M).
- Therefore every threshold in `(668, 973M)` ties at `54/54` and `0/382` — 10,000, 65,535, 1 M, 200 M
  are indistinguishable. The scorecard ranks nothing; it measures the decline filter.
- The `size > 256 MiB` row is worse: **ACCEPT is only reachable past that exact test**, so its
  `0/382` is forced by the source and could never have printed otherwise.

And the threshold dies on a hand-built instance with no second title needed: with `stride == 0`,
**`NUM_RECORDS` is a byte count** (#2528), so any raw buffer ≥ 64 KiB carries `num_records ≥ 65536`
by definition of the field.

**What survives as genuinely empirical:** the accept-side `0/382` for `num_records > 65535` — accepts
were free to exceed it, since `stride=16, num_records=1M` is 16 MiB and would be accepted — and that
**two** accepted records are legitimately formatless (`stride=112 records=267`), which disposes of
`fmt == 0` as a descriptor test too: untyped loads move raw dwords regardless of declared format.

Three further instrument limitations, stated rather than buried: the denominators are per-dispatch
**line counts**, not distinct records; `fmt`/`comps` are partly definitional on the reject side, being
set together with the forbid flag; and the per-record `break` censors the ACCEPT population by the
REJECT event.

## What this deliberately does NOT do

**No predicate is proposed and none is implemented.** After three refutations I do not think my
picking a fourth from a scorecard is worth much — a perfect separator on one title's one route is
still a heuristic, and `num_records > 65535` would misclassify a legitimate million-element
structured buffer in some other title. The value here is that the next proposal can be *evaluated*
rather than argued about.

I would genuinely welcome a reviewer's read on whether any row above is sound enough to build on, and
on what a second title would have to show before it were.

## Verification

```
ctest --test-dir prosper/build-linux --no-tests=error -j6    CTEST=0, 286/286 passed
python3 prosper/tools/env/check_diag_gates.py                all checks passed
```

Refs #2481, #2412, #2757, #2774, #2780.

