### PR TITLE
docs: a PR that adds a screenshot adds a BLOG.md entry — and findings count too

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -35,6 +35,28 @@ this is the real scene, not a cutscene. Tracker [#1898](...).
 
 ## 2026-08-21
 
+### Why The Plucky Squire's cutscene never ends
+
+No picture for this one — it is a measurement, and it replaced a guess that had been sitting in the
+notes as the frontier.
+
+The record said the route "stops driving input at 525 s", implying the cutscene was waiting for a
+button. It is not waiting at all. It advances roughly **300x too slowly to finish**, and two facts
+multiply into that:
+
+- the guest's tick rate **collapses 147x** when the 3D world streams in — about 25 polls per second
+  in the menus, **0.19** once the level loads;
+- in-game time advances **per flip, not per second**. That is deliberate and correct — each flip is
+  budgeted one refresh interval — but it means the game clock moves ~16.7 ms per flip however long
+  that flip actually took.
+
+At 0.19 flips per second, a 60-second intro needs hours. The 1,200-second run that "never reached
+gameplay" had bought a few seconds of it.
+
+It is demonstrated rather than argued: raising only the flip rate walks the guest straight past the
+intro to the storybook camera. So the wall is throughput, and the title is CPU-bound in texture
+realization — the GPU sits at 5-16% throughout.
+
 ### Two more titles reach gameplay — and one reaches it in the dark
 
 **Beneath** (`PPSA27640`) plays. This is the opening dive aboard the science ship: the waypoint

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -602,6 +602,27 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     fine and often better** — an fps counter, a timestamp, a route or frame ordinal. Those add measured
     facts about the run; they do not change what the run rendered. Keep annotation legible and out of
     the way of whatever the capture is evidence *for*, and say in the caption that it is on.
+  - **A PR that adds a screenshot adds a `BLOG.md` entry in the same PR.** `BLOG.md` is the progress
+    blog — hand-written, newest first — and it is the file the project owner actually reads to see
+    what is new. It is **not** generated, so nothing backfills a missing entry and nothing goes red
+    when one is skipped: the picture simply never surfaces, which is the whole failure this file
+    exists to prevent.
+    Put the entry at the top under a `## YYYY-MM-DD` heading, with the image and a sentence about
+    **what you are looking at** — not what the change was. The commit subject already says what the
+    change was, and that is exactly what made the old generated feed useless. A paragraph when a
+    title finally does something ("we finally reached gameplay in X, look"), one line when it is just
+    another capture.
+    Write it even when the news is bad or the picture is ugly: *Sonic Frontiers*' black-world capture
+    is in there precisely because the honest record is the point. And write it even when the rung did
+    **not** move — a capture of a title that got further and still fell short is worth more than
+    silence.
+    **A finding with no picture is welcome too**, and this is the half that gets skipped: a lane that
+    measures something surprising and ships no screenshot currently leaves no trace anywhere the owner
+    reads. *The Plucky Squire*'s cutscene turning out to advance 300x too slowly — because the guest's
+    tick rate collapses 147x when the 3D world streams in, and in-game time advances per flip rather
+    than per second — is a better read than most screenshots, and it went unwritten because the PR
+    happened to contain no image. Keep those short, and skip them when there is genuinely nothing a
+    reader would enjoy; a blog nobody wants to read is worse than a thin one.
   Run the strongest relevant local checks and wait for every applicable required CI check. Before
   merging, synchronize with the live target branch when needed, inspect the resulting diff, run `diff --check`,
   and address every known correctness concern.


### PR DESCRIPTION
Project-owner request: subagents keep not updating the blog.

`BLOG.md` landed *after* most current lane briefs went out, so nothing in the charter tells a lane
it is part of finishing. And because it is hand-written, **nothing backfills a missing entry and no
gate goes red when one is skipped** — the picture simply never surfaces, which is the exact failure
the file exists to prevent.

## The rule

> **A PR that adds a screenshot adds a `BLOG.md` entry in the same PR.** Put it at the top under a
> `## YYYY-MM-DD` heading, with the image and a sentence about **what you are looking at** — not what
> the change was. The commit subject already says what the change was, and that is exactly what made
> the old generated feed useless.
>
> Write it even when the news is bad or the picture is ugly. **A finding with no picture is welcome
> too** — keep those short, and skip them when there is genuinely nothing a reader would enjoy.

## Checking the case that prompted this

The Plucky Squire lane was the example, so I checked it rather than assuming: **that merge added
zero images** — `CMakeLists.txt`, a status doc, a route README, a `.pad`, `hle_agc.cpp`,
`render_cadence.hpp`, a test. Nothing was skipped by the letter of any rule.

The rule was simply too narrow. That lane measured something well worth reading — its cutscene
advances **~300x too slowly to finish**, because the guest's tick rate collapses **147x** when the
3D world streams in and in-game time advances **per flip rather than per second** — and it left no
trace anywhere the owner looks, purely because the PR happened to contain no image. So the
obligation now covers findings, not just pictures.

That entry is added to the blog in this PR, as the worked example of an image-less entry.

## Verification

```
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py   -> exit 0
git diff --check                                                                       -> clean
git diff --name-only origin/master...HEAD | grep -v '\.md$'                            -> empty
```

Docs-only; merging under the documented exception.
