### PR TITLE
docs: wording on compatibility

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -70,14 +70,14 @@ So a module preloaded for one title had been silently wedging another, and the f
 only when something actually imports it.
 
 Which raised the obvious question a reviewer asked and I had not: *how many titles does that change?*
-I had checked two. The answer is a census — of 47 dumps here, 42 ship that PRX, 40 keep it, and two
+I had checked two. The answer is a census — across the tracked titles, 42 ship that PRX, 40 keep it, and two
 lose it: this title, and **Sonic Frontiers**, which nobody had looked at and which has no snapshot
 guard to notice. It appears to be harmless (import resolution is by NID, and not one of the 41,638
 NIDs that module exports is imported by anything in Frontiers' link graph) but "appears to be" is the
 honest phrasing, and a confirming boot of Frontiers belongs to the lane that owns it. A flag on a
 shared list is never a two-title question.
 
-Behind that wall the title is still at rung 0, and honestly so. On the real dump with the fix in, it
+Behind that wall the title is still at rung 0, and honestly so. Unmodified, with the fix in, it
 boots in 91 ms, streams its assets, and drives a 4K present loop at ~21 flips a second — while prosper
 composites exactly nothing. Every sample is a raw guest scanout: one distinct colour, zero non-black
 pixels, `published_frames=0`. Two runs on two different trees agree, so it is not an artifact. The

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -64,9 +64,9 @@ Last updated: 2026-08-17
 | *The House of the Dead 2: Remake* | `PPSA24203` | — | 🚧 Training 1 gameplay | [#1896](https://github.com/mattias800/prosper/issues/1896) |
 | *Bendy and the Dark Revival* | `PPSA27624` | Unity / IL2CPP | 🚧 Chapter 1 gameplay; the menu's background video is not composited | [#1897](https://github.com/mattias800/prosper/issues/1897) |
 | *Beneath* | `PPSA27640` | Unity / IL2CPP | 🚧 Opening dive gameplay aboard the science ship | [#1898](https://github.com/mattias800/prosper/issues/1898) |
-| *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2864](https://github.com/mattias800/prosper/issues/2864) |
+| *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2864](https://github.com/mattias800/prosper/issues/2864) |
 | *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Rung 0 — boots in 91 ms and drives a 4K present loop at ~21 flips/s, but every frame is black: no pass produces a present source ([#2871](https://github.com/mattias800/prosper/issues/2871)). The boot deadlock in a preloaded PRX the title never imports is fixed | [#2867](https://github.com/mattias800/prosper/issues/2867) |
-| *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — dump added 2026-08-21, nothing run against it | [#2876](https://github.com/mattias800/prosper/issues/2876) |
+| *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — nothing run against it yet | [#2876](https://github.com/mattias800/prosper/issues/2876) |
 
 ## At a glance
 
@@ -76,17 +76,16 @@ ten of the twenty-four titles that reach gameplay are marked 🚧 rather than �
 three different states — two at different rungs, and one not yet run at all. Counting markers gives a
 different — and wrong — answer.
 
-**"Not yet booted" is a real category, not a rung.** A dump can be present and never measured, and
+**"Not yet booted" is a real category, not a rung.** A title can be tracked and never measured, and
 that is different from having been measured and found wanting. It is counted separately so an
-unmeasured title is never mistaken for a failing one — nine more dumps are arriving, and they will
-land here first.
+unmeasured title is never mistaken for a failing one; newly tracked titles start here.
 
 | Where the title stops | Titles |
 | --- | --- |
 | **Gameplay reached**, with the scene rendering (rung 3 or better) | 24 |
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
-| **Not yet booted** — dump present, never run | 2 |
+| **Not yet booted** — tracked, no run attempted yet | 2 |
 | Total tracked | 42 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.


### PR DESCRIPTION
Project-owner request: the public wording should be about **compatibility**, not about acquiring
game dumps.

Some of the per-title notes had drifted into reading like an acquisition log — *"dump added
2026-08-21"*, *"of 47 dumps here"*. That is the wrong subject for this repository irrespective of
the legal position, and the legal position is already stated where it belongs: `README.md` says
twice that you must supply your own legally-obtained dump, and `CLAUDE.md` carries the full
scope-and-legitimacy section.

## Reworded

| was | now |
|---|---|
| `Not yet booted — dump added 2026-08-21, nothing run against it` | `Not yet booted — nothing run against it yet` |
| `**Not yet booted** — dump present, never run` | `**Not yet booted** — tracked, no run attempted yet` |
| "A **dump can be present** and never measured" | "A **title can be tracked** and never measured" |
| "the answer is a census — **of 47 dumps here**, 42 ship that PRX" | "…**across the tracked titles**, 42 ship that PRX" |
| "On **the real dump** with the fix in, it boots in 91 ms" | "**Unmodified**, with the fix in, it boots in 91 ms" |

The three new tracker issues (#2864, #2867, #2876) were edited the same way — their opening lines no
longer carry an acquisition date, and their `Size` rows now read `Application size`, describing the
title rather than an inventory entry.

## Deliberately kept

- **"You must supply your own legally-obtained dump"** (README ×2) and **"user-supplied … dumps"**
  (README, COMPATIBILITY) — these are the *defensive* statements. Removing them would weaken the
  position, not strengthen it.
- **`<DUMP_ROOT>`** in commands — the charter's own path-sanitisation placeholder.
- `--dump` (a CLI flag) and `self_dump` (a tool that dumps SELF structure, unrelated).

## Verification

```
grep -iE 'dumps here|dump added|dump landed|dump arrived' over the user-facing docs  -> no hits
gen_progress_tracker.py --check   -> exit 0
check_numbered_table.py over .md  -> exit 0
git diff --check                  -> clean
```

Diff is `BLOG.md` and `COMPATIBILITY.md` only. Docs-only; merging under the documented exception.
