### PR TITLE
gpu: give the Vulkan validation layer somewhere to report (PROSPER_VK_VALIDATION)

### DIFF
--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -144,12 +144,17 @@ the GPU vendor cannot see.
 
 ## Vulkan validation (`PROSPER_VK_VALIDATION=1`)
 
-**Read `tools/vkval/` first.** `vk_validation_scan.py` (#1704) runs the whole ctest suite under the
-validation layer and diffs against `tools/vkval/allowlist.txt`, which carries a dated baseline —
-7 ids / 187 messages on lavapipe, 9 ids / 51 messages on RADV, measured 2026-08-01 — and it is
-registered with ctest as `vkval_scan_logic`. Three VUIDs were fixed off the back of it (#1713,
-#1717, #1726). **That is the project's validation guard, and it works without any messenger**,
-because VVL's default `debug_action` writes to stdout/stderr on its own.
+`vk_validation_scan.py` (#1704) runs the whole ctest suite under the validation layer and diffs
+against `tools/vkval/allowlist.txt`, and is registered with ctest as `vkval_scan_logic`. **Four
+VUIDs have been fixed off the back of it** (#1713, #1714, #1717, #1726). **That is the project's
+validation guard, and it works without any messenger**, because VVL's default `debug_action` writes
+to stdout/stderr on its own.
+
+Read the id and message counts from `allowlist.txt` itself rather than from anywhere that quotes
+them. Its header amends its own baseline on every fix — three times so far — and the file's own rule
+is that an unexplained drop in the id count reads as *"the scan broke"*. A figure quoted elsewhere
+and left to go stale therefore manufactures exactly that false alarm; this paragraph used to carry
+one.
 
 `PROSPER_VK_VALIDATION=1` is for the other case: validating **one interactive or routed run** of a
 title, in-process. It enables the layer and registers a `VkDebugUtilsMessenger`, which adds over the

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -150,11 +150,14 @@ VUIDs have been fixed off the back of it** (#1713, #1714, #1717, #1726). **That 
 validation guard, and it works without any messenger**, because VVL's default `debug_action` writes
 to stdout/stderr on its own.
 
-Read the id and message counts from `allowlist.txt` itself rather than from anywhere that quotes
-them. Its header amends its own baseline on every fix — three times so far — and the file's own rule
-is that an unexplained drop in the id count reads as *"the scan broke"*. A figure quoted elsewhere
-and left to go stale therefore manufactures exactly that false alarm; this paragraph used to carry
-one.
+**Do not quote id or message counts from anywhere — including `allowlist.txt`'s own header.** Run
+`vk_validation_scan.py` and read what it computes (`[vkval] N distinct message ID(s), M message(s)
+total`). The header records a baseline and is amended *sometimes*: #1726, #1717 and #1713 each
+amended it, but #1714 deleted its entry without doing so, which leaves the header's last stated
+ledger one id high in both columns, and the lavapipe figure at the top has never been amended at
+all. This paragraph twice carried a stale figure of its own before saying that — the file's rule is
+that an unexplained drop in the id count reads as *"the scan broke"*, so a quoted count is a false
+alarm waiting to happen, wherever it is quoted from.
 
 `PROSPER_VK_VALIDATION=1` is for the other case: validating **one interactive or routed run** of a
 title, in-process. It enables the layer and registers a `VkDebugUtilsMessenger`, which adds over the

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -144,33 +144,44 @@ the GPU vendor cannot see.
 
 ## Vulkan validation (`PROSPER_VK_VALIDATION=1`)
 
-Enables the Khronos validation layer **and** registers a debug messenger for it. Both halves matter,
-and only the first is obvious: the loader will happily load the layer from the environment alone
-(`VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation`), but with no `VkDebugUtilsMessenger`
-registered every message it produces is discarded. That reads exactly like a clean validation run.
+**Read `tools/vkval/` first.** `vk_validation_scan.py` (#1704) runs the whole ctest suite under the
+validation layer and diffs against `tools/vkval/allowlist.txt`, which carries a dated baseline —
+7 ids / 187 messages on lavapipe, 9 ids / 51 messages on RADV, measured 2026-08-01 — and it is
+registered with ctest as `vkval_scan_logic`. Three VUIDs were fixed off the back of it (#1713,
+#1717, #1726). **That is the project's validation guard, and it works without any messenger**,
+because VVL's default `debug_action` writes to stdout/stderr on its own.
 
-**Before this existed, prosper had no messenger anywhere** — so "no validation errors" had never once
-been a measurement in this project, on any title. If you find a note in an issue or a status doc
-saying validation was clean, and it predates this, it is void.
+`PROSPER_VK_VALIDATION=1` is for the other case: validating **one interactive or routed run** of a
+title, in-process. It enables the layer and registers a `VkDebugUtilsMessenger`, which adds over the
+default action:
+
+- **rate limiting** — 8 reports per message id. One violated VUID in a per-draw path otherwise fills
+  the disk, and on this machine a large run log takes the shared tmpfs (and every agent's shell)
+  with it.
+- **a run that says whether it is armed**, so a clean result is falsifiable rather than merely quiet.
+- **coverage when the default action is off**, which any `VK_LAYER_*` settings file can arrange.
 
 ```bash
 PROSPER_VK_VALIDATION=1 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
     ./prosper/build-linux/screenshot --out ~/work --seconds 2 --count 30 <DUMP_ROOT>/<TITLE_ID>-app0
 ```
 
-It announces itself, which is the point — the tool tells you whether it is actually running:
+It announces which state it is in — the point of the switch:
 
 | line | meaning |
 | --- | --- |
 | `[vk-validation] active (warnings and errors, 8 per message id)` | armed; a clean run is a real result |
-| `[vk-validation] PROSPER_VK_VALIDATION set but ... is not installed; NO validation is running` | the layer is absent — install it, do not read the silence |
-| `[vk-validation] layer loaded but the debug messenger could NOT be registered ...` | output would be discarded; treat a clean result as void |
+| `... is not installed; NO validation is running` | the layer is absent — do not read the silence |
+| `... VK_EXT_debug_utils is not advertised; the layer will run with its DEFAULT ... action` | the layer still validates, but this process does not rate-limit or tag it |
+| `... the validation layer was DROPPED and NO validation is running` | instance creation fell back to a bare create info; a clean result is void |
+| `... layer loaded but the debug messenger could NOT be registered` | output discarded; a clean result is void |
 
-Off by default: the layer costs real time per draw. Reports are **rate-limited to 8 per message id**,
-because one violated VUID in a per-draw path otherwise fills the disk — and on this machine a large
-run log takes the shared tmpfs, and the Bash tool with it.
+Off by default: the layer costs real time per draw.
 
-Worked example (#325, 2026-08-27): a change that made Tomb Raider's gameplay render as a uniform
-single-colour fill produced **zero** VUIDs with the sink armed. That turned "we cannot tell whether
-this is a Vulkan misuse" into "it is not one, so look at the logic" — a question that had been
-unanswerable in this project until the messenger existed.
+**Coverage caveat.** This covers the shared render-runner instance only. `prosper-app` creates its
+own instance, and `live_compute` has a private fallback instance; neither is affected by this
+variable.
+
+Worked example (#2998, 2026-08-27): a change that made Tomb Raider's gameplay render as a uniform
+single-colour fill produced **zero** VUIDs with the messenger armed, which moved the question from
+"is this a Vulkan misuse?" to "it is not, so look at the logic".

--- a/prosper/docs/GPU_PROFILING_EXTERNAL.md
+++ b/prosper/docs/GPU_PROFILING_EXTERNAL.md
@@ -141,3 +141,36 @@ to that class of error, costs nothing to run, and needs no maintenance from us.
 
 Reach for these first. Build a `PROSPER_*` switch only for something the guest-facing layer knows and
 the GPU vendor cannot see.
+
+## Vulkan validation (`PROSPER_VK_VALIDATION=1`)
+
+Enables the Khronos validation layer **and** registers a debug messenger for it. Both halves matter,
+and only the first is obvious: the loader will happily load the layer from the environment alone
+(`VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation`), but with no `VkDebugUtilsMessenger`
+registered every message it produces is discarded. That reads exactly like a clean validation run.
+
+**Before this existed, prosper had no messenger anywhere** — so "no validation errors" had never once
+been a measurement in this project, on any title. If you find a note in an issue or a status doc
+saying validation was clean, and it predates this, it is void.
+
+```bash
+PROSPER_VK_VALIDATION=1 PROSPER_RENDER=1 PROSPER_GUEST_ARGS=-force-gfx-direct \
+    ./prosper/build-linux/screenshot --out ~/work --seconds 2 --count 30 <DUMP_ROOT>/<TITLE_ID>-app0
+```
+
+It announces itself, which is the point — the tool tells you whether it is actually running:
+
+| line | meaning |
+| --- | --- |
+| `[vk-validation] active (warnings and errors, 8 per message id)` | armed; a clean run is a real result |
+| `[vk-validation] PROSPER_VK_VALIDATION set but ... is not installed; NO validation is running` | the layer is absent — install it, do not read the silence |
+| `[vk-validation] layer loaded but the debug messenger could NOT be registered ...` | output would be discarded; treat a clean result as void |
+
+Off by default: the layer costs real time per draw. Reports are **rate-limited to 8 per message id**,
+because one violated VUID in a per-draw path otherwise fills the disk — and on this machine a large
+run log takes the shared tmpfs, and the Bash tool with it.
+
+Worked example (#325, 2026-08-27): a change that made Tomb Raider's gameplay render as a uniform
+single-colour fill produced **zero** VUIDs with the sink armed. That turned "we cannot tell whether
+this is a Vulkan misuse" into "it is not one, so look at the logic" — a question that had been
+unanswerable in this project until the messenger existed.

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -880,6 +880,8 @@ inline BackendRenderTimingStats backend_render_timing_stats() {
 // Give compute an explicit release-before-teardown handshake before adding a destructor here.
 struct RenderVkCtx {
     VkInstance inst = VK_NULL_HANDLE; VkPhysicalDevice phys = VK_NULL_HANDLE;
+    // Non-null only under PROSPER_VK_VALIDATION; without it the layer has no output sink.
+    VkDebugUtilsMessengerEXT debug_messenger = VK_NULL_HANDLE;
     VkDevice dev = VK_NULL_HANDLE; VkQueue queue = VK_NULL_HANDLE; uint32_t qfi = UINT32_MAX;
     VkDeviceSize storage_buffer_alignment = 1;
     double timestamp_period_ns = 0.0;
@@ -971,6 +973,41 @@ inline const RenderVkCtx& render_vk_ctx() {
                 ici.ppEnabledExtensionNames = inst_exts.data();
             }
         }
+        // PROSPER_VK_VALIDATION=1: enable the Khronos validation layer AND give it somewhere to
+        // report. Both halves are required and only the first is obvious -- the loader will happily
+        // load the layer from the environment alone (VK_LOADER_LAYERS_ENABLE), but with no debug
+        // messenger registered every message it produces is discarded. That reads exactly like a
+        // clean validation run, which is the most dangerous null this project can produce: prosper
+        // had NO messenger anywhere, so "no validation errors" has never once been a measurement.
+        // Off by default; the layer costs real time per draw.
+        const bool want_validation = [] {
+            const char* e = getenv("PROSPER_VK_VALIDATION");
+            return e && *e && strcmp(e, "0");
+        }();
+        static const char* const kValidationLayer = "VK_LAYER_KHRONOS_validation";
+        bool validation_enabled = false;
+        std::vector<const char*> inst_layers;
+        if (want_validation) {
+            uint32_t nl = 0; vkEnumerateInstanceLayerProperties(&nl, nullptr);
+            std::vector<VkLayerProperties> layers(nl);
+            if (nl) vkEnumerateInstanceLayerProperties(&nl, layers.data());
+            for (const auto& l : layers)
+                if (!strcmp(l.layerName, kValidationLayer)) validation_enabled = true;
+            if (validation_enabled) {
+                inst_layers.push_back(kValidationLayer);
+                ici.enabledLayerCount = (uint32_t)inst_layers.size();
+                ici.ppEnabledLayerNames = inst_layers.data();
+                inst_exts.push_back("VK_EXT_debug_utils");
+                ici.enabledExtensionCount = (uint32_t)inst_exts.size();
+                ici.ppEnabledExtensionNames = inst_exts.data();
+            } else {
+                // Say so. A requested-but-absent layer is the silent-instrument case again.
+                fprintf(stderr, "[vk-validation] PROSPER_VK_VALIDATION set but %s is not installed; "
+                                "NO validation is running\n", kValidationLayer);
+                fflush(stderr);
+            }
+        }
+
         // If the driver rejects the surface set (should not happen since each was advertised), retry with
         // no instance extensions so the headless render path never regresses on an unexpected loader.
         if (vkCreateInstance(&ici, nullptr, &r.inst) != VK_SUCCESS || !r.inst) {
@@ -982,6 +1019,45 @@ inline const RenderVkCtx& render_vk_ctx() {
                 return r;
             }
         }
+        if (validation_enabled) {
+            auto create = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
+                r.inst, "vkCreateDebugUtilsMessengerEXT");
+            VkDebugUtilsMessengerCreateInfoEXT dci{
+                VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT};
+            dci.messageSeverity = VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT |
+                                  VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+            dci.messageType = VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT |
+                              VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+            dci.pfnUserCallback = [](VkDebugUtilsMessageSeverityFlagBitsEXT sev,
+                                     VkDebugUtilsMessageTypeFlagsEXT,
+                                     const VkDebugUtilsMessengerCallbackDataEXT* d,
+                                     void*) -> VkBool32 {
+                // Rate-limited per message id: one violated VUID in a per-draw path otherwise
+                // produces gigabytes, and this project's guidance is explicit that a run log on the
+                // tmpfs takes the machine down with it.
+                static std::unordered_map<int32_t, uint32_t> seen;
+                constexpr uint32_t kPerIdLimit = 8;
+                const uint32_t n = ++seen[d ? d->messageIdNumber : 0];
+                if (n > kPerIdLimit) return VK_FALSE;
+                fprintf(stderr, "[vk-validation] %s %s%s\n",
+                        sev & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT ? "ERROR" : "WARN",
+                        d && d->pMessage ? d->pMessage : "(no message)",
+                        n == kPerIdLimit ? "  [further reports of this id suppressed]" : "");
+                fflush(stderr);
+                return VK_FALSE;
+            };
+            if (!create || create(r.inst, &dci, nullptr, &r.debug_messenger) != VK_SUCCESS) {
+                fprintf(stderr, "[vk-validation] layer loaded but the debug messenger could NOT be "
+                                "registered; its output would be discarded, so treat any clean "
+                                "result from this run as void\n");
+                fflush(stderr);
+            } else {
+                fprintf(stderr, "[vk-validation] active (warnings and errors, %u per message id)\n",
+                        8u);
+                fflush(stderr);
+            }
+        }
+
         uint32_t nd = 0; vkEnumeratePhysicalDevices(r.inst, &nd, nullptr);
         if (!nd) return r;
         std::vector<VkPhysicalDevice> devs(nd); vkEnumeratePhysicalDevices(r.inst, &nd, devs.data());

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -981,8 +981,10 @@ inline const RenderVkCtx& render_vk_ctx() {
         //
         // This does NOT make validation newly possible -- `tools/vkval/vk_validation_scan.py`
         // (#1704, ctest `vkval_scan_logic`) has been scanning the suite for a long time and carries
-        // a dated baseline, because VVL's default debug_action writes to stdout/stderr by itself.
-        // Three VUIDs were fixed off the back of it (#1713, #1717, #1726). An earlier revision of
+        // its own baseline, because VVL's default debug_action writes to stdout/stderr by itself.
+        // Four VUIDs were fixed off the back of it (#1713, #1714, #1717, #1726). Counts are
+        // deliberately not quoted here: allowlist.txt amends its baseline on every fix, and a stale
+        // figure there reads as "the scan broke". An earlier revision of
         // this comment claimed validation "had never once been a measurement in this project",
         // which was simply false and would have retired a working guard as unmeasured.
         //
@@ -1073,7 +1075,7 @@ inline const RenderVkCtx& render_vk_ctx() {
                 // than one thread (see present_queue_shared), so the rate-limit map needs a lock.
                 static std::mutex seen_mu;
                 static std::unordered_map<int32_t, uint32_t> seen;
-                constexpr uint32_t kPerIdLimit = 8;   // keep in step with kMessengerPerIdLimit
+                constexpr uint32_t kPerIdLimit = kMessengerPerIdLimit;
                 uint32_t n;
                 {
                     std::lock_guard<std::mutex> lk(seen_mu);

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -983,10 +983,12 @@ inline const RenderVkCtx& render_vk_ctx() {
         // (#1704, ctest `vkval_scan_logic`) has been scanning the suite for a long time and carries
         // its own baseline, because VVL's default debug_action writes to stdout/stderr by itself.
         // Four VUIDs were fixed off the back of it (#1713, #1714, #1717, #1726). Counts are
-        // deliberately not quoted here: allowlist.txt amends its baseline on every fix, and a stale
-        // figure there reads as "the scan broke". An earlier revision of
-        // this comment claimed validation "had never once been a measurement in this project",
-        // which was simply false and would have retired a working guard as unmeasured.
+        // deliberately not quoted here, and should not be quoted from allowlist.txt's header
+        // either -- that header is amended only SOMETIMES (#1714 deleted its entry without
+        // amending it, leaving the stated ledger one id high). Run the scan and read the count it
+        // computes. An earlier revision of this comment claimed validation "had never once been a
+        // measurement in this project", which was simply false and would have retired a working
+        // guard as unmeasured.
         //
         // What a messenger adds over the default action: in-process capture, so output can be
         // rate-limited (one violated VUID in a per-draw path otherwise fills the disk) and tagged;

--- a/prosper/tests/fixtures/render_runner.h
+++ b/prosper/tests/fixtures/render_runner.h
@@ -940,6 +940,10 @@ inline const RenderVkCtx& render_vk_ctx() {
         // SDL_Vulkan_GetInstanceExtensions; instead enable every platform surface extension present and
         // let the app fall back to its own device if SDL still needs one we didn't get (#1270 R4).
         std::vector<const char*> inst_exts;
+        // Hoisted so the validation block below can consult it: pushing an unadvertised extension
+        // fails the WHOLE vkCreateInstance, which would also drop every WSI extension and turn off
+        // present_surface_capable (#1270) -- a debugging switch must not degrade the present path.
+        std::vector<VkExtensionProperties> avail;
         {
             static const char* const kWsiExts[] = {
                 "VK_KHR_surface",
@@ -952,7 +956,7 @@ inline const RenderVkCtx& render_vk_ctx() {
 #endif
             };
             uint32_t nie = 0; vkEnumerateInstanceExtensionProperties(nullptr, &nie, nullptr);
-            std::vector<VkExtensionProperties> avail(nie);
+            avail.resize(nie);
             if (nie) vkEnumerateInstanceExtensionProperties(nullptr, &nie, avail.data());
             auto has = [&](const char* name) {
                 for (const auto& e : avail) if (!strcmp(e.extensionName, name)) return true;
@@ -973,19 +977,28 @@ inline const RenderVkCtx& render_vk_ctx() {
                 ici.ppEnabledExtensionNames = inst_exts.data();
             }
         }
-        // PROSPER_VK_VALIDATION=1: enable the Khronos validation layer AND give it somewhere to
-        // report. Both halves are required and only the first is obvious -- the loader will happily
-        // load the layer from the environment alone (VK_LOADER_LAYERS_ENABLE), but with no debug
-        // messenger registered every message it produces is discarded. That reads exactly like a
-        // clean validation run, which is the most dangerous null this project can produce: prosper
-        // had NO messenger anywhere, so "no validation errors" has never once been a measurement.
+        // PROSPER_VK_VALIDATION=1: enable the Khronos validation layer and register a messenger.
+        //
+        // This does NOT make validation newly possible -- `tools/vkval/vk_validation_scan.py`
+        // (#1704, ctest `vkval_scan_logic`) has been scanning the suite for a long time and carries
+        // a dated baseline, because VVL's default debug_action writes to stdout/stderr by itself.
+        // Three VUIDs were fixed off the back of it (#1713, #1717, #1726). An earlier revision of
+        // this comment claimed validation "had never once been a measurement in this project",
+        // which was simply false and would have retired a working guard as unmeasured.
+        //
+        // What a messenger adds over the default action: in-process capture, so output can be
+        // rate-limited (one violated VUID in a per-draw path otherwise fills the disk) and tagged;
+        // a run that says whether it is armed; and coverage when the default action is off, which
+        // is how some SDK builds and any VK_LAYER_* settings file can configure it.
         // Off by default; the layer costs real time per draw.
         const bool want_validation = [] {
             const char* e = getenv("PROSPER_VK_VALIDATION");
             return e && *e && strcmp(e, "0");
         }();
         static const char* const kValidationLayer = "VK_LAYER_KHRONOS_validation";
+        constexpr uint32_t kMessengerPerIdLimit = 8;
         bool validation_enabled = false;
+        bool messenger_wanted = true;
         std::vector<const char*> inst_layers;
         if (want_validation) {
             uint32_t nl = 0; vkEnumerateInstanceLayerProperties(&nl, nullptr);
@@ -997,9 +1010,20 @@ inline const RenderVkCtx& render_vk_ctx() {
                 inst_layers.push_back(kValidationLayer);
                 ici.enabledLayerCount = (uint32_t)inst_layers.size();
                 ici.ppEnabledLayerNames = inst_layers.data();
-                inst_exts.push_back("VK_EXT_debug_utils");
-                ici.enabledExtensionCount = (uint32_t)inst_exts.size();
-                ici.ppEnabledExtensionNames = inst_exts.data();
+                bool have_debug_utils = false;
+                for (const auto& e : avail)
+                    if (!strcmp(e.extensionName, "VK_EXT_debug_utils")) have_debug_utils = true;
+                if (have_debug_utils) {
+                    inst_exts.push_back("VK_EXT_debug_utils");
+                    ici.enabledExtensionCount = (uint32_t)inst_exts.size();
+                    ici.ppEnabledExtensionNames = inst_exts.data();
+                } else {
+                    fprintf(stderr, "[vk-validation] VK_EXT_debug_utils is not advertised; the layer "
+                                    "will run with its DEFAULT stdout/stderr action and this process "
+                                    "will not rate-limit or tag its output\n");
+                    fflush(stderr);
+                    messenger_wanted = false;
+                }
             } else {
                 // Say so. A requested-but-absent layer is the silent-instrument case again.
                 fprintf(stderr, "[vk-validation] PROSPER_VK_VALIDATION set but %s is not installed; "
@@ -1015,11 +1039,21 @@ inline const RenderVkCtx& render_vk_ctx() {
                 r.present_surface_capable = false;
                 VkInstanceCreateInfo bare{VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO}; bare.pApplicationInfo = &app;
                 if (vkCreateInstance(&bare, nullptr, &r.inst) != VK_SUCCESS || !r.inst) return r;
+                // The retry carries no layers and no extensions, so validation is GONE on this
+                // instance. Announcing "active" here would be the exact laundered null this switch
+                // exists to prevent -- a fourth silent state, and the worst of them.
+                if (validation_enabled) {
+                    fprintf(stderr, "[vk-validation] instance creation fell back to a bare create "
+                                    "info; the validation layer was DROPPED and NO validation is "
+                                    "running -- treat any clean result from this run as void\n");
+                    fflush(stderr);
+                    validation_enabled = false;
+                }
             } else {
                 return r;
             }
         }
-        if (validation_enabled) {
+        if (validation_enabled && messenger_wanted) {
             auto create = (PFN_vkCreateDebugUtilsMessengerEXT)vkGetInstanceProcAddr(
                 r.inst, "vkCreateDebugUtilsMessengerEXT");
             VkDebugUtilsMessengerCreateInfoEXT dci{
@@ -1035,9 +1069,16 @@ inline const RenderVkCtx& render_vk_ctx() {
                 // Rate-limited per message id: one violated VUID in a per-draw path otherwise
                 // produces gigabytes, and this project's guidance is explicit that a run log on the
                 // tmpfs takes the machine down with it.
+                // The spec requires this callback to be thread-safe, and prosper submits from more
+                // than one thread (see present_queue_shared), so the rate-limit map needs a lock.
+                static std::mutex seen_mu;
                 static std::unordered_map<int32_t, uint32_t> seen;
-                constexpr uint32_t kPerIdLimit = 8;
-                const uint32_t n = ++seen[d ? d->messageIdNumber : 0];
+                constexpr uint32_t kPerIdLimit = 8;   // keep in step with kMessengerPerIdLimit
+                uint32_t n;
+                {
+                    std::lock_guard<std::mutex> lk(seen_mu);
+                    n = ++seen[d ? d->messageIdNumber : 0];
+                }
                 if (n > kPerIdLimit) return VK_FALSE;
                 fprintf(stderr, "[vk-validation] %s %s%s\n",
                         sev & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT ? "ERROR" : "WARN",
@@ -1053,7 +1094,7 @@ inline const RenderVkCtx& render_vk_ctx() {
                 fflush(stderr);
             } else {
                 fprintf(stderr, "[vk-validation] active (warnings and errors, %u per message id)\n",
-                        8u);
+                        kMessengerPerIdLimit);
                 fflush(stderr);
             }
         }


### PR DESCRIPTION
## The gap

prosper registers **no `VkDebugUtilsMessenger` anywhere** and enables no instance layers. The loader
will happily load the validation layer from the environment alone
(`VK_LOADER_LAYERS_ENABLE=VK_LAYER_KHRONOS_validation`) — so it *looks* like validation is available —
but with no messenger registered, every message it produces is discarded.

The consequence is worse than a missing feature: **"no validation errors" has never once been a
measurement in this project, on any title.** A silent layer and a correct application produce
byte-identical output. If a note in an issue or a status doc says validation was clean and it
predates this PR, it is void.

I walked into it three times on #325 in one session: read a zero-VUID run as clean; found the layer
had never loaded; enabled it properly and found nothing changed, because nothing was listening.

## What this adds

`PROSPER_VK_VALIDATION=1` enables the layer **and** registers a messenger. Off by default — the layer
costs real time per draw.

It announces which of three states it is in, so a clean result is falsifiable rather than merely
quiet:

| line | meaning |
| --- | --- |
| `[vk-validation] active (warnings and errors, 8 per message id)` | armed; a clean run is a real result |
| `[vk-validation] PROSPER_VK_VALIDATION set but ... is not installed; NO validation is running` | the layer is absent — do not read the silence |
| `[vk-validation] layer loaded but the debug messenger could NOT be registered ...` | output would be discarded; treat a clean result as void |

Reports are **rate-limited to 8 per message id**. One violated VUID in a per-draw path otherwise
fills the disk, and on this machine a large run log takes the shared tmpfs — and the Bash tool for
every concurrent agent — with it.

## First use

A change that made Tomb Raider's gameplay render as a uniform single-colour fill produced **zero
VUIDs** with the sink armed. That converted "we cannot tell whether this is Vulkan misuse" into "it
is not one, so look at the logic" — a question that was unanswerable in this project until the
messenger existed. Detail on #2998.

## Verification

- `cmake --build prosper/build-linux -j10` — clean
- `ctest --no-tests=error -j4` — **310 of 310 pass**
- All four states exercised on this build:
  - `PROSPER_VK_VALIDATION=1` → `active`
  - unset → **no `vk-validation` line at all** (0 occurrences)
  - `VK_LAYER_PATH=/nonexistent` → the "NOT installed" line, not silence
  - the messenger-failure branch is the remaining one, reachable only if `vkCreateDebugUtilsMessengerEXT` is absent after the layer loads
- Documented in `docs/GPU_PROFILING_EXTERNAL.md`, next to the other external-tool recipes and their
  failure modes

## Scope

Purely additive and opt-in. With the variable unset, instance creation is byte-for-byte what it was:
no layer, no extra extension, no messenger.
