### PR TITLE
fix(gpu_replay): type replay_output_extent's operation indices and drop three hand-rolled item lookups

### DIFF
--- a/prosper/tests/test_gpu_replay_extent.cpp
+++ b/prosper/tests/test_gpu_replay_extent.cpp
@@ -158,39 +158,39 @@ int main() {
         exact.items = {writer};
         exact.operations = {{SubmitOperationKind::Draw, 41, 100, true}};
 
-        const auto selected = replay_output_target_after_operation(exact, 0, 0x2010000000ull);
+        const auto selected = replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull);
         CHECK(selected.status == OutputTargetAfterStatus::Selected &&
-                  selected.target.operation_index == 0 && selected.target.draw_index == 41 &&
+                  selected.target.operation_index == prosper::tools::OperationIndex{0} && selected.target.draw_index == 41 &&
                   selected.target.slot == 0 && selected.target.guest_addr == 0x2010000000ull &&
                   selected.target.width == 1920 && selected.target.height == 1080 &&
                   selected.target.format == 37 && !selected.target.fixed_function_resolve,
               "exact selector retains operation/draw/slot/address/extent/format write proof");
 
-        CHECK(replay_output_target_after_operation(exact, 1, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{1}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::InvalidOperation,
               "exact selector distinguishes an invalid operation index");
         exact.operations[0].kind = SubmitOperationKind::Dispatch;
-        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::NonDrawOperation,
               "exact selector distinguishes a non-draw operation");
         exact.operations[0].kind = SubmitOperationKind::Draw;
         exact.operations[0].realized = false;
-        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::UnrealizedOperation,
               "exact selector distinguishes an unrealized draw operation");
         exact.operations[0].realized = true;
         exact.operations[0].source_index = 42;
-        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::DrawUnavailable,
               "exact selector distinguishes missing realized draw state");
         exact.operations[0].source_index = 41;
         exact.items[0].ps.color_targets[0].write_mask = 0;
-        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::NotWrittenByOperation,
               "a merely bound target with zero effective write mask is not an output");
         exact.items[0].ps.color_targets[0].write_mask = 0xf;
         exact.items[0].color_targets[0].width = 0;
-        CHECK(replay_output_target_after_operation(exact, 0, 0x2010000000ull).status ==
+        CHECK(replay_output_target_after_operation(exact, prosper::tools::OperationIndex{0}, 0x2010000000ull).status ==
                   OutputTargetAfterStatus::TargetIdentityUnavailable,
               "a written target with incomplete extent fails as unavailable identity");
     }
@@ -217,12 +217,12 @@ int main() {
         resolve.operations = {{SubmitOperationKind::Draw, 77, 600, true}};
 
         const auto destination =
-            replay_output_target_after_operation(resolve, 0, 0x2011800000ull);
+            replay_output_target_after_operation(resolve, prosper::tools::OperationIndex{0}, 0x2011800000ull);
         CHECK(destination.status == OutputTargetAfterStatus::Selected &&
                   destination.target.slot == 1 && destination.target.format == 97 &&
                   destination.target.fixed_function_resolve,
               "MODE=RESOLVE selects raw color1 destination despite zero shader write mask");
-        CHECK(replay_output_target_after_operation(resolve, 0, 0x2011000000ull).status ==
+        CHECK(replay_output_target_after_operation(resolve, prosper::tools::OperationIndex{0}, 0x2011000000ull).status ==
                   OutputTargetAfterStatus::NotWrittenByOperation,
               "MODE=RESOLVE never reports raw color0 source as an output");
     }
@@ -239,7 +239,7 @@ int main() {
         writer.ps.color_write_mask = 0xb;
         legacy.items = {writer};
         legacy.operations = {{SubmitOperationKind::Draw, 5, 10, true}};
-        const auto selected = replay_output_target_after_operation(legacy, 0, 0x12340000ull);
+        const auto selected = replay_output_target_after_operation(legacy, prosper::tools::OperationIndex{0}, 0x12340000ull);
         CHECK(selected.status == OutputTargetAfterStatus::Selected &&
                   selected.target.width == 320 && selected.target.height == 180 &&
                   selected.target.format == 37 && selected.target.slot == 0,
@@ -265,9 +265,9 @@ int main() {
         final.operations[0].source_index = 99;
 
         const auto predecessor = replay_bundle_output_target_after_operation(
-            earlier, 3, 4, 0, 0x2011800000ull);
+            earlier, 3, 4, prosper::tools::OperationIndex{0}, 0x2011800000ull);
         const auto selected_final = replay_bundle_output_target_after_operation(
-            final, 4, 4, 0, 0x2011800000ull);
+            final, 4, 4, prosper::tools::OperationIndex{0}, 0x2011800000ull);
         CHECK(!predecessor.applies_to_submit,
               "bundle exact selector leaves retained predecessor submit unbounded");
         CHECK(selected_final.applies_to_submit &&

--- a/prosper/tools/gpu_replay/gpu_replay.cpp
+++ b/prosper/tools/gpu_replay/gpu_replay.cpp
@@ -172,7 +172,7 @@ bool plan_exact_output_target(
     prosper::gpu::replay_tool::OutputTargetAfterOperation& target,
     uint64_t bundle_submit = UINT64_MAX) {
     const auto selected = prosper::gpu::replay_tool::replay_output_target_after_operation(
-        replay, operation_index, guest_addr);
+        replay, prosper::tools::OperationIndex{operation_index}, guest_addr);
     using Status = prosper::gpu::replay_tool::OutputTargetAfterStatus;
     if (selected.status != Status::Selected) {
         switch (selected.status) {
@@ -227,7 +227,7 @@ bool plan_exact_output_target(
     std::fprintf(stderr,
                  "[gpureplay] armed exact output%s op=%zu draw=%llu slot=%u addr=%016llx "
                  "extent=%ux%u format=%u resolve=%s\n",
-                 submit_tag, target.operation_index,
+                 submit_tag, prosper::tools::raw(target.operation_index),
                  static_cast<unsigned long long>(target.draw_index),
                  target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
                  target.height, target.format, target.fixed_function_resolve ? "yes" : "no");
@@ -245,7 +245,7 @@ bool read_exact_output_target(
         std::fprintf(stderr,
                      "gpu_replay: exact output readback unavailable op=%zu draw=%llu slot=%u "
                      "addr=%016llx extent=%ux%u format=%u/%u\n",
-                     target.operation_index, static_cast<unsigned long long>(target.draw_index),
+                     prosper::tools::raw(target.operation_index), static_cast<unsigned long long>(target.draw_index),
                      target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
                      target.height, target.format,
                      static_cast<unsigned>(requested_backend_format));
@@ -258,7 +258,7 @@ bool read_exact_output_target(
         std::fprintf(stderr,
                      "gpu_replay: exact output readback identity mismatch op=%zu draw=%llu "
                      "slot=%u addr=%016llx requested=%ux%u/%u/%u actual=%ux%u/%u\n",
-                     target.operation_index, static_cast<unsigned long long>(target.draw_index),
+                     prosper::tools::raw(target.operation_index), static_cast<unsigned long long>(target.draw_index),
                      target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
                      target.height, target.format,
                      static_cast<unsigned>(requested_backend_format), snapshot.width,
@@ -272,7 +272,7 @@ bool read_exact_output_target(
         std::fprintf(stderr,
                      "gpu_replay: exact output conversion unavailable op=%zu addr=%016llx "
                      "expected=%llu actual=%zu\n",
-                     target.operation_index, static_cast<unsigned long long>(target.guest_addr),
+                     prosper::tools::raw(target.operation_index), static_cast<unsigned long long>(target.guest_addr),
                      static_cast<unsigned long long>(expected_bytes), pixels.size());
         return false;
     }
@@ -283,7 +283,7 @@ bool read_exact_output_target(
     std::fprintf(stderr,
                  "[gpureplay] exact output%s op=%zu draw=%llu slot=%u addr=%016llx "
                  "extent=%ux%u format=%u/%u bytes=%zu hash=%016llx\n",
-                 submit_tag, target.operation_index,
+                 submit_tag, prosper::tools::raw(target.operation_index),
                  static_cast<unsigned long long>(target.draw_index),
                  target.slot, static_cast<unsigned long long>(target.guest_addr), target.width,
                  target.height, target.format, static_cast<unsigned>(requested_backend_format),
@@ -1491,7 +1491,8 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
         const auto selected =
             prosper::gpu::replay_tool::replay_bundle_output_target_after_operation(
                 final_replay, final_submit_index, final_submit_index,
-                output_target_after_operation, output_target_after_addr);
+                prosper::tools::OperationIndex{output_target_after_operation},
+                output_target_after_addr);
         if (!selected.applies_to_submit) {
             std::fprintf(stderr,
                          "gpu_replay: exact output selector did not apply to final bundle submit\n");
@@ -1684,7 +1685,8 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
         const auto exact_for_submit = output_target_after_operation != SIZE_MAX
             ? prosper::gpu::replay_tool::replay_bundle_output_target_after_operation(
                   replay, i, bundle.submits.size() - 1,
-                  output_target_after_operation, output_target_after_addr)
+                  prosper::tools::OperationIndex{output_target_after_operation},
+                  output_target_after_addr)
             : prosper::gpu::replay_tool::BundleOutputTargetAfterSelection{};
         if (exact_for_submit.applies_to_submit) {
             if (exact_for_submit.selection.status !=
@@ -1694,7 +1696,7 @@ int replay_bundle(const std::string& path, const char* output_path, bool zero_bo
                              "preflight validation\n");
                 return 2;
             }
-            operation_limit = exact_for_submit.selection.target.operation_index + 1;
+            operation_limit = prosper::tools::raw(exact_for_submit.selection.target.operation_index) + 1;
         } else if (i + 1 < bundle.submits.size() && intermediate_target_width) {
             operation_limit = 0;
             for (size_t operation_index = 0; operation_index < replay.operations.size(); ++operation_index) {
@@ -3578,7 +3580,7 @@ int main(int argc, char** argv) {
         return 0;
     }
     const size_t operation_limit = exact_output_target
-        ? exact_output_target.operation_index + 1
+        ? prosper::tools::raw(exact_output_target.operation_index) + 1
         : through_operation >= 0
             ? static_cast<size_t>(through_operation) + 1 : selected_operation_limit;
     const bool selected_draws_only = draw_selected && !draw_with_compute_prefix;
@@ -3770,7 +3772,7 @@ int main(int argc, char** argv) {
         std::snprintf(target_tag, sizeof target_tag,
                       " target=%016llx op=%zu draw=%llu slot=%u format=%u",
                       static_cast<unsigned long long>(exact_output_target.guest_addr),
-                      exact_output_target.operation_index,
+                      prosper::tools::raw(exact_output_target.operation_index),
                       static_cast<unsigned long long>(exact_output_target.draw_index),
                       exact_output_target.slot, exact_output_target.format);
     else if (output_extent.target_addr)

--- a/prosper/tools/gpu_replay/replay_output_extent.hpp
+++ b/prosper/tools/gpu_replay/replay_output_extent.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "gpu/capture/gpu_capture.hpp"
+#include "realized_shader_dump.hpp"
+#include "replay_indices.hpp"
 
 #include <algorithm>
 #include <cstddef>
@@ -45,7 +47,9 @@ struct OutputTarget {
 // compare every field; looking the format up again by address would allow a later alias/version to
 // masquerade as the requested surface.
 struct OutputTargetAfterOperation {
-    size_t operation_index = SIZE_MAX;
+    // Typed: an index into replay.operations, not a draw ordinal and not an item index.
+    // See replay_indices.hpp for the defect that motivated separating them.
+    prosper::tools::OperationIndex operation_index = prosper::tools::kNoOperationIndex;
     uint64_t guest_addr = 0;
     uint32_t width = 0;
     uint32_t height = 0;
@@ -55,7 +59,8 @@ struct OutputTargetAfterOperation {
     bool fixed_function_resolve = false;
 
     explicit operator bool() const {
-        return operation_index != SIZE_MAX && guest_addr && width && height && format &&
+        return operation_index != prosper::tools::kNoOperationIndex && guest_addr && width &&
+               height && format &&
                draw_index != UINT64_MAX && slot < kColorTargetCount;
     }
 };
@@ -114,16 +119,24 @@ inline uint32_t replay_color_write_mask(const DrawItem& draw, uint32_t slot) {
 // raw color1 binding is the destination even though the pixel shader exports nothing and therefore
 // has a zero shader/write mask; raw color0 is only the source and must never be reported as output.
 inline OutputTargetAfterSelection replay_output_target_after_operation(
-    const GpuReplayFrame& replay, size_t operation_index, uint64_t guest_addr) {
-    if (operation_index >= replay.operations.size())
+    const GpuReplayFrame& replay, prosper::tools::OperationIndex operation_index,
+    uint64_t guest_addr) {
+    if (prosper::tools::raw(operation_index) >= replay.operations.size())
         return {OutputTargetAfterStatus::InvalidOperation, {}};
-    const auto& operation = replay.operations[operation_index];
+    const auto& operation = replay.operations[prosper::tools::raw(operation_index)];
     if (operation.kind != SubmitOperationKind::Draw)
         return {OutputTargetAfterStatus::NonDrawOperation, {}};
     if (!operation.realized)
         return {OutputTargetAfterStatus::UnrealizedOperation, {}};
-    const auto found = std::find_if(replay.items.begin(), replay.items.end(),
-        [&](const DrawItem& draw) { return draw.draw_index == operation.source_index; });
+    // The shared lookup, not a fourth hand-rolled copy: #2739 seam 2 was partly a hand-rolled loop
+    // at a call site that omitted a filter the shared helper applies, and every copy is another
+    // place for that to happen again.
+    const auto found_index =
+        prosper::tools::replay_item_index_for_draw(
+            replay, prosper::tools::DrawIndex{operation.source_index});
+    const auto found = found_index == prosper::tools::kNoItemIndex
+        ? replay.items.end()
+        : replay.items.begin() + static_cast<std::ptrdiff_t>(prosper::tools::raw(found_index));
     if (found == replay.items.end())
         return {OutputTargetAfterStatus::DrawUnavailable, {}};
 
@@ -166,7 +179,7 @@ inline OutputTargetAfterSelection replay_output_target_after_operation(
 // full even if it happens to contain the same operation/address pair.
 inline BundleOutputTargetAfterSelection replay_bundle_output_target_after_operation(
     const GpuReplayFrame& replay, size_t current_submit_index, size_t selected_final_submit_index,
-    size_t operation_index, uint64_t guest_addr) {
+    prosper::tools::OperationIndex operation_index, uint64_t guest_addr) {
     if (current_submit_index != selected_final_submit_index) return {};
     return {true, replay_output_target_after_operation(replay, operation_index, guest_addr)};
 }
@@ -183,8 +196,11 @@ inline OutputTarget replay_last_target_matching_extent(const GpuReplayFrame& rep
     for (size_t operation_index = 0; operation_index < count; ++operation_index) {
         const auto& operation = replay.operations[operation_index];
         if (!operation.realized || operation.kind != SubmitOperationKind::Draw) continue;
-        const auto draw = std::find_if(replay.items.begin(), replay.items.end(),
-            [&](const auto& item) { return item.draw_index == operation.source_index; });
+        const auto draw_index = prosper::tools::replay_item_index_for_draw(
+            replay, prosper::tools::DrawIndex{operation.source_index});
+        const auto draw = draw_index == prosper::tools::kNoItemIndex
+            ? replay.items.end()
+            : replay.items.begin() + static_cast<std::ptrdiff_t>(prosper::tools::raw(draw_index));
         if (draw == replay.items.end() || !draw->color0_base ||
             draw->color0_width != width || draw->color0_height != height)
             continue;
@@ -213,8 +229,11 @@ inline OutputExtent replay_output_extent(const GpuReplayFrame& replay, OutputExt
         for (size_t operation_index = 0; operation_index < count; ++operation_index) {
             const auto& operation = replay.operations[operation_index];
             if (!operation.realized || operation.kind != SubmitOperationKind::Draw) continue;
-            const auto draw = std::find_if(replay.items.begin(), replay.items.end(),
-                [&](const auto& item) { return item.draw_index == operation.source_index; });
+            const auto draw_index = prosper::tools::replay_item_index_for_draw(
+                replay, prosper::tools::DrawIndex{operation.source_index});
+            const auto draw = draw_index == prosper::tools::kNoItemIndex
+                ? replay.items.end()
+                : replay.items.begin() + static_cast<std::ptrdiff_t>(prosper::tools::raw(draw_index));
             if (draw != replay.items.end()) select_draw(*draw);
         }
     }


### PR DESCRIPTION
Completes #2739 seam 2 across the file review flagged as carrying the same family.

## The three hand-rolled lookups

`replay_output_extent.hpp` had **three** `std::find_if` copies of the item lookup. They are replaced
by the shared `replay_item_index_for_draw()`. Zero copies remain; the helper is used three times.

That is the point rather than tidiness: **the seam-2 defect was partly a hand-rolled loop at a call
site that omitted a filter the shared helper applies.** Each copy is another place for that omission
to recur.

## Typed indices

`OutputTargetAfterOperation::operation_index` and both entry points now take `OperationIndex` rather
than `size_t`, so an item index or a draw ordinal can no longer be passed where an operation index
belongs.

## The #2844 gate earned itself immediately

Typing the operation indices turned **five** printf sites into build errors:

```
gpu_replay.cpp:228, :246, :259, :273, :284
error: format '%zu' expects argument of type 'size_t',
       but argument N has type 'prosper::tools::OperationIndex' [-Werror=format=]
```

This is precisely the recurrence predicted when that gate was proposed — *"gpu_replay.cpp prints
those with %zu at roughly sixteen more sites, so the class recurs the moment that lands"*. **Without
the gate these would have been silent UB in five diagnostics at once**, in a tool whose whole job is
to be believed. Wrapped in `raw()`.

## Verification

```
cmake --build prosper/build-linux -j6      BUILD_RC=0
ctest --no-tests=error                     CTEST_RC=0
100% tests passed out of 284
210/284 gpu_replay_output_extent ...... Passed
```

Test #210 is the case that exercises the rewritten lookups, so I confirmed it *executed* rather than
relying on the suite total. `git diff --check` clean; session-trailer gate 0.

Fixes #2840
