### PR TITLE
compat: onboard Metaphor: ReFantazio (PPSA20800) — Atlus GFD, and a third string-census false positive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 41 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 42 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -66,6 +66,7 @@ Last updated: 2026-08-17
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Opening dive gameplay aboard the science ship | [#1898](https://github.com/mattias800/prosper/issues/1898) |
 | *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2864](https://github.com/mattias800/prosper/issues/2864) |
 | *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Rung 0 — boots in 91 ms and drives a 4K present loop at ~21 flips/s, but every frame is black: no pass produces a present source ([#2871](https://github.com/mattias800/prosper/issues/2871)). The boot deadlock in a preloaded PRX the title never imports is fixed | [#2867](https://github.com/mattias800/prosper/issues/2867) |
+| *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2876](https://github.com/mattias800/prosper/issues/2876) |
 
 ## At a glance
 
@@ -86,7 +87,7 @@ land here first.
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
 | **Not yet booted** — dump present, never run | 2 |
-| Total tracked | 41 |
+| Total tracked | 42 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -154,6 +154,7 @@ of its manifest.
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Sonic Origins | `PPSA05325` | 1 | `1-----` | - | - | none | [#2267](https://github.com/mattias800/prosper/issues/2267), [#2731](https://github.com/mattias800/prosper/issues/2731), [#1905](https://github.com/mattias800/prosper/issues/1905), [#1720](https://github.com/mattias800/prosper/issues/1720) | [#1871](https://github.com/mattias800/prosper/issues/1871) | [`GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) |
 | ArcRunner | `PPSA21406` | 0 | `------` | - | - | none | [#1226](https://github.com/mattias800/prosper/issues/1226), [#2084](https://github.com/mattias800/prosper/issues/2084) | [#1817](https://github.com/mattias800/prosper/issues/1817) | [`ARCRUNNER_STATUS.md`](prosper/docs/ARCRUNNER_STATUS.md) |
+| Metaphor: ReFantazio | `PPSA20800` | 0 | `------` | none | - | none | - | [#2876](https://github.com/mattias800/prosper/issues/2876) | - |
 | Sniper Ghost Warrior Contracts 2 | `PPSA03130` | 0 | `------` | none | - | none | - | [#2867](https://github.com/mattias800/prosper/issues/2867) | - |
 | Yakuza Kiwami | `PPSA31334` | 0 | `------` | none | - | none | - | [#2864](https://github.com/mattias800/prosper/issues/2864) | - |
 
@@ -166,8 +167,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 3 |
+| 0 -- not started | 4 |
 
-**4 of 41** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 42** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.


### PR DESCRIPTION
Third of ten new dumps, and the largest yet at **71 GB**. Onboards **Metaphor: ReFantazio
(`PPSA20800`)** — tracker **#2876**, `COMPATIBILITY.md` row, regenerated `PROGRESS_TRACKER.md`,
count 41 → 42.

Not booted. Everything recorded is derived from the dump's bytes.

## Engine: Atlus GFD, derived from its own source-tree paths

```
..\..\..\gfd\include\../../framework/TPL/TPL/GenericLibrary/STL/TPLStlAllocate.h
GFD_PS5_H
COMMON/init/gfdDefaultEnvToon.dds
```

629 `GFD` strings against **zero** for Unreal, Unity, Havok, Wwise and Bink. The asset layout
agrees: 1567 `.ENV`, 134 `.bin`, 30 `.dds`, 4 `.GMD` (Atlus's model container).

**CRIWARE is genuinely present** — `CRIWARE/Compressor`, `CRIWARE/ChannelBinauralizer` — and
corroborated by asset types rather than strings alone: `.acb` / `.awb` (CRI ADX banks) and `.usm`
(CRI movie container).

That last point has direct consequences here: `.usm` and `.acb`/`.awb` are the paths behind
**#2731** (decoded video with chroma collapsed, `Cr == Cb`), **#2270** and **#1955**. Movie trouble
on this title should check those before being treated as new.

## The third string-census false positive in three onboardings

`FMOD` reports **113 hits** and this title does **not** use FMOD. Every one is `fldLayoutOfModel_*`
— *fldLayoutO**fMod**el*.

| onboarding | false positive | cause |
|---|---|---|
| Yakuza Kiwami | every pattern "present" | `grep -c` exits 1 on zero matches, so `\|\| echo 0` made the variable `"0\n0"` |
| SGW Contracts 2 | `Unity`, `FMOD` | `OnLocalPlayerImm**unity**On`, `**FMod**e:%d` |
| Metaphor | `FMOD` | `fldLayoutO**fMod**el_*` |

Three different mechanisms, one lesson, now recorded on the tracker: **a substring census must have
its hits read, never merely counted.** Each of these would have produced a confident wrong engine
attribution in a permanent record.

## Also in this diff

The *Sniper Ghost Warrior Contracts 2* row is left as its own lane rewrote it (it now boots in 91 ms
and drives a 4K present loop) — I only inserted the new row beneath it rather than touching it.

## Flagged, untested

`requiredSystemSoftwareVersion` is `0x1120…` — **SDK 11.20, below 13**, the same bracket as ArcRunner
and Crisis Core for the post-submit visibility contract (#2219). Unknown whether it bites here.

The tracker also carries the trap-214 warning for whoever boots it first: `screenshot --timeout`
cannot bound a boot, so wrap the run and quote which limit fired.

## Verification

```
gen_progress_tracker.py --check   -> exit 0   (42 trackers, 42 parsed)
check_numbered_table.py over .md  -> exit 0
git diff --check                  -> clean
CLAUDE.md "42 tracked titles" / COMPATIBILITY "Total tracked | 42" / 42 actual rows — all agree
```

Docs-only; merging under the documented exception. Refs #2876.
