### PR TITLE
loader: give Il2cppUserAssemblies.prx a real module-param descriptor — PGA TOUR 2K25's 1.2 s PSN crash

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -33,6 +33,51 @@ this is the real scene, not a cutscene. Tracker [#1898](...).
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,
 > because the point of a blog is that it records *when* things happened.
 
+## 2026-08-22
+
+### PGA TOUR 2K25 told us exactly what was wrong, in English, and it was not what it said
+
+No picture with this one — the title still does not render. The finding is what moved.
+
+A new Unity 6 / IL2CPP title, 35 GB, and it died 1.2 seconds into every boot. What made it unusual
+is that it *announced* the crash first:
+
+```
+ERROR...
+ PSN is an old version that cannot be used by the current player runtime.
+ Please update the PSN native module and any associated managed assemblies to the latest versions
+```
+
+That message is a lie in the most useful possible way. Nothing is old, and no module is missing.
+The string is not in the dump anywhere as plain text — it lives compressed inside the Unity data —
+so it had to be chased through the disassembly of `Il2cppUserAssemblies.prx` instead, which is where
+it turned into an exact mechanism. The game holds two globals: an argument count and a pointer to a
+"plugin args" struct. It checks the count has a bit above the low nibble, then checks the struct
+says `size == 0x10` and `version == 0x200`. Both globals were zero, so it took the mismatch branch —
+and the mismatch branch's own third `printf`, the one that would have politely told us which version
+it found, reads that version straight off the NULL pointer. The error handler is the crash.
+
+`tools/re/xref.py` found exactly one writer of the pointer, and it was a two-instruction function
+that stores `rdi` and `rsi` and returns: the module's `module_start(size_t argc, const void *argp)`.
+prosper was starting the module with `(0, NULL)`.
+
+The good part is what was already in the tree. prosper has had that exact descriptor —
+`{size = 0x10, version = 0x200, callback = 0}` — since the PSN.prx work, sitting in
+`exec_image_linux.cpp` under a comment reading *"the descriptor Sony's PSN/SaveData plugin
+module_start validates"*. Same two constants. The Unity PSN package simply does not always ship as
+its own `PSN.prx`: with IL2CPP its native half can be linked straight into the user-assemblies
+module, and then the handshake belongs to *that* module's `module_start`. It only ever needed to be
+told about one more module.
+
+With that fixed the title runs six times longer, streams its assets through Ampr, brings up the
+compute backend and submits over a thousand draws — and then dies again, on a thread called
+`Background Job.`, in a loop scanning for `:` and CRLF. An HTTP header parser, walking a NULL
+buffer, because `sceHttp2SendRequest` returned `0` for a request that was never sent, `0` is
+`SCE_OK`, and `sceHttp2GetAllResponseHeaders` then reported success without writing anything to its
+out-parameters. Rung 0 still, but every metre of that is now named:
+[#2894](https://github.com/mattias800/prosper/issues/2894), tracker
+[#2895](https://github.com/mattias800/prosper/issues/2895).
+
 ## 2026-08-21
 
 ### Yakuza Kiwami allocates its entire game heap through a Sony API nobody had implemented

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -19,7 +19,7 @@ see [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md), which is **generated from the 
 and kept in step with them by CI. Neither file is authoritative over a tracker; when this page and
 a tracker disagree, the tracker wins.
 
-Last updated: 2026-08-17
+Last updated: 2026-08-22
 
 ## Summary
 
@@ -74,6 +74,7 @@ Last updated: 2026-08-17
 | *Spacebase Startopia* | `PPSA02846` | Unity 2020.3.1 / IL2CPP | 🔬 Not yet booted — nothing run against it yet | [#2887](https://github.com/mattias800/prosper/issues/2887) |
 | *Sifu* | `PPSA03001` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2885](https://github.com/mattias800/prosper/issues/2885) |
 | *Unbound: Worlds Apart* | `PPSA03274` | Unreal Engine 4 | 🔬 Not yet booted — nothing run against it yet | [#2886](https://github.com/mattias800/prosper/issues/2886) |
+| *PGA TOUR 2K25* | `PPSA17952` | Unity 6 / IL2CPP | 🔬 Rung 0 — boots in 437 ms, streams its Unity assets and submits real draws, but every frame is black and a worker thread dies parsing a NULL HTTP response header ([#2894](https://github.com/mattias800/prosper/issues/2894)). The PSN `module_start` handshake that killed it at 1.2 s is fixed | [#2895](https://github.com/mattias800/prosper/issues/2895) |
 
 ## At a glance
 
@@ -93,7 +94,7 @@ unmeasured title is never mistaken for a failing one; newly tracked titles start
 | **Title screen or menu** reached, or gameplay reached without a rendered world (rung 2) | 14 |
 | **Below a title screen** — logo or splash only (rung 1) | 1 |
 | **Not yet booted** — tracked, no run attempted yet | 9 |
-| Total tracked | 49 |
+| Total tracked | 50 |
 
 "Gameplay reached" is the ladder's rung 3 and says nothing about how complete the rendered scene is.
 **Rung 3 requires the gameplay scene to actually render, not merely to be reached.** The bar is

--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -159,6 +159,7 @@ of its manifest.
 | Judgment | `PPSA02739` | 0 | `------` | none | - | none | - | [#2880](https://github.com/mattias800/prosper/issues/2880) | - |
 | Little Nightmares II | `PPSA02154` | 0 | `------` | none | - | none | - | [#2884](https://github.com/mattias800/prosper/issues/2884) | - |
 | Metaphor: ReFantazio | `PPSA20800` | 0 | `------` | none | - | none | - | [#2876](https://github.com/mattias800/prosper/issues/2876) | - |
+| PGA TOUR 2K25 | `PPSA17952` | 0 | `------` | none | - | none | [#2894](https://github.com/mattias800/prosper/issues/2894) | [#2895](https://github.com/mattias800/prosper/issues/2895) | [`PGA_TOUR_2K25_STATUS.md`](prosper/docs/PGA_TOUR_2K25_STATUS.md) |
 | Sifu | `PPSA03001` | 0 | `------` | none | - | none | - | [#2885](https://github.com/mattias800/prosper/issues/2885) | - |
 | Sniper Ghost Warrior Contracts 2 | `PPSA03130` | 0 | `------` | none | - | none | - | [#2867](https://github.com/mattias800/prosper/issues/2867) | - |
 | Spacebase Startopia | `PPSA02846` | 0 | `------` | none | - | none | - | [#2887](https://github.com/mattias800/prosper/issues/2887) | - |
@@ -175,8 +176,8 @@ of its manifest.
 | 3 -- gameplay with the scene rendering | 8 |
 | 2 -- title screen | 14 |
 | 1 -- any real graphics | 1 |
-| 0 -- not started | 11 |
+| 0 -- not started | 12 |
 
-**4 of 50** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 51** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -1206,6 +1206,14 @@ if(TARGET prosper_core)
   target_include_directories(test_support_modules PRIVATE src)
   add_test(NAME loader_support_modules COMMAND test_support_modules)
 
+  # Which preloaded modules are started with a real SCE module-param descriptor. Pure policy over
+  # the fixed guest base map: no dump, no SELF parser, no filesystem — so both the inclusion and the
+  # exclusion direction are checkable in ordinary CI.
+  add_executable(test_module_start_params tests/host/image/test_module_start_params.cpp
+                                          src/host/image/module_start_params.cpp)
+  target_include_directories(test_module_start_params PRIVATE src)
+  add_test(NAME module_start_params COMMAND test_module_start_params)
+
   add_executable(test_boot_phase_log tests/diagnostics/test_boot_phase_log.cpp)
   target_link_libraries(test_boot_phase_log PRIVATE prosper_core)
   add_test(NAME diagnostics_boot_phase_log COMMAND test_boot_phase_log)

--- a/prosper/docs/PGA_TOUR_2K25_STATUS.md
+++ b/prosper/docs/PGA_TOUR_2K25_STATUS.md
@@ -1,0 +1,175 @@
+# PGA TOUR 2K25 (`PPSA17952`) — bring-up status
+
+**Rung 0** as of 2026-08-22. The guest boots, links, loads assets and submits real GPU work, but no
+frame the live renderer publishes is anything other than black, and the process dies on a worker
+thread before a title screen. First bring-up session; nothing about this title existed in the repo
+before it.
+
+| | |
+| --- | --- |
+| Engine | Unity **6000.0.20f1** (Unity 6) / IL2CPP |
+| SDK | **9.00** (`sdkVersion 0x0900000000000000`) — below the SDK ≥ 13 post-submit-visibility gate |
+| Content | `UP1001-PPSA17952_00-PGATOUR2K25GBL00`, `contentVersion 01.026.000` |
+| Video out | 3840x2160, `hdr-display-enabled=1`, `gfx-threading-mode=4`, native gfx jobs |
+| Modules | `Media/Modules/{Il2cppUserAssemblies,PS5Util}.prx`, five `Media/Plugins/*.prx` (Photon Voice, Burst, Opus, spatializer), `sce_module/{libc,libSceFace,libSceFaceTracker,libSceJobManager,libSceNpCppWebApi,libScePfs}.prx` |
+
+## Reproduction route
+
+No pad route exists yet — the title dies before any menu, so there is nothing to drive.
+
+```bash
+PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct PROSPER_BOOTPHASE=1 \
+PROSPER_SAVE0=<WORK>/save0 SDL_VIDEODRIVER=offscreen \
+  ./build-linux/screenshot <DUMP_ROOT>/PPSA17952-app0 \
+    --seconds 7 --count 20 --out <WORK>/shots --timeout 300
+```
+
+Frontend: `tools/screenshot`, default route, no pad input. Outer `timeout 480` differs from the
+inner `--timeout 300` deliberately (instrument trap 214), and `--seconds 7` is prime (trap 211).
+
+## What works
+
+Boot is fast and clean — `BOOT_COMPLETE` at **+437 ms**, ten modules linked and mapped. The engine
+then reaches deep into its own startup: it streams `Media/data.unity3d` through the **Ampr** path
+(`[apr] read-submit … OK`), opens `StreamingAssets/ContentArchives/archive_dependencies.bin` and the
+DOTS `StreamingAssets/EntityScenes/scene_info.bin`, brings up the live Vulkan compute backend, and
+submits real draws — `CB_COLOR_CONTROL.MODE=0` alone is counted past 1024 draws in a 7 s window.
+
+So neither the loader, the IL2CPP path, the asset layer nor the recompiler is the frontier here.
+
+## The first blocker (fixed in this session)
+
+The title died at **1.2 s on every boot** with `SIGSEGV addr=0x4 rip=Il2cpp+0x6a112`, immediately
+after printing its own diagnosis:
+
+```
+ERROR...
+ PSN is an old version that cannot be used by the current player runtime.
+ Please update the PSN native module and any associated managed assemblies to the latest versions
+```
+
+That message is not about a missing module. Disassembling `Il2cppUserAssemblies.prx` names the
+mechanism exactly:
+
+```
+6a09a:  mov  rax,[rip+…]            # global A
+6a0ae:  cmp  rax,-1
+6a0b2:  je   0x6a12f                ; -1 => not initialized, skip
+6a0b4:  mov  rbx,[rip+…]            # global B = the plugin-args pointer
+6a0bb:  test eax,0xfffffff0
+6a0c0:  je   0x6a0dd                ; argc has no high bits => ERROR path
+6a0c2:  cmp  DWORD PTR [rbx],0x10   ; argp->size    == 0x10
+6a0c7:  cmp  DWORD PTR [rbx+4],0x200; argp->version == 0x200
+6a0d0:  mov  rax,[rbx+8]            ; argp->callback
+…
+6a112:  mov  esi,DWORD PTR [rbx+0x4]   ; <-- faults: rbx is NULL
+```
+
+`xref.py` finds exactly **one** writer of global B, a two-instruction setter that stores `rdi` and
+`rsi` — i.e. the module's `module_start(size_t argc, const void *argp)` arguments. prosper started
+that module with `(0, NULL)`, so both globals were zero: `A != -1` so no skip, `A & ~0xF == 0` so the
+error branch, and then the error branch's own third `printf` reads `argp->version` off a NULL `argp`.
+
+prosper already had the descriptor this handshake wants — `{size=0x10, version=0x200, cb=0}` in
+`src/host/image/exec_image_linux.cpp`, commented as *"the descriptor Sony's PSN/SaveData plugin
+module_start validates"*. It was simply not registered for this module, because on every title seen
+until now the Unity PSN package shipped as a separate `PSN.prx`. **With IL2CPP the package's native
+half can be linked straight into `Il2cppUserAssemblies.prx` instead**, and then it is that module's
+`module_start` which performs the handshake. Registering `{BOOT_IL2CPP, BOOT_PSNCORE}` in
+`set_module_start_param_ranges` fixes it.
+
+The blast radius is one function per module: every module prosper links has `DT_INIT` at `image+0x10`
+and an **empty** `DT_INIT_ARRAY` (measured with `PROSPER_INITLOG=1` across all ten of this title's
+modules), so the range selects the real `module_start` and never a C++ static constructor.
+
+## The current blocker
+
+With the handshake fixed the title runs ~6x longer and reaches GPU submission, then dies on a
+**worker thread named `Background Job.`**:
+
+```
+[prosper] WORKER-THREAD FAULT: sig=11 addr=(nil) rip=0x41142d5e0 (image+0x142d5e0)
+[prosper]   insn bytes @rip: 41 0f b6 14 0b   (movzx edx,BYTE PTR [r11+rcx*1])   r11=0 rcx=0
+```
+
+`eboot+0x142d5e0` is an **HTTP response-header parser** — it scans for `0x09..0x0d`/`0x20`
+whitespace, then `:` (0x3a), then CR/LF — and it is walking a NULL buffer. Immediately before the
+fault the log shows the whole libSceHttp2 request lifecycle answered by the dispatcher's
+unregistered-NID default of `0`:
+
+| NID | Name | prosper today |
+| --- | --- | --- |
+| `+wCt7fCijgk` | `sceHttp2CreateTemplate` | 0 |
+| `mmyOCxQMVYQ` | `sceHttp2CreateRequestWithURL` | 0 |
+| `N4UfjvWJsMw` | `sceHttp2CreateCookieBox` | 0 |
+| `nrPfOE8TQu0` | `sceHttp2AddRequestHeader` | 0 |
+| `rbqZig38AT8` | `sceHttp2SendRequest` | 0 |
+| `-rdXUi2XW90` | `sceHttp2GetAllResponseHeaders` | 0 |
+| `9XYJwCf3lEA` | `sceHttp2GetStatusCode` | 0 |
+| `o0DBQpFE13o` | `sceHttp2GetResponseContentLength` | 0 |
+
+`0` is `SCE_OK`. So `sceHttp2SendRequest` reports that a request the emulator never sent
+**succeeded**, and `sceHttp2GetAllResponseHeaders` reports that it returned headers while writing
+nothing to its out-parameters. The guest then parses the NULL it was handed. This is precisely the
+silent-success-stub failure the charter names, and `src/hle/net/hle_http.cpp` already states the
+right principle for this library family in its first comment: *"Network requests remain offline, but
+parsing is local and deterministic: returning success without filling this structure makes callers
+dereference stale pointer fields."*
+
+The fix is to implement libSceHttp2's lifecycle honestly — local resource creation genuinely
+succeeds, setters genuinely record state, and anything that would need a network answer **reports
+failure instead of `SCE_OK`**, leaving out-parameters untouched. That was deliberately **not** done
+in this session: the correct Sony error values for the libSceHttp2 facility are not derivable from
+the dump, from `../PS5-3.20_Libs/` (which gives names and NIDs only, no values), or from prosper's
+existing `0x8043xxxx` libSceHttp constants, and inventing one would be fabrication rather than
+reimplementation. Tracked separately.
+
+Other unimplemented NIDs seen on the same boot, none of which is implicated in the fault:
+`sceNpAuthCreateAsyncRequest`, `sceNpAuthGetAuthorizationCodeV3`, `sceNpAuthWaitAsync`,
+`sceNpRegisterNpReachabilityStateCallback`, `sceNpSessionSignalingInitialize`,
+`sceShareRegisterContentEventCallback`, `sce::Json::InitParameter2::InitParameter2`,
+`sce::Json::InitParameterRtti2::setAllocatorRtti`, and one libkernel NID (`tU5e3f9gSiU`) that is
+**not present in FW 3.20** and so cannot be named from the reference library set.
+
+## Rendering
+
+Not yet assessable, and deliberately not called a defect. The single frame the run captured before
+dying is pure black (1 distinct colour over 3840x2160), and the renderer says why:
+
+```
+[rtt] GUEST SCANOUT #1: no present source and no renderer target at the flipped buffer 0x0
+[rtt] PRESENT SOURCE EXTENT MISMATCH #1: no pass produced a 3840x2160 present source
+[render] frame 0: Vulkan render FAILED (3840x2160)
+```
+
+The guest flips a buffer whose address is `0x0`. Whether that is an independent renderer problem or
+another consequence of the aborted startup cannot be separated until the title survives past the
+HTTP fault, so no hypothesis is recorded here yet.
+
+## Ruled out
+
+- **"The `only_if_imported` filter (#2870/#2890) drops `sce_module/libSceNpCppWebApi.prx` for this
+  title, and that is what makes the PSN handshake fail."** Falsified 2026-08-22 on `97b184ef`:
+  `PROSPER_INITLOG=1` lists it as **module 8, base `0x4d0000000`** — it is linked, mapped and
+  started. Something among the non-candidate modules vouches for it. The PSN failure was the
+  `module_start` descriptor above and had nothing to do with module selection.
+- **"`PROSPER_NULL_PAGE=1` gets this title past the worker-thread fault."** Falsified 2026-08-22:
+  with it set, the same thread still dies, `0x23` bytes further along at `eboot+0x142d603` — the
+  null-backed read is re-executed and the *next* access in the same header parser faults. The switch
+  is a bounded diagnostic (its own comment says *"Diagnostic, NOT a fix"*), and what it established
+  here is that the cascade is short and local to one parser, which is what pointed at the NULL
+  header buffer rather than at broken heap state.
+- **"The unimplemented libkernel NID `tU5e3f9gSiU` is the cause of the 1.2 s death."** Falsified
+  2026-08-22: it is still unimplemented and still returns `0` after the `module_start` fix, and the
+  crash is gone. It was adjacency, not causation — worth recording because it was the only
+  unimplemented NID in the entire pre-fix boot, which made it look conclusive.
+
+## Not yet investigated
+
+- Whether a title screen sits directly behind the HTTP fault, or behind further walls. The faulting
+  thread is a Unity job thread, so it is not obvious that the main thread would reach a menu even if
+  the job survived; this has not been tested and should not be assumed either way.
+- The SDK-9 submit race (#2219). This title is pre-13 like *ArcRunner* (SDK 10) and *Crisis Core*,
+  so `PROSPER_POST_SUBMIT_VISIBILITY=1` is a known lever if an unexplained mid-boot death appears
+  later. It has **not** been needed so far and was not exercised — the two deaths seen here are both
+  fully explained above.

--- a/prosper/docs/PGA_TOUR_2K25_STATUS.md
+++ b/prosper/docs/PGA_TOUR_2K25_STATUS.md
@@ -133,8 +133,10 @@ Other unimplemented NIDs seen on the same boot, none of which is implicated in t
 
 ## Rendering
 
-Not yet assessable, and deliberately not called a defect. The single frame the run captured before
-dying is pure black (1 distinct colour over 3840x2160), and the renderer says why:
+Not yet assessable, and deliberately not called a defect. Every frame captured is pure black — 1
+distinct colour over 3840x2160 — and that is not an artifact of the sampling interval: a second run
+at `--seconds 1` (30 requested, `--allow-guest-fault --no-stop-after-guest-fault`) captured 3 frames
+before the fault and all 3 are uniformly black. The renderer says why:
 
 ```
 [rtt] GUEST SCANOUT #1: no present source and no renderer target at the flipped buffer 0x0

--- a/prosper/src/host/image/boot_program.cpp
+++ b/prosper/src/host/image/boot_program.cpp
@@ -3,6 +3,7 @@
 // (Linux/macOS: exec_image_linux.cpp; Windows: exec_image_win.cpp).
 #include "host/image/boot_program.hpp"
 #include "host/image/module_path_policy.hpp"
+#include "host/image/module_start_params.hpp"
 
 #include <algorithm>
 #include <cctype>
@@ -377,12 +378,17 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
     // Enable real runtime PRX loading now that the fixed set is linked, mapped and stubbed (#639).
     runtime_module_loader_init(&p);
 
-    // PSN.prx / SaveData.prx native plugins validate a module-param descriptor and null-fault if
-    // started with (argc=0, argp=NULL). Register their guest ranges so run_guest_inits starts them
-    // with the real descriptor. Skipped when PROSPER_NO_PSN drops them.
+    // Native Unity PSN/SaveData plugins validate a module-param descriptor at module_start and
+    // null-fault if started with (argc=0, argp=NULL). Register their guest ranges so run_guest_inits
+    // starts them with the real descriptor. Which ranges, and why each one, is module_start_params.
+    // Skipped when PROSPER_NO_PSN drops them.
+    //
+    // Every module prosper links has DT_INIT at image+0x10 and an EMPTY DT_INIT_ARRAY, so a range
+    // there selects exactly one function — the module's real module_start — and never a C++ static
+    // constructor. A module_start that ignores its arguments is unaffected either way: (0x10, &desc)
+    // and (0, NULL) are both just unread registers to it.
     if (!getenv("PROSPER_NO_PSN"))
-        set_module_start_param_ranges({ { BOOT_PSN, BOOT_SAVEDATA }, { BOOT_SAVEDATA, BOOT_LIBC },
-                                        { BOOT_PSNCORE, 0x490000000ull }, { BOOT_PSNCOMMON, 0x4b0000000ull } });
+        set_module_start_param_ranges(module_start_param_ranges());
 
     // Diagnostics: guest initialization running.
     diagnostics::record_boot_phase(diagnostics::BootPhase::GUEST_INITS_RUNNING);

--- a/prosper/src/host/image/module_start_params.cpp
+++ b/prosper/src/host/image/module_start_params.cpp
@@ -1,0 +1,40 @@
+// module_start_params.cpp — see module_start_params.hpp.
+
+#include "host/image/module_start_params.hpp"
+
+#include "host/image/boot_program.hpp"
+
+namespace prosper {
+
+std::vector<std::pair<uint64_t, uint64_t>> module_start_param_ranges() {
+    return {
+        // Il2cppUserAssemblies.prx. The Unity PSN package does not always ship as its own PSN.prx:
+        // with IL2CPP its native half can be linked straight into the user-assemblies module, and
+        // then it is THAT module's module_start which stashes (argc, argp) for the handshake.
+        // PGA TOUR 2K25 (PPSA17952) is the measured case — its module_start stores both arguments,
+        // and the managed PSN initializer later requires argc & ~0xF and validates
+        // argp->{size==0x10, version==0x200}. Started with (0, NULL) it takes the mismatch branch,
+        // prints "PSN is an old version that cannot be used by the current player runtime", and
+        // then reads argp->version off the NULL argp — SIGSEGV at addr=0x4, 1.2 s into every boot.
+        // Same descriptor as PSN.prx below, because it is the same Unity package.
+        // CONFIDENCE: HIGH (guest disassembly at Il2cpp+0x6a0b4..0x6a112, one writer found by
+        // tools/re/xref.py). The upper bound is BOOT_PSNCORE because that is exactly how
+        // boot_program.hpp's own address classifier bounds the Il2cpp image.
+        { BOOT_IL2CPP,   BOOT_PSNCORE },
+        // Sony's native PSN.prx / SaveData.prx Unity plugins, the original case: their user
+        // module_start dereferences argp and null-faults when started with (0, NULL).
+        { BOOT_PSN,      BOOT_SAVEDATA },
+        { BOOT_SAVEDATA, BOOT_LIBC },
+        // PPSA02664's split Unity PSN native plugin (PSNCore.prx + PSNCommon.prx).
+        { BOOT_PSNCORE,  0x490000000ull },
+        { BOOT_PSNCOMMON, BOOT_COMMONDIALOG },
+    };
+}
+
+bool module_start_wants_param_descriptor(uint64_t addr) {
+    for (const auto& r : module_start_param_ranges())
+        if (addr >= r.first && addr < r.second) return true;
+    return false;
+}
+
+} // namespace prosper

--- a/prosper/src/host/image/module_start_params.hpp
+++ b/prosper/src/host/image/module_start_params.hpp
@@ -1,0 +1,28 @@
+// module_start_params.hpp — which linked modules need a real SCE module-param descriptor.
+//
+// prosper preloads a title's PRXs itself and starts each one through the PS5 module-entry ABI,
+// `module_start(size_t argc, const void *argp)`. Most modules ignore both arguments, so the default
+// (0, NULL) is fine. A native plugin that performs a version handshake does NOT: it stores argc and
+// argp at module_start and validates them later, and (0, NULL) makes it take its mismatch branch and
+// then dereference the NULL argp.
+//
+// This is pure policy over the fixed guest base map in boot_program.hpp — no dump, no SELF parser,
+// no filesystem — so both the "needs it" and the "must not get it" direction are checkable in
+// ordinary CI. The second direction is the load-bearing one: a predicate that answered true for
+// everything would satisfy the first arm perfectly while changing the entry ABI of every module
+// prosper links.
+#pragma once
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace prosper {
+
+// Guest [begin, end) ranges whose module_start must receive the descriptor. See the .cpp for why
+// each one is here.
+std::vector<std::pair<uint64_t, uint64_t>> module_start_param_ranges();
+
+// True when an init function at guest address `addr` falls in one of the ranges above.
+bool module_start_wants_param_descriptor(uint64_t addr);
+
+} // namespace prosper

--- a/prosper/tests/host/image/test_module_start_params.cpp
+++ b/prosper/tests/host/image/test_module_start_params.cpp
@@ -1,0 +1,81 @@
+// test_module_start_params.cpp — which modules are started with a real SCE module-param descriptor.
+//
+// The defect this pins: prosper starts every preloaded PRX through the PS5 module-entry ABI
+// `module_start(size_t argc, const void *argp)`, defaulting to (0, NULL). A native Unity plugin that
+// performs a version handshake stores both arguments at module_start and validates them later, so
+// (0, NULL) makes it take its mismatch branch and then dereference the NULL argp.
+//
+// Until PGA TOUR 2K25 (PPSA17952) the handshake had only ever been seen in a separate PSN.prx, so
+// only those ranges were registered. That title links the Unity PSN package's native half straight
+// into Media/Modules/Il2cppUserAssemblies.prx, whose module_start then does the handshake — and the
+// title died at 1.2 s on every boot with SIGSEGV addr=0x4 reading argp->version off NULL, after
+// printing "PSN is an old version that cannot be used by the current player runtime".
+//
+// Both directions are asserted and the EXCLUSION arm is the load-bearing one: a predicate that
+// answered true for everything would satisfy the inclusion arm perfectly while silently changing
+// the entry ABI of every module prosper links.
+
+#include <cstdio>
+#include <cstdint>
+
+#include "host/image/boot_program.hpp"
+#include "host/image/module_start_params.hpp"
+
+using prosper::module_start_param_ranges;
+using prosper::module_start_wants_param_descriptor;
+
+static int fails = 0;
+#define CHECK(cond, msg) do { if (!(cond)) { printf("  [FAIL] %s\n", msg); fails++; } \
+                              else        { printf("  [ok]   %s\n", msg); } } while (0)
+
+// Every module prosper links has DT_INIT at image+0x10 and an empty DT_INIT_ARRAY (measured with
+// PROSPER_INITLOG=1 across all ten of PPSA17952's modules), so a module's single init function is
+// its base + 0x10. Query that address rather than the bare base: it is what run_guest_inits sees.
+static constexpr uint64_t kInit = 0x10;
+
+int main() {
+    printf("module_start param ranges\n");
+
+    // --- INCLUSION: modules whose module_start performs the handshake. ---
+    CHECK(module_start_wants_param_descriptor(prosper::BOOT_IL2CPP + kInit),
+          "Il2cppUserAssemblies.prx module_start gets the descriptor (PPSA17952)");
+    CHECK(module_start_wants_param_descriptor(prosper::BOOT_PSN + kInit),
+          "PSN.prx module_start gets the descriptor");
+    CHECK(module_start_wants_param_descriptor(prosper::BOOT_SAVEDATA + kInit),
+          "SaveData.prx module_start gets the descriptor");
+    CHECK(module_start_wants_param_descriptor(prosper::BOOT_PSNCORE + kInit),
+          "PSNCore.prx module_start gets the descriptor (PPSA02664)");
+    CHECK(module_start_wants_param_descriptor(prosper::BOOT_PSNCOMMON + kInit),
+          "PSNCommon.prx module_start gets the descriptor (PPSA02664)");
+
+    // --- EXCLUSION: everything else keeps the (0, NULL) entry ABI it has always had. ---
+    // Without these a blanket-true predicate passes the whole inclusion block above.
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_EBOOT + kInit),
+          "the main executable is NOT given the descriptor");
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_LIBC + kInit),
+          "libc.prx is NOT given the descriptor");
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_PS5UTIL + kInit),
+          "PS5Util.prx is NOT given the descriptor");
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_NPCPPWEBAPI + kInit),
+          "libSceNpCppWebApi.prx is NOT given the descriptor");
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_COMMONDIALOG + kInit),
+          "CommonDialog.prx is NOT given the descriptor");
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_PLUGIN_AUTO_BASE + kInit),
+          "an auto-discovered Unity plugin is NOT given the descriptor");
+
+    // --- STRUCTURE: a range whose end is below its start silently matches nothing, which would
+    // make an inclusion arm above fail for a reason that reads as policy rather than as a typo. ---
+    const auto ranges = module_start_param_ranges();
+    CHECK(!ranges.empty(), "the range list is non-empty");
+    bool ordered = true;
+    for (const auto& r : ranges) if (r.first >= r.second) ordered = false;
+    CHECK(ordered, "every range is a non-empty [begin, end)");
+
+    // The Il2cpp range must stop at the next module base rather than swallowing its neighbours:
+    // boot_program.hpp's own address classifier bounds the Il2cpp image at BOOT_PSNCORE.
+    CHECK(!module_start_wants_param_descriptor(prosper::BOOT_IL2CPP - 1),
+          "the Il2cpp range does not extend below BOOT_IL2CPP");
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Onboards **PGA TOUR 2K25 (`PPSA17952`)** — a new Unity 6 / IL2CPP title, nothing about it existed in
the repo before — and fixes the first of its two boot deaths.

Tracker #2895. Refs #2895 (not `Fixes`, per the tracker convention).

## The failure

The title died at **1.2 s on every boot**, `SIGSEGV addr=0x4 rip=Il2cpp+0x6a112`, immediately after
printing its own diagnosis:

```
ERROR...
 PSN is an old version that cannot be used by the current player runtime.
 Please update the PSN native module and any associated managed assemblies to the latest versions
```

Nothing is old and no module is missing. The message is not present in the dump as plain text (it
lives compressed inside the Unity data), so it was chased through the disassembly of
`Il2cppUserAssemblies.prx`:

```
6a09a:  mov  rax,[rip+…]             # global A
6a0ae:  cmp  rax,-1
6a0b2:  je   0x6a12f                 ; -1 => not initialized, skip
6a0b4:  mov  rbx,[rip+…]             # global B = the plugin-args pointer
6a0bb:  test eax,0xfffffff0
6a0c0:  je   0x6a0dd                 ; argc has no bits above the low nibble => ERROR branch
6a0c2:  cmp  DWORD PTR [rbx],0x10    ; argp->size    == 0x10
6a0c7:  cmp  DWORD PTR [rbx+4],0x200 ; argp->version == 0x200
…
6a112:  mov  esi,DWORD PTR [rbx+0x4] ; <-- faults, rbx is NULL
```

The error branch's own third `printf` — the one that would have reported *which* version it found,
` Plugin args version, found %04x, expected %04x` — reads `argp->version` off the NULL `argp`. The
error handler is the crash.

`tools/re/xref.py` finds **exactly one** writer of global B: a two-instruction function that stores
`rdi` and `rsi` and returns, i.e. the module's `module_start(size_t argc, const void *argp)`
arguments. prosper started that module with `(0, NULL)`, so both globals were zero.

## Behavioral contract

prosper already had the descriptor this handshake wants — `{size=0x10, version=0x200, cb=0}` in
`exec_image_linux.cpp`, commented as *"the descriptor Sony's PSN/SaveData plugin module_start
validates"*, i.e. **the same two constants**. It was simply never registered for this module,
because on every title seen until now the Unity PSN package shipped as a separate `PSN.prx`. With
IL2CPP the package's native half can be linked straight into `Il2cppUserAssemblies.prx`, and then
the handshake belongs to *that* module's `module_start`.

`CONFIDENCE: HIGH` — guest disassembly plus a single-writer xref, and the fix is verified to remove
the fault on a live boot.

## Approach

`{BOOT_IL2CPP, BOOT_PSNCORE}` joins the range list. The upper bound is not arbitrary: it is exactly
how `boot_program.hpp`'s own address classifier already bounds the Il2cpp image.

The list moves out of `boot_program.cpp` into a pure-policy translation unit,
`src/host/image/module_start_params.{hpp,cpp}`, following the pattern
`src/loader/support_modules.cpp` established — no dump, no SELF parser, no filesystem, so the policy
is unit-testable in ordinary CI. `{BOOT_PSNCOMMON, 0x4b0000000ull}` becomes
`{BOOT_PSNCOMMON, BOOT_COMMONDIALOG}`, which is the same value written as the constant it already
equals.

## Affected and deliberately unaffected

**Blast radius is one function per module.** Every module prosper links has `DT_INIT` at
`image+0x10` and an **empty** `DT_INIT_ARRAY` — measured with `PROSPER_INITLOG=1` across all ten of
this title's modules — so a range selects the module's real `module_start` and never a C++ static
constructor. A `module_start` that ignores its arguments is unaffected either way: `(0x10, &desc)`
and `(0, NULL)` are both just unread registers to it.

The change does reach the IL2CPP `module_start` of **every** Unity title, which is the one thing
worth a reviewer's attention. Mitigations: the argument is only read by a module that looks at it;
`PROSPER_NO_PSN` still disables the whole mechanism; and the full suite is green. No snapshot matrix
was run — per `CLAUDE.md` snapshots are a release-time inventory rather than a merge gate — so if a
reviewer wants a guarded Unity title exercised before merge, say which and I will run it.

## Verification

Built and tested in the `ps5ys` distrobox, `-DGAME_DUMP=<DUMP_ROOT>/PPSA17952-app0`.

```
ctest --test-dir prosper/build-linux --no-tests=error --output-on-failure
100% tests passed out of 299
```

299 executed, 4 skipped, all four dump-parameterized: `module_loads_eboot`,
`boot_reaches_first_syscall`, `real_shader_render` (#1573, they assert against PPSA24651's bytes)
and `plugin_autolink` (skips because this dump ships no `PSN.prx` — *"21 of 30 local dumps ship no
PSN.prx"*, #1675, which is precisely the condition this PR is about). Baseline before the change on
the same dump was 298/298 with the same 4 skips; the new count is +1 for the test added here.

**The new test fails without the fix.** With `{BOOT_IL2CPP, BOOT_PSNCORE}` removed and nothing else
changed, exactly one assertion flips and the rest stay green:

```
  [FAIL] Il2cppUserAssemblies.prx module_start gets the descriptor (PPSA17952)
  [ok]   PSN.prx module_start gets the descriptor
  … 12 more ok …
FAILED (1)
```

The test asserts both directions, and the **exclusion** arm is the load-bearing one — eboot, libc,
PS5Util, libSceNpCppWebApi, CommonDialog and an auto-discovered plugin must all still be started
`(0, NULL)`. Without it a predicate that answered true for everything would pass the inclusion block
perfectly.

**On the live title** (`tools/screenshot`, default route, no pad input): the PSN error and the
`addr=0x4` fault are gone, `BOOT_COMPLETE` at ~400 ms, and the title now runs about six times
longer — streaming `data.unity3d` through Ampr, opening its DOTS `EntityScenes`, bringing up the
live Vulkan compute backend and submitting real draws (over 1024 in one 7 s window).

## What this does NOT fix

The title stays at **rung 0** and this PR claims no rung change. It now dies later, on a worker
thread named `Background Job.`, in an HTTP response-header parser at `eboot+0x142d5e0` walking a
NULL buffer: `sceHttp2SendRequest` returns `0` (`SCE_OK`) for a request that was never sent and
`sceHttp2GetAllResponseHeaders` returns `0` without writing its out-parameters. Filed as **#2894**
with the full NID census and a suggested fix; deliberately not attempted here because the correct
libSceHttp2 error values are not derivable from the dump or from `../PS5-3.20_Libs/`, and inventing
one would be fabrication.

No screenshot is attached, because the only frame captured is uniformly black — that is not
progression evidence.

## Also in this PR

- `prosper/docs/PGA_TOUR_2K25_STATUS.md` — new status doc, including a `## Ruled out` section with
  three falsifications recorded (the `only_if_imported` module-drop hypothesis, `PROSPER_NULL_PAGE`
  as a fix, and the unimplemented libkernel NID that looked conclusive and was pure adjacency).
- `COMPATIBILITY.md` row and `BLOG.md` entry (a finding without a picture, as the file invites).
- `PROGRESS_TRACKER.md` regenerated — `gen_progress_tracker.py` reports **51 trackers, 51 parsed**.

One note for the maintainer, recorded rather than silently "fixed": `COMPATIBILITY.md`'s *At a
glance* sub-counts do not sum to their own total (24+14+1+9 = 48 against a stated 49, before this
PR), and there is no bucket for a rung-0 title that has been booted. I bumped **Total tracked** to
50 and left the sub-counts alone rather than publish figures I had not verified.
