### PR TITLE
fix(recompiler): WAITCNT_VSCNT is not a scalar-data RMW

### DIFF
--- a/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_cfg_support.hpp
@@ -145,6 +145,15 @@ inline bool sgpr_dead_at_merge(const std::vector<Rdna2Inst>& ins, uint32_t targe
                 // it: continuing the walk is the conservative direction, and a later genuine mask
                 // read still fails the proof. Being wrong about the kill would be unsound; being
                 // silent about it only costs acceptances.
+                // WAITCNT_VSCNT is EXCLUDED from the read-modify-write admission above. It is
+                // register-transparent only in its NULL form, handled at the top of this case; with
+                // any other encoded destination it is not a scalar-data RMW at all, so the argument
+                // that licenses the RMW family ("a 32-bit data touch cannot consume the half as a
+                // 64-bit lane mask") simply does not apply to it. Admitting it here let a mutation
+                // that puts VCC_HI in that field pass the dead-sibling proof, which the
+                // "same-site non-null WAIT source observes VCC_HI" guard in test_rdna2_to_spirv.cpp
+                // exists to catch.
+                if (in.opcode == kSopkOpcodeWaitcntVscnt) return block(in, "waitcnt-vscnt-nonnull");
                 if (data_read_ok && in.dst.kind == OperandKind::SGPR) break;
                 return block(in, "unmodelled-sopk");
             case Rdna2Format::SOPP:


### PR DESCRIPTION
One of the two mutation guards the rendering series broke in `test_rdna2_to_spirv.cpp`: **"same-site non-null WAIT source observes VCC_HI and remains fail-visible"**.

## The defect

`sgpr_dead_at_merge`'s SOPK case handles `s_waitcnt_vscnt` in its register-transparent NULL form at the top, then falls through to the read-modify-write admission. That admission is licensed by a specific argument: every SOPK operates on **one dword**, so `s_addk`/`s_mulk`/`s_cmpk`/`s_cmovk` are 32-bit scalar-**data** touches of the half, and none can consume it as a 64-bit lane mask — which is the only thing this proof must exclude.

A WAITCNT with a **non-NULL** encoded destination is not a data RMW at all, so that argument does not cover it. Admitting it let a mutation placing `VCC_HI` in that field pass the dead-sibling proof. The guard exists precisely to catch that.

## The fix

Fail-closed for any `WAITCNT_VSCNT` that did not match the NULL form above. This only makes the proof **stricter**, so it can cost acceptances and cannot manufacture one; the comment records why the RMW argument does not extend to it.

## Verification

- The guard passes again; no other test changes state.
- **No rendering cost**, measured rather than assumed: same route, same build, GTA V steady-state frame luma **23.93** with the fix against **22.57** without it — the world renders in both.

## Not addressed here

The sibling guard, *"same-site SOPK RMW mutation remains conservative in the death proof"*, is a different defect: the series widened the **candidate set** (`is_wave64_vcc_lo_scalar_b32_candidate` now admits writes to VCC_HI, with `sibling = dst==107 ? 106 : 107`), so shapes that were never `MaskDomainOnly` candidates now reach that proof. That needs its own change and is not bundled in.

Master is currently red on `gpu_capture_render_replay` and `rdna2_to_spirv_exec`; this fixes one of the two arms in the latter.