### PR TITLE
libScePosix: register pthread_setschedparam under its POSIX spelling

### DIFF
--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -4906,7 +4906,8 @@ void register_kernel_hle() {
     R("scePthreadAttrSetaffinity", k_attr_noop);         // accept affinity requests (we don't pin)
     R("scePthreadGetaffinity", k_attr_getaffinity);      R("scePthreadSetaffinity", k_attr_noop);
     R("scePthreadGetschedparam", k_getschedparam);  R("pthread_getschedparam", k_getschedparam);
-    R("scePthreadSetschedparam", k_log_setschedparam);  R("scePthreadSetprio", k_log_setprio);
+    R("scePthreadSetschedparam", k_log_setschedparam);  R("pthread_setschedparam", k_log_setschedparam);  // #2914
+    R("scePthreadSetprio", k_log_setprio);
     R("scePthreadGetprio", k_getprio);
     R("scePthreadGetname", k_pthread_getname);   // bare ON PURPOSE — see the block above the body
     R("scePthreadRename", k_sce_pthread_rename);

--- a/prosper/tests/hle/test_hle_registered.cpp
+++ b/prosper/tests/hle/test_hle_registered.cpp
@@ -33,6 +33,8 @@ int main() {
         "scePthreadCreate", "scePthreadMutexLock", "scePthreadCondWait", "pthread_equal",
         "sceKernelInstallExceptionHandler", "sceKernelRaiseException",
         "sceKernelIsStack", "scePthreadGetschedparam",
+        // POSIX spellings must answer identically to the sce ones (#2914)
+        "pthread_getschedparam", "pthread_setschedparam",
         // time / event queues
         "sceKernelClockGettime", "sceKernelUsleep", "sceKernelCreateEqueue", "sceKernelWaitEqueue",
         "getpid",


### PR DESCRIPTION
Fixes #2914.

## Failure scenario

`libScePosix`'s `pthread_setschedparam` (NID `Xs9hdiD7sAA`) was not registered: the setter existed only under its Sony spelling, while both spellings of the *getter* were aliased (`hle_kernel.cpp`, registration block). Guests importing the POSIX name fell to the dispatcher default `0`. *Beast of Reincarnation* hits it 6,143 times per 240 s boot — the largest unimplemented-NID census entry for the title and invisible to `PROSPER_PRIOLOG`.

## Contract

Same handler (`k_log_setschedparam`), same answer, now bound under the imported NID — the "answer the same question the same way through every library that exposes it" rule. No behavioral delta today (the handler is a logging no-op returning 0); the win is diagnostic coverage + census noise removal.

## Change

- `hle_kernel.cpp`: one `R("pthread_setschedparam", k_log_setschedparam)` line mirroring the getter's alias.
- `test_hle_registered.cpp`: pins both POSIX spellings (`pthread_getschedparam` was already live and unguarded).

## Verification

- Red first: with only the test change built, `test_hle_registered` prints `[FAIL] not registered: pthread_setschedparam`, exit 1.
- After the fix: `== PASS: all 63 checked HLE functions registered ==`, exit 0.
- Full `cmake --build` + `ctest --no-tests=error` running on this exact head; results posted before merge.

## Deliberately unaffected

The other pthread spellings named by the #2178 sweep; `scePthreadSetprio` untouched (split onto its own line for readability).