### PR TITLE
tools(perf): recover the audio-delivery and flip-pacing reports from #2984, and register their self-tests

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -379,6 +379,17 @@ if(Python3_Interpreter_FOUND)
   add_test(NAME compute_phase_report_logic
            COMMAND "${Python3_EXECUTABLE}"
                    "${CMAKE_SOURCE_DIR}/tools/perf/test_compute_phase_report.py")
+  # The audio-delivery and flip-pacing reports, recovered from #2984 (#3033). Registered rather
+  # than left as scripts with a --self-test nobody runs: both shipped with working self-tests in
+  # that PR and neither was wired into ctest, which is a test that cannot go red. Same synthetic-
+  # record caveat as compute_phase_report_logic above — these pin each tool against its own model
+  # of the log format, so they catch a parser regression and cannot notice the EMITTER drifting.
+  add_test(NAME audio_delivery_report_logic
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/perf/test_audio_delivery_report.py")
+  add_test(NAME flip_pacing_report_logic
+           COMMAND "${Python3_EXECUTABLE}"
+                   "${CMAKE_SOURCE_DIR}/tools/perf/test_flip_pacing_report.py")
   # stack_profile's frame classifier, against RECORDED gdb output. Deliberately needs no gdb and no
   # ptrace: an end-to-end variant would skip silently wherever ptrace is unavailable, and a silently
   # skipped test is indistinguishable from a passing one. What it pins is the case that already

--- a/prosper/tools/perf/audio_delivery_report.py
+++ b/prosper/tools/perf/audio_delivery_report.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Aggregate `[audio-dbg]` lines into an audio-delivery health report.
+
+WHY THIS EXISTS
+---------------
+Audio underrun hunts on Windows dev boxes have been ear-driven: "it stutters like a small
+buffer", then a cycle of pacing changes and listen tests. `PROSPER_AUDIO_DEBUG=1` makes the
+SDL sink log every guest grain delivery (arrival gap, frames, queued bytes); this tool turns
+that log into the numbers that name the failure mode, offline, without listening:
+
+  * delivery cadence -- mean/median/p99/max inter-arrival gap per port, and the fraction of
+    gaps beyond one and two grain periods;
+  * queue health -- mean/min queued bytes, and the share of arrivals that found the queue
+    below one grain (the device starved between deliveries) and below a quarter grain
+    (audible underrun territory);
+  * effective delivery rate vs the device rate -- a persistent deficit is a CLOCK DRIFT
+    between the guest's budgeted audio clock and the device crystal; no cushion survives it,
+    and the fix is drift compensation, not deeper buffering;
+  * burst clustering -- the fraction of arrivals that carry more than one grain of audio
+    after a gap of more than two grain periods, which names a quantized mixer wake.
+
+WHAT THIS TOOL DOES NOT SEE
+---------------------------
+`[audio-dbg]` is emitted per accepted `output()` call from the guest. Grains the guest never
+delivers (a mixer that skipped a period) appear only as a longer gap. Content-level defects
+(a mixer that produced silence or repeated samples) are invisible here; the queue level and
+the delivery rate are the report's whole world.
+
+Usage:
+    audio_delivery_report.py [LOG ...] [--port P] [--device-hz H] [--channels C] [--bytes-per-frame N]
+"""
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+
+RECORD = re.compile(
+    r"\[audio-dbg\] port=(\d+) gap=([0-9.]+)ms frames=(\d+) queued_before=(\d+)")
+
+# The device consumes `device_hz * channels * bytes_per_frame` bytes per second. The guest's
+# delivery rate against THAT number is the clock-drift measurement; a persistent deficit
+# drains any cushion at the deficit rate no matter how deep the buffer is.
+
+
+def parse_streams(paths):
+    for path in paths:
+        if path == "-":
+            for line in sys.stdin:
+                yield path, line
+        else:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    yield path, line
+
+
+def analyze(paths, port_filter, device_hz, channels, bytes_per_frame):
+    per_port = {}
+    for path, line in parse_streams(paths):
+        m = RECORD.search(line)
+        if not m:
+            continue
+        port = int(m.group(1))
+        if port_filter is not None and port != port_filter:
+            continue
+        gap_ms = float(m.group(2))
+        frames = int(m.group(3))
+        queued = int(m.group(4))
+        slot = per_port.setdefault(port, {
+            "gaps": [], "frames": [], "queued": [], "sources": defaultdict(int),
+        })
+        slot["gaps"].append(gap_ms)
+        slot["frames"].append(frames)
+        slot["queued"].append(queued)
+    return per_port
+
+
+def percentile(sorted_values, fraction):
+    if not sorted_values:
+        return 0.0
+    index = min(len(sorted_values) - 1, int(fraction * len(sorted_values)))
+    return sorted_values[index]
+
+
+def report_port(port, slot, device_hz, channels, bytes_per_frame):
+    gaps = sorted(slot["gaps"])
+    queued = sorted(slot["queued"])
+    frames_total = sum(slot["frames"])
+    calls = len(slot["gaps"])
+    span_s = sum(gaps) / 1000.0
+    grain_frames = slot["frames"][0] if slot["frames"] else 0
+    grain_ms = grain_frames / device_hz * 1000.0 if device_hz else 0.0
+
+    print(f"port {port}: calls={calls} span={span_s:.1f}s grain={grain_frames} frames"
+          f" ({grain_ms:.2f} ms)")
+
+    if not gaps:
+        print("  no inter-arrival gaps recorded -- nothing to analyze")
+        return
+
+    mean_gap = sum(gaps) / len(gaps)
+    print(f"  delivery cadence: mean {mean_gap:.2f} ms  median {percentile(gaps, 0.5):.2f} ms"
+          f"  p99 {percentile(gaps, 0.99):.2f} ms  max {gaps[-1]:.2f} ms")
+
+    one_grain = [g for g in gaps if g > grain_ms]
+    two_grain = [g for g in gaps if g > 2 * grain_ms]
+    if grain_ms > 0:
+        print(f"  gaps beyond 1 grain ({grain_ms:.2f} ms): {len(one_grain)}"
+              f" ({100 * len(one_grain) / len(gaps):.1f}%)")
+        print(f"  gaps beyond 2 grains:             {len(two_grain)}"
+              f" ({100 * len(two_grain) / len(gaps):.1f}%)")
+
+    if queued:
+        mean_q = sum(queued) / len(queued)
+        under_one = sum(1 for q in queued if q < bytes_per_frame * channels)
+        under_quarter = sum(1 for q in queued if q < bytes_per_frame * channels // 4)
+        print(f"  queue at arrival: mean {mean_q:.0f} B  min {queued[0]} B")
+        print(f"  arrivals below 1 grain of buffer:  {under_one}"
+              f" ({100 * under_one / len(queued):.1f}%) -- the device starved between"
+              f" deliveries")
+        print(f"  arrivals below 1/4 grain:          {under_quarter}"
+              f" ({100 * under_quarter / len(queued):.1f}%) -- audible underrun territory")
+
+    if span_s > 0 and device_hz:
+        delivered_hz = frames_total / span_s
+        device_hz_total = device_hz
+        drift_pct = 100.0 * (delivered_hz - device_hz_total) / device_hz_total
+        print(f"  effective delivery: {delivered_hz:.0f} frames/s vs device {device_hz_total}"
+              f" -> drift {drift_pct:+.2f}%")
+        if drift_pct < -0.3:
+            print("  VERDICT: the guest's audio clock runs below the device rate -- a clock"
+                  " deficit, not a buffering defect. No cushion survives it; fix the guest"
+                  " audio clock or compensate the drift in the sink.")
+        elif drift_pct > 0.3:
+            print("  VERDICT: the guest's audio clock runs above the device rate -- the"
+                  " cushion grows until the depth cap; drift compensation should slow the"
+                  " delivery.")
+        else:
+            print("  VERDICT: delivery matches the device rate -- a stutter at this rate is"
+                  " a burst/quantization problem, not a clock deficit. See the cadence and"
+                  " burst rows above.")
+
+    if grain_ms > 0:
+        bursts = sum(1 for g in gaps if g > 2 * grain_ms)
+        if bursts > len(gaps) * 0.2 and mean_gap > 1.5 * grain_ms:
+            print("  VERDICT: the inter-arrival cadence clusters beyond two grain periods --"
+                  " the mixer's wake is quantized (a timed wait resolving on a coarse tick),"
+                  " not a buffering defect. Fix the wait primitive's resolution.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate [audio-dbg] lines into an audio-delivery health report.")
+    parser.add_argument("logs", nargs="*", help="run logs (PROSPER_AUDIO_DEBUG=1); '-' = stdin")
+    parser.add_argument("--port", type=int, default=None,
+                        help="analyze one port (default: every port with records)")
+    parser.add_argument("--device-hz", type=int, default=48000,
+                        help="the playback device's sample rate (default 48000)")
+    parser.add_argument("--channels", type=int, default=2, help="output channels (default 2)")
+    parser.add_argument("--bytes-per-frame", type=int, default=4,
+                        help="bytes per frame per channel-set as delivered (default 4)")
+    args = parser.parse_args()
+
+    paths = args.logs if args.logs else ["-"]
+    per_port = analyze(paths, args.port, args.device_hz, args.channels, args.bytes_per_frame)
+    if not per_port:
+        print("no [audio-dbg] records found (run with PROSPER_AUDIO_DEBUG=1)")
+        return 1
+    for port in sorted(per_port):
+        report_port(port, per_port[port], args.device_hz, args.channels, args.bytes_per_frame)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/perf/flip_pacing_report.py
+++ b/prosper/tools/perf/flip_pacing_report.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Aggregate `[ev] GpuFlip t=<seconds>` lines into a guest frame-pacing report.
+
+WHY THIS EXISTS
+---------------
+Guest frame-rate hunts on Windows dev boxes have been fps-counter-driven: an average says
+"32 fps" but not WHY. The flip timestamps (PROSPER_EVLOG=1) carry the guest's production
+cadence directly, and the INTERVAL DISTRIBUTION names the limiter class:
+
+  * a tight spike at one period -- a hard pacer (a vsync, a fixed timer);
+  * clustering at timer-tick multiples (~15.6/31.25 ms on Windows) -- a wait in the
+    production path resolving on the OS tick, regardless of the requested timeout;
+  * a wide spread -- work-bound production (profile the fold, don't hunt waits).
+
+The report also splits the timeline into windows so a cinematic-to-gameplay phase change
+does not smear one phase's numbers over another.
+
+Usage:
+    flip_pacing_report.py [LOG ...] [--window-s S] [--tick-ms]
+"""
+
+import argparse
+import collections
+import re
+import statistics
+import sys
+
+FLIP = re.compile(r"\[ev\] GpuFlip t=([0-9.]+)")
+# The Win32 timer tick on dev boxes is 15.625 ms; quantized waits land on its multiples.
+TICK_MS = 15.625
+
+
+def parse_flips(paths):
+    stamps = []
+    for path in paths:
+        if path == "-":
+            handle = sys.stdin
+            for line in handle:
+                m = FLIP.search(line)
+                if m:
+                    stamps.append(float(m.group(1)))
+        else:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    m = FLIP.search(line)
+                    if m:
+                        stamps.append(float(m.group(1)))
+    stamps.sort()
+    return stamps
+
+
+def classify(ms, tick):
+    """Name the bucket an interval falls into, for the quantization verdict."""
+    nearest = max(1, round(ms / tick))
+    error = abs(ms - nearest * tick)
+    if error <= 0.15 * tick:
+        return f"{nearest} tick(s)"
+    return "between ticks"
+
+
+def report(stamps, window_s, tick):
+    if len(stamps) < 2:
+        print("fewer than 2 flips recorded -- nothing to pace")
+        return
+    intervals = [ms for ms in ((b - a) * 1000.0 for a, b in zip(stamps, stamps[1:]))
+                 if ms > 0.5]
+    if not intervals:
+        print("no usable intervals")
+        return
+
+    overall = 1000.0 / statistics.mean(intervals)
+    print(f"flips={len(stamps)} intervals={len(intervals)} "
+          f"mean period {statistics.mean(intervals):.2f} ms "
+          f"-> {overall:.1f} fps average")
+
+    quantized = sum(1 for ms in intervals if classify(ms, tick) != "between ticks")
+    print(f"tick-aligned intervals (within 15% of a {tick:.3f} ms tick multiple): "
+          f"{quantized} ({100 * quantized / len(intervals):.1f}%)")
+
+    hist = collections.Counter(round(ms) for ms in intervals)
+    print("interval histogram (ms: count, top buckets):")
+    for bucket, count in sorted(hist.items()):
+        if count >= max(2, len(intervals) // 200):
+            print(f"  {bucket:4d} ms x{count}")
+
+    # Windowed view: a phase change (cinematic -> gameplay) must not smear two regimes.
+    window_flips = max(1, int(window_s * (1000.0 / statistics.mean(intervals))))
+    print(f"windows of ~{window_flips} flips:")
+    start = 0
+    while start < len(intervals):
+        chunk = intervals[start:start + window_flips]
+        mean_ms = statistics.mean(chunk)
+        quantized = sum(1 for ms in chunk if classify(ms, tick) != "between ticks")
+        print(f"  flips {start:5d}-{start + len(chunk):5d}: "
+              f"{1000.0 / mean_ms:6.1f} fps  mean {mean_ms:6.2f} ms  "
+              f"tick-aligned {100 * quantized / len(chunk):5.1f}%")
+        start += window_flips
+
+    slowest = sorted(range(len(intervals)), key=lambda i: -intervals[i])[:5]
+    print("slowest intervals (ms):",
+          ", ".join(f"{intervals[i]:.1f} @ flip {i}" for i in slowest))
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Aggregate [ev] GpuFlip timestamps into a guest frame-pacing report.")
+    parser.add_argument("logs", nargs="*", help="run logs (PROSPER_EVLOG=1); '-' = stdin")
+    parser.add_argument("--window-s", type=float, default=10.0,
+                        help="window length in seconds for the phase split (default 10)")
+    parser.add_argument("--tick-ms", type=float, default=TICK_MS,
+                        help="the OS timer tick to test quantization against (default 15.625)")
+    args = parser.parse_args()
+
+    paths = args.logs if args.logs else ["-"]
+    stamps = parse_flips(paths)
+    report(stamps, args.window_s, args.tick_ms)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/perf/test_audio_delivery_report.py
+++ b/prosper/tools/perf/test_audio_delivery_report.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Self-test for audio_delivery_report.py.
+
+The report's whole job is to name the failure mode (clock deficit vs quantized mixer wake
+vs device starvation) from a delivery log. Each case here is a failure mode the report must
+classify, plus the traps: a port filter that must exclude other ports, and a zero-queue
+all-fast log that must NOT be called a clock deficit.
+
+Run: python3 tools/perf/test_audio_delivery_report.py
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent / "audio_delivery_report.py"
+
+
+def dbg(port=17, gap=5.33, frames=256, queued=1024):
+    return f"[audio-dbg] port={port} gap={gap:.2f}ms frames={frames} queued_before={queued} (grain=1024)\n"
+
+
+def run(log_text, extra=None):
+    proc = subprocess.run(
+        [sys.executable, str(TOOL), "-", *(extra or [])],
+        input=log_text, capture_output=True, text=True)
+    return proc.stdout + proc.stderr, proc.returncode
+
+
+def main():
+    failures = []
+
+    def expect(text, needle, what):
+        if needle not in text:
+            failures.append(f"{what}: expected {needle!r} in the report")
+
+    def reject(text, needle, what):
+        if needle in text:
+            failures.append(f"{what}: expected {needle!r} to be absent")
+
+    # 1. Real-time delivery, deep queue: no defect. The verdict must NOT name a clock
+    #    deficit (a plausible wrong call: an average at the device rate with jitter).
+    log = "".join(dbg(gap=5.33, queued=3072) for _ in range(200))
+    out, _ = run(log)
+    expect(out, "delivery matches the device rate", "case 1 verdict")
+
+    # 2. Clock deficit: every call arrives 1/3 late with an empty queue. The verdict must
+    #    name the clock deficit -- this is exactly the Blasphemous 2 signature.
+    log = "".join(dbg(gap=15.7, queued=64) for _ in range(300))
+    out, _ = run(log)
+    expect(out, "clock deficit", "case 2 verdict")
+    expect(out, "the device starved between deliveries", "case 2 starvation row")
+
+    # 3. Quantized mixer wake: the combined delivery averages real-time (256 frames per
+    #    5.33 ms) but the arrivals cluster -- 1 ms after a tick, then 9.66 ms of silence.
+    #    The verdict must name the burst/quantization problem, not a clock deficit.
+    log = "".join(dbg(gap=1.0, queued=4096) + dbg(gap=9.66, queued=4096)
+                  for _ in range(300))
+    out, _ = run(log)
+    expect(out, "delivery matches the device rate", "case 3 drift verdict")
+    expect(out, "burst/quantization problem", "case 3 burst verdict")
+    reject(out, "the guest's audio clock runs below the device rate", "case 3 must not miscall a clock deficit")
+
+    # 4. Port filter: records for another port must not leak into the report.
+    log = ("".join(dbg(port=17, gap=15.7, queued=64) for _ in range(100))
+           + "".join(dbg(port=18, gap=99.0, queued=0) for _ in range(100)))
+    out, _ = run(log, ["--port", "17"])
+    reject(out, "99.00", "case 4 port filter")
+    expect(out, "port 17:", "case 4 port header")
+
+    # 5. Empty input: a clean refusal, not a traceback.
+    out, _ = run("")
+    if "no [audio-dbg] records" not in out:
+        failures.append(f"case 5: expected the no-records refusal, got: {out!r}")
+
+    if failures:
+        print("FAILURES:")
+        for failure in failures:
+            print(" -", failure)
+        return 1
+    print("audio_delivery_report self-test: all cases pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/prosper/tools/perf/test_flip_pacing_report.py
+++ b/prosper/tools/perf/test_flip_pacing_report.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Self-test for flip_pacing_report.py.
+
+The report's whole job is to name the pacing limiter class from the flip-interval
+distribution. Each case is a regime the report must classify, plus the trap: a phase change
+(cinematic -> gameplay) that must appear as two windows, not one smeared average.
+
+Run: python3 tools/perf/test_flip_pacing_report.py
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+TOOL = Path(__file__).resolve().parent / "flip_pacing_report.py"
+
+
+def run(log_text, extra=None):
+    proc = subprocess.run(
+        [sys.executable, str(TOOL), "-", *(extra or [])],
+        input=log_text, capture_output=True, text=True)
+    return proc.stdout + proc.stderr, proc.returncode
+
+
+def main():
+    failures = []
+
+    def expect(text, needle, what):
+        if needle not in text:
+            failures.append(f"{what}: expected {needle!r} in the report")
+
+    # 1. Tick-quantized production: alternating ~16/~31 ms intervals (the measured
+    #    Blasphemous 2 signature). The report must call it tick-aligned.
+    stamps = []
+    t = 1.0
+    for i in range(600):
+        t += 0.016 if i % 2 else 0.031
+        stamps.append(t)
+    log = "".join(f"[ev] GpuFlip t={t:.3f}\n" for t in stamps)
+    out, _ = run(log)
+    expect(out, "tick-aligned", "case 1 quantization verdict")
+    expect(out, "fps average", "case 1 average line")
+
+    # 2. Work-bound production: a wide spread around 8 ms. The report must NOT call a
+    #    spread distribution tick-aligned.
+    stamps = []
+    t = 1.0
+    for i in range(600):
+        t += 0.0075 + 0.002 * ((i * 37) % 11) / 11.0
+        stamps.append(t)
+    log = "".join(f"[ev] GpuFlip t={t:.3f}\n" for t in stamps)
+    out, _ = run(log)
+    expect(out, "fps average", "case 2 average line")
+
+    # 3. Phase change: 300 flips at 60 Hz then 300 at 30 Hz. The windowed split must show
+    #    both rates rather than one smeared average.
+    stamps = []
+    t = 1.0
+    for i in range(300):
+        t += 1 / 60.0
+        stamps.append(t)
+    for i in range(300):
+        t += 1 / 30.0
+        stamps.append(t)
+    log = "".join(f"[ev] GpuFlip t={t:.3f}\n" for t in stamps)
+    out, _ = run(log, ["--window-s", "5"])
+    expect(out, "windows of", "case 3 window rows")
+
+    # 4. Too few flips: a clean refusal, not a traceback.
+    out, _ = run("[ev] GpuFlip t=1.000\n")
+    if "fewer than 2 flips" not in out:
+        failures.append(f"case 4: expected the too-few-flips refusal, got: {out!r}")
+
+    if failures:
+        print("FAILURES:")
+        for failure in failures:
+            print(" -", failure)
+        return 1
+    print("flip_pacing_report self-test: all cases pass")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #3033. First slice of the #2984 recovery.

## Why this slice first

PR #2984 carries a lot of value but cannot be merged as it stands: its render half is **superseded**
(master's `render_runner.h` has since gained `allow_native_fragment_vote_width`, and master's
`RECOMPILER_REMAINING.md` ruling is strictly more complete than the branch's), its CI is red from one
unguarded `-lwinmm`, it conflicts in four files, and its audio/kernel commits overlap the open #3019 and
#3022.

`23b38cad` is the one commit in it that touches **only new files** (`tools/perf/*.py`), so it conflicts
with nothing and can land immediately. #3033 records the rest of the harvest and, importantly, what not
to re-harvest.

## What the tools do

Two hunts this project keeps doing by hand become one command each:

- `audio_delivery_report.py` — a port's delivery log → whether the guest kept up with real time.
- `flip_pacing_report.py` — flip timestamps → the pacing distribution.

Directly relevant right now: #3016 is an audio-underrun issue whose evidence section admits its own
handoff-sampled meter cannot see a queue draining *between* handoffs. These are the offline half of that
toolchain.

## The change I made on top of the cherry-pick

Both tools shipped in #2984 with working self-tests, and **neither was registered in CMakeLists** — so
they were tests that could not go red. Registered as `audio_delivery_report_logic` and
`flip_pacing_report_logic`, beside `compute_phase_report_logic` which they resemble.

They carry the same caveat that file already records for its neighbour, and I have repeated it in the
comment rather than let a reader assume more: these feed each tool **synthetic** records, so they pin a
parser against its own model of the log format. They catch a parser regression; they cannot notice the
**emitter** drifting away from the format. That is a real limit, not a formality — it is the same shape
as the instrument gaps this repo keeps recording.

## Affected / unaffected

- **Affected:** two new tools under `tools/perf/`, two new ctest cases.
- **Unaffected:** everything else. No source file changes, no behavioural change, nothing links or
  compiles differently. The only edit outside `tools/perf/` is two `add_test` calls.

## Verification (exact head)

```
cmake -S prosper -B prosper/build-mingw-app -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DPROSPER_APP=ON
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4 -R report_logic
  4/4 passed  (audio_delivery_report_logic, flip_pacing_report_logic + the two existing)

cmake --build prosper/build-mingw-app -j8          # exit 0
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4   # exit 0
100% tests passed, 0 tests failed out of 244
```

244 against 242 before, which is the two registrations — quoted because a count is falsifiable and an
exit code alone is not.

## Risk

Close to none. The tools are standalone Python, run only by their own ctest cases, and imported by
nothing. The realistic failure mode is the synthetic-fixture limitation above: a green
`*_report_logic` says the parser still parses what the test believes the emitter writes, and no more.