### PR TITLE
docs: move the blog's authoring rules out of the blog and into the charter

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -12,43 +12,8 @@ blog, so the generator and its CI gate are gone.
 [`PROGRESS_TRACKER.md`](PROGRESS_TRACKER.md) the per-title rung table — that one *is* still generated
 from the tracker issues, and still gated, because it is a projection of state rather than a story.
 
-## How to add an entry
-
-**This is a screenshot blog. Image-heavy, text-light — always.**
-
-Put the entry at the **top**, under a `## YYYY-MM-DD` heading.
-
-**Pictures: as many as you have.** Every screenshot a PR produced belongs in its entry. An entry
-covering eight titles shows eight titles, not one. A picture costs the reader nothing to skip and
-everything to not have, and it is the only part of this file that shows what prosper actually does.
-Never economise here.
-
-**Words: one sentence saying what now works.** That is genuinely enough:
-
-> *We now reach correct rendering of the Sonic Frontiers title screen.*
-
-Then the screenshot. Add a second sentence only if the picture is misleading without it — a defect
-you want noticed, or a caveat about what the reader is seeing.
-
-**The one exception: a fix that moves several titles at once.** Those are worth a short paragraph
-explaining the problem and the fix, because they are the interesting ones and someone will want to
-know. Keep it to a paragraph, in plain language, and still lead with the pictures. A fix for one
-title does not get this — link its tracker instead.
-
-Everything else — measurements, bisects, censuses, mechanisms, reasoning — belongs in the tracker,
-the PR or the status doc. Link, never transcribe. Someone reads this file top to bottom to catch up,
-and a 900-word entry buries the four entries under it.
-
-```markdown
-## 2026-08-21
-
-### Beneath reaches gameplay
-
-<p align="center"><img src="assets/screenshots/beneath-gameplay.png" alt="..."></p>
-
-The opening dive. The waypoint counts down as the route moves and the dialogue plays over it —
-this is the real scene, not a cutscene. Tracker [#1898](...).
-```
+<!-- How to add an entry: see CLAUDE.md, the BLOG.md bullet under PR verification.
+     Image-heavy, text-light. Pictures: as many as you have. Words: one sentence. -->
 
 > An entry is evidence of what rendered **on the day it was written**. It is not a claim about the
 > title's current state — for that, read the tracker. Nothing is ever removed when a title moves on,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -621,11 +621,26 @@ either, and do not read `RENDER_LOOP.md`'s "Status: open" as current.
     what is new. It is **not** generated, so nothing backfills a missing entry and nothing goes red
     when one is skipped: the picture simply never surfaces, which is the whole failure this file
     exists to prevent.
-    Put the entry at the top under a `## YYYY-MM-DD` heading, with the image and a sentence about
-    **what you are looking at** — not what the change was. The commit subject already says what the
-    change was, and that is exactly what made the old generated feed useless. A paragraph when a
-    title finally does something ("we finally reached gameplay in X, look"), one line when it is just
-    another capture.
+    **It is a screenshot blog: image-heavy, text-light, always.** The rules used to live in
+    `BLOG.md`'s own header, which put authoring instructions in front of every reader who opened the
+    file to look at progress. They live here now.
+    - **Pictures: as many as you have.** Every screenshot the PR produced goes in the entry. An entry
+      covering eight titles shows eight titles, not one — that happened, and the other seven captures
+      sat in `assets/screenshots/` invisible to the only audience they existed for. A picture costs a
+      reader nothing to skip and everything to not have. Never economise here.
+    - **Words: one sentence saying what now works.** *"We now reach correct rendering of the Sonic
+      Frontiers title screen."* Then the screenshot. A second sentence only if the picture misleads
+      without one — a defect you want noticed, or a caveat about what is being seen. Say what you are
+      **looking at**, not what the change was; the commit subject already says what the change was,
+      and that is exactly what made the old generated feed useless.
+    - **One exception: a fix that moves several titles at once** earns a short plain-language
+      paragraph on the problem and the fix, because those are the ones a reader wants explained. Still
+      lead with the pictures. A single-title fix links its tracker instead.
+    - Everything else — measurements, bisects, censuses, mechanisms, reasoning — belongs in the
+      tracker, the PR or the status doc. Link, never transcribe. If an entry has a table, a code
+      block, or more than one or two numbers, it is a report wearing a blog entry's clothes. Six
+      entries filed in one day ran 330-946 words against the file's own median of about 60, and the
+      owner noticed before any check did.
     Write it even when the news is bad or the picture is ugly: *Sonic Frontiers*' black-world capture
     is in there precisely because the honest record is the point. And write it even when the rung did
     **not** move — a capture of a title that got further and still fell short is worth more than


### PR DESCRIPTION
`BLOG.md` is reader-facing, and its first 40 lines were instructions for writing entries — so anyone opening it to look at progress met a style guide before a screenshot. The first entry now starts at **line 22**.

The rules move to `CLAUDE.md`, beside the obligation that already lived there, and are sharpened rather than transplanted:

- **Pictures: as many as you have.** An entry covering eight titles shows eight titles — that happened this week, and the other seven captures sat in `assets/screenshots/` invisible to the only audience they existed for.
- **Words: one sentence** saying what now works, then the screenshot.
- **One exception:** a fix that moves several titles earns a short plain-language paragraph on the problem and the fix.

`BLOG.md` keeps an HTML-comment pointer — visible to an agent editing the file, invisible to a reader of the rendered page.

Image count 154 → 153: the removed reference is the **example** inside the lifted how-to block. The real Beneath entry it was copied from is untouched at line 317 — verified by diffing sorted reference lists, not by counting.

Docs-only. Numbered-table gate green on all `.md`; orchestration table 1..220 with no baseline row deleted.