### PR TITLE
fix(gpu_replay): make the three replay index spaces distinct types (#2739 seam 2)

### DIFF
--- a/prosper/tests/gpu/diagnostics/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/gpu/diagnostics/test_gpu_replay_shader_dump.cpp
@@ -25,6 +25,15 @@ static_assert(!std::is_convertible_v<size_t, prosper::tools::DrawIndex>,
               "a bare integer must not implicitly become a draw ordinal");
 static_assert(!std::is_convertible_v<prosper::tools::ItemIndex, size_t>,
               "an item index must not decay to a bare integer");
+// Asymmetry is a hole: with only the ItemIndex decay pinned, collapsing OperationIndex or DrawIndex
+// alone back to a bare integer passed every assertion here AND the runtime CHECK below. Each space
+// gets its own, so no single one can quietly rejoin the integers.
+static_assert(!std::is_convertible_v<prosper::tools::OperationIndex, size_t>,
+              "an operation index must not decay to a bare integer");
+static_assert(!std::is_convertible_v<prosper::tools::DrawIndex, uint64_t>,
+              "a draw ordinal must not decay to a bare integer");
+static_assert(!std::is_convertible_v<prosper::tools::ItemIndex, prosper::tools::DrawIndex>,
+              "an item index must not convert to a draw ordinal");
 static_assert(prosper::tools::raw(prosper::tools::ItemIndex{7}) == 7u,
               "raw() round-trips the underlying value");
 

--- a/prosper/tests/gpu/diagnostics/test_gpu_replay_shader_dump.cpp
+++ b/prosper/tests/gpu/diagnostics/test_gpu_replay_shader_dump.cpp
@@ -3,12 +3,30 @@
 #include "gpu/diagnostics/diagnostic_selectors.hpp"
 
 #include <cstdio>
+#include <type_traits>
 
 using namespace prosper;
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
                          else std::printf("  [ok]   %s\n", m); } while (0)
+
+// The seam this file guards is a TYPE property, so pin it as one: if any of these three index
+// spaces ever collapses back into a bare integer, or into each other, this stops compiling. That is
+// the whole mechanism -- #2739 seam 2 was a silent implicit conversion, and a runtime CHECK cannot
+// observe a conversion that the compiler performs for you.
+static_assert(!std::is_convertible_v<prosper::tools::ItemIndex, prosper::tools::OperationIndex>,
+              "an item index must not convert to an operation index");
+static_assert(!std::is_convertible_v<prosper::tools::OperationIndex, prosper::tools::ItemIndex>,
+              "an operation index must not convert to an item index");
+static_assert(!std::is_convertible_v<prosper::tools::DrawIndex, prosper::tools::ItemIndex>,
+              "a draw ordinal must not convert to an item index");
+static_assert(!std::is_convertible_v<size_t, prosper::tools::DrawIndex>,
+              "a bare integer must not implicitly become a draw ordinal");
+static_assert(!std::is_convertible_v<prosper::tools::ItemIndex, size_t>,
+              "an item index must not decay to a bare integer");
+static_assert(prosper::tools::raw(prosper::tools::ItemIndex{7}) == 7u,
+              "raw() round-trips the underlying value");
 
 int main() {
     std::printf("== test_gpu_replay_shader_dump ==\n");
@@ -102,9 +120,15 @@ int main() {
     CHECK(vs == &replay.raw_shader_versions[1] && fs == &replay.raw_shader_versions[0] &&
               main == &replay.raw_shader_versions[2],
           "selector resolves a semantic draw ID instead of a compact item offset");
-    CHECK(tools::replay_item_index_for_draw(replay, 11) == 1 &&
-              tools::replay_operation_index_for_draw(replay, 11) == 2 &&
-              tools::replay_item_index_for_draw(replay, 1) == SIZE_MAX,
+    // Draw 11 resolves to item 1 but operation 2 -- the two spaces DIVERGE in this fixture, which
+    // is what makes the next assertion meaningful rather than a tautology. Before these were
+    // distinct types both results were bare size_t, so either function's answer satisfied either
+    // comparison and the mix-up that caused #2739 seam 2 compiled silently.
+    CHECK(tools::replay_item_index_for_draw(replay, tools::DrawIndex{11}) == tools::ItemIndex{1} &&
+              tools::replay_operation_index_for_draw(replay, tools::DrawIndex{11}) ==
+                  tools::OperationIndex{2} &&
+              tools::replay_item_index_for_draw(replay, tools::DrawIndex{1}) ==
+                  tools::kNoItemIndex,
           "draw IDs map across compact-item holes and mixed operation indices");
     CHECK(!tools::select_realized_raw_shader(replay, "2:vs", error) &&
               error.find("realized draw 2 not found") != std::string::npos,

--- a/prosper/tests/test_gpu_replay_resource_override.cpp
+++ b/prosper/tests/test_gpu_replay_resource_override.cpp
@@ -94,7 +94,7 @@ int main() {
               replay.items[0].prt->resources[1].host_data == original_neighbour_pointer &&
               neighbour == std::vector<uint8_t>({0xaa, 0xbb, 0xcc, 0xdd}),
           "unselected stage and binding retain their original objects and bytes");
-    CHECK(applied.target.item_index == 0 && applied.target.resource_index == 0 &&
+    CHECK(applied.target.item_index == prosper::tools::ItemIndex{0} && applied.target.resource_index == 0 &&
               applied.target.gpu_addr == 0x12345000 && applied.target.captured_size == 4,
           "installed override reports exact draw-resource identity and captured span");
 

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1900,7 +1900,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                 prosper::tools::replay_operation_index_for_draw(
                     replay, prosper::tools::DrawIndex{resource_override_draw_index});
             if (overridden_operation == prosper::tools::kNoOperationIndex ||
-                raw(overridden_operation) >= operation_limit)
+                prosper::tools::raw(overridden_operation) >= operation_limit)
                 std::fprintf(stderr,
                              "gpu_replay: WARNING the overridden draw (%llu) is NOT in this "
                              "submit's executed prefix (%llu of %llu operations), so it cannot "
@@ -2697,13 +2697,13 @@ int main(int argc, char** argv) {
         const prosper::tools::ItemIndex item_index =
             prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{n});
         if (item_index != prosper::tools::kNoItemIndex) {
-            auto& it = replay.items[raw(item_index)];
+            auto& it = replay.items[prosper::tools::raw(item_index)];
             const prosper::tools::OperationIndex operation_index =
                 prosper::tools::replay_operation_index_for_draw(
                     replay, prosper::tools::DrawIndex{n});
             const long long operation_label =
                 operation_index == prosper::tools::kNoOperationIndex
-                    ? -1 : static_cast<long long>(raw(operation_index));
+                    ? -1 : static_cast<long long>(prosper::tools::raw(operation_index));
             const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
             const auto* system_inputs = it.has_system_inputs ? &it.system_inputs : nullptr;
             std::vector<uint32_t> rebuilt_geometry;
@@ -2738,7 +2738,7 @@ int main(int argc, char** argv) {
                 std::fprintf(stderr,
                              "[geom-probe] draw=%llu item=%zu operation=%lld reused stored VS "
                              "with xfb in GS (%zu VS words, %zu GS words, lds=%u dwords)\n",
-                             draw_label, item_index, operation_label, it.vs_words().size(),
+                             draw_label, prosper::tools::raw(item_index), operation_label, it.vs_words().size(),
                              it.gs.size(), it.vertex_lds_dwords);
             } else {
                 const auto& raw = replay.raw_shader_versions[it.vs_raw_shader_index];
@@ -2765,7 +2765,7 @@ int main(int argc, char** argv) {
                 std::fprintf(stderr,
                              "[geom-probe] draw=%llu item=%zu operation=%lld VS%s re-recompiled "
                              "with xfb in VS (%zu VS words, 0 GS words, lds=%u dwords)\n",
-                             draw_label, item_index, operation_label,
+                             draw_label, prosper::tools::raw(item_index), operation_label,
                              linked ? "+main" : "", it.vs_words().size(),
                              it.vertex_lds_dwords);
             }
@@ -2799,13 +2799,13 @@ int main(int argc, char** argv) {
         const prosper::tools::ItemIndex item_index =
             prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{n});
         if (item_index != prosper::tools::kNoItemIndex) {
-            auto& it = replay.items[raw(item_index)];
+            auto& it = replay.items[prosper::tools::raw(item_index)];
             const prosper::tools::OperationIndex operation_index =
                 prosper::tools::replay_operation_index_for_draw(
                     replay, prosper::tools::DrawIndex{n});
             const long long operation_label =
                 operation_index == prosper::tools::kNoOperationIndex
-                    ? -1 : static_cast<long long>(raw(operation_index));
+                    ? -1 : static_cast<long long>(prosper::tools::raw(operation_index));
             if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
                 const auto interpolation = prosper::gpu::fragment_interpolation_layout(
@@ -2822,7 +2822,7 @@ int main(int argc, char** argv) {
                     std::fprintf(stderr,
                                  "[fs-tap] draw=%llu item=%zu operation=%lld FS re-recompiled "
                                  "at pc=%u with colour tap (%zu words)\n",
-                                 draw_label, item_index, operation_label, tap_pc, it.fs.size());
+                                 draw_label, prosper::tools::raw(item_index), operation_label, tap_pc, it.fs.size());
                 } else {
                     std::fprintf(stderr, "[fs-tap] draw %llu: FS re-recompile produced no output "
                                          "(no raw stream / unsupported)\n", draw_label);
@@ -2946,7 +2946,7 @@ int main(int argc, char** argv) {
                          list_resources_spec.c_str());
             return 2;
         }
-        const auto* table = stage == "vs" ? replay.items[raw(di)].vrt.get() : replay.items[raw(di)].prt.get();
+        const auto* table = stage == "vs" ? replay.items[prosper::tools::raw(di)].vrt.get() : replay.items[prosper::tools::raw(di)].prt.get();
         if (!table) {
             std::printf("draw %llu %s: no captured resource table\n", draw_index, stage.c_str());
             return 0;
@@ -2979,7 +2979,7 @@ int main(int argc, char** argv) {
         if (di == prosper::tools::kNoItemIndex || (stage != "vs" && stage != "ps")) {
             std::fprintf(stderr, "gpu_replay: invalid resource selector %s\n", dump_spec.c_str()); return 2;
         }
-        const auto* table = stage == "vs" ? replay.items[raw(di)].vrt.get() : replay.items[raw(di)].prt.get();
+        const auto* table = stage == "vs" ? replay.items[prosper::tools::raw(di)].vrt.get() : replay.items[prosper::tools::raw(di)].prt.get();
         const prosper::gpu::ShaderResource* found = nullptr;
         if (table) for (const auto& resource : table->resources)
             if (static_cast<int>(resource.binding) == binding) { found = &resource; break; }

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -1896,9 +1896,11 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
             // evidence because that submit realized all 30 operations, where the two coincide.
             // replay_operation_index_for_draw() also filters on `realized`, which the hand-rolled
             // loop did not.
-            const size_t overridden_operation = prosper::tools::replay_operation_index_for_draw(
-                replay, resource_override_draw_index);
-            if (overridden_operation == SIZE_MAX || overridden_operation >= operation_limit)
+            const prosper::tools::OperationIndex overridden_operation =
+                prosper::tools::replay_operation_index_for_draw(
+                    replay, prosper::tools::DrawIndex{resource_override_draw_index});
+            if (overridden_operation == prosper::tools::kNoOperationIndex ||
+                raw(overridden_operation) >= operation_limit)
                 std::fprintf(stderr,
                              "gpu_replay: WARNING the overridden draw (%llu) is NOT in this "
                              "submit's executed prefix (%llu of %llu operations), so it cannot "
@@ -2692,13 +2694,16 @@ int main(int argc, char** argv) {
             return 2;
         }
         const auto draw_label = static_cast<unsigned long long>(n);
-        const size_t item_index = prosper::tools::replay_item_index_for_draw(replay, n);
-        if (item_index != SIZE_MAX) {
-            auto& it = replay.items[item_index];
-            const size_t operation_index =
-                prosper::tools::replay_operation_index_for_draw(replay, n);
-            const long long operation_label = operation_index == SIZE_MAX
-                ? -1 : static_cast<long long>(operation_index);
+        const prosper::tools::ItemIndex item_index =
+            prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{n});
+        if (item_index != prosper::tools::kNoItemIndex) {
+            auto& it = replay.items[raw(item_index)];
+            const prosper::tools::OperationIndex operation_index =
+                prosper::tools::replay_operation_index_for_draw(
+                    replay, prosper::tools::DrawIndex{n});
+            const long long operation_label =
+                operation_index == prosper::tools::kNoOperationIndex
+                    ? -1 : static_cast<long long>(raw(operation_index));
             const auto* pixel_inputs = it.has_pixel_inputs ? &it.pixel_inputs : nullptr;
             const auto* system_inputs = it.has_system_inputs ? &it.system_inputs : nullptr;
             std::vector<uint32_t> rebuilt_geometry;
@@ -2791,13 +2796,16 @@ int main(int argc, char** argv) {
             return 2;
         }
         const auto draw_label = static_cast<unsigned long long>(n);
-        const size_t item_index = prosper::tools::replay_item_index_for_draw(replay, n);
-        if (item_index != SIZE_MAX) {
-            auto& it = replay.items[item_index];
-            const size_t operation_index =
-                prosper::tools::replay_operation_index_for_draw(replay, n);
-            const long long operation_label = operation_index == SIZE_MAX
-                ? -1 : static_cast<long long>(operation_index);
+        const prosper::tools::ItemIndex item_index =
+            prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{n});
+        if (item_index != prosper::tools::kNoItemIndex) {
+            auto& it = replay.items[raw(item_index)];
+            const prosper::tools::OperationIndex operation_index =
+                prosper::tools::replay_operation_index_for_draw(
+                    replay, prosper::tools::DrawIndex{n});
+            const long long operation_label =
+                operation_index == prosper::tools::kNoOperationIndex
+                    ? -1 : static_cast<long long>(raw(operation_index));
             if (it.fs_raw_shader_index < replay.raw_shader_versions.size()) {
                 const auto& raw = replay.raw_shader_versions[it.fs_raw_shader_index];
                 const auto interpolation = prosper::gpu::fragment_interpolation_layout(
@@ -2930,15 +2938,15 @@ int main(int argc, char** argv) {
             std::strtoull(list_resources_spec.c_str(), &draw_end, 0);
         const std::string stage = colon == std::string::npos
             ? std::string() : list_resources_spec.substr(colon + 1);
-        const size_t di = colon != std::string::npos &&
+        const prosper::tools::ItemIndex di = colon != std::string::npos &&
                           draw_end == list_resources_spec.c_str() + colon
-            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
-        if (di == SIZE_MAX || (stage != "vs" && stage != "ps")) {
+            ? prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{draw_index}) : prosper::tools::kNoItemIndex;
+        if (di == prosper::tools::kNoItemIndex || (stage != "vs" && stage != "ps")) {
             std::fprintf(stderr, "gpu_replay: invalid selector %s (want DRAW:vs|ps)\n",
                          list_resources_spec.c_str());
             return 2;
         }
-        const auto* table = stage == "vs" ? replay.items[di].vrt.get() : replay.items[di].prt.get();
+        const auto* table = stage == "vs" ? replay.items[raw(di)].vrt.get() : replay.items[raw(di)].prt.get();
         if (!table) {
             std::printf("draw %llu %s: no captured resource table\n", draw_index, stage.c_str());
             return 0;
@@ -2964,14 +2972,14 @@ int main(int argc, char** argv) {
         if (c1 == std::string::npos || c2 == std::string::npos) { usage(argv[0]); return 2; }
         char* draw_end = nullptr;
         const unsigned long long draw_index = std::strtoull(dump_spec.c_str(), &draw_end, 0);
-        const size_t di = dump_spec[0] != '-' && draw_end == dump_spec.c_str() + c1
-            ? prosper::tools::replay_item_index_for_draw(replay, draw_index) : SIZE_MAX;
+        const prosper::tools::ItemIndex di = dump_spec[0] != '-' && draw_end == dump_spec.c_str() + c1
+            ? prosper::tools::replay_item_index_for_draw(replay, prosper::tools::DrawIndex{draw_index}) : prosper::tools::kNoItemIndex;
         std::string stage = dump_spec.substr(c1 + 1, c2 - c1 - 1);
         int binding = std::atoi(dump_spec.c_str() + c2 + 1);
-        if (di == SIZE_MAX || (stage != "vs" && stage != "ps")) {
+        if (di == prosper::tools::kNoItemIndex || (stage != "vs" && stage != "ps")) {
             std::fprintf(stderr, "gpu_replay: invalid resource selector %s\n", dump_spec.c_str()); return 2;
         }
-        const auto* table = stage == "vs" ? replay.items[di].vrt.get() : replay.items[di].prt.get();
+        const auto* table = stage == "vs" ? replay.items[raw(di)].vrt.get() : replay.items[raw(di)].prt.get();
         const prosper::gpu::ShaderResource* found = nullptr;
         if (table) for (const auto& resource : table->resources)
             if (static_cast<int>(resource.binding) == binding) { found = &resource; break; }

--- a/prosper/tools/gpu_replay/realized_shader_dump.hpp
+++ b/prosper/tools/gpu_replay/realized_shader_dump.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "gpu/capture/gpu_capture.hpp"
+#include "replay_indices.hpp"
 
 #include <cerrno>
 #include <cstdint>
@@ -43,23 +44,29 @@ inline RecompiledShaderView recompiled_shader_view(const gpu::DrawItem& draw,
                   : RecompiledShaderView{&draw.fs_words(), static_cast<bool>(draw.fs_shared)};
 }
 
-inline size_t replay_item_index_for_draw(const gpu::GpuReplayFrame& replay,
-                                         uint64_t draw_index) {
+// Returns an ITEM index -- into replay.items, realized draws only. See replay_indices.hpp for why
+// the return type is not interchangeable with the operation lookup's below.
+inline ItemIndex replay_item_index_for_draw(const gpu::GpuReplayFrame& replay,
+                                            DrawIndex draw_index) {
     for (size_t item_index = 0; item_index < replay.items.size(); ++item_index)
-        if (replay.items[item_index].draw_index == draw_index) return item_index;
-    return SIZE_MAX;
+        if (replay.items[item_index].draw_index == raw(draw_index))
+            return ItemIndex{item_index};
+    return kNoItemIndex;
 }
 
-inline size_t replay_operation_index_for_draw(const gpu::GpuReplayFrame& replay,
-                                              uint64_t draw_index) {
+// Returns an OPERATION index -- into replay.operations, which interleaves draws and computes. Also
+// filters on `realized`, which a hand-rolled loop at the call site did not, and that omission is
+// half of the defect recorded in replay_indices.hpp.
+inline OperationIndex replay_operation_index_for_draw(const gpu::GpuReplayFrame& replay,
+                                                      DrawIndex draw_index) {
     for (size_t operation_index = 0; operation_index < replay.operations.size();
          ++operation_index) {
         const auto& operation = replay.operations[operation_index];
         if (operation.kind == gpu::SubmitOperationKind::Draw && operation.realized &&
-            operation.source_index == draw_index)
-            return operation_index;
+            operation.source_index == raw(draw_index))
+            return OperationIndex{operation_index};
     }
-    return SIZE_MAX;
+    return kNoOperationIndex;
 }
 
 inline bool parse_realized_shader_selector(const std::string& spec,
@@ -89,12 +96,13 @@ inline const std::vector<uint32_t>* select_recompiled_shader(
         error = "invalid shader selector " + spec;
         return nullptr;
     }
-    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
-    if (item_index == SIZE_MAX) {
+    const ItemIndex item_index =
+        replay_item_index_for_draw(replay, DrawIndex{selector.draw_index});
+    if (item_index == kNoItemIndex) {
         error = "realized draw " + std::to_string(selector.draw_index) + " not found";
         return nullptr;
     }
-    const auto selection = recompiled_shader_view(replay.items[item_index], selector.vertex);
+    const auto selection = recompiled_shader_view(replay.items[raw(item_index)], selector.vertex);
     shared = selection.shared;
     error.clear();
     return selection.words;
@@ -107,12 +115,13 @@ inline const gpu::GpuCaptureRawShaderVersion* select_realized_raw_shader(
         error = "invalid realized-shader selector " + spec;
         return nullptr;
     }
-    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
-    if (item_index == SIZE_MAX) {
+    const ItemIndex item_index =
+        replay_item_index_for_draw(replay, DrawIndex{selector.draw_index});
+    if (item_index == kNoItemIndex) {
         error = "realized draw " + std::to_string(selector.draw_index) + " not found";
         return nullptr;
     }
-    const auto& draw = replay.items[item_index];
+    const auto& draw = replay.items[raw(item_index)];
     const uint32_t raw_index = selector.vertex_main
         ? draw.vs_chain_raw_shader_index
         : (selector.vertex ? draw.vs_raw_shader_index : draw.fs_raw_shader_index);

--- a/prosper/tools/gpu_replay/replay_indices.hpp
+++ b/prosper/tools/gpu_replay/replay_indices.hpp
@@ -1,0 +1,46 @@
+#pragma once
+// Three index spaces over one replayed submit, as distinct types.
+//
+// WHY THESE EXIST. A replayed submit is indexed three different ways, and until this header they
+// were all bare integers, so every one of them converted silently into every other:
+//
+//   DrawIndex       the semantic draw ordinal the CAPTURE assigned. Counts every draw, including
+//                   ones replay did not realize.
+//   ItemIndex       an index into GpuReplayFrame::items, which holds ONLY realized draws. An
+//                   unrealized draw leaves a HOLE, so this diverges from DrawIndex from the first
+//                   unrealized draw onward.
+//   OperationIndex  an index into GpuReplayFrame::operations, which interleaves draws and computes.
+//
+// The divergence is not theoretical. Matching an operation by ITEM index silently resolved to an
+// EARLIER draw's operation, so a truncated prefix looked executed and the guard that depended on it
+// never fired — reintroducing the void comparison that guard exists to prevent (#2739 seam 2). It
+// was invisible in the evidence at the time because that submit realized all 30 of its operations,
+// which is exactly the case where the two coincide.
+//
+// A second instance of the same family cost a whole survey on 2026-08-21: `--output-target-after`
+// takes an OPERATION index while `--inspect-only` prints DRAW indices, and they differ by the number
+// of interleaved computes — measured at +5 in one submit and +17 in another on one GTA V frame.
+//
+// Scoped enums rather than a struct wrapper: they are distinct types with no implicit conversion in
+// either direction, they cost nothing at runtime, and they deliberately have no arithmetic. Code
+// that wants to do sums or comparisons has to say `raw(...)` and is thereby visible in review, which
+// is the point — the bug above was an invisible conversion.
+#include <cstddef>
+#include <cstdint>
+
+namespace prosper::tools {
+
+enum class DrawIndex : uint64_t {};
+enum class ItemIndex : size_t {};
+enum class OperationIndex : size_t {};
+
+inline constexpr uint64_t raw(DrawIndex value) { return static_cast<uint64_t>(value); }
+inline constexpr size_t raw(ItemIndex value) { return static_cast<size_t>(value); }
+inline constexpr size_t raw(OperationIndex value) { return static_cast<size_t>(value); }
+
+// "no such index". Named per space so a not-found item cannot be compared against a not-found
+// operation, which is the same conversion this header exists to stop.
+inline constexpr ItemIndex kNoItemIndex{SIZE_MAX};
+inline constexpr OperationIndex kNoOperationIndex{SIZE_MAX};
+
+}  // namespace prosper::tools

--- a/prosper/tools/gpu_replay/resource_override.hpp
+++ b/prosper/tools/gpu_replay/resource_override.hpp
@@ -3,6 +3,7 @@
 #include "gpu/diagnostics/diagnostic_selectors.hpp"
 #include "gpu/capture/gpu_capture.hpp"
 #include "realized_shader_dump.hpp"
+#include "replay_indices.hpp"
 
 #include <cstdint>
 #include <fstream>
@@ -26,7 +27,9 @@ struct ResourceOverrideSelector {
 };
 
 struct ResourceOverrideTarget {
-    size_t item_index = SIZE_MAX;
+    // Typed: this is an index into replay.items (realized draws only), NOT a draw ordinal and
+    // NOT an operation index. See replay_indices.hpp.
+    ItemIndex item_index = kNoItemIndex;
     size_t resource_index = SIZE_MAX;
     uint64_t gpu_addr = 0;
     uint64_t captured_size = 0;
@@ -121,12 +124,13 @@ inline bool find_resource_override_target(const gpu::GpuReplayFrame& replay,
                                           const ResourceOverrideSelector& selector,
                                           ResourceOverrideTarget& target,
                                           std::string& error) {
-    const size_t item_index = replay_item_index_for_draw(replay, selector.draw_index);
-    if (item_index == SIZE_MAX) {
+    const ItemIndex item_index =
+        replay_item_index_for_draw(replay, DrawIndex{selector.draw_index});
+    if (item_index == kNoItemIndex) {
         error = "realized draw " + std::to_string(selector.draw_index) + " not found";
         return false;
     }
-    const auto& draw = replay.items[item_index];
+    const auto& draw = replay.items[raw(item_index)];
     const auto& table = selector.stage == ResourceOverrideStage::Vertex ? draw.vrt : draw.prt;
     if (!table) {
         error = "draw " + std::to_string(selector.draw_index) + " " +
@@ -219,7 +223,7 @@ inline bool apply_resource_override(gpu::GpuReplayFrame& replay,
         return false;
     }
 
-    auto& draw = replay.items[target.item_index];
+    auto& draw = replay.items[raw(target.item_index)];
     auto& selected_table = selector.stage == ResourceOverrideStage::Vertex ? draw.vrt : draw.prt;
     const auto& original_resource = selected_table->resources[target.resource_index];
 


### PR DESCRIPTION
Closes seam 2 on #2739, which that issue calls *"the highest value-per-effort item here — worth doing
on its own, ahead of any reorganisation."*

## The problem

A replayed submit is indexed **three** ways, and all three were bare integers:

| space | what it indexes |
| --- | --- |
| `DrawIndex` | the semantic draw ordinal the capture assigned — **includes unrealized draws** |
| `ItemIndex` | `GpuReplayFrame::items` — **only realized draws**, so unrealized ones leave holes |
| `OperationIndex` | `GpuReplayFrame::operations` — draws and computes interleaved |

Every one converted silently into every other. The two lookup helpers were the epicentre — both took
`uint64_t` and both returned `size_t`:

```cpp
size_t replay_item_index_for_draw     (const GpuReplayFrame&, uint64_t);  // -> items
size_t replay_operation_index_for_draw(const GpuReplayFrame&, uint64_t);  // -> operations
```

#2739 records the cost: matching an operation by **item** index silently resolved to an **earlier**
draw's operation, so a truncated prefix looked executed and the guard depending on it never fired —
reintroducing the void comparison that guard exists to prevent. Invisible in the evidence at the
time because that submit realized all 30 of its operations, the one case where the two coincide.

## Approach

Scoped enums, not a struct wrapper: distinct in both directions, zero runtime cost, and deliberately
**no arithmetic** — code wanting a sum or comparison must say `raw()`, which makes it visible in
review. The bug was an invisible conversion; the fix is to make the conversion say its own name.

**CORRECTED after review — the compiler did NOT find every site.** This section originally read "the
compiler found every site" and the Review note below claimed "a missed call site cannot compile".
**Both are false**, and review found the counter-example: three `std::fprintf` calls passed the
scoped `ItemIndex` straight into `%zu`. Varargs performs no conversion, so there is nothing for the
type system to object to, and prosper builds this file with only `-std=gnu++20 -Werror=switch` — no
`-Wall`, no `-Wformat`. **Varargs is a hole in the discipline this header installs**, and it was open
at three of the sites this PR touched. Fixed with a qualified `raw()`; the claim is corrected rather
than left standing.

The compiler did find the *typed* sites: 10 errors on first compile. Eight were mechanical wrapping;
**two were genuine seams** — `ResourceOverrideTarget` stored an item index as a bare `size_t`, and a
consumer indexed `items` with it. Both are now typed, so the distinction survives the struct
boundary.

## Tests

The existing fixture **already exercised the divergence** — draw 11 resolves to item **1** but
operation **2** — which is what makes the assertion meaningful rather than a tautology. Before this,
both results were `size_t`, so either function's answer satisfied either comparison.

Six `static_assert`s pin non-convertibility in both directions and against bare integers. The
property is a **type** property, and a runtime `CHECK` cannot observe a conversion the compiler
performs for you.

**Mutation-checked at the production site:** making `ItemIndex` an *unscoped* enum (which does decay)
fails exactly `an item index must not decay to a bare integer`. Restored, and green again.

## Verification (exact head)

```
cmake --build prosper/build-linux -j6      BUILD_RC=0
ctest --no-tests=error                     CTEST_RC=0
100% tests passed out of 283
209/282 gpu_replay_shader_dump ....... Passed
210/282 gpu_replay_resource_override . Passed
```

`git diff --check` clean; session-trailer gate 0. Scope is the replay tool only — I deliberately did
**not** touch `draw_index` in `gpu_capture.hpp`, whose structs are serialized.

## Review note

Reviewed (REJECTED, then addressed). That judgement was **wrong on its central point** — see the
correction above: varargs is not type-checked, so a missed call site *can* compile. Review also found
the guard itself asymmetric: only the `ItemIndex` decay was pinned, so collapsing `OperationIndex` or
`DrawIndex` alone passed all six asserts *and* the runtime CHECK. Each space now has its own decay
assert, mutation-checked.

Also from review, and verified independently by the reviewer rather than taken from me: no index
space is backwards (`operation.source_index` traced end-to-end and confirmed to be a draw ordinal),
`ResourceOverrideTarget::item_index` has exactly one writer and one real reader repo-wide and both
are item-space, and all `raw()` escapes are legitimate. Follow-up for the adjacent instances in
`replay_output_extent.hpp` is #2840.

Refs #2739

