### PR TITLE
build(gpu_replay): gate on -Werror=format, so a typed index reaching printf fails the build

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1836,6 +1836,19 @@ if(TARGET prosper_core)
         # and was caught only in review. #2840 will type the operation indices too, and gpu_replay.cpp
         # prints those with %zu at roughly sixteen more sites, so the class recurs the moment that
         # lands. Measured clean under -Wformat=2 before this gate was added.
+        #
+        # THIS GATE BINDS ON GCC ONLY, despite the GNU|Clang guard above. Clang deliberately looks
+        # through a scoped enum to its underlying type here and stays silent at -Wformat,
+        # -Werror=format, -Wformat=2 AND -Wall -Wextra; only -Wformat-pedantic makes it fire. The
+        # same positive control that errors under g++ exits 0 under clang++. It still protects every
+        # build this project actually performs -- both the Linux and the MinGW Windows legs are GCC,
+        # and the control was verified to fire on both -- but do not read the guard as Clang cover.
+        # -Wformat-pedantic on a Clang-only branch was measured clean on this TU if that is ever
+        # wanted; it is left out because no build here uses Clang and an unrecognized option is its
+        # own hazard. Deliberately NOT widened to -Wformat=2: GCC already diagnoses this class at
+        # plain -Wformat, so =2 adds only unrelated surface, and it does not even mean the same thing
+        # to the two compilers (GCC gives -Wformat-nonliteral where Clang gives
+        # -Wmissing-format-attribute, which GCC lacks entirely).
         target_compile_options(gpu_replay PRIVATE -Werror=switch -Werror=format)
       endif()
     else()
@@ -2058,6 +2071,19 @@ if(TARGET prosper_core)
         # and was caught only in review. #2840 will type the operation indices too, and gpu_replay.cpp
         # prints those with %zu at roughly sixteen more sites, so the class recurs the moment that
         # lands. Measured clean under -Wformat=2 before this gate was added.
+        #
+        # THIS GATE BINDS ON GCC ONLY, despite the GNU|Clang guard above. Clang deliberately looks
+        # through a scoped enum to its underlying type here and stays silent at -Wformat,
+        # -Werror=format, -Wformat=2 AND -Wall -Wextra; only -Wformat-pedantic makes it fire. The
+        # same positive control that errors under g++ exits 0 under clang++. It still protects every
+        # build this project actually performs -- both the Linux and the MinGW Windows legs are GCC,
+        # and the control was verified to fire on both -- but do not read the guard as Clang cover.
+        # -Wformat-pedantic on a Clang-only branch was measured clean on this TU if that is ever
+        # wanted; it is left out because no build here uses Clang and an unrecognized option is its
+        # own hazard. Deliberately NOT widened to -Wformat=2: GCC already diagnoses this class at
+        # plain -Wformat, so =2 adds only unrelated surface, and it does not even mean the same thing
+        # to the two compilers (GCC gives -Wformat-nonliteral where Clang gives
+        # -Wmissing-format-attribute, which GCC lacks entirely).
         target_compile_options(gpu_replay PRIVATE -Werror=switch -Werror=format)
       endif()
 

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1828,7 +1828,15 @@ if(TARGET prosper_core)
       target_include_directories(gpu_replay PRIVATE src tests)
       target_link_libraries(gpu_replay PRIVATE prosper_core prosper_live_renderer Vulkan::Vulkan)
       if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        target_compile_options(gpu_replay PRIVATE -Werror=switch)
+        # -Werror=format for the same reason as -Werror=switch above, and found the same way: by a
+        # defect this tool's own diagnostics hid. gpu_replay prints index values with %zu, and #2836
+        # gave three of those printf arguments a distinct type (ItemIndex) while the format stayed
+        # %zu. Varargs performs no conversion, so the type system has nothing to check, and this
+        # target compiled with neither -Wall nor -Wformat -- the mismatch was invisible in the build
+        # and was caught only in review. #2840 will type the operation indices too, and gpu_replay.cpp
+        # prints those with %zu at roughly sixteen more sites, so the class recurs the moment that
+        # lands. Measured clean under -Wformat=2 before this gate was added.
+        target_compile_options(gpu_replay PRIVATE -Werror=switch -Werror=format)
       endif()
     else()
       message(STATUS "Vulkan not found — Windows boot_trace built without the live renderer")
@@ -2042,7 +2050,15 @@ if(TARGET prosper_core)
       # prosper_live_renderer so the exhaustiveness contract holds at every mapping, not just the
       # ones inside frontends/shared/live/live_target_format.hpp.
       if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-        target_compile_options(gpu_replay PRIVATE -Werror=switch)
+        # -Werror=format for the same reason as -Werror=switch above, and found the same way: by a
+        # defect this tool's own diagnostics hid. gpu_replay prints index values with %zu, and #2836
+        # gave three of those printf arguments a distinct type (ItemIndex) while the format stayed
+        # %zu. Varargs performs no conversion, so the type system has nothing to check, and this
+        # target compiled with neither -Wall nor -Wformat -- the mismatch was invisible in the build
+        # and was caught only in review. #2840 will type the operation indices too, and gpu_replay.cpp
+        # prints those with %zu at roughly sixteen more sites, so the class recurs the moment that
+        # lands. Measured clean under -Wformat=2 before this gate was added.
+        target_compile_options(gpu_replay PRIVATE -Werror=switch -Werror=format)
       endif()
 
       # Seed flags are renderer-registration inputs. Exercise the real gpu_replay process so an


### PR DESCRIPTION
Acts on the forward-looking note from the review of #2836. Two lines of CMake, plus the reasoning.

## Why

#2836 gave three `printf` arguments in `gpu_replay.cpp` a distinct type (`ItemIndex`) while their
format stayed `%zu`. **Varargs performs no conversion, so the type system had nothing to check**, and
this target compiled with neither `-Wall` nor `-Wformat` — the mismatch was invisible in the build
and was caught only in review.

A type discipline with an unchecked hole at its `printf` boundary is worth closing at the boundary
rather than one call site at a time.

**This is not hypothetical going forward:** #2840 will type the operation indices too, and
`gpu_replay.cpp` prints those with `%zu` at roughly sixteen more sites, so the class recurs the
moment that lands — silently, exactly as it did here.

## Scope

`PRIVATE` to the `gpu_replay` target, matching the `-Werror=switch` gate it sits beside (both
occurrences). Nothing else in the build is affected.

## Verified in both directions

A gate that cannot be shown to fire is not a gate, so:

- **Clean with the gate:** the target builds with zero diagnostics. (The reviewer of #2836
  independently measured this TU clean under the stricter `-Wformat=2`, including
  `-Wformat-nonliteral`.)
- **Fires on the real defect:** unwrapping one of the fixed sites reproduces the original bug as a
  build error —

```
gpu_replay.cpp:2739:61: error: format '%zu' expects argument of type 'size_t',
but argument 4 has type 'const prosper::tools::ItemIndex' [-Werror=format=]
```

- **Restored byte-identical** afterwards (`diff -q` clean) and builds clean again.

## Verification

```
cmake --build prosper/build-linux -j6      BUILD_RC=0
ctest --no-tests=error                     CTEST_RC=0
100% tests passed out of 283
```

`git diff --check` clean; session-trailer gate 0.

Refs #2836, #2840
