### PR TITLE
fix: sequence the power-of-two log throttles — their cadence was undefined behaviour

### DIFF
--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4491,7 +4491,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 auto& seen_masks = masks[r.gpu_addr];
                                 seen_masks.first |= present_mask;   // any slice ever VALID
                                 seen_masks.second |= known_mask;    // any slice ever KNOWN
-                                if (((++samples) & (samples - 1)) == 0 && samples >= 64) {
+                                // Increment SEQUENCED before the test: `(++samples) & (samples - 1)`
+                                // reads and modifies `samples` with no sequencing between the
+                                // operands of `&`, so the throttle's cadence was whatever the
+                                // optimiser chose. That matters here beyond tidiness -- CLAUDE.md
+                                // tells readers to reason about this power-of-two schedule when
+                                // interpreting the log, and that reasoning is only sound if the
+                                // schedule is defined. Do not fold these back together.
+                                ++samples;
+                                if ((samples & (samples - 1)) == 0 && samples >= 64) {
                                     fprintf(stderr,
                                             "[cube-depth] residency after %llu cube samples "
                                             "(faces resident -> times seen):\n",

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -7826,7 +7826,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             if (use_depth) ++row.used_depth;
             if (depth_used_meaningfully) ++row.meaningful;
             if (use_depth && depth_used_meaningfully) ++row.claimed;
-            if (((++n) & (n - 1)) == 0 && n >= 256) {
+            // Increment SEQUENCED before the test -- see the same fix in live_renderer.cpp.
+            // `(++n) & (n - 1)` has no sequencing between the operands of `&`, so this
+            // throttle's cadence was undefined. Do not fold these back together.
+            ++n;
+            if ((n & (n - 1)) == 0 && n >= 256) {
                 fprintf(stderr, "[ds-slice] after %llu DS passes:\n", (unsigned long long)n);
                 for (const auto& e : tally)
                     fprintf(stderr,


### PR DESCRIPTION
`((++n) & (n - 1)) == 0` reads and modifies `n` with no sequencing between the operands of `&`, so
**how often these diagnostics fired was whatever the optimiser chose.**

## Two sites, not the one filed — and the second is not a test fixture

```
frontends/shared/live/live_renderer.cpp:4494   [cube-depth] residency throttle
tests/fixtures/render_runner.h:7829            [ds-slice]  tally throttle
```

## Why this is worth more than tidiness

Both are the **power-of-two log-throttle** idiom, and this cadence is something the project's own
records tell readers to reason about when interpreting a log.

**Citation corrected after review** — I originally attributed both the phrasing and the incident to
`CLAUDE.md`. That is wrong, and the distinction matters because one is a general rule and the other
is a measured event:

- `CLAUDE.md:164` says only: *"Check a diagnostic's rate limit before quoting its volume as a
  frequency."*
- The specific phrasing — *"the instrument emits on a power-of-two schedule, so lines are not
  events"* — and the **450x** under-report are in `prosper/docs/GTA5_STATUS.md:830`/`:834`,
  § *A correction that understated its own evidence*, where a real result was written up as roughly
  450x weaker than it was because emitted lines were counted as events.
That interpretation rule is only sound if the schedule is defined. Here it was not.

## A correction to #2846

The issue says GCC is silent on this class. **It is not.** On a probe carrying both spellings:

```
g++ -Wall   → warning: operation on 'n' may be undefined [-Wsequence-point]
clang++     → warning: unsequenced modification and access to 'n' [-Wunsequenced]
```

Both flag the old form; **neither flags the new one**. What let it survive is that prosper compiles
**without `-Wall`**, so GCC is never asked to look — the *same root cause* as the printf/varargs
defect found in #2836 and gated in #2844.

That distinction matters for the remedy: "the compiler cannot see it" argues for a different fix than
"we did not turn the check on". This is the second.

## Follow-up available, deliberately not bundled

`-Wsequence-point` is clean across the 40 `prosper_core` sources I sampled, so a narrow gate in the
shape of #2844's is available. Kept out of this PR so the fix and the policy change stay separable.

## Verification

```
cmake --build prosper/build-linux -j6      BUILD_RC=0
ctest --no-tests=error                     CTEST_RC=0
100% tests passed out of 284
```

`git diff --check` clean; session-trailer gate 0.

Fixes #2846

