### PR TITLE
docs: regenerate SCREENSHOTS.md — master's Docs gate was red on every open PR

### DIFF
--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -9,7 +9,7 @@
 
 **Every screenshot checked into this repository, most recent first.** Read down from the top and stop when you reach one you have already seen.
 
-**137 images**, most recent **2026-08-20**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
+**138 images**, most recent **2026-08-21**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
 
 This file is generated from git history by [`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) and is regenerated and diffed in CI, so it cannot drift from the tree. [`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a reverse-chronological index of the images themselves.
 
@@ -17,6 +17,16 @@ This file is generated from git history by [`prosper/tools/docs/gen_screenshot_f
 > a claim about the title's current state — for that, read the tracker. An image is never
 > removed from this feed when a title moves on, because the point of a feed is that it is
 > a record of *when* things happened.
+
+## 2026-08-21
+
+### rtype-delta-stage1-restored.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-stage1-restored.png" alt="rtype delta stage1 restored"></p>
+
+fix(recompiler): a saved wave-mask alias must not outlive its SGPR pair — R-Type Delta's whole post-title render, blank for nine days (#2799)
+
+`e653f271` · [`assets/screenshots/rtype-delta-stage1-restored.png`](assets/screenshots/rtype-delta-stage1-restored.png)
 
 ## 2026-08-20
 


### PR DESCRIPTION
docs: regenerate SCREENSHOTS.md — master's Docs gate was red on every open PR

e653f271 (#2799) added assets/screenshots/rtype-delta-stage1-restored.png without
regenerating the feed, so master carried 137 entries against 138 images in the tree.
The gate compares the committed file to the tree, so it failed on master AND on every
PR branched from it -- a lane hit it today and correctly repaired from origin/master
rather than assuming its own diff was at fault.

This is the documented cost of a generated file that cannot be produced before its own
merge: a PR cannot include its entry, because squash-merge creates the commit the image
is attributed to. The regeneration therefore has to follow the merge, and I did not do
it. Recording that plainly because the failure mode is mine, not the gate's -- the gate
did exactly what it exists to do, loudly and immediately.

Verified in both directions rather than assumed:
  --check before -> exit 1, naming the file, its line count, and the ref compared
  --check after  -> exit 0, 138 images

Follow-up worth considering, not done here: merging a PR that adds an image should be
followed by the regeneration in the same step, or the feed should be generated in CI
rather than committed. Three regenerations have now been needed in two days.