### PR TITLE
compat: onboard Yakuza Kiwami (PPSA31334) — first of ten new dumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 39 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 40 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -64,20 +64,28 @@ Last updated: 2026-08-17
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Chapter 1 gameplay; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Opening dive gameplay aboard the science ship | [#1898](https://github.com/mattias800/prosper/issues/1898) |
+| *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2864](https://github.com/mattias800/prosper/issues/2864) |
 
 ## At a glance
 
 Derived from the table above by reading each row's **milestone text** against the six-rung bring-up
 ladder in `CLAUDE.md`. It is *not* derived from the ✅/🚧/🔬 markers, which are not a rung scale:
-ten of the twenty-four titles that reach gameplay are marked 🚧 rather than ✅, and the two 🔬 rows sit
-at two different rungs. Counting markers gives a different — and wrong — answer.
+ten of the twenty-four titles that reach gameplay are marked 🚧 rather than ✅, and the 🔬 rows sit at
+three different states — two at different rungs, and one not yet run at all. Counting markers gives a
+different — and wrong — answer.
+
+**"Not yet booted" is a real category, not a rung.** A dump can be present and never measured, and
+that is different from having been measured and found wanting. It is counted separately so an
+unmeasured title is never mistaken for a failing one — nine more dumps are arriving, and they will
+land here first.
 
 | Where the title stops | Titles |
 | --- | --- |
 | **Gameplay reached**, with the scene rendering (rung 3 or better) | 24 |
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
-| Total tracked | 39 |
+| **Not yet booted** — dump present, never run | 1 |
+| Total tracked | 40 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -154,6 +154,7 @@ of its manifest.
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Sonic Origins | `PPSA05325` | 1 | `1-----` | - | - | none | [#2267](https://github.com/mattias800/prosper/issues/2267), [#2731](https://github.com/mattias800/prosper/issues/2731), [#1905](https://github.com/mattias800/prosper/issues/1905), [#1720](https://github.com/mattias800/prosper/issues/1720) | [#1871](https://github.com/mattias800/prosper/issues/1871) | [`GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) |
 | ArcRunner | `PPSA21406` | 0 | `------` | - | - | none | [#1226](https://github.com/mattias800/prosper/issues/1226), [#2084](https://github.com/mattias800/prosper/issues/2084) | [#1817](https://github.com/mattias800/prosper/issues/1817) | [`ARCRUNNER_STATUS.md`](prosper/docs/ARCRUNNER_STATUS.md) |
+| Yakuza Kiwami | `PPSA31334` | 0 | `------` | none | - | none | - | [#2864](https://github.com/mattias800/prosper/issues/2864) | - |
 
 ## Counts
 
@@ -164,8 +165,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 1 |
+| 0 -- not started | 2 |
 
-**4 of 39** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 40** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.


### PR DESCRIPTION
First of ten new dumps. Onboards **Yakuza Kiwami (`PPSA31334`)** — tracker **#2864**, row in
`COMPATIBILITY.md`, regenerated `PROGRESS_TRACKER.md`, and the tracked-title count moves 39 → 40.

**Nothing has been run against this title.** Every fact recorded is derived from the dump's own
bytes; none of it is a claim about how prosper behaves, because prosper has not been pointed at it.

## Engine derived, not assumed

| marker | count in `eboot.bin` |
|---|---|
| `Yakuza` | 172 |
| `CRIWARE` | 38 |
| `Dragon Engine` | **0** |
| `Unreal` / `Unity` / `Havok` / `RGG` | **0** |

Plus 12 `.par` archives in `data/` — `chara.par`, `hact.par`, `bootpar`, `battlepar`, `2dpar` —
with `db.nex` and `drama_scanner`. That layout is the diagnostic evidence for the Ryu Ga Gotoku
PAR-archive engine; the string counts corroborate it.

**"Dragon Engine" being absent is the expected answer**, recorded explicitly so nobody infers it
from the series name: Kiwami is the 2016 remake on the older engine, and Dragon Engine postdates it.

**CRIWARE is the interesting one for this project** — it is the middleware family behind the
AvPlayer/Videodec2 work, so this title's movies will likely exercise paths with history here
(#2731, #2270, #1955).

### How the first version of that table was wrong

Worth recording because it produced a confident false answer. The census initially used:

```bash
c=$(grep -c "$m" eboot.bin || echo 0)
```

`grep -c` **exits 1 on zero matches**, so `|| echo 0` appended a second `0`, the variable became
`"0\n0"`, and `[ "$c" != "0" ]` was true for **every** pattern — reporting that the eboot mentioned
Unreal *and* Unity *and* Dragon Engine. `strings` finds none of them. Recounted with `;` separation
and cross-checked. This is instrument-trap 40, and it very nearly went into a tracker issue as the
engine attribution.

## A new bucket: "Not yet booted"

```
| Gameplay reached, with the scene rendering (rung 3 or better) | 24 |
| Title screen or menu, or gameplay without a rendered world (rung 2) | 14 |
| Below a title screen — logo or splash only (rung 1) | 1 |
| Not yet booted — dump present, never run | 1 |     <- new
| Total tracked | 40 |
```

A dump that is present and never measured is **not** the same as one measured and found wanting,
and counting them together makes the second look worse than it is. Nine more dumps are arriving and
they all land here first, so the distinction is about to matter repeatedly.

## Flagged, explicitly untested

`requiredSystemSoftwareVersion` is `0x1240…` — **SDK 12.4, below 13**. prosper's post-submit
completion-visibility contract is armed only for SDK >= 13 (#2219), and titles requesting below it
have shown submit races (#1226, #2084). Whether this title is affected is **unknown**; it is on the
tracker as a thing to check early, not as a diagnosis.

## Verification

```
gen_progress_tracker.py --check   -> exit 0   (40 trackers, 40 parsed — parsed first try)
check_numbered_table.py over .md  -> exit 0
git diff --check                  -> clean
git diff --name-only ... | grep -v '\.md$'  -> empty
```

Docs-only; merging under the documented exception. Refs #2864.
