### PR TITLE
gpu: group a colour pass on the surface it renders to, not a second representation of it

### DIFF
--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -13,16 +13,27 @@
 // classified stale named state as a live binding, which denies the authoritative direct-GPU path and
 // — when no CPU snapshot exists — degrades to guest bytes rather than to a slower correct source.
 //
+// One asymmetry this header does NOT itself resolve: for SLOT 0 the two read different
+// representations. Grouping takes slot 0's identity from the named fields (see
+// `mrt_same_color_pass`), because that is where live_renderer takes the address it renders to,
+// while feedback stays array-first through `mrt_active_color`. They agree because every producer
+// mirrors `color_targets[0]` from the named triple, not because anything here enforces it — so a
+// producer that ever filled the two independently would break the agreement without this header
+// changing.
+//
 // The rule: a slot is active when it has a base, a non-zero write mask, and a format the backend
 // accepts. That last term is TOTAL in the current backend -- `backend_color_format` maps every
 // unrecognised value, zero included, onto R8G8B8A8_UNORM, so it never rejects anything and a zero
 // format means "use the fallback" rather than "undefined". It is kept as a parameter because it is
 // the backend's decision to make, not this header's, and a backend that ever narrows it must narrow
-// grouping and feedback together. The
+// grouping and feedback together. For the ACTIVE-BINDING rule above, the
 // named `color0_*` / `color1_*` fields are consulted ONLY when the array representation is absent,
 // because `DrawItem` predates the complete array and capture versions through v33 carry the first
 // two attachments in those fields. Falling back whenever the array mask merely reads zero is a
 // different and wrong rule: a genuinely masked-off slot then inherits a stale named mask.
+//
+// That "ONLY" scopes to the active-binding rule and does not extend to slot 0's PASS IDENTITY,
+// which is named-first for the reason given at `mrt_same_color_pass`.
 namespace prosper::frontend {
 
 inline prosper::gpu::DrawItem::ColorTargetBinding mrt_color_binding(
@@ -98,13 +109,17 @@ bool mrt_same_color_pass(const prosper::gpu::DrawItem& first,
     // attachment -- and two draws that render to DIFFERENT addresses then share a pass, so the
     // second draw's target is silently discarded and its pixels are never published.
     //
-    // On captured and live draws the two representations are identical, because every producer
-    // derives color_targets[0] from the named fields rather than filling it independently
-    // (gpu_capture.cpp:518/2392/5190, gpu_execute.hpp:2398 and :1603) -- so this is a no-op there.
-    // It differs only for a caller that builds a DrawItem directly and populates the named aliases
-    // alone, which is exactly the shape gpu_execute.hpp:2398 exists to repair and which the render
-    // fixtures construct. Falling back to `mrt_color_binding` when `color0_base` is 0 keeps the
-    // previous answer for a draw that names no slot-0 surface at all.
+    // On captured and live draws the two representations are identical, so this is a no-op there.
+    // For captures a divergence is not merely absent but INEXPRESSIBLE: the wire format carries
+    // slots 2 and up only, and `restore_legacy_color_target_aliases` re-derives slots 0/1 from the
+    // named triple on every load. For live draws the same mirror sits at the single success exit of
+    // `realize_draw_item`. Neither is asserted anywhere, which is the one soft spot -- they are
+    // conventions held by every producer rather than a checked invariant.
+    //
+    // The two differ only for a caller that builds a DrawItem directly and populates the named
+    // aliases alone: exactly the shape `realize_draw_item`'s mirror exists to repair, and the shape
+    // the render fixtures construct. Falling back to `mrt_color_binding` when `color0_base` is 0
+    // keeps the previous answer for a draw that names no slot-0 surface at all.
     auto pass_binding = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
         if (slot == 0 && draw.color0_base)
             return prosper::gpu::DrawItem::ColorTargetBinding{

--- a/prosper/frontends/shared/rtt/mrt_binding.hpp
+++ b/prosper/frontends/shared/rtt/mrt_binding.hpp
@@ -91,11 +91,31 @@ template <typename FormatDefined, typename FormatAt>
 bool mrt_same_color_pass(const prosper::gpu::DrawItem& first,
                          const prosper::gpu::DrawItem& candidate,
                          FormatDefined format_defined, FormatAt format_at) {
+    // Slot 0 is compared on the NAMED triple whenever it names a surface, because that is the
+    // surface the pass actually renders to: live_renderer takes `pass_bases[0]` from `color0_base`,
+    // while every slot above 0 goes through the array. Reading slot 0's identity from the array
+    // instead makes GROUPING and TARGET SELECTION consult different representations of one
+    // attachment -- and two draws that render to DIFFERENT addresses then share a pass, so the
+    // second draw's target is silently discarded and its pixels are never published.
+    //
+    // On captured and live draws the two representations are identical, because every producer
+    // derives color_targets[0] from the named fields rather than filling it independently
+    // (gpu_capture.cpp:518/2392/5190, gpu_execute.hpp:2398 and :1603) -- so this is a no-op there.
+    // It differs only for a caller that builds a DrawItem directly and populates the named aliases
+    // alone, which is exactly the shape gpu_execute.hpp:2398 exists to repair and which the render
+    // fixtures construct. Falling back to `mrt_color_binding` when `color0_base` is 0 keeps the
+    // previous answer for a draw that names no slot-0 surface at all.
+    auto pass_binding = [](const prosper::gpu::DrawItem& draw, uint32_t slot) {
+        if (slot == 0 && draw.color0_base)
+            return prosper::gpu::DrawItem::ColorTargetBinding{
+                draw.color0_base, draw.color0_width, draw.color0_height};
+        return mrt_color_binding(draw, slot);
+    };
     const uint32_t count = mrt_active_color_count(first, format_defined);
     if (mrt_active_color_count(candidate, format_defined) != count) return false;
     for (uint32_t slot = 0; slot < count; ++slot) {
-        const auto a = mrt_color_binding(first, slot);
-        const auto b = mrt_color_binding(candidate, slot);
+        const auto a = pass_binding(first, slot);
+        const auto b = pass_binding(candidate, slot);
         const uint64_t a_base = slot == 0 ? a.base
             : mrt_active_color(first, slot, format_defined);
         const uint64_t b_base = slot == 0 ? b.base

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -217,6 +217,54 @@ int main() {
                                 format_defined));
     }
 
+    // Slot 0's pass identity is the surface the pass RENDERS to.
+    //
+    // live_renderer takes `pass_bases[0]` from the named `color0_base`, while every slot above 0
+    // goes through the array. Grouping therefore has to read slot 0 from the same place: when it
+    // read the array instead, two draws rendering to DIFFERENT addresses grouped into one pass and
+    // the second draw's target was silently discarded -- it produced no pass, published no pixels,
+    // and the chain returned the previous draw's surface at the previous draw's extent.
+    //
+    // Every production producer derives `color_targets[0]` from the named fields rather than
+    // filling it independently (gpu_capture.cpp:518/2392/5190, gpu_execute.hpp:2398 and :1603), so
+    // the two representations agree on captured and live draws and this costs nothing there. They
+    // diverge only for a caller that builds a DrawItem directly and sets the named aliases alone --
+    // the "direct/synthetic callers" gpu_execute.hpp:2398 exists to repair, and the shape the render
+    // fixtures construct. Regression for four gpu_capture_render_replay arms.
+    {
+        auto producer = make_draw();
+        producer.color_targets[0].base = 0x200000ull;  // a stale mirror of an earlier target
+        producer.color0_base = 0x300000ull;
+        producer.color0_width = 32u;
+        producer.color0_height = 2u;
+        producer.ps.color_write_mask = 0xfu;
+
+        auto consumer = producer;                      // same stale array entry ...
+        consumer.color0_base = 0x400000ull;            // ... a different rendered surface
+        consumer.color0_width = 16u;
+        consumer.color0_height = 16u;
+        CHECK(!mrt_same_color_pass(producer, consumer, format_defined, format_at));
+        CHECK(mrt_same_color_pass(producer, producer, format_defined, format_at));
+
+        // The series added the extent term to stop GTA V's 64x32 and 32x16 mip levels sharing one
+        // attachment. Reading slot 0 from the array defeated that term as well, because a stale
+        // array entry carries no extent and unknown extents never conflict: same address, both
+        // extents 0x0, grouped. The named extents are what conflict.
+        auto smaller_level = producer;
+        smaller_level.color0_width = 16u;
+        smaller_level.color0_height = 16u;
+        CHECK(!mrt_same_color_pass(producer, smaller_level, format_defined, format_at));
+
+        // With no named slot-0 surface the array remains the answer, exactly as before.
+        auto array_only = make_draw();
+        array_only.color_targets[0].base = 0x500000ull;
+        array_only.ps.color_write_mask = 0xfu;
+        auto array_other = array_only;
+        array_other.color_targets[0].base = 0x600000ull;
+        CHECK(!mrt_same_color_pass(array_only, array_other, format_defined, format_at));
+        CHECK(mrt_same_color_pass(array_only, array_only, format_defined, format_at));
+    }
+
     if (failures == 0) std::printf("mrt_binding: OK\n");
     return failures == 0 ? 0 : 1;
 }

--- a/prosper/frontends/shared/tests/test_mrt_binding.cpp
+++ b/prosper/frontends/shared/tests/test_mrt_binding.cpp
@@ -226,18 +226,18 @@ int main() {
     // and the chain returned the previous draw's surface at the previous draw's extent.
     //
     // Every production producer derives `color_targets[0]` from the named fields rather than
-    // filling it independently (gpu_capture.cpp:518/2392/5190, gpu_execute.hpp:2398 and :1603), so
-    // the two representations agree on captured and live draws and this costs nothing there. They
-    // diverge only for a caller that builds a DrawItem directly and sets the named aliases alone --
-    // the "direct/synthetic callers" gpu_execute.hpp:2398 exists to repair, and the shape the render
-    // fixtures construct. Regression for four gpu_capture_render_replay arms.
+    // filling it independently -- `restore_legacy_color_target_aliases` on every capture load, and
+    // the mirror at `realize_draw_item`'s single success exit for live draws -- so the two agree on
+    // captured and live draws and this costs nothing there. They diverge only for a caller that
+    // builds a DrawItem directly and sets the named aliases alone: the "direct/synthetic callers"
+    // that mirror exists to repair, and the shape the render fixtures construct. Regression for
+    // four gpu_capture_render_replay arms.
     {
         auto producer = make_draw();
         producer.color_targets[0].base = 0x200000ull;  // a stale mirror of an earlier target
         producer.color0_base = 0x300000ull;
         producer.color0_width = 32u;
         producer.color0_height = 2u;
-        producer.ps.color_write_mask = 0xfu;
 
         auto consumer = producer;                      // same stale array entry ...
         consumer.color0_base = 0x400000ull;            // ... a different rendered surface
@@ -245,6 +245,15 @@ int main() {
         consumer.color0_height = 16u;
         CHECK(!mrt_same_color_pass(producer, consumer, format_defined, format_at));
         CHECK(mrt_same_color_pass(producer, producer, format_defined, format_at));
+
+        // Isolate the BASE term: same named extent, a different rendered surface. Without this arm
+        // the set is satisfied by a change that keeps the ARRAY base and takes only the named
+        // EXTENT -- which gets this fix's whole subject, the address the pass renders to, backwards.
+        // The arm above cannot catch that mutant because it differs in base AND extent, and the one
+        // below isolates the extent; nothing else here varies the base alone.
+        auto other_surface = producer;
+        other_surface.color0_base = 0x400000ull;  // extents stay 32x2
+        CHECK(!mrt_same_color_pass(producer, other_surface, format_defined, format_at));
 
         // The series added the extent term to stop GTA V's 64x32 and 32x16 mip levels sharing one
         // attachment. Reading slot 0 from the array defeated that term as well, because a stale
@@ -258,7 +267,6 @@ int main() {
         // With no named slot-0 surface the array remains the answer, exactly as before.
         auto array_only = make_draw();
         array_only.color_targets[0].base = 0x500000ull;
-        array_only.ps.color_write_mask = 0xfu;
         auto array_other = array_only;
         array_other.color_targets[0].base = 0x600000ull;
         CHECK(!mrt_same_color_pass(array_only, array_other, format_defined, format_at));


### PR DESCRIPTION
## What this is

**A same-day regression fix that un-reds master.** `97ecc58a` ("gpu: GTA V world rendering series")
introduced `mrt_same_color_pass` and, with it, silently changed where pass grouping reads slot 0's
identity from. Its own diff shows the predicate it replaced:

```
-  if (draw.color0_base != base || ...)                                  // named color0_base
+  if (!prosper::frontend::mrt_same_color_pass(pass_head, draw, ...))    // array-first
```

The address the pass **actually renders to** was not changed and still comes from the named
`color0_base` (`live_renderer.cpp:7046`, and `pass_bases[0]` at `:7207`; every slot above 0 goes
through the array on both paths). So grouping and target selection began consulting two different
representations of one attachment.

When they disagree, **two draws that render to different addresses group into one pass.** The group
renders at the first draw's target, so the second draw's surface is silently discarded: no pass, no
published pixels, and the frame falls back to the previous draw's surface at the previous draw's
extent.

The same read also defeated — for slot 0 only — the extent term that series added to stop two mip
levels sharing one attachment. A stale array entry carries no extent, and unknown extents never
conflict, so same-address/different-extent draws grouped anyway.

## Failure scenario

`render_submit_items({producer, consumer}, 64, 64)`, producer rendering to `0x300000` at 32x2 and
consumer to `0x400000` at 16x16, returns **256 bytes** (32x2x4 — the producer's extent) instead of
1024. Measured:

```
[lane] item=0 named_base=0x300000 named=32x2  array_base=0x200000 array=0x0
[lane] item=1 named_base=0x400000 named=16x16 array_base=0x200000 array=0x0
[pass] cb=31 pass=2/2 base=0x300000 32x2 ... bytes=256
```

Both items carry the same stale array entry, so grouping produced one pass at the producer's target
(`pass=2/2` — the cursor consumed both items). `present_extent.hpp` documents this contract and names
the failing assertion by its exact text.

## The change

Compare slot 0 on the named triple whenever it names a surface; fall back to `mrt_color_binding`
when `color0_base` is 0, which preserves the previous answer for a draw that names no slot-0 surface.

## Why this cannot change captured or live rendering

Not merely "no divergence was found" — for captures a divergence is **inexpressible**: the wire
format carries slots 2 and up only, and `restore_legacy_color_target_aliases` re-derives slots 0/1
from the named triple on every load. For live draws the same mirror sits at the **single success
exit** of `realize_draw_item`. `render_state.cpp` derives the named field *from* the array, keeping
them equal in the other direction too. Given that mirror, the fix is provably identical for all
inputs, not just for the cases exercised.

The soft spot is that none of this is **asserted** anywhere — it is a convention every producer
happens to follow. Closing that is worth doing separately, and is filed as **#3026** — which also records why the
obvious guard is the wrong one: an assertion inside `realize_draw_item` would sit two lines below the
mirror it checks, so it would pass forever and catch nothing. Enforcement has to sit where the two
representations are read apart.

## Affected / deliberately unaffected

- Affected: pass grouping for a `DrawItem` whose named and array slot-0 entries disagree.
- Unaffected: slots 1 and above, feedback detection, `mrt_color_binding`'s own precedence, and every
  captured and live draw.
- **Same defect class left in place deliberately:** the resolve path takes its destination from raw
  `color1_base` while grouping keys slot 1 on `mrt_active_color`, which is 0 for every resolve — so
  consecutive resolves into different destinations group and all but the first are dropped. Filed as
  **#3025**, out of scope here.

## Verification

```
cmake --build prosper/build-linux -j6          # 0 errors
ctest --no-tests=error                         # 100% tests passed out of 302
```

Master before this PR: **301/302** locally; CI's Linux job fails **2 of 303** —
`gpu_capture_render_replay` (this PR) and `recompiled_shaders_render` (#3012, unrelated and
pre-existing).

**Result on this head — the prediction held exactly:**

```
282/303 Test #282: recompiled_shaders_render ......................***Failed    0.11 sec
99% tests passed, 1 tests failed out of 303
```

`gpu_capture_render_replay` passes in CI. The one remaining failure is #3012, which is red on master
too and which this PR does not touch. Every other required check is green.

**Why local reads 302 and CI reads 303** — the sets differ by three named tests, not by anything
silently unregistered. CI's Linux job passes `-DPROSPER_DIAGNOSTICS=ON` and so adds
`diagnostics_enabled_capture` and `diagnostics_json_format`; this machine has SDL3 audio and so adds
`audio_sdl3`, which that job does not build. 302 + 2 - 1 = 303, and a name-by-name diff of the two
lists accounts for every entry.

**Mutation arms — the suite rejects both wrong fixes:**

| mutant | caught by |
| --- | --- |
| revert slot 0 to array-first | `:246`, `:256`, `:265` and all four `gpu_capture_render_replay` arms |
| keep the ARRAY base, take only the named EXTENT (gets the subject backwards) | `:256` **only** |

The second arm exists because the first version of this test could not tell those apart — the
reviewer built that mutant and it passed everything. The two array-only control arms keep passing
under both mutants, which is what separates "changed slot-0 precedence" from "changed the predicate
wholesale".

**Rendering smoke check** — routed GTA V run on this branch, `tools/screenshot`,
performance-mode route: 40/40 screenshots, 35 pixel-distinct, **0 device losses**, guest running,
`status=ok`. The prologue bank interior renders at 4K.

To be precise about what that does and does not show: it is **corroborating, not discriminating**.
If the no-op argument above is right, a healthy run is *entailed* — it could not have come out
otherwise. So it rules out a crash or device-loss regression, and it does **not** independently
establish pixel parity, which would need the frames diffed against a master run. It is here as a
smoke test; nobody should later cite it for more than that.

Fixes #3015
