### PR TITLE
test(recompiler): the scalar-VCC arm demanded a wave64 skip from a shader that never needed wave64

### DIFF
--- a/prosper/tests/gpu/recompiler/test_recompiled_shaders.cpp
+++ b/prosper/tests/gpu/recompiler/test_recompiled_shaders.cpp
@@ -88,16 +88,36 @@ int main() {
             (ctx.subgroup_operations & VK_SUBGROUP_FEATURE_VOTE_BIT);
         if (p) printf("  scalar-vcc center=(%u,%u,%u,%u) wave64-vote=%d\n",
                       p[0], p[1], p[2], p[3], static_cast<int>(supports_fragment_wave64_vote));
-        // The skipped arm pairs the clear colour with the module's own declared requirement, so it
-        // asserts "this shader demanded wave64 and the device therefore left the target untouched"
-        // rather than the weaker "no draw landed here", which any pipeline failure would satisfy.
-        CHECK(p && (supports_fragment_wave64_vote
-                        ? (p[0] > 0x80 && p[1] < 0x40 && p[2] < 0x40)
-                        : (fragment_spirv_required_subgroup_size(scalar_vcc_frag) == 64 &&
-                           p[2] > 0x80 && p[0] < 0x40 && p[1] < 0x40)),
-              supports_fragment_wave64_vote
-                  ? "fragment scalar VCC_LO dword reaches compare/select exactly"
-                  : "device without fragment wave64 vote skips the scalar-VCC draw fail-visible");
+        // This arm is NOT device-gated, and the reason is a measurement rather than a preference.
+        //
+        // It used to be: on a device without fragment wave64 vote it demanded that the target stay
+        // at its BLUE clear, pairing that with `required_subgroup_size == 64` so the assertion meant
+        // "this shader demanded wave64 and the device therefore left the target untouched" rather
+        // than the weaker "no draw landed here". The pairing is good practice; the premise is false
+        // for this shader. The module declares **no** required subgroup size, and the backend's skip
+        // is `required_fragment_subgroup_size && (...device terms...)` -- so a zero short-circuits
+        // the whole conjunction and the draw runs on every device, whatever it supports. The arm
+        // could therefore never hold where it was actually evaluated, and CI is exactly there: it
+        // reported `center=(255,0,0,255)`, which is this arm's own SUCCESS colour.
+        //
+        // Zero is the CORRECT answer here, which is why it is pinned rather than tolerated. VCC_LO
+        // in this fixture is a 32-bit scratch dword -- `s_and_b32 vcc_lo, s18, 3` writes it and
+        // `s_cmp_eq_u32 1, vcc_lo` reads the whole dword straight back. Nothing consults it as a
+        // lane mask, so the result cannot depend on the wave width, and demanding a 64-lane wave
+        // would over-constrain the module onto hardware with no reason to be excluded.
+        //
+        // The device gate is not weakened in general -- it is simply not this shader's contract.
+        // `test_recompiled_fragment` still exercises it through `skipped_wave64_draw`, and those
+        // modules still declare 64 (measured the same day: `direct_break_frag` -> 64 against this
+        // one's 0). That contrast is what separates "the requirement was correctly narrowed to the
+        // shaders that need it" from "the requirement stopped being emitted", and only the first is
+        // consistent with both numbers.
+        const uint32_t scalar_vcc_required =
+            fragment_spirv_required_subgroup_size(scalar_vcc_frag);
+        CHECK(scalar_vcc_required == 0,
+              "width-independent VCC_LO dword use declares no required subgroup size");
+        CHECK(p && p[0] > 0x80 && p[1] < 0x40 && p[2] < 0x40,
+              "fragment scalar VCC_LO dword reaches compare/select exactly on any wave width");
     }
 
     // An NGG hardware vertex program uses LDS even when its logical output is an ordinary vertex.


### PR DESCRIPTION
## The failure

`recompiled_shaders_render` is the last red test on master's Linux CI. One arm fails:

```
scalar-vcc center=(255,0,0,255) wave64-vote=0
[FAIL] device without fragment wave64 vote skips the scalar-VCC draw fail-visible
== FAIL: 1 ==
```

`(255,0,0,255)` is that arm's **own success colour** (`p[0] > 0x80 && p[1] < 0x40 && p[2] < 0x40`).
So the draw ran and produced the right answer; what failed is the demand that it be *skipped*.

## Why the draw was right to run

The module declares **no** required subgroup size, and the backend's skip is

```cpp
bool fragment_subgroup_skip = required_fragment_subgroup_size && (...device terms...);
```

A zero short-circuits the whole conjunction, so the draw executes on every device regardless of what
it supports. The arm could never hold anywhere it was actually evaluated — it is satisfiable only on
a device that lacks wave64 vote, and on exactly those devices its first term is false.

Zero is also the **correct** declaration, which is why this PR pins it rather than tolerating it.
VCC_LO in this fixture is a 32-bit scratch dword — `s_and_b32 vcc_lo, s18, 3` writes it and
`s_cmp_eq_u32 1, vcc_lo` reads the whole dword straight back. Nothing consults it as a lane mask, so
the result cannot depend on the wave width, and demanding a 64-lane wave would over-constrain the
module onto hardware with no reason to be excluded.

## The change

Drop the device gate from this one arm — it is not this shader's contract — and pin the two facts
that replace it:

1. the module declares no required subgroup size, and
2. the draw produces the exact compare/select result **on any wave width**.

## The device gate keeps its coverage

This is the part worth checking rather than asserting, because "the assertion was adjusted until it
passed" is the failure mode #3012 explicitly warned against.

`test_recompiled_fragment` still exercises the gate through `skipped_wave64_draw`
(`required == 64 && is_blue_clear(p)`) at three arms, and **those modules still declare 64**.
Measured the same day:

| module | declared required subgroup size |
| --- | --- |
| `direct_break_frag` (v_cmpx + `s_mov_b64 exec`, real wave semantics) | **64** |
| `scalar_vcc_frag` (VCC_LO as a 32-bit dword) | **0** |

That contrast is the evidence. It separates "the requirement was correctly narrowed to the shaders
that need it" from "the requirement stopped being emitted", and only the first is consistent with
both numbers. `recompiled_fragment` also passes on CI's no-wave64 device today, which is an
independent confirmation from the other direction: those arms take the *skip* branch there and hold.

## Verified on the CI device class, locally

Nobody had tried this, and it is why the bug survived three PRs measured as "301/302": the arm is
**unreachable on a wave64-capable GPU**. lavapipe reproduces the CI device class on an ordinary
workstation:

```bash
VK_DRIVER_FILES=/usr/share/vulkan/icd.d/lvp_icd.x86_64.json ./test_recompiled_shaders
```

| | pre-fix | with fix |
| --- | --- | --- |
| lavapipe (`wave64-vote=0`, CI's class) | `== FAIL: 1 ==` — byte-identical to CI | `== PASS ==` |
| RADV (`wave64-vote=1`) | `== PASS ==` — why nobody saw it | `== PASS ==` |

The pre-fix/lavapipe row is a genuine local reproduction, not a simulation: same
`center=(255,0,0,255) wave64-vote=0` line, same single failing arm.

`recompile_fragment` takes no device or context argument (its only width input is `wave32`, defaulted
and not passed here), so the SPIR-V — and therefore the declared requirement — is device-independent.
That is what makes the lavapipe result transferable to CI rather than merely suggestive.

## Verification

```
cmake --build prosper/build-linux -j6          # 0 errors
ctest --no-tests=error                         # 100% tests passed out of 302   (RADV)
```

Local reads 302 and CI 303 because CI passes `-DPROSPER_DIAGNOSTICS=ON` (adding
`diagnostics_enabled_capture` and `diagnostics_json_format`) while this machine has SDL3 audio and
adds `audio_sdl3`. 302 + 2 - 1 = 303; a name-by-name diff accounts for every entry.

**This takes master's Linux `Test` step to 0 failures of 303** — confirmed on this PR's own CI run,
which reports `100% tests passed, 0 tests failed out of 303`. `gpu_capture_render_replay`, the other
half of master's red test count, was fixed by #3023 and confirmed passing in CI there.

**It does not by itself make the Linux JOB green, and the PR should not be read as claiming that.**
With the tests finally passing, the job proceeds to a step it has not reached in months — the Vulkan
validation scan — and that step fails on `VUID-VkWriteDescriptorSet-descriptorType-00328` x8 from
`game_compute_exec`. That is **#1727**, pre-existing and unrelated to this change: the scan has been
*skipped* rather than passing on every master commit since the tests went red, and last ran green at
`97ecc58a^`. Reproduced locally under lavapipe (`offset (4)` against a required multiple of 16), and
the site is `live_compute.cpp`'s compare-flags buffer, which strides one `uint32_t` per target
without consulting `minStorageBufferOffsetAlignment`.

So this PR removes one of the two things keeping the job red, and makes the second one *visible* for
the first time. #1727 is the remaining one.

Fixes #3012
