### PR TITLE
compat: onboard Sniper Ghost Warrior Contracts 2 (PPSA03130) — the project's first CryEngine title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 40 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 41 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -65,6 +65,7 @@ Last updated: 2026-08-17
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Chapter 1 gameplay; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Opening dive gameplay aboard the science ship | [#1898](https://github.com/mattias800/prosper/issues/1898) |
 | *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2864](https://github.com/mattias800/prosper/issues/2864) |
+| *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2867](https://github.com/mattias800/prosper/issues/2867) |
 
 ## At a glance
 
@@ -84,8 +85,8 @@ land here first.
 | **Gameplay reached**, with the scene rendering (rung 3 or better) | 24 |
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
-| **Not yet booted** — dump present, never run | 1 |
-| Total tracked | 40 |
+| **Not yet booted** — dump present, never run | 2 |
+| Total tracked | 41 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -154,6 +154,7 @@ of its manifest.
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Sonic Origins | `PPSA05325` | 1 | `1-----` | - | - | none | [#2267](https://github.com/mattias800/prosper/issues/2267), [#2731](https://github.com/mattias800/prosper/issues/2731), [#1905](https://github.com/mattias800/prosper/issues/1905), [#1720](https://github.com/mattias800/prosper/issues/1720) | [#1871](https://github.com/mattias800/prosper/issues/1871) | [`GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) |
 | ArcRunner | `PPSA21406` | 0 | `------` | - | - | none | [#1226](https://github.com/mattias800/prosper/issues/1226), [#2084](https://github.com/mattias800/prosper/issues/2084) | [#1817](https://github.com/mattias800/prosper/issues/1817) | [`ARCRUNNER_STATUS.md`](prosper/docs/ARCRUNNER_STATUS.md) |
+| Sniper Ghost Warrior Contracts 2 | `PPSA03130` | 0 | `------` | none | - | none | - | [#2867](https://github.com/mattias800/prosper/issues/2867) | - |
 | Yakuza Kiwami | `PPSA31334` | 0 | `------` | none | - | none | - | [#2864](https://github.com/mattias800/prosper/issues/2864) | - |
 
 ## Counts
@@ -165,8 +166,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 2 |
+| 0 -- not started | 3 |
 
-**4 of 40** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 41** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.


### PR DESCRIPTION
Second of ten new dumps. Onboards **Sniper Ghost Warrior Contracts 2 (`PPSA03130`)** — tracker
**#2867**, `COMPATIBILITY.md` row, regenerated `PROGRESS_TRACKER.md`, count 40 → 41.

Not booted. Everything recorded is derived from the dump's bytes.

## CryEngine — and it is the project's first

Proven, not inferred from the publisher. The eboot carries the engine's own build paths:

```
c:\SGWC2\BinTemp\uber_files\CryAction/..\..\..\Code\CryEngine\CryAction\VehicleSystem\...
c:\SGWC2\BinTemp\uber_files\CrySystem/..\..\..\Code\CryEngine\CrySystem\PlatformOS\...
```

`SGWC2` is this title. Corroborated by `engine/` and `gamesdk/` at the dump root — the standard
CryEngine layout — and 15 `CryEngine` / 3 `CryTek` strings. Audio middleware is **Wwise**.

Every other tracked title is Unity-family (19), Unreal-family (10), RAGE, Ryu Ga Gotoku or bespoke.
**CryEngine is a new bring-up surface**, so first-time gaps are more likely here than on a title
whose engine a sibling has already worn in.

## Two false positives, recorded so they are not re-found

A case-insensitive census reports `Unity` ×2 and `FMOD` ×2. Read, they are:

| hit | actual string |
|---|---|
| `Unity` | `OnLocalPlayerImmunityOn` / `...Off` — *imm-**unity*** |
| `FMOD` | `fFmodCharacterTypeParam`, `FMode:%d` |

**This title uses neither Unity nor FMOD.** A substring census needs its hits read, not counted —
the same lesson as the `grep -c || echo 0` trap on the previous onboarding, arriving by a different
route.

## 21 declared entitlements — the local-inventory case at scale

`dlc1`..`dlc22`, **172 KB total** — declarations, not content. Each is a ~77-byte manifest:

```xml
<dlc minversion="1.0.0.33416" name="dlcSkullBones" id="25"><crcs/></dlc>
```

Cosmetic packs and skins: `dlcAbstractAssassin`, `dlcAngloPack`, `dlcHunter`, `dlcPreorder1`,
`dlcSkullBones`, `dlcXrayted` and sixteen more.

This is the charter's local-inventory case at more scale than any tracked title, and the tracker
flags **both** failure directions: never answer "owned" unconditionally (that would make prosper
perform the circumvention itself), and equally never under-report what **is** present — which fails
in the direction that looks safe, and makes the title explain our defect in its own words.

## Verification

```
gen_progress_tracker.py --check   -> exit 0   (41 trackers, 41 parsed)
check_numbered_table.py over .md  -> exit 0
git diff --check                  -> clean
git diff --name-only ... | grep -v '\.md$'  -> empty
```

Docs-only; merging under the documented exception. Refs #2867.
