### PR TITLE
ci(win): build boot_trace in the Vulkan-enabled Windows job, and correct what #3014 actually was

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -555,6 +555,25 @@ jobs:
           cmake --build prosper/build-windows-app
           --target prosper-app test_prosper_app_pad_overlay test_audio_sdl3 test_pad_sdl3
 
+      # Separate step, and deliberately NOT folded into the target list above: prosper-app does not
+      # depend on boot_trace, and naming it in the app build would make this job cover something its
+      # name does not claim. What it IS here for: this is the only Windows job that installs the
+      # Vulkan headers and loader, so it is the only one where PROSPER_HAVE_VULKAN gets defined
+      # (CMakeLists.txt sets it only when Vulkan is found). windows-mingw builds the whole tree but
+      # passes -DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE, so every Vulkan-gated block is preprocessed
+      # away there.
+      #
+      # That split is how #3014 survived a fortnight: boot_trace.cpp called POSIX setenv inside its
+      # PROSPER_HAVE_VULKAN block, so the job that builds the target never compiled the code and the
+      # job that would compile the code never built the target. Neither was red. Any Windows tool with
+      # Vulkan-gated code needs a line here, or it is uncompiled on this platform.
+      - name: Build Windows tools that only compile with Vulkan enabled
+        shell: msys2 {0}
+        run: >-
+          cmake --build prosper/build-windows-app
+          --target boot_trace
+
+
       # See the linux job (#2187) for --no-tests=error. This job is the one it matters most for:
       # it is the only job testing a directory other than build-ci, so a --test-dir that drifted
       # back to the common name would find an absent or unbuilt tree, register nothing, and pass.

--- a/prosper/tools/boot_trace/boot_trace.cpp
+++ b/prosper/tools/boot_trace/boot_trace.cpp
@@ -1,7 +1,8 @@
 // boot_trace — link the game's modules, boot the guest, and report how far it got:
 // the unimplemented-call trace (via stderr from dispatch), first-frame capture (--capture-first-frame),
 // plus, on a fault, the register state and an rbp-chain backtrace classified by module. The primary bring-up debugging
-// tool. Linux only. Usage: boot_trace <dump-root> [--capture-first-frame [output.bmp]]
+// tool. Builds on Linux and Windows (the Windows path is narrower; --capture-first-frame needs a
+// Vulkan-enabled build). Usage: boot_trace <dump-root> [--capture-first-frame [output.bmp]]
 #include "loader/linker.hpp"
 #include "host/image/exec_image.hpp"
 #include "host/image/boot_program.hpp"          // shared guest-boot path (also used by prosper-app)
@@ -260,17 +261,20 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[first-frame] output: %s\n", capture_first_frame_path.c_str());
         
         // Enable rendering (required for present_write_frame to produce frames).
-        // Not bare setenv: MinGW has no POSIX setenv, so this tool did not COMPILE on Windows at
-        // all -- and because it is one target in a whole-tree build, its failure stopped ninja
-        // before most test executables were linked, which surfaced as ~15 ctest cases Not Run
-        // rather than as a broken tool. Present since the --capture-first-frame commit (#3014).
+        // Not bare setenv: MinGW has no POSIX setenv. This block is inside PROSPER_HAVE_VULKAN, so
+        // the tool still built in the no-Vulkan configuration CI uses -- which is exactly why the
+        // break survived a fortnight, and why the earlier wording here ("did not COMPILE on Windows
+        // at all") was wrong. A Vulkan-enabled Windows build failed here, and ninja stopping at it
+        // left ~15 ctest cases unbuilt on that build -- a -k 1 scheduling effect, not a dependency,
+        // since nothing links against boot_trace. Introduced with --capture-first-frame, fixed in
+        // #3014; ci.yml now builds this target in the Vulkan-enabled Windows job so the two
+        // configurations cannot hide it between them again.
 #ifdef _WIN32
         _putenv_s("PROSPER_RENDER", "1");
 #else
         setenv("PROSPER_RENDER", "1", 1);
 #endif
 
-        
         // Register the live renderer (same as screenshot tool / prosper-app)
         prosper::frontend::register_live_renderer(".", /*dump_bmps=*/false);
         


### PR DESCRIPTION
Follow-up to #3014 (fixed in #3018 / `bf2504ce`). That fix landed with a wrong account of itself, and
with the gap that allowed it still open. Both were found in independent review of #3018.

## The gap is not "no Windows job builds the whole tree"

`windows-mingw` builds the whole tree on every commit and did so throughout the fortnight the break
was live. It passes `-DCMAKE_DISABLE_FIND_PACKAGE_Vulkan=TRUE`, so `PROSPER_HAVE_VULKAN` is undefined
and the offending block was preprocessed away.

Meanwhile the one Windows job that **does** define it — `windows-app` — builds an explicit target list
(`ci.yml:553-556`) that does not include `boot_trace`.

> The job that built the target never compiled the code; the job that would compile the code never
> built the target. Neither was ever red.

## Approach

A **separate step** in `windows-app`, not an extension of the app build's target list. `prosper-app`
does not depend on `boot_trace`, and naming it there would make the job cover something its name does
not claim — the project owner raised exactly this when the one-line version was proposed. The step
reuses the existing configure, so it costs a compile and no extra MSYS2 setup.

Scoped to `boot_trace` alone: it is `if(WIN32)`-unconditional (`CMakeLists.txt:1966`) so it certainly
exists in that configuration. `gpu_replay` is a candidate too but sits inside a nested conditional I did
not verify, and naming an absent target would fail the job — worth a follow-up rather than a guess.

## Two comment corrections, both overstatements caught in review

- *"this tool did not COMPILE on Windows at all"* — it compiled fine without Vulkan, which is the entire
  reason the break survived. The comment misstated the very mechanism it exists to record.
- *"its failure stopped ninja before most test executables were linked"* implied the tests depend on
  `boot_trace`. They do not: `CMakeLists.txt:1966-1971` makes it a standalone executable and nothing
  links against it. The 15 `Not Run` cases were real but are a **ninja `-k 1` scheduling effect**, so the
  damage depends on the build driver's keep-going setting rather than on the graph.

Also drops the file header's stale "Linux only" (it has had a `WIN32` build since #683) and a
trailing-whitespace line left by `bf2504ce`.

## Affected / unaffected

- **Affected:** the `windows-app` CI job gains one build step; `boot_trace`'s comments and header text.
- **Unaffected:** all other jobs, every platform's build output, and `boot_trace`'s runtime behaviour —
  no code changes, only comments plus a CI step.

## Verification (exact head, merged with `8b2afa6c`)

```
cmake --build prosper/build-mingw-app -j8                       # exit 0
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4    # exit 0
100% tests passed, 0 tests failed out of 242
```

`boot_trace` also builds clean on Windows/MinGW **with Vulkan enabled** locally, which is the
configuration this step adds to CI. `ci.yml` parses and the new step lands in the `windows-app` job
(checked by loading the YAML and listing that job's step names).

## Risk

The step adds ~1 compile to a job already at ~8 min. If `boot_trace` ever becomes conditional on more
than `WIN32`, this step fails on an unknown target rather than silently skipping — which is the
fail-visible direction, but worth knowing.