### PR TITLE
docs(gta5): what the rendering series teaches

### DIFF
--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -13,6 +13,29 @@ presses for a reason).
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
+## The Windows Performance route does not require a compute skip (2026-08-26)
+
+The routed native-4K Performance-mode scene now completes with
+`PROSPER_COMPUTE_SKIP_PROGRAM` unset. On the current Windows/NVIDIA branch, the fixed
+`scripts/gta5/reach-story-mode-static.pad` route captured 25/25 samples over 500 seconds, exited
+normally with the guest still running, and recorded zero `VK_ERROR_DEVICE_LOST` or live-compute
+disable events. The final bank frame retains the world, character and water-cooler materials, radar,
+tutorial text and reflections. `PROSPER_WAVE64_APPROX` was also unset.
+
+The retained selector was not rescuing this route. In the immediately preceding control with
+`PROSPER_COMPUTE_SKIP_PROGRAM=0x413dc6700`, the parser announced the selector but emitted zero
+`[compute-decline] ... reason=skipped-by-selector` records. A matched non-fast-path dispatch always
+reports that decline, and `0x413dc6700` cannot match the sole CPU fast path's one-buffer fill shape.
+An exact `PROSPER_COMPUTELOG_CODE=0x413dc6700` trace also recorded zero matching executions throughout
+the 500-second no-skip route, including 160 seconds in the bank scene. The old address therefore did
+not reach the selector on this route. Removing the environment variable changes no executed work.
+
+This does not retract the historical Linux/RADV evidence below: that older route did execute the
+program and could lose the device while consuming a cyclic traversal table. It establishes the
+narrower current fact that carrying its address into the patched Windows Performance route was an
+inert launch requirement, not a workaround. Keep `PROSPER_COMPUTE_SKIP_PROGRAM` as a generic
+diagnostic selector, but do not set it for the accepted GTA V route.
+
 ## The F9 bundle works now, and the gameplay frame is dissectable offline (2026-08-19)
 
 `make_capture_manifest()` copied a `GpuCaptureFile` field by field and omitted `format_version`, so

--- a/prosper/docs/GTA5_STATUS.md
+++ b/prosper/docs/GTA5_STATUS.md
@@ -13,6 +13,109 @@ presses for a reason).
 Historical design note for the descriptor work: `docs/FLAT_LOAD_DESIGN.md`. Do not start from it; the
 descriptor-array lift it describes is complete.
 
+## What the rendering series changed, and what it teaches (2026-08-26)
+
+A nine-commit series lands the mechanisms below. Recorded here as *mechanisms*, because most of them
+are not GTA V facts at all — they are contracts prosper was getting wrong that this title happened to
+exercise hardest, and several map onto open issues for other reasons.
+
+### The core rendering defect: two descriptors at one address were two images
+
+**GTA V's 4K output shader writes the four 8x8 quadrants of each 16x16 block through FOUR bindings at
+the same guest address.** Captures materialize each descriptor's bytes into an independently-owned
+blob, so pointer equality is not a backing identity — and prosper treated the four reconstructed blobs
+as four separate images. **Three of the four stores were therefore lost**, leaving the red/green
+checker pattern in Performance mode. Two exact image descriptors naming the same non-null guest range
+must alias **one** Vulkan image.
+
+This is the single change most directly responsible for the world appearing, and it is worth reading
+as a general lesson: *reconstructed* bytes lose the aliasing that the guest expressed through
+addresses, so identity has to be re-established explicitly rather than inherited from the capture.
+
+### Typed storage aliases: the guest writes integers and samples them as something else
+
+GTA V writes full-resolution transition surfaces through **integer storage images** and then samples
+the *same bits* through normalized, Float32 or packed views. Geometry and allocation are identical;
+only the view's numeric interpretation differs. The series creates exactly those storage allocations
+**mutable** and leases the consumer's view without a copy. Admitted pairs, deliberately narrow:
+
+| producer | consumer | note |
+| --- | --- | --- |
+| `R32_UINT` | `R32_SFLOAT` | a depth-like transition surface; exact equal-width copy |
+| `Uint8` / `Uint16` storage | UNORM sampled | integer texels sampled as normalized values |
+| `R32_UINT` (carrier) | `B10G11R11` | packed R11G11B10; storage stays `R32_UINT` so driver float rounding cannot alter the bits |
+| `R10G10B10A2` (GFX10 format 50) | Vulkan `A2B10G10R10` | same low-to-high bit placement; detile + byte copy |
+
+**Not generalized** to signed, sRGB, component-count or size aliases — the series is explicit that this
+is an allowlist, not a relaxed key, and that is the right shape.
+
+Note the Fidelity bug in that table: the packed sampled path **fell through the generic
+per-component-width test**, because packed formats deliberately report zero width there, and the whole
+dispatch was skipped. A zero-width probe silently meaning "unsupported" is a trap worth remembering.
+
+### Two open issues this addresses directly
+
+- **#2723** — every shadow input refused by the DS bridge, cubes gated on `img_dim != 1`. The series
+  adds the explicit shape alias: a compute `U#` writes the six `R16_UINT` shadow faces through
+  `DIM=2D_ARRAY`, while the later graphics `T#` names the byte-identical allocation as `DIM=CUBE`, and
+  graphics lowers cube sampling to a vertical 2D stack.
+- **#2402** — the YUV composite draw skipped on NVIDIA because its fragment shader requires subgroup
+  size 64 on a 32-wide device. The series runs Wave64 fragment programs at native Wave32 **for this
+  title only**, and only for the narrow class whose sole remaining width reason is a control-flow
+  `WaveAny`; ballots, lane identity and scalar reductions stay exact, and every other title keeps
+  master's fail-visible exact-width contract.
+
+### Wave-vote exactness — and what it means for the hang investigation
+
+The series models the guest Wave64 **exactly** on a host subgroup that is not 64 wide, through
+`guest_wave_readlane` with an LDS-scratch path when the guest wave does not fit the host subgroup, and
+adds `V_READLANE_B32` / `V_WRITELANE` support. One added comment names a specific defect: a MAC between
+a uniform compare and `VCCZ` **created a false Wave64 vote**.
+
+That is the same area this file's own analysis pointed at. The recorded frontier reading was that
+`0x413dc6700`'s only loop exit is `v_cmpx` → EXEC → `s_cbranch_execz`, that the emitted module votes
+workgroup-wide where the guest votes per-wave, and that the dispatcher ran ~117x past what the data
+could justify (#2858). A false wave vote is exactly a defect of that shape. **This is corroboration of
+the direction, not proof of the mechanism** — nothing here has yet shown that this specific correction
+is what stops that dispatch running away, and #2858's per-ordinal histogram would still be what
+settles it.
+
+### Platform contracts worth knowing outside this title
+
+- **Windows cannot page-protect guest mappings for dirty tracking.** A VEH frame is built below the
+  interrupted SysV RSP and would corrupt the guest's live red zone. The series keeps one exact
+  guest-format mirror for exportable compute results instead, with `memcmp` validation so direct CPU
+  writes still fail closed. Linux keeps the ordered journal plus page-protection write watch; the
+  mirror must never launder a *known* architectural writer whose bytes happen to compare equal.
+- **Driver pipeline caches are not safe to load by default.** Repeated GTA V runs on NVIDIA reproduced
+  an `nvoglv64.dll` crash **only** on the cache-load route. UUID/header validation proves device
+  compatibility, not blob robustness, so persistence is opt-in. The version-one header prefix is
+  parsed field by field rather than cast, so short or unaligned files are rejected before any read,
+  and a driver rejection is treated as a cache miss rather than a reason to disable compute.
+- **Disabling driver optimization for large modules is a false economy.** It reduced cold compile
+  latency on NVIDIA but turned GTA V's repeated 1440p dispatches from ~1.7 ms into **47-50 ms**.
+  Optimization is on by default for large portable-CFG modules; the opt-out remains for investigations
+  where bounded first-use latency matters more than steady state.
+- **Win32 surfaces can transiently publish `currentExtent = 0x0`** during a minimize/fullscreen/DPI
+  transition even after SDL reports a non-zero pixel size. That is an unavailable surface, not a fatal
+  swapchain failure — keep the old swapchain and retry.
+
+### What is NOT established
+
+- **The validation is Windows/NVIDIA, on a route this repository does not contain.** The compute-skip
+  section below cites `scripts/gta5/reach-story-mode-static.pad` and `PROSPER_WAVE64_APPROX`; **neither
+  exists in this tree**. So its 25/25-sample result cannot be reproduced here as written, and the
+  Linux/RADV behaviour of this series is **unmeasured**.
+- **Six tests that pass on master fail with the series applied** — `dynfetch_fold`,
+  `indirect_pointer_static_footprint`, `indirect_pointer_descriptor_range`, `gpu_capture_render_replay`,
+  `rdna2_to_spirv_exec`, `gpu_execute`. Measured against an unpatched-master control on the same
+  machine (302/302 vs 296/302). Four are not referenced by the series, so they are existing assertions
+  the new behaviour breaks, and each needs triage before merge.
+- **`live_target_format.hpp` calls itself "the one place a LiveTargetPixelFormat is mapped onto
+  anything else." It is not** — `tools/gpu_replay/gpu_replay.cpp` maps it a second time, and extending
+  the enum from three values to ten left that switch behind. `-Werror=switch` (#2844) caught it; a
+  fall-through would have inspected every R8/R32/Rg8/Rgba32/Rg16/R16 target as 8-bit RGBA.
+
 ## The Windows Performance route does not require a compute skip (2026-08-26)
 
 The routed native-4K Performance-mode scene now completes with

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -1060,7 +1060,8 @@ static bool start_guest(const std::string& app0_root, std::string* err) {
 #ifdef PROSPER_HAVE_LIVE_RENDERER
     prosper::frontend::register_live_renderer(
         getenv("PROSPER_FRAME_DIR") ? getenv("PROSPER_FRAME_DIR") : ".",
-        getenv("PROSPER_APP_DUMP_FRAMES") != nullptr);
+        getenv("PROSPER_APP_DUMP_FRAMES") != nullptr,
+        prosper::frontend::title_id_from_app0_path(app0_root));
 #else
     fprintf(stderr, "[app] built without the live renderer; the window will stay blank.\n");
 #endif

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -274,7 +274,7 @@ bool pick_device(Vk& vk) {
 bool create_swapchain(Vk& vk, uint32_t w, uint32_t h,
                       prosper::frontend::AppPresentMode requestedPresentMode) {
     VkSurfaceCapabilitiesKHR caps; vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk.phys, vk.surface, &caps);
-    vk.scExtent = caps.currentExtent.width != UINT32_MAX ? caps.currentExtent : VkExtent2D{w, h};
+    vk.scExtent = prosper::frontend::select_swapchain_extent(caps.currentExtent, {w, h});
     if (vk.scExtent.width == 0 || vk.scExtent.height == 0) return false;   // minimized
 
     uint32_t fmtN = 0; vkGetPhysicalDeviceSurfaceFormatsKHR(vk.phys, vk.surface, &fmtN, nullptr);
@@ -2134,6 +2134,25 @@ int main(int argc, char** argv) {
             if (dw <= 0 || dh <= 0) {
                 std::this_thread::sleep_for(std::chrono::milliseconds(2));
                 continue;   // minimized or between fullscreen modes; retry after the next event
+            }
+            // SDL's non-zero pixel size can lead the Win32 Vulkan surface during a display/DPI
+            // transition. Do not destroy the still-valid swapchain until the surface publishes a
+            // usable extent too; create_swapchain would otherwise see 0x0 and the app would exit
+            // after an ordinary transient resize.
+            VkSurfaceCapabilitiesKHR resizeCaps{};
+            const VkResult resizeCapsResult = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(
+                vk.phys, vk.surface, &resizeCaps);
+            if (resizeCapsResult != VK_SUCCESS) {
+                fprintf(stderr, "[app] Vulkan error %d while querying a resized surface\n",
+                        static_cast<int>(resizeCapsResult));
+                running = false;
+                break;
+            }
+            if (!prosper::frontend::swapchain_extent_available(
+                    resizeCaps.currentExtent,
+                    {static_cast<uint32_t>(dw), static_cast<uint32_t>(dh)})) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(2));
+                continue;
             }
             {
                 // #1270: on a shared present queue, hold the submit mutex across the device drain so no

--- a/prosper/frontends/prosper-app/present_policy.hpp
+++ b/prosper/frontends/prosper-app/present_policy.hpp
@@ -76,6 +76,20 @@ private:
 // What present_frame should do after a BOUNDED vkAcquireNextImageKHR.
 enum class AcquireAction { proceed, skip, recreate, fail };
 
+// Select the extent Vulkan will use for a swapchain. Win32 surfaces normally publish a fixed
+// currentExtent, but can transiently report 0x0 while a minimize/fullscreen/DPI transition is in
+// flight even after SDL has already observed a non-zero pixel size. That is an unavailable surface,
+// not a fatal swapchain-creation failure: keep the old swapchain alive and retry on a later event-loop
+// iteration. Platforms with a variable extent use the requested SDL pixel size instead.
+constexpr VkExtent2D select_swapchain_extent(VkExtent2D current, VkExtent2D requested) {
+    return current.width != UINT32_MAX ? current : requested;
+}
+
+constexpr bool swapchain_extent_available(VkExtent2D current, VkExtent2D requested) {
+    const VkExtent2D selected = select_swapchain_extent(current, requested);
+    return selected.width != 0 && selected.height != 0;
+}
+
 // Classify vkAcquireNextImageKHR under a bounded (non-infinite) timeout.
 //  - VK_SUCCESS / VK_SUBOPTIMAL_KHR: an image was acquired (SUBOPTIMAL still yields a usable image) —
 //    proceed to blit + present. SUBOPTIMAL is handled at present time, matching the pre-#1182 behavior.

--- a/prosper/frontends/prosper-app/test_present_policy.cpp
+++ b/prosper/frontends/prosper-app/test_present_policy.cpp
@@ -76,6 +76,15 @@ int main() {
     CHECK(rendered_frame_counter(false, 0) == 0);
     CHECK(rendered_frame_counter(false, 73) == 73);
 
+    // A Win32 surface can briefly publish currentExtent=0x0 during a display transition while SDL's
+    // pixel size is already non-zero. Preserve the live swapchain and retry; a variable-extent
+    // surface, on the other hand, takes the SDL size and is immediately usable.
+    CHECK(!swapchain_extent_available({0, 0}, {1920, 1080}));
+    CHECK(swapchain_extent_available({3840, 2160}, {1920, 1080}));
+    const VkExtent2D variable_extent = select_swapchain_extent(
+        {UINT32_MAX, UINT32_MAX}, {1920, 1080});
+    CHECK(variable_extent.width == 1920 && variable_extent.height == 1080);
+
     // Acquire: a usable image (SUCCESS or SUBOPTIMAL) → proceed to blit+present.
     CHECK(classify_acquire(VK_SUCCESS) == AcquireAction::proceed);
     CHECK(classify_acquire(VK_SUBOPTIMAL_KHR) == AcquireAction::proceed);

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -173,6 +173,11 @@ bool pack_live_target_r11g11b10(const prosper::gpu::LiveTargetSnapshot& snapshot
         std::memcpy(packed, snapshot.pixels->data(), packed_size);
         return true;
     }
+    if (layout == prosper::frontend::LiveTargetSourceLayout::Unorm8x1 ||
+        layout == prosper::frontend::LiveTargetSourceLayout::Unorm8x2 ||
+        layout == prosper::frontend::LiveTargetSourceLayout::Uint32x1 ||
+        layout == prosper::frontend::LiveTargetSourceLayout::Float32x1)
+        return false;
     for (size_t t = 0; t < static_cast<size_t>(texels); ++t) {
         float rgb[3]{};
         if (layout == prosper::frontend::LiveTargetSourceLayout::Float16x4) {
@@ -230,7 +235,15 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
           (format == DataFormat::Float16 &&
            target_format == LiveTargetPixelFormat::Rgba16Float))) ||
         (components == 3 && format == DataFormat::Float10_11_11 &&
-         target_format == LiveTargetPixelFormat::R11G11B10Float);
+         target_format == LiveTargetPixelFormat::R11G11B10Float) ||
+        (components == 1 && format == DataFormat::Unorm8 &&
+         target_format == LiveTargetPixelFormat::R8Unorm) ||
+        (components == 2 && format == DataFormat::Unorm8 &&
+         target_format == LiveTargetPixelFormat::Rg8Unorm) ||
+        (components == 1 && format == DataFormat::Uint32 &&
+         target_format == LiveTargetPixelFormat::R32Uint) ||
+        (components == 1 && format == DataFormat::Float32 &&
+         target_format == LiveTargetPixelFormat::R32Float);
     // The renderer's RGBA8 fallback already stores the numeric UNORM value. Expanding each byte to
     // uint16 as byte*257 and reading R16_UNORM produces exactly byte/255 again. Vulkan performs
     // that UNORM-to-float conversion for normalized sampling and integer-coordinate OpImageFetch,
@@ -396,7 +409,10 @@ void copy_compute_buffer(void* destination, const void* source, size_t bytes) {
 }
 
 #if defined(PROSPER_HAVE_TARGET_F16C)
-__attribute__((target("avx2")))
+// MinGW's out-of-line AVX target-function call may spill the by-value YMM argument with VMOVAPS to
+// a worker thread's only 16-byte-aligned stack. Keep this leaf in the caller so no cross-function
+// YMM spill exists; the generated arithmetic and the runtime AVX2 gate remain unchanged.
+__attribute__((target("avx2"), always_inline)) inline
 __m128i storage_pack_unorm8x8_avx2(__m256 values) {
     const __m256 zero = _mm256_setzero_ps();
     const __m256 one = _mm256_set1_ps(1.0f);
@@ -5857,7 +5873,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
                          r->format == DataFormat::Float16 && nc == 4) ||
                         (live_target.format == LiveTargetPixelFormat::R11G11B10Float &&
-                         r->format == DataFormat::Float10_11_11 && nc == 3);
+                         r->format == DataFormat::Float10_11_11 && nc == 3) ||
+                        (live_target.format == LiveTargetPixelFormat::R8Unorm &&
+                         r->format == DataFormat::Unorm8 && nc == 1) ||
+                        (live_target.format == LiveTargetPixelFormat::Rg8Unorm &&
+                         r->format == DataFormat::Unorm8 && nc == 2) ||
+                        (live_target.format == LiveTargetPixelFormat::R32Uint &&
+                         (r->format == DataFormat::Uint32 ||
+                          r->format == DataFormat::Float32) && nc == 1) ||
+                        (live_target.format == LiveTargetPixelFormat::R32Float &&
+                         r->format == DataFormat::Float32 && nc == 1);
                     if (!compatible) {
                         // The same allocation can carry another target view before this compute
                         // operation (Astro Bot uses R8G8 and RGBA16F views at one base). A snapshot
@@ -5914,6 +5939,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     p->dcc_metadata_size == r->dcc_metadata_size &&
                     p->dcc_metadata_host_data == r->dcc_metadata_host_data &&
                     p->dcc_metadata_host_data_size == r->dcc_metadata_host_data_size;
+                // Captures materialize each descriptor's bytes into an independently-owned blob,
+                // so pointer equality is not an architectural backing identity. Two exact image
+                // descriptors for the same non-null guest range must still alias one Vulkan image:
+                // GTA V's 4K output shader writes the four 8x8 quadrants of each 16x16 block through
+                // four bindings at the same address. Treating the reconstructed blobs as four
+                // images loses three stores and leaves the red/green checker in Performance mode.
+                const bool same_host_backing = p &&
+                    (p->host_data == r->host_data ||
+                     (p->gpu_addr != 0 && p->gpu_addr == r->gpu_addr &&
+                      p->host_data_size == r->host_data_size));
                 const bool same_view = p && same_backing_representation &&
                     prior.storage == bi.storage &&
                     p->gpu_addr == r->gpu_addr && p->size == r->size &&
@@ -5925,7 +5960,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     p->layer_mip_offset_bytes == r->layer_mip_offset_bytes &&
                     p->in_mip_tail == r->in_mip_tail &&
                     p->mip_tail_x == r->mip_tail_x && p->mip_tail_y == r->mip_tail_y &&
-                    p->srgb == r->srgb && p->host_data == r->host_data &&
+                    p->srgb == r->srgb && same_host_backing &&
                     p->host_data_size == r->host_data_size && same_dcc_identity;
                 bool same_sampler = true;
                 if (!bi.storage && same_view) {
@@ -6724,26 +6759,37 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool r11g11b10 = sampled_r11g11b10;
                 if (renderer_owned) {
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
-                    // Classify the snapshot's texel layout once. Every conversion below reads it as
-                    // either UNORM8x4 or FLOAT16x4; the packed R11G11B10 layout is served by the
-                    // byte-copy and reconstruction branches, and a packed renderer target under any
-                    // other view already declined ownership above. Testing the layout instead of
-                    // "is it RGBA8, else assume FP16" keeps a future pixel format from silently
-                    // reading eight bytes out of a four-byte texel.
+                    // Classify the snapshot's texel layout once. The common conversion branches
+                    // read UNORM8x4 or FLOAT16x4, packed R11G11B10 has its own reconstruction, and
+                    // exact narrow layouts take only byte-identical paths. Testing the layout instead
+                    // of "is it RGBA8, else assume FP16" keeps a future pixel format from silently
+                    // reading eight bytes out of a smaller texel.
                     using prosper::frontend::LiveTargetSourceLayout;
                     const LiveTargetSourceLayout source_layout =
                         prosper::frontend::live_target_source_layout(live_target.format);
                     const bool source_unorm8 = source_layout == LiveTargetSourceLayout::Unorm8x4;
                     const bool source_float16 = source_layout == LiveTargetSourceLayout::Float16x4;
-                    // DO NOT DELETE AS DEAD CODE. This never fires for today's three enumerators,
-                    // but it is not redundant: the packed-view check above is written as
+                    const bool source_r8 = source_layout == LiveTargetSourceLayout::Unorm8x1;
+                    const bool source_rg8 = source_layout == LiveTargetSourceLayout::Unorm8x2;
+                    const bool source_r32 = source_layout == LiveTargetSourceLayout::Uint32x1;
+                    const bool source_f32 = source_layout == LiveTargetSourceLayout::Float32x1;
+                    const bool exact_narrow_layout =
+                        (source_r8 &&
+                         (r8 || (sampled_uint8_native && sampled_components == 1))) ||
+                        (source_rg8 &&
+                         (sampled_unorm8x2 ||
+                          (sampled_uint8_native && sampled_components == 2))) ||
+                        (source_r32 && sampled_components == 1 &&
+                         (sampled_float32_native || sampled_uint32_native)) ||
+                        (source_f32 && sampled_components == 1 && sampled_float32_native);
+                    // This is not redundant: the packed-view check above is written as
                     // `format == R11G11B10Float && <incompatible view>`, which for any NEW format
                     // is false and therefore RETAINS ownership. That predicate fails OPEN, so this
                     // guard and the `!bpp` decline above are what actually keep an unclassified
                     // layout out of the two-layout conversions below - where "not UNORM8" means
                     // "read eight bytes per texel" and a four-byte snapshot is read out of bounds.
                     if (!bi.unorm_rtt_value_reuse && !r11g11b10 &&
-                        !source_unorm8 && !source_float16) {
+                        !source_unorm8 && !source_float16 && !exact_narrow_layout) {
                         skip_image(r, "renderer-owned RTT layout has no sampled conversion"); break;
                     }
                     if (bi.unorm_rtt_value_reuse) {
@@ -6772,7 +6818,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
                             for (uint32_t c = 0; c < sampled_components; ++c) {
-                                if (source_unorm8) {
+                                if (source_r8) {
+                                    upload[t] = pixels[t];
+                                } else if (source_rg8) {
+                                    upload[t * sampled_components + c] = pixels[t * 2 + c];
+                                } else if (source_unorm8) {
                                     upload[t * sampled_components + c] = pixels[t * 4 + c];
                                 } else {
                                     uint16_t half = 0;
@@ -6789,7 +6839,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
                             for (uint32_t c = 0; c < 2; ++c) {
-                                if (source_unorm8) {
+                                if (source_rg8) {
+                                    upload[t * 2 + c] = pixels[t * 2 + c];
+                                } else if (source_unorm8) {
                                     upload[t * 2 + c] = pixels[t * 4 + c];
                                 } else {
                                     uint16_t half = 0;
@@ -6848,6 +6900,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                     }
                                 }
                             });
+                    } else if (source_r8 && r8) {
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            const uint8_t value = pixels[t];
+                            upload[t * 4 + 0] = value;
+                            upload[t * 4 + 1] = value;
+                            upload[t * 4 + 2] = value;
+                            upload[t * 4 + 3] = value;
+                        }
                     } else if (source_unorm8) {
                         std::memcpy(upload, pixels.data(), upload_size);
                     } else {
@@ -9079,6 +9140,50 @@ bool storage_image_materialize_raw_uvec4(
     return detiled && storage_image_unpack_raw_uvec4(
         linear.data(), linear.size(), format, components, texels,
         channels, channel_dwords);
+}
+
+bool storage_image_writeback_raw_uvec4(
+    const uint32_t* channels, size_t channel_dwords,
+    prosper::gpu::DataFormat format, uint32_t components,
+    uint32_t width, uint32_t height, uint32_t depth, uint32_t tile_mode,
+    bool in_mip_tail, uint32_t mip_tail_bytes,
+    uint32_t mip_tail_x, uint32_t mip_tail_y,
+    uint8_t* destination, size_t destination_bytes) {
+    const uint32_t guest_texel = storage_image_guest_texel_bytes(format, components);
+    const size_t required_destination = storage_image_raw_uvec4_source_bytes(
+        format, components, width, height, depth, tile_mode,
+        in_mip_tail, mip_tail_bytes);
+    if (!channels || !destination || !guest_texel || !storage_pack_supported(format) ||
+        !required_destination || destination_bytes < required_destination ||
+        width > SIZE_MAX / height)
+        return false;
+    const size_t plane_texels = static_cast<size_t>(width) * height;
+    if (plane_texels > SIZE_MAX / depth) return false;
+    const size_t texels = plane_texels * depth;
+    if (texels > SIZE_MAX / 4u || channel_dwords < texels * 4u ||
+        texels > SIZE_MAX / guest_texel)
+        return false;
+
+    std::vector<uint8_t> linear(texels * guest_texel);
+    storage_pack_range(channels, format, components, texels,
+                       linear.data(), guest_texel);
+    if (!prosper::gpu::tile_mode_is_tiled(tile_mode)) {
+        std::memcpy(destination, linear.data(), linear.size());
+        return true;
+    }
+    if (depth > 1u)
+        return prosper::gpu::tile_volume(
+            destination, destination_bytes, linear.data(),
+            width, height, depth, tile_mode, guest_texel);
+    if (in_mip_tail) {
+        prosper::gpu::tile_surface_level(
+            destination, destination_bytes, linear.data(), width, height,
+            tile_mode, guest_texel, mip_tail_x, mip_tail_y);
+        return true;
+    }
+    prosper::gpu::tile_surface(
+        destination, linear.data(), width, height, tile_mode, 0, guest_texel);
+    return true;
 }
 
 bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat format,

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -234,6 +234,10 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
            target_format == LiveTargetPixelFormat::Rgba8Unorm) ||
           (format == DataFormat::Float16 &&
            target_format == LiveTargetPixelFormat::Rgba16Float))) ||
+        (components == 2 && format == DataFormat::Float16 &&
+         target_format == LiveTargetPixelFormat::Rg16Float) ||
+        (components == 1 && format == DataFormat::Float16 &&
+         target_format == LiveTargetPixelFormat::R16Float) ||
         (components == 3 && format == DataFormat::Float10_11_11 &&
          target_format == LiveTargetPixelFormat::R11G11B10Float) ||
         (components == 1 && format == DataFormat::Unorm8 &&
@@ -268,7 +272,11 @@ bool sampled_rtt_snapshot_byte_compatible(
              target_format == LiveTargetPixelFormat::R32Uint)) ||
         (components == 4 &&
          (format == DataFormat::Float32 || format == DataFormat::Uint32) &&
-         target_format == LiveTargetPixelFormat::Rgba32Float);
+         target_format == LiveTargetPixelFormat::Rgba32Float) ||
+        (components == 2 && format == DataFormat::Float16 &&
+         target_format == LiveTargetPixelFormat::Rg16Float) ||
+        (components == 1 && format == DataFormat::Float16 &&
+         target_format == LiveTargetPixelFormat::R16Float);
 }
 
 namespace {
@@ -5888,6 +5896,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                          r->format == DataFormat::Unorm8 && nc == 4) ||
                         (live_target.format == LiveTargetPixelFormat::Rgba16Float &&
                          r->format == DataFormat::Float16 && nc == 4) ||
+                        (live_target.format == LiveTargetPixelFormat::Rg16Float &&
+                         r->format == DataFormat::Float16 && nc == 2) ||
+                        (live_target.format == LiveTargetPixelFormat::R16Float &&
+                         r->format == DataFormat::Float16 && nc == 1) ||
                         (live_target.format == LiveTargetPixelFormat::R11G11B10Float &&
                          r->format == DataFormat::Float10_11_11 && nc == 3) ||
                         (live_target.format == LiveTargetPixelFormat::R8Unorm &&
@@ -6792,13 +6804,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const bool source_r32 = source_layout == LiveTargetSourceLayout::Uint32x1;
                     const bool source_f32 = source_layout == LiveTargetSourceLayout::Float32x1;
                     const bool source_f32x4 = source_layout == LiveTargetSourceLayout::Float32x4;
+                    const bool source_f16x2 = source_layout == LiveTargetSourceLayout::Float16x2;
+                    const bool source_f16x1 = source_layout == LiveTargetSourceLayout::Float16x1;
                     const bool exact_narrow_layout =
                         (source_r8 &&
                          (r8 || (sampled_uint8_native && sampled_components == 1))) ||
                         (source_rg8 &&
                          (sampled_unorm8x2 ||
                           (sampled_uint8_native && sampled_components == 2))) ||
-                        ((source_r32 || source_f32 || source_f32x4) &&
+                        ((source_r32 || source_f32 || source_f32x4 || source_f16x2 || source_f16x1) &&
                          sampled_rtt_snapshot_byte_compatible(
                              r->format, sampled_components, live_target.format));
                     // This is not redundant: the packed-view check above is written as
@@ -6826,6 +6840,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          r->width, r->height,
                                          prosper::frontend::live_target_pixel_format_name(
                                              live_target.format));
+                    } else if ((source_f16x2 || source_f16x1) && f16) {
+                        std::memcpy(upload, pixels.data(), upload_size);
                     } else if (sampled_float32_native || sampled_uint16_native ||
                                sampled_uint32_native) {
                         // A renderer-owned target is authoritative only when its cached texel is

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -35,6 +35,8 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <filesystem>
+#include <fstream>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -55,6 +57,28 @@
 #endif
 
 namespace prosper::frontend {
+
+bool compute_pipeline_cache_blob_compatible(
+    const uint8_t* blob, size_t blob_bytes,
+    uint32_t vendor_id, uint32_t device_id,
+    const uint8_t* pipeline_cache_uuid, size_t uuid_bytes) {
+    // VkPipelineCacheHeaderVersionOne is a serialized five-field prefix. Avoid casting untrusted
+    // file bytes to the structure so short and unaligned files are rejected before any read.
+    constexpr size_t scalar_bytes = 4u * sizeof(uint32_t);
+    constexpr size_t prefix_bytes = scalar_bytes + VK_UUID_SIZE;
+    if (!blob || !pipeline_cache_uuid || uuid_bytes != VK_UUID_SIZE ||
+        blob_bytes < prefix_bytes)
+        return false;
+    uint32_t header_size = 0, header_version = 0, cached_vendor = 0, cached_device = 0;
+    std::memcpy(&header_size, blob + 0u * sizeof(uint32_t), sizeof(uint32_t));
+    std::memcpy(&header_version, blob + 1u * sizeof(uint32_t), sizeof(uint32_t));
+    std::memcpy(&cached_vendor, blob + 2u * sizeof(uint32_t), sizeof(uint32_t));
+    std::memcpy(&cached_device, blob + 3u * sizeof(uint32_t), sizeof(uint32_t));
+    return header_size >= prefix_bytes && header_size <= blob_bytes &&
+           header_version == VK_PIPELINE_CACHE_HEADER_VERSION_ONE &&
+           cached_vendor == vendor_id && cached_device == device_id &&
+           std::memcmp(blob + scalar_bytes, pipeline_cache_uuid, VK_UUID_SIZE) == 0;
+}
 
 LiveComputeBufferDescriptorPlan plan_live_compute_buffer_descriptors(
     const std::vector<prosper::gpu::SpirvDescriptorBinding>& descriptors,
@@ -295,6 +319,18 @@ std::atomic<bool> g_force_next_image_result_host_fallback_for_test{false};
 std::atomic<bool> g_fail_next_image_result_buffer_retain_for_test{false};
 std::atomic<bool> g_force_next_queue_submit_device_lost_for_test{false};
 std::atomic<uint64_t> g_live_compute_queue_submit_attempts{0};
+thread_local uint64_t g_perf_compute_gpu_timestamp_samples = 0;
+thread_local double g_perf_compute_gpu_device_ms = 0.0;
+thread_local double g_perf_compute_gpu_shader_ms = 0.0;
+thread_local double g_perf_compute_gpu_pre_ms = 0.0;
+thread_local double g_perf_compute_gpu_storage_copy_ms = 0.0;
+thread_local double g_perf_compute_gpu_compare_ms = 0.0;
+thread_local double g_perf_compute_gpu_restore_ms = 0.0;
+thread_local double g_perf_compute_setup_ms = 0.0;
+thread_local double g_perf_compute_pipeline_ms = 0.0;
+thread_local double g_perf_compute_dispatch_wait_ms = 0.0;
+thread_local double g_perf_compute_writeback_ms = 0.0;
+thread_local double g_perf_compute_cleanup_ms = 0.0;
 
 VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t components) {
     using prosper::gpu::DataFormat;
@@ -303,6 +339,11 @@ VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t comp
         if (components == 1) return VK_FORMAT_R8_UNORM;
         if (components == 2) return VK_FORMAT_R8G8_UNORM;
         if (components == 4) return VK_FORMAT_R8G8B8A8_UNORM;
+        break;
+    case DataFormat::Unorm16:
+        if (components == 1) return VK_FORMAT_R16_UNORM;
+        if (components == 2) return VK_FORMAT_R16G16_UNORM;
+        if (components == 4) return VK_FORMAT_R16G16B16A16_UNORM;
         break;
     case DataFormat::Float16:
         if (components == 1) return VK_FORMAT_R16_SFLOAT;
@@ -317,10 +358,49 @@ VkFormat native_storage_vk_format(prosper::gpu::DataFormat format, uint32_t comp
     case DataFormat::Float10_11_11:
         if (components == 3) return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
         break;
+    case DataFormat::Uint32:
+        if (components == 1) return VK_FORMAT_R32_UINT;
+        break;
+    case DataFormat::Uint16:
+        if (components == 1) return VK_FORMAT_R16_UINT;
+        break;
+    case DataFormat::Uint8:
+        if (components == 1) return VK_FORMAT_R8_UINT;
+        if (components == 4) return VK_FORMAT_R8G8B8A8_UINT;
+        break;
     default:
         break;
     }
     return VK_FORMAT_UNDEFINED;
+}
+
+// The exact R11G11B10 storage lowering deliberately writes packed words through R32_UINT to avoid
+// driver-dependent float rounding. Vulkan image copies are bit-preserving between these equal-size
+// uncompressed texel formats, so a later B10G11R11 sampled image may be seeded without round-tripping
+// 33 MiB through guest memory. Uint8 and Uint16 storage images are the other deliberate cross-view
+// cases: GTA V writes integer texels and immediately samples those same bits as normalized values.
+// Their images are created mutable and leased through compatible UNORM views without a copy.
+VkFormat compute_transfer_storage_vk_format(prosper::gpu::DataFormat format,
+                                            uint32_t components) {
+    if (format == prosper::gpu::DataFormat::Float10_11_11 && components == 3)
+        return VK_FORMAT_R32_UINT;
+    return native_storage_vk_format(format, components);
+}
+
+bool compute_transfer_vk_formats_bit_compatible(prosper::gpu::DataFormat format,
+                                                uint32_t components,
+                                                VkFormat storage_format,
+                                                VkFormat sampled_format) {
+    return storage_format == sampled_format ||
+        (format == prosper::gpu::DataFormat::Float10_11_11 && components == 3 &&
+         storage_format == VK_FORMAT_R32_UINT &&
+         sampled_format == VK_FORMAT_B10G11R11_UFLOAT_PACK32) ||
+        // GTA V writes a depth-like transition surface through R32_UINT and reads the same four
+        // bytes through an R32_SFLOAT sampled descriptor. This is an exact equal-width image copy;
+        // no numeric conversion or relaxed component/extent matching is involved.
+        (format == prosper::gpu::DataFormat::Float32 && components == 1 &&
+         storage_format == VK_FORMAT_R32_UINT &&
+         sampled_format == VK_FORMAT_R32_SFLOAT);
 }
 
 bool native_storage_image_create_supported(VkPhysicalDevice physical, VkFormat format,
@@ -825,6 +905,7 @@ struct CachedComputeImage {
     // write changed the architectural backing. This is separate from source validation: a failed
     // dispatch can leave the old guest mirror valid while making the Vulkan result unknowable.
     prosper::gpu::GuestGpuWriteSnapshot graphics_export_snapshot;
+    uint64_t graphics_export_command_order = 0;
     bool graphics_export_valid = false;
     prosper::gpu::GuestGpuWriteSnapshot compute_transfer_snapshot;
     bool compute_transfer_valid = false;
@@ -1034,10 +1115,15 @@ struct VulkanComputeContext {
     VkDevice device = VK_NULL_HANDLE;
     VkQueue queue = VK_NULL_HANDLE;
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
+    std::filesystem::path pipeline_cache_path;
+    std::mutex pipeline_cache_mutex;
     VkDescriptorPool descriptor_pool = VK_NULL_HANDLE;
     VkCommandPool command_pool = VK_NULL_HANDLE;
     VkCommandBuffer command_buffer = VK_NULL_HANDLE;
     VkFence dispatch_fence = VK_NULL_HANDLE;
+    VkQueryPool dispatch_timestamp_pool = VK_NULL_HANDLE;
+    float timestamp_period_ns = 0.0f;
+    uint32_t timestamp_valid_bits = 0;
     uint32_t descriptor_buffer_capacity = 0;
     uint32_t descriptor_sampled_capacity = 0;
     uint32_t descriptor_storage_capacity = 0;
@@ -1095,11 +1181,155 @@ struct VulkanComputeContext {
     // and this context then retain objects that Vulkan may still own; neither may be destroyed.
     bool completion_unproven = false;
 
+    std::filesystem::path persistent_pipeline_cache_path() const {
+        if (std::getenv("PROSPER_NO_DISK_PIPELINE_CACHE")) return {};
+        if (const char* explicit_path = std::getenv("PROSPER_COMPUTE_PIPELINE_CACHE_PATH")) {
+            if (*explicit_path) return std::filesystem::path(explicit_path);
+            return {};
+        }
+        // Loading a driver-produced cache blob is not yet a safe default. Repeated GTA V runs on
+        // NVIDIA reproduced an nvoglv64.dll crash only on the cache-load route; UUID/header
+        // validation proves device compatibility, not that the vendor blob itself is robust. Keep
+        // persistence available for controlled measurements, but require an explicit opt-in until
+        // that driver failure has a guarded reproducer.
+        if (!std::getenv("PROSPER_DISK_PIPELINE_CACHE")) return {};
+        const char* base = nullptr;
+        [[maybe_unused]] bool base_is_home = false;
+#ifdef _WIN32
+        base = std::getenv("LOCALAPPDATA");
+#else
+        base = std::getenv("XDG_CACHE_HOME");
+        if (!base || !*base) {
+            base = std::getenv("HOME");
+            base_is_home = true;
+        }
+#endif
+        if (!base || !*base) return {};
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
+        char identity[160]{};
+        char* out = identity;
+        const size_t remaining = sizeof(identity);
+        const int prefix = std::snprintf(
+            out, remaining, "compute-vkcache-v1-%08x-%08x-",
+            properties.vendorID, properties.deviceID);
+        if (prefix < 0 || static_cast<size_t>(prefix) >= remaining) return {};
+        out += prefix;
+        for (uint8_t byte : properties.pipelineCacheUUID) {
+            const int written = std::snprintf(out,
+                static_cast<size_t>(identity + sizeof(identity) - out), "%02x", byte);
+            if (written != 2) return {};
+            out += 2;
+        }
+        std::filesystem::path directory(base);
+#ifndef _WIN32
+        if (base_is_home) directory /= ".cache";
+#endif
+        return directory / "prosper" / identity;
+    }
+
+    bool create_pipeline_cache() {
+        pipeline_cache_path = persistent_pipeline_cache_path();
+        std::vector<uint8_t> initial;
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
+        if (!pipeline_cache_path.empty()) {
+            std::error_code ec;
+            const uintmax_t bytes = std::filesystem::file_size(pipeline_cache_path, ec);
+            constexpr uintmax_t max_cache_bytes = 256ull * 1024ull * 1024ull;
+            if (!ec && bytes && bytes <= max_cache_bytes) {
+                initial.resize(static_cast<size_t>(bytes));
+                std::ifstream input(pipeline_cache_path, std::ios::binary);
+                input.read(reinterpret_cast<char*>(initial.data()),
+                           static_cast<std::streamsize>(initial.size()));
+                if (!input || !compute_pipeline_cache_blob_compatible(
+                        initial.data(), initial.size(), properties.vendorID,
+                        properties.deviceID, properties.pipelineCacheUUID, VK_UUID_SIZE))
+                    initial.clear();
+            }
+        }
+        VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
+        pcci.initialDataSize = initial.size();
+        pcci.pInitialData = initial.empty() ? nullptr : initial.data();
+        VkResult result = vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache);
+        if (result != VK_SUCCESS && !initial.empty()) {
+            // Driver rejection of an otherwise identity-compatible blob is a cache miss, not a
+            // reason to disable compute. Recreate empty and replace the stale file on clean exit.
+            pcci.initialDataSize = 0;
+            pcci.pInitialData = nullptr;
+            result = vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache);
+            initial.clear();
+        }
+        if (result != VK_SUCCESS) return false;
+        if (!pipeline_cache_path.empty())
+            std::fprintf(stderr, "[compute] disk pipeline cache %s: %s (%zu bytes)\n",
+                         initial.empty() ? "cold" : "loaded",
+                         pipeline_cache_path.string().c_str(), initial.size());
+        return true;
+    }
+
+    void persist_pipeline_cache() {
+        if (!pipeline_cache || pipeline_cache_path.empty() || device_lost ||
+            completion_unproven)
+            return;
+        // VkPipelineCache is externally synchronized. The frontend's _Exit flush can overlap the
+        // last guest dispatch even after a cooperative-stop request, so serialize it against every
+        // vkCreateComputePipelines call that mutates the cache.
+        std::lock_guard<std::mutex> cache_lock(pipeline_cache_mutex);
+        size_t bytes = 0;
+        if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, nullptr) != VK_SUCCESS ||
+            !bytes || bytes > 256ull * 1024ull * 1024ull)
+            return;
+        std::vector<uint8_t> blob(bytes);
+        if (vkGetPipelineCacheData(device, pipeline_cache, &bytes, blob.data()) != VK_SUCCESS)
+            return;
+        blob.resize(bytes);
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
+        if (!compute_pipeline_cache_blob_compatible(
+                blob.data(), blob.size(), properties.vendorID, properties.deviceID,
+                properties.pipelineCacheUUID, VK_UUID_SIZE))
+            return;
+        std::error_code ec;
+        std::filesystem::create_directories(pipeline_cache_path.parent_path(), ec);
+        if (ec) return;
+        const auto nonce = std::chrono::steady_clock::now().time_since_epoch().count();
+        std::filesystem::path temporary = pipeline_cache_path;
+        temporary += ".tmp-" + std::to_string(nonce);
+        {
+            std::ofstream output(temporary, std::ios::binary | std::ios::trunc);
+            output.write(reinterpret_cast<const char*>(blob.data()),
+                         static_cast<std::streamsize>(blob.size()));
+            output.flush();
+            if (!output) {
+                output.close();
+                std::filesystem::remove(temporary, ec);
+                return;
+            }
+        }
+        std::filesystem::rename(temporary, pipeline_cache_path, ec);
+        if (ec) {
+            ec.clear();
+            std::filesystem::remove(pipeline_cache_path, ec);
+            ec.clear();
+            std::filesystem::rename(temporary, pipeline_cache_path, ec);
+        }
+        if (ec) {
+            ec.clear();
+            std::filesystem::remove(temporary, ec);
+            return;
+        }
+        std::fprintf(stderr, "[compute] disk pipeline cache saved: %s (%zu bytes)\n",
+                     pipeline_cache_path.string().c_str(), blob.size());
+    }
+
     ~VulkanComputeContext() {
         release_cached_buffers();
         release_cached_images();
         release_cached_memory();
         if (dispatch_fence) vkDestroyFence(device, dispatch_fence, nullptr);
+        if (dispatch_timestamp_pool)
+            vkDestroyQueryPool(device, dispatch_timestamp_pool, nullptr);
         if (command_pool) vkDestroyCommandPool(device, command_pool, nullptr);
         if (descriptor_pool) vkDestroyDescriptorPool(device, descriptor_pool, nullptr);
         if (compare_pipeline) vkDestroyPipeline(device, compare_pipeline, nullptr);
@@ -1117,6 +1347,7 @@ struct VulkanComputeContext {
             if (cached.descriptor_layout)
                 vkDestroyDescriptorSetLayout(device, cached.descriptor_layout, nullptr);
         }
+        persist_pipeline_cache();
         if (pipeline_cache) vkDestroyPipelineCache(device, pipeline_cache, nullptr);
         if (borrowed) return;                       // renderer owns the device/instance
         if (device) vkDestroyDevice(device, nullptr);
@@ -1152,6 +1383,29 @@ struct VulkanComputeContext {
             return false;
         }
         return command_buffer != VK_NULL_HANDLE;
+    }
+
+    bool prepare_dispatch_timestamps() {
+        if (dispatch_timestamp_pool) return timestamp_valid_bits != 0;
+        uint32_t family_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, nullptr);
+        if (queue_family >= family_count) return false;
+        std::vector<VkQueueFamilyProperties> families(family_count);
+        vkGetPhysicalDeviceQueueFamilyProperties(physical, &family_count, families.data());
+        timestamp_valid_bits = families[queue_family].timestampValidBits;
+        VkPhysicalDeviceProperties properties{};
+        vkGetPhysicalDeviceProperties(physical, &properties);
+        timestamp_period_ns = properties.limits.timestampPeriod;
+        if (!timestamp_valid_bits || timestamp_period_ns <= 0.0f) return false;
+        VkQueryPoolCreateInfo info{VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO};
+        info.queryType = VK_QUERY_TYPE_TIMESTAMP;
+        info.queryCount = 6;
+        if (vkCreateQueryPool(device, &info, nullptr, &dispatch_timestamp_pool) != VK_SUCCESS) {
+            dispatch_timestamp_pool = VK_NULL_HANDLE;
+            timestamp_valid_bits = 0;
+            return false;
+        }
+        return true;
     }
 
     VkDescriptorPool prepare_descriptor_pool(uint32_t buffers, uint32_t sampled,
@@ -1793,11 +2047,13 @@ struct VulkanComputeContext {
         found->second.compute_transfer_valid = false;
     }
 
-    void authorize_cached_image_export(const ComputeImageCacheKey& key) {
+    void authorize_cached_image_export(const ComputeImageCacheKey& key,
+                                       uint64_t producer_command_order) {
         const auto found = image_cache.find(key);
         if (found == image_cache.end() || !found->second.content_valid || !found->second.image)
             return;
         found->second.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        found->second.graphics_export_command_order = producer_command_order;
         found->second.graphics_export_valid = true;
     }
 
@@ -1805,27 +2061,71 @@ struct VulkanComputeContext {
         const auto found = image_cache.find(key);
         if (found == image_cache.end() || !found->second.content_valid || !found->second.image)
             return false;
-        found->second.compute_transfer_snapshot = prosper::gpu::guest_gpu_write_snapshot();
-        found->second.compute_transfer_valid = true;
+        CachedComputeImage& cached = found->second;
+#if defined(_WIN32)
+        // Windows deliberately cannot page-protect guest mappings for dirty tracking: a VEH frame
+        // is built below the interrupted SysV RSP and would corrupt the guest's live red zone. Keep
+        // one exact guest-format mirror for exportable compute results instead. A changed full-
+        // overwrite result clears the old snapshot before this point; an unchanged result can keep
+        // it. The later borrower validates with memcmp, so direct CPU writes still fail closed.
+        if (!key.host_data && cached.source_snapshot.empty() &&
+            prosper::gpu::guest_readable(key.gpu_addr, key.guest_bytes)) {
+            remember_image_source_snapshot(
+                cached, reinterpret_cast<const uint8_t*>(uintptr_t(key.gpu_addr)),
+                key.guest_bytes, true);
+        }
+#endif
+        cached.compute_transfer_snapshot = prosper::gpu::guest_gpu_write_snapshot();
+        cached.compute_transfer_valid = true;
         return true;
     }
 
+    bool cached_image_exact_guest_mirror_unchanged(
+        const ComputeImageCacheKey& key, const CachedComputeImage& cached) const {
+#if !defined(_WIN32)
+        // Linux has the ordered journal plus page-protection write watch. Falling back to byte
+        // equality after either authority becomes unknown would revive a retained image after an
+        // explicitly notified architectural writer. The mirror exists solely for Windows, where
+        // protecting guest pages would corrupt the SysV red zone under VEH.
+        (void)key;
+        (void)cached;
+        return false;
+#else
+        return !key.host_data && cached.source_snapshot.size() == key.guest_bytes &&
+            prosper::gpu::guest_readable(key.gpu_addr, key.guest_bytes) &&
+            std::memcmp(cached.source_snapshot.data(),
+                        reinterpret_cast<const void*>(uintptr_t(key.gpu_addr)),
+                        key.guest_bytes) == 0;
+#endif
+    }
+
     bool borrow_cached_image_for_graphics(const ComputeImageCacheKey& key,
-                                          VkImage& image) {
+                                          VkImage& image,
+                                          uint64_t& producer_command_order) {
         const auto found = image_cache.find(key);
         if (found == image_cache.end()) return false;
         CachedComputeImage& cached = found->second;
         if (!cached.graphics_export_valid || !cached.content_valid || !cached.image) return false;
-        const bool submit_unchanged =
+        const prosper::gpu::GuestGpuWriteQuery submit_query =
             prosper::gpu::guest_gpu_writes_since(cached.graphics_export_snapshot,
-                                                  key.gpu_addr, key.guest_bytes) ==
-            prosper::gpu::GuestGpuWriteQuery::Unchanged;
+                                                  key.gpu_addr, key.guest_bytes);
+        const bool submit_unchanged =
+            submit_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
         const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
             cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
-        if (!submit_unchanged && !watch_unchanged) return false;
+        // An exact mirror is the fail-closed fallback only when neither ordered journal nor page
+        // watch can decide. It must never launder a KNOWN architectural writer whose bytes happened
+        // to compare equal (for example a same-value clear or the explicit GPU-write test hook).
+        const bool exact_unchanged =
+            submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown && !watch_unchanged &&
+            cached_image_exact_guest_mirror_unchanged(key, cached);
+        if (!submit_unchanged && !watch_unchanged && !exact_unchanged) return false;
+        if (exact_unchanged)
+            cached.graphics_export_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.last_use = ++image_cache_clock;
         ++cached.pins;
         image = cached.image;
+        producer_command_order = cached.graphics_export_command_order;
         return true;
     }
 
@@ -1859,7 +2159,10 @@ struct VulkanComputeContext {
             submit_query == prosper::gpu::GuestGpuWriteQuery::Unchanged;
         const bool watch_unchanged = !submit_unchanged && cached.write_watch &&
             cached.write_watch.query() == prosper::host::GuestWriteWatchQuery::Unchanged;
-        if (!submit_unchanged && !watch_unchanged) {
+        const bool exact_unchanged =
+            submit_query == prosper::gpu::GuestGpuWriteQuery::Unknown && !watch_unchanged &&
+            cached_image_exact_guest_mirror_unchanged(key, cached);
+        if (!submit_unchanged && !watch_unchanged && !exact_unchanged) {
             if (result) *result = ComputeTransferBorrowResult::AuthorityChanged;
             if (trace)
                 std::fprintf(stderr,
@@ -1869,6 +2172,8 @@ struct VulkanComputeContext {
                              cached.write_watch ? 1u : 0u);
             return false;
         }
+        if (exact_unchanged)
+            cached.compute_transfer_snapshot = prosper::gpu::guest_gpu_write_snapshot();
         cached.last_use = ++image_cache_clock;
         ++cached.pins;
         image = cached.image;
@@ -2215,6 +2520,7 @@ struct VulkanComputeContext {
         cpci.stage.module = compare_shader;
         cpci.stage.pName = "main";
         cpci.layout = compare_pipeline_layout;
+        std::lock_guard<std::mutex> cache_lock(pipeline_cache_mutex);
         return vkCreateComputePipelines(device, pipeline_cache, 1, &cpci, nullptr,
                                         &compare_pipeline) == VK_SUCCESS;
     }
@@ -2278,8 +2584,7 @@ struct VulkanComputeContext {
                 shared.compute_subgroup_arithmetic;
             min_native_subgroup_size = shared.min_compute_subgroup_size;
             max_native_subgroup_size = shared.max_compute_subgroup_size;
-            VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
-            if (vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache) == VK_SUCCESS) {
+            if (create_pipeline_cache()) {
                 vkGetPhysicalDeviceMemoryProperties(physical, &memory);
                 query_subgroup_support();
                 std::fprintf(stderr, "[compute] Vulkan device: adopted the renderer's device "
@@ -2468,8 +2773,7 @@ struct VulkanComputeContext {
         dci.ppEnabledExtensionNames = dev_exts.empty() ? nullptr : dev_exts.data();
         if (vkCreateDevice(physical, &dci, nullptr, &device) != VK_SUCCESS) return false;
         vkGetDeviceQueue(device, queue_family, 0, &queue);
-        VkPipelineCacheCreateInfo pcci{VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO};
-        if (vkCreatePipelineCache(device, &pcci, nullptr, &pipeline_cache) != VK_SUCCESS)
+        if (!create_pipeline_cache())
             return false;
         vkGetPhysicalDeviceMemoryProperties(physical, &memory);
         query_subgroup_support();
@@ -2555,10 +2859,13 @@ struct BoundImage {
     uint32_t binding = 0;
     bool storage = false;               // storage image: read back + pack to guest after the dispatch
     bool native_float_storage = false;  // Vulkan performs exact UNORM/float conversion at native width
+    bool native_uint_storage = false;   // exact guest-width integer texels
     bool packed_r11_storage = false;    // shader packs exact R11G11B10 words into typed R32_UINT
     bool unorm_rtt_value_reuse = false; // float R16 view reuses authoritative RGBA8 values
     bool graphics_sampled_usage = false;// native image was created with SAMPLED usage for export
-    bool exact_storage_bytes() const { return native_float_storage || packed_r11_storage; }
+    bool exact_storage_bytes() const {
+        return native_float_storage || native_uint_storage || packed_r11_storage;
+    }
     uint32_t texel_depth = 1;           // logical Z/layer count represented in the staging buffer
     uint32_t array_layers = 1;           // Vulkan array-layer count (3D depth remains one layer)
     bool arrayed_2d = false;            // SPIR-V requires a real 2D-array view (not base-slice fallback)
@@ -4204,7 +4511,8 @@ std::optional<bool> execute_cpu_fast_path(const prosper::gpu::ComputeItem& item)
             resource->gpu_addr, static_cast<size_t>(written_bytes));
     const uint32_t pattern[4] = {
         item.user_sgprs[4], item.user_sgprs[5], item.user_sgprs[6], item.user_sgprs[7]};
-    if (!(pattern[0] | pattern[1] | pattern[2] | pattern[3])) {
+    const bool zero_fill = !(pattern[0] | pattern[1] | pattern[2] | pattern[3]);
+    if (zero_fill) {
         std::memset(destination, 0, static_cast<size_t>(written_bytes));
     } else {
         for (uint64_t record = 0; record < records; ++record)
@@ -4518,6 +4826,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double image_cache_ms = 0.0;
     const std::vector<uint32_t>& spirv = item.spirv;
     const bool trace = trace_compute_item(item);
+    const bool perf_capture_timing =
+        prosper::perf::interactive_performance_capture().detailed_timing_active();
+    const bool perf_gpu_timing = perf_capture_timing && ctx.prepare_dispatch_timestamps();
     // Per-resource table dump for a traced program. The writeback line names a BINDING and the
     // disassembly names a fetch PC; without the mapping between them, attributing a buffer's contents
     // to the instruction that wrote it is guesswork. Printing the table closes that gap, and it is
@@ -4736,6 +5047,8 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::getenv("PROSPER_COMPUTE_PHASE_TIMING") != nullptr;
     const bool image_timing_requested =
         std::getenv("PROSPER_COMPUTE_IMAGE_TIMING") != nullptr;
+    const bool timing_capture_only =
+        std::getenv("PROSPER_COMPUTE_TIMING_CAPTURE_ONLY") != nullptr;
     // Preserve the cheap timing address pre-filter. The transfer gate census deliberately hashes
     // every reflected compute candidate because its two stable hashes have no address constraint.
     uint64_t timing_program_hash = 0;
@@ -4771,6 +5084,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         std::getenv("PROSPER_COMPUTE_TIMING_TRACE_ONLY") != nullptr;
     const bool phase_timing =
         phase_timing_requested && timing_item_selected &&
+        (!timing_capture_only || perf_capture_timing) &&
         (!timing_trace_only || trace);
     // Keep timing selection and the transfer/authority censuses above this return so investigations
     // still observe the proven no-op program. No Vulkan objects or queue submission are needed.
@@ -5371,6 +5685,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         };
         const bool image_timing =
             image_timing_requested && timing_item_selected &&
+            (!timing_capture_only || perf_capture_timing) &&
             (!timing_trace_only || trace);
         for (size_t i = 0; i < image_descriptors.size() && images_ready; i++) {
             // Every skip_image call below is inside this loop, so the cursor is always the binding
@@ -5401,8 +5716,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 r->num_components ? r->num_components : 1;
             const VkFormat native_storage_format =
                 native_storage_vk_format(r->format, descriptor_components);
-            const bool spirv_native_storage = bi.storage &&
+            const bool spirv_native_float_storage = bi.storage &&
                 image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Float;
+            const bool spirv_native_uint_storage = bi.storage &&
+                image_descriptors[i].image_numeric_class == SpirvImageNumericClass::Uint &&
+                !image_descriptors[i].atomic_access &&
+                ((r->format == DataFormat::Uint32 && descriptor_components == 1 &&
+                  image_descriptors[i].storage_image_format == kSpirvImageFormatR32ui) ||
+                 (r->format == DataFormat::Uint8 && descriptor_components == 1 &&
+                  image_descriptors[i].storage_image_format == kSpirvImageFormatR8ui) ||
+                 (r->format == DataFormat::Uint8 && descriptor_components == 4 &&
+                  image_descriptors[i].storage_image_format == kSpirvImageFormatRgba8ui) ||
+                 (r->format == DataFormat::Uint16 && descriptor_components == 1 &&
+                  image_descriptors[i].storage_image_format == kSpirvImageFormatR16ui));
+            const bool spirv_native_storage =
+                spirv_native_float_storage || spirv_native_uint_storage;
             bi.packed_r11_storage = bi.storage && !spirv_native_storage &&
                 !image_descriptors[i].atomic_access &&
                 image_descriptors[i].storage_image_format == kSpirvImageFormatR32ui &&
@@ -5412,16 +5740,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 image_descriptors[i].image_arrayed,
                 image_descriptors[i].image_multisampled);
             const bool native_2d_storage = bi.storage &&
-                shader_resource_uses_native_2d_storage_image(
-                    *r, image_descriptors[i].image_dim == 1u,
-                    image_descriptors[i].image_arrayed,
-                    image_descriptors[i].image_multisampled);
+                (shader_resource_uses_native_2d_storage_image(
+                     *r, image_descriptors[i].image_dim == 1u,
+                     image_descriptors[i].image_arrayed,
+                     image_descriptors[i].image_multisampled) ||
+                 (spirv_native_uint_storage &&
+                  shader_resource_uses_native_uint_2d_storage_image(
+                      *r, image_descriptors[i].image_dim == 1u,
+                      image_descriptors[i].image_arrayed,
+                      image_descriptors[i].image_multisampled)));
             const bool ordinary_3d_storage = r->img_dim == 2 && r->depth &&
                                              !r->depth_compare;
             const VkImageType native_storage_type = ordinary_3d_storage
                 ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D;
-            const bool native_storage_semantic = native_float_storage_image(
-                r->format, descriptor_components, r->srgb);
+            const bool native_storage_semantic =
+                native_float_storage_image(r->format, descriptor_components, r->srgb) ||
+                native_uint_storage_image(r->format, descriptor_components, r->srgb);
             // vkGetPhysicalDeviceImageFormatProperties is a driver query, not a cheap metadata
             // lookup. Sampled and raw-uvec4 descriptors cannot take this typed-storage path, so do
             // not repeat that query for every one of their per-frame bindings.
@@ -5434,9 +5768,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     native_2d_storage && image_descriptors[i].image_arrayed
                         ? r->depth : 1u);
             const bool native_storage_supported = spirv_native_storage &&
-                native_float_storage_image_supported(
-                    r->format, descriptor_components, r->srgb,
-                    native_storage_device);
+                (spirv_native_float_storage
+                     ? native_float_storage_image_supported(
+                           r->format, descriptor_components, r->srgb,
+                           native_storage_device)
+                     : native_uint_storage_image_supported(
+                           r->format, descriptor_components, r->srgb,
+                           native_storage_device));
             transfer_gate_census.record_reflection(
                 transfer_gate_observation.role, image_descriptors[i], *r, bi.storage,
                 ordinary_2d_view, native_storage_semantic, native_storage_device,
@@ -5448,12 +5786,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // SPIR-V is authoritative here: a raw-uvec4 module must keep the conversion path even
             // if this replay device supports the optional typed format, while a live module is only
             // emitted as float after the frontend's physical-device feature query.
-            bi.native_float_storage = spirv_native_storage;
-            bi.graphics_sampled_usage = bi.native_float_storage &&
-                (ordinary_2d_view || ordinary_3d_storage) &&
+            bi.native_float_storage = spirv_native_float_storage;
+            bi.native_uint_storage = spirv_native_uint_storage;
+            bi.graphics_sampled_usage =
+                (bi.native_float_storage || bi.native_uint_storage ||
+                 bi.packed_r11_storage) &&
+                (ordinary_2d_view || ordinary_3d_storage ||
+                 (native_2d_storage && image_descriptors[i].image_arrayed)) &&
                 native_storage_image_create_supported(
                     ctx.physical, native_storage_format, native_storage_type,
-                    r->width, r->height, ordinary_3d_storage ? r->depth : 1u, 1u,
+                    r->width, r->height, ordinary_3d_storage ? r->depth : 1u,
+                    native_2d_storage && image_descriptors[i].image_arrayed
+                        ? r->depth : 1u,
                     VK_IMAGE_USAGE_SAMPLED_BIT);
             if (trace)
                 std::fprintf(stderr,
@@ -5462,7 +5806,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                              bi.binding, bi.storage ? "storage" : "sampled",
                              (unsigned long long)r->gpu_addr, r->width, r->height, r->depth,
                              (unsigned)r->format, r->num_components, r->tile_mode,
-                             bi.native_float_storage ? 1u : 0u);
+                             bi.exact_storage_bytes() ? 1u : 0u);
             if (trace && bi.packed_r11_storage)
                 std::fprintf(stderr,
                              "[compute]   image binding=%u exact packed R11G11B10 storage via R32_UINT\n",
@@ -6071,9 +6415,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             // retained native storage result from seeding the next ping-pong sample on the GPU.
             // Ordinary guest-backed 2D FP16 keeps its historical RGBA8 conversion: native RGBA16F
             // sampling was measured 7x slower in Astro Bot's full-resolution composite on RADV.
+            const bool sampled_renderer_narrow_float16 = renderer_owned &&
+                ((live_target.format == LiveTargetPixelFormat::R16Float &&
+                  sampled_components == 1) ||
+                 (live_target.format == LiveTargetPixelFormat::Rg16Float &&
+                  sampled_components == 2));
             const bool sampled_float16_native = !bi.storage &&
-                r->format == DataFormat::Float16 && sampled_components == 4 &&
-                (bi.imported || dim_3d);
+                r->format == DataFormat::Float16 && sampled_components != 3 &&
+                ((sampled_components == 4 && (bi.imported || dim_3d)) ||
+                 sampled_renderer_narrow_float16);
             const bool sampled_unorm8x2 = !bi.storage && r->format == DataFormat::Unorm8 &&
                                           sampled_components == 2;
             const bool sampled_unorm16_native = !bi.storage && r->format == DataFormat::Unorm16 &&
@@ -6108,7 +6458,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          : sampled_float32_native ? sampled_components * 4u
                                          : sampled_float32 ? 16u
                                          : sampled_depth ? data_format_bytes(r->format)
-                                         : sampled_float16_native ? 8u
+                                         : sampled_float16_native ? sampled_components * 2u
                                          : sampled_uint32_native ? sampled_components * 4u
                                          : sampled_uint16_native ? sampled_components * 2u
                                          : sampled_unorm16_native ? sampled_components * 2u
@@ -6116,11 +6466,21 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          : sampled_unorm8x2 ? 2u : 4u;
             const bool sampled_r11g11b10 = !bi.storage &&
                 r->format == DataFormat::Float10_11_11 && sampled_components == 3;
+            // Fidelity GTA V feeds a full-resolution packed R10G10B10A2 scene surface into a
+            // compute post-process.  Storage already supports this exact guest word, but the
+            // sampled path used to fall through the generic per-component-width test (packed
+            // formats deliberately report zero there) and skipped the complete dispatch.  Vulkan's
+            // A2B10G10R10 layout has the same low-to-high R/G/B/A bit placement as GFX10 format 50,
+            // so a detile followed by a byte copy is both sufficient and lossless.
+            const bool sampled_unorm2_10_10_10 = !bi.storage &&
+                r->format == DataFormat::Unorm2_10_10_10 && sampled_components == 4;
             const VkFormat image_format = bi.imported_depth ? bi.imported_format
                 : bi.imported
                     ? prosper::frontend::live_target_pixel_format_vk(bi.imported_pixel_format)
                 : bi.unorm_rtt_value_reuse ? VK_FORMAT_R8G8B8A8_UNORM
                 : bi.packed_r11_storage ? VK_FORMAT_R32_UINT
+                : bi.native_uint_storage
+                    ? native_storage_format
                 : bi.native_float_storage
                 ? (r->format == DataFormat::Unorm8
                        ? (sampled_components == 1 ? VK_FORMAT_R8_UNORM
@@ -6139,7 +6499,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 : sampled_depth
                     ? (r->format == DataFormat::Float32
                            ? VK_FORMAT_D32_SFLOAT : VK_FORMAT_D16_UNORM)
-                : sampled_float16_native ? VK_FORMAT_R16G16B16A16_SFLOAT
+                : sampled_float16_native
+                    ? (sampled_components == 1 ? VK_FORMAT_R16_SFLOAT
+                       : sampled_components == 2 ? VK_FORMAT_R16G16_SFLOAT
+                                                  : VK_FORMAT_R16G16B16A16_SFLOAT)
                 : sampled_uint8_native
                     ? (sampled_components == 1 ? VK_FORMAT_R8_UINT
                        : sampled_components == 2 ? VK_FORMAT_R8G8_UINT
@@ -6153,6 +6516,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                        : sampled_components == 2 ? VK_FORMAT_R32G32_UINT
                                                   : VK_FORMAT_R32G32B32A32_UINT)
                 : sampled_r11g11b10 ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
+                : sampled_unorm2_10_10_10 ? VK_FORMAT_A2B10G10R10_UNORM_PACK32
                 : sampled_unorm8x2 ? VK_FORMAT_R8G8_UNORM
                 : sampled_unorm16_native
                     ? (sampled_components == 1 ? VK_FORMAT_R16_UNORM
@@ -6235,9 +6599,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     }
                 } else if (sampled_rgba8 || sampled_uint8 || sampled_r8 || sampled_f16 ||
                            sampled_f32 || sampled_r11g11b10 || sampled_unorm8x2 ||
+                           sampled_unorm2_10_10_10 ||
                            sampled_unorm16_native || sampled_uint8_native ||
                            sampled_uint16_native || sampled_uint32_native || sampled_depth) {
-                    const uint32_t bpt = sampled_r11g11b10 ? 4u : sampled_cb * sampled_nc;
+                    const uint32_t bpt = (sampled_r11g11b10 || sampled_unorm2_10_10_10)
+                        ? 4u : sampled_cb * sampled_nc;
                     if (cube_face_as_2d && r->layer_stride_bytes) {
                         const size_t selected_slice = r->in_mip_tail
                             ? r->mip_tail_bytes
@@ -6352,7 +6718,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 bi.cache_candidate = !sampled_dcc_fast_clear && dcc_cache_safe &&
                     persistent_compute_image_enabled(sbytes, ComputeImageCacheClass::sampled);
                 const VkFormat transfer_native_format =
-                    native_storage_vk_format(r->format, sampled_components);
+                    compute_transfer_storage_vk_format(r->format, sampled_components);
+                const bool float32_uint32_transfer_alias =
+                    ordinary_2d_view && r->format == DataFormat::Float32 &&
+                    sampled_components == 1 && image_format == VK_FORMAT_R32_SFLOAT;
+                const VkFormat transfer_alias_storage_format =
+                    float32_uint32_transfer_alias ? VK_FORMAT_R32_UINT : VK_FORMAT_UNDEFINED;
                 const bool transfer_format_compatible =
                     compute_native_2d_transfer_format_compatible(
                         r->format, sampled_components);
@@ -6361,7 +6732,12 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     (ordinary_2d_view && native_2d_transfer_enabled() &&
                      transfer_format_compatible);
                 const bool transfer_hostless = !r->host_data;
-                const bool transfer_format_match = transfer_native_format == image_format;
+                const bool transfer_format_match =
+                    compute_transfer_vk_formats_bit_compatible(
+                        r->format, sampled_components, transfer_native_format, image_format) ||
+                    compute_transfer_vk_formats_bit_compatible(
+                        r->format, sampled_components,
+                        transfer_alias_storage_format, image_format);
                 const bool transfer_validation_enabled =
                     adaptive_storage_result_validation_enabled();
                 const bool transfer_native_defined =
@@ -6403,12 +6779,38 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     if (native_transfer_dimension && transfer_hostless &&
                         transfer_format_match && transfer_validation_enabled &&
                         transfer_native_defined) {
-                        const ComputeImageCacheKey storage_key = storage_image_cache_key(
+                        ComputeImageCacheKey storage_key = storage_image_cache_key(
                             *r, static_cast<uint32_t>(sampled_guest_need),
                             transfer_native_format);
-                        if (ctx.borrow_cached_image_for_compute_transfer(
+                        bool borrowed = ctx.borrow_cached_image_for_compute_transfer(
+                            storage_key, bi.compute_transfer_seed, trace,
+                            &transfer_borrow_result);
+                        // The producer identity is part of the cache key. Retry only GTA V's exact
+                        // one-word numeric-view alias after the consumer's own Float32 identity
+                        // misses: Uint32/R32_UINT producer -> Float32/R32_SFLOAT consumer. The
+                        // retained source and sampled destination remain distinct images, so an
+                        // in-place read/modify/write dispatch cannot alias itself.
+                        if (!borrowed && float32_uint32_transfer_alias &&
+                            compute_transfer_vk_formats_bit_compatible(
+                                r->format, sampled_components,
+                                transfer_alias_storage_format, image_format)) {
+                            prosper::gpu::ShaderResource storage_identity = *r;
+                            storage_identity.format = DataFormat::Uint32;
+                            storage_key = storage_image_cache_key(
+                                storage_identity,
+                                static_cast<uint32_t>(sampled_guest_need),
+                                transfer_alias_storage_format);
+                            borrowed = ctx.borrow_cached_image_for_compute_transfer(
                                 storage_key, bi.compute_transfer_seed, trace,
-                                &transfer_borrow_result)) {
+                                &transfer_borrow_result);
+                            if (borrowed && trace)
+                                std::fprintf(stderr,
+                                             "[compute]   sampled 2D binding=%u addr=0x%llx "
+                                             "matched exact R32_UINT producer alias\n",
+                                             bi.binding,
+                                             (unsigned long long)r->gpu_addr);
+                        }
+                        if (borrowed) {
                             bi.compute_transfer_seed_key = storage_key;
                             bi.compute_transfer_seed_borrowed = true;
                             g_compute_storage_transfer_seeds.fetch_add(
@@ -6787,8 +7189,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 const bool f16 = sampled_f16;
                 const bool f32 = sampled_f32;
                 const bool r11g11b10 = sampled_r11g11b10;
+                const bool unorm2_10_10_10 = sampled_unorm2_10_10_10;
                 if (renderer_owned) {
                     const std::vector<uint8_t>& pixels = *live_target.pixels;
+                    auto copy_snapshot_exact = [&]() {
+                        if (pixels.size() != upload_size) return false;
+                        std::memcpy(upload, pixels.data(), upload_size);
+                        return true;
+                    };
                     // Classify the snapshot's texel layout once. The common conversion branches
                     // read UNORM8x4 or FLOAT16x4, packed R11G11B10 has its own reconstruction, and
                     // exact narrow layouts take only byte-identical paths. Testing the layout instead
@@ -6821,12 +7229,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     // guard and the `!bpp` decline above are what actually keep an unclassified
                     // layout out of the two-layout conversions below - where "not UNORM8" means
                     // "read eight bytes per texel" and a four-byte snapshot is read out of bounds.
-                    if (!bi.unorm_rtt_value_reuse && !r11g11b10 &&
+                    if (!bi.unorm_rtt_value_reuse && !r11g11b10 && !unorm2_10_10_10 &&
                         !source_unorm8 && !source_float16 && !exact_narrow_layout) {
                         skip_image(r, "renderer-owned RTT layout has no sampled conversion"); break;
                     }
                     if (bi.unorm_rtt_value_reuse) {
-                        std::memcpy(upload, pixels.data(), upload_size);
+                        if (!copy_snapshot_exact()) {
+                            skip_image(r, "renderer RTT direct copy byte count mismatch");
+                            break;
+                        }
                     } else if (r11g11b10) {
                         if (!pack_live_target_r11g11b10(live_target, upload, upload_size)) {
                             skip_image(r, "renderer RTT R11G11B10 reconstruction failed");
@@ -6840,15 +7251,49 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                          r->width, r->height,
                                          prosper::frontend::live_target_pixel_format_name(
                                              live_target.format));
-                    } else if ((source_f16x2 || source_f16x1) && f16) {
-                        std::memcpy(upload, pixels.data(), upload_size);
+                    } else if (unorm2_10_10_10) {
+                        // The renderer currently retains this guest target as normalized RGBA8 or
+                        // RGBA16F.  Re-quantize those numeric values into the exact sampled Vulkan
+                        // layout.  Guest-backed surfaces take the lossless memcpy path below.
+                        const size_t texels = static_cast<size_t>(volume_texels);
+                        for (size_t t = 0; t < texels; ++t) {
+                            uint32_t channels[4]{};
+                            for (uint32_t c = 0; c < 4; ++c) {
+                                float value = 0.0f;
+                                if (source_unorm8) {
+                                    value = pixels[t * 4 + c] / 255.0f;
+                                } else {
+                                    uint16_t half = 0;
+                                    std::memcpy(&half, pixels.data() + t * 8 + c * 2,
+                                                sizeof(half));
+                                    value = half_to_float(half);
+                                    if (!std::isfinite(value)) value = 0.0f;
+                                    value = std::clamp(value, 0.0f, 1.0f);
+                                }
+                                channels[c] = static_cast<uint32_t>(std::lround(
+                                    value * (c == 3 ? 3.0f : 1023.0f)));
+                            }
+                            const uint32_t packed = channels[0] | (channels[1] << 10) |
+                                (channels[2] << 20) | (channels[3] << 30);
+                            std::memcpy(upload + t * sizeof(packed), &packed, sizeof(packed));
+                        }
+                    } else if (sampled_float16_native &&
+                               ((source_f16x2 && sampled_components == 2) ||
+                                (source_f16x1 && sampled_components == 1))) {
+                        if (!copy_snapshot_exact()) {
+                            skip_image(r, "renderer RTT narrow FP16 byte count mismatch");
+                            break;
+                        }
                     } else if (sampled_float32_native || sampled_uint16_native ||
                                sampled_uint32_native) {
                         // A renderer-owned target is authoritative only when its cached texel is
                         // byte-identical to the UINT view.  Sonic aliases an RGBA16F render target
                         // as RGBA16_UINT for a compute resolve: those eight bytes must be
                         // reinterpreted, not numerically converted through float or UNORM.
-                        std::memcpy(upload, pixels.data(), upload_size);
+                        if (!copy_snapshot_exact()) {
+                            skip_image(r, "renderer RTT typed copy byte count mismatch");
+                            break;
+                        }
                     } else if (sampled_uint8_native) {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
@@ -6945,7 +7390,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                             upload[t * 4 + 3] = value;
                         }
                     } else if (source_unorm8) {
-                        std::memcpy(upload, pixels.data(), upload_size);
+                        if (!copy_snapshot_exact()) {
+                            skip_image(r, "renderer RTT RGBA8 copy byte count mismatch");
+                            break;
+                        }
                     } else {
                         const size_t texels = static_cast<size_t>(volume_texels);
                         for (size_t t = 0; t < texels; ++t) {
@@ -7045,7 +7493,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                         }
                         if (!images_ready) break;
                     } else if (needs_sampled_upload) {
-                        const uint32_t bpt = r11g11b10 ? 4u : cb * nc;
+                        const uint32_t bpt = (r11g11b10 || unorm2_10_10_10) ? 4u : cb * nc;
                         const size_t linear_bytes = static_cast<size_t>(volume_texels) * bpt;
                         std::unique_ptr<uint8_t[]> linear;
                         const uint8_t* sampled_source = src;
@@ -7131,7 +7579,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                            r->tile_mode, 0, bpt);
                         }
                         const size_t texels = (size_t)volume_texels;
-                        if (rgba8 || uint8 || r11g11b10 ||
+                        if (rgba8 || uint8 || r11g11b10 || unorm2_10_10_10 ||
                             sampled_unorm8x2 || sampled_unorm16_native ||
                             sampled_uint8_native || sampled_uint16_native ||
                             sampled_uint32_native || sampled_float32_native ||
@@ -7178,6 +7626,20 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
 
             // Device-local image.
             VkImageCreateInfo ici{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+            // A byte is byte-identical whether the guest's producer declares UINT storage or its
+            // consumer declares normalized/float sampling. The admitted UINT/UNORM and
+            // UINT/SFLOAT pairs, plus packed R11's R32_UINT storage carrier, are all same-width
+            // Vulkan format-compatible views. Creating only those exact storage allocations
+            // mutable lets the graphics backend request the consumer view later; all resource
+            // identity and write-authority checks still happen in the cache importer.
+            if (bi.storage && bi.native_uint_storage && bi.graphics_sampled_usage &&
+                ((r->format == DataFormat::Uint8 &&
+                  (descriptor_components == 1 || descriptor_components == 4)) ||
+                 (r->format == DataFormat::Uint16 && descriptor_components == 1) ||
+                 (r->format == DataFormat::Uint32 && descriptor_components == 1)))
+                ici.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
+            if (bi.storage && bi.packed_r11_storage && bi.graphics_sampled_usage)
+                ici.flags |= VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
             ici.imageType = dim_1d ? VK_IMAGE_TYPE_1D : (dim_3d ? VK_IMAGE_TYPE_3D : VK_IMAGE_TYPE_2D);
             ici.format = image_format;
             ici.extent = {r->width, dim_cube_stacked ? r->height * 6u : r->height,
@@ -7481,6 +7943,13 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             if (!vk_ok(vkCreatePipelineLayout(ctx.device, &plci, nullptr, &pipeline_layout),
                        "pipeline-layout")) break;
             VkComputePipelineCreateInfo cpci{VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO};
+            const bool low_latency_compile =
+                compute_pipeline_is_large(spirv.size()) &&
+                std::getenv("PROSPER_COMPUTE_FAST_COMPILE_LARGE") != nullptr &&
+                // Retain the old affirmative switch as an override for existing launch recipes.
+                std::getenv("PROSPER_COMPUTE_OPTIMIZE_LARGE") == nullptr;
+            if (low_latency_compile)
+                cpci.flags |= VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
             cpci.stage = {VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO};
             cpci.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;
             cpci.stage.module = shader;
@@ -7496,11 +7965,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             cpci.layout = pipeline_layout;
             if (trace)
                 std::fprintf(stderr,
-                             "[compute]   creating compute pipeline words=%zu descriptors=%zu "
-                             "subgroup=%u\n",
-                             spirv.size(), descriptors.size(), item.required_subgroup_size);
-            if (!vk_ok(vkCreateComputePipelines(ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr,
-                                                &pipeline), "compute-pipeline")) break;
+                              "[compute]   creating compute pipeline words=%zu descriptors=%zu "
+                              "subgroup=%u optimization=%s\n",
+                              spirv.size(), descriptors.size(), item.required_subgroup_size,
+                              low_latency_compile ? "disabled-for-cold-latency" : "driver-default");
+            VkResult pipeline_result = VK_SUCCESS;
+            {
+                std::lock_guard<std::mutex> cache_lock(ctx.pipeline_cache_mutex);
+                pipeline_result = vkCreateComputePipelines(
+                    ctx.device, ctx.pipeline_cache, 1, &cpci, nullptr, &pipeline);
+            }
+            if (!vk_ok(pipeline_result, "compute-pipeline")) break;
             if (trace) std::fprintf(stderr, "[compute]   compute pipeline ready\n");
             if (ctx.pipelines.size() < kMaxCachedComputePipelines) {
                 ctx.pipelines.emplace(std::move(pipeline_key), CachedComputePipeline{
@@ -7627,6 +8102,11 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         VkCommandBufferBeginInfo begin{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO};
         begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         if (!vk_ok(vkBeginCommandBuffer(command, &begin), "command-begin")) break;
+        if (perf_gpu_timing) {
+            vkCmdResetQueryPool(command, ctx.dispatch_timestamp_pool, 0, 6);
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                                ctx.dispatch_timestamp_pool, 0);
+        }
         // From this point a submitted storage dispatch can replace a retained image even if a
         // later fence/readback step fails. Revoke its graphics authority up front; only the complete
         // success path below republishes it.
@@ -7952,6 +8432,10 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT, 0, 0, nullptr, 0, nullptr,
                                  1, &to_general);
         }
+        if (perf_gpu_timing) {
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                ctx.dispatch_timestamp_pool, 1);
+        }
         vkCmdBindPipeline(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
         vkCmdBindDescriptorSets(command, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout,
                                 0, 1, &descriptor_set, 0, nullptr);
@@ -7960,6 +8444,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                static_cast<uint32_t>(item.user_sgprs.size() * sizeof(uint32_t)),
                                item.user_sgprs.data());
         vkCmdDispatch(command, item.launch.groups_x, item.launch.groups_y, item.launch.groups_z);
+        if (perf_gpu_timing)
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+                                ctx.dispatch_timestamp_pool, 2);
         // Storage images: copy the written texels back into the staging buffer for guest writeback.
         // When this private image was seeded from an exact borrowed renderer target, copy the final
         // result back to that same image as well. The CPU writeback below remains mandatory for
@@ -8030,6 +8517,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                      0, nullptr, 1, &to_general);
             }
         }
+        if (perf_gpu_timing)
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                                ctx.dispatch_timestamp_pool, 3);
         // Compare retained exact results before replacing their baselines. Guest-buffer shader
         // writes and image transfer writes become comparator reads; one atomic flag per target then
         // becomes a four-byte host read after the fence.
@@ -8140,6 +8630,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr, 1, &flags,
                                  0, nullptr);
         }
+        if (perf_gpu_timing)
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                ctx.dispatch_timestamp_pool, 4);
         // Hand every borrowed renderer image back in the layout its owner left it in (#1095), so the
         // renderer's own layout tracking stays true whether the dispatch only sampled it or the
         // device-local mirror above replaced its pixels. Include transfer writes in the source scope.
@@ -8168,6 +8661,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                                  VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
                                  1, &restore);
         }
+        if (perf_gpu_timing)
+            vkCmdWriteTimestamp(command, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+                                ctx.dispatch_timestamp_pool, 5);
         if (!vk_ok(vkEndCommandBuffer(command), "command-end")) break;
         VkSubmitInfo submit{VK_STRUCTURE_TYPE_SUBMIT_INFO};
         submit.commandBufferCount = 1;
@@ -8238,6 +8734,34 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             break;
         }
         completion_proven = true;
+        if (perf_gpu_timing) {
+            uint64_t timestamps[6]{};
+            if (vkGetQueryPoolResults(ctx.device, ctx.dispatch_timestamp_pool, 0, 6,
+                                      sizeof(timestamps), timestamps, sizeof(uint64_t),
+                                      VK_QUERY_RESULT_64_BIT) == VK_SUCCESS) {
+                const uint64_t mask = ctx.timestamp_valid_bits >= 64
+                    ? UINT64_MAX : ((uint64_t{1} << ctx.timestamp_valid_bits) - 1u);
+                const uint64_t device_ticks = (timestamps[5] - timestamps[0]) & mask;
+                const uint64_t shader_ticks = (timestamps[2] - timestamps[1]) & mask;
+                ++g_perf_compute_gpu_timestamp_samples;
+                g_perf_compute_gpu_device_ms +=
+                    static_cast<double>(device_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_shader_ms +=
+                    static_cast<double>(shader_ticks) * ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_pre_ms += static_cast<double>(
+                    (timestamps[1] - timestamps[0]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_storage_copy_ms += static_cast<double>(
+                    (timestamps[3] - timestamps[2]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_compare_ms += static_cast<double>(
+                    (timestamps[4] - timestamps[3]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+                g_perf_compute_gpu_restore_ms += static_cast<double>(
+                    (timestamps[5] - timestamps[4]) & mask) *
+                    ctx.timestamp_period_ns / 1'000'000.0;
+            }
+        }
         if (trace) std::fprintf(stderr, "[compute]   dispatch complete\n");
         phase_dispatch = ComputeClock::now();
         const auto writeback_prepare_start = phase_dispatch;
@@ -8946,12 +9470,14 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
         for (const BoundImage& image : images) {
             if (!image.storage) continue;
             const bool unique = image.alias_of == SIZE_MAX;
-            const bool publish_eligible = image.native_float_storage && unique &&
+            const bool native_exact_storage = image.native_float_storage ||
+                image.native_uint_storage || image.packed_r11_storage;
+            const bool publish_eligible = native_exact_storage && unique &&
                 image.cache_candidate && image.persistent;
             const bool authorized = publish_eligible &&
                 ctx.authorize_cached_image_compute_transfer(image.cache_key);
             transfer_gate_census.record_storage_publish(
-                transfer_gate_observation.role, image.native_float_storage, unique,
+                transfer_gate_observation.role, native_exact_storage, unique,
                 image.cache_candidate, image.persistent, authorized);
             if (authority_observation.selected && unique && image.resource) {
                 authority_census.record_selected_storage_output(
@@ -8961,7 +9487,7 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     authorized);
             }
             if (publish_eligible && image.graphics_sampled_usage)
-                ctx.authorize_cached_image_export(image.cache_key);
+                ctx.authorize_cached_image_export(image.cache_key, item.command_order);
         }
         writeback_publish_ms = std::chrono::duration<double, std::milli>(
             ComputeClock::now() - writeback_publish_start).count();
@@ -9054,11 +9580,18 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     // that the GPU may still own. Deliberately retain this raw-handle closure; the sticky entry
     // check prevents reuse and the atexit handler retains the context itself.
     if (!ctx.completion_unproven) cleanup();
+    const auto phase_cleanup = ComputeClock::now();
+    auto phase_milliseconds = [](auto begin, auto end) {
+        return std::chrono::duration<double, std::milli>(end - begin).count();
+    };
+    if (perf_capture_timing) {
+        g_perf_compute_setup_ms += phase_milliseconds(phase_start, phase_setup);
+        g_perf_compute_pipeline_ms += phase_milliseconds(phase_setup, phase_pipeline);
+        g_perf_compute_dispatch_wait_ms += phase_milliseconds(phase_pipeline, phase_dispatch);
+        g_perf_compute_writeback_ms += phase_milliseconds(phase_dispatch, phase_writeback);
+        g_perf_compute_cleanup_ms += phase_milliseconds(phase_writeback, phase_cleanup);
+    }
     if (phase_timing) {
-        const auto phase_cleanup = ComputeClock::now();
-        auto milliseconds = [](auto begin, auto end) {
-            return std::chrono::duration<double, std::milli>(end - begin).count();
-        };
         std::fprintf(stderr,
                      "[compute-phase] submit=%llu code=0x%llx hash=0x%016llx ok=%u "
                      "setup_ms=%.2f setup_validate_ms=%.2f setup_buffers_ms=%.2f "
@@ -9070,17 +9603,17 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                      "cleanup_ms=%.2f total_ms=%.2f subgroup=%u\n",
                      (unsigned long long)item.submit_no, (unsigned long long)item.code_addr,
                      (unsigned long long)timing_program_hash, ok ? 1u : 0u,
-                     milliseconds(phase_start, phase_setup),
+                     phase_milliseconds(phase_start, phase_setup),
                      setup_validate_ms, setup_buffers_ms,
-                     milliseconds(phase_setup, phase_pipeline),
-                     milliseconds(phase_pipeline, phase_dispatch),
-                     milliseconds(phase_dispatch, phase_writeback),
+                     phase_milliseconds(phase_setup, phase_pipeline),
+                     phase_milliseconds(phase_pipeline, phase_dispatch),
+                     phase_milliseconds(phase_dispatch, phase_writeback),
                      writeback_prepare_ms, writeback_buffers_ms,
                      writeback_images_ms, writeback_publish_ms,
                      image_map_ms, image_prepare_ms, image_watch_ms,
                      pack_ms, layout_ms, image_notify_ms, image_cache_ms,
-                     milliseconds(phase_writeback, phase_cleanup),
-                     milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
+                     phase_milliseconds(phase_writeback, phase_cleanup),
+                     phase_milliseconds(phase_start, phase_cleanup), item.required_subgroup_size);
     }
     return ok;
 }
@@ -9224,13 +9757,59 @@ bool storage_image_writeback_raw_uvec4(
 bool compute_native_2d_transfer_format_compatible(prosper::gpu::DataFormat format,
                                                   uint32_t components) {
     // Keep this intentionally narrower than every format the sampled uploader can materialize.
-    // Ordinary 2D FP16 is deliberately converted to RGBA8 on the sampled side, and packed R11 uses
-    // its exact R32_UINT recovery representation on the storage side. Only formats whose current
-    // ordinary-2D sampled and typed-storage paths select the same native VkFormat may transfer.
+    // Ordinary 2D FP16 is deliberately converted to RGBA8 on the sampled side. Packed R11 is the
+    // one cross-format exception: exact storage uses R32_UINT and sampling uses B10G11R11, whose
+    // equal four-byte texels are copied bit-for-bit. Other admitted formats use one native VkFormat.
     using prosper::gpu::DataFormat;
-    if (format != DataFormat::Float32 && format != DataFormat::Unorm8) return false;
-    if (components != 1 && components != 2 && components != 4) return false;
+    const bool packed_r11 =
+        format == DataFormat::Float10_11_11 && components == 3;
+    const bool float_or_unorm = format == DataFormat::Float32 ||
+        format == DataFormat::Unorm8 || packed_r11;
+    const bool exact_uint = native_uint_storage_image(format, components, false);
+    if (!float_or_unorm && !exact_uint) return false;
+    if (!packed_r11 && !exact_uint &&
+        components != 1 && components != 2 && components != 4)
+        return false;
     return native_storage_vk_format(format, components) != VK_FORMAT_UNDEFINED;
+}
+
+uint32_t live_compute_graphics_import_native_format(
+    prosper::gpu::DataFormat format, uint32_t components) {
+    using prosper::gpu::DataFormat;
+    const bool admitted =
+        (format == DataFormat::Float32 &&
+         (components == 1 || components == 2 || components == 4)) ||
+        (format == DataFormat::Float16 &&
+         (components == 1 || components == 2 || components == 4)) ||
+        (format == DataFormat::Float10_11_11 && components == 3) ||
+        (format == DataFormat::Unorm16 && components == 1) ||
+        (format == DataFormat::Unorm8 && (components == 1 || components == 4)) ||
+        (format == DataFormat::Uint32 && components == 1) ||
+        (format == DataFormat::Uint16 && components == 1) ||
+        (format == DataFormat::Uint8 && (components == 1 || components == 4));
+    return admitted
+        ? static_cast<uint32_t>(native_storage_vk_format(format, components))
+        : static_cast<uint32_t>(VK_FORMAT_UNDEFINED);
+}
+
+uint64_t live_compute_graphics_import_guest_bytes(
+    const prosper::gpu::ShaderResource& sampled_resource,
+    uint64_t decoded_source_bytes) {
+    using prosper::gpu::DataFormat;
+    const uint32_t components = sampled_resource.num_components
+        ? sampled_resource.num_components : 1u;
+    const bool r16_cube_array_alias = sampled_resource.img_dim == 3u &&
+        sampled_resource.depth == 6u && components == 1u &&
+        (sampled_resource.format == DataFormat::Uint16 ||
+         sampled_resource.format == DataFormat::Unorm16);
+    if (r16_cube_array_alias)
+        return prosper::gpu::gpu_capture_resource_footprint(sampled_resource);
+    if (decoded_source_bytes) return decoded_source_bytes;
+    if (components == 1u &&
+        (sampled_resource.format == DataFormat::Uint16 ||
+         sampled_resource.format == DataFormat::Unorm16))
+        return prosper::gpu::gpu_capture_resource_footprint(sampled_resource);
+    return 0;
 }
 
 void report_live_compute_timing_selector_summary() {
@@ -9239,29 +9818,82 @@ void report_live_compute_timing_selector_summary() {
     runtime_compute_authority_census().report_summary();
 }
 
+void flush_live_compute_pipeline_cache() {
+    VulkanComputeContext* context = g_live_compute_context;
+    if (context) context->persist_pipeline_cache();
+}
+
 bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
                                        uint64_t guest_bytes,
                                        LiveComputeImageImport& import) {
     import = {};
     VulkanComputeContext* context = g_live_compute_context;
+    const bool ordinary_shape =
+        (sampled_resource.img_dim == 1 && sampled_resource.depth == 1) ||
+        (sampled_resource.img_dim == 2 && sampled_resource.depth != 0);
+    // A compute U# writes GTA V's six R16_UINT shadow faces through DIM=2D_ARRAY, while the later
+    // graphics T# names the byte-identical allocation as DIM=CUBE. Graphics lowers cube sampling to
+    // a vertical 2D stack, so this is an explicit shape alias rather than a generic relaxed key.
+    const bool cube_array_alias = sampled_resource.img_dim == 3 &&
+        sampled_resource.depth == 6 &&
+        (sampled_resource.format == prosper::gpu::DataFormat::Uint16 ||
+         sampled_resource.format == prosper::gpu::DataFormat::Unorm16) &&
+        (sampled_resource.num_components ? sampled_resource.num_components : 1u) == 1u &&
+        sampled_resource.layer_stride_bytes != 0;
     if (!context || !context->device || !sampled_resource.gpu_addr ||
         sampled_resource.cls != prosper::gpu::ResourceClass::Texture ||
         sampled_resource.host_data || !guest_bytes || guest_bytes > UINT32_MAX ||
-        !((sampled_resource.img_dim == 1 && sampled_resource.depth == 1) ||
-          (sampled_resource.img_dim == 2 && sampled_resource.depth != 0)) ||
+        (!ordinary_shape && !cube_array_alias) ||
         sampled_resource.declared_mip_levels != 1 || sampled_resource.in_mip_tail ||
         sampled_resource.srgb ||
         sampled_resource.depth_compare)
         return false;
     const uint32_t components = sampled_resource.num_components
         ? sampled_resource.num_components : 1u;
-    const VkFormat native_format =
+    const VkFormat sampled_native_format =
         native_storage_vk_format(sampled_resource.format, components);
-    if (native_format == VK_FORMAT_UNDEFINED) return false;
-    const ComputeImageCacheKey key = storage_image_cache_key(
-        sampled_resource, static_cast<uint32_t>(guest_bytes), native_format);
+    if (sampled_native_format == VK_FORMAT_UNDEFINED) return false;
+    prosper::gpu::ShaderResource storage_identity = sampled_resource;
+    if (cube_array_alias) storage_identity.img_dim = 5u; // exact producer DIM=2D_ARRAY identity
+    ComputeImageCacheKey key = storage_image_cache_key(
+        storage_identity, static_cast<uint32_t>(guest_bytes), sampled_native_format);
     VkImage image = VK_NULL_HANDLE;
-    if (!context->borrow_cached_image_for_graphics(key, image)) return false;
+    uint64_t producer_command_order = 0;
+    bool borrowed = context->borrow_cached_image_for_graphics(
+        key, image, producer_command_order);
+    // GTA V writes several full-resolution transition surfaces through integer storage images, then
+    // samples the same bits through normalized, Float32, or packed R11 graphics views. The geometry
+    // and allocation are identical; only the view's numeric interpretation differs. Retry the exact
+    // producer identity, whose image was created mutable, while returning the consumer format for
+    // its VkImageView. Do not generalize this to signed, sRGB, component-count, or size aliases.
+    const bool normalized_uint8_alias =
+        sampled_resource.format == prosper::gpu::DataFormat::Unorm8 &&
+        (components == 1 || components == 4);
+    const bool normalized_uint16_alias =
+        sampled_resource.format == prosper::gpu::DataFormat::Unorm16 && components == 1;
+    const bool float32_uint32_alias =
+        sampled_resource.format == prosper::gpu::DataFormat::Float32 && components == 1;
+    const bool packed_r11_uint32_alias =
+        sampled_resource.format == prosper::gpu::DataFormat::Float10_11_11 && components == 3;
+    if (!borrowed && (normalized_uint8_alias || normalized_uint16_alias ||
+                      float32_uint32_alias || packed_r11_uint32_alias)) {
+        if (normalized_uint8_alias)
+            storage_identity.format = prosper::gpu::DataFormat::Uint8;
+        else if (normalized_uint16_alias)
+            storage_identity.format = prosper::gpu::DataFormat::Uint16;
+        else if (float32_uint32_alias)
+            storage_identity.format = prosper::gpu::DataFormat::Uint32;
+        // Packed R11 retains its guest format identity: only its exact storage VkFormat is R32_UINT.
+        const VkFormat producer_format = native_storage_vk_format(
+            float32_uint32_alias || packed_r11_uint32_alias
+                ? prosper::gpu::DataFormat::Uint32 : storage_identity.format,
+            float32_uint32_alias || packed_r11_uint32_alias ? 1u : components);
+        key = storage_image_cache_key(
+            storage_identity, static_cast<uint32_t>(guest_bytes), producer_format);
+        borrowed = context->borrow_cached_image_for_graphics(
+            key, image, producer_command_order);
+    }
+    if (!borrowed) return false;
     try {
         auto lease = std::make_shared<BorrowedComputeImageLease>();
         lease->context = context;
@@ -9269,7 +9901,9 @@ bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampl
         import.width = sampled_resource.width;
         import.height = sampled_resource.height;
         import.depth = sampled_resource.depth;
-        import.native_format = static_cast<uint32_t>(native_format);
+        import.vertical_stack_layers = cube_array_alias ? sampled_resource.depth : 0u;
+        import.producer_command_order = producer_command_order;
+        import.native_format = static_cast<uint32_t>(sampled_native_format);
         import.layout = static_cast<uint32_t>(VK_IMAGE_LAYOUT_GENERAL);
         import.image = static_cast<void*>(image);
         import.device = static_cast<void*>(context->device);
@@ -9484,7 +10118,6 @@ void sampled_float16_to_unorm8_range(const uint8_t* source, uint32_t components,
         });
 }
 
-
 // TripBoundWitnessScope lives in trip_bound_witness.hpp so its save/restore contract can be
 // exercised by a regression test rather than only by a routed run.
 
@@ -9578,6 +10211,18 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
     const bool timing_enabled = timing_mode.measure;
     const auto timing_start = timing_enabled
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
+    g_perf_compute_gpu_timestamp_samples = 0;
+    g_perf_compute_gpu_device_ms = 0.0;
+    g_perf_compute_gpu_shader_ms = 0.0;
+    g_perf_compute_gpu_pre_ms = 0.0;
+    g_perf_compute_gpu_storage_copy_ms = 0.0;
+    g_perf_compute_gpu_compare_ms = 0.0;
+    g_perf_compute_gpu_restore_ms = 0.0;
+    g_perf_compute_setup_ms = 0.0;
+    g_perf_compute_pipeline_ms = 0.0;
+    g_perf_compute_dispatch_wait_ms = 0.0;
+    g_perf_compute_writeback_ms = 0.0;
+    g_perf_compute_cleanup_ms = 0.0;
     context.begin_write_watch_promotions();
     // Dispatches are independent PM4-order operations: one item failing (e.g. an image shape the
     // backend can't bind yet, #590) must not abort the rest of the batch — that would regress
@@ -9634,6 +10279,18 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
                 }
             }
             record.total_ms = elapsed;
+            record.gpu_timestamp_samples = g_perf_compute_gpu_timestamp_samples;
+            record.gpu_device_ms = g_perf_compute_gpu_device_ms;
+            record.gpu_shader_ms = g_perf_compute_gpu_shader_ms;
+            record.gpu_pre_ms = g_perf_compute_gpu_pre_ms;
+            record.gpu_storage_copy_ms = g_perf_compute_gpu_storage_copy_ms;
+            record.gpu_compare_ms = g_perf_compute_gpu_compare_ms;
+            record.gpu_restore_ms = g_perf_compute_gpu_restore_ms;
+            record.setup_ms = g_perf_compute_setup_ms;
+            record.pipeline_ms = g_perf_compute_pipeline_ms;
+            record.dispatch_wait_ms = g_perf_compute_dispatch_wait_ms;
+            record.writeback_ms = g_perf_compute_writeback_ms;
+            record.cleanup_ms = g_perf_compute_cleanup_ms;
             prosper::perf::interactive_performance_capture().record_compute(record);
         }
         if (timing_mode.log) {

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -243,7 +243,9 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
         (components == 1 && format == DataFormat::Uint32 &&
          target_format == LiveTargetPixelFormat::R32Uint) ||
         (components == 1 && format == DataFormat::Float32 &&
-         target_format == LiveTargetPixelFormat::R32Float);
+         target_format == LiveTargetPixelFormat::R32Float) ||
+        (components == 4 && format == DataFormat::Float32 &&
+         target_format == LiveTargetPixelFormat::Rgba32Float);
     // The renderer's RGBA8 fallback already stores the numeric UNORM value. Expanding each byte to
     // uint16 as byte*257 and reading R16_UNORM produces exactly byte/255 again. Vulkan performs
     // that UNORM-to-float conversion for normalized sampling and integer-coordinate OpImageFetch,
@@ -253,6 +255,20 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
         format == DataFormat::Unorm16 &&
         target_format == LiveTargetPixelFormat::Rgba8Unorm;
     return exact || equivalent_unorm_values;
+}
+
+bool sampled_rtt_snapshot_byte_compatible(
+    prosper::gpu::DataFormat format, uint32_t components,
+    prosper::gpu::LiveTargetPixelFormat target_format) {
+    using prosper::gpu::DataFormat;
+    using prosper::gpu::LiveTargetPixelFormat;
+    return (components == 1 &&
+            (format == DataFormat::Float32 || format == DataFormat::Uint32) &&
+            (target_format == LiveTargetPixelFormat::R32Float ||
+             target_format == LiveTargetPixelFormat::R32Uint)) ||
+        (components == 4 &&
+         (format == DataFormat::Float32 || format == DataFormat::Uint32) &&
+         target_format == LiveTargetPixelFormat::Rgba32Float);
 }
 
 namespace {
@@ -5882,7 +5898,9 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                          (r->format == DataFormat::Uint32 ||
                           r->format == DataFormat::Float32) && nc == 1) ||
                         (live_target.format == LiveTargetPixelFormat::R32Float &&
-                         r->format == DataFormat::Float32 && nc == 1);
+                         r->format == DataFormat::Float32 && nc == 1) ||
+                        (live_target.format == LiveTargetPixelFormat::Rgba32Float &&
+                         r->format == DataFormat::Float32 && nc == 4);
                     if (!compatible) {
                         // The same allocation can carry another target view before this compute
                         // operation (Astro Bot uses R8G8 and RGBA16F views at one base). A snapshot
@@ -6773,15 +6791,16 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                     const bool source_rg8 = source_layout == LiveTargetSourceLayout::Unorm8x2;
                     const bool source_r32 = source_layout == LiveTargetSourceLayout::Uint32x1;
                     const bool source_f32 = source_layout == LiveTargetSourceLayout::Float32x1;
+                    const bool source_f32x4 = source_layout == LiveTargetSourceLayout::Float32x4;
                     const bool exact_narrow_layout =
                         (source_r8 &&
                          (r8 || (sampled_uint8_native && sampled_components == 1))) ||
                         (source_rg8 &&
                          (sampled_unorm8x2 ||
                           (sampled_uint8_native && sampled_components == 2))) ||
-                        (source_r32 && sampled_components == 1 &&
-                         (sampled_float32_native || sampled_uint32_native)) ||
-                        (source_f32 && sampled_components == 1 && sampled_float32_native);
+                        ((source_r32 || source_f32 || source_f32x4) &&
+                         sampled_rtt_snapshot_byte_compatible(
+                             r->format, sampled_components, live_target.format));
                     // This is not redundant: the packed-view check above is written as
                     // `format == R11G11B10Float && <incompatible view>`, which for any NEW format
                     // is false and therefore RETAINS ownership. That predicate fails OPEN, so this

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -130,6 +130,18 @@ bool storage_image_materialize_raw_uvec4(
     uint32_t mip_tail_x, uint32_t mip_tail_y,
     uint32_t* channels, size_t channel_dwords);
 
+// Reverse the portable raw-uvec4 materialization after a writable Vulkan storage image has
+// completed. `channels` contains four 32-bit values per texel; the helper restores the descriptor's
+// compact guest format and then its linear, tiled-surface, mip-tail, or tiled-volume layout. The
+// destination must cover the complete footprint returned by storage_image_raw_uvec4_source_bytes.
+bool storage_image_writeback_raw_uvec4(
+    const uint32_t* channels, size_t channel_dwords,
+    prosper::gpu::DataFormat format, uint32_t components,
+    uint32_t width, uint32_t height, uint32_t depth, uint32_t tile_mode,
+    bool in_mip_tail, uint32_t mip_tail_bytes,
+    uint32_t mip_tail_x, uint32_t mip_tail_y,
+    uint8_t* destination, size_t destination_bytes);
+
 // A typed Vulkan storage image already exposes the guest format as exact row-major bytes. For a
 // tiled guest surface the tiler can therefore read the mapped staging image directly, unless a
 // poison-proving dispatch still needs a mutable linear copy to restore untouched texels.

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -44,6 +44,26 @@ constexpr bool compute_image_cache_default_eligible(
     return bytes >= compute_image_cache_default_minimum_bytes(image_class);
 }
 
+// Large portable-CFG modules are intentionally explicit: one guest instruction can become several
+// SPIR-V operations plus dispatcher state. Keep the 32K-word classification independently testable,
+// but optimize these modules by default. Disabling driver optimization reduced cold compile latency
+// on NVIDIA at the cost of turning GTA V's repeated 1440p dispatches from roughly 1.7 ms into 47-50
+// ms. PROSPER_COMPUTE_FAST_COMPILE_LARGE remains the diagnostic opt-out for investigations where
+// bounded first-use latency matters more than steady-state execution.
+constexpr bool compute_pipeline_is_large(size_t spirv_words) {
+    return spirv_words >= 32u * 1024u;
+}
+
+// Vulkan pipeline-cache blobs are driver-owned, but their fixed version-one prefix identifies the
+// exact vendor, device, and pipelineCacheUUID that may consume them. Validate that prefix ourselves
+// before passing persistent bytes to vkCreatePipelineCache: a stale driver cache is then a clean
+// miss rather than a startup failure. The UUID is passed as bytes to keep Vulkan types out of this
+// shared policy header and its unit tests.
+bool compute_pipeline_cache_blob_compatible(
+    const uint8_t* blob, size_t blob_bytes,
+    uint32_t vendor_id, uint32_t device_id,
+    const uint8_t* pipeline_cache_uuid, size_t uuid_bytes);
+
 // A sampled descriptor needs guest validation/conversion only when neither renderer authority path
 // supplied its pixels. Depth images can be imported from the persistent Vulkan DS cache even though
 // they deliberately have no color-RTT identity; that import must not fall through and snapshot stale
@@ -208,6 +228,15 @@ bool execute_live_compute_items(const std::vector<prosper::gpu::ComputeItem>& it
 // shared interface does not expose Vulkan types.
 struct LiveComputeImageImport {
     uint32_t width = 0, height = 0, depth = 0;
+    // Non-zero when `image` is a 2D-array result that a graphics cube descriptor must consume
+    // through prosper's established vertical-face-stack lowering. The renderer copies each source
+    // layer into one `width x (height * vertical_stack_layers)` sampled image on the GPU. Ordinary
+    // direct imports keep this zero.
+    uint32_t vertical_stack_layers = 0;
+    // Global PM4 command ordinal of the storage dispatch that produced this image. A graphics
+    // consumer can use it to merge a later renderer-owned attachment write without replacing the
+    // other layers with stale guest memory.
+    uint64_t producer_command_order = 0;
     uint32_t native_format = 0; // opaque VkFormat
     uint32_t layout = 0;        // opaque VkImageLayout; currently GENERAL
     void* image = nullptr;      // borrowed VkImage
@@ -221,6 +250,21 @@ struct LiveComputeImageImport {
 bool import_live_compute_storage_image(const prosper::gpu::ShaderResource& sampled_resource,
                                        uint64_t guest_bytes,
                                        LiveComputeImageImport& import);
+
+// Exact Vulkan format a graphics sampled descriptor must request when attempting to lease a
+// retained typed-storage result. Kept on the compute side so the publisher/importer and renderer
+// cannot grow independent format allowlists. The integer is an opaque VkFormat just like
+// LiveComputeImageImport::native_format; zero means the current graphics path must use guest bytes.
+uint32_t live_compute_graphics_import_native_format(
+    prosper::gpu::DataFormat format, uint32_t components);
+
+// Exact guest-byte identity used to look up a retained storage image from a graphics sampled
+// descriptor. Ordinary decoded textures already know their source span. A six-face R16 cube is
+// different: the ordinary decoder reports one face, while the compute producer owns the complete
+// 2D-array allocation. Returning the full descriptor footprint here keeps both cache keys equal.
+uint64_t live_compute_graphics_import_guest_bytes(
+    const prosper::gpu::ShaderResource& sampled_resource,
+    uint64_t decoded_source_bytes);
 
 // Monotonic diagnostic count of writable-buffer results whose exact GPU comparison avoided a host
 // mapping/scan. Exposed so the production-backend test can prove that optimization path executes.
@@ -297,5 +341,10 @@ void register_live_compute();
 // Publish the stable timing selector's final seen/matched verdict. Idempotent with the ordinary
 // destructor fallback; prosper-app calls this before its deliberate _Exit teardown path.
 void report_live_compute_timing_selector_summary();
+
+// Persist the driver pipeline cache without tearing the compute context down. prosper-app cannot
+// run C++/Vulkan destructors while its guest thread is detached, so its deliberate _Exit path calls
+// this explicitly after requesting the guest stop.
+void flush_live_compute_pipeline_cache();
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/live/live_compute.hpp
+++ b/prosper/frontends/shared/live/live_compute.hpp
@@ -160,6 +160,14 @@ bool direct_sampled_rtt_compatible(prosper::gpu::DataFormat format, uint32_t com
                                    prosper::gpu::LiveTargetPixelFormat target_format,
                                    bool float_sampled_values);
 
+// Whether a CPU snapshot of a renderer-owned target can be copied byte-for-byte into the sampled
+// image format requested by a compute descriptor. Unlike direct binding, this may admit a
+// same-width typed alias (for example R32_SFLOAT -> R32_UINT): the snapshot is uploaded into a new
+// image with the descriptor's exact Vulkan type, so no incompatible image view is created.
+bool sampled_rtt_snapshot_byte_compatible(
+    prosper::gpu::DataFormat format, uint32_t components,
+    prosper::gpu::LiveTargetPixelFormat target_format);
+
 // Reconstruct a packed R11G11B10 sampled surface from the renderer's canonical color snapshot.
 // The renderer keeps float targets as RGBA16F and ordinary targets as RGBA8; compute descriptors
 // can subsequently alias that same target as GFX10 10_11_11_FLOAT. This conversion restores the

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -416,6 +416,10 @@ bool capture_color_format(VkFormat format, prosper::gpu::GpuCaptureColorFormat& 
         captured = prosper::gpu::GpuCaptureColorFormat::R8Unorm;
     else if (format == VK_FORMAT_R32_UINT)
         captured = prosper::gpu::GpuCaptureColorFormat::R32Uint;
+    else if (format == VK_FORMAT_R32_SFLOAT)
+        captured = prosper::gpu::GpuCaptureColorFormat::R32Float;
+    else if (format == VK_FORMAT_R8G8_UNORM)
+        captured = prosper::gpu::GpuCaptureColorFormat::Rg8Unorm;
     else
         return false;
     return true;
@@ -430,6 +434,10 @@ VkFormat replay_color_format(prosper::gpu::GpuCaptureColorFormat format) {
         return VK_FORMAT_R8_UNORM;
     if (format == prosper::gpu::GpuCaptureColorFormat::R32Uint)
         return VK_FORMAT_R32_UINT;
+    if (format == prosper::gpu::GpuCaptureColorFormat::R32Float)
+        return VK_FORMAT_R32_SFLOAT;
+    if (format == prosper::gpu::GpuCaptureColorFormat::Rg8Unorm)
+        return VK_FORMAT_R8G8_UNORM;
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
@@ -3108,7 +3116,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                       r.format, r.num_components ? r.num_components : 1u)
                                 : 0u;
                         const bool portable_storage_shape =
-                            !writable_storage_image && !r.compression_enabled &&
+                            !r.compression_enabled &&
                             !reflected_binding->image_arrayed &&
                             !reflected_binding->image_multisampled &&
                             ((reflected_binding->image_dim == 1u && r.img_dim == 1u) ||
@@ -4713,7 +4721,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 ? copy_resource(
                                       source.data(), sampled_source_addr, source_bytes)
                                 : 0u;
-                            decoded = decoded && got == source_bytes &&
+                            const bool materialized = decoded && got == source_bytes &&
                                 storage_image_materialize_raw_uvec4(
                                     source.data(), got, r.format,
                                     r.num_components ? r.num_components : 1u,
@@ -4722,7 +4730,20 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     r.mip_tail_x, r.mip_tail_y,
                                 reinterpret_cast<uint32_t*>(texture_pixels.data()),
                                 texture_pixels.size() / sizeof(uint32_t));
+                            decoded = decoded && materialized;
                             if (!decoded) {
+                                static std::set<std::tuple<uint32_t, uint32_t, uint32_t>> reported;
+                                if (reported.emplace(fr.set, fr.binding,
+                                                     static_cast<uint32_t>(r.format)).second)
+                                    std::fprintf(stderr,
+                                        "[render] storage-image materialize failed: set=%u binding=%u "
+                                        "source=%zu got=%zu output=%zu fmt=%u comps=%u "
+                                        "extent=%ux%ux%u tile=%u tail=%u contract=%u\n",
+                                        fr.set, fr.binding, source_bytes, got,
+                                        texture_pixels.size(), static_cast<unsigned>(r.format),
+                                        r.num_components, tw, th, materialize_depth,
+                                        materialize_tile_mode, r.in_mip_tail ? 1u : 0u,
+                                        fr.storage_image_contract_valid ? 1u : 0u);
                                 fr.storage_image_contract_valid = false;
                                 std::fill(texture_pixels.begin(), texture_pixels.end(), 0);
                             }
@@ -5466,6 +5487,88 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         // overlapping submit-local decode and let the next pass rebuild it
                                         // from the now-current guest bytes.
                                         if (guest_addr) {
+                                            for (auto it = decoded_textures.begin();
+                                                 it != decoded_textures.end();) {
+                                                const uint64_t cached_addr = it->first.gpu_addr;
+                                                const uint64_t cached_bytes = std::max<uint64_t>(
+                                                    std::max<uint64_t>(it->first.size,
+                                                                       it->first.source_span_bytes),
+                                                    1u);
+                                                const bool overlaps = cached_addr <= guest_addr
+                                                    ? guest_addr - cached_addr < cached_bytes
+                                                    : cached_addr - guest_addr < guest_bytes;
+                                                if (overlaps) {
+                                                    if (it->second.texstore_slot <
+                                                        texstore_pinned.size())
+                                                        texstore_pinned[
+                                                            it->second.texstore_slot] = false;
+                                                    it = decoded_textures.erase(it);
+                                                } else {
+                                                    ++it;
+                                                }
+                                            }
+                                        }
+                                    };
+                            }
+                        }
+                        if (portable_raw_uvec4_storage && writable_storage_image &&
+                            fr.storage_image_contract_valid) {
+                            const bool tiled = prosper::gpu::tile_mode_is_tiled(r.tile_mode) &&
+                                !PROSPER_ENV_VALUE("PROSPER_NODETILE");
+                            const uint32_t writeback_tile_mode = tiled ? r.tile_mode : 0u;
+                            const uint32_t writeback_depth = is_volume ? r.depth : 1u;
+                            const uint32_t components =
+                                r.num_components ? r.num_components : 1u;
+                            const size_t guest_bytes = storage_image_raw_uvec4_source_bytes(
+                                r.format, components, tw, th, writeback_depth,
+                                writeback_tile_mode, r.in_mip_tail, r.mip_tail_bytes);
+                            const size_t texels = static_cast<size_t>(tw) * th * writeback_depth;
+                            const size_t expanded_bytes = texels <= SIZE_MAX / 16u
+                                ? texels * 16u : 0u;
+                            const bool backing_fits = guest_bytes && expanded_bytes &&
+                                (!r.host_data || guest_bytes <= r.host_data_size);
+                            if (!backing_fits) {
+                                fr.storage_image_contract_valid = false;
+                            } else {
+                                const uint64_t guest_addr = r.gpu_addr;
+                                uint8_t* const replay_data = r.host_data;
+                                const auto format = r.format;
+                                const bool in_mip_tail = r.in_mip_tail;
+                                const uint32_t mip_tail_bytes = r.mip_tail_bytes;
+                                const uint32_t mip_tail_x = r.mip_tail_x;
+                                const uint32_t mip_tail_y = r.mip_tail_y;
+                                fr.storage_image_writeback =
+                                    [guest_addr, replay_data, guest_bytes, expanded_bytes,
+                                     format, components, tw, th, writeback_depth,
+                                     writeback_tile_mode, in_mip_tail, mip_tail_bytes,
+                                     mip_tail_x, mip_tail_y](const uint8_t* pixels, size_t bytes) {
+                                        if (!pixels || bytes != expanded_bytes) return;
+                                        uint8_t* destination = replay_data;
+                                        if (!destination) {
+                                            if (guest_bytes > UINT32_MAX ||
+                                                !prosper::gpu::guest_writable(
+                                                    guest_addr,
+                                                    static_cast<uint32_t>(guest_bytes)))
+                                                return;
+                                            prosper::host::guest_write_watch_notify_host_write(
+                                                guest_addr, guest_bytes);
+                                            destination = reinterpret_cast<uint8_t*>(
+                                                static_cast<uintptr_t>(guest_addr));
+                                        }
+                                        if (!storage_image_writeback_raw_uvec4(
+                                                reinterpret_cast<const uint32_t*>(pixels),
+                                                bytes / sizeof(uint32_t), format, components,
+                                                tw, th, writeback_depth, writeback_tile_mode,
+                                                in_mip_tail, mip_tail_bytes,
+                                                mip_tail_x, mip_tail_y,
+                                                destination, guest_bytes))
+                                            return;
+                                        if (guest_addr) {
+                                            prosper::gpu::set_guest_gpu_write_origin(
+                                                "renderer-writeback(portable-uvec4)");
+                                            prosper::gpu::notify_guest_gpu_write(
+                                                guest_addr, guest_bytes);
+                                            prosper::gpu::set_guest_gpu_write_origin(nullptr);
                                             for (auto it = decoded_textures.begin();
                                                  it != decoded_textures.end();) {
                                                 const uint64_t cached_addr = it->first.gpu_addr;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -100,6 +100,9 @@ struct RttSurf {
     std::array<float, 4> uniform_color{};
     uint32_t w = 0, h = 0;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
+    // Raw guest CB_COLOR format before backend_color_format() canonicalizes the Vulkan attachment.
+    // Consumers need this to compose their T# DST_SEL with the host image's component order.
+    VkFormat guest_format = VK_FORMAT_UNDEFINED;
     bool gpu_valid = false;
     // A color target can be cleared by a compute write to its DCC metadata rather than by a
     // color-plane write. Remember the sampled descriptor's metadata range so that write can
@@ -424,6 +427,10 @@ bool capture_color_format(VkFormat format, prosper::gpu::GpuCaptureColorFormat& 
         captured = prosper::gpu::GpuCaptureColorFormat::Rg8Unorm;
     else if (format == VK_FORMAT_R32G32B32A32_SFLOAT)
         captured = prosper::gpu::GpuCaptureColorFormat::Rgba32Float;
+    else if (format == VK_FORMAT_R16G16_SFLOAT)
+        captured = prosper::gpu::GpuCaptureColorFormat::Rg16Float;
+    else if (format == VK_FORMAT_R16_SFLOAT)
+        captured = prosper::gpu::GpuCaptureColorFormat::R16Float;
     else
         return false;
     return true;
@@ -444,6 +451,10 @@ VkFormat replay_color_format(prosper::gpu::GpuCaptureColorFormat format) {
         return VK_FORMAT_R8G8_UNORM;
     if (format == prosper::gpu::GpuCaptureColorFormat::Rgba32Float)
         return VK_FORMAT_R32G32B32A32_SFLOAT;
+    if (format == prosper::gpu::GpuCaptureColorFormat::Rg16Float)
+        return VK_FORMAT_R16G16_SFLOAT;
+    if (format == prosper::gpu::GpuCaptureColorFormat::R16Float)
+        return VK_FORMAT_R16_SFLOAT;
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
@@ -488,6 +499,36 @@ std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
             rgba[texel * 4 + 0] = pixels[texel * 2 + 0];
             rgba[texel * 4 + 1] = pixels[texel * 2 + 1];
             rgba[texel * 4 + 2] = 0;
+            rgba[texel * 4 + 3] = 255;
+        }
+        return rgba;
+    }
+    if (format == VK_FORMAT_R16G16_SFLOAT && pixels.size() == texels * 4) {
+        std::vector<uint8_t> rgba(texels * 4);
+        for (size_t texel = 0; texel < texels; ++texel) {
+            for (uint32_t channel = 0; channel < 2; ++channel) {
+                uint16_t half = 0;
+                std::memcpy(&half, pixels.data() + texel * 4 + channel * 2, sizeof(half));
+                const float value = prosper::gpu::half_to_float(half);
+                rgba[texel * 4 + channel] = !std::isfinite(value) || value <= 0.0f ? 0
+                    : value >= 1.0f ? 255 : static_cast<uint8_t>(value * 255.0f + 0.5f);
+            }
+            rgba[texel * 4 + 2] = 0;
+            rgba[texel * 4 + 3] = 255;
+        }
+        return rgba;
+    }
+    if (format == VK_FORMAT_R16_SFLOAT && pixels.size() == texels * 2) {
+        std::vector<uint8_t> rgba(texels * 4);
+        for (size_t texel = 0; texel < texels; ++texel) {
+            uint16_t half = 0;
+            std::memcpy(&half, pixels.data() + texel * 2, sizeof(half));
+            const float value = prosper::gpu::half_to_float(half);
+            const uint8_t visible = !std::isfinite(value) || value <= 0.0f ? 0
+                : value >= 1.0f ? 255 : static_cast<uint8_t>(value * 255.0f + 0.5f);
+            rgba[texel * 4 + 0] = visible;
+            rgba[texel * 4 + 1] = visible;
+            rgba[texel * 4 + 2] = visible;
             rgba[texel * 4 + 3] = 255;
         }
         return rgba;
@@ -1474,6 +1515,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             published.w = write.width;
             published.h = write.height;
             published.format = format;
+            published.guest_format = format;
             published.gpu_valid = true;
         });
     prosper::gpu::set_live_target_byte_range_reader(
@@ -1543,6 +1585,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             RttSurf& surface = g_rtt[seed.guest_addr];
             surface.w = seed.width; surface.h = seed.height;
             surface.format = format;
+            // Capture seeds contain canonical backend pixels. Older capture versions do not carry
+            // the producing CB_COLOR order, so retain the exact format they do name.
+            surface.guest_format = format;
             surface.rgba = std::make_shared<const std::vector<uint8_t>>(seed.rgba);
             surface.has_uniform_color = false;
             surface.gpu_valid = false;
@@ -5959,8 +6004,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     };
                             }
                         }
-                        // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples the
-                        // way the game asked instead of a fixed LINEAR/clamp sampler (#<sampler-fix>).
+                        // Carry the decoded S# sampler state (filter/wrap/mip) so the pipeline samples
+                        // the way the game asked instead of using fixed LINEAR/clamp state.
                         fr.mag_filter = r.mag_filter; fr.min_filter = r.min_filter; fr.mip_filter = r.mip_filter;
                         // Draw/binding-scoped sampler A/B. This shares TESTTEX's selectors but leaves
                         // the sampled pixels intact, isolating descriptor filtering from texture content.
@@ -5998,6 +6043,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             fr.swizzle[0]=4; fr.swizzle[1]=5; fr.swizzle[2]=6; fr.swizzle[3]=7;
                         }
                         else { for (int k=0;k<4;k++) fr.swizzle[k] = r.swizzle[k]; }
+                        if (resource_rtt_hit && live_rtt != g_rtt.end())
+                            fr.render_target_guest_format = live_rtt->second.guest_format;
                         // PROSPER_ALPHA1: force the sampled alpha to constant 1 (opaque). Diagnostic for a
                         // black scene whose textures decode to real RGB but composite to nothing — if the
                         // level appears with this, the alpha channel (decode or DST_SEL swizzle) is the bug (#300).
@@ -7672,6 +7719,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.w = gw;
                         surface.h = gh;
                         surface.format = pass_format;
+                        surface.guest_format = pass.empty()
+                            ? pass_format
+                            : static_cast<VkFormat>(
+                                  prosper::frontend::mrt_raw_format(*pass.front(), 0));
                         surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                         surface.gpu_valid = prosper::test::find_persistent_color_target(
@@ -7714,6 +7765,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.w = gw;
                         surface.h = gh;
                         surface.format = pass_format;
+                        surface.guest_format = pass.empty()
+                            ? pass_format
+                            : static_cast<VkFormat>(
+                                  prosper::frontend::mrt_raw_format(*pass.front(), 0));
                         surface.gpu_valid = false;
                         surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
@@ -7772,6 +7827,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.w = gw;
                         surface.h = gh;
                         surface.format = pass_formats[slot];
+                        surface.guest_format = pass.empty()
+                            ? pass_formats[slot]
+                            : static_cast<VkFormat>(
+                                  prosper::frontend::mrt_raw_format(*pass.front(), slot));
                         surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                         // Any slot with a retained target is GPU-valid, not only slot 1. The
@@ -8447,6 +8506,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         RttSurf& s = g_rtt[tgt];
                         s.rgba = selected_pixels; s.w = w; s.h = h;
                         s.format = VK_FORMAT_R8G8B8A8_UNORM; s.gpu_valid = false;
+                        s.guest_format = items.empty()
+                            ? VK_FORMAT_R8G8B8A8_UNORM
+                            : static_cast<VkFormat>(
+                                  prosper::frontend::mrt_raw_format(items.front(), 0));
                         s.has_uniform_color = false;
                         s.dcc_metadata_dirty = false;
                         prosper::test::invalidate_persistent_color_target(tgt);

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -628,6 +628,9 @@ struct TextureDecodeKey {
     bool reflected_image_arrayed = false;
     bool reflected_image_multisampled = false;
     bool reflected_image_writable = false;
+    // Renderer-owned layers that are newer than the guest/compute backing participate in the
+    // decoded identity. This is zero for ordinary textures.
+    uint64_t renderer_overlay_version = 0;
     bool operator==(const TextureDecodeKey&) const = default;
 };
 
@@ -658,6 +661,7 @@ struct TextureDecodeKeyHash {
         mix(key.reflected_image_arrayed);
         mix(key.reflected_image_multisampled);
         mix(key.reflected_image_writable);
+        mix(key.renderer_overlay_version);
         return hash;
     }
 };
@@ -1919,6 +1923,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 uint64_t tex_rtt_n = 0, tex_compute_n = 0, tex_local_n = 0;
                 uint64_t tex_persist_hit_n = 0, tex_persist_reuse_n = 0, tex_persist_miss_n = 0;
                 uint64_t tex_other_n = 0;
+                double tex_other_slowest_ms = 0;
+                uint64_t tex_other_addr = 0, tex_other_source_bytes = 0;
+                uint32_t tex_other_width = 0, tex_other_height = 0, tex_other_depth = 0;
+                uint32_t tex_other_format = 0, tex_other_components = 0;
+                uint32_t tex_other_tile_mode = 0, tex_other_img_dim = 0, tex_other_class = 0;
+                bool tex_other_compute_candidate = false;
+                bool tex_other_persistent_candidate = false;
+                bool tex_other_compressed = false, tex_other_depth_compare = false;
+                bool tex_other_host_backed = false;
                 // Exhaustive partition of build_resources_ms, the frontend materialiser (#2215).
                 // It had two named leaves -- texture_ms and buffer_ms, both from INSIDE build_R --
                 // covering 10.2 of 48.95 ms on a Blue Prince gameplay submit, with no assertion
@@ -1941,6 +1954,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // continues before reaching the build contributes to neither and lands in the
                 // residual, which is correct -- and visible, rather than folded into a leaf.
                 double pass_pre_ms = 0, pass_post_ms = 0;
+                double post_stats_ms = 0, post_slot0_ms = 0, post_mrt_ms = 0,
+                       post_rest_ms = 0;
                 // pre+post measured 0.23 ms of a 43.85 ms pass_control, so the cost is NOT the
                 // per-group work either side of the measured pair. head/tail bound the two regions
                 // outside the group loop. `tail` subtracts the build_resources+backend the tail
@@ -1999,7 +2014,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             static thread_local std::vector<RttTimingRecord> pending_rtt_timing;
             const bool perf_capture_timing =
                 prosper::perf::interactive_performance_capture().detailed_timing_active();
-            const bool timing_log_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr;
+            const bool timing_capture_only =
+                getenv("PROSPER_RENDER_TIMING_CAPTURE_ONLY") != nullptr;
+            const bool timing_log_enabled = getenv("PROSPER_RENDER_TIMING") != nullptr &&
+                (!timing_capture_only || perf_capture_timing);
             const prosper::frontend::PerformanceTimingMode timing_mode =
                 prosper::frontend::performance_timing_mode(timing_log_enabled,
                                                             perf_capture_timing);
@@ -2013,7 +2031,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             // WITHOUT changing that -- which is why it is the better fix here than caching.
             const char* const render_timing_env = getenv("PROSPER_RENDER_TIMING");
             const bool render_timing_detail =
-                render_timing_env && strcmp(render_timing_env, "detail") == 0;
+                ((render_timing_env && strcmp(render_timing_env, "detail") == 0 &&
+                  (!timing_capture_only || perf_capture_timing)) ||
+                 (perf_capture_timing &&
+                  getenv("PROSPER_RENDER_TIMING_DETAIL_CAPTURE") != nullptr));
             // render_runner.h cannot depend on the app capture singleton: it is also compiled into
             // standalone Vulkan tests. This thread-local scope activates its backend clocks only
             // inside this production callback and restores the prior state on every return path.
@@ -2093,7 +2114,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 //                               the payloads are genuinely distinct; the fix is not
                 //                               dedup at all but not staging through a mapped copy
                 //   refs >> memo_hits        -> repeat references within one call are being missed
-                if (timing_enabled) {
+                if (timing_mode.log) {
                     // CUMULATIVE, not a per-call snapshot. The first draft printed one call's
                     // numbers at diag_should_print's ordinals (first 64, then powers of two) --
                     // which is a UNIFORM sample of a heavily skewed distribution, so it could not
@@ -2584,6 +2605,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         ? RenderClock::now() : RenderClock::time_point{};
                     bool resource_rtt_hit = false;
                     bool resource_compute_image_hit = false;
+                    bool resource_compute_image_candidate = false;
+                    bool resource_compute_depth_hybrid = false;
+                    uint64_t resource_compute_producer_order = 0;
+                    uint32_t resource_compute_depth_overlay_mask = 0;
                     bool resource_local_reuse = false;
                     bool resource_persistent_hit = false;
                     bool resource_persistent_submit_reuse = false;
@@ -2752,7 +2777,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             ? prosper::gpu::tiled_msaa_surface_bytes(
                                   tw, th, r.tile_mode, 4u, r.sample_count)
                             : 0u;
-                        const TextureDecodeKey decode_key{
+                        TextureDecodeKey decode_key{
                             r.gpu_addr, static_cast<uint64_t>(reinterpret_cast<uintptr_t>(r.host_data)),
                             r.host_data_size, r.size, msaa_tiled_source_span,
                             static_cast<uint32_t>(r.cls),
@@ -3035,8 +3060,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             return v > 0 ? static_cast<uint32_t>(v) : 1u;
                         }();
                         // Deferred RTT readback (#1284): a GPU-resident target consumed in a way the
-                        // direct GPU bind below cannot serve (extent mismatch, feedback into its own
-                        // pass, storage image) materializes its CPU copy here on demand. The producer
+                        // GPU bind below cannot serve (extent mismatch or storage image) materializes
+                        // its CPU copy here on demand. Exact 2D attachment feedback is served by the
+                        // backend's prior-version GPU snapshot rather than by a synchronous readback.
+                        // The producer
                         // ran in an earlier batch — same-batch CPU consumers force the eager readback
                         // at defer time — so the queue-ordered copy reads current pixels.
                         if (live_rtt != g_rtt.end() && live_gpu_targets && r.img_dim != 2u &&
@@ -3058,7 +3085,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 prosper::test::find_persistent_color_target(
                                     sampled_source_addr, surface.w, surface.h,
                                     surface.format) != nullptr,
-                                mrt_format_defined);
+                                mrt_format_defined,
+                                /*feedback_copy_supported=*/true);
                             const VkFormat surface_format =
                                 prosper::test::backend_color_format(surface.format);
                             const uint32_t surface_bpp =
@@ -3136,7 +3164,6 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
                                 normalized_sampling) &&
-                            !draw_binds_color_target(draw, sampled_source_addr, tw, th) &&
                             prosper::test::find_persistent_color_target(
                                 sampled_source_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
@@ -3211,6 +3238,31 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         }
                         const bool is_cube = r.img_dim == 3u;   // CUBE: six faces stacked vertically (#273)
                         const bool is_volume = r.img_dim == 2u;
+                        // GTA V retains each shadow-cube face as a renderer-owned D32 image, then
+                        // samples the cube through a UNORM16 descriptor. Guest memory is not the
+                        // authority for these pixels. Select the complete six-face generation now
+                        // and include it in the decode identity; unchanged cubes can then reuse the
+                        // already quantized vertical stack without six synchronous depth readbacks.
+                        prosper::test::PersistentDsCubeSelection retained_depth_cube;
+                        bool retained_depth_cube_cache_candidate = false;
+                        if (is_cube && r.depth == 6u &&
+                            r.format == prosper::gpu::DataFormat::Unorm16 &&
+                            r.num_components == 1u && r.cls == RC::Texture && !r.host_data &&
+                            !has_live_rtt && !has_ds_live && !fr.is_storage_image &&
+                            prosper::test::is_retained_ds_plane(r.gpu_addr)) {
+                            if (r.layer_stride_bytes)
+                                prosper::test::note_ds_layer_stride(
+                                    r.gpu_addr, tw, th, r.layer_stride_bytes);
+                            retained_depth_cube =
+                                prosper::test::select_persistent_ds_cube_depth(
+                                    r.gpu_addr, tw, th);
+                            retained_depth_cube_cache_candidate =
+                                retained_depth_cube.present_mask == 0x3fu &&
+                                retained_depth_cube.overlay_version != 0;
+                            if (retained_depth_cube_cache_candidate)
+                                decode_key.renderer_overlay_version =
+                                    retained_depth_cube.overlay_version;
+                        }
                         const uint32_t persistent_pitch = PROSPER_ENV_VALUE("PROSPER_PITCH")
                             ? static_cast<uint32_t>(atoi(getenv("PROSPER_PITCH"))) : 0;
                         const uint32_t persistent_bc_block_bytes =
@@ -3245,6 +3297,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         const bool persistent_fp32_texture =
                             r.format == prosper::gpu::DataFormat::Float32 &&
                             (r.num_components == 1 || r.num_components == 2 || r.num_components == 4);
+                        // Exact single-channel integer compute outputs may be consumed immediately
+                        // by graphics. Their guest bytes and native Vulkan texels have the same
+                        // width, so the existing submit journal can authorize a device-local image
+                        // lease instead of a writeback -> detile -> upload round trip.
+                        const bool persistent_uint8_texture =
+                            r.format == prosper::gpu::DataFormat::Uint8 &&
+                            r.num_components == 1;
+                        const bool persistent_uint32_texture =
+                            r.format == prosper::gpu::DataFormat::Uint32 &&
+                            r.num_components == 1;
                         // Packed 32-bit sampled formats are also pure decode inputs.  Keeping their
                         // decoded pixels is especially important for full-resolution HDR intermediates:
                         // unpacking R11G11B10F scalar-by-scalar on every callback otherwise dominates an
@@ -3275,13 +3337,22 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         const bool persistent_format_supported =
                             persistent_unorm8_texture || persistent_fp16_texture ||
                             persistent_unorm16_texture || persistent_fp32_texture ||
+                            persistent_uint8_texture || persistent_uint32_texture ||
                             persistent_packed32_texture ||
                             (persistent_bc_block_bytes != 0 && !is_volume);
+                        // GTA V's five shadow cubes are ordinary tiled Z16 allocations. The fallback
+                        // decoder below reads all six faces from one exact descriptor footprint, so
+                        // unlike the broad non-BC cube class that regressed Plucky Squire this one
+                        // narrow shape can use exact-byte validation safely.
+                        const bool exact_unorm16_cube = is_cube && r.depth == 6u &&
+                            persistent_unorm16_texture && r.num_components == 1u &&
+                            !r.compression_enabled;
                         const bool persistent_sampled_texture = texture_decode_cache_candidate(
                             has_live_rtt_authority, has_ds_live, r.host_data != nullptr, r.img_dim,
                             r.cls == RC::Texture, persistent_format_supported,
-                            persistent_bc_block_bytes != 0);
-                        resource_persistent_candidate = persistent_sampled_texture;
+                            persistent_bc_block_bytes != 0, exact_unorm16_cube);
+                        resource_persistent_candidate = persistent_sampled_texture ||
+                            retained_depth_cube_cache_candidate;
                         const bool persistent_source_is_tiled =
                             persistent_sampled_texture && !PROSPER_ENV_VALUE("PROSPER_NODETILE") &&
                             prosper::gpu::tile_mode_is_tiled(r.tile_mode);
@@ -3463,11 +3534,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                              (!PROSPER_ENV_VALUE("PROSPER_DETILE") || atoi(PROSPER_ENV_VALUE("PROSPER_DETILE")) == 0));
                         const size_t persistent_base_source_size = [&] {
                             if (!persistent_sampled_texture) return size_t{0};
+                            if (is_cube)
+                                return layered_cube_source_size(
+                                    persistent_bc_block_bytes != 0 || exact_unorm16_cube,
+                                    sampled_source_addr,
+                                    prosper::gpu::gpu_capture_resource_footprint(r));
                             if (persistent_bc_block_bytes) {
-                                if (is_cube)
-                                    return block_compressed_cube_source_size(
-                                        true, sampled_source_addr,
-                                        prosper::gpu::gpu_capture_resource_footprint(r));
                                 const uint32_t bw = (tw + 3) / 4;
                                 const uint32_t bh = (th + 3) / 4;
                                 return persistent_source_is_tiled
@@ -3488,7 +3560,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     : static_cast<size_t>(tw) * th *
                                           (is_volume ? r.depth : 1u) * 4u;
                             // fp32 sources are 4 B/component, fp16/unorm16 are 2, and unorm8 is 1.
-                            const uint32_t source_component_bytes = persistent_fp32_texture ? 4u
+                            const uint32_t source_component_bytes =
+                                (persistent_fp32_texture || persistent_uint32_texture) ? 4u
                                 : ((persistent_fp16_texture || persistent_unorm16_texture) ? 2u : 1u);
                             const uint32_t source_bpt = r.num_components * source_component_bytes;
                             if (persistent_source_is_tiled)
@@ -3542,33 +3615,38 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         resource_texture_source_bytes = persistent_source_size;
                         // A successful typed-storage compute dispatch may still own this exact
                         // sampled image on the shared Vulkan device. Prefer that image only for the
-                        // two native formats the graphics backend preserves today. The compute cache
+                        // exact native formats the graphics backend preserves today. The compute cache
                         // independently requires the complete descriptor key plus a current-submit
                         // journal or page-watch proof; a miss falls through to the existing exact
                         // guest-byte decode/cache path.
                         prosper::frontend::LiveComputeImageImport compute_image_import;
-                        VkFormat compute_image_format = VK_FORMAT_UNDEFINED;
-                        if (r.format == prosper::gpu::DataFormat::Float16 &&
-                            r.num_components == 4)
-                            compute_image_format = VK_FORMAT_R16G16B16A16_SFLOAT;
-                        else if (r.format == prosper::gpu::DataFormat::Float10_11_11 &&
-                                 r.num_components == 3)
-                            compute_image_format = VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+                        const VkFormat compute_image_format = static_cast<VkFormat>(
+                            prosper::frontend::live_compute_graphics_import_native_format(
+                                r.format, r.num_components));
+                        // A cube decoder's ordinary source span covers one face, while its retained
+                        // Uint16 2D-array producer is keyed by all six. Keep that exception beside
+                        // the importer; ordinary decoded formats continue to use the exact span the
+                        // persistent cache validates.
+                        const uint64_t compute_image_guest_bytes =
+                            prosper::frontend::live_compute_graphics_import_guest_bytes(
+                                r, persistent_source_size);
                         const bool compute_image_shape =
                             (r.img_dim == 1u && r.depth == 1u) ||
-                            (r.img_dim == 2u && r.depth != 0u);
+                            (r.img_dim == 2u && r.depth != 0u) ||
+                            (r.img_dim == 3u && r.depth == 6u);
                         const bool compute_image_candidate =
                             !PROSPER_ENV_VALUE("PROSPER_NO_DIRECT_COMPUTE_IMAGE_BIND") &&
                             !has_live_rtt && !has_ds_live && r.cls == RC::Texture &&
                             compute_image_shape && !r.in_mip_tail &&
                             r.declared_mip_levels == 1u && !r.srgb &&
                             !r.depth_compare && !r.host_data &&
-                            persistent_source_size &&
+                            compute_image_guest_bytes &&
                             (!r.compression_enabled || persistent_dcc_uncompressed) &&
                             compute_image_format != VK_FORMAT_UNDEFINED;
+                        resource_compute_image_candidate = compute_image_candidate;
                         if (compute_image_candidate &&
                             prosper::frontend::import_live_compute_storage_image(
-                                r, persistent_source_size, compute_image_import)) {
+                                r, compute_image_guest_bytes, compute_image_import)) {
                             const prosper::test::RenderVkCtx& render_context =
                                 prosper::test::render_vk_ctx();
                             resource_compute_image_hit = compute_image_import.valid() &&
@@ -3581,19 +3659,51 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     static_cast<void*>(render_context.dev);
                             if (!resource_compute_image_hit) compute_image_import = {};
                         }
+                        if (resource_compute_image_hit &&
+                            compute_image_import.vertical_stack_layers == 6u) {
+                            // The compute image is the exact five-face copy result. A later graphics
+                            // span can render the remaining face into a retained D32 attachment at
+                            // the same guest cube address. Merge only attachment writes ordered
+                            // after this producer; older retained faces are precisely what compute
+                            // replaced and must not win merely because they still reside in cache.
+                            if (r.layer_stride_bytes)
+                                prosper::test::note_ds_layer_stride(
+                                    r.gpu_addr, tw, th, r.layer_stride_bytes);
+                            const auto overlay =
+                                prosper::test::select_persistent_ds_cube_depth_after(
+                                    r.gpu_addr, tw, th,
+                                    compute_image_import.producer_command_order);
+                            if (overlay.present_mask) {
+                                resource_compute_depth_hybrid = true;
+                                resource_compute_producer_order =
+                                    compute_image_import.producer_command_order;
+                                resource_compute_depth_overlay_mask = overlay.present_mask;
+                                decode_key.renderer_overlay_version = overlay.overlay_version;
+                                compute_image_import = {}; // release the lease; CPU builds the hybrid
+                                resource_compute_image_hit = false;
+                            }
+                        }
                         auto copy_persistent_source = [&](uint8_t* dst, size_t bytes) {
                             return persistent_dcc_fast_clear
                                 ? copy_dcc_metadata(dst, bytes)
                                 : copy_resource(dst, sampled_source_addr, bytes);
                         };
-                        const bool persistent_cache_eligible =
+                        const bool guest_persistent_cache_eligible =
                             persistent_texture_decode_cache_eligible(
-                                persistent_sampled_texture, resource_compute_image_hit,
+                                persistent_sampled_texture,
+                                resource_compute_image_hit || resource_compute_depth_hybrid,
                                 fr.is_storage_image,
                                 PROSPER_ENV_VALUE("PROSPER_NO_TEXTURE_DECODE_CACHE") != nullptr,
                                 !r.compression_enabled || persistent_dcc_uncompressed ||
                                     persistent_dcc_fast_clear,
                                 persistent_decode_limit, persistent_source_size);
+                        const bool retained_depth_cube_cache_eligible =
+                            retained_depth_cube_cache_candidate &&
+                            !PROSPER_ENV_VALUE("PROSPER_NO_TEXTURE_DECODE_CACHE") &&
+                            persistent_decode_limit != 0;
+                        const bool persistent_cache_eligible =
+                            guest_persistent_cache_eligible ||
+                            retained_depth_cube_cache_eligible;
                         // Range a submit-scoped identity entry may be re-proved against across a span
                         // boundary (#1691). It is exactly the range the persistent decode cache
                         // validates for this identity — the same bytes `validate_exact()` compares and
@@ -3602,8 +3712,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // (captured replay backing, storage images, unsupported DCC states, cache
                         // disabled) have no such established range, so they keep the pre-#1691
                         // span-local lifetime instead of being retained against an unverified extent.
-                        const uint64_t cross_span_source_size =
-                            persistent_cache_eligible ? persistent_source_size : 0u;
+                        const uint64_t cross_span_source_size = persistent_cache_eligible
+                            ? persistent_source_size : 0u;
                         static const bool cross_submit_watch_enabled =
                             !PROSPER_ENV_VALUE("PROSPER_NO_CROSS_SUBMIT_TEXTURE_WRITE_WATCH");
                         // Page-protection watches have a fixed setup/query cost and may need to
@@ -3657,11 +3767,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // PERMISSIVE verdict, and if the two same-span tests ever drift apart
                             // the placeholder would silently authorise reuse. Unknown fails closed
                             // at identical cost.
-                            const prosper::gpu::GuestGpuWriteQuery journal_query = same_span
-                                ? prosper::gpu::GuestGpuWriteQuery::Unknown
-                                : prosper::gpu::guest_gpu_writes_since(
-                                      reused->second.snapshot, reused->second.source_addr,
-                                      reused->second.source_size);
+                            prosper::gpu::GuestGpuWriteQuery journal_query =
+                                prosper::gpu::GuestGpuWriteQuery::Unknown;
+                            if (!same_span) {
+                                journal_query = prosper::gpu::guest_gpu_writes_since(
+                                    reused->second.snapshot, reused->second.source_addr,
+                                    reused->second.source_size);
+                            }
                             if (!submit_local_texture_decode_reusable(
                                     reused->second.span, decode_span_ordinal,
                                     reused->second.source_addr, reused->second.source_size,
@@ -3824,8 +3936,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             prosper::host::GuestWriteWatch::create(
                                                 persistent_source_addr, persistent_source_size);
                                 }
-                                bool content_matches = false;
-                                if (submit_unchanged || watch_unchanged) {
+                                bool content_matches = retained_depth_cube_cache_eligible;
+                                if (retained_depth_cube_cache_eligible) {
+                                    // The key carries the newest selected retained-depth write.
+                                    // Finding this entry is the exact renderer-authority proof;
+                                    // there are intentionally no guest bytes to compare.
+                                    resource_texture_exact_validation = false;
+                                } else if (submit_unchanged || watch_unchanged) {
                                     const bool audit = submit_unchanged
                                         ? audit_submit_reuse : audit_cross_submit_watch;
                                     content_matches = audit ? validate_exact() : true;
@@ -4065,9 +4182,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             fr.borrowed_compute_image_layout = compute_image_import.layout;
                             fr.borrowed_compute_image_lease =
                                 std::move(compute_image_import.lease);
+                            fr.borrowed_compute_vertical_stack_layers =
+                                compute_image_import.vertical_stack_layers;
                             fr.tw = compute_image_import.width;
-                            fr.th = compute_image_import.height;
-                            fr.td = compute_image_import.depth;
+                            fr.th = compute_image_import.height *
+                                std::max(compute_image_import.vertical_stack_layers, 1u);
+                            fr.td = compute_image_import.vertical_stack_layers
+                                ? 1u : compute_image_import.depth;
                             fr.img_dim = r.img_dim;
                             fr.texture_format = compute_image_format;
                         } else if (has_ds_live) {
@@ -4166,9 +4287,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                    fr.persistent_texture_id,
                                                    fr.persistent_texture_version,
                                                    decode_span_ordinal,
-                                                   prosper::gpu::guest_gpu_write_snapshot(),
-                                                   persistent_source_addr,
-                                                   cross_span_source_size, SIZE_MAX, nullptr,
+                                    prosper::gpu::guest_gpu_write_snapshot(),
+                                    persistent_source_addr,
+                                    cross_span_source_size, SIZE_MAX, nullptr,
                                                    fr.texture_format,
                                                    fr.storage_image_contract_valid});
                             if (timing_enabled) pending_timing.texture_reuses++;
@@ -4451,7 +4572,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         bool f16_done = false, f32_done = false;
                         // RTT (#167): if this texture's base is a color target we rendered into, inject those
                         // pixels (nearest-scaled to tw x th) instead of reading empty guest memory.
-                        bool rtt_hit = false;
+                        // Direct compute imports already own the complete sampled image. Mark the
+                        // CPU materializer complete as well; otherwise it performs a discarded
+                        // guest decode (and, for a cube, synchronous retained-depth readbacks)
+                        // before the backend binds the borrowed image.
+                        bool rtt_hit = resource_compute_image_hit;
                         // Why a sampled resource never consulted the renderer-owned RTT cache. Without
                         // this, a draw that reads a target prosper rendered but takes the guest-decode
                         // path instead is invisible in the log: no "sample tex" line is emitted at all,
@@ -4865,7 +4990,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // faithful, the precision is not the guest's, and a shadow compare is
                         // precision-sensitive. Recorded rather than hidden.
                         bool cube_depth_bridged = false;
-                        if (is_cube && !rtt_hit && !fr.is_storage_image && r.depth == 6u &&
+                        if (is_cube && !rtt_hit && !resource_compute_depth_hybrid &&
+                            !fr.is_storage_image && r.depth == 6u &&
                             prosper::test::is_retained_ds_plane(r.gpu_addr)) {
                             std::array<std::vector<float>, 6> faces;
                             uint32_t slices_found = 0;
@@ -4876,10 +5002,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             if (r.layer_stride_bytes)
                                 prosper::test::note_ds_layer_stride(r.gpu_addr, tw, th,
                                                                     r.layer_stride_bytes);
-                            uint32_t present_mask = 0, known_mask = 0;
-                            const bool complete = prosper::test::read_persistent_ds_cube_depth(
-                                r.gpu_addr, tw, th, faces, slices_found, cube_error,
-                                &present_mask, &known_mask);
+                            uint32_t present_mask = retained_depth_cube.present_mask;
+                            uint32_t known_mask = retained_depth_cube.known_mask;
+                            for (uint32_t face = 0; face < 6u; ++face)
+                                slices_found += (present_mask >> face) & 1u;
+                            // Selection above is metadata-only. Do not synchronously read back four
+                            // or five resident faces merely to discover that the sixth is absent and
+                            // discard every byte into the guest fallback. Only a complete selection
+                            // can enter this all-renderer bridge; the compute/DS hybrid is handled by
+                            // its independently ordered path below.
+                            const bool complete = retained_depth_cube_cache_candidate &&
+                                prosper::test::read_persistent_ds_cube_depth(
+                                    r.gpu_addr, tw, th, faces, slices_found, cube_error,
+                                    &present_mask, &known_mask);
                             // Residency DISTRIBUTION, not a first-sight snapshot. "1 of 6 faces"
                             // seen once is consistent with three different worlds: the guest
                             // amortises faces across frames, prosper's invalidation evicts them
@@ -5084,6 +5219,65 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 }
                             }
                             cube_done = true;
+                            if (resource_compute_depth_hybrid && !decoded_reuse) {
+                                std::array<std::vector<float>, 6> overlay_faces;
+                                uint32_t overlay_mask = 0, known_mask = 0;
+                                std::string overlay_error;
+                                const bool overlay_ok =
+                                    prosper::test::read_persistent_ds_cube_depth_after(
+                                        r.gpu_addr, tw, th,
+                                        resource_compute_producer_order,
+                                        overlay_faces, overlay_mask, known_mask,
+                                        overlay_error);
+                                if (overlay_ok && overlay_mask ==
+                                        resource_compute_depth_overlay_mask) {
+                                    for (uint32_t face = 0; face < 6u; ++face) {
+                                        if (!(overlay_mask & (1u << face))) continue;
+                                        const std::vector<float>& src = overlay_faces[face];
+                                        uint8_t* dst = texture_pixels.data() +
+                                            static_cast<size_t>(face) * tw * th * 4u;
+                                        for (size_t i = 0;
+                                             i < static_cast<size_t>(tw) * th && i < src.size();
+                                             ++i) {
+                                            const float d = std::clamp(src[i], 0.0f, 1.0f);
+                                            const uint8_t q = static_cast<uint8_t>(
+                                                d * 255.0f + 0.5f);
+                                            dst[i * 4 + 0] = q;
+                                            dst[i * 4 + 1] = q;
+                                            dst[i * 4 + 2] = q;
+                                            dst[i * 4 + 3] = 0xffu;
+                                        }
+                                    }
+                                    static std::mutex hybrid_log_mutex;
+                                    static std::map<uint64_t, uint64_t> hybrid_counts;
+                                    std::lock_guard lock(hybrid_log_mutex);
+                                    const uint64_t n = ++hybrid_counts[r.gpu_addr];
+                                    if ((n & (n - 1)) == 0)
+                                        std::fprintf(
+                                            stderr,
+                                            "[cube-depth] compute/DS hybrid addr=0x%llx "
+                                            "producer-order=%llu overlay=0x%02x known=0x%02x "
+                                            "(x%llu)\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)
+                                                resource_compute_producer_order,
+                                            overlay_mask, known_mask,
+                                            (unsigned long long)n);
+                                } else {
+                                    static uint64_t hybrid_failures = 0;
+                                    if (((++hybrid_failures) & (hybrid_failures - 1)) == 0)
+                                        std::fprintf(
+                                            stderr,
+                                            "[cube-depth] compute/DS hybrid FAILED "
+                                            "addr=0x%llx expected=0x%02x got=0x%02x "
+                                            "known=0x%02x error=%s (x%llu)\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            resource_compute_depth_overlay_mask,
+                                            overlay_mask, known_mask,
+                                            overlay_error.c_str(),
+                                            (unsigned long long)hybrid_failures);
+                                }
+                            }
                         }
                         // Block-compressed (BC1/2/3): read the (possibly tiled) compressed blocks, block-
                         // detile, and decode to RGBA8 in-place. The blocks are the tiled element (BC3 =
@@ -5685,7 +5879,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             fr.declared_mip_levels = r.declared_mip_levels;
                         if (persistent_cache_eligible) {
                             size_t source_prefix_size = linear_source_prefix_size;
-                            if (!persistent_source_matches_pixels) {
+                            if (!persistent_source_matches_pixels && persistent_source_size) {
                                 persistent_validation_scratch.resize(persistent_source_size);
                                 source_prefix_size = copy_persistent_source(
                                     persistent_validation_scratch.data(),
@@ -6213,12 +6407,39 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // nothing above claimed, and a signed remainder of ms -- and they
                             // disagree only if the classification is wrong.
                             if (resource_rtt_hit)                      { pending_timing.tex_rtt_ms += elapsed;           ++pending_timing.tex_rtt_n; }
-                            else if (resource_compute_image_hit)       { pending_timing.tex_compute_ms += elapsed;       ++pending_timing.tex_compute_n; }
+                            else if (resource_compute_image_hit ||
+                                     resource_compute_depth_hybrid)    { pending_timing.tex_compute_ms += elapsed;       ++pending_timing.tex_compute_n; }
                             else if (resource_persistent_submit_reuse) { pending_timing.tex_persist_reuse_ms += elapsed; ++pending_timing.tex_persist_reuse_n; }
                             else if (resource_persistent_hit)          { pending_timing.tex_persist_hit_ms += elapsed;   ++pending_timing.tex_persist_hit_n; }
                             else if (resource_persistent_miss)         { pending_timing.tex_persist_miss_ms += elapsed;  ++pending_timing.tex_persist_miss_n; }
                             else if (resource_local_reuse)             { pending_timing.tex_local_ms += elapsed;         ++pending_timing.tex_local_n; }
-                            else                                       { ++pending_timing.tex_other_n; }
+                            else {
+                                ++pending_timing.tex_other_n;
+                                if (elapsed > pending_timing.tex_other_slowest_ms) {
+                                    pending_timing.tex_other_slowest_ms = elapsed;
+                                    pending_timing.tex_other_addr = r.gpu_addr;
+                                    pending_timing.tex_other_source_bytes =
+                                        resource_persistent_source_size;
+                                    pending_timing.tex_other_width = r.width;
+                                    pending_timing.tex_other_height = r.height;
+                                    pending_timing.tex_other_depth = r.depth;
+                                    pending_timing.tex_other_format =
+                                        static_cast<uint32_t>(r.format);
+                                    pending_timing.tex_other_components = r.num_components;
+                                    pending_timing.tex_other_tile_mode = r.tile_mode;
+                                    pending_timing.tex_other_img_dim = r.img_dim;
+                                    pending_timing.tex_other_class =
+                                        static_cast<uint32_t>(r.cls);
+                                    pending_timing.tex_other_compute_candidate =
+                                        resource_compute_image_candidate;
+                                    pending_timing.tex_other_persistent_candidate =
+                                        resource_persistent_candidate;
+                                    pending_timing.tex_other_compressed =
+                                        r.compression_enabled;
+                                    pending_timing.tex_other_depth_compare = r.depth_compare;
+                                    pending_timing.tex_other_host_backed = r.host_data != nullptr;
+                                }
+                            }
                             pending_timing.textures++;
                             pending_timing.texture_bytes += static_cast<uint64_t>(fr.tw) * fr.th * fr.td *
                                 fr.sample_count *
@@ -6235,15 +6456,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 static_cast<uint64_t>(g_this_submit) >= detail_min_submit) {
                                 static uint64_t detail_lines = 0;
                                 if ((elapsed >= 0.5 || resource_persistent_invalidation ||
-                                     resource_compute_image_hit) &&
+                                     resource_compute_image_hit ||
+                                     resource_compute_depth_hybrid) &&
                                     detail_lines++ < 250) {
                                     const char* cache_state = resource_rtt_hit ? "rtt" :
+                                        (resource_compute_depth_hybrid ? "compute-depth-hybrid" :
                                         (resource_compute_image_hit ? "compute-image" :
                                         (resource_local_reuse ? "local" :
                                         (resource_persistent_submit_reuse ? "persistent-submit" :
                                         (resource_persistent_hit ? "persistent-hit" :
                                         (resource_persistent_invalidation ? "persistent-invalid" :
-                                        (resource_persistent_miss ? "persistent-miss" : "uncached"))))));
+                                        (resource_persistent_miss ? "persistent-miss" : "uncached")))))));
                                     auto submit_query_name = [](int query) {
                                         switch (query) {
                                             case static_cast<int>(
@@ -6276,7 +6499,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             "[render-timing] texture addr=0x%llx %ux%ux%u out=%ux%ux%u "
                                             "dim=%u fmt=%u comps=%u tile=%u class=%u storage=%d "
                                             "host=%d live=%d depth-live=%d candidate=%d source=%zu "
-                                            "compressed=%d "
+                                            "compressed=%d depth-compare=%d compute-candidate=%d "
                                             "cache=%s id=%llu validate=%s %.2fms/%zuB/%zuB "
                                             "submit=%s watch=%s active=%d disabled=%d only=%d stable=%u "
                                             "total=%.2f ms\n",
@@ -6290,7 +6513,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             static_cast<int>(resource_has_ds_live),
                                             static_cast<int>(resource_persistent_candidate),
                                             resource_persistent_source_size,
-                                            static_cast<int>(r.compression_enabled), cache_state,
+                                            static_cast<int>(r.compression_enabled),
+                                            static_cast<int>(r.depth_compare),
+                                            static_cast<int>(resource_compute_image_candidate),
+                                            cache_state,
                                             (unsigned long long)fr.persistent_texture_id,
                                             resource_texture_exact_validation ? "exact" : "skip",
                                             resource_texture_validation_ms,
@@ -6552,6 +6778,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
                     bd.draw_index = it.draw_index;
+                    bd.command_order = it.command_order;
                     bd.vcount = refvs ? 3u : it.vertex_count;
                     bd.instance_count = it.instance_count;
                     bd.vertex_offset = refvs ? 0 : it.vertex_offset;
@@ -7435,6 +7662,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         bool sampled_exact = false;
                         bool feedback = false;
                         bool cpu_needed = false;
+                        uint32_t storage_references = 0;
+                        uint32_t dimension_mismatches = 0;
+                        uint32_t extent_mismatches = 0;
+                        uint32_t feedback_references = 0;
                     };
                     // A later pass in THIS batch that reads the target's CPU bytes cannot be served
                     // lazily: the producing commands are still unsubmitted when it binds, so a
@@ -7477,10 +7708,49 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         result.sampled_exact = true;
                                         result.feedback |= same_pass_target;
                                     }
+                                    // Exact 2D color feedback is GPU-bindable: the backend copies
+                                    // the prior attachment version to a distinct sampled image before
+                                    // the render pass. Storage, dimension, and extent mismatches still
+                                    // require the CPU representation.
                                     const bool direct_bindable =
                                         resource.cls == RC::Texture && resource.img_dim == 1u &&
-                                        sampled_extent_compatible && !same_pass_target;
-                                    if (!direct_bindable) result.cpu_needed = true;
+                                        sampled_extent_compatible;
+                                    if (!direct_bindable) {
+                                        result.cpu_needed = true;
+                                        result.storage_references +=
+                                            resource.cls == RC::StorageImage;
+                                        result.dimension_mismatches += resource.img_dim != 1u;
+                                        result.extent_mismatches += !sampled_extent_compatible;
+                                        result.feedback_references += same_pass_target;
+                                        static const uint64_t diagnose_min_submit = [] {
+                                            const char* text = PROSPER_ENV_VALUE(
+                                                "PROSPER_READBACK_WHY_MIN_SUBMIT");
+                                            return text ? std::strtoull(text, nullptr, 0) : 0ull;
+                                        }();
+                                        static std::atomic<uint64_t> diagnose_lines{0};
+                                        if (PROSPER_ENV_ON("PROSPER_READBACK_WHY") &&
+                                            static_cast<uint64_t>(g_this_submit) >=
+                                                diagnose_min_submit &&
+                                            diagnose_lines.fetch_add(
+                                                1, std::memory_order_relaxed) < 64) {
+                                            fprintf(stderr,
+                                                    "[readback-consumer] submit=%d target=0x%llx "
+                                                    "producer-pass=%zu consumer-draw=%zu "
+                                                    "class=%s dim=%u extent=%ux%u target-extent=%ux%u "
+                                                    "storage=%u dimension=%u extent-mismatch=%u "
+                                                    "feedback=%u\n",
+                                                    g_this_submit,
+                                                    (unsigned long long)target_base, pass_i - 1,
+                                                    later,
+                                                    resource.cls == RC::StorageImage
+                                                        ? "storage" : "texture",
+                                                    resource.img_dim, rw, rh, gw, gh,
+                                                    resource.cls == RC::StorageImage ? 1u : 0u,
+                                                    resource.img_dim != 1u ? 1u : 0u,
+                                                    !sampled_extent_compatible ? 1u : 0u,
+                                                    same_pass_target ? 1u : 0u);
+                                        }
+                                    }
                                 }
                             };
                             inspect(items[later].vrt.get());
@@ -7491,6 +7761,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const LaterTargetConsumers consumers0 = inspect_later_consumers(base);
                     const LaterTargetConsumers consumers1 = use_color1
                         ? inspect_later_consumers(base1) : LaterTargetConsumers{};
+                    std::array<LaterTargetConsumers, prosper::gpu::kColorTargetCount>
+                        consumers_slots{};
+                    for (uint32_t slot = 2; slot < mrt_count; ++slot)
+                        consumers_slots[slot] = inspect_later_consumers(pass_bases[slot]);
                     const bool sampled_exact_later = consumers0.sampled_exact;
                     const bool feedback_later = consumers0.feedback;
                     const bool cpu_needed_same_batch = consumers0.cpu_needed;
@@ -7518,6 +7792,17 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const bool defer_readback1 = live_gpu_targets && vo_n > 0 && use_color1 &&
                         base1 && base1 != base && !phase.authoritative_readback &&
                         base1 != front_va && rtt_defer_ok1;
+                    std::array<bool, prosper::gpu::kColorTargetCount> defer_readback_slots{};
+                    for (uint32_t slot = 2; slot < mrt_count; ++slot) {
+                        const LaterTargetConsumers& consumers = consumers_slots[slot];
+                        const bool rtt_defer_ok_slot = defer_rtt_readback
+                            ? !consumers.cpu_needed
+                            : (consumers.sampled_exact && !consumers.feedback);
+                        const uint64_t slot_base = pass_bases[slot];
+                        defer_readback_slots[slot] = live_gpu_targets && vo_n > 0 &&
+                            slot_base && !phase.authoritative_readback &&
+                            slot_base != front_va && rtt_defer_ok_slot;
+                    }
                     // PROSPER_READBACK_WHY (#1284): classify WHY each non-deferred pass takes the
                     // synchronous CPU readback (75-79 ms/window on Blue Prince's Day One frame).
                     // The dominant reason selects the next optimization; behavior unchanged.
@@ -7529,6 +7814,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             enum { kNoLive, kNoVo, kNoBase, kAuth, kVoFinal, kFront,
                                    kSameBatchCpu, kNotSampledExact, kFeedback, kBuckets };
                             static std::atomic<uint64_t> counts[kBuckets], bytes[kBuckets];
+                            static std::atomic<uint64_t> same_batch_storage{0};
+                            static std::atomic<uint64_t> same_batch_dimension{0};
+                            static std::atomic<uint64_t> same_batch_extent{0};
+                            static std::atomic<uint64_t> same_batch_feedback{0};
                             static std::atomic<uint64_t> c_total{0};
                             int bucket = kNotSampledExact;
                             if (!live_gpu_targets) bucket = kNoLive;
@@ -7540,6 +7829,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             else if (cpu_needed_same_batch) bucket = kSameBatchCpu;
                             else if (sampled_exact_later && feedback_later) bucket = kFeedback;
                             ++counts[bucket];
+                            if (bucket == kSameBatchCpu) {
+                                same_batch_storage += consumers0.storage_references;
+                                same_batch_dimension += consumers0.dimension_mismatches;
+                                same_batch_extent += consumers0.extent_mismatches;
+                                same_batch_feedback += consumers0.feedback_references;
+                            }
                             // #2398: bill bytes only when colour pixels are ACTUALLY requested.
                             // #2283 narrowed the readback to `want_color_readback` (the same
                             // any_of over pass_bases used at the call below) and this accounting
@@ -7572,7 +7867,13 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     fprintf(stderr, " %s=%llu/%lluMB", names[i],
                                             (unsigned long long)counts[i].load(),
                                             (unsigned long long)(bytes[i].load() >> 20));
-                                fprintf(stderr, "\n");
+                                fprintf(stderr,
+                                        " same_batch_reasons=storage:%llu,dimension:%llu,"
+                                        "extent:%llu,feedback:%llu\n",
+                                        (unsigned long long)same_batch_storage.load(),
+                                        (unsigned long long)same_batch_dimension.load(),
+                                        (unsigned long long)same_batch_extent.load(),
+                                        (unsigned long long)same_batch_feedback.load());
                             }
                         }
                     }
@@ -7621,6 +7922,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     for (uint32_t slot = 2; slot < mrt_count; ++slot) {
                         backend_target.persistent_id_slots[slot] = pass_bases[slot];
                         backend_target.load_existing_slots[slot] = seed_target(pass_bases[slot]);
+                        backend_target.readback_slots[slot] = !defer_readback_slots[slot];
                     }
                     auto backend_draws = build_bds(render_pass);
                     const auto build_done = timing_enabled
@@ -7707,6 +8009,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         pending_timing.color_target_cached_bytes = color_target_call.cached_bytes;
                         pending_timing.color_target_cached_entries = color_target_call.cached_entries;
                     }
+                    const auto post_stats_done = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
                     static const std::string dump_spec =
                         PROSPER_ENV_VALUE("PROSPER_DUMP_PASS")
                             ? PROSPER_ENV_VALUE("PROSPER_DUMP_PASS") : "";
@@ -7773,6 +8077,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.has_uniform_color = false;
                         surface.dcc_metadata_dirty = false;
                     }
+                    const auto post_slot0_done = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
                     for (uint32_t slot = 1; slot < mrt_count; ++slot) {
                         auto& pixels = mrt_outputs.colors[slot];
                         if (!pass_bases[slot]) continue;  // transient attachment for a sparse export hole
@@ -7847,6 +8153,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         else
                             surface.rgba.reset();
                     }
+                    const auto post_mrt_done = timing_enabled
+                        ? RenderClock::now() : RenderClock::time_point{};
                     const std::vector<uint8_t>& rendered_pixels = *pass_pixels;
                     // Both dims parse to 0 when PROSPER_RESOURCE_HASH_DIM is UNSET, so an extent
                     // comparison alone made every 0x0 pass satisfy the filter and switch the
@@ -8281,9 +8589,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // the paths that reached the render, which are exactly the paths `pre` counted,
                     // so the two spans cover the same population and their sum is comparable to
                     // pass_groups.
-                    if (timing_enabled)
+                    if (timing_enabled) {
+                        const auto post_done = RenderClock::now();
                         pending_timing.pass_post_ms += std::chrono::duration<double, std::milli>(
-                            RenderClock::now() - backend_done).count();
+                            post_done - backend_done).count();
+                        pending_timing.post_stats_ms += std::chrono::duration<double, std::milli>(
+                            post_stats_done - backend_done).count();
+                        pending_timing.post_slot0_ms += std::chrono::duration<double, std::milli>(
+                            post_slot0_done - post_stats_done).count();
+                        pending_timing.post_mrt_ms += std::chrono::duration<double, std::milli>(
+                            post_mrt_done - post_slot0_done).count();
+                        pending_timing.post_rest_ms += std::chrono::duration<double, std::milli>(
+                            post_done - post_mrt_done).count();
+                    }
                 }
                 // Everything after the group loop: present selection, scanout resolution, the final
                 // render, RTT publication. The tail performs its own build_resources+backend, and
@@ -8821,19 +9139,85 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     record.texture_bytes = pending_timing.texture_bytes;
                     record.buffer_bytes = pending_timing.buffer_bytes;
                     record.total_ms = pending_timing.total_ms;
+                    record.prelude_ms = pending_timing.prelude_ms;
+                    record.pass_ms = pending_timing.pass_ms;
                     record.build_resources_ms = pending_timing.build_resources_ms;
                     record.backend_ms = pending_timing.backend_ms;
                     record.output_copy_ms = pending_timing.output_copy_ms;
+                    record.pass_head_ms = pending_timing.pass_head_ms;
+                    record.pass_loop_ms = pending_timing.pass_loop_ms;
+                    record.pass_pre_ms = pending_timing.pass_pre_ms;
+                    record.pass_post_ms = pending_timing.pass_post_ms;
+                    record.post_stats_ms = pending_timing.post_stats_ms;
+                    record.post_slot0_ms = pending_timing.post_slot0_ms;
+                    record.post_mrt_ms = pending_timing.post_mrt_ms;
+                    record.post_rest_ms = pending_timing.post_rest_ms;
+                    record.pass_tail_ms = pending_timing.pass_tail_ms;
+                    record.resolve_stall_ms = pending_timing.resolve_stall_ms;
+                    record.resolve_read_ms = pending_timing.resolve_read_ms;
+                    record.resolve_copy_stall_ms = pending_timing.resolve_copy_stall_ms;
+                    record.resolve_copy_ms = pending_timing.resolve_copy_ms;
+                    record.resolve_count = pending_timing.resolve_n;
+                    record.resolve_read_count = pending_timing.resolve_read_n;
+                    record.resolve_bytes = pending_timing.resolve_bytes;
                     record.gpu_wait_ms = pending_timing.backend_gpu_wait_ms;
                     record.gpu_timestamp_samples =
                         pending_timing.backend_gpu_timestamp_samples;
                     record.gpu_device_ms = pending_timing.backend_gpu_device_ms;
                     record.readback_ms = pending_timing.backend_readback_ms;
+                    record.backend_target_ms = pending_timing.backend_target_ms;
+                    record.backend_draw_setup_ms = pending_timing.backend_draw_setup_ms;
+                    record.backend_record_upload_ms = pending_timing.backend_record_upload_ms;
+                    record.backend_cleanup_ms = pending_timing.backend_cleanup_ms;
+                    record.backend_setup_shader_ms = pending_timing.backend_setup_shader_ms;
+                    record.backend_setup_fixed_ms = pending_timing.backend_setup_fixed_ms;
                     record.setup_resources_ms = pending_timing.backend_setup_resources_ms;
+                    record.backend_setup_pipeline_ms =
+                        pending_timing.backend_setup_pipeline_ms;
+                    record.backend_pipeline_refs = pending_timing.backend_pipeline_refs;
+                    record.backend_pipeline_hits = pending_timing.backend_pipeline_hits;
+                    record.backend_pipeline_misses = pending_timing.backend_pipeline_misses;
+                    record.backend_pipeline_bypasses = pending_timing.backend_pipeline_bypasses;
+                    record.backend_pipeline_entries = pending_timing.backend_pipeline_entries;
+                    record.backend_pipeline_evictions = pending_timing.backend_pipeline_evictions;
                     // Frontend and backend, kept apart by name. These two are build_resources' own
                     // texture/buffer time and are NOT parts of setup_resources_ms above.
                     record.frontend_texture_ms = pending_timing.texture_ms;
                     record.frontend_buffer_ms = pending_timing.buffer_ms;
+                    record.frontend_tex_rtt_ms = pending_timing.tex_rtt_ms;
+                    record.frontend_tex_compute_ms = pending_timing.tex_compute_ms;
+                    record.frontend_tex_local_ms = pending_timing.tex_local_ms;
+                    record.frontend_tex_persist_hit_ms = pending_timing.tex_persist_hit_ms;
+                    record.frontend_tex_persist_reuse_ms = pending_timing.tex_persist_reuse_ms;
+                    record.frontend_tex_persist_miss_ms = pending_timing.tex_persist_miss_ms;
+                    record.frontend_tex_other_slowest_ms =
+                        pending_timing.tex_other_slowest_ms;
+                    record.frontend_tex_other_addr = pending_timing.tex_other_addr;
+                    record.frontend_tex_other_source_bytes =
+                        pending_timing.tex_other_source_bytes;
+                    record.frontend_tex_other_width = pending_timing.tex_other_width;
+                    record.frontend_tex_other_height = pending_timing.tex_other_height;
+                    record.frontend_tex_other_depth = pending_timing.tex_other_depth;
+                    record.frontend_tex_other_format = pending_timing.tex_other_format;
+                    record.frontend_tex_other_components = pending_timing.tex_other_components;
+                    record.frontend_tex_other_tile_mode = pending_timing.tex_other_tile_mode;
+                    record.frontend_tex_other_img_dim = pending_timing.tex_other_img_dim;
+                    record.frontend_tex_other_class = pending_timing.tex_other_class;
+                    record.frontend_tex_other_compute_candidate =
+                        pending_timing.tex_other_compute_candidate;
+                    record.frontend_tex_other_persistent_candidate =
+                        pending_timing.tex_other_persistent_candidate;
+                    record.frontend_tex_other_compressed =
+                        pending_timing.tex_other_compressed;
+                    record.frontend_tex_other_depth_compare =
+                        pending_timing.tex_other_depth_compare;
+                    record.frontend_tex_other_host_backed =
+                        pending_timing.tex_other_host_backed;
+                    record.frontend_build_draw_ms = pending_timing.build_r_ms;
+                    record.frontend_validate_ms = pending_timing.build_validate_ms;
+                    record.frontend_poison_ms = pending_timing.build_poison_ms;
+                    record.frontend_indices_ms = pending_timing.build_indices_ms;
+                    record.frontend_reflect_ms = pending_timing.build_reflect_ms;
                     // These four DO decompose setup_resources_ms, so an offline report can attribute
                     // the largest bucket in the capture instead of leaving a plausible residue.
                     record.res_texture_ms = pending_timing.backend_res_texture_ms;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -199,8 +199,10 @@ bool mrt_format_defined(uint32_t raw) {
     return prosper::test::backend_color_format(static_cast<VkFormat>(raw)) != VK_FORMAT_UNDEFINED;
 }
 
-bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr) {
-    return prosper::frontend::mrt_draw_binds_target(draw, addr, mrt_format_defined);
+bool draw_binds_color_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
+                             uint32_t sampled_width = 0u, uint32_t sampled_height = 0u) {
+    return prosper::frontend::mrt_draw_binds_target_view(
+        draw, addr, sampled_width, sampled_height, mrt_format_defined);
 }
 
 // PROSPER_RTT_INVALIDATE_WATCH=<0xaddr>[,<0xaddr>…] — why a renderer-owned surface's CPU snapshot is,
@@ -420,6 +422,8 @@ bool capture_color_format(VkFormat format, prosper::gpu::GpuCaptureColorFormat& 
         captured = prosper::gpu::GpuCaptureColorFormat::R32Float;
     else if (format == VK_FORMAT_R8G8_UNORM)
         captured = prosper::gpu::GpuCaptureColorFormat::Rg8Unorm;
+    else if (format == VK_FORMAT_R32G32B32A32_SFLOAT)
+        captured = prosper::gpu::GpuCaptureColorFormat::Rgba32Float;
     else
         return false;
     return true;
@@ -438,6 +442,8 @@ VkFormat replay_color_format(prosper::gpu::GpuCaptureColorFormat format) {
         return VK_FORMAT_R32_SFLOAT;
     if (format == prosper::gpu::GpuCaptureColorFormat::Rg8Unorm)
         return VK_FORMAT_R8G8_UNORM;
+    if (format == prosper::gpu::GpuCaptureColorFormat::Rgba32Float)
+        return VK_FORMAT_R32G32B32A32_SFLOAT;
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
@@ -483,6 +489,18 @@ std::vector<uint8_t> inspection_rgba8(const std::vector<uint8_t>& pixels,
             rgba[texel * 4 + 1] = pixels[texel * 2 + 1];
             rgba[texel * 4 + 2] = 0;
             rgba[texel * 4 + 3] = 255;
+        }
+        return rgba;
+    }
+    if (format == VK_FORMAT_R32G32B32A32_SFLOAT && pixels.size() == texels * 16) {
+        std::vector<uint8_t> rgba(texels * 4);
+        for (size_t texel = 0; texel < texels; ++texel) {
+            for (uint32_t channel = 0; channel < 4; ++channel) {
+                float value = 0.0f;
+                std::memcpy(&value, pixels.data() + texel * 16 + channel * 4, sizeof(value));
+                rgba[texel * 4 + channel] = !std::isfinite(value) || value <= 0.0f ? 0
+                    : value >= 1.0f ? 255 : static_cast<uint8_t>(value * 255.0f + 0.5f);
+            }
         }
         return rgba;
     }
@@ -777,6 +795,98 @@ bool sampled_msaa_fetch_shape_supported(const prosper::gpu::ShaderResource& reso
         resource.declared_mip_levels == 1u && !resource.in_mip_tail &&
         resource.mip_tail_bytes == 0u && resource.layer_stride_bytes == 0u &&
         resource.layer_mip_offset_bytes == 0u && reflected_msaa_fetch;
+}
+
+bool native_r11_sampled_upload_supported(const prosper::gpu::ShaderResource& resource) {
+    using prosper::gpu::DataFormat;
+    using prosper::gpu::ResourceClass;
+    return resource.cls == ResourceClass::Texture && resource.img_dim == 1u &&
+        resource.depth == 1u && resource.format == DataFormat::Float10_11_11 &&
+        resource.num_components == 3u && !resource.compression_enabled && !resource.srgb;
+}
+
+struct DiagnosticAddressSelector {
+    bool configured = false;
+    bool valid = true;
+    std::vector<uint64_t> addresses;
+
+    bool includes(uint64_t address) const {
+        return !configured ||
+            (valid && std::find(addresses.begin(), addresses.end(), address) != addresses.end());
+    }
+};
+
+DiagnosticAddressSelector parse_diagnostic_address_selector(const char* env_name) {
+    DiagnosticAddressSelector selector;
+    // Each caller stores the result in a function-local static, so this generic parser keeps the
+    // same one-read-per-process contract as PROSPER_ENV_VALUE without passing a runtime name into
+    // that macro's captureless lambda.
+    const char* spec = std::getenv(env_name);
+    if (!spec || !*spec) return selector;
+    selector.configured = true;
+    selector.valid = prosper::gpu::parse_hex_watch_list(spec, selector.addresses);
+    if (!selector.valid) {
+        std::fprintf(stderr,
+                     "[render] ignoring malformed %s=\"%s\" (expected 0x-prefixed hex "
+                     "addresses, comma separated) -- selector matches NOTHING\n",
+                     env_name, spec);
+        selector.addresses.clear();
+    } else {
+        std::fprintf(stderr, "[render] %s selects %zu address(es)\n",
+                     env_name, selector.addresses.size());
+    }
+    return selector;
+}
+
+const DiagnosticAddressSelector& native_r11_sampled_selector() {
+    static const DiagnosticAddressSelector selector =
+        parse_diagnostic_address_selector("PROSPER_NATIVE_R11_SAMPLED_ONLY");
+    return selector;
+}
+
+const DiagnosticAddressSelector& renderer_mip_chain_selector() {
+    static const DiagnosticAddressSelector selector =
+        parse_diagnostic_address_selector("PROSPER_RENDERER_MIP_CHAIN_ONLY");
+    return selector;
+}
+
+const DiagnosticAddressSelector& rtt_no_seed_target_selector() {
+    static const DiagnosticAddressSelector selector =
+        parse_diagnostic_address_selector("PROSPER_RTT_NOSEED_TARGET");
+    return selector;
+}
+
+RendererMipChainLayout renderer_mip_chain_layout(uint64_t level_zero_address,
+                                                 uint32_t width, uint32_t height,
+                                                 uint32_t bytes_per_texel,
+                                                 uint32_t tile_mode,
+                                                 uint32_t declared_mip_levels) {
+    RendererMipChainLayout result;
+    if (!level_zero_address || !width || !height || !bytes_per_texel ||
+        declared_mip_levels < 2u || declared_mip_levels > result.level_ids.size())
+        return result;
+    const uint32_t max_mip = declared_mip_levels - 1u;
+    const prosper::gpu::TiledMipLevelLayout level_zero =
+        prosper::gpu::tiled_mip_level_layout(
+            width, height, bytes_per_texel, tile_mode, max_mip, 0u);
+    // This helper starts from a descriptor selecting allocation level zero. A level-zero tail view
+    // cannot identify the allocation origin by subtraction and remains on the established fallback.
+    if (!level_zero.supported || level_zero.in_tail ||
+        level_zero.byte_offset > level_zero_address)
+        return result;
+    const uint64_t allocation_base = level_zero_address - level_zero.byte_offset;
+    for (uint32_t level = 0; level < declared_mip_levels; ++level) {
+        const prosper::gpu::TiledMipLevelLayout layout =
+            prosper::gpu::tiled_mip_level_layout(
+                width, height, bytes_per_texel, tile_mode, max_mip, level);
+        if (!layout.supported ||
+            (!layout.in_tail && layout.byte_offset > UINT64_MAX - allocation_base))
+            return {};
+        result.level_ids[level] = layout.in_tail
+            ? allocation_base : allocation_base + layout.byte_offset;
+    }
+    result.level_count = declared_mip_levels;
+    return result;
 }
 
 bool persistent_texture_decode_cache_eligible(bool guest_decode_candidate,
@@ -1460,10 +1570,19 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     // Retain intermediate color targets on the GPU by default. Captures and per-target pixel
     // diagnostics require authoritative CPU pixels at every pass, so they retain the established
     // readback path. The explicit opt-out keeps a direct A/B and a recovery switch for driver issues.
+    // Bundle replay normally requests CPU-visible RTT checkpoints so its inspection/export modes can
+    // observe every pass. That fallback cannot carry MRT2..7 between independent render groups (the
+    // public CPU seed parameters historically cover only MRT0/MRT1), and therefore is not an oracle
+    // for a deferred frame that accumulates a wider G-buffer. This explicit diagnostic makes replay
+    // use the production GPU-resident contract while still restoring the bundle's boundary seeds.
+    // It is deliberately opt-in: export/readback diagnostics keep their established behaviour.
+    static const bool replay_live_targets =
+        PROSPER_ENV_VALUE("PROSPER_GPU_REPLAY_LIVE_TARGETS") != nullptr;
     static const bool live_gpu_targets = pertarget &&
         !PROSPER_ENV_VALUE("PROSPER_NO_LIVE_PERSISTENT_COLOR_TARGETS") && !getenv("PROSPER_GPU_CAPTURE") &&
         timeline_capture_permits_live_targets && !PROSPER_ENV_VALUE("PROSPER_GPU_REPLAY_EXPORT_RTT") &&
-        !getenv("PROSPER_GPU_REPLAY_RTT_SEEDS") && !PROSPER_ENV_VALUE("PROSPER_DUMP_SAMPLED_RTT") &&
+        (!getenv("PROSPER_GPU_REPLAY_RTT_SEEDS") || replay_live_targets) &&
+        !PROSPER_ENV_VALUE("PROSPER_DUMP_SAMPLED_RTT") &&
         !PROSPER_ENV_VALUE("PROSPER_DUMP_RTGROUPS") && !getenv("PROSPER_DUMP_RTGROUPS_RGBA") &&
         !PROSPER_ENV_VALUE("PROSPER_DUMP_DRAWSTEPS") &&
         !PROSPER_ENV_VALUE("PROSPER_RESOURCE_HASH_DIM") && !PROSPER_ENV_VALUE("PROSPER_TARGET_STEP_HASH_DIM") &&
@@ -1478,7 +1597,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     static const bool batch_backend_submits = live_gpu_targets &&
         !PROSPER_ENV_VALUE("PROSPER_NO_BACKEND_BATCH_SUBMITS");
     if (live_gpu_targets)
-        fprintf(stderr, "[render] persistent GPU color targets enabled (experimental)\n");
+        fprintf(stderr, "[render] persistent GPU color targets enabled (experimental%s)\n",
+                replay_live_targets ? ", replay parity" : "");
     if (batch_backend_submits)
         fprintf(stderr, "[render] backend target-submit batching enabled (experimental)\n");
     prosper::gpu::set_submit_renderer(
@@ -1521,16 +1641,114 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 uint32_t width = 0, height = 0;
                 VkFormat format = VK_FORMAT_UNDEFINED;
             };
+            struct PinnedRendererMipTarget {
+                uint64_t id = 0;
+                uint32_t width = 0, height = 0;
+                VkFormat format = VK_FORMAT_UNDEFINED;
+                // A mipmapped T# has named this exact independently rendered level. Keep the pin
+                // through the backend call that consumes it, then release it at the logical
+                // submit's final span. Unconsumed producers deliberately cross submit boundaries.
+                bool consumed = false;
+            };
             static thread_local std::vector<PinnedScanout> pinned_scanouts;
+            static thread_local std::vector<PinnedRendererMipTarget>
+                pinned_renderer_mip_targets;
             auto release_pinned_scanouts = [&] {
                 for (const PinnedScanout& target : pinned_scanouts)
                     prosper::test::unpin_persistent_color_target(
                         target.id, target.width, target.height, target.format);
                 pinned_scanouts.clear();
             };
+            auto release_consumed_renderer_mip_targets = [&] {
+                auto target = pinned_renderer_mip_targets.begin();
+                while (target != pinned_renderer_mip_targets.end()) {
+                    if (!target->consumed) {
+                        ++target;
+                        continue;
+                    }
+                    prosper::test::unpin_persistent_color_target(
+                        target->id, target->width, target->height, target->format);
+                    target = pinned_renderer_mip_targets.erase(target);
+                }
+            };
+            auto pin_renderer_mip_target = [&](uint64_t id, uint32_t width, uint32_t height,
+                                               VkFormat format, bool gpu_valid) {
+                if (!gpu_valid || !id || !width || !height ||
+                    !prosper::frontend::renderer_mip_target_requires_submit_retention(format))
+                    return;
+                const auto already_pinned = std::find_if(
+                    pinned_renderer_mip_targets.begin(), pinned_renderer_mip_targets.end(),
+                    [&](const PinnedRendererMipTarget& target) {
+                        return target.id == id && target.width == width &&
+                               target.height == height && target.format == format;
+                    });
+                if (already_pinned != pinned_renderer_mip_targets.end()) {
+                    // A new production supersedes any earlier consumption of the same identity.
+                    // It must remain retained for the next mip consumer, which may be in a later
+                    // logical submit.
+                    already_pinned->consumed = false;
+                    return;
+                }
+                // This is a narrow bridge for independently rendered packed-HDR mip levels, not a
+                // second unbounded residency cache. GTA V's observed scene uses 22 identities;
+                // retaining substantially more without one being consumed indicates a different
+                // workload and must fall back visibly to the ordinary LRU contract.
+                constexpr size_t kMaxPendingRendererMipTargets = 64;
+                if (pinned_renderer_mip_targets.size() >= kMaxPendingRendererMipTargets) {
+                    const PinnedRendererMipTarget oldest = pinned_renderer_mip_targets.front();
+                    prosper::test::unpin_persistent_color_target(
+                        oldest.id, oldest.width, oldest.height, oldest.format);
+                    pinned_renderer_mip_targets.erase(pinned_renderer_mip_targets.begin());
+                    static std::atomic<uint64_t> overflows{0};
+                    const uint64_t occurrence = overflows.fetch_add(1) + 1;
+                    if (prosper::diag_should_print(occurrence))
+                        fprintf(stderr,
+                                "[renderer-mips] pending producer cap reached #%llu; "
+                                "released unconsumed target=0x%llx extent=%ux%u\n",
+                                (unsigned long long)occurrence,
+                                (unsigned long long)oldest.id, oldest.width, oldest.height);
+                }
+                if (prosper::test::pin_persistent_color_target(id, width, height, format)) {
+                    pinned_renderer_mip_targets.push_back({id, width, height, format, false});
+                    return;
+                }
+                // The target was proven GPU-valid immediately before this call, so a failed pin
+                // means frontend/backend cache identity drift. Report it even without diagnostics:
+                // silently continuing would recreate the missing-middle-mip corruption this pin
+                // exists to prevent.
+                static std::atomic<uint64_t> failures{0};
+                const uint64_t occurrence = failures.fetch_add(1) + 1;
+                if (prosper::diag_should_print(occurrence))
+                    fprintf(stderr,
+                            "[renderer-mips] submit-retention pin FAILED #%llu: "
+                            "target=0x%llx extent=%ux%u format=%d\n",
+                            (unsigned long long)occurrence, (unsigned long long)id,
+                            width, height, (int)format);
+            };
+            auto consume_renderer_mip_chain = [&](const RendererMipChainLayout& chain,
+                                                  uint32_t width, uint32_t height,
+                                                  VkFormat format) {
+                size_t matched = 0;
+                for (uint32_t level = 0; level < chain.level_count; ++level) {
+                    const uint64_t id = chain.level_ids[level];
+                    const uint32_t level_width = std::max(width >> level, 1u);
+                    const uint32_t level_height = std::max(height >> level, 1u);
+                    for (PinnedRendererMipTarget& target : pinned_renderer_mip_targets) {
+                        if (target.id != id || target.width != level_width ||
+                            target.height != level_height || target.format != format)
+                            continue;
+                        if (!target.consumed) ++matched;
+                        target.consumed = true;
+                        break;
+                    }
+                }
+                return matched;
+            };
             // A terminal callback normally releases every pin. Recover conservatively if an earlier
             // submit was aborted after rendering but before frontend finalization.
             if (phase.first_span && !pinned_scanouts.empty()) release_pinned_scanouts();
+            if (phase.first_span && !pinned_renderer_mip_targets.empty())
+                release_consumed_renderer_mip_targets();
             // PROSPER_RENDER_FIRST=<N>: skip the slow (~400x) Vulkan render for the first N GPU submits, so
             // the game reaches a LATE scene (e.g. the level1 cutscene, which only starts submitting after
             // ~5000 title-loop submits) at native speed before we begin rendering/dumping. Returning {}
@@ -2789,7 +3007,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // refused the direct image because the collision is real, and the
                             // resource fell through to stale guest bytes with no snapshot to use.
                             const bool direct_serves = prosper::frontend::mrt_direct_serves(
-                                draw, sampled_source_addr, fr.is_storage_image, r.img_dim,
+                                draw, sampled_source_addr, tw, th,
+                                fr.is_storage_image, r.img_dim,
                                 sampled_extent_compatible,
                                 prosper::test::find_persistent_color_target(
                                     sampled_source_addr, surface.w, surface.h,
@@ -2872,12 +3091,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             prosper::frontend::rtt_sampled_extent_compatible(
                                 tw, th, live_rtt->second.w, live_rtt->second.h, render_scale,
                                 normalized_sampling) &&
-                            !draw_binds_color_target(draw, sampled_source_addr) &&
+                            !draw_binds_color_target(draw, sampled_source_addr, tw, th) &&
                             prosper::test::find_persistent_color_target(
                                 sampled_source_addr, live_rtt->second.w, live_rtt->second.h,
                                 live_rtt->second.format) != nullptr;
                         const bool has_uniform_live_rtt = prosper::frontend::mrt_uniform_live_serves(
-                            draw, sampled_source_addr,
+                            draw, sampled_source_addr, tw, th,
                             /*preconditions=*/!fr.is_storage_image &&
                                 !uniform_cpu_diagnostic_path && sampled_2d_view &&
                                 !r.in_mip_tail && live_rtt != g_rtt.end() &&
@@ -3094,6 +3313,28 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         // the real 2-byte element size and then preserves both U and V because
                         // avplayer_chroma_layout is set.
                         const bool native_rg8_sampled = avplayer_chroma_layout && r.tile_mode == 0u;
+                        // R11G11B10F is already a native Vulkan sampled format. Preserve the packed
+                        // words after detiling instead of expanding to RGBA8: the old conversion
+                        // clamped every HDR channel above 1.0, destroying environment-light energy.
+                        // GTA V's 1024x512 lighting map has 2,536 of 6,123 sampled channels above
+                        // 1.0 (1,791 above 16.0), so this was a semantic collapse, not quantization.
+                        const bool native_r11_eligible =
+                            native_r11_sampled_upload_supported(r);
+                        const bool native_r11_sampled = native_r11_eligible &&
+                            PROSPER_ENV_VALUE("PROSPER_NO_NATIVE_R11_SAMPLED") == nullptr &&
+                            native_r11_sampled_selector().includes(r.gpu_addr);
+                        if (native_r11_eligible &&
+                            PROSPER_ENV_VALUE("PROSPER_NATIVE_R11_SAMPLED_LOG") != nullptr) {
+                            static std::set<uint64_t> logged_native_r11;
+                            if (logged_native_r11.insert(r.gpu_addr).second)
+                                std::fprintf(stderr,
+                                             "[native-r11] addr=0x%llx %ux%ux%u tile=%u "
+                                             "declared_mips=%u selected=%u\n",
+                                             static_cast<unsigned long long>(r.gpu_addr),
+                                             r.width, r.height, r.depth, r.tile_mode,
+                                             r.declared_mip_levels,
+                                             native_r11_sampled ? 1u : 0u);
+                        }
                         // Storage-image atomics require a typed integer Vulkan view. Keep R32_UINT
                         // texels byte-exact through the existing 4-B read/detile path instead of
                         // silently normalizing the view to RGBA8_UNORM.
@@ -3166,8 +3407,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                : (native_r32ui_storage ? VK_FORMAT_R32_UINT
                                : (native_r8_sampled ? VK_FORMAT_R8_UNORM
                                : (native_rg8_sampled ? VK_FORMAT_R8G8_UNORM
+                               : (native_r11_sampled ? VK_FORMAT_B10G11R11_UFLOAT_PACK32
                                : (sampled_source_f32 ? VK_FORMAT_R16G16B16A16_SFLOAT
-                                                     : VK_FORMAT_R8G8B8A8_UNORM)))));
+                                                     : VK_FORMAT_R8G8B8A8_UNORM))))));
                         const bool persistent_source_matches_pixels =
                             native_r8_sampled || native_rg8_sampled ||
                             (persistent_unorm8_texture && r.num_components == 4 &&
@@ -3668,6 +3910,100 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             fr.th = live_rtt->second.h;
                             fr.td = 1; fr.img_dim = r.img_dim;
                             fr.texture_format = live_rtt->second.format;
+                            // CB_COLOR renders one mip view per target, while this T# samples the
+                            // complete allocation. Reconstruct the target identities and retain
+                            // every level that is still authoritative on the GPU. The backend will
+                            // copy them into one sampled mip image. Expose only the contiguous
+                            // renderer-owned prefix: inventing a missing tail by filtering the last
+                            // live level corrupts temporal/bloom chains whose real producer has not
+                            // run yet. Requiring at least two live levels keeps the
+                            // historical zero-copy bind for ordinary single-target resources.
+                            uint32_t mip_bytes_per_texel =
+                                prosper::gpu::data_format_bytes(r.format) *
+                                (r.num_components ? r.num_components : 1u);
+                            if ((r.format == prosper::gpu::DataFormat::Float10_11_11 &&
+                                 r.num_components == 3u) ||
+                                (r.format == prosper::gpu::DataFormat::Unorm2_10_10_10 &&
+                                 r.num_components == 4u))
+                                mip_bytes_per_texel = 4u;
+                            const bool renderer_mip_chain_selected =
+                                PROSPER_ENV_VALUE("PROSPER_NO_RENDERER_MIP_CHAIN") == nullptr &&
+                                renderer_mip_chain_selector().includes(sampled_source_addr);
+                            const RendererMipChainLayout mip_chain = renderer_mip_chain_selected
+                                ? renderer_mip_chain_layout(
+                                      sampled_source_addr, tw, th, mip_bytes_per_texel,
+                                      r.tile_mode, r.declared_mip_levels)
+                                : RendererMipChainLayout{};
+                            const VkFormat mip_format = prosper::test::backend_color_format(
+                                live_rtt->second.format);
+                            const size_t retained_mips_consumed = mip_chain.level_count > 1u
+                                ? consume_renderer_mip_chain(mip_chain, fr.tw, fr.th, mip_format)
+                                : 0u;
+                            uint32_t live_mip_levels = 0;
+                            uint32_t live_mip_mask = 0;
+                            uint32_t present_mip_mask = 0;
+                            if (mip_chain.level_count > 1u) {
+                                for (uint32_t level = 0; level < mip_chain.level_count; ++level) {
+                                    const uint32_t level_w = std::max(fr.tw >> level, 1u);
+                                    const uint32_t level_h = std::max(fr.th >> level, 1u);
+                                    auto* retained = prosper::test::find_persistent_color_target(
+                                        mip_chain.level_ids[level], level_w, level_h,
+                                        mip_format, false);
+                                    if (retained) present_mip_mask |= 1u << level;
+                                    if (retained && retained->valid) {
+                                        fr.persistent_render_target_mip_ids[level] =
+                                            mip_chain.level_ids[level];
+                                        ++live_mip_levels;
+                                        live_mip_mask |= 1u << level;
+                                    }
+                                }
+                            }
+                            uint32_t exposed_mip_levels = 0;
+                            while (exposed_mip_levels < mip_chain.level_count &&
+                                   (live_mip_mask & (1u << exposed_mip_levels)) != 0u)
+                                ++exposed_mip_levels;
+                            if (exposed_mip_levels > 1u &&
+                                fr.persistent_render_target_mip_ids[0] ==
+                                    fr.persistent_render_target_id) {
+                                fr.persistent_render_target_mip_count = exposed_mip_levels;
+                                fr.declared_mip_levels = exposed_mip_levels;
+                            } else {
+                                fr.persistent_render_target_mip_ids = {};
+                            }
+                            if (PROSPER_ENV_VALUE("PROSPER_RENDERER_MIP_CHAIN_LOG") != nullptr &&
+                                r.declared_mip_levels > 1u) {
+                                static std::set<uint64_t> logged_renderer_mips;
+                                if (logged_renderer_mips.insert(sampled_source_addr).second) {
+                                    std::fprintf(stderr,
+                                                 "[renderer-mips] addr=0x%llx %ux%u fmt=%u "
+                                                 "tile=%u declared=%u layout=%u live=%u "
+                                                 "present=0x%x valid=0x%x exposed=%u "
+                                                 "selected=%u retained=%zu shader=%llu set=%u binding=%u "
+                                                 "lod=%.3f..%.3f bias=%.3f filter=%u/%u/%u "
+                                                 "cache=%zu/%.1fMiB limit=%zu/%.1fMiB ids=",
+                                                 static_cast<unsigned long long>(sampled_source_addr),
+                                                 tw, th, static_cast<unsigned>(r.format), r.tile_mode,
+                                                 r.declared_mip_levels, mip_chain.level_count,
+                                                 live_mip_levels, present_mip_mask, live_mip_mask,
+                                                 exposed_mip_levels,
+                                                 renderer_mip_chain_selected ? 1u : 0u,
+                                                 retained_mips_consumed,
+                                                 static_cast<unsigned long long>(shader_identity),
+                                                 set, r.binding, r.min_lod, r.max_lod, r.lod_bias,
+                                                 r.mag_filter, r.min_filter, r.mip_filter,
+                                                 prosper::test::persistent_color_target_cache().size(),
+                                                 prosper::test::persistent_color_target_bytes() /
+                                                     (1024.0 * 1024.0),
+                                                 prosper::test::persistent_color_target_count_limit(),
+                                                 prosper::test::persistent_color_target_limit() /
+                                                     (1024.0 * 1024.0));
+                                    for (uint32_t level = 0; level < mip_chain.level_count; ++level)
+                                        std::fprintf(stderr, "%s0x%llx", level ? "," : "",
+                                                     static_cast<unsigned long long>(
+                                                         mip_chain.level_ids[level]));
+                                    std::fprintf(stderr, "\n");
+                                }
+                            }
                             resource_rtt_hit = true;
                         } else if (has_uniform_live_rtt) {
                             fr.has_uniform_color = true;
@@ -3866,7 +4202,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 else if (!live_rtt->second.gpu_valid) rtt_notvalid++;
                                 else if (live_rtt->second.w != tw || live_rtt->second.h != th)
                                     rtt_dimmismatch++;
-                                else if (draw_binds_color_target(draw, sampled_source_addr))
+                                else if (draw_binds_color_target(draw, sampled_source_addr, tw, th))
                                     rtt_self++;
                                 else if (prosper::test::find_persistent_color_target(
                                              sampled_source_addr, tw, th,
@@ -4344,11 +4680,18 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         std::snprintf(first_text, sizeof first_text, "0x%02x",
                                                       metadata[0]);
                                     fprintf(stderr,
-                                            "[render] compressed sampled image kind=%s addr=0x%llx "
+                                            "[render] compressed sampled image kind=%s draw=%llu "
+                                            "order=%llu fs=0x%llx fs-id=%llu target=0x%llx "
+                                            "addr=0x%llx "
                                             "meta=0x%llx %ux%ux%u fmt=%u ncomp=%u dim=%u tile=%u "
                                             "samples=%u pipe_aligned=%u ds_live=%u is unsupported; "
                                             "metadata=%zu/%llu first=%s\n",
                                             kind_name,
+                                            (unsigned long long)draw.draw_index,
+                                            (unsigned long long)draw.command_order,
+                                            (unsigned long long)draw.fs_guest_addr,
+                                            (unsigned long long)draw.fs_identity,
+                                            (unsigned long long)draw.color0_base,
                                             (unsigned long long)r.gpu_addr,
                                             (unsigned long long)r.metadata_addr,
                                             tw, th, r.depth, (unsigned)r.format, r.num_components,
@@ -5033,11 +5376,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             else prosper::gpu::detile_surface(
                                 texture_pixels.data(), tiled.data(), tw, th, tmode, pitch);
                         }
-                        // Packed R11G11B10F (Gen5 IMG_FMT 36 -> DataFormat::Float10_11_11, #294): UE4's
-                        // scene-color RT format. The texel IS 4 bytes, so the generic read + auto-detile
-                        // above already produced linear packed words; unpack each to RGBA8 in place with
-                        // the same semantics as the fp16 path (NaN/neg -> 0, clamp [0,1], no alpha -> 255).
+                        // Legacy fallback for packed R11G11B10F shapes outside the exact native upload
+                        // contract above. The texel IS 4 bytes, so the generic read + auto-detile already
+                        // produced linear packed words; only unsupported shapes still narrow to RGBA8.
                         if (!rtt_hit && !dcc_fast_clear_done && !portable_raw_uvec4_storage &&
+                            !native_r11_sampled &&
                             r.format == prosper::gpu::DataFormat::Float10_11_11) {
                             uint8_t* tp = texture_pixels.data();
                             const size_t decoded_texels = volume_texels * (cube_done ? 6u : 1u);
@@ -5192,6 +5535,29 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 (((size_t)z * th + y) * tw + x) * 2];
                                             p[0] = ck ? 200 : 40;
                                             p[1] = ck ? 40 : 200;
+                                        }
+                            } else if (fr.texture_format ==
+                                       VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
+                                for (uint32_t z = 0; z < slices; ++z)
+                                    for (uint32_t y = 0; y < th; ++y)
+                                        for (uint32_t x = 0; x < tw; ++x) {
+                                            const bool ck = ((x / 64) ^ (y / 64) ^ z) & 1;
+                                            const float values[3] = {
+                                                static_cast<float>(x) / tw,
+                                                static_cast<float>(y) / th,
+                                                ck ? 8.0f : 0.16f,
+                                            };
+                                            const uint32_t packed =
+                                                static_cast<uint32_t>(
+                                                    prosper::gpu::float_to_f11(values[0])) |
+                                                (static_cast<uint32_t>(
+                                                     prosper::gpu::float_to_f11(values[1])) << 11) |
+                                                (static_cast<uint32_t>(
+                                                     prosper::gpu::float_to_f10(values[2])) << 22);
+                                            std::memcpy(
+                                                texture_pixels.data() +
+                                                    (((size_t)z * th + y) * tw + x) * 4,
+                                                &packed, sizeof(packed));
                                         }
                             } else {
                                 for (uint32_t z = 0; z < slices; ++z)
@@ -6357,6 +6723,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                 // the backbuffer, incremental HUD updates) composites OVER the earlier content instead
                 // of starting from the diagnostic clear. Real RT memory persists exactly this way.
                 static const bool seed_rtt = getenv("PROSPER_RTT_NOSEED") == nullptr;
+                const auto& no_seed_targets = rtt_no_seed_target_selector();
+                const auto seed_target = [&](uint64_t target) {
+                    return seed_rtt && !(no_seed_targets.configured &&
+                        no_seed_targets.includes(target));
+                };
                 // Pass grouping and same-pass feedback detection must not disagree about what an
                 // active binding is, so both go through frontends/shared/rtt/mrt_binding.hpp. These
                 // were duplicated lambdas; a second, looser copy in the feedback path classified
@@ -6586,17 +6957,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                           prosper::test::ds_depth_view_slice_start(
                                               draw.ps.db_depth_view));
                     };
-                    const auto ds0 = ds_identity(items[pass_i]);
+                    const prosper::gpu::DrawItem& pass_head = items[pass_i];
+                    const auto ds0 = ds_identity(pass_head);
                     std::vector<const prosper::gpu::DrawItem*> pass;
                     auto same_targets = [&](const prosper::gpu::DrawItem& draw) {
-                        if (draw.color0_base != base ||
-                            active_color_count(draw) != requested_color_count ||
-                            active_format(draw, 0) != format0)
+                        if (!prosper::frontend::mrt_same_color_pass(
+                                pass_head, draw, mrt_format_defined, active_format))
                             return false;
                         if (ds_identity(draw) != ds0) return false;
-                        for (uint32_t slot = 1; slot < requested_color_count; ++slot)
-                            if (active_color(draw, slot) != pass_bases[slot] ||
-                                active_format(draw, slot) != pass_formats[slot]) return false;
                         return true;
                     };
                     while (pass_i < items.size() && same_targets(items[pass_i]) &&
@@ -6942,6 +7310,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const uint8_t* seed = nullptr;
                     const float* retained_uniform_clear = nullptr;
                     bool gpu_seed_available = false;
+                    const bool seed_rtt0 = seed_target(base);
                     const VkFormat pass_format = format0;
                     uint32_t mrt_count = requested_color_count;
                     if (PROSPER_ENV_ON("PROSPER_NO_MRT1") || PROSPER_ENV_ON("PROSPER_NO_MRT")) mrt_count = 1;
@@ -6982,7 +7351,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const VkFormat pass_format1 = use_color1 ? format1 : VK_FORMAT_UNDEFINED;
                     const size_t pass_bytes = static_cast<size_t>(gw) * gh *
                         prosper::test::backend_color_bytes_per_pixel(pass_format);
-                    if (seed_rtt && base) { auto sit = g_rtt.find(base);
+                    if (seed_rtt0 && base) { auto sit = g_rtt.find(base);
                         gpu_seed_available = live_gpu_targets && sit != g_rtt.end() &&
                             sit->second.gpu_valid && sit->second.w == gw && sit->second.h == gh &&
                             sit->second.format == pass_format &&
@@ -7163,7 +7532,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const uint8_t* seed1 = nullptr;
                     const float* retained_uniform_clear1 = nullptr;
                     bool gpu_seed1_available = false;
-                    if (seed_rtt && use_color1) { auto sit = g_rtt.find(base1);
+                    const bool seed_rtt1 = seed_target(base1);
+                    if (seed_rtt1 && use_color1) { auto sit = g_rtt.find(base1);
                         gpu_seed1_available = live_gpu_targets && sit != g_rtt.end() &&
                             sit->second.gpu_valid &&
                             sit->second.w == gw && sit->second.h == gh &&
@@ -7192,9 +7562,9 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     const auto build_start = timing_enabled
                         ? RenderClock::now() : RenderClock::time_point{};
                     prosper::test::BackendColorTarget backend_target{
-                        base, seed_rtt, !defer_readback, pass_format};
+                        base, seed_rtt0, !defer_readback, pass_format};
                     backend_target.persistent_id1 = use_color1 ? base1 : 0;
-                    backend_target.load_existing1 = seed_rtt;
+                    backend_target.load_existing1 = seed_rtt1;
                     backend_target.readback1 = !defer_readback1;
                     backend_target.format1 = pass_format1;
                     // Slots 2..7 retain across render groups on the same terms as slots 0 and 1.
@@ -7203,7 +7573,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     // images cleared per backend call.
                     for (uint32_t slot = 2; slot < mrt_count; ++slot) {
                         backend_target.persistent_id_slots[slot] = pass_bases[slot];
-                        backend_target.load_existing_slots[slot] = seed_rtt;
+                        backend_target.load_existing_slots[slot] = seed_target(pass_bases[slot]);
                     }
                     auto backend_draws = build_bds(render_pass);
                     const auto build_done = timing_enabled
@@ -7308,6 +7678,11 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             base, gw, gh, pass_format) != nullptr;
                         if (!pass_pixels->empty()) surface.rgba = pass_pixels;
                         else surface.rgba.reset();
+                        // GTA V builds its packed-HDR bloom pyramid as separate CB_COLOR targets,
+                        // then samples them as one mipmapped T#. A target may be hundreds of LRU
+                        // insertions old by that final draw. Pin every produced level now, while its
+                        // exact identity is known, and release the small set at the submit boundary.
+                        pin_renderer_mip_target(base, gw, gh, pass_format, surface.gpu_valid);
                         if (defer_readback && is_vo && surface.gpu_valid) {
                             const auto already_pinned = std::find_if(
                                 pinned_scanouts.begin(), pinned_scanouts.end(),
@@ -7405,6 +7780,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                         surface.gpu_valid =
                             prosper::test::find_persistent_color_target(
                                 pass_bases[slot], gw, gh, pass_formats[slot]) != nullptr;
+                        pin_renderer_mip_target(pass_bases[slot], gw, gh, pass_formats[slot],
+                                                surface.gpu_valid);
                         if (!pixels.empty())
                             surface.rgba = std::make_shared<const std::vector<uint8_t>>(
                                 std::move(pixels));
@@ -7835,7 +8212,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     "raw_fmt=%u\n",
                                     (unsigned long long)at, pass_i, items.size(),
                                     (unsigned long long)base, gw, gh, (int)pass_format,
-                                    (int)is_vo, (int)seed_rtt, (int)defer_readback,
+                                    (int)is_vo, (int)seed_rtt0, (int)defer_readback,
                                     (unsigned long long)color_target_call.writes, nz,
                                     rendered_pixels.size(),
                                     pass.empty() ? 0u : pass.front()->ps.color0_format);
@@ -8314,7 +8691,10 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
             if (timing_enabled && phase.final_span)
                 pending_timing.output_copy_ms += std::chrono::duration<double, std::milli>(
                     RenderClock::now() - output_copy_start).count();
-            if (phase.final_span) release_pinned_scanouts();
+            if (phase.final_span) {
+                release_pinned_scanouts();
+                release_consumed_renderer_mip_targets();
+            }
             if (phase.final_span && lightweight_rtt_timing && rtt_log_in_range &&
                 pending_timing.backend_draws >= rtt_timing_min_draws) {
                 std::string output;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -1163,11 +1163,17 @@ extern "C" int prosper_thread_in_renderer_callback(unsigned long native_tid) {
     return prosper::frontend::tid_is_in_renderer_callback(native_tid) ? 1 : 0;
 }
 
-void register_live_renderer(const std::string& frame_dir, bool dump_bmps_requested) {
+void register_live_renderer(const std::string& frame_dir, bool dump_bmps_requested,
+                            const std::string& title_id) {
     // Keep the legacy global disable authoritative for every frontend, including callers with their
     // own explicit opt-in such as PROSPER_APP_DUMP_FRAMES.
     const bool dump_bmps = frame_dump_request_allowed(
         dump_bmps_requested, PROSPER_ENV_VALUE("PROSPER_NO_FRAME_DUMPS"));
+    // GTA V's reviewed Performance-mode route contains Wave64 fragment programs whose only
+    // remaining width reason is a control-flow WaveAny. The backend may run that narrow class at
+    // NVIDIA's native Wave32 only for this title; every other title keeps master's fail-visible
+    // exact-width contract, and ballots/lane identity/scalar reductions stay exact even here.
+    const bool gta5_native_fragment_vote = title_id == "PPSA04263";
     // Create (and thereby PUBLISH) the renderer's Vulkan device up front so the compute backend can
     // adopt it (#1091). Compute initializes lazily on its first dispatch, and titles routinely
     // dispatch before their first draw -- without this the compute device would be created first and
@@ -1651,7 +1657,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
     if (batch_backend_submits)
         fprintf(stderr, "[render] backend target-submit batching enabled (experimental)\n");
     prosper::gpu::set_submit_renderer(
-        [frame_dir, dump_bmps, invalidate_ds](const std::vector<prosper::gpu::DrawItem>& items,
+        [frame_dir, dump_bmps, invalidate_ds, gta5_native_fragment_vote](const std::vector<prosper::gpu::DrawItem>& items,
                                uint32_t w, uint32_t h) -> prosper::gpu::RenderedFrame {
             using RC = prosper::gpu::ResourceClass;
             // #2215 instrument: publish which thread is inside a submit-render callback right
@@ -6777,6 +6783,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                     }
                     bd.vs_identity = refvs ? 0 : it.vs_identity;
                     bd.fs_identity = fs_ov ? 0 : it.fs_identity;
+                    bd.allow_native_fragment_vote_width =
+                        !fs_ov && gta5_native_fragment_vote;
                     bd.draw_index = it.draw_index;
                     bd.command_order = it.command_order;
                     bd.vcount = refvs ? 3u : it.vertex_count;

--- a/prosper/frontends/shared/live/live_renderer.hpp
+++ b/prosper/frontends/shared/live/live_renderer.hpp
@@ -147,7 +147,8 @@ bool texture_source_snapshot_can_follow_watch(bool source_matches_pixels,
 // written; it does not enable them. PROSPER_NO_FRAME_DUMPS remains a final kill switch even when a
 // caller explicitly requests dumps.
 void register_live_renderer(const std::string& frame_dir = ".",
-                            bool dump_bmps = kFrameDumpsByDefault);
+                            bool dump_bmps = kFrameDumpsByDefault,
+                            const std::string& title_id = {});
 
 // #2215: which OS thread is currently inside a live submit-render callback, or 0.
 //

--- a/prosper/frontends/shared/live/live_renderer.hpp
+++ b/prosper/frontends/shared/live/live_renderer.hpp
@@ -6,6 +6,7 @@
 // present layer (present_write_frame → present_readback). All the boot-time diagnostics
 // (PROSPER_RENDER_*, PROSPER_DUMP_*, PROSPER_TESTTEX, …) are preserved and remain env-gated.
 #pragma once
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -92,6 +93,27 @@ size_t texture_decode_cache_limit_bytes(const char* override_mib,
 bool sampled_msaa_fetch_shape_supported(const prosper::gpu::ShaderResource& resource,
                                         bool is_storage_image,
                                         bool reflected_msaa_fetch);
+
+// Preserve an ordinary guest R11G11B10F sampled texture in its native packed-HDR representation.
+// Expanding this format to RGBA8 is not merely a precision loss: every channel above 1.0 is clamped,
+// which removes the light energy from environment maps before the shader can consume it. Keep the
+// first exact path deliberately narrow; compressed, sRGB, array/cube/volume, and storage images retain
+// their existing materialization until those shapes have their own upload contracts.
+bool native_r11_sampled_upload_supported(const prosper::gpu::ShaderResource& resource);
+
+// Reconstruct the independently addressable CB_COLOR identities belonging to a sampled thin-2D
+// mip chain. Tiled allocations are tail-first/reverse: level zero is generally not the allocation
+// base, while every packed-tail level shares that base. The result describes address layout only;
+// the caller must still prove which identities currently exist in the renderer-owned target cache.
+struct RendererMipChainLayout {
+    std::array<uint64_t, 16> level_ids{};
+    uint32_t level_count = 0;
+};
+RendererMipChainLayout renderer_mip_chain_layout(uint64_t level_zero_address,
+                                                 uint32_t width, uint32_t height,
+                                                 uint32_t bytes_per_texel,
+                                                 uint32_t tile_mode,
+                                                 uint32_t declared_mip_levels);
 
 // Apply the remaining runtime gates to a texture_decode_cache_candidate(). Keeping the candidate
 // explicit is important: DCC metadata can provide a nonzero source span even when renderer-owned

--- a/prosper/frontends/shared/live/live_target_format.hpp
+++ b/prosper/frontends/shared/live/live_target_format.hpp
@@ -27,7 +27,15 @@ namespace prosper::frontend {
 // How one texel of the renderer's CPU snapshot is laid out. Conversion loops that implement a
 // subset of the layouts branch on THIS rather than on "is it RGBA8, else assume FP16", so a new
 // pixel format must be classified explicitly before it can reach a decoder that cannot read it.
-enum class LiveTargetSourceLayout : uint8_t { Unorm8x4, Float16x4, PackedR11G11B10 };
+enum class LiveTargetSourceLayout : uint8_t {
+    Unorm8x4,
+    Float16x4,
+    PackedR11G11B10,
+    Unorm8x1,
+    Uint32x1,
+    Float32x1,
+    Unorm8x2,
+};
 
 constexpr LiveTargetSourceLayout live_target_source_layout(
     prosper::gpu::LiveTargetPixelFormat format) {
@@ -38,6 +46,14 @@ constexpr LiveTargetSourceLayout live_target_source_layout(
             return LiveTargetSourceLayout::Float16x4;
         case prosper::gpu::LiveTargetPixelFormat::R11G11B10Float:
             return LiveTargetSourceLayout::PackedR11G11B10;
+        case prosper::gpu::LiveTargetPixelFormat::R8Unorm:
+            return LiveTargetSourceLayout::Unorm8x1;
+        case prosper::gpu::LiveTargetPixelFormat::R32Uint:
+            return LiveTargetSourceLayout::Uint32x1;
+        case prosper::gpu::LiveTargetPixelFormat::R32Float:
+            return LiveTargetSourceLayout::Float32x1;
+        case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:
+            return LiveTargetSourceLayout::Unorm8x2;
     }
     return LiveTargetSourceLayout::Unorm8x4;
 }
@@ -53,6 +69,14 @@ constexpr VkFormat live_target_pixel_format_vk(prosper::gpu::LiveTargetPixelForm
             return VK_FORMAT_R16G16B16A16_SFLOAT;
         case prosper::gpu::LiveTargetPixelFormat::R11G11B10Float:
             return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
+        case prosper::gpu::LiveTargetPixelFormat::R8Unorm:
+            return VK_FORMAT_R8_UNORM;
+        case prosper::gpu::LiveTargetPixelFormat::R32Uint:
+            return VK_FORMAT_R32_UINT;
+        case prosper::gpu::LiveTargetPixelFormat::R32Float:
+            return VK_FORMAT_R32_SFLOAT;
+        case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:
+            return VK_FORMAT_R8G8_UNORM;
     }
     return VK_FORMAT_UNDEFINED;
 }
@@ -64,6 +88,10 @@ constexpr uint32_t live_target_pixel_format_bytes(prosper::gpu::LiveTargetPixelF
         case prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm:      return 4u;
         case prosper::gpu::LiveTargetPixelFormat::Rgba16Float:     return 8u;
         case prosper::gpu::LiveTargetPixelFormat::R11G11B10Float:  return 4u;
+        case prosper::gpu::LiveTargetPixelFormat::R8Unorm:         return 1u;
+        case prosper::gpu::LiveTargetPixelFormat::R32Uint:         return 4u;
+        case prosper::gpu::LiveTargetPixelFormat::R32Float:        return 4u;
+        case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return 2u;
     }
     return 0u;
 }
@@ -75,6 +103,10 @@ constexpr const char* live_target_pixel_format_name(prosper::gpu::LiveTargetPixe
         case prosper::gpu::LiveTargetPixelFormat::Rgba8Unorm:      return "rgba8";
         case prosper::gpu::LiveTargetPixelFormat::Rgba16Float:     return "rgba16f";
         case prosper::gpu::LiveTargetPixelFormat::R11G11B10Float:  return "r11g11b10";
+        case prosper::gpu::LiveTargetPixelFormat::R8Unorm:         return "r8";
+        case prosper::gpu::LiveTargetPixelFormat::R32Uint:         return "r32ui";
+        case prosper::gpu::LiveTargetPixelFormat::R32Float:        return "r32f";
+        case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return "rg8";
     }
     return "unknown";
 }
@@ -95,6 +127,22 @@ constexpr bool live_target_pixel_format_from_vk(VkFormat vk_format,
     }
     if (vk_format == VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
         format = prosper::gpu::LiveTargetPixelFormat::R11G11B10Float;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R8_UNORM) {
+        format = prosper::gpu::LiveTargetPixelFormat::R8Unorm;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R32_UINT) {
+        format = prosper::gpu::LiveTargetPixelFormat::R32Uint;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R32_SFLOAT) {
+        format = prosper::gpu::LiveTargetPixelFormat::R32Float;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R8G8_UNORM) {
+        format = prosper::gpu::LiveTargetPixelFormat::Rg8Unorm;
         return true;
     }
     return false;

--- a/prosper/frontends/shared/live/live_target_format.hpp
+++ b/prosper/frontends/shared/live/live_target_format.hpp
@@ -36,6 +36,8 @@ enum class LiveTargetSourceLayout : uint8_t {
     Float32x1,
     Unorm8x2,
     Float32x4,
+    Float16x2,
+    Float16x1,
 };
 
 constexpr LiveTargetSourceLayout live_target_source_layout(
@@ -57,6 +59,10 @@ constexpr LiveTargetSourceLayout live_target_source_layout(
             return LiveTargetSourceLayout::Unorm8x2;
         case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:
             return LiveTargetSourceLayout::Float32x4;
+        case prosper::gpu::LiveTargetPixelFormat::Rg16Float:
+            return LiveTargetSourceLayout::Float16x2;
+        case prosper::gpu::LiveTargetPixelFormat::R16Float:
+            return LiveTargetSourceLayout::Float16x1;
     }
     return LiveTargetSourceLayout::Unorm8x4;
 }
@@ -82,6 +88,10 @@ constexpr VkFormat live_target_pixel_format_vk(prosper::gpu::LiveTargetPixelForm
             return VK_FORMAT_R8G8_UNORM;
         case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:
             return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case prosper::gpu::LiveTargetPixelFormat::Rg16Float:
+            return VK_FORMAT_R16G16_SFLOAT;
+        case prosper::gpu::LiveTargetPixelFormat::R16Float:
+            return VK_FORMAT_R16_SFLOAT;
     }
     return VK_FORMAT_UNDEFINED;
 }
@@ -98,6 +108,8 @@ constexpr uint32_t live_target_pixel_format_bytes(prosper::gpu::LiveTargetPixelF
         case prosper::gpu::LiveTargetPixelFormat::R32Float:        return 4u;
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return 2u;
         case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:     return 16u;
+        case prosper::gpu::LiveTargetPixelFormat::Rg16Float:       return 4u;
+        case prosper::gpu::LiveTargetPixelFormat::R16Float:        return 2u;
     }
     return 0u;
 }
@@ -114,6 +126,8 @@ constexpr const char* live_target_pixel_format_name(prosper::gpu::LiveTargetPixe
         case prosper::gpu::LiveTargetPixelFormat::R32Float:        return "r32f";
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return "rg8";
         case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:     return "rgba32f";
+        case prosper::gpu::LiveTargetPixelFormat::Rg16Float:       return "rg16f";
+        case prosper::gpu::LiveTargetPixelFormat::R16Float:        return "r16f";
     }
     return "unknown";
 }
@@ -154,6 +168,14 @@ constexpr bool live_target_pixel_format_from_vk(VkFormat vk_format,
     }
     if (vk_format == VK_FORMAT_R32G32B32A32_SFLOAT) {
         format = prosper::gpu::LiveTargetPixelFormat::Rgba32Float;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R16G16_SFLOAT) {
+        format = prosper::gpu::LiveTargetPixelFormat::Rg16Float;
+        return true;
+    }
+    if (vk_format == VK_FORMAT_R16_SFLOAT) {
+        format = prosper::gpu::LiveTargetPixelFormat::R16Float;
         return true;
     }
     return false;

--- a/prosper/frontends/shared/live/live_target_format.hpp
+++ b/prosper/frontends/shared/live/live_target_format.hpp
@@ -35,6 +35,7 @@ enum class LiveTargetSourceLayout : uint8_t {
     Uint32x1,
     Float32x1,
     Unorm8x2,
+    Float32x4,
 };
 
 constexpr LiveTargetSourceLayout live_target_source_layout(
@@ -54,6 +55,8 @@ constexpr LiveTargetSourceLayout live_target_source_layout(
             return LiveTargetSourceLayout::Float32x1;
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:
             return LiveTargetSourceLayout::Unorm8x2;
+        case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:
+            return LiveTargetSourceLayout::Float32x4;
     }
     return LiveTargetSourceLayout::Unorm8x4;
 }
@@ -77,6 +80,8 @@ constexpr VkFormat live_target_pixel_format_vk(prosper::gpu::LiveTargetPixelForm
             return VK_FORMAT_R32_SFLOAT;
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:
             return VK_FORMAT_R8G8_UNORM;
+        case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:
+            return VK_FORMAT_R32G32B32A32_SFLOAT;
     }
     return VK_FORMAT_UNDEFINED;
 }
@@ -92,6 +97,7 @@ constexpr uint32_t live_target_pixel_format_bytes(prosper::gpu::LiveTargetPixelF
         case prosper::gpu::LiveTargetPixelFormat::R32Uint:         return 4u;
         case prosper::gpu::LiveTargetPixelFormat::R32Float:        return 4u;
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return 2u;
+        case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:     return 16u;
     }
     return 0u;
 }
@@ -107,6 +113,7 @@ constexpr const char* live_target_pixel_format_name(prosper::gpu::LiveTargetPixe
         case prosper::gpu::LiveTargetPixelFormat::R32Uint:         return "r32ui";
         case prosper::gpu::LiveTargetPixelFormat::R32Float:        return "r32f";
         case prosper::gpu::LiveTargetPixelFormat::Rg8Unorm:        return "rg8";
+        case prosper::gpu::LiveTargetPixelFormat::Rgba32Float:     return "rgba32f";
     }
     return "unknown";
 }
@@ -145,7 +152,20 @@ constexpr bool live_target_pixel_format_from_vk(VkFormat vk_format,
         format = prosper::gpu::LiveTargetPixelFormat::Rg8Unorm;
         return true;
     }
+    if (vk_format == VK_FORMAT_R32G32B32A32_SFLOAT) {
+        format = prosper::gpu::LiveTargetPixelFormat::Rgba32Float;
+        return true;
+    }
     return false;
+}
+
+// Packed-HDR render targets can be the independently rendered levels of one sampled mip chain.
+// The frontend therefore keeps each such target resident until the logical submit ends: otherwise
+// ordinary LRU pressure can evict one middle level before the final consumer assembles the chain,
+// and deriving the missing level with a linear blit changes the guest's custom downsample result.
+// Keep this predicate exact rather than treating every four-byte target as interchangeable.
+constexpr bool renderer_mip_target_requires_submit_retention(VkFormat format) {
+    return format == VK_FORMAT_B10G11R11_UFLOAT_PACK32;
 }
 
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/perf/performance_capture.cpp
+++ b/prosper/frontends/shared/perf/performance_capture.cpp
@@ -352,16 +352,83 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
                 << ",\"texture_bytes\":" << record.texture_bytes
                 << ",\"buffer_bytes\":" << record.buffer_bytes
                 << ",\"total_ms\":" << record.total_ms
+                << ",\"prelude_ms\":" << record.prelude_ms
+                << ",\"pass_ms\":" << record.pass_ms
                 << ",\"build_resources_ms\":" << record.build_resources_ms
                 << ",\"backend_ms\":" << record.backend_ms
                 << ",\"output_copy_ms\":" << record.output_copy_ms
+                << ",\"pass_head_ms\":" << record.pass_head_ms
+                << ",\"pass_loop_ms\":" << record.pass_loop_ms
+                << ",\"pass_pre_ms\":" << record.pass_pre_ms
+                << ",\"pass_post_ms\":" << record.pass_post_ms
+                << ",\"pass_tail_ms\":" << record.pass_tail_ms
+                << ",\"post_stats_ms\":" << record.post_stats_ms
+                << ",\"post_slot0_ms\":" << record.post_slot0_ms
+                << ",\"post_mrt_ms\":" << record.post_mrt_ms
+                << ",\"post_rest_ms\":" << record.post_rest_ms
+                << ",\"resolve_stall_ms\":" << record.resolve_stall_ms
+                << ",\"resolve_read_ms\":" << record.resolve_read_ms
+                << ",\"resolve_copy_stall_ms\":" << record.resolve_copy_stall_ms
+                << ",\"resolve_copy_ms\":" << record.resolve_copy_ms
+                << ",\"resolve_count\":" << record.resolve_count
+                << ",\"resolve_read_count\":" << record.resolve_read_count
+                << ",\"resolve_bytes\":" << record.resolve_bytes
                 << ",\"gpu_wait_ms\":" << record.gpu_wait_ms
                 << ",\"gpu_timestamp_samples\":" << record.gpu_timestamp_samples
                 << ",\"gpu_device_ms\":" << record.gpu_device_ms
                 << ",\"readback_ms\":" << record.readback_ms
+                << ",\"backend_target_ms\":" << record.backend_target_ms
+                << ",\"backend_draw_setup_ms\":" << record.backend_draw_setup_ms
+                << ",\"backend_record_upload_ms\":" << record.backend_record_upload_ms
+                << ",\"backend_cleanup_ms\":" << record.backend_cleanup_ms
+                << ",\"backend_setup_shader_ms\":" << record.backend_setup_shader_ms
+                << ",\"backend_setup_fixed_ms\":" << record.backend_setup_fixed_ms
                 << ",\"setup_resources_ms\":" << record.setup_resources_ms
+                << ",\"backend_setup_pipeline_ms\":" << record.backend_setup_pipeline_ms
+                << ",\"backend_pipeline_refs\":" << record.backend_pipeline_refs
+                << ",\"backend_pipeline_hits\":" << record.backend_pipeline_hits
+                << ",\"backend_pipeline_misses\":" << record.backend_pipeline_misses
+                << ",\"backend_pipeline_bypasses\":" << record.backend_pipeline_bypasses
+                << ",\"backend_pipeline_entries\":" << record.backend_pipeline_entries
+                << ",\"backend_pipeline_evictions\":" << record.backend_pipeline_evictions
                 << ",\"frontend_texture_ms\":" << record.frontend_texture_ms
                 << ",\"frontend_buffer_ms\":" << record.frontend_buffer_ms
+                << ",\"frontend_tex_rtt_ms\":" << record.frontend_tex_rtt_ms
+                << ",\"frontend_tex_compute_ms\":" << record.frontend_tex_compute_ms
+                << ",\"frontend_tex_local_ms\":" << record.frontend_tex_local_ms
+                << ",\"frontend_tex_persist_hit_ms\":" << record.frontend_tex_persist_hit_ms
+                << ",\"frontend_tex_persist_reuse_ms\":" << record.frontend_tex_persist_reuse_ms
+                << ",\"frontend_tex_persist_miss_ms\":" << record.frontend_tex_persist_miss_ms
+                << ",\"frontend_tex_other_slowest_ms\":"
+                << record.frontend_tex_other_slowest_ms
+                << ",\"frontend_tex_other_addr\":" << record.frontend_tex_other_addr
+                << ",\"frontend_tex_other_source_bytes\":"
+                << record.frontend_tex_other_source_bytes
+                << ",\"frontend_tex_other_width\":" << record.frontend_tex_other_width
+                << ",\"frontend_tex_other_height\":" << record.frontend_tex_other_height
+                << ",\"frontend_tex_other_depth\":" << record.frontend_tex_other_depth
+                << ",\"frontend_tex_other_format\":" << record.frontend_tex_other_format
+                << ",\"frontend_tex_other_components\":"
+                << record.frontend_tex_other_components
+                << ",\"frontend_tex_other_tile_mode\":"
+                << record.frontend_tex_other_tile_mode
+                << ",\"frontend_tex_other_img_dim\":" << record.frontend_tex_other_img_dim
+                << ",\"frontend_tex_other_class\":" << record.frontend_tex_other_class
+                << ",\"frontend_tex_other_compute_candidate\":"
+                << (record.frontend_tex_other_compute_candidate ? "true" : "false")
+                << ",\"frontend_tex_other_persistent_candidate\":"
+                << (record.frontend_tex_other_persistent_candidate ? "true" : "false")
+                << ",\"frontend_tex_other_compressed\":"
+                << (record.frontend_tex_other_compressed ? "true" : "false")
+                << ",\"frontend_tex_other_depth_compare\":"
+                << (record.frontend_tex_other_depth_compare ? "true" : "false")
+                << ",\"frontend_tex_other_host_backed\":"
+                << (record.frontend_tex_other_host_backed ? "true" : "false")
+                << ",\"frontend_build_draw_ms\":" << record.frontend_build_draw_ms
+                << ",\"frontend_validate_ms\":" << record.frontend_validate_ms
+                << ",\"frontend_poison_ms\":" << record.frontend_poison_ms
+                << ",\"frontend_indices_ms\":" << record.frontend_indices_ms
+                << ",\"frontend_reflect_ms\":" << record.frontend_reflect_ms
                 << ",\"res_texture_ms\":" << record.res_texture_ms
                 << ",\"res_buffer_ms\":" << record.res_buffer_ms
                 << ",\"res_buffer_copy_ms\":" << record.res_buffer_copy_ms
@@ -380,7 +447,19 @@ void InteractivePerformanceCapture::publish_completed(std::unique_ptr<PendingCap
             write_optional(out, record.program_addr);
             out << ",\"program_hash\":";
             write_optional(out, record.program_hash);
-            out << ",\"total_ms\":" << record.total_ms << "}\n";
+            out << ",\"total_ms\":" << record.total_ms
+                << ",\"gpu_timestamp_samples\":" << record.gpu_timestamp_samples
+                << ",\"gpu_device_ms\":" << record.gpu_device_ms
+                << ",\"gpu_shader_ms\":" << record.gpu_shader_ms
+                << ",\"gpu_pre_ms\":" << record.gpu_pre_ms
+                << ",\"gpu_storage_copy_ms\":" << record.gpu_storage_copy_ms
+                << ",\"gpu_compare_ms\":" << record.gpu_compare_ms
+                << ",\"gpu_restore_ms\":" << record.gpu_restore_ms
+                << ",\"setup_ms\":" << record.setup_ms
+                << ",\"pipeline_ms\":" << record.pipeline_ms
+                << ",\"dispatch_wait_ms\":" << record.dispatch_wait_ms
+                << ",\"writeback_ms\":" << record.writeback_ms
+                << ",\"cleanup_ms\":" << record.cleanup_ms << "}\n";
         }
         out << "{\"type\":\"footer\",\"complete\":true,\"pre_samples\":"
             << capture->pre_samples.size() << ",\"post_samples\":" << capture->post_samples.size()

--- a/prosper/frontends/shared/perf/performance_capture.hpp
+++ b/prosper/frontends/shared/perf/performance_capture.hpp
@@ -35,20 +35,81 @@ struct RendererTimingRecord {
     uint64_t texture_bytes = 0;
     uint64_t buffer_bytes = 0;
     double total_ms = 0;
+    double prelude_ms = 0;
+    double pass_ms = 0;
     double build_resources_ms = 0;
     double backend_ms = 0;
     double output_copy_ms = 0;
+    double pass_head_ms = 0;
+    double pass_loop_ms = 0;
+    double pass_pre_ms = 0;
+    double pass_post_ms = 0;
+    double pass_tail_ms = 0;
+    double post_stats_ms = 0;
+    double post_slot0_ms = 0;
+    double post_mrt_ms = 0;
+    double post_rest_ms = 0;
+    double resolve_stall_ms = 0;
+    double resolve_read_ms = 0;
+    double resolve_copy_stall_ms = 0;
+    double resolve_copy_ms = 0;
+    uint64_t resolve_count = 0;
+    uint64_t resolve_read_count = 0;
+    uint64_t resolve_bytes = 0;
     double gpu_wait_ms = 0;
     uint64_t gpu_timestamp_samples = 0;
     double gpu_device_ms = 0;
     double readback_ms = 0;
+    double backend_target_ms = 0;
+    double backend_draw_setup_ms = 0;
+    double backend_record_upload_ms = 0;
+    double backend_cleanup_ms = 0;
+    double backend_setup_shader_ms = 0;
+    double backend_setup_fixed_ms = 0;
     double setup_resources_ms = 0;
+    double backend_setup_pipeline_ms = 0;
+    uint64_t backend_pipeline_refs = 0;
+    uint64_t backend_pipeline_hits = 0;
+    uint64_t backend_pipeline_misses = 0;
+    uint64_t backend_pipeline_bypasses = 0;
+    uint64_t backend_pipeline_entries = 0;
+    uint64_t backend_pipeline_evictions = 0;
     // FRONTEND resource time, accumulated in build_resources. These are NOT sub-buckets of
     // setup_resources_ms below: that one is the BACKEND's, and the two are different layers.
     // Subtracting these from it is a category error that produces a large, plausible, meaningless
     // residue -- I published one (#2215) before noticing, so the names now say which layer they are.
     double frontend_texture_ms = 0;
     double frontend_buffer_ms = 0;
+    double frontend_tex_rtt_ms = 0;
+    double frontend_tex_compute_ms = 0;
+    double frontend_tex_local_ms = 0;
+    double frontend_tex_persist_hit_ms = 0;
+    double frontend_tex_persist_reuse_ms = 0;
+    double frontend_tex_persist_miss_ms = 0;
+    // Slowest texture reference that reached none of the named outcome classes in this semantic
+    // submit. One fixed-size witness keeps F8 non-perturbing while still giving an offline report
+    // the exact resource identity needed to explain the residual.
+    double frontend_tex_other_slowest_ms = 0;
+    uint64_t frontend_tex_other_addr = 0;
+    uint64_t frontend_tex_other_source_bytes = 0;
+    uint32_t frontend_tex_other_width = 0;
+    uint32_t frontend_tex_other_height = 0;
+    uint32_t frontend_tex_other_depth = 0;
+    uint32_t frontend_tex_other_format = 0;
+    uint32_t frontend_tex_other_components = 0;
+    uint32_t frontend_tex_other_tile_mode = 0;
+    uint32_t frontend_tex_other_img_dim = 0;
+    uint32_t frontend_tex_other_class = 0;
+    bool frontend_tex_other_compute_candidate = false;
+    bool frontend_tex_other_persistent_candidate = false;
+    bool frontend_tex_other_compressed = false;
+    bool frontend_tex_other_depth_compare = false;
+    bool frontend_tex_other_host_backed = false;
+    double frontend_build_draw_ms = 0;
+    double frontend_validate_ms = 0;
+    double frontend_poison_ms = 0;
+    double frontend_indices_ms = 0;
+    double frontend_reflect_ms = 0;
     // BACKEND sub-buckets, which DO decompose setup_resources_ms:
     //     setup_resources_ms = res_texture + res_buffer + res_descriptor + other
     // `other` is deliberately not stored -- it is the remainder, and storing a number the reader can
@@ -83,6 +144,18 @@ struct ComputeTimingRecord {
     std::optional<uint64_t> program_addr;
     std::optional<uint64_t> program_hash;
     double total_ms = 0;
+    uint64_t gpu_timestamp_samples = 0;
+    double gpu_device_ms = 0;
+    double gpu_shader_ms = 0;
+    double gpu_pre_ms = 0;
+    double gpu_storage_copy_ms = 0;
+    double gpu_compare_ms = 0;
+    double gpu_restore_ms = 0;
+    double setup_ms = 0;
+    double pipeline_ms = 0;
+    double dispatch_wait_ms = 0;
+    double writeback_ms = 0;
+    double cleanup_ms = 0;
 };
 
 struct CaptureConfig {

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -80,19 +80,63 @@ uint32_t mrt_active_color_count(const prosper::gpu::DrawItem& draw, FormatDefine
     return count;
 }
 
-// Does this draw bind `addr` as any ACTIVE colour target? The feedback question, answered through
-// the same rule pass grouping uses rather than a second interpretation of it.
+// Can two consecutive draws share one backend colour pass?
+//
+// A target address is not a complete attachment identity.  Packed mip tails legitimately give two
+// rendered levels the same guest address while their extents still differ.  Grouping only on
+// address and format made GTA V's 64x32 and 32x16 R11G11B10F levels share
+// one 64x32 Vulkan attachment.  The missing last level was then sampled as undefined max-float data
+// by deferred lighting.  Unknown 0x0 extents remain non-conflicting, matching mrt_extent_conflicts.
+template <typename FormatDefined, typename FormatAt>
+bool mrt_same_color_pass(const prosper::gpu::DrawItem& first,
+                         const prosper::gpu::DrawItem& candidate,
+                         FormatDefined format_defined, FormatAt format_at) {
+    const uint32_t count = mrt_active_color_count(first, format_defined);
+    if (mrt_active_color_count(candidate, format_defined) != count) return false;
+    for (uint32_t slot = 0; slot < count; ++slot) {
+        const auto a = mrt_color_binding(first, slot);
+        const auto b = mrt_color_binding(candidate, slot);
+        const uint64_t a_base = slot == 0 ? a.base
+            : mrt_active_color(first, slot, format_defined);
+        const uint64_t b_base = slot == 0 ? b.base
+            : mrt_active_color(candidate, slot, format_defined);
+        if (a_base != b_base || format_at(first, slot) != format_at(candidate, slot))
+            return false;
+        const bool active = slot == 0 || a_base || b_base;
+        if (active && mrt_extent_conflicts(a.width, a.height, b.width, b.height))
+            return false;
+    }
+    return true;
+}
+
+// Does this draw bind the sampled VIEW as any ACTIVE colour target? Address alone is insufficient:
+// packed mip tails may give two levels the same guest base even though they are separate Vulkan
+// images. Known, conflicting extents therefore prove that the sampled view is not the attachment.
+// Unknown extents remain conservative and count an address match as feedback -- unlike pass
+// grouping, this decision protects us from binding one image simultaneously for sampling and
+// rendering, so absence of evidence cannot make the operation safe.
+template <typename FormatDefined>
+bool mrt_draw_binds_target_view(const prosper::gpu::DrawItem& draw, uint64_t addr,
+                                uint32_t sampled_width, uint32_t sampled_height,
+                                FormatDefined format_defined) {
+    if (!addr) return false;
+    for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
+        if (mrt_active_color(draw, slot, format_defined) != addr) continue;
+        const auto binding = mrt_color_binding(draw, slot);
+        if (mrt_extent_conflicts(binding.width, binding.height,
+                                 sampled_width, sampled_height))
+            continue;
+        return true;
+    }
+    return false;
+}
+
+// Address-only compatibility wrapper. With an unknown sampled extent it deliberately keeps the
+// historical conservative behaviour.
 template <typename FormatDefined>
 bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
                            FormatDefined format_defined) {
-    if (!addr) return false;
-    uint64_t bases[prosper::gpu::kColorTargetCount]{};
-    bool active[prosper::gpu::kColorTargetCount]{};
-    for (uint32_t slot = 0; slot < prosper::gpu::kColorTargetCount; ++slot) {
-        bases[slot] = mrt_active_color(draw, slot, format_defined);
-        active[slot] = bases[slot] != 0u;
-    }
-    return mrt_target_feedback(bases, active, prosper::gpu::kColorTargetCount, addr);
+    return mrt_draw_binds_target_view(draw, addr, 0u, 0u, format_defined);
 }
 
 // The two materialization decisions that key on feedback, as seams that OWN their gate.
@@ -110,10 +154,12 @@ bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
 // May the retained GPU image serve this sample directly?
 template <typename FormatDefined>
 bool mrt_direct_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
+                       uint32_t sampled_width, uint32_t sampled_height,
                        bool is_storage_image, uint32_t img_dim, bool extent_compatible,
                        bool has_persistent_target, FormatDefined format_defined) {
     return !is_storage_image && img_dim == 1u && extent_compatible && has_persistent_target &&
-           !mrt_draw_binds_target(draw, sampled, format_defined);
+           !mrt_draw_binds_target_view(draw, sampled, sampled_width, sampled_height,
+                                       format_defined);
 }
 
 // May the uniform-colour fast path serve this sample? `preconditions` folds the caller's own
@@ -121,8 +167,11 @@ bool mrt_direct_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
 // with a usable extent) so this seam owns exactly the feedback gate and nothing it cannot see.
 template <typename FormatDefined>
 bool mrt_uniform_live_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
+                             uint32_t sampled_width, uint32_t sampled_height,
                              bool preconditions, FormatDefined format_defined) {
-    return preconditions && !mrt_draw_binds_target(draw, sampled, format_defined);
+    return preconditions &&
+           !mrt_draw_binds_target_view(draw, sampled, sampled_width, sampled_height,
+                                       format_defined);
 }
 
 }  // namespace prosper::frontend

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -151,15 +151,21 @@ bool mrt_draw_binds_target(const prosper::gpu::DrawItem& draw, uint64_t addr,
 // and the resource degrades to guest bytes. So a feedback collision has to be seen by BOTH, and it
 // used to be seen by neither above slot 1.
 
-// May the retained GPU image serve this sample directly?
+// May the retained GPU image serve this sample without materializing guest/CPU bytes? An ordinary
+// non-feedback sample borrows the target directly. When `feedback_copy_supported` is true, an exact
+// attachment collision is also admitted because the backend snapshots the prior attachment version
+// into a distinct sampled image before beginning the render pass. The default preserves the
+// conservative contract for callers that do not implement that GPU copy.
 template <typename FormatDefined>
 bool mrt_direct_serves(const prosper::gpu::DrawItem& draw, uint64_t sampled,
                        uint32_t sampled_width, uint32_t sampled_height,
                        bool is_storage_image, uint32_t img_dim, bool extent_compatible,
-                       bool has_persistent_target, FormatDefined format_defined) {
+                       bool has_persistent_target, FormatDefined format_defined,
+                       bool feedback_copy_supported = false) {
+    const bool feedback = mrt_draw_binds_target_view(
+        draw, sampled, sampled_width, sampled_height, format_defined);
     return !is_storage_image && img_dim == 1u && extent_compatible && has_persistent_target &&
-           !mrt_draw_binds_target_view(draw, sampled, sampled_width, sampled_height,
-                                       format_defined);
+           (!feedback || feedback_copy_supported);
 }
 
 // May the uniform-colour fast path serve this sample? `preconditions` folds the caller's own

--- a/prosper/frontends/shared/rtt/mrt_extent.hpp
+++ b/prosper/frontends/shared/rtt/mrt_extent.hpp
@@ -77,4 +77,15 @@ constexpr bool mrt_extent_conflicts(uint32_t slot_w, uint32_t slot_h,
     return slot_w != pass_w || slot_h != pass_h;
 }
 
+// The view-aware form used when both the sampled resource and the pass attachment have measured
+// extents. Packed mip tails may reuse one guest base for multiple independently rendered Vulkan
+// images; an address match with conflicting known extents is therefore not feedback. Unknown
+// extents retain the conservative address-only answer.
+constexpr bool mrt_target_view_feedback(const uint64_t* bases, const bool* active, uint32_t count,
+                                        uint64_t sampled, uint32_t sampled_w, uint32_t sampled_h,
+                                        uint32_t attachment_w, uint32_t attachment_h) {
+    if (mrt_extent_conflicts(sampled_w, sampled_h, attachment_w, attachment_h)) return false;
+    return mrt_target_feedback(bases, active, count, sampled);
+}
+
 } // namespace prosper::frontend

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -180,6 +180,8 @@ int main() {
         // become the same image.
         CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, true, true,
                                  format_defined));
+        CHECK(mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, true, true,
+                                format_defined, /*feedback_copy_supported=*/true));
         // The non-feedback preconditions still gate it.
         CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
                                  /*is_storage_image=*/true, 1u, true, true,

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -34,6 +34,10 @@ namespace {
 // fails rather than silently invalidating this file.
 bool format_defined(uint32_t raw) { (void)raw; return true; }
 
+uint32_t format_at(const prosper::gpu::DrawItem& draw, uint32_t slot) {
+    return prosper::frontend::mrt_raw_format(draw, slot);
+}
+
 prosper::gpu::DrawItem make_draw() {
     prosper::gpu::DrawItem draw{};
     return draw;
@@ -45,6 +49,8 @@ int main() {
     using prosper::frontend::mrt_active_color;
     using prosper::frontend::mrt_active_color_count;
     using prosper::frontend::mrt_draw_binds_target;
+    using prosper::frontend::mrt_draw_binds_target_view;
+    using prosper::frontend::mrt_same_color_pass;
 
     constexpr uint64_t kMrt0 = 0x2050000000ull;
     constexpr uint64_t kMrt2 = 0x2083e00000ull;
@@ -120,6 +126,38 @@ int main() {
         CHECK(mrt_active_color_count(draw, format_defined) == 1u);
     }
 
+    // A packed mip tail may place two different rendered levels at the same guest address.  They
+    // must form different backend passes: one Vulkan attachment has one extent and cannot represent
+    // both GTA V's 64x32 and 32x16 levels.  Exact peers still group, while an unknown legacy extent
+    // remains non-conflicting rather than inventing evidence.
+    {
+        constexpr uint64_t kTail = 0x209c980000ull;
+        auto mip4 = make_draw();
+        mip4.color_targets[0] = {kTail, 64u, 32u};
+        mip4.ps.color_targets[0].format = 122u;
+        mip4.ps.color_targets[0].write_mask = 0xfu;
+
+        auto peer = mip4;
+        CHECK(mrt_same_color_pass(mip4, peer, format_defined, format_at));
+
+        auto mip5 = mip4;
+        mip5.color_targets[0].width = 32u;
+        mip5.color_targets[0].height = 16u;
+        CHECK(!mrt_same_color_pass(mip4, mip5, format_defined, format_at));
+
+        // The mip-5 draw samples mip 4 by the same guest address. Different known extents prove
+        // that these are different attachment views, so this is not feedback. An exact peer is;
+        // an unknown extent remains conservative because binding the wrong live image is unsafe.
+        CHECK(!mrt_draw_binds_target_view(mip5, kTail, 64u, 32u, format_defined));
+        CHECK(mrt_draw_binds_target_view(mip5, kTail, 32u, 16u, format_defined));
+        CHECK(mrt_draw_binds_target_view(mip5, kTail, 0u, 0u, format_defined));
+
+        auto legacy_unknown = mip4;
+        legacy_unknown.color_targets[0].width = 0u;
+        legacy_unknown.color_targets[0].height = 0u;
+        CHECK(mrt_same_color_pass(mip4, legacy_unknown, format_defined, format_at));
+    }
+
     // The two materialization decisions, at the seams that own their gate. Written against the
     // decisions rather than the helper because the previous round's tests called
     // mrt_draw_binds_target() directly and stayed green when either production site was reverted to
@@ -134,29 +172,36 @@ int main() {
         draw.ps.color_targets[2].write_mask = 0xfu;
 
         // Sampling an unrelated surface: the direct image serves.
-        CHECK(mrt_direct_serves(draw, 0x2099cc0000ull, /*is_storage_image=*/false, /*img_dim=*/1u,
+        CHECK(mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                /*is_storage_image=*/false, /*img_dim=*/1u,
                                 /*extent_compatible=*/true, /*has_persistent_target=*/true,
                                 format_defined));
         // Sampling THIS pass's MRT2: it must not, or the descriptor and the colour attachment
         // become the same image.
-        CHECK(!mrt_direct_serves(draw, kMrt2, false, 1u, true, true, format_defined));
+        CHECK(!mrt_direct_serves(draw, kMrt2, 64u, 32u, false, 1u, true, true,
+                                 format_defined));
         // The non-feedback preconditions still gate it.
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, /*is_storage_image=*/true, 1u, true, true,
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                 /*is_storage_image=*/true, 1u, true, true,
                                  format_defined));
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, /*img_dim=*/5u, true, true,
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                 false, /*img_dim=*/5u, true, true,
                                  format_defined));
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, 1u, /*extent_compatible=*/false,
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                 false, 1u, /*extent_compatible=*/false,
                                  true, format_defined));
-        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, false, 1u, true,
+        CHECK(!mrt_direct_serves(draw, 0x2099cc0000ull, 64u, 32u, false, 1u, true,
                                  /*has_persistent_target=*/false, format_defined));
 
         // The uniform fast path carries the same gate. It and mrt_direct_serves must agree: if this
         // one said yes on a collision the CPU materialisation would be skipped, and the direct bind
         // would then be refused with no snapshot left to fall back to.
-        CHECK(mrt_uniform_live_serves(draw, 0x2099cc0000ull, /*preconditions=*/true,
+        CHECK(mrt_uniform_live_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                      /*preconditions=*/true,
                                       format_defined));
-        CHECK(!mrt_uniform_live_serves(draw, kMrt2, true, format_defined));
-        CHECK(!mrt_uniform_live_serves(draw, 0x2099cc0000ull, /*preconditions=*/false,
+        CHECK(!mrt_uniform_live_serves(draw, kMrt2, 64u, 32u, true, format_defined));
+        CHECK(!mrt_uniform_live_serves(draw, 0x2099cc0000ull, 64u, 32u,
+                                       /*preconditions=*/false,
                                        format_defined));
 
         // A slot that is bound but MASKED OFF is not a target, so sampling it is not feedback and
@@ -166,7 +211,8 @@ int main() {
         masked.color_targets[2].base = kMrt2;
         masked.ps.color_targets[2].format = 37u;
         masked.ps.color_targets[2].write_mask = 0u;
-        CHECK(mrt_direct_serves(masked, kMrt2, false, 1u, true, true, format_defined));
+        CHECK(mrt_direct_serves(masked, kMrt2, 64u, 32u, false, 1u, true, true,
+                                format_defined));
     }
 
     if (failures == 0) std::printf("mrt_binding: OK\n");

--- a/prosper/frontends/shared/tests/test_mrt_extent.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_extent.cpp
@@ -139,6 +139,16 @@ int main() {
         CHECK(!prosper::frontend::mrt_target_feedback(bases, all_active, 8, 0));
         CHECK(!prosper::frontend::mrt_target_feedback(nullptr, all_active, 8, 0x2050000000ull));
         CHECK(!prosper::frontend::mrt_target_feedback(bases, nullptr, 8, 0x2050000000ull));
+
+        // Packed-tail image views can share a guest base without sharing an attachment identity.
+        // Known 64x32 versus 32x16 extents prove this is not feedback; equal or unknown extents
+        // preserve the conservative collision answer.
+        CHECK(!prosper::frontend::mrt_target_view_feedback(
+            bases, all_active, 8, 0x2050000000ull, 64, 32, 32, 16));
+        CHECK(prosper::frontend::mrt_target_view_feedback(
+            bases, all_active, 8, 0x2050000000ull, 32, 16, 32, 16));
+        CHECK(prosper::frontend::mrt_target_view_feedback(
+            bases, all_active, 8, 0x2050000000ull, 0, 0, 32, 16));
     }
 
     // Printed LAST, after every check above has run. It sat before the checks added in the

--- a/prosper/frontends/shared/tests/test_performance_capture.cpp
+++ b/prosper/frontends/shared/tests/test_performance_capture.cpp
@@ -130,6 +130,18 @@ int main() {
         record.callbacks = 1;
         record.draws = 100 + i;
         record.total_ms = 20 + i;
+        record.pass_loop_ms = 7 + i;
+        record.frontend_tex_persist_miss_ms = 2 + i;
+        record.frontend_tex_other_slowest_ms = 1.5 + i;
+        record.frontend_tex_other_addr = 0x2046960000ull + i * 0x1000;
+        record.frontend_tex_other_width = 2560;
+        record.frontend_tex_other_height = 1440;
+        record.frontend_tex_other_depth = 1;
+        record.frontend_tex_other_format = 1;
+        record.frontend_tex_other_components = 1;
+        record.frontend_tex_other_tile_mode = 24;
+        record.frontend_tex_other_compute_candidate = true;
+        record.resolve_read_count = 3 + i;
         record.setup_resources_ms = 10 + i;
         record.gpu_timestamp_samples = 2 + i;
         capture.record_renderer(record);
@@ -185,6 +197,12 @@ int main() {
           "serialized detail counts match the bounded retained records");
     check(text.find("\"gpu_timestamp_samples\":2") != std::string::npos,
           "renderer records serialize the GPU timestamp availability discriminator");
+    check(text.find("\"pass_loop_ms\":7") != std::string::npos &&
+          text.find("\"frontend_tex_persist_miss_ms\":2") != std::string::npos &&
+          text.find("\"frontend_tex_other_addr\":138623188992") != std::string::npos &&
+          text.find("\"frontend_tex_other_compute_candidate\":true") != std::string::npos &&
+          text.find("\"resolve_read_count\":3") != std::string::npos,
+          "renderer records serialize the frontend phase, cache-class, residual witness, and resolve diagnostics");
     check(text.find("\"program_addr\":78187493376") != std::string::npos &&
           text.find("\"program_hash\":18364758544493064720") != std::string::npos,
           "compute records serialize the bounded program identity");

--- a/prosper/frontends/shared/texture/texture_decode_cache_policy.hpp
+++ b/prosper/frontends/shared/texture/texture_decode_cache_policy.hpp
@@ -8,36 +8,44 @@ namespace prosper::frontend {
 // Decide whether guest bytes are the authoritative source for a sampled-texture decode. Retained
 // color and depth targets are already represented by Vulkan images and must bypass CPU decode-cache
 // validation; captured host backing and non-texture resources follow their dedicated paths. Supported
-// 3D volume inputs, the graphics backend's base-slice 2D-array view, and block-compressed cubes are
-// pure guest-byte decodes and may be retained. Non-BC cubes remain excluded: broad Float16 cube
-// retention caused cache/write-watch churn on Plucky Squire, while BC cubes avoid an expensive,
-// deterministic block decode and have an exact six-face source range.
+// 3D volume inputs, the graphics backend's base-slice 2D-array view, and exact layered cubes are pure
+// guest-byte decodes and may be retained. Non-BC cubes remain excluded by default: broad Float16 cube
+// retention caused cache/write-watch churn on Plucky Squire. A caller may explicitly admit a narrow
+// uncompressed cube class only after proving that its decoder reads an exact six-face source range.
 constexpr bool texture_decode_cache_candidate(bool has_live_color_target,
                                                bool has_live_depth_target,
                                                bool has_captured_host_data,
                                                uint32_t image_dimension,
                                                bool is_sampled_texture,
                                                bool format_supported,
-                                               bool block_compressed) {
+                                               bool block_compressed,
+                                               bool exact_uncompressed_cube = false) {
     return !has_live_color_target && !has_live_depth_target &&
         !has_captured_host_data &&
         (image_dimension == 1u || image_dimension == 2u || image_dimension == 5u ||
-         (image_dimension == 3u && block_compressed)) &&
+         (image_dimension == 3u && (block_compressed || exact_uncompressed_cube))) &&
         is_sampled_texture && format_supported;
 }
 
-// Convert a block-compressed cube's descriptor footprint into the exact contiguous validation span.
+// Convert a layered cube's descriptor footprint into the exact contiguous validation span.
 // The footprint covers the selected level in all six independently-strided face chains, including
 // alignment gaps. Zero and overflowing ranges fail closed so cache reuse can never be proved against
 // less memory than the layer-aware decoder reads.
-constexpr size_t block_compressed_cube_source_size(bool block_compressed_cube,
-                                                    uint64_t gpu_address,
-                                                    uint64_t descriptor_footprint) {
-    if (!block_compressed_cube || !descriptor_footprint ||
+constexpr size_t layered_cube_source_size(bool exact_layered_cube,
+                                          uint64_t gpu_address,
+                                          uint64_t descriptor_footprint) {
+    if (!exact_layered_cube || !descriptor_footprint ||
         descriptor_footprint > SIZE_MAX ||
         gpu_address > UINT64_MAX - descriptor_footprint)
         return 0;
     return static_cast<size_t>(descriptor_footprint);
+}
+
+constexpr size_t block_compressed_cube_source_size(bool block_compressed_cube,
+                                                    uint64_t gpu_address,
+                                                    uint64_t descriptor_footprint) {
+    return layered_cube_source_size(
+        block_compressed_cube, gpu_address, descriptor_footprint);
 }
 
 } // namespace prosper::frontend

--- a/prosper/src/gpu/agc/agc_shader_layout.cpp
+++ b/prosper/src/gpu/agc/agc_shader_layout.cpp
@@ -1054,25 +1054,7 @@ ShaderResourceTable build_shader_resources(const AgcShaderHeader& shdr,
                     uint32_t sm_buf[4];
                     if (load_sharp(soff, 4, sm_buf) != 0xFFFFFFFFu) {
                         const uint32_t* sm = sm_buf;
-                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
-                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
-                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
-                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
-                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
-                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
-                        // Remaining SQ_IMG_SAMP fields (#262). WORD0: MAX_ANISO_RATIO[11:9],
-                        // DEPTH_COMPARE_FUNC[14:12], FORCE_UNNORMALIZED[15]. WORD1: MIN_LOD[11:0],
-                        // MAX_LOD[23:12] (u4.8). WORD2: LOD_BIAS[13:0] (s5.8, signed). WORD3:
-                        // BORDER_COLOR_TYPE[31:30]. CONFIDENCE: HIGH (standard GCN/RDNA2 SQ_IMG_SAMP layout).
-                        r.max_aniso_ratio    = (sm[0] >> 9)  & 0x7u;
-                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
-                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
-                        r.min_lod            = (float)( sm[1]        & 0xFFFu) / 256.0f;
-                        r.max_lod            = (float)((sm[1] >> 12) & 0xFFFu) / 256.0f;
-                        int32_t bias14       = (int32_t)(sm[2] & 0x3FFFu);
-                        if (bias14 & 0x2000) bias14 -= 0x4000;           // sign-extend the 14-bit s5.8
-                        r.lod_bias           = (float)bias14 / 256.0f;
-                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
+                        apply_sampler_descriptor(r, sm);
                         if (getenv("PROSPER_GFXLOG"))
                             fprintf(stderr, "[s#] slot%u mag=%u min=%u mip=%u addr=%u,%u,%u | aniso=%u cmp=%u unnorm=%u "
                                     "lod=[%.3f,%.3f] bias=%.3f border=%u | raw %08x %08x %08x %08x\n",

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -1165,6 +1165,8 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
         case GpuCaptureColorFormat::R11G11B10Float: bytes_per_pixel = 4; break;
         case GpuCaptureColorFormat::R8Unorm: bytes_per_pixel = 1; break;
         case GpuCaptureColorFormat::R32Uint: bytes_per_pixel = 4; break;
+        case GpuCaptureColorFormat::R32Float: bytes_per_pixel = 4; break;
+        case GpuCaptureColorFormat::Rg8Unorm: bytes_per_pixel = 2; break;
         default: error = "RTT seed has an unsupported color format"; return false;
     }
     const uint64_t pixels = checked_mul(seed.width, seed.height);

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -1172,6 +1172,8 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
         case GpuCaptureColorFormat::R32Float: bytes_per_pixel = 4; break;
         case GpuCaptureColorFormat::Rg8Unorm: bytes_per_pixel = 2; break;
         case GpuCaptureColorFormat::Rgba32Float: bytes_per_pixel = 16; break;
+        case GpuCaptureColorFormat::Rg16Float: bytes_per_pixel = 4; break;
+        case GpuCaptureColorFormat::R16Float: bytes_per_pixel = 2; break;
         default: error = "RTT seed has an unsupported color format"; return false;
     }
     const uint64_t pixels = checked_mul(seed.width, seed.height);

--- a/prosper/src/gpu/capture/gpu_capture.cpp
+++ b/prosper/src/gpu/capture/gpu_capture.cpp
@@ -133,7 +133,9 @@ constexpr char kMagic[8] = {'P','R','G','P','C','A','P','\0'};
 // source records, and carrier witnesses instead of being trusted as serialized authority.
 // v54: retain the explicit scalar S_BUFFER dword bound. The ordinary resource size remains the V#'s
 // independent vector footprint; replay cannot reconstruct one from the other when STRIDE < 4.
-constexpr uint32_t kVersion = 55;
+// v55: append each depth/stencil seed's optional stencil bytes and stencil-presence marker.
+// v56: extend the append-only RTT-seed format enum with native RGBA32F surfaces.
+constexpr uint32_t kVersion = 56;
 constexpr uint32_t kEndian = 0x01020304u;
 constexpr uint64_t kMaxFileBytes = 4ull << 30;
 constexpr uint64_t kMaxBlobDefaultBytes = 1ull << 30;
@@ -680,10 +682,15 @@ uint64_t resource_footprint_impl(const ShaderResource& r, bool legacy_linear_tig
         }
     } else {
         uint32_t bpt = data_format_bytes(r.format) * (r.num_components ? r.num_components : 1);
-        const bool native_wide = r.cls == ResourceClass::StorageImage ||
-            (r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8)) ||
-            (r.format == DataFormat::Float32 && (bpt == 4 || bpt == 8 || bpt == 16));
-        if (bpt == 0 || (bpt > 4 && !native_wide)) bpt = 4;
+        // This is the GUEST allocation footprint, not the backend's eventual upload width.  A
+        // sampled image may be converted to RGBA8 later, but its captured source must still include
+        // every native component.  Clamping sampled texels wider than four bytes truncated GTA V's
+        // 640x360 Uint32x2 SW_64KB_R_X surface to its declared tight span (1,843,200 bytes) instead
+        // of the padded tiled span (1,966,080 bytes).  The live compute consumer could read it while
+        // replay declined the same ordered producer -> consumer edge as "sampled surface unreadable".
+        // Packed formats deliberately report zero per-component width and retain the four-byte word
+        // fallback below.
+        if (bpt == 0) bpt = 4;
         if (tile_mode_is_tiled(r.tile_mode)) {
             const bool tiled_msaa = r.img_dim == 6u && r.sample_count > 1u;
             if (tiled_msaa) {
@@ -1087,10 +1094,7 @@ bool capture_table(const ShaderResourceTable* src, const std::vector<Interval>& 
                 : resource_width;
             uint32_t bpt = bc ? bc : data_format_bytes(r.format) *
                 (r.num_components ? r.num_components : 1u);
-            const bool native_wide =
-                (r.format == DataFormat::Float16 && (bpt == 2 || bpt == 4 || bpt == 8)) ||
-                (r.format == DataFormat::Float32 && (bpt == 4 || bpt == 8 || bpt == 16));
-            if (bpt == 0 || (bpt > 4 && !native_wide && !bc)) bpt = 4;
+            if (bpt == 0) bpt = 4;
             c.resource.linear_row_pitch_bytes = resolved_linear_row_pitch(
                 r, pitch_width, bpt);
         }
@@ -1167,6 +1171,7 @@ bool validate_rtt_seed(const GpuCaptureRttSeed& seed, std::string& error) {
         case GpuCaptureColorFormat::R32Uint: bytes_per_pixel = 4; break;
         case GpuCaptureColorFormat::R32Float: bytes_per_pixel = 4; break;
         case GpuCaptureColorFormat::Rg8Unorm: bytes_per_pixel = 2; break;
+        case GpuCaptureColorFormat::Rgba32Float: bytes_per_pixel = 16; break;
         default: error = "RTT seed has an unsupported color format"; return false;
     }
     const uint64_t pixels = checked_mul(seed.width, seed.height);

--- a/prosper/src/gpu/capture/gpu_capture.hpp
+++ b/prosper/src/gpu/capture/gpu_capture.hpp
@@ -311,6 +311,8 @@ enum class GpuCaptureColorFormat : uint32_t {
     R32Float = 6,
     Rg8Unorm = 7,
     Rgba32Float = 8,
+    Rg16Float = 9,
+    R16Float = 10,
 };
 
 struct GpuCaptureRttSeed {

--- a/prosper/src/gpu/capture/gpu_capture.hpp
+++ b/prosper/src/gpu/capture/gpu_capture.hpp
@@ -308,6 +308,8 @@ enum class GpuCaptureColorFormat : uint32_t {
     R11G11B10Float = 3,
     R8Unorm = 4,
     R32Uint = 5,
+    R32Float = 6,
+    Rg8Unorm = 7,
 };
 
 struct GpuCaptureRttSeed {

--- a/prosper/src/gpu/capture/gpu_capture.hpp
+++ b/prosper/src/gpu/capture/gpu_capture.hpp
@@ -310,6 +310,7 @@ enum class GpuCaptureColorFormat : uint32_t {
     R32Uint = 5,
     R32Float = 6,
     Rg8Unorm = 7,
+    Rgba32Float = 8,
 };
 
 struct GpuCaptureRttSeed {

--- a/prosper/src/gpu/execute/gpu_dependency_graph.cpp
+++ b/prosper/src/gpu/execute/gpu_dependency_graph.cpp
@@ -225,6 +225,10 @@ bool gpu_dependency_rtt_seed_matches(const GpuDependencyAccess& access,
             return access.format == DataFormat::Unorm8 && access.num_components == 2;
         case GpuCaptureColorFormat::Rgba32Float:
             return access.format == DataFormat::Float32 && access.num_components == 4;
+        case GpuCaptureColorFormat::Rg16Float:
+            return access.format == DataFormat::Float16 && access.num_components == 2;
+        case GpuCaptureColorFormat::R16Float:
+            return access.format == DataFormat::Float16 && access.num_components == 1;
     }
     return false;
 }

--- a/prosper/src/gpu/execute/gpu_dependency_graph.cpp
+++ b/prosper/src/gpu/execute/gpu_dependency_graph.cpp
@@ -219,6 +219,12 @@ bool gpu_dependency_rtt_seed_matches(const GpuDependencyAccess& access,
             return access.format == DataFormat::Unorm8 && access.num_components == 1;
         case GpuCaptureColorFormat::R32Uint:
             return access.format == DataFormat::Uint32 && access.num_components == 1;
+        case GpuCaptureColorFormat::R32Float:
+            return access.format == DataFormat::Float32 && access.num_components == 1;
+        case GpuCaptureColorFormat::Rg8Unorm:
+            return access.format == DataFormat::Unorm8 && access.num_components == 2;
+        case GpuCaptureColorFormat::Rgba32Float:
+            return access.format == DataFormat::Float32 && access.num_components == 4;
     }
     return false;
 }
@@ -309,7 +315,16 @@ bool build_gpu_dependency_graph(const GpuReplayFrame& replay,
                 error = "realized dispatch operation has no materialized item";
                 return false;
             }
-            if (!append_compute_accesses(*it->second, reads, writes, error)) return false;
+            const ComputeItem& compute = *it->second;
+            // A zero in any dispatch dimension is an architecturally empty launch. Keep its
+            // semantic node -- command order and the fact that the packet was realized still
+            // matter to diagnostics -- but it cannot read or write a descriptor. Treating the
+            // reflected storage-image bindings as work made an empty GTA V dispatch the producer
+            // of the later bloom history, hiding the real temporal leaf from bundle closure.
+            if (compute.launch.groups_x && compute.launch.groups_y &&
+                compute.launch.groups_z &&
+                !append_compute_accesses(compute, reads, writes, error))
+                return false;
         } else {
             if (operation.source_index >= replay.dma_copies.size()) {
                 error = "realized DMA operation has no materialized copy";

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1067,6 +1067,8 @@ enum class LiveTargetPixelFormat : uint8_t {
     R32Float,
     Rg8Unorm,
     Rgba32Float,
+    Rg16Float,
+    R16Float,
 };
 struct LiveTargetSnapshot {
     uint32_t width = 0, height = 0;

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -93,6 +93,10 @@ struct DrawItem {
     uint32_t raw_draw_count = 0;
     bool raw_indexed = false;
     uint64_t raw_draw_modifier = 0;
+    // A vertex-buffer-backed PS5 RectList is submitted as three vertices. GFX10 synthesizes the
+    // post-VS affine fourth corner; Vulkan does not, so the generated geometry stage does it.
+    // Capture keeps this semantic bit so current-translator replay can rebuild that generated stage.
+    bool rect_list_synthesis = false;
     // GE_INDX_OFFSET at this draw. Vulkan consumes it as firstVertex for non-indexed draws and as
     // vertexOffset for indexed draws, preserving the hardware gl_VertexIndex contract.
     int32_t vertex_offset = 0;
@@ -1062,6 +1066,7 @@ enum class LiveTargetPixelFormat : uint8_t {
     R32Uint,
     R32Float,
     Rg8Unorm,
+    Rgba32Float,
 };
 struct LiveTargetSnapshot {
     uint32_t width = 0, height = 0;
@@ -1330,6 +1335,19 @@ inline bool index_buffer_is_unannounced_32bit(const uint16_t* p16, const uint32_
 // (#400) before this runs, so draw_count is non-zero in practice and the vb_records fallback is a guard.
 inline uint32_t resolve_nonindexed_vertex_count(uint32_t draw_count, uint32_t vb_records) {
     return draw_count ? draw_count : vb_records;
+}
+
+inline bool needs_rect_list_synthesis(uint32_t primitive_type, bool indexed,
+                                      uint32_t draw_count,
+                                      const ShaderResourceTable* vertex_resources) {
+    if ((primitive_type != 7u && primitive_type != 17u) || indexed || draw_count != 3u ||
+        !vertex_resources)
+        return false;
+    return std::any_of(
+        vertex_resources->resources.begin(), vertex_resources->resources.end(),
+        [](const ShaderResource& resource) {
+            return resource.cls == ResourceClass::VertexBuffer && resource.stride != 0u;
+        });
 }
 
 struct ColorStateTraceConfig {
@@ -1606,6 +1624,22 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     }
     std::shared_ptr<ShaderResourceTable> prt = build_stage_table(
         ds, rs.ps_addr, true, vcount_hint, draw ? draw->command_order : 0);
+    const bool rect_list = rs.prim_type == 7u || rs.prim_type == 17u;
+    const bool rect_list_synthesis = needs_rect_list_synthesis(
+        rs.prim_type, draw && draw->indexed, vcount_hint, vrt.get());
+    // Keep this diagnostic narrow enough for a routed title run.  PROSPER_DBG/GFXLOG both perturb
+    // GTA V heavily and generate enormous logs; this switch proves that the post-VS RectList path
+    // actually armed, and names the exact producer/consumer pair, without changing execution.
+    if (rect_list_synthesis && getenv("PROSPER_RECTLOG")) {
+        static std::atomic<uint32_t> logged{0};
+        const uint32_t ordinal = logged.fetch_add(1, std::memory_order_relaxed);
+        if (ordinal < 64u)
+            fprintf(stderr,
+                    "[rect-list] synthesize draw=%llu prim=%u count=%u vs=0x%llx ps=0x%llx\n",
+                    (unsigned long long)(draw ? draw->command_order : 0), rs.prim_type,
+                    vcount_hint, (unsigned long long)vs_program_addr,
+                    (unsigned long long)rs.ps_addr);
+    }
     const auto table_done = phase_timing
         ? std::chrono::steady_clock::now() : std::chrono::steady_clock::time_point{};
     // PROSPER_RTLOG: correlate this draw's render-target address (CB_COLOR0_BASE) with the addresses of
@@ -1678,7 +1712,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
         reinterpret_cast<const uint32_t*>(static_cast<uintptr_t>(rs.ps_addr)),
         max_shader_dwords, system_input_ptr, pixel_input_ptr);
     const bool capture_vertex_position = getenv("PROSPER_GEOM_PROBE") != nullptr &&
-                                         !interpolation.requires_geometry;
+                                         !interpolation.requires_geometry &&
+                                         !rect_list_synthesis;
     uint64_t vs_identity = 0, fs_identity = 0;
     SharedShaderWords vs_shared, fs_shared;
     std::vector<uint32_t> vs, fs;
@@ -1748,14 +1783,15 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     const std::vector<uint32_t>& vs_words = vs_shared ? *vs_shared : vs;
     const std::vector<uint32_t>& fs_words = fs_shared ? *fs_shared : fs;
     std::vector<uint32_t> gs;
-    if (interpolation.requires_geometry && interpolation.valid) {
+    if ((interpolation.requires_geometry || rect_list_synthesis) && interpolation.valid) {
         // Geometry `Triangles` accepts list, strip, and fan input assembly. Points/lines cannot
         // provide the three AMD vertex parameters and remain fail-visible.
         const bool triangle_topology = resolved_pipeline.topology >= 3u &&
                                        resolved_pipeline.topology <= 5u;
         if (triangle_topology)
             gs = recompile_interpolation_geometry(
-                interpolation, getenv("PROSPER_GEOM_PROBE") != nullptr);
+                interpolation, getenv("PROSPER_GEOM_PROBE") != nullptr,
+                rect_list_synthesis);
     }
     if (phase_timing) {
         const auto shader_done = std::chrono::steady_clock::now();
@@ -1784,7 +1820,8 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
             nd++;
         }
     }
-    if (vs_words.empty() || fs_words.empty() || (interpolation.requires_geometry && gs.empty())) {
+    if (vs_words.empty() || fs_words.empty() ||
+        ((interpolation.requires_geometry || rect_list_synthesis) && gs.empty())) {
         report_dropped_draw_target(rs.color0_base, "shader-recompile", rs.cb_target_mask,
                                    rs.cb_shader_mask);
         if (failure) failure->reason = RealizationFailureReason::ShaderRecompile;
@@ -2042,7 +2079,6 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // no vertex-buffer inputs, and submits count=3; invoke index 3 and render the four results as a
     // triangle strip. Restrict the expansion to that observed no-VB form: a general VB-backed RectList
     // needs post-VS fourth-vertex synthesis and must not speculatively fetch a fourth input record.
-    const bool rect_list = rs.prim_type == 7u || rs.prim_type == 17u;
     if (rect_list && out.indices.empty() && vertex_count == 3u && vb_entries == 0u) {
         vertex_count = 4u;
         if (log) fprintf(stderr, "[exec] RectList: expanded procedural 3-vertex rectangle to 4-vertex strip\n");
@@ -2163,6 +2199,7 @@ inline bool realize_draw_item(const GpuState& ds, const GpuState::Draw* draw, ui
     // #1256: record the raw draw-packet state (pre-realization) so a capture can be checked offline for
     // realization divergence. vcount_hint is the DrawIndexAuto/DrawIndex index_count decoded from the guest.
     out.raw_draw_count = vcount_hint; out.raw_indexed = (draw && draw->indexed);
+    out.rect_list_synthesis = rect_list_synthesis;
     out.raw_draw_modifier = draw ? draw->modifier : 0;
     out.vertex_offset = draw && draw->has_vertex_offset_override
         ? draw->indirect_vertex_offset

--- a/prosper/src/gpu/execute/gpu_execute.hpp
+++ b/prosper/src/gpu/execute/gpu_execute.hpp
@@ -1054,7 +1054,15 @@ void set_metadata_kind_query(MetadataKindQueryFn fn);
 CompressionMetadataKind classify_compression_metadata_kind(const MetadataKindRequest& request);
 void set_live_target_query(LiveTargetQueryFn fn);
 bool is_live_render_target(uint64_t gpu_addr);
-enum class LiveTargetPixelFormat : uint8_t { Rgba8Unorm, Rgba16Float, R11G11B10Float };
+enum class LiveTargetPixelFormat : uint8_t {
+    Rgba8Unorm,
+    Rgba16Float,
+    R11G11B10Float,
+    R8Unorm,
+    R32Uint,
+    R32Float,
+    Rg8Unorm,
+};
 struct LiveTargetSnapshot {
     uint32_t width = 0, height = 0;
     LiveTargetPixelFormat format = LiveTargetPixelFormat::Rgba8Unorm;

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -9657,7 +9657,28 @@ DispatchArgumentResolution resolve_indirect_dispatch_arguments(
     }
     uint32_t args[3] = {};
     std::memcpy(args, reinterpret_cast<const void*>(source.indirect_args_addr), sizeof(args));
+    const auto log_resolution = [&](const char* outcome, const ComputeLaunchDimensions* launch) {
+        if (!std::getenv("PROSPER_INDIRECTLOG")) return;
+        static std::atomic<int> logged{0};
+        if (logged.fetch_add(1) >= 256) return;
+        const uint64_t code_addr = source.state
+            ? compute_dispatch_code_addr(*source.state, source) : 0;
+        std::fprintf(stderr,
+                     "[agc-indirect-resolve] outcome=%s args=0x%llx code=0x%llx "
+                     "dims=%ux%ux%u groups=%ux%ux%u\n",
+                     outcome,
+                     static_cast<unsigned long long>(source.indirect_args_addr),
+                     static_cast<unsigned long long>(code_addr),
+                     args[0], args[1], args[2],
+                     launch ? launch->groups_x : 0u,
+                     launch ? launch->groups_y : 0u,
+                     launch ? launch->groups_z : 0u);
+    };
     if (!args[0] || !args[1] || !args[2]) {
+        // Log at ordered realization, after every preceding compute fence and writeback. The
+        // command-processor's similarly named packet trace runs while the stream is still being
+        // folded and can therefore show the producer's previous-frame contents instead.
+        log_resolution("zero-argument", nullptr);
         census.zero_args.fetch_add(1, std::memory_order_relaxed);
         return DispatchArgumentResolution::Noop;
     }
@@ -9667,6 +9688,7 @@ DispatchArgumentResolution resolve_indirect_dispatch_arguments(
     resolved.indirect = false;
     const ComputeLaunchDimensions launch = resolve_compute_launch(resolved);
     if (!launch.groups_x || !launch.groups_y || !launch.groups_z) {
+        log_resolution("zero-groups", &launch);
         static std::atomic<int> warned{0};
         if (warned.fetch_add(1) < 24)
             std::fprintf(stderr,
@@ -9677,19 +9699,7 @@ DispatchArgumentResolution resolve_indirect_dispatch_arguments(
         census.zero_groups.fetch_add(1, std::memory_order_relaxed);
         return DispatchArgumentResolution::Noop;
     }
-    if (std::getenv("PROSPER_INDIRECTLOG")) {
-        static std::atomic<int> logged{0};
-        const uint64_t code_addr = source.state
-            ? compute_dispatch_code_addr(*source.state, source) : 0;
-        if (logged.fetch_add(1) < 256)
-            std::fprintf(stderr,
-                         "[agc-indirect] dispatch args=0x%llx code=0x%llx "
-                         "dims=%ux%ux%u groups=%ux%ux%u\n",
-                         static_cast<unsigned long long>(source.indirect_args_addr),
-                         static_cast<unsigned long long>(code_addr),
-                         args[0], args[1], args[2], launch.groups_x, launch.groups_y,
-                         launch.groups_z);
-    }
+    log_resolution("ready", &launch);
     census.ready.fetch_add(1, std::memory_order_relaxed);
     return DispatchArgumentResolution::Ready;
 }

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -7236,8 +7236,13 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                                 r0.mip_tail_y == view.mip_tail_y &&
                                 r0.layer_stride_bytes == view.layer_stride &&
                                 r0.layer_mip_offset_bytes == view.layer_mip_offset) {
-                                if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
-                                if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
+                                if (attach_image_use(
+                                        r0, u.use_pc,
+                                        wanted == ResourceClass::Texture && u.has_samp
+                                            ? u.s4.data() : nullptr)) {
+                                    mapped = true;
+                                    break;
+                                }
                             }
                         if (mapped) continue;
                     }
@@ -7287,22 +7292,7 @@ std::shared_ptr<ShaderResourceTable> build_stage_table(const GpuState& st, uint6
                     if (wanted == ResourceClass::Texture && u.has_samp) {
                         // Paired S# (same SQ_IMG_SAMP decode as the sharp path). Storage operations do
                         // not consume a sampler even when their SSAMP bits alias known user SGPRs.
-                        const uint32_t* sm = u.s4.data();
-                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
-                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
-                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
-                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
-                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
-                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
-                        r.max_aniso_ratio    = (sm[0] >> 9)  & 0x7u;
-                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
-                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
-                        r.min_lod            = (float)( sm[1]        & 0xFFFu) / 256.0f;
-                        r.max_lod            = (float)((sm[1] >> 12) & 0xFFFu) / 256.0f;
-                        int32_t bias14       = (int32_t)(sm[2] & 0x3FFFu);
-                        if (bias14 & 0x2000) bias14 -= 0x4000;
-                        r.lod_bias           = (float)bias14 / 256.0f;
-                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
+                        apply_sampler_descriptor(r, u.s4.data());
                     }
                     if (log) fprintf(stderr, "[srt] %s %s key=0x%x %ux%u fmt=%u base=0x%llx tile=%u samp=%d\n",
                                      is_ps ? "PS" : "VS",
@@ -7778,8 +7768,13 @@ std::vector<ComputeItem> realize_compute_dispatches(
                                 r0.mip_tail_y == view.mip_tail_y &&
                                 r0.layer_stride_bytes == view.layer_stride &&
                                 r0.layer_mip_offset_bytes == view.layer_mip_offset) {
-                                if (r0.fetch_pc == 0xFFFFFFFFu) { r0.fetch_pc = u.use_pc; mapped = true; break; }
-                                if (r0.fetch_pc == u.use_pc)    { mapped = true; break; }
+                                if (attach_image_use(
+                                        r0, u.use_pc,
+                                        wanted == ResourceClass::Texture && u.has_samp
+                                            ? u.s4.data() : nullptr)) {
+                                    mapped = true;
+                                    break;
+                                }
                             }
                         if (mapped) continue;
                     }
@@ -7838,22 +7833,7 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     r.srt_offset = clash ? 0xFFFFFFFFu : u.key;
                     r.fetch_pc = u.use_pc;               // per-use pc provenance (the image op)
                     if (u.has_samp) {
-                        const uint32_t* sm = u.s4.data();
-                        r.mag_filter  = ((sm[2] >> 20) & 0x3u) ? 1u : 0u;
-                        r.min_filter  = ((sm[2] >> 22) & 0x3u) ? 1u : 0u;
-                        r.mip_filter  = ((sm[2] >> 26) & 0x3u) ? 1u : 0u;
-                        r.addr_uvw[0] = (sm[0] >> 0) & 0x7u;
-                        r.addr_uvw[1] = (sm[0] >> 3) & 0x7u;
-                        r.addr_uvw[2] = (sm[0] >> 6) & 0x7u;
-                        r.max_aniso_ratio    = (sm[0] >> 9) & 0x7u;
-                        r.depth_compare_func = (sm[0] >> 12) & 0x7u;
-                        r.unnormalized       = (sm[0] >> 15) & 0x1u;
-                        r.min_lod            = static_cast<float>(sm[1] & 0xFFFu) / 256.0f;
-                        r.max_lod            = static_cast<float>((sm[1] >> 12) & 0xFFFu) / 256.0f;
-                        int32_t bias14        = static_cast<int32_t>(sm[2] & 0x3FFFu);
-                        if (bias14 & 0x2000) bias14 -= 0x4000;
-                        r.lod_bias           = static_cast<float>(bias14) / 256.0f;
-                        r.border_color_type  = (sm[3] >> 30) & 0x3u;
+                        apply_sampler_descriptor(r, u.s4.data());
                     }
                     table->resources.push_back(r);
                 }

--- a/prosper/src/gpu/execute/gpu_executor.cpp
+++ b/prosper/src/gpu/execute/gpu_executor.cpp
@@ -5724,8 +5724,7 @@ bool shader_resource_allows_zero_mip_specialization(
     const DecodedImageView& view) {
     return use.proven_zero_mip && descriptor.sample_count == 1u &&
         descriptor.base_level == 0u && descriptor.last_level == 0u &&
-        descriptor.max_mip == 0u && !view.in_mip_tail &&
-        !descriptor.compression_enabled;
+        descriptor.max_mip == 0u && !view.in_mip_tail;
 }
 
 std::vector<SrtUse> add_compute_buffer_resources(ShaderResourceTable& table,
@@ -7758,8 +7757,10 @@ std::vector<ComputeItem> realize_compute_dispatches(
                     const uint32_t img_dim = image_type_to_dim(d.type);
                     // This is deliberately narrower than "the backend currently uploads one mip".
                     // The instruction proof belongs to this exact use, and the descriptor must also
-                    // declare one uncompressed base level. In particular, do not reinterpret a DCC
-                    // allocation as raw texels merely because IMAGE_*_MIP selected level zero.
+                    // declare one base level. Compression is deliberately not part of this marker:
+                    // it proves only that discarding the mip operand is exact. The live backend must
+                    // independently acquire authoritative pixels from a renderer image, an
+                    // all-uncompressed metadata plane, or a supported DCC decode before execution.
                     const bool proven_zero_mip =
                         shader_resource_allows_zero_mip_specialization(u, d, view);
                     {

--- a/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
@@ -2182,7 +2182,10 @@ inline BarrierPhasedCompute analyze_barrier_phased_compute(const std::vector<Rdn
     // A proved guard is deliberately excluded: every invocation in the workgroup takes it together.
     result.guarded = guarded;
     const size_t body_begin = guarded ? result.guard_index + 1 : 0;
-    bool valid = result.end_index < ins.size() && branch_count > 2;
+    // Safety comes from the cross-edge, trap and EXEC-save checks below. A straight-line kernel
+    // whose only control-flow instruction is a barrier satisfies that proof trivially; requiring
+    // an unrelated branch-count threshold dropped GTA V's partial-workgroup barrier passes.
+    bool valid = result.end_index < ins.size();
 
     for (size_t i = body_begin; valid && i < result.end_index; ++i)
         if (ins[i].fmt == Rdna2Format::SOPP && ins[i].opcode == 0x0a)

--- a/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
@@ -310,9 +310,19 @@ inline std::unordered_set<uint32_t> proven_cselect_b64_low_only_pcs(
 // word. The scalar-data-vs-mask decision remains path-local in emit_alu; this predicate only names
 // B32 packets for which a dead-high proof can make that scalar path discard the old predicate.
 inline bool is_wave64_vcc_lo_scalar_b32_candidate(const Rdna2Inst& in) {
-    return is_wave64_vcc_lo_scalar_cselect(in) ||
+    const auto scalar_constant = [](const Operand& operand) {
+        return operand.kind == OperandKind::InlineInt ||
+               operand.kind == OperandKind::InlineFloat ||
+               operand.kind == OperandKind::Literal;
+    };
+    const bool scalar_cselect_hi =
+        in.fmt == Rdna2Format::SOP2 && in.opcode == kSop2OpcodeCselectB32 &&
+        in.dst.kind == OperandKind::SGPR && in.dst.value == 107 &&
+        scalar_constant(in.src[0]) && scalar_constant(in.src[1]);
+    return is_wave64_vcc_lo_scalar_cselect(in) || scalar_cselect_hi ||
         (in.fmt == Rdna2Format::SOP2 && sop2_is_b32_logical(in.opcode) &&
-         in.dst.kind == OperandKind::SGPR && in.dst.value == 106);
+         in.dst.kind == OperandKind::SGPR &&
+         (in.dst.value == 106 || in.dst.value == 107));
 }
 
 inline std::unordered_set<uint32_t> proven_wave64_vcc_b32_low_only_pcs(
@@ -323,8 +333,13 @@ inline std::unordered_set<uint32_t> proven_wave64_vcc_b32_low_only_pcs(
         const bool candidate = include_logical
             ? is_wave64_vcc_lo_scalar_b32_candidate(in)
             : is_wave64_vcc_lo_scalar_cselect(in);
+        // Scalar scratch may use either physical VCC word and combine the two as ordinary dwords.
+        // The sibling may be read as scalar data, but it must be dead before any pair/mask-domain
+        // observation. MaskDomainOnly is exactly that whole-CFG proof.
+        const int sibling = in.dst.value == 107 ? 106 : 107;
         if (candidate &&
-            sgpr_dead_at_merge(ins, in.pc + in.len_dwords, 107))
+            sgpr_dead_at_merge(ins, in.pc + in.len_dwords, sibling,
+                               ScalarMergeProof::MaskDomainOnly))
             result.insert(in.pc);
     }
     return result;
@@ -528,14 +543,12 @@ inline bool cannot_write_vcc(const Rdna2Inst& in) {
             // sequences of these two ops between a uniform VOPC and its s_cbranch_vccz.
             if (in.opcode == 0x361) return true;
             if (in.opcode == 0x360) return sgpr_dst_misses_vcc(1);
-            if (in.opcode == 0x176)
-                return in.sdst.value != 106 && in.sdst.value != 107; // v_mad_u64_u32 carry-out
-            // The remaining VOP3B ops inside the plain-VALU window — v_div_scale_f32/f64 (0x16D/
-            // 0x16E) and v_mad_i64_i32 (0x177) — write a scalar carry/flag SDST that may be VCC;
-            // their VGPR dst would otherwise satisfy sgpr_dst_misses_vcc. Stop the walk for them.
-            if (in.opcode == 0x16D || in.opcode == 0x16E || in.opcode == 0x177) return false;
-            return in.opcode >= 0x140 && in.opcode < 0x300 &&
-                   sgpr_dst_misses_vcc(1);                         // plain-VALU window only
+            // Decoder storage has an SDST-shaped field for every VOP3 packet, but only VOP3B
+            // operations architecturally write it. Treat ordinary VOP3A VALU as VCC-transparent;
+            // otherwise a MAC between a uniform compare and VCCZ creates a false Wave64 vote.
+            if (vop3_writes_mask_sdst(in))
+                return in.sdst.value != 106 && in.sdst.value != 107;
+            return in.dst.kind == OperandKind::VGPR;
         case Rdna2Format::SOP1: case Rdna2Format::SOP2: case Rdna2Format::SOPK:
             return sgpr_dst_misses_vcc(2);                         // conservative 64-bit pair
         case Rdna2Format::SMEM: {

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -7063,6 +7063,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 const bool native_2d_storage =
                     shader_resource_uses_native_2d_storage_image(
                         *res, dim == Dim_2D, arrayed, ms);
+                const bool native_uint_2d_storage =
+                    shader_resource_uses_native_uint_2d_storage_image(
+                        *res, dim == Dim_2D, arrayed, ms);
                 const bool ordinary_3d = in.mimg_dim == SQ_DIM_3D && res->img_dim == 2 &&
                                          res->depth && !arrayed && !ms &&
                                          !res->depth_compare;
@@ -7082,9 +7085,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     native_float_storage_image_supported(
                         res->format, components, res->srgb,
                         (b.native_storage_format_support & native_support_bit) != 0);
-                // Existing load/store-only uint images retain the raw uvec4/Format=Unknown contract
-                // used by the compute backend. The atomic's exact R32_UINT gate above is the only path
-                // that opts into a typed R32ui image.
+                const bool native_uint = !packed_r11 && native_uint_2d_storage && !is_atomic &&
+                    native_uint_storage_image_supported(
+                        res->format, components, res->srgb,
+                        (b.native_storage_format_support & native_support_bit) != 0);
                 const bool compute_atomic_buffer = is_atomic && b.is_compute;
                 if (compute_atomic_buffer) {
                     if (!b.declare_compute_atomic_image_buffer(res->binding)) {
@@ -7093,9 +7097,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     }
                 } else {
                     const bool native_r32ui = is_atomic;
+                    const uint32_t native_uint_format = res->format == DataFormat::Uint32
+                        ? ImgFmt_R32ui : res->format == DataFormat::Uint16
+                            ? ImgFmt_R16ui : components == 4
+                                ? ImgFmt_Rgba8ui : ImgFmt_R8ui;
                     b.declare_storage_image(res->binding, dim, arrayed, ms, native_float,
                                             (native_r32ui || packed_r11)
-                                                ? ImgFmt_R32ui : ImgFmt_Unknown,
+                                                ? ImgFmt_R32ui
+                                                : native_uint ? native_uint_format : ImgFmt_Unknown,
                                             packed_r11);
                 }
                 // Coordinate VGPR per axis. Non-NSA (len==2): consecutive from VADDR (src[0]). NSA (len>2):

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -220,9 +220,27 @@ uint32_t emit_f16_unary(SpirvCompute& b, uint32_t opcode, uint32_t x) {
 // Emit one ALU instruction (VOP1/2/C/3 or SOP1/2) into `b`, updating `rs`. Returns true if `in` is an
 // ALU format handled here; sets ok=false if it is an ALU op this stage doesn't support yet. Non-ALU
 // formats (EXP/memory/...) return false so the stage-specific caller can handle them.
+static bool instruction_reads_scc_as_scalar_data(const Rdna2Inst& in) {
+    switch (in.fmt) {
+        case Rdna2Format::SOP2:
+            return in.opcode == kSop2OpcodeAddcU32 || in.opcode == 0x05u ||
+                   in.opcode == kSop2OpcodeCselectB32 ||
+                   in.opcode == kSop2OpcodeCselectB64;
+        case Rdna2Format::SOP1:
+            return in.opcode == kSop1OpcodeCmovB32 ||
+                   in.opcode == kSop1OpcodeCmovB64;
+        case Rdna2Format::SOPK:
+            return in.opcode == kSopkOpcodeCmovkI32;
+        default:
+            return false;
+    }
+}
+
 bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool allow_exec_update,
               const std::unordered_set<uint32_t>* safe_execz, bool allow_smem,
               const ShaderResourceTable* rt, bool allow_wave) {
+    if (b.is_fragment && instruction_reads_scc_as_scalar_data(in))
+        b.mark_fragment_wave_scalar_use(rs.scc);
     auto& vreg = rs.vreg; uint32_t& vcc = rs.vcc;
     auto val = [&](const Operand& o) { return operand_bits(b, rs, in, o, &ok); };
     auto write_vop3b_carry_output = [&](uint32_t carry_mask) {
@@ -2080,9 +2098,26 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     rs.sreg[in.dst.value] = result;
                     rs.sreg_srt.erase(in.dst.value);
                     rs.scc = b.ucmp(Op_INotEqual, result, b.uconst(0));
+                    const bool writes_hi = in.dst.value == 107;
+                    // A whole-CFG proof can establish that this physical VCC word is scalar data
+                    // only: the untouched sibling dies before any mask-domain read. Do not ask for
+                    // a guest lane merely to manufacture a predicate that no later instruction can
+                    // observe. Vertex emission has a separate one-lane virtual-wave contract, so
+                    // this applies only to fragment and compute stages.
+                    const bool scalar_low_only = (b.is_fragment || b.is_compute) &&
+                        b.vcc_b32_low_only_pcs.contains(in.pc);
+                    if (b.wave_size != 32 && scalar_low_only) {
+                        rs.vcc = 0;
+                        rs.sreg_bool.erase(106);
+                        rs.sreg_bool_narrowed.erase(106);
+                        rs.sreg_bool_b32.erase(106);
+                        rs.sreg_bool.erase(107);
+                        rs.sreg_bool_narrowed.erase(107);
+                        rs.sreg_bool_b32.erase(107);
+                        return true;
+                    }
                     uint32_t lane = b.guest_lane_id();
                     lane = b.ibin(Op_BitwiseAnd, lane, b.uconst(b.wave_size - 1));
-                    const bool writes_hi = in.dst.value == 107;
                     const uint32_t in_written_half = writes_hi
                         ? b.ucmp(Op_UGreaterThanEqual, lane, b.uconst(32))
                         : b.ucmp(Op_ULessThan, lane, b.uconst(32));
@@ -2092,8 +2127,6 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         b.ibin(Op_BitwiseAnd,
                                b.ibin(Op_ShiftRightLogical, result, bit), b.uconst(1)),
                         b.uconst(0));
-                    const bool scalar_low_only = b.is_compute &&
-                        b.vcc_b32_low_only_pcs.contains(in.pc);
                     if (b.wave_size == 32) {
                         // A complete scalar write covers every architectural bit of VCC_LO in
                         // Wave32, so it establishes a fresh predicate without needing the old VCC
@@ -3978,15 +4011,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     if (source == rs.vreg.end()) { ok = false; return true; }
                     const uint32_t selector = val(in.src[1]);
                     if (!ok) return true;
-                    if (b.wave_size == 64) b.mark_subgroup_min64();
-                    else b.mark_subgroup_min32();
-                    const uint32_t native_lane = b.subgroup_local_id();
-                    const uint32_t wave_mask = b.uconst(b.wave_size - 1u);
-                    const uint32_t wave_base = b.ibin(
-                        Op_BitwiseAnd, native_lane, b.uconst(~(b.wave_size - 1u)));
-                    const uint32_t source_lane = b.ibin(
-                        Op_BitwiseOr, wave_base, b.ibin(Op_BitwiseAnd, selector, wave_mask));
-                    const uint32_t result = b.subgroup_shuffle(source->second, source_lane);
+                    uint32_t result = 0;
+                    if (allow_wave && b.is_compute &&
+                        b.native_subgroup_size != b.wave_size) {
+                        // A workgroup-uniform site can model the guest wave exactly through
+                        // scratch even when a Wave64 guest does not fit in the host subgroup.
+                        result = b.guest_wave_readlane(source->second, selector);
+                    } else {
+                        if (b.wave_size == 64) b.mark_subgroup_min64();
+                        else b.mark_subgroup_min32();
+                        const uint32_t native_lane = b.subgroup_local_id();
+                        const uint32_t wave_mask = b.uconst(b.wave_size - 1u);
+                        const uint32_t wave_base = b.ibin(
+                            Op_BitwiseAnd, native_lane, b.uconst(~(b.wave_size - 1u)));
+                        const uint32_t source_lane = b.ibin(
+                            Op_BitwiseOr, wave_base,
+                            b.ibin(Op_BitwiseAnd, selector, wave_mask));
+                        result = b.subgroup_shuffle(source->second, source_lane);
+                    }
                     rs.sreg[in.dst.value] = result;
                     rs.sreg_bool.erase(in.dst.value);
                     rs.sreg_bool_narrowed.erase(in.dst.value);
@@ -7565,15 +7607,18 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 }
                 return true;
             } else {
+                const bool load_2d_array = b.is_compute && in.opcode == 0x00 &&
+                    in.mimg_dim == 5u && res->img_dim == 5u;
                 const bool mip_load_2d_array = b.is_compute && is_zero_mip_load &&
                     in.mimg_dim == 5u && res->img_dim == 5u;
                 const bool array_sample = b.is_compute && in.mimg_dim == 5u &&
                     res->img_dim == 5u && (is_sample || is_sample_l || is_sample_lz);
-                const bool host_array = mip_load_2d_array || array_sample || msaa_array_fetch;
+                const bool host_array = load_2d_array || mip_load_2d_array ||
+                    array_sample || msaa_array_fetch;
                 if (!b.declare_texture(res->binding, Dim_2D, uint_texture, host_array)) {
                     ok = false; return true;
                 }
-                if (msaa_array_fetch || mip_load_2d_array) {
+                if (msaa_array_fetch || load_2d_array || mip_load_2d_array) {
                     b.image_fetch_2d_array(
                         res->binding, vread(cvg(0)), vread(cvg(1)), vread(cvg(2)), out);
                 } else if (array_sample) {

--- a/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_alu.cpp
@@ -3520,6 +3520,24 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             return true;
         }
         case Rdna2Format::VOPC: {                                     // v_cmp_* -> VCC; v_cmpx_* also -> EXEC
+            const auto scalar_data_operand = [&](const Operand& source) {
+                switch (source.kind) {
+                    case OperandKind::InlineInt:
+                    case OperandKind::InlineFloat:
+                    case OperandKind::Literal:
+                        return true;
+                    case OperandKind::SGPR:
+                        return rs.sreg.contains(source.value) ||
+                            rs.sreg_input.contains(source.value);
+                    case OperandKind::Special:
+                        if (source.value == 125) return true; // SGPR_NULL
+                        if (source.value == 253) return rs.scc != 0;
+                        return source.value >= 106 && source.value <= 124 &&
+                            rs.sreg.contains(source.value);
+                    default:
+                        return false;
+                }
+            };
             const uint32_t ra = val(in.src[0]), rc = val(in.src[1]);  // raw bits (f16 compares re-derive)
             uint32_t a = ra, c = rc;
             uint32_t op = in.opcode;
@@ -3529,6 +3547,25 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool integer64_compare =
                 (eff >= 0xA1u && eff <= 0xA6u) ||
                 (eff >= 0xE1u && eff <= 0xE6u);
+            auto scalar_integer64_operand = [&](const Operand& source) {
+                if (!scalar_data_operand(source)) return false;
+                if (source.kind == OperandKind::SGPR ||
+                    (source.kind == OperandKind::Special && source.value >= 106 &&
+                     source.value <= 123)) {
+                    Operand high = source;
+                    ++high.value;
+                    return scalar_data_operand(high);
+                }
+                // Inline integers sign-extend, while literals and SGPR_NULL zero-extend.  Each
+                // implied high half is a compile-time scalar.  Inline floats are rejected later
+                // by integer64_halves and therefore cannot publish a proof from this path.
+                return source.kind != OperandKind::InlineFloat;
+            };
+            const bool compare_wave_uniform = !is_cmpx && !rs.exec_narrowed &&
+                (integer64_compare
+                    ? scalar_integer64_operand(in.src[0]) &&
+                      scalar_integer64_operand(in.src[1])
+                    : scalar_data_operand(in.src[0]) && scalar_data_operand(in.src[1]));
             // Integer compares have no ABS/NEG source semantics. A malformed e64 packet carrying
             // those bits must not be lowered as an unmodified integer operation.
             if (integer64_compare &&
@@ -3804,6 +3841,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         // so a following s_mov_b32 save sees the fresh predicate rather than stale
                         // dispatcher-loaded scalar data.
                         vcc = masked;
+                        rs.vcc_wave_uniform = compare_wave_uniform ? masked : 0;
                         if (b.wave_size == 32) {
                             rs.sreg.erase(106);
                             rs.sreg_srt.erase(106);
@@ -6893,6 +6931,60 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             const bool uint_texture = res->format == DataFormat::Uint8 ||
                                       res->format == DataFormat::Uint16 ||
                                       res->format == DataFormat::Uint32;
+            // D16 packs two floating-point result components into each VDATA dword. The image
+            // helpers expose normalized/float resources as ordinary f32 bits, so the back-half
+            // must explicitly convert and pack those values rather than writing one f32 per VGPR.
+            // Likewise an IMAGE_STORE D16 consumes consecutive packed halves, not four full-width
+            // VGPRs. GTA V's FSR1 RCAS pass depends on both halves of this contract: its dmask-f
+            // R11G11B10F load writes v[12:13], and its dmask-f RGBA8 stores read v[14:15].
+            // Integer D16 conversion has a distinct bit/integer contract and remains fail-visible.
+            const bool d16_float_resource =
+                res->format == DataFormat::Float32 || res->format == DataFormat::Float16 ||
+                res->format == DataFormat::Unorm16 || res->format == DataFormat::Snorm16 ||
+                res->format == DataFormat::Unorm8 || res->format == DataFormat::Snorm8 ||
+                res->format == DataFormat::Float10_11_11 ||
+                res->format == DataFormat::Unorm2_10_10_10 ||
+                res->format == DataFormat::Snorm2_10_10_10;
+            auto write_mimg_results = [&](const uint32_t out[4]) -> bool {
+                const int vd = in.dst.value;
+                if (!in.mimg_d16) {
+                    int written = 0;
+                    for (uint32_t component = 0; component < 4; ++component) {
+                        if (!(in.mimg_dmask & (1u << component))) continue;
+                        const uint32_t old = vreg_old(b, rs, vd + written);
+                        rs.vreg[vd + written] = out[component];
+                        predicate_write(b, rs, vd + written, old);
+                        ++written;
+                    }
+                    return true;
+                }
+                if (!d16_float_resource) return false;
+
+                uint32_t packed = b.uconst(0);
+                int component_index = 0;
+                int word_index = 0;
+                auto write_packed = [&](uint32_t value) {
+                    const uint32_t old = vreg_old(b, rs, vd + word_index);
+                    rs.vreg[vd + word_index] = value;
+                    predicate_write(b, rs, vd + word_index, old);
+                    ++word_index;
+                };
+                for (uint32_t component = 0; component < 4; ++component) {
+                    if (!(in.mimg_dmask & (1u << component))) continue;
+                    const uint32_t half = b.pack_half_lo(out[component]);
+                    if ((component_index & 1) == 0) {
+                        packed = half;
+                    } else {
+                        packed = b.ibin(
+                            Op_BitwiseOr, packed,
+                            b.ibin(Op_ShiftLeftLogical, half, b.uconst(16)));
+                        write_packed(packed);
+                    }
+                    ++component_index;
+                }
+                if (component_index & 1) write_packed(packed); // odd dmask: high half is zero.
+                return true;
+            };
 
             // --- Storage-image path: image_load (0x00), image_store[_mip] (0x08/0x09), and R32_UINT
             if (res->cls == ResourceClass::StorageImage) {
@@ -6962,7 +7054,7 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 // every frame. The INSTRUCTION half stays here, because only this site sees it.
                 if (is_atomic &&
                     ((in.mimg_dim != SQ_DIM_2D && !atomic_2d_array) || ms || in.len_dwords < 2 ||
-                     in.mimg_unorm || in.mimg_dmask != 1u ||
+                     in.mimg_unorm || in.mimg_d16 || in.mimg_dmask != 1u ||
                      arrayed != (res->img_dim == SQ_DIM_2D_ARRAY) ||
                      !shader_resource_supports_atomic_image_buffer(*res))) {
                     ok = false;
@@ -7021,18 +7113,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 uint32_t sample = ms ? vread(coord_vgpr(ncoord)) : 0;   // MSAA sample index = coord after the spatial ones
                 if (is_ld) {
                     uint32_t out[4]; b.image_read(res->binding, dim, arrayed, ncoord, coords, out, ms, sample);
-                    int vd = in.dst.value, w = 0;   // dmask -> consecutive VDATA VGPRs (LSB=R first)
-                    for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) {
-                        uint32_t old = vreg_old(b, rs, vd + w); rs.vreg[vd + w] = out[c];
-                        predicate_write(b, rs, vd + w, old); w++;
-                    }
+                    if (!write_mimg_results(out)) { ok = false; return true; }
                 } else if (is_st) {
                     // image_store: gather the VDATA VGPRs selected by dmask into an RGBA texel (channels
                     // absent from dmask store as 0). Under a narrowed EXEC (e.g. a grid-tail bounds check),
                     // the write is EXEC-predicated so inactive lanes don't write out-of-range texels.
                     uint32_t vals[4] = { b.uconst(0), b.uconst(0), b.uconst(0), b.uconst(0) };
                     int vd = in.dst.value, w = 0;
-                    for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) { vals[c] = vread(vd + w); w++; }
+                    if (in.mimg_d16 && !d16_float_resource) { ok = false; return true; }
+                    for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) {
+                        vals[c] = in.mimg_d16
+                            ? b.unpack_half(vread(vd + w / 2), static_cast<uint32_t>(w & 1))
+                            : vread(vd + w);
+                        ++w;
+                    }
                     b.image_write(res->binding, dim, arrayed, ncoord, coords, vals, rs.exec_narrowed, rs.exec);
                 } else {
                     // IMAGE_ATOMIC_SWAP/ADD reads its operand from VDATA. GLC=1 overwrites that VGPR
@@ -7276,6 +7370,17 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
             // coords (normalized float for sample, integer texel for load). Non-NSA: consecutive from VADDR.
             // NSA (len>2): coord0 = VADDR, coord k>=1 = byte (k-1) of the extra address dwords words[2..3].
             const bool nsa = in.len_dwords > 2;
+            // GTA V's FSR1 RCAS packet uses ordinary 2D IMAGE_LOAD with A16: unsigned x/y
+            // texel coordinates occupy the low/high 16-bit halves of ONE VADDR VGPR (LLVM prints
+            // `image_load ..., v0, ... a16 d16`, not `v[0:1]`). Sample-family A16 carries fp16
+            // addresses, and NSA/array/MSAA have different operand shapes; retain only the exact
+            // integer-load contract until those forms have independent evidence.
+            if (in.mimg_a16 &&
+                (in.opcode != 0x00 || in.mimg_dim != SQ_DIM_2D ||
+                 res->img_dim != SQ_DIM_2D || nsa)) {
+                ok = false;
+                return true;
+            }
             int va = in.src[0].value;
             auto cvg = [&](uint32_t k) -> int { if (!nsa || k == 0) return va + (nsa ? 0 : (int)k);
                 uint32_t j = k - 1; return (int)((in.words[2 + j / 4] >> (8 * (j % 4))) & 0xFFu); };
@@ -7412,7 +7517,10 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                 } else { ok = false; return true; }
             } else if (is_gather_lz || is_gather_lz_o) {
                 // gather4 dmask selects ONE channel (must be a single bit); the result is always the
-                // four texels of that channel -> 4 consecutive VDATA VGPRs, gather order preserved.
+                // four texels of that channel, with gather order preserved. D16 changes only the
+                // physical VDATA layout: the four fp16 results occupy two consecutive VGPRs. GTA V's
+                // FSR1 EASU shaders consume those packed halves with VOP3P; writing four f32 VGPRs
+                // clobbers the following temporaries and turns an otherwise intact scene into bands.
                 uint32_t dm = in.mimg_dmask;
                 if (dm != 1u && dm != 2u && dm != 4u && dm != 8u) { ok = false; return true; }
                 uint32_t comp = dm == 1u ? 0u : dm == 2u ? 1u : dm == 4u ? 2u : 3u;
@@ -7431,10 +7539,20 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         normalized_spatial(vread(cvg(0)), res->width),
                         normalized_spatial(vread(cvg(1)), res->height), comp, out);
                 int vd = in.dst.value;
-                for (uint32_t c = 0; c < 4; c++) {
-                    uint32_t old = vreg_old(b, rs, vd + (int)c);
-                    rs.vreg[vd + (int)c] = out[c];
-                    predicate_write(b, rs, vd + (int)c, old);
+                if (in.mimg_d16) {
+                    if (!d16_float_resource) { ok = false; return true; }
+                    for (uint32_t word = 0; word < 2; ++word) {
+                        const uint32_t old = vreg_old(b, rs, vd + static_cast<int>(word));
+                        rs.vreg[vd + static_cast<int>(word)] =
+                            b.pack_half2x16(out[word * 2], out[word * 2 + 1]);
+                        predicate_write(b, rs, vd + static_cast<int>(word), old);
+                    }
+                } else {
+                    for (uint32_t c = 0; c < 4; c++) {
+                        uint32_t old = vreg_old(b, rs, vd + static_cast<int>(c));
+                        rs.vreg[vd + static_cast<int>(c)] = out[c];
+                        predicate_write(b, rs, vd + static_cast<int>(c), old);
+                    }
                 }
                 return true;
             } else {
@@ -7480,7 +7598,15 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                         normalized_spatial(vread(cvg(2)), res->width),
                         normalized_spatial(vread(cvg(3)), res->height), out);
                 } else {
-                    uint32_t cu = vread(cvg(0)), cv = vread(cvg(1));
+                    uint32_t cu, cv;
+                    if (in.mimg_a16) {
+                        const uint32_t packed = vread(cvg(0));
+                        cu = b.bfe_u(packed, b.uconst(0), b.uconst(16));
+                        cv = b.bfe_u(packed, b.uconst(16), b.uconst(16));
+                    } else {
+                        cu = vread(cvg(0));
+                        cv = vread(cvg(1));
+                    }
                     if (!is_load) {
                         cu = normalized_spatial(cu, res->width);
                         cv = normalized_spatial(cv, res->height);
@@ -7494,14 +7620,9 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
                     else                   b.image_fetch_2d (res->binding, cu, cv, out);
                 }
             }
-            // dmask selects which result components are written to consecutive VDATA VGPRs (LSB=R first).
-            int vd = in.dst.value, w = 0;
-            for (uint32_t c = 0; c < 4; c++) if (in.mimg_dmask & (1u << c)) {
-                uint32_t old = vreg_old(b, rs, vd + w);
-                rs.vreg[vd + w] = out[c];
-                predicate_write(b, rs, vd + w, old);
-                w++;
-            }
+            // D16 changes the VDATA layout, not the logical image result: selected components are
+            // still in dmask order, but two binary16 values share each consecutive VGPR.
+            if (!write_mimg_results(out)) { ok = false; return true; }
             return true;
         }
         case Rdna2Format::DS: {

--- a/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
@@ -1500,6 +1500,17 @@ bool emit_cfg_state_machine(
     std::unordered_set<uint32_t> compute_dpp_add_row_mask_pcs;
     std::unordered_map<uint32_t, uint32_t> portable_mask_ffbh_event_for_pc;
     std::set<int> portable_mask_ffbh_dsts;
+    std::unordered_map<uint32_t, uint32_t> portable_readlane_event_for_pc;
+    std::set<int> portable_readlane_dsts;
+    // A VGPR written by V_WRITELANE is a scalar spill array. Its lane slots must remain in one
+    // dispatcher case so the exact slot lowering can resolve them; only ordinary VGPR lifetimes
+    // use the synchronized generic readlane phase.
+    std::set<int> writelane_spill_arrays;
+    for (const auto& in : ins) {
+        if (in.is_end) break;
+        if (in.fmt == Rdna2Format::VOP3 && in.opcode == 0x361)
+            writelane_spill_arrays.insert(in.dst.value);
+    }
     std::unordered_set<uint32_t> synchronized_lds_store_pcs;
     std::unordered_set<uint32_t> lds_fminmax_pcs;
     for (size_t i = 0; i < ins.size(); ++i) {
@@ -1575,6 +1586,16 @@ bool emit_cfg_state_machine(
             portable_mask_ffbh_event_for_pc.emplace(
                 in.pc, static_cast<uint32_t>(portable_mask_ffbh_event_for_pc.size() + 1));
             portable_mask_ffbh_dsts.insert(in.dst.value);
+            start_set.insert(in.pc);
+            if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
+                start_set.insert(ins[i + 1].pc);
+        }
+        if (b.is_compute && !b.native_subgroup_size &&
+            in.fmt == Rdna2Format::VOP3 && in.opcode == 0x360 &&
+            !writelane_spill_arrays.contains(in.src[0].value)) {
+            portable_readlane_event_for_pc.emplace(
+                in.pc, static_cast<uint32_t>(portable_readlane_event_for_pc.size() + 1));
+            portable_readlane_dsts.insert(in.dst.value);
             start_set.insert(in.pc);
             if (i + 1 < ins.size() && ins[i + 1].pc <= end_pc)
                 start_set.insert(ins[i + 1].pc);
@@ -1957,6 +1978,13 @@ bool emit_cfg_state_machine(
                 }
 
                 int b32_write_reg = writes_b32_mask ? in.dst.value : -1;
+                const bool wave32_b64_vcc_mask_write =
+                    in.fmt == Rdna2Format::SOP2 && in.dst.value == 106 &&
+                    in.opcode >= 0x0f && in.opcode <= 0x1d &&
+                    (in.opcode & 1u) == 1 &&
+                    source_mask(in.src[0]) && source_mask(in.src[1]);
+                if (wave32_b64_vcc_mask_write)
+                    b32_write_reg = 106;
                 if (in.fmt == Rdna2Format::VOP3 && in.opcode >= 0x128 &&
                     in.opcode <= 0x12a && in.sdst.kind == OperandKind::SGPR) {
                     const Operand& carry_in = in.src[2];
@@ -3353,6 +3381,15 @@ bool emit_cfg_state_machine(
         ? b.function_var(b.t_u32, ptr_u32) : 0;
     const uint32_t mask_ffbh_dst_var = has_portable_mask_ffbh
         ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const bool has_portable_readlane = !portable_readlane_event_for_pc.empty();
+    const uint32_t readlane_pending_var = has_portable_readlane
+        ? b.function_var(b.t_bool, ptr_bool) : 0;
+    const uint32_t readlane_source_var = has_portable_readlane
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t readlane_selector_var = has_portable_readlane
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
+    const uint32_t readlane_dst_var = has_portable_readlane
+        ? b.function_var(b.t_u32, ptr_u32) : 0;
 
     const uint32_t zero = b.uconst(0), no = b.bfalse(), yes = b.btrue();
     for (const auto& kv : vv) {
@@ -3445,6 +3482,11 @@ bool emit_cfg_state_machine(
         b.store_function(mask_ffbh_event_var, zero);
         b.store_function(mask_ffbh_half_var, zero);
         b.store_function(mask_ffbh_dst_var, zero);
+    }
+    if (has_portable_readlane) {
+        b.store_function(readlane_source_var, zero);
+        b.store_function(readlane_selector_var, zero);
+        b.store_function(readlane_dst_var, zero);
     }
 
     auto load_state = [&](uint32_t dispatch = UINT32_MAX) {
@@ -3736,6 +3778,8 @@ bool emit_cfg_state_machine(
         b.store_function(mask_ffbh_write_var, no);
         b.store_function(mask_ffbh_event_var, zero);
     }
+    if (has_portable_readlane)
+        b.store_function(readlane_pending_var, no);
     b.emit_loopmerge(loop_merge, loop_continue);
     b.emit_branch(switch_header);
     b.emit_label(switch_header);
@@ -3794,6 +3838,7 @@ bool emit_cfg_state_machine(
         const Rdna2Inst* dpp_row_ror8 = nullptr;
         const Rdna2Inst* dpp_add_row_mask = nullptr;
         const Rdna2Inst* mask_ffbh = nullptr;
+        const Rdna2Inst* readlane = nullptr;
         const Rdna2Inst* mask_compare = nullptr;
         const Rdna2Inst* exec_saved_mask_compare = nullptr;
         const Rdna2Inst* saved_mask_pair_compare = nullptr;
@@ -3818,6 +3863,7 @@ bool emit_cfg_state_machine(
             const Rdna2Inst* block_dpp_row_ror8 = nullptr;
             const Rdna2Inst* block_dpp_add_row_mask = nullptr;
             const Rdna2Inst* block_mask_ffbh = nullptr;
+            const Rdna2Inst* block_readlane = nullptr;
             const Rdna2Inst* block_mask_compare = nullptr;
             const Rdna2Inst* block_exec_saved_mask_compare = nullptr;
             const Rdna2Inst* block_saved_mask_pair_compare = nullptr;
@@ -3913,6 +3959,19 @@ bool emit_cfg_state_machine(
                         block_mask_ffbh = &in;
                         break;
                     }
+                }
+                if (portable_readlane_event_for_pc.contains(in.pc) &&
+                    !spill_vgprs.contains(in.src[0].value) &&
+                    !state.vgpr_lane_slots.contains(in.src[0].value) &&
+                    !state.vgpr_lane_mask_slots.contains(in.src[0].value)) {
+                    if (getenv("PROSPER_DBG"))
+                        std::fprintf(stderr,
+                                     "[compute-cfg-portable-readlane] program=0x%llx "
+                                     "pc=%u dst=s%d src=v%d\n",
+                                     (unsigned long long)b.diagnostic.program_address,
+                                     in.pc, in.dst.value, in.src[0].value);
+                    block_readlane = &in;
+                    break;
                 }
                 const int mask_compare_source =
                     mask_zero_compare_candidate_source(in);
@@ -4052,7 +4111,8 @@ bool emit_cfg_state_machine(
                     block_swizzle || block_bpermute ||
                     block_dpp_min_row_shr || block_dpp_add_row_shr ||
                     block_dpp_row_ror8 ||
-                    block_dpp_add_row_mask || block_mask_ffbh || block_mask_compare ||
+                    block_dpp_add_row_mask || block_mask_ffbh || block_readlane ||
+                    block_mask_compare ||
                     block_exec_saved_mask_compare || block_saved_mask_pair_compare ||
                     block_vopc_mask_compare ||
                     block_b64_mask_scc_vote ||
@@ -4073,6 +4133,7 @@ bool emit_cfg_state_machine(
             dpp_row_ror8 = block_dpp_row_ror8;
             dpp_add_row_mask = block_dpp_add_row_mask;
             mask_ffbh = block_mask_ffbh;
+            readlane = block_readlane;
             mask_compare = block_mask_compare;
             exec_saved_mask_compare = block_exec_saved_mask_compare;
             saved_mask_pair_compare = block_saved_mask_pair_compare;
@@ -4101,6 +4162,26 @@ bool emit_cfg_state_machine(
                 b.uconst(static_cast<uint32_t>(source - mask_base)));
             b.store_function(mask_ffbh_dst_var,
                 b.uconst(static_cast<uint32_t>(mask_ffbh->dst.value)));
+        }
+        if (readlane) {
+            if (!portable_readlane_event_for_pc.contains(readlane->pc))
+                return reject_cfg(readlane->pc, "portable-readlane-event");
+            const auto source = state.vreg.find(readlane->src[0].value);
+            if (source == state.vreg.end())
+                return reject_cfg(readlane->pc, "portable-readlane-source");
+            bool selector_ok = true;
+            const uint32_t readlane_selector = operand_bits(
+                b, state, *readlane, readlane->src[1], &selector_ok);
+            if (!selector_ok || !readlane_selector)
+                return reject_cfg(readlane->pc, "portable-readlane-selector");
+            b.store_function(readlane_pending_var, yes);
+            b.store_function(readlane_source_var, source->second);
+            b.store_function(readlane_selector_var, readlane_selector);
+            b.store_function(readlane_dst_var,
+                b.uconst(static_cast<uint32_t>(readlane->dst.value)));
+            state.sreg.erase(readlane->dst.value);
+            state.sreg_input.erase(readlane->dst.value);
+            state.sreg_srt.erase(readlane->dst.value);
         }
         if (mbcnt) {
             if (graphics) {
@@ -4601,6 +4682,9 @@ bool emit_cfg_state_machine(
         if (mask_ffbh) {
             if (!set_next(mask_ffbh->pc + mask_ffbh->len_dwords))
                 return reject_cfg(mask_ffbh->pc, "mask-ffbh-successor");
+        } else if (readlane) {
+            if (!set_next(readlane->pc + readlane->len_dwords))
+                return reject_cfg(readlane->pc, "portable-readlane-successor");
         } else if (mbcnt) {
             if (!set_next(mbcnt->pc + mbcnt->len_dwords))
                 return reject_cfg(mbcnt->pc, "mbcnt-successor");
@@ -5300,6 +5384,74 @@ bool emit_cfg_state_machine(
                    b.uconst(static_cast<uint32_t>(kv.first.first))));
         const uint32_t old = b.load_function(b.t_bool, kv.second);
         b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    b.barrier();
+    }
+
+    if (has_portable_readlane) {
+    // Every invocation publishes its ordinary VGPR value unconditionally; V_READLANE ignores EXEC.
+    // A pending wave then reads the selected lane from its own guest-wave slice. This common region
+    // is reached uniformly by every dispatcher invocation, so the workgroup barriers are exact even
+    // when the host subgroup is narrower than the guest Wave64.
+    const uint32_t readlane_pending = b.load_function(b.t_bool, readlane_pending_var);
+    const uint32_t readlane_source = b.load_function(b.t_u32, readlane_source_var);
+    b.cfg_scratch_store(b.linear_localid, readlane_source);
+    b.barrier();
+
+    const uint32_t readlane_shift = b.uconst(b.wave_size == 32 ? 5u : 6u);
+    const uint32_t readlane_wave_base = b.ibin(
+        Op_ShiftLeftLogical,
+        b.ibin(Op_ShiftRightLogical, b.linear_localid, readlane_shift),
+        readlane_shift);
+    const uint32_t readlane_lane = b.ibin(
+        Op_BitwiseAnd, b.load_function(b.t_u32, readlane_selector_var),
+        b.uconst(b.wave_size - 1u));
+    const uint32_t readlane_index = b.ibin(
+        Op_IAdd, readlane_wave_base, readlane_lane);
+    const uint32_t readlane_valid = b.ucmp(
+        Op_ULessThan, readlane_index, b.uconst(b.local_count));
+    const uint32_t readlane_result = b.sel(
+        readlane_valid,
+        b.cfg_scratch_load(b.sel(readlane_valid, readlane_index, zero)), zero);
+    const uint32_t readlane_dst = b.load_function(b.t_u32, readlane_dst_var);
+    for (int reg : portable_readlane_dsts) {
+        const auto destination = sv.find(reg);
+        if (destination == sv.end())
+            return reject_cfg(0, "missing-portable-readlane-dst");
+        const uint32_t selected = b.land(
+            readlane_pending,
+            b.ucmp(Op_IEqual, readlane_dst,
+                   b.uconst(static_cast<uint32_t>(reg))));
+        const uint32_t old = b.load_function(b.t_u32, destination->second);
+        b.store_function(destination->second, b.sel(selected, readlane_result, old));
+    }
+    for (const auto& kv : mv) {
+        if (!portable_readlane_dsts.contains(kv.first)) continue;
+        const uint32_t selected = b.land(
+            readlane_pending,
+            b.ucmp(Op_IEqual, readlane_dst,
+                   b.uconst(static_cast<uint32_t>(kv.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    for (const auto& kv : mhv) {
+        if (!portable_readlane_dsts.contains(kv.first)) continue;
+        const uint32_t selected = b.land(
+            readlane_pending,
+            b.ucmp(Op_IEqual, readlane_dst,
+                   b.uconst(static_cast<uint32_t>(kv.first))));
+        const uint32_t old = b.load_function(b.t_bool, kv.second);
+        b.store_function(kv.second, b.bsel(selected, no, old));
+    }
+    if (portable_readlane_dsts.contains(106)) {
+        const uint32_t selected = b.land(
+            readlane_pending,
+            b.ucmp(Op_IEqual, readlane_dst, b.uconst(106u)));
+        const uint32_t bit = b.ucmp(
+            Op_INotEqual,
+            b.ibin(Op_BitwiseAnd, readlane_result, b.uconst(1u)), zero);
+        const uint32_t old = b.load_function(b.t_bool, vcc_var);
+        b.store_function(vcc_var, b.bsel(selected, bit, old));
     }
     b.barrier();
     }
@@ -6548,6 +6700,30 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                 log_recompile_diagnostic(
                     b.diagnostic, "compute-cfg-reject", "terminal",
                     "reason=portable-dpp-row-ror8-dispatcher-unsafe guest-barrier=1");
+                return false;
+            }
+            const int emitted = try_cfg_dispatcher();
+            if (emitted > 0) return true;
+            return false;
+        }
+        std::set<int> cfg_writelane_spill_arrays;
+        for (const auto& in : ins) {
+            if (in.is_end) break;
+            if (in.fmt == Rdna2Format::VOP3 && in.opcode == 0x361)
+                cfg_writelane_spill_arrays.insert(in.dst.value);
+        }
+        const bool portable_compute_cfg_readlane = b.is_compute &&
+            !b.native_subgroup_size && (!Fs.empty() || !Ls.empty()) &&
+            std::any_of(ins.begin(), ins.end(), [&](const Rdna2Inst& in) {
+                return !in.is_end && in.fmt == Rdna2Format::VOP3 &&
+                    in.opcode == 0x360 &&
+                    !cfg_writelane_spill_arrays.contains(in.src[0].value);
+            });
+        if (allow_cfg_dispatcher && portable_compute_cfg_readlane) {
+            if (!cfg_dispatch_safe) {
+                log_recompile_diagnostic(
+                    b.diagnostic, "compute-cfg-reject", "terminal",
+                    "reason=portable-readlane-dispatcher-unsafe guest-barrier=1");
                 return false;
             }
             const int emitted = try_cfg_dispatcher();

--- a/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_emit_cfg.cpp
@@ -6020,7 +6020,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             if (!F.on_exec && !F.on_vcc && !rs.scc) return false;
             if (F.on_vcc && !rs.vcc) return false;
             uint32_t condition = F.on_exec ? rs.exec : (F.on_vcc ? rs.vcc : rs.scc);
-            if (b.is_fragment && (F.on_exec || F.on_vcc))
+            if (b.is_fragment && (F.on_exec || F.on_vcc) &&
+                !(F.on_vcc && rs.vcc == rs.vcc_wave_uniform &&
+                  vcc_exit_is_wave_uniform(ins, F.branch_pc)))
                 condition = b.fragment_wave_any(condition);
             condition = F.on_scc0 ? condition : b.logical_not(condition);
             const RegState before = rs;
@@ -6680,7 +6682,10 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
             // EXECZ/VCCZ are scalar wave decisions. Keeping every fragment invocation in the loop
             // until the complete guest wave becomes empty makes scalar state and nested wave votes
             // exact; vector writes remain predicated by the per-lane EXEC bool.
-            if (b.is_fragment && L.condition != DivLoop::Condition::Scc)
+            if (b.is_fragment && L.condition != DivLoop::Condition::Scc &&
+                !(L.condition == DivLoop::Condition::Vcc &&
+                  rs.vcc == rs.vcc_wave_uniform &&
+                  vcc_exit_is_wave_uniform(ins, L.exit_branch_pc)))
                 loop_cond = b.fragment_wave_any(loop_cond);
             const uint32_t chk_end = b.cur_block;
             b.emit_condbranch(loop_cond, body, merge);         // canonical exit: branch on continue predicate
@@ -6813,7 +6818,9 @@ bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                     cond_reg = b.native_subgroup_size
                         ? b.native_wave_any(cond_reg)
                         : b.guest_wave_any(cond_reg);
-                else if (b.is_fragment && (F.on_exec || F.on_vcc))
+                else if (b.is_fragment && (F.on_exec || F.on_vcc) &&
+                         !(F.on_vcc && rs.vcc == rs.vcc_wave_uniform &&
+                           vcc_exit_is_wave_uniform(ins, F.branch_pc)))
                     cond_reg = b.fragment_wave_any(cond_reg);
                 uint32_t exec_cond = F.on_scc0 ? cond_reg : b.bsel(cond_reg, b.bfalse(), b.btrue());
                 if (active_direct_wave_loop && active_direct_wave_continue &&

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -230,9 +230,10 @@ void apply_fragment_consumption(PixelInputMapping& mapping,
 }
 
 std::vector<uint32_t> recompile_interpolation_geometry(
-        const FragmentInterpolationLayout& layout, bool capture_position) {
+        const FragmentInterpolationLayout& layout, bool capture_position,
+        bool synthesize_rect) {
     SpirvCompute builder;
-    return builder.build_interpolation_geometry(layout, capture_position);
+    return builder.build_interpolation_geometry(layout, capture_position, synthesize_rect);
 }
 
 namespace {

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.cpp
@@ -2124,7 +2124,10 @@ bool prepare_lds_fminmax_synchronization(std::vector<Rdna2Inst>& ins,
 std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
                                      const ShaderResourceTable* rt, uint32_t lds_bytes,
-                                     uint32_t compute_pgm_rsrc1) {
+                                     uint32_t compute_pgm_rsrc1,
+                                     bool force_cfg_for_test,
+                                     uint32_t local_x_for_test,
+                                     uint32_t threads_x_for_test) {
     std::vector<Rdna2Inst> ins;
     rdna2_walk(code, dwords, ins);
     // This shell publishes register state after the structured region, so both terminal arms can
@@ -2146,16 +2149,28 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
         uint32_t dw = (lds_bytes + 3) / 4;
         b.lds_dwords = dw > 16384u ? 16384u : (dw ? dw : 1u);
     }
-    b.begin(num_inputs ? num_inputs : 1, rt);
+    if (!local_x_for_test || local_x_for_test > 1024) return {};
+    b.begin(num_inputs ? num_inputs : 1, rt, local_x_for_test, 1, 1, 64, 0);
     b.declare_guest_scratch(scratch);
     RegState rs; rs.vcc = b.bfalse(); rs.scc = b.bfalse(); rs.exec = b.btrue();
     auto safe_branches = safe_execz_branches(ins);
     for (uint32_t wpc : waterfall_branches(ins)) safe_branches.insert(wpc);   // readfirstlane waterfalls (#273)
     for (uint32_t k = 0; k < num_inputs; k++) rs.vreg[(int)k] = b.load_input(k);
     // Compute kernels have no EXP output; reject if one appears.
-    if (!emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true, /*allow_smem*/true,
-                   [](RegState&, const Rdna2Inst&){ return false; }, code, dwords,
-                   nullptr, true, 0, false, lds_fminmax_synchronization.needs_dispatcher)) return {};
+    const auto no_export = [](RegState&, const Rdna2Inst&){ return false; };
+    const uint32_t initial_active =
+        force_cfg_for_test && threads_x_for_test &&
+                threads_x_for_test % local_x_for_test != 0
+            ? b.invocation_within_extent(threads_x_for_test, 1, 1)
+            : 0;
+    const bool emitted = force_cfg_for_test
+        ? emit_cfg_state_machine(
+              b, rs, ins, safe_branches, rt, /*allow_exec_update*/true,
+              /*allow_smem*/true, no_export, code, dwords, initial_active, false)
+        : emit_body(b, rs, ins, safe_branches, rt, /*allow_exec_update*/true,
+                    /*allow_smem*/true, no_export, code, dwords,
+                    nullptr, true, 0, false, lds_fminmax_synchronization.needs_dispatcher);
+    if (!emitted) return {};
     auto it = rs.vreg.find((int)out_vgpr);
     uint32_t outbits = it == rs.vreg.end() ? b.uconst(0) : it->second;
     // If EXEC is still narrowed (a v_cmpx with no restore), masked-off lanes keep the output slot's prior
@@ -2163,6 +2178,13 @@ std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
     if (!rs.exec_narrowed) b.store_output(outbits);
     else                   b.store_output_pred(outbits, rs.exec);
     return b.finish();
+}
+
+bool fragment_vcc_branch_is_wave_uniform_for_test(
+        const uint32_t* code, size_t dwords, uint32_t branch_pc) {
+    std::vector<Rdna2Inst> instructions;
+    rdna2_walk(code, dwords, instructions);
+    return vcc_exit_is_wave_uniform(instructions, branch_pc);
 }
 
 std::vector<uint32_t> recompile_compute(const uint32_t* code, size_t dwords,

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -372,7 +372,8 @@ bool dead_varying_elimination_enabled();
 // triangle-strip lowering all feed Vulkan's `Triangles` geometry input primitive. The optional
 // capture flag decorates this final pre-rasterization stage for the geometry diagnostic only.
 std::vector<uint32_t> recompile_interpolation_geometry(
-    const FragmentInterpolationLayout& layout, bool capture_position = false);
+    const FragmentInterpolationLayout& layout, bool capture_position = false,
+    bool synthesize_rect = false);
 
 // Translate a straight-line float-VALU RDNA2 stream to a compute-shader SPIR-V module.
 // Returns {} if the stream contains an opcode/format this stage does not yet handle. An optional

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -383,7 +383,10 @@ std::vector<uint32_t> recompile_interpolation_geometry(
 std::vector<uint32_t> recompile_valu(const uint32_t* code, size_t dwords,
                                      uint32_t num_inputs, uint32_t out_vgpr,
                                      const ShaderResourceTable* rt = nullptr, uint32_t lds_bytes = 0,
-                                     uint32_t compute_pgm_rsrc1 = kDefaultComputePgmRsrc1);
+                                     uint32_t compute_pgm_rsrc1 = kDefaultComputePgmRsrc1,
+                                     bool force_cfg_for_test = false,
+                                     uint32_t local_x_for_test = 64,
+                                     uint32_t threads_x_for_test = 0);
 
 // Register and launch state for a real compute program. User SGPR values are supplied as one
 // push-constant dword per register; enabled system SGPRs follow them in hardware order. TIDIG_COMP_CNT
@@ -467,6 +470,10 @@ std::vector<uint32_t> recompile_fragment(const uint32_t* code, size_t dwords,
 // mode from SPI_PS_IN_CONTROL.PS_W32_EN.
 std::vector<uint32_t> recompile_fragment_wave32_for_test(
     const uint32_t* code, size_t dwords);
+// Test hook for the static half of the scalar-uniform VCC branch proof. Production additionally
+// requires the live VCC SSA value to carry the matching uniform marker.
+bool fragment_vcc_branch_is_wave_uniform_for_test(
+    const uint32_t* code, size_t dwords, uint32_t branch_pc);
 // Test hook for the byte-exact legacy capture exception: it must select one coherent Wave32
 // contract, not Wave32 masks inside a Wave64 native subgroup.
 uint32_t fragment_effective_wave_size_for_test(uint32_t requested_wave_size,

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv.hpp
@@ -506,6 +506,11 @@ inline constexpr uint32_t kFragmentWaveReasonShuffle    = 1u << 5;  // lane-addr
 // be. Reporting both as "wave-any" made the recoverable and unrecoverable cases one number: on
 // PPSA04263 that number was 68 of 112 skipped fragment shaders, with no way to ask how it divides.
 inline constexpr uint32_t kFragmentWaveReasonWaveBallot = 1u << 6;  // OpGroupNonUniformBallot (reduce)
+// A WaveAny result that reaches a guest scalar-data consumer. A native Wave32 subgroup may
+// disagree with the other half of the guest Wave64, so this qualifier always retains the exact
+// width contract. Kept separate from WaveAny so a title-scoped, empirically reviewed control-flow
+// route cannot accidentally admit a scalar reduction.
+inline constexpr uint32_t kFragmentWaveReasonScalarReduce = 1u << 7;
 
 // Reasons recorded by the emitter, or UINT32_MAX when the module carries no reason marker at
 // all (built, cached or captured before #2147). Absent must not read as none.

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -554,6 +554,13 @@ struct SpirvCompute {
     // `required-ops` field scans for Vote/Arithmetic/Shuffle CAPABILITIES and the lane-id path
     // declares none of them -- so the two cases printed identically.
     uint32_t fragment_wave_reasons=0;
+    // SSA provenance for fragment WaveAny results. A vote needs the exact guest-wave width when
+    // that particular bool reaches a guest scalar-data consumer. Tracking result ids avoids the
+    // false whole-module inference "this shader contains both a vote and S_CSELECT".
+    std::unordered_set<uint32_t> fragment_wave_vote_values;
+    std::unordered_set<uint32_t> fragment_wave_vote_scalar_consumers;
+    std::unordered_map<uint32_t, std::vector<uint32_t>> fragment_wave_vote_dependents;
+    std::unordered_map<size_t, uint32_t> fragment_wave_vote_phi_patch_results;
     uint32_t v_subgroupid=0, v_subgroup_localid=0, t_ptr_in_u32=0;
     uint32_t v_helper_invocation=0, t_ptr_in_bool=0;
     uint32_t v_internal_gds=0, t_ptr_gds_u32=0;
@@ -751,7 +758,46 @@ struct SpirvCompute {
     uint32_t fcmp(uint32_t cmpop, uint32_t a, uint32_t b) { uint32_t r = id(); put(code, cmpop, {t_bool, r, bcf(a), bcf(b)}); return r; }
     uint32_t bfalse() { if (!bconst_false) { bconst_false = id(); put(types, Op_ConstantFalse, {t_bool, bconst_false}); } return bconst_false; }
     uint32_t sel(uint32_t cond, uint32_t tval, uint32_t fval) { uint32_t r = id(); put(code, Op_Select, {t_u32, r, cond, tval, fval}); return r; }
-    uint32_t bsel(uint32_t cond, uint32_t tval, uint32_t fval) { uint32_t r = id(); put(code, Op_Select, {t_bool, r, cond, tval, fval}); return r; }  // bool-domain select (wave masks)
+    bool is_fragment_wave_vote_value(uint32_t value) const {
+        return fragment_wave_vote_values.contains(value);
+    }
+    void mark_fragment_wave_vote_value(uint32_t value) {
+        std::vector<uint32_t> pending{value};
+        while (!pending.empty()) {
+            const uint32_t current = pending.back();
+            pending.pop_back();
+            if (!fragment_wave_vote_values.insert(current).second) continue;
+            if (fragment_wave_vote_scalar_consumers.contains(current))
+                fragment_wave_reasons |= kFragmentWaveReasonScalarReduce;
+            const auto dependent = fragment_wave_vote_dependents.find(current);
+            if (dependent != fragment_wave_vote_dependents.end())
+                pending.insert(pending.end(), dependent->second.begin(), dependent->second.end());
+        }
+    }
+    void add_fragment_wave_vote_dependency(uint32_t result, uint32_t source) {
+        fragment_wave_vote_dependents[source].push_back(result);
+        if (is_fragment_wave_vote_value(source)) mark_fragment_wave_vote_value(result);
+    }
+    void propagate_fragment_wave_vote(uint32_t result, uint32_t source) {
+        add_fragment_wave_vote_dependency(result, source);
+    }
+    void propagate_fragment_wave_vote(uint32_t result, uint32_t a, uint32_t b_) {
+        add_fragment_wave_vote_dependency(result, a);
+        add_fragment_wave_vote_dependency(result, b_);
+    }
+    void mark_fragment_wave_scalar_use(uint32_t value) {
+        fragment_wave_vote_scalar_consumers.insert(value);
+        if (is_fragment_wave_vote_value(value))
+            fragment_wave_reasons |= kFragmentWaveReasonScalarReduce;
+    }
+    uint32_t bsel(uint32_t cond, uint32_t tval, uint32_t fval) {
+        uint32_t r = id();
+        put(code, Op_Select, {t_bool, r, cond, tval, fval});
+        add_fragment_wave_vote_dependency(r, cond);
+        add_fragment_wave_vote_dependency(r, tval);
+        add_fragment_wave_vote_dependency(r, fval);
+        return r;
+    }  // bool-domain select (wave masks)
 
     // --- Structured control-flow primitives (for counted-loop reconstruction) ---
     uint32_t cur_block = 0;   // label id of the block currently being emitted (predecessor for OpPhi)
@@ -765,9 +811,17 @@ struct SpirvCompute {
         uint32_t r = id();
         put(code, Op_Phi, {type, r, v0, l0, 0u, 0u});
         patch_off = code.size() - 2;   // the trailing {v1, l1} placeholders
+        propagate_fragment_wave_vote(r, v0);
+        fragment_wave_vote_phi_patch_results[patch_off] = r;
         return r;
     }
-    void patch_phi(size_t patch_off, uint32_t v1, uint32_t l1) { code[patch_off] = v1; code[patch_off + 1] = l1; }
+    void patch_phi(size_t patch_off, uint32_t v1, uint32_t l1) {
+        code[patch_off] = v1;
+        code[patch_off + 1] = l1;
+        const auto result = fragment_wave_vote_phi_patch_results.find(patch_off);
+        if (result != fragment_wave_vote_phi_patch_results.end())
+            propagate_fragment_wave_vote(result->second, v1);
+    }
     void emit_selmerge(uint32_t m) { put(code, Op_SelectionMerge, {m, 0}); }   // structured if (before condbranch)
     void emit_switch(uint32_t selector, uint32_t fallback,
                      const std::vector<std::pair<uint32_t, uint32_t>>& cases) {
@@ -868,11 +922,22 @@ struct SpirvCompute {
         replace(index + 1u, 0, bits - low_bits, low_bits);
     }
     uint32_t load_function(uint32_t type, uint32_t var) {
-        uint32_t value = id(); put(code, Op_Load, {type, value, var}); return value;
+        uint32_t value = id();
+        put(code, Op_Load, {type, value, var});
+        add_fragment_wave_vote_dependency(value, var);
+        return value;
     }
-    void store_function(uint32_t var, uint32_t value) { put(code, Op_Store, {var, value}); }
+    void store_function(uint32_t var, uint32_t value) {
+        put(code, Op_Store, {var, value});
+        // Function storage can join dynamic paths and loops. Keep an explicit dependency edge so
+        // a vote emitted later can propagate back through loads already generated by a dispatcher.
+        add_fragment_wave_vote_dependency(var, value);
+    }
     uint32_t logical_not(uint32_t value) {
-        uint32_t result = id(); put(code, Op_LogicalNot, {t_bool, result, value}); return result;
+        uint32_t result = id();
+        put(code, Op_LogicalNot, {t_bool, result, value});
+        propagate_fragment_wave_vote(result, value);
+        return result;
     }
     uint32_t subgroup_local_id() {
         if (!declared_subgroup) {
@@ -919,6 +984,7 @@ struct SpirvCompute {
         uint32_t result = id();
         put(code, Op_GroupNonUniformAny,
             {t_bool, result, uconst(Scope_Subgroup), active_bit});
+        mark_fragment_wave_vote_value(result);
         return result;
     }
     // Fragment-side ballot (#2412). Same exactness argument as native_wave_ballot_half, but the
@@ -1408,7 +1474,10 @@ struct SpirvCompute {
     }
     // OpPhi with two fully-known predecessors (both edges' values available now) — for an if/merge join.
     uint32_t emit_phi_2way(uint32_t type, uint32_t va, uint32_t la, uint32_t vb, uint32_t lb) {
-        uint32_t r = id(); put(code, Op_Phi, {type, r, va, la, vb, lb}); return r;
+        uint32_t r = id();
+        put(code, Op_Phi, {type, r, va, la, vb, lb});
+        propagate_fragment_wave_vote(r, va, vb);
+        return r;
     }
     // Signed-int helpers: bits are bitcast to i32, the op runs, and the i32 result is bitcast to bits.
     uint32_t bcs(uint32_t u) { uint32_t r = id(); put(code, Op_Bitcast, {t_i32, r, u}); return r; }   // bits -> i32
@@ -3263,6 +3332,38 @@ struct SpirvCompute {
         put(code, Op_Load, {t_u32, result, result_ptr_all});
         return ucmp(Op_INotEqual, result, zero);
     }
+    // V_READLANE_B32 at a workgroup-uniform site. Publish every invocation's source value and
+    // address the selected lane within this invocation's own guest wave. This is exact at any
+    // host subgroup width; unlike a native subgroup shuffle it does not require a Wave64 guest
+    // wave to fit inside one Vulkan subgroup. V_READLANE ignores EXEC, so publication is
+    // unconditional. Missing lanes in a partial final wave read as zero.
+    uint32_t guest_wave_readlane(uint32_t source_value, uint32_t selector) {
+        declare_wave_lds();
+        uint32_t source_ptr = id();
+        putv(code, Op_AccessChain,
+             {t_ptr_wg_u32b, source_ptr, lds_wave, linear_localid});
+        put(code, Op_Store, {source_ptr, source_value});
+        barrier();
+
+        const uint32_t wave_shift = wave_size == 32 ? 5u : 6u;
+        const uint32_t wave_base = ibin(
+            Op_ShiftLeftLogical,
+            ibin(Op_ShiftRightLogical, linear_localid, uconst(wave_shift)),
+            uconst(wave_shift));
+        const uint32_t lane = ibin(
+            Op_BitwiseAnd, selector, uconst(wave_size - 1u));
+        const uint32_t index = ibin(Op_IAdd, wave_base, lane);
+        const uint32_t zero = uconst(0);
+        const uint32_t valid = ucmp(Op_ULessThan, index, uconst(local_count));
+        const uint32_t safe_index = sel(valid, index, zero);
+        uint32_t result_ptr = id();
+        putv(code, Op_AccessChain,
+             {t_ptr_wg_u32b, result_ptr, lds_wave, safe_index});
+        uint32_t result = id();
+        put(code, Op_Load, {t_u32, result, result_ptr});
+        barrier();
+        return sel(valid, result, zero);
+    }
     // v_mbcnt_lo/hi: count active lanes below this one. active_bool = this lane's mask bit (EXEC); acc =
     // src1 accumulator (bits); `lo` selects the [0,32) half (lo) or [32,64) half (hi). Combined lo→hi over
     // a wave = the lane's compaction index among active lanes. Populate LDS[lane]=active, barrier, then an
@@ -3524,8 +3625,18 @@ struct SpirvCompute {
         return value;
     }
     // Logical AND / OR of two bools (EXEC narrowing / saveexec).
-    uint32_t land(uint32_t a, uint32_t b_) { uint32_t r = id(); put(code, Op_LogicalAnd, {t_bool, r, a, b_}); return r; }
-    uint32_t lor(uint32_t a, uint32_t b_)  { uint32_t r = id(); put(code, Op_LogicalOr,  {t_bool, r, a, b_}); return r; }
+    uint32_t land(uint32_t a, uint32_t b_) {
+        uint32_t r = id();
+        put(code, Op_LogicalAnd, {t_bool, r, a, b_});
+        propagate_fragment_wave_vote(r, a, b_);
+        return r;
+    }
+    uint32_t lor(uint32_t a, uint32_t b_) {
+        uint32_t r = id();
+        put(code, Op_LogicalOr, {t_bool, r, a, b_});
+        propagate_fragment_wave_vote(r, a, b_);
+        return r;
+    }
 
     void begin(uint32_t input_stride, const ShaderResourceTable* rt = nullptr,
                uint32_t local_x = 64, uint32_t local_y = 1, uint32_t local_z = 1,

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -4202,6 +4202,10 @@ struct SpirvCompute {
 // operands may reference either (SGPR is a valid ALU operand), so both are resolved by operand_bits.
 struct RegState {
     std::unordered_map<int, uint32_t> vreg, sreg;
+    // The latest VCC SSA value proved identical in every guest lane. A fragment VCCZ branch over
+    // that exact value is already scalar and needs no subgroup vote. Tying the proof to the SSA id
+    // makes an overwrite or control-flow merge invalidate it automatically.
+    uint32_t vcc_wave_uniform = 0;
     // Before the first compact structured construct, map presence means that the scalar value
     // reaches this exact linear path. Branch/loop PHIs can synthesize zero for an absent SGPR and
     // clear this marker. The CFG dispatcher likewise allocates Function variables for every
@@ -4722,6 +4726,14 @@ bool emit_alu(SpirvCompute& b, RegState& rs, const Rdna2Inst& in, bool& ok, bool
 
 // emit_body and the CFG state machine it drives live in rdna2_emit_cfg.cpp. As with emit_alu, the
 // default arguments are stated here and nowhere else.
+bool emit_cfg_state_machine(
+    SpirvCompute& b, RegState& initial, const std::vector<Rdna2Inst>& ins,
+    const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
+    bool allow_exec_update, bool allow_smem,
+    const std::function<bool(RegState&, const Rdna2Inst&)>& exp_fn,
+    const uint32_t* code, size_t dwords, uint32_t initial_active,
+    bool synchronize_lds_fminmax);
+
 bool emit_body(SpirvCompute& b, RegState& rs, const std::vector<Rdna2Inst>& ins,
                const std::unordered_set<uint32_t>& safe, const ShaderResourceTable* rt,
                bool allow_exec_update, bool allow_smem,

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -3969,10 +3969,15 @@ struct SpirvCompute {
 
     // Descriptor-free geometry pass-through used when a fragment program asks for AMD's explicit
     // P0/P10/P20 vertex parameters on a Vulkan device without a barycentric/vertex-parameter
-    // extension. Input assembly has already decomposed lists/strips/fans into triangles here.
+    // extension. Input assembly has already decomposed lists/strips/fans into triangles here. A
+    // three-vertex PS5 RectList whose attributes come from a vertex buffer also comes through this
+    // stage: GFX10 synthesizes its fourth corner after vertex shading, while Vulkan has no RectList
+    // topology. The missing post-VS position and every consumed varying are the affine fourth
+    // corner P1 + P2 - P0; emitting P0,P1,P2,P3 as a strip preserves the hardware rectangle.
     std::vector<uint32_t> build_interpolation_geometry(
-            const FragmentInterpolationLayout& layout, bool capture_geometry_position) {
-        if (!layout.requires_geometry || !layout.valid) return {};
+            const FragmentInterpolationLayout& layout, bool capture_geometry_position,
+            bool synthesize_rect = false) {
+        if ((!layout.requires_geometry && !synthesize_rect) || !layout.valid) return {};
 
         t_void = id(); t_fn = id(); t_f32 = id(); t_u32 = id(); t_i32 = id(); t_bool = id();
         t_v4f = id();
@@ -3990,7 +3995,8 @@ struct SpirvCompute {
         for (uint32_t attr = 0; attr < 32; ++attr) {
             if (!(layout.attribute_mask & (1u << attr))) continue;
             attribute_inputs[attr] = id();
-            if (layout.smooth_mask & (1u << attr)) attribute_outputs[attr] = id();
+            if ((layout.smooth_mask & (1u << attr)) || synthesize_rect)
+                attribute_outputs[attr] = id();
             for (uint32_t selector = 0; selector < 3; ++selector)
                 if (layout.parameter_locations[attr][selector] !=
                     FragmentInterpolationLayout::kUnusedLocation)
@@ -4009,7 +4015,7 @@ struct SpirvCompute {
         exec_model = Exec_Geometry;
         put(exec, Op_ExecutionMode, {f_main, EM_Triangles});
         put(exec, Op_ExecutionMode, {f_main, EM_OutputTriangleStrip});
-        put(exec, Op_ExecutionMode, {f_main, EM_OutputVertices, 3});
+        put(exec, Op_ExecutionMode, {f_main, EM_OutputVertices, synthesize_rect ? 4u : 3u});
         if (capture_geometry_position) put(exec, Op_ExecutionMode, {f_main, EM_Xfb});
 
         put(deco, Op_MemberDecorate, {t_input_per_vertex, 0, Dec_BuiltIn, BI_Position});
@@ -4094,6 +4100,7 @@ struct SpirvCompute {
             }
         }
         std::array<std::array<uint32_t, 3>, 32> parameters{};
+        std::array<uint32_t, 32> rect_attribute_values{};
         for (uint32_t attr = 0; attr < 32; ++attr) {
             if (!attribute_inputs[attr]) continue;
             parameters[attr][2] = attribute_values[attr][0];
@@ -4108,13 +4115,35 @@ struct SpirvCompute {
                 put(code, Op_FSub, {t_v4f, parameters[attr][1],
                                     attribute_values[attr][2], attribute_values[attr][0]});
             }
+            if (synthesize_rect) {
+                const uint32_t sum = id();
+                put(code, Op_FAdd, {t_v4f, sum,
+                                    attribute_values[attr][1], attribute_values[attr][2]});
+                rect_attribute_values[attr] = id();
+                put(code, Op_FSub, {t_v4f, rect_attribute_values[attr],
+                                    sum, attribute_values[attr][0]});
+            }
         }
 
+        std::array<uint32_t, 3> positions{};
         for (uint32_t vertex = 0; vertex < 3; ++vertex) {
-            uint32_t input_pointer = id();
+            const uint32_t input_pointer = id();
             put(code, Op_AccessChain,
                 {ptr_in_v4f, input_pointer, input_position, uconst(vertex), uconst(0)});
-            uint32_t position = id(); put(code, Op_Load, {t_v4f, position, input_pointer});
+            positions[vertex] = id();
+            put(code, Op_Load, {t_v4f, positions[vertex], input_pointer});
+        }
+        uint32_t rect_position = 0;
+        if (synthesize_rect) {
+            const uint32_t sum = id();
+            put(code, Op_FAdd, {t_v4f, sum, positions[1], positions[2]});
+            rect_position = id();
+            put(code, Op_FSub, {t_v4f, rect_position, sum, positions[0]});
+        }
+
+        const uint32_t output_vertices = synthesize_rect ? 4u : 3u;
+        for (uint32_t vertex = 0; vertex < output_vertices; ++vertex) {
+            const uint32_t position = vertex < 3 ? positions[vertex] : rect_position;
             uint32_t output_pointer = id();
             put(code, Op_AccessChain,
                 {ptr_out_v4f, output_pointer, output_position, uconst(0)});
@@ -4123,14 +4152,15 @@ struct SpirvCompute {
             for (uint32_t attr = 0; attr < 32; ++attr) {
                 if (attribute_outputs[attr])
                     put(code, Op_Store,
-                        {attribute_outputs[attr], attribute_values[attr][vertex]});
+                        {attribute_outputs[attr], vertex < 3
+                            ? attribute_values[attr][vertex] : rect_attribute_values[attr]});
                 for (uint32_t selector = 0; selector < 3; ++selector)
                     if (parameter_outputs[attr][selector])
                         put(code, Op_Store,
                             {parameter_outputs[attr][selector], parameters[attr][selector]});
             }
-            const float i = vertex == 1 ? 1.0f : 0.0f;
-            const float j = vertex == 2 ? 1.0f : 0.0f;
+            const float i = vertex == 1 || vertex == 3 ? 1.0f : 0.0f;
+            const float j = vertex == 2 || vertex == 3 ? 1.0f : 0.0f;
             const uint32_t barycentric = id();
             putv(code, Op_CompositeConstruct,
                  {t_v4f, barycentric, fconstf(i), fconstf(j), fconstf(1.0f), fconstf(1.0f)});

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -253,6 +253,7 @@ enum : uint32_t {
     Cap_Sampled1D=43, Cap_Image1D=44,   // Dim=1D needs Sampled1D; a 1D STORAGE image (read/write) also needs Image1D
     Cap_StorageImageMultisample=27,      // MS=1 storage image (read/write a multisampled image)
     Cap_ImageMSArray=48,                 // MS=1 AND Arrayed=1 image (2D_MSAA_ARRAY)
+    Cap_StorageImageExtendedFormats=49,  // typed formats outside the core R32/RGBA32 set
     Cap_StorageImageReadWithoutFormat=55, Cap_StorageImageWriteWithoutFormat=56,  // for Format=Unknown storage images
     Cap_ImageGatherExtended=25,          // dynamic (non-const) Offset image operand on OpImageGather
     Cap_ImageQuery=50,                   // OpImageQuerySizeLod (the sample_*_o texel->UV offset fold)
@@ -260,6 +261,9 @@ enum : uint32_t {
     Img_Sampled_Storage=2,   // OpTypeImage "Sampled" operand: 2 = used WITHOUT a sampler (read/write storage image)
     ImgFmt_Unknown=0,        // OpTypeImage "Image Format": Unknown (runtime view format; needs the caps above)
     ImgFmt_R32ui=kSpirvImageFormatR32ui, // exact uint32 storage image format required by image atomics
+    ImgFmt_Rgba8ui=kSpirvImageFormatRgba8ui, // exact four-byte RGBA unsigned storage image
+    ImgFmt_R16ui=kSpirvImageFormatR16ui, // exact halfword-width unsigned storage image
+    ImgFmt_R8ui=kSpirvImageFormatR8ui,   // exact byte-width unsigned storage image
     ImgOp_Bias=1, ImgOp_Lod=2, ImgOp_Grad=4, ImgOp_Sample=0x40,   // ImageOperands bits.
     SC_Workgroup=4, Scope_Device=1, Scope_Workgroup=2, Scope_Subgroup=3,
     MemSem_UniformAcquire=0x42, MemSem_UniformRelease=0x44,
@@ -2079,7 +2083,9 @@ struct SpirvCompute {
     std::unordered_map<uint32_t, bool> stg_img_float;      // binding -> float (rather than uint) texels
     std::unordered_map<uint32_t, uint32_t> stg_img_format; // binding -> SPIR-V Image Format
     std::unordered_map<uint32_t, bool> stg_img_packed_r11; // binding -> R11G11B10 packed in R32ui
-    bool declared_read_wo_fmt = false, declared_write_wo_fmt = false, declared_sampled1d = false, declared_ms = false, declared_msarray = false;
+    bool declared_read_wo_fmt = false, declared_write_wo_fmt = false,
+         declared_storage_extended = false, declared_sampled1d = false,
+         declared_ms = false, declared_msarray = false;
     static uint32_t stg_key(uint32_t dim, bool arrayed, bool ms, bool float_texel,
                             uint32_t image_format) {
         return dim | (arrayed ? 0x100u : 0u) | (ms ? 0x200u : 0u) |
@@ -2098,6 +2104,12 @@ struct SpirvCompute {
         }
         if (ms && !declared_ms) { put(caps, Op_Capability, {Cap_StorageImageMultisample}); declared_ms = true; }
         if (ms && arrayed && !declared_msarray) { put(caps, Op_Capability, {Cap_ImageMSArray}); declared_msarray = true; }
+        if ((image_format == ImgFmt_R8ui || image_format == ImgFmt_R16ui ||
+             image_format == ImgFmt_Rgba8ui) &&
+            !declared_storage_extended) {
+            put(caps, Op_Capability, {Cap_StorageImageExtendedFormats});
+            declared_storage_extended = true;
+        }
         uint32_t key = stg_key(dim, arrayed, ms, float_texel, image_format);
         if (!stg_img_type.count(key)) {
             uint32_t ti = id();
@@ -2199,8 +2211,22 @@ struct SpirvCompute {
             put(code, Op_CompositeConstruct,
                 {t_v4f, texel, bcf(vals[0]), bcf(vals[1]), bcf(vals[2]), bcf(vals[3])});
         else
+        {
+            // Vulkan's narrow integer storage conversion may saturate a u32 value that does not fit
+            // the target, while the guest image-store contract discards the high bits. Make that
+            // conversion explicit so typed R8ui/R16ui stay identical to the raw CPU pack fallback
+            // for arbitrary shader values, not only values loaded from another narrow surface.
+            const uint32_t width_mask =
+                (stg_img_format[binding] == ImgFmt_R8ui ||
+                 stg_img_format[binding] == ImgFmt_Rgba8ui) ? 0xffu
+                : stg_img_format[binding] == ImgFmt_R16ui ? 0xffffu : 0u;
+            uint32_t narrowed[4] = {vals[0], vals[1], vals[2], vals[3]};
+            if (width_mask)
+                for (uint32_t c = 0; c < 4; ++c)
+                    narrowed[c] = ibin(Op_BitwiseAnd, vals[c], uconst(width_mask));
             put(code, Op_CompositeConstruct,
-                {t_v4u(), texel, vals[0], vals[1], vals[2], vals[3]});
+                {t_v4u(), texel, narrowed[0], narrowed[1], narrowed[2], narrowed[3]});
+        }
         if (!predicated) { put(code, Op_ImageWrite, {img, coord, texel}); return; }
         uint32_t then = id(), merge = id();
         put(code, Op_SelectionMerge, {merge, 0});

--- a/prosper/src/gpu/resources/shader_resources.hpp
+++ b/prosper/src/gpu/resources/shader_resources.hpp
@@ -122,6 +122,27 @@ constexpr bool native_float_storage_image_supported(DataFormat format, uint32_t 
     return storage_image_feature && native_float_storage_image(format, components, srgb);
 }
 
+// Narrow unsigned integer storage has the same exact byte contract as the guest surface:
+// Vulkan zero-extends narrow texels on load and discards the high bits on store. Keeping these
+// images typed avoids the portable RGBA32_UINT interchange representation (16 bytes per texel)
+// without changing any shader-visible value. The 16-bit arm is important for GTA V's layered depth
+// copies: the raw fallback expands a six-face 512x512 Uint16 cube from 3 MiB to 24 MiB for every
+// single-face dispatch. RGBA8_UINT is equally exact and avoids expanding GTA V's 4K transition
+// target from 33 MiB to 127 MiB. Keep integer 3D separate so no unqueried dimensional contract is
+// implied.
+constexpr bool native_uint_storage_image(DataFormat format, uint32_t components, bool srgb) {
+    return !srgb &&
+           ((components == 1 &&
+             (format == DataFormat::Uint32 || format == DataFormat::Uint16 ||
+              format == DataFormat::Uint8)) ||
+            (components == 4 && format == DataFormat::Uint8));
+}
+
+constexpr bool native_uint_storage_image_supported(DataFormat format, uint32_t components,
+                                                   bool srgb, bool storage_image_feature) {
+    return storage_image_feature && native_uint_storage_image(format, components, srgb);
+}
+
 // Stable, Vulkan-independent bits used to carry per-format storage-image capabilities from the
 // device-owning frontend into the compute recompiler. Zero means the semantic format is not a native
 // typed-storage candidate; otherwise each exact VkFormat candidate has its own bit.
@@ -136,6 +157,11 @@ constexpr uint32_t native_storage_format_support_bit(DataFormat format, uint32_t
         return components == 1 ? 1u << 6 : components == 2 ? 1u << 7
              : components == 4 ? 1u << 8 : 0u;
     if (format == DataFormat::Float10_11_11 && components == 3) return 1u << 9;
+    // Bits 10..19 retain their capture-stable meaning as the 3D mirrors of bits 0..9.
+    if (format == DataFormat::Uint32 && components == 1) return 1u << 20;
+    if (format == DataFormat::Uint8 && components == 1) return 1u << 21;
+    if (format == DataFormat::Uint16 && components == 1) return 1u << 22;
+    if (format == DataFormat::Uint8 && components == 4) return 1u << 23;
     return 0;
 }
 
@@ -144,10 +170,11 @@ constexpr uint32_t native_storage_format_support_bit(DataFormat format, uint32_t
 // the corresponding 3D image never compiles a shader the live backend cannot bind.
 constexpr uint32_t native_storage_3d_format_support_bit(DataFormat format,
                                                         uint32_t components) {
-    return native_storage_format_support_bit(format, components) << 10;
+    const uint32_t format_bit = native_storage_format_support_bit(format, components);
+    return (format_bit & ((1u << 10) - 1u)) ? format_bit << 10 : 0u;
 }
 
-constexpr uint32_t kNativeStorageFormatSupportMask = (1u << 20) - 1u;
+constexpr uint32_t kNativeStorageFormatSupportMask = (1u << 24) - 1u;
 
 // IEEE-754 binary16 -> binary32 (handles subnormals, +/-inf, NaN). Used by the texture upload path to
 // convert a sampled Float16 surface to the RGBA8 the backend uploads (#290). Pure + testable.
@@ -569,6 +596,23 @@ constexpr bool shader_resource_uses_native_2d_storage_image(
             !resource.depth_compare);
 }
 
+// Exact unsigned integer storage also admits a real multi-layer 2D-array view. The live backend
+// already stages every physical slice independently and creates an array image with the reflected
+// layer count; keeping this separate from the float predicate prevents an unrelated format from
+// silently broadening its dimensional contract. A shader-declared non-arrayed view still uses the
+// ordinary/base-slice rule above.
+constexpr bool shader_resource_uses_native_uint_2d_storage_image(
+    const ShaderResource& resource,
+    bool shader_2d,
+    bool shader_arrayed,
+    bool shader_multisampled) {
+    return shader_resource_uses_native_2d_storage_image(
+               resource, shader_2d, shader_arrayed, shader_multisampled) ||
+           (shader_2d && shader_arrayed && !shader_multisampled &&
+            resource.img_dim == 5 && resource.depth >= 1 &&
+            !resource.depth_compare);
+}
+
 // The RESOURCE half of "may this R32_UINT storage image be lowered to a detiled linear atomic SSBO"
 // (the RADV image-atomic workaround: RADV hangs/reset-poisons the device on a compute R32_UINT image
 // atomic, so compute reaches the image through a buffer view instead).
@@ -796,6 +840,9 @@ enum class StorageBufferTailSemantic : uint32_t {
 // SPIR-V Image Format operand used by the exact one-word storage fallback. Keep this public so the
 // recompiler, reflection, live backend, and their contract tests cannot drift through magic values.
 constexpr uint32_t kSpirvImageFormatR32ui = 33;
+constexpr uint32_t kSpirvImageFormatRgba8ui = 32;
+constexpr uint32_t kSpirvImageFormatR16ui = 38;
+constexpr uint32_t kSpirvImageFormatR8ui = 39;
 
 // A declared descriptor-array length that reflection could not read (#2412). Distinct from 0, which
 // means exactly `OpTypeRuntimeArray` -- a length deliberately supplied at bind time and therefore

--- a/prosper/src/gpu/resources/shader_resources.hpp
+++ b/prosper/src/gpu/resources/shader_resources.hpp
@@ -465,6 +465,39 @@ struct ShaderResource {
     uint32_t scalar_buffer_dword_count = 0;
 };
 
+// Decode the exact SQ_IMG_SAMP state consumed by one MIMG instruction. Metadata describes a
+// texture's usual paired sampler, but shaders may load or patch a different S# before the sample.
+// In that case instruction-time descriptor folding is authoritative.
+inline void apply_sampler_descriptor(ShaderResource& resource, const uint32_t sampler[4]) {
+    resource.mag_filter  = ((sampler[2] >> 20) & 0x3u) ? 1u : 0u;
+    resource.min_filter  = ((sampler[2] >> 22) & 0x3u) ? 1u : 0u;
+    resource.mip_filter  = ((sampler[2] >> 26) & 0x3u) ? 1u : 0u;
+    resource.addr_uvw[0] = (sampler[0] >> 0) & 0x7u;
+    resource.addr_uvw[1] = (sampler[0] >> 3) & 0x7u;
+    resource.addr_uvw[2] = (sampler[0] >> 6) & 0x7u;
+    resource.max_aniso_ratio    = (sampler[0] >> 9)  & 0x7u;
+    resource.depth_compare_func = (sampler[0] >> 12) & 0x7u;
+    resource.unnormalized       = (sampler[0] >> 15) & 0x1u;
+    resource.min_lod            = static_cast<float>(sampler[1] & 0xFFFu) / 256.0f;
+    resource.max_lod            = static_cast<float>((sampler[1] >> 12) & 0xFFFu) / 256.0f;
+    int32_t bias14              = static_cast<int32_t>(sampler[2] & 0x3FFFu);
+    if (bias14 & 0x2000) bias14 -= 0x4000;
+    resource.lod_bias           = static_cast<float>(bias14) / 256.0f;
+    resource.border_color_type  = (sampler[3] >> 30) & 0x3u;
+}
+
+// Attach one exact MIMG use to an otherwise identical metadata resource. The use may carry a live
+// S# that differs from the metadata slot's paired sampler; retaining the old normalized sampler
+// while publishing the new fetch PC creates a self-contradictory resource record.
+inline bool attach_image_use(ShaderResource& resource, uint32_t use_pc,
+                             const uint32_t* sampler) {
+    if (resource.fetch_pc != 0xFFFFFFFFu && resource.fetch_pc != use_pc) return false;
+    resource.fetch_pc = use_pc;
+    if (resource.cls == ResourceClass::Texture && sampler)
+        apply_sampler_descriptor(resource, sampler);
+    return true;
+}
+
 inline bool is_gta5_selected_sbuffer_marker_candidate(const ShaderResource& resource) {
     return resource.selected_sbuffer_soffset != UINT32_MAX;
 }

--- a/prosper/src/gpu/state/render_state.cpp
+++ b/prosper/src/gpu/state/render_state.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include "gpu/pm4/pm4_registers.hpp"
+#include "gpu/texture/tile.hpp"
 #include "gpu/state/vk_translate.hpp"
 #include <algorithm>
 #include <atomic>
@@ -27,6 +28,68 @@ uint32_t rd(const RegisterFile& file, uint32_t off) {
 // GraphicsRun.cpp (`(lo<<8) | ((hi&0xff)<<40)`).
 uint64_t addr_of(uint32_t lo, uint32_t hi) {
     return (static_cast<uint64_t>(lo) << 8) | (static_cast<uint64_t>(hi & 0xffu) << 40);
+}
+
+uint32_t color_format_bytes_per_texel(uint32_t format, uint32_t number_type,
+                                      uint32_t comp_swap) {
+    switch (vk_color_format(format, number_type, comp_swap)) {
+        case VkFormat::R8_UNORM:
+        case VkFormat::R8_SNORM:
+        case VkFormat::R8_UINT:
+        case VkFormat::R8_SINT:
+            return 1u;
+        case VkFormat::R16_UNORM:
+        case VkFormat::R16_SNORM:
+        case VkFormat::R16_UINT:
+        case VkFormat::R16_SINT:
+        case VkFormat::R16_SFLOAT:
+        case VkFormat::R8G8_UNORM:
+        case VkFormat::R8G8_SNORM:
+        case VkFormat::R8G8_UINT:
+        case VkFormat::R8G8_SINT:
+        case VkFormat::B5G6R5_UNORM_PACK16:
+        case VkFormat::R5G6B5_UNORM_PACK16:
+            return 2u;
+        case VkFormat::R32_UINT:
+        case VkFormat::R32_SINT:
+        case VkFormat::R32_SFLOAT:
+        case VkFormat::R16G16_UNORM:
+        case VkFormat::R16G16_SNORM:
+        case VkFormat::R16G16_UINT:
+        case VkFormat::R16G16_SINT:
+        case VkFormat::R16G16_SFLOAT:
+        case VkFormat::B10G11R11_UFLOAT_PACK32:
+        case VkFormat::A2B10G10R10_UNORM_PACK32:
+        case VkFormat::A2R10G10B10_UNORM_PACK32:
+        case VkFormat::A2B10G10R10_UINT_PACK32:
+        case VkFormat::A2R10G10B10_UINT_PACK32:
+        case VkFormat::R8G8B8A8_UNORM:
+        case VkFormat::R8G8B8A8_SNORM:
+        case VkFormat::R8G8B8A8_UINT:
+        case VkFormat::R8G8B8A8_SINT:
+        case VkFormat::R8G8B8A8_SRGB:
+        case VkFormat::B8G8R8A8_UNORM:
+        case VkFormat::B8G8R8A8_SNORM:
+        case VkFormat::B8G8R8A8_UINT:
+        case VkFormat::B8G8R8A8_SINT:
+        case VkFormat::B8G8R8A8_SRGB:
+            return 4u;
+        case VkFormat::R32G32_UINT:
+        case VkFormat::R32G32_SINT:
+        case VkFormat::R32G32_SFLOAT:
+        case VkFormat::R16G16B16A16_UNORM:
+        case VkFormat::R16G16B16A16_SNORM:
+        case VkFormat::R16G16B16A16_UINT:
+        case VkFormat::R16G16B16A16_SINT:
+        case VkFormat::R16G16B16A16_SFLOAT:
+            return 8u;
+        case VkFormat::R32G32B32A32_UINT:
+        case VkFormat::R32G32B32A32_SINT:
+        case VkFormat::R32G32B32A32_SFLOAT:
+            return 16u;
+        default:
+            return 0u;
+    }
 }
 
 // PA_CL_VPORT_* registers hold IEEE-754 floats.
@@ -267,21 +330,63 @@ RenderState extract_render_state(const GpuState& st) {
         const uint32_t info_reg = P::CB_COLOR0_INFO + slot * kColorRegisterStride;
         const uint32_t clear0_reg = P::CB_COLOR0_CLEAR_WORD0 + slot * kColorRegisterStride;
         const uint32_t clear1_reg = clear0_reg + 1u;
-        target.base = addr_of(rd(st.cx, base_reg), rd(st.cx, P::CB_COLOR0_BASE_EXT + slot));
+        target.allocation_base =
+            addr_of(rd(st.cx, base_reg), rd(st.cx, P::CB_COLOR0_BASE_EXT + slot));
+        target.base = target.allocation_base;
         const uint32_t info = rd(st.cx, info_reg);
         target.format = PM4_FIELD(info, CB_COLOR0_INFO, FORMAT);
         target.number_type = PM4_FIELD(info, CB_COLOR0_INFO, NUMBER_TYPE);
         target.comp_swap = PM4_FIELD(info, CB_COLOR0_INFO, COMP_SWAP);
+        const uint32_t view = rd(st.cx, P::CB_COLOR0_VIEW + slot * kColorRegisterStride);
+        target.mip_level = PM4_FIELD(view, CB_COLOR0_VIEW, MIP_LEVEL);
         const auto attrib2 = st.cx.find(P::CB_COLOR0_ATTRIB2 + slot);
         if (attrib2 != st.cx.end()) {
             target.has_extent = true;
             target.width = PM4_FIELD(attrib2->second, CB_COLOR0_ATTRIB2, MIP0_WIDTH) + 1u;
             target.height = PM4_FIELD(attrib2->second, CB_COLOR0_ATTRIB2, MIP0_HEIGHT) + 1u;
+            target.max_mip = PM4_FIELD(attrib2->second, CB_COLOR0_ATTRIB2, MAX_MIP);
+        }
+        const uint32_t attrib3 = rd(st.cx, P::CB_COLOR0_ATTRIB3 + slot);
+        target.color_sw_mode = PM4_FIELD(attrib3, CB_COLOR0_ATTRIB3, COLOR_SW_MODE);
+
+        // The CB base is the allocation origin, not necessarily the address of the selected view.
+        // GTA V's environment-lighting pass renders a six-level 1024x512 R11G11B10F chain by keeping
+        // BASE fixed and advancing VIEW.MIP_LEVEL. Treating all six draws as mip 0 made every pass
+        // overwrite one surface and left the later lighting shader sampling stale guest bytes.
+        if (target.has_extent && target.base && target.mip_level <= target.max_mip) {
+            const uint32_t mip0_width = target.width;
+            const uint32_t mip0_height = target.height;
+            const uint32_t bytes_per_texel = color_format_bytes_per_texel(
+                target.format, target.number_type, target.comp_swap);
+            const TiledMipLevelLayout layout = tiled_mip_level_layout(
+                mip0_width, mip0_height, bytes_per_texel, target.color_sw_mode,
+                target.max_mip, target.mip_level);
+            if (layout.supported) {
+                target.in_mip_tail = layout.in_tail;
+                target.mip_tail_offset = static_cast<uint32_t>(layout.byte_offset);
+                target.mip_tail_x = layout.tail_x;
+                target.mip_tail_y = layout.tail_y;
+                if (!layout.in_tail && layout.byte_offset <= UINT64_MAX - target.base)
+                    target.base += layout.byte_offset;
+                target.width = std::max(mip0_width >> target.mip_level, 1u);
+                target.height = std::max(mip0_height >> target.mip_level, 1u);
+            }
         }
         target.has_clear = st.cx.count(clear0_reg) || st.cx.count(clear1_reg);
         target.clear_word0 = st.cx.count(clear0_reg) ? rd(st.cx, clear0_reg) : 0u;
         target.clear_word1 = st.cx.count(clear1_reg) ? rd(st.cx, clear1_reg) : 0u;
     }
+
+    // The named MRT0/MRT1 fields are compatibility aliases used by older capture and backend paths.
+    // Keep them identical to the complete array after applying CB_COLORn_VIEW.
+    rs.color0_base = rs.color_targets[0].base;
+    rs.color0_has_extent = rs.color_targets[0].has_extent;
+    rs.color0_width = rs.color_targets[0].width;
+    rs.color0_height = rs.color_targets[0].height;
+    rs.color1_base = rs.color_targets[1].base;
+    rs.color1_has_extent = rs.color_targets[1].has_extent;
+    rs.color1_width = rs.color_targets[1].width;
+    rs.color1_height = rs.color_targets[1].height;
 
     // Primitive topology. VGT_PRIMITIVE_TYPE (0x242) is a UCONFIG register in RDNA2 (the game sets it via
     // a Uc-class SetRegsIndirect / CreatePrimState's uc[2]), NOT a context register — read it from st.uc.

--- a/prosper/src/gpu/state/render_state.hpp
+++ b/prosper/src/gpu/state/render_state.hpp
@@ -30,6 +30,15 @@ struct ColorTargetState {
     bool separate_alpha_blend = false;
     uint32_t alpha_src_blend = 0, alpha_dst_blend = 0, alpha_comb_fcn = 0;
     bool disable_rop3 = false;
+
+    // GFX10 color-target view identity. CB_COLORn_BASE names the complete allocation while
+    // CB_COLORn_VIEW.MIP_LEVEL selects the level rendered by this attachment. `base`, `width`, and
+    // `height` above are the effective level view consumed by the backend; these fields retain the
+    // allocation programming needed to diagnose packed-tail aliases and reconstruct full chains.
+    uint64_t allocation_base = 0;
+    uint32_t mip_level = 0, max_mip = 0, color_sw_mode = 0;
+    bool in_mip_tail = false;
+    uint32_t mip_tail_offset = 0, mip_tail_x = 0, mip_tail_y = 0;
 };
 
 struct RenderState {

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -5133,6 +5133,123 @@ namespace {
         }
         return nullptr;
     }
+
+    // Turn a fragmented, entirely guest-owned fixed range into one free placeholder which
+    // MapViewOfFile3 can replace.  Windows cannot replace several adjacent placeholders with one
+    // section view, even when every byte belongs to the guest.  RAGE produces exactly that shape:
+    //
+    //   guest placeholder | MEM_FREE gap | guest placeholder
+    //
+    // and then BatchMap MAP_DIRECTs across all three pieces.  MAP_FIXED on the guest is allowed to
+    // replace its reservations; the host ownership split is an implementation detail.  Admit only
+    // tracked free/guest placeholders plus genuinely MEM_FREE regions.  A committed page, direct
+    // view, private placeholder view, or untracked reservation keeps the old fail-visible result.
+    bool normalize_fragmented_guest_placeholder_range(uint64_t base, uint64_t len) {
+        if (!base || !len || base > UINT64_MAX - len || (base & 0xfff) || (len & 0xfff))
+            return false;
+        const PlaceholderApis& apis = placeholder_apis();
+        if (!apis.virtual_alloc2 || !apis.map_view_of_file3) return false;
+        const uint64_t end = base + len;
+
+        std::lock_guard<std::mutex> lk(g_dview_mx);
+        for (const DmemView& view : g_dviews)
+            if (view.guest_base < end && base < view.guest_base + view.guest_size)
+                return false;
+        for (const PrivatePlaceholderView& view : g_private_placeholder_views)
+            if (view.base < end && base < view.base + view.size)
+                return false;
+
+        // Do not turn an arbitrary free address into a successful guest UNMAP.  This repair is
+        // only for fragmentation around at least one reservation already owned by the guest/HLE.
+        bool has_tracked_placeholder = false;
+        for (const PlaceholderSpan& span : g_free_placeholders)
+            has_tracked_placeholder |= span.base < end && base < span.base + span.size;
+        for (const PlaceholderSpan& span : g_guest_placeholders)
+            has_tracked_placeholder |= span.base < end && base < span.base + span.size;
+        if (!has_tracked_placeholder) return false;
+
+        // Claim every real host hole first.  VirtualAlloc2 at an exact base is the atomic ownership
+        // check: if another thread obtains any hole, this fails without touching that memory.  The
+        // cover may extend by less than one allocation granule outside the guest request, but only
+        // within the same VirtualQuery-proven MEM_FREE region; the surplus remains in the free pool.
+        uint64_t cursor = base;
+        while (cursor < end) {
+            MEMORY_BASIC_INFORMATION mbi{};
+            if (!VirtualQuery(reinterpret_cast<void*>(static_cast<uintptr_t>(cursor)),
+                              &mbi, sizeof(mbi))) return false;
+            const uint64_t region_base =
+                static_cast<uint64_t>(reinterpret_cast<uintptr_t>(mbi.BaseAddress));
+            if (region_base > UINT64_MAX - static_cast<uint64_t>(mbi.RegionSize)) return false;
+            const uint64_t region_end = region_base + static_cast<uint64_t>(mbi.RegionSize);
+            const uint64_t piece_end = std::min(end, region_end);
+            if (piece_end <= cursor) return false;
+            if (mbi.State == MEM_COMMIT) return false;
+            if (mbi.State == MEM_FREE) {
+                const uint64_t cover_base =
+                    cursor & ~(kWinAllocationGranularity - 1);
+                if (piece_end > UINT64_MAX - (kWinAllocationGranularity - 1)) return false;
+                const uint64_t cover_end =
+                    align_up(piece_end, kWinAllocationGranularity);
+                if (cover_base < region_base || cover_end > region_end) return false;
+                void* got = apis.virtual_alloc2(
+                    GetCurrentProcess(),
+                    reinterpret_cast<void*>(static_cast<uintptr_t>(cover_base)),
+                    static_cast<SIZE_T>(cover_end - cover_base),
+                    MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS, nullptr, 0);
+                if (!got) return false;
+                remember_free_placeholder_locked(cover_base, cover_end - cover_base);
+            } else if (mbi.State != MEM_RESERVE) {
+                return false;
+            }
+            cursor = piece_end;
+        }
+
+        // Registry coverage is the authority for every reserved byte.  A plain host reservation
+        // that happens to be PAGE_NOACCESS is not enough: it may belong to the loader or frontend.
+        std::vector<PlaceholderSpan> covered;
+        std::vector<PlaceholderSpan> guest_cuts;
+        auto collect = [&](const std::vector<PlaceholderSpan>& spans, bool guest) {
+            for (const PlaceholderSpan& span : spans) {
+                const uint64_t cut_begin = std::max(base, span.base);
+                const uint64_t cut_end = std::min(end, span.base + span.size);
+                if (cut_begin >= cut_end) continue;
+                covered.push_back({cut_begin, cut_end - cut_begin});
+                if (guest) guest_cuts.push_back({cut_begin, cut_end - cut_begin});
+            }
+        };
+        collect(g_free_placeholders, false);
+        collect(g_guest_placeholders, true);
+        std::sort(covered.begin(), covered.end(),
+                  [](const PlaceholderSpan& a, const PlaceholderSpan& b) {
+                      return a.base < b.base;
+                  });
+        cursor = base;
+        for (const PlaceholderSpan& span : covered) {
+            if (span.base > cursor) break;
+            if (span.base + span.size > cursor)
+                cursor = std::min(end, span.base + span.size);
+            if (cursor == end) break;
+        }
+        if (cursor != end) return false;
+
+        // A fixed mapping consumes the guest reservations it overlaps.  Splitting a guest span at
+        // either edge preserves the unconsumed prefix/suffix under guest ownership.  Moving each cut
+        // to the free list lets remember_placeholder_locked coalesce it with the newly claimed holes.
+        for (const PlaceholderSpan& cut : guest_cuts) {
+            if (!take_guest_placeholder_locked(cut.base, cut.size, 0x1000)) return false;
+            remember_free_placeholder_locked(cut.base, cut.size);
+        }
+        for (const PlaceholderSpan& span : g_free_placeholders) {
+            if (base >= span.base && end <= span.base + span.size) {
+                MLOG("map_dmem FIXED repair: normalized fragmented placeholder range "
+                     "0x%llx +0x%llx\n",
+                     (unsigned long long)base, (unsigned long long)len);
+                return true;
+            }
+        }
+        return false;
+    }
+
     void* win_map_phys(uint64_t hint, uint64_t len, int hp, uint64_t phys, uint64_t align,
                        bool fixed) {
         // MAP_FIXED is replacement semantics on the guest. RAGE also uses it idempotently: GTA V
@@ -5161,6 +5278,10 @@ namespace {
         if (hint && !fixed) {
             if (void* p = map_section_view(0, len, hp, phys, align)) return p;
         }
+        // A fixed guest range may be split across several host placeholders and real free gaps.
+        // Normalize only ranges whose complete ownership the registries prove, then retry once.
+        if (fixed && normalize_fragmented_guest_placeholder_range(hint, len))
+            if (void* p = map_section_view(hint, len, hp, phys, align)) return p;
         // FIXED MAP_DIRECT over a placeholder too small for it (#2424). The guest maps a range,
         // unmaps it, then remaps the SAME base with a LARGER length -- GTA V (PPSA04263) does exactly
         // this at 0x1550880000: 0x40000, unmap, then 0x80000. The unmap leaves a free placeholder of
@@ -6381,6 +6502,11 @@ HLE(k_batch_map) {
             }
             case 1: {                               // UNMAP
                 ok = !start || win_unmap(start, len);
+                // A guest unmap may span several Windows placeholders with real MEM_FREE holes
+                // between them.  The holes are already unmapped from the guest's perspective;
+                // normalize the completely guest-owned topology and retry the transactional path.
+                if (!ok && normalize_fragmented_guest_placeholder_range(start, len))
+                    ok = win_unmap(start, len);
                 if (!ok) { win_err = GetLastError(); win_err_valid = true; }
                 if (ok && start) untrack(start, len);
                 break;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -5135,6 +5135,25 @@ namespace {
     }
     void* win_map_phys(uint64_t hint, uint64_t len, int hp, uint64_t phys, uint64_t align,
                        bool fixed) {
+        // MAP_FIXED is replacement semantics on the guest. RAGE also uses it idempotently: GTA V
+        // submits the exact same one-page BatchMap MAP_DIRECT twice without an intervening UNMAP.
+        // Linux mmap(MAP_FIXED) accepts that naturally, while MapViewOfFile3 cannot replace a live
+        // view and reports ERROR_INVALID_ADDRESS. Treat only a byte-for-byte identical existing
+        // direct view as an idempotent remap; a different physical offset or extent still follows
+        // the fail-visible replacement path below rather than silently preserving the wrong alias.
+        if (fixed && hint && len) {
+            std::lock_guard<std::mutex> lk(g_dview_mx);
+            for (const DmemView& view : g_dviews) {
+                if (view.guest_base != hint || view.guest_size != len || view.phys != phys)
+                    continue;
+                if (!protect_committed_regions(hint, len, hp)) return nullptr;
+                MLOG("map_dmem FIXED identical view already present va=0x%llx len=0x%llx "
+                     "phys=0x%llx\n",
+                     (unsigned long long)hint, (unsigned long long)len,
+                     (unsigned long long)phys);
+                return reinterpret_cast<void*>(static_cast<uintptr_t>(hint));
+            }
+        }
         if (void* p = map_section_view(hint, len, hp, phys, align)) return p;
         // Without SCE_KERNEL_MAP_FIXED, addrInOut is a search hint. If Windows cannot extend a
         // run of adjacent section views at that exact VA, relocate the mapping and return the
@@ -5180,6 +5199,10 @@ namespace {
                     const uint64_t span_end = s.base + s.size;
                     const uint64_t req_end = hint + len;
                     if (s.base > hint || hint >= span_end || req_end <= span_end) continue;
+                    // remember_free_placeholder_locked() mutates and can reallocate this vector.
+                    // Keep the values used by the diagnostic before invalidating the reference.
+                    const uint64_t span_base = s.base;
+                    const uint64_t span_size = s.size;
                     const uint64_t tail_base = span_end;
                     const uint64_t tail_size =
                         align_up(req_end - span_end, kWinAllocationGranularity);
@@ -5216,8 +5239,8 @@ namespace {
                     // grew.
                     MLOG("map_dmem FIXED repair: free placeholder 0x%llx grew 0x%llx -> 0x%llx to "
                          "cover request 0x%llx +0x%llx -- retrying view\n",
-                         (unsigned long long)s.base, (unsigned long long)s.size,
-                         (unsigned long long)(s.size + tail_size),
+                         (unsigned long long)span_base, (unsigned long long)span_size,
+                         (unsigned long long)(span_size + tail_size),
                          (unsigned long long)hint, (unsigned long long)len);
                     retry = true;
                     break;

--- a/prosper/src/host/image/exec_image_win.cpp
+++ b/prosper/src/host/image/exec_image_win.cpp
@@ -910,7 +910,10 @@ namespace {
     // frames, so the missing caller frame is immaterial. The recorded alignment makes the contract
     // regression-testable on Windows rather than relying on current compiler tolerance (#633).
     extern "C" {
-        volatile uint64_t prosper_veh_recover_call_rsp_mod16 = ~uint64_t{0};
+        // The handwritten thunk names this C symbol directly. GCC 15 otherwise gives the
+        // anonymous-namespace definition an internal assembler name and leaves it unresolved.
+        volatile uint64_t prosper_veh_recover_call_rsp_mod16
+            __asm__("prosper_veh_recover_call_rsp_mod16") = ~uint64_t{0};
         void prosper_veh_recover_thunk();
     }
     extern "C" __attribute__((noinline, noreturn)) void prosper_veh_recover_longjmp() {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -207,6 +207,10 @@ struct FrameResource {
     void* borrowed_compute_image = nullptr;
     void* borrowed_compute_device = nullptr;
     uint32_t borrowed_compute_image_layout = 0;
+    // A 2D-array compute result cannot be bound directly to the vertically-stacked 2D image expected
+    // by the cube lowering. Non-zero asks the backend to copy these source layers into consecutive
+    // vertical regions of a sampled image without visiting host/guest memory.
+    uint32_t borrowed_compute_vertical_stack_layers = 0;
     std::shared_ptr<void> borrowed_compute_image_lease;
     const uint32_t* buffer_words_data() const {
         return dwords_view && dwords_view_count
@@ -324,6 +328,10 @@ inline VkFormat backend_color_format(VkFormat format) {
         return format;
     if (format == VK_FORMAT_R8_UNORM)
         return VK_FORMAT_R8_UNORM;
+    if (format == VK_FORMAT_R8_UINT)
+        return VK_FORMAT_R8_UINT;
+    if (format == VK_FORMAT_R8G8B8A8_UINT)
+        return VK_FORMAT_R8G8B8A8_UINT;
     if (format == VK_FORMAT_R8G8_UNORM)
         return VK_FORMAT_R8G8_UNORM;
     if (format == VK_FORMAT_R32_UINT)
@@ -366,7 +374,7 @@ inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
     if (format == VK_FORMAT_R16G16B16A16_SFLOAT) return 8u;
     if (format == VK_FORMAT_R16G16_SFLOAT) return 4u;
     if (format == VK_FORMAT_R16_SFLOAT) return 2u;
-    if (format == VK_FORMAT_R8_UNORM) return 1u;
+    if (format == VK_FORMAT_R8_UNORM || format == VK_FORMAT_R8_UINT) return 1u;
     if (format == VK_FORMAT_R8G8_UNORM) return 2u;
     return 4u;
 }
@@ -374,6 +382,8 @@ inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
 inline prosper::gpu::SpirvImageNumericClass backend_image_numeric_class(VkFormat format) {
     using NumericClass = prosper::gpu::SpirvImageNumericClass;
     switch (backend_color_format(format)) {
+        case VK_FORMAT_R8_UINT:
+        case VK_FORMAT_R8G8B8A8_UINT:
         case VK_FORMAT_R32_UINT:
         case VK_FORMAT_R32G32B32A32_UINT:
             return NumericClass::Uint;
@@ -462,6 +472,9 @@ struct BackendDraw {
     // Stable semantic draw ID from DrawItem::draw_index. Diagnostics must not use this backend
     // vector's pass-local offset: target/compute splitting can make that offset differ per pass.
     uint64_t draw_index = UINT64_MAX;
+    // Global PM4 ordinal. Unlike draw_index this is comparable with interleaved compute operations
+    // and therefore identifies which retained attachment layer is newer than a compute image.
+    uint64_t command_order = 0;
     const prosper::gpu::ResolvedPipelineState* ps = nullptr;   // null -> triangle-list, write RGBA, no depth
     std::vector<FrameResource> R;                              // set-tagged resources (empty -> no descriptors)
     uint32_t vcount = 3;
@@ -1270,6 +1283,14 @@ inline const RenderVkCtx& render_vk_ctx() {
             add_native_storage_format(
                 prosper::gpu::DataFormat::Float10_11_11, 3,
                 VK_FORMAT_B10G11R11_UFLOAT_PACK32);
+            add_native_storage_format(
+                prosper::gpu::DataFormat::Uint32, 1, VK_FORMAT_R32_UINT);
+            add_native_storage_format(
+                prosper::gpu::DataFormat::Uint8, 1, VK_FORMAT_R8_UINT);
+            add_native_storage_format(
+                prosper::gpu::DataFormat::Uint8, 4, VK_FORMAT_R8G8B8A8_UINT);
+            add_native_storage_format(
+                prosper::gpu::DataFormat::Uint16, 1, VK_FORMAT_R16_UINT);
             // Present unification (#1270): advertise present adoption only when the instance is
             // surface-capable AND the device enabled VK_KHR_swapchain AND a present queue was resolved.
             shared.present_capable = r.present_surface_capable && r.present_swapchain_capable &&
@@ -2747,6 +2768,7 @@ struct PersistentDsImage {
     bool depth_valid = false;
     bool stencil_valid = false;
     uint64_t last_depth_write = 0;   // sampled-bridge recency (#1275)
+    uint64_t last_depth_command_order = 0;
 };
 
 inline uint64_t& persistent_ds_write_generation() {
@@ -2786,9 +2808,12 @@ constexpr bool stencil_clear_effective(bool clear_enabled, bool stencil_enabled,
 }
 
 inline void note_persistent_ds_depth_write(PersistentDsImage& image, bool use_depth,
-                                           bool depth_may_be_written) {
-    if (use_depth && depth_may_be_written)
+                                           bool depth_may_be_written,
+                                           uint64_t command_order = 0) {
+    if (use_depth && depth_may_be_written) {
         image.last_depth_write = ++persistent_ds_write_generation();
+        image.last_depth_command_order = command_order;
+    }
 }
 
 inline PersistentDsKey persistent_ds_key_for(const prosper::gpu::ResolvedPipelineState& ps,
@@ -3781,6 +3806,42 @@ inline bool read_persistent_ds_depth(PersistentDsImage& image, uint32_t width, u
     return true;
 }
 
+// Metadata-only selection for a retained depth cube. `overlay_version` is the newest selected
+// depth-write generation, so a CPU-decoded six-face stack can be cached against renderer authority
+// without consulting stale guest bytes. Any new face write advances that generation; an invalid or
+// missing face makes the selection incomplete and therefore ineligible for that cache.
+struct PersistentDsCubeSelection {
+    std::array<PersistentDsImage*, 6> faces{};
+    uint32_t present_mask = 0;
+    uint32_t known_mask = 0;
+    uint64_t overlay_version = 0;
+};
+
+inline PersistentDsCubeSelection select_persistent_ds_cube_depth(
+    uint64_t base, uint32_t width, uint32_t height) {
+    PersistentDsCubeSelection selected;
+    std::array<uint64_t, 6> recency{};
+    if (!base || !width || !height) return selected;
+    for (auto& [key, image] : persistent_ds_cache()) {
+        if (key.w != width || key.h != height ||
+            (key.dr != base && key.dw != base) || key.slice >= 6u)
+            continue;
+        selected.known_mask |= 1u << key.slice;
+        if (!image.depth_valid || !image.layout_initialized || !image.image)
+            continue;
+        if (!selected.faces[key.slice] || image.last_depth_write > recency[key.slice]) {
+            selected.faces[key.slice] = &image;
+            recency[key.slice] = image.last_depth_write;
+            selected.present_mask |= 1u << key.slice;
+        }
+    }
+    for (uint32_t slice = 0; slice < 6u; ++slice)
+        if (selected.faces[slice])
+            selected.overlay_version = std::max(
+                selected.overlay_version, selected.faces[slice]->last_depth_write);
+    return selected;
+}
+
 // All six faces of a depth cube whose faces are retained separately, or false when any is missing.
 // `slices_found` reports how many were present, so a partial cube is a stated fact rather than a
 // silent half-result.
@@ -3791,34 +3852,65 @@ inline bool read_persistent_ds_cube_depth(uint64_t base, uint32_t width, uint32_
                                           uint32_t* known_mask = nullptr) {
     error.clear();
     slices_found = 0;
-    if (present_mask) *present_mask = 0;
-    // Slices the cache holds an ENTRY for, whether or not its depth is currently valid. The
-    // difference between the two masks separates "prosper never rendered this face" from "it was
-    // rendered and then invalidated", which are different defects with different fixes.
-    if (known_mask) {
-        *known_mask = 0;
-        for (const auto& [key, image] : persistent_ds_cache()) {
-            (void)image;
-            if (key.w != width || key.h != height) continue;
-            if (key.dr != base && key.dw != base) continue;
-            if (key.slice < 6u) *known_mask |= 1u << key.slice;
-        }
-    }
+    const PersistentDsCubeSelection selected =
+        select_persistent_ds_cube_depth(base, width, height);
+    if (present_mask) *present_mask = selected.present_mask;
+    if (known_mask) *known_mask = selected.known_mask;
     for (uint32_t slice = 0; slice < 6u; ++slice) {
-        PersistentDsImage* found = nullptr;
-        for (auto& [key, image] : persistent_ds_cache()) {
-            if (key.slice != slice || key.w != width || key.h != height) continue;
-            if (key.dr != base && key.dw != base) continue;
-            if (!image.depth_valid || !image.layout_initialized || !image.image) continue;
-            found = &image;
-            break;
-        }
+        PersistentDsImage* found = selected.faces[slice];
         if (!found) continue;
         if (!read_persistent_ds_depth(*found, width, height, faces[slice], error)) return false;
-        if (present_mask) *present_mask |= 1u << slice;
         ++slices_found;
     }
     return slices_found == 6u;
+}
+
+// Retained depth faces produced after a compute image. GTA V builds each shadow cube by copying
+// five unchanged R16 layers in compute and then rendering the sixth face into a D32 attachment.
+// Comparing the global PM4 ordinals makes that split explicit: only the renderer-newer face may
+// replace the exact compute result. `last_depth_write` breaks ties between re-keyed cache entries;
+// it is deliberately not compared with a command ordinal because those counters have different
+// domains.
+inline PersistentDsCubeSelection select_persistent_ds_cube_depth_after(
+    uint64_t base, uint32_t width, uint32_t height, uint64_t producer_command_order) {
+    PersistentDsCubeSelection selected;
+    std::array<uint64_t, 6> recency{};
+    if (!base || !producer_command_order) return selected;
+    for (auto& [key, image] : persistent_ds_cache()) {
+        if (key.w != width || key.h != height ||
+            (key.dr != base && key.dw != base) || key.slice >= 6u)
+            continue;
+        selected.known_mask |= 1u << key.slice;
+        if (!image.depth_valid || !image.layout_initialized || !image.image ||
+            image.last_depth_command_order <= producer_command_order)
+            continue;
+        if (!selected.faces[key.slice] || image.last_depth_write > recency[key.slice]) {
+            selected.faces[key.slice] = &image;
+            recency[key.slice] = image.last_depth_write;
+            selected.present_mask |= 1u << key.slice;
+            selected.overlay_version = std::max(
+                selected.overlay_version, image.last_depth_write);
+        }
+    }
+    return selected;
+}
+
+inline bool read_persistent_ds_cube_depth_after(
+    uint64_t base, uint32_t width, uint32_t height, uint64_t producer_command_order,
+    std::array<std::vector<float>, 6>& faces, uint32_t& present_mask,
+    uint32_t& known_mask, std::string& error) {
+    error.clear();
+    const PersistentDsCubeSelection selected = select_persistent_ds_cube_depth_after(
+        base, width, height, producer_command_order);
+    present_mask = selected.present_mask;
+    known_mask = selected.known_mask;
+    for (uint32_t slice = 0; slice < 6u; ++slice) {
+        if (!(present_mask & (1u << slice))) continue;
+        if (!read_persistent_ds_depth(*selected.faces[slice], width, height,
+                                      faces[slice], error))
+            return false;
+    }
+    return true;
 }
 
 inline bool snapshot_persistent_ds_images(std::vector<prosper::gpu::GpuCaptureDsSeed>& seeds,
@@ -4376,15 +4468,19 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     bool depth_was_valid = false, stencil_was_valid = false;
     bool depth_used_meaningfully = false;
     bool depth_may_be_written = false;
+    uint64_t depth_write_command_order = 0;
     bool stencil_may_be_written = false;
     for (const auto& d : draws) {
         if (!d.ps) continue;
         depth_used_meaningfully |= effective_depth_clear(d.ps) || d.ps->depth_write_enable ||
             (d.ps->depth_test_enable && d.ps->depth_compare_op != VK_COMPARE_OP_ALWAYS &&
                                         d.ps->depth_compare_op != VK_COMPARE_OP_NEVER);
-        depth_may_be_written |= persistent_ds_pass_may_write_depth(
+        const bool draw_may_write_depth = persistent_ds_pass_may_write_depth(
             d.ps->depth_clear_enable, d.ps->depth_test_enable, d.ps->depth_write_enable,
             d.ps->depth_compare_op);
+        depth_may_be_written |= draw_may_write_depth;
+        if (draw_may_write_depth)
+            depth_write_command_order = std::max(depth_write_command_order, d.command_order);
         stencil_may_be_written |= stencil_clear_effective(
             d.ps->stencil_clear_enable, d.ps->stencil_enable,
             d.ps->stencil_write_mask[0], d.ps->stencil_write_mask[1]);
@@ -5038,7 +5134,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // rather than merely slows (#2253). Mirrors SharedBufferUpload::arena on the storage path.
         VkDeviceSize ioffset = 0;
         bool iarena = false;
+        VkViewport viewport{};
         VkRect2D scissor{};
+        float line_width = 1.0f;
+        float depth_bias_constant = 0.0f;
+        float depth_bias_clamp = 0.0f;
+        float depth_bias_slope = 0.0f;
+        VkStencilOpState stencil_front{};
+        VkStencilOpState stencil_back{};
         uint32_t n_sets = 1, vcount = 3, icount = 0, instance_count = 1;
         int32_t vertex_offset = 0;
         bool use_desc = false, ok = false, pipeline_cached = false;
@@ -5097,6 +5200,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         bool uniform_clear = false;
         VkClearColorValue uniform_color{};
         bool borrowed_target = false;
+        // Color-attachment feedback cannot borrow the attachment image itself. Snapshot its
+        // pre-pass contents into this upload's distinct sampled image with a queue-ordered GPU copy.
+        bool feedback_snapshot = false;
+        VkImage feedback_source = VK_NULL_HANDLE;
+        VkImageLayout feedback_source_layout = VK_IMAGE_LAYOUT_UNDEFINED;
         // Independent one-level renderer targets copied into this upload's mip levels. Sources
         // retain their persistent-cache layout after the copy; a zero image is generated from the
         // preceding destination level.
@@ -5104,6 +5212,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         std::array<VkImage, 16> target_mip_images{};
         std::array<VkImageLayout, 16> target_mip_layouts{};
         bool borrowed_compute = false;
+        bool stacked_compute = false;
+        VkImage stacked_compute_source = VK_NULL_HANDLE;
+        uint32_t stacked_compute_layers = 0;
         VkImageLayout borrowed_compute_layout = VK_IMAGE_LAYOUT_UNDEFINED;
         std::shared_ptr<void> borrowed_compute_lease;
         // Sampled depth bridge (#1275): image borrowed from the persistent DS cache. The view uses
@@ -5302,15 +5413,24 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         return bits;
     };
     std::vector<DV> dv(draws.size());
-    std::vector<std::vector<FrameResource>> effective_resources(draws.size());
+    // Most draws use the frontend's immutable resource vector verbatim. Copying every FrameResource
+    // here copied owned buffer payloads, callbacks and shared owners for thousands of draws before
+    // the backend could even consult its upload caches. Only a shader that needs prosper's synthetic
+    // GDS binding requires an augmented vector; all ordinary draws borrow the caller-owned vector for
+    // this synchronous backend call.
+    std::vector<std::vector<FrameResource>> augmented_resources(draws.size());
+    std::vector<const std::vector<FrameResource>*> effective_resources(draws.size());
     for (size_t i = 0; i < draws.size(); ++i) {
-        effective_resources[i] = draws[i].R;
         if (fragment_uses_internal_gds_memoized(draws[i].fs_identity, draws[i].fs_words())) {
+            augmented_resources[i] = draws[i].R;
             FrameResource gds;
             gds.set = 1;
             gds.binding = 0;
             gds.is_internal_gds = true;
-            effective_resources[i].push_back(std::move(gds));
+            augmented_resources[i].push_back(std::move(gds));
+            effective_resources[i] = &augmented_resources[i];
+        } else {
+            effective_resources[i] = &draws[i].R;
         }
     }
     std::vector<SharedTextureUpload> texture_uploads;
@@ -5407,7 +5527,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     uint64_t storage_buffers = 0;
     uint64_t sampled_images = 0;
     uint64_t storage_images = 0;
-    for (const auto& resources : effective_resources) {
+    for (const auto* resource_ptr : effective_resources) {
+        const auto& resources = *resource_ptr;
         if (resources.empty()) continue;
         uint32_t set_count = 1;
         for (const FrameResource& resource : resources) {
@@ -5822,11 +5943,25 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         VkViewport vp{0, 0, (float)W, (float)H, 0, 1}; VkRect2D sc{{0, 0}, {W, H}};
         if (ps && ps->has_viewport)
             vp = {ps->viewport_x, ps->viewport_y, ps->viewport_w, ps->viewport_h, ps->min_depth, ps->max_depth};
+        v.viewport = vp;
         VkPipelineViewportStateCreateInfo vpst{VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO};
         vpst.viewportCount = 1; vpst.pViewports = &vp; vpst.scissorCount = 1; vpst.pScissors = &sc;
-        const VkDynamicState dynamic_states[] = {VK_DYNAMIC_STATE_SCISSOR};
+        // Viewports are draw state, not a shader/render-pass compatibility axis. Baking the camera's
+        // sub-pixel viewport into every pipeline key made GTA V create 20-30 nominally new graphics
+        // pipelines on every 1440p gameplay frame. Vulkan 1.0 makes viewport dynamic in core; record
+        // the resolved per-draw value beside the already-dynamic scissor.
+        const VkDynamicState dynamic_states[] = {
+            VK_DYNAMIC_STATE_VIEWPORT,
+            VK_DYNAMIC_STATE_SCISSOR,
+            VK_DYNAMIC_STATE_LINE_WIDTH,
+            VK_DYNAMIC_STATE_DEPTH_BIAS,
+            VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK,
+            VK_DYNAMIC_STATE_STENCIL_WRITE_MASK,
+            VK_DYNAMIC_STATE_STENCIL_REFERENCE,
+        };
         VkPipelineDynamicStateCreateInfo dynamic_state{VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO};
-        dynamic_state.dynamicStateCount = 1; dynamic_state.pDynamicStates = dynamic_states;
+        dynamic_state.dynamicStateCount = static_cast<uint32_t>(std::size(dynamic_states));
+        dynamic_state.pDynamicStates = dynamic_states;
         VkPipelineRasterizationStateCreateInfo rs{VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO};
         rs.polygonMode = VK_POLYGON_MODE_FILL; rs.cullMode = VK_CULL_MODE_NONE; rs.frontFace = VK_FRONT_FACE_COUNTER_CLOCKWISE; rs.lineWidth = 1.0f;
         // Honor the guest's PA_SU_SC_MODE_CNTL cull/front-face/polygon mode (#456). Resolve encodes these
@@ -5850,6 +5985,10 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             rs.depthBiasSlopeFactor    = ps->depth_bias_slope;
             rs.depthBiasClamp = render_vk_ctx().depth_bias_clamp_enabled ? ps->depth_bias_clamp : 0.0f;
         }
+        v.line_width = rs.lineWidth;
+        v.depth_bias_constant = rs.depthBiasConstantFactor;
+        v.depth_bias_clamp = rs.depthBiasClamp;
+        v.depth_bias_slope = rs.depthBiasSlopeFactor;
         VkPipelineMultisampleStateCreateInfo ms{VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO};
         ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
         const auto fixed_viewport_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
@@ -5982,12 +6121,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         ps->stencil_fail_op[1], ps->stencil_pass_op[1], ps->stencil_depth_fail_op[1],
                         dss.front.reference, dss.back.reference, (unsigned)ps->cull_mode, (int)ps->depth_test_enable);
         }
+        v.stencil_front = dss.front;
+        v.stencil_back = dss.back;
         // Descriptor resources for this draw (two-set: VS=set0, PS=set1 — same layout as the single path).
         const auto fixed_dss_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) res_fixed_depth_stencil_ms += setup_elapsed_ms(fixed_blend_ready, fixed_dss_ready);
         const auto setup_fixed_ready = timing_enabled ? TimingClock::now() : TimingClock::time_point{};
         if (timing_enabled) setup_fixed_ms += setup_elapsed_ms(setup_shaders_ready, setup_fixed_ready);
-        const auto& R = effective_resources[di];
+        const auto& R = *effective_resources[di];
         v.use_desc = !R.empty();
         for (auto& r : R) v.n_sets = std::max(v.n_sets, r.set + 1);
         std::vector<VkDescriptorSetLayout> dsls(v.n_sets, VK_NULL_HANDLE);
@@ -6364,8 +6505,16 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             r.borrowed_compute_image_layout !=
                                 static_cast<uint32_t>(VK_IMAGE_LAYOUT_UNDEFINED) &&
                             r.borrowed_compute_image_lease) {
-                            upload.image = static_cast<VkImage>(r.borrowed_compute_image);
-                            upload.borrowed_compute = true;
+                            if (r.borrowed_compute_vertical_stack_layers) {
+                                upload.stacked_compute = true;
+                                upload.stacked_compute_source =
+                                    static_cast<VkImage>(r.borrowed_compute_image);
+                                upload.stacked_compute_layers =
+                                    r.borrowed_compute_vertical_stack_layers;
+                            } else {
+                                upload.image = static_cast<VkImage>(r.borrowed_compute_image);
+                                upload.borrowed_compute = true;
+                            }
                             upload.borrowed_compute_layout = static_cast<VkImageLayout>(
                                 r.borrowed_compute_image_layout);
                             upload.borrowed_compute_lease = r.borrowed_compute_image_lease;
@@ -6378,15 +6527,34 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         }
                         if (!upload.borrowed_compute && !r.is_storage_image &&
                             !upload.assembled_target_mips && persistent_color_targets_enabled &&
-                            !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
                             if (auto* target = find_persistent_color_target(
                                     r.persistent_render_target_id, r.tw, r.th,
                                     backend_color_format(r.texture_format))) {
                                 target->last_use = color_target_generation;
-                                upload.image = target->image;
-                                upload.image_bytes = target->bytes;
-                                upload.borrowed_target = true;
+                                if (target_feedback) {
+                                    upload.feedback_snapshot = true;
+                                    upload.feedback_source = target->image;
+                                    upload.feedback_source_layout = target->layout;
+                                    // Earlier barriers in this command buffer move a retained
+                                    // attachment that will LOAD to COLOR_ATTACHMENT_OPTIMAL. Record
+                                    // the layout the copy actually sees, not the cache's pre-call
+                                    // resting layout.
+                                    if ((target == cached_color && load_cached_color) ||
+                                        (target == cached_color1 && load_cached_color1)) {
+                                        upload.feedback_source_layout =
+                                            VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+                                    } else {
+                                        for (uint32_t slot = 2; slot < color_count; ++slot)
+                                            if (target == cached_extra[slot] && load_extra[slot])
+                                                upload.feedback_source_layout =
+                                                    VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+                                    }
+                                } else {
+                                    upload.image = target->image;
+                                    upload.image_bytes = target->bytes;
+                                    upload.borrowed_target = true;
+                                }
                                 ++color_target_stats.sampled_hits;
                             }
                         }
@@ -6412,8 +6580,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                     sampled_ds.aspect == VK_IMAGE_ASPECT_STENCIL_BIT;
                             }
                         }
-                        upload.persistent_id =
-                            r.is_storage_image || upload.borrowed_ds ? 0 : r.persistent_texture_id;
+                        upload.persistent_id = r.is_storage_image || upload.borrowed_ds ||
+                                upload.feedback_snapshot
+                            ? 0 : r.persistent_texture_id;
                         upload.persistent_version = r.persistent_texture_version;
                         const PersistentTextureKey persistent_key{
                             r.persistent_texture_id, r.tw, r.th, r.td, r.img_dim,
@@ -6525,7 +6694,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 upload.uniform_clear = true;
                                 std::copy(r.uniform_color.begin(), r.uniform_color.end(),
                                           upload.uniform_color.float32);
-                            } else if (!upload.assembled_target_mips) {
+                            } else if (!upload.feedback_snapshot &&
+                                       !upload.assembled_target_mips && !upload.stacked_compute) {
                                 const VkDeviceSize tbytes =
                                     static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
                                     r.sample_count *
@@ -6993,7 +7163,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 memcpy(&word, &value, sizeof word);
                 append(word);
             };
-            append(10); // key schema version (descriptor arity, #2471; MRT formats, #1390)
+            append(12); // dynamic viewport/bias/stencil values; descriptor arity #2471; MRT formats #1390
             append(W); append(H); append(color_count);
             for (uint32_t slot = 0; slot < color_count; ++slot)
                 append(static_cast<uint32_t>(color_formats[slot]));
@@ -7053,11 +7223,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 }
             }
             append(ia.topology); append(ia.primitiveRestartEnable);
-            append_float(vp.x); append_float(vp.y); append_float(vp.width); append_float(vp.height);
-            append_float(vp.minDepth); append_float(vp.maxDepth);
-            append(rs.polygonMode); append(rs.cullMode); append(rs.frontFace); append_float(rs.lineWidth);
-            append(rs.depthBiasEnable); append_float(rs.depthBiasConstantFactor);
-            append_float(rs.depthBiasSlopeFactor); append_float(rs.depthBiasClamp);
+            append(rs.polygonMode); append(rs.cullMode); append(rs.frontFace);
+            append(rs.depthBiasEnable);
             append(cb.logicOpEnable); append(cb.logicOp);
             for (uint32_t attachment = 0; attachment < color_count; ++attachment) {
                 append(cba[attachment].blendEnable); append(cba[attachment].srcColorBlendFactor);
@@ -7071,8 +7238,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 append(dss.depthBoundsTestEnable); append(dss.stencilTestEnable);
                 auto append_stencil = [&](const VkStencilOpState& stencil) {
                     append(stencil.failOp); append(stencil.passOp); append(stencil.depthFailOp);
-                    append(stencil.compareOp); append(stencil.compareMask); append(stencil.writeMask);
-                    append(stencil.reference);
+                    append(stencil.compareOp);
                 };
                 append_stencil(dss.front); append_stencil(dss.back);
                 append_float(dss.minDepthBounds); append_float(dss.maxDepthBounds);
@@ -7193,7 +7359,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     texture_stats.persistent_hits = persistent_texture_hits;
     texture_stats.persistent_misses = persistent_texture_misses;
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips)
+        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips &&
+            !upload.feedback_snapshot)
             continue;
         ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
@@ -7470,7 +7637,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Upload each distinct texture once. Draw descriptors may use separate views/samplers over the
     // same image, preserving per-binding swizzle and sampler state without duplicating pixel storage.
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips)
+        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips &&
+            !upload.stacked_compute && !upload.feedback_snapshot)
             continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = upload.persistent_refresh
@@ -7487,7 +7655,97 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 ? (VK_PIPELINE_STAGE_VERTEX_SHADER_BIT | VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT)
                 : VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
             VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &b0);
-        if (upload.uniform_clear) {
+        if (upload.feedback_snapshot) {
+            VkImageMemoryBarrier source_to_copy{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            source_to_copy.oldLayout = upload.feedback_source_layout;
+            source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            source_to_copy.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                           VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                           VK_ACCESS_SHADER_READ_BIT |
+                                           VK_ACCESS_TRANSFER_READ_BIT |
+                                           VK_ACCESS_TRANSFER_WRITE_BIT;
+            source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            source_to_copy.image = upload.feedback_source;
+            source_to_copy.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            vkCmdPipelineBarrier(
+                cmd,
+                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                    VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                0, nullptr, 0, nullptr, 1, &source_to_copy);
+            VkImageCopy copy{};
+            copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+            copy.extent = {upload.key.width, upload.key.height, 1};
+            vkCmdCopyImage(
+                cmd, upload.feedback_source, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+            VkImageMemoryBarrier source_restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            source_restore.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            source_restore.newLayout = upload.feedback_source_layout;
+            source_restore.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            source_restore.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                           VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                           VK_ACCESS_SHADER_READ_BIT;
+            source_restore.srcQueueFamilyIndex = source_restore.dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            source_restore.image = upload.feedback_source;
+            source_restore.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+            vkCmdPipelineBarrier(
+                cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                    VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                    VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &source_restore);
+        } else if (upload.stacked_compute) {
+            VkImageMemoryBarrier source_to_copy{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            source_to_copy.oldLayout = upload.borrowed_compute_layout;
+            source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            source_to_copy.srcAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT |
+                                           VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            source_to_copy.image = upload.stacked_compute_source;
+            source_to_copy.subresourceRange = {
+                VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, upload.stacked_compute_layers};
+            vkCmdPipelineBarrier(
+                cmd, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &source_to_copy);
+            const uint32_t face_height = upload.stacked_compute_layers
+                ? upload.key.height / upload.stacked_compute_layers : 0u;
+            std::vector<VkImageCopy> regions(upload.stacked_compute_layers);
+            for (uint32_t layer = 0; layer < upload.stacked_compute_layers; ++layer) {
+                VkImageCopy& copy = regions[layer];
+                copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, layer, 1};
+                copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                copy.dstOffset = {0, static_cast<int32_t>(layer * face_height), 0};
+                copy.extent = {upload.key.width, face_height, 1};
+            }
+            vkCmdCopyImage(
+                cmd, upload.stacked_compute_source, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                static_cast<uint32_t>(regions.size()), regions.data());
+            VkImageMemoryBarrier source_restore{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+            source_restore.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+            source_restore.newLayout = upload.borrowed_compute_layout;
+            source_restore.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+            source_restore.dstAccessMask = VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT |
+                                           VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT;
+            source_restore.srcQueueFamilyIndex = source_restore.dstQueueFamilyIndex =
+                VK_QUEUE_FAMILY_IGNORED;
+            source_restore.image = upload.stacked_compute_source;
+            source_restore.subresourceRange = {
+                VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, upload.stacked_compute_layers};
+            vkCmdPipelineBarrier(
+                cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT | VK_PIPELINE_STAGE_TRANSFER_BIT,
+                0, 0, nullptr, 0, nullptr, 1, &source_restore);
+        } else if (upload.uniform_clear) {
             const VkImageSubresourceRange range{
                 VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
                 0, upload.key.sample_count};
@@ -7572,6 +7830,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // Each source level transitions DST->SRC before feeding the next; the final barrier below
         // then flips the whole chain to shader-read. RGBA8 linear-blit support is mandatory Vulkan.
         for (uint32_t l = 1; !upload.uniform_clear && !upload.assembled_target_mips &&
+             !upload.stacked_compute && !upload.feedback_snapshot &&
              l < upload.key.mip_levels; l++) {
             VkImageMemoryBarrier bs{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             bs.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
@@ -7599,6 +7858,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                            VK_FILTER_LINEAR);
         }
         if (!upload.uniform_clear && !upload.assembled_target_mips &&
+            !upload.stacked_compute && !upload.feedback_snapshot &&
             upload.key.mip_levels > 1) {
             // Levels 0..N-2 sit in TRANSFER_SRC after feeding the cascade; return them to
             // TRANSFER_DST so the single final-layout barrier below covers the whole chain.
@@ -7879,7 +8139,23 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             ds_ctx.occlusion_precise ? VK_QUERY_CONTROL_PRECISE_BIT : 0);
         }
         vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.pipe);
+        vkCmdSetViewport(cmd, 0, 1, &v.viewport);
         vkCmdSetScissor(cmd, 0, 1, &v.scissor);
+        vkCmdSetLineWidth(cmd, v.line_width);
+        vkCmdSetDepthBias(cmd, v.depth_bias_constant, v.depth_bias_clamp,
+                          v.depth_bias_slope);
+        vkCmdSetStencilCompareMask(cmd, VK_STENCIL_FACE_FRONT_BIT,
+                                   v.stencil_front.compareMask);
+        vkCmdSetStencilCompareMask(cmd, VK_STENCIL_FACE_BACK_BIT,
+                                   v.stencil_back.compareMask);
+        vkCmdSetStencilWriteMask(cmd, VK_STENCIL_FACE_FRONT_BIT,
+                                 v.stencil_front.writeMask);
+        vkCmdSetStencilWriteMask(cmd, VK_STENCIL_FACE_BACK_BIT,
+                                 v.stencil_back.writeMask);
+        vkCmdSetStencilReference(cmd, VK_STENCIL_FACE_FRONT_BIT,
+                                 v.stencil_front.reference);
+        vkCmdSetStencilReference(cmd, VK_STENCIL_FACE_BACK_BIT,
+                                 v.stencil_back.reference);
         if (v.use_desc) vkCmdBindDescriptorSets(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, v.layout, 0, v.n_sets, v.dsets.data(), 0, nullptr);
         const bool geom_here = geom_active && di == geom_item;
         if (geom_here) {
@@ -8288,7 +8564,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         // Sampled depth bridge (#1275): recency for find_persistent_ds_sampled — two valid
         // entries can share a plane address (a surface re-keyed D32 -> D32S8 keeps its old
         // entry), and the most recently written one is the live truth.
-        note_persistent_ds_depth_write(*cached_ds, use_depth, depth_may_be_written);
+        note_persistent_ds_depth_write(*cached_ds, use_depth, depth_may_be_written,
+                                       depth_write_command_order);
     }
     if (cached_color) {
         active_submission.add_failure_cleanup([cached_color]() {

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -469,6 +469,9 @@ struct BackendDraw {
     std::vector<uint32_t> vs, gs, fs;
     prosper::gpu::SharedShaderWords vs_shared, fs_shared;
     uint64_t vs_identity = 0, fs_identity = 0;
+    // Live-title authority for GTA V's reviewed WaveAny-only fragment route. Tests, replay and all
+    // other titles leave this false, preserving the strict exact-wave admission contract.
+    bool allow_native_fragment_vote_width = false;
     // Stable semantic draw ID from DrawItem::draw_index. Diagnostics must not use this backend
     // vector's pass-local offset: target/compute splitting can make that offset differ per pass.
     uint64_t draw_index = UINT64_MAX;
@@ -5709,7 +5712,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             available_fragment_subgroup_features |= prosper::gpu::kFragmentSubgroupBallot;
         const bool uses_internal_gds =
             fragment_uses_internal_gds_memoized(bd.fs_identity, bd_fs);
-        if (required_fragment_subgroup_size &&
+        bool fragment_subgroup_skip = required_fragment_subgroup_size &&
             (!ctx.subgroup_size_control ||
              required_fragment_subgroup_size < ctx.min_subgroup_size ||
              required_fragment_subgroup_size > ctx.max_subgroup_size ||
@@ -5718,7 +5721,39 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
              !prosper::gpu::fragment_subgroup_features_supported(
                  required_fragment_subgroup_features,
                  available_fragment_subgroup_features) ||
-             (uses_internal_gds && !ctx.fragment_stores_atomics))) {
+             (uses_internal_gds && !ctx.fragment_stores_atomics));
+        uint32_t subgroup_reasons = UINT32_MAX;
+        if (fragment_subgroup_skip && bd.allow_native_fragment_vote_width &&
+            (ctx.subgroup_stages & VK_SHADER_STAGE_FRAGMENT_BIT) &&
+            prosper::gpu::fragment_subgroup_features_supported(
+                required_fragment_subgroup_features,
+                available_fragment_subgroup_features) &&
+            !(uses_internal_gds && !ctx.fragment_stores_atomics)) {
+            subgroup_reasons =
+                prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs);
+            // This is deliberately title-scoped and narrower than PROSPER_WAVE64_APPROX: only a
+            // WaveAny with no lane, ballot, shuffle or scalar-reduction qualifier is admitted.
+            // The source branch's reviewed bank route preserves both world and characters under
+            // this exact classifier; every unreviewed title remains on the strict master path.
+            if (subgroup_reasons == prosper::gpu::kFragmentWaveReasonWaveAny) {
+                const uint64_t shader_key = bd.fs_identity
+                    ? bd.fs_identity : hash_buffer_words(bd_fs.data(), bd_fs.size());
+                static std::mutex native_width_log_mutex;
+                static std::unordered_set<uint64_t> native_width_logged;
+                std::lock_guard<std::mutex> lock(native_width_log_mutex);
+                if (native_width_logged.insert(shader_key).second)
+                    std::fprintf(stderr,
+                                 "[render] GTA V native-width fragment vote: subgroup %u -> %u "
+                                 "(why=0x%x)\n",
+                                 required_fragment_subgroup_size, ctx.max_subgroup_size,
+                                 subgroup_reasons);
+                // Omitting the required-size pNext below selects the device's native fragment
+                // subgroup. On the current NVIDIA host that is 32 lanes.
+                required_fragment_subgroup_size = 0;
+                fragment_subgroup_skip = false;
+            }
+        }
+        if (fragment_subgroup_skip) {
             const uint64_t shader_key = bd.fs_identity
                 ? bd.fs_identity : hash_buffer_words(bd_fs.data(), bd_fs.size());
             static std::mutex log_mutex;
@@ -5734,8 +5769,9 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 // census that decides whether such a lowering is worth writing cannot be taken.
                 //
                 // Inside the dedupe guard, so it costs once per distinct shader, not per draw.
-                const uint32_t why =
-                    prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs);
+                const uint32_t why = subgroup_reasons != UINT32_MAX
+                    ? subgroup_reasons
+                    : prosper::gpu::fragment_spirv_required_subgroup_reasons(bd_fs);
                 char why_text[160];
                 if (why == UINT32_MAX) {
                     // Absent, not none. A module built before #2147 carries no marker, and printing
@@ -5752,6 +5788,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         {prosper::gpu::kFragmentWaveReasonReadLane64, " readlane64"},
                         {prosper::gpu::kFragmentWaveReasonShuffle,    " shuffle"},
                         {prosper::gpu::kFragmentWaveReasonWaveBallot, " wave-ballot"},
+                        {prosper::gpu::kFragmentWaveReasonScalarReduce, " scalar-reduce"},
                     };
                     for (const auto& entry : kReasonNames)
                         if ((why & entry.bit) && n > 0 && n < static_cast<int>(sizeof why_text))

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -169,6 +169,12 @@ struct FrameResource {
     // T# DST_SEL channel swizzle (SQ_SEL per channel: 0=0,1=1,4=R,5=G,6=B,7=A). Default = identity
     // (R,G,B,A) == a no-op VkComponentMapping, so tests that build FrameResources directly are unchanged.
     uint32_t swizzle[4] = {4, 5, 6, 7};
+    // Original guest CB_COLOR format when these pixels came from a renderer-owned target. The
+    // backend stores color attachments in `backend_color_format()`'s canonical component order;
+    // a later T# still describes the guest allocation's component order. Keeping the producer
+    // format lets the sampled view compose those two mappings instead of applying the storage-order
+    // swap a second time. Undefined means ordinary guest texture / no such canonicalization.
+    VkFormat render_target_guest_format = VK_FORMAT_UNDEFINED;
     // Non-zero only when the frontend has revalidated the complete guest source backing and can
     // prove these decoded pixels are the same content version as a prior callback. The Vulkan
     // backend may retain an uploaded image under this ID; zero remains callback-local/transient.
@@ -311,7 +317,9 @@ struct BackendMrtOutputs {
 };
 
 inline VkFormat backend_color_format(VkFormat format) {
-    if (format == VK_FORMAT_R16G16B16A16_SFLOAT ||
+    if (format == VK_FORMAT_R16_SFLOAT ||
+        format == VK_FORMAT_R16G16_SFLOAT ||
+        format == VK_FORMAT_R16G16B16A16_SFLOAT ||
         format == VK_FORMAT_B10G11R11_UFLOAT_PACK32)
         return format;
     if (format == VK_FORMAT_R8_UNORM)
@@ -329,11 +337,35 @@ inline VkFormat backend_color_format(VkFormat format) {
     return VK_FORMAT_R8G8B8A8_UNORM;
 }
 
+inline std::array<uint32_t, 4> backend_sampled_component_swizzle(
+    const FrameResource& resource) {
+    std::array<uint32_t, 4> result{
+        resource.swizzle[0], resource.swizzle[1],
+        resource.swizzle[2], resource.swizzle[3]};
+    // CB_COLOR ALT stores COLOR_8_8_8_8 as BGRA, while prosper deliberately materializes that
+    // attachment as canonical RGBA8. SQ_IMG_RSRC DST_SEL is expressed against the guest's format
+    // components, so translate R<->B selectors into the canonical host image's component space.
+    // Constants, G/A, ordinary textures, and targets whose storage order was already RGBA remain
+    // unchanged. This is composition, not suppression: semantic permutations still survive.
+    if ((resource.render_target_guest_format == VK_FORMAT_B8G8R8A8_UNORM ||
+         resource.render_target_guest_format == VK_FORMAT_B8G8R8A8_SRGB) &&
+        backend_color_format(resource.render_target_guest_format) ==
+            VK_FORMAT_R8G8B8A8_UNORM) {
+        for (uint32_t& selector : result) {
+            if (selector == 4u) selector = 6u;
+            else if (selector == 6u) selector = 4u;
+        }
+    }
+    return result;
+}
+
 inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
     format = backend_color_format(format);
     if (format == VK_FORMAT_R32G32B32A32_UINT ||
         format == VK_FORMAT_R32G32B32A32_SFLOAT) return 16u;
     if (format == VK_FORMAT_R16G16B16A16_SFLOAT) return 8u;
+    if (format == VK_FORMAT_R16G16_SFLOAT) return 4u;
+    if (format == VK_FORMAT_R16_SFLOAT) return 2u;
     if (format == VK_FORMAT_R8_UNORM) return 1u;
     if (format == VK_FORMAT_R8G8_UNORM) return 2u;
     return 4u;
@@ -348,6 +380,8 @@ inline prosper::gpu::SpirvImageNumericClass backend_image_numeric_class(VkFormat
         case VK_FORMAT_R8_UNORM:
         case VK_FORMAT_R8G8_UNORM:
         case VK_FORMAT_R8G8B8A8_UNORM:
+        case VK_FORMAT_R16_SFLOAT:
+        case VK_FORMAT_R16G16_SFLOAT:
         case VK_FORMAT_R16G16B16A16_SFLOAT:
         case VK_FORMAT_R32G32B32A32_SFLOAT:
         case VK_FORMAT_R32_SFLOAT:
@@ -6571,8 +6605,11 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         }
                     };
                     // Vulkan component mappings do not apply to storage-image accesses.
-                    if (!r.is_storage_image && !getenv("PROSPER_NO_SWIZZLE"))
-                        tvci.components = {vkswz(r.swizzle[0]), vkswz(r.swizzle[1]), vkswz(r.swizzle[2]), vkswz(r.swizzle[3])};
+                    if (!r.is_storage_image && !getenv("PROSPER_NO_SWIZZLE")) {
+                        const auto swizzle = backend_sampled_component_swizzle(r);
+                        tvci.components = {vkswz(swizzle[0]), vkswz(swizzle[1]),
+                                           vkswz(swizzle[2]), vkswz(swizzle[3])};
+                    }
                     tvci.subresourceRange =
                         {VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels,
                          0, r.sample_count};

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -181,6 +181,14 @@ struct FrameResource {
     // target is available, bind its GPU image directly instead of uploading `tex_rgba` again.
     // `tex_rgba` remains an optional conservative fallback for an invalidated/missing target.
     uint64_t persistent_render_target_id = 0;
+    // A guest mip chain is rendered as one independent persistent color target per level because
+    // CB_COLOR names a single mip view at a time. A later T# names the complete allocation as one
+    // sampled image. The frontend records the renderer-owned level identities here so the backend
+    // can assemble them into one Vulkan mip image instead of binding level zero and silently
+    // discarding every smaller level. Zero entries are missing levels; the backend derives those
+    // from the previous available destination level. The count is the requested chain length.
+    std::array<uint64_t, 16> persistent_render_target_mip_ids{};
+    uint32_t persistent_render_target_mip_count = 0;
     // Non-zero identifies a persistent depth/stencil surface whose DEPTH plane this resource
     // samples (a shadow map / depth pyramid tap, #1275). The backend binds the retained Vulkan
     // depth image directly — prosper never writes rendered depth back to guest memory, so there
@@ -314,6 +322,8 @@ inline VkFormat backend_color_format(VkFormat format) {
         return VK_FORMAT_R32_UINT;
     if (format == VK_FORMAT_R32G32B32A32_UINT)
         return VK_FORMAT_R32G32B32A32_UINT;
+    if (format == VK_FORMAT_R32G32B32A32_SFLOAT)
+        return VK_FORMAT_R32G32B32A32_SFLOAT;
     if (format == VK_FORMAT_R32_SFLOAT)
         return VK_FORMAT_R32_SFLOAT;
     return VK_FORMAT_R8G8B8A8_UNORM;
@@ -321,7 +331,8 @@ inline VkFormat backend_color_format(VkFormat format) {
 
 inline uint32_t backend_color_bytes_per_pixel(VkFormat format) {
     format = backend_color_format(format);
-    if (format == VK_FORMAT_R32G32B32A32_UINT) return 16u;
+    if (format == VK_FORMAT_R32G32B32A32_UINT ||
+        format == VK_FORMAT_R32G32B32A32_SFLOAT) return 16u;
     if (format == VK_FORMAT_R16G16B16A16_SFLOAT) return 8u;
     if (format == VK_FORMAT_R8_UNORM) return 1u;
     if (format == VK_FORMAT_R8G8_UNORM) return 2u;
@@ -338,6 +349,7 @@ inline prosper::gpu::SpirvImageNumericClass backend_image_numeric_class(VkFormat
         case VK_FORMAT_R8G8_UNORM:
         case VK_FORMAT_R8G8B8A8_UNORM:
         case VK_FORMAT_R16G16B16A16_SFLOAT:
+        case VK_FORMAT_R32G32B32A32_SFLOAT:
         case VK_FORMAT_R32_SFLOAT:
         case VK_FORMAT_B10G11R11_UFLOAT_PACK32:
             return NumericClass::Float;
@@ -1852,6 +1864,22 @@ inline size_t persistent_color_target_count_limit() {
     return count;
 }
 
+// One ordered frontend callback may record several render groups into one Vulkan submission batch.
+// While that batch is open, none of the existing targets can be evicted because an earlier command
+// buffer may still reference it. Refusing every new persistent target at the nominal count limit is
+// nevertheless incorrect: the new target becomes transient before the frontend can pin it, so a
+// producer followed by a later group in the same batch loses the only GPU-authoritative copy. Keep a
+// small, bounded admission window while eviction is deferred. Once the batch completes, the normal
+// cleanup path prunes unpinned entries back to the configured limit; targets claimed by the frontend
+// remain protected until their consumer releases them.
+inline size_t persistent_color_target_count_ceiling(bool eviction_deferred) {
+    const size_t limit = persistent_color_target_count_limit();
+    constexpr size_t kDeferredEvictionHeadroom = 64;
+    if (!eviction_deferred) return limit;
+    return limit > SIZE_MAX - kDeferredEvictionHeadroom
+        ? SIZE_MAX : limit + kDeferredEvictionHeadroom;
+}
+
 inline PersistentColorTargetImage* find_persistent_color_target(
     uint64_t id, uint32_t width, uint32_t height, VkFormat format, bool require_valid = true) {
     if (!id) return nullptr;
@@ -3144,7 +3172,19 @@ inline size_t invalidate_persistent_ds_guest_write(uint64_t addr, uint64_t size)
             const char* v = getenv("PROSPER_DS_HTILE_INVALIDATE");
             return !(v && v[0] == '0');
         }();
-        const bool htile_kill = htile_overlap && htile_invalidates;
+        // A byte-preserving HTILE write cannot change the logical depth/stencil surface. This is
+        // narrower than treating every compute HTILE pass as a harmless "decompress": a changed
+        // metadata plane can still encode a real fast clear and therefore keeps the conservative
+        // invalidation below.
+        //
+        // GTA V's transition kernel 0x413cdf900 is the hand-checkable positive instance. It reads
+        // and rewrites exactly the 294,912-byte HTILE plane at 0x204ca00000; the GPU comparator
+        // proves changed=0, after which `notify_guest_gpu_write_preserving_bytes` names the write
+        // `gpu-preserving`. Invalidating on that notification discarded the non-zero retained
+        // depth produced by submits 3416-3425 immediately before deferred lighting.
+        const bool byte_preserving =
+            std::strcmp(prosper::gpu::guest_gpu_write_origin(), "gpu-preserving") == 0;
+        const bool htile_kill = htile_overlap && htile_invalidates && !byte_preserving;
         if (!depth_overlap && !stencil_overlap && !htile_kill) continue;
         if (depth_overlap || htile_kill) image.depth_valid = false;
         if (stencil_overlap || htile_kill) image.stencil_valid = false;
@@ -4414,11 +4454,24 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Protect every GPU target sampled by this call from LRU eviction while its descriptors are built.
     for (const auto& draw : draws)
         for (const auto& resource : draw.R)
-            if (persistent_color_targets_enabled && resource.persistent_render_target_id)
+            if (persistent_color_targets_enabled && resource.persistent_render_target_id) {
                 if (auto* sampled = find_persistent_color_target(
                         resource.persistent_render_target_id, resource.tw, resource.th,
                         backend_color_format(resource.texture_format)))
                     sampled->last_use = color_target_generation;
+                const uint32_t mip_count = std::min<uint32_t>(
+                    resource.persistent_render_target_mip_count,
+                    static_cast<uint32_t>(resource.persistent_render_target_mip_ids.size()));
+                for (uint32_t level = 1; level < mip_count; ++level) {
+                    const uint64_t id = resource.persistent_render_target_mip_ids[level];
+                    if (!id) continue;
+                    if (auto* sampled = find_persistent_color_target(
+                            id, std::max(resource.tw >> level, 1u),
+                            std::max(resource.th >> level, 1u),
+                            backend_color_format(resource.texture_format)))
+                        sampled->last_use = color_target_generation;
+                }
+            }
 
     bool persistent_color = persistent_color_enabled;
     PersistentColorTargetKey color_key{};
@@ -4459,7 +4512,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                    (persistent_color_target_cache().size() > persistent_color_target_count_limit() || ir.size > limit ||
                     persistent_color_target_bytes() > limit - ir.size) &&
                    evict_persistent_color_target(ctx, color_target_generation)) {}
-            if (ir.size <= limit && persistent_color_target_cache().size() <= persistent_color_target_count_limit() &&
+            if (ir.size <= limit && persistent_color_target_cache().size() <=
+                    persistent_color_target_count_ceiling(avoid_cache_eviction) &&
                 persistent_color_target_bytes() <= limit - ir.size &&
                 vkAllocateMemory(dev, &iai, nullptr, &imem) == VK_SUCCESS) {
                 cached_color->bytes = ir.size;
@@ -4572,7 +4626,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                    evict_persistent_color_target(ctx, color_target_generation)) {}
             if (color1_requirements.size <= limit &&
                 persistent_color_target_cache().size() <=
-                    persistent_color_target_count_limit() &&
+                    persistent_color_target_count_ceiling(avoid_cache_eviction) &&
                 persistent_color_target_bytes() <= limit - color1_requirements.size &&
                 vkAllocateMemory(dev, &color1_allocation, nullptr, &imem1) == VK_SUCCESS) {
                 cached_color1->bytes = color1_requirements.size;
@@ -4679,7 +4733,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                    evict_persistent_color_target(ctx, color_target_generation)) {}
             if (requirements.size <= limit &&
                 persistent_color_target_cache().size() <=
-                    persistent_color_target_count_limit() &&
+                    persistent_color_target_count_ceiling(avoid_cache_eviction) &&
                 persistent_color_target_bytes() <= limit - requirements.size &&
                 vkAllocateMemory(dev, &allocation, nullptr, &extra_memories[slot]) == VK_SUCCESS) {
                 cached_extra[slot]->bytes = requirements.size;
@@ -4735,6 +4789,27 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     for (uint32_t slot = 2; slot < color_count; ++slot)
         load_extra[slot] = cached_extra[slot] && cached_extra[slot]->valid &&
                            color_target && color_target->load_existing_slots[slot];
+    if (color_target && getenv("PROSPER_BACKEND_LOAD_LOG")) {
+        if (use_color1)
+            fprintf(stderr,
+                    "[backend-load] slot=1 id=0x%llx %ux%u fmt=%d cached=%d valid=%d "
+                    "load_existing=%d seed=%d readback=%d -> load=%d\n",
+                    (unsigned long long)color_target->persistent_id1, W, H, (int)FMT1,
+                    cached_color1 != nullptr, cached_color1 ? (int)cached_color1->valid : -1,
+                    (int)color_target->load_existing1, effective_seed1 != nullptr,
+                    (int)color_target->readback1, (int)load_cached_color1);
+        for (uint32_t slot = 2; slot < color_count; ++slot)
+            fprintf(stderr,
+                    "[backend-load] slot=%u id=0x%llx %ux%u fmt=%d cached=%d valid=%d "
+                    "load_existing=%d seed=%d readback=%d -> load=%d\n",
+                    slot,
+                    (unsigned long long)color_target->persistent_id_slots[slot], W, H,
+                    (int)color_formats[slot], cached_extra[slot] != nullptr,
+                    cached_extra[slot] ? (int)cached_extra[slot]->valid : -1,
+                    (int)color_target->load_existing_slots[slot],
+                    color_target->seed_slots[slot] != nullptr,
+                    (int)color_target->readback_slots[slot], (int)load_extra[slot]);
+    }
 
     if (use_ds && !dimg) {
         VkImageCreateInfo dci{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
@@ -4988,6 +5063,12 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
         bool uniform_clear = false;
         VkClearColorValue uniform_color{};
         bool borrowed_target = false;
+        // Independent one-level renderer targets copied into this upload's mip levels. Sources
+        // retain their persistent-cache layout after the copy; a zero image is generated from the
+        // preceding destination level.
+        bool assembled_target_mips = false;
+        std::array<VkImage, 16> target_mip_images{};
+        std::array<VkImageLayout, 16> target_mip_layouts{};
         bool borrowed_compute = false;
         VkImageLayout borrowed_compute_layout = VK_IMAGE_LAYOUT_UNDEFINED;
         std::shared_ptr<void> borrowed_compute_lease;
@@ -5524,10 +5605,13 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         std::snprintf(why_text + n, sizeof why_text - n, " none");
                 }
                 std::fprintf(stderr,
-                             "[render] skip draw: fragment shader requires subgroup size %u "
+                             "[render] skip draw=%zu fs=%016llx: fragment shader requires subgroup size %u "
                              "(device range %u..%u required-stages=0x%x subgroup-stages=0x%x "
                              "ops=0x%x required-ops=0x%x control=%d gds=%d fragment-atomics=%d "
                              "why=%s)\n",
+                             static_cast<size_t>(bd.draw_index != UINT64_MAX
+                                 ? bd.draw_index : di),
+                             static_cast<unsigned long long>(shader_key),
                              required_fragment_subgroup_size, ctx.min_subgroup_size,
                              ctx.max_subgroup_size, ctx.required_subgroup_size_stages,
                              ctx.subgroup_stages, ctx.subgroup_operations,
@@ -6110,6 +6194,39 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                         ? (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)
                         : VK_SHADER_STAGE_FRAGMENT_BIT;
                     texture_references++;
+                    // Every ACTIVE bound slot, not just 0 and 1. A sampled renderer mip chain must
+                    // not copy any level that is also an attachment of this pass; the copy is
+                    // recorded before the render pass and would observe the previous contents.
+                    auto target_is_feedback = [&](uint64_t target_id,
+                                                  uint32_t target_w,
+                                                  uint32_t target_h) {
+                        if (!color_target || !target_id) return false;
+                        uint64_t bases[prosper::gpu::kColorTargetCount]{};
+                        bool active[prosper::gpu::kColorTargetCount]{};
+                        bases[0] = color_target->persistent_id;
+                        active[0] = persistent_color;
+                        bases[1] = color_target->persistent_id1;
+                        active[1] = persistent_color1;
+                        for (uint32_t slot = 2; slot < color_count; ++slot) {
+                            bases[slot] = color_target->persistent_id_slots[slot];
+                            active[slot] = cached_extra[slot] != nullptr;
+                        }
+                        return prosper::frontend::mrt_target_view_feedback(
+                            bases, active, color_count, target_id,
+                            target_w, target_h, W, H);
+                    };
+                    const bool target_feedback = target_is_feedback(
+                        r.persistent_render_target_id, r.tw, r.th);
+                    bool target_mip_feedback = target_feedback;
+                    const uint32_t requested_target_mips = std::min<uint32_t>(
+                        r.persistent_render_target_mip_count,
+                        static_cast<uint32_t>(r.persistent_render_target_mip_ids.size()));
+                    for (uint32_t level = 1;
+                         !target_mip_feedback && level < requested_target_mips; ++level)
+                        target_mip_feedback = target_is_feedback(
+                            r.persistent_render_target_mip_ids[level],
+                            std::max(r.tw >> level, 1u),
+                            std::max(r.th >> level, 1u));
                     // #1272: effective generated-mip chain — bounded by the chain the T# itself
                     // declares (declared_mip_levels; 1 = historical single-level behavior), and
                     // restricted to plain-2D RGBA8 sampled guest textures. Cube/volume stacks,
@@ -6128,11 +6245,49 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 (unsigned long long)r.persistent_depth_target_id,
                                 r.tex_rgba != nullptr, r.min_lod, r.max_lod,
                                 r.mag_filter, r.min_filter, r.mip_filter);
+                    const VkFormat sampled_format = backend_color_format(r.texture_format);
+                    bool generated_mip_format_supported =
+                        sampled_format == VK_FORMAT_R8G8B8A8_UNORM;
+                    if (sampled_format == VK_FORMAT_B10G11R11_UFLOAT_PACK32) {
+                        VkFormatProperties properties{};
+                        vkGetPhysicalDeviceFormatProperties(phys, sampled_format, &properties);
+                        constexpr VkFormatFeatureFlags required =
+                            VK_FORMAT_FEATURE_BLIT_SRC_BIT |
+                            VK_FORMAT_FEATURE_BLIT_DST_BIT |
+                            VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
+                        generated_mip_format_supported =
+                            (properties.optimalTilingFeatures & required) == required;
+                    }
+                    std::array<VkImage, 16> renderer_mip_images{};
+                    std::array<VkImageLayout, 16> renderer_mip_layouts{};
+                    uint32_t renderer_mip_sources = 0;
+                    if (!r.is_storage_image && !target_mip_feedback && r.img_dim == 1u &&
+                        r.td == 1u && r.sample_count == 1u && generated_mip_format_supported &&
+                        requested_target_mips > 1u &&
+                        requested_target_mips == r.declared_mip_levels) {
+                        for (uint32_t level = 0; level < requested_target_mips; ++level) {
+                            const uint64_t id = r.persistent_render_target_mip_ids[level];
+                            if (!id) continue;
+                            auto* target = find_persistent_color_target(
+                                id, std::max(r.tw >> level, 1u),
+                                std::max(r.th >> level, 1u), sampled_format);
+                            if (!target || !target->image ||
+                                target->layout == VK_IMAGE_LAYOUT_UNDEFINED)
+                                continue;
+                            target->last_use = color_target_generation;
+                            renderer_mip_images[level] = target->image;
+                            renderer_mip_layouts[level] = target->layout;
+                            ++renderer_mip_sources;
+                        }
+                    }
+                    const bool assemble_renderer_mips = renderer_mip_sources > 1u &&
+                        renderer_mip_images[0] != VK_NULL_HANDLE;
                     if (!r.is_storage_image && r.img_dim == 1 && r.td == 1 &&
-                        !r.persistent_render_target_id && r.tex_rgba &&
+                        ((!r.persistent_render_target_id && r.tex_rgba) ||
+                         assemble_renderer_mips) &&
                         // Widening this format gate requires BLIT_SRC/BLIT_DST +
                         // SAMPLED_IMAGE_FILTER_LINEAR on the new format (the blit cascade below).
-                        backend_color_format(r.texture_format) == VK_FORMAT_R8G8B8A8_UNORM &&
+                        generated_mip_format_supported &&
                         r.declared_mip_levels > 1 && (r.tw > 1 || r.th > 1)) {
                         uint32_t full = 1;
                         for (uint32_t m = r.tw > r.th ? r.tw : r.th; m > 1; m >>= 1) full++;
@@ -6182,28 +6337,14 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                             upload.borrowed_compute_lease = r.borrowed_compute_image_lease;
                         }
 
-                        // Every ACTIVE bound slot, not just 0 and 1. A higher slot's image is now
-                        // persistent and SAMPLED-capable, so without this a draw sampling an active
-                        // MRT2+ target borrows the very same VkImage as both descriptor and colour
-                        // attachment -- bypassing the established CPU fallback and using one image
-                        // as shader-read and colour-attachment simultaneously.
-                        const bool target_feedback = [&] {
-                            if (!color_target || !r.persistent_render_target_id) return false;
-                            uint64_t bases[prosper::gpu::kColorTargetCount]{};
-                            bool active[prosper::gpu::kColorTargetCount]{};
-                            bases[0] = color_target->persistent_id;
-                            active[0] = persistent_color;
-                            bases[1] = color_target->persistent_id1;
-                            active[1] = persistent_color1;
-                            for (uint32_t slot = 2; slot < color_count; ++slot) {
-                                bases[slot] = color_target->persistent_id_slots[slot];
-                                active[slot] = cached_extra[slot] != nullptr;
-                            }
-                            return prosper::frontend::mrt_target_feedback(
-                                bases, active, color_count, r.persistent_render_target_id);
-                        }();
+                        if (assemble_renderer_mips) {
+                            upload.assembled_target_mips = true;
+                            upload.target_mip_images = renderer_mip_images;
+                            upload.target_mip_layouts = renderer_mip_layouts;
+                        }
                         if (!upload.borrowed_compute && !r.is_storage_image &&
-                            persistent_color_targets_enabled && !target_feedback &&
+                            !upload.assembled_target_mips && persistent_color_targets_enabled &&
+                            !target_feedback &&
                             r.persistent_render_target_id && r.img_dim == 1) {
                             if (auto* target = find_persistent_color_target(
                                     r.persistent_render_target_id, r.tw, r.th,
@@ -6350,7 +6491,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                                 upload.uniform_clear = true;
                                 std::copy(r.uniform_color.begin(), r.uniform_color.end(),
                                           upload.uniform_color.float32);
-                            } else {
+                            } else if (!upload.assembled_target_mips) {
                                 const VkDeviceSize tbytes =
                                     static_cast<VkDeviceSize>(r.tw) * r.th * r.td *
                                     r.sample_count *
@@ -7015,7 +7156,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     texture_stats.persistent_hits = persistent_texture_hits;
     texture_stats.persistent_misses = persistent_texture_misses;
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging && !upload.uniform_clear) continue;
+        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips)
+            continue;
         ++texture_stats.unique_uploads;
         texture_stats.upload_bytes += static_cast<uint64_t>(upload.key.width) * upload.key.height *
                                       upload.key.depth * upload.key.sample_count *
@@ -7291,7 +7433,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
     // Upload each distinct texture once. Draw descriptors may use separate views/samplers over the
     // same image, preserving per-binding swizzle and sampler state without duplicating pixel storage.
     for (const auto& upload : texture_uploads) {
-        if (!upload.staging && !upload.uniform_clear)
+        if (!upload.staging && !upload.uniform_clear && !upload.assembled_target_mips)
             continue;  // exact-validated persistent image already has shader-read layout
         VkImageMemoryBarrier b0{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
         b0.oldLayout = upload.persistent_refresh
@@ -7314,7 +7456,7 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                 0, upload.key.sample_count};
             vkCmdClearColorImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                  &upload.uniform_color, 1, &range);
-        } else {
+        } else if (!upload.assembled_target_mips) {
             VkBufferImageCopy tc{};
             tc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0,
                                    upload.key.sample_count};
@@ -7322,11 +7464,78 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
             vkCmdCopyBufferToImage(cmd, upload.staging, upload.image,
                                    VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &tc);
         }
+        if (upload.assembled_target_mips) {
+            // Each source is an independent one-level persistent color target resting in its
+            // recorded cache layout. Zero the destination first, then copy only levels the guest
+            // actually rendered and restore every source immediately. A missing level must remain
+            // unavailable/black: deriving it from a neighbour invents guest output and amplified
+            // GTA V's incomplete bloom chain into a full-screen glare.
+            const VkClearColorValue missing_level_clear{};
+            const VkImageSubresourceRange missing_level_range{
+                VK_IMAGE_ASPECT_COLOR_BIT, 0, upload.key.mip_levels, 0, 1};
+            vkCmdClearColorImage(cmd, upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                                 &missing_level_clear, 1, &missing_level_range);
+            for (uint32_t level = 0; level < upload.key.mip_levels; ++level) {
+                const uint32_t level_w = std::max(upload.key.width >> level, 1u);
+                const uint32_t level_h = std::max(upload.key.height >> level, 1u);
+                if (upload.target_mip_images[level]) {
+                    VkImageMemoryBarrier source_to_copy{
+                        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                    source_to_copy.oldLayout = upload.target_mip_layouts[level];
+                    source_to_copy.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                    source_to_copy.srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT |
+                                                   VK_ACCESS_SHADER_READ_BIT |
+                                                   VK_ACCESS_TRANSFER_READ_BIT;
+                    source_to_copy.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    source_to_copy.srcQueueFamilyIndex = source_to_copy.dstQueueFamilyIndex =
+                        VK_QUEUE_FAMILY_IGNORED;
+                    source_to_copy.image = upload.target_mip_images[level];
+                    source_to_copy.subresourceRange = {
+                        VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                    vkCmdPipelineBarrier(
+                        cmd,
+                        VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT |
+                            VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                            VK_PIPELINE_STAGE_TRANSFER_BIT,
+                        VK_PIPELINE_STAGE_TRANSFER_BIT, 0,
+                        0, nullptr, 0, nullptr, 1, &source_to_copy);
+                    VkImageCopy copy{};
+                    copy.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+                    copy.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, level, 0, 1};
+                    copy.extent = {level_w, level_h, 1};
+                    vkCmdCopyImage(
+                        cmd, upload.target_mip_images[level],
+                        VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, upload.image,
+                        VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
+                    VkImageMemoryBarrier source_restore{
+                        VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
+                    source_restore.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
+                    source_restore.newLayout = upload.target_mip_layouts[level];
+                    source_restore.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
+                    source_restore.dstAccessMask = VK_ACCESS_SHADER_READ_BIT |
+                                                   VK_ACCESS_COLOR_ATTACHMENT_READ_BIT |
+                                                   VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+                    source_restore.srcQueueFamilyIndex = source_restore.dstQueueFamilyIndex =
+                        VK_QUEUE_FAMILY_IGNORED;
+                    source_restore.image = upload.target_mip_images[level];
+                    source_restore.subresourceRange = {
+                        VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+                    vkCmdPipelineBarrier(
+                        cmd, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                        VK_PIPELINE_STAGE_VERTEX_SHADER_BIT |
+                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT |
+                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                        0, 0, nullptr, 0, nullptr, 1, &source_restore);
+                }
+            }
+        }
         // #1272: generate levels 1..N-1 with a linear-filtered blit cascade (GPU-side, once per
         // upload — a CPU box filter here collapsed titles that re-upload large textures per frame).
         // Each source level transitions DST->SRC before feeding the next; the final barrier below
         // then flips the whole chain to shader-read. RGBA8 linear-blit support is mandatory Vulkan.
-        for (uint32_t l = 1; !upload.uniform_clear && l < upload.key.mip_levels; l++) {
+        for (uint32_t l = 1; !upload.uniform_clear && !upload.assembled_target_mips &&
+             l < upload.key.mip_levels; l++) {
             VkImageMemoryBarrier bs{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};
             bs.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
             bs.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -7352,7 +7561,8 @@ inline std::vector<uint8_t> render_draw_pass_rgba(std::span<const BackendDraw> d
                            upload.image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit,
                            VK_FILTER_LINEAR);
         }
-        if (!upload.uniform_clear && upload.key.mip_levels > 1) {
+        if (!upload.uniform_clear && !upload.assembled_target_mips &&
+            upload.key.mip_levels > 1) {
             // Levels 0..N-2 sit in TRANSFER_SRC after feeding the cascade; return them to
             // TRANSFER_DST so the single final-layout barrier below covers the whole chain.
             VkImageMemoryBarrier br{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER};

--- a/prosper/tests/gpu/capture/test_gpu_capture.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture.cpp
@@ -2153,6 +2153,28 @@ int main(int argc, char** argv) {
           fp16_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba16Float &&
           fp16_loaded.rtt_seeds[0].rgba == fp16_capture.rtt_seeds[0].rgba,
           "native FP16 RTT seed format and bytes round-trip");
+    GpuCaptureFile rg16_capture = captured;
+    rg16_capture.rtt_seeds[0].format = GpuCaptureColorFormat::Rg16Float;
+    rg16_capture.rtt_seeds[0].rgba.assign(2 * 2 * 4, 0x36);
+    std::vector<uint8_t> rg16_bytes;
+    GpuCaptureFile rg16_loaded;
+    CHECK(serialize_gpu_capture(rg16_capture, rg16_bytes, error) &&
+          deserialize_gpu_capture(rg16_bytes, rg16_loaded, error) &&
+          rg16_loaded.rtt_seeds.size() == 1 &&
+          rg16_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rg16Float &&
+          rg16_loaded.rtt_seeds[0].rgba == rg16_capture.rtt_seeds[0].rgba,
+          "native RG16F RTT seed format and bytes round-trip");
+    GpuCaptureFile r16_capture = captured;
+    r16_capture.rtt_seeds[0].format = GpuCaptureColorFormat::R16Float;
+    r16_capture.rtt_seeds[0].rgba.assign(2 * 2 * 2, 0x3a);
+    std::vector<uint8_t> r16_bytes;
+    GpuCaptureFile r16_loaded;
+    CHECK(serialize_gpu_capture(r16_capture, r16_bytes, error) &&
+          deserialize_gpu_capture(r16_bytes, r16_loaded, error) &&
+          r16_loaded.rtt_seeds.size() == 1 &&
+          r16_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::R16Float &&
+          r16_loaded.rtt_seeds[0].rgba == r16_capture.rtt_seeds[0].rgba,
+          "native R16F RTT seed format and bytes round-trip");
     GpuCaptureFile fp32_capture = captured;
     fp32_capture.rtt_seeds[0].format = GpuCaptureColorFormat::Rgba32Float;
     fp32_capture.rtt_seeds[0].rgba.assign(2 * 2 * 16, 0x3f);

--- a/prosper/tests/gpu/capture/test_gpu_capture.cpp
+++ b/prosper/tests/gpu/capture/test_gpu_capture.cpp
@@ -844,7 +844,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame descriptor_array_replay;
     CHECK(serialize_gpu_capture(descriptor_array_capture, descriptor_array_bytes, error) &&
               deserialize_gpu_capture(descriptor_array_bytes, descriptor_array_loaded, error) &&
-              descriptor_array_loaded.format_version == 55 &&
+              descriptor_array_loaded.format_version == 56 &&
               materialize_gpu_replay(descriptor_array_loaded, descriptor_array_replay, error) &&
               descriptor_array_replay.computes.size() == 1 &&
               descriptor_array_replay.computes[0].resources &&
@@ -1226,7 +1226,7 @@ int main(int argc, char** argv) {
         deserialize_gpu_capture(msaa_bytes, msaa_loaded, error);
     if (!msaa_deserialized) std::printf("  [diag] MSAA capture deserialization: %s\n", error.c_str());
     CHECK(msaa_deserialized &&
-              msaa_loaded.format_version == 55 &&
+              msaa_loaded.format_version == 56 &&
               msaa_loaded.draws[0].vrt.resources[0].resource.sample_count == 4 &&
               msaa_loaded.blobs.size() == 2 &&
               msaa_loaded.blobs[1].bytes.size() == 32768u &&
@@ -1317,6 +1317,17 @@ int main(int argc, char** argv) {
     video_chroma.size = 1920u * 1080u;
     CHECK(gpu_capture_resource_footprint(video_chroma) == 2048u * 1080u,
           "capture includes 256-byte row padding for a guest-backed linear R8 sampled image");
+    ShaderResource gta_visibility = video_chroma;
+    gta_visibility.gpu_addr = 0x2078aa0000ull;
+    gta_visibility.format = DataFormat::Uint32;
+    gta_visibility.num_components = 2;
+    gta_visibility.width = 640;
+    gta_visibility.height = 360;
+    gta_visibility.tile_mode = static_cast<uint32_t>(TileMode::Sw64KbRX);
+    gta_visibility.size = 640u * 360u * 8u;
+    CHECK(gpu_capture_resource_footprint(gta_visibility) ==
+              tiled_surface_bytes(640, 360, static_cast<uint32_t>(TileMode::Sw64KbRX), 0, 8),
+          "capture retains GTA V's padded Uint32x2 sampled visibility surface");
     uint8_t host_video_texel = 0;
     video_chroma.host_data = &host_video_texel;
     CHECK(gpu_capture_resource_footprint(video_chroma) == 1920u * 1080u,
@@ -1341,7 +1352,7 @@ int main(int argc, char** argv) {
     };
     GpuCaptureFile video_capture;
     CHECK(capture_draw_items({video_draw}, meta, video_reader, video_capture, error) &&
-              video_capture.format_version == 55 && video_capture.blobs.size() == 1 &&
+              video_capture.format_version == 56 && video_capture.blobs.size() == 1 &&
               video_capture.blobs[0].bytes.size() == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_capture.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048,
@@ -1352,7 +1363,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame video_replay;
     CHECK(serialize_gpu_capture(video_capture, video_capture_bytes, error) &&
               deserialize_gpu_capture(video_capture_bytes, video_loaded, error) &&
-              video_loaded.format_version == 55 &&
+              video_loaded.format_version == 56 &&
               video_loaded.draws[0].prt.resources[0].resource.proven_zero_mip &&
               video_loaded.draws[0].prt.resources[0].captured_size == video_memory.size() &&
               video_loaded.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
@@ -1396,7 +1407,7 @@ int main(int argc, char** argv) {
     GpuReplayFrame upgraded_video_replay;
     CHECK(serialize_gpu_capture(legacy_video, upgraded_video_bytes, error) &&
               deserialize_gpu_capture(upgraded_video_bytes, upgraded_video, error) &&
-              upgraded_video.format_version == 55 &&
+              upgraded_video.format_version == 56 &&
               upgraded_video.draws[0].prt.resources[0].captured_size == video_chroma.size &&
               upgraded_video.draws[0].prt.resources[0].resource.linear_row_pitch_bytes == 2048 &&
               materialize_gpu_replay(upgraded_video, upgraded_video_replay, error) &&
@@ -1478,7 +1489,7 @@ int main(int argc, char** argv) {
           "Plucky RGBA16 32-cubed S3 capture uses its four true 3D macroblocks");
     CHECK(serialize_gpu_capture(array_layout_capture, array_layout_bytes, error) &&
               deserialize_gpu_capture(array_layout_bytes, array_layout_loaded, error) &&
-              array_layout_loaded.format_version == 55 &&
+              array_layout_loaded.format_version == 56 &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_stride_bytes == 720896u &&
               array_layout_loaded.draws[0].vrt.resources[0].resource.layer_mip_offset_bytes == 65536u,
           "v32 capture round-trips thin-array slice stride and selected-mip offset");
@@ -1706,7 +1717,7 @@ int main(int argc, char** argv) {
     CHECK(write_gpu_capture(path.string(), captured, error), "versioned capture writes atomically");
     GpuCaptureFile loaded;
     CHECK(read_gpu_capture(path.string(), loaded, error), "versioned capture reads back");
-    CHECK(loaded.format_version == 55 &&
+    CHECK(loaded.format_version == 56 &&
               loaded.draws[0].vrt.resources[1].resource.size == 16u &&
               loaded.draws[0].vrt.resources[1].resource.scalar_buffer_dword_count == 4u &&
               shader_resource_buffer_binding_bytes(
@@ -2142,6 +2153,17 @@ int main(int argc, char** argv) {
           fp16_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba16Float &&
           fp16_loaded.rtt_seeds[0].rgba == fp16_capture.rtt_seeds[0].rgba,
           "native FP16 RTT seed format and bytes round-trip");
+    GpuCaptureFile fp32_capture = captured;
+    fp32_capture.rtt_seeds[0].format = GpuCaptureColorFormat::Rgba32Float;
+    fp32_capture.rtt_seeds[0].rgba.assign(2 * 2 * 16, 0x3f);
+    std::vector<uint8_t> fp32_bytes;
+    GpuCaptureFile fp32_loaded;
+    CHECK(serialize_gpu_capture(fp32_capture, fp32_bytes, error) &&
+          deserialize_gpu_capture(fp32_bytes, fp32_loaded, error) &&
+          fp32_loaded.rtt_seeds.size() == 1 &&
+          fp32_loaded.rtt_seeds[0].format == GpuCaptureColorFormat::Rgba32Float &&
+          fp32_loaded.rtt_seeds[0].rgba == fp32_capture.rtt_seeds[0].rgba,
+          "native RGBA32F RTT seed format and bytes round-trip");
     GpuCaptureFile scalar_seed_capture = captured;
     scalar_seed_capture.rtt_seeds[0].format = GpuCaptureColorFormat::R8Unorm;
     scalar_seed_capture.rtt_seeds[0].rgba.assign(2 * 2, 0x7f);
@@ -3263,7 +3285,7 @@ int main(int argc, char** argv) {
     GpuCaptureFile failed_compute_loaded;
     CHECK(serialize_gpu_capture(failed_compute_capture, failed_compute_bytes, error) &&
               deserialize_gpu_capture(failed_compute_bytes, failed_compute_loaded, error) &&
-              failed_compute_loaded.format_version == 55 &&
+              failed_compute_loaded.format_version == 56 &&
               failed_compute_loaded.failure_diagnostics[0].compute_launch.threads_x == 37 &&
               failed_compute_loaded.failure_diagnostics[0].stages[0]
                       .recompile_config.user_sgprs ==
@@ -3502,7 +3524,7 @@ int main(int argc, char** argv) {
                 loaded_failed_msaa = &resource;
         }
     }
-    CHECK(failed_loaded.format_version == 55 && loaded_shadow &&
+    CHECK(failed_loaded.format_version == 56 && loaded_shadow &&
           loaded_shadow->resource.depth == 4 &&
           loaded_shadow->resource.max_uncompressed_block_size == 2 &&
           loaded_shadow->resource.max_compressed_block_size == 1 &&
@@ -3790,9 +3812,9 @@ int main(int argc, char** argv) {
     CHECK(deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
           !legacy_loaded.failure_diagnostics_available && legacy_loaded.failure_diagnostics.empty(),
           "v6 capture reopens with failed-operation diagnostics reported unavailable");
-    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 56;   // kVersion + 1: a future version
+    if (legacy_bytes.size() >= 12) legacy_bytes[8] = 57;   // kVersion + 1: a future version
     CHECK(!deserialize_gpu_capture(legacy_bytes, legacy_loaded, error) &&
-          error == "unsupported capture version 56",
+          error == "unsupported capture version 57",
           "future capture versions fail with a concrete version error");
 
     GpuCaptureFile bad_hash = mixed;

--- a/prosper/tests/gpu/execute/test_gpu_dependency_graph.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_dependency_graph.cpp
@@ -68,6 +68,7 @@ int main() {
     ComputeItem compute;
     compute.dispatch_index = 2;
     compute.command_order = 20;
+    compute.launch.groups_x = compute.launch.groups_y = compute.launch.groups_z = 1;
     compute.resources = std::make_shared<ShaderResourceTable>();
     compute.resources->resources.push_back(resource(0x3000, 0x80, 2, ResourceClass::ConstantBuffer));
 
@@ -134,6 +135,8 @@ int main() {
     ComputeItem scalar_compute;
     scalar_compute.dispatch_index = 636;
     scalar_compute.command_order = 636;
+    scalar_compute.launch.groups_x = scalar_compute.launch.groups_y =
+        scalar_compute.launch.groups_z = 1;
     scalar_compute.resources = std::make_shared<ShaderResourceTable>(
         build_shader_resources(scalar_header, scalar_sgprs, 32));
     GpuReplayFrame scalar_replay;
@@ -186,6 +189,8 @@ int main() {
     ComputeItem reflected_compute;
     reflected_compute.dispatch_index = 637;
     reflected_compute.command_order = 637;
+    reflected_compute.launch.groups_x = reflected_compute.launch.groups_y =
+        reflected_compute.launch.groups_z = 1;
     reflected_compute.spirv = storage_image_copy_spirv();
     reflected_compute.resources = std::make_shared<ShaderResourceTable>();
     ShaderResource reflected_src = resource(0x7000, 4, 5, ResourceClass::StorageImage);
@@ -229,6 +234,31 @@ int main() {
                                                wrong_format) &&
               !gpu_dependency_rtt_seed_matches(srgb_access, exact_seed),
           "address-only RTT matches cannot hide extent, format, or sRGB reinterpretation");
+
+    ComputeItem zero_compute = reflected_compute;
+    zero_compute.dispatch_index = 639;
+    zero_compute.command_order = 639;
+    zero_compute.launch.groups_x = 0;
+    DrawItem zero_consumer;
+    zero_consumer.draw_index = 640;
+    zero_consumer.command_order = 640;
+    zero_consumer.prt = std::make_shared<ShaderResourceTable>();
+    zero_consumer.prt->resources = {reflected_dst};
+    GpuReplayFrame zero_replay;
+    zero_replay.computes = {zero_compute};
+    zero_replay.items = {zero_consumer};
+    zero_replay.operations = {
+        {SubmitOperationKind::Dispatch, 639, 639, true},
+        {SubmitOperationKind::Draw, 640, 640, true},
+    };
+    GpuDependencyGraph zero_graph;
+    CHECK(build_gpu_dependency_graph(zero_replay, zero_graph, error) &&
+              zero_graph.nodes.size() == 2 && zero_graph.nodes[0].realized &&
+              zero_graph.edges.empty() && zero_graph.external_leaves.size() == 1 &&
+              zero_graph.external_leaves[0].access.addr == reflected_dst.gpu_addr &&
+              zero_graph.external_leaves[0].consumer_operations.size() == 1 &&
+              zero_graph.external_leaves[0].consumer_operations[0] == 1,
+          "a zero-workgroup dispatch remains a semantic node but cannot consume or produce data");
 
     GpuReplayFrame image_overlap_replay;
     DrawItem image_writer;

--- a/prosper/tests/gpu/execute/test_gpu_execute.cpp
+++ b/prosper/tests/gpu/execute/test_gpu_execute.cpp
@@ -274,8 +274,8 @@ int main() {
 
     // Exercise the complete compute realization path: user pointer -> s_load T# fold -> per-use zero
     // proof -> descriptor materialization -> cached recompile. This pins the production assignment in
-    // realize_compute_dispatches, while the unsafe arms prove DCC/multilevel descriptors cannot gain
-    // the marker or reuse the safe module.
+    // realize_compute_dispatches. A multilevel descriptor cannot gain the marker; a DCC descriptor
+    // keeps the instruction proof and leaves decompressed-source authority to the live backend.
     {
         auto create_shader = prosper::Hle::lookup("f3dg2CSgRKY");
         AgcShaderHeader zero_mip_compute_header{};
@@ -361,8 +361,15 @@ int main() {
         };
         CHECK(unsafe_realization_fails(multilevel_tsharp, false, 2),
               "compute realization keeps a multilevel IMAGE_LOAD_MIP fail-visible");
-        CHECK(unsafe_realization_fails(dcc_tsharp, true, 1),
-              "compute realization keeps GTA-shaped DCC IMAGE_LOAD_MIP fail-visible");
+        std::vector<OperationRealizationFailure> dcc_failures;
+        const std::vector<ComputeItem> dcc_items = realize_compute_dispatches(
+            make_zero_mip_submit(dcc_tsharp), 2483, &dcc_failures);
+        const ShaderResource* dcc_texture = dcc_items.size() == 1 && dcc_items[0].resources
+            ? dcc_items[0].resources->by_fetch_pc(4) : nullptr;
+        CHECK(dcc_items.size() == 1 && dcc_failures.empty() && dcc_texture &&
+                  dcc_texture->proven_zero_mip && dcc_texture->compression_enabled &&
+                  dcc_texture->declared_mip_levels == 1,
+              "compute realization carries GTA-shaped DCC IMAGE_LOAD_MIP to source validation");
     }
 
     // #584: graphics and compute are one PM4 timeline. The planner must retain the asymmetric
@@ -778,6 +785,20 @@ int main() {
         CHECK(made_rect && rect_item.vertex_count == 4u &&
               rect_item.ps.topology == static_cast<uint32_t>(VkTopology::TriangleStrip),
               "PS5 procedural RectList expands three vertices to a four-corner Vulkan strip");
+
+        ShaderResourceTable rect_vrt;
+        ShaderResource rect_vb;
+        rect_vb.cls = ResourceClass::VertexBuffer;
+        rect_vb.stride = 12u;
+        rect_vb.size = 3u * rect_vb.stride;
+        rect_vrt.resources.push_back(rect_vb);
+        CHECK(needs_rect_list_synthesis(7u, false, 3u, &rect_vrt) &&
+              needs_rect_list_synthesis(17u, false, 3u, &rect_vrt),
+              "GFX10 and standard VB-backed RectList forms request post-VS fourth-corner synthesis");
+        CHECK(!needs_rect_list_synthesis(7u, true, 3u, &rect_vrt) &&
+              !needs_rect_list_synthesis(7u, false, 6u, &rect_vrt) &&
+              !needs_rect_list_synthesis(6u, false, 3u, &rect_vrt),
+              "RectList synthesis does not alter indexed, non-three-vertex, or ordinary strip draws");
     }
 
     // #1163: a non-indexed DrawIndexAuto count is the AUTHORITATIVE hardware vertex count. The bound VB's

--- a/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
+++ b/prosper/tests/gpu/execute/test_shader_recompile_cache.cpp
@@ -745,9 +745,24 @@ int main() {
         0x7e040282u, // 6: v_mov_b32 v2, 2
         0xbf810000u, // 7: s_endpgm
     };
+    // A partial workgroup whose barrier cannot be lifted into uniform control flow.
+    //
+    // This was `{ s_barrier, s_endpgm }` -- a partial workgroup with ANY barrier used to reject, so
+    // the shortest such program served as the vehicle. That combination now compiles: the stream is
+    // split at its barriers and each barrier-free phase runs under the dispatcher's ACTIVE bit, with
+    // the barrier emitted at function scope. Keeping the old bytes here would have quietly turned an
+    // assertion about the diagnostic plumbing into an assertion that nothing had changed.
+    //
+    // The branch at pc1 jumps from before the barrier to after it, so no phase boundary is legal at
+    // pc2 and the split is refused -- which is a real and permanent limit, not a missing lowering.
+    // The reject, its reason string, and the extents below are therefore unchanged.
     static const uint32_t kPartialBarrierReject[] = {
-        0xbf8a0000u, // s_barrier
-        0xbf810000u, // s_endpgm
+        0xbf060000u, // 0: s_cmp_eq_u32 s0, s0
+        0xbf840002u, // 1: s_cbranch_scc0 +2 -> pc4, crossing the barrier
+        0xbf8a0000u, // 2: s_barrier
+        0x7e040282u, // 3: v_mov_b32 v2, 2
+        0x7e040281u, // 4: v_mov_b32 v2, 1
+        0xbf810000u, // 5: s_endpgm
     };
     ComputeShaderConfig rejected_config;
     rejected_config.local_x = 64;
@@ -867,9 +882,15 @@ int main() {
     // consequent even though the compiler's terminal diagnostic and the helper itself still work.
     prosper::register_agc_hle();
     auto create_shader = prosper::Hle::lookup("f3dg2CSgRKY");
+    // Same shape, and for the same reason, as kPartialBarrierReject above: a barrier the phase split
+    // cannot lift, because a guest branch crosses it.
     alignas(256) static const uint32_t kLivePartialBarrierReject[] = {
-        0xbf8a0000u, // s_barrier
-        0xbf810000u, // s_endpgm
+        0xbf060000u, // 0: s_cmp_eq_u32 s0, s0
+        0xbf840002u, // 1: s_cbranch_scc0 +2 -> pc4, crossing the barrier
+        0xbf8a0000u, // 2: s_barrier
+        0x7e040282u, // 3: v_mov_b32 v2, 2
+        0x7e040281u, // 4: v_mov_b32 v2, 1
+        0xbf810000u, // 5: s_endpgm
     };
     ShaderReg live_reject_registers[2] = {
         {prosper::agc::Pm4::COMPUTE_PGM_LO, 0},

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -80,9 +80,11 @@ int main() {
 #ifdef _WIN32
     _putenv_s("PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB", "0");
     _putenv_s("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1");
+    _putenv_s("PROSPER_NO_DISK_PIPELINE_CACHE", "1");
 #else
     setenv("PROSPER_COMPUTE_IMAGE_CACHE_MIN_KB", "0", 1);
     setenv("PROSPER_COMPUTE_BUFFER_RESULT_MIN_MB", "1", 1);
+    setenv("PROSPER_NO_DISK_PIPELINE_CACHE", "1", 1);
 #endif
     const bool adaptive_storage_result_validation_enabled =
         std::getenv("PROSPER_NO_ADAPTIVE_STORAGE_RESULT_VALIDATION") == nullptr;
@@ -119,6 +121,36 @@ int main() {
           prosper::frontend::compute_image_cache_default_limit_bytes(UINT64_MAX) ==
               2048ull * 1024ull * 1024ull,
           "image cache limit scales with local memory and retains bounded floor and ceiling");
+    CHECK(!prosper::frontend::compute_pipeline_is_large(32u * 1024u - 1u) &&
+          prosper::frontend::compute_pipeline_is_large(32u * 1024u),
+          "large portable compute modules retain an exact diagnostic policy boundary");
+    std::array<uint8_t, 32> pipeline_cache_header{};
+    const uint32_t pipeline_header_size = static_cast<uint32_t>(pipeline_cache_header.size());
+    const uint32_t pipeline_header_version = 1;
+    const uint32_t pipeline_vendor = 0x10de;
+    const uint32_t pipeline_device = 0x2b85;
+    std::array<uint8_t, 16> pipeline_uuid{};
+    for (size_t i = 0; i < pipeline_uuid.size(); ++i)
+        pipeline_uuid[i] = static_cast<uint8_t>(i * 7u + 3u);
+    std::memcpy(pipeline_cache_header.data() + 0, &pipeline_header_size, sizeof(uint32_t));
+    std::memcpy(pipeline_cache_header.data() + 4, &pipeline_header_version, sizeof(uint32_t));
+    std::memcpy(pipeline_cache_header.data() + 8, &pipeline_vendor, sizeof(uint32_t));
+    std::memcpy(pipeline_cache_header.data() + 12, &pipeline_device, sizeof(uint32_t));
+    std::memcpy(pipeline_cache_header.data() + 16, pipeline_uuid.data(), pipeline_uuid.size());
+    CHECK(prosper::frontend::compute_pipeline_cache_blob_compatible(
+              pipeline_cache_header.data(), pipeline_cache_header.size(),
+              pipeline_vendor, pipeline_device, pipeline_uuid.data(), pipeline_uuid.size()),
+          "disk compute pipeline cache accepts its exact Vulkan device identity");
+    pipeline_cache_header[16] ^= 1u;
+    CHECK(!prosper::frontend::compute_pipeline_cache_blob_compatible(
+              pipeline_cache_header.data(), pipeline_cache_header.size(),
+              pipeline_vendor, pipeline_device, pipeline_uuid.data(), pipeline_uuid.size()),
+          "disk compute pipeline cache rejects a mismatched driver UUID");
+    pipeline_cache_header[16] ^= 1u;
+    CHECK(!prosper::frontend::compute_pipeline_cache_blob_compatible(
+              pipeline_cache_header.data(), pipeline_cache_header.size() - 1,
+              pipeline_vendor, pipeline_device, pipeline_uuid.data(), pipeline_uuid.size()),
+          "disk compute pipeline cache rejects a truncated Vulkan header");
     CHECK(prosper::frontend::compute_sampled_guest_prepare_required(false, false, false),
           "guest-backed sampled image prepares its source");
     CHECK(!prosper::frontend::compute_sampled_guest_prepare_required(false, true, false),
@@ -1594,6 +1626,433 @@ int main() {
         if (bad) std::printf("  image copy mismatched bytes = %u/%u (b0 src=%02x dst=%02x)\n",
                              bad, W * 4, img_src[0], img_dst[0]);
         CHECK(bad == 0, "Unorm8 unpack -> uvec4 copy -> pack writeback is byte-exact (#590)");
+    }
+
+    // GTA V's heavy Windows transition copies two 2560x1440 single-channel surfaces and writes a
+    // 3840x2160 Uint8x4 target. Keeping them in the raw RGBA32_UINT interchange image inflated the
+    // allocations to 59/127 MiB; exercise the device-gated typed path end to end, including the
+    // exact reflected image format.
+    auto run_native_typed_copy = [&](DataFormat format, uint32_t spirv_format,
+                                     SpirvImageNumericClass numeric_class,
+                                     uint32_t components, uint32_t texel_bytes,
+                                     const std::vector<uint8_t>& source,
+                                     DataFormat sampled_format = DataFormat::Unknown) {
+        std::vector<uint8_t> destination(source.size(), 0xa5);
+        ShaderResourceTable table;
+        auto add_uint_image = [&](uint32_t binding, uint32_t sgpr, void* data) {
+            ShaderResource image{};
+            image.cls = ResourceClass::StorageImage;
+            image.img_dim = 1;
+            image.binding = binding;
+            image.sgpr_base = sgpr;
+            image.format = format;
+            image.num_components = components;
+            image.width = W;
+            image.height = image.depth = 1;
+            image.gpu_addr = reinterpret_cast<uint64_t>(data);
+            image.size = W * texel_bytes;
+            table.resources.push_back(image);
+        };
+        add_uint_image(4, 0, const_cast<uint8_t*>(source.data()));
+        add_uint_image(5, 8, destination.data());
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(16);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(format, components);
+        const std::vector<uint32_t> spirv = recompile_compute(
+            image_copy_2d, std::size(image_copy_2d), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const bool typed = !spirv.empty() && report.ok() && report.descriptors.size() == 2 &&
+            std::all_of(report.descriptors.begin(), report.descriptors.end(),
+                        [&](const SpirvDescriptorBinding& descriptor) {
+                            return descriptor.kind == SpirvDescriptorKind::StorageImage &&
+                                   descriptor.image_numeric_class == numeric_class &&
+                                   descriptor.storage_image_format == spirv_format;
+                        });
+        if (!typed) return std::tuple{false, destination, false, uint32_t{0}};
+        ComputeItem item;
+        item.spirv = spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(table);
+        item.launch.threads_x = W;
+        item.launch.local_x = W;
+        item.launch.groups_x = 1;
+        item.launch.threads_y = item.launch.threads_z = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = format == DataFormat::Float32 ? 0x59059fu
+            : format == DataFormat::Uint32 ? 0x5905a0u
+            : format == DataFormat::Uint16 ? 0x5905a1u : 0x5905a2u;
+        // The first sight of a write-only program poison-proves full coverage. The following
+        // ordered submit is the production state: the proven output may retain/export its exact
+        // typed image to the immediately following graphics consumer.
+        const bool coverage_proven =
+            prosper::frontend::execute_live_compute_items({item});
+        item.dispatch_index = format == DataFormat::Float32 ? 50u
+            : format == DataFormat::Uint32 ? 51u
+            : format == DataFormat::Uint16 ? 52u : 53u;
+        item.command_order = 10;
+        DrawItem consumer;
+        consumer.draw_index = format == DataFormat::Float32 ? 60u
+            : format == DataFormat::Uint32 ? 61u
+            : format == DataFormat::Uint16 ? 62u : 63u;
+        consumer.command_order = 20;
+        bool imported = false;
+        uint32_t imported_format = 0;
+        const OrderedSubmitResult ordered = execute_ordered_items(
+            {{SubmitOperationKind::Dispatch, item.dispatch_index, item.command_order},
+             {SubmitOperationKind::Draw, consumer.draw_index, consumer.command_order}},
+            {consumer}, {item},
+            [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                ShaderResource sampled = table.resources.back();
+                sampled.cls = ResourceClass::Texture;
+                if (sampled_format != DataFormat::Unknown)
+                    sampled.format = sampled_format;
+                prosper::frontend::LiveComputeImageImport compute_import;
+                imported = prosper::frontend::import_live_compute_storage_image(
+                    sampled, sampled.size, compute_import) && compute_import.valid();
+                if (imported) imported_format = compute_import.native_format;
+                return RenderedFrame{};
+            },
+            [&](const std::vector<ComputeItem>& items) {
+                return prosper::frontend::execute_live_compute_items(items);
+            },
+            1, 1);
+        return std::tuple{
+            coverage_proven && ordered.compute_executed,
+            destination, imported, imported_format};
+    };
+    {
+        static const uint32_t fill_r32_2d[] = {
+            0x7e080300u,                         // v4 = x
+            0x7e0a0280u,                         // v5 = y = 0
+            0x7e0002f2u,                         // v0 = 1.0f
+            0xf0200108u, 0x00020004u,            // IMAGE_STORE x at (v4,v5)
+            0xbf810000u,
+        };
+        std::vector<uint32_t> destination(W, 0xdeadbeefu);
+        ShaderResource output{};
+        output.cls = ResourceClass::StorageImage;
+        output.img_dim = 1;
+        output.binding = 5;
+        output.sgpr_base = 8;
+        output.format = DataFormat::Float32;
+        output.num_components = 1;
+        output.width = W;
+        output.height = output.depth = 1;
+        output.gpu_addr = reinterpret_cast<uint64_t>(destination.data());
+        output.size = static_cast<uint32_t>(destination.size() * sizeof(uint32_t));
+        ShaderResourceTable table;
+        table.resources.push_back(output);
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(16);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Float32, 1);
+        const std::vector<uint32_t> spirv = recompile_compute(
+            fill_r32_2d, std::size(fill_r32_2d), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const SpirvDescriptorBinding* binding =
+            find_spirv_descriptor_binding(report, 0, output.binding);
+        // Native float storage keeps the SPIR-V image format Unknown and carries the exact
+        // R32_SFLOAT choice in the resource/device contract. That preserves the existing
+        // formatless float shader ABI; the imported VkFormat assertion below pins the concrete
+        // device image separately.
+        CHECK(!spirv.empty() && report.ok() && binding && binding->storage_float &&
+                  binding->image_numeric_class == SpirvImageNumericClass::Float &&
+                  binding->storage_image_format == 0u,
+              "R32_SFLOAT fill reflects native float storage");
+        if (!spirv.empty() && report.ok() && binding && binding->storage_float) {
+            ComputeItem item;
+            item.spirv = spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(table);
+            item.launch.threads_x = W;
+            item.launch.local_x = W;
+            item.launch.groups_x = 1;
+            item.launch.threads_y = item.launch.threads_z = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = 0x59059fu;
+            const bool coverage_proven =
+                prosper::frontend::execute_live_compute_items({item});
+            item.dispatch_index = 50;
+            item.command_order = 10;
+            DrawItem consumer;
+            consumer.draw_index = 60;
+            consumer.command_order = 20;
+            bool imported = false;
+            const OrderedSubmitResult ordered = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, item.dispatch_index, item.command_order},
+                 {SubmitOperationKind::Draw, consumer.draw_index, consumer.command_order}},
+                {consumer}, {item},
+                [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                    ShaderResource sampled = output;
+                    sampled.cls = ResourceClass::Texture;
+                    prosper::frontend::LiveComputeImageImport compute_import;
+                    imported = prosper::frontend::import_live_compute_storage_image(
+                        sampled, sampled.size, compute_import) && compute_import.valid() &&
+                        compute_import.native_format == 100u &&
+                        compute_import.producer_command_order == item.command_order;
+                    return RenderedFrame{};
+                },
+                [&](const std::vector<ComputeItem>& items) {
+                    return prosper::frontend::execute_live_compute_items(items);
+                },
+                1, 1);
+            CHECK(coverage_proven && ordered.compute_executed &&
+                      std::all_of(destination.begin(), destination.end(),
+                                  [](uint32_t value) { return value == 0x3f800000u; }),
+                  "typed R32_SFLOAT fill executes and writes every finite value exactly");
+            CHECK(imported,
+                  "same-submit graphics consumer leases the exact typed R32_SFLOAT result");
+        }
+    }
+    {
+        std::vector<uint8_t> source(W * sizeof(uint32_t));
+        for (uint32_t x = 0; x < W; ++x) {
+            const uint32_t value = 0xf0120000u ^ (x * 0x1020304u);
+            std::memcpy(source.data() + x * sizeof(value), &value, sizeof(value));
+        }
+        const auto [executed, destination, imported, imported_format] = run_native_typed_copy(
+            DataFormat::Uint32, kSpirvImageFormatR32ui, SpirvImageNumericClass::Uint,
+            1, sizeof(uint32_t), source);
+        CHECK(executed && destination == source,
+              "typed R32_UINT storage copy reflects and executes byte-exactly");
+        CHECK(imported && imported_format == 98u, // VK_FORMAT_R32_UINT
+              "same-submit graphics consumer leases the exact typed R32_UINT result");
+    }
+    {
+        std::vector<uint8_t> source(W * sizeof(uint16_t));
+        for (uint32_t x = 0; x < W; ++x) {
+            const uint16_t value = static_cast<uint16_t>(0xf000u ^ (x * 0x123u));
+            std::memcpy(source.data() + x * sizeof(value), &value, sizeof(value));
+        }
+        const auto [executed, destination, imported, imported_format] = run_native_typed_copy(
+            DataFormat::Uint16, kSpirvImageFormatR16ui, SpirvImageNumericClass::Uint,
+            1, sizeof(uint16_t), source);
+        CHECK(executed && destination == source,
+              "typed R16_UINT storage copy reflects and executes byte-exactly");
+        CHECK(imported && imported_format == 74u, // VK_FORMAT_R16_UINT
+              "same-submit graphics consumer leases the exact typed R16_UINT result");
+        const auto [alias_executed, alias_destination, alias_imported, alias_format] =
+            run_native_typed_copy(DataFormat::Uint16, kSpirvImageFormatR16ui,
+                                  SpirvImageNumericClass::Uint, 1,
+                                  sizeof(uint16_t), source, DataFormat::Unorm16);
+        CHECK(alias_executed && alias_destination == source,
+              "typed R16_UINT storage remains byte-exact for an R16_UNORM graphics consumer");
+        CHECK(alias_imported && alias_format == 70u, // VK_FORMAT_R16_UNORM
+              "same-submit R16_UNORM consumer leases a mutable view of the exact R16_UINT result");
+    }
+    {
+        // GTA V writes a six-layer R16_UINT DIM=2D_ARRAY shadow allocation, then samples the same
+        // bytes through a DIM=CUBE descriptor. The graphics recompiler's established cube ABI is a
+        // vertically stacked 2D image, so import must preserve the exact producer identity while
+        // explicitly requesting a six-layer device-local stack copy.
+        constexpr uint32_t layers = 6;
+        static const uint32_t fill_r16_2d_array[] = {
+            0x7e080300u,                         // v4 = x
+            0x7e0a0301u,                         // v5 = y
+            0x7e0c0302u,                         // v6 = array layer
+            0x7e000302u,                         // v0 = layer value
+            0xf0200128u, 0x00020004u,            // IMAGE_STORE x at (v4,v5,v6), DIM=2D_ARRAY
+            0xbf810000u,
+        };
+        const size_t layer_bytes = W * sizeof(uint16_t);
+        std::vector<uint8_t> destination(layer_bytes * layers, 0xa5);
+        ShaderResource output{};
+        output.cls = ResourceClass::StorageImage;
+        output.img_dim = 5;
+        output.binding = 5;
+        output.sgpr_base = 8;
+        output.format = DataFormat::Uint16;
+        output.num_components = 1;
+        output.width = W;
+        output.height = 1;
+        output.depth = layers;
+        output.gpu_addr = reinterpret_cast<uint64_t>(destination.data());
+        output.size = static_cast<uint32_t>(destination.size());
+        output.linear_row_pitch_bytes = static_cast<uint32_t>(layer_bytes);
+        output.layer_stride_bytes = static_cast<uint32_t>(layer_bytes);
+        ShaderResourceTable table;
+        table.resources.push_back(output);
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(16);
+        config.local_x = W;
+        config.local_y = 1;
+        config.local_z = layers;
+        config.tidig_comp_cnt = 2;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Uint16, 1);
+        const std::vector<uint32_t> spirv = recompile_compute(
+            fill_r16_2d_array, std::size(fill_r16_2d_array), &table, config);
+        const DescriptorValidationReport report = validate_spirv_descriptor_interface(
+            spirv, &table, 0, SpirvShaderStage::Compute, false);
+        const SpirvDescriptorBinding* binding =
+            find_spirv_descriptor_binding(report, 0, output.binding);
+        CHECK(!spirv.empty() && report.ok() && binding && binding->image_arrayed &&
+                  binding->image_numeric_class == SpirvImageNumericClass::Uint &&
+                  binding->storage_image_format == kSpirvImageFormatR16ui,
+              "six-layer R16 producer reflects exact arrayed typed storage");
+        if (!spirv.empty() && report.ok() && binding) {
+            ComputeItem item;
+            item.spirv = spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(table);
+            item.launch.threads_x = W;
+            item.launch.threads_y = 1;
+            item.launch.threads_z = layers;
+            item.launch.local_x = W;
+            item.launch.local_y = 1;
+            item.launch.local_z = layers;
+            item.launch.groups_x = item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = 0x5905a3u;
+            const bool coverage_proven = prosper::frontend::execute_live_compute_items({item});
+            item.dispatch_index = 54;
+            item.command_order = 10;
+            DrawItem consumer;
+            consumer.draw_index = 64;
+            consumer.command_order = 20;
+            bool imported = false;
+            bool normalized_imported = false;
+            bool mismatches_rejected = false;
+            const OrderedSubmitResult ordered = execute_ordered_items(
+                {{SubmitOperationKind::Dispatch, item.dispatch_index, item.command_order},
+                 {SubmitOperationKind::Draw, consumer.draw_index, consumer.command_order}},
+                {consumer}, {item},
+                [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                    ShaderResource cube = output;
+                    cube.cls = ResourceClass::Texture;
+                    cube.img_dim = 3;
+                    prosper::frontend::LiveComputeImageImport compute_import;
+                    imported = prosper::frontend::import_live_compute_storage_image(
+                        cube, cube.size, compute_import) && compute_import.valid() &&
+                        compute_import.native_format == 74u &&
+                        compute_import.vertical_stack_layers == layers &&
+                        compute_import.producer_command_order == item.command_order;
+                    ShaderResource normalized_cube = cube;
+                    normalized_cube.format = DataFormat::Unorm16;
+                    CHECK(prosper::frontend::live_compute_graphics_import_guest_bytes(
+                              normalized_cube, layer_bytes) == normalized_cube.size,
+                          "R16 cube import identity covers all six faces, not one decoded face");
+                    prosper::frontend::LiveComputeImageImport normalized_import;
+                    normalized_imported =
+                        prosper::frontend::import_live_compute_storage_image(
+                            normalized_cube, normalized_cube.size, normalized_import) &&
+                        normalized_import.valid() && normalized_import.native_format == 70u &&
+                        normalized_import.vertical_stack_layers == layers &&
+                        normalized_import.producer_command_order == item.command_order;
+                    ShaderResource mismatch = cube;
+                    --mismatch.depth;
+                    prosper::frontend::LiveComputeImageImport rejected;
+                    const bool depth_rejected =
+                        !prosper::frontend::import_live_compute_storage_image(
+                            mismatch, cube.size, rejected);
+                    mismatch = cube;
+                    mismatch.layer_stride_bytes += sizeof(uint16_t);
+                    const bool stride_rejected =
+                        !prosper::frontend::import_live_compute_storage_image(
+                            mismatch, cube.size, rejected);
+                    mismatches_rejected = depth_rejected && stride_rejected;
+                    return RenderedFrame{};
+                },
+                [&](const std::vector<ComputeItem>& items) {
+                    return prosper::frontend::execute_live_compute_items(items);
+                },
+                1, 1);
+            CHECK(coverage_proven && ordered.compute_executed && imported,
+                  "same-submit cube consumer leases exact six-layer R16 storage for GPU stacking");
+            CHECK(normalized_imported,
+                  "R16_UNORM cube consumer leases the mutable exact R16_UINT array producer");
+            CHECK(mismatches_rejected,
+                  "cube-array import rejects depth and layer-stride identity mismatches");
+        }
+    }
+    {
+        std::vector<uint8_t> source(W);
+        for (uint32_t x = 0; x < W; ++x)
+            source[x] = static_cast<uint8_t>(x * 53u + 7u);
+        const auto [executed, destination, imported, imported_format] = run_native_typed_copy(
+            DataFormat::Uint8, kSpirvImageFormatR8ui, SpirvImageNumericClass::Uint,
+            1, 1, source);
+        CHECK(executed && destination == source,
+              "typed R8_UINT storage copy reflects and executes byte-exactly");
+        CHECK(imported && imported_format == 13u, // VK_FORMAT_R8_UINT
+              "same-submit graphics consumer leases the exact typed R8_UINT result");
+        const auto [alias_executed, alias_destination, alias_imported, alias_format] =
+            run_native_typed_copy(DataFormat::Uint8, kSpirvImageFormatR8ui,
+                                  SpirvImageNumericClass::Uint, 1, 1, source,
+                                  DataFormat::Unorm8);
+        CHECK(alias_executed && alias_destination == source,
+              "typed R8_UINT storage remains byte-exact for an R8_UNORM graphics consumer");
+        CHECK(alias_imported && alias_format == 9u, // VK_FORMAT_R8_UNORM
+              "same-submit R8_UNORM consumer leases a mutable view of the exact R8_UINT result");
+    }
+    {
+        std::vector<uint8_t> source(W * 4u);
+        for (uint32_t x = 0; x < W; ++x) {
+            source[x * 4u + 0u] = static_cast<uint8_t>(x * 53u + 7u);
+            source[x * 4u + 1u] = static_cast<uint8_t>(x * 31u + 11u);
+            source[x * 4u + 2u] = static_cast<uint8_t>(x * 17u + 13u);
+            source[x * 4u + 3u] = static_cast<uint8_t>(255u - x * 3u);
+        }
+        const auto [executed, destination, imported, imported_format] = run_native_typed_copy(
+            DataFormat::Uint8, kSpirvImageFormatRgba8ui, SpirvImageNumericClass::Uint,
+            4, 4, source);
+        CHECK(executed && destination == source,
+              "typed RGBA8_UINT storage copy reflects and executes byte-exactly");
+        CHECK(imported && imported_format == 41u, // VK_FORMAT_R8G8B8A8_UINT
+              "same-submit graphics consumer leases the exact typed RGBA8_UINT result");
+    }
+    {
+        static const uint32_t store_low_byte_2d[] = {
+            0x7e080300u,                         // v4 = x
+            0x7e0002ffu, 0x00001234u,            // v0 = value; guest Uint8 store keeps low byte
+            0x7e0a0280u,                         // v5 = y = 0
+            0xf0200108u, 0x00020004u,            // IMAGE_STORE x to binding 5
+            0xbf810000u,
+        };
+        std::vector<uint8_t> destination(W, 0xa5);
+        ShaderResourceTable table;
+        ShaderResource output{};
+        output.cls = ResourceClass::StorageImage;
+        output.img_dim = 1;
+        output.binding = 5;
+        output.sgpr_base = 8;
+        output.format = DataFormat::Uint8;
+        output.num_components = 1;
+        output.width = W;
+        output.height = output.depth = 1;
+        output.gpu_addr = reinterpret_cast<uint64_t>(destination.data());
+        output.size = W;
+        table.resources.push_back(output);
+        ComputeShaderConfig config;
+        config.user_sgprs.resize(16);
+        config.local_x = W;
+        config.local_y = config.local_z = 1;
+        config.tidig_comp_cnt = 0;
+        config.native_storage_format_support =
+            native_storage_format_support_bit(DataFormat::Uint8, 1);
+        const std::vector<uint32_t> spirv = recompile_compute(
+            store_low_byte_2d, std::size(store_low_byte_2d), &table, config);
+        ComputeItem item;
+        item.spirv = spirv;
+        item.resources = std::make_shared<ShaderResourceTable>(table);
+        item.launch.threads_x = W;
+        item.launch.local_x = W;
+        item.launch.groups_x = 1;
+        item.launch.threads_y = item.launch.threads_z = 1;
+        item.launch.local_y = item.launch.local_z = 1;
+        item.launch.groups_y = item.launch.groups_z = 1;
+        item.code_addr = 0x5905a3u;
+        CHECK(!spirv.empty() && prosper::frontend::execute_live_compute_items({item}) &&
+                  std::all_of(destination.begin(), destination.end(),
+                              [](uint8_t value) { return value == 0x34u; }),
+              "typed R8_UINT storage truncates a 32-bit guest value to its exact low byte");
     }
 
     // GTA V gameplay's exact IMAGE_LOAD_MIP / IMAGE_STORE_MIP packets. The live backend has one
@@ -3247,6 +3706,93 @@ int main() {
         CHECK(live_dst != stale_rtt, "renderer RTT import does not use stale guest backing");
     }
 
+    // GTA V Fidelity retains single-channel R16F post-process targets in the renderer and later
+    // samples them from compute. The CPU fallback must bind the snapshot at its native texel width:
+    // treating R16F as the historical RGBA8 fallback doubled the memcpy byte count, read past the
+    // immutable snapshot, and crashed Windows in ucrtbase!memmove before gameplay. RG16F has the
+    // same byte count as RGBA8 but still needs its native numeric interpretation, so cover both.
+    auto run_live_narrow_float16 = [&](uint32_t components,
+                                       LiveTargetPixelFormat pixel_format) {
+        const uint32_t source_bytes = W * components * sizeof(uint16_t);
+        std::vector<uint8_t> stale(source_bytes, 0);
+        auto live = std::make_shared<std::vector<uint8_t>>(source_bytes);
+        std::vector<uint8_t> destination(W * 4, 0xee);
+        for (uint32_t texel = 0; texel < W; ++texel) {
+            for (uint32_t channel = 0; channel < components; ++channel) {
+                const float value = ((texel >> channel) & 1u) ? 1.0f : 0.0f;
+                const uint16_t half = float_to_half(value);
+                std::memcpy(live->data() +
+                                (texel * components + channel) * sizeof(half),
+                            &half, sizeof(half));
+            }
+        }
+        ShaderResourceTable table = live_rt;
+        for (ShaderResource& resource : table.resources) {
+            if (resource.binding == 4) {
+                resource.cls = ResourceClass::Texture;
+                resource.format = DataFormat::Float16;
+                resource.num_components = components;
+                resource.width = W;
+                resource.height = resource.depth = 1;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(stale.data());
+                resource.size = source_bytes;
+            } else if (resource.binding == 5) {
+                resource.cls = ResourceClass::StorageImage;
+                resource.format = DataFormat::Unorm8;
+                resource.num_components = 4;
+                resource.width = W;
+                resource.height = resource.depth = 1;
+                resource.gpu_addr = reinterpret_cast<uint64_t>(destination.data());
+                resource.size = static_cast<uint32_t>(destination.size());
+            }
+        }
+        const uint64_t address = reinterpret_cast<uint64_t>(stale.data());
+        set_live_target_query([address](uint64_t candidate) { return candidate == address; });
+        set_live_target_reader(
+            [address, live, pixel_format, W](uint64_t candidate, LiveTargetSnapshot& snapshot) {
+                if (candidate != address) return false;
+                snapshot.width = W;
+                snapshot.height = 1;
+                snapshot.format = pixel_format;
+                snapshot.pixels = live;
+                return true;
+            });
+        const std::vector<uint32_t> spirv = recompile_valu(
+            image_copy_2d, std::size(image_copy_2d), 1, 0, &table);
+        CHECK(!spirv.empty(), components == 1
+              ? "R16F renderer RTT sampled-image copy kernel recompiles"
+              : "RG16F renderer RTT sampled-image copy kernel recompiles");
+        bool executed = false;
+        if (!spirv.empty()) {
+            ComputeItem item;
+            item.spirv = spirv;
+            item.resources = std::make_shared<ShaderResourceTable>(table);
+            item.launch.threads_x = W;
+            item.launch.local_x = 64;
+            item.launch.groups_x = 1;
+            item.launch.local_y = item.launch.local_z = 1;
+            item.launch.groups_y = item.launch.groups_z = 1;
+            item.code_addr = components == 1 ? 0x5905b0 : 0x5905b1;
+            executed = prosper::frontend::execute_live_compute_items({item});
+        }
+        CHECK(executed, components == 1
+              ? "live backend samples an R16F renderer RTT without widening its upload"
+              : "live backend samples an RG16F renderer RTT at native width");
+        bool exact = executed;
+        for (uint32_t texel = 0; texel < W && exact; ++texel) {
+            exact &= destination[texel * 4 + 0] == ((texel & 1u) ? 255u : 0u);
+            exact &= destination[texel * 4 + 1] ==
+                (components == 2 && (texel & 2u) ? 255u : 0u);
+            exact &= destination[texel * 4 + 2] == 0u;
+            exact &= destination[texel * 4 + 3] == 255u;
+        }
+        CHECK(exact, components == 1
+              ? "R16F renderer snapshot preserves R and Vulkan missing-channel defaults"
+              : "RG16F renderer snapshot preserves RG and Vulkan missing-channel defaults");
+    };
+    run_live_narrow_float16(1, LiveTargetPixelFormat::R16Float);
+    run_live_narrow_float16(2, LiveTargetPixelFormat::Rg16Float);
+
     // A renderer target can become a writable storage image before its pixels have been materialized
     // in guest RAM. Seed the dispatch from the immutable renderer snapshot, modify row zero, and
     // prove writeback preserves every untouched row while publishing a cache-invalidation write.
@@ -3479,6 +4025,8 @@ int main() {
           "tiled R32_UINT sampled values reach storage writeback byte-exactly");
     CHECK(sampled_uint_roundtrip(DataFormat::Uint16, 4, 8, 0x590164),
           "tiled RGBA16_UINT sampled values reach storage writeback byte-exactly");
+    CHECK(sampled_uint_roundtrip(DataFormat::Unorm2_10_10_10, 4, 4, 0x590210),
+          "tiled R10G10B10A2_UNORM sampled words reach storage writeback bit-exactly");
 
     // GPU captures preserve descriptor addresses but materialize resource bytes in owned host
     // arrays. Warm replay must retain those sampled images just like the live guest-backed path,
@@ -3706,6 +4254,186 @@ int main() {
                       journal_imported,
                   "same-submit journal authorizes the first retained compute-image consumer");
 
+            // GTA V's transition depth-like surface is written through R32_UINT storage and then
+            // sampled as R32_SFLOAT. The guest allocation is one exact 32-bit word per texel; only
+            // the consumer view changes its numeric interpretation. Prove the integer producer can
+            // be leased by the float descriptor without a guest readback/detile/upload round trip.
+            std::vector<uint32_t> uint_alias_guest(W, 0x3f000000u);
+            ShaderResourceTable uint_alias_rt;
+            ShaderResource uint_alias_dst = fdst;
+            uint_alias_dst.format = DataFormat::Uint32;
+            uint_alias_dst.num_components = 1;
+            uint_alias_dst.gpu_addr = reinterpret_cast<uint64_t>(uint_alias_guest.data());
+            uint_alias_dst.size = static_cast<uint32_t>(uint_alias_guest.size() * sizeof(uint32_t));
+            uint_alias_rt.resources.push_back(uint_alias_dst);
+            ComputeShaderConfig uint_alias_config = fill_config;
+            uint_alias_config.native_storage_format_support =
+                native_storage_format_support_bit(DataFormat::Uint32, 1);
+            const std::vector<uint32_t> uint_alias_spirv = recompile_compute(
+                fill_1d, std::size(fill_1d), &uint_alias_rt, uint_alias_config);
+            const DescriptorValidationReport uint_alias_report =
+                validate_spirv_descriptor_interface(
+                    uint_alias_spirv, &uint_alias_rt, 0, SpirvShaderStage::Compute, false);
+            const SpirvDescriptorBinding* uint_alias_binding =
+                find_spirv_descriptor_binding(
+                    uint_alias_report, 0, uint_alias_dst.binding);
+            CHECK(!uint_alias_spirv.empty() && uint_alias_report.ok() && uint_alias_binding &&
+                      uint_alias_binding->image_numeric_class == SpirvImageNumericClass::Uint &&
+                      uint_alias_binding->storage_image_format == kSpirvImageFormatR32ui,
+                  "R32_UINT alias producer retains an exact typed storage contract");
+            if (!uint_alias_spirv.empty() && uint_alias_report.ok() && uint_alias_binding) {
+                ComputeItem uint_alias_item = it;
+                uint_alias_item.spirv = uint_alias_spirv;
+                uint_alias_item.resources =
+                    std::make_shared<ShaderResourceTable>(uint_alias_rt);
+                uint_alias_item.code_addr = 0x1122f13du;
+                uint_alias_item.dispatch_index = 35;
+                uint_alias_item.command_order = 10;
+                CHECK(prosper::frontend::execute_live_compute_items({uint_alias_item}),
+                      "R32_UINT alias producer proves complete write coverage");
+                CHECK(prosper::frontend::execute_live_compute_items({uint_alias_item}),
+                      "R32_UINT alias producer repeats after its full-coverage proof");
+                ShaderResource cross_submit_float_alias = uint_alias_dst;
+                cross_submit_float_alias.cls = ResourceClass::Texture;
+                cross_submit_float_alias.format = DataFormat::Float32;
+                prosper::frontend::LiveComputeImageImport cross_submit_import;
+                const bool cross_submit_imported =
+                    prosper::frontend::import_live_compute_storage_image(
+                        cross_submit_float_alias, uint_alias_dst.size,
+                        cross_submit_import) && cross_submit_import.valid();
+#if defined(_WIN32)
+                CHECK(cross_submit_imported,
+                      "Windows exact guest mirror authorizes a cross-submit R32_UINT-to-R32_SFLOAT import");
+#else
+                CHECK(!cross_submit_imported,
+                      "Linux does not replace journal/write-watch authority with byte equality");
+#endif
+                cross_submit_import = {};
+                const uint32_t uint_alias_word = uint_alias_guest[1];
+                uint_alias_guest[1] ^= 1u;
+                prosper::frontend::LiveComputeImageImport rejected_cross_submit_import;
+                CHECK(!prosper::frontend::import_live_compute_storage_image(
+                          cross_submit_float_alias, uint_alias_dst.size,
+                          rejected_cross_submit_import),
+                      "an unnotified CPU write rejects the exact cross-submit compute image");
+                uint_alias_guest[1] = uint_alias_word;
+                bool uint_float_imported = false;
+                DrawItem uint_alias_consumer;
+                uint_alias_consumer.draw_index = 49;
+                uint_alias_consumer.command_order = 20;
+                const OrderedSubmitResult uint_alias_result = execute_ordered_items(
+                    {{SubmitOperationKind::Dispatch, uint_alias_item.dispatch_index,
+                      uint_alias_item.command_order},
+                     {SubmitOperationKind::Draw, uint_alias_consumer.draw_index,
+                      uint_alias_consumer.command_order}},
+                    {uint_alias_consumer}, {uint_alias_item},
+                    [&](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                        ShaderResource sampled_alias = uint_alias_dst;
+                        sampled_alias.cls = ResourceClass::Texture;
+                        sampled_alias.format = DataFormat::Float32;
+                        prosper::frontend::LiveComputeImageImport compute_import;
+                        uint_float_imported =
+                            prosper::frontend::import_live_compute_storage_image(
+                                sampled_alias, uint_alias_dst.size, compute_import) &&
+                            compute_import.valid() && compute_import.native_format == 100u;
+                        return RenderedFrame{};
+                    },
+                    [&](const std::vector<ComputeItem>& items) {
+                        return prosper::frontend::execute_live_compute_items(items);
+                    },
+                    1, 1);
+                CHECK(uint_alias_result.compute_executed &&
+                          uint_alias_result.render_spans == 1 && uint_float_imported,
+                      "R32_UINT storage result imports directly through an R32_SFLOAT graphics view");
+
+                // The next GTA V pass consumes the same numeric-view alias from compute, not
+                // graphics. Keep the sampled destination separate and prove that the Float32
+                // descriptor is seeded by a device-local copy of the retained Uint32 producer.
+                // Exact output bits are the oracle: R32_UINT -> R32_SFLOAT must not numerically
+                // convert the producer words on the way to the sampled image.
+                std::vector<uint32_t> uint_alias_copy_guest(W, 0xdeadbeefu);
+                ShaderResourceTable uint_alias_consumer_rt;
+                ShaderResource uint_alias_sampled = uint_alias_dst;
+                uint_alias_sampled.cls = ResourceClass::Texture;
+                uint_alias_sampled.format = DataFormat::Float32;
+                uint_alias_sampled.binding = 4;
+                uint_alias_sampled.sgpr_base = 0;
+                uint_alias_sampled.swizzle[0] = 4;
+                uint_alias_sampled.swizzle[1] = 5;
+                uint_alias_sampled.swizzle[2] = 6;
+                uint_alias_sampled.swizzle[3] = 7;
+                uint_alias_consumer_rt.resources.push_back(uint_alias_sampled);
+                ShaderResource uint_alias_copy_dst = uint_alias_sampled;
+                uint_alias_copy_dst.cls = ResourceClass::StorageImage;
+                uint_alias_copy_dst.binding = 5;
+                uint_alias_copy_dst.sgpr_base = 8;
+                uint_alias_copy_dst.gpu_addr =
+                    reinterpret_cast<uint64_t>(uint_alias_copy_guest.data());
+                uint_alias_consumer_rt.resources.push_back(uint_alias_copy_dst);
+                ComputeShaderConfig uint_alias_consumer_config = fill_config;
+                uint_alias_consumer_config.native_storage_format_support =
+                    native_storage_format_support_bit(DataFormat::Float32, 1);
+                const std::vector<uint32_t> uint_alias_consumer_spirv = recompile_compute(
+                    image_copy_2d, std::size(image_copy_2d),
+                    &uint_alias_consumer_rt, uint_alias_consumer_config);
+                CHECK(!uint_alias_consumer_spirv.empty(),
+                      "R32_SFLOAT compute alias consumer recompiles");
+                if (!uint_alias_consumer_spirv.empty()) {
+                    ComputeItem uint_alias_consumer = uint_alias_item;
+                    uint_alias_consumer.spirv = uint_alias_consumer_spirv;
+                    uint_alias_consumer.resources =
+                        std::make_shared<ShaderResourceTable>(uint_alias_consumer_rt);
+                    uint_alias_consumer.code_addr = 0x1122f13eu;
+                    uint_alias_consumer.dispatch_index = 36;
+                    uint_alias_consumer.command_order = 20;
+                    const uint64_t cross_submit_seeds_before =
+                        prosper::frontend::live_compute_storage_transfer_seeds();
+                    CHECK(prosper::frontend::execute_live_compute_items(
+                              {uint_alias_consumer}) &&
+                              uint_alias_copy_guest == uint_alias_guest,
+                          "cross-submit R32_SFLOAT compute consumer preserves exact producer bits");
+#if defined(_WIN32)
+                    CHECK(!native_2d_compute_transfer_available ||
+                              prosper::frontend::live_compute_storage_transfer_seeds() >
+                                  cross_submit_seeds_before,
+                          "Windows exact guest mirror seeds the cross-submit compute consumer on-GPU");
+#else
+                    CHECK(prosper::frontend::live_compute_storage_transfer_seeds() ==
+                              cross_submit_seeds_before,
+                          "Linux cross-submit consumer keeps the authority-unknown image on guest fallback");
+#endif
+                    const uint64_t uint_alias_seeds_before =
+                        prosper::frontend::live_compute_storage_transfer_seeds();
+                    const OrderedSubmitResult uint_alias_compute_result =
+                        execute_ordered_items(
+                            {{SubmitOperationKind::Dispatch,
+                              uint_alias_item.dispatch_index,
+                              uint_alias_item.command_order},
+                             {SubmitOperationKind::Dispatch,
+                              uint_alias_consumer.dispatch_index,
+                              uint_alias_consumer.command_order}},
+                            {}, {uint_alias_item, uint_alias_consumer},
+                            [](const std::vector<DrawItem>&, uint32_t, uint32_t) {
+                                return RenderedFrame{};
+                            },
+                            [&](const std::vector<ComputeItem>& items) {
+                                return prosper::frontend::execute_live_compute_items(items);
+                            },
+                            1, 1);
+                    const uint64_t uint_alias_seeds_after =
+                        prosper::frontend::live_compute_storage_transfer_seeds();
+                    CHECK(uint_alias_compute_result.compute_executed &&
+                              uint_alias_copy_guest == uint_alias_guest,
+                          "R32_UINT producer to R32_SFLOAT compute consumer preserves exact bits");
+                    CHECK(!native_2d_compute_transfer_available ||
+                              uint_alias_seeds_after > uint_alias_seeds_before,
+                          "R32_UINT producer seeds R32_SFLOAT compute consumer on-GPU");
+                    CHECK(native_2d_compute_transfer_available ||
+                              uint_alias_seeds_after == uint_alias_seeds_before,
+                          "disabled native transfer keeps the numeric-view alias on the guest fallback");
+                }
+            }
+
             // Syberia's save-warning pass dispatches eleven shrinking rectangles over one native
             // Float32x1 atlas in a single ordered guest submit. Its producer uses a real one-layer
             // DIM=2D_ARRAY storage image while the next dispatch samples an ordinary DIM=2D view of
@@ -3717,9 +4445,32 @@ int main() {
             // cannot silently turn the production check into the guest fallback.
             CHECK(prosper::frontend::compute_native_2d_transfer_format_compatible(
                       DataFormat::Float32, 1) &&
+                      prosper::frontend::compute_native_2d_transfer_format_compatible(
+                          DataFormat::Float10_11_11, 3) &&
                       !prosper::frontend::compute_native_2d_transfer_format_compatible(
                           DataFormat::Float16, 1),
-                  "native 2D transfer candidate requires exact sampled/storage format equality");
+                  "native 2D transfer admits exact formats and packed R11 bit-copy compatibility");
+            CHECK(prosper::frontend::live_compute_graphics_import_native_format(
+                      DataFormat::Float32, 1) == 100u && // VK_FORMAT_R32_SFLOAT
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Unorm8, 1) == 9u && // VK_FORMAT_R8_UNORM
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Unorm8, 4) == 37u && // VK_FORMAT_R8G8B8A8_UNORM
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Float16, 1) == 76u && // VK_FORMAT_R16_SFLOAT
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Float16, 2) == 83u && // VK_FORMAT_R16G16_SFLOAT
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Float16, 4) == 97u && // VK_FORMAT_R16G16B16A16_SFLOAT
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Float10_11_11, 3) == 122u &&
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Unorm16, 1) == 70u && // VK_FORMAT_R16_UNORM
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Uint8, 4) == 41u &&
+                      prosper::frontend::live_compute_graphics_import_native_format(
+                          DataFormat::Unorm8, 3) == 0u,
+                  "graphics import policy includes exact FP16/RGBA8 post-FX outputs and rejects unsupported views");
             static const uint32_t transfer_fill_2d_array[] = {
                 0x7E080300u,             // v4 = x coordinate
                 0x7E0A0280u,             // v5 = y = 0
@@ -4132,21 +4883,34 @@ int main() {
             const uint64_t cold_result_snapshots_after =
                 prosper::frontend::live_compute_image_result_snapshot_bytes();
             if (cold_storage_snapshot_deferral_enabled) {
+#if defined(_WIN32)
+                CHECK(cold_source_snapshots_after >=
+                          cold_source_snapshots_before + fill_guest_bytes,
+                      "Windows retains an exact guest mirror for a cold exportable target");
+#else
                 CHECK(cold_source_snapshots_after == cold_source_snapshots_before,
                       "deferring policy admits a cold proven-full target without a source copy");
+#endif
 
                 // A later standalone backend invocation has no same-submit journal authority. The
-                // first repeat therefore cannot trust the deferred source: it must take ordinary
-                // writeback and establish the exact baseline used by later source validation.
+                // first repeat uses either Windows' exact mirror or the platform write-watch/
+                // deferred-source path. Both remain collision-free and preserve the guest result.
                 const std::vector<uint8_t> cold_expected = cold_guest;
                 const uint64_t repeat_snapshots_before =
                     prosper::frontend::live_compute_storage_result_snapshot_bytes();
                 CHECK(prosper::frontend::execute_live_compute_items({cold_item}),
                       "first invalidated repeat repairs a deferred cold target");
+#if defined(_WIN32)
+                CHECK(cold_guest == cold_expected &&
+                          prosper::frontend::live_compute_storage_result_snapshot_bytes() ==
+                              repeat_snapshots_before,
+                      "Windows exact mirror authorizes the repeat without recopying its baseline");
+#else
                 CHECK(cold_guest == cold_expected &&
                           prosper::frontend::live_compute_storage_result_snapshot_bytes() >=
                               repeat_snapshots_before + fill_guest_bytes,
                       "first invalidated repeat establishes exact source authority");
+#endif
 
                 cold_guest[0] ^= 0xff;
                 CHECK(cold_guest != cold_expected,
@@ -4752,6 +5516,22 @@ int main() {
             consumer_item.command_order = 20;
             consumer_item.code_addr = native_capability_present ? 0x1790a119u : 0x1790b119u;
 
+            // Poison-prove the producer against an independent destination. The ordered handoff
+            // below must exercise the steady-state retained image, while the real LUT remains the
+            // old sentinel so the separately primed sampled cache is a meaningful stale positive.
+            std::vector<uint8_t> proof_guest = lut_guest;
+            ShaderResourceTable proof_rt = producer_rt;
+            proof_rt.resources.back().gpu_addr =
+                reinterpret_cast<uint64_t>(proof_guest.data());
+            ComputeItem proof_item = producer_item;
+            proof_item.resources = std::make_shared<ShaderResourceTable>(proof_rt);
+            proof_item.dispatch_index += 2000;
+            proof_item.command_order = 2;
+            CHECK(prosper::frontend::execute_live_compute_items({proof_item}),
+                  native_capability_present
+                      ? "native-capability packed R11 producer proves complete coverage"
+                      : "portable packed R11 producer proves complete coverage");
+
             // Prime the sampled-image cache with the old guest LUT. The ordered run must still see
             // the producer's new result; otherwise a first-use upload would accidentally make the
             // test green without exercising same-submit invalidation/authority.
@@ -4783,6 +5563,9 @@ int main() {
             std::array<uint32_t, 2> callback_dispatches = {UINT32_MAX, UINT32_MAX};
             size_t callback_count = 0;
             bool callbacks_ok = true;
+            bool packed_graphics_imported = false;
+            const uint64_t packed_transfer_seeds_before =
+                prosper::frontend::live_compute_storage_transfer_seeds();
             const OrderedSubmitResult submit = execute_ordered_items(
                 {{SubmitOperationKind::Dispatch, producer_item.dispatch_index,
                   producer_item.command_order},
@@ -4797,12 +5580,21 @@ int main() {
                     if (callback_count < callback_dispatches.size() && singleton)
                         callback_dispatches[callback_count] = items[0].dispatch_index;
                     ++callback_count;
-                    const bool ok = singleton &&
-                        prosper::frontend::execute_live_compute_items(items);
-                    callbacks_ok &= ok;
+                     const bool ok = singleton &&
+                         prosper::frontend::execute_live_compute_items(items);
+                     if (ok && items[0].dispatch_index == producer_item.dispatch_index) {
+                         prosper::frontend::LiveComputeImageImport graphics_import;
+                         packed_graphics_imported =
+                             prosper::frontend::import_live_compute_storage_image(
+                                 sampled_lut, lut_guest.size(), graphics_import) &&
+                             graphics_import.valid() && graphics_import.native_format == 122u;
+                     }
+                     callbacks_ok &= ok;
                     return ok;
                 },
                 1, 1);
+            const uint64_t packed_transfer_seeds_after =
+                prosper::frontend::live_compute_storage_transfer_seeds();
             CHECK(submit.compute_executed && callbacks_ok && callback_count == 2,
                   native_capability_present
                       ? "native-capability ordered submit executes both dispatches exactly once"
@@ -4812,6 +5604,20 @@ int main() {
                   native_capability_present
                       ? "native-capability submit preserves producer-before-consumer order"
                       : "portable submit preserves producer-before-consumer order");
+            CHECK(!native_2d_compute_transfer_available ||
+                      packed_transfer_seeds_after > packed_transfer_seeds_before,
+                  native_capability_present
+                      ? "native-capability packed R11 producer seeds sampled volume on-GPU"
+                      : "portable packed R11 producer seeds sampled volume on-GPU");
+            CHECK(native_2d_compute_transfer_available ||
+                      packed_transfer_seeds_after == packed_transfer_seeds_before,
+                  native_capability_present
+                      ? "disabled transfer keeps native-capability packed R11 on the guest fallback"
+                      : "disabled transfer keeps portable packed R11 on the guest fallback");
+            CHECK(!native_2d_compute_transfer_available || packed_graphics_imported,
+                  native_capability_present
+                      ? "native-capability packed R11 storage result exports to graphics on-GPU"
+                      : "portable packed R11 storage result exports to graphics on-GPU");
 
             std::vector<uint32_t> produced_packed(LUT_TEXELS, 0xDEADBEEFu);
             const bool produced_detiled = detile_volume(

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -353,9 +353,13 @@ int main() {
                                         LiveTargetPixelFormat::Rgba8Unorm, false) &&
           direct_sampled_rtt_compatible(DataFormat::Float16, 4,
                                         LiveTargetPixelFormat::Rgba16Float, false) &&
+          direct_sampled_rtt_compatible(DataFormat::Float16, 2,
+                                        LiveTargetPixelFormat::Rg16Float, false) &&
+          direct_sampled_rtt_compatible(DataFormat::Float16, 1,
+                                        LiveTargetPixelFormat::R16Float, false) &&
           direct_sampled_rtt_compatible(DataFormat::Float10_11_11, 3,
                                         LiveTargetPixelFormat::R11G11B10Float, false),
-          "renderer RTT direct bind accepts exact RGBA8, RGBA16F, and R11G11B10 views");
+          "renderer RTT direct bind accepts exact RGBA8, RG16F, RGBA16F, and R11G11B10 views");
     CHECK(!direct_sampled_rtt_compatible(DataFormat::Float16, 4,
                                          LiveTargetPixelFormat::Rgba8Unorm, true) &&
           !direct_sampled_rtt_compatible(DataFormat::Unorm8, 4,
@@ -381,6 +385,22 @@ int main() {
           !direct_sampled_rtt_compatible(DataFormat::Float32, 1,
                                          LiveTargetPixelFormat::R32Uint, true),
           "single-channel live RTT imports require an exact Vulkan sampled type");
+    using prosper::frontend::sampled_rtt_snapshot_byte_compatible;
+    CHECK(sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Uint32, 1, LiveTargetPixelFormat::R32Float) &&
+          sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Float32, 1, LiveTargetPixelFormat::R32Uint) &&
+          sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Uint32, 4, LiveTargetPixelFormat::Rgba32Float) &&
+          sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Float16, 2, LiveTargetPixelFormat::Rg16Float) &&
+          sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Float16, 1, LiveTargetPixelFormat::R16Float) &&
+          !sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Uint32, 1, LiveTargetPixelFormat::Rgba32Float) &&
+          !sampled_rtt_snapshot_byte_compatible(
+              DataFormat::Float16, 2, LiveTargetPixelFormat::R32Float),
+           "renderer RTT snapshots preserve exact-width float/integer bit aliases only");
     // A renderer-owned target is stored canonically as RGBA8 or RGBA16F, while a later compute
     // descriptor can alias it as packed R11G11B10. Reconstruct the descriptor-visible words rather
     // than sampling stale guest backing or dropping the dispatch.

--- a/prosper/tests/gpu/recompiler/test_game_compute.cpp
+++ b/prosper/tests/gpu/recompiler/test_game_compute.cpp
@@ -370,6 +370,17 @@ int main() {
           !direct_sampled_rtt_compatible(DataFormat::Unorm16, 2,
                                          LiveTargetPixelFormat::Rgba8Unorm, true),
           "float RGBA16-UNORM sampled values may reuse RGBA8 without widening texels");
+    CHECK(direct_sampled_rtt_compatible(DataFormat::Unorm8, 1,
+                                        LiveTargetPixelFormat::R8Unorm, true) &&
+          direct_sampled_rtt_compatible(DataFormat::Unorm8, 2,
+                                        LiveTargetPixelFormat::Rg8Unorm, true) &&
+          direct_sampled_rtt_compatible(DataFormat::Uint32, 1,
+                                        LiveTargetPixelFormat::R32Uint, false) &&
+          direct_sampled_rtt_compatible(DataFormat::Float32, 1,
+                                        LiveTargetPixelFormat::R32Float, true) &&
+          !direct_sampled_rtt_compatible(DataFormat::Float32, 1,
+                                         LiveTargetPixelFormat::R32Uint, true),
+          "single-channel live RTT imports require an exact Vulkan sampled type");
     // A renderer-owned target is stored canonically as RGBA8 or RGBA16F, while a later compute
     // descriptor can alias it as packed R11G11B10. Reconstruct the descriptor-visible words rather
     // than sampling stale guest backing or dropping the dispatch.
@@ -628,6 +639,80 @@ int main() {
                         spirv_descriptor_kind_name(issue.actual));
     }
     CHECK(report.ok(), "real compute descriptor interface validates");
+
+    // --- a partial workgroup that also uses a barrier -------------------------------------------
+    //
+    // The kernel above already ends in a partial workgroup (130 records launched as 3x64), and the
+    // divergent entry guard is what keeps its padded lanes from writing. Add one s_barrier and that
+    // guard becomes illegal: the padded invocations would skip the body, and with it the barrier
+    // their peers block on. Twelve of GTA V's compute dispatches were dropped for exactly this
+    // (`reason=partial-workgroup-barrier threads=1143x1x1 local=64x1x1`).
+    //
+    // The correct lowering already existed -- split the stream at its barriers, compile each
+    // barrier-free phase through the dispatcher's per-lane ACTIVE bit, and emit each barrier from
+    // the outer shell where every invocation reaches it. It was gated behind `branch_count > 2`,
+    // which excluded precisely the programs that satisfy its soundness proof most easily.
+    {
+        auto count_opcode = [](const std::vector<uint32_t>& words, uint16_t opcode) {
+            size_t count = 0;
+            for (size_t at = 5; at < words.size();) {
+                const uint32_t length = words[at] >> 16;
+                if (length == 0) break;
+                count += static_cast<uint16_t>(words[at]) == opcode;
+                at += length;
+            }
+            return count;
+        };
+        constexpr uint16_t kOpSwitch = 251, kOpControlBarrier = 224;
+        // SOPP opcode 0x0a (SoppOpcode::Barrier) at the SOPP encoding base 0xbf800000.
+        constexpr uint32_t kSBarrier = 0xbf8a0000u;
+        std::vector<uint32_t> barrier_code(code, code + std::size(code));
+        // Ahead of the store, so the guest memory effect sits on the far side of the barrier and the
+        // program genuinely splits into two non-empty phases.
+        barrier_code.insert(barrier_code.end() - 3, kSBarrier);
+
+        const std::vector<uint32_t> barrier_spirv =
+            recompile_compute(barrier_code.data(), barrier_code.size(), &rt, config);
+        CHECK(!barrier_spirv.empty(),
+              "a partial workgroup that uses a barrier recompiles instead of being rejected");
+        // Guards against a vacuous pass: were the barrier dropped in translation, the module would
+        // compile for the wrong reason and every assertion below would still hold.
+        // Measured: 5 barriers for one guest s_barrier. One is the guest's, emitted by the phase
+        // shell at function scope; the other four are the two dispatchers' own synchronized common
+        // phases. Those are uniform by construction -- a padded invocation stays inside the
+        // dispatcher loop and reaches them, and only its switch selector differs -- which is the
+        // same property that makes ACTIVE=false safe in the first place. So the count is not the
+        // interesting number here; that it is non-zero rules out the barrier having been dropped.
+        CHECK(count_opcode(barrier_spirv, kOpControlBarrier) > 0,
+              "the recompiled module really does contain the barrier under test");
+        // THE discriminator, and the reason this is asserted by structure rather than by exit code.
+        // Two lowerings both produce a module that compiles and contains a barrier:
+        //   sound -- split at the barrier, one dispatcher per phase, barrier between them at
+        //            function scope, reached by every invocation: TWO OpSwitch.
+        //   unsound -- one dispatcher over the whole stream with the barrier inside a switch case,
+        //            reached only by invocations whose ACTIVE bit is set: ONE OpSwitch, and a
+        //            latent deadlock that no exit code, and no spirv-val run, would report.
+        // Counting them is what tells those two apart.
+        CHECK(count_opcode(barrier_spirv, kOpSwitch) == 2,
+              "the barrier splits the program into two dispatched phases rather than sitting inside "
+              "one switch case, where only active invocations would reach it");
+
+        const std::vector<uint32_t> guarded_spirv =
+            recompile_compute(code, std::size(code), &rt, config);
+        CHECK(!guarded_spirv.empty() && count_opcode(guarded_spirv, kOpControlBarrier) == 0 &&
+                  count_opcode(guarded_spirv, kOpSwitch) == 0,
+              "the same program without the barrier still takes the cheap entry guard, so the fix "
+              "did not route every partial workgroup through a dispatcher");
+
+        // A complete workgroup has no padded lane to suppress, so a barrier costs it nothing and
+        // this was never the rejected case -- the arm that keeps the claim about WHY it was rejected
+        // honest, rather than merely about the barrier being present.
+        ComputeShaderConfig exact_config = config;
+        exact_config.threads_x = 192;
+        CHECK(!recompile_compute(barrier_code.data(), barrier_code.size(), &rt,
+                                 exact_config).empty(),
+              "a barrier in a workgroup with no partial tail was never the rejected case");
+    }
 
     ComputeItem item;
     item.spirv = spirv;

--- a/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
+++ b/prosper/tests/gpu/recompiler/test_rdna2_to_spirv.cpp
@@ -11509,23 +11509,19 @@ int main() {
         codeT25e, std::size(codeT25e), 1, 0);
     CHECK(!spvT25e.empty(),
           "recompiled T25e (Plucky V_READLANE_B32 lane 63 exact word) -> SPIR-V");
-    CHECK(compute_spirv_min_subgroup_size(spvT25e) == 64,
-          "T25e: wave64 readlane advertises its 64-lane host contract");
-    if (can_shuffleT25b && subgroupT25b.size >= 64) {
+    CHECK(compute_spirv_min_subgroup_size(spvT25e) == 0,
+          "T25e: portable wave64 readlane carries no host-width demand");
+    if (can_shuffleT25b) {
         std::vector<float> inT25e(128), expectedT25e(128);
         for (uint32_t i = 0; i < 128; ++i) inT25e[i] = static_cast<float>(i);
-        for (uint32_t i = 0; i < 128; ++i) {
-            const uint32_t subgroup_lane = i % subgroupT25b.size;
-            const uint32_t subgroup_base = i - subgroup_lane;
-            expectedT25e[i] = inT25e[subgroup_base + (subgroup_lane & ~63u) + 63u];
-        }
+        for (uint32_t i = 0; i < 128; ++i)
+            expectedT25e[i] = inT25e[(i & ~63u) + 63u];
         const std::vector<float> gotT25e = prosper::test::run_compute(
             spvT25e, inT25e, 128, 128);
         CHECK(gotT25e == expectedT25e,
               "T25e: V_READLANE_B32 broadcasts lane 63 within each guest wave64");
     } else {
-        std::printf("  [skip] T25e execution: host subgroup %u is narrower than 64\n",
-                    subgroupT25b.size);
+        std::printf("  [skip] T25e execution: no compute-capable host device\n");
     }
 
     // T25f (#1390): DS_SWIZZLE_B32 does not access LDS; it maps the source VGPR across active

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -248,6 +248,35 @@ static void set_descriptor_mode(const char* value) {
 }
 
 int main() {
+    {
+        // A metadata texture can be reused for an exact instruction-time T# match. Its paired
+        // metadata sampler is not authoritative in that case: scalar code may have loaded or
+        // patched a different S# before this exact MIMG use.
+        ShaderResource texture{};
+        texture.cls = ResourceClass::Texture;
+        texture.fetch_pc = 0xFFFFFFFFu;
+        const uint32_t sampler[4] = {
+            (1u << 3) | (6u << 6) | (5u << 9) | (4u << 12) | (1u << 15),
+            0x180u | (0xA40u << 12),
+            0x3F00u | (1u << 20) | (2u << 22) | (3u << 26),
+            2u << 30,
+        };
+        CHECK(attach_image_use(texture, 0x138u, sampler) &&
+                  texture.fetch_pc == 0x138u &&
+                  texture.addr_uvw[0] == 0u && texture.addr_uvw[1] == 1u &&
+                  texture.addr_uvw[2] == 6u && texture.mag_filter == 1u &&
+                  texture.min_filter == 1u && texture.mip_filter == 1u &&
+                  texture.max_aniso_ratio == 5u && texture.depth_compare_func == 4u &&
+                  texture.unnormalized == 1u && texture.min_lod == 1.5f &&
+                  texture.max_lod == 10.25f && texture.lod_bias == -1.0f &&
+                  texture.border_color_type == 2u,
+              "an exact image use replaces a reused metadata texture's stale paired sampler");
+        const uint32_t retained_address_u = texture.addr_uvw[0];
+        CHECK(!attach_image_use(texture, 0x139u, sampler) &&
+                  texture.fetch_pc == 0x138u && texture.addr_uvw[0] == retained_address_u,
+              "a resource already owned by another image PC is not mutated during merge");
+    }
+
     printf("== test_shader_resources ==\n");
 
     CHECK(data_format_bytes(DataFormat::Float32) == 4 && data_format_bytes(DataFormat::Uint32) == 4,

--- a/prosper/tests/gpu/resources/test_shader_resources.cpp
+++ b/prosper/tests/gpu/resources/test_shader_resources.cpp
@@ -527,6 +527,13 @@ int main() {
     CHECK(!native_float_storage_image_supported(DataFormat::Unorm8, 4, true, true) &&
               !native_float_storage_image_supported(DataFormat::Float16, 3, false, true),
           "device support cannot override semantic native-storage exclusions");
+    CHECK(native_uint_storage_image_supported(DataFormat::Uint32, 1, false, true) &&
+              native_uint_storage_image_supported(DataFormat::Uint16, 1, false, true) &&
+              native_uint_storage_image_supported(DataFormat::Uint8, 1, false, true) &&
+              native_uint_storage_image_supported(DataFormat::Uint8, 4, false, true) &&
+              !native_uint_storage_image_supported(DataFormat::Uint16, 4, false, true) &&
+              !native_uint_storage_image_supported(DataFormat::Uint8, 1, true, true),
+          "native unsigned storage accepts exact scalar and RGBA8 linear formats");
     const uint32_t r8_storage =
         native_storage_format_support_bit(DataFormat::Unorm8, 1);
     const uint32_t rg8_storage =
@@ -535,11 +542,26 @@ int main() {
         native_storage_format_support_bit(DataFormat::Float10_11_11, 3);
     const uint32_t fp16_3d_storage =
         native_storage_3d_format_support_bit(DataFormat::Float16, 4);
+    const uint32_t r32ui_storage =
+        native_storage_format_support_bit(DataFormat::Uint32, 1);
+    const uint32_t r8ui_storage =
+        native_storage_format_support_bit(DataFormat::Uint8, 1);
+    const uint32_t r16ui_storage =
+        native_storage_format_support_bit(DataFormat::Uint16, 1);
+    const uint32_t rgba8ui_storage =
+        native_storage_format_support_bit(DataFormat::Uint8, 4);
     CHECK(r8_storage && rg8_storage && packed_storage && fp16_3d_storage &&
+              r32ui_storage && r16ui_storage && r8ui_storage && rgba8ui_storage &&
               r8_storage != rg8_storage &&
               rg8_storage != packed_storage &&
+              r32ui_storage != r16ui_storage && r16ui_storage != r8ui_storage &&
+              r8ui_storage != rgba8ui_storage &&
               !(fp16_3d_storage & ((1u << 10) - 1u)) &&
               !(fp16_3d_storage & ~kNativeStorageFormatSupportMask) &&
+              !(r32ui_storage & ~kNativeStorageFormatSupportMask) &&
+              !(r16ui_storage & ~kNativeStorageFormatSupportMask) &&
+              !(rgba8ui_storage & ~kNativeStorageFormatSupportMask) &&
+              native_storage_3d_format_support_bit(DataFormat::Uint32, 1) == 0 &&
               native_storage_format_support_bit(DataFormat::Float16, 3) == 0,
           "native storage capability bits distinguish exact typed VkFormat and dimension candidates");
 

--- a/prosper/tests/gpu/state/test_render_state.cpp
+++ b/prosper/tests/gpu/state/test_render_state.cpp
@@ -173,6 +173,50 @@ int main() {
     run_command_buffer(buffer, 256, st);
     RenderState rs = extract_render_state(st);
 
+    // GFX10 CB_COLORn_BASE names a complete allocation; VIEW.MIP_LEVEL selects the rendered view.
+    // GTA V builds this exact 1024x512 R11G11B10F SW_64KB_R_X chain one draw per level. Pin the
+    // reverse/tail-first addresses here so a regression cannot silently collapse all six passes
+    // back onto allocation base + mip-0 extent.
+    {
+        constexpr uint64_t allocation = 0x209c980000ull;
+        constexpr uint32_t mip0_width = 1024u, mip0_height = 512u, max_mip = 5u;
+        constexpr uint64_t expected_base[] = {
+            allocation + 0xC0000u, allocation + 0x40000u, allocation + 0x20000u,
+            allocation + 0x10000u, allocation, allocation,
+        };
+        constexpr uint32_t expected_width[] = {1024u, 512u, 256u, 128u, 64u, 32u};
+        constexpr uint32_t expected_height[] = {512u, 256u, 128u, 64u, 32u, 16u};
+        bool chain_ok = true;
+        for (uint32_t mip = 0; mip <= max_mip; ++mip) {
+            GpuState mip_state;
+            mip_state.cx[P::CB_COLOR0_BASE] = static_cast<uint32_t>(allocation >> 8);
+            mip_state.cx[P::CB_COLOR0_BASE_EXT] = static_cast<uint32_t>(allocation >> 40);
+            mip_state.cx[P::CB_COLOR0_VIEW] =
+                mip << P::CB_COLOR0_VIEW_MIP_LEVEL_SHIFT;
+            mip_state.cx[P::CB_COLOR0_INFO] =
+                (0x7u << P::CB_COLOR0_INFO_FORMAT_SHIFT) |
+                (0x7u << P::CB_COLOR0_INFO_NUMBER_TYPE_SHIFT);
+            mip_state.cx[P::CB_COLOR0_ATTRIB2] =
+                (max_mip << P::CB_COLOR0_ATTRIB2_MAX_MIP_SHIFT) |
+                ((mip0_width - 1u) << P::CB_COLOR0_ATTRIB2_MIP0_WIDTH_SHIFT) |
+                ((mip0_height - 1u) << P::CB_COLOR0_ATTRIB2_MIP0_HEIGHT_SHIFT);
+            mip_state.cx[P::CB_COLOR0_ATTRIB3] =
+                27u << P::CB_COLOR0_ATTRIB3_COLOR_SW_MODE_SHIFT;
+            const RenderState mip_render = extract_render_state(mip_state);
+            const ColorTargetState& target = mip_render.color_targets[0];
+            chain_ok = chain_ok && target.allocation_base == allocation &&
+                target.base == expected_base[mip] && target.width == expected_width[mip] &&
+                target.height == expected_height[mip] && target.mip_level == mip &&
+                target.max_mip == max_mip && target.color_sw_mode == 27u &&
+                target.in_mip_tail == (mip >= 4u) &&
+                mip_render.color0_base == target.base &&
+                mip_render.color0_width == target.width &&
+                mip_render.color0_height == target.height;
+        }
+        CHECK(chain_ok,
+              "CB_COLOR0_VIEW selects distinct reverse/tail-first mip target views");
+    }
+
     CHECK(rs.ps_addr == rdna2_addr(0x00ABCDEFu, 0x12u), "PS shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.es_addr == rdna2_addr(0x00111111u, 0x34u), "ES shader addr = (LO<<8)|(HI<<40)");
     CHECK(rs.gs_addr == 0 && rs.hs_addr == 0, "unset GS/HS shader addrs are 0");

--- a/prosper/tests/gpu/test_agc_shader.cpp
+++ b/prosper/tests/gpu/test_agc_shader.cpp
@@ -557,8 +557,8 @@ int main() {
     const prosper::gpu::ShaderResource* dcc_zero_mip_texture =
         realized_dcc_zero_mip ? realized_dcc_zero_mip->by_fetch_pc(1) : nullptr;
     CHECK(dcc_zero_mip_texture && dcc_zero_mip_texture->compression_enabled &&
-              !dcc_zero_mip_texture->proven_zero_mip,
-          "build_stage_table leaves DCC-backed IMAGE_LOAD_MIP fail-visible");
+              dcc_zero_mip_texture->proven_zero_mip,
+          "build_stage_table preserves mip-zero proof on a DCC-backed IMAGE_LOAD_MIP");
 
     const uint32_t direct_seed_fetch[] = {
         0xE0002000u, 0x80020100u,   // pc=0: buffer_load_format_x v1, v0, s[8:11], 0 idxen

--- a/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
@@ -1836,6 +1836,36 @@ int main() {
         printf("  [ok]   a vote-only fragment module does not claim a ballot\n");
     }
 
+    // A scalar SCC consumer elsewhere in the module says nothing about the WaveAny producer above
+    // it. The scalar compare overwrites SCC before S_CSELECT, so only producer-to-consumer SSA
+    // provenance may attach ScalarReduce.
+    const uint32_t execz_vote_with_unrelated_scalar_select[] = {
+        0x7e020280u,              // v_mov_b32 v1, 0
+        0x7c2200f0u,              // v_cmp_* -> VCC
+        0xbf880002u,              // s_cbranch_execz +2 (WaveAny control-flow vote)
+        0xbe8503f2u, 0x7e020205u,
+        0xbec0037eu,              // s_mov_b32 s64, exec_lo
+        0xbf060000u,              // s_cmp_eq_u32 s0, s0 -> fresh scalar SCC
+        0x856b807eu,              // s_cselect_b32 vcc_hi, exec_lo, 0
+        0x8a406b40u,              // s_andn2_b32 s64, s64, vcc_hi
+        0xbefe0940u,              // s_wqm_b32 exec_lo, s64
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800180fu, 0x03020100u,
+        0xbf810000u,
+    };
+    const auto unrelated_scalar_select_spv = recompile_fragment_wave32_for_test(
+        execz_vote_with_unrelated_scalar_select,
+        std::size(execz_vote_with_unrelated_scalar_select));
+    const uint32_t unrelated_scalar_select_reasons =
+        fragment_spirv_required_subgroup_reasons(unrelated_scalar_select_spv);
+    if (unrelated_scalar_select_spv.empty() ||
+        unrelated_scalar_select_reasons != kFragmentWaveReasonWaveAny) {
+        printf("  [FAIL] an unrelated scalar SCC consumer tightened a WaveAny vote "
+               "(reasons=0x%x)\n", unrelated_scalar_select_reasons);
+        return 1;
+    }
+    printf("  [ok]   unrelated scalar SCC consumers do not tighten WaveAny votes\n");
+
     // GTA V's intro compositor compares a scalar-buffer value held in VCC_LO against zero, then
     // branches on VCCZ before an optional texture sample.  The comparison is identical in every
     // lane, so voting it with OpGroupNonUniformAny is an identity and must not force the guest's
@@ -1858,6 +1888,36 @@ int main() {
     }
     printf("  [ok]   scalar-uniform VCC producer is certified at its VCCZ branch\n");
 
+    // An ordinary VOP3A MAC has an SDST-shaped decode field but does not write VCC. Keep it
+    // transparent to the uniform-producer walk; a real VOP3B carry packet is the mutation control.
+    const uint32_t uniform_vccz_across_mac_fragment[] = {
+        0xbe9003f2u,              // s_mov_b32 s16, 1.0
+        0x7c0900f9u, 0x86860010u, // v_cmp_lg_f32 vcc, s16, 0
+        0xd51f8011u, 0x40021b08u, // v_mac_f32_e64: VOP3A, no scalar destination
+        0xbf860002u,              // s_cbranch_vccz +2
+        0xbe8503f2u, 0x7e020205u,
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800180fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!fragment_vcc_branch_is_wave_uniform_for_test(
+            uniform_vccz_across_mac_fragment,
+            std::size(uniform_vccz_across_mac_fragment), 5)) {
+        printf("  [FAIL] VOP3A MAC was mistaken for a VCC write between compare and branch\n");
+        return 1;
+    }
+    uint32_t vop3b_vcc_mutation[std::size(uniform_vccz_across_mac_fragment)];
+    std::copy(std::begin(uniform_vccz_across_mac_fragment),
+              std::end(uniform_vccz_across_mac_fragment),
+              std::begin(vop3b_vcc_mutation));
+    vop3b_vcc_mutation[3] = 0xd70f6a11u; // v_add_co_u32_e64 ..., sdst=vcc
+    if (fragment_vcc_branch_is_wave_uniform_for_test(
+            vop3b_vcc_mutation, std::size(vop3b_vcc_mutation), 5)) {
+        printf("  [FAIL] a real VOP3B VCC write was treated as transparent\n");
+        return 1;
+    }
+    printf("  [ok]   VOP3A MAC is VCC-transparent while a VOP3B write is not\n");
+
     const uint32_t divergent_vccz_fragment[] = {
         0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1 (unproven lane-local inputs)
         0xbf860002u,              // s_cbranch_vccz +2
@@ -1873,6 +1933,45 @@ int main() {
         return 1;
     }
     printf("  [ok]   unproven lane-local VCC producer retains its wave-vote requirement\n");
+
+    // RAGE recycles both physical VCC dwords as scalar scratch in the deferred-light epilogue.
+    // Scalar reads may observe those dwords, but no mask-domain consumer may survive the proof.
+    const uint32_t fragment_scalar_vcc_suffix[] = {
+        0xbe840381u,              // s_mov_b32 s4, 1
+        0xbf0d8004u,              // s_cmp_lg_u32 s4, 0
+        0x856b80c0u,              // s_cselect_b32 vcc_hi, 64, 0
+        0xbf0d8104u,              // s_cmp_lg_u32 s4, 1
+        0x856a80ffu, 0x00000080u,// s_cselect_b32 vcc_lo, 128, 0
+        0x886a6a6bu,              // s_or_b32 vcc_lo, vcc_lo, vcc_hi
+        0x7e080c6au,              // v_cvt_f32_u32 v4, vcc_lo
+        0x7e000280u, 0x7e020280u, 0x7e040280u, 0x7e060280u,
+        0xf800000fu, 0x03020100u,
+        0xbf810000u,
+    };
+    const auto fragment_scalar_vcc_suffix_spv = recompile_fragment(
+        fragment_scalar_vcc_suffix, std::size(fragment_scalar_vcc_suffix));
+    if (fragment_scalar_vcc_suffix_spv.empty() ||
+        fragment_spirv_required_subgroup_size(fragment_scalar_vcc_suffix_spv) != 0) {
+        printf("  [FAIL] scalar-only fragment VCC suffix retained a subgroup contract "
+               "(words=%zu size=%u)\n",
+               fragment_scalar_vcc_suffix_spv.size(),
+               fragment_spirv_required_subgroup_size(fragment_scalar_vcc_suffix_spv));
+        return 1;
+    }
+    std::vector<uint32_t> fragment_live_vcc_suffix(
+        std::begin(fragment_scalar_vcc_suffix), std::end(fragment_scalar_vcc_suffix));
+    fragment_live_vcc_suffix.insert(fragment_live_vcc_suffix.begin() + 8,
+                                    0x02020100u); // v_cndmask observes implicit VCC
+    const auto fragment_live_vcc_suffix_spv = recompile_fragment(
+        fragment_live_vcc_suffix.data(), fragment_live_vcc_suffix.size());
+    if (fragment_live_vcc_suffix_spv.empty() ||
+        fragment_spirv_required_subgroup_size(fragment_live_vcc_suffix_spv) != 64 ||
+        !(fragment_spirv_required_subgroup_reasons(fragment_live_vcc_suffix_spv) &
+          kFragmentWaveReasonLaneId)) {
+        printf("  [FAIL] live fragment VCC mutation lost its exact lane-id contract\n");
+        return 1;
+    }
+    printf("  [ok]   scalar-only fragment VCC scratch avoids lane identity; mask use retains it\n");
 
     // Astro Bot's Wave32 graphics shaders save/copy/restore active-lane masks through the low
     // halves of EXEC and VCC.  These are the B32 equivalents of the B64 mask moves already modeled
@@ -3178,6 +3277,31 @@ int main() {
     }
     printf("  [ok]   Wave64 VCC branch retains ordinary LDS effects after an exact wave vote\n");
 
+    // GTA V's RCAS/EASU kernels end in an EXECZ early-out followed by ordinary V_READLANE lane-32
+    // broadcasts. A 32-lane NVIDIA subgroup cannot implement that Wave64 read with a shuffle. The
+    // CFG dispatcher must intercept it in its uniform common phase instead of stamping min=64.
+    const uint32_t wave64_compute_exec_readlane[] = {
+        0x7d8a0080u,                         // pc0: v_cmp_eq_u32 vcc,0,v0
+        0xbf860003u,                         // pc1: s_cbranch_vccz -> pc5
+        0xd7600000u, 0x00014100u,            // pc2: v_readlane_b32 s0,v0,32
+        0x7e000200u,                         // pc4: v_mov_b32 v0,s0
+        0xbf810000u,                         // pc5: s_endpgm
+    };
+    const auto wave64_compute_exec_readlane_spv = recompile_compute(
+        wave64_compute_exec_readlane, std::size(wave64_compute_exec_readlane), nullptr,
+        portable_wave64_compute_config);
+    if (wave64_compute_exec_readlane_spv.empty() ||
+        !has_opcode(wave64_compute_exec_readlane_spv, 224) || // OpControlBarrier
+        !has_opcode(wave64_compute_exec_readlane_spv, 251) || // OpSwitch dispatcher
+        has_opcode(wave64_compute_exec_readlane_spv, 345) ||  // no native subgroup shuffle
+        compute_spirv_min_subgroup_size(wave64_compute_exec_readlane_spv) != 0 ||
+        !type_result_ids_are_nonzero(wave64_compute_exec_readlane_spv, nullptr) ||
+        !phi_ids_are_nonzero(wave64_compute_exec_readlane_spv)) {
+        printf("  [FAIL] Wave64 EXECZ readlane retained a native subgroup-width dependency\n");
+        return 1;
+    }
+    printf("  [ok]   Wave64 EXECZ readlane uses the portable CFG common phase\n");
+
     // The acceptance above must not become a blanket escape hatch for operations whose lowering
     // contains a workgroup/subgroup synchronization phase. Those remain fail-visible inside a
     // per-wave arm until a common-phase transformation proves every invocation participates.
@@ -4388,9 +4512,12 @@ int main() {
     };
     auto mask_pair_module_is_exact = [&](const std::vector<uint32_t>& spirv,
                                          uint32_t wave_size, bool inverted) {
+        const uint32_t reasons = fragment_spirv_required_subgroup_reasons(spirv);
         return !spirv.empty() && has_opcode(spirv, 251) &&
             opcode_count(spirv, 335) == 1 &&
             fragment_spirv_required_subgroup_size(spirv) == wave_size &&
+            reasons != UINT32_MAX &&
+            (reasons & kFragmentWaveReasonScalarReduce) != 0 &&
             wave_vote_reaches_later_select(spirv, inverted) &&
             type_result_ids_are_nonzero(spirv, nullptr) &&
             phi_ids_are_nonzero(spirv);

--- a/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
+++ b/prosper/tests/gpu/test_rdna2_spirv_struct.cpp
@@ -103,6 +103,20 @@ bool has_glsl_ext_inst(const std::vector<uint32_t>& spv, uint32_t instruction) {
     return false;
 }
 
+uint32_t glsl_ext_inst_count(const std::vector<uint32_t>& spv, uint32_t instruction) {
+    constexpr uint32_t OpExtInst = 12;
+    uint32_t count = 0;
+    if (spv.size() < 5) return count;
+    for (size_t i = 5; i < spv.size();) {
+        const uint32_t op = spv[i] & 0xffffu, wc = spv[i] >> 16u;
+        if (!wc || i + wc > spv.size()) return 0;
+        // OpExtInst operands: result type, result, instruction set, instruction, operands...
+        count += op == OpExtInst && wc >= 6 && spv[i + 4] == instruction;
+        i += wc;
+    }
+    return count;
+}
+
 uint32_t opcode_count(const std::vector<uint32_t>& spv, uint32_t opcode) {
     uint32_t count = 0;
     if (spv.size() < 5) return count;
@@ -1806,7 +1820,7 @@ int main() {
         0xbf880002u,              // s_cbranch_execz +2  (routes through the fragment wave vote)
         0xbe8503f2u, 0x7e020205u,
         0x7e000280u, 0x7e040280u, 0x7e0602f2u,
-        0xf800000fu, 0x03020100u,
+        0xf800180fu, 0x03020100u,
         0xbf810000u,
     };
     const auto execz_vote_spv =
@@ -1821,6 +1835,44 @@ int main() {
         }
         printf("  [ok]   a vote-only fragment module does not claim a ballot\n");
     }
+
+    // GTA V's intro compositor compares a scalar-buffer value held in VCC_LO against zero, then
+    // branches on VCCZ before an optional texture sample.  The comparison is identical in every
+    // lane, so voting it with OpGroupNonUniformAny is an identity and must not force the guest's
+    // Wave64 width on a 32-wide host.  The mutation control below builds a genuinely divergent
+    // VGPR comparison by hand; it must retain the vote and its exact-width contract.
+    const uint32_t uniform_vccz_fragment[] = {
+        0xbeea03f2u,              // s_mov_b32 vcc_lo, 1.0 (ordinary scalar-data lifetime)
+        0x7c0900f9u, 0x8686006au, // v_cmp_lg_f32 vcc, vcc_lo, 0 (GTA V compositor packet)
+        0xbf860002u,              // s_cbranch_vccz +2
+        0xbe8503f2u,              // optional arm: scalar value feeding a lane-local result
+        0x7e020205u,
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800180fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (!fragment_vcc_branch_is_wave_uniform_for_test(
+            uniform_vccz_fragment, std::size(uniform_vccz_fragment), 3)) {
+        printf("  [FAIL] scalar-uniform VCC producer was not certified at its VCCZ branch\n");
+        return 1;
+    }
+    printf("  [ok]   scalar-uniform VCC producer is certified at its VCCZ branch\n");
+
+    const uint32_t divergent_vccz_fragment[] = {
+        0x7c020300u,              // v_cmp_lt_f32 vcc, v0, v1 (unproven lane-local inputs)
+        0xbf860002u,              // s_cbranch_vccz +2
+        0xbe8503f2u,
+        0x7e020205u,
+        0x7e000280u, 0x7e040280u, 0x7e0602f2u,
+        0xf800180fu, 0x03020100u,
+        0xbf810000u,
+    };
+    if (fragment_vcc_branch_is_wave_uniform_for_test(
+            divergent_vccz_fragment, std::size(divergent_vccz_fragment), 1)) {
+        printf("  [FAIL] unproven lane-local VCC producer was certified wave-uniform\n");
+        return 1;
+    }
+    printf("  [ok]   unproven lane-local VCC producer retains its wave-vote requirement\n");
 
     // Astro Bot's Wave32 graphics shaders save/copy/restore active-lane masks through the low
     // halves of EXEC and VCC.  These are the B32 equivalents of the B64 mask moves already modeled
@@ -4973,6 +5025,81 @@ int main() {
         return 1;
     }
     printf("  [ok]   compute-shell image_sample lowers to OpImageSampleExplicitLod (LOD 0)\n");
+
+    // GTA V's FSR1 RCAS pass combines both compact MIMG controls on its scene input: A16 packs
+    // integer x/y into one address VGPR, while D16 packs the four floating-point result components
+    // into two VDATA VGPRs. The old lowering ignored both flags, sampled y from an unrelated VGPR,
+    // and overwrote two registers beyond VDATA; the matching D16 stores then consumed four full
+    // VGPRs and produced the title's exact red/green/black 8x8 checker.
+    const uint32_t gta_rcas_a16_d16_load[] = {
+        0xf0000f08u, 0xc0000c00u,            // IMAGE_LOAD v[12:13], v0, s[0:7] xyzw 2D A16 D16
+        0xbf810000u,
+    };
+    ShaderResourceTable rcas_load_rt;
+    { ShaderResource texture{}; texture.cls = ResourceClass::Texture;
+      texture.format = DataFormat::Float10_11_11; texture.num_components = 3;
+      texture.binding = 4; texture.fetch_pc = 0; texture.sgpr_base = 0; texture.img_dim = 1;
+      texture.width = 2; texture.height = 2; texture.size = 16;
+      rcas_load_rt.resources.push_back(texture); }
+    const std::vector<uint32_t> rcas_load_spv = recompile_valu(
+        gta_rcas_a16_d16_load, std::size(gta_rcas_a16_d16_load), 64, 0, &rcas_load_rt);
+    if (rcas_load_spv.empty() || !has_opcode(rcas_load_spv, 95u) ||
+        opcode_count(rcas_load_spv, 203u) < 2u || !has_glsl_ext_inst(rcas_load_spv, 58u)) {
+        printf("  [FAIL] GTA RCAS A16/D16 load did not unpack x/y and pack fp16 VDATA\n");
+        return 1;
+    }
+
+    const uint32_t gta_rcas_d16_store[] = {
+        0x7e080300u,                         // v4 = x from the compute shell
+        0x7e0a0280u,                         // v5 = y = 0
+        0xf0200f08u, 0x80020004u,            // IMAGE_STORE v[0:1], v[4:5], s[8:15] xyzw 2D D16
+        0xbf810000u,
+    };
+    ShaderResourceTable rcas_store_rt;
+    { ShaderResource image{}; image.cls = ResourceClass::StorageImage;
+      image.format = DataFormat::Unorm8; image.num_components = 4;
+      image.binding = 4; image.fetch_pc = 2; image.sgpr_base = 8; image.img_dim = 1;
+      image.width = 2; image.height = 2; image.size = 16;
+      rcas_store_rt.resources.push_back(image); }
+    const std::vector<uint32_t> rcas_store_spv = recompile_valu(
+        gta_rcas_d16_store, std::size(gta_rcas_d16_store), 64, 0, &rcas_store_rt);
+    ShaderResourceTable integer_d16_rt = rcas_load_rt;
+    integer_d16_rt.resources[0].format = DataFormat::Uint8;
+    if (rcas_store_spv.empty() || !has_opcode(rcas_store_spv, 99u) ||
+        !has_glsl_ext_inst(rcas_store_spv, 62u) ||
+        !recompile_valu(gta_rcas_a16_d16_load, std::size(gta_rcas_a16_d16_load),
+                        64, 0, &integer_d16_rt).empty()) {
+        printf("  [FAIL] GTA RCAS D16 store did not unpack fp16 VDATA or admitted integer D16\n");
+        return 1;
+    }
+    printf("  [ok]   GTA RCAS A16/D16 load/store preserves packed address and VDATA contracts\n");
+
+    // The preceding ordinary-load coverage does not exercise gather's distinct result shape: its
+    // single-bit dmask selects a source channel, but all four gathered texels are returned. This is
+    // an exact GTA V FSR1 EASU packet. Under D16 those four fp16 values must occupy two VDATA VGPRs,
+    // rather than the four full-width registers used by the non-D16 gather path.
+    const uint32_t gta_easu_d16_gather[] = {
+        0xf11c010au, 0x80401420u, 0x00000032u, // IMAGE_GATHER4_LZ v[20:21], [v32,v50], D16 NSA
+        0xbf810000u,
+    };
+    ShaderResourceTable easu_gather_rt;
+    { ShaderResource texture{}; texture.cls = ResourceClass::Texture;
+      texture.format = DataFormat::Unorm8; texture.num_components = 4;
+      texture.binding = 4; texture.fetch_pc = 0; texture.sgpr_base = 0; texture.img_dim = 1;
+      texture.width = 2; texture.height = 2; texture.size = 16;
+      easu_gather_rt.resources.push_back(texture); }
+    const std::vector<uint32_t> easu_gather_spv = recompile_valu(
+        gta_easu_d16_gather, std::size(gta_easu_d16_gather), 64, 0, &easu_gather_rt);
+    ShaderResourceTable integer_easu_gather_rt = easu_gather_rt;
+    integer_easu_gather_rt.resources[0].format = DataFormat::Uint8;
+    if (easu_gather_spv.empty() || !has_opcode(easu_gather_spv, 96u) ||
+        glsl_ext_inst_count(easu_gather_spv, 58u) != 2u ||
+        !recompile_valu(gta_easu_d16_gather, std::size(gta_easu_d16_gather),
+                        64, 0, &integer_easu_gather_rt).empty()) {
+        printf("  [FAIL] GTA EASU D16 gather did not pack four fp16 texels into two VDATA VGPRs\n");
+        return 1;
+    }
+    printf("  [ok]   GTA EASU D16 gather preserves its two-VGPR packed result contract\n");
 
     // GTA V gameplay's exact single-level IMAGE_LOAD_MIP / IMAGE_STORE_MIP subset. The resource
     // marker is the independent materialization proof; removing it, changing the descriptor to DCC,

--- a/prosper/tests/gpu/test_recompile_coverage.cpp
+++ b/prosper/tests/gpu/test_recompile_coverage.cpp
@@ -2636,19 +2636,45 @@ int main() {
 
     // A partial AGC thread-dimension workgroup needs a divergent entry guard to mask Vulkan's padded
     // invocations. That is safe for ordinary kernels, but not when the module contains a workgroup
-    // barrier: every Vulkan invocation must reach OpControlBarrier uniformly. Keep exact workgroups
-    // supported and reject the partial+barrier combination rather than risking a hang or undefined LDS.
+    // barrier: every Vulkan invocation must reach OpControlBarrier uniformly.
+    //
+    // This combination USED to be rejected outright, and this assertion pinned that. The rejection
+    // was a conservative stand-in for a lowering the recompiler already had and was not permitting
+    // itself to use: split the stream at its barriers, compile each barrier-free phase through the
+    // dispatcher's per-lane ACTIVE bit, and emit each barrier from the outer phase shell at function
+    // scope, where a padded invocation reaches it because it never left uniform control flow. The
+    // divergent entry guard is not emitted on that route at all.
+    //
+    // So the property worth asserting is the one the rejection was protecting -- the barrier is
+    // uniform -- and not the rejection itself. The `>= 1` barrier count rules out the degenerate way
+    // to satisfy that (dropping the barrier in translation), which would otherwise pass silently.
     const uint32_t barrier_only[] = { 0xBF8A0000u, 0xBF810000u };
     ComputeShaderConfig exact_barrier;
     exact_barrier.local_x = 64;
     exact_barrier.exact_thread_extent = true;
     exact_barrier.threads_x = 64;
     exact_barrier.threads_y = exact_barrier.threads_z = 1;
-    CHECK(!recompile_compute(barrier_only, 2, nullptr, exact_barrier).empty(),
+    const std::vector<uint32_t> exact_barrier_spirv =
+        recompile_compute(barrier_only, 2, nullptr, exact_barrier);
+    CHECK(!exact_barrier_spirv.empty(),
           "an exact thread-dimension workgroup may retain a uniform barrier");
     exact_barrier.threads_x = 63;
-    CHECK(recompile_compute(barrier_only, 2, nullptr, exact_barrier).empty(),
-          "a partial thread-dimension workgroup with a barrier rejects fail-visibly");
+    const std::vector<uint32_t> partial_barrier_spirv =
+        recompile_compute(barrier_only, 2, nullptr, exact_barrier);
+    auto spirv_opcode_count = [](const std::vector<uint32_t>& words, uint16_t opcode) {
+        size_t count = 0;
+        for (size_t at = 5; at < words.size();) {
+            const uint32_t length = words[at] >> 16;
+            if (length == 0) break;
+            count += static_cast<uint16_t>(words[at]) == opcode;
+            at += length;
+        }
+        return count;
+    };
+    CHECK(!partial_barrier_spirv.empty() &&
+              spirv_opcode_count(partial_barrier_spirv, /*OpControlBarrier=*/224) >= 1,
+          "a partial thread-dimension workgroup keeps its barrier through the phase split "
+          "instead of being rejected");
 
     // A wave-empty saveexec/execz guard may surround a scalar counted loop when the body preserves
     // both EXEC and the guard's saved mask. This is the Evergate color-conversion shape.

--- a/prosper/tests/gpu/test_texture_mip_render.cpp
+++ b/prosper/tests/gpu/test_texture_mip_render.cpp
@@ -92,6 +92,81 @@ int main() {
     CHECK(ok && rgb[0] > 0xC0 && rgb[2] < 0x40,
           "declared_mip_levels=1 (the default) keeps the historical single-level clamp-to-0 behavior");
 
+    // CB_COLOR exposes one persistent Vulkan image per mip view. Build two deliberately different
+    // renderer-owned levels (red level 0, green level 1), then sample them through one FrameResource
+    // mip chain. Green at LOD 1 cannot come from the red base-level image and therefore proves the
+    // backend copied the independent target instead of direct-binding mip 0. Leave level 2 absent;
+    // black there proves the backend does not invent output for a producer that never ran.
+    const uint8_t red_texels[4 * 4 * 4] = {
+        255,0,0,255, 255,0,0,255, 255,0,0,255, 255,0,0,255,
+        255,0,0,255, 255,0,0,255, 255,0,0,255, 255,0,0,255,
+        255,0,0,255, 255,0,0,255, 255,0,0,255, 255,0,0,255,
+        255,0,0,255, 255,0,0,255, 255,0,0,255, 255,0,0,255,
+    };
+    const uint8_t green_texels[2 * 2 * 4] = {
+        0,255,0,255, 0,255,0,255, 0,255,0,255, 0,255,0,255,
+    };
+    auto make_lod_fragment = [&](uint32_t lod_bits) {
+        std::vector<uint32_t> ps(
+            ps_template, ps_template + sizeof(ps_template) / sizeof(ps_template[0]));
+        ps[1] = U; ps[3] = U; ps[5] = lod_bits;
+        return recompile_fragment(ps.data(), ps.size(), &rt);
+    };
+    const std::vector<uint32_t> lod0_frag = make_lod_fragment(LOD0);
+    auto publish_target = [&](uint64_t id, const uint8_t* source,
+                              uint32_t width, uint32_t height) {
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tex_rgba = source; resource.tw = width; resource.th = height;
+        resource.mip_filter = 0;
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = lod0_frag; draw.R = {resource}; draw.vcount = 3;
+        prosper::test::BackendColorTarget target;
+        target.persistent_id = id;
+        target.load_existing = false;
+        target.readback = false;
+        prosper::test::render_draws_rgba(
+            {draw}, width, height, nullptr, nullptr, false, &target,
+            nullptr, nullptr, nullptr, nullptr, true, nullptr, false);
+    };
+    constexpr uint64_t MIP_TARGET0 = 0x1272001000ull;
+    constexpr uint64_t MIP_TARGET1 = 0x1272002000ull;
+    publish_target(MIP_TARGET0, red_texels, 4u, 4u);
+    publish_target(MIP_TARGET1, green_texels, 2u, 2u);
+    CHECK(prosper::test::find_persistent_color_target(
+              MIP_TARGET0, 4u, 4u, VK_FORMAT_R8G8B8A8_UNORM) &&
+              prosper::test::find_persistent_color_target(
+                  MIP_TARGET1, 2u, 2u, VK_FORMAT_R8G8B8A8_UNORM),
+          "independent CB_COLOR mip views remain renderer-owned and sampleable");
+    auto render_assembled_lod = [&](uint32_t lod_bits, uint8_t out_rgb[3]) {
+        prosper::test::FrameResource resource;
+        resource.binding = 4; resource.set = 1;
+        resource.tw = resource.th = 4u;
+        resource.declared_mip_levels = 3u;
+        resource.persistent_render_target_id = MIP_TARGET0;
+        resource.persistent_render_target_mip_ids[0] = MIP_TARGET0;
+        resource.persistent_render_target_mip_ids[1] = MIP_TARGET1;
+        resource.persistent_render_target_mip_count = 3u;
+        resource.mip_filter = 0;
+        resource.max_lod = 8.0f;
+        prosper::test::BackendDraw draw;
+        draw.vs = vert; draw.fs = make_lod_fragment(lod_bits);
+        draw.R = {resource}; draw.vcount = 3;
+        const std::vector<uint8_t> px =
+            prosper::test::render_draws_rgba({draw}, W, H);
+        if (px.size() != static_cast<size_t>(W) * H * 4u) return false;
+        const uint8_t* center =
+            &px[(static_cast<size_t>(H / 2) * W + W / 2) * 4u];
+        out_rgb[0] = center[0]; out_rgb[1] = center[1]; out_rgb[2] = center[2];
+        return true;
+    };
+    ok = render_assembled_lod(0x3f800000u /*1.0f*/, rgb);
+    CHECK(ok && rgb[1] > 0xC0 && rgb[0] < 0x40 && rgb[2] < 0x40,
+          "assembled renderer mip chain samples the independent green level 1");
+    ok = render_assembled_lod(LOD2, rgb);
+    CHECK(ok && rgb[0] < 0x20 && rgb[1] < 0x20 && rgb[2] < 0x20,
+          "missing final renderer mip remains black instead of fabricating guest output");
+
     // IMAGE_SAMPLE_D supplies [Ds/Dx, Dt/Dx, Ds/Dy, Dt/Dy, u, v]. Unit normalized-coordinate
     // gradients over a 4x4 texture select LOD 2, while the literal UV has zero implicit quad
     // derivatives and selects LOD 0. Purple therefore proves that the explicit Grad operands survive.

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -24,6 +24,14 @@ static int fails = 0;
 int main() {
     printf("== test_texture_sample_render ==\n");
     const uint32_t W = 64, H = 64;
+    const auto center_red_at = [](const std::vector<uint8_t>& pixels,
+                                  uint32_t width, uint32_t height) -> uint8_t {
+        return pixels.size() == static_cast<size_t>(width) * height * 4
+            ? pixels[(static_cast<size_t>(height / 2) * width + width / 2) * 4] : 0;
+    };
+    const auto center_red = [=](const std::vector<uint8_t>& pixels) -> uint8_t {
+        return center_red_at(pixels, W, H);
+    };
 
     using prosper::test::BackendSubmissionState;
     using prosper::test::backend_submission_state;
@@ -35,6 +43,35 @@ int main() {
               prosper::test::backend_timestamp_delta(11u, 29u, 64) == 18u &&
               prosper::test::backend_timestamp_delta(11u, 29u, 0) == 0u,
           "device timestamp deltas handle valid-bit wrap and unsupported queues");
+
+    {
+        prosper::test::FrameResource bgra_target;
+        bgra_target.swizzle[0] = 6u;
+        bgra_target.swizzle[1] = 5u;
+        bgra_target.swizzle[2] = 4u;
+        bgra_target.swizzle[3] = 7u;
+        bgra_target.render_target_guest_format = VK_FORMAT_B8G8R8A8_UNORM;
+        const auto canonical =
+            prosper::test::backend_sampled_component_swizzle(bgra_target);
+        CHECK((canonical == std::array<uint32_t, 4>{4u, 5u, 6u, 7u}),
+              "BGRA renderer target composes DST_SEL into canonical RGBA component order");
+
+        bgra_target.render_target_guest_format = VK_FORMAT_R8G8B8A8_UNORM;
+        const auto semantic =
+            prosper::test::backend_sampled_component_swizzle(bgra_target);
+        CHECK((semantic == std::array<uint32_t, 4>{6u, 5u, 4u, 7u}),
+              "RGBA renderer target retains a semantic BGR component permutation");
+
+        bgra_target.render_target_guest_format = VK_FORMAT_B8G8R8A8_UNORM;
+        bgra_target.swizzle[0] = 4u;
+        bgra_target.swizzle[1] = 4u;
+        bgra_target.swizzle[2] = 4u;
+        bgra_target.swizzle[3] = 1u;
+        const auto replicated =
+            prosper::test::backend_sampled_component_swizzle(bgra_target);
+        CHECK((replicated == std::array<uint32_t, 4>{6u, 6u, 6u, 1u}),
+              "BGRA target composition preserves replication and constant selectors");
+    }
 
     {
         bool speculative_state_valid = true;
@@ -131,6 +168,19 @@ int main() {
                   VK_FORMAT_R8G8_UNORM &&
                   prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R8G8_UNORM) == 2,
               "native RG8 upload retains two channels and accounts two bytes per texel");
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_R16G16_SFLOAT) ==
+                  VK_FORMAT_R16G16_SFLOAT &&
+                  prosper::test::backend_color_bytes_per_pixel(
+                      VK_FORMAT_R16G16_SFLOAT) == 4 &&
+                  prosper::test::backend_image_numeric_class(
+                      VK_FORMAT_R16G16_SFLOAT) == SpirvImageNumericClass::Float,
+              "native RG16F targets retain two half-float channels and their sampled type");
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_R16_SFLOAT) ==
+                  VK_FORMAT_R16_SFLOAT &&
+                  prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R16_SFLOAT) == 2 &&
+                  prosper::test::backend_image_numeric_class(VK_FORMAT_R16_SFLOAT) ==
+                      SpirvImageNumericClass::Float,
+              "native R16F targets retain one half-float channel and their sampled type");
         CHECK(prosper::test::backend_color_format(VK_FORMAT_R32_UINT) == VK_FORMAT_R32_UINT &&
                   prosper::test::backend_color_bytes_per_pixel(VK_FORMAT_R32_UINT) == 4,
               "R32_UINT storage images retain their typed four-byte Vulkan format");
@@ -418,6 +468,19 @@ int main() {
                   sampled_stats.sampled_hits == 1,
               "GPU-resident target sampling matches CPU readback+upload byte-for-byte");
 
+        prosper::test::FrameResource bgra_gpu_resource = gpu_resource;
+        bgra_gpu_resource.render_target_guest_format = VK_FORMAT_B8G8R8A8_UNORM;
+        bgra_gpu_resource.swizzle[0] = 6u;
+        bgra_gpu_resource.swizzle[1] = 5u;
+        bgra_gpu_resource.swizzle[2] = 4u;
+        bgra_gpu_resource.swizzle[3] = 7u;
+        prosper::test::BackendDraw bgra_gpu_sample = gpu_sample;
+        bgra_gpu_sample.R = {bgra_gpu_resource};
+        const std::vector<uint8_t> bgra_canonical_sample =
+            prosper::test::render_draws_rgba({bgra_gpu_sample}, W, H);
+        CHECK(bgra_canonical_sample == cpu_roundtrip && center_red(bgra_canonical_sample) > 0x80,
+              "BGRA target plus BGR DST_SEL samples the canonical renderer red channel");
+
         // A packed mip tail may use the same guest ID for two independently rendered extents. The
         // 32x16 destination is not feedback against the retained 64x32 source: declining the borrow
         // on address alone leaves this resource with neither GPU pixels nor a CPU fallback and
@@ -430,7 +493,8 @@ int main() {
                 &same_id_smaller_target);
         const auto same_id_stats = prosper::test::backend_color_target_stats();
         CHECK(!same_id_different_extent.empty() &&
-                  center_red(same_id_different_extent) == center_red(cpu_roundtrip) &&
+                  center_red_at(same_id_different_extent, W / 2u, H / 2u) ==
+                      center_red(cpu_roundtrip) &&
                   same_id_stats.sampled_hits == 1,
               "same-address different-extent target borrows the retained source view");
 
@@ -701,10 +765,6 @@ int main() {
             consumer.vcount = 3;
             std::vector<uint8_t> cpu_sampled = prosper::test::render_draws_rgba(
                 {consumer}, W, H);
-            auto center_red = [&](const std::vector<uint8_t>& pixels) -> uint8_t {
-                return pixels.size() == static_cast<size_t>(W) * H * 4
-                    ? pixels[(static_cast<size_t>(H / 2) * W + W / 2) * 4] : 0;
-            };
             const uint8_t cpu_red = center_red(cpu_sampled);
             CHECK(cpu_red >= 126 && cpu_red <= 129,
                   "FP16 readback/upload consumer observes 2.0 before scaling to 0.5");
@@ -740,6 +800,104 @@ int main() {
                       borrowed_fp16_followup == cpu_sampled,
                   "borrowed native FP16 image preserves HDR sampling, layout, and lifetime");
             prosper::test::invalidate_persistent_color_target(fp16_target_id);
+
+            // GTA V's normal/material G-buffer is a two-channel FP16 attachment. Treating its four
+            // bytes as RGBA8 leaves allocation sizes deceptively valid while changing both numeric
+            // values. Prove the exact native producer, readback/upload, and resident-image routes.
+            ResolvedPipelineState rg16_state = fp16_state;
+            rg16_state.color0_format = VK_FORMAT_R16G16_SFLOAT;
+            producer.ps = &rg16_state;
+            constexpr uint64_t rg16_target_id = 0x7590000000000012ull;
+            prosper::test::BackendColorTarget rg16_target{
+                rg16_target_id, false, true, VK_FORMAT_R16G16_SFLOAT};
+            const std::vector<uint8_t> rg16_native = prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &rg16_target);
+            bool rg16_native_ok = rg16_native.size() == static_cast<size_t>(W) * H * 4;
+            if (rg16_native_ok) {
+                uint16_t halves[2]{};
+                std::memcpy(halves, rg16_native.data() +
+                    ((static_cast<size_t>(H / 2) * W + W / 2) * 4), sizeof(halves));
+                const float red_value = half_to_float(halves[0]);
+                const float green_value = half_to_float(halves[1]);
+                rg16_native_ok = red_value > 1.99f && red_value < 2.01f &&
+                                 green_value > 0.249f && green_value < 0.251f;
+            }
+            CHECK(rg16_native_ok,
+                  "native RG16F G-buffer readback preserves two half-float values");
+
+            prosper::test::FrameResource rg16_resource;
+            rg16_resource.binding = 4; rg16_resource.set = 1;
+            rg16_resource.tex_rgba = rg16_native.data();
+            rg16_resource.tw = W; rg16_resource.th = H;
+            rg16_resource.texture_format = VK_FORMAT_R16G16_SFLOAT;
+            consumer.R = {rg16_resource};
+            const std::vector<uint8_t> rg16_cpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            const size_t rg16_center_offset =
+                (static_cast<size_t>(H / 2) * W + W / 2) * 4;
+            const bool rg16_cpu_ok = rg16_cpu_sampled.size() ==
+                    static_cast<size_t>(W) * H * 4 &&
+                rg16_cpu_sampled[rg16_center_offset] >= 126 &&
+                rg16_cpu_sampled[rg16_center_offset] <= 129 &&
+                rg16_cpu_sampled[rg16_center_offset + 1] >= 63 &&
+                rg16_cpu_sampled[rg16_center_offset + 1] <= 65;
+            CHECK(rg16_cpu_ok,
+                  "RG16F readback/upload consumer observes native R and G values");
+
+            prosper::test::FrameResource gpu_rg16_resource = rg16_resource;
+            gpu_rg16_resource.tex_rgba = nullptr;
+            gpu_rg16_resource.persistent_render_target_id = rg16_target_id;
+            consumer.R = {gpu_rg16_resource};
+            const std::vector<uint8_t> rg16_gpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            const auto rg16_sample_stats = prosper::test::backend_color_target_stats();
+            CHECK(rg16_sample_stats.sampled_hits == 1 &&
+                      rg16_gpu_sampled == rg16_cpu_sampled,
+                  "GPU-resident RG16F G-buffer sampling matches its native CPU round-trip");
+            prosper::test::invalidate_persistent_color_target(rg16_target_id);
+
+            // The adjacent one-channel material target must retain the same FP16 numeric contract;
+    // widening it to RGBA8 changed both texel width and numeric values.
+            ResolvedPipelineState r16_state = fp16_state;
+            r16_state.color0_format = VK_FORMAT_R16_SFLOAT;
+            producer.ps = &r16_state;
+            constexpr uint64_t r16_target_id = 0x7590000000000013ull;
+            prosper::test::BackendColorTarget r16_target{
+                r16_target_id, false, true, VK_FORMAT_R16_SFLOAT};
+            const std::vector<uint8_t> r16_native = prosper::test::render_draws_rgba(
+                {producer}, W, H, nullptr, nullptr, false, &r16_target);
+            bool r16_native_ok = r16_native.size() == static_cast<size_t>(W) * H * 2;
+            if (r16_native_ok) {
+                uint16_t half = 0;
+                std::memcpy(&half, r16_native.data() +
+                    ((static_cast<size_t>(H / 2) * W + W / 2) * 2), sizeof(half));
+                const float red_value = half_to_float(half);
+                r16_native_ok = red_value > 1.99f && red_value < 2.01f;
+            }
+            CHECK(r16_native_ok,
+                  "native R16F material target readback preserves its half-float value");
+
+            prosper::test::FrameResource r16_resource;
+            r16_resource.binding = 4; r16_resource.set = 1;
+            r16_resource.tex_rgba = r16_native.data();
+            r16_resource.tw = W; r16_resource.th = H;
+            r16_resource.texture_format = VK_FORMAT_R16_SFLOAT;
+            consumer.R = {r16_resource};
+            const std::vector<uint8_t> r16_cpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            prosper::test::FrameResource gpu_r16_resource = r16_resource;
+            gpu_r16_resource.tex_rgba = nullptr;
+            gpu_r16_resource.persistent_render_target_id = r16_target_id;
+            consumer.R = {gpu_r16_resource};
+            const std::vector<uint8_t> r16_gpu_sampled =
+                prosper::test::render_draws_rgba({consumer}, W, H);
+            const auto r16_sample_stats = prosper::test::backend_color_target_stats();
+            CHECK(r16_sample_stats.sampled_hits == 1 &&
+                      center_red(r16_cpu_sampled) >= 126 &&
+                      center_red(r16_cpu_sampled) <= 129 &&
+                      r16_gpu_sampled == r16_cpu_sampled,
+                  "GPU-resident R16F material sampling matches its native CPU round-trip");
+            prosper::test::invalidate_persistent_color_target(r16_target_id);
 
             ResolvedPipelineState r11_state = fp16_state;
             r11_state.color0_format = VK_FORMAT_B10G11R11_UFLOAT_PACK32;

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -139,6 +139,11 @@ int main() {
                   prosper::test::backend_color_bytes_per_pixel(
                       VK_FORMAT_R32G32B32A32_UINT) == 16,
               "portable raw-uvec4 storage images retain all four dword channels");
+        CHECK(prosper::test::backend_color_format(VK_FORMAT_R32G32B32A32_SFLOAT) ==
+                  VK_FORMAT_R32G32B32A32_SFLOAT &&
+                  prosper::test::backend_color_bytes_per_pixel(
+                      VK_FORMAT_R32G32B32A32_SFLOAT) == 16,
+              "RGBA32F color targets retain all four float channels");
     }
 
     // A uniform DCC clear reaches the sampled image without a full CPU-sized pixel allocation or
@@ -412,6 +417,22 @@ int main() {
         CHECK(!gpu_resident.empty() && gpu_resident == cpu_roundtrip &&
                   sampled_stats.sampled_hits == 1,
               "GPU-resident target sampling matches CPU readback+upload byte-for-byte");
+
+        // A packed mip tail may use the same guest ID for two independently rendered extents. The
+        // 32x16 destination is not feedback against the retained 64x32 source: declining the borrow
+        // on address alone leaves this resource with neither GPU pixels nor a CPU fallback and
+        // samples transparent black.
+        prosper::test::BackendColorTarget same_id_smaller_target{
+            target_id, false, true};
+        const std::vector<uint8_t> same_id_different_extent =
+            prosper::test::render_draws_rgba(
+                {gpu_sample}, W / 2u, H / 2u, nullptr, nullptr, false,
+                &same_id_smaller_target);
+        const auto same_id_stats = prosper::test::backend_color_target_stats();
+        CHECK(!same_id_different_extent.empty() &&
+                  center_red(same_id_different_extent) == center_red(cpu_roundtrip) &&
+                  same_id_stats.sampled_hits == 1,
+              "same-address different-extent target borrows the retained source view");
 
         // Exercise the generic compute-image borrow carried by FrameResource. Reuse this exact
         // backend-owned image as a convenient fixture, but address it only through the opaque

--- a/prosper/tests/host/test_dmem.cpp
+++ b/prosper/tests/host/test_dmem.cpp
@@ -745,6 +745,21 @@ int main() {
               fixed_phys, 0x4000) == 0 && fixed_alias,
           "map ordinary alias for incompatible fixed view");
     if (fixed_mapped && fixed_alias) {
+        // GTA V submits an identical fixed BatchMap MAP_DIRECT twice without unmapping it. Linux
+        // accepts the second mmap(MAP_FIXED) as replacement semantics; Windows must not turn the
+        // live MapViewOfFile3 collision into ENOMEM.
+        alignas(8) uint8_t duplicate_direct[0x20]{};
+        *(uint64_t*)(duplicate_direct + 0x00) = fixed_va;
+        *(uint64_t*)(duplicate_direct + 0x08) = fixed_phys;
+        *(uint64_t*)(duplicate_direct + 0x10) = fixed_len;
+        duplicate_direct[0x18] = 0x2;
+        *(int32_t*)(duplicate_direct + 0x1c) = 0; // MAP_DIRECT
+        int32_t duplicate_done = -1;
+        CHECK(batch((uint64_t)(uintptr_t)duplicate_direct, 1,
+                    (uint64_t)(uintptr_t)&duplicate_done, 0, 0, 0) == 0 &&
+                  duplicate_done == 1,
+              "identical fixed BatchMap direct remap is idempotent");
+
         *(volatile uint64_t*)(uintptr_t)(fixed_va + 0x0100) = 0x1111222233334444ull;
         *(volatile uint64_t*)(uintptr_t)(fixed_va + 0x4100) = 0x5555666677778888ull;
         *(volatile uint64_t*)(uintptr_t)(fixed_va + 0xc100) = 0x9999aaaabbbbccccull;

--- a/prosper/tests/host/test_dmem.cpp
+++ b/prosper/tests/host/test_dmem.cpp
@@ -881,6 +881,116 @@ int main() {
                            "clean up reserved read-only alias range");
     if (fixed_phys) release(fixed_phys, fixed_len, 0, 0, 0, 0);
 
+    // GTA V's gameplay allocator reserves disjoint Windows placeholders with one genuinely free
+    // allocation granule between them, then BatchMap MAP_DIRECTs across the whole fragmented range.
+    // MapViewOfFile3 cannot replace multiple placeholders; the HLE must normalize only this
+    // completely guest-owned topology into one replaceable placeholder first.
+    constexpr uint64_t fragmented_base = 0x30000500000ull;
+    constexpr uint64_t fragmented_map_len = 0x40000;
+    constexpr uint64_t fragmented_tail_base = fragmented_base + 0x20000;
+    constexpr uint64_t fragmented_tail_len = 0x30000;
+    uint64_t fragmented_head = fragmented_base;
+    uint64_t fragmented_tail = fragmented_tail_base;
+    uint64_t fragmented_phys = 0;
+    uint64_t fragmented_alias = 0;
+    const bool fragmented_reserved =
+        reserve((uint64_t)(uintptr_t)&fragmented_head, 0x10000,
+                0x10 /* SCE_KERNEL_MAP_FIXED */, 0x10000, 0, 0) == 0 &&
+        fragmented_head == fragmented_base &&
+        reserve((uint64_t)(uintptr_t)&fragmented_tail, fragmented_tail_len,
+                0x10 /* SCE_KERNEL_MAP_FIXED */, 0x10000, 0, 0) == 0 &&
+        fragmented_tail == fragmented_tail_base;
+    CHECK(fragmented_reserved,
+          "reserve the guest/free/guest placeholder topology from GTA V gameplay");
+    CHECK(alloc(0, kEnd, fragmented_map_len, 0x4000, 0,
+                (uint64_t)(uintptr_t)&fragmented_phys) == 0 && fragmented_phys,
+          "allocate physical pages for fragmented fixed BatchMap");
+    bool fragmented_mapped = false;
+    if (fragmented_reserved && fragmented_phys) {
+        alignas(8) uint8_t entry[0x20]{};
+        *(uint64_t*)(entry + 0x00) = fragmented_base;
+        *(uint64_t*)(entry + 0x08) = fragmented_phys;
+        *(uint64_t*)(entry + 0x10) = fragmented_map_len;
+        entry[0x18] = 0x2;
+        *(int32_t*)(entry + 0x1c) = 0; // MAP_DIRECT
+        int32_t done = -1;
+        fragmented_mapped =
+            batch((uint64_t)(uintptr_t)entry, 1, (uint64_t)(uintptr_t)&done,
+                  0, 0, 0) == 0 && done == 1;
+        CHECK(fragmented_mapped,
+              "fragmented guest/free/guest BatchMap MAP_DIRECT succeeds exactly");
+        MEMORY_BASIC_INFORMATION mapped_info{}, retained_tail_info{};
+        VirtualQuery((void*)(uintptr_t)fragmented_base, &mapped_info,
+                     sizeof(mapped_info));
+        VirtualQuery((void*)(uintptr_t)(fragmented_base + fragmented_map_len),
+                     &retained_tail_info, sizeof(retained_tail_info));
+        CHECK(fragmented_mapped && mapped_info.State == MEM_COMMIT &&
+                  mapped_info.RegionSize >= fragmented_map_len,
+              "fragmented fixed range becomes one committed section view");
+        CHECK(retained_tail_info.State == MEM_RESERVE,
+              "unconsumed suffix of the second guest placeholder remains reserved");
+        CHECK(map((uint64_t)(uintptr_t)&fragmented_alias, fragmented_map_len, 0x2, 0,
+                  fragmented_phys, 0x4000) == 0 && fragmented_alias,
+              "map an alias for fragmented fixed BatchMap coherence");
+        if (fragmented_mapped && fragmented_alias) {
+            *(volatile uint64_t*)(uintptr_t)(fragmented_base + 0x21000) =
+                0x5a17f1edb47c0deull;
+            CHECK(*(volatile uint64_t*)(uintptr_t)(fragmented_alias + 0x21000) ==
+                      0x5a17f1edb47c0deull,
+                  "normalized fragmented mapping preserves physical alias coherence");
+        }
+    }
+    if (fragmented_mapped)
+        CHECK(unmap(fragmented_base, fragmented_map_len, 0, 0, 0, 0) == 0,
+              "unmap normalized fragmented fixed view");
+    if (fragmented_alias)
+        CHECK(unmap(fragmented_alias, fragmented_map_len, 0, 0, 0, 0) == 0,
+              "unmap fragmented fixed alias");
+    if (fragmented_reserved)
+        CHECK(unmap(fragmented_base + fragmented_map_len, 0x10000, 0, 0, 0, 0) == 0,
+              "clean up retained fragmented guest-placeholder suffix");
+    if (fragmented_phys)
+        release(fragmented_phys, fragmented_map_len, 0, 0, 0, 0);
+
+    // The same RAGE allocator unmaps across a fragmented guest/free/guest range before a later
+    // fixed remap.  A real host hole is already unmapped and must not turn the whole guest UNMAP
+    // into ERROR_INVALID_ADDRESS.
+    constexpr uint64_t fragmented_unmap_base = 0x30000600000ull;
+    uint64_t fragmented_unmap_head = fragmented_unmap_base;
+    uint64_t fragmented_unmap_tail = fragmented_unmap_base + 0x20000;
+    const bool fragmented_unmap_reserved =
+        reserve((uint64_t)(uintptr_t)&fragmented_unmap_head, 0x10000,
+                0x10 /* SCE_KERNEL_MAP_FIXED */, 0x10000, 0, 0) == 0 &&
+        fragmented_unmap_head == fragmented_unmap_base &&
+        reserve((uint64_t)(uintptr_t)&fragmented_unmap_tail, 0x30000,
+                0x10 /* SCE_KERNEL_MAP_FIXED */, 0x10000, 0, 0) == 0 &&
+        fragmented_unmap_tail == fragmented_unmap_base + 0x20000;
+    CHECK(fragmented_unmap_reserved,
+          "reserve fragmented guest/free/guest topology for BatchMap UNMAP");
+    if (fragmented_unmap_reserved) {
+        alignas(8) uint8_t entry[0x20]{};
+        *(uint64_t*)(entry + 0x00) = fragmented_unmap_base;
+        *(uint64_t*)(entry + 0x10) = fragmented_map_len;
+        *(int32_t*)(entry + 0x1c) = 1; // UNMAP
+        int32_t done = -1;
+        CHECK(batch((uint64_t)(uintptr_t)entry, 1, (uint64_t)(uintptr_t)&done,
+                    0, 0, 0) == 0 && done == 1,
+              "fragmented guest/free/guest BatchMap UNMAP succeeds exactly");
+        MEMORY_BASIC_INFORMATION unmap_info{}, unmap_tail_info{};
+        VirtualQuery((void*)(uintptr_t)fragmented_unmap_base, &unmap_info,
+                     sizeof(unmap_info));
+        VirtualQuery((void*)(uintptr_t)(fragmented_unmap_base + fragmented_map_len),
+                     &unmap_tail_info, sizeof(unmap_tail_info));
+        CHECK(unmap_info.State == MEM_RESERVE &&
+                  unmap_info.RegionSize >= fragmented_map_len,
+              "fragmented UNMAP leaves one reusable placeholder");
+        CHECK(unmap_tail_info.State == MEM_RESERVE,
+              "fragmented UNMAP preserves the unconsumed guest-placeholder suffix");
+        CHECK(unmap(fragmented_unmap_base + fragmented_map_len, 0x10000,
+                    0, 0, 0, 0) == 0,
+              "clean up fragmented UNMAP retained suffix");
+    }
+
     if (fails) { printf("== FAIL: %d check(s) ==\n", fails); return 1; }
     printf("== PASS ==\n");
     return 0;

--- a/prosper/tests/render/test_ds_layer_stride.cpp
+++ b/prosper/tests/render/test_ds_layer_stride.cpp
@@ -229,6 +229,41 @@ int main() {
               "...and a stencil-only write leaves the depth aspect valid");
     }
 
+    // ---- 10. A proven byte-preserving HTILE rewrite does not discard live depth ---------------
+    // GTA V runs a read/modify/write kernel over its complete HTILE plane between the G-buffer and
+    // deferred-lighting passes. When the exact GPU comparator proves the result byte-identical,
+    // the metadata describes the same logical surface as before. The ordinary changed-write arm is
+    // kept beside it: this exception must not hide a fast clear or any other real metadata update.
+    {
+        constexpr uint64_t kDepth = 0x20e0000000ull;
+        constexpr uint64_t kStencil = 0x20f0000000ull;
+        constexpr uint64_t kHtile = 0x2100000000ull;
+        constexpr uint32_t kW = 256, kH = 256;
+
+        prosper::gpu::ResolvedPipelineState ps;
+        ps.depth_read_base = ps.depth_write_base = kDepth;
+        ps.stencil_read_base = ps.stencil_write_base = kStencil;
+        const PersistentDsKey key =
+            prosper::test::persistent_ds_key_for(ps, kHtile, kW, kH, /*format=*/7);
+        auto& image = prosper::test::persistent_ds_cache()[key];
+        image.depth_valid = true;
+        image.stencil_valid = true;
+
+        prosper::gpu::set_guest_gpu_write_origin("gpu-preserving");
+        const size_t preserved =
+            prosper::test::invalidate_persistent_ds_guest_write(kHtile, 4096);
+        prosper::gpu::set_guest_gpu_write_origin(nullptr);
+        check(preserved == 0 && image.depth_valid && image.stencil_valid,
+              "a byte-identical HTILE rewrite preserves both retained aspects");
+
+        prosper::gpu::set_guest_gpu_write_origin("compute-writeback(buffer-full)");
+        const size_t changed =
+            prosper::test::invalidate_persistent_ds_guest_write(kHtile, 4096);
+        prosper::gpu::set_guest_gpu_write_origin(nullptr);
+        check(changed == 1 && !image.depth_valid && !image.stencil_valid,
+              "a changed HTILE write still invalidates both aspects");
+    }
+
     if (failures) { std::fprintf(stderr, "== FAIL: %d ==\n", failures); return 1; }
     std::fprintf(stderr, "== PASS ==\n");
     return 0;

--- a/prosper/tests/shared/diagnostics/test_cfg_trip_bound.cpp
+++ b/prosper/tests/shared/diagnostics/test_cfg_trip_bound.cpp
@@ -118,6 +118,51 @@ int main() {
           "v_cmpx narrows EXEC and s_cbranch_execz exits only when every lane has dropped out "
           "(lane i walks exactly i steps)");
 
+    // The isolated loop normally takes the compact structurizer, while the same loop in GTA's
+    // barrier-separated phase is deliberately sent through the portable CFG dispatcher. Exercise
+    // the exact instruction stream through that production lowering too: the SAVEEXEC packet at
+    // pc2, V_CMPX, EXECZ vote, back edge and EXEC restore must retain the same per-lane result.
+    const std::vector<uint32_t> forced_dispatcher =
+        recompile_valu(kExecWalk, kWords, 2, 2, nullptr, 0,
+                       kDefaultComputePgmRsrc1, true);
+    CHECK(!forced_dispatcher.empty(),
+          "the exact EXEC-walk loop recompiles through the forced portable CFG dispatcher");
+    const std::vector<float> dispatcher_walked =
+        prosper::test::run_compute(forced_dispatcher, input, kLanes, kLanes);
+    uint32_t dispatcher_wrong = 0;
+    for (uint32_t lane = 0;
+         lane < kLanes && dispatcher_walked.size() == kLanes; ++lane)
+        if (std::fabs(dispatcher_walked[lane] - static_cast<float>(lane)) > 0.5f)
+            ++dispatcher_wrong;
+    CHECK(dispatcher_walked.size() == kLanes && dispatcher_wrong == 0,
+          "the portable dispatcher preserves GTA's saveexec/cmpx/execz loop semantics");
+
+    // GTA's failing launch is 2,063 threads in 256-wide workgroups. The final workgroup therefore
+    // has 15 real lanes and 241 padded synchronization participants, which is the condition that
+    // forces the portable dispatcher in production. A complete-workgroup test cannot validate that
+    // ACTIVE/EXEC boundary. Keep every real lane's chain short and distinct enough to detect a
+    // workgroup-wide collapse while reproducing the exact 9-group geometry.
+    constexpr uint32_t kPartialThreads = 2063;
+    constexpr uint32_t kPartialLocal = 256;
+    std::vector<float> partial_input(kPartialThreads * 2, 0.0f);
+    for (uint32_t lane = 0; lane < kPartialThreads; ++lane)
+        partial_input[lane * 2 + 1] = static_cast<float>(lane % 12u);
+    const std::vector<uint32_t> partial_dispatcher = recompile_valu(
+        kExecWalk, kWords, 2, 2, nullptr, 0, kDefaultComputePgmRsrc1, true,
+        kPartialLocal, kPartialThreads);
+    CHECK(!partial_dispatcher.empty(),
+          "the exact EXEC walk recompiles for GTA's partial 2063x256 launch");
+    const std::vector<float> partial_walked = prosper::test::run_compute(
+        partial_dispatcher, partial_input, kPartialThreads, kPartialThreads,
+        {}, {}, nullptr, kPartialLocal);
+    uint32_t partial_wrong = 0;
+    for (uint32_t lane = 0;
+         lane < kPartialThreads && partial_walked.size() == kPartialThreads; ++lane)
+        if (std::fabs(partial_walked[lane] - static_cast<float>(lane % 12u)) > 0.5f)
+            ++partial_wrong;
+    CHECK(partial_walked.size() == kPartialThreads && partial_wrong == 0,
+          "the portable dispatcher preserves the EXEC walk in GTA's partial final workgroup");
+
     // --- the diagnostic ------------------------------------------------------------------------
     // Disarmed, the emitter must be inert: not "close enough", byte-identical. This is the property
     // that lets the bound exist in shipped code at all.

--- a/prosper/tests/shared/live/test_live_target_format.cpp
+++ b/prosper/tests/shared/live/test_live_target_format.cpp
@@ -104,6 +104,13 @@ static bool set_test_env(const char* name, const char* value) {
 } // namespace
 
 int main() {
+    const size_t target_count_limit = prosper::test::persistent_color_target_count_limit();
+    CHECK(prosper::test::persistent_color_target_count_ceiling(false) == target_count_limit &&
+              prosper::test::persistent_color_target_count_ceiling(true) >= target_count_limit &&
+              prosper::test::persistent_color_target_count_ceiling(true) - target_count_limit ==
+                  64u,
+          "an open submission batch gets bounded color-target admission headroom");
+
     // The renderer's replay seed writer is the only public way to publish an RTT identity, and it is
     // registered only when this is set at registration time.
     set_test_env("PROSPER_GPU_REPLAY_RTT_SEEDS", "1");
@@ -118,7 +125,8 @@ int main() {
                                          LiveTargetPixelFormat::R8Unorm,
                                          LiveTargetPixelFormat::R32Uint,
                                          LiveTargetPixelFormat::R32Float,
-                                         LiveTargetPixelFormat::Rg8Unorm};
+                                         LiveTargetPixelFormat::Rg8Unorm,
+                                         LiveTargetPixelFormat::Rgba32Float};
     bool mapped = true, round_trips = true;
     for (LiveTargetPixelFormat format : all) {
         const VkFormat vk = prosper::frontend::live_target_pixel_format_vk(format);
@@ -136,6 +144,13 @@ int main() {
     CHECK(prosper::frontend::live_target_pixel_format_vk(
               LiveTargetPixelFormat::R11G11B10Float) == VK_FORMAT_B10G11R11_UFLOAT_PACK32,
           "R11G11B10Float maps to VK_FORMAT_B10G11R11_UFLOAT_PACK32, not RGBA8");
+    CHECK(prosper::frontend::renderer_mip_target_requires_submit_retention(
+              VK_FORMAT_B10G11R11_UFLOAT_PACK32) &&
+              !prosper::frontend::renderer_mip_target_requires_submit_retention(
+                  VK_FORMAT_R8G8B8A8_UNORM) &&
+              !prosper::frontend::renderer_mip_target_requires_submit_retention(
+                  VK_FORMAT_R16G16B16A16_SFLOAT),
+          "submit-lifetime mip retention selects packed HDR targets only");
 
     // The load-bearing assertions: the registered notifier, for each format the importer accepts.
     const FormatCase cases[] = {
@@ -154,6 +169,8 @@ int main() {
          LiveTargetPixelFormat::R32Float, VK_FORMAT_R32_SFLOAT, 4, "r32f"},
         {prosper::gpu::GpuCaptureColorFormat::Rg8Unorm,
          LiveTargetPixelFormat::Rg8Unorm, VK_FORMAT_R8G8_UNORM, 2, "rg8"},
+        {prosper::gpu::GpuCaptureColorFormat::Rgba32Float,
+         LiveTargetPixelFormat::Rgba32Float, VK_FORMAT_R32G32B32A32_SFLOAT, 16, "rgba32f"},
     };
     uint64_t base = 0x2110310000ull;
     for (const FormatCase& c : cases) {

--- a/prosper/tests/shared/live/test_live_target_format.cpp
+++ b/prosper/tests/shared/live/test_live_target_format.cpp
@@ -114,7 +114,11 @@ int main() {
     using prosper::gpu::LiveTargetPixelFormat;
     const LiveTargetPixelFormat all[] = {LiveTargetPixelFormat::Rgba8Unorm,
                                          LiveTargetPixelFormat::Rgba16Float,
-                                         LiveTargetPixelFormat::R11G11B10Float};
+                                         LiveTargetPixelFormat::R11G11B10Float,
+                                         LiveTargetPixelFormat::R8Unorm,
+                                         LiveTargetPixelFormat::R32Uint,
+                                         LiveTargetPixelFormat::R32Float,
+                                         LiveTargetPixelFormat::Rg8Unorm};
     bool mapped = true, round_trips = true;
     for (LiveTargetPixelFormat format : all) {
         const VkFormat vk = prosper::frontend::live_target_pixel_format_vk(format);
@@ -142,6 +146,14 @@ int main() {
         {prosper::gpu::GpuCaptureColorFormat::R11G11B10Float,
          LiveTargetPixelFormat::R11G11B10Float, VK_FORMAT_B10G11R11_UFLOAT_PACK32, 4,
          "r11g11b10"},
+        {prosper::gpu::GpuCaptureColorFormat::R8Unorm,
+         LiveTargetPixelFormat::R8Unorm, VK_FORMAT_R8_UNORM, 1, "r8"},
+        {prosper::gpu::GpuCaptureColorFormat::R32Uint,
+         LiveTargetPixelFormat::R32Uint, VK_FORMAT_R32_UINT, 4, "r32ui"},
+        {prosper::gpu::GpuCaptureColorFormat::R32Float,
+         LiveTargetPixelFormat::R32Float, VK_FORMAT_R32_SFLOAT, 4, "r32f"},
+        {prosper::gpu::GpuCaptureColorFormat::Rg8Unorm,
+         LiveTargetPixelFormat::Rg8Unorm, VK_FORMAT_R8G8_UNORM, 2, "rg8"},
     };
     uint64_t base = 0x2110310000ull;
     for (const FormatCase& c : cases) {

--- a/prosper/tests/shared/live/test_live_target_format.cpp
+++ b/prosper/tests/shared/live/test_live_target_format.cpp
@@ -126,7 +126,9 @@ int main() {
                                          LiveTargetPixelFormat::R32Uint,
                                          LiveTargetPixelFormat::R32Float,
                                          LiveTargetPixelFormat::Rg8Unorm,
-                                         LiveTargetPixelFormat::Rgba32Float};
+                                         LiveTargetPixelFormat::Rgba32Float,
+                                         LiveTargetPixelFormat::Rg16Float,
+                                         LiveTargetPixelFormat::R16Float};
     bool mapped = true, round_trips = true;
     for (LiveTargetPixelFormat format : all) {
         const VkFormat vk = prosper::frontend::live_target_pixel_format_vk(format);
@@ -171,6 +173,10 @@ int main() {
          LiveTargetPixelFormat::Rg8Unorm, VK_FORMAT_R8G8_UNORM, 2, "rg8"},
         {prosper::gpu::GpuCaptureColorFormat::Rgba32Float,
          LiveTargetPixelFormat::Rgba32Float, VK_FORMAT_R32G32B32A32_SFLOAT, 16, "rgba32f"},
+        {prosper::gpu::GpuCaptureColorFormat::Rg16Float,
+         LiveTargetPixelFormat::Rg16Float, VK_FORMAT_R16G16_SFLOAT, 4, "rg16f"},
+        {prosper::gpu::GpuCaptureColorFormat::R16Float,
+         LiveTargetPixelFormat::R16Float, VK_FORMAT_R16_SFLOAT, 2, "r16f"},
     };
     uint64_t base = 0x2110310000ull;
     for (const FormatCase& c : cases) {

--- a/prosper/tools/screenshot/screenshot.cpp
+++ b/prosper/tools/screenshot/screenshot.cpp
@@ -584,7 +584,7 @@ int main(int argc, char** argv) {
 
     // Register the shared live renderer (feeds the present layer; no BMP spam), then boot + run the
     // guest on its own thread while this thread samples the present layer.
-    prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);
+    prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false, code);
     Program prog; std::string err;
     if (!boot_program(dump, prog, &err, [&]{
 #ifdef PROSPER_AUDIO_FFMPEG


### PR DESCRIPTION
**Docs-only**, stacked on #2996. Records what the rendering series teaches so the knowledge survives
independently of whether every line of the series does.

Written as **mechanisms**, not as a changelog, because most of what the series fixes is not a GTA V
fact — it is a contract prosper had wrong that this title exercised hardest, and several map onto open
issues filed for unrelated reasons.

## The headline

**The core rendering defect was descriptor aliasing.** GTA V's 4K output shader writes the four 8x8
quadrants of each 16x16 block through **four bindings at one guest address**. Captures materialize each
descriptor's bytes into an independently-owned blob, so pointer equality is not a backing identity —
prosper made four images and **lost three of the four stores**, leaving a red/green checker.

The general lesson, which outlives this title: *reconstructed* bytes lose the aliasing the guest
expressed through addresses, so identity has to be re-established explicitly rather than inherited
from the capture.

## Also recorded

- **Typed storage aliases**, with the admitted producer/consumer pairs tabulated (`R32_UINT`→`R32_SFLOAT`,
  `Uint8/16`→UNORM, `R32_UINT` carrier→`B10G11R11`, GFX10 format 50→`A2B10G10R10`) and the deliberate
  refusal to generalize them noted as the right shape.
- **A trap worth remembering:** packed formats report *zero* component width by design, so a generic
  per-component-width test read that as "unsupported" and silently skipped an entire Fidelity dispatch.
- **Wave-vote exactness**, including the *"false Wave64 vote"* from a MAC between a uniform compare and
  `VCCZ` — recorded as **corroboration** of the #2858 frontier reading, explicitly not as proof of it.
- **Platform contracts that outlive this title:** why Windows cannot page-protect guest mappings (a VEH
  frame below the SysV red zone), why driver pipeline caches must be opt-in (an `nvoglv64` crash only
  on the cache-load route), why disabling driver optimization cost 1.7 ms → 47-50 ms per dispatch, and
  the transient Win32 `currentExtent = 0x0`.

## And what is NOT established

- The series' validation is **Windows/NVIDIA on a route this repository does not contain** — it cites
  `scripts/gta5/reach-story-mode-static.pad` and `PROSPER_WAVE64_APPROX`, and **neither exists here**.
- **Linux/RADV measured since:** the world *does* render (prologue bank interior, default launch, no
  compute-skip lever; frame luma 0.3–2.2 → 21.88; 6,077 frames at mean 141.6 fps), but the
  `0x413dc6700` runaway **still hard-recovers the device** at the same program and dispatch index the
  record has always named. Rendering solved; hang not solved.
- Six tests that pass on master fail with the series applied; two were stale version pins, four are
  behavioural and under investigation.

## Verification

`check_numbered_table.py` across every tracked `.md`: passes (`GTA5_STATUS.md`: 69 tables, 287 rows).
`git diff --check`: clean. Diff is `.md`-only.

Refs #1873, #2402, #2723, #2844, #2858, #2863
