### PR TITLE
compat: onboard Judgment (PPSA02739) — shares Yakuza Kiwami's exact AMM blocker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 42 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 43 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -67,6 +67,7 @@ Last updated: 2026-08-17
 | *Yakuza Kiwami* | `PPSA31334` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2864](https://github.com/mattias800/prosper/issues/2864) |
 | *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Rung 0 — boots in 91 ms and drives a 4K present loop at ~21 flips/s, but every frame is black: no pass produces a present source ([#2871](https://github.com/mattias800/prosper/issues/2871)). The boot deadlock in a preloaded PRX the title never imports is fixed | [#2867](https://github.com/mattias800/prosper/issues/2867) |
 | *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — nothing run against it yet | [#2876](https://github.com/mattias800/prosper/issues/2876) |
+| *Judgment* | `PPSA02739` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2880](https://github.com/mattias800/prosper/issues/2880) |
 
 ## At a glance
 
@@ -85,8 +86,8 @@ unmeasured title is never mistaken for a failing one; newly tracked titles start
 | **Gameplay reached**, with the scene rendering (rung 3 or better) | 24 |
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
-| **Not yet booted** — tracked, no run attempted yet | 2 |
-| Total tracked | 42 |
+| **Not yet booted** — tracked, no run attempted yet | 3 |
+| Total tracked | 43 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -154,6 +154,7 @@ of its manifest.
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Sonic Origins | `PPSA05325` | 1 | `1-----` | - | - | none | [#2267](https://github.com/mattias800/prosper/issues/2267), [#2731](https://github.com/mattias800/prosper/issues/2731), [#1905](https://github.com/mattias800/prosper/issues/1905), [#1720](https://github.com/mattias800/prosper/issues/1720) | [#1871](https://github.com/mattias800/prosper/issues/1871) | [`GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) |
 | ArcRunner | `PPSA21406` | 0 | `------` | - | - | none | [#1226](https://github.com/mattias800/prosper/issues/1226), [#2084](https://github.com/mattias800/prosper/issues/2084) | [#1817](https://github.com/mattias800/prosper/issues/1817) | [`ARCRUNNER_STATUS.md`](prosper/docs/ARCRUNNER_STATUS.md) |
+| Judgment | `PPSA02739` | 0 | `------` | none | - | none | - | [#2880](https://github.com/mattias800/prosper/issues/2880) | - |
 | Metaphor: ReFantazio | `PPSA20800` | 0 | `------` | none | - | none | - | [#2876](https://github.com/mattias800/prosper/issues/2876) | - |
 | Sniper Ghost Warrior Contracts 2 | `PPSA03130` | 0 | `------` | none | - | none | - | [#2867](https://github.com/mattias800/prosper/issues/2867) | - |
 | Yakuza Kiwami | `PPSA31334` | 0 | `------` | none | - | none | - | [#2864](https://github.com/mattias800/prosper/issues/2864) | - |
@@ -167,8 +168,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 4 |
+| 0 -- not started | 5 |
 
-**4 of 42** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 43** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.


### PR DESCRIPTION
Fourth new title; **43 tracked**. Not booted — everything derived by static inspection.

## It shares *Yakuza Kiwami*'s exact blocker, compared by NID

Judgment imports **all seven** `libSceAmpr` AMM functions that kill Kiwami 0.0 s into boot:
`Constructor`, `Map`, `SubmitCommandBuffer2`, `WaitCommandBufferCompletion`, `GiveDirectMemory`, `GetVirtualAddressRanges`, `CommandBufferGetBufferBaseAddress`.

Compared by **NID, not library name** — imports resolve by NID, so a shared `libSceAmpr` string would prove nothing. `libSceAmpr` also appears in four of its bundled arcade PRXs, not only the eboot.

So **#2875 is expected to matter here too** — recorded on the tracker as a prediction from the import tables, explicitly **not** a measurement, since nobody has booted it.

## Engine

Ryu Ga Gotoku PAR-archive family (33 `.par` archives) with CRIWARE. Zero hits for Unreal, Unity, Havok, Wwise.

**"Dragon Engine" does not appear in the binary**, exactly as on Kiwami. Judgment is usually described as a Dragon Engine title, so the absence is stated rather than papered over — do not record an engine version the bytes do not evidence.

## It bundles other games as separate modules

`vf5fs/` and `m2ftg/` carry their own PS5 PRXs and asset trees (Virtua Fighter 5, Virtua Fighter 2, Fighting Vipers). Bring-up should note the rung applies to Judgment itself; a minigame rendering is a different milestone.

## Verification

```
gen_progress_tracker.py --check   -> exit 0  (43 trackers, 43 parsed)
check_numbered_table.py over .md  -> exit 0
CLAUDE.md 43 / COMPATIBILITY total 43 / 43 actual rows — agree
```

Docs-only. Refs #2880.