### PR TITLE
libSceHttp: hand out real library/template ids instead of the dispatcher's 0

### DIFF
--- a/prosper/src/hle/net/hle_http.cpp
+++ b/prosper/src/hle/net/hle_http.cpp
@@ -1,5 +1,8 @@
-// libSceHttp URI helpers. Network requests remain offline, but parsing is local and deterministic:
-// returning success without filling this structure makes callers dereference stale pointer fields.
+// libSceHttp URI helpers plus the library/template id lifecycle. Network requests remain
+// offline, but parsing is local and deterministic, and id-returning entry points hand out
+// real tracked ids: returning success without filling this structure makes callers dereference
+// stale pointer fields, and answering 0 for an id hands the guest a valid-looking handle that
+// was never allocated (#2930).
 #include "hle/net/hle_http.hpp"
 #include "hle/dispatch/dispatch.hpp"
 
@@ -7,6 +10,7 @@
 #include <cctype>
 #include <cstdint>
 #include <cstring>
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -169,10 +173,62 @@ HLE(h_http_uri_parse) { // (out, src_uri, pool, required_size, pool_size)
     return 0;
 }
 
+// --- Library/template id lifecycle (#2930) ----------------------------------------------
+// sceHttpInit and sceHttpCreateTemplate return IDS, and an id-returning contract must never
+// answer 0: the dispatcher's unregistered default is a valid-looking context/template id that
+// six of eight surveyed titles carry into later calls. Offline there is no network behind these
+// objects, but the ids are real - allocated here, tracked, deletable.
+//
+// Deliberately not invented until a live caller supplies evidence (id positivity itself is
+// CONFIDENCE: HIGH from the published contract): repeated Init hands out a further independent
+// context, CreateTemplate accepts whatever context it is given, and DeleteTemplate answers
+// SCE_OK for any argument - the dispatcher default it replaces was also 0, so registering the
+// explicit no-op removes census noise without fabricating an SDK error encoding. PS5 3.20
+// libSceHttp exports no sceHttpTerminate: contexts live for the process.
+
+struct HttpLibCtx   { bool in_use = false; };
+struct HttpTemplate { bool in_use = false; };
+constexpr int kMaxHttpLibs      = 4;
+constexpr int kMaxHttpTemplates = 16;
+
+std::mutex g_http_mx;  // guards both tables below
+HttpLibCtx   g_http_libs[kMaxHttpLibs];
+HttpTemplate g_http_templates[kMaxHttpTemplates];
+
+HLE(h_http_init) { // sceHttpInit() -> library context id (>0)
+    std::lock_guard<std::mutex> lk(g_http_mx);
+    for (int i = 0; i < kMaxHttpLibs; i++) {
+        if (g_http_libs[i].in_use) continue;
+        g_http_libs[i].in_use = true;
+        return (uint64_t)(i + 1);
+    }
+    return (uint64_t)(int64_t)-1;  // table exhausted: negative, never an id-shaped answer
+}
+
+HLE(h_http_create_template) { // sceHttpCreateTemplate(libCtxId, ...) -> template id (>0)
+    std::lock_guard<std::mutex> lk(g_http_mx);
+    for (int i = 0; i < kMaxHttpTemplates; i++) {
+        if (g_http_templates[i].in_use) continue;
+        g_http_templates[i].in_use = true;
+        return (uint64_t)(i + 1);
+    }
+    return (uint64_t)(int64_t)-1;
+}
+
+HLE(h_http_delete_template) { // sceHttpDeleteTemplate(templateId) -> SCE_OK offline
+    std::lock_guard<std::mutex> lk(g_http_mx);
+    if (int id = (int32_t)a0; id >= 1 && id <= kMaxHttpTemplates)
+        g_http_templates[id - 1].in_use = false;
+    return 0;
+}
 } // namespace
 
 void register_http_hle() {
     Hle::register_fn("IWalAn-guFs", (HleFn)h_http_uri_parse, "sceHttpUriParse");
+    // Id lifecycle (#2930): an id-returning contract must never answer the dispatcher's 0.
+    Hle::register_fn("A9cVMUtEp4Y", (HleFn)h_http_init, "sceHttpInit");
+    Hle::register_fn("0gYjPTR-6cY", (HleFn)h_http_create_template, "sceHttpCreateTemplate");
+    Hle::register_fn("4I8vEpuEhZ8", (HleFn)h_http_delete_template, "sceHttpDeleteTemplate");
 }
 
 } // namespace prosper

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -270,8 +270,18 @@ void test_http_ids() {
     HleFn del_fn = Hle::lookup(kHttpDeleteTemplate);
     CHECK(del_fn != nullptr, "sceHttpDeleteTemplate is registered");
     if (!del_fn) return;
-    // Kills: a delete that reports failure (or a crash) on the id this test just created.
+    // Kills three mutations at once: a delete whose body is just `return 0` (never clearing its
+    // slot), a table that never frees, and an exhaustion path answering an id-shaped value. Fill
+    // the table to exhaustion, free ONE live id, and the allocator must hand out a positive id
+    // again.
+    uint64_t probe = tmpl;
+    while ((int64_t)probe > 0)
+        probe = create_fn(ctx, 0, 0, 0, 0, 0);
+    CHECK((int64_t)probe < 0, "an exhausted template table answers NEGATIVE, not a fake id");
+    // Kills: a delete that reports failure (or a crash) on a live id.
     CHECK(del_fn(tmpl, 0, 0, 0, 0, 0) == 0, "sceHttpDeleteTemplate answers SCE_OK for a live id");
+    probe = create_fn(ctx, 0, 0, 0, 0, 0);
+    CHECK((int64_t)probe > 0, "a freed slot is handed out again (delete actually cleared its slot)");
 }
 
 } // namespace

--- a/prosper/tests/hle/test_false_success_nids.cpp
+++ b/prosper/tests/hle/test_false_success_nids.cpp
@@ -240,6 +240,40 @@ void test_savedata_transferring_mount() {
     }
 }
 
+// libSceHttp answers every entry point except the URI parser with the dispatcher default 0
+// (#2930). For the two entry points every caller starts with, that 0 IS a valid-looking id:
+// sceHttpInit's contract returns a positive library context, sceHttpCreateTemplate a positive
+// template id bound to it. Six of eight surveyed titles call both.
+constexpr const char* kHttpInit            = "A9cVMUtEp4Y";
+constexpr const char* kHttpCreateTemplate  = "0gYjPTR-6cY";
+constexpr const char* kHttpDeleteTemplate  = "4I8vEpuEhZ8";
+
+void test_http_ids() {
+    printf("-- libSceHttp::sceHttpInit / sceHttpCreateTemplate --\n");
+    HleFn init_fn = Hle::lookup(kHttpInit);
+    // Kills: leaving the NID unregistered -- the dispatcher default 0 is the whole bug.
+    CHECK(init_fn != nullptr, "sceHttpInit is registered");
+    if (!init_fn) return;
+    uint64_t ctx = init_fn(0, 0, 0, 0, 0, 0);
+    CHECK(ctx != 0, "sceHttpInit returns a non-zero library context id");
+    // Kills: answering with a negative error instead of an id -- guest sites carry the value
+    // into later calls, so any id-shaped answer must have the sign bit clear.
+    CHECK((int64_t)ctx > 0, "sceHttpInit returns a POSITIVE id, not an error");
+
+    HleFn create_fn = Hle::lookup(kHttpCreateTemplate);
+    CHECK(create_fn != nullptr, "sceHttpCreateTemplate is registered");
+    if (!create_fn) return;
+    uint64_t tmpl = create_fn(ctx, 0, 0, 0, 0, 0);
+    CHECK(tmpl != 0, "sceHttpCreateTemplate returns a non-zero template id");
+    CHECK((int64_t)tmpl > 0, "sceHttpCreateTemplate returns a POSITIVE id, not an error");
+
+    HleFn del_fn = Hle::lookup(kHttpDeleteTemplate);
+    CHECK(del_fn != nullptr, "sceHttpDeleteTemplate is registered");
+    if (!del_fn) return;
+    // Kills: a delete that reports failure (or a crash) on the id this test just created.
+    CHECK(del_fn(tmpl, 0, 0, 0, 0, 0) == 0, "sceHttpDeleteTemplate answers SCE_OK for a live id");
+}
+
 } // namespace
 
 int main() {
@@ -248,6 +282,7 @@ int main() {
     test_random();
     test_nptrophy2_info_queries();
     test_savedata_transferring_mount();
+    test_http_ids();
     if (fails) { printf("== FAIL: %d check(s) failed ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;


### PR DESCRIPTION
Refs #2930.

## Failure scenario

`libSceHttp` registered exactly one function (`sceHttpUriParse`). Everything else fell to the dispatcher default `0` — and for `sceHttpInit` (`A9cVMUtEp4Y`) and `sceHttpCreateTemplate` (`0gYjPTR-6cY`) that 0 is **not** an error but a valid-looking id: the contracts return a positive library context / template id on success. Six of eight surveyed titles call both and carry the fake id into later calls (evidence table in the issue).

## Contract & approach

An id-returning contract must never answer 0. Both entry points now allocate from small tracked tables (ids ≥ 1, mutex-guarded), and `sceHttpDeleteTemplate` (`4I8vEpuEhZ8`) is registered as the explicit SCE_OK no-op it already was by accident.

**Deliberately not invented** (no live caller supplies evidence yet, so any constant would be fabrication): context-validation semantics, double-init behaviour, and SDK error encodings — the exhausted-table path answers a generic negative rather than a made-up `SCE_HTTP_ERROR_*`. PS5 3.20 libSceHttp exports no `sceHttpTerminate`, so contexts live for the process. The request-path honesty suggested in the issue is future work once a title actually reaches it; noted on the issue.

## Verification

- Red first: with only the test change built, `test_false_success_nids` fails at `sceHttpInit is registered`.
- After the fix: all 8 new HTTP arms pass (`== PASS ==`, exit 0), including sign checks that kill an error-shaped answer masquerading as an id.
- Full `cmake --build` + `ctest --no-tests=error` running on this exact head inside the toolchain container; results posted before merge.

## Risks

Titles that previously saw Init→0 may now branch differently on a real id; none of the six surveyed stops in HTTP today, and every later unregistered call keeps today's behaviour.
