### PR TITLE
feat(shader_inspect): enumerate EVERY unsupported instruction, not just the first

### DIFF
--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -2622,7 +2622,9 @@ std::vector<uint32_t> mask_test_branches_for_test(const uint32_t* code, size_t d
     return std::vector<uint32_t>(branches.begin(), branches.end());
 }
 
-RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
+RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords,
+                                     std::vector<RecompileUnsupportedSite>* sites) {
+    if (sites) sites->clear();
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     uint32_t synthetic_branch_pc = UINT32_MAX;
@@ -2789,6 +2791,9 @@ RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords) {
                 cov.first_bad_op = in.opcode;
                 cov.first_bad_pc = in.pc;
             }
+            // Recorded from the SAME branch that increments the counter, so the enumeration cannot
+            // disagree with `unsupported` about which instructions are in the class.
+            if (sites) sites->push_back({(int)in.fmt, in.opcode, in.pc});
         }
     }
     return cov;

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -518,7 +518,24 @@ struct RecompileCoverage {
     uint32_t first_bad_op  = 0;
     uint32_t first_bad_pc  = 0xFFFFFFFFu; // dword offset of that instruction (-1 if none)
 };
-RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords);
+
+// One truly-unsupported instruction, for callers that need the WHOLE census rather than the first
+// site. `first_bad_*` above answers "does this shader recompile?"; it cannot answer "which of these
+// 27 instructions feeds the value that comes out wrong?", which is the question an investigation
+// actually asks once a program is known to be blocked.
+struct RecompileUnsupportedSite {
+    int      fmt = -1;      // Rdna2Format
+    uint32_t opcode = 0;
+    uint32_t pc = 0;        // dword offset
+};
+
+// `sites` is OPTIONAL and defaults to nullptr, which is what every existing caller passes
+// implicitly. That matters: this runs on the failed-draw path and at F9 capture, so the enumeration
+// must cost nothing unless a diagnostic asks for it. Passing a vector fills it with every
+// unsupported instruction in stream order; sites[0] always agrees with `first_bad_*`, and a test
+// pins that agreement so the two can never drift into disagreeing about the same shader.
+RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords,
+                                     std::vector<RecompileUnsupportedSite>* sites = nullptr);
 
 // Test seam for the whole-stream liveness gate on GTA V's incomplete S_CSELECT_B64 source pair.
 // A returned PC is admitted at the select itself; later failure to materialize VCC_HI cannot make

--- a/prosper/tests/gpu/test_recompile_coverage.cpp
+++ b/prosper/tests/gpu/test_recompile_coverage.cpp
@@ -2700,6 +2700,56 @@ int main() {
                          std::size(guarded_counted_loop_inner_save), 0, 0).empty(),
           "guarded counted loop rejects an uncarried inner EXEC mutation");
 
+    // --- The unsupported-site ENUMERATION, not just the first site -------------------------------
+    //
+    // `first_bad_*` answers "does this shader recompile?". It cannot answer "which instructions are
+    // blocked", which is the question an investigation asks once a program is known to be blocked --
+    // GTA V's 0x413dc6700 reports unsupported=27 behind a single `first=SMEM/0x1`, and deciding
+    // whether any of the 27 feeds a particular value needs all of them. The optional out-parameter
+    // exists so that census costs nothing on the failed-draw and F9-capture paths that call this.
+    //
+    // Composed from the two single-unsupported MTBUF kernels asserted above, so each half is
+    // independently pinned: whichever arm breaks, the cause is already localized.
+    {
+        const uint32_t two_bad[] = {
+            0xe8682000u, 0x80220000u,   // MTBUF D16   -> unsupported, op 8
+            0xe8b02000u, 0x80820100u,   // MTBUF TFE   -> unsupported, op 0
+            0xBF810000u,
+        };
+        std::vector<RecompileUnsupportedSite> sites;
+        const RecompileCoverage cov =
+            recompile_coverage(two_bad, std::size(two_bad), &sites);
+
+        CHECK(cov.unsupported == 2, "the composed kernel really does carry two unsupported sites");
+        CHECK(sites.size() == cov.unsupported,
+              "the enumeration reports exactly as many sites as the counter counts");
+        // The point of the feature: the SECOND site is reachable at all. Before this, op 0 at pc 2
+        // was invisible behind op 8 at pc 0.
+        CHECK(sites.size() == 2 && sites[1].opcode == 0u && sites[1].pc == 2u,
+              "the second unsupported site is enumerated, not hidden behind the first");
+        CHECK(!sites.empty() && sites[0].opcode == 8u && sites[0].pc == 0u,
+              "the first enumerated site is the first blocker in stream order");
+        // Agreement, so the two reports can never drift into describing the same shader differently.
+        CHECK(!sites.empty() && sites[0].fmt == cov.first_bad_fmt &&
+                  sites[0].opcode == cov.first_bad_op && sites[0].pc == cov.first_bad_pc,
+              "sites[0] agrees with first_bad_* on fmt, opcode and pc");
+
+        // Passing no vector must not change what is REPORTED -- every existing caller relies on that.
+        const RecompileCoverage without = recompile_coverage(two_bad, std::size(two_bad));
+        CHECK(without.unsupported == cov.unsupported && without.total == cov.total &&
+                  without.first_bad_op == cov.first_bad_op && without.alu == cov.alu,
+              "omitting the out-parameter leaves the coverage numbers identical");
+
+        // Negative arm. Without it, every assertion above is also satisfied by an implementation that
+        // unconditionally appends, so this is what makes the others mean anything.
+        std::vector<RecompileUnsupportedSite> clean_sites{{0, 7u, 7u}};  // pre-dirtied on purpose
+        const uint32_t clean[] = { 0x06000300u, 0x10000500u, 0xBF810000u };
+        const RecompileCoverage clean_cov =
+            recompile_coverage(clean, std::size(clean), &clean_sites);
+        CHECK(clean_cov.unsupported == 0 && clean_sites.empty(),
+              "a fully-supported kernel enumerates NO sites, and clears a dirty caller vector");
+    }
+
     if (fails) { printf("== FAIL: %d ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tools/shader_inspect/shader_inspect.cpp
+++ b/prosper/tools/shader_inspect/shader_inspect.cpp
@@ -124,7 +124,9 @@ int main(int argc, char** argv) {
     std::memcpy(words.data(), bytes.data(), bytes.size());
     std::vector<Rdna2Inst> instructions;
     const size_t consumed = rdna2_walk(words.data(), words.size(), instructions);
-    const RecompileCoverage coverage = recompile_coverage(words.data(), words.size());
+    std::vector<RecompileUnsupportedSite> unsupported_sites;
+    const RecompileCoverage coverage =
+        recompile_coverage(words.data(), words.size(), &unsupported_sites);
     const bool ended = !instructions.empty() && instructions.back().is_end;
     std::printf("file=%s bytes=%zu dwords=%zu consumed=%zu instructions=%zu endpgm=%d\n",
                 argv[1], bytes.size(), words.size(), consumed, instructions.size(), ended);
@@ -133,6 +135,19 @@ int main(int argc, char** argv) {
                 coverage.unsupported,
                 coverage.first_bad_fmt < 0 ? "none" : format_name(static_cast<Rdna2Format>(coverage.first_bad_fmt)),
                 coverage.first_bad_op);
+    // Every unsupported site, not just the first. `first=` above answers "does this recompile?";
+    // this answers "which instructions are blocked", which is what you need to decide whether any of
+    // them feeds a particular value. Printed one per line so it greps and diffs.
+    for (const RecompileUnsupportedSite& site : unsupported_sites) {
+        std::printf("generic-unsupported pc=%04u fmt=%s op=0x%x\n", site.pc,
+                    format_name(static_cast<Rdna2Format>(site.fmt)), site.opcode);
+    }
+    if (unsupported_sites.size() != coverage.unsupported) {
+        // Cannot happen -- both come from one branch -- so say so loudly rather than print a census
+        // that silently disagrees with its own total.
+        std::printf("generic-unsupported WARNING enumerated=%zu but counted=%u\n",
+                    unsupported_sites.size(), coverage.unsupported);
+    }
     bool stage_ok = true;
     bool stage_undetermined = false;
     if (!stage.empty()) {


### PR DESCRIPTION
## Problem

`recompile_coverage()` reports a count and a single site:

```
generic-coverage total=780 alu=753 exp=0 table=0 unsupported=27 first=SMEM/0x1
```

There was no way to see the other 26. `first_bad_*` answers *"does this shader recompile?"* — the
right question for a gate. It cannot answer *"which instructions are blocked"*, which is what an
investigation asks once a program is already known to be blocked, and deciding whether any of them
feeds a particular value requires all of them.

## Approach

`recompile_coverage()` gains an **optional** out-parameter:

```cpp
RecompileCoverage recompile_coverage(const uint32_t* code, size_t dwords,
                                     std::vector<RecompileUnsupportedSite>* sites = nullptr);
```

- **Defaulted to `nullptr`**, which is what every existing caller passes implicitly, so no call site
  changes and the enumeration costs nothing on the failed-draw and F9-capture paths that invoke this.
- Sites are pushed **from the same branch that increments `unsupported`**, so the census and its own
  total cannot drift apart.
- `shader_inspect` prints one `generic-unsupported pc=… fmt=… op=…` line per site, and prints a loud
  `WARNING` if the enumerated count and the counted total ever disagree — a census that can detect
  its own incompleteness rather than one that silently under-reports.

## What it found immediately

On GTA V's `0x413dc6700` — the program that measurably feeds the lighting (#2542) — the 27 resolve to:

| class | count |
| --- | ---: |
| SOPP branches (`0x8` `s_cbranch_execz`, `0x6`, `0x2` `s_branch`) | **19** |
| SMEM `0x01` | 4 |
| SOP1 `0x1d` | 4 |
| **VALU / VOP** | **0** |

The zero is the useful part: **no arithmetic instruction in that shader is blocked**, so its emitted
values cannot be wrong through a dropped ALU op. That retires a live hypothesis about the six stores
that feed its traversal table.

It also exposed that the four SMEM sites are the shader's *own descriptor loads* (destinations `s16`,
`s8`, `s12`, `s0` — the four buffers in its orientation table), misfiled as `unsupported` rather than
`table_dependent`, which is what makes `first=SMEM/0x1` mis-name the blocker. **Filed as #2797 and
deliberately not fixed here**: the tempting one-line predicate widening (`opcode >= 0x01 && <= 0x04`)
would over-credit, because the emitter's x2 path is additionally gated on
`smem_x2_descriptor_fragment_loads`, a whole-stream analysis the coverage shell does not run. Moving
the error from over-reporting to under-reporting would be worse.

## Affected / unaffected

- **Affected:** `shader_inspect` output gains `generic-unsupported` lines.
- **Unaffected:** every existing `recompile_coverage()` caller (default argument), all emitted SPIR-V,
  and every coverage number — pinned by an arm asserting the no-vector call returns identical
  `total`/`alu`/`unsupported`/`first_bad_op`.

## Tests — seven arms, mutation-checked

Composed from the two single-unsupported MTBUF kernels already asserted in this file, so each half is
independently pinned:

- the composed kernel really carries two unsupported sites
- the enumeration reports exactly as many sites as the counter counts
- **the second site is enumerated, not hidden behind the first** ← the feature
- the first enumerated site is the first blocker in stream order
- `sites[0]` agrees with `first_bad_*` on fmt, opcode and pc
- omitting the out-parameter leaves every coverage number identical
- **negative arm:** a fully-supported kernel enumerates nothing and clears a pre-dirtied caller vector

**Mutation, applied at the production site** (`if (sites && sites->empty())`, mimicking first-only):
reddens exactly *"reports exactly as many sites as the counter counts"* and *"the second unsupported
site is enumerated"*; the negative arm stays green under both. Without that mutation the arms could
be satisfied by an implementation that unconditionally appends.

## Verification (exact head)

```
cmake --build prosper/build-linux -j6        BUILD_RC=0
ctest --no-tests=error                       CTEST_RC=0
100% tests passed out of 281
```

281 registered, not 284: this box has no PS5 dump, so CMake did not register the three dump-backed
cases (`module_loads_eboot`, `boot_reaches_first_syscall`, `real_shader_render`) and reported so at
configure time. `plugin_autolink` skipped as usual. `git diff --check` clean; session-trailer gate 0.

End-to-end: `shader_inspect` on the GTA V raw dump emits 27 `generic-unsupported` lines, matching its
own `unsupported=27`.

## Review note

Judged well-bounded low-risk: the only production-code change is one `push_back` inside an existing
branch plus a defaulted parameter; no emitted code changes; the no-vector-call arm pins that existing
callers are unaffected; and the test is mutation-verified. Happy to have a reviewer look if that
judgement seems wrong.

Refs #2797, #2542


---

## CORRECTION (same session): the "no PS5 dump on this box" statement in this PR is FALSE

The GTA V dump is present at `<REPO_ROOT>/testdata/PPSA04263-app0` (96 GB), with 43 other titles
beside it. My conclusion came from `find / -maxdepth 6`; those paths are at depth **7**, so the
search missed them by one level and I reported the null as a fact.

It is the instrument-not-the-subject failure, and the bad part is the direction: a **negative**
result from a search I never validated, when a positive control was free — the Messenger dump is
referenced throughout this repo, so a search that could not find *that* either was a search to
distrust rather than a fact to publish.

**No technical content of this PR depends on it.** Every measurement here was derived from artifacts
on disk and from the source tree, not from the absence of a dump; only the "why this was not taken
further" framing was wrong. The route is now being run.
