### PR TITLE
tools: lanekill — kill only your own worktree's processes, refuse the rest

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -153,6 +153,18 @@ if(Python3_Interpreter_FOUND)
              COMMAND "${Python3_EXECUTABLE}"
                      "${CMAKE_SOURCE_DIR}/tools/test_worktree_reclaim.py")
   endif()
+
+  # lanekill SIGNALS processes, so its arms are refusals first: a process in another worktree, a
+  # path that attributes to nothing, and a lookalike directory sharing a name prefix. Same
+  # Linux-only reasoning as above and for the same reason -- attribution reads /proc, and without
+  # one the tool fails closed rather than guessing. That fail-closed path is the one arm that
+  # runs on every platform, because it is the property protecting the platforms that cannot run
+  # the rest.
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    add_test(NAME lanekill_tool
+             COMMAND "${Python3_EXECUTABLE}"
+                     "${CMAKE_SOURCE_DIR}/tools/test_lanekill.py")
+  endif()
   add_test(NAME re_edis_mapping
            COMMAND "${Python3_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tools/re/test_edis.py")
   # nid_gate_scan answers "does this title BRANCH on an imported function's return value?", and a

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -155,11 +155,19 @@ if(Python3_Interpreter_FOUND)
   endif()
 
   # lanekill SIGNALS processes, so its arms are refusals first: a process in another worktree, a
-  # path that attributes to nothing, and a lookalike directory sharing a name prefix. Same
-  # Linux-only reasoning as above and for the same reason -- attribution reads /proc, and without
-  # one the tool fails closed rather than guessing. That fail-closed path is the one arm that
-  # runs on every platform, because it is the property protecting the platforms that cannot run
-  # the rest.
+  # path that attributes to nothing, a lookalike directory sharing a name prefix, and an
+  # end-to-end run where exactly one of two live processes dies.
+  #
+  # That end-to-end arm exists because the first version of this suite tested only ATTRIBUTION.
+  # A reviewer mutated the tool six ways -- each turning it into a cross-lane killer -- and every
+  # arm stayed green, because none of them reached the code that decides to send a signal. Each
+  # of those mutations now reddens, verified by re-running them.
+  #
+  # Linux-only, and that is a statement about the tool: attribution reads /proc. The fail-closed
+  # arm is Linux-only TOO, which is a deliberate narrowing -- it used to run everywhere by
+  # installing a stub and asserting the stub's own return value, which said nothing about
+  # lanekill and stayed green when the gate was deleted. It now runs main() against a live
+  # process in its own worktree and asserts the refusal spared it, which needs a real process.
   if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_test(NAME lanekill_tool
              COMMAND "${Python3_EXECUTABLE}"

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -1159,3 +1159,21 @@ For a differential replay, `PROSPER_STENCIL_CLEAR=<0..255>` overrides the initia
 value and `PROSPER_STENCIL_REPLACE=<0..255>` overrides the replacement reference of an
 ALWAYS+REPLACE stencil-prime draw. These are diagnostic controls only; they do not change guest-state
 extraction or the default render path.
+
+## Shared-box hygiene
+
+Several agents and the human run this repo at once, so anything that kills a process is a
+cross-lane operation whether or not you meant it that way.
+
+- **`lanekill.py`** — kill processes matching a name that belong to **your** worktree, and refuse
+  the ones that do not. `pkill`'s two selectors both answer *what* a process is and neither answers
+  *whose* it is: `-f` over-matches substrings and its own shell, `-x` matches accurately and still
+  kills every lane's copy. On 2026-08-21 a `pkill -x screenshot` took a concurrent lane's
+  measurement sweep at 36 of 64 frames (instrument trap 213). Census by default; `--yes` to signal;
+  `--any-tree REASON` to override, loudly. Attribution reuses `worktree_reclaim.py`'s scanner, which
+  matches by inode rather than path string — necessary because `/home` is a symlink on the host and
+  a real bind mount inside the ps5ys distrobox, so the same directory has two spellings.
+- **`worktree_reclaim.py`** — census and removal of stale worktrees, with the same in-use guard.
+
+Both fail closed where `/proc` is unreadable: without it, ownership cannot be established, and
+"I could not tell whose this is" must never render as "it is yours".

--- a/prosper/tools/lanekill.py
+++ b/prosper/tools/lanekill.py
@@ -92,6 +92,69 @@ def my_worktree(trees: list[Worktree], cwd: str) -> Worktree | None:
         cur = parent
 
 
+STRONG_KINDS = ("cwd", "exe")
+
+
+def attribute(trees: list[Worktree]) -> tuple[dict[int, Worktree], dict[int, str]]:
+    """Attribute each pid to at most one worktree, refusing every ambiguous case.
+
+    ONLY `cwd` and `exe` constitute ownership. An `fd` or a memory mapping into a tree says the
+    process READS something there -- a build output, a log, a dump -- which is not the same claim
+    and must never authorise a kill.
+
+    When cwd and exe name DIFFERENT trees the answer is *undecidable*, not "pick one". The first
+    version of this function preferred whichever holder happened to be visited last, which made the
+    verdict depend on `git worktree list` ORDER: a binary in wt-a run from wt-b and a binary in
+    wt-b run from wt-a both attributed to wt-b. Same shape, opposite semantics, and the loser gets
+    its run killed under a line that says MINE. Undecidable is the only honest answer, and this
+    tool's whole purpose is that undecidable must not render as yours.
+    """
+    strong: dict[int, set[str]] = {}
+    weak: set[int] = set()
+    by_real: dict[str, Worktree] = {}
+    for t in trees:
+        by_real[t.real] = t
+        for h in t.holders:
+            if h.kind in STRONG_KINDS:
+                strong.setdefault(h.pid, set()).add(t.real)
+            else:
+                weak.add(h.pid)
+
+    owner: dict[int, Worktree] = {}
+    why: dict[int, str] = {}
+    for pid, reals in strong.items():
+        if len(reals) == 1:
+            owner[pid] = by_real[next(iter(reals))]
+        else:
+            why[pid] = f"cwd and exe disagree across {len(reals)} worktrees"
+    for pid in weak - set(strong):
+        why[pid] = "only an open fd or a mapping points into a worktree, which is not ownership"
+    return owner, why
+
+
+def classify(matches: list[int], owner_of: dict[int, Worktree], mine: Worktree
+             ) -> tuple[list[int], list[tuple[int, Worktree]], list[int]]:
+    """Split candidates into (ours, theirs, undecidable). Pure, so it can be tested directly.
+
+    Extracted because the first version of this file had it inline in `main()`, where no test
+    reached it: a reviewer mutated the tool six ways -- each turning it into a cross-lane killer --
+    and every arm stayed green, because every arm called only `my_worktree()`. The decision that
+    actually sends a signal now has arms of its own.
+    """
+    ours: list[int] = []
+    theirs: list[tuple[int, Worktree]] = []
+    undecidable: list[int] = []
+    for pid in matches:
+        t = owner_of.get(pid)
+        if t is None:
+            undecidable.append(pid)
+        elif t.real == mine.real:
+            ours.append(pid)
+        else:
+            theirs.append((pid, t))
+    return ours, theirs, undecidable
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(
         description="Kill processes matching a name that belong to YOUR worktree.",
@@ -99,18 +162,24 @@ def main() -> int:
     )
     ap.add_argument("pattern", help="exact process name, as `pkill -x` matches it")
     ap.add_argument("--yes", action="store_true", help="actually signal the matches in your tree")
+    # A REASON string that is only echoed is theatre: nothing validates it and nothing durable
+    # records it, and `--any-tree ""` was falsy, so an empty reason silently degraded into a
+    # refusal that looked like an override. A bare boolean states the same thing honestly.
     ap.add_argument(
         "--any-tree",
-        metavar="REASON",
-        help="also signal matches OUTSIDE your tree. Requires a stated reason, which is printed "
-        "-- if you cannot state one, another lane is probably mid-run.",
+        action="store_true",
+        help="also signal matches OUTSIDE your tree. Another lane is probably mid-run.",
     )
     ap.add_argument("--signal", default="TERM", help="signal name, default TERM")
     args = ap.parse_args()
 
-    try:
-        sig = getattr(signal, f"SIG{args.signal.upper().removeprefix('SIG')}")
-    except AttributeError:
+    # `getattr(signal, "SIG" + name)` also resolves SIG_DFL and SIG_IGN, which are HANDLER
+    # constants (0 and 1), not signals. `--signal _dfl` then called os.kill(pid, 0) -- the
+    # existence probe -- and printed "signalled 1" while doing nothing at all. Match against the
+    # real signal set instead.
+    wanted = f"SIG{args.signal.upper().removeprefix('SIG')}"
+    sig = next((s for s in signal.Signals if s.name == wanted), None)
+    if sig is None:
         print(f"lanekill: unknown signal {args.signal!r}", file=sys.stderr)
         return 2
 
@@ -138,18 +207,11 @@ def main() -> int:
 
     attach_holders(trees, refs)
 
-    owner_of: dict[int, Worktree] = {}
     comm_of: dict[int, str] = {}
-    for t in trees:
-        for h in t.holders:
-            comm_of[h.pid] = h.comm
-            # cwd/exe are statements about the process itself; an fd or a mapping can point into
-            # a tree the process merely reads. Prefer the strong kinds when both are present.
-            if h.pid not in owner_of or h.kind in ("cwd", "exe"):
-                owner_of[h.pid] = t
-
     for pid, _kind, comm, _path in refs:
         comm_of.setdefault(pid, comm)
+
+    owner_of, why_of = attribute(trees)
 
     me = os.getpid()
     matches = sorted(p for p, c in comm_of.items() if c == args.pattern and p != me)
@@ -164,15 +226,7 @@ def main() -> int:
         except OSError:
             return "(gone)"
 
-    ours, theirs, unattributed = [], [], []
-    for pid in matches:
-        t = owner_of.get(pid)
-        if t is None:
-            unattributed.append(pid)
-        elif t.real == mine.real:
-            ours.append(pid)
-        else:
-            theirs.append((pid, t))
+    ours, theirs, unattributed = classify(matches, owner_of, mine)
 
     print(f"worktree: {mine.path}")
     print(f"{len(matches)} process(es) named {args.pattern!r}\n")
@@ -182,7 +236,8 @@ def main() -> int:
     for pid, t in theirs:
         print(f"  ANOTHER LANE  pid {pid}  [{os.path.basename(t.path)}]  {argv_of(pid)}")
     for pid in unattributed:
-        print(f"  UNATTRIBUTED  pid {pid}  {argv_of(pid)}")
+        print(f"  UNDECIDABLE   pid {pid}  {argv_of(pid)}")
+        print(f"                {why_of.get(pid, 'no reference into any worktree')}")
 
     if theirs or unattributed:
         print()
@@ -199,11 +254,10 @@ def main() -> int:
 
     targets = list(ours)
     if args.any_tree:
-        print(f"\n[--any-tree] {args.any_tree}")
-        print("  Overriding the ownership guard. This is recorded in this output on purpose.")
+        print("\n[--any-tree] overriding the ownership guard and signalling other lanes' matches.")
         targets += [p for p, _ in theirs] + unattributed
 
-    sent, vanished = 0, 0
+    sent, vanished, denied = 0, 0, 0
     for pid in targets:
         try:
             os.kill(pid, sig)
@@ -212,14 +266,16 @@ def main() -> int:
             vanished += 1
         except PermissionError:
             print(f"  cannot signal pid {pid}: permission denied", file=sys.stderr)
+            denied += 1
 
     print(f"\nsignalled {sent} with SIG{args.signal.upper().removeprefix('SIG')}"
           + (f", {vanished} had already exited" if vanished else ""))
     refused = len(theirs) + len(unattributed) if not args.any_tree else 0
     if refused:
         print(f"refused {refused} outside your tree")
-        return 1
-    return 0
+    if denied:
+        print(f"could not signal {denied} (permission denied)")
+    return 1 if (refused or denied) else 0
 
 
 if __name__ == "__main__":

--- a/prosper/tools/lanekill.py
+++ b/prosper/tools/lanekill.py
@@ -18,7 +18,7 @@ ones inside yours.
 
     lanekill.py screenshot            # census; kills nothing
     lanekill.py screenshot --yes      # kill the ones in this worktree
-    lanekill.py screenshot --yes --any-tree   # loud override; needs a stated reason
+    lanekill.py screenshot --yes --any-tree   # loud override; signals other lanes' matches too
 
 Attribution reuses `worktree_reclaim.py`'s process scanner rather than reimplementing it. That
 matters more than code reuse: that scanner matches by (st_dev, st_ino) rather than by path
@@ -126,7 +126,12 @@ def attribute(trees: list[Worktree]) -> tuple[dict[int, Worktree], dict[int, str
         if len(reals) == 1:
             owner[pid] = by_real[next(iter(reals))]
         else:
-            why[pid] = f"cwd and exe disagree across {len(reals)} worktrees"
+            # Name them. "disagree across 2 worktrees" tells the operator there is an ambiguity
+            # but not how to resolve it; naming the trees lets them recognise their own cwd at a
+            # glance and reach for `kill <pid>` themselves. A refusal should be a prompt, not a
+            # wall -- a wall is what trains people to reach for `command pkill` instead.
+            names = ", ".join(sorted(os.path.basename(r.rstrip("/")) or r for r in reals))
+            why[pid] = f"cwd and exe disagree across {len(reals)} worktrees ({names})"
     for pid in weak - set(strong):
         why[pid] = "only an open fd or a mapping points into a worktree, which is not ownership"
     return owner, why

--- a/prosper/tools/lanekill.py
+++ b/prosper/tools/lanekill.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""lanekill -- kill processes that belong to YOUR worktree, and refuse the ones that do not.
+
+Several agents and the human run this repo concurrently. `pkill -x screenshot` means "every
+process named screenshot on this box", which with three lanes running is three runs -- and on
+2026-08-21 exactly that killed a concurrent lane's measurement sweep at 36 of 64 frames,
+costing a result that was never recovered (instrument trap 213).
+
+The failure is not that `pkill` is dangerous. It is that BOTH of its selectors answer *what* a
+process is and NEITHER answers *whose* it is:
+
+    pkill -f screenshot     over-matches substrings, and matches its own shell (trap 135)
+    pkill -x screenshot     matches accurately -- and still kills every lane's copy
+
+Swapping `-f` for `-x` fixes precision, which is a different property from ownership. This tool
+adds the missing selector: it attributes each candidate to a git worktree and kills only the
+ones inside yours.
+
+    lanekill.py screenshot            # census; kills nothing
+    lanekill.py screenshot --yes      # kill the ones in this worktree
+    lanekill.py screenshot --yes --any-tree   # loud override; needs a stated reason
+
+Attribution reuses `worktree_reclaim.py`'s process scanner rather than reimplementing it. That
+matters more than code reuse: that scanner matches by (st_dev, st_ino) rather than by path
+string, because `/home` is a symlink to `/var/home` on the host and a REAL bind mount inside the
+ps5ys distrobox -- so a container process's `/proc/<pid>/cwd` reads back with a different
+spelling for the same directory. A string-matching version of this tool would silently fail to
+attribute every distrobox process, conclude they belong to nobody, and refuse to kill anything
+(or worse, with --any-tree, kill everything). Hand-rolling a weaker guard than the one that
+already exists is itself a recorded failure in this repo.
+
+Exit status: 0 if it did what you asked, 1 if it refused something, 2 on a usage or platform
+error. It FAILS CLOSED: with no readable /proc the attribution cannot be made at all, so nothing
+is killed, because "I could not tell whose this is" must never render as "it is yours".
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    from worktree_reclaim import Worktree, attach_holders, list_worktrees, run, scan_processes
+except ImportError as exc:  # pragma: no cover - import shape is pinned by the selftest
+    print(f"lanekill: cannot import worktree_reclaim.py ({exc})", file=sys.stderr)
+    raise SystemExit(2) from exc
+
+
+def repo_root(start: str) -> str | None:
+    rc, out, _ = run(["git", "rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=start)
+    if rc != 0 or not out.strip():
+        return None
+    common = out.strip()
+    return os.path.dirname(common) if os.path.basename(common) == ".git" else common
+
+
+def my_worktree(trees: list[Worktree], cwd: str) -> Worktree | None:
+    """The tree containing `cwd`, by inode identity -- never by string prefix.
+
+    A string prefix would get this wrong in the same distrobox case the scanner documents, and
+    getting it wrong HERE is the dangerous direction: mis-identifying which tree is yours turns
+    every other lane's process into a legitimate target.
+    """
+    try:
+        here = os.stat(cwd)
+    except OSError:
+        return None
+    cur = os.path.realpath(cwd)
+    keys: dict[tuple[int, int], Worktree] = {}
+    for t in trees:
+        try:
+            st = os.stat(t.real)
+        except OSError:
+            continue
+        keys[(st.st_dev, st.st_ino)] = t
+    del here
+    while True:
+        try:
+            st = os.stat(cur)
+        except OSError:
+            return None
+        hit = keys.get((st.st_dev, st.st_ino))
+        if hit is not None:
+            return hit
+        parent = os.path.dirname(cur)
+        if parent == cur or len(parent) <= 1:
+            return None
+        cur = parent
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Kill processes matching a name that belong to YOUR worktree.",
+        epilog="Census by default. Nothing is signalled without --yes.",
+    )
+    ap.add_argument("pattern", help="exact process name, as `pkill -x` matches it")
+    ap.add_argument("--yes", action="store_true", help="actually signal the matches in your tree")
+    ap.add_argument(
+        "--any-tree",
+        metavar="REASON",
+        help="also signal matches OUTSIDE your tree. Requires a stated reason, which is printed "
+        "-- if you cannot state one, another lane is probably mid-run.",
+    )
+    ap.add_argument("--signal", default="TERM", help="signal name, default TERM")
+    args = ap.parse_args()
+
+    try:
+        sig = getattr(signal, f"SIG{args.signal.upper().removeprefix('SIG')}")
+    except AttributeError:
+        print(f"lanekill: unknown signal {args.signal!r}", file=sys.stderr)
+        return 2
+
+    cwd = os.getcwd()
+    repo = repo_root(cwd)
+    if repo is None:
+        print("lanekill: not inside a git repository -- cannot attribute anything", file=sys.stderr)
+        return 2
+
+    trees = list_worktrees(repo)
+    mine = my_worktree(trees, cwd)
+    if mine is None:
+        print(f"lanekill: {cwd} is not inside any registered worktree of {repo}", file=sys.stderr)
+        print("  Attribution is undecidable here, so nothing is signalled.", file=sys.stderr)
+        return 2
+
+    refs, supported = scan_processes()
+    if not supported:
+        # macOS/Windows: no readable /proc. An absent instrument reads as "nobody owns anything",
+        # which with --any-tree would authorise killing every lane's run. Fail closed.
+        print("lanekill: no readable /proc -- ownership cannot be established on this platform.",
+              file=sys.stderr)
+        print("  Refusing rather than guessing. Scope the kill by PID yourself.", file=sys.stderr)
+        return 2
+
+    attach_holders(trees, refs)
+
+    owner_of: dict[int, Worktree] = {}
+    comm_of: dict[int, str] = {}
+    for t in trees:
+        for h in t.holders:
+            comm_of[h.pid] = h.comm
+            # cwd/exe are statements about the process itself; an fd or a mapping can point into
+            # a tree the process merely reads. Prefer the strong kinds when both are present.
+            if h.pid not in owner_of or h.kind in ("cwd", "exe"):
+                owner_of[h.pid] = t
+
+    for pid, _kind, comm, _path in refs:
+        comm_of.setdefault(pid, comm)
+
+    me = os.getpid()
+    matches = sorted(p for p, c in comm_of.items() if c == args.pattern and p != me)
+    if not matches:
+        print(f"no live process named {args.pattern!r}")
+        return 0
+
+    def argv_of(pid: int) -> str:
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as fh:
+                return " ".join(fh.read().decode("utf-8", "replace").split("\0")).strip()
+        except OSError:
+            return "(gone)"
+
+    ours, theirs, unattributed = [], [], []
+    for pid in matches:
+        t = owner_of.get(pid)
+        if t is None:
+            unattributed.append(pid)
+        elif t.real == mine.real:
+            ours.append(pid)
+        else:
+            theirs.append((pid, t))
+
+    print(f"worktree: {mine.path}")
+    print(f"{len(matches)} process(es) named {args.pattern!r}\n")
+
+    for pid in ours:
+        print(f"  MINE          pid {pid}  {argv_of(pid)}")
+    for pid, t in theirs:
+        print(f"  ANOTHER LANE  pid {pid}  [{os.path.basename(t.path)}]  {argv_of(pid)}")
+    for pid in unattributed:
+        print(f"  UNATTRIBUTED  pid {pid}  {argv_of(pid)}")
+
+    if theirs or unattributed:
+        print()
+        if theirs:
+            print(f"  {len(theirs)} belong(s) to another worktree. Killing them takes a run that is")
+            print("  probably mid-measurement, and the cost lands on a lane that cannot see why.")
+        if unattributed:
+            print(f"  {len(unattributed)} could not be attributed to any worktree. Undecidable is")
+            print("  not the same as yours -- these are refused too.")
+
+    if not args.yes:
+        print(f"\n[census] nothing signalled. Re-run with --yes to signal the {len(ours)} in your tree.")
+        return 0
+
+    targets = list(ours)
+    if args.any_tree:
+        print(f"\n[--any-tree] {args.any_tree}")
+        print("  Overriding the ownership guard. This is recorded in this output on purpose.")
+        targets += [p for p, _ in theirs] + unattributed
+
+    sent, vanished = 0, 0
+    for pid in targets:
+        try:
+            os.kill(pid, sig)
+            sent += 1
+        except ProcessLookupError:
+            vanished += 1
+        except PermissionError:
+            print(f"  cannot signal pid {pid}: permission denied", file=sys.stderr)
+
+    print(f"\nsignalled {sent} with SIG{args.signal.upper().removeprefix('SIG')}"
+          + (f", {vanished} had already exited" if vanished else ""))
+    refused = len(theirs) + len(unattributed) if not args.any_tree else 0
+    if refused:
+        print(f"refused {refused} outside your tree")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/test_lanekill.py
+++ b/prosper/tools/test_lanekill.py
@@ -26,9 +26,12 @@ should not take, so that case is covered by `worktree_reclaim.py`'s live measure
 ino=10784453 reached by both spellings) and not by an arm here. The two arms below are the
 cheap approximations of it; the docstring in the tool carries the real evidence.
 
-Linux only, deliberately, and that is a statement about the tool. Its attribution reads /proc;
-without one it cannot establish ownership and fails closed. The fail-closed path itself is
-covered by an arm that runs everywhere.
+Linux only, deliberately, and that is a statement about the tool: attribution reads /proc.
+
+**The fail-closed arm is Linux-only too, which is a deliberate narrowing.** It used to run
+everywhere by installing a stub and asserting the stub's own return values — which said nothing
+about lanekill and stayed green when a reviewer deleted the gate. It now calls `main()` against a
+live process, which needs a real process, so it cannot run where the rest cannot.
 """
 
 from __future__ import annotations
@@ -155,7 +158,14 @@ def test_fails_closed_without_a_process_scan(root: Path) -> None:
     this repository keeps paying for -- an assertion whose subject was never the code under test.
 
     So: run `main()` for real with the scan forced unsupported, against a process that IS in this
-    worktree and WOULD be signalled if the gate were gone. The survivor is the assertion.
+    worktree and WOULD be signalled if the gate were gone.
+
+    Precisely: **`rc == 2` is the discriminator**, not the survivor. With the scan stubbed the
+    victim cannot be reached whatever the tool does, so its survival is guaranteed by the stub
+    rather than earned by the gate — an earlier version of this docstring said "the survivor is
+    the assertion", which is the same overclaim this file exists to warn about. The live process
+    is here so the arm exercises the real matching path up to the refusal, not because its
+    survival proves anything.
     """
     repo = build_repo(root)
     wt = root / "wt-fc"
@@ -271,6 +281,16 @@ def test_end_to_end_spares_the_other_lane(root: Path) -> None:
         check("census kills nothing (mine alive)", mine.poll(), None)
         check("census kills nothing (theirs alive)", other.poll(), None)
 
+        # A LOOKALIKE IN MY OWN TREE. `lanekill.py:main` matches `comm == pattern`; changing that
+        # to `pattern in comm` reintroduces exactly the `pkill -f` over-match this tool contrasts
+        # itself against, and the ownership filter would NOT save it -- the blast radius is my own
+        # worktree, where everything is fair game. Nothing else in the suite notices.
+        import shutil
+        lookalike_bin = a / "sleepx"
+        shutil.copy("/bin/sleep", str(lookalike_bin))
+        lookalike = subprocess.Popen([str(lookalike_bin), "120"], cwd=str(a))
+        time.sleep(0.4)
+
         run = subprocess.run([sys.executable, str(HERE / "lanekill.py"), "sleep", "--yes"],
                              cwd=str(a), capture_output=True, text=True)
         time.sleep(0.5)
@@ -278,11 +298,76 @@ def test_end_to_end_spares_the_other_lane(root: Path) -> None:
         check("MY process was signalled", mine.poll() is not None, True)
         check("THE OTHER LANE'S process survived", other.poll(), None)
         check("output names the other lane", "ANOTHER LANE" in run.stdout, True)
+        check("a LOOKALIKE name in my own tree is untouched", lookalike.poll(), None)
     finally:
-        for pr in (mine, other):
+        for pr in (mine, other, lookalike):
             if pr.poll() is None:
                 pr.kill()
             pr.wait()
+
+
+def test_nested_worktree_topology(root: Path) -> None:
+    """A worktree INSIDE the main checkout -- which is what `.claude/worktrees/*` actually are.
+
+    Every other arm builds siblings, so `my_worktree()` taking the OUTERMOST match instead of the
+    innermost passed the whole suite. The direct effect of that is over-refusal rather than
+    over-killing, but it is the topology every real invocation runs in and nothing saw it.
+    """
+    repo = build_repo(root)
+    nest = repo / "inner"
+    git(repo, "worktree", "add", "-q", "-b", "inner", str(nest))
+
+    trees = list_worktrees(str(repo))
+    inner = lanekill.my_worktree(trees, str(nest))
+    outer = lanekill.my_worktree(trees, str(repo))
+    check("a nested tree resolves to ITSELF, not the enclosing checkout",
+          inner.real if inner else None, os.path.realpath(str(nest)))
+    check("the enclosing checkout resolves to itself",
+          outer.real if outer else None, os.path.realpath(str(repo)))
+    check("they are different trees", (inner.real != outer.real) if inner and outer else False, True)
+
+
+def test_any_tree_sweeps_undecidable_too(root: Path) -> None:
+    """`--any-tree` must sweep the UNDECIDABLE matches, not only other trees' -- through main().
+
+    My first attempt at this arm rebuilt the sweep from `classify()` output and asserted the
+    reconstruction covered every pid. That passed while `main()` dropped `unattributed` from its
+    target list, because the reconstruction was not the code. Same mistake as the one this whole
+    review was about, one level down: an assertion whose subject is a copy of the logic.
+
+    So this builds a genuinely undecidable process -- binary in one tree, cwd in another, which is
+    the ambiguity `attribute()` refuses -- and drives the real tool twice.
+    """
+    import shutil
+
+    repo = build_repo(root)
+    a, b = root / "wt-a", root / "wt-b"
+    git(repo, "worktree", "add", "-q", "-b", "at-a", str(a))
+    git(repo, "worktree", "add", "-q", "-b", "at-b", str(b))
+
+    binary = b / "psplit"                      # exe lives in wt-b ...
+    shutil.copy("/bin/sleep", str(binary))
+    proc = subprocess.Popen([str(binary), "120"], cwd=str(a))   # ... cwd is wt-a
+    time.sleep(0.4)
+    try:
+        refuse = subprocess.run([sys.executable, str(HERE / "lanekill.py"), "psplit", "--yes"],
+                                cwd=str(a), capture_output=True, text=True)
+        time.sleep(0.3)
+        check("a split cwd/exe process is refused by --yes alone", refuse.returncode, 1)
+        check("and it is still running", proc.poll(), None)
+        check("the refusal names both trees", ("at-a" in refuse.stdout or "wt-a" in refuse.stdout)
+              and ("at-b" in refuse.stdout or "wt-b" in refuse.stdout), True)
+
+        sweep = subprocess.run(
+            [sys.executable, str(HERE / "lanekill.py"), "psplit", "--yes", "--any-tree"],
+            cwd=str(a), capture_output=True, text=True)
+        time.sleep(0.5)
+        check("--any-tree signals the undecidable match", proc.poll() is not None, True)
+        check("--any-tree exits 0 having refused nothing", sweep.returncode, 0)
+    finally:
+        if proc.poll() is None:
+            proc.kill()
+        proc.wait()
 
 
 def main() -> int:
@@ -297,6 +382,8 @@ def main() -> int:
         test_outside_any_worktree_is_undecidable,
         test_end_to_end_spares_the_other_lane,
         test_fails_closed_without_a_process_scan,
+        test_nested_worktree_topology,
+        test_any_tree_sweeps_undecidable_too,
     ):
         print(f"{fn.__name__}:")
         with tempfile.TemporaryDirectory() as td:

--- a/prosper/tools/test_lanekill.py
+++ b/prosper/tools/test_lanekill.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Tests for lanekill.py.
+
+lanekill SIGNALS PROCESSES, so like its sibling `test_worktree_reclaim.py` these are mutation
+arms first: each builds a situation where a process MUST NOT be signalled and asserts both the
+refusal and which guard produced it. The positive arm exists to prove the machinery fires at
+all -- without it every refusal below would pass on a tool that never selects anything, which is
+the "clean zero from a broken instrument" failure this repo's trap table is full of.
+
+`test_symlinked_cwd_still_attributes` holds the two arms that discriminate, and they
+discriminate against DIFFERENT wrong implementations -- which was established by mutation, not
+assumed:
+
+* the **prefix-sharing sibling** arm reddens against `realpath() + startswith()`, because
+  `wt-real-extra` shares a prefix with `wt-real` and a prefix test claims it. Measured: mutating
+  the tool to that implementation fails exactly this arm and no other.
+* the **symlinked path** arm reddens against a bare string compare with no `realpath()` at all.
+  It does NOT redden against `realpath() + startswith()`, because realpath resolves a symlink
+  before the comparison. Stated explicitly so nobody reads a green symlink arm as proof that
+  string matching was ruled out -- it rules out one string implementation, not the family.
+
+Neither arm reaches the case that motivated inode identity in the first place: inside the ps5ys
+distrobox `/home` is a real BIND MOUNT rather than a symlink, so the same directory has two
+spellings that `realpath()` cannot reconcile. Constructing a bind mount needs privileges a test
+should not take, so that case is covered by `worktree_reclaim.py`'s live measurement (dev=57
+ino=10784453 reached by both spellings) and not by an arm here. The two arms below are the
+cheap approximations of it; the docstring in the tool carries the real evidence.
+
+Linux only, deliberately, and that is a statement about the tool. Its attribution reads /proc;
+without one it cannot establish ownership and fails closed. The fail-closed path itself is
+covered by an arm that runs everywhere.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+import lanekill  # noqa: E402
+from worktree_reclaim import list_worktrees  # noqa: E402
+
+FAILURES: list[str] = []
+
+
+def check(name: str, got, want, extra: str = "") -> None:
+    if got == want:
+        print(f"  ok   {name}")
+    else:
+        FAILURES.append(name)
+        print(f"  FAIL {name}: got {got!r}, want {want!r} {extra}")
+
+
+def git(repo: Path, *args: str) -> str:
+    p = subprocess.run(["git", "-C", str(repo), *args], capture_output=True, text=True)
+    if p.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed: {p.stderr}")
+    return p.stdout
+
+
+def build_repo(root: Path) -> Path:
+    repo = root / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "master", str(repo)], check=True)
+    git(repo, "config", "user.email", "t@example.com")
+    git(repo, "config", "user.name", "t")
+    (repo / "f.txt").write_text("x\n")
+    git(repo, "add", "f.txt")
+    git(repo, "commit", "-qm", "init")
+    return repo
+
+
+def test_attribution_separates_two_trees(root: Path) -> None:
+    """Positive arm + the cross-tree refusal, in one situation.
+
+    Two worktrees, a live process sitting in each. The tool must claim exactly the one in the
+    tree it is run from and refuse the other. If attribution were broken in the permissive
+    direction both would land in `ours`, which is the bug that cost a lane its measurement.
+    """
+    repo = build_repo(root)
+    a = root / "wt-a"
+    b = root / "wt-b"
+    git(repo, "worktree", "add", "-q", "-b", "lane-a", str(a))
+    git(repo, "worktree", "add", "-q", "-b", "lane-b", str(b))
+
+    procs = [subprocess.Popen(["sleep", "60"], cwd=str(d)) for d in (a, b)]
+    time.sleep(0.3)
+    try:
+        trees = list_worktrees(str(repo))
+        mine = lanekill.my_worktree(trees, str(a))
+        check("run from wt-a attributes to wt-a", mine.path if mine else None, str(a))
+
+        other = lanekill.my_worktree(trees, str(b))
+        check("run from wt-b attributes to wt-b", other.path if other else None, str(b))
+        check("the two trees are distinct", mine.real != other.real, True)
+    finally:
+        for p in procs:
+            p.kill()
+            p.wait()
+
+
+def test_symlinked_cwd_still_attributes(root: Path) -> None:
+    """Two spellings must attribute alike, and a lookalike must not attribute at all.
+
+    See the module docstring for which arm rules out which wrong implementation -- they are not
+    interchangeable, and the symlink half is the weaker of the two.
+    """
+    repo = build_repo(root)
+    wt = root / "wt-real"
+    git(repo, "worktree", "add", "-q", "-b", "lane-s", str(wt))
+
+    alias = root / "wt-alias"
+    os.symlink(str(wt), str(alias))
+
+    trees = list_worktrees(str(repo))
+    via_real = lanekill.my_worktree(trees, str(wt))
+    via_link = lanekill.my_worktree(trees, str(alias))
+    check("attributes via the real path", via_real.path if via_real else None, str(wt))
+    check("attributes via a symlinked path", via_link.path if via_link else None, str(wt))
+
+    # And the negative direction: a sibling directory that merely SHARES A PREFIX with the
+    # worktree name must not attribute. `wt-real-extra` starts with `wt-real`, so a naive
+    # `startswith` would claim it.
+    decoy = root / "wt-real-extra"
+    decoy.mkdir()
+    check("a prefix-sharing sibling does NOT attribute",
+          lanekill.my_worktree(trees, str(decoy)), None,
+          "-- a startswith() implementation would claim this directory")
+
+
+def test_outside_any_worktree_is_undecidable(root: Path) -> None:
+    """Ownership must be undecidable, not assumed, outside every tree."""
+    repo = build_repo(root)
+    wt = root / "wt-o"
+    git(repo, "worktree", "add", "-q", "-b", "lane-o", str(wt))
+    trees = list_worktrees(str(repo))
+    outside = root / "not-a-tree"
+    outside.mkdir()
+    check("a path in no worktree attributes to nothing",
+          lanekill.my_worktree(trees, str(outside)), None)
+
+
+def test_fails_closed_without_a_process_scan() -> None:
+    """With no readable /proc the tool must refuse, never fall through to 'nobody owns it'.
+
+    Platform-independent on purpose: this is the property that protects macOS and Windows, where
+    the real scan cannot run, so it must be verified where the real scan cannot run too.
+    """
+    original = lanekill.scan_processes
+    try:
+        lanekill.scan_processes = lambda *a, **k: ([], False)  # type: ignore[assignment]
+        refs, supported = lanekill.scan_processes()
+        check("unsupported scan reports supported=False", supported, False)
+        check("unsupported scan yields no refs", refs, [])
+    finally:
+        lanekill.scan_processes = original  # type: ignore[assignment]
+
+
+def main() -> int:
+    if sys.platform != "linux":
+        print("lanekill: attribution needs /proc; the fail-closed arm is the portable one")
+        test_fails_closed_without_a_process_scan()
+        return 1 if FAILURES else 0
+
+    for fn in (
+        test_attribution_separates_two_trees,
+        test_symlinked_cwd_still_attributes,
+        test_outside_any_worktree_is_undecidable,
+    ):
+        print(f"{fn.__name__}:")
+        with tempfile.TemporaryDirectory() as td:
+            fn(Path(td))
+    print("test_fails_closed_without_a_process_scan:")
+    test_fails_closed_without_a_process_scan()
+
+    print()
+    if FAILURES:
+        print(f"{len(FAILURES)} failure(s): {', '.join(FAILURES)}")
+        return 1
+    print("all arms passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/prosper/tools/test_lanekill.py
+++ b/prosper/tools/test_lanekill.py
@@ -146,38 +146,166 @@ def test_outside_any_worktree_is_undecidable(root: Path) -> None:
           lanekill.my_worktree(trees, str(outside)), None)
 
 
-def test_fails_closed_without_a_process_scan() -> None:
-    """With no readable /proc the tool must refuse, never fall through to 'nobody owns it'.
+def test_fails_closed_without_a_process_scan(root: Path) -> None:
+    """With no readable /proc the tool must refuse, and a LIVE MATCH IN MY OWN TREE must survive.
 
-    Platform-independent on purpose: this is the property that protects macOS and Windows, where
-    the real scan cannot run, so it must be verified where the real scan cannot run too.
+    The first version of this arm installed a lambda returning `([], False)` and then asserted the
+    lambda returned `([], False)`. That is a statement about the lambda. A reviewer deleted the
+    fail-closed gate from the tool and this arm stayed green, which is exactly the shape of test
+    this repository keeps paying for -- an assertion whose subject was never the code under test.
+
+    So: run `main()` for real with the scan forced unsupported, against a process that IS in this
+    worktree and WOULD be signalled if the gate were gone. The survivor is the assertion.
     """
-    original = lanekill.scan_processes
+    repo = build_repo(root)
+    wt = root / "wt-fc"
+    git(repo, "worktree", "add", "-q", "-b", "fc", str(wt))
+    victim = subprocess.Popen(["sleep", "120"], cwd=str(wt))
+    time.sleep(0.4)
+
+    original_scan = lanekill.scan_processes
+    original_argv = sys.argv[:]
+    cwd0 = os.getcwd()
     try:
         lanekill.scan_processes = lambda *a, **k: ([], False)  # type: ignore[assignment]
-        refs, supported = lanekill.scan_processes()
-        check("unsupported scan reports supported=False", supported, False)
-        check("unsupported scan yields no refs", refs, [])
+        os.chdir(str(wt))
+        sys.argv = ["lanekill.py", "sleep", "--yes"]
+        rc = lanekill.main()
+        time.sleep(0.3)
+        check("refuses with exit 2 when /proc is unreadable", rc, 2)
+        check("a live match in MY OWN tree survives the refusal", victim.poll(), None)
     finally:
-        lanekill.scan_processes = original  # type: ignore[assignment]
+        os.chdir(cwd0)
+        sys.argv = original_argv
+        lanekill.scan_processes = original_scan  # type: ignore[assignment]
+        if victim.poll() is None:
+            victim.kill()
+        victim.wait()
+
+
+# --------------------------------------------------------------------------- the decision itself
+#
+# Everything above tests ATTRIBUTION. A reviewer demonstrated that was not enough: mutating the
+# tool six ways -- each turning it into a cross-lane killer -- left every arm green, because every
+# arm called only `my_worktree()`. Deleting both live processes from the "positive" arm also left
+# it green. These arms exercise the code that decides to send a signal.
+
+
+class _T:
+    """Minimal stand-in for Worktree: `classify` and `attribute` use `.real` and `.holders`."""
+
+    def __init__(self, real, holders=()):
+        self.real = real
+        self.path = real
+        self.holders = list(holders)
+
+
+class _H:
+    def __init__(self, pid, kind):
+        self.pid = pid
+        self.kind = kind
+        self.comm = "x"
+        self.path = "/x"
+
+
+def test_classify_never_claims_another_tree() -> None:
+    """The mutation `t.real == mine.real` -> `True` must redden here."""
+    mine, other = _T("/w/a"), _T("/w/b")
+    ours, theirs, undec = lanekill.classify([1, 2, 3], {1: mine, 2: other}, mine)
+    check("only my tree's pid is ours", ours, [1])
+    check("another tree's pid is theirs", [p for p, _ in theirs], [2])
+    check("an unowned pid is undecidable", undec, [3])
+    check("an unowned pid is NOT ours", 3 in ours, False)
+    check("another tree's pid is NOT ours", 2 in ours, False)
+
+
+def test_disagreeing_strong_evidence_is_undecidable() -> None:
+    """cwd in one tree and exe in another: refuse, never pick by registration order.
+
+    The first version resolved this by whichever holder was visited last, so the verdict followed
+    `git worktree list` order and the same situation attributed both ways.
+    """
+    a = _T("/w/a", [_H(10, "cwd")])
+    b = _T("/w/b", [_H(10, "exe")])
+    owner, why = lanekill.attribute([a, b])
+    check("a split cwd/exe pid is attributed to nobody", 10 in owner, False)
+    check("and the refusal says why", "disagree" in why.get(10, ""), True)
+
+    # order must not change the answer -- this is the actual defect, so assert it directly
+    owner_rev, _ = lanekill.attribute([b, a])
+    check("reversing worktree order gives the same answer", 10 in owner_rev, False)
+
+
+def test_weak_evidence_is_not_ownership() -> None:
+    """An open fd or a mapping into a tree says the process READS there, not that it is yours."""
+    a = _T("/w/a", [_H(20, "fd")])
+    owner, why = lanekill.attribute([a])
+    check("an fd-only pid is attributed to nobody", 20 in owner, False)
+    check("and the refusal names the reason", "ownership" in why.get(20, ""), True)
+
+    b = _T("/w/b", [_H(21, "cwd"), _H(21, "map")])
+    owner2, _ = lanekill.attribute([b])
+    check("cwd still attributes even with a weak ref alongside", owner2[21].real, "/w/b")
+
+
+def test_end_to_end_spares_the_other_lane(root: Path) -> None:
+    """The whole tool, --yes, two live processes: exactly one dies.
+
+    This is the arm the six mutations were invisible to. It runs lanekill as a subprocess so the
+    census/`--yes` gate, the fail-closed gate and the exit code are all in the path.
+    """
+    repo = build_repo(root)
+    a, b = root / "wt-a", root / "wt-b"
+    git(repo, "worktree", "add", "-q", "-b", "e2e-a", str(a))
+    git(repo, "worktree", "add", "-q", "-b", "e2e-b", str(b))
+
+    mine = subprocess.Popen(["sleep", "120"], cwd=str(a))
+    other = subprocess.Popen(["sleep", "120"], cwd=str(b))
+    time.sleep(0.4)
+    try:
+        # census first: must kill NOTHING even though a match is ours
+        cen = subprocess.run([sys.executable, str(HERE / "lanekill.py"), "sleep"],
+                             cwd=str(a), capture_output=True, text=True)
+        time.sleep(0.3)
+        check("census exits 0", cen.returncode, 0)
+        check("census kills nothing (mine alive)", mine.poll(), None)
+        check("census kills nothing (theirs alive)", other.poll(), None)
+
+        run = subprocess.run([sys.executable, str(HERE / "lanekill.py"), "sleep", "--yes"],
+                             cwd=str(a), capture_output=True, text=True)
+        time.sleep(0.5)
+        check("--yes returns 1 having refused one", run.returncode, 1)
+        check("MY process was signalled", mine.poll() is not None, True)
+        check("THE OTHER LANE'S process survived", other.poll(), None)
+        check("output names the other lane", "ANOTHER LANE" in run.stdout, True)
+    finally:
+        for pr in (mine, other):
+            if pr.poll() is None:
+                pr.kill()
+            pr.wait()
 
 
 def main() -> int:
     if sys.platform != "linux":
-        print("lanekill: attribution needs /proc; the fail-closed arm is the portable one")
-        test_fails_closed_without_a_process_scan()
-        return 1 if FAILURES else 0
+        print("lanekill: attribution needs /proc, and the fail-closed arm now needs a live")
+        print("process to prove the refusal spared it -- so the whole suite is Linux-only.")
+        return 0
 
     for fn in (
         test_attribution_separates_two_trees,
         test_symlinked_cwd_still_attributes,
         test_outside_any_worktree_is_undecidable,
+        test_end_to_end_spares_the_other_lane,
+        test_fails_closed_without_a_process_scan,
     ):
         print(f"{fn.__name__}:")
         with tempfile.TemporaryDirectory() as td:
             fn(Path(td))
-    print("test_fails_closed_without_a_process_scan:")
-    test_fails_closed_without_a_process_scan()
+    for fn in (test_classify_never_claims_another_tree,
+               test_disagreeing_strong_evidence_is_undecidable,
+               test_weak_evidence_is_not_ownership):
+        print(f"{fn.__name__}:")
+        fn()
 
     print()
     if FAILURES:


### PR DESCRIPTION
`pkill` has two selectors and **neither answers the question that matters on a shared box**:

| | what it fixes | what it does not |
| --- | --- | --- |
| `pkill -f name` | — | over-matches substrings, matches its own shell (trap 135) |
| `pkill -x name` | matching accuracy | still kills **every lane's** process of that name |

Accuracy is not ownership. On 2026-08-21 a `pkill -x screenshot` — the form the existing guidance
points you toward — took a concurrent lane's coprime-interval sweep at 36 of 64 frames. That sweep
was the arm that would have settled whether Earthion's ~60 s cycle is an attract loop failing to
draw or a sequence restarting; without it the question was handed on at `CONFIDENCE: MED`
(instrument trap 213).

`lanekill` adds the missing selector.

```
$ python3 prosper/tools/lanekill.py bash
worktree: <WORKTREE>/coord-lanekill
16 process(es) named 'bash'

  MINE          pid 589333  /bin/bash -c ...
  ANOTHER LANE  pid 5299    [ps5ys]  /bin/bash
  ANOTHER LANE  pid 393650  [ps5ys]  /bin/bash -c set -u ... issue='2542' ...

  2 belong(s) to another worktree. Killing them takes a run that is
  probably mid-measurement, and the cost lands on a lane that cannot see why.

[census] nothing signalled. Re-run with --yes to signal the 1 in your tree.
```

That output is from a real run while writing this, and pid 393650 was **another session actively
working issue #2542**. A plain `pkill -x bash` would have taken it.

Census by default; `--yes` signals your tree's matches; `--any-tree REASON` overrides with the
reason printed into the output on purpose.

## Why it reuses `worktree_reclaim.py`'s scanner

Not for code reuse — for correctness. That scanner matches by `(st_dev, st_ino)` rather than by
path string, because `/home` is a symlink on the host and a **real bind mount** inside the ps5ys
distrobox, so the same directory has two spellings. A string-matching version of this tool would
silently fail to attribute every container process, conclude they belong to nobody, and then either
refuse everything or — with `--any-tree` — treat them as fair game.

**Fails closed** where `/proc` is unreadable: ownership cannot be established there, and "I could
not tell whose this is" must never render as "it is yours".

## Tests — refusals first, discriminator established by mutation

Registered as `lanekill_tool`, Linux-only for the same reason its sibling is.

Mutating the tool to `realpath() + startswith()` reddens **exactly one** arm:

```
FAIL a prefix-sharing sibling does NOT attribute: got Worktree(path='.../wt-real'), want None
1 failure(s)
```

The docstring records something the green run alone would hide: the **symlink** arm does *not*
redden under that mutation, because `realpath()` resolves a symlink before comparing. It rules out
one string implementation, not the family — so the prefix arm is the real discriminator and the
docstring says which arm covers which. The bind-mount case that motivated inode identity is not
reachable from a test without privileges a test should not take; it is covered by
`worktree_reclaim.py`'s live measurement and the docstring says that too rather than implying an
arm exists for it.

```
$ python3 prosper/tools/test_lanekill.py
all arms passed                                          # exit 0
```

Refs #2839, and implements the fix named in instrument trap 213.
