### PR TITLE
Add gitignored LOCAL.md as the per-machine companion to this charter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ __pycache__/
 
 # Local per-game launch scripts (prosper/scripts/play/) — convenience only, not project state.
 prosper/scripts/play/
+
+# Machine-local agent instructions (pointed at by CLAUDE.md) — per-computer, never committed.
+/LOCAL.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # prosper — project charter & working context (read first)
 
+> **Machine-local instructions:** if a `LOCAL.md` file exists next to this one, read it before
+> starting work. It is gitignored and holds per-computer facts (hardware, paths, installed tools)
+> that must not be written into this committed charter.
+
 ## What this project is
 
 **prosper is a PS5→PC compatibility layer — "Wine/Proton for PS5."** It runs PS5 games natively on


### PR DESCRIPTION
Docs-only change.

- **CLAUDE.md**: a blockquote directly under the title instructs agents to read `LOCAL.md` before starting work when it exists next to the charter. It is gitignored and holds per-computer facts only.
- **.gitignore**: `/LOCAL.md` — every clone/worktree keeps its own untracked copy once merged.

Rationale: machine-specific instructions (hardware/GPU, dump-library paths, installed tooling) must not be written into the committed charter or pushed to the shared repo; each checkout that wants them creates its own file. Same spirit as the established `.git/info/exclude` use for `.claude/worktrees/`.

Verified: diff is exactly these two files (+7 lines); `git check-ignore -v LOCAL.md` matches; no code paths touched.