### PR TITLE
compat: track the six titles that were present but never onboarded (49 tracked)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ For anything title- or subsystem-specific, use the table in the next section rat
 
 ## Where the project stands (2026-08-17)
 
-`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 43 tracked titles
+`COMPATIBILITY.md` is authoritative for the **user-facing per-title milestones** — 49 tracked titles
 at this refresh. Do not duplicate its rung counts here; read it, then open the one doc named below for
 whatever you are about to touch. This section is a map, not a status report. Long-lived `tracker:game`
 issues and their comments carry each active title's current development rung, route, blockers and

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -68,6 +68,12 @@ Last updated: 2026-08-17
 | *Sniper Ghost Warrior Contracts 2* | `PPSA03130` | CryEngine | 🔬 Rung 0 — boots in 91 ms and drives a 4K present loop at ~21 flips/s, but every frame is black: no pass produces a present source ([#2871](https://github.com/mattias800/prosper/issues/2871)). The boot deadlock in a preloaded PRX the title never imports is fixed | [#2867](https://github.com/mattias800/prosper/issues/2867) |
 | *Metaphor: ReFantazio* | `PPSA20800` | Atlus GFD | 🔬 Not yet booted — nothing run against it yet | [#2876](https://github.com/mattias800/prosper/issues/2876) |
 | *Judgment* | `PPSA02739` | Ryu Ga Gotoku (PAR) | 🔬 Not yet booted — nothing run against it yet | [#2880](https://github.com/mattias800/prosper/issues/2880) |
+| *BALAN WONDERWORLD* | `PPSA02058` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2882](https://github.com/mattias800/prosper/issues/2882) |
+| *Stray* | `PPSA02101` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2883](https://github.com/mattias800/prosper/issues/2883) |
+| *Little Nightmares II* | `PPSA02154` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2884](https://github.com/mattias800/prosper/issues/2884) |
+| *Spacebase Startopia* | `PPSA02846` | Unity 2020.3.1 / IL2CPP | 🔬 Not yet booted — nothing run against it yet | [#2887](https://github.com/mattias800/prosper/issues/2887) |
+| *Sifu* | `PPSA03001` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2885](https://github.com/mattias800/prosper/issues/2885) |
+| *Unbound: Worlds Apart* | `PPSA03274` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2886](https://github.com/mattias800/prosper/issues/2886) |
 
 ## At a glance
 
@@ -86,8 +92,8 @@ unmeasured title is never mistaken for a failing one; newly tracked titles start
 | **Gameplay reached**, with the scene rendering (rung 3 or better) | 24 |
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
-| **Not yet booted** — tracked, no run attempted yet | 3 |
-| Total tracked | 43 |
+| **Not yet booted** — tracked, no run attempted yet | 9 |
+| Total tracked | 49 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -154,9 +154,15 @@ of its manifest.
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | Sonic Origins | `PPSA05325` | 1 | `1-----` | - | - | none | [#2267](https://github.com/mattias800/prosper/issues/2267), [#2731](https://github.com/mattias800/prosper/issues/2731), [#1905](https://github.com/mattias800/prosper/issues/1905), [#1720](https://github.com/mattias800/prosper/issues/1720) | [#1871](https://github.com/mattias800/prosper/issues/1871) | [`GRIS_SONIC_COBRA_BRINGUP.md`](prosper/docs/GRIS_SONIC_COBRA_BRINGUP.md) |
 | ArcRunner | `PPSA21406` | 0 | `------` | - | - | none | [#1226](https://github.com/mattias800/prosper/issues/1226), [#2084](https://github.com/mattias800/prosper/issues/2084) | [#1817](https://github.com/mattias800/prosper/issues/1817) | [`ARCRUNNER_STATUS.md`](prosper/docs/ARCRUNNER_STATUS.md) |
+| BALAN WONDERWORLD | `PPSA02058` | 0 | `------` | none | - | none | - | [#2882](https://github.com/mattias800/prosper/issues/2882) | - |
 | Judgment | `PPSA02739` | 0 | `------` | none | - | none | - | [#2880](https://github.com/mattias800/prosper/issues/2880) | - |
+| Little Nightmares II | `PPSA02154` | 0 | `------` | none | - | none | - | [#2884](https://github.com/mattias800/prosper/issues/2884) | - |
 | Metaphor: ReFantazio | `PPSA20800` | 0 | `------` | none | - | none | - | [#2876](https://github.com/mattias800/prosper/issues/2876) | - |
+| Sifu | `PPSA03001` | 0 | `------` | none | - | none | - | [#2885](https://github.com/mattias800/prosper/issues/2885) | - |
 | Sniper Ghost Warrior Contracts 2 | `PPSA03130` | 0 | `------` | none | - | none | - | [#2867](https://github.com/mattias800/prosper/issues/2867) | - |
+| Spacebase Startopia | `PPSA02846` | 0 | `------` | none | - | none | - | [#2887](https://github.com/mattias800/prosper/issues/2887) | - |
+| Stray | `PPSA02101` | 0 | `------` | none | - | none | - | [#2883](https://github.com/mattias800/prosper/issues/2883) | - |
+| Unbound: Worlds Apart | `PPSA03274` | 0 | `------` | none | - | none | - | [#2886](https://github.com/mattias800/prosper/issues/2886) | - |
 | Yakuza Kiwami | `PPSA31334` | 0 | `------` | none | - | none | - | [#2864](https://github.com/mattias800/prosper/issues/2864) | - |
 
 ## Counts
@@ -168,8 +174,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 13 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 5 |
+| 0 -- not started | 11 |
 
-**4 of 43** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 49** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.


### PR DESCRIPTION
The tracker and the available titles had silently diverged: **43 tracked against 49 present**. Nothing was wrong in the repo — 43 was accurate for what was tracked — but it under-reported what can be tested, which is the direction that looks safe and so goes unnoticed.

## The six

| title ID | title | engine | tracker |
|---|---|---|---|
| `PPSA02058` | BALAN WONDERWORLD | Unreal Engine 4 | #2882 |
| `PPSA02101` | Stray | Unreal Engine 4 | #2883 |
| `PPSA02154` | Little Nightmares II | Unreal Engine 4 | #2884 |
| `PPSA02846` | Spacebase Startopia | Unity 2020.3.1 / IL2CPP | #2887 |
| `PPSA03001` | Sifu | Unreal Engine 4 | #2885 |
| `PPSA03274` | Unbound: Worlds Apart | Unreal Engine 4 | #2886 |

## Engines derived from layout, not from the publisher

The five UE4 titles each have an `engine/` directory beside a project directory (`happiness`, `hk_project`, `helios`, `sifu`, `unbound`), a `ue4commandline.txt`, and a `.pak`.

**None has a `.utoc`, so all five are `.pak` builds rather than IoStore** — `docs/UE4_APR_IOSTORE_BRINGUP.md` does not apply to them. **No engine version appears in the eboot strings, so none is recorded** rather than guessed.

Spacebase Startopia has the standard Unity IL2CPP shape — `Media/globalgamemanagers`, `boot.config`, an il2cpp payload — with version strings giving 2020.3.1.

## What this changes about the shape of the table

- **Fifteen Unreal titles now**, still none at gameplay. That is the largest single cohort waiting.
- **Little Nightmares II is a sibling of the already-tracked Little Nightmares III** (#1890) — same studio and series, so compare before treating a finding on either as new.
- Spacebase's tracker notes the Unity level-index oracle probably applies, **and to establish it rather than assume it**: that oracle has already failed twice, on *Tales of Graces f* (one level file, so the index is a constant) and on *Bendy*'s own sequel.

## Verification

```
gen_progress_tracker.py --check   -> exit 0  (49 trackers, 49 parsed)
check_numbered_table.py over .md  -> exit 0
git diff --check                  -> clean
CLAUDE.md 49 / COMPATIBILITY total 49 / 49 rows / 49 present — all agree
```

Docs-only. Refs #2882, #2883, #2884, #2885, #2886, #2887.