### PR TITLE
fix(app): the --fps HUD reports a real rate under GPU present, instead of "no frames published yet"

### DIFF
--- a/BLOG.md
+++ b/BLOG.md
@@ -31,6 +31,15 @@ Croft Manor now renders with correct geometry — same route, same scene, same b
 
 Surfaces are still untextured — that is the next thing. [#2990](https://github.com/mattias800/prosper/issues/2990)
 
+### The fps counter works now, and it can tell a frozen picture from a running one
+
+`--fps` read `no frames published yet` for the whole life of every real game boot, on every platform.
+It now shows the presented rate and the rate the picture actually *changes* at, and says
+`picture not changing` when those disagree -- which is what a hung title looks like from outside,
+since a frozen picture still presents at 60.
+
+No picture: it is a number on a HUD, easier to see by running `--fps` than to photograph.
+
 ### Tomb Raider I-III Remastered boots for the first time, and reaches its title screen
 
 We now reach the rendered Tomb Raider I title screen. This title had never been launched in prosper

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -171,6 +171,24 @@ struct Vk {
     VkDeviceMemory  stageImgMem = VK_NULL_HANDLE;
     uint32_t        stageW = 0, stageH = 0;
 
+    // --fps content sampling on the GPU present path (#3010). The swapchain blit reads the
+    // renderer's image and never touches host memory, so the distinct-frame counter had nothing to
+    // observe. These take a small NEAREST-filtered copy of the same image in the same command
+    // buffer, which is a point-sample grid over the presented picture, and read it back one frame
+    // late so no extra fence wait is introduced.
+    //
+    // Allocated only when --fps asked for the counter: this is an instrument, and an instrument that
+    // runs when nobody asked for it is how a measurement pass ends up measuring itself (#2113).
+    VkImage         sampleImg    = VK_NULL_HANDLE;
+    VkDeviceMemory  sampleImgMem = VK_NULL_HANDLE;
+    VkBuffer        sampleBuf    = VK_NULL_HANDLE;
+    VkDeviceMemory  sampleMem    = VK_NULL_HANDLE;
+    void*           sampleMapped = nullptr;
+    // A sample recorded last present and not yet signed. The fence that guards it is inFlight,
+    // which present_frame_gpu already waits on at entry, so the read is free.
+    bool            samplePending = false;
+
+
     VkCommandPool   cmdPool = VK_NULL_HANDLE;
     VkCommandBuffer cmd     = VK_NULL_HANDLE;
     VkSemaphore     acquireSem = VK_NULL_HANDLE;
@@ -364,6 +382,64 @@ bool ensure_stage(Vk& vk, uint32_t w, uint32_t h) {
     VKCHECK(vkAllocateMemory(vk.device, &ai, nullptr, &vk.stageImgMem), "stage image mem");
     vkBindImageMemory(vk.device, vk.stageImg, vk.stageImgMem, 0);
     return true;
+}
+
+// The --fps content-sample grid (#3010). Fixed size, so it survives swapchain and source-extent
+// changes untouched: the signature only has to be comparable with the PREVIOUS signature, and a grid
+// that resized would make consecutive frames incomparable for one frame every time the guest
+// reconfigured VideoOut -- reporting a content change that did not happen.
+//
+// 256x144 is 36,864 points, above the ~8,100 pixels frame_content_signature samples from a 1080p
+// frame, and it costs 147,456 bytes of host memory and one small blit per present.
+constexpr uint32_t kFpsSampleW = 256, kFpsSampleH = 144;
+constexpr VkDeviceSize kFpsSampleBytes = (VkDeviceSize)kFpsSampleW * kFpsSampleH * 4;
+
+// True once the sample grid is usable. Failure is not fatal and not retried: --fps degrades to the
+// unmeasured HUD rather than taking the app down over an instrument.
+bool ensure_fps_sample(Vk& vk) {
+    if (vk.sampleBuf) return true;
+
+    VkBufferCreateInfo bi{VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO};
+    bi.size = kFpsSampleBytes;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    if (vkCreateBuffer(vk.device, &bi, nullptr, &vk.sampleBuf) != VK_SUCCESS) return false;
+    VkMemoryRequirements mr; vkGetBufferMemoryRequirements(vk.device, vk.sampleBuf, &mr);
+    VkMemoryAllocateInfo ai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+    ai.allocationSize = mr.size;
+    ai.memoryTypeIndex = find_mem(vk.phys, mr.memoryTypeBits,
+                                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (vkAllocateMemory(vk.device, &ai, nullptr, &vk.sampleMem) != VK_SUCCESS) goto fail;
+    vkBindBufferMemory(vk.device, vk.sampleBuf, vk.sampleMem, 0);
+    if (vkMapMemory(vk.device, vk.sampleMem, 0, kFpsSampleBytes, 0, &vk.sampleMapped) != VK_SUCCESS)
+        goto fail;
+
+    {
+        VkImageCreateInfo ii{VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO};
+        ii.imageType = VK_IMAGE_TYPE_2D; ii.format = VK_FORMAT_R8G8B8A8_UNORM;
+        ii.extent = {kFpsSampleW, kFpsSampleH, 1};
+        ii.mipLevels = 1; ii.arrayLayers = 1; ii.samples = VK_SAMPLE_COUNT_1_BIT;
+        ii.tiling = VK_IMAGE_TILING_OPTIMAL;
+        ii.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
+        ii.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        if (vkCreateImage(vk.device, &ii, nullptr, &vk.sampleImg) != VK_SUCCESS) goto fail;
+        VkMemoryRequirements imr; vkGetImageMemoryRequirements(vk.device, vk.sampleImg, &imr);
+        VkMemoryAllocateInfo iai{VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO};
+        iai.allocationSize = imr.size;
+        iai.memoryTypeIndex = find_mem(vk.phys, imr.memoryTypeBits, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        if (vkAllocateMemory(vk.device, &iai, nullptr, &vk.sampleImgMem) != VK_SUCCESS) goto fail;
+        vkBindImageMemory(vk.device, vk.sampleImg, vk.sampleImgMem, 0);
+    }
+    return true;
+
+fail:
+    fprintf(stderr, "[fps] content sampling unavailable; the HUD will report the presented rate only\n");
+    if (vk.sampleMapped) { vkUnmapMemory(vk.device, vk.sampleMem); vk.sampleMapped = nullptr; }
+    if (vk.sampleImg)    { vkDestroyImage(vk.device, vk.sampleImg, nullptr); vk.sampleImg = VK_NULL_HANDLE; }
+    if (vk.sampleImgMem) { vkFreeMemory(vk.device, vk.sampleImgMem, nullptr); vk.sampleImgMem = VK_NULL_HANDLE; }
+    if (vk.sampleBuf)    { vkDestroyBuffer(vk.device, vk.sampleBuf, nullptr); vk.sampleBuf = VK_NULL_HANDLE; }
+    if (vk.sampleMem)    { vkFreeMemory(vk.device, vk.sampleMem, nullptr); vk.sampleMem = VK_NULL_HANDLE; }
+    return false;
 }
 
 void barrier(VkCommandBuffer c, VkImage img, VkImageLayout from, VkImageLayout to,
@@ -600,7 +676,7 @@ bool try_adopt_shared_present(Vk& vk, SDL_Window* win) {
 // now in flight and returns the acquire/present outcome.
 prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::frontend::GpuScanoutFrame& gf,
                                                     int& prevSlot, bool requestReadback,
-                                                    bool& readbackReady,
+                                                    bool& readbackReady, bool sampleContent,
                                                     const std::vector<std::string>* overlayLines = nullptr) {
     readbackReady = false;
     const VkResult previousWait = vkWaitForFences(
@@ -614,6 +690,15 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
         fprintf(stderr, "[app] gpu-present fence wait failed (%d); stopping\n",
                 static_cast<int>(previousWait));
         return prosper::frontend::PresentAttempt::failed;
+    }
+    // The wait above is the same fence that guarded last present's sample copy, so the sample is
+    // readable here at no cost. Signing it one frame late is invisible in a rate: the counter needs
+    // the interval between distinct frames, not the frame's own timestamp.
+    if (vk.samplePending) {
+        vk.samplePending = false;
+        gpu::note_present_publication_signature(
+            gpu::dense_content_signature(static_cast<const uint8_t*>(vk.sampleMapped),
+                                         (size_t)kFpsSampleBytes));
     }
     if (prevSlot >= 0) { prosper::frontend::present_blit_release(prevSlot); prevSlot = -1; }
     if (requestReadback && !ensure_stage(vk, gf.width, gf.height)) {
@@ -651,6 +736,41 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
     blit.dstOffsets[1] = {(int32_t)vk.scExtent.width, (int32_t)vk.scExtent.height, 1};
     vkCmdBlitImage(vk.cmd, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                    vk.scImages[imgIndex], VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_LINEAR);
+    // --fps content sample (#3010): a NEAREST-filtered reduction of the SAME image the swapchain
+    // blit just read, copied to host memory. NEAREST rather than LINEAR on purpose -- averaging
+    // would let a small bright change cancel against its neighbours, and this exists to detect
+    // change, not to look good. Signed at the top of the NEXT present, under the fence already
+    // waited on there, so this adds no synchronisation.
+    if (sampleContent && vk.sampleImg) {
+        barrier(vk.cmd, vk.sampleImg, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                0, VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT);
+        VkImageBlit sb{};
+        sb.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        sb.srcOffsets[1] = {(int32_t)gf.width, (int32_t)gf.height, 1};
+        sb.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        sb.dstOffsets[1] = {(int32_t)kFpsSampleW, (int32_t)kFpsSampleH, 1};
+        vkCmdBlitImage(vk.cmd, gf.image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                       vk.sampleImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &sb, VK_FILTER_NEAREST);
+        barrier(vk.cmd, vk.sampleImg, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_ACCESS_TRANSFER_WRITE_BIT,
+                VK_ACCESS_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                VK_PIPELINE_STAGE_TRANSFER_BIT);
+        VkBufferImageCopy sc{};
+        sc.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
+        sc.imageExtent = {kFpsSampleW, kFpsSampleH, 1};
+        vkCmdCopyImageToBuffer(vk.cmd, vk.sampleImg, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                               vk.sampleBuf, 1, &sc);
+        VkBufferMemoryBarrier sh{VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER};
+        sh.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+        sh.dstAccessMask = VK_ACCESS_HOST_READ_BIT;
+        sh.srcQueueFamilyIndex = sh.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        sh.buffer = vk.sampleBuf; sh.offset = 0; sh.size = kFpsSampleBytes;
+        vkCmdPipelineBarrier(vk.cmd, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_HOST_BIT,
+                             0, 0, nullptr, 1, &sh, 0, nullptr);
+        vk.samplePending = true;
+    }
+
     if (requestReadback) {
         VkBufferImageCopy copy{};
         copy.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -1764,6 +1884,9 @@ int main(int argc, char** argv) {
     prosper::gpu::PresentRateSnapshot fpsWindow = prosper::gpu::present_rate_snapshot();
     prosper::gpu::FrameRate fpsRate;
     std::vector<std::string> fpsLines;
+    // The extent last presented through the GPU path, for the HUD's resolution field (#3010).
+    uint32_t gpuPresentedW = 0, gpuPresentedH = 0;
+
 #ifdef PROSPER_HAVE_LIBRARY_UI
     // The library replaces the empty idle window. Only meaningful when this run has no game of its own
     // and is not feeding a test pattern; a failure to bring it up is not fatal — the flat idle colour
@@ -2403,15 +2526,26 @@ int main(int argc, char** argv) {
                                      vk.scFormat, vk.scImages, vk.scExtent)) {
                     fprintf(stderr, "[app] --fps could not start; continuing without the counter.\n");
                     showFps = false;
+                } else if (vk.gpu_present) {
+                    // GPU present publishes no CPU pixels, so the counter has to sample the
+                    // presented image itself (#3010). Allocated only here: with --fps off the
+                    // present path stays byte-for-byte what it was.
+                    ensure_fps_sample(vk);
                 }
             }
+
             const prosper::gpu::PresentRateSnapshot now = prosper::gpu::present_rate_snapshot();
             if (prosper::frontend::fps_window_due(fpsWindow.now_seconds, now.now_seconds,
                                                   kFpsWindowSeconds)) {
                 fpsRate = prosper::gpu::frame_rate_between(fpsWindow, now);
                 fpsWindow = now;
+                // present_frame_width/height are fed by the CPU publish path and read 0 under GPU
+                // present, so the HUD showed "0x0" there. Prefer the extent actually presented.
                 fpsLines = prosper::frontend::fps_hud_lines(
-                    fpsRate, gpu::present_frame_width(), gpu::present_frame_height(), now.distinct);
+                    fpsRate,
+                    gpuPresentedW ? gpuPresentedW : gpu::present_frame_width(),
+                    gpuPresentedH ? gpuPresentedH : gpu::present_frame_height(),
+                    now.distinct);
             }
         }
         // Only a HUD that has something to say is passed down; an empty list leaves both present
@@ -2433,7 +2567,9 @@ int main(int argc, char** argv) {
                 }
                 bool grabReady = false;
                 PresentAttempt attempt = present_frame_gpu(
-                    vk, gf, gpuPrevSlot, !pendingGrabScreenshot.empty(), grabReady, fpsForPresent);
+                    vk, gf, gpuPrevSlot, !pendingGrabScreenshot.empty(), grabReady,
+                    showFps, fpsForPresent);
+                gpuPresentedW = gf.width; gpuPresentedH = gf.height;
                 if (grabReady)
                     flushGrabScreenshot(static_cast<const uint8_t*>(vk.stageMapped),
                                         gf.width, gf.height);
@@ -2452,8 +2588,19 @@ int main(int argc, char** argv) {
                     if (shown - mark >= 60) {
                         auto now = std::chrono::steady_clock::now();
                         double s = std::chrono::duration<double>(now - t0).count();
-                        fprintf(stderr, "[app] %.1f fps (%llu frames, gpu-present)\n",
-                                (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown);
+                        // The PRESENTED rate, and -- when --fps armed the content sample (#3010) --
+                        // the DISTINCT rate beside it. Both, because they answer different questions:
+                        // a title whose picture is frozen still presents at 60, and this line alone
+                        // read healthy right through the Windows splash stall in #3011.
+                        char distinct[64] = "";
+                        if (showFps && fpsRate.measured)
+                            snprintf(distinct, sizeof distinct, ", %.1f distinct%s",
+                                     fpsRate.distinct_fps,
+                                     prosper::gpu::frame_rate_is_mostly_unchanged(fpsRate)
+                                         ? " PICTURE NOT CHANGING" : "");
+                        fprintf(stderr, "[app] %.1f fps (%llu frames, gpu-present%s)\n",
+                                (shown - mark) / (s > 0 ? s : 1), (unsigned long long)shown, distinct);
+
                         t0 = now; mark = shown;
                     }
                 }
@@ -2539,10 +2686,20 @@ int main(int argc, char** argv) {
                                     (unsigned long long)gpu::present_count(), nonzeroRgbBytes,
                                     (size_t)w * h * 3);
                         } else {
-                            fprintf(stderr, "[app] %.1f fps (%llu frames)\n",
+                            // Same two rates as the GPU branch (#3010), so a run can be compared
+                            // across present paths. Here the distinct rate comes from the CPU
+                            // publish hash rather than from a sampled grid.
+                            char distinct[64] = "";
+                            if (showFps && fpsRate.measured)
+                                snprintf(distinct, sizeof distinct, ", %.1f distinct%s",
+                                         fpsRate.distinct_fps,
+                                         prosper::gpu::frame_rate_is_mostly_unchanged(fpsRate)
+                                             ? " PICTURE NOT CHANGING" : "");
+                            fprintf(stderr, "[app] %.1f fps (%llu frames%s)\n",
                                     (shown - mark) / (s > 0 ? s : 1),
-                                    (unsigned long long)shown);
+                                    (unsigned long long)shown, distinct);
                         }
+
                         t0 = now; mark = shown;
                     }
                 }
@@ -2596,6 +2753,14 @@ int main(int argc, char** argv) {
     libraryUi.shutdown();
 #endif
     vkDeviceWaitIdle(vk.device);
+    // After the idle above: these are read by the present command buffer, so they can only be
+    // released once no submit can still be reading them (#3010).
+    if (vk.sampleMapped) vkUnmapMemory(vk.device, vk.sampleMem);
+    if (vk.sampleImg)    vkDestroyImage(vk.device, vk.sampleImg, nullptr);
+    if (vk.sampleImgMem) vkFreeMemory(vk.device, vk.sampleImgMem, nullptr);
+    if (vk.sampleBuf)    vkDestroyBuffer(vk.device, vk.sampleBuf, nullptr);
+    if (vk.sampleMem)    vkFreeMemory(vk.device, vk.sampleMem, nullptr);
+
     SDL_DestroyWindow(win); SDL_Quit();
     return exitCode;
 }

--- a/prosper/frontends/prosper-app/main.cpp
+++ b/prosper/frontends/prosper-app/main.cpp
@@ -394,8 +394,10 @@ bool ensure_stage(Vk& vk, uint32_t w, uint32_t h) {
 constexpr uint32_t kFpsSampleW = 256, kFpsSampleH = 144;
 constexpr VkDeviceSize kFpsSampleBytes = (VkDeviceSize)kFpsSampleW * kFpsSampleH * 4;
 
-// True once the sample grid is usable. Failure is not fatal and not retried: --fps degrades to the
-// unmeasured HUD rather than taking the app down over an instrument.
+// True once the sample grid is usable. Failure is not fatal: --fps degrades to the unmeasured HUD
+// rather than taking the app down over an instrument. It IS re-attempted, because the caller runs
+// this whenever the overlay is not yet ready -- the early-out on the first line is what makes a
+// success cheap, not a latch that would stop a retry.
 bool ensure_fps_sample(Vk& vk) {
     if (vk.sampleBuf) return true;
 
@@ -820,8 +822,14 @@ prosper::frontend::PresentAttempt present_frame_gpu(Vk& vk, const prosper::front
     }
     if (submitResult != VK_SUCCESS) {
         prosper::frontend::present_blit_release(gf.slot);
+        // The sample copy was RECORDED but never executed, so the buffer still holds the previous
+        // frame (or is indeterminate on the first pass). Clearing the flag keeps the counter from
+        // signing bytes no present produced -- one spurious distinct-or-not verdict, in bounds and
+        // harmless, but it would be a measurement of nothing.
+        vk.samplePending = false;
         return recover_submit_failure(vk, submitResult);
     }
+
     prevSlot = gf.slot;
     if (requestReadback) {
         const VkResult waitResult = vkWaitForFences(vk.device, 1, &vk.inFlight, VK_TRUE, UINT64_MAX);
@@ -2588,7 +2596,15 @@ int main(int argc, char** argv) {
                     if (shown - mark >= 60) {
                         auto now = std::chrono::steady_clock::now();
                         double s = std::chrono::duration<double>(now - t0).count();
+                        // present_frame_rate.hpp says any caller of frame_rate_is_mostly_unchanged
+                        // must report active_fraction beside it, to separate "a static menu that HAS
+                        // produced frames" from "a title producing nothing". frame_rate_between
+                        // cannot supply it (:290 leaves it unfilled by construction), so the
+                        // PRESENTED rate printed on this same line carries that job: a non-zero
+                        // presented rate is exactly the evidence that frames are still arriving.
+                        // Recorded as #3027 rather than left as a silent divergence.
                         // The PRESENTED rate, and -- when --fps armed the content sample (#3010) --
+
                         // the DISTINCT rate beside it. Both, because they answer different questions:
                         // a title whose picture is frozen still presents at 60, and this line alone
                         // read healthy right through the Windows splash stall in #3011.

--- a/prosper/src/gpu/present/present_frame_rate.cpp
+++ b/prosper/src/gpu/present/present_frame_rate.cpp
@@ -239,6 +239,32 @@ void note_present_publication(const uint8_t* pixels, size_t bytes, uint32_t widt
     g_rate.observe(signature, at);
 }
 
+uint64_t dense_content_signature(const uint8_t* pixels, size_t bytes) {
+    uint64_t h = 0xcbf29ce484222325ull;
+    mix(h, static_cast<uint64_t>(bytes));
+    if (!pixels || bytes == 0) return h;
+    // Every 8-byte word, then the unaligned tail. The buffer is small by construction (the caller
+    // owns the sample grid), so there is nothing to gain by skipping any of it.
+    size_t i = 0;
+    for (; i + sizeof(uint64_t) <= bytes; i += sizeof(uint64_t)) {
+        uint64_t word = 0;
+        std::memcpy(&word, pixels + i, sizeof word);
+        mix(h, word);
+    }
+    if (i < bytes) {
+        uint64_t tail = 0;
+        std::memcpy(&tail, pixels + i, bytes - i);
+        mix(h, tail);
+    }
+    return h;
+}
+
+void note_present_publication_signature(uint64_t signature) {
+    const double at = now_seconds();
+    std::lock_guard<std::mutex> lk(g_rate_mx);
+    g_rate.observe(signature, at);
+}
+
 void reset_present_rate() {
     std::lock_guard<std::mutex> lk(g_rate_mx);
     g_rate.reset();

--- a/prosper/src/gpu/present/present_frame_rate.hpp
+++ b/prosper/src/gpu/present/present_frame_rate.hpp
@@ -343,6 +343,38 @@ bool frame_rate_is_mostly_unchanged(const FrameRate& rate,
 // state, so it must not lengthen that critical section.
 void note_present_publication(const uint8_t* pixels, size_t bytes, uint32_t width, uint32_t height);
 
+// The GPU present path (#1270) has no CPU pixels: prosper-app blits the renderer's front-buffer image
+// straight to the swapchain and the renderer skips the CPU readback entirely (live_renderer.cpp), so
+// note_present_publication above is never reached and this counter stayed unfed for the whole life of
+// every interactive boot -- the HUD read "no frames published yet" while thousands of frames were on
+// screen (#3010). That path feeds these two instead: it samples the presented image into a small
+// host-visible buffer on the GPU, signs the sample DENSELY, and publishes the signature.
+//
+// Dense, not sampled, and the distinction is the point. frame_content_signature reads 16 bytes per
+// 4 KiB block, which is the right ratio for a multi-megabyte frame but would reduce a 256x144 sample
+// to ~144 sampled pixels -- weak enough to call a changing picture frozen. Signing every byte of a
+// deliberately small point-sampled image keeps the sensitivity in ONE place (the sample grid) instead
+// of multiplying two lossy stages together.
+//
+// The resulting distinct rate remains a LOWER bound on the true rate of new frames, for the same
+// reason the CPU path's is: a change confined to pixels the grid misses is invisible to it. The grid
+// is 36,864 points against the CPU path's ~8,100 sampled pixels at 1080p, so it is a tighter bound
+// than the path it stands in for -- but it is still a bound, and must not be read as an exact count.
+//
+// One asymmetry to know about: these two entry points sign in DIFFERENT spaces (a dense 256x144
+// sample here, a sparse whole-frame hash there), so a run that alternates between them -- GPU
+// present with occasional publish misses falling back to the CPU path -- records a distinct frame at
+// every crossing even when the picture did not change. Misses are rare enough that this does not
+// move a rate in practice, but it means the distinct count is not a strict lower bound on a MIXED
+// run the way it is on either path alone.
+
+uint64_t dense_content_signature(const uint8_t* pixels, size_t bytes);
+
+// Publish a signature computed by the caller. Same accounting as note_present_publication -- one
+// publication, distinct if the signature differs from the immediately preceding one.
+void note_present_publication_signature(uint64_t signature);
+
+
 // Cleared by present_reset(), so a test that resets the present layer resets the rate with it.
 void reset_present_rate();
 

--- a/prosper/tests/gpu/present/test_present_frame_rate.cpp
+++ b/prosper/tests/gpu/present/test_present_frame_rate.cpp
@@ -344,6 +344,50 @@ void present_layer_wiring() {
     present_reset();
 }
 
+// The GPU present path signs a SMALL sample densely instead of a large frame sparsely (#3010).
+// Both halves of that choice are pinned here, and the sample buffers are built BY HAND rather than
+// drawn from whatever the accumulator would produce (instrument trap 122).
+void dense_signature_pins_the_gpu_path() {
+    // The grid prosper-app actually uses: 256x144 RGBA8.
+    constexpr size_t kBytes = 256u * 144u * 4u;
+    std::vector<uint8_t> a(kBytes, 0x40);
+    std::vector<uint8_t> b = a;
+    // ONE pixel, in the middle, changed by one step. This is the case the counter has to see: a
+    // title whose picture changes only in a small region must not read as frozen.
+    const size_t px = ((144u / 2) * 256u + 128u) * 4u;
+    b[px + 1] = 0x41;
+
+    CHECK(dense_content_signature(a.data(), a.size()) !=
+          dense_content_signature(b.data(), b.size()),
+          "the dense signature sees a single changed pixel in the sample grid");
+    CHECK(dense_content_signature(a.data(), a.size()) ==
+          dense_content_signature(a.data(), a.size()),
+          "...and is stable for identical bytes");
+    CHECK(dense_content_signature(nullptr, 0) == dense_content_signature(nullptr, 0),
+          "an empty sample signs consistently rather than trapping");
+
+    // WHY dense: at this buffer size the sparse whole-frame signature reads only a few hundred
+    // bytes, so it can miss the same change. Recorded as a measurement, not an assumption -- if
+    // this ever stops holding, the dense variant has lost its justification and should go.
+    const bool sparse_misses_it =
+        frame_content_signature(a.data(), a.size(), 256, 144) ==
+        frame_content_signature(b.data(), b.size(), 256, 144);
+    std::printf("   sparse signature on a 256x144 sample %s this change\n",
+                sparse_misses_it ? "MISSES" : "sees");
+
+    // And the publication accounting is the same as the pixel entry point's.
+    present_reset();
+    const uint64_t sig_a = dense_content_signature(a.data(), a.size());
+    const uint64_t sig_b = dense_content_signature(b.data(), b.size());
+    note_present_publication_signature(sig_a);
+    note_present_publication_signature(sig_a);
+    note_present_publication_signature(sig_b);
+    const PresentRateSnapshot s = present_rate_snapshot();
+    CHECK(s.published == 3, "three signatures published");
+    CHECK(s.distinct == 2, "the repeat is not distinct; the changed one is");
+    present_reset();
+}
+
 } // namespace
 
 int main() {
@@ -355,6 +399,7 @@ int main() {
     std::printf("== estimator accuracy ==\n");           interval_estimator_is_accurate();
     std::printf("== window arithmetic ==\n");            window_math();
     std::printf("== present-layer wiring ==\n");         present_layer_wiring();
+    std::printf("== dense signature (GPU path) ==\n"); dense_signature_pins_the_gpu_path();
     std::printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
     return fails ? 1 : 0;
 }

--- a/prosper/tests/gpu/present/test_present_frame_rate.cpp
+++ b/prosper/tests/gpu/present/test_present_frame_rate.cpp
@@ -366,14 +366,14 @@ void dense_signature_pins_the_gpu_path() {
     CHECK(dense_content_signature(nullptr, 0) == dense_content_signature(nullptr, 0),
           "an empty sample signs consistently rather than trapping");
 
-    // WHY dense: at this buffer size the sparse whole-frame signature reads only a few hundred
-    // bytes, so it can miss the same change. Recorded as a measurement, not an assumption -- if
-    // this ever stops holding, the dense variant has lost its justification and should go.
-    const bool sparse_misses_it =
-        frame_content_signature(a.data(), a.size(), 256, 144) ==
-        frame_content_signature(b.data(), b.size(), 256, 144);
-    std::printf("   sparse signature on a 256x144 sample %s this change\n",
-                sparse_misses_it ? "MISSES" : "sees");
+    // WHY dense, ASSERTED rather than printed: at this buffer size the sparse whole-frame signature
+    // reads only a few hundred bytes and misses the same change. This was a printf, which made it an
+    // experiment that could not fail -- if the sparse signature ever became sensitive enough here the
+    // dense variant would have lost its justification and nobody would have been told. Now the day
+    // that changes, this goes red and someone removes dense_content_signature on purpose.
+    CHECK(frame_content_signature(a.data(), a.size(), 256, 144) ==
+              frame_content_signature(b.data(), b.size(), 256, 144),
+          "the sparse whole-frame signature MISSES it at this size -- which is why dense exists");
 
     // And the publication accounting is the same as the pixel entry point's.
     present_reset();


### PR DESCRIPTION
Fixes #3010.

## Failure scenario

`prosper-app --dump <dump> --fps` on any real game. The title boots, presents thousands of frames,
stderr reports `[app] 64.0 fps (7560 frames, gpu-present)` — and the on-screen HUD reads
`-- fps` / `no frames published yet` for the entire run. Reproduced on Windows/NVIDIA with *The
Messenger* and *Grand Theft Auto V*; the cause is platform-independent and this was the **default path
for every game**, since `request_gpu_present()` returns true for any boot with a dump.

## Behavioural contract

The HUD's headline is deliberately the **distinct** (content-changed) rate, not the presented rate —
`fps_hud.hpp` argues this at length, because a title whose picture is frozen still presents at ~60
(the R-Type Delta shape, #2783, instrument trap 90). That contract was intact; its **feed** was not.

## Cause

`note_present_publication` had exactly one caller: `present_write_frame`
(`videoout_present.cpp:53`). GPU present (#1270) bypasses it at both ends —

- `live_renderer.cpp:8910` *"SKIP\[s\] the CPU readback+reupload entirely"* when the front-buffer blit
  succeeds, so no CPU frame is published;
- `main.cpp`'s `if (vk.gpu_present)` branch blits to the swapchain directly and does not call it either.

So `FrameRate::measured` stayed false forever. The app's stderr line was unaffected because it counts
with its own local counter — hence one run reporting two contradictory things.

## Why no test caught it

`live_renderer.cpp:8904` says it outright: `gpu_present_active()` is *"false in every
headless/test/screenshot process"*. `tools/screenshot`, the snapshot guards and the core suite all
exercise the CPU path, where the counter works correctly. `test_fps_hud.cpp` asserts the pure decision
function — including the `no frames published yet` string — and passes. **The decision was covered; the
feed was not.** The only configuration on the broken path is the interactive app, which is also the
only place a human reads this HUD.

## Approach

The GPU path samples the presented image itself: a **256x144 `VK_FILTER_NEAREST`** reduction of the
same image the swapchain blit just read, recorded in the same command buffer, copied to host memory,
and signed at the top of the **next** present — under the fence `present_frame_gpu` already waits on,
so **no synchronisation is added**. NEAREST, not LINEAR: averaging lets a small bright change cancel
against its neighbours, and this exists to detect change.

Signed **densely** rather than with `frame_content_signature`, and the test *measures* why rather than
asserting it: the sparse signature reads 16 bytes per 4 KiB block, which is right for a
multi-megabyte frame but reduces a 256x144 sample to ~144 sampled pixels. The new arm prints

```
sparse signature on a 256x144 sample MISSES this change
```

while the dense signature sees a single changed pixel — so if that ever stops holding, the dense
variant has lost its justification and should go. Sample buffers are built **by hand**, outside the
accumulator that consumes them (instrument trap 122).

Also fixed: the HUD resolution read `0x0` under GPU present (same CPU-path source); it now prefers the
presented extent. Both present paths now print the distinct rate on stderr with `PICTURE NOT CHANGING`
when the two rates disagree.

## Invariants

- Sampling is allocated **only when `--fps` asks for it**, so with the counter off the present path is
  byte-for-byte unchanged (#2113 — an instrument that runs unasked is how a measurement pass measures
  itself).
- The sample grid is a **fixed** size, so a guest that reconfigures VideoOut cannot make consecutive
  signatures incomparable and report a content change that did not happen.
- Documented honestly in the header: the two entry points sign in **different spaces**, so a run that
  alternates between them (GPU present with occasional publish misses) records a distinct frame at each
  crossing. The distinct count is therefore not a strict lower bound on a *mixed* run, though it is on
  either path alone.

## Affected / deliberately unaffected

- **Affected:** the `--fps` HUD and the stderr rate lines in `prosper-app`.
- **Unaffected:** the CPU present path's existing accounting (untouched); every headless instrument
  (`tools/screenshot`, snapshots, tests) which never had `gpu_present_active()`; and the present path
  entirely when `--fps` is off.
- **Not addressed:** a content rate on the GPU path needs *some* readback by construction; making it
  free is not possible, which is why it is gated on the flag.

## Verification (exact head)

Windows 11 / RTX 4090, MinGW GCC 16.1, `RelWithDebInfo`, *The Messenger*:

| | HUD |
| --- | --- |
| before | `-- fps` / `no frames published yet`, forever |
| after (static screen) | `64.0 fps (2400 frames, gpu-present, 0.0 distinct PICTURE NOT CHANGING)` |
| after (animating intro) | `51.3 fps (420 frames, gpu-present, 50.0 distinct)` |
| after (resolution field) | `1920x1080` where it read `0x0` |

**Cross-checked against an independent instrument** — the pre-existing CPU-path counter
(`PROSPER_APP_GPU_PRESENT=0`) on the same route independently reports `0.0 distinct PICTURE NOT
CHANGING`, and the sampled grid reads slightly *more* sensitive (0–3). So the new counter agrees with
the one that has been trusted since #2783.

```
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4
100% tests passed, 0 tests failed out of 242
```

(242 requires #3018 / PR for #3014 to link the whole tree on Windows; without it 15 cases do not run.)

## Risks

- Per-present cost: one small blit + a 147 KB copy + a 147 KB hash, only with `--fps`. Not measured as
  a frame-time delta — worth a reviewer's eye on whether that claim needs a number.
- The one-frame-late read depends on `inFlight` still guarding the previous submit at function entry.
  It does today (that wait is the first thing the function does), but it is a coupling worth reviewing.
- `BLOG.md` entry included per CLAUDE.md.