### PR TITLE
fix(win): guest semaphore timedwait off the winpthreads tick, POSIX untouched

### DIFF
--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -626,14 +626,18 @@ if(TARGET prosper_core)
   target_link_libraries(test_kernel_nanosleep PRIVATE prosper_core)
   add_test(NAME kernel_nanosleep COMMAND test_kernel_nanosleep)
 
-  # The guest semaphore timed wait, on BOTH axes (#3013). Platform-neutral like the nanosleep case
-  # above and for the same reason: the Windows fix is a poll loop and the defect is a Windows one, so
-  # gating it on UNIX would build it everywhere except where it matters. What makes this test worth
-  # having is that the two arms constrain each other -- the Windows fix buys timeout accuracy WITH
-  # wake latency, so pinning only the timeout would let a future change widen the poll slice and stay
-  # green while destroying responsiveness, and pinning only the wake would let it revert to
-  # winpthreads' 15.6 ms timeout. Thresholds are loose enough for a loaded host and still far inside
-  # both failures.
+  # The guest semaphore timed wait (#3013). Platform-neutral like the nanosleep case above and for
+  # the same reason: the fix is Windows-only, so gating on UNIX would build the test everywhere
+  # except where the defect is.
+  #
+  # It asserts the MECHANISM -- which primitive served the wait, via sleep_backend_name() -- rather
+  # than a wall-clock duration, following test_videoout.cpp and what test_kernel_nanosleep.cpp's
+  # header asks for. The first version asserted durations only and review showed NONE of its arms
+  # could redden on the pre-fix code: its 40 ms ceiling sat 2.6x above the 15.57 ms defect, and its
+  # other two arms measured a POSTED semaphore, which unfixed winpthreads serves in 0.01 ms -- better
+  # than the poll loop, so they preferred the defect. A mechanism assertion cannot be satisfied by a
+  # lucky duration and does not flake under load. Mutation-checked: reverting to the winpthreads
+  # delegation reddens two arms and prints "via none".
   add_executable(test_kernel_sem_timedwait tests/hle/kernel/test_kernel_sem_timedwait.cpp)
   target_link_libraries(test_kernel_sem_timedwait PRIVATE prosper_core)
   add_test(NAME kernel_sem_timedwait COMMAND test_kernel_sem_timedwait)

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -641,6 +641,9 @@ if(TARGET prosper_core)
   add_executable(test_kernel_sem_timedwait tests/hle/kernel/test_kernel_sem_timedwait.cpp)
   target_link_libraries(test_kernel_sem_timedwait PRIVATE prosper_core)
   add_test(NAME kernel_sem_timedwait COMMAND test_kernel_sem_timedwait)
+  # Bounded for the same reason as the nanosleep case: the fixed path returns in ~5 ms, so a
+  # regression that reverts to a blocking wait on a semaphore nothing will ever post would hang
+  # rather than fail, and CTest's default 1500 s hang reads as neither pass nor fail.
   set_tests_properties(kernel_sem_timedwait PROPERTIES TIMEOUT 60)
   # Bounded because arm 3 guards a ~292-YEAR sleep: without a timeout a regression there presents as
   # CTest hanging for its default 1500 s rather than as a failure, and a hang is the one outcome nobody

--- a/prosper/CMakeLists.txt
+++ b/prosper/CMakeLists.txt
@@ -625,6 +625,19 @@ if(TARGET prosper_core)
   add_executable(test_kernel_nanosleep tests/hle/kernel/test_kernel_nanosleep.cpp)
   target_link_libraries(test_kernel_nanosleep PRIVATE prosper_core)
   add_test(NAME kernel_nanosleep COMMAND test_kernel_nanosleep)
+
+  # The guest semaphore timed wait, on BOTH axes (#3013). Platform-neutral like the nanosleep case
+  # above and for the same reason: the Windows fix is a poll loop and the defect is a Windows one, so
+  # gating it on UNIX would build it everywhere except where it matters. What makes this test worth
+  # having is that the two arms constrain each other -- the Windows fix buys timeout accuracy WITH
+  # wake latency, so pinning only the timeout would let a future change widen the poll slice and stay
+  # green while destroying responsiveness, and pinning only the wake would let it revert to
+  # winpthreads' 15.6 ms timeout. Thresholds are loose enough for a loaded host and still far inside
+  # both failures.
+  add_executable(test_kernel_sem_timedwait tests/hle/kernel/test_kernel_sem_timedwait.cpp)
+  target_link_libraries(test_kernel_sem_timedwait PRIVATE prosper_core)
+  add_test(NAME kernel_sem_timedwait COMMAND test_kernel_sem_timedwait)
+  set_tests_properties(kernel_sem_timedwait PROPERTIES TIMEOUT 60)
   # Bounded because arm 3 guards a ~292-YEAR sleep: without a timeout a regression there presents as
   # CTest hanging for its default 1500 s rather than as a failure, and a hang is the one outcome nobody
   # reads as a red test. Generous against a loaded host -- what it catches is seconds-to-forever.

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -3082,11 +3082,18 @@ HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem
 // up to 2 ms on every wake, which is 37% of the 5.33 ms grain period this exists to serve: it would
 // fix the cadence and blunt the responsiveness in the same change. Short slices for the first few
 // milliseconds keep the wake tight where pacing lives; longer slices afterwards keep a guest parked
-// for seconds from spinning at 5 kHz for no benefit.
+// for seconds from spinning at 2 kHz for no benefit. (An earlier revision of this comment said
+// 5 kHz, which was the 200 us slice that revision used before the floor measurement below
+// replaced it.)
 HLE(k_sem_timedwait) {
     auto* s = ensure_sem(a0);
     if (!s) return prosper::hle::kSceKernelErrorEINVAL;
-    hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, a1 * 1000ull);
+    // Saturating, matching guest_ns_from in hle_kernel_time.cpp (#3022): a1 is guest-controlled,
+    // and a wrap here would turn a very long timeout into a short one. That file states the rule
+    // for the whole family, so this member of it should not be the exception.
+    const uint64_t kNsMax = ~0ull;
+    const uint64_t timeout_ns = a1 > kNsMax / 1000ull ? kNsMax : (uint64_t)a1 * 1000ull;
+    hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, timeout_ns);
 #ifndef _WIN32
     timespec dl = abs_deadline_us(a1);
     int rc = sem_timedwait(s, &dl);
@@ -3096,7 +3103,11 @@ HLE(k_sem_timedwait) {
     if (sem_trywait(s) == 0) return 0;
     const uint64_t start_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                                   std::chrono::steady_clock::now().time_since_epoch()).count();
-    const uint64_t deadline_ns = start_ns + (uint64_t)a1 * 1000ull;
+    // Saturating again on the addition: start_ns + timeout_ns can itself wrap for a huge timeout,
+    // and a wrapped deadline lands in the past, which would turn a long wait into an instant
+    // timeout -- the loud direction, but still wrong.
+    const uint64_t deadline_ns =
+        timeout_ns > kNsMax - start_ns ? kNsMax : start_ns + timeout_ns;
     // 500 us while the wait is young, 2 ms after 8 ms have passed. The crossover is above one grain
     // period so an audio pacing wait never leaves the tight regime.
     //
@@ -3110,6 +3121,11 @@ HLE(k_sem_timedwait) {
     const uint64_t kFineSliceNs = 500000ull, kCoarseSliceNs = 2000000ull, kFineWindowNs = 8000000ull;
     for (;;) {
         if (sem_trywait(s) == 0) return 0;
+        // EAGAIN means "not posted yet", which is the whole point of the loop. Anything else --
+        // EINVAL on a semaphore whose storage was retired, say -- will not become true by waiting,
+        // so report it instead of spinning to the deadline and then reporting a timeout that
+        // misdescribes what happened. EINTR is retried, as a wait should be.
+        if (errno != EAGAIN && errno != EINTR) return sce_pthread_rc(fbsd_errno(errno));
         const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
                                     std::chrono::steady_clock::now().time_since_epoch()).count();
         if (now_ns >= deadline_ns) { errno = ETIMEDOUT; return sce_pthread_rc(fbsd_errno(errno)); }

--- a/prosper/src/hle/kernel/hle_kernel.cpp
+++ b/prosper/src/hle/kernel/hle_kernel.cpp
@@ -20,6 +20,7 @@
 #include "host/platform/immortal.hpp"        // #2613: registries a guest thread can reach after exit()
 #include "hle/sync/pthread_slot.hpp"   // #2596: the two guest-slot resolvers are defined here
 #include "hle/kernel/timedwait_census.hpp"   // PROSPER_TIMEDWAIT_CENSUS (#3013)
+#include "host/platform/precise_sleep.hpp"   // guest sem timedwait must not inherit the tick (#3013)
 #include "hle/sync/sync_futex.hpp"
 #include "hle/sync/sync_retire.hpp"   // #2042: a destroyed guest sync object's storage is retired, not freed
 #include "gpu/execute/mb3_freelist.hpp"
@@ -3058,7 +3059,66 @@ HLE(k_sem_wait)      { auto* s = ensure_sem(a0); if (!s) return 0x16; if (semlog
 HLE(k_sem_trywait)   { auto* s = ensure_sem(a0); if (!s) return 0x16; return sem_trywait(s) == 0 ? 0 : fbsd_errno(errno); }   // EAGAIN (would block) is 11 here, 35 on the PS5
 // scePthreadSemTimedwait is the one member of the family with no POSIX spelling registered on its
 // body, so it encodes in place; the other six go through SCE_PTHREAD_ALIAS below (#2178).
-HLE(k_sem_timedwait) { auto* s = ensure_sem(a0); if (!s) return prosper::hle::kSceKernelErrorEINVAL; hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, a1 * 1000ull); timespec dl = abs_deadline_us(a1); int rc = sem_timedwait(s, &dl); return rc == 0 ? 0 : sce_pthread_rc(fbsd_errno(errno)); }
+// scePthreadSemTimedwait / sem_timedwait: acquire with a RELATIVE microsecond timeout.
+//
+// #3013 fixed the guest SLEEP primitives; this is the TIMED WAIT half, recovered from #2984's
+// c45debbf and reshaped. On Windows sem_timedwait is winpthreads', whose timed waits resolve on its
+// own master tick regardless of timeBeginPeriod -- measured on this toolchain at 15.57 ms for a
+// 5.33 ms request. FMOD's mixer paces 256-frame blocks on exactly this call, so a guest asking for
+// one grain was released once per tick instead: audio delivered at roughly a third of real time
+// (Blasphemous 2, #2985).
+//
+// Two deliberate departures from the recovered form, both measured rather than assumed.
+//
+// FIRST, the POSIX path is left alone. That commit polled on every platform, which is a needless
+// regression on Linux and macOS where sem_timedwait already honours the deadline: polling there
+// replaces one exact wait with a loop that is strictly worse on both latency and CPU. The tick is a
+// Windows property, so the workaround is Windows-only and POSIX keeps the native call and its exact
+// semantics.
+//
+// SECOND, the poll interval is adaptive rather than a flat 2 ms. The whole reason this call needs care
+// is that a POSTED semaphore returns in 0.01 ms natively (measured, #3013's probe, and its control
+// arm) -- so any poll loop TRADES AWAY wake latency to buy timeout accuracy. A flat 2 ms slice costs
+// up to 2 ms on every wake, which is 37% of the 5.33 ms grain period this exists to serve: it would
+// fix the cadence and blunt the responsiveness in the same change. Short slices for the first few
+// milliseconds keep the wake tight where pacing lives; longer slices afterwards keep a guest parked
+// for seconds from spinning at 5 kHz for no benefit.
+HLE(k_sem_timedwait) {
+    auto* s = ensure_sem(a0);
+    if (!s) return prosper::hle::kSceKernelErrorEINVAL;
+    hle::WaitCensusScope c(hle::WaitKind::SemTimedwait, a1 * 1000ull);
+#ifndef _WIN32
+    timespec dl = abs_deadline_us(a1);
+    int rc = sem_timedwait(s, &dl);
+    return rc == 0 ? 0 : sce_pthread_rc(fbsd_errno(errno));
+#else
+    // trywait first: an already-posted semaphore costs nothing and never reaches the loop.
+    if (sem_trywait(s) == 0) return 0;
+    const uint64_t start_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                  std::chrono::steady_clock::now().time_since_epoch()).count();
+    const uint64_t deadline_ns = start_ns + (uint64_t)a1 * 1000ull;
+    // 500 us while the wait is young, 2 ms after 8 ms have passed. The crossover is above one grain
+    // period so an audio pacing wait never leaves the tight regime.
+    //
+    // 500 us and not less, because that is the FLOOR of a short high-resolution-timer sleep on
+    // this host, measured rather than assumed: requests of 0.05, 0.10 and 0.20 ms all cost a
+    // median of 0.52 ms (200 samples each; 0.50 ms -> 1.02, 1.00 -> 1.51, 2.00 -> 2.07). An
+    // earlier revision asked for 200 us, which reads as a tighter loop than the machine can
+    // actually run and would mislead the next person tuning it. What the fine window buys is a
+    // poll interval about 4x shorter than the coarse one (0.52 ms against 2.07), not the 10x the
+    // constants implied.
+    const uint64_t kFineSliceNs = 500000ull, kCoarseSliceNs = 2000000ull, kFineWindowNs = 8000000ull;
+    for (;;) {
+        if (sem_trywait(s) == 0) return 0;
+        const uint64_t now_ns = (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                    std::chrono::steady_clock::now().time_since_epoch()).count();
+        if (now_ns >= deadline_ns) { errno = ETIMEDOUT; return sce_pthread_rc(fbsd_errno(errno)); }
+        const uint64_t slice = (now_ns - start_ns) < kFineWindowNs ? kFineSliceNs : kCoarseSliceNs;
+        const uint64_t remaining = deadline_ns - now_ns;
+        prosper::host::sleep_until_steady_ns(now_ns + (remaining < slice ? remaining : slice));
+    }
+#endif
+}
 HLE(k_sem_post)      { auto* s = ensure_sem(a0); if (!s) return 0x16; int rc = sem_post(s); if (semlog()) fprintf(stderr, "[sem] post slot=%p rc=%d\n", (void*)(uintptr_t)a0, rc); return rc == 0 ? 0 : fbsd_errno(errno); }
 HLE(k_sem_getvalue)  { auto* s = ensure_sem(a0); if (!s) return 0x16; int v = 0; sem_getvalue(s, &v); if (a1) *(int*)(uintptr_t)a1 = v; return 0; }
 // Quarantined, not freed, and `sem_destroy` deferred to reclaim — a thread parked in `sem_wait` is

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -1,26 +1,44 @@
-// test_kernel_sem_timedwait (#3013) - the guest semaphore timed wait must be accurate on BOTH axes.
+// test_kernel_sem_timedwait (#3013) - the guest semaphore timed wait.
 //
-// The reason this test exists rather than a timing comment: the Windows fix for timeout accuracy is a
-// poll loop, and a poll loop BUYS accuracy WITH wake latency. Pinning only the timeout would let a
-// future change widen the slice to 50 ms and stay green while destroying the responsiveness the call
-// is used for; pinning only the wake would let it revert to winpthreads' 15.6 ms timeout. Both arms
-// together are what make the design claim checkable.
+// THIS TEST'S FIRST VERSION COULD NOT FAIL, which is why the mechanism arm below exists.
 //
-// Thresholds are deliberately loose - a loaded CI host must not turn this red - and they are still far
-// inside the failures they guard: the timeout arm catches 15.6 ms quantization at a 40 ms budget on a
-// 5 ms request, and the wake arm catches a 2 ms flat slice at a 1.5 ms budget. What is NOT asserted is
-// sleep precision, which belongs to host::sleep_until_steady_ns.
+// It asserted wall-clock bounds: a 5 ms timeout under a 40 ms ceiling, and the latency of a POSTED
+// semaphore. Review showed none of the three arms could redden on the pre-fix code. 40 ms sits 2.6x
+// above the 15.57 ms defect it claimed to catch, so the tick passed it comfortably; and a posted
+// semaphore is served by UNFIXED winpthreads in 0.01 ms - better than the poll loop that replaced it -
+// so the wake arms preferred the defect. Meanwhile the file header and two arm comments all stated
+// that the tick was pinned. Confident labels over assertions that could not discriminate.
+//
+// The fix is the pattern this repo already prescribes and uses. test_kernel_nanosleep.cpp says it in
+// words - "precise_sleep exposes sleep_backend() so the MECHANISM can be asserted instead" - and
+// test_videoout.cpp:274/:315 is the worked example: assert WHICH primitive served the wait, not how
+// long it took. A mechanism assertion cannot be satisfied by a lucky duration, and it does not flake
+// on a loaded host.
+//
+// So the arms are:
+//   1. MECHANISM  - the wait was served by the high-resolution timer, not ::Sleep's tick. Reddens on
+//                   the pre-fix code, which never touches precise_sleep at all.
+//   2. ENCODING   - the timeout returns exactly 0x8002003c, FreeBSD ETIMEDOUT as the guest reads it.
+//                   Nothing else in the suite covers this path's encoding.
+//   3. BOUNDS     - a lower bound as well as an upper one. The upper alone cannot catch a wait that
+//                   returns instantly; the lower alone cannot catch the tick.
+//   4. FAST PATH  - an already-posted semaphore never enters the loop.
+//
+// Deliberately NOT asserted: the poll slice length. A short high-resolution sleep on this host has a
+// ~0.52 ms floor, so the adaptive 0.5 ms slice and a flat 2 ms one produce overlapping latency
+// distributions and no honest single-run bound separates them. That measurement lives at the call site.
 #include "hle/dispatch/dispatch.hpp"
 #include "hle/dispatch/nid.hpp"
+#include "hle/kernel/sce_errno.hpp"
+#include "host/platform/precise_sleep.hpp"
 
-#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <semaphore.h>
 #include <thread>
-#include <vector>
 
 using namespace prosper;
 using clk = std::chrono::steady_clock;
@@ -29,10 +47,6 @@ static int fails = 0;
 #define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
                          else       { printf("  [ok]   %s\n", m); } } while (0)
 
-static double ms_since(clk::time_point t) {
-    return std::chrono::duration<double, std::milli>(clk::now() - t).count();
-}
-
 int main() {
     printf("== test_kernel_sem_timedwait ==\n");
     register_builtin_hle();
@@ -40,101 +54,59 @@ int main() {
     HleFn sem_init_fn = Hle::lookup(nid_hash("scePthreadSemInit").c_str());
     HleFn timedwait   = Hle::lookup(nid_hash("scePthreadSemTimedwait").c_str());
     HleFn post        = Hle::lookup(nid_hash("scePthreadSemPost").c_str());
-    if (!timedwait) {
-        // Fall back to the POSIX spellings if the Sony ones are not the registered names here.
-        timedwait = Hle::lookup(nid_hash("sem_timedwait").c_str());
-        post      = Hle::lookup(nid_hash("sem_post").c_str());
-        sem_init_fn = Hle::lookup(nid_hash("sem_init").c_str());
-    }
-    CHECK(timedwait != nullptr, "the guest semaphore timedwait is registered");
-    CHECK(post != nullptr, "the guest semaphore post is registered");
-    if (!timedwait || !post) { printf("== FAIL (unresolved) ==\n"); return 1; }
+    CHECK(sem_init_fn != nullptr, "scePthreadSemInit is registered");
+    CHECK(timedwait != nullptr, "scePthreadSemTimedwait is registered");
+    CHECK(post != nullptr, "scePthreadSemPost is registered");
+    if (!sem_init_fn || !timedwait || !post) { printf("== FAIL (unresolved) ==\n"); return 1; }
 
-    // The HLE takes an opaque guest slot; a real sem_t backs it via ensure_sem.
+    // The guest handle is an opaque slot; ensure_sem backs it with a real sem_t. Initialised through
+    // the HLE and CHECKED - the first version declared a bare `sem_t slot;` and called init with its
+    // result ignored, so an init that silently failed would have left every arm below operating on an
+    // uninitialised object.
     sem_t slot;
     const uint64_t handle = (uint64_t)(uintptr_t)&slot;
-    if (sem_init_fn) sem_init_fn(handle, 0, 0, 0, 0, 0);
+    CHECK(sem_init_fn(handle, 0, 0, 0, 0, 0) == 0, "the semaphore initialises to a count of 0");
 
-    // ARM 1 - TIMEOUT ACCURACY. 5000 us with no poster must return in well under one winpthreads
-    // tick's worth of overshoot. Pre-fix this took ~15.6 ms.
+    // ARM 1 + 2 + 3: one unposted wait, three independent properties.
     {
+        // "none" first, so the mechanism assertion below cannot be satisfied by an accessor that is a
+        // compiled-in constant. test_videoout.cpp uses the same guard for the same reason.
+        CHECK(strcmp(host::sleep_backend_name(), "none") == 0,
+              "no precise wait has run on this thread yet");
+
         const auto t0 = clk::now();
-        const uint64_t rc = timedwait(handle, 5000, 0, 0, 0, 0);
-        const double ms = ms_since(t0);
-        CHECK(rc != 0, "an unposted wait reports a timeout rather than success");
-        CHECK(ms < 40.0, "a 5 ms timeout does NOT resolve on the ~15.6 ms winpthreads tick");
-        printf("         (timeout took %.2f ms)\n", ms);
+        const uint64_t rc = timedwait(handle, 5000, 0, 0, 0, 0);   // 5 ms, nothing will post
+        const double ms = std::chrono::duration<double, std::milli>(clk::now() - t0).count();
+
+        // ARM 2: the encoding the guest actually compares against.
+        CHECK(rc == prosper::hle::kSceKernelErrorETIMEDOUT,
+              "a timeout returns FreeBSD ETIMEDOUT encoded as the guest reads it (0x8002003c)");
+
+        // ARM 3: bounded on BOTH sides. An upper bound alone passes a wait that returns instantly;
+        // a lower bound alone passes the 15.6 ms tick.
+        CHECK(ms >= 4.0, "it actually waited (a stub returning at once fails this)");
+        CHECK(ms < 12.0, "and returned inside one winpthreads tick of the request, not after it");
+
+        // ARM 1: WHICH primitive served it. This is the arm that reddens on the pre-fix code, which
+        // delegates to winpthreads and never enters precise_sleep, leaving the backend at "none".
+#ifdef _WIN32
+        CHECK(strcmp(host::sleep_backend_name(), "win32-high-resolution-timer") == 0,
+              "the wait was served by the high-resolution timer, NOT ::Sleep's ~15.6 ms tick");
+#else
+        CHECK(strcmp(host::sleep_backend_name(), "posix-sleep-until") == 0,
+              "POSIX keeps the native timed wait; no polling was introduced there");
+#endif
+        printf("         (timeout took %.2f ms via %s)\n", ms, host::sleep_backend_name());
     }
 
-    // ARM 2 - WAKE LATENCY after a post, over twelve posts, judged on the MEDIAN.
-    //
-    // Two things had to be got right here and both were wrong first time round.
-    //
-    // (a) Measure a LATENCY, not a schedule. The obvious form - sleep 5 ms in a poster thread, assert
-    //     the wait returned by ~6.5 ms - failed, because the poster's own std::this_thread::sleep_for
-    //     is subject to the SAME winpthreads tick this fix is about: a "5 ms" post landed at ~12 ms and
-    //     the arm blamed the code under test for its own harness. The poster now records when it
-    //     actually posted, and the assertion is on (wake - post).
-    //
-    // (b) Judge a DISTRIBUTION, not one sample. Single latencies ranged 0.11-1.65 ms across five runs,
-    //     so any single-sample threshold either flakes or is too loose to discriminate - and
-    //     discriminating is the entire point, since the Windows fix buys timeout accuracy WITH wake
-    //     latency and a future change could widen the poll slice. A flat 2 ms slice yields latency
-    //     roughly uniform on [0, 2] ms, median ~1.0; the adaptive 200 us slice gives a median around
-    //     0.3. A median bound of 0.8 ms separates those two designs and tolerates an outlier, which a
-    //     max bound cannot do.
+    // ARM 4: an already-posted semaphore is taken by the trywait fast path and never enters the loop.
     {
-        const int kPosts = 12;
-        std::vector<double> lat;
-        lat.reserve(kPosts);
-        for (int i = 0; i < kPosts; i++) {
-            std::atomic<bool> posted{false};
-            std::atomic<long long> post_ticks{0};
-            std::thread poster([&] {
-                std::this_thread::sleep_for(std::chrono::milliseconds(3));   // WHEN is not asserted
-                post_ticks.store((long long)clk::now().time_since_epoch().count());
-                posted = true;
-                post(handle, 0, 0, 0, 0, 0);
-            });
-            const uint64_t rc = timedwait(handle, 2000000, 0, 0, 0, 0);   // 2 s budget
-            const long long wake = (long long)clk::now().time_since_epoch().count();
-            poster.join();
-            if (rc != 0 || !posted.load()) { CHECK(false, "each post releases its wait"); break; }
-            lat.push_back(std::chrono::duration<double, std::milli>(
-                clk::duration(wake - post_ticks.load())).count());
-        }
-        CHECK((int)lat.size() == kPosts, "every post released its wait rather than timing out");
-        if ((int)lat.size() == kPosts) {
-            std::vector<double> s = lat;
-            std::sort(s.begin(), s.end());
-            const double med = s[s.size() / 2];
-            // 5 ms, and the loose bound is deliberate. What this arm CAN catch is a gross
-            // regression: reverting to winpthreads (15.6 ms) or widening the poll slice to tens
-            // of milliseconds. What it CANNOT do is separate the adaptive 0.5 ms slice from a
-            // flat 2 ms one, and an earlier revision of this arm claimed exactly that with a
-            // 0.8 ms bound - it failed 3 runs in 5. The reason is measured: a short
-            // high-resolution-timer sleep on this host has a ~0.52 ms floor whatever is
-            // requested, so the two designs give median latencies of roughly 0.5 and 1.0 ms and
-            // their run-to-run spread overlaps. Tightening the bound until it passed would have
-            // produced a flaky arm; claiming the discrimination it cannot make would have been
-            // worse. The slice length is documented at the call site instead, with its
-            // measurement.
-            CHECK(med < 5.0,
-                  "median wake latency is milliseconds-not-ticks: no reversion to the 15.6 ms path");
-            printf("         (wake latency: median %.3f ms, min %.3f, max %.3f over %d posts)\n",
-                   med, s.front(), s.back(), kPosts);
-        }
-    }
-
-    // ARM 3 - an ALREADY-posted semaphore costs nothing and never enters the loop.
-    {
-        post(handle, 0, 0, 0, 0, 0);
+        CHECK(post(handle, 0, 0, 0, 0, 0) == 0, "post succeeds");
         const auto t0 = clk::now();
         const uint64_t rc = timedwait(handle, 1000000, 0, 0, 0, 0);
-        const double ms = ms_since(t0);
+        const double ms = std::chrono::duration<double, std::milli>(clk::now() - t0).count();
         CHECK(rc == 0, "an already-posted semaphore is acquired");
-        CHECK(ms < 1.0, "...immediately, via the trywait fast path");
-        printf("         (fast path took %.3f ms)\n", ms);
+        CHECK(ms < 1.0, "...immediately, without entering the poll loop");
     }
 
     printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -32,13 +32,11 @@
 #include "hle/kernel/sce_errno.hpp"
 #include "host/platform/precise_sleep.hpp"
 
-#include <atomic>
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
 #include <semaphore.h>
-#include <thread>
 
 using namespace prosper;
 using clk = std::chrono::steady_clock;
@@ -65,7 +63,10 @@ int main() {
     // uninitialised object.
     sem_t slot;
     const uint64_t handle = (uint64_t)(uintptr_t)&slot;
-    CHECK(sem_init_fn(handle, 0, 0, 0, 0, 0) == 0, "the semaphore initialises to a count of 0");
+    // Asserts that init REPORTS success, not that the count is observably 0 -- the count is then
+    // established by arm 1 timing out rather than being acquired. The earlier message claimed the
+    // stronger thing.
+    CHECK(sem_init_fn(handle, 0, 0, 0, 0, 0) == 0, "scePthreadSemInit reports success");
 
     // ARM 1 + 2 + 3: one unposted wait, three independent properties.
     {
@@ -93,7 +94,17 @@ int main() {
         CHECK(strcmp(host::sleep_backend_name(), "win32-high-resolution-timer") == 0,
               "the wait was served by the high-resolution timer, NOT ::Sleep's ~15.6 ms tick");
 #else
-        CHECK(strcmp(host::sleep_backend_name(), "posix-sleep-until") == 0,
+        // STILL "none" on POSIX, and that is the assertion. The POSIX branch is the native
+        // sem_timedwait and never enters sleep_until_steady_ns, so the backend is unchanged by the
+        // wait. An earlier revision asserted "posix-sleep-until" here -- which, with the "none"
+        // pre-check above, asserted two different values for one unchanged state, so ONE of the two
+        // arms failed on every POSIX host regardless of the starting value. A Windows-only run
+        // cannot see that, and Linux/macOS CI had not yet built this file.
+        //
+        // Asserting "none" is not a weaker check for being the unchanged value: it is a real guard
+        // against someone later unifying both platforms onto the poll loop, which would enter
+        // precise_sleep here and redden this line.
+        CHECK(strcmp(host::sleep_backend_name(), "none") == 0,
               "POSIX keeps the native timed wait; no polling was introduced there");
 #endif
         printf("         (timeout took %.2f ms via %s)\n", ms, host::sleep_backend_name());

--- a/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
+++ b/prosper/tests/hle/kernel/test_kernel_sem_timedwait.cpp
@@ -1,0 +1,142 @@
+// test_kernel_sem_timedwait (#3013) - the guest semaphore timed wait must be accurate on BOTH axes.
+//
+// The reason this test exists rather than a timing comment: the Windows fix for timeout accuracy is a
+// poll loop, and a poll loop BUYS accuracy WITH wake latency. Pinning only the timeout would let a
+// future change widen the slice to 50 ms and stay green while destroying the responsiveness the call
+// is used for; pinning only the wake would let it revert to winpthreads' 15.6 ms timeout. Both arms
+// together are what make the design claim checkable.
+//
+// Thresholds are deliberately loose - a loaded CI host must not turn this red - and they are still far
+// inside the failures they guard: the timeout arm catches 15.6 ms quantization at a 40 ms budget on a
+// 5 ms request, and the wake arm catches a 2 ms flat slice at a 1.5 ms budget. What is NOT asserted is
+// sleep precision, which belongs to host::sleep_until_steady_ns.
+#include "hle/dispatch/dispatch.hpp"
+#include "hle/dispatch/nid.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <semaphore.h>
+#include <thread>
+#include <vector>
+
+using namespace prosper;
+using clk = std::chrono::steady_clock;
+
+static int fails = 0;
+#define CHECK(c, m) do { if (!(c)) { printf("  [FAIL] %s\n", m); fails++; } \
+                         else       { printf("  [ok]   %s\n", m); } } while (0)
+
+static double ms_since(clk::time_point t) {
+    return std::chrono::duration<double, std::milli>(clk::now() - t).count();
+}
+
+int main() {
+    printf("== test_kernel_sem_timedwait ==\n");
+    register_builtin_hle();
+
+    HleFn sem_init_fn = Hle::lookup(nid_hash("scePthreadSemInit").c_str());
+    HleFn timedwait   = Hle::lookup(nid_hash("scePthreadSemTimedwait").c_str());
+    HleFn post        = Hle::lookup(nid_hash("scePthreadSemPost").c_str());
+    if (!timedwait) {
+        // Fall back to the POSIX spellings if the Sony ones are not the registered names here.
+        timedwait = Hle::lookup(nid_hash("sem_timedwait").c_str());
+        post      = Hle::lookup(nid_hash("sem_post").c_str());
+        sem_init_fn = Hle::lookup(nid_hash("sem_init").c_str());
+    }
+    CHECK(timedwait != nullptr, "the guest semaphore timedwait is registered");
+    CHECK(post != nullptr, "the guest semaphore post is registered");
+    if (!timedwait || !post) { printf("== FAIL (unresolved) ==\n"); return 1; }
+
+    // The HLE takes an opaque guest slot; a real sem_t backs it via ensure_sem.
+    sem_t slot;
+    const uint64_t handle = (uint64_t)(uintptr_t)&slot;
+    if (sem_init_fn) sem_init_fn(handle, 0, 0, 0, 0, 0);
+
+    // ARM 1 - TIMEOUT ACCURACY. 5000 us with no poster must return in well under one winpthreads
+    // tick's worth of overshoot. Pre-fix this took ~15.6 ms.
+    {
+        const auto t0 = clk::now();
+        const uint64_t rc = timedwait(handle, 5000, 0, 0, 0, 0);
+        const double ms = ms_since(t0);
+        CHECK(rc != 0, "an unposted wait reports a timeout rather than success");
+        CHECK(ms < 40.0, "a 5 ms timeout does NOT resolve on the ~15.6 ms winpthreads tick");
+        printf("         (timeout took %.2f ms)\n", ms);
+    }
+
+    // ARM 2 - WAKE LATENCY after a post, over twelve posts, judged on the MEDIAN.
+    //
+    // Two things had to be got right here and both were wrong first time round.
+    //
+    // (a) Measure a LATENCY, not a schedule. The obvious form - sleep 5 ms in a poster thread, assert
+    //     the wait returned by ~6.5 ms - failed, because the poster's own std::this_thread::sleep_for
+    //     is subject to the SAME winpthreads tick this fix is about: a "5 ms" post landed at ~12 ms and
+    //     the arm blamed the code under test for its own harness. The poster now records when it
+    //     actually posted, and the assertion is on (wake - post).
+    //
+    // (b) Judge a DISTRIBUTION, not one sample. Single latencies ranged 0.11-1.65 ms across five runs,
+    //     so any single-sample threshold either flakes or is too loose to discriminate - and
+    //     discriminating is the entire point, since the Windows fix buys timeout accuracy WITH wake
+    //     latency and a future change could widen the poll slice. A flat 2 ms slice yields latency
+    //     roughly uniform on [0, 2] ms, median ~1.0; the adaptive 200 us slice gives a median around
+    //     0.3. A median bound of 0.8 ms separates those two designs and tolerates an outlier, which a
+    //     max bound cannot do.
+    {
+        const int kPosts = 12;
+        std::vector<double> lat;
+        lat.reserve(kPosts);
+        for (int i = 0; i < kPosts; i++) {
+            std::atomic<bool> posted{false};
+            std::atomic<long long> post_ticks{0};
+            std::thread poster([&] {
+                std::this_thread::sleep_for(std::chrono::milliseconds(3));   // WHEN is not asserted
+                post_ticks.store((long long)clk::now().time_since_epoch().count());
+                posted = true;
+                post(handle, 0, 0, 0, 0, 0);
+            });
+            const uint64_t rc = timedwait(handle, 2000000, 0, 0, 0, 0);   // 2 s budget
+            const long long wake = (long long)clk::now().time_since_epoch().count();
+            poster.join();
+            if (rc != 0 || !posted.load()) { CHECK(false, "each post releases its wait"); break; }
+            lat.push_back(std::chrono::duration<double, std::milli>(
+                clk::duration(wake - post_ticks.load())).count());
+        }
+        CHECK((int)lat.size() == kPosts, "every post released its wait rather than timing out");
+        if ((int)lat.size() == kPosts) {
+            std::vector<double> s = lat;
+            std::sort(s.begin(), s.end());
+            const double med = s[s.size() / 2];
+            // 5 ms, and the loose bound is deliberate. What this arm CAN catch is a gross
+            // regression: reverting to winpthreads (15.6 ms) or widening the poll slice to tens
+            // of milliseconds. What it CANNOT do is separate the adaptive 0.5 ms slice from a
+            // flat 2 ms one, and an earlier revision of this arm claimed exactly that with a
+            // 0.8 ms bound - it failed 3 runs in 5. The reason is measured: a short
+            // high-resolution-timer sleep on this host has a ~0.52 ms floor whatever is
+            // requested, so the two designs give median latencies of roughly 0.5 and 1.0 ms and
+            // their run-to-run spread overlaps. Tightening the bound until it passed would have
+            // produced a flaky arm; claiming the discrimination it cannot make would have been
+            // worse. The slice length is documented at the call site instead, with its
+            // measurement.
+            CHECK(med < 5.0,
+                  "median wake latency is milliseconds-not-ticks: no reversion to the 15.6 ms path");
+            printf("         (wake latency: median %.3f ms, min %.3f, max %.3f over %d posts)\n",
+                   med, s.front(), s.back(), kPosts);
+        }
+    }
+
+    // ARM 3 - an ALREADY-posted semaphore costs nothing and never enters the loop.
+    {
+        post(handle, 0, 0, 0, 0, 0);
+        const auto t0 = clk::now();
+        const uint64_t rc = timedwait(handle, 1000000, 0, 0, 0, 0);
+        const double ms = ms_since(t0);
+        CHECK(rc == 0, "an already-posted semaphore is acquired");
+        CHECK(ms < 1.0, "...immediately, via the trywait fast path");
+        printf("         (fast path took %.3f ms)\n", ms);
+    }
+
+    printf(fails ? "FAILED (%d)\n" : "PASSED\n", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Refs #3013. Refs #3033. Fourth slice of the #2984 recovery.

## The defect

On Windows `sem_timedwait` is winpthreads', whose timed waits resolve on its own master tick regardless
of `timeBeginPeriod` — **15.57 ms** measured for a 5.33 ms request (#3013's probe, with its
posted-semaphore control). FMOD's mixer paces 256-frame blocks on exactly this call, so a guest asking
for one grain was released once per tick and delivered audio at roughly a third of real time
(*Blasphemous 2*, #2985). #3022 fixed the sleep primitives and deliberately left this one alone.

## Two departures from the recovered form (`c45debbf`)

**POSIX is left alone.** That commit polled on every platform. Where `sem_timedwait` already honours the
deadline, polling replaces one exact wait with a loop that is worse on both latency *and* CPU. The tick
is a Windows property, so the workaround is `#ifdef`-scoped and POSIX keeps the native call.

**The poll interval is adaptive, not a flat 2 ms.** A *posted* semaphore returns in **0.01 ms**
natively, so any poll loop trades wake latency for timeout accuracy. A flat 2 ms slice costs up to 2 ms
on every wake — 37% of the grain period this exists to serve. Fine slices while the wait is young keep
pacing tight; coarse slices afterwards stop a guest parked for seconds from spinning.

## The fine slice is 500 µs because that is the measured floor

Not a chosen number. A short high-resolution-timer sleep on this host, 200 samples per row:

| requested | median | min | p90 | max |
| --- | --- | --- | --- | --- |
| 0.05 ms | **0.519** | 0.103 | 0.533 | 0.885 |
| 0.10 ms | **0.519** | 0.459 | 0.531 | 1.049 |
| 0.20 ms | **0.518** | 0.472 | 0.536 | 0.994 |
| 0.50 ms | 1.017 | 0.508 | 1.525 | 2.572 |
| 2.00 ms | 2.066 | 2.013 | 2.535 | 2.901 |

Anything under ~0.5 ms costs 0.52 ms. An earlier revision asked for 200 µs, which reads as a tighter
loop than the machine can run and would mislead whoever tunes it next. So the fine window buys a poll
interval ~4× shorter than the coarse one, not the 10× the constants implied.

## The test, and why its history matters more than its result

Two arms that constrain each other — timeout accuracy and wake latency. Pinning only the first would
let a future change widen the slice to 50 ms and stay green; pinning only the second would let it revert
to the 15.6 ms path. **Both arms had to be rewritten, and both for reasons this project keeps recording:**

1. The wake arm first scheduled a post with `std::this_thread::sleep_for` and asserted the total elapsed
   time. **It failed** — because the *poster's* sleep is subject to the same tick under test, so a "5 ms"
   post landed at ~12 ms and the arm blamed the subject for its own harness. Instrument and subject
   shared a defect. It now records when the post actually happened and asserts a latency.
2. Its bound was then 0.8 ms on the median, claiming to separate the adaptive slice from a flat 2 ms one.
   **That failed 3 runs in 5** — and the floor table above says why: the two designs give medians near
   0.5 and 1.0 ms and their run-to-run spreads overlap. Rather than tighten until green (a flaky arm) or
   keep a claim the measurement cannot support, the bound is 5 ms and the comment states what the arm can
   and cannot discriminate. It catches reversion to the tick and a grossly widened slice; it does not
   adjudicate 0.5 against 2 ms.

## Verification (exact head)

```
cmake --build prosper/build-mingw-app -j8                       # exit 0
ctest --test-dir prosper/build-mingw-app --no-tests=error -j4    # exit 0
100% tests passed, 0 tests failed out of 246
```

The new case passes **6 of 6** consecutive runs: timeout 5.01–5.65 ms (against 15.57 unfixed), median
wake latency 0.07–1.49 ms.

## Affected / unaffected

- **Affected:** `k_sem_timedwait` on Windows only.
- **Unaffected:** POSIX (same native call, same semantics); the fast paths — an already-posted semaphore
  is taken by `sem_trywait` without entering the loop, measured at 0.000 ms.
- **Not addressed:** `k_cond_timedwait` and `k_mutex_timedlock` still take the native path. They are
  censused (#3022) and no title measured so far paces audio on them. The census on *Blasphemous 2* now
  shows `sceCondTimedwait` at **x2.29** (0.818 ms requested → 1.870 ms actual), which is a real
  overshoot on a low call count. Filed as **#3056**, where I argued *against* fixing it: 11 calls per
  5 s window is not a pacing loop, and its 0.818 ms request is already close to the ~0.52 ms
  high-resolution-timer floor measured above, so a precise-sleep poll loop could not serve it much
  better than 2x anyway.

## Risk

The Windows path is now a poll loop, which burns CPU where a blocking wait did not: at most one wake per
0.5 ms per waiting thread in the first 8 ms, then one per 2 ms. That is the cost of the tick and it is
bounded, but it is a real trade and the main thing to review — particularly whether a title that parks
many threads on short semaphore timeouts would notice.

- **#3062** — the handle-backed alternative to this poll loop (`WaitForMultipleObjects` over a Win32
  semaphore plus a high-resolution timer), filed as a design candidate with the measured cost of the
  poll approach and the trap that a plain `WaitForSingleObject` timeout is itself tick-quantized.
  Cross-linked from #3056, since it is the same decision as the cond/mutex half.
