### PR TITLE
scripts(tomb-raider): headless route to the opening cutscene, and correct the menu map

### DIFF
--- a/prosper/scripts/tomb-raider-PPSA16901/AGENTS.md
+++ b/prosper/scripts/tomb-raider-PPSA16901/AGENTS.md
@@ -29,9 +29,19 @@ Two independent axes, which is what makes this menu easy to misread:
   Left and right traverse it in opposite directions; `Lara's Home` is the item selected on arrival.
 - **Cross selects the ring item.**
 
-**There is no New Game or Load Game item on that ring**, which is why `reach-gameplay.pad` enters
-the world through `Lara's Home` (Croft Manor, a real playable level) rather than through a new-game
-flow. Whether the missing passport item is a prosper defect is open — see the status doc.
+**The item labelled `Game` IS the New Game entry** — not a settings category. An earlier version of
+this file said the ring carried no New Game item; that was wrong, and it was wrong in the expensive
+direction, because it sent a lane looking for a missing passport item that is not missing. Three
+LEFTs from the default `Lara's Home` reach it, and Cross starts a new game with its opening cutscene.
+`reach-fmv.pad` does exactly that.
+
+`reach-gameplay.pad` still enters through `Lara's Home` because that reaches a playable level in a
+few seconds with no cutscene to sit through — a route choice, not a limitation.
+
+**The cutscenes are the title's own Theora files and the guest decodes them itself**: a run of
+`reach-fmv.pad` logs zero AvPlayer and zero videodec activity. Their pacing is therefore the game's
+clock, not prosper's video backend, so a timing defect seen in a cutscene is not an AvPlayer bug.
+Ground truth for timing work is in the dump — `ffprobe` the FMV and count its packets.
 
 ## Timing
 

--- a/prosper/scripts/tomb-raider-PPSA16901/reach-fmv.pad
+++ b/prosper/scripts/tomb-raider-PPSA16901/reach-fmv.pad
@@ -1,0 +1,18 @@
+# PPSA16901: default launch -> Tomb Raider I's opening FMV (SNOW.OGV), headless.
+#
+# The ring item named "Game" IS the New Game entry, not a settings category -- three LEFTs from the
+# default "Lara's Home" lands on it (Lara's Home -> Controls -> Extras -> Game). Cross starts a new
+# game and the opening cutscene plays. The FMV begins at roughly t=137 s on the development host.
+#
+# The cutscene is Theora in the dump's own FMV/HD/SNOW.OGV, and the guest decodes it ITSELF: a run of
+# this route logs zero AvPlayer and zero videodec activity. So its pacing is the title's own clock,
+# not prosper's video backend -- do not go looking in AvPlayer for a defect seen here.
+#
+# Ground truth for timing work: SNOW.OGV is 1528 video packets over 101.968635 s = 14.985 fps.
+6-14:down
+16-18:cross
+42-43:left
+47-48:left
+52-53:left
+58-60:cross
+66-68:cross


### PR DESCRIPTION
Scripts + docs only. Two things, both from playtesting Tomb Raider I-III Remastered (`PPSA16901`).

## 1. A headless route to the opening cutscene

`reach-fmv.pad` drives a default launch to the title's opening cutscene, so cutscene timing stops
depending on someone with a stopwatch. Verified reaching the FMV; the playback window is readable
directly from the capture manifest by its letterboxing (the FMV is pillarboxed against a full-frame
menu/gameplay composite, so `nonblack_rgb_pixels` separates them cleanly).

## 2. A correction to the menu map, in the expensive direction

The `AGENTS.md` in that folder stated **"There is no New Game or Load Game item on that ring"**. That
is wrong: the item labelled **`Game` IS the New Game entry**, three LEFTs from the default
`Lara's Home`. The old text invited a reader to go looking for a missing passport item that is not
missing — and it did exactly that to me before the owner reported reaching New Game by hand.

## Also recorded: whose clock paces a cutscene here

A run of this route logs **zero AvPlayer and zero videodec activity**. The cutscenes are the title's
own Theora files in `<game>/FMV/HD/*.OGV` and **the guest decodes them itself**, so their pacing is
the game's own clock rather than prosper's video backend.

That matters because there is active, recent work in the AvPlayer pacing area (#2979 GRIS's FMV
playing too fast; #2989's PTS gate) which looks like it should apply here and does not. I spent a
detour there before measuring it. Both the route file and the map now say so.

Ground truth for timing work is in the dump itself — `ffprobe` the `.OGV` and count its packets. For
example `2/FMV/HD/ANCIENT.OGV` is 1528 packets over 145.3 s = 14.985 fps, which is how the playback
ratio was measured without a hardware oracle.

## Verification

- `check_numbered_table.py` over every tracked `.md` — exit 0.
- `git diff --check` — clean.
- No `Claude-Session:` trailer.
- No code changes: the diff is one `.pad` route and one `AGENTS.md`.

An earlier `reach-fmv-tr1.pad` was written and then **dropped rather than committed** — it did not
reach a cutscene, and a route file that documents a path it does not take is worse than no file.

Refs #2990, #3021
