### PR TITLE
prosper-app: line-buffer stdout so boot diagnostics land chronologically in logs

### DIFF
--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1200,6 +1200,11 @@ static bool relaunch_with_dump(int argc, char** argv, const std::string& app0_ro
 } // namespace
 
 int main(int argc, char** argv) {
+    // Line-buffer stdout: the boot/loader diagnostics go through printf (stdout), and under a
+    // file redirect stdout block-buffers — every boot-time line then flushes at exit and lands
+    // AFTER hours' worth of unbuffered stderr in a merged `> log 2>&1`, making the log read as
+    // if the modules loaded at shutdown (misled a #2981 FMV measurement session).
+    setvbuf(stdout, nullptr, _IOLBF, 0);
     bool testPattern = false; int exitAfter = 0; uint32_t winW = 1280, winH = 720;
     prosper::frontend::AppPresentMode requestedPresentMode = prosper::frontend::AppPresentMode::fifo;
     std::string dump;


### PR DESCRIPTION
One-line fix from the #2981 FMV measurement session.

The boot/loader diagnostics (linked modules, export aliases, skipped
modules) print through printf/stdout. Under a file redirect, stdout
block-buffers — so every boot-time line sat in the buffer and flushed at
process exit, landing AFTER the entire unbuffered stderr stream in a
merged `> log 2>&1`. The merged log then read as if the game's modules
loaded at shutdown, which sent the #2981 FMV session chasing a phantom
module-load stall for a measurement cycle.

`setvbuf(stdout, nullptr, _IOLBF, 0)` at main() entry: every stdout
diagnostic line lands chronologically in merged logs. stderr is already
unbuffered; nothing else changes.