### PR TITLE
gpu(backend): admit guest 2D_ARRAY textures through the layer channel (#325)

### DIFF
--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -95,24 +95,33 @@ Two further details cost time and are worth keeping:
 
 ## Ruled out
 
+> The `PROSPER_*` probes cited below are **not on master**. They live on the unmerged WIP branch
+> `wip/issue-325-texture-arrays` (`e1b0fbb2` and later), which exists so these measurements stay
+> reproducible. Check that branch out before trying to re-run one.
+
 - **"Memory pressure is why 256 decoded layers fail" — false.** A `PROSPER_ARRAY_MAX_LAYERS` bisect
   over an early array upload rendered at 1 layer and failed identically at **4, 16 and 64**. Four
   layers is trivially small, so the failure was structural, not a working-set problem. The actual
   cause was `backend_texture_plane_span_valid`, which admitted `sample_count > 1` only for the
   four-plane R32_SFLOAT guest-MSAA shape and rejected everything else (#3043).
 - **"The world samples its array with a non-array instruction, so it always reads slice 0" — false.**
-  A full `PROSPER_MIMGCENSUS` census over a gameplay route — the whole population, not a sample —
-  found **every** MIMG touching an array texture uses `DIM=5`: op `0x2f` on bindings 39-46 at depth 1
-  (64 events), and op `0x20` on bindings 34/36/47 at depth 256 (16 events). There is no DIM≠5 case
-  to explain the flat world (#2998).
+  A full census over a gameplay route — the whole population, not a sample — found **every** MIMG
+  touching an array texture uses `DIM=5`: op `0x2f` on bindings 39-46 at depth 1 (64 events), and
+  op `0x20` on bindings 34/36/47 (20 events, of which 12 are at depth 256; binding 34's four span
+  depths 1/29/32/256). The census is not circular: it selects on the resource's `img_dim` and
+  reports the *instruction's* `mimg_dim`, which are independent fields. There is no DIM≠5 case to
+  explain the flat world (#2998).
 - **The decoded slices are not duplicates of slice 0.** Per-layer checksums (`PROSPER_ARRAYTEX`) give
   13 distinct hashes for one array binding and 8 for another, so the decoder does not replicate the
   base slice (#2998).
-- **Forcing the array layer to a constant changes nothing, and the probe proves it fired.**
-  `PROSPER_FORCE_LAYER=200` substitutes a constant layer *and prints when it does*; it fired on all
-  four array bindings and the gameplay frame was unchanged — identical average- and difference-hash,
-  luma differing in one byte of 288. So the layer coordinate was never the variable; the resource was
-  being uploaded with one layer (#2998).
+- **Forcing the array layer to a constant changes nothing for the plain-SAMPLE path.** A probe
+  substituting a constant layer *and printing when it does* fired on the four bindings reached by op
+  `0x20`, and the gameplay frame was unchanged — identical average- and difference-hash, luma
+  differing in one byte of 288. **Scope, because the first version of this line overstated it:** the
+  probe sits in the implicit-LOD array sampler only, so it covers the `0x20` events and
+  *structurally cannot* cover the 64 `SAMPLE_C_LZ` (`0x2f`) events, which take a different lowering.
+  Within that scope the layer coordinate was not the variable; the resource was uploaded with one
+  layer (#2998).
 - **Binding numbers are not texture identities.** A binding is a per-shader descriptor slot, and the
   decoded-texture cache keys by guest address — so "binding 36 never reaches the array decode gate"
   does not mean its texture is never decoded there. It is decoded once under whatever slot referenced

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -107,7 +107,7 @@ Two further details cost time and are worth keeping:
 - **"The world samples its array with a non-array instruction, so it always reads slice 0" — false.**
   A full census over a gameplay route — the whole population, not a sample — found **every** MIMG
   touching an array texture uses `DIM=5`: op `0x2f` on bindings 39-46 at depth 1 (64 events), and
-  op `0x20` on bindings 34/36/47 (20 events, of which 12 are at depth 256; binding 34's four span
+  op `0x20` on bindings 34/36/39/47 (17 events, of which 14 are at depth 256; binding 34's four span
   depths 1/29/32/256). The census is not circular: it selects on the resource's `img_dim` and
   reports the *instruction's* `mimg_dim`, which are independent fields. There is no DIM≠5 case to
   explain the flat world (#2998).
@@ -115,8 +115,8 @@ Two further details cost time and are worth keeping:
   13 distinct hashes for one array binding and 8 for another, so the decoder does not replicate the
   base slice (#2998).
 - **Forcing the array layer to a constant changes nothing for the plain-SAMPLE path.** A probe
-  substituting a constant layer *and printing when it does* fired on the four bindings reached by op
-  `0x20`, and the gameplay frame was unchanged — identical average- and difference-hash, luma
+  substituting a constant layer *and printing when it does* fired on all four bindings reached by op
+  `0x20` (34/36/39/47), and the gameplay frame was unchanged — identical average- and difference-hash, luma
   differing in one byte of 288. **Scope, because the first version of this line overstated it:** the
   probe sits in the implicit-LOD array sampler only, so it covers the `0x20` events and
   *structurally cannot* cover the 64 `SAMPLE_C_LZ` (`0x2f`) events, which take a different lowering.

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -95,6 +95,30 @@ Two further details cost time and are worth keeping:
 
 ## Ruled out
 
+- **"Memory pressure is why 256 decoded layers fail" — false.** A `PROSPER_ARRAY_MAX_LAYERS` bisect
+  over an early array upload rendered at 1 layer and failed identically at **4, 16 and 64**. Four
+  layers is trivially small, so the failure was structural, not a working-set problem. The actual
+  cause was `backend_texture_plane_span_valid`, which admitted `sample_count > 1` only for the
+  four-plane R32_SFLOAT guest-MSAA shape and rejected everything else (#3043).
+- **"The world samples its array with a non-array instruction, so it always reads slice 0" — false.**
+  A full `PROSPER_MIMGCENSUS` census over a gameplay route — the whole population, not a sample —
+  found **every** MIMG touching an array texture uses `DIM=5`: op `0x2f` on bindings 39-46 at depth 1
+  (64 events), and op `0x20` on bindings 34/36/47 at depth 256 (16 events). There is no DIM≠5 case
+  to explain the flat world (#2998).
+- **The decoded slices are not duplicates of slice 0.** Per-layer checksums (`PROSPER_ARRAYTEX`) give
+  13 distinct hashes for one array binding and 8 for another, so the decoder does not replicate the
+  base slice (#2998).
+- **Forcing the array layer to a constant changes nothing, and the probe proves it fired.**
+  `PROSPER_FORCE_LAYER=200` substitutes a constant layer *and prints when it does*; it fired on all
+  four array bindings and the gameplay frame was unchanged — identical average- and difference-hash,
+  luma differing in one byte of 288. So the layer coordinate was never the variable; the resource was
+  being uploaded with one layer (#2998).
+- **Binding numbers are not texture identities.** A binding is a per-shader descriptor slot, and the
+  decoded-texture cache keys by guest address — so "binding 36 never reaches the array decode gate"
+  does not mean its texture is never decoded there. It is decoded once under whatever slot referenced
+  it first, then served from cache under every later slot. Chasing a binding number instead of an
+  address cost a full measurement cycle (#2998).
+
 - **The byte pattern of a misread 32-bit index buffer is NOT sufficient to identify one.** A genuine
   16-bit buffer with a period-2 pattern — a fan or cone as a triangle strip `[rim, apex, rim, apex, …]`,
   or a line list radiating from one hub — is **byte-identical** to a clustered 32-bit list whenever the

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -414,12 +414,18 @@ inline bool backend_storage_image_numeric_contract_valid(const FrameResource& re
 // The first exact guest-MSAA contract is intentionally narrow. Ordinary resources retain their
 // historical implicit byte-span behavior; a 2D_MSAA plane array must prove all four complete R32F
 // planes are readable before any Vulkan object or memcpy is attempted.
-// Vulkan guarantees `maxImageArrayLayers >= 2048`; a guest T# can declare up to 8192. Since this
-// predicate has no device handle, it bounds against the guaranteed minimum rather than the actual
-// limit, so a resource it admits is creatable on every conformant device. Anything above is
-// rejected fail-visibly here instead of reaching vkCreateImage, whose result the upload path does
-// not check (pre-existing, all image creation, filed separately) -- an over-large arrayLayers would
-// otherwise yield VK_NULL_HANDLE and be passed straight to vkGetImageMemoryRequirements.
+// A pragmatic ceiling, NOT a portability guarantee -- an earlier revision of this comment claimed
+// 2048 was "Vulkan's guaranteed minimum for maxImageArrayLayers" and that is wrong. The Core
+// Required Limits table gives **256**; 2048 is the Roadmap 2022 / Vulkan 1.4 figure, and this
+// backend requests VK_API_VERSION_1_1 (see vkCreateInstance below), so the guarantee that actually
+// applies here is 256. This box's RADV reports 8192.
+//
+// So what this bound does is keep an absurd layer count away from vkCreateImage, whose result the
+// upload path discards (#3045) -- an over-large arrayLayers yields VK_NULL_HANDLE and is passed
+// straight to vkGetImageMemoryRequirements. It does NOT prove creatability on an arbitrary device;
+// a device reporting the Core minimum of 256 can still reject a 512-layer image, and it will do so
+// through that same unchecked path until #3045 lands. Querying the real limit is the correct fix
+// and belongs with #3045, since this predicate has no device handle.
 inline constexpr uint32_t kBackendMaxArrayLayers = 2048u;
 
 // A guest 2D_ARRAY is the same shape as the MSAA plane array with a different provenance: N

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -414,8 +414,31 @@ inline bool backend_storage_image_numeric_contract_valid(const FrameResource& re
 // The first exact guest-MSAA contract is intentionally narrow. Ordinary resources retain their
 // historical implicit byte-span behavior; a 2D_MSAA plane array must prove all four complete R32F
 // planes are readable before any Vulkan object or memcpy is attempted.
+// A guest 2D_ARRAY is the same shape as the MSAA plane array with a different provenance: N
+// ordinary color layers laid out one after another, carried through the SAME `sample_count`
+// channel, and owed the same proof that every layer is readable before any Vulkan object or memcpy
+// exists. Everything downstream is already layer-generic -- the staging buffer sizes itself
+// `tw*th*td*sample_count*bpp`, the image takes `arrayLayers = sample_count`, and the view selects
+// VK_IMAGE_VIEW_TYPE_2D_ARRAY above 1 -- so this predicate was the single gate keeping graphics
+// array textures out (#325). Mip generation is already excluded for `sample_count > 1`, which is
+// what stops a generated chain bleeding across layer boundaries.
+inline bool backend_texture_array_span_valid(const FrameResource& resource) {
+    if (resource.img_dim != 5u || resource.td != 1u || resource.is_storage_image ||
+        !resource.tex_rgba || !resource.tw || !resource.th || resource.sample_count < 2u)
+        return false;
+    const uint32_t bpp = backend_color_bytes_per_pixel(resource.texture_format);
+    if (!bpp) return false;
+    const size_t row_bytes = static_cast<size_t>(resource.tw) * bpp;
+    if (row_bytes / bpp != resource.tw) return false;
+    if (resource.th > SIZE_MAX / row_bytes) return false;
+    const size_t layer_bytes = row_bytes * resource.th;
+    if (resource.sample_count > SIZE_MAX / layer_bytes) return false;
+    return resource.tex_byte_size >= layer_bytes * resource.sample_count;
+}
+
 inline bool backend_texture_plane_span_valid(const FrameResource& resource) {
     if (resource.sample_count == 1u) return true;
+    if (resource.img_dim == 5u) return backend_texture_array_span_valid(resource);
     if (resource.sample_count != 4u || resource.img_dim != 6u || resource.td != 1u ||
         resource.declared_mip_levels != 1u || resource.is_storage_image ||
         backend_color_format(resource.texture_format) != VK_FORMAT_R32_SFLOAT ||

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -414,17 +414,26 @@ inline bool backend_storage_image_numeric_contract_valid(const FrameResource& re
 // The first exact guest-MSAA contract is intentionally narrow. Ordinary resources retain their
 // historical implicit byte-span behavior; a 2D_MSAA plane array must prove all four complete R32F
 // planes are readable before any Vulkan object or memcpy is attempted.
+// Vulkan guarantees `maxImageArrayLayers >= 2048`; a guest T# can declare up to 8192. Since this
+// predicate has no device handle, it bounds against the guaranteed minimum rather than the actual
+// limit, so a resource it admits is creatable on every conformant device. Anything above is
+// rejected fail-visibly here instead of reaching vkCreateImage, whose result the upload path does
+// not check (pre-existing, all image creation, filed separately) -- an over-large arrayLayers would
+// otherwise yield VK_NULL_HANDLE and be passed straight to vkGetImageMemoryRequirements.
+inline constexpr uint32_t kBackendMaxArrayLayers = 2048u;
+
 // A guest 2D_ARRAY is the same shape as the MSAA plane array with a different provenance: N
 // ordinary color layers laid out one after another, carried through the SAME `sample_count`
 // channel, and owed the same proof that every layer is readable before any Vulkan object or memcpy
 // exists. Everything downstream is already layer-generic -- the staging buffer sizes itself
 // `tw*th*td*sample_count*bpp`, the image takes `arrayLayers = sample_count`, and the view selects
-// VK_IMAGE_VIEW_TYPE_2D_ARRAY above 1 -- so this predicate was the single gate keeping graphics
-// array textures out (#325). Mip generation is already excluded for `sample_count > 1`, which is
-// what stops a generated chain bleeding across layer boundaries.
+// VK_IMAGE_VIEW_TYPE_2D_ARRAY above 1 -- so once a frontend publishes a layer count, this predicate
+// is what stands between it and the upload (#325). Mip generation is already excluded for
+// `sample_count > 1`, which is what stops a generated chain bleeding across layer boundaries.
 inline bool backend_texture_array_span_valid(const FrameResource& resource) {
     if (resource.img_dim != 5u || resource.td != 1u || resource.is_storage_image ||
-        !resource.tex_rgba || !resource.tw || !resource.th || resource.sample_count < 2u)
+        !resource.tex_rgba || !resource.tw || !resource.th || resource.sample_count < 2u ||
+        resource.sample_count > kBackendMaxArrayLayers)
         return false;
     const uint32_t bpp = backend_color_bytes_per_pixel(resource.texture_format);
     if (!bpp) return false;

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -1144,6 +1144,31 @@ int main() {
         CHECK(!prosper::test::backend_texture_plane_span_valid(wide_format),
               "2D_ARRAY span scales with the format's bytes per texel, not a fixed 4");
 
+        // An unbounded layer count reaches vkCreateImage, whose result the upload path does not
+        // check -- so a guest T# declaring more layers than any conformant device allows would
+        // produce VK_NULL_HANDLE and be handed to vkGetImageMemoryRequirements. Guest arrays reach
+        // 8192; Vulkan guarantees only 2048. A 4x4 RGBA8 array of 8192 layers is 512 KiB, so the
+        // span check alone does NOT bound this in practice -- which is why the arm exists.
+        {
+            const uint32_t huge = prosper::test::kBackendMaxArrayLayers + 1u;
+            std::vector<uint8_t> huge_bytes(static_cast<size_t>(LW) * LH * 4u * huge, 0x40);
+            prosper::test::FrameResource too_many = arr;
+            too_many.tex_rgba = huge_bytes.data();
+            too_many.tex_byte_size = huge_bytes.size();
+            too_many.sample_count = huge;
+            CHECK(!prosper::test::backend_texture_plane_span_valid(too_many),
+                  "a layer count above the guaranteed device maximum is rejected even when its "
+                  "span is complete");
+            prosper::test::FrameResource at_limit = arr;
+            at_limit.sample_count = prosper::test::kBackendMaxArrayLayers;
+            at_limit.tex_byte_size =
+                static_cast<size_t>(LW) * LH * 4u * prosper::test::kBackendMaxArrayLayers;
+            std::vector<uint8_t> limit_bytes(at_limit.tex_byte_size, 0x40);
+            at_limit.tex_rgba = limit_bytes.data();
+            CHECK(prosper::test::backend_texture_plane_span_valid(at_limit),
+                  "exactly the guaranteed device maximum is still accepted");
+        }
+
         prosper::test::FrameResource volume = arr;
         volume.td = 2;
         CHECK(!prosper::test::backend_texture_plane_span_valid(volume),

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -1105,6 +1105,75 @@ int main() {
               "unsupported host sample-plane counts remain fail-visible at the backend boundary");
     }
 
+    // #325: a guest 2D_ARRAY rides the same `sample_count` layer channel as the MSAA plane array.
+    // Before this, the span predicate admitted sample_count > 1 ONLY for the four-plane R32F MSAA
+    // shape, so every graphics array texture was rejected at the backend boundary and fell back to
+    // its base slice -- which is why Tomb Raider I-III Remastered, whose whole world is textured
+    // from one 256-slice array, rendered flat. The arms below are chosen to fail if the bounds
+    // arithmetic is dropped rather than merely to agree with the implementation.
+    {
+        const uint32_t LW = 4, LH = 4, LAYERS = 8;
+        std::vector<uint8_t> layer_bytes(static_cast<size_t>(LW) * LH * 4u * LAYERS, 0x40);
+        prosper::test::FrameResource arr{};
+        arr.tex_rgba = layer_bytes.data();
+        arr.tex_byte_size = layer_bytes.size();
+        arr.tw = LW; arr.th = LH; arr.td = 1;
+        arr.img_dim = 5;
+        arr.sample_count = LAYERS;
+        arr.texture_format = VK_FORMAT_R8G8B8A8_UNORM;
+        CHECK(prosper::test::backend_texture_plane_span_valid(arr),
+              "a complete 8-layer 2D_ARRAY span is accepted (#325)");
+
+        prosper::test::FrameResource short_arr = arr;
+        short_arr.tex_byte_size = layer_bytes.size() - 1;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(short_arr),
+              "a 2D_ARRAY one byte short of its last layer is rejected before Vulkan");
+
+        // The bound must scale with the LAYER COUNT, not merely with one layer. A predicate that
+        // checked a single layer's worth of bytes would pass this, and would then memcpy 8 layers
+        // out of a 1-layer allocation.
+        prosper::test::FrameResource one_layer_span = arr;
+        one_layer_span.tex_byte_size = static_cast<size_t>(LW) * LH * 4u;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(one_layer_span),
+              "a 2D_ARRAY span covering only one layer is rejected for an 8-layer resource");
+
+        // Bytes-per-texel must come from the format. Declaring a 16-byte format over the same
+        // buffer needs four times the span, so this arm fails if bpp is assumed to be 4.
+        prosper::test::FrameResource wide_format = arr;
+        wide_format.texture_format = VK_FORMAT_R32G32B32A32_SFLOAT;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(wide_format),
+              "2D_ARRAY span scales with the format's bytes per texel, not a fixed 4");
+
+        prosper::test::FrameResource volume = arr;
+        volume.td = 2;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(volume),
+              "a layered resource that is also a volume is not an array upload");
+
+        prosper::test::FrameResource storage = arr;
+        storage.is_storage_image = true;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(storage),
+              "a layered storage image is not admitted by the array arm");
+
+        prosper::test::FrameResource no_pixels = arr;
+        no_pixels.tex_rgba = nullptr;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(no_pixels),
+              "a layered resource with no pixels is rejected");
+
+        // The historical single-layer contract is untouched: tex_byte_size == 0 still means "no
+        // explicit span" and must keep passing, or every ordinary texture in the project regresses.
+        prosper::test::FrameResource single = arr;
+        single.sample_count = 1;
+        single.tex_byte_size = 0;
+        CHECK(prosper::test::backend_texture_plane_span_valid(single),
+              "single-layer resources keep the historical implicit-span contract");
+
+        // And the MSAA arm still routes by img_dim, so admitting arrays cannot widen it.
+        prosper::test::FrameResource msaa_two = arr;
+        msaa_two.img_dim = 6; msaa_two.sample_count = 2;
+        CHECK(!prosper::test::backend_texture_plane_span_valid(msaa_two),
+              "the MSAA plane-array arm is unchanged by the 2D_ARRAY addition");
+    }
+
     // The same image_load instruction becomes OpImageRead when its resource class is StorageImage.
     // That SPIR-V interface must be backed by a STORAGE_IMAGE descriptor over an image with STORAGE
     // usage in GENERAL layout, not the sampled texture's combined-image-sampler contract (#374).

--- a/prosper/tests/gpu/test_texture_sample_render.cpp
+++ b/prosper/tests/gpu/test_texture_sample_render.cpp
@@ -1106,11 +1106,12 @@ int main() {
     }
 
     // #325: a guest 2D_ARRAY rides the same `sample_count` layer channel as the MSAA plane array.
-    // Before this, the span predicate admitted sample_count > 1 ONLY for the four-plane R32F MSAA
-    // shape, so every graphics array texture was rejected at the backend boundary and fell back to
-    // its base slice -- which is why Tomb Raider I-III Remastered, whose whole world is textured
-    // from one 256-slice array, rendered flat. The arms below are chosen to fail if the bounds
-    // arithmetic is dropped rather than merely to agree with the implementation.
+    // The span predicate admitted sample_count > 1 ONLY for the four-plane R32F MSAA shape, so it
+    // is what a frontend publishing a layer count would run into first. It was NOT what made
+    // Tomb Raider I-III Remastered render flat: every graphics array arrives with sample_count == 1
+    // today and passes at the `== 1u` fast path, so nothing is being rejected here yet. The arms
+    // below are chosen to fail if the bounds arithmetic is dropped rather than merely to agree with
+    // the implementation.
     {
         const uint32_t LW = 4, LH = 4, LAYERS = 8;
         std::vector<uint8_t> layer_bytes(static_cast<size_t>(LW) * LH * 4u * LAYERS, 0x40);
@@ -1145,10 +1146,11 @@ int main() {
               "2D_ARRAY span scales with the format's bytes per texel, not a fixed 4");
 
         // An unbounded layer count reaches vkCreateImage, whose result the upload path does not
-        // check -- so a guest T# declaring more layers than any conformant device allows would
-        // produce VK_NULL_HANDLE and be handed to vkGetImageMemoryRequirements. Guest arrays reach
-        // 8192; Vulkan guarantees only 2048. A 4x4 RGBA8 array of 8192 layers is 512 KiB, so the
-        // span check alone does NOT bound this in practice -- which is why the arm exists.
+        // check -- so an absurd arrayLayers produces VK_NULL_HANDLE and is handed to
+        // vkGetImageMemoryRequirements (#3045). A 4x4 RGBA8 array of 8192 layers is only 512 KiB,
+        // so the span check alone does NOT bound this in practice -- which is why the arm exists.
+        // kBackendMaxArrayLayers is a pragmatic ceiling, not a portability guarantee: Vulkan Core
+        // requires only 256 and this backend requests 1.1.
         {
             const uint32_t huge = prosper::test::kBackendMaxArrayLayers + 1u;
             std::vector<uint8_t> huge_bytes(static_cast<size_t>(LW) * LH * 4u * huge, 0x40);
@@ -1157,7 +1159,7 @@ int main() {
             too_many.tex_byte_size = huge_bytes.size();
             too_many.sample_count = huge;
             CHECK(!prosper::test::backend_texture_plane_span_valid(too_many),
-                  "a layer count above the guaranteed device maximum is rejected even when its "
+                  "a layer count above the backend's array-layer ceiling is rejected even when its "
                   "span is complete");
             prosper::test::FrameResource at_limit = arr;
             at_limit.sample_count = prosper::test::kBackendMaxArrayLayers;
@@ -1166,7 +1168,7 @@ int main() {
             std::vector<uint8_t> limit_bytes(at_limit.tex_byte_size, 0x40);
             at_limit.tex_rgba = limit_bytes.data();
             CHECK(prosper::test::backend_texture_plane_span_valid(at_limit),
-                  "exactly the guaranteed device maximum is still accepted");
+                  "exactly the backend's array-layer ceiling is still accepted");
         }
 
         prosper::test::FrameResource volume = arr;


### PR DESCRIPTION
Enabling half of #325. **No behaviour changes** — this only permits a shape nothing currently
produces.

## Why the backend was the blocker

Everything an array texture needs is already in place:

| what | where | status |
| --- | --- | --- |
| layer channel | `FrameResource::sample_count` — its own comment documents it for MSAA-as-array | already there |
| staging size | `tw*th*td*sample_count*bpp` | already layer-generic |
| image creation | `tci.arrayLayers = r.sample_count` | already layer-generic |
| view type | `sample_count > 1 ? VK_IMAGE_VIEW_TYPE_2D_ARRAY : ..._2D` | already layer-generic |
| **span contract** | `backend_texture_plane_span_valid` | **admitted only the 4-plane R32F MSAA shape** |

That last row rejected every graphics 2D_ARRAY at the backend boundary — which is exactly what the
recompiler's own comment records:

> *"The shared graphics backend currently exposes 2D_ARRAY textures as its documented base-slice 2D
> view (#325). Keep that established fallback for graphics until its resource uploader can create
> matching array views."*

This PR is that "until".

It also explains a failure I could not account for earlier: setting `sample_count = 256` on an
array made offline replay report `Vulkan render FAILED`, and a layer-count bisect showed it failing
at **4** layers as readily as at 256 — ruling out memory and pointing at a contract. It was this
predicate returning false.

## What the arm does

Same obligation the MSAA arm states — prove every layer is readable before any Vulkan object or
memcpy exists — with bytes-per-texel derived from the format rather than assumed. Mip generation is
already excluded for `sample_count > 1`, which is what stops a generated chain bleeding across layer
boundaries.

## Tests

Nine arms, chosen to fail if the arithmetic is dropped rather than to agree with it:

- a complete 8-layer span is accepted
- one byte short of the last layer is rejected
- **a span covering only ONE layer is rejected for an 8-layer resource** — a predicate checking a
  single layer's bytes would pass this and then memcpy 8 layers out of a 1-layer allocation
- **a 16-byte format over the same buffer is rejected** — fails if bpp is assumed to be 4
- volume / storage-image / null-pixel resources are rejected
- single-layer resources keep the historical implicit-span (`tex_byte_size == 0`) contract, or every
  ordinary texture in the project regresses
- the MSAA arm still routes by `img_dim`, so admitting arrays cannot widen it

Mutating the bound from `layer_bytes * sample_count` to `layer_bytes` turns the suite red (verified).

## Verification

- `cmake --build prosper/build-linux -j12` — clean, 0 errors
- `ctest --no-tests=error -j4` — **310 of 311 pass**, 4 skipped
- The one failure is `trap_identifies_imports`, which is pre-existing #2997 (`test_trap_linux` fails
  rather than skips on any dump with fewer than 500 import stubs) and is unrelated to a texture span
  predicate — this build is configured against `PPSA16901`, which is also why the four Messenger-
  specific cases skip.

## What is NOT in this PR

The producing half — making the decode path fill all layers, carrying the layer count through the
decoded-texture cache, and publishing `sample_count` on reuse — plus the recompiler change that
keeps the array slice in the SPIR-V coordinate for graphics stages. Those are riskier and touch the
renderer's hottest path, so they land separately on top of this. Findings so far are on #2998.
