### PR TITLE
diag(#2998): PROSPER_SLICEMAP and PROSPER_FORCE_LAYER for guest array textures

### DIFF
--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,11 +120,17 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
-- **The atlas is only ever ~4.75 MiB populated of its 86 MiB span** — falsified 2026-08-27. The
-  `[occupancy]` reading `filled=18/344` is an observation at one instant, not a steady state. With
-  the write trace armed at bucket 200 (`offset=0x83cc000`, target `0x204c3cc000`) the upper atlas
-  takes **32 events, `selected=yes changed-during-window=yes`**, against a positive control at
-  bucket 0 that also fired 32. Do not restart "the guest never fills the upper atlas". (#2998)
+- **The atlas is only ever ~4.75 MiB populated of its 86 MiB span, for the whole run** — falsified
+  2026-08-27, but **read the scope before using this**. With the write trace armed at bucket 200
+  (`offset=0x83cc000`, target `0x204c3cc000`) that bucket takes **32 events, `selected=yes
+  changed-during-window=yes`**, against a positive control at bucket 0 that also fired 32. So the
+  allocation is filled progressively and `filled=19/344` is one instant, not a steady state.
+  **What this does NOT establish:** bucket 200 is byte 52,428,800, i.e. slice **148.8** at
+  `layer_stride=352256` — it sits *below* the interior's slices 186-248, which are buckets
+  **249.9-333.2**. This probe never touched the region the interior samples, and the separate
+  finding that slice 248 reads zero throughout still stands (re-confirmed 2026-08-27). An earlier
+  version of this row said "do not restart 'the guest never fills the upper atlas'" without that
+  qualification, which overstated a probe taken below the range in question. (#2998)
 - **A stale persistent decode cache holds an early, near-empty snapshot** — falsified 2026-08-27.
   `PROSPER_NO_TEXTURE_DECODE_CACHE=1` over `scripts/tomb-raider-PPSA16901/reach-gameplay.pad`
   changes nothing: the atlas still decodes once. Caveat on the instrument: `[occupancy]` is gated
@@ -138,22 +144,31 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 - **The guest CPU writer of the atlas cannot be observed** — falsified 2026-08-27, and the cause
   was an allocator, not the watchpoint. `PROSPER_DMEM_WRITE_TRACE` could not target this title
   because only `sceKernelAllocateMainDirectMemory` published a caller chain, while the title
-  allocates through `sceKernelAllocateDirectMemory`. With both entry points sharing one attribution
-  helper the writer is named immediately: `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing
-  8x16 B per iteration to offsets computed in `%ymm10`. (#2998, #3054)
+  allocates through `sceKernelAllocateDirectMemory`, which minted none — so no selector could name
+  a byte it owns. With both entry points sharing one attribution helper the writer is named
+  immediately: `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per iteration to
+  offsets computed in `%ymm10`.
+  **Reproduction needs code that is NOT on master.** `attribute_dmem_allocation` is not in this PR
+  and not in `origin/master`; it is tracked in **#3054**. Until it lands, the recipe below reports
+  `caller-chain=0` for this title and the trace refuses to arm — which is the very failure the row
+  retires, so do not read a failed arm as contradicting it. (#2998, #3054)
 
 - **Nothing maps into the atlas per-slice, and no host/kernel write streams into it** — both with
   controls, both new instruments. `PROSPER_MAPWATCH` sees one 1 GiB `map_dmem` covering the atlas,
   established once, never per-slice (control: watching all of dmem shows two maps).
   `PROSPER_HOSTWRITEWATCH` sees **zero** writes into the atlas while its control — the same watch
   over all of dmem — records **107**. So the ~18 slices that do arrive are written by guest CPU
-  stores, which no instrument in the tree can observe.
+  stores, which no instrument in the tree could observe **when this was written**. Superseded
+  2026-08-27: they are observable now — see the writer row in `## Ruled out` (`eboot+0xebb82..`),
+  which also records why the trace could not previously be aimed at this title.
   That is what makes **#3054** the blocking tool: `PROSPER_HWWATCH` is register-relative and cannot
   arm on a fixed guest address, so the one mechanism that would catch a plain guest store is
   unreachable through its current interface.
 
-- **The atlas allocation contains about 4.75 MB of content and nothing else, measured WITHOUT any
-  stride assumption.** `PROSPER_OCCUPANCY=1` walks the guest allocation in 256 KiB buckets and asks
+- **At the moment prosper decodes it, the atlas allocation holds about 4.75 MB of content and
+  nothing above it, measured WITHOUT any stride assumption.** (Scope corrected 2026-08-27: this is
+  one instant, not the whole run. Bucket 200 is written later — see `## Ruled out`. The interior's
+  own slices 186-248, buckets 249.9-333.2, are a separate question and remain unwritten.) `PROSPER_OCCUPANCY=1` walks the guest allocation in 256 KiB buckets and asks
   only "is there content here", so it cannot be fooled by a wrong per-slice layout — which every
   earlier measurement could, since they all addressed slices through `layer_stride`:
 
@@ -192,11 +207,12 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   receives about eighteen slices' worth. Whatever moves DDS content into this allocation is doing so
   for a small fraction of what the title loads.
 
-- **Everything on prosper's side of the interior defect is measured and correct; the atlas is
-  genuinely unpopulated in guest memory.** Twelve candidates eliminated, each with its control or
+- **Everything on prosper's side of the interior defect is measured and correct; the slices the
+  interior samples are genuinely unpopulated in guest memory.** (Scoped 2026-08-27 — see
+  `## Ruled out`.) Twelve candidates eliminated, each with its control or
   its stated scope: layer index (traced twice to a constant 248), flat interpolation (#3051, the
   title never sets FLAT_SHADE), mixed-slice triangles (constant per draw), stale decode cache (guest
-  memory probed ~138,000 times, never becomes non-zero), per-slice stride and mip offset (both
+  memory at the sampled slice probed ~138,000 times, never becomes non-zero), per-slice stride and mip offset (both
   layouts tested), `depth` mis-decode (raw T# confirms 256 / base_array 0), truncated reads
   (`short_reads=0`), partial residency (one `rw-s` mapping covers the whole span), base-address
   mis-decode (dword0 `<< 8` matches), compute STORE (control fired, no compute binds it), recorded
@@ -205,8 +221,10 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   remaining work is a forward investigation from the title's asset/streaming logic, not from the
   frame. Full evidence on #2998.
 
-- **The interior's wrong textures are not prosper mis-reading the atlas. The atlas is genuinely
-  almost empty in GUEST memory, for the whole run.** Measured, each point with the control that
+- **The interior's wrong textures are not prosper mis-reading the atlas. The slices the interior
+  samples are genuinely empty in GUEST memory for the whole run** — narrowed 2026-08-27 from "the
+  atlas is almost empty for the whole run", which is false: the allocation IS filled progressively
+  below slice ~149. The claim that survives is about the interior's OWN slice range. Measured, each point with the control that
   makes it mean something:
   - `PROSPER_SLICEMAP=1`: the 512x512x256 world atlas decodes with **slices 0-13 populated and
     14-255 empty** — contiguous, from the full 256-character map. **`short_reads=0`**, so every
@@ -214,7 +232,9 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
     scan samples one byte in 61.)
   - `PROSPER_SLICEWATCH=1` samples GUEST memory at slice 248 on the reuse path, which runs about
     138,000 times per route: it reads **zero on the first reference and never becomes non-zero**.
-    So the guest never fills it, at any point — which retires the decode-cache hypothesis properly.
+    So the guest never fills **slice 248**, at any point — which retires the decode-cache
+    hypothesis properly. Note the scope: this is one slice inside the interior's range, and is NOT
+    evidence about the allocation as a whole (`## Ruled out` records a write at bucket 200).
     An earlier attempt to retire it was **void**: the `PROSPER_NO_TEXTURE_DECODE_CACHE` run never
     left the title screen (its colour count sits at the title's ~210k for all 300 s), so its 233
     re-decodes all happened before the level streamed anything.
@@ -224,7 +244,8 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   - The world shader samples slice **248**, traced twice: `vertexIndex*24 + 3` from binding 7, a byte
     constant across all 4,206 vertices, through `OpBitFieldUExtract(dword, 24, 8)` to the fragment
     varying.
-  So the guest samples a slice that nothing ever wrote, and prosper reads that correctly. **The
+  So the guest samples a slice that nothing ever wrote — that slice, not the whole allocation —
+  and prosper reads that correctly. **The
   missing piece is an atlas upload path prosper does not perform**, not the array plumbing, which is
   now measured end to end. Compute is excluded; DMA is untested (a `PROSPER_DMA_WATCH_DST` run was
   silent but had no control, so it is not evidence).

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,21 +120,30 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
-- **The interior's wrong textures are NOT the layer index arriving wrong, NOT stale cache, NOT
-  interpolation, and NOT the stride.** What they are is still open, but the search space is much
-  smaller. Measured, in order:
-  - `PROSPER_SLICEMAP=1` (new): the 512x512x256 world atlas decodes with **14 of 256 slices holding
-    content**, all at the start of the range. The 2048x2048x29 array decodes **29 of 29**.
-  - The atlas is decoded **once** per run. With `PROSPER_NO_TEXTURE_DECODE_CACHE=1` it re-decodes
-    **233 times and reports 14 every time**, so a stale cache is not hiding later-streamed slices.
-  - The world shader asks for slice **248**: `vertexIndex*24 + 3` from binding 7, a byte that is
-    constant across all 4,206 vertices of the draw. Traced through
-    `OpBitFieldUExtract(dword, 24, 8)` to the fragment varying at Location 1.
-  - `PROSPER_FORCE_LAYER=248` produces a **completely different frame** from the unforced run
-    (262 colours vs 122,087), so the unforced draws are not all sampling 248 -- different draws use
-    different slices.
-  - `PROSPER_FORCE_LAYER=10` gives full-screen content (184,541 colours); **200 gives 262 colours,
-    almost entirely black**. Slices above the populated range are empty.
+- **The interior's wrong textures are not prosper mis-reading the atlas. The atlas is genuinely
+  almost empty in GUEST memory, for the whole run.** Measured, each point with the control that
+  makes it mean something:
+  - `PROSPER_SLICEMAP=1`: the 512x512x256 world atlas decodes with **slices 0-13 populated and
+    14-255 empty** — contiguous, from the full 256-character map. **`short_reads=0`**, so every
+    slice was read completely; "empty" here is not "unreadable". (The count is a lower bound: the
+    scan samples one byte in 61.)
+  - `PROSPER_SLICEWATCH=1` samples GUEST memory at slice 248 on the reuse path, which runs about
+    138,000 times per route: it reads **zero on the first reference and never becomes non-zero**.
+    So the guest never fills it, at any point — which retires the decode-cache hypothesis properly.
+    An earlier attempt to retire it was **void**: the `PROSPER_NO_TEXTURE_DECODE_CACHE` run never
+    left the title screen (its colour count sits at the title's ~210k for all 300 s), so its 233
+    re-decodes all happened before the level streamed anything.
+  - `PROSPER_COMPUTE_BINDS` over the atlas plus three controls: the one line printed is a **control**
+    — the compute program binds a different 4 MiB buffer and executes — so no compute STORE produces
+    this atlas.
+  - The world shader samples slice **248**, traced twice: `vertexIndex*24 + 3` from binding 7, a byte
+    constant across all 4,206 vertices, through `OpBitFieldUExtract(dword, 24, 8)` to the fragment
+    varying.
+  So the guest samples a slice that nothing ever wrote, and prosper reads that correctly. **The
+  missing piece is an atlas upload path prosper does not perform**, not the array plumbing, which is
+  now measured end to end. Compute is excluded; DMA is untested (a `PROSPER_DMA_WATCH_DST` run was
+  silent but had no control, so it is not evidence).
+
 - **`r.depth = 256` is NOT a mis-decode.** The raw descriptor (`PROSPER_TDUMP=512x512`) reads
   `t = 20491cc0 cb600000 007fc07f d0550fac 000000ff 00700050 00000000 00000000` ->
   `512x512 fmt=182 type=13 tile=5 mips=0..5 depth=256 base_array=0`. The layer count, the base slice

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,6 +120,25 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
+- **The atlas allocation contains about 4.75 MB of content and nothing else, measured WITHOUT any
+  stride assumption.** `PROSPER_OCCUPANCY=1` walks the guest allocation in 256 KiB buckets and asks
+  only "is there content here", so it cannot be fooled by a wrong per-slice layout — which every
+  earlier measurement could, since they all addressed slices through `layer_stride`:
+
+  ```
+  [occupancy] 0x20491cc000 span=86 MiB bucket=256KiB filled=18/344 last_filled_bucket=18
+  .##################...........(325 more)
+  ```
+
+  Content sits in buckets 1-18 and stops. The interior samples slices 186-248, which lie 48-87 MB
+  into the allocation. So the data those draws need is not in this allocation at ANY layout, and the
+  earlier per-slice findings were not artefacts of the stride the probes assumed.
+- **The title reads its textures; they simply do not arrive here.** `PROSPER_READBYTES=1` counts
+  bytes delivered per path with no stack walk: **`.DDS opened=299 read=297`** over a route, alongside
+  `.TRM 98/52` and smaller sets. So asset I/O works and 297 texture files are read, while this atlas
+  receives about eighteen slices' worth. Whatever moves DDS content into this allocation is doing so
+  for a small fraction of what the title loads.
+
 - **Everything on prosper's side of the interior defect is measured and correct; the atlas is
   genuinely unpopulated in guest memory.** Twelve candidates eliminated, each with its control or
   its stated scope: layer index (traced twice to a constant 248), flat interpolation (#3051, the

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,6 +120,25 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
+- **The interior's wrong textures are NOT the layer index arriving wrong, NOT stale cache, NOT
+  interpolation, and NOT the stride.** What they are is still open, but the search space is much
+  smaller. Measured, in order:
+  - `PROSPER_SLICEMAP=1` (new): the 512x512x256 world atlas decodes with **14 of 256 slices holding
+    content**, all at the start of the range. The 2048x2048x29 array decodes **29 of 29**.
+  - The atlas is decoded **once** per run. With `PROSPER_NO_TEXTURE_DECODE_CACHE=1` it re-decodes
+    **233 times and reports 14 every time**, so a stale cache is not hiding later-streamed slices.
+  - The world shader asks for slice **248**: `vertexIndex*24 + 3` from binding 7, a byte that is
+    constant across all 4,206 vertices of the draw. Traced through
+    `OpBitFieldUExtract(dword, 24, 8)` to the fragment varying at Location 1.
+  - `PROSPER_FORCE_LAYER=248` produces a **completely different frame** from the unforced run
+    (262 colours vs 122,087), so the unforced draws are not all sampling 248 -- different draws use
+    different slices.
+  - `PROSPER_FORCE_LAYER=10` gives full-screen content (184,541 colours); **200 gives 262 colours,
+    almost entirely black**. Slices above the populated range are empty.
+  So the guest indexes a slice our decoded array does not have content for. The leading remaining
+  question is whether `r.depth = 256` describes the guest array's real layer count at all -- if the
+  true array is ~16 layers, an index of 248 means something other than a layer.
+
 - **Missing SPIR-V `Flat` on the varying that carries the array slice is NOT why interiors sample
   the wrong layers.** The gap is real — `is_flat_shaded()` is decoded, used to build the guest's PS
   input control word, and never reaches the SPIR-V (#3051) — but this title never asks for it. A

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -135,9 +135,20 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
     different slices.
   - `PROSPER_FORCE_LAYER=10` gives full-screen content (184,541 colours); **200 gives 262 colours,
     almost entirely black**. Slices above the populated range are empty.
-  So the guest indexes a slice our decoded array does not have content for. The leading remaining
-  question is whether `r.depth = 256` describes the guest array's real layer count at all -- if the
-  true array is ~16 layers, an index of 248 means something other than a layer.
+- **`r.depth = 256` is NOT a mis-decode.** The raw descriptor (`PROSPER_TDUMP=512x512`) reads
+  `t = 20491cc0 cb600000 007fc07f d0550fac 000000ff 00700050 00000000 00000000` ->
+  `512x512 fmt=182 type=13 tile=5 mips=0..5 depth=256 base_array=0`. The layer count, the base slice
+  and the mip range are exactly what the decode reports, so the layer mapping is faithful and the
+  question is not "how many layers".
+- **Nor is it the slice LAYOUT.** With the array treated as fully tight -- stride = one selected-mip
+  surface AND no per-slice mip offset, the combination an earlier test got wrong by changing only the
+  stride -- the populated count moves 14 -> 19 of 256 and the interior is still wrong. Every layout
+  tried leaves the same invariant: **only about 5 MB of the atlas's 67 MB is non-zero**, whichever
+  way the slices are addressed.
+  So the remaining question is not how prosper reads the atlas but **why most of it was never
+  written**: the guest declares 256 slices at `0x20491cc000` and samples slice 248, while the memory
+  there is zero. That points at a content path prosper does not observe (a DMA or compute upload
+  into the atlas) rather than at the array plumbing, which is now measured end to end.
 
 - **Missing SPIR-V `Flat` on the varying that carries the array slice is NOT why interiors sample
   the wrong layers.** The gap is real — `is_flat_shaded()` is decoded, used to build the guest's PS

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,6 +120,19 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
+- **Everything on prosper's side of the interior defect is measured and correct; the atlas is
+  genuinely unpopulated in guest memory.** Twelve candidates eliminated, each with its control or
+  its stated scope: layer index (traced twice to a constant 248), flat interpolation (#3051, the
+  title never sets FLAT_SHADE), mixed-slice triangles (constant per draw), stale decode cache (guest
+  memory probed ~138,000 times, never becomes non-zero), per-slice stride and mip offset (both
+  layouts tested), `depth` mis-decode (raw T# confirms 256 / base_array 0), truncated reads
+  (`short_reads=0`), partial residency (one `rw-s` mapping covers the whole span), base-address
+  mis-decode (dword0 `<< 8` matches), compute STORE (control fired, no compute binds it), recorded
+  PM4 write paths (all four recorders armed, zero hits), and an unimplemented
+  `sceAgcDriverInitResourceRegistration` (its family is profiler labelling, not memory). The
+  remaining work is a forward investigation from the title's asset/streaming logic, not from the
+  frame. Full evidence on #2998.
+
 - **The interior's wrong textures are not prosper mis-reading the atlas. The atlas is genuinely
   almost empty in GUEST memory, for the whole run.** Measured, each point with the control that
   makes it mean something:

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,6 +120,28 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
+- **The atlas is only ever ~4.75 MiB populated of its 86 MiB span** — falsified 2026-08-27. The
+  `[occupancy]` reading `filled=18/344` is an observation at one instant, not a steady state. With
+  the write trace armed at bucket 200 (`offset=0x83cc000`, target `0x204c3cc000`) the upper atlas
+  takes **32 events, `selected=yes changed-during-window=yes`**, against a positive control at
+  bucket 0 that also fired 32. Do not restart "the guest never fills the upper atlas". (#2998)
+- **A stale persistent decode cache holds an early, near-empty snapshot** — falsified 2026-08-27.
+  `PROSPER_NO_TEXTURE_DECODE_CACHE=1` over `scripts/tomb-raider-PPSA16901/reach-gameplay.pad`
+  changes nothing: the atlas still decodes once. Caveat on the instrument: `[occupancy]` is gated
+  on `is_array && depth > 64`, so "one print" is **not** "one decode" — do not quote it as one.
+  (#2998)
+- **`base_array` is dropped between the T# and the uploader** — falsified 2026-08-27. It is
+  applied in `agc_shader_layout.cpp` `image_base_level_view()`:
+  `view.base += (uint64_t)d.base_array * stride;` with `view.layer_stride = stride` set alongside,
+  on the `thin_2d_layered` `depth > 1` path. `live_renderer.cpp` never names `base_array` because
+  the shift is already folded into `gpu_addr`, which is correct, not a gap. (#2998)
+- **The guest CPU writer of the atlas cannot be observed** — falsified 2026-08-27, and the cause
+  was an allocator, not the watchpoint. `PROSPER_DMEM_WRITE_TRACE` could not target this title
+  because only `sceKernelAllocateMainDirectMemory` published a caller chain, while the title
+  allocates through `sceKernelAllocateDirectMemory`. With both entry points sharing one attribution
+  helper the writer is named immediately: `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing
+  8x16 B per iteration to offsets computed in `%ymm10`. (#2998, #3054)
+
 - **Nothing maps into the atlas per-slice, and no host/kernel write streams into it** — both with
   controls, both new instruments. `PROSPER_MAPWATCH` sees one 1 GiB `map_dmem` covering the atlas,
   established once, never per-slice (control: watching all of dmem shows two maps).
@@ -136,16 +158,37 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   earlier measurement could, since they all addressed slices through `layer_stride`:
 
   ```
-  [occupancy] 0x20491cc000 span=86 MiB bucket=256KiB filled=18/344 last_filled_bucket=18
-  .##################...........(325 more)
+  [occupancy] 0x20491cc000 span=86 MiB bucket=256KiB FULL-BUCKET scan filled=19/344 scanned
+              (of 344 total) last_filled_bucket=18 unreadable=0
+  ###################...........(325 more)
   ```
 
-  Content sits in buckets 1-18 and stops. The interior samples slices 186-248, which lie 48-87 MB
-  into the allocation. So the data those draws need is not in this allocation at ANY layout, and the
-  earlier per-slice findings were not artefacts of the stride the probes assumed.
+  Content sits in buckets 0-18 and stops. At `layer_stride=352256` over `depth=256`, the interior's
+  slices 186-248 begin **65.5 MB** into the allocation and end at 87.4 MB. So the data those draws
+  need is not in this allocation *at the moment of decode*, at any layout, and the earlier per-slice
+  findings were not artefacts of the stride the probes assumed.
+
+  **Two corrections to what this box used to say.** The reading was `filled=18/344` with bucket 0
+  shown EMPTY, and the range was given as "48-87 MB". Both were wrong. `[occupancy]` sampled only
+  the first 512 B of each 256 KiB bucket (0.195%) and reported that head sample as a census, so a
+  bucket whose content began past the window read as empty -- which is exactly what happened to
+  bucket 0, and `[slicemap]` contradicted it at the time. It now scans every byte of each bucket and
+  distinguishes unreadable (`?`) from empty (`.`). The lower bound of the slice range was simple
+  arithmetic error. Neither changes the conclusion, and note the scope this box does NOT establish:
+  it is one observation at decode time, not a statement about the whole run -- see the entry below.
+
+- **The allocation is NOT static, and the upper region IS written later in the run.** With the write
+  trace armed at bucket 200 (`PROSPER_DMEM_WRITE_TRACE=2:0x40000000:0x83cc000:128`, target
+  `0x204c3cc000`) the upper atlas takes **32 events, `selected=yes changed-during-window=yes`**,
+  against a positive control at bucket 0 that also fires 32. So "the guest never fills the upper
+  atlas" is false; what the occupancy box above measures is the state at the one moment prosper
+  decodes. The writer is `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per
+  iteration to offsets computed in `%ymm10`.
 - **The title reads its textures; they simply do not arrive here.** `PROSPER_READBYTES=1` counts
-  bytes delivered per path with no stack walk: **`.DDS opened=299 read=297`** over a route, alongside
-  `.TRM 98/52` and smaller sets. So asset I/O works and 297 texture files are read, while this atlas
+  bytes delivered per path with no stack walk: **`.DDS open-events=299 paths-read=297`** over a
+  route, alongside `.TRM 98/52` and smaller sets. (Those two fields carry DIFFERENT units -- open
+  *events* against distinct *paths* read -- and were previously printed as `opened=`/`read=`, which
+  invited reading them as a matched pair.) So asset I/O works and 297 texture files are read, while this atlas
   receives about eighteen slices' worth. Whatever moves DDS content into this allocation is doing so
   for a small fraction of what the title loads.
 

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -82,8 +82,15 @@ Two further details cost time and are worth keeping:
 ## Open defects
 
 1. **Every world and character surface is untextured** and the scene is over-bright
-   ([#2998](https://github.com/mattias800/prosper/issues/2998)). The atlas is bound and holds real
-   data (84 MB non-zero), nothing is rejected, and the menus are fully textured.
+   ([#2998](https://github.com/mattias800/prosper/issues/2998)). The atlas is bound, nothing is
+   rejected, and the menus are fully textured.
+   **The "84 MB non-zero" this line used to carry is withdrawn (2026-08-27).** A full-byte census
+   of the guest allocation reads `filled=19/344` 256 KiB buckets -- about **4.75 MB of 86 MiB** --
+   with `unreadable=0`, which the old figure cannot be reconciled with. It arrived in `227f5fbe`
+   (#3006) without a recorded method, and **what it actually measured is not established** -- so it
+   is withdrawn rather than reinterpreted. Do not repair it by guessing a plausible source (the
+   decoded host image is the obvious guess, and guessing is how the head-sample figure survived);
+   re-derive it or leave it out. See `## Ruled out`.
 2. **Text is intermittently garbled** ([#2999](https://github.com/mattias800/prosper/issues/2999)) —
    the EULA body and the title-screen game selector draw the wrong glyphs while the same font
    renders headings, numerals and every ring label correctly.
@@ -192,13 +199,19 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
   arithmetic error. Neither changes the conclusion, and note the scope this box does NOT establish:
   it is one observation at decode time, not a statement about the whole run -- see the entry below.
 
-- **The allocation is NOT static, and the upper region IS written later in the run.** With the write
-  trace armed at bucket 200 (`PROSPER_DMEM_WRITE_TRACE=2:0x40000000:0x83cc000:128`, target
-  `0x204c3cc000`) the upper atlas takes **32 events, `selected=yes changed-during-window=yes`**,
-  against a positive control at bucket 0 that also fires 32. So "the guest never fills the upper
-  atlas" is false; what the occupancy box above measures is the state at the one moment prosper
-  decodes. The writer is `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per
-  iteration to offsets computed in `%ymm10`.
+- **The allocation is NOT static: it is filled progressively, and a region ABOVE the decode-time
+  content is written later in the run.** With the write trace armed at bucket 200
+  (`PROSPER_DMEM_WRITE_TRACE=2:0x40000000:0x83cc000:128`, target `0x204c3cc000`) that bucket takes
+  **32 events, `selected=yes changed-during-window=yes`**, against a positive control at bucket 0
+  that also fires 32. So the occupancy box above measures the state at the one moment prosper
+  decodes, not the whole run.
+  **Read the scope.** Bucket 200 is byte 52,428,800 = slice **148.8** at `layer_stride=352256`,
+  which sits *below* the interior's slices 186-248 (buckets **249.9-333.2**). This probe says
+  nothing about the interior's own slices, and the finding that slice 248 reads zero throughout
+  stands. An earlier version of this bullet concluded "so 'the guest never fills the upper atlas'
+  is false" without that qualification; that conclusion is retracted -- see `## Ruled out`.
+  The writer is `eboot+0xebb82..0xebbfa`, an unrolled AVX scatter storing 8x16 B per iteration to
+  offsets computed in `%ymm10`.
 - **The title reads its textures; they simply do not arrive here.** `PROSPER_READBYTES=1` counts
   bytes delivered per path with no stack walk: **`.DDS open-events=299 paths-read=297`** over a
   route, alongside `.TRM 98/52` and smaller sets. (Those two fields carry DIFFERENT units -- open
@@ -258,11 +271,15 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 - **Nor is it the slice LAYOUT.** With the array treated as fully tight -- stride = one selected-mip
   surface AND no per-slice mip offset, the combination an earlier test got wrong by changing only the
   stride -- the populated count moves 14 -> 19 of 256 and the interior is still wrong. Every layout
-  tried leaves the same invariant: **only about 5 MB of the atlas's 67 MB is non-zero**, whichever
-  way the slices are addressed.
-  So the remaining question is not how prosper reads the atlas but **why most of it was never
-  written**: the guest declares 256 slices at `0x20491cc000` and samples slice 248, while the memory
-  there is zero. That points at a content path prosper does not observe (a DMA or compute upload
+  tried leaves the same invariant **at decode time**: only about 5 MB of the atlas's 67 MB is
+  non-zero, whichever way the slices are addressed. (67 MB here is the mip-0-only footprint,
+  256 x 262,144; the 86 MiB used elsewhere in this doc is the full `layer_stride=352256` span. Both
+  are correct for what they measure -- name which one you mean.) That figure is a decode-time
+  observation: the allocation IS filled progressively above it, though not, as far as anything has
+  measured, in the interior's own slice range.
+  So the remaining question is not how prosper reads the atlas but **why the slices the interior
+  samples were never written**: the guest declares 256 slices at `0x20491cc000` and samples slice
+  248, while the memory there is zero. That points at a content path prosper does not observe (a DMA or compute upload
   into the atlas) rather than at the array plumbing, which is now measured end to end.
 
 - **Missing SPIR-V `Flat` on the varying that carries the array slice is NOT why interiors sample

--- a/prosper/docs/TOMB_RAIDER_STATUS.md
+++ b/prosper/docs/TOMB_RAIDER_STATUS.md
@@ -120,6 +120,16 @@ Measured layout, for anyone extending this: `layer_stride = 352256` for the 512x
 
 ## Ruled out
 
+- **Nothing maps into the atlas per-slice, and no host/kernel write streams into it** — both with
+  controls, both new instruments. `PROSPER_MAPWATCH` sees one 1 GiB `map_dmem` covering the atlas,
+  established once, never per-slice (control: watching all of dmem shows two maps).
+  `PROSPER_HOSTWRITEWATCH` sees **zero** writes into the atlas while its control — the same watch
+  over all of dmem — records **107**. So the ~18 slices that do arrive are written by guest CPU
+  stores, which no instrument in the tree can observe.
+  That is what makes **#3054** the blocking tool: `PROSPER_HWWATCH` is register-relative and cannot
+  arm on a fixed guest address, so the one mechanism that would catch a plain guest store is
+  unreachable through its current interface.
+
 - **The atlas allocation contains about 4.75 MB of content and nothing else, measured WITHOUT any
   stride assumption.** `PROSPER_OCCUPANCY=1` walks the guest allocation in 256 KiB buckets and asks
   only "is there content here", so it cannot be fooled by a wrong per-slice layout — which every

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4296,6 +4296,44 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 fr.sample_count = decoded_reuse->layers;
                                 fr.tex_byte_size = decoded_reuse->pixels_bytes;
                             }
+                            // #2998: does the GUEST fill high slices after we decoded the atlas?
+                            // The decode happens once and is then served from cache, so a guest that
+                            // streams slices in later is invisible to every instrument that samples
+                            // the DECODE. This samples guest memory directly on the reuse path,
+                            // which runs on every reference, and reports the first time a high slice
+                            // becomes non-zero. If that ever fires, the cache is serving stale
+                            // pixels and the decode simply happened too early.
+                            if (is_array && r.depth > 64u && getenv("PROSPER_SLICEWATCH")) {
+                                static uint64_t watched = 0;
+                                static bool announced_zero = false, announced_nz = false;
+                                const uint64_t stride = r.layer_stride_bytes
+                                    ? r.layer_stride_bytes
+                                    : (uint64_t)tw * th;  // conservative
+                                const uint64_t probe_slice = r.depth - 8u;
+                                const uint64_t addr = r.gpu_addr + probe_slice * stride;
+                                uint8_t buf[256] = {0};
+                                const size_t got = copy_resource(buf, addr, sizeof buf);
+                                bool nz = false;
+                                for (size_t k = 0; k < got && !nz; ++k) nz = buf[k] != 0;
+                                ++watched;
+                                if (!nz && !announced_zero) {
+                                    announced_zero = true;
+                                    fprintf(stderr, "[slicewatch] slice %llu of 0x%llx reads ZERO "
+                                                    "(got=%zu) on reference %llu\n",
+                                            (unsigned long long)probe_slice,
+                                            (unsigned long long)r.gpu_addr, got,
+                                            (unsigned long long)watched);
+                                }
+                                if (nz && !announced_nz) {
+                                    announced_nz = true;
+                                    fprintf(stderr, "[slicewatch] slice %llu of 0x%llx BECAME "
+                                                    "NON-ZERO on reference %llu -- the guest filled "
+                                                    "it after our decode\n",
+                                            (unsigned long long)probe_slice,
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)watched);
+                                }
+                            }
                             fr.td = is_volume ? r.depth : 1u;
                             fr.img_dim = r.img_dim;
                             fr.texture_format = decoded_reuse->texture_format;
@@ -5202,6 +5240,8 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 return r.gpu_addr + static_cast<uint64_t>(face) * stride;
                             };
                             const uint32_t slice_count = is_cube ? 6u : decoded_layers;
+                            std::vector<uint32_t> slice_short(slice_count, 0);
+                            uint32_t slice_short_count = 0;
                             // Reports the GUEST's declared layout only. Deliberately not the
                             // decoded slice count: that is what PROSPER_ARRAY_DECODE_BUDGET_MIB
                             // measures, and a diagnostic that prints a field a different switch
@@ -5233,9 +5273,16 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     const uint64_t selected_addr = face_base(fface, selected_span) +
                                         (r.in_mip_tail ? 0u : r.layer_mip_offset_bytes);
                                     std::vector<uint8_t> lin(comp, 0);
+                                    // #2998: keep the byte count. safe_copy stops at the first
+                                    // uncommitted 64 KiB page and leaves the tail zero-filled, so a
+                                    // slice prosper could not READ is byte-identical to one the
+                                    // guest never WROTE -- and every "the atlas is mostly empty"
+                                    // conclusion turns on telling those apart. The non-BC branch
+                                    // below already checks its `got`; this one discarded it.
+                                    size_t slice_got = 0;
                                     if (ctiled) {
                                         std::vector<uint8_t> traw(selected_span, 0);
-                                        copy_resource(
+                                        slice_got = copy_resource(
                                             traw.data(), selected_addr, selected_span);
                                         if (r.in_mip_tail)
                                             prosper::gpu::detile_elements_level(
@@ -5246,12 +5293,15 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 lin.data(), traw.data(), traw.size(), bw, bh, cb,
                                                 r.tile_mode);
                                     } else if (linear_padded_read) {
-                                        copy_linear_padded_rows_from(
+                                        slice_got = copy_linear_padded_rows_from(
                                             lin.data(), selected_addr,
                                             static_cast<size_t>(bw) * cb, bh);
                                     } else {
-                                        copy_resource(lin.data(), selected_addr, comp);
+                                        slice_got = copy_resource(lin.data(), selected_addr, comp);
                                     }
+                                    if (slice_short_count < slice_count &&
+                                        slice_got < (ctiled ? selected_span : comp))
+                                        slice_short[slice_short_count++] = fface;
                                     std::vector<uint8_t> face((size_t)tw * th * 4, 0);
                                     prosper::gpu::bc_decode_surface(face.data(), lin.data(), lin.size(), tw, th, r.format);
                                     std::memcpy(slice, face.data(), face.size());
@@ -5358,33 +5408,44 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // HEIGHT (fr.th = th*6) and an array through LAYERS (fr.sample_count), so the
                             // two completion flags must stay distinct.
                             if (getenv("PROSPER_SLICEMAP") && !is_cube && slice_count > 1) {
-                                // #2998: which decoded slices actually hold content, across the
-                                // WHOLE range rather than a prefix. Written because a prefix cannot
-                                // answer the question that matters -- an array whose first slices
-                                // decode and whose later ones are empty looks identical, in every
-                                // per-layer checksum of the first eight, to one that decoded
-                                // completely. The SHAPE of the map is the measurement: content
-                                // concentrated at the start means the addressing walks off the
-                                // populated data (or the guest has not written it), while gaps
-                                // spread through the range mean something else.
+                                // #2998: which decoded slices hold content, across the WHOLE range.
+                                // A prefix cannot answer the question -- an array whose first slices
+                                // decode and whose later ones are empty is identical, in every
+                                // per-layer checksum of the first eight, to one that decoded fully.
                                 //
-                                // It found the fact that matters for Tomb Raider: 14 of 256.
+                                // Two things this MUST report alongside the map, because without
+                                // them its output is not interpretable:
+                                //  - the sample rate. "empty" here means "no non-zero byte at a
+                                //    sampled offset", and the sample is sparse, so a slice with
+                                //    little content can read empty. It is a lower bound on content,
+                                //    never an exact count.
+                                //  - the SHORT READS. safe_copy stops at the first uncommitted page
+                                //    and zero-fills the rest, so a slice prosper could not READ is
+                                //    byte-identical to one the guest never WROTE. Reporting empties
+                                //    without this invites exactly the wrong conclusion, which is the
+                                //    one it invited from me.
                                 const size_t lsz = (size_t)tw * th * 4u;
+                                const size_t step = 61u;
                                 std::string map;
                                 uint32_t nonempty = 0;
                                 for (uint32_t L = 0; L < slice_count; ++L) {
                                     if ((size_t)(L + 1) * lsz > texture_pixels.size()) break;
                                     const uint8_t* q = texture_pixels.data() + (size_t)L * lsz;
                                     bool any = false;
-                                    for (size_t i = 0; i < lsz && !any; i += 61u)
-                                        any = (q[i] != 0);
+                                    for (size_t k = 0; k < lsz && !any; k += step) any = (q[k] != 0);
                                     nonempty += any;
-                                    if ((L % 8u) == 0u) map += any ? '#' : '.';
+                                    map += any ? '#' : '.';
                                 }
-                                fprintf(stderr, "[slicemap] addr=0x%llx %ux%u slices=%u nonempty=%u "
-                                                "map(every 8th)=%s\n",
+                                fprintf(stderr,
+                                        "[slicemap] addr=0x%llx %ux%u slices=%u nonempty>=%u "
+                                        "(1 byte in %zu sampled) short_reads=%u%s map=%s\n",
                                         (unsigned long long)r.gpu_addr, tw, th, slice_count,
-                                        nonempty, map.c_str());
+                                        nonempty, step, slice_short_count,
+                                        slice_short_count ? " <- EMPTY MAY MEAN UNREADABLE" : "",
+                                        map.c_str());
+                                if (slice_short_count)
+                                    fprintf(stderr, "[slicemap]   first short slice=%u\n",
+                                            slice_short[0]);
                             }
                             if (is_cube) cube_done = true; else array_done = true;
                             if (resource_compute_depth_hybrid && !decoded_reuse) {

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4340,6 +4340,39 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 (unsigned long long)lo, (unsigned long long)hi);
                                 }
                             }
+                            // #2998: a coarse occupancy map of the GUEST allocation itself, in
+                            // 256 KiB buckets, independent of any stride assumption. Every previous
+                            // measurement addressed slices with layer_stride, so a wrong stride made
+                            // "slice N is zero" trivially true by probing outside the data. This
+                            // asks the only question that needs no layout at all: WHERE in this
+                            // allocation is there content?
+                            if (is_array && r.depth > 64u && PROSPER_ENV_ON("PROSPER_OCCUPANCY")) {
+                                static std::set<uint64_t> done;
+                                if (done.insert(r.gpu_addr).second) {
+                                    const uint64_t span = (uint64_t)r.layer_stride_bytes * r.depth;
+                                    const uint64_t bucket = 256u * 1024u;
+                                    const uint64_t n = span / bucket;
+                                    std::string map;
+                                    uint64_t filled = 0, last_filled = 0;
+                                    for (uint64_t i = 0; i < n && i < 512; ++i) {
+                                        uint8_t probe[512] = {0};
+                                        const size_t got = copy_resource(
+                                            probe, r.gpu_addr + i * bucket, sizeof probe);
+                                        bool any = false;
+                                        for (size_t k = 0; k < got && !any; ++k) any = probe[k] != 0;
+                                        if (any) { ++filled; last_filled = i; }
+                                        map += any ? '#' : '.';
+                                    }
+                                    fprintf(stderr,
+                                            "[occupancy] 0x%llx span=%llu MiB bucket=256KiB "
+                                            "filled=%llu/%llu last_filled_bucket=%llu\n%s\n",
+                                            (unsigned long long)r.gpu_addr,
+                                            (unsigned long long)(span >> 20),
+                                            (unsigned long long)filled, (unsigned long long)n,
+                                            (unsigned long long)last_filled, map.c_str());
+                                    fflush(stderr);
+                                }
+                            }
                             if (is_array && r.depth > 64u && PROSPER_ENV_ON("PROSPER_SLICEWATCH")) {
                                 // Per-address, not global: with two arrays in flight a global flag
                                 // lets the first silence the second's report entirely.

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4352,25 +4352,56 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     const uint64_t span = (uint64_t)r.layer_stride_bytes * r.depth;
                                     const uint64_t bucket = 256u * 1024u;
                                     const uint64_t n = span / bucket;
+                                    if (!n) {
+                                        // filled=0/0 read as "scanned and empty". It is neither.
+                                        fprintf(stderr,
+                                                "[occupancy] 0x%llx span=%llu bytes -- NO complete "
+                                                "256KiB bucket (layer_stride=%u depth=%u); "
+                                                "NOTHING SCANNED\n",
+                                                (unsigned long long)r.gpu_addr,
+                                                (unsigned long long)span,
+                                                r.layer_stride_bytes, r.depth);
+                                        fflush(stderr);
+                                    } else {
+                                    // Scan every byte of each bucket, not a head sample. This probed
+                                    // only the first 512 B of each 256 KiB bucket (0.195%), so a
+                                    // bucket whose content began past that window read as EMPTY --
+                                    // a false negative that reached TOMB_RAIDER_STATUS.md as
+                                    // "not in this allocation at ANY layout".
+                                    const uint64_t scan_n = n < 512u ? n : 512u;
+                                    std::vector<uint8_t> probe(64u * 1024u);
                                     std::string map;
-                                    uint64_t filled = 0, last_filled = 0;
-                                    for (uint64_t i = 0; i < n && i < 512; ++i) {
-                                        uint8_t probe[512] = {0};
-                                        const size_t got = copy_resource(
-                                            probe, r.gpu_addr + i * bucket, sizeof probe);
-                                        bool any = false;
-                                        for (size_t k = 0; k < got && !any; ++k) any = probe[k] != 0;
+                                    uint64_t filled = 0, last_filled = 0, unreadable = 0;
+                                    for (uint64_t i = 0; i < scan_n; ++i) {
+                                        bool any = false, short_read = false;
+                                        for (uint64_t off = 0; off < bucket && !any; off += probe.size()) {
+                                            const size_t want = (size_t)std::min<uint64_t>(
+                                                probe.size(), bucket - off);
+                                            const size_t got = copy_resource(
+                                                probe.data(), r.gpu_addr + i * bucket + off, want);
+                                            for (size_t k = 0; k < got && !any; ++k)
+                                                any = probe[k] != 0;
+                                            if (got < want) { short_read = true; break; }
+                                        }
                                         if (any) { ++filled; last_filled = i; }
-                                        map += any ? '#' : '.';
+                                        else if (short_read) ++unreadable;
+                                        // '?' is NOT '.': prosper could not read it, so it is
+                                        // unknown, not known-empty.
+                                        map += any ? '#' : (short_read ? '?' : '.');
                                     }
                                     fprintf(stderr,
                                             "[occupancy] 0x%llx span=%llu MiB bucket=256KiB "
-                                            "filled=%llu/%llu last_filled_bucket=%llu\n%s\n",
+                                            "FULL-BUCKET scan filled=%llu/%llu scanned "
+                                            "(of %llu total) last_filled_bucket=%llu "
+                                            "unreadable=%llu ('?' = unreadable, NOT empty)\n%s\n",
                                             (unsigned long long)r.gpu_addr,
                                             (unsigned long long)(span >> 20),
-                                            (unsigned long long)filled, (unsigned long long)n,
-                                            (unsigned long long)last_filled, map.c_str());
+                                            (unsigned long long)filled,
+                                            (unsigned long long)scan_n, (unsigned long long)n,
+                                            (unsigned long long)last_filled,
+                                            (unsigned long long)unreadable, map.c_str());
                                     fflush(stderr);
+                                    }
                                 }
                             }
                             if (is_array && r.depth > 64u && PROSPER_ENV_ON("PROSPER_SLICEWATCH")) {
@@ -4391,18 +4422,34 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 ++watched;
                                 if (!nz && said_zero.insert(r.gpu_addr).second) {
                                     fprintf(stderr, "[slicewatch] slice %llu of 0x%llx reads ZERO "
-                                                    "(got=%zu) on reference %llu\n",
+                                                    "(got=%zu of %zu) on reference %llu%s\n",
                                             (unsigned long long)probe_slice,
-                                            (unsigned long long)r.gpu_addr, got,
-                                            (unsigned long long)watched);
+                                            (unsigned long long)r.gpu_addr, got, sizeof buf,
+                                            (unsigned long long)watched,
+                                            r.layer_stride_bytes ? "" : " [probe used the tw*th "
+                                                                        "stride FALLBACK, not a "
+                                                                        "guest-declared stride]");
                                 }
                                 if (nz && said_nz.insert(r.gpu_addr).second) {
-                                    fprintf(stderr, "[slicewatch] slice %llu of 0x%llx BECAME "
-                                                    "NON-ZERO on reference %llu -- the guest filled "
-                                                    "it after our decode\n",
+                                    // A transition needs a PRIOR zero reading for this address.
+                                    // Without one this is just the first observation, and saying
+                                    // "the guest filled it after our decode" would assert an
+                                    // ordering nothing here measured.
+                                    const bool saw_zero_first = said_zero.count(r.gpu_addr) != 0;
+                                    fprintf(stderr,
+                                            saw_zero_first
+                                              ? "[slicewatch] slice %llu of 0x%llx BECAME NON-ZERO "
+                                                "on reference %llu -- it read ZERO earlier, so the "
+                                                "guest filled it after that reading%s\n"
+                                              : "[slicewatch] slice %llu of 0x%llx reads NON-ZERO on "
+                                                "reference %llu -- FIRST observation, no prior ZERO "
+                                                "reading, so this is NOT an observed transition%s\n",
                                             (unsigned long long)probe_slice,
                                             (unsigned long long)r.gpu_addr,
-                                            (unsigned long long)watched);
+                                            (unsigned long long)watched,
+                                            r.layer_stride_bytes ? "" : " [probe used the tw*th "
+                                                                        "stride FALLBACK, not a "
+                                                                        "guest-declared stride]");
                                 }
                             }
                             fr.td = is_volume ? r.depth : 1u;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4308,7 +4308,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // mapping explains an allocation whose tail reads zero far better than
                             // "the game never wrote it". Printed once per address, from the host
                             // process's own map, because the guest VA is mapped into it.
-                            if (is_array && r.depth > 64u && getenv("PROSPER_SLICEMAPS")) {
+                            if (is_array && r.depth > 64u && PROSPER_ENV_ON("PROSPER_SLICEMAPS")) {
                                 static std::set<uint64_t> shown;
                                 if (shown.insert(r.gpu_addr).second) {
                                     const uint64_t lo = r.gpu_addr;
@@ -4316,15 +4316,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                         (uint64_t)r.layer_stride_bytes * r.depth;
                                     FILE* m = fopen("/proc/self/maps", "r");
                                     char line[512];
-                                    uint32_t printed = 0;
-                                    while (m && fgets(line, sizeof line, m) && printed < 8) {
+                                    uint32_t printed = 0, overlapping = 0;
+                                    while (m && fgets(line, sizeof line, m)) {
                                         unsigned long long a = 0, b = 0;
                                         if (sscanf(line, "%llx-%llx", &a, &b) != 2) continue;
                                         if (b <= lo || a >= hi) continue;
+                                        ++overlapping;
+                                        if (printed >= 8u) continue;   // counted below, never hidden
                                         fprintf(stderr, "[slicemaps] 0x%llx..0x%llx overlaps: %s",
                                                 (unsigned long long)lo, (unsigned long long)hi, line);
                                         ++printed;
                                     }
+                                    // The COUNT is the measurement -- a span split across many
+                                    // mappings is precisely the partial-residency case, and a
+                                    // silently truncated list would read as "one clean mapping".
+                                    if (overlapping > printed)
+                                        fprintf(stderr, "[slicemaps]   ... %u overlapping mapping(s) "
+                                                        "total, %u shown\n", overlapping, printed);
                                     if (m) fclose(m);
                                     if (!printed)
                                         fprintf(stderr, "[slicemaps] 0x%llx..0x%llx has NO mapping "
@@ -4332,9 +4340,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 (unsigned long long)lo, (unsigned long long)hi);
                                 }
                             }
-                            if (is_array && r.depth > 64u && getenv("PROSPER_SLICEWATCH")) {
-                                static uint64_t watched = 0;
-                                static bool announced_zero = false, announced_nz = false;
+                            if (is_array && r.depth > 64u && PROSPER_ENV_ON("PROSPER_SLICEWATCH")) {
+                                // Per-address, not global: with two arrays in flight a global flag
+                                // lets the first silence the second's report entirely.
+                                static std::map<uint64_t, uint64_t> watched_by_addr;
+                                static std::set<uint64_t> said_zero, said_nz;
+                                uint64_t& watched = watched_by_addr[r.gpu_addr];
                                 const uint64_t stride = r.layer_stride_bytes
                                     ? r.layer_stride_bytes
                                     : (uint64_t)tw * th;  // conservative
@@ -4345,16 +4356,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                 bool nz = false;
                                 for (size_t k = 0; k < got && !nz; ++k) nz = buf[k] != 0;
                                 ++watched;
-                                if (!nz && !announced_zero) {
-                                    announced_zero = true;
+                                if (!nz && said_zero.insert(r.gpu_addr).second) {
                                     fprintf(stderr, "[slicewatch] slice %llu of 0x%llx reads ZERO "
                                                     "(got=%zu) on reference %llu\n",
                                             (unsigned long long)probe_slice,
                                             (unsigned long long)r.gpu_addr, got,
                                             (unsigned long long)watched);
                                 }
-                                if (nz && !announced_nz) {
-                                    announced_nz = true;
+                                if (nz && said_nz.insert(r.gpu_addr).second) {
                                     fprintf(stderr, "[slicewatch] slice %llu of 0x%llx BECAME "
                                                     "NON-ZERO on reference %llu -- the guest filled "
                                                     "it after our decode\n",
@@ -5347,10 +5356,12 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                     const uint64_t selected_addr = face_base(fface, selected_span) +
                                         (r.in_mip_tail ? 0u : r.layer_mip_offset_bytes);
                                     std::vector<uint8_t> linear(linear_bytes, 0);
+                                    size_t nbc_got = 0, nbc_want = 0;
                                     if (ctiled) {
                                         std::vector<uint8_t> traw(selected_span, 0);
                                         const size_t got = copy_resource(
                                             traw.data(), selected_addr, selected_span);
+                                        nbc_got = got; nbc_want = selected_span;
                                         if (got < linear.size()) {
                                             copy_resource(
                                                 linear.data(), selected_addr, linear.size());
@@ -5365,13 +5376,14 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                                 r.tile_mode, 0, source_bpt);
                                         }
                                     } else if (linear_padded_read) {
+                                        nbc_want = static_cast<size_t>(tw) * source_bpt * th;
                                         // #325: use the SAME pitch the single-surface path uses
                                         // (`linear_src_row`), not one recomputed from tw/bpt here.
                                         // They can differ -- the single-surface figure honours a
                                         // registered pitch and its own row width -- and slice 0 of
                                         // an array must decode byte-identically to the way that
                                         // same surface decoded before it was treated as an array.
-                                        copy_linear_padded_rows_from(
+                                        nbc_got = copy_linear_padded_rows_from(
                                             linear.data(), selected_addr,
                                             static_cast<size_t>(tw) * source_bpt, th);
                                     } else if (r.layer_stride_bytes) {
@@ -5380,13 +5392,23 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                                             : prosper::gpu::linear_sampled_row_pitch(
                                                   tw, source_bpt);
                                         for (uint32_t y = 0; y < th; ++y)
-                                            copy_resource(
+                                            nbc_got += copy_resource(
                                                 linear.data() + static_cast<size_t>(y) * tw * source_bpt,
                                                 selected_addr + static_cast<uint64_t>(y) * row_pitch,
                                                 static_cast<size_t>(tw) * source_bpt);
+                                        nbc_want = static_cast<size_t>(tw) * source_bpt * th;
                                     } else {
-                                        copy_resource(linear.data(), selected_addr, linear.size());
+                                        nbc_got = copy_resource(linear.data(), selected_addr,
+                                                                linear.size());
+                                        nbc_want = linear.size();
                                     }
+                                    // Measured, not assumed: this branch left slice_short_count
+                                    // untouched, so an uncompressed array printed short_reads=0
+                                    // having counted nothing -- a clean result the instrument had
+                                    // not earned, which is the exact failure it exists to prevent.
+                                    if (slice_short_count < slice_count &&
+                                        nbc_want && nbc_got < nbc_want)
+                                        slice_short[slice_short_count++] = fface;
                                     if (f16) {
                                         const uint32_t nc = source_bpt / 2;
                                         for (size_t texel = 0; texel < (size_t)tw * th; ++texel) {
@@ -5436,7 +5458,7 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // The loop above filled `slice_count` slices. A cube publishes them through
                             // HEIGHT (fr.th = th*6) and an array through LAYERS (fr.sample_count), so the
                             // two completion flags must stay distinct.
-                            if (getenv("PROSPER_SLICEMAP") && !is_cube && slice_count > 1) {
+                            if (PROSPER_ENV_ON("PROSPER_SLICEMAP") && !is_cube && slice_count > 1) {
                                 // #2998: which decoded slices hold content, across the WHOLE range.
                                 // A prefix cannot answer the question -- an array whose first slices
                                 // decode and whose later ones are empty is identical, in every

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -5357,6 +5357,35 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // The loop above filled `slice_count` slices. A cube publishes them through
                             // HEIGHT (fr.th = th*6) and an array through LAYERS (fr.sample_count), so the
                             // two completion flags must stay distinct.
+                            if (getenv("PROSPER_SLICEMAP") && !is_cube && slice_count > 1) {
+                                // #2998: which decoded slices actually hold content, across the
+                                // WHOLE range rather than a prefix. Written because a prefix cannot
+                                // answer the question that matters -- an array whose first slices
+                                // decode and whose later ones are empty looks identical, in every
+                                // per-layer checksum of the first eight, to one that decoded
+                                // completely. The SHAPE of the map is the measurement: content
+                                // concentrated at the start means the addressing walks off the
+                                // populated data (or the guest has not written it), while gaps
+                                // spread through the range mean something else.
+                                //
+                                // It found the fact that matters for Tomb Raider: 14 of 256.
+                                const size_t lsz = (size_t)tw * th * 4u;
+                                std::string map;
+                                uint32_t nonempty = 0;
+                                for (uint32_t L = 0; L < slice_count; ++L) {
+                                    if ((size_t)(L + 1) * lsz > texture_pixels.size()) break;
+                                    const uint8_t* q = texture_pixels.data() + (size_t)L * lsz;
+                                    bool any = false;
+                                    for (size_t i = 0; i < lsz && !any; i += 61u)
+                                        any = (q[i] != 0);
+                                    nonempty += any;
+                                    if ((L % 8u) == 0u) map += any ? '#' : '.';
+                                }
+                                fprintf(stderr, "[slicemap] addr=0x%llx %ux%u slices=%u nonempty=%u "
+                                                "map(every 8th)=%s\n",
+                                        (unsigned long long)r.gpu_addr, tw, th, slice_count,
+                                        nonempty, map.c_str());
+                            }
                             if (is_cube) cube_done = true; else array_done = true;
                             if (resource_compute_depth_hybrid && !decoded_reuse) {
                                 std::array<std::vector<float>, 6> overlay_faces;

--- a/prosper/frontends/shared/live/live_renderer.cpp
+++ b/prosper/frontends/shared/live/live_renderer.cpp
@@ -4303,6 +4303,35 @@ void register_live_renderer(const std::string& frame_dir, bool dump_bmps_request
                             // which runs on every reference, and reports the first time a high slice
                             // becomes non-zero. If that ever fires, the cache is serving stale
                             // pixels and the decode simply happened too early.
+                            // #2998: what BACKS this atlas? If the guest maps texture data in
+                            // (a file mapping, or several separate mappings), a short or partial
+                            // mapping explains an allocation whose tail reads zero far better than
+                            // "the game never wrote it". Printed once per address, from the host
+                            // process's own map, because the guest VA is mapped into it.
+                            if (is_array && r.depth > 64u && getenv("PROSPER_SLICEMAPS")) {
+                                static std::set<uint64_t> shown;
+                                if (shown.insert(r.gpu_addr).second) {
+                                    const uint64_t lo = r.gpu_addr;
+                                    const uint64_t hi = r.gpu_addr +
+                                        (uint64_t)r.layer_stride_bytes * r.depth;
+                                    FILE* m = fopen("/proc/self/maps", "r");
+                                    char line[512];
+                                    uint32_t printed = 0;
+                                    while (m && fgets(line, sizeof line, m) && printed < 8) {
+                                        unsigned long long a = 0, b = 0;
+                                        if (sscanf(line, "%llx-%llx", &a, &b) != 2) continue;
+                                        if (b <= lo || a >= hi) continue;
+                                        fprintf(stderr, "[slicemaps] 0x%llx..0x%llx overlaps: %s",
+                                                (unsigned long long)lo, (unsigned long long)hi, line);
+                                        ++printed;
+                                    }
+                                    if (m) fclose(m);
+                                    if (!printed)
+                                        fprintf(stderr, "[slicemaps] 0x%llx..0x%llx has NO mapping "
+                                                        "in /proc/self/maps\n",
+                                                (unsigned long long)lo, (unsigned long long)hi);
+                                }
+                            }
                             if (is_array && r.depth > 64u && getenv("PROSPER_SLICEWATCH")) {
                                 static uint64_t watched = 0;
                                 static bool announced_zero = false, announced_nz = false;

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -1856,8 +1856,25 @@ struct SpirvCompute {
     void image_sample_2d_array(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
                                uint32_t layer_bits, uint32_t out[4]) {
         uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        // #2998: PROSPER_FORCE_LAYER=<n> substitutes a constant array layer, and SAYS SO, which is
+        // the point -- it separates "the shader is given the wrong slice" from "the slice it asks
+        // for holds the wrong content", two failures that look identical on screen. A probe that
+        // could not show its own lever moved would leave a null meaning nothing.
+        //
+        // This forces guest-visible state, so its output illustrates an investigation and is never
+        // acceptance evidence for a rendered frame.
+        static const int forced_layer = [] {
+            const char* e = getenv("PROSPER_FORCE_LAYER"); return e ? atoi(e) : -1; }();
+        uint32_t layer_use = bcf(layer_bits);
+        if (forced_layer >= 0) {
+            layer_use = fconstf((float)forced_layer);
+            static uint32_t said = 0;
+            if (said++ < 4u)
+                fprintf(stderr, "[force-layer] binding=%u substituted constant layer %d\n",
+                        binding, forced_layer);
+        }
         uint32_t coord = id(); put(code, Op_CompositeConstruct,
-                                   {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(layer_bits)});
+                                   {t_v3f(), coord, bcf(u_bits), bcf(v_bits), layer_use});
         uint32_t res = id();
         if (is_fragment)
             put(code, Op_ImageSampleImplicitLod, {texture_vec4(binding), res, si, coord});

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -1853,6 +1853,20 @@ struct SpirvCompute {
     // lowering a plain SAMPLE through the explicit-LOD helper would pin every textured surface to
     // the base level. Outside a fragment stage there are no derivatives, so LOD 0 is the only
     // legal choice -- which is exactly what image_sample_2d already does for the non-array case.
+    // PROSPER_FORCE_LAYER=<n>: the constant array layer to substitute, or -1 for off. A malformed
+    // or empty value DISABLES the probe rather than forcing layer 0 -- a typo must cost a
+    // measurement, never produce a wrong one silently.
+    static int forced_array_layer() {
+        static const int v = [] {
+            const char* e = getenv("PROSPER_FORCE_LAYER");
+            if (!e || !*e) return -1;
+            char* end = nullptr;
+            const long n = strtol(e, &end, 10);
+            if (!end || *end || n < 0 || n > 65535) return -1;
+            return (int)n;
+        }();
+        return v;
+    }
     void image_sample_2d_array(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
                                uint32_t layer_bits, uint32_t out[4]) {
         uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
@@ -1863,8 +1877,7 @@ struct SpirvCompute {
         //
         // This forces guest-visible state, so its output illustrates an investigation and is never
         // acceptance evidence for a rendered frame.
-        static const int forced_layer = [] {
-            const char* e = getenv("PROSPER_FORCE_LAYER"); return e ? atoi(e) : -1; }();
+        const int forced_layer = forced_array_layer();
         uint32_t layer_use = bcf(layer_bits);
         if (forced_layer >= 0) {
             layer_use = fconstf((float)forced_layer);
@@ -1886,8 +1899,14 @@ struct SpirvCompute {
     void image_sample_lod_2d_array(uint32_t binding, uint32_t u_bits, uint32_t v_bits,
                                    uint32_t layer_bits, uint32_t lod_bits, uint32_t out[4]) {
         uint32_t si = id(); put(code, Op_Load, {tex_binding_simg[binding], si, tex_var[binding]});
+        // #2998: PROSPER_FORCE_LAYER applies HERE TOO. Covering only the implicit-LOD sampler is
+        // the scope error this session already made once and had to withdraw: the census puts most
+        // of this title's array events on other opcodes, so a probe on one helper produces a null
+        // that means nothing about the rest.
+        uint32_t lod_layer = forced_array_layer() >= 0
+            ? fconstf((float)forced_array_layer()) : bcf(layer_bits);
         uint32_t coord = id(); put(code, Op_CompositeConstruct,
-                                   {t_v3f(), coord, bcf(u_bits), bcf(v_bits), bcf(layer_bits)});
+                                   {t_v3f(), coord, bcf(u_bits), bcf(v_bits), lod_layer});
         uint32_t res = id(); put(code, Op_ImageSampleExplicitLod,
                                  {texture_vec4(binding), res, si, coord,
                                   ImgOp_Lod, bcf(lod_bits)});

--- a/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
+++ b/prosper/src/gpu/recompiler/rdna2_to_spirv_internal.hpp
@@ -1856,6 +1856,17 @@ struct SpirvCompute {
     // PROSPER_FORCE_LAYER=<n>: the constant array layer to substitute, or -1 for off. A malformed
     // or empty value DISABLES the probe rather than forcing layer 0 -- a typo must cost a
     // measurement, never produce a wrong one silently.
+    // Announce a substitution, from whichever sampler performed it. Both must announce or the
+    // probe produces exactly the null it exists to prevent: a title that samples only through the
+    // explicit-LOD helper would otherwise get full substitution with no output at all.
+    static void announce_forced_layer(uint32_t binding, int layer) {
+        static std::atomic<uint32_t> said{0};
+        if (said.fetch_add(1, std::memory_order_relaxed) < 4u) {
+            fprintf(stderr, "[force-layer] binding=%u substituted constant layer %d\n",
+                    binding, layer);
+            fflush(stderr);
+        }
+    }
     static int forced_array_layer() {
         static const int v = [] {
             const char* e = getenv("PROSPER_FORCE_LAYER");
@@ -1881,10 +1892,7 @@ struct SpirvCompute {
         uint32_t layer_use = bcf(layer_bits);
         if (forced_layer >= 0) {
             layer_use = fconstf((float)forced_layer);
-            static uint32_t said = 0;
-            if (said++ < 4u)
-                fprintf(stderr, "[force-layer] binding=%u substituted constant layer %d\n",
-                        binding, forced_layer);
+            announce_forced_layer(binding, forced_layer);
         }
         uint32_t coord = id(); put(code, Op_CompositeConstruct,
                                    {t_v3f(), coord, bcf(u_bits), bcf(v_bits), layer_use});
@@ -1903,8 +1911,11 @@ struct SpirvCompute {
         // the scope error this session already made once and had to withdraw: the census puts most
         // of this title's array events on other opcodes, so a probe on one helper produces a null
         // that means nothing about the rest.
-        uint32_t lod_layer = forced_array_layer() >= 0
-            ? fconstf((float)forced_array_layer()) : bcf(layer_bits);
+        uint32_t lod_layer = bcf(layer_bits);
+        if (forced_array_layer() >= 0) {
+            lod_layer = fconstf((float)forced_array_layer());
+            announce_forced_layer(binding, forced_array_layer());
+        }
         uint32_t coord = id(); put(code, Op_CompositeConstruct,
                                    {t_v3f(), coord, bcf(u_bits), bcf(v_bits), lod_layer});
         uint32_t res = id(); put(code, Op_ImageSampleExplicitLod,

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -476,7 +476,10 @@ namespace {
             for (const auto& o : g_readbytes_opens)
                 if (!g_readbytes.count(o.first)) ++opened_never_read;
             for (const auto& r : g_readbytes) total += r.second.first;
-            fprintf(stderr, "[readbytes] %zu path(s) opened, %zu delivered bytes, "
+            // Every field names its own UNIT. g_readbytes.size() is a count of PATHS that
+            // delivered at least one byte -- it was previously printed as "delivered bytes",
+            // which reads as a byte total on a line whose last field really is one.
+            fprintf(stderr, "[readbytes] %zu path(s) opened, %zu path(s) delivered bytes, "
                             "%llu opened-but-never-read, %llu total bytes\n",
                     g_readbytes_opens.size(), g_readbytes.size(),
                     (unsigned long long)opened_never_read, (unsigned long long)total);
@@ -489,7 +492,10 @@ namespace {
                 if (g_readbytes.count(o.first)) ++by_ext[ext].second;
             }
             for (const auto& e : by_ext)
-                fprintf(stderr, "[readbytes]   %-8s opened=%llu read=%llu\n", e.first.c_str(),
+                // open-events vs paths-read: DIFFERENT units. `first` accumulates o.second,
+                // an open-event count; `second` counts distinct paths that were read. Printing
+                // them as `opened=`/`read=` invited reading them as a matched pair.
+                fprintf(stderr, "[readbytes]   %-8s open-events=%llu paths-read=%llu\n", e.first.c_str(),
                         (unsigned long long)e.second.first,
                         (unsigned long long)e.second.second);
             fflush(stderr);

--- a/prosper/src/hle/fs/hle_file.cpp
+++ b/prosper/src/hle/fs/hle_file.cpp
@@ -393,21 +393,111 @@ namespace {
     }
 #endif
 
+    bool readbytes_on();   // fwd: the fd->path map below is shared with it
+
     void filelog_remember_fd(int fd, const std::string& path) {
-        if (!filelog() || fd < 0) return;
+        if ((!filelog() && !readbytes_on()) || fd < 0) return;
         std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
         g_filelog_fd_paths[fd] = path;
     }
 
     std::string filelog_fd_path(int fd) {
-        if (!filelog()) return {};
+        if (!filelog() && !readbytes_on()) return {};
         std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
         auto it = g_filelog_fd_paths.find(fd);
         return it == g_filelog_fd_paths.end() ? std::string() : it->second;
     }
 
+    // PROSPER_READBYTES=1 -- how many bytes each file actually DELIVERS, against how many times it
+    // was opened. Written because the question "does the title read what it opens?" had no cheap
+    // answer: PROSPER_FILELOG sees opens and PROSPER_PREADLOG sees reads, but the latter walks the
+    // guest stack on every fd operation to recover a call chain, and enabling both together slows a
+    // load past the point a routed run survives -- a measurement that reports "one file read"
+    // because the run never got further. This keeps a counter per path and nothing else, so it costs
+    // an addition and a map lookup per read, and it prints once at exit.
+    //
+    // What its null does NOT cover: reads that never reach this layer. It counts what these HLE
+    // entry points deliver, so a title using a path prosper services elsewhere is invisible to it.
+    std::mutex g_readbytes_mx;
+    std::map<std::string, std::pair<uint64_t, uint64_t>> g_readbytes;   // path -> {bytes, reads}
+    std::map<std::string, uint64_t> g_readbytes_opens;                  // path -> opens
+
+    bool readbytes_on() {
+        static const int on = [] {
+            const char* e = getenv("PROSPER_READBYTES");
+            return e && *e && strcmp(e, "0") ? 1 : 0;
+        }();
+        return on != 0;
+    }
+
+    void readbytes_note_open(const std::string& path) {
+        if (!readbytes_on() || path.empty()) return;
+        std::lock_guard<std::mutex> lk(g_readbytes_mx);
+        ++g_readbytes_opens[path];
+    }
+
+    void readbytes_note_read(int fd, int64_t bytes) {
+        if (!readbytes_on() || bytes <= 0) return;
+        const std::string path = filelog_fd_path(fd);
+        if (path.empty()) return;
+        std::lock_guard<std::mutex> lk(g_readbytes_mx);
+        auto& e = g_readbytes[path];
+        e.first += (uint64_t)bytes;
+        ++e.second;
+    }
+
+    // Reported DURING the run, every N opens, rather than only at exit: this frontend does not
+    // unwind static destructors, so an exit-time report printed nothing at all -- an instrument that
+    // silently produces no output is the failure mode this whole investigation kept hitting.
+    void readbytes_report_locked();
+
+    void readbytes_maybe_report() {
+        if (!readbytes_on()) return;
+        static uint64_t last = 0;
+        std::lock_guard<std::mutex> lk(g_readbytes_mx);
+        if (g_readbytes_opens.size() < last + 100u) return;
+        last = g_readbytes_opens.size();
+        readbytes_report_locked();
+    }
+
+    struct ReadBytesReport {
+        ~ReadBytesReport() {
+            if (!readbytes_on()) return;
+            std::lock_guard<std::mutex> lk(g_readbytes_mx);
+            readbytes_report_locked();
+        }
+    };
+    ReadBytesReport g_readbytes_report;
+
+    // Caller holds g_readbytes_mx.
+    void readbytes_report_locked() {
+        {
+            uint64_t total = 0, opened_never_read = 0;
+            for (const auto& o : g_readbytes_opens)
+                if (!g_readbytes.count(o.first)) ++opened_never_read;
+            for (const auto& r : g_readbytes) total += r.second.first;
+            fprintf(stderr, "[readbytes] %zu path(s) opened, %zu delivered bytes, "
+                            "%llu opened-but-never-read, %llu total bytes\n",
+                    g_readbytes_opens.size(), g_readbytes.size(),
+                    (unsigned long long)opened_never_read, (unsigned long long)total);
+            // The extensions matter more than individual files for an asset question.
+            std::map<std::string, std::pair<uint64_t, uint64_t>> by_ext;   // ext -> {opened, read}
+            for (const auto& o : g_readbytes_opens) {
+                const size_t dot = o.first.rfind('.');
+                std::string ext = dot == std::string::npos ? "(none)" : o.first.substr(dot);
+                by_ext[ext].first += o.second;
+                if (g_readbytes.count(o.first)) ++by_ext[ext].second;
+            }
+            for (const auto& e : by_ext)
+                fprintf(stderr, "[readbytes]   %-8s opened=%llu read=%llu\n", e.first.c_str(),
+                        (unsigned long long)e.second.first,
+                        (unsigned long long)e.second.second);
+            fflush(stderr);
+        }
+    }
+
     void filelog_forget_fd(int fd) {
-        if (!filelog()) return;
+        if (!filelog() && !readbytes_on()) return;
         std::lock_guard<std::mutex> lk(g_filelog_fd_mx);
         g_filelog_fd_paths.erase(fd);
     }
@@ -1105,6 +1195,8 @@ HLE(f_open)  { std::string h = translate(CS(a0)); int host_flags = host_open_fla
 #endif
                int err = fd < 0 ? errno : 0;
                filelog_remember_fd(fd, h);
+               readbytes_note_open(h);
+               readbytes_maybe_report();
                if (filelog()) fprintf(stderr,
                    "[file] open-result host='%s' guest-flags=0x%llx host-flags=0x%x -> fd=%d error=%d\n",
                    h.c_str(), (unsigned long long)a1, host_flags, fd, err);
@@ -1408,6 +1500,7 @@ HLE(f_read)  { int fd = (int)a0; int64_t off = -1;
                if (filelog() || fdlog_on()) off = (int64_t)::lseek(fd, 0, SEEK_CUR);
                if (fdlog_on()) preadlog("read", a0, (uint64_t)off, a2);
                auto logged_return = [&](int64_t r) -> uint64_t {
+                   readbytes_note_read(fd, r);
                    const int error = r < 0 ? errno : 0;
                    filelog_fd_io("read", fd, off, a2, r, error);
                    if (r < 0) errno = error;
@@ -1478,6 +1571,7 @@ HLE(f_lseek) { if (fdlog_on() && ((int)a2 != SEEK_CUR || a1 != 0)) preadlog("lse
                return (uint64_t)(int64_t)::lseek((int)a0, (off_t)a1, (int)a2); }
 #ifndef _WIN32
 HLE(f_pread)  { preadlog("pread", a0, a3, a2); int64_t r = read_full((int)a0, P(a1), (size_t)a2, true, (off_t)a3);
+                readbytes_note_read((int)a0, r);
                 const int error = r < 0 ? errno : 0;
                 filelog_fd_io("pread", (int)a0, (int64_t)a3, a2, r, error);
                 if (r < 0) errno = error;

--- a/prosper/src/hle/memory/hle_kernel_mem.cpp
+++ b/prosper/src/hle/memory/hle_kernel_mem.cpp
@@ -1700,6 +1700,29 @@ static uint64_t map_dmem_impl(uint64_t addr_in_out, uint64_t len, uint64_t prot,
     uint64_t hint = addr_in_out ? *(uint64_t*)addr_in_out : 0;
     const bool fixed = (flags & 0x10) != 0;
     void* p = map_phys_at(hint, len, host_prot(prot), phys, align, fixed);
+    // PROSPER_MAPWATCH=0xADDR[:SIZE] (#2998): report every direct-memory map whose RESULT overlaps
+    // one guest range, with the physical offset and whether the placement was fixed. The question it
+    // answers is "does the title map physical memory INTO this allocation later?" -- the shape a
+    // sparse or per-slice-committed texture would have. Nothing else could answer it: the dmem
+    // caller log attributes ALLOCATIONS, and the write watches see stores, so a mapping that changes
+    // what an address resolves to is invisible to both.
+    if (const char* w = getenv("PROSPER_MAPWATCH")) {
+        char* end = nullptr;
+        const uint64_t lo = strtoull(w, &end, 0);
+        const uint64_t size = (end && *end == ':') ? strtoull(end + 1, nullptr, 0) : (64ull << 20);
+        const uint64_t got = (uint64_t)(uintptr_t)p;
+        if (lo && got && got < lo + size && got + len > lo) {
+            static uint32_t said = 0;
+            if (said++ < 32u) {
+                fprintf(stderr, "[mapwatch] map_dmem -> 0x%llx..0x%llx phys=0x%llx fixed=%d "
+                                "overlaps watch 0x%llx+0x%llx\n",
+                        (unsigned long long)got, (unsigned long long)(got + len),
+                        (unsigned long long)phys, (int)fixed,
+                        (unsigned long long)lo, (unsigned long long)size);
+                fflush(stderr);
+            }
+        }
+    }
     if (!p) { MLOG("map_dmem hint=0x%llx len=0x%llx flags=0x%llx phys=0x%llx align=0x%llx FAILED\n",
                    (unsigned long long)hint, (unsigned long long)len,
                    (unsigned long long)flags, (unsigned long long)phys,

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1692,7 +1692,33 @@ void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
     invalidate_phys_range_locked(w, phys, phys + size);
 }
 
+// PROSPER_HOSTWRITEWATCH=0xADDR[:SIZE] (#2998): report every HOST write -- a read()/pread() that
+// streams bytes straight into a guest buffer -- landing in one guest range, with the offset within
+// it. This is the path a title uses to load file bytes directly into a texture allocation, and it is
+// invisible to every GPU-side instrument: the PM4 recorders see prosper's own stores, the compute
+// watch sees dispatch tables, and a kernel write into guest memory is neither.
+//
+// Its null has a real scope: only writes the HLE routes through this notification are seen. A guest
+// that reads into a staging buffer and memcpys from there in guest code writes with plain stores,
+// which nothing here can observe.
 void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
+    if (const char* w = getenv("PROSPER_HOSTWRITEWATCH")) {
+        char* end = nullptr;
+        const uint64_t lo = strtoull(w, &end, 0);
+        const uint64_t span = (end && *end == ':') ? strtoull(end + 1, nullptr, 0) : (64ull << 20);
+        if (lo && addr < lo + span && addr + size > lo) {
+            static std::atomic<uint32_t> said{0};
+            static std::atomic<uint64_t> bytes{0};
+            const uint64_t total = bytes.fetch_add(size, std::memory_order_relaxed) + size;
+            const uint32_t n = said.fetch_add(1, std::memory_order_relaxed);
+            if (n < 24u || (n % 256u) == 0u)
+                fprintf(stderr, "[hostwrite] 0x%llx +0x%llx (offset 0x%llx in watch) "
+                                "hit=%u total=%llu KiB\n",
+                        (unsigned long long)addr, (unsigned long long)size,
+                        (unsigned long long)(addr - lo), n + 1,
+                        (unsigned long long)(total >> 10));
+        }
+    }
     if (!addr || !size || addr > UINT64_MAX - size) return;
     WatchState& w = state();
     // Hot path: the HLE calls this before EVERY read()/pread(), mostly into non-dmem heap buffers. When

--- a/prosper/src/host/memory/guest_write_watch.cpp
+++ b/prosper/src/host/memory/guest_write_watch.cpp
@@ -1702,24 +1702,40 @@ void guest_write_watch_notify_physical_write(uint64_t phys, uint64_t size) {
 // that reads into a staging buffer and memcpys from there in guest code writes with plain stores,
 // which nothing here can observe.
 void guest_write_watch_notify_host_write(uint64_t addr, uint64_t size) {
-    if (const char* w = getenv("PROSPER_HOSTWRITEWATCH")) {
+    if (!addr || !size || addr > UINT64_MAX - size) return;
+    // The watch spec is parsed ONCE. This function runs before every read()/pread() and once per
+    // iovec element of readv()/preadv(), so an uncached getenv() here would be a production cost
+    // paid on the hot path with the switch unset -- and the guard above must come first, or a
+    // malformed (addr, size) is formatted before it is rejected.
+    struct HostWriteWatchSpec { uint64_t lo = 0, span = 0; };
+    static const HostWriteWatchSpec hww = [] {
+        HostWriteWatchSpec h;
+        const char* w = getenv("PROSPER_HOSTWRITEWATCH");
+        if (!w || !*w) return h;
         char* end = nullptr;
         const uint64_t lo = strtoull(w, &end, 0);
         const uint64_t span = (end && *end == ':') ? strtoull(end + 1, nullptr, 0) : (64ull << 20);
-        if (lo && addr < lo + span && addr + size > lo) {
-            static std::atomic<uint32_t> said{0};
-            static std::atomic<uint64_t> bytes{0};
-            const uint64_t total = bytes.fetch_add(size, std::memory_order_relaxed) + size;
-            const uint32_t n = said.fetch_add(1, std::memory_order_relaxed);
-            if (n < 24u || (n % 256u) == 0u)
-                fprintf(stderr, "[hostwrite] 0x%llx +0x%llx (offset 0x%llx in watch) "
-                                "hit=%u total=%llu KiB\n",
-                        (unsigned long long)addr, (unsigned long long)size,
-                        (unsigned long long)(addr - lo), n + 1,
-                        (unsigned long long)(total >> 10));
-        }
+        // A malformed or overflowing spec DISABLES the watch rather than arming a different one.
+        if (!lo || !span || lo > UINT64_MAX - span) return h;
+        h.lo = lo;
+        h.span = span;
+        return h;
+    }();
+    if (hww.lo && addr < hww.lo + hww.span && addr + size > hww.lo) {
+        static std::atomic<uint32_t> said{0};
+        static std::atomic<uint64_t> bytes{0};
+        const uint64_t total = bytes.fetch_add(size, std::memory_order_relaxed) + size;
+        const uint32_t n = said.fetch_add(1, std::memory_order_relaxed);
+        // A write may START below the watch base and overlap into it. Report the offset of the
+        // OVERLAP, never addr-lo, which underflows to a nonsense offset in exactly that case.
+        const uint64_t overlap_lo = addr >= hww.lo ? addr : hww.lo;
+        if (n < 24u || (n % 256u) == 0u)
+            fprintf(stderr, "[hostwrite] 0x%llx +0x%llx (overlap at offset 0x%llx in watch) "
+                            "hit=%u total=%llu KiB\n",
+                    (unsigned long long)addr, (unsigned long long)size,
+                    (unsigned long long)(overlap_lo - hww.lo), n + 1,
+                    (unsigned long long)(total >> 10));
     }
-    if (!addr || !size || addr > UINT64_MAX - size) return;
     WatchState& w = state();
     // Hot path: the HLE calls this before EVERY read()/pread(), mostly into non-dmem heap buffers. When
     // the feature is off (the default) nothing is ever armed, so skip without even taking the lock.


### PR DESCRIPTION
Two diagnostics for guest array textures, and the measurements they produced on Tomb Raider's
mis-textured interiors (#2998).

Both exist because the instruments already present could not separate the cases that matter.

## `PROSPER_SLICEMAP=1`

Reports which decoded slices hold content **across the whole range**, not a prefix. That distinction
is the whole point: an array whose first slices decode and whose later ones are empty is identical,
in every per-layer checksum of the first eight, to one that decoded completely. The *shape* of the
map is the measurement.

```
[slicemap] addr=0x20491cc000 512x512 slices=256 nonempty=14  map(every 8th)=##..............................
[slicemap] addr=0x204ef0c000 2048x2048 slices=29 nonempty=29 map(every 8th)=####
```

## `PROSPER_FORCE_LAYER=<n>`

Substitutes a constant array layer **and says so**. It separates *"the shader is given the wrong
slice"* from *"the slice it asks for holds the wrong content"* — two failures that look identical on
screen, and which I had conflated twice before writing this.

It forces guest-visible state, so its output illustrates an investigation and is **never acceptance
evidence** for a rendered frame. That is stated at the code, not just here.

## What they measured

| observation | |
| --- | --- |
| world atlas (512×512×256) | **14 of 256** slices hold content, all at the start of the range |
| other array (2048×2048×29) | **29 of 29** |
| decode count | atlas decodes **once** per run; with the cache disabled it re-decodes **233 times and reports 14 every time** |
| the slice the shader asks for | **248** — `vertexIndex*24 + 3` from binding 7, constant across all 4,206 vertices of the draw |
| `FORCE_LAYER=248` | a completely different frame from unforced (262 colours vs 122,087) — so different draws use different slices |
| `FORCE_LAYER=10` vs `200` | 184,541 colours full-screen vs **262 colours, almost entirely black** |

So the guest indexes a slice our decoded array has no content for.

## Four hypotheses killed

All recorded in `TOMB_RAIDER_STATUS.md` § Ruled out so nobody re-derives them:

- **flat interpolation** — falsified, the title never sets FLAT_SHADE anywhere (#3051, now latent)
- **mixed-slice triangles** — falsified, the slice is constant per draw
- **stale decode cache** — falsified, 233 re-decodes all report 14
- **tight per-slice stride** — falsified, tested and reverted, gives *different* wrong textures

I also withdrew a "reads past the declared `size`" mechanism of my own: the arithmetic was right but
`r.size` does not gate the reads, so the consequence I drew from it was wrong.

## What is still open

Whether `r.depth = 256` describes the guest array's real layer count at all. If the true array is
~16 layers, an index of 248 means something other than a layer, and the whole framing changes.

## Verification

- build clean; `ctest --no-tests=error -j4` — **311 of 311**
- `check_diag_gates.py` — all checks passed (each diagnostic prints only what its own switch measured)
- No behaviour change with either variable unset
