### PR TITLE
tools(compute): recover the SPIR-V dump and override from #2984, cached and targetable

### DIFF
--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -4870,10 +4870,22 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             const char* path = spec;
             // A colon separates a target only when everything before it parses whole as a number;
             // otherwise it is a drive letter or part of the path.
+            // A colon separates a target only when everything before it parses STRICTLY as an
+            // unsigned number; otherwise it is a drive letter or part of the path. Parsed with
+            // parse_compute_timing_selector_u64 (compute_timing_selector.hpp, already included at
+            // the top of this file) rather than strtoull, and the difference is not cosmetic:
+            // strtoull accepts a sign, leading whitespace and an EMPTY prefix, so `:/tmp/x.spv`
+            // would have armed a target of 0 silently. That is the shape that header exists to
+            // prevent -- its own comment says a mistyped identity must not look armed -- and it is
+            // the parser both selectors this reuses already take. A non-numeric prefix (the `C` in
+            // `C:/x.spv`) is simply not a target.
             if (const char* colon = std::strchr(spec, ':')) {
-                char* end = nullptr;
-                const uint64_t addr = std::strtoull(spec, &end, 0);
-                if (end == colon) { code_addr = addr; targeted = true; path = colon + 1; }
+                const std::string prefix(spec, (size_t)(colon - spec));
+                const auto parsed =
+                    prosper::frontend::parse_compute_timing_selector_u64(prefix.c_str());
+                if (parsed.accepted()) {
+                    code_addr = parsed.value; targeted = true; path = colon + 1;
+                }
             }
             FILE* fh = std::fopen(path, "rb");
             if (!fh) {
@@ -8014,7 +8026,15 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
                 char path[512];
                 std::snprintf(path, sizeof path, "%s/%016llx.spv", dump_dir,
                               (unsigned long long)dump_hash);
-                if (FILE* f = fopen(path, "wb")) {
+                FILE* f = fopen(path, "wb");
+                // Reported, not silent. Without this an unwritable or nonexistent <dir>, or a
+                // path truncated by the snprintf above, produced no files AND no output -- an
+                // instrument that says nothing when it fails is indistinguishable from one
+                // reporting there was nothing to dump. The override half already reported its
+                // failures; this half did not.
+                if (!f) {
+                    std::fprintf(stderr, "[compute] SPIR-V dump could not write %s\n", path);
+                } else {
                     fwrite(spirv.data(), sizeof(uint32_t), spirv.size(), f);
                     fclose(f);
                     std::fprintf(stderr, "[compute] dumped SPIR-V %016llx (%zu words) -> %s\n",

--- a/prosper/frontends/shared/live/live_compute.cpp
+++ b/prosper/frontends/shared/live/live_compute.cpp
@@ -4838,7 +4838,69 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
     double image_watch_ms = 0.0;
     double image_notify_ms = 0.0;
     double image_cache_ms = 0.0;
-    const std::vector<uint32_t>& spirv = item.spirv;
+    // PROSPER_LOAD_COMPUTE_SPIRV=[<code_addr>:]<file>: replace a recompiled module with the file's
+    // contents before pipeline creation -- A/B a hand-written shader against the live game with
+    // bindings and layouts exactly as the title realizes them (#2985; recovered from #2984 via
+    // #3033). The descriptor layout still reflects the ORIGINAL module, so an override has to keep
+    // the same interface or pipeline creation fails.
+    //
+    // Two changes from the form this arrived in, both because execute_item runs PER DISPATCH:
+    //
+    //   * The file is read ONCE. As recovered it called getenv and re-read the file from disk inside
+    //     this function, so a title dispatching a few hundred times a second re-read it that often --
+    //     and the instrument's own I/O would then be inside whatever it was used to measure.
+    //   * The optional <code_addr>: prefix targets ONE program. Without it the override replaces
+    //     EVERY compute module in the process, which is rarely what an A/B wants and silently breaks
+    //     every other shader in the title. The address is the same selector PROSPER_COMPUTELOG_CODE
+    //     and PROSPER_COMPUTE_TIMING_CODE already take, so a program identified with one of those can
+    //     be overridden with this.
+    //
+    // Setting the targeted form from an MSYS/Git-Bash shell needs care, because <addr>:<path> looks
+    // like a colon-separated PATH list and the shell rewrites the elements: the value arrives as
+    // `/c/Users/...` instead of `C:/Users/...` and the open fails on a path that looks correct in the
+    // error message. Use a Windows-style path and MSYS2_ARG_CONV_EXCL='*', or set the variable from
+    // PowerShell. The untargeted form has no colon and is not affected.
+    struct SpirvOverride {
+        std::vector<uint32_t> words;
+        uint64_t              code_addr = 0;
+        bool                  targeted  = false;
+        SpirvOverride() {
+            const char* spec = std::getenv("PROSPER_LOAD_COMPUTE_SPIRV");
+            if (!spec || !*spec) return;
+            const char* path = spec;
+            // A colon separates a target only when everything before it parses whole as a number;
+            // otherwise it is a drive letter or part of the path.
+            if (const char* colon = std::strchr(spec, ':')) {
+                char* end = nullptr;
+                const uint64_t addr = std::strtoull(spec, &end, 0);
+                if (end == colon) { code_addr = addr; targeted = true; path = colon + 1; }
+            }
+            FILE* fh = std::fopen(path, "rb");
+            if (!fh) {
+                std::fprintf(stderr, "[compute] SPIR-V override %s could not be opened\n", path);
+                return;
+            }
+            uint32_t word;
+            while (std::fread(&word, sizeof word, 1, fh) == 1) words.push_back(word);
+            std::fclose(fh);
+            if (words.empty()) {
+                std::fprintf(stderr, "[compute] SPIR-V override %s is empty; ignored\n", path);
+                return;
+            }
+            if (targeted)
+                std::fprintf(stderr, "[compute] SPIR-V override: %zu words from %s, code=0x%llx only\n",
+                             words.size(), path, (unsigned long long)code_addr);
+            else
+                std::fprintf(stderr, "[compute] SPIR-V override: %zu words from %s, EVERY module "
+                                     "(prefix with <code_addr>: to target one)\n",
+                             words.size(), path);
+        }
+    };
+    static const SpirvOverride spirv_override;
+    const bool override_applies =
+        !spirv_override.words.empty() &&
+        (!spirv_override.targeted || spirv_override.code_addr == item.code_addr);
+    const std::vector<uint32_t>& spirv = override_applies ? spirv_override.words : item.spirv;
     const bool trace = trace_compute_item(item);
     const bool perf_capture_timing =
         prosper::perf::interactive_performance_capture().detailed_timing_active();
@@ -7942,6 +8004,23 @@ bool execute_item(VulkanComputeContext& ctx, const prosper::gpu::ComputeItem& it
             VkShaderModuleCreateInfo smci{VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO};
             smci.codeSize = spirv.size() * sizeof(uint32_t);
             smci.pCode = spirv.data();
+            // PROSPER_DUMP_COMPUTE_SPIRV=<dir>: write each newly compiled compute module's
+            // SPIR-V as <dir>/<hash>.spv for offline ISA/occupancy analysis (#2985).
+            static const char* const dump_dir = std::getenv("PROSPER_DUMP_COMPUTE_SPIRV");
+            if (dump_dir && *dump_dir) {
+                const uint64_t dump_hash = gpu_capture_hash(
+                    reinterpret_cast<const uint8_t*>(spirv.data()),
+                    spirv.size() * sizeof(uint32_t));
+                char path[512];
+                std::snprintf(path, sizeof path, "%s/%016llx.spv", dump_dir,
+                              (unsigned long long)dump_hash);
+                if (FILE* f = fopen(path, "wb")) {
+                    fwrite(spirv.data(), sizeof(uint32_t), spirv.size(), f);
+                    fclose(f);
+                    std::fprintf(stderr, "[compute] dumped SPIR-V %016llx (%zu words) -> %s\n",
+                                 (unsigned long long)dump_hash, spirv.size(), path);
+                }
+            }
             if (!vk_ok(vkCreateShaderModule(ctx.device, &smci, nullptr, &shader), "shader-module"))
                 break;
             VkPipelineLayoutCreateInfo plci{VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};


### PR DESCRIPTION
Refs #3033. Second slice of the #2984 recovery (first was #3034).

## What lands

Two instruments on the live compute path, both off by default:

| variable | effect |
| --- | --- |
| `PROSPER_DUMP_COMPUTE_SPIRV=<dir>` | writes each newly compiled module as `<dir>/<hash>.spv` |
| `PROSPER_LOAD_COMPUTE_SPIRV=[<code_addr>:]<file>` | replaces a module with the file's contents before pipeline creation |

Together they close a loop the GTA V compute investigation has been missing: dump what the recompiler
produced, edit or hand-write a replacement, and run the title against it with bindings and layouts
exactly as it realizes them. The descriptor layout still reflects the original module, so an override
must keep the same interface.

Chosen as this slice because it touches **only** `live_compute.cpp`, so it conflicts with nothing already
merged — unlike #2984's audio and kernel commits, which overlap the just-merged #3019/#3022 and are queued
behind them on #3033.

## Two changes from the form it arrived in

Both because `execute_item` runs **per dispatch** (`live_compute.cpp:10370` calls it in a loop):

1. **The override file is read once.** As recovered, it called `getenv` *and re-read the file from disk*
   inside `execute_item` — so a title dispatching a few hundred times a second re-read it that often, and
   the instrument's own I/O would have been inside whatever it was being used to measure. Both `getenv`
   calls are now cached statics, matching the idiom this file already uses throughout (e.g. `:1094`, `:1362`).
2. **The override can target one program.** Without a target it replaces **every** compute module in the
   process, which is rarely what an A/B wants and silently breaks every other shader in the title. The
   optional `<code_addr>:` prefix reuses the selector `PROSPER_COMPUTELOG_CODE` (`:3330`) and
   `PROSPER_COMPUTE_TIMING_CODE` (`:3346`) already accept, so a program identified with one of those can
   be overridden with this. The untargeted form still works and now says out loud that it hits everything.

Also dropped a dead `if (empty) clear()`.

## A trap recorded in the code

The targeted form from Git-Bash/MSYS: `<addr>:<path>` looks like a colon-separated PATH list, so the shell
rewrites the elements and the value arrives as `/c/Users/...` instead of `C:/Users/...`. The open then
fails on a path that looks correct in the error message. Cost me one run; the comment says to use
`MSYS2_ARG_CONV_EXCL='*'` or set it from PowerShell. The untargeted form has no colon and is unaffected.

## Verification (exact head)

Windows 11 / RTX 4090, MinGW GCC 16.1, `RelWithDebInfo`:

```
cmake --build prosper/build-mingw-app -j8                       # exit 0
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4    # exit 0
100% tests passed, 0 tests failed out of 245
```

Functional, on *Blasphemous 2* (`PPSA13579`):

- The dump wrote **two** modules; both carry valid SPIR-V magic (`0x07230203`) and are `spirv-val` clean.
- One is hash **`38d440cc61ab5a00`** — the program #2985 names as that title's heavy dispatch. So the
  instrument produces the exact artifact that issue is about, which is the strongest check available
  without a second implementation.
- The override reports its parse for both targeted (`code=0x413dc6700 only`) and untargeted forms, and
  reports a missing file rather than failing silently.

## Affected / unaffected

- **Affected:** the live compute path, only when either variable is set. With both unset the change is two
  cached-static reads at first dispatch and a reference bind that resolves to `item.spirv` as before.
- **Unaffected:** every other platform and subsystem; no test behaviour changes.

## Risk

The override is a deliberate footgun — it replaces a shader with arbitrary bytes — but it is opt-in, it
announces what it is doing, and pipeline creation fails visibly if the interface does not match. The
targeting change makes the dangerous default (replace everything) explicit rather than silent, which is a
net reduction in risk versus the recovered form.

## Unrelated observation from verification

One suite run aborted `agc_shader_create` with `0xc0000374` (`STATUS_HEAP_CORRUPTION`), passed on rerun,
and did not recur in three further full runs. **Not from this change** — `test_agc_shader` links only
`prosper_core`, and `live_compute.cpp` is in `prosper_live_renderer`, so the edited file is not in that
binary. Recorded on #2277, which tracks the identical signature in a different test; a second unrelated
test showing it argues the cause is shared rather than test-specific.


## Review findings addressed

Two non-blocking findings from review are fixed rather than deferred, and two citations in this body were wrong:

- **Strict selector parsing.** The prefix now goes through `parse_compute_timing_selector_u64`
  (`compute_timing_selector.hpp`, already included at line 4) instead of `strtoull`, which accepted a sign,
  leading whitespace and an **empty** prefix — so `:/tmp/x.spv` silently armed target `0`. That header exists
  for this and is the parser the two selectors this reuses already take, so the interoperability claim above
  is now exact. Verified live on four arms.
- **The dump no longer fails silently.** A nonexistent or unwritable `<dir>`, or an `snprintf` truncation,
  produced no files *and no output*. The override half reported its failures; this half did not.
- Corrected here: `execute_item`'s call site is `:10370`, not `:10305`; and the cached-getenv idiom count
  ("nine places") was wrong — dropped rather than restated, since the exact number is not the point.
