### PR TITLE
docs(gta5): the offline 0x413dc6700 dissection describes the EMPTY-SRT startup variant (#2542)

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -110,6 +110,49 @@ conclusion; it sharpens what "essentially all black" looks like.
 
 ## Ruled out (2026-08-19)
 
+- **The offline dissection of `0x413dc6700` describes the EMPTY-SRT startup variant, not the hanging
+  one.** `dc6700.prgcap` was taken with `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` and **no**
+  `PROSPER_GPU_CAPTURE_AT=`, so it fired inside the first-88-fold window that
+  § *The first 88 folds see an EMPTY SRT* describes. Measured on the derived disassembly: **45**
+  `StorageBuffer` variables declared, **exactly one** access chain into any of them, 980 Workgroup,
+  0 image ops — against **41** guest MUBUF sites (`shader_inspect` on the same raw dump). That is the
+  empty-SRT signature exactly, down to the single surviving non-MUBUF chain. Two consequences:
+  (a) the *"the pc88..97 cycle appears to TERMINATE"* reading is explained rather than in tension with
+  the device witness — the pointer chase folded to a constant, so the loop exits for that reason and
+  says nothing about the resolved variant; (b) the proposed ctest that embeds the program's 903 raw
+  dwords is **void as specified**, since raw dwords carry no descriptors and recompiling them
+  reproduces the terminating variant. `shader_inspect` states this on the dump itself:
+  `status=undetermined-no-resource-table`, `table_dependent=41`, and the rejection is
+  **unattributable**. Any arm must supply a *resolved* table. (2026-08-20, #2542.)
+
+- **`dispatch-range=N..M` in a `[cfg-trip-bound] HIT` line does NOT bound the runaway cycle.** It is an
+  atomic min/max over switch-case ordinals observed across *all* invocations of that dispatch, so a wave
+  that walks 0->8 and then spins, while other invocations run to the end, prints `0..14` — the whole
+  table — for a two-block cycle. Phase 0's dispatcher graph, derived from every write of the next-block
+  variable (the constant writes plus the taken/untaken pair the vote resolves), is:
+  `0->{1,6} 1->{2,3} 2->3 3->{4,5} 4->5 5->6 6->{7,11} 7->8 8->{9,10} 9->8 10->11 11->{12,13} 12->13
+  13->14 14->exit`. **The only cycle is 8<->9**; every other edge moves strictly forward and there is no
+  back edge to block 0. This is the third direction in which this witness's fields have been misread —
+  see trap 172. (2026-08-20, #2542.)
+
+- **"The vote never resolves, so the dispatcher re-enters the same block" is not the mechanism.** The
+  vote's final write of the next-block variable is guarded by a conjunction of the has-branch flag and
+  the negations of two others; those two are stored `false` in the phase preamble and never rewritten
+  anywhere in phase 0, while every branching block sets the has-branch flag, so the guard reduces to
+  that flag alone and the branch target *is* applied. (2026-08-20, #2542.)
+
+- **`robustBufferAccess` is enabled on the compute device, so "OOB buffer loads are undefined here" is
+  not available as an explanation for the traversal failing to terminate.** `live_compute.cpp` checks
+  `supported.robustBufferAccess`, refuses the device without it, sets `enabled.robustBufferAccess =
+  VK_TRUE`, and passes it through `pEnabledFeatures`. This matters because the guest loop's only exit is
+  the `v_cmpx_ne_u32` on the loaded link, so a load returning 0 past the record count is *what
+  terminates it on hardware*, and that contract is switched on. **Not checked, and still open:** whether
+  the bound descriptor **range** equals the V#'s `num_records x stride` on the compute path. Vulkan
+  bounds a robust access to the bound range, not to the guest's `NUM_RECORDS`, so a looser range would
+  return neighbouring bytes where hardware returns 0 — and the FLAT path already documents a deliberate
+  "loose-bounds divergence from HW" of exactly this kind. That end-to-end contract has no test.
+  (2026-08-20.)
+
 - **Any predicate over `num_records` or `size_bytes` is UNFALSIFIABLE on the `reach-story-mode`
   route — the run cannot contain a counterexample.** Four successive attempts to classify a
   runtime-selected descriptor-table record as "not a descriptor" were refuted (#2481): page


### PR DESCRIPTION
## What this is

Four falsifications from re-deriving `0x413dc6700`'s phase-0 dispatcher offline, landed in
`GTA5_STATUS.md`'s `## Ruled out` so they are in the project record rather than only in an issue
thread. Docs-only; no behaviour changes.

## The finding that matters

`#2542`'s last comment ended on an unresolved conflict: the emitted SPIR-V reads as *terminating in
about three dispatcher iterations*, while the device witness records `trips=4096` on `phase=0`. It
concluded "one of the two must be wrong, and I cannot settle it by reading."

**Neither is wrong.** The artifact everything was read from — `dc6700.prgcap` and the `.spv` /
`.spvasm` derived from it — was captured with `PROSPER_GPU_CAPTURE_COMPUTE_ADDR` and **no**
`PROSPER_GPU_CAPTURE_AT=`, so it fired inside the first-88-fold window that this document already
describes in § *The first 88 folds see an EMPTY SRT*. Its signature confirms the identification:

| quantity | measured |
| --- | --- |
| `StorageBuffer` variables declared | **45** |
| access chains into any of them | **1** |
| Workgroup / PushConstant chains | 980 / 2 |
| image ops, PhysicalStorageBuffer ops | **0** |
| guest MUBUF sites needing a table (`shader_inspect`, same raw dump) | **41** |

0 of 41 MUBUF sites emit a memory access, and one non-MUBUF chain survives — which is what the
empty-SRT section predicts, down to its parenthetical.

So the loop "terminates" because the pointer chase folded to a constant, which says nothing about
the resolved-descriptor variant that hangs. And the ctest proposed in that comment — embed the
program's 903 raw dwords, recompile, run phase 0 — is **void as specified**: raw dwords carry no
descriptors, so it would reproduce the terminating variant and assert that the fold folded.
`shader_inspect` says as much on this dump (`status=undetermined-no-resource-table`,
`table_dependent=41`, rejection **unattributable**).

## Also recorded

- **`dispatch-range=N..M` does not bound the runaway cycle** — it is an atomic min/max over ordinals
  across all invocations. Phase 0's graph is included; its **only** cycle is 8↔9, every other edge
  moves forward, and there is no back edge to block 0. This is the third direction in which this
  witness's fields have been misread (trap 172), which is why the graph is written down.
- **"The vote never resolves" is not the mechanism** — the guard reduces to the has-branch flag,
  which every branching block sets, so the branch target is applied.
- **`robustBufferAccess` IS enabled on the compute device**, so "OOB loads are undefined here" is not
  available as an explanation. The guest loop's only exit is `v_cmpx_ne_u32` on the loaded link, so a
  load returning 0 past the record count is what terminates it on hardware. The **untested** half is
  named as still open: whether the bound descriptor *range* equals the V#'s `num_records × stride`.

## Scope note

I could not run the route to take a representative capture — **no PS5 dump is present on this
machine** (only a Messenger test fixture), so live reproduction was unavailable this session. Every
claim here is derived from artifacts already on disk plus the source tree.

## Verification

- `git diff --name-only origin/master...HEAD` → `.md` only
- `check_numbered_table.py` over every tracked `.md` → unbroken, every row matching its header
- `git diff --check` → clean
- Session-trailer gate → 0

Refs #2542, #1873


---

## CORRECTION (same session): the "no PS5 dump on this box" statement in this PR is FALSE

The GTA V dump is present at `<REPO_ROOT>/testdata/PPSA04263-app0` (96 GB), with 43 other titles
beside it. My conclusion came from `find / -maxdepth 6`; those paths are at depth **7**, so the
search missed them by one level and I reported the null as a fact.

It is the instrument-not-the-subject failure, and the bad part is the direction: a **negative**
result from a search I never validated, when a positive control was free — the Messenger dump is
referenced throughout this repo, so a search that could not find *that* either was a search to
distrust rather than a fact to publish.

**No technical content of this PR depends on it.** Every measurement here was derived from artifacts
on disk and from the source tree, not from the absence of a dump; only the "why this was not taken
further" framing was wrong. The route is now being run.
