### PR TITLE
gpu: execute retained DMAs at the dependency point instead of rejecting

### DIFF
--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -4150,6 +4150,23 @@ static void diagnose_ordered_wait_acceptance(
                  write_data_overlays, effects.size());
 }
 
+
+// Apply all retained address-backed DMA copies to guest memory, in stream order, and clear the
+// retention. Called at a dependency point (WAIT_REG_MEM / SetRegsIndirect / Jump that reads a
+// retained DMA's destination) so the dependent command sees the DMA-written data — in-order
+// execution, matching real hardware where there is no "rejection", only ordering.
+void apply_retained_dma_copies(std::vector<GpuState::DmaCopy>& copies) {
+    for (const auto& copy : copies) {
+        if (!copy.dst || !copy.src || !copy.bytes) continue;
+        if (!guest_readable(copy.src, copy.bytes)) continue;
+        if (!guest_readable(copy.dst, copy.bytes)) continue;
+        memmove(reinterpret_cast<void*>(uintptr_t(copy.dst)),
+                reinterpret_cast<const void*>(uintptr_t(copy.src)),
+                copy.bytes);
+    }
+    copies.clear();
+}
+
 void GpuState::apply(const Pm4Command& c) {
     using K = Pm4Command::Kind;
     command_order = c.stream_order ? c.stream_order : command_order + 1;
@@ -4163,18 +4180,10 @@ void GpuState::apply(const Pm4Command& c) {
             const bool overlaps_effect = !ordered_memory_effects.empty() &&
                 retained_ordered_effect_destination_overlaps(
                     ordered_memory_effects, c.regs_vaddr, regs_bytes);
-            if (overlaps_dma || overlaps_effect) {
-                dma_execution_rejected = true;
-                static std::atomic<int> warned{0};
-                if (warned.fetch_add(1) < 24)
-                    fprintf(stderr,
-                            "[agc] ordered DMA submit rejected: SetRegsIndirect overlaps earlier "
-                            "retained %s destination (addr=0x%llx bytes=%llu order=%llu)\n",
-                            overlaps_effect ? "memory-effect" : "DMA",
-                            (unsigned long long)c.regs_vaddr, (unsigned long long)regs_bytes,
-                            (unsigned long long)command_order);
-                break;
-            }
+            // In-order execution: apply the retained DMAs so the reader sees the copied
+            // bytes, then proceed. Real hardware has no "rejection" — only ordering.
+            if (overlaps_dma) apply_retained_dma_copies(dma_copies);
+            if (overlaps_effect) ordered_memory_effects.clear();
             // #312/#448: the indirect-register array lives in GUEST memory (regs_vaddr from the packet),
             // and a freed/decommitted or recycled command buffer can leave it unmapped. Every other
             // guest read in this file is guest_readable-guarded; this reader (up to 4096*8 = 32 KiB) was
@@ -4752,7 +4761,13 @@ void GpuState::apply(const Pm4Command& c) {
             if (ordered_wait_satisfied)
                 diagnose_ordered_wait_acceptance(
                     c, ordered_memory_effects, ordered_base_value, ordered_overlay);
-            if (wait_overlaps_dma || (wait_overlaps_effect && !ordered_wait_satisfied)) {
+            if (wait_overlaps_dma) {
+                // In-order execution: apply the retained DMAs so the wait observes the copied
+                // bytes. Real hardware has no "rejection" — the DMA engine writes, then the
+                // wait polls the written value and proceeds.
+                apply_retained_dma_copies(dma_copies);
+            }
+            if (wait_overlaps_effect && !ordered_wait_satisfied) {
                 dma_execution_rejected = true;
                 diagnose_ordered_wait_rejection(
                     c, dma_copies, ordered_memory_effects, wait_readable,
@@ -4761,8 +4776,7 @@ void GpuState::apply(const Pm4Command& c) {
                 if (warned.fetch_add(1) < 24)
                     fprintf(stderr,
                             "[agc] ordered DMA submit rejected: WAIT_REG_MEM has unresolved earlier "
-                            "retained %s dependency (addr=0x%llx order=%llu)\n",
-                            wait_overlaps_dma ? "DMA" : "memory-effect",
+                            "retained memory-effect dependency (addr=0x%llx order=%llu)\n",
                             (unsigned long long)c.wm_addr,
                             (unsigned long long)command_order);
                 break;
@@ -5050,16 +5064,21 @@ void GpuState::apply(const Pm4Command& c) {
                  (c.jump_pred && pred_cond_addr &&
                   retained_ordered_effect_destination_overlaps(
                       ordered_memory_effects, pred_cond_addr, 8)));
-            if (jump_reads_dma || jump_reads_effect) {
+            if (jump_reads_dma) {
+                // In-order execution: apply the retained DMAs so the jump target/predication
+                // reads see the copied bytes.
+                apply_retained_dma_copies(dma_copies);
+            }
+            if (jump_reads_effect) {
                 dma_execution_rejected = true;
                 static std::atomic<int> warned{0};
                 const uint64_t ord = warned.fetch_add(1) + 1;
                 if (ord <= 24 || (ord & (ord - 1)) == 0)
                     fprintf(stderr,
                             "[agc] ordered DMA submit rejected #%llu: Jump reads target/predication "
-                            "memory overlapping a retained %s (target=0x%llx bytes=%llu "
+                            "memory overlapping a retained memory-effect (target=0x%llx bytes=%llu "
                             "cond=0x%llx order=%llu)\n",
-                            (unsigned long long)ord, jump_reads_effect ? "memory-effect" : "DMA",
+                            (unsigned long long)ord,
                             (unsigned long long)c.jump_addr, (unsigned long long)jump_bytes,
                             (unsigned long long)pred_cond_addr,
                             (unsigned long long)command_order);

--- a/prosper/src/gpu/pm4/command_processor.cpp
+++ b/prosper/src/gpu/pm4/command_processor.cpp
@@ -4152,14 +4152,21 @@ static void diagnose_ordered_wait_acceptance(
 
 
 // Apply all retained address-backed DMA copies to guest memory, in stream order, and clear the
-// retention. Called at a dependency point (WAIT_REG_MEM / SetRegsIndirect / Jump that reads a
-// retained DMA's destination) so the dependent command sees the DMA-written data — in-order
-// execution, matching real hardware where there is no "rejection", only ordering.
+// retention. Called at a DMA-overlap dependency point (WAIT_REG_MEM / SetRegsIndirect / Jump
+// that reads a retained DMA's destination) so the dependent command sees the DMA-written data —
+// in-order execution, matching real hardware where there is no "rejection", only ordering.
 void apply_retained_dma_copies(std::vector<GpuState::DmaCopy>& copies) {
     for (const auto& copy : copies) {
         if (!copy.dst || !copy.src || !copy.bytes) continue;
-        if (!guest_readable(copy.src, copy.bytes)) continue;
-        if (!guest_readable(copy.dst, copy.bytes)) continue;
+        if (!guest_readable(copy.src, copy.bytes) || !guest_readable(copy.dst, copy.bytes)) {
+            static std::atomic<int> n{0};
+            if (n.fetch_add(1) < 8)
+                fprintf(stderr, "[agc] apply_retained_dma_copies: skipping unmapped DMA "
+                        "dst=0x%llx src=0x%llx bytes=%llu\n",
+                        (unsigned long long)copy.dst, (unsigned long long)copy.src,
+                        (unsigned long long)copy.bytes);
+            continue;
+        }
         memmove(reinterpret_cast<void*>(uintptr_t(copy.dst)),
                 reinterpret_cast<const void*>(uintptr_t(copy.src)),
                 copy.bytes);
@@ -4180,10 +4187,17 @@ void GpuState::apply(const Pm4Command& c) {
             const bool overlaps_effect = !ordered_memory_effects.empty() &&
                 retained_ordered_effect_destination_overlaps(
                     ordered_memory_effects, c.regs_vaddr, regs_bytes);
-            // In-order execution: apply the retained DMAs so the reader sees the copied
-            // bytes, then proceed. Real hardware has no "rejection" — only ordering.
-            if (overlaps_dma) apply_retained_dma_copies(dma_copies);
-            if (overlaps_effect) ordered_memory_effects.clear();
+            if (overlaps_dma) {
+                // In-order execution (#2975): apply the retained DMAs so the reader sees the
+                // copied bytes, then proceed. Real hardware has no "rejection" — only ordering.
+                apply_retained_dma_copies(dma_copies);
+            }
+            if (overlaps_effect) {
+                // Effect overlaps are a different mechanism (retained WRITE_DATA, not DMA) and
+                // keep their fail-closed rejection — the correct fix for those is separate.
+                dma_execution_rejected = true;
+                break;
+            }
             // #312/#448: the indirect-register array lives in GUEST memory (regs_vaddr from the packet),
             // and a freed/decommitted or recycled command buffer can leave it unmapped. Every other
             // guest read in this file is guest_readable-guarded; this reader (up to 4096*8 = 32 KiB) was
@@ -4762,9 +4776,9 @@ void GpuState::apply(const Pm4Command& c) {
                 diagnose_ordered_wait_acceptance(
                     c, ordered_memory_effects, ordered_base_value, ordered_overlay);
             if (wait_overlaps_dma) {
-                // In-order execution: apply the retained DMAs so the wait observes the copied
-                // bytes. Real hardware has no "rejection" — the DMA engine writes, then the
-                // wait polls the written value and proceeds.
+                // In-order execution (#2975): apply the retained DMAs so the wait observes the
+                // copied bytes. Real hardware has no "rejection" — the DMA engine writes, then
+                // the wait polls the written value and proceeds.
                 apply_retained_dma_copies(dma_copies);
             }
             if (wait_overlaps_effect && !ordered_wait_satisfied) {
@@ -5065,8 +5079,8 @@ void GpuState::apply(const Pm4Command& c) {
                   retained_ordered_effect_destination_overlaps(
                       ordered_memory_effects, pred_cond_addr, 8)));
             if (jump_reads_dma) {
-                // In-order execution: apply the retained DMAs so the jump target/predication
-                // reads see the copied bytes.
+                // In-order execution (#2975): apply the retained DMAs so the jump target and
+                // predication reads see the copied bytes.
                 apply_retained_dma_copies(dma_copies);
             }
             if (jump_reads_effect) {

--- a/prosper/tests/gpu/test_eop_write.cpp
+++ b/prosper/tests/gpu/test_eop_write.cpp
@@ -837,10 +837,11 @@ int main() {
         stream[7] = PM4(4, IT_NOP, R_SH_REGS_INDIRECT);
         stream[8] = 1; stream[9] = (uint32_t)dst; stream[10] = (uint32_t)(dst >> 32);
         GpuState st; run_cb(stream, 11, st);
-        CHECK(st.dma_copies.size() == 1 && st.dma_execution_rejected,
-              "DMA before indirect registers is retained and rejected fail-closed");
-        CHECK(target_reg.value == 0x11111111u && st.sh.find(0x44) == st.sh.end(),
-              "rejected DMA/indirect submit executes neither copy nor stale register fold");
+        CHECK(st.dma_copies.empty() && !st.dma_execution_rejected,
+              "DMA before indirect registers applies the copy and proceeds (#2975)");
+        CHECK(target_reg.value == 0xA1B2C3D4u && st.sh.find(0x44) != st.sh.end() &&
+                  st.sh[0x44] == 0xA1B2C3D4u,
+              "applied DMA lands the copy and the register fold reads the copied bytes");
     }
 
     // VA-disjoint ranges outside the authoritative guest mapping table are not evidence of physical
@@ -863,9 +864,10 @@ int main() {
         stream[7] = PM4(4, IT_NOP, R_SH_REGS_INDIRECT);
         stream[8] = 1; stream[9] = (uint32_t)regs; stream[10] = (uint32_t)(regs >> 32);
         GpuState st; run_cb(stream, 11, st);
-        CHECK(st.dma_execution_rejected && untracked.target.value == 0x11111111u &&
-                  st.sh.find(untracked.independent.offset) == st.sh.end(),
-              "VA-disjoint untracked topology remains fail-closed");
+        CHECK(!st.dma_execution_rejected && untracked.target.value == 0xAABBCCDDu &&
+                  st.sh.find(untracked.independent.offset) != st.sh.end() &&
+                  st.sh[untracked.independent.offset] == 0x22222222u,
+              "VA-disjoint untracked topology: DMA applies and the register fold reads it");
     }
 
     // Tactics Ogre uploads movie rows and later reads unrelated command arrays/fence labels in the
@@ -930,10 +932,10 @@ int main() {
             stream[8] = 1; stream[9] = (uint32_t)alias_regs;
             stream[10] = (uint32_t)(alias_regs >> 32);
             GpuState aliased_regs; run_cb(stream, 11, aliased_regs);
-            CHECK(aliased_regs.dma_execution_rejected &&
-                      aliased_regs.sh.find(0x46) == aliased_regs.sh.end() &&
-                      alias_reg->value == 0x11111111u,
-                  "VA-disjoint same-physical indirect registers still reject fail-closed");
+            CHECK(!aliased_regs.dma_execution_rejected &&
+                      aliased_regs.sh.find(0x46) != aliased_regs.sh.end() &&
+                      aliased_regs.sh[0x46] == copied_reg.value,
+                  "VA-disjoint same-physical indirect registers: DMA applies, register fold reads it");
 
             auto emit_wait = [&](uint64_t condition_address, uint64_t destination_address,
                                  uint64_t source_address, uint32_t* wait_stream) {
@@ -970,8 +972,8 @@ int main() {
                       (uint64_t)(uintptr_t)wait_target,
                       (uint64_t)(uintptr_t)&wait_source, wait_stream);
             GpuState aliased_wait; run_cb(wait_stream, 15, aliased_wait);
-            CHECK(aliased_wait.dma_execution_rejected && *wait_target == 0,
-                  "VA-disjoint same-physical wait still rejects fail-closed");
+            CHECK(!aliased_wait.dma_execution_rejected && *wait_target == 1,
+                  "VA-disjoint same-physical wait: DMA applies and the wait is satisfied");
 
             // Retained effects after the first address copy are earlier producers too. Prove the
             // original copy is physically disjoint from B, then write B and eagerly read B through


### PR DESCRIPTION
Fixes #2975.

## Failure scenario

Blasphemous 2 (`PPSA13579`) title screen flickers between 4 states in app mode (3-frame cycle): correct / pitch-smeared / diagonally truncated / black. Root cause: address-backed DMA copies (the title-screen texture upload) are retained by the ordered executor, but the WAIT_REG_MEM that polls the written value triggers a **whole-submit rejection** because the DMA hasn't been applied yet. The texture upload never lands.

## Fix

At the three dependency points (WAIT_REG_MEM, SetRegsIndirect, Jump — each reads guest memory that a retained DMA targets), apply the retained DMAs to guest memory (CPU memcpy, in stream order) and proceed. This is in-order execution: the DMA was submitted before the wait/read, so the data should be visible. Real hardware has no "rejection" — only ordering.

Memory-effect overlaps keep their existing rejection (different mechanism, different fix — tracked separately).

## Verification

- The five Vulkan-execution tests pass on this head.
- Full CI on this head.

## Deliberately unaffected

The `ordered_memory_effects` rejection path (different mechanism). The `PROSPER_DMA_TOPOLOGY_RELAX` gate from the diagnostic phase is not landed — the default is now apply-and-proceed for DMA overlaps, reject for effect overlaps.