### PR TITLE
docs(vkprobe): four record corrections from the #2958 re-review

### DIFF
--- a/prosper/docs/GRAPHICS.md
+++ b/prosper/docs/GRAPHICS.md
@@ -1171,9 +1171,12 @@ picture from run to run. Everything below was measured on master `99d5f738`, Lin
 - **Superseded by the rows above: "the remaining suspects are prosper's generated SPIR-V, prosper's
   host-side usage as an amplifier, and the driver/hardware."** The first is dead. The third is the
   answer. The middle one is *unresolved and now unimportant* — prosper's rate is higher than the
-  control's, but the two move together (0.79 against 0.13) and the load rows explain the gap at
-  least as well as an amplifier does: prosper's reproduction generates its own GPU load. Do not
-  spend anything more on it before the driver defect is reported. #2945.
+  control's **per draw** (10.7% of 309 replay rounds bad, against ~3.9% of the control's indexed
+  iterations) and LOWER per run (33 against 63 of those same 309 rounds), so name the unit before
+  quoting it. Either way the two move together (P(vkprobe fails | the replay drew nothing) = 0.79
+  against 0.13) and the load rows explain the association at least as well as an amplifier does:
+  prosper's reproduction generates its own GPU load. Do not spend anything more on it before the
+  driver defect is reported. #2945.
 
 
 ## Recommended implementation order

--- a/prosper/tools/vkprobe/README.md
+++ b/prosper/tools/vkprobe/README.md
@@ -135,12 +135,14 @@ Two things that follow for anyone using this tool:
 - **Reach for `--vs-b` with a `shaders/` module first.** Running a dumped module alone can never
   separate "the driver is wrong" from "prosper emitted bad SPIR-V", because both are in every run.
   A paired run separates them in one command.
-- **Concurrent GPU work from another process is what opens the failing window.** The "drift over
-  minutes" this README and `GRAPHICS.md` describe is not weather: three heavy `gpu_replay` full-submit
+- **Concurrent GPU work from another process INDUCES the failing window on demand.** The "drift over
+  minutes" this README and `GRAPHICS.md` describe responds to load: three heavy `gpu_replay` full-submit
   replays flipped a quiet machine into failing within one round and it recovered within ~15 s of
-  them stopping, and a second `vkprobe` used purely as a load reproduces it more weakly. So run the
-  control against a *quiet* GPU when you want a negative, and put a load beside it when you want the
-  defect. `pgrep -x 'prosper-app|screenshot|boot_trace'` will not see another agent's `gpu_replay`.
+  them stopping, and a second `vkprobe` used purely as a load reproduces it more weakly. Load is
+  **sufficient, not necessary** — failing windows have been measured opening on a box with no other
+  GPU process running — so put deliberate load beside the control when you want the defect to show
+  itself, and read a quiet-box negative as *undecided*, never clean (see below).
+  `pgrep -x 'prosper-app|screenshot|boot_trace'` will not see another agent's `gpu_replay`.
 
 **This probe has itself reproduced the #2945 class on a VALID pipeline, and that is its most
 important result so far.** On the corrected build, running

--- a/prosper/tools/vkprobe/correlate_with_replay.sh
+++ b/prosper/tools/vkprobe/correlate_with_replay.sh
@@ -7,7 +7,10 @@
 # with the same machine-wide rhythm -- which is exactly the situation in which two separate
 # measurement sessions cannot be compared. Interleaving them inside one loop turns "they both fail
 # sometimes" into a per-round paired observation: if the control is bad on the rounds the subject is
-# bad and good on the rounds it is good, they share a cause, and the control's verdict transfers.
+# bad and good on the rounds it is good, they go bad in the same WINDOWS -- which transfers the
+# control's verdict to those windows and no further. It does not by itself establish a shared
+# MECHANISM: a common environmental driver (GPU load from another process) produces exactly this
+# association without any shared defect.
 #
 # It lives beside vkprobe rather than in tools/gpu_replay because the QUESTION is the control's.
 # Note the boundary this folder's AGENTS.md draws is about linkage: this script starts gpu_replay as

--- a/prosper/tools/vkprobe/shaders/minimal_ssbo_vs.spvasm
+++ b/prosper/tools/vkprobe/shaders/minimal_ssbo_vs.spvasm
@@ -12,7 +12,9 @@
 ;   * bitcast to float for x and y; z = 0, w = 1; OpStore into gl_Position
 ; Everything prosper's module carries beyond that -- the second (unused) binding, the `Aliased`
 ; decorations, the absent `NonWritable`, the unused gl_InstanceIndex load -- is deliberately absent
-; here and is varied one factor at a time by the sibling modules in this folder.
+; here, and NO sibling varies these factors one at a time: the siblings vary the storage-buffer LOAD
+; (`no_ssbo_vs`) and what is reported (`index_readback_vs`), nothing else. Treat everything beyond
+; the loads as unvaried by this family.
 ;
 ; Assemble with:  spirv-as --target-env vulkan1.1 minimal_ssbo_vs.spvasm -o minimal_ssbo_vs.spv
 ; (vulkan1.1 so the header says SPIR-V 1.3, matching the modules prosper emits.)


### PR DESCRIPTION
Lands the four residual non-blocking findings named in the APPROVED re-review of #2958 (head `0114c73e`). They live in files that PR introduced, so they follow it onto master.

1. **`tools/vkprobe/README.md`** — the bullet "run the control against a *quiet* GPU when you want a negative" contradicted the same file's later "a quiet-box null is undecided rather than clean" (the round-1 Blocking-2 correction). Now aligned: load is sufficient-not-necessary, quiet-box negatives are weak.
2. **`tools/vkprobe/correlate_with_replay.sh`** — the header claimed per-round association means two instruments "share a cause". Association establishes a shared *window*; a common environmental driver produces it without any shared defect. Header now says exactly that.
3. **`docs/GRAPHICS.md`** superseded row — "prosper's rate is higher than the control's" was unit-less, true per draw and false per run. Both units now named with numbers re-derived from `correlate.csv` by me during re-review (309 rounds: replay bad 33/309 = 10.7% of draws against ~3.9% of control indexed iterations; per run 33 vs 63 — the claim reverses).
4. **`tools/vkprobe/shaders/minimal_ssbo_vs.spvasm`** — header claimed its omitted factors are "varied one factor at a time by the sibling modules"; no sibling varies them. Now states what actually varies.

### Verification

- Comment-only diffs; no behaviour change anywhere.
- All four `.spvasm` sources re-assembled and `spirv-val --target-env vulkan1.2` clean via `check_controls.py`: `4 of 4 controls valid`.
- Numbered-table gate over every tracked `.md`: clean; `Claude-Session` trailer count on `origin/master..HEAD`: 0.
- `git diff --check`: clean.

Refs #2945, #2958