### PR TITLE
AvPlayer: PTS-gate video delivery — GRIS intro FMV played at 3.86x (#2981)

### DIFF
--- a/PROGRESS_TRACKER.md
+++ b/PROGRESS_TRACKER.md
@@ -156,6 +156,7 @@ of its manifest.
 | The Oregon Trail | `PPSA19244` | 2 | `12----` | - | - | none | [#1945](https://github.com/mattias800/prosper/issues/1945), [#1606](https://github.com/mattias800/prosper/issues/1606), [#1641](https://github.com/mattias800/prosper/issues/1641), [#1634](https://github.com/mattias800/prosper/issues/1634) | [#1886](https://github.com/mattias800/prosper/issues/1886) | [`OREGON_TRAIL_STATUS.md`](prosper/docs/OREGON_TRAIL_STATUS.md) |
 | The Pathless | `PPSA01826` | 2 | `12----` | - | - | none | [#1570](https://github.com/mattias800/prosper/issues/1570), [#1213](https://github.com/mattias800/prosper/issues/1213) | [#1883](https://github.com/mattias800/prosper/issues/1883) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
 | The Plucky Squire | `PPSA15319` | 2 | `12----` | - | - | none | [#1390](https://github.com/mattias800/prosper/issues/1390) | [#1882](https://github.com/mattias800/prosper/issues/1882) | [`GAME_COMPAT_ORCHESTRATION.md`](prosper/docs/GAME_COMPAT_ORCHESTRATION.md) |
+| Tomb Raider I-III Remastered | `PPSA16901` | 2 | `12----` | - | - | none | - | [#2990](https://github.com/mattias800/prosper/issues/2990) | [`TOMB_RAIDER_STATUS.md`](prosper/docs/TOMB_RAIDER_STATUS.md) |
 | Unbound: Worlds Apart | `PPSA03274` | 2 | `12----` | **17.9** fps · 21% active · 4K · past the title screen and intro to the first level's map load, level a flat clear · screenshot · 2026-08-22 | - | none | [#2932](https://github.com/mattias800/prosper/issues/2932), [#2931](https://github.com/mattias800/prosper/issues/2931), [#2930](https://github.com/mattias800/prosper/issues/2930) | [#2886](https://github.com/mattias800/prosper/issues/2886) | [`NEVER_BOOTED_SURVEY_2026_08.md`](prosper/docs/NEVER_BOOTED_SURVEY_2026_08.md) |
 | Beast of Reincarnation | `PPSA29343` | 1 | `1-----` | **9.2** fps · 56% active · 4K · GAME FREAK logo then the Digital Deluxe bonus dialog, with PROSPER_CB_EFC_NO_COLOR=1 · screenshot · 2026-08-22 | - | none | [#1588](https://github.com/mattias800/prosper/issues/1588), [#2911](https://github.com/mattias800/prosper/issues/2911), [#2915](https://github.com/mattias800/prosper/issues/2915) | [#2916](https://github.com/mattias800/prosper/issues/2916) | [`BEAST_OF_REINCARNATION_STATUS.md`](prosper/docs/BEAST_OF_REINCARNATION_STATUS.md) |
 | Little Nightmares II | `PPSA02154` | 1 | `1-----` | **6.9** fps · 19% active · 4K · boot logo sequence, then a flat white clear · screenshot · 2026-08-22 | - | none | [#2932](https://github.com/mattias800/prosper/issues/2932), [#2929](https://github.com/mattias800/prosper/issues/2929), [#2930](https://github.com/mattias800/prosper/issues/2930) | [#2884](https://github.com/mattias800/prosper/issues/2884) | [`NEVER_BOOTED_SURVEY_2026_08.md`](prosper/docs/NEVER_BOOTED_SURVEY_2026_08.md) |
@@ -177,10 +178,10 @@ of its manifest.
 | 6 -- reviewed automatic gameplay snapshot guard | 14 |
 | 4 -- manual visual verification | 2 |
 | 3 -- gameplay with the scene rendering | 8 |
-| 2 -- title screen | 18 |
+| 2 -- title screen | 19 |
 | 1 -- any real graphics | 3 |
 | 0 -- not started | 9 |
 
-**4 of 54** trackers record a PS5 hardware-oracle comparison; the rest carry
+**4 of 55** trackers record a PS5 hardware-oracle comparison; the rest carry
 `Oracle record: none`. That ratio is the reason this column exists -- before #2730 it took a
 scan of 6,224 issue comments to establish, and it was wrong by nine titles.

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -34,7 +34,12 @@ namespace prosper::video {
 namespace {
 
 constexpr size_t kVideoQueueCapacity = 6;
-constexpr size_t kAudioQueueCapacity = 32;
+// Runway against the demux interleave: AAC frames arrive ~2:1 over video frames, so the worker
+// services audio ~48/s while the guest consumes ~46.9/s — barely positive. Any jitter (a video
+// enqueue blocking a frame longer, a poll hiccup) emptied the old 32-frame queue (682 ms) and the
+// starvation drop path fired ~24 times per 10 s, losing 12% of GRIS's intro frames (#2981 FMV).
+// 512 frames ≈ 10.9 s of audio ≈ 4 MB: the drain margin stops being reachable in practice.
+constexpr size_t kAudioQueueCapacity = 512;
 
 // A guest counts as an ACTIVE audio consumer for this long after its last next_audio() call. It has
 // to be a window rather than a flag because both of the states that matter -- "this title routes
@@ -690,13 +695,16 @@ void decode_session(Session& session, std::stop_token stop) {
             return receive_frames(decoder, video);
         };
 
-        // Compressed video packets awaiting queue room. When the video queue fills, the worker
-        // HOLDS the packet and keeps demuxing/servicing audio instead of blocking inside
-        // enqueue_video: blocking there starves the audio consumer (the audio queue drains while
-        // the worker sleeps on video), which tripped the starvation drop path ~24 times per 10 s —
-        // 12% of the intro's frames lost (#2981 FMV). Held packets are compressed (bytes, not
-        // frames), so the hold costs kilobytes for the tens of milliseconds the queue needs to
-        // drain. RAII: every exit path through this scope, goto `finished` included, unrefs them.
+        // Audio runway: the demux interleaves ~2 audio packets per video packet, but a worker
+        // blocked on a full video queue services audio only between video pops — a net drain of
+        // ~1 packet/s against a queue that starts EMPTY. Any jitter then empties it and the
+        // starvation drop path fires ~24 times per 10 s (12% of GRIS's intro frames, #2981 FMV).
+        // So: while the audio queue is below the runway target, video packets are HELD
+        // (compressed — kilobytes) and the demux keeps flowing to the audio packets until the
+        // runway is built. Past the target the video queue's own backpressure throttles decode
+        // as before, with the runway absorbing jitter. The hold is bounded twice: it ends when
+        // the runway is built; enqueue_audio's own backpressure then paces the demux.
+        constexpr size_t kAudioRunwayTarget = kAudioQueueCapacity / 2;
         struct HeldVideo {
             std::deque<AVPacket*> q;
             ~HeldVideo() { while (!q.empty()) { av_packet_unref(q.front()); q.pop_front(); } }
@@ -705,19 +713,23 @@ void decode_session(Session& session, std::stop_token stop) {
             std::lock_guard<std::mutex> lock(session.mutex);
             return session.video_queue.size() < kVideoQueueCapacity;
         };
-        auto flush_held_video = [&]() -> bool {
-            while (!held_video.q.empty() && video_queue_has_room()) {
-                AVPacket* held = held_video.q.front();
-                held_video.q.pop_front();
-                if (!submit_packet(pipeline.video, held, true)) { av_packet_unref(held); return false; }
-                av_packet_unref(held);
-            }
-            return true;
+        auto audio_queue_has_runway = [&]() {
+            std::lock_guard<std::mutex> lock(session.mutex);
+            return !session.stream_info.has_audio ||
+                   session.audio_queue.size() >= kAudioRunwayTarget;
         };
-
         bool decode_ok = true;
         while (!session_stopping(session, stop)) {
-            if (!flush_held_video()) { decode_ok = false; break; }
+            // Flush held packets while the video queue has room.
+            while (!held_video.q.empty() && video_queue_has_room() &&
+                   !session_stopping(session, stop)) {
+                AVPacket* held = held_video.q.front();
+                held_video.q.pop_front();
+                decode_ok = submit_packet(pipeline.video, held, true);
+                av_packet_unref(held);
+                if (!decode_ok) break;
+            }
+            if (!decode_ok || session_stopping(session, stop)) break;
             result = av_read_frame(pipeline.format, pipeline.packet);
             if (result == AVERROR_EOF) break;
             if (result < 0) {
@@ -726,7 +738,13 @@ void decode_session(Session& session, std::stop_token stop) {
                 break;
             }
             if (pipeline.packet->stream_index == video_stream) {
-                if (video_queue_has_room()) {
+                // Direct-submit only when nothing is held (stream order — submitting a newer
+                // packet while older ones are held corrupts libavcodec's decode order) and both
+                // queues are healthy; otherwise hold. The hold is bounded by the audio-runway
+                // build: once kAudioRunwayTarget is reached, enqueue_audio's own backpressure
+                // paces the demux, and the guest's pops drain the held tail.
+                if (held_video.q.empty() && video_queue_has_room() &&
+                    audio_queue_has_runway()) {
                     decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
                 } else {
                     AVPacket* held = av_packet_clone(pipeline.packet);
@@ -734,25 +752,23 @@ void decode_session(Session& session, std::stop_token stop) {
                     else decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
                 }
             }
-            else if (pipeline.audio && pipeline.packet->stream_index == audio_stream) {
+            else if (pipeline.audio && pipeline.packet->stream_index == audio_stream)
                 decode_ok = submit_packet(pipeline.audio, pipeline.packet, false);
-                if (decode_ok && !flush_held_video()) break;
-            }
             av_packet_unref(pipeline.packet);
             if (!decode_ok) break;
         }
         if (decode_ok && !session_stopping(session, stop)) {
             // Drain the held tail, then flush both decoders.
             while (!held_video.q.empty() && !session_stopping(session, stop)) {
-                if (video_queue_has_room()) {
-                    AVPacket* held = held_video.q.front();
-                    held_video.q.pop_front();
-                    decode_ok = submit_packet(pipeline.video, held, true);
-                    av_packet_unref(held);
-                    if (!decode_ok) break;
-                } else {
+                if (!video_queue_has_room()) {
                     std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                    continue;
                 }
+                AVPacket* held = held_video.q.front();
+                held_video.q.pop_front();
+                decode_ok = submit_packet(pipeline.video, held, true);
+                av_packet_unref(held);
+                if (!decode_ok) break;
             }
             if (decode_ok) decode_ok = submit_packet(pipeline.video, nullptr, true);
             if (decode_ok && pipeline.audio)
@@ -997,7 +1013,9 @@ VaapiBackend& shared_vaapi_backend() {
 
 uint64_t VaapiBackend::video_frames_dropped(int id) {
     const auto session = impl_->get(id);
-    return session ? session->video_frames_dropped : 0;
+    if (!session) return 0;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    return session->video_frames_dropped;
 }
 
 uint64_t VaapiBackend::video_frames_dropped_for_test(int id) {

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -695,41 +695,8 @@ void decode_session(Session& session, std::stop_token stop) {
             return receive_frames(decoder, video);
         };
 
-        // Audio runway: the demux interleaves ~2 audio packets per video packet, but a worker
-        // blocked on a full video queue services audio only between video pops — a net drain of
-        // ~1 packet/s against a queue that starts EMPTY. Any jitter then empties it and the
-        // starvation drop path fires ~24 times per 10 s (12% of GRIS's intro frames, #2981 FMV).
-        // So: while the audio queue is below the runway target, video packets are HELD
-        // (compressed — kilobytes) and the demux keeps flowing to the audio packets until the
-        // runway is built. Past the target the video queue's own backpressure throttles decode
-        // as before, with the runway absorbing jitter. The hold is bounded twice: it ends when
-        // the runway is built; enqueue_audio's own backpressure then paces the demux.
-        constexpr size_t kAudioRunwayTarget = kAudioQueueCapacity / 2;
-        struct HeldVideo {
-            std::deque<AVPacket*> q;
-            ~HeldVideo() { while (!q.empty()) { av_packet_unref(q.front()); q.pop_front(); } }
-        } held_video;
-        auto video_queue_has_room = [&]() {
-            std::lock_guard<std::mutex> lock(session.mutex);
-            return session.video_queue.size() < kVideoQueueCapacity;
-        };
-        auto audio_queue_has_runway = [&]() {
-            std::lock_guard<std::mutex> lock(session.mutex);
-            return !session.stream_info.has_audio ||
-                   session.audio_queue.size() >= kAudioRunwayTarget;
-        };
         bool decode_ok = true;
         while (!session_stopping(session, stop)) {
-            // Flush held packets while the video queue has room.
-            while (!held_video.q.empty() && video_queue_has_room() &&
-                   !session_stopping(session, stop)) {
-                AVPacket* held = held_video.q.front();
-                held_video.q.pop_front();
-                decode_ok = submit_packet(pipeline.video, held, true);
-                av_packet_unref(held);
-                if (!decode_ok) break;
-            }
-            if (!decode_ok || session_stopping(session, stop)) break;
             result = av_read_frame(pipeline.format, pipeline.packet);
             if (result == AVERROR_EOF) break;
             if (result < 0) {
@@ -737,40 +704,15 @@ void decode_session(Session& session, std::stop_token stop) {
                 decode_ok = false;
                 break;
             }
-            if (pipeline.packet->stream_index == video_stream) {
-                // Direct-submit only when nothing is held (stream order — submitting a newer
-                // packet while older ones are held corrupts libavcodec's decode order) and both
-                // queues are healthy; otherwise hold. The hold is bounded by the audio-runway
-                // build: once kAudioRunwayTarget is reached, enqueue_audio's own backpressure
-                // paces the demux, and the guest's pops drain the held tail.
-                if (held_video.q.empty() && video_queue_has_room() &&
-                    audio_queue_has_runway()) {
-                    decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
-                } else {
-                    AVPacket* held = av_packet_clone(pipeline.packet);
-                    if (held) held_video.q.push_back(held);
-                    else decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
-                }
-            }
+            if (pipeline.packet->stream_index == video_stream)
+                decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
             else if (pipeline.audio && pipeline.packet->stream_index == audio_stream)
                 decode_ok = submit_packet(pipeline.audio, pipeline.packet, false);
             av_packet_unref(pipeline.packet);
             if (!decode_ok) break;
         }
         if (decode_ok && !session_stopping(session, stop)) {
-            // Drain the held tail, then flush both decoders.
-            while (!held_video.q.empty() && !session_stopping(session, stop)) {
-                if (!video_queue_has_room()) {
-                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
-                    continue;
-                }
-                AVPacket* held = held_video.q.front();
-                held_video.q.pop_front();
-                decode_ok = submit_packet(pipeline.video, held, true);
-                av_packet_unref(held);
-                if (!decode_ok) break;
-            }
-            if (decode_ok) decode_ok = submit_packet(pipeline.video, nullptr, true);
+            decode_ok = submit_packet(pipeline.video, nullptr, true);
             if (decode_ok && pipeline.audio)
                 decode_ok = submit_packet(pipeline.audio, nullptr, false);
         }
@@ -1009,6 +951,13 @@ void VaapiBackend::close(int id) {
 VaapiBackend& shared_vaapi_backend() {
     static VaapiBackend backend_instance;
     return backend_instance;
+}
+
+int VaapiBackend::video_queue_depth(int id) {
+    const auto session = impl_->get(id);
+    if (!session) return -1;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    return (int)session->video_queue.size();
 }
 
 uint64_t VaapiBackend::video_frames_dropped(int id) {

--- a/prosper/frontends/video_vaapi/vaapi_backend.cpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.cpp
@@ -690,8 +690,34 @@ void decode_session(Session& session, std::stop_token stop) {
             return receive_frames(decoder, video);
         };
 
+        // Compressed video packets awaiting queue room. When the video queue fills, the worker
+        // HOLDS the packet and keeps demuxing/servicing audio instead of blocking inside
+        // enqueue_video: blocking there starves the audio consumer (the audio queue drains while
+        // the worker sleeps on video), which tripped the starvation drop path ~24 times per 10 s —
+        // 12% of the intro's frames lost (#2981 FMV). Held packets are compressed (bytes, not
+        // frames), so the hold costs kilobytes for the tens of milliseconds the queue needs to
+        // drain. RAII: every exit path through this scope, goto `finished` included, unrefs them.
+        struct HeldVideo {
+            std::deque<AVPacket*> q;
+            ~HeldVideo() { while (!q.empty()) { av_packet_unref(q.front()); q.pop_front(); } }
+        } held_video;
+        auto video_queue_has_room = [&]() {
+            std::lock_guard<std::mutex> lock(session.mutex);
+            return session.video_queue.size() < kVideoQueueCapacity;
+        };
+        auto flush_held_video = [&]() -> bool {
+            while (!held_video.q.empty() && video_queue_has_room()) {
+                AVPacket* held = held_video.q.front();
+                held_video.q.pop_front();
+                if (!submit_packet(pipeline.video, held, true)) { av_packet_unref(held); return false; }
+                av_packet_unref(held);
+            }
+            return true;
+        };
+
         bool decode_ok = true;
         while (!session_stopping(session, stop)) {
+            if (!flush_held_video()) { decode_ok = false; break; }
             result = av_read_frame(pipeline.format, pipeline.packet);
             if (result == AVERROR_EOF) break;
             if (result < 0) {
@@ -699,15 +725,36 @@ void decode_session(Session& session, std::stop_token stop) {
                 decode_ok = false;
                 break;
             }
-            if (pipeline.packet->stream_index == video_stream)
-                decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
-            else if (pipeline.audio && pipeline.packet->stream_index == audio_stream)
+            if (pipeline.packet->stream_index == video_stream) {
+                if (video_queue_has_room()) {
+                    decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
+                } else {
+                    AVPacket* held = av_packet_clone(pipeline.packet);
+                    if (held) held_video.q.push_back(held);
+                    else decode_ok = submit_packet(pipeline.video, pipeline.packet, true);
+                }
+            }
+            else if (pipeline.audio && pipeline.packet->stream_index == audio_stream) {
                 decode_ok = submit_packet(pipeline.audio, pipeline.packet, false);
+                if (decode_ok && !flush_held_video()) break;
+            }
             av_packet_unref(pipeline.packet);
             if (!decode_ok) break;
         }
         if (decode_ok && !session_stopping(session, stop)) {
-            decode_ok = submit_packet(pipeline.video, nullptr, true);
+            // Drain the held tail, then flush both decoders.
+            while (!held_video.q.empty() && !session_stopping(session, stop)) {
+                if (video_queue_has_room()) {
+                    AVPacket* held = held_video.q.front();
+                    held_video.q.pop_front();
+                    decode_ok = submit_packet(pipeline.video, held, true);
+                    av_packet_unref(held);
+                    if (!decode_ok) break;
+                } else {
+                    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                }
+            }
+            if (decode_ok) decode_ok = submit_packet(pipeline.video, nullptr, true);
             if (decode_ok && pipeline.audio)
                 decode_ok = submit_packet(pipeline.audio, nullptr, false);
         }
@@ -825,6 +872,23 @@ bool VaapiBackend::info(int id, StreamInfo& out) {
     return session->init_ok;
 }
 
+bool VaapiBackend::peek_video(int id, VideoFrame& out) {
+    const auto session = impl_->get(id);
+    if (!session) return false;
+    std::lock_guard<std::mutex> lock(session->mutex);
+    if (session->video_queue.empty()) return false;
+    const auto& front = session->video_queue.front();
+    out.y = front.nv12.data();
+    const size_t y_bytes = static_cast<size_t>(front.stride) * front.height;
+    out.uv = front.nv12.data() + y_bytes;
+    out.width = front.width;
+    out.height = front.height;
+    out.y_stride = front.stride;
+    out.uv_stride = front.stride;
+    out.pts_us = front.pts_us;
+    return true;
+}
+
 bool VaapiBackend::next_video(int id, VideoFrame& out) {
     const auto session = impl_->get(id);
     if (!session) return false;
@@ -929,6 +993,11 @@ void VaapiBackend::close(int id) {
 VaapiBackend& shared_vaapi_backend() {
     static VaapiBackend backend_instance;
     return backend_instance;
+}
+
+uint64_t VaapiBackend::video_frames_dropped(int id) {
+    const auto session = impl_->get(id);
+    return session ? session->video_frames_dropped : 0;
 }
 
 uint64_t VaapiBackend::video_frames_dropped_for_test(int id) {

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -22,8 +22,9 @@ public:
     int open(const std::string& host_path) override;
     int open_memory(const std::string& debug_name, const uint8_t* data, size_t bytes) override;
     bool info(int id, StreamInfo& out) override;
-    bool next_video(int id, VideoFrame& out) override;
     bool peek_video(int id, VideoFrame& out) override;
+    bool can_peek_video() const override { return true; }
+    bool next_video(int id, VideoFrame& out) override;
     bool next_audio(int id, AudioFrame& out) override;
     bool eof(int id) override;
     bool seek(int id, uint64_t position_us) override;

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -23,12 +23,14 @@ public:
     int open_memory(const std::string& debug_name, const uint8_t* data, size_t bytes) override;
     bool info(int id, StreamInfo& out) override;
     bool next_video(int id, VideoFrame& out) override;
+    bool peek_video(int id, VideoFrame& out) override;
     bool next_audio(int id, AudioFrame& out) override;
     bool eof(int id) override;
     bool seek(int id, uint64_t position_us) override;
     void close(int id) override;
 
     // The implementation behind vaapi_video_frames_dropped below.
+    uint64_t video_frames_dropped(int id) override;
     uint64_t video_frames_dropped_for_test(int id);
 
     // sceVideodec2's access-unit path (#2270). The guest submits one compressed access unit and

--- a/prosper/frontends/video_vaapi/vaapi_backend.hpp
+++ b/prosper/frontends/video_vaapi/vaapi_backend.hpp
@@ -32,6 +32,7 @@ public:
 
     // The implementation behind vaapi_video_frames_dropped below.
     uint64_t video_frames_dropped(int id) override;
+    int video_queue_depth(int id) override;
     uint64_t video_frames_dropped_for_test(int id);
 
     // sceVideodec2's access-unit path (#2270). The guest submits one compressed access unit and

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -1344,7 +1344,7 @@ struct AvpPlayer {
     // that stops polling (title screen) resumes where it stopped instead of fast-forwarding
     // through the gap, and Pause/Resume/JumpToTime need no special cases (see
     // s_avp_getvideodataex, #2981 FMV speed).
-    uint64_t gate_pts_ms = 0;
+    uint64_t gate_media_ms = 0;
     std::chrono::steady_clock::time_point gate_wall = std::chrono::steady_clock::now();
     bool gate_started = false;
     // When the title supplies its AvPlayer texture allocator, decoded NV12 must be written into those
@@ -1562,6 +1562,13 @@ uint64_t avp_synth_duration_ms() {
     return value ? strtoull(value, nullptr, 0) : avp_synth_frames() * 33;
 }
 bool avp_log() { static const bool enabled = getenv("PROSPER_AVPLOG") != nullptr; return enabled; }
+// One shared monotonic timeline for every [avp] log line — per-site static t0s made cross-
+// referencing deliveries against each other guesswork (#2981 FMV measurement).
+uint64_t avp_ms() {
+    static const auto t0 = std::chrono::steady_clock::now();
+    return (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+}
 // PROSPER_AVP_PAUSED_DELIVER — a PRESERVED FALSIFICATION LEVER, NOT A FEATURE, AND NOT A FIX.
 // It MUST stay off by default; do not "enable" it and do not promote it into the paused contract.
 //
@@ -2193,8 +2200,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
                 p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0;
                 p.paused = false; p.stop_fired = false; p.seek_deliver = false;
                 p.video_request_at = std::chrono::steady_clock::now();
-            p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
-                p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
+                p.gate_media_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
                 p.texture_frames.clear(); p.texture_frame_bytes = 0; p.next_texture_frame = 0;
                 p.backend = nullptr; p.backend_id = -1;
                 // Non-zero placeholder dims/fps: a title that queries GetStreamInfo up-front (before it
@@ -2238,7 +2244,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
             p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0; p.paused = false;
             p.stop_fired = false; p.seek_deliver = false;
             p.video_request_at = std::chrono::steady_clock::now();
-            p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
+            p.gate_media_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
             p.texture_frames = std::move(textures);
             p.texture_frame_bytes = texture_bytes;
             p.next_texture_frame = 0;
@@ -2417,27 +2423,37 @@ HLE(s_avp_getvideodata) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
-        if (p.gate_started) {
+        {
             const auto now = std::chrono::steady_clock::now();
-            if (now - p.gate_wall > std::chrono::milliseconds(1000))
+            // Tick the media clock between polls; a gap longer than 200 ms pauses it (title
+            // screens, stream transitions) — shorter ones are decode jitter and count as media
+            // time, matching a player that plays autonomously between polls.
+            if (p.gate_started) {
+                if (now - p.gate_wall > std::chrono::milliseconds(200))
+                    p.gate_wall = now;
+                else {
+                    p.gate_media_ms +=
+                        (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+                            now - p.gate_wall).count();
+                    p.gate_wall = now;
+                }
+            } else {
                 p.gate_wall = now;
+            }
         }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
             // Media-clock gate, same as GetVideoDataEx above (#2981 FMV speed).
-            bool have = b->peek_video(p.backend_id, vf);
-            if (have && !p.seek_deliver) {
-                const uint64_t pts_ms = vf.pts_us / 1000;
-                const uint64_t due_ms = p.gate_started
-                    ? p.gate_pts_ms + (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now() - p.gate_wall).count()
-                    : 0;
-                if (pts_ms > due_ms) have = false;
+            const bool gated = p.gate_started && b->can_peek_video();
+            bool have = gated ? b->peek_video(p.backend_id, vf) : true;
+            if (have && gated && !p.seek_deliver) {
+                if (vf.pts_us / 1000 > p.gate_media_ms) have = false;   // not due; re-poll
             }
             if (have && b->next_video(p.backend_id, vf)) {
-                p.gate_pts_ms = vf.pts_us / 1000;
-                p.gate_wall = std::chrono::steady_clock::now();
-                p.gate_started = true;
+                if (!p.gate_started) {
+                    p.gate_media_ms = vf.pts_us / 1000;   // anchor at the first frame's PTS
+                    p.gate_started = true;
+                }
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 if (avp_stage_video(p, vf, false, staged, pitch)) {
@@ -2478,6 +2494,7 @@ HLE(s_avp_getvideodataex) {
     svc_log("sceAvPlayerGetVideoDataEx", a0,a1,a2,a3,a4,a5);
     auto* fi = (AvpFrameInfoEx*)PW(a1); if (!fi) return 0;
     void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false; uint64_t result = 0;
+    uint64_t media_snapshot = UINT64_MAX;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0);
@@ -2492,10 +2509,23 @@ HLE(s_avp_getvideodataex) {
         // this shifts the gate's anchor so the movie RESUMES where delivery stopped instead of
         // fast-forwarding through the gap (a 53 s title screen must not skip the intro's first
         // 53 s — measured live, #2981 FMV).
-        if (p.gate_started) {
+        {
             const auto now = std::chrono::steady_clock::now();
-            if (now - p.gate_wall > std::chrono::milliseconds(1000))
+            // Tick the media clock between polls; a gap longer than 200 ms pauses it (title
+            // screens, stream transitions) — shorter ones are decode jitter and count as media
+            // time, matching a player that plays autonomously between polls.
+            if (p.gate_started) {
+                if (now - p.gate_wall > std::chrono::milliseconds(200))
+                    p.gate_wall = now;
+                else {
+                    p.gate_media_ms +=
+                        (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+                            now - p.gate_wall).count();
+                    p.gate_wall = now;
+                }
+            } else {
                 p.gate_wall = now;
+            }
         }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
@@ -2505,23 +2535,20 @@ HLE(s_avp_getvideodataex) {
             // pacing must live HERE, not in the guest. Peek first: next_video pops, and a frame
             // refused after the pop would be lost. 20 ms lead = half a 24 fps frame, so the poll
             // loop (measured ~5 ms cadence) picks the frame up on the first poll after it is due.
-            bool have = b->peek_video(p.backend_id, vf);
-            if (have && !p.seek_deliver) {
-                const uint64_t pts_ms = vf.pts_us / 1000;
-                const uint64_t due_ms = p.gate_started
-                    ? p.gate_pts_ms + (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
-                          std::chrono::steady_clock::now() - p.gate_wall).count()
-                    : 0;
-                // No delivery lead: a lead here accumulates per frame (each frame delivers
-                // lead-ms early, shifting the whole movie) — measured 1.59x with a 20 ms lead
-                // at the guest's ~38 Hz poll cadence. The poll interval is 5-10 ms, so the
-                // zero-lead delivery latency is bounded by one poll.
-                if (pts_ms > due_ms) have = false;   // not due yet; the guest re-polls
+            // The PTS gate needs a non-destructive peek. A backend without one keeps ungated
+            // delivery (the pre-gate behavior) — refusing frames it cannot re-inspect would
+            // deliver nothing at all (#2989 review, blocking 1).
+            const bool gated = p.gate_started && b->can_peek_video();
+            bool have = gated ? b->peek_video(p.backend_id, vf) : true;
+            if (have && gated && !p.seek_deliver) {
+                if (vf.pts_us / 1000 > p.gate_media_ms) have = false;   // not due; re-poll
             }
             if (have && b->next_video(p.backend_id, vf)) {
-                p.gate_pts_ms = vf.pts_us / 1000;
-                p.gate_wall = std::chrono::steady_clock::now();
-                p.gate_started = true;
+                if (!p.gate_started) {
+                    p.gate_media_ms = vf.pts_us / 1000;   // anchor at the first frame's PTS
+                    p.gate_started = true;
+                }
+                media_snapshot = p.gate_media_ms;
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 // Publish the frame only if its metadata is publishable: a refused fill would
@@ -2557,17 +2584,15 @@ HLE(s_avp_getvideodataex) {
     if (fire_stop) avp_fire(obj, cb, AVP_STOP);
     if (avp_log()) {
         static std::atomic<uint64_t> delivered{0};
-        static const auto t0 = std::chrono::steady_clock::now();
-        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::steady_clock::now() - t0).count();
         if (result)
-            fprintf(stderr, "[avp] video-ex handle=0x%llx DELIVER #%llu t=%llums pts=%llums\n",
+            fprintf(stderr, "[avp] video-ex handle=0x%llx DELIVER #%llu t=%llums pts=%llums media=%llums\n",
                     (unsigned long long)a0,
                     (unsigned long long)delivered.fetch_add(1) + 1,
-                    (unsigned long long)ms, (unsigned long long)fi->timestamp);
+                    (unsigned long long)avp_ms(), (unsigned long long)fi->timestamp,
+                    (unsigned long long)media_snapshot);
         else
             fprintf(stderr, "[avp] video-ex handle=0x%llx empty t=%llums\n",
-                    (unsigned long long)a0, (unsigned long long)ms);
+                    (unsigned long long)a0, (unsigned long long)avp_ms());
     }
     return result;
 }
@@ -2592,16 +2617,11 @@ HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFr
         AvpAudio details{(uint16_t)af.channels, {}, af.sample_rate,
                          (uint32_t)(af.samples * af.channels * sizeof(int16_t)), {}};
         memcpy(&fi->d0, &details, sizeof(details));
-        if (avp_log()) {
-            static std::atomic<uint64_t> adelivered{0};
-            static const auto at0 = std::chrono::steady_clock::now();
-            const auto ams = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now() - at0).count();
+        if (avp_log())
             fprintf(stderr, "[avp] audio-deliver handle=0x%llx #%llu t=%llums pts=%llums samples=%u\n",
                     (unsigned long long)a0,
-                    (unsigned long long)adelivered.fetch_add(1) + 1,
-                    (unsigned long long)ams, (unsigned long long)fi->timestamp, af.samples);
-        }
+                    (unsigned long long)0, (unsigned long long)avp_ms(),
+                    (unsigned long long)fi->timestamp, af.samples);
         return 1;
     }
     if (!p.synthetic || p.audio_poll >= avp_synth_frames()) return 0;

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -2436,6 +2436,7 @@ HLE(s_avp_getvideodata) {
     svc_log("sceAvPlayerGetVideoData", a0,a1,a2,a3,a4,a5);
     auto* fi = (AvpFrameInfo*)PW(a1); if (!fi) return 0;
     void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false; uint64_t result = 0;
+    prosper::video::VideoBackend* log_backend = nullptr; int log_backend_id = -1;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0);

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -1339,6 +1339,14 @@ struct AvpPlayer {
     // Those are also every place `paused` is cleared, which is what keeps paused time — during which
     // nothing is presented and nothing should be pulled — from counting as an absent consumer.
     std::chrono::steady_clock::time_point video_request_at = std::chrono::steady_clock::now();
+    // The delivery gate's clock: the next frame is due at (last delivered pts + wall time since
+    // that delivery). Re-anchoring on every delivery makes the gate self-correcting — a guest
+    // that stops polling (title screen) resumes where it stopped instead of fast-forwarding
+    // through the gap, and Pause/Resume/JumpToTime need no special cases (see
+    // s_avp_getvideodataex, #2981 FMV speed).
+    uint64_t gate_pts_ms = 0;
+    std::chrono::steady_clock::time_point gate_wall = std::chrono::steady_clock::now();
+    bool gate_started = false;
     // When the title supplies its AvPlayer texture allocator, decoded NV12 must be written into those
     // guest-visible buffers.  A host vector is invisible to the title's pre-wired texture descriptors.
     std::vector<uint8_t*> texture_frames;
@@ -2185,6 +2193,8 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
                 p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0;
                 p.paused = false; p.stop_fired = false; p.seek_deliver = false;
                 p.video_request_at = std::chrono::steady_clock::now();
+            p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
+                p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
                 p.texture_frames.clear(); p.texture_frame_bytes = 0; p.next_texture_frame = 0;
                 p.backend = nullptr; p.backend_id = -1;
                 // Non-zero placeholder dims/fps: a title that queries GetStreamInfo up-front (before it
@@ -2228,6 +2238,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
             p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0; p.paused = false;
             p.stop_fired = false; p.seek_deliver = false;
             p.video_request_at = std::chrono::steady_clock::now();
+            p.gate_pts_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
             p.texture_frames = std::move(textures);
             p.texture_frame_bytes = texture_bytes;
             p.next_texture_frame = 0;
@@ -2283,7 +2294,7 @@ HLE(s_avp_start) {   // s32 sceAvPlayerStart(handle) — used when auto_start is
         AvpPlayer& p = it->second;
         if (p.have_source && !p.playing && !p.stop_fired) {
             p.playing = true; p.paused = false; play = true; obj = p.ev_obj; cb = p.ev_cb;
-            p.video_request_at = std::chrono::steady_clock::now();   // the media clock starts here
+            p.video_request_at = std::chrono::steady_clock::now();
         }
     }
     if (play) avp_fire(obj, cb, AVP_PLAY);
@@ -2406,9 +2417,27 @@ HLE(s_avp_getvideodata) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
+        if (p.gate_started) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now - p.gate_wall > std::chrono::milliseconds(1000))
+                p.gate_wall = now;
+        }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
-            if (b->next_video(p.backend_id, vf)) {
+            // Media-clock gate, same as GetVideoDataEx above (#2981 FMV speed).
+            bool have = b->peek_video(p.backend_id, vf);
+            if (have && !p.seek_deliver) {
+                const uint64_t pts_ms = vf.pts_us / 1000;
+                const uint64_t due_ms = p.gate_started
+                    ? p.gate_pts_ms + (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - p.gate_wall).count()
+                    : 0;
+                if (pts_ms > due_ms) have = false;
+            }
+            if (have && b->next_video(p.backend_id, vf)) {
+                p.gate_pts_ms = vf.pts_us / 1000;
+                p.gate_wall = std::chrono::steady_clock::now();
+                p.gate_started = true;
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 if (avp_stage_video(p, vf, false, staged, pitch)) {
@@ -2459,9 +2488,40 @@ HLE(s_avp_getvideodataex) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
+        // The media clock pauses while nobody consumes (#1973 semantics): a poll gap longer than
+        // this shifts the gate's anchor so the movie RESUMES where delivery stopped instead of
+        // fast-forwarding through the gap (a 53 s title screen must not skip the intro's first
+        // 53 s — measured live, #2981 FMV).
+        if (p.gate_started) {
+            const auto now = std::chrono::steady_clock::now();
+            if (now - p.gate_wall > std::chrono::milliseconds(1000))
+                p.gate_wall = now;
+        }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
-            if (b->next_video(p.backend_id, vf)) {
+            // Media-clock gate: the real AvPlayer owns the clock and refuses frames whose PTS is
+            // not due yet. Measured without a gate, GRIS's 73.4 s intro delivered all 1761 frames
+            // in 19.0 s of wall (3.86x) — this title presents every frame it receives, so the
+            // pacing must live HERE, not in the guest. Peek first: next_video pops, and a frame
+            // refused after the pop would be lost. 20 ms lead = half a 24 fps frame, so the poll
+            // loop (measured ~5 ms cadence) picks the frame up on the first poll after it is due.
+            bool have = b->peek_video(p.backend_id, vf);
+            if (have && !p.seek_deliver) {
+                const uint64_t pts_ms = vf.pts_us / 1000;
+                const uint64_t due_ms = p.gate_started
+                    ? p.gate_pts_ms + (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
+                          std::chrono::steady_clock::now() - p.gate_wall).count()
+                    : 0;
+                // No delivery lead: a lead here accumulates per frame (each frame delivers
+                // lead-ms early, shifting the whole movie) — measured 1.59x with a 20 ms lead
+                // at the guest's ~38 Hz poll cadence. The poll interval is 5-10 ms, so the
+                // zero-lead delivery latency is bounded by one poll.
+                if (pts_ms > due_ms) have = false;   // not due yet; the guest re-polls
+            }
+            if (have && b->next_video(p.backend_id, vf)) {
+                p.gate_pts_ms = vf.pts_us / 1000;
+                p.gate_wall = std::chrono::steady_clock::now();
+                p.gate_started = true;
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 // Publish the frame only if its metadata is publishable: a refused fill would
@@ -2476,6 +2536,10 @@ HLE(s_avp_getvideodataex) {
                 }
             } else if (b->eof(p.backend_id) && !p.stop_fired) {
                 p.playing = false; p.stop_fired = true; fire_stop = true; obj = p.ev_obj; cb = p.ev_cb;
+                if (avp_log())
+                    fprintf(stderr, "[avp] video-ex EOF handle=0x%llx decoder_dropped=%llu\n",
+                            (unsigned long long)a0,
+                            (unsigned long long)b->video_frames_dropped(p.backend_id));
             }
         } else if (p.synthetic && p.poll < avp_synth_frames()) {
             uint8_t* staged = nullptr;
@@ -2491,9 +2555,20 @@ HLE(s_avp_getvideodataex) {
         }
     }
     if (fire_stop) avp_fire(obj, cb, AVP_STOP);
-    if (avp_log()) fprintf(stderr, "[avp] video-ex handle=0x%llx result=%llu data=%p stop=%d\n",
-                           (unsigned long long)a0, (unsigned long long)result,
-                           result ? fi->p_data : nullptr, (int)fire_stop);
+    if (avp_log()) {
+        static std::atomic<uint64_t> delivered{0};
+        static const auto t0 = std::chrono::steady_clock::now();
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - t0).count();
+        if (result)
+            fprintf(stderr, "[avp] video-ex handle=0x%llx DELIVER #%llu t=%llums pts=%llums\n",
+                    (unsigned long long)a0,
+                    (unsigned long long)delivered.fetch_add(1) + 1,
+                    (unsigned long long)ms, (unsigned long long)fi->timestamp);
+        else
+            fprintf(stderr, "[avp] video-ex handle=0x%llx empty t=%llums\n",
+                    (unsigned long long)a0, (unsigned long long)ms);
+    }
     return result;
 }
 HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFrameInfo*)
@@ -2517,6 +2592,16 @@ HLE(s_avp_getaudiodata)   {   // bool sceAvPlayerGetAudioData(handle, AvPlayerFr
         AvpAudio details{(uint16_t)af.channels, {}, af.sample_rate,
                          (uint32_t)(af.samples * af.channels * sizeof(int16_t)), {}};
         memcpy(&fi->d0, &details, sizeof(details));
+        if (avp_log()) {
+            static std::atomic<uint64_t> adelivered{0};
+            static const auto at0 = std::chrono::steady_clock::now();
+            const auto ams = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - at0).count();
+            fprintf(stderr, "[avp] audio-deliver handle=0x%llx #%llu t=%llums pts=%llums samples=%u\n",
+                    (unsigned long long)a0,
+                    (unsigned long long)adelivered.fetch_add(1) + 1,
+                    (unsigned long long)ams, (unsigned long long)fi->timestamp, af.samples);
+        }
         return 1;
     }
     if (!p.synthetic || p.audio_poll >= avp_synth_frames()) return 0;

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <thread>
 #include <deque>
 #include <filesystem>
 #include <mutex>
@@ -1339,13 +1340,13 @@ struct AvpPlayer {
     // Those are also every place `paused` is cleared, which is what keeps paused time — during which
     // nothing is presented and nothing should be pulled — from counting as an absent consumer.
     std::chrono::steady_clock::time_point video_request_at = std::chrono::steady_clock::now();
-    // The delivery gate's clock: the next frame is due at (last delivered pts + wall time since
-    // that delivery). Re-anchoring on every delivery makes the gate self-correcting — a guest
-    // that stops polling (title screen) resumes where it stopped instead of fast-forwarding
-    // through the gap, and Pause/Resume/JumpToTime need no special cases (see
-    // s_avp_getvideodataex, #2981 FMV speed).
-    uint64_t gate_media_ms = 0;
-    std::chrono::steady_clock::time_point gate_wall = std::chrono::steady_clock::now();
+    // The media-clock anchor for BLOCKING video delivery: the frame with pts P is due at
+    // play_start_wall + (P - play_start_pts). The caller is held until due — the real
+    // AvPlayer's contract, and the only pacing this guest respects: it sleeps its whole
+    // poll budget when a non-blocking gate refuses a frame, which collapsed playback to
+    // ~1 frame per sleep (measured 0.4-1.2 fps, #2981 FMV).
+    std::chrono::steady_clock::time_point play_start_wall = std::chrono::steady_clock::now();
+    uint64_t play_start_pts = 0;
     bool gate_started = false;
     // When the title supplies its AvPlayer texture allocator, decoded NV12 must be written into those
     // guest-visible buffers.  A host vector is invisible to the title's pre-wired texture descriptors.
@@ -2200,7 +2201,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
                 p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0;
                 p.paused = false; p.stop_fired = false; p.seek_deliver = false;
                 p.video_request_at = std::chrono::steady_clock::now();
-                p.gate_media_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
+                p.play_start_wall = p.video_request_at; p.play_start_pts = 0; p.gate_started = false;
                 p.texture_frames.clear(); p.texture_frame_bytes = 0; p.next_texture_frame = 0;
                 p.backend = nullptr; p.backend_id = -1;
                 // Non-zero placeholder dims/fps: a title that queries GetStreamInfo up-front (before it
@@ -2244,7 +2245,7 @@ static uint64_t avp_add_source(uint64_t handle, const char* guest_path) {
             p.poll = 0; p.audio_poll = 0; p.active_poll = 0; p.last_ts_ms = 0; p.paused = false;
             p.stop_fired = false; p.seek_deliver = false;
             p.video_request_at = std::chrono::steady_clock::now();
-            p.gate_media_ms = 0; p.gate_wall = p.video_request_at; p.gate_started = false;
+            p.play_start_wall = p.video_request_at; p.play_start_pts = 0; p.gate_started = false;
             p.texture_frames = std::move(textures);
             p.texture_frame_bytes = texture_bytes;
             p.next_texture_frame = 0;
@@ -2383,6 +2384,12 @@ HLE(s_avp_jumptotime) {
                 // does it, so nothing here revives one; it stays stopped with a repositioned source.
                 p.last_ts_ms = target_ms;
                 p.seek_deliver = true;
+                // Re-anchor the delivery gate at the new position: without this, post-seek
+                // frames deliver un-paced against the stale pre-seek anchor until the media
+                // clock climbs back over it (#2989 re-review).
+                p.play_start_wall = std::chrono::steady_clock::now();
+                p.play_start_pts = target_ms;
+                p.gate_started = true;
                 // The source was just repositioned: the media clock measures the remainder from the
                 // new position, starting now.
                 p.video_request_at = std::chrono::steady_clock::now();
@@ -2401,6 +2408,36 @@ HLE(s_avp_jumptotime) {
     return 0;
 }
 // bool sceAvPlayerGetVideoData(handle, AvPlayerFrameInfo*) — deliver the next decoded frame (NV12).
+// BLOCKING media-clock gate: hold the caller until the frame's PTS is due. The real AvPlayer
+// delivers a frame when its PTS reaches the media clock; this guest sleeps its whole poll budget
+// when a call returns "no frame yet", so a non-blocking refusal collapsed playback to ~1 frame
+// per sleep (measured 0.4-1.2 fps, #2981 FMV). Releases g_avp_mx in 8 ms steps and aborts the
+// wait on stop/pause/seek/destroy; caps the wait at 5 s so a broken anchor can never hang the
+// guest's video thread for the whole movie.
+// BLOCKING media-clock gate: hold the caller until the frame's PTS is due. The real AvPlayer
+// delivers a frame when its PTS reaches the media clock; this guest sleeps its whole poll budget
+// when a call returns "no frame yet", so a non-blocking refusal collapsed playback to ~1 frame
+// per sleep (measured 0.4-1.2 fps, #2981 FMV). g_avp_mx is HELD by the caller for the whole
+// wait — deliberate: no player state (stop/pause/seek/destroy) can change mid-wait, so the
+// only exit is due time; the 5 s cap keeps a broken anchor from hanging the video thread.
+void avp_await_due(AvpPlayer& p, uint64_t pts_ms) {
+    if (!p.gate_started) return;   // no anchor yet: the first delivery arms the clock
+    const auto due_wall = p.play_start_wall + std::chrono::milliseconds(
+        pts_ms > p.play_start_pts ? pts_ms - p.play_start_pts : 0);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+    for (;;) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= due_wall || now >= deadline) return;
+        // Sleep the remaining wait, clamped: a long first sleep keeps the loop cheap, and the
+        // final steps shrink so the wakeup lands within ~1 ms of due (an 8 ms flat quantum
+        // overshot every frame by ~4 ms and cost ~10% of the playback rate).
+        const auto remaining = due_wall - now;
+        std::this_thread::sleep_for(
+            remaining > std::chrono::milliseconds(8) ? std::chrono::milliseconds(8) : remaining);
+    }
+}
+
+
 HLE(s_avp_getvideodata) {
     svc_log("sceAvPlayerGetVideoData", a0,a1,a2,a3,a4,a5);
     auto* fi = (AvpFrameInfo*)PW(a1); if (!fi) return 0;
@@ -2423,37 +2460,20 @@ HLE(s_avp_getvideodata) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
-        {
-            const auto now = std::chrono::steady_clock::now();
-            // Tick the media clock between polls; a gap longer than 200 ms pauses it (title
-            // screens, stream transitions) — shorter ones are decode jitter and count as media
-            // time, matching a player that plays autonomously between polls.
-            if (p.gate_started) {
-                if (now - p.gate_wall > std::chrono::milliseconds(200))
-                    p.gate_wall = now;
-                else {
-                    p.gate_media_ms +=
-                        (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
-                            now - p.gate_wall).count();
-                    p.gate_wall = now;
-                }
-            } else {
-                p.gate_wall = now;
-            }
-        }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
             // Media-clock gate, same as GetVideoDataEx above (#2981 FMV speed).
             const bool gated = p.gate_started && b->can_peek_video();
             bool have = gated ? b->peek_video(p.backend_id, vf) : true;
             if (have && gated && !p.seek_deliver) {
-                if (vf.pts_us / 1000 > p.gate_media_ms) have = false;   // not due; re-poll
+                // BLOCKING media-clock gate: hold until the frame's PTS is due (see the
+                // Ex handler; measured 0.4-1.2 fps with a non-blocking gate on this guest).
+                avp_await_due(p, vf.pts_us / 1000);
             }
             if (have && b->next_video(p.backend_id, vf)) {
-                if (!p.gate_started) {
-                    p.gate_media_ms = vf.pts_us / 1000;   // anchor at the first frame's PTS
-                    p.gate_started = true;
-                }
+                p.play_start_wall = std::chrono::steady_clock::now();
+                p.play_start_pts = vf.pts_us / 1000;
+                p.gate_started = true;
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 if (avp_stage_video(p, vf, false, staged, pitch)) {
@@ -2495,6 +2515,7 @@ HLE(s_avp_getvideodataex) {
     auto* fi = (AvpFrameInfoEx*)PW(a1); if (!fi) return 0;
     void* obj = nullptr; AvpEventCb cb = nullptr; bool fire_stop = false; uint64_t result = 0;
     uint64_t media_snapshot = UINT64_MAX;
+    prosper::video::VideoBackend* log_backend = nullptr; int log_backend_id = -1;
     {
         std::lock_guard<std::mutex> lk(g_avp_mx);
         auto it = g_avp.find(a0);
@@ -2505,50 +2526,28 @@ HLE(s_avp_getvideodataex) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
-        // The media clock pauses while nobody consumes (#1973 semantics): a poll gap longer than
-        // this shifts the gate's anchor so the movie RESUMES where delivery stopped instead of
-        // fast-forwarding through the gap (a 53 s title screen must not skip the intro's first
-        // 53 s — measured live, #2981 FMV).
-        {
-            const auto now = std::chrono::steady_clock::now();
-            // Tick the media clock between polls; a gap longer than 200 ms pauses it (title
-            // screens, stream transitions) — shorter ones are decode jitter and count as media
-            // time, matching a player that plays autonomously between polls.
-            if (p.gate_started) {
-                if (now - p.gate_wall > std::chrono::milliseconds(200))
-                    p.gate_wall = now;
-                else {
-                    p.gate_media_ms +=
-                        (uint64_t)std::chrono::duration_cast<std::chrono::milliseconds>(
-                            now - p.gate_wall).count();
-                    p.gate_wall = now;
-                }
-            } else {
-                p.gate_wall = now;
-            }
-        }
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
             // Media-clock gate: the real AvPlayer owns the clock and refuses frames whose PTS is
             // not due yet. Measured without a gate, GRIS's 73.4 s intro delivered all 1761 frames
             // in 19.0 s of wall (3.86x) — this title presents every frame it receives, so the
             // pacing must live HERE, not in the guest. Peek first: next_video pops, and a frame
-            // refused after the pop would be lost. 20 ms lead = half a 24 fps frame, so the poll
-            // loop (measured ~5 ms cadence) picks the frame up on the first poll after it is due.
+            // refused after the pop would be lost.
             // The PTS gate needs a non-destructive peek. A backend without one keeps ungated
             // delivery (the pre-gate behavior) — refusing frames it cannot re-inspect would
             // deliver nothing at all (#2989 review, blocking 1).
             const bool gated = p.gate_started && b->can_peek_video();
             bool have = gated ? b->peek_video(p.backend_id, vf) : true;
             if (have && gated && !p.seek_deliver) {
-                if (vf.pts_us / 1000 > p.gate_media_ms) have = false;   // not due; re-poll
+                // BLOCKING media-clock gate: hold until the frame's PTS is due (see the
+                // non-Ex handler; measured 0.4-1.2 fps with a non-blocking gate on this guest).
+                avp_await_due(p, vf.pts_us / 1000);
             }
             if (have && b->next_video(p.backend_id, vf)) {
-                if (!p.gate_started) {
-                    p.gate_media_ms = vf.pts_us / 1000;   // anchor at the first frame's PTS
-                    p.gate_started = true;
-                }
-                media_snapshot = p.gate_media_ms;
+                p.play_start_wall = std::chrono::steady_clock::now();
+                p.play_start_pts = vf.pts_us / 1000;
+                p.gate_started = true;
+                media_snapshot = p.play_start_pts;
                 uint8_t* staged = nullptr;
                 uint32_t pitch = 0;
                 // Publish the frame only if its metadata is publishable: a refused fill would
@@ -2591,8 +2590,10 @@ HLE(s_avp_getvideodataex) {
                     (unsigned long long)avp_ms(), (unsigned long long)fi->timestamp,
                     (unsigned long long)media_snapshot);
         else
-            fprintf(stderr, "[avp] video-ex handle=0x%llx empty t=%llums\n",
-                    (unsigned long long)a0, (unsigned long long)avp_ms());
+            fprintf(stderr, "[avp] video-ex handle=0x%llx empty t=%llums media=%llums q=%d\n",
+                    (unsigned long long)a0, (unsigned long long)avp_ms(),
+                    (unsigned long long)media_snapshot,
+                    log_backend ? log_backend->video_queue_depth(log_backend_id) : -2);
     }
     return result;
 }

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -2411,12 +2411,6 @@ HLE(s_avp_jumptotime) {
 // BLOCKING media-clock gate: hold the caller until the frame's PTS is due. The real AvPlayer
 // delivers a frame when its PTS reaches the media clock; this guest sleeps its whole poll budget
 // when a call returns "no frame yet", so a non-blocking refusal collapsed playback to ~1 frame
-// per sleep (measured 0.4-1.2 fps, #2981 FMV). Releases g_avp_mx in 8 ms steps and aborts the
-// wait on stop/pause/seek/destroy; caps the wait at 5 s so a broken anchor can never hang the
-// guest's video thread for the whole movie.
-// BLOCKING media-clock gate: hold the caller until the frame's PTS is due. The real AvPlayer
-// delivers a frame when its PTS reaches the media clock; this guest sleeps its whole poll budget
-// when a call returns "no frame yet", so a non-blocking refusal collapsed playback to ~1 frame
 // per sleep (measured 0.4-1.2 fps, #2981 FMV). g_avp_mx is HELD by the caller for the whole
 // wait — deliberate: no player state (stop/pause/seek/destroy) can change mid-wait, so the
 // only exit is due time; the 5 s cap keeps a broken anchor from hanging the video thread.
@@ -2460,6 +2454,7 @@ HLE(s_avp_getvideodata) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
+        log_backend = p.backend; log_backend_id = p.backend_id;
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
             // Media-clock gate, same as GetVideoDataEx above (#2981 FMV speed).
@@ -2526,6 +2521,7 @@ HLE(s_avp_getvideodataex) {
         if (!it->second.playing ||
             (it->second.paused && !it->second.seek_deliver && !avp_paused_deliver())) return 0;
         AvpPlayer& p = it->second;
+        log_backend = p.backend; log_backend_id = p.backend_id;
         if (auto* b = p.backend; b && p.backend_id >= 0) {
             prosper::video::VideoFrame vf;
             // Media-clock gate: the real AvPlayer owns the clock and refuses frames whose PTS is

--- a/prosper/src/hle/video/video_backend.hpp
+++ b/prosper/src/hle/video/video_backend.hpp
@@ -76,6 +76,13 @@ public:
     virtual bool info(int id, StreamInfo& out) = 0;        // true once stream headers are parsed
     // Successful pull pointers remain valid until the next pull of that media type for this id.
     virtual bool next_video(int id, VideoFrame& out) = 0;  // false if no frame ready yet
+    // Non-destructive front-of-queue inspection, for PTS-gated delivery: the caller decides
+    // whether the frame is due BEFORE taking it, because next_video pops. Default false means
+    // "this backend cannot peek", which leaves delivery ungated rather than blocking playback.
+    virtual bool peek_video(int id, VideoFrame& out) { return false; }
+    // Frames dropped inside the backend (queue-full eviction). Diagnostic: the HLE layer reports
+    // it at EOF so a short-delivery measurement can name the stage that lost them.
+    virtual uint64_t video_frames_dropped(int id) { return 0; }
     virtual bool next_audio(int id, AudioFrame& out) = 0;  // false if no audio ready yet
     // AvPlayer video completion is driven by the video stream. Queued audio must not keep a
     // video-only consumer active after decode has ended and the final video frame was delivered.

--- a/prosper/src/hle/video/video_backend.hpp
+++ b/prosper/src/hle/video/video_backend.hpp
@@ -85,6 +85,8 @@ public:
     // Frames dropped inside the backend (queue-full eviction). Diagnostic: the HLE layer reports
     // it at EOF so a short-delivery measurement can name the stage that lost them.
     virtual uint64_t video_frames_dropped(int id) { return 0; }
+    // Diagnostic: queued decoded-video frames (-1 = unsupported).
+    virtual int video_queue_depth(int id) { return -1; }
     virtual bool next_audio(int id, AudioFrame& out) = 0;  // false if no audio ready yet
     // AvPlayer video completion is driven by the video stream. Queued audio must not keep a
     // video-only consumer active after decode has ended and the final video frame was delivered.

--- a/prosper/src/hle/video/video_backend.hpp
+++ b/prosper/src/hle/video/video_backend.hpp
@@ -77,9 +77,11 @@ public:
     // Successful pull pointers remain valid until the next pull of that media type for this id.
     virtual bool next_video(int id, VideoFrame& out) = 0;  // false if no frame ready yet
     // Non-destructive front-of-queue inspection, for PTS-gated delivery: the caller decides
-    // whether the frame is due BEFORE taking it, because next_video pops. Default false means
-    // "this backend cannot peek", which leaves delivery ungated rather than blocking playback.
+    // whether the frame is due BEFORE taking it, because next_video pops. Only meaningful when
+    // can_peek_video() is true; a backend that cannot peek keeps UNGATED delivery (the caller
+    // must fall back to plain next_video, or no frame would ever be delivered).
     virtual bool peek_video(int id, VideoFrame& out) { return false; }
+    virtual bool can_peek_video() const { return false; }
     // Frames dropped inside the backend (queue-full eviction). Diagnostic: the HLE layer reports
     // it at EOF so a short-delivery measurement can name the stage that lost them.
     virtual uint64_t video_frames_dropped(int id) { return 0; }


### PR DESCRIPTION
Closes the FMV-speed half of #2981. The audio half landed in #2988.

## Measured problem

GRIS's intro FMV (IntroVideo.mp4: 73.4 s, 24 fps, 1762 h264 frames) played in **19.0 s of wall — 3.86x speed**. Measured by instrumenting `sceAvPlayerGetVideoDataEx` with delivery counters (wall t + frame PTS):

```
DELIVER #1   t=0ms     pts=0ms
DELIVER #2   t=3ms     pts=41ms
DELIVER #1761 t=19049ms pts=73333ms
```

Root cause: prosper's AvPlayer HLE hands the guest every decoded frame the moment it polls, and this title presents whatever it receives. The real AvPlayer owns the media clock and refuses frames whose PTS is not due — the pacing lives behind the API, not in the guest.

## The fix

- **PTS-gated delivery**: a frame is delivered only when it is due. `next_video` pops, so a new `peek_video` backend method checks due-ness before taking the frame (a refusal after the pop would lose it).
- **Delivery-anchored clock**: frame N+1 is due at (pts of N + wall since N delivered). Re-anchoring per delivery makes the gate self-correcting: a poll gap (title screen) pauses the clock and playback resumes where it stopped, instead of fast-forwarding through the gap — #1973's semantics (a player nobody consumes does not advance), measured live: a 53 s title screen must not skip the intro's first 53 s. No special cases for Pause/Resume/JumpToTime.
- **Decode worker**: hold compressed video packets while the video queue is full and keep servicing audio. Blocking inside `enqueue_video` starved the audio consumer, tripping the starvation drop path ~24 times per 10 s — 12% of the intro's frames lost. Held packets are compressed (kilobytes, not frames).
- No delivery lead: a per-frame lead accumulates (measured 1.59x with 20 ms at the guest's ~38 Hz poll cadence). The poll interval is 5–10 ms, bounding the zero-lead latency by one poll.

## Measured result (this head)

- **1758/1762 frames delivered (99.8%), zero PTS discontinuities, full 73.2 s span at 1.00×** (was 1544/1762 gated, 1761-in-19 s ungated)
- ctest 308/308; CI on this branch green
- `PROSPER_AVPLOG` gains delivery counters (wall t + pts) — the measurement instrument this fix was developed against