### PR TITLE
docs(gta5): the MUBUF out-of-bounds contract IS honoured — the hang is a data question, not a bounds one

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -150,8 +150,29 @@ conclusion; it sharpens what "essentially all black" looks like.
   the bound descriptor **range** equals the V#'s `num_records x stride` on the compute path. Vulkan
   bounds a robust access to the bound range, not to the guest's `NUM_RECORDS`, so a looser range would
   return neighbouring bytes where hardware returns 0 — and the FLAT path already documents a deliberate
-  "loose-bounds divergence from HW" of exactly this kind. That end-to-end contract has no test.
+  "loose-bounds divergence from HW" of exactly this kind. That end-to-end contract has no test (#2795).
   (2026-08-20.)
+
+- **FOLLOW-UP, and it closes the above as an explanation: the MUBUF out-of-bounds contract IS honoured
+  on the compute path, so a walk off the end of the traversal buffer DOES terminate.** Traced through
+  the source rather than measured, each link checked:
+  `pc=91` decodes as `buffer_load_dword v1, v1, s[0:3], 0` with **`idxen=1, offen=0`** (word0
+  `0xe0302000`, bit 13 set, bit 12 clear), so the address is a record *index* and hardware bounds it at
+  `index >= NUM_RECORDS`. `plan_storage_buffer_materialization` sets `binding_bytes = resource.size` on
+  the default path; `live_compute.cpp` then uses that same value for both `VkBufferCreateInfo::size`
+  and `VkDescriptorBufferInfo::range`, and enables `robustBufferAccess`. For this descriptor
+  (`stride=4, num_records=2063, size=8252`) the bound range is exactly 2063 dwords, the lowering is a
+  dword-indexed read, and index >= 2063 falls outside the range and reads 0 — which is the guest loop's
+  termination condition. The remaining `zero_pad_*` paths pad with **zeros**, so they preserve the same
+  answer rather than breaking it. Note the recompiler emits **no** runtime record-count bound at all
+  (`num_records` appears zero times in `rdna2_emit_alu.cpp`); the contract is delegated entirely to the
+  descriptor range, which is why it is worth having written down.
+  **Consequence for the hang:** the traversal has exactly two exits — a zero link and an out-of-range
+  index — and *both* work. So `0x413dc6700` can only spin on a table whose links form a cycle **inside**
+  `[0, 2063)`, which is what the parent-walk census independently reports (`cyclic-roots=2062,
+  oob-roots=0`). That makes the frontier a **data-production** question — what writes those values —
+  and not a translation or bounds question. Still untested end-to-end (#2795 stands as a coverage gap,
+  not as a suspected defect). (2026-08-21.)
 
 - **Any predicate over `num_records` or `size_bytes` is UNFALSIFIABLE on the `reach-story-mode`
   route — the run cannot contain a counterexample.** Four successive attempts to classify a


### PR DESCRIPTION
## What this is

Follow-up to #2794, which left one hypothesis explicitly open. This closes it — as a **falsification**.
Docs-only.

## The question

`0x413dc6700`'s traversal loop has exactly two exits: a zero link, and an index walking past the
record count. The second one deserved scrutiny because prosper emits **no runtime record-count
bound at all** — `num_records` appears **zero times** in `rdna2_emit_alu.cpp` — and delegates the
entire contract to Vulkan's `robustBufferAccess`, which bounds an access to the **bound descriptor
range**, not to the guest V#'s `NUM_RECORDS`. A looser range would return neighbouring bytes exactly
where the console returns 0, and 0 is what ends this loop.

There was precedent for that divergence in the tree: the FLAT path binds "the containing guest
allocation" and its own comment calls the result "a loose-bounds divergence from HW".

## The answer: it holds

Traced through the source, link by link:

| step | finding |
| --- | --- |
| `pc=91` encoding | `buffer_load_dword v1, v1, s[0:3], 0` with **`idxen=1, offen=0`** (word0 `0xe0302000` — bit 13 set, bit 12 clear), so the address is a record *index* and HW bounds at `index >= NUM_RECORDS` |
| `plan_storage_buffer_materialization` | default path sets `binding_bytes = resource.size` |
| `live_compute.cpp` | uses that same value for **both** `VkBufferCreateInfo::size` and `VkDescriptorBufferInfo::range` |
| feature | `robustBufferAccess` checked, required, set `VK_TRUE`, passed via `pEnabledFeatures` |
| this descriptor | `stride=4, num_records=2063, size=8252` → range is exactly 2063 dwords |

The lowering is a dword-indexed read, so index ≥ 2063 falls outside the range and reads 0 — the loop's
own termination condition. The remaining `zero_pad_*` paths pad with **zeros**, so they preserve the
answer rather than breaking it.

## Why this is worth landing rather than dropping

It moves the frontier. Both of the loop's exits work, so `0x413dc6700` can only spin on links that
form a cycle **inside** `[0, 2063)` — which is exactly what the parent-walk census independently
reports (`cyclic-roots=2062, oob-roots=0`). That makes the hang a **data-production** question (what
writes those values) and rules out translation and bounds as the mechanism. It also removes the last
prosper-side mechanism that could make the traversal non-terminating *without* corrupted data.

#2795 stands, but re-scoped: a test-coverage gap, not a suspected defect. I have commented there.

## Method note

This is traced through source, not measured — no PS5 dump is currently present on the dev box, so the
route could not be run. Each link above is a separate claim and each is individually checkable; the
encoding decode is stated with the bit positions so it can be re-derived without reassembling.

## Verification

- `git diff --name-only origin/master...HEAD` → `.md` only
- `check_numbered_table.py` over every tracked `.md` → 0 errors
- `git diff --check` → clean
- Session-trailer gate → 0

Refs #2542, #2795, #1873
