### PR TITLE
fix(gpu): the scalar fold maintains SCC but cannot read it — Sonic Frontiers' top compute blocker is an operand, not an opcode

### DIFF
--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -3405,7 +3405,24 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
         switch (o.kind) {
             case OperandKind::SGPR:      return known(o.value, v);
             case OperandKind::InlineInt: v = (uint32_t)o.value; return true;
-            case OperandKind::Special:   return (o.value == 106 || o.value == 107) ? known(o.value, v) : false;
+            case OperandKind::Special:
+                if (o.value == 106 || o.value == 107) return known(o.value, v);
+                // SCC (source field 253) is the one architectural bit this fold already MAINTAINS:
+                // `scc` is written by every modelled SOP2/SOPC/SOPK above and consumed by
+                // s_cselect. Reading it as a SOURCE was simply never wired up, so an instruction
+                // whose operand the fold holds in hand still gave up. Measured cost: Sonic
+                // Frontiers' most-repeated compute blocker is `s_or_b32 vcc_lo, scc, vcc_hi`
+                // (word 886a6bfd) on three separate programs -- the OPCODE is modelled, and the
+                // fold failed on the operand (#2790).
+                //
+                // -1 means unknown and must stay unreadable; SCC is a single bit, so a known value
+                // is exactly 0 or 1.
+                if (o.value == 253) {
+                    if (scc < 0) return false;
+                    v = static_cast<uint32_t>(scc);
+                    return true;
+                }
+                return false;
             case OperandKind::Literal:   v = 0; return false;   // literal is in in.literal; handled per-op
             default: return false;
         }

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -4016,7 +4016,10 @@ resolve_dynamic_fetch(const uint32_t* code, size_t dwords, const uint32_t* user_
                             (in.src[0].kind == OperandKind::Special && in.src[0].value == 106))
                                                                           khi = known(in.src[0].value + 1, ahi);
                         else if (in.src[0].kind == OperandKind::InlineInt) { ahi = in.src[0].value < 0 ? 0xFFFFFFFFu : 0u; khi = true; }
-                        else                                               { ahi = 0; khi = true; }   // 32-bit literal
+                        // 32-bit literal -- and, since SCC became readable, also `Special{253}`.
+                        // Zero is right for both: a literal's upper half is zero-extended, and SCC
+                        // is a single bit.
+                        else                                               { ahi = 0; khi = true; }
                         if (!khi && wid != 0 && off + wid > 32) { ok = false; wrote_pair = true; break; }
                         uint64_t src64 = (uint64_t)a | ((uint64_t)ahi << 32);
                         uint64_t res = wid == 0 ? 0 : (wid >= 64 ? (src64 >> off) : ((src64 >> off) & (((uint64_t)1 << wid) - 1)));

--- a/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
+++ b/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
@@ -215,6 +215,61 @@ int main() {
     CHECK(saved_exec_vertex.size() == 1 &&
               saved_exec_vertex[0].index_mode == VertexFetchIndexMode::Vertex,
           "a saved-EXEC copy still identifies a vertex_id fetch through s_cselect_b64");
+
+    // #2790: SCC must be readable as a SCALAR SOURCE, not merely maintained. The fold tracks `scc`
+    // through every modelled SOP2/SOPC/SOPK and consumes it in s_cselect, but `srcval` admitted only
+    // VCC_LO/VCC_HI among the Special operands -- so an instruction reading SCC gave up on a value
+    // the fold had in hand. Sonic Frontiers' most-repeated compute blocker is exactly that shape:
+    // `s_or_b32 vcc_lo, scc, vcc_hi`, word 886a6bfd, on three separate programs, with the OPCODE
+    // fully modelled.
+    //
+    // The fixture builds a V# whose NUM_RECORDS word is computed FROM SCC, so the descriptor
+    // resolves only if SCC was readable:
+    //     pc0  s_cmp_eq_u32 0, 0        -> SCC = 1
+    //     pc1  s_or_b32 s10, scc, s4    -> s10 = 1 | 2 = 3   (NUM_RECORDS)
+    //     pc2  buffer_load_dword v0, v0, s[8:11], 0
+    // s8/s9/s11 are seeded user data; only s10 depends on SCC.
+    //
+    // MUTATION: remove the `o.value == 253` arm from srcval in gpu_executor.cpp and this goes red --
+    // s10 becomes unknown, the SRSRC is incomplete and no resource is published. Nothing else in the
+    // suite detects it, because no other fixture reads SCC as a source.
+    alignas(16) static uint32_t scc_src_backing[64]{};
+    const uint64_t scc_src_base = reinterpret_cast<uint64_t>(scc_src_backing);
+    uint32_t scc_src_seed[16]{};
+    scc_src_seed[4]  = 2u;                                   // s4  -> the OR's other operand
+    scc_src_seed[8]  = static_cast<uint32_t>(scc_src_base);  // s8  -> V# base lo
+    scc_src_seed[9]  = (static_cast<uint32_t>(scc_src_base >> 32) & 0xffffu) | (16u << 16);
+    scc_src_seed[11] = 0xfacu | (20u << 12u);                // s11 -> DST_SEL identity, Uint32
+    const std::array<uint32_t, 5> scc_src_shader = {
+        0xBF068080u,               // pc0: s_cmp_eq_u32 0, 0        -> SCC = 1
+        0x880A04FDu,               // pc1: s_or_b32 s10, scc, s4    -> NUM_RECORDS = 3
+        0xE0301000u, 0x80020000u,  // pc2: buffer_load_dword v0, v0, s[8:11], 0
+        0xBF810000u,               // pc4: s_endpgm
+    };
+    ShaderResourceTable scc_src_rt;
+    add_compute_buffer_resources(scc_src_rt, scc_src_shader.data(), scc_src_shader.size(),
+                                 scc_src_seed, std::size(scc_src_seed));
+    assign_convention_bindings(scc_src_rt, 2);
+    const ShaderResource* scc_src_resource = scc_src_rt.by_fetch_pc(2u);
+    CHECK(scc_src_resource && scc_src_resource->gpu_addr == scc_src_base &&
+              scc_src_resource->stride == 16u && scc_src_resource->size == 3u * 16u,
+          "SCC is readable as a scalar source, so a descriptor word computed from it resolves");
+
+    // NEGATIVE ARM: with SCC UNKNOWN the same shader must still fail closed. Without this, the fix
+    // is indistinguishable from "always report SCC as 0" -- which would fold a wrong NUM_RECORDS
+    // and bind a descriptor the guest never described. `s_cbranch_scc0` is not modelled, so SCC is
+    // -1 at the OR; the only difference from the arm above is the missing s_cmp.
+    const std::array<uint32_t, 4> scc_unknown_shader = {
+        0x880A04FDu,               // pc0: s_or_b32 s10, scc, s4   -- SCC never set: unknown
+        0xE0301000u, 0x80020000u,  // pc1: buffer_load_dword v0, v0, s[8:11], 0
+        0xBF810000u,               // pc3: s_endpgm
+    };
+    ShaderResourceTable scc_unknown_rt;
+    add_compute_buffer_resources(scc_unknown_rt, scc_unknown_shader.data(),
+                                 scc_unknown_shader.size(), scc_src_seed, std::size(scc_src_seed));
+    assign_convention_bindings(scc_unknown_rt, 2);
+    CHECK(scc_unknown_rt.by_fetch_pc(1u) == nullptr,
+          "an UNKNOWN SCC still fails closed rather than folding to zero");
     ngg_seed[106 - 8] = 1u;                  // SCC=false -> select v8 (instance_id)
     auto saved_exec_instance = resolve_dynamic_fetch(
         ngg_saved_exec_fetch, std::size(ngg_saved_exec_fetch), ngg_seed.data(), ngg_seed.size(), 8);

--- a/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
+++ b/prosper/tests/gpu/recompiler/test_dynfetch_fold.cpp
@@ -257,8 +257,11 @@ int main() {
 
     // NEGATIVE ARM: with SCC UNKNOWN the same shader must still fail closed. Without this, the fix
     // is indistinguishable from "always report SCC as 0" -- which would fold a wrong NUM_RECORDS
-    // and bind a descriptor the guest never described. `s_cbranch_scc0` is not modelled, so SCC is
-    // -1 at the OR; the only difference from the arm above is the missing s_cmp.
+    // and bind a descriptor the guest never described. SCC is -1 at the OR simply because NOTHING
+    // has written it since the fold initialised `int scc = -1` -- the only difference from the arm
+    // above is the missing s_cmp. (An earlier version of this comment blamed an unmodelled
+    // `s_cbranch_scc0`; there is no branch in this fixture at all. Asserting a mechanism without
+    // disassembling the words is how the wrong explanation gets into a test and outlives it.)
     const std::array<uint32_t, 4> scc_unknown_shader = {
         0x880A04FDu,               // pc0: s_or_b32 s10, scc, s4   -- SCC never set: unknown
         0xE0301000u, 0x80020000u,  // pc1: buffer_load_dword v0, v0, s[8:11], 0


### PR DESCRIPTION
## The defect

`srcval` in the executor's scalar const-fold admitted only `VCC_LO`/`VCC_HI` among the `Special`
operands:

```cpp
case OperandKind::Special: return (o.value == 106 || o.value == 107) ? known(o.value, v) : false;
```

`decode_src_field` maps source field **253 to `Special{253}`** — SCC. So any instruction sourcing SCC
returned false, `ok = ka && kc` failed, and the destination was forgotten.

**Meanwhile the fold tracks SCC.** `int scc = -1` is declared at `:2988`, written by every modelled
`SOP2`/`SOPC`/`SOPK`, and consumed by `s_cselect` — and `srcval` is a `[&]` lambda declared at `:3404`,
so the value was in scope the entire time. The fold was refusing to read the one architectural bit it
maintains.

## How it was found

By cross-checking *Sonic Frontiers*' black world (#2790) against GTA V's. Their most-repeated compute
blocker is word `886a6bfd`, on three separate programs, which decodes as:

```
SOP2 op=0x10  sdst=VCC_LO  ssrc0=SCC  ssrc1=VCC_HI   ->  s_or_b32 vcc_lo, scc, vcc_hi
```

`0x10` is `kSop2OpcodeOrB32`, and that case **is** handled in the fold's SOP2 switch. The opcode was
never the problem — the operand was.

## Tests

Nothing in the suite read SCC as a *source*, so both arms are new:

- **Positive** — a V# whose `NUM_RECORDS` word is computed from SCC (`s_cmp_eq_u32 0,0` then
  `s_or_b32 s10, scc, s4`) must resolve to exactly 3 records. Only `s10` depends on SCC; `s8/s9/s11`
  are seeded user data.
- **Negative** — the same shader *without* the `s_cmp`, so SCC is unknown, must still fail closed.
  Without this the change is indistinguishable from *"report SCC as 0"*, which would fold a wrong
  `NUM_RECORDS` and bind a descriptor the guest never described.

**Mutation at the production site:**

```
=== MUTANT: SCC source arm removed ===
  [FAIL] SCC is readable as a scalar source, so a descriptor word computed from it resolves
  [ok]   an UNKNOWN SCC still fails closed rather than folding to zero
== FAIL: 1 ==
=== RESTORED ===  == PASS ==
```

Exactly one named check red; the negative arm green under both, which is what shows it does not
depend on the term.

## What is NOT claimed

**No title-level effect is demonstrated, and I want that read before the diff.**

- **GTA V is measurably unchanged** — 10 rejecting programs before and after, identical set, on the
  same routed 480 s route. Expected: its SOP2 blocker sources `VCC_LO`, not SCC.
- **Sonic Frontiers could not be measured here.** A 500 s run on that lane's route (fetched read-only
  from #2791) reached only 5 programs and never the Cyber Space stage, so none of the three
  SCC-blocked programs appeared.

Whether this unblocks them is for #2790's lane to measure. The unit evidence stands on its own: a
tracked value that could not be read now can be, with a mutation-checked test and a fail-closed
negative arm.

## Verification

```
cmake --build prosper/build-linux -j6                        BUILD=0
ctest --test-dir prosper/build-linux --no-tests=error -j6    CTEST=0, 286/286 passed
python3 prosper/tools/env/check_diag_gates.py                all checks passed
```

Refs #2790, #2481, #2412.
