### PR TITLE
fix(win): guest sleeps and the audio grain pacer stop resolving on the winpthreads ~15.6 ms tick

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -605,6 +605,18 @@ if(TARGET prosper_core)
 
   # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
   # code is Linux-only (guest %fs), so gate the test on it too.
+  # sceKernelNanosleep's GUEST timespec contract (#3013). Registered OUTSIDE the if(UNIX) block
+  # below ON PURPOSE: what it pins is a WINDOWS defect -- MinGW-w64 declares a 32-bit `long tv_nsec`
+  # while the guest timespec is FreeBSD x86-64's 64-bit field, so writing the remainder through a
+  # host struct covered 12 of 16 bytes -- and a Unix-only registration would build it everywhere
+  # except the platform it is about. The second property, that a malformed tv_nsec returns promptly
+  # rather than sleeping ~2 s or ~292 years, is platform-independent. Asserts promptness, not
+  # accuracy: sleep precision belongs to host::sleep_until_steady_ns and a wall-clock assertion on
+  # it would flake on a loaded host.
+  add_executable(test_kernel_nanosleep tests/hle/kernel/test_kernel_nanosleep.cpp)
+  target_link_libraries(test_kernel_nanosleep PRIVATE prosper_core)
+  add_test(NAME kernel_nanosleep COMMAND test_kernel_nanosleep)
+
   if(UNIX)
     add_executable(test_guest_tls_align tests/loader/test_guest_tls_align.cpp)
     target_link_libraries(test_guest_tls_align PRIVATE prosper_core)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -603,8 +603,6 @@ if(TARGET prosper_core)
   target_link_libraries(test_self_segment_key PRIVATE prosper_core)
   add_test(NAME self_segment_key COMMAND test_self_segment_key)
 
-  # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
-  # code is Linux-only (guest %fs), so gate the test on it too.
   # sceKernelNanosleep's GUEST timespec contract (#3013). Registered OUTSIDE the if(UNIX) block
   # below ON PURPOSE: what it pins is a WINDOWS defect -- MinGW-w64 declares a 32-bit `long tv_nsec`
   # while the guest timespec is FreeBSD x86-64's 64-bit field, so writing the remainder through a
@@ -616,7 +614,13 @@ if(TARGET prosper_core)
   add_executable(test_kernel_nanosleep tests/hle/kernel/test_kernel_nanosleep.cpp)
   target_link_libraries(test_kernel_nanosleep PRIVATE prosper_core)
   add_test(NAME kernel_nanosleep COMMAND test_kernel_nanosleep)
+  # Bounded because arm 3 guards a ~292-YEAR sleep: without a timeout a regression there presents as
+  # CTest hanging for its default 1500 s rather than as a failure, and a hang is the one outcome nobody
+  # reads as a red test. Generous against a loaded host -- what it catches is seconds-to-forever.
+  set_tests_properties(kernel_nanosleep PROPERTIES TIMEOUT 60)
 
+  # Guest static-TLS Variant II layout uses each module's real PT_TLS p_align (#143). The layout
+  # code is Linux-only (guest %fs), so gate the test on it too.
   if(UNIX)
     add_executable(test_guest_tls_align tests/loader/test_guest_tls_align.cpp)
     target_link_libraries(test_guest_tls_align PRIVATE prosper_core)

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -9,32 +9,29 @@
 #include "host/platform/lifecycle.hpp"
 #include "host/platform/precise_sleep.hpp"   // the grain pacer must not quantize to the winpthreads tick (#3016)
 
-namespace {
-// Off by default: reading the device queue at every handoff is cheap, but an instrument that runs
-// unasked is how a measurement pass ends up measuring itself.
-bool legacy_pacer() {
-    static const bool on = getenv("PROSPER_GUEST_SLEEP_LEGACY") != nullptr;
-    return on;
-}
-
-bool queue_trace() {
-    static const bool on = getenv("PROSPER_AUDIO_QUEUE_TRACE") != nullptr;
-    return on;
-}
-}  // namespace
-
-
 #include <SDL3/SDL.h>
 
 #include <array>
-#include <cstdlib>   // getenv: the trace/legacy gates below. Transitive via libstdc++ on GCC, absent on clang.
 #include <chrono>
+#include <cstdlib>   // getenv, for the opt-in gates below (transitive via libstdc++, not via libc++)
 #include <mutex>
 #include <thread>
 #include <string>
 
 namespace prosper {
 namespace {
+
+// Both off by default: reading the device queue at every handoff is cheap, but an instrument that
+// runs unasked is how a measurement pass ends up measuring itself (#2113).
+bool legacy_pacer() {
+    static const bool on = getenv("PROSPER_GUEST_SLEEP_LEGACY") != nullptr;
+    return on;
+}
+bool queue_trace() {
+    static const bool on = getenv("PROSPER_AUDIO_QUEUE_TRACE") != nullptr;
+    return on;
+}
+
 
 // 16 public sceAudioOut ports plus four host-only streams for concurrent AudioOut2 contexts.
 // SDL mixes the bound streams into the same playback device while each retains its own pacing

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -27,6 +27,7 @@ bool queue_trace() {
 #include <SDL3/SDL.h>
 
 #include <array>
+#include <cstdlib>   // getenv: the trace/legacy gates below. Transitive via libstdc++ on GCC, absent on clang.
 #include <chrono>
 #include <mutex>
 #include <thread>

--- a/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
+++ b/prosper/frontends/audio_sdl3/audio_sink_sdl3.cpp
@@ -7,6 +7,22 @@
 #include "audio_sdl3.hpp"
 #include "hle/audio/audio.hpp"
 #include "host/platform/lifecycle.hpp"
+#include "host/platform/precise_sleep.hpp"   // the grain pacer must not quantize to the winpthreads tick (#3016)
+
+namespace {
+// Off by default: reading the device queue at every handoff is cheap, but an instrument that runs
+// unasked is how a measurement pass ends up measuring itself.
+bool legacy_pacer() {
+    static const bool on = getenv("PROSPER_GUEST_SLEEP_LEGACY") != nullptr;
+    return on;
+}
+
+bool queue_trace() {
+    static const bool on = getenv("PROSPER_AUDIO_QUEUE_TRACE") != nullptr;
+    return on;
+}
+}  // namespace
+
 
 #include <SDL3/SDL.h>
 
@@ -181,13 +197,61 @@ public:
                 s.put_failed = true;
             }
             s.dump.write(pcm, frames, s.channels, s.f32);
+            // PROSPER_AUDIO_QUEUE_TRACE=1: the device queue depth AT each grain handoff, reported
+            // as a per-second MINIMUM rather than a mean. A mean cannot see this defect -- #3016
+            // averaged 100% of real time while the queue emptied in every gap -- so the minimum is
+            // the whole point, together with the count of handoffs that found less than one grain
+            // buffered, which is the moment a real device would underrun.
+            if (queue_trace()) {
+                const int queued = SDL_GetAudioStreamQueued(s.stream);
+                if (queued >= 0) {
+                    if (s.q_min < 0 || queued < s.q_min) s.q_min = queued;
+                    if (queued > s.q_max) s.q_max = queued;
+                    if (s.grain_bytes > 0 && queued < s.grain_bytes) s.q_starved++;
+                    s.q_calls++;
+                    const auto now2 = std::chrono::steady_clock::now();
+                    if (s.q_last.time_since_epoch().count() == 0) s.q_last = now2;
+                    if (now2 - s.q_last >= std::chrono::seconds(1)) {
+                        SDL_Log("prosper-audio: port %d queue min=%d max=%d bytes (grain=%d) "
+                                "handoffs=%llu below-one-grain=%llu",
+                                port, s.q_min, s.q_max, s.grain_bytes,
+                                (unsigned long long)s.q_calls, (unsigned long long)s.q_starved);
+                        s.q_min = -1; s.q_max = 0; s.q_calls = 0; s.q_starved = 0; s.q_last = now2;
+                    }
+                }
+            }
+
         }
         // Pace the guest thread to real time. This sleep IS the Heaps unqueueBuffer signal
         // (#2978): by the time it returns, the previous grain has been consumed by the audio
         // device, giving Heaps the buffer-completion timing it needs to unqueue SFX buffers
         // instead of re-triggering them. The sleep must be outside the lock so other audio
         // operations (open/close/volume) can proceed while this grain plays.
-        if (freq > 0) std::this_thread::sleep_until(target);
+        if (freq > 0) {
+            // NOT std::this_thread::sleep_until (#3016). On Windows that resolves on the
+            // winpthreads master tick -- measured 15.6 ms for a 5.33 ms request, and unaffected by
+            // timeBeginPeriod -- while one 256-frame grain at 48 kHz IS 5.33 ms. Because `s.next`
+            // accumulates an ABSOLUTE target, an overshoot leaves the next few targets already in
+            // the past, so those calls returned instantly: delivery clumped into bursts of ~3
+            // grains every ~15.6 ms. The one-second AVERAGE stayed at ~100% of real time, which is
+            // why this hid from a delivery-rate check, while the device queue drained inside every
+            // gap -- continuous small underruns in every title, Windows only.
+            //
+            // sleep_until_steady_ns uses a high-resolution waitable timer, so the grain boundary is
+            // honoured and the pacing stays evenly spaced, which is the property the comment above
+            // this function has always depended on.
+            // PROSPER_GUEST_SLEEP_LEGACY=1 restores the pre-fix pacer so the A/B stays
+            // reproducible, the same way PROSPER_UD_TAIL_ALIGN does. Do not set it to fix anything.
+            if (legacy_pacer()) {
+                std::this_thread::sleep_until(target);
+            } else {
+                prosper::host::sleep_until_steady_ns(
+                    (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        target.time_since_epoch()).count());
+            }
+
+        }
+
     }
 
     void set_volume(int port, uint32_t mask, const int* vols) override {
@@ -244,6 +308,11 @@ private:
                   std::chrono::steady_clock::time_point next{};     // per-grain pacing deadline
                   int channels = 2; bool f32 = false;               // dump format (#2981)
                   WavDump dump;                                     // PROSPER_AUDIO_DUMP_WAV
+                  // PROSPER_AUDIO_QUEUE_TRACE accounting, reset each reporting second (#3016).
+                  int q_min = -1, q_max = 0;
+                  unsigned long long q_calls = 0, q_starved = 0;
+                  std::chrono::steady_clock::time_point q_last{};
+
                   // A defaulted default ctor keeps slots_{} value-initialization off the
                   // copy-construct path, which WavDump's deleted copy would reject.
                   Slot() = default;

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -19,6 +19,7 @@
 #include "host/image/exec_image.hpp"      // describe_code_address (host frame naming)
 #include "host/platform/immortal.hpp"        // #2613: registries a guest thread can reach after exit()
 #include "hle/sync/pthread_slot.hpp"   // #2596: the two guest-slot resolvers are defined here
+#include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS (#3013)
 #include "hle/sync/sync_futex.hpp"
 #include "hle/sync/sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "gpu/execute/mb3_freelist.hpp"
@@ -1312,6 +1313,7 @@ HLE(k_cond_timedwait) {
     if (gts[0] < 0 || gts[1] < 0 || gts[1] >= 1'000'000'000ll) return 22;
     struct timespec dl { (time_t)gts[0], (long)gts[1] };
     const int32_t clock_id = guest_cond_snapshot(c).clock_id;
+    hle::WaitCensusScope census(hle::WaitKind::CondTimedwait, 0);
     int rc = interruptible_cond_clock_timedwait(
         c, m, dl, clock_id, nullptr, kGuestMutexCondWaitBookkeeping);
     return fbsd_errno(rc);   // host ETIMEDOUT (Linux 110) -> FreeBSD 60
@@ -2914,6 +2916,7 @@ static timespec abs_deadline_us(uint64_t usec) {
 HLE(k_mutex_timedlock) {
     auto* m = ensure_mutex(a0); if (!m) return prosper::hle::kSceKernelErrorEINVAL;
     if (guest_mutex_self_deadlock(m)) return prosper::hle::kSceKernelErrorEDEADLK;
+    hle::WaitCensusScope census(hle::WaitKind::MutexTimedlock, a1 * 1000ull);
     timespec dl = abs_deadline_us(a1);
     int rc = pthread_mutex_timedlock(m, &dl);
     if (rc == 0) guest_mutex_acquired(m);
@@ -3049,7 +3052,7 @@ HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog
 HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : fbsd_errno(errno); }   // EAGAIN (would block) is 11 here, 35 on the PS5
 // scePthreadSemTimedwait is the one member of the family with no POSIX spelling registered on its
 // body, so it encodes in place; the other six go through SCE_PTHREAD_ALIAS below (#2178).
-HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return prosper::hle::kSceKernelErrorEINVAL; timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : sce_pthread_rc(fbsd_errno(errno)); }
+HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return prosper::hle::kSceKernelErrorEINVAL; hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, a1 * 1000ull); timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : sce_pthread_rc(fbsd_errno(errno)); }
 HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 // Quarantined, not freed, and `sem_destroy` deferred to reclaim — a thread parked in `sem_wait` is

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -2942,6 +2942,12 @@ HLE(k_cond_timedwait_sce) {
     // host already implements the FreeBSD contract itself.
     if (guest_mutex_not_owned_by_self(m)) return prosper::hle::kSceKernelErrorEPERM;
     GuestCondWaiterScope waiting(c);   // #2168: this body parks too, and was not counted either
+    // Censused separately from k_cond_timedwait: this is the Sony spelling and its timeout is
+    // RELATIVE microseconds, so unlike the POSIX abstime form it yields an exact requested
+    // interval. Leaving it out made the census report a clean zero for cond waits on titles
+    // that only ever call this one, which is the shape CLAUDE.md warns about: the null was
+    // about the bodies instrumented, not about the guest.
+    hle::WaitCensusScope census(hle::WaitKind::CondTimedwaitSce, a2 * 1000ull);
     timespec dl = abs_deadline_us(a2);
     int rc = interruptible_cond_timedwait(c, m, &dl, GuestWaitKind::ConditionSequence, 0,
                                           nullptr, kGuestMutexCondWaitBookkeeping);

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -448,7 +448,7 @@ HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 10000
 // host-struct write therefore covers 12 of the 16 guest bytes and leaves the HIGH half of tv_nsec
 // holding whatever was there, so the remainder a guest reads back is not zero and it may resume a
 // wait already served. The READ survived the same cast only by little-endian accident, since every
-// legal nanosecond value fits in the low half. Line 277 already indexes explicitly for this reason.
+// legal nanosecond value fits in the low half. Line 278 already indexes explicitly for this reason.
 //
 // An out-of-range tv_nsec is CARRIED into the total rather than rejected: this entry point has always
 // returned 0 unconditionally, and turning a malformed request into an error return would be a new
@@ -456,9 +456,26 @@ HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 10000
 HLE(k_nanosleep){
     if (!a0) return 0;
     const int64_t* req = (const int64_t*)P(a0);
-    const int64_t  sec  = req[0] > 0 ? req[0] : 0;
-    const int64_t  nsec = req[1] > 0 ? req[1] : 0;
-    const uint64_t want_ns = (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
+    const int64_t  sec = req[0], nsec = req[1];
+    // A malformed request returns WITHOUT sleeping, which is what this entry point already did: the
+    // old body handed the guest struct straight to the host nanosleep, and POSIX makes a tv_nsec
+    // outside [0, 1e9) EINVAL -- so the host refused instantly and the HLE returned 0 having slept
+    // nothing. Preserving that matters in BOTH directions. An earlier version of this fix carried an
+    // out-of-range tv_nsec into the total, which turns a garbage 0x7fff... into a near-infinite
+    // sleep: a hang where there used to be an immediate return. Returning an error instead would be
+    // the opposite new failure mode, for guests that currently see success. Same range rule as
+    // hle_kernel.cpp:1313, which validates the guest timespec it is handed.
+    if (sec < 0 || nsec < 0 || nsec >= 1000000000ll) {
+        // Zeroed rather than left untouched (the host would have left it) so a guest reading the
+        // remainder after a refused request cannot resume on uninitialised memory.
+        if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }
+        return 0;
+    }
+    // Saturating rather than wrapping: tv_sec is guest-controlled and unbounded, and a wrap would
+    // turn a very long sleep into a short one, which is worse than a long one.
+    const uint64_t kNsMax = ~0ull;
+    const uint64_t want_ns = (uint64_t)sec > kNsMax / 1000000000ull
+        ? kNsMax : (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
     { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want_ns); guest_sleep_ns(want_ns); }
     if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }   // slept in full
     return 0;

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -5,6 +5,8 @@
 #include "hle/kernel/hle_kernel_time.hpp"
 #include "host/image/boot_program.hpp"   // #1659: shared guest-module labelling
 #include "host/platform/posix_shim.hpp"     // PROSPER_ASM_TRAMPOLINE (pass entry %rsp as 7th arg)
+#include "host/platform/precise_sleep.hpp"   // guest sleeps must not inherit the winpthreads tick (#3013)
+#include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS: which primitive a title paces on
 #include "host/image/runtime_module_load.hpp"   // #639: real runtime PRX loading
 #include "host/memory/guest_write_watch.hpp"     // flush dmem writer diagnostic before guest _Exit
 #include "hle/dispatch/callback_fs.hpp"            // recover the caller's guest %fs from the import-stub frame
@@ -399,13 +401,55 @@ HLE(k_rtc_get_tick) {   // (const SceRtcDateTime* dt, SceRtcTick* tick)
     return 0;
 }
 
-// real sleeps so timed wait loops actually yield the CPU (and advance real time)
-HLE(k_usleep)   { uint64_t us = a0; struct timespec ts{ (time_t)(us / 1000000), (long)((us % 1000000) * 1000) }; nanosleep(&ts, nullptr); return 0; }
+// Real sleeps so timed wait loops actually yield the CPU (and advance real time).
+//
+// NOT nanosleep, and on Windows that is the whole point (#3013). MinGW's nanosleep is winpthreads',
+// whose timed waits resolve on the winpthreads master tick REGARDLESS of timeBeginPeriod -- measured
+// on this toolchain at 15.67 ms mean for a 5.33 ms request, unchanged (15.59 ms) with the process
+// timer resolution raised to 1 ms. A guest audio mixer pacing 256-frame grains at 48 kHz asks for
+// 5.33 ms and got 15.6 ms: it delivered one grain per tick instead of per grain, ~2.9x too slowly,
+// and every title underran continuously on Windows while Linux was clean.
+//
+// sleep_until_steady_ns uses CREATE_WAITABLE_TIMER_HIGH_RESOLUTION, which is independent of the
+// process timer period: 5.64 ms mean / 5.99 ms worst for the same request on the same box. It also
+// takes an ABSOLUTE deadline, so the per-call overhead cannot compound across a pacing loop the way
+// a relative sleep's does.
+//
+// The deadline is computed BEFORE anything else in the body: it is the guest's schedule, and any
+// work done first would be silently added to the interval the guest asked for.
+static inline void guest_sleep_ns(uint64_t ns) {
+    // PROSPER_GUEST_SLEEP_LEGACY=1 restores the pre-#3013 nanosleep path. It exists ONLY so the A/B
+    // that established the fix stays reproducible -- the same reason PROSPER_UD_TAIL_ALIGN survives
+    // (CLAUDE.md). Measured with it on/off, The Messenger audio delivery against the 384,000 B/s that
+    // f32/2ch/48 kHz needs: 100.8% off (healthy) vs the legacy path. Do not set it to fix anything.
+    static const bool legacy = getenv("PROSPER_GUEST_SLEEP_LEGACY") != nullptr;
+    if (legacy) {
+        struct timespec ts{ (time_t)(ns / 1000000000ull), (long)(ns % 1000000000ull) };
+        nanosleep(&ts, nullptr);
+        return;
+    }
+    const uint64_t deadline = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                  std::chrono::steady_clock::now().time_since_epoch()).count() + ns;
+    prosper::host::sleep_until_steady_ns(deadline);
+}
+
+HLE(k_usleep)   { hle::WaitCensusScope c(hle::WaitKind::Usleep, a0 * 1000ull); guest_sleep_ns(a0 * 1000ull); return 0; }
+
 // POSIX sleep() returns the number of seconds LEFT unslept (0 on full completion), not the input.
 // Returning the input breaks the canonical resume idiom `while ((left = sleep(left))) ;` into an
 // infinite busy-sleep. We always sleep the full duration, so return 0 (Kyty KernelSleep returns OK/0).
-HLE(k_sleep_s)  { struct timespec ts{ (time_t)a0, 0 }; nanosleep(&ts, nullptr); return 0; }
-HLE(k_nanosleep){ if (a0) nanosleep((const struct timespec*)P(a0), a1 ? (struct timespec*)P(a1) : nullptr); return 0; }
+HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 1000000000ull); guest_sleep_ns(a0 * 1000000000ull); return 0; }
+// The remainder out-parameter is written ZERO rather than left untouched: we always sleep the full
+// duration, and a guest that reads an uninitialised remainder would resume a wait it already served.
+HLE(k_nanosleep){
+    if (!a0) return 0;
+    const struct timespec* req = (const struct timespec*)P(a0);
+    const uint64_t want_ns = (uint64_t)req->tv_sec * 1000000000ull + (uint64_t)req->tv_nsec;
+    { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want_ns); guest_sleep_ns(want_ns); }
+    if (a1) { struct timespec* rem = (struct timespec*)P(a1); rem->tv_sec = 0; rem->tv_nsec = 0; }
+    return 0;
+}
+
 
 // --- select / pselect: the PURE-SLEEP shape only (#1660) --------------------------------------
 //

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -441,14 +441,29 @@ HLE(k_usleep)   { hle::WaitCensusScope c(hle::WaitKind::Usleep, a0 * 1000ull); g
 HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 1000000000ull); guest_sleep_ns(a0 * 1000000000ull); return 0; }
 // The remainder out-parameter is written ZERO rather than left untouched: we always sleep the full
 // duration, and a guest that reads an uninitialised remainder would resume a wait it already served.
+//
+// Both fields are indexed as int64 rather than reached through a HOST struct timespec, because the
+// two layouts differ on the platform this targets: the guest is FreeBSD x86-64, where tv_nsec is
+// 64-bit, while MinGW-w64 declares long tv_nsec (sys/types.h) -- 32-bit on Windows x64. A
+// host-struct write therefore covers 12 of the 16 guest bytes and leaves the HIGH half of tv_nsec
+// holding whatever was there, so the remainder a guest reads back is not zero and it may resume a
+// wait already served. The READ survived the same cast only by little-endian accident, since every
+// legal nanosecond value fits in the low half. Line 277 already indexes explicitly for this reason.
+//
+// An out-of-range tv_nsec is CARRIED into the total rather than rejected: this entry point has always
+// returned 0 unconditionally, and turning a malformed request into an error return would be a new
+// failure mode for guests that currently sleep. Negative values clamp to zero.
 HLE(k_nanosleep){
     if (!a0) return 0;
-    const struct timespec* req = (const struct timespec*)P(a0);
-    const uint64_t want_ns = (uint64_t)req->tv_sec * 1000000000ull + (uint64_t)req->tv_nsec;
+    const int64_t* req = (const int64_t*)P(a0);
+    const int64_t  sec  = req[0] > 0 ? req[0] : 0;
+    const int64_t  nsec = req[1] > 0 ? req[1] : 0;
+    const uint64_t want_ns = (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
     { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want_ns); guest_sleep_ns(want_ns); }
-    if (a1) { struct timespec* rem = (struct timespec*)P(a1); rem->tv_sec = 0; rem->tv_nsec = 0; }
+    if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }   // slept in full
     return 0;
 }
+
 
 
 // --- select / pselect: the PURE-SLEEP shape only (#1660) --------------------------------------

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -415,13 +415,23 @@ HLE(k_rtc_get_tick) {   // (const SceRtcDateTime* dt, SceRtcTick* tick)
 // takes an ABSOLUTE deadline, so the per-call overhead cannot compound across a pacing loop the way
 // a relative sleep's does.
 //
-// The deadline is computed BEFORE anything else in the body: it is the guest's schedule, and any
-// work done first would be silently added to the interval the guest asked for.
+// The deadline is taken as early as the body allows, because it is the guest's schedule and any work
+// done first is silently added to the interval it asked for. Not an absolute: the census scope's
+// constructor and, in k_nanosleep, the guest read and range guard necessarily precede it. Those are
+// a few hundred nanoseconds against a millisecond-scale request, which is why the ordering is worth
+// stating as an intent rather than asserting as an invariant.
 static inline void guest_sleep_ns(uint64_t ns) {
     // PROSPER_GUEST_SLEEP_LEGACY=1 restores the pre-#3013 nanosleep path. It exists ONLY so the A/B
     // that established the fix stays reproducible -- the same reason PROSPER_UD_TAIL_ALIGN survives
-    // (CLAUDE.md). Measured with it on/off, The Messenger audio delivery against the 384,000 B/s that
-    // f32/2ch/48 kHz needs: 100.8% off (healthy) vs the legacy path. Do not set it to fix anything.
+    // (CLAUDE.md). Do not set it to fix anything.
+    //
+    // What the A/B does and does NOT show, because an earlier version of this comment cited the
+    // wrong half: audio DELIVERY RATE does not discriminate. The Messenger measures ~100% of the
+    // 384,000 B/s that f32/2ch/48 kHz needs in BOTH arms (385,024-389,120 B/s legacy), which is
+    // exactly why a delivery-rate check cannot find this defect -- quoting the 100.8% as evidence
+    // for the fix, as that comment did, points a reader at a number that separates nothing. What the
+    // lever does separate is sleep ACCURACY: requested 18.17 -> actual 23.74 ms (x1.31) legacy
+    // against 15.41 -> 15.69 (x1.02) fixed, on the same route.
     static const bool legacy = getenv("PROSPER_GUEST_SLEEP_LEGACY") != nullptr;
     if (legacy) {
         struct timespec ts{ (time_t)(ns / 1000000000ull), (long)(ns % 1000000000ull) };
@@ -433,14 +443,28 @@ static inline void guest_sleep_ns(uint64_t ns) {
     prosper::host::sleep_until_steady_ns(deadline);
 }
 
-HLE(k_usleep)   { hle::WaitCensusScope c(hle::WaitKind::Usleep, a0 * 1000ull); guest_sleep_ns(a0 * 1000ull); return 0; }
+// Saturating, for the same reason k_nanosleep saturates: the argument is guest-controlled and a wrap
+// turns a long sleep into a short one. Benign in consequence here -- a wrapped deadline lands in the
+// past and precise_sleep returns at once -- but having one of these three saturate and the others
+// wrap is an inconsistency the next reader has to re-derive, so they all do.
+static inline uint64_t guest_ns_from(uint64_t value, uint64_t ns_per_unit) {
+    const uint64_t kNsMax = ~0ull;
+    return value > kNsMax / ns_per_unit ? kNsMax : value * ns_per_unit;
+}
+
+HLE(k_usleep)   { const uint64_t ns = guest_ns_from(a0, 1000ull);
+                  hle::WaitCensusScope c(hle::WaitKind::Usleep, ns); guest_sleep_ns(ns); return 0; }
 
 // POSIX sleep() returns the number of seconds LEFT unslept (0 on full completion), not the input.
 // Returning the input breaks the canonical resume idiom `while ((left = sleep(left))) ;` into an
 // infinite busy-sleep. We always sleep the full duration, so return 0 (Kyty KernelSleep returns OK/0).
-HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 1000000000ull); guest_sleep_ns(a0 * 1000000000ull); return 0; }
-// The remainder out-parameter is written ZERO rather than left untouched: we always sleep the full
-// duration, and a guest that reads an uninitialised remainder would resume a wait it already served.
+HLE(k_sleep_s)  { const uint64_t ns = guest_ns_from(a0, 1000000000ull);
+                  hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, ns); guest_sleep_ns(ns); return 0; }
+// The remainder out-parameter is written ZERO rather than left untouched, on BOTH exits: a served
+// request sleeps in full so nothing remains, and a refused one slept nothing but must still not hand
+// back whatever was in that memory. Either way a guest reading an uninitialised remainder could
+// resume a wait it should not. (This paragraph previously said "we always sleep the full duration",
+// which the refusal path made false.)
 //
 // Both fields are indexed as int64 rather than reached through a HOST struct timespec, because the
 // two layouts differ on the platform this targets: the guest is FreeBSD x86-64, where tv_nsec is
@@ -450,7 +474,7 @@ HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 10000
 // wait already served. The READ survived the same cast only by little-endian accident, since every
 // legal nanosecond value fits in the low half. Line 278 already indexes explicitly for this reason.
 //
-// An out-of-range or negative tv_nsec is REFUSED -- the body returns 0 without sleeping. The comment
+// A negative tv_sec, or a negative or out-of-range tv_nsec, is REFUSED -- the body returns 0 without sleeping. The comment
 // on the guard itself says why that is the behaviour to preserve. (An earlier revision of this block
 // described the OPPOSITE, carrying the value into the total. That text survived the commit that added
 // the guard and read as a rationale for removing it, which is how a comment gets a safety check

--- a/prosper/src/hle/kernel/hle_kernel_time.cpp
+++ b/prosper/src/hle/kernel/hle_kernel_time.cpp
@@ -450,9 +450,11 @@ HLE(k_sleep_s)  { hle::WaitCensusScope c(hle::WaitKind::SleepSeconds, a0 * 10000
 // wait already served. The READ survived the same cast only by little-endian accident, since every
 // legal nanosecond value fits in the low half. Line 278 already indexes explicitly for this reason.
 //
-// An out-of-range tv_nsec is CARRIED into the total rather than rejected: this entry point has always
-// returned 0 unconditionally, and turning a malformed request into an error return would be a new
-// failure mode for guests that currently sleep. Negative values clamp to zero.
+// An out-of-range or negative tv_nsec is REFUSED -- the body returns 0 without sleeping. The comment
+// on the guard itself says why that is the behaviour to preserve. (An earlier revision of this block
+// described the OPPOSITE, carrying the value into the total. That text survived the commit that added
+// the guard and read as a rationale for removing it, which is how a comment gets a safety check
+// deleted.)
 HLE(k_nanosleep){
     if (!a0) return 0;
     const int64_t* req = (const int64_t*)P(a0);
@@ -471,11 +473,16 @@ HLE(k_nanosleep){
         if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }
         return 0;
     }
-    // Saturating rather than wrapping: tv_sec is guest-controlled and unbounded, and a wrap would
-    // turn a very long sleep into a short one, which is worse than a long one.
-    const uint64_t kNsMax = ~0ull;
-    const uint64_t want_ns = (uint64_t)sec > kNsMax / 1000000000ull
-        ? kNsMax : (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
+    // Saturating, and the second disjunct is the boundary the first one misses: sec == kNsMax/1e9
+    // passes a bare `sec > kNsMax/1e9` test, and then `+ nsec` overflows for nsec > kNsMax%1e9 and
+    // wraps a 584-year sleep into a short one -- the long-to-short direction this clamp exists to
+    // prevent. tv_sec is guest-controlled, so the boundary is reachable by a hostile value.
+    const uint64_t kNsMax   = ~0ull;
+    const uint64_t kSecMax  = kNsMax / 1000000000ull;      // 18446744073
+    const uint64_t kNsecRem = kNsMax % 1000000000ull;      // 709551615
+    const uint64_t want_ns =
+        ((uint64_t)sec > kSecMax || ((uint64_t)sec == kSecMax && (uint64_t)nsec > kNsecRem))
+            ? kNsMax : (uint64_t)sec * 1000000000ull + (uint64_t)nsec;
     { hle::WaitCensusScope c(hle::WaitKind::Nanosleep, want_ns); guest_sleep_ns(want_ns); }
     if (a1) { int64_t* rem = (int64_t*)P(a1); rem[0] = 0; rem[1] = 0; }   // slept in full
     return 0;

--- a/prosper/src/hle/kernel/timedwait_census.hpp
+++ b/prosper/src/hle/kernel/timedwait_census.hpp
@@ -1,0 +1,118 @@
+#pragma once
+// timedwait_census — which guest timed-wait primitive a title paces on, and by how much each one
+// overshoots what the guest asked for. `PROSPER_TIMEDWAIT_CENSUS=1`; off costs two branches.
+//
+// This exists because #3013 was diagnosed from the primitives' granularity rather than from the
+// guest's use of them, and those are different claims. Knowing that winpthreads quantizes every
+// timed wait to ~15.6 ms does NOT tell you which call a given title's mixer paces on -- FMOD paces
+// on a semaphore timedwait, other middleware sleeps, and a fix aimed at the wrong one is untestable
+// and looks like a regression when it changes nothing. So: measure the caller, not just the callee.
+//
+// What it reports per primitive: call count, mean requested interval, mean ACTUAL interval, and the
+// ratio. A ratio near 1.0 is a primitive serving the guest's schedule; the ~2.9x that #3013 measured
+// for a 5.33 ms audio grain is what starvation looks like from inside.
+//
+// Deliberately NOT a rate limiter on the measurement itself: every call is counted, and only the
+// REPORT is throttled. A census that sampled would answer "how often does this happen" with a number
+// about its own sampling.
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
+namespace prosper::hle {
+
+enum class WaitKind { Usleep, Nanosleep, SleepSeconds, SemTimedwait, CondTimedwait,
+                     MutexTimedlock, Count };
+
+inline const char* wait_kind_name(WaitKind k) {
+    switch (k) {
+    case WaitKind::Usleep:        return "usleep";
+    case WaitKind::Nanosleep:     return "nanosleep";
+    case WaitKind::SleepSeconds:  return "sleep(s)";
+    case WaitKind::SemTimedwait:  return "sem_timedwait";
+    case WaitKind::CondTimedwait: return "cond_timedwait";
+    case WaitKind::MutexTimedlock: return "mutex_timedlock";
+    default:                      return "?";
+    }
+}
+
+// inline variables: ONE set of counters across every translation unit that includes this. A
+// header-only `static` would give each TU its own, so the sleeps and the timed waits would be
+// counted into different tables and each would report the other as never called.
+inline std::atomic<uint64_t> g_wait_calls[(size_t)WaitKind::Count];
+inline std::atomic<uint64_t> g_wait_requested_ns[(size_t)WaitKind::Count];
+inline std::atomic<uint64_t> g_wait_actual_ns[(size_t)WaitKind::Count];
+inline std::atomic<uint64_t> g_wait_next_report_ns{0};
+
+inline bool timedwait_census() {
+    static const bool on = getenv("PROSPER_TIMEDWAIT_CENSUS") != nullptr;
+    return on;
+}
+
+inline uint64_t census_now_ns() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch()).count();
+}
+
+inline void report_timedwait_census(uint64_t now_ns) {
+    // Every 5 s, from whichever thread happens to cross the deadline first. The compare_exchange
+    // means concurrent crossers do not each print the same table.
+    uint64_t due = g_wait_next_report_ns.load(std::memory_order_relaxed);
+    if (due == 0) {   // first call establishes the schedule rather than reporting an empty table
+        g_wait_next_report_ns.compare_exchange_strong(due, now_ns + 5000000000ull);
+        return;
+    }
+    if (now_ns < due) return;
+    if (!g_wait_next_report_ns.compare_exchange_strong(due, now_ns + 5000000000ull)) return;
+
+    for (size_t i = 0; i < (size_t)WaitKind::Count; i++) {
+        const uint64_t n = g_wait_calls[i].load(std::memory_order_relaxed);
+        if (!n) continue;
+        const uint64_t req_total = g_wait_requested_ns[i].load(std::memory_order_relaxed);
+        // A primitive whose deadline is ABSOLUTE in a clock epoch this layer does not resolve
+        // (cond_timedwait) records no requested interval rather than a wrong one: subtracting the
+        // wrong clock-s now from a guest deadline yields a plausible-looking number that means
+        // nothing. Those report duration and call count, and no ratio.
+        if (req_total == 0) {
+            fprintf(stderr, "[timedwait] %-15s calls=%-9llu requested=      ?     actual=%7.3f ms\n",
+                    wait_kind_name((WaitKind)i), (unsigned long long)n,
+                    g_wait_actual_ns[i].load(std::memory_order_relaxed) / 1e6 / n);
+            continue;
+        }
+        const double req_ms = req_total / 1e6 / n;
+
+        const double act_ms = g_wait_actual_ns[i].load(std::memory_order_relaxed) / 1e6 / n;
+        fprintf(stderr, "[timedwait] %-15s calls=%-9llu requested=%7.3f ms  actual=%7.3f ms  x%.2f\n",
+                wait_kind_name((WaitKind)i), (unsigned long long)n, req_ms, act_ms,
+                req_ms > 0 ? act_ms / req_ms : 0.0);
+    }
+}
+
+// RAII: times the wait it encloses and records it. Constructed disabled when the census is off, so
+// the cost on a normal run is the one cached getenv branch.
+class WaitCensusScope {
+public:
+    WaitCensusScope(WaitKind kind, uint64_t requested_ns)
+        : kind_(kind), requested_ns_(requested_ns), on_(timedwait_census()),
+          start_ns_(on_ ? census_now_ns() : 0) {}
+    ~WaitCensusScope() {
+        if (!on_) return;
+        const uint64_t end = census_now_ns();
+        const size_t i = (size_t)kind_;
+        g_wait_calls[i].fetch_add(1, std::memory_order_relaxed);
+        g_wait_requested_ns[i].fetch_add(requested_ns_, std::memory_order_relaxed);
+        g_wait_actual_ns[i].fetch_add(end - start_ns_, std::memory_order_relaxed);
+        report_timedwait_census(end);
+    }
+    WaitCensusScope(const WaitCensusScope&) = delete;
+    WaitCensusScope& operator=(const WaitCensusScope&) = delete;
+private:
+    WaitKind kind_;
+    uint64_t requested_ns_;
+    bool     on_;
+    uint64_t start_ns_;
+};
+
+}  // namespace prosper::hle

--- a/prosper/src/hle/kernel/timedwait_census.hpp
+++ b/prosper/src/hle/kernel/timedwait_census.hpp
@@ -86,9 +86,9 @@ inline void report_timedwait_census(uint64_t now_ns) {
             fprintf(stderr, "[timedwait 5s] %-16s calls=%-9llu requested=      ?     actual=%7.3f ms\n",
                     wait_kind_name((WaitKind)i), (unsigned long long)n,
                     g_wait_actual_ns[i].load(std::memory_order_relaxed) / 1e6 / n);
-        g_wait_calls[i].store(0, std::memory_order_relaxed);
-        g_wait_requested_ns[i].store(0, std::memory_order_relaxed);
-        g_wait_actual_ns[i].store(0, std::memory_order_relaxed);
+            g_wait_calls[i].store(0, std::memory_order_relaxed);
+            g_wait_requested_ns[i].store(0, std::memory_order_relaxed);
+            g_wait_actual_ns[i].store(0, std::memory_order_relaxed);
             continue;
         }
         const double req_ms = req_total / 1e6 / n;

--- a/prosper/src/hle/kernel/timedwait_census.hpp
+++ b/prosper/src/hle/kernel/timedwait_census.hpp
@@ -13,8 +13,14 @@
 // for a 5.33 ms audio grain is what starvation looks like from inside.
 //
 // Deliberately NOT a rate limiter on the measurement itself: every call is counted, and only the
-// REPORT is throttled. A census that sampled would answer "how often does this happen" with a number
-// about its own sampling.
+// REPORT is throttled. A census that sampled would answer "how often does this happen" with a
+// number about its own sampling.
+//
+// Counters are zeroed once printed, so each line describes ITS OWN window rather than the run so
+// far. A cumulative mean drifts toward whatever the title did early and stops responding to a
+// regime change -- which is the thing this exists to catch. Calls occurring between the read and
+// the reset are lost from the totals; that is an accepted rounding error in a diagnostic, not a
+// count anything is asserted against.
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -24,7 +30,7 @@
 namespace prosper::hle {
 
 enum class WaitKind { Usleep, Nanosleep, SleepSeconds, SemTimedwait, CondTimedwait,
-                     MutexTimedlock, Count };
+                     CondTimedwaitSce, MutexTimedlock, Count };
 
 inline const char* wait_kind_name(WaitKind k) {
     switch (k) {
@@ -33,6 +39,7 @@ inline const char* wait_kind_name(WaitKind k) {
     case WaitKind::SleepSeconds:  return "sleep(s)";
     case WaitKind::SemTimedwait:  return "sem_timedwait";
     case WaitKind::CondTimedwait: return "cond_timedwait";
+    case WaitKind::CondTimedwaitSce: return "sceCondTimedwait";
     case WaitKind::MutexTimedlock: return "mutex_timedlock";
     default:                      return "?";
     }
@@ -76,17 +83,23 @@ inline void report_timedwait_census(uint64_t now_ns) {
         // wrong clock-s now from a guest deadline yields a plausible-looking number that means
         // nothing. Those report duration and call count, and no ratio.
         if (req_total == 0) {
-            fprintf(stderr, "[timedwait] %-15s calls=%-9llu requested=      ?     actual=%7.3f ms\n",
+            fprintf(stderr, "[timedwait 5s] %-16s calls=%-9llu requested=      ?     actual=%7.3f ms\n",
                     wait_kind_name((WaitKind)i), (unsigned long long)n,
                     g_wait_actual_ns[i].load(std::memory_order_relaxed) / 1e6 / n);
+        g_wait_calls[i].store(0, std::memory_order_relaxed);
+        g_wait_requested_ns[i].store(0, std::memory_order_relaxed);
+        g_wait_actual_ns[i].store(0, std::memory_order_relaxed);
             continue;
         }
         const double req_ms = req_total / 1e6 / n;
 
         const double act_ms = g_wait_actual_ns[i].load(std::memory_order_relaxed) / 1e6 / n;
-        fprintf(stderr, "[timedwait] %-15s calls=%-9llu requested=%7.3f ms  actual=%7.3f ms  x%.2f\n",
+        fprintf(stderr, "[timedwait 5s] %-16s calls=%-9llu requested=%7.3f ms  actual=%7.3f ms  x%.2f\n",
                 wait_kind_name((WaitKind)i), (unsigned long long)n, req_ms, act_ms,
                 req_ms > 0 ? act_ms / req_ms : 0.0);
+        g_wait_calls[i].store(0, std::memory_order_relaxed);
+        g_wait_requested_ns[i].store(0, std::memory_order_relaxed);
+        g_wait_actual_ns[i].store(0, std::memory_order_relaxed);
     }
 }
 

--- a/prosper/tests/hle/kernel/test_kernel_nanosleep.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_nanosleep.cpp
@@ -78,7 +78,12 @@ int main() {
         CHECK(ms < 500.0, "a garbage tv_nsec returns promptly rather than sleeping ~292 years");
     }
 
-    // 4. A negative tv_sec is refused the same way, and a NULL request is a no-op.
+    // 4. Contract documentation, NOT a regression arm, and labelled so rather than left to look like
+    //    one: a negative tv_sec and a NULL request both returned 0 promptly in every version of this
+    //    body -- the original (host nanosleep EINVALs), the intermediate one (negatives clamped to 0),
+    //    and the current guard. So these cannot fail for the fix's sake and pin only the stable part
+    //    of the contract. Kept because that part is worth stating; counted honestly because an arm
+    //    that cannot distinguish the versions is not evidence about them.
     {
         int64_t req[2] = { -1, 0 };
         CHECK(ns((uint64_t)(uintptr_t)req, 0, 0, 0, 0, 0) == 0, "a negative tv_sec returns 0");

--- a/prosper/tests/hle/kernel/test_kernel_nanosleep.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_nanosleep.cpp
@@ -1,0 +1,90 @@
+// test_kernel_nanosleep (#3013) — the guest timespec contract of sceKernelNanosleep, which is a
+// GUEST-memory layout question and not a timing one.
+//
+// Two properties, and both were broken at some point in #3022's history, which is why they are pinned
+// here rather than argued in a comment:
+//
+//  1. The remainder out-param is filled with SIXTEEN zero bytes. The guest timespec is FreeBSD
+//     x86-64's {int64 tv_sec, int64 tv_nsec}; MinGW-w64's HOST struct declares `long tv_nsec`, which
+//     is 32-bit on Windows x64. Writing the remainder through a host struct therefore covered 12 of
+//     the 16 bytes and left the high half of the guest's tv_nsec holding whatever was there, so a
+//     guest reading it back saw a non-zero remainder and could resume a wait already served. This
+//     test seeds BOTH slots with a sentinel, so it fails on any partial write.
+//
+//  2. A malformed request returns PROMPTLY. POSIX makes tv_nsec outside [0, 1e9) EINVAL, and the
+//     original body -- which handed the guest struct to the host nanosleep -- was refused instantly
+//     and returned 0 having slept nothing. An intermediate version of the fix carried the
+//     out-of-range value into the total instead, turning a garbage tv_nsec into a near-infinite
+//     sleep. Asserting "promptly" rather than an exact duration keeps this off the host scheduler:
+//     the failure mode it guards is seconds-to-forever, so a generous ceiling still catches it.
+//
+// Deliberately NOT a test of sleep accuracy. That is a property of host::sleep_until_steady_ns and a
+// wall-clock assertion on it would be a flake on a loaded machine; precise_sleep exposes
+// sleep_backend() so the MECHANISM can be asserted instead.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+
+using namespace prosper;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+int main() {
+    printf("== test_kernel_nanosleep ==\n");
+    register_builtin_hle();
+
+    const std::string nid = nid_hash("sceKernelNanosleep");
+    HleFn ns = Hle::lookup(nid.c_str());
+    CHECK(ns != nullptr, "sceKernelNanosleep is registered (resolves to a real impl, not the stub)");
+    if (!ns) { printf("== FAIL (unresolved) ==\n"); return 1; }
+
+    constexpr int64_t kSentinel = (int64_t)0x0BADF00DDEADBEEFll;
+
+    // 1. A 1 ms request: both remainder slots must come back zero.
+    {
+        int64_t req[2] = { 0, 1000000 };                 // 1 ms
+        int64_t rem[2] = { kSentinel, kSentinel };
+        const uint64_t rc = ns((uint64_t)(uintptr_t)req, (uint64_t)(uintptr_t)rem, 0, 0, 0, 0);
+        CHECK(rc == 0, "a valid request returns 0");
+        CHECK(rem[0] == 0, "remainder tv_sec is zeroed");
+        CHECK(rem[1] == 0, "remainder tv_nsec is zeroed IN FULL (all 8 bytes, not just the low 4)");
+    }
+
+    // 2. tv_nsec >= 1e9 is malformed: return promptly, sleep nothing, and still define the remainder.
+    {
+        int64_t req[2] = { 0, 2000000000ll };            // 2e9 ns: out of range
+        int64_t rem[2] = { kSentinel, kSentinel };
+        const auto t0 = std::chrono::steady_clock::now();
+        const uint64_t rc = ns((uint64_t)(uintptr_t)req, (uint64_t)(uintptr_t)rem, 0, 0, 0, 0);
+        const double ms = std::chrono::duration<double, std::milli>(
+                              std::chrono::steady_clock::now() - t0).count();
+        CHECK(rc == 0, "a malformed request still returns 0 (the contract this entry point always had)");
+        CHECK(ms < 500.0, "a malformed tv_nsec does NOT become a long sleep (carried, it was ~2 s)");
+        CHECK(rem[0] == 0 && rem[1] == 0, "the remainder is defined even on a refused request");
+    }
+
+    // 3. A garbage tv_nsec must not sleep for years. Same guard, at the value that motivated it.
+    {
+        int64_t req[2] = { 0, (int64_t)0x7fffffffffffffffll };
+        const auto t0 = std::chrono::steady_clock::now();
+        ns((uint64_t)(uintptr_t)req, 0, 0, 0, 0, 0);
+        const double ms = std::chrono::duration<double, std::milli>(
+                              std::chrono::steady_clock::now() - t0).count();
+        CHECK(ms < 500.0, "a garbage tv_nsec returns promptly rather than sleeping ~292 years");
+    }
+
+    // 4. A negative tv_sec is refused the same way, and a NULL request is a no-op.
+    {
+        int64_t req[2] = { -1, 0 };
+        CHECK(ns((uint64_t)(uintptr_t)req, 0, 0, 0, 0, 0) == 0, "a negative tv_sec returns 0");
+        CHECK(ns(0, 0, 0, 0, 0, 0) == 0, "a NULL request is a no-op returning 0");
+    }
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #3013. Fixes #3016.

## Failure scenario

Audio underruns continuously on Windows in **every** title, while Linux is clean. The cause is not in
the audio path: on Windows every guest timed wait resolved on the winpthreads master tick, so a mixer
pacing small grains was woken ~3x too slowly.

## The measurement, and its control

Hand-built probe **outside prosper** (so it tests the primitives, not our wrapper), asking for
**5.33 ms** — one 256-frame grain at 48 kHz:

| primitive | no `timeBeginPeriod` | with `timeBeginPeriod(1)` |
| --- | --- | --- |
| `nanosleep` | **15.67 ms** | 15.59 ms |
| `sem_timedwait` | **15.57 ms** | 15.66 ms |
| `cv.wait_for` | **15.73 ms** | 15.63 ms |
| `sem_timedwait`, **posted every 0.5 ms** | 0.01 ms | 0.00 ms |

That last row is the control and it carries the diagnosis: the **wake** path is fine (0.01 ms), so this
is not scheduling latency — only the **timeout** path is quantized; and the probe's lever demonstrably
moves, so the figure is not a constant.

`timeBeginPeriod(1)` not helping is the counter-intuitive part: raising the process timer resolution
is the obvious remedy and it does nothing here, so the tick is winpthreads' own rather than the OS
timer's.

**prosper does not call `timeBeginPeriod` anywhere** — six prose-only lines across four files, no call, `winmm`
linked nowhere, and `src/host/platform/precise_sleep.cpp:14` states it outright. An earlier version of
this text claimed it did; that came from an uncommitted local diff which was later discarded, and was
wrong. The probe applied the call in-process itself, which is where the second column above comes
from. Since nothing in the tree raises the period, `precise_sleep.cpp:16`'s own figure — `Sleep(1)` =
15.554 ms by default against 1.930 ms after the call — describes a **live lever**, not one already
pulled.

`CREATE_WAITABLE_TIMER_HIGH_RESOLUTION` — which `precise_sleep.cpp` has used since #1765 — serves the
same request in **5.64 ms mean / 5.99 ms worst**, no timer-period change. It had exactly one caller
(`hle_graphics.cpp`); the kernel time path never adopted it.

## Two fixes

**1. The sleep family** (`k_usleep`, `k_sleep_s`, `k_nanosleep`) computes an **absolute** deadline and
calls `sleep_until_steady_ns`. Absolute matters: a relative sleep adds its own overhead to every
iteration of a pacing loop and the deficit compounds. `k_nanosleep` also writes its remainder
out-parameter as zero instead of leaving it untouched.

| The Messenger | requested | actual | ratio | sleep cycles in run |
| --- | --- | --- | --- | --- |
| legacy | 18.17 ms | 23.74 ms | **×1.31** | 6,097 |
| fixed | 15.41 ms | 15.69 ms | **×1.02** | 9,211 |

**2. The audio grain pacer** (`audio_sink_sdl3.cpp`) paced the guest's audio thread with
`std::this_thread::sleep_until`, one grain per `sceAudioOutOutput`. Because `s.next` accumulates an
**absolute** target, a 15.6 ms overshoot leaves the next two or three targets already in the past — so
those calls return **instantly**. Delivery clumped into bursts of ~3 grains, then a ~15.6 ms gap.

**The per-second average stayed at real time** — 385,024–389,120 B/s against the 384,000 B/s that
f32/2ch/48 kHz needs — while the queue drained in every gap. That is why a delivery-rate check does
not find this, and it reintroduced by a different route exactly the burstiness #1016 removed.

| pacer | handoffs/s | queue min | queue **max** |
| --- | --- | --- | --- |
| legacy | 187–191 | 2048–3328 | **11264–11776** (5.5 grains) |
| fixed | 188 | 2048 (exactly one grain) | **5888** (2.9 grains) |

**Read that table with its polarity in mind, which an earlier version of this body did not.** The sample
is taken *after* the put, so "min pinned at exactly one grain" means the stream was empty immediately
*before* the put, and the legacy arm's larger max is **buffer**, not starvation. The table is therefore
**not** evidence in the underrun direction and must not be quoted as such (raised in review).

What does stand: the **mechanism** — an absolute target plus a quantized sleep leaves later targets
past-due, so those calls return instantly and delivery clumps — and the project owner confirming **by
ear** that the underruns are gone on a build carrying this fix, where the immediately preceding build
had them. The instrument that would settle it without a human is the 1 ms sampler on #3033.

## Two new instruments, both off by default

- **`PROSPER_TIMEDWAIT_CENSUS=1`** — per-primitive call count, mean requested vs mean actual, and the
  ratio, across all seven primitives it instruments. Built because knowing the primitives quantize does **not**
  say which one a title's mixer paces on, and a fix aimed at the wrong one is untestable. It already
  earned itself: *The Messenger* and *Blasphemous 2* both pace on **`usleep` alone**, calling none of
  any of the four instrumented timed waits — so the `sem_timedwait` fix a local branch measured against
  FMOD is not what
  either of these titles needs.
- **`PROSPER_AUDIO_QUEUE_TRACE=1`** — queue depth at each handoff as a per-second **minimum**, plus
  handoffs that found under one grain buffered.

`PROSPER_GUEST_SLEEP_LEGACY=1` restores both old paths so the A/B stays reproducible
(`PROSPER_UD_TAIL_ALIGN` precedent).

## Deliberately not fixed

`k_sem_timedwait`, `k_cond_timedwait` and `k_mutex_timedlock` are **censused but unchanged**. A
poll-and-precise-sleep loop would trade away the 0.01 ms post wake measured above, and no title
measured so far calls them on an audio path. They get the instrument, not a speculative fix.

## Honest limit on the evidence

`PROSPER_AUDIO_QUEUE_TRACE` samples **at handoffs**, so it is event-sampled, not time-sampled: a queue
draining *between* handoffs is invisible to it. `below-one-grain=0` appears in **both** arms and must
not be read as "no underruns". A ~1 ms time-based sampler is needed for that claim, and one exists on
the unmerged `blasphemous2-windows` branch (`b2b90280`), alongside `c45debbf` which fixes the
`k_sem_timedwait` half. Neither is an ancestor of `origin/master`.

**So: mechanism confirmed, direction correct, and the audible outcome since confirmed by ear** — the
project owner reports no artefacts on a build carrying this fix, where the immediately preceding build
had continuous small underruns. (An earlier revision of this line said the audible outcome was *not yet*
verified, and it survived the edit that added the confirmation above, so this section asserted and denied
the same thing. The instrument that would settle it without a human is still the 1 ms sampler on #3033.)

## Affected / unaffected

- **Affected:** Windows guest sleep accuracy and audio grain pacing, in every title.
- **Linux/macOS are AFFECTED, contrary to an earlier version of this section.**
  `sleep_until_steady_ns` falls through to a `sleep_until` loop there, and that loop **restarts on
  EINTR** where the bare `nanosleep` it replaces did not — so a signal no longer truncates a guest
  sleep. Very likely an improvement, but it is a behaviour change, and filing it under "unaffected" was
  wrong (raised in review). `precise_sleep.cpp` reports which backend ran, so a test can assert the
  mechanism rather than a wall-clock duration.
- **Unaffected:** the four instrumented timed waits' behaviour (census is an RAII timer, two branches
  when off).

## Risks

- `hle_kernel.cpp` census scopes sit near the `#2168` `GuestCondWaiterScope` discipline, which has been
  got wrong twice (#2596, #2623). They are plain timers that take no locks and park nothing, but a
  reviewer should confirm placement cannot alter park/retire ordering.
- `guest_sleep_ns` changes the sleep primitive for **every** guest sleep on Windows, which is broad
  blast radius for an audio fix. Mitigated by the legacy lever and a green suite, but it is the main
  thing to review.
- The census header uses `inline` variables for shared counters across TUs; a `static` there would give
  each TU its own table and each would report the other as never called.

## Verification (exact head)

Windows 11 / RTX 4090, MinGW GCC 16.1, `RelWithDebInfo`:

```
cmake --build prosper/build-mingw-app -j8                      # exit 0
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4   # exit 0
100% tests passed, 0 tests failed out of 243     # +1 over master's Windows count: test_kernel_nanosleep
```

*The Messenger* and *Blasphemous 2* both boot and run with audio. (242 requires PR #3018 to link the
whole tree on Windows.)


