### PR TITLE
blog: New Joe & Mac has been rung 6 for weeks and never appeared here

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -21,6 +21,18 @@ from the tracker issues, and still gated, because it is a projection of state ra
 
 ## 2026-08-22
 
+### New Joe & Mac: Caveman Ninja plays start to finish
+
+<p align="center"><img src="assets/screenshots/joe-mac.png" alt="New Joe & Mac: Caveman Ninja — gameplay: Joe crouched in a jungle level with palms, pink blossom, a volcano behind and coiled snakes either side, with the name plate, score, health bar and a lives counter reading x3"></p>
+
+<p align="center"><img src="assets/screenshots/joe-mac-menu.png" alt="New Joe & Mac: Caveman Ninja — the game's menu at 1920x1080"></p>
+
+We play this one through, and have done for a while — it is rung 6 with a reviewed `joe-mac-gameplay`
+snapshot guard, and it had somehow never appeared here. Tracker
+[#1876](https://github.com/mattias800/prosper/issues/1876).
+
+## 2026-08-22
+
 ### BALAN's language menu was never waiting for Cross
 
 <p align="center"><img src="assets/screenshots/balan-wonderworld-prologue.png" alt="BALAN WONDERWORLD — the opening story cutscene at 3840x2160: Leo and Emma standing in a city park at golden hour, a basketball court with graffiti-covered fencing behind them, children playing, trees and a brick building in the background, and speaker cabinets flanking the frame"></p>


### PR DESCRIPTION
A reviewed **rung 6** title with a passing `joe-mac-gameplay` snapshot guard and two captures already sitting in `assets/screenshots/` — and no blog entry, so the one place that progress was meant to be visible never showed it.

Found by checking every rung-2-or-better title in `PROGRESS_TRACKER.md` against `BLOG.md`. Of 39, it was the **only** one missing.

Two images, one sentence, per the rules that just moved to `CLAUDE.md`.

Docs and existing images only — no new captures.