### PR TITLE
docs: regenerate SCREENSHOTS.md — master's Docs gate is red on two new gameplay captures

### DIFF
--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -9,7 +9,7 @@
 
 **Every screenshot checked into this repository, most recent first.** Read down from the top and stop when you reach one you have already seen.
 
-**138 images**, most recent **2026-08-21**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
+**140 images**, most recent **2026-08-21**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
 
 This file is generated from git history by [`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) and is regenerated and diffed in CI, so it cannot drift from the tree. [`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a reverse-chronological index of the images themselves.
 
@@ -19,6 +19,22 @@ This file is generated from git history by [`prosper/tools/docs/gen_screenshot_f
 > a record of *when* things happened.
 
 ## 2026-08-21
+
+### sonic-frontiers-cyberspace-hud.png
+
+<p align="center"><img src="assets/screenshots/sonic-frontiers-cyberspace-hud.png" alt="sonic frontiers cyberspace hud"></p>
+
+feat(sonic-frontiers): a route reaches Cyber Space gameplay, and the world behind the HUD is black for a measured reason (#2791)
+
+`412b66c5` · [`assets/screenshots/sonic-frontiers-cyberspace-hud.png`](assets/screenshots/sonic-frontiers-cyberspace-hud.png)
+
+### beneath-gameplay.png
+
+<p align="center"><img src="assets/screenshots/beneath-gameplay.png" alt="beneath gameplay"></p>
+
+compat(beneath): PPSA27640 reaches gameplay — a Cross-only route, and the boot fault is the guest's own stack unwinder (#1898) (#2817)
+
+`9aef9f13` · [`assets/screenshots/beneath-gameplay.png`](assets/screenshots/beneath-gameplay.png)
 
 ### rtype-delta-stage1-restored.png
 


### PR DESCRIPTION
Master's Docs gate is red: `SCREENSHOTS.md` describes 138 images while master's tree holds 140.

```
$ comm -23 <(git ls-tree -r --name-only origin/master -- assets/screenshots | xargs -n1 basename | sort -u) \
           <(git show origin/master:SCREENSHOTS.md | grep '^### ' | sed 's/^### //' | sort -u)
beneath-gameplay.png
sonic-frontiers-cyberspace-hud.png
```

Both arrived in the last hour, from #2817 (Beneath reaches gameplay) and #2791 (a Sonic Frontiers
route reaches Cyber Space gameplay). Neither carried the follow-up regeneration, so every open PR
that merges master in now fails Docs on a file it never touched — currently #2820 and #2784.

## Why this is a post-merge step and not something the merging PR can do

The feed records, per image, the **SHA and date of the commit that added it**, and a squash merge
only mints those at merge time. A feed regenerated on a branch is therefore stale the instant it
lands. The CI gate encodes this deliberately — it checks the PR's file against the images in
`origin/master`, and `ci.yml` says so:

> The feed describes MASTER, and is regenerated after a screenshot merge -- so the check
> regenerates from `origin/master` too, and both sides agree on a PR branch that has not merged yet.

So a PR adding a screenshot is *supposed* to leave the feed alone. That contract is sound; what is
missing is anything that guarantees the post-merge regeneration actually happens. It has now been
missed three times in about 36 hours (#2823, #2826, this). Mechanism, measurements and three
candidate fixes are in **#2827** — my preference is regenerating in CI so the manual step stops
existing.

## Verification

```
$ python3 prosper/tools/docs/gen_screenshot_feed.py
140 image(s) scanned
$ python3 prosper/tools/docs/gen_screenshot_feed.py --check --ref origin/master
SCREENSHOTS.md is up to date with the tree (140 images).      # exit 0
$ git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py
                                                              # exit 0, 130 files
$ git diff --name-only origin/master...HEAD | grep -v '\.md$'
                                                              # empty -- docs-only
```

Generated output only; no prose was hand-edited. Merging under the documented docs-only exception,
since master is currently red and nothing CI can say about a `.md`-only diff bears on that.

Refs #2827
