### PR TITLE
docs(gta5): 0x413dc6700 has ONE guest loop, and the runaway is ~100x its data ceiling

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -5559,9 +5559,12 @@ disabled process-wide, the indirect latch drops every remaining draw, and skippi
 yields zero device losses and the first real scene content this title has produced. The mechanism
 inside the shader is not established, and the "183 must become 0" oracle is void.
 
-The pointer-chase loop is now *less* likely to be the hang: it is one of three dispatcher loops in the
-module, and it is the one just shown to be bounded at 11 iterations on the hanging dispatch's own
-data. The other two are unexamined.
+The pointer-chase loop is now *less* likely to be the hang: it is bounded at 11 iterations on the
+hanging dispatch's own data. **Superseded in one respect — see "`0x413dc6700` has exactly ONE loop"
+below.** The "three dispatcher loops" are prosper's own, one per barrier-delimited phase, not three
+guest loops: the guest program has a single back-edge and no indirect branches, and it is this one. So
+"the other two are unexamined" is a statement about our CFG lowering, and the phases those two wrap
+contain no guest loop at all.
 
 ## The first 88 folds see an EMPTY SRT — and a capture taken during them is unrepresentative
 
@@ -5637,6 +5640,86 @@ bases resolved across a *whole run*, not one dispatch's. This program runs many 
 **different tables**, and attributing one dispatch's buffer to another is precisely the error that
 produced the retracted cyclic-table root cause. Re-deriving the link graph from `0x20f848417c` and
 finding it acyclic reproduces the *succeeding* dispatch's measurement, not the hanging one's.
+
+## `0x413dc6700` has exactly ONE loop, and the runaway exceeds what its data can justify by ~100x
+
+Measured 2026-08-21 from `shader_inspect`'s disassembly of the raw dump. This is **ISA structure**, so
+unlike the SPIR-V dissection voided by #2794 it is unaffected by the empty-SRT startup window — the
+fold changes which memory ops survive, never which branches exist.
+
+| phase | guest pc | instrs | MUBUF | DS | **back-edges** | fwd branches | blocks |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 0 | 0..115 | 90 | 5 | 1 | **1** | 6 | 14 |
+| 1 | 116..129 | 12 | 0 | 2 | **0** | 1 | 2 |
+| 2 | 130..902 | 679 | 36 | 2 | **0** | 38 | 72 |
+
+**The whole program has one back-edge and zero indirect branches** (no `s_setpc_b64`/`s_swappc_b64`).
+The block counts are an independent census (leaders = branch targets + fall-throughs) and they agree
+with the ordinal→pc map the emitter itself announces when a bound arms: phase 0 prints 15 ordinals,
+the last being the empty `pc116..<116` terminator.
+
+### Guest loops and dispatcher loops are DIFFERENT OBJECTS — this file has invited the conflation
+
+An earlier line here said the pointer chase "is one of three dispatcher loops in the module" and that
+"the other two are unexamined". Those three are **prosper's own**: `rdna2_emit_cfg.cpp` emits one
+dispatcher per barrier-delimited phase (`b.cfg_phase_ordinal++`), which is what
+`PROSPER_CFG_TRIP_BOUND_PHASE` selects. The guest has **one** loop, in phase 0. So "examine the other
+two" is a question about **our lowering**, not about the guest program — and phases 1 and 2 wrap code
+with no guest loop at all, which makes any repeated visit there unambiguously ours.
+
+### The loop, and why it cannot self-limit
+
+```
+88: v_mov_b32     v2, s22            ; save step count
+89: v_cmpx_ne_u32 exec, 0, v1        ; lanes whose link is 0 drop out
+90: s_cbranch_execz -> 98            ; the ONLY exit
+91: buffer_load_dword v1, v1, s[0:3] idxen
+93: s_add_i32     s22, s22, 1        ; incremented, NEVER compared
+95: v_bfe_u32     v1, v1, 3, 27      ; next = (word >> 3) & 0x7FFFFFF
+97: s_branch -> 88                   ; UNCONDITIONAL back-edge
+```
+
+`s22` is a step *count*, not a bound; nothing in the body tests it. EXEC is saved to VCC at pc 85 and
+restored at pc 98, so the loop is a standard "chase until every lane hits a zero link" with no trip
+limit of its own. **Termination is entirely a property of loaded data.**
+
+### The contradiction
+
+`scan_parent_array`'s link function is `(words[i] >> 3) & 0x7FFFFFFu` — **exactly** the shader's
+`v_bfe_u32 v1, v1, 3, 27`. So the acyclic verdict on the hanging dispatch's table is not an instrument
+artifact: the offline walk follows the same edges the shader does. With longest chain 11 (13–16 in
+other samples) and 2 of phase 0's 14 blocks inside the loop, the dispatcher ceiling is
+`12 + 2x11 = 34` trips.
+
+**Measured: 4,096 trips, on 11 separate dispatches** (`trips=4096 dispatch-range=6..14`, submit 5620,
+dispatches 38..42 among them). Roughly **100x** the ceiling the data allows.
+
+### What the witness can and cannot localise
+
+The extremes are **sound**: they are updated on every back-edge traversal, reading `pc_var` *before*
+the `hit` predicate, so the cap's own truncation does not contaminate them
+(`rdna2_emit_cfg.cpp:4917`). `dispatch-range=6..14` therefore establishes something real —
+**ordinals 0..5 (guest pc 0..73) are never revisited**, so the runaway is confined to the phase's
+second half, and the single loop (ordinals 8 = `pc88..<91`, 9 = `pc91..<98`) lies inside that span.
+
+**They cannot say more than that.** A run concentrating its trips in `{8,9}` and a state machine
+genuinely cycling across `6..14` produce an identical min/max record, and those two have different
+fixes — the first says our lowering is not honouring the `v_cmpx` → EXEC → `s_cbranch_execz` exit, the
+second says our dispatcher revisits blocks the guest does not. Separating them needs a per-ordinal
+visit histogram (**#2858**).
+
+### Also settled here
+
+- **Both `s_barrier`s (pc 116, 129) are reached unconditionally by every wave.** No forward branch
+  skips either, and no earlier branch exits to `endpgm` before them, so they are uniform — consistent
+  with the barrier lever having been inert (trap 164).
+- **#2542's positive control passes but does not cover this.** It shows per-lane EXEC narrowing and
+  the cross-lane `execz` vote are correct — with a body that "decrements the index instead of chasing
+  a buffer". So it exercises the exit *mechanism* and never the loaded value the exit *depends on*.
+  A candidate mechanism that fits every observation without requiring corruption — lanes walking past
+  the extent `scan_parent_array` classified, so no zero link is ever met — is recorded as a
+  **hypothesis** on #2858, along with the `PROSPER_DYNTRACE_ADDR` check that would settle it before
+  anyone touches the recompiler.
 
 ## Other open defects
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -5653,10 +5653,18 @@ fold changes which memory ops survive, never which branches exist.
 | 1 | 116..129 | 12 | 0 | 2 | **0** | 1 | 2 |
 | 2 | 130..902 | 679 | 36 | 2 | **0** | 38 | 72 |
 
-**The whole program has one back-edge and zero indirect branches** (no `s_setpc_b64`/`s_swappc_b64`).
-The block counts are an independent census (leaders = branch targets + fall-throughs) and they agree
-with the ordinal→pc map the emitter itself announces when a bound arms: phase 0 prints 15 ordinals,
-the last being the empty `pc116..<116` terminator.
+**The whole program has one back-edge and zero indirect branches.** Three further forms are absent
+and were checked by encoding rather than assumed: no SOPP `0x17`–`0x1a` (the CDBG branch family), **no
+SOPK at all** (so no `s_call_b64`, no `s_subvector_loop_*`), and no `s_getpc_b64` anywhere — there is
+no mechanism in this program to materialise a PC.
+
+The block counts are an independent census (leaders = branch targets + fall-throughs). **They line up
+with the emitter's announced ordinal→pc map for phase 0 only** — it prints 15 ordinals, the last being
+the empty `pc116..<116` terminator, against 14 leaders. That agreement does **not** extend to the other
+phases, and the reason is structural rather than a discrepancy: the emitter's partition always contains
+its phase's own first pc (`rdna2_emit_cfg.cpp:1659` asserts it), so it announces **4** ordinals for
+phase 1 and **73** for phase 2 against the 2 and 72 leaders below. Phase 0 agrees only because pc 0 is
+both the program entry and the phase front.
 
 ### Guest loops and dispatcher loops are DIFFERENT OBJECTS — this file has invited the conflation
 
@@ -5686,27 +5694,71 @@ limit of its own. **Termination is entirely a property of loaded data.**
 ### The contradiction
 
 `scan_parent_array`'s link function is `(words[i] >> 3) & 0x7FFFFFFu` — **exactly** the shader's
-`v_bfe_u32 v1, v1, 3, 27`. So the acyclic verdict on the hanging dispatch's table is not an instrument
-artifact: the offline walk follows the same edges the shader does. With longest chain 11 (13–16 in
-other samples) and 2 of phase 0's 14 blocks inside the loop, the dispatcher ceiling is
-`12 + 2x11 = 34` trips.
+`v_bfe_u32 v1, v1, 3, 27` (BFE with offset 3, width 27, is that mask). So the offline walk follows the
+**same edges** the shader does.
+
+**It does not follow the same DOMAIN, and that is an open fork rather than a detail.** The walk calls a
+chain terminating at `i == 0 || i >= records`, with `records = byte_count / 4` — the **host buffer's**
+size, not the SRD's `NUM_RECORDS`. So it reproduces the edges and *assumes* the extent. If the
+"lanes walk past the classified extent" hypothesis below is right, then the acyclic verdict is itself
+an extent artifact and the ceiling below is **void rather than exceeded**. Both readings are live;
+what is established is the link function, not the domain.
+
+Taking the acyclic verdict at face value *for the moment*: with longest chain 11 (13–16 in other
+samples) and 2 of phase 0's 14 blocks inside the loop, the ceiling is `12 + 2x11 + 1 = 35` dispatcher
+trips — the `+1` because the loop's entry ordinal is dispatched once more than the body is traversed.
 
 **Measured: 4,096 trips, on 11 separate dispatches** (`trips=4096 dispatch-range=6..14`, submit 5620,
-dispatches 38..42 among them). Roughly **100x** the ceiling the data allows.
+dispatches 38..42 among them). And 4,096 is the **cap**, not the loop's natural length — the run stopped
+there because the bound fired — so it is a **floor**. The excess over the data-implied ceiling is
+therefore **at least ~120x**, with no upper figure available from this instrument.
 
 ### What the witness can and cannot localise
 
-The extremes are **sound**: they are updated on every back-edge traversal, reading `pc_var` *before*
-the `hit` predicate, so the cap's own truncation does not contaminate them
-(`rdna2_emit_cfg.cpp:4917`). `dispatch-range=6..14` therefore establishes something real —
-**ordinals 0..5 (guest pc 0..73) are never revisited**, so the runaway is confined to the phase's
-second half, and the single loop (ordinals 8 = `pc88..<91`, 9 = `pc91..<98`) lies inside that span.
+The extremes are **sound as far as they go**: updated on every back-edge traversal, reading `pc_var`
+*before* the `hit` predicate, so the cap's own truncation cannot contaminate them
+(`rdna2_emit_cfg.cpp:4918-4925`, with `hit` not computed until `:4932`).
 
-**They cannot say more than that.** A run concentrating its trips in `{8,9}` and a state machine
-genuinely cycling across `6..14` produce an identical min/max record, and those two have different
+**But `dispatch-range=6..14` establishes less than it appears to, and the reason is the reduction, not
+the shape.** The two fields are published with `AtomicUMin`/`AtomicUMax` **across invocations**, so the
+range is a *union* over every capped invocation rather than one invocation's itinerary. `min=6` in
+particular needs no cycling at all to explain: pc 40's `s_cbranch_execz` jumps straight to ordinal 6,
+so an invocation can simply *start* its back-edge history there. Read it as "ordinals 0..5
+(guest pc 0..72) were never the target of a back-edge in any capped invocation", which is weaker than
+"the runaway is confined to the second half".
+
+**What min/max cannot do at all is localise.** A run concentrating its trips in `{8,9}` and a state
+machine genuinely cycling across `6..14` produce an identical record, and those two have different
 fixes — the first says our lowering is not honouring the `v_cmpx` → EXEC → `s_cbranch_execz` exit, the
 second says our dispatcher revisits blocks the guest does not. Separating them needs a per-ordinal
 visit histogram (**#2858**).
+
+### `0x413dc6700` is NOT a shipped fxdb shader (2026-08-21)
+
+Checked against the title's own shader archive — `fxdb/sga_prospero_final.awc`, magic `SGD2`, 43.4 MB
+("prospero" is the PS5 codename) — and against a 4,884-file extraction of it:
+
+| probe | result |
+| --- | --- |
+| whole 3,612-byte program, byte-identical | absent |
+| first 128 / 64 / 32 bytes | absent |
+| the 7-dword loop body (pc 91..97) | absent |
+| `v_bfe_u32 v1,v1,3,27` + its MUBUF, as a pair | absent |
+| same probes against the **packed** `.awc` | absent |
+
+**The null is controlled, which is the only reason it is worth recording.** Positive controls run
+against the same corpus: 20 real bytes lifted out of one archive member match 1,051 files; **1,318 of
+4,884** members contain a MUBUF at all; the exact dword `0xe0302000` appears in **75** members; and a
+known member's first 64 bytes are present verbatim in the packed `.awc`. So the search machinery
+fires, the corpus contains comparable code, and the absence is a property of the subject.
+
+Two consequences. **The archive is a working naming oracle** — a live-dumped lighting program matched
+one member exactly, naming it `s5_182_raytraced_lighting_CS_RaytraceReflectionLightPass`, so live
+programs *can* be identified this way when they are shipped ones. And `0x413dc6700` is **not** among
+them, nor are any of the eight `lane-*` traversal-table writers, so whatever it is, it is not loaded
+from the fxdb — leaving runtime generation or another source, which is a narrower question than
+before. Note the archive members begin directly with RDNA2 ISA: the `_Wrapped` in their names is part
+of the shader's name, not a container, so byte comparison against a raw dump is valid.
 
 ### Also settled here
 

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -5711,7 +5711,7 @@ trips — the `+1` because the loop's entry ordinal is dispatched once more than
 **Measured: 4,096 trips, on 11 separate dispatches** (`trips=4096 dispatch-range=6..14`, submit 5620,
 dispatches 38..42 among them). And 4,096 is the **cap**, not the loop's natural length — the run stopped
 there because the bound fired — so it is a **floor**. The excess over the data-implied ceiling is
-therefore **at least ~120x**, with no upper figure available from this instrument.
+therefore **at least ~117x**, with no upper figure available from this instrument.
 
 ### What the witness can and cannot localise
 
@@ -5735,8 +5735,10 @@ visit histogram (**#2858**).
 
 ### `0x413dc6700` is NOT a shipped fxdb shader (2026-08-21)
 
-Checked against the title's own shader archive — `fxdb/sga_prospero_final.awc`, magic `SGD2`, 43.4 MB
-("prospero" is the PS5 codename) — and against a 4,884-file extraction of it:
+Checked against the title's **two** shipped shader archives — `fxdb/sga_prospero_final.awc` (magic
+`SGD2`, 43.4 MB; "prospero" is the PS5 codename) and `fxdb/sga_prospero_final_init.awc`, which holds
+the 195 `final_init` members and is a *separate* file whose contents are absent from the big one — and
+against a 4,864-member extraction of them:
 
 | probe | result |
 | --- | --- |
@@ -5744,21 +5746,38 @@ Checked against the title's own shader archive — `fxdb/sga_prospero_final.awc`
 | first 128 / 64 / 32 bytes | absent |
 | the 7-dword loop body (pc 91..97) | absent |
 | `v_bfe_u32 v1,v1,3,27` + its MUBUF, as a pair | absent |
-| same probes against the **packed** `.awc` | absent |
+| same probes against **both packed archives** | absent |
 
-**The null is controlled, which is the only reason it is worth recording.** Positive controls run
-against the same corpus: 20 real bytes lifted out of one archive member match 1,051 files; **1,318 of
-4,884** members contain a MUBUF at all; the exact dword `0xe0302000` appears in **75** members; and a
-known member's first 64 bytes are present verbatim in the packed `.awc`. So the search machinery
-fires, the corpus contains comparable code, and the absence is a property of the subject.
+**The null is controlled, which is the only reason it is worth recording** — and the control that
+matters is not the machinery but a **positive instance of the class under test, drawn from a different
+source**. That exists here: of 20 independently live-dumped programs, **13 are byte-identical to
+archive members** (11 of the 13 that exceed 200 bytes). Same probe, same corpus, a shipped program
+found — so the probe can express the case, and `0x413dc6700`'s absence is a property of the subject
+rather than of the search.
 
-Two consequences. **The archive is a working naming oracle** — a live-dumped lighting program matched
-one member exactly, naming it `s5_182_raytraced_lighting_CS_RaytraceReflectionLightPass`, so live
-programs *can* be identified this way when they are shipped ones. And `0x413dc6700` is **not** among
-them, nor are any of the eight `lane-*` traversal-table writers, so whatever it is, it is not loaded
-from the fxdb — leaving runtime generation or another source, which is a narrower question than
-before. Note the archive members begin directly with RDNA2 ISA: the `_Wrapped` in their names is part
-of the shader's name, not a container, so byte comparison against a raw dump is valid.
+Supporting controls on the same corpus: 20 real bytes lifted from one member match 1,051 files;
+**1,318 of 4,864** members contain a MUBUF at all; the exact dword `0xe0302000` appears in **75**;
+`v_bfe_u32` occurs 1,888 times across 1,359 members and its exact dword `0xd5480001` in 83 — yet the
+`(3,27)` operand pair is absent everywhere. The size gap (13.2 MB extracted against 43.4 MB packed) is
+metadata being dropped, not members being missed: every sampled `final` and `ptfx_sprite` member is
+present verbatim in the packed file (250/250 and 95/95).
+
+Two consequences. **The archive is a working naming oracle**, on 13 exact matches rather than one —
+a live-dumped lighting program resolves to `s5_182_raytraced_lighting_CS_RaytraceReflectionLightPass`.
+And `0x413dc6700` is **not** among them, nor are any of the eight `lane-*` traversal-table writers.
+
+**The obvious objection — that a shipped shader could be relocated, patched or specialised at load
+time, so absence proves nothing — is answered empirically rather than dismissed.** For 11 of the 13
+matches the archived and runtime bytes are *identical*, so this title does not transform programs as a
+rule. The two residuals separate the failure modes and place `0x413dc6700` in the harmless one: one
+live program matches a member for 128 bytes and then diverges (transformation does happen, and it
+leaves a matching **prefix**), while `0x413dc6700` has no head match at **any** length. A
+shipped-then-diverged program would still match its prologue; this one never does.
+
+Byte comparison is valid because members begin directly with RDNA2 ISA — the `_Wrapped` in their names
+is part of the shader's name, not a container. Corpus-wide, 4,809 of 4,864 members open with a SOPP
+dword, there are only 16 distinct first dwords, and **4,627 open with `0xbfa00003`, which is this
+program's own first dword** — so a differing prologue cannot explain the miss.
 
 ### Also settled here
 


### PR DESCRIPTION
Docs-only. Records an ISA-level structural census of the hanging program and corrects a line that has been inviting a category error.

## What is measured

| phase | guest pc | instrs | MUBUF | back-edges | blocks |
| --- | --- | --- | --- | --- | --- |
| 0 | 0..115 | 90 | 5 | **1** | 14 |
| 1 | 116..129 | 12 | 0 | **0** | 2 |
| 2 | 130..902 | 679 | 36 | **0** | 72 |

One back-edge in the whole program, zero indirect branches. Method: `shader_inspect` disassembly of the raw dump, restricted to real SOPP branch opcodes. Block counts are an independent census (leaders = branch targets + fall-throughs) and **agree with the ordinal→pc map the emitter itself prints** when a bound arms — phase 0 announces 15 ordinals, the last being the empty `pc116..<116` terminator.

Unlike the SPIR-V dissection voided by #2794, this is unaffected by the empty-SRT startup window: the fold changes which memory ops survive, never which branches exist.

## The correction

This file said the pointer chase *"is one of three dispatcher loops in the module"* with *"the other two unexamined"*. Those three are **prosper's own** — one dispatcher per barrier-delimited phase (`b.cfg_phase_ordinal++`), which is what `PROSPER_CFG_TRIP_BOUND_PHASE` selects. The guest has **one**. So "examine the other two" is a question about our lowering, and the phases they wrap contain no guest loop at all.

## The contradiction it exposes

`scan_parent_array`'s link function is `(words[i] >> 3) & 0x7FFFFFF` — **exactly** the shader's `v_bfe_u32 v1, v1, 3, 27` — so the acyclic verdict is not an instrument artifact. With longest chain 11 and 2 of phase 0's 14 blocks inside the loop, the ceiling is `12 + 2×11 = 34` dispatcher trips. **Measured: 4,096, on 11 separate dispatches.**

The loop also has no trip bound of its own: unconditional back-edge, counter incremented but never compared, exit only via `s_cbranch_execz`.

## Honest about instrument limits

The witness extremes are **sound** — updated on every back-edge *before* the `hit` predicate, so the cap's truncation cannot contaminate them — and they do establish that ordinals 0..5 are never revisited. But min/max cannot separate "the loop spins" from "our state machine cycles across `6..14`"; both produce an identical record. That needs the per-ordinal histogram proposed in #2858, and the section says so rather than picking a reading.

## Verification

- `check_numbered_table.py` on `GAME_COMPAT_ORCHESTRATION.md` with `--baseline origin/master`: 14 tables, 275 rows, 213 numbered, none deleted.
- Same tool across every tracked `.md`: all pass (`GTA5_STATUS.md`: 67 tables, 278 rows).
- `git diff --check` clean; `git diff --name-only origin/master...HEAD | grep -v '\.md$'` empty.

Refs #2481, #2542, #2858