### PR TITLE
docs: "unmodified capture" forbids misrepresenting progress, not annotating it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -584,8 +584,16 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
   and deliberately unaffected behavior, record risks, and list the exact build/test/snapshot commands and
   results. PRs that advance a game's visible progression must attach representative screenshots and identify
   the title, platform, and reached checkpoint; black or diagnostic-only captures are not progression evidence.
-  Use direct, unmodified frontend captures and name the frontend plus the run route in each caption; output
+  Use direct frontend captures and name the frontend plus the run route in each caption; output
   produced by forced guest-state diagnostics may illustrate an investigation but is not acceptance evidence.
+  - **What "unaltered" forbids is misrepresenting the progress, not annotating it.** The rule exists so a
+    screenshot cannot be made to show more than the emulator actually achieved. So: no retouching, no
+    compositing several frames into one, no substituting artwork or an icon for something that did not
+    render, no cherry-picked frame passed off as the steady state, and no forcing guest state to
+    manufacture a better-looking frame. **Annotation that prosper itself draws over its own output is
+    fine and often better** — an fps counter, a timestamp, a route or frame ordinal. Those add measured
+    facts about the run; they do not change what the run rendered. Keep annotation legible and out of
+    the way of whatever the capture is evidence *for*, and say in the caption that it is on.
   Run the strongest relevant local checks and wait for every applicable required CI check. Before
   merging, synchronize with the live target branch when needed, inspect the resulting diff, run `diff --check`,
   and address every known correctness concern.


### PR DESCRIPTION
Project-owner clarification. The evidence rule read as a blanket ban on touching the pixels; what it
is actually for is narrower and sharper.

## Before

> Use direct, **unmodified** frontend captures and name the frontend plus the run route in each caption

## After

> Use direct frontend captures and name the frontend plus the run route in each caption
>
> - **What "unaltered" forbids is misrepresenting the progress, not annotating it.** The rule exists so
>   a screenshot cannot be made to show more than the emulator actually achieved. So: no retouching, no
>   compositing several frames into one, no substituting artwork or an icon for something that did not
>   render, no cherry-picked frame passed off as the steady state, and no forcing guest state to
>   manufacture a better-looking frame. **Annotation that prosper itself draws over its own output is
>   fine and often better** — an fps counter, a timestamp, a route or frame ordinal. Those add measured
>   facts about the run; they do not change what the run rendered. Keep annotation legible and out of
>   the way of whatever the capture is evidence *for*, and say in the caption that it is on.

## Why now

The incoming `--fps` work burns a framerate into captures so every screenshot is self-documenting
about performance — which matters a lot here, since some titles run at ~1 fps and some at full speed
and that fact is currently nowhere in the project record.

Read literally, the old wording made exactly that annotation inadmissible as progression evidence.
That is backwards: the anti-fraud teeth are entirely in "you may not make the frame show more than
the emulator achieved", and an fps counter drawn by prosper over prosper's own output does the
opposite — it tells the reader something true about the run that the raw frame cannot.

Every forbidden case in the new list is a real way to overstate progress, and each is now named
explicitly rather than left to be inferred from one adjective. The forced-guest-state sentence is
unchanged and still carries its own prohibition.

## Verification

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   -> exit 0
git diff --check                                                                       -> clean
git diff --name-only origin/master...HEAD | grep -v '\.md$'                            -> empty
```

Docs-only; merging under the documented exception. Touches a different region of `CLAUDE.md` than
#2834 (line ~587 vs the rung ladder at ~401), so the two do not conflict.
