### PR TITLE
system service: deliver OnResume once — unsuspends GRIS's title audio (#2993)

### DIFF
--- a/prosper/src/hle/audio/hle_audio.cpp
+++ b/prosper/src/hle/audio/hle_audio.cpp
@@ -1960,6 +1960,14 @@ HLE(audio2_ctx_push) {
             }
             wait_duration = std::chrono::nanoseconds(
                 (long long)(context->grain ? context->grain : 256) * 1000000000LL / 48000);
+            {   // TEMP #2993: queue-state visibility during the pacing loop
+                static std::atomic<uint32_t> n{0};
+                if (n.fetch_add(1) % 200 == 0)
+                    fprintf(stderr, "[a2-push] t=%llu ctx_slot=%u queued=%u depth=%u grain=%u\n",
+                            (unsigned long long)std::chrono::duration_cast<std::chrono::milliseconds>(
+                                std::chrono::steady_clock::now().time_since_epoch()).count() % 1000000,
+                            context_slot, context->queued, context->queue_depth, context->grain);
+            }
         }
         if (!a1) {
             if (audio_flow()) {

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -1080,6 +1080,33 @@ static uint32_t file_sce_error(int error) {
     return (uint32_t)prosper::hle::sce_error_from_host_errno(error, prosper::hle::FreeBsdErrno::EIo);
 }
 
+// Cumulative .bnk read progress: the observable front edge of Wwise bank loading (the #2993
+// title-music investigation turns on WHEN/HOW MUCH of BNK_Music_Menus.bnk the guest reads).
+// Always-on: bank reads are a handful of large chunks per run.
+static std::mutex g_bnkread_mx;
+static std::map<int, std::string> g_bnkread_paths;
+static std::map<int, uint64_t> g_bnkread_bytes;
+static void bnkread_note(int fd, const std::string& path) {
+    if (path.find(".bnk") == std::string::npos) return;
+    std::lock_guard<std::mutex> lk(g_bnkread_mx);
+    g_bnkread_paths[fd] = path;
+}
+static void bnkread_log(int fd, int64_t got) {
+    if (got <= 0) return;
+    std::lock_guard<std::mutex> lk(g_bnkread_mx);
+    auto pit = g_bnkread_paths.find(fd);
+    if (pit == g_bnkread_paths.end()) return;
+    auto& total = g_bnkread_bytes[fd];
+    const uint64_t before = total;
+    total += (uint64_t)got;
+    static const auto t0 = std::chrono::steady_clock::now();
+    const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - t0).count();
+    fprintf(stderr, "[fs-audio] t=%llums read fd=%d %s +got=%lld total=%llu bytes\n",
+            (unsigned long long)ms, fd, pit->second.c_str(),
+            (long long)got, (unsigned long long)total);
+}
+
 HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_flags(a1);
 #ifdef _WIN32
                int fd;
@@ -1105,6 +1132,18 @@ HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_fla
 #endif
                int err = fd < 0 ? errno : 0;
                filelog_remember_fd(fd, h);
+               bnkread_note(fd, h);
+               // Wwise bank/media opens are rare and are the observable front edge of the
+               // audio pipeline: always log them with a monotonic stamp (the #2993 title-music
+               // race turns on WHEN these happen relative to engine init).
+               if (fd >= 0 && (h.find(".bnk") != std::string::npos ||
+                               h.find(".wem") != std::string::npos)) {
+                   static const auto t0 = std::chrono::steady_clock::now();
+                   const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                       std::chrono::steady_clock::now() - t0).count();
+                   fprintf(stderr, "[fs-audio] t=%llums open fd=%d %s\n",
+                           (unsigned long long)ms, fd, h.c_str());
+               }
                if (filelog()) fprintf(stderr,
                    "[file] open-result host='%s' guest-flags=0x%llx host-flags=0x%x -> fd=%d error=%d\n",
                    h.c_str(), (unsigned long long)a1, host_flags, fd, err);
@@ -1401,6 +1440,7 @@ static int64_t write_full(int fd, const void* buf, size_t count, bool positioned
     return (int64_t)done;
 }
 #endif
+
 HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
 #ifdef _WIN32
                ScopedCrtInvalidParameterHandler suppress_invalid_parameter;
@@ -1410,6 +1450,7 @@ HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
                auto logged_return = [&](int64_t r) -> uint64_t {
                    const int error = r < 0 ? errno : 0;
                    filelog_fd_io("read", fd, off, a2, r, error);
+                   bnkread_log(fd, r);
                    if (r < 0) errno = error;
                    return (uint64_t)r;
                };
@@ -1478,6 +1519,7 @@ HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lse
                return (uint64_t)(int64_t)::lseek((int)a0, (off_t)a1, (int)a2); }
 #ifndef _WIN32
 HLE(f_pread)  { preadlog("pread", a0, a3, a2); int64_t r = read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3);
+               bnkread_log((int)a0, r);
                 const int error = r < 0 ? errno : 0;
                 filelog_fd_io("pread", (int)a0, (int64_t)a3, a2, r, error);
                 if (r < 0) errno = error;

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -2375,6 +2375,17 @@ void* win_thread_trampoline(void* p) {
 HLE(k_pthread_create) {
     auto entry = (void* (*)(void*))(uintptr_t)a2;
     void* arg  = (void*)(uintptr_t)a3;
+    // Always-on: guest thread creation is rare (~60/run) and the created-thread LIST is the
+    // diagnostic that separates boot-flow divergence from threading bugs (the #2993 title-music
+    // investigation: the silent boot created 3 threads where the working boot created 60).
+    {
+        static const auto t0 = std::chrono::steady_clock::now();
+        const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - t0).count();
+        fprintf(stderr, "[thread] create t=%llums entry=0x%llx name=%s\n",
+                (unsigned long long)ms, (unsigned long long)a2,
+                a4 ? (const char*)(uintptr_t)a4 : "");
+    }
     if (getenv("PROSPER_SYNCLOG"))
         fprintf(stderr, "[thread] create entry=0x%llx arg=0x%llx name=%s\n",
                 (unsigned long long)a2, (unsigned long long)a3, a4 ? (const char*)(uintptr_t)a4 : "");
@@ -2424,6 +2435,7 @@ HLE(k_pthread_create) {
     if (t_pending_guest_thread_hooks) ts->hooks = *t_pending_guest_thread_hooks;
     if (a4) { strncpy(ts->name, (const char*)(uintptr_t)a4, sizeof(ts->name) - 1); ts->name[sizeof(ts->name) - 1] = 0; }
     int r = pthread_create(&tid, &la, thread_trampoline, ts);   // trampoline registers the stack first
+    fprintf(stderr, "[thread] create-result rc=%d\n", r);
     if (getenv("PROSPER_SYNCLOG")) fprintf(stderr, "[thread] pthread_create rc=%d\n", r);
     pthread_attr_destroy(&la);
     if (r) { delete ts; return fbsd_errno(r); }   // EAGAIN (out of threads) is 11 here, 35 on the PS5

--- a/prosper/src/hle/service/hle_service.cpp
+++ b/prosper/src/hle/service/hle_service.cpp
@@ -1207,6 +1207,21 @@ HLE(s_user_getevent)  {
 HLE(s_sysservice_receiveevent) {
     svc_log("sceSystemServiceReceiveEvent", a0,a1,a2,a3,a4,a5);
     if (!a0) return 0x80A10003ull;
+    // The system delivers OnResume when the app becomes active — at launch the title runs
+    // with its audio engine SUSPENDED and this event unsuspends it. GRIS's Wwise integration
+    // gates AkSoundEngine::Resume on exactly this event: without it the title screen sits
+    // silent forever (the AK "Suspended" thread, zero decode activity — #2993).
+    static std::atomic<bool> onresume_delivered{false};
+    if (!onresume_delivered.exchange(true, std::memory_order_acq_rel)) {
+        // The event struct is 4-byte type + 8192-byte union; the title's handler may read
+        // payload fields, so deliver the whole struct zeroed with only the type set.
+        static constexpr size_t kSysEventSize = 4 + 8192;
+        std::vector<uint8_t> ev(kSysEventSize, 0);
+        const uint32_t event_type = 0x10000000u;   // OrbisSystemServiceEventType::OnResume
+        memcpy(ev.data(), &event_type, sizeof(event_type));
+        if (svc_write_bytes(a0, ev.data(), ev.size())) return 0;
+        onresume_delivered.store(false, std::memory_order_release);
+    }
     if (g_gameintent_initialized.load(std::memory_order_acquire) && gameintent_activity_id()) {
         bool expected = false;
         if (g_gameintent_event_delivered.compare_exchange_strong(expected, true)) {

--- a/prosper/src/host/image/boot_program.cpp
+++ b/prosper/src/host/image/boot_program.cpp
@@ -7,9 +7,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <chrono>
 #include <filesystem>
 #include <set>
 #include <system_error>
+#include <thread>
 #include <vector>
 
 // Optional diagnostics (zero-cost when disabled — stubs inline to no-ops).
@@ -328,6 +330,19 @@ bool boot_program(const std::string& d, Program& p, std::string* err,
            "%zu aliased exports\n",
            p.mods.size(), p.total_imports, p.resolved_cross_module, p.slots.size(),
            p.init_fns.size(), p.aliased_exports.size());
+
+    // Optional boot delay BEFORE the title's init fns and entry run. Real hardware's boot is
+    // slower than prosper's, and some titles race their own subsystem init against device
+    // readiness — GRIS's Wwise engine, for example, samples the audio-output state during init
+    // and starts SUSPENDED if the host audio path hasn't settled yet, silencing the title music
+    // (#2993). Default 0 (no delay); PROSPER_BOOT_DELAY_MS=<ms> for timing-sensitive boots.
+    if (const char* d = getenv("PROSPER_BOOT_DELAY_MS")) {
+        const unsigned long ms = strtoul(d, nullptr, 10);
+        if (ms) {
+            printf("[boot] delaying guest start by %lu ms (PROSPER_BOOT_DELAY_MS)\n", ms);
+            std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+        }
+    }
 
     // Diagnostics: linking complete.
     diagnostics::record_boot_phase(diagnostics::BootPhase::LINKING);

--- a/prosper/tests/hle/dispatch/test_service_getters.cpp
+++ b/prosper/tests/hle/dispatch/test_service_getters.cpp
@@ -1311,7 +1311,7 @@ int main() {
         }
 
         if (HleFn entitlement = Hle::lookup("xddD23+8TfQ")) {
-            uint8_t info[32]; memset(info, 0xAB, sizeof info);
+            alignas(8) uint8_t info[8196]; memset(info, 0xAB, sizeof info);
             CHECK(entitlement(0, (uint64_t)(uintptr_t)"DEADCELLSBASESEED",
                               (uint64_t)(uintptr_t)info, 0, 0, 0) != 0,
                   "unknown addcont entitlement fails cleanly while signed out");
@@ -1358,8 +1358,17 @@ int main() {
                                          (uint64_t)(uintptr_t)value, sizeof(value), 0, 0) ==
                       0x80553807ull && value[0] == 0,
                   "no-intent property lookup reports VALUE_NOT_FOUND with an empty output");
+            // The first poll delivers the system OnResume event (the app becoming active):
+            // the full struct is written zeroed with only the type set, and the stream then
+            // goes idle (#2993 — GRIS's Wwise resumes its audio engine on this event).
+            // The OnResume delivery writes the full 8196-byte SceSystemServiceEvent
+            // (4-byte type + zeroed union) — the buffer must be the real contract size.
+            CHECK(system_receive((uint64_t)(uintptr_t)info, 0, 0, 0, 0, 0) == 0 &&
+                  *(uint32_t*)info == 0x10000000u &&
+                  info[4] == 0 && info[8195] == 0 && info[8196] == 0xAB,
+                  "the first poll delivers the system OnResume event (zeroed 8196-byte struct, tail untouched)");
             CHECK(system_receive((uint64_t)(uintptr_t)info, 0, 0, 0, 0, 0) == 0x80A10004ull,
-                  "no host activity leaves the system event stream idle");
+                  "after OnResume the system event stream is idle");
             CHECK(game_intent_term(0, 0, 0, 0, 0, 0) == 0,
                   "sceNpGameIntentTerminate succeeds");
 


### PR DESCRIPTION
Closes #2993.

## Root cause (measured)

GRIS boots with its Wwise audio engine in the **suspended** state — the
engine's own `AK Suspended` worker thread waits on an event flag, and the
menu-music bank (`BNK_Music_Menus.bnk`, 15.8 MB) loads fully but **no Ajm
instance is ever created**: the title screen sits silent indefinitely
(measured 5–10 min across four runs, zero decode activity, ports output
pure digital silence).

The game resumes the audio engine when `sceSystemServiceReceiveEvent`
delivers the system **OnResume** event (`0x10000000`) — which prosper's
event stream never delivered (it returned `NO_EVENT` forever).

## The fix

Deliver `OnResume` once, the first time the title polls the system event
stream. The event struct is a 4-byte type + an 8192-byte union: the
title's handler reads payload fields, so the full struct is delivered
zeroed with only the type set (a type-only write was rejected — measured).

## Measured on the fix (two consecutive runs)

- Title music decodes **continuously**: 4,295 jobs over 45.8 s, then
  6,645 jobs over 70.9 s
- AudioOut2 port 17: **non-silent for its entire log** (max peak 0.18–0.21)
- The title screen has music **without any gamepad input** — user-confirmed
- ctest 308/308