### PR TITLE
docs(tracker): regenerate PROGRESS_TRACKER.md — Beneath reached rung 3

### DIFF
--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -75,12 +75,12 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | Asterix & Obelix - Babylon Mission | `PPSA30490` | 3 | `123---` | - | none | [#1599](https://github.com/mattias800/prosper/issues/1599), [#2743](https://github.com/mattias800/prosper/issues/2743), [#2738](https://github.com/mattias800/prosper/issues/2738) | [#1884](https://github.com/mattias800/prosper/issues/1884) | [`ASTERIX_BABYLON_STATUS.md`](prosper/docs/ASTERIX_BABYLON_STATUS.md) |
 | Bendy and the Dark Revival | `PPSA27624` | 3 | `123---` | - | none | [#1979](https://github.com/mattias800/prosper/issues/1979), [#1955](https://github.com/mattias800/prosper/issues/1955) | [#1897](https://github.com/mattias800/prosper/issues/1897) | - |
 | Bendy and the Ink Machine | `PPSA27616` | 3 | `123---` | - | none | [#1178](https://github.com/mattias800/prosper/issues/1178), [#1177](https://github.com/mattias800/prosper/issues/1177) | [#1881](https://github.com/mattias800/prosper/issues/1881) | - |
+| Beneath | `PPSA27640` | 3 | `123---` | - | none | [#2813](https://github.com/mattias800/prosper/issues/2813), [#2815](https://github.com/mattias800/prosper/issues/2815) | [#1898](https://github.com/mattias800/prosper/issues/1898) | [`BENEATH_STATUS.md`](prosper/docs/BENEATH_STATUS.md) |
 | Grand Theft Auto V | `PPSA04263` | 3 | `123---` | - | none | [#2429](https://github.com/mattias800/prosper/issues/2429) | [#1873](https://github.com/mattias800/prosper/issues/1873) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Syberia: Remastered | `PPSA30140` | 3 | `123---` | - | none | [#1790](https://github.com/mattias800/prosper/issues/1790), [#1627](https://github.com/mattias800/prosper/issues/1627), [#1737](https://github.com/mattias800/prosper/issues/1737), [#1628](https://github.com/mattias800/prosper/issues/1628) | [#1811](https://github.com/mattias800/prosper/issues/1811) | [`SYBERIA_STATUS.md`](prosper/docs/SYBERIA_STATUS.md) |
 | Tactics Ogre: Reborn | `PPSA03839` | 3 | `123---` | - | none | [#1913](https://github.com/mattias800/prosper/issues/1913), [#1784](https://github.com/mattias800/prosper/issues/1784) | [#1892](https://github.com/mattias800/prosper/issues/1892) | - |
 | The House of the Dead 2: Remake | `PPSA24203` | 3 | `123---` | - | none | [#1907](https://github.com/mattias800/prosper/issues/1907) | [#1896](https://github.com/mattias800/prosper/issues/1896) | - |
 | Astro Bot | `PPSA21564` | 2 | `12----` | - | none | [#1732](https://github.com/mattias800/prosper/issues/1732), [#1459](https://github.com/mattias800/prosper/issues/1459), [#1730](https://github.com/mattias800/prosper/issues/1730), [#1731](https://github.com/mattias800/prosper/issues/1731) | [#1809](https://github.com/mattias800/prosper/issues/1809) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
-| Beneath | `PPSA27640` | 2 | `12----` | - | none | - | [#1898](https://github.com/mattias800/prosper/issues/1898) | - |
 | Crisis Core –Final Fantasy VII– Reunion | `PPSA07809` | 2 | `12----` | - | none | [#1945](https://github.com/mattias800/prosper/issues/1945), [#2057](https://github.com/mattias800/prosper/issues/2057), [#2058](https://github.com/mattias800/prosper/issues/2058), [#2027](https://github.com/mattias800/prosper/issues/2027) | [#1894](https://github.com/mattias800/prosper/issues/1894) | [`CRISIS_CORE_STATUS.md`](prosper/docs/CRISIS_CORE_STATUS.md) |
 | Dragon Quest VII Reimagined | `PPSA17942` | 2 | `12----` | - | none | [#1486](https://github.com/mattias800/prosper/issues/1486), [#1588](https://github.com/mattias800/prosper/issues/1588), [#1706](https://github.com/mattias800/prosper/issues/1706), [#2778](https://github.com/mattias800/prosper/issues/2778) | [#1874](https://github.com/mattias800/prosper/issues/1874) | [`DRAGON_QUEST_STATUS.md`](prosper/docs/DRAGON_QUEST_STATUS.md) |
 | Earthion | `PPSA28061` | 2 | `12----` | - | none | [#1773](https://github.com/mattias800/prosper/issues/1773) | [#1880](https://github.com/mattias800/prosper/issues/1880) | - |
@@ -102,8 +102,8 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | --- | --- |
 | 6 -- reviewed automatic gameplay snapshot guard | 14 |
 | 4 -- manual visual verification | 2 |
-| 3 -- gameplay with real GPU draws | 7 |
-| 2 -- title screen | 14 |
+| 3 -- gameplay with real GPU draws | 8 |
+| 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
 | 0 -- not started | 1 |
 


### PR DESCRIPTION
docs(tracker): regenerate PROGRESS_TRACKER.md — Beneath reached rung 3

Tracker #1898 was ticked to rung 3 (PPSA27640 reaches Media/level14, the Science Ship
opening dive, with the title's own waypoint HUD counting the objective down 39m -> 14m
across a walked route). The projection reads tracker bodies, so master's committed copy
went stale the moment that edit landed and the Docs gate has been red on every open PR
since -- a reviewer hit it on an unrelated branch and correctly identified it as
pre-existing on their base rather than hunting their own diff.

  Beneath: rung 2 -> 3, ladder `12----` -> `123---`
  distribution: rung 3 count 7 -> 8, rung 2 count 14 -> 13

Regenerated with the tool, not hand-edited.

This is the second generated-file gate to go red on master today; SCREENSHOTS.md was the
other (#2823). Both have the same shape and it is worth naming: a file generated from
state that lives OUTSIDE the commit -- GitHub tracker bodies here, the image set plus its
add-commits there -- cannot be produced correctly before the merge that changes that
state. So the regeneration is always a separate step after the fact, and a missed step
turns every unrelated PR red.

The gates are behaving correctly and loudly; the cost is real and now measured at three
misses in two days. Worth considering, not done here: regenerate in CI and commit from
there, or make the merge step regenerate. Filed as a note rather than acted on
unilaterally.