### PR TITLE
compat: R-Type Delta and Sonic Frontiers reach gameplay — and the summary counts were already wrong by three

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -47,8 +47,8 @@ Last updated: 2026-08-17
 | *The Plucky Squire* | `PPSA15319` | Unreal Engine 4 | 🚧 Title and save/play-style menus | [#1882](https://github.com/mattias800/prosper/issues/1882) |
 | *The Pathless* | `PPSA01826` | Unreal Engine 4 | 🚧 Title screen | [#1883](https://github.com/mattias800/prosper/issues/1883) |
 | *ArcRunner* | `PPSA21406` | Unreal Engine 4 | 🚧 Intro cinematic and title screen; needs one default-off switch, not the throttle | [#1817](https://github.com/mattias800/prosper/issues/1817) |
-| *Asterix &amp; Obelix: Babylon Mission* | `PPSA30490` | Unity 6 / IL2CPP | 🚧 Logo movies, intro cutscene, and title menu | [#1884](https://github.com/mattias800/prosper/issues/1884) |
-| *R-Type Delta: HD Boosted* | `PPSA26414` | Custom | 🚧 Title screen and attract mode | [#1810](https://github.com/mattias800/prosper/issues/1810) |
+| *Asterix &amp; Obelix: Babylon Mission* | `PPSA30490` | Unity 6 / IL2CPP | 🚧 `World_3_10` harbour-level gameplay, reached 1 run in 5 | [#1884](https://github.com/mattias800/prosper/issues/1884) |
+| *R-Type Delta: HD Boosted* | `PPSA26414` | Custom | 🚧 Stage 1 gameplay on a scripted route | [#1810](https://github.com/mattias800/prosper/issues/1810) |
 | *Nikoderiko: The Magical World* | `PPSA23760` | Unreal Engine 4 | 🚧 Title screen and EULA | [#1885](https://github.com/mattias800/prosper/issues/1885) |
 | *The Oregon Trail* | `PPSA19244` | Unreal Engine 4 | 🚧 Title screen reached and rendered | [#1886](https://github.com/mattias800/prosper/issues/1886) |
 | *Greak: Memories of Azur* | `PPSA02849` | Unity / IL2CPP | ✅ First-level gameplay | [#1887](https://github.com/mattias800/prosper/issues/1887) |
@@ -68,33 +68,37 @@ Last updated: 2026-08-17
 
 Derived from the table above by reading each row's **milestone text** against the six-rung bring-up
 ladder in `CLAUDE.md`. It is *not* derived from the ✅/🚧/🔬 markers, which are not a rung scale:
-seven of the twenty-one titles that reach gameplay are marked 🚧 rather than ✅, and the two 🔬 rows sit
+twelve of the twenty-six titles that reach gameplay are marked 🚧 rather than ✅, and the two 🔬 rows sit
 at two different rungs. Counting markers gives a different — and wrong — answer.
 
 | Where the title stops | Titles |
 | --- | --- |
-| **Gameplay reached** with real GPU draws (rung 3 or better) | 21 |
-| **Title screen or menu** reached, gameplay not yet reached (rung 2) | 17 |
+| **Gameplay reached** with real GPU draws (rung 3 or better) | 26 |
+| **Title screen or menu** reached, gameplay not yet reached (rung 2) | 12 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
 | Total tracked | 39 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 It includes *Grand Theft Auto V*, which enters Story Mode with a correct HUD and radar over an absent
-3D world, and *Syberia: Remastered*, whose gameplay composite is degraded.
+3D world, *Sonic Frontiers*, which reaches a running Cyber Space stage whose world is entirely black,
+and *Syberia: Remastered*, whose gameplay composite is degraded. **Three of the 23 therefore reach
+gameplay without a visible world.** That is a deliberate reading of the ladder, not an oversight: rung
+3 asks for gameplay with real GPU draws, and a HUD over a running stage clock is real draws. If the
+project would rather rung 3 require a visible world, all three rows move together.
 
 ### Where the titles accumulate
 
-The 17 titles that stop at a title screen or menu, by the engine recorded in the table:
+The 12 titles that stop at a title screen or menu, by the engine recorded in the table:
 
 | Engine | Titles |
 | --- | --- |
 | Unreal Engine — 8 × UE4, 1 × UE5, 1 unversioned | 10 |
-| Unity / IL2CPP, including Unity 6 | 3 |
-| Hedgehog Engine 2, Custom, Custom (Ancient), ASOBI — one each | 4 |
+| Custom (Ancient), ASOBI — one each | 2 |
 
 **Every Unreal title in the table is in this group.** Ten of the 39 rows are Unreal; all ten reach a
 title screen and none has reached gameplay. The distribution is the mirror image on the other side:
-16 of the 21 titles at gameplay are Unity-family, as are 12 of the 14 ✅ rows.
+19 of the 26 titles at gameplay are Unity-family, as are 12 of the 14 ✅ rows — and **no Unity title
+remains below gameplay.** The rung-2 group is now ten Unreal titles plus *Earthion* and *Astro Bot*.
 
 **This is an observation about where titles accumulate, not a claim that the ten Unreal titles share
 one root cause.** A common cause is an untested hypothesis, and the per-title records currently cut
@@ -361,16 +365,22 @@ This is not yet counted as a title screen on a default launch, because it still 
 
 <p align="center"><img src="assets/screenshots/asterix-babylon-intro-cutscene.png" alt="Asterix &amp; Obelix: Babylon Mission — narrated intro cutscene"></p>
 <p align="center"><img src="assets/screenshots/asterix-babylon-title.png" alt="Asterix &amp; Obelix: Babylon Mission — title screen and main menu"></p>
+<p align="center"><img src="assets/screenshots/asterix-babylon-gameplay.png" alt="Asterix &amp; Obelix: Babylon Mission — the World_3_10 harbour level, both character portraits with heart meters, Asterix and Obelix among NPCs with parallax and water"></p>
 
-Both publisher logo movies, the narrated intro cutscene and the title screen with its `ADVENTURE` / `OPTIONS` menu render at native 1920×1080. See the [tracker](https://github.com/mattias800/prosper/issues/1884).
+Both publisher logo movies, the narrated intro cutscene and the title screen with its `ADVENTURE` / `OPTIONS` menu render at native 1920×1080, and the route crosses them into the `World_3_10` harbour level — both character portraits with heart meters, Asterix and Obelix in a composed scene with NPCs, parallax, water and rotating Roman-helmet collectibles, inspected over 43 samples in 430 s with no black or flat frame.
+
+**Gameplay here is demonstrated rather than reproducible**, which is why the row is 🚧: the committed route reaches it **1 run in 5**, and the other four stop on the `SoloCoopMenu` character-select screen while the guest is *observed* receiving 66 Cross presses ([#2743](https://github.com/mattias800/prosper/issues/2743)). The nondeterminism sits below the route, so a rerun is not a fix. See the [tracker](https://github.com/mattias800/prosper/issues/1884).
 
 ## R-Type Delta: HD Boosted — `PPSA26414`
 
 <p align="center"><img src="assets/screenshots/rtype-delta-opening-movie-colour.png" alt="R-Type Delta — the opening movie's R-9 hangar shot in full colour"></p>
 <p align="center"><img src="assets/screenshots/rtype-delta-title.png" alt="R-Type Delta: HD Boosted — title screen"></p>
 <p align="center"><img src="assets/screenshots/rtype-delta-force-select.png" alt="R-Type Delta — attract-mode demonstration, the R-9 and its Force device"></p>
+<p align="center"><img src="assets/screenshots/rtype-delta-stage1-restored.png" alt="R-Type Delta — stage 1 gameplay: the R-9 and its Force device over the sunset cityscape, enemy formations, and the BEAM and score HUD"></p>
 
-The Clear River Games publisher logo and the full opening movie — the R-9 fighter in its hangar — render live at 1920×1080 from the real GPU command stream, in full colour, and the run continues into the **title screen** and the attract-mode demonstration. Gameplay has not yet been reached.
+The Clear River Games publisher logo and the full opening movie — the R-9 fighter in its hangar — render live at 1920×1080 from the real GPU command stream, in full colour, and the run continues into the **title screen**, the attract-mode demonstration and **stage 1 gameplay**.
+
+Gameplay needs the scripted route [`prosper/scripts/rtype-delta-PPSA26414/reach-gameplay.pad`](prosper/scripts/rtype-delta-PPSA26414/reach-gameplay.pad): the title screen's prompt is the PS5 **OPTIONS** glyph rather than Cross, so a Cross-only arm never clears it. Player control is distinguished from the attract loop — which plays stage 1 by itself with the pad untouched — by three things a neutral-input control arm never produces: `loadsel_Release.prx`, `loads1_Release.prx` and a `SaveData.dat` write.
 
 Reaching this needs the game's files **evicted from the host page cache** first, which takes one command and no change to how the title is launched:
 

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -77,6 +77,8 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | Bendy and the Ink Machine | `PPSA27616` | 3 | `123---` | - | none | [#1178](https://github.com/mattias800/prosper/issues/1178), [#1177](https://github.com/mattias800/prosper/issues/1177) | [#1881](https://github.com/mattias800/prosper/issues/1881) | - |
 | Beneath | `PPSA27640` | 3 | `123---` | - | none | [#2813](https://github.com/mattias800/prosper/issues/2813), [#2815](https://github.com/mattias800/prosper/issues/2815) | [#1898](https://github.com/mattias800/prosper/issues/1898) | [`BENEATH_STATUS.md`](prosper/docs/BENEATH_STATUS.md) |
 | Grand Theft Auto V | `PPSA04263` | 3 | `123---` | - | none | [#2429](https://github.com/mattias800/prosper/issues/2429) | [#1873](https://github.com/mattias800/prosper/issues/1873) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
+| R-Type Delta: HD Boosted | `PPSA26414` | 3 | `123---` | - | none | [#1746](https://github.com/mattias800/prosper/issues/1746), [#1591](https://github.com/mattias800/prosper/issues/1591) | [#1810](https://github.com/mattias800/prosper/issues/1810) | [`R_TYPE_DELTA_STATUS.md`](prosper/docs/R_TYPE_DELTA_STATUS.md) |
+| Sonic Frontiers | `PPSA03831` | 3 | `123---` | - | none | [#2206](https://github.com/mattias800/prosper/issues/2206), [#657](https://github.com/mattias800/prosper/issues/657) | [#1891](https://github.com/mattias800/prosper/issues/1891) | [`SONIC_FRONTIERS_STATUS.md`](prosper/docs/SONIC_FRONTIERS_STATUS.md) |
 | Syberia: Remastered | `PPSA30140` | 3 | `123---` | - | none | [#1790](https://github.com/mattias800/prosper/issues/1790), [#1627](https://github.com/mattias800/prosper/issues/1627), [#1737](https://github.com/mattias800/prosper/issues/1737), [#1628](https://github.com/mattias800/prosper/issues/1628) | [#1811](https://github.com/mattias800/prosper/issues/1811) | [`SYBERIA_STATUS.md`](prosper/docs/SYBERIA_STATUS.md) |
 | Tactics Ogre: Reborn | `PPSA03839` | 3 | `123---` | - | none | [#1913](https://github.com/mattias800/prosper/issues/1913), [#1784](https://github.com/mattias800/prosper/issues/1784) | [#1892](https://github.com/mattias800/prosper/issues/1892) | - |
 | The House of the Dead 2: Remake | `PPSA24203` | 3 | `123---` | - | none | [#1907](https://github.com/mattias800/prosper/issues/1907) | [#1896](https://github.com/mattias800/prosper/issues/1896) | - |
@@ -86,8 +88,6 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | Earthion | `PPSA28061` | 2 | `12----` | - | none | [#1773](https://github.com/mattias800/prosper/issues/1773) | [#1880](https://github.com/mattias800/prosper/issues/1880) | - |
 | Little Nightmares III | `PPSA05143` | 2 | `12----` | - | none | [#2014](https://github.com/mattias800/prosper/issues/2014), [#2022](https://github.com/mattias800/prosper/issues/2022), [#2028](https://github.com/mattias800/prosper/issues/2028), [#1977](https://github.com/mattias800/prosper/issues/1977) | [#1893](https://github.com/mattias800/prosper/issues/1893) | [`LITTLE_NIGHTMARES_3_STATUS.md`](prosper/docs/LITTLE_NIGHTMARES_3_STATUS.md) |
 | Nikoderiko: The Magical World | `PPSA23760` | 2 | `12----` | - | none | [#1607](https://github.com/mattias800/prosper/issues/1607) | [#1885](https://github.com/mattias800/prosper/issues/1885) | [`NIKODERIKO_STATUS.md`](prosper/docs/NIKODERIKO_STATUS.md) |
-| R-Type Delta: HD Boosted | `PPSA26414` | 2 | `12----` | - | none | [#2783](https://github.com/mattias800/prosper/issues/2783), [#1746](https://github.com/mattias800/prosper/issues/1746), [#1591](https://github.com/mattias800/prosper/issues/1591) | [#1810](https://github.com/mattias800/prosper/issues/1810) | [`R_TYPE_DELTA_STATUS.md`](prosper/docs/R_TYPE_DELTA_STATUS.md) |
-| Sonic Frontiers | `PPSA03831` | 2 | `12----` | - | none | [#2206](https://github.com/mattias800/prosper/issues/2206), [#657](https://github.com/mattias800/prosper/issues/657) | [#1891](https://github.com/mattias800/prosper/issues/1891) | [`SONIC_FRONTIERS_STATUS.md`](prosper/docs/SONIC_FRONTIERS_STATUS.md) |
 | Sonic Racing: CrossWorlds | `PPSA08804` | 2 | `12----` | - | none | [#2361](https://github.com/mattias800/prosper/issues/2361), [#2362](https://github.com/mattias800/prosper/issues/2362), [#2363](https://github.com/mattias800/prosper/issues/2363), [#2309](https://github.com/mattias800/prosper/issues/2309), [#2303](https://github.com/mattias800/prosper/issues/2303) | [#1895](https://github.com/mattias800/prosper/issues/1895) | [`SONIC_CROSSWORLDS_STATUS.md`](prosper/docs/SONIC_CROSSWORLDS_STATUS.md) |
 | The Forgotten City | `PPSA03026` | 2 | `12----` | - | none | [#1961](https://github.com/mattias800/prosper/issues/1961), [#1945](https://github.com/mattias800/prosper/issues/1945), [#1226](https://github.com/mattias800/prosper/issues/1226) | [#1890](https://github.com/mattias800/prosper/issues/1890) | - |
 | The Oregon Trail | `PPSA19244` | 2 | `12----` | - | none | [#1945](https://github.com/mattias800/prosper/issues/1945), [#1606](https://github.com/mattias800/prosper/issues/1606), [#1641](https://github.com/mattias800/prosper/issues/1641), [#1634](https://github.com/mattias800/prosper/issues/1634) | [#1886](https://github.com/mattias800/prosper/issues/1886) | [`OREGON_TRAIL_STATUS.md`](prosper/docs/OREGON_TRAIL_STATUS.md) |
@@ -102,8 +102,8 @@ cannot parse and writes no file at all, so a row that is present is a row that w
 | --- | --- |
 | 6 -- reviewed automatic gameplay snapshot guard | 14 |
 | 4 -- manual visual verification | 2 |
-| 3 -- gameplay with real GPU draws | 8 |
-| 2 -- title screen | 13 |
+| 3 -- gameplay with real GPU draws | 10 |
+| 2 -- title screen | 11 |
 | 1 -- any real graphics | 1 |
 | 0 -- not started | 1 |
 

--- a/SCREENSHOTS.md
+++ b/SCREENSHOTS.md
@@ -9,7 +9,7 @@
 
 **Every screenshot checked into this repository, most recent first.** Read down from the top and stop when you reach one you have already seen.
 
-**140 images**, most recent **2026-08-21**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
+**141 images**, most recent **2026-08-21**. Captions are the subject line of the commit that added each image, so they say what the change was rather than what the picture is.
 
 This file is generated from git history by [`prosper/tools/docs/gen_screenshot_feed.py`](prosper/tools/docs/gen_screenshot_feed.py) and is regenerated and diffed in CI, so it cannot drift from the tree. [`COMPATIBILITY.md`](COMPATIBILITY.md) remains the per-title overview and [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table; this is only a reverse-chronological index of the images themselves.
 
@@ -19,6 +19,14 @@ This file is generated from git history by [`prosper/tools/docs/gen_screenshot_f
 > a record of *when* things happened.
 
 ## 2026-08-21
+
+### rtype-delta-stage1-gameplay.png
+
+<p align="center"><img src="assets/screenshots/rtype-delta-stage1-gameplay.png" alt="rtype delta stage1 gameplay"></p>
+
+scripts+docs(rtype-delta): an input route for PPSA26414 that reaches stage 1 — and the regression (#2783) that stops master drawing any of it (#2784)
+
+`6dd608bb` · [`assets/screenshots/rtype-delta-stage1-gameplay.png`](assets/screenshots/rtype-delta-stage1-gameplay.png)
 
 ### sonic-frontiers-cyberspace-hud.png
 


### PR DESCRIPTION
Two titles reach gameplay, and the summary counts are **re-derived from the table rows** instead of
adjusted by hand — which turned up two errors that were already on master.

## The two rung-3 ticks

**R-Type Delta: HD Boosted** (#1810) renders stage 1 — the R-9, its Force device, enemy formations
over the sunset cityscape, and the `BEAM`/charge/score HUD. Two independent things had to land: the
**input route** (#2784; the title screen's prompt is the PS5 OPTIONS glyph, not Cross) and the
**renderer** (#2799; a saved wave-mask alias outlived its SGPR pair, so the recompiler refused
`shader/sprite_i_vv.ags`, the sprite vertex shader — one rejection that dropped every menu, HUD and
gameplay draw while the logo and movie kept rendering). #2783 closed on a 46-of-46 A/B over this
route. Player control is distinguished from the attract loop — which plays stage 1 by itself with
the pad untouched — by `loadsel_Release.prx` + `loads1_Release.prx` + a `SaveData.dat` write.

**Sonic Frontiers** (#1891) reaches a running Cyber Space stage on the #2791 route — stage HUD,
clock, BGM, one hundred streamed terrain sectors — **with the world black behind it** (#2790).

> **This tick is a judgement call and the tracker records it as reversible.** The ladder says
> "gameplay with real GPU draws", and COMPATIBILITY.md already counts *Grand Theft Auto V* at
> gameplay in its own words — "enters Story Mode with a correct HUD and a black world". Counting one
> and not the other would make the table depend on which lane wrote the row. If rung 3 should
> require a visible world, revert **both** titles together; the inconsistency is what is worth
> avoiding, not the specific answer. Three of the 26 now reach gameplay without a visible world, and
> the caveat paragraph says so explicitly.

Frontiers' black capture is linked from its tracker and described in prose but **not embedded in the
gallery**, matching how GTA V is already handled.

## Two pre-existing errors, found by deriving rather than adjusting

* **Asterix & Obelix: Babylon Mission reached gameplay at #2736 on 2026-08-19**, and its row still
  read *"Logo movies, intro cutscene, and title menu"* — stale for two days, so the summary was
  already undercounting before today. Corrected, with `asterix-babylon-gameplay.png` added and the
  route's **1-in-5** nondeterminism (#2743) stated where a reader will see it rather than only in
  the tracker.
* **The rung-2 engine table claimed 3 Unity/IL2CPP titles. There are none.** That group is ten
  Unreal titles plus *Earthion* (Custom (Ancient)) and *Astro Bot* (ASOBI). The Unity row was
  decremented by hand across several PRs and drifted.

Both are the same failure as #2827 in a hand-maintained file: a derived number updated by
adjustment rather than recomputation drifts silently, because nothing checks it.

## Counts

| | before | after |
|---|---|---|
| Gameplay (rung 3+) | 23 | **26** |
| Title screen / menu (rung 2) | 15 | **12** |
| Below a title screen | 1 | 1 |
| **Total** | 39 | **39** |

Engine table sums 10 + 2 = 12. `PROGRESS_TRACKER.md` independently agrees: 26 rows at rung ≥ 3.

## Verification

```
gen_screenshot_feed.py --check --ref origin/master   -> exit 0  (141 images)
gen_progress_tracker.py --check                      -> exit 0  (39 trackers, 39 parsed)
check_numbered_table.py over all .md                 -> exit 0
git diff --check                                     -> clean
git diff --name-only origin/master...HEAD | grep -v '\.md$'  -> empty
```

Both generated files regenerated, not hand-edited. Docs-only; merging under the documented
exception.

Refs #1810, Refs #1891, Refs #1884
