### PR TITLE
prosper-app: per-title guest launch arguments from the settings file

### DIFF
--- a/prosper/frontends/prosper-app/README.md
+++ b/prosper/frontends/prosper-app/README.md
@@ -128,6 +128,14 @@ hand. Settings a build does not recognize are carried through unchanged when it 
 older build will not delete a newer build's settings — but comments are not preserved, since the app
 regenerates its own header.
 
+Two more keys feed the guest's own command line (`PROSPER_GUEST_ARGS`) at boot:
+`guest_args = <args>` sets arguments for **every** title, and `guest_args.<TITLE_ID> = <args>`
+overrides for one title (e.g. `guest_args.PPSA02664 = -force-gfx-direct`). An explicit
+`PROSPER_GUEST_ARGS` in the environment still wins over both. These exist because some titles'
+engines need a specific graphics mode to render in this app — Unity titles currently need
+`-force-gfx-direct` (their default MT gfx-jobs path is not emulated yet; #2973) — while others
+must not receive it, so the choice is explicit and per-title rather than a silent global.
+
 The scan looks **one level deep** and accepts a child directory as a title when
 `resolve_app0_root()` does — the same test the drop and picker paths use. A title's own asset
 subdirectories are therefore never mistaken for separate games, and the games directory itself is not

--- a/prosper/frontends/prosper-app/app_config.hpp
+++ b/prosper/frontends/prosper-app/app_config.hpp
@@ -11,6 +11,7 @@
 // Parsing and serializing are pure and unit-tested; choosing the file's location and touching the disk
 // stays in main.cpp.
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -28,6 +29,14 @@ struct AppConfig {
     // Reading tolerating unknown keys is not enough on its own: --set-games-dir rewrites the whole
     // file, so without this a release build would silently delete whatever a newer build had stored.
     std::vector<std::string> unknown_lines;
+
+    // Guest launch arguments (PROSPER_GUEST_ARGS), applied when the user's environment does not
+    // already set one (#2973): Unity titles need `-force-gfx-direct` to reach their frame loop in
+    // this app (the MT gfx-jobs handshake is not emulated yet — see RENDER_LOOP.md), while some
+    // titles must NOT receive it. `guest_args_default` applies to every title;
+    // `guest_args_by_title` overrides per TITLE_ID (config key spelling: `guest_args.PPSA02664`).
+    std::string guest_args_default;                                  // "" = none
+    std::map<std::string, std::string> guest_args_by_title;
 };
 
 // Trim ASCII spaces and tabs from both ends.
@@ -58,6 +67,9 @@ inline AppConfig parse_app_config(const std::string& text) {
         else if (key == "launcher_music")
             // Anything other than an explicit off is on, so a hand-edited "yes" or "1" behaves.
             cfg.launcher_music = !(value == "0" || value == "false" || value == "off" || value == "no");
+        else if (key == "guest_args") cfg.guest_args_default = value;
+        else if (key.rfind("guest_args.", 0) == 0)
+            cfg.guest_args_by_title[key.substr(11)] = value;
         else cfg.unknown_lines.push_back(line);   // preserved across a rewrite
         if (nl == text.size()) break;
     }
@@ -74,6 +86,9 @@ inline std::string serialize_app_config(const AppConfig& cfg) {
     // whereas an absent games_dir simply means nothing was chosen.
     out += std::string("launcher_music = ") + (cfg.launcher_music ? "1" : "0") + "\n";
     for (const std::string& line : cfg.unknown_lines) out += line + "\n";
+    for (const auto& [title, args] : cfg.guest_args_by_title)
+        out += "guest_args." + title + " = " + args + "\n";
+    if (!cfg.guest_args_default.empty()) out += "guest_args = " + cfg.guest_args_default + "\n";
     return out;
 }
 
@@ -83,6 +98,15 @@ inline std::string resolve_games_dir(const std::string& flag, const std::string&
     if (!flag.empty()) return flag;
     if (!env.empty()) return env;
     return file.games_dir;
+}
+
+// Per-title launch arguments for the guest: a `guest_args.<TITLE_ID>` entry wins over the global
+// `guest_args` default; "" when neither is set. The caller decides precedence against the user's
+// own environment (see main.cpp — the environment always wins over this file).
+inline std::string guest_args_for(const AppConfig& cfg, const std::string& title_id) {
+    const auto it = cfg.guest_args_by_title.find(title_id);
+    if (it != cfg.guest_args_by_title.end()) return it->second;
+    return cfg.guest_args_default;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1161,7 +1161,7 @@ static bool relaunch_with_dump(int argc, char** argv, const std::string& app0_ro
     // forbid it). Removing it lets the child re-resolve from its own title's settings. A
     // USER-authored value is left alone: the documented precedence is that the environment wins
     // over the file.
-    if (g_guest_args_app_set) unsetenv("PROSPER_GUEST_ARGS");
+    if (g_guest_args_app_set) clear_environment("PROSPER_GUEST_ARGS");
 #ifdef _WIN32
     // CreateProcess takes a single command line, so every argument is quoted — dump paths routinely
     // contain spaces, and a trailing backslash would otherwise escape the closing quote.

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1033,6 +1033,19 @@ static bool start_guest(const std::string& app0_root, std::string* err) {
         return false;
     }
     g_boot_attempted = true;
+    // Per-title guest launch arguments (#2973): Unity titles need `-force-gfx-direct` to reach
+    // their frame loop in this app (the MT gfx-jobs handshake is not emulated yet — RENDER_LOOP.md);
+    // some titles must NOT receive it, so this is explicitly configured, never a silent default.
+    // The user's own environment wins over the config file, matching the app_config precedence.
+    if (!getenv("PROSPER_GUEST_ARGS")) {
+        const prosper::frontend::AppConfig cfg = load_app_config();
+        const std::string args = prosper::frontend::guest_args_for(
+            cfg, prosper::frontend::title_id_from_app0_path(app0_root));
+        if (!args.empty()) {
+            set_environment("PROSPER_GUEST_ARGS", args.c_str());
+            fprintf(stderr, "[app] guest args (config): %s\n", args.c_str());
+        }
+    }
 #ifdef PROSPER_HAVE_LIVE_RENDERER
     prosper::frontend::register_live_renderer(
         getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".",

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -951,6 +951,9 @@ static std::string window_title_for(const std::string& dump, bool test_pattern) 
 Program g_prog;
 std::thread g_guest_thread;
 bool g_guest_started = false;
+// True when THIS process authored PROSPER_GUEST_ARGS from the settings file (start_guest). A
+// relaunch must strip an app-authored value so the next title re-resolves its own (#2973 review).
+bool g_guest_args_app_set = false;
 bool g_boot_attempted = false;
 
 // Install the host frontends (audio out, controller in, dialogs) at the same point boot_trace does:
@@ -1043,7 +1046,7 @@ static bool start_guest(const std::string& app0_root, std::string* err) {
             cfg, prosper::frontend::title_id_from_app0_path(app0_root));
         if (!args.empty()) {
             set_environment("PROSPER_GUEST_ARGS", args.c_str());
-            fprintf(stderr, "[app] guest args (config): %s\n", args.c_str());
+        g_guest_args_app_set = true;
         }
     }
 #ifdef PROSPER_HAVE_LIVE_RENDERER
@@ -1144,6 +1147,13 @@ static bool relaunch_with_dump(int argc, char** argv, const std::string& app0_ro
     for (int i = 1; i < argc; i++) args.emplace_back(argv[i]);
     args.emplace_back("--dump");
     args.push_back(app0_root);
+    // If THIS process authored PROSPER_GUEST_ARGS from the config (see start_guest), the value
+    // belongs to the title that is shutting down — a relaunch inherits environ verbatim, so leaving
+    // it would apply the previous title's args to the new one (whose config entry may differ or
+    // forbid it). Removing it lets the child re-resolve from its own title's settings. A
+    // USER-authored value is left alone: the documented precedence is that the environment wins
+    // over the file.
+    if (g_guest_args_app_set) unsetenv("PROSPER_GUEST_ARGS");
 #ifdef _WIN32
     // CreateProcess takes a single command line, so every argument is quoted — dump paths routinely
     // contain spaces, and a trailing backslash would otherwise escape the closing quote.
@@ -1157,7 +1167,6 @@ static bool relaunch_with_dump(int argc, char** argv, const std::string& app0_ro
     }
     CloseHandle(pi.hThread);
     CloseHandle(pi.hProcess);
-    return true;
 #else
     std::vector<char*> cargv;
     cargv.reserve(args.size() + 1);

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -136,6 +136,13 @@ bool set_environment(const char* name, const char* value) {
     return setenv(name, value, 1) == 0;
 #endif
 }
+bool clear_environment(const char* name) {
+#ifdef _WIN32
+    return _putenv_s(name, "") == 0;   // MSVC/MinGW: an empty value REMOVES the variable
+#else
+    return unsetenv(name) == 0;
+#endif
+}
 
 // ---- tiny Vulkan error helper -----------------------------------------------------------------
 #define VKCHECK(x, msg) do { VkResult _r = (x); if (_r != VK_SUCCESS) { \
@@ -1045,8 +1052,9 @@ static bool start_guest(const std::string& app0_root, std::string* err) {
         const std::string args = prosper::frontend::guest_args_for(
             cfg, prosper::frontend::title_id_from_app0_path(app0_root));
         if (!args.empty()) {
-            set_environment("PROSPER_GUEST_ARGS", args.c_str());
+        set_environment("PROSPER_GUEST_ARGS", args.c_str());
         g_guest_args_app_set = true;
+        fprintf(stderr, "[app] guest args (config): %s\n", args.c_str());
         }
     }
 #ifdef PROSPER_HAVE_LIVE_RENDERER

--- a/prosper/frontends/prosper-app/test_game_library.cpp
+++ b/prosper/frontends/prosper-app/test_game_library.cpp
@@ -21,6 +21,7 @@ using prosper::frontend::path_basename;
 using prosper::frontend::resolve_games_dir;
 using prosper::frontend::scan_game_library;
 using prosper::frontend::serialize_app_config;
+using prosper::frontend::guest_args_for;
 
 static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { std::printf("  [FAIL] %s\n", m); ++fails; } \
@@ -273,6 +274,27 @@ int main() {
     CHECK(parse_app_config("games_dir = /a\ngames_dir = /b").games_dir == "/b", "a later duplicate wins");
     CHECK(parse_app_config("future_key = 1\ngames_dir = /games").games_dir == "/games",
           "an unknown key does not break parsing");
+    CHECK(parse_app_config("guest_args = -force-gfx-direct").guest_args_default == "-force-gfx-direct",
+          "a default guest_args value is read");
+    AppConfig pt = parse_app_config("guest_args.PPSA02664 = -a\nguest_args.PPSA02664 = -b");
+    CHECK(pt.guest_args_by_title.size() == 1 && pt.guest_args_by_title.at("PPSA02664") == "-b",
+          "per-title guest_args: later duplicate wins, key splits on the dot");
+    CHECK(guest_args_for(pt, "PPSA02664") == "-b" && guest_args_for(pt, "PPSA99999") == "",
+          "per-title resolution falls back to empty without a default");
+    AppConfig both = parse_app_config(
+        "guest_args = -force-gfx-direct\nguest_args.PPSA02664 = -title-specific");
+    CHECK(guest_args_for(both, "PPSA02664") == "-title-specific" &&
+              guest_args_for(both, "PPSA24651") == "-force-gfx-direct",
+          "per-title entry wins over the default; other titles get the default");
+    AppConfig rt = parse_app_config("guest_args = d\n");
+    rt.guest_args_by_title["PPSA02664"] = "x";
+    const std::string round = serialize_app_config(rt);
+    AppConfig back = parse_app_config(round);
+    CHECK(back.guest_args_default == "d" && back.guest_args_by_title.at("PPSA02664") == "x",
+          "guest args survive a serialize round trip");
+    CHECK(round.find("guest_args.PPSA02664 = x") != std::string::npos &&
+              round.find("guest_args = d") != std::string::npos,
+          "serialized keys use the documented spellings");
     CHECK(parse_app_config("future_key = 1").unknown_lines.size() == 1,
           "an unknown key is retained rather than discarded");
     CHECK(parse_app_config("games_dir = /g").unknown_lines.empty(),


### PR DESCRIPTION
Fixes the user-facing half of #2973: Unity titles (Alex Kidd verified) need `PROSPER_GUEST_ARGS=-force-gfx-direct` to render in `prosper-app` — the MT gfx-jobs handshake they otherwise use is not emulated yet (RENDER_LOOP.md). Headless tooling always set it; library and interactive launches never did, so those titles came up black and some crashed at the first scene transition.

## What this lands

Two settings keys in `prosper-app.conf`, applied at boot **only when the user's environment does not already set `PROSPER_GUEST_ARGS`** (the file never overrides the environment — the app_config precedence rule):

- `guest_args = <args>` — applied to every title
- `guest_args.<TITLE_ID> = <args>` — overrides for one title (e.g. `guest_args.PPSA02664 = -force-gfx-direct`)

The choice is explicit and per-title by design: some titles must NOT receive Unity-specific switches (DOLL, Dragon Quest — see their status docs), so there is deliberately **no silent global default**. The durable fix for the underlying gap (emulating the gfx-jobs handshake) stays tracked on #2973.

## Verification

- Config parse/serialize arms in `test_prosper_app_game_library`: default read, per-title key split + later-duplicate-wins, per-title-over-default resolution, serialize round trip, documented key spellings — all pass (suite exit 0).
- End-to-end on PPSA02664, config entry only, **no env**: boot log shows `[app] guest args (config): -force-gfx-direct`; 30 s run, 238 dumped frames of which 117 carry real content (the rest are the game's own black loading screens); zero faults.
- A launch with the entry removed and no env reproduces the black-composite behavior, confirming the key is what matters.

## Deliberately unaffected

Titles whose owners set nothing: behavior is byte-identical to today (empty args). The underlying gfx-jobs emulation gap remains open on #2973.