### PR TITLE
hle(ampr): implement the libSceAmpr AMM memory manager — Yakuza Kiwami's 0.0 s death was an out-parameter nobody wrote

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -35,6 +35,42 @@ this is the real scene, not a cutscene. Tracker [#1898](...).
 
 ## 2026-08-21
 
+### Yakuza Kiwami allocates its entire game heap through a Sony API nobody had implemented
+
+No picture with this one — the title still does not render. The finding is what moved.
+
+*Yakuza Kiwami* (`PPSA31334`) died **0.0 seconds** into every boot, writing to address `0x1d0000`.
+That address is the tell: it is far too low to be a real guest pointer, and it is what you get when
+an allocator is handed a base address of roughly nothing and starts walking.
+
+The base came from `sceAmprAmmGetVirtualAddressRanges`. AMM is the memory-mapping half of
+libSceAmpr — the same command-buffer construct prosper already used for asynchronous **file reads**,
+pointed at pages instead of bytes — and this title runs its *whole* game heap through it: it asks
+AMM for up to 512 GiB of address space, hands it 10 GiB of physical memory, and then maps 2 MiB
+chunks in on demand for the rest of the run. All seven of the AMM entry points it needs fell to
+prosper's unimplemented default, which returns 0 and writes nothing.
+
+Returning 0 sounds harmless. It is not, when the guest is reading your *out-parameters*: the
+initialiser reaches that call on a path that never zeroes its own struct, so "wrote nothing" meant
+the allocator took its virtual-address window from whatever was left on the stack. Everything after
+that was the allocator faithfully doing what it was told.
+
+With AMM implemented the boot now reserves a real 68 GiB window, takes its 10 GiB pool, and services
+23 map commands before it gets somewhere new — far enough to initialise save data and start loading
+assets, where it stops with the game's own message:
+
+```
+Failed!! Load Devil2 Shader Archive
+Failed!! Load Ptc Shader Archive
+```
+
+That is the next wall, and it is a different one: `sceAmprAprCommandBufferReadFileGatherScatter`
+([#2872](https://github.com/mattias800/prosper/issues/2872)), the scatter/gather sibling of a file
+read prosper already implements. The archives never arrive, so the object is null, so the next
+method call dereferences it. Still rung 0 — but the fault moved from the memory allocator to the
+asset loader, which is the direction that counts. Tracker
+[#2864](https://github.com/mattias800/prosper/issues/2864).
+
 ### Our first CryEngine title deadlocks 81 ms in, on a library it never asked for
 
 No picture this time — the interesting thing about *Sniper Ghost Warrior Contracts 2* (`PPSA03130`)

--- a/BLOG.md
+++ b/BLOG.md
@@ -71,6 +71,11 @@ method call dereferences it. Still rung 0 — but the fault moved from the memor
 asset loader, which is the direction that counts. Tracker
 [#2864](https://github.com/mattias800/prosper/issues/2864).
 
+One footnote worth having: this turned out not to be a one-title fix. *Judgment* (`PPSA02739`),
+onboarded the same day, imports **all seven** of the same AMM entry points — and both of the follow-up
+gaps too, the scatter/gather read and AMM's `Unmap`. Checked by NID against its own import table,
+not inferred from the shared publisher.
+
 ### Our first CryEngine title deadlocks 81 ms in, on a library it never asked for
 
 No picture this time — the interesting thing about *Sniper Ghost Warrior Contracts 2* (`PPSA03130`)

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -64,7 +64,7 @@ Last updated: 2026-08-17
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Chapter 1 gameplay; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Opening dive gameplay aboard the science ship | [#1898](https://github.com/mattias800/prosper/issues/1898) |
-| *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2864](https://github.com/mattias800/prosper/issues/2864) |
+| *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Rung 0 — boots, allocates its whole game heap through libSceAmpr AMM, and dies loading its shader archives ([#2872](https://github.com/mattias800/prosper/issues/2872)); no frames yet | [#2864](https://github.com/mattias800/prosper/issues/2864) |
 | *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Rung 0 — boots in 91 ms and drives a 4K present loop at ~21 flips/s, but every frame is black: no pass produces a present source ([#2871](https://github.com/mattias800/prosper/issues/2871)). The boot deadlock in a preloaded PRX the title never imports is fixed | [#2867](https://github.com/mattias800/prosper/issues/2867) |
 | *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — nothing run against it yet | [#2876](https://github.com/mattias800/prosper/issues/2876) |
 | *Judgment* | `PPSA02739` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2880](https://github.com/mattias800/prosper/issues/2880) |

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1280,6 +1280,9 @@ if(TARGET prosper_core)
   add_executable(test_ampr_tracks_offset tests/hle/memory/test_ampr_tracks_offset.cpp)
   target_link_libraries(test_ampr_tracks_offset PRIVATE prosper_core)
   add_test(NAME ampr_tracks_offset COMMAND test_ampr_tracks_offset)
+  add_executable(test_ampr_amm tests/hle/memory/test_ampr_amm.cpp)
+  target_link_libraries(test_ampr_amm PRIVATE prosper_core)
+  add_test(NAME ampr_amm COMMAND test_ampr_amm)
 
   # GTA V (#1139/#1142) net-new HLE regression guards: sceKernelAprGetFileStat fills the real stat
   # (#1133) and sceAudioOut2GetSpeakerArrayMemorySize returns a non-zero allocation size (#1134). The

--- a/prosper/src/hle/memory/AGENTS.md
+++ b/prosper/src/hle/memory/AGENTS.md
@@ -41,3 +41,14 @@ subsystem. New mapping code goes through those two functions.
 **A "reservation" is a real, tracked object.** `track(..., committed=false, ...)` plus a `PROT_NONE`
 mapping is what makes a range later commitable in place; a bare `mmap(PROT_NONE)` that nobody
 tracked is indistinguishable from somebody else's memory.
+
+**And a tracked reservation is NOT inert — on Linux it is a lazy-commit target.** The SIGSEGV
+handler treats a fault above `0x1000000000` inside one as "the guest touched a page it believes it
+committed" and backs it with a 64 KiB anonymous read/write page. Several titles' allocator bring-up
+depends on that, so it stays the default — but it means a range you reserved to hold a *particular*
+kind of memory will be silently filled with a different kind the moment anything touches an unmapped
+part of it, and the guest cannot tell. Register such a range as declining lazy commit
+(`g_no_lazy_commit_*`, which makes `prosper_reserved_range_state` answer **3** instead of 1) so the
+touch faults where it happened. This is the thing a newcomer gets wrong here, and it was found in
+review rather than by testing, because every symptom of getting it wrong looks like a bug somewhere
+else.

--- a/prosper/src/hle/memory/AGENTS.md
+++ b/prosper/src/hle/memory/AGENTS.md
@@ -48,7 +48,9 @@ committed" and backs it with a 64 KiB anonymous read/write page. Several titles'
 depends on that, so it stays the default — but it means a range you reserved to hold a *particular*
 kind of memory will be silently filled with a different kind the moment anything touches an unmapped
 part of it, and the guest cannot tell. Register such a range as declining lazy commit
-(`g_no_lazy_commit_*`, which makes `prosper_reserved_range_state` answer **3** instead of 1) so the
-touch faults where it happened. This is the thing a newcomer gets wrong here, and it was found in
+(`g_amm_no_lazy_commit_base`, which makes `prosper_reserved_range_state` answer **4** instead of 1)
+so the touch faults where it happened. That function's return values are one contract shared by both
+platform arms and they are **not** dense — 3 refines "committed" and belongs to the Windows arm,
+4 refines "reserved" — so read its table before adding a value. This is the thing a newcomer gets wrong here, and it was found in
 review rather than by testing, because every symptom of getting it wrong looks like a bug somewhere
 else.

--- a/prosper/src/hle/memory/AGENTS.md
+++ b/prosper/src/hle/memory/AGENTS.md
@@ -1,0 +1,43 @@
+# `src/hle/memory` — the guest's address space
+
+Everything the guest can do to its own memory through libkernel, plus the libSceAmpr command-buffer
+constructs that also move memory around. If a Sony entry point answers "where does this live, how
+big is it, and who may touch it", it belongs here.
+
+The PS5 memory model this reimplements has three layers and they are not interchangeable:
+**reserve** a virtual range (address space, no pages), **allocate** direct memory (physical pages as
+an opaque pool offset), then **map** one into the other — or map *flexible* memory, which has no
+physical identity at all. `sceKernelVirtualQuery`, `sceKernelDirectMemoryQuery` and the fault
+handler's lazy-commit probe all answer from the tracking tables this folder owns, so a mapping that
+happens without being tracked is a mapping the rest of prosper cannot see.
+
+## The boundary against its siblings
+
+* `host/memory/` is the *host* side — the write-watch, the readable-mapping interval set, the
+  page-protection generation counter. This folder calls into it to publish what it just did; it
+  never reimplements it.
+* `hle/fs/` owns the APR **file read** half of libSceAmpr. This folder owns the command-buffer
+  object itself (construct / set-buffer / reset / cursor) and the **AMM** memory-mapping half. The
+  two share `AmprCbState` and the completion bookkeeping, which is why both live above the
+  platform split in `hle_kernel_mem.cpp` rather than in either arm.
+* `hle/kernel/` owns the event queues an APR completion is posted to.
+
+## What a newcomer gets wrong here
+
+**`hle_kernel_mem.cpp` contains two complete implementations of almost everything** — a POSIX arm
+and a Windows arm, thousands of lines apart, separated by one
+`#if defined(__linux__) || defined(__APPLE__)` near the top. Nothing local tells you which arm you
+are reading, and reading one as though it were the whole file is a mistake this project has made
+three times in a single session (#2376, #2384). Grep for a symbol and expect **two** definitions;
+when you change a guest-visible answer, change both, because a capacity or a base address is a fact
+about the guest's object rather than about the host prosper happens to run on (#1970, #2139).
+
+**Never place a mapping without proving the target is free.** `map_at` and `map_phys_at` refuse a
+`MAP_FIXED` over anything except prosper's own *uncommitted reservation* — that discipline is the
+only thing standing between a wrong guest address and a silent overwrite of live heap, and both
+issues that established it (#88, #107) presented as unrelated crashes hours later in another
+subsystem. New mapping code goes through those two functions.
+
+**A "reservation" is a real, tracked object.** `track(..., committed=false, ...)` plus a `PROT_NONE`
+mapping is what makes a range later commitable in place; a bare `mmap(PROT_NONE)` that nobody
+tracked is indistinguishable from somebody else's memory.

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -52,7 +52,15 @@ uint64_t guest_memory_gpu_write_successes_for_test() {
 // Keep the fixed capacity and appended-byte cursor together so constructor and reset operations
 // cannot leave half-stale state when guest addresses are recycled.
 namespace {
-struct AmprCbState { uint64_t capacity = 0, offset = 0; bool tracks_offset = false; };
+struct AmprCbState {
+    uint64_t capacity = 0, offset = 0;
+    // The storage sceAmprCommandBufferSetBuffer attached to this command buffer, recorded by both
+    // platform arms so sceAmprCommandBufferGetBufferBaseAddress can answer it. The AMM flow is what
+    // needs it: the SDK's inline Submit wrapper reads the base and the byte cursor off the object
+    // and hands the kernel that raw span, so a zero base is a null command stream.
+    uint64_t buffer_base = 0, buffer_size = 0;
+    bool tracks_offset = false;
+};
 std::mutex g_ampr_cb_state_mx;
 std::unordered_map<uint64_t, AmprCbState> g_ampr_cb_state;
 
@@ -168,6 +176,27 @@ uint64_t ampr_cb_offset(uint64_t cb) {
     std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
     auto it = g_ampr_cb_state.find(cb);
     return it == g_ampr_cb_state.end() ? 0 : it->second.offset;
+}
+
+// sceAmprCommandBufferSetBuffer(cb, base, size) attaches storage to a command buffer. Record it
+// for BOTH platform arms, and independently of what either arm does with the memory: the record is
+// a fact about the guest's object, not about the host mapping. It is deliberately NOT cleared by
+// ampr_cb_construct, for the same reason `capacity` is not -- several SDK flows refresh a live
+// object through a constructor-shaped call.
+void ampr_cb_set_buffer(uint64_t cb, uint64_t base, uint64_t size) {
+    if (!cb) return;
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    if (g_ampr_cb_state.size() >= 4096 && !g_ampr_cb_state.count(cb))
+        g_ampr_cb_state.erase(g_ampr_cb_state.begin());
+    auto& state = g_ampr_cb_state[cb];
+    state.buffer_base = base;
+    state.buffer_size = size;
+}
+
+uint64_t ampr_cb_buffer_base(uint64_t cb) {
+    std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    auto it = g_ampr_cb_state.find(cb);
+    return it == g_ampr_cb_state.end() ? 0 : it->second.buffer_base;
 }
 }
 
@@ -2184,6 +2213,11 @@ HLE(k_ampr_push_map) {
     MLOG("ampr SetBuffer args a0=0x%llx a1=0x%llx a2=0x%llx a3=0x%llx a4=0x%llx a5=0x%llx\n",
          (unsigned long long)a0, (unsigned long long)a1, (unsigned long long)a2,
          (unsigned long long)a3, (unsigned long long)a4, (unsigned long long)a5);
+    // Record the attachment for sceAmprCommandBufferGetBufferBaseAddress FIRST and unconditionally.
+    // Which flavor this call is (below) decides what happens to the MEMORY; it does not change the
+    // fact that this buffer is now the command buffer's storage, and the AMM submit path reads that
+    // back through the accessor whichever flavor ran.
+    ampr_cb_set_buffer(a0, a1, a2);
     if (a1 && a2) {
         // Back the page from the shared phys pool so BOTH pool views alias the same bytes: the
         // guest WRITES its MallocBinned pool-page headers through this (high) view and READS them
@@ -2268,6 +2302,322 @@ HLE(k_ampr_push_map) {
         }
     }
     return 0;
+}
+
+// --- libSceAmpr AMM (asynchronous memory manager) ----------------------------------------------
+//
+// AMM is the memory-mapping sibling of the APR file reader above (and in hle_file.cpp): the guest
+// records commands into an Ampr command buffer, submits it, and waits for completion — except that
+// the commands MAP and UNMAP pages of a large, sparsely populated virtual heap instead of reading
+// files. Yakuza Kiwami (PPSA31334) runs its entire game heap through it, which is why a boot with
+// these NIDs unimplemented dies at 0.0 s writing to a low address: every one of them fell to the
+// dispatcher's return-0 default, so the guest's AMM virtual-address window stayed whatever its
+// stack happened to hold and its allocator walked into it (#2864).
+//
+// EVIDENCE. Argument order comes from the SDK's own inline wrappers, which are in the eboot at
+// 0xcc4bb0..0xcc4ca0 and are what turn a register dump into a signature; the semantics come from
+// the guest's AMM initialiser at eboot+0xdbf390 and its heap-grow path at eboot+0xdbbdc6. Names
+// and NIDs are the PS5 3.20 firmware database's (`stub_nid_map.py --names ../PS5-3.20_Libs`
+// resolves all seven). The firmware database gives names only — every argument layout below is
+// re-derived from this title's own code.
+//
+//   sceAmprAmmGetVirtualAddressRanges(u64* r0, u64* r1, u64* r2, u64* r3)
+//       Reports the virtual-address window AMM maps into. The SDK wrapper at 0xcc4c10 takes one
+//       struct pointer and passes &s[0]..&s[3], so all four are out-parameters. The guest uses
+//       r1 - r0 as the span, keeps min(requested, span - 4 GiB) of it, and thereafter classifies
+//       a pointer as AMM memory with (p - r0) < that size (eboot+0xda0f61, +0xda2ac0). It
+//       requests 0x8000000000 (512 GiB), so the window is address space, not memory.
+//   sceAmprAmmGiveDirectMemory(searchStart, searchEnd, len, alignment, memoryType, off_t* out)
+//       Hands AMM a physical pool — the kernel allocator's own six-argument order, and the live
+//       call says so: (0, 0x400000000 = sceKernelGetDirectMemorySize(), 0x280000000 = 10 GiB,
+//       0x200000, 1, &state+0xec98). A negative return aborts the guest's whole AMM init.
+//       Reading a3/a4 the other way round produced a "memory type" of 2,097,152 and a 16 KiB
+//       alignment where the guest asked for 2 MiB — visible in the [amm] pool line, which is why
+//       that line prints both.
+//   sceAmprAmmCommandBufferMap(cb, va, size, memoryType, protection)
+//       Live: (cb, <a VA inside the window>, 0x10000..0x240000, 0xb, 0xc3 or 0xf3). Here a3 really
+//       IS the memory type — it is constant at 0xb across every call, the variable form computes
+//       it as 0xb + (x & 7) (eboot+0xd9f7cc), and 0xf3 - 0xc3 = 0x30 is the GPU read/write pair,
+//       so a4 is as clearly a protection as a3 is not an alignment.
+//   sceAmprAmmSubmitCommandBuffer2(bufferBase, usedBytes, flags, u32* out, u32* outCompletionId)
+//       The wrapper at 0xcc4c40 turns Submit(cb, flags, p1, p2) into this by calling
+//       GetBufferBaseAddress(cb) and GetCurrentOffset(cb) first — which is why
+//       sceAmprCommandBufferGetBufferBaseAddress had to be implemented too. All nine call sites
+//       pass p1 = &state+0xed34 and p2 = &state+0xed30 and then wait on *(u32*)(state+0xed30), so
+//       the COMPLETION ID is the last argument and both slots are 32 bits wide (they are adjacent
+//       dwords — a 64-bit store through either clobbers the other).
+//   sceAmprAmmWaitCommandBufferCompletion(completionId)
+//
+// prosper performs the mapping at RECORD time, exactly as the APR reader performs its reads at
+// append time, so submit == complete and the wait is already satisfied when it is made.
+//
+// THE INVARIANT THAT KEEPS THIS FROM CORRUPTING THE GUEST. A map is refused unless it lands inside
+// the window prosper itself reserved for AMM. That window is a PROT_NONE reservation prosper tracks
+// as UNCOMMITTED, so map_phys_at's no-clobber discipline (#137, and the clobbers it exists to stop
+// — #88, #107) independently refuses to place a mapping anywhere else. Two guards, either of which
+// alone turns a wrong VA into a loud refusal instead of a MAP_FIXED over live guest memory.
+// CONFIDENCE: HIGH on the argument layouts (SDK wrappers + nine consistent call sites), MED on the
+// window's size and placement (prosper chooses those; the guest only requires the span), LOW on
+// the meaning of the three out-parameters this title never reads — see each below.
+namespace {
+    // 4 GiB the guest deducts from the span before using it, plus 64 GiB it can actually use. The
+    // residency cap is the guest's own: it counts mapped bytes against the direct memory it gave
+    // AMM (11.5 GiB) and stops growing, so a roomy window costs address space and nothing else.
+    constexpr uint64_t kAmmWindowSize   = 0x1100000000ull;    // 68 GiB
+    // Search from 1 TiB rather than from kGuestAutoMapBase: the window is a single 68 GiB span and
+    // placing it at the bottom of the auto-map region would push every ordinary guest mapping above
+    // it. It stays inside [kGuestAutoMapBase, kGuestAutoMapLimit) either way.
+    constexpr uint64_t kAmmWindowSearch = 0x10000000000ull;   // 1 TiB
+    constexpr uint64_t kAmmWindowAlign  = 0x200000ull;        // the alignment the guest asks for
+
+    struct AmmState {
+        std::mutex mx;
+        uint64_t va_base = 0, va_size = 0;                   // the reported window
+        uint64_t pool_base = 0, pool_end = 0, pool_cursor = 0; // physical pool from GiveDirectMemory
+        std::atomic<uint32_t> next_completion{1};
+        int refusals = 0;
+    };
+    // Never destroyed: guest threads can still be inside an AMM call during process teardown.
+    AmmState& amm() { static AmmState* state = new AmmState; return *state; }
+
+    // Reserve the window on first use and publish it. PROT_NONE + a tracked UNCOMMITTED record is
+    // the same shape sceKernelReserveVirtualRange produces, which is exactly what makes
+    // map_phys_at willing to commit inside it and unwilling to commit outside it.
+    bool amm_window_ensure(uint64_t& base_out, uint64_t& size_out) {
+        AmmState& state = amm();
+        std::lock_guard<std::mutex> lk(state.mx);
+        if (!state.va_base) {
+            void* p = map_guest_from(kAmmWindowSearch, kAmmWindowSize, PROT_NONE, kAmmWindowAlign);
+            if (!p) {
+                fprintf(stderr, "[amm] could NOT reserve the 0x%llx-byte AMM virtual-address "
+                                "window -- the guest's AMM heap stays unavailable\n",
+                        (unsigned long long)kAmmWindowSize);
+                return false;
+            }
+            state.va_base = (uint64_t)p;
+            state.va_size = kAmmWindowSize;
+            track(state.va_base, state.va_size, 0, 0, false, "ampr-amm-window");
+            fprintf(stderr, "[amm] virtual-address window [0x%llx,0x%llx) reserved\n",
+                    (unsigned long long)state.va_base,
+                    (unsigned long long)(state.va_base + state.va_size));
+        }
+        base_out = state.va_base;
+        size_out = state.va_size;
+        return true;
+    }
+
+    bool amm_window_contains(uint64_t va, uint64_t len) {
+        AmmState& state = amm();
+        std::lock_guard<std::mutex> lk(state.mx);
+        if (!state.va_base || !len) return false;
+        return va >= state.va_base && len <= state.va_size &&
+               va - state.va_base <= state.va_size - len;
+    }
+
+    // Publish the physical pool AMM was given. A second, NON-CONTIGUOUS pool is refused rather
+    // than allowed to replace the first: replacing it would rewind the cursor across physical
+    // pages already mapped into the guest's heap and hand them out a second time — the silent
+    // double-allocation this whole change is written to avoid. Contiguous growth cannot alias, so
+    // it is accepted. No title is known to give twice; if one does, the caller says so loudly and
+    // the fix is a range list rather than one span.
+    bool amm_pool_publish(uint64_t phys, uint64_t len) {
+        AmmState& state = amm();
+        std::lock_guard<std::mutex> lk(state.mx);
+        if (!state.pool_end) {
+            state.pool_base = phys;
+            state.pool_end = phys + len;
+            state.pool_cursor = phys;
+            return true;
+        }
+        if (phys == state.pool_end) { state.pool_end = phys + len; return true; }
+        return false;
+    }
+
+    // Carve the next `len` bytes of the pool the guest gave AMM. A bump cursor, not a free list:
+    // nothing returns pages to it yet because sceAmprAmmCommandBufferUnmap is still unimplemented
+    // (deliberately out of scope here — see the note at the registration site, and #2873), so a
+    // free list would have no callers and would only look like one.
+    bool amm_pool_take(uint64_t len, uint64_t& phys_out) {
+        AmmState& state = amm();
+        std::lock_guard<std::mutex> lk(state.mx);
+        if (!state.pool_end || !len) return false;
+        const uint64_t base = align_up(state.pool_cursor, kGuestPageSize);
+        if (base < state.pool_cursor || len > state.pool_end - base) return false;
+        state.pool_cursor = base + len;
+        phys_out = base;
+        return true;
+    }
+
+    // Give back the most recent carve when the map that asked for it could not be placed. Only
+    // valid while the cursor still sits at its end — anything else means another thread has
+    // already carved past it, and rewinding then would alias.
+    void amm_pool_untake(uint64_t phys, uint64_t len) {
+        AmmState& state = amm();
+        std::lock_guard<std::mutex> lk(state.mx);
+        if (state.pool_cursor == phys + len) state.pool_cursor = phys;
+    }
+
+    // Bounded so a guest that asks for something impossible in a loop cannot flood the log, but
+    // never silent for the first few: a refused map is a page the guest believes it owns, and the
+    // fault it produces later is meaningless without this line. `what` carries its own verb.
+    void amm_say(const char* what, uint64_t a, uint64_t b, uint64_t c) {
+        AmmState& state = amm();
+        int n;
+        { std::lock_guard<std::mutex> lk(state.mx); n = state.refusals++; }
+        if (n < 16)
+            fprintf(stderr, "[amm] %s (0x%llx, 0x%llx, 0x%llx)\n", what,
+                    (unsigned long long)a, (unsigned long long)b, (unsigned long long)c);
+        else if (n == 16)
+            fprintf(stderr, "[amm] further AMM complaints suppressed\n");
+    }
+}
+
+// sceAmprAmmGetVirtualAddressRanges(u64* r0, u64* r1, u64* r2, u64* r3).
+// r0/r1 are the window's [start, end). r2/r3 are out-parameters whose meaning this title never
+// reveals — it passes their addresses and never reads them back (verified over the whole eboot:
+// the two stack slots have no reader after the call). They are written as ZERO rather than left
+// alone, because the guest's own initialiser reaches this call on a path that does NOT pre-zero
+// its struct, so "leave it" means "hand back stack residue" — the exact failure this whole change
+// exists to remove. Zero is the absent/empty answer in every reading of a "ranges" out-parameter.
+// CONFIDENCE: LOW on r2/r3 specifically; HIGH that writing something defined beats writing nothing.
+HLE(k_amm_get_va_ranges) {
+    ampr_arglog("wkQR9+xTFKY(AmmGetVirtualAddressRanges)", a0, a1, a2, a3, a4, a5);
+    uint64_t base = 0, size = 0;
+    if (!amm_window_ensure(base, size)) return 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
+    if (a0 > 0xffff) *(uint64_t*)a0 = base;
+    if (a1 > 0xffff) *(uint64_t*)a1 = base + size;
+    if (a2 > 0xffff) *(uint64_t*)a2 = 0;
+    if (a3 > 0xffff) *(uint64_t*)a3 = 0;
+    return 0;
+}
+
+// sceAmprAmmGiveDirectMemory(searchStart, searchEnd, len, memoryType, alignment, off_t* physOut).
+// Claims `len` bytes of the direct-memory pool for AMM and remembers the range; every later map
+// carves its pages out of it, so the guest's own residency budget is enforced by physics rather
+// than by trust. Failure is reported as ENOMEM, which the guest handles by abandoning AMM init —
+// the fail-visible direction, since the alternative is an allocator with no memory behind it.
+HLE(k_amm_give_dmem) {
+    ampr_arglog("Q07J7XpvhrU(AmmGiveDirectMemory)", a0, a1, a2, a3, a4, a5);
+    // a3 is the ALIGNMENT and a4 the MEMORY TYPE — the same order sceKernelAllocateDirectMemory
+    // uses, established from the live call (a3 = 0x200000, a4 = 1) and not from the name. Both are
+    // still sanitised rather than trusted, because the 3.20 database gives this entry point's name
+    // and not its signature: an alignment is honoured only when it is a power-of-two multiple of
+    // the 16 KiB direct-memory granule, a type only when the pool can carry it. Those two
+    // predicates are also what makes the swapped reading fail loudly instead of quietly — 1 is not
+    // a legal alignment and 0x200000 is a preposterous type, and the [amm] line below prints both
+    // so a future title passing a different shape is visible rather than inferred.
+    const uint64_t align = (a3 >= kGuestPageSize && (a3 & (a3 - 1)) == 0 &&
+                            (a3 & (kGuestPageSize - 1)) == 0) ? a3 : kGuestPageSize;
+    const int type = a4 <= (uint64_t)kMaxDirectMemoryType ? (int)a4 : 0;
+    if (!a2 || (a2 & (kGuestPageSize - 1)) != 0) {
+        amm_say("REFUSED give-direct-memory: length is not a 16 KiB multiple", a2, align, a4);
+        return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    }
+    uint64_t phys = 0;
+    if (!dmem_take(a2, align, type, phys, a0, a1 ? a1 : ~0ull)) {
+        amm_say("REFUSED give-direct-memory: the direct-memory pool cannot satisfy it", a2, align, a1);
+        return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
+    }
+    if (!amm_pool_publish(phys, a2)) {
+        amm_say("REFUSED give-direct-memory: AMM already holds a pool and this one is not "
+                "contiguous with it -- prosper tracks a single span", phys, a2, 0);
+        dmem_release(phys, a2);
+        return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
+    }
+    if (a5 > 0xffff) *(uint64_t*)a5 = phys;
+    fprintf(stderr, "[amm] direct-memory pool [0x%llx,0x%llx) (%llu MiB, type %d, align 0x%llx)\n",
+            (unsigned long long)phys, (unsigned long long)(phys + a2),
+            (unsigned long long)(a2 >> 20), type, (unsigned long long)align);
+    return 0;
+}
+
+// sceAmprAmmCommandBufferConstructor(cb). One argument: the SDK wrapper at eboot+0xcc4bb0 calls
+// the base sceAmprCommandBufferConstructor first and only rdi survives that call, so every other
+// register at this entry point is the caller's residue and must not be read.
+HLE(k_amm_cb_construct) {
+    ampr_arglog("EDq5bqCqYpA(AmmCommandBufferConstructor)", a0, a1, a2, a3, a4, a5);
+    ampr_cb_reset(a0);
+    return 0;
+}
+
+// sceAmprAmmCommandBufferMap(cb, va, size, memoryType, protection). Performed here rather than at
+// submit, matching how prosper serves APR reads at append time.
+HLE(k_amm_cb_map) {
+    ampr_arglog("JEVYGhDc97M(AmmCommandBufferMap)", a0, a1, a2, a3, a4, a5);
+    const uint64_t va = a1, len = a2;
+    if (!va || !len || (va & (kGuestPageSize - 1)) != 0 || (len & (kGuestPageSize - 1)) != 0) {
+        amm_say("REFUSED map: address or length is not 16 KiB aligned", va, len, a0);
+        return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    }
+    uint64_t window_base = 0, window_size = 0;
+    if (!amm_window_ensure(window_base, window_size) || !amm_window_contains(va, len)) {
+        amm_say("REFUSED map: target is OUTSIDE the AMM window", va, len, window_base);
+        return 0x80020016ull;
+    }
+    uint64_t phys = 0;
+    if (!amm_pool_take(len, phys)) {
+        amm_say("REFUSED map: AMM's own direct-memory pool is exhausted", va, len, 0);
+        return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
+    }
+    int prot = host_prot(a4);
+    if (!prot) {
+        // Every observed AMM map asks for 0xc3, whose low two bits are exactly the CPU read/write
+        // pair host_prot decodes. The variable form (eboot+0xd9f7c5 reads its protection out of a
+        // structure field) could in principle be zero, and host_prot deliberately renders zero as
+        // NO ACCESS. Mapping an allocator's heap page with no access would surface as an
+        // unexplainable SIGSEGV inside guest code instead of as a diagnosable refusal here, so
+        // fall back to read/write — and say so, because a fallback nobody sees is a fallback
+        // nobody fixes. CONFIDENCE: LOW (the zero case has never been observed).
+        amm_say("NOTE map: protection 0 decodes to no access; mapping read/write instead",
+                va, len, a4);
+        prot = PROT_READ | PROT_WRITE;
+    }
+    void* p = map_phys_at(va, len, prot, phys);
+    if (!p) {
+        amm_say("REFUSED map: the host refused the mapping (target is not a free reservation)", va, len, phys);
+        amm_pool_untake(phys, len);
+        return 0x8002000cull;
+    }
+    // The physical range keeps the type it was pooled with; only the VA record carries the type
+    // the guest declares per map. Retyping the pool per 2 MiB map would shatter the direct-memory
+    // allocator's range list into thousands of entries for a distinction no observed caller reads.
+    track((uint64_t)p, len, prot, (uint32_t)a4, true, "ampr-amm-map",
+          kVirtualQueryDirect, phys, (int32_t)(a3 <= (uint64_t)kMaxDirectMemoryType ? a3 : 0));
+    MLOG("amm map va=0x%llx len=0x%llx phys=0x%llx mtype=0x%llx prot=0x%llx\n",
+         (unsigned long long)va, (unsigned long long)len, (unsigned long long)phys,
+         (unsigned long long)a3, (unsigned long long)a4);
+    return 0;
+}
+
+// sceAmprAmmSubmitCommandBuffer2(bufferBase, usedBytes, flags, u32* out, u32* outCompletionId).
+// Every recorded map already ran, so this only hands back a completion id the wait can accept.
+// Both slots are written as 32-bit stores: the guest's two out-parameters are adjacent dwords in
+// one struct, so a 64-bit store through either would overwrite the other.
+// It must never return SCE_KERNEL_ERROR_EAGAIN (0x80020010) — that is the guest's retry sentinel
+// and it spins on it (eboot+0xdbbe90) sleeping a second per attempt.
+HLE(k_amm_submit2) {
+    ampr_arglog("OJf3vCckPAM(AmmSubmitCommandBuffer2)", a0, a1, a2, a3, a4, a5);
+    const uint32_t id = amm().next_completion.fetch_add(1, std::memory_order_relaxed);
+    if (a3 > 0xffff) *(uint32_t*)a3 = 0;
+    if (a4 > 0xffff) *(uint32_t*)a4 = id;
+    return 0;
+}
+
+// sceAmprAmmWaitCommandBufferCompletion(completionId). Submit == complete here, so there is
+// nothing to wait for. Deliberately does NOT validate the id: an id prosper never issued is still
+// an id with no work behind it, and refusing it would only invent a stall.
+HLE(k_amm_wait) {
+    ampr_arglog("HXymib4T8gc(AmmWaitCommandBufferCompletion)", a0, a1, a2, a3, a4, a5);
+    return 0;
+}
+
+// sceAmprCommandBufferGetBufferBaseAddress(cb) — the storage sceAmprCommandBufferSetBuffer
+// attached. Not AMM-specific (it is the generic command-buffer accessor), but AMM is what made it
+// load-bearing: the Submit wrapper reads it and passes the result to the kernel as the command
+// stream's base, so the return-0 default handed the kernel a null stream.
+HLE(k_ampr_get_buffer_base) {
+    ampr_arglog("RPCAhx-aabE(GetBufferBaseAddress)", a0, a1, a2, a3, a4, a5);
+    return ampr_cb_buffer_base(a0);
 }
 
 // sceKernelReleaseDirectMemory(off_t start, size_t len) — return a range to the pool. Any VA still
@@ -2718,6 +3068,28 @@ void register_kernel_mem_hle() {
     // exact firmware name is unknown (not in the 3.20 dump, and it does not hash from Kyty's guessed
     // "sceAmprCommandBufferWriteAddress"), so the label carries a "?" per the unverified-name convention.
     Hle::register_fn("j0+3uJMxYJY", (HleFn)k_ampr_write_address, "sceAmprCommandBufferWriteAddress?");
+    // libSceAmpr AMM — the memory-mapping half of the same command-buffer construct (#2864).
+    // Names and NIDs from the PS5 3.20 firmware export database; argument layouts re-derived from
+    // Yakuza Kiwami's own SDK wrappers (the block above k_amm_get_va_ranges records both).
+    Hle::register_fn("RPCAhx-aabE", (HleFn)k_ampr_get_buffer_base,
+                     "sceAmprCommandBufferGetBufferBaseAddress");
+    Hle::register_fn("EDq5bqCqYpA", (HleFn)k_amm_cb_construct,
+                     "sceAmprAmmCommandBufferConstructor");
+    Hle::register_fn("JEVYGhDc97M", (HleFn)k_amm_cb_map, "sceAmprAmmCommandBufferMap");
+    Hle::register_fn("OJf3vCckPAM", (HleFn)k_amm_submit2, "sceAmprAmmSubmitCommandBuffer2");
+    Hle::register_fn("HXymib4T8gc", (HleFn)k_amm_wait, "sceAmprAmmWaitCommandBufferCompletion");
+    Hle::register_fn("Q07J7XpvhrU", (HleFn)k_amm_give_dmem, "sceAmprAmmGiveDirectMemory");
+    Hle::register_fn("wkQR9+xTFKY", (HleFn)k_amm_get_va_ranges,
+                     "sceAmprAmmGetVirtualAddressRanges");
+    // DELIBERATELY NOT registered, and a real gap rather than an oversight:
+    //   pvUFDOHilnE  sceAmprAmmCommandBufferDestructor
+    //   M-VFI2DJWQA  sceAmprAmmCommandBufferUnmap      (7 call sites in PPSA31334)
+    // Unmap is k_amm_cb_map's symmetric operation and its absence LEAKS: the guest believes a range
+    // went back to AMM's pool while prosper keeps it mapped and keeps its pages carved out of
+    // amm_pool_take's bump cursor. That is a bounded, NAMED leak (the pool-exhausted refusal above
+    // is what it eventually looks like) rather than a corruption, which is why a boot can proceed
+    // without it — but it is the next thing to implement, and implementing it means giving
+    // amm_pool_take a real free list. Tracked as #2873.
 }
 
 // #1755 test hook: exposes the internal scan clamp so a unit test can prove the walk stays inside
@@ -5808,7 +6180,20 @@ HLE(k_ampr_apr_cb_construct_stub) {
     return ampr_arglog("a8uLzYY--tM(AprCommandBufferConstructor, WINDOWS STUB)", a0, a1, a2, a3, a4, a5);
 }
 HLE(k_ampr_set_buffer_stub) {
+    // The MEMORY half stays a stub here (see the comment above). The RECORD half is not
+    // platform-specific — which buffer a command buffer carries is a fact about the guest's object
+    // — so it is kept identical to POSIX so sceAmprCommandBufferGetBufferBaseAddress cannot answer
+    // one thing on Linux and another on Windows (#1970's rule).
+    ampr_cb_set_buffer(a0, a1, a2);
     return ampr_arglog("N-FSPA4S3nI(SetBuffer, WINDOWS STUB)", a0, a1, a2, a3, a4, a5);
+}
+// sceAmprCommandBufferGetBufferBaseAddress — portable, and registered on both arms for the reason
+// above. The AMM handlers next to it on POSIX are NOT registered here: they map guest pages, and
+// the Windows arm's mapping primitives are a separate implementation that needs its own evidence
+// and review. Leaving them on the dispatcher's return-0 default keeps Windows exactly as it was.
+HLE(k_ampr_get_buffer_base) {
+    ampr_arglog("RPCAhx-aabE(GetBufferBaseAddress)", a0, a1, a2, a3, a4, a5);
+    return ampr_cb_buffer_base(a0);
 }
 // #1674: this half destroyed the capacity/offset record but never the completion BINDING, so on
 // Windows no binding of either flavor was ever pruned — strictly worse than the POSIX bug, which
@@ -6206,6 +6591,8 @@ void register_kernel_mem_hle() {
     Hle::register_fn("8aI7R7WaOlc", (HleFn)k_ampr_init, "sceAmprCommandBufferConstructor");
     Hle::register_fn("a8uLzYY--tM", (HleFn)k_ampr_apr_cb_construct_stub, "sceAmprAprCommandBufferConstructor");
     Hle::register_fn("N-FSPA4S3nI", (HleFn)k_ampr_set_buffer_stub, "sceAmprCommandBufferSetBuffer");
+    Hle::register_fn("RPCAhx-aabE", (HleFn)k_ampr_get_buffer_base,
+                     "sceAmprCommandBufferGetBufferBaseAddress");
     Hle::register_fn("baQO9ez2gL4", (HleFn)k_ampr_reset, "sceAmprCommandBufferReset");
     Hle::register_fn("ULvXMDz56po", (HleFn)k_ampr_reset, "sceAmprCommandBufferClearBuffer");
     Hle::register_fn("tZDDEo2tE5k", (HleFn)k_ampr_getsize, "sceAmprCommandBufferGetSize");

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -2321,9 +2321,17 @@ HLE(k_ampr_push_map) {
 // only a log line to say so. Raised in review of the AMM change; the AMM window is the first
 // occupant, and one range is enough until there is a second.
 //
-// Written once, before the window is published, and read from a SIGNAL HANDLER — hence atomics
+// Written once, before the window is published, and read from a SIGNAL HANDLER — hence an atomic
 // rather than the mutex the rest of this file uses.
-std::atomic<uint64_t> g_no_lazy_commit_base{0}, g_no_lazy_commit_end{0};
+//
+// ONE atomic, not a base/end pair. A pair has to be published in some order, and both orders are
+// wrong here: base-first leaves a window in which the range does not yet decline, and end-first
+// leaves one in which `addr >= 0 && addr < end` matches EVERY low address, so unrelated
+// reservations would briefly decline lazy commit and other titles' allocator bring-up would break.
+// The extent is a compile-time constant (kAmmWindowSize), so deriving the end removes the question
+// rather than answering it. Raised in review; the suggested end-first ordering is the wider blast
+// radius of the two, which is why this took neither.
+std::atomic<uint64_t> g_amm_no_lazy_commit_base{0};
 
 // --- libSceAmpr AMM (asynchronous memory manager) ----------------------------------------------
 //
@@ -2438,8 +2446,7 @@ namespace {
             // Order matters: decline lazy commit BEFORE the range becomes a tracked reservation,
             // because the instant `track` publishes it the fault handler would otherwise treat any
             // touch of the still-unmapped remainder as a page to back with anonymous memory.
-            g_no_lazy_commit_base.store((uint64_t)p, std::memory_order_relaxed);
-            g_no_lazy_commit_end.store((uint64_t)p + kAmmWindowSize, std::memory_order_relaxed);
+            g_amm_no_lazy_commit_base.store((uint64_t)p, std::memory_order_relaxed);
             state.va_base = (uint64_t)p;
             state.va_size = kAmmWindowSize;
             track(state.va_base, state.va_size, 0, 0, false, "ampr-amm-window");
@@ -2529,6 +2536,18 @@ namespace {
 // CONFIDENCE: LOW on r2/r3 specifically; HIGH that writing something defined beats writing nothing.
 HLE(k_amm_get_va_ranges) {
     ampr_arglog("wkQR9+xTFKY(AmmGetVirtualAddressRanges)", a0, a1, a2, a3, a4, a5);
+    // Same rule as GiveDirectMemory below, applied to the two slots the guest demonstrably reads:
+    // reporting SCE_OK for a window we did not write is the silent-error class the whole change is
+    // about, and it does not become acceptable because the pointer was the guest's mistake rather
+    // than ours. a2/a3 stay optional — their meaning is unknown, so requiring them would be
+    // inventing a contract; they are written when they are plausible and that is all that can
+    // honestly be said. The SDK wrapper derives all four from one struct pointer
+    // (eboot+0xcc4c10), so in practice they are plausible together or not at all.
+    if (a0 <= 0xffff || a1 <= 0xffff) {
+        amm_say(true, "REFUSED get-virtual-address-ranges: no plausible out-parameters for the "
+                      "window", a0, a1, a2);
+        return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    }
     uint64_t base = 0, size = 0;
     const bool ok = amm_window_ensure(base, size);
     // The out-parameters are written on EVERY path, including the failure one. Returning an error
@@ -2539,14 +2558,20 @@ HLE(k_amm_get_va_ranges) {
     // residue exactly as before. An all-zero window is also the answer that makes the guest fail
     // SAFELY: it stores the base at state+0xeca8, and its heap-grow path tests that slot for zero
     // (eboot+0xdbbdc6) and takes its own no-AMM branch. Raised in review.
-    if (a0 > 0xffff) *(uint64_t*)a0 = ok ? base : 0;
-    if (a1 > 0xffff) *(uint64_t*)a1 = ok ? base + size : 0;
+    *(uint64_t*)a0 = ok ? base : 0;          // both validated above, before anything was reserved
+    *(uint64_t*)a1 = ok ? base + size : 0;
     if (a2 > 0xffff) *(uint64_t*)a2 = 0;
     if (a3 > 0xffff) *(uint64_t*)a3 = 0;
     return ok ? 0 : 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
 }
 
-// sceAmprAmmGiveDirectMemory(searchStart, searchEnd, len, memoryType, alignment, off_t* physOut).
+// sceAmprAmmGiveDirectMemory(searchStart, searchEnd, len, alignment, memoryType, off_t* physOut).
+// ALIGNMENT then TYPE — the kernel allocator's own order, established from the live call
+// (a3 = 0x200000, a4 = 1) and re-derived at eboot+0xdbf4e6/0xdbf4f1. This line said the opposite
+// until review caught it, which is worth a sentence rather than a silent correction: it is the
+// first thing a reader sees, it survived a review pass AND a fix pass, and a signature comment that
+// disagrees with its own body is worse than none because it is believed instead of checked.
+//
 // Claims `len` bytes of the direct-memory pool for AMM and remembers the range; every later map
 // carves its pages out of it, so the guest's own residency budget is enforced by physics rather
 // than by trust. Failure is reported as ENOMEM, which the guest handles by abandoning AMM init —
@@ -2566,6 +2591,20 @@ HLE(k_amm_give_dmem) {
     const int type = a4 <= (uint64_t)kMaxDirectMemoryType ? (int)a4 : 0;
     if (!a2 || (a2 & (kGuestPageSize - 1)) != 0) {
         amm_say(true, "REFUSED give-direct-memory: length is not a 16 KiB multiple", a2, align, a4);
+        return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    }
+    // EVERY validation happens BEFORE the pool is touched, and the out-parameter is checked here
+    // rather than at the write. This ordering is the contract, not a style choice: an implausible
+    // a5 discovered after dmem_take/dmem_zero/amm_pool_publish would leave the pool consumed and
+    // handed to AMM while the guest is told SCE_OK with its slot untouched — and the guest tests
+    // only for a negative return (eboot+0xdbf4fe is `test %eax,%eax; js`), so it would then read an
+    // uninitialised qword. That is the 0x1d0000 mechanism this whole change exists to remove,
+    // reintroduced one layer up. This file already carries the same lesson at valid_dmem_allocation
+    // (`phys_out > 0xffff`, checked before k_alloc_dmem's dmem_take), and k_alloc_dmem avoids the
+    // trap only by that ordering. Raised in review.
+    if (a5 <= 0xffff) {
+        amm_say(true, "REFUSED give-direct-memory: no plausible out-parameter for the physical "
+                      "offset", a2, align, a5);
         return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
     }
     uint64_t phys = 0;
@@ -2588,7 +2627,7 @@ HLE(k_amm_give_dmem) {
         dmem_release(phys, a2);
         return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
     }
-    if (a5 > 0xffff) *(uint64_t*)a5 = phys;
+    *(uint64_t*)a5 = phys;   // unconditional: a5 was validated above, before anything was consumed
     fprintf(stderr, "[amm] direct-memory pool [0x%llx,0x%llx) (%llu MiB, type %d, align 0x%llx)\n",
             (unsigned long long)phys, (unsigned long long)(phys + a2),
             (unsigned long long)(a2 >> 20), type, (unsigned long long)align);
@@ -2661,9 +2700,20 @@ HLE(k_amm_cb_map) {
 // and it spins on it (eboot+0xdbbe90) sleeping a second per attempt.
 HLE(k_amm_submit2) {
     ampr_arglog("OJf3vCckPAM(AmmSubmitCommandBuffer2)", a0, a1, a2, a3, a4, a5);
+    // a4 is the slot the guest reads back and hands to WaitCommandBufferCompletion
+    // (eboot+0xdbbea3 loads it with a 32-bit `mov` immediately after this call returns). Answering
+    // SCE_OK without writing it would leave the guest waiting on residue — a silent error, and the
+    // reason this refuses instead. NOT EAGAIN: that is the guest's retry sentinel and it spins on
+    // it (eboot+0xdbbe90), so the one wrong answer here is the one that looks like backpressure.
+    // a3 stays optional for the same reason as GetVirtualAddressRanges' a2/a3 — no call site reads
+    // it, so its meaning is unestablished and demanding it would be inventing a contract.
+    if (a4 <= 0xffff) {
+        amm_say(true, "REFUSED submit: no plausible out-parameter for the completion id", a0, a1, a4);
+        return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
+    }
     const uint32_t id = amm().next_completion.fetch_add(1, std::memory_order_relaxed);
     if (a3 > 0xffff) *(uint32_t*)a3 = 0;
-    if (a4 > 0xffff) *(uint32_t*)a4 = id;
+    *(uint32_t*)a4 = id;
     return 0;
 }
 
@@ -2693,10 +2743,22 @@ HLE(k_release_dmem) {
     return 0;
 }
 
-// Most-specific tracked-mapping state at `addr` for the fault handler's lazy-commit probe:
-// 0 = untracked, 1 = reserved-but-uncommitted, 2 = committed, 3 = reserved and DECLINING lazy
-// commit (see above). Every caller tests `== 1`, so 3 declines everywhere at once — which is the
-// point: a range prosper will not back itself must not be backed by the APR completion write or the
+// Most-specific tracked-mapping state at `addr` for the fault handler's lazy-commit probe. The
+// numbering is ONE contract shared by both platform arms, and it is written out here in full
+// because it is not: 3 was already taken.
+//
+//   0  untracked
+//   1  reserved, uncommitted            — the lazy-commit target; every caller tests for exactly 1
+//   2  committed
+//   3  committed, sparse direct page awaiting host commitment   (WINDOWS arm only)
+//   4  reserved, uncommitted, DECLINING lazy commit             (POSIX arm only, see above)
+//
+// 3 and 4 are sub-cases of DIFFERENT parents — 3 refines "committed", 4 refines "reserved" — so
+// they are not interchangeable and a reader who assumes the values are dense will get it wrong.
+// The AMM change originally allocated 3 for the decline, which collided; review caught it.
+//
+// Every caller tests `== 1`, so any other value declines the lazy commit, which is the point: a
+// range prosper will not back itself must not be backed by the APR completion write or the
 // file-read destination commit either. Called from a signal handler on the FAULTING thread — that
 // thread is in guest code, so it cannot itself hold g_mx (only HLE memory entry points take it,
 // briefly); a contended lock just waits for the other thread's release.
@@ -2712,8 +2774,9 @@ extern "C" int prosper_reserved_range_state(uint64_t addr) {
     const bool contains = addr >= mapping.base && addr - mapping.base < mapping.size;
     if (!contains) return 0;
     if (mapping.committed) return 2;
-    return (addr >= g_no_lazy_commit_base.load(std::memory_order_relaxed) &&
-            addr < g_no_lazy_commit_end.load(std::memory_order_relaxed)) ? 3 : 1;
+    const uint64_t decline_base = g_amm_no_lazy_commit_base.load(std::memory_order_relaxed);
+    return (decline_base && addr >= decline_base &&
+            addr - decline_base < kAmmWindowSize) ? 4 : 1;
 }
 
 // sceKernelBatchMap(SceKernelBatchMapEntry* entries, int numberOfEntries, int* numberOfEntriesOut)
@@ -5727,8 +5790,13 @@ extern "C" int prosper_try_commit_reserved_placeholder(uint64_t addr, uint64_t l
 }
 
 // Fault-handler lazy-commit probe parity (Linux exports this for its SIGSEGV handler). The Windows
-// VEH uses this to back reserved guest pages on first touch: 0 = untracked, 1 = reserved,
-// 2 = committed, 3 = guest-committed sparse direct page awaiting host commitment.
+// VEH uses this to back reserved guest pages on first touch. The value numbering is ONE contract
+// shared with the POSIX arm — see the full table there; the short form is
+//   0 untracked, 1 reserved-uncommitted, 2 committed,
+//   3 committed sparse direct page awaiting host commitment (this arm only),
+//   4 reserved-uncommitted and DECLINING lazy commit        (POSIX arm only, libSceAmpr AMM).
+// 3 and 4 refine different parents and are not interchangeable. This arm cannot answer 4 because it
+// does not implement AMM; if it ever does, 4 is the value to use rather than a second private one.
 extern "C" int prosper_reserved_range_state(uint64_t addr) {
     bool tracked = false;
     bool committed = false;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -2559,20 +2559,37 @@ HLE(k_amm_get_va_ranges) {
     // SAFELY: it stores the base at state+0xeca8, and its heap-grow path tests that slot for zero
     // (eboot+0xdbbdc6) and takes its own no-AMM branch. Raised in review.
     //
-    // The caveat a reviewer raised about that zero, checked rather than inherited. The guest also
-    // classifies pointers against the window at eboot+0xda0f5e:
+    // What the zero costs, stated the right way round. This comment previously claimed the opposite
+    // and the correction is worth keeping visible, because the mistake was not a misread
+    // instruction — the disassembly was right — it was substituting the value I EXPECTED for the
+    // one the guest computes from it.
     //
-    //     rdx = 0x100000000 + state[0xecd0]      ; 4 GiB + the AMM size
-    //     rcx = ptr - state[0xeca8]              ; ptr - the AMM base
+    // The guest classifies pointers against the window at eboot+0xda0f5e:
+    //
+    //     rdx = 0x100000000 + state[0xecd0]      ; 4 GiB + the AMM SIZE
+    //     rcx = ptr - state[0xeca8]              ; ptr - the AMM BASE
     //     cmp %rdx,%rcx ; jbe 0xda0fad           ; taken => treat as AMM memory
     //
-    // With base and size both zero that reduces to "ptr <= 4 GiB", so the AMM arm is taken for any
-    // pointer below 4 GiB and for nothing above it. No guest pointer is below 4 GiB — the eboot
-    // maps at 0x410000000 and the auto-map region starts at 0x2000000000 — so on this path the arm
-    // is unreachable for a real pointer, which is why the zero stands. It is worth knowing rather
-    // than worth changing: the path is reachable only when the 68 GiB reservation itself fails,
-    // which announces itself loudly, and the only alternative answer is the stack residue that
-    // produced the 0x1d0000 fault in the first place.
+    // The base is zero here. The SIZE IS NOT. The initialiser derives it as
+    // min(requested, span - 4 GiB) at eboot+0xdbf532-0xdbf538, and on a zero window `span - 4 GiB`
+    // UNDERFLOWS to 0xffffffff00000000, so the `cmovb` picks the other operand — the guest's own
+    // request, 0x8000000000. That lands at state+0xecd0 via eboot+0xdbf62f, which is where both
+    // bail branches jump AND what straight-line execution reaches. (Neither bail even fires:
+    // 0x8000000000 is not < 0x8020, and the `je` needs a base of exactly -4 GiB.)
+    //
+    // So rdx = 0x8100000000 and the arm is taken for every pointer below 516 GiB — which is EVERY
+    // real guest pointer: the eboot maps at 0x410000000 and the auto-map region starts at
+    // 0x2000000000. The classifier answers "this is AMM memory" for all of them, and misses only
+    // addresses above 516 GiB, i.e. exactly where the window would have been had it been reserved.
+    //
+    // Zero is still the right answer, and for a reason that is not "it is harmless": a NON-zero
+    // base would defeat the gate that actually saves this path. The heap-grow path tests
+    // state+0xeca8 for zero at eboot+0xdbbdc6 and takes its own no-AMM branch, so nothing is ever
+    // mapped into the window that does not exist. That gate is doing all of the work, and the
+    // residual risk is whatever else consults the classifier afterwards — which is NOT established.
+    // Tracked as #2889 rather than papered over with a confident sentence. Reachable only when the
+    // 68 GiB reservation itself fails, which announces itself loudly, and the only alternative
+    // answer on this path is the stack residue that produced the 0x1d0000 fault in the first place.
     *(uint64_t*)a0 = ok ? base : 0;          // both validated above, before anything was reserved
     *(uint64_t*)a1 = ok ? base + size : 0;
     if (a2 > 0xffff) *(uint64_t*)a2 = 0;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -2558,6 +2558,21 @@ HLE(k_amm_get_va_ranges) {
     // residue exactly as before. An all-zero window is also the answer that makes the guest fail
     // SAFELY: it stores the base at state+0xeca8, and its heap-grow path tests that slot for zero
     // (eboot+0xdbbdc6) and takes its own no-AMM branch. Raised in review.
+    //
+    // The caveat a reviewer raised about that zero, checked rather than inherited. The guest also
+    // classifies pointers against the window at eboot+0xda0f5e:
+    //
+    //     rdx = 0x100000000 + state[0xecd0]      ; 4 GiB + the AMM size
+    //     rcx = ptr - state[0xeca8]              ; ptr - the AMM base
+    //     cmp %rdx,%rcx ; jbe 0xda0fad           ; taken => treat as AMM memory
+    //
+    // With base and size both zero that reduces to "ptr <= 4 GiB", so the AMM arm is taken for any
+    // pointer below 4 GiB and for nothing above it. No guest pointer is below 4 GiB — the eboot
+    // maps at 0x410000000 and the auto-map region starts at 0x2000000000 — so on this path the arm
+    // is unreachable for a real pointer, which is why the zero stands. It is worth knowing rather
+    // than worth changing: the path is reachable only when the 68 GiB reservation itself fails,
+    // which announces itself loudly, and the only alternative answer is the stack residue that
+    // produced the 0x1d0000 fault in the first place.
     *(uint64_t*)a0 = ok ? base : 0;          // both validated above, before anything was reserved
     *(uint64_t*)a1 = ok ? base + size : 0;
     if (a2 > 0xffff) *(uint64_t*)a2 = 0;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -186,6 +186,11 @@ uint64_t ampr_cb_offset(uint64_t cb) {
 void ampr_cb_set_buffer(uint64_t cb, uint64_t base, uint64_t size) {
     if (!cb) return;
     std::lock_guard<std::mutex> lock(g_ampr_cb_state_mx);
+    // #2878: this eviction picks an ARBITRARY victim, and adding buffer_base to the record made
+    // that newly consequential — an evicted victim's GetBufferBaseAddress answers 0, which on the
+    // AMM submit path is a null command stream. Latent (no title comes near 4096 live command
+    // buffers; PPSA31334 constructs two) and left as-is here rather than swapped for a different
+    // arbitrary rule without evidence.
     if (g_ampr_cb_state.size() >= 4096 && !g_ampr_cb_state.count(cb))
         g_ampr_cb_state.erase(g_ampr_cb_state.begin());
     auto& state = g_ampr_cb_state[cb];
@@ -2304,6 +2309,22 @@ HLE(k_ampr_push_map) {
     return 0;
 }
 
+// A reservation prosper made for ITSELF, which the fault handler must never silently back.
+//
+// The default for a tracked-but-uncommitted range is the opposite: exec_image_linux.cpp's SIGSEGV
+// handler treats state 1 above 0x1000000000 as "the guest touched a page it believes it committed"
+// and MAP_FIXEDs a 64 KiB anonymous read/write page over it. Several titles' allocator bring-up
+// depends on that, so it is right as a default — but it is exactly wrong for a window prosper
+// reserved to hold a specific kind of memory, because it converts a REFUSED mapping into a silently
+// substituted one: the guest gets anonymous pages with no physical alias, no write-watch coverage,
+// and a g_maps record still saying "uncommitted", and the run continues on divergent memory with
+// only a log line to say so. Raised in review of the AMM change; the AMM window is the first
+// occupant, and one range is enough until there is a second.
+//
+// Written once, before the window is published, and read from a SIGNAL HANDLER — hence atomics
+// rather than the mutex the rest of this file uses.
+std::atomic<uint64_t> g_no_lazy_commit_base{0}, g_no_lazy_commit_end{0};
+
 // --- libSceAmpr AMM (asynchronous memory manager) ----------------------------------------------
 //
 // AMM is the memory-mapping sibling of the APR file reader above (and in hle_file.cpp): the guest
@@ -2355,7 +2376,21 @@ HLE(k_ampr_push_map) {
 // the window prosper itself reserved for AMM. That window is a PROT_NONE reservation prosper tracks
 // as UNCOMMITTED, so map_phys_at's no-clobber discipline (#137, and the clobbers it exists to stop
 // — #88, #107) independently refuses to place a mapping anywhere else. Two guards, either of which
-// alone turns a wrong VA into a loud refusal instead of a MAP_FIXED over live guest memory.
+// alone turns a wrong VA into a refusal instead of a MAP_FIXED over live guest memory.
+//
+// A refusal is only *visible* because of the third thing, and this paragraph claimed the opposite
+// until review caught it. On Linux a tracked-but-uncommitted range above 0x1000000000 is a
+// LAZY-COMMIT TARGET: exec_image_linux.cpp's SIGSEGV handler backs a touch of one with a 64 KiB
+// anonymous page and re-executes. Left that way, a refused AMM map would be silently rescued with
+// memory that has no physical alias, no write-watch coverage and a g_maps record still reading
+// "uncommitted" — and the guest could not tell, because it does not test Map's return value
+// (eboot+0xdbbe64 is followed straight by a `lea`, with no `test %eax,%eax` before eax is
+// clobbered). So the window is registered as DECLINING lazy commit (g_no_lazy_commit_*), which
+// turns a refused map into a fault at the exact VA the guest asked for, with this file's log line
+// naming the reason immediately above it. That also closes a straddle: the lazy commit rounds to
+// 64 KiB while a map is only required to be 16 KiB aligned, so a fault in the uncommitted half of a
+// 64 KiB page could otherwise have MAP_FIXED anonymous memory over the committed half — the #88 /
+// #107 clobber class arriving through the fault handler rather than through map_at.
 // CONFIDENCE: HIGH on the argument layouts (SDK wrappers + nine consistent call sites), MED on the
 // window's size and placement (prosper chooses those; the guest only requires the span), LOW on
 // the meaning of the three out-parameters this title never reads — see each below.
@@ -2375,7 +2410,10 @@ namespace {
         uint64_t va_base = 0, va_size = 0;                   // the reported window
         uint64_t pool_base = 0, pool_end = 0, pool_cursor = 0; // physical pool from GiveDirectMemory
         std::atomic<uint32_t> next_completion{1};
-        int refusals = 0;
+        // Separate counters: a run that trips the protection-0 NOTE sixteen times must not go on to
+        // swallow the first real REFUSED line, which is the one that explains a fault. Raised in
+        // review.
+        int refusals = 0, notes = 0;
     };
     // Never destroyed: guest threads can still be inside an AMM call during process teardown.
     AmmState& amm() { static AmmState* state = new AmmState; return *state; }
@@ -2383,6 +2421,9 @@ namespace {
     // Reserve the window on first use and publish it. PROT_NONE + a tracked UNCOMMITTED record is
     // the same shape sceKernelReserveVirtualRange produces, which is exactly what makes
     // map_phys_at willing to commit inside it and unwilling to commit outside it.
+    // Lock order is AmmState::mx -> g_mx: map_guest_from and track both take g_mx underneath this
+    // lock. Nothing takes g_mx and then calls into AMM, so there is no cycle — written down rather
+    // than left to be re-derived, because that is the property a future edit could break silently.
     bool amm_window_ensure(uint64_t& base_out, uint64_t& size_out) {
         AmmState& state = amm();
         std::lock_guard<std::mutex> lk(state.mx);
@@ -2394,6 +2435,11 @@ namespace {
                         (unsigned long long)kAmmWindowSize);
                 return false;
             }
+            // Order matters: decline lazy commit BEFORE the range becomes a tracked reservation,
+            // because the instant `track` publishes it the fault handler would otherwise treat any
+            // touch of the still-unmapped remainder as a page to back with anonymous memory.
+            g_no_lazy_commit_base.store((uint64_t)p, std::memory_order_relaxed);
+            g_no_lazy_commit_end.store((uint64_t)p + kAmmWindowSize, std::memory_order_relaxed);
             state.va_base = (uint64_t)p;
             state.va_size = kAmmWindowSize;
             track(state.va_base, state.va_size, 0, 0, false, "ampr-amm-window");
@@ -2460,15 +2506,16 @@ namespace {
     // Bounded so a guest that asks for something impossible in a loop cannot flood the log, but
     // never silent for the first few: a refused map is a page the guest believes it owns, and the
     // fault it produces later is meaningless without this line. `what` carries its own verb.
-    void amm_say(const char* what, uint64_t a, uint64_t b, uint64_t c) {
+    void amm_say(bool is_refusal, const char* what, uint64_t a, uint64_t b, uint64_t c) {
         AmmState& state = amm();
         int n;
-        { std::lock_guard<std::mutex> lk(state.mx); n = state.refusals++; }
+        { std::lock_guard<std::mutex> lk(state.mx);
+          n = is_refusal ? state.refusals++ : state.notes++; }
         if (n < 16)
             fprintf(stderr, "[amm] %s (0x%llx, 0x%llx, 0x%llx)\n", what,
                     (unsigned long long)a, (unsigned long long)b, (unsigned long long)c);
         else if (n == 16)
-            fprintf(stderr, "[amm] further AMM complaints suppressed\n");
+            fprintf(stderr, "[amm] further %s suppressed\n", is_refusal ? "refusals" : "notes");
     }
 }
 
@@ -2483,12 +2530,20 @@ namespace {
 HLE(k_amm_get_va_ranges) {
     ampr_arglog("wkQR9+xTFKY(AmmGetVirtualAddressRanges)", a0, a1, a2, a3, a4, a5);
     uint64_t base = 0, size = 0;
-    if (!amm_window_ensure(base, size)) return 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
-    if (a0 > 0xffff) *(uint64_t*)a0 = base;
-    if (a1 > 0xffff) *(uint64_t*)a1 = base + size;
+    const bool ok = amm_window_ensure(base, size);
+    // The out-parameters are written on EVERY path, including the failure one. Returning an error
+    // without writing them would be byte-for-byte the defect this handler exists to remove — and
+    // worse than it looks, because the guest never reads the return value: eboot+0xdbf4d4 is
+    // followed immediately by `call 0xe8fcc0`, with no `test %eax,%eax` in between. An unwritten
+    // slot would therefore be indistinguishable from success and the allocator would walk stack
+    // residue exactly as before. An all-zero window is also the answer that makes the guest fail
+    // SAFELY: it stores the base at state+0xeca8, and its heap-grow path tests that slot for zero
+    // (eboot+0xdbbdc6) and takes its own no-AMM branch. Raised in review.
+    if (a0 > 0xffff) *(uint64_t*)a0 = ok ? base : 0;
+    if (a1 > 0xffff) *(uint64_t*)a1 = ok ? base + size : 0;
     if (a2 > 0xffff) *(uint64_t*)a2 = 0;
     if (a3 > 0xffff) *(uint64_t*)a3 = 0;
-    return 0;
+    return ok ? 0 : 0x8002000cull;   // SCE_KERNEL_ERROR_ENOMEM
 }
 
 // sceAmprAmmGiveDirectMemory(searchStart, searchEnd, len, memoryType, alignment, off_t* physOut).
@@ -2510,16 +2565,25 @@ HLE(k_amm_give_dmem) {
                             (a3 & (kGuestPageSize - 1)) == 0) ? a3 : kGuestPageSize;
     const int type = a4 <= (uint64_t)kMaxDirectMemoryType ? (int)a4 : 0;
     if (!a2 || (a2 & (kGuestPageSize - 1)) != 0) {
-        amm_say("REFUSED give-direct-memory: length is not a 16 KiB multiple", a2, align, a4);
+        amm_say(true, "REFUSED give-direct-memory: length is not a 16 KiB multiple", a2, align, a4);
         return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
     }
     uint64_t phys = 0;
     if (!dmem_take(a2, align, type, phys, a0, a1 ? a1 : ~0ull)) {
-        amm_say("REFUSED give-direct-memory: the direct-memory pool cannot satisfy it", a2, align, a1);
+        amm_say(true, "REFUSED give-direct-memory: the direct-memory pool cannot satisfy it", a2, align, a1);
         return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
     }
+    // Fresh direct memory reads back ZERO on hardware, and prosper's pool is one process-wide memfd
+    // that RETAINS bytes across release and reuse (see dmem_zero). Every other fresh-allocation path
+    // in this file punches the range; this one must too, or an AMM pool landing on previously
+    // released offsets hands the guest's heap allocator somebody else's bytes. Raised in review; the
+    // test that appeared to cover it could not, because a fresh test process reads zero through
+    // sparseness whether or not this call happens. Cheap on Linux (a hole punch, and the range stays
+    // sparse); the Darwin branch memsets through a scratch mapping, which a multi-GiB pool makes
+    // genuinely expensive — worth knowing, not worth skipping.
+    dmem_zero(phys, a2);
     if (!amm_pool_publish(phys, a2)) {
-        amm_say("REFUSED give-direct-memory: AMM already holds a pool and this one is not "
+        amm_say(true, "REFUSED give-direct-memory: AMM already holds a pool and this one is not "
                 "contiguous with it -- prosper tracks a single span", phys, a2, 0);
         dmem_release(phys, a2);
         return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
@@ -2546,17 +2610,17 @@ HLE(k_amm_cb_map) {
     ampr_arglog("JEVYGhDc97M(AmmCommandBufferMap)", a0, a1, a2, a3, a4, a5);
     const uint64_t va = a1, len = a2;
     if (!va || !len || (va & (kGuestPageSize - 1)) != 0 || (len & (kGuestPageSize - 1)) != 0) {
-        amm_say("REFUSED map: address or length is not 16 KiB aligned", va, len, a0);
+        amm_say(true, "REFUSED map: address or length is not 16 KiB aligned", va, len, a0);
         return 0x80020016ull;                                   // SCE_KERNEL_ERROR_EINVAL
     }
     uint64_t window_base = 0, window_size = 0;
     if (!amm_window_ensure(window_base, window_size) || !amm_window_contains(va, len)) {
-        amm_say("REFUSED map: target is OUTSIDE the AMM window", va, len, window_base);
+        amm_say(true, "REFUSED map: target is OUTSIDE the AMM window", va, len, window_base);
         return 0x80020016ull;
     }
     uint64_t phys = 0;
     if (!amm_pool_take(len, phys)) {
-        amm_say("REFUSED map: AMM's own direct-memory pool is exhausted", va, len, 0);
+        amm_say(true, "REFUSED map: AMM's own direct-memory pool is exhausted", va, len, 0);
         return 0x8002000cull;                                   // SCE_KERNEL_ERROR_ENOMEM
     }
     int prot = host_prot(a4);
@@ -2568,13 +2632,13 @@ HLE(k_amm_cb_map) {
         // unexplainable SIGSEGV inside guest code instead of as a diagnosable refusal here, so
         // fall back to read/write — and say so, because a fallback nobody sees is a fallback
         // nobody fixes. CONFIDENCE: LOW (the zero case has never been observed).
-        amm_say("NOTE map: protection 0 decodes to no access; mapping read/write instead",
+        amm_say(false, "NOTE map: protection 0 decodes to no access; mapping read/write instead",
                 va, len, a4);
         prot = PROT_READ | PROT_WRITE;
     }
     void* p = map_phys_at(va, len, prot, phys);
     if (!p) {
-        amm_say("REFUSED map: the host refused the mapping (target is not a free reservation)", va, len, phys);
+        amm_say(true, "REFUSED map: the host refused the mapping (target is not a free reservation)", va, len, phys);
         amm_pool_untake(phys, len);
         return 0x8002000cull;
     }
@@ -2630,9 +2694,12 @@ HLE(k_release_dmem) {
 }
 
 // Most-specific tracked-mapping state at `addr` for the fault handler's lazy-commit probe:
-// 0 = untracked, 1 = reserved-but-uncommitted, 2 = committed. Called from a signal handler on the
-// FAULTING thread — that thread is in guest code, so it cannot itself hold g_mx (only HLE memory
-// entry points take it, briefly); a contended lock just waits for the other thread's release.
+// 0 = untracked, 1 = reserved-but-uncommitted, 2 = committed, 3 = reserved and DECLINING lazy
+// commit (see above). Every caller tests `== 1`, so 3 declines everywhere at once — which is the
+// point: a range prosper will not back itself must not be backed by the APR completion write or the
+// file-read destination commit either. Called from a signal handler on the FAULTING thread — that
+// thread is in guest code, so it cannot itself hold g_mx (only HLE memory entry points take it,
+// briefly); a contended lock just waits for the other thread's release.
 extern "C" int prosper_reserved_range_state(uint64_t addr) {
     std::lock_guard<std::mutex> lk(g_mx);
     const auto after = std::upper_bound(
@@ -2643,7 +2710,10 @@ extern "C" int prosper_reserved_range_state(uint64_t addr) {
     if (after == g_maps.begin()) return 0;
     const Mapping& mapping = *std::prev(after);
     const bool contains = addr >= mapping.base && addr - mapping.base < mapping.size;
-    return contains ? (mapping.committed ? 2 : 1) : 0;
+    if (!contains) return 0;
+    if (mapping.committed) return 2;
+    return (addr >= g_no_lazy_commit_base.load(std::memory_order_relaxed) &&
+            addr < g_no_lazy_commit_end.load(std::memory_order_relaxed)) ? 3 : 1;
 }
 
 // sceKernelBatchMap(SceKernelBatchMapEntry* entries, int numberOfEntries, int* numberOfEntriesOut)
@@ -3086,10 +3156,15 @@ void register_kernel_mem_hle() {
     //   M-VFI2DJWQA  sceAmprAmmCommandBufferUnmap      (7 call sites in PPSA31334)
     // Unmap is k_amm_cb_map's symmetric operation and its absence LEAKS: the guest believes a range
     // went back to AMM's pool while prosper keeps it mapped and keeps its pages carved out of
-    // amm_pool_take's bump cursor. That is a bounded, NAMED leak (the pool-exhausted refusal above
-    // is what it eventually looks like) rather than a corruption, which is why a boot can proceed
-    // without it — but it is the next thing to implement, and implementing it means giving
-    // amm_pool_take a real free list. Tracked as #2873.
+    // amm_pool_take's bump cursor.
+    //
+    // That is a bounded leak rather than a corruption, and the reason is the bump cursor itself: it
+    // only ever moves forward, and amm_pool_untake rewinds only its own just-taken tail, so a page
+    // carved for a VA the guest later "unmaps" is NEVER reissued to a second VA. The failure mode is
+    // exhaustion, not aliasing, and both ends of it are named in the log — a re-map of a still-mapped
+    // VA is refused as "target is not a free reservation", and the pool running dry is refused as
+    // "AMM's own direct-memory pool is exhausted". Spelled out here (raised in review) so the next
+    // reader does not have to re-derive that the leak cannot alias. Tracked as #2873.
 }
 
 // #1755 test hook: exposes the internal scan clamp so a unit test can prove the walk stays inside

--- a/prosper/tests/hle/memory/test_ampr_amm.cpp
+++ b/prosper/tests/hle/memory/test_ampr_amm.cpp
@@ -27,6 +27,11 @@
 
 using namespace prosper;
 
+// The memory HLE's lazy-commit probe, as the SIGSEGV handler sees it. Declared here rather than
+// pulled from a header because that is how every other caller declares it (exec_image_linux.cpp,
+// hle_file.cpp).
+extern "C" int prosper_reserved_range_state(uint64_t addr);
+
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
                          else       { std::printf("  [ok]   %s\n", m); } } while (0)
@@ -111,6 +116,60 @@ int main() {
           "the window is stable across calls (the guest caches r0 and classifies pointers against it)");
 
     // ---- the physical pool -----------------------------------------------------------------
+    // Two properties of GiveDirectMemory are asserted below, and NEITHER can be observed against a
+    // virgin direct-memory pool — which is how both of them were void in the first version of this
+    // test, and is worth stating because the failure is invisible rather than wrong:
+    //
+    //   * the ALIGNMENT arm. The pool's first-fit gap starts at kDmemBase = 0x10000000, which is
+    //     already 2 MiB aligned, so honouring a 2 MiB alignment and silently falling back to the
+    //     16 KiB granule produce the SAME offset. Fix: hold a 16 KiB allocation so the next gap
+    //     starts at 0x10004000, where the two answers differ.
+    //   * the ZEROING arm further down. prosper's pool is one process-wide memfd that retains bytes
+    //     across release and reuse; in a fresh test process nothing has ever written it, so it reads
+    //     back zero through sparseness whether or not the allocator punches the range. Fix: dirty
+    //     the physical range first, then release it, then let the AMM pool land on it.
+    //
+    // Both were raised in review as same-source positive controls (the charter's instrument trap
+    // 122): a control drawn from the same source as the null it validates tests the discriminator,
+    // never the domain.
+    HleFn alloc_dmem   = Hle::lookup("rTXw65xmLIA");   // sceKernelAllocateDirectMemory
+    HleFn map_dmem     = Hle::lookup("L-Q3LEjIbgA");   // sceKernelMapDirectMemory
+    // NIDs resolved from the PS5 3.20 firmware export database, not guessed — the first draft of
+    // this line carried an invented NID for munmap and would have silently skipped the dirtying
+    // step, leaving the zero arm exactly as void as it was before.
+    HleFn munmap_fn    = Hle::lookup("cQke9UuBQOk");   // sceKernelMunmap
+    HleFn release_dmem = Hle::lookup("MBuItvba6z8");   // sceKernelReleaseDirectMemory
+    CHECK(alloc_dmem && map_dmem && munmap_fn && release_dmem,
+          "the direct-memory NIDs this test builds its preconditions from are registered");
+    if (!(alloc_dmem && map_dmem && munmap_fn && release_dmem)) {
+        std::printf("FAILED\n");
+        return 1;
+    }
+
+    // (1) Hold a 16 KiB block forever, so the pool's first free gap is no longer 2 MiB aligned.
+    uint64_t pin = 0;
+    CHECK(alloc_dmem(0, 16ull << 30, 0x4000, 0x4000, 0, (uint64_t)&pin) == 0,
+          "a 16 KiB direct-memory block can be pinned to unalign the pool's first free gap");
+    CHECK((pin & (0x200000ull - 1)) == 0 && pin != 0,
+          "...and it starts at the pool base, so the gap after it is NOT 2 MiB aligned");
+
+    // (2) Dirty the physical range the AMM pool is about to be carved from, then release it. This
+    // is what makes the zero-read arm below a statement about the allocator rather than about an
+    // untouched file.
+    constexpr uint64_t kDirtyLen = 0x400000ull;       // 4 MiB, spanning the next 2 MiB boundary
+    uint64_t dirty = 0;
+    CHECK(alloc_dmem(0, 16ull << 30, kDirtyLen, 0x4000, 0, (uint64_t)&dirty) == 0,
+          "a scratch direct-memory block can be allocated over the pool's next gap");
+    uint64_t dirty_va = 0;
+    const uint64_t map_rc = map_dmem((uint64_t)&dirty_va, kDirtyLen, /*prot=*/0x3, /*flags=*/0,
+                                     dirty, 0x4000);
+    CHECK(map_rc == 0 && dirty_va != 0, "the scratch block maps");
+    if (map_rc == 0 && dirty_va) {
+        std::memset((void*)(uintptr_t)dirty_va, 0xa5, (size_t)kDirtyLen);
+        munmap_fn(dirty_va, kDirtyLen, 0, 0, 0, 0);
+    }
+    release_dmem(dirty, kDirtyLen, 0, 0, 0, 0);
+
     // Shape taken verbatim from the live call under PROSPER_AMPRLOG:
     //   Q07J7XpvhrU a0=0x0 a1=0x400000000 a2=0x280000000 a3=0x200000 a4=0x1 a5=<out>
     // i.e. (searchStart, searchEnd, len, ALIGNMENT, MEMORY TYPE, off_t* out) — the kernel
@@ -121,12 +180,14 @@ int main() {
           "GiveDirectMemory claims a physical pool");
     CHECK(phys != kPoison && phys != 0,
           "GiveDirectMemory WRITES the physical offset out-parameter");
-    // The alignment argument is honoured, which is the arm that separates the two readings of
-    // a3/a4: with them swapped, a3 = 1 is rejected as an alignment and the carve falls back to the
-    // 16 KiB granule, so a 2 MiB-aligned offset stops being guaranteed. (a4 = 1 as an alignment
-    // would be rejected too, so this cannot pass by accident either way round.)
-    CHECK((phys & (0x200000ull - 1)) == 0,
+    // Now discriminating, thanks to the pin above: the first fit is somewhere in [0x10004000, …),
+    // so an honoured 2 MiB alignment lands on 0x10200000 and a 16 KiB fallback does not. Reading
+    // a3/a4 the other way round rejects a3 = 1 as an alignment and reddens exactly here.
+    CHECK(phys > pin && (phys & (0x200000ull - 1)) == 0,
           "the physical offset honours the 2 MiB alignment the guest asked for in a3");
+    CHECK(phys >= dirty && phys + 0x40000ull <= dirty + kDirtyLen,
+          "...and the pool's first 256 KiB lands inside the range the scratch block dirtied, so "
+          "the zero arm below can actually fail");
 
     // ---- record, submit, wait, and then actually use the memory -----------------------------
     constexpr uint64_t kCb = 0x7f0000030000ull;
@@ -151,14 +212,33 @@ int main() {
     CHECK(amm_wait(slots[0], 0, 0, 0, 0, 0) == 0,
           "WaitCommandBufferCompletion accepts the id the submit handed out");
 
-    // The whole point: the guest can use the page. Fresh direct memory reads back zero on hardware.
+    // The whole point: the guest can use the page. Fresh direct memory reads back zero on hardware,
+    // and this range was filled with 0xa5 and released above, so a pool that skips the punch shows
+    // it here rather than reading zero from an untouched file.
     volatile uint64_t* mapped = (volatile uint64_t*)(uintptr_t)window_base;
-    CHECK(mapped[0] == 0 && mapped[(kMapLen / 8) - 1] == 0,
-          "the mapped range reads back zero across its whole length");
+    bool all_zero = true;
+    for (uint64_t i = 0; i < kMapLen / 8; ++i)
+        if (mapped[i] != 0) { all_zero = false; break; }
+    CHECK(all_zero,
+          "the mapped range reads back zero across its whole length, over physical memory that "
+          "held 0xa5 before it was released");
     mapped[0] = 0x0123456789abcdefull;
     mapped[(kMapLen / 8) - 1] = 0xfedcba9876543210ull;
     CHECK(mapped[0] == 0x0123456789abcdefull && mapped[(kMapLen / 8) - 1] == 0xfedcba9876543210ull,
           "the mapped range is writable and reads back what was written");
+
+    // ---- the window declines lazy commit ------------------------------------------------------
+    // Without this, the window is not inert: exec_image_linux.cpp's SIGSEGV handler backs any touch
+    // of a tracked-but-uncommitted range above 0x1000000000 with a 64 KiB anonymous page, which
+    // would turn every REFUSED map below into a silent substitution the guest cannot detect (it
+    // does not test Map's return value). State 3 is what declines it. Raised in review.
+    CHECK(prosper_reserved_range_state(window_base + kMapLen) == 3,
+          "an unmapped page of the AMM window declines lazy commit, so a refused map faults at the "
+          "guest's own address instead of being backed with anonymous memory");
+    CHECK(prosper_reserved_range_state(window_end - 0x4000) == 3,
+          "...at the far end of the window too");
+    CHECK(prosper_reserved_range_state(window_base) == 2,
+          "...while a page this run actually mapped reads as committed");
 
     // ---- the corruption guard ---------------------------------------------------------------
     // A map whose target is OUTSIDE the window must be refused as a BAD ADDRESS, before any

--- a/prosper/tests/hle/memory/test_ampr_amm.cpp
+++ b/prosper/tests/hle/memory/test_ampr_amm.cpp
@@ -1,0 +1,190 @@
+// libSceAmpr AMM (asynchronous memory manager) — the seven NIDs Yakuza Kiwami (PPSA31334) drives
+// its entire game heap through (#2864).
+//
+// What this protects, and why an unimplemented AMM is not a harmless stub. Every one of these NIDs
+// fell to the dispatcher's return-0 default, which for a VALUE-RETURNING contract is not "nothing
+// happened": three of them have OUT-PARAMETERS the guest reads back. The one that matters is
+// sceAmprAmmGetVirtualAddressRanges — the guest's AMM initialiser (eboot+0xdbf390) reaches it on a
+// path that does not pre-zero its four-quadword struct, so a handler that returns 0 and writes
+// nothing hands the allocator STACK RESIDUE as its virtual-address window. PPSA31334 then walked
+// that window and died at 0.0 s: `movq $0x0,(%r12)` at eboot+0xdbc0f8, SIGSEGV at 0x1d0000.
+//
+// So the arms below are about the two directions that can go wrong:
+//   * WRITE the out-parameters. `poison_survives` is the pre-fix behaviour, byte for byte.
+//   * Never write OUTSIDE the window prosper reserved for AMM. A half-right AMM that maps where the
+//     guest asks would MAP_FIXED over live guest memory, which is the #88 / #107 corruption class —
+//     silent, and surfacing hours later somewhere unrelated.
+//
+// The window's own dimensions are asserted against the GUEST's gate, not against prosper's
+// constant: the initialiser keeps min(requested, span - 4 GiB) and refuses to use the heap at all
+// unless that is at least 0x8020 bytes (eboot+0xdbf571). Asserting the guest's inequality rather
+// than kAmmWindowSize means resizing the window stays legal and shrinking it below what the guest
+// can use does not.
+#include "hle/dispatch/dispatch.hpp"
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { std::printf("  [ok]   %s\n", m); } } while (0)
+
+namespace {
+constexpr uint64_t kPoison  = 0xdeadbeefdeadbeefull;   // what "wrote nothing" looks like
+constexpr uint32_t kPoison32 = 0xdeadbeefu;
+constexpr uint64_t kEinval  = 0x80020016ull;           // SCE_KERNEL_ERROR_EINVAL
+constexpr uint64_t kEagain  = 0x80020010ull;           // the guest's retry sentinel — never return it
+constexpr uint64_t kFourGiB = 0x100000000ull;
+}
+
+int main() {
+    std::printf("== test_ampr_amm ==\n");
+    register_builtin_hle();
+
+    // sceAmprCommandBufferGetBufferBaseAddress is the generic accessor and is registered on every
+    // platform; the six AMM entry points map guest pages and are POSIX-only for now (the Windows
+    // arm's mapping primitives are a separate implementation). If this guard ever becomes
+    // unnecessary, delete it — that is what "Windows AMM landed" looks like.
+    HleFn set_buffer  = Hle::lookup("N-FSPA4S3nI");
+    HleFn get_base    = Hle::lookup("RPCAhx-aabE");
+    CHECK(set_buffer != nullptr, "sceAmprCommandBufferSetBuffer is registered");
+    CHECK(get_base != nullptr,   "sceAmprCommandBufferGetBufferBaseAddress is registered");
+
+    if (set_buffer && get_base) {
+        // BUFFER flavor (a3 == a1): "this buffer already exists, just attach it". Deliberately not
+        // the map flavor — this test is about the accessor, and the map flavor would ask the host
+        // to place a mapping over the test's own storage.
+        constexpr uint64_t kCb   = 0x7f0000010000ull;
+        constexpr uint64_t kBuf  = 0x7f0000020000ull;
+        constexpr uint64_t kSize = 0x40000ull;
+        set_buffer(kCb, kBuf, kSize, kBuf, 0, 3);
+        CHECK(get_base(kCb, 0, 0, 0, 0, 0) == kBuf,
+              "GetBufferBaseAddress returns the buffer SetBuffer attached");
+        CHECK(get_base(kCb + 0x1000, 0, 0, 0, 0, 0) == 0,
+              "GetBufferBaseAddress answers 0 for a command buffer with no buffer attached");
+    }
+
+#if defined(__linux__) || defined(__APPLE__)
+    HleFn get_ranges  = Hle::lookup("wkQR9+xTFKY");
+    HleFn give_dmem   = Hle::lookup("Q07J7XpvhrU");
+    HleFn amm_ctor    = Hle::lookup("EDq5bqCqYpA");
+    HleFn amm_map     = Hle::lookup("JEVYGhDc97M");
+    HleFn amm_submit  = Hle::lookup("OJf3vCckPAM");
+    HleFn amm_wait    = Hle::lookup("HXymib4T8gc");
+    CHECK(get_ranges && give_dmem && amm_ctor && amm_map && amm_submit && amm_wait,
+          "all six libSceAmpr AMM NIDs are registered");
+    if (!(get_ranges && give_dmem && amm_ctor && amm_map && amm_submit && amm_wait)) {
+        std::printf("%s\n", fails ? "FAILED" : "PASSED");
+        return fails ? 1 : 0;
+    }
+
+    // ---- the window ------------------------------------------------------------------------
+    // Four out-parameters, pre-filled with residue exactly as the guest's stack slots are.
+    uint64_t ranges[4] = { kPoison, kPoison, kPoison, kPoison };
+    CHECK(get_ranges((uint64_t)&ranges[0], (uint64_t)&ranges[1],
+                     (uint64_t)&ranges[2], (uint64_t)&ranges[3], 0, 0) == 0,
+          "GetVirtualAddressRanges succeeds");
+    CHECK(ranges[0] != kPoison && ranges[1] != kPoison,
+          "GetVirtualAddressRanges WRITES the window start and end (the pre-fix defect: it did not)");
+    CHECK(ranges[2] == 0 && ranges[3] == 0,
+          "GetVirtualAddressRanges leaves no residue in the two out-parameters it cannot name");
+    // Stop here rather than carry a poisoned window into the arms below. Without this the
+    // no-write mutation does not FAIL the test, it SIGBUSes it on `mapped[0]` — which ctest scores
+    // as a failure either way, but which reports a crash where the actual finding is "the handler
+    // did not write its out-parameter". An instrument should say what it found.
+    if (ranges[0] == kPoison || ranges[1] == kPoison) {
+        std::printf("  [stop]  the window out-parameters were not written; the arms below would "
+                    "dereference residue\n");
+        std::printf("FAILED\n");
+        return 1;
+    }
+    const uint64_t window_base = ranges[0], window_end = ranges[1];
+    CHECK(window_base != 0 && window_end > window_base, "the window is a real, non-empty range");
+    CHECK(window_end - window_base > kFourGiB + 0x8020ull,
+          "the window clears the guest's own usability gate (span - 4 GiB >= 0x8020, eboot+0xdbf571)");
+
+    uint64_t again[4] = { kPoison, kPoison, kPoison, kPoison };
+    get_ranges((uint64_t)&again[0], (uint64_t)&again[1], (uint64_t)&again[2], (uint64_t)&again[3], 0, 0);
+    CHECK(again[0] == window_base && again[1] == window_end,
+          "the window is stable across calls (the guest caches r0 and classifies pointers against it)");
+
+    // ---- the physical pool -----------------------------------------------------------------
+    // Shape taken verbatim from the live call under PROSPER_AMPRLOG:
+    //   Q07J7XpvhrU a0=0x0 a1=0x400000000 a2=0x280000000 a3=0x200000 a4=0x1 a5=<out>
+    // i.e. (searchStart, searchEnd, len, ALIGNMENT, MEMORY TYPE, off_t* out) — the kernel
+    // allocator's order. A smaller len keeps the test from claiming the whole pool.
+    constexpr uint64_t kPoolLen = 0x1000000ull;   // 16 MiB
+    uint64_t phys = kPoison;
+    CHECK(give_dmem(0, 16ull << 30, kPoolLen, 0x200000, 1, (uint64_t)&phys) == 0,
+          "GiveDirectMemory claims a physical pool");
+    CHECK(phys != kPoison && phys != 0,
+          "GiveDirectMemory WRITES the physical offset out-parameter");
+    // The alignment argument is honoured, which is the arm that separates the two readings of
+    // a3/a4: with them swapped, a3 = 1 is rejected as an alignment and the carve falls back to the
+    // 16 KiB granule, so a 2 MiB-aligned offset stops being guaranteed. (a4 = 1 as an alignment
+    // would be rejected too, so this cannot pass by accident either way round.)
+    CHECK((phys & (0x200000ull - 1)) == 0,
+          "the physical offset honours the 2 MiB alignment the guest asked for in a3");
+
+    // ---- record, submit, wait, and then actually use the memory -----------------------------
+    constexpr uint64_t kCb = 0x7f0000030000ull;
+    amm_ctor(kCb, 0, 0, 0, 0, 0);
+    constexpr uint64_t kMapLen = 0x40000ull;      // 256 KiB
+    CHECK(amm_map(kCb, window_base, kMapLen, 0xb, 0xc3, 0) == 0,
+          "AmmCommandBufferMap accepts a target inside the window");
+
+    // Two ADJACENT dwords, because that is what the guest passes: it hands p1 = &state+0xed34 and
+    // p2 = &state+0xed30 and reads the completion id back with a 32-bit load. Passing a3 = 0 here
+    // leaves the neighbour poisoned on purpose: a 64-bit store of the id through p2 would erase it,
+    // and that is precisely the mistake this arm exists to catch.
+    volatile uint32_t slots[2] = { kPoison32, kPoison32 };
+    const uint64_t submit_rc = amm_submit(/*bufferBase=*/0x7f0000020000ull, /*usedBytes=*/0x20,
+                                          /*flags=*/0, /*p1=*/0, (uint64_t)&slots[0], 0);
+    CHECK(submit_rc != kEagain,
+          "SubmitCommandBuffer2 never answers EAGAIN (the guest spins on it, sleeping a second a turn)");
+    CHECK(slots[0] != kPoison32 && slots[0] != 0,
+          "SubmitCommandBuffer2 WRITES a nonzero completion id through its last out-parameter");
+    CHECK(slots[1] == kPoison32,
+          "the completion-id store is 32 bits wide and does not reach the adjacent dword");
+    CHECK(amm_wait(slots[0], 0, 0, 0, 0, 0) == 0,
+          "WaitCommandBufferCompletion accepts the id the submit handed out");
+
+    // The whole point: the guest can use the page. Fresh direct memory reads back zero on hardware.
+    volatile uint64_t* mapped = (volatile uint64_t*)(uintptr_t)window_base;
+    CHECK(mapped[0] == 0 && mapped[(kMapLen / 8) - 1] == 0,
+          "the mapped range reads back zero across its whole length");
+    mapped[0] = 0x0123456789abcdefull;
+    mapped[(kMapLen / 8) - 1] = 0xfedcba9876543210ull;
+    CHECK(mapped[0] == 0x0123456789abcdefull && mapped[(kMapLen / 8) - 1] == 0xfedcba9876543210ull,
+          "the mapped range is writable and reads back what was written");
+
+    // ---- the corruption guard ---------------------------------------------------------------
+    // A map whose target is OUTSIDE the window must be refused as a BAD ADDRESS, before any
+    // physical page is carved and before the host is asked to place anything. The error code is
+    // load-bearing: EINVAL says "not your address", and it is the answer that disappears if the
+    // window check is deleted — the host mapping layer's own no-clobber refusal further down
+    // reports ENOMEM instead, so the two are distinguishable and this arm can tell them apart.
+    static uint64_t live[0x10000 / sizeof(uint64_t)];
+    for (size_t i = 0; i < sizeof live / sizeof live[0]; ++i) live[i] = 0xa5a5a5a5a5a5a5a5ull;
+    const uint64_t outside = ((uint64_t)(uintptr_t)live + 0x3fff) & ~0x3fffull;
+    CHECK(amm_map(kCb, outside, 0x4000, 0xb, 0xc3, 0) == kEinval,
+          "a map OUTSIDE the AMM window is refused as EINVAL, not attempted");
+    bool intact = true;
+    for (size_t i = 0; i < sizeof live / sizeof live[0]; ++i)
+        if (live[i] != 0xa5a5a5a5a5a5a5a5ull) { intact = false; break; }
+    CHECK(intact, "the refused target's contents are untouched");
+
+    CHECK(amm_map(kCb, window_base + 1, kMapLen, 0xb, 0xc3, 0) == kEinval,
+          "a misaligned map target is refused as EINVAL");
+    CHECK(amm_map(kCb, window_base, kMapLen + 1, 0xb, 0xc3, 0) == kEinval,
+          "a map length that is not a 16 KiB multiple is refused as EINVAL");
+#else
+    std::printf("  [skip] the six AMM entry points are POSIX-only for now (see the registration "
+                "site in hle_kernel_mem.cpp)\n");
+#endif
+
+    std::printf("%s\n", fails ? "FAILED" : "PASSED");
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/hle/memory/test_ampr_amm.cpp
+++ b/prosper/tests/hle/memory/test_ampr_amm.cpp
@@ -170,11 +170,20 @@ int main() {
     }
     release_dmem(dirty, kDirtyLen, 0, 0, 0, 0);
 
+    constexpr uint64_t kPoolLen = 0x1000000ull;   // 16 MiB
+    // A call that cannot deliver its result must not report success — and must not consume the pool
+    // on the way to saying so. Both halves matter: the return value alone would still let a handler
+    // take the memory first and refuse afterwards, which is how the guest ends up owning a pool it
+    // was never told the address of. The second half is checked by the arms that follow: if this
+    // call had consumed 16 MiB and published it, the real GiveDirectMemory below would be refused
+    // as a non-contiguous second pool and every arm after it would redden. Raised in review.
+    CHECK(give_dmem(0, 16ull << 30, kPoolLen, 0x200000, 1, /*out=*/0) == kEinval,
+          "GiveDirectMemory refuses a call with no out-parameter instead of reporting success");
+
     // Shape taken verbatim from the live call under PROSPER_AMPRLOG:
     //   Q07J7XpvhrU a0=0x0 a1=0x400000000 a2=0x280000000 a3=0x200000 a4=0x1 a5=<out>
     // i.e. (searchStart, searchEnd, len, ALIGNMENT, MEMORY TYPE, off_t* out) — the kernel
     // allocator's order. A smaller len keeps the test from claiming the whole pool.
-    constexpr uint64_t kPoolLen = 0x1000000ull;   // 16 MiB
     uint64_t phys = kPoison;
     CHECK(give_dmem(0, 16ull << 30, kPoolLen, 0x200000, 1, (uint64_t)&phys) == 0,
           "GiveDirectMemory claims a physical pool");
@@ -211,6 +220,17 @@ int main() {
           "the completion-id store is 32 bits wide and does not reach the adjacent dword");
     CHECK(amm_wait(slots[0], 0, 0, 0, 0, 0) == 0,
           "WaitCommandBufferCompletion accepts the id the submit handed out");
+    // The same rule for the submit's own out-parameter: no slot to write the completion id into
+    // means the guest would wait on residue, so this refuses rather than answering SCE_OK. And it
+    // must not answer EAGAIN either — that is the retry sentinel the guest spins on.
+    const uint64_t no_slot_rc = amm_submit(0x7f0000020000ull, 0x20, 0, 0, /*outCompletionId=*/0, 0);
+    CHECK(no_slot_rc == kEinval,
+          "SubmitCommandBuffer2 refuses a call with no completion-id out-parameter");
+    CHECK(no_slot_rc != kEagain, "...and does not answer with the guest's retry sentinel");
+    uint64_t ranges_bad[2] = { kPoison, kPoison };
+    CHECK(get_ranges(0, (uint64_t)&ranges_bad[1], 0, 0, 0, 0) == kEinval &&
+              ranges_bad[1] == kPoison,
+          "GetVirtualAddressRanges refuses a call with no out-parameter for the window base");
 
     // The whole point: the guest can use the page. Fresh direct memory reads back zero on hardware,
     // and this range was filled with 0xa5 and released above, so a pool that skips the punch shows
@@ -231,11 +251,13 @@ int main() {
     // Without this, the window is not inert: exec_image_linux.cpp's SIGSEGV handler backs any touch
     // of a tracked-but-uncommitted range above 0x1000000000 with a 64 KiB anonymous page, which
     // would turn every REFUSED map below into a silent substitution the guest cannot detect (it
-    // does not test Map's return value). State 3 is what declines it. Raised in review.
-    CHECK(prosper_reserved_range_state(window_base + kMapLen) == 3,
+    // does not test Map's return value). State 4 is what declines it — 4 and not 3, because 3 is
+    // the Windows arm's "committed sparse direct page", a sub-case of a different parent. Both
+    // points raised in review.
+    CHECK(prosper_reserved_range_state(window_base + kMapLen) == 4,
           "an unmapped page of the AMM window declines lazy commit, so a refused map faults at the "
           "guest's own address instead of being backed with anonymous memory");
-    CHECK(prosper_reserved_range_state(window_end - 0x4000) == 3,
+    CHECK(prosper_reserved_range_state(window_end - 0x4000) == 4,
           "...at the far end of the window too");
     CHECK(prosper_reserved_range_state(window_base) == 2,
           "...while a page this run actually mapped reads as committed");

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -334,11 +334,25 @@ int main(int argc, char** argv) {
            (unsigned long long)r.rdx, (unsigned long long)r.rbp, (unsigned long long)r.rsp);
     printf("  backtrace (%zu frames):\n", r.backtrace.size());
     for (uint64_t a : r.backtrace) printf("    %-12s +0x%llx\n", cls(a), (unsigned long long)bof(a));
-    // Classify the fault address vs our tracked guest mappings (0=untracked/gap, 1=reserved-uncommitted,
-    // 2=committed). A write at a page boundary whose predecessor byte is committed but which is itself
-    // reserved/untracked pinpoints a guest run-off-the-end-of-a-region (Windows memory-model diagnosis).
+    // Classify the fault address vs our tracked guest mappings. A write at a page boundary whose
+    // predecessor byte is committed but which is itself reserved/untracked pinpoints a guest
+    // run-off-the-end-of-a-region (Windows memory-model diagnosis).
+    //
+    // Every state prosper_reserved_range_state can return is named here. It used to name three of
+    // them and fold the rest into "untracked/gap", which is the worst possible default for a
+    // fault-diagnosis tool: it reports the OPPOSITE of what happened (the range is tracked) and it
+    // did so for the Windows arm's sparse-direct-page state as well as for the AMM decline. Both of
+    // those are states a fault is LIKELY to land in, which is the whole reason they exist.
     if (r.kind == 2 && r.fault_addr) {
-        auto st = [](int s){ return s==2?"committed":s==1?"reserved":"untracked/gap"; };
+        auto st = [](int s){
+            switch (s) {
+                case 1: return "reserved";
+                case 2: return "committed";
+                case 3: return "committed(sparse-direct, awaiting host commit)";
+                case 4: return "reserved(declines lazy commit -- libSceAmpr AMM window)";
+                default: return "untracked/gap";
+            }
+        };
         printf("  [memclass] fault_addr=%s  fault_addr-8=%s  fault_addr-0x1000=%s\n",
                st(prosper_reserved_range_state(r.fault_addr)),
                st(prosper_reserved_range_state(r.fault_addr - 8)),


### PR DESCRIPTION
Implements the seven `libSceAmpr` AMM (memory-manager) entry points *Yakuza Kiwami* (`PPSA31334`)
needs. Scope is exactly those seven; the two AMM NIDs left out are named below and in the code.

Refs #2864.

## The failure

A default boot died **0.0 s** in:

```
[shot] guest thread ended: kind=2 detail=SIGSEGV at addr=0x1d0000 rip=0x410dbc0f8 (image+0xdbc0f8)
0/24 screenshots, stop=guest-fault
```

`0x1d0000` is far too low to be a guest pointer, which is the tell. AMM is the **memory-mapping**
sibling of the APR file reader prosper already implements — the same command-buffer construct
pointed at pages instead of bytes — and this title runs its *entire game heap* through it: it asks
AMM for up to `0x8000000000` (512 GiB) of address space, hands it `0x280000000` (10 GiB) of direct
memory, and maps `0x10000`–`0x240000` chunks in on demand for the rest of the run.

All seven entry points fell to the dispatcher's return-0 default. For a value-returning contract
that is not "nothing happened": **three of them have out-parameters the guest reads back.** The one
that killed it is `sceAmprAmmGetVirtualAddressRanges`. The guest's AMM initialiser
(`eboot+0xdbf390`) reaches that call on a path that does **not** pre-zero its four-quadword struct —
the zeroing sits inside a branch this boot skips — so "returned 0 and wrote nothing" meant the
allocator took its virtual-address window from **stack residue** and walked it. The faulting
instruction, `movq $0x0,(%r12)`, is that walk.

## What is implemented

| NID | name | note |
| --- | --- | --- |
| `wkQR9+xTFKY` | `sceAmprAmmGetVirtualAddressRanges` | reserves and reports a 68 GiB window |
| `Q07J7XpvhrU` | `sceAmprAmmGiveDirectMemory` | claims AMM's physical pool from the dmem allocator |
| `EDq5bqCqYpA` | `sceAmprAmmCommandBufferConstructor` | one argument — see below |
| `JEVYGhDc97M` | `sceAmprAmmCommandBufferMap` | performs the map at record time |
| `OJf3vCckPAM` | `sceAmprAmmSubmitCommandBuffer2` | hands back a completion id |
| `HXymib4T8gc` | `sceAmprAmmWaitCommandBufferCompletion` | submit == complete, so a no-op |
| `RPCAhx-aabE` | `sceAmprCommandBufferGetBufferBaseAddress` | generic accessor; **registered on both platform arms** |

Maps are executed at **record** time, exactly as prosper serves APR reads at append time, so submit
== complete and the wait is already satisfied when it is made.

## How the argument layouts were derived — and one they corrected

The 3.20 firmware database gives **names and NIDs only**. Every layout here comes from the guest:
the SDK's inline wrappers at `eboot+0xcc4bb0..0xcc4ca0` fix the low-level order (e.g. the Submit
wrapper calls `GetBufferBaseAddress` and `GetCurrentOffset` itself, which is *why*
`GetBufferBaseAddress` had to be implemented — the return-0 default handed the kernel a null command
stream), and a live `PROSPER_AMPRLOG=1` run confirmed all seven.

That live run also **corrected** one I had inferred wrongly from disassembly alone:

```
[amprlog] Q07J7XpvhrU(AmmGiveDirectMemory) a0=0x0 a1=0x400000000 a2=0x280000000 a3=0x200000 a4=0x1 a5=…
```

`a3` is the **alignment** and `a4` the **memory type** — `sceKernelAllocateDirectMemory`'s own
order. Read the other way round it produced a "memory type" of 2,097,152 and dropped the guest's
2 MiB alignment to 16 KiB. The `[amm]` pool line prints both so this stays visible rather than
inferred, and a test arm asserts the alignment is honoured.

Two other things the live log settled:

* `AmmCommandBufferMap`'s `a3` really is a memory type (constant `0xb`; the variable form computes
  `0xb + (x & 7)` at `eboot+0xd9f7cc`) and `a4` a protection (`0xc3`, and `0xf3` = `0xc3 | 0x30`,
  the GPU read/write pair).
* The guest read back exactly the `u32` completion ids we wrote — `Wait` was called with `1, 2, 3,
  4, 5, 6…` in order — which is the end-to-end confirmation that the id contract is right.

## The invariant that keeps a half-right AMM from corrupting the guest

**A map is refused unless it lands inside the window prosper itself reserved for AMM.** That window
is a `PROT_NONE` reservation prosper tracks as *uncommitted*, so `map_phys_at`'s no-clobber
discipline (#137, and the clobbers it exists to stop — #88, #107) **independently** refuses to place
a mapping anywhere else. Two guards, either of which alone turns a wrong VA into a loud refusal
rather than a `MAP_FIXED` over live guest memory. There is a test arm for each, and they are
distinguishable: out-of-window answers `EINVAL` ("not your address"), while the host layer's own
refusal answers `ENOMEM`.

Everything is **lazy**: the window is reserved on the first AMM call, so a title that never touches
AMM sees no change at all.

## Behaviour changed for titles other than PPSA31334 — one item, stated plainly

`RPCAhx-aabE` was previously unimplemented (returned 0) and is now answered from the buffer
`sceAmprCommandBufferSetBuffer` attached. Scanning the import tables of the dumps on this box:

* **No guarded rung-6 title imports it** — Messenger `PPSA24651`, Dead Cells `PPSA15552`,
  Blasphemous 2 `PPSA13579`, Alex Kidd `PPSA02664`, Blue Prince `PPSA25009`, GRIS `PPSA09804`,
  Cobra `PPSA17337`: none.
* **Four non-guarded titles do**: `PPSA17942` (DOLL/UE4), `PPSA04263` (GTA V), `PPSA03026` (The
  Forgotten City), `PPSA03831` (Sonic Frontiers).

For those four the answer changes only where `SetBuffer` was actually called for that command
buffer — i.e. exactly where 0 was a lie. **I did not run them**: the task explicitly restricted this
lane to `PPSA31334` while another lane was smoke-testing `PPSA03130`, so this is the one thing in
this PR I could not verify by running, and I would rather say so than imply coverage I do not have.

## Verification

Built in the `ps5ys` distrobox with `TMPDIR` off the tmpfs, `-j6`, `-DPROSPER_APP=ON`,
`-DGAME_DUMP=<REPO_ROOT>/testdata/PPSA24651-app0`. CMake reported
`Vulkan found (/usr/lib64/libvulkan.so) — offscreen graphics harness enabled`, so the Vulkan
execution tests ran (`real_shader_render`, `gpu_execute`, `rdna2_to_spirv_exec` all present and
passing), and the dump is the Messenger's so **nothing was skipped**.

```
ctest -N                                   -> Total Tests: 294
ctest --no-tests=error -j4 --output-on-failure
                                           -> 100% tests passed out of 294, exit 0
                                              (#154 ampr_amm among them)
git diff --check                           -> clean
git ls-files '*.md' -z | xargs -0 python3 prosper/tools/docs/check_numbered_table.py -> exit 0
```

### The boot, both directions, one variable

Same command, and the two builds differ by exactly one thing — whether the seven NIDs are
registered:

```
PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
    build-linux/screenshot <DUMP_ROOT>/PPSA31334-app0 --seconds 5 --count 24 --out ~/yak-work
```

| | registrations reverted | this PR |
| --- | --- | --- |
| unimplemented AMPR calls | 7 | 0 |
| fault | `SIGSEGV addr=0x1d0000 rip=eboot+0xdbc0f8` | `SIGSEGV addr=0x1d4 rip=eboot+0x6ecf6` |
| time of death | 0.0 s | 0.1 s |
| reached | nothing | save-data init, then asset loading |
| AMM work served | none | 68 GiB window, 10 GiB pool, 23 maps |

The "before" column is **measured, not quoted from the brief** — I reverted the registrations,
rebuilt, and reproduced `0x1d0000` exactly.

### Regression test and its mutation arms

`prosper/tests/hle/memory/test_ampr_amm.cpp`, 25 checks, driven through `Hle::lookup` — no guest
needed. It maps a real page inside the window and writes to it, so it exercises the whole path
rather than the return values.

Each arm was shown to fail for its own reason, by mutating that behaviour alone and rebuilding:

| mutation | what reddens |
| --- | --- |
| `GetVirtualAddressRanges` stops writing `r0`/`r1` (the exact pre-fix semantic) | *"GetVirtualAddressRanges WRITES the window start and end"* |
| delete the window-containment check | *"a map OUTSIDE the AMM window is refused as EINVAL"* — the host layer still refuses, so memory stays intact, but the answer degrades to `ENOMEM` |
| widen the completion-id store to 64 bits | *"the completion-id store is 32 bits wide and does not reach the adjacent dword"* |
| revert the seven `register_fn` calls | the two registration arms |

The first mutation originally **SIGBUSed** the test instead of failing it — it dereferenced the
poisoned window — so the test now stops with a message when the out-parameters were not written.
An instrument should say what it found.

## Deliberately not in this PR

* `M-VFI2DJWQA` `sceAmprAmmCommandBufferUnmap` and `pvUFDOHilnE`
  `sceAmprAmmCommandBufferDestructor` — **#2873**. Unmap's absence *leaks* (the VA stays mapped and
  its pages stay carved out of the pool's bump cursor). Bounded and **named** —
  `[amm] REFUSED map: AMM's own direct-memory pool is exhausted` — rather than silent, which is why
  a boot proceeds without it. Implementing it means giving the pool a real free list, which is a
  change with its own evidence and its own review.
* `libkernel::tU5e3f9gSiU` — **not in any of the 275 libraries of the 3.20 dump**, so it gets no
  invented name and stays unimplemented. From its use it is a *hardware-tier query*: three call
  sites treat the result as a boolean, one selects between scale factors 1.4 and 1.2 on a 3840×2160
  output, and another gates a block that adds 1.1875 GiB of budget. Returning 0 picks the **lower**
  tier, which is the conservative direction — but note it is *not* free: it is also what makes the
  guest skip the pre-init block that would otherwise have zeroed the struct above.
* Windows. The six AMM handlers map guest pages and the Windows arm's mapping primitives are a
  separate implementation needing its own evidence; leaving them on the return-0 default keeps
  Windows exactly as it was. The portable half — recording `SetBuffer`'s attachment and answering
  `GetBufferBaseAddress` — **is** done on both arms, per #1970's rule that a fact about the guest's
  object must not depend on the host.

## Result

`PPSA31334` stays at **rung 0** — no frames. What moved is that the fault left the memory allocator
and reached the asset loader: `sceAmprAprCommandBufferReadFileGatherScatter` is unimplemented
(**#2872**), so `Failed!! Load Devil2 Shader Archive`, so a method runs on a null `this`. `BLOG.md`
carries the finding as an image-less entry per #2852.
