### PR TITLE
loader: refuse third-party replacements of Sony libraries, and make the charter's claims checkable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,9 +2,9 @@
 
 ## What this project is
 
-**prosper is a PS5→PC compatibility layer — "Wine/Proton for PS5."** It runs a **legally-owned** PS5 game
-(*The Messenger*, `PPSA24651`) natively on Linux/Windows by reimplementing Sony's published user-space
-library interfaces and translating the console's GPU command stream + RDNA2 shaders to Vulkan/SPIR-V.
+**prosper is a PS5→PC compatibility layer — "Wine/Proton for PS5."** It runs PS5 games natively on
+Linux/Windows by reimplementing Sony's published user-space library interfaces and translating the
+console's GPU command stream + RDNA2 shaders to Vulkan/SPIR-V.
 
 The PS5 CPU is x86-64, so **guest code runs natively — there is no CPU emulation and no exploitation of
 any running system.** The engineering is: ELF/SELF loading, multi-module linking, ABI/API reimplementation
@@ -25,9 +25,23 @@ and target are what distinguish work like this from anything harmful — and her
 - **Interoperability & preservation, not exploitation.** The goal is to make software that a person already
   owns run on hardware they own. Nothing is attacked; nothing external or third-party is touched. Every
   tool runs against *this* emulator's own process.
-- **No DRM circumvention, no piracy.** The target dump's SELF segments are **already unencrypted**; the
-  project uses **no console keys, no signature bypass, no copy-protection defeat**. The game dump is the
-  developer's own legally-obtained copy, is **never redistributed**, and is gitignored.
+- **No DRM circumvention — and none delegated, either.** The project uses **no console keys, no
+  signature bypass, no copy-protection defeat**, and prosper contains no decryption of any kind. The
+  SELF segments it reads are already unencrypted, which is now *measured* rather than assumed: across
+  the whole local corpus every eboot carries plaintext code (Shannon entropy 6.4–6.8 bits/byte), and
+  the two dumps that preserve an untouched console original show that original at **8.000**,
+  indistinguishable from `/dev/urandom`. Game content is **never redistributed** and is gitignored.
+  The second half of this is the part that needs enforcing, because not circumventing is not enough on
+  its own. Some dumps ship third-party replacements of Sony libraries — `dlc_emu` and `ampr_emu` build
+  stand-ins for `libSceAppContent`, `libSceNpEntitlementAccess`, `libSceGameUpdate` and `libSceAmpr`
+  that answer platform queries from a local file. **prosper implements those APIs itself and refuses
+  to link any of them.** `src/host/image/module_path_policy.hpp` is a reject-by-default allowlist of
+  the dump locations a module may come from, applied at the one point where the link list is complete
+  and before anything parses a module, with no environment variable to switch it off;
+  `tests/host/image/test_module_path_policy.cpp` reddens if the guard is removed, and
+  `tools/dump_hygiene.py` finds such files on disk. An emulator that loaded somebody else's bypass
+  would be performing the circumvention by proxy — and would also invalidate its own measurements,
+  since the guest would then be answered by a stub instead of by prosper.
 - **No Sony code, firmware, or keys** are included or reproduced. prosper reimplements *published* library
   interfaces from scratch (clean-room-style), the way Wine reimplements the Win32 API.
 - **The low-level tooling** (`PROSPER_HWBP` hardware breakpoints, `fault_handler` SIGSEGV handling,

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1172,6 +1172,17 @@ if(TARGET prosper_core)
   target_link_libraries(test_module_path_case PRIVATE prosper_core)
   add_test(NAME module_path_case COMMAND test_module_path_case)
 
+  # Module path policy: prosper links guest modules only from the dump locations it names
+  # (eboot.bin, sce_module/, Media/Modules/, Media/Plugins/), rejects everything else by default,
+  # and never links a Sony-named library out of the wholesale-auto-linked Media directories. Some
+  # dumps ship third-party replacements of libSceAppContent / libSceNpEntitlementAccess /
+  # libSceAmpr; loading one would shadow prosper's own implementation and answer the guest with
+  # somebody else's stub. Pure string policy plus one end-to-end arm against a temp tree.
+  add_executable(test_module_path_policy tests/host/image/test_module_path_policy.cpp)
+  target_include_directories(test_module_path_policy PRIVATE tests)
+  target_link_libraries(test_module_path_policy PRIVATE prosper_core)
+  add_test(NAME module_path_policy COMMAND test_module_path_policy)
+
   # Diagnostics: disabled-path test — verifies stubs are zero-cost (always runs).
   add_executable(test_diagnostics_disabled tests/diagnostics/test_diagnostics_disabled.cpp)
   target_link_libraries(test_diagnostics_disabled PRIVATE prosper_core)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1183,6 +1183,13 @@ if(TARGET prosper_core)
   target_link_libraries(test_module_path_policy PRIVATE prosper_core)
   add_test(NAME module_path_policy COMMAND test_module_path_policy)
 
+  # dump_hygiene classifies files in a game dump that prosper must never load, and can delete them.
+  # Its control arms matter more than its positive ones: during development it twice classified
+  # AUTHENTIC dump content as removable. The suite pins both regressions and the guards behind them.
+  add_test(NAME dump_hygiene_classifier
+           COMMAND ${Python3_EXECUTABLE} -m unittest tests.tools.test_dump_hygiene
+           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
   # Diagnostics: disabled-path test — verifies stubs are zero-cost (always runs).
   add_executable(test_diagnostics_disabled tests/diagnostics/test_diagnostics_disabled.cpp)
   target_link_libraries(test_diagnostics_disabled PRIVATE prosper_core)

--- a/prosper/src/host/image/AGENTS.md
+++ b/prosper/src/host/image/AGENTS.md
@@ -1,0 +1,46 @@
+# src/host/image — turning a game dump into a running process image
+
+This folder owns the step between "a directory of files on disk" and "guest code mapped and
+entered". It decides **which files in a dump are modules**, in what order they link, where each one
+is based, and how the host actually maps them. Everything here is dump-layout knowledge and
+per-platform mapping; nothing here knows about Sony API semantics (that is `src/hle/`) or about the
+relocatable-image format itself (that is `src/self/` and `src/loader/`).
+
+The boundary against `src/loader/` is worth stating because the two are easy to confuse:
+`src/loader/` links a set of modules it is *handed* and knows nothing about dumps. This folder is
+what produces that set — it is where `<dump>/Media/Plugins/…` becomes a `LinkInput`.
+
+## What lives here
+
+- **`boot_program.*`** — the boot sequence. `boot_link_inputs()` is the single definition of the
+  loader's real link set, and is deliberately public so tools (`nid_census`) report on the same set
+  the loader uses rather than re-deriving it and silently disagreeing (#2199). Note it *prints* while
+  it works; that output is part of the loader's behaviour.
+- **`module_path_policy.*`** — the reject-by-default allowlist of dump locations a module may be
+  linked from. Read its header before touching module discovery: some dumps ship third-party
+  replacements of Sony libraries, and this is what keeps them from being linked and shadowing
+  prosper's own implementations.
+- **`exec_image_{linux,win}.cpp`** behind `exec_image.hpp` — the per-platform mapping substrate.
+  Platform divergence belongs *here*, not in `boot_program.cpp`.
+- **`runtime_module_load.*`** — the guest asking for a module after boot, as opposed to the fixed
+  preload list. True runtime PRX loading is not implemented (#639), which is why the preload list
+  carries so many optional entries: they exist so a first P/Invoke resolves instead of hanging.
+
+## Things a newcomer learns the hard way
+
+**Dump layout is not consistent between titles, and casing is not either.** The same Unity module
+ships as `Il2cppUserAssemblies.prx` and `Il2CppUserAssemblies.prx` depending on the title, so paths
+are case-corrected against the real directory entry (`resolve_host_path_case`, #1006). On a
+case-insensitive host the wrong casing "works" and hides the bug; on Linux it silently drops the
+module and the guest null-jumps.
+
+**Order in the link list is reverse init order.** A module's init function runs *after* those listed
+below it, so a dependency goes later in the list, not earlier. Several comments in
+`boot_program.cpp` restate this at each site because getting it backwards produces a
+plausible-looking list that initializes FMOD's studio layer before its core.
+
+**Adding a module to the discovery path is a security-relevant change, not just a convenience.**
+`discover_extra_plugin_modules()` links whatever a dump ships in one directory (#1609). Widening
+that — recursing, accepting another extension, scanning another directory — changes which
+third-party code prosper will execute on behalf of the guest. `module_path_policy` is the guard, and
+`tests/host/image/test_module_path_policy.cpp` is what makes it real; extend both together.

--- a/prosper/src/host/image/boot_program.cpp
+++ b/prosper/src/host/image/boot_program.cpp
@@ -2,6 +2,7 @@
 // (behavior-preserving); backed by whichever exec_image_<os> substrate the platform provides
 // (Linux/macOS: exec_image_linux.cpp; Windows: exec_image_win.cpp).
 #include "host/image/boot_program.hpp"
+#include "host/image/module_path_policy.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -252,6 +253,12 @@ std::vector<LinkInput> boot_link_inputs(const std::string& d, bool verbose) {
             slot++;
         }
     }
+    // The link list is complete here, so this is the chokepoint: every path above, fixed or
+    // discovered, is judged against the reject-by-default allowlist in module_path_policy.hpp
+    // before anything opens or parses it. See that header for why the policy is enforced rather
+    // than left as an emergent property of the discovery code, and why it is not switchable.
+    for (const auto& r : enforce_module_path_policy(d, in))
+        say("module REFUSED by path policy: %s -- %s\n", r.path.c_str(), r.reason.c_str());
     if (getenv("PROSPER_NO_PSN"))
         for (size_t i = in.size(); i-- > 0; )
             if (in[i].path.find("PSN.prx") != std::string::npos ||

--- a/prosper/src/host/image/module_path_policy.cpp
+++ b/prosper/src/host/image/module_path_policy.cpp
@@ -1,0 +1,159 @@
+#include "host/image/module_path_policy.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace prosper {
+namespace {
+
+std::string lower(std::string s) {
+    for (auto& c : s) c = (char)std::tolower((unsigned char)c);
+    return s;
+}
+
+// Normalize separators and collapse repeated slashes. Trailing slashes are dropped so a dump root
+// given as ".../PPSA24651-app0/" compares equal to one given without.
+std::string normalize(const std::string& in) {
+    std::string out;
+    out.reserve(in.size());
+    for (char c : in) {
+        const char n = (c == '\\') ? '/' : c;
+        if (n == '/' && !out.empty() && out.back() == '/') continue;
+        out.push_back(n);
+    }
+    while (out.size() > 1 && out.back() == '/') out.pop_back();
+    return out;
+}
+
+std::vector<std::string> split(const std::string& p) {
+    std::vector<std::string> parts;
+    std::string cur;
+    for (char c : p) {
+        if (c == '/') {
+            if (!cur.empty()) parts.push_back(cur);
+            cur.clear();
+        } else {
+            cur.push_back(c);
+        }
+    }
+    if (!cur.empty()) parts.push_back(cur);
+    return parts;
+}
+
+// A rejected path gets a reason that says what the file appears to BE, not just that a string did
+// not match. `fakelib` and a `libSce*` basename are the two signals that actually occur, and the
+// difference between "prosper does not link from here" and "this is a replacement Sony library"
+// is the difference between a puzzling log line and an actionable one.
+std::string describe_rejection(const std::vector<std::string>& rel_parts) {
+    const std::string dir = rel_parts.empty() ? std::string() : lower(rel_parts.front());
+    const std::string base = rel_parts.empty() ? std::string() : rel_parts.back();
+    const bool sony_named = lower(base).rfind("libsce", 0) == 0;
+
+    if (dir == "fakelib") {
+        return sony_named
+            ? "third-party replacement of a Sony library, in `fakelib/`. prosper answers "
+              "entitlement and add-content queries from its own local inventory and never delegates "
+              "them to a bundled module"
+            : "in `fakelib/`, a directory prosper never links from";
+    }
+    if (sony_named) {
+        return "a Sony-named library outside `sce_module/`; prosper links Sony libraries only from "
+               "the dump's own `sce_module/` directory";
+    }
+    return "in a directory prosper does not link modules from";
+}
+
+}  // namespace
+
+ModulePathDecision classify_module_path(const std::string& dump_root, const std::string& path) {
+    ModulePathDecision d;
+
+    const std::string root = normalize(dump_root);
+    const std::string full = normalize(path);
+
+    if (root.empty() || full.empty()) {
+        d.verdict = ModulePathVerdict::OutsideDumpRoot;
+        d.reason = "empty dump root or module path";
+        return d;
+    }
+
+    // Must sit strictly under the root. Compare on a component boundary so `/dump-evil/x` is not
+    // accepted as living under `/dump`.
+    if (full.size() <= root.size() || full.compare(0, root.size(), root) != 0 ||
+        full[root.size()] != '/') {
+        d.verdict = ModulePathVerdict::OutsideDumpRoot;
+        d.reason = "not inside the dump directory";
+        return d;
+    }
+
+    const std::vector<std::string> parts = split(full.substr(root.size() + 1));
+    if (parts.empty()) {
+        d.verdict = ModulePathVerdict::OutsideDumpRoot;
+        d.reason = "resolves to the dump directory itself";
+        return d;
+    }
+    // Refuse rather than resolve: `a/../../etc/passwd` escapes, and lexical rejection keeps this
+    // function pure. `.` is refused for the same reason — it should never appear in a path the
+    // loader built, and accepting it would mean two spellings of one location.
+    for (const auto& p : parts) {
+        if (p == ".." || p == ".") {
+            d.verdict = ModulePathVerdict::OutsideDumpRoot;
+            d.reason = "contains a `" + p + "` component";
+            return d;
+        }
+    }
+
+    if (parts.size() == 1) {
+        for (const char* f : kPermittedRootFiles) {
+            if (lower(parts[0]) == lower(f)) {
+                d.verdict = ModulePathVerdict::Permitted;
+                return d;
+            }
+        }
+        d.verdict = ModulePathVerdict::DirectoryNotPermitted;
+        d.reason = "in the dump root, which holds no linkable module other than eboot.bin";
+        return d;
+    }
+
+    std::string dir;
+    for (size_t i = 0; i + 1 < parts.size(); i++) {
+        if (i) dir += '/';
+        dir += parts[i];
+    }
+    for (const char* permitted : kPermittedModuleDirs) {
+        if (lower(dir) != lower(permitted)) continue;
+        // Permitted directory — but a Sony-named library is allowed only out of sce_module/.
+        // See the kSonyLibraryPrefix comment in the header for why the Media/* directories are
+        // held to a stricter rule than their being on the allowlist would suggest.
+        const bool is_sce_module = lower(dir) == "sce_module";
+        if (!is_sce_module && lower(parts.back()).rfind(kSonyLibraryPrefix, 0) == 0) {
+            d.verdict = ModulePathVerdict::SonyLibraryOutsideSceModule;
+            d.reason = "a Sony-named library under `" + dir +
+                       "/`, which prosper auto-links wholesale; Sony libraries are linked only from "
+                       "the dump's own `sce_module/` directory";
+            return d;
+        }
+        d.verdict = ModulePathVerdict::Permitted;
+        return d;
+    }
+
+    d.verdict = ModulePathVerdict::DirectoryNotPermitted;
+    d.reason = describe_rejection(parts);
+    return d;
+}
+
+std::vector<RejectedModule> enforce_module_path_policy(const std::string& dump_root,
+                                                       std::vector<LinkInput>& in) {
+    std::vector<RejectedModule> rejected;
+    for (size_t i = in.size(); i-- > 0;) {
+        const ModulePathDecision d = classify_module_path(dump_root, in[i].path);
+        if (d.permitted()) continue;
+        rejected.push_back({ in[i].path, d.reason });
+        in.erase(in.begin() + (ptrdiff_t)i);
+    }
+    // Iterated backwards so erasing is safe; hand the caller the list in list order.
+    std::reverse(rejected.begin(), rejected.end());
+    return rejected;
+}
+
+}  // namespace prosper

--- a/prosper/src/host/image/module_path_policy.hpp
+++ b/prosper/src/host/image/module_path_policy.hpp
@@ -1,0 +1,95 @@
+#pragma once
+// module_path_policy — which files inside a game dump prosper is willing to link as a guest module.
+//
+// REJECT BY DEFAULT. `kPermittedModuleDirs` below is the COMPLETE set of dump-relative locations a
+// module may be linked from; anything else is refused and reported, whatever the file is called and
+// whatever produced it.
+//
+// Why this is an enforced policy and not merely a property of how boot_link_inputs happens to be
+// written today: some dumps in circulation ship a `fakelib/` directory of replacement Sony
+// libraries — libSceAppContent, libSceNpEntitlementAccess, libSceGameUpdate — whose purpose is to
+// answer ownership queries with an unconditional yes. prosper answers those queries itself, from
+// the locally declared inventory (`src/hle/service/hle_addcontent.cpp`), and the project charter
+// draws the line exactly here: reimplementing a platform query faithfully is the job; manufacturing
+// a positive answer to an ownership query is circumvention performed by the emulator. Linking a
+// third-party module that does it on our behalf lands on the wrong side of that line, and it would
+// also silently invalidate every entitlement result we measure — the guest would be answered by
+// somebody else's stub while our own implementation sat unused.
+//
+// Before this policy existed prosper already did not load those files, but only as a side effect of
+// three unrelated details of `discover_extra_plugin_modules()`: it scans one fixed directory, it is
+// not recursive, and it matches `.prx` where `fakelib` ships `.sprx`. Any one of those changing
+// would have started loading them with nothing anywhere to notice — and #1609 widened module
+// discovery once already. A property that no test asserts is not a property.
+//
+// Deliberately NOT switchable. There is no environment variable and no flag, because a flag is
+// precisely the thing that would end up set. Widening the allowlist is a source change, and so gets
+// a reviewer.
+//
+// CONFIDENCE: HIGH — the permitted set is enumerated directly from every dump-relative path
+// `boot_link_inputs()` can construct.
+#include "loader/linker.hpp"
+
+#include <string>
+#include <vector>
+
+namespace prosper {
+
+// The complete set of dump-relative directories a linkable module may live in. Compared
+// case-insensitively, with `/` and `\` treated alike.
+inline constexpr const char* kPermittedModuleDirs[] = {
+    "Media/Modules",
+    "Media/Plugins",
+    "sce_module",
+};
+
+// Files permitted directly in the dump root.
+inline constexpr const char* kPermittedRootFiles[] = {
+    "eboot.bin",
+};
+
+// A Sony-named module (`libSce*`) may be linked ONLY from `sce_module/`, never from the two Media
+// directories. Those two are auto-linked wholesale by #1609 — every `.prx` a dump ships in
+// `Media/Plugins` gets linked — so without this a dump could substitute any Sony library simply by
+// dropping it in the Unity plugin folder, and the `fakelib/` rejection above would be trivially
+// sidestepped by moving the file. `Media/*` is where a title's OWN native plugins live; a Sony
+// library there is not something a legitimate build produces.
+//
+// CONFIDENCE: HIGH for the corpus — measured across all 50 local dumps, zero ship a `libSce*` under
+// `Media/Plugins` or `Media/Modules`, while three ship exactly such files under `fakelib/`. MED as a
+// universal claim about PS5 titles. If a real title ever does need one, the refusal is loud and
+// names the file, and widening the rule is a reviewed source change — which is the right direction
+// for the error to point, because the alternative failure is silent.
+inline constexpr const char* kSonyLibraryPrefix = "libsce";  // compared lowercased
+
+enum class ModulePathVerdict {
+    Permitted,
+    OutsideDumpRoot,             // not under the dump root at all, or escapes it via `..`
+    DirectoryNotPermitted,       // inside the dump, in a directory prosper never links from
+    SonyLibraryOutsideSceModule, // a libSce* module in an auto-linked Media directory
+};
+
+struct ModulePathDecision {
+    ModulePathVerdict verdict = ModulePathVerdict::DirectoryNotPermitted;
+    // Human-readable and specific: this string is what a person debugging a missing module reads.
+    std::string reason;
+
+    bool permitted() const { return verdict == ModulePathVerdict::Permitted; }
+};
+
+// Pure, filesystem-free, and therefore testable: decides from the two strings alone. `path` is
+// judged lexically against `dump_root`, so a `..` component is refused rather than resolved.
+ModulePathDecision classify_module_path(const std::string& dump_root, const std::string& path);
+
+struct RejectedModule {
+    std::string path;
+    std::string reason;
+};
+
+// Removes every entry of `in` whose path the policy refuses, and returns what was removed so the
+// caller can report it. Reporting is the caller's job because a dropped module is invisible
+// afterwards, and silence here is the failure mode this whole file exists to prevent.
+std::vector<RejectedModule> enforce_module_path_policy(const std::string& dump_root,
+                                                       std::vector<LinkInput>& in);
+
+}  // namespace prosper

--- a/prosper/tests/host/image/test_module_path_policy.cpp
+++ b/prosper/tests/host/image/test_module_path_policy.cpp
@@ -1,0 +1,188 @@
+// test_module_path_policy — prosper links guest modules only from the dump locations it names, and
+// refuses everything else by default.
+//
+// Two layers, and they are NOT the same strength, so the difference is stated rather than left for a
+// reader to assume:
+//
+//   1. `classify_module_path` unit arms. Pure string policy; every arm reddens under a targeted
+//      mutation of the function.
+//   2. ONE end-to-end arm through `boot_link_inputs`. It is built specifically so that it FAILS
+//      without the guard: `Media/Plugins/libSceNpEntitlementAccess.prx` sits in a directory that
+//      #1609 auto-links wholesale, so before this policy existed the loader linked it. That makes it
+//      a real regression arm rather than a restatement of an invariant that already held.
+//
+//      By contrast a `fakelib/*.sprx` fixture would pass with OR without the guard — wrong
+//      directory, not recursive, wrong extension — so it is included only as an invariant arm and
+//      labelled as one. It cannot fail today; its job is to fail the day module discovery widens.
+#include "fixtures/test_scratch.h"
+#include "host/image/boot_program.hpp"
+#include "host/image/module_path_policy.hpp"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+using namespace prosper;
+namespace fs = std::filesystem;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static void permit(const char* root, const char* path, const char* what) {
+    const ModulePathDecision d = classify_module_path(root, path);
+    if (!d.permitted()) printf("         (refused: %s)\n", d.reason.c_str());
+    CHECK(d.permitted(), what);
+}
+
+static void refuse(const char* root, const char* path, ModulePathVerdict want, const char* what) {
+    const ModulePathDecision d = classify_module_path(root, path);
+    const bool ok = !d.permitted() && d.verdict == want && !d.reason.empty();
+    if (!ok && d.permitted()) printf("         (permitted, but should not be)\n");
+    CHECK(ok, what);
+}
+
+static void write_file(const fs::path& p, const char* bytes) {
+    fs::create_directories(p.parent_path());
+    std::ofstream f(p, std::ios::binary);
+    f.write(bytes, (std::streamsize)std::char_traits<char>::length(bytes));
+}
+
+static bool linked(const std::vector<LinkInput>& in, const std::string& needle) {
+    for (const auto& e : in)
+        if (e.path.find(needle) != std::string::npos) return true;
+    return false;
+}
+
+int main() {
+    printf("== test_module_path_policy ==\n");
+    const char* R = "/dumps/PPSA00000-app0";
+
+    printf("-- permitted locations --\n");
+    permit(R, "/dumps/PPSA00000-app0/eboot.bin", "eboot.bin in the dump root");
+    permit(R, "/dumps/PPSA00000-app0/sce_module/libc.prx", "sce_module/libc.prx");
+    permit(R, "/dumps/PPSA00000-app0/sce_module/libSceNpCppWebApi.prx",
+           "sce_module MAY hold a Sony library -- that is the whole point of the directory");
+    permit(R, "/dumps/PPSA00000-app0/Media/Plugins/PSN.prx", "Media/Plugins/PSN.prx");
+    permit(R, "/dumps/PPSA00000-app0/Media/Modules/Il2cppUserAssemblies.prx", "Media/Modules/...");
+    // Casing: PS5 module paths are effectively case-insensitive and #1006 case-corrects them, so a
+    // policy that were case-SENSITIVE would refuse modules the loader legitimately resolved.
+    permit(R, "/dumps/PPSA00000-app0/media/plugins/PSN.prx", "directory match is case-insensitive");
+    permit(R, "/dumps/PPSA00000-app0/Media/Modules/Il2CppUserAssemblies.prx",
+           "the #1006 alternate casing of a real module is still permitted");
+    // Separator normalization, so a Windows-shaped path is judged the same way.
+    permit("C:\\dumps\\PPSA00000-app0", "C:\\dumps\\PPSA00000-app0\\sce_module\\libc.prx",
+           "backslash-separated Windows path");
+    permit("/dumps/PPSA00000-app0/", "/dumps/PPSA00000-app0//sce_module/libc.prx",
+           "trailing and doubled separators normalize away");
+
+    printf("-- refused: outside the dump --\n");
+    refuse(R, "/etc/ld.so.preload", ModulePathVerdict::OutsideDumpRoot, "an absolute host path");
+    refuse(R, "/dumps/PPSA00000-app0-evil/sce_module/libc.prx", ModulePathVerdict::OutsideDumpRoot,
+           "a sibling directory sharing the root's prefix is NOT inside it");
+    refuse(R, "/dumps/PPSA00000-app0/sce_module/../../other/x.prx",
+           ModulePathVerdict::OutsideDumpRoot, "`..` is refused, not resolved");
+    refuse(R, "/dumps/PPSA00000-app0/./sce_module/libc.prx", ModulePathVerdict::OutsideDumpRoot,
+           "`.` is refused so one location has exactly one spelling");
+
+    printf("-- refused: wrong directory --\n");
+    refuse(R, "/dumps/PPSA00000-app0/fakelib/libSceNpEntitlementAccess.sprx",
+           ModulePathVerdict::DirectoryNotPermitted, "fakelib/libSceNpEntitlementAccess.sprx");
+    refuse(R, "/dumps/PPSA00000-app0/fakelib/libSceAmpr.sprx",
+           ModulePathVerdict::DirectoryNotPermitted, "fakelib/libSceAmpr.sprx");
+    refuse(R, "/dumps/PPSA00000-app0/FAKELIB/libSceAppContent.sprx",
+           ModulePathVerdict::DirectoryNotPermitted, "...and renaming the directory's case does not help");
+    refuse(R, "/dumps/PPSA00000-app0/prx/anything.prx", ModulePathVerdict::DirectoryNotPermitted,
+           "a `prx/` directory some dumps ship is still not on the allowlist");
+    refuse(R, "/dumps/PPSA00000-app0/libc.prx", ModulePathVerdict::DirectoryNotPermitted,
+           "the dump root holds no linkable module but eboot.bin");
+    refuse(R, "/dumps/PPSA00000-app0/Media/Plugins/sub/deep.prx",
+           ModulePathVerdict::DirectoryNotPermitted,
+           "a SUBdirectory of a permitted directory is not itself permitted");
+
+    printf("-- refused: a Sony library outside sce_module --\n");
+    refuse(R, "/dumps/PPSA00000-app0/Media/Plugins/libSceNpEntitlementAccess.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule,
+           "moving the bypass into the auto-linked plugin directory does not smuggle it in");
+    refuse(R, "/dumps/PPSA00000-app0/Media/Modules/libSceAppContent.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "same for Media/Modules");
+    refuse(R, "/dumps/PPSA00000-app0/Media/Plugins/LIBSCEampr.prx",
+           ModulePathVerdict::SonyLibraryOutsideSceModule, "the libSce test is case-insensitive");
+
+    printf("-- the rejection reason names what the file is --\n");
+    {
+        const auto d = classify_module_path(R, "/dumps/PPSA00000-app0/fakelib/libSceAppContent.sprx");
+        CHECK(d.reason.find("entitlement") != std::string::npos ||
+              d.reason.find("local inventory") != std::string::npos,
+              "a fakelib Sony library is described as an entitlement matter, not just a path miss");
+    }
+
+    printf("-- enforce_module_path_policy filters and reports --\n");
+    {
+        std::vector<LinkInput> in = {
+            { std::string(R) + "/eboot.bin", 0x1000 },
+            { std::string(R) + "/fakelib/libSceAppContent.sprx", 0x2000 },
+            { std::string(R) + "/sce_module/libc.prx", 0x3000 },
+            { std::string(R) + "/Media/Plugins/libSceGameUpdate.prx", 0x4000 },
+        };
+        const auto rejected = enforce_module_path_policy(R, in);
+        CHECK(in.size() == 2, "two of four inputs survive");
+        CHECK(linked(in, "/eboot.bin") && linked(in, "/sce_module/libc.prx"),
+              "the two survivors are the permitted ones");
+        CHECK(rejected.size() == 2, "both refusals are reported back to the caller");
+        CHECK(rejected.size() == 2 && rejected[0].path.find("fakelib") != std::string::npos,
+              "reported in list order, so the log reads like the link list");
+        bool all_explained = true;
+        for (const auto& r : rejected) if (r.reason.empty()) all_explained = false;
+        CHECK(all_explained, "every refusal carries a reason -- a silent drop is the failure mode");
+    }
+
+    printf("-- end-to-end through boot_link_inputs --\n");
+    {
+        const fs::path root = prosper_test::test_scratch_dir() / "prosper_test_module_path_policy";
+        std::error_code ec;
+        fs::remove_all(root, ec);
+
+        // Deliberately NOT valid SELF images: boot_link_inputs only stats these paths, and using
+        // non-images keeps the arm about path policy alone.
+        write_file(root / "eboot.bin", "not-a-real-image");
+        write_file(root / "Media" / "Plugins" / "RealPlugin.prx", "not-a-real-image");
+        write_file(root / "Media" / "Plugins" / "libSceNpEntitlementAccess.prx", "not-a-real-image");
+        write_file(root / "fakelib" / "libSceAppContent.sprx", "not-a-real-image");
+
+        const std::vector<LinkInput> in = boot_link_inputs(root.string(), /*verbose=*/false);
+
+        // THE regression arm. Without the policy, #1609's auto-link discovers every .prx in
+        // Media/Plugins and links this one -- so this assertion fails on a tree with the guard
+        // removed. Verified by doing exactly that before trusting it.
+        CHECK(!linked(in, "libSceNpEntitlementAccess"),
+              "a Sony library dropped into the auto-linked plugin directory is NOT linked");
+
+        // Positive control for the arm above: the guard must not have simply disabled auto-linking.
+        // Without this, deleting the whole #1609 block would also make the arm pass.
+        CHECK(linked(in, "RealPlugin.prx"),
+              "...while a genuine title plugin in the same directory still IS linked");
+
+        CHECK(linked(in, "eboot.bin"), "the eboot is linked");
+
+        // INVARIANT arm, not a regression arm: this passes with or without the guard, because
+        // discovery never reaches fakelib/ today. It exists to fail if discovery ever widens.
+        CHECK(!linked(in, "fakelib"), "[invariant] nothing under fakelib/ is linked");
+
+        // Whole-list invariant: whatever the loader decided to link, all of it is permitted.
+        bool all_permitted = true;
+        for (const auto& e : in)
+            if (!classify_module_path(root.string(), e.path).permitted()) {
+                printf("         (unpermitted survivor: %s)\n", e.path.c_str());
+                all_permitted = false;
+            }
+        CHECK(all_permitted, "[invariant] every linked path satisfies the policy");
+
+        fs::remove_all(root, ec);
+    }
+
+    printf(fails ? "== FAILED (%d) ==\n" : "== passed ==\n", fails);
+    return fails ? 1 : 0;
+}

--- a/prosper/tests/tools/test_dump_hygiene.py
+++ b/prosper/tests/tools/test_dump_hygiene.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""test_dump_hygiene — the classifier must not delete authentic dump content.
+
+This tool has a destructive mode, and during development it was wrong twice in exactly the
+direction that matters:
+
+  * `.bin` was in the module-suffix list, so a sweep reported 1,012 `Media/StreamingAssets/**/*.bin`
+    and 914 `COMMON/ui/uv/*.bin` GAME DATA files as refused modules.
+  * `sce_sys/about/right.sprx` — a Sony file present in every dump, including ones with no
+    third-party additions at all — was classified REFUSED, so `--strip` would have deleted it from
+    all 50.
+
+Both were caught by running against a dump known to be clean, not by reading the code. So the
+control arms below matter more than the positive ones: it is easy to write a detector that finds
+`fakelib`, and hard to write one that finds only `fakelib`.
+
+A note on WHY those two arms now hold, because it is not the reason you would guess and the
+distinction decides what they are worth. The classifier was rewritten to key on "impersonates a Sony
+library" rather than "is a module somewhere unexpected". Under that rule `settings.bin` and
+`sce_sys/about/right.sprx` are ignored because neither is named `libSce*` -- NOT because of
+MODULE_SUFFIXES or SONY_DATA_DIRS. Mutation-checking proved it: re-adding `.bin` to MODULE_SUFFIXES
+and deleting the SONY_DATA_DIRS check both leave the suite green, because both are now
+defence-in-depth rather than load-bearing.
+
+Those two arms are therefore kept as REGRESSION arms against the old design returning, and each is
+paired below with an arm that does exercise the guard it is named after.
+"""
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "tools"))
+import dump_hygiene as dh  # noqa: E402
+
+HEADER = Path(__file__).resolve().parents[2] / "src/host/image/module_path_policy.hpp"
+
+
+class ClassifierAgreesWithTheLoader(unittest.TestCase):
+    def test_permitted_dirs_match_the_cpp_header(self):
+        """The tool's allowlist must equal the loader's, or it reports on a policy nobody enforces.
+
+        Parsed out of the header rather than duplicated in a comment, so the two cannot drift.
+        """
+        text = HEADER.read_text()
+        start = text.index("kPermittedModuleDirs[] = {")
+        body = text[start:text.index("};", start)]
+        from_cpp = tuple(s.strip().strip('",') for s in body.splitlines()[1:] if '"' in s)
+        self.assertEqual(from_cpp, dh.PERMITTED_MODULE_DIRS,
+                         "dump_hygiene.PERMITTED_MODULE_DIRS has drifted from "
+                         "module_path_policy.hpp's kPermittedModuleDirs")
+
+
+class FindsTheRealThing(unittest.TestCase):
+    def test_fakelib_modules_are_refused(self):
+        for name in ("libSceAppContent.sprx", "libSceNpEntitlementAccess.sprx",
+                     "libSceGameUpdate.sprx", "libSceAmpr.sprx"):
+            got = dh.classify(f"fakelib/{name}", is_dir=False)
+            self.assertIsNotNone(got, name)
+            self.assertEqual(got[0], dh.REFUSED, name)
+
+    def test_a_sony_library_outside_sce_module_is_refused_wherever_it_hides(self):
+        # Moving the file must not launder it.
+        for rel in ("Media/Plugins/libSceNpEntitlementAccess.prx",
+                    "Media/Modules/libSceAppContent.prx",
+                    "libSceAmpr.prx",
+                    "vendor/libSceGameUpdate.sprx"):
+            got = dh.classify(rel, is_dir=False)
+            self.assertIsNotNone(got, rel)
+            self.assertEqual(got[0], dh.REFUSED, rel)
+
+    def test_release_group_markers(self):
+        self.assertEqual(dh.classify("_DUPLEX_", is_dir=True)[0], dh.MARKER)
+        self.assertEqual(dh.classify("_UNLiMiTED_", is_dir=True)[0], dh.MARKER)
+        self.assertEqual(dh.classify("some/where/release.nfo", is_dir=False)[0], dh.MARKER)
+
+
+class DoesNotTouchAuthenticContent(unittest.TestCase):
+    """The arms that would have caught both real bugs."""
+
+    def test_sce_sys_is_never_reported(self):
+        # Present in EVERY dump, clean ones included. Reported once => --strip deletes it from all.
+        # Holds today because right.sprx is not libSce*-named, not because of SONY_DATA_DIRS; the
+        # arm below is the one that actually exercises that constant.
+        self.assertIsNone(dh.classify("sce_sys/about/right.sprx", is_dir=False))
+        self.assertIsNone(dh.classify("sce_sys/param.json", is_dir=False))
+        self.assertIsNone(dh.classify("sce_sys/about", is_dir=True))
+
+    def test_sce_sys_exclusion_is_load_bearing_for_marker_suffixes(self):
+        """The arm that reddens when SONY_DATA_DIRS is removed.
+
+        A `.nfo` under sce_sys would otherwise classify as MARKER -- i.e. strippable -- because the
+        marker-suffix test runs before any location check. Authentic Sony metadata must not become
+        deletable just because of its extension.
+        """
+        self.assertIsNone(dh.classify("sce_sys/about/readme.nfo", is_dir=False))
+        self.assertIsNone(dh.classify("sce_sys/_DUPLEX_", is_dir=True))
+
+    def test_module_suffix_gate_is_load_bearing_for_sony_named_data(self):
+        """The arm that reddens when `.bin` is added back to MODULE_SUFFIXES.
+
+        A title is free to ship a data file whose name begins with the Sony prefix. Only real module
+        extensions may reach the impersonation test, or such a file becomes strippable.
+        """
+        self.assertIsNone(dh.classify("data/libSceFontCache.bin", is_dir=False))
+        self.assertIsNone(dh.classify("Media/libSceSettings.dat", is_dir=False))
+
+    def test_game_data_is_never_reported(self):
+        for rel in ("Media/StreamingAssets/PostProcess/settings.bin",
+                    "COMMON/ui/uv/atlas.bin",
+                    "data/tex/character.bin",
+                    "data/2dpar/sprite_c.par",
+                    "engine/content/renderer/shaders.bin"):
+            self.assertIsNone(dh.classify(rel, is_dir=False), rel)
+
+    def test_a_titles_own_native_plugins_are_not_our_business(self):
+        # Wwise, shipped by the developer. prosper not linking from prx/ is a loader question,
+        # not a hygiene one -- and deleting these would remove real game content.
+        for rel in ("prx/akaudioinput.prx", "prx/akcompressor.prx", "Media/Plugins/PSN.prx"):
+            self.assertIsNone(dh.classify(rel, is_dir=False), rel)
+
+    def test_sce_module_sony_libraries_are_permitted(self):
+        for rel in ("sce_module/libc.prx", "sce_module/libSceNpCppWebApi.prx",
+                    "sce_module/libSceJobManager.prx"):
+            self.assertIsNone(dh.classify(rel, is_dir=False), rel)
+
+    def test_consumed_and_retained_are_never_strippable(self):
+        for rel, cat in (("dlc_emu.ini", dh.CONSUMED_K),
+                         ("ampr_emu.index", dh.RETAINED_K)):
+            got = dh.classify(rel, is_dir=False)
+            self.assertEqual(got[0], cat, rel)
+            self.assertNotIn(got[0], (dh.REFUSED, dh.MARKER),
+                             f"{rel} must never fall into a strippable category")
+
+    def test_original_files_is_retained_not_stripped(self):
+        # Holds the dump's encrypted original eboot -- the only local evidence of the untouched
+        # file. Stripping it would destroy exactly the thing that proves provenance.
+        got = dh.classify("_original_files", is_dir=True)
+        self.assertEqual(got[0], dh.RETAINED_K)
+
+
+class StripSafety(unittest.TestCase):
+    def test_strip_refuses_a_directory_that_is_not_a_dump(self, ):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "fakelib").mkdir()
+            (root / "fakelib" / "libSceAppContent.sprx").write_bytes(b"x")
+            self.assertFalse(dh.looks_like_a_dump(root))
+            r = subprocess.run(
+                [sys.executable, str(Path(dh.__file__)), "--strip", "--yes", str(root)],
+                capture_output=True, text=True)
+            self.assertTrue((root / "fakelib" / "libSceAppContent.sprx").exists(),
+                            "refused to strip, so the file must still be there")
+            self.assertIn("does not look", r.stderr)
+
+    def test_strip_removes_refused_but_keeps_consumed_and_retained(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "sce_sys").mkdir()
+            (root / "sce_sys" / "param.json").write_text("{}")
+            (root / "sce_sys" / "about").mkdir()
+            (root / "sce_sys" / "about" / "right.sprx").write_bytes(b"authentic")
+            (root / "sce_module").mkdir()
+            (root / "sce_module" / "libc.prx").write_bytes(b"authentic")
+            (root / "fakelib").mkdir()
+            (root / "fakelib" / "libSceAppContent.sprx").write_bytes(b"foreign")
+            (root / "_DUPLEX_").mkdir()
+            (root / "_DUPLEX_" / "duplex.nfo").write_text("nfo")
+            (root / "dlc_emu.ini").write_text("[PSAL]")
+            (root / "ampr_emu.index").write_bytes(b"AMPRIDX3")
+
+            r = subprocess.run(
+                [sys.executable, str(Path(dh.__file__)), "--strip", "--yes", str(root)],
+                capture_output=True, text=True)
+            self.assertEqual(r.returncode, 0, r.stderr)
+
+            self.assertFalse((root / "fakelib" / "libSceAppContent.sprx").exists(), "REFUSED gone")
+            self.assertFalse((root / "_DUPLEX_").exists(), "MARKER gone")
+            self.assertTrue((root / "dlc_emu.ini").exists(), "CONSUMED kept")
+            self.assertTrue((root / "ampr_emu.index").exists(), "RETAINED kept")
+            self.assertTrue((root / "sce_module" / "libc.prx").exists(), "Sony library kept")
+            self.assertTrue((root / "sce_sys" / "about" / "right.sprx").exists(),
+                            "authentic sce_sys content kept -- this is the arm that would have "
+                            "caught the right.sprx bug")
+
+    def test_check_exit_code(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "sce_sys").mkdir()
+            (root / "sce_sys" / "param.json").write_text("{}")
+            clean = subprocess.run(
+                [sys.executable, str(Path(dh.__file__)), "--check", str(root)],
+                capture_output=True, text=True)
+            self.assertEqual(clean.returncode, 0)
+            (root / "fakelib").mkdir()
+            (root / "fakelib" / "libSceAmpr.sprx").write_bytes(b"x")
+            dirty = subprocess.run(
+                [sys.executable, str(Path(dh.__file__)), "--check", str(root)],
+                capture_output=True, text=True)
+            self.assertEqual(dirty.returncode, 1)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/prosper/tools/dump_hygiene.py
+++ b/prosper/tools/dump_hygiene.py
@@ -269,6 +269,22 @@ def main() -> int:
                 except OSError as e:
                     print(f"  FAILED to remove {r['path']}: {e}", file=sys.stderr)
                     exit_code = 2
+            # Removing every file out of `fakelib/` leaves the directory behind, which still reads
+            # as "this dump carries a fakelib" to anyone who looks. Prune directories that the strip
+            # emptied -- only those, and only if they really are empty, so a rmdir can never take
+            # content with it.
+            for r in removable:
+                parent = (dump / r["path"]).parent
+                while parent != dump and parent.is_dir():
+                    try:
+                        next(parent.iterdir())
+                        break                      # not empty: stop, and leave it alone
+                    except StopIteration:
+                        parent.rmdir()
+                        print(f"  removed emptied directory {parent.relative_to(dump)}")
+                        parent = parent.parent
+                    except OSError:
+                        break
 
     if args.json:
         print(json.dumps(report, indent=2))

--- a/prosper/tools/dump_hygiene.py
+++ b/prosper/tools/dump_hygiene.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""dump_hygiene — report (and optionally remove) files in a game dump that prosper must never load.
+
+Some dumps in circulation ship third-party replacements of Sony libraries: `dlc_emu` builds
+libSceAppContent / libSceNpEntitlementAccess / libSceGameUpdate, and `ampr_emu` builds libSceAmpr.
+They exist because on real hardware you cannot reimplement the platform — the only lever is
+substituting a library. prosper *is* the platform layer, so those substitutions are redundant, and
+worse than redundant: linking one would shadow prosper's own implementation and answer the guest
+with somebody else's stub, so every entitlement or asset result measured afterwards would be theirs
+rather than ours.
+
+`src/host/image/module_path_policy.hpp` already makes the loader refuse them. This tool is the
+other half: it finds them, says what each one is, and can take them off the disk entirely, so the
+question does not depend on a runtime guard staying correct forever.
+
+Four categories, and the distinction between the last two is the whole reason this is a tool rather
+than an `rm`:
+
+  REFUSED   a module prosper will never link (`fakelib/`, or any module outside the permitted
+            directories). Removing it changes nothing prosper does. `--strip` removes these.
+  MARKER    release-group provenance — an `.nfo`, a group directory. Read by nothing. `--strip`
+            removes these.
+  CONSUMED  prosper genuinely reads this. `dlc_emu.ini` is the declared add-content inventory that
+            `src/hle/service/hle_addcontent.cpp` parses. NEVER removed, at any flag combination.
+  RETAINED  third-party data prosper does not currently read, but which describes where the dump's
+            real content lives — `ampr_emu.index` maps the APR file-id API onto a repacked tree.
+            Reported so you know it is there; never removed, because deleting a description of
+            where assets are is not reversible by re-running anything.
+
+usage:
+    dump_hygiene.py <dump>...              # report only
+    dump_hygiene.py --strip --yes <dump>   # remove REFUSED + MARKER
+    dump_hygiene.py --check <dump>...      # exit nonzero if any REFUSED remain (onboarding gate)
+    dump_hygiene.py --json <dump>...       # machine-readable
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+# Must stay equal to kPermittedModuleDirs in src/host/image/module_path_policy.hpp. A drift here
+# would make the tool report a module as REFUSED that the loader in fact links, or vice versa — so
+# tests/tools/test_dump_hygiene.py reads the C++ header and asserts the two agree, rather than
+# trusting this comment.
+PERMITTED_MODULE_DIRS = ("Media/Modules", "Media/Plugins", "sce_module")
+
+# Only real module extensions. `.bin` was here briefly and was a disaster: it is the most generic
+# data extension there is, and a sweep of the corpus reported 1,012 `Media/StreamingAssets/**/*.bin`
+# and 914 `COMMON/ui/uv/*.bin` game-data files as refused modules. A tool whose output is thousands
+# of false rows is a tool nobody reads.
+MODULE_SUFFIXES = (".prx", ".sprx")
+
+# The signal this tool exists to find: a module that IMPERSONATES a Sony library. A title's own
+# native plugins are game content and are none of our business, even in directories prosper does not
+# link from -- `prx/akaudioinput.prx` is Wwise, shipped by the developer. What matters is a `libSce*`
+# somewhere it could shadow prosper's own implementation of that same library.
+SONY_LIBRARY_PREFIX = "libsce"
+
+# Sony's own metadata directory. Authentic dump content, present in every dump including ones with
+# no third-party additions at all. prosper does not LINK from here -- `sce_sys/about/right.sprx` is
+# not a module the loader wants -- but "prosper does not link it" and "it does not belong in the
+# dump" are different claims, and only the second is this tool's business. Caught by dry-running
+# against a known-clean dump: without this exclusion every one of the 50 dumps reported a REFUSED
+# row for right.sprx, and --strip would have deleted an authentic Sony file from all of them.
+SONY_DATA_DIRS = ("sce_sys",)
+
+# Files prosper parses. Never removed.
+CONSUMED = {
+    "dlc_emu.ini": "declared add-content inventory, parsed by hle_addcontent.cpp",
+}
+
+# Not read by prosper, and still never removed -- for two quite different reasons.
+RETAINED_FILES = {
+    "ampr_emu.index": "maps the APR file-id API onto a repacked asset tree; nothing else "
+                      "describes that layout",
+}
+RETAINED_DIRS = {
+    "_original_files": "holds the dump's ORIGINAL Sony files, including an encrypted eboot.bin "
+                       "(entropy 8.000). This is the most provenance-valuable thing in the dump "
+                       "and the only local evidence of what the untouched file looked like",
+}
+
+# Directory names that carry no content, only provenance.
+MARKER_DIRS = ("_duplex_", "_unlimited_")
+MARKER_SUFFIXES = (".nfo", ".diz", ".sfv")
+
+REFUSED, MARKER, CONSUMED_K, RETAINED_K = "REFUSED", "MARKER", "CONSUMED", "RETAINED"
+
+
+def classify(rel: str, is_dir: bool) -> tuple[str, str] | None:
+    """Classify one dump-relative path. Returns (category, why) or None if unremarkable.
+
+    Pure: takes a relative path string, touches no filesystem. `rel` uses forward slashes.
+    """
+    parts = [p for p in rel.replace("\\", "/").split("/") if p]
+    if not parts:
+        return None
+    name = parts[-1]
+    lname = name.lower()
+    top = parts[0].lower()
+    directory = "/".join(parts[:-1])
+
+    if top in SONY_DATA_DIRS:
+        return None
+
+    if is_dir:
+        if lname in RETAINED_DIRS:
+            return (RETAINED_K, RETAINED_DIRS[lname])
+        if lname in MARKER_DIRS:
+            return (MARKER, "release-group directory; read by nothing")
+        return None
+
+    if name in CONSUMED:
+        return (CONSUMED_K, CONSUMED[name])
+    if name in RETAINED_FILES:
+        return (RETAINED_K, RETAINED_FILES[name])
+
+    if top in MARKER_DIRS or lname.endswith(MARKER_SUFFIXES):
+        return (MARKER, "release-group provenance; read by nothing")
+
+    if not lname.endswith(MODULE_SUFFIXES):
+        return None
+
+    if top == "fakelib":
+        return (REFUSED, "third-party replacement of a Sony library; prosper implements these "
+                         "APIs itself and must not delegate them to a bundled module")
+
+    # A Sony-named module anywhere but sce_module/ is the thing worth finding: it can only either
+    # shadow prosper's own implementation or sit there pretending to be a platform library.
+    if lname.startswith(SONY_LIBRARY_PREFIX) and directory.lower() != "sce_module":
+        where = f"{directory}/" if directory else "the dump root"
+        return (REFUSED, f"a Sony-named library in {where}; prosper implements the Sony libraries "
+                         f"itself and links them only from sce_module/")
+
+    return None
+
+
+def scan(dump: Path) -> list[dict]:
+    findings = []
+    for dirpath, dirnames, filenames in os.walk(dump, followlinks=False):
+        rel_dir = os.path.relpath(dirpath, dump)
+        rel_dir = "" if rel_dir == "." else rel_dir.replace(os.sep, "/")
+
+        # Classify directories, and do not descend into one we are going to report wholesale —
+        # otherwise a marker directory's contents each produce their own redundant row.
+        for d in list(dirnames):
+            rel = f"{rel_dir}/{d}" if rel_dir else d
+            got = classify(rel, is_dir=True)
+            if got:
+                cat, why = got
+                findings.append({"path": rel, "kind": "dir", "category": cat, "why": why,
+                                 "bytes": dir_size(Path(dirpath) / d)})
+                dirnames.remove(d)
+
+        for f in filenames:
+            rel = f"{rel_dir}/{f}" if rel_dir else f
+            got = classify(rel, is_dir=False)
+            if got:
+                cat, why = got
+                p = Path(dirpath) / f
+                findings.append({"path": rel, "kind": "file", "category": cat, "why": why,
+                                 "bytes": p.stat().st_size if p.is_file() else 0})
+    findings.sort(key=lambda x: (x["category"], x["path"]))
+    return findings
+
+
+def dir_size(p: Path) -> int:
+    total = 0
+    for dirpath, _, filenames in os.walk(p, followlinks=False):
+        for f in filenames:
+            fp = Path(dirpath) / f
+            try:
+                total += fp.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def human(n: float) -> str:
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if n < 1024 or unit == "GiB":
+            return f"{n:.0f} {unit}" if unit == "B" else f"{n:.1f} {unit}"
+        n /= 1024.0
+    return f"{n:.1f} GiB"
+
+
+def looks_like_a_dump(p: Path) -> bool:
+    # Guard for --strip: refuse to delete inside anything that is not recognisably a game dump.
+    return (p / "sce_sys").is_dir() and (
+        (p / "sce_sys" / "param.json").is_file() or (p / "sce_sys" / "param.sfo").is_file()
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0],
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("dumps", nargs="+", type=Path)
+    ap.add_argument("--strip", action="store_true",
+                    help="remove REFUSED and MARKER entries (never CONSUMED or RETAINED)")
+    ap.add_argument("--yes", action="store_true", help="do not prompt (required with --strip when "
+                                                       "stdin is not a terminal)")
+    ap.add_argument("--check", action="store_true",
+                    help="exit nonzero if any REFUSED entry is present")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+    args = ap.parse_args()
+
+    report, any_refused, exit_code = {}, False, 0
+
+    for dump in args.dumps:
+        if not dump.is_dir():
+            print(f"not a directory: {dump}", file=sys.stderr)
+            exit_code = 2
+            continue
+        findings = scan(dump)
+        report[str(dump)] = findings
+        if any(f["category"] == REFUSED for f in findings):
+            any_refused = True
+
+        if args.json:
+            continue
+
+        print(f"\n=== {dump.name} ===")
+        if not findings:
+            print("  clean — nothing prosper refuses, no provenance markers")
+            continue
+        for cat in (REFUSED, MARKER, CONSUMED_K, RETAINED_K):
+            rows = [f for f in findings if f["category"] == cat]
+            if not rows:
+                continue
+            verb = {REFUSED: "prosper will not link",
+                    MARKER: "read by nothing",
+                    CONSUMED_K: "prosper reads this — kept",
+                    RETAINED_K: "not read by prosper, but kept"}[cat]
+            print(f"  {cat} ({verb}):")
+            for r in rows:
+                print(f"    {r['path']}{'/' if r['kind'] == 'dir' else ''}  [{human(r['bytes'])}]")
+                print(f"        {r['why']}")
+
+        if args.strip:
+            removable = [f for f in findings if f["category"] in (REFUSED, MARKER)]
+            if not removable:
+                print("  nothing to strip")
+                continue
+            if not looks_like_a_dump(dump):
+                print(f"  REFUSING to strip: {dump} has no sce_sys/param.* — this does not look "
+                      f"like a game dump", file=sys.stderr)
+                exit_code = 2
+                continue
+            if not args.yes:
+                if not sys.stdin.isatty():
+                    print("  --strip needs --yes when stdin is not a terminal", file=sys.stderr)
+                    exit_code = 2
+                    continue
+                if input(f"  remove {len(removable)} entries from {dump.name}? [y/N] ").lower() != "y":
+                    print("  skipped")
+                    continue
+            for r in removable:
+                target = dump / r["path"]
+                try:
+                    if r["kind"] == "dir":
+                        shutil.rmtree(target)
+                    else:
+                        target.unlink()
+                    print(f"  removed {r['path']}")
+                except OSError as e:
+                    print(f"  FAILED to remove {r['path']}: {e}", file=sys.stderr)
+                    exit_code = 2
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+
+    if args.check and any_refused:
+        return 1
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

prosper must never load a third-party module that answers a platform query on its behalf. It
already didn't — but only by accident, and nothing said so or tested it. This makes it a contract,
adds the tool that finds such files on disk, and rewrites the charter's legitimacy claims so every
one of them is checkable from the repository.

## The problem

Some PS5 dumps ship a `fakelib/` directory of replacement Sony libraries. Identified from the
binaries themselves — they carry their own build paths:

| library | tool | reads |
| --- | --- | --- |
| `libSceAppContent`, `libSceNpEntitlementAccess`, `libSceGameUpdate` | `dlc_emu` | `/app0/dlc_emu.ini` |
| `libSceAmpr` | `ampr_emu` | `/app0/ampr_emu.index` |

They exist because on real hardware you cannot reimplement the platform — the only available lever
is substituting a library. prosper *is* the platform layer, so those substitutions are redundant.
Linking one would shadow prosper's own implementation and answer the guest with somebody else's
stub, which is both the one thing the charter says the emulator must never do and a silent
invalidation of every entitlement or asset result measured afterwards.

**prosper did not load them — for three unrelated reasons, none of them stated or tested.**
`discover_extra_plugin_modules()` scans one fixed directory, is not recursive, and matches `.prx`
where `fakelib` ships `.sprx`. #1609 widened module discovery once already; any of those three
changing would have started loading them with nothing anywhere to notice.

## What changed

**`src/host/image/module_path_policy.{hpp,cpp}`** — a reject-by-default allowlist of the dump
locations a module may be linked from (`eboot.bin`, `sce_module/`, `Media/Modules/`,
`Media/Plugins/`), applied at the one point where the link list is complete and before anything
opens or parses a module. Deliberately not switchable: a flag is what would end up set, so widening
is a source change and gets a reviewer.

It also closes a hole that was real rather than hypothetical. `Media/Plugins` is auto-linked
wholesale by #1609, so a Sony-named library placed there **would have been linked today**. `libSce*`
is now permitted only from `sce_module/`. Measured across all 50 local dumps: zero ship a `libSce*`
under `Media/*`; 27 shipped exactly such files under `fakelib/`.

**`tools/dump_hygiene.py`** — finds them on disk, in four categories, because "prosper does not link
it" and "it does not belong in the dump" are different claims:

- `REFUSED` — impersonates a Sony library. `--strip` removes.
- `MARKER` — release-group provenance, read by nothing. `--strip` removes.
- `CONSUMED` — prosper parses it (`dlc_emu.ini`). Never removed.
- `RETAINED` — never removed for a different reason: `ampr_emu.index` describes where a repacked
  dump's assets are, and `_original_files/` holds the dump's **original** Sony files.

**`CLAUDE.md`** — the charter asserted the dump is "the developer's own legally-obtained copy". That
is a claim about the developer, not the software; nothing in the repository can verify it; and a
public charter asserting something unverifiable invites the scrutiny it is meant to avoid. Replaced
with claims that are true of the code and checkable, including the new one this PR earns: prosper
refuses to link third-party replacements of Sony libraries, with a guard and a test behind the
sentence.

## Measurements that went into it

Corpus-wide, 50 dumps:

- **Every eboot is plaintext** — Shannon entropy 6.4–6.8 bits/byte. The two dumps that preserve an
  untouched console original show that original at **8.000**, indistinguishable from `/dev/urandom`.
  So the charter's "SELF segments are already unencrypted" is now measured across the corpus rather
  than asserted for one title.
- **The additions are additive.** `sce_module/` holds the genuine Sony libraries in all 50; nothing
  was removed or stubbed. Ignore the additions and you are reading the authentic dump.
- **The eboot magic split is not a provenance signal.** 14 dumps use `0x1D3D154F` and 36 use
  `0xEEF51454`, both appear on plaintext eboots, and it tracks neither firmware version nor
  scene markers. `module.cpp:85` already documented the two as byte-identical from offset 4.
- `ampr_emu.index` indexes the dump's **own** files (`/app0/data/2dpar/sprite_c.par` …), so no asset
  tree was rearranged and APR work is against a real layout.

## Verification

- `cmake --build -j6` clean, 0 errors.
- `ctest --no-tests=error -j4` → **297/297 passed, exit 0**, Vulkan present so the execution tests
  ran rather than skipping.
- **`test_module_path_policy`: 33 checks. Nine mutations applied, built and run; all nine redden.**
  Removing the call site reddens the end-to-end arm — which is what makes it a regression guard
  rather than a restatement of an invariant. The `fakelib` arm is labelled in the source as the
  weaker *invariant* kind, because discovery never reaches it today and it cannot fail now; its job
  is to fail if discovery widens.
- **`dump_hygiene_classifier`: 15 tests, five mutations, all five redden.** Two of them did **not**
  at first: rewriting the classifier to key on "impersonates a Sony library" rather than "module in
  an unexpected place" had quietly made `MODULE_SUFFIXES` and `SONY_DATA_DIRS` defence-in-depth
  rather than load-bearing, so those arms were passing for a different reason than their names
  claimed. Each is now paired with an arm that exercises the guard it is named after, and the file
  says which is which.
- The tool was **wrong twice during development, both times in the direction that deletes authentic
  content** — `.bin` in the module-suffix list produced 1,926 false rows over game data, and
  `sce_sys/about/right.sprx` was reported REFUSED in all 50 dumps including clean ones, so `--strip`
  would have deleted an authentic Sony file from every one. Both were caught by dry-running against
  a dump known to be clean, not by reading the code. Both are pinned.

Local dumps were stripped after recording a provenance manifest: 81 entries removed, 27 emptied
`fakelib` directories pruned. Post-strip: `--check` exits 0 on all 50; `dlc_emu.ini` 9/9,
`ampr_emu.index` 18/18, `_original_files` 2/2, `sce_sys/about/right.sprx` 50/50 and `sce_module/`
50/50 all intact.

Docs gate: `GAME_COMPAT_ORCHESTRATION.md` 14 tables / 278 rows, numbered column 1..216 unique and
ascending, no baseline row deleted; all repo `.md` unbroken.

## Deliberately unaffected

Windows and macOS behaviour is unchanged — the policy is pure string logic with no platform
branches. No title's boot path changes: every dump's link set is identical before and after, which
is what the whole-list invariant arm asserts.
