### PR TITLE
fix(tools): boot_trace compiles on Windows again — and 15 ctest cases stop silently not running

### DIFF
--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -259,8 +259,17 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[first-frame] CAPTURE MODE ENABLED\n");
         fprintf(stderr, "[first-frame] output: %s\n", capture_first_frame_path.c_str());
         
-        // Enable rendering (required for present_write_frame to produce frames)
+        // Enable rendering (required for present_write_frame to produce frames).
+        // Not bare setenv: MinGW has no POSIX setenv, so this tool did not COMPILE on Windows at
+        // all -- and because it is one target in a whole-tree build, its failure stopped ninja
+        // before most test executables were linked, which surfaced as ~15 ctest cases Not Run
+        // rather than as a broken tool. Present since the --capture-first-frame commit (#3014).
+#ifdef _WIN32
+        _putenv_s("PROSPER_RENDER", "1");
+#else
         setenv("PROSPER_RENDER", "1", 1);
+#endif
+
         
         // Register the live renderer (same as screenshot tool / prosper-app)
         prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);


### PR DESCRIPTION
Fixes #3014.

## Failure scenario

`prosper/tools/boot_trace/boot_trace.cpp:263` called POSIX `setenv`, which MinGW does not provide:

```
boot_trace.cpp:263:9: error: 'setenv' was not declared in this scope; did you mean 'getenv'?
```

Present since `d154907a` (2026-08-11, the `--capture-first-frame` observer).

## Why it mattered more than one tool

`boot_trace` is one target in a whole-tree build, so ninja stops there and **most test executables
never link**. The observable result was not "a tool is broken" but:

```
ctest EXIT=8 ... 15 cases (Not Run)
```

`initfault_dump_survives`, `hle_stack_args`, `ime_fs`, `x86_read_decode`, `fault_context`,
`agc_dcb_callback_abi`, `agc_submit_to_gpustate`, `videoout_queries`, `game_compute_exec`,
`game_compute_exec_no_adaptive_storage_result`, `video_media_foundation`, `audio_sdl3`,
`shared_vulkan_device`, `live_target_format`, `present_blit`.

That is the shape CLAUDE.md warns about, where "no tests ran" and "everything passed" are hard to
distinguish. Anyone building a subset target (`--target prosper-app`) never sees it, which is how it
survived a fortnight on a platform that is actively developed.

## Approach

Guard it exactly as `prosper-app` already does (`frontends/prosper-app/main.cpp:132`,
`set_environment`): `_putenv_s` on `_WIN32`, `setenv` elsewhere. No behavioural change on Linux or
macOS — the non-Windows branch is the original call.

## Affected / deliberately unaffected

- **Affected:** the Windows build of `boot_trace`, and therefore whether the Windows test suite links.
- **Unaffected:** every non-Windows platform (same `setenv` call), and `boot_trace`'s runtime
  behaviour on all platforms (the variable set is identical).

## Verification (exact head)

Windows 11, MinGW-w64/UCRT GCC 16.1, `RelWithDebInfo`, `-DPROSPER_APP=ON`:

| | build | ctest |
| --- | --- | --- |
| before | exit **1** | exit **8**, 15 Not Run, 227 attempted |
| after | exit **0** | exit **0**, **242/242 passed**, 23.9 s |

```
cmake --build prosper/build-mingw-app -j8
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4
```

`--no-tests=error` per CLAUDE.md, and the count is quoted rather than only the exit code.

## Risk

Minimal — a two-line platform guard on an `#ifdef` pattern already used in this repo. The residual
risk is that no Windows CI job builds the whole tree, so the next instance of this class will also
surface as silently-skipped tests rather than as a build failure. Worth a follow-up job; noted in the
issue.