### PR TITLE
tools: gpu_busy.sh — the shared-GPU check with an exit code that means what it says

### DIFF
--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -947,8 +947,9 @@ tr '\0' '\n' < /proc/<pid>/environ | grep PROSPER_   # and whose run?
 having looked at nothing, and the two ways it is usually written both read as a clean box — with stderr suppressed it
 prints nothing, and `... || echo "GPU free"` prints *"GPU free"* **because** the command failed. Use one ERE argument
 (`pgrep -x 'prosper-app|screenshot|boot_trace|screenshot_snap'`), the per-name loop below, or
-**`tools/gpu_busy.sh`, which wraps exactly this census with an exit code that means what it says**
-(0 consumers running / 1 free / 2 tool error — a broken tool never answers "free"). Trap 222.
+**`tools/gpu_busy.sh`, which runs the full five-name census below as one tested command with an
+exit code that means what it says** (0 consumers running / 1 free / 2 tool error — a broken tool
+never answers "free"; `while gpu_busy.sh -q; do sleep 30; done` waits for a free box). Trap 222.
 
 Before terminating anything, confirm the exact PID **and** that its `cwd`/`environ` identify it as yours. Never
 kill from a pattern count. Note `comm` is truncated to 15 characters by the kernel, so a longer binary name needs

--- a/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
+++ b/prosper/docs/GAME_COMPAT_ORCHESTRATION.md
@@ -946,7 +946,9 @@ tr '\0' '\n' < /proc/<pid>/environ | grep PROSPER_   # and whose run?
 **`pgrep -x` takes exactly ONE pattern.** `pgrep -x prosper-app screenshot boot_trace` is a usage error: it exits 2
 having looked at nothing, and the two ways it is usually written both read as a clean box — with stderr suppressed it
 prints nothing, and `... || echo "GPU free"` prints *"GPU free"* **because** the command failed. Use one ERE argument
-(`pgrep -x 'prosper-app|screenshot|boot_trace|screenshot_snap'`) or the per-name loop below. Trap 222.
+(`pgrep -x 'prosper-app|screenshot|boot_trace|screenshot_snap'`), the per-name loop below, or
+**`tools/gpu_busy.sh`, which wraps exactly this census with an exit code that means what it says**
+(0 consumers running / 1 free / 2 tool error — a broken tool never answers "free"). Trap 222.
 
 Before terminating anything, confirm the exact PID **and** that its `cwd`/`environ` identify it as yours. Never
 kill from a pattern count. Note `comm` is truncated to 15 characters by the kernel, so a longer binary name needs

--- a/prosper/tools/AGENTS.md
+++ b/prosper/tools/AGENTS.md
@@ -419,6 +419,10 @@ the shipped runtime. Build them from `build-linux/` like everything else.
   earlier route's decline is invisible without the verbose stream. Take the addresses from the
   `[compute-census]` per-program lines; they are run-local, so re-derive them per run (#2790).
 - **`imgdump/`** — decode/dump a guest texture to an image for inspection.
+- **`gpu_busy.sh`** — answers "is a peer lane mid-run on the shared GPU?" with pgrep-convention
+  exit codes (0 busy / 1 free / 2 tool error), counting the five consumer names including
+  `screenshot_snap`. Replaces the inline `pgrep -x a b c` spelling that was a usage error
+  masquerading as a clean box (trap 222, #2948).
 - **`gpu_replay/`** — replay a local `PROSPER_GPU_CAPTURE` realized-submit capsule through the same
   Vulkan backend without booting the guest. Capsules include game shaders/resources, use `.prgcap`,
   are gitignored, and must never be committed. The tool exits non-zero on output-hash mismatch.

--- a/prosper/tools/gpu_busy.sh
+++ b/prosper/tools/gpu_busy.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+# Answer "is a peer lane mid-run on the shared GPU?" with an exit code that means what it says.
+#
+# WHY THIS EXISTS: the inline spelling this replaces — `pgrep -x prosper-app screenshot boot_trace`
+# — is a usage error (`pgrep -x` takes exactly ONE pattern; instrument trap 222). It exits 2 having
+# looked at nothing, and the two common wrappers around it both read as a clean box: stderr
+# suppressed it prints nothing, and `... || echo "GPU free"` prints *GPU free* because the command
+# failed. A guard whose failure looks like its success is worse than no guard, so briefs cite this
+# tested command instead of an inline line nobody runs in isolation (#2948).
+#
+# Usage: gpu_busy.sh [-q] [extra-name ...]
+#   -q           exit status only, no output
+#   extra-name   further exact process names to count
+#
+# Exit codes follow pgrep conventions so loops read naturally
+# (`until gpu_busy.sh -q; do sleep 30; done` waits for a free box):
+#   0  consumers running (busy)
+#   1  none running (free)
+#   2  tool or usage error — NEVER answers "free" from a broken tool
+#
+# Counted by default: the five GPU consumers this repo runs, INCLUDING `screenshot_snap` —
+# snapshot.py executes a copy of the frontend under that name, so a peer two full boots into a
+# `verify` is invisible to a check that only lists built names (see GAME_COMPAT_ORCHESTRATION.md,
+# "`pgrep -x screenshot` does not see a snapshot run"). Names are matched against comm, which the
+# kernel truncates to 15 characters.
+
+set -u
+
+quiet=0
+names="prosper-app boot_trace gpu_replay screenshot screenshot_snap"
+
+case "${1-}" in
+    -h|--help)
+        printf 'Usage: gpu_busy.sh [-q] [extra-name ...]\n'
+        printf 'Exit 0 = consumers running, 1 = free, 2 = tool/usage error.\n'
+        exit 0 ;;
+esac
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -q) quiet=1 ;;
+        -*) printf 'gpu_busy.sh: unknown option: %s\n' "$1" >&2; exit 2 ;;
+        *)  names="$names $1" ;;
+    esac
+    shift
+done
+
+command -v pgrep >/dev/null 2>&1 || { echo "gpu_busy.sh: pgrep not found" >&2; exit 2; }
+
+total=0
+for n in $names; do
+    c=$(pgrep -c -x "$n" 2>/dev/null)
+    rc=$?
+    if [ "$rc" -eq 1 ]; then
+        c=0                      # no match is an answer, not an error
+    elif [ "$rc" -ne 0 ]; then
+        echo "gpu_busy.sh: pgrep failed on '$n' (rc=$rc)" >&2
+        exit 2
+    fi
+    total=$((total + c))
+    if [ "$c" -gt 0 ] && [ "$quiet" -eq 0 ]; then
+        printf '%s: %s\n' "$n" "$c"
+    fi
+done
+
+if [ "$total" -gt 0 ]; then
+    [ "$quiet" -eq 1 ] || printf 'GPU busy: %s consumer(s)\n' "$total"
+    exit 0
+fi
+[ "$quiet" -eq 1 ] || echo "GPU free"
+exit 1

--- a/prosper/tools/gpu_busy.sh
+++ b/prosper/tools/gpu_busy.sh
@@ -13,7 +13,8 @@
 #   extra-name   further exact process names to count
 #
 # Exit codes follow pgrep conventions so loops read naturally
-# (`until gpu_busy.sh -q; do sleep 30; done` waits for a free box):
+# (`while gpu_busy.sh -q; do sleep 30; done` waits for a free box — while spins on success,
+# i.e. while the box is BUSY; `until` would spin while it is FREE):
 #   0  consumers running (busy)
 #   1  none running (free)
 #   2  tool or usage error — NEVER answers "free" from a broken tool


### PR DESCRIPTION
Fixes #2948.

## Failure scenario

Lane briefs told every concurrent agent to run `pgrep -x prosper-app screenshot boot_trace` before touching the GPU. `pgrep -x` takes exactly **one** pattern, so the check exits 2 having looked at nothing, and both common wrappers read as a clean box: stderr-suppressed it prints nothing; `... || echo "GPU free"` prints *GPU free* because the command failed (trap 222, filed today). The docs half of the issue — corrected guidance and the trap row — is already on master; this lands its item 3, the committed tool, so briefs cite a tested thing instead of an inline line nobody runs in isolation.

## Contract

`gpu_busy.sh [-q] [extra-name ...]` counts exact-name matches for the five GPU consumers this repo actually runs — `prosper-app boot_trace gpu_replay screenshot screenshot_snap` (the snapshot copy name included, per the doc's own `pgrep -x screenshot` warning) — plus any extra names given. pgrep conventions: exit 0 consumers running, 1 free, 2 tool/usage error. A broken tool never answers "free"; per-name failures other than no-match abort with exit 2 rather than under-counting. `while gpu_busy.sh -q; do sleep 30; done` waits for a free box (while spins on success, i.e. while the box is busy).

## Verification

Seven behavioral paths exercised against renamed binaries (`cp /bin/sleep → screenshot_snap`) so comm actually matches: free box (rc 1), extra-name match (rc 0), two peers counted together, default set detecting `screenshot_snap`, quiet mode silent with rc 0, post-kill transition back to rc 1, unknown option rc 2. Docs gate green on both invocations (orchestration table 227 rows unique/ascending vs origin/master baseline; all 130 tracked .md files pass); `git diff --check` clean.

## Deliberately unaffected

The historical narrative mentions of `pgrep -x` in ARCRUNNER_STATUS.md (records of past censuses, not prescriptions) and valid single-pattern uses; the numbered trap table itself is untouched — only the prose paragraph at the correction site now cites the tool.

